### PR TITLE
ci(pipeline): R3-A deterministic one-item bound + R3-B recycle stale PRs

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -69,6 +69,21 @@ jobs:
             echo "max_turns=30" >> "$GITHUB_OUTPUT"
           fi
           echo "Fix tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
+          # Aggregate detection (deterministic, da titolo "N item deferred", N>=2).
+          # Il parsing dei singoli item dal body è freeform/fragile → ci basiamo
+          # sul COUNT nel titolo (affidabile) per attivare il circuit-breaker
+          # one-item nel prompt (R3-A): il prompt-only R2-A non sempre teneva
+          # (#1172 error_max_turns post-merge). is_aggregate guida l'istruzione
+          # forte "fixa 1 item poi STOP".
+          N=$(printf '%s' "$body" | grep -oiE '[0-9]+ item deferred' | head -1 | grep -oE '^[0-9]+' || true)
+          if [ "${N:-0}" -ge 2 ] 2>/dev/null; then
+            echo "is_aggregate=true" >> "$GITHUB_OUTPUT"
+            echo "agg_count=${N}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_aggregate=false" >> "$GITHUB_OUTPUT"
+            echo "agg_count=0" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Aggregate: is_aggregate=$(grep is_aggregate= "$GITHUB_OUTPUT" | tail -1)"
 
       - name: Configure git identity
         run: |
