### PR TITLE
test(seo): cover rate-mode ratchet gates + harden bfs new-shard tier (#1095)

### DIFF
--- a/scripts/audit-bfs-depth.mjs
+++ b/scripts/audit-bfs-depth.mjs
@@ -349,6 +349,82 @@ function printTable(perSitemap) {
   }
 }
 
+// maxDeltaPp caps the relative term: a sitemap already ~75% below crawl depth
+// would otherwise tolerate +11pp from relPct alone (a silent indexability
+// regression). With the cap the worst-case slack is maxDeltaPp + absPp.
+export const DEFAULT_BFS_TOL = { relPct: 15, absPp: 5, minAbsDelta: 20, maxDeltaPp: 8 };
+
+// Item 2 hard-fail (#1095): a brand-new sitemap shard has no baseline entry so
+// the per-shard rate ratchet cannot judge it. Without this gate an entire new
+// content tier shipping 100% below crawl depth would only WARN and then get
+// "floored" into the next rebaseline — buried state accepted forever (zero
+// organic traffic on that tier). We hard-fail a non-baseline shard only when it
+// is overwhelmingly buried AND carries enough URLs to be a real tier (not a
+// 1-2 URL fluke). The thresholds are deliberately conservative so a legit new
+// tier with a shallow hub link path never trips them: a new shard is expected
+// to be reachable, so ≥90% buried over ≥minAbsDelta URLs is a genuine bug, not
+// organic noise.
+export const NEW_SHARD_BURIED_RATE_FAIL = 90; // percent of URLs below crawl depth
+
+/**
+ * Pure decision core of the BFS-depth ratchet. Compares the current per-sitemap
+ * roll-up against a baseline and classifies each shard. No I/O, no process.exit
+ * — returns structured results the CLI turns into logs + exit codes. Exported so
+ * the rate-gate AND the new-shard hard-fail are unit-testable (issue #1095).
+ *
+ * @param {object} args
+ * @param {Record<string, { total: number; atDepthGtMax: number; deepest: number }>} args.perSitemap
+ * @param {object} args.baseline  parsed baseline JSON ({ mode|version, perSitemap, tolerance })
+ * @param {{ relPct: number; absPp: number; minAbsDelta: number; maxDeltaPp: number }} [args.tol]
+ * @returns {{
+ *   regressions: Array<{ name: string; prev: number; current: number; deepest: number; prevRate?: number; curRate?: number; rateCap?: number }>,
+ *   unbaselined: Array<{ name: string; atDepthGtMax: number; ratePct: number }>,
+ *   buriedNewShards: Array<{ name: string; atDepthGtMax: number; total: number; ratePct: number }>
+ * }}
+ */
+export function evaluateBfsGate({ perSitemap, baseline, tol }) {
+  const isRate = baseline?.mode === 'rate' || Number(baseline?.version) >= 2;
+  const resolvedTol = { ...DEFAULT_BFS_TOL, ...(tol ?? baseline?.tolerance ?? {}) };
+  const regressions = [];
+  const unbaselined = [];
+  const buriedNewShards = [];
+  for (const [name, row] of Object.entries(perSitemap)) {
+    const prev = baseline?.perSitemap?.[name];
+    if (!prev) {
+      // A brand-new sitemap shard has no baseline entry, so the rate ratchet
+      // can't judge it (same in v1). Surface ones that ship buried URLs as a
+      // NON-gating warning so an entirely-buried new content tier doesn't slip
+      // in silently — it gets registered (and floored) on the next rebaseline.
+      if (row.atDepthGtMax > 0) {
+        const ratePct = row.total ? Number((row.atDepthGtMax / row.total * 100).toFixed(2)) : 0;
+        unbaselined.push({ name, atDepthGtMax: row.atDepthGtMax, ratePct });
+        // Item 2 (#1095): hard-fail an overwhelmingly-buried new tier so it can
+        // never be silently floored into the baseline as "accepted buried".
+        if (ratePct >= NEW_SHARD_BURIED_RATE_FAIL && row.atDepthGtMax >= resolvedTol.minAbsDelta) {
+          buriedNewShards.push({ name, atDepthGtMax: row.atDepthGtMax, total: row.total, ratePct });
+        }
+      }
+      continue;
+    }
+    const prevOff = Number(prev.atDepthGtMax ?? 0);
+    if (isRate) {
+      // Rate-ratchet: fail only when the share below crawl depth genuinely
+      // worsens (beyond tolerance) AND the offender count grows meaningfully.
+      // Organic URL growth keeps the rate flat → no regression.
+      const curRate = row.total ? (row.atDepthGtMax / row.total * 100) : 0;
+      const prevRate = Number(prev.ratePct ?? (Number(prev.total ?? 0) ? prevOff / Number(prev.total) * 100 : 0));
+      const rateCap = prevRate + Math.min(prevRate * resolvedTol.relPct / 100, resolvedTol.maxDeltaPp) + resolvedTol.absPp;
+      if (curRate > rateCap && row.atDepthGtMax > prevOff + resolvedTol.minAbsDelta) {
+        regressions.push({ name, prev: prevOff, current: row.atDepthGtMax, deepest: row.deepest, prevRate: Number(prevRate.toFixed(3)), curRate: Number(curRate.toFixed(3)), rateCap: Number(rateCap.toFixed(3)) });
+      }
+    } else if (row.atDepthGtMax > prevOff) {
+      // Legacy v1 absolute-count ratchet (un-migrated baseline).
+      regressions.push({ name, prev: prevOff, current: row.atDepthGtMax, deepest: row.deepest });
+    }
+  }
+  return { regressions, unbaselined, buriedNewShards };
+}
+
 // ---------------------------------------------------------------------------
 // Main.
 // ---------------------------------------------------------------------------
