### PR TITLE
ci(lighthouse): add postcss/tsconfig to push paths + document PR-trigger asymmetry (#983)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,6 +15,19 @@ name: Lighthouse CI
 on:
   pull_request:
     branches: [main]
+    # Accepted-by-design asymmetry vs the push:main paths below (issue #983):
+    # this PR trigger intentionally keeps a NARROWER include-list (no
+    # components/**, App.tsx, services/** etc.). Two reasons make the
+    # asymmetry deliberate, not a gap:
+    #   1. The job audits PRODUCTION live (https://frontaliereticino.ch), NOT
+    #      the PR's own build — so running it on a component-only PR would
+    #      re-measure already-deployed prod, not the proposed change. Pre-merge
+    #      symmetry with push:main is therefore largely moot.
+    #   2. Most PRs touch components/** / services/**; widening here would fire
+    #      this heavy job on nearly every PR for no added pre-merge signal.
+    # The push:main trigger (runs after the change is live) is the real
+    # regression gate. Revisit only if the PR job is ever pointed at the PR's
+    # own preview build instead of prod.
     paths:
       - 'build-plugins/**'
       - 'services/locales/**'
@@ -45,10 +58,15 @@ on:
       - 'build-plugins/**'
       - 'public/**'
       # Build / dependency config that changes the emitted bundle.
+      # Same rationale as tailwind.config.js/vite.config.ts: postcss.config.js
+      # alters emitted CSS (autoprefixer / transforms) and tsconfig.json alters
+      # emitted JS (target / compile), so both can shift rendered output → CLS.
       - 'vite.config.ts'
       - 'package.json'
       - 'package-lock.json'
       - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - 'tsconfig.json'
       # The audit definition itself.
       - 'lighthouserc.json'
       - '.github/workflows/lighthouse-ci.yml'


### PR DESCRIPTION
Closes #983

Follow-up to #978: two deferred items on the `lighthouse-ci.yml` paths filters.

## Implementato

**Item 1 — push:main include-list gap (reviewer 🟡 nit).** Added `postcss.config.js` and `tsconfig.json` to the `push:main` `paths` include-list (verified both exist at repo root). They alter emitted output by the same logic that already includes `tailwind.config.js` / `vite.config.ts`: `postcss.config.js` changes emitted CSS (autoprefixer / transforms), `tsconfig.json` changes emitted JS (target / compile). Both can shift rendered output → CLS → AdSense RPM. Without them, changes to these files would not trigger the Lighthouse gate on `push:main`. An inline comment records the rationale.

**Item 2 — pull_request ↔ push:main paths asymmetry: documented as accepted-by-design.** Chose the documented-tradeoff option over expanding the `pull_request` paths, because:
- The `pull_request` job audits **production live** (`https://frontaliereticino.ch`), NOT the PR's own build. Running it on a component-only PR re-measures already-deployed prod, not the proposed change — so pre-merge symmetry with `push:main` is largely moot.
- Most PRs touch `components/**` / `services/**`; widening the PR trigger would fire this heavy job on nearly every PR for zero added pre-merge signal.

The `push:main` trigger (runs after the change is live) remains the real regression gate. Added an inline comment on the `pull_request` block documenting the asymmetry and noting it should be revisited only if the PR job is ever pointed at the PR's own preview build instead of prod.

## Non implementato (ancora)

- **Expanding the `pull_request` paths for literal symmetry** — deliberately not done (see Item 2). It would add cost (Lighthouse on most PRs) with no pre-merge value while the job audits prod rather than the PR build. Out of scope; the asymmetry is now documented as accepted-by-design rather than left as a silent gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)