### PR TITLE
feat(currency): avvicina conversione+comparazione su cambio-franco-euro

### DIFF
--- a/components/comparators/CurrencyExchange.tsx
+++ b/components/comparators/CurrencyExchange.tsx
@@ -473,17 +473,6 @@ const CurrencyExchange: React.FC = () => {
  </a>
  )}
 
- {/* Important Notice — sibling, not nested */}
- <aside role="note" className="flex items-start gap-3 border-l-0 border border-warning-border bg-warning-subtle rounded-xl px-4 py-3">
- <AlertCircle size={20} className="flex-shrink-0 mt-0.5 text-warning" aria-hidden="true" />
- <div className="text-sm text-body">
- <p className="font-bold mb-1 text-strong">{t('currency.notice_title')}</p>
- <p className="text-subtle leading-relaxed">
- {t('currency.notice_text')}
- </p>
- </div>
- </aside>
-
  {/* Sub-tab navigation */}
  <SegmentControl
  options={[
@@ -497,9 +486,7 @@ const CurrencyExchange: React.FC = () => {
 
  {exchangeSubTab === 'overview' ? (
  <>
- {/* Calculator + History Side by Side */}
- <div className="grid lg:grid-cols-2 gap-6 min-h-[420px]">
- {/* Calculator */}
+ {/* Calculator — conversion first, full width */}
  <div className="bg-surface rounded-2xl border border-edge p-4 sm:p-6 shadow-sm">
  <div className="flex items-center justify-between mb-4">
  <h2 className="text-lg font-bold font-display text-strong flex items-center gap-2">
@@ -516,7 +503,7 @@ const CurrencyExchange: React.FC = () => {
  </button>
  </div>
 
- <div className="space-y-4">
+ <div className="grid sm:grid-cols-2 gap-4 items-start">
  <div className="space-y-2">
  <label htmlFor="exchange-amount" className="text-xs font-bold text-muted uppercase tracking-wide">{t('currency.amount_to_convert')}</label>
  <div className="relative">
@@ -566,50 +553,6 @@ const CurrencyExchange: React.FC = () => {
  {lastUpdate ? `${t('currency.updated')}: ${lastUpdate.toLocaleTimeString('it-IT')}` : '\u00A0'}
  </p>
  </div>
- </div>
- </div>
-
- {/* History Chart */}
- <div className="bg-surface rounded-2xl border border-edge p-4 sm:p-6 shadow-sm">
- <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
- <h2 className="text-lg font-bold font-display text-strong flex items-center gap-2">
- <BarChart3 size={20} className="text-success" />
- {t('currency.history_title')}
- </h2>
- <div className="flex gap-1.5">
- {(['1m', '3m', '6m', '1y', '5y'] as const).map(p => (
- <button key={p}
- onClick={() => setHistoryPeriod(p)}
- className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors ${historyPeriod === p ? 'bg-success-strong text-on-accent shadow' : 'bg-surface-raised text-subtle hover:bg-surface-raised'}`}
- >
- {p === '1m' ? '1M' : p === '3m' ? '3M' : p === '6m' ? '6M' : p === '1y' ? '1A' : '5A'}
- </button>
- ))}
- </div>
- </div>
- {historyLoading ? (
- <div className="h-[280px] flex items-center justify-center text-muted">
- <RefreshCw size={24} className="animate-spin" />
- </div>
- ) : historyData.length > 0 ? (
- <div role="img" aria-label="Grafico tasso di cambio CHF/EUR" tabIndex={0}>
- <Suspense fallback={<div className="h-[280px] flex items-center justify-center text-muted"><RefreshCw size={24} className="animate-spin" /></div>}>
- <LazyExchangeChart data={historyData} />
- </Suspense>
- </div>
- ) : (
- <div className="h-[280px] flex items-center justify-center text-muted text-sm">
- {t('currency.no_data_available')}
- </div>
- )}
- {historyData.length > 1 && (
- <div className="flex justify-between mt-3 text-xs text-muted min-h-[20px]">
- <span>Min: {Math.min(...historyData.map(d => d.rate)).toFixed(4)}</span>
- <span>{t('currency.average')}: {(historyData.reduce((s, d) => s + d.rate, 0) / historyData.length).toFixed(4)}</span>
- <span>Max: {Math.max(...historyData.map(d => d.rate)).toFixed(4)}</span>
- </div>
- )}
- {historyData.length <= 1 && <div className="min-h-[20px] mt-3" />}
  </div>
  </div>
 
@@ -670,6 +613,17 @@ const CurrencyExchange: React.FC = () => {
  </div>
  </div>
  </div>
+
+ {/* Important Notice — rates disclaimer, demoted below conversion result */}
+ <aside role="note" className="flex items-start gap-3 border-l-0 border border-warning-border bg-warning-subtle rounded-xl px-4 py-3">
+ <AlertCircle size={20} className="flex-shrink-0 mt-0.5 text-warning" aria-hidden="true" />
+ <div className="text-sm text-body">
+ <p className="font-bold mb-1 text-strong">{t('currency.notice_title')}</p>
+ <p className="text-subtle leading-relaxed">
+ {t('currency.notice_text')}
+ </p>
+ </div>
+ </aside>
 
  {/* Comparison Table */}
  <div>
@@ -795,6 +749,49 @@ const CurrencyExchange: React.FC = () => {
  );
  })}
  </div>
+ </div>
+
+ {/* History Chart — moved below conversion + comparison, secondary context */}
+ <div className="bg-surface rounded-2xl border border-edge p-4 sm:p-6 shadow-sm">
+ <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+ <h2 className="text-lg font-bold font-display text-strong flex items-center gap-2">
+ <BarChart3 size={20} className="text-success" />
+ {t('currency.history_title')}
+ </h2>
+ <div className="flex gap-1.5">
+ {(['1m', '3m', '6m', '1y', '5y'] as const).map(p => (
+ <button key={p}
+ onClick={() => setHistoryPeriod(p)}
+ className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors ${historyPeriod === p ? 'bg-success-strong text-on-accent shadow' : 'bg-surface-raised text-subtle hover:bg-surface-raised'}`}
+ >
+ {p === '1m' ? '1M' : p === '3m' ? '3M' : p === '6m' ? '6M' : p === '1y' ? '1A' : '5A'}
+ </button>
+ ))}
+ </div>
+ </div>
+ {historyLoading ? (
+ <div className="h-[280px] flex items-center justify-center text-muted">
+ <RefreshCw size={24} className="animate-spin" />
+ </div>
+ ) : historyData.length > 0 ? (
+ <div role="img" aria-label="Grafico tasso di cambio CHF/EUR" tabIndex={0}>
+ <Suspense fallback={<div className="h-[280px] flex items-center justify-center text-muted"><RefreshCw size={24} className="animate-spin" /></div>}>
+ <LazyExchangeChart data={historyData} />
+ </Suspense>
+ </div>
+ ) : (
+ <div className="h-[280px] flex items-center justify-center text-muted text-sm">
+ {t('currency.no_data_available')}
+ </div>
+ )}
+ {historyData.length > 1 && (
+ <div className="flex justify-between mt-3 text-xs text-muted min-h-[20px]">
+ <span>Min: {Math.min(...historyData.map(d => d.rate)).toFixed(4)}</span>
+ <span>{t('currency.average')}: {(historyData.reduce((s, d) => s + d.rate, 0) / historyData.length).toFixed(4)}</span>
+ <span>Max: {Math.max(...historyData.map(d => d.rate)).toFixed(4)}</span>
+ </div>
+ )}
+ {historyData.length <= 1 && <div className="min-h-[20px] mt-3" />}
  </div>
 
  {/* Experimental: Exchange Timing Analysis */}


### PR DESCRIPTION
## Implementato

Riordino della overview su `/compara-servizi/cambio-franco-euro/` per avvicinare l'utente al contenuto utile (richiesta: "avviciniamo l'utente più al contenuto importante"). Solo `components/comparators/CurrencyExchange.tsx`, puro riordino JSX.

- **Calcolatore in cima, full-width**: i campi *Importo da convertire* | *Tasso di mercato* ora affiancati (`grid sm:grid-cols-2`), prima il calcolatore era half-width dentro una grid 2-col condivisa col grafico.
- **Grafico storico CHF/EUR spostato sotto la tabella comparazione**: prima stava a fianco del calcolatore (~280px) e su mobile (75% traffico) spingeva conversione+comparazione sotto il fold. Ora la sequenza è: calcolatore → tiles miglior/peggior offerta → alert risparmio → tabella confronto provider → grafico storico.
- **Avviso "tassi indicativi" demotato**: spostato sotto il risultato della conversione (era sopra il tool, come barriera). Il disclaimer è più pertinente accanto ai numeri che disclaima.

Verifica:
- `tsc --noEmit`: zero errori sul file (residui sono pre-esistenti/ambientali: `data/jobs.json` generato assente nel worktree, fixture test non correlati).
- `vitest tests/calculator/inline-ads.test.tsx`: 7/7 verde (guard slot AdSense `ARTICLE_INLINE_MOBILE` preservato).
- Screenshot mobile 390px + desktop 1280px: calcolatore visibile nel primo viewport, comparazione subito sotto, grafico in basso.
- GitNexus impact `CurrencyExchange` upstream: LOW, 0 dipendenti diretti.

## Non implementato (ancora)

- **Banner best-offer affiliate + segment-nav lasciati invariati** sopra il calcolatore: sono revenue/navigazione e l'utente ha scelto esplicitamente di demotare *solo* il disclaimer, non l'affiliate (mantiene rendering cross-tab, zero perdita revenue). Out of scope.
- **Nessuna modifica al contenuto editoriale SEO** (`editorialContent.ts` / blocchi statici): solo ordine UI nella SPA. Out of scope.
- **Stat tiles dedicate / lede una-riga** della checklist SEO landing non aggiunte: la pagina è un comparatore con tool interattivo, non una landing prose; struttura esistente preservata. Posposto salvo richiesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)