### PR TITLE
chore(agents): class-complete fix rule + stale-PR self-healing signal

### DIFF
--- a/.github/workflows/stale-pr-rescuer.yml
+++ b/.github/workflows/stale-pr-rescuer.yml
@@ -1,0 +1,102 @@
+name: Stale PR rescuer (self-healing signal)
+
+# Converte gli stalli silenziosi della pipeline PR in un segnale labellato +
+# queryable entro ~1h, invece di lasciarli fermi giorni (osservato 2026-06-02:
+# #1073 e #1075 ferme 23h). Due classi di stallo, entrambe documentate in
+# AGENTS.md ma finora SOLO manuali:
+#   A) workflow-validation drift: pr-review-loop fallisce con review body vuoto
+#      (branch indietro sui file workflow → app-token 401). Fix: merge origin/main.
+#   B) 🔴 Important non ripreso: il reviewer ha postato 🔴 sull'head corrente,
+#      auto-merge skipped, nessun commit nuovo. Fix: commit sullo stesso branch.
+#
+# DETERMINISTICO (zero Claude → zero quota Max, coerente con la frugalità di
+# issue-triage). Azione = label `stale-review` + UN commento idempotente con la
+# rescue instruction. NON fa auto-push (l'auto-merge-origin-main per la classe A
+# richiede PAT con scope `workflows`; è il follow-up dichiarato). Alert-only =
+# safe da girare live accanto agli agent locali attivi sui branch.
+
+on:
+  schedule:
+    - cron: '20 * * * *'  # hourly @ :20 — cattura lo stallo entro ~1h
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Solo log, niente label/commenti'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: stale-pr-rescuer
+  cancel-in-progress: false
+
+jobs:
+  rescue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Scan open PRs and flag stalled ones
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          NOW=$(date -u +%s)
+          AGE_MIN_S=7200  # 2h: non toccare PR con lavoro recente (agent attivo)
+
+          # PR aperte, autore owner (skip fork/dependabot). updatedAt per age gate.
+          prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
+            --json number,headRefName,headRefOid,updatedAt,author,labels)
+
+          echo "$prs" | jq -c '.[]' | while read -r pr; do
+            N=$(echo "$pr" | jq -r '.number')
+            BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            HEAD=$(echo "$pr" | jq -r '.headRefOid')
+            UPD=$(echo "$pr" | jq -r '.updatedAt')
+            AUTHOR=$(echo "$pr" | jq -r '.author.login')
+            HAS_LABEL=$(echo "$pr" | jq -r '[.labels[].name] | index("stale-review") // empty')
+
+            # Idempotenza: già flaggata → skip.
+            if [ -n "$HAS_LABEL" ]; then echo "PR #$N già stale-review — skip"; continue; fi
+
+            # Age gate: aggiornata da <2h → probabile lavoro attivo, non disturbare.
+            UPD_S=$(date -u -d "$UPD" +%s 2>/dev/null || echo "$NOW")
+            if [ $((NOW - UPD_S)) -lt $AGE_MIN_S ]; then echo "PR #$N fresca (<2h) — skip"; continue; fi
+
+            # Ultimo run pr-review-loop sul branch.
+            run=$(gh run list --repo "$REPO" --workflow=pr-review-loop.yml \
+              --branch "$BRANCH" --limit 1 --json conclusion,headSha 2>/dev/null || echo '[]')
+            RV_CONCL=$(echo "$run" | jq -r '.[0].conclusion // "none"')
+
+            # Ultima review del bot reviewer (claude) + commit a cui si riferisce.
+            reviews=$(gh api "repos/$REPO/pulls/$N/reviews" 2>/dev/null || echo '[]')
+            LAST_BODY=$(echo "$reviews" | jq -r '[.[] | select(.user.login|test("claude";"i"))] | last | .body // ""')
+            LAST_CID=$(echo "$reviews" | jq -r '[.[] | select(.user.login|test("claude";"i"))] | last | .commit_id // ""')
+
+            REASON=""; RESCUE=""
+            if [ "$RV_CONCL" = "failure" ] && { [ -z "$LAST_BODY" ] || [ "$LAST_CID" != "$HEAD" ]; }; then
+              # Classe A: review fallita senza body valido sull'head corrente.
+              REASON="workflow-validation drift (pr-review-loop=failure, review body assente per l'head corrente)"
+              RESCUE="\`git fetch origin main && git merge origin/main\` nel branch \`$BRANCH\` poi push (allinea i workflow file → review re-run con app-token valido). Vedi AGENTS.md → \"Workflow-validation drift\"."
+            elif echo "$LAST_BODY" | grep -q "🔴" && [ "$LAST_CID" = "$HEAD" ]; then
+              # Classe B: 🔴 sull'head corrente, non ripreso.
+              REASON="🔴 Important non ripreso (review sull'head corrente $HEAD, auto-merge skipped, nessun commit nuovo)"
+              RESCUE="applica il fix del 🔴 in un nuovo commit sullo stesso branch \`$BRANCH\` → re-review automatica. Vedi la review più recente sulla PR."
+            else
+              echo "PR #$N nessuno stallo noto (review=$RV_CONCL) — skip"; continue
+            fi
+
+            echo "::warning::PR #$N STALLED — $REASON"
+            if [ "${DRY_RUN:-false}" = "true" ]; then echo "(dry-run) skip azione PR #$N"; continue; fi
+
+            gh pr edit "$N" --repo "$REPO" --add-label "stale-review" 2>/dev/null || \
+              echo "label stale-review assente nel repo — creala una volta: gh label create stale-review"
+            gh pr comment "$N" --repo "$REPO" --body "$(printf '🔧 **stale-review** (auto): PR ferma >2h.\n\nClasse: %s\n\nRescue: %s\n\n_Segnale deterministico da stale-pr-rescuer.yml (zero-Claude). Auto-rescue con push = follow-up (serve PAT scope workflows)._' "$REASON" "$RESCUE")" \
+              2>/dev/null || echo "comment fallito PR #$N"
+          done
+          echo "Scan completo."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Iniettato in ogni sessione agent. Detail durevole nei docs, carica on-demand.
 3. Job page structured data DEVE includere in ogni locale: `baseSalary`, `postalCode`, `streetAddress`, `title`, `description`, `datePosted`, `hiringOrganization.name`, `jobLocation`, `employmentType`. Source mancante → safe default, non rimozione check.
 4. Mai accettare thin content indicizzato <50 parole.
 5. Test fail → trattare test come right finché non provato contrario.
