### PR TITLE
feat(cdn): move all static (JS/CSS bundle + all data JSON) to cdn.frontaliereticino.ch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -430,6 +430,14 @@ jobs:
           # sharedWriteRegistry claim()). Knob removed; investigate the
           # real bottleneck instead. See data/build-perf-history.md.
           BUILD_PROFILE: '1'
+          # Emit absolute CDN URLs for all bundler assets (JS/CSS/chunks) via
+          # vite.config experimental.renderBuiltUrl, so dist/assets can be
+          # offloaded to the frontaliere-cdn Pages site. The post-build steps push
+          # dist/assets there and (after verifying they serve) delete them from the
+          # artifact. NOTE: this bakes the CDN URL into HTML/JS — if the CDN push
+          # or verify fails, the deploy is FAILED (last good stays live), since
+          # there is no same-origin fallback for boot-critical assets.
+          ASSET_CDN: 'https://cdn.frontaliereticino.ch'
           # ALWAYS sequential on the GH free-tier runner (2 vCPU / 7 GB).
           # Empirical comparison on the same source tree (2026-05-07):
           #   sequential build job: 12m41s, peak heap ~max(single plugin)
@@ -637,31 +645,30 @@ jobs:
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)
         run: cp dist/index.html dist/404.html
 
-      # ── Generated-asset offload (best-effort, non-fatal) ──────────────────
-      # Push build-generated, NOT-git-tracked assets to the dedicated CDN repo
-      # `valerielinc-ops/frontaliere-cdn` (its own GitHub Pages site, Fastly
-      # edge), then offload them out of dist via scripts/offload-generated-
-      # images-cdn.mjs:
-      #   • dist/og            (~170 MB) — per-job OG cards; og:image refs in
-      #                                    static HTML rewritten to ${CDN_BASE}/og.
-      #   • dist/data/job-detail (~225 MB) — per-job detail JSON fetched at
-      #                                    runtime by the SPA; the script injects
-      #                                    window.__CDN_DATA_BASE__=${CDN_BASE}
-      #                                    into every page so cdnDataUrl() resolves.
+      # ── Static-asset offload to CDN repo ──────────────────────────────────
+      # Push build-generated, NOT-git-tracked static to the dedicated CDN repo
+      # `valerielinc-ops/frontaliere-cdn` (its own GitHub Pages site, Fastly edge):
+      #   • dist/og     — per-job OG cards; og:image refs in HTML rewritten to
+      #                   ${CDN_BASE}/og by the offload script (non-fatal).
+      #   • dist/data   — ALL runtime-fetched JSON (job-detail, jobs-<locale>,
+      #                   indexes, slug-map, stats, fuel, health, …). Every fetch
+      #                   site routes through services/cdnDataBase.ts → cdnDataUrl;
+      #                   the script injects window.__CDN_DATA_BASE__=${CDN_BASE}
+      #                   and deletes the cdn-only files (keeps any /data/ path
+      #                   referenced same-origin in HTML/XML) (non-fatal).
+      #   • dist/assets — JS/CSS bundle. ASSET_CDN/renderBuiltUrl already rebased
+      #                   its URLs to the CDN at build time; the verify step below
+      #                   deletes dist/assets only after confirming the CDN serves
+      #                   them AND no same-origin ref survives (FAIL-SAFE).
       # GitHub Pages (NOT raw / NOT jsDelivr): raw is rate-limited + serves JSON as
       # text/plain; jsDelivr 403/502s on fresh orphan refs. The CDN repo's Pages
-      # site serves every file via Fastly with the correct Content-Type
-      # (application/json, image/webp) and `access-control-allow-origin: *`, and a
-      # second Pages site has its own ~1 GB / 100 GB-month quota (doubles headroom
-      # vs everything on the main artifact). URLs are STABLE (no SHA pin).
+      # site serves every file via Fastly with the correct Content-Type and
+      # `access-control-allow-origin: *`, STABLE URLs (no SHA pin), and its own
+      # ~1 GB / 100 GB-month quota (doubles headroom vs the main artifact).
       #
-      # Eventual-consistency: the CDN repo's Pages build runs async (~30–60 s) after
-      # the push, so for a brief window assets may 404 — og is sparse/crawler-
-      # fetched and job-detail degrades gracefully (fetchJobDetail catches → {}),
-      # and the SSG static HTML always carries full content, so this never breaks a
-      # page or SEO. BOTH steps are continue-on-error and the script is internally
-      # non-fatal: any failure leaves dist untouched (assets ship in the artifact
-      # as before).
+      # The push + the og/data offload script are continue-on-error / internally
+      # non-fatal (failure → those assets ship in the artifact as before). Only the
+      # boot-critical dist/assets delete is fail-safe-by-failing (see its step).
       #
       # Auth: SSH deploy key (write-only to frontaliere-cdn) in secret
       # CDN_DEPLOY_KEY — least privilege, cannot touch any other repo.
