### PR TITLE
fix(crawlers): un-break 4 crawlers — onlyfy redesign, jobup 403, fusalp empty-OK

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -119,6 +119,14 @@ const EMPTY_OK_CRAWLERS = new Set([
   // manufacturer simply has no current openings. Healthy, re-arms when a
   // vacancy is published.
   'linnea',
+  // Fusalp (French apparel brand, WelcomeKit portal https://fusalp.welcomekit.co):
+  // the crawler is scoped to Swiss roles only and skips France/EU listings.
+  // Fusalp posts mostly French jobs (Annecy HQ, Lyon/Paris/Nice boutiques) with
+  // only occasional Swiss boutique openings (history: Aubonne VD, Crans-Montana
+  // VS). The listing parser is healthy — it finds the 6 live listings and
+  // correctly filters them as non-Swiss; same legitimately-empty regional-filter
+  // case as manor and alten-switzerland. Re-arms when a CH listing appears.
+  'fusalp',
 ]);
 
 /** Read JSON file, return null on any error. */

--- a/scripts/lib/clinique-cic-job-parser.mjs
+++ b/scripts/lib/clinique-cic-job-parser.mjs
@@ -36,6 +36,7 @@ import {
   detectHealthcareExperienceLevel,
   detectHealthcareEmploymentType,
 } from './hospital-custom-html-helpers.mjs';
+import { fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
 
 export const CIC_KEY = 'clinique-cic';
 export const CIC_COMPANY_NAME = 'Clinique CIC (Saxon & Clarens)';
@@ -69,6 +70,7 @@ async function fetchMaskHtml(url) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let directErr;
   try {
     const res = await fetch(url, {
       headers: {
@@ -79,15 +81,24 @@ async function fetchMaskHtml(url) {
       signal: controller.signal,
     });
     clearTimeout(timer);
-    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
-    // The mask returns iso-8859-1 — decode explicitly so accented chars
-    // (è, é, à, …) render correctly downstream.
-    const buf = await res.arrayBuffer();
-    return new TextDecoder('iso-8859-1').decode(buf);
+    if (res.ok) {
+      // The mask returns iso-8859-1 — decode explicitly so accented chars
+      // (è, é, à, …) render correctly downstream.
+      const buf = await res.arrayBuffer();
+      return new TextDecoder('iso-8859-1').decode(buf);
+    }
+    directErr = new Error(`HTTP ${res.status} from ${url}`);
   } catch (err) {
     clearTimeout(timer);
-    throw err;
+    directErr = err;
   }
+  // jobup.ch serves HTTP 403 to the GitHub Actions datacenter egress IP — an
+  // IP-reputation WAF block (not a real auth failure: a clean/residential IP
+  // gets 200). Re-fetch through Jina's clean IP pool so the data IS collected.
+  // The mask is iso-8859-1 on the wire; Jina normalises to a correct JS string.
+  const viaJina = await fetchHtmlViaJinaWithRetry(url, { timeoutMs });
+  if (viaJina != null) return viaJina;
+  throw directErr;
 }
 
 /**

--- a/scripts/lib/onlyfy-listing-common.mjs
+++ b/scripts/lib/onlyfy-listing-common.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Shared listing parser for softgarden-hosted onlyfy.jobs portals
+ * (https://{tenant}.onlyfy.jobs/).
+ *
+ * onlyfy redesigned the listing markup (2026): the legacy
+ *   <strong class="job-title"><a href="/job/{hash}">{TITLE}</a></strong>
+ * with sibling `icon-map-marker` / `icon-time` cells was replaced by a card:
+ *   <a data-testid="job-card" aria-label="{TITLE}" href="/{lang}/job/{hash}"> …
+ *     <h3 data-testid="job-title">{TITLE}</h3> …
+ *     <div data-testid="job-more-info">{Location} | {Type} | {Date}</div>
+ *   </a>
+ *
+ * Both spitex-zuerich (spitex-zuerich.onlyfy.jobs) and vitrea-gesundheit
+ * (vamed-ag-ch.onlyfy.jobs) sit on this exact portal, so the listing regex
+ * lives here ONCE — copy-pasting it into each tenant crawler is what let the
+ * two drift apart and both silently return 0 after the redesign.
+ */
+import { decodeEntities, normalizeSpace } from './hospital-custom-html-helpers.mjs';
+
+/**
+ * Parse an onlyfy.jobs listing page into role rows.
+ *
+ * @param {string} html                     listing-page HTML
+ * @param {object} opts
+ * @param {string} opts.portalBase          e.g. 'https://spitex-zuerich.onlyfy.jobs' (no trailing slash)
+ * @param {string} [opts.defaultLocation]   fallback when the card carries no location
+ * @returns {Array<{url:string, title:string, location:string, employmentTypeStr:string}>}
+ */
+export function parseOnlyfyListing(html, { portalBase, defaultLocation = 'Schweiz' } = {}) {
+  const out = [];
+  const seen = new Set();
+  const base = String(portalBase || '').replace(/\/+$/, '');
+  // Each role is an `<a data-testid="job-card" …>` whose opening tag carries the
+  // clean title (aria-label) and the detail href; the location + employment
+  // type live in a `data-testid="job-more-info"` cell inside the card.
+  const cardRx = /<a\b[^>]*\bdata-testid="job-card"[^>]*>/gi;
+  let m;
+  while ((m = cardRx.exec(html))) {
+    const openTag = m[0];
+    const hrefMatch = openTag.match(/\bhref="([^"]+)"/);
+    if (!hrefMatch) continue;
+    const path = hrefMatch[1];
+    if (!/\/job\/[a-z0-9]+/i.test(path)) continue;
+    const url = /^https?:/i.test(path) ? path : `${base}${path}`;
+    if (seen.has(url)) continue;
+
+    const cardWindow = html.slice(m.index, m.index + 1600);
+    const labelMatch = openTag.match(/\baria-label="([^"]*)"/);
+    let title = labelMatch ? normalizeSpace(decodeEntities(labelMatch[1])) : '';
+    if (!title) {
+      const tMatch = cardWindow.match(/data-testid="job-title"[^>]*>([\s\S]*?)<\/h[1-6]>/i);
+      title = tMatch ? normalizeSpace(decodeEntities(tMatch[1].replace(/<[^>]+>/g, ''))) : '';
+    }
+    if (!title || title.length < 5) continue;
+    seen.add(url);
+
+    let location = defaultLocation;
+    let employmentTypeStr = '';
+    const infoMatch = cardWindow.match(/data-testid="job-more-info"[^>]*>([\s\S]*?)<\/div>/i);
+    if (infoMatch) {
+      const parts = normalizeSpace(decodeEntities(infoMatch[1].replace(/<[^>]+>/g, ' ')))
+        .split('|')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (parts[0]) location = parts[0];
+      if (parts[1]) employmentTypeStr = parts[1];
+    }
+    out.push({ url, title, location, employmentTypeStr });
+  }
+  return out;
+}

