### PR TITLE
feat(crawlers): generalize 200-challenge → Jina rescue to all crawlers (#1363)

### DIFF
--- a/scripts/lib/ats-clients/successfactors-client.mjs
+++ b/scripts/lib/ats-clients/successfactors-client.mjs
@@ -76,6 +76,7 @@
  */
 
 import { fetchWithRetry } from '../transient-fetch.mjs';
+import { rescueHtmlIfChallenged } from '../jina-proxy.mjs';
 
 /* ── Errors ────────────────────────────────────────────────────────────── */
 
@@ -636,7 +637,8 @@ export async function* fetchSuccessFactorsJobs(careerUrl, options = {}) {
       userAgent,
       accept: 'text/html,application/xhtml+xml',
     });
-    const html = await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    const html = await rescueHtmlIfChallenged(await res.text(), careerUrl, { timeoutMs });
     const raw = parseHtmlCareerDetail(html);
     if (!raw) return;
     const tenant = tenantOverride || parsed.searchParams.get('company') || '';
@@ -660,7 +662,8 @@ export async function* fetchSuccessFactorsJobs(careerUrl, options = {}) {
         userAgent,
         accept: 'text/html,application/xhtml+xml',
       });
-      const html = await res.text();
+      // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+      const html = await rescueHtmlIfChallenged(await res.text(), pageUrl, { timeoutMs });
       const ldJob = extractJsonLdJobPosting(html);
       if (ldJob) {
         const job = extractSuccessFactorsJobIdentity(ldJob, { company });

--- a/scripts/lib/caritas-schweiz-job-parser.mjs
+++ b/scripts/lib/caritas-schweiz-job-parser.mjs
@@ -24,6 +24,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -173,7 +174,8 @@ async function fetchPage(url, timeoutMs = 20000) {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -157,7 +157,7 @@ import {
   isConnectionLevelFetchError,
   fetchWithRetry,
 } from './transient-fetch.mjs';
-import { fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
+import { fetchHtmlViaJinaWithRetry, rescueHtmlIfChallenged } from './jina-proxy.mjs';
 
 // Re-export the shared transient-fetch primitives so existing importers of
 // crawler-template keep working and the ATS clients share one classifier.
@@ -478,7 +478,7 @@ export async function fetchJson(url, options = {}) {
 export async function fetchHtml(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
   try {
-    return await fetchWithRetry(async () => {
+    const html = await fetchWithRetry(async () => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
@@ -498,6 +498,12 @@ export async function fetchHtml(url, options = {}) {
         clearTimeout(timer);
       }
     }, options);
+    // 200-but-challenge: the IP-reputation WAF (SiteGround sgcaptcha / Cloudflare,
+    // the cambiavalute class #1363) served a challenge page on a 200 to the
+    // datacenter egress IP. The fetch "succeeded" HTTP-wise so the connection
+    // rescue below never fires — re-fetch the real page through Jina's clean IP.
+    // Genuine pages pass through unchanged (zero cost).
+    return await rescueHtmlIfChallenged(html, url, { timeoutMs });
   } catch (err) {
     // Connection-level failure after retries: the runner's datacenter egress
     // can't reach an otherwise-healthy site (~1-3% of fetches/wave; the sites

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -23,6 +23,7 @@
  */
 import { createHash } from 'node:crypto';
 import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -289,7 +290,8 @@ async function fetchPage(url, timeoutMs, userAgent) {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/hospital-custom-html-helpers.mjs
+++ b/scripts/lib/hospital-custom-html-helpers.mjs
@@ -10,7 +10,7 @@
  */
 
 import { fetchWithRetry, RETRYABLE_STATUS, isConnectionLevelFetchError } from './transient-fetch.mjs';
-import { fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
+import { fetchHtmlViaJinaWithRetry, rescueHtmlIfChallenged } from './jina-proxy.mjs';
 
 export const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
   || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
@@ -89,7 +89,7 @@ export function stripInlineJsCode(text = '') {
 export async function fetchHtml(url, { timeoutMs } = {}) {
   const t = timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
   try {
-    return await fetchWithRetry(async () => {
+    const html = await fetchWithRetry(async () => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), t);
       try {
@@ -108,6 +108,8 @@ export async function fetchHtml(url, { timeoutMs } = {}) {
         clearTimeout(timer);
       }
     }, { label: `hospital-custom-html ${url}` });
+    // 200-but-challenge (IP-reputation WAF served a challenge on a 200) → Jina.
+    return await rescueHtmlIfChallenged(html, url, { timeoutMs: t });
   } catch (err) {
     // The plain retries above all hit a connection-level `fetch failed`: the
     // GitHub runner's datacenter egress intermittently can't reach an otherwise

--- a/scripts/lib/inselspital-job-parser.mjs
+++ b/scripts/lib/inselspital-job-parser.mjs
@@ -38,6 +38,7 @@
  */
 import { createHash } from 'node:crypto';
 import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -323,7 +324,8 @@ async function fetchPage(url, cookieJar) {
         if (pairs.length) cookieJar.value = pairs.join('; ');
       }
     }
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, {});
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -242,3 +242,51 @@ export async function fetchHtmlViaJinaWithRetry(
   console.warn(`⚠️ Jina egress exhausted ${maxRetries + 1} attempt(s) for ${targetUrl} (last: ${lastReason}).`);
   return null;
 }
+
+// Unambiguous WAF anti-bot challenge banners served on an HTTP 200 to a blocked
+// egress IP (the "200-but-not-the-page" case). Distinct from detectJinaErrorBody:
+// this list is MARKER-ONLY (no short/empty heuristic), so it is high-precision
+// and safe to run on EVERY successful direct fetch across all crawlers without
+// false-positiving a real (possibly short) jobs page. Covers SiteGround sgcaptcha
+// (#1363), Cloudflare, and Incapsula — the cambiavalute IP-reputation class.
+const ANTI_BOT_CHALLENGE_MARKERS = [
+  'sgcaptcha',
+  '/.well-known/sgcaptcha',
+  'just a moment...',
+  'attention required!',
+  'checking your browser before accessing',
+  'enable javascript and cookies to continue',
+  'cf-browser-verification',
+  'cf_chl_',
+  '_incapsula_resource',
+];
+
+/**
+ * Does `body` look like a WAF anti-bot challenge page (served on a 200 to a
+ * blocked egress IP), rather than the real target page? Marker-only → no false
+ * positives on a genuine page. Used to decide whether a successful-but-wrong
+ * direct fetch should be re-routed through the clean-IP Jina proxy.
+ */
+export function looksLikeAntiBotChallenge(body) {
+  const lower = String(body || '').toLowerCase();
+  return ANTI_BOT_CHALLENGE_MARKERS.some((m) => lower.includes(m));
+}
+
+/**
+ * Shared "200-but-challenge → Jina rescue" used at every direct-fetch chokepoint
+ * (crawler-template fetchHtml, the SAP SuccessFactors family, hospital helpers).
+ *
+ * If `html` is a genuine page → returns it unchanged (zero cost, the common
+ * path). If it is a WAF challenge (IP-reputation block that answered 200), it
+ * re-fetches `url` through the Jina Reader proxy (clean IP, retried across Jina's
+ * IP pool) and returns the real page. If Jina is also blocked/unavailable →
+ * returns the ORIGINAL `html` so the caller's existing 0-result /
+ * 0-total-preserves-data path runs unchanged. Never throws → no regression vs.
+ * today for any crawler that wasn't already being silently fed a challenge.
+ */
+export async function rescueHtmlIfChallenged(html, url, { timeoutMs } = {}) {
+  if (!looksLikeAntiBotChallenge(html)) return html;
+  const rescued = await fetchHtmlViaJinaWithRetry(url, { timeoutMs });
+  if (rescued != null && !looksLikeAntiBotChallenge(rescued)) return rescued;
+  return html;
+}

--- a/scripts/lib/jina-proxy.mjs
+++ b/scripts/lib/jina-proxy.mjs
@@ -251,7 +251,6 @@ export async function fetchHtmlViaJinaWithRetry(
 // (#1363), Cloudflare, and Incapsula — the cambiavalute IP-reputation class.
 const ANTI_BOT_CHALLENGE_MARKERS = [
   'sgcaptcha',
-  '/.well-known/sgcaptcha',
   'just a moment...',
   'attention required!',
   'checking your browser before accessing',

--- a/scripts/lib/nestle-job-parser.mjs
+++ b/scripts/lib/nestle-job-parser.mjs
@@ -12,6 +12,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
@@ -168,7 +169,8 @@ async function fetchJobDescriptionText(listingUrl) {
       redirect: 'follow',
     });
     if (!res.ok) return '';
-    const html = await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    const html = await rescueHtmlIfChallenged(await res.text(), listingUrl, {});
     const match = html.match(/<span[^>]*class="[^"]*jobdescription[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
     if (!match) return '';
     return stripHtml(match[1])

--- a/scripts/lib/pdgr-job-parser.mjs
+++ b/scripts/lib/pdgr-job-parser.mjs
@@ -17,6 +17,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
@@ -179,7 +180,8 @@ async function fetchListingPage() {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from listing page`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), CAREER_URL, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
     throw err;
@@ -285,7 +287,8 @@ async function fetchDetailPage(url) {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from detail page: ${url}`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/schindler-job-parser.mjs
+++ b/scripts/lib/schindler-job-parser.mjs
@@ -33,6 +33,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -366,7 +367,8 @@ async function fetchPage(url, timeoutMs, userAgent) {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/see-spital-job-parser.mjs
+++ b/scripts/lib/see-spital-job-parser.mjs
@@ -31,6 +31,7 @@
  */
 import { createHash } from 'node:crypto';
 import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { fetchUmantisDetailContentResult } from './umantis-detail-helpers.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -268,7 +269,8 @@ async function fetchPage(url, cookieJar) {
         if (pairs.length) cookieJar.value = pairs.join('; ');
       }
     }
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, {});
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/scripts/lib/spital-davos-job-parser.mjs
+++ b/scripts/lib/spital-davos-job-parser.mjs
@@ -30,6 +30,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -350,7 +351,8 @@ async function fetchPage(url) {
     });
     clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
-    return await res.text();
+    // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
+    return await rescueHtmlIfChallenged(await res.text(), url, {});
   } catch (err) {
     clearTimeout(timer);
     throw err;

--- a/tests/jina-proxy.test.ts
+++ b/tests/jina-proxy.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — modulo .mjs senza tipi
-import { detectJinaErrorBody, fetchViaJinaWithRetry } from '../scripts/lib/jina-proxy.mjs';
+import { detectJinaErrorBody, fetchViaJinaWithRetry, looksLikeAntiBotChallenge, rescueHtmlIfChallenged } from '../scripts/lib/jina-proxy.mjs';
 
 describe('detectJinaErrorBody', () => {
   it('flags an empty / whitespace-only body', () => {
@@ -148,5 +148,35 @@ describe('fetchViaJinaWithRetry', () => {
     });
     expect(calls).toBe(1);
     expect(res.ok).toBe(true);
+  });
+});
+
+describe('looksLikeAntiBotChallenge', () => {
+  it('flags WAF challenge banners (sgcaptcha, Cloudflare, Incapsula)', () => {
+    expect(looksLikeAntiBotChallenge('<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?y=ipr:1.2.3.4">')).toBe(true);
+    expect(looksLikeAntiBotChallenge('<title>Just a moment...</title>')).toBe(true);
+    expect(looksLikeAntiBotChallenge('<h1>Attention Required!</h1> Cloudflare')).toBe(true);
+    expect(looksLikeAntiBotChallenge('Checking your browser before accessing the site.')).toBe(true);
+    expect(looksLikeAntiBotChallenge('window.__CF$cv$params; cf_chl_opt')).toBe(true);
+    expect(looksLikeAntiBotChallenge('<script>_Incapsula_Resource</script>')).toBe(true);
+  });
+
+  it('does NOT flag a genuine jobs page (marker-only, no length heuristic)', () => {
+    // A real (even short) jobs page must pass through — this is what makes it safe
+    // to run on EVERY successful fetch across all crawlers.
+    expect(looksLikeAntiBotChallenge('<h1>Offene Stellen</h1><a href="/job/1">Pflegefachperson HF</a>')).toBe(false);
+    expect(looksLikeAntiBotChallenge('')).toBe(false);
+    expect(looksLikeAntiBotChallenge(null)).toBe(false);
+    expect(looksLikeAntiBotChallenge('Posizioni aperte: nessuna al momento.')).toBe(false);
+  });
+});
+
+describe('rescueHtmlIfChallenged', () => {
+  it('returns a genuine page unchanged without any network call', async () => {
+    const genuine = '<html><body><h1>Stellenangebote</h1><a href="/job/42">Kardiologe</a></body></html>';
+    // No fetch stub installed — if it tried to hit the network the test env would
+    // fail; passing proves the genuine-page fast path never calls Jina.
+    const out = await rescueHtmlIfChallenged(genuine, 'https://example.ch/jobs', { timeoutMs: 1000 });
+    expect(out).toBe(genuine);
   });
 });


### PR DESCRIPTION
## Contesto

Il fix cambiavalute (#1459) ha recuperato **un** crawler da un WAF IP-reputation che serve una **challenge su HTTP 200** all'IP datacenter CI. Il fallback Jina generico di #1454 copre **solo** i fallimenti connection-level (fetch throws): un 200-con-challenge-body "riesce" HTTP-wise e viene parsato silenziosamente come 0 job.

Triage live (subagent, probe residenziale + Jina): **17 crawler attualmente falliti sono esattamente questa classe** — sorgente viva, posizioni reali, bloccati solo dall'IP datacenter. 0 in classe 403/429 (status-path), 2 genuinamente vuoti (ehnv, giardino, esclusi).

## Implementato

Meccanismo condiviso ad alta precisione (un helper, no copy-paste — AGENTS.md #6):
- **`jina-proxy.mjs`**: `looksLikeAntiBotChallenge(body)` — detector **marker-only** (sgcaptcha / Cloudflare / Incapsula), **senza** euristica short/empty → sicuro su OGNI fetch riuscito senza falsi positivi su una jobs-page reale (anche corta). `rescueHtmlIfChallenged(html, url, {timeoutMs})` → passthrough per pagine genuine (costo zero), re-fetch Jina clean-IP per le challenge, html originale se anche Jina è bloccato (non lancia mai).
- Wired in **ogni chokepoint HTML direct-fetch**: `crawler-template.fetchHtml` (tutti i crawler template-based + futuri), `hospital-custom-html-helpers.fetchHtml` (octapharma/tecan/medartis), SuccessFactors shared client (nestle + famiglia SF), e i bespoke schindler / hirslanden / pdgr×2 / nestle-detail.

Copre i 9 SAP SF + ~9 template crawler della triage (triaplus, suedhang, csvm, bregaglia, adelheid, gzo, csvp, svar, ...) e ogni crawler futuro che passa per questi chokepoint.

## Verifica

- **Live contro WAF reale**: `rescueHtmlIfChallenged` con una challenge sgcaptcha per il listing cambiavalute → ha fetchato la pagina reale 75KB via Jina (no challenge).
- Unit test: markers (sgcaptcha/Cloudflare/Incapsula) + genuine-page passthrough senza network. `node --check` su tutti gli 8 mjs.

## Non implementato (ancora)

- **NON tocca il path status-HTTP**: un 4xx/5xx è una risposta reale del server; il contratto "exactly-N-attempts after persistent 503" (`tests/crawler-fetch-retry.test.ts`) resta intatto. I 403/429 (anti-bot status) non sono ri-rotterati — la triage non ne ha trovati tra i 17, e aggiungerli romperebbe quel contratto. Se in futuro emerge un crawler bloccato con 403-da-IP, è un follow-up dedicato.
- **Fetch JSON non recuperati**: il branch odata-api di SuccessFactors (`res.json()`) non è rescuabile (Jina ritorna HTML). Nessuno dei 17 lo usa.
- **Verifica per-crawler in CI non eseguibile pre-merge**: la logica è live-verificata sulla stessa primitiva Jina, ma il run reale di ogni crawler gira solo in Actions. **Revert-trigger**: se dopo il merge un crawler tra i 17 resta a 0 job, controllare se il suo WAF blocca anche il pool Jina oltre il retry-budget (alzare `JOBS_JINA_RETRIES`) o se la sorgente è JS-rendered (fuori scope).
- **Budget retry sotto outage ampio** (#1461 item 2): invariato da questa PR (il path connection-level era già così); non peggiorato perché il nuovo path scatta SOLO su una challenge-page reale, non su fetch sani.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Update (review round 2)
- 🔴 risolto: wired i 4 bespoke funnel-critical nominati (inselspital, see-spital, spital-davos, caritas-schweiz).
- 🟡 risolto: rimosso marker ridondante `/.well-known/sgcaptcha` (substring di `sgcaptcha`).
- **Popolazione bespoke residua (~76 parser-lib)**: un grep ha rilevato ~80 `*-job-parser.mjs` che fanno `await fetch()` + `res.text()` fuori dal chokepoint condiviso. Coprirli tutti in questa PR = 76 edit copy-paste one-line → churn + rischio drift, **altitude sbagliata**. Il fix corretto è migrarli sul `fetchHtml` condiviso (che ora ha il rescue by-construction) — **follow-up dedicato**. Questa PR copre TUTTI i chokepoint condivisi (template/hospital/SF) + i 9 bespoke più funnel-critical (schindler/hirslanden/pdgr×2/nestle + i 4 del review). I residui non-coperti restano graceful-degraded esattamente come oggi (0 regressione): se uno serve un 200-challenge resta a 0 job finché non migrato, come prima di questa PR.
