### PR TITLE
feat(evidence): ingest full GSC page-level impressions into traffic gate (Buco G)

### DIFF
--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -8,6 +8,10 @@
 //
 //   data/evidence-index.json
 //     - gsc.queries[query].topLandingPage  → URLs that own a search query
+//     - gsc.pages[path]                    → every URL Google showed ≥1 time
+//                                            (page dimension, ~52k paths) —
+//                                            the comprehensive page-level
+//                                            impression signal (Buco G)
 //     - ga4.pages[path].sessions           → URLs with ≥3 sessions in 90d
 //     - posthog.pages[path]                → either newsletterSignups OR
 //                                            pageviews (or both); key
@@ -30,7 +34,9 @@
 //     1. Find approved pattern matching urlClass.
 //        No pattern → 'full'.
 //     2. Check evidence:
-//        URL ∈ ga4.pages ∪ topLandingPages ∪ posthog.pages ∪ promotions.urls
+//        URL ∈ ga4.pages ∪ topLandingPages ∪ gsc.pages ∪ posthog.pages
+//             ∪ indexed-cluster ∪ gsc-job-urls ∪ orphan-slugs
+//             ∪ orphan-enriched ∪ promotions.urls
 //        → 'full' (URL has real traffic, keep current full HTML).
 //     3. URL ∉ evidence + pattern says action='thin' → 'thin'.
 //     4. (Future: action='skip' for tier 3.)
