### PR TITLE
fix(ci): add id-token:write to compress-contract-docs (OIDC for Claude action)

### DIFF
--- a/.github/workflows/compress-contract-docs.yml
+++ b/.github/workflows/compress-contract-docs.yml
@@ -34,6 +34,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # richiesto da claude-code-action per l'OIDC token exchange
 
 concurrency:
   group: compress-contract-docs


### PR DESCRIPTION
## Implementato

Fix one-line: aggiunge `id-token: write` ai permissions di `compress-contract-docs.yml`.

Il force-dispatch di validazione live (run 26803193320) falliva su **tutti e 4** i matrix job allo step "Gentle compress (Claude)" con:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

`anthropics/claude-code-action@v1` richiede `id-token: write` per l'OIDC token exchange (anche con `claude_code_oauth_token`). `pr-review-loop.yml` lo ha già; il workflow nuovo (PR #1098) l'aveva omesso. Bug catturato proprio dal test live (test_new_workflows_live).

## Non implementato (ancora)

- **Re-validazione live**: dopo il merge rilancio `workflow_dispatch force=true` per confermare che i 4 job aprano le draft PR e che la compressione preservi le regole.

## Note merge

Tocca solo `compress-contract-docs.yml` (NON workflow-validation protected) → reviewer-bot gira, auto-merge su `## LGTM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