@@ -107,7 +122,7 @@ jobs:
             - Se la issue è categoria `revenue` o `tracker` (strategica) → posta "Richiede giudizio umano, non auto-fixabile. Rimuovere `agent:fix`." e TERMINA.
             - **Capability guard (valuta SUBITO, prima di implementare — risparmio token):** questo ambiente ha solo `GH_TOKEN` (GitHub App) che NON ha lo scope `workflows` e NON ha PAT/Firebase SA. Dai path target estratti dal body: se il fix richiederebbe di modificare file in `.github/workflows/**` → il `git push` fallirebbe sempre (push di workflow rifiutato senza scope `workflows`) → niente PR. Allora NON implementare: posta un commento col diff/azione proposta + "blocco scope `workflows`: serve PAT abilitato o mano umana" e TERMINA SUBITO. Lo stesso vale se il fix è puramente una repo-setting/branch-protection/admin-API (es. `gh api .../branches/main/protection` → 403) o richiede segreti non in CI: documenta e TERMINA senza implementare. Razionale: fare il fix completo per poi scoprire il blocco al push spreca ~1M token/run (vedi #983); il blocco è deterministico dallo scope, va rilevato a turno 1.
 
-            - **Follow-up aggregata multi-item (valuta SUBITO — anti `error_max_turns`):** se la issue è un follow-up con N item (titolo "N item deferred" / lista di item distinti), NON tentare di fixarli tutti in un run: 3 issue/giorno osservate il 2026-06-02 sforavano il turn budget → `error_max_turns` → 0 PR, ~2M token persi. Invece: (a) applica il capability guard **PER-ITEM** (scarta gli item che toccano `.github/workflows/**` o admin/secret — NON abortire l'intera issue come faresti per una issue singola; gli item fixabili restano), (b) scegli il SINGOLO item in-capability a massimo valore funnel, fixalo, (c) apri PR con `Closes #$ISSUE_NUMBER` ed elenca gli item rimanenti in `## Non implementato` con motivo `follow-up` o `blocked` — `post-merge-followup` li ri-accoda automaticamente come nuova follow-up (re-queue esistente, nessun loop: ogni ciclo chiude ≥1 item → converge). Una issue NON-aggregata = comportamento invariato (capability guard whole-issue come sopra).
+            - **Follow-up aggregata multi-item — is_aggregate=${{ steps.tier.outputs.is_aggregate }} (count=${{ steps.tier.outputs.agg_count }}):** se `is_aggregate=true` questa issue ha ${{ steps.tier.outputs.agg_count }} item distinti e tentarli TUTTI in un run sfora il turn budget → `error_max_turns` → 0 PR, ~2M token persi (osservato #1095/#1101/#1172). **REGOLA FERREA (circuit-breaker):** fixa **ESATTAMENTE UN item** poi FERMATI. Procedura: (a) capability guard **PER-ITEM** — salta gli item che toccano `.github/workflows/**`/admin/secret (NON abortire l'intera issue), (b) scegli il PRIMO item in-capability a massimo valore funnel, (c) implementa SOLO quello, (d) **appena la PR per quell'unico item è aperta → STOP IMMEDIATO, non iniziare un secondo item** (anche se hai turni residui), (e) elenca tutti gli altri item in `## Non implementato` (motivo `follow-up`/`blocked`) → `post-merge-followup` li ri-accoda come nuova follow-up (re-queue esistente; ogni ciclo chiude ≥1 item → converge). Se `is_aggregate=false`: issue singola, comportamento invariato (capability guard whole-issue come sopra). Razionale: il budget di turni basta per 1 item con margine; 2+ item lo bruciano.
 
             **Fix flow (vedi ISSUES.md):**
             1. Branch isolato: `git checkout -b fix/issue-$ISSUE_NUMBER`.

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -1,0 +1,140 @@
+name: Recycle stale PRs (close + re-queue source issue)
+
+# R3-B: una PR flaggata `stale-review` da stale-pr-rescuer resta comunque ferma
+# se nessuno agisce (alert-only). Osservato 2026-06-02: #1073/#1075 ferme ~29h.
+# Far ripartire un branch vecchio contro un `main` che si è mosso di 100+ commit
+# è conflict-prone e di basso valore. Meglio RICICLARE: chiudere la PR
+# profondamente stale e ri-accodare la issue sorgente con `agent:fix` → fix
+# fresco contro il `main` corrente (issue-fix apre un branch nuovo).
+#
+# Conservativo: agisce SOLO su PR `stale-review` aperte >24h E senza commit nuovi
+# da >24h E con issue sorgente ancora OPEN. Daily (non urgente). dry_run per test.
+# Separato da stale-pr-rescuer (che fira a ogni review completion) per non
+# pagare npm ci + PAT ad ogni evento.
+
+on:
+  schedule:
+    - cron: '40 6 * * *'  # daily 06:40 UTC (cleanup non urgente)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Solo log, niente close/re-queue'
+        type: boolean
+        default: true
+      max_age_hours:
+        description: 'Soglia "deeply stale" in ore (default 24)'
+        type: string
+        default: '24'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: recycle-stale-prs
+  cancel-in-progress: false
+
+jobs:
+  recycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna Firebase SA — GITHUB_PAT non caricato; il re-queue (agent:fix) verrà SALTATO (serve PAT per triggerare issue-fix). La PR verrà comunque chiusa."
+          fi
+
+      - name: Load secrets from Remote Config (GITHUB_PAT)
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Recycle deeply-stale stale-review PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT: ${{ env.GITHUB_PAT }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '24' }}
+        run: |
+          set -uo pipefail
+          # Default dry_run=true per lo schedule (input vuoto su cron) → primo giro
+          # safe; passa a false esplicito via dispatch quando validato.
+          DRY="${DRY_RUN:-true}"
+          NOW=$(date -u +%s)
+          MAXAGE=$(( ${MAX_AGE_HOURS:-24} * 3600 ))
+
+          prs=$(gh pr list --repo "$REPO" --state open --label stale-review --limit 50 \
+            --json number,title,body,createdAt,author)
+          COUNT=$(printf '%s' "$prs" | jq 'length')
+          echo "stale-review PRs aperte: $COUNT"
+
+          printf '%s' "$prs" | jq -c '.[]' | while read -r pr; do
+            N=$(printf '%s' "$pr" | jq -r '.number')
+            TITLE=$(printf '%s' "$pr" | jq -r '.title')
+            BODY=$(printf '%s' "$pr" | jq -r '.body // ""')
+            CREATED=$(printf '%s' "$pr" | jq -r '.createdAt')
+
+            # Gate 1: PR aperta da >MAXAGE.
+            CS=$(date -u -d "$CREATED" +%s 2>/dev/null || echo "$NOW")
+            if [ $((NOW - CS)) -lt "$MAXAGE" ]; then echo "PR #$N non abbastanza vecchia — skip"; continue; fi
+
+            # Gate 2: nessun commit nuovo da >MAXAGE (lavoro davvero abbandonato).
+            LASTCOMMIT=$(gh pr view "$N" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // empty' 2>/dev/null || true)
+            if [ -n "$LASTCOMMIT" ]; then
+              LCS=$(date -u -d "$LASTCOMMIT" +%s 2>/dev/null || echo 0)
+              if [ $((NOW - LCS)) -lt "$MAXAGE" ]; then echo "PR #$N ha commit recenti — skip (lavoro attivo)"; continue; fi
+            fi
+
+            # Source issue: "(#N)" nel titolo o "Closes #N" nel body.
+            ISSUE=$(printf '%s' "$TITLE" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)
+            if [ -z "${ISSUE:-}" ]; then
+              ISSUE=$(printf '%s' "$BODY" | grep -oiE 'closes #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+            fi
+            if [ -z "${ISSUE:-}" ]; then echo "PR #$N nessuna issue sorgente identificabile — skip (no recycle cieco)"; continue; fi
+
+            # La issue sorgente deve essere OPEN (altrimenti non c'è cosa ri-accodare).
+            IST=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            if [ "$IST" != "OPEN" ]; then echo "PR #$N → issue #$ISSUE stato=$IST (non OPEN) — skip"; continue; fi
+
+            echo "::notice::PR #$N RICICLABILE → chiudi + re-queue issue #$ISSUE"
+            if [ "$DRY" = "true" ]; then echo "(dry-run) skip azione PR #$N"; continue; fi
+
+            gh pr close "$N" --repo "$REPO" --comment "$(printf '♻️ **recycle** (auto): PR ferma >%sh come \x60stale-review\x60 con branch indietro su un main mosso di molti commit. Chiusa e issue sorgente #%s ri-accodata per un fix fresco contro main corrente (issue-fix aprirà un branch nuovo). Il lavoro non è perso: la issue resta aperta.' "${MAX_AGE_HOURS:-24}" "$ISSUE")" \
+              2>/dev/null || echo "close fallito PR #$N"
+
+            # Re-queue: serve PAT (un agent:fix via GITHUB_TOKEN NON triggera
+            # issue-fix — anti-ricorsione; sender github-actions[bot] non passa il
+            # gate). Con PAT il sender è valerielinc-ops → trigger valido.
+            if [ -n "${PAT:-}" ]; then
+              GH_TOKEN="$PAT" gh issue edit "$ISSUE" --repo "$REPO" --remove-label agent:fix 2>/dev/null || true
+              sleep 2
+              GH_TOKEN="$PAT" gh issue edit "$ISSUE" --repo "$REPO" --add-label agent:fix 2>/dev/null \
+                && echo "issue #$ISSUE ri-accodata (agent:fix via PAT)" \
+                || echo "re-label fallito issue #$ISSUE"
+            else
+              echo "⚠️ PAT assente — issue #$ISSUE NON ri-accodata automaticamente. Ri-applicare agent:fix a mano."
+              gh issue comment "$ISSUE" --repo "$REPO" --body "♻️ PR sorgente chiusa come stale. Ri-applicare \`agent:fix\` (serve PAT) per un fix fresco." 2>/dev/null || true
+            fi
+          done
+          echo "Recycle scan completo."

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -27,7 +27,7 @@ on:
         default: '24'
 
 permissions:
-  contents: read
+  contents: write   # serve per --delete-branch sul gh pr close (vedi sotto)
   pull-requests: write
   issues: write
 
@@ -120,7 +120,13 @@ jobs:
             echo "::notice::PR #$N RICICLABILE → chiudi + re-queue issue #$ISSUE"
             if [ "$DRY" = "true" ]; then echo "(dry-run) skip azione PR #$N"; continue; fi
 
-            gh pr close "$N" --repo "$REPO" --comment "$(printf '♻️ **recycle** (auto): PR ferma >%sh come \x60stale-review\x60 con branch indietro su un main mosso di molti commit. Chiusa e issue sorgente #%s ri-accodata per un fix fresco contro main corrente (issue-fix aprirà un branch nuovo). Il lavoro non è perso: la issue resta aperta.' "${MAX_AGE_HOURS:-24}" "$ISSUE")" \
+            # --delete-branch OBBLIGATORIO: issue-fix ricrea il branch con nome
+            # DETERMINISTICO `fix/issue-N` e pusha con `git push -u` (no force). Se
+            # il branch remoto della PR chiusa sopravvive, la storia diverge
+            # (vecchio commit su main vecchio) → push non-fast-forward → rifiutato
+            # → 0 PR → R3-B no-opa sul path che deve fixare. Cancellare il ref
+            # libera il nome per il push fresco. (richiede permissions.contents:write)
+            gh pr close "$N" --repo "$REPO" --delete-branch --comment "$(printf '♻️ **recycle** (auto): PR ferma >%sh come \x60stale-review\x60 con branch indietro su un main mosso di molti commit. Chiusa (branch remoto cancellato) e issue sorgente #%s ri-accodata per un fix fresco contro main corrente (issue-fix aprirà un branch nuovo con lo stesso nome). Il lavoro non è perso: la issue resta aperta.' "${MAX_AGE_HOURS:-24}" "$ISSUE")" \
               2>/dev/null || echo "close fallito PR #$N"
 
             # Re-queue: serve PAT (un agent:fix via GITHUB_TOKEN NON triggera

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -74,12 +74,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PAT: ${{ env.GITHUB_PAT }}
           REPO: ${{ github.repository }}
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          # Posture: lo SCHEDULE agisce (false) — è l'intento autonomo; il
+          # DISPATCH manuale resta safe-by-default (input default true) per test.
+          # Senza questo, il cron passa dry_run vuoto → permanentemente dry-run →
+          # non riciclerebbe mai (reviewer nit). I gate conservativi (>24h + no
+          # commit + issue OPEN) tengono il blast radius minimo.
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.dry_run }}
           MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '24' }}
         run: |
           set -uo pipefail
