### PR TITLE
fix(deploy): additive CDN assets/ — stop clobbering in-flight entry hashes (outage root fix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -707,23 +707,56 @@ jobs:
             echo "no offloadable assets present — skipping CDN push"; exit 0
           fi
           printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"
-          echo "CDN payload: $(du -sh "$stage" | cut -f1)"
-          # Flag if the CDN repo nears the GitHub Pages ~1 GB published-site soft limit.
-          payload_bytes="$(du -sb "$stage" | cut -f1)"
-          if [ "$payload_bytes" -gt 950000000 ]; then
-            echo "::warning::CDN payload ${payload_bytes} bytes (>950 MB) — approaching GitHub Pages ~1 GB soft limit; consider splitting (e.g. keep blog heroes on jsDelivr)"
-          fi
           keyfile="$RUNNER_TEMP/cdn_deploy_key"
           printf '%s\n' "$CDN_DEPLOY_KEY" > "$keyfile" && chmod 600 "$keyfile"
           export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+          # ── Additive assets/ (anti-clobber) ──────────────────────────────────
+          # The bundler assets/ are CONTENT-HASHED (index-*.js / App-*.js etc) and
+          # therefore immutable: a given hash always holds identical bytes. The old
+          # force-push replaced the whole CDN repo each deploy, DELETING the entry
+          # hashes still referenced by the currently-live HTML — which, for the
+          # ~13 GB Pages site, keeps serving the previous build for the 10-20 min
+          # the new publish takes to propagate (and longer on a rollback). Result:
+          # live HTML → 404 on its own JS → SPA dead (prod outage 2026-06-04).
+          # Fix: carry forward the prior CDN assets/ and merge the new build ON TOP
+          # (cp -n never overwrites a freshly-built file), so old + new hashes
+          # coexist and any in-flight HTML keeps booting. og/data/images are
+          # same-path and fully refreshed above (overwrite is correct for them).
+          # Sparse + blob:none keeps the clone to the small assets/ tree only.
+          if [ -d "$stage/assets" ]; then
+            prev="$RUNNER_TEMP/cdn-prev"; rm -rf "$prev"
+            if git clone --depth 1 --filter=blob:none --sparse \
+                 git@github.com:valerielinc-ops/frontaliere-cdn.git "$prev" 2>/dev/null; then
+              git -C "$prev" sparse-checkout set assets 2>/dev/null || true
+              if [ -d "$prev/assets" ]; then
+                cp -rn "$prev/assets/." "$stage/assets/" 2>/dev/null || true
+                echo "additive CDN: carried forward prior assets/ (now $(ls -1 "$stage/assets" | wc -l) files)"
+              fi
+            else
+              echo "additive CDN: no prior CDN clone (first push / transient) — proceeding with new assets only"
+            fi
+            rm -rf "$prev"
+          fi
+          echo "CDN payload: $(du -sh "$stage" | cut -f1)"
+          # Flag if the CDN repo nears the GitHub Pages ~1 GB published-site soft limit.
+          # With additive assets/ the payload grows slowly across deploys (only NEW
+          # hashes accumulate; data/og/images are refreshed, not stacked). A separate
+          # zero-Claude janitor cron prunes assets/ hashes no longer referenced by
+          # any live sitemap page once past a grace window (follow-up).
+          payload_bytes="$(du -sb "$stage" | cut -f1)"
+          if [ "$payload_bytes" -gt 950000000 ]; then
+            echo "::warning::CDN payload ${payload_bytes} bytes (>950 MB) — approaching GitHub Pages ~1 GB soft limit; run the CDN assets/ janitor or split (e.g. keep blog heroes on jsDelivr)"
+          fi
           cd "$stage"
           git init -q
           git checkout -q -b main
           git config user.email "deploy-bot@frontaliereticino.ch"
           git config user.name "deploy-bot"
           git add -A
-          git commit -qm "cdn assets (og + data + assets) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          git commit -qm "cdn assets (og + data + additive assets) ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
           # Force-push a single fresh commit → CDN repo history never accumulates.
+          # Content is additive (prior assets/ merged above), so the force-push no
+          # longer clobbers in-flight entry hashes — it just flattens history.
           if git push -f git@github.com:valerielinc-ops/frontaliere-cdn.git main; then
             echo "CDN_BASE=https://cdn.frontaliereticino.ch" >> "$GITHUB_ENV"
             echo "✅ pushed assets to frontaliere-cdn"


### PR DESCRIPTION
## Implementato

Fix **strutturale** della causa radice dell'outage 2026-06-04 (SPA morta, entry `index-*.js`/`App-*.js` 404 sul CDN).

**Root cause:** lo step "Push generated assets to CDN repo" faceva `git init` + **`git push -f`** di un repo a commit-singolo ad ogni deploy → **cancellava** gli asset content-hashed ancora referenziati dall'HTML live. Per il sito ~13GB il publish Pages impiega 10-20min a propagare (di più su rollback), quindi il build live puntava a hash JS che il deploy successivo aveva già cancellato → 404 → SPA morta. **Ogni deploy che cambia gli hash del bundle ri-rompeva il sito.**

**Fix (Q1 additive):** gli `assets/` sono immutabili (content-hashed) → porto avanti gli `assets/` esistenti del CDN e fondo i nuovi sopra (`cp -n` non sovrascrive mai un file appena buildato). Vecchi + nuovi hash coesistono → qualsiasi HTML in volo continua a bootare. Clone `--sparse --filter=blob:none` limitato al solo albero `assets/` (veloce). `og/`/`data/`/`images/` restano full-refresh same-path (corretto). **Fail-safe:** se il clone fallisce → log + fallback al comportamento attuale (new-assets-only), mai peggio di oggi.

Tiene l'hashing (Q2): immutabilità → `Cache-Control: immutable`. I "buchi" venivano dalla cancellazione, non dall'hash.

## Non implementato (ancora)

- **Claim non validabile pre-merge** (modifica deploy-path, gira solo post-merge su `main`): se il prossimo deploy con questo step fallisce il CDN push o l'additive non preserva → **revert-trigger**: ripristinare il force-push fresco. Da osservare al primo deploy live (log "additive CDN: carried forward prior assets/").
- **GC della crescita `assets/`**: l'additive accumula hash vecchi. Crescita lenta (solo nuovi hash; data/og/images refreshati non impilati) + guard 950MB già presente. Janitor cron zero-Claude che pota gli hash non più referenziati da nessuna pagina-sitemap oltre una grace-window → **follow-up separato**.
- **Bug deploy.yml retry-cancel** (`deploy-pages` cancella il publish server-side al cap 10min sui 13GB + falsa-verde su deployment stale) → issue distinta, non in questa PR.

> ⚠️ Modifica `deploy.yml` → workflow-validation drift: reviewer non parte, merge manuale `gh pr merge --squash` (eccezione AGENTS.md). Da mergere DOPO che il sito è recuperato (#1424) e PRIMA di riabilitare deploy.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)