### PR TITLE
feat(agent-loop): follow-up queue drainer — fix issue-fix starvation autonomamente

### DIFF
--- a/.github/workflows/followup-drainer.yml
+++ b/.github/workflows/followup-drainer.yml
@@ -1,0 +1,74 @@
+name: Follow-up drainer (queue → agent:fix, no-Claude)
+
+# Drena la coda dei follow-up `agent:fix-queued` UNO alla volta, promuovendo a
+# `agent:fix` solo quando lo slot issue-fix è libero → la run promossa è l'unica
+# pending → mai cancellata-in-coda. Fix della starvation osservata 2026-06-04
+# (slot concurrency globale issue-fix + cancel:false → 60% fix-run follow-up
+# cancellate, ~20 issue stuck). Rescue+park degli agent:fix orfani (run morta,
+# nessuna PR) per terminazione autonoma senza intervento umano.
+# ZERO Claude: tutto deterministico (scripts/ci/followup-drainer.mjs + gh).
+
+on:
+  schedule:
+    - cron: '*/20 * * * *' # drena la coda ~ogni 20min
+  workflow_run:
+    workflows: ['Issue fix (Claude → PR)'] # appena un fix finisce, promuovi il prossimo
+    types: [completed]
+  workflow_dispatch:
+
+# Una sola run drainer alla volta: evita race di doppia-promozione sullo slot.
+concurrency:
+  group: followup-drainer
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna Firebase SA — GITHUB_PAT non caricato; promozione inerte (un labeled da GITHUB_TOKEN non triggererebbe issue-fix)."
+          fi
+
+      - name: Load secrets from Remote Config
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Drain follow-up queue (deterministic, no Claude)
+        env:
+          # PAT (owner) OBBLIGATORIO: il `labeled` agent:fix deve triggerare
+          # issue-fix e passare il gate `sender == valerielinc-ops` (GITHUB_TOKEN
+          # no, anti-ricorsione). Senza PAT → exit con warning (inerte).
+          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::GITHUB_PAT assente → drainer inerte (promozione non triggererebbe issue-fix)."
+            exit 0
+          fi
+          node scripts/ci/followup-drainer.mjs

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -84,7 +84,9 @@ jobs:
           echo "decision=$decision"
           cat=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).category)" "$decision")
           autofix=$(node -e "process.stdout.write(String(JSON.parse(process.argv[1]).autofix===true))" "$decision")
-          echo "category=$cat autofix=$autofix"
+          route=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).route||'none')" "$decision")
+          fuprio=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).fuPrio||'')" "$decision")
+          echo "category=$cat autofix=$autofix route=$route fuPrio=$fuprio"
 
           # --- Label anti-loop sempre (GITHUB_TOKEN: non deve triggerare nulla) ---
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "agent:triaged" || true
@@ -99,23 +101,37 @@ jobs:
               gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "🤖 Triage automatico: categoria non riconosciuta (\`other\`) — needs manual triage." || true ;;
           esac
 
-          # --- Routing agent:fix via PAT (solo crawler/follow-up, issue OPEN) -----
-          # agent:fix DEVE essere via PAT, non GITHUB_TOKEN: (1) anti-ricorsione
-          # GitHub — un `labeled` da GITHUB_TOKEN non triggera issue-fix; (2) il
-          # gate issue-fix `sender == valerielinc-ops` non matcha github-actions[bot].
-          # Col PAT (owner) trigger + gate OK. Stesso meccanismo di auto-merge-on-lgtm.
-          if [ "$autofix" != "true" ]; then
-            echo "autofix=false → nessun agent:fix."; exit 0
+          # --- Routing via PAT (crawler→fix immediato, follow-up→queue) ----------
+          # Le label di routing DEVONO essere via PAT, non GITHUB_TOKEN:
+          # (1) anti-ricorsione GitHub — un `labeled` da GITHUB_TOKEN non triggera
+          # issue-fix/drainer; (2) il gate issue-fix `sender == valerielinc-ops`
+          # non matcha github-actions[bot]. Col PAT (owner) trigger + gate OK.
+          #
+          # route='fix'   → agent:fix subito (crawler, production-critical).
+          # route='queue' → agent:fix-queued + fu-prio:<prio> (follow-up): NON parte
+          #   subito; `followup-drainer.yml` lo promuove a agent:fix uno alla volta
+          #   solo a slot issue-fix libero → mai cancellato-in-coda (fix starvation
+          #   osservata 2026-06-04). high (funnel/priority) drenato prima di low.
+          if [ "$route" = "none" ] || [ "$autofix" != "true" ]; then
+            echo "route=$route autofix=$autofix → nessun routing."; exit 0
           fi
           if [ "$state" != "OPEN" ]; then
