### PR TITLE
fix(generate-article): exclude frontaliere-specific topics from national svizzera selection

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -367,6 +367,7 @@ NON è rilevante:
 - Eventi culturali, sportivi, festival, gastronomia
 - Notizie estere senza impatto diretto su chi vive o lavora in Svizzera
 - Singoli episodi di cronaca (multe, incidenti, arresti)
+- Temi SPECIFICI DEI FRONTALIERI Italia-Svizzera (appartengono a una sezione separata, NON a quella nazionale): permesso G/B/C per frontalieri, ristorni Ticino-Italia, imposta alla fonte/tassazione frontalieri, dogane/valichi e pendolarismo Italia-Svizzera, telelavoro frontalieri, accordo frontalieri Italia-Svizzera, soglia 20 km. In questa sezione nazionale sarebbero duplicati fuori scopo
 
 HEADLINE: ${String(headline || '').slice(0, 240)}
 ${summary ? `SOMMARIO: ${String(summary).slice(0, 320)}\n` : ''}
@@ -1448,6 +1449,7 @@ CRITERI DI SELEZIONE (in ordine di priorità):
 5. NO SPORT: Evita risultati sportivi, partite, campionati
 6. NO INTRATTENIMENTO: Evita gossip, spettacolo, celebrità senza rilevanza politico-economica
 7. RESPIRO NAZIONALE: La notizia può riguardare qualsiasi cantone o le istituzioni federali; non limitarti al Ticino.
+8. ⚠️ NO TEMI FRONTALIERI (CRITICO): SCARTA le headline su temi specifici dei frontalieri Italia-Svizzera (permesso G/B/C, ristorni Ticino-Italia, imposta alla fonte frontalieri, dogane/valichi e pendolarismo IT-CH, telelavoro frontalieri, accordo frontalieri IT-CH, soglia 20 km). Appartengono alla sezione frontalieri separata; qui sarebbero duplicati fuori scopo. Scegli temi a interesse nazionale generale.
 
 Rispondi con un JSON object (no markdown, no code fences):
 {


### PR DESCRIPTION
## Implementato

Verifica live post-fix-framing: la sezione svizzera (nazionale) **generava ancora articoli a TOPIC frontaliere** ("Permesso G vs B frontalieri 2026: oltre 20 km", "Frontalieri in Svizzera" — 68× frontalieri nel body). Il framing nazionale funziona (es. "Svizzera respinge dazi USA su lavoro forzato" = nazionale corretto, 3× frontalieri), ma il gap è la **selezione del topic**: classifier + headline-selection svizzera accettano i temi frontaliere perché "i frontalieri lavorano in Svizzera" → passano la rilevanza nazionale. Le sorgenti (`NEWS_SOURCES_SVIZZERA`) sono già feed nazionali corretti.

Aggiungo un'**esclusione esplicita dei temi frontaliere-specifici** a entrambi i branch svizzera:
- **classifier** (`classifyFrontaliereRelevance`, branch svizzera): nuova voce "NON è rilevante" → permesso G/B/C frontalieri, ristorni Ticino-Italia, imposta alla fonte frontalieri, dogane/valichi e pendolarismo IT-CH, telelavoro frontalieri, accordo frontalieri IT-CH, soglia 20 km.
- **headline-selection** (`HEADLINE_SELECTION_PROMPT`, branch svizzera): criterio 8 "NO TEMI FRONTALIERI (CRITICO): SCARTA queste headline".

Questi temi appartengono alla sezione frontalieri separata; nella sezione nazionale sarebbero **duplicati fuori scopo**. Branch frontaliere intatto. node --check OK; smoke svizzera pulito.

## Non implementato (ancora)

- **Articoli svizzera frontaliere-topic già pubblicati** (Permesso G vs B, Frontalieri in Svizzera, Festività in Ticino): lasciati live per scelta owner (i FUTURI saranno nazionali). Rigenerazione/cleanup separato se richiesto.
- Il fact-check gate svizzera (punto 11) accetta rilevanza nazionale e non ri-FAIL un topic frontaliere che sfuggisse: la difesa è alla selezione (classifier+headline), sufficiente; il fact-check resta gate di sola rilevanza nazionale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
