### PR TITLE
fix(crawlers): self-healing Chromium launch — kill the install-step gap class fleet-wide

### DIFF
--- a/scripts/audit-cls-stripping.mjs
+++ b/scripts/audit-cls-stripping.mjs
@@ -29,7 +29,7 @@
  * Dependencies: `playwright` is already a project dep (used by e2e tests).
  */
 
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 
 const args = process.argv.slice(2);
 const JSON_OUT = args.includes('--json');
@@ -94,7 +94,7 @@ async function probeOne(page, url, viewport, label) {
   });
 }
 
-const browser = await chromium.launch({ headless: true });
+const browser = await launchChromium({ headless: true });
 const ctx = await browser.newContext({
   userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
 });

--- a/scripts/audit-jobs-source-match.mjs
+++ b/scripts/audit-jobs-source-match.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import { JSDOM, VirtualConsole } from 'jsdom';
 import { extractPdfJobContentFromUrl } from './lib/pdf-job-content.mjs';
 
@@ -313,15 +314,11 @@ async function fetchWithTimeout(url, { timeoutMs = 15000, headers = {}, redirect
   }
 }
 
-let playwrightModulePromise = null;
 let browserPromise = null;
 
 async function getBrowser() {
-  if (!playwrightModulePromise) playwrightModulePromise = import('playwright');
   if (!browserPromise) {
-    browserPromise = playwrightModulePromise.then(({ chromium }) =>
-      chromium.launch({ headless: true }).catch(() => null)
-    );
+    browserPromise = launchChromium({ headless: true }).catch(() => null);
   }
   return browserPromise;
 }

--- a/scripts/lib/ats-clients/playwright-runtime.mjs
+++ b/scripts/lib/ats-clients/playwright-runtime.mjs
@@ -7,7 +7,7 @@
  * Flow:
  *
  *   ┌──────────────────┐
- *   │  createBrowser   │   chromium.launch(headless, stealth args)
+ *   │  createBrowser   │   launchChromium(headless, stealth args)
  *   └────────┬─────────┘
  *            │ Browser
  *            ▼
@@ -42,7 +42,7 @@
  *   - AntiBotBlockError
  */
 
-import { chromium } from 'playwright';
+import { launchChromium } from '../ensure-chromium.mjs';
 
 const DEFAULT_USER_AGENT =
   'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/bot)';