-          # Default dry_run=true per lo schedule (input vuoto su cron) → primo giro
-          # safe; passa a false esplicito via dispatch quando validato.
           DRY="${DRY_RUN:-true}"
           NOW=$(date -u +%s)
           MAXAGE=$(( ${MAX_AGE_HOURS:-24} * 3600 ))


### PR DESCRIPTION
## Implementato

Round-3 dell'osservazione pipeline. Due refinement dei fix round-2.

**R3-A — bound deterministico one-item su follow-up aggregate** (`issue-fix.yml`)
- R2-A (prompt-only) ha ridotto `error_max_turns` 3→1 ma non l'ha eliminato: #1172 (2-item) ha ancora sforato il turn budget POST-merge → 0 PR, ~2M token persi. Il prompt "fixa 1 item" non è seguito in modo affidabile sotto pressione turni.
- Fix: detection **deterministica** `is_aggregate` nello step tier (parse `N item deferred` dal titolo, N≥2 — affidabile; il parsing dei singoli item dal body è freeform/fragile) + **circuit-breaker** nel prompt: fixa ESATTAMENTE 1 item poi STOP immediato (non iniziare un 2° anche con turni residui). Item residui ri-accodati da post-merge-followup. Parse testato (2/6 item→true, 1/no-count→false).

