### PR TITLE
test(jina-proxy): pad sgcaptcha fixture so the marker fires (fix main-red #1459)

### DIFF
--- a/tests/jina-proxy.test.ts
+++ b/tests/jina-proxy.test.ts
@@ -61,7 +61,14 @@ describe('detectJinaErrorBody', () => {
 });
 
 describe('fetchViaJinaWithRetry', () => {
-  const SGCAPTCHA = `<html><head><meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?y=ipr:34.96.49.15"></head><body></body></html>`;
+  // Padded past detectJinaErrorBody's too-short floor so these tests exercise the
+  // explicit `sgcaptcha` marker (not the length heuristic) — a long real challenge
+  // variant, which is exactly what the marker exists to catch. (The short form
+  // was caught only by "body too short", so the exhaustion assertion below — which
+  // checks for the marker reason specifically — needs the marker to fire.)
+  const SGCAPTCHA =
+    `<html><head><meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?y=ipr:34.96.49.15"></head>` +
+    `<body>${'x'.repeat(400)}</body></html>`;
   const REAL_SITEMAP =
     `<html><body>` +
     `<a href="https://cambiavalute.ch/annuncio-di-lavoro/legal-compliance-officer/">job</a>` +


### PR DESCRIPTION
## Implementato

Fix del **main-red** introdotto da #1459: il test `fetchViaJinaWithRetry > returns the last response shape when every attempt is blocked` asseriva che il reason fosse l'`error/challenge marker` esplicito, ma la fixture `SGCAPTCHA` era < 200 char → `detectJinaErrorBody` ritornava `body too short` invece del marker → **1 failed | 730 passed** su `main` (l'auto-merge scatta su `## LGTM` senza attendere vitest).

Pad della fixture oltre il floor too-short così esercita il path del marker `sgcaptcha` — variante lunga e realistica della challenge, che è esattamente ciò che il marker serve a catturare. **Test-only, nessun cambio di logica.**

Validato standalone (node, modulo merged): 5/5 pass, exhaust reason = `error/challenge marker: "sgcaptcha"`.

## Non implementato (ancora)

Nulla — fix chirurgico single-class. La logica `fetchViaJinaWithRetry`/`detectJinaErrorBody` resta invariata e già live-verificata (#1459, 10/10 contro il WAF reale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)