### PR TITLE
feat(cdn): offload JS/CSS bundle + boot assets to cdn.frontaliereticino.ch (post-build rewrite)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -756,7 +756,10 @@ jobs:
             echo "::error::CDN asset $url not serving after ~4min — failing deploy (assets stay live on last good build)"; exit 1
           fi
           # Guard B: any surviving SAME-ORIGIN /assets/ reference in dist HTML?
-          if grep -rlE "[\"'(]/?assets/[A-Za-z0-9._-]+\.(js|css|woff2?|png|jpe?g|webp|svg)" --include='*.html' dist 2>/dev/null | head -1 | grep -q .; then
+          # Extension/path coverage is a SUPERSET of the offload script's Phase 3
+          # (offloadAssetRefs ASSET_FILE) — else a same-origin ref of a type Phase 3
+          # misses would also evade this guard and 404 after delete.
+          if grep -rlE "[\"'(]/?assets/[^\"'() ]*\.(js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)" --include='*.html' dist 2>/dev/null | head -1 | grep -q .; then
             echo "⚠️ some dist HTML still references same-origin /assets/ (not CDN-rebased) — KEEPING dist/assets (no breakage, no asset reduction this round)"
             exit 0
           fi

--- a/build-plugins/asyncCssPlugin.ts
+++ b/build-plugins/asyncCssPlugin.ts
@@ -23,8 +23,10 @@ export function asyncCssPlugin(): Plugin {
  enforce: 'post',
  transformIndexHtml(html) {
  // Add fetchpriority="high" to the entry script for faster JS parsing
+ // src may be same-origin (/assets/…) or an absolute CDN URL
+ // (https://cdn.…/assets/…) when ASSET_CDN/renderBuiltUrl is active.
  html = html.replace(
- /<script type="module" crossorigin src="(\/assets\/index-[^"]+\.js)">/,
+ /<script type="module" crossorigin src="((?:https?:\/\/[^"]+)?\/assets\/index-[^"]+\.js)">/,
  '<script type="module" crossorigin fetchpriority="high" src="$1">'
  );
 
