### PR TITLE
test(jobs): lock canton-aware footer + half-canton sub-hub link graph (#959)

### DIFF
--- a/scripts/lib/crawler-location-config.mjs
+++ b/scripts/lib/crawler-location-config.mjs
@@ -503,7 +503,19 @@ export const HQ_REGISTRY = COMPANY_HQ;
  * embed a region label in the job description. Replaces hardcoded ternaries
  * like `canton === 'GR' ? 'Grigioni' : 'Ticino'` (docs/crawler-parametrizzazione-plan.md).
  *
- * @param {string} cantonCode - 2-letter canton code (TI, GR, VS, …)
+ * @param {string} cantonCode - 2-letter BFS canton code (TI, GR, VS, … incl.
+ *   the real half-canton codes BL/BS/AI/AR). This keys on {@link SWISS_CANTONS}
+ *   (BFS codes only) and intentionally does NOT carry the half-canton URL
+ *   *group* keys (`BASILEA`, `APPENZELLO`). Those group keys are a URL-emission
+ *   concept produced by `resolveCantonGroup`; every caller of THIS helper feeds
+ *   it a BFS code straight from `inferAnyCanton`/`getCompanyDefaults` (crawlers
+ *   tag jobs with BFS codes — verified: scripts/update-ist-jobs.mjs,
+ *   scripts/update-trumpf-jobs.mjs). The build plugins that emit per-GROUP
+ *   pages (weeklyEmployers/jobMarketSnapshot CH-canton pages) shadow this name
+ *   with their own local `getCantonDisplayName` keyed on a CANTON_DISPLAY map
+ *   that DOES include the group keys, so they never reach this function either.
+ *   If a future crawler ever passes a group key here, add BASILEA/APPENZELLO to
+ *   the `map` below for parity with `getCantonDisplayLabel` (#959, follow-up #954).
  * @param {'it'|'de'|'fr'|'en'} locale - output language; defaults to 'it'
  * @returns {string} canton name in the requested language, or the raw code if unknown.
  */

--- a/tests/half-canton-merge.test.ts
+++ b/tests/half-canton-merge.test.ts
@@ -22,6 +22,7 @@
 import { describe, expect, it } from 'vitest';
 import { parsePath, buildPath, getJobBoardSlugForCanton, resolveCantonGroup as resolveCantonGroupTs } from '@/services/router';
 import { resolveCantonGroup as resolveCantonGroupMjs, getCantonGroupMembers, getCantonUrlSlug, parseCantonUrlSlug } from '../scripts/lib/canton-url-slugs.mjs';
+import { hubSlugFor } from '@/build-plugins/seoHubsData';
 
 type Locale = 'it' | 'en' | 'de' | 'fr';
 const ALL_LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
@@ -201,5 +202,75 @@ describe('Router buildPath / getJobBoardSlugForCanton — collapse BFS codes ont
 
   it('TI legacy DE form (jobs-im-tessin) preserved', () => {
     expect(getJobBoardSlugForCanton('TI', 'de')).toBe('jobs-im-tessin');
+  });
+});
+
+// ── Follow-up #959 (item 3): sub-hub (tutti / settori / aziende) emission for
+// the new half-canton URL groups. The footer "Tutte le aziende →" link
+// (App.tsx, via seoHubSlugFor) and the per-canton hub page emission
+// (seoHubsPlugin.emitThinCantonHubs, both via the SAME hubSlugFor helper) must
+// agree by construction. The risk the reviewer flagged: if hubSlugFor returned
+// a raw group key (`/cerca-lavoro-BASILEA/aziende/`) the footer link would
+// 404 against the emitted slug (`/cerca-lavoro-basilea/aziende/`). Lock the
+// slug shape for BASILEA + APPENZELLO across every locale + facet so the
+// footer/emitter contract can't silently drift.
+describe('hubSlugFor — sub-hub facets resolve for new half-canton groups (#959)', () => {
+  // Expected canonical section slug per group/locale (no raw group key leak,
+  // lowercase, locale-correct — matches getJobBoardSlugForCanton above).
+  const SECTION: Record<'BASILEA' | 'APPENZELLO', Record<Locale, string>> = {
+    BASILEA: {
+      it: 'cerca-lavoro-basilea',
+      en: 'find-jobs-basel',
+      de: 'jobs-in-basel',
+      fr: 'trouver-emploi-bale',
+    },
+    APPENZELLO: {
+      it: 'cerca-lavoro-appenzello',
+      en: 'find-jobs-appenzell',
+      de: 'jobs-in-appenzell',
+      fr: 'trouver-emploi-appenzell',
+    },
+  };
+  // Trailing path component per facet/locale (mirrors HUB_SLUG_BY_LOCALE in
+  // seoHubsData.ts — the table the emitter and footer both consume).
+  const FACET: Record<'tutti' | 'settori' | 'aziende', Record<Locale, string>> = {
+    tutti: { it: 'tutti', en: 'all', de: 'alle', fr: 'tous' },
+    settori: { it: 'settori', en: 'sectors', de: 'branchen', fr: 'secteurs' },
+    aziende: { it: 'aziende', en: 'companies', de: 'unternehmen', fr: 'entreprises' },
+  };
+
+  for (const group of ['BASILEA', 'APPENZELLO'] as const) {
+    for (const locale of ALL_LOCALES) {
+      for (const facet of ['tutti', 'settori', 'aziende'] as const) {
+        it(`${group} + ${locale} + ${facet} → valid lowercase section slug (no 404)`, () => {
+          const prefix = locale === 'it' ? '' : `/${locale}`;
+          const expected = `${prefix}/${SECTION[group][locale]}/${FACET[facet][locale]}/`;
+          expect(hubSlugFor(group, locale, facet)).toBe(expected);
+        });
+      }
+    }
+  }
+
+  it('never leaks a raw group key into the emitted URL', () => {
+    for (const group of ['BASILEA', 'APPENZELLO'] as const) {
+      for (const locale of ALL_LOCALES) {
+        for (const facet of ['tutti', 'settori', 'aziende'] as const) {
+          const slug = hubSlugFor(group, locale, facet);
+          expect(slug).not.toContain('BASILEA');
+          expect(slug).not.toContain('APPENZELLO');
+        }
+      }
+    }
+  });
+
+  it('member BFS codes collapse onto the same hub slug as the group key', () => {
+    // hubSlugFor resolves the group internally, so AI/AR and BL/BS must produce
+    // the SAME sub-hub URL as APPENZELLO / BASILEA (one emitted page per group).
+    for (const locale of ALL_LOCALES) {
+      expect(hubSlugFor('AI', locale, 'aziende')).toBe(hubSlugFor('APPENZELLO', locale, 'aziende'));
+      expect(hubSlugFor('AR', locale, 'settori')).toBe(hubSlugFor('APPENZELLO', locale, 'settori'));
+      expect(hubSlugFor('BL', locale, 'tutti')).toBe(hubSlugFor('BASILEA', locale, 'tutti'));
+      expect(hubSlugFor('BS', locale, 'aziende')).toBe(hubSlugFor('BASILEA', locale, 'aziende'));
+    }
   });
 });

--- a/tests/regression/footer-canton-scoped-seo-hubs.test.tsx
+++ b/tests/regression/footer-canton-scoped-seo-hubs.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Regression (follow-up #959 / origin PR #954): canton-scoped footer SEO hubs.
+ *
+ * App.tsx renders a `data-testid="footer-seo-hubs"` <nav> whose links are
+ * canton-aware. On a per-canton job-board route (e.g. /cerca-lavoro-basilea/)
+ * the `isCantonScoped` branch must:
+ *   (a) suppress the Ticino city chips (`/cerca-lavoro-ticino/<city>/`) and the
+ *       Ticino company chips — otherwise every non-TI canton page leaks ~36
+ *       Ticino internal links into its SEO link graph;
+ *   (b) point the "Tutti i lavori →" / "Tutti i settori →" / "Tutte le aziende →"
+ *       hubs at THAT canton's section (`/cerca-lavoro-basilea/...`).
+ *
+ * The previous bug (pre-PR #954) was the static footer always rendering the
+ * Ticino scope. A silent regression of `isCantonScoped` (e.g. returning false
+ * for some route) would re-inject the Ticino links with no test catching it.
+ * This test locks the link-graph invariant by driving `parsePath` to a Basilea
+ * job-board route and asserting the rendered footer.
+ *
+ * Pattern mirrors tests/regression/footer-on-seo-pages.test.tsx (renders <App />
+ * with a mocked router so the heavy SPA tree boots in jsdom).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import App from '@/App';
+import { hubSlugFor } from '@/build-plugins/seoHubsData';
+
+vi.mock('@/hooks/seoHelpers', () => ({
+  enableRuntimeSeo: vi.fn(),
+  isRuntimeSeoEnabled: vi.fn(() => false),
+  updateMetaTags: vi.fn(),
+  trackSectionView: vi.fn(),
+  _resetRuntimeSeoForTests: vi.fn(),
+}));
+
+// Router mock — parsePath returns a per-canton job-board route. The footer
+// branch in App.tsx reads parsePath(window.location.pathname) directly, so the
+// same mock implementation drives both the render route and the footer scope.
+const mockParsePath = vi.fn();
+
+vi.mock('@/services/router', () => ({
+  parsePath: (path: string) => mockParsePath(path),
+  parseHashToPath: vi.fn(() => null),
+  pushRoute: vi.fn(),
+  replaceRoute: vi.fn(),
+  buildPath: vi.fn(() => '/'),
+  buildAllLocalePaths: vi.fn(() => ({ it: '/', en: '/en/', de: '/de/', fr: '/fr/' })),
+  getSeoSection: vi.fn(() => 'job-board'),
+  updatePathForLocale: vi.fn(),
+  scrollToAnchor: vi.fn(() => false),
+  getHashSection: vi.fn((_keys: readonly string[], fallback: string) => fallback),
+  preloadBlogData: vi.fn(() => Promise.resolve()),
+  resolveBlogSlug: vi.fn(() => undefined),
+  ALL_GLOSSARY_TERM_IDS: [],
+  ALL_BORDER_CROSSING_IDS: [],
+}));
+
+vi.mock('@/services/recaptchaService', () => ({
+  recaptchaService: { verify: vi.fn() },
+}));
+
+vi.mock('@/services/trafficService', () => ({
+  trafficService: {
+    hasApiKey: vi.fn(() => false),
+    getEstimatedTravelTimes: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+vi.mock('@/services/i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/i18n')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      locale: 'it' as const,
+    }),
+    t: (key: string) => key,
+    getLocale: () => 'it' as const,
+    setLocale: vi.fn(),
+    initLocale: vi.fn(),
+    onLocaleChange: vi.fn(() => vi.fn()),
+    useLocale: () => ['it' as const, vi.fn()],
+    loadBlogTranslations: vi.fn(() => Promise.resolve()),
+    loadBlogMeta: vi.fn(() => Promise.resolve()),
+    loadArticleBody: vi.fn(() => Promise.resolve()),
+    loadTabTranslations: vi.fn(() => Promise.resolve()),
+    loadAllTranslations: vi.fn(() => Promise.resolve()),
+    itReady: Promise.resolve(),
+    isTranslationsReady: () => true,
+    LOCALE_LABELS: {
+      it: { flag: '🇮🇹', name: 'Italian', nativeName: 'Italiano' },
+      en: { flag: '🇬🇧', name: 'English', nativeName: 'English' },
+      de: { flag: '🇩🇪', name: 'German', nativeName: 'Deutsch' },
+      fr: { flag: '🇫🇷', name: 'French', nativeName: 'Français' },
+    },
+  };
+});
+
+const mockTaxResult = {
+  grossIncome: 80000,
+  familyAllowance: 0,
+  socialContributions: 8000,
+  taxableIncome: 72000,
+  taxes: 7200,
+  healthInsurance: 4800,
+  customExpensesTotal: 0,
+  netIncomeAnnual: 60000,
+  netIncomeMonthly: 5000,
+  currency: 'CHF' as const,
+  breakdown: [{ label: 'Quellensteuer', amount: 400, percentage: 5 }],
+  details: { regime: 'Quellensteuer', effectiveRate: 10, source: 'Test', notes: [] },
+};
+
+vi.mock('@/services/calculationService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/calculationService')>();
+  return {
+    ...actual,
+    calculateSimulation: vi.fn(() => ({
+      chResident: { ...mockTaxResult },
+      itResident: { ...mockTaxResult, currency: 'EUR' as const },
+      savingsCHF: 500,
+      savingsEUR: 460,
+      exchangeRate: 0.92,
+      monthsBasis: 12,
+    })),
+  };
+});
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+function mockBasilea() {
+  mockParsePath.mockImplementation(() => ({
+    route: { activeTab: 'job-board' as const, jobBoardCanton: 'BASILEA' },
+    locale: 'it' as const,
+  }));
+}
+
+function mockTicino() {
+  mockParsePath.mockImplementation(() => ({
+    route: { activeTab: 'job-board' as const, jobBoardCanton: 'TI' },
+    locale: 'it' as const,
+  }));
+}
+
+function getFooterHubsNav(): HTMLElement {
+  const nav = document.querySelector<HTMLElement>('[data-testid="footer-seo-hubs"]');
+  if (!nav) throw new Error('footer-seo-hubs nav not found in rendered <App />');
+  return nav;
+}
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  window.history.replaceState(null, '', '/cerca-lavoro-basilea/');
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
+});
+
+describe('Regression: canton-scoped footer SEO hubs (#959)', () => {
+  it('a — emits NO Ticino city chips on a non-TI canton route', () => {
+    mockBasilea();
+    render(<App />);
+    const hrefs = Array.from(getFooterHubsNav().querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? '',
+    );
+    // No `/cerca-lavoro-ticino/<city>/` city/company chips may leak under Basilea.
+    const tiCityChips = hrefs.filter((h) => /\/cerca-lavoro-ticino\/[a-z-]+\/?$/.test(h));
+    expect(
+      tiCityChips,
+      `Ticino city/company chips leaked into the Basilea footer: ${tiCityChips.join(', ')}`,
+    ).toHaveLength(0);
+    // Stronger: no href in the canton-scoped footer may contain the Ticino section at all.
+    expect(hrefs.some((h) => h.includes('cerca-lavoro-ticino'))).toBe(false);
+  });
+
+  it('b — points the "all hubs" links at the Basilea section', () => {
+    mockBasilea();
+    render(<App />);
+    const hrefs = Array.from(getFooterHubsNav().querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? '',
+    );
+    // The canton root hubs are produced by hubSlugFor(canton, locale, kind).
+    expect(hrefs).toContain(hubSlugFor('BASILEA', 'it', 'tutti'));
+    expect(hrefs).toContain(hubSlugFor('BASILEA', 'it', 'settori'));
+    expect(hrefs).toContain(hubSlugFor('BASILEA', 'it', 'aziende'));
+    // Sanity: the Basilea section slug is what we expect (no raw group key in URL).
+    expect(hubSlugFor('BASILEA', 'it', 'tutti')).toBe('/cerca-lavoro-basilea/tutti/');
+  });
+
+  it('TI route keeps the legacy Ticino city chips (no over-suppression)', () => {
+    mockTicino();
+    render(<App />);
+    const hrefs = Array.from(getFooterHubsNav().querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? '',
+    );
+    // On the Ticino route the footer must still carry Ticino city chips.
+    expect(hrefs.some((h) => /\/cerca-lavoro-ticino\/[a-z-]+\/$/.test(h))).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up #959 (origin PR #954): 5 deferred items on canton-aware per-canton job-board naming. Resolves the 3 pre-merge-verifiable, link-graph-locking items (1, 3, 4); defers the 2 live-only ones (2, 5).

## Implementato

**Item 1 — canton-scoped footer SEO link graph (test).** New `tests/regression/footer-canton-scoped-seo-hubs.test.tsx` renders `<App />` on a mocked `/cerca-lavoro-basilea/` job-board route (same `parsePath`-mock pattern as `footer-on-seo-pages.test.tsx`) and asserts the `footer-seo-hubs` nav:
- (a) emits **no** `cerca-lavoro-ticino/<city>/` chips and contains no `cerca-lavoro-ticino` href at all;
- (b) points "Tutti i lavori / settori / aziende →" at the Basilea section via `hubSlugFor('BASILEA', 'it', …)`;
- a TI route still keeps its Ticino city chips (guards against over-suppression).

This locks the fix against a silent `isCantonScoped` regression re-injecting ~36 Ticino internal links onto every non-TI canton page.

**Item 3 — half-canton sub-hub emission (test).** Extended `tests/half-canton-merge.test.ts` with a `hubSlugFor` facet suite. The footer "Tutte le aziende →" link **and** the `seoHubsPlugin.emitThinCantonHubs` page emission both route through the *same* `hubSlugFor` helper, so the footer→page contract is consistent by construction. The test asserts `hubSlugFor` yields valid **lowercase** locale-correct section slugs (e.g. `/cerca-lavoro-basilea/aziende/`, `/de/jobs-in-appenzell/unternehmen/`) for `{BASILEA, APPENZELLO} × 4 locales × {tutti, settori, aziende}`, never leaks a raw group key into a URL, and that member BFS codes (AI/AR/BL/BS) collapse onto the same group hub. This is the statically-checkable form of "every group emits an aziende/settori sub-hub without 404" — the actual HTML emission is job-count-gated (`MIN_JOBS_FOR_CANTON_PAGE` + `isCantonNoindex`), so a build-output existence test would need a full SEO build (OOM locally; not run per AGENTS.md).

**Item 4 — `getCantonDisplayName` (crawler-location-config.mjs).** Documenting comment only, no logic change. Traced every call site:
- `scripts/update-ist-jobs.mjs`, `scripts/update-trumpf-jobs.mjs` → pass BFS codes from `inferAnyCanton` (iterates `SWISS_CANTONS` keys = BFS codes only; group keys `BASILEA`/`APPENZELLO` are never produced).
- `build-plugins/weeklyEmployersChCantonPages.ts`, `build-plugins/jobMarketSnapshotChCantonPages.ts` → each **shadow** the import with a local `getCantonDisplayName` keyed on a local `CANTON_DISPLAY` map that already includes the group keys; the imported helper is not used there.

No path reaches the imported helper with a URL group key, so the `BASILEA`/`APPENZELLO` labels are deliberately **not** added (would be dead code, and `BS`/`BL` already map correctly to distinct BFS names). The comment records why and the parity instruction if a future crawler ever passes a group key.

Blast radius: zero — two test files + one JSDoc comment. `gitnexus_impact` on the local `getCantonDisplayName`: LOW (1 direct caller, 0 processes). No symbol logic touched.

Test result: `tests/half-canton-merge.test.ts` (90 tests) + `tests/regression/footer-canton-scoped-seo-hubs.test.tsx` (3 tests) green.

## Non implementato (ancora)

**Item 2 — live test-plan boxes + de/fr H1 vs `<title>` accent mismatch.** Requires post-deploy live verification (`/cerca-lavoro-basilea/` SPA H1+footer, static `<title>` "Basilea", `/cerca-lavoro-ticino/` invariance). The accent-divergence (H1 "Zurich" via ASCII `getCantonLabel` slug vs static `<title>` "Zürich" keeping accents on de/fr pages) is cosmetic, secondary-locale, and tied to the separately-deferred accent work — out of scope for a surgical pre-merge PR. The static-`<title>`-casing item is the only pre-merge-checkable piece, but it can't be confirmed without a full SEO build (OOM locally per AGENTS.md). Defer to live audit replay.

**Item 5 — SPA hydration flash on `/cerca-lavoro-basilea/`.** Requires a throttled (3G) Playwright run capturing per-frame screenshots of the live deploy to confirm no Ticino-scope flash before route state settles — a live/E2E verification, not a unit-testable invariant. Defer to post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)