### PR TITLE
chore(build): force GC in mem probes — garbage-vs-live OOM diagnosis + possible fix (#1290)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -136,14 +136,23 @@ import { getCantonCities, normalizeCitySlug } from './shared/cantonCities';
 // build log reveals which phase accretes the ~9.9 GB live heap / external spike.
 // No effect on emitted output. Remove once the retainer is fixed.
 function logBuildMem(label: string, collector?: unknown): void {
-  const m = process.memoryUsage();
   const mb = (n: number) => Math.round(n / 1048576);
+  // Force a full GC first (build:ci runs with --expose-gc) so the reported heap
+  // is the LIVE set, not garbage V8 keeps lazily under its 12 GB ceiling. DUAL
+  // PURPOSE: if this reclaims the per-phase growth, the gc() calls themselves
+  // bound the peak and prevent the OOM (cheap fix); if heap stays high post-gc
+  // it's genuine retention needing a code fix — and `gcFreed` tells us which. (#1290)
+  const gc = (globalThis as { gc?: () => void }).gc;
+  const beforeHeap = process.memoryUsage().heapUsed;
+  if (typeof gc === 'function') gc();
+  const m = process.memoryUsage();
+  const freed = mb(beforeHeap - m.heapUsed);
   const c = collector as { writes?: Map<unknown, unknown>; _pendingFlushes?: Set<unknown> } | undefined;
   const extra = c
     ? ` pendingWrites=${c.writes?.size ?? '?'} inflightFlushes=${c._pendingFlushes?.size ?? '?'}`
     : '';
   console.log(
-    `\x1b[35m[mem]\x1b[0m ${label} heapUsed=${mb(m.heapUsed)}MB external=${mb(m.external)}MB arrayBuffers=${mb(m.arrayBuffers)}MB rss=${mb(m.rss)}MB${extra}`,
+    `\x1b[35m[mem]\x1b[0m ${label} heapUsed=${mb(m.heapUsed)}MB (gcFreed=${freed}MB) external=${mb(m.external)}MB arrayBuffers=${mb(m.arrayBuffers)}MB rss=${mb(m.rss)}MB${extra}`,
   );
 }
 


### PR DESCRIPTION
## Scopo
Prossimo ciclo diagnostico #1290. Il deploy instrumentato ha dato la curva:

| milestone | heapUsed | external | pendingWrites |
|---|---|---|---|
| collector-created | 4145MB | 407 | 0 |
| **company-landing** (2084 pp) | **8345MB (+4200)** | 526 | 4409 |
| city-hubs (8040) | 9830 | 568 | 4663 |
| sector-hubs | 10119 | 595 | 1933 |
| company×city | 10517 | 627 | — |
| job-pages (27508) | 10577 | 627 | 2682 |
| → OOM | | | |

**Diagnosi**: NON è il collector (pendingWrites bounded, external ~600MB). È **heap** che cresce monotòno e non scende. Il salto enorme è **company-landing: +4.2GB per 2084 pagine** (~2MB/pagina, ~4min). Ma con ceiling V8 a 12GB, "heapUsed" può includere garbage non raccolto.

## Implementato
`logBuildMem` ora forza `global.gc()` (build:ci ha `--expose-gc`) prima di misurare + logga `gcFreed`. **Dual purpose**: se la GC recupera la crescita per-fase → le chiamate stesse limitano il picco e prevengono l'OOM (fix economico); se l'heap resta ~10GB post-gc → retention vera, e `gcFreed≈0` lo conferma → fix di codice mirato sulla fase company-landing.

## Atteso
Se `gcFreed` è grande a company-landing/job-pages → era garbage → build passa (FIXATO). Se `gcFreed≈0` e ancora OOM → retention vera, prossimo ciclo: investigo cosa company-landing trattiene (companyMap / buildSeoPageHtml / shared helpers).

## Non implementato
- Fix di codice del retainer (se gc non basta) — prossimo ciclo, mirato sulla fase identificata.
- Rimozione instrumentation — dopo verifica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)