### PR TITLE
feat(cdn): serve offloaded assets from frontaliere-cdn Pages (real CDN, replaces raw)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -638,53 +638,73 @@ jobs:
         run: cp dist/index.html dist/404.html
 
       # ── Generated-asset offload (best-effort, non-fatal) ──────────────────
-      # Push build-generated, NOT-git-tracked assets to an orphan `cdn-assets`
-      # branch, then offload them out of dist via scripts/offload-generated-
+      # Push build-generated, NOT-git-tracked assets to the dedicated CDN repo
+      # `valerielinc-ops/frontaliere-cdn` (its own GitHub Pages site, Fastly
+      # edge), then offload them out of dist via scripts/offload-generated-
       # images-cdn.mjs:
       #   • dist/og            (~170 MB) — per-job OG cards; og:image refs in
-      #                                    static HTML rewritten to raw@<sha>.
+      #                                    static HTML rewritten to ${CDN_BASE}/og.
       #   • dist/data/job-detail (~225 MB) — per-job detail JSON fetched at
       #                                    runtime by the SPA; the script injects
-      #                                    window.__CDN_DATA_BASE__=raw@<sha> into
-      #                                    every page so cdnDataUrl() resolves it.
-      # raw (NOT jsDelivr): jsDelivr 403/502s on a fresh orphan ref, while raw
-      # serves each file directly (image/webp; application/json). These assets
-      # are sparse/per-session fetches so raw's rate limits are acceptable. BOTH
-      # steps are continue-on-error and the script is internally non-fatal: any
-      # failure leaves dist untouched (assets ship as before) and the SSG static
-      # HTML keeps full content either way — the offload can never break a deploy
-      # or SEO.
-      - name: Push generated assets to cdn-assets branch (CDN source)
+      #                                    window.__CDN_DATA_BASE__=${CDN_BASE}
+      #                                    into every page so cdnDataUrl() resolves.
+      # GitHub Pages (NOT raw / NOT jsDelivr): raw is rate-limited + serves JSON as
+      # text/plain; jsDelivr 403/502s on fresh orphan refs. The CDN repo's Pages
+      # site serves every file via Fastly with the correct Content-Type
+      # (application/json, image/webp) and `access-control-allow-origin: *`, and a
+      # second Pages site has its own ~1 GB / 100 GB-month quota (doubles headroom
+      # vs everything on the main artifact). URLs are STABLE (no SHA pin).
+      #
+      # Eventual-consistency: the CDN repo's Pages build runs async (~30–60 s) after
+      # the push, so for a brief window assets may 404 — og is sparse/crawler-
+      # fetched and job-detail degrades gracefully (fetchJobDetail catches → {}),
+      # and the SSG static HTML always carries full content, so this never breaks a
+      # page or SEO. BOTH steps are continue-on-error and the script is internally
+      # non-fatal: any failure leaves dist untouched (assets ship in the artifact
+      # as before).
+      #
+      # Auth: SSH deploy key (write-only to frontaliere-cdn) in secret
+      # CDN_DEPLOY_KEY — least privilege, cannot touch any other repo.
+      - name: Push generated assets to CDN repo (frontaliere-cdn / Pages)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CDN_DEPLOY_KEY: ${{ secrets.CDN_DEPLOY_KEY }}
         run: |
           set -uo pipefail
-          stage=/tmp/cdn-assets
+          if [ -z "${CDN_DEPLOY_KEY:-}" ]; then
+            echo "no CDN_DEPLOY_KEY secret — skipping CDN push, assets stay in dist"; exit 0
+          fi
+          stage=/tmp/cdn-stage
           rm -rf "$stage" && mkdir -p "$stage"
+          : > "$stage/.nojekyll"   # serve every path verbatim, skip Jekyll
           [ -d dist/og ] && cp -r dist/og "$stage/og"
           if [ -d dist/data/job-detail ]; then
             mkdir -p "$stage/data" && cp -r dist/data/job-detail "$stage/data/job-detail"
           fi
           if [ ! -d "$stage/og" ] && [ ! -d "$stage/data/job-detail" ]; then
-            echo "no offloadable assets present — skipping cdn-assets push"; exit 0
+            echo "no offloadable assets present — skipping CDN push"; exit 0
           fi
-          echo "cdn-assets payload: $(du -sh "$stage" | cut -f1)"
+          printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"
+          echo "CDN payload: $(du -sh "$stage" | cut -f1)"
+          keyfile="$RUNNER_TEMP/cdn_deploy_key"
+          printf '%s\n' "$CDN_DEPLOY_KEY" > "$keyfile" && chmod 600 "$keyfile"
+          export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
           cd "$stage"
           git init -q
-          git checkout -q -b cdn-assets
+          git checkout -q -b main
           git config user.email "deploy-bot@frontaliereticino.ch"
           git config user.name "deploy-bot"
           git add -A
           git commit -qm "cdn assets (og + job-detail) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
