### PR TITLE
feat(crawlers): crawl all of Switzerland — drop single-canton geo filters

### DIFF
--- a/scripts/lib/bls-job-parser.mjs
+++ b/scripts/lib/bls-job-parser.mjs
@@ -280,10 +280,10 @@ function detectBlsEmploymentType(jsonLdType = '', pensum = '') {
 }
 
 /**
- * Fetch all BLS AG jobs in Valais.
+ * Fetch all BLS AG jobs in Switzerland.
  * Strategy:
  *   1. Fetch the BLS listing page (inline HTML with job links)
- *   2. Filter for Valais locations
+ *   2. Filter for Swiss locations
  *   3. Fetch each detail page at jobs.bls.ch for JSON-LD data
  *   4. Build ParsedJob objects
  *
@@ -402,6 +402,6 @@ export async function fetchAllBlsJobs() {
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  console.log(`\n📋 Total BLS AG Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total BLS AG Swiss jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/bls-job-parser.mjs
+++ b/scripts/lib/bls-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -101,19 +101,6 @@ function detectEmploymentType(text = '') {
   if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
   return 'OTHER';
 }
-
-/* ── Valais keywords for location filtering ──────────────── */
-
-// Canton VS (Valais) locations where BLS operates. Goppenstein is the south
-// portal of the Lötschberg tunnel (VS) — BLS lists it as "Goppenstein" on the
-// careers page, so it must match here. Kandersteg is BE but kept for the
-// adjacent Lötschberg corridor where BLS rotates VS-side staff.
-const VALAIS_KEYWORDS = [
-  'brig', 'visp', 'sion', 'sierre', 'martigny', 'monthey',
-  'naters', 'glis', 'wallis', 'valais', 'steg', 'raron',
-  'leuk', 'gampel', 'kandersteg', 'lötschberg', 'loetschberg',
-  'goppenstein', 'iselle', 'hohtenn', 'ausserberg',
-];
 
 /* ── HTTP helpers ─────────────────────────────────────────── */
 
@@ -205,14 +192,6 @@ function parseListingPage(html = '') {
     seen.add(e.uuid);
     return true;
   });
-}
-
-/**
- * Check if a job is in a Valais location based on listing page context.
- */
-function isValaisJob(entry) {
-  const combined = `${entry.locationRaw} ${entry.title}`.toLowerCase();
-  return VALAIS_KEYWORDS.some((kw) => combined.includes(kw));
 }
 
 /**
@@ -317,24 +296,24 @@ export async function fetchAllBlsJobs() {
   console.log(`🔍 Fetching BLS AG jobs`);
   console.log(`   Listing: ${LISTING_URL}`);
   console.log(`   Detail:  ${JOBS_BASE}/offene-stellen/{slug}/{uuid}`);
-  console.log(`   Strategy: Listing page → filter Valais → detail JSON-LD\n`);
+  console.log(`   Strategy: Listing page → filter Switzerland → detail JSON-LD\n`);
 
   const listingHtml = await fetchHtml(LISTING_URL);
   const allEntries = parseListingPage(listingHtml);
   console.log(`  📋 Total jobs on listing page: ${allEntries.length}`);
 
-  const valaisEntries = allEntries.filter(isValaisJob);
-  console.log(`  🏔️ Valais jobs: ${valaisEntries.length}`);
+  const swissEntries = allEntries.filter((e) => isTargetSwissLocation(`${e.locationRaw} ${e.title}`));
+  console.log(`  🇨🇭 Swiss jobs: ${swissEntries.length}`);
 
-  if (valaisEntries.length === 0) {
-    console.warn('⚠️ No Valais BLS job listings found.');
+  if (swissEntries.length === 0) {
+    console.warn('⚠️ No Swiss BLS job listings found.');
     return [];
   }
 
-  console.log(`\n  📋 Fetching ${valaisEntries.length} detail pages...\n`);
+  console.log(`\n  📋 Fetching ${swissEntries.length} detail pages...\n`);
 
   const jobs = [];
-  for (const entry of valaisEntries) {
+  for (const entry of swissEntries) {
     try {
       const detailHtml = await fetchHtml(entry.url);
       const jsonLd = extractJsonLd(detailHtml);
@@ -348,8 +327,8 @@ export async function fetchAllBlsJobs() {
       if (!title || title.length < 3) continue;
 
       const loc = extractLocation(jsonLd);
-      const location = loc.locality || entry.locationRaw || 'Brig';
-      const canton = inferAnyCanton(location) || 'VS';
+      const location = loc.locality || entry.locationRaw || '';
+      const canton = inferAnyCanton(location) || '';
       const descriptionText = buildDescription(jsonLd);
       const requirements = extractRequirements(jsonLd);
 

--- a/scripts/lib/bms-building-job-parser.mjs
+++ b/scripts/lib/bms-building-job-parser.mjs
@@ -267,11 +267,11 @@ function parseDetailPage(html = '') {
 }
 
 /**
- * Fetch all BMS Building Materials jobs in Valais.
+ * Fetch all BMS Building Materials jobs in Switzerland.
  * Strategy:
  *   1. Fetch the listing page HTML
  *   2. Parse job entries from HTML
- *   3. Filter for Valais locations
+ *   3. Filter for Swiss locations
  *   4. Fetch detail pages for richer descriptions
  *
  * Returns an array of ParsedJob objects (source-locale only).
@@ -363,6 +363,6 @@ export async function fetchAllBmsBuildingJobs() {
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  console.log(`\n📋 Total BMS Building Materials Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total BMS Building Materials Swiss jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/bms-building-job-parser.mjs
+++ b/scripts/lib/bms-building-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -102,14 +102,6 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
-/* ── Valais keywords for location filtering ──────────────── */
-
-const VALAIS_KEYWORDS = [
-  'naters', 'brig', 'visp', 'sion', 'sierre', 'martigny',
-  'monthey', 'glis', 'wallis', 'valais', 'conthey',
-  'st-maurice', 'saxon', 'leuk', 'steg', 'raron',
-];
-
 /* ── HTTP helpers ─────────────────────────────────────────── */
 
 const LISTING_URL = 'https://jobs.bmsuisse.ch/jobs/offene-stellen/';
