### PR TITLE
perf(agent-loop): token levers — pr-review concurrency-cancel, issue-fix tier, drop supersede

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -52,14 +52,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        # Tier high (opus, max-turns alti): issue che toccherà con ogni probabilità
-        # scripts/crawler/build-plugin/workflow/test (categoria crawler, o body che
-        # cita questi path). Bug lì = rischio propagato su ogni merge. Tier normal
-        # (sonnet) per il resto. Mirror della logica di pr-review-loop.
+        # Tier high (opus, max-turns alti): issue funnel-critical — crawler/parser/
+        # build-plugin/workflow CI/test gate, o uno script che MUTA/emette dati
+        # indicizzati (backfill/migrate/assemble/sitemap/canonical/slug/
+        # structured-data/seo). Bug lì = rischio propagato su ogni merge → probing
+        # opus paga. Tier normal (sonnet) per il resto. Mirror ESATTO di
+        # pr-review-loop: il bare `scripts/` NON escala più (mandava ogni menzione
+        # di script — inclusi helper `scripts/{ci,dev,evals}/` e audit/report
+        # read-only — a opus@40; osservato 2026-06-04 come tier-breadth waste). Gli
+        # script funnel restano high via i loro keyword semantici/path index-muting.
         run: |
           set -euo pipefail
           body=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels --jq '.title + "\n" + .body + "\n" + (.labels[].name)')
-          if echo "$body" | grep -qiE 'crawler|parser|scripts/|build-plugin|\.github/workflows/|test gate|validator|migrator'; then
+          if echo "$body" | grep -qiE 'crawler|parser|build-plugin|\.github/workflows/|test gate|validator|migrator' \
+             || echo "$body" | grep -qiE 'scripts/[a-z0-9_./-]*(backfill|migrate|assemble|sitemap|canonical|slug|structured-data|seo|index)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
             echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
             echo "max_turns=40" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -65,12 +65,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # max-turns 20 (era 15): il triage completo (parse PR body + reviews,
-          # filtro churn/funnel, dedup, in-flight overlap, gh issue create, +
-          # supersede detection) sforava sistematicamente i 15 turni → 6 run
-          # `error_max_turns` il 2026-05-30 (num_turns 16+) con triage perso per
-          # PR #1015/#1012/#979 (nessun re-run → 🟡/❓ + `## Non implementato`
-          # mai triagiati). 15 troncava prima degli step obbligatori; AGENTS.md
-          # vieta di abbassarli proprio per questo. Allineato a lessons-harvester (20).
+          # filtro churn/funnel, dedup, in-flight overlap, gh issue create)
+          # sforava sistematicamente i 15 turni → 6 run `error_max_turns` il
+          # 2026-05-30 (num_turns 16+) con triage perso per PR #1015/#1012/#979
+          # (nessun re-run → 🟡/❓ + `## Non implementato` mai triagiati). 15
+          # troncava prima degli step obbligatori; AGENTS.md vieta di abbassarli
+          # proprio per questo. Allineato a lessons-harvester (20).
+          # NB: la supersede detection è stata RIMOSSA da questo prompt (2026-06-04)
+          # — la fa già `followup-reconcile.yml` deterministico daily (zero-Claude).
           claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Triage automatico follow-up per PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }} (${{ github.event_name }}).
@@ -100,13 +102,12 @@ jobs:
             - Dedup vs issue `follow-up` esistenti (titolo >70% similar → skip).
             - **In-flight PR overlap** (anti self-flag): escludi item su file che una PR aperta sta già modificando (`gh pr list --state open` + `gh pr diff <n> --name-only`) → log "in-flight in PR #N". Vedi FOLLOWUP.md § Dedup.
             - Crea issue per candidate validi, max 10/PR. Label: `follow-up` + UNO funnel-* se inferibile.
-            - **Supersede detection** (FOLLOWUP.md § Supersede detection): per le issue `follow-up` aperte che citano un file toccato da questa PR (`gh pr diff $PR_NUMBER --name-only`), posta UN commento `🔗 Possibile supersede` (idempotente). **Mai chiudere** — solo segnalazione; chiude solo l'autore con `Closes #N`.
             - Posta `## Post-merge follow-up triage` summary commento sulla PR. Include la sezione `Live-verification` (checklist `- [ ]` batchata degli item `live-verify-only`, nessuna issue/fixer) se ce ne sono; vedi FOLLOWUP.md § Closing comment.
 
             **Constraint:**
-            - Read-only eccetto `gh issue create`, `gh pr comment`, `gh issue comment` (solo Supersede detection).
+            - Read-only eccetto `gh issue create`, `gh pr comment`.
             - Mai modificare PR label/state/title.
