### PR TITLE
fix(fuel): show 'unchanged' word instead of 0,000 CHF for flat day delta

### DIFF
--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -420,6 +420,22 @@ function formatDelta(delta: number | null, locale: FuelDailyLocale): string {
   return `${sign}${val.replace('.', sep)} CHF`;
 }
 
+/**
+ * Daily-zone-page delta presentation: same as {@link formatDelta} but renders
+ * an explicit "unchanged" word for an exact-zero delta instead of "0,000 CHF",
+ * which users read as "no data" (see the live Locarno case). Display-only —
+ * NOT used by station/Italian-city pages, which parse formatDelta's numeric
+ * output (strip sign + "CHF"/"EUR"), so the raw helper stays untouched there.
+ */
+function formatDeltaDisplay(
+  delta: number | null,
+  locale: FuelDailyLocale,
+  copy: FuelCopy,
+): string {
+  if (delta === 0) return copy.unchangedLabel;
+  return formatDelta(delta, locale);
+}
+
 function formatPrice(price: number | null, locale: FuelDailyLocale): string {
   if (price === null || Number.isNaN(price)) return '—';
   const sep = locale === 'it' || locale === 'fr' ? ',' : '.';
@@ -457,6 +473,12 @@ interface FuelCopy {
   avgLabel: string;
   vsYesterday: string;
   vs7d: string;
+  /**
+   * Word shown in place of a "0,000 CHF" delta when the price is unchanged
+   * vs the comparison point. A literal "0,000 CHF" reads like missing data;
+   * an explicit "stabile"/"unchanged" word reads as "no change".
+   */
+  unchangedLabel: string;
   top3Label: string;
   trendLabel: string;
   trendEmpty: string;
@@ -496,6 +518,7 @@ const COPY: Record<FuelDailyLocale, FuelCopy> = {
     avgLabel: 'Prezzo medio oggi',
     vsYesterday: 'vs ieri',
     vs7d: 'vs 7 giorni fa',
+    unchangedLabel: 'stabile',
     top3Label: 'Le 3 stazioni più economiche',
     trendLabel: 'Andamento storico del prezzo',
     trendEmpty: 'Storico in costruzione: il grafico si aggiorna ogni giorno a partire da oggi.',
@@ -541,6 +564,7 @@ const COPY: Record<FuelDailyLocale, FuelCopy> = {
     avgLabel: 'Average price today',
     vsYesterday: 'vs yesterday',
     vs7d: 'vs 7 days ago',
+    unchangedLabel: 'unchanged',
     top3Label: 'Top 3 cheapest stations',
     trendLabel: 'Historical price trend',
     trendEmpty: 'History is being collected: the chart fills in day by day.',
@@ -586,6 +610,7 @@ const COPY: Record<FuelDailyLocale, FuelCopy> = {
     avgLabel: 'Durchschnittspreis heute',
     vsYesterday: 'vs gestern',
     vs7d: 'vs 7 Tage',
+    unchangedLabel: 'unverändert',
     top3Label: 'Top 3 günstigste Tankstellen',
     trendLabel: 'Historischer Preisverlauf',
     trendEmpty: 'Historie wird aufgebaut: das Diagramm füllt sich Tag für Tag.',
@@ -631,6 +656,7 @@ const COPY: Record<FuelDailyLocale, FuelCopy> = {
     avgLabel: 'Prix moyen aujourd\'hui',
     vsYesterday: 'vs hier',
     vs7d: 'vs 7 jours',
+    unchangedLabel: 'stable',
     top3Label: 'Top 3 stations les moins chères',
     trendLabel: 'Tendance historique du prix',
     trendEmpty: 'Historique en cours de construction : le graphique se remplit jour par jour.',
@@ -1571,8 +1597,8 @@ function renderPage(inp: PageInputs): string {
   const delta7 = computeDeltaVsYesterday(avg, weekAgo);
 
   const priceFmt = formatPrice(avg, locale);
-  const deltaYestFmt = formatDelta(deltaYest, locale);
-  const delta7Fmt = formatDelta(delta7, locale);
+  const deltaYestFmt = formatDeltaDisplay(deltaYest, locale, copy);
+  const delta7Fmt = formatDeltaDisplay(delta7, locale, copy);
 
   const h1 = zone ? copy.zoneH1(fuelLabel, zoneLabel) : copy.regionalH1(fuelLabel);
   const intro = copy.intro(fuelLabel, zoneLabel, priceFmt, dateStamp);

--- a/tests/fuel-daily-pages.test.ts
+++ b/tests/fuel-daily-pages.test.ts
@@ -332,6 +332,46 @@ describe('fuel-daily page generation — diesel data sourcing (F6 real diesel)',
   });
 });
 
+describe('fuel-daily page generation — unchanged-delta UX', () => {
+  const today = new Date('2026-04-20T06:00:00.000Z');
+  // Single Chiasso benzina station at 1.800; yesterday's snapshot carries the
+  // same 1.800 → delta is exactly 0. The page must render an explicit
+  // "unchanged" word, NOT "0,000 CHF" (which reads as missing data).
+  const isolated = {
+    generatedAt: '2026-04-20T06:00:00.000Z',
+    municipalities: [
+      {
+        municipality: 'Test',
+        province: 'CO',
+        swiss: {
+          nearbyStations: [
+            { id: 'u1', name: 'Stable Station', brand: 'TEST', address: 'Via Test 1, 6830 Chiasso', sp95PriceChf: 1.8 },
+          ],
+        },
+      },
+    ],
+  };
+  const history = [
+    { date: '2026-04-19', zones: { chiasso: { benzina: 1.8 } }, regional: {} },
+  ];
+
+  it('IT: renders "stabile" instead of "0,000 CHF" for a zero day-over-day delta', () => {
+    // @ts-expect-error partial HistorySnapshot shape (single zone) acceptable for this test
+    const pages = generateFuelDailyPages({ rootDir: '/tmp/frontaliere-fuel-unchanged-it', dataset: isolated, history, today });
+    const html = pages['/prezzi-benzina/chiasso/oggi/'];
+    expect(html).toContain('stabile rispetto a ieri');
+    expect(html).not.toContain('0,000 CHF rispetto a ieri');
+  });
+
+  it('EN: renders "unchanged" instead of "0.000 CHF" for a zero day-over-day delta', () => {
+    // @ts-expect-error partial HistorySnapshot shape (single zone) acceptable for this test
+    const pages = generateFuelDailyPages({ rootDir: '/tmp/frontaliere-fuel-unchanged-en', dataset: isolated, history, today });
+    const html = pages['/en/gasoline-price-switzerland/chiasso/today/'];
+    expect(html).toContain('unchanged compared to yesterday');
+    expect(html).not.toContain('0.000 CHF compared to yesterday');
+  });
+});
+
 describe('fuel-daily archive generation', () => {
   it('generates archives only for past months', () => {
     const today = new Date('2026-04-20T06:00:00.000Z');


### PR DESCRIPTION
## Implementato

Le pagine prezzi-carburante per zona/giorno (es. `/prezzi-benzina/locarno/oggi/`) mostravano un letterale **`0,000 CHF`** nel tile "vs ieri" (e nella tagline + paragrafo intro) quando il prezzo di oggi è uguale a quello di ieri. Visivamente sembra "dato mancante", mentre significa "prezzo invariato".

Esempio live confermato: Locarno benzina ferma a 1,800 CHF dal 30 mag → tile "vs ieri 0,000 CHF". Il delta a 7 giorni invece si muoveva correttamente (−0,070 CHF), aumentando la confusione.

- Nuovo helper **display-only** `formatDeltaDisplay(delta, locale, copy)`: per delta **esattamente 0** ritorna una parola localizzata invece di `0,000 CHF`.
- Nuovo campo copy `unchangedLabel` nei 4 locali: `stabile` / `unchanged` / `unverändert` / `stable`.
- Usato nel render della pagina daily-zone per tile vs-ieri, tile vs-7gg, tagline e paragrafo. Risultato:
  - Tile: "vs ieri → **stabile**"
  - Paragrafo IT: "...1,800 CHF/litro, **stabile rispetto a ieri** e −0,070 CHF rispetto a 7 giorni fa."
  - EN: "...**unchanged compared to yesterday**..."
- `formatDelta` originale **non toccato**: le pagine stazione e città-EUR fanno parsing del suo output numerico (strip segno + `CHF`/`EUR`), quindi cambiarlo le romperebbe.
- Logica di colore dei tile invariata (zero → tile neutro come prima).
- Test render aggiunti (IT+EN) che verificano la parola "unchanged" e l'assenza di `0,000 CHF`/`0.000 CHF`. Suite fuel-daily verde (31 test), typecheck pulito sui file toccati.

## Non implementato (ancora)

- **Prezzo assoluto di ieri accanto al tile** (es. "= 1,800 come ieri"): out of scope — la parola "stabile" già risolve la comprensibilità; aggiungere il valore è un arricchimento separato, non un bug.
- **Distinzione delta quasi-zero per arrotondamento** (es. −0,0003 → mostra "stabile" ma colore success): edge case rarissimo, lasciato invariato per non toccare la logica colore (cambio chirurgico).
- **Locale EUR città italiane**: non interessato — usano `formatDelta` raw (intoccato), scope diverso (#1049 MIMIT/diesel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)