### PR TITLE
chore(deploy): strip build-debug .write-collisions from the Pages artifact (~2.9MB)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -972,6 +972,8 @@ jobs:
             -cf "$RUNNER_TEMP/artifact.tar" \
             --exclude=.git \
             --exclude=.github \
+            --exclude=.write-collisions.json \
+            --exclude=.write-collisions-data \
             .
           # Surface size early so a regression past the 1 GB Pages
           # threshold is visible in the workflow log right after pack


### PR DESCRIPTION
## Implementato

Esclude i file **debug di build** `dist/.write-collisions.json` (~2.9MB) + `dist/.write-collisions-data/` dal **Pages artifact** (prod), dove erano spediti e serviti live (200) senza servire a nulla sul sito.

- **Scritti da**: `writeRegistryLifecyclePlugin` (closeBundle) — diagnostica collisioni di write durante il build.
- **Consumer reali (preservati)**: solo offline — `scripts/analyze-write-collisions.mjs` (legge da `dist/` locale o dall'artifact CI) + lo step esistente **`Upload write-collisions analysis`** (`deploy.yml`) che li carica come **GitHub Actions artifact** `write-collisions-analysis-<run_id>` (retention 7gg). `audit-spa-bundle-injection.mjs` e `jobsSeoPagesPlugin.ts` li citano solo in **commenti/messaggi** (dicono "scarica l'artifact su CI"), nessuna dipendenza pipeline.
- **Fix**: 2 `--exclude` allo step `Pack dist/ into Pages tar archive` → esclusi da `artifact.tar` (il Pages artifact) **senza toccare `dist/`** → l'Actions-upload a valle li cattura ancora per `npm run analyze:write-collisions`.

**Verifica**: test tar locale → `.write-collisions{.json,-data}` esclusi, contenuto reale (`index.html`) incluso; replica esatta degli `--exclude` già presenti (`.git`/`.github`, basename match). `dist/` invariato → step Actions-upload (legge `dist/.write-collisions.json`) intatto. YAML valido.

## Non implementato (ancora)

- **Validazione live post-merge** (l'effetto si vede solo nel deploy su `main`): dopo il prossimo deploy, `curl -I https://frontaliereticino.ch/.write-collisions.json` deve dare **404** (non più servito) e l'artifact `write-collisions-analysis-<run_id>` deve restare scaricabile (`gh run download`). Riduzione artifact attesa ~2.9MB. Zero rischio funzionale (file non referenziato da nessuna pagina).
