### PR TITLE
fix(deploy): move CDN asset live-serve check from build job to validate-live

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -735,38 +735,26 @@ jobs:
 
       # Boot-critical asset offload. The build already rebased Vite asset URLs to
       # the CDN (ASSET_CDN/renderBuiltUrl) → the artifact's HTML/JS point at
-      # cdn.frontaliereticino.ch/assets/* with no same-origin fallback. Two guards
-      # before deleting dist/assets:
-      #   (A) FAIL the deploy if the push failed (CDN_BASE unset) or a sample asset
-      #       never serves from the CDN within ~4min — the Vite refs are already
-      #       baked to the CDN with no fallback, so publishing would break boot.
-      #       Failing keeps the last good deploy live.
-      #   (B) If ANY dist HTML still references a SAME-ORIGIN /assets/ path (e.g. a
+      # cdn.frontaliereticino.ch/assets/* with no same-origin fallback. BUILD-TIME
+      # guards before deleting dist/assets (no live polling here — the CDN Pages
+      # build lags the push, which made an inline poll a flaky false-negative that
+      # blocked the whole build; the CDN-serves-live check now runs post-deploy in
+      # validate-live, with the rollback job as the safety net):
+      #   (A) FAIL the deploy if the push failed (CDN_BASE unset) — the Vite refs
+      #       are already baked to the CDN with no fallback, so the artifact is
+      #       broken; failing keeps the last good deploy live.
+      #   (B) If ANY dist HTML still references a SAME-ORIGIN /assets/ path (a
       #       custom SSG emitter that didn't go through renderBuiltUrl), KEEP
       #       dist/assets (skip the delete) — non-fatal: those pages keep working
-      #       same-origin while the Vite refs use the CDN. No artifact win for
-      #       assets that round, but nothing breaks.
-      - name: Verify CDN assets live, then drop dist/assets (fail-safe)
+      #       same-origin while the Vite refs use the CDN. No artifact win this
+      #       round, but nothing breaks.
+      - name: Drop dist/assets after CDN push (build-time guards; live check in validate-live)
         if: github.event.inputs.profile_sequential != 'true'
         run: |
           set -uo pipefail
           [ -d dist/assets ] || { echo "no dist/assets — nothing to offload"; exit 0; }
           if [ -z "${CDN_BASE:-}" ]; then
             echo "::error::CDN push failed but dist/assets URLs are already rebased to the CDN (no fallback) — failing deploy (last good stays live)"; exit 1
-          fi
-          sample="$(cd dist/assets && ls -1 *.js 2>/dev/null | head -1)"
-          [ -z "$sample" ] && sample="$(cd dist/assets && ls -1 | head -1)"
-          url="${CDN_BASE}/assets/${sample}"
-          echo "verifying $url (CDN Pages build may lag the push)…"
-          ok=""
-          for i in $(seq 1 24); do
-            code="$(curl -s -o /dev/null -w '%{http_code}' "$url" || echo 000)"
-            echo "  attempt $i: $code"
-            [ "$code" = "200" ] && { ok=1; break; }
-            sleep 10
-          done
-          if [ -z "$ok" ]; then
-            echo "::error::CDN asset $url not serving after ~4min — failing deploy (assets stay live on last good build)"; exit 1
           fi
           # Guard B: any surviving SAME-ORIGIN /assets/ reference in dist HTML?
           # Extension/path coverage is a SUPERSET of the offload script's Phase 3
@@ -778,7 +766,7 @@ jobs:
           fi
           freed="$(du -sh dist/assets | cut -f1)"
           rm -rf dist/assets
-          echo "✅ assets verified on CDN + no same-origin refs; dropped dist/assets (${freed}) from artifact"
+          echo "✅ no same-origin /assets/ refs survive; dropped dist/assets (${freed}) from artifact (CDN: ${CDN_BASE}/assets — verified live in validate-live)"
 
       - name: Capture pre-deploy sitemap URLs (for IndexNow diff)
         if: github.event.inputs.profile_sequential != 'true'

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -185,22 +185,33 @@ jobs:
           LIVE_BASE_URL: https://frontaliereticino.ch
         run: |
           set -uo pipefail
-          html="$(curl -s --max-time 30 "${LIVE_BASE_URL}/" || true)"
+          # Retry the homepage fetch so a transient network blip can't masquerade
+          # as "no CDN ref → nothing to verify" and silently skip the gate.
+          html=""
+          for i in 1 2 3 4; do
+            html="$(curl -s --max-time 30 "${LIVE_BASE_URL}/" || true)"
+            [ -n "$html" ] && break
+            sleep 5
+          done
+          if [ -z "$html" ]; then
+            echo "[validate-live] homepage fetch returned empty after 4 tries — inconclusive (transient); the e2e:live smoke below exercises boot end-to-end. Skipping CDN gate."
+            exit 0
+          fi
           asset="$(printf '%s' "$html" | grep -oE 'https://cdn\.frontaliereticino\.ch/assets/[^"'"'"' )]+\.(js|css)' | head -1)"
           if [ -z "$asset" ]; then
-            echo "[validate-live] homepage references no cdn.frontaliereticino.ch/assets bundle — assets served same-origin this deploy; nothing to verify."
+            echo "[validate-live] homepage (non-empty) references no cdn.frontaliereticino.ch/assets bundle — assets served same-origin this deploy; nothing to verify."
             exit 0
           fi
           echo "[validate-live] verifying boot bundle on CDN: $asset"
           ok=""
-          for i in $(seq 1 6); do
+          for i in $(seq 1 12); do
             code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$asset" || echo 000)"
             echo "  attempt $i: $code"
             [ "$code" = "200" ] && { ok=1; break; }
             sleep 10
           done
           if [ -z "$ok" ]; then