@@ -39,7 +41,7 @@ export function asyncCssPlugin(): Plugin {
  // strip href attributes from session recordings. The same async pattern
  // is already used in jobsSeoPagesPlugin.ts for SPA-shell SEO pages.
  html = html.replace(
- /<link rel="stylesheet" crossorigin href="(\/assets\/[^"]+\.css)">/g,
+ /<link rel="stylesheet" crossorigin href="((?:https?:\/\/[^"]+)?\/assets\/[^"]+\.css)">/g,
  '<link rel="preload" as="style" crossorigin href="$1" data-clarity-unmask="true">' +
  '<link rel="stylesheet" crossorigin href="$1" media="print" onload="this.media=\'all\'" data-clarity-unmask="true">' +
  '<noscript><link rel="stylesheet" crossorigin href="$1" data-clarity-unmask="true"></noscript>'

--- a/build-plugins/shared/seoPageShell.ts
+++ b/build-plugins/shared/seoPageShell.ts
@@ -89,8 +89,9 @@ export function resolveEntryAssets(distDir: string): EntryAssets {
   try {
     const indexHtmlPath = np.join(distDir, 'index.html');
     const built = fs.readFileSync(indexHtmlPath, 'utf-8');
-    entryJs = built.match(/src="\/assets\/(index-[A-Za-z0-9_-]+\.js)"/)?.[1] ?? '';
-    entryCss = built.match(/href="\/assets\/(index-[A-Za-z0-9_-]+\.css)"/)?.[1] ?? '';
+    // src/href may be same-origin or an absolute CDN URL (ASSET_CDN/renderBuiltUrl).
+    entryJs = built.match(/src="[^"]*\/assets\/(index-[A-Za-z0-9_-]+\.js)"/)?.[1] ?? '';
+    entryCss = built.match(/href="[^"]*\/assets\/(index-[A-Za-z0-9_-]+\.css)"/)?.[1] ?? '';
   } catch {
     // dist/index.html missing — tests run without a prior Vite build.
     // buildSimplePage handles empty strings by skipping the hydration tags.

--- a/scripts/analyze-write-collisions.mjs
+++ b/scripts/analyze-write-collisions.mjs
@@ -92,7 +92,7 @@ if (!dumpAvailable) {
  */
 function inspectContent(html) {
   return {
-    hasSpaBundle: /<script[^>]*type="module"[^>]*src="\/assets\/index-[A-Za-z0-9_-]+\.js"/.test(html),
+    hasSpaBundle: /<script[^>]*type="module"[^>]*src="(?:https?:\/\/[^"]+)?\/assets\/index-[A-Za-z0-9_-]+\.js"/.test(html),
     jsonLdCount: (html.match(/<script[^>]+type="application\/ld\+json"/g) || []).length,
     bodyTextLength: html
       .replace(/<script[\s\S]*?<\/script>/gi, ' ')

--- a/scripts/audit-spa-bundle-injection.mjs
+++ b/scripts/audit-spa-bundle-injection.mjs
@@ -82,8 +82,11 @@ if (!fs.existsSync(DIST)) {
  * unquoted attr values containing `/`; the only trailing-slash case is rejected
  * upstream to avoid `/>` self-close collision, and `.js` doesn't end in `/`).
  */
+// src may be same-origin (/assets/…) or an absolute CDN URL
+// (https://cdn.frontaliereticino.ch/assets/…) when ASSET_CDN/renderBuiltUrl is
+// active — the post-deploy artifact is post-rewrite, so tolerate both.
 const SPA_BUNDLE_RX =
-  /<script[^>]*type=["']?module["']?[^>]*src=["']?\/assets\/index-[A-Za-z0-9_-]+\.js["']?/;
+  /<script[^>]*type=["']?module["']?[^>]*src=["']?(?:https?:\/\/[^"'\s]+)?\/assets\/index-[A-Za-z0-9_-]+\.js["']?/;
 
 /**
  * Per-slug index.html files MAY legitimately not contain the SPA bundle when

--- a/scripts/canary-article-content.mjs
+++ b/scripts/canary-article-content.mjs
@@ -121,8 +121,9 @@ async function probe(url) {
   if (bytes < MIN_BYTES) {
     return { url, ok: false, reason: `body=${bytes}B < ${MIN_BYTES}B (stub?)`, bytes };
   }
-  if (!body.includes('src="/assets/index-')) {
-    return { url, ok: false, reason: "missing SPA bundle <script src=/assets/index-*.js>", bytes };
+  // src may be same-origin or an absolute CDN URL (ASSET_CDN/renderBuiltUrl).
+  if (!/src="[^"]*\/assets\/index-/.test(body)) {
+    return { url, ok: false, reason: "missing SPA bundle <script src=.../assets/index-*.js>", bytes };
   }
   // Self-redirect loop detector: bridges contain `location.replace("<self URL>"`.
   // Real articles ship a location.replace ONLY in their flat-sibling shell, not

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -222,6 +222,40 @@ function offloadGeneratedData(distDir, cdnBase) {
   log(`data → ${cdnBase} ; injected base into ${injected}/${htmlSeen} HTML ; removed ${removed} files (kept ${kept} HTML-referenced) ; freed ${(freed / 1048576).toFixed(0)} MB`);
 }
 
+// ── Phase 3: bundler + boot assets (rewrite every /assets/ ref in HTML) ───────
+// dist/assets holds the Vite bundle (entry JS/CSS + content-hashed chunks) AND
+// custom build-emitted assets (early-boot, gtag, PostHog, the AdSense loader,
+// seo-static/bridge CSS, logo) referenced same-origin as `/assets/<file>` across
+// HTML. Vite's renderBuiltUrl already rebased the bundler-internal references
+// (JS chunk imports, CSS url()) to the CDN; this phase rewrites the remaining
+// same-origin `/assets/<file>` references in the EMITTED HTML (entry tags,
+// modulepreload hints, boot <script>s, CSS <link>s) to ${CDN}/assets/<file>.
+//
+// This phase only REWRITES — it does NOT delete dist/assets. The deploy's
+// "Verify CDN assets live, then drop dist/assets" step deletes it, but only
+// after (a) confirming the CDN actually serves a sample asset and (b) re-scanning
+// that NO same-origin /assets/ reference survives (fail-safe; if any does, it
+// keeps dist/assets — no breakage). So a missed rewrite here can never 404.
+const ASSET_FILE = "([^\"'\\s)?]+?\\.(?:js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json))";
+
+function offloadAssetRefs(distDir, cdnBase) {
+  const escOrigin = ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const reAbs = new RegExp(escOrigin + '/assets/' + ASSET_FILE, 'g');
+  // site-relative /assets/, NOT preceded by a word char (so an already-absolute
+  // CDN URL `…cdn.frontaliereticino.ch/assets/…` — preceded by `h` — is skipped).
+  const reRel = new RegExp('(?<![\\w.@])/assets/' + ASSET_FILE, 'g');
+  const repl = (_m, file) => `${cdnBase}/assets/${file}`;
+  let scanned = 0;
+  let rewritten = 0;
+  walk(distDir, (fp) => {
+    scanned++;
+    const orig = fs.readFileSync(fp, 'utf8');
+    const out = orig.replace(reAbs, repl).replace(reRel, repl);
+    if (out !== orig) { fs.writeFileSync(fp, out); rewritten++; }
+  });
+  log(`assets → ${cdnBase}/assets ; rewrote /assets/ refs in ${rewritten}/${scanned} HTML/XML/TXT files (dist/assets deleted by the deploy verify step)`);
+}
+
 function main() {
   // CDN_BASE is the full origin+path of the CDN repo's GitHub Pages site
   // (e.g. https://valerielinc-ops.github.io/frontaliere-cdn), exported by the
@@ -244,6 +278,7 @@ function main() {
 
   offloadOgImages(distDir, cdnBase);
   offloadGeneratedData(distDir, cdnBase);
+  offloadAssetRefs(distDir, cdnBase);
 }
 
 try {

--- a/tests/e2e/post-deploy-rendering-live.spec.ts
+++ b/tests/e2e/post-deploy-rendering-live.spec.ts
@@ -71,8 +71,10 @@ const TARGETS: readonly TargetUrl[] = [
   },
 ];
 
+// src may be same-origin (/assets/…) or an absolute CDN URL
+// (https://cdn.frontaliereticino.ch/assets/…) when ASSET_CDN/renderBuiltUrl is active.
 const SPA_BUNDLE_RX =
-  /<script[^>]+type="module"[^>]+src="\/assets\/index-[A-Za-z0-9_-]+\.js"/;
+  /<script[^>]+type="module"[^>]+src="(?:https?:\/\/[^"]+)?\/assets\/index-[A-Za-z0-9_-]+\.js"/;
 
 /** The bug pattern: '/path-no-slash' (always missing trailing slash) + location.hash */
 function selfBouncingScript(path: string): string {

--- a/tests/e2e/sectors-landing-live.spec.ts
+++ b/tests/e2e/sectors-landing-live.spec.ts
@@ -47,7 +47,8 @@ const HREFLANG_ALTERNATES: ReadonlyArray<{ hreflang: string; path: string }> = [
   { hreflang: 'x-default', path: '/cerca-lavoro-ticino/settori/' },
 ];
 
-const SPA_BUNDLE_RX = /<script[^>]+type="module"[^>]+src="\/assets\/index-[A-Za-z0-9_-]+\.js"/;
+// src may be same-origin or an absolute CDN URL (ASSET_CDN/renderBuiltUrl).
+const SPA_BUNDLE_RX = /<script[^>]+type="module"[^>]+src="(?:https?:\/\/[^"]+)?\/assets\/index-[A-Za-z0-9_-]+\.js"/;
 
 interface FetchedHtml {
   status: number;


### PR DESCRIPTION
## Scopo
Completa l'offload del bundle JS/CSS + asset boot su `cdn.frontaliereticino.ch` (richiesta utente: "sposta TUTTO /assets/, AdSense incluso"). Meccanismo: **un solo rewrite post-build** dell'HTML (come il pattern provato og/blog/data), NON 50+ edit nei template.

## Implementato
- `scripts/offload-generated-images-cdn.mjs` — **Phase 3**: riscrive ogni `/assets/<file>` same-origin nell'HTML dist → `${CDN}/assets/…`. Copre: entry tag Vite, modulepreload, gli script boot custom (early-boot, gtag, PostHog, **loader AdSense**), e le CSS `seo-static`/`bridge`. Cioè tutto ciò che `renderBuiltUrl` (che già rebasava chunk-import JS + CSS `url()`) NON raggiunge. Gli URL già-CDN sono saltati (lookbehind origin) → niente doppio-rewrite.
- `asyncCssPlugin` + `seoPageShell`: regex di estrazione/transform di index.html rese tolleranti agli URL CDN assoluti (stesso fix di #1296 per spaBundleResolver) → async-CSS + hydration shell continuano a funzionare.

## Fail-safe (invariato, da #1293)
Lo step deploy "Verify CDN assets live, drop dist/assets" cancella `dist/assets` SOLO dopo aver confermato che il CDN serve un asset campione E che NON sopravvive alcun ref `/assets/` same-origin. Quindi:
- rewrite mancato → asset restano in dist (nessun 404, nessuna riduzione)
- CDN non serve → **deploy fallisce** (resta live l'ultimo build buono)
- chunk JS / CSS url() → coperti da renderBuiltUrl

## Validazione
- Phase 3 testato: riscrive entry+modulepreload+early-boot+adsense+css, lascia intatti gli URL CDN, zero same-origin residui ✓. esbuild + node --check verde.
- ⚠️ Il build completo + il boot reale (AdSense/analytics/CSS da CDN) si validano SOLO sul deploy live (build OOM in locale). Rischio accettato esplicitamente: se il CDN ha un problema al boot, ads/analytics/CSS degradano finché revert+re-deploy. Stessa infra del sito (GitHub Pages/Fastly).

## Dopo il merge
Monitorare il primo deploy: sito bootta, AdSense carica, CSS applicata, job board fetch ok, `dist/assets` cancellato (artifact −~152MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Non implementato (ancora)
- **Thumbnails blog 480w (~49MB)**: restano same-origin (URL srcSet costruite a runtime nel bundle) — follow-up separato.
- **Riduzione sotto i 10GB**: NON raggiunta — il muro restano le pagine HTML SEO (fuori scope per decisione utente). Il bundle (~152MB) cala l'artifact ma resta >10GB.
- **Validazione build/boot completa**: solo sul deploy live (build Vite OOM in locale) — vedi ## Validazione per il fail-safe.
