### PR TITLE
fix(border-wait): SVG self-close quotes (site-wide console errors) + live card above advice

### DIFF
--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -1681,8 +1681,8 @@ function renderLeafPage(inp: LeafInputs): string {
     <h1 style="${H1_STYLE}">${esc(h1)}</h1>
     <p style="${LEDE_STYLE}">${esc(intro)}</p>
   </header>
-  ${adviceBannerHtml}
   ${currentCardHtml}
+  ${adviceBannerHtml}
   ${webcamHtml}
   ${hourlyHtml}
   ${weeklyHtml}

--- a/build-plugins/shared/htmlMinify.ts
+++ b/build-plugins/shared/htmlMinify.ts
@@ -93,7 +93,14 @@ const START_TAG_RX = /<\/?[A-Za-z][^<>]*>/g;
 // HTML5 unquoted attribute values may not contain whitespace, quotes, `=`,
 // `<`, `>`, or backticks. We also keep trailing-slash URL values quoted to
 // avoid `<link href=https://example.com/>` self-close ambiguity.
-const SAFE_ATTR_VALUE_RX = /(\s[A-Za-z_:][A-Za-z0-9:._-]*)=(["'])([^"'<>=`\s]+)\2/g;
+//
+// `(?!\/)` after the closing quote keeps the LAST attribute quoted when it is
+// immediately followed by a self-closing slash with no space: `<circle r="10"/>`.
+// Unquoting there yields `<circle r=10/>`, where the HTML parser folds the `/`
+// into the unquoted value (`r` becomes "10/") → "Expected length" SVG render
+// error in the console. Inline SVG icons (hubChrome glyphs etc.) author their
+// attributes as `attr="n"/>`, so this case is hit on every page emitting them.
+const SAFE_ATTR_VALUE_RX = /(\s[A-Za-z_:][A-Za-z0-9:._-]*)=(["'])([^"'<>=`\s]+)\2(?!\/)/g;
 
 function unquoteSafeAttributes(html: string): string {
   return html.replace(START_TAG_RX, (tag) =>

--- a/tests/seo/html-minify.test.ts
+++ b/tests/seo/html-minify.test.ts
@@ -218,6 +218,24 @@ describe('minifyHtml — safe attribute-quote removal', () => {
     expect(out).toContain('href=/assets/index-abc.css');
   });
 
+  it('keeps the last attribute quoted before a self-closing slash (SVG icons)', () => {
+    // `<circle r="10"/>` must NOT become `<circle r=10/>` — the unquoted value
+    // would absorb the `/` (`r="10/"`) and the SVG renderer throws
+    // "Expected length". hubChrome inline icons author attrs as `attr="n"/>`.
+    const out = minifyHtml(
+      '<svg><circle cx="12" cy="12" r="10"/><line x1="8" y1="2" x2="8" y2="18"/></svg>',
+    );
+    // The slash-adjacent attribute keeps its quotes…
+    expect(out).toContain('r="10"/>');
+    expect(out).toContain('y2="18"/>');
+    // …no malformed unquoted self-close survives.
+    expect(out).not.toMatch(/r=10\/>/);
+    expect(out).not.toMatch(/y2=18\/>/);
+    // …while earlier (space-separated) attributes still get unquoted.
+    expect(out).toContain('cx=12');
+    expect(out).toContain('x1=8');
+  });
+
   it('preserves quotes inside JSON-LD body (opaque)', () => {
     const out = minifyHtml(
       '<script type="application/ld+json">{"@type":"Foo","key":"value"}</script>',


### PR DESCRIPTION
Analisi UI/UX della pagina `/traffico-dogane/gaggiolo/oggi/` (mobile-first). Questa PR applica i fix **P0/P1** chiari e root-cause; gli altri item sono documentati sotto con motivo.

## Implementato

### P0 — bug SVG console (root cause, site-wide)
`build-plugins/shared/htmlMinify.ts`: il passo `removeAttributeQuotes` strippava le virgolette anche all'ultimo attributo prima di un self-close senza spazio:
`<circle ... r="10"/>` → `<circle ... r=10/>`. In parsing HTML il valore unquoted assorbe lo slash → `r="10/"` → il renderer SVG lancia `Error: <circle> attribute r: Expected length, "10/"` (8 errori/pagina, da glifi `hubChrome` presenti in **tutte** le pagine SEO).
**Fix:** lookahead `(?!\/)` nella `SAFE_ATTR_VALUE_RX` → la virgoletta dell'attributo adiacente allo slash è preservata. Cambio conservativo (mantiene *più* virgolette), DOM-equivalente, nessuna regressione di byte significativa.
+ regression test in `tests/seo/html-minify.test.ts` (`<circle r="10"/>` / `<line y2="18"/>`).

### P1 — numero live above-fold
`build-plugins/borderWaitPagesPlugin.ts`: la card **"Stato attuale"** (minuti di attesa) ora precede il banner "Consiglio", invertendo l'ordine precedente. Allinea l'ordine SEO documentato ("stat tile → advice banner") e alza il dato chiave sopra la fold su mobile (75% del traffico). Solo riordino di 2 righe nel template, nessuna modifica di copy/contenuto.

### P0-b — webcam fallback: già presente
Verificato: `renderWebcamSection` ha già `onerror` con placeholder SVG inline (riga ~1007). L'errore `ERR_CONTENT_LENGTH_MISMATCH` osservato dalla webcam `ti.ch` è coperto dal fallback esistente. Nessuna modifica.

## Non implementato (ancora)

- **Pill "live (Firestore)" vs Fonte "tempo reale non disponibile"** — contraddizione percepita di trust. Posposto: il fix corretto è lato **hydration script** (cross-module) che deve aggiornare anche la label Fonte quando sostituisce i dati live; tocca semantica data-provenance (non-negotiable trust) → merita PR dedicata. Distinto da #1106 (che riguarda la freshness del dato, non la label).
- **Dedup data nell'header (3× la data) + lede ≤120 char** — out of scope qui: `intro` alimenta anche `<meta description>` e 2× JSON-LD `description`; accorciarlo è entangled e richiede decoupling separato.
- **Grafici "Andamento orario / Pattern settimanale" quasi vuoti** — riflettono dati genuinamente sparsi per il valico; nasconderli rischia il gate thin-content. Follow-up consigliato: caption "dati in accumulo" sotto soglia-copertura (decisione di copy).
- **Toast gamification "Prima simulazione" + Google One Tap su pagina traffico** — componenti SPA globali (`GamificationWidget`), blast radius fuori da questo plugin → PR dedicata a livello app.
- **Ripetizione "(Cantello-Stabio)" nella prosa** — `BORDER_CROSSING_DISPLAY` è usato in H1/title/breadcrumb/schema/alt/prose: cambiarlo non è surgical (blast radius enorme + SEO).

## Test
- [x] `tests/seo/html-minify.test.ts` — 28/28 (inclusa nuova regression self-close)
- [x] `tests/border-wait-pages.test.ts` + `borderWaitHeroCard` + `borderWaitContrast` — 35/35 (ordine sezioni OK post-swap)
- [ ] Verifica live post-deploy: console pulita (0 errori `<circle>/<line>`) su `/traffico-dogane/gaggiolo/oggi/` + numero live sopra la fold mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
