### PR TITLE
fix(orchestrator): shard crawler dispatch so the t–z tail stops going stale

### DIFF
--- a/.github/workflows/orchestrate-crawlers.yml
+++ b/.github/workflows/orchestrate-crawlers.yml
@@ -42,39 +42,7 @@ env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
 
 jobs:
-  # Reap once per wave, before any shard dispatches. Kept in its own job so the
-  # parallel dispatch shards don't each race to cancel the same queued runs.
-  reap:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Reap zombie queued runs (>30 min)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Known GH Actions scheduler bug: occasional runs get stranded in `queued`
-          # forever and block their concurrency group, masking future dispatches as
-          # "no-op" or causing false-failure cascades. Cancel anything queued >30 min
-          # before starting the new wave.
-          cutoff=$(date -u -d '-30 minutes' '+%Y-%m-%dT%H:%M:%SZ')
-          mapfile -t zombies < <(
-            gh api --paginate \
-              "/repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=100" \
-              --jq ".workflow_runs[] | select(.created_at < \"${cutoff}\") | .id"
-          )
-          if [ ${#zombies[@]} -eq 0 ]; then
-            echo "🧟 No zombie queued runs."
-          else
-            echo "🧟 Cancelling ${#zombies[@]} zombie queued run(s) older than ${cutoff}:"
-            for z in "${zombies[@]}"; do
-              echo "  - run $z"
-              gh run cancel "$z" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
-            done
-          fi
-
   dispatch:
-    needs: reap
     runs-on: ubuntu-latest
     timeout-minutes: 180
     # FRO-432: shard the dispatch across parallel jobs. A single sequential pass
@@ -100,6 +68,39 @@ jobs:
           sparse-checkout: .github/workflows
           sparse-checkout-cone-mode: false
           fetch-depth: 1
+
+      # Run inside each shard (not as a separate gating job) on purpose: a
+      # standalone `reap` job that `dispatch needs:` would, on its own
+      # failure/cancellation, leave both shards SKIPPED — a silent stale wave
+      # with no failure signal (skipped != failed, so the Report-failure step
+      # never fires), the exact symptom this workflow fixes. As a step here, a
+      # reap error fails the shard job → visible red + Report failure fires,
+      # while the other shard still dispatches its half. Cancelling already-gone
+      # queued runs is a no-op, so the two shards reaping concurrently is safe.
+      - name: Reap zombie queued runs (>30 min)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Known GH Actions scheduler bug: occasional runs get stranded in `queued`
+          # forever and block their concurrency group, masking future dispatches as
+          # "no-op" or causing false-failure cascades. Cancel anything queued >30 min
+          # before starting the new wave.
+          cutoff=$(date -u -d '-30 minutes' '+%Y-%m-%dT%H:%M:%SZ')
+          mapfile -t zombies < <(
+            gh api --paginate \
+              "/repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=100" \
+              --jq ".workflow_runs[] | select(.created_at < \"${cutoff}\") | .id"
+          )
+          if [ ${#zombies[@]} -eq 0 ]; then
+            echo "🧟 No zombie queued runs."
+          else
+            echo "🧟 Cancelling ${#zombies[@]} zombie queued run(s) older than ${cutoff}:"
+            for z in "${zombies[@]}"; do
+              echo "  - run $z"
+              gh run cancel "$z" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+            done
+          fi
 
       - name: Discover and dispatch crawler workflows
         env:
@@ -206,7 +207,6 @@ jobs:
           # Dispatch this shard's crawlers in alphabetical order; delay between each based on volume
           for wf in "${workflows[@]}"; do
             filename=$(basename "$wf")
-            wf_name=$(head -1 "$wf" | sed 's/^name: //')
             counter=$((dispatched + skipped + failed + 1))
 
             this_delay=$(get_delay "$filename")

--- a/.github/workflows/orchestrate-crawlers.yml
+++ b/.github/workflows/orchestrate-crawlers.yml
@@ -42,18 +42,12 @@ env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
 
 jobs:
-  dispatch-all:
+  # Reap once per wave, before any shard dispatches. Kept in its own job so the
+  # parallel dispatch shards don't each race to cancel the same queued runs.
+  reap:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
-
+    timeout-minutes: 10
     steps:
-      - name: Checkout (workflow files only)
-        uses: actions/checkout@v5
-        with:
-          sparse-checkout: .github/workflows
-          sparse-checkout-cone-mode: false
-          fetch-depth: 1
-
       - name: Reap zombie queued runs (>30 min)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,6 +72,34 @@ jobs:
               gh run cancel "$z" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
             done
           fi
+
+  dispatch:
+    needs: reap
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    # FRO-432: shard the dispatch across parallel jobs. A single sequential pass
+    # over the full crawler set (425 on 2026-06-03) cannot finish inside the
+    # 180-min job timeout — the run was cancelled at ~386/425, so the
+    # alphabetical tail (t–z: tschuggen … zurzach-care) was never dispatched and
+    # those ~27 crawlers went `stale` in the health monitor. Sharding splits the
+    # set so every crawler is reached well within the timeout, with headroom for
+    # growth. Keep SHARD_TOTAL small (2): each shard's API call rate stays under
+    # the 1000 req/hour GITHUB_TOKEN ceiling even when both run concurrently.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: '2'
+
+    steps:
+      - name: Checkout (workflow files only)
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/workflows
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
 
       - name: Discover and dispatch crawler workflows
         env:
@@ -152,23 +174,36 @@ jobs:
             return 1
           }
 
-          # Discover all crawler workflow files
-          mapfile -t workflows < <(find .github/workflows -name 'update-jobs-*.yml' -type f | sort)
-          total=${#workflows[@]}
+          # Discover all crawler workflow files (stable alphabetical order so the
+          # interleave below is deterministic across shards).
+          mapfile -t all_workflows < <(find .github/workflows -name 'update-jobs-*.yml' -type f | sort)
+          grand_total=${#all_workflows[@]}
 
-          if [ "$total" -eq 0 ]; then
+          if [ "$grand_total" -eq 0 ]; then
             echo "❌ No crawler workflows found!"
             exit 1
           fi
 
-          echo "📋 Found $total crawler workflows (FRO-326: volume-based staggering)"
+          # FRO-432: keep only the crawlers belonging to this shard. Interleave by
+          # position (index % SHARD_TOTAL == SHARD_INDEX) rather than slicing a
+          # contiguous block, so each shard is a representative mix of letters and
+          # a single failed shard never starves a whole alphabet range.
+          workflows=()
+          for i in "${!all_workflows[@]}"; do
+            if [ "$(( i % SHARD_TOTAL ))" -eq "$SHARD_INDEX" ]; then
+              workflows+=("${all_workflows[$i]}")
+            fi
+          done
+          total=${#workflows[@]}
+
+          echo "📋 Shard ${SHARD_INDEX}/${SHARD_TOTAL}: dispatching $total of $grand_total crawler workflows (FRO-326 volume-based staggering)"
           echo ""
 
           dispatched=0
           skipped=0
           failed=0
 
-          # Dispatch crawlers alphabetically; delay between each based on volume
+          # Dispatch this shard's crawlers in alphabetical order; delay between each based on volume
           for wf in "${workflows[@]}"; do
             filename=$(basename "$wf")
             wf_name=$(head -1 "$wf" | sed 's/^name: //')
@@ -205,10 +240,11 @@ jobs:
 
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  📦 Shard:      ${SHARD_INDEX}/${SHARD_TOTAL}"
           echo "  ✅ Dispatched: $dispatched"
           echo "  ❌ Failed:     $failed"
           echo "  ⏭️  Skipped:    $skipped"
-          echo "  📊 Total:      $total"
+          echo "  📊 Shard total: $total (of $grand_total overall)"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
           if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
## Implementato

Fix root-cause della raffica di issue `[crawler-health] *: stale` (~27 crawler della coda alfabetica `t–z`: #1364, #1366–#1392).

**Diagnosi:** `orchestrate-crawlers.yml` scopre tutti i 425 `update-jobs-*.yml` e li dispatcha **sequenzialmente** in ordine alfabetico con stagger 20–120s + verify-poll. Il run del 2026-06-03 è stato `cancelled` a esatti **180min** (timeout del job, run `26917004827`: created 22:28:48 → end 01:28:59) dopo aver dispatchato solo **386/425** (fino a `update-jobs-tecan`). I crawler 387–425 (`tschuggen … zurzach-care`) non venivano **mai** raggiunti → summary slice congelato → flag `stale` (>7gg). Il timeout esce come `cancelled`, che non triggera `if: failure()` → nessuna issue "Orchestrate", solo i downstream crawler-health.

**Fix:** `dispatch` diventa una **matrix a 2 shard** interleaved per posizione (`index % SHARD_TOTAL == SHARD_INDEX`), così ogni shard è un mix rappresentativo di lettere e uno shard fallito non affama un blocco alfabetico contiguo. Il reap degli zombie `queued` è ora il **primo step dentro ogni shard** (non un job gating separato — vedi review fix sotto). Delay volume-based e verify-by-observation invariati. `SHARD_TOTAL=2` tenuto basso così il rate di chiamate API concorrenti resta sotto il ceiling 1000 req/h del `GITHUB_TOKEN`.

**Review fixes applicati (2 🔴):**
- *Monitoring regression (reap SPOF):* un job `reap` separato con `dispatch needs: reap` avrebbe, su fallimento di reap, lasciato **entrambi** gli shard `skipped` = wave silenziosa senza segnale (skipped ≠ failed → `Report failure` non scatta). Risolto inglobando reap come primo step di ogni shard: un errore reap fallisce lo shard (rosso visibile + Report failure scatta) e l'altro shard dispatcha comunque la sua metà. Reaping concorrente è idempotente (cancellare un queued già sparito è no-op).
- Rimosso il `wf_name` dead-assignment (SC2034). `actionlint` pulito.

Validato: YAML parse ok, `actionlint` clean, shard bilanciati 213/212, coda 387–424 coperta su entrambi gli shard.

## Non implementato (ancora)

- **Claim wall-time non misurabile pre-merge → revert-trigger esplicito.** La stima "~213 crawler/shard entro 180min" è derivata da misura reale (il run single-job ha raggiunto 386/425 in 180min ≈ 2.14 crawler/min effettivi → 213/2.14 ≈ 100min/shard), ma il post-fix è verificabile **solo post-merge** (dispatchare 425 crawler reali non è praticabile sul `pull_request`). **Revert-trigger: se il prossimo wave (cron 08/20 UTC o dispatch manuale) NON chiude entrambi gli shard `dispatch` entro 180min, o se compaiono nuove issue `[crawler-health] *: stale` sulla coda t–z dopo il primo wave → revert di questo sharding.**
- **Bilanciamento delay-sum per parità d'indice non misurato** (adversarial): i 7 LARGE (120s) + 25 MEDIUM (60s) sono distribuiti per posizione alfabetica; un eventuale clustering su uno shard sposta la somma-delay di ~+14min worst-case — verosimilmente entro il margine (~80min di headroom), incluso comunque nel revert-trigger sopra.
- **Secondary rate-limit di `workflow_dispatch` con 2 shard concorrenti** (adversarial): lo ~900/h è l'happy-path; se i run non si registrano in fretta, `dispatch_and_verify` cicla i 15s pieni e con 2 shard il rate raddoppia → possibile throttle → false-failure. È la ragione per cui `SHARD_TOTAL` è tenuto a **2** e non 4. Se emergesse, prossimo step è ridurre il poll-window o passare il verify a un singolo batch-check post-dispatch (follow-up, non in questa PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
