### PR TITLE
fix(crawlers): proxy short-circuit GET-only + drain non-2xx Jina body (#1459 review)

### DIFF
--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -223,6 +223,9 @@ export async function fetchHtmlViaJinaWithRetry(
         if (!reason) return html;
         lastReason = reason;
       } else {
+        // Drain the unused non-2xx body so undici reclaims the connection before
+        // retrying (same leak fixed in fetchViaJinaWithRetry above).
+        try { await res.arrayBuffer(); } catch { /* already aborted/closed */ }
         lastReason = `HTTP ${res.status}`;
       }
     } catch (err) {

--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -82,6 +82,9 @@ export async function fetchViaJinaWithRetry(
       lastStatus = res.status;
       if (!res.ok) {
         // Jina's own non-2xx (rate limit / upstream) — a fresh IP may fare better.
+        // Drain the unused body so undici reclaims the connection before retrying;
+        // otherwise N abandoned streams pile up under concurrent proxied fetches.
+        try { await res.arrayBuffer(); } catch { /* already aborted/closed */ }
         lastBody = '';
         lastReason = `HTTP ${res.status}`;
       } else {

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -2293,7 +2293,11 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
     // sgcaptcha IP-reputation WAF, so a single proxied fetch drops that detail
     // page → the job is parsed empty. Short-circuit so every proxied detail page
     // gets the same retry-until-clean-IP treatment as the sitemap discovery.
-    if (canRetry) {
+    // GET-only: Jina Reader always issues a GET, so a HEAD must NOT be routed here
+    // (canRetry also allows HEAD) — it would silently become a GET with a full
+    // body. Let HEAD fall through to the generic proxied fetch below, which keeps
+    // the original method.
+    if (canRetry && upperMethod === 'GET') {
       return await fetchViaJinaWithRetry(url, { timeoutMs: REQUEST_TIMEOUT_MS });
     }
     const proxied = jinaProxiedRequest(url);

--- a/tests/jina-proxy.test.ts
+++ b/tests/jina-proxy.test.ts
@@ -110,6 +110,31 @@ describe('fetchViaJinaWithRetry', () => {
     expect(detectJinaErrorBody(await res.text())).toMatch(/error\/challenge marker/);
   });
 
+  it('retries (and drains the body) on a Jina non-2xx, then returns the clean page', async () => {
+    let calls = 0;
+    let drained = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      if (calls < 3) {
+        // 429 from Jina rate-limit — body must be drained before the next attempt.
+        const r = new Response('rate limited', { status: 429 });
+        const orig = r.arrayBuffer.bind(r);
+        r.arrayBuffer = async () => { drained += 1; return orig(); };
+        return r;
+      }
+      return new Response(REAL_SITEMAP, { status: 200 });
+    };
+    const res = await fetchViaJinaWithRetry('https://cambiavalute.ch/career-sitemap.xml', {
+      attempts: 4,
+      retryDelayMs: 0,
+      fetchImpl,
+    });
+    expect(calls).toBe(3);
+    expect(drained).toBe(2); // both 429 bodies drained
+    expect(res.ok).toBe(true);
+    expect(await res.text()).toContain('legal-compliance-officer');
+  });
+
   it('returns immediately on a clean first attempt (no wasted retries)', async () => {
     let calls = 0;
     const fetchImpl = async () => {


### PR DESCRIPTION
## Implementato

Due hardening dal **code-review** di #1459 (retry Jina egress):

1. **HEAD→GET silenzioso** — `shared-jobs-crawler.mjs` `fetchWithTimeout`: lo short-circuit proxy scattava su `canRetry` (GET **o** HEAD), ma `fetchViaJinaWithRetry` emette sempre un GET via Jina Reader → una HEAD verso un host proxy-listed diventava silenziosamente un GET con body completo. Guard a `upperMethod === 'GET'`; la HEAD ricade nel fetch proxied generico che ne preserva il metodo. Latente oggi (nessun host proxied fa HEAD), chiuso prima che morda.
2. **Body non drenato su Jina non-2xx** — `fetchViaJinaWithRetry`: il branch `!res.ok` passava al tentativo successivo senza drenare il body → una connessione undici trapelata per ogni tentativo fallito (es. 429 ripetuti) sotto fetch proxied concorrenti. Drain con `await res.arrayBuffer()`, stesso pattern già usato nel loop fetch generico.

Test-locked: nuovo caso 429→429→200 → ritenta, drena entrambi i body 429, ritorna la pagina pulita.

## Verifica

- Standalone (node, modulo reale): retry+drain `calls=3 drained=2 ok=true`; exhaust-429 → `status 429, !ok` (graceful skip). `node --check` OK su entrambi gli mjs.
- Il falso positivo del review ("`fetchViaJinaWithRetry` inesistente") era un artefatto di un checkout `main` locale stale 1331 commit dietro — la funzione esiste su `origin/main` (#1459 merged, test verdi).

## Non implementato (ancora)

- Finding latenti del review NON funnel-critical e non attivi: Workday content-type negotiation e `adapter.userAgent` droppati sul path proxied valgono **solo** se un adapter Workday o un UA-override venisse aggiunto per cambiavalute/goline (oggi nessuno; Jina ignora comunque l'UA target usando il proprio browser). Documentati qui; nessun fix finché non diventano reali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)