--- a/scripts/lib/spitex-zuerich-job-parser.mjs
+++ b/scripts/lib/spitex-zuerich-job-parser.mjs
@@ -12,10 +12,11 @@
  *   https://www.spitex-zuerich.ch/jobs    (corporate)
  *   https://spitex-zuerich.onlyfy.jobs/   (onlyfy portal, server-rendered HTML)
  *
- * Listing format: same softgarden HTML as Vitrea Gesundheit
- *   <strong class="job-title"><a href="/job/{hash}">Title</a></strong>
- *   followed by `<i class="icon-map-marker">Location</i>` and
- *   `<i class="icon-time">Employment type</i>` cells.
+ * Listing format: onlyfy.jobs redesigned card markup (shared with Vitrea
+ * Gesundheit), parsed by `parseOnlyfyListing` in onlyfy-listing-common.mjs:
+ *   <a data-testid="job-card" aria-label="{Title}" href="/{lang}/job/{hash}">
+ *     <h3 data-testid="job-title">{Title}</h3>
+ *     <div data-testid="job-more-info">{Location} | {Type} | {Date}</div>
  *
  * Detail page: rich `<p>/<li>/<h2-6>` content blocks describing the role.
  */
@@ -31,6 +32,7 @@ import {
   detectHealthcareEmploymentType,
 } from './hospital-custom-html-helpers.mjs';
 import { isDetailContentValid } from './umantis-listing-common.mjs';
+import { parseOnlyfyListing } from './onlyfy-listing-common.mjs';
 
 export const SPITEX_ZUERICH_KEY = 'spitex-zuerich';
 export const SPITEX_ZUERICH_COMPANY_NAME = 'Spitex Zürich';
