### PR TITLE
fix(seo): drop migros-ticino from brand aliases — real subsidiary, not a dedup alias

### DIFF
--- a/build-plugins/shared/brandCanonicalMap.ts
+++ b/build-plugins/shared/brandCanonicalMap.ts
@@ -86,15 +86,19 @@ export const BRAND_CANONICAL_MAP: Readonly<Record<string, BrandCanonicalEntry>> 
   // jobs from Migros-group entities present in the dataset (Banca
   // Migros, Scuola Club Migros, Cooperativa Migros Ticino, ...) and
   // renders them on a single indexable hub page. The cosmetic
-  // brand-search variations `migros-ticino` and `gruppo-migros`
-  // bridge to the umbrella canonical to consolidate brand signals.
-  // Real subsidiary hubs (banca-migros, scuola-club-migros, ...)
-  // keep their own distinct canonicals — they are real, separate
-  // employers and must NOT bridge to the umbrella.
+  // brand-search variation `gruppo-migros` bridges to the umbrella
+  // canonical to consolidate brand signals.
+  // Real subsidiary hubs (banca-migros, scuola-club-migros,
+  // migros-ticino — i.e. Cooperativa Migros Ticino, ...) keep their
+  // own distinct canonicals — they are real, separate employers with
+  // their own jobs in the dataset and must NOT be declared aliases
+  // here, or the company-hub emitter would noindex-bridge their real
+  // indexable hub away (regression: `migros-ticino` was wrongly listed
+  // as an alias yet resolves to a real subsidiary → its self-canonical
+  // hub collided with the brand-dedup contract, main red 2026-06-03).
   'migros': {
     canonical: 'migros',
     aliases: [
-      'migros-ticino',
       'gruppo-migros',
     ],
   },


### PR DESCRIPTION
## Implementato

`main` rosso (run 26875963867, gate `gate:seo-source` → `validate-dist` fail post-deploy). Root cause: il test committed `tests/seo/brand-dedup.test.ts` fallisce perché l'alias `migros-ticino` emette un hub **self-canonical** invece di un noindex bridge → primary:

```
FAIL  every alias slug points canonical to the primary (not self) and is noindex
  Expected: "/cerca-lavoro-ticino/azienda-migros/"
  Received: "https://.../cerca-lavoro-ticino/azienda-migros-ticino/"
```

`migros-ticino` = **Cooperativa Migros Ticino**, datore reale con job propri nel dataset (HQ registrato in `companyHqAddresses.ts`: Via Serrai 1, 6592 S. Antonino TI; city-hub `azienda-migros-ticino-aarwangen` presente nel dist). Il loop company-hub (`jobsSeoPagesPlugin.ts`, no filtro `isBrandAlias`) scrive l'hub self-canonical con `_qw` incondizionato → vince sul bridge noindex (`if !exists`) → contratto brand-dedup violato.

Listare un slug che risolve a una company reale tra gli alias **contraddice la policy già documentata nel file stesso**: «Real subsidiary hubs (banca-migros, scuola-club-migros, …) keep their own distinct canonicals … must NOT bridge to the umbrella».

Fix: rimosso `'migros-ticino'` dall'array `aliases` di `migros` in `build-plugins/shared/brandCanonicalMap.ts`. Ora `migros-ticino` emette un hub self-canonical indicizzabile legittimo (come `banca-migros`/`scuola-club-migros`). Commento aggiornato per spiegare la regola e marcare la regressione. **Zero page-loss** (nessuna pagina rimossa/noindex; al contrario, ripristina l'hub reale). `gruppo-migros` (cosmetico, nessuna company reale) resta come noindex bridge → `migros`.

Verifica locale: `npx vitest run tests/seo/brand-dedup.test.ts` → 9 passed, 3 skipped (build-output skip senza dist locale). I test map-level passano con `migros-ticino` rimosso. La parte build-output (dist) ora non itera più su `migros-ticino` → assertion eliminata alla radice; `gruppo-migros` bridge → canonical `/azienda-migros/` (già verde pre-fix). GitNexus `detect_changes`: risk none (data-const literal).

Closes #1247

## Non implementato (ancora)

- **Guard difensivo nell'emitter** (`if (isBrandAlias(cSlug)) skip self-canonical emit`) per pre-emptare collisioni future alias↔company-reale su altri brand (guess/medacta/casale): **deliberatamente scartato**. Convertirebbe in noindex un eventuale futuro hub reale collidente (page-loss silenzioso, contro policy «never cut pages without OK»). Nessun sibling è attualmente rotto (guess/medacta/casale non hanno company reali collidenti in `known-company-slugs.json`). La protezione di classe esiste già: il test committed `brand-dedup` cattura ogni collisione futura come red esplicito (è così che questa è emersa). Out of scope qui.
- `validate-live` dello stesso run = `propagation_timeout` (build-id non ancora live entro 240s; live = build precedente VALIDO). Classe nota benigna (backlog Pages), non rollback, non correlata a questo fix. Nessuna azione.