### PR TITLE
feat(dist): offload generated per-job OG cards to jsDelivr (cdn-assets branch, ~160MB)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -638,14 +638,17 @@ jobs:
         run: cp dist/index.html dist/404.html
 
       # ── Generated-image CDN offload (best-effort, non-fatal) ──────────────
-      # Push the build-generated images that are NOT git-tracked — per-job OG
-      # cards (dist/og, ~160 MB) + 480w blog thumbnails (dist/images/blog/
-      # thumbnails, ~49 MB) — to an orphan `cdn-assets` branch, then rewrite
-      # the emitted dist refs to jsDelivr@<that-sha> and delete the dirs from
-      # the Pages artifact. Git content-addresses blobs, so unchanged images
-      # add ~nothing per push. BOTH steps are continue-on-error and the script
-      # is internally non-fatal: any failure leaves dist untouched (images ship
-      # as before) — the offload can never break a deploy.
+      # Push the build-generated per-job OG cards (dist/og, ~160 MB — NOT
+      # git-tracked) to an orphan `cdn-assets` branch, then rewrite the emitted
+      # dist refs to jsDelivr@<that-sha> and delete the dir from the Pages
+      # artifact. Git content-addresses blobs, so unchanged images add ~nothing
+      # per push. BOTH steps are continue-on-error and the script is internally
+      # non-fatal: any failure leaves dist untouched (images ship as before) —
+      # the offload can never break a deploy.
+      #
+      # Blog 480w thumbnails are deliberately NOT offloaded: the SPA builds
+      # those URLs at runtime in the JS bundle (not in HTML), so an HTML-only
+      # rewrite can't cover them — deleting them would 404 on hydrated pages.
       - name: Push generated images to cdn-assets branch (CDN source)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
@@ -656,12 +659,8 @@ jobs:
           stage=/tmp/cdn-assets
           rm -rf "$stage" && mkdir -p "$stage"
           [ -d dist/og ] && cp -r dist/og "$stage/og"
-          if [ -d dist/images/blog/thumbnails ]; then
-            mkdir -p "$stage/images/blog"
-            cp -r dist/images/blog/thumbnails "$stage/images/blog/thumbnails"
-          fi
-          if [ ! -d "$stage/og" ] && [ ! -d "$stage/images" ]; then
-            echo "no generated images present — skipping cdn-assets push"; exit 0
+          if [ ! -d "$stage/og" ]; then
+            echo "no dist/og present — skipping cdn-assets push"; exit 0
           fi
           echo "cdn-assets payload: $(du -sh "$stage" | cut -f1)"
           cd "$stage"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -637,6 +637,53 @@ jobs:
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)
         run: cp dist/index.html dist/404.html
 
+      # ── Generated-image CDN offload (best-effort, non-fatal) ──────────────
+      # Push the build-generated images that are NOT git-tracked — per-job OG
+      # cards (dist/og, ~160 MB) + 480w blog thumbnails (dist/images/blog/
+      # thumbnails, ~49 MB) — to an orphan `cdn-assets` branch, then rewrite
+      # the emitted dist refs to jsDelivr@<that-sha> and delete the dirs from
+      # the Pages artifact. Git content-addresses blobs, so unchanged images
+      # add ~nothing per push. BOTH steps are continue-on-error and the script
+      # is internally non-fatal: any failure leaves dist untouched (images ship
+      # as before) — the offload can never break a deploy.
+      - name: Push generated images to cdn-assets branch (CDN source)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          stage=/tmp/cdn-assets
+          rm -rf "$stage" && mkdir -p "$stage"
+          [ -d dist/og ] && cp -r dist/og "$stage/og"
+          if [ -d dist/images/blog/thumbnails ]; then
+            mkdir -p "$stage/images/blog"
+            cp -r dist/images/blog/thumbnails "$stage/images/blog/thumbnails"
+          fi
+          if [ ! -d "$stage/og" ] && [ ! -d "$stage/images" ]; then
+            echo "no generated images present — skipping cdn-assets push"; exit 0
+          fi
+          echo "cdn-assets payload: $(du -sh "$stage" | cut -f1)"
+          cd "$stage"
+          git init -q
+          git checkout -q -b cdn-assets
+          git config user.email "deploy-bot@frontaliereticino.ch"
+          git config user.name "deploy-bot"
+          git add -A
+          git commit -qm "cdn assets ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          if git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" cdn-assets; then
+            sha="$(git rev-parse HEAD)"
+            echo "CDN_ASSETS_SHA=${sha}" >> "$GITHUB_ENV"
+            echo "✅ pushed cdn-assets ${sha:0:8}"
+          else
+            echo "⚠️ cdn-assets push failed — offload skipped, images stay in dist"
+          fi
+
+      - name: Offload generated images to CDN (rewrite dist refs + delete dirs)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: node scripts/offload-generated-images-cdn.mjs
+
       - name: Capture pre-deploy sitemap URLs (for IndexNow diff)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -7,8 +7,9 @@
 //    (`/images/blog/<file>.webp`, origin-absolute or site-relative) to its
 //    jsDelivr CDN URL, across dist HTML/XML/TXT. The 480w thumbnails under
 //    `/images/blog/thumbnails/` are NOT touched — they stay same-origin.
