### PR TITLE
fix(seo-404): restore 657k compat paths + floor-guard against catastrophic truncation

### DIFF
--- a/scripts/discover-404s-via-inspection.mjs
+++ b/scripts/discover-404s-via-inspection.mjs
@@ -311,6 +311,26 @@ async function main() {
         : `${compat.source || 'gsc-export'}+url-inspection`,
       lastUpdated: new Date().toISOString().slice(0, 10),
     };
+    // Floor-guard (2026-06-04, #404-truncation): il compat è un ACCUMULATORE
+    // (~300-650k path). Se la lettura iniziale (riga ~154) è fallita con fallback
+    // `{paths:[]}` — es. file già toccato da un job cancellato mid-write, o read
+    // race — `compatSet` parte vuoto e questo write SOVRASCRIVE i 657k path buoni
+    // con poche migliaia → 404→301 resolver giù in prod (osservato: commit
+    // 06546ba ha troncato 657594→0, main rosso, test floor 150000 violato). Mai
+    // distruggere dati buoni: se il write scende sotto una soglia di sanità,
+    // ABORTISCI con exit 1 (il workflow fallisce RUMOROSAMENTE → restore manuale,
+    // niente commit di regressione).
+    const SANITY_FLOOR = 100_000;
+    const prevCount = readJsonSafe(compatPath, { paths: [] }).paths?.length ?? 0;
+    if (updatedCompat.paths.length < SANITY_FLOOR && prevCount >= SANITY_FLOOR) {
+      console.error(
+        `❌ ABORT write: ${updatedCompat.paths.length} path < floor ${SANITY_FLOOR} ` +
+          `mentre l'esistente ne ha ${prevCount} → troncamento catastrofico evitato. ` +
+          `La lettura iniziale del compat è probabilmente fallita (fallback a vuoto). ` +
+          `NON sovrascrivo. Indaga (file corrotto/race) e ripristina se serve.`
+      );
+      process.exit(1);
+    }
     fs.writeFileSync(compatPath, JSON.stringify(updatedCompat, null, 2) + '\n');
     console.log(`\n✅ Wrote ${compatPath} (${updatedCompat.paths.length} total paths)`);
   } else {


### PR DESCRIPTION
## Incidente
`data/seo-404-compat-paths.json` troncato **657.594 → 0 path** dal commit `06546ba` (`discover-404s.yml`, github-actions[bot], 2026-06-04 07:56). Il **404→301 compat resolver è giù in produzione** per ~657k URL (impatto SEO), **main rosso** (test `search-console-compat` floor 150000 violato → blocca ogni PR, incl. #1337).

## Root cause
`discover-404s-via-inspection.mjs:154` legge il compat con fallback `{paths:[]}`. Se la lettura fallisce (file corrotto / già toccato da un job cancellato mid-write — cfr. data-job concurrency-cancel osservato 05:08) o c'è una read race, `compatSet` parte **vuoto**; il sweep aggiunge poche migliaia di nuovi 404 e il write a riga 314 **sovrascrive i 657k path buoni** con quelle poche migliaia. Nessun floor-guard.

## Fix
- **Restore** `data/seo-404-compat-paths.json` da `d520b63e1b6` (657.594 path, ultimo buono 06:58) — blob già nel repo, referenziato per SHA (no re-upload 66MB).
- **Floor-guard**: prima del write, se il nuovo conteggio scende sotto `SANITY_FLOOR` (100k) mentre l'esistente su disco è sopra → **`exit 1`** (il workflow fallisce RUMOROSAMENTE → restore manuale, niente commit di regressione). Il compat è un accumulatore ~300-650k: non deve MAI crollare a migliaia.

## Verifica
- `node --check` OK; `readJsonSafe` in scope.
- Diff = **solo 2 file** (data restore +657598, script +20). Nessun file foreign.
- `vitest tests/search-console-compat.test.ts` ora passa (657594 ≥ 150000) → sblocca main.

Scoperto durante l'audit loop-optimization (classe data-job-truncation, finding #8). Non tocca `.github/workflows/` → review normale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)