### PR TITLE
refactor(ci): compress-contract-docs → deterministic flag-issue ratchet

### DIFF
--- a/.github/workflows/compress-contract-docs.yml
+++ b/.github/workflows/compress-contract-docs.yml
@@ -1,25 +1,21 @@
 name: Compress contract docs
 
-# Mantiene lean i contratti/doc "hot" — letti ripetutamente dagli agent e dai
-# workflow Claude, quindi ogni byte si paga moltiplicato:
+# Tiene lean i contratti/doc "hot" — letti ripetutamente da agent e workflow
+# Claude, quindi ogni byte si paga moltiplicato:
 #   - AGENTS.md   → iniettato in OGNI sessione agent (via @AGENTS.md in CLAUDE.md)
 #   - REVIEW.md   → letto a ogni run di pr-review-loop × ~24-31 turni
 #   - ISSUES.md   → contratto della pipeline issue (issue-fix/triage)
 #   - FOLLOWUP.md → contratto di post-merge-followup
 #
-# I contratti crescono organicamente (nuove regole, war-story); questo job evita
-# il bloat senza buttare quota:
-#   1. Gate DETERMINISTICO sulla size per file (zero Claude). Sotto ceiling → no-op.
-#   2. Solo SE un file supera il ceiling → compressione GENTILE via Claude
-#      (preserva ogni heading/regola/gate/lista/code-block/stringa esatta;
-#      comprime solo prosa ridondante) → apre una DRAFT PR.
-#
-# Perché DRAFT: il reviewer-bot salta i draft (`pr-review-loop` ha
-# `if: draft == false`) → niente `## LGTM` → `auto-merge-on-lgtm` non scatta.
-# Quindi un contratto di gating non si auto-muta MAI: un umano legge il diff,
-# verifica che nessuna regola sia persa, marca ready e mergia. Safety-net
-# anti-drift uniforme. (REVIEW.md ha in più il blocco workflow-validation.)
-# Frugalità: Claude gira solo sul file effettivamente in bloat.
+# RATCHET DETERMINISTICO (zero Claude / zero quota / zero drift): controlla la
+# size di ogni doc; se uno supera il ceiling apre/aggiorna UNA follow-up issue
+# deduplicata. La compressione gentile NON la fa la CI: la esegue un umano o
+# l'agent on-demand (più turni, review normale, occhio umano su un doc
+# normativo). Questa scelta sostituisce un precedente tentativo di
+# auto-compress-in-CI rivelatosi fragile: `gh pr create` da Actions è vietato
+# ("GitHub Actions is not permitted to create pull requests") e la compressione
+# preserva-tutto su file grossi (15-21KB) sbocca `error_max_turns`. `gh issue
+# create` invece È permesso col GITHUB_TOKEN, quindi il ratchet è robusto.
 
 on:
   schedule:
@@ -27,139 +23,67 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Comprimi anche i file sotto ceiling'
+        description: 'Apri la issue anche se tutti i file sono sotto ceiling (test)'
         type: boolean
         default: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write # richiesto da claude-code-action per l'OIDC token exchange
+  contents: read
+  issues: write
 
 concurrency:
   group: compress-contract-docs
   cancel-in-progress: false
 
 jobs:
-  compress:
+  check-bloat:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - file: AGENTS.md
-            ceiling: 24000
-          - file: REVIEW.md
-            ceiling: 14000
-          - file: ISSUES.md
-            ceiling: 17000
-          - file: FOLLOWUP.md
-            ceiling: 11000
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Check size (deterministic gate)
-        id: gate
-        env:
-          FILE: ${{ matrix.file }}
-          CEILING: ${{ matrix.ceiling }}
-          FORCE: ${{ github.event.inputs.force }}
-        run: |
-          set -euo pipefail
-          bytes=$(wc -c < "$FILE")
-          echo "$FILE = ${bytes} bytes (ceiling ${CEILING})."
-          if [ "$bytes" -le "$CEILING" ] && [ "$FORCE" != "true" ]; then
-            echo "Under ceiling → skip (no Claude burn)."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Over ceiling (o force) → gentle compress."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup Node.js
-        if: steps.gate.outputs.run == 'true'
         uses: actions/setup-node@v5
         with:
           node-version: '22'
 
