### PR TITLE
feat(data-guard): catch-all anti-truncation guard for committed accumulators

### DIFF
--- a/.github/workflows/guard-data-integrity.yml
+++ b/.github/workflows/guard-data-integrity.yml
@@ -1,0 +1,133 @@
+name: Guard data integrity (anti-truncation)
+
+# Catch-all contro il troncamento catastrofico dei file-dati accumulatori su
+# main. I 43 workflow che committano dati committano DIRETTAMENTE su main (no PR
+# → no vitest/review gate): un writer che sovrascrive un accumulatore con un
+# fallback vuoto va live silenziosamente (incidente 2026-06-04: seo-404-compat-
+# paths.json 657594→0 da discover-404s.yml → 404→301 resolver giù). Questo guard
+# gira DOPO ogni push su main, rileva i crolli di size catastrofici (>70% su file
+# >1MB), AUTO-REVERTA il file al contenuto pre-push e apre una issue urgente col
+# colpevole. Byte-size based = copre tutti i writer (presenti e futuri), array e
+# object-map, senza manifest per-file. Zero-Claude.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/**'
+      - 'public/data/**'
+
+# Serialize: due push ravvicinati non devono revertare in parallelo.
+concurrency:
+  group: guard-data-integrity
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    # Non girare sui commit di revert del guard stesso (anti-ricorsione): il
+    # revert restaura il file (cresce → nessuno shrink → no-op comunque), ma
+    # saltarlo evita una run inutile.
+    if: ${{ !contains(github.event.head_commit.message, '[data-guard revert]') }}
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Detect catastrophic truncation
+        id: detect
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          violations=$(node scripts/ci/guard-data-integrity.mjs "$BEFORE" "$AFTER")
+          echo "violations=$violations"
+          echo "violations=$violations" >> "$GITHUB_OUTPUT"
+          count=$(node -e "process.stdout.write(String(JSON.parse(process.argv[1]).length))" "$violations")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Trovate $count violazioni."
+
+      - name: Auto-revert truncated files + open urgent issue
+        if: steps.detect.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          VIOLATIONS: ${{ steps.detect.outputs.violations }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Ripristina ogni file troncato al contenuto PRE-push (ultimo buono).
+          files=$(node -e "JSON.parse(process.argv[1]).forEach(v=>console.log(v.file))" "$VIOLATIONS")
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "revert $f -> $BEFORE"
+            git checkout "$BEFORE" -- "$f"
+            git add "$f"
+          done <<< "$files"
+
+          if git diff --cached --quiet; then
+            echo "Niente da revertare (gia allineato)."
+          else
+            git commit -m "fix(data-guard): auto-revert troncamento catastrofico dal push ${AFTER} [data-guard revert]"
+            git fetch origin main || true
+            git rebase origin/main || { git rebase --abort 2>/dev/null || true; git reset --hard origin/main; }
+            git push origin HEAD:main || echo "::error::push del revert fallito — restore manuale necessario."
+          fi
+
+          # Issue urgente DEDUPLICATA (titolo stabile + idempotenza per-commit).
+          culprit=$(git show -s --format='%an' "$AFTER" 2>/dev/null || echo "unknown")
+          culprit_msg=$(git show -s --format='%s' "$AFTER" 2>/dev/null || echo "?")
+          run_url="${GITHUB_SERVER_URL}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
+          rows=$(node -e "JSON.parse(process.argv[1]).forEach(x=>console.log('- \`'+x.file+'\`: '+x.prevBytes+' B -> '+x.newBytes+' B (-'+x.shrinkPct+'%)'))" "$VIOLATIONS")
+          TITLE="Data integrity: troncamento catastrofico auto-revertato"
+          BODY="$(printf '%s\n' \
+            "## 🚨 File-dati accumulatore troncato su main — auto-revertato" \
+            "" \
+            "Il push \`${AFTER}\` (\"${culprit_msg}\", autore ${culprit}) ha ridotto uno o piu" \
+            "file-dati accumulatori oltre la soglia di sanita (>70% su file >1MB). Il guard" \
+            "li ha **ripristinati automaticamente** al contenuto pre-push (\`${BEFORE}\`)." \
+            "" \
+            "### File troncati (ripristinati)" \
+            "${rows}" \
+            "" \
+            "### Azione" \
+            "1. Trova il writer responsabile (workflow/script dietro il commit \`${AFTER}\`)." \
+            "2. Aggiungi un floor-guard al write (mai sovrascrivere l'accumulatore con un" \
+            "   fallback vuoto — vedi \`scripts/discover-404s-via-inspection.mjs\` SANITY_FLOOR)." \
+            "3. Chiudi questa issue quando il writer e hardenato." \
+            "" \
+            "Run: ${run_url}" \
+            "_Filed automatically by Guard data integrity._")"
+
+          existing=$(gh issue list --repo "$GH_REPO" --state open --search "in:title \"$TITLE\"" \
+            --json number,title --jq "[.[] | select(.title==\"$TITLE\")][0].number" 2>/dev/null || true)
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh issue comment "$existing" --repo "$GH_REPO" --body "🔁 Nuovo troncamento auto-revertato (push \`${AFTER}\`). ${run_url}" || true
+          else
+            gh issue create --repo "$GH_REPO" --title "$TITLE" --body "$BODY" \
+              --label bug --label priority:urgent || echo "::warning::gh issue create fallito."
+          fi
+
+      - name: Fail the run (so the revert is visible)
+        if: steps.detect.outputs.count != '0'
+        run: |
+          echo "Troncamento rilevato e auto-revertato — run rossa per visibilita."
+          exit 1