-6. Changes chirurgiche: no drive-by refactor, no speculative abstraction, no formatting churn.
+6. Changes chirurgiche: no drive-by refactor, no speculative abstraction, no formatting churn. «Chirurgico» = la *classe* del bug, NON il singolo file. Per fix di pattern (regex/replace/guard/floor/threshold/selector): prima di aprire PR, `grep` dei sibling funnel-critical (`scripts/update-*.mjs`, `build-plugins/**`, `services/seoService.ts`) per lo stesso costrutto → fixa l'intera classe nella STESSA PR, oppure giustifica OGNI sibling non toccato in `## Non implementato`. Pre-empt del 🔴 reviewer "stesso antipattern nel file gemello" (4/5 PR osservate 2026-06-02) → risparmia un ciclo review+fix (~3M token quota Max).
 7. Mai disabilitare AdSense Auto Ads (anchor/in-page/vignette). Mai globale, per-route, loader gating, `enable_page_level_ads:false`, meta opt-out. ~95% revenue. CLS/layout fix da Auto Ads → reserve space (`min-height`/`aspect-ratio`/`contain: layout`), pre-declared `<ins>` placeholder fixed dim, image/font width-height fix. MAI sopprimere ad system.
 
 ## Privacy


### PR DESCRIPTION
## Implementato

Da ~2h di osservazione della pipeline (2026-06-02 04:45–06:26 UTC: 11 merge, 5 follow-up, 2 PR ferme 23h). Due fix azionabili e verificati:

**P1 — class-complete fix rule** (`AGENTS.md` non-negotiable #6)
- Osservazione: 4 PR su 5 hanno preso 🔴 Important della STESSA classe — *"la PR fixa l'antipattern nel file A ma resta identico nel sibling B funnel-critical non toccato"* (#1082 seoService, #1083 update-colin-cie, #1084 monitor, #1085 jobsSeoPagesPlugin). Causa: tensione tra «chirurgico» (regola #6) e l'aspettativa class-complete del reviewer. Ogni mismatch = +1 review (~1.6M token) + fix cycle + backlog.
- Fix: #6 ora definisce «chirurgico = la *classe* del bug, non il file». Per fix di pattern (regex/guard/floor/selector): grep dei sibling funnel-critical → fix dell'intera classe in 1 PR, o giustifica ogni sibling non toccato in `## Non implementato`. Single-source in AGENTS.md → propaga a local + remote agent (issue-fix prompt già legge #6 a bootstrap).

**P3 — stale-PR self-healing signal** (`.github/workflows/stale-pr-rescuer.yml`, nuovo)
- Osservazione: #1073 (🔴 non ripreso) e #1075 (workflow-validation drift) ferme 23h senza alcun self-healing.
- Fix: cron orario DETERMINISTICO (zero Claude → zero quota Max) che flagga le PR ferme >2h sui due failure-mode noti con label `stale-review` + commento rescue idempotente. Converte stalli silenziosi (23h) in segnale queryable entro ~1h. Alert-only + age-gate 2h → safe accanto agli agent locali attivi sui branch. Label `stale-review` creata. `workflow_dispatch` + `dry_run` per live-test.

## Non implementato (ancora)

- **Auto-rescue con push** (merge `origin/main` per la classe drift; commit-fix auto per la classe 🔴): richiede PAT con scope `workflows` (push di file workflow) + validazione live → follow-up. Per ora il rescuer è alert-only (azione = label+commento, no push) per non interferire con gli agent locali attivi. Motivo: out of scope di questo bundle + rischio su pipeline live.
- **P2 (follow-up treadmill gate)**: GIÀ implementato in `post-merge-followup.yml` (hard-exclude churn + filtro funnel-scope + dedup + in-flight overlap + max 10/PR). La leva residua è P1 a monte (meno deferral → meno follow-up). Nessuna modifica necessaria.
- **P4 (issue-fix trigger efficiency)**: investigato e SCARTATO — gli skipped/cancelled non provisionano runner (gate `if:` job-level + concurrency pending-supersede nativo di GitHub). Nessuno spreco reale; GitHub non filtra eventi `labeled` per nome nell'`on:` → niente di azionabile.
- **P5 (token: trim context)**: GIÀ coperto — `compress-contract-docs.yml` (#1098) auto-comprime AGENTS.md/REVIEW/ISSUES/FOLLOWUP con byte-gate; CLAUDE.md + `.claude/skills/` sono gitignored (local-only, non caricati dagli agent remoti).

## Test plan
- [ ] Post-merge: `gh workflow run stale-pr-rescuer.yml --ref main -f dry_run=true` → verifica che logghi #1073/#1075 come stalled senza side-effect.
- [ ] Poi run senza dry_run → verifica label+commento applicati una sola volta (idempotenza).

🤖 Generated with [Claude Code](https://claude.com/claude-code)