### PR TITLE
fix(email-cascade): mitigate Mailtrap 403 burst on provider exhaustion

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -22,7 +22,7 @@
  *   MAILGUN_API_KEY          — Mailgun API key (EU region)
  *   MAILGUN_DOMAIN           — Mailgun sending domain
  *   UNOSEND_API_KEY          — Unosend API key (6000/mo free tier)
- *   MAILTRAP_API_TOKEN       — Mailtrap API token (1000/mo free tier)
+ *   MAILTRAP_API_TOKEN       — Mailtrap API token (4000/mo, 150/day free tier)
  *   MAILEROO_API_KEY         — Maileroo sending key (3000/mo free tier)
  *   RESEND_API_KEY           — Resend API key (fallback only)
  */
@@ -466,6 +466,20 @@ const SEND_FNS = {
  * @param {string} [forceProvider] - If set, only use this specific provider
  * @returns {{ messageId: string, provider: string }}
  */
+/**
+ * Detect a hard rate-limit / quota-reached signal in a provider error message.
+ * Covers HTTP 429 and 403 burst/quota throttles (e.g. Mailtrap free Send API
+ * returns `403 {"errors":["Your account has reached ..."]}` when hammered).
+ * When matched, the provider is marked exhausted for the rest of the run so the
+ * cascade stops re-trying it (the root cause of the 258-in-5s 403 burst).
+ */
+function isRateLimitedError(msg) {
+  if (!msg) return false;
+  if (msg.includes('429')) return true;
+  if (msg.includes('403') && /reached|rate.?limit|too many|quota|limit of/i.test(msg)) return true;
+  return false;
+}
+
 async function sendSingle(email, forceProvider) {
   const errors = [];
   const providers = forceProvider
@@ -482,9 +496,9 @@ async function sendSingle(email, forceProvider) {
       return result;
     } catch (err) {
       errors.push(`[${provider.id}] ${err.message}`);
-      if (err.message.includes('429')) {
+      if (isRateLimitedError(err.message)) {
         incrementCounter(provider.id, remainingQuota(provider.id));
-        console.warn(`⚠️  ${provider.id} rate-limited — skipping for today`);
+        console.warn(`⚠️  ${provider.id} rate-limited/exhausted — skipping for rest of run`);
       }
     }
   }
@@ -512,9 +526,18 @@ async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs) {
     }
   }
 
