### PR TITLE
fix(weekly-employers): link top employer in company-city banner + newcomer no-brand test

### DIFF
--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -3470,9 +3470,26 @@ export function renderCompanyCityPage(inp: CompanyCityPageInputs): string {
     : variant === 'archive'
       ? ccTileLabels.adviceStableArchive(weekNum, year)
       : ccTileLabels.adviceStable;
+  // Mirror the weekly-employers hub fix: link the highlighted employer's name
+  // inside the advice sentence straight to its brand hub (or job-board `?q=`
+  // fallback) so the "focus here" CTA is one tap away. `color:inherit` keeps
+  // the link readable on the tinted banner; the function-form replace avoids
+  // `$`-pattern interpretation in the name. Only when the positive-delta copy
+  // (which embeds `employer`) is in play.
+  const ccEmployerHref =
+    employerBrandPath(stats.employerKey, employer, knownSlugs) ??
+    `${weeklyEmployersJobBoardPath(locale, cityWeeklyEmployerCanton(city))}?q=${encodeURIComponent(employer)}`;
+  const ccAdviceHtml =
+    ccHasPositiveDelta && employer
+      ? esc(ccAdviceText).replace(
+          esc(employer),
+          () =>
+            `<a href="${esc(ccEmployerHref)}" style="color:inherit;text-decoration:underline;font-weight:700">${esc(employer)}</a>`,
+        )
+      : esc(ccAdviceText);
   const ccAdviceBannerHtml = `<aside data-we-advice aria-label="${esc(ccTileLabels.adviceEyebrow)}" style="${ccAdviceTone};margin:0 0 18px">
     <div class="s-a8IQOM">${esc(ccTileLabels.adviceEyebrow)}</div>
-    <p class="s-lEdUfz">${esc(ccAdviceText)}</p>
+    <p class="s-lEdUfz">${ccAdviceHtml}</p>
   </aside>`;
 
   // Phase 6 (Cathedral): per-company×city CTA points at the city's canton-

--- a/tests/weekly-employers.test.ts
+++ b/tests/weekly-employers.test.ts
@@ -413,6 +413,43 @@ describe('renderWeeklyEmployersPage', () => {
     expect(html).toContain('"@type":"FAQPage"');
   });
 
+  it('renders a newcomer WITHOUT a brand hub as a ?q= job-board link (no dead <strong>)', () => {
+    // Regression for PR #1099: newcomers used to render as a bare un-linked
+    // <strong> company name. They now render as clickable employer cards via
+    // `employerHref` — brand hub when known, `?q=` job-board fallback otherwise.
+    // This exercises the no-brand branch (employerKey undefined → no matching
+    // hub → fallback), the exact case the PR fixed.
+    const newcomerName = 'Zzqx Newcomer GmbH';
+    const stats = {
+      city: 'lugano' as WeeklyEmployersCity,
+      activeJobsCount: 5,
+      topCompanies: [
+        { employer: 'Acme SA', employerKey: 'acme', active: 5, delta: 2 },
+      ],
+      newcomers: [{ employer: newcomerName, employerKey: undefined, active: 2 }],
+      topRoles: [{ role: 'sviluppatore software', count: 2 }],
+    };
+    const html = renderWeeklyEmployersPage({
+      locale: 'it',
+      city: 'lugano',
+      variant: 'current',
+      weekNum: 17,
+      year: 2026,
+      stats,
+      hasHistoricalDelta: true,
+      canonicalPath: buildCurrentWeekPath('it', 'lugano'),
+      today: new Date('2026-04-20T12:00:00Z'),
+      indexable: true,
+    });
+    // (a) the newcomer card is a job-board link pre-filtered on the employer.
+    const encoded = encodeURIComponent(newcomerName);
+    expect(html).toContain(`?q=${encoded}`);
+    expect(html).toMatch(new RegExp(`<a href="[^"]*\\?q=${encoded.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*"`));
+    // (b) the employer name is never emitted as an un-linked <strong>.
+    expect(html).not.toContain(`<strong>${newcomerName}</strong>`);
+    expect(html).not.toMatch(/<strong>Zzqx Newcomer GmbH/);
+  });
+
   it('uses cold-start copy when no historical delta is available', () => {
     const stats = {
       city: 'stabio' as WeeklyEmployersCity,


### PR DESCRIPTION
## Implementato

Follow-up dei 2 item deferred da #1099 (funnel-ux).

**Item 1 — `renderCompanyCityPage` advice banner top-employer linkato.**
Il banner di `renderCompanyCityPage` (build-plugins/weeklyEmployersPlugin.ts) mostrava il nome del top employer come testo morto (non collegato). Applicato lo stesso pattern del fix hub weekly-employers (#1099): il nome dell'employer nella frase advice (ramo positive-delta, l'unico che lo incorpora) ora è un link al brand hub se esiste, altrimenti fallback `?q=` sul job-board canton-aware (`weeklyEmployersJobBoardPath(locale, cityWeeklyEmployerCanton(city))`). Stesso styling `color:inherit;text-decoration:underline;font-weight:700` per contrasto sul background tinto, e function-form `.replace` per evitare l'interpretazione dei pattern `$` nel nome. Mirror esatto del fix hub esistente.

**Item 2 — test newcomer-senza-brand.**
Aggiunto in `tests/weekly-employers.test.ts`, accanto al test novex (newcomer con brand key), un test per il ramo `employerHref` fallback: newcomer con `employerKey: undefined` (nessun brand hub). Asserisce (a) la card contiene `<a href` con `?q=<employer>` (link job-board), (b) nessun `<strong>` non linkato per il nome employer — esattamente lo scenario strong-tag-morto che #1099 ha risolto. Copre entrambi i rami di `employerHref`.

### Blast radius (GitNexus)
- `renderCompanyCityPage` → upstream LOW, unico chiamante `generateWeeklyEmployerPages`. Firma invariata, solo stringa HTML interna.
- `employerBrandPath` → upstream LOW, già usato da entrambi i renderer. Nessuna modifica alla funzione.

### Test
`FAST_BUILD= npx vitest run tests/weekly-employers.test.ts` → 40/40 verde (incluso il nuovo test).

## Non implementato (ancora)

- Nessuna sezione "newcomers" su `renderCompanyCityPage` (la pagina company×city è single-employer; i newcomers sono un concetto del hub city aggregato). Out of scope: l'issue richiedeva solo il linking del banner, non un riassetto strutturale della pagina.
- Nessun cambiamento ai locali EN/DE/FR oltre al rendering (copy advice già localizzato via `ccTileLabels`); nessun nuovo testo user-facing introdotto.

Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)