-            echo "Issue non OPEN ($state) → skip agent:fix."; exit 0
+            echo "Issue non OPEN ($state) → skip routing."; exit 0
           fi
           if [ -z "${GITHUB_PAT:-}" ]; then
-            echo "::warning::GITHUB_PAT assente → routing inerte (GITHUB_TOKEN non triggererebbe issue-fix)."; exit 0
+            echo "::warning::GITHUB_PAT assente → routing inerte (GITHUB_TOKEN non triggererebbe issue-fix/drainer)."; exit 0
           fi
-          echo "Applico agent:fix via PAT su #$ISSUE_NUMBER (category=$cat) → triggera issue-fix."
           # Non-fatal: se il PAT manca dei permessi issues:write o la label non
           # esiste, NON rompere il triage (già completato: triaged + commento) —
           # emetti warning visibile (routing inerte da indagare).
-          GH_TOKEN="$GITHUB_PAT" gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "agent:fix" \
-            || echo "::warning::agent:fix via PAT fallito (scope PAT issues:write? label assente?) — routing non applicato, triage comunque completato."
+          if [ "$route" = "queue" ]; then
+            prio="${fuprio:-low}"
+            echo "Accodo #$ISSUE_NUMBER → agent:fix-queued + fu-prio:$prio (drenato dal followup-drainer)."
+            GH_TOKEN="$GITHUB_PAT" gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+              --add-label "agent:fix-queued" --add-label "fu-prio:$prio" \
+              || echo "::warning::accodamento via PAT fallito (scope/label?) — routing non applicato, triage completato."
+          else
+            echo "Applico agent:fix via PAT su #$ISSUE_NUMBER (category=$cat) → triggera issue-fix."
+            GH_TOKEN="$GITHUB_PAT" gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "agent:fix" \
+              || echo "::warning::agent:fix via PAT fallito (scope PAT issues:write? label assente?) — routing non applicato, triage completato."
+          fi

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -34,8 +34,8 @@ Nessun dedup-close: i duplicati sono evitati a monte (vedi "Scopo"). Misclassifi
 
 | Categoria | Azione triage |
 |---|---|
-| `crawler` | **Auto-route `agent:fix`.** Regen parser deterministico, basso blast-radius, coperto da `generate-company-parser.mjs`. |
-| `follow-up` | **Auto-route `agent:fix`.** Micro-task / verifica deferred, basso blast-radius. |
+| `crawler` | **Auto-route `agent:fix` immediato** (`route='fix'`). Regen parser deterministico, basso blast-radius, coperto da `generate-company-parser.mjs`. Production-critical, non è il treadmill source. |
+| `follow-up` | **Auto-route `agent:fix-queued`** (`route='queue'`, 2026-06-04) + `fu-prio:high\|low`. NON parte subito: `followup-drainer.yml` lo promuove a `agent:fix` UNO alla volta, solo a slot `issue-fix` libero (high prima). Fix della starvation (vedi "Drenare il backlog" sotto). |
 | `validation-failure` | **NO auto-fix.** Spesso transiente; transiente-vs-persistente non è decidibile in modo deterministico (bash). Commento "verifica ricorrenza 🔁 prima di `agent:fix` manuale". |
 | `revenue` / `tracker` | NO auto-fix MAI. Giudizio strategico → mano umana (`/fix-issue` locale o manuale). |
 | `other` | NO auto-fix. Commento "needs manual triage". |
