### PR TITLE
perf(cdn): single-pass image-offload finalize scan (~16min → ~8min)

### DIFF
--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -43,31 +43,17 @@ const reLeak = new RegExp(
   '(?:' + ESC_ORIGIN + '/images/blog/|(?<![\\w.@])/images/blog/)(?!thumbnails/)' + FILE,
 );
 
-// Perf: full blog hero images are referenced ONLY in article pages, feeds, and
-// sitemaps — never in the job-board corpus (cerca-lavoro-* / find-jobs-* /
-// stellensuche-* / jobs-im-* / trouver-emploi-* and the search-cluster `ricerca`
-// tree), which is ~700k of the ~1.2M emitted files and carries ZERO /images/blog
-// references (verified across all 4 locales). Skipping those dirs turns a ~16min
-// scan into seconds. The dirs are matched at the dist root (and one level under
-// each locale prefix), so article dirs like `articoli-frontaliere/` and
-// `en/cross-border-articles/` are always scanned.
-const SKIP_TOPDIR_RX = /^cerca-lavoro-|^ricerca$/;
-const SKIP_LOCALEDIR_RX = /^(find-jobs-|stellensuche-|jobs-im-|trouver-emploi-|emploi|cerca-lavoro-)/;
-const LOCALE_PREFIXES = new Set(['en', 'de', 'fr']);
-
-function walk(distDir: string, dir: string, fn: (fp: string) => void): void {
+// Perf: the original finalize scanned every file TWICE (a rewrite pass + a
+// separate guard pass). The single pass in closeBundle below rewrites and
+// verifies each file in one read — halving the I/O — while the guard still
+// covers EVERY emitted file (no dir is skipped), so a stray /images/blog
+// reference anywhere (even in the job-board corpus, which today carries none)
+// is still caught before any image is deleted.
+function walk(dir: string, fn: (fp: string) => void): void {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
-    if (e.isDirectory()) {
-      const rel = path.relative(distDir, fp);
-      const parts = rel.split(path.sep);
-      // Skip job-board / search-cluster dirs (zero blog refs) for speed.
-      if (parts.length === 1 && SKIP_TOPDIR_RX.test(parts[0])) continue;
-      if (parts.length === 2 && LOCALE_PREFIXES.has(parts[0]) && SKIP_LOCALEDIR_RX.test(parts[1])) continue;
-      walk(distDir, fp, fn);
-    } else if (SCAN_EXT.has(path.extname(e.name))) {
-      fn(fp);
-    }
+    if (e.isDirectory()) walk(fp, fn);
+    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
   }
 }
 
@@ -94,7 +80,7 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
       // deploy. Worst case the artifact ships the blog images as before (no
       // reduction) — never a 404 or a failed build.
       const leaks: string[] = [];
