### PR TITLE
feat(cdn): move blog heroes off jsDelivr to cdn.frontaliereticino.ch (consistency)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,16 +686,25 @@ jobs:
           rm -rf "$stage" && mkdir -p "$stage"
           : > "$stage/.nojekyll"                              # serve every path verbatim, skip Jekyll
           printf 'cdn.frontaliereticino.ch' > "$stage/CNAME"  # keep custom domain (force-push would else wipe it)
-          # Offloadable dirs: og cards, ALL runtime data JSON, and the bundler
-          # assets (JS/CSS) whose URLs renderBuiltUrl already rebased to the CDN.
-          [ -d dist/og ]     && cp -r dist/og     "$stage/og"
-          [ -d dist/data ]   && cp -r dist/data   "$stage/data"
-          [ -d dist/assets ] && cp -r dist/assets "$stage/assets"
-          if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ]; then
+          # Offloadable dirs: og cards, ALL runtime data JSON, the bundler assets
+          # (JS/CSS) whose URLs renderBuiltUrl already rebased to the CDN, and the
+          # git-tracked full blog heroes (served at cdn.frontaliereticino.ch/images/
+          # blog; finalize plugin already rewrote HTML + deleted dist heroes, so we
+          # push from the public/ source). 480w thumbnails stay same-origin.
+          [ -d dist/og ]           && cp -r dist/og           "$stage/og"
+          [ -d dist/data ]         && cp -r dist/data         "$stage/data"
+          [ -d dist/assets ]       && cp -r dist/assets       "$stage/assets"
+          [ -d public/images/blog ] && mkdir -p "$stage/images" && cp -r public/images/blog "$stage/images/blog"
+          if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ]; then
             echo "no offloadable assets present — skipping CDN push"; exit 0
           fi
           printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"
           echo "CDN payload: $(du -sh "$stage" | cut -f1)"
+          # Flag if the CDN repo nears the GitHub Pages ~1 GB published-site soft limit.
+          payload_bytes="$(du -sb "$stage" | cut -f1)"
+          if [ "$payload_bytes" -gt 950000000 ]; then
+            echo "::warning::CDN payload ${payload_bytes} bytes (>950 MB) — approaching GitHub Pages ~1 GB soft limit; consider splitting (e.g. keep blog heroes on jsDelivr)"
+          fi
           keyfile="$RUNNER_TEMP/cdn_deploy_key"
           printf '%s\n' "$CDN_DEPLOY_KEY" > "$keyfile" && chmod 600 "$keyfile"
           export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -1,11 +1,12 @@
 // blogImageCdnFinalizePlugin.ts
 //
-// Post-build step that offloads full blog hero images to jsDelivr and removes
-// them from the GitHub Pages artifact. Runs last (enforce: 'post').
+// Post-build step that offloads full blog hero images to the frontaliere-cdn
+// Pages site (cdn.frontaliereticino.ch) and removes them from the main GitHub
+// Pages artifact. Runs last (enforce: 'post').
 //
 // 1. Rewrite every SSG-emitted reference to a FULL blog image
 //    (`/images/blog/<file>.webp`, origin-absolute or site-relative) to its
-//    jsDelivr CDN URL, across dist HTML/XML/TXT. The 480w thumbnails under
+//    CDN URL, across dist HTML/XML/TXT. The 480w thumbnails under
 //    `/images/blog/thumbnails/` are NOT touched — they stay same-origin.
 // 2. GUARD: re-scan; if any full-blog reference survives, ABORT the offload
 //    (keep the images in dist) rather than delete — never ship a 404, never
@@ -14,15 +15,15 @@
 //
 // SPA runtime <img> references come from data/blog-articles-data.ts, whose
 // ARTICLES export is already CDN-rewritten via cdnBlogImage — so this plugin
-// only needs to handle the static HTML/XML the crawler sees. The repo is
-// public, so jsDelivr (and the raw.githubusercontent fallback) can serve the
-// images pinned to the build commit SHA.
+// only needs to handle the static HTML/XML the crawler sees. The deploy workflow
+// pushes the git-tracked public/images/blog heroes to the CDN repo (raw@SHA is
+// the <img> error fallback).
 
 import type { Plugin } from 'vite';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { JSDELIVR_BLOG_BASE } from './shared/blogImageCdn';
+import { CDN_BLOG_BASE } from './shared/blogImageCdn';
 
 const ORIGIN = 'https://frontaliereticino.ch';
 const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
@@ -38,7 +39,7 @@ const reAbs = new RegExp(ESC_ORIGIN + '/images/blog/' + FILE, 'g');
 const reRel = new RegExp('(?<![\\w.@])/images/blog/' + FILE, 'g');
 // Guard: a SURVIVING full-blog reference that would 404 once the dir is gone —
 // origin-absolute, or relative not preceded by a word char (so `/public/images/
