### PR TITLE
feat(ci): pipeline hardening — vitest-gated auto-merge, auto-rebase, collision detector, bounded 🔴 fixer

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -1,8 +1,28 @@
 name: Auto-merge on Claude LGTM
 
+# Auto-merge scatta SOLO quando coesistono DUE condizioni, qualunque arrivi prima:
+#   A) review claude-bot sulla HEAD corrente con `## LGTM` e NO `🔴 Important`;
+#   B) check-run `vitest (unit + integration)` sulla HEAD == `success`.
+# In passato il gate vitest bloccava SOLO su conclusion==failure: se vitest era
+# pending/mancante il merge PROCEDEVA → una PR poteva mergiare prima della fine
+# dei test e, se poi andavano rossi, main andava rosso (osservato #1454: LGTM
+# mentre vitest girava → vitest failure → main red cascade). Ora il merge
+# richiede vitest == success.
+#
+# Per coprire entrambi gli ordini di arrivo ci sono DUE trigger:
+#   - pull_request_review (LGTM appena postato): se vitest non è ancora success,
+#     esce 0 quietamente — il completamento di `tests` ri-valuterà.
+#   - workflow_run di `tests` completato: se vitest è verde, risolve la PR dalla
+#     head e ri-valuta (potrebbe esserci già un `## LGTM` in attesa).
+# La decisione è centralizzata in scripts/ci/auto-merge-eval.mjs (single source
+# of truth: stessi gate per entrambi i trigger).
+
 on:
   pull_request_review:
     types: [submitted]
+  workflow_run:
+    workflows: ['tests'] # name: del workflow tests.yml (check-run vitest)
+    types: [completed]
 
 permissions:
   contents: write
@@ -10,29 +30,24 @@ permissions:
 
 jobs:
   auto-merge:
-    # Trigger condizioni:
-    # - review autore = GitHub App "claude[bot]" (user.type=='Bot' + startsWith
-    #   safety net).
-    # - review.state = "commented" (gh pr review --comment).
-    # - body contiene `## LGTM` (signal esplicito da REVIEW.md: "Zero 🔴
-    #   Important: chiudi con `## LGTM`"). Sostituisce il check precedente
-    #   `!contains(body, '🔴')` che generava false negatives quando il bot
-    #   scriveva meta-language tipo "Nessun 🔴 Important" per affermare zero
-    #   blocker — l'emoji nel testo di negazione bloccava il merge.
-    # - body NON contiene `🔴 Important` (guard belt-and-suspenders contro
-    #   reviewer-error: se il bot scrive `## LGTM` per sbaglio E lascia un
-    #   `🔴 Important` nei findings, l'auto-merge non scatta). Token
-    #   `🔴 Important` (non solo emoji 🔴) per evitare di bloccare merge dove
-    #   l'emoji appare in legend/meta-language. REVIEW.md istruisce comunque
-    #   il reviewer a NON scrivere `## LGTM` con 🔴 aperto.
-    # - PR non draft.
+    # Pre-filtro a livello di evento (il resto dei gate è in auto-merge-eval.mjs,
+    # uguale per entrambi i trigger):
+    #   - pull_request_review: review autore = claude-bot (user.type=='Bot' +
+    #     startsWith 'claude'), state 'commented', body con `## LGTM` e senza
+    #     `🔴 Important`, PR non draft.
+    #   - workflow_run: solo se la run di `tests` è conclusa con success (vitest
+    #     verde) — altrimenti inutile valutare.
     if: |
-      github.event.review.user.type == 'Bot' &&
-      startsWith(github.event.review.user.login, 'claude') &&
-      github.event.review.state == 'commented' &&
-      contains(github.event.review.body, '## LGTM') &&
-      !contains(github.event.review.body, '🔴 Important') &&
-      github.event.pull_request.draft == false
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.type == 'Bot' &&
+        startsWith(github.event.review.user.login, 'claude') &&
+        github.event.review.state == 'commented' &&
+        contains(github.event.review.body, '## LGTM') &&
+        !contains(github.event.review.body, '🔴 Important') &&
+        github.event.pull_request.draft == false)
+      ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       # ── Perché tutto questo setup per un semplice merge ──────────────────
@@ -75,74 +90,63 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
-      # ── vitest gate guard ────────────────────────────────────────────
-      # PERCHÉ: l'auto-merge scatta appena il reviewer Claude posta `## LGTM`,
-      # SENZA aspettare la CI (design "don't wait for CI" — vedi AGENTS.md). Ma
-      # `tests.yml` (job `vitest (unit + integration)`) si auto-dichiara
-      # "BLOCKING CI gate": se i test sono ROSSI e il reviewer dà comunque LGTM
-      # (es. PR #955, che ha mergiato con `tests/faq-coverage.test.ts` rosso →
-      # main rosso fino al fix di follow-up), il merge avveniva lo stesso.
-      # COSA: prima di mergiare, leggiamo i check-runs della HEAD SHA della PR e
-      # cerchiamo il check `vitest (unit + integration)`.
-      #   - conclusion == failure  → ROSSO NOTO: failiamo il job (no merge).
-      #   - conclusion == success  → verde: si procede.
-      #   - pending/queued/mancante/altro (non ancora concluso) → si procede,
-      #     così NON aggiungiamo latenza nel caso comune (preserva il design
-      #     "don't wait for CI"). Blocchiamo SOLO su un fallimento NOTO.
-      # AUTH: query read-only sui check-runs → basta `GH_TOKEN: github.token`
-      # (non serve il GITHUB_PAT, che resta dedicato al merge col cascade).
-      - name: Block merge if vitest gate is RED
+      # ── Risolvi il PR number dall'evento ─────────────────────────────────
+      # pull_request_review: PR = quella dell'evento.
+      # workflow_run: l'evento NON porta il PR; lo risolviamo dalla head del run
+      # di `tests`. Prima via head_sha (più preciso: matcha il commit testato),
+      # poi fallback su head_branch. Se non c'è PR aperta per quella head →
+      # niente da fare (pr_number resta vuoto, lo step di merge fa skip).
+      - name: Resolve PR number
+        id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_PR: ${{ github.event.pull_request.number }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # HEAD SHA della PR (il commit che la CI ha effettivamente testato).
-          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q .headRefOid)
-          echo "PR #$PR_NUMBER HEAD SHA: $HEAD_SHA"
-          # conclusion del check-run `vitest (unit + integration)` per quella SHA.
-          # Stringa vuota se il check non è ancora stato registrato/concluso.
-          VITEST_CONCLUSION=$(gh api \
-            "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
-            --jq '[.check_runs[] | select(.name == "vitest (unit + integration)")][0].conclusion // ""')
-          echo "vitest gate conclusion: '${VITEST_CONCLUSION:-<none>}'"
-          if [ "$VITEST_CONCLUSION" = "failure" ]; then
-            echo "::error::vitest gate is RED — refusing to auto-merge to protect main; fix tests, re-review"
-            exit 1
-          elif [ "$VITEST_CONCLUSION" = "success" ]; then
-            echo "vitest gate è VERDE — procedo col merge."
-          else
-            echo "::warning::vitest gate non ancora concluso (conclusion='${VITEST_CONCLUSION:-<none>}') — procedo (design: non aspetto la CI, blocco solo su fallimento NOTO)."
+          set -uo pipefail
+          if [ "$EVENT_NAME" = "pull_request_review" ]; then
+            echo "pr_number=$REVIEW_PR" >> "$GITHUB_OUTPUT"
+            echo "Risolto PR #$REVIEW_PR (pull_request_review)."
+            exit 0
           fi