-      walk(distDir, distDir, (fp) => {
+      walk(distDir, (fp) => {
         scanned++;
         const orig = fs.readFileSync(fp, 'utf8');
         const out = orig.replace(reAbs, repl).replace(reRel, repl);

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -43,11 +43,31 @@ const reLeak = new RegExp(
   '(?:' + ESC_ORIGIN + '/images/blog/|(?<![\\w.@])/images/blog/)(?!thumbnails/)' + FILE,
 );
 
-function walk(dir: string, fn: (fp: string) => void): void {
+// Perf: full blog hero images are referenced ONLY in article pages, feeds, and
+// sitemaps — never in the job-board corpus (cerca-lavoro-* / find-jobs-* /
+// stellensuche-* / jobs-im-* / trouver-emploi-* and the search-cluster `ricerca`
+// tree), which is ~700k of the ~1.2M emitted files and carries ZERO /images/blog
+// references (verified across all 4 locales). Skipping those dirs turns a ~16min
+// scan into seconds. The dirs are matched at the dist root (and one level under
+// each locale prefix), so article dirs like `articoli-frontaliere/` and
+// `en/cross-border-articles/` are always scanned.
+const SKIP_TOPDIR_RX = /^cerca-lavoro-|^ricerca$/;
+const SKIP_LOCALEDIR_RX = /^(find-jobs-|stellensuche-|jobs-im-|trouver-emploi-|emploi|cerca-lavoro-)/;
+const LOCALE_PREFIXES = new Set(['en', 'de', 'fr']);
+
+function walk(distDir: string, dir: string, fn: (fp: string) => void): void {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
-    if (e.isDirectory()) walk(fp, fn);
-    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+    if (e.isDirectory()) {
+      const rel = path.relative(distDir, fp);
+      const parts = rel.split(path.sep);
+      // Skip job-board / search-cluster dirs (zero blog refs) for speed.
+      if (parts.length === 1 && SKIP_TOPDIR_RX.test(parts[0])) continue;
+      if (parts.length === 2 && LOCALE_PREFIXES.has(parts[0]) && SKIP_LOCALEDIR_RX.test(parts[1])) continue;
+      walk(distDir, fp, fn);
+    } else if (SCAN_EXT.has(path.extname(e.name))) {
+      fn(fp);
+    }
   }
 }
 
@@ -67,7 +87,14 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
       const repl = (_m: string, file: string): string => `${JSDELIVR_BLOG_BASE}/${file}`;
       let scanned = 0;
       let rewritten = 0;
-      walk(distDir, (fp) => {
+      // Single pass: rewrite each file, then verify the RESULT in-memory (no
+      // second filesystem scan). Guard — nothing full-blog (non-thumbnail,
+      // non-CDN) may remain. If any does, ABORT the offload (keep the images
+      // in dist) rather than throw: a missed reference must never break the
+      // deploy. Worst case the artifact ships the blog images as before (no
+      // reduction) — never a 404 or a failed build.
+      const leaks: string[] = [];
+      walk(distDir, distDir, (fp) => {
         scanned++;
         const orig = fs.readFileSync(fp, 'utf8');
         const out = orig.replace(reAbs, repl).replace(reRel, repl);
@@ -75,16 +102,7 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
           fs.writeFileSync(fp, out);
           rewritten++;
         }
-      });
-
-      // Guard — nothing full-blog (non-thumbnail, non-CDN) may remain. If any
-      // does, ABORT the offload (keep the images in dist) rather than throw:
-      // a missed reference must never break the deploy. Worst case the artifact
-      // ships the blog images as before (no reduction) — never a 404 or a
-      // failed build. Logged loudly so the gap is visible in the build log.
-      const leaks: string[] = [];
-      walk(distDir, (fp) => {
-        if (reLeak.test(fs.readFileSync(fp, 'utf8'))) leaks.push(path.relative(distDir, fp));
+        if (reLeak.test(out)) leaks.push(path.relative(distDir, fp));
       });
       if (leaks.length > 0) {
         console.warn(

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
 // offload-generated-images-cdn.mjs
 //
-// Offload BUILD-GENERATED images (per-job OG cards + 480w blog thumbnails) from
-// the GitHub Pages artifact to jsDelivr, pinned to a cdn-assets commit SHA.
+// Offload BUILD-GENERATED per-job OG cards (dist/og) from the GitHub Pages
+// artifact to jsDelivr, pinned to a cdn-assets commit SHA.
+//
+// (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
+// the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
+// stay same-origin. Only og:image refs, which ARE in static HTML, move.)
 //
 // Unlike the full blog hero images (git-tracked → served from main@sha by
-// build-plugins/blogImageCdnFinalizePlugin), og/jobs and images/blog/thumbnails
-// are generated at build time and are NOT in git. The deploy workflow first
-// force-pushes dist/og + dist/images/blog/thumbnails to an orphan `cdn-assets`
-// branch and passes that commit SHA as CDN_ASSETS_SHA; this script then rewrites
+// build-plugins/blogImageCdnFinalizePlugin), og/jobs is generated at build time
+// and is NOT in git. The deploy workflow first force-pushes dist/og to an
+// orphan `cdn-assets` branch and passes that commit SHA as CDN_ASSETS_SHA;
+// this script then rewrites
 // the emitted dist references to the jsDelivr URL and deletes the offloaded
 // directories from dist.
 //
@@ -90,34 +94,40 @@ function main() {
     return;
   }
 
+  // Precompile per-target regexes once (og:image refs live in EVERY page's
+  // <head>, so no dir can be skipped — but a single pass over each file that
+  // rewrites AND verifies in-memory avoids a second filesystem scan).
+  const compiled = presentTargets.map((t) => {
+    const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return {
+      t,
+      reAbs: new RegExp(escOrigin + escUrl + fileTail, 'g'),
+      reRel: new RegExp('(?<![\\w.@])' + escUrl + fileTail, 'g'),
+      reLeak: new RegExp('(?:' + escOrigin + escUrl + '|(?<![\\w.@])' + escUrl + ')' + fileTail),
+      repl: (_m, file) => `${cdnBase}${t.url}${file}`,
+    };
+  });
+
   let scanned = 0;
   let rewritten = 0;
-  for (const t of presentTargets) {
-    const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const reAbs = new RegExp(escOrigin + escUrl + fileTail, 'g');
-    const reRel = new RegExp('(?<![\\w.@])' + escUrl + fileTail, 'g');
-    const repl = (_m, file) => `${cdnBase}${t.url}${file}`;
-    walk(distDir, (fp) => {
-      scanned++;
-      const orig = fs.readFileSync(fp, 'utf8');
-      const out = orig.replace(reAbs, repl).replace(reRel, repl);
-      if (out !== orig) {
-        fs.writeFileSync(fp, out);
-        rewritten++;
-      }
-    });
-  }
-
-  // GUARD — no surviving origin/relative ref to an offloaded path may remain
-  // (it would 404 once the dir is deleted). On a leak, abort WITHOUT deleting.
+  // Single pass: rewrite every target in the file, then verify the result
+  // in-memory. GUARD — no surviving origin/relative ref to an offloaded path
+  // may remain (it would 404 once the dir is deleted). On a leak, abort
+  // WITHOUT deleting.
   const leaks = [];
-  for (const t of presentTargets) {
-    const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const reLeak = new RegExp('(?:' + escOrigin + escUrl + '|(?<![\\w.@])' + escUrl + ')' + fileTail);
-    walk(distDir, (fp) => {
-      if (reLeak.test(fs.readFileSync(fp, 'utf8'))) leaks.push(`${t.url} in ${path.relative(distDir, fp)}`);
-    });
-  }
+  walk(distDir, (fp) => {
+    scanned++;
+    const orig = fs.readFileSync(fp, 'utf8');
+    let out = orig;
+    for (const c of compiled) out = out.replace(c.reAbs, c.repl).replace(c.reRel, c.repl);
+    if (out !== orig) {
+      fs.writeFileSync(fp, out);
+      rewritten++;
+    }
+    for (const c of compiled) {
+      if (c.reLeak.test(out)) leaks.push(`${c.t.url} in ${path.relative(distDir, fp)}`);
+    }
+  });
   if (leaks.length > 0) {
     log(`GUARD: ${leaks.length} unrewritten ref(s) survive — ABORTING offload (images kept in dist): ${leaks.slice(0, 5).join('; ')}`);
     return; // non-fatal: keep images, deploy proceeds


### PR DESCRIPTION
## Implementato
The blog-image-cdn finalize plugin scanned every emitted file **twice** (~941s/16min in the build): a rewrite pass + a separate full-tree guard pass. Collapse them into **one** filesystem pass — rewrite each file, then verify the result **in-memory** — so the guard still covers EVERY file (full defense-in-depth, no dir skipped) while halving I/O. Same single-pass applied to the og offload script.

## Non implementato (per reviewer 🔴)
An earlier revision also **skipped job-board dirs** for extra speed, but the reviewer correctly flagged that folding the guard into a dir-skipping walk shrank the guard's coverage (a stray /images/blog ref in a skipped dir could 404 after delete) — and the skip list had drifted from the router (jobs-im- vs jobs-in-). **The skip was removed**; only the risk-free single-pass remains. So the realistic win is ~16min → **~8min** (halved), not 'seconds'.

## Safety
Both scans stay **non-fatal**: a guard leak aborts the offload (keeps images), never a 404 / broken build. Guard now re-covers the full tree.

## Verifica
- [x] tsc clean; node --check og script
- [x] single-pass output reasoned byte-equivalent to the two-loop version (reLeak tests the rewritten `out` = what the old guard re-read)
- [ ] live: next build's `blog-image-cdn-finalize` profile drops from ~941s toward ~450-500s