### PR TITLE
feat(crawlers): egress proxy for IP-blocked sources — unblock cambiavalute + goline (#1363 #1408)

### DIFF
--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -1,0 +1,53 @@
+/**
+ * Jina Reader egress proxy for IP-blocked crawler sources.
+ *
+ * Some career sites (e.g. cambiavalute.ch, #1363/#1417) sit behind a WAF that
+ * serves a challenge / empty page to GitHub Actions datacenter IPs, even when
+ * the UA + headers are a perfect browser match — the block is on the egress IP
+ * reputation, which no header tweak can fix. The jobs ARE reachable from a
+ * residential / clean IP.
+ *
+ * Jina Reader (https://r.jina.ai) fetches a URL with a real browser from its own
+ * (non-blocked) IP pool and, with `X-Return-Format: html`, returns the raw HTML.
+ * Routing the blocked host's requests through it transparently yields the real
+ * page so the existing parsers work unchanged. Free, no key required for the
+ * handful of requests a dedicated crawler makes per run (an optional
+ * `JINA_API_KEY` raises the rate limit if ever needed).
+ *
+ * Opt-in only: the shared crawler applies this when `JOBS_CRAWLER_FETCH_PROXY`
+ * lists the request's host, so the default path for the other ~400 crawlers is
+ * completely untouched.
+ */
+
+export const JINA_READER_BASE = 'https://r.jina.ai/';
+
+/** Build the Jina-proxied request (URL + headers) for a target URL. */
+export function jinaProxiedRequest(targetUrl) {
+  const headers = {
+    // Return the page's raw HTML (not Jina's default markdown) so downstream
+    // HTML/JSON-LD parsers see exactly what a direct fetch would have returned.
+    'X-Return-Format': 'html',
+  };
+  const key = (process.env.JINA_API_KEY || '').trim();
+  if (key) headers.Authorization = `Bearer ${key}`;
+  return { url: `${JINA_READER_BASE}${targetUrl}`, headers };
+}
+
+/**
+ * Does `url`'s host match any entry in the comma-separated `listCsv`
+ * (`JOBS_CRAWLER_FETCH_PROXY`)? Matches the host exactly or as a subdomain.
+ */
+export function hostMatchesProxyList(url, listCsv) {
+  if (!listCsv) return false;
+  let host;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return String(listCsv)
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .some((h) => host === h || host.endsWith(`.${h}`));
+}

--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -34,6 +34,23 @@ export function jinaProxiedRequest(targetUrl) {
 }
 
 /**
+ * Fetch a URL through the Jina proxy with an AbortController timeout, so a slow
+ * or hanging Jina request can never stall a crawler run until the global job
+ * timeout. Returns the raw `Response`. Used by dedicated crawlers that fetch
+ * outside the shared `fetchWithTimeout` chokepoint (discovery / single-page).
+ */
+export async function fetchViaJina(targetUrl, { timeoutMs = 30000, fetchImpl = fetch } = {}) {
+  const { url, headers } = jinaProxiedRequest(targetUrl);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Does `url`'s host match any entry in the comma-separated `listCsv`
  * (`JOBS_CRAWLER_FETCH_PROXY`)? Matches the host exactly or as a subdomain.
  */

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -98,6 +98,7 @@ import {
 import { translateWithMyMemory, getMyMemoryStats } from './mymemory-translate.mjs';
 import { freeTranslateWithRetry, logCascadeSummary } from './free-translate.mjs';
 import { parseSupsiJobDetail } from './supsi-job-parser.mjs';
+import { jinaProxiedRequest, hostMatchesProxyList } from './jina-proxy.mjs';
 import {
   extractMigrosStructuredData,
   extractMigrosSectionItems,
@@ -2277,6 +2278,19 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
   const maxAttempts = canRetry ? 1 + FETCH_RETRY_ATTEMPTS : 1;
   let lastErr = null;
 
+  // Opt-in egress proxy for IP-blocked sources (JOBS_CRAWLER_FETCH_PROXY lists
+  // the host(s) to route via Jina Reader). Default unset → no effect on any
+  // other crawler. The proxied request returns the target's raw HTML, so the
+  // caller and all downstream parsers are unchanged; the original `url` is still
+  // what callers use for the job's canonical URL.
+  let targetUrl = url;
+  let proxyHeaders = {};
+  if (hostMatchesProxyList(url, process.env.JOBS_CRAWLER_FETCH_PROXY)) {
+    const proxied = jinaProxiedRequest(url);
+    targetUrl = proxied.url;
+    proxyHeaders = proxied.headers;
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const controller = new AbortController();
     let timer = null;
@@ -2286,7 +2300,7 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
         reject(new Error(`timeout after ${REQUEST_TIMEOUT_MS}ms`));
       }, REQUEST_TIMEOUT_MS);
     });
-    const fetchPromise = fetch(url, {
+    const fetchPromise = fetch(targetUrl, {
       method: upperMethod,
       signal: controller.signal,
       redirect: 'follow',
@@ -2294,6 +2308,7 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'User-Agent': userAgent || CRAWLER_USER_AGENT,
         ...headers,
+        ...proxyHeaders,
       },
       body,
     });

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { launchChromium } from './lib/ensure-chromium.mjs';
+import { jinaProxiedRequest } from './lib/jina-proxy.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -315,6 +316,27 @@ async function fetchCambiavalute() {
     }
   }
 
