### PR TITLE
fix(articles): allow "mezzi pubblici" link text for nav:transport (follow-up #1255)

### DIFF
--- a/scripts/lib/article-sanitizers.mjs
+++ b/scripts/lib/article-sanitizers.mjs
@@ -237,7 +237,7 @@ const NAV_SEMANTIC_KEYWORDS_IT = {
   ],
   transport: [
     'transport', 'trasport', 'mobilità', 'pendolar', 'tragitto',
-    'tempo\\s+di\\s+viaggio', 'percorso',
+    'tempo\\s+di\\s+viaggio', 'percorso', 'mezzi\\s+pubblici',
   ],
   'salary-compare': [
     'stipend', 'salari', 'comparatore\\s+sal', 'comparazione',


### PR DESCRIPTION
## Implementato

- **nav:transport allowlist gap (#1255 item 2)** — Added `mezzi\s+pubblici` to `NAV_SEMANTIC_KEYWORDS_IT.transport` in `scripts/lib/article-sanitizers.mjs`. Both article-generation hint blocks in `scripts/create-article.mjs` (L3737 frontaliere, L3747 svizzera) instruct the model that the `nav:transport` link text is "mezzi pubblici", but that exact string was not in the positive allowlist, so `sanitizeNavLinkSemantics` silently stripped every `[mezzi pubblici](nav:transport)` internal link → one fewer internal SEO link per affected article. Fix is **class-complete** (single allowlist entry covers both hint blocks per AGENTS.md §6) and **purely additive**: no off-topic text is newly admitted (transport has no anti-keywords for transit themes; `meteo`/route still rejected). Verified: `mezzi pubblici` → match, `trasporti pubblici` → still match, `meteo` → still rejected.
- Tests: `tests/article-sanitizers.test.ts` 39/39 pass (existing `nav:transport` "tragitto" preservation test unaffected).

## Non implementato (ancora)

- **#1255 item 1** — regenerate/remove the 3-4 pre-fix frontaliere-skewed svizzera articles (neutralizzazione-stime, lavoro-media-ssr, Berna-attriti, hantavirus). **Posposto: removing/regenerating live pages requires explicit owner OK** (project rule: never cut/regenerate published pages without approval). Left open on #1255 with this rationale; owner to decide regenerate-vs-keep.

Addresses #1255 (item 2). Does not `Closes` — item 1 stays open pending owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)