### PR TITLE
feat(dist): serve full blog hero images from jsDelivr CDN (-~224MB)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -88,6 +88,7 @@ import { useSimulationState } from '@/hooks/useSimulationState';
 import { useNavigationState } from '@/hooks/useNavigationState';
 import { setDefaultConsent } from '@/services/consentService';
 import { prefetchTab } from '@/services/prefetch';
+import { installBlogImageCdnFallback } from '@/services/seo/blogImageCdn';
 import { initPostHog } from '@/services/posthog';
 import { useSeoPageTracking } from '@/hooks/useSeoPageTracking';
 import { useKillSwitches } from '@/hooks/useKillSwitches';
@@ -195,6 +196,10 @@ const App: React.FC = () => {
  // refresh-thin-promotions.yml can lift the URL back into the "full" set
  // on its next refresh. Single-shot per page-load — uses a window flag
  // gate to dedup if React StrictMode double-mounts the component.
+ // Blog hero images load from jsDelivr (CDN). If it's unreachable, swap the
+ // failing <img> to its raw.githubusercontent fallback (same SHA).
+ useEffect(() => { installBlogImageCdnFallback(); }, []);
+
  useEffect(() => {
  if (typeof window === 'undefined') return;
  const w = window as unknown as { __THIN_SHELL__?: number; __THIN_SHELL_REPORTED__?: number };

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -1,0 +1,107 @@
+// blogImageCdnFinalizePlugin.ts
+//
+// Post-build step that offloads full blog hero images to jsDelivr and removes
+// them from the GitHub Pages artifact. Runs last (enforce: 'post').
+//
+// 1. Rewrite every SSG-emitted reference to a FULL blog image
+//    (`/images/blog/<file>.webp`, origin-absolute or site-relative) to its
+//    jsDelivr CDN URL, across dist HTML/XML/TXT. The 480w thumbnails under
+//    `/images/blog/thumbnails/` are NOT touched — they stay same-origin.
+// 2. GUARD: re-scan; if any full-blog reference survives, throw (fails CI)
+//    rather than ship a 404 after the directory is deleted.
+// 3. Delete the full blog images from dist/images/blog (keep thumbnails/).
+//
+// SPA runtime <img> references come from data/blog-articles-data.ts, whose
+// ARTICLES export is already CDN-rewritten via cdnBlogImage — so this plugin
+// only needs to handle the static HTML/XML the crawler sees. The repo is
+// public, so jsDelivr (and the raw.githubusercontent fallback) can serve the
+// images pinned to the build commit SHA.
+
+import type { Plugin } from 'vite';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { JSDELIVR_BLOG_BASE } from './shared/blogImageCdn';
+
+const ORIGIN = 'https://frontaliereticino.ch';
+const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
+
+// A FULL blog image: `/images/blog/<file>.<ext>` with no further path segment
+// (so `/images/blog/thumbnails/...` never matches — it has an extra `/`).
+const FILE = "([^\"'\\s/?)]+?\\.(?:webp|png|jpe?g|avif))";
+const ESC_ORIGIN = ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// Rewrite targets: origin-absolute, and site-relative NOT preceded by a word
+// char. The `(?<![\w.@])` guard means CDN/raw URLs (`…/public/images/blog/…`,
+// the `c` of `public` is a word char) are never matched — they're left intact.
+const reAbs = new RegExp(ESC_ORIGIN + '/images/blog/' + FILE, 'g');
+const reRel = new RegExp('(?<![\\w.@])/images/blog/' + FILE, 'g');
+// Guard: a SURVIVING full-blog reference that would 404 once the dir is gone —
+// origin-absolute, or relative not preceded by a word char (so `/public/images/
+// blog/…` inside an emitted jsDelivr/raw URL is excluded), excluding thumbnails.
+const reLeak = new RegExp(
+  '(?:' + ESC_ORIGIN + '/images/blog/|(?<![\\w.@])/images/blog/)(?!thumbnails/)' + FILE,
+);
+
+function walk(dir: string, fn: (fp: string) => void): void {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fp = path.join(dir, e.name);
+    if (e.isDirectory()) walk(fp, fn);
+    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+  }
+}
+
+export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
+  return {
+    name: 'blog-image-cdn-finalize',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const distDir = path.resolve(rootDir, 'dist');
+      const blogDir = path.join(distDir, 'images', 'blog');
+      if (!fs.existsSync(blogDir)) {
+        console.log('[blog-image-cdn] no dist/images/blog — skipping');
+        return;
+      }
+
+      const repl = (_m: string, file: string): string => `${JSDELIVR_BLOG_BASE}/${file}`;
+      let scanned = 0;
+      let rewritten = 0;
+      walk(distDir, (fp) => {
+        scanned++;
+        const orig = fs.readFileSync(fp, 'utf8');
+        const out = orig.replace(reAbs, repl).replace(reRel, repl);
+        if (out !== orig) {
+          fs.writeFileSync(fp, out);
+          rewritten++;
+        }
+      });
+
+      // Guard — nothing full-blog (non-thumbnail, non-CDN) may remain.
+      const leaks: string[] = [];
+      walk(distDir, (fp) => {
+        if (reLeak.test(fs.readFileSync(fp, 'utf8'))) leaks.push(path.relative(distDir, fp));
+      });
+      if (leaks.length > 0) {
+        throw new Error(
+          `[blog-image-cdn] ${leaks.length} file(s) still reference full /images/blog images after CDN rewrite ` +
+            `(would 404 once the directory is offloaded): ${leaks.slice(0, 8).join(', ')}${leaks.length > 8 ? ' …' : ''}`,
+        );
+      }
+
+      // Delete full images; keep the thumbnails/ subdirectory (served local).
+      let deleted = 0;
+      let freed = 0;
+      for (const e of fs.readdirSync(blogDir, { withFileTypes: true })) {
+        if (e.isDirectory()) continue; // thumbnails/
+        const fp = path.join(blogDir, e.name);
+        freed += fs.statSync(fp).size;
+        fs.rmSync(fp);
+        deleted++;
+      }
+      console.log(
+        `[blog-image-cdn] rewrote ${rewritten}/${scanned} files → jsDelivr; ` +
+          `deleted ${deleted} full blog images (${(freed / 1048576).toFixed(0)} MB freed; thumbnails kept local)`,
+      );
+    },
+  };
+}

