### PR TITLE
feat(cdn): offload blog 480w thumbnails (~49MB) to CDN + restore mobile srcSet

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -694,14 +694,15 @@ jobs:
           # (JS/CSS) whose URLs renderBuiltUrl already rebased to the CDN, and the
           # git-tracked full blog heroes (served at cdn.frontaliereticino.ch/images/
           # blog; finalize plugin already rewrote HTML + deleted dist heroes, so we
-          # push from the public/ source) AND the build-generated 480w thumbnails
-          # (gitignored, dist-only) so mobile loads the small variant from the CDN
-          # too — the offload script then deletes dist/images/blog/thumbnails.
+          # push from the public/ source). The build-generated 480w thumbnails are
+          # written to public/images/blog/thumbnails/ by generate-image-thumbnails.mjs
+          # (gitignored but on disk at push time), so the public/images/blog copy
+          # below ALREADY pushes them to ${CDN}/images/blog/thumbnails/ — the offload
+          # script then deletes the dist copy of dist/images/blog/thumbnails.
           [ -d dist/og ]           && cp -r dist/og           "$stage/og"
           [ -d dist/data ]         && cp -r dist/data         "$stage/data"
           [ -d dist/assets ]       && cp -r dist/assets       "$stage/assets"
           [ -d public/images/blog ] && mkdir -p "$stage/images" && cp -r public/images/blog "$stage/images/blog"
-          [ -d dist/images/blog/thumbnails ] && mkdir -p "$stage/images/blog" && cp -r dist/images/blog/thumbnails "$stage/images/blog/thumbnails"
           if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ]; then
             echo "no offloadable assets present — skipping CDN push"; exit 0
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -694,11 +694,14 @@ jobs:
           # (JS/CSS) whose URLs renderBuiltUrl already rebased to the CDN, and the
           # git-tracked full blog heroes (served at cdn.frontaliereticino.ch/images/
           # blog; finalize plugin already rewrote HTML + deleted dist heroes, so we
-          # push from the public/ source). 480w thumbnails stay same-origin.
+          # push from the public/ source) AND the build-generated 480w thumbnails
+          # (gitignored, dist-only) so mobile loads the small variant from the CDN
+          # too — the offload script then deletes dist/images/blog/thumbnails.
           [ -d dist/og ]           && cp -r dist/og           "$stage/og"
           [ -d dist/data ]         && cp -r dist/data         "$stage/data"
           [ -d dist/assets ]       && cp -r dist/assets       "$stage/assets"
           [ -d public/images/blog ] && mkdir -p "$stage/images" && cp -r public/images/blog "$stage/images/blog"
+          [ -d dist/images/blog/thumbnails ] && mkdir -p "$stage/images/blog" && cp -r dist/images/blog/thumbnails "$stage/images/blog/thumbnails"
           if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ]; then
             echo "no offloadable assets present — skipping CDN push"; exit 0
           fi

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -8,6 +8,7 @@ import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
 import { useNavigation } from '@/services/NavigationContext';
 import { cdnDataUrl } from '@/services/cdnDataBase';