-      - name: Gentle compress (Claude)
-        if: steps.gate.outputs.run == 'true'
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # 25 turni: comprimere gentilmente un doc da 15-21KB preservando ogni
-          # regola richiede più Edit; con 12 ISSUES.md (15KB) terminava
-          # `error_max_turns` senza output (run 26803481810). Compress fira solo
-          # su bloat (raro) → turni alti accettabili.
-          claude_args: "--max-turns 25 --model claude-sonnet-4-6 --allowedTools 'Read,Edit'"
-          prompt: |
-            Comprimi GENTILMENTE il file `${{ matrix.file }}` (contratto/doc operativo letto ripetutamente da agent e workflow — ogni byte si paga moltiplicato).
-
-            **Obiettivo:** ridurre i byte tagliando SOLO prosa ridondante, mantenendo il documento semanticamente IDENTICO.
-
-            **Preserva VERBATIM (non toccare):**
-            - Ogni heading (`#`/`##`/`###`) e l'ordine delle sezioni.
-            - Ogni regola, non-negotiable, gate, vincolo, item di lista normativo. In particolare in `AGENTS.md`: i Non-Negotiables, la sezione Privacy, le regole di Workflow/merge. In `REVIEW.md`: quando scrivere o NON scrivere `## LGTM`, le escalation ❓→🔴, il filtro scopo, i marker severity.
-            - Ogni tabella e il suo contenuto.
-            - Ogni step numerato e la sua logica.
-            - Ogni code-block, comando, path, nome-file, numero-issue (`#NNN`) e stringa esatta (es. `## LGTM`, `🔴 Important`, env var, nomi workflow) — byte-identici.
-            - Link `[[...]]` e riferimenti incrociati.
-
-            **Puoi comprimere SOLO:**
-            - Prosa esplicativa ridondante e ripetizioni.
-            - War-story verbose ("Caso reale: #814 ... #816/#817") → ref terso (es. "(cfr. #814→#816/#817)") MANTENENDO i numeri-issue come puntatori.
-            - Filler/hedging.
-
-            **Vincoli:**
-            - Mai rimuovere una regola, un gate, un esempio, un numero-issue: solo accorciare la prosa attorno.
-            - Se non riesci a tagliare un blocco senza perdere informazione normativa, lascialo invariato.
-            - Non aggiungere contenuto nuovo. Output = stesso file, più corto, stesse regole.
-
-            Applica le modifiche con Edit su `${{ matrix.file }}`. Non aprire PR, non committare: ci pensa il workflow.
-
-      - name: Open draft PR if shrunk
-        if: steps.gate.outputs.run == 'true'
+      - name: Check ceilings and flag bloat
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FILE: ${{ matrix.file }}
-          CEILING: ${{ matrix.ceiling }}
+          FORCE: ${{ github.event.inputs.force }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- "$FILE"; then
-            echo "Nessuna modifica (Claude non ha potuto comprimere senza perdere regole). No PR."
+          # file:ceiling (byte). Ceiling = size attuale + ~12-15% headroom; il
+          # ratchet scatta quando il doc cresce oltre, segno che va ricompresso.
+          DOCS="AGENTS.md:24000 REVIEW.md:14000 ISSUES.md:17000 FOLLOWUP.md:11000"
+          over=""
+          for entry in $DOCS; do
+            f="${entry%%:*}"; c="${entry##*:}"
+            b=$(wc -c < "$f")
+            if [ "$b" -gt "$c" ] || [ "$FORCE" = "true" ]; then
+              pct=$(( (b - c) * 100 / c ))
+              over="${over}- \`${f}\`: ${b} B (ceiling ${c} B, +${pct}%)"$'\n'
+              echo "OVER: $f ${b}B > ${c}B"
+            else
+              echo "ok:   $f ${b}B <= ${c}B"
+            fi
+          done
+          if [ -z "$over" ]; then
+            echo "Tutti i doc sotto ceiling → no-op, nessuna issue."
             exit 0
           fi
-          before=$(git show HEAD:"$FILE" | wc -c)
-          after=$(wc -c < "$FILE")
-          saved=$((before - after))
-          echo "Compresso: ${before} → ${after} bytes (-${saved})."
-          slug=$(echo "$FILE" | tr '[:upper:]./' '[:lower:]--')
-          branch="chore/compress-${slug}-${{ github.run_id }}"
-          git config user.name 'Valerie Linc'
-          git config user.email 'valerielinc@gmail.com'
-          git checkout -b "$branch"
-          git add "$FILE"
-          git commit -m "chore(docs): gentle-compress ${FILE} (-${saved}B)"
-          # Push col token esplicito nell'URL: il credential persistito da
-          # actions/checkout non sopravvive allo step della claude-code-action
-          # (`git push origin` → "Password authentication is not supported",
-          # run 26803481810). GITHUB_TOKEN ha contents:write = sufficiente.
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
-          body="$RUNNER_TEMP/pr-body-${slug}.md"
+          desc_file="$RUNNER_TEMP/compress-issue.md"
           {
-            echo "## Implementato"
-            echo "- Compressione gentile automatica di \`${FILE}\` (superato ceiling ${CEILING}B: ${before} → ${after}, -${saved}B)."
-            echo "- Solo prosa ridondante/war-story tagliata; regole, non-negotiable, gate, tabelle, step, code-block e numeri-issue preservati verbatim per istruzione."
-            echo ""
-            echo "## Non implementato (ancora)"
-            echo "- **Merge automatico**: out of scope by design. PR aperta come **draft** → il reviewer-bot la salta (\`pr-review-loop\` gira solo su non-draft) → niente \`## LGTM\` → niente auto-merge. **Richiede review + merge manuale umano**: verificare che nessuna regola/gate sia persa nel diff prima di mergere (safety-net anti-drift su un doc normativo)."
-            echo ""
-            echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-          } > "$body"
-          gh pr create \
-            --draft \
-            --title "chore(docs): gentle-compress ${FILE} (-${saved}B)" \
-            --body-file "$body" \
-            --base main --head "$branch"
+            printf '%s\n\n' "I seguenti contratti/doc 'hot' (letti ripetutamente da agent e workflow Claude) hanno superato il loro compress-ceiling:"
+            printf '%s\n' "$over"
+            printf '%s\n\n' "**Azione richiesta (on-demand, non automatica):** comprimi gentilmente i file elencati — taglia SOLO prosa ridondante e war-story verbose (→ ref terso mantenendo i numeri-issue), **preservando verbatim** ogni heading, regola/non-negotiable/gate, tabella, step numerato, code-block, path e stringa esatta (es. \`## LGTM\`, \`🔴 Important\`). Apri una PR normale (review + merge umano) e ricontrolla che la size scenda sotto il ceiling."
+            printf '%s\n\n' "Razionale: ogni byte di questi doc entra nel context a ogni sessione/turno → il bloat costa quota Max moltiplicata. Vedi \`compress-contract-docs.yml\`."
+            printf '%s\n' "_Issue aperta dal ratchet deterministico; ri-emessa (commento) finché i file restano sopra ceiling._"
+          } > "$desc_file"
+          node scripts/lib/github-issue-creator.mjs \
+            --title "📏 Contract docs over compress ceiling — gentle-compress needed" \
+            --description "$(cat "$desc_file")" \
+            --priority 4 \
+            --label follow-up \
+            --workflow "Compress contract docs"