-          if git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" cdn-assets; then
-            sha="$(git rev-parse HEAD)"
-            echo "CDN_ASSETS_SHA=${sha}" >> "$GITHUB_ENV"
-            echo "✅ pushed cdn-assets ${sha:0:8}"
+          # Force-push a single fresh commit → CDN repo history never accumulates.
+          if git push -f git@github.com:valerielinc-ops/frontaliere-cdn.git main; then
+            echo "CDN_BASE=https://valerielinc-ops.github.io/frontaliere-cdn" >> "$GITHUB_ENV"
+            echo "✅ pushed assets to frontaliere-cdn"
           else
-            echo "⚠️ cdn-assets push failed — offload skipped, assets stay in dist"
+            echo "⚠️ CDN push failed — offload skipped, assets stay in dist"
           fi
+          rm -f "$keyfile"
 
       - name: Offload generated assets to CDN (og refs + job-detail base + delete)
         if: github.event.inputs.profile_sequential != 'true'

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -1,30 +1,34 @@
 #!/usr/bin/env node
 // offload-generated-images-cdn.mjs
 //
-// Offload BUILD-GENERATED assets from the GitHub Pages artifact to
-// raw.githubusercontent, pinned to a cdn-assets commit SHA. Two phases:
+// Offload BUILD-GENERATED assets out of the GitHub Pages artifact, rewriting
+// their references to the dedicated CDN repo's Pages site (CDN_BASE). Two phases:
 //   1. per-job OG cards (dist/og)            — rewrite static og:image refs
 //   2. per-job detail JSON (dist/data/job-detail) — inject runtime CDN base
-// (raw, not jsDelivr: jsDelivr 403/502s on the fresh orphan ref — see cdnBase.)
 //
 // (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
 // the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
 // stay same-origin. og:image refs ARE in static HTML so Phase 1 rewrites them;
 // job-detail JSON is also runtime-fetched so Phase 2 injects a runtime base.)
 //
-// Unlike the full blog hero images (git-tracked → served from main@sha by
+// Unlike the full blog hero images (git-tracked → served from jsDelivr@main by
 // build-plugins/blogImageCdnFinalizePlugin), dist/og and dist/data/job-detail
 // are generated at build time and are NOT in git. The deploy workflow first
-// force-pushes both to an orphan `cdn-assets` branch and passes that commit SHA
-// as CDN_ASSETS_SHA; this script then, per phase:
-//   • Phase 1 (og): rewrites the emitted og:image references in dist HTML to the
-//     raw.githubusercontent URL, then deletes dist/og.
-//   • Phase 2 (job-detail): injects window.__CDN_DATA_BASE__=<raw base> into
+// pushes both to the `frontaliere-cdn` repo (its own GitHub Pages site, Fastly
+// edge, `access-control-allow-origin: *`, correct Content-Type, STABLE URLs) and
+// exports its base URL as CDN_BASE; this script then, per phase:
+//   • Phase 1 (og): rewrites the emitted og:image references in dist HTML to
+//     ${CDN_BASE}/og/…, then deletes dist/og.
+//   • Phase 2 (job-detail): injects window.__CDN_DATA_BASE__=${CDN_BASE} into
 //     every dist HTML page (read by services/cdnDataBase.ts → cdnDataUrl at
 //     runtime), then deletes dist/data/job-detail.
 //
+// Pages (NOT raw / NOT jsDelivr): raw is rate-limited and serves JSON as
+// text/plain; jsDelivr 403/502s on fresh orphan refs. The CDN repo's Pages site
+// is a real Fastly-backed CDN, so it has neither problem.
+//
 // SAFETY — BEST-EFFORT / NON-FATAL: this runs in the deploy critical path, so it
-// must NEVER break a deploy. On a missing SHA, a guard leak, or ANY thrown
+// must NEVER break a deploy. On a missing CDN_BASE, a guard leak, or ANY thrown
 // error it leaves dist exactly as-is and exits 0 — the assets simply ship in the
 // artifact as before (no reduction, no breakage). The deploy step that invokes
 // it also uses continue-on-error.
@@ -34,7 +38,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const REPO = 'valerielinc-ops/frontaliere-si-o-no';
 const ORIGIN = 'https://frontaliereticino.ch';
 const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
 
