### PR TITLE
fix(seo): link articoli-svizzera hub from footer — un-orphan blog-ch tier (fix deploy bfs-depth gate)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -105,7 +105,7 @@ import { buildFuelTodayPath } from '@/build-plugins/fuelDailyData';
 import { buildCurrentWeekPath } from '@/build-plugins/weeklyEmployersData';
 import { buildHubPath as buildJobMarketHubPath } from '@/build-plugins/jobMarketSnapshotData';
 import { buildHealthPremiumsCantonPath } from '@/build-plugins/healthPremiumsData';
-import { HUB_SLUGS as SEO_HUB_SLUGS, FOOTER_TOP_SECTORS as SEO_FOOTER_TOP_SECTORS, FOOTER_TOP_CITIES as SEO_FOOTER_TOP_CITIES, HUB_SECTORS as SEO_HUB_SECTORS, hubSlugFor as seoHubSlugFor, type HubLocale as SeoHubLocale } from '@/build-plugins/seoHubsData';
+import { HUB_SLUGS as SEO_HUB_SLUGS, FOOTER_TOP_SECTORS as SEO_FOOTER_TOP_SECTORS, FOOTER_TOP_CITIES as SEO_FOOTER_TOP_CITIES, HUB_SECTORS as SEO_HUB_SECTORS, hubSlugFor as seoHubSlugFor, svizzeraArticlesArchiveBasePaths as seoSvizzeraArticlesArchiveBasePaths, type HubLocale as SeoHubLocale } from '@/build-plugins/seoHubsData';
 import { resolveCantonSection as resolveSeoCantonSection } from '@/build-plugins/shared/cantonSection';
 import { SECTOR_HUB_KEYS, buildSectorHubPath, type SectorHubKey } from '@/build-plugins/jobSectorLanding';
 import { pushRoute, buildPath, getSeoSection, AppRoute, parsePath } from '@/services/router';