-            echo "::error::[validate-live] CDN boot bundle $asset not serving (live site references it but it 404s) — failing → rollback"
+            echo "::error::[validate-live] CDN boot bundle $asset not serving after ~2min (live homepage references it but it 404s) — failing → rollback"
             exit 1
           fi
           echo "✅ [validate-live] CDN boot bundle serves 200 from cdn.frontaliereticino.ch"

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -170,6 +170,41 @@ jobs:
           echo "::error::[validate-live] propagation_timeout — deploy not live within window. Skipping smoke/gates; caller will NOT rollback (live is a valid earlier build)."
           exit 1
 
+      # Verify the offloaded JS/CSS bundle actually serves from the CDN on the
+      # LIVE site. Moved here from the build job: the CDN Pages build lags the
+      # push, so an inline build-time poll was a flaky false-negative that blocked
+      # the whole build. By the time validate-live runs the deploy is propagated
+      # and the CDN repo's Pages site has long since built, so this is reliable.
+      # The boot chain (entry JS/CSS) is rebased to cdn.frontaliereticino.ch by
+      # ASSET_CDN/renderBuiltUrl; if the homepage references such a URL it MUST
+      # serve 200, else the live site can't boot → fail → caller rolls back.
+      # If no CDN /assets/ ref is present (assets stayed same-origin this round —
+      # Guard B kept dist/assets), there is nothing to verify → pass.
+      - name: Verify CDN-offloaded bundle serves live
+        env:
+          LIVE_BASE_URL: https://frontaliereticino.ch
+        run: |
+          set -uo pipefail
+          html="$(curl -s --max-time 30 "${LIVE_BASE_URL}/" || true)"
+          asset="$(printf '%s' "$html" | grep -oE 'https://cdn\.frontaliereticino\.ch/assets/[^"'"'"' )]+\.(js|css)' | head -1)"
+          if [ -z "$asset" ]; then
+            echo "[validate-live] homepage references no cdn.frontaliereticino.ch/assets bundle — assets served same-origin this deploy; nothing to verify."
+            exit 0
+          fi
+          echo "[validate-live] verifying boot bundle on CDN: $asset"
+          ok=""
+          for i in $(seq 1 6); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$asset" || echo 000)"
+            echo "  attempt $i: $code"
+            [ "$code" = "200" ] && { ok=1; break; }
+            sleep 10
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::[validate-live] CDN boot bundle $asset not serving (live site references it but it 404s) — failing → rollback"
+            exit 1
+          fi
+          echo "✅ [validate-live] CDN boot bundle serves 200 from cdn.frontaliereticino.ch"
+
       - name: Live smoke (probe 5xx + e2e:live)
         env:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright


### PR DESCRIPTION
## Scopo (richiesta utente)
Spostare la verifica CDN dal build job allo step **validate-live**.

## Problema
Lo step inline "Verify CDN assets live" (build job) faceva polling ~4min sull'asset campione prima di cancellare dist/assets. Ma la build Pages del repo CDN è in ritardo rispetto al push (+ lo step offload precedente ora dura ~19min sul dist enorme), quindi il poll era un **falso-negativo** che falliva l'INTERO build anche se l'asset serve regolarmente (verificato 200 live). Run 26925955512 falliva esattamente qui nonostante push CDN ok (955M) + Pages built.

## Fix
- **Build job**: tiene solo le guard BUILD-TIME prima di cancellare dist/assets — `CDN_BASE` settato (push riuscito) + Guard B (nessun ref `/assets/` same-origin sopravvive). Niente poll live.
- **post-deploy-validate-live.yml**: nuovo step verifica che il bundle di boot CDN della homepage LIVE (`cdn.frontaliereticino.ch/assets/*.js|css`) serva 200 — gira dopo la propagazione, quando la Pages del repo CDN è ormai buildato → affidabile. Fallisce → il caller fa **rollback**. Salta pulito se gli asset sono rimasti same-origin (Guard B).

## Contesto
Il fix OOM #1290 (backpressure, #1302) FUNZIONA: questo run ha **passato l'emit SSG senza OOM** e raggiunto gli step CDN. Restava solo questo falso-negativo del verify inline. (Separato: il build resta lento ~1.5-2h per crescita dataset — decisione strutturale a parte.)

## Validazione
- YAML ok (deploy.yml + validate-live). Lo step skippa se non c'è ref CDN, fallisce solo se la homepage referenzia un asset CDN che 404a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Implementato
- Build job: rimosso il poll live ~4min; tiene solo Guard A (CDN_BASE set) + Guard B (no ref /assets/ same-origin) prima di cancellare dist/assets.
- validate-live: nuovo step che verifica il boot bundle CDN della homepage live (200), con retry sul fetch homepage e poll ~2min; fallimento -> rollback; skip pulito se asset same-origin.

## Non implementato (ancora)
- **Revert-risk del failure-mode invertito**: il check ora puo far ROLLBACK un deploy sano se il bundle CDN non serve entro ~2min in validate-live (lag CDN-Pages non misurato a quel timestamp; in pratica la Pages del repo CDN e buildato da ore quando validate-live gira). Self-healing: il rollback mantiene live l ultimo build valido. Se mai falso-rollbacka, alzare la finestra poll o gate su e2e:live.
- Il check ispeziona solo la homepage `/` (assunzione: renderBuiltUrl mette l entry CDN nell HTML SSR di index.html); e2e:live smoke copre le altre pagine a valle.
- Wall-time build ~1.5-2h (crescita dataset) + payload CDN 955M vicino al limite 1GB Pages: follow-up strutturali separati.
