### PR TITLE
feat(career-landings): playful delight pass (cl-fun) on UI/UX

### DIFF
--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -328,8 +328,9 @@ function renderEmployerGridReplacement(text: string): string {
 }
 
 function renderApprofondisciDivider(label: string): string {
-  return `<div class="s-7V0OIo" role="separator" aria-label="${esc(label)}">
+  return `<div class="s-7V0OIo cl-divider" role="separator" aria-label="${esc(label)}">
     <span class="s-EIg6N7" aria-hidden="true"></span>
+    <span class="cl-divider-mark" aria-hidden="true">🧭</span>
     <span style="${SMALL_HEADING_STYLE};margin:0">${esc(label)}</span>
     <span class="s-EIg6N7" aria-hidden="true"></span>
   </div>`;
@@ -531,7 +532,7 @@ function renderPage(opts: {
       <p class="s-y8VKoI">${esc(copy.lede)}</p>
     </section>`;
 
-  const bodyHtml = `<main class="s-xzWvwM">${body}</main>`;
+  const bodyHtml = `<main class="s-xzWvwM cl-fun">${body}</main>`;
 
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">

--- a/build-plugins/shared/landingHeroPersonality.ts
+++ b/build-plugins/shared/landingHeroPersonality.ts
@@ -400,7 +400,7 @@ export function renderLandingHero(
 ): string {
   const badge = HERO_BADGES[id];
   const eyebrow = badge
-    ? `<p class="text-sm font-semibold text-accent flex items-center gap-1.5"><span aria-hidden="true">${badge.emoji}</span>${escHtml(badge.eyebrowLabel[locale])}</p>`
+    ? `<p class="text-sm font-semibold text-accent flex items-center gap-1.5"><span class="lh-emoji" aria-hidden="true">${badge.emoji}</span>${escHtml(badge.eyebrowLabel[locale])}</p>`
     : '';
   const tagline = badge
     ? badge.taglineTemplate[locale](vars)

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -1593,3 +1593,109 @@ aside.seo-footer-block .seo-fb-section-body a:hover,
 .s-tbl { width:100%;border-collapse:collapse;margin:1rem 0 }
 .s-thd { text-align:left;padding:10px 12px;font-size:13px;font-weight:700;color:var(--color-subtle);border-bottom:2px solid var(--color-edge);background:var(--color-surface-alt) }
 .s-tcl { padding:10px 12px;border-bottom:1px solid var(--color-edge);color:var(--color-body);font-size:14px }
+
+/* ── Career-landing "delight" pass (cl-fun) ─────────────────────────────────
+   Scoped to <main class="s-xzWvwM cl-fun"> emitted by careerLandingsPlugin.ts
+   (4 landing IDs × 4 locales). Adds tasteful, mobile-first micro-interactions:
+   staggered stat-tile entrance, gentle card lift, a one-time hero-emoji wave,
+   a satisfying CTA press, and an animated FAQ chevron. Pure transform/opacity
+   (no layout properties) → zero CLS, no impact on AdSense reserved space. The
+   global `prefers-reduced-motion` rule in index.css neutralises every animation
+   here; the block below is a defensive duplicate in case this stylesheet ever
+   loads standalone. Brand: warm, confidently-playful (impeccable .impeccable.md). */
+
+/* Hero emoji: one orchestrated wave on load (not on repeat — special stays special). */
+@keyframes cl-wave {
+  0%,100% { transform: rotate(0); }
+  15% { transform: rotate(13deg); }
+  30% { transform: rotate(-8deg); }
+  45% { transform: rotate(9deg); }
+  60% { transform: rotate(-4deg); }
+  75% { transform: rotate(2deg); }
+}
+.cl-fun .lh-emoji {
+  display: inline-block;
+  transform-origin: 70% 75%;
+  animation: cl-wave 1.5s ease-in-out 0.45s 1 both;
+}
+
+/* Stat tiles: staggered rise on load + gentle lift and value "pop" on hover. */
+@keyframes cl-rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: none; }
+}
+.cl-fun .s-XENO3U > * {
+  animation: cl-rise 420ms cubic-bezier(0.16,1,0.3,1) both;
+  transition: transform 170ms ease, box-shadow 170ms ease, border-color 170ms ease;
+}
+.cl-fun .s-XENO3U > *:nth-child(1) { animation-delay: 60ms; }
+.cl-fun .s-XENO3U > *:nth-child(2) { animation-delay: 140ms; }
+.cl-fun .s-XENO3U > *:nth-child(3) { animation-delay: 220ms; }
+.cl-fun .s-XENO3U > *:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 22px var(--color-shadow-soft, rgba(15,23,42,0.10));
+}
+.cl-fun .s-XENO3U .s-tval {
+  transition: transform 170ms cubic-bezier(0.16,1,0.3,1);
+  transform-origin: left center;
+}
+.cl-fun .s-XENO3U > *:hover .s-tval { transform: scale(1.06); }
+
+/* Primary + secondary CTAs: satisfying lift, press, and glow. */
+.cl-fun .s-cta, .cl-fun .s-eXgANZ {
+  transition: transform 140ms cubic-bezier(0.16,1,0.3,1), box-shadow 140ms ease, background-color 140ms ease, border-color 140ms ease;
+}
+.cl-fun .s-cta:hover {
+  transform: translateY(-2px);
+  background: var(--color-accent-hover, var(--color-accent));
+  box-shadow: 0 9px 22px rgba(83,58,253,0.28);
+}
+.cl-fun .s-cta:active { transform: translateY(0); box-shadow: 0 2px 6px rgba(83,58,253,0.22); }
+.cl-fun .s-eXgANZ:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-accent-border);
+  box-shadow: 0 7px 18px var(--color-shadow-soft, rgba(15,23,42,0.10));
+}
+.cl-fun .s-eXgANZ:active { transform: translateY(0); }
+
+/* "Approfondisci" divider: a small warm compass mark that breathes once. */
+.cl-fun .cl-divider-mark {
+  flex-shrink: 0;
+  font-size: 16px;
+  line-height: 1;
+  animation: cl-rise 600ms ease-out 200ms both;
+}
+
+/* FAQ: replace the native triangle with an accent chevron that flips on open. */
+.cl-fun details > summary {
+  list-style: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  transition: color 140ms ease;
+}
+.cl-fun details > summary::-webkit-details-marker { display: none; }
+.cl-fun details > summary::after {
+  content: "⌄";
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--color-accent);
+  transform: translateY(-2px);
+  transition: transform 220ms cubic-bezier(0.16,1,0.3,1);
+}
+.cl-fun details[open] > summary::after { transform: translateY(2px) rotate(180deg); }
+.cl-fun details > summary:hover { color: var(--color-accent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .cl-fun .lh-emoji,
+  .cl-fun .s-XENO3U > *,
+  .cl-fun .cl-divider-mark { animation: none; }
+  .cl-fun .s-XENO3U > *,
+  .cl-fun .s-XENO3U .s-tval,
+  .cl-fun .s-cta,
+  .cl-fun .s-eXgANZ,
+  .cl-fun details > summary,
+  .cl-fun details > summary::after { transition: none; }
+}

--- a/tests/build-plugins/landing-hero-integration.test.ts
+++ b/tests/build-plugins/landing-hero-integration.test.ts
@@ -9,7 +9,7 @@ describe('renderLandingHero — full rendering', () => {
       { openings: 47, medianSalary: 65000 },
       'Lavoro come educatore in Ticino',
     );
-    expect(html).toMatch(/<span aria-hidden="true">🎓<\/span>/);
+    expect(html).toMatch(/<span class="lh-emoji" aria-hidden="true">🎓<\/span>/);
     expect(html).toContain('Professione · Educatore in Ticino');
     expect(html).toContain('<h1');
     expect(html).toContain('Lavoro come educatore in Ticino');
@@ -22,7 +22,7 @@ describe('renderLandingHero — full rendering', () => {
     const locales = ['it', 'en', 'de', 'fr'] as const;
     for (const loc of locales) {
       const html = renderLandingHero('educatore', loc, { openings: 5 }, 'X');
-      expect(html, `${loc} missing eyebrow`).toMatch(/<span aria-hidden="true">🎓<\/span>/);
+      expect(html, `${loc} missing eyebrow`).toMatch(/<span class="lh-emoji" aria-hidden="true">🎓<\/span>/);
       expect(html, `${loc} missing h1`).toContain('<h1');
     }
   });

--- a/tests/build-plugins/landing-hero-personality.test.ts
+++ b/tests/build-plugins/landing-hero-personality.test.ts
@@ -101,6 +101,6 @@ describe('renderLandingHero', () => {
 
   it('renders eyebrow emoji aria-hidden', () => {
     const html = renderLandingHero('educatore', 'it', { openings: 5 }, 'X');
-    expect(html).toMatch(/<span aria-hidden="true">🎓<\/span>/);
+    expect(html).toMatch(/<span class="lh-emoji" aria-hidden="true">🎓<\/span>/);
   });
 });


### PR DESCRIPTION
Richiesta utente: rendere la pagina /agenzie-del-lavoro-lugano/ "più giocosa e fun" migliorando UI/UX. Applicato il design language del plugin **impeccable** (`/delight` + `.impeccable.md`: brand *Precise · Warm · Trustworthy*, fintech-friendly-playful, warmth mediterranea) in modo chirurgico.

La pagina è generata dal template condiviso `careerLandingsPlugin.ts` → l'intervento copre tutte e 4 le career landing (agenzie/concorsi/stage/contratti) × 4 locali = 16 pagine, in modo coerente.

## Implementato
- **Scoping sicuro**: nuova classe `cl-fun` sul `<main>` delle career landing. Tutto il CSS playful è scopato sotto `.cl-fun` in `public/assets/seo-static.css` → blast radius = esattamente queste 16 pagine, nessun'altra SEO landing toccata (`s-xzWvwM`/`.s-*` restano invariati ovunque).
- **Stat tiles**: entrata staggered (`cl-rise`, delay 60/140/220ms), hover lift gentile + "pop" del valore numerico.
- **CTA primaria + secondaria**: micro-interazione soddisfacente — lift su hover, press su active, glow accent (`--color-accent-hover`).
- **Emoji eyebrow hero**: un singolo "wave" orchestrato al load (impeccable: "one well-orchestrated page load"). Aggiunta classe additiva `lh-emoji` in `renderLandingHero` (condiviso da 4 plugin, ma animato solo sotto `.cl-fun`).
- **Divider "Approfondisci"**: piccolo segno bussola 🧭 (warmth, esplorazione). Il nodo di testo della label resta esattamente `Approfondisci` (contratto e2e preservato).
- **FAQ `<details>`**: il triangolo nativo diventa un chevron accent che ruota 180° all'apertura (affordance + delight).
- **Test**: aggiornate 3 asserzioni hero (`landing-hero-personality`/`-integration`) per la classe additiva `lh-emoji`. Intento ("emoji aria-hidden") preservato. Tutti i 139 test build-plugins verdi.

Vincoli rispettati: **mobile-first** (above-the-fold contract 414×736 intatto), **zero CLS** (solo transform/opacity, nessuna layout property), **AdSense reserved space intoccato**, `prefers-reduced-motion` neutralizza ogni animazione (duplicato difensivo in seo-static.css), nessun `border-left` ≥3px (banned), **nessun cambio a copy / JSON-LD / contenuto SEO / locali**. GitNexus impact su `renderLandingHero` = **LOW** (4 caller; classe inerte fuori da `.cl-fun`).

Verifica visiva: preview self-contained con i token light-theme + la `seo-static.css` reale → hero+emoji, tiles colorati, CTA, divider con bussola, chevron FAQ che flippa, layout integro, tiles+CTA ben sopra il fold mobile. Le animazioni (wave/rise/hover) sono CSS valido, non catturabili in un frame statico.

## Non implementato (ancora)
- **Count-up animato dei numeri nelle tile** — richiederebbe JS sulle pagine statiche (no hydration del contenuto static-overlay): out of scope per un pass CSS-only; eventuale follow-up.
- **Emoji per-tile / per-sezione** — i label tile vengono da `careerLandingsCopy` per-id×locale: aggiungere emoji semanticamente corrette richiederebbe estendere la copy di tutte e 4 le landing × 4 locali: posposto (cambio dati ampio, non funnel-critico).
- **Warmth mediterranea a livello di token globali** (palette più calda richiesta in `.impeccable.md`) — modifica `--color-*` globale = blast radius sull'intero sito: out of scope per questa PR scopata alle career landing.
- **Estensione del pass `cl-fun` ad altre famiglie di landing** (profession/nursing/cost-of-living) — stesso renderer hero, fattibile in follow-up se l'effetto piace.