### PR TITLE
feat(dist): offload OG cards (~170MB) via raw.githubusercontent (jsDelivr 502s)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -637,14 +637,49 @@ jobs:
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)
         run: cp dist/index.html dist/404.html
 
-      # NOTE: the per-job OG-card CDN offload (orphan `cdn-assets` branch +
-      # scripts/offload-generated-images-cdn.mjs) was REVERTED — jsDelivr
-      # returns 502 on that branch's large single orphan commit (~168 MB /
-      # 6000 files), so the rewritten og:image refs were unreachable (raw
-      # serves them, jsDelivr can't package the commit). OG cards therefore
-      # stay in the Pages artifact, served same-origin. Re-attempt would need
-      # a CDN that handles the big commit (or smaller, paginated commits). The
-      # git-tracked blog hero images (served from main@sha) are unaffected.
+      # ── Generated OG-card offload (best-effort, non-fatal) ────────────────
+      # Push the build-generated per-job OG cards (dist/og, ~170 MB — NOT
+      # git-tracked) to an orphan `cdn-assets` branch, then rewrite the emitted
+      # og:image refs to raw.githubusercontent@<that-sha> and delete dist/og.
+      # raw (NOT jsDelivr): jsDelivr 502s packaging the large single orphan
+      # commit, while raw serves each file directly with Content-Type
+      # image/webp. og:image is crawler/social-fetched (sparse) so raw's rate
+      # limits are acceptable. BOTH steps are continue-on-error and the script
+      # is internally non-fatal: any failure leaves dist untouched (og ships as
+      # before) — the offload can never break a deploy.
+      - name: Push generated OG cards to cdn-assets branch (CDN source)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          stage=/tmp/cdn-assets
+          rm -rf "$stage" && mkdir -p "$stage"
+          [ -d dist/og ] && cp -r dist/og "$stage/og"
+          if [ ! -d "$stage/og" ]; then
+            echo "no dist/og present — skipping cdn-assets push"; exit 0
+          fi
+          echo "cdn-assets payload: $(du -sh "$stage" | cut -f1)"
+          cd "$stage"
+          git init -q
+          git checkout -q -b cdn-assets
+          git config user.email "deploy-bot@frontaliereticino.ch"
+          git config user.name "deploy-bot"
+          git add -A
+          git commit -qm "cdn og cards ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          if git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" cdn-assets; then
+            sha="$(git rev-parse HEAD)"
+            echo "CDN_ASSETS_SHA=${sha}" >> "$GITHUB_ENV"
+            echo "✅ pushed cdn-assets ${sha:0:8}"
+          else
+            echo "⚠️ cdn-assets push failed — offload skipped, og stays in dist"
+          fi
+
+      - name: Offload OG cards to CDN (rewrite og:image refs + delete dist/og)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: node scripts/offload-generated-images-cdn.mjs
 
       - name: Capture pre-deploy sitemap URLs (for IndexNow diff)
         if: github.event.inputs.profile_sequential != 'true'

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -2,7 +2,8 @@
 // offload-generated-images-cdn.mjs
 //
 // Offload BUILD-GENERATED per-job OG cards (dist/og) from the GitHub Pages
-// artifact to jsDelivr, pinned to a cdn-assets commit SHA.
+// artifact to raw.githubusercontent, pinned to a cdn-assets commit SHA.
+// (raw, not jsDelivr: jsDelivr 502s on the large orphan commit — see cdnBase.)
 //
 // (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
 // the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
@@ -81,7 +82,12 @@ function main() {
     log('no dist/ — skipping');
     return;
   }
-  const cdnBase = `https://cdn.jsdelivr.net/gh/${REPO}@${sha}`;
+  // Serve via raw.githubusercontent, NOT jsDelivr: jsDelivr returns 502 trying
+  // to package the cdn-assets orphan branch's large single commit (~168 MB /
+  // 6000 files), whereas raw serves each file directly with the correct
+  // Content-Type (image/webp, 200). og:image is crawler/social-fetched (sparse)
+  // so raw's rate limits are acceptable here; it is NOT a general CDN.
+  const cdnBase = `https://raw.githubusercontent.com/${REPO}/${sha}`;
 
   // Build rewrite + guard regexes per target. A target file is any path under
   // the url prefix ending in a known image extension (no quote/space/paren).


### PR DESCRIPTION
## Implementato
Re-enables the per-job OG-card offload (reverted in #1267), now serving `og:image` from **raw.githubusercontent** instead of jsDelivr.

**Il problema (perché era fermo):** jsDelivr ritorna **502** impacchettando il commit orphan grande di `cdn-assets` (~168 MB / 6000 file). **raw** serve ogni file direttamente con `Content-Type: image/webp` (200, verificato). og:image è fetch da crawler/social (sparso) → i rate-limit di raw sono accettabili (raw NON è una CDN generale, ma il volume og è basso).

- `deploy.yml`: force-push `dist/og` → orphan `cdn-assets` → `CDN_ASSETS_SHA` → script riscrive og:image a `raw.githubusercontent@<sha>/og/jobs/*.webp` + cancella `dist/og`. Entrambi gli step `continue-on-error`; script non-fatale (guard leak / errore → og resta in dist, deploy non tocco).
- Rimuove **~170 MB** dall'artifact Pages.

## Non implementato / nota onesta
- **NON porta l'artifact sotto i 10 GB** da solo (~10.75 GB dopo). Il gap residuo (~750 MB) è nel **corpus pagine** (jobs-seo 7.6 GB), off-limits per la regola no-page-cut. Quindi il deploy resta sopra il cap finché non si riduce il corpus (skip-tier) o si ristruttura (flatten HTML).
- raw rate-limit: og previews potrebbero 429 transitoriamente sotto burst di crawl. Accettabile per og (non-visibile). "poi vediamo".

## Verifica
- [x] raw serve .webp come image/webp 200 (verificato live)
- [x] script node --check + YAML valido; rewrite/guard logica invariata (solo base URL jsDelivr→raw)
- [ ] post-deploy: og:image punta a raw@sha 200; dist/og cancellato (~170MB freed nel log)