**R3-B — recycle PR stale** (`recycle-stale-prs.yml`, nuovo)
- Le PR flaggate `stale-review` da stale-pr-rescuer restano ferme se nessuno agisce (alert-only): #1073/#1075 ~29h. Far ripartire un branch a 29h contro un main mosso di 100+ commit = conflict-prone.
- Fix: job **daily** (dry_run default true) che chiude le PR `stale-review` aperte >24h E senza commit >24h E con issue sorgente ancora OPEN, poi ri-applica `agent:fix` sulla issue via **PAT** → fix fresco contro main corrente (issue-fix apre branch nuovo). Separato da stale-pr-rescuer per non pagare npm ci+PAT a ogni review-event. Parse issue sorgente testato (#1073→#1071, #1075→#1072). PAT assente → chiude PR + commenta, salta auto-requeue.

**Audit modelli (richiesto, read-only — nessun cambio):** tutti i workflow Claude usano ID current e tiering corretto: issue-fix/pr-review opus-4-8 (critico/funnel) · sonnet-4-6 (routine), post-merge-followup/lessons-harvester sonnet-4-6 fisso, issue-triage/gh-pat-expiry zero-Claude. Nessun ID stale. haiku-4-5 inutilizzato (possibile micro-frugalità su followup ma il filtro funnel-scope richiede giudizio → sonnet è la scelta sicura). **Verdetto: corretto.**

## Non implementato (ancora)
- **R3-C (token cache_read)**: osservativo — cache_read ~1.7M domina (context iniettato × turni); leve già shippate (#1096 tiering, #1098 compress). Nessuna nuova leva review-side senza rischio qualità. Nessuna azione.
- **R3-A parsing per-item**: bound è sul COUNT (titolo), non estrae il singolo item (body freeform). La selezione dell'item resta al giudizio dell'agent (guidato dal circuit-breaker). Estrazione deterministica del singolo item = follow-up se #1172-class ricorre.
- **R3-B cadenza**: daily cron; su questo account i cron a volte slittano (vedi R2-C) — accettabile per cleanup non urgente; dispatch manuale disponibile.

## Test plan
- [ ] Post-merge: `gh workflow run recycle-stale-prs.yml --ref main -f dry_run=true` → verifica logghi #1073/#1075 come riciclabili (issue #1071/#1072 OPEN) senza side-effect.
- [ ] Prossima follow-up aggregata (N≥2) → verifica is_aggregate=true nei log tier + issue-fix apre PR per 1 item (no error_max_turns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)