### PR TITLE
perf(seo-404): hoist compat resolver regexes — fix main-red vitest timeout

### DIFF
--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -169,6 +169,14 @@ const JOB_BOARD_SECTION_PATTERN_SEGMENT: string = (() => {
  return sorted.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
 })();
 
+// Both patterns depend only on the pre-computed section segment, so they are
+// constant across calls. Compile them once at module init — building them per
+// call recompiles a ~1.2k-char, 100-branch alternation on every invocation,
+// which is O(paths) regex-compilation and blows the resolver budget when the
+// committed 404-path corpus is large (605k+ entries → multi-second loops).
+const COMPANY_COMPAT_PATTERN = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/(azienda|company|unternehmen|entreprise)-(.+)$`);
+const JOB_BOARD_SECTION_COMPAT_PATTERN = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/([^/]+)\\/?$`);
+
 export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConsoleCompatResolution | null {
  const path = normalizePath(inputPath);
  const exact = COMPAT_REDIRECTS[path] || COMPAT_REDIRECTS[`${path}/`];
@@ -190,8 +198,7 @@ export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConso
  };
  }
 
- const companyPattern = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/(azienda|company|unternehmen|entreprise)-(.+)$`);
- const companyMatch = path.match(companyPattern);
+ const companyMatch = path.match(COMPANY_COMPAT_PATTERN);
  if (companyMatch) {
  const slug = companyMatch[4];
  // Company hubs stay on TI listing (legacy preservation — company hub
@@ -204,8 +211,7 @@ export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConso
  };
  }
 
- const jobBoardSectionPattern = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/([^/]+)\\/?$`);
- const jobSectionMatch = path.match(jobBoardSectionPattern);
+ const jobSectionMatch = path.match(JOB_BOARD_SECTION_COMPAT_PATTERN);
  if (jobSectionMatch) {
  const slug = jobSectionMatch[3] || '';
  return {


### PR DESCRIPTION
## Implementato

Fix del **main-red** su `tests/search-console-compat.test.ts > covers the committed live 404 export paths` (vitest timeout 15000ms, deterministico — riprodotto su `main` HEAD e su ogni branch che eredita).

**Root cause**
`resolveSearchConsoleCompatTarget` (in `build-plugins/searchConsoleCompat.ts`) compilava **due `RegExp` ad ogni chiamata** (company pattern + job-board-section pattern), ognuna embeddando `JOB_BOARD_SECTION_PATTERN_SEGMENT` (~1.2k caratteri, 100 branch di alternation). Il test itera **tutti i 605.625** path committati in `data/seo-404-compat-paths.json` (accumulatore 404 cresciuto via sweep GSC/URL-Inspection) → ~1.2M compilazioni di regex → loop multi-secondo → timeout.

**Fix (perf-only, byte-identical)**
Hoist delle due pattern a costanti di modulo (`COMPANY_COMPAT_PATTERN`, `JOB_BOARD_SECTION_COMPAT_PATTERN`), compilate una volta a module-init — esattamente come `JOB_BOARD_SECTION_PATTERN_SEGMENT` già fa. Le pattern dipendono solo dal segment precomputato → costanti. Regex non-global → `.match()` stateless → nessun cambio di comportamento. Coverage piena dei 605k path preservata, **nessun timeout alzato, nessun sample, nessun gate abbassato**.

**Misura (bench locale su 605.625 path reali)**
- per-call compile di **1 sola** delle 2 regex: **13.2s**
- hoisted (1 sola): **3.0s**
- il codice ne compilava **2** → ~26s → oltre il budget 15s. Hoisted entrambe → ~6s, comodamente verde.

## Non implementato (ancora)

- **Pruning dell'accumulatore `data/seo-404-compat-paths.json`** (605k path, 60MB): per policy resta fat (accumulatore, prune CI-only). Non toccato — il fix rende il resolver O(1)/call quindi il test regge la crescita. Se il corpus continua a gonfiarsi indefinitamente si potrà valutare un cap separato, ma è out of scope qui.
- **Verifica vitest locale del test**: non eseguibile in worktree (`data/jobs.json` è artifact generato in CI, assente localmente → import fallisce a monte). Validazione affidata a CI vitest di questa PR + bench sopra + invarianza di comportamento.
