### PR TITLE
fix(crawlers): sweep safeLocationToken sugli slug-site restanti (#952)

### DIFF
--- a/scripts/update-alpiq-jobs.mjs
+++ b/scripts/update-alpiq-jobs.mjs
@@ -10,6 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { snapshotJobSlugs, computeCrawlDiff, printCrawlChangeSummary, writeCrawlChangeSummaryToGH, printPublishedJobUrls, writeJobsSummary, setCrawlerStartTime, getCrawlerElapsedMs } from './jobs-url-helper.mjs';
 import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
   registerCrawlerSummaryGuard, assembleJobsDataset, readExistingCrawlerJobs,
@@ -70,7 +71,10 @@ async function main() {
   console.log(`\ud83e\udde9 Found ${rawJobs.length} Swiss Alpiq jobs.`);
   const parsedJobs = rawJobs.map((raw) => {
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-alpiq-${raw.location || 'switzerland'}`);
+    // Slug-only guard: a literal "undefined"/"null" location string is truthy
+    // and would slip past `|| 'switzerland'` into an active slug (#952, class
+    // #900/#901). addressLocality stays as-is (choke-point normalizer handles it).
+    const jobSlug = slugify(`${raw.title}-alpiq-${safeLocationToken(raw.location, 'switzerland')}`);
     const desc = raw.description || `Posizione aperta presso Alpiq (${raw.location || 'Svizzera'}). Alpiq \u00e8 uno dei principali produttori di energia in Svizzera con centrali idroelettriche in Ticino. Candidati tramite il portale SuccessFactors.`;
     return {
       id: `alpiq-${urlHash}`, slug: jobSlug, slugByLocale: { it: jobSlug },

--- a/scripts/update-bps-suisse-jobs.mjs
+++ b/scripts/update-bps-suisse-jobs.mjs
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
@@ -218,7 +219,10 @@ async function fetchJobs() {
     });
 
     const urlHash = createHash('sha1').update(listing.url).digest('hex').slice(0, 12);
-    const slug = slugify(`${listing.title}-bps-suisse-${location}`);
+    // Slug-only guard: `location` is reassigned from `detail.location`, which can
+    // be the literal "undefined"/"null" string (truthy) → `-undefined` in an active
+    // slug (#952, class #900/#901). addressLocality untouched (choke-point normalizer).
+    const slug = slugify(`${listing.title}-bps-suisse-${safeLocationToken(location, 'Lugano')}`);
 
     jobs.push({
       id: `bps-suisse-${urlHash}`,

--- a/scripts/update-casale-jobs.mjs
+++ b/scripts/update-casale-jobs.mjs
@@ -10,6 +10,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { snapshotJobSlugs, computeCrawlDiff, printCrawlChangeSummary, writeCrawlChangeSummaryToGH, setCrawlerStartTime, getCrawlerElapsedMs } from './jobs-url-helper.mjs';
 import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
   registerCrawlerSummaryGuard, assembleJobsDataset, readExistingCrawlerJobs,
@@ -56,7 +57,10 @@ async function fetchJobs() {
 
   return swissOffers.map((offer) => {
     const built = buildJobFromApi(offer);
-    const slug = slugify(`${built.title} casale ${built.city}`);
+    // Slug-only guard: `built.city` can be the literal "undefined"/"null" string
+    // (truthy) → `-undefined` in an active slug (#952, class #900/#901). location/
+    // addressLocality keep raw `built.city` (choke-point normalizer owns de-index).
+    const slug = slugify(`${built.title} casale ${safeLocationToken(built.city, 'Lugano')}`);
     const fallbackDesc = `${built.title} — posizione aperta presso Casale SA a Lugano, Canton Ticino, Svizzera. Casale SA è un'azienda globale di ingegneria con sede a Lugano, specializzata nella progettazione e costruzione di impianti per la produzione di fertilizzanti e prodotti chimici (ammoniaca, urea, metanolo, melamina, nitrati e fosfati). L'azienda offre un ambiente di lavoro stimolante e internazionale nel cuore del Ticino, con opportunità di crescita professionale in un contesto globale.`;
     const description = (built.description && built.description.length >= 220) ? built.description : fallbackDesc;
     return {

--- a/scripts/update-confederazione-jobs.mjs
+++ b/scripts/update-confederazione-jobs.mjs
@@ -31,6 +31,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -328,7 +329,10 @@ function buildLocalizedContent(job = {}, sourceLang = 'it') {
   return {
     titleByLocale: { [sourceLang]: title },
     descriptionByLocale: { [sourceLang]: sourceDesc || title },
-    slugByLocale: { [sourceLang]: slugify(`${title} confederazione ${city}`) },
+    // Slug-only guard: `job.city` can be the literal "undefined"/"null" string
+    // (truthy) → `-undefined` in an active slug (#952, class #900/#901). Fallback is
+    // `regionLabel` (Ticino/Grigioni), region-correct. addressLocality untouched.
+    slugByLocale: { [sourceLang]: slugify(`${title} confederazione ${safeLocationToken(city, regionLabel)}`) },
   };
 }
 

--- a/scripts/update-corner-jobs.mjs
+++ b/scripts/update-corner-jobs.mjs
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { printPublishedJobUrls, writeJobsSummary, snapshotJobSlugs, computeCrawlDiff, printCrawlChangeSummary, writeCrawlChangeSummaryToGH, setCrawlerStartTime, getCrawlerElapsedMs } from './jobs-url-helper.mjs';
 import {
   writeJobsCrawlerSlice,
@@ -231,17 +232,22 @@ function parseCornerOffer(offer) {
   const reqFr = frTrans.requirements ? parseBullets(frTrans.requirements) : [];
   const requirementsByLocale = { it: reqIt, en: reqEn, de: reqDe, fr: reqFr };
 
-  // Build locale slugs
+  // Build locale slugs.
+  // Slug-only guard: `city` (`loc.city || offer.city || 'Lugano'`) can be the
+  // literal "undefined"/"null" string (truthy) → `-undefined` in active slugs
+  // (#952, class #900/#901). location/addressLocality keep raw `city` (choke-point
+  // normalizer owns de-index); guard only the slug token.
+  const slugCity = safeLocationToken(city, 'Lugano');
   const slugByLocale = {
-    it: slugify(`${titleByLocale.it}-corner-banca-${city}`),
-    en: slugify(`${titleByLocale.en}-corner-banca-${city}`),
-    de: slugify(`${titleByLocale.de}-corner-banca-${city}`),
-    fr: slugify(`${titleByLocale.fr}-corner-banca-${city}`),
+    it: slugify(`${titleByLocale.it}-corner-banca-${slugCity}`),
+    en: slugify(`${titleByLocale.en}-corner-banca-${slugCity}`),
+    de: slugify(`${titleByLocale.de}-corner-banca-${slugCity}`),
+    fr: slugify(`${titleByLocale.fr}-corner-banca-${slugCity}`),
   };
 
   return {
     id,
-    slug: slugify(`${title}-corner-banca-${city}`),
+    slug: slugify(`${title}-corner-banca-${slugCity}`),
     slugByLocale,
     company: 'Cornèr Banca',
     companyKey: CORNER_KEY,

--- a/scripts/update-debiopharm-jobs.mjs
+++ b/scripts/update-debiopharm-jobs.mjs
@@ -19,6 +19,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -219,7 +220,11 @@ function buildDebiopharmJob(listing, detail) {
   const parsed = parseDebiopharmJobDetailPayload(detail);
   const title = parsed.title || String(listing?.title || '').trim();
   const city = parsed.city || 'Lausanne';
-  const slug = slugify(`${title} ${COMPANY_NAME} ${city} ${parsed.inferredCanton} Switzerland`);
+  // Slug-only guard: both `city` and `parsed.inferredCanton` can be the literal
+  // "undefined"/"null" string (truthy) → `-undefined` in an active slug (#952, class
+  // #900/#901). location/addressLocality keep raw `city` (choke-point normalizer
+  // owns de-index); guard only the slug tokens here.
+  const slug = slugify(`${title} ${COMPANY_NAME} ${safeLocationToken(city, 'Lausanne')} ${safeLocationToken(parsed.inferredCanton, 'Vaud')} Switzerland`);
   const detailUrl = buildDebiopharmDetailUrl(listing.shortcode);
   const applyUrl = buildDebiopharmApplyUrl(listing.shortcode);
   const publishedDate = toIsoDate(parsed.publishedDate);

--- a/scripts/update-guess-jobs.mjs
+++ b/scripts/update-guess-jobs.mjs
@@ -16,6 +16,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -211,7 +212,10 @@ function buildGuessJob(listing, detail) {
   const parsed = parseGuessJobDetailPayload(detail);
   const title = parsed.title || String(listing?.title || '').trim();
   const city = parsed.city || String(listing?.city || '').trim() || 'Bioggio';
-  const slug = slugify(`${title} ${COMPANY_NAME} ${city} Ticino Switzerland`);
+  // Slug-only guard: `city` can be the literal "undefined"/"null" string (truthy)
+  // → `-undefined` in an active slug (#952, class #900/#901). location/addressLocality
+  // keep raw `city` (choke-point normalizer owns de-index).
+  const slug = slugify(`${title} ${COMPANY_NAME} ${safeLocationToken(city, 'Bioggio')} Ticino Switzerland`);
   const detailUrl = buildGuessDetailUrl(listing.shortcode);
   const applyUrl = buildGuessApplyUrl(listing.shortcode);
   const publishedDate = toIsoDate(parsed.publishedDate || listing.published_on || listing.created_at);

--- a/scripts/update-kronenhof-jobs.mjs
+++ b/scripts/update-kronenhof-jobs.mjs
@@ -21,6 +21,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -277,7 +278,10 @@ function buildJob(raw, detailDescription = '') {
   const { employmentType, contractType } = mapContractType(raw.contract_duration);
   // Include vacancy ID to prevent slug collisions when two vacancies share
   // the same title + company + city (e.g., two "Office Employee" openings).
-  const slug = slugify(`${title}-${company}-${city}-${raw.id}`);
+  // Slug-only guard for the location token, consistent with the crawler sweep
+  // (#952, class #900/#901). `mapLocation` currently returns hardcoded cities, so
+  // this is defensive against a future parser regression leaking "undefined"/"null".
+  const slug = slugify(`${title}-${company}-${safeLocationToken(city, 'Pontresina')}-${raw.id}`);
   const detailUrl = `https://careers.kronenhof.com/en/vacancies/${raw.id}`;
   const postedDate = raw.contract_starts_at
     ? raw.contract_starts_at.slice(0, 10)

--- a/scripts/update-ksgr-jobs.mjs
+++ b/scripts/update-ksgr-jobs.mjs
@@ -7,6 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 import {
   printPublishedJobUrls,
@@ -145,7 +146,11 @@ function buildJobFromApiData(apiJob, existingByUrl) {
   const existing = existingByUrl.get(String(apiJob.detailUrl || '').toLowerCase());
   const title = apiJob.title;
   const description = apiJob.description || '';
-  const slug = slugify(`${title} ${COMPANY_NAME} ${apiJob.location || 'graubuenden'}`);
+  // Guard the slug location token so a literal "undefined"/"null" from the API
+  // (both truthy → slip past `|| 'graubuenden'`) can never leak `-undefined`
+  // into an active slug (sitemap-canonical gate). Slug-only; addressLocality is
+  // backfilled by the choke-point normalizer. Issue #952 (class #900/#901).
+  const slug = slugify(`${title} ${COMPANY_NAME} ${safeLocationToken(apiJob.location, 'graubuenden')}`);
 
   return {
     id: apiJob.id,

--- a/scripts/update-prada-jobs.mjs
+++ b/scripts/update-prada-jobs.mjs
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -157,7 +158,11 @@ async function main() {
       continue;
     }
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-prada-group-${loc}`);
+    // Slug-only guard: `loc` (`detail?.location || raw.location || 'Mendrisio'`)
+    // can be the literal "undefined"/"null" string (truthy) → `-undefined` in an
+    // active slug (#952, class #900/#901). addressLocality keeps `loc` (choke-point
+    // normalizer handles de-index).
+    const jobSlug = slugify(`${raw.title}-prada-group-${safeLocationToken(loc, 'Mendrisio')}`);
     parsedJobs.push({
       id: `prada-${urlHash}`,
       slug: jobSlug,

--- a/scripts/update-sbb-jobs.mjs
+++ b/scripts/update-sbb-jobs.mjs
@@ -40,6 +40,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { printPublishedJobUrls, writeJobsSummary, snapshotJobSlugs, computeCrawlDiff, printCrawlChangeSummary, writeCrawlChangeSummaryToGH, setCrawlerStartTime, getCrawlerElapsedMs } from './jobs-url-helper.mjs';
 import {
   writeJobsCrawlerSlice,
@@ -849,7 +850,12 @@ async function parseSbbJobFromDetailUrl(detailUrl, apiMetaByUrl, apiMetaByTitle 
     sbbParsed?.location
   ).trim();
   const canton = inferAnyCanton(`${location} ${apiMeta?.region || ''}`) || DEFAULT_CANTON;
-  const slugBase = slugify(`${title}-${SBB_KEY}-${location}`) || createHash('sha1').update(normalizeDetailUrl(detailUrl)).digest('hex').slice(0, 16);
+  // Slug-only guard: `location` is `String(...).trim()`, so all-undefined sources
+  // collapse to the literal "undefined"/"null" string → `-undefined` in an active
+  // slug (#952, class #900/#901). Keep `location`/`addressLocality` untouched
+  // (choke-point normalizer owns de-index); guard only the slug token here.
+  const slugLocation = safeLocationToken(location, 'Switzerland');
+  const slugBase = slugify(`${title}-${SBB_KEY}-${slugLocation}`) || createHash('sha1').update(normalizeDetailUrl(detailUrl)).digest('hex').slice(0, 16);
   const id = `sbb-${createHash('sha1').update(normalizeDetailUrl(detailUrl)).digest('hex').slice(0, 12)}`;
   const postedDate = toIsoDate(apiMeta?.datePosted || jobPosting?.datePosted);
 
@@ -886,7 +892,7 @@ async function parseSbbJobFromDetailUrl(detailUrl, apiMetaByUrl, apiMetaByTitle 
   const localeSlugs = Object.fromEntries(
     ['it', 'en', 'de', 'fr'].map((locale) => {
       const localizedTitle = String(localeTitles[locale] || title).trim();
-      return [locale, slugify(`${localizedTitle}-${SBB_KEY}-${location}`) || slugBase];
+      return [locale, slugify(`${localizedTitle}-${SBB_KEY}-${slugLocation}`) || slugBase];
     })
   );
 

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
@@ -269,7 +270,10 @@ function refreshLocalizedSlugs() {
     for (const locale of LOCALES) {
       const localizedTitle = String(next.titleByLocale?.[locale] || '').trim();
       if (!localizedTitle) continue;
-      const localizedLocation = String(next.addressLocality || next.location || 'Ticino').trim();
+      // Slug-only guard: `addressLocality`/`location` can be the literal
+      // "undefined"/"null" string (truthy → slips past `|| 'Ticino'`) → `-undefined`
+      // in an active slug (#952, class #900/#901). Stored addressLocality untouched.
+      const localizedLocation = safeLocationToken(next.addressLocality || next.location, 'Ticino');
       const slug = slugify(`${localizedTitle} ${COMPANY_NAME} ${localizedLocation}`);
       if (slug && next.slugByLocale[locale] !== slug) {
         next.slugByLocale[locale] = slug;


### PR DESCRIPTION
## Implementato

Sweep difensivo di `safeLocationToken` (`scripts/lib/safe-location-token.mjs`) sugli **slug-site** dei 12 crawler non coperti da #951 — stessa classe di #900/#901, lato slug.

Una stringa letterale `"undefined"`/`"null"` da un detail parser è truthy → supera `|| fallback` → leak `-undefined` negli slug attivi → fallimento `audit:sitemap-canonicals` (gate post-deploy prima di `publish`, famiglia #823/#852). Il choke-point `sanitizeJobLocationField` copre già `addressLocality` per tutti i crawler, ma lo slug è costruito per-crawler e non viene rigenerato dal normalizer.

Wrap **solo del token location dentro `slugify(...)`**, con fallback per-crawler region-appropriato. Il path `addressLocality`/de-index NON è toccato (resta a carico del normalizer, #951).

| Crawler | Slug-site | Fallback |
|---|---|---|
| `update-ksgr-jobs.mjs` | `apiJob.location` | `graubuenden` |
| `update-alpiq-jobs.mjs` | `raw.location` | `switzerland` |
| `update-prada-jobs.mjs` | `loc` (`detail?.location \|\| raw.location`) | `Mendrisio` |
| `update-sbb-jobs.mjs` | `location` (2 siti: `slugBase` + `localeSlugs`, via `slugLocation`) | `Switzerland` |
| `update-bps-suisse-jobs.mjs` | `location` | `Lugano` |
| `update-corner-jobs.mjs` | `city` (5 siti, via `slugCity`) | `Lugano` |
| `update-guess-jobs.mjs` | `city` | `Bioggio` |
| `update-debiopharm-jobs.mjs` | `city` + `parsed.inferredCanton` | `Lausanne` / `Vaud` |
| `update-confederazione-jobs.mjs` | `city` | `regionLabel` (Ticino/Grigioni) |
| `update-kronenhof-jobs.mjs` | `city` | `Pontresina` |
| `update-casale-jobs.mjs` | `built.city` | `Lugano` |
| `update-skyguide-jobs.mjs` | `addressLocality \|\| location` (slug refresh) | `Ticino` |

**Blast radius:** GitNexus impact su `buildJobFromApiData` (ksgr) e `refreshLocalizedSlugs` (skyguide) → entrambi **LOW**, funzioni leaf per-crawler chiamate solo dal `main` del crawler stesso. Nessuna firma cambiata, solo il valore interpolato nello slug → zero impatto a valle.

**Validazione:** `node --check` su tutti i 12 file → OK. `node scripts/assemble-jobs-dataset.mjs --stats` → 6210 active jobs assemblati; gli unici 2 slug `-undefined` residui sono `*-hilcona-undefined` (dominio #951, entry stale pre-fix in `data/jobs.json` non-tracked, già fixate alla sorgente) — nessuno dei 12 crawler toccati emette `-undefined`. Conferma la natura latente/difensiva.

Note minori vs spec dell'issue:
- **SBB**: due slug-site (`slugBase` L852 + `localeSlugs` L889) consolidati su un singolo `slugLocation` guardato, per non duplicare il wrap.
- **kronenhof**: `mapLocation` ritorna città hardcoded (`Pontresina`/`St. Moritz`), quindi lo slug-site non è realmente esposto oggi — wrappato comunque per coerenza del sweep difensivo.
- **debiopharm**: lo slug interpola anche `parsed.inferredCanton` (stessa classe di difetto) → guardato pure quello, oltre a `city`.

## Non implementato (ancora)

- **Cleanup retroattivo** dei 2 slug `-hilcona-undefined` stale in `data/jobs.json`: out of scope (dominio #951, già fixato alla sorgente; sono entry pre-fix preservate per stable-id merge). Si auto-risolveranno quando quei job scadono/ri-crawlati. Non funnel-bloccante (hilcona già guardato).
- **Nessun nuovo test unitario**: per policy del progetto i nit "manca test" non sono in scope; `safe-location-token.mjs` è già una utility pura testabile e il fix è puro wrap di una funzione esistente già provata da #951.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)