@@ -420,11 +496,6 @@ async function main() {
     };
   }
 
-  // maxDeltaPp caps the relative term: a sitemap already ~75% below crawl depth
-  // would otherwise tolerate +11pp from relPct alone (a silent indexability
-  // regression). With the cap the worst-case slack is maxDeltaPp + absPp.
-  const DEFAULT_BFS_TOL = { relPct: 15, absPp: 5, minAbsDelta: 20, maxDeltaPp: 8 };
-
   if (WRITE_BASELINE_PATH && typeof WRITE_BASELINE_PATH === 'string') {
     const baseline = {
       version: 2,
@@ -465,43 +536,42 @@ async function main() {
       console.error(`   --max-depth=${baseline.maxDepth} or rebaseline with the new value.`);
       process.exit(2);
     }
-    const isRate = baseline.mode === 'rate' || Number(baseline.version) >= 2;
-    const tol = { ...DEFAULT_BFS_TOL, ...(baseline.tolerance ?? {}) };
-    /** @type {Array<{ name: string; prev: number; current: number; deepest: number; prevRate?: number; curRate?: number; rateCap?: number }>} */
-    const regressions = [];
-    /** @type {Array<{ name: string; atDepthGtMax: number; ratePct: number }>} */
-    const unbaselined = [];
-    for (const [name, row] of Object.entries(perSitemap)) {
-      const prev = baseline.perSitemap?.[name];
-      if (!prev) {
-        // A brand-new sitemap shard has no baseline entry, so the ratchet can't
-        // judge it (same in v1). Surface ones that ship buried URLs as a
-        // NON-gating warning so an entirely-buried new content tier doesn't slip
-        // in silently — it gets registered (and floored) on the next rebaseline.
-        if (row.atDepthGtMax > 0) unbaselined.push({ name, atDepthGtMax: row.atDepthGtMax, ratePct: row.total ? Number((row.atDepthGtMax / row.total * 100).toFixed(2)) : 0 });
-        continue;
-      }
-      const prevOff = Number(prev.atDepthGtMax ?? 0);
-      if (isRate) {
-        // Rate-ratchet: fail only when the share below crawl depth genuinely
-        // worsens (beyond tolerance) AND the offender count grows meaningfully.
-        // Organic URL growth keeps the rate flat → no regression.
-        const curRate = row.total ? (row.atDepthGtMax / row.total * 100) : 0;
-        const prevRate = Number(prev.ratePct ?? (Number(prev.total ?? 0) ? prevOff / Number(prev.total) * 100 : 0));
-        const rateCap = prevRate + Math.min(prevRate * tol.relPct / 100, tol.maxDeltaPp) + tol.absPp;
-        if (curRate > rateCap && row.atDepthGtMax > prevOff + tol.minAbsDelta) {
-          regressions.push({ name, prev: prevOff, current: row.atDepthGtMax, deepest: row.deepest, prevRate: Number(prevRate.toFixed(3)), curRate: Number(curRate.toFixed(3)), rateCap: Number(rateCap.toFixed(3)) });
-        }
-      } else if (row.atDepthGtMax > prevOff) {
-        // Legacy v1 absolute-count ratchet (un-migrated baseline).
-        regressions.push({ name, prev: prevOff, current: row.atDepthGtMax, deepest: row.deepest });
-      }
-    }
+    const { regressions, unbaselined, buriedNewShards } = evaluateBfsGate({ perSitemap, baseline });
     if (unbaselined.length > 0) {
       process.stderr.write(`\n[audit-bfs-depth] WARNING (non-gating): ${unbaselined.length} sitemap shard(s) not in baseline ship URLs below crawl depth — rebaseline to register (and floor) them:\n`);
       for (const u of unbaselined.sort((a, b) => b.ratePct - a.ratePct)) {
         process.stderr.write(`  ${u.name}: ${u.atDepthGtMax} URLs > depth ${MAX_DEPTH} (${u.ratePct}%)\n`);
       }
+    }
+    // Item 2 hard-fail (#1095): a new, un-baselined shard that is overwhelmingly
+    // buried (≥ NEW_SHARD_BURIED_RATE_FAIL% of ≥ minAbsDelta URLs below crawl
+    // depth) is a genuine indexability hole, not organic noise. Block the build
+    // so it can never be silently floored into the baseline as "accepted buried".
+    if (buriedNewShards.length > 0) {
+      console.error('\n══════════════════════════════════════════════════════════════════════');
+      console.error('FAIL: new sitemap shard ships an entire content tier below crawl depth');
+      console.error('══════════════════════════════════════════════════════════════════════');
+      console.error('');
+      console.error('A brand-new sitemap shard has no baseline entry, so the rate ratchet');
+      console.error('cannot judge it. These shards ship the OVERWHELMING majority of their');
+      console.error(`URLs at BFS depth > ${MAX_DEPTH} from / — effectively orphan from`);
+      console.error('Ahrefs/Googlebot, which cap crawl depth. Floored into the next');
+      console.error('baseline they would be accepted buried forever (zero organic traffic).');
+      console.error('');
+      for (const b of buriedNewShards.sort((a, c) => c.ratePct - a.ratePct)) {
+        const full = perSitemap[b.name]?.offendersList || [];
+        console.error(`  ${b.name}: ${b.atDepthGtMax}/${b.total} URLs (${b.ratePct}%) at depth > ${MAX_DEPTH}`);
+        for (const o of full) console.error(`    depth=${o.depth}  ${o.url}`);
+      }
+      console.error('');
+      console.error('How to fix');
+      console.error('----------');
+      console.error(`Link this tier's URLs from a hub page at depth ≤ ${MAX_DEPTH - 1} so real`);
+      console.error('crawlers reach them, then rebuild. Per CLAUDE.md non-negotiable #5:');
+      console.error('orphans are fixed via internal links, never noindex, never by');
+      console.error('flooring the buried state into the baseline.');
+      await writeReport(false, { before: 0, after: buriedNewShards.reduce((s, b) => s + b.atDepthGtMax, 0), regression: buriedNewShards.reduce((s, b) => s + b.atDepthGtMax, 0) });
+      process.exit(1);
     }
     if (regressions.length > 0) {
       console.error('\n══════════════════════════════════════════════════════════════════════');
@@ -567,7 +637,16 @@ async function main() {
   await writeReport(flatOffenders.length === 0, null);
 }
 
-main().catch((err) => {
-  console.error('audit-bfs-depth crashed:', err.stack || err.message);
-  process.exit(2);
-});
+// Only crawl + gate when run as a CLI. Importing this module (e.g. the unit
+// tests for `evaluateBfsGate`) must NOT trigger the live sitemap fetch / BFS.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('audit-bfs-depth crashed:', err.stack || err.message);
+    process.exit(2);
+  });
+}

