### PR TITLE
test(ai-models): pin discovery shape/maxAdd/empty-listing guards (#893)

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1175,8 +1175,12 @@ export function collectOfferedIds(cfg, list) {
  * Discover usable models for a single provider config and merge them into
  * DEFAULT_CHAIN. Returns { added, stale }. Throws on network/API error so the
  * caller can isolate and log per-provider.
+ *
+ * Exported for unit tests that pin the discovery safety-nets (issue #893):
+ * listing shape auto-detect, the `maxAdd` cap, and the `offeredIds.size > 0`
+ * markStale guard. Production callers go through `discoverFreeModels`.
  */
-async function _discoverProvider(cfg) {
+export async function _discoverProvider(cfg) {
   const apiKey = cfg.getKey();
   if (!apiKey) return { added: 0, stale: 0 };
 

--- a/tests/scripts/ai-models-discovery-shape-guard.test.ts
+++ b/tests/scripts/ai-models-discovery-shape-guard.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Pins the discovery safety-nets introduced in PR #887 (issue #893): the listing
+// SHAPE auto-detect (bare array / `{data:[]}` / `{models:[]}`), the per-provider
+// `maxAdd` cap, and the `offeredIds.size > 0` guard that stops a 200-with-empty-body
+// from pre-exhausting (markStale) a whole provider's static chain entries. These are
+// the headline regressions #887 fixed; without a committed test a future refactor of
+// `_discoverProvider` (flip the guard, drop the cap) would stay green.
+
+const aiModels = (await import('../../scripts/lib/ai-models.mjs')) as unknown as {
+  _discoverProvider: (cfg: unknown) => Promise<{ added: number; stale: number }>;
+  resetState: () => void;
+  getStats: () => { exhaustedModels: string[] };
+  DEFAULT_CHAIN: string[];
+  DISCOVERY_PROVIDERS: ReadonlyArray<{ name: string; getList?: (d: unknown) => unknown[] }>;
+};
+
+const { _discoverProvider, resetState, getStats, DEFAULT_CHAIN, DISCOVERY_PROVIDERS } = aiModels;
+
+const PREFIX = 'testprov/';
+
+type Cfg = Record<string, unknown>;
+
+function makeCfg(overrides: Cfg = {}): Cfg {
+  return {
+    name: 'TestProv',
+    prefix: PREFIX,
+    getKey: () => 'fake-key',
+    url: 'https://test.example/v1/models',
+    pick: (m: { id?: string }) => m?.id ?? null,
+    ...overrides,
+  };
+}
+
+function mockFetch(body: unknown, { ok = true, status = 200 } = {}): void {
+  // _discoverProvider only touches res.ok / res.status / res.json().
+  (globalThis as { fetch: unknown }).fetch = async () => ({
+    ok,
+    status,
+    json: async () => body,
+  });
+}
+
+let originalFetch: typeof globalThis.fetch;
+let baseChainLen = 0;
+
+beforeEach(() => {
+  resetState();
+  originalFetch = globalThis.fetch;
+  baseChainLen = DEFAULT_CHAIN.length;
+});
+
+afterEach(() => {
+  // Drop anything discovery pushed onto the shared chain, and any seeded statics.
+  DEFAULT_CHAIN.length = baseChainLen;
+  resetState();
+  globalThis.fetch = originalFetch;
+});
+
+describe('discovery listing SHAPE auto-detect (issue #893)', () => {
+  it('bare top-level array (Together-style) → models added', async () => {
+    mockFetch([{ id: 'm1' }, { id: 'm2' }]);
+    const res = await _discoverProvider(makeCfg());
+    expect(res.added).toBe(2);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}m1`);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}m2`);
+  });
+
+  it('OpenAI-compatible `{data:[]}` (most providers) → models added', async () => {
+    mockFetch({ data: [{ id: 'm1' }] });
+    const res = await _discoverProvider(makeCfg());
+    expect(res.added).toBe(1);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}m1`);
+  });
+
+  it('`{models:[]}` via cfg.getList (Cohere-style) → models added', async () => {
+    const cfg = makeCfg({
+      getList: (d: { models?: unknown[] }) => (Array.isArray(d?.models) ? d.models : []),
+      pick: (m: { name?: string }) => m?.name ?? null,
+    });
+    mockFetch({ models: [{ name: 'command-r' }] });
+    const res = await _discoverProvider(cfg);
+    expect(res.added).toBe(1);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}command-r`);
+  });
+
+  it('the real Cohere cfg.getList unwraps `{models:[]}` and rejects non-array bodies', () => {
+    const cohere = DISCOVERY_PROVIDERS.find((p) => p.name === 'Cohere');
+    if (!cohere?.getList) throw new Error('Cohere provider/getList missing');
+    expect(cohere.getList({ models: [{ name: 'a' }, { name: 'b' }] })).toHaveLength(2);
+    expect(cohere.getList({})).toEqual([]);
+    expect(cohere.getList(null)).toEqual([]);
+  });
+
+  it('unrecognized body shape → empty list, nothing added', async () => {
+    mockFetch({ unexpected: 'garbage' });
+    const res = await _discoverProvider(makeCfg());
+    expect(res.added).toBe(0);
+    expect(DEFAULT_CHAIN.length).toBe(baseChainLen);
+  });
+});
+
+describe('discovery `maxAdd` flood cap (issue #893)', () => {
+  it('injects at most `maxAdd` new models even when the listing is larger', async () => {
+    const listing = Array.from({ length: 5 }, (_, i) => ({ id: `m${i}` }));
+    mockFetch(listing);
+    const res = await _discoverProvider(makeCfg({ maxAdd: 2 }));
+    expect(res.added).toBe(2);
+    // Exactly the first two (Set preserves listing order), the rest skipped.
+    expect(DEFAULT_CHAIN.length).toBe(baseChainLen + 2);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}m0`);
+    expect(DEFAULT_CHAIN).toContain(`${PREFIX}m1`);
+    expect(DEFAULT_CHAIN).not.toContain(`${PREFIX}m2`);
+  });
+});
+
+describe('discovery markStale empty-listing guard (issue #893 / #835)', () => {
+  it('a 200 with an EMPTY body does NOT pre-exhaust the static chain', async () => {
+    // Seed two static chain entries for this provider.
+    DEFAULT_CHAIN.push(`${PREFIX}static-a`, `${PREFIX}static-b`);
+    mockFetch([]); // glitch: usable listing came back empty
+    const res = await _discoverProvider(makeCfg({ markStale: true }));
+    expect(res.stale).toBe(0);
+    const exhausted = getStats().exhaustedModels;
+    expect(exhausted).not.toContain(`${PREFIX}static-a`);
+    expect(exhausted).not.toContain(`${PREFIX}static-b`);
+  });
+
+  it('a NON-empty listing still pre-exhausts only the entries the provider dropped', async () => {
+    DEFAULT_CHAIN.push(`${PREFIX}static-a`, `${PREFIX}static-b`);
+    mockFetch([{ id: 'static-a' }]); // only static-a still offered
+    const res = await _discoverProvider(makeCfg({ markStale: true }));
+    expect(res.stale).toBe(1);
+    const exhausted = getStats().exhaustedModels;
+    expect(exhausted).toContain(`${PREFIX}static-b`); // decommissioned
+    expect(exhausted).not.toContain(`${PREFIX}static-a`); // still live
+  });
+});
+
+describe('discovery transport guard', () => {
+  it('a non-ok API response is a no-op (keeps the static list)', async () => {
+    mockFetch({}, { ok: false, status: 500 });
+    const res = await _discoverProvider(makeCfg({ markStale: true }));
+    expect(res).toEqual({ added: 0, stale: 0 });
+    expect(DEFAULT_CHAIN.length).toBe(baseChainLen);
+  });
+});


### PR DESCRIPTION
## Implementato

Committa i test "safety-net" della discovery promessi nel body di PR #887 ma mai landati (follow-up #893). Pinnano i 3 guard headline di `scripts/lib/ai-models.mjs` (tier-high), prima coperti **solo** lato id-matching (`collectOfferedIds`, #892):

- **Shape auto-detect** del listing provider — 3 forme: bare array top-level (Together), `{data:[]}` (OpenAI-compat), `{models:[]}` via `cfg.getList` (Cohere). Più un check diretto sul `getList` reale di Cohere (unwrap + reject non-array).
- **`maxAdd` flood cap** — provider con 5 modelli, `maxAdd:2` → esattamente 2 iniettati, il resto skippato.
- **Guard `offeredIds.size > 0` su markStale** — un `200` con body vuoto NON pre-esaurisce l'intera static chain del provider (classe di regressione #835); control: un listing non-vuoto pre-esaurisce solo gli id davvero droppati.
- Bonus: transport guard (`!res.ok` → no-op).

`_discoverProvider` ottiene un `export` (solo per test; la produzione passa da `discoverFreeModels`). I test usano `fetch` mockato + cfg sintetica con prefix isolato, snapshot/restore di `DEFAULT_CHAIN`, nessuna mutazione persistente dello stato globale.

**Verifica**: 9/9 verde. Mutation-checked — rimuovendo il cap `maxAdd` o il guard `offeredIds.size>0` i rispettivi test diventano rossi (gate reale, non fake).

GitNexus impact su `_discoverProvider`: d=1 = solo `discoverFreeModels` (caller interno); il cambio è puramente additivo (`export`, signature/body invariati) → zero break.

Closes #893

## Non implementato (ancora)

- Niente. Lo scope di #893 (shape/maxAdd/empty-guard) è interamente coperto. L'id-matching markStale (#892) era già testato in `ai-models-discovery-markstale.test.ts` e resta invariato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)