### PR TITLE
fix(profiler): sync stripSearchQueryBoilerplate 4th copy with production (🟡 #1107)

### DIFF
--- a/scripts/profile-cluster-emission.mjs
+++ b/scripts/profile-cluster-emission.mjs
@@ -83,16 +83,38 @@ const SEARCH_QUERY_BOILERPLATE_PHRASES = [
   'offerte di lavoro', 'posti di lavoro', 'offerte lavoro',
   'offres d emplois', 'offre d emplois', 'offres d emploi', 'offre d emploi',
   'offres emplois', 'offre emplois', 'offres emploi', 'offre emploi',
-  'recherche emploi', 'stellenangebote', 'stellen',
-  'lavoro', 'offerte', 'jobs', 'job', 'emplois', 'emploi',
+  'recherche emploi', 'recherche d emploi', 'recherche d emplois',
+  'stellenangebote', 'stellenangebot', 'stellen',
+  'lavori', 'lavoro', 'impieghi', 'impiego', 'offerte', 'jobs', 'job',
+  'emplois', 'emploi', 'stipendio', 'mansioni',
+];
+// Trailing nation/salary/requirements template suffixes — keep in sync with
+// SEARCH_QUERY_TEMPLATE_SUFFIX_TERMS in services/relatedSearchClusters.ts.
+const SEARCH_QUERY_TEMPLATE_SUFFIX_TERMS = [
+  'salary', 'wage', 'salaire', 'gehalt', 'lohn', 'stipendio',
+  'switzerland', 'suisse', 'schweiz', 'svizzera',
+  'requirements', 'requirement', 'requisiti', 'exigences', 'anforderungen',
+  'mansioni', 'aufgaben', 'taches',
 ];
 const SEARCH_QUERY_BOILERPLATE_PREFIX = new RegExp(
   `^(?:${SEARCH_QUERY_BOILERPLATE_PHRASES.map((p) => p.replace(/\s+/g, '\\s+')).join('|')})\\s+`,
   'i',
 );
+const SEARCH_QUERY_TEMPLATE_SUFFIX = new RegExp(
+  `\\s+(?:${SEARCH_QUERY_TEMPLATE_SUFFIX_TERMS.join('|')})$`,
+  'i',
+);
 function stripSearchQueryBoilerplate(query) {
-  const stripped = query.replace(SEARCH_QUERY_BOILERPLATE_PREFIX, '').trim();
-  return stripped || query;
+  let stripped = String(query || '').trim();
+  let prev = '';
+  while (stripped && stripped !== prev) {
+    prev = stripped;
+    stripped = stripped
+      .replace(SEARCH_QUERY_BOILERPLATE_PREFIX, '')
+      .replace(SEARCH_QUERY_TEMPLATE_SUFFIX, '')
+      .trim();
+  }
+  return stripped || String(query || '');
 }
 
 function queryMatchScore(haystack, queryTokens) {


### PR DESCRIPTION
## Implementato

Porta nel 4° copy di `stripSearchQueryBoilerplate` (`scripts/profile-cluster-emission.mjs`, L82-96) la logica aggiunta in #1107:
- **Trailing strip** dei suffissi template/nazione (`SEARCH_QUERY_TEMPLATE_SUFFIX_TERMS`: salary/wage/salaire/gehalt/lohn/stipendio, switzerland/suisse/schweiz/svizzera, requirements/requisiti/exigences/anforderungen, mansioni/aufgaben/taches) — iterativo, never-empty.
- **Nuovi prefissi leading**: `recherche d emploi(s)`, `stellenangebot`, `lavori`, `impieghi/impiego`, `stipendio`, `mansioni`.

Il file era rimasto leading-only → dopo #1107 i suoi bucket AND/OR divergevano da `buildClusterContext` (produzione), reintroducendo esattamente la divergenza che #1061 aveva chiuso. Il commento del file stesso (L80-81) impone la sync.

Indirizza il 🟡 della review di #1107.

## Non implementato (ancora)

- Niente helper condiviso per de-duplicare i 4 copy della strip (services + audit.mjs + profiler + …): refactor cross-runtime (TS↔node) fuori scope, è il motivo per cui esistono i copy duplicati (no import .ts sotto plain `node`). I 4 ora sono allineati e ciascuno ha il commento di sync.

## Note

Profiler-only: nessuna mutazione di index/dati, nessun impatto su funnel/SEO/revenue. Cambia solo i conteggi di profiling che ora rispecchiano la produzione.