-// blog/…` inside an emitted jsDelivr/raw URL is excluded), excluding thumbnails.
+// blog/…` inside an emitted CDN/raw URL is excluded), excluding thumbnails.
 const reLeak = new RegExp(
   '(?:' + ESC_ORIGIN + '/images/blog/|(?<![\\w.@])/images/blog/)(?!thumbnails/)' + FILE,
 );
@@ -70,7 +71,7 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
         return;
       }
 
-      const repl = (_m: string, file: string): string => `${JSDELIVR_BLOG_BASE}/${file}`;
+      const repl = (_m: string, file: string): string => `${CDN_BLOG_BASE}/${file}`;
       let scanned = 0;
       let rewritten = 0;
       // Single pass: rewrite each file, then verify the RESULT in-memory (no
@@ -110,7 +111,7 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
         deleted++;
       }
       console.log(
-        `[blog-image-cdn] rewrote ${rewritten}/${scanned} files → jsDelivr; ` +
+        `[blog-image-cdn] rewrote ${rewritten}/${scanned} files → CDN; ` +
           `deleted ${deleted} full blog images (${(freed / 1048576).toFixed(0)} MB freed; thumbnails kept local)`,
       );
     },

--- a/build-plugins/shared/blogImageCdn.ts
+++ b/build-plugins/shared/blogImageCdn.ts
@@ -1,10 +1,8 @@
 // blogImageCdn.ts (build-side)
 //
-// Build-plugin counterpart of services/seo/blogImageCdn.ts. Build plugins run
-// in Node (no Vite `__COMMIT_HASH__` define), so the commit SHA comes from
-// build-plugins/constants.ts (git rev-parse / CI env). Keep the jsDelivr base
-// + rewrite logic byte-compatible with the app-side helper so SSG-emitted URLs
-// and SPA-rendered URLs match (preload/og/JSON-LD ↔ hydrated <img>).
+// Build-plugin counterpart of services/seo/blogImageCdn.ts. Keep the CDN base +
+// rewrite logic byte-compatible with the app-side helper so SSG-emitted URLs and
+// SPA-rendered URLs match (preload/og/JSON-LD ↔ hydrated <img>).
 //
 // See services/seo/blogImageCdn.ts for the full rationale.
 
@@ -13,7 +11,11 @@ import { COMMIT_HASH } from '../constants';
 const REPO = 'valerielinc-ops/frontaliere-si-o-no';
 const SHA = COMMIT_HASH && COMMIT_HASH !== 'unknown' ? COMMIT_HASH : 'main';
 
