### PR TITLE
fix(deploy): publish via non-cancelled Pages API deployment (13GB publish wall — outage root fix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1308,8 +1308,45 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          # ── Root fix for the publish wall ────────────────────────────────
+          # Both deploy-pages attempts above CANCEL their Pages deployment at
+          # the action's 10-min polling cap — for the ~13 GB site the
+          # server-side file-sync routinely runs longer, so the publish never
+          # lands and the live build is stranded (prod outage 2026-06-04/05).
+          # Here we create a FRESH deployment straight through the Pages API
+          # (OIDC, in-workflow) from the already-uploaded github-pages
+          # artifact and NEVER cancel it — GitHub finishes the sync server-side
+          # in its own time. We then poll BOTH that api-versioned deployment
+          # and any sha-scoped deployment until one reports success.
+          ver=""
+          art=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+                  --jq '[.artifacts[] | select(.name=="github-pages" and .expired==false)][0].id // empty' 2>/dev/null || echo "")
+          oidc=$(curl -s "${ACTIONS_ID_TOKEN_REQUEST_URL}" \
+                  -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                  | jq -r '.value // empty' 2>/dev/null || echo "")
+          if [ -n "$art" ] && [ -n "$oidc" ]; then
+            ver="api-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            if printf '{"artifact_id":%s,"pages_build_version":"%s","oidc_token":"%s"}' "$art" "$ver" "$oidc" \
+                 | gh api -X POST "repos/${GITHUB_REPOSITORY}/pages/deployments" --input - >/dev/null 2>&1; then
+              echo "✅ created non-cancelled Pages deployment via API (version ${ver}, artifact ${art})"
+            else
+              echo "::warning::API deployment create failed (OIDC/permissions?) — falling back to polling deploy-pages deployments"
+              ver=""
+            fi
+          else
+            echo "::warning::no github-pages artifact_id ('${art}') or OIDC token — falling back to polling existing deployments"
+          fi
           deadline=$(( $(date +%s) + 40*60 ))
           while [ "$(date +%s)" -lt "$deadline" ]; do
+            # (a) our own non-cancelled API deployment, polled by version
+            if [ -n "$ver" ]; then
+              apist=$(gh api "repos/${GITHUB_REPOSITORY}/pages/deployments/${ver}" --jq '.status // empty' 2>/dev/null || echo "")
+              echo "$(date -u +%H:%M:%S) api deployment ${ver} status=${apist:-<none>}"
+              case "$apist" in
+                succeed) echo "✅ GitHub Pages published our build server-side (API, no cancel)."; exit 0 ;;
+              esac
+            fi
+            # (b) any deploy-pages deployment for this sha that completes anyway
             ids=$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=github-pages&sha=${GITHUB_SHA}&per_page=20" --jq '.[].id' 2>/dev/null || echo "")
             if [ -n "$ids" ]; then
               any_active=0
@@ -1323,12 +1360,13 @@ jobs:
                 # error/failure/in_progress/pending/<none> may still reach success → keep waiting
                 if [ "$st" != "inactive" ]; then any_active=1; fi
               done
-              if [ "$any_active" = "0" ]; then
+              # Only give up early on supersession when we have NO live API deployment of our own.
+              if [ "$any_active" = "0" ] && [ -z "$ver" ]; then
                 echo "::warning::All github-pages deployments for ${GITHUB_SHA} are inactive (superseded by a newer deploy) — not waiting further."
                 exit 1
               fi
             else
-              echo "$(date -u +%H:%M:%S) no github-pages deployment for ${GITHUB_SHA} yet — waiting"
+              echo "$(date -u +%H:%M:%S) no sha-scoped github-pages deployment for ${GITHUB_SHA} yet — waiting"
             fi
             sleep 60
           done


### PR DESCRIPTION
## Implementato

Risolve la causa radice del muro di publish che ha tenuto giù il sito (outage 2026-06-04/05).

**Problema:** entrambi i tentativi `actions/deploy-pages` **cancellano** il loro Pages deployment al cap 10min dell'action. Per il sito ~13GB il file-sync server-side supera spesso i 10min → il publish viene cancellato prima di completare → il build live resta orfano. In più il vecchio extended-poll **falsa-verde** matchando un deployment stale dello stesso SHA → "success" senza publish reale.

**Fix:** lo step extended-poll ora PRIMA crea un deployment **fresco via Pages API diretta** (OIDC mintato in-workflow con `id-token: write`, dall'artifact `github-pages` già caricato dal build) e **non lo cancella mai**, poi polla quel deployment (per versione `api-<sha>-<run>-<attempt>`) + quelli per-SHA finché uno è `succeed`. GitHub completa il sync 13GB server-side con i suoi tempi.

- **Additivo + fail-safe:** se OIDC/API-create fallisce → fallback al comportamento sha-poll precedente (zero regressione).
- Si combina con l'**additive-CDN** (#1426): un publish lento non può più orfanare il sito.

## Non implementato (ancora)

- **Claim non validabile pre-merge** (modifica deploy-path, gira solo post-merge su main; OIDC/Pages-API non testabili sul `pull_request`): **revert-trigger** dichiarato — se il prossimo deploy mostra `API deployment create failed` nel log dello step o non pubblica, il fallback sha-poll preserva il comportamento attuale; se regredisce → revert. Da osservare al primo deploy live (cerca `created non-cancelled Pages deployment via API`).
- Riduzione size dist (thin moderato) accantonata su scelta utente: si punta a far completare il publish 13GB invece di ridurlo.

> ⚠️ Modifica `deploy.yml` → workflow-validation drift: reviewer non parte → merge manuale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)