### PR TITLE
refactor(career-landings): drop unused cl-divider class

### DIFF
--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -328,7 +328,7 @@ function renderEmployerGridReplacement(text: string): string {
 }
 
 function renderApprofondisciDivider(label: string): string {
-  return `<div class="s-7V0OIo cl-divider" role="separator" aria-label="${esc(label)}">
+  return `<div class="s-7V0OIo" role="separator" aria-label="${esc(label)}">
     <span class="s-EIg6N7" aria-hidden="true"></span>
     <span class="cl-divider-mark" aria-hidden="true">🧭</span>
     <span style="${SMALL_HEADING_STYLE};margin:0">${esc(label)}</span>


### PR DESCRIPTION
Risolve il 🟡 nit del reviewer su PR #1117.

## Implementato
- Rimossa la classe `cl-divider` dal `<div>` del divider "Approfondisci" in `careerLandingsPlugin.ts`: era un dead hook (nessuna regola CSS `.cl-divider` è mai esistita; solo `.cl-divider-mark`, che resta intatta e renderizza il 🧭). Output HTML byte-più-corto, zero cambio visivo.

## Non implementato (ancora)
- Nessun altro scope: fix chirurgico di un solo nit. Le altre micro-interazioni `cl-fun` di #1117 sono già live-merged e invariate.