### PR TITLE
fix(images): swiss articles hero images broken on live (CDN regression from #1213)

### DIFF
--- a/data/swiss-articles-data.ts
+++ b/data/swiss-articles-data.ts
@@ -10,10 +10,13 @@
  * `services/routerSwissData.ts`. See `services/articleSections.ts`.
  */
 import type { Article } from './blog-articles-data';
+// Relative (not `@/`): this module is in vite.config's build graph; the config
+// loader can't resolve `@/`. See feedback_no_alias_imports_in_config_graph.
+import { cdnBlogImage } from '../services/seo/blogImageCdn';
 
 export type { Article };
 
-export const SWISS_ARTICLES: Article[] = [
+const RAW_SWISS_ARTICLES: Article[] = [
   {
     id: 'costo-vita-svizzera-2026',
     category: 'pratico',
@@ -123,3 +126,12 @@ export const SWISS_ARTICLES: Article[] = [
     authorName: 'Marco Ferrari',
    },
 ];
+
+// Full blog hero images are served from jsDelivr (CDN) and deleted from the
+// Pages artifact (build-plugins/blogImageCdnFinalizePlugin) — so the runtime
+// export must point at the CDN, exactly like blog-articles-data.ts. The raw
+// literals above stay site-relative for the regex-parsing build plugins.
+export const SWISS_ARTICLES: Article[] = RAW_SWISS_ARTICLES.map((a) => ({
+  ...a,
+  image: cdnBlogImage(a.image),
+}));


### PR DESCRIPTION
## Urgent — live prod breakage
Hero images invisible on `/articoli-svizzera/*` (e.g. neutralizzazione-stime-2026-classi-media).

## Implementato
Regression from #1213: the blog-image CDN offload deletes `dist/images/blog`, so the SPA must reference the jsDelivr URL at runtime. `blog-articles-data.ts` was transformed (ARTICLES → cdnBlogImage), but **`swiss-articles-data.ts`** (national mirror, 10 `/images/blog` refs, same `BlogArticles` component, `section='svizzera'`) was **not** → the SPA re-rendered swiss hero images at the origin path which no longer exists → 404 after hydration.

Fix: mirror the blog-articles-data transform — `RAW_SWISS_ARTICLES` + mapped `SWISS_ARTICLES` export running `image` through `cdnBlogImage`. **Relative** import (not `@/`) since this file is in vite.config's build graph (the #1240 lesson).

## Non implementato
Only these two data files reference `/images/blog` (verified) — no other source affected.

## Verifica
- [x] esbuild config-load (`--tsconfig-raw='{}'`) clean → no `@/` break
- [x] jsDelivr@sha serves the image (HTTP 200)
- [x] edits mirror the working blog-articles-data fix exactly