### PR TITLE
fix(jobs-seo): declass inner main on canton-hub + min-width:0 (#974)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9103,7 +9103,15 @@ ${staticAnalyticsHtml}
      }
 
      const bodyHtml = [
-       `<main class="seo-static-content s-LFxJYv">`,
+       // #974: drop `seo-static-content` from this INNER <main> (keep the
+       // `s-LFxJYv` layout class). buildSeoPageHtml wraps bodyHtml in the OUTER
+       // main.seo-static-content (display:grid); leaving the class here made the
+       // inner main a nested grid item with default min-width:auto, so its track
+       // could not shrink and wide content forced horizontal overflow on mobile
+       // (382px). Mirrors comparisonsHub #962 / borderWaitMap #958. The outer
+       // shell main still carries seo-static-content (lite-shell detector +
+       // staticOverlay handoff preserved).
+       `<main class="s-LFxJYv">`,
        `<nav class="s-ZVaIKh"><a class="s-t_pXue" href="/">${esc(homeLabel[entry.locale])}</a> &rarr; <span aria-current="page">${esc(display)}</span></nav>`,
        `<header class="s-TYF4UK"><h1 class="s-Wb8ho2">${esc(display)}</h1><p class="s-b7cYUf">${esc(labels.lede)}</p></header>`,
        tileGrid,

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -1022,7 +1022,7 @@ main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; gap:
 .s-lEdUfz { margin:6px 0 0;font-size:15px;line-height:1.55;color:var(--color-heading);font-weight:500 }
 .s-lEEXLG { font-size:1.15rem;font-weight:700;margin:1rem 0 .5rem }
 .s-lfB4Bo { margin:1.5rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem }
-.s-LFxJYv { max-width:1080px;margin:0 auto;padding:24px 16px }
+.s-LFxJYv { min-width:0;max-width:1080px;margin:0 auto;padding:24px 16px }
 .s-lGLtkq { margin:14px 0 10px;font-size:16px;font-weight:700;color:var(--color-heading) }
 .s-LGtGh9 { margin:0;font-size:15.5px }
 .s-lHdmvf { font-size:1.25rem;font-weight:700;margin-bottom:.5rem }


### PR DESCRIPTION
## Implementato

Risolve l'ultima istanza rimasta dell'anti-pattern nested-grid mobile-overflow di #961 (audit della issue #974).

**Root cause confermata via audit.** In `jobsSeoPagesPlugin.ts` la pagina canton-hub costruisce `bodyHtml` partendo da `<main class="seo-static-content s-LFxJYv">` e lo passa a `buildSeoPageHtml`, che lo avvolge nell'OUTER `main.seo-static-content` (`display:grid`). L'inner main ereditava `display:grid` per specificità (`main.seo-static-content` 0,1,1 batte `.s-LFxJYv` 0,1,0) e, come grid item annidato con `min-width:auto` di default, il suo track non si comprimeva → overflow orizzontale a 382px quando il contenuto è largo. Identico a #961.

**Fix (mirror di comparisonsHub #962 + borderWaitMap #958):**
- `build-plugins/jobsSeoPagesPlugin.ts` (1 occorrenza, l'inner `<main>` del canton-hub fed a `buildSeoPageHtml`): rimossa la classe `seo-static-content`, mantenuta la layout class `s-LFxJYv`.
- `public/assets/seo-static.css` `.s-LFxJYv`: aggiunto `min-width:0` (additivo) così il grid item declassato può comprimersi e i wrapper `overflow-x:auto` esistenti si riattivano — stesso add che #962 fece su `.s-xzWvwM`/`.s-wtIcSy`.

L'OUTER shell main conserva `seo-static-content` → lite-shell detector + staticOverlay handoff preservati. La regola condivisa `main.seo-static-content` NON è stata toccata (HIGH blast-radius).

**Audit dei candidati della issue #974:**
- I 7 sibling plugin originariamente elencati (comparisonsHub, frSalaireNet, costOfLiving, careerLandings, faqHub, weeklyEmployers, jobMarketSnapshot) erano **già stati fixati in #962** (declass inner main + `min-width:0` su `s-xzWvwM`/`s-wtIcSy`/`fh-main`).
- `jobSectorPagesPlugin` (`s-Ziv1Xn`), `jobRecencyPagesPlugin` (`s-xzWvwM`), `seoHubsPlugin` (`s-xzWvwM`) e le inline-template di `jobsSeoPagesPlugin` (`s-it71Rt`, `static-job-page`) emettono un **SINGLE OUTER main** direttamente sotto `<body><div id="root">` (nessun wrap annidato). L'outer main è figlio di `<body>` (non di un grid) → non è un grid item, quindi `min-width:auto` non lo vincola: NON è l'anti-pattern annidato. Lasciati intatti (toccarli romperebbe il lite-shell detector / staticOverlay).
- Unica vera occorrenza nested residua = `s-LFxJYv` (canton-hub), fixata qui.

**Validazione:**
- `git diff`: 2 file, +10/-2; solo class-string HTML + 1 dichiarazione CSS additiva. Nessun hex inline, nessuna modifica alla regola `main.seo-static-content`.
- `gitnexus detect_changes`: 0 symbol-level changes (edit puramente HTML/CSS, nessun cambio di call-graph) → blast radius a livello di codice nullo.
- Vitest mirati verdi (249/249): `jobs-seo-pages-plugin`, `app-lite-shell`, `multi-canton-seo`, `city-jobs-hub`, `job-sector-landing`, `job-market-snapshot`.

## Non implementato (ancora)

- **Verifica reale render a 382px (live, post-deploy).** Come la issue #974 stessa raccomanda ("auditare il rendering reale a 382px prima di applicare il fix"), la conferma visiva dell'assenza di overflow sulla canton-hub si fa post-deploy su `frontaliereticino.ch` (no full vite build locale — OOM). Il fix è strutturalmente identico a quello già validato dal reviewer in #962/#958.
- Nessun altro plugin necessita intervento: l'audit (sopra) ha escluso tutti gli altri candidati della issue come OUTER-main non annidati o già fixati in #962.

Closes #974
Refs #961 #962 #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)