### PR TITLE
fix(seo): restore img loading attr on nav/hero logos (page-weight gate)

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -199,7 +199,7 @@ export function buildCanonicalBridgePage(options: {
  <body>
  <main class="card">
  <div class="logo">
- <img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">
+ <img src="/assets/logo.svg" width="28" height="28" alt="" loading="eager" decoding="async">
  <span>Frontaliere Ticino</span>
  </div>
  <h1>${title}</h1>
@@ -253,7 +253,7 @@ export function buildFlatRedirect(
  <body>
  <main class="card">
  <div class="logo">
- <img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">
+ <img src="/assets/logo.svg" width="28" height="28" alt="" loading="eager" decoding="async">
  <span>Frontaliere Ticino</span>
  </div>
  <h1>Versione canonica disponibile</h1>

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10098,7 +10098,7 @@ ${staticAnalyticsHtml}
  // Externalised from inline <svg> (~700 B/page) — same logo now served from
  // /assets/logo.svg, cached by browser. Saves ~68 MB across ~98k soft-landing
  // pages. Static path; browser caches first-load globally.
- const navSvg = `<img src="/assets/logo.svg" width="28" height="28" alt="" decoding="async">`;
+ const navSvg = `<img src="/assets/logo.svg" width="28" height="28" alt="" loading="eager" decoding="async">`;
  const spaBundleCss = hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">` : '';
  const spaBundleJs = hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : '';
  // Per-locale pre-built nav + footer (only 4 strings to cache).


### PR DESCRIPTION
## Implementato

Ripristina l'attributo `loading` sui logo `<img>` nav/hero che **#1398** (`c959db26c0a`) aveva strippato, sbloccando il gate `validate-dist`.

**Root cause** (deploy run [26954042506](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26954042506) → validate-dist FAILED → rollback):
- #1398 ha rimosso `loading="lazy"` dai logo above-fold (motivo: lazy su above-fold differisce LCP).
- Ma l'auditor `page-weight` (`scripts/audit-page-weight.mjs` → `findImgIssues`) esige che **ogni** `<img>` porti `loading=` **oppure** `fetchpriority="high"`, a tolleranza zero (`passed = !hasOffenders`).
- Risultato: **217474 img-attr offender** (210855 job-board + spa-locale/spa-other/blog/border-wait) → `audit:all` rc=1 → `validate-dist` rosso → rollback.

**Fix**: `loading="eager"` invece di rimuovere l'attributo. `eager` è il valore corretto above-fold (non differisce LCP → preserva l'intento di #1398) e soddisfa il contratto dell'auditor.

Punti corretti (classe completa, AGENTS.md #6 — sono i 3 emit che #1398 ha strippato):
- `build-plugins/constants.ts:202` (bridge shell)
- `build-plugins/constants.ts:256` (redirect shell)
- `build-plugins/jobsSeoPagesPlugin.ts:10101` (`navSvg`, soft-landing)

Gate NON toccato (AGENTS.md #1: mai abbassare la validation per passare il build). Verificato: nessun altro emit statico di logo `<img>` privo dell'attributo.

## Non implementato (ancora)

- Claim perf/byte non validabili pre-merge: `loading="eager"` aggiunge ~16 byte/pagina vs la forma strippata di #1398. Trade-off accettato — l'auditor è un gate hard senza alternativa byte-free (serve `loading` o `fetchpriority`). Nessun impatto LCP atteso (eager = comportamento di default per img non-lazy). Se un audit post-deploy segnala regressione page-weight inattesa → indagare, ma è strutturalmente impossibile (solo +attr su tag già esistenti).
- Nessun test aggiunto: esclusione nit "manca test" (AGENTS.md / policy follow-up). Il gate `page-weight` stesso è già il test eseguibile dell'invariante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)