@@ -56,7 +56,7 @@ Tutte le automazioni Claude usano **solo `CLAUDE_CODE_OAUTH_TOKEN`** (Max sub, z
 - **No fixer su issue non-OPEN**: il routing salta le issue chiuse.
 - Concurrency `cancel-in-progress: false` serializza i fixer.
 - **fix/review/followup restano Claude** (giudizio necessario): max-turns NON tagliati (quality gate; budget basso → `error_max_turns`, cfr. #795/#802/#838). Sono meno frequenti del triage e producono valore.
-- **Residuo**: l'auto-route `follow-up` può auto-alimentarsi (fix→merge→followup→nuovo follow-up). Bound da: batch 1-issue/PR (meno volume), concurrency 1-alla-volta, gate `## LGTM`. Un fix pulito non genera nuovi follow-up → converge.
+- **Residuo**: l'auto-route `follow-up` può auto-alimentarsi (fix→merge→followup→nuovo follow-up). Bound da: batch 1-issue/PR (meno volume), **coda drenata 1-alla-volta** (`followup-drainer`), gate `## LGTM`, e **terminazione autonoma** (`followup-drainer` parcheggia a `fu-attempt:3` → `fu-parked`, no loop infinito, no perdita). Un fix pulito non genera nuovi follow-up → converge.
 
 ## Fix flow (`issue-fix.yml`, on `issues: labeled == agent:fix`)
 
@@ -98,9 +98,13 @@ I file rigenerati `data/**` (job JSON, snapshot, translation-cache, blog-article
 - Mai un fix speculativo pur di produrre una PR.
 - **Ogni abort DEVE chiudere con `<!-- FIX_OUTCOME: <code> -->` nel commento** (codici validi: `no-root-cause` / `blocked-workflows-scope` / `blocked-secrets` / `blocked-admin-settings` / `overlap-skip` / `pr-already-open` / `already-fixed` / `revenue-tracker-manual`). Senza marker → harvester classifica il run come `no-pr-unspecified`, indistinguibile da un crash silenzioso → il pattern non è migliorabile.
 
-### Drenare il backlog `agent:fix` (re-label sequenziale)
+### Drenare il backlog follow-up (`followup-drainer.yml`, automatico)
 
-`issue-fix` ha `concurrency: { group: issue-fix, cancel-in-progress: false }`: GitHub tiene **un solo run pending** per gruppo e un nuovo trigger **cancella (supersede) il pending precedente**. Re-labelare in raffica N issue → sopravvivono solo la prima (già `in_progress`) e l'ultima (pending); quelle in mezzo finiscono `cancelled` **silenziosamente** (osservato: #974/#959/#960 droppate). Per ri-processare più issue: re-applica `agent:fix` **una alla volta**, aspettando che la precedente sia almeno `in_progress` prima della successiva. È anche la protezione anti-pile-up (no N agent concorrenti = no OOM / no burst quota Max condivisa).
+`issue-fix` ha `concurrency: { group: issue-fix, cancel-in-progress: false }`: GitHub tiene **un solo run pending** per gruppo e un nuovo trigger **cancella (supersede) il pending precedente**. Re-labelare `agent:fix` in raffica N follow-up → sopravvivono solo la prima (già `in_progress`) e l'ultima (pending); quelle in mezzo finiscono `cancelled` **silenziosamente** e restano `agent:fix` senza retry → backlog stuck (osservato 2026-06-04: ~20 issue, root cause del backlog follow-up; storicamente #974/#959/#960 droppate).
+
+**Risolto da `followup-drainer.yml`** (cron ~20min + `workflow_run` dopo ogni `issue-fix` + dispatch, **zero-Claude**, `scripts/ci/followup-drainer.mjs`): i follow-up entrano come `agent:fix-queued` (non `agent:fix`); il drainer promuove **UNO** a `agent:fix` solo quando lo slot `issue-fix` è libero (in-flight==0) → la run promossa è l'unica pending → **mai cancellata-in-coda**. Ordine: `fu-prio:high` prima, poi più vecchia. Resta la protezione anti-pile-up (1 fixer alla volta = no OOM / no burst quota Max).
+
+**Rescue + park (terminazione autonoma, no human):** un `agent:fix` follow-up orfano (run morta, nessuna PR `fix/issue-N`, `updatedAt` > 30min) viene ri-accodato con `fu-attempt:N`++; a `fu-attempt:3` → `fu-parked` (esce dalla coda attiva, **non chiuso**: nessuna perdita, ri-tentabile a mano). Solo a slot libero, così non tocca mai una run viva. Per ri-processare a mano un follow-up: applica `agent:fix-queued` (il drainer fa il resto) — non più `agent:fix` diretto.
 
 ## Local fixer (`/fix-issue N`)
 

--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -1,0 +1,161 @@
+/**
+ * followup-drainer.mjs — gestore coda follow-up (zero-Claude, deterministico).
+ *
+ * Risolve la STARVATION osservata 2026-06-04: `issue-fix.yml` ha un solo slot
+ * concurrency globale (`group: issue-fix`, `cancel-in-progress: false`). GitHub
+ * con cancel=false CANCELLA le run PENDING tenendo solo l'in-progress + l'ultima
+ * queued. In un burst di follow-up auto-routati a agent:fix → 60% delle fix-run
+ * cancellate-in-coda, mai ri-tentate (nessun nuovo evento `labeled`), ~20 issue
+ * bloccate `agent:fix` ma non lavorate.
+ *
+ * Design (vedi AUTONOMOUS-LOOP-DESIGN): i follow-up non ricevono più `agent:fix`
+ * diretto da triage ma `agent:fix-queued`. Questo drainer (cron ~20min +
+ * workflow_run dopo issue-fix) promuove UNO alla volta a `agent:fix`, e SOLO
+ * quando lo slot issue-fix è libero → la run promossa è l'unica pending → non
+ * viene mai cancellata. Starvation eliminata per costruzione.
+ *
+ * Termina autonomamente (no human): un follow-up promosso che non produce PR
+ * (run cancellata/error_max_turns) viene rilevato come orfano e RI-ACCODATO con
+ * `fu-attempt:N` incrementato; a N>=MAX_ATTEMPTS → `fu-parked` (esce dalla coda
+ * attiva, nessuna perdita: resta aperto, ri-tentabile a mano/in futuro).
+ *
+ * Tutte le mutazioni label passano dal PAT (GH_TOKEN=GITHUB_PAT a monte) così il
+ * `labeled` agent:fix triggera issue-fix (GITHUB_TOKEN no, anti-ricorsione).
+ *
+ * Uso:  node scripts/ci/followup-drainer.mjs [--dry-run]
+ * Env:  GH_TOKEN (PAT), GITHUB_REPOSITORY (owner/repo). Richiede `gh` in PATH.
+ */
+import { execFileSync } from 'node:child_process';
+
+const DRY = process.argv.includes('--dry-run');
+const REPO = process.env.GITHUB_REPOSITORY || '';
+const MAX_ATTEMPTS = 3;
+// Margine prima di considerare un agent:fix "orfano" (la run deve aver avuto il
+// tempo di partire + aprire la PR). Conservativo per non ri-accodare run vive.
+const ORPHAN_MIN_AGE_MIN = 30;
+
+const LBL_QUEUED = 'agent:fix-queued';
+const LBL_FIX = 'agent:fix';
+const LBL_PARKED = 'fu-parked';
+
+function gh(args, { json = true } = {}) {
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return json ? JSON.parse(out) : out;
+}
+
+/** Quante run issue-fix sono in volo (queued|in_progress). 0 = slot libero. */
+function inFlightFixCount() {
+  let n = 0;
+  for (const status of ['queued', 'in_progress']) {
+    try {
+      const runs = gh([
+        'run', 'list', '--workflow', 'issue-fix.yml',
+        '--status', status, '--json', 'databaseId', '--limit', '20',
+      ]);
+      n += Array.isArray(runs) ? runs.length : 0;
+    } catch {
+      // su errore transient API conta come "occupato" (conservativo: non promuovere)
+      return Number.POSITIVE_INFINITY;
+    }
+  }
+  return n;
+}
+
+function listIssues(label) {
+  try {
+    return gh([
+      'issue', 'list', '--repo', REPO, '--state', 'open', '--label', label,
+      '--json', 'number,title,labels,createdAt,updatedAt', '--limit', '100',
+    ]);
+  } catch {
+    return [];
+  }
+}
+
+const names = (iss) => (iss.labels || []).map((l) => l.name);
+const has = (iss, n) => names(iss).includes(n);
+const attemptOf = (iss) => {
+  const m = names(iss).map((n) => /^fu-attempt:(\d+)$/.exec(n)).find(Boolean);
+  return m ? parseInt(m[1], 10) : 0;
+};
+const prioRank = (iss) => (has(iss, 'fu-prio:high') ? 0 : 1); // high prima
+
+function edit(num, { add = [], remove = [] }) {
+  const args = ['issue', 'edit', String(num), '--repo', REPO];
+  for (const l of add) args.push('--add-label', l);
+  for (const l of remove) args.push('--remove-label', l);
+  if (DRY) { console.log(`[dry] edit #${num} +[${add}] -[${remove}]`); return; }
+  try { gh(args, { json: false }); }
+  catch (e) { console.log(`::warning::edit #${num} fallito: ${String(e).slice(0, 120)}`); }
+}
+
+/** Esiste una PR fix aperta o mergiata per questa issue? (head fix/issue-N) */
+function hasFixPR(num) {
+  for (const branch of [`fix/issue-${num}`]) {
+    try {
+      const prs = gh(['pr', 'list', '--repo', REPO, '--head', branch, '--state', 'all', '--json', 'number', '--limit', '1']);
+      if (Array.isArray(prs) && prs.length) return true;
+    } catch { /* ignore */ }
+  }
+  return false;
+}
+
+function minutesSince(iso) {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - then) / 60000;
+}
+
+function main() {
+  if (!REPO) { console.error('GITHUB_REPOSITORY mancante'); process.exit(1); }
+  console.log(`followup-drainer${DRY ? ' [DRY-RUN]' : ''} repo=${REPO}`);
+
+  // Tutto (rescue + drain) gira SOLO a slot issue-fix libero: così il rescue non
+  // può mai toccare la issue di una run viva (evita di togliere agent:fix mentre
+  // il fix è in corso), e la promozione resta l'unica pending → mai cancellata.
+  const inflight = inFlightFixCount();
+  if (inflight > 0) {
+    console.log(`slot issue-fix occupato (in-flight=${inflight}) → nessuna azione.`);
+    return;
+  }
+
+  // --- RESCUE + PARK: agent:fix orfani (nessuna PR, nessuna run, vecchi) -------
+  // Un follow-up promosso la cui run è morta (cancel/error_max_turns) resta
+  // agent:fix senza PR e senza nuovo trigger → stuck. Ri-accoda (bump attempt),
+  // park a MAX_ATTEMPTS. Solo su follow-up (label `follow-up`) per non toccare i
+  // crawler agent:fix (production-critical, gestione separata).
+  const stuckFix = listIssues(LBL_FIX).filter(
+    (i) => has(i, 'follow-up') && !has(i, LBL_QUEUED) && !has(i, LBL_PARKED)
+  );
+  for (const iss of stuckFix) {
+    if (minutesSince(iss.updatedAt) < ORPHAN_MIN_AGE_MIN) continue; // run forse viva
+    if (hasFixPR(iss.number)) continue; // ha già prodotto una PR → non orfano
+    const attempt = attemptOf(iss) + 1;
+    const prevAttemptLabel = attemptOf(iss) ? `fu-attempt:${attemptOf(iss)}` : null;
+    if (attempt >= MAX_ATTEMPTS) {
+      console.log(`PARK #${iss.number} (attempt ${attempt} >= ${MAX_ATTEMPTS})`);
+      edit(iss.number, {
+        add: [LBL_PARKED, `fu-attempt:${attempt}`],
+        remove: [LBL_FIX, LBL_QUEUED, prevAttemptLabel].filter(Boolean),
+      });
+    } else {
+      console.log(`RE-QUEUE #${iss.number} (orfano, attempt ${attempt})`);
+      edit(iss.number, {
+        add: [LBL_QUEUED, `fu-attempt:${attempt}`],
+        remove: [LBL_FIX, prevAttemptLabel].filter(Boolean),
+      });
+    }
+  }
+
+  // --- DRAIN: promuovi 1 queued a agent:fix (slot già verificato libero) -------
+  const queued = listIssues(LBL_QUEUED)
+    .filter((i) => !has(i, LBL_PARKED))
+    .sort((a, b) => prioRank(a) - prioRank(b) || Date.parse(a.createdAt) - Date.parse(b.createdAt));
+  if (!queued.length) { console.log('coda vuota → niente da promuovere.'); return; }
+
+  const pick = queued[0];
+  console.log(`PROMUOVO #${pick.number} (${has(pick, 'fu-prio:high') ? 'high' : 'low'}) → ${LBL_FIX} [coda residua: ${queued.length - 1}]`);
+  edit(pick.number, { add: [LBL_FIX], remove: [LBL_QUEUED] });
+}
+
+main();

--- a/scripts/lib/classify-issue.mjs
+++ b/scripts/lib/classify-issue.mjs
@@ -12,13 +12,25 @@
  * micro-task). validation-failure NO (transiente non decidibile); revenue/
  * tracker/other NO (giudizio umano / non riconosciuta).
  *
+ * route — COME applicare il fix (2026-06-04, anti-starvation):
+ *   'fix'   → agent:fix immediato (crawler: production-critical, non è il
+ *             treadmill source).
+ *   'queue' → agent:fix-queued (follow-up): NON parte subito. `followup-drainer`
+ *             lo promuove a agent:fix UNO alla volta, solo quando lo slot
+ *             issue-fix è libero → mai cancellato-in-coda. Fix della starvation
+ *             osservata 2026-06-04 (slot concurrency globale + cancel:false →
+ *             60% fix-run follow-up cancellate-in-coda, ~20 issue stuck).
+ *   'none'  → nessun routing (umano).
+ * fuPrio — ordine di drenaggio per i follow-up: 'high' (funnel monetization/seo
+ *   o priority:high) drenato prima di 'low'. null per i non-follow-up.
+ *
  * Uso modulo:
  *   import { classifyIssue } from './classify-issue.mjs';
- *   const { category, autofix } = classifyIssue(title, labels); // labels: string[]
+ *   const { category, autofix, route, fuPrio } = classifyIssue(title, labels);
  *
  * Uso CLI (dal workflow):
  *   node scripts/lib/classify-issue.mjs "<title>" '<labels-json-array>'
- *   → stdout JSON: {"category":"crawler","autofix":true}
+ *   → stdout JSON: {"category":"crawler","autofix":true,"route":"fix","fuPrio":null}
  */
 
 export function classifyIssue(title = '', labels = []) {
@@ -28,6 +40,8 @@ export function classifyIssue(title = '', labels = []) {
 
   let category = 'other';
   let autofix = false;
+  let route = 'none';
+  let fuPrio = null;
 
   if (has('revenue') || has('rpm-canary') || t(/RPM canary|\bRPM\b/i)) {
     category = 'revenue';
@@ -42,15 +56,21 @@ export function classifyIssue(title = '', labels = []) {
     // parser-regen, natura crawler, funnel-rilevante (boilerplate → thin).
     category = 'crawler';
     autofix = true;
+    route = 'fix'; // immediato: production-critical, non è il treadmill source
   } else if (t(/^follow-up\(#/i) || has('follow-up')) {
     category = 'follow-up';
     autofix = true;
+    route = 'queue'; // drenato 1-alla-volta dal followup-drainer (anti-starvation)
+    fuPrio =
+      has('funnel-monetization') || has('funnel-seo') || has('priority:high')
+        ? 'high'
+        : 'low';
   } else if (t(/Validation Failure/i) || (has('bug') && has('priority:urgent'))) {
     // NO autofix: transiente-vs-persistente non decidibile deterministicamente.
     category = 'validation-failure';
   }
 
-  return { category, autofix };
+  return { category, autofix, route, fuPrio };
 }
 
 // CLI mode

--- a/tests/classify-issue.test.ts
+++ b/tests/classify-issue.test.ts
@@ -11,39 +11,50 @@ import { describe, it, expect } from 'vitest';
 import { classifyIssue } from '../scripts/lib/classify-issue.mjs';
 
 describe('classifyIssue', () => {
-  const cases: Array<{ title: string; labels: string[]; category: string; autofix: boolean }> = [
-    // crawler → autofix
-    { title: '[crawler-health] Coop Ticino broken', labels: ['priority:high', 'bug'], category: 'crawler', autofix: true },
-    { title: 'Crawler Failure: Update TECAN', labels: ['bug'], category: 'crawler', autofix: true },
+  const cases: Array<{
+    title: string;
+    labels: string[];
+    category: string;
+    autofix: boolean;
+    route: string;
+    fuPrio: string | null;
+  }> = [
+    // crawler → agent:fix immediato (route='fix', non passa dalla coda)
+    { title: '[crawler-health] Coop Ticino broken', labels: ['priority:high', 'bug'], category: 'crawler', autofix: true, route: 'fix', fuPrio: null },
+    { title: 'Crawler Failure: Update TECAN', labels: ['bug'], category: 'crawler', autofix: true, route: 'fix', fuPrio: null },
     // parser-health → crawler (🟡 review #927: era 'other' sotto regex bash)
-    { title: '[parser-health] octapharma boilerplate-only', labels: ['parser-broken', 'automated'], category: 'crawler', autofix: true },
-    // follow-up → autofix
-    { title: 'follow-up(#852): 7 crawler senza fallback', labels: ['follow-up', 'funnel-seo'], category: 'follow-up', autofix: true },
+    { title: '[parser-health] octapharma boilerplate-only', labels: ['parser-broken', 'automated'], category: 'crawler', autofix: true, route: 'fix', fuPrio: null },
+    // follow-up → coda (route='queue'); fuPrio da funnel/priority
+    { title: 'follow-up(#852): 7 crawler senza fallback', labels: ['follow-up', 'funnel-seo'], category: 'follow-up', autofix: true, route: 'queue', fuPrio: 'high' },
     // validation-failure → NO autofix (transiente)
-    { title: 'Validation Failure (dist): post-deploy', labels: ['bug', 'priority:urgent'], category: 'validation-failure', autofix: false },
-    { title: 'Validation Failure (live): post-deploy', labels: ['bug', 'priority:urgent'], category: 'validation-failure', autofix: false },
+    { title: 'Validation Failure (dist): post-deploy', labels: ['bug', 'priority:urgent'], category: 'validation-failure', autofix: false, route: 'none', fuPrio: null },
+    { title: 'Validation Failure (live): post-deploy', labels: ['bug', 'priority:urgent'], category: 'validation-failure', autofix: false, route: 'none', fuPrio: null },
     // revenue → NO autofix (anche se è un follow-up: RPM vince, conservativo)
-    { title: 'RPM canary regression detected', labels: ['revenue'], category: 'revenue', autofix: false },
-    { title: 'follow-up(#851): Verifica RPM recovery', labels: ['follow-up', 'funnel-monetization'], category: 'revenue', autofix: false },
+    { title: 'RPM canary regression detected', labels: ['revenue'], category: 'revenue', autofix: false, route: 'none', fuPrio: null },
+    { title: 'follow-up(#851): Verifica RPM recovery', labels: ['follow-up', 'funnel-monetization'], category: 'revenue', autofix: false, route: 'none', fuPrio: null },
     // tracker → NO autofix
-    { title: 'Master tracker: SEO recovery plan', labels: [], category: 'tracker', autofix: false },
+    { title: 'Master tracker: SEO recovery plan', labels: [], category: 'tracker', autofix: false, route: 'none', fuPrio: null },
     // other → NO autofix (fail-safe)
-    { title: 'Qualche cosa di strano', labels: [], category: 'other', autofix: false },
+    { title: 'Qualche cosa di strano', labels: [], category: 'other', autofix: false, route: 'none', fuPrio: null },
     // company-name collision guards (#933 item 1): conservative ordering fires
     // revenue/tracker BEFORE crawler — intentional override; prevents future
     // code reordering from silently removing the guardrail.
-    { title: '[crawler-health] RPM Software AG broken', labels: ['priority:high', 'bug'], category: 'revenue', autofix: false },
-    { title: '[parser-health] recovery GmbH boilerplate-only', labels: ['parser-broken', 'automated'], category: 'tracker', autofix: false },
-    // follow-up + funnel-monetization without RPM → autofix=true (#933 item 2):
+    { title: '[crawler-health] RPM Software AG broken', labels: ['priority:high', 'bug'], category: 'revenue', autofix: false, route: 'none', fuPrio: null },
+    { title: '[parser-health] recovery GmbH boilerplate-only', labels: ['parser-broken', 'automated'], category: 'tracker', autofix: false, route: 'none', fuPrio: null },
+    // follow-up + funnel-monetization without RPM → queue, high (#933 item 2):
     // body is NOT inspected; funnel sensitivity is gated by pr-review-loop ## LGTM.
-    { title: 'follow-up(#900): tune AdSense vignette threshold', labels: ['follow-up', 'funnel-monetization'], category: 'follow-up', autofix: true },
+    { title: 'follow-up(#900): tune AdSense vignette threshold', labels: ['follow-up', 'funnel-monetization'], category: 'follow-up', autofix: true, route: 'queue', fuPrio: 'high' },
+    // follow-up senza funnel/priority → coda a priorità bassa
+    { title: 'follow-up(#910): de-rot comment anchor', labels: ['follow-up', 'funnel-ux'], category: 'follow-up', autofix: true, route: 'queue', fuPrio: 'low' },
   ];
 
   for (const c of cases) {
-    it(`"${c.title}" [${c.labels.join(',')}] → ${c.category} (autofix=${c.autofix})`, () => {
+    it(`"${c.title}" [${c.labels.join(',')}] → ${c.category} (route=${c.route})`, () => {
       const out = classifyIssue(c.title, c.labels);
       expect(out.category).toBe(c.category);
       expect(out.autofix).toBe(c.autofix);
+      expect(out.route).toBe(c.route);
+      expect(out.fuPrio).toBe(c.fuPrio);
     });
   }
 
@@ -54,14 +65,22 @@ describe('classifyIssue', () => {
     }
   });
 
+  it("route='queue' SOLO per follow-up; 'fix' SOLO per crawler", () => {
+    for (const c of cases) {
+      const out = classifyIssue(c.title, c.labels);
+      if (out.route === 'queue') expect(out.category).toBe('follow-up');
+      if (out.route === 'fix') expect(out.category).toBe('crawler');
+    }
+  });
+
   it('label con virgola nel nome non rompe il match (array, non comma-join)', () => {
     // un nome label con virgola non deve falsare il set
     const out = classifyIssue('follow-up(#1): x', ['weird,label', 'follow-up']);
     expect(out.category).toBe('follow-up');
   });
 
-  it('input vuoto/degenere → other, no autofix', () => {
-    expect(classifyIssue('', [])).toEqual({ category: 'other', autofix: false });
-    expect(classifyIssue(undefined as unknown as string, undefined as unknown as string[])).toEqual({ category: 'other', autofix: false });
+  it('input vuoto/degenere → other, no autofix, no route', () => {
+    expect(classifyIssue('', [])).toEqual({ category: 'other', autofix: false, route: 'none', fuPrio: null });
+    expect(classifyIssue(undefined as unknown as string, undefined as unknown as string[])).toEqual({ category: 'other', autofix: false, route: 'none', fuPrio: null });
   });
 });


### PR DESCRIPTION
**BUNDLE-2** del loop-optimization (segue #1334). Risolve il **finding headline** dell'osservazione 2h: la *issue-fix starvation*, root cause del backlog follow-up.

## Problema (osservato live 2026-06-04)
`issue-fix` ha un solo slot concurrency globale (`group: issue-fix`, `cancel-in-progress: false`). In un burst di follow-up auto-routati a `agent:fix`, GitHub **cancella le run PENDING** tenendo solo l'in-progress + l'ultima queued → **60% delle fix-run follow-up cancellate-in-coda**, mai ri-tentate (nessun nuovo `labeled`), **~20 issue stuck** `agent:fix` ma non lavorate. `recycle-stale-prs` salva solo PR, non queste.

## Soluzione (zero-Claude, deterministica)
- I follow-up non ricevono più `agent:fix` diretto da triage ma **`agent:fix-queued` + `fu-prio:high|low`**.
- **`followup-drainer.yml`** (cron ~20min + `workflow_run` dopo ogni `issue-fix` + dispatch) promuove **UNO** a `agent:fix`, solo a **slot `issue-fix` libero** (in-flight==0) → la run promossa è l'unica pending → **mai cancellata-in-coda**. Starvation eliminata per costruzione. `fu-prio:high` (funnel/priority) drenato prima.
- **Terminazione autonoma (no human):** un `agent:fix` follow-up orfano (run morta, nessuna PR `fix/issue-N`, `updatedAt` > 30min) → ri-accodato `fu-attempt:N`++; a **`fu-attempt:3` → `fu-parked`** (esce dalla coda, **NON chiuso**: nessuna perdita, ri-tentabile). Rescue+drain girano solo a slot libero → mai toccano una run viva.
- Crawler invariati: `agent:fix` immediato (production-critical, non treadmill source).

## Implementato
- `scripts/lib/classify-issue.mjs`: +`route` (`'fix'`|`'queue'`|`'none'`) + `fuPrio`. Additivo (category/autofix invariati → backward-compat).
- `issue-triage.yml`: routing route-aware (`queue` → `agent:fix-queued` + `fu-prio`).
- `followup-drainer.yml` + `scripts/ci/followup-drainer.mjs`: **nuovo** (drain + rescue/park, `--dry-run`).
- `tests/classify-issue.test.ts`: +`route`/`fuPrio`.
- `ISSUES.md`: documenta coda+drainer; la sez. "Drenare il backlog" non è più un workaround manuale.
- Label create nel repo: `agent:fix-queued`, `fu-prio:high|low`, `fu-parked`, `fu-attempt:1-3`.

## Non implementato (deferred)
- **Gen-counter** (`gen:N`, profondità discendente followup-of-followup → auto-park dei discendenti low-value): l'attempt-park già bound il loop; il gen-counter è una raffinazione (richiede post-merge-followup tracci la generazione al conio). BUNDLE successivo.
- **BUNDLE-3**: crawler issue rollup + PAT-load-failure alert + auto-route validation-failure.

## Verifica
- `node --check` (entrambi gli script), **vitest 18/18** (classify-issue), YAML lint (triage+drainer).
- **Dry-run live**: rileva correttamente i ~17 follow-up orfani stuck (#1322/#1294/#1272/#1256/#1255/#1242/#1230/#1226/#1201/#1189/#1183/#1166/#1139/#1133/#1055/#1007…) e li ri-accoderebbe; early-exit corretto a slot occupato (in-flight=1).
- Tocca `.github/workflows/` → workflow-validation block atteso → **merge manuale** (come #1334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)