### PR TITLE
feat(ci): weekly funnel-metrics snapshot for RPM/CLS trackers

### DIFF
--- a/.github/workflows/funnel-metrics-snapshot.yml
+++ b/.github/workflows/funnel-metrics-snapshot.yml
@@ -1,0 +1,129 @@
+name: Funnel Metrics Snapshot (weekly)
+
+# Collects the field metrics the open RPM/CLS tracker issues need so they stop
+# being "blocked on unavailable data":
+#   #886 / #855 — CLS p75 mobile/desktop (PostHog $web_vitals)
+#   #888        — GSC avg position + CTR by URL bucket (high-CPC ranking)
+#   #857        — AdSense RPM (content-mix dilution proxy)
+#
+# Reuses the existing fail-soft aggregator `scripts/revenue-monitor.mjs --json`
+# (one source of truth, no duplicated API logic), distils a compact snapshot
+# into the append-only `data/funnel-metrics-history.json`, and posts a one-line
+# summary comment to each tracker. ZERO Claude usage — pure node/bash, so it
+# never touches the Max quota.
+#
+# Runs Monday 07:00 UTC (after Revenue Monitor at 06:15) to avoid overlapping
+# AdSense/GSC calls.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      skip_comment:
+        description: 'Collect + commit snapshot but do not comment on tracker issues'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: funnel-metrics-snapshot
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Write Service Account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::warning::FIREBASE_SERVICE_ACCOUNT_JSON not set — metric sources will be skipped (fail-soft)."
+          fi
+
+      - name: Load secrets from Remote Config
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Collect funnel metrics (revenue-monitor JSON)
+        # revenue-monitor exits 0 even when a source errors; we still want a
+        # (partial) JSON payload, so never let this step fail the run.
+        run: |
+          node scripts/revenue-monitor.mjs --json > /tmp/revenue.json 2> /tmp/revenue.err || true
+          if [ ! -s /tmp/revenue.json ]; then
+            echo "::warning::revenue-monitor produced no JSON — writing empty payload"
+            echo '{"generatedAt":"","current":{"errors":["revenue-monitor produced no output"],"warnings":[]}}' > /tmp/revenue.json
+          fi
+          echo "----- revenue-monitor stderr -----"
+          cat /tmp/revenue.err || true
+
+      - name: Build snapshot + append history + render summary
+        run: |
+          node scripts/funnel-metrics-snapshot.mjs \
+            --in=/tmp/revenue.json \
+            --history=data/funnel-metrics-history.json \
+            --summary-out=/tmp/funnel-summary.md
+          echo "## Funnel metrics snapshot" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/funnel-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit snapshot history
+        id: commit
+        run: |
+          if [ -n "$(git status --porcelain data/funnel-metrics-history.json)" ]; then
+            git config user.name "Valerie Linc"
+            git config user.email "valerielinc@gmail.com"
+            git add data/funnel-metrics-history.json
+            git commit -m "📊 Funnel metrics snapshot $(date -u +%Y-%m-%d)"
+            for i in 1 2 3; do
+              git pull --rebase origin main && git push && { echo "pushed=true" >> "$GITHUB_OUTPUT"; exit 0; }
+              sleep $((i * 5))
+            done
+            echo "::warning::Failed to push funnel-metrics history after 3 attempts"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No snapshot changes to commit"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment snapshot on tracker issues
+        if: ${{ inputs.skip_comment != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Commenting is allowed for GITHUB_TOKEN (unlike PR creation). Each
+          # tracker gets the same snapshot; fail-soft per issue so one closed/
+          # locked tracker doesn't abort the rest.
+          for issue in 886 855 888 857; do
+            if gh issue comment "$issue" --body-file /tmp/funnel-summary.md; then
+              echo "✅ commented on #$issue"
+            else
+              echo "::warning::could not comment on #$issue (closed/locked?) — continuing"
+            fi
+          done
+
+      - name: Cleanup credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/data/funnel-metrics-history.json
+++ b/data/funnel-metrics-history.json
@@ -1,0 +1,4 @@
+{
+  "updatedAt": null,
+  "entries": []
+}

--- a/scripts/funnel-metrics-snapshot.mjs
+++ b/scripts/funnel-metrics-snapshot.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * funnel-metrics-snapshot.mjs — turn a revenue-monitor JSON payload into a
+ * compact, append-only funnel-metrics snapshot + a markdown summary for the
+ * RPM/CLS tracker issues (#886, #855, #888, #857).
+ *
+ * It does NOT fetch anything itself: it consumes the JSON already produced by
+ * `scripts/revenue-monitor.mjs --json` (which is fail-soft and aggregates
+ * AdSense RPM, GSC avg position + CTR-by-bucket, and PostHog CLS p75
+ * mobile/desktop). This keeps a single source of truth for the field data and
+ * zero duplicated API logic — and zero Claude usage.
+ *
+ * Pipeline (see .github/workflows/funnel-metrics-snapshot.yml):
+ *   node scripts/revenue-monitor.mjs --json > /tmp/revenue.json
+ *   node scripts/funnel-metrics-snapshot.mjs \
+ *     --in=/tmp/revenue.json \
+ *     --history=data/funnel-metrics-history.json \
+ *     --summary-out=/tmp/funnel-summary.md
+ *
+ * Behaviour:
+ *   - Reads the revenue JSON, extracts only the funnel-relevant fields.
+ *   - Appends one dated entry to the history file (capped to MAX_ENTRIES so the
+ *     accumulator stays small — this is a metrics log, not the fat job data).
+ *   - Writes a markdown summary (current snapshot + tracker-relevant deltas).
+ *   - Always exits 0 unless the input is unreadable: a partial snapshot (e.g.
+ *     PostHog down but GSC/AdSense fine) is still committed and surfaced.
+ *
+ * Flags:
+ *   --in=<path>           revenue-monitor --json output (required)
+ *   --history=<path>      history JSON to append to (required)
+ *   --summary-out=<path>  markdown summary destination (optional)
+ *   --max-entries=<n>     history cap (default 104 ≈ 2y weekly)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const args = process.argv.slice(2);
+function flag(name, fallback = null) {
+  const a = args.find((x) => x.startsWith(`--${name}=`));
+  return a ? a.slice(name.length + 3) : fallback;
+}
+
+const IN = flag('in');
+const HISTORY = flag('history');
+const SUMMARY_OUT = flag('summary-out');
+const MAX_ENTRIES = parseInt(flag('max-entries', '104'), 10) || 104;
+
+if (!IN || !HISTORY) {
+  console.error('funnel-metrics-snapshot: --in and --history are required');
+  process.exit(2);
+}
+if (!existsSync(IN)) {
+  console.error(`funnel-metrics-snapshot: input not found: ${IN}`);
+  process.exit(2);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(IN, 'utf8'));
+} catch (e) {
+  console.error(`funnel-metrics-snapshot: cannot parse ${IN}: ${e.message}`);
+  process.exit(2);
+}
+
+const cur = payload.current || {};
+const adsense = cur.adsense || null;
+const gsc = cur.gsc || null;
+const posthog = cur.posthog || null;
+const errors = Array.isArray(cur.errors) ? cur.errors : [];
+const warnings = Array.isArray(cur.warnings) ? cur.warnings : [];
+
+// Compact snapshot: only the fields the trackers care about.
+const snapshot = {
+  date: new Date().toISOString().slice(0, 10),
+  generatedAt: payload.generatedAt || new Date().toISOString(),
+  // CLS field data (#886, #855)
+  cls: posthog
+    ? {
+        p75Mobile: posthog.clsP75Mobile ?? null,
+        p75Desktop: posthog.clsP75Desktop ?? null,
+        window: posthog.window ?? null,
+      }
+    : null,
+  // GSC ranking + CTR (#888)
+  gsc: gsc
+    ? {
+        avgPosition: gsc.avgPosition ?? null,
+        clicksPerDay: gsc.clicksPerDay ?? null,
+        ctrByBucket: gsc.ctrByBucket ?? null,
+      }
+    : null,
+  // AdSense RPM (#857 content-mix dilution; per-platform is the granularity
+  // AdSense exposes here — true per-category RPM is not available via the API).
+  adsense: adsense
+    ? {
+        rpmCHF: adsense.rpmCHF ?? null,
+        desktopRpmCHF: adsense.desktopRpmCHF ?? null,
+        revenuePerDayCHF: adsense.revenuePerDayCHF ?? null,
+      }
+    : null,
+  sourcesOk: {
+    cls: !!posthog,
+    gsc: !!gsc,
+    adsense: !!adsense,
+  },
+  errors,
+  warnings,
+};
+
+// Append to history (capped, deduped by date — last write wins).
+let history = { updatedAt: null, entries: [] };
+if (existsSync(HISTORY)) {
+  try {
+    const parsed = JSON.parse(readFileSync(HISTORY, 'utf8'));
+    if (parsed && Array.isArray(parsed.entries)) history = parsed;
+  } catch (e) {
+    console.error(`funnel-metrics-snapshot: history unreadable, starting fresh: ${e.message}`);
+  }
+}
+history.entries = history.entries.filter((e) => e.date !== snapshot.date);
+history.entries.push(snapshot);
+history.entries.sort((a, b) => (a.date < b.date ? -1 : 1));
+if (history.entries.length > MAX_ENTRIES) {
+  history.entries = history.entries.slice(history.entries.length - MAX_ENTRIES);
+}
+history.updatedAt = new Date().toISOString();
+
+mkdirSync(dirname(HISTORY), { recursive: true });
+writeFileSync(HISTORY, JSON.stringify(history, null, 2) + '\n');
+console.error(`funnel-metrics-snapshot: appended ${snapshot.date} -> ${HISTORY} (${history.entries.length} entries)`);
+
+// Markdown summary for the tracker issue comments.
+function fmt(v, unit = '') {
+  if (v === null || v === undefined) return '—';
+  return `${v}${unit}`;
+}
+
+const prev = history.entries.length >= 2 ? history.entries[history.entries.length - 2] : null;
+function delta(curV, prevV, { higherIsBetter = true } = {}) {
+  if (curV == null || prevV == null) return '';
+  const d = curV - prevV;
+  if (Math.abs(d) < 1e-9) return ' (→)';
+  const better = higherIsBetter ? d > 0 : d < 0;
+  const sign = d > 0 ? '+' : '';
+  return ` (${better ? '🟢' : '🔴'} ${sign}${Number(d.toFixed(3))} vs ${prevV})`;
+}
+
+const lines = [];
+lines.push(`### 📊 Funnel metrics snapshot — ${snapshot.date}`);
+lines.push('');
+lines.push('_Field data auto-collected weekly by `funnel-metrics-snapshot.yml` (revenue-monitor → PostHog/GSC/AdSense). These trackers are now data-backed._');
+lines.push('');
+
+lines.push('**CLS p75 (PostHog `$web_vitals`, last 7d)** — #886, #855');
+if (snapshot.cls) {
+  const m = snapshot.cls.p75Mobile;
+  const d = snapshot.cls.p75Desktop;
+  lines.push(`- Mobile: \`${fmt(m)}\`${delta(m, prev?.cls?.p75Mobile, { higherIsBetter: false })}`);
+  lines.push(`- Desktop: \`${fmt(d)}\`${delta(d, prev?.cls?.p75Desktop, { higherIsBetter: false })}`);
+} else {
+  lines.push('- _unavailable this run (PostHog source skipped/errored — see notes)_');
+}
+lines.push('');
+
+lines.push('**GSC ranking & CTR (last 7d)** — #888');
+if (snapshot.gsc) {
+  lines.push(`- Avg position: \`${fmt(snapshot.gsc.avgPosition)}\`${delta(snapshot.gsc.avgPosition, prev?.gsc?.avgPosition, { higherIsBetter: false })}`);
+  lines.push(`- Clicks/day: \`${fmt(snapshot.gsc.clicksPerDay)}\``);
+  if (snapshot.gsc.ctrByBucket && Object.keys(snapshot.gsc.ctrByBucket).length) {
+    lines.push('- CTR by URL bucket (high-CPC = `/fisco/`, `/calcola-stipendio/`, `/guida-frontaliere/`):');
+    for (const [bucket, ctr] of Object.entries(snapshot.gsc.ctrByBucket)) {
+      const prevCtr = prev?.gsc?.ctrByBucket?.[bucket];
+      lines.push(`  - \`${bucket}\`: ${fmt(ctr, '%')}${delta(ctr, prevCtr, { higherIsBetter: true })}`);
+    }
+  }
+} else {
+  lines.push('- _unavailable this run (GSC source skipped/errored — see notes)_');
+}
+lines.push('');
+
+lines.push('**AdSense RPM (last 7d)** — #857');
+if (snapshot.adsense) {
+  lines.push(`- RPM (CHF): \`${fmt(snapshot.adsense.rpmCHF)}\`${delta(snapshot.adsense.rpmCHF, prev?.adsense?.rpmCHF, { higherIsBetter: true })}`);
+  lines.push(`- Desktop RPM (CHF): \`${fmt(snapshot.adsense.desktopRpmCHF)}\`${delta(snapshot.adsense.desktopRpmCHF, prev?.adsense?.desktopRpmCHF, { higherIsBetter: true })}`);
+  lines.push(`- Revenue/day (CHF): \`${fmt(snapshot.adsense.revenuePerDayCHF)}\``);
+  lines.push('- _Note: AdSense exposes RPM per platform (mobile/desktop), not per content category. For content-mix dilution use CTR-by-bucket above as the category proxy._');
+} else {
+  lines.push('- _unavailable this run (AdSense source skipped/errored — see notes)_');
+}
+lines.push('');
+
+if (errors.length || warnings.length) {
+  lines.push('**Source notes**');
+  for (const w of warnings) lines.push(`- ⚪ ${w}`);
+  for (const e of errors) lines.push(`- ⚠️ ${e}`);
+  lines.push('');
+}
+
+lines.push(`Full history: [\`data/funnel-metrics-history.json\`](../blob/main/data/funnel-metrics-history.json) (${history.entries.length} snapshots).`);
+
+const summary = lines.join('\n') + '\n';
+if (SUMMARY_OUT) {
+  writeFileSync(SUMMARY_OUT, summary);
+  console.error(`funnel-metrics-snapshot: summary -> ${SUMMARY_OUT}`);
+} else {
+  process.stdout.write(summary);
+}


### PR DESCRIPTION
## Implementato

Una funzionalità CI schedulata che raccoglie le metriche di funnel di cui hanno bisogno le tracker issue aperte su RPM/CLS, così smettono di essere "bloccate su dati non disponibili".

**Nuovo workflow `.github/workflows/funnel-metrics-snapshot.yml`** (cron settimanale lun 07:00 UTC, dopo Revenue Monitor, + `workflow_dispatch`):
- Carica le credenziali con il path già collaudato (`FIREBASE_SERVICE_ACCOUNT_JSON` → `/tmp/firebase-sa.json` → `node scripts/load-rc-env.mjs`), identico a `revenue-monitor.yml` / `sync-gsc-orphans.yml`.
- **Riusa** `scripts/revenue-monitor.mjs --json` (già fail-soft, già aggrega tutte le metriche servite) — nessuna logica API duplicata.
- Distilla uno **snapshot compatto append-only** in `data/funnel-metrics-history.json` (cap 104 entry ≈ 2 anni weekly, dedup per data).
- Posta un **commento riepilogo** su ciascuna tracker (#886, #855, #888, #857) via `gh issue comment` con `GITHUB_TOKEN` (commenting consentito al `GITHUB_TOKEN`).
- **ZERO Claude** (puro node/bash) → non tocca la quota Max.
- **Fail-soft**: se una sorgente (PostHog/GSC/AdSense) erra, le altre vengono comunque snapshot-ate, committate e pubblicate; il commento elenca le sorgenti mancanti.

**Nuovo `scripts/funnel-metrics-snapshot.mjs`**: consuma il JSON del revenue-monitor, estrae solo i campi rilevanti per le tracker (CLS p75 mobile/desktop; GSC avg position + clicks/day + CTR per bucket URL; AdSense RPM + desktop RPM + revenue/day), appende alla history e rende il markdown con delta direction-aware (posizione giù = verde, RPM su = verde, CTR su = verde) verso lo snapshot precedente.

**Nuovo `data/funnel-metrics-history.json`**: seed vuoto (`{ "updatedAt": null, "entries": [] }`).

Cosa raccoglie e dove emerge, per tracker:
- **#886 / #855** — CLS p75 mobile/desktop da PostHog `$web_vitals`.
- **#888** — GSC avg position + CTR per bucket URL (proxy high-CPC: `/fisco/`, `/calcola-stipendio/`, `/guida-frontaliere/`).
- **#857** — AdSense RPM (mobile/desktop) come proxy della content-mix dilution.

Reference (non chiude — restano tracker, ora data-backed): #886, #855, #888, #857.

Test:
- [x] `node --check` sullo script: OK.
- [x] Dry-run locale con payload mock revenue-monitor: append history, dedup-by-date, delta colorati, fail-soft con PostHog down (GSC+AdSense comunque emessi). Verificato output markdown.
- [x] YAML del workflow valido (10 step).
- [x] `gitnexus detect_changes`: 0 simboli/processi affetti (file net-new, nessun edit a codice esistente).
- [ ] Run live `workflow_dispatch` post-merge per validare creds reali + commento sulle tracker (da fare su `main`).

## Non implementato (ancora)

- **Chrome DevTools trace per #886** (pin reflow hydration): chrome-devtools MCP non configurato in CI → out of scope, deferito (richiesto esplicitamente di saltare la parte trace).
- **RPM vero per categoria di contenuto** (#857): l'API AdSense espone RPM per piattaforma (mobile/desktop), non per categoria di contenuto. Surfato il RPM per piattaforma + CTR per bucket URL come proxy di categoria; lo split RPM per-categoria reale resta non disponibile dalla sorgente → follow-up se servirà attribuzione più fine (es. via ad-unit naming per sezione).
- **Validazione live**: il workflow gira solo post-merge (`gh workflow run funnel-metrics-snapshot.yml --ref main`); non eseguito qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)