-            - Mai chiudere/riaprire issue (nemmeno le superseded — solo commento).
+            - Mai chiudere/riaprire issue.
             - Incerto sul filtro → crea con rationale "needs triage".
             - Zero candidate → `## Post-merge follow-up triage: zero outstanding items.` e termina.
 

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Una review opus@40 dura 8-11min. Senza questo, ogni `synchronize` (commit
+# nuovo su un branch fix) lancia una review da zero mentre la precedente è
+# ancora in volo → review opus SOVRAPPOSTE sullo stesso PR su SHA superati
+# (osservato live 2026-06-04: 2 review opus su fix/umantis, ~8min di overlap,
+# doppio costo quota). cancel-in-progress collassa i push rapidi a una sola
+# review sull'ultimo SHA. Keyed sul PR così PR diversi non si cancellano a
+# vicenda. `tests` ha già questo cancel; pr-review-loop no — asimmetria che
+# faceva girare la review opus fino in fondo su commit morti.
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -144,26 +144,17 @@ La sezione `Live-verification` raccoglie **tutti** gli item `live-verify-only` (
 
 Se zero item sopravvivono al filtro+dedup (e nessuna voce live-verify) → posta `## Post-merge follow-up triage: zero outstanding items.` (nessuna issue creata). Se sopravvivono SOLO voci live-verify (zero issue) → posta il summary con la sola sezione `Live-verification` e la riga `Created: 0 issue (solo live-verification batchata)`.
 
-## Supersede detection (comment-only, mai chiudere)
+## Supersede detection → spostata su `followup-reconcile` (deterministica, zero-Claude)
 
-Dopo il triage, segnala le issue `follow-up` aperte che **questa PR potrebbe aver reso obsolete**, così non restano orfane (es. PR che riscrive un workflow rendendo moot gli item di hardening su quel file). **Non chiudere mai** su euristica: una PR può toccare un file senza coprire lo specifico item — chiudere distruggerebbe scope ancora valido. Solo l'autore, con `Closes #N` / `Supersedes #N` nel body (vedi `AGENTS.md → Workflow`), chiude davvero (GitHub nativo per `Closes`).
+**2026-06-04:** la supersede detection è stata RIMOSSA dal prompt Claude di `post-merge-followup.yml`. Il flag grossolano su file-touch (comment-only, advisory) bruciava turni Claude + un `gh issue list --search` per-file a ogni merge, per una segnalazione che l'autore raramente azionava. La copertura è ora di `followup-reconcile.yml` (`scripts/ci/reconcile-followups.mjs`, cron daily, **zero-Claude**): per ogni issue `follow-up` aperta estrae i file/token citati e verifica se la fix è **presente verbatim** nel file → label `maybe-resolved` (check di risoluzione reale, più preciso del flag file-touch). La chiusura finale resta umana / `Closes #N`.
 
-1. File toccati da questa PR: `gh pr diff $PR_NUMBER --name-only`.
-2. Candidati supersede, **scoped per-file** (mai dump bulk dei body): per ogni file del diff `gh issue list --label follow-up --state open --search "<file>" --json number,title --limit 20` (GitHub indicizza il body → ritorna solo le issue che citano quel path). Unisci i risultati, escludi quella appena creata per questa PR. NON usare `--json number,title,body --limit 50` su tutte le aperte: ~28 body emoji-heavy ≈ 82KB, troncabile a un boundary di surrogate UTF-16 → `400 no low surrogate in string` (stessa classe del bulk overview a `post-merge-followup.yml`).
-3. Per ciascun candidato scoped, conferma con `gh issue view <N> --json body` che il path sia citato in `## Suggested action` / `## Item`; se sì:
-   - Se non hai già commentato (cerca `🔗 Possibile supersede` nei commenti, idempotenza) → posta:
-     ```markdown
-     🔗 Possibile supersede: PR #<PR_NUMBER> (<PR_TITLE>) ha modificato `<file>` — <motivo dal PR title/body>. Verifica se gli item di questa issue sono ancora pertinenti; se coperti, chiudi a mano. (segnalazione automatica, non chiusura)
-     ```
-4. Nel summary commento sulla PR aggiungi una riga `Superseding flags: <N> issue segnalate (#a, #b)` se >0.
-
-Solo segnalazione: il giudizio finale resta umano. Mai più di un commento di supersede per coppia (PR, issue).
+Gap residuo accettato: un refactor che rende moot un item SENZA aggiungere i token citati non viene flaggato da nessuno dei due (reconcile cerca i token verbatim). Trade-off scelto per ridurre la spesa Claude per-merge.
 
 ## Constraint
 
-- Read-only su tutto eccetto: `gh issue create`, `gh pr comment`, `gh issue comment` (solo per la Supersede detection — segnalazione, mai chiusura).
+- Read-only su tutto eccetto: `gh issue create`, `gh pr comment`.
 - Mai modificare label/state/title della PR.
-- Mai chiudere/riaprire issue (nemmeno le superseded — solo commento).
+- Mai chiudere/riaprire issue.
 - Zero finding accettabile (PR LGTM puro senza Non implementato). NON inventare.
 - Incerto sul filtro scopo → crea issue comunque, rationale "needs triage". Drop è più costoso di una issue extra.
 - Limite hard: max 10 item nella issue aggregata. Oltre → includi i primi 10 e aggiungi in coda al summary "throttled: >10 item, restanti richiedono triage manuale".

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -186,9 +186,9 @@ After dispatching, **does not wait**. All crawlers run concurrently. `translate-
 
 **`pr-review-loop.yml` — tiered review (PR #769)**
 
-- `Determine review tier` step inspects the PR's changed paths and computes `model` + `max_turns` dynamically:
-  - **high tier** — triggered by changes under `tests/`, `.github/workflows/`, `scripts/`, or `build-plugins/`. Uses Opus, `max_turns: 25`, runs the adversarial-check sweep on top of the baseline review.
-  - **normal tier** — everything else. Uses Sonnet, `max_turns: 15`.
+- `Determine review tier` step inspects the PR's changed paths and computes `model` + `max_turns` dynamically. **The exact model/turn values + path patterns live in the workflow step `Determine review tier` (`.github/workflows/pr-review-loop.yml`) — do not hard-code numbers here, they drift** (this doc said Opus/`max_turns: 25` long after the workflow moved to 40):
+  - **high tier** — Opus, runs the adversarial-check sweep. Triggered by funnel-critical CODE: `tests/`, `.github/workflows/`, `build-plugins/`, or index-mutating `scripts/`. Non-funnel helper scripts (`scripts/{ci,dev,evals}/`) and read-only audit/report scripts stay **normal**. DATA/docs-only diffs (`data/**`, `public/**`, `reports/**`, `docs/**`) never escalate the tier.
+  - **normal tier** — everything else. Sonnet.
 - Tool whitelist widened to include `Bash(rg:*)` and `Bash(git:*)` so the reviewer can do cross-file pattern probing (`REVIEW.md` step 5) and PR-history checks.
 - Test plan compliance is enforced by `REVIEW.md` step 6 — the reviewer cross-checks the PR body's test plan against the diff.
 - Green output ends with the literal `## LGTM` marker; that is the single signal `auto-merge-on-lgtm.yml` watches for. See `REVIEW.md` for what scenarios are allowed to emit `## LGTM`.


### PR DESCRIPTION
Da **osservazione live 2h del loop agent** (2026-06-04 04:47-06:28 UTC, 7 PR merged osservate). Riduce la spesa Claude sui 3 workflow che la consumano, **senza cambiare il comportamento funzionale**. La quota Max è condivisa con le sessioni interattive → meno spreco qui = più budget per il lavoro funnel.

## Implementato
- **pr-review-loop: concurrency-cancel.** `group: pr-review-${pr.number}`, `cancel-in-progress: true`. Una review opus@40 dura 8-11min; senza cancel ogni `synchronize` lanciava una review da zero mentre la precedente era in volo → **review opus SOVRAPPOSTE su SHA superati** (osservato live: 2 review su `fix/umantis`, ~8min di overlap, doppio costo). `tests` aveva già il cancel, pr-review no.
- **issue-fix tier regex.** Il bare `scripts/` mandava OGNI menzione di script a opus@40 (inclusi helper `scripts/{ci,dev,evals}/` e audit/report read-only). Allineato a pr-review: opus solo per funnel-critical (crawler/parser/build-plugin/workflow/test) o script che mutano l'indice (backfill/migrate/assemble/sitemap/canonical/slug/structured-data/seo/index); il resto → sonnet@30.
- **post-merge-followup: drop supersede-detection.** Rimossa dal prompt Claude (turni + un `gh issue list --search` per-file a ogni merge). Copertura già di `followup-reconcile.yml` (`reconcile-followups.mjs`, daily, **zero-Claude**) con check più preciso (token citati verbatim → `maybe-resolved`). FOLLOWUP.md aggiornato.
- **docs/CI-CD-PIPELINE.md: fix tier stale** (diceva Opus/`max_turns: 25`, reale 40) → referenzia lo step del workflow invece di hard-codare numeri che driftano.

## Non implementato (deferred, con motivo)
- **Drainer follow-up + classifica fu-prio + gen-cap/park** (loop autonomo che risolve la *issue-fix starvation*: slot concurrency globale + `cancel:false` → 60% fix-run cancellate-in-coda, ~20 issue stuck). È **net-new infra che muta label via PAT** → richiede validazione live (un drainer buggato mis-etichetta issue in massa). PR separata validata.
- **B1 collapse dual GitNexus block** (~2700 tok/sessione locale): NON è un cambio PR pulito — `CLAUDE.md` è gitignored (file locale) e il blocco in `AGENTS.md` è auto-generato (`gitnexus:start/end`). Concern di config-tooling, non di repo.
- **B2 dedup regole cross-file contract**; **crawler issue rollup + PAT-load-failure alert + auto-route validation-failure**: PR successive.

## Verifica
- YAML lint OK (python yaml.safe_load) su tutti e 3 i workflow.
- Regex tier testato: `scripts/ci/lint`+audit → normal (sonnet, era opus = il fix); `crawler` → high; `scripts/backfill-slugs sitemap` → high. ✓
- Nessun cambio funzionale: solo tier-selection, concurrency, e rimozione di una segnalazione advisory ridondante.