### PR TITLE
fix(crawlers): unblock cambiavalute — WAF gates on Chrome major version (#1363)

### DIFF
--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -55,6 +55,11 @@ const CAMBIAVALUTE_COMPANY_NAME = 'CambiaValute.ch';
 const CAMBIAVALUTE_COMPANY_DOMAIN = 'cambiavalute.ch';
 const CAMBIAVALUTE_HOST = 'cambiavalute.ch';
 const CAMBIAVALUTE_LISTING_URL = 'https://cambiavalute.ch/annunci-di-lavoro/';
+// Yoast sitemap for the "career" (annuncio-di-lavoro) custom post type. Used as
+// a discovery fallback when the listing-page DOM yields 0 links — it lists the
+// canonical job URLs as plain <loc> entries, so it survives Elementor layout
+// changes and is a second path past the same WAF (gated by the same UA window).
+const CAMBIAVALUTE_SITEMAP_URL = 'https://cambiavalute.ch/career-sitemap.xml';
 const CAMBIAVALUTE_LOCALES = ['it', 'en', 'de', 'fr'];
 
 /* ── HTML helpers ──────────────────────────────────────────── */
@@ -145,13 +150,48 @@ function parseJobLinksFromHtml(html = '') {
   return [...seen.values()];
 }
 
+/**
+ * Extract job detail links from a Yoast sitemap XML body. Same /annuncio-di-lavoro/
+ * filter + canonicalization as parseJobLinksFromHtml, but over <loc> entries.
+ */
+function parseJobLinksFromSitemap(xml = '') {
+  const source = String(xml || '');
+  const locRe = /<loc>\s*([^<\s]+)\s*<\/loc>/gi;
+  const seen = new Map();
+  let match = null;
+  while ((match = locRe.exec(source)) !== null) {
+    const absolute = toAbsoluteUrl(decodeHtmlEntities(match[1] || ''));
+    if (!absolute) continue;
+    if (!/\/annuncio-di-lavoro\/[^/?#]+/i.test(absolute)) continue;
+    try {
+      const url = new URL(absolute);
+      if (url.hostname.toLowerCase() !== CAMBIAVALUTE_HOST) continue;
+      const canonical = `${url.origin}${url.pathname.replace(/\/+$/, '/')}`
+        .replace(/([^/])$/, '$1/');
+      const key = canonical.toLowerCase();
+      if (!seen.has(key)) seen.set(key, canonical);
+    } catch {
+      // skip malformed URLs
+    }
+  }
+  return [...seen.values()];
+}
+
 // Realistic browser User-Agents rotated across attempts to defeat anti-bot
-// 403s (cambiavalute.ch blocks the bot UA — issues #1277/#1303). Same pattern
-// as the goline crawler (scripts/update-goline-jobs.mjs:fetchPage).
+// 403s (cambiavalute.ch blocks the bot UA — issues #1277/#1303/#1363).
+//
+// IMPORTANT — the WAF gates on the Chrome MAJOR version, not just "browser vs
+// bot": empirically (2026-06-04, residential probe) Chrome/122–130 return 200
+// while Chrome/120 and Chrome/131+ return 403. The previous UAs were ALL
+// Chrome/131, so every plain-fetch attempt AND the Playwright fallback (which
+// sets page UA = BROWSER_USER_AGENTS[0]) were served the anti-bot page → 0 job
+// links parsed in CI. Pin a few versions inside the known-good window. If the
+// window drifts and these start 403'ing again, the run skips gracefully (no
+// false-failure issue) — bump the versions then.
 const BROWSER_USER_AGENTS = [
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
 ];
 
 async function fetchListingPage(url, timeoutMs, userAgent) {
@@ -161,12 +201,21 @@ async function fetchListingPage(url, timeoutMs, userAgent) {
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'it-CH,it;q=0.9,en-US;q=0.8,en;q=0.7',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Cache-Control': 'no-cache',
+        // Mirror a real Chrome top-level navigation. The Sec-Fetch-* metadata +
+        // Upgrade-Insecure-Requests are sent by every modern browser; their
+        // absence is a strong bot tell for the WAF. `Accept-Encoding` is left
+        // unset on purpose so undici negotiates + auto-decompresses the body
+        // (manually pinning br/gzip makes res.text() return compressed bytes).
+        // No fake `Referer` — a direct navigation has Sec-Fetch-Site: none.
+        Accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Upgrade-Insecure-Requests': '1',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'none',
+        'Sec-Fetch-User': '?1',
         'User-Agent': userAgent,
-        Referer: 'https://www.google.com/',
       },
     });
     const html = await res.text();
@@ -245,8 +294,26 @@ async function fetchCambiavalute() {
     return { seedUrls: [], seedMetaByUrl: {} };
   }
 
-  const links = parseJobLinksFromHtml(html);
-  console.log(`📦 Found ${links.length} job detail link(s).`);
+  let links = parseJobLinksFromHtml(html);
+  console.log(`📦 Found ${links.length} job detail link(s) on the listing page.`);
+
+  // Fallback: the listing DOM yielded nothing (anti-bot challenge page, or an
+  // Elementor layout change). Try the career sitemap, which lists the canonical
+  // job URLs as plain <loc> entries and is far harder to break.
+  if (links.length === 0) {
+    console.log(`🗺️  Listing empty — trying career sitemap ${CAMBIAVALUTE_SITEMAP_URL}...`);
+    try {
+      const sitemapXml = await fetchListingPageWithRetry(
+        CAMBIAVALUTE_SITEMAP_URL,
+        timeoutMs,
+        userAgent,
+      );
+      links = parseJobLinksFromSitemap(sitemapXml);
+      console.log(`📦 Found ${links.length} job detail link(s) via sitemap.`);
+    } catch (err) {
+      console.warn(`⚠️ Sitemap fallback failed: ${err?.message || err}.`);
+    }
+  }
 
   const seedMetaByUrl = {};
   for (const link of links) {


### PR DESCRIPTION
## Implementato

Sblocca il crawler **cambiavalute** (#1363, `broken` per 4 run a 0 job) — la sorgente è viva con **3 job reali a Chiasso/TI** (Legal & Compliance Officer + 2 Sales/Marketing assistant), verificati con browser reale.

**Root cause (diagnosi live 2026-06-04):** il WAF di cambiavalute.ch **filtra sulla major version di Chrome nello UA**, non solo bot-vs-browser. Probe ripetuti (residenziale, spaziati per evitare il rate-limit):

| Chrome UA | esito |
|---|---|
| 120 | 403 |
| **122 / 124 / 126 / 128 / 130** | **200** |
| 131 | 403 |
| bot UA (`FrontaliereTicinoBot`) | 403 |

I `BROWSER_USER_AGENTS` del crawler erano **tutti Chrome/131** → ogni plain-fetch **e** il fallback Playwright (che usa `page UA = BROWSER_USER_AGENTS[0]`) ricevevano la pagina anti-bot → `parseJobLinksFromHtml` = 0 link → `broken`. Spiega anche il log CI "browser fallback → Found 0 link" (non un 403 secco: una challenge-page da 200 con 0 job).

**Fix:**
- UA pinnati nel window noto-buono (126/128/130).
- Header di una vera navigazione top-level: `Sec-Fetch-*` + `Upgrade-Insecure-Requests` (la loro assenza è un tell-bot forte). Rimossi: `Accept-Encoding` manuale (faceva ritornare a undici byte compressi su `res.text()`) e il `Referer: google.com` fittizio.
- **Fallback discovery via `career-sitemap.xml`** (Yoast) quando il listing dà 0 link: elenca gli URL job canonici come `<loc>`, robusto a cambi layout Elementor e secondo percorso oltre il WAF.

**Verificato da node/undici** (stesso engine di CI), non solo curl: listing + sitemap → entrambi **200** ed estraggono i **3 slug job**. Il graceful-skip su fetch totalmente fallito è invariato.

## Non implementato (ancora)

- **Brittleness del UA-window**: se il WAF sposta la finestra (es. blocca anche 130), il crawler tornerà a 0 link. Non verificabile pre-merge dall'IP datacenter di GitHub Actions (probe fatto da IP residenziale; ma il segnale è UA-version, non IP — bot-UA 403 / browser-UA 200 in modo deterministico). **Revert-trigger**: se i prossimi run cambiavalute restano a 0 job dopo il merge → bump delle versioni UA, e se persiste ripropongo retire (sorgente minuscola, 3 job). Il graceful-skip garantisce zero regressione nel frattempo.
- **Promozione dell'header-set / UA-window al fetch layer condiviso**: altri crawler potrebbero avere lo stesso muro UA-version. Non toccati speculativamente (cambio di comportamento su 400+ crawler) → follow-up se emerge un secondo caso.
- **Test unit** per `parseJobLinksFromSitemap`: le funzioni del crawler non sono esportate → servirebbe refactor; fuori scope.

Closes #1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