--- a/build-plugins/shared/blogImageCdn.ts
+++ b/build-plugins/shared/blogImageCdn.ts
@@ -1,0 +1,33 @@
+// blogImageCdn.ts (build-side)
+//
+// Build-plugin counterpart of services/seo/blogImageCdn.ts. Build plugins run
+// in Node (no Vite `__COMMIT_HASH__` define), so the commit SHA comes from
+// build-plugins/constants.ts (git rev-parse / CI env). Keep the jsDelivr base
+// + rewrite logic byte-compatible with the app-side helper so SSG-emitted URLs
+// and SPA-rendered URLs match (preload/og/JSON-LD ↔ hydrated <img>).
+//
+// See services/seo/blogImageCdn.ts for the full rationale.
+
+import { COMMIT_HASH } from '../constants';
+
+const REPO = 'valerielinc-ops/frontaliere-si-o-no';
+const SHA = COMMIT_HASH && COMMIT_HASH !== 'unknown' ? COMMIT_HASH : 'main';
+
+export const JSDELIVR_BLOG_BASE = `https://cdn.jsdelivr.net/gh/${REPO}@${SHA}/public/images/blog`;
+export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/public/images/blog`;
+
+// Full blog image at the section root (NOT under thumbnails/). Accepts a
+// site-relative path or an absolute same-origin URL.
+const FULL_BLOG_RX = /^(?:https?:\/\/[^/]+)?\/images\/blog\/([^/]+\.(?:webp|png|jpe?g|avif))$/i;
+
+/**
+ * Rewrite a full blog hero image reference to its jsDelivr CDN URL.
+ * Thumbnails (`/images/blog/thumbnails/...`) and non-blog paths pass through.
+ */
+export function cdnBlogImage(path: string | undefined | null): string {
+  if (!path) return path ?? '';
+  if (path.startsWith(JSDELIVR_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
+  const m = path.match(FULL_BLOG_RX);
+  if (!m) return path;
+  return `${JSDELIVR_BLOG_BASE}/${m[1]}`;
+}

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -655,6 +655,13 @@ type ResponsiveImageSet = {
 };
 
 function getResponsiveImageSet(imagePath: string): ResponsiveImageSet | null {
+ // Blog hero images are served from jsDelivr (CDN, full image only); their
+ // 480w thumbnails stay same-origin under /images/blog/thumbnails/. Accept
+ // the CDN URL form and map it back to the local thumbnail path.
+ const cdn = imagePath.match(/\/public\/images\/blog\/([^/]+)\.(jpe?g|png|webp|avif)$/i);
+ if (cdn) {
+ return { thumbWebp: `/images/blog/thumbnails/${cdn[1]}-480w.webp` };
+ }
  const match = imagePath.match(/^(\/images\/(?:blog|places))\/([^/]+)\.(jpe?g|png|webp|avif)$/i);
  if (!match) return null;
 
@@ -1249,7 +1256,9 @@ function BlogArticles({
  },
  isPartOf: { '@type': 'WebSite', '@id': 'https://frontaliereticino.ch/#website', name: 'Frontaliere Ticino' },
  mainEntityOfPage: canonicalUrl,
- image: `https://frontaliereticino.ch${article.image}`,
+ // article.image may already be an absolute CDN URL (blog heroes on jsDelivr);
+ // only prefix the origin for same-origin relative paths (e.g. /images/places).
+ image: article.image.startsWith('http') ? article.image : `https://frontaliereticino.ch${article.image}`,
  inLanguage: locale,
  isAccessibleForFree: true,
  articleSection: article.category,

