### PR TITLE
fix(test): generous timeout for 404-compat full-coverage scan (unblock main-red)

### DIFF
--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -35,6 +35,10 @@ describe('Search Console 404 compatibility resolver', () => {
     });
   });
 
+  // Full-coverage scan over the committed 404 export. This file is an unbounded
+  // GSC-orphan accumulator (300k+ paths, ~30MB) so the loop cost scales with data
+  // size; the default 15s vitest budget overflows under CI load (observed ~20s).
+  // Explicit generous timeout preserves full coverage without sampling/weakening.
   it('covers the committed live 404 export paths', () => {
     const compatPaths = JSON.parse(
       readFileSync(path.resolve(__dirname, '..', 'data', 'seo-404-compat-paths.json'), 'utf-8')
@@ -44,7 +48,7 @@ describe('Search Console 404 compatibility resolver', () => {
     for (const value of compatPaths.paths) {
       expect(resolveSearchConsoleCompatTarget(value), value).not.toBeNull();
     }
-  });
+  }, 60000);
 
   it('resolves non-job section 404s to their landing pages', () => {
     expect(resolveSearchConsoleCompatTarget('/vivere-in-ticino/vivere-in-svizzera')).toEqual({


### PR DESCRIPTION
## Implementato
`tests/search-console-compat.test.ts` > "covers the committed live 404 export paths" itera **ogni** path di `data/seo-404-compat-paths.json` — accumulatore GSC-orphan non-bounded ora a 300k+ entry (~30MB). Il costo del loop scala col volume del file e ha superato il budget vitest default 15s **sotto carico CI** (osservato ~20s), portando `main` rosso su puro confine di crescita-dati senza alcun code change. Aggiunto timeout esplicito 60s a quel solo `it()`.

- Coverage **invariata**: nessun sampling, nessun threshold abbassato (AGENTS.md #1). Solo il budget di esecuzione del singolo test.
- Root cause = volume time-bomb (classe analoga alle date-time-bomb #1035, ma volume non calendario).
- `caller-bad.yml → callee.yml` nei log era red-herring: `workflow-permissions-parity` test è verde (fixture intenzionali).

## Non implementato (ancora)
- **Bound del file accumulator** `data/seo-404-compat-paths.json` (append unbounded da sync-gsc-orphans/enrich/discover-404s): out of scope qui, è una scelta di data-retention separata. Il timeout regge fino a ~3x il volume attuale; se il file continua a crescere oltre, valutare prune o cap. Follow-up se ricapita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)