### PR TITLE
fix(audit): strip inline script/style before no-literal-markdown scan

### DIFF
--- a/scripts/audit-no-literal-markdown.mjs
+++ b/scripts/audit-no-literal-markdown.mjs
@@ -36,14 +36,19 @@ const MAIN_CLOSE = /<\/main>/i;
 const LITERAL_BOLD_RE = /\*\*[^*\n]{1,200}\*\*/g;
 // 3+ run of `_`, `=`, `~` as separator decoration
 const SEPARATOR_RUN_RE = /[_=~]{3,}/g;
+// Inline <script>/<style> blocks are code, not visible body. Their contents
+// can legitimately contain `===` (JS strict-equality, e.g. the per-card logo
+// fallback script `w.length===0`) or `~`/`_` runs that are NOT literal
+// markdown. Strip them before detection so code can't false-flag the gate.
+const CODE_BLOCK_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
 
 function extractMainBody(html) {
   const openMatch = html.match(SEO_STATIC_OPEN);
   if (!openMatch) return '';
   const startIdx = openMatch.index + openMatch[0].length;
   const closeIdx = html.slice(startIdx).search(MAIN_CLOSE);
-  if (closeIdx < 0) return html.slice(startIdx);
-  return html.slice(startIdx, startIdx + closeIdx);
+  const raw = closeIdx < 0 ? html.slice(startIdx) : html.slice(startIdx, startIdx + closeIdx);
+  return raw.replace(CODE_BLOCK_RE, '');
 }
 
 function isJobDetailPage(absPath) {

--- a/tests/seo/audit-no-literal-markdown.test.ts
+++ b/tests/seo/audit-no-literal-markdown.test.ts
@@ -20,4 +20,22 @@ describe('audit-no-literal-markdown', () => {
     expect(report.offendersTotal).toBe(1);
     expect(report.offenders[0].literalBoldSamples).toEqual(['**non convertito**']);
   });
+
+  it('does not flag === / runs inside inline <script> as literal markdown', () => {
+    // The per-card logo fallback script (jcLF) carries JS strict-equality
+    // `===` runs; these are code, not visible markdown separators, and must
+    // not trip the separator gate.
+    const html = minifyHtml(`<!doctype html><html><body>
+      <main class="seo-static-content"><h1>Offerta</h1><p>Testo regolare</p>
+      <script>function jcLF(c){var w=c.split(' ').filter(Boolean);return w.length===0?'?':w.length===1?w[0].slice(0,2):w[0][0]+w[1][0]}</script>
+      </main>
+    </body></html>`);
+
+    const audit = createAuditor();
+    audit.collect(JOB_PATH, html);
+    const report = audit.report();
+
+    expect(report.passed).toBe(true);
+    expect(report.offendersTotal).toBe(0);
+  });
 });


### PR DESCRIPTION
## Implementato

Risolve il falso positivo del gate `no-literal-markdown` che teneva `validate-dist` rosso (→ rollback → outage) **dopo** che #1420 aveva già risolto page-weight.

**Root cause:** `scripts/audit-no-literal-markdown.mjs` estrae `<main class=seo-static-content>` e flagga run di 3+ `=`/`_`/`~` come separatori markdown (`SEPARATOR_RUN_RE`), ma **non strippava gli `<script>` inline**. Lo script per-card di logo-fallback (`jcLF`, introdotto da #1399 oggi) contiene operatori JS strict-equality `===` (es. `w.length===0`) → scambiati per separatore markdown `===` su **741 di 136485 job page** → `audit:all` rc=1 → `validate-dist` rosso → rollback.

**Fix:** strip di `<script>`/`<style>` dal body estratto prima della detection (`CODE_BLOCK_RE`). Il codice non è body visibile. Verificato:
- pagina offender reale: `seps=["===","==="]` → dopo strip `seps=[]`
- markdown vero in testo visibile (`**bold**`, `===` standalone): **ancora rilevato** → gate intatto
- test esistente verde + **test di regressione aggiunto** (`===` JS in `<main>` non flaggato)

Gate NON indebolito (AGENTS.md #1): rimuove un falso positivo, non copertura.

## Non implementato (ancora)

- **Sibling auditor** (AGENTS.md #6): `audit-footer-root-presence.mjs` e `audit-salary-landing-template.mjs` estraggono anch'essi `<main>` ma **non** fanno pattern-match di `===`/`**`/run → codice inline non può falsarli → fuori scope per questa classe.
- **Issue strutturali dell'outage** (separate, a freddo): (1) CDN asset **additivi** invece di force-replace single-commit (elimina la race/clobber); (2) bug `deploy.yml` retry-cancel (l'action `deploy-pages` cancella il publish server-side sui 13GB al cap 10min e falsa-verde su deployment stale). Non in questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)