### PR TITLE
perf(ci): cut PR-review token cost — code/data tiering + periodic contract compress

### DIFF
--- a/.github/workflows/compress-review-contract.yml
+++ b/.github/workflows/compress-review-contract.yml
@@ -1,0 +1,136 @@
+name: Compress review contract
+
+# Mantiene lean i contratti operativi letti dal reviewer a OGNI run di
+# `pr-review-loop` (REVIEW.md entra nel context per ~30 turni × ogni PR → ogni
+# byte si paga moltiplicato). I contratti crescono organicamente (nuove regole,
+# war-story); questo job evita il bloat senza buttare quota:
+#
+#   1. Check DETERMINISTICO della size (zero Claude). Sotto ceiling → no-op.
+#   2. Solo SE supera il ceiling → compressione GENTILE via Claude (preserva
+#      ogni heading/tabella/step/gate/esempio; comprime solo prosa ridondante)
+#      → apre una PR.
+#
+# La PR NON auto-mergia: REVIEW.md è nella allowlist workflow-validation, quindi
+# il reviewer-bot non parte e `auto-merge-on-lgtm` non scatta → la rivede e
+# mergia un umano. È il safety-net anti-drift: un contratto di gating non si
+# muta mai senza occhio umano. Frugalità: Claude gira solo quando serve.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # lunedì 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Comprimi anche se sotto ceiling'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: compress-review-contract
+  cancel-in-progress: false
+
+env:
+  TARGET_FILE: REVIEW.md
+  CEILING_BYTES: '14000'
+
+jobs:
+  compress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check contract size (deterministic gate)
+        id: gate
+        run: |
+          set -euo pipefail
+          bytes=$(wc -c < "$TARGET_FILE")
+          echo "$TARGET_FILE = ${bytes} bytes (ceiling ${CEILING_BYTES})."
+          force="${{ github.event.inputs.force }}"
+          if [ "$bytes" -le "$CEILING_BYTES" ] && [ "$force" != "true" ]; then
+            echo "Under ceiling → skip (no Claude burn)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Over ceiling (o force) → gentle compress."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Gentle compress (Claude)
+        if: steps.gate.outputs.run == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 12 --model claude-sonnet-4-6 --allowedTools 'Read,Edit'"
+          prompt: |
+            Comprimi GENTILMENTE il file `${{ env.TARGET_FILE }}` (contratto di review, letto dal reviewer-bot a ogni PR — ogni byte si paga moltiplicato per i turni).
+
+            **Obiettivo:** ridurre i byte tagliando SOLO prosa ridondante, mantenendo il contratto semanticamente identico.
+
+            **Preserva VERBATIM (non toccare):**
+            - Ogni heading (`#`/`##`/`###`) e l'ordine delle sezioni.
+            - Ogni tabella (severity, tier) e il suo contenuto.
+            - Ogni step numerato (1..7) della "Reviewer behavior" e la sua logica.
+            - Ogni gate/regola: in particolare quando scrivere o NON scrivere `## LGTM`, le condizioni di escalation ❓→🔴, il filtro scopo, i marker severity.
+            - Ogni esempio in code-block e ogni riga `<file>:L<n>: ...`.
+            - Stringhe esatte (`## LGTM`, `🔴 Important`, ecc.) byte-identiche.
+
+            **Puoi comprimere SOLO:**
+            - Prosa esplicativa ridondante e ripetizioni.
+            - War-story verbose ("Caso reale: #814 ... #816/#817") → ref terso (es. "(cfr. #814→#816/#817)") MANTENENDO il numero-issue come puntatore.
+            - Filler/hedging.
+
+            **Vincoli:**
+            - Mai rimuovere una regola, un gate, o un esempio: solo accorciare la prosa attorno.
+            - Se non riesci a tagliare senza perdere una regola, lascia invariato.
+            - Non aggiungere contenuto nuovo. Output = stesso file, più corto.
+
+            Applica le modifiche con Edit. Non aprire PR, non committare: ci pensa il workflow.
+
+      - name: Open compression PR if shrunk
+        if: steps.gate.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$TARGET_FILE"; then
+            echo "Nessuna modifica (Claude non ha potuto comprimere senza perdere regole). No PR."
+            exit 0
+          fi
+          before=$(git show HEAD:"$TARGET_FILE" | wc -c)
+          after=$(wc -c < "$TARGET_FILE")
+          saved=$((before - after))
+          echo "Compresso: ${before} → ${after} bytes (-${saved})."
+          branch="chore/compress-review-contract-${{ github.run_id }}"
+          git config user.name 'Valerie Linc'
+          git config user.email 'valerielinc@gmail.com'
+          git checkout -b "$branch"
+          git add "$TARGET_FILE"
+          git commit -m "chore(review): gentle-compress ${TARGET_FILE} (-${saved}B)"
+          git push origin "$branch"
+          body="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "## Implementato"
+            echo "- Compressione gentile automatica di \`${TARGET_FILE}\` (superato ceiling ${CEILING_BYTES}B: ${before} → ${after}, -${saved}B)."
+            echo "- Solo prosa ridondante/war-story tagliata; regole, gate (\`## LGTM\`/escalation), tabelle, step ed esempi preservati verbatim per istruzione."
+            echo ""
+            echo "## Non implementato (ancora)"
+            echo "- **Merge automatico**: out of scope by design — \`${TARGET_FILE}\` è workflow-validation protected, quindi il reviewer-bot non parte e l'auto-merge non scatta. **Richiede review + merge manuale umano**: verificare che nessuna regola/gate sia persa nel diff prima di mergere (safety-net anti-drift su un contratto di gating)."
+            echo "- Estensione ad \`AGENTS.md\` (anch'esso iniettato a ogni sessione): follow-up, stesso pattern."
+            echo ""
+            echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          } > "$body"
+          gh pr create \
+            --title "chore(review): gentle-compress ${TARGET_FILE} (-${saved}B)" \
+            --body-file "$body" \
+            --base main --head "$branch"

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -35,11 +35,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        # Tier high (opus, max-turns 40, adversarial pass): toccato test gate,
-        # workflow CI, script crawler/migrator/validator, build-plugin. Bug in
-        # questi path = falso senso di sicurezza che si propaga su ogni merge,
-        # quindi probing più profondo paga. Tier normal (sonnet, max-turns 15)
-        # per tutto il resto. Vedi REVIEW.md → "Tier review".
+        # Tier high (opus, max-turns 40, adversarial pass): toccato CODE
+        # funnel-critical — test gate, workflow CI, build-plugin SEO, o script
+        # che mutano/emettono dati indicizzati (crawler/parser/adapter, backfill,
+        # migrate, assemble dataset, sitemap/canonical/slug/structured-data).
+        # Bug in questi path = falso senso di sicurezza che si propaga su ogni
+        # merge, quindi probing opus paga. Tier normal (sonnet, max-turns 15) per
+        # tutto il resto, inclusi gli script NON-funnel: `scripts/{ci,dev,evals}/`
+        # (helper CI/dev) e gli audit/report read-only (`audit-*`, `analytics*`,
+        # `*-report` — non mutano l'indice, verificano soltanto). Vedi REVIEW.md
+        # → "Tier review".
+        #
+        # CODE vs DATA: il tier si decide SOLO sui file code. I file dati/static
+        # rigenerati (data/**, public/**, reports/**, _newsletter_variants/**,
+        # docs/**) NON sono reviewabili come code → non escalano il tier e una PR
+        # data/docs-only resta normal (sonnet posta comunque `## LGTM` →
+        # auto-merge). Questo evita che 50 `data/jobs/*.json` rigenerati da un
+        # crawler trascinino su opus o gonfino il diff.
         #
         # Budget 25→40: con l'espansione del contratto (REVIEW.md no-short-circuit
         # su tier high + step 7 perf-claim + escalation ❓ funnel-critical, sopra
