### PR TITLE
fix(seo): de-dup 404-compat dataset + sustainable sweep test (main-red fix)

### DIFF
--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -169,6 +169,18 @@ const JOB_BOARD_SECTION_PATTERN_SEGMENT: string = (() => {
  return sorted.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
 })();
 
+// Compiled once at module init. `JOB_BOARD_SECTION_PATTERN_SEGMENT` is a
+// constant, so these patterns never vary per call — building them inside
+// `resolveSearchConsoleCompatTarget` re-compiled a fresh RegExp on every
+// invocation, which the 605k-path compat sweep test multiplied into ~1.2M
+// needless compilations and blew the 15s test timeout.
+const COMPANY_COMPAT_PATTERN = new RegExp(
+ `^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/(azienda|company|unternehmen|entreprise)-(.+)$`,
+);
+const JOB_BOARD_SECTION_COMPAT_PATTERN = new RegExp(
+ `^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/([^/]+)\\/?$`,
+);
+
 export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConsoleCompatResolution | null {
  const path = normalizePath(inputPath);
  const exact = COMPAT_REDIRECTS[path] || COMPAT_REDIRECTS[`${path}/`];
@@ -190,8 +202,7 @@ export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConso
  };
  }
 
- const companyPattern = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/(azienda|company|unternehmen|entreprise)-(.+)$`);
- const companyMatch = path.match(companyPattern);
+ const companyMatch = path.match(COMPANY_COMPAT_PATTERN);
  if (companyMatch) {
  const slug = companyMatch[4];
  // Company hubs stay on TI listing (legacy preservation — company hub
@@ -204,8 +215,7 @@ export function resolveSearchConsoleCompatTarget(inputPath: string): SearchConso
  };
  }
 
- const jobBoardSectionPattern = new RegExp(`^\\/(?:(en|de|fr)\\/)?(${JOB_BOARD_SECTION_PATTERN_SEGMENT})\\/([^/]+)\\/?$`);
- const jobSectionMatch = path.match(jobBoardSectionPattern);
+ const jobSectionMatch = path.match(JOB_BOARD_SECTION_COMPAT_PATTERN);
  if (jobSectionMatch) {
  const slug = jobSectionMatch[3] || '';
  return {

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -41,10 +41,33 @@ describe('Search Console 404 compatibility resolver', () => {
     );
     expect(Array.isArray(compatPaths.paths)).toBe(true);
     expect(compatPaths.paths.length).toBeGreaterThanOrEqual(603);
+    // Guard against the dataset doubling via a merge/concat artifact (seen
+    // 2026-06-02: 306k → 605k exact duplicates). Dup bloat silently doubles
+    // the resolve loop below and trips the 15s timeout — fail fast & cheap on
+    // duplicates instead of timing out.
+    const unique = new Set<string>(compatPaths.paths);
+    expect(
+      unique.size,
+      `seo-404-compat-paths.json has ${compatPaths.paths.length - unique.size} duplicate entries`,
+    ).toBe(compatPaths.paths.length);
+    // Resolve every committed path (full coverage) but collect misses and
+    // assert once. A per-path expect() over 300k+ entries cost ~90µs each
+    // (~30s+) — that per-assertion overhead, not the resolver, is what blew
+    // the timeout. Single assert keeps identical coverage at a fraction of
+    // the cost.
+    const unresolved: string[] = [];
     for (const value of compatPaths.paths) {
-      expect(resolveSearchConsoleCompatTarget(value), value).not.toBeNull();
+      if (resolveSearchConsoleCompatTarget(value) === null) unresolved.push(value);
     }
-  });
+    expect(
+      unresolved,
+      `${unresolved.length} committed 404 paths did not resolve (e.g. ${unresolved.slice(0, 5).join(', ')})`,
+    ).toEqual([]);
+    // 60s ceiling (vs default 15s): this resolves the full committed dataset
+    // (300k+ paths and growing as GSC accumulates 404s) — legitimate O(N)
+    // work that needs headroom on loaded CI runners. Coverage/assertions stay
+    // strict; only the runtime ceiling is raised.
+  }, 60_000);
 
   it('resolves non-job section 404s to their landing pages', () => {
     expect(resolveSearchConsoleCompatTarget('/vivere-in-ticino/vivere-in-svizzera')).toEqual({


### PR DESCRIPTION
## Implementato

Fix del **main-red** che bloccava a cascata ogni PR (vitest-red ereditato): `tests/search-console-compat.test.ts > covers the committed live 404 export paths` andava in **timeout 15s** su `main` (sha `e1ce94d7`).

**Root cause — NON il resolver:**
- `data/seo-404-compat-paths.json` era **raddoppiato a 605.625 entry con 299.336 duplicati esatti** (306.289 uniche). Artefatto di merge/concat atterrato il 2026-06-02 ~07:12 (commit `114ddeaf`). Entrambi i generatori (`discover-404s-via-inspection`, `sync-gsc-orphans`) già deduplicano con `Set`+`sort` → erano **dati committati corrotti**, non un bug ricorrente del generatore. **Deduplicato + riordinato → 306.289 uniche** (forma canonica `[...Set].sort()`, che i generatori manterranno).
- Il test faceva un `expect()` **per ogni path** (~90µs l'uno → ~30s+ a questa dimensione): è quell'overhead per-assertion, **non** `resolveSearchConsoleCompatTarget`, a far esplodere il timeout. **Restructure**: risolve ogni path (coverage piena invariata) ma asserisce **una volta sola** sui miss raccolti.
- **Guard di unicità**: se i duplicati tornano, il test fallisce subito e a basso costo invece di andare in timeout (+coverage, cattura la regressione appena vista).
- **Ceiling del singolo test a 60s** (da default 15s): fa lavoro O(N) legittimo su un dataset grande e crescente (GSC accumula 404 nel tempo). Assertion e coverage restano strict — alzato solo il limite di runtime, nessuna tolerance/threshold abbassata.
- **Hoist** delle 2 `RegExp` compilate per-chiamata nel resolver a costanti di modulo (la sorgente del pattern è costante) — micro-speedup behavior-neutral.

### Test
- Riprodotto il timeout su `main`; **ora verde** in locale (~12.5s anche col dataset ancora non-deduplicato; molto più rapido deduplicato).
- `tsc --noEmit` pulito sui file toccati.
- Profilato: resolver-only 605k = 12.5s (20.7µs/call); il resto dei 68s del run = overhead `expect()` ×605k.

## Non implementato (ancora)

- **Origine esatta dei duplicati**: entrambi i writer noti deduplicano già, quindi il raddoppio è quasi certamente un artefatto di **merge git** (due run di automation hanno toccato il file, il merge ha concatenato senza ri-dedup). Non ho ricostruito quale merge specifico — la guard di unicità nel test ora intercetta la classe di problema a monte di ogni PR futura. Follow-up: valutare un `git merge` driver/hook che ri-deduplichi i file dataset auto-generati, oppure spostare la dedup in un pre-commit. **Non** ho toccato i generatori (sono già corretti).
- Nessuna riduzione del dataset oltre la dedup (i 306k path unici sono coverage 404 legittima).

**Contesto**: sbloccato perché stavo mergiando un refresh UX delle sector-landing (PR #1118, reviewata `LGTM`-clean ma bloccata da questo main-red). Questa PR è indipendente e prioritaria (main verde sblocca tutte le PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)