### PR TITLE
fix(ci): compress-docs push auth + bump max-turns 12→25

### DIFF
--- a/.github/workflows/compress-contract-docs.yml
+++ b/.github/workflows/compress-contract-docs.yml
@@ -89,7 +89,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 12 --model claude-sonnet-4-6 --allowedTools 'Read,Edit'"
+          # 25 turni: comprimere gentilmente un doc da 15-21KB preservando ogni
+          # regola richiede più Edit; con 12 ISSUES.md (15KB) terminava
+          # `error_max_turns` senza output (run 26803481810). Compress fira solo
+          # su bloat (raro) → turni alti accettabili.
+          claude_args: "--max-turns 25 --model claude-sonnet-4-6 --allowedTools 'Read,Edit'"
           prompt: |
             Comprimi GENTILMENTE il file `${{ matrix.file }}` (contratto/doc operativo letto ripetutamente da agent e workflow — ogni byte si paga moltiplicato).
 
@@ -138,7 +142,11 @@ jobs:
           git checkout -b "$branch"
           git add "$FILE"
           git commit -m "chore(docs): gentle-compress ${FILE} (-${saved}B)"
-          git push origin "$branch"
+          # Push col token esplicito nell'URL: il credential persistito da
+          # actions/checkout non sopravvive allo step della claude-code-action
+          # (`git push origin` → "Password authentication is not supported",
+          # run 26803481810). GITHUB_TOKEN ha contents:write = sufficiente.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
           body="$RUNNER_TEMP/pr-body-${slug}.md"
           {
             echo "## Implementato"


### PR DESCRIPTION
## Implementato

Fixa i due bug esposti dal force-validation run 26803481810 di `compress-contract-docs.yml`:

1. **Push auth** — lo step "Open draft PR" falliva su `git push origin "$branch"` con `Invalid username or token. Password authentication is not supported`. Il credential persistito da `actions/checkout` non sopravvive allo step `claude-code-action`. Fix: push col token esplicito nell'URL (`https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`); `GITHUB_TOKEN` con `contents:write` basta.
2. **`error_max_turns`** — il job ISSUES.md (15KB) terminava `Reached maximum number of turns (12)` senza output. La compressione gentile preservando ogni regola richiede più Edit su file grandi. Bump `--max-turns 12 → 25` (compress fira solo su bloat = raro, turni alti accettabili; stesso lesson di pr-review-loop).

**La compressione in sé è già validata corretta** dal run precedente: REVIEW.md 12175→11958 (-217B, diff 5 ins/5 del = gentile); AGENTS.md no-op (Claude non ha maciullato i non-negotiables → `git diff --quiet` → niente PR). Mancava solo il push per materializzare le draft PR.

## Non implementato (ancora)

- **Re-validazione finale**: dopo merge rilancio `workflow_dispatch force=true`; atteso ora = draft PR aperte per i file che si comprimono, no-op per quelli che non si accorciano. Le draft PR resteranno aperte per review umana (non le mergio).

## Note merge

Tocca solo `compress-contract-docs.yml` (NON workflow-validation protected) → reviewer-bot gira, auto-merge su `## LGTM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