+          # workflow_run: cerca la PR aperta con quella head SHA.
+          PRN=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+            --jq '[.[] | select(.state == "open")][0].number // empty' 2>/dev/null || true)
+          if [ -z "${PRN:-}" ] && [ -n "${RUN_HEAD_BRANCH:-}" ]; then
+            PRN=$(gh pr list --repo "$REPO" --head "$RUN_HEAD_BRANCH" --state open \
+              --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          fi
+          if [ -z "${PRN:-}" ]; then
+            echo "Nessuna PR aperta per head_sha=$RUN_HEAD_SHA / branch=$RUN_HEAD_BRANCH — niente da mergiare."
+          else
+            echo "Risolto PR #$PRN (workflow_run tests completato)."
+          fi
+          echo "pr_number=${PRN:-}" >> "$GITHUB_OUTPUT"
 
-      - name: Squash-merge + delete branch
+      # ── Valutazione unica + merge ────────────────────────────────────────
+      # La decisione (LGTM + vitest==success + collision gate) e il merge vivono
+      # in auto-merge-eval.mjs, identici per entrambi i trigger. Esce 0 quando un
+      # gate non è soddisfatto (l'altro trigger ri-valuterà): non è un errore.
+      - name: Evaluate gates + squash-merge
+        if: steps.resolve.outputs.pr_number != ''
         env:
+          # GH_TOKEN read-only per le query (check-runs/reviews/compare).
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           # Token primario = env.GITHUB_PAT (da Remote Config): il push del merge
           # triggera deploy.yml + tests + lighthouse, e il pull_request:closed
           # triggera post-merge-followup. Il GITHUB_TOKEN di fallback serve in
           # DUE casi (entrambi → merge avviene ma senza cascade, = pre-fix):
           #   1. RC non carica → env.GITHUB_PAT vuoto → fallback diretto.
           #   2. Merge col PAT fallisce (es. PAT senza scope PR-write) → retry
-          #      sotto con GITHUB_TOKEN, così l'auto-merge non si rompe mai.
-          PRIMARY_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #      con GITHUB_TOKEN, così l'auto-merge non si rompe mai.
+          MERGE_PRIMARY_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          MERGE_FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAS_PAT: ${{ env.GITHUB_PAT != '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [ "$HAS_PAT" = "true" ]; then
-            echo "Auto-merge PR #$PR_NUMBER via GITHUB_PAT (cascade atteso: deploy + followup)."
-          else
-            echo "::warning::GITHUB_PAT assente — merge via GITHUB_TOKEN, nessun cascade (deploy/followup non partiranno)."
-          fi
-          if ! GH_TOKEN="$PRIMARY_TOKEN" gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$REPO"; then
-            if [ "$HAS_PAT" = "true" ]; then
-              echo "::warning::Merge col GITHUB_PAT fallito (scope insufficiente?) — retry con GITHUB_TOKEN, nessun cascade."
-              GH_TOKEN="$FALLBACK_TOKEN" gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$REPO"
-            else
-              exit 1
-            fi
-          fi
+        run: node scripts/ci/auto-merge-eval.mjs "${{ steps.resolve.outputs.pr_number }}"
 
       - name: Cleanup Firebase credentials
         if: always()

--- a/.github/workflows/pr-autorebase.yml
+++ b/.github/workflows/pr-autorebase.yml
@@ -1,0 +1,85 @@
+name: PR auto-rebase (near-merge only, no-Claude)
+
+# Esegue davvero il rebase che stale-pr-rescuer si limita a SUGGERIRE: una PR a
+# un passo dal merge ma dietro main resta ferma perché nessuno fa
+# `git merge origin/main`. Qui lo facciamo, ma FRUGALMENTE — un push di rebase
+# ri-triggera pr-review-loop (= quota Claude Max condivisa), quindi tocchiamo
+# SOLO le PR "near-merge" (LGTM già dato, oppure label collision-risk/
+# stale-review). Tutto deterministico (scripts/ci/pr-autorebase.mjs + gh + git).
+# ZERO Claude.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # ogni 30min
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Solo log, niente merge/push/label/commenti'
+        type: boolean
+        default: false
+
+# Una rebase-run alla volta: evita push concorrenti sullo stesso branch.
+concurrency:
+  group: pr-autorebase
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autorebase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # serve l'intera storia per merge origin/main nei branch
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna Firebase SA — GITHUB_PAT non caricato; autorebase inerte (push via GITHUB_TOKEN NON ri-triggererebbe review/vitest — anti-ricorsione)."
+          fi
+
+      - name: Load secrets from Remote Config (GITHUB_PAT)
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Rebase near-merge PRs (deterministic, no Claude)
+        env:
+          # PAT OBBLIGATORIO: il push del rebase deve ri-triggerare pr-review-loop
+          # + tests (GITHUB_TOKEN no, anti-ricorsione → review/vitest non
+          # ripartirebbero e la PR resterebbe comunque ferma).
+          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::GITHUB_PAT assente → autorebase inerte (push non ri-triggererebbe review/vitest)."
+            exit 0
+          fi
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            node scripts/ci/pr-autorebase.mjs --dry-run
+          else
+            node scripts/ci/pr-autorebase.mjs
+          fi
+
+      - name: Cleanup Firebase credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/.github/workflows/pr-collision-detector.yml
+++ b/.github/workflows/pr-collision-detector.yml
@@ -1,0 +1,81 @@
+name: PR collision detector (funnel-critical, no-Claude)
+
+# Rileva coppie di PR aperte che toccano gli STESSI file funnel-critical (root
+# cause del main-red #1454↔#1459: due PR parallele sugli stessi file, la seconda
+# mergiata senza rebase). Etichetta `collision-risk` su entrambe → il gate di
+# auto-merge-on-lgtm (P1) blocca il merge della seconda finché non è rebasata
+# oltre la prima. Tutto deterministico (scripts/ci/pr-collision-detector.mjs).
+# ZERO Claude.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '*/30 * * * *' # ricalcolo periodico (anche per togliere la label)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Solo log, niente label/commenti'
+        type: boolean
+        default: false
+
+# Serializza: evita due scan concorrenti che si pestano sulle label.
+concurrency:
+  group: pr-collision-detector
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "ℹ️ Nessuna Firebase SA — GITHUB_PAT non caricato; le label collision-risk verranno applicate via GITHUB_TOKEN (sufficiente per il gating di P1)."
+          fi
+
+      - name: Load secrets from Remote Config (GITHUB_PAT)
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Detect funnel-critical collisions (deterministic, no Claude)
+        env:
+          # PAT preferito per coerenza con gli altri workflow, ma una label via
+          # GITHUB_TOKEN è sufficiente per il gating di P1 → fallback su token.
+          GH_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            node scripts/ci/pr-collision-detector.mjs --dry-run
+          else
+            node scripts/ci/pr-collision-detector.mjs
+          fi
+
+      - name: Cleanup Firebase credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -30,13 +30,16 @@ jobs:
   redflag-fix:
     # Gate evento (tutti necessari):
     #   - review autore = claude-bot (user.type=='Bot' + startsWith 'claude').
-    #   - review body contiene un 🔴 (finding important).
+    #   - review body contiene `🔴 Important` (finding important reale; NON il
+    #     bare 🔴 che può comparire in prosa/legenda anche in una review LGTM
+    #     pulita → falso trigger che brucerebbe un round Claude. Simmetrico col
+    #     gate di blocco in auto-merge-eval.mjs).
     #   - PR autonoma: autore Bot OPPURE head ref `fix/*`. MAI su PR umane.
     #   - PR non draft.
     if: |
       github.event.review.user.type == 'Bot' &&
       startsWith(github.event.review.user.login, 'claude') &&
-      contains(github.event.review.body, '🔴') &&
+      contains(github.event.review.body, '🔴 Important') &&
       github.event.pull_request.draft == false &&
       (github.event.pull_request.user.type == 'Bot' ||
        startsWith(github.event.pull_request.head.ref, 'fix/'))

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -1,0 +1,204 @@
+name: PR 🔴 fixer (bounded loop-closure on bot PRs)
+
+# Quando il reviewer Claude posta un `🔴` su una PR autonoma (bot-authored o
+# head `fix/*`), questo workflow auto-applica il fix sullo stesso branch — in
+# modo BOUNDED. Il push ri-triggera pr-review-loop (re-review) → se pulito,
+# auto-merge; se 🔴 di nuovo, questo workflow ri-parte fino al round cap.
+# NON agisce mai su PR scritte da umani.
+#
+# ANTI-LOOP: un marker nascosto `<!-- REDFLAG_FIX_ROUND: N -->` sulla PR conta i
+# round. A N>=2 → label `needs-human` + escalation, STOP senza Claude (frugalità
+# quota: non bruciare turni in un loop che non converge).
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+# Un fixer alla volta per PR: evita due round Claude concorrenti sullo stesso
+# branch (push race).
+concurrency:
+  group: redflag-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  redflag-fix:
+    # Gate evento (tutti necessari):
+    #   - review autore = claude-bot (user.type=='Bot' + startsWith 'claude').
+    #   - review body contiene un 🔴 (finding important).
+    #   - PR autonoma: autore Bot OPPURE head ref `fix/*`. MAI su PR umane.
+    #   - PR non draft.
+    if: |
+      github.event.review.user.type == 'Bot' &&
+      startsWith(github.event.review.user.login, 'claude') &&
+      contains(github.event.review.body, '🔴') &&
+      github.event.pull_request.draft == false &&
+      (github.event.pull_request.user.type == 'Bot' ||
+       startsWith(github.event.pull_request.head.ref, 'fix/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna Firebase SA — GITHUB_PAT non caricato; il push del fix userà GITHUB_TOKEN (non ri-triggera la re-review automatica)."
+          fi
+
+      - name: Load secrets from Remote Config (GITHUB_PAT)
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      # ── Round cap + capability guard (deterministico, prima di Claude) ────
+      # Conta i marker `<!-- REDFLAG_FIX_ROUND: N -->` già sulla PR. A N>=2 →
+      # escalation a needs-human, STOP senza Claude. Altrimenti incrementa.
+      # Capability guard: se la PR tocca .github/workflows/** e non c'è PAT, il
+      # push verrebbe rifiutato (scope workflows) → skip senza bruciare un turno.
+      - name: Round cap + capability guard + tier
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HAS_PAT: ${{ env.GITHUB_PAT != '' }}
+        run: |
+          set -uo pipefail
+          MAX_ROUNDS=2
+
+          # Round corrente = numero di marker già presenti.
+          comments=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | .body] | join("\n")' 2>/dev/null || echo "")
+          ROUND=$(printf '%s' "$comments" | grep -oE 'REDFLAG_FIX_ROUND: [0-9]+' \
+            | grep -oE '[0-9]+' | sort -rn | head -1 || true)
+          ROUND=${ROUND:-0}
+          NEXT=$((ROUND + 1))
+          echo "Round 🔴-fix correnti: $ROUND (cap $MAX_ROUNDS)"
+
+          if [ "$ROUND" -ge "$MAX_ROUNDS" ]; then
+            echo "::warning::Round cap raggiunto ($ROUND >= $MAX_ROUNDS) → escalation needs-human, no Claude."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-human" 2>/dev/null \
+              || echo "label needs-human assente — creala: gh label create needs-human"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '🛑 **needs-human** (auto): il 🔴-fixer ha già tentato %s round senza chiudere i findings 🔴. STOP automatico (anti-loop, frugalità quota). Serve revisione umana: leggi le review più recenti e applica il fix a mano.' "$ROUND")" \
+              2>/dev/null || true
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # File cambiati dalla PR (per tier + capability guard).
+          files=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' 2>/dev/null || echo "")
+          touches_wf=$(echo "$files" | grep -E '^\.github/workflows/' || true)
+          if [ -n "$touches_wf" ] && [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::PR tocca .github/workflows/** ma manca PAT (scope workflows) → push rifiutato, skip senza bruciare un turno Claude."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '⏭️ 🔴-fixer skip: la PR tocca \x60.github/workflows/**\x60 e non è disponibile un PAT con scope \x60workflows\x60 → il push fallirebbe. Applicare il fix dei 🔴 a mano.')" \
+              2>/dev/null || true
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Tier (mirror di pr-review-loop / issue-fix): high (opus) se la PR
+          # tocca CODE funnel-critical (tests/, build-plugins/, scripts/lib/,
+          # services/seo*), normal (sonnet) altrimenti.
+          crit=$(echo "$files" | grep -E '^(tests/|build-plugins/|scripts/lib/|services/seo)' || true)
+          if [ -n "$crit" ]; then
+            echo "tier=high"   >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-4-8"   >> "$GITHUB_OUTPUT"
+          else
+            echo "tier=normal" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Posta/incrementa il marker round PRIMA di invocare Claude (così se la
+          # run muore, il round è comunque contato → l'anti-loop tiene).
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '<!-- REDFLAG_FIX_ROUND: %s -->\n_🔴-fixer round %s/%s avviato (auto)._' "$NEXT" "$NEXT" "$MAX_ROUNDS")" \
+            2>/dev/null || true
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "round=$NEXT"  >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          git config user.name "Valerie Linc"
+          git config user.email "valerielinc@gmail.com"
+
+      # Push via PAT (ri-attiva pr-review-loop = re-review). Senza PAT il push
+      # userebbe GITHUB_TOKEN e la re-review non partirebbe (anti-ricorsione);
+      # il fix verrebbe comunque committato. Esposto come remote authenticato.
+      - name: Configure PAT remote
+        if: steps.guard.outputs.proceed == 'true' && env.GITHUB_PAT != ''
+        env:
+          GITHUB_PAT: ${{ env.GITHUB_PAT }}
+          REPO: ${{ github.repository }}
+        run: git remote set-url origin "https://x-access-token:${GITHUB_PAT}@github.com/${REPO}.git"
+
+      - name: Run Claude 🔴-fix
+        id: claude_review
+        if: steps.guard.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+          FIX_TIER: ${{ steps.guard.outputs.tier }}
+          FIX_ROUND: ${{ steps.guard.outputs.round }}
+        with:
+          # Auth via subscription Max (zero API cost). MAI ANTHROPIC_API_KEY.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          # Le review/PR autonome sono di claude[bot] / github-actions[bot].
+          allowed_bots: 'github-actions[bot], claude[bot]'
+          claude_args: "--max-turns 30 --model ${{ steps.guard.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
+          prompt: |
+            Sei l'agent di chiusura 🔴 per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.guard.outputs.tier }}. Round: ${{ steps.guard.outputs.round }}/2.
+
+            **Bootstrap:**
+            1. Leggi `REVIEW.md` (severity/scopo) + `AGENTS.md` (non-negotiables + Privacy). VINCOLANTI.
+            2. Carica la PR + le review: `gh pr view $PR_NUMBER --json title,body,headRefName,files`, `gh api repos/$REPO/pulls/$PR_NUMBER/reviews --jq '[.[] | select(.user.login|test("claude";"i"))] | last | .body'`. Il branch è già checkoutato sulla head della PR.
+
+            **Obiettivo:** applica un fix CLASS-COMPLETE ai SOLI findings `🔴 Important` della review più recente su QUESTO branch. NON mergiare.
+
+            **Regole:**
+            - Fix CHIRURGICO alla CLASSE del bug (AGENTS.md non-negotiable #6): se il 🔴 segnala un pattern (regex/guard/floor/threshold/selector/idiom), `rg` i sibling funnel-critical (`scripts/update-*.mjs`, `scripts/lib/*-parser.mjs`, `build-plugins/**`, `services/seoService.ts`) e sweepa l'intera classe nella STESSA commit, oppure giustifica ogni sibling non toccato in `## Non implementato`.
+            - Mai abbassare quality gate/test/validation/SEO gate per "far passare" (#1). Mai disabilitare AdSense Auto Ads (#7). Mai path home assoluti o email personali (Privacy).
+            - CODE vs DATA: non scorrere i blob `data/**`/`public/**`; fixa il CODE che li genera.
+            - Esegui i test pertinenti: `npm test` (o il subset rilevante) per validare il fix prima di committare.
+            - Commit con identity canonica già configurata (Valerie Linc <valerielinc@gmail.com>), messaggio conventional, nessuna email non-canonica in coda.
+            - Push sullo stesso branch: `git push origin HEAD:${{ github.event.pull_request.head.ref }}`. Il remote `origin` è già autenticato col PAT (se disponibile) → ri-attiva pr-review-loop (re-review). Se il push fallisce per scope/auth → documenta in un commento e TERMINA.
+            - Aggiorna il body della PR (`gh pr edit $PR_NUMBER --body`) mantenendo `## Implementato` (aggiungi cosa hai fixato) + `## Non implementato (ancora)`.
+
+            **Constraint:**
+            - SOLO i 🔴 della review corrente. Non rifare l'intera PR, non drive-by.
+            - Se i 🔴 non sono fixabili con confidenza (root cause non chiara / serve giudizio umano) → commenta "🔴 non auto-fixabile: <motivo>" e TERMINA senza commit (il round cap + needs-human gestiranno l'escalation).
+            - Una sola passata: applica, valida, committa, pusha, aggiorna body, STOP.
+
+      - name: Claude usage metrics
+        if: always() && steps.guard.outputs.proceed == 'true'
+        run: node scripts/ci/claude-usage-summary.mjs "${{ steps.claude_review.outputs.execution_file }}" "pr-redflag-fixer"
+
+      - name: Cleanup Firebase credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -204,8 +204,19 @@ After dispatching, **does not wait**. All crawlers run concurrently. `translate-
 
 **`auto-merge-on-lgtm.yml`**
 
-- Fires on `pull_request_review` events where the review author is the Claude review bot.
-- If the review body contains the exact marker `## LGTM`, squash-merges the PR via `gh pr merge --squash --delete-branch`. Any other body content is a no-op. See `REVIEW.md` for which review outcomes are allowed to emit `## LGTM`.
+- Fires on **two** triggers: `pull_request_review` (the Claude review bot just posted) **and** `workflow_run` of the `tests` workflow `completed` (vitest just finished). Either ordering is covered.
+- The merge decision is centralized in `scripts/ci/auto-merge-eval.mjs` (single source of truth, identical gates for both triggers). It squash-merges PR `N` **only when ALL hold**: PR open + not draft; the latest claude-bot review on the **current head** contains `## LGTM` and **not** `🔴 Important`; the `vitest (unit + integration)` check-run on the head is `success` (**not** merely `!= failure` — pending/missing does **not** merge); and the P3 collision gate passes. Merge mechanism unchanged (PAT primary for the deploy/follow-up cascade, `GITHUB_TOKEN` fallback). See `REVIEW.md` for which outcomes emit `## LGTM`.
+- **Why two triggers + require-success:** previously the gate only blocked on vitest `conclusion == failure`; a pending/missing vitest **proceeded** → a PR could merge before its tests finished, and if they went red, main went red (`#1454`: merged on LGTM while vitest was still running → vitest failed → main red cascade). On `pull_request_review` with vitest not yet `success`, the job exits 0 quietly; the `tests` completion re-evaluates.
+
+### Pipeline hardening — auto-rebase, collision detector, bounded 🔴 fixer
+
+Three deterministic (zero-Claude) helpers + one bounded Claude fixer close the gaps around near-merge PRs. **Labels used:** `collision-risk` (P1 gate input), `needs-human` (P4 escalation), plus the existing `stale-review`. Create them once if missing: `gh label create collision-risk` / `gh label create needs-human` (idempotent, `|| true`).
+
+| Workflow | Trigger | Role |
+|---|---|---|
+| `.github/workflows/pr-autorebase.yml` | `schedule` `*/30` + dispatch | `scripts/ci/pr-autorebase.mjs`: actually runs `git merge origin/main` + push (PAT) for **near-merge** PRs behind main, so review + vitest re-run. **Frugality gate:** only PRs that already have a `## LGTM` review or carry `collision-risk`/`stale-review` (a rebase push re-triggers the Claude reviewer = quota). `MERGEABLE` only; `CONFLICTING` → abort + ensure `stale-review` + one dedup'd comment (`<!-- AUTOREBASE_CONFLICT -->`). Cap ~10 PR/run. |
+| `.github/workflows/pr-collision-detector.yml` | `pull_request` (open/sync/reopen) + `schedule` `*/30` + dispatch | `scripts/ci/pr-collision-detector.mjs`: labels `collision-risk` on **both** PRs of any open pair sharing ≥1 funnel-critical file (globs: `scripts/lib/**`, `build-plugins/**`, `services/seoService.ts`, `services/seo/**`, `.github/workflows/**`, `scripts/update-*.mjs`), one dedup'd comment per PR (`<!-- COLLISION:<other> -->`). Recomputed every run — removes the label when a PR no longer collides. This feeds P1's collision gate: the second-to-merge must rebase past the first. Root cause of the `#1454`↔`#1459` main-red. |
+| `.github/workflows/pr-redflag-fixer.yml` | `pull_request_review` submitted | When the reviewer posts a `🔴` on an **autonomous** PR (author Bot **or** head `fix/*` — never human PRs), Claude applies a class-complete fix on the same branch, runs tests, commits (canonical identity) + pushes (PAT re-triggers re-review). **Anti-loop:** a hidden `<!-- REDFLAG_FIX_ROUND: N -->` marker counts rounds; at `N>=2` → label `needs-human` + escalation comment, **STOP without Claude**. Capability guard: PR touching `.github/workflows/**` without a PAT → skip (push would be rejected). Tier: opus if funnel-critical (`tests/`, `build-plugins/`, `scripts/lib/`, `services/seo*`) else sonnet. Auth via `CLAUDE_CODE_OAUTH_TOKEN`. |
 
 ### GITHUB_TOKEN Limitation
 

--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -1,0 +1,156 @@
+/**
+ * auto-merge-eval.mjs — decisione di auto-merge (deterministico, zero-Claude).
+ *
+ * Centralizza la SINGOLA valutazione di merge usata da entrambi i trigger di
+ * auto-merge-on-lgtm.yml:
+ *   - `pull_request_review: submitted` (il reviewer ha appena postato `## LGTM`)
+ *   - `workflow_run` del workflow `tests` completato (vitest appena concluso)
+ * In passato la decisione viveva inline nello YAML e bloccava SOLO su vitest
+ * conclusion == failure: se vitest era pending/mancante l'auto-merge PROCEDEVA →
+ * una PR poteva mergiare PRIMA che i test finissero, e se poi andavano rossi
+ * main andava rosso (osservato #1454: LGTM mentre vitest girava → vitest failure
+ * → main red cascade). Qui il merge scatta SOLO con vitest == success.
+ *
+ * Dato un PR number, valuta (e logga ogni gate):
+ *   1. PR aperta e NON draft.
+ *   2. Ultima review del bot reviewer (login startsWith `claude`, type Bot) sulla
+ *      HEAD corrente contiene `## LGTM` e NON `🔴 Important`.
+ *   3. check-run `vitest (unit + integration)` sulla HEAD == `success`
+ *      (NON solo != failure: richiede success → niente merge su pending/missing).
+ *   4. Collision gate (P3): se la PR ha label `collision-risk` ED è behind
+ *      origin/main → NON mergiare (va prima rebasata oltre la PR collidente;
+ *      pr-autorebase la rebasa). `collision-risk` ma 0 behind → consentito.
+ *
+ * Se tutti i gate passano → squash-merge con PAT (stesso meccanismo di prima:
+ * PRIMARY_TOKEN=GITHUB_PAT per il cascade deploy/followup, fallback GITHUB_TOKEN).
+ *
+ * Uso:  node scripts/ci/auto-merge-eval.mjs <prNumber>
+ * Env:  GH_TOKEN (read-only, per le query), GITHUB_REPOSITORY,
+ *       MERGE_PRIMARY_TOKEN (PAT o GITHUB_TOKEN), MERGE_FALLBACK_TOKEN,
+ *       HAS_PAT ('true'|'false'). Richiede `gh` in PATH.
+ *
+ * Exit 0 sempre (anche quando NON mergia): un gate non soddisfatto è un esito
+ * atteso (l'altro trigger ri-valuterà), non un errore di workflow.
+ */
+import { execFileSync } from 'node:child_process';
+
+const REPO = process.env.GITHUB_REPOSITORY || '';
+const PR = process.argv[2];
+
+function gh(args, { json = true, token } = {}) {
+  const env = { ...process.env };
+  if (token) env.GH_TOKEN = token;
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, env });
+  return json ? JSON.parse(out) : out;
+}
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(0); // esito atteso, non errore di workflow
+}
+
+function main() {
+  if (!REPO) fail('GITHUB_REPOSITORY mancante — skip.');
+  if (!PR || !/^\d+$/.test(PR)) fail(`PR number mancante/invalido ('${PR}') — skip.`);
+  console.log(`auto-merge-eval PR #${PR} repo=${REPO}`);
+
+  // 1. PR data.
+  let pr;
+  try {
+    pr = gh(['pr', 'view', PR, '--repo', REPO, '--json',
+      'number,state,isDraft,headRefOid,labels,mergeStateStatus']);
+  } catch (e) {
+    return fail(`Impossibile leggere PR #${PR}: ${String(e).slice(0, 160)} — skip.`);
+  }
+  if (pr.state !== 'OPEN') return fail(`PR #${PR} stato=${pr.state} (non OPEN) — skip.`);
+  if (pr.isDraft) return fail(`PR #${PR} è draft — skip.`);
+  const head = pr.headRefOid;
+  const labels = (pr.labels || []).map((l) => l.name);
+  console.log(`HEAD SHA: ${head} · labels: [${labels.join(', ') || '—'}]`);
+
+  // 2. Ultima review del bot reviewer sulla HEAD corrente: `## LGTM` e NO 🔴 Important.
+  let reviews;
+  try {
+    reviews = gh(['api', `repos/${REPO}/pulls/${PR}/reviews`, '--paginate']);
+  } catch (e) {
+    return fail(`Impossibile leggere reviews PR #${PR}: ${String(e).slice(0, 160)} — skip.`);
+  }
+  const botReviews = (reviews || []).filter(
+    (r) => r.user && r.user.type === 'Bot' && /^claude/i.test(r.user.login || '')
+  );
+  const lastBot = botReviews.length ? botReviews[botReviews.length - 1] : null;
+  if (!lastBot) return fail(`Nessuna review claude-bot su PR #${PR} — skip.`);
+  const body = lastBot.body || '';
+  if (lastBot.commit_id && lastBot.commit_id !== head) {
+    return fail(`Ultima review claude-bot riferita a ${lastBot.commit_id} ≠ HEAD ${head} (stale) — skip; un push nuovo ri-attiverà il review.`);
+  }
+  if (!body.includes('## LGTM')) return fail(`Ultima review claude-bot senza '## LGTM' — skip.`);
+  if (body.includes('🔴 Important')) return fail(`Ultima review claude-bot contiene '🔴 Important' — skip (no merge).`);
+  console.log('Gate review: ## LGTM presente, nessun 🔴 Important ✔');
+
+  // 3. vitest check-run == success (NON solo != failure).
+  let conclusion = '';
+  try {
+    conclusion = gh(['api', `repos/${REPO}/commits/${head}/check-runs?per_page=100`,
+      '--jq', '[.check_runs[] | select(.name == "vitest (unit + integration)")][0].conclusion // ""'],
+      { json: false }).trim();
+  } catch (e) {
+    return fail(`Impossibile leggere check-runs HEAD ${head}: ${String(e).slice(0, 160)} — skip.`);
+  }
+  if (conclusion !== 'success') {
+    return fail(`vitest gate conclusion='${conclusion || '<none/pending>'}' ≠ success — skip; il completamento di 'tests' ri-valuterà (no merge su pending/missing).`);
+  }
+  console.log('Gate vitest: success ✔');
+
+  // 4. Collision gate (P3): collision-risk + behind main → NO merge (va rebasata).
+  if (labels.includes('collision-risk')) {
+    // `behind` via compare main...head: ahead_by sarebbe i commit della PR;
+    // behind_by = commit di main non nella PR. >0 → la PR è dietro main.
+    let behind = 0;
+    try {
+      const cmp = gh(['api', `repos/${REPO}/compare/main...${head}`, '--jq', '.behind_by // 0'],
+        { json: false }).trim();
+      behind = parseInt(cmp, 10) || 0;
+    } catch (e) {
+      // Se non riesco a calcolare il behind con confidenza, sii conservativo:
+      // una PR collision-risk NON va mergiata al cieco → skip.
+      return fail(`collision-risk PR #${PR}: impossibile calcolare behind_by (${String(e).slice(0, 120)}) — skip conservativo.`);
+    }
+    if (behind > 0) {
+      return fail(`collision-risk PR #${PR} è ${behind} commit dietro main — skip; va rebasata oltre la PR collidente prima del merge (pr-autorebase la gestisce).`);
+    }
+    console.log(`Gate collision: collision-risk ma 0 dietro main → consentito ✔`);
+  }
+
+  // Tutti i gate passano → squash-merge.
+  const hasPat = process.env.HAS_PAT === 'true';
+  const primary = process.env.MERGE_PRIMARY_TOKEN || '';
+  const fallback = process.env.MERGE_FALLBACK_TOKEN || '';
+  if (!primary) return fail('Nessun token di merge disponibile (MERGE_PRIMARY_TOKEN vuoto) — skip.');
+
+  console.log(hasPat
+    ? `Tutti i gate OK → squash-merge PR #${PR} via GITHUB_PAT (cascade atteso: deploy + followup).`
+    : `::warning::Tutti i gate OK → squash-merge PR #${PR} via GITHUB_TOKEN (PAT assente, nessun cascade deploy/followup).`);
+
+  const mergeArgs = ['pr', 'merge', PR, '--squash', '--delete-branch', '--repo', REPO];
+  try {
+    gh(mergeArgs, { json: false, token: primary });
+    console.log(`PR #${PR} mergiata.`);
+  } catch (e) {
+    if (hasPat && fallback) {
+      console.log(`::warning::Merge col GITHUB_PAT fallito (scope insufficiente?) — retry con GITHUB_TOKEN, nessun cascade.`);
+      try {
+        gh(mergeArgs, { json: false, token: fallback });
+        console.log(`PR #${PR} mergiata (fallback GITHUB_TOKEN).`);
+      } catch (e2) {
+        console.error(`::error::Merge fallito anche col fallback: ${String(e2).slice(0, 200)}`);
+        process.exit(1);
+      }
+    } else {
+      console.error(`::error::Merge fallito: ${String(e).slice(0, 200)}`);
+      process.exit(1);
+    }
+  }
+}
+
+main();

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -1,0 +1,218 @@
+/**
+ * pr-autorebase.mjs — rebase reale delle PR a un passo dal merge (zero-Claude).
+ *
+ * stale-pr-rescuer.yml oggi LABELLA + commenta "fai git merge origin/main", ma
+ * nessuno lo esegue → le PR restano ferme. Qui lo automatizziamo, ma con
+ * FRUGALITÀ: un push di rebase ri-triggera pr-review-loop (= quota Claude Max
+ * condivisa), quindi tocchiamo SOLO le PR già "near-merge". Le altre verranno
+ * rebasate quando il loro autore pusha.
+ *
+ * Per ogni PR OPEN non-draft:
+ *   GATE (frugalità): procedi solo se "near-merge" =
+ *     - ha una review claude-bot con `## LGTM` su un qualche commit, OPPURE
+ *     - porta label `collision-risk` o `stale-review`.
+ *     Altrimenti skip.
+ *   - behind = commit di origin/main non nella head; behind==0 → skip.
+ *   - mergeable (gh pr view --json mergeable; UNKNOWN → poll una volta dopo una
+ *     breve attesa; se ancora UNKNOWN → skip questo run).
+ *   - MERGEABLE → fetch + checkout branch + `git merge origin/main` (identity
+ *     canonica). Clean → push via PAT (ri-attiva review + vitest). Log.
+ *   - CONFLITTO (CONFLICTING o merge nonzero) → `git merge --abort`; assicura
+ *     label `stale-review` (così rescuer/recycle gestiscono); commenta UNA volta
+ *     (dedup via marker `<!-- AUTOREBASE_CONFLICT -->`). Niente loop.
+ *   Cap: ~10 PR/run; logga le skippate per cap (AGENTS.md no-silent-cap).
+ *
+ * Uso:  node scripts/ci/pr-autorebase.mjs [--dry-run]
+ * Env:  GH_TOKEN (PAT, per push/label che ri-triggerano i workflow),
+ *       GITHUB_REPOSITORY. Richiede `gh` + `git` in un checkout full-history.
+ */
+import { execFileSync } from 'node:child_process';
+
+const DRY = process.argv.includes('--dry-run');
+const REPO = process.env.GITHUB_REPOSITORY || '';
+const TOKEN = process.env.GH_TOKEN || '';
+const MAX_PER_RUN = 10;
+const CONFLICT_MARKER = '<!-- AUTOREBASE_CONFLICT -->';
+
+function gh(args, { json = true, allowFail = false } = {}) {
+  try {
+    const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    return json ? JSON.parse(out) : out;
+  } catch (e) {
+    if (allowFail) return json ? null : '';
+    throw e;
+  }
+}
+
+function git(args, { allowFail = false } = {}) {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (e) {
+    if (allowFail) return null;
+    throw e;
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function authedUrl() {
+  // Push via PAT così review + vitest ri-partono (anti-ricorsione GITHUB_TOKEN).
+  return `https://x-access-token:${TOKEN}@github.com/${REPO}.git`;
+}
+
+/** Una review claude-bot con `## LGTM` (su qualunque commit)? */
+function hasLgtmReview(num) {
+  const reviews = gh(['api', `repos/${REPO}/pulls/${num}/reviews`, '--paginate'], { allowFail: true });
+  if (!Array.isArray(reviews)) return false;
+  return reviews.some(
+    (r) => r.user && r.user.type === 'Bot' && /^claude/i.test(r.user.login || '') &&
+      (r.body || '').includes('## LGTM')
+  );
+}
+
+/** behind_by: commit di main non nella head. */
+function behindMain(head) {
+  const out = gh(['api', `repos/${REPO}/compare/main...${head}`, '--jq', '.behind_by // 0'],
+    { json: false, allowFail: true });
+  return parseInt((out || '0').trim(), 10) || 0;
+}
+
+/** mergeable con un poll su UNKNOWN. */
+async function mergeableState(num) {
+  let m = gh(['pr', 'view', String(num), '--repo', REPO, '--json', 'mergeable',
+    '--jq', '.mergeable'], { json: false, allowFail: true });
+  m = (m || '').trim();
+  if (m === 'UNKNOWN' || m === '') {
+    await sleep(4000); // GitHub calcola la mergeability in async
+    m = gh(['pr', 'view', String(num), '--repo', REPO, '--json', 'mergeable',
+      '--jq', '.mergeable'], { json: false, allowFail: true });
+    m = (m || '').trim();
+  }
+  return m;
+}
+
+function ensureStaleLabel(num) {
+  if (DRY) { console.log(`[dry] +label stale-review #${num}`); return; }
+  gh(['pr', 'edit', String(num), '--repo', REPO, '--add-label', 'stale-review'],
+    { json: false, allowFail: true });
+}
+
+function commentConflictOnce(num, branch) {
+  // Dedup: salta se il marker è già presente in un commento.
+  const comments = gh(['api', `repos/${REPO}/issues/${num}/comments`, '--paginate',
+    '--jq', '[.[] | .body] | join("\\n")'], { json: false, allowFail: true }) || '';
+  if (comments.includes(CONFLICT_MARKER)) {
+    console.log(`PR #${num}: marker conflitto già presente — no comment.`);
+    return;
+  }
+  const body = `${CONFLICT_MARKER}\n♻️ **autorebase**: \`git merge origin/main\` su \`${branch}\` ha prodotto un CONFLITTO — abort eseguito, branch invariato. Etichettata \`stale-review\`: il branch è dietro main e va rebasato a mano (o verrà riciclato da recycle-stale-prs se resta fermo). _Segnale deterministico da pr-autorebase.yml (zero-Claude)._`;
+  if (DRY) { console.log(`[dry] comment conflict #${num}`); return; }
+  gh(['pr', 'comment', String(num), '--repo', REPO, '--body', body], { json: false, allowFail: true });
+}
+
+async function processPR(pr) {
+  const num = pr.number;
+  const branch = pr.headRefName;
+  const head = pr.headRefOid;
+  const labels = (pr.labels || []).map((l) => l.name);
+
+  // GATE frugalità: solo near-merge.
+  const nearMerge =
+    labels.includes('collision-risk') ||
+    labels.includes('stale-review') ||
+    hasLgtmReview(num);
+  if (!nearMerge) {
+    console.log(`PR #${num} non near-merge (no LGTM/collision-risk/stale-review) — skip.`);
+    return;
+  }
+
+  const behind = behindMain(head);
+  if (behind === 0) { console.log(`PR #${num} 0 dietro main — skip (già up-to-date).`); return; }
+  console.log(`PR #${num} (${branch}) è ${behind} dietro main, near-merge → valuto rebase.`);
+
+  const m = await mergeableState(num);
+  if (m === 'UNKNOWN' || m === '') {
+    console.log(`PR #${num} mergeable=UNKNOWN dopo poll — skip questo run (riprova al prossimo tick).`);
+    return;
+  }
+
+  if (m === 'CONFLICTING') {
+    console.log(`PR #${num} mergeable=CONFLICTING → label stale-review + comment once.`);
+    ensureStaleLabel(num);
+    commentConflictOnce(num, branch);
+    return;
+  }
+
+  if (m !== 'MERGEABLE') {
+    console.log(`PR #${num} mergeable=${m} (non MERGEABLE/CONFLICTING) — skip.`);
+    return;
+  }
+
+  // MERGEABLE → tenta il merge di origin/main nel branch.
+  if (DRY) { console.log(`[dry] rebase #${num}: fetch + merge origin/main + push ${branch}`); return; }
+
+  git(['fetch', 'origin', branch, 'main'], { allowFail: true });
+  // checkout del branch sull'head remoto (worktree CI pulito).
+  const co = git(['checkout', '-B', branch, `origin/${branch}`], { allowFail: true });
+  if (co === null) { console.log(`PR #${num}: checkout di ${branch} fallito — skip.`); return; }
+  git(['config', 'user.name', 'Valerie Linc']);
+  git(['config', 'user.email', 'valerielinc@gmail.com']);
+
+  const merged = git(['merge', '--no-edit', 'origin/main'], { allowFail: true });
+  if (merged === null) {
+    // Conflitto a runtime (mergeable era ottimista o è cambiato).
+    console.log(`PR #${num}: merge origin/main ha conflitto → abort + stale-review + comment.`);
+    git(['merge', '--abort'], { allowFail: true });
+    ensureStaleLabel(num);
+    commentConflictOnce(num, branch);
+    return;
+  }
+
+  // Push via PAT (ri-attiva review + vitest). TOCTOU: tra mergeable-check e push
+  // un nuovo commit potrebbe essere arrivato → push non-fast-forward fallisce
+  // (no --force): semplicemente skip, il prossimo tick ricalcola.
+  const pushed = git(['push', authedUrl(), `${branch}:${branch}`], { allowFail: true });
+  if (pushed === null) {
+    console.log(`PR #${num}: push fallito (probabile non-fast-forward / TOCTOU) — skip, riprova al prossimo tick.`);
+    return;
+  }
+  console.log(`✅ PR #${num}: rebasata su origin/main e pushata (${branch}) → review + vitest ri-partono.`);
+}
+
+async function main() {
+  if (!REPO) { console.error('GITHUB_REPOSITORY mancante'); process.exit(1); }
+  if (!TOKEN) { console.error('::warning::GH_TOKEN (PAT) assente → autorebase inerte (push non ri-triggererebbe i workflow).'); process.exit(0); }
+  console.log(`pr-autorebase${DRY ? ' [DRY-RUN]' : ''} repo=${REPO}`);
+
+  let prs;
+  try {
+    prs = gh(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '50',
+      '--json', 'number,headRefName,headRefOid,isDraft,labels']);
+  } catch (e) {
+    console.error(`gh pr list fallito: ${String(e).slice(0, 160)}`);
+    process.exit(0);
+  }
+  const open = (prs || []).filter((p) => !p.isDraft);
+  console.log(`PR open non-draft: ${open.length}`);
+
+  let processed = 0;
+  let cappedSkipped = 0;
+  for (const pr of open) {
+    if (processed >= MAX_PER_RUN) {
+      cappedSkipped++;
+      continue;
+    }
+    processed++;
+    try {
+      await processPR(pr);
+    } catch (e) {
+      console.log(`::warning::PR #${pr.number} errore in processPR: ${String(e).slice(0, 160)}`);
+    }
+  }
+  if (cappedSkipped > 0) {
+    console.log(`::warning::cap raggiunto (${MAX_PER_RUN}/run): ${cappedSkipped} PR non valutate questo run (verranno valutate al prossimo tick).`);
+  }
+  console.log('autorebase scan completo.');
+}
+
+main();

--- a/scripts/ci/pr-collision-detector.mjs
+++ b/scripts/ci/pr-collision-detector.mjs
@@ -1,0 +1,141 @@
+/**
+ * pr-collision-detector.mjs — rileva PR aperte che toccano gli stessi file
+ * funnel-critical (zero-Claude, deterministico).
+ *
+ * Root cause del main-red #1454↔#1459: due PR aperte in parallelo mutavano gli
+ * stessi file funnel-critical; la seconda mergiata senza rebase sulla prima ha
+ * mandato main rosso. Qui rileviamo a monte le coppie collidenti e le
+ * etichettiamo `collision-risk` → il gate di auto-merge-on-lgtm (P1) impedisce
+ * alla seconda di mergiare finché non è rebasata oltre la prima.
+ *
+ * Logica:
+ *   - lista PR OPEN; per ognuna i file cambiati (gh pr view N --json files).
+ *   - FUNNEL-CRITICAL globs: scripts/lib/**, build-plugins/**,
+ *     services/seoService.ts, services/seo/**, .github/workflows/**,
+ *     scripts/update-*.mjs.
+ *   - per ogni COPPIA di PR open che condivide ≥1 file funnel-critical:
+ *     label `collision-risk` su ENTRAMBE + UN commento per PR che nomina la PR
+ *     collidente + i file condivisi (dedup via marker `<!-- COLLISION:<other> -->`).
+ *   - ricalcolo ad ogni run: una PR che non collide più con nessuna →
+ *     RIMUOVI `collision-risk` (il vecchio commento resta, innocuo).
+ *
+ * Uso:  node scripts/ci/pr-collision-detector.mjs [--dry-run]
+ * Env:  GH_TOKEN (PAT preferito per coerenza; label via GITHUB_TOKEN basta per
+ *       il gating), GITHUB_REPOSITORY. Richiede `gh` in PATH.
+ */
+import { execFileSync } from 'node:child_process';
+
+const DRY = process.argv.includes('--dry-run');
+const REPO = process.env.GITHUB_REPOSITORY || '';
+
+// Glob funnel-critical → predicate. Manteniamo i pattern espliciti e ristretti:
+// allargarli genererebbe falsi positivi (ogni PR collide con ogni PR).
+const FUNNEL_PREDICATES = [
+  (f) => f.startsWith('scripts/lib/'),
+  (f) => f.startsWith('build-plugins/'),
+  (f) => f === 'services/seoService.ts',
+  (f) => f.startsWith('services/seo/'),
+  (f) => f.startsWith('.github/workflows/'),
+  (f) => /^scripts\/update-[^/]*\.mjs$/.test(f),
+];
+
+const isFunnel = (f) => FUNNEL_PREDICATES.some((p) => p(f));
+
+function gh(args, { json = true, allowFail = false } = {}) {
+  try {
+    const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    return json ? JSON.parse(out) : out;
+  } catch (e) {
+    if (allowFail) return json ? null : '';
+    throw e;
+  }
+}
+
+function addLabel(num, label) {
+  if (DRY) { console.log(`[dry] +label ${label} #${num}`); return; }
+  gh(['pr', 'edit', String(num), '--repo', REPO, '--add-label', label], { json: false, allowFail: true });
+}
+
+function removeLabel(num, label) {
+  if (DRY) { console.log(`[dry] -label ${label} #${num}`); return; }
+  gh(['pr', 'edit', String(num), '--repo', REPO, '--remove-label', label], { json: false, allowFail: true });
+}
+
+function commentOnce(num, marker, body) {
+  const comments = gh(['api', `repos/${REPO}/issues/${num}/comments`, '--paginate',
+    '--jq', '[.[] | .body] | join("\\n")'], { json: false, allowFail: true }) || '';
+  if (comments.includes(marker)) {
+    console.log(`PR #${num}: marker ${marker} già presente — no comment.`);
+    return;
+  }
+  if (DRY) { console.log(`[dry] comment ${marker} #${num}`); return; }
+  gh(['pr', 'comment', String(num), '--repo', REPO, '--body', `${marker}\n${body}`], { json: false, allowFail: true });
+}
+
+function main() {
+  if (!REPO) { console.error('GITHUB_REPOSITORY mancante'); process.exit(1); }
+  console.log(`pr-collision-detector${DRY ? ' [DRY-RUN]' : ''} repo=${REPO}`);
+
+  let prs;
+  try {
+    prs = gh(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '50',
+      '--json', 'number,labels']);
+  } catch (e) {
+    console.error(`gh pr list fallito: ${String(e).slice(0, 160)}`);
+    process.exit(0);
+  }
+  prs = prs || [];
+  if (prs.length < 1) { console.log('Nessuna PR aperta.'); return; }
+
+  // File funnel-critical per PR.
+  const funnelFiles = new Map(); // num -> Set(files)
+  const hasLabel = new Map();    // num -> bool collision-risk già presente
+  for (const pr of prs) {
+    hasLabel.set(pr.number, (pr.labels || []).some((l) => l.name === 'collision-risk'));
+    let files = [];
+    try {
+      files = gh(['pr', 'view', String(pr.number), '--repo', REPO, '--json', 'files',
+        '--jq', '[.files[].path]'], { allowFail: true }) || [];
+    } catch { files = []; }
+    const set = new Set(files.filter(isFunnel));
+    funnelFiles.set(pr.number, set);
+    if (set.size) console.log(`PR #${pr.number}: ${set.size} file funnel-critical.`);
+  }
+
+  // Coppie collidenti.
+  const colliders = new Map(); // num -> Map(otherNum -> [shared files])
+  const nums = prs.map((p) => p.number);
+  for (let i = 0; i < nums.length; i++) {
+    for (let j = i + 1; j < nums.length; j++) {
+      const a = nums[i], b = nums[j];
+      const sa = funnelFiles.get(a), sb = funnelFiles.get(b);
+      const shared = [...sa].filter((f) => sb.has(f));
+      if (shared.length) {
+        if (!colliders.has(a)) colliders.set(a, new Map());
+        if (!colliders.has(b)) colliders.set(b, new Map());
+        colliders.get(a).set(b, shared);
+        colliders.get(b).set(a, shared);
+      }
+    }
+  }
+
+  // Applica/rimuovi label + commenta.
+  for (const num of nums) {
+    const cols = colliders.get(num);
+    if (cols && cols.size) {
+      if (!hasLabel.get(num)) addLabel(num, 'collision-risk');
+      else console.log(`PR #${num}: collision-risk già presente.`);
+      for (const [other, shared] of cols) {
+        const list = shared.map((f) => `\`${f}\``).join(', ');
+        commentOnce(num, `<!-- COLLISION:${other} -->`,
+          `⚠️ **collision-risk**: questa PR tocca file funnel-critical condivisi con la PR #${other}: ${list}. La seconda a raggiungere il merge DEVE prima rebasare oltre l'altra (\`git merge origin/main\` dopo che l'altra è mergiata) — l'auto-merge è bloccato finché \`collision-risk\` + dietro main. _Segnale deterministico da pr-collision-detector.yml (zero-Claude)._`);
+      }
+    } else if (hasLabel.get(num)) {
+      console.log(`PR #${num}: non collide più → rimuovo collision-risk.`);
+      removeLabel(num, 'collision-risk');
+    }
+  }
+  console.log('collision scan completo.');
+}
+
+main();


### PR DESCRIPTION
## Implementato

Single bundle PR (AGENTS.md single-bundle rule) hardening the PR automation pipeline. Four behaviors:

**P1 — auto-merge waits for vitest SUCCESS** (`.github/workflows/auto-merge-on-lgtm.yml` + new `scripts/ci/auto-merge-eval.mjs`)
- Adds a second `workflow_run` trigger on the `tests` workflow (`completed`) alongside the existing `pull_request_review` — either ordering re-evaluates.
- Merge decision centralized in `scripts/ci/auto-merge-eval.mjs` (single source of truth, identical gates for both triggers). **Exact condition:** PR open + not draft **AND** latest claude-bot review (`user.type=='Bot'` + login `^claude`) on the **current head** contains `## LGTM` and **not** `🔴 Important` **AND** the `vitest (unit + integration)` check-run on the head conclusion `== success` (require success — NOT merely `!= failure`; pending/missing does **not** merge) **AND** the P3 collision gate. All true → squash-merge with PAT (unchanged: PAT primary for deploy/follow-up cascade, `GITHUB_TOKEN` fallback, `--delete-branch`).
- On `pull_request_review` with vitest not yet success → exit 0 quietly; the `tests` completion re-evaluates. On `workflow_run` → only proceed if `conclusion == success`, resolve the PR from `head_sha` (via `repos/.../commits/<sha>/pulls`) then `head_branch` fallback.
- **Collision gate:** `collision-risk` label + behind origin/main (`compare/main...<head>` `behind_by > 0`) → do NOT merge; `collision-risk` + 0 behind → allow.
- Fixes the `#1454` class: merged on LGTM while vitest was still running → vitest failed → main red cascade.

**P2 — real auto-rebase of near-merge PRs** (`scripts/ci/pr-autorebase.mjs` + `.github/workflows/pr-autorebase.yml`)
- `schedule */30` + dispatch, concurrency `pr-autorebase`, full-history checkout, PAT via load-rc-env.
- **Frugality gate:** only PRs that already have a `## LGTM` review OR carry `collision-risk`/`stale-review` (a rebase push re-triggers the Claude reviewer = quota). `behind == 0` → skip.
- `mergeable` with one poll on `UNKNOWN`; `MERGEABLE` → `git merge origin/main` (canonical identity) + push via PAT (re-runs review + vitest). `CONFLICTING`/nonzero merge → `git merge --abort` + ensure `stale-review` + one dedup'd comment (`<!-- AUTOREBASE_CONFLICT -->`). Cap ~10 PR/run (logs skipped-by-cap). Zero-Claude.

**P3 — parallel-PR collision detector** (`scripts/ci/pr-collision-detector.mjs` + `.github/workflows/pr-collision-detector.yml`)
- `pull_request` (open/sync/reopen) + `schedule */30` + dispatch.
- Funnel-critical globs: `scripts/lib/**`, `build-plugins/**`, `services/seoService.ts`, `services/seo/**`, `.github/workflows/**`, `scripts/update-*.mjs`. Any open PR pair sharing ≥1 such file → label `collision-risk` on BOTH + one comment per PR naming the other PR# + shared files (dedup `<!-- COLLISION:<other> -->`). Recomputed each run — removes `collision-risk` when a PR no longer collides. Feeds P1's gate. Zero-Claude. Root cause of `#1454`↔`#1459`.

**P4 — bounded 🔴 loop-closure** (`.github/workflows/pr-redflag-fixer.yml`)
- `pull_request_review`; guard: reviewer claude-bot + body contains `🔴` + PR autonomous (`user.type=='Bot'` OR head `^fix/`) + not draft. **Never** human-authored PRs.
- **Anti-loop:** counts `<!-- REDFLAG_FIX_ROUND: N -->` markers; `N >= 2` → label `needs-human` + escalation comment, STOP without Claude. Else post/increment marker BEFORE invoking Claude (so a dead run still counts the round).
- Capability guard: PR touches `.github/workflows/**` without PAT → skip (push would be rejected). Tier: opus if funnel-critical (`tests/`, `build-plugins/`, `scripts/lib/`, `services/seo*`) else sonnet. `anthropics/claude-code-action@v1` with `CLAUDE_CODE_OAUTH_TOKEN` (never `ANTHROPIC_API_KEY`), `--max-turns 30`. Claude applies class-complete fix on the branch, runs tests, commits (canonical) + pushes (PAT re-triggers re-review), updates PR body. concurrency `redflag-fix-<pr>`.

**Cross-cutting**
- Labels `collision-risk` + `needs-human` created (`gh label create`, done on this repo).
- All scripts node ESM (followup-drainer style), `node --check` ✔. All YAML `python3 yaml.safe_load` ✔.
- Docs: new section in `docs/CI-CD-PIPELINE.md` documenting the 4 behaviors + both labels.
- Verified: `lint:gha-node-runtime` OK (1099 refs Node≥24), `audit:no-merge-markers` OK, workflow-permissions-parity + deploy-workflow + lint-gha tests green (33), funnel-glob predicate unit-checked, no home paths, only canonical email.

## Non implementato (ancora)

- **TOCTOU on autorebase (P2):** between the `mergeable` check and the push, a new commit can land on the branch → push is non-fast-forward and fails (no `--force` by design). Handled gracefully (skip + retry next tick), not eliminated — eliminating it would need a lock the platform doesn't offer. Documented inline.
- **Collision globs are heuristic (P3):** funnel-critical path list is curated, not derived from the dependency graph; two PRs touching the same *logical* area via different files won't be flagged, and two PRs touching the same funnel file in non-overlapping regions are flagged conservatively (false positive → just requires a rebase). Tuning the glob set is a follow-up.
- **P4 quota note:** each 🔴-fix round invokes Claude (shared Max quota); the round cap (2) bounds the burn per PR but a burst of bot PRs each taking 2 rounds still consumes quota. The cap + `needs-human` escalation is the frugality lever; no global rate-limit added.
- **collision gate `behind_by` source (P1):** uses `compare/main...<head>` which reflects the default-branch tip at API call time; a merge landing on main between the eval and the merge is a narrow race (conservative: skip on compare error).

---

> ⚠️ **This PR edits `.github/workflows/auto-merge-on-lgtm.yml`** → the GitHub App reviewer's workflow-validation will block the auto-reviewer (it requires byte-identical review-workflow files vs main, and the auto-merge workflow is in the gated set). The auto-reviewer will not post `## LGTM` and auto-merge will not fire — **expected**. **Maintainer reviews + merges manually** via `gh pr merge --squash --delete-branch`. Validate the new behaviors on the next organic PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)