@@ -679,11 +686,12 @@ jobs:
           rm -rf "$stage" && mkdir -p "$stage"
           : > "$stage/.nojekyll"                              # serve every path verbatim, skip Jekyll
           printf 'cdn.frontaliereticino.ch' > "$stage/CNAME"  # keep custom domain (force-push would else wipe it)
-          [ -d dist/og ] && cp -r dist/og "$stage/og"
-          if [ -d dist/data/job-detail ]; then
-            mkdir -p "$stage/data" && cp -r dist/data/job-detail "$stage/data/job-detail"
-          fi
-          if [ ! -d "$stage/og" ] && [ ! -d "$stage/data/job-detail" ]; then
+          # Offloadable dirs: og cards, ALL runtime data JSON, and the bundler
+          # assets (JS/CSS) whose URLs renderBuiltUrl already rebased to the CDN.
+          [ -d dist/og ]     && cp -r dist/og     "$stage/og"
+          [ -d dist/data ]   && cp -r dist/data   "$stage/data"
+          [ -d dist/assets ] && cp -r dist/assets "$stage/assets"
+          if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ]; then
             echo "no offloadable assets present — skipping CDN push"; exit 0
           fi
           printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"
@@ -697,20 +705,64 @@ jobs:
           git config user.email "deploy-bot@frontaliereticino.ch"
           git config user.name "deploy-bot"
           git add -A
-          git commit -qm "cdn assets (og + job-detail) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          git commit -qm "cdn assets (og + data + assets) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
           # Force-push a single fresh commit → CDN repo history never accumulates.
           if git push -f git@github.com:valerielinc-ops/frontaliere-cdn.git main; then
             echo "CDN_BASE=https://cdn.frontaliereticino.ch" >> "$GITHUB_ENV"
             echo "✅ pushed assets to frontaliere-cdn"
           else
-            echo "⚠️ CDN push failed — offload skipped, assets stay in dist"
+            echo "⚠️ CDN push failed — offload skipped, og/data stay in dist"
           fi
           rm -f "$keyfile"
 
-      - name: Offload generated assets to CDN (og refs + job-detail base + delete)
+      - name: Offload og refs + data base into dist (non-fatal)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
         run: node scripts/offload-generated-images-cdn.mjs