-  const result = await sendSingle(email, forceProvider);
-  // Track the timestamp of the provider that actually sent
-  if (result?.provider) {
+  let result;
+  try {
+    result = await sendSingle(email, forceProvider);
+  } finally {
+    // Advance the throttle clock for the attempted provider even when the send
+    // FAILS. Otherwise a run of consecutive failures fires as an unthrottled
+    // burst (the timestamp was previously set only on success), which is exactly
+    // what produced 258 Mailtrap 403s in 5 seconds.
+    if (nextProvider) lastSendMap[nextProvider.id] = Date.now();
+  }
+  // If a different provider ended up sending, track its timestamp too.
+  if (result?.provider && result.provider !== nextProvider?.id) {
     lastSendMap[result.provider] = Date.now();
   }
   return result;
@@ -641,4 +664,4 @@ export function getCascadeDailyCapacity() {
   return PROVIDERS.reduce((sum, p) => sum + p.dailyLimit, 0);
 }
 
-export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs };
+export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs, isRateLimitedError };

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import {
+  isRateLimitedError,
+  sendEmailCascade,
+  PROVIDERS,
+} from '../scripts/lib/email-cascade.mjs';
+
+/* ------------------------------------------------------------------ */
+/*  isRateLimitedError — burst/quota signal detection                 */
+/* ------------------------------------------------------------------ */
+
+describe('isRateLimitedError', () => {
+  it('matches the real Mailtrap 403 burst body', () => {
+    const msg = 'Mailtrap 403: {"success":false,"errors":["Your account has reached the limit"]}';
+    expect(isRateLimitedError(msg)).toBe(true);
+  });
+
+  it('matches HTTP 429', () => {
+    expect(isRateLimitedError('Mistral 429: rate limited')).toBe(true);
+  });
+
+  it('matches 403 with rate/quota keywords', () => {
+    expect(isRateLimitedError('Provider 403: rate limit exceeded')).toBe(true);
+    expect(isRateLimitedError('Provider 403: monthly quota exhausted')).toBe(true);
+  });
+
+  it('does NOT match a generic 403 (e.g. bad domain / auth)', () => {
+    expect(isRateLimitedError('Mailtrap 403: {"errors":["Forbidden: domain not verified"]}')).toBe(false);
+  });
+
+  it('does NOT match unrelated errors', () => {
+    expect(isRateLimitedError('Mailgun 500: internal error')).toBe(false);
+    expect(isRateLimitedError('')).toBe(false);
+    expect(isRateLimitedError(undefined)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Burst mitigation — a 403 "reached" stops re-hitting the provider  */
+/* ------------------------------------------------------------------ */
+
+describe('sendEmailCascade burst mitigation', () => {
+  const realFetch = globalThis.fetch;
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+    process.env.MAILTRAP_API_TOKEN = 'test-token';
+    // Mock every network call. Mailtrap stats/accounts → benign; send → 403 reached.
+    globalThis.fetch = (async (url: string, opts?: any) => {
+      calls.push(String(url));
+      if (String(url).includes('send.api.mailtrap.io')) {
+        return {
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          text: async () => '{"success":false,"errors":["Your account has reached the limit"]}',
+          json: async () => ({ success: false }),
+        } as any;
+      }
+      // accounts / stats lookups during syncQuotasFromAPIs
+      if (String(url).includes('/api/accounts')) {
+        return { ok: true, status: 200, json: async () => [{ id: 1 }], text: async () => '[]' } as any;
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' } as any;
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.MAILTRAP_API_TOKEN;
+  });
+
+  it('hits the Mailtrap send endpoint only once for a 50-email batch', async () => {
+    const emails = Array.from({ length: 50 }, (_, i) => ({
+      payload: { from: 'a@b.ch', to: ['x@y.com'], subject: 's', html: '<p>h</p>' },
+      recipient: { email: `r${i}@y.com` },
+      meta: {},
+    }));
+
+    const { sent, failed } = await sendEmailCascade(emails, {
+      forceProvider: 'mailtrap',
+      delayMs: 0,
+    });
+
+    const sendCalls = calls.filter(u => u.includes('send.api.mailtrap.io')).length;
+    // Before the fix: 50 burst calls. After: provider marked exhausted on the
+    // first 403 → remainingQuota 0 → every subsequent email is skipped locally.
+    expect(sendCalls).toBe(1);
+    expect(sent.length).toBe(0);
+    expect(failed.length).toBe(50);
+  });
+});


### PR DESCRIPTION
## Implementato

Mitiga il burst che ha generato 258 fallimenti Mailtrap in 5 secondi (CI run [26812009889](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26812009889)), ognuno `403 {"errors":["Your account has reached ..."]}`.

**Diagnosi (verificata live):** NON era esaurimento quota. Billing API Mailtrap in tempo reale: `sending 795/4000` mensile, `~1/150` daily, `testing 0/50`. Invio singolo e burst da 30 concorrenti a una mia email → tutti `200 OK`. Root cause = il cascade che martella il provider:

1. **Throttle anche sui fail.** `sendSingleThrottled` avanzava il clock di throttle per-provider **solo sul successo** → una serie di fallimenti partiva senza throttle. Ora il clock avanza in un `finally` anche per il provider tentato che fallisce.
2. **403 "reached"/rate → provider esausto per il run.** `sendSingle` marcava il provider esausto solo su HTTP 429. Il free Send API di Mailtrap risponde 403 "reached" sul burst-throttle → il cascade continuava a ritentarlo. Nuovo helper `isRateLimitedError` matcha anche 403 + keyword rate/quota (`reached|rate limit|too many|quota|limit of`) → provider saltato per il resto del run.

**Effetto netto:** il primo 403 marca Mailtrap esausto → le email rimanenti lo saltano localmente (0 ulteriori chiamate API) invece di bustare. Il generico 403 (es. dominio non verificato/auth) NON viene scambiato per rate-limit.

- Nuovo test `tests/email-cascade-burst.test.ts`: 6 casi. Asserisce **1 sola chiamata** al send endpoint per un batch di 50 email (prima: 50). Copre detection 403/429 + esclusione 403 generico.
- Fix commento stale: Mailtrap free = 4000/mo, 150/day (era "1000/mo").
- Test correlati verdi: `email-cascade-burst` (6) + `job-alert-email` (66) + `email-validation` (24) + `newsletter-engagement-ratelimit` (10) = 100 pass.

Impatto GitNexus: LOW (helper interni, nessun cambio di firma; chiamanti `worker → sendEmailCascade → send-newsletter/send-job-alerts`).

## Non implementato (ancora)

- **Tracking daily Mailtrap inaffidabile** (follow-up): `fetchMailtrapDailyUsage` legge `stats?start_date=today` che lagga pesantemente (ha riportato `delivery_count:1` dopo 31 invii reali) → il counter daily sottostima e contribuisce all'over-send. Fuori scope: questa PR ferma il burst a valle (skip-on-403); il fix del counting a monte richiede una fonte usage più affidabile (es. billing endpoint) ed è un cambiamento separato.
- **Backoff/retry cross-run** dei 403: non aggiunto cooldown persistente tra run (il fix è per-run). Posposto: il throttle per-run + skip-on-rate-limit copre il sintomo osservato; un cooldown persistente è ottimizzazione separata.