@@ -2803,6 +2803,11 @@ const App: React.FC = () => {
            <li>
              <a href={hubs.articlesAll} className="text-xs font-semibold text-accent hover:underline no-underline">
                {t('seoHubs.footer.allArticles') || 'Tutti gli articoli →'}
+             </a>
+           </li>
+           <li>
+             <a href={seoSvizzeraArticlesArchiveBasePaths()[hubLoc]} className="text-xs font-semibold text-accent hover:underline no-underline">
+               {t('seoHubs.footer.allSwissArticles') || 'Tutti gli articoli Svizzera →'}
              </a>
            </li>
          </ul>

--- a/services/locales/de-seo-links.ts
+++ b/services/locales/de-seo-links.ts
@@ -75,6 +75,7 @@ const deSeoLinks: Record<string, string> = {
   'seoHubs.footer.allCompanies': 'Alle Firmen →',
   'seoHubs.footer.articles': 'Neueste Artikel',
   'seoHubs.footer.allArticles': 'Alle Artikel →',
+  'seoHubs.footer.allSwissArticles': 'Alle Schweiz-Artikel →',
 
   // Phase 2-UI — SEO hub-page
   'seo.hub.jobs.title': 'Alle Stellenangebote',

--- a/services/locales/en-seo-links.ts
+++ b/services/locales/en-seo-links.ts
@@ -75,6 +75,7 @@ const enSeoLinks: Record<string, string> = {
   'seoHubs.footer.allCompanies': 'All companies →',
   'seoHubs.footer.articles': 'Latest articles',
   'seoHubs.footer.allArticles': 'All articles →',
+  'seoHubs.footer.allSwissArticles': 'All Switzerland articles →',
 
   // Phase 2-UI — SEO hub-page
   'seo.hub.jobs.title': 'All job listings',

--- a/services/locales/fr-seo-links.ts
+++ b/services/locales/fr-seo-links.ts
@@ -75,6 +75,7 @@ const frSeoLinks: Record<string, string> = {
   'seoHubs.footer.allCompanies': 'Toutes les entreprises →',
   'seoHubs.footer.articles': 'Derniers articles',
   'seoHubs.footer.allArticles': 'Tous les articles →',
+  'seoHubs.footer.allSwissArticles': 'Tous les articles Suisse →',
 
   // Phase 2-UI — SEO hub-page
   'seo.hub.jobs.title': 'Toutes les offres d’emploi',

--- a/services/locales/it-seo-links.ts
+++ b/services/locales/it-seo-links.ts
@@ -84,6 +84,7 @@ const translations: Record<string, string> = {
   'seoHubs.footer.allCompanies': 'Tutte le aziende →',
   'seoHubs.footer.articles': 'Ultimi articoli',
   'seoHubs.footer.allArticles': 'Tutti gli articoli →',
+  'seoHubs.footer.allSwissArticles': 'Tutti gli articoli Svizzera →',
 
   // Phase 2-UI — SEO hub-page (used by SeoHubPages.tsx and the static emitter)
   'seo.hub.jobs.title': 'Tutti gli annunci di lavoro',


### PR DESCRIPTION
## Implementato
Sblocca il gate `audit:max-bfs-depth` che faceva fallire **ogni** deploy (validate-dist: "11 passed, 1 failed", commenta su #1247).

**Root cause:** il nuovo shard `sitemap-blog-ch.xml` (sezione "Svizzera", PR #1173) spediva **22/22 (100%)** URL `/articoli-svizzera/*` a **BFS depth > 4** dalla home → orfani. Il tier IT gemello `/articoli-frontaliere/*` passa perché il suo archivio `/tutti/` è linkato dal **footer site-wide** (depth ≤ 3). Il mirror Svizzera emetteva lo stesso archivio (`svizzeraArticlesArchiveBasePaths()` → `/articoli-svizzera/tutti/`) ma **senza alcun link inbound a depth ≤ 3**: l'unico ingresso era il SubTabNav *dentro* il tab blog SPA (depth 1, non crawlabile nello static HTML).

**Fix** (non-negotiable #5: orfani → link interni, mai noindex/flooring baseline; simmetrico al tier IT, #6):
- `App.tsx` — `<li>` nel footer accanto a `allArticles`, link a `svizzeraArticlesArchiveBasePaths()[hubLoc]`.
- `it/en/de/fr-seo-links.ts` — nuova chiave `seoHubs.footer.allSwissArticles` (4 locali).

Il footer è site-wide nello static output (l'IT lo dimostra) → al prossimo build `/articoli-svizzera/tutti/` sta a depth 1 e i 22 articoli a depth 2 (≤ 4): lo shard non spedisce più 100% > depth4.

**Test:** `tests/i18n-completeness.test.ts` (16) + `tests/blog/svizzera-section-routing.test.ts` (5) → 21/21 green.

Risolve la causa corrente di #1247 (validation-failure canonica, ri-usata): il gate auto-resolve l'issue al primo deploy verde (step "Resolve GitHub Issue on success"), nessun `Closes` su issue-bucket riusato.

## Non implementato (ancora)
- **bfs-depth non validabile pre-merge.** Il gate `audit:max-bfs-depth` gira solo post-merge su `main` (build:ci OOM-prone, non sul `pull_request`). Claim verde calcolato per costruzione (footer site-wide = depth 1 archivio → depth 2 articoli), non da run misurato. **Revert-trigger:** se il prossimo deploy ri-fallisce `audit:max-bfs-depth` su `sitemap-blog-ch.xml` → revert + indagare se l'archivio `/articoli-svizzera/tutti/` non linka realmente i 22 articoli nello static.
- **#1189 item 1** (pre-render del bare `/articoli-svizzera/` grid SPA-only): correlato ma scope distinto — questo PR linka l'**archivio** `/tutti/` (già pre-renderizzato), che basta a de-orfanizzare il tier. Il bare hub resta follow-up. Non chiuso.
- **#1189 item 2** (embeddings dedup svizzera): fuori scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)