### PR TITLE
docs(cdn): refresh stale thumbnail-offload comments (🟡 nits #1354)

### DIFF
--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -7,11 +7,15 @@
 // 1. Rewrite every SSG-emitted reference to a FULL blog image
 //    (`/images/blog/<file>.webp`, origin-absolute or site-relative) to its
 //    CDN URL, across dist HTML/XML/TXT. The 480w thumbnails under
-//    `/images/blog/thumbnails/` are NOT touched — they stay same-origin.
+//    `/images/blog/thumbnails/` are NOT touched here — they have no SSG-emitted
+//    same-origin refs (the SPA's getResponsiveImageSet emits their CDN URL at
+//    runtime) and are offloaded separately by
+//    scripts/offload-generated-images-cdn.mjs (pushed to the CDN, then deleted).
 // 2. GUARD: re-scan; if any full-blog reference survives, ABORT the offload
 //    (keep the images in dist) rather than delete — never ship a 404, never
 //    break the deploy. Non-fatal: worst case the artifact is unchanged.
-// 3. Delete the full blog images from dist/images/blog (keep thumbnails/).
+// 3. Delete the full blog images from dist/images/blog (keep the thumbnails/
+//    subdir for the offload script to push to the CDN and then delete).
 //
 // SPA runtime <img> references come from data/blog-articles-data.ts, whose
 // ARTICLES export is already CDN-rewritten via cdnBlogImage — so this plugin
@@ -100,11 +104,13 @@ export function blogImageCdnFinalizePlugin(rootDir: string): Plugin {
         return;
       }
 
-      // Delete full images; keep the thumbnails/ subdirectory (served local).
+      // Delete full images; keep the thumbnails/ subdirectory here for the
+      // offload script (offload-generated-images-cdn.mjs) to push to the CDN and
+      // then delete — they are NOT served same-origin.
       let deleted = 0;
       let freed = 0;
       for (const e of fs.readdirSync(blogDir, { withFileTypes: true })) {
-        if (e.isDirectory()) continue; // thumbnails/
+        if (e.isDirectory()) continue; // thumbnails/ (offloaded separately)
         const fp = path.join(blogDir, e.name);
         freed += fs.statSync(fp).size;
         fs.rmSync(fp);

--- a/services/seo/blogImageCdn.ts
+++ b/services/seo/blogImageCdn.ts
@@ -7,17 +7,22 @@
 // the CDN repo under /images/blog, served at a STABLE URL — consistent with
 // og/data/assets, all on the one CDN (no jsDelivr).
 //
-// Scope: ONLY full hero images (~224 MB) move to the CDN. The 480w responsive
-// thumbnails under /images/blog/thumbnails/ are build-generated (gitignored)
-// and stay same-origin — so the responsive `srcSet` keeps a local 480w entry
-// and a CDN 1200w entry. A post-build plugin deletes the full images from
-// dist/images/blog (keeping thumbnails) and fails the build if any full-image
-// origin reference survives in the emitted HTML.
+// Scope: full hero images (~224 MB) AND the 480w responsive thumbnails (~49 MB)
+// move to the CDN. The thumbnails are build-generated (gitignored) under
+// /images/blog/thumbnails/; getResponsiveImageSet (components/community/
+// BlogArticles.tsx) emits the CDN thumbnail URL so the responsive `srcSet` is a
+// CDN 480w + CDN 1200w pair, and scripts/offload-generated-images-cdn.mjs deletes
+// dist/images/blog/thumbnails after the deploy pushes them to the CDN. A
+// post-build plugin (blogImageCdnFinalizePlugin) deletes the full images from
+// dist/images/blog — keeping the thumbnails/ subdir for that offload step to push
+// and delete — and fails the build if any full-image origin ref survives in HTML.
 //
 // Fallback: if the CDN is briefly unreachable, installBlogImageCdnFallback()
 // rewrites the failing <img> to raw.githubusercontent.com at the build SHA
 // (git-tracked source). raw serves images fine — its text/plain MIME + nosniff
-// only block scripts, not images.
+// only block scripts, not images. NOTE: thumbnails have NO raw copy (gitignored),
+// so rawFallbackForBlog() returns null for /thumbnails/ URLs — the cleared srcSet
+// then degrades to the full CDN hero, which DOES recover on raw during an outage.
 
 const REPO = 'valerielinc-ops/frontaliere-si-o-no';
 


### PR DESCRIPTION
## Implementato

Aggiorna i 2 commenti stale segnalati come 🟡 nit nella review di #1354 (offload thumbnails). Comment-only, zero cambi funzionali:
- `services/seo/blogImageCdn.ts` (header Scope): non più "thumbnails stay same-origin / local 480w entry" → ora descrivono l'offload CDN (`getResponsiveImageSet` emette URL CDN, offload script pusha+cancella) + la nota su `rawFallbackForBlog` che ritorna null per `/thumbnails/`.
- `build-plugins/blogImageCdnFinalizePlugin.ts` (L9-10 + L107): il `thumbnails/` viene tenuto **per l'offload script** che lo pusha su CDN e lo cancella, NON "served local" same-origin.

Previene che il prossimo maintainer reintroduca l'assunzione same-origin (esatto punto del reviewer). AGENTS.md #6 (cambio meccanismo → aggiorna commenti).

## Non implementato (ancora)

- **Public images non-blog (~3MB: brands/providers/insurers/logos/authors)** — tracked separatamente (vedi issue collegata). Logo brand funnel-critical referenziati in ~4 file runtime + 6+ build-plugin con catena di fallback domain esistente; offload = ~10 file + push + wrap resolver, stessa classe rischio CDN-down dimostrata in #1354, per soli 3MB → cost/benefit sfavorevole vs gli 111MB già migrati (data #1344 + thumbnails #1354).