--- a/data/blog-articles-data.ts
+++ b/data/blog-articles-data.ts
@@ -5,6 +5,7 @@
  * FRO-328: ~113KB of article data extracted to its own chunk.
  */
 import type { BlogArticleId } from '@/services/router';
+import { cdnBlogImage } from '@/services/seo/blogImageCdn';
 
 export interface Article {
  // Loose `string` to avoid TS2590 union-too-complex when ARTICLES literal is checked.
@@ -28,7 +29,7 @@ export interface Article {
  authorName?: string;
 }
 
-export const ARTICLES = [
+const RAW_ARTICLES = [
  {
  id: 'stipendio-netto-2026',
  category: 'fiscale',
@@ -25212,3 +25213,13 @@ export const ARTICLES = [
  authorName: 'Redazione Frontaliere Ticino',
  },
 ] satisfies Article[];
+
+// Full blog hero images are served from jsDelivr (git-backed CDN, SHA-pinned)
+// instead of the Pages artifact — see services/seo/blogImageCdn.ts. The raw
+// literals above stay site-relative so the build plugins that regex-parse this
+// file still read `/images/blog/...`; the runtime export rewrites them. The
+// 480w thumbnails (getResponsiveImageSet) remain same-origin.
+export const ARTICLES: Article[] = RAW_ARTICLES.map((a) => ({
+ ...a,
+ image: cdnBlogImage(a.image),
+}));

--- a/services/seo/blogImageCdn.ts
+++ b/services/seo/blogImageCdn.ts
@@ -1,0 +1,81 @@
+// blogImageCdn.ts
+//
+// Serve full blog hero images from jsDelivr (git-backed free CDN) instead of
+// bundling them into the GitHub Pages artifact. The full images live in the
+// repo at public/images/blog/*.webp (git-tracked), so jsDelivr serves them
+// pinned to the build commit SHA — available immediately (the commit exists
+// on GitHub before deploy) and immutably cacheable.
+//
+// Scope: ONLY full hero images (~224 MB) move to the CDN. The 480w responsive
+// thumbnails under /images/blog/thumbnails/ are build-generated (gitignored)
+// and stay same-origin — so the responsive `srcSet` keeps a local 480w entry
+// and a CDN 1200w entry. A post-build plugin deletes the full images from
+// dist/images/blog (keeping thumbnails) and fails the build if any full-image
+// origin reference survives in the emitted HTML.
+//
+// Fallback: if jsDelivr is unreachable, installBlogImageCdnFallback() rewrites
+// the failing <img> to raw.githubusercontent.com at the same SHA. raw serves
+// images fine — its text/plain MIME + nosniff only block scripts, not images.
+
+const REPO = 'valerielinc-ops/frontaliere-si-o-no';
+
+// Pinned to the build commit. __COMMIT_HASH__ is injected by Vite
+// (vite.config.ts define, declared in vite-env.d.ts). Falls back to the
+// `main` branch ref when the hash is unavailable (e.g. dev server) — jsDelivr
+// resolves @main too, only without the immutable-cache / instant-new-file
+// guarantee, which dev doesn't need.
+const SHA =
+  typeof __COMMIT_HASH__ !== 'undefined' && __COMMIT_HASH__ && __COMMIT_HASH__ !== 'unknown'
+    ? __COMMIT_HASH__
+    : 'main';
+
+export const JSDELIVR_BLOG_BASE = `https://cdn.jsdelivr.net/gh/${REPO}@${SHA}/public/images/blog`;
+export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/public/images/blog`;
+
+// Full blog image at the section root (NOT under thumbnails/). Matches both a
+// site-relative path and an absolute same-origin URL so callers can pass
+// either `/images/blog/x.webp` or `https://host/images/blog/x.webp`.
+const FULL_BLOG_RX = /^(?:https?:\/\/[^/]+)?\/images\/blog\/([^/]+\.(?:webp|png|jpe?g|avif))$/i;
+
+/**
+ * Rewrite a full blog hero image reference to its jsDelivr CDN URL.
+ * Thumbnails (`/images/blog/thumbnails/...`), non-blog paths, and URLs that
+ * are already absolute to another host pass through unchanged.
+ */
+export function cdnBlogImage(path: string | undefined | null): string {
+  if (!path) return path ?? '';
+  if (path.startsWith(JSDELIVR_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
+  const m = path.match(FULL_BLOG_RX);
+  if (!m) return path;
+  return `${JSDELIVR_BLOG_BASE}/${m[1]}`;
+}
+
+/** Map a jsDelivr blog URL to its raw.githubusercontent fallback, or null. */
+export function rawFallbackForBlog(url: string): string | null {
+  if (!url.startsWith(JSDELIVR_BLOG_BASE + '/')) return null;
+  return RAW_BLOG_BASE + url.slice(JSDELIVR_BLOG_BASE.length);
+}
+
+let _fallbackInstalled = false;
+/**
+ * Install a one-time capture-phase error listener that swaps a failed jsDelivr
+ * blog image to its raw.githubusercontent fallback. Image `error` events don't
+ * bubble, so capture phase is required to catch them at the document level.
+ */
+export function installBlogImageCdnFallback(): void {
+  if (_fallbackInstalled || typeof document === 'undefined') return;
+  _fallbackInstalled = true;
+  document.addEventListener(
+    'error',
+    (e) => {
+      const t = e.target as HTMLImageElement | null;
+      if (!t || t.tagName !== 'IMG' || t.dataset.cdnFallback) return;
+      const raw = rawFallbackForBlog(t.currentSrc || t.src);
+      if (!raw) return;
+      t.dataset.cdnFallback = '1';
+      if (t.srcset) t.srcset = '';
+      t.src = raw;
+    },
+    true,
+  );
+}

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -9,6 +9,7 @@ import { ALL_GLOSSARY_TERM_IDS, ALL_BORDER_CROSSING_IDS } from './router';
 import { resolveCompanyLogoUrl, isMultiLocation } from './jobDataNormalization';
 import { reportCaughtError } from './errorReporter';
 import { normalizeStructuredData } from './seo/schema-normalizers';
+import { cdnBlogImage } from './seo/blogImageCdn';
 import { translateSchema } from './seo/schema-translators';
 import { buildJobPostingSchema, type JobInput } from '../build-plugins/shared/jobPostingSchema';
 import { buildTitleWithBrand, buildJobTitleWithLocation } from '../build-plugins/shared/titleSuffix';
@@ -4144,7 +4145,10 @@ export async function updateMetaTags(section: string): Promise<void> {
  const sd = blogArticleSd;
  const imgUrl = typeof sd.image === 'string' ? sd.image : sd.image?.url;
  if (imgUrl) {
- const resolvedImgUrl = imgUrl.startsWith('http') ? imgUrl : `${BASE_URL}${imgUrl}`;
+ // Full blog hero images are served from jsDelivr (CDN). cdnBlogImage maps
+ // both relative and absolute-origin /images/blog/*.webp to the CDN URL and
+ // passes non-blog paths (e.g. /images/places) through unchanged.
+ const resolvedImgUrl = cdnBlogImage(imgUrl.startsWith('http') ? imgUrl : `${BASE_URL}${imgUrl}`);
  updateOrCreateMetaTag('property', 'og:image', resolvedImgUrl);
  const imgW = typeof sd.image === 'object' ? String(sd.image.width ?? '1344') : '1200';
  const imgH = typeof sd.image === 'object' ? String(sd.image.height ?? '756') : '630';

--- a/tests/blogImageCdn.test.ts
+++ b/tests/blogImageCdn.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cdnBlogImage,
+  rawFallbackForBlog,
+  JSDELIVR_BLOG_BASE,
+  RAW_BLOG_BASE,
+} from '@/services/seo/blogImageCdn';
+
+describe('cdnBlogImage', () => {
+  it('rewrites a site-relative full blog image to the jsDelivr CDN', () => {
+    const out = cdnBlogImage('/images/blog/inter-scudetto-chivu-2026.webp');
+    expect(out).toBe(`${JSDELIVR_BLOG_BASE}/inter-scudetto-chivu-2026.webp`);
+  });
+
+  it('rewrites an absolute same-origin full blog image', () => {
+    const out = cdnBlogImage('https://frontaliereticino.ch/images/blog/x.webp');
+    expect(out).toBe(`${JSDELIVR_BLOG_BASE}/x.webp`);
+  });
+
+  it('leaves 480w thumbnails same-origin (extra path segment)', () => {
+    const p = '/images/blog/thumbnails/x-480w.webp';
+    expect(cdnBlogImage(p)).toBe(p);
+  });
+
+  it('passes through non-blog images (e.g. /images/places)', () => {
+    const p = '/images/places/lugano-view.webp';
+    expect(cdnBlogImage(p)).toBe(p);
+  });
+
+  it('is idempotent on an already-CDN URL', () => {
+    const cdn = `${JSDELIVR_BLOG_BASE}/x.webp`;
+    expect(cdnBlogImage(cdn)).toBe(cdn);
+  });
+
+  it('handles empty / nullish input safely', () => {
+    expect(cdnBlogImage('')).toBe('');
+    expect(cdnBlogImage(undefined)).toBe('');
+    expect(cdnBlogImage(null)).toBe('');
+  });
+});
+
+describe('rawFallbackForBlog', () => {
+  it('maps a jsDelivr blog URL to its raw.githubusercontent fallback', () => {
+    const cdn = `${JSDELIVR_BLOG_BASE}/x.webp`;
+    expect(rawFallbackForBlog(cdn)).toBe(`${RAW_BLOG_BASE}/x.webp`);
+  });
+
+  it('returns null for non-jsDelivr URLs', () => {
+    expect(rawFallbackForBlog('/images/blog/x.webp')).toBeNull();
+    expect(rawFallbackForBlog('https://frontaliereticino.ch/images/blog/x.webp')).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,7 @@ import { legacyAliasPlugin } from './build-plugins/legacyAliasPlugin';
 import { flatHtmlRedirectPlugin } from './build-plugins/flatHtmlRedirectPlugin';
 import { hreflangPostprocessPlugin } from './build-plugins/hreflangPostprocessPlugin';
 import { postWalkCoordinatorPlugin } from './build-plugins/postWalkCoordinatorPlugin';
+import { blogImageCdnFinalizePlugin } from './build-plugins/blogImageCdnFinalizePlugin';
 import {
   writeRegistryResetPlugin,
   writeRegistryReportPlugin,
@@ -300,6 +301,11 @@ export default defineConfig(({ mode }) => {
  // build-plugins/precompressHtmlPlugin.ts for future revival.
  // precompressHtmlPlugin(__dirname),
  ]),
+ // Blog-image CDN offload — MUST be last: rewrites full /images/blog refs in
+ // emitted HTML/XML to jsDelivr (SHA-pinned), guards against any survivor,
+ // then deletes the full images from dist (keeps 480w thumbnails). Runs after
+ // postWalkCoordinator so it sees the final HTML. ~224 MB off the Pages artifact.
+ blogImageCdnFinalizePlugin(__dirname),
  // ── Content-hash manifest finalize DISABLED 2026-04-28 ──────
  // Paired with the disabled bootstrap above. Code retained for future
  // revival once a use-case (rollback / hotfix-only chains) emerges.


### PR DESCRIPTION
## Contesto

Riduzione dell'artifact GitHub Pages (~10GB) offloadando static su CDN. L'analisi (vedi PR #1210 Buco G) ha mostrato che ~88% è corpus HTML (non offloadabile) e ~0.88GB è static. Questa PR sposta il pezzo più grande e pulito: le **immagini hero del blog**.

## Implementato

**Full blog hero images → jsDelivr CDN (SHA-pinned) — ~224MB fuori dal dist.**

Le immagini full sono già git-tracked in `public/images/blog/*.webp` → jsDelivr le serve `@<commit-sha>` (immutabile, disponibile prima del deploy) con **fallback `raw.githubusercontent`** (per le immagini funziona: il MIME `text/plain`+nosniff blocca solo gli script). Repo pubblico verificato; jsDelivr+raw testati live (200).

- `services/seo/blogImageCdn.ts` — helper app `cdnBlogImage()` + `rawFallbackForBlog()` + installer onerror (SHA via `__COMMIT_HASH__`).
- `build-plugins/shared/blogImageCdn.ts` — gemello build-side (SHA via `COMMIT_HASH`).
- `data/blog-articles-data.ts` — l'export `ARTICLES` riscrive `image → CDN` una volta sola (i build-plugin che fanno **regex-parsing** leggono i literal raw site-relative → intatti).
- `components/community/BlogArticles.tsx` — `getResponsiveImageSet` mappa hero-CDN → **thumbnail locale**; fix bug double-prefix JSON-LD (niente origin davanti a URL CDN assoluto).
- `services/seoService.ts` — `og:image` instradato via `cdnBlogImage`.
- `App.tsx` — installa il fallback raw on-mount.
- `build-plugins/blogImageCdnFinalizePlugin.ts` — **post-build** (enforce post, ultimo): riscrive i ref full-blog in HTML/XML→jsDelivr, **GUARD che fa fallire la build se ne sopravvive uno** (impossibile deployare 404), poi cancella le immagini full da `dist/images/blog` (tiene i thumbnail locali).
- test: `cdnBlogImage` rewrite/passthrough/idempotenza/fallback (8 verdi).

**Scope chirurgico:** solo immagini full migrano. I **480w thumbnails** (build-generati) restano same-origin → lo `srcSet` resta `480w locale + 1200w CDN`. Nessuna pagina rimossa, nessun JS/CSS toccato.

## Non implementato (ancora)

- **og/jobs (160MB)**: build-generato per-job (non in git) → serve la pipeline branch `cdn-assets` (push generato + SHA-pin) e modifica a `deploy.yml`. Follow-up separato (rischio deploy). og **non eliminati** (servono per preview Google/FB), solo da spostare su CDN via branch.
- **assets/ JS-CSS (152M)**: NON su CDN — `raw.githubusercontent` non esegue JS (`text/plain`+nosniff) quindi niente fallback → single-point-of-failure. Restano same-origin; riduzione via bundle-audit (code-split/tree-shake). Follow-up.
- **≥1GB / Solution A (branch-serving)**: il vero ≥1GB è nel corpus HTML (9.2GB) → skip-tier delle pagine expired zero-traffico (provabile via Buco G #1210). Solution A (serving da gh-pages) è gated sul ridurre l'HTML a ~1GB. Follow-up.

## Test plan

- [x] `vitest` helper CDN (8/8) + test articoli (related/google-news/category/readingTime — 43/43; il solo fail è `data/jobs.json` assente in locale, ambientale)
- [x] `tsc --noEmit` pulito sui file toccati
- [x] live: jsDelivr + raw 200 su un'immagine blog campione
- [ ] **Post-build/deploy**: nel log build verificare `[blog-image-cdn] rewrote … deleted N full blog images (~224 MB freed)` e che il GUARD non scatti; confermare via `dist` della CI che gli articoli referenziano `cdn.jsdelivr.net/...@<sha>` e che le immagini caricano (Playwright)
- [ ] Post-deploy: spot-check live di un articolo (hero + card thumbnails) + og:image preview
