### PR TITLE
fix(cdn): stop rebasing public/ assets to CDN — favicon/PWA/manifest/fonts/llms/ai-plugin 404 every page

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -321,10 +321,20 @@ export default defineConfig(({ mode }) => {
  ...(ASSET_CDN
  ? {
  experimental: {
- renderBuiltUrl(filename: string) {
- // filename is output-relative, e.g. "assets/index-abc.js" → served
- // from the CDN repo at the same path.
- return `${ASSET_CDN}/${filename}`;
+ renderBuiltUrl(filename: string, { type }: { type: 'asset' | 'public' }) {
+ // Only BUNDLER-emitted assets (dist/assets/* JS/CSS/chunks) are pushed to the
+ // CDN, so only those may be rebased. public/* files — favicon, PWA icons,
+ // manifest.webmanifest, fonts, llms.txt, AND /.well-known/ai-plugin.json — are
+ // copied as-is and MUST stay same-origin: they are NOT on the CDN (rebasing
+ // 404s every page) and several are origin-bound by contract (AI/plugin
+ // discovery + the PWA manifest & its icons). #1293's blanket rebase sent them
+ // all to the CDN (incl. a malformed `${ASSET_CDN}//fonts/…` double slash from
+ // @font-face url(/fonts/…)); scoping to `type === 'asset'` fixes the whole class.
+ // public assets → same-origin absolute (matches the pre-#1293 base '/' default;
+ // strip a leading slash so a CSS `url(/fonts/…)` filename doesn't double it).
+ if (type !== 'asset') return `/${filename.replace(/^\/+/, '')}`;
+ // bundler assets → CDN, same output-relative path (e.g. "assets/index-abc.js").
+ return `${ASSET_CDN}/${filename.replace(/^\/+/, '')}`;
  },
  },
  }


### PR DESCRIPTION
## Implementato

Fix di un bug **pre-esistente (#1293, live dal 2026-06-03)** trovato durante la verifica live della migrazione CDN: `vite.config renderBuiltUrl` ribasava **OGNI** URL buildato a `${ASSET_CDN}`, inclusi i file `public/*` che **NON sono pushati sul CDN** (il push copre solo og/data/assets/images-blog). Su **ogni pagina**:

```
cdn.frontaliereticino.ch/fonts/{inter,space-grotesk}-latin.woff2  → 404
cdn.frontaliereticino.ch//fonts/...                               → 404 (double-slash malformato da @font-face url(/fonts/...))
cdn.frontaliereticino.ch/favicon.{ico,svg}, /icons/*, /og-image.* → 404
cdn.frontaliereticino.ch/manifest.webmanifest                     → 404 (PWA rotta)
cdn.frontaliereticino.ch/llms.txt, /llms-full.txt                 → 404
cdn.frontaliereticino.ch/.well-known/ai-plugin.json               → 404 (AI discovery rotta)
```
Tutti servono **200 same-origin**; l'HTML li punta al CDN. Impatto: brand font → fallback system, PWA install/icone rotte, e `llms.txt`+`ai-plugin.json` (origin-bound by contract — i crawler li prendono dal dominio principale, MAI dal CDN) spariti.

**Perché same-origin e non push-su-CDN**: manifest+icone (PWA) e `.well-known/ai-plugin.json`+`llms.txt` (discovery) DEVONO stare sul dominio principale. Pusharli su CDN romperebbe PWA + AI-discovery. I font sono ~140KB (negligibile) → coerente tenerli con gli altri public same-origin.

**Fix**: scope di `renderBuiltUrl` a `type === 'asset'` (il bundle JS/CSS che È pushato sul CDN). I `type === 'public'` ritornano il path same-origin assoluto (comportamento base `'/'` pre-#1293), con strip del leading-slash così un `url(/fonts/...)` CSS non lo raddoppia. L'offload bundler/asset + il delete di `dist/assets` restano invariati.

**Verifica**: logica testata (7/7: asset→CDN, fonts/favicon/icons/manifest/llms/ai-plugin→same-origin) + `tsc` pulito. La migrazione data #1344 + thumbnails #1354 è stata verificata live PULITA (0 img rotte, srcSet→CDN, 0 richieste same-origin /data o /images/blog, 0 errori console su blog/health).

## Non implementato (ancora)

- **Validazione build non possibile pre-merge** (`build:ci` OOM-prone gira solo post-merge su `main`; `renderBuiltUrl` è build-critical). **Revert-trigger**: se il prossimo deploy build fallisce, o i ref `/assets/` smettono di puntare al CDN, o i public asset non tornano 200 same-origin → revert. Verifica post-deploy: `curl -I cdn.frontaliereticino.ch/assets/<hash>.js` (200, asset ancora su CDN) + `curl -I frontaliereticino.ch/{favicon.ico,manifest.webmanifest,fonts/inter-latin.woff2,.well-known/ai-plugin.json}` tutti 200 + nessun ref `cdn.../fonts|favicon|manifest|llms` nell'HTML servito.
- **Riduzione artifact: N/A** — i public asset (favicon/fonts/icone/manifest/llms, pochi 100KB) RESTANO same-origin nell'artifact di proposito (devono esserlo). Nessun impatto sui 111MB già offloadati (data+thumbnails).
