### PR TITLE
fix(validate-dist): restore CDN-offloaded crawler-summaries from jobs-master artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -848,20 +848,28 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      # Master jobs.json for post-deploy validators. The deploy artifact
-      # strips dist/data/jobs.json (jobsJsonDistCleanupPlugin, PR #712) to
-      # stay under the 10 GB GH Pages cap — runtime SPA fetches the
-      # per-locale shards instead. Validators like
-      # validate:translation-completeness still need the master file with
-      # titleByLocale / descriptionByLocale, so we upload it as a small
-      # dedicated artifact (retention 1d) that post-deploy-validate-dist
-      # downloads back into data/.
-      - name: Upload master jobs.json for post-deploy validators
+      # Master source data for post-deploy validators. The deploy artifact
+      # strips dist/data/jobs.json (jobsJsonDistCleanupPlugin, PR #712) and
+      # offloads the rest of dist/data/ to the CDN repo, DELETING the
+      # cdn-only copies from dist (offload-generated-images-cdn.mjs, PR
+      # #1288) — to stay under the 10 GB GH Pages cap; runtime SPA fetches
+      # the per-locale shards / CDN instead. Validators still read the
+      # master source files from data/:
+      #   • jobs.json                   — validate:translation-completeness
+      #                                   (titleByLocale / descriptionByLocale)
+      #   • jobs-crawler-summaries.json — validate:crawler-summaries
+      #                                   (gitignored, assembled at build; its
+      #                                   dist copy is CDN-offloaded + deleted)
+      # so we upload both as one small dedicated artifact (retention 1d)
+      # that post-deploy-validate-dist downloads back into data/.
+      - name: Upload master source data for post-deploy validators
         if: github.event.inputs.profile_sequential != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: jobs-master-${{ github.run_id }}
-          path: data/jobs.json
+          path: |
+            data/jobs.json
+            data/jobs-crawler-summaries.json
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -179,10 +179,12 @@ jobs:
           # Expose jobs.json to scripts that expect public/data/jobs.json.
           mkdir -p public/data
           cp -f data/jobs.json public/data/jobs.json
-          # validate:crawler-summaries reads data/jobs-crawler-summaries.json,
-          # gitignored and produced by `assemble-jobs-dataset.mjs` during
-          # build (then copied into dist/data/ by vite). Same pattern.
-          cp -f dist/data/jobs-crawler-summaries.json data/jobs-crawler-summaries.json 2>/dev/null || true
+          # validate:crawler-summaries reads data/jobs-crawler-summaries.json
+          # (gitignored, assembled at build). Its dist/data/ copy is offloaded
+          # to the CDN repo AND deleted from dist by offload-generated-images-
+          # cdn.mjs (PR #1288), so it is NOT in the Pages artifact — restore it
+          # from the jobs-master artifact (same channel as jobs.json above).
+          cp -f /tmp/jobs-master/jobs-crawler-summaries.json data/jobs-crawler-summaries.json
 
           # Optional artifacts — copy if present.
           if [ -f /tmp/pre-deploy-snapshot/pre-deploy-sitemap-urls.json ]; then


### PR DESCRIPTION
## Implementato

`validate:crawler-summaries` falliva post-deploy con `data/jobs-crawler-summaries.json does not exist` ([run 26931599731](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26931599731/job/79460339496)), bloccando il gate `validate-dist`.

**Root cause.** `dist/data/jobs-crawler-summaries.json` viene offloadato sul repo CDN **e cancellato da dist** da `offload-generated-images-cdn.mjs` (PR #1288, data offload su CDN) → non è più nell'artifact Pages. `validate-dist` lo ripristinava con `cp -f dist/data/jobs-crawler-summaries.json … 2>/dev/null || true`: un no-op silenzioso quando il file è assente. Il validator (`readCrawlerSummaryStore` senza `allowMissing`) quindi hard-failava. Il file sorgente è gitignored e assemblato a build-time (120 entry confermate nel build log, `04:59`), ma vive solo in `data/` del job di build, non nel job separato `validate-dist`.

**Stessa classe di `jobs.json`** — strippato da `jobsJsonDistCleanupPlugin` (PR #712) e ripristinato via l'artifact `jobs-master`. Il fix aggancia summaries allo **stesso canale**, non a un ripristino fragile da dist:

- `deploy.yml`: l'artifact `jobs-master` ora carica `data/jobs.json` **+** `data/jobs-crawler-summaries.json` (LCA = `data/` → root artifact invariato; `if-no-files-found: error` resta — le 437 slice committate in `data/jobs-crawler-summaries/by-crawler/` garantiscono che il file sia sempre assemblato).
- `post-deploy-validate-dist.yml`: ripristina summaries da `/tmp/jobs-master/jobs-crawler-summaries.json` (cp hard, niente `|| true`), come già fa per `jobs.json`.

**Closes #1247** (issue canonica rolling "Validation Failure (dist): post-deploy").

## Non implementato (ancora)

- **Verifica live**: il fix è validabile solo post-merge sul prossimo deploy `main` (validate-dist gira solo nel workflow `Deploy to GitHub Pages`, non sul `pull_request`). Trigger di revert: se il prossimo `validate-dist` post-merge fallisce ancora su `crawler-summaries` → l'artifact non contiene il file (controllare lo step upload `jobs-master`).
- **Altri validator**: verificata l'intera classe. `validate:translation-completeness` legge `data/jobs.json` (già ripristinato via `jobs-master`); `validate:third-party-secrets` usa `existsSync`-filter (non-fatal su file mancanti, ora comunque coperto); `gate:seo-source` è source-only (`tests/seo/`, nessuna lettura `dist/data`). Solo `crawler-summaries` aveva il ripristino fragile da dist → unico hard-fail. Nessun sibling con lo stesso antipattern resta.
- **`allowMissing` sul validator**: non adottato di proposito — abbasserebbe il gate (un file summaries genuinamente assente passerebbe silenzioso). Si ripristina il file invece di tollerarne l'assenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)