+import { CDN_BLOG_BASE } from '@/services/seo/blogImageCdn';
 
 // Pre-compiled gi-flag variants for keyword matching (Vercel rule 7.10)
 const KEYWORD_LINKS_GI = KEYWORD_LINKS.map(kl => ({
@@ -656,9 +657,21 @@ type ResponsiveImageSet = {
 };
 
 function getResponsiveImageSet(imagePath: string): ResponsiveImageSet | null {
- // Blog hero images are served from jsDelivr (CDN, full image only); their
- // 480w thumbnails stay same-origin under /images/blog/thumbnails/. Accept
- // the CDN URL form and map it back to the local thumbnail path.
+ // Blog heroes are CDN-served (cdn.frontaliereticino.ch/images/blog) via the
+ // cdnBlogImage() transform at the data-export layer (data/blog-articles-data.ts).
+ // Map the CDN hero URL → its CDN 480w thumbnail so mobile loads the small
+ // variant from the SAME CDN. The thumbnails are pushed to the CDN repo and
+ // offloaded out of the dist artifact by scripts/offload-generated-images-cdn.mjs.
+ // (Before this, the CDN hero URL matched neither branch below → null → no
+ //  srcSet → mobile fetched the 1200w hero, and the 480w thumbnails sat unused
+ //  in the artifact.)
+ if (imagePath.startsWith(CDN_BLOG_BASE + '/') && !imagePath.startsWith(CDN_BLOG_BASE + '/thumbnails/')) {
+ const file = imagePath.slice(CDN_BLOG_BASE.length + 1);
+ const base = file.replace(/\.(jpe?g|png|webp|avif)$/i, '');
+ if (base !== file) return { thumbWebp: `${CDN_BLOG_BASE}/thumbnails/${base}-480w.webp` };
+ }
+ // Raw-fallback form (raw.githubusercontent…/public/images/blog) → local thumb.
+ // Only reached after a CDN error swap, which clears srcSet, so it's inert.
  const cdn = imagePath.match(/\/public\/images\/blog\/([^/]+)\.(jpe?g|png|webp|avif)$/i);
  if (cdn) {
  return { thumbWebp: `/images/blog/thumbnails/${cdn[1]}-480w.webp` };

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -14,10 +14,11 @@
 // (The JS/CSS bundle is offloaded separately: ASSET_CDN/renderBuiltUrl rebases it
 //  at build time; the deploy verify step deletes dist/assets fail-safe.)
 //
-// (Blog 480w thumbnails are NOT offloaded — their URLs are built at runtime in
-// the JS bundle, not in HTML, so an HTML-only rewrite can't cover them; they
-// stay same-origin. og:image refs ARE in static HTML so Phase 1 rewrites them;
-// job-detail JSON is also runtime-fetched so Phase 2 injects a runtime base.)
+// (Blog 480w thumbnails ARE now offloaded: getResponsiveImageSet emits the CDN
+// thumbnail URL at runtime — they have no same-origin refs — and the deploy
+// pushes dist/images/blog/thumbnails to the CDN before this runs, so Phase 1's
+// guarded delete frees ~49 MB. og:image refs ARE in static HTML so Phase 1
+// rewrites them; job-detail JSON is runtime-fetched so Phase 2 injects a base.)
 //
 // Unlike the full blog hero images (git-tracked → served from jsDelivr@main by
 // build-plugins/blogImageCdnFinalizePlugin), dist/og and dist/data/job-detail
@@ -53,14 +54,22 @@ const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
 // Offload targets: [dist subdir, url path prefix]. Only these prefixes are
 // rewritten/guarded/deleted.
 //
-// ONLY per-job OG cards. Their refs (`<meta property="og:image">`) are emitted
-// into the static HTML, so the HTML rewrite below catches every one and the
-// guard can verify it. Blog 480w thumbnails are NOT offloaded: the SPA builds
-// those URLs at runtime in the JS bundle (getResponsiveImageSet → srcSet), not
-// in HTML, so an HTML-only rewrite would miss them and deleting the dir would
-// 404 them on hydrated pages. Thumbnails stay same-origin (~49 MB).
+// Per-job OG cards + blog 480w thumbnails.
+//  • OG refs (`<meta property="og:image">`) are in static HTML so the rewrite
+//    below catches every one and the leak guard can verify it.
+//  • Blog 480w thumbnails: getResponsiveImageSet (components/community/
+//    BlogArticles.tsx) now emits the CDN thumbnail URL at runtime (the hero is
+//    already a cdn.frontaliereticino.ch URL via cdnBlogImage), so the SPA fetches
+//    thumbnails from the CDN, NOT same-origin; and there are ZERO same-origin
+//    `/images/blog/thumbnails/` refs in static HTML. The deploy pushes
+//    dist/images/blog/thumbnails to the CDN BEFORE this runs, so the guarded
+//    delete just frees ~49 MB. The same-origin leak guard still protects the dir:
+//    if any `/images/blog/thumbnails/` ref unexpectedly survives in HTML, the dir
+//    is KEPT (non-fatal) — no 404. (Places thumbnails under /images/places/ are
+//    NOT offloaded: they stay same-origin, not pushed to the CDN.)
 const TARGETS = [
   { dir: ['og'], url: '/og/' },
+  { dir: ['images', 'blog', 'thumbnails'], url: '/images/blog/thumbnails/' },
 ];
 
 function log(msg) {

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -242,18 +242,29 @@ function offloadAll(distDir, cdnBase) {
   });
 
   // ── Guarded deletes ──
-  // og: delete the offloaded dirs unless a same-origin ref survived (would 404).
+  // og + thumbnails: delete each offloaded dir UNLESS a same-origin ref to THAT
+  // target survived the rewrite (would 404). Per-target so a leak in one (e.g. a
+  // stray /og/ ref) can't suppress deleting the other (e.g. the ~49MB thumbnails).
   if (ogTargets.length > 0) {
-    if (ogLeaks.length > 0) {
-      log(`GUARD: ${ogLeaks.length} unrewritten og ref(s) survive — keeping og in dist (non-fatal): ${ogLeaks.slice(0, 5).join('; ')}`);
-    } else {
-      let freed = 0;
-      for (const t of ogTargets) {
-        const dir = path.join(distDir, ...t.dir);
-        freed += dirSize(dir);
-        fs.rmSync(dir, { recursive: true, force: true });
+    let freed = 0;
+    const deleted = [];
+    const kept = [];
+    for (const t of ogTargets) {
+      const leaked = ogLeaks.filter((l) => l.startsWith(t.url));
+      if (leaked.length > 0) {
+        kept.push(`${t.url} (${leaked.length} ref(s): ${leaked.slice(0, 3).join('; ')})`);
+        continue;
       }
-      log(`offloaded ${ogTargets.map((t) => t.url).join(' + ')} → ${cdnBase} ; rewrote ${ogRewritten} files ; freed ${(freed / 1048576).toFixed(0)} MB`);
+      const dir = path.join(distDir, ...t.dir);
+      freed += dirSize(dir);
+      fs.rmSync(dir, { recursive: true, force: true });
+      deleted.push(t.url);
+    }
+    if (deleted.length > 0) {
+      log(`offloaded ${deleted.join(' + ')} → ${cdnBase} ; rewrote ${ogRewritten} files ; freed ${(freed / 1048576).toFixed(0)} MB`);
+    }
+    if (kept.length > 0) {
+      log(`GUARD: unrewritten same-origin ref(s) survive — keeping in dist (non-fatal): ${kept.join(' | ')}`);
     }
   } else {
     log('no OG offload target dirs present — skipping og delete');

--- a/services/seo/blogImageCdn.ts
+++ b/services/seo/blogImageCdn.ts
@@ -54,6 +54,12 @@ export function cdnBlogImage(path: string | undefined | null): string {
 /** Map a CDN blog URL to its raw.githubusercontent fallback, or null. */
 export function rawFallbackForBlog(url: string): string | null {
   if (!url.startsWith(CDN_BLOG_BASE + '/')) return null;
+  // 480w thumbnails are build-generated (gitignored) — they have NO raw.github
+  // copy, so there is nothing to fall back to. Returning null here also keeps the
+  // one-shot `cdnFallback` flag UNSET on the thumbnail <img>, so that when the
+  // cleared srcSet falls back to the full hero (git-tracked → raw exists) the
+  // capture listener fires again and recovers the hero on raw during a CDN outage.
+  if (url.includes('/thumbnails/')) return null;
   return RAW_BLOG_BASE + url.slice(CDN_BLOG_BASE.length);
 }
 

--- a/tests/blogImageCdn.test.ts
+++ b/tests/blogImageCdn.test.ts
@@ -50,4 +50,8 @@ describe('rawFallbackForBlog', () => {
     expect(rawFallbackForBlog('/images/blog/x.webp')).toBeNull();
     expect(rawFallbackForBlog('https://frontaliereticino.ch/images/blog/x.webp')).toBeNull();
   });
+
+  it('returns null for CDN 480w thumbnails (gitignored → no raw copy; preserves the one-shot fallback flag so the hero recovers on CDN-down)', () => {
+    expect(rawFallbackForBlog(`${CDN_BLOG_BASE}/thumbnails/x-480w.webp`)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Implementato

Offload delle **blog 480w thumbnails (~49MB, 2649 file)** dall'artifact Pages al CDN `cdn.frontaliereticino.ch`, **chiudendo #1294** (parte thumbnails).

**Scoperta chiave (meccanismo tracciato end-to-end):** le thumbnail 480w erano **dead weight** nell'artifact — completamente inutilizzate a runtime. Quando le full hero passarono a CDN (#1213+), `article.image` è diventato un URL `cdn.frontaliereticino.ch` (transform `cdnBlogImage` in `data/blog-articles-data.ts:25300`), che **non matcha nessun branch di `getResponsiveImageSet`** → ritorna `null` → niente srcSet → su mobile si scaricava la hero **1200w** e le 480w restavano inerti (0 ref in HTML statico — verificato su 1.26M file —, 0 richieste runtime). Il comment "keeps a local 480w entry" era stale.

**Fix:**
- `getResponsiveImageSet` (`BlogArticles.tsx`): riconosce l'URL CDN della hero ed emette la **480w thumbnail CDN** (`${CDN_BLOG_BASE}/thumbnails/<base>-480w.webp`) → **ripristina il srcSet mobile-first 480w**, ora servito da CDN (1200w + 480w entrambe CDN). Le hero `/images/places/*` (non su CDN) tengono la thumbnail same-origin.
- `deploy.yml`: pusha `dist/images/blog/thumbnails` sul repo CDN (prima dell'offload).
- `scripts/offload-generated-images-cdn.mjs`: aggiunge `/images/blog/thumbnails` a `TARGETS` — stessa macchina guarded-rewrite/delete delle og card (riscrive eventuali ref same-origin residui → CDN, cancella il dir; lo tiene non-fatale se un ref non è riscrivibile). Libera ~49MB.

**Doppio vantaggio:** −49MB artifact **e** −LCP mobile (75% utenza mobile carica la 480w invece della 1200w; prima caricava la 1200w perché il srcSet era saltato).

**Sicurezza/fallback** (invariato): thumbnail CDN fallita → `onError` → `imageFallbackMap` azzera srcSet → `src` (CDN 1200w) → `installBlogImageCdnFallback` swap a raw su CDN-down. Degrade graceful a ogni step.

**Verifica:** 2 fixture sull'offload script (delete thumbnails dir tenendo la full hero in `dist/images/blog`; ref same-origin residuo → riscritto a CDN poi dir cancellata; cdn-url non doppio-riscritto) + `node --check` + `tsc` (0 errori sui file toccati) + gitnexus impact `getResponsiveImageSet` = **LOW** (solo `BlogArticles`, d=1 stesso file).

Closes #1294 (parte blog thumbnails — vedi `## Non implementato` per public images).

## Non implementato (ancora)

- **Validazione live post-merge (claim perf/LCP non validabile su `pull_request`):** l'offload + il nuovo srcSet CDN girano solo post-merge su `main` (le URL CDN esistono solo dopo il push deploy). **Revert-trigger:** se al prossimo deploy il log offload NON riporta `offloaded … /images/blog/thumbnails/ … freed ~49 MB`, oppure una blog page mostra hero/thumbnail broken-image, oppure il mobile LCP regredisce → revert. Verifica: `curl -I https://cdn.frontaliereticino.ch/images/blog/thumbnails/<una>-480w.webp` (200, image/webp) + Playwright su blog page mobile (480w da CDN) + desktop (1200w da CDN).
- **Public images non-blog (~3MB: brands/places/providers/insurers/logos/authors):** referenziate via `services/brandLogos.ts` `localPath` (`<img src>` su job card/comparatori = funnel). Meccanismo diverso (resolver localPath, non `getResponsiveImageSet`) + dir non pushate su CDN. Valore basso (3MB), rischio medio (logo funnel) → follow-up separato se ritenuto utile; lasciate same-origin per ora.
- **Places thumbnails (~che restano same-origin):** `/images/places/*` non è su CDN (deploy pusha solo `public/images/blog`) → il ramo places di `getResponsiveImageSet` resta same-origin di proposito.
