### PR TITLE
ci(ops): auto-close validation/build/deploy issues when the gate goes green

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1151,8 +1151,25 @@ jobs:
           **Branch:** ${{ github.ref_name }}
           **Trigger:** ${{ github.event_name }}" \
             --priority 1 \
+            --reopen-within-hours 6 \
             --label Bug \
             --workflow "${{ github.workflow }}"
+
+      - name: Resolve build GitHub Issue on success
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Build succeeded → close the canonical "CI Failure (build)" issue if
+          # open. Paired with --reopen-within-hours 6 on the reporter above so the
+          # close↔reopen cycle stays on ONE canonical issue (no per-run storm,
+          # no stale issue while green). Idempotent no-op when nothing is open.
+          node scripts/lib/github-issue-creator.mjs \
+            --resolve \
+            --title "CI Failure (build): ${{ github.workflow }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ───────────────────────────────────────────────────────────────────────
   # deploy: publish dist/ to GitHub Pages (actions/deploy-pages reads the
@@ -1404,8 +1421,24 @@ jobs:
           **Branch:** ${{ github.ref_name }}
           **Trigger:** ${{ github.event_name }}" \
             --priority 1 \
+            --reopen-within-hours 6 \
             --label Bug \
             --workflow "${{ github.workflow }}"
+
+      - name: Resolve deploy GitHub Issue on success
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Deploy succeeded → close the canonical "CI Failure (deploy)" issue if
+          # open. Paired with --reopen-within-hours 6 above so close↔reopen stay
+          # on ONE canonical issue. Idempotent no-op when nothing is open.
+          node scripts/lib/github-issue-creator.mjs \
+            --resolve \
+            --title "CI Failure (deploy): ${{ github.workflow }}" \
+            --workflow "${{ github.workflow }}" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ───────────────────────────────────────────────────────────────────────
   # validate-dist: dist-side gates (bfs-depth, text-html-ratio, ...).

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -566,3 +566,20 @@ jobs:
             --reopen-within-hours 6 \
             --label Bug \
             --workflow "Post-deploy Validate Dist"
+
+      - name: Resolve GitHub Issue on success
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mirror of the failure reporter: every gating step above passed, so
+          # close the canonical "Validation Failure (dist)" issue if it is open.
+          # Without this the issue stays open while the state is already green
+          # (stale-issue churn). Idempotent no-op when nothing is open; the
+          # failure reporter's --reopen-within-hours 6 reopens it on a re-flap.
+          node scripts/lib/github-issue-creator.mjs \
+            --resolve \
+            --title "Validation Failure (dist): post-deploy" \
+            --workflow "Post-deploy Validate Dist" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -318,3 +318,19 @@ jobs:
             --reopen-within-hours 6 \
             --label Bug \
             --workflow "Post-deploy Validate Live"