--- a/scripts/ci/guard-data-integrity.mjs
+++ b/scripts/ci/guard-data-integrity.mjs
@@ -1,0 +1,100 @@
+/**
+ * guard-data-integrity.mjs — catch-all contro il troncamento catastrofico dei
+ * file-dati accumulatori committati su main (zero-Claude, deterministico).
+ *
+ * Perché (incidente 2026-06-04): `discover-404s.yml` (github-actions[bot]) ha
+ * committato DIRETTAMENTE su main una versione di `data/seo-404-compat-paths.json`
+ * troncata 657594→0 (read fallback `{paths:[]}` → sovrascrive l'accumulatore con
+ * vuoto). I 43 workflow che committano dati su main NON passano da PR → nessun
+ * vitest/review li gata → la regressione è andata live silenziosamente fino a
+ * rompere il 404→301 resolver. Serve un guard UNICO post-push, byte-size based
+ * (universale: array E object-map), che copra tutti i writer presenti e futuri.
+ *
+ * Cosa fa: confronta la size di ogni file-dati cambiato tra il commit PRIMA del
+ * push (`beforeSha`) e DOPO (`afterSha`). Se un file GRANDE (> MIN_BYTES) si
+ * restringe oltre SHRINK_PCT → è un troncamento catastrofico. Emette la lista
+ * delle violazioni come JSON su stdout (il workflow le auto-reverta + apre issue).
+ *
+ * Uso: node scripts/ci/guard-data-integrity.mjs <beforeSha> <afterSha>
+ * Output stdout: JSON array di { file, prevBytes, newBytes, shrinkPct }
+ * Exit: 0 sempre (il giudizio è del workflow; qui solo detection pura).
+ *
+ * Soglie volutamente conservative per non sbagliare su prune legittimi:
+ * solo file già grandi (>1MB) e crolli forti (>70%) — un prune reale taglia
+ * raramente l'80% di un accumulatore da centinaia di migliaia di righe.
+ */
+import { execFileSync } from 'node:child_process';
+
+const MIN_BYTES = 1_000_000; // solo accumulatori grandi (>1MB)
+const SHRINK_PCT = 70; // crollo > 70% = sospetto troncamento
+
+// Path-glob dei file-dati protetti. I file che cambiano size legittimamente
+// (snapshot rigenerati, cache volatili) restano coperti: la soglia size+pct li
+// salva dai falsi positivi; un crollo >70% di un file >1MB non è mai "normale".
+const DATA_PREFIXES = ['data/', 'public/data/'];
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+}
+
+/** Byte-size di un blob a un dato ref, o null se il path non esiste lì. */
+function sizeAt(ref, file) {
+  try {
+    // `git cat-file -s ref:path` = size del blob senza materializzarlo (veloce).
+    const out = execFileSync('git', ['cat-file', '-s', `${ref}:${file}`], {
+      encoding: 'utf8',
+    }).trim();
+    const n = parseInt(out, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null; // path assente a quel ref (file nuovo / cancellato)
+  }
+}
+
+function main() {
+  const [beforeSha, afterSha] = process.argv.slice(2);
+  if (!beforeSha || !afterSha) {
+    console.error('usage: guard-data-integrity.mjs <beforeSha> <afterSha>');
+    process.exit(2);
+  }
+  // Push su branch nuovo / primo commit: before = 000…0 → niente baseline, skip.
+  if (/^0+$/.test(beforeSha)) {
+    console.log('[]');
+    return;
+  }
+
+  // File cambiati nel range, ristretti ai prefissi dati.
+  let changed = [];
+  try {
+    changed = git(['diff', '--name-only', beforeSha, afterSha])
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((f) => DATA_PREFIXES.some((p) => f.startsWith(p)));
+  } catch (e) {
+    console.error(`diff fallito: ${String(e).slice(0, 160)}`);
+    console.log('[]');
+    return;
+  }
+
+  const violations = [];
+  for (const file of changed) {
+    const prevBytes = sizeAt(beforeSha, file);
+    const newBytes = sizeAt(afterSha, file);
+    if (prevBytes == null || newBytes == null) continue; // creato/cancellato: non è un troncamento
+    if (prevBytes < MIN_BYTES) continue; // non era un accumulatore grande
+    const shrinkPct = ((prevBytes - newBytes) / prevBytes) * 100;
+    if (shrinkPct > SHRINK_PCT) {
+      violations.push({
+        file,
+        prevBytes,
+        newBytes,
+        shrinkPct: Math.round(shrinkPct * 10) / 10,
+      });
+    }
+  }
+
+  process.stdout.write(JSON.stringify(violations));
+}
+
+main();


### PR DESCRIPTION
Prevenzione **sistemica** della classe di incidenti del troncamento 404 (#1341): un workflow bot che sovrascrive un accumulatore con un fallback vuoto e committa DIRETTAMENTE su main (no PR → no vitest/review gate) → regressione live silenziosa. **43 workflow** committano dati su main così.

## Implementato
- **`guard-data-integrity.yml`** (push:main, paths `data/**` + `public/data/**`): un solo guard catch-all, copre tutti i 43 writer + futuri.
- **`scripts/ci/guard-data-integrity.mjs`**: confronta la **byte-size** di ogni file-dati cambiato `before`→`after`. Crollo **>70% su file >1MB** = troncamento catastrofico. Byte-size = universale (array E object-map), nessun manifest per-file.
- **Reazione (decisione utente): AUTO-REVERT + issue urgente.** Ripristina il file al contenuto pre-push (ultimo buono), pusha il revert (`[data-guard revert]` → anti-ricorsione), apre/dedup una issue `priority:urgent` col commit/autore colpevole + tabella dei file troncati + l'azione (aggiungi floor-guard al writer). Run rossa per visibilità.

## Soglie conservative (anti-falso-positivo)
Solo file già grandi (>1MB) e crolli forti (>70%): un prune legittimo taglia raramente l'80% di un accumulatore da centinaia di migliaia di righe. Push su branch nuovo (before=0…0) → skip.

## Verifica
- `node --check` + YAML lint OK.
- **Test funzionale contro l'incidente reale**: `guard-data-integrity.mjs d520b63e1b6 06546ba503c` → rileva `data/seo-404-compat-paths.json 65997003→18 (-100%)` ✓.
- **Negative test** (range commit normale) → 0 violazioni ✓.

Difesa-in-profondità: complementa i floor-guard at-source (es. SANITY_FLOOR in discover-404s da #1341). Tocca `.github/workflows/` → merge manuale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)