@@ -50,28 +62,41 @@ jobs:
         # 26 turni ≈ 3.5 min; 40 ≈ ~5.5 min, ben dentro il timeout 15 min.
         run: |
           set -euo pipefail
+          set_tier() {
+            echo "tier=$1" >> "$GITHUB_OUTPUT"
+            echo "model=$2" >> "$GITHUB_OUTPUT"
+            echo "max_turns=$3" >> "$GITHUB_OUTPUT"
+            echo "Review tier: $1 ($2, max-turns $3)"
+          }
           files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
           # Guard PR vuota (rebase-only, base == head): files vuoto. Default tier
-          # normal + log esplicito, evita di affidarsi al fallback implicito
-          # `grep -q` su input vuoto. Reviewer comunque posta `## LGTM` (no
-          # finding) e auto-merge scatta.
+          # normal: reviewer posta comunque `## LGTM` (no finding) e auto-merge
+          # scatta.
           if [ -z "$files" ]; then
-            echo "Empty file list (rebase-only or empty PR), tier=normal."
-            echo "tier=normal" >> "$GITHUB_OUTPUT"
-            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
-            echo "max_turns=15" >> "$GITHUB_OUTPUT"
+            echo "Empty file list (rebase-only or empty PR)."
+            set_tier normal claude-sonnet-4-6 15
             exit 0
           fi
