### PR TITLE
fix(build): cut SSG-emit peak memory to clear build OOM (#1290)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -438,6 +438,10 @@ jobs:
           # or verify fails, the deploy is FAILED (last good stays live), since
           # there is no same-origin fallback for boot-critical assets.
           ASSET_CDN: 'https://cdn.frontaliereticino.ch'
+          # Cap the post-walk worker pool so it doesn't structured-clone the full
+          # ~247K-path list into cpus()-many workers at once (memory headroom for
+          # the build OOM, #1290). Output-identical — only fewer parallel workers.
+          POST_WALK_WORKERS: '2'
           # ALWAYS sequential on the GH free-tier runner (2 vCPU / 7 GB).
           # Empirical comparison on the same source tree (2026-05-07):
           #   sequential build job: 12m41s, peak heap ~max(single plugin)

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -1278,8 +1278,9 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  resolveJobsSeoPagesFlushed();
  return;
  }
- const jobsRaw = JSON.parse(fs.readFileSync(jobsPath, 'utf-8'));
- const jobs = Array.isArray(jobsRaw) ? jobsRaw : [];
+ let jobsRaw: any = JSON.parse(fs.readFileSync(jobsPath, 'utf-8'));
+ let jobs: any[] = Array.isArray(jobsRaw) ? jobsRaw : [];
+ jobsRaw = null; // drop the parse ref immediately — `jobs` holds the array
  const slugify = (input: string) => String(input || '')
  .toLowerCase()
  .normalize('NFD')
@@ -1364,6 +1365,10 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  if (ta !== tb) return tb - ta;
  return String(a.id || a.slug || '').localeCompare(String(b.id || b.slug || ''));
  });
+ // Release the raw dataset: validJobs is an independent spread-copy (new objects
+ // per job), and `jobs` is never read past this point — free ~150-250 MB before
+ // the heavy per-page emit + expired/bridge pre-scans. (Build OOM fix, #1290.)
+ jobs = [];
 
  /**
   * Per-slug canonical override map (Semrush cannibalization fix). Loaded from

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2320,13 +2320,27 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       if (!prepassDisabled && totalTokens >= POSTINGS_PREPASS_MIN_TOKENS) {
         const workerUrl = new URL('./relatedSearchPostingsWorker.mjs', import.meta.url);
         const localeKeys = Array.from(tokensByLocale.keys());
+        // Build a SLIM, same-order projection once: the worker reads only these
+        // six fields (relatedSearchPostingsWorker buildJobHaystack) and returns
+        // postings by job INDEX, so order/length must match `jobs` exactly. This
+        // avoids structured-cloning the full ~88 MB dataset into each of up to 4
+        // worker boot payloads simultaneously (the "external memory pressure" in
+        // the build OOM). Output is byte-identical. (Build OOM fix, #1290.)
+        const slimJobs = jobs.map((j: any) => ({
+          title: j.title,
+          titleByLocale: j.titleByLocale,
+          description: j.description,
+          descriptionByLocale: j.descriptionByLocale,
+          company: j.company,
+          location: j.location,
+        }));
         const results = await Promise.all(
           localeKeys.map((workerLocale) => {
             const localeTokens = Array.from(tokensByLocale.get(workerLocale) as Set<string>);
             return new Promise<{ locale: Locale; entries: Array<{ token: string; list: number[] }> }>(
               (resolve, reject) => {
                 const worker = new Worker(workerUrl, {
-                  workerData: { jobs, locale: workerLocale, tokens: localeTokens },
+                  workerData: { jobs: slimJobs, locale: workerLocale, tokens: localeTokens },
                 });
                 worker.once('message', resolve);
                 worker.once('error', reject);


### PR DESCRIPTION
## Scopo
Sblocca i deploy: `build:ci` va in **OOM** durante l'emit SSG ("Ineffective mark-compacts near heap limit … external memory pressure", heap ~10GB su runner 16GB). **0/60 deploy recenti riusciti** → produzione congelata. Closes #1290.

## Causa (NON il lavoro CDN)
Crescita organica del dataset job (decine di auto-update crawler oggi) → la SOMMA delle strutture residenti del build supera il limite ~16GB del runner. Pre-esistente: **#1292 (pre-ASSET_CDN) andava in OOM identico**; lo streak è iniziato ~15:08, prima di #1293. Alzare `--max-old-space-size` non aiuta (l'heap non è il limite; la pressione è off-heap/external).

## Implementato (3 riduzioni, zero cambi di output)
1. **jobsSeoPagesPlugin**: l'array raw `jobs` (~88MB JSON → ~150-250MB live) restava pinnato per tutto l'emit accanto a `validJobs` (copia indipendente via spread). Rilasciato (`jobsRaw=null` dopo il parse; `jobs=[]` dopo aver derivato validJobs) — non più letto oltre quel punto.
2. **relatedSearchClustersPlugin**: i worker postings ricevevano lo structured-clone dell'array `jobs` COMPLETO in fino a 4 payload worker simultanei (~350MB external spike = la "external memory pressure"). Ora passo una **proiezione slim same-order** dei soli 6 campi che il worker legge (title/titleByLocale, description/descriptionByLocale, company, location). I postings sono per INDICE job → output byte-identico.
3. **deploy.yml**: `POST_WALK_WORKERS=2` per non clonare la lista ~247K path in cpus()-worker simultanei (output-identico).

## Non implementato (in riserva se serve un 2° giro)
- write-registry: ridurre la ritenzione `contentHash`/`callSite` per-path (~100MB) — più invasivo (logica collision-detection), tenuto da parte.
- relatedSearch: null `candidates`/`enriched` raw dopo `contexts` (~75MB peak).
- Runner più grande (32GB) = costo $ — escluso.

## Validazione
- esbuild dei 2 file TS ✓; `POST_WALK_WORKERS` confermato letto (postWalkCoordinatorPlugin:133); YAML ✓; grep conferma i rilasci in posizione.
- ⚠️ Il build completo OOMa in locale → la riduzione di memoria si valida SOLO sul deploy live. Ogni tentativo = ~30-90min. Se ancora OOM, applico le riserve sopra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)