### PR TITLE
perf(dist): offload per-job detail JSON (~225MB) to cdn-assets via raw

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -637,17 +637,24 @@ jobs:
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)
         run: cp dist/index.html dist/404.html
 
-      # ── Generated OG-card offload (best-effort, non-fatal) ────────────────
-      # Push the build-generated per-job OG cards (dist/og, ~170 MB — NOT
-      # git-tracked) to an orphan `cdn-assets` branch, then rewrite the emitted
-      # og:image refs to raw.githubusercontent@<that-sha> and delete dist/og.
-      # raw (NOT jsDelivr): jsDelivr 502s packaging the large single orphan
-      # commit, while raw serves each file directly with Content-Type
-      # image/webp. og:image is crawler/social-fetched (sparse) so raw's rate
-      # limits are acceptable. BOTH steps are continue-on-error and the script
-      # is internally non-fatal: any failure leaves dist untouched (og ships as
-      # before) — the offload can never break a deploy.
-      - name: Push generated OG cards to cdn-assets branch (CDN source)
+      # ── Generated-asset offload (best-effort, non-fatal) ──────────────────
+      # Push build-generated, NOT-git-tracked assets to an orphan `cdn-assets`
+      # branch, then offload them out of dist via scripts/offload-generated-
+      # images-cdn.mjs:
+      #   • dist/og            (~170 MB) — per-job OG cards; og:image refs in
+      #                                    static HTML rewritten to raw@<sha>.
+      #   • dist/data/job-detail (~225 MB) — per-job detail JSON fetched at
+      #                                    runtime by the SPA; the script injects
+      #                                    window.__CDN_DATA_BASE__=raw@<sha> into
+      #                                    every page so cdnDataUrl() resolves it.
+      # raw (NOT jsDelivr): jsDelivr 403/502s on a fresh orphan ref, while raw
+      # serves each file directly (image/webp; application/json). These assets
+      # are sparse/per-session fetches so raw's rate limits are acceptable. BOTH
+      # steps are continue-on-error and the script is internally non-fatal: any
+      # failure leaves dist untouched (assets ship as before) and the SSG static
+      # HTML keeps full content either way — the offload can never break a deploy
+      # or SEO.
+      - name: Push generated assets to cdn-assets branch (CDN source)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
         env:
@@ -657,8 +664,11 @@ jobs:
           stage=/tmp/cdn-assets
           rm -rf "$stage" && mkdir -p "$stage"
           [ -d dist/og ] && cp -r dist/og "$stage/og"
-          if [ ! -d "$stage/og" ]; then
-            echo "no dist/og present — skipping cdn-assets push"; exit 0
+          if [ -d dist/data/job-detail ]; then
+            mkdir -p "$stage/data" && cp -r dist/data/job-detail "$stage/data/job-detail"
+          fi
+          if [ ! -d "$stage/og" ] && [ ! -d "$stage/data/job-detail" ]; then
+            echo "no offloadable assets present — skipping cdn-assets push"; exit 0
           fi
           echo "cdn-assets payload: $(du -sh "$stage" | cut -f1)"
           cd "$stage"
@@ -667,16 +677,16 @@ jobs:
           git config user.email "deploy-bot@frontaliereticino.ch"
           git config user.name "deploy-bot"
           git add -A
-          git commit -qm "cdn og cards ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          git commit -qm "cdn assets (og + job-detail) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
           if git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" cdn-assets; then
             sha="$(git rev-parse HEAD)"
             echo "CDN_ASSETS_SHA=${sha}" >> "$GITHUB_ENV"
             echo "✅ pushed cdn-assets ${sha:0:8}"
           else
-            echo "⚠️ cdn-assets push failed — offload skipped, og stays in dist"
+            echo "⚠️ cdn-assets push failed — offload skipped, assets stay in dist"
           fi
 
-      - name: Offload OG cards to CDN (rewrite og:image refs + delete dist/og)
+      - name: Offload generated assets to CDN (og refs + job-detail base + delete)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
         run: node scripts/offload-generated-images-cdn.mjs

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, Suspense } from 'react';
 import { lazyRetry } from '@/services/lazyRetry';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 const JobAlertForm = lazyRetry(() => import('@/components/community/JobAlertForm'));
 const JobAlertStickyBanner = lazyRetry(() => import('@/components/community/JobAlertStickyBanner'));
 const JobAlertEndCard = lazyRetry(() => import('@/components/community/JobAlertEndCard'));
