### PR TITLE
fix(seo): consolidate nationwide migros-ticino onto azienda-migros umbrella (refines #1274)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2224,6 +2224,18 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  return slugifyCompanyBuild(company);
  };
 
+ // Company-hub URL slug: same as canonicalCompanySlugBuild but folds declared
+ // brand aliases onto their canonical (e.g. migros-ticino → migros). Use this
+ // EVERYWHERE a company-hub page is emitted OR linked (per-canton hubs, job-page
+ // banner/footer, canton navigator) so emit and links agree on one canonical
+ // slug and an alias never produces an indexable self-hub or an orphan link to
+ // an un-emitted page. The raw companyMap key (companyMap construction) stays
+ // unfolded so the BRAND_UMBRELLAS aggregation still sees each real key.
+ const companyHubSlugBuild = (company: string, companyKey?: string): string => {
+ const raw = canonicalCompanySlugBuild(company, companyKey);
+ return raw ? (resolveBrandCanonical(raw) ?? raw) : raw;
+ };
+
  // ── Pre-compute title-collision map per locale ──
  // The base <title> formula (role + company + city) collapses to identical
  // strings whenever two jobs differ only by slug suffix (AFC vs CFP variants),
@@ -2937,7 +2949,7 @@ ${staticAnalyticsHtml}
  </article>
  ${renderRightRail({ job, locale, addressLocality, addressRegion, postalCode, salaryMin, salaryText, canonicalKeywords, esc })}
  ${(() => {
- const cSlugBanner = canonicalCompanySlugBuild(job.company, job.companyKey);
+ const cSlugBanner = companyHubSlugBuild(job.company, job.companyKey);
  // Relative href — internal navigation resolves against canonical (absolute).
  const cHref = withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}/${companyRoutePrefix[locale]}-${cSlugBanner}`.replace(/\/+/g, '/'));
  const cLogo = companyLogo(job);
@@ -3185,7 +3197,7 @@ ${staticAnalyticsHtml}
  })()}
  <nav class="fn">
  <a href="${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}`.replace(/\/+/g, '/'))}" class="lnk-acc">${esc(cantonSectionName(locale, dc))} &rarr;</a>${(() => {
- const cSlug = canonicalCompanySlugBuild(job.company, job.companyKey);
+ const cSlug = companyHubSlugBuild(job.company, job.companyKey);
  if (!cSlug) return '';
  const cPrefix = companyRoutePrefix[locale];
  const cFullSlug = `${cPrefix}-${cSlug}`;