-export const JSDELIVR_BLOG_BASE = `https://cdn.jsdelivr.net/gh/${REPO}@${SHA}/public/images/blog`;
+// Full blog heroes are pushed to the frontaliere-cdn Pages site (Fastly) under
+// /images/blog. STABLE URL (no SHA) — consistent with og/data/assets on the same
+// CDN. The raw.githubusercontent fallback (git-tracked source @SHA) covers an
+// <img> error if the CDN is briefly unreachable.
+export const CDN_BLOG_BASE = `https://cdn.frontaliereticino.ch/images/blog`;
 export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/public/images/blog`;
 
 // Full blog image at the section root (NOT under thumbnails/). Accepts a
@@ -21,13 +23,13 @@ export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/p
 const FULL_BLOG_RX = /^(?:https?:\/\/[^/]+)?\/images\/blog\/([^/]+\.(?:webp|png|jpe?g|avif))$/i;
 
 /**
- * Rewrite a full blog hero image reference to its jsDelivr CDN URL.
+ * Rewrite a full blog hero image reference to its CDN URL.
  * Thumbnails (`/images/blog/thumbnails/...`) and non-blog paths pass through.
  */
 export function cdnBlogImage(path: string | undefined | null): string {
   if (!path) return path ?? '';
-  if (path.startsWith(JSDELIVR_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
+  if (path.startsWith(CDN_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
   const m = path.match(FULL_BLOG_RX);
   if (!m) return path;
-  return `${JSDELIVR_BLOG_BASE}/${m[1]}`;
+  return `${CDN_BLOG_BASE}/${m[1]}`;
 }

--- a/services/seo/blogImageCdn.ts
+++ b/services/seo/blogImageCdn.ts
@@ -1,10 +1,11 @@
 // blogImageCdn.ts
 //
-// Serve full blog hero images from jsDelivr (git-backed free CDN) instead of
-// bundling them into the GitHub Pages artifact. The full images live in the
-// repo at public/images/blog/*.webp (git-tracked), so jsDelivr serves them
-// pinned to the build commit SHA — available immediately (the commit exists
-// on GitHub before deploy) and immutably cacheable.
+// Serve full blog hero images from the frontaliere-cdn GitHub Pages site (Fastly
+// edge) on cdn.frontaliereticino.ch instead of bundling them into the main
+// GitHub Pages artifact. The full images live in the repo at
+// public/images/blog/*.webp (git-tracked); the deploy workflow pushes them to
+// the CDN repo under /images/blog, served at a STABLE URL — consistent with
+// og/data/assets, all on the one CDN (no jsDelivr).
 //
 // Scope: ONLY full hero images (~224 MB) move to the CDN. The 480w responsive
 // thumbnails under /images/blog/thumbnails/ are build-generated (gitignored)
@@ -13,23 +14,23 @@
 // dist/images/blog (keeping thumbnails) and fails the build if any full-image
 // origin reference survives in the emitted HTML.
 //
-// Fallback: if jsDelivr is unreachable, installBlogImageCdnFallback() rewrites
-// the failing <img> to raw.githubusercontent.com at the same SHA. raw serves
-// images fine — its text/plain MIME + nosniff only block scripts, not images.
+// Fallback: if the CDN is briefly unreachable, installBlogImageCdnFallback()
+// rewrites the failing <img> to raw.githubusercontent.com at the build SHA
+// (git-tracked source). raw serves images fine — its text/plain MIME + nosniff
+// only block scripts, not images.
 
 const REPO = 'valerielinc-ops/frontaliere-si-o-no';
 
-// Pinned to the build commit. __COMMIT_HASH__ is injected by Vite
-// (vite.config.ts define, declared in vite-env.d.ts). Falls back to the
-// `main` branch ref when the hash is unavailable (e.g. dev server) — jsDelivr
-// resolves @main too, only without the immutable-cache / instant-new-file
-// guarantee, which dev doesn't need.
+// raw fallback is pinned to the build commit. __COMMIT_HASH__ is injected by
+// Vite (vite.config.ts define, declared in vite-env.d.ts); falls back to `main`
+// when unavailable (e.g. dev server). The primary CDN base has no SHA — it's a
+// stable domain whose Fastly cache is purged on each CDN-repo deploy.
 const SHA =
   typeof __COMMIT_HASH__ !== 'undefined' && __COMMIT_HASH__ && __COMMIT_HASH__ !== 'unknown'
     ? __COMMIT_HASH__
     : 'main';
 
-export const JSDELIVR_BLOG_BASE = `https://cdn.jsdelivr.net/gh/${REPO}@${SHA}/public/images/blog`;
+export const CDN_BLOG_BASE = `https://cdn.frontaliereticino.ch/images/blog`;
 export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/public/images/blog`;
 
 // Full blog image at the section root (NOT under thumbnails/). Matches both a
@@ -38,27 +39,27 @@ export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/p
 const FULL_BLOG_RX = /^(?:https?:\/\/[^/]+)?\/images\/blog\/([^/]+\.(?:webp|png|jpe?g|avif))$/i;
 
 /**
- * Rewrite a full blog hero image reference to its jsDelivr CDN URL.
+ * Rewrite a full blog hero image reference to its CDN URL (cdn.frontaliereticino.ch).
  * Thumbnails (`/images/blog/thumbnails/...`), non-blog paths, and URLs that
  * are already absolute to another host pass through unchanged.
  */
 export function cdnBlogImage(path: string | undefined | null): string {
   if (!path) return path ?? '';
-  if (path.startsWith(JSDELIVR_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
+  if (path.startsWith(CDN_BLOG_BASE) || path.startsWith(RAW_BLOG_BASE)) return path;
   const m = path.match(FULL_BLOG_RX);
   if (!m) return path;
-  return `${JSDELIVR_BLOG_BASE}/${m[1]}`;
+  return `${CDN_BLOG_BASE}/${m[1]}`;
 }
 
-/** Map a jsDelivr blog URL to its raw.githubusercontent fallback, or null. */
+/** Map a CDN blog URL to its raw.githubusercontent fallback, or null. */
 export function rawFallbackForBlog(url: string): string | null {
-  if (!url.startsWith(JSDELIVR_BLOG_BASE + '/')) return null;
-  return RAW_BLOG_BASE + url.slice(JSDELIVR_BLOG_BASE.length);
+  if (!url.startsWith(CDN_BLOG_BASE + '/')) return null;
+  return RAW_BLOG_BASE + url.slice(CDN_BLOG_BASE.length);
 }
 
 let _fallbackInstalled = false;
 /**
- * Install a one-time capture-phase error listener that swaps a failed jsDelivr
+ * Install a one-time capture-phase error listener that swaps a failed CDN
  * blog image to its raw.githubusercontent fallback. Image `error` events don't
  * bubble, so capture phase is required to catch them at the document level.
  */

--- a/tests/blogImageCdn.test.ts
+++ b/tests/blogImageCdn.test.ts
@@ -3,19 +3,19 @@ import { describe, expect, it } from 'vitest';
 import {
   cdnBlogImage,
   rawFallbackForBlog,
-  JSDELIVR_BLOG_BASE,
+  CDN_BLOG_BASE,
   RAW_BLOG_BASE,
 } from '@/services/seo/blogImageCdn';
 
 describe('cdnBlogImage', () => {
-  it('rewrites a site-relative full blog image to the jsDelivr CDN', () => {
+  it('rewrites a site-relative full blog image to the CDN', () => {
     const out = cdnBlogImage('/images/blog/inter-scudetto-chivu-2026.webp');
-    expect(out).toBe(`${JSDELIVR_BLOG_BASE}/inter-scudetto-chivu-2026.webp`);
+    expect(out).toBe(`${CDN_BLOG_BASE}/inter-scudetto-chivu-2026.webp`);
   });
 
   it('rewrites an absolute same-origin full blog image', () => {
     const out = cdnBlogImage('https://frontaliereticino.ch/images/blog/x.webp');
-    expect(out).toBe(`${JSDELIVR_BLOG_BASE}/x.webp`);
+    expect(out).toBe(`${CDN_BLOG_BASE}/x.webp`);
   });
 
   it('leaves 480w thumbnails same-origin (extra path segment)', () => {
@@ -29,7 +29,7 @@ describe('cdnBlogImage', () => {
   });
 
   it('is idempotent on an already-CDN URL', () => {
-    const cdn = `${JSDELIVR_BLOG_BASE}/x.webp`;
+    const cdn = `${CDN_BLOG_BASE}/x.webp`;
     expect(cdnBlogImage(cdn)).toBe(cdn);
   });
 
@@ -41,12 +41,12 @@ describe('cdnBlogImage', () => {
 });
 
 describe('rawFallbackForBlog', () => {
-  it('maps a jsDelivr blog URL to its raw.githubusercontent fallback', () => {
-    const cdn = `${JSDELIVR_BLOG_BASE}/x.webp`;
+  it('maps a CDN blog URL to its raw.githubusercontent fallback', () => {
+    const cdn = `${CDN_BLOG_BASE}/x.webp`;
     expect(rawFallbackForBlog(cdn)).toBe(`${RAW_BLOG_BASE}/x.webp`);
   });
 
-  it('returns null for non-jsDelivr URLs', () => {
+  it('returns null for non-CDN URLs', () => {
     expect(rawFallbackForBlog('/images/blog/x.webp')).toBeNull();
     expect(rawFallbackForBlog('https://frontaliereticino.ch/images/blog/x.webp')).toBeNull();
   });


### PR DESCRIPTION
## Scopo
Consolida TUTTO su una sola CDN: le blog hero images passano da **jsDelivr** → **`cdn.frontaliereticino.ch/images/blog`** (stesso CDN di og/data/assets). Zero dipendenza jsDelivr. Richiesta utente: "coerenza su tutto".

## Implementato
- `services/seo/blogImageCdn.ts` + `build-plugins/shared/blogImageCdn.ts`: `JSDELIVR_BLOG_BASE` → `CDN_BLOG_BASE` (`https://cdn.frontaliereticino.ch/images/blog`, stabile, no SHA, no /public). `RAW_BLOG_BASE@SHA` resta come fallback `<img>` onerror; `rawFallbackForBlog` mappa CDN→RAW.
- `blogImageCdnFinalizePlugin.ts`: riscrive i ref HTML SSG a `CDN_BLOG_BASE` (logica invariata: guard + delete heroes in dist, thumbnails restano).
- `deploy.yml`: push di `public/images/blog` (git-tracked) → repo CDN `/images/blog`; warning se il payload CDN si avvicina al limite soft ~1 GB di GitHub Pages.

## Note importanti
- **Nessuna riduzione artifact**: le blog heroes erano già fuori artifact via jsDelivr — questo è **solo coerenza** (una CDN, zero jsDelivr).
- **Limite ~1 GB Pages sul repo CDN**: ora ospita og+data+assets+blog; il deploy logga un `::warning::` se supera 950 MB → in tal caso si splitta (es. blog di nuovo su jsDelivr).
- **480w thumbnails**: restano same-origin (invariate).

## Validazione locale
- esbuild dei 3 file ✓; `node --check`/YAML ✓; grep zero `JSDELIVR_BLOG_BASE` residui + zero altri importer ✓; functional `cdnBlogImage` (hero→cdn, thumb→same-origin, abs→cdn, idempotente) ✓.
- Build completo si valida su deploy live (vincolo OOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)