### PR TITLE
refactor(newsletter): nest maileroo lookup under newsletter_subscribers/_meta_

### DIFF
--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -89,6 +89,21 @@ function getOccurredAt(event) {
   return new Date().toISOString();
 }
 
+// ── Resolve the refId → recipient lookup record ──────────────
+// Primary location is newsletter_subscribers/_meta_/maileroo_refs/{refId} (aligned
+// with the rest of the tracking). The legacy top-level maileroo_message_meta is read
+// as a fallback so in-flight messages sent before this change still attribute their
+// opens/clicks during the transition window.
+async function readMailerooRef(db, refId) {
+  const primary = (await db.collection('newsletter_subscribers').doc('_meta_')
+    .collection('maileroo_refs').doc(refId).get()).data();
+  if (primary && typeof primary.email === 'string' && primary.email.includes('@')) {
+    return primary;
+  }
+  const legacy = (await db.collection('maileroo_message_meta').doc(refId).get()).data();
+  return legacy || primary || null;
+}
+
 // ── Persist a single event to Firestore ──────────────────────
 
 export async function persistMailerooEvent(db, event) {
@@ -100,15 +115,13 @@ export async function persistMailerooEvent(db, event) {
 
   // Maileroo 'opened'/'clicked' events carry NEITHER the recipient nor tags —
   // only message_reference_id. The send pipeline (persistDelivery) writes an
-  // authoritative lookup record at maileroo_message_meta/{referenceId} with the
-  // real recipient, campaign id and job-alert flag. Read it (keyed by refId) to
-  // resolve the subscriber for opens/clicks and to enrich campaign/routing that
-  // the webhook payload itself omits. Falls back to the event fields when the
-  // record is absent (e.g. an 'accepted'/'delivered' event, which does carry the
-  // recipient in event_data.to).
-  const metaDoc = refId
-    ? (await db.collection('maileroo_message_meta').doc(refId).get()).data()
-    : null;
+  // authoritative lookup record at newsletter_subscribers/_meta_/maileroo_refs/
+  // {referenceId} with the real recipient, campaign id and job-alert flag. Read it
+  // (keyed by refId) to resolve the subscriber for opens/clicks and to enrich
+  // campaign/routing that the webhook payload itself omits. Falls back to the event
+  // fields when the record is absent (e.g. an 'accepted'/'delivered' event, which
+  // does carry the recipient in event_data.to).
+  const metaDoc = refId ? await readMailerooRef(db, refId) : null;
   // The lookup record is only authoritative if it actually resolved an email.
   const meta = (metaDoc && typeof metaDoc.email === 'string' && metaDoc.email.includes('@')) ? metaDoc : null;
   const email = meta ? meta.email : getRecipient(event);

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1430,10 +1430,12 @@ async function persistDelivery(recipient, messageId, meta) {
     }, { merge: true });
     // Maileroo's open/click webhooks carry only message_reference_id (no recipient,
     // no tags). Persist an authoritative lookup keyed by that id so the webhook can
-    // resolve the subscriber + real campaign for opens/clicks. See
+    // resolve the subscriber + real campaign for opens/clicks. Stored under
+    // newsletter_subscribers/_meta_/maileroo_refs (same family as the rest of the
+    // tracking) rather than a top-level collection. See
     // functions/src/newsletterMailerooWebhookCore.js.
     if (meta.provider === 'maileroo' && messageId) {
-      await db.collection('maileroo_message_meta').doc(String(messageId)).set({
+      await metaDocRef().collection('maileroo_refs').doc(String(messageId)).set({
         email,
         campaign_id: meta.campaignId,
         is_job_alert: false,

--- a/tests/newsletter-maileroo-webhook-core.test.ts
+++ b/tests/newsletter-maileroo-webhook-core.test.ts
@@ -28,6 +28,13 @@ function createFakeDb(existingDocs: Record<string, Record<string, Record<string,
             set: async (data: Record<string, unknown>, _opts?: unknown) => {
               sets.push({ collection: subPath, docId: subDocId, data });
             },
+            get: async () => {
+              const docData = existingDocs[subPath]?.[subDocId];
+              return {
+                exists: !!docData,
+                data: () => docData || undefined,
+              };
+            },
           }),
           add: async (data: Record<string, unknown>) => {
             adds.push({ collection: subPath, data });
@@ -137,11 +144,11 @@ describe('newsletterMailerooWebhookCore', () => {
     expect(db.__sets.some((s) => s.collection === 'newsletter_subscribers')).toBe(false);
   });
 
-  it('resolves recipient for opened/clicked events (no recipient/tags in payload) via maileroo_message_meta', async () => {
+  it('resolves recipient for opened/clicked events (no recipient/tags in payload) via newsletter_subscribers/_meta_/maileroo_refs', async () => {
     // Maileroo opened/clicked webhooks carry only message_reference_id — the send
     // pipeline pre-seeds the lookup record. Verify the click is attributed.
     const db = createFakeDb({
-      maileroo_message_meta: {
+      'newsletter_subscribers/_meta_/maileroo_refs': {
         ref_abc: { email: 'resolved@example.com', campaign_id: 'weekly_2026-06-01', is_job_alert: false },
       },
     });
@@ -166,7 +173,7 @@ describe('newsletterMailerooWebhookCore', () => {
 
   it('routes opened/clicked to job_alert_subscribers when the lookup record flags job-alert', async () => {
     const db = createFakeDb({
-      maileroo_message_meta: {
+      'newsletter_subscribers/_meta_/maileroo_refs': {
         ref_ja: { email: 'seeker@example.com', campaign_id: 'job_alert_x', is_job_alert: true },
       },
     });
@@ -179,6 +186,30 @@ describe('newsletterMailerooWebhookCore', () => {
     });
 
     expect(result).toMatchObject({ processed: true, type: 'open', collection: 'job_alert_subscribers' });
+  });
+
+  it('falls back to legacy maileroo_message_meta for in-flight refs', async () => {
+    // Messages sent before the path migration stored their lookup in the top-level
+    // collection. The webhook must still attribute their opens/clicks.
+    const db = createFakeDb({
+      maileroo_message_meta: {
+        ref_legacy: { email: 'legacy@example.com', campaign_id: 'weekly_old', is_job_alert: false },
+      },
+    });
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'opened',
+      message_reference_id: 'ref_legacy',
+      tags: null,
+      event_data: { ip: '7.7.7.7' },
+    });
+
+    expect(result).toMatchObject({
+      processed: true,
+      type: 'open',
+      email: 'legacy@example.com',
+      campaignId: 'weekly_old',
+    });
   });
 
   it('skips opened/clicked when no lookup record exists (unattributable)', async () => {


### PR DESCRIPTION
## Implementato

Allinea il tracking Maileroo agli altri provider spostando la tabella di lookup `refId→recipient` da una collection top-level a una sotto la famiglia `newsletter_subscribers`.

- **Write** (`scripts/send-newsletter.mjs`): `persistDelivery` scrive il record lookup in `newsletter_subscribers/_meta_/maileroo_refs/{messageId}` (via `metaDocRef()`, stessa convenzione di `campaign_sends`/`campaign_logs`) invece di `maileroo_message_meta/{messageId}`. Stessi 4 campi (`email`, `campaign_id`, `is_job_alert`, `updated_at`).
- **Read** (`functions/src/newsletterMailerooWebhookCore.js`): nuovo helper `readMailerooRef(db, refId)` legge prima il path nidificato; **fallback** alla legacy `maileroo_message_meta` per i messaggi già inviati prima del deploy (finestra di transizione → nessuna perdita di attribution open/click).
- **Test**: fixtures aggiornate al nuovo path + nuovo test `falls back to legacy maileroo_message_meta for in-flight refs`. Fake DB subcollection ora supporta `.get()`. 14/14 verdi.

### Perché
Il tracking effettivo (counters, `campaign_deliveries`, `events`) era **già** su `newsletter_subscribers` come tutti i provider. `maileroo_message_meta` non era tracking parallelo ma un indice reverse, necessario perché i webhook `opened`/`clicked` di Maileroo portano solo `message_reference_id` (no recipient, no tags). Questa PR è puramente cosmetica: porta anche quell'indice dentro la stessa famiglia di collection, senza cambiare logica.

## Non implementato (ancora)

- **Eliminazione dell'indice di lookup**: out of scope. Non possibile finché Maileroo non echeggia il recipient/tag negli eventi open/click; l'indice reverse resta necessario.
- **Migrazione dati legacy esistenti**: non necessaria. Il fallback read copre gli in-flight; i record vecchi scadono naturalmente (sono usati solo finché arrivano open/click per quella campagna). Nessun backfill.
- **Rimozione del ramo fallback legacy**: follow-up, da fare dopo che tutte le campagne pre-deploy hanno smesso di generare open/click (qualche settimana).

🤖 Generated with [Claude Code](https://claude.com/claude-code)