@@ -104,7 +104,7 @@ export class AntiBotBlockError extends Error {
 export async function createBrowser(options = {}) {
   const userAgent = options.userAgent || DEFAULT_USER_AGENT;
   try {
-    const browser = await chromium.launch({
+    const browser = await launchChromium({
       headless: true,
       args: ['--disable-blink-features=AutomationControlled'],
     });

--- a/scripts/lib/clinica-holistica-engiadina-job-parser.mjs
+++ b/scripts/lib/clinica-holistica-engiadina-job-parser.mjs
@@ -23,6 +23,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+import { launchChromium } from './ensure-chromium.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -47,17 +48,6 @@ const PW_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
 /* ── Helpers ───────────────────────────────────────────────── */
-
-async function loadPlaywright() {
-  try {
-    const mod = await import('playwright');
-    return mod.chromium;
-  } catch (err) {
-    throw new Error(
-      `Playwright not available — install with \`npx playwright install chromium\`. (${err?.message || err})`,
-    );
-  }
-}
 
 async function createStealthContext(browser) {
   const ctx = await browser.newContext({
@@ -271,10 +261,9 @@ export async function fetchAllClinicaHolisticaJobs() {
   console.log(`🏥 Fetching Clinica Holistica Engiadina jobs`);
   console.log(`   Public career page: ${PUBLIC_CAREER_URL}\n`);
 
-  const chromium = await loadPlaywright();
   let browser;
   try {
-    browser = await chromium.launch({ headless: true, args: PW_LAUNCH_ARGS });
+    browser = await launchChromium({ headless: true, args: PW_LAUNCH_ARGS });
   } catch (err) {
     console.warn(`⚠️ chromium launch failed: ${err?.message || err}`);
     return [];

--- a/scripts/lib/ensure-chromium.mjs
+++ b/scripts/lib/ensure-chromium.mjs
@@ -1,0 +1,93 @@
+/**
+ * ensure-chromium.mjs — self-healing Playwright Chromium launcher.
+ *
+ * THE PROBLEM this solves (structural, fleet-wide):
+ * ~398/425 dedicated-crawler workflows reach a Playwright browser fallback
+ * (the shared crawler enables it by default — `JOBS_BROWSER_FALLBACK_ENABLED`
+ * defaults to '1'), but `npm ci` installs the playwright *package* without the
+ * *browser binary*. A workflow that lacks an explicit `npx playwright install`
+ * step makes `chromium.launch()` throw "Executable doesn't exist"; crawlers
+ * caught that and silently returned 0 jobs (lost indexable content with no
+ * signal), or hard-failed and opened a `Crawler Failure` issue. The reviewer
+ * kept flagging this per-crawler (cambiavalute → colin-cie → eHnv/cnp →
+ * pole-sante…), an unbounded manual loop.
+ *
+ * THE FIX: every launch goes through `launchChromium()`. If the binary is
+ * missing, it installs Chromium ON-DEMAND (once per process, memoized) and
+ * retries — so the browser is guaranteed available wherever it's actually
+ * needed, regardless of whether the workflow remembered the install step. The
+ * cost is paid lazily, only when a crawler genuinely hits the fallback (most
+ * never do), instead of a wasted install step on every run of 398 workflows.
+ *
+ * Use `launchChromium(opts)` instead of `chromium.launch(opts)` everywhere.
+ */
+import { execFileSync } from 'node:child_process';
+
+// Signals that Chromium's binary (or its system libs) is missing — i.e. an
+// install would fix it. Anything else (OOM, sandbox, a real bug) is rethrown.
+const MISSING_BROWSER_RE =
+  /Executable doesn'?t exist|please run the following command to download|playwright install|error while loading shared libraries|cannot open shared object file|libnss3|libatk|host system is missing dependencies/i;
+
+let _chromium = null;
+let _installPromise = null;
+
+function isMissingBrowserError(err) {
+  return MISSING_BROWSER_RE.test(String(err?.message || err || ''));
+}
+
+/** Lazy-import the playwright chromium handle (memoized). */
+export async function getChromium() {
+  if (!_chromium) {
+    const mod = await import('playwright');
+    _chromium = mod?.chromium || mod?.default?.chromium || null;
+    if (!_chromium) throw new Error('playwright module has no chromium export');
+  }
+  return _chromium;
+}
+
+/**
+ * Install the Chromium browser binary on-demand. Memoized: at most one install
+ * per process even under concurrent callers. Tries `--with-deps` first (CI
+ * runners have passwordless sudo and may lack system libs), then falls back to
+ * the binary-only install (dev machines / where sudo is unavailable).
+ */
+export function ensureChromiumInstalled() {
+  if (_installPromise) return _installPromise;
+  _installPromise = (async () => {
+    const attempts = [
+      ['playwright', 'install', '--with-deps', 'chromium'],
+      ['playwright', 'install', 'chromium'],
+    ];
+    let lastErr;
+    for (const args of attempts) {
+      try {
+        console.warn(`🩹 Chromium binary missing — installing on-demand: npx ${args.join(' ')}`);
+        execFileSync('npx', args, { stdio: 'inherit', timeout: 6 * 60_000 });
+        return;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw new Error(`on-demand Chromium install failed: ${lastErr?.message || lastErr}`);
+  })();
+  return _installPromise;
+}
+
+/**
+ * Drop-in replacement for `chromium.launch(opts)` that self-heals a missing
+ * browser binary by installing it once and retrying. Same return value
+ * (Promise<Browser>) and same options as `chromium.launch`.
+ */
+export async function launchChromium(launchOptions = {}) {
+  const chromium = await getChromium();
+  try {
+    return await chromium.launch(launchOptions);
+  } catch (err) {
+    if (!isMissingBrowserError(err)) throw err;
+    await ensureChromiumInstalled();
+    return await chromium.launch(launchOptions);
+  }
+}
+
+// Exposed for testing the error-classifier in isolation.
+export const __test = { isMissingBrowserError };

--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -33,6 +33,7 @@ import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify } from './crawler-template.mjs';
 import { fetchWithRetry } from './transient-fetch.mjs';
+import { launchChromium } from './ensure-chromium.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
@@ -83,8 +84,7 @@ export function looksLikeJsonFeedBody(text) {
 async function fetchFeedViaPlaywright(url) {
   let browser;
   try {
-    const { chromium } = await import('playwright');
-    browser = await chromium.launch({ headless: true });
+    browser = await launchChromium({ headless: true });
     const context = await browser.newContext({
       userAgent: BROWSER_USER_AGENTS[0],
       locale: 'fr-CH',

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -460,6 +460,8 @@ async function getFastXmlParserModule() {
   return fastXmlParserModulePromise;
 }
 
+import { launchChromium } from './ensure-chromium.mjs';
+
 async function getPlaywrightChromium() {
   if (playwrightChromiumPromise) return playwrightChromiumPromise;
   playwrightChromiumPromise = import('playwright')
@@ -2486,7 +2488,7 @@ async function discoverCareerUrlsWithBrowserFallback(companyWebsite) {
   let browser = null;
   const out = new Set();
   try {
-    browser = await chromium.launch({ headless: true });
+    browser = await launchChromium({ headless: true });
     const page = await browser.newPage({ userAgent: CRAWLER_USER_AGENT });
     await page.goto(companyWebsite, { waitUntil: 'domcontentloaded', timeout: BROWSER_FALLBACK_TIMEOUT_MS });
     if (BROWSER_FALLBACK_WAIT_MS > 0) {

--- a/scripts/lib/topic-sources/googleTrends.mjs
+++ b/scripts/lib/topic-sources/googleTrends.mjs
@@ -16,6 +16,7 @@
 import { fnv1a8, normalizeKeyword } from './gscOrphans.mjs';
 import { FRONTALIERI_DOMAIN_RE } from '../perf-sources/domainTerms.mjs';
 import { detectLocale } from './detectLocale.mjs';
+import { launchChromium } from '../ensure-chromium.mjs';
 
 // Soft-bias for Lombardia cross-tagging: independent of FRONTALIERI_DOMAIN_RE
 // because we want to surface "auto in Varese" / "Como confine" even when
@@ -168,8 +169,7 @@ const RELATED_QUERIES_SELECTORS = [
 async function _playwrightFallbackInner(keyword, geo) {
   let browser = null;
   try {
-    const { chromium } = await import('playwright');
-    browser = await chromium.launch({ headless: true });
+    browser = await launchChromium({ headless: true });
     const ctx = await browser.newContext({
       userAgent:
         'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',

--- a/scripts/lib/topic-sources/reddit.mjs
+++ b/scripts/lib/topic-sources/reddit.mjs
@@ -10,6 +10,7 @@
 import { fnv1a8, normalizeKeyword } from './gscOrphans.mjs';
 import { FRONTALIERI_DOMAIN_RE } from '../perf-sources/domainTerms.mjs';
 import { detectLocale } from './detectLocale.mjs';
+import { launchChromium } from '../ensure-chromium.mjs';
 
 // Reddit relevance — split into TWO regexes (2026-05-07 tightening):
 //
@@ -313,8 +314,7 @@ async function playwrightFallback(endpointOrUrl) {
 
   let browser = null;
   try {
-    const { chromium } = await import('playwright');
-    browser = await chromium.launch({ headless: true });
+    browser = await launchChromium({ headless: true });
     const ctx = await browser.newContext({ userAgent: USER_AGENT });
     const page = await ctx.newPage();
 

--- a/scripts/newsletter-qa.mjs
+++ b/scripts/newsletter-qa.mjs
@@ -18,7 +18,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import { buildNewsletter, FEATURED_TOOLS, nlNormLocale } from '../services/newsletter-template.mjs';
 import { matchJobsForSubscriber, getFallbackBriefing, loadDashboardMetrics } from '../services/newsletter-content.mjs';
 
@@ -241,7 +241,7 @@ function runStressChecks(html, stressHtml) {
 /* ── Screenshots via Playwright ─────────────────────────────── */
 
 async function takeScreenshots(html, prefix) {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchChromium({ headless: true });
   const screenshots = {};
   try {
     for (const { width, label } of [

--- a/scripts/seo-audit-visual.mjs
+++ b/scripts/seo-audit-visual.mjs
@@ -10,7 +10,7 @@
  * Samples 25 representative URLs covering all SEO page types.
  */
 import { writeFileSync, mkdirSync } from 'node:fs';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 
 const OUT_DIR = '.orchestration/audit';
 mkdirSync(OUT_DIR, { recursive: true });
@@ -132,7 +132,7 @@ async function checkUrl(browser, entry) {
 }
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchChromium({ headless: true });
   const results = [];
   for (const entry of URLS) {
     console.log(`[${entry.type}] ${entry.url}`);

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -132,7 +132,7 @@ async function waitForDetail(page) {
 }
 
 async function withBrowser(fn) {
-  const browser = await chromium.launch({ headless: process.env.JOBS_ALTEN_HEADLESS === '1' });
+  const browser = await launchChromium({ headless: process.env.JOBS_ALTEN_HEADLESS === '1' });
   const context = await browser.newContext({
     userAgent:
       process.env.JOBS_CRAWLER_USER_AGENT ||

--- a/scripts/update-bosch-jobs.mjs
+++ b/scripts/update-bosch-jobs.mjs
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -104,7 +104,7 @@ async function fetchText(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
 }
 
 async function fetchRenderedBoschListings() {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchChromium({ headless: true });
   try {
     const page = await browser.newPage({
       userAgent: 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -17,6 +17,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -180,8 +181,7 @@ async function fetchListingPage(url, timeoutMs, userAgent) {
 // A real headless Chromium passes the JS/TLS fingerprint checks that block
 // node's fetch. Lazy-imported so the dependency is only loaded on fallback.
 async function fetchListingPageViaBrowser(url, timeoutMs) {
-  const { chromium } = await import('playwright');
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchChromium({ headless: true });
   try {
     const page = await browser.newPage({ userAgent: BROWSER_USER_AGENTS[0] });
     // domcontentloaded (not networkidle): the listing is static HTML; networkidle

--- a/scripts/update-colin-cie-jobs.mjs
+++ b/scripts/update-colin-cie-jobs.mjs
@@ -25,6 +25,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { extractStableJobId } from './lib/job-match-key.mjs';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -178,8 +179,7 @@ async function fetchPage(url) {
       } else {
         console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying Playwright fallback...`);
         try {
-          const { chromium } = await import('playwright');
-          const browser = await chromium.launch({ headless: true });
+          const browser = await launchChromium({ headless: true });
           try {
             const page = await browser.newPage({ userAgent: USER_AGENTS[0] });
             await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });

--- a/scripts/update-delvitech-jobs.mjs
+++ b/scripts/update-delvitech-jobs.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -113,7 +113,7 @@ async function fetchText(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
 }
 
 async function fetchWithBrowser(url) {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await launchChromium({ headless: true });
   try {
     const page = await browser.newPage({
       userAgent: BROWSER_UA,

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -27,6 +27,7 @@ import {
   mergePreserveLocaleData,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseGolineOpportunitiesPage, buildGolineLocalizedContent } from './lib/goline-job-parser.mjs';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -113,8 +114,7 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
       } else {
         console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying Playwright fallback...`);
         try {
-          const { chromium } = await import('playwright');
-          const browser = await chromium.launch({ headless: true });
+          const browser = await launchChromium({ headless: true });
           try {
             const page = await browser.newPage({ userAgent: USER_AGENTS[0] });
             await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 });

--- a/scripts/update-grace-jobs.mjs
+++ b/scripts/update-grace-jobs.mjs
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -252,7 +252,7 @@ async function dismissConsent(page) {
 
 async function withBrowser(fn) {
   const headless = process.env.JOBS_GRACE_HEADLESS === '1';
-  const browser = await chromium.launch({
+  const browser = await launchChromium({
     headless,
     args: ['--disable-blink-features=AutomationControlled'],
   });

--- a/scripts/update-migros-jobs.mjs
+++ b/scripts/update-migros-jobs.mjs
@@ -29,7 +29,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 import { printPublishedJobUrls, writeJobsSummary, snapshotJobSlugs, computeCrawlDiff, printCrawlChangeSummary, writeCrawlChangeSummaryToGH, setCrawlerStartTime, getCrawlerElapsedMs } from './jobs-url-helper.mjs';
 import {
   writeJobsCrawlerSlice,
@@ -145,7 +145,7 @@ async function fetchMigrosJobDetailUrls() {
   // runaway pagination control. Was 25 → silently dropped ~380 of 1180 jobs.
   const maxPages = Number(process.env.JOBS_MIGROS_MAX_PAGES) || 1000;
 
-  const browser = await chromium.launch({
+  const browser = await launchChromium({
     headless,
     args: ['--disable-blink-features=AutomationControlled'],
   });

--- a/scripts/validate-spa-render.mjs
+++ b/scripts/validate-spa-render.mjs
@@ -21,7 +21,7 @@
 import { createServer } from 'node:http';
 import { readFileSync, existsSync, readdirSync, statSync, appendFileSync } from 'node:fs';
 import { join, extname } from 'node:path';
-import { chromium } from 'playwright';
+import { launchChromium } from './lib/ensure-chromium.mjs';
 
 const ROOT = process.cwd();
 const DIST = join(ROOT, 'dist');
@@ -181,7 +181,7 @@ async function main() {
   // Launch browser
   let browser;
   try {
-    browser = await chromium.launch({ headless: true });
+    browser = await launchChromium({ headless: true });
   } catch (e) {
     console.error('❌ Failed to launch Chromium. Run: npx playwright install chromium');
     console.error(`   ${e.message}`);

--- a/tests/playwright-launch-self-heal.test.ts
+++ b/tests/playwright-launch-self-heal.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Source-prevention guard for the fleet-wide "Chromium binary not installed"
+ * crawler-failure class.
+ *
+ * ~398/425 dedicated-crawler workflows reach a Playwright browser fallback
+ * (enabled by default in the shared crawler) but `npm ci` does not install the
+ * browser binary. Any `chromium.launch()` that is NOT routed through
+ * `scripts/lib/ensure-chromium.mjs#launchChromium` will throw
+ * "Executable doesn't exist" on those workflows and silently lose jobs (or open
+ * a Crawler Failure issue). The reviewer kept catching this per-crawler — an
+ * unbounded manual loop.
+ *
+ * This guard makes the gap impossible to merge: every browser launch must go
+ * through the self-healing `launchChromium`, which installs Chromium on-demand.
+ * If you add a new `chromium.launch(...)`, route it through `launchChromium`.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { __test } from '../scripts/lib/ensure-chromium.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPTS = path.join(ROOT, 'scripts');
+const HELPER_REL = 'scripts/lib/ensure-chromium.mjs';
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      out.push(...walk(full));
+    } else if (/\.(mjs|js|ts)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Strip line comments + block comments so we only match real code. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+describe('playwright launch self-heal guard', () => {
+  it('every chromium.launch() in scripts/ routes through ensure-chromium.mjs#launchChromium', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SCRIPTS)) {
+      const rel = path.relative(ROOT, file);
+      if (rel === HELPER_REL) continue; // the helper itself is the single allowed launch site
+      const code = stripComments(fs.readFileSync(file, 'utf8'));
+      const matches = code.match(/\bchromium\s*\.\s*launch\s*\(/g);
+      if (matches) offenders.push(`${rel} (${matches.length}×)`);
+    }
+    expect(
+      offenders,
+      `Raw chromium.launch() found — route these through launchChromium() from ${HELPER_REL} ` +
+        `so the Chromium binary self-installs on crawler workflows that lack an explicit install step:\n` +
+        offenders.map((o) => `  - ${o}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('classifies missing-browser errors as installable, real errors as not', () => {
+    const { isMissingBrowserError } = __test;
+    // Missing binary / missing system libs → install-and-retry
+    expect(isMissingBrowserError(new Error("browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1234/chrome-linux/chrome"))).toBe(true);
+    expect(isMissingBrowserError(new Error('Please run the following command to download new browsers: npx playwright install'))).toBe(true);
+    expect(isMissingBrowserError(new Error('error while loading shared libraries: libnss3.so: cannot open shared object file'))).toBe(true);
+    expect(isMissingBrowserError(new Error('Host system is missing dependencies to run browsers'))).toBe(true);
+    // Real launch failures → must NOT trigger a pointless install (rethrow)
+    expect(isMissingBrowserError(new Error('Target page, context or browser has been closed'))).toBe(false);
+    expect(isMissingBrowserError(new Error('Out of memory'))).toBe(false);
+    expect(isMissingBrowserError(new Error('net::ERR_CONNECTION_REFUSED'))).toBe(false);
+    expect(isMissingBrowserError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Fix STRUTTURALE alla radice di una classe di crawler-failure ricorrente che il reviewer ha pescato 4 volte questa settimana (cambiavalute → colin-cie → eHnv/cnp → pole-sante) — un loop manuale senza fine.

### Root cause (misurato)
**398 di 425** crawler workflow raggiungono un fallback Playwright (il shared crawler ha `JOBS_BROWSER_FALLBACK_ENABLED` default = `1`), ma `npm ci` installa il **pacchetto** playwright **senza il binario** del browser. Un workflow privo dello step `npx playwright install` fa throware `chromium.launch()` con "Executable doesn't exist" → il crawler ritorna 0 job in silenzio (contenuto indicizzabile perso) oppure apre una "Crawler Failure" issue. Aggiungere lo step a 398 workflow = churn enorme + spreco CI + gap ricorrente su OGNI nuovo crawler.

### Fix (alla fonte, generalizzato)
Nuovo `scripts/lib/ensure-chromium.mjs` → `launchChromium()`, drop-in di `chromium.launch()` che, su errore di binario mancante, **installa Chromium on-demand una volta (memoized) e ritenta**. Tutti i `chromium.launch()` in `scripts/` (19 siti) sono instradati lì → il browser è garantito ovunque serva davvero, su tutti i 398 workflow **e ogni crawler futuro**, con **zero workflow toccati**. Il costo dell'install è pagato lazy, solo quando un crawler colpisce davvero il fallback (la maggioranza non lo fa), invece di uno step sprecato a ogni run di 398 workflow.

### Source-prevention guard
`tests/playwright-launch-self-heal.test.ts` fa **fallire la CI** se qualcuno aggiunge un `chromium.launch()` raw fuori dall'helper → la classe non può più riapparire silenziosamente (presente E futura). + unit test del classificatore errori (binario mancante / libs mancanti → install-and-retry; OOM/target-closed/network → rethrow, niente install inutile).

### Siti wired (19)
Shared: `shared-jobs-crawler`, `jobup-ch-feed-common`, `ats-clients/playwright-runtime`. Parser dedicati: `clinica-holistica-engiadina`. Standalone: grace/alten/delvitech/migros/bosch/colin-cie/cambiavalute/goline. Tooling: seo-audit-visual/newsletter-qa/validate-spa-render/audit-cls-stripping/audit-jobs-source-match + topic-sources reddit/googleTrends. Rimosso dead code (`loadPlaywright`, `playwrightModulePromise`) reso obsoleto dall'helper.

### Verifica
Guard 2/2 + crawler regression 7/7 (shared-jobs/jobup/crawler-template/dedicated-loc) + import-resolution smoke su tutti i moduli toccati + `node --check` su tutti. Nessun `chromium.launch()` raw residuo in `scripts/`.

## Non implementato (ancora)

- Gli step `npx playwright install` espliciti già presenti su 27 workflow (goline/grace/bosch/migros…) sono **lasciati**: sono innocui e rendono il primo fallback più veloce (nessun churn a rimuoverli). L'helper è la rete di sicurezza per gli altri 398.
- Il runtime install usa `npx playwright install --with-deps chromium` con fallback a `chromium`-only se `--with-deps` (sudo/apt) non è disponibile; su runner GitHub Actions `--with-deps` funziona (sudo passwordless).