### PR TITLE
perf(seo): trim redundant bytes from emitted SEO/EJP shells

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -199,7 +199,7 @@ export function buildCanonicalBridgePage(options: {
  <body>
  <main class="card">
  <div class="logo">
- <img src="/assets/logo.svg" width="28" height="28" alt="" loading="lazy" decoding="async">
+ <img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">
  <span>Frontaliere Ticino</span>
  </div>
  <h1>${title}</h1>
@@ -253,7 +253,7 @@ export function buildFlatRedirect(
  <body>
  <main class="card">
  <div class="logo">
- <img src="/assets/logo.svg" width="28" height="28" alt="" loading="lazy" decoding="async">
+ <img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">
  <span>Frontaliere Ticino</span>
  </div>
  <h1>Versione canonica disponibile</h1>

--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -197,7 +197,7 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  const ogLocale = ogLocaleOverride || LOCALE_OG[locale] || 'it_IT';
  const extraHead = extraHeadHtml ? `\n${extraHeadHtml}` : '';
  const ldTags = jsonLdScripts.map(ld => ` <script type="application/ld+json">${ld}</script>`).join('\n');
- const cssLink = entryCss ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : '';
+ const cssLink = entryCss ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : '';
  // PR #454 extracted ~3 920 static inline `style=` attributes into content-
  // hashed CSS classes (s-{6char}) appended to public/assets/seo-static.css.
  // The hand-rolled HTML in jobsSeoPagesPlugin / seoHubsPlugin already inlines

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -296,7 +296,7 @@ ${alternates}
             `/${SECTION_BY_LOCALE.it}/${JOB_RECENCY_LANDING_SLUGS[variant].it}`.replace(/\/+/g, '/'),
           )}">
     <script type="application/ld+json">${breadcrumbLd}</script>
-    <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n    <script type="application/ld+json">${itemListLd}</script>` : ''}${faqLd ? `\n    <script type="application/ld+json">${faqLd}</script>` : ''}${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
+    <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n    <script type="application/ld+json">${itemListLd}</script>` : ''}${faqLd ? `\n    <script type="application/ld+json">${faqLd}</script>` : ''}${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
     ${SEO_STATIC_CSS_LINK}
     ${GTAG_SNIPPET}
     ${ADSENSE_SNIPPET}

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -387,7 +387,7 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
 ${alternates}
     <link rel="alternate" hreflang="x-default" href="${BASE_URL}${xDefaultPath}">
     <script type="application/ld+json">${breadcrumbLd}</script>
-    <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n    <script type="application/ld+json">${itemListLd}</script>` : ''}${faqLd ? `\n    <script type="application/ld+json">${faqLd}</script>` : ''}${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
+    <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n    <script type="application/ld+json">${itemListLd}</script>` : ''}${faqLd ? `\n    <script type="application/ld+json">${faqLd}</script>` : ''}${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
     ${SEO_STATIC_CSS_LINK}
     ${GTAG_SNIPPET}
     ${ADSENSE_SNIPPET}

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -4568,7 +4568,7 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
- <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -4729,7 +4729,7 @@ ${staticAnalyticsHtml}
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
  <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}
- <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -4896,7 +4896,7 @@ ${staticAnalyticsHtml}
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
  <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}
- <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -5075,7 +5075,7 @@ ${staticAnalyticsHtml}
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
  <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}
- <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${faqLd}</script>${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -5239,7 +5239,7 @@ ${staticAnalyticsHtml}
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
- <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -5424,7 +5424,7 @@ ${staticAnalyticsHtml}
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
- <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -5641,7 +5641,7 @@ ${staticAnalyticsHtml}
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
- <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -5800,7 +5800,7 @@ ${staticAnalyticsHtml}
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
  <script type="application/ld+json">${breadcrumbLd}</script>
- <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : ''}
+ <script type="application/ld+json">${collectionLd}</script>${itemListLd ? `\n <script type="application/ld+json">${itemListLd}</script>` : ''}${hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : ''}
  ${SEO_STATIC_CSS_LINK}
 ${staticAnalyticsHtml}
  </head>
@@ -10085,8 +10085,8 @@ ${staticAnalyticsHtml}
  // Externalised from inline <svg> (~700 B/page) — same logo now served from
  // /assets/logo.svg, cached by browser. Saves ~68 MB across ~98k soft-landing
  // pages. Static path; browser caches first-load globally.
- const navSvg = `<img src="/assets/logo.svg" width="28" height="28" alt="" loading="lazy" decoding="async">`;
- const spaBundleCss = hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : '';
+ const navSvg = `<img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">`;
+ const spaBundleCss = hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : '';
  const spaBundleJs = hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : '';
  // Per-locale pre-built nav + footer (only 4 strings to cache).
  //
