### PR TITLE
fix(crawlers): transient fetch failure → soft-skip instead of false-positive Crawler Failure (#1332)

### DIFF
--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -585,7 +585,28 @@ export async function runStandardCrawlerPipeline(config) {
 
   // ─── Step 2: Fetch ──────────────────────────────────────────
   // Parser returns source-locale jobs only. DO NOT set non-source locale fields.
-  const parsedJobs = await fetchJobs();
+  let parsedJobs;
+  try {
+    parsedJobs = await fetchJobs();
+  } catch (err) {
+    // A purely transient network failure (source briefly unreachable — a burst
+    // of these hits the evening dispatch wave when many crawlers run at once)
+    // must NOT hard-fail the run. Exiting 1 here opens a noisy per-run "Crawler
+    // Failure" issue even though the same source crawls fine minutes later
+    // (#1393-#1437, all `crawler-transient`). Treat it like the empty case:
+    // keep the existing slice and exit cleanly. A genuinely persistent outage is
+    // still surfaced by the crawler-health monitor (stale after 7d / broken),
+    // because this early return — like the no-jobs path — writes no fresh
+    // summary. Structural errors (parse bugs, 4xx) still throw → real failure.
+    if (isTransientFetchError(err)) {
+      console.log(
+        `\n⚠️ ${companyLabel}: transient fetch failure (${err?.message || err}). ` +
+          'Keeping existing jobs, skipping this run (no false-positive failure).',
+      );
+      return;
+    }
+    throw err;
+  }
 
   if (!parsedJobs || parsedJobs.length === 0) {
     console.log(`\n⚠️ No ${companyLabel} jobs discovered. Keeping existing jobs.`);

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -35,6 +35,7 @@ import {
   inferSkyguideCanton,
   buildSkyguideLocalizedContent,
 } from './lib/skyguide-job-parser.mjs';
+import { isTransientFetchError } from './lib/transient-fetch.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -385,6 +386,16 @@ async function main() {
 }
 
 main().catch((err) => {
+  // Skyguide runs a bespoke pipeline (not crawler-template), so apply the same
+  // transient-skip guard here: a network blip must not open a false-positive
+  // "Crawler Failure" issue (#1404). Persistent outages are still caught by the
+  // crawler-health monitor (stale/broken). Structural errors still exit 1.
+  if (isTransientFetchError(err)) {
+    console.warn(
+      `⚠️ Skyguide: transient fetch failure (${err?.message || err}). Keeping existing jobs, skipping this run.`,
+    );
+    process.exit(0);
+  }
   console.error(`❌ Skyguide crawler failed: ${err?.message || err}`);
   process.exit(1);
 });

--- a/tests/crawler-template-transient-skip.test.ts
+++ b/tests/crawler-template-transient-skip.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error — JS module without types
+import { runStandardCrawlerPipeline } from '../scripts/lib/crawler-template.mjs';
+
+/**
+ * A transient network failure during fetch must NOT hard-fail the run (that
+ * opens a noisy per-run "Crawler Failure" issue while the source is fine minutes
+ * later). It should keep the existing slice and return cleanly. Structural
+ * errors must still propagate so a genuine bug surfaces.
+ */
+describe('runStandardCrawlerPipeline transient-fetch handling', () => {
+  let root: string;
+  const COMPANY_KEY = 'acme-test';
+  const existingJob = {
+    id: 'acme-test-1',
+    slug: 'existing-role-acme',
+    company: 'Acme Test',
+    companyKey: COMPANY_KEY,
+    title: 'Existing Role',
+    url: 'https://acme.example/jobs/existing',
+    postedDate: '2026-06-01',
+  };
+  const isCompanyJob = (job: any) => job?.companyKey === COMPANY_KEY;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'crawler-tpl-'));
+    fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'data', 'jobs.json'),
+      `${JSON.stringify([existingJob], null, 2)}\n`,
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const baseConfig = (fetchJobs: () => Promise<any[]>) => ({
+    companyKey: COMPANY_KEY,
+    companyLabel: 'Acme Test',
+    root,
+    fetchJobs,
+    isCompanyJob,
+  });
+
+  it('keeps the existing slice and does not throw on a transient fetch failure', async () => {
+    const fetchJobs = async () => {
+      throw new Error('Failed to fetch https://acme.example/search: fetch failed');
+    };
+    await expect(runStandardCrawlerPipeline(baseConfig(fetchJobs))).resolves.toBeUndefined();
+    const after = JSON.parse(fs.readFileSync(path.join(root, 'data', 'jobs.json'), 'utf-8'));
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe('acme-test-1');
+  });
+
+  it('re-throws a structural (non-transient) error', async () => {
+    const fetchJobs = async () => {
+      throw new TypeError("Cannot read properties of undefined (reading 'title')");
+    };
+    await expect(runStandardCrawlerPipeline(baseConfig(fetchJobs))).rejects.toThrow(
+      /Cannot read properties/,
+    );
+  });
+});


### PR DESCRIPTION
## Implementato

Elimina alla radice la raffica di issue **"Crawler Failure: Update X (Dedicated)"** (`crawler-transient`: #1393–#1437, ~26 aperte, con duplicati CSVP/SVAR).

**Diagnosi:** non sono breakage per-parser — gli stessi crawler vanno `success` ai wave mattutini e falliscono nel **wave serale (~22:00 UTC)**, dove tanti crawler girano insieme → burst di `fetch failed` (blip rete transitori). Ogni crawler, esaurite le 3 retry, faceva `throw → process.exit(1)` → workflow failed → issue. (Tecan/Nestlé/Octapharma/Schindler/CSVP: tutti `❌ crawler failed: ... fetch failed`.)

**Fix (class-complete):** in `runStandardCrawlerPipeline` (condiviso da **293 crawler**), il fetch è ora in try/catch: su errore **transient** (`isTransientFetchError` — già classifica `fetch failed`/`ECONN*`/timeout wrappati, vedi `transient-fetch.mjs`) → log + **preserva la slice esistente + return pulito** (exit 0), identico al path "no jobs discovered". Errori **strutturali** (parse bug, 4xx) → `throw` come prima (failure legittima).

Doppia rete di sicurezza: l'early-return non scrive summary fresco → un'outage **persistente** è comunque catturata dal crawler-health monitor (stale 7gg / broken). Quindi si elimina solo il rumore per-run, non il segnale reale.

Stessa guard aggiunta a **skyguide** (#1404, pipeline bespoke fuori dal template).

**Test:** `tests/crawler-template-transient-skip.test.ts` — la pipeline preserva la slice e risolve senza throw su errore transient; ri-throw su errore strutturale. 2/2 verde. Classifier verificato sui 5 messaggi di errore reali.

## Non implementato (ancora)

- **Chiusura delle ~26 issue transient esistenti**: il fix previene le NUOVE, ma le aperte vanno chiuse a parte → le bulk-chiudo dopo il merge (referenziando questa PR), così il wave serale non ne riapre nel frattempo.
- **Dedup (CSVP 3×, SVAR 2×)**: reso **moot** dal fix (le issue non vengono più aperte). Non tocco la logica di dedup di `github-issue-creator`.
- **Altri crawler bespoke** (non-template) con `main().catch(exit 1)` proprio: coperto skyguide (failure corrente); altri adotteranno lo stesso pattern se emergono — non li tocco speculativamente.

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
