### PR TITLE
🔴 fix(generate-article): repair 'routerSrc is not defined' breaking ALL article generation

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -5302,12 +5302,18 @@ function checkForDuplicates(data) {
     }
   }
 
-  // 3. Also check slug overlap (different title, same slug concept)
+  // 3. Also check slug overlap (different title, same slug concept). Scoped to
+  // the ACTIVE section's slug-data file — slugs only collide within a section's
+  // URL space (`/articoli-frontaliere/{slug}` vs `/articoli-svizzera/{slug}`
+  // are distinct hubs). `routerSrc` here was a dangling reference left by the
+  // section refactor (it is a local of modifyRouterTs), which threw
+  // "routerSrc is not defined" and broke EVERY generation run.
+  const sectionSlugSrc = readSectionSlugData();
   for (const locale of ['it']) {
     const newSlug = data.slugs[locale];
     const slugPattern = new RegExp(`'${escapeRegex(newSlug)}'`, 'g');
-    if (slugPattern.test(routerSrc)) {
-      throw new Error(`❌ DUPLICATO: Lo slug "${newSlug}" esiste già in router.ts!`);
+    if (slugPattern.test(sectionSlugSrc)) {
+      throw new Error(`❌ DUPLICATO: Lo slug "${newSlug}" esiste già in ${SECTION_SLUG_DATA_FILE}!`);
     }
   }
 


### PR DESCRIPTION
## Implementato

🔴 **Hotfix outage**: dal refactor sezione (#1173, merged ~12:19) **ogni** run di `create-article.mjs` — **frontaliere (~95% revenue)** e svizzera — falliva con `❌ Errore: routerSrc is not defined` nello slug-overlap check di `checkForDuplicates` (L5309).

`routerSrc` è una variabile **locale di `modifyRouterTs`** (L6144), mai in scope a L5309: il refactor ha lasciato un riferimento dangling. Non intercettato perché quel path gira solo durante una generazione completa **con rete + chiavi LLM** (nessun test/smoke locale lo raggiunge — i model falliscono prima per assenza di key).

**Fix**: leggo la slug-data della **sezione attiva** via `readSectionSlugData()` (`routerBlogData.ts` per frontaliere, `routerSwissData.ts` per svizzera). Lo slug-overlap è per-hub URL-space, quindi lo scope active-section è corretto.

Evidenza: run live `workflow_dispatch section=svizzera` (id 26845170433) → step Generate `❌ routerSrc is not defined`; run schedule frontaliere 17:48/12:59 = failure (12:06/11:40 pre-#1173 = success). Conferma il blast radius: generazione ferma da ~8h.

## Non implementato (ancora)

- **Test di regressione sul path slug-overlap**: `checkForDuplicates` referenzia molti helper di modulo (similarity, readSectionMetaIt, getAllArticleIds) → estrazione via `new Function` fragile. Validazione affidata a `node --check` + ri-trigger live post-merge. La copertura unit di quel path resta un follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