@@ -310,7 +311,7 @@ const jobDetailCache = new Map<string, Promise<Partial<JobListing>>>();
  */
 function fetchJobDetail(jobId: string): Promise<Partial<JobListing>> {
  if (!jobDetailCache.has(jobId)) {
- const promise = fetch(`/data/job-detail/${jobId}.json`)
+ const promise = fetch(cdnDataUrl(`/data/job-detail/${jobId}.json`))
  .then((res) => { if (!res.ok) throw new Error(`${res.status}`); return res.json(); })
  .then((data: unknown) => (data && typeof data === 'object' ? data : {}) as Partial<JobListing>)
  .catch(() => ({} as Partial<JobListing>));

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // offload-generated-images-cdn.mjs
 //
-// Offload BUILD-GENERATED per-job OG cards (dist/og) from the GitHub Pages
-// artifact to raw.githubusercontent, pinned to a cdn-assets commit SHA.
-// (raw, not jsDelivr: jsDelivr 502s on the large orphan commit — see cdnBase.)
+// Offload BUILD-GENERATED assets from the GitHub Pages artifact to
+// raw.githubusercontent, pinned to a cdn-assets commit SHA. Two phases:
+//   1. per-job OG cards (dist/og)            — rewrite static og:image refs
+//   2. per-job detail JSON (dist/data/job-detail) — inject runtime CDN base
+// (raw, not jsDelivr: jsDelivr 403/502s on the fresh orphan ref — see cdnBase.)
 //
 // (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
 // the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
@@ -71,24 +73,10 @@ function walkAll(dir, fn) {
   }
 }
 
-function main() {
-  const sha = (process.env.CDN_ASSETS_SHA || '').trim();
-  if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
-    log(`no valid CDN_ASSETS_SHA (got "${sha}") — skipping offload, images stay in dist`);
-    return;
-  }
-  const distDir = path.resolve(process.cwd(), 'dist');
-  if (!fs.existsSync(distDir)) {
-    log('no dist/ — skipping');
-    return;
-  }
-  // Serve via raw.githubusercontent, NOT jsDelivr: jsDelivr returns 502 trying
-  // to package the cdn-assets orphan branch's large single commit (~168 MB /
-  // 6000 files), whereas raw serves each file directly with the correct
-  // Content-Type (image/webp, 200). og:image is crawler/social-fetched (sparse)
-  // so raw's rate limits are acceptable here; it is NOT a general CDN.
-  const cdnBase = `https://raw.githubusercontent.com/${REPO}/${sha}`;
-
+// ── Phase 1: OG-card images (rewrite static og:image refs in HTML) ───────────
+// og:image refs are emitted into static HTML, so an HTML rewrite catches every
+// one and a guard can verify nothing leaks before the dir is deleted.
+function offloadOgImages(distDir, cdnBase) {
   // Build rewrite + guard regexes per target. A target file is any path under
   // the url prefix ending in a known image extension (no quote/space/paren).
   const fileTail = "([^\"'\\s)?]+?\\.(?:webp|png|jpe?g|avif|svg))";
@@ -96,7 +84,7 @@ function main() {
 
   const presentTargets = TARGETS.filter((t) => fs.existsSync(path.join(distDir, ...t.dir)));
   if (presentTargets.length === 0) {
-    log('no offload target dirs present in dist — nothing to do');
+    log('no OG offload target dirs present in dist — skipping image phase');
     return;
   }
 
@@ -135,7 +123,7 @@ function main() {
     }
   });
   if (leaks.length > 0) {
-    log(`GUARD: ${leaks.length} unrewritten ref(s) survive — ABORTING offload (images kept in dist): ${leaks.slice(0, 5).join('; ')}`);
+    log(`GUARD: ${leaks.length} unrewritten ref(s) survive — ABORTING image offload (images kept in dist): ${leaks.slice(0, 5).join('; ')}`);
     return; // non-fatal: keep images, deploy proceeds
   }
 
@@ -147,6 +135,86 @@ function main() {
     fs.rmSync(dir, { recursive: true, force: true });
   }
   log(`offloaded ${presentTargets.map((t) => t.url).join(' + ')} → ${cdnBase} ; rewrote ${rewritten}/${scanned} files ; freed ${(freed / 1048576).toFixed(0)} MB`);
+}
+
+// ── Phase 2: generated runtime-fetched data (per-job detail JSON) ─────────────
+// dist/data/job-detail/<id>.json (~225 MB) is fetched on demand by the SPA
+// (components/community/JobBoard.tsx → fetchJobDetail) using a URL built at
+// RUNTIME in the JS bundle — it is NOT referenced in static HTML, so it cannot
+// be rewritten like og:image. Instead we inject the CDN base as a global the
+// fetch helper reads (services/cdnDataBase.ts → cdnDataUrl), then delete the dir.
+//
+// GRACEFUL DEGRADATION: the static SSG job pages already contain the full job
+// content in HTML (crawler-visible SEO is unaffected). job-detail.json only
+// enriches the hydrated SPA detail view, and fetchJobDetail() catches any
+// failure → {} (no enrichment, page still renders). So a missed inject or a raw
+// hiccup degrades the interactive detail view but never breaks a page or SEO.
+const DATA_DIRS = [['data', 'job-detail']];
+
+function offloadGeneratedData(distDir, cdnBase) {
+  const present = DATA_DIRS.filter((d) => fs.existsSync(path.join(distDir, ...d)));
+  if (present.length === 0) {
+    log('no generated-data dirs present in dist — skipping data phase');
+    return;
+  }
+
+  // Inject `<script>window.__CDN_DATA_BASE__="<cdnBase>"</script>` right after the
+  // first <head> of every HTML page so the base is set before the SPA boots.
+  // Idempotent (skip if already present). Runs only over .html (the SPA shell +
+  // SSG pages — any of which can client-nav to a job detail).
+  const injectTag = `<script>window.__CDN_DATA_BASE__=${JSON.stringify(cdnBase)}</script>`;
+  let injected = 0;
+  let htmlSeen = 0;
+  walk(distDir, (fp) => {
+    if (path.extname(fp) !== '.html') return;
+    htmlSeen++;
+    const html = fs.readFileSync(fp, 'utf8');
+    if (html.includes('__CDN_DATA_BASE__')) { injected++; return; } // already done
+    const m = html.match(/<head[^>]*>/i);
+    if (!m) return; // no <head>: leave it (its SPA fetch degrades gracefully)
+    const at = m.index + m[0].length;
+    fs.writeFileSync(fp, html.slice(0, at) + injectTag + html.slice(at));
+    injected++;
+  });
+
+  // Only delete if at least one page carries the base — otherwise every
+  // job-detail fetch would 404 (still graceful, but pointless). If nothing was
+  // injected, keep the data in dist.
+  if (injected === 0) {
+    log(`GUARD: base injected into 0/${htmlSeen} HTML pages — keeping data in dist`);
+    return;
+  }
+  let freed = 0;
+  for (const d of present) {
+    const dir = path.join(distDir, ...d);
+    freed += dirSize(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  log(`offloaded ${present.map((d) => '/' + d.join('/') + '/').join(' + ')} → ${cdnBase} ; injected base into ${injected}/${htmlSeen} HTML ; freed ${(freed / 1048576).toFixed(0)} MB`);
+}
+
+function main() {
+  const sha = (process.env.CDN_ASSETS_SHA || '').trim();
+  if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
+    log(`no valid CDN_ASSETS_SHA (got "${sha}") — skipping offload, assets stay in dist`);
+    return;
+  }
+  const distDir = path.resolve(process.cwd(), 'dist');
+  if (!fs.existsSync(distDir)) {
+    log('no dist/ — skipping');
+    return;
+  }
+  // Serve via raw.githubusercontent, NOT jsDelivr: jsDelivr 403/502s on a fresh
+  // orphan-branch ref ("Failed to fetch version info" — its per-repo version
+  // refresh chokes on this giant repo for cold refs), whereas raw serves each
+  // file directly with the correct Content-Type (image/webp; application/json
+  // parses fine via fetch().json()) and CORS `*`. The offloaded assets are
+  // sparse/per-session fetches so raw's rate limits are acceptable; it is NOT a
+  // general CDN. (Main-tracked assets like blog heroes DO use jsDelivr@main.)
+  const cdnBase = `https://raw.githubusercontent.com/${REPO}/${sha}`;
+
+  offloadOgImages(distDir, cdnBase);
+  offloadGeneratedData(distDir, cdnBase);
 }
 
 try {

--- a/services/cdnDataBase.ts
+++ b/services/cdnDataBase.ts
@@ -1,0 +1,38 @@
+// cdnDataBase.ts
+//
+// Runtime CDN base for BUILD-GENERATED data files that are offloaded out of the
+// GitHub Pages artifact to the orphan `cdn-assets` branch at deploy time
+// (served via raw.githubusercontent — jsDelivr 502/403s on fresh orphan refs,
+// see scripts/offload-generated-images-cdn.mjs).
+//
+// The base is injected as an inline `<script>window.__CDN_DATA_BASE__="…"</script>`
+// into every dist HTML page during the post-build offload step (AFTER the orphan
+// branch is pushed, when its commit SHA is known — it cannot be a Vite build-time
+// define because the SHA does not exist yet at build time).
+//
+// GRACEFUL DEGRADATION: when the base is unset (dev, or the non-fatal offload was
+// skipped / failed), `cdnDataUrl` returns the original same-origin path, so the
+// file is fetched from dist/ exactly as before. Callers must therefore keep
+// working whether or not the offload ran.
+
+declare global {
+  interface Window {
+    __CDN_DATA_BASE__?: string;
+  }
+}
+
+/** The injected raw.githubusercontent base (e.g. `https://raw.githubusercontent.com/<repo>/<sha>`), or '' when not offloaded. */
+export function cdnDataBase(): string {
+  if (typeof window === 'undefined') return '';
+  const b = window.__CDN_DATA_BASE__;
+  return typeof b === 'string' && b ? b : '';
+}
+
+/**
+ * Resolve a same-origin generated-data path (e.g. `/data/job-detail/123.json`) to
+ * its CDN URL when the file was offloaded, else return the path unchanged.
+ */
+export function cdnDataUrl(path: string): string {
+  const base = cdnDataBase();
+  return base ? base + path : path;
+}


### PR DESCRIPTION
## Scopo
Continua il programma dist-shrink (blog heroes + OG già offloadati). Sposta fuori dall'artifact GitHub Pages il payload `dist/data/job-detail/<id>.json` (~225 MB, ~15k file), il singolo blocco statico residuo più grosso, **senza toccare nessuna pagina SEO**.

## Implementato
- **`services/cdnDataBase.ts`** — `cdnDataUrl(path)` risolve `/data/job-detail/X.json` al CDN se la base runtime `window.__CDN_DATA_BASE__` è iniettata, altrimenti ritorna il path same-origin (dev / offload skippato).
- **`JobBoard.fetchJobDetail`** — usa `cdnDataUrl(...)`.
- **`scripts/offload-generated-images-cdn.mjs`** — nuova Fase 2: inietta `<script>window.__CDN_DATA_BASE__=raw@<sha></script>` in ogni HTML (idempotente, dopo `<head>`) e cancella `dist/data/job-detail`. Guard: cancella solo se la base è entrata in ≥1 pagina. Fase OG invariata.
- **`deploy.yml`** — lo stage push verso il branch orfano `cdn-assets` include ora `dist/data/job-detail` accanto a `dist/og`; un solo commit/force-push serve entrambi.

## Perché raw e non jsDelivr
Verificato live (oggi): jsDelivr **403→502** su un ref orfano fresco — body *"Failed to fetch version info for …"*: il refresh version-info per-repo va in timeout su questo repo gigante per i ref freddi. `@main` resta caldo (per quello i blog heroes usano jsDelivr@main). raw serve ogni file con Content-Type corretto + CORS `*`. job-detail è fetch sparso per-sessione → limiti raw accettabili.

## SEO-safe by construction
Le pagine job statiche SSG contengono **già** il contenuto completo nell'HTML (visibile ai crawler). `job-detail.json` arricchisce solo la detail-view SPA idratata, e `fetchJobDetail()` cattura ogni errore → `{}` (la pagina si renderizza comunque). Ogni punto di fallimento (offload skippato / push fallito / inject mancato / raw down) degrada **solo** l'arricchimento interattivo, mai una pagina né la SEO. Pipeline `continue-on-error` + script internamente non-fatale.

## Non implementato (per scelta)
- `jobs-{locale}.json` (~96 MB) **resta same-origin**: è il floor affidabile + fetch ad alto volume (ogni listing) e funge da fallback del detail.
- Static git-tracked minori (~31 MB: health/fuel/stats/immagini non-blog) non offloadati: basso valore, macchinario separato; potrebbero usare jsDelivr@main in futuro.
- jsDelivr-primary per i dati generati: non applicabile (403/502 su orphan); raw è l'operativo. I blog heroes main-tracked continuano su jsDelivr@main.

## Note
- Non raggiunge la riduzione ≥1GB (atteso: il grosso dell'artifact sono le pagine HTML, fuori scope per decisione utente). Riduzione attesa ~225 MB.
- Test funzionale dello script eseguito localmente: og rewrite ✓, base injection 2/2 HTML ✓, dir cancellate ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)