+  // Still nothing → the egress IP is WAF-blocked (datacenter IP on CI gets a
+  // challenge page even with a perfect browser UA — see #1363). Fetch the
+  // sitemap through the Jina Reader proxy (clean IP) for discovery; the detail
+  // pages are then fetched through the same proxy by the shared crawler via
+  // JOBS_CRAWLER_FETCH_PROXY (set in runBaseCrawler below).
+  if (links.length === 0) {
+    try {
+      const { url: proxyUrl, headers: proxyHeaders } = jinaProxiedRequest(CAMBIAVALUTE_SITEMAP_URL);
+      console.log('🛰️  Sitemap empty from direct fetch — retrying via egress proxy...');
+      const res = await fetch(proxyUrl, { headers: proxyHeaders });
+      if (res.ok) {
+        links = parseJobLinksFromSitemap(await res.text());
+        console.log(`📦 Found ${links.length} job detail link(s) via proxied sitemap.`);
+      } else {
+        console.warn(`⚠️ Proxied sitemap returned HTTP ${res.status}.`);
+      }
+    } catch (err) {
+      console.warn(`⚠️ Proxied sitemap fallback failed: ${err?.message || err}.`);
+    }
+  }
+
   const seedMetaByUrl = {};
   for (const link of links) {
     seedMetaByUrl[link] = {
@@ -366,6 +388,11 @@ async function runBaseCrawler() {
     companyKeys: CAMBIAVALUTE_KEY,
     disableWorkdayForce: true,
     forceLocalizationWhenAiEnabledOnly: true,
+    // Route cambiavalute.ch fetches (the detail pages) through the Jina Reader
+    // egress proxy: the WAF blocks GitHub Actions datacenter IPs regardless of
+    // UA/headers (#1363), but the jobs are reachable from a clean IP. Scoped to
+    // this host only — every other crawler's fetch path is untouched.
+    extraEnv: { JOBS_CRAWLER_FETCH_PROXY: CAMBIAVALUTE_HOST },
   });
 }
 

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -18,7 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { launchChromium } from './lib/ensure-chromium.mjs';
-import { jinaProxiedRequest } from './lib/jina-proxy.mjs';
+import { fetchViaJina } from './lib/jina-proxy.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -323,11 +323,18 @@ async function fetchCambiavalute() {
   // JOBS_CRAWLER_FETCH_PROXY (set in runBaseCrawler below).
   if (links.length === 0) {
     try {
-      const { url: proxyUrl, headers: proxyHeaders } = jinaProxiedRequest(CAMBIAVALUTE_SITEMAP_URL);
       console.log('🛰️  Sitemap empty from direct fetch — retrying via egress proxy...');
-      const res = await fetch(proxyUrl, { headers: proxyHeaders });
+      const res = await fetchViaJina(CAMBIAVALUTE_SITEMAP_URL, { timeoutMs });
       if (res.ok) {
-        links = parseJobLinksFromSitemap(await res.text());
+        const body = await res.text();
+        // Jina with X-Return-Format: html renders the XML sitemap as an HTML
+        // page (<a href> links, not <loc>), so parse with both extractors and
+        // union — robust whether the proxy returns raw XML or rendered HTML.
+        const merged = new Map();
+        for (const link of [...parseJobLinksFromSitemap(body), ...parseJobLinksFromHtml(body)]) {
+          merged.set(link.toLowerCase(), link);
+        }
+        links = [...merged.values()];
         console.log(`📦 Found ${links.length} job detail link(s) via proxied sitemap.`);
       } else {
         console.warn(`⚠️ Proxied sitemap returned HTTP ${res.status}.`);

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -3,7 +3,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { jinaProxiedRequest } from './lib/jina-proxy.mjs';
+import { fetchViaJina } from './lib/jina-proxy.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -122,8 +122,7 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
         // IP and returns the page's raw HTML, which the parser handles unchanged.
         console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying egress proxy...`);
         try {
-          const { url: proxyUrl, headers: proxyHeaders } = jinaProxiedRequest(url);
-          const pr = await fetch(proxyUrl, { headers: proxyHeaders });
+          const pr = await fetchViaJina(url, { timeoutMs });
           if (pr.ok) return await pr.text();
           console.log(`  ⚠️  egress proxy returned HTTP ${pr.status}, trying Playwright fallback...`);
         } catch (proxyErr) {

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -3,6 +3,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { jinaProxiedRequest } from './lib/jina-proxy.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -81,10 +82,12 @@ function slugify(value = '') {
 }
 
 async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 30000) {
+  // Chrome major version inside the window WAFs tend to accept (some block the
+  // newest, e.g. 131+, as bot-common) — see the cambiavalute finding (#1363).
   const USER_AGENTS = [
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
   ];
 
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -112,7 +115,20 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
         console.log(`  ⚠️  fetch attempt ${attempt + 1} failed (${err.message}), retrying in ${delay / 1000}s...`);
         await new Promise((r) => setTimeout(r, delay));
       } else {
-        console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying Playwright fallback...`);
+        // The direct 403 is typically an anti-bot/IP block: goline.ch serves a
+        // challenge to GitHub Actions datacenter IPs even via a real browser, so
+        // the Playwright fallback also comes back empty (#1408). Try the Jina
+        // Reader egress proxy first — it fetches with a real browser from a clean
+        // IP and returns the page's raw HTML, which the parser handles unchanged.
+        console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying egress proxy...`);
+        try {
+          const { url: proxyUrl, headers: proxyHeaders } = jinaProxiedRequest(url);
+          const pr = await fetch(proxyUrl, { headers: proxyHeaders });
+          if (pr.ok) return await pr.text();
+          console.log(`  ⚠️  egress proxy returned HTTP ${pr.status}, trying Playwright fallback...`);
+        } catch (proxyErr) {
+          console.log(`  ⚠️  egress proxy failed (${proxyErr.message}), trying Playwright fallback...`);
+        }
         try {
           const browser = await launchChromium({ headless: true });
           try {


### PR DESCRIPTION
## Implementato

Sblocca **cambiavalute** (#1363/#1417) e **goline** (#1408) — stessa classe: sorgenti con un job TI reale ma bloccate per **IP-reputation** dagli IP datacenter di GitHub Actions. Introduce un meccanismo riusabile.

**Perché il fix UA non bastava:** dopo che #1407 ha tolto il 403, da IP CI cambiavalute.ch serve comunque una **challenge-page 200 con 0 job** (listing e sitemap). I 3 job TI (Legal & Compliance Officer + 2 Sales/Marketing, ELP SA, Chiasso) sono raggiungibili solo da IP pulito. goline.ch/opportunities ha un ruolo reale (Web Full Stack Developer) ma risponde 403 anti-bot in CI, e anche il fallback Playwright riceve la challenge. **Nessun header risolve un blocco IP.**

**Soluzione — egress proxy via Jina Reader** (`r.jina.ai`, `X-Return-Format: html`): fetcha con un browser reale da un IP non bloccato e ritorna l'**HTML grezzo** del target → i parser esistenti funzionano invariati. Gratis, ~4 fetch/run (key opzionale `JINA_API_KEY`).

- **`scripts/lib/jina-proxy.mjs`** (nuovo): `jinaProxiedRequest()`, `fetchViaJina()` (con AbortController timeout), `hostMatchesProxyList()`.
- **`shared-jobs-crawler.mjs` `fetchWithTimeout`** (unico chokepoint fetch, listing+detail): se `JOBS_CRAWLER_FETCH_PROXY` elenca l'host → routa via Jina. **Default unset → zero effetto sugli altri ~400 crawler.** Il caller mantiene l'URL originale per il canonical.
- **`update-cambiavalute-jobs.mjs`**: discovery seed via sitemap **proxata** quando il diretto è bloccato (parse union `<loc>`+`href` perché Jina-html rende l'XML come HTML); `extraEnv JOBS_CRAWLER_FETCH_PROXY=cambiavalute.ch` → le detail page passano dal chokepoint proxato.
- **`update-goline-jobs.mjs`**: goline ha un `fetchPage` proprio → aggiunto fallback `fetchViaJina` prima di Playwright + UA nel window accettato.

**Verificato localmente (node):** gating (host/subdomain/altro/empty); cambiavalute sitemap via `fetchViaJina` → 200 + 3 link union; detail proxato → 200 + 79KB HTML reale; goline via `fetchViaJina` → 200 + HTML ruolo reale. Latenza Jina 0.75–2s (≪ timeout).

**Review fixes (round 2):** 🟡 timeout/AbortController sui fetch proxy standalone (via `fetchViaJina`); ❓ Jina-html rende la sitemap XML come HTML → parse union dei due extractor (verificato 3 link); 🟡 body ripulito (goline è in `## Implementato`).

## Non implementato (ancora)

- **Validazione full-pipeline solo in CI → revert-trigger.** Fetch+gating+discovery verificati in locale, ma estrazione record + gate structured-data (`baseSalary`/`postalCode`/`jobLocation`/…) + translation girano nel base crawler in CI (no full build locale). **Revert-trigger: se i prossimi run `update-jobs-cambiavalute` / `update-jobs-goline` restano a 0 job, o se il gate structured-data fallisce → revert.** Cambio gated (default off) → zero regressione altri crawler; entrambe mantengono graceful-skip se il proxy fallisce.
- **Rate-limit Jina**: free ~20 RPM senza key; ~4 fetch/run → ampiamente dentro. Se in futuro molti host usano il proxy → settare `JINA_API_KEY`.

Closes #1363
Closes #1417
Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)
