### PR TITLE
fix(build): spaBundleResolver match CDN-rebased asset URLs (unblock RED main)

### DIFF
--- a/build-plugins/spaBundleResolver.ts
+++ b/build-plugins/spaBundleResolver.ts
@@ -49,8 +49,14 @@ export interface SpaBundleInfo {
   readonly hasSpaBundle: true;
 }
 
-const ENTRY_JS_RX = /src="\/assets\/(index-[A-Za-z0-9_-]+\.js)"/;
-const ENTRY_CSS_RX = /href="\/assets\/(index-[A-Za-z0-9_-]+\.css)"/;
+// The `[^"]*` before `/assets/` tolerates an optional origin prefix so the
+// resolver matches whether Vite emitted a same-origin `src="/assets/index-…js"`
+// or an absolute CDN URL `src="https://cdn.frontaliereticino.ch/assets/index-…js"`
+// (vite.config experimental.renderBuiltUrl, gated on ASSET_CDN). The capture
+// group is always the bare hashed filename, unchanged. Without this tolerance an
+// ASSET_CDN build makes both regexes miss → poll exhausted → build fails.
+const ENTRY_JS_RX = /src="[^"]*\/assets\/(index-[A-Za-z0-9_-]+\.js)"/;
+const ENTRY_CSS_RX = /href="[^"]*\/assets\/(index-[A-Za-z0-9_-]+\.css)"/;
 
 /**
  * Module-level cache. Keyed by `distDir` so a build that targets multiple

--- a/tests/spa-bundle-resolver.test.ts
+++ b/tests/spa-bundle-resolver.test.ts
@@ -40,6 +40,22 @@ describe('resolveSpaBundle', () => {
     expect(info.hasSpaBundle).toBe(true);
   });
 
+  it('extracts entry hashes when the URLs are absolute CDN URLs (ASSET_CDN/renderBuiltUrl)', () => {
+    // When ASSET_CDN is set, Vite emits absolute CDN URLs for the entry tags.
+    // The resolver must still extract the bare hashed filename (regression: this
+    // failed the entire deploy build with "poll exhausted" — run 26901403074).
+    const html = `<!doctype html>
+<html><head>
+<link rel="stylesheet" href="https://cdn.frontaliereticino.ch/assets/index-BHVvZKod.css">
+<script type="module" crossorigin src="https://cdn.frontaliereticino.ch/assets/index-B0v4sJnp.js"></script>
+</head><body><div id="root"></div></body></html>`;
+    fs.writeFileSync(path.join(distDir, 'index.html'), html, 'utf-8');
+    const info = resolveSpaBundle(distDir);
+    expect(info.entryJs).toBe('index-B0v4sJnp.js');
+    expect(info.entryCss).toBe('index-BHVvZKod.css');
+    expect(info.hasSpaBundle).toBe(true);
+  });
+
   it('caches per distDir — second call does not re-read', () => {
     writeIndexHtml(distDir, 'AAA', 'BBB');
     const first = resolveSpaBundle(distDir);


### PR DESCRIPTION
## URGENTE — sblocca main RED (deploy bloccati)
Il build del deploy fallisce (run 26901403074): dopo #1293, `ASSET_CDN`/`renderBuiltUrl` riscrive i tag entry di `dist/index.html` in URL CDN assoluti (`src="https://cdn.frontaliereticino.ch/assets/index-…js"`), ma `spaBundleResolver` cercava il letterale `src="/assets/…"` (same-origin) → regex miss → **"poll exhausted" → ogni build fallisce**.

## Fix
- `spaBundleResolver.ts`: `ENTRY_JS_RX`/`ENTRY_CSS_RX` ora usano `[^"]*\/assets\/` → matchano sia same-origin che URL CDN assoluti; il capture group resta il filename hashato nudo.
- Test: nuovo caso CDN-URL in `tests/spa-bundle-resolver.test.ts` (7/7 verde) — guard contro la regressione.

## Effetto
Build verde. `index.html` carica gli asset da CDN; le pagine SSG continuano a referenziare gli asset same-origin (gli injector SSG non sono CDN-aware) → la guard del deploy (`Verify CDN assets…`) **mantiene** `dist/assets` (nessuna riduzione asset, nessuna rottura). og+data offload restano attivi. Nota: per offloadare davvero il bundle servirebbe rendere gli injector SSG CDN-aware (segnalo a parte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)