### PR TITLE
fix(visual): gate home baseline on hydration + generic skeleton net

### DIFF
--- a/tests/e2e/seo-visual-regression.spec.ts
+++ b/tests/e2e/seo-visual-regression.spec.ts
@@ -38,9 +38,15 @@ interface VisualCase {
 
 const CASES: VisualCase[] = [
   // Home renders CalcolatoreTabContent: InputCard is lazy + its locale chunk
-  // (`it-calculator.ts`) is lazy too. Without a ready selector the screenshot
-  // can fire while SkeletonInputCard is still rendered, producing ~11% diff.
-  { name: 'home', url: '/', readySelector: '[data-testid="calculator-input-card"]' },
+  // (`it-calculator.ts`) is lazy too. But gating only on the left InputCard is
+  // NOT enough: the right-side ResultsView hydrates independently (default
+  // RAL=75k auto-computes), and `results-advantage-banner` is the last element
+  // to mount — same as salary-calculator. Gating only on the input card let the
+  // screenshot fire while the entire ResultsView (Analisi Comparativa + Vivere
+  // cards) was still empty, baking an empty-results-pane baseline that then
+  // diffed ~11% against every fully-hydrated live render (run 26999410533).
+  // Gate on the banner so the capture is always at full hydration.
+  { name: 'home', url: '/', readySelector: '[data-testid="results-advantage-banner"]' },
   {
     name: 'salary-calculator',
     url: '/calcola-stipendio/',

--- a/tests/e2e/seo-visual-regression.spec.ts
+++ b/tests/e2e/seo-visual-regression.spec.ts
@@ -70,6 +70,46 @@ const DYNAMIC_REGION_SELECTORS = [
 
 test.use({ viewport: { width: 1280, height: 800 } });
 
+// ---- Structural guardrail against partial-hydration baselines ----
+// A per-case `readySelector` only proves ONE element mounted. Other
+// above-the-fold regions can still be showing a loading skeleton when the
+// screenshot fires — and if that happens during baseline *generation*, the
+// partial state is frozen into the PNG and diffs against every fully-hydrated
+// live render forever (the home ResultsView empty-pane bug, run 26999410533,
+// 108122px / ratio 0.11). Because both baseline-gen and validate-live share
+// this spec, a single capture-path gate fixes both sides.
+//
+// Every loading placeholder in the app carries the same signature: the
+// `animate-pulse` class AND a `surface-raised` background (see the `pulse`
+// primitive in components/shared/Skeletons.tsx and every Suspense fallback in
+// the calculator tree). Decorative pulses (Lucide icons: Volume2, Trophy) use
+// `animate-pulse` WITHOUT a surface-raised background, so they're excluded.
+// AdSense slots never match this signature, so the ad system is untouched.
+//
+// This is generic: a future VisualCase whose `readySelector` resolves early
+// while another hero region is still a skeleton is caught here, with no
+// per-page knowledge required.
+async function waitForNoAboveFoldSkeletons(
+  page: import('playwright/test').Page,
+  viewportHeight: number,
+): Promise<void> {
+  await page.waitForFunction(
+    (vh) => {
+      const nodes = Array.from(document.querySelectorAll('[class*="animate-pulse"]'));
+      return !nodes.some((el) => {
+        const cls = (el.getAttribute('class') ?? '').toString();
+        // Skeleton loaders carry a surface-raised bg; decorative icon pulses don't.
+        if (!cls.includes('surface-raised')) return false;
+        const r = el.getBoundingClientRect();
+        // Only count placeholders intersecting the captured viewport.
+        return r.top < vh && r.bottom > 0 && r.width > 0 && r.height > 0;
+      });
+    },
+    viewportHeight,
+    { timeout: 20_000 },
+  );
+}
+
 // `salary-calculator` baseline is stale after commit 5f81803062
 // ("fix(seo): scope seo-static.css h1-h4 + main rules to main.seo-static-content"):
 // SPA H1/H2 sizes now correctly resolve via Tailwind preflight + per-component
@@ -99,6 +139,10 @@ for (const c of CASES) {
     }
     await page.evaluate(() => document.fonts.ready);
     await page.evaluate(() => window.scrollTo(0, 0));
+    // Structural net: no above-the-fold loading skeleton may remain, on ANY
+    // page, before we capture — prevents freezing a partial-hydration baseline
+    // even if a future case's readySelector under-specifies readiness.
+    await waitForNoAboveFoldSkeletons(page, 800);
     // Brief settle: wait for layout shift to stabilize after font load.
     await page.waitForTimeout(500);
     // Viewport-only screenshot (1280x800). Full-page / element screenshots


### PR DESCRIPTION
## Implementato

`validate-live` fallisce ad ogni deploy sul caso `visual baseline: home` (es. run [26999410533](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26999410533/job/79687797830)): **108122px diff (ratio 0.11)** vs cap `maxDiffPixelRatio: 0.02`.

**Root cause** (confermato dal diff artifact `visual-diffs-live`): il baseline `home-chromium-linux.png` è stato catturato **mid-hydration** col pannello destro ResultsView VUOTO. Il `readySelector` di home aspettava solo la `InputCard` sinistra (`[data-testid=calculator-input-card]`); la ResultsView destra idrata in modo indipendente (RAL=75k default auto-calcola) ed era ancora vuota allo screenshot. Il live render mostra `Analisi Comparativa` + chip + card "Vivere in Ticino/Italia" — nessuna mascherata → diffano in pieno.

Due fix, in bundle (instanza + classe):

1. **Fix istanza** — home aspetta `[data-testid=results-advantage-banner]` (ultimo elemento ResultsView a montare), come già fa `salary-calculator`. Capture sempre a full-hydration.
2. **Prevenzione classe** — nuovo gate generico nel capture-path condiviso: prima di OGNI screenshot, attende che NESSUNo skeleton di caricamento resti above-the-fold. Firma skeleton = `animate-pulse` + background `surface-raised` (primitive `pulse` in `Skeletons.tsx` + tutti i Suspense fallback dell'albero calculator). Pulse decorativi (icone Lucide Volume2/Trophy) NON hanno `surface-raised` → esclusi; gli slot AdSense non matchano mai → ad system intatto. Zero conoscenza per-pagina: una futura VisualCase con readySelector sotto-specificato viene catturata qui. Sia `regenerate-visual-baselines.yml` sia `validate-live` usano questo spec → un solo gate indurisce entrambi i lati.

## Non implementato (ancora)

- **Rigenerazione del PNG baseline**: il fix dello spec da solo NON sblocca `validate-live` finché `home-chromium-linux.png` resta quello vecchio (empty-results). Il PNG `-linux.png` è platform-specific → non generabile in locale (darwin). **Azione post-merge**: dispatch `regenerate-visual-baselines.yml` su `main` — ora che lo spec aspetta il banner + il gate skeleton, ricattura il baseline corretto dal live e committa. Poi il deploy successivo passa. (Il workflow di regen è `workflow_dispatch`-only by design.)
- salary-calculator resta `STALE_BASELINES` skipped (motivo H1 30px, scope separato — non toccato qui).