### PR TITLE
fix(ci): RC load in refine-url uses Firebase SA, not GSC-only SA (#1141)

### DIFF
--- a/.github/workflows/refine-url-first-seen.yml
+++ b/.github/workflows/refine-url-first-seen.yml
@@ -64,23 +64,39 @@ jobs:
           echo "Running: node scripts/refine-url-first-seen-via-gsc.mjs $FLAGS"
           node scripts/refine-url-first-seen-via-gsc.mjs $FLAGS
 
-      # Load GITHUB_PAT (Firebase Remote Config) into $GITHUB_ENV. The GSC SA
-      # materialized above doubles as the Firebase SA, so RC is reachable here
-      # (must run BEFORE "Cleanup SA" deletes /tmp/sa.json). Needed because a
-      # `gh pr create` authenticated by secrets.GITHUB_TOKEN is rejected by
-      # GitHub anti-recursion ("GitHub Actions is not permitted to create pull
-      # requests") → the old PR step failed red on every data diff and the
-      # grace-window/GSC refresh never landed (issue #1114). The PAT creates the
-      # PR as a real user, which is permitted.
+      # Load GITHUB_PAT (Firebase Remote Config) into $GITHUB_ENV. RC reachability
+      # requires the *Firebase* SA (secrets.FIREBASE_SERVICE_ACCOUNT_JSON), the
+      # same credential every other RC-loading workflow uses (sync-gsc-orphans,
+      # traffic-scheduler, deploy, …). The GSC SA above (GSC_SERVICE_ACCOUNT_JSON)
+      # is a distinct, GSC-only service account and is NOT guaranteed to have the
+      # Firebase Remote Config viewer role — using it here left load-rc-env unable
+      # to read GITHUB_PAT, so the #1114 fix never actually worked (issue #1141).
+      # Needed because a `gh pr create` authenticated by secrets.GITHUB_TOKEN is
+      # rejected by GitHub anti-recursion ("GitHub Actions is not permitted to
+      # create pull requests") → the old PR step failed red on every data diff and
+      # the grace-window/GSC refresh never landed (issue #1114). The PAT creates
+      # the PR as a real user, which is permitted.
+      - name: Materialize Firebase SA (Remote Config)
+        if: inputs.dry_run == 'false'
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error::Secret FIREBASE_SERVICE_ACCOUNT_JSON not set — cannot load GITHUB_PAT from Remote Config; the PR step would fail (issue #1114/#1141)."
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          chmod 600 /tmp/firebase-sa.json
+
       - name: Load RC secrets (GITHUB_PAT)
         if: inputs.dry_run == 'false'
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
         run: node scripts/load-rc-env.mjs
 
       - name: Cleanup SA
         if: always()
-        run: rm -f /tmp/sa.json
+        run: rm -f /tmp/sa.json /tmp/firebase-sa.json
 
       - name: Open PR if data changed
         if: inputs.dry_run == 'false'


### PR DESCRIPTION
## Implementato
Il fix #1114 (mergiato in #1134) instradava il load di GITHUB_PAT in `refine-url-first-seen.yml` via `load-rc-env.mjs` con `GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json` = il SA `GSC_SERVICE_ACCOUNT_JSON`. Quel SA è **GSC-only** (secret distinto, creato 2026-05-28) e non è garantito abbia il ruolo **Firebase Remote Config viewer** → `load-rc-env` non poteva leggere GITHUB_PAT → lo step PR PAT-autenticato fallirebbe comunque su ogni data diff: **il fix #1114 non funzionava davvero** (issue #1141, reviewer ❓).

Evidenza: **tutti** i ~hundreds di workflow che caricano RC (sync-gsc-orphans, traffic-scheduler, deploy, auto-merge-on-lgtm, send-newsletter, …) usano `secrets.FIREBASE_SERVICE_ACCOUNT_JSON` per lo step RC. **Zero** usano `GSC_SERVICE_ACCOUNT_JSON`. refine-url era l'unico outlier.

Fix (mirror del pattern provato):
- Nuovo step `Materialize Firebase SA (Remote Config)` → scrive `secrets.FIREBASE_SERVICE_ACCOUNT_JSON` in `/tmp/firebase-sa.json` (fail-loud se unset, gated su `dry_run==false`).
- `Load RC secrets` ora punta a `/tmp/firebase-sa.json`.
- Il refinement GSC continua a usare `/tmp/sa.json` (GSC SA). `Cleanup SA` rimuove entrambi i file.
- Commento aggiornato per documentare la distinzione GSC-SA vs Firebase-SA.

YAML validato. `git merge origin/main` allineato (workflow byte-aligned).

Closes #1141

## Non implementato (ancora)
- Validazione live end-to-end (un run `dry_run=false` con data diff reale che crea la PR via PAT) — verificabile solo post-merge facendo girare il workflow; finora non ha mai eseguito lo step PR (unico run storico era dry_run). Da osservare al primo run con diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)