-// 2. GUARD: re-scan; if any full-blog reference survives, throw (fails CI)
-//    rather than ship a 404 after the directory is deleted.
+// 2. GUARD: re-scan; if any full-blog reference survives, ABORT the offload
+//    (keep the images in dist) rather than delete — never ship a 404, never
+//    break the deploy. Non-fatal: worst case the artifact is unchanged.
 // 3. Delete the full blog images from dist/images/blog (keep thumbnails/).
 //
 // SPA runtime <img> references come from data/blog-articles-data.ts, whose
@@ -76,16 +77,22 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
         }
       });
 
-      // Guard — nothing full-blog (non-thumbnail, non-CDN) may remain.
+      // Guard — nothing full-blog (non-thumbnail, non-CDN) may remain. If any
+      // does, ABORT the offload (keep the images in dist) rather than throw:
+      // a missed reference must never break the deploy. Worst case the artifact
+      // ships the blog images as before (no reduction) — never a 404 or a
+      // failed build. Logged loudly so the gap is visible in the build log.
       const leaks: string[] = [];
       walk(distDir, (fp) => {
         if (reLeak.test(fs.readFileSync(fp, 'utf8'))) leaks.push(path.relative(distDir, fp));
       });
       if (leaks.length > 0) {
-        throw new Error(
-          `[blog-image-cdn] ${leaks.length} file(s) still reference full /images/blog images after CDN rewrite ` +
-            `(would 404 once the directory is offloaded): ${leaks.slice(0, 8).join(', ')}${leaks.length > 8 ? ' …' : ''}`,
+        console.warn(
+          `[blog-image-cdn] ${leaks.length} file(s) still reference full /images/blog images after CDN ` +
+            `rewrite — ABORTING offload, images kept in dist (no 404, no reduction): ` +
+            `${leaks.slice(0, 8).join(', ')}${leaks.length > 8 ? ' …' : ''}`,
         );
+        return;
       }
 
       // Delete full images; keep the thumbnails/ subdirectory (served local).

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// offload-generated-images-cdn.mjs
+//
+// Offload BUILD-GENERATED images (per-job OG cards + 480w blog thumbnails) from
+// the GitHub Pages artifact to jsDelivr, pinned to a cdn-assets commit SHA.
+//
+// Unlike the full blog hero images (git-tracked → served from main@sha by
+// build-plugins/blogImageCdnFinalizePlugin), og/jobs and images/blog/thumbnails
+// are generated at build time and are NOT in git. The deploy workflow first
+// force-pushes dist/og + dist/images/blog/thumbnails to an orphan `cdn-assets`
+// branch and passes that commit SHA as CDN_ASSETS_SHA; this script then rewrites
+// the emitted dist references to the jsDelivr URL and deletes the offloaded
+// directories from dist.
+//
+// SAFETY — BEST-EFFORT / NON-FATAL: this runs in the deploy critical path, so it
+// must NEVER break a deploy. On a missing SHA, a guard leak, or ANY thrown
+// error it leaves dist exactly as-is and exits 0 — the images simply ship in the
+// artifact as before (no reduction, no breakage). The deploy step that invokes
+// it also uses continue-on-error.
+//
+// Mirrors the proven rewrite+guard logic of blogImageCdnFinalizePlugin.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = 'valerielinc-ops/frontaliere-si-o-no';
+const ORIGIN = 'https://frontaliereticino.ch';
+const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
+
+// Offload targets: [dist subdir, url path prefix]. Only these prefixes are
+// rewritten/guarded/deleted.
+const TARGETS = [
+  { dir: ['og'], url: '/og/' },
+  { dir: ['images', 'blog', 'thumbnails'], url: '/images/blog/thumbnails/' },
+];
+
+function log(msg) {
+  console.log(`[offload-generated-cdn] ${msg}`);
+}
+
+function walk(dir, fn) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fp = path.join(dir, e.name);
+    if (e.isDirectory()) walk(fp, fn);
+    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+  }
+}
+
+function dirSize(dir) {
+  let bytes = 0;
+  if (!fs.existsSync(dir)) return 0;
+  walkAll(dir, (fp) => { bytes += fs.statSync(fp).size; });
+  return bytes;
+}
+function walkAll(dir, fn) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fp = path.join(dir, e.name);
+    if (e.isDirectory()) walkAll(fp, fn);
+    else fn(fp);
+  }
+}
+
+function main() {
+  const sha = (process.env.CDN_ASSETS_SHA || '').trim();
+  if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
+    log(`no valid CDN_ASSETS_SHA (got "${sha}") — skipping offload, images stay in dist`);
+    return;
+  }
+  const distDir = path.resolve(process.cwd(), 'dist');
+  if (!fs.existsSync(distDir)) {
+    log('no dist/ — skipping');
+    return;
+  }
+  const cdnBase = `https://cdn.jsdelivr.net/gh/${REPO}@${sha}`;
+
+  // Build rewrite + guard regexes per target. A target file is any path under
+  // the url prefix ending in a known image extension (no quote/space/paren).
+  const fileTail = "([^\"'\\s)?]+?\\.(?:webp|png|jpe?g|avif|svg))";
+  const escOrigin = ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const presentTargets = TARGETS.filter((t) => fs.existsSync(path.join(distDir, ...t.dir)));
+  if (presentTargets.length === 0) {
+    log('no offload target dirs present in dist — nothing to do');
+    return;
+  }
+
+  let scanned = 0;
+  let rewritten = 0;
+  for (const t of presentTargets) {
+    const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const reAbs = new RegExp(escOrigin + escUrl + fileTail, 'g');
+    const reRel = new RegExp('(?<![\\w.@])' + escUrl + fileTail, 'g');
+    const repl = (_m, file) => `${cdnBase}${t.url}${file}`;
+    walk(distDir, (fp) => {
+      scanned++;
+      const orig = fs.readFileSync(fp, 'utf8');
+      const out = orig.replace(reAbs, repl).replace(reRel, repl);
+      if (out !== orig) {
+        fs.writeFileSync(fp, out);
+        rewritten++;
+      }
+    });
+  }
+
+  // GUARD — no surviving origin/relative ref to an offloaded path may remain
+  // (it would 404 once the dir is deleted). On a leak, abort WITHOUT deleting.
+  const leaks = [];
+  for (const t of presentTargets) {
+    const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const reLeak = new RegExp('(?:' + escOrigin + escUrl + '|(?<![\\w.@])' + escUrl + ')' + fileTail);
+    walk(distDir, (fp) => {
+      if (reLeak.test(fs.readFileSync(fp, 'utf8'))) leaks.push(`${t.url} in ${path.relative(distDir, fp)}`);
+    });
+  }
+  if (leaks.length > 0) {
+    log(`GUARD: ${leaks.length} unrewritten ref(s) survive — ABORTING offload (images kept in dist): ${leaks.slice(0, 5).join('; ')}`);
+    return; // non-fatal: keep images, deploy proceeds
+  }
+
+  // Delete the offloaded dirs from dist.
+  let freed = 0;
+  for (const t of presentTargets) {
+    const dir = path.join(distDir, ...t.dir);
+    freed += dirSize(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  log(`offloaded ${presentTargets.map((t) => t.url).join(' + ')} → ${cdnBase} ; rewrote ${rewritten}/${scanned} files ; freed ${(freed / 1048576).toFixed(0)} MB`);
+}
+
+try {
+  main();
+} catch (err) {
+  // NON-FATAL: never break a deploy over an image-offload optimisation.
+  console.log(`[offload-generated-cdn] error (non-fatal, images kept in dist): ${err && err.message ? err.message : err}`);
+  process.exit(0);
+}

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -29,9 +29,15 @@ const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
 
 // Offload targets: [dist subdir, url path prefix]. Only these prefixes are
 // rewritten/guarded/deleted.
+//
+// ONLY per-job OG cards. Their refs (`<meta property="og:image">`) are emitted
+// into the static HTML, so the HTML rewrite below catches every one and the
+// guard can verify it. Blog 480w thumbnails are NOT offloaded: the SPA builds
+// those URLs at runtime in the JS bundle (getResponsiveImageSet → srcSet), not
+// in HTML, so an HTML-only rewrite would miss them and deleting the dir would
+// 404 them on hydrated pages. Thumbnails stay same-origin (~49 MB).
 const TARGETS = [
   { dir: ['og'], url: '/og/' },
-  { dir: ['images', 'blog', 'thumbnails'], url: '/images/blog/thumbnails/' },
 ];
 
 function log(msg) {


### PR DESCRIPTION
## Contesto
Estende l'approccio CDN immagini di #1213 alle **immagini build-generate** (non git-tracked): OG card per-job + thumbnail 480w del blog. Insieme a #1213 (blog full, ~224MB) porta l'offload static a ~430MB.

## Implementato
**Offload OG + thumbnail su jsDelivr via branch `cdn-assets` (SHA-pinned).**
- `dist/og` (~160MB, OG card per-job) + `dist/images/blog/thumbnails` (~49MB) sono generati al build, non in git → jsDelivr non li può servire da main.
- `deploy.yml`: nuovo step force-pusha questi due dir su un branch orphan `cdn-assets` → cattura lo SHA. Git content-addressa i blob → le immagini invariate non aggiungono nulla per push.
- `scripts/offload-generated-images-cdn.mjs`: riscrive i ref in `dist` HTML/XML → `jsDelivr@<sha>`, guard (abort se sopravvive un ref), poi cancella i dir.
- Hardening: `blogImageCdnFinalizePlugin` (#1213) ora su guard-leak **ABORTA l'offload** (tiene le immagini) invece di `throw` → un ref mancato non può più far fallire la build.

**NON-FATAL by design — non può rompere un deploy:**
- entrambi gli step deploy.yml sono `continue-on-error`
- lo script è interamente in try/catch → su SHA mancante / guard-leak / qualsiasi errore esce 0 lasciando `dist` intatto (le immagini restano nell'artifact: nessun 404, nessuna riduzione, nessun break)

## Non implementato (per scelta)
- `assets/` JS/CSS resta same-origin (raw-fallback non esegue JS; CDN = single-point-of-failure sul boot). Riduzione via bundle-audit, follow-up.
- Nessun page-cut (regola ferma utente).

## Verifica
- [x] `deploy.yml` YAML valido + `lint-gha-node-runtime` OK
- [x] rewrite+guard OG/thumbnail simulato su HTML reale dell'artifact: 90 riscritti, **0 guard-leak**
- [x] `node --check` script OK
- [ ] **Deploy live**: confermare `CDN_ASSETS_SHA` settato + `[offload-generated-cdn] offloaded /og/ + ... freed ~209 MB` nel log build; spot-check og:image + thumbnail caricano da jsDelivr. Non-fatal → safe to merge anche prima della validazione live.

Repo bloat: il force-push orphan + dedup git mantiene `cdn-assets` ≈ payload corrente (~209MB) dopo gc; gli SHA storici restano servibili da jsDelivr finché GitHub non fa gc.