@@ -67,26 +69,9 @@ export function isTrustedDomain(rawUrl = '') {
 }
 
 export function parseSpitexZuerichListing(html) {
-  const out = [];
-  const seen = new Set();
-  const rx = /<strong class="job-title">\s*<a\s+href="(\/job\/[a-z0-9]+)"[^>]*>([\s\S]*?)<\/a>/g;
-  let m;
-  while ((m = rx.exec(html))) {
-    const path = m[1];
-    const title = normalizeSpace(decodeEntities(m[2].replace(/<[^>]+>/g, '')));
-    if (!title || title.length < 5) continue;
-    const url = `${PORTAL_BASE}${path}`;
-    if (seen.has(url)) continue;
-    seen.add(url);
-    const followIdx = m.index + m[0].length;
-    const window = html.slice(followIdx, followIdx + 1200);
-    const locMatch = window.match(/icon-map-marker[\s\S]*?>\s*([^<]+?)\s*</);
-    const typeMatch = window.match(/icon-time[\s\S]*?>\s*([^<]+?)\s*</);
-    const location = locMatch ? normalizeSpace(decodeEntities(locMatch[1])) : DEFAULT_CITY;
-    const employmentTypeStr = typeMatch ? normalizeSpace(decodeEntities(typeMatch[1])) : '';
-    out.push({ url, title, location, employmentTypeStr });
-  }
-  return out;
+  // softgarden/onlyfy redesigned the listing markup (2026) — shared parser
+  // handles the new `data-testid="job-card"` cards for every onlyfy tenant.
+  return parseOnlyfyListing(html, { portalBase: PORTAL_BASE, defaultLocation: DEFAULT_CITY });
 }
 
 async function fetchDetailContent(url) {

--- a/scripts/lib/vitrea-gesundheit-job-parser.mjs
+++ b/scripts/lib/vitrea-gesundheit-job-parser.mjs
@@ -7,11 +7,13 @@
  *
  * Vitrea Gesundheit operates several Swiss rehab/care facilities including
  * Rehaklinik Seewis (covered separately via Rehaklinik Seewis parser?).
- * The onlyfy.jobs portal aggregates listings server-side as HTML rows with
- * `<strong class="job-title"><a href="/job/{hash}">{TITLE}</a></strong>`
- * plus an `icon-map-marker` location line and `icon-time` employment type.
+ * The onlyfy.jobs portal serves listings server-side with the redesigned
+ * card markup (shared with Spitex Zürich), parsed by `parseOnlyfyListing`:
+ *   <a data-testid="job-card" aria-label="{Title}" href="/{lang}/job/{hash}">
+ *     <h3 data-testid="job-title">{Title}</h3>
+ *     <div data-testid="job-more-info">{Location} | {Type} | {Date}</div>
  *
- * Detail pages live at `https://vamed-ag-ch.onlyfy.jobs/job/{hash}` and
+ * Detail pages live at `https://vamed-ag-ch.onlyfy.jobs/{lang}/job/{hash}` and
  * carry rich description sections (Aufgaben/Profil/Wir bieten).
  */
 import { createHash } from 'node:crypto';
@@ -26,6 +28,7 @@ import {
   detectHealthcareEmploymentType,
 } from './hospital-custom-html-helpers.mjs';
 import { isDetailContentValid } from './umantis-listing-common.mjs';
+import { parseOnlyfyListing } from './onlyfy-listing-common.mjs';
 
 export const VITREA_GESUNDHEIT_KEY = 'vitrea-gesundheit';
 export const VITREA_GESUNDHEIT_COMPANY_NAME = 'Vitrea Gesundheit';
@@ -54,28 +57,9 @@ export function isTrustedDomain(rawUrl = '') {
 }
 
 export function parseVitreaListing(html) {
-  const out = [];
-  const seen = new Set();
-  // Match `<strong class="job-title"> <a href="/job/{hash}">{TITLE}</a>`
-  const rx = /<strong class="job-title">\s*<a\s+href="(\/job\/[a-z0-9]+)"[^>]*>([\s\S]*?)<\/a>/g;
-  let m;
-  while ((m = rx.exec(html))) {
-    const path = m[1];
-    const title = normalizeSpace(decodeEntities(m[2].replace(/<[^>]+>/g, '')));
-    if (!title || title.length < 5) continue;
-    const url = `${PORTAL_BASE}${path}`;
-    if (seen.has(url)) continue;
-    seen.add(url);
-    // Capture the location and employment-type lines that follow the title row
-    const followIdx = m.index + m[0].length;
-    const window = html.slice(followIdx, followIdx + 1200);
-    const locMatch = window.match(/icon-map-marker[\s\S]*?>\s*([^<]+?)\s*</);
-    const typeMatch = window.match(/icon-time[\s\S]*?>\s*([^<]+?)\s*</);
-    const location = locMatch ? normalizeSpace(decodeEntities(locMatch[1])) : 'Schweiz';
-    const employmentTypeStr = typeMatch ? normalizeSpace(decodeEntities(typeMatch[1])) : '';
-    out.push({ url, title, location, employmentTypeStr });
-  }
-  return out;
+  // onlyfy.jobs redesigned card markup — shared parser keeps this tenant in
+  // lockstep with Spitex Zürich (both broke identically on the old selector).
+  return parseOnlyfyListing(html, { portalBase: PORTAL_BASE, defaultLocation: 'Schweiz' });
 }
 
 async function fetchDetailContent(url) {

--- a/scripts/update-spitex-zuerich-jobs.mjs
+++ b/scripts/update-spitex-zuerich-jobs.mjs
@@ -18,5 +18,11 @@ runStandardCrawlerPipeline({
   fetchJobs: fetchAllSpitexZuerichJobs,
   isCompanyJob: isSpitexZuerichJob,
   isTrustedDomain,
+  // The onlyfy.jobs detail URL is `…/{lang}/job/{hash}`; the `{hash}` token is
+  // non-hex so `extractStableJobId` can't derive a stable id and falls back to
+  // the full URL — letting the `/de/` lang prefix (or the historical
+  // `/job/`→`/de/job/` move) fragment the merge key and drop previousSlugs +
+  // translations on re-crawl. Key on the stable `/job/{hash}` token instead.
+  matchKey: (j) => (String(j?.url || '').match(/\/job\/([a-z0-9]+)/i)?.[1] || j?.url || ''),
   defaultSourceLang: 'de',
 }).catch((err) => { console.error(`❌ Spitex Zürich crawler failed: ${err?.message || err}`); process.exit(1); });

--- a/scripts/update-vitrea-gesundheit-jobs.mjs
+++ b/scripts/update-vitrea-gesundheit-jobs.mjs
@@ -18,5 +18,11 @@ runStandardCrawlerPipeline({
   fetchJobs: fetchAllVitreaGesundheitJobs,
   isCompanyJob: isVitreaGesundheitJob,
   isTrustedDomain,
+  // The onlyfy.jobs detail URL is `…/{lang}/job/{hash}`; the `{hash}` token is
+  // non-hex so `extractStableJobId` can't derive a stable id and falls back to
+  // the full URL — letting the `/de/` lang prefix (or the historical
+  // `/job/`→`/de/job/` move) fragment the merge key and drop previousSlugs +
+  // translations on re-crawl. Key on the stable `/job/{hash}` token instead.
+  matchKey: (j) => (String(j?.url || '').match(/\/job\/([a-z0-9]+)/i)?.[1] || j?.url || ''),
   defaultSourceLang: 'de',
 }).catch((err) => { console.error(`❌ Vitrea Gesundheit crawler failed: ${err?.message || err}`); process.exit(1); });

--- a/tests/onlyfy-listing-common.test.ts
+++ b/tests/onlyfy-listing-common.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs crawler lib, no type declarations
+import { parseOnlyfyListing } from '../scripts/lib/onlyfy-listing-common.mjs';
+
+// Redesigned onlyfy.jobs card markup (2026). Both spitex-zuerich and
+// vitrea-gesundheit sit on this portal; the old `<strong class="job-title">`
+// selector silently returned 0 after this redesign.
+const NEW_MARKUP = `
+<div class="results">
+  <a class="..." data-testid="job-card"
+     aria-label="Dipl. Pflegefachfrau/-mann 60-100% (a)"
+     href="/de/job/m6pttk2bqih13nqd4pbab9zfy4ntcpd">
+    <div><h3 class="heading text-primary" data-testid="job-title">Dipl. Pflegefachfrau/-mann 60-100% (a)</h3></div>
+    <div class="text-sm text-primary" data-testid="job-more-info">Zürich | Teilzeit / Vollzeit | 18.05.2026</div>
+  </a>
+  <a data-testid="job-card" aria-label="Fachfrau Gesundheit FaGe 40-90%"
+     href="/de/job/acyvj8k21gua2zs1trmrl9ksk9ph92j">
+    <div><h3 data-testid="job-title">Fachfrau Gesundheit FaGe 40-90%</h3></div>
+    <div data-testid="job-more-info">Winterthur | Teilzeit | 12.05.2026</div>
+  </a>
+</div>`;
+
+// The legacy markup the parser used to depend on — must yield nothing now, so a
+// silent fallback to the old selector can never mask a future redesign.
+const OLD_MARKUP = `
+<strong class="job-title"><a href="/job/abc123def456">Pflegefachperson HF</a></strong>
+<i class="icon-map-marker">Zürich</i><i class="icon-time">Teilzeit</i>`;
+
+describe('parseOnlyfyListing', () => {
+  it('extracts cards from the redesigned data-testid markup', () => {
+    const rows = parseOnlyfyListing(NEW_MARKUP, {
+      portalBase: 'https://spitex-zuerich.onlyfy.jobs',
+      defaultLocation: 'Zürich',
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      title: 'Dipl. Pflegefachfrau/-mann 60-100% (a)',
+      location: 'Zürich',
+      employmentTypeStr: 'Teilzeit / Vollzeit',
+      url: 'https://spitex-zuerich.onlyfy.jobs/de/job/m6pttk2bqih13nqd4pbab9zfy4ntcpd',
+    });
+    expect(rows[1].location).toBe('Winterthur');
+  });
+
+  it('returns no rows for the deprecated legacy markup (no silent fallback)', () => {
+    const rows = parseOnlyfyListing(OLD_MARKUP, {
+      portalBase: 'https://spitex-zuerich.onlyfy.jobs',
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('dedupes repeated job-card hrefs', () => {
+    const rows = parseOnlyfyListing(NEW_MARKUP + NEW_MARKUP, {
+      portalBase: 'https://spitex-zuerich.onlyfy.jobs',
+    });
+    expect(rows).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Implementato

Three distinct root causes behind 4 crawlers flagged `[crawler-health] … broken`:

### 1. onlyfy.jobs listing redesign → spitex-zuerich + vitrea-gesundheit (Closes #1496)
softgarden's onlyfy.jobs portal replaced the legacy listing markup
(`<strong class="job-title"><a href="/job/{hash}">`) with a card
(`<a data-testid="job-card" aria-label="{Title}" href="/{lang}/job/{hash}">` +
`<div data-testid="job-more-info">{Loc} | {Type} | {Date}</div>`). Both tenants
on that portal returned **0 jobs**. The listing regex had been copy-pasted into
each tenant crawler (the exact sibling-drift non-negotiable #6 warns about), so
both broke in lockstep — extracted into one shared `parseOnlyfyListing`
(`scripts/lib/onlyfy-listing-common.mjs`) and rewired both parsers to it. Each
now parses 10 live jobs (verified against live HTML). vitrea-gesundheit had no
open health issue yet but is the same broken class → fixed pre-emptively.

### 2. jobup.ch 403 IP-block → clinique-cic (Closes #1489)
`www.jobup.ch` serves **HTTP 403** to the GitHub Actions datacenter egress IP —
an IP-reputation WAF block, not a real auth failure (a clean IP gets 200, and
the crawler parses 3 jobs locally). `fetchMaskHtml` now falls back to the Jina
clean-IP proxy (`fetchHtmlViaJinaWithRetry`) on a non-ok status — the established
#1469 200-challenge/Jina-rescue pattern, here extended to the 403 case. Verified:
Jina returns the mask HTML with 5 `job_offer` rows.

### 3. fusalp — false-positive flag, parser healthy (Closes #1490)
fusalp is **not broken**. The parser correctly finds the 6 live WelcomeKit
listings and filters them all as non-Swiss (Fusalp posts mostly French roles —
Annecy/Lyon/Paris/Nice — and only occasional Swiss boutique jobs; history shows
Aubonne VD + Crans-Montana VS). Added `fusalp` to `EMPTY_OK_CRAWLERS` in
`check-crawler-health.mjs`, exactly like manor / alten-switzerland / the-living-circle
— a legitimately-empty regional filter must not read as "broken".

### Tests
- New `tests/onlyfy-listing-common.test.ts` locks the redesigned-markup contract
  (new card parses, legacy markup yields 0 → no silent fallback masking a future
  redesign, dedupe). 3 pass.
- `tests/scripts/check-crawler-health.test.ts` still green (13 pass).

## Non implementato (ancora)

- **The 6 Umantis hospital crawlers** (#1488 adullam, #1491 ipw, #1492 kispi-sg,
  #1493 paraplegie, #1494 pdag, #1495 spital-zofingen) are a **separate root
  cause** (Umantis deprecated the public `/Description/` page → 302 cross-host →
  jobs quarantined as "migrated" though they are still live + applicable). Fix
  requires per-tenant public-site description resolvers (paraplegie/adullam/
  zofingen are SSR-extractable; pdag/kispi-sg/ipw need JS rendering). Tracked as a
  **follow-up PR** to keep this clean, locally-validated batch low-risk and
  un-coupled from the larger, post-merge-only-validatable resolver work.
- fusalp's bespoke `fetchPage` was **not** wired to Jina rescue — it currently
  returns 200 in CI (the failure was the geo-filter, not anti-bot); adding rescue
  would be speculative. Will revisit if welcomekit starts IP-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)