### PR TITLE
fix(crawler-health): allowlist linnea as legitimately-empty (#1418)

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -113,6 +113,12 @@ const EMPTY_OK_CRAWLERS = new Set([
   // cooperative bank legitimately has no openings for weeks at a time; the
   // crawler completes cleanly and re-arms when a vacancy is published.
   'banca-raiffeisen-vedeggio-cassarate',
+  // Linnea SA (Riazzino, TI): the careers page (https://www.linnea.ch/careers/)
+  // returns HTTP 200 and explicitly states "No open positions at this time."
+  // The parser correctly finds 0 accordion items; the botanical-ingredients
+  // manufacturer simply has no current openings. Healthy, re-arms when a
+  // vacancy is published.
+  'linnea',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Implementato

`linnea` (#1418) flaggato `broken` ma è **legit-empty**: la careers page (https://www.linnea.ch/careers/) ritorna HTTP 200 e dichiara esplicitamente **"No open positions at this time."** (verificato via browser reale). Il parser trova correttamente 0 accordion items. Stesso caso filtro/empty di `the-living-circle`, `ail-lugano`, `citta-di-locarno`.

Aggiunto `linnea` a `EMPTY_OK_CRAWLERS` → `consecutiveEmptyRuns` resta 0 → il monitor smette di aprire issue `broken` spurie e auto-chiude #1418.

Verificato: `node --check` ok, `tests/scripts/check-crawler-health.test.ts` 13/13.

## Non implementato (ancora)

- **`goline` (#1408) e `cambiavalute` (#1417) — NON in questa PR.** Sono blocchi anti-bot reali (HTTP 403 / challenge IP), non sorgenti vuote → non vanno in `EMPTY_OK` (maschererebbe un fetch-failure). Decisione separata (retire vs degraded), vedi discussione PR/issue.

Closes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