### PR DESCRIPTION
## Implementato

Pivot da auto-compress-in-CI (fragile) a **ratchet deterministico flag-issue** per `compress-contract-docs.yml`:

- **Gate deterministico** (zero Claude, zero quota, zero drift): loop sui doc "hot" (`AGENTS.md`@24k, `REVIEW.md`@14k, `ISSUES.md`@17k, `FOLLOWUP.md`@11k); se uno supera il ceiling → apre/aggiorna **una** follow-up issue deduplicata via `scripts/lib/github-issue-creator.mjs` (dedup sui primi 60 char del titolo → commenta invece di duplicare).
- La compressione gentile **NON** la fa la CI: la esegue un umano o l'agent **on-demand** (più turni, review normale, occhio umano su un doc normativo).
- Tutti i file sono ora sotto ceiling → in esercizio normale (cron lunedì) è un **no-op** a costo zero finché non crescono.

**Perché il pivot** (validato live, force-run 26803481810/26804118017):
- `gh pr create` da Actions è **vietato** ("GitHub Actions is not permitted to create or approve pull requests"); il repo crea PR via app-token claude[bot] o GITHUB_PAT da Firebase RC, mai con GITHUB_TOKEN. `gh issue create` invece **è permesso**.
- La compressione preserva-tutto su file grossi (ISSUES 15KB, AGENTS 21KB) sbocca `error_max_turns` anche a 25 turni.
- La compressione gentile in sé è confermata corretta (REVIEW.md 12175→11791, −384B, diff 4/4) — ma il plumbing auto-PR-in-CI non è robusto.

## Non implementato (ancora)

- **Validazione live**: dopo merge lancio `workflow_dispatch force=true` → atteso = apre 1 follow-up issue elencando i 4 file. La lascio aperta come demo (o la chiudo dopo verifica).
- **Auto-route a issue-fix**: la issue è solo `follow-up` (non `agent:fix`) → la compressione resta human-driven by design (un doc normativo non si auto-muta).

## Note merge

Tocca solo `compress-contract-docs.yml` (NON workflow-validation protected) → reviewer-bot gira, auto-merge su `## LGTM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