@@ -194,18 +186,6 @@ function parseListingPage(html = '') {
     seen.add(e.jobId);
     return true;
   });
-}
-
-/**
- * Check if a job is in a Valais location.
- */
-function isValaisJob(entry) {
-  const combined = `${entry.city} ${entry.postalCode}`.toLowerCase();
-  // Valais postal codes: 1870-1997 (Bas-Valais) and 3900-3999 (Haut-Valais)
-  const pc = parseInt(entry.postalCode, 10);
-  if (pc >= 1870 && pc <= 1997) return true;
-  if (pc >= 3900 && pc <= 3999) return true;
-  return VALAIS_KEYWORDS.some((kw) => combined.includes(kw));
 }
 
 /**
@@ -302,31 +282,31 @@ function parseDetailPage(html = '') {
 export async function fetchAllBmsBuildingJobs() {
   console.log(`🔍 Fetching BMS Building Materials jobs`);
   console.log(`   Source: ${LISTING_URL}`);
-  console.log(`   Strategy: Listing page → filter Valais → detail pages\n`);
+  console.log(`   Strategy: Listing page → filter Switzerland → detail pages\n`);
 
   const listingHtml = await fetchHtml(LISTING_URL);
   const allEntries = parseListingPage(listingHtml);
   console.log(`  📋 Total jobs on listing page: ${allEntries.length}`);
 
-  const valaisEntries = allEntries.filter(isValaisJob);
-  console.log(`  🏔️ Valais jobs: ${valaisEntries.length}`);
+  const swissEntries = allEntries.filter((e) => isTargetSwissLocation(`${e.city} ${e.postalCode}`));
+  console.log(`  🇨🇭 Swiss jobs: ${swissEntries.length}`);
 
-  if (valaisEntries.length === 0) {
-    console.warn('⚠️ No Valais job listings found.');
+  if (swissEntries.length === 0) {
+    console.warn('⚠️ No Swiss job listings found.');
     return [];
   }
 
-  console.log(`\n  📋 Fetching ${valaisEntries.length} detail pages...\n`);
+  console.log(`\n  📋 Fetching ${swissEntries.length} detail pages...\n`);
 
   const jobs = [];
-  for (const entry of valaisEntries) {
+  for (const entry of swissEntries) {
     try {
       const detailHtml = await fetchHtml(entry.url);
       const detail = parseDetailPage(detailHtml);
 
       const title = detail?.title || entry.title;
-      const location = entry.city || 'Naters';
-      const canton = inferAnyCanton(location) || 'VS';
+      const location = entry.city || '';
+      const canton = inferAnyCanton(location) || '';
       // Ensure description has meaningful content (>30 chars) for SEO
       const rawDesc = detail?.description || '';
       const descriptionText = rawDesc.length >= 30

--- a/scripts/lib/coopers-job-parser.mjs
+++ b/scripts/lib/coopers-job-parser.mjs
@@ -114,18 +114,14 @@ function detectEmploymentType(text = '') {
  *   - Location, contract type, hours, reference code, posted date
  *   - Detail URL pattern: /en/jobs/detail.php?refCode={CODE}
  *
- * We filter for Visp/Wallis/Valais locations only (pharma hub in Valais).
+ * All Swiss listings are included (nationwide crawl).
  *
  * Coopers is a staffing agency — jobs are placed at client companies
- * (typically Lonza, other pharma firms in Visp). The hiring org is
- * Coopers as the recruiter.
+ * across Switzerland. The hiring org is Coopers as the recruiter.
  */
 
 const COOPERS_BASE = 'https://www.coopers.ch';
 const JOBS_URL = `${COOPERS_BASE}/en/jobs/index.php`;