-          if echo "$files" | grep -qE '^(tests/|\.github/workflows/|scripts/|build-plugins/)'; then
-            echo "tier=high" >> "$GITHUB_OUTPUT"
-            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
-            echo "max_turns=40" >> "$GITHUB_OUTPUT"
-          else
-            echo "tier=normal" >> "$GITHUB_OUTPUT"
-            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
-            echo "max_turns=15" >> "$GITHUB_OUTPUT"
+          # Strip DATA/static: il tier si decide solo sul CODE.
+          code_files=$(echo "$files" | grep -vE '^(data/|public/|reports/|_newsletter_variants/|docs/)' || true)
+          if [ -z "$code_files" ]; then
+            echo "Data/docs-only PR (no reviewable code touched)."
+            set_tier normal claude-sonnet-4-6 15
+            exit 0
           fi
-          echo "Review tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
+          # CODE funnel-critical → high. Match diretto su test/CI/build-plugin,
+          # più gli script che mutano/emettono l'indice (tutto scripts/ ECCETTO
+          # gli helper non-funnel `{ci,dev,evals}/` e gli audit/report read-only).
+          crit=$(echo "$code_files" | grep -E '^(tests/|\.github/workflows/|build-plugins/)' || true)
+          scripts_crit=$(echo "$code_files" \
+            | grep -E '^scripts/' \
+            | grep -vE '^scripts/(ci|dev|evals)/' \
+            | grep -viE '(audit|analytics|report)' || true)
+          if [ -n "$crit$scripts_crit" ]; then
+            set_tier high claude-opus-4-8 40
+          else
+            set_tier normal claude-sonnet-4-6 15
+          fi
 
       - name: Run Claude review
         id: claude_review
@@ -103,7 +128,7 @@ jobs:
             **Bootstrap:**
             1. Leggi `REVIEW.md` — contratto operativo completo (tier, severity, filtro scopo, completeness contract, cross-file pattern repetition, test plan compliance, adversarial check, format).
             2. `AGENTS.md` solo come contesto progetto (non-negotiables, architettura) — opzionale, leggi solo se serve.
