### PR TITLE
fix(i18n): eager-load CTA "Prova anche" labels (it/de/fr raw-key flash)

### DIFF
--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -43,6 +43,9 @@ const deCore: Record<string, string> = {
  'nav.support': 'Helfen Sie uns',
  'nav.subtitle': 'Steueranalyse 2026',
  'comparators.exchange': 'Währungstausch',
+ // CTA "Prova anche" labels — eager-loaded (sibling chunks comparatori/guide load post-paint via requestIdleCallback)
+ 'strumenti.permitCompare': 'G vs B',
+ 'guide.tabs.calendar': 'Steuerfristen',
  'comparators.traffic': 'Grenzverkehr',
  'comparators.mobile': 'Mobilfunk',
  'comparators.banks': 'Bankkonten',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -43,6 +43,9 @@ const frCore: Record<string, string> = {
  'nav.support': 'Aidez-nous',
  'nav.subtitle': 'Analyse Fiscale 2026',
  'comparators.exchange': 'Change Devise',
+ // CTA "Prova anche" labels — eager-loaded (sibling chunks comparatori/guide load post-paint via requestIdleCallback)
+ 'strumenti.permitCompare': 'G vs B',
+ 'guide.tabs.calendar': 'Échéances fiscales',
  'comparators.traffic': 'Trafic Douanes',
  'comparators.mobile': 'Téléphonie Mobile',
  'comparators.banks': 'Comptes Bancaires',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -52,6 +52,9 @@ const translations: Record<string, string> = {
  
  // Comparator sub-tabs
  'comparators.exchange': 'Cambio Valuta',
+ // CTA "Prova anche" labels — eager-loaded (sibling chunks comparatori/guide load post-paint via requestIdleCallback)
+ 'strumenti.permitCompare': 'G vs B',
+ 'guide.tabs.calendar': 'Scadenze Fiscali',
  'comparators.traffic': 'Traffico Valichi',
  'comparators.mobile': 'Telefonia Mobile',
  'comparators.banks': 'Conti Correnti',


### PR DESCRIPTION
## Implementato

Fix race lazy-load: la sezione CTA **"Prova anche"** mostrava le raw key `strumenti.permitCompare` e `guide.tabs.calendar` invece delle label tradotte (vedi screenshot owner, locale IT).

**Causa.** Quelle 2 chiavi vivevano **solo** nei chunk lazy `comparatori`/`guide`, caricati post-paint via `requestIdleCallback` (`services/i18n.ts:262/513`). Il CTA renderizza prima → `t()` fa fallback alla raw key (`i18n.ts:349-354`). La sorella `comparators.exchange` ("Cambio Valuta") funziona perché sta in `*-core.ts` (eager, atteso prima del render). EN non si rompe perché entrambe le chiavi sono **duplicate** in `en-critical.ts` (eager).

**Bug di classe: 3 locali × 2 chiavi** (IT/DE/FR). Fix = mirror del pattern `comparators.exchange`/`en-critical`: aggiungo le 2 chiavi al bundle eager `*-core.ts`:

| file | strumenti.permitCompare | guide.tabs.calendar |
|---|---|---|
| `it-core.ts` | `G vs B` | `Scadenze Fiscali` |
| `de-core.ts` | `G vs B` | `Steuerfristen` |
| `fr-core.ts` | `G vs B` | `Échéances fiscales` |

Valori copiati 1:1 dai rispettivi chunk lazy (nessuna nuova traduzione inventata). Le chiavi restano anche nei chunk lazy: duplicato cross-chunk innocuo (merge sovrascrive con stesso valore), identico a come EN già fa (en-critical + en-comparatori).

**Test.** `i18n-guard`, `i18n-completeness`, `i18n`, `translation-length-ratio-gate` → 36/36 verdi. esbuild parse OK sui 3 file. GitNexus detect_changes: 0 symbol (solo data literal), risk none.

## Non implementato (ancora)

- **EN invariato**: già corretto via `en-critical` — nessun byte cambiato, diff minimo.
- **Non aggiunte a `*-critical`**: per IT/DE/FR il bundle eager-before-paint è `core`+`calculator` (atteso prima del render); `core` è sufficiente e allinea esattamente alla collocazione della chiave funzionante `comparators.exchange`. `it-critical` non necessario (out of scope: aggiungerebbe peso sync senza beneficio extra).
- **Nessun audit altre raw-key potenziali**: scope chirurgico alle 2 chiavi del bug osservato. Se servisse un guard test che impedisca a chiavi referenziate dal CTA di stare solo in chunk lazy → follow-up (no nit "manca test" per policy).