-
-/** Location keywords that indicate Valais/Visp area. */
-const VALAIS_LOCATIONS = ['visp', 'wallis', 'valais', 'brig', 'naters', 'raron', 'gamsen'];
 
 /**
  * Fetch HTML with timeout handling.
@@ -161,13 +157,6 @@ function parseEuDate(raw = '') {
   return m ? `${m[3]}-${m[2]}-${m[1]}` : '';
 }
 
-/**
- * Check if a location string indicates Valais/Visp area.
- */
-function isValaisLocation(location = '') {
-  const lower = normalize(location);
-  return VALAIS_LOCATIONS.some(kw => lower.includes(kw));
-}
 
 /**
  * Parse the Coopers listing page HTML to extract job cards.
@@ -270,11 +259,11 @@ function normalizeCoopersLocation(raw = '') {
   if (lower.includes('brig')) return 'Brig';
   if (lower.includes('naters')) return 'Naters';
   if (lower.includes('raron')) return 'Raron';
-  return normalizeSpace(raw) || 'Visp';
+  return normalizeSpace(raw) || '';
 }
 
 /**
- * Fetch all Coopers Group AG jobs in Valais.
+ * Fetch all Coopers Group AG jobs in Switzerland.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
@@ -284,7 +273,7 @@ export async function fetchAllCoopersJobs() {
   console.log(`🔍 Fetching Coopers Group AG jobs`);
   console.log(`   Source: ${JOBS_URL}`);
   console.log(`   Platform: PHP site (HTML scraping)`);
-  console.log(`   Filter: Visp/Wallis/Valais locations\n`);
+  console.log(`   Filter: Switzerland — nationwide\n`);
 
   // Step 1: Fetch the full listing page
   console.log(`  📄 Fetching listing page...`);
@@ -293,23 +282,22 @@ export async function fetchAllCoopersJobs() {
 
   console.log(`  📋 Total listings on page: ${allListings.length}`);
 
-  // Step 2: Filter to Valais/Visp area only
-  const valaisListings = allListings.filter(l => isValaisLocation(l.location));
-  console.log(`  🎯 Valais/Visp listings: ${valaisListings.length}`);
+  // Step 2: Keep all Swiss listings (nationwide crawl)
+  const swissListings = allListings;
 
-  if (valaisListings.length === 0) {
-    console.warn('⚠️ No Valais job listings found.');
+  if (swissListings.length === 0) {
+    console.warn('⚠️ No job listings found.');
     return [];
   }
 
   // Step 3: Fetch detail pages and build job objects
   const jobs = [];
-  for (const listing of valaisListings) {
+  for (const listing of swissListings) {
     const title = normalizeSpace(listing.title);
     if (!title || title.length < 3) continue;
 
     const city = normalizeCoopersLocation(listing.location);
-    const canton = inferAnyCanton(city) || 'VS';
+    const canton = inferAnyCanton(city) || '';
 
     // Fetch detail for description
     console.log(`  📥 Fetching detail: ${title.substring(0, 50)}...`);
@@ -319,7 +307,7 @@ export async function fetchAllCoopersJobs() {
     const requirements = detail.requirements || [];
 
     const sourceLang = detectLang(descriptionText || title, 'en');
-    const jobSlug = slugify(`${title} coopers ${city || 'visp'}`);
+    const jobSlug = slugify(`${title} coopers ${city}`);
     const urlHash = createHash('sha1').update(listing.url).digest('hex').slice(0, 12);
 
     const job = {
@@ -368,6 +356,6 @@ export async function fetchAllCoopersJobs() {
     await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
-  console.log(`\n📋 Total Coopers Group AG Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total Coopers Group AG Swiss jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/coopers-job-parser.mjs
+++ b/scripts/lib/coopers-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -282,8 +282,10 @@ export async function fetchAllCoopersJobs() {
 
   console.log(`  📋 Total listings on page: ${allListings.length}`);
 
-  // Step 2: Keep all Swiss listings (nationwide crawl)
-  const swissListings = allListings;
+  // Step 2: Keep Swiss listings only (nationwide; coopers.ch has no country
+  // param and the dedicated pipeline applies no geo validation, so gate here —
+  // a staffing agency may list cross-border placements).
+  const swissListings = allListings.filter((l) => isTargetSwissLocation(l.location));
 
   if (swissListings.length === 0) {
     console.warn('⚠️ No job listings found.');

--- a/scripts/lib/csd-engineers-job-parser.mjs
+++ b/scripts/lib/csd-engineers-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -102,22 +102,13 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
-/* ── Valais location filter ────────────────────────────────── */
+/* ── Swiss location filter ─────────────────────────────────── */
 
 /**
- * Valais-relevant locations: Sion HQ + satellite offices in canton VS.
- * CSD also has offices in Lausanne, Zurich, Bern, Chur, Luxembourg, etc.
- * We only keep jobs physically based in Valais.
+ * CSD has offices across Switzerland (Sion HQ + Lausanne, Zurich, Bern,
+ * Chur, etc.). All Swiss jobs are kept (foreign jobs, e.g. Luxembourg,
+ * are excluded by the Swiss-location filter).
  */
-const VALAIS_PATTERNS = [
-  'sion', 'sierre', 'martigny', 'monthey', 'visp', 'brig',
-  'naters', 'saxon', 'valais', 'wallis',
-];
-
-function isValaisLocation(text = '') {
-  const t = String(text || '').toLowerCase();
-  return VALAIS_PATTERNS.some((p) => t.includes(p));
-}
 
 /* ── RSS + Detail Page Fetch ──────────────────────────────── */
 
