### PR TITLE
fix(job-alerts): write maileroo_message_meta for open/click attribution

### DIFF
--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -815,7 +815,28 @@ async function sendBatch(emails) {
     };
   });
 
-  const result = await sendEmailCascade(cascadeEmails, { concurrency: 3 });
+  // Maileroo's open/click webhooks carry only message_reference_id (no recipient,
+  // no tags). Persist an authoritative lookup record keyed by that id so the webhook
+  // can attribute opens/clicks to the job-alert subscriber. Mirrors the newsletter
+  // path in send-newsletter.mjs (persistDelivery). See
+  // functions/src/newsletterMailerooWebhookCore.js.
+  const onSent = async (item, sendResult) => {
+    if (sendResult?.provider !== 'maileroo' || !sendResult?.messageId) return;
+    const email = item.recipient?.email;
+    if (!email) return;
+    try {
+      const db = await getFirestoreAdmin();
+      await db.collection('maileroo_message_meta').doc(String(sendResult.messageId)).set({
+        email,
+        is_job_alert: true,
+        updated_at: new Date(),
+      }, { merge: true });
+    } catch (e) {
+      console.warn('⚠️ Maileroo meta persist failed:', e?.message);
+    }
+  };
+
+  const result = await sendEmailCascade(cascadeEmails, { concurrency: 3, onSent });
   logProviderSummary();
   return {
     sent: result.sent.length,

--- a/tests/newsletter-maileroo-webhook-core.test.ts
+++ b/tests/newsletter-maileroo-webhook-core.test.ts
@@ -165,9 +165,12 @@ describe('newsletterMailerooWebhookCore', () => {
   });
 
   it('routes opened/clicked to job_alert_subscribers when the lookup record flags job-alert', async () => {
+    // send-job-alerts.mjs (sendBatch onSent) writes exactly { email, is_job_alert: true }
+    // to maileroo_message_meta/{referenceId} — no campaign_id (job-alerts have no
+    // campaign concept). Mirror that prod shape here.
     const db = createFakeDb({
       maileroo_message_meta: {
-        ref_ja: { email: 'seeker@example.com', campaign_id: 'job_alert_x', is_job_alert: true },
+        ref_ja: { email: 'seeker@example.com', is_job_alert: true },
       },
     });
 


### PR DESCRIPTION
## Implementato
- `scripts/send-job-alerts.mjs` (`sendBatch`): aggiunge una callback `onSent` passata a `sendEmailCascade`. Per ogni invio andato a buon fine via provider `maileroo`, scrive il record di lookup `maileroo_message_meta/{referenceId}` = `{ email, is_job_alert: true, updated_at }` (merge). Rispecchia il path newsletter di `send-newsletter.mjs:persistDelivery` (fix #1069). `referenceId` = `result.messageId`, che per Maileroo nel cascade è `data.data.reference_id`; `email` = `item.recipient.email` (= destinatario job-alert).
- Effetto: i webhook Maileroo `opened`/`clicked` per le email job-alert ora risolvono il subscriber tramite il record meta invece di cadere su `skipped` (vedi `functions/src/newsletterMailerooWebhookCore.js`, lookup su `maileroo_message_meta/{refId}`).
- `tests/newsletter-maileroo-webhook-core.test.ts`: il test job-alert lookup-record ora semina la forma reale scritta in prod (`{ email, is_job_alert: true }`, **senza** `campaign_id` — i job-alert non hanno concetto di campaign; il `campaignId` cade sul fallback `extractCampaignId`). Il path newsletter resta intatto.

Blast radius (GitNexus, upstream `sendBatch`): LOW — unico caller diretto `main()` nello stesso file; return shape invariata (aggiunta solo opzione `onSent`, già supportata da `sendEmailCascade`).

Test: `tests/newsletter-maileroo-webhook-core.test.ts` 13/13 verde, `tests/job-alert-email.test.ts` 63/63 verde. `node --check` su `send-job-alerts.mjs` OK.

## Non implementato (ancora)
- Nessun backfill retroattivo dei messaggi job-alert già inviati prima di questo fix (non risolvibili: i loro webhook open/click restano non attribuiti). Out of scope: il fix è forward-only, identico al comportamento di #1069 per la newsletter.
- Nessun `campaign_id` nel record job-alert: i job-alert non hanno un campaign id stabile; il webhook usa già il fallback `extractCampaignId`. Intenzionale, non un gap.

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)