-            3. Carica PR: `gh pr view $PR_NUMBER --json title,body,labels`, `gh pr diff $PR_NUMBER`, `gh pr view $PR_NUMBER --json files`.
+            3. Carica PR: `gh pr view $PR_NUMBER --json title,body,labels`, `gh pr view $PR_NUMBER --json files`, poi il diff del SOLO code: `gh pr diff $PR_NUMBER -- ':(exclude)data/**' ':(exclude)public/**' ':(exclude)reports/**' ':(exclude)_newsletter_variants/**'`. I file dati/static rigenerati (`data/**` job JSON, snapshot, translation-cache, blog-articles; `public/**` immagini/asset) NON sono code: NON revieware il loro contenuto riga-per-riga né contarli come finding — valuta solo se il CODE che li genera è corretto. Se serve un campione di output dati, aprilo mirato con `Read`, non scorrere l'intero blob nel diff.
 
             **Esegui workflow di review come specificato in REVIEW.md:**
             - completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → cross-file pattern repetition (step 5) → test plan compliance (step 6) → claim perf non validato (step 7) → output.
@@ -112,7 +137,7 @@ jobs:
             - **Claim perf non validato (REVIEW.md step 7):** PR perf/build/CI che dichiara speedup/regressione attesa senza misura baseline pre-merge (solo "atteso X→Y" / "il profiler misura post-deploy") su tier high → 🔴 Important. Chiedi misura pre/post o revert-risk esplicito.
             - **Escalation ❓ funnel-critical (REVIEW.md Verification):** un ❓ q (incluso quelli nell'adversarial check) il cui soggetto impatta monetizzazione/traffico (writeJson/persistenza dataset indicizzato, canonical/redirect/previousSlugs, structured data, sitemap, AdSense) → promuovi a 🔴 o apri follow-up issue + linkala. Mai ❓ funnel-critical passivo accanto a `## LGTM`.
 
-            **Cross-file pattern probing (REVIEW.md step 5):** quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
+            **Cross-file pattern probing (REVIEW.md step 5):** quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. **Scopa la ricerca al CODE** — `rg <pattern> scripts build-plugins components services functions server hooks tests` (oppure `rg <pattern> -g '!data/**' -g '!public/**' -g '!reports/**'`): cercare dentro `data/`/`public/` matcha migliaia di blob dati rigenerati = turni e token sprecati senza segnale. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
 
             **Posta UNA review:**
             `gh pr review $PR_NUMBER --comment --body "<markdown formato REVIEW.md>"`

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -35,14 +35,27 @@ Non passa nessuno → drop. Non importante per questo progetto.
 
 ## Tier review (effort + adversarial depth)
 
-Determina tier dai file toccati. Reviewer regola depth+probing in base a tier.
+Determina tier dai file toccati. Reviewer regola depth+probing in base a tier. Tier auto-calcolato dal workflow (`pr-review-loop.yml`) e passato nel prompt; le righe sotto sono il razionale.
 
-| Tier | Trigger files | Adversarial depth |
+**Il tier si decide SOLO sul CODE.** I file dati/static rigenerati — `data/**` (job JSON, snapshot, translation-cache, blog-articles), `public/**` (immagini/asset), `reports/**`, `_newsletter_variants/**`, `docs/**` — NON sono code: non escalano il tier e non vanno revieweati riga-per-riga (vedi "CODE vs DATA nel diff").
+
+| Tier | Trigger files (CODE) | Adversarial depth |
 |---|---|---|
-| **high** | `tests/**`, `.github/workflows/**`, `scripts/**` (validators, migrators, crawlers), `build-plugins/**` | Bug nel test/CI/build = falso senso sicurezza che si propaga su ogni merge. Probe regex/assertion/exit-code/idempotency. Lista 3 cose NON verificate prima dell'output (`## Adversarial check`). |
-| **normal** | tutto il resto | Single-pass standard. No adversarial step obbligatorio. |
+| **high** | `tests/**`, `.github/workflows/**`, `build-plugins/**`, e gli script **funnel-critical**: crawler/parser/adapter, `backfill-*`, `migrate-*`, `assemble-*`, sitemap/canonical/slug/redirect/structured-data — tutto `scripts/**` ECCETTO i non-funnel sotto | Bug nel test/CI/build/emitter = falso senso sicurezza che si propaga su ogni merge. Probe regex/assertion/exit-code/idempotency. Lista 3 cose NON verificate prima dell'output (`## Adversarial check`). |
+| **normal** | tutto il resto, inclusi gli script NON-funnel: `scripts/{ci,dev,evals}/` (helper CI/dev) e gli audit/report read-only (`audit-*`, `analytics*`, `*-report` — verificano, non mutano l'indice) | Single-pass standard. No adversarial step obbligatorio. |
 
 High-tier non implica più 🔴 — implica più probing. Filtro scopo identico.
+
+### CODE vs DATA nel diff
+
+Carica il diff del solo code (Bootstrap step 3 esclude `data/** public/** reports/** _newsletter_variants/**`). I file dati/static rigenerati NON sono reviewabili come code:
+
+- **Non** revieware riga-per-riga il contenuto di `data/jobs/*.json`, snapshot, `translation-cache`, immagini `public/**`, blog-articles generati. Non sono finding.
+- Valuta solo se il **CODE che li genera/emette** è corretto (parser, crawler, build-plugin, writeJson).
+- Serve un campione di output? Apri il file mirato con `Read`, non scorrere l'intero blob nel diff.
+- `rg`/`grep` cross-file (step 5) scopati al code, mai dentro `data/`/`public/`.
+
+Eccezione: un file `data/**` checked-in che è **config/fixture** (non output rigenerato) e che il diff modifica a mano → reviewalo come code.
 
 ## Completeness contract
 
@@ -63,14 +76,14 @@ PR body DEVE avere:
 3. **Diff fa cose non dichiarate** → 🟡 scope drift: "diff fa X non in scope. PR separata o aggiungi a Implementato."
 4. **Sezioni mancanti** → 🔴 process: "manca Implementato/Non implementato nel PR body. Aggiungere prima review sostanziale."
    - **Tier normal**: termina qui, no altri finding (path basso rischio, review sostanziale rimandata al re-push conforme).
-   - **Tier high (`tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`): NON terminare.** Posta il 🔴 process E prosegui con la review sostanziale + `## Adversarial check` completi nello stesso pass. Motivo: il 🔴 process blocca solo l'auto-merge (`## LGTM`), non un merge manuale; se la sostanza è deferita ("re-review post-update") e l'autore mergia a mano, il probing non avviene mai e i bug si propagano. Caso reale: #814 deferì idempotency-retry-loop + `rebase --abort` autostash → mergiato a mano dopo 40s → diventati le issue #816/#817. #795/#802 fermati al solo process gate → mergiati → entrambi revertati (#822, +17% wall). Non deferire mai il probing su tier high.
-5. **Cross-file pattern repetition** → quando il diff fix-a un pattern (regex, parsing idiom, assertion shape) in 1 file, `rg`/`grep` su pattern equivalente nel resto repo. Se stesso anti-pattern presente altrove non toccato → 🔴 se file funnel-critico (crawler/build-plugin/test gate), 🟡 altrove. Esempio: A3 fix regex `<link rel="canonical"...>` → cerca regex simili su HTML in altri test/crawler.
+   - **Tier high (vedi tabella "Tier review"): NON terminare.** Posta il 🔴 process E prosegui con la review sostanziale + `## Adversarial check` completi nello stesso pass. Motivo: il 🔴 process blocca solo l'auto-merge (`## LGTM`), non un merge manuale; se la sostanza è deferita ("re-review post-update") e l'autore mergia a mano, il probing non avviene mai e i bug si propagano. Caso reale: #814 deferì idempotency + autostash → merge manuale → issue #816/#817; #795/#802 fermati al process gate → mergiati → revertati (#822). Non deferire mai il probing su tier high.
+5. **Cross-file pattern repetition** → quando il diff fix-a un pattern (regex, parsing idiom, assertion shape) in 1 file, `rg`/`grep` su pattern equivalente nel resto repo. **Scopa la ricerca al CODE**: `rg <pattern> scripts build-plugins components services functions server hooks tests` (o `rg <pattern> -g '!data/**' -g '!public/**' -g '!reports/**'`) — cercare in `data/`/`public/` matcha migliaia di blob rigenerati = token sprecati. Se stesso anti-pattern presente altrove non toccato → 🔴 se file funnel-critico (crawler/build-plugin/test gate), 🟡 altrove. Esempio: A3 fix regex `<link rel="canonical"...>` → cerca regex simili su HTML in altri test/crawler.
 6. **Test plan compliance** → PR body con `## Test plan` o checklist `- [ ]`: ogni voce è verificabile pre-merge o richiede live? Se richiede live, ok merged-without-tick MA flag come 🟡 ricorda spunta post-merge. Se verificabile pre-merge + non spuntata + reviewer non può confermare dal diff → 🟡 chiedi conferma o issue follow-up.
-7. **Claim perf/optimization non validato** → PR perf/build/CI che dichiara uno speedup o riduzione regressione (`atteso 65s → 5-10s`, `~60s sparmiati`, `177s → ~110s`) **senza misura baseline pre-merge** — solo "il profiler misura al prossimo deploy" / numeri "attesi" — su path tier high → 🔴 Important: "claim perf non validato pre-merge; mergi su speculazione. Allega misura pre/post oppure dichiara esplicito revert-risk nel `## Non implementato`." Motivo: #795 (IN_FLIGHT 4→8) e #802 (async BFS walkHtml) mergiati su claim attesi non misurati → entrambi regrediti (+17% post-walk wall) → revertati 24h dopo (#822). Parallelismo/IO-tuning su runner condiviso (4-vCPU GitHub) è il caso classico dove il claim atteso diverge dal misurato. Eccezione: ottimizzazione byte-identica banale (es. dedup-early provabile dal diff) o claim già supportato da un run linkato con numeri pre/post.
+7. **Claim perf/optimization non validato** → PR perf/build/CI che dichiara uno speedup o riduzione regressione (`atteso 65s → 5-10s`, `~60s risparmiati`) **senza misura baseline pre-merge** (solo "il profiler misura al prossimo deploy" / numeri "attesi") su path tier high → 🔴 Important: "claim perf non validato pre-merge; mergi su speculazione. Allega misura pre/post oppure dichiara revert-risk esplicito nel `## Non implementato`." Motivo: #795/#802 mergiati su claim attesi non misurati → regrediti (+17% wall) → revertati (#822); parallelismo/IO-tuning su runner condiviso 4-vCPU è il caso classico dove atteso ≠ misurato. Eccezione: ottimizzazione byte-identica banale provabile dal diff, o claim già supportato da un run linkato con numeri pre/post.
 
 ### Pre-output adversarial check (tier high)
 
-PR a tier `high` (`tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`): prima del summary finale, includi sezione `## Adversarial check` con 3 cose NON verificate (regex edge case non testato, exit-code path non esplorato, file related non aperto, idempotency assumption). Surface come ❓ q dove pertinente. Tier normal: skip questa sezione.
+PR a tier `high` (vedi tabella "Tier review"): prima del summary finale, includi sezione `## Adversarial check` con 3 cose NON verificate (regex edge case non testato, exit-code path non esplorato, file related non aperto, idempotency assumption). Surface come ❓ q dove pertinente. Tier normal: skip questa sezione.
 
 **Un ❓ dell'adversarial check il cui soggetto è funnel-critical NON resta sepolto qui.** Se mentre lo scrivi riconosci che, se vero, l'item impatta monetizzazione/traffico (SEO/redirect/structured-data/AdSense/sitemap/indicizzabilità) → promuovilo a 🔴 Important in `## Findings` (vedi Verification → escalation). L'adversarial check è per incertezze residue non-bloccanti, non per parcheggiare bug funnel-critical con un punto di domanda. Caso reale: #829 mise `orphanResult.merged` vs `.mergedCount` (writeJson previousSlugs morto → redirect bridge non persistito) come ❓ qui + `## LGTM` → auto-merge, zero follow-up.
 


### PR DESCRIPTION
## Implementato

Riduce il consumo token/quota di `pr-review-loop` (run reale #1083: **1.46M token, opus, 31 turni, $0.96**) senza abbassare la review depth sul codice funnel-critical.

**Fix 1 — Tier deciso solo sul CODE (`pr-review-loop.yml`)**
- Strip `data/ public/ reports/ _newsletter_variants/ docs/` prima della classificazione: il tier non viene più gonfiato dai dati rigenerati.
- PR **data/docs-only** → `normal` (sonnet posta comunque `## LGTM` → auto-merge intatto).
- Tier `high` (opus) ristretto al **CODE funnel-critical**: crawler/parser/adapter, `backfill-*`, `migrate-*`, `assemble-*`, sitemap/canonical/slug/structured-data + `build-plugins/ tests/ .github/workflows/`. Script **non-funnel** → `normal` (sonnet): `scripts/{ci,dev,evals}/`, `audit-*`, `analytics*`, `*-report` (read-only, non mutano l'indice).
- Verificato per classificazione: parser #1083 → HIGH (resta opus, corretto — il review trovò un 🔴 reale), audit/analytics/ci → normal, data-only → normal, build-plugin/test/backfill-slug/assemble → HIGH.

**Fix 2 — Diff data-aware**
- Il reviewer carica il diff del **solo code** (`gh pr diff -- ':(exclude)data/**' ':(exclude)public/**' ...`); i blob dati rigenerati (job JSON, snapshot, translation-cache, immagini) non vengono revieweati riga-per-riga né contati come finding.

**Fix 3 — Cross-file `rg` scopato al code**
- Step 5 di REVIEW.md + prompt: `rg` scopato a `scripts build-plugins components services functions server hooks tests`, mai dentro `data/`/`public/` (matchavano migliaia di blob = turni/token sprecati).

**Fix 4 — Contratto lean + meccanismo periodico**
- `REVIEW.md`: doctrine tier + sezione "CODE vs DATA nel diff" aggiornate; compressione gentile delle war-story verbose (preservando ogni regola/gate/esempio).
- Nuovo `compress-review-contract.yml`: gate **deterministico** sul byte-ceiling (zero Claude se sotto), **solo se bloat** lancia compressione gentile + apre PR. REVIEW.md entra nel context a ogni run × ~30 turni → ogni byte si paga moltiplicato.

## Non implementato (ancora)

- **Misura del risparmio post-merge**: il delta token/turni va osservato live sui prossimi run di `pr-review-loop` (no baseline pre-merge affidabile senza un PR campione). Follow-up: confrontare `CLAUDE_USAGE` su una PR crawler equivalente.
- **Auto-merge della PR di compressione**: out of scope by design — `REVIEW.md`/workflow sono workflow-validation protected → review-bot non parte, merge manuale umano (safety-net anti-drift su un contratto di gating).
- **Estensione del compress ad `AGENTS.md`** (anch'esso iniettato a ogni sessione agent): follow-up, stesso pattern del nuovo workflow.
- **Edge tier**: uno script funnel-critical il cui nome contenga `report`/`audit` finirebbe in `normal` (scelta aggressiva esplicita dell'owner). Se emergesse, aggiungere un'eccezione al grep.

## Note merge

Questa PR modifica `pr-review-loop.yml` + `REVIEW.md` → **workflow-validation failure attesa**: il reviewer-bot non posta, niente `## LGTM`, niente auto-merge. Merge manuale via `gh pr merge --squash --delete-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
