### PR TITLE
feat(cdn): activate custom domain cdn.frontaliereticino.ch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -677,7 +677,8 @@ jobs:
           fi
           stage=/tmp/cdn-stage
           rm -rf "$stage" && mkdir -p "$stage"
-          : > "$stage/.nojekyll"   # serve every path verbatim, skip Jekyll
+          : > "$stage/.nojekyll"                              # serve every path verbatim, skip Jekyll
+          printf 'cdn.frontaliereticino.ch' > "$stage/CNAME"  # keep custom domain (force-push would else wipe it)
           [ -d dist/og ] && cp -r dist/og "$stage/og"
           if [ -d dist/data/job-detail ]; then
             mkdir -p "$stage/data" && cp -r dist/data/job-detail "$stage/data/job-detail"
@@ -699,7 +700,7 @@ jobs:
           git commit -qm "cdn assets (og + job-detail) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
           # Force-push a single fresh commit → CDN repo history never accumulates.
           if git push -f git@github.com:valerielinc-ops/frontaliere-cdn.git main; then
-            echo "CDN_BASE=https://valerielinc-ops.github.io/frontaliere-cdn" >> "$GITHUB_ENV"
+            echo "CDN_BASE=https://cdn.frontaliereticino.ch" >> "$GITHUB_ENV"
             echo "✅ pushed assets to frontaliere-cdn"
           else
             echo "⚠️ CDN push failed — offload skipped, assets stay in dist"


### PR DESCRIPTION
## Scopo
Attiva il dominio custom `cdn.frontaliereticino.ch` sul repo CDN `frontaliere-cdn` (DNS creato dall'utente). Gli asset offloadati (og + job-detail) ora usano il dominio brandizzato invece dell'URL github.io.

## Verificato live
- DNS `cdn → valerielinc-ops.github.io → 185.199.108-111.153` ✓
- `https://cdn.frontaliereticino.ch/data/_probe.json` → 200, `application/json`, `access-control-allow-origin: *`, Fastly (`via: varnish`)
- HTTPS enforced, `http → https` 301 ✓

## Implementato
- `CDN_BASE` → `https://cdn.frontaliereticino.ch`.
- Stage del file `CNAME` ad ogni push CDN (il force-push altrimenti cancellerebbe la config custom-domain).

## Non implementato (in valutazione separata)
- Spostamento di assets JS/CSS, immagini residue, e altri JSON oltre og+job-detail: vedi domanda di scope all'utente (rischio boot-critical per i bundle JS + non testabile in locale per il vincolo OOM del build Vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)