+
+      - name: Resolve GitHub Issue on success
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mirror of the failure reporter: live validation passed, so close the
+          # canonical "Validation Failure (live)" issue if open — no stale issue
+          # while the state is green. Idempotent; reopens on a re-flap via the
+          # failure reporter's --reopen-within-hours 6.
+          node scripts/lib/github-issue-creator.mjs \
+            --resolve \
+            --title "Validation Failure (live): post-deploy" \
+            --workflow "Post-deploy Validate Live" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/lib/github-issue-creator.mjs
+++ b/scripts/lib/github-issue-creator.mjs
@@ -187,6 +187,53 @@ function setIssuePriorityLabel(issueNumber, targetPriorityLabel, extraAdd = []) 
 }
 
 /**
+ * Resolve (close) the canonical OPEN issue with the given stable title prefix.
+ *
+ * The mirror of the `reopenWithinHours` flap-collapse logic: failure reporters
+ * REOPEN the canonical issue on red, so a green run must CLOSE it again —
+ * otherwise the issue stays open while the state is already OK (stale-issue
+ * churn). Idempotent: a no-op when no matching OPEN issue exists, so it's safe
+ * to run on every green pass. Best-effort — never throws; returns the closed
+ * issue ref or null.
+ *
+ * @param {string} titlePrefix  Stable title (first DEDUP_TITLE_PREFIX_LEN chars
+ *                              are matched, exactly as createGithubIssue dedups).
+ * @param {{ workflow?: string, runUrl?: string }} [ctx]
+ */
+export function resolveGithubIssue(titlePrefix, { workflow, runUrl } = {}) {
+  if (process.env.ENABLE_FAILURE_REPORT === 'false') {
+    console.log('[github-issue-creator] ENABLE_FAILURE_REPORT=false, skipping resolve');
+    return null;
+  }
+  if (!titlePrefix) {
+    console.error('[github-issue-creator] resolve: title is required');
+    return null;
+  }
+  const prefix = titlePrefix.slice(0, DEDUP_TITLE_PREFIX_LEN);
+  const existing = findOpenIssueByTitlePrefix(prefix);
+  if (!existing) {
+    console.log(`[github-issue-creator] resolve: no open issue matching "${prefix}" — nothing to close`);
+    return null;
+  }
+  const note = [
+    '✅ Auto-resolved — the failing check is green again' + (workflow ? ` (${workflow})` : '') + '.',
+    runUrl ? `\nGreen run: ${runUrl}` : '',
+    '\nClosed automatically; it will reopen if the same failure recurs.',
+  ].join('');
+  gh(['issue', 'comment', String(existing.number), '--body', note, ...repoFlag()], { allowFailure: true });
+  const closed = gh(
+    ['issue', 'close', String(existing.number), '--reason', 'completed', ...repoFlag()],
+    { allowFailure: true },
+  );
+  if (closed !== null) {
+    console.log(`[github-issue-creator] resolve: closed #${existing.number} — ${existing.title}`);
+    return { number: existing.number, title: existing.title, url: existing.url };
+  }
+  console.error(`[github-issue-creator] resolve: could not close #${existing.number} (best-effort)`);
+  return null;
+}
+
+/**
  * Create a GitHub issue, or comment on an existing open duplicate.
  */
 export async function createGithubIssue({
@@ -381,8 +428,16 @@ if (process.argv[1]?.endsWith('github-issue-creator.mjs')) {
 
   const title = get('--title');
   if (!title) {
-    console.error('Usage: node github-issue-creator.mjs --title "..." [--description "..."] [--priority N] [--label Bug] [--workflow "Update Coop"] [--reopen-within-hours N] [--consecutive-gate N] [--gate-window-hours H]');
+    console.error('Usage: node github-issue-creator.mjs --title "..." [--description "..."] [--priority N] [--label Bug] [--workflow "Update Coop"] [--reopen-within-hours N] [--consecutive-gate N] [--gate-window-hours H] [--resolve]');
     process.exit(1);
+  }
+
+  // --resolve: close the OPEN canonical issue with this stable title (green run).
+  // Mirror of the failure reporter; runs from `if: success()` steps so a recovered
+  // gate doesn't leave a stale open issue. Best-effort, always exits 0.
+  if (args.includes('--resolve')) {
+    resolveGithubIssue(title, { workflow: get('--workflow'), runUrl: get('--run-url') });
+    process.exit(0);
   }
 
   // --consecutive-gate: N>0 forces the gate (escalate on the Nth failure);

--- a/tests/github-issue-resolve.test.ts
+++ b/tests/github-issue-resolve.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock `gh` invocations, routed by sub-command — same approach as
+// github-issue-creator-gate.test.ts.
+const execFileSync = vi.fn();
+vi.mock('node:child_process', () => {
+  const mock = { execFileSync: (...args: unknown[]) => execFileSync(...args) };
+  return { ...mock, default: mock };
+});
+
+const { resolveGithubIssue } = await import('../scripts/lib/github-issue-creator.mjs');
+
+function ghCalls(): string[][] {
+  return execFileSync.mock.calls
+    .filter((c) => c[0] === 'gh')
+    .map((c) => c[1] as string[]);
+}
+
+beforeEach(() => {
+  execFileSync.mockReset();
+  delete process.env.GH_REPO;
+  delete process.env.ENABLE_FAILURE_REPORT;
+});
+
+describe('resolveGithubIssue — close canonical issue on green', () => {
+  it('closes the OPEN canonical issue (comment + close --reason completed)', () => {
+    execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'list') {
+        return JSON.stringify([
+          { number: 1247, title: 'Validation Failure (dist): post-deploy', url: 'u', state: 'OPEN' },
+        ]);
+      }
+      return ''; // comment + close succeed
+    });
+
+    const res = resolveGithubIssue('Validation Failure (dist): post-deploy', {
+      workflow: 'Post-deploy Validate Dist',
+      runUrl: 'https://example/run/1',
+    });
+
+    expect(res?.number).toBe(1247);
+    const calls = ghCalls();
+    const close = calls.find((a) => a[0] === 'issue' && a[1] === 'close');
+    expect(close).toBeTruthy();
+    expect(close).toContain('1247');
+    expect(close).toContain('--reason');
+    expect(close).toContain('completed');
+    const comment = calls.find((a) => a[0] === 'issue' && a[1] === 'comment');
+    expect(comment?.[2]).toBe('1247');
+  });
+
+  it('is a no-op when no matching OPEN issue exists', () => {
+    execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'list') return '[]';
+      return '';
+    });
+
+    const res = resolveGithubIssue('CI Failure (build): Deploy to GitHub Pages', {});
+
+    expect(res).toBeNull();
+    expect(ghCalls().some((a) => a[1] === 'close')).toBe(false);
+  });
+
+  it('only matches an exact stable-title prefix, not a fuzzy token hit', () => {
+    // gh search is fuzzy: a "(live)" issue must not be closed by a "(dist)" green.
+    execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'issue' && args[1] === 'list') {
+        return JSON.stringify([
+          { number: 800, title: 'Validation Failure (live): post-deploy', url: 'u', state: 'OPEN' },
+        ]);
+      }
+      return '';
+    });
+
+    const res = resolveGithubIssue('Validation Failure (dist): post-deploy', {});
+
+    expect(res).toBeNull();
+    expect(ghCalls().some((a) => a[1] === 'close')).toBe(false);
+  });
+
+  it('respects ENABLE_FAILURE_REPORT=false (skips entirely)', () => {
+    process.env.ENABLE_FAILURE_REPORT = 'false';
+    const res = resolveGithubIssue('Validation Failure (dist): post-deploy', {});
+    expect(res).toBeNull();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Implementato

Le segnalazioni di fallimento (validate-dist, validate-live, build, deploy) **riaprivano** la issue canonica sul rosso (`--reopen-within-hours 6`) ma **niente la chiudeva sul verde** → issue come #1247 (`Validation Failure (dist): post-deploy`) e #1299 (`CI Failure (build): ...`) restavano aperte mentre lo stato era già OK (stale-issue churn). Questa PR aggiunge la metà mancante del ciclo flap-collapse.

- **`resolveGithubIssue()` + CLI `--resolve`** in `scripts/lib/github-issue-creator.mjs`: chiude la issue canonica **OPEN** (match esatto sul prefisso stabile del titolo, commento ✅ + `issue close --reason completed`). Idempotente: no-op quando non c'è nulla di aperto; best-effort, esce sempre 0. Il match è prefix-esatto → un verde `(dist)` non chiude mai una issue `(live)`.
- **Step `if: success()`** che chiamano `--resolve` aggiunti a `post-deploy-validate-dist.yml`, `post-deploy-validate-live.yml`, e `deploy.yml` (job `build` e `deploy`). Girano solo se tutti gli step gating del job sono passati.
- **Close-on-green accoppiato a reopen-on-reflap**: aggiunto `--reopen-within-hours 6` ai reporter `build` + `deploy` (dist/live ce l'avevano già) così il ciclo chiudi↔riapri resta su **UNA** issue canonica invece di generarne una nuova a ogni fallimento.
- **Chiuse subito** le 2 stale (#1247, #1299) dogfoodando il nuovo `--resolve` contro l'ultimo deploy verde (run 26994626740).

Zero-Claude (solo `gh` CLI), coerente con la frugalità quota.

Verificato: `tests/github-issue-resolve.test.ts` (close / no-op / fuzzy-exactness / `ENABLE_FAILURE_REPORT=false` skip) + gate test esistente verdi (8 test); `node --check` lib OK; YAML dei 3 workflow valido (python `yaml.safe_load`).

## Non implementato (ancora)

- **Auto-close di altri reporter** (rollback `Rollback: post-deploy`, crawler-failure, validation-failure non-deploy): non toccati — alcuni hanno già self-heal proprio (traffic-data-freshness, crawler-health-monitor), altri sono per-evento strategici. Estensione possibile come follow-up se emergono altre stale.
- **Backfill storico**: non chiudo in massa vecchie validation-failure già risolte oltre #1247/#1299; il meccanismo le coprirà al prossimo verde se riaperte, oppure vanno triagiate a mano (strategiche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)