+
+      # Boot-critical asset offload. The build already rebased Vite asset URLs to
+      # the CDN (ASSET_CDN/renderBuiltUrl) → the artifact's HTML/JS point at
+      # cdn.frontaliereticino.ch/assets/* with no same-origin fallback. Two guards
+      # before deleting dist/assets:
+      #   (A) FAIL the deploy if the push failed (CDN_BASE unset) or a sample asset
+      #       never serves from the CDN within ~4min — the Vite refs are already
+      #       baked to the CDN with no fallback, so publishing would break boot.
+      #       Failing keeps the last good deploy live.
+      #   (B) If ANY dist HTML still references a SAME-ORIGIN /assets/ path (e.g. a
+      #       custom SSG emitter that didn't go through renderBuiltUrl), KEEP
+      #       dist/assets (skip the delete) — non-fatal: those pages keep working
+      #       same-origin while the Vite refs use the CDN. No artifact win for
+      #       assets that round, but nothing breaks.
+      - name: Verify CDN assets live, then drop dist/assets (fail-safe)
+        if: github.event.inputs.profile_sequential != 'true'
+        run: |
+          set -uo pipefail
+          [ -d dist/assets ] || { echo "no dist/assets — nothing to offload"; exit 0; }
+          if [ -z "${CDN_BASE:-}" ]; then
+            echo "::error::CDN push failed but dist/assets URLs are already rebased to the CDN (no fallback) — failing deploy (last good stays live)"; exit 1
+          fi
+          sample="$(cd dist/assets && ls -1 *.js 2>/dev/null | head -1)"
+          [ -z "$sample" ] && sample="$(cd dist/assets && ls -1 | head -1)"
+          url="${CDN_BASE}/assets/${sample}"
+          echo "verifying $url (CDN Pages build may lag the push)…"
+          ok=""
+          for i in $(seq 1 24); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' "$url" || echo 000)"
+            echo "  attempt $i: $code"
+            [ "$code" = "200" ] && { ok=1; break; }
+            sleep 10
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::CDN asset $url not serving after ~4min — failing deploy (assets stay live on last good build)"; exit 1
+          fi
+          # Guard B: any surviving SAME-ORIGIN /assets/ reference in dist HTML?
+          if grep -rlE "[\"'(]/?assets/[A-Za-z0-9._-]+\.(js|css|woff2?|png|jpe?g|webp|svg)" --include='*.html' dist 2>/dev/null | head -1 | grep -q .; then
+            echo "⚠️ some dist HTML still references same-origin /assets/ (not CDN-rebased) — KEEPING dist/assets (no breakage, no asset reduction this round)"
+            exit 0
+          fi
+          freed="$(du -sh dist/assets | cut -f1)"
+          rm -rf dist/assets
+          echo "✅ assets verified on CDN + no same-origin refs; dropped dist/assets (${freed}) from artifact"
 
       - name: Capture pre-deploy sitemap URLs (for IndexNow diff)
         if: github.event.inputs.profile_sequential != 'true'

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -7,6 +7,7 @@ import type { BlogArticleId, AppRoute } from '@/services/router';
 import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
 import { useNavigation } from '@/services/NavigationContext';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 // Pre-compiled gi-flag variants for keyword matching (Vercel rule 7.10)
 const KEYWORD_LINKS_GI = KEYWORD_LINKS.map(kl => ({
@@ -1141,7 +1142,7 @@ function BlogArticles({
  useEffect(() => {
  if (!selectedArticle) return;
  let cancelled = false;
- fetch(`/data/jobs-${locale}.json`)
+ fetch(cdnDataUrl(`/data/jobs-${locale}.json`))
  .then(res => {
  if (!res.ok) throw new Error(`${res.status}`);
  return res.json();

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1980,12 +1980,12 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const slimIndexUrl = `/data/jobs-${locale}-index.json`;
  const localeUrl = `/data/jobs-${locale}.json`;
  try {
- const res = await fetch(slimIndexUrl);
+ const res = await fetch(cdnDataUrl(slimIndexUrl));
  if (res.ok) return (await res.json()) as JobListing[];
  throw new Error(`slim index ${res.status}`);
  } catch {
  try {
- const res = await fetch(localeUrl);
+ const res = await fetch(cdnDataUrl(localeUrl));
  if (res.ok) return (await res.json()) as JobListing[];
  throw new Error(`locale jobs ${res.status}`);
  } catch {
@@ -2220,7 +2220,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // SPA's primary loader path). Filter to just the target job by
  // stable id so we don't replace `jobs` wholesale.
  try {
- const res = await fetch(`/data/jobs-${locale}-index.json`);
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`));
  if (res.ok) {
  const all = await res.json();
  if (Array.isArray(all)) {
@@ -2820,7 +2820,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  try {
  const responses = await Promise.allSettled(
  otherLocales.map(async (l) => {
- const res = await fetch(`/data/jobs-${l}-index.json`);
+ const res = await fetch(cdnDataUrl(`/data/jobs-${l}-index.json`));
  if (!res.ok) return [] as unknown[];
  const data = await res.json();
  return Array.isArray(data) ? (data as unknown[]) : [];
@@ -2871,11 +2871,11 @@ const JobBoard: React.FC<JobBoardProps> = ({
  (async () => {
  try {
  let pool: unknown[] = [];
- const slimRes = await fetch(`/data/jobs-${locale}-index.json`);
+ const slimRes = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`));
  if (slimRes.ok) {
  pool = await slimRes.json();
  } else {
- const localeRes = await fetch(`/data/jobs-${locale}.json`);
+ const localeRes = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
  if (localeRes.ok) pool = await localeRes.json();
  }
  if (cancelled) return;

--- a/components/comparators/HealthInsurance.tsx
+++ b/components/comparators/HealthInsurance.tsx
@@ -6,6 +6,7 @@ import { Analytics } from '@/services/analytics';
 import PartnerRecommendations from '@/components/shared/PartnerRecommendations';
 import ProviderLogo from '@/components/shared/ProviderLogo';
 import { lazyRetry } from '@/services/lazyRetry';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 const LeadMagnetCTA = lazyRetry(() => import('@/components/shared/LeadMagnetCTA'));
 const RelatedTools = lazyRetry(() => import('@/components/shared/RelatedTools'));
 
@@ -161,11 +162,11 @@ const HealthInsurance: React.FC = () => {
  const year = new Date().getUTCFullYear();
  const primary = `/data/health-premiums/${year}.json`;
  const fallback = '/data/health-premiums.json';
- fetch(primary)
+ fetch(cdnDataUrl(primary))
  .then(r => r.ok ? r.json() : null)
  .then(d => {
  if (d) { setData(d); return; }
- return fetch(fallback).then(r => r.ok ? r.json() : null).then(d2 => { if (d2) setData(d2); });
+ return fetch(cdnDataUrl(fallback)).then(r => r.ok ? r.json() : null).then(d2 => { if (d2) setData(d2); });
  })
  .catch(() => {});
  }, []);

--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -8,6 +8,7 @@ import { getSerpExperimentDiagnostics } from '@/services/seoService';
 import { getConfigValue } from '@/services/firebase';
 import { useAuth } from '@/services/authService';
 import { buildNewsletterPreviewHtml } from '@/services/newsletterPreview';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 import {
  Shield, Copy, Check, ExternalLink,
  AlertTriangle, CheckCircle2, Eye,
@@ -507,7 +508,7 @@ export default function AdminPanel() {
  setJobsCrawlerConfigMessage(null);
  try {
  const fromStatic = async (): Promise<JobsCrawlerConfigState> => {
- const raw = await safeFetchJson('/data/jobs-crawler-config.json');
+ const raw = await safeFetchJson(cdnDataUrl('/data/jobs-crawler-config.json'));
  if (!raw) return DEFAULT_JOBS_CRAWLER_CONFIG;
  return {
  domainWhitelist: Array.isArray(raw?.domainWhitelist) ? raw.domainWhitelist : [],
@@ -574,7 +575,7 @@ export default function AdminPanel() {
  setSourceSeedsByNameText(JSON.stringify(cfg.sourceSeedsByName || {}, null, 2));
 
  {
- const crawlerSummariesJson = await safeFetchJson('/data/jobs-crawler-summaries.json');
+ const crawlerSummariesJson = await safeFetchJson(cdnDataUrl('/data/jobs-crawler-summaries.json'));
  const summaries = Array.isArray(crawlerSummariesJson?.summaries) ? crawlerSummariesJson.summaries : [];
  setCrawlerSummaries(
  summaries.map((entry: any) => ({
@@ -609,7 +610,7 @@ export default function AdminPanel() {
  );
  }
  {
- const crawlerWorkflowsJson = await safeFetchJson('/data/jobs-crawler-workflows.json');
+ const crawlerWorkflowsJson = await safeFetchJson(cdnDataUrl('/data/jobs-crawler-workflows.json'));
  if (crawlerWorkflowsJson?.workflows) {
  setDynamicCrawlerWorkflows(
  (crawlerWorkflowsJson.workflows as any[]).map((w: any) => ({

--- a/components/pages/FuelPriceStats.tsx
+++ b/components/pages/FuelPriceStats.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, ChevronUp, ExternalLink, Fuel, Loader2, MapP
 import { useTranslation } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
 import { buildSwissStationSlug, fetchFuelPrices, type FuelPricesDataset, type FuelStationItaly, type FuelStationSwitzerland, type MunicipalityFuelRow, zoneFromAddress } from '@/services/fuelPricesService';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 import { FUEL_DAILY_LOCALES, buildFuelItalianStationPath, buildStationSlug, slugify, type FuelDailyLocale } from '@/build-plugins/fuelDailyData';
 
 type SortKey = 'saving' | 'delta' | 'italy' | 'swiss' | 'name';
@@ -446,7 +447,7 @@ export default function FuelPriceStats() {
  .finally(() => {
  if (!cancelled) setLoading(false);
  });
- fetch('/data/fuel-italian-station-pages.json')
+ fetch(cdnDataUrl('/data/fuel-italian-station-pages.json'))
  .then((r) => (r.ok ? r.json() : null))
  .then((j: { stations?: string[] } | null) => {
  if (!cancelled && Array.isArray(j?.stations)) setStationPages(new Set(j!.stations));

--- a/components/pages/HealthPremiumStats.tsx
+++ b/components/pages/HealthPremiumStats.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Heart, TrendingDown, TrendingUp, MapPin, Filter, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import { useTranslation } from '@/services/i18n';
 import DataFreshness from '@/components/shared/DataFreshness';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 interface RankingEntry {
  municipality: string;
@@ -39,11 +40,11 @@ const HealthPremiumStats: React.FC = () => {
  const year = new Date().getUTCFullYear();
  const primary = `/data/health-premiums/${year}.json`;
  const fallback = '/data/health-premiums.json';
- fetch(primary)
+ fetch(cdnDataUrl(primary))
  .then(r => r.ok ? r.json() : null)
  .then(d => {
  if (d) { setData(d); return; }
- return fetch(fallback).then(r => r.ok ? r.json() : null).then(d2 => { if (d2) setData(d2); });
+ return fetch(cdnDataUrl(fallback)).then(r => r.ok ? r.json() : null).then(d2 => { if (d2) setData(d2); });
  })
  .catch(() => {});
  }, []);

--- a/components/vita/TicinoCompanies.tsx
+++ b/components/vita/TicinoCompanies.tsx
@@ -8,6 +8,7 @@ import { Analytics } from '@/services/analytics';
 import { buildPath } from '@/services/router';
 import { resolveCompanyWebsiteHost } from '@/services/jobDataNormalization';
 import { reportCaughtError } from '@/services/errorReporter';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 import extraCompaniesData from '@/data/ticino-companies-extra.json';
 import crawlerCompaniesData from '@/data/crawler-companies-auto.json';
 import ProviderLogo from '@/components/shared/ProviderLogo';
@@ -571,12 +572,12 @@ const TicinoCompanies: React.FC = () => {
 
  useEffect(() => {
  let cancelled = false;
- fetch(`/data/jobs-${locale}.json?fresh=${Date.now()}`, { cache: 'no-store' })
+ fetch(cdnDataUrl(`/data/jobs-${locale}.json?fresh=${Date.now()}`), { cache: 'no-store' })
  .then((res) => {
  if (!res.ok) throw new Error(`${res.status}`);
  return res.json();
  })
- .catch(() => fetch(`/data/jobs.json?fresh=${Date.now()}`, { cache: 'no-store' }).then((r) => r.json()))
+ .catch(() => fetch(cdnDataUrl(`/data/jobs.json?fresh=${Date.now()}`), { cache: 'no-store' }).then((r) => r.json()))
  .then((data: JobListingLite[]) => {
  if (cancelled || !Array.isArray(data)) return;
  const counts: Record<string, number> = {};

--- a/hooks/useExpiredJob.ts
+++ b/hooks/useExpiredJob.ts
@@ -7,6 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 export interface ExpiredJob {
  slug: string;
@@ -29,7 +30,7 @@ let fetchPromise: Promise<ExpiredJob[]> | null = null;
 function fetchExpiredJobs(): Promise<ExpiredJob[]> {
  if (cachedExpiredJobs) return Promise.resolve(cachedExpiredJobs);
  if (!fetchPromise) {
- fetchPromise = fetch('/data/expired-jobs.json')
+ fetchPromise = fetch(cdnDataUrl('/data/expired-jobs.json'))
  .then((r) => r.json() as Promise<ExpiredJob[]>)
  .then((data) => {
  cachedExpiredJobs = data;

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -3,8 +3,11 @@
 //
 // Offload BUILD-GENERATED assets out of the GitHub Pages artifact, rewriting
 // their references to the dedicated CDN repo's Pages site (CDN_BASE). Two phases:
-//   1. per-job OG cards (dist/og)            — rewrite static og:image refs
-//   2. per-job detail JSON (dist/data/job-detail) — inject runtime CDN base
+//   1. per-job OG cards (dist/og)  — rewrite static og:image refs in HTML
+//   2. all runtime data JSON (dist/data) — inject runtime CDN base, delete the
+//      cdn-only files (keep any /data/ path referenced same-origin in HTML/XML)
+// (The JS/CSS bundle is offloaded separately: ASSET_CDN/renderBuiltUrl rebases it
+//  at build time; the deploy verify step deletes dist/assets fail-safe.)
 //
 // (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
 // the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
@@ -144,31 +147,34 @@ function offloadOgImages(distDir, cdnBase) {
   log(`offloaded ${presentTargets.map((t) => t.url).join(' + ')} → ${cdnBase} ; rewrote ${rewritten}/${scanned} files ; freed ${(freed / 1048576).toFixed(0)} MB`);
 }
 
-// ── Phase 2: generated runtime-fetched data (per-job detail JSON) ─────────────
-// dist/data/job-detail/<id>.json (~225 MB) is fetched on demand by the SPA
-// (components/community/JobBoard.tsx → fetchJobDetail) using a URL built at
-// RUNTIME in the JS bundle — it is NOT referenced in static HTML, so it cannot
-// be rewritten like og:image. Instead we inject the CDN base as a global the
-// fetch helper reads (services/cdnDataBase.ts → cdnDataUrl), then delete the dir.
+// ── Phase 2: generated runtime-fetched data (all of dist/data) ────────────────
+// dist/data/**.json (job-detail ~225 MB, jobs-<locale> ~96 MB, indexes, slug-map,
+// stats, fuel, health, …) is fetched on demand by the SPA via fetch() URLs built
+// at RUNTIME in the JS bundle — NOT referenced in static HTML, so they can't be
+// rewritten like og:image. Every such fetch site routes through
+// services/cdnDataBase.ts → cdnDataUrl(); here we inject the CDN base as the
+// global cdnDataUrl reads, then delete the offloaded files from dist.
 //
-// GRACEFUL DEGRADATION: the static SSG job pages already contain the full job
-// content in HTML (crawler-visible SEO is unaffected). job-detail.json only
-// enriches the hydrated SPA detail view, and fetchJobDetail() catches any
-// failure → {} (no enrichment, page still renders). So a missed inject or a raw
-// hiccup degrades the interactive detail view but never breaks a page or SEO.
-const DATA_DIRS = [['data', 'job-detail']];
+// GUARD: a /data/… path that appears LITERALLY in dist HTML/XML/TXT (sitemap
+// entries, <a href> downloads, <link>) is loaded same-origin — NOT through
+// cdnDataUrl — so it MUST stay in the artifact. Those files are kept; the rest
+// (only ever fetched via cdnDataUrl) are deleted and served from the CDN.
+//
+// GRACEFUL DEGRADATION: the static SSG job pages already contain full job
+// content in HTML (crawler-visible SEO unaffected). The data JSON only feeds the
+// hydrated SPA, and the fetch sites catch failures. So a missed inject or a CDN
+// hiccup degrades an interactive view but never breaks a page or SEO.
 
 function offloadGeneratedData(distDir, cdnBase) {
-  const present = DATA_DIRS.filter((d) => fs.existsSync(path.join(distDir, ...d)));
-  if (present.length === 0) {
-    log('no generated-data dirs present in dist — skipping data phase');
+  const dataDir = path.join(distDir, 'data');
+  if (!fs.existsSync(dataDir)) {
+    log('no dist/data — skipping data phase');
     return;
   }
 
   // Inject `<script>window.__CDN_DATA_BASE__="<cdnBase>"</script>` right after the
   // first <head> of every HTML page so the base is set before the SPA boots.
-  // Idempotent (skip if already present). Runs only over .html (the SPA shell +
-  // SSG pages — any of which can client-nav to a job detail).
+  // Idempotent (skip if already present).
   const injectTag = `<script>window.__CDN_DATA_BASE__=${JSON.stringify(cdnBase)}</script>`;
   let injected = 0;
   let htmlSeen = 0;
@@ -184,20 +190,36 @@ function offloadGeneratedData(distDir, cdnBase) {
     injected++;
   });
 
-  // Only delete if at least one page carries the base — otherwise every
-  // job-detail fetch would 404 (still graceful, but pointless). If nothing was
-  // injected, keep the data in dist.
+  // Only delete if the base reached at least one page — else every cdnDataUrl
+  // fetch would 404 (still graceful, but pointless). If nothing injected, keep.
   if (injected === 0) {
-    log(`GUARD: base injected into 0/${htmlSeen} HTML pages — keeping data in dist`);
+    log(`GUARD: base injected into 0/${htmlSeen} HTML pages — keeping dist/data`);
     return;
   }
+
+  // Collect every same-origin /data/… path referenced LITERALLY in HTML/XML/TXT
+  // (these load same-origin, not via cdnDataUrl) — keep those files.
+  const referenced = new Set();
+  const reData = /\/data\/[^"'\s)?<>]+/g;
+  walk(distDir, (fp) => {
+    if (!SCAN_EXT.has(path.extname(fp))) return;
+    const txt = fs.readFileSync(fp, 'utf8');
+    let m;
+    while ((m = reData.exec(txt))) referenced.add(decodeURIComponent(m[0].split('?')[0]));
+  });
+
+  // Delete every dist/data file NOT referenced same-origin in HTML/XML/TXT.
   let freed = 0;
-  for (const d of present) {
-    const dir = path.join(distDir, ...d);
-    freed += dirSize(dir);
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  log(`offloaded ${present.map((d) => '/' + d.join('/') + '/').join(' + ')} → ${cdnBase} ; injected base into ${injected}/${htmlSeen} HTML ; freed ${(freed / 1048576).toFixed(0)} MB`);
+  let removed = 0;
+  let kept = 0;
+  walkAll(dataDir, (fp) => {
+    const rel = '/' + path.relative(distDir, fp).split(path.sep).join('/'); // /data/…
+    if (referenced.has(rel)) { kept++; return; }
+    freed += fs.statSync(fp).size;
+    fs.rmSync(fp, { force: true });
+    removed++;
+  });
+  log(`data → ${cdnBase} ; injected base into ${injected}/${htmlSeen} HTML ; removed ${removed} files (kept ${kept} HTML-referenced) ; freed ${(freed / 1048576).toFixed(0)} MB`);
 }
 
 function main() {

--- a/services/chatbotTools.ts
+++ b/services/chatbotTools.ts
@@ -17,6 +17,7 @@
  */
 
 import { buildPath } from '@/services/router';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -249,7 +250,7 @@ export function buildJobUrl(job: JobRecord, locale: Locale): string {
 /** Safe dataset loader — returns [] on any error so the tool never throws. */
 async function loadJobs(locale: Locale): Promise<JobRecord[]> {
  try {
- const res = await fetch(`/data/jobs-${locale}.json`, { cache: 'force-cache' });
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`), { cache: 'force-cache' });
  if (!res.ok) return [];
  const data = await res.json();
  return Array.isArray(data) ? (data as JobRecord[]) : [];

--- a/services/fuelPricesService.ts
+++ b/services/fuelPricesService.ts
@@ -1,4 +1,5 @@
 import { reportCaughtError } from '@/services/errorReporter';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 export type FuelComparisonCountry = 'IT' | 'CH' | 'SAME' | 'NO_DATA';
 
@@ -171,7 +172,7 @@ async function fetchFromFirestore(): Promise<FuelPricesDataset> {
 /** Fallback: fetch the daily JSON cache from the static build */
 async function fetchFromStaticJson(forceRefresh: boolean): Promise<FuelPricesDataset> {
  const url = forceRefresh ? '/data/fuel-prices.json?t=' + Date.now() : '/data/fuel-prices.json';
- const response = await fetch(url, { cache: forceRefresh ? 'no-store' : 'default' });
+ const response = await fetch(cdnDataUrl(url), { cache: forceRefresh ? 'no-store' : 'default' });
  if (!response.ok) {
  throw new Error('Fuel static JSON unavailable (' + response.status + ')');
  }

--- a/services/jobBoardStatsService.ts
+++ b/services/jobBoardStatsService.ts
@@ -1,3 +1,5 @@
+import { cdnDataUrl } from './cdnDataBase';
+
 export interface JobBoardActionTotals {
  added: number;
  updated: number;
@@ -69,7 +71,7 @@ export interface JobBoardStatsData {
 
 export async function fetchJobBoardStats(forceRefresh = false): Promise<JobBoardStatsData | null> {
  const suffix = forceRefresh ? `?fresh=${Date.now()}` : '';
- const response = await fetch(`/data/jobs-stats.json${suffix}`, {
+ const response = await fetch(cdnDataUrl(`/data/jobs-stats.json${suffix}`), {
  cache: forceRefresh ? 'no-store' : 'default',
  });
  if (!response.ok) {

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -47,6 +47,7 @@
  */
 
 import { expandCantonGroup } from './cantonList';
+import { cdnDataUrl } from './cdnDataBase';
 import type { Locale } from './i18n';
 
 /**
@@ -165,7 +166,7 @@ function idbPut(db: IDBDatabase, record: CantonCacheRecord): Promise<void> {
 
 function buildShardUrl(cantonCode: string): string {
  // Encode just in case a code contains characters needing escaping (e.g. '_AGGREGATE_').
- return `${SHARD_BASE_PATH}/${encodeURIComponent(cantonCode)}.json`;
+ return cdnDataUrl(`${SHARD_BASE_PATH}/${encodeURIComponent(cantonCode)}.json`);
 }
 
 async function fetchShardDirect(cantonCode: string): Promise<{
@@ -415,7 +416,7 @@ export function getDefaultCantonForVisit(): string {
  * `dist/` by `jobsJsonDistCleanupPlugin`. Bypasses the IDB cache entirely.
  */
 export async function fetchAllJobs(locale: Locale): Promise<Job[]> {
- const res = await fetch(`/data/jobs-${locale}.json`);
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
  if (!res.ok) {
   throw new Error(`[jobsService] fetchAllJobs(${locale}): HTTP ${res.status}`);
  }

--- a/services/newsletterPreview.ts
+++ b/services/newsletterPreview.ts
@@ -9,6 +9,7 @@ import {
  FALLBACK_SUBJECT,
 } from '@/services/newsletter-content.mjs';
 import { reportCaughtError } from '@/services/errorReporter';
+import { cdnDataUrl } from '@/services/cdnDataBase';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 const GEMINI_MODEL = 'gemini-2.0-flash-lite';
@@ -192,7 +193,7 @@ export async function buildNewsletterPreviewHtml(
  // Newsletter preview is IT-only (sample render for the editor); the
  // per-locale split (data/jobs-it.json) has identical jobs flattened to
  // IT strings — same content as the old monolithic jobs.json for IT.
- const res = await fetch('/data/jobs-it.json');
+ const res = await fetch(cdnDataUrl('/data/jobs-it.json'));
  jobs = res.ok ? await res.json() : [];
  } catch (e) {
  reportCaughtError(e, 'newsletterPreview.fetchJobsData');

--- a/services/router.ts
+++ b/services/router.ts
@@ -15,6 +15,7 @@
  */
 
 import { getLocale, type Locale } from './i18n';
+import { cdnDataUrl } from './cdnDataBase';
 import {
  CITY_HUB_KEYS,
  CITY_HUB_DISPLAY_NAME,
@@ -1645,7 +1646,7 @@ export function getJobMetaForSlug(slug: string): { id?: string; canton?: string;
 export async function ensureJobSlugMapLoaded(): Promise<void> {
  if (_jobSlugMap) return;
  if (!_jobSlugMapPromise) {
- _jobSlugMapPromise = fetch('/data/jobs-slug-map.json')
+ _jobSlugMapPromise = fetch(cdnDataUrl('/data/jobs-slug-map.json'))
  .then(r => r.ok ? r.json() : Promise.reject(r.status))
  .then((data: Array<{ id?: string; canton?: string; slug?: string; slugByLocale?: Partial<Record<string, string>>; previousSlugs?: string[]; previousSlugsByLocale?: Partial<Record<string, string[]>> }>) => {
  registerJobSlugMap(data);

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -8,6 +8,7 @@ import { parsePath, buildPath, buildAllLocalePaths, type AppRoute } from './rout
 import { ALL_GLOSSARY_TERM_IDS, ALL_BORDER_CROSSING_IDS } from './router';
 import { resolveCompanyLogoUrl, isMultiLocation } from './jobDataNormalization';
 import { reportCaughtError } from './errorReporter';
+import { cdnDataUrl } from './cdnDataBase';
 import { normalizeStructuredData } from './seo/schema-normalizers';
 import { cdnBlogImage } from './seo/blogImageCdn';
 import { translateSchema } from './seo/schema-translators';
@@ -276,7 +277,7 @@ async function loadJobsBySlug(locale: Locale): Promise<Map<string, any>> {
  const promise = (async () => {
  const out = new Map<string, any>();
  try {
- const res = await fetch(`/data/jobs-${locale}.json`);
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
  if (!res.ok) return out;
  const list = await res.json();
  if (!Array.isArray(list)) return out;

--- a/services/unemploymentRateService.ts
+++ b/services/unemploymentRateService.ts
@@ -1,3 +1,5 @@
+import { cdnDataUrl } from './cdnDataBase';
+
 export interface SwitzerlandUnemploymentRateData {
  rate: number;
  unit: 'percent';
@@ -15,7 +17,7 @@ const DATA_URL = '/data/switzerland-unemployment-rate.json';
 
 export async function fetchSwitzerlandUnemploymentRate(): Promise<SwitzerlandUnemploymentRateData | null> {
  try {
- const res = await fetch(DATA_URL);
+ const res = await fetch(cdnDataUrl(DATA_URL));
  if (!res.ok) return null;
  const data = (await res.json()) as SwitzerlandUnemploymentRateData;
  if (!data || typeof data.rate !== 'number' || !data.period) return null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -310,8 +310,25 @@ export default defineConfig(({ mode }) => {
  // Paired with the disabled bootstrap above. Code retained for future
  // revival once a use-case (rollback / hotfix-only chains) emerges.
  ];
+ // When ASSET_CDN is set (deploy build only), emit absolute CDN URLs for all
+ // bundler assets (JS/CSS/chunks) so dist/assets can be offloaded to the
+ // frontaliere-cdn Pages site. Unset (dev / normal builds) → renderBuiltUrl is
+ // absent → 100% default base-relative behaviour, nothing changes.
+ const ASSET_CDN = (process.env.ASSET_CDN || '').trim().replace(/\/+$/, '');
+
  return {
  base: '/',
+ ...(ASSET_CDN
+ ? {
+ experimental: {
+ renderBuiltUrl(filename: string) {
+ // filename is output-relative, e.g. "assets/index-abc.js" → served
+ // from the CDN repo at the same path.
+ return `${ASSET_CDN}/${filename}`;
+ },
+ },
+ }
+ : {}),
  server: {
  port: 3000,
  host: '0.0.0.0',


### PR DESCRIPTION
## Scopo
Estende l'offload CDN da og+job-detail a **tutto lo static** (bundle JS/CSS + tutti i JSON runtime), servito dal repo `frontaliere-cdn` sul dominio custom `cdn.frontaliereticino.ch` (già live + merged in #1291). Richiesta utente: "move everything there".

## Implementato
- **Bundle JS/CSS** → CDN via `vite.config` `experimental.renderBuiltUrl`, **gated su `ASSET_CDN`**: in dev/build normali la chiave è assente → comportamento default invariato. Il deploy setta `ASSET_CDN`, pusha `dist/assets`, e li cancella SOLO dopo un **verify fail-safe**:
  - sample asset deve servire da CDN (poll ~4min, lag build Pages), **altrimenti FAIL del deploy** (asset boot-critical, nessun fallback → resta live l'ultimo deploy buono);
  - se un qualsiasi HTML in dist riferisce ancora `/assets/` same-origin (es. emitter SSG non passato da renderBuiltUrl) → **tiene** `dist/assets` (non-fatale, nessuna riduzione quel giro, zero rotture).
- **Tutti i JSON runtime** → CDN: 28 fetch `('/data/…')` nell'app instradati via `services/cdnDataBase.ts` → `cdnDataUrl`. Lo script offload inietta `window.__CDN_DATA_BASE__` e cancella tutto `dist/data` **tranne** i file referenziati same-origin in HTML/XML (sitemap, `<a href>`) — quelli restano nell'artifact (guard testato).
- **Deploy**: push `dist/og` + `dist/data` + `dist/assets` al repo CDN in un solo force-push (single commit, no bloat history); `CNAME` ristampato ad ogni push.

## Sicurezza
- og + data: `continue-on-error` / script non-fatale (fallimento → restano in dist).
- assets (boot-critical): fail-safe-by-failing + guard same-origin (vedi sopra). Stessa infra del sito (GitHub Pages/Fastly) → no nuovo single-point-of-failure.
- SEO intatta: HTML SSG ha sempre il contenuto completo; data/og degradano graceful.

## Validazione locale (limite: build Vite va in OOM, non eseguibile in locale)
- `node --check` script ✓; offload script functional test (guard keep/delete, base inject, og rewrite) ✓; tutti i 15 file editati `esbuild` ✓ + import presenti; `vite.config` `esbuild` ✓; gating renderBuiltUrl (assente senza ASSET_CDN) ✓; regex Guard B (CDN url non matchato, same-origin matchato) ✓; YAML ✓.
- Il build completo + il rebasing asset si validano solo sul **deploy live** (vincolo OOM noto). Fail-safe progettato per non pubblicare un artifact rotto.

## Non implementato (per scelta)
- **Blog hero images**: già offloadate su jsDelivr@main (fuori artifact) — non spostate (nessun guadagno artifact, eviterei regressioni).
- **Blog 480w thumbnails (~49M) + immagini public minori (~3M)**: same-origin; le thumbnail richiedono rework del srcSet runtime → follow-up separato.
- Non scende sotto i 10GB (il muro restano le pagine HTML, fuori scope per tua decisione).

🤖 Generated with [Claude Code](https://claude.com/claude-code)