### PR TITLE
docs(adsense): correct shared-guard comment — idle path is not a one-shot trigger

### DIFF
--- a/components/shared/AdSenseBanner.tsx
+++ b/components/shared/AdSenseBanner.tsx
@@ -218,12 +218,15 @@ export default function AdSenseBanner({
  return;
  }
 
- // Shared one-shot guard: the ad commits to loading exactly once. Whichever
- // path wins — IO fill, idle fallback, or first interaction — marks `triggered`
- // and detaches the interaction listeners, so a later mousemove/scroll can't
- // call setState('waiting_width') on an already-filled ad and hide it
- // (viewability/CLS regression). Mirrors the idempotent `loadScript` guard in
- // ADSENSE_LOADER_CONTENT (build-plugins/constants.ts).
+ // Shared one-shot guard: this slot commits to width-wait exactly once. The
+ // two paths that set state — IO fill and first interaction — mark `triggered`
+ // and detach the interaction listeners, so a later mousemove/scroll can't call
+ // setState('waiting_width') on an already-filled ad and hide it (viewability/
+ // CLS regression). The idle fallback is NOT in this set: it only loads
+ // adsbygoogle.js globally for Auto Ads while this manual slot still fills via a
+ // later interaction/scroll — setting `triggered` there would wrongly freeze the
+ // slot. Mirrors the idempotent `loadScript` guard in ADSENSE_LOADER_CONTENT
+ // (build-plugins/constants.ts).
  const INTERACTION_EVENTS: Array<keyof DocumentEventMap> = ['scroll', 'touchstart', 'pointerdown', 'keydown', 'mousemove'];
  let triggered = false;
  const removeInteractionListeners = () => {


### PR DESCRIPTION
## Implementato

Follow-up del 🟡 reviewer su #1479. Il commento dello shared one-shot guard in `AdSenseBanner.tsx` elencava l'**idle fallback** tra i path che "marcano `triggered` e staccano i listener". Falso: l'idle carica solo `adsbygoogle.js` globalmente per gli Auto Ads, mentre questo slot manuale si riempie comunque via una interazione/scroll successiva — settare `triggered` lì **congelerebbe** lo slot. Il codice era già corretto (solo i path IO-fill + first-interaction sono one-shot); ho corretto il commento esplicitando perché l'idle è escluso.

Comment-only, zero cambi di comportamento.

## Non implementato (ancora)

- Asimmetria static-vs-SPA notata nell'adversarial check #2 (lo static loader non fa `io.disconnect()` nei listener di interazione — innocuo per il guard `loaded`): non funnel, non in scope.
- INP/LCP profiling dell'anticipo fetch script: coperto dal revert-trigger `revenue-monitor` 7gg già dichiarato in #1479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)