@@ -198,9 +201,17 @@ function offloadGeneratedData(distDir, cdnBase) {
 }
 
 function main() {
-  const sha = (process.env.CDN_ASSETS_SHA || '').trim();
-  if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
-    log(`no valid CDN_ASSETS_SHA (got "${sha}") — skipping offload, assets stay in dist`);
+  // CDN_BASE is the full origin+path of the CDN repo's GitHub Pages site
+  // (e.g. https://valerielinc-ops.github.io/frontaliere-cdn), exported by the
+  // deploy step only after the assets were successfully pushed there. Pages
+  // serves every file via Fastly with the correct Content-Type (application/json,
+  // image/webp) and `access-control-allow-origin: *`, with STABLE URLs (no SHA
+  // pin) — a real CDN, unlike raw (rate-limited, JSON as text/plain) or jsDelivr
+  // (403/502 on fresh orphan refs). Main-tracked assets like blog heroes still
+  // use jsDelivr@main separately.
+  const cdnBase = (process.env.CDN_BASE || '').trim().replace(/\/+$/, '');
+  if (!/^https:\/\/\S+$/.test(cdnBase)) {
+    log(`no valid CDN_BASE (got "${cdnBase}") — skipping offload, assets stay in dist`);
     return;
   }
   const distDir = path.resolve(process.cwd(), 'dist');
@@ -208,14 +219,6 @@ function main() {
     log('no dist/ — skipping');
     return;
   }
-  // Serve via raw.githubusercontent, NOT jsDelivr: jsDelivr 403/502s on a fresh
-  // orphan-branch ref ("Failed to fetch version info" — its per-repo version
-  // refresh chokes on this giant repo for cold refs), whereas raw serves each
-  // file directly with the correct Content-Type (image/webp; application/json
-  // parses fine via fetch().json()) and CORS `*`. The offloaded assets are
-  // sparse/per-session fetches so raw's rate limits are acceptable; it is NOT a
-  // general CDN. (Main-tracked assets like blog heroes DO use jsDelivr@main.)
-  const cdnBase = `https://raw.githubusercontent.com/${REPO}/${sha}`;
 
   offloadOgImages(distDir, cdnBase);
   offloadGeneratedData(distDir, cdnBase);


### PR DESCRIPTION
## Scopo
Sostituisce il serving degli asset offloadati (OG cards + per-job detail JSON) da **raw.githubusercontent / orphan-branch** → **repo CDN dedicato `valerielinc-ops/frontaliere-cdn` con il suo GitHub Pages (Fastly edge)**. Upgrade a CDN vera, $0.

## Perché (verificato live)
GitHub Pages serve ogni file via Fastly con:
- `content-type: application/json; charset=utf-8` (raw dà text/plain!) e `image/webp`
- `access-control-allow-origin: *` (fetch cross-origin OK)
- `via: varnish` / `x-served-by: cache-…` (CDN edge), `cache-control: max-age=600`
- URL **stabili** (niente SHA pin)

Nessun limite raw (rate-limit, hotlink-discouraged) né jsDelivr (403/502 "Failed to fetch version info" su ref orfani freschi). Un secondo sito Pages ha la **sua** quota ~1GB / 100GB-mese → raddoppia headroom vs tutto-su-main.

**Niente dipendenza DNS**: l'URL `valerielinc-ops.github.io/frontaliere-cdn` è già una CDN Fastly reale e funziona da subito. Il dominio `cdn.frontaliereticino.ch` è solo estetica, aggiungibile dopo.

## Implementato
- **Repo CDN creato** (`frontaliere-cdn`, Pages ON, `.nojekyll`, probe verificato 200 + CORS + content-type).
- **Deploy key SSH write-only** sul solo repo CDN → secret `CDN_DEPLOY_KEY` (least privilege; non può toccare altri repo). Push cross-repo testato ✓.
- **deploy.yml**: pusha `og` + `data/job-detail` a `frontaliere-cdn` main via deploy key, singolo commit force-push (history mai cresce). Esporta `CDN_BASE=https://valerielinc-ops.github.io/frontaliere-cdn` solo on-success.
- **offload-generated-images-cdn.mjs**: `cdnBase` ora da env `CDN_BASE` (URL Pages completo, no SHA); og→`${CDN_BASE}/og`, job-detail inject→`${CDN_BASE}`. Fasi/guard invariate. Test funzionale ✓ (rewrite, inject 2/2, delete, trailing-slash, empty-skip).

## Sicurezza/robustezza
- `continue-on-error` + script salta su `CDN_BASE` mancante → asset restano in dist (comportamento odierno). Mai rompe deploy.
- HTML SSG ha sempre il contenuto job completo; `fetchJobDetail` cattura→{}. Finestra eventual-consistency (build Pages CDN ~30-60s post-push) tocca solo og sparsi / job-detail che degrada → mai pagina o SEO.

## Non implementato (per scelta)
- **Dominio custom `cdn.frontaliereticino.ch`**: serve record DNS (CNAME → `valerielinc-ops.github.io`) lato registrar. Solo estetica; il github.io funziona già. Si attiva dopo.
- **Blog heroes**: restano su jsDelivr@main (già funzionante, git-tracked). Non toccati.
- **Vecchio branch `cdn-assets`**: lasciato finché il prossimo deploy non popola il repo CDN (evita 404 sugli og live attuali); cleanup dopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)