### PR TITLE
fix(crawler-health): allowlist the-living-circle + raiffeisen-vc as legitimately-empty

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -101,6 +101,18 @@ const EMPTY_OK_CRAWLERS = new Set([
   // Ticino/Graubünden roles; same legitimately-empty regional-filter case as
   // zurich-insurance-sede-ticino and manor. Parser is healthy.
   'alten-switzerland',
+  // The Living Circle: the feed (https://jobs.thelivingcircle.ch/jobs.feed.json)
+  // currently returns 13 open jobs CH-wide but 0 in Ticino. The luxury-hotel
+  // group hires mostly in ZH/GR/VS; the crawler is scoped to TI and is healthy
+  // — same legitimately-empty regional-filter case as manor and alten-switzerland.
+  // Re-arms when a TI listing appears.
+  'the-living-circle',
+  // Banca Raiffeisen Vedeggio-Cassarate: the single regional bank's careers page
+  // (https://www.raiffeisen.ch/vedeggio-cassarate/it/chi-siamo/carriera/lavorare-banca-raiffeisen.html)
+  // returns HTTP 200 with 0 open positions ("Offerte attive: 0"). A small local
+  // cooperative bank legitimately has no openings for weeks at a time; the
+  // crawler completes cleanly and re-arms when a vacancy is published.
+  'banca-raiffeisen-vedeggio-cassarate',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Implementato

Risolve 2 dei 3 falsi-`broken` del crawler-health monitor aggiungendoli a `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs` (stesso meccanismo già usato per `manor`, `alten-switzerland`, `zurich-insurance-sede-ticino`, `ail-lugano`, `citta-di-locarno`):

- **`the-living-circle`** (#1365): il feed `https://jobs.thelivingcircle.ch/jobs.feed.json` ritorna **13 job CH-wide, 0 in Ticino** (log run 26952616488: `Found 13 total jobs, 0 in Ticino`). Il crawler è scoped a TI ed è sano — identico caso filtro-geografico di `manor`/`alten-switzerland`.
- **`banca-raiffeisen-vedeggio-cassarate`** (#1362): la pagina careers ritorna **HTTP 200 con 0 posizioni aperte** (log run 26954181993: `Total jobs: 0`, `Offerte attive: 0`, `No Raiffeisen VC jobs found after crawl. Exiting OK`, durata 59.5s, nessun errore HTTP). Piccola banca cooperativa regionale, legittimamente vuota per settimane.

Con l'allowlist, `consecutiveEmptyRuns` resta 0 per entrambi → il monitor smette di aprire issue `broken` spurie.

Verificato: `node --check` ok, `tests/scripts/check-crawler-health.test.ts` 13/13 verde.

## Non implementato (ancora)

- **`cambiavalute` (#1363) — NON aggiunto di proposito.** Non è una sorgente vuota: è un **blocco anti-bot HTTP 403** reale (log run 26948543917: `Listing fetch attempt 1/3 failed: HTTP 403` ×3 → `Plain fetch exhausted (HTTP 403). Trying Playwright browser fallback` → `Found 0 job detail link(s)`). Aggiungerlo a `EMPTY_OK_CRAWLERS` maschererebbe un fetch-failure genuino. Richiede decisione separata: hardening anti-bot del fetch vs retire (sorgente viva ma muro 403; shop di cambio valuta piccolo, 2 job storici). Lasciato all'owner.
- **`lastFetchOutcome` per-summary** (follow-up già citato nel docblock di `check-crawler-health.mjs`): distinguerebbe `filtered_empty`/`anti_bot_block`/`selector_miss` al primo run invece di aspettare la empty-streak, eliminando questa categoria di allowlist manuale. Cambio più ampio (writer summary condiviso) → fuori scope di questo fix mirato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