@@ -81,6 +87,15 @@ interface ApprovedConfig {
 interface EvidenceIndex {
   gsc?: {
     queries?: Record<string, { topLandingPage?: string }>;
+    /**
+     * Full page-level impression set: every URL Google showed ≥1 time in
+     * the window (page dimension), keyed by path → impression count.
+     * Populated by scripts/lib/evidence/gscFetcher.mjs Pass 3. Far broader
+     * than `queries[].topLandingPage` (which only surfaces ~one page per
+     * query); without it the long tail of impressed pages is invisible to
+     * the has-traffic gate and risks being thinned despite Google interest.
+     */
+    pages?: Record<string, number>;
   };
   ga4?: {
     pages?: Record<string, { sessions?: number }>;
@@ -148,7 +163,7 @@ export class TrafficEvidenceFilter {
 
     // Build a single normalized "has traffic" set from every signal source.
     const trafficSet = new Set<string>();
-    let evGa4 = 0, evPosthog = 0, evGscTop = 0, evIndexed = 0, evGscJobs = 0,
+    let evGa4 = 0, evPosthog = 0, evGscTop = 0, evGscPages = 0, evIndexed = 0, evGscJobs = 0,
         evOrphanSlugs = 0, evOrphanEnriched = 0, evPromo = 0;
     const addToSet = (raw: string | null | undefined, counter: () => void): void => {
       if (!raw) return;
@@ -164,6 +179,13 @@ export class TrafficEvidenceFilter {
       for (const q of Object.values(ev.gsc?.queries ?? {})) {
         if (q?.topLandingPage) addToSet(q.topLandingPage, () => evGscTop++);
       }
+      // Buco G: full GSC page-level impression set. The single largest
+      // traffic source — every URL Google showed ≥1 time (page dimension),
+      // ~52 k paths vs the ~9 k surfaced via `topLandingPage`. Closes the
+      // gap where long-tail impressed pages were invisible to the has-
+      // traffic gate and risked being thinned despite confirmed Google
+      // interest. Populated by gscFetcher Pass 3.
+      for (const p of Object.keys(ev.gsc?.pages ?? {})) addToSet(p, () => evGscPages++);
     }
     // PR #743 follow-up: `data/indexed-cluster-urls.json` is the merged
     // GSC + GA4 + PostHog union of cluster URLs Google has indexed in
@@ -260,7 +282,7 @@ export class TrafficEvidenceFilter {
         `[traffic-evidence-filter] traffic-set=${trafficSet.size} paths, ${patternCount} approved patterns, ` +
         `${firstSeen.size} first-seen timestamps ` +
         `(sources: ga4=${evGa4} posthog=${evPosthog} gsc-top=${evGscTop} ` +
-        `indexed-cluster=${evIndexed} gsc-jobs=${evGscJobs} ` +
+        `gsc-pages=${evGscPages} indexed-cluster=${evIndexed} gsc-jobs=${evGscJobs} ` +
         `orphan-slugs=${evOrphanSlugs} orphan-enriched=${evOrphanEnriched} ` +
         `promotions=${evPromo})`
       );

--- a/scripts/build-evidence-index.mjs
+++ b/scripts/build-evidence-index.mjs
@@ -91,7 +91,7 @@ async function main() {
     windowDays,
     gsc: gscResult.error
       ? {}
-      : { queries: gscResult.queries, orphanQueries: gscResult.orphanQueries },
+      : { queries: gscResult.queries, orphanQueries: gscResult.orphanQueries, pages: gscResult.pages || {} },
     ga4: ga4Result.error ? {} : { pages: ga4Result.pages },
     posthog: posthogResult.error ? {} : { pages: posthogResult.pages },
     clusterStats,
@@ -101,12 +101,13 @@ async function main() {
   atomicWriteJson(OUTPUT_PATH, index);
 
   const queryCount = Object.keys(gscResult.queries || {}).length;
+  const gscPageCount = Object.keys(gscResult.pages || {}).length;
   const ga4PageCount = Object.keys(ga4Result.pages || {}).length;
   const posthogPageCount = Object.keys(posthogResult.pages || {}).length;
   const clusterCount = Object.keys(clusterStats).length;
 
   console.error(
-    `EVIDENCE_BUILD_DONE queries=${queryCount} ga4Pages=${ga4PageCount} `
+    `EVIDENCE_BUILD_DONE queries=${queryCount} gscPages=${gscPageCount} ga4Pages=${ga4PageCount} `
     + `posthogPages=${posthogPageCount} clusters=${clusterCount} failures=${failures.length}`,
   );
 

--- a/scripts/lib/evidence/gscFetcher.mjs
+++ b/scripts/lib/evidence/gscFetcher.mjs
@@ -79,7 +79,7 @@ function pathFromGscPage(value) {
  * @param {number} [options.rowLimit=25000]
  * @param {Function} [options.fetchImpl=fetch]
  * @param {Function} [options.getTokenImpl=getServiceAccountToken]
- * @returns {Promise<{queries: object, orphanQueries: array, error?: string}>}
+ * @returns {Promise<{queries: object, orphanQueries: array, pages: object, error?: string}>}
  */
 export async function fetchGscQueries({
   startDate,
@@ -157,6 +157,46 @@ export async function fetchGscQueries({
       if (startRow >= rowLimit * 10) break;
     }
 
+    // Pass 3 — page-only aggregation. The full set of URLs Google has shown
+    // at least once in the window (page dimension, not just the per-query
+    // top-1 landing page captured in Pass 2). This is the comprehensive
+    // page-level impression signal the traffic-evidence filter needs to gate
+    // thinning correctly: Pass 2's `topLandingPage` only surfaces ~one page
+    // per query (a few thousand), whereas the page dimension surfaces every
+    // impressed URL (tens of thousands), including long-tail pages that rank
+    // #2+ for any query and never own a query outright. Without this, those
+    // pages are invisible to the "has-traffic" gate and risk being thinned
+    // despite confirmed Google interest. Threshold at 1 impression so any
+    // page Google has shown is protected.
+    const pages = {};
+    startRow = 0;
+    while (true) {
+      const data = await gscQuery(
+        token,
+        {
+          startDate,
+          endDate,
+          dimensions: ['page'],
+          rowLimit,
+          startRow,
+        },
+        fetchImpl,
+      );
+      const rows = data.rows || [];
+      for (const r of rows) {
+        const path = pathFromGscPage(r.keys?.[0] || '');
+        if (!path) continue;
+        const imp = r.impressions || 0;
+        if (imp < 1) continue;
+        // Store impressions as a compact number (key presence is what the
+        // filter checks; the count aids diagnostics/tuning).
+        pages[path] = imp;
+      }
+      if (rows.length < rowLimit) break;
+      startRow += rowLimit;
+      if (startRow >= rowLimit * 10) break;
+    }
+
     const queries = {};
     const orphanQueries = [];
     for (const [q, agg] of queryAgg) {
@@ -183,9 +223,9 @@ export async function fetchGscQueries({
         });
       }
     }
-    return { queries, orphanQueries };
+    return { queries, orphanQueries, pages };
   } catch (err) {
     const reason = err && err.message ? err.message : String(err);
-    return { queries: {}, orphanQueries: [], error: reason };
+    return { queries: {}, orphanQueries: [], pages: {}, error: reason };
   }
 }

--- a/tests/scripts/lib/evidence/gscFetcher.test.ts
+++ b/tests/scripts/lib/evidence/gscFetcher.test.ts
@@ -55,6 +55,49 @@ describe('fetchGscQueries', () => {
     expect(result.orphanQueries[0].query).toBe('orphan query');
   });
 
+  it('Pass 3: aggregates the full page-level impression set (Buco G)', async () => {
+    // Pass 1 (query), Pass 2 (query+page), Pass 3 (page) — the new pass
+    // returns every impressed URL keyed by path → impressions.
+    const queryRows = {
+      rows: [{ keys: ['ticino lavoro'], impressions: 80, clicks: 5, position: 6, ctr: 0.06 }],
+    };
+    const queryPageRows = {
+      rows: [{ keys: ['ticino lavoro', '/cerca-lavoro-ticino/'], impressions: 80 }],
+    };
+    const pageRows = {
+      rows: [
+        { keys: ['https://frontaliereticino.ch/cerca-lavoro-ticino/'], impressions: 80 },
+        { keys: ['/cerca-lavoro-ticino/ricerca-infermiere/'], impressions: 3 },
+        { keys: ['/cerca-lavoro-ticino/zero-imp/'], impressions: 0 }, // dropped (<1)
+      ],
+    };
+
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call++;
+      if (call === 1) return jsonRes(queryRows);
+      if (call === 2) return jsonRes(queryPageRows);
+      if (call === 3) return jsonRes(pageRows);
+      return jsonRes({ rows: [] });
+    });
+
+    const result = await fetchGscQueries({
+      startDate: '2026-02-01',
+      endDate: '2026-05-01',
+      fetchImpl,
+      getTokenImpl: async () => 'fake-token',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.pages).toBeDefined();
+    // absolute URL normalized to path
+    expect(result.pages['/cerca-lavoro-ticino/']).toBe(80);
+    // long-tail page that never owns a query is still captured
+    expect(result.pages['/cerca-lavoro-ticino/ricerca-infermiere/']).toBe(3);
+    // zero-impression rows are dropped
+    expect(result.pages['/cerca-lavoro-ticino/zero-imp/']).toBeUndefined();
+  });
+
   it('returns error key when token mint fails (does not throw)', async () => {
     const result = await fetchGscQueries({
       startDate: '2026-02-01',


### PR DESCRIPTION
## Contesto

Studio dell'artifact deploy-pages (10GB) per ridurlo ≥1GB senza perdere pagine SEO. L'analisi ha mostrato che ~88% del peso sono job/article page su 4 locali, già aggredite da un sistema di thinning esistente (`trafficEvidenceFilter` + EJP soft-landing thin shell). Il vero buco strutturale è nella **validazione del traffico**, non nel meccanismo di thinning.

## Implementato

**Buco G — ingestion GSC page-level nel gate "has-traffic".**

Il filtro vedeva GSC solo via proxy: `queries[].topLandingPage` (~9k, top-1 landing per query), `gsc-job-urls.json` (~2k), `indexed-cluster-urls.json` (~4.9k), orphan slugs. Totale ~18k path. Ma il set reale a dimensione `page` è **~52k URL con ≥1 impression** in 90gg. Quindi **~35k pagine viste da Google erano invisibili al gate** → rischio di thinning su pagine che guadagnano + validazione "zero impression" incompleta.

- `scripts/lib/evidence/gscFetcher.mjs`: aggiunto **Pass 3** (dimensione `page`) → aggrega ogni URL con ≥1 impression → ritorna `pages`.
- `scripts/build-evidence-index.mjs`: scrive `gsc.pages` nell'evidence-index + logga `gscPages=`.
- `build-plugins/shared/trafficEvidenceFilter.ts`: ingerisce `ev.gsc.pages` nel `trafficSet` (nuova sorgente, source-log `gsc-pages=`).
- Test: nuovo caso che verifica cattura long-tail, normalizzazione URL assoluti→path, drop righe 0-imp.

Effetto: ogni pagina che Google mostra è protetta dal thinning, **e** lo "zero traffico" diventa dimostrabile su tutte le sorgenti (GSC page-level + GA4 + PostHog + proxy) prima di assottigliare qualsiasi pagina. È il prerequisito di sicurezza per qualsiasi pruning più aggressivo.

Nessun cambio di workflow: `build-evidence-and-tune.yml` chiama già `build-evidence-index.mjs`, quindi `gsc.pages` si popola in automatico al prossimo run. Test evidence-layer: 20/20 verdi.

## Non implementato (ancora)

- **Riduzione ≥1GB vera e propria.** Buco G è correttezza/sicurezza (rende il gate PIÙ protettivo: aggiunge ~52k pagine → assottiglia di meno, non di più). Non riduce il dist da solo. Il sistema di thinning ha già aggredito il grosso (174k pagine IT già a ~4KB; una thin shell è già lean ~3.6KB). Le leve residue per ≥1GB richiedono una decisione esplicita perché o **rimuovono pagine** o spostano asset:
  - **Skip-tier per expired verificati-morti** (la leva reale ≥1GB): emettere `410`/niente pagina per soft-landing di job scaduti con zero traffico su TUTTE le sorgenti (ora provabile grazie a Buco G) e oltre una grace lunga. Rimuove pagine (zero-impression, già morte) → richiede OK utente. `action:'skip'` è già previsto come "Future" nel filtro.
  - **CDN immagini blog** via jsDelivr (`cdn.jsdelivr.net/gh/...@<sha>/public/images/blog/...`): ~273MB fuori dal dist, zero costo. `raw.githubusercontent` **scartato** (non è una CDN: rate-limit per-IP, no cache-control, ToS sconsiglia hotlink produzione, può servire `text/plain`). `og/jobs` (160MB) non idoneo: generato al build, non nel repo.
  - **Junk non-pagina**: `.write-collisions.json` (~3MB diagnostico di build) escludibile dal deploy.
- **Fix A (byte-minimize thin shell)**: valutato e **scartato** — una thin shell è già ~3.6KB (head 2.4KB, body 1.1KB, JSON-LD = solo BreadcrumbList 545B; JobPosting già rimosso sugli scaduti). Margine residuo minimo e toccherebbe breadcrumb/meta → rischio SEO non giustificato.

## Test plan

- [x] `vitest run tests/scripts/lib/evidence/` + `build-evidence-index.test.ts` → 20/20
- [x] `node --check` su entrambi gli `.mjs`
- [ ] Post-merge: verificare nel log di `build-evidence-and-tune.yml` `gscPages=~52000` e nel build `[traffic-evidence-filter] ... gsc-pages=~52000`
- [ ] Post-merge: confermare che il `trafficSet` cresca e che nessuna pagina earning venga assottigliata (self-heal promotions resta basso)