--- a/tests/seo/audit-bfs-depth-rate-gate.test.ts
+++ b/tests/seo/audit-bfs-depth-rate-gate.test.ts
@@ -1,0 +1,184 @@
+/**
+ * audit-bfs-depth-rate-gate.test.ts
+ *
+ * Unit coverage for the rate-based BFS-depth ratchet introduced in PR #1085
+ * and the new-shard hard-fail added for issue #1095. The gating decision lives
+ * in the pure, exported `evaluateBfsGate` (scripts/audit-bfs-depth.mjs) so it
+ * can be exercised without crawling a live dist.
+ *
+ * The gate is funnel-critical: it is the primary defence against false-fails
+ * from organic URL growth (churn category #1077) while still catching a real
+ * internal-link regression that buries previously-shallow URLs (orphan from
+ * Ahrefs/Googlebot → zero organic traffic). A future edit that weakens it —
+ * flipping the AND (`&&`) to OR, dropping `minAbsDelta`, or removing the
+ * new-shard hard-fail — MUST break one of these tests.
+ *
+ * Do NOT relax the asserted thresholds to make a failing build pass
+ * (AGENTS.md non-negotiable #1). Fix the gate's root cause instead.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateBfsGate,
+  DEFAULT_BFS_TOL,
+  NEW_SHARD_BURIED_RATE_FAIL,
+} from '../../scripts/audit-bfs-depth.mjs';
+
+type SitemapRow = { total: number; atDepthGtMax: number; deepest: number };
+
+const evaluate = evaluateBfsGate as (args: {
+  perSitemap: Record<string, SitemapRow>;
+  baseline: unknown;
+  tol?: Record<string, number>;
+}) => {
+  regressions: Array<{ name: string; prev: number; current: number; curRate?: number; rateCap?: number }>;
+  unbaselined: Array<{ name: string; atDepthGtMax: number; ratePct: number }>;
+  buriedNewShards: Array<{ name: string; atDepthGtMax: number; total: number; ratePct: number }>;
+};
+
+const TOL = DEFAULT_BFS_TOL as { relPct: number; absPp: number; minAbsDelta: number; maxDeltaPp: number };
+
+/** Build a rate-mode baseline (v2) from a per-sitemap snapshot. */
+function rateBaseline(perSitemap: Record<string, SitemapRow>): unknown {
+  const out: Record<string, { total: number; atDepthGtMax: number; ratePct: number }> = {};
+  for (const [name, row] of Object.entries(perSitemap)) {
+    out[name] = {
+      total: row.total,
+      atDepthGtMax: row.atDepthGtMax,
+      ratePct: row.total ? Number((row.atDepthGtMax / row.total * 100).toFixed(4)) : 0,
+    };
+  }
+  return { version: 2, mode: 'rate', maxDepth: 4, tolerance: TOL, perSitemap: out };
+}
+
+const row = (total: number, atDepthGtMax: number, deepest = 6): SitemapRow => ({ total, atDepthGtMax, deepest });
+
+describe('evaluateBfsGate — rate-mode ratchet (#1085)', () => {
+  it('(a) flat rate under proportional organic growth → PASS', () => {
+    // Baseline: 100 URLs, 5 buried (5%). The shard 4× in size (organic growth)
+    // with the SAME 5% buried rate → 20 buried. Absolute count jumps +15 but the
+    // RATE is flat, so the gate must NOT fire (this is the #1077 false-fail it
+    // was built to stop).
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 5) });
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-jobs.xml': row(400, 20) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(0);
+  });
+
+  it('(b) per-template regression (≈2.4× thin rate) → FAIL', () => {
+    // Baseline 5% buried (rateCap = 5 + min(5*.15, 8) + 5 = 10.75%). A real
+    // internal-link regression buries 12% on a same-size shard. Rate exceeds the
+    // cap AND absolute count grows by more than minAbsDelta (120 > 50+20) →
+    // must FAIL.
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(1000, 50) });
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-jobs.xml': row(1000, 120) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(1);
+    expect(regressions[0].name).toBe('sitemap-jobs.xml');
+    expect(regressions[0].current).toBe(120);
+  });
+
+  it('(c) absolute noise (+ a few offenders, rate ~unchanged) → PASS', () => {
+    // Baseline 5% buried on 1000 URLs. +minAbsDelta worth of absolute noise but
+    // the rate barely moves (stays within tolerance) → the absolute-delta arm of
+    // the AND-condition is not enough on its own; gate must NOT fire.
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(1000, 50) });
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-jobs.xml': row(1000, 52) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(0);
+  });
+
+  it('AND-condition guard: a rate spike with a sub-minAbsDelta count bump does NOT fail', () => {
+    // Tiny shard: rate doubles (high relative) but only +3 absolute offenders,
+    // below minAbsDelta. The `&&` (not `||`) means BOTH arms must trip. If a
+    // future edit flips `&&`→`||`, this rate-only spike would wrongly FAIL and
+    // break this test.
+    const baseline = rateBaseline({ 'sitemap-tiny.xml': row(40, 2) });
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-tiny.xml': row(40, 5) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(0);
+  });
+
+  it('minAbsDelta guard: rate clearly over cap but count delta == minAbsDelta does NOT fail', () => {
+    // Baseline 1/100 = 1% (rateCap = 1 + min(1*.15, 8) + 5 = 6.15%). New rate
+    // jumps to 21% (clearly over cap → the RATE arm of the AND trips), but the
+    // count grows by exactly minAbsDelta (not strictly more) so the COUNT arm
+    // does NOT. The `> baseOff + minAbsDelta` guard keeps it green. If a future
+    // edit drops that arm, this rate spike would wrongly FAIL and break the test.
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 1) });
+    const atExactlyDelta = 1 + TOL.minAbsDelta; // count delta == minAbsDelta (21)
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-jobs.xml': row(100, atExactlyDelta) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(0);
+  });
+
+  it('legacy absolute-count baseline (v1) fails on any growth', () => {
+    // mode/version absent → isRate false → any atDepthGtMax > prev fails.
+    const baseline = { maxDepth: 4, perSitemap: { 'sitemap-jobs.xml': { atDepthGtMax: 5, total: 100 } } };
+    const { regressions } = evaluate({
+      perSitemap: { 'sitemap-jobs.xml': row(400, 6) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(1);
+  });
+});
+
+describe('evaluateBfsGate — new non-baseline shard (#1095 item 2)', () => {
+  it('100% buried new tier over minAbsDelta URLs → hard-fail (buriedNewShards)', () => {
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 0) });
+    const buriedCount = NEW_SHARD_BURIED_RATE_FAIL; // ≥ minAbsDelta and 100% buried
+    const { buriedNewShards, unbaselined, regressions } = evaluate({
+      perSitemap: { 'sitemap-new-tier.xml': row(buriedCount, buriedCount) },
+      baseline,
+    });
+    expect(regressions).toHaveLength(0);
+    expect(unbaselined.map((u) => u.name)).toContain('sitemap-new-tier.xml');
+    expect(buriedNewShards).toHaveLength(1);
+    expect(buriedNewShards[0].name).toBe('sitemap-new-tier.xml');
+    expect(buriedNewShards[0].ratePct).toBe(100);
+  });
+
+  it('small new tier (< minAbsDelta buried URLs) only WARNs, never hard-fails', () => {
+    // A legit new tier with a shallow hub path may have a handful of deep URLs;
+    // we must NOT false-fail it. Below minAbsDelta → warning only.
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 0) });
+    const tiny = TOL.minAbsDelta - 1;
+    const { buriedNewShards, unbaselined } = evaluate({
+      perSitemap: { 'sitemap-small-tier.xml': row(tiny, tiny) },
+      baseline,
+    });
+    expect(buriedNewShards).toHaveLength(0);
+    expect(unbaselined.map((u) => u.name)).toContain('sitemap-small-tier.xml');
+  });
+
+  it('partly-buried new tier below the rate threshold only WARNs, never hard-fails', () => {
+    // Large new shard but only ~50% buried (below NEW_SHARD_BURIED_RATE_FAIL).
+    // Not "an entire tier below crawl depth" → warning, not a hard-fail.
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 0) });
+    const { buriedNewShards, unbaselined } = evaluate({
+      perSitemap: { 'sitemap-half.xml': row(200, 100) },
+      baseline,
+    });
+    expect(buriedNewShards).toHaveLength(0);
+    expect(unbaselined.find((u) => u.name === 'sitemap-half.xml')?.ratePct).toBe(50);
+  });
+
+  it('fully-reachable new tier produces no warning and no hard-fail', () => {
+    const baseline = rateBaseline({ 'sitemap-jobs.xml': row(100, 0) });
+    const { buriedNewShards, unbaselined } = evaluate({
+      perSitemap: { 'sitemap-clean.xml': row(500, 0) },
+      baseline,
+    });
+    expect(buriedNewShards).toHaveLength(0);
+    expect(unbaselined).toHaveLength(0);
+  });
+});