@@ -10104,10 +10104,9 @@ ${staticAnalyticsHtml}
  // for `footer.ft-f` (drops inner `<div class="ft-wrap">`).
  const localeShells = Object.fromEntries(localeList.map(l => {
  const lp = `${localePrefix[l]}/${sectionByLocale[l]}/`.replace(/\/+/g, '/');
- const sectionLink = `${BASE_URL}${lp}`;
  const sectionName = esc(localeCopy[l].sectionName);
- const nav = `<nav class="ft-n" aria-label="Navigazione principale"><a href="/" class="ft-nb">${navSvg} Frontaliere Ticino</a><a href="${sectionLink}" class="ft-ns">${sectionName}</a></nav>`;
- const footer = `<footer class="ft-f">&copy; ${currentYear} <a href="/">Frontaliere Ticino</a> &mdash; <a href="${sectionLink}">${sectionName}</a></footer>`;
+ const nav = `<nav class="ft-n" aria-label="Navigazione principale"><a href="/" class="ft-nb">${navSvg} Frontaliere Ticino</a><a href="${lp}" class="ft-ns">${sectionName}</a></nav>`;
+ const footer = `<footer class="ft-f">&copy; ${currentYear} <a href="/">Frontaliere Ticino</a> &mdash; <a href="${lp}">${sectionName}</a></footer>`;
  return [l, { nav, footer, listingPath: lp }];
  }));
 

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1234,7 +1234,7 @@ function buildHtml(args: BuildHtmlArgs): string {
     <link rel="canonical" href="${canonicalUrl}">
 ${hreflangs}${xDefault}${prevLink}${nextLink}
     <script type="application/ld+json">${breadcrumbLd}</script>
-    <script type="application/ld+json">${collectionLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
+    <script type="application/ld+json">${collectionLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
     ${SEO_STATIC_CSS_LINK}
     ${ADSENSE_SNIPPET}
   </head>
@@ -1782,7 +1782,7 @@ function buildThinCantonHubHtml(args: {
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <link rel="canonical" href="${canonicalUrl}">
     ${SEO_STATIC_CSS_LINK}
-    <script type="application/ld+json">${breadcrumbLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
+    <script type="application/ld+json">${breadcrumbLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
     ${ADSENSE_SNIPPET}
   </head>
   <body class="bg-surface-alt text-heading overflow-x-hidden">


### PR DESCRIPTION
## Implementato

Byte-trim **DOM-equivalent** sull'emit statico SEO/soft-landing, applicato all'**intera classe** (AGENTS.md #6), non solo allo shell EJP della pagina segnalata.

**1. `media="all"` ridondante (default CSS) rimosso dai link bloccanti** in tutti i sibling:
- `jobsSeoPagesPlugin.ts` (9 occorrenze: soft-landing + collection/faq SPA shells)
- `seoHubsPlugin.ts` (2), `jobSectorPagesPlugin.ts`, `jobRecencyPagesPlugin.ts`, `htmlTemplate.ts`
- Pattern async `media="print" onload="this.media='all'"` (asyncCssPlugin + speakable preload) **intatto** — quello è funzionale.

**2. `loading="lazy"` rimosso dai logo nav/hero above-fold** (`jobsSeoPagesPlugin` navSvg + `constants.ts` bridge/redirect card): lazy above-fold ritarda LCP. `decoding="async"` mantenuto. I logo card below-fold (jobCardHtml) restano lazy.

**3. Link interni nav+footer soft-landing → root-relative** (`${lp}` invece di `${BASE_URL}${lp}`), coerente con i link prose già relativi nella stessa pagina. Risparmio ~56 B/pagina (2× `https://frontaliereticino.ch`).

Risparmio EJP/soft-landing ≈ **~80 B/pagina raw** (12 media + 15 lazy + 56 relative) × ~98k–470k pagine soft-landing; trim minori sugli altri tipi pagina.

### `data-clarity-unmask="true"` — KEPT (non era no-op)
La stima iniziale "no-op su `<link>`" era **sbagliata**. `asyncCssPlugin.ts:13-15,40-42` documenta che tiene Microsoft Clarity dallo strippare l'`href` dello stylesheet nelle session-recording (senza, i replay renderizzano **senza CSS**). Funzionale → lasciato ovunque.

## Non implementato (ancora)

- **Delta dist aggregato non validabile pre-merge**: il full SEO build OOMa in CI sul `pull_request`; la riduzione byte è DOM-equivalente con test verdi, niente revert-trigger (nessun claim memoria/wall-time). Si osserva il calo artifact post-deploy su `main`.
- **`__STATIC_BODY_HTML__` snapshot script + `media="all"` su email-HTML newsletter**: fuori scope (il primo è handoff hydration JobOrphanView, il secondo è MIME email dove `media` non è default-ridondante).

## Test
- [x] `soft-landing-seo` (9), `thin-shell-ejp-marker` (17), `spa-bundle-resolver` (7) verdi
- [x] `seo-landing-pattern` (31), `job-sector-landing` (121), `city-jobs-hub` (62), `job-recency-landing` (33), `flat-html-redirect`, `redirect-page-builders`, `previous-slugs-bridge`, `no-hex-in-seo-plugins` verdi (304 passed / 2 skipped totali)
- [x] esbuild parse OK; async-CSS print pattern preservato (4 occorrenze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)