@@ -287,21 +278,22 @@ export async function fetchAllCsdEngineersJobs() {
 
   console.log(`  📋 Total RSS items: ${rssItems.length}`);
 
-  // Pre-filter by location from RSS metadata (tt:city, tt:name, tt:department)
-  const valaisItems = rssItems.filter((item) => {
+  // Pre-filter by location from RSS metadata (tt:city, tt:name, tt:department).
+  // Keep all Swiss jobs (nationwide); foreign jobs are excluded.
+  const swissItems = rssItems.filter((item) => {
     const locationText = `${item.city} ${item.locationName} ${item.department} ${item.country}`;
-    return isValaisLocation(locationText);
+    return isTargetSwissLocation(locationText);
   });
 
-  console.log(`  🏔️  Valais-relevant items: ${valaisItems.length}`);
+  console.log(`  🇨🇭 Swiss items: ${swissItems.length}`);
 
-  if (valaisItems.length === 0) {
-    console.warn('⚠️ No Valais jobs found in RSS feed.');
+  if (swissItems.length === 0) {
+    console.warn('⚠️ No Swiss jobs found in RSS feed.');
     return [];
   }
 
   const jobs = [];
-  for (const item of valaisItems) {
+  for (const item of swissItems) {
     const title = item.title;
     if (!title || title.length < 3) continue;
 
@@ -317,9 +309,9 @@ export async function fetchAllCsdEngineersJobs() {
       await new Promise((r) => setTimeout(r, 300));
     }
 
-    // Use RSS city/location data, fall back to detail page or defaults
-    const city = item.city || detail?.city || 'Sion';
-    const canton = inferAnyCanton(city) || 'VS';
+    // Use RSS city/location data, fall back to detail page
+    const city = item.city || detail?.city || '';
+    const canton = inferAnyCanton(city) || '';
     const descriptionText = detail?.description || `${title} — CSD ENGINEERS, ${city}`;
     const publicUrl = item.link || CAREER_URL;
 
@@ -358,8 +350,8 @@ export async function fetchAllCsdEngineersJobs() {
 
       // ── Recommended fields ──
       addressLocality: city,
-      postalCode: item.postalCode || detail?.postalCode || '1950',
-      streetAddress: item.street || detail?.street || 'Rue de l\'Industrie 54',
+      postalCode: item.postalCode || detail?.postalCode || '',
+      streetAddress: item.street || detail?.street || '',
       addressCountry: 'CH',
       country: 'CH',
       category: detectCategory(title),

--- a/scripts/lib/csd-engineers-job-parser.mjs
+++ b/scripts/lib/csd-engineers-job-parser.mjs
@@ -257,13 +257,13 @@ async function fetchDetailPage(url) {
 /* ── Main fetch function ──────────────────────────────────── */
 
 /**
- * Fetch all CSD ENGINEERS jobs in Valais from the Teamtailor RSS feed.
+ * Fetch all CSD ENGINEERS jobs in Switzerland from the Teamtailor RSS feed.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * Flow:
  *   1. Fetch RSS feed (all jobs globally)
- *   2. Filter for Valais-based jobs (location in RSS or detail page)
- *   3. Fetch detail page for each Valais job (JSON-LD for description)
+ *   2. Filter for Swiss jobs (location in RSS or detail page)
+ *   3. Fetch detail page for each Swiss job (JSON-LD for description)
  *   4. Build ParsedJob objects
  */
 export async function fetchAllCsdEngineersJobs() {
@@ -370,6 +370,6 @@ export async function fetchAllCsdEngineersJobs() {
     jobs.push(job);
   }
 
-  console.log(`\n📋 Total CSD ENGINEERS Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total CSD ENGINEERS Swiss jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/migros-hq-job-parser.mjs
+++ b/scripts/lib/migros-hq-job-parser.mjs
@@ -106,9 +106,8 @@ export function isTrustedDomain(rawUrl = '') {
 /* ── Location Filter ───────────────────────────────────────── */
 
 /**
- * Keep only postings located in Zürich (HQ) and the wider ZH canton.
- * Filtering out other cantons avoids overlap with sibling crawlers
- * (Migros Ticino) and keeps this crawler scoped to the HQ.
+ * Keep every posting located in Switzerland (nationwide crawl). Foreign
+ * postings are still dropped; the canton is no longer restricted to ZH.
  *
  * Used as the `options.filter` predicate passed to the shared SR client.
  */
@@ -118,11 +117,7 @@ function isHqLocation(loc = {}) {
   const city = normalize(loc.city || '');
   const region = normalize(loc.region || '');
   if (!city && !region) return false;
-  const composite = [loc.city, loc.region, loc.country].filter(Boolean).join(', ');
-  const canton = inferAnyCanton(composite) || inferSwissTargetCanton(composite);
-  if (canton === 'ZH') return true;
-  // Common ZH city names that may resolve weakly through inferAnyCanton.
-  return /(zurich|zürich|zuerich|kloten|wallisellen|opfikon|dietikon|schlieren|bülach|buelach|winterthur)/.test(city);
+  return true;
 }
 
 /* ── Category Detection ────────────────────────────────────── */

--- a/scripts/lib/omega-job-parser.mjs
+++ b/scripts/lib/omega-job-parser.mjs
@@ -24,10 +24,10 @@
  *   - section.language-requirements     — language requirements
  *   - a.apply href                      — Lumesse TalentLink apply URL
  *
- * Only Valais-located jobs are included (filtered by region in address).
+ * All Swiss-located jobs are included (country_id=40 restricts to Switzerland).
  *
  * Exports the 4 required functions for the crawler template:
- *   - fetchAllOmegaJobs()     — Fetch and parse all Valais jobs
+ *   - fetchAllOmegaJobs()     — Fetch and parse all Swiss jobs
  *   - isOmegaJob()            — Match jobs belonging to this company
  *   - isTrustedDomain()       — Validate URLs belong to this company
  *   - slugify() / stripHtml() — Re-exported from crawler-template.mjs
@@ -45,16 +45,6 @@ export const OMEGA_COMPANY_DOMAIN = 'omegawatches.com';
 
 const BASE_URL = 'https://www.omegawatches.com';
 const LIST_URL = `${BASE_URL}/careers/list?country_id=40`;
-
-/**
- * Valais region identifiers in Omega's address strings.
- * Format: "Street, ZIP City, Country - Country (Region)"
- */
-const VALAIS_PATTERNS = [
-  'valais', 'wallis', 'vallese',
-  'zermatt', 'sierre', 'sion', 'visp', 'brig', 'martigny', 'monthey',
-  'crans-montana', 'verbier', 'naters', 'saas-fee',
-];
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -89,14 +79,6 @@ function htmlToText(html = '') {
     .replace(/\n{3,}/g, '\n\n')
     .replace(/^\s+|\s+$/gm, '')
     .trim();
-}
-
-/**
- * Check if a location string refers to Valais/Wallis.
- */
-function isValaisLocation(locationStr = '') {
-  const lower = normalize(locationStr);
-  return VALAIS_PATTERNS.some((p) => lower.includes(p));
 }
 
 /**
@@ -385,7 +367,7 @@ function buildDescription(sections = {}, title = '', city = '') {
   }
 
   if (parts.length === 0) {
-    return `${title} - OMEGA SA, ${city || 'Valais'}, Switzerland`;
+    return `${title} - OMEGA SA, ${city ? `${city}, ` : ''}Switzerland`;
   }
 
   return parts.join('\n\n');
@@ -413,7 +395,7 @@ function extractRequirements(sections = {}) {
 /* ── Main Fetcher ─────────────────────────────────────────── */
 
 /**
- * Fetch all OMEGA SA jobs in Valais.
+ * Fetch all OMEGA SA jobs in Switzerland.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
@@ -423,7 +405,7 @@ export async function fetchAllOmegaJobs() {
   console.log(`🔍 Fetching OMEGA SA jobs`);
   console.log(`   Platform: Custom Magento career portal (Lumesse TalentLink ATS)`);
   console.log(`   List URL: ${LIST_URL}`);
-  console.log(`   Filter: Switzerland (country_id=40), then Valais by address\n`);
+  console.log(`   Filter: Switzerland (country_id=40) — nationwide\n`);
 
   // Step 1: Fetch the list page
   console.log(`  📄 Fetching Switzerland job listings...`);
@@ -441,18 +423,18 @@ export async function fetchAllOmegaJobs() {
   const listings = parseListPage(listHtml);
   console.log(`  📦 Found ${listings.length} Switzerland jobs total`);
 
-  // Step 2: Filter to Valais-only jobs
-  const valaisListings = listings.filter((l) => isValaisLocation(l.locationStr));
-  console.log(`  🏔️ Valais jobs: ${valaisListings.length}`);
+  // Step 2: Keep all Swiss listings (nationwide crawl; country_id=40 already
+  // restricts the listing to Switzerland)
+  const swissListings = listings;
 
-  if (valaisListings.length === 0) {
-    console.warn('⚠️ No Valais job listings found.');
+  if (swissListings.length === 0) {
+    console.warn('⚠️ No job listings found.');
     return [];
   }
 
   // Step 3: Fetch each detail page for full information
   const jobs = [];
-  for (const listing of valaisListings) {
+  for (const listing of swissListings) {
     console.log(`  📄 Fetching detail: ${listing.title}`);
 
     let detailData = { sections: {}, applyUrl: '', detailTitle: '', detailLocation: '', tags: [] };
@@ -470,8 +452,8 @@ export async function fetchAllOmegaJobs() {
 
     const locationStr = detailData.detailLocation || listing.locationStr;
     const address = parseAddress(locationStr);
-    const city = address.city || 'Zermatt';
-    const canton = normalizeCantonCode(address.region) || inferAnyCanton(city) || 'VS';
+    const city = address.city || '';
+    const canton = normalizeCantonCode(address.region) || inferAnyCanton(city) || '';
 
     // Tags from detail or list
     const tags = detailData.tags.length > 0 ? detailData.tags : listing.tags;
@@ -548,7 +530,7 @@ export async function fetchAllOmegaJobs() {
     console.log(`  ✅ ${title} — ${city} (${canton})`);
   }
 
-  console.log(`\n📋 Total OMEGA SA Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total OMEGA SA Swiss jobs discovered: ${jobs.length}`);
   return jobs;
 }
 

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -679,7 +679,9 @@ function normalizeAdapterSeedMeta(rawMeta) {
 function isAdapterSeedMetaTargetRelevant(seedMeta) {
   const meta = normalizeAdapterSeedMeta(seedMeta);
   if (!meta) return false;
-  if (meta.canton === 'TI' || meta.canton === 'GR') return true;
+  // Any recognized Swiss canton qualifies (nationwide crawl). normalizeCantonCode
+  // only yields a non-empty code for one of the 26 Swiss cantons.
+  if (meta.canton) return true;
   if (meta.location && isTargetSwissLocation(meta.location)) return true;
   return false;
 }
@@ -720,10 +722,8 @@ let _geocodeApiCalls = 0;
 const GEOCODE_MAX_API_CALLS = clampNum(process.env.JOBS_GEOCODE_MAX_CALLS, 5, 200, 80);
 const GEOCODE_RATE_LIMIT_MS = 250; // 4 req/sec — well within Google's 50/sec
 
-// Ticino-relevant area: Canton TI, Canton GR (Mesolcina/Bregaglia), and
-// northern Italian border provinces close enough for cross-border commuting.
-const TICINO_RELEVANT_CANTONS = new Set(['ticino', 'ti', 'tessin']);
-const TICINO_ADJACENT_CANTONS = new Set(['graubünden', 'gr', 'grigioni', 'grisons', 'grischun']);
+// Relevant area: all of Switzerland (nationwide crawl), plus northern Italian
+// border provinces close enough for cross-border commuting.
 const BORDER_PROVINCES_IT = new Set([
   'varese', 'como', 'lecco', 'sondrio',
   'verbano-cusio-ossola', 'verbania', 'novara',
@@ -827,18 +827,9 @@ function isGeocodedLocationTicinoRelevant(geo) {
 
   const { country, canton, cantonShort, province, lat, lng } = geo;
 
-  // ── Switzerland ──
+  // ── Switzerland → all 26 cantons relevant (nationwide crawl) ──
   if (country === 'CH') {
-    if (TICINO_RELEVANT_CANTONS.has(canton) || TICINO_RELEVANT_CANTONS.has(cantonShort?.toLowerCase())) {
-      return { relevant: true, reason: 'ch_canton_ticino' };
-    }
-    if (TICINO_ADJACENT_CANTONS.has(canton) || TICINO_ADJACENT_CANTONS.has(cantonShort?.toLowerCase())) {
-      // GR: only relevant if in the southern part (Mesolcina/Bregaglia/Poschiavo — lat < 46.6)
-      if (lat && lat < 46.6) return { relevant: true, reason: 'ch_canton_gr_south' };
-      return { relevant: false, reason: 'ch_canton_gr_north' };
-    }
-    // Other Swiss cantons — not Ticino-relevant
-    return { relevant: false, reason: `ch_canton_${cantonShort || canton}_not_ticino` };
+    return { relevant: true, reason: `ch_canton_${cantonShort || canton || 'unknown'}` };
   }
 
   // ── Italy ──
@@ -864,9 +855,10 @@ function isGeocodedLocationTicinoRelevant(geo) {
  * Applied on the final merged job list so ALL crawler types benefit.
  *
  * Strategy:
- *  1. Skip jobs whose location text-matches Ticino tokens (already verified)
+ *  1. Skip jobs whose location text-matches a Swiss location (already verified)
  *  2. Geocode remaining ambiguous locations
- *  3. Reject jobs whose geocoded location is clearly outside the Ticino area
+ *  3. Reject jobs whose geocoded location is clearly outside Switzerland
+ *     (foreign, except northern-Italian border provinces)
  *  4. If geocoding fails → keep the job (fail open)
  *
  * @param {Array} jobs - Merged, deduplicated jobs list
@@ -917,7 +909,7 @@ async function filterJobsByGeolocation(jobs) {
   }
 
   if (removed.length > 0) {
-    console.log(`\n🗺️  Geocoding filter removed ${removed.length} job(s) outside Ticino area:`);
+    console.log(`\n🗺️  Geocoding filter removed ${removed.length} job(s) outside Switzerland:`);
     for (const { job, geo, reason } of removed) {
       console.log(`   ❌ [${job.company}] "${job.title}" — ${job.location} → ${geo?.formattedAddress || '?'} (${reason})`);
     }

--- a/scripts/update-denner-jobs.mjs
+++ b/scripts/update-denner-jobs.mjs
@@ -48,7 +48,7 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { extractMigrosStructuredData } from './lib/migros-job-parser.mjs';
 import { inferEmploymentType } from './lib/denner-job-parser.mjs';
-import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 
 /* -- Constants --------------------------------------------------------- */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -57,13 +57,11 @@ const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const DENNER_KEY = 'denner';
-const DEFAULT_CANTON = getCompanyDefaults(DENNER_KEY)?.canton || 'TI';
 const DENNER_COMPANY_NAME = 'Denner';
 const DENNER_HOST = 'jobs.migros.ch';
 const DENNER_LISTING_BASE = 'https://jobs.migros.ch/it/le-nostre-imprese/denner-sa/posti-di-lavoro-vacanti';
-const REGION_IDS = { 'Svizzera meridionale': '871', Grigioni: '868' };
 
-/** Ticino city → postal code map for Denner store locations */
+/** Ticino city → postal code map (postalCode enrichment for Denner TI stores) */
 const TICINO_PLZ = {
   lugano: '6900', bellinzona: '6500', locarno: '6600', mendrisio: '6850',
   chiasso: '6830', biasca: '6710', giubiasco: '6512', agno: '6982',
@@ -136,11 +134,8 @@ async function fetchDennerJobUrls() {
   const allUrls = new Set();
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 15000;
 
+  // No REGION filter → nationwide (all Swiss Denner stores)
   const pagesToFetch = [
-    ...Object.entries(REGION_IDS).map(([name, id]) => ({
-      name,
-      url: `${DENNER_LISTING_BASE}?REGION=${id}`,
-    })),
     { name: 'All regions', url: DENNER_LISTING_BASE },
   ];
 
@@ -270,12 +265,12 @@ async function fetchAndParseDetailPages(urls) {
         requirements: migrosData?.requirements || [],
         requirementsByLocale: { it: migrosData?.requirements || [] },
         location,
-        postalCode: postalCode || TICINO_PLZ[location.toLowerCase()] || '6500',
-        canton: TICINO_PLZ[location.toLowerCase()] ? 'TI' : (postalCode ? '' : DEFAULT_CANTON),
-        addressLocality: location || 'Bellinzona',
-        addressRegion: TICINO_PLZ[location.toLowerCase()] ? 'TI' : (postalCode ? '' : DEFAULT_CANTON),
+        postalCode: postalCode || TICINO_PLZ[location.toLowerCase()] || '',
+        canton: inferAnyCanton(location) || '',
+        addressLocality: location || '',
+        addressRegion: inferAnyCanton(location) || '',
         addressCountry: 'CH',
-        streetAddress: location ? `Denner ${location}` : 'Denner Ticino',
+        streetAddress: location ? `Denner ${location}` : 'Denner',
         employmentType: inferEmploymentType(rawTitle, description, workPct || ''),
         category: 'retail',
         contract: migrosData?.employmentType || 'full-time',

--- a/scripts/update-migros-jobs.mjs
+++ b/scripts/update-migros-jobs.mjs
@@ -393,7 +393,18 @@ async function main() {
     const allJobs = Array.isArray(raw) ? raw : [];
     const migrosJobs = allJobs.filter(isMigrosJob);
     const report = runQualityGuards(migrosJobs, {
-      companyName: ['Migros', 'Migros Ticino', 'Migros Aare', 'Gruppo Migros'],
+      // Migros group entities. Cooperatives all contain "Migros". Migros
+      // Industrie (M-Industrie) brands and group retailers do not, so they are
+      // listed explicitly — otherwise nationwide jobs from e.g. Delica AG
+      // (Stabio TI / Birsfelden BL) get rejected as "implausible company".
+      companyName: [
+        'Migros', 'Migros Ticino', 'Migros Aare', 'Gruppo Migros',
+        // M-Industrie
+        'Delica', 'Jowa', 'Mibelle', 'Midor', 'Chocolat Frey', 'Micarna',
+        'Mifa', 'Bischofszell', 'Estavayer', 'Aproz', 'Riseria',
+        // Group retail / services
+        'Migrol', 'Hotelplan', 'Ex Libris', 'Digitec', 'Galaxus', 'SportXX',
+      ],
       minDescription: 200,
       logger: (msg) => console.warn(msg),
     });

--- a/scripts/update-migros-jobs.mjs
+++ b/scripts/update-migros-jobs.mjs
@@ -402,8 +402,10 @@ async function main() {
         // M-Industrie
         'Delica', 'Jowa', 'Mibelle', 'Midor', 'Chocolat Frey', 'Micarna',
         'Mifa', 'Bischofszell', 'Estavayer', 'Aproz', 'Riseria',
-        // Group retail / services
+        'Fresh Food', 'Fresh Food & Beverage',
+        // Group retail / services / leisure
         'Migrol', 'Hotelplan', 'Ex Libris', 'Digitec', 'Galaxus', 'SportXX',
+        'Activ Fitness', 'Fitnesspark',
       ],
       minDescription: 200,
       logger: (msg) => console.warn(msg),

--- a/scripts/update-migros-jobs.mjs
+++ b/scripts/update-migros-jobs.mjs
@@ -6,30 +6,25 @@
  *
  * The Migros careers portal at jobs.migros.ch is a Nuxt.js SPA.
  * The listing page renders ~7 pinned jobs in the SSR HTML, but the
- * full result set (54+ positions across Ticino/Grigioni) is only
+ * full result set (all open positions across Switzerland) is only
  * visible after client-side hydration and pagination clicks.
  *
  * This script:
- *   1. Launches a headless Chromium via Playwright on the listing
- *      URL with REGION=868,871,878 (Ticino + Svizzera meridionale
- *      + Grigioni Italiani), accepts the cookie banner, then clicks
- *      "Pagina successiva" repeatedly until the button is disabled.
+ *   1. Launches a headless Chromium via Playwright on the unfiltered
+ *      listing URL (no REGION param → nationwide), accepts the cookie
+ *      banner, then clicks "Pagina successiva" repeatedly until the
+ *      button is disabled.
  *   2. Collects every job detail href (any locale prefix) and sets
  *      them as adapter seed URLs.
  *   3. Runs the base crawler which fetches each detail page and
  *      parses the HTML content (no JSON-LD — Migros uses Nuxt
  *      with __NUXT_DATA__ hydration payloads).
  *
- * Listing URL pattern:
- *   https://jobs.migros.ch/it/le-nostre-imprese/gruppo-migros/posti-di-lavoro-vacanti?REGION={ids}
+ * Listing URL pattern (unfiltered → nationwide):
+ *   https://jobs.migros.ch/it/le-nostre-imprese/gruppo-migros/posti-di-lavoro-vacanti
  *
  * Detail page URL pattern:
  *   https://jobs.migros.ch/{it|de|fr|en}/{le-nostre-imprese|unsere-unternehmen|nos-entreprises|our-companies}/job/{company-slug}/{job-slug}/{uuid}
- *
- * Region IDs (Migros internal taxonomy):
- *   868 = Grigioni
- *   871 = Svizzera meridionale (includes Ticino area)
- *   878 = Regione bilingue Grigioni italiano
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -53,14 +48,13 @@ const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapte
 const MIGROS_KEY = 'migros-ticino';
 
 /**
- * Migros listing page URL with all Italian-speaking/adjacent region IDs combined.
- *
- *   868 = Grigioni
- *   871 = Svizzera meridionale (includes Ticino)
- *   878 = Regione bilingue Grigioni italiano
+ * Migros listing page URL — no REGION filter, so the whole of Switzerland is
+ * crawled (all cantons + every Migros group company, incl. Migros Industrie
+ * brands like Delica which the REGION taxonomy classified by HQ, not by the
+ * job's physical location).
  */
 const LISTING_URL =
-  'https://jobs.migros.ch/it/le-nostre-imprese/gruppo-migros/posti-di-lavoro-vacanti?REGION=868,871,878';
+  'https://jobs.migros.ch/it/le-nostre-imprese/gruppo-migros/posti-di-lavoro-vacanti';
 
 /**
  * Regex matching a Migros job detail href in any of the four locale prefixes.
@@ -133,7 +127,7 @@ function isTrustedMigrosDomain(rawUrl = '') {
  * is driven by a "Pagina successiva" button (no query-string paging).
  *
  * This function:
- *   1. Opens the listing with REGION=868,871,878 in Chromium.
+ *   1. Opens the unfiltered listing (no REGION param → nationwide) in Chromium.
  *   2. Accepts the OneTrust cookie banner (required — without it, the results
  *      panel renders only a handful of "suggested" jobs).
  *   3. Collects every anchor matching {locale}/{segment}/job/... .
@@ -353,7 +347,7 @@ async function main() {
   registerCrawlerSummaryGuard(MIGROS_KEY, 'Migros');
   console.log('🛒 Running dedicated Migros Ticino jobs crawler...');
   console.log('   Platform: Nuxt.js SPA (jobs.migros.ch) via Playwright');
-  console.log('   Regions: 868 (Grigioni) + 871 (Svizzera meridionale) + 878 (bilingue)');
+  console.log('   Scope: nationwide (no REGION filter — all Swiss cantons)');
   console.log('');
 
   // Step 1: Fetch job detail URLs from the SSR listing pages

--- a/scripts/update-rittmeyer-jobs.mjs
+++ b/scripts/update-rittmeyer-jobs.mjs
@@ -45,7 +45,8 @@ const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Rittmeyer AG';
 const COMPANY_HOST = 'karriere.rittmeyer.com';
 const COMPANY_DOMAIN = 'rittmeyer.com';
-const CAREERS_URL = 'https://karriere.rittmeyer.com/offene-stellen/?suche=&location=23&country=1';
+// No `location` filter → all Swiss Rittmeyer sites (country=1 keeps it Swiss-only).
+const CAREERS_URL = 'https://karriere.rittmeyer.com/offene-stellen/?suche=&country=1';
 const DETAIL_BASE = 'https://karriere.rittmeyer.com';
 const LOCALES = ['it', 'en', 'de', 'fr'];
 

--- a/scripts/update-zurich-jobs.mjs
+++ b/scripts/update-zurich-jobs.mjs
@@ -27,15 +27,13 @@ const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapte
 const ZURICH_KEY = 'zurich-insurance-sede-ticino';
 
 /**
- * Broad search terms for the Zurich careers portal (SuccessFactors ATS).
- * We use region-level queries rather than individual city searches:
- * - "Ticino" / "Tessin" cover ALL positions in the TI canton (IT / DE naming)
- * - "Lugano" catches jobs tagged specifically by city in the main hub
- * - "Graubünden" / "Grisons" / "Chur" cover GR canton positions
+ * Country-level search terms for the Zurich careers portal (SuccessFactors ATS).
+ * We query by country name in all four national languages so the crawl covers
+ * ALL of Switzerland (nationwide) while still excluding foreign postings.
  * Keeping the list short is critical: each seed URL triggers a full BFS crawl
  * in crawlGenericListingJobs() (up to 8 listing + 12 detail pages per seed).
  */
-const SEED_SEARCH_TERMS = ['Ticino', 'Tessin', 'Lugano', 'Graubünden', 'Grisons', 'Chur'];
+const SEED_SEARCH_TERMS = ['Switzerland', 'Schweiz', 'Suisse', 'Svizzera'];
 
 const ZURICH_SEARCH_BASE = 'https://www.careers.zurich.com/search/';
 


### PR DESCRIPTION
## Implementato

Rimossi/allargati i filtri **regione** e **cantone** nei crawler di lavoro: ora coprono **tutta la Svizzera (26 cantoni)**; l'estero resta escluso (gate Svizzera-only intatto).

Motivazione: un job **Delica AG** (Migros Industrie) a **Stabio (TI)** non veniva crawlato perché la tassonomia `REGION` di jobs.migros.ch classifica i posting Industrie per sede HQ, non per località del job.

**Crawler con narrowing rimosso/allargato:**
- `shared-jobs-crawler`: la geo-relevance (geocoding) e la seed-meta relevance accettano **qualsiasi cantone CH** (erano TI + GR-sud).
- `migros` (ticino): drop `?REGION=868,871,878` → listing nationwide. **+ quality-guard ora accetta i brand Migros Industrie** (Delica, Jowa, Mibelle, Midor, Chocolat Frey, Micarna, …) e i retailer di gruppo → i job Delica (Stabio TI / Birsfelden BL) non sono più scartati come "implausible company".
- `migros-hq`: `isHqLocation` mantiene tutti i posting svizzeri (era solo ZH).
- `coopers`, `omega`, `bls`, `bms-building`, `csd-engineers`: predicato Valais-only → `isTargetSwissLocation` (26 cantoni); rimossi i fallback indirizzo geo-biased (VS/Sion/Naters/Zermatt).
- `denner`: drop loop `REGION_IDS` (il pass "All regions" è già nationwide); canton via `inferAnyCanton` invece dei default TI.
- `rittmeyer`: drop `?location=23` (filtro server su un sito); resta `country=1` (Svizzera).
- `zurich`: seed search da città TI/GR → livello-paese (Switzerland/Schweiz/Suisse/Svizzera).

**Lasciati intatti di proposito:**
- `isZurichJob` = match-azienda (Zurich Insurance), non un filtro cantonale.
- Gate Svizzera-only (`isSwissLocation` / `SWISS_LOCATION_IDS` su novartis/roche/nestlé/… ) — l'utente vuole "tutta la CH, no estero".
- 6 crawler erano **già** tutta-CH (delegano a `isTargetSwissLocation`, già a 26 cantoni dal 2026-05-10): AGIE Charmilles, Agroscope, AFRY, Artificialy, Guess, Knowledge Lab — nessuna modifica necessaria.

### Verifica before/after (workflow remoti su questo branch)

| crawler | prima | dopo | esito |
|---|---|---|---|
| migros | 24 | 41 | ✅ (TI 3, GR 16, **altri cantoni 22**) |
| coopers | 3 | **66** | ✅ |
| csd-engineers | 2 | **40** | ✅ (Bulle, Zurich, Bern, Pratteln…) |
| bms-building | 4 | **38** | ✅ |
| bls | 1 | **23** | ✅ |
| rittmeyer | 2 | **12** | ✅ |
| denner | 12 | 11 | varianza quality-gate/expiry (32 URL scoperti → broad ok) |
| omega | 0 | 0 | listing vuoto upstream (no regressione) |
| zurich | 0 | 0 | ricerca paese non produce job (no regressione) |
| migros-hq | 0 | 0 | feed SmartRecruiters `Migros` vuoto upstream |

Test: i 196 test dei crawler toccati passano. I 7 file rossi della suite completa (`mine-topic-candidates`, `job-locale-*`, `sitemap-slug-integrity`, …) falliscono **anche con questo branch stashato** = main-red pre-esistente, non introdotto qui.

## Non implementato (ancora)

- **Mikron**: il crawler hardcoda ogni job a Agno (`location:'Agno'`, `postalCode:'6982'`, `streetAddress:'Via Ginnasio 17'`). Allargarlo darebbe indirizzi/CAP **sbagliati** ai job di altri siti (es. Boudry NE) → viola la correttezza structured-data (AGENTS.md #3). Richiede estrazione address per-job prima di rimuovere lo scope Agno → **follow-up**, lasciato invariato.
- **Fallback postalCode/streetAddress**: per i crawler con predicato Valais rimosso, i job senza indirizzo nella sorgente ora ricevono `''` invece dell'indirizzo HQ (che sarebbe geograficamente errato a livello nazionale). Il normalize downstream applica un safe-default (log: `addressRegion defaulted 40`). Arricchimento `postalCode` per-città = **follow-up**.
- **omega / zurich / migros-hq = 0 job**: listing/feed vuoti a monte (omega `country_id=40` non ritorna job; la ricerca careers.zurich.com per paese non estrae job; il tenant SR `Migros` è deprecato/vuoto). Nessuna regressione, ma il broadening non recupera ancora job lì → **follow-up** se si vogliono recuperare (es. seed alternativi per Zurich, sorgente diversa per Migros-HQ).
- **Step "Commit and push" dei workflow `update-jobs-*`**: fallisce se il workflow è dispatchato su un **feature branch** (`git-commit-data.sh` fa `git push … main`, assente nel checkout del branch). **Il crawl riesce** (conteggi letti dai log del run). Su `main` (run schedulati) funziona regolarmente — non modificato qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
