### PR TITLE
fix(followup): clear API 400 surrogate — drop emoji-heavy bodies from bulk issue lists

### DIFF
--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -88,7 +88,7 @@ jobs:
             3. Carica:
                - `gh pr view $PR_NUMBER --json number,title,body,mergedAt,mergeCommit,url`
                - `gh api repos/$REPO/pulls/$PR_NUMBER/reviews`
-               - `gh issue list --label follow-up --state all --json number,title,body --limit 50`
+               - `gh issue list --label follow-up --state all --json number,title --limit 50` (SOLO `number,title`: il bulk overview serve per la vista d'insieme/titoli; il dedup vero è item-level scoped via `--search` — vedi FOLLOWUP.md § Dedup. MAI aggiungere `,body`: con ~170 issue follow-up il dump arriva a ~170KB emoji-heavy, viene troncato a un boundary di surrogate UTF-16 → lone surrogate → request body API JSON invalido `400 no low surrogate in string`, ogni run fallisce.)
 
             **Esegui workflow come specificato in FOLLOWUP.md:**
             - Parse PR body `## Non implementato` (skip motivi `out of scope` / `posposto`).

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -149,8 +149,8 @@ Se zero item sopravvivono al filtro+dedup (e nessuna voce live-verify) → posta
 Dopo il triage, segnala le issue `follow-up` aperte che **questa PR potrebbe aver reso obsolete**, così non restano orfane (es. PR che riscrive un workflow rendendo moot gli item di hardening su quel file). **Non chiudere mai** su euristica: una PR può toccare un file senza coprire lo specifico item — chiudere distruggerebbe scope ancora valido. Solo l'autore, con `Closes #N` / `Supersedes #N` nel body (vedi `AGENTS.md → Workflow`), chiude davvero (GitHub nativo per `Closes`).
 
 1. File toccati da questa PR: `gh pr diff $PR_NUMBER --name-only`.
-2. Issue follow-up aperte: `gh issue list --label follow-up --state open --json number,title,body --limit 50` (escludi quella appena creata per questa PR).
-3. Per ogni issue il cui body cita un file presente nel diff della PR (path match in `## Suggested action` / `## Item`):
+2. Candidati supersede, **scoped per-file** (mai dump bulk dei body): per ogni file del diff `gh issue list --label follow-up --state open --search "<file>" --json number,title --limit 20` (GitHub indicizza il body → ritorna solo le issue che citano quel path). Unisci i risultati, escludi quella appena creata per questa PR. NON usare `--json number,title,body --limit 50` su tutte le aperte: ~28 body emoji-heavy ≈ 82KB, troncabile a un boundary di surrogate UTF-16 → `400 no low surrogate in string` (stessa classe del bulk overview a `post-merge-followup.yml`).
+3. Per ciascun candidato scoped, conferma con `gh issue view <N> --json body` che il path sia citato in `## Suggested action` / `## Item`; se sì:
    - Se non hai già commentato (cerca `🔗 Possibile supersede` nei commenti, idempotenza) → posta:
      ```markdown
      🔗 Possibile supersede: PR #<PR_NUMBER> (<PR_TITLE>) ha modificato `<file>` — <motivo dal PR title/body>. Verifica se gli item di questa issue sono ancora pertinenti; se coperti, chiudi a mano. (segnalazione automatica, non chiusura)


### PR DESCRIPTION
## Implementato

`post-merge-followup` falliva su **ogni run** dal 2026-06-03 ~17:47 (ultima success @17:24) con:

```
API Error: 400 The request body is not valid JSON: no low surrogate in string: line 1 column NNNNN
```

**Root cause** (non auth/quota/max-turns — falso indizio `ANTHROPIC_API_KEY: ""` innocuo): il bootstrap esegue `gh issue list --label follow-up --state all --json number,title,body --limit 50` → ~**170KB** di JSON emoji-heavy (~170 issue follow-up accumulate, 42 emoji). Il troncamento dell'output tool cade su un boundary di surrogate UTF-16 → **lone high surrogate** → request body inviato all'API Anthropic non è JSON valido → `400 no low surrogate in string`. La posizione char varia per-PR (49301/53574/55648/56401) perché il buffer cumulativo cambia; l'onset coincide con la soglia size superata dall'accumulo issue (success @170 issue-1, fail subito dopo).

Fix class-complete (AGENTS.md #6 — fixato l'intera classe `--json ...,body --limit 50`, non solo il file colpito):

- **`.github/workflows/post-merge-followup.yml`** bootstrap: `--json number,title` (drop `body`). 170KB → 6.5KB (26×). Il dedup vero è già **item-level scoped** via `--search` (FOLLOWUP.md § Dedup) → il bulk non ha mai avuto bisogno dei body, serve solo per la vista titoli.
- **`FOLLOWUP.md`** supersede detection (sibling a rischio, ~82KB su `--state open`): da dump bulk di tutti i body aperti a **search scoped per-file** (`gh issue list --search "<file>" --json number,title --limit 20`, GitHub indicizza il body) + conferma `gh issue view <N> --json body` solo sui pochi candidati.

Aggiunto in entrambi i siti un commento `MAI aggiungere ,body` con la causa, per prevenire regressione.

## Non implementato (ancora)

- **Hardening lato harness del troncamento surrogate-safe**: out of scope — non controlliamo `claude-code-action`/SDK; la difesa corretta dal nostro lato è non alimentare 170KB emoji-heavy in un colpo (fatto).
- **Backfill dei follow-up persi** dalle ~8 run fallite (PR #1290/#1298/#1311 ecc.): posposto — `post-merge-followup.yml` supporta `workflow_dispatch` backfill per-PR; se l'owner vuole recuperare lo scope deferred si lanciano i dispatch dopo il merge di questa PR (triage ora funziona).

> Nota merge: tocca `post-merge-followup.yml` + `FOLLOWUP.md` → workflow-validation della GitHub App, reviewer non posta `## LGTM`, auto-merge non scatta → **merge manuale** `gh pr merge --squash --delete-branch` (eccezione AGENTS.md). Validazione sulla prossima PR organica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)