### PR TITLE
fix(crawlers): retry Jina egress on a fresh IP to beat sgcaptcha WAF (#1363)

### DIFF
--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -51,6 +51,71 @@ export async function fetchViaJina(targetUrl, { timeoutMs = 30000, fetchImpl = f
 }
 
 /**
+ * Fetch a URL through the Jina proxy, retrying on a fresh Jina egress IP when the
+ * response is a WAF challenge / non-target page (not the real page).
+ *
+ * Why this exists: the IP-reputation WAF (SiteGround sgcaptcha, cambiavalute.ch
+ * #1363) flags a *subset* of Jina Reader's IP pool. A SINGLE `fetchViaJina` call
+ * therefore succeeds ~80% of the time and lands on a blocked IP the other ~20%,
+ * getting an HTTP 200 with a challenge body → `detectJinaErrorBody` flags it but
+ * the single-shot callers could only log + skip → 0 jobs on an unlucky run even
+ * though the source is live. Jina rotates its egress IP per request, so simply
+ * retrying picks a fresh IP: 4 attempts at ~80%/try ≈ 99.8% success. Each retry
+ * is a brand-new request (no IP affinity to pin), which is the whole point.
+ *
+ * Returns a fresh, unconsumed `Response` (body already validated and re-wrapped,
+ * so callers can still `.text()` it). On exhaustion it returns the LAST response
+ * shape (status + body) unchanged, so every caller's existing
+ * `res.ok` / `detectJinaErrorBody` graceful-skip path runs as before — this never
+ * throws of its own accord and never converts a dead source into a hard failure.
+ */
+export async function fetchViaJinaWithRetry(
+  targetUrl,
+  { timeoutMs = 30000, attempts = 4, retryDelayMs = 800, fetchImpl = fetch } = {},
+) {
+  let lastBody = '';
+  let lastStatus = 0;
+  let lastReason = 'no attempt made';
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const res = await fetchViaJina(targetUrl, { timeoutMs, fetchImpl });
+      lastStatus = res.status;
+      if (!res.ok) {
+        // Jina's own non-2xx (rate limit / upstream) — a fresh IP may fare better.
+        lastBody = '';
+        lastReason = `HTTP ${res.status}`;
+      } else {
+        const body = await res.text();
+        lastBody = body;
+        const reason = detectJinaErrorBody(body);
+        if (!reason) {
+          // Real target page from a non-blocked Jina IP.
+          return new Response(body, {
+            status: 200,
+            headers: { 'content-type': res.headers.get('content-type') || 'text/html' },
+          });
+        }
+        lastReason = reason;
+      }
+    } catch (err) {
+      lastReason = err?.message || String(err);
+    }
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
+    }
+  }
+  // Every attempt hit a blocked IP / error. Hand back the last response shape so
+  // the caller's unchanged graceful-skip path takes over (no false failure).
+  return new Response(lastBody, {
+    status: lastStatus || 502,
+    headers: {
+      'content-type': 'text/html',
+      'x-jina-retry-reason': String(lastReason).slice(0, 120),
+    },
+  });
+}
+
+/**
  * Jina answers HTTP 200 even when it could not actually serve the target page:
  * an upstream failure (target unreachable from Jina, a challenge/error page, or
  * a rate-limit notice) comes back as a 200 with a non-target body. `res.ok` is
@@ -88,6 +153,13 @@ export function detectJinaErrorBody(body, { minLength = 200 } = {}) {
     'attention required!',
     'checking your browser before accessing',
     'enable javascript and cookies to continue',
+    // SiteGround "sgcaptcha" IP-reputation challenge (cambiavalute.ch, #1363):
+    // a meta-refresh to /.well-known/sgcaptcha/?…&y=ipr:<ip> served to blocked
+    // egress IPs. Jina's IP pool is mostly clean but ~1-in-5 attempts land on a
+    // flagged IP and get this page on a 200. Explicit marker so a long variant
+    // (over the too-short floor) is still flagged → fetchViaJinaWithRetry rotates
+    // to a fresh Jina IP instead of silently parsing the challenge as 0 jobs.
+    'sgcaptcha',
   ];
   const hit = ERROR_MARKERS.find((m) => lower.includes(m));
   return hit ? `error/challenge marker: "${hit}"` : null;

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -98,7 +98,7 @@ import {
 import { translateWithMyMemory, getMyMemoryStats } from './mymemory-translate.mjs';
 import { freeTranslateWithRetry, logCascadeSummary } from './free-translate.mjs';
 import { parseSupsiJobDetail } from './supsi-job-parser.mjs';
-import { jinaProxiedRequest, hostMatchesProxyList } from './jina-proxy.mjs';
+import { jinaProxiedRequest, hostMatchesProxyList, fetchViaJinaWithRetry } from './jina-proxy.mjs';
 import {
   extractMigrosStructuredData,
   extractMigrosSectionItems,
@@ -2286,6 +2286,16 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
   let targetUrl = url;
   let proxyHeaders = {};
   if (hostMatchesProxyList(url, process.env.JOBS_CRAWLER_FETCH_PROXY)) {
+    // Route through Jina Reader, and for idempotent GET/HEAD retry on a fresh
+    // Jina egress IP when the proxy lands on a WAF-flagged IP (the challenge
+    // comes back HTTP 200, so the generic status-based retry below never fires).
+    // Same root cause as discovery (#1363): ~1-in-5 Jina IPs are blocked by the
+    // sgcaptcha IP-reputation WAF, so a single proxied fetch drops that detail
+    // page → the job is parsed empty. Short-circuit so every proxied detail page
+    // gets the same retry-until-clean-IP treatment as the sitemap discovery.
+    if (canRetry) {
+      return await fetchViaJinaWithRetry(url, { timeoutMs: REQUEST_TIMEOUT_MS });
+    }
     const proxied = jinaProxiedRequest(url);
     targetUrl = proxied.url;
     proxyHeaders = proxied.headers;

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -18,7 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { launchChromium } from './lib/ensure-chromium.mjs';
-import { fetchViaJina, detectJinaErrorBody } from './lib/jina-proxy.mjs';
+import { fetchViaJinaWithRetry, detectJinaErrorBody } from './lib/jina-proxy.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -324,7 +324,7 @@ async function fetchCambiavalute() {
   if (links.length === 0) {
     try {
       console.log('🛰️  Sitemap empty from direct fetch — retrying via egress proxy...');
-      const res = await fetchViaJina(CAMBIAVALUTE_SITEMAP_URL, { timeoutMs });
+      const res = await fetchViaJinaWithRetry(CAMBIAVALUTE_SITEMAP_URL, { timeoutMs });
       if (res.ok) {
         const body = await res.text();
         // Jina answers 200 even when it never reached the target (challenge /

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -3,7 +3,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { fetchViaJina, detectJinaErrorBody } from './lib/jina-proxy.mjs';
+import { fetchViaJinaWithRetry, detectJinaErrorBody } from './lib/jina-proxy.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -122,7 +122,7 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
         // IP and returns the page's raw HTML, which the parser handles unchanged.
         console.log(`  ⚠️  all fetch attempts failed (${err.message}), trying egress proxy...`);
         try {
-          const pr = await fetchViaJina(url, { timeoutMs });
+          const pr = await fetchViaJinaWithRetry(url, { timeoutMs });
           if (pr.ok) {
             const html = await pr.text();
             // Jina answers 200 even when it never reached the target (challenge /

--- a/tests/jina-proxy.test.ts
+++ b/tests/jina-proxy.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — modulo .mjs senza tipi
-import { detectJinaErrorBody } from '../scripts/lib/jina-proxy.mjs';
+import { detectJinaErrorBody, fetchViaJinaWithRetry } from '../scripts/lib/jina-proxy.mjs';
 
 describe('detectJinaErrorBody', () => {
   it('flags an empty / whitespace-only body', () => {
@@ -48,5 +48,73 @@ describe('detectJinaErrorBody', () => {
     const body = `<html><body>${'x'.repeat(120)}</body></html>`;
     expect(detectJinaErrorBody(body, { minLength: 100 })).toBeNull();
     expect(detectJinaErrorBody(body, { minLength: 500 })).toMatch(/body too short/);
+  });
+
+  it('flags a SiteGround sgcaptcha IP-reputation challenge even when long', () => {
+    // The challenge a blocked egress IP gets on a 200 — padded past the too-short
+    // floor so this proves the explicit marker (not just the length heuristic).
+    const body =
+      `<html><head><meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fcareer-sitemap.xml&y=ipr:34.96.49.15">` +
+      `</head><body>${'x'.repeat(400)}</body></html>`;
+    expect(detectJinaErrorBody(body)).toMatch(/error\/challenge marker/);
+  });
+});
+
+describe('fetchViaJinaWithRetry', () => {
+  const SGCAPTCHA = `<html><head><meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?y=ipr:34.96.49.15"></head><body></body></html>`;
+  const REAL_SITEMAP =
+    `<html><body>` +
+    `<a href="https://cambiavalute.ch/annuncio-di-lavoro/legal-compliance-officer/">job</a>` +
+    `<a href="https://cambiavalute.ch/annuncio-di-lavoro/sales-marketing-mercato-tedesco/">job</a>` +
+    `${'real sitemap content '.repeat(20)}</body></html>`;
+
+  it('retries on a fresh Jina IP when a 200 challenge is returned, then returns the clean page', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      // First two attempts land on blocked IPs (challenge), third is clean.
+      return new Response(calls < 3 ? SGCAPTCHA : REAL_SITEMAP, { status: 200 });
+    };
+    const res = await fetchViaJinaWithRetry('https://cambiavalute.ch/career-sitemap.xml', {
+      attempts: 4,
+      retryDelayMs: 0,
+      fetchImpl,
+    });
+    expect(res.ok).toBe(true);
+    expect(calls).toBe(3);
+    const body = await res.text();
+    expect(body).toContain('legal-compliance-officer');
+    expect(detectJinaErrorBody(body)).toBeNull();
+  });
+
+  it('returns the last response shape (no throw) when every attempt is blocked', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return new Response(SGCAPTCHA, { status: 200 });
+    };
+    const res = await fetchViaJinaWithRetry('https://cambiavalute.ch/career-sitemap.xml', {
+      attempts: 3,
+      retryDelayMs: 0,
+      fetchImpl,
+    });
+    expect(calls).toBe(3);
+    // Graceful: caller's existing detectJinaErrorBody warning + skip path runs.
+    expect(detectJinaErrorBody(await res.text())).toMatch(/error\/challenge marker/);
+  });
+
+  it('returns immediately on a clean first attempt (no wasted retries)', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return new Response(REAL_SITEMAP, { status: 200 });
+    };
+    const res = await fetchViaJinaWithRetry('https://cambiavalute.ch/career-sitemap.xml', {
+      attempts: 4,
+      retryDelayMs: 0,
+      fetchImpl,
+    });
+    expect(calls).toBe(1);
+    expect(res.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Problema (test case: cambiavalute.ch)

cambiavalute.ch ha **3 job reali a Chiasso/TI** ma il crawler trova **0 job**. Catena di blocchi diagnosticata live:

1. WAF = **SiteGround sgcaptcha**, blocca per **reputazione IP egress** (non più solo UA-version come #1407). Risposta: HTTP **200** con meta-refresh challenge `/.well-known/sgcaptcha/?…&y=ipr:<ip>`.
2. Il proxy Jina Reader (#1421) aggira l'IP datacenter CI, **ma il pool IP di Jina è misto**: ~1 su 5 richieste cade su un IP flaggato → riceve la challenge su un 200.
3. **Tutti i caller del proxy erano single-shot**: una run sfortunata parsa la challenge come 0 job → `detectJinaErrorBody` logga ma non ritenta → 0 job pubblicati con sorgente viva.

Probe live: Jina single-shot ~80% successo; gli altri proxy free pubblici (allorigins/corsproxy/codetabs) tutti morti (522/plan-gated); wp-json REST custom-post-type non esposto (404); Wayback pulito ma snapshot stale (2026-01-01).

## Implementato

Fix **strutturale + condiviso** (un solo modulo, niente copy-paste — AGENTS.md #6):

- **`scripts/lib/jina-proxy.mjs`** — nuova `fetchViaJinaWithRetry`: loop `fetchViaJina` → `detectJinaErrorBody` → retry su **fresh Jina IP** (ogni richiesta ruota l'IP), N=4 (~80%/try ⇒ ~99.8%). Ritorna una `Response` fresca e ri-leggibile; a esaurimento restituisce l'ultima shape (status+body) così il path graceful-skip esistente gira invariato — **non lancia mai**, nessun false-positive failure.
- **`detectJinaErrorBody`** — marker esplicito `sgcaptcha` così una variante lunga della challenge (oltre il floor too-short) è comunque flaggata.
- Wire nei **3** caller proxy single-shot: cambiavalute discovery, **goline** discovery (sibling, stessa classe WAF #1408), e il **chokepoint detail-page** della shared crawler (`fetchWithTimeout`, short-circuit GET/HEAD; path non-proxato 100% intoccato perché gated da `JOBS_CRAWLER_FETCH_PROXY`, vuoto per gli altri ~400 crawler).
- Test `tests/jina-proxy.test.ts`: sgcaptcha-long flagged, retry-until-clean, exhaustion-no-throw, clean-first-no-waste.

## Verifica

- **Live contro il WAF reale**: `fetchViaJinaWithRetry` × 10 → **10/10** restituisce tutti i 3 job (`mercato-francese`, `mercato-tedesco`, `legal-compliance-officer` del 2026-06-02, quest'ultimo finora **mancante** nello slice). Single-shot falliva ~20%.
- Logic standalone (node, no deps) **7/7 pass**.
- `node --check` su tutti gli mjs editati OK.

## Non implementato (ancora)

- **Verifica detail-crawl live in CI non eseguibile pre-merge**: la discovery è validata live; il path detail-page via chokepoint shared è validato per logica + e2e sulla stessa primitiva, ma il run reale del crawler (con `JOBS_CRAWLER_FETCH_PROXY=cambiavalute.ch`) gira solo in Actions. **Revert-trigger**: se il prossimo run `update-jobs-cambiavalute` resta a 0 job o le detail-page tornano vuote → investigare se il WAF blocca anche i fetch detail-page via Jina a tasso > retry-budget (alzare `attempts`).
- **Brittleness residua**: se il WAF inasprisce e blocca *l'intero* pool Jina, retry non basta → fallback successivo sarebbe Wayback (stale) o un egress residenziale (richiede signup/$); fuori scope, graceful-skip = zero regressione nel frattempo.
- **`JINA_API_KEY`** opzionale non configurato: free tier regge i pochi fetch/run; se in futuro si rate-limita, aggiungere il secret alza il limite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)