### PR TITLE
fix(crawlers): csvp — extract linked PDF into description (parser not broken; content lives in PDF)

### DIFF
--- a/scripts/lib/csvp-poschiavo-job-parser.mjs
+++ b/scripts/lib/csvp-poschiavo-job-parser.mjs
@@ -108,7 +108,11 @@ export async function fetchAllCsvpPoschiavoJobs() {
         'Centro Sanitario Valposchiavo — Ospedale San Sisto, Poschiavo (GR).',
       ].filter(Boolean),
     });
-    const sourceLang = detectLang(description || title, 'it');
+    // Detect the source locale from the stable Italian listing fields (title +
+    // intro), NOT the now-PDF-backed description: a German-leaning PDF could
+    // otherwise flip sourceLang to 'de' and route the text to descriptionByLocale.de
+    // while the boilerplate guard reads descriptionByLocale.it.
+    const sourceLang = detectLang(`${title} ${it.intro || ''}`.trim() || description, 'it');
     const jobSlug = slugify(`${title} ${CSVP_POSCHIAVO_KEY} poschiavo`);
     const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
     jobs.push({

--- a/scripts/lib/csvp-poschiavo-job-parser.mjs
+++ b/scripts/lib/csvp-poschiavo-job-parser.mjs
@@ -10,6 +10,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify } from './crawler-template.mjs';
+import { extractPdfJobContentFromUrl, buildPdfBackedDescription } from './pdf-job-content.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -82,11 +83,31 @@ export async function fetchAllCsvpPoschiavoJobs() {
   const jobs = [];
   for (const it of items) {
     const title = it.title;
-    const description = [
-      it.intro,
-      it.pdfUrl ? `Dettagli (PDF): ${it.pdfUrl}` : '',
-      'Centro Sanitario Valposchiavo — Ospedale San Sisto, Poschiavo (GR).',
-    ].filter(Boolean).join('\n\n');
+    // The listing's inline intro is just "80-100% (m/f) — start date": the real
+    // job content (Compiti / Profilo / Requisiti) lives in the linked PDF. Fetch
+    // and extract it so the description is real content, not boilerplate — older
+    // postings happened to carry a richer inline intro, but IT/admin roles put
+    // everything in the PDF and would otherwise trip the boilerplate guard
+    // (#1393-class: 1/1 jobs boilerplate-only). Falls back to the thin intro if
+    // the PDF is unreachable/image-only.
+    let pdfText = '';
+    if (it.pdfUrl) {
+      try {
+        const extracted = await extractPdfJobContentFromUrl(it.pdfUrl);
+        pdfText = extracted?.text || '';
+      } catch (err) {
+        console.warn(`   ⚠️ PDF extraction failed for ${it.pdfUrl}: ${err?.message || err}`);
+      }
+    }
+    const description = buildPdfBackedDescription({
+      introLines: [it.intro],
+      pdfText,
+      fallbackText: it.intro,
+      footerLines: [
+        it.pdfUrl ? `Dettagli (PDF): ${it.pdfUrl}` : '',
+        'Centro Sanitario Valposchiavo — Ospedale San Sisto, Poschiavo (GR).',
+      ].filter(Boolean),
+    });
     const sourceLang = detectLang(description || title, 'it');
     const jobSlug = slugify(`${title} ${CSVP_POSCHIAVO_KEY} poschiavo`);
     const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);

--- a/tests/csvp-poschiavo-pdf-crawler.test.ts
+++ b/tests/csvp-poschiavo-pdf-crawler.test.ts
@@ -1,0 +1,74 @@
+/**
+ * CSVP (Centro Sanitario Valposchiavo) crawler — PDF-backed description.
+ *
+ * The csvp.ch listing carries only a thin inline intro ("80-100% (m/f) — start
+ * date"); the real job content (Compiti / Profilo / Requisiti) lives in a linked
+ * PDF. Before the fix the parser only LINKED the PDF, so an IT/admin posting had
+ * a boilerplate-only description and tripped the boilerplate guard (1/1 jobs).
+ * This test pins that the parser now extracts the PDF text into the description.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchHtml, extractPdfJobContentFromUrl } = vi.hoisted(() => ({
+  fetchHtml: vi.fn(),
+  extractPdfJobContentFromUrl: vi.fn(),
+}));
+
+vi.mock('@/scripts/lib/hospital-custom-html-helpers.mjs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, fetchHtml };
+});
+vi.mock('@/scripts/lib/pdf-job-content.mjs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, extractPdfJobContentFromUrl };
+});
+
+// @ts-expect-error — JS module without types
+import { fetchAllCsvpPoschiavoJobs } from '@/scripts/lib/csvp-poschiavo-job-parser.mjs';
+
+const LISTING_HTML = `
+  <article>
+    <h1><a href="/it/lavora-con-noi/cerchiamo/905-responsabile-informatica" title="Responsabile informatica">Responsabile informatica e manager di progetti</a></h1>
+    <p>80 - 100% (m/f) Inizio in data da convenire</p>
+    <a class="pdfLink" href="/images/Posti_di_lavoro_PDF/Responsabile_informatica.pdf">PDF</a>
+  </article>`;
+
+const PDF_TEXT = `Il Centro sanitario Valposchiavo cerca un Responsabile informatica e manager di progetti 80-100% (m/f).
+Compiti principali: Gestione del software clinico e delle relative interfacce. Supporto di primo livello (1st Level Support).
+Collaborazione con i fornitori di servizi IT esterni. Supporto e sviluppo della digitalizzazione interna.
+Profilo richiesto: formazione informatica, esperienza nella gestione di progetti, ottime conoscenze di italiano e tedesco.`;
+
+describe('CSVP crawler — PDF-backed description', () => {
+  afterEach(() => {
+    fetchHtml.mockReset();
+    extractPdfJobContentFromUrl.mockReset();
+  });
+
+  it('extracts the linked PDF text into the job description (not just a link)', async () => {
+    fetchHtml.mockResolvedValue(LISTING_HTML);
+    extractPdfJobContentFromUrl.mockResolvedValue({ text: PDF_TEXT, totalPages: 1, rawText: PDF_TEXT });
+
+    const jobs = await fetchAllCsvpPoschiavoJobs();
+
+    expect(jobs).toHaveLength(1);
+    expect(extractPdfJobContentFromUrl).toHaveBeenCalledWith(
+      expect.stringContaining('/images/Posti_di_lavoro_PDF/Responsabile_informatica.pdf'),
+    );
+    const desc = jobs[0].descriptionByLocale?.it || jobs[0].description || '';
+    expect(desc).toContain('Compiti principali');
+    expect(desc).toContain('1st Level Support');
+    // Real content → well above the 30-unique-word boilerplate threshold.
+    expect(desc.split(/\s+/).filter(Boolean).length).toBeGreaterThan(30);
+  });
+
+  it('falls back to the thin intro when PDF extraction fails (no crash)', async () => {
+    fetchHtml.mockResolvedValue(LISTING_HTML);
+    extractPdfJobContentFromUrl.mockRejectedValue(new Error('fetch failed'));
+
+    const jobs = await fetchAllCsvpPoschiavoJobs();
+
+    expect(jobs).toHaveLength(1);
+    const desc = jobs[0].descriptionByLocale?.it || jobs[0].description || '';
+    expect(desc).toContain('80 - 100% (m/f)');
+  });
+});


### PR DESCRIPTION
## Implementato

**Indagine richiesta — il parser csvp NON è rotto.** Funziona correttamente; non modificato di recente.

**Vera causa:** il job attuale (*Responsabile informatica*) tiene il contenuto reale (Compiti/Profilo/Requisiti) **nel PDF linkato**; sul listing c'è solo un intro thin (44 char). Il parser **linkava** il PDF senza estrarlo → descrizione metadata-only → il **boilerplate-guard** (`assemble-jobs-dataset.mjs`, <30 parole uniche) la flagga 1/1 e hard-failà il crawler (csvp NON ha `SKIP_BOILERPLATE_GUARD`).

**Fix (root cause, no indebolimento guard):** estrai il testo PDF via l'helper condiviso `pdf-job-content.mjs` (`extractPdfJobContentFromUrl` + `buildPdfBackedDescription`) — stessa infra di fart/berit-klinik — fallback all'intro se il PDF è irraggiungibile/image-only.

**Verificato live:** descrizione da boilerplate → **220 parole** reali; `detectBoilerplateDescriptions` **1/1 → 0/1** (guard passa). Test 2/2.

## Review fixes (round 2)

- 🔴 **csvm-mustair sibling — premessa inesatta**: NON fa hard-fail del guard. Il suo workflow setta `SKIP_BOILERPLATE_GUARD: '1'` (`update-jobs-csvm-mustair.yml:L78`, onorato in `assemble-jobs-dataset.mjs:L740`) → il suo template boilerplate non triggera mai il guard. Il fallimento 06-04 era fetch-transient (risolto da #1454). csvm ha lo stesso anti-pattern ma papered-over con lo skip → **estrazione contenuto detail-page tracciata come follow-up #1480** (meccanismo diverso: detail-page inline, non PDF-link diretto).
- **Adversarial — `detectLang` flip**: ora derivo `sourceLang` dai campi listing stabili (title+intro, sempre italiano) invece della descrizione PDF-backed → un PDF a maggioranza tedesca non sposta la sorgente su `de`.
- **Adversarial — try/catch "morto"**: corretto: `extractPdfJobContentFromUrl` cattura internamente e risolve `{text:''}` (non rilancia). Il fallback reale è `extracted?.text || ''` → `buildPdfBackedDescription(fallbackText: intro)`. Il try/catch resta come difesa belt-and-suspenders.

## Non implementato (ancora)

- **csvm-mustair** (#1480): estrazione contenuto detail-page + rimozione `SKIP_BOILERPLATE_GUARD` → follow-up separato (meccanismo diverso, detail page rumoroso).
- **Fetch PDF senza egress-fallback Jina**: `extractPdfJobContentFromUrl` usa `fetch` raw; un fetch PDF sull'egress flaky → `{text:''}` → fallback intro thin (boilerplate quel run, recupera al successivo). Verificato che `csvp.ch` serve il PDF al bot-UA (test locale: 1329 char estratti). Fallback Jina al PDF fuori scope (PDF≠HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
