### PR TITLE
chore(issue-fix): data-blob guard for the fixer (mirror reviewer #1096)

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -128,6 +128,7 @@ jobs:
             **Constraint:**
             - Changes chirurgiche, root-cause, una issue alla volta.
             - Mai toccare file fuori scope della issue.
+            - **CODE vs DATA — no scroll dei blob (ISSUES.md → "CODE vs DATA", mirror #1096 del reviewer):** i file rigenerati `data/**` (job JSON, snapshot, translation-cache, blog-articles), `public/**` (asset), `reports/**`, `_newsletter_variants/**` NON sono code da leggere riga-per-riga. Se la root cause è un drift di output dati → fixa il CODE che li genera (parser/crawler/build-plugin), non `cat`/scorrere il blob né editarlo a mano. Campione → `Read` mirato (offset/limit). `rg`/`grep` scopati al code: `rg <pattern> scripts build-plugins components services -g '!data/**' -g '!public/**' -g '!reports/**'` — cercare nei blob dati = token bruciati. Eccezione: un `data/**` config/fixture checked-in editato a mano dal fix.
             - Mai disabilitare AdSense Auto Ads (non-negotiable #7).
             - Mai committare path home assoluti o email personali (Privacy).
             - Se la root cause non è determinabile con confidenza → NON forzare un fix; posta su issue "Root cause non determinata: <cosa hai trovato>. Serve indagine umana." rimuovi nulla e TERMINA senza PR.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -81,6 +81,15 @@ Trigger sull'aggiunta della label `agent:fix`. La label È il consenso. Può met
 | high | issue tocca `crawler`/`parser`/`scripts/`/`build-plugin`/`.github/workflows/`/test gate | opus, 40 |
 | normal | resto | sonnet, 30 |
 
+### CODE vs DATA (no scroll dei blob — frugalità token, mirror del guard reviewer #1096)
+
+I file rigenerati `data/**` (job JSON, snapshot, translation-cache, blog-articles), `public/**` (immagini/asset), `reports/**`, `_newsletter_variants/**` **NON sono code** da leggere riga-per-riga: scorrerli intero nel contesto brucia token senza segnale (il reviewer lo evita via #1096; il fixer deve fare lo stesso).
+
+- **Root cause su output dati = fixa il CODE che li genera** (parser/crawler/build-plugin), non editare il blob a mano né `cat`/scorrere il file intero.
+- Serve un campione di output? `Read` **mirato** (offset/limit) sul file, mai l'intero blob.
+- `rg`/`grep` cross-file (diagnosi, pattern repetition) **scopati al code**: `rg <pattern> scripts build-plugins components services functions server hooks tests` (o `rg <pattern> -g '!data/**' -g '!public/**' -g '!reports/**'`). Cercare dentro `data/`/`public/` = migliaia di match su blob rigenerati = turni e token sprecati.
+- **Eccezione:** un file `data/**` checked-in che è **config/fixture** (non output rigenerato) e che il fix modifica a mano → trattalo come code.
+
 ### Abort senza PR (no fix forzato)
 
 - Root cause non determinabile con confidenza → commento "serve indagine umana" + termina.


### PR DESCRIPTION
## Implementato

Chiude il gap data-awareness sull'unico step agentico ancora scoperto: il **fixer** (`issue-fix.yml`).

Il **reviewer** (`pr-review-loop`, PR #1096) già: decide il tier solo sul code, carica il diff con `:(exclude)data/** public/** reports/** _newsletter_variants/**`, e scopa `rg` al code → non brucia token scorrendo i blob rigenerati. Il **fixer** non aveva l'equivalente: una issue che punta vicino a `data/**` poteva fargli `cat`/scorrere job JSON, snapshot, translation-cache o blog-articles riga-per-riga.

- **`ISSUES.md`** — nuova subsection "CODE vs DATA (no scroll dei blob)" sotto Fix flow → Tier: contratto durevole (gemello di REVIEW.md "CODE vs DATA"). Root cause su output dati → fixa il CODE che li genera; campione via `Read` mirato; `rg` scopato al code; eccezione per `data/**` config/fixture editati a mano.
- **`issue-fix.yml`** — bullet di rinforzo nei Constraint del prompt che referenzia la regola.

Stessa leva di frugalità di #1096, applicata al pezzo mancante. Nessun cambio di comportamento funzionale del fixer (solo guida anti-spreco-token).

## Non implementato (ancora)

- **`FOLLOWUP.md` / post-merge-followup**: non reso data-aware in questo PR. Rischio minore — il triage crea issue, non fa deep-read dei blob dati; il diff che ispeziona è già `gh pr diff --name-only` (nomi file, non contenuto). Follow-up se emerge consumo reale.
- **`reconcile-followups.mjs`**: zero-Claude, fa solo `grep` di un token sui file citati (cheap); non necessita guard.
- Nessun enforcement automatico (è guida prompt/doc, come #1096): l'aderenza dipende dal modello, coerente con l'approccio esistente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)