### PR TITLE
fix(email-cascade): require limit/quota context for 403 rate-limit match

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -469,14 +469,22 @@ const SEND_FNS = {
 /**
  * Detect a hard rate-limit / quota-reached signal in a provider error message.
  * Covers HTTP 429 and 403 burst/quota throttles (e.g. Mailtrap free Send API
- * returns `403 {"errors":["Your account has reached ..."]}` when hammered).
+ * returns `403 {"errors":["Your account has reached the limit"]}` when hammered).
  * When matched, the provider is marked exhausted for the rest of the run so the
  * cascade stops re-trying it (the root cause of the 258-in-5s 403 burst).
+ *
+ * The "reached" branch requires limit/quota context — bare "reached" is too
+ * broad (e.g. a generic 403 carrying "host could not be reached") and would
+ * wrongly retire a healthy provider; in forced-provider mode that fails the
+ * whole run.
  */
 function isRateLimitedError(msg) {
   if (!msg) return false;
   if (msg.includes('429')) return true;
-  if (msg.includes('403') && /reached|rate.?limit|too many|quota|limit of/i.test(msg)) return true;
+  if (msg.includes('403') &&
+      /reached[^"]{0,40}(limit|quota|cap|messages)|rate.?limit|too many|quota|limit of/i.test(msg)) {
+    return true;
+  }
   return false;
 }
 

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -28,6 +28,11 @@ describe('isRateLimitedError', () => {
     expect(isRateLimitedError('Mailtrap 403: {"errors":["Forbidden: domain not verified"]}')).toBe(false);
   });
 
+  it('does NOT match a 403 with bare "reached" lacking limit/quota context', () => {
+    // e.g. a network-style 403 body — must not retire a healthy provider.
+    expect(isRateLimitedError('Mailgun 403: {"errors":["upstream host could not be reached"]}')).toBe(false);
+  });
+
   it('does NOT match unrelated errors', () => {
     expect(isRateLimitedError('Mailgun 500: internal error')).toBe(false);
     expect(isRateLimitedError('')).toBe(false);


### PR DESCRIPTION
## Implementato

Hardening del ❓ sollevato dal reviewer su #1181 (mitigazione burst Mailtrap 403).

Il branch "reached" di `isRateLimitedError` matchava `reached` da solo → un 403 generico che porta es. `"host could not be reached"` (proxy/host non raggiunto) verrebbe classificato come rate-limit e il provider sano ritirato per il resto del run. Impatto:
- **cascade default** (`EMAIL_PROVIDER=cascade`): innocuo, cade sul provider successivo (nessuna perdita di delivery).
- **forced-provider mode** (`EMAIL_PROVIDER=mailtrap|mailgun|...`): farebbe fallire l'intero run.

Fix: `reached` ora deve co-occorrere con contesto limit/quota entro 40 char — `reached[^"]{0,40}(limit|quota|cap|messages)`. I rami `429`, `rate.?limit`, `too many`, `quota`, `limit of` invariati. Il body reale di Mailtrap (`"Your account has reached the limit"`) continua a matchare.

- Test `tests/email-cascade-burst.test.ts`: +1 caso (403 con `"host could not be reached"` → `false`); 7 totali, tutti verdi.
- `node --check` OK. Impatto GitNexus: LOW (helper interno puro, nessun cambio firma).

## Non implementato (ancora)

- **`fetchMailtrapDailyUsage` counter inaffidabile** — tracciato in issue follow-up #1184 (`agent:fix`, gestita dalla pipeline autonoma). Fuori scope qui: questa PR riguarda solo la robustezza del match 403, non la fonte usage a monte.