### PR TITLE
fix(ci): PAT/token hardening — refine-url PR creation + traffic watchdog (#1106, #1114)

### DIFF
--- a/.github/workflows/refine-url-first-seen.yml
+++ b/.github/workflows/refine-url-first-seen.yml
@@ -64,6 +64,20 @@ jobs:
           echo "Running: node scripts/refine-url-first-seen-via-gsc.mjs $FLAGS"
           node scripts/refine-url-first-seen-via-gsc.mjs $FLAGS
 
+      # Load GITHUB_PAT (Firebase Remote Config) into $GITHUB_ENV. The GSC SA
+      # materialized above doubles as the Firebase SA, so RC is reachable here
+      # (must run BEFORE "Cleanup SA" deletes /tmp/sa.json). Needed because a
+      # `gh pr create` authenticated by secrets.GITHUB_TOKEN is rejected by
+      # GitHub anti-recursion ("GitHub Actions is not permitted to create pull
+      # requests") → the old PR step failed red on every data diff and the
+      # grace-window/GSC refresh never landed (issue #1114). The PAT creates the
+      # PR as a real user, which is permitted.
+      - name: Load RC secrets (GITHUB_PAT)
+        if: inputs.dry_run == 'false'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+        run: node scripts/load-rc-env.mjs
+
       - name: Cleanup SA
         if: always()
         run: rm -f /tmp/sa.json
@@ -71,11 +85,19 @@ jobs:
       - name: Open PR if data changed
         if: inputs.dry_run == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_PAT is loaded into $GITHUB_ENV by the RC step above (Firebase
+          # RC, NOT an Actions secret — `secrets.GH_PAT` does not exist). Used
+          # for BOTH the branch push and `gh pr create`: a PR created with
+          # secrets.GITHUB_TOKEN is blocked by anti-recursion (issue #1114).
+          GH_TOKEN: ${{ env.GITHUB_PAT }}
         run: |
           if git diff --quiet data/url-first-seen.json; then
             echo "No diff in data/url-first-seen.json — nothing to PR."
             exit 0
+          fi
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GITHUB_PAT not loaded from Remote Config — cannot create PR (a secrets.GITHUB_TOKEN PR is blocked by anti-recursion). Check Firebase SA / RC availability."
+            exit 1
           fi
           BRANCH="chore/url-first-seen-refresh-${GITHUB_RUN_ID}"
           git config user.name "url-first-seen-bot"
@@ -83,7 +105,9 @@ jobs:
           git checkout -b "$BRANCH"
           git add data/url-first-seen.json
           git commit -m "chore(grace-window): GSC refinement (run ${GITHUB_RUN_ID})"
-          git push origin "$BRANCH"
+          # Push with the PAT in the URL: the credential persisted by
+          # actions/checkout is the GITHUB_TOKEN, which cannot open the PR below.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH"
           gh pr create \
             --base main \
             --head "$BRANCH" \

--- a/.github/workflows/traffic-data-freshness.yml
+++ b/.github/workflows/traffic-data-freshness.yml
@@ -105,6 +105,30 @@ jobs:
         if: steps.check.outputs.STALE == 'true'
         run: node scripts/load-rc-env.mjs
 
+      # Fail LOUD if the PAT didn't load. load-rc-env.mjs exits 0 even when
+      # Firebase auth fails (creds expired, network, RC downtime) WITHOUT setting
+      # GITHUB_PAT → trigger-self.sh would then find no token and silently skip
+      # (exit 0) — the exact no-op #1104 claimed to fix. Failing here surfaces
+      # the regression to the owner (red run + failure issue) instead of letting
+      # the watchdog quietly degrade. The page's OWN traffic-scheduler cron +
+      # runtime-fetch fallback stay intact, so the funnel never stops — but the
+      # self-heal reliability is now observable, not assumed (issue #1106 item 1).
+      - name: Verify PAT loaded (fail-loud guard)
+        if: steps.check.outputs.STALE == 'true'
+        run: |
+          if [ -z "${GITHUB_PAT:-}" ]; then
+            echo "::error::GITHUB_PAT not set after load-rc-env.mjs — Firebase/RC auth likely failed. Self-heal dispatch would silently no-op (the regression #1104 addressed). Check Firebase SA credentials / RC availability."
+            {
+              echo "### ⚠️ Self-heal PAT load FAILED"
+              echo ""
+              echo "\`GITHUB_PAT\` is unset after \`load-rc-env.mjs\` — Firebase/RC auth failed."
+              echo "The traffic-scheduler self-heal dispatch would have silently no-op'd."
+              echo "Page funnel is protected by traffic-scheduler cron + runtime fetch, but the watchdog needs attention."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "GITHUB_PAT present — self-heal dispatch can proceed."
+
       - name: Self-heal — dispatch traffic-scheduler (via PAT)
         if: steps.check.outputs.STALE == 'true'
         continue-on-error: true

--- a/.github/workflows/traffic-scheduler.yml
+++ b/.github/workflows/traffic-scheduler.yml
@@ -18,7 +18,14 @@ on:
 
 concurrency:
   group: traffic-scheduler
-  cancel-in-progress: true
+  # cancel-in-progress is FALSE so a freshness-watchdog re-dispatch (issue #1106
+  # item 2) can never cancel an in-flight run that is about to write the data
+  # file: under sustained stale (>90min) the hourly watchdog dispatches this
+  # workflow every hour, and with cancel=true an arriving dispatch would kill a
+  # */15 cron run mid-collect, leaving data stale → watchdog re-dispatches → loop.
+  # Runs are ≤10min and crons are spaced ≥15min, so serialized queueing (group
+  # without cancel) still prevents overlap without the cancellation race.
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Implementato

Bundle di hardening token/PAT su GitHub Actions (entrambe le issue toccano lo stesso anti-pattern `secrets.GITHUB_TOKEN` su path che richiedono un PAT).

### #1114 — `refine-url-first-seen.yml`: `gh pr create` con `GITHUB_TOKEN` non landa mai
Stesso anti-pattern che PR #1110 ha stabilito come rotto: un `gh pr create` autenticato con `secrets.GITHUB_TOKEN` è bloccato dall'anti-recursion di GitHub ("GitHub Actions is not permitted to create pull requests"). Lo step "Open PR if data changed" falliva **rosso a ogni diff** di `data/url-first-seen.json` → il refresh grace-window/GSC non landava mai.
- **Pivot a `GITHUB_PAT`** (Firebase Remote Config). La SA GSC materializzata nel workflow **doppia come Firebase SA**, quindi RC è raggiungibile: nuovo step `Load RC secrets (GITHUB_PAT)` eseguito **prima** del cleanup di `/tmp/sa.json`.
- Push del branch **e** `gh pr create` ora usano `${{ env.GITHUB_PAT }}` (push via URL `x-access-token:$PAT` perché la credenziale persistita da `actions/checkout` è il `GITHUB_TOKEN`).
- **Fail-loud** se il PAT non si carica (`exit 1` con `::error::`) invece di un fallimento opaco di `gh pr create`.
- Coerente col pattern repo per workflow che devono triggerare/landare via PAT (`sync-gsc-orphans.yml`, `compress-contract-docs.yml` post-#1110).

### #1106 item 1 — `traffic-data-freshness.yml`: self-heal silent-no-op se RC auth fallisce
`load-rc-env.mjs` esce **0 non-bloccante** anche quando l'auth Firebase fallisce (creds scadute, network, RC downtime) **senza** settare `GITHUB_PAT` → `trigger-self.sh` non trova token → skip silenzioso (exit 0): esattamente il no-op che #1104 dichiarava di risolvere.
- Nuovo step **`Verify PAT loaded (fail-loud guard)`** dopo `load-rc-env.mjs`: se `GITHUB_PAT` è vuoto → `exit 1` + `::error::` + alert nel `$GITHUB_STEP_SUMMARY`, così l'owner se ne accorge (run rosso + failure-issue dello step finale).
- **Non rompe il path non-dispatch**: il guard è gated su `STALE == 'true'`; il cron proprio di `traffic-scheduler` + il runtime-fetch della pagina restano intatti → il funnel non si ferma. La reliability del watchdog diventa **osservabile**, non assunta.

### #1106 item 2 — `traffic-scheduler.yml`: race `cancel-in-progress` sotto stale prolungato
Sotto stale >90min il watchdog ridispatcha `traffic-scheduler` ogni ora; il target aveva `cancel-in-progress: true`. Un dispatch in arrivo poteva cancellare un run cron `*/15` **in volo prima del write dei dati** → dati restano stale → ridispatch → loop.
- **`cancel-in-progress: true → false`**: il concurrency group **serializza** ancora (niente overlap), ma non cancella più un run che sta per scrivere il file dati. Run ≤10min, cron spaziati ≥15min → il queueing è sicuro e rompe la race di cancellazione senza disabilitare il dedup legittimo.

## Non implementato (ancora)
- **Retry/fallback dentro `load-rc-env.mjs`** (item 1 menziona "verificare anche che l'auth Firebase su STALE path sia robusta — retry/fallback"): out of scope per questa PR chirurgica. Il fail-loud rende il failure visibile; un retry interno è un follow-up separato che tocca uno script condiviso da ~30 workflow (blast radius alto, va valutato a parte).
- **Validazione empirica live** della race di cancellazione (#1106 item 2 suggerisce in alternativa "verificare empiricamente i log"): scelto il fix conservativo (config-only) invece dell'osservazione, come consentito dall'issue. Da confermare sui run post-merge.
- **Self-merge**: questa PR tocca file `.github/workflows/` → può incappare nel workflow-validation gate (reviewer-bot non posta `## LGTM`, auto-merge non scatta). **Richiede merge manuale dell'owner** via `gh pr merge --squash --delete-branch`.

Closes #1106
Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)