@@ -6890,12 +6902,8 @@ ${staticAnalyticsHtml}
  for (const job of validJobs) {
  const c = sharedResolveJobCanton(job as { canton?: string; location?: string });
  if (c === 'TI') continue;
- const rawCanon = canonicalCompanySlugBuild(job.company, job.companyKey);
- if (!rawCanon) continue;
- // Fold brand aliases (e.g. migros-ticino → migros) onto the canonical
- // umbrella so per-canton hubs consolidate under /azienda-{canonical}/ and
- // never emit an indexable alias-slug page (brand-dedup contract).
- const canonical = resolveBrandCanonical(rawCanon) ?? rawCanon;
+ const canonical = companyHubSlugBuild(job.company, job.companyKey);
+ if (!canonical) continue;
  if (!cantonCompanyBuckets.has(c)) cantonCompanyBuckets.set(c, new Map());
  const byCompany = cantonCompanyBuckets.get(c)!;
  if (!byCompany.has(canonical)) byCompany.set(canonical, { name: job.company, jobs: [] });
@@ -7107,12 +7115,8 @@ ${staticAnalyticsHtml}
  for (const job of validJobs) {
  const c = sharedResolveJobCanton(job as { canton?: string; location?: string });
  if (c === 'TI') continue;
- const rawCanon = canonicalCompanySlugBuild(job.company, job.companyKey);
- if (!rawCanon) continue;
- // Fold brand aliases (e.g. migros-ticino → migros) onto the canonical
- // umbrella so per-canton company×city hubs consolidate under
- // /azienda-{canonical}/ and never emit an indexable alias-slug page.
- const canonical = resolveBrandCanonical(rawCanon) ?? rawCanon;
+ const canonical = companyHubSlugBuild(job.company, job.companyKey);
+ if (!canonical) continue;
  const rawLocation = String((job as any).location || '').split(/[,(]/)[0].trim();
  if (!rawLocation) continue;
  const citySlug = normalizeCitySlug(rawLocation);
@@ -8987,9 +8991,11 @@ ${staticAnalyticsHtml}
        // BFS-depth closure (Phase 8a follow-up — May 2026): top company hubs
        // (`/cerca-lavoro-{canton}/azienda-{empKey}/`) are emitted by the
        // per-canton company-hub block (~line 6275-6400) using
-       // `canonicalCompanySlugBuild`, gated MIN_JOBS_PER_CANTON_COMPANY=3.
-       // Re-derive the slug here using the SAME `canonicalCompanySlugBuild`
-       // helper so the hrefs exactly match what's emitted. Top 6 by job
+       // `companyHubSlugBuild`, gated MIN_JOBS_PER_CANTON_COMPANY=3.
+       // Re-derive the slug here using the SAME `companyHubSlugBuild`
+       // helper (brand-alias-folded) so the hrefs exactly match what's
+       // emitted — an alias like migros-ticino folds to azienda-migros, the
+       // page that is actually written. Top 6 by job
        // count keeps the navigator focused; ties broken by slug for
        // determinism.
        const companyHubs: Array<{ slug: string; label: string }> = [];
@@ -8997,7 +9003,7 @@ ${staticAnalyticsHtml}
          const companyCounts = new Map<string, { name: string; count: number }>();
          for (const j of cantonJobsAll) {
            const jc = j as { company?: string; companyKey?: string };
-           const cSlug = canonicalCompanySlugBuild(jc.company || '', jc.companyKey);
+           const cSlug = companyHubSlugBuild(jc.company || '', jc.companyKey);
            if (!cSlug) continue;
            const cur = companyCounts.get(cSlug);
            if (cur) { cur.count++; }

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -3531,6 +3531,13 @@ ${staticAnalyticsHtml}
 
  let companyPagesCount = 0;
  for (const [cSlug, { name: companyName, jobs: companyJobs, rawSlugs }] of companyMap) {
+ // Brand aliases (e.g. migros-ticino → migros umbrella) must NOT self-emit an
+ // indexable hub here: their jobs already surface on the canonical umbrella via
+ // the BRAND_UMBRELLAS aggregation above, and the alias URL is owned by the
+ // noindex bridge block below (BRAND_CANONICAL_MAP). Self-emitting would write an
+ // indexable page first, defeating that bridge's file-exists guard and
+ // duplicating umbrella content (brand-dedup main-red #1247 / PR #1274).
+ if (isBrandAlias(cSlug)) continue;
  for (const locale of localeList) {
  const __tCompany = startTimer();
  const prefix = companyRoutePrefix[locale];

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -63,6 +63,7 @@ import {
  BRAND_CANONICAL_MAP,
  isBrandAlias,
  listAllBrandAliases,
+ resolveBrandCanonical,
 } from './shared/brandCanonicalMap';
 import {
  buildJobCareVariantLandingModel,
@@ -4103,7 +4104,10 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  // Ratchet: only write if the new set is at least as large as the existing one
  // to prevent fixture-data local builds from corrupting the production list.
  {
- const companySlugs = [...companyMap.keys()].sort();
+ // Exclude brand aliases (e.g. migros-ticino) — they resolve to a noindex
+ // bridge, so CompaniesHub / employerLinks must not surface them as real
+ // company hubs (mirrors the sitemap filter at the alias-aware emitter).
+ const companySlugs = [...companyMap.keys()].filter((s) => !isBrandAlias(s)).sort();
  const companySlugsPath = np.resolve(rootDir, 'data/known-company-slugs.json');
  let existingCount = 0;
  try {
@@ -6886,8 +6890,12 @@ ${staticAnalyticsHtml}
  for (const job of validJobs) {
  const c = sharedResolveJobCanton(job as { canton?: string; location?: string });
  if (c === 'TI') continue;
- const canonical = canonicalCompanySlugBuild(job.company, job.companyKey);
- if (!canonical) continue;
+ const rawCanon = canonicalCompanySlugBuild(job.company, job.companyKey);
+ if (!rawCanon) continue;
+ // Fold brand aliases (e.g. migros-ticino → migros) onto the canonical
+ // umbrella so per-canton hubs consolidate under /azienda-{canonical}/ and
+ // never emit an indexable alias-slug page (brand-dedup contract).
+ const canonical = resolveBrandCanonical(rawCanon) ?? rawCanon;
  if (!cantonCompanyBuckets.has(c)) cantonCompanyBuckets.set(c, new Map());
  const byCompany = cantonCompanyBuckets.get(c)!;
  if (!byCompany.has(canonical)) byCompany.set(canonical, { name: job.company, jobs: [] });
@@ -7099,8 +7107,12 @@ ${staticAnalyticsHtml}
  for (const job of validJobs) {
  const c = sharedResolveJobCanton(job as { canton?: string; location?: string });
  if (c === 'TI') continue;
- const canonical = canonicalCompanySlugBuild(job.company, job.companyKey);
- if (!canonical) continue;
+ const rawCanon = canonicalCompanySlugBuild(job.company, job.companyKey);
+ if (!rawCanon) continue;
+ // Fold brand aliases (e.g. migros-ticino → migros) onto the canonical
+ // umbrella so per-canton company×city hubs consolidate under
+ // /azienda-{canonical}/ and never emit an indexable alias-slug page.
+ const canonical = resolveBrandCanonical(rawCanon) ?? rawCanon;
  const rawLocation = String((job as any).location || '').split(/[,(]/)[0].trim();
  if (!rawLocation) continue;
  const citySlug = normalizeCitySlug(rawLocation);

--- a/build-plugins/shared/brandCanonicalMap.ts
+++ b/build-plugins/shared/brandCanonicalMap.ts
@@ -82,23 +82,30 @@ export const BRAND_CANONICAL_MAP: Readonly<Record<string, BrandCanonicalEntry>> 
   },
   // Migros umbrella canonical. The `migros` slug is a synthetic
   // umbrella hub (NOT a real subsidiary) injected by the
-  // jobsSeoPagesPlugin company aggregation: it pulls together all
-  // jobs from Migros-group entities present in the dataset (Banca
-  // Migros, Scuola Club Migros, Cooperativa Migros Ticino, ...) and
-  // renders them on a single indexable hub page. The cosmetic
-  // brand-search variation `gruppo-migros` bridges to the umbrella
-  // canonical to consolidate brand signals.
-  // Real subsidiary hubs (banca-migros, scuola-club-migros,
-  // migros-ticino — i.e. Cooperativa Migros Ticino, ...) keep their
-  // own distinct canonicals — they are real, separate employers with
-  // their own jobs in the dataset and must NOT be declared aliases
-  // here, or the company-hub emitter would noindex-bridge their real
-  // indexable hub away (regression: `migros-ticino` was wrongly listed
-  // as an alias yet resolves to a real subsidiary → its self-canonical
-  // hub collided with the brand-dedup contract, main red 2026-06-03).
+  // jobsSeoPagesPlugin company aggregation (BRAND_UMBRELLAS regex): it
+  // unions all jobs from Migros-group entities present in the dataset
+  // (Banca Migros, Scuola Club Migros, Cooperativa Migros Ticino, ...)
+  // onto a single indexable hub page `azienda-migros`. This union is
+  // driven by a name/slug regex, INDEPENDENT of the aliases below, so
+  // an alias's jobs always still surface on the umbrella — declaring an
+  // alias here never orphans its jobs.
+  //
+  // `migros-ticino` is the nationwide Migros crawler key (widened to
+  // all 26 cantons by #1231: 483 jobs, only ~7 in Ticino). Letting its
+  // hub `azienda-migros-ticino` stay self-canonical+indexable (PR #1274)
+  // made TWO indexable hubs carry the same 483 jobs → duplicate content
+  // (#1247). So it bridges to the umbrella here, alongside the cosmetic
+  // `gruppo-migros` variation, consolidating all brand signals on one
+  // canonical. The company-hub emitter skips self-emitting a hub for any
+  // alias key (`isBrandAlias` guard in jobsSeoPagesPlugin) so the
+  // noindex bridge owns the alias path.
+  //
+  // Real, SEPARATE subsidiary hubs (banca-migros, scuola-club-migros)
+  // are NOT aliases — they keep their own distinct indexable canonicals.
   'migros': {
     canonical: 'migros',
     aliases: [
+      'migros-ticino',
       'gruppo-migros',
     ],
   },


### PR DESCRIPTION
## Implementato

Follow-up di #1274. Dopo #1231 (crawler `migros-ticino` nationwide: **483 job, ~7 in TI**), l'umbrella `azienda-migros` aggrega gli stessi job via regex `BRAND_UMBRELLAS` → con #1274 (che rese `azienda-migros-ticino` self-canonical) si avevano **due hub indicizzabili con contenuto identico = duplicate content**. Questa PR consolida tutto su un unico hub canonico.

Root cause: gli emitter company-hub auto-emettono un hub indicizzabile per **ogni** companyKey (alias inclusi); il bridge noindex si auto-salta per `!fs.existsSync`.

Fix — un helper unico `companyHubSlugBuild` (= `canonicalCompanySlugBuild` + `resolveBrandCanonical` fold) instradato su **tutti i 5 siti hub-URL** (2 emit + 3 link), così emit e link concordano sempre su uno slug canonico:
- **Loop emit TI (`:3540`)**: `if (isBrandAlias(cSlug)) continue;` → l'alias non si auto-emette; il bridge del primary possiede `azienda-migros-ticino` (TI) come noindex. I job restano: l'umbrella regex li ha già unionati su `azienda-migros`.
- **Per-canton emit (Phase 3.3 + 3.4)**: bucketano da `validJobs` reali (no umbrella sintetico) → re-key alias→canonical via helper → consolidano su `/cerca-lavoro-{canton}/azienda-migros/(-{city})`, mai slug alias, nessun orfano.
- **Link derivations (banner job-page `:2940`, footer `:3188`, navigator canton-hub `:9000`)**: stesso helper → i link interni puntano all'hub realmente emesso (`azienda-migros`), non a `azienda-migros-ticino` (mai emesso off-TI → era soft-404 + hub orfano, regressione del round-1 ora chiusa).
- **`known-company-slugs.json` writer (`:4106`)**: filtra `!isBrandAlias` (come sitemap) → CompaniesHub/employerLinks non linkano lo slug bridge.

La chiave `companyMap` (`:3496`) resta **non-foldata** così `BRAND_UMBRELLAS` continua a vedere ogni key reale per l'aggregazione. Verificato: un solo `canonicalCompanySlugBuild` raw residuo (companyMap), helper su tutti i 5 siti hub-URL.

Risultato: `azienda-migros` = **unico hub Migros indicizzabile su TUTTI i cantoni**, con link interni in entrata (no orfani, BFS-depth chiusa); `azienda-migros-ticino` = solo bridge noindex (TI).

Semantica verificata runtime: `isBrandAlias`: `migros`→false, `migros-ticino`/`gruppo-migros`→true, `banca-migros`/`scuola-club-migros`→false. `resolveBrandCanonical('migros-ticino')`→`migros`, non-alias→null→fallback. Adversarial: `companyCityMatches (:3403)` costruisce chip città/settore, non link `azienda-{company}-{city}` → nessun'altra derivazione link raw.

Test: brand-dedup (12, incl. assert dist-level alias→noindex→primary), employer-brand-hub (54), brand-logos (8) verdi; zero nuovi error tsc; GitNexus risk none. Refines #1274. #1247 già chiusa da #1274.

## Non implementato (ancora)

- **Display-name cosmetico**: gli hub per-cantone re-keyati a `azienda-migros` mantengono il display name del primo job (`"Migros Ticino"`) invece di `"Migros"` → `<title>`/H1 "Migros Ticino" su URL `azienda-migros`. Slug/canonical corretti (ciò che conta per dedup); l'H1 può essere riallineato in un follow-up cosmetico. Non funnel-critical.
- **Edge zero-job**: se un filtro azzerasse TUTTI i job Migros, l'umbrella TI non verrebbe emessa e l'alias TI (skippato) non avrebbe bridge → 404. Rischio nullo con 483 job.
- **Verifica dist-level live**: le assert dist-scanning girano solo in `validate-dist` post-deploy (skipped in locale); logica verificata, conferma byte-level al primo deploy.