--- a/tests/seo/audit-text-html-ratio-rate-gate.test.ts
+++ b/tests/seo/audit-text-html-ratio-rate-gate.test.ts
@@ -1,0 +1,133 @@
+/**
+ * audit-text-html-ratio-rate-gate.test.ts
+ *
+ * Unit coverage for the rate-based offender ratchet in
+ * scripts/audit-text-html-ratio.mjs (PR #1085). The existing tests exercise
+ * the per-page threshold / offender-detection path; this file drives the
+ * `mode:'rate'` baseline comparison — the funnel-critical AND-condition
+ * `curRate > rateCap && curOff > baseOff + minAbsDelta`.
+ *
+ * The gate is the primary defence against false-fails from organic content
+ * growth (more pages of the same template, same per-page quality → flat rate)
+ * while still catching a genuine per-template quality regression (the offender
+ * RATE rising). A future edit that weakens it — flipping `&&`→`||` or dropping
+ * `minAbsDelta` — MUST break one of these tests.
+ *
+ * Do NOT relax the thresholds to make a failing build pass (AGENTS.md
+ * non-negotiable #1). Fix the root cause instead.
+ *
+ * The auditor is driven directly via `createAuditor` + an on-disk baseline
+ * file; no live dist crawl. Feature classification is path-driven, so the
+ * fixtures use `cerca-lavoro-ticino/...` (→ feature "job-board") paths and
+ * craft HTML with a known visible-text-to-HTML ratio.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAuditor } from '../../scripts/audit-text-html-ratio.mjs';
+
+interface AuditReport {
+  passed: boolean;
+  offendersTotal: number;
+  baselineDelta: { before: number; after: number; beforeRate?: number; afterRate?: number } | null;
+  extra: {
+    regressedFeatures: Array<{ feature: string; count: number; rate?: number; maxRate?: number }>;
+    rateByFeature: Record<string, number>;
+  };
+}
+
+type Auditor = {
+  collect: (file: string, html: string) => void;
+  report: () => Promise<AuditReport>;
+};
+
+// An OFFENDER page: tag-heavy, almost no visible text → ratio well under the
+// 10 % hard floor (empirically ~0.4 %).
+const THIN = `<html><body><div class="x">${'<span></span>'.repeat(40)}t</div></body></html>`;
+// A HEALTHY page: lots of visible prose → ratio ~98 %, never an offender.
+const FAT = `<html><body><p>${'word '.repeat(120)}</p></body></html>`;
+
+// All fixtures live under cerca-lavoro-ticino/* so classifyFeature() buckets
+// them as the single feature "job-board".
+const FEATURE = 'job-board';
+const jobPath = (root: string, n: number) => join(root, 'cerca-lavoro-ticino', `p${n}`, 'index.html');
+
+describe('audit-text-html-ratio — rate-mode ratchet (#1085)', () => {
+  let dir: string;
+  let baselinePath: string;
+
+  // Write a rate baseline: feature "job-board" at 5 % offender rate
+  // (5 offenders / 100 scanned), total 5 % as well.
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'audit-text-ratio-'));
+    baselinePath = join(dir, 'baseline.json');
+    const baseline = {
+      generated: new Date().toISOString(),
+      mode: 'rate',
+      threshold: 10,
+      tolerance: { relPct: 20, absPp: 1.0, minAbsDelta: 5, maxDeltaPp: 3 },
+      scanned: 100,
+      totalOffenders: 5,
+      totalRatePct: 5,
+      byFeature: {
+        [FEATURE]: { scanned: 100, offenders: 5, ratePct: 5 },
+      },
+    };
+    writeFileSync(baselinePath, JSON.stringify(baseline, null, 2));
+  });
+  afterAll(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  /** Feed `scanned` synthetic job-board pages, `offenders` of them thin. */
+  function run(scanned: number, offenders: number): Promise<AuditReport> {
+    const auditor = createAuditor({ threshold: 10, baselinePath }) as unknown as Auditor;
+    for (let i = 0; i < scanned; i++) {
+      const html = i < offenders ? THIN : FAT;
+      auditor.collect(jobPath('/dist', i), html);
+    }
+    return auditor.report();
+  }
+
+  it('(a) flat rate under proportional organic growth → PASS', async () => {
+    // 4× the pages, same 5 % offender rate → 20 offenders. Absolute count jumps
+    // +15 but the RATE is flat, so the gate must NOT fire (the #1077 false-fail
+    // it was built to stop).
+    const r = await run(400, 20);
+    expect(r.extra.rateByFeature[FEATURE]).toBeCloseTo(5, 5);
+    expect(r.extra.regressedFeatures).toHaveLength(0);
+    expect(r.passed).toBe(true);
+  });
+
+  it('(b) per-template regression (≈3× thin rate) → FAIL', async () => {
+    // Same 100-page shard, but a template regression triples the offender rate
+    // to 15 %. Rate exceeds the feature cap baseRate + min(baseRate*relPct/100,
+    // maxDeltaPp) + absPp = 5 + min(1, 3) + 1 = 7 % AND the absolute count grows
+    // by more than minAbsDelta (15 > 5 + 5 = 10) → must FAIL.
+    const r = await run(100, 15);
+    expect(r.extra.rateByFeature[FEATURE]).toBeCloseTo(15, 5);
+    expect(r.extra.regressedFeatures.map((f) => f.feature)).toContain(FEATURE);
+    expect(r.passed).toBe(false);
+  });
+
+  it('(c) absolute noise (+2 offenders, rate ~unchanged) → PASS', async () => {
+    // Grow the shard so +2 offenders barely moves the rate: 7 offenders / 140
+    // pages = 5 % (flat). Absolute count up by 2 but rate within tolerance →
+    // gate must NOT fire.
+    const r = await run(140, 7);
+    expect(r.extra.rateByFeature[FEATURE]).toBeCloseTo(5, 5);
+    expect(r.extra.regressedFeatures).toHaveLength(0);
+    expect(r.passed).toBe(true);
+  });
+
+  it('AND-condition guard: high relative rate spike but sub-minAbsDelta count does NOT fail', async () => {
+    // Tiny shard: 4 offenders / 40 pages = 10 % (rate over the 7 % cap) but only
+    // +(4-? ) — absolute offender count is 4, baseline 5, so the count arm
+    // (curOff > baseOff + minAbsDelta = 5 + 5 = 10) is false. The `&&` (not `||`)
+    // keeps it green. If a future edit flips `&&`→`||`, this rate-only spike
+    // would wrongly FAIL and break the test.
+    const r = await run(40, 4);
+    expect(r.extra.rateByFeature[FEATURE]).toBeCloseTo(10, 5);
+    expect(r.extra.regressedFeatures).toHaveLength(0);
+    expect(r.passed).toBe(true);
+  });
+});

--- a/tests/seo/gsc-keyword-title-fallback.test.ts
+++ b/tests/seo/gsc-keyword-title-fallback.test.ts
@@ -1,0 +1,91 @@
+/**
+ * gsc-keyword-title-fallback.test.ts
+ *
+ * Item 3 of issue #1095. The Italian GSC-keyword landing in
+ * build-plugins/jobsSeoPagesPlugin.ts builds its <title> as:
+ *
+ *   curated = buildTitleWithBrand(itCopy.title without brand)
+ *   if norm(curated) !== norm(itCopy.heading) → use curated
+ *   else → fall back to buildRoleHubTitle({ count, year, … })
+ *
+ * The PR #1085 claim is "title can never equal h1 for any future data". This
+ * test asserts the fallback actually fires AND produces a title structurally
+ * distinct from the heading when a long `itCopy.title` collapses to the bare
+ * heading (brand dropped at the 66-char cap → title === h1 → would trip the
+ * 0-tolerance audit:h1-title-duplicates ratchet).
+ *
+ * It also guards the orphan-`**` nuke (`/\*{2,}/g` in stripLiteralMarkdown):
+ * a legitimate corpus title with no markdown survives byte-identical, so the
+ * nuke can't silently mangle real titles.
+ *
+ * These helpers are pure and exported; the test mirrors the plugin's exact
+ * fallback expression rather than crawling dist (so it gates pre-build).
+ */
+import { describe, expect, it } from 'vitest';
+import { buildRoleHubTitle } from '../../services/seo/job-board-titles';
+import { buildTitleWithBrand } from '../../build-plugins/shared/titleSuffix';
+import { stripLiteralMarkdown } from '../../build-plugins/shared/stripLiteralMarkdown';
+
+const norm = (s: string) => String(s).replace(/\s+/g, ' ').trim().toLowerCase();
+
+/** Exact replica of the IT GSC-keyword title expression (jobsSeoPagesPlugin). */
+function buildItKwTitle(itCopy: { title: string; heading: string }, kwQueryDisplay: string, count: number, year: number): string {
+  const curated = buildTitleWithBrand(String(itCopy.title || '').replace(/\s*\|\s*Frontaliere Ticino\s*$/i, ''));
+  if (norm(curated) !== norm(String(itCopy.heading || ''))) return curated;
+  return buildRoleHubTitle({ locale: 'it', roleDisplay: kwQueryDisplay || 'Jobs', count, year });
+}
+
+describe('IT GSC-keyword <title> fallback (#1095 item 3)', () => {
+  it('long itCopy.title that collapses to the bare heading → fallback ≠ heading', () => {
+    // A heading just over the brand-drop boundary: heading + " | Frontaliere
+    // Ticino" (21 chars) exceeds the 66-char cap, so buildTitleWithBrand drops
+    // the brand and `curated` becomes byte-identical to the heading.
+    const heading = 'Lavoro infermiere a domicilio Lugano Mendrisio Chiasso turni';
+    expect(heading.length + ' | Frontaliere Ticino'.length).toBeGreaterThan(66);
+    const itCopy = { title: heading, heading };
+
+    // Sanity: the curated path WOULD collide (this is the case the fallback exists for).
+    const curated = buildTitleWithBrand(heading);
+    expect(norm(curated)).toBe(norm(heading));
+
+    const title = buildItKwTitle(itCopy, 'Infermiere', 42, 2026);
+    // Fallback fired → role-hub title, structurally distinct from the heading.
+    expect(norm(title)).not.toBe(norm(heading));
+    // It is the count+year role-hub form.
+    expect(title).toContain('2026');
+    expect(title).toContain('42');
+  });
+
+  it('the role-hub fallback itself is never equal to a degenerate role-hub heading', () => {
+    // Even if the heading happens to look like a role-hub phrase, the count+year
+    // title carries a distinct numeric/temporal structure → no collision.
+    const roleHub = buildRoleHubTitle({ locale: 'it', roleDisplay: 'Infermiere', count: 42, year: 2026 });
+    const headingLookalike = 'Infermiere in Ticino';
+    expect(norm(roleHub)).not.toBe(norm(headingLookalike));
+  });
+
+  it('short itCopy.title keeps its curated brand suffix (no needless fallback)', () => {
+    const itCopy = { title: 'Lavoro infermiere Lugano', heading: 'Offerte infermiere a Lugano' };
+    const title = buildItKwTitle(itCopy, 'Infermiere', 12, 2026);
+    expect(title).toBe('Lavoro infermiere Lugano | Frontaliere Ticino');
+    expect(norm(title)).not.toBe(norm(itCopy.heading));
+  });
+});
+
+describe('stripLiteralMarkdown — no collateral damage to legit titles (#1095 item 3)', () => {
+  it('a plain corpus title with no markdown survives byte-identical', () => {
+    const legit = 'Lavoro infermiere a Lugano — turni diurni e notturni';
+    expect(stripLiteralMarkdown(legit)).toBe(legit);
+  });
+
+  it('titles with a single literal `*` (not a 2+ run) are not nuked mid-string', () => {
+    // The `/\*{2,}/g` nuke targets only runs of 2+ asterisks. A lone `*` between
+    // words is left in place by rule 2 (rules 4/5 only trim leading/trailing).
+    const s = 'Lavoro 5 * stelle a Lugano';
+    expect(stripLiteralMarkdown(s)).toBe('Lavoro 5 * stelle a Lugano');
+  });
+
+  it('orphan `**` runs ARE stripped (the gate this nuke exists for)', () => {
+    expect(stripLiteralMarkdown('Requisiti:** svizzera')).toBe('Requisiti: svizzera');
+  });
+});


### PR DESCRIPTION
Closes #1095

Follow-up to PR #1085 (rate-based ratchet for validate-dist gates). All 3 deferred items addressed.

## Implementato

### Item 1 (core) — unit tests for the `mode:'rate'` gating branch
The funnel-critical AND-condition `curRate > rateCap && curOff > baseOff + minAbsDelta` had no committed test on either auditor (only the strip-helper got one). Added:

- **`tests/seo/audit-text-html-ratio-rate-gate.test.ts`** — drives the exported `createAuditor` + an on-disk rate baseline:
  - (a) flat rate under proportional organic growth → **PASS**
  - (b) per-template regression (≈3× thin rate) → **FAIL**
  - (c) absolute noise (+2 offenders, rate unchanged) → **PASS**
  - AND-condition guard: relative rate spike with sub-`minAbsDelta` count → **PASS**
- **`tests/seo/audit-bfs-depth-rate-gate.test.ts`** — same flat/regression/noise scenarios plus an explicit `&&` guard, a `minAbsDelta` guard, and the legacy v1 absolute-count path.

To make the bfs gate testable without a live crawl, the inlined per-sitemap decision in `main()` was extracted into a **pure, exported `evaluateBfsGate()`** (no I/O, no `process.exit`). `main()` now calls it. Also guarded `main()` behind an `invokedDirectly` check (mirrors `audit-text-html-ratio.mjs`) so importing the module for tests no longer fires the live sitemap fetch/BFS. The CLI (`npm run audit:max-bfs-depth`) is unchanged — verified it still runs.

**Mutation-verified**: flipping `&&`→`||` or dropping the `minAbsDelta` arm breaks the new tests on both auditors.

### Item 2 — hard-fail an overwhelmingly-buried new content tier
**Decision: add a hard-fail with a conservative threshold** (the safer option). A brand-new sitemap shard shipping the overwhelming majority of its URLs below crawl depth previously only WARNed, then got floored into the next rebaseline → buried-forever indexability hole (zero organic traffic on that tier). `evaluateBfsGate` now flags non-baseline shards with **≥90% buried over ≥`minAbsDelta` (20) URLs** as `buriedNewShards`, and `main()` hard-fails the build with a diagnostic + fix instructions.

Why this threshold is false-fail-safe: a legitimate new tier is *expected* to be reachable via a shallow hub link. A shard with 20+ URLs **all** below crawl depth is a genuine internal-link bug, not organic noise. Small new tiers (<20 buried URLs) and partly-buried tiers (<90%) still only WARN — covered by tests (`small new tier`, `partly-buried tier`, `fully-reachable tier` cases).

### Item 3 — assert the IT `<title>` fallback can't collide with the H1
**`tests/seo/gsc-keyword-title-fallback.test.ts`** mirrors the IT GSC-keyword title expression. When a long `itCopy.title` collapses to the bare heading (brand dropped at the 66-char cap → `title === h1`, would trip `audit:h1-title-duplicates`), the fallback to `buildRoleHubTitle` (count+year) fires and is structurally distinct from the heading. Also confirms `stripLiteralMarkdown`'s `/\*{2,}/g` nuke leaves a legit markdown-free corpus title **byte-identical** (no collateral damage), while still stripping orphan `**` runs.

## Non implementato (ancora)
- Nessuno. Tutti e 3 gli item dell'issue sono coperti (Item 1 test, Item 2 hard-fail + test, Item 3 test). Nessuno scope rimandato.

## Test
- [x] `npx vitest run tests/seo/audit-bfs-depth-rate-gate.test.ts tests/seo/audit-text-html-ratio-rate-gate.test.ts tests/seo/gsc-keyword-title-fallback.test.ts` → 20 passed
- [x] Related existing suites green (audit-runner, job-board-text-ratio-regression, strip-literal-markdown, h1-not-equal-title)
- [x] Mutation check: `&&`→`||`, drop `minAbsDelta`, remove new-shard hard-fail each break a test
- [x] `node scripts/audit-bfs-depth.mjs --json` still crawls (CLI entry intact); module import no longer triggers the crawl

## Blast radius
LOW. `scripts/audit-bfs-depth.mjs` is a leaf CLI; only its own `main()` calls the extracted logic, no external importers, no execution flows affected. `audit-text-html-ratio.mjs` is untouched (tested via its existing exported `createAuditor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)