### PR TITLE
fix(auth): suppress One Tap + job gate during newsletter autologin

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -131,6 +131,8 @@ import {
  consumeAuthJobContext,
 } from '@/services/authService';
 import type { AuthJobContext } from '@/services/authService';
+import { settleNewsletterAutologin } from '@/services/newsletterAutologinSignal';
+import { useNewsletterAutologinInFlight } from '@/hooks/useNewsletterAutologinInFlight';
 import {
  upsertNewsletterSubscriber as upsertNewsletterSubscriberRecord,
  normalizeNewsletterEmail,
@@ -168,6 +170,11 @@ const App: React.FC = () => {
  signInFacebook: facebookSignIn,
  signInEmail,
  } = useAuth();
+
+ // True while a newsletter autologin code is being exchanged for a session.
+ // Suppresses One Tap (and downstream auth gates) so newsletter visitors see
+ // the linked content immediately instead of a redundant sign-in prompt.
+ const newsletterAutologinInFlight = useNewsletterAutologinInFlight();
 
  // Navigation state: tabs, sub-tabs, deep links, popstate, SEO effects, etc.
  const {
@@ -478,6 +485,10 @@ const App: React.FC = () => {
  } catch (error) {
  reportCaughtError(error, 'app.newsletterAutologin');
  Analytics.trackUIInteraction('newsletter', 'autologin', 'error');
+ } finally {
+ // Re-enable sign-in affordances (One Tap, auth gates) once the exchange
+ // resolves — success or failure. Idempotent + no-op when never in flight.
+ settleNewsletterAutologin();
  }
  })();
  return () => { cancelled = true; };
@@ -965,6 +976,9 @@ const App: React.FC = () => {
  cancelOneTap();
  return; // Already signed in
  }
+ // Don't even arm the prompt while a newsletter autologin is exchanging — the
+ // user is about to be signed in. Effect re-runs when the signal settles.
+ if (newsletterAutologinInFlight) return;
  if (sessionStorage.getItem('onetap_prompted')) return;
 
  let queued = false;
@@ -1004,19 +1018,20 @@ const App: React.FC = () => {
  window.removeEventListener(e, trigger, { capture: true });
  cancelOneTap();
  };
- }, [authLoading, authUser]);
+ }, [authLoading, authUser, newsletterAutologinInFlight]);
 
  // If the first interaction happened while auth was still loading,
  // trigger One Tap as soon as auth state is resolved.
  useEffect(() => {
  if (authLoading || authUser) return;
+ if (newsletterAutologinInFlight) return;
  if (sessionStorage.getItem('onetap_prompted')) return;
  if (sessionStorage.getItem('onetap_pending') !== '1') return;
 
  sessionStorage.setItem('onetap_prompted', '1');
  sessionStorage.removeItem('onetap_pending');
  promptOneTap().catch(() => {});
- }, [authLoading, authUser]);
+ }, [authLoading, authUser, newsletterAutologinInFlight]);
 
  // Theme init, analytics init, SPA pageview tracking, deferred widgets,
  // and toggleTheme are all managed by useUIState (hooks/useUIState.ts).

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -101,6 +101,7 @@ import {
  type Inline as JobDescInline,
 } from '@/build-plugins/shared/jobDescription/parser';
 import { useAuthGateHeadlineVariant } from '@/services/authGateExperiment';
+import { useNewsletterAutologinInFlight } from '@/hooks/useNewsletterAutologinInFlight';
 import {
  isMultiLocation,
  normalizeJobCategory,
@@ -1700,6 +1701,9 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const { t } = useTranslation();
  const [locale] = useLocale();
  const { headline: gateHeadline } = useAuthGateHeadlineVariant(locale, t('jobBoard.gate.title'));
+ // Hold the detail skeleton (not the auth gate) while a newsletter autologin is
+ // exchanging — the visitor is about to be signed in; flashing the gate is noise.
+ const newsletterAutologinInFlight = useNewsletterAutologinInFlight();
  const nav = useNavigation();
  const pageSize = 10;
  // Runtime kill-switches for the "Strumenti correlati" sidebar cross-links.
@@ -5799,10 +5803,12 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  if (selectedJob) {
- if (!authResolved) {
+ if (!authResolved || newsletterAutologinInFlight) {
  // Use a layout-matching skeleton instead of a tiny spinner to prevent CLS:
  // the spinner occupies ~80px but the full detail layout is 800-1200px,
  // causing a large measurable layout shift when auth resolves.
+ // Also hold the skeleton while a newsletter autologin is exchanging so the
+ // gate never flashes before the imminent sign-in lands.
  return <SkeletonJobDetail />;
  }
  if (!hasAccess) {

--- a/hooks/useNewsletterAutologinInFlight.ts
+++ b/hooks/useNewsletterAutologinInFlight.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { isNewsletterAutologinInFlight, subscribeNewsletterAutologin } from '@/services/newsletterAutologinSignal';
+
+/**
+ * Reactive view of the newsletter autologin in-flight signal.
+ *
+ * Returns `true` while a newsletter autologin code is being exchanged for a
+ * Firebase session, then flips to `false` once it settles (success or failure).
+ * Components use this to suppress sign-in affordances (Google One Tap, the
+ * job/chatbot auth gate) during the brief window so a newsletter visitor sees
+ * the linked content immediately instead of a redundant sign-in prompt.
+ */
+export function useNewsletterAutologinInFlight(): boolean {
+ const [inFlight, setInFlight] = useState(isNewsletterAutologinInFlight);
+ useEffect(() => {
+ if (!isNewsletterAutologinInFlight()) {
+ setInFlight(false);
+ return;
+ }
+ return subscribeNewsletterAutologin(() => setInFlight(false));
+ }, []);
+ return inFlight;
+}

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -12,6 +12,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { hasActiveSlot } from '@/services/popupQueue';
 import { reportCaughtError } from '@/services/errorReporter';
+import { isNewsletterAutologinInFlight } from '@/services/newsletterAutologinSignal';
 
 // ─── Resilient Dynamic Import ────────────────────────────────
 // After a deploy, old chunk hashes no longer exist on the CDN.
@@ -1441,6 +1442,9 @@ async function handleOneTapResponse(response: OneTapResponse): Promise<void> {
  * Call this when the user arrives at a sign-in page
  */
 export async function promptOneTap(): Promise<void> {
+ // Suppress while a newsletter autologin is exchanging — the user is about to
+ // be signed in, so prompting now is redundant and delays the linked content.
+ if (isNewsletterAutologinInFlight()) return;
  await ensureFirebaseAuth();
  const authInstance = getAuthInstance();
  if (authInstance?.currentUser) return;

--- a/services/newsletterAutologinSignal.ts
+++ b/services/newsletterAutologinSignal.ts
@@ -1,0 +1,60 @@
+/**
+ * Newsletter autologin in-flight signal.
+ *
+ * A user arriving from a newsletter link carries an autologin code
+ * (`ac`/`at`/`authToken` + recipient email). App.tsx exchanges it for a Firebase
+ * session asynchronously (Cloud Function round-trip). During that window we must
+ * NOT surface any sign-in affordance — Google One Tap, the job/chatbot auth gate
+ * — because the user is about to be signed in: prompting is redundant noise and
+ * delays the content the newsletter linked to.
+ *
+ * Consumers read {@link isNewsletterAutologinInFlight} and subscribe via
+ * {@link subscribeNewsletterAutologin} to re-evaluate once it settles. The signal
+ * is computed synchronously at module load (before App.tsx strips the params).
+ *
+ * Kept in its own dependency-free module (no Firebase) so the detection logic is
+ * unit-testable without the heavy authService import graph.
+ */
+
+let inFlight = ((): boolean => {
+ if (typeof window === 'undefined') return false;
+ try {
+ const p = new URLSearchParams(window.location.search);
+ const action = p.get('action');
+ if (action === 'unsubscribe' || action === 'resubscribe') return false;
+ const hasCode = Boolean(p.get('ac') || p.get('at') || p.get('authToken'));
+ const hasEmail = Boolean(p.get('ne') || p.get('newsletter_email') || p.get('email'));
+ return hasCode && hasEmail;
+ } catch {
+ return false;
+ }
+})();
+
+const subscribers = new Set<() => void>();
+
+export function isNewsletterAutologinInFlight(): boolean {
+ return inFlight;
+}
+
+/** Subscribe to the moment newsletter autologin settles. No-op if already settled. */
+export function subscribeNewsletterAutologin(cb: () => void): () => void {
+ if (!inFlight) return () => {};
+ subscribers.add(cb);
+ return () => { subscribers.delete(cb); };
+}
+
+/** Mark newsletter autologin settled (success or failure) and notify subscribers. Idempotent. */
+export function settleNewsletterAutologin(): void {
+ if (!inFlight) return;
+ inFlight = false;
+ for (const cb of Array.from(subscribers)) {
+ try { cb(); } catch { /* a listener error must not block settle */ }
+ }
+ subscribers.clear();
+}
+
+// Safety backstop: never suppress sign-in affordances indefinitely if the
+// exchange hangs or the owning handler never settles.
+if (inFlight && typeof window !== 'undefined') {
+ window.setTimeout(settleNewsletterAutologin, 8000);
+}

--- a/tests/newsletter-autologin-onetap-suppression.test.ts
+++ b/tests/newsletter-autologin-onetap-suppression.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(__dirname, '..');
+
+// The newsletter-autologin-in-flight signal is computed at module load from
+// window.location.search (before App.tsx strips the newsletter params), so each
+// case sets the URL, then re-imports the signal module fresh via resetModules().
+
+const ORIGINAL_LOCATION = window.location;
+
+function setSearch(search: string): void {
+ Object.defineProperty(window, 'location', {
+ configurable: true,
+ value: new URL(`https://frontaliereticino.ch/articoli-frontaliere/x/${search}`),
+ });
+}
+
+async function freshSignal() {
+ vi.resetModules();
+ // Avoid leaving a real 8s backstop timer dangling after the test process.
+ vi.spyOn(window, 'setTimeout').mockReturnValue(0 as unknown as ReturnType<typeof setTimeout>);
+ return import('@/services/newsletterAutologinSignal');
+}
+
+afterEach(() => {
+ Object.defineProperty(window, 'location', { configurable: true, value: ORIGINAL_LOCATION });
+ vi.restoreAllMocks();
+});
+
+describe('newsletter autologin → sign-in affordance suppression', () => {
+ it('is in-flight when the URL carries an autologin code + recipient email', async () => {
+ setSearch('?ne=a%40b.com&ac=deadbeef&utm_medium=newsletter');
+ const sig = await freshSignal();
+ expect(sig.isNewsletterAutologinInFlight()).toBe(true);
+ });
+
+ it('settles to false, notifies subscribers, and is idempotent', async () => {
+ setSearch('?ne=a%40b.com&ac=deadbeef');
+ const sig = await freshSignal();
+ const cb = vi.fn();
+ const unsub = sig.subscribeNewsletterAutologin(cb);
+
+ expect(sig.isNewsletterAutologinInFlight()).toBe(true);
+ sig.settleNewsletterAutologin();
+ expect(sig.isNewsletterAutologinInFlight()).toBe(false);
+ expect(cb).toHaveBeenCalledTimes(1);
+
+ sig.settleNewsletterAutologin(); // second call must be a no-op
+ expect(cb).toHaveBeenCalledTimes(1);
+ unsub();
+ });
+
+ it('subscribe is a no-op (returns a safe unsubscribe) once already settled', async () => {
+ setSearch(''); // not in flight
+ const sig = await freshSignal();
+ const cb = vi.fn();
+ const unsub = sig.subscribeNewsletterAutologin(cb);
+ sig.settleNewsletterAutologin();
+ expect(cb).not.toHaveBeenCalled();
+ expect(() => unsub()).not.toThrow();
+ });
+
+ it('is NOT in-flight for a plain newsletter link without an autologin code', async () => {
+ setSearch('?ne=a%40b.com&utm_medium=newsletter');
+ const sig = await freshSignal();
+ expect(sig.isNewsletterAutologinInFlight()).toBe(false);
+ });
+
+ it('is NOT in-flight for unsubscribe / resubscribe actions', async () => {
+ setSearch('?ne=a%40b.com&ac=x&action=unsubscribe');
+ const sig = await freshSignal();
+ expect(sig.isNewsletterAutologinInFlight()).toBe(false);
+ });
+});
+
+describe('promptOneTap suppression wiring', () => {
+ it('promptOneTap bails out while a newsletter autologin is in flight', () => {
+ const source = readFileSync(resolve(root, 'services/authService.ts'), 'utf8');
+ // Guard sits before any Firebase/GIS work at the top of promptOneTap.
+ expect(source).toContain('if (isNewsletterAutologinInFlight()) return;');
+ expect(source).toContain("from '@/services/newsletterAutologinSignal'");
+ });
+});


### PR DESCRIPTION
## Contesto

Click da newsletter su un articolo (`?ne=<email>&ac=<code>&utm_medium=newsletter`) → console mostrava `Provider's accounts list is empty.` + Google One Tap che parte. One Tap **non c'entra** con l'autologin: l'autologin è `ac` HMAC code → `exchangeNewsletterAuthCode` (Cloud Function) → custom token → `signInWithCustomToken`. One Tap è un sistema separato che partiva in **race** con l'exchange async e mostrava un prompt di sign-in a un utente che sta per essere loggato — rumore inutile che ritarda il contenuto linkato.

## Implementato

Nuovo modulo `services/newsletterAutologinSignal.ts` (dependency-free, no Firebase → unit-testabile) che segnala la finestra "autologin in volo":
- Calcolato **sincrono al module-load** (prima che App.tsx strippi i param) da `(ac|at|authToken)` + `(ne|newsletter_email|email)`, escluso `action=unsubscribe|resubscribe`.
- `settleNewsletterAutologin()` idempotente chiamato nel `finally` dell'effect di autologin (success/fail) + backstop 8s anti-stuck.
- Hook reattivo `useNewsletterAutologinInFlight` (subscribe → re-render al settle).

Consumatori (fix della **classe** "auth prompt durante autologin"):
- **`promptOneTap` bail-out al sorgente** — un solo guard copre TUTTI i caller (App, `useUserState`, `Newsletter`, `NewsletterPopup`, `UserProfile`, gate JobBoard).
- I due One Tap effect in `App.tsx` non si armano mentre in volo; si ri-eseguono al settle (dep aggiunta).
- `JobBoard` tiene lo `SkeletonJobDetail` invece di flashare l'auth gate (estesa la condizione skeleton già esistente, anti-CLS preservato).

Il contenuto articolo già rendeva subito (SSR, 1316 parole, `index,follow`); questo toglie solo il flicker di sign-in sopra.

Test: `tests/newsletter-autologin-onetap-suppression.test.ts` (6) — detection in-flight, settle+notify idempotente, no-op senza code, esclusione unsubscribe, wiring guard `promptOneTap`. Verde anche l'intera suite auth/onetap/userstate + `app-smoke` (render App col nuovo hook).

## Non implementato (ancora)

- **Gate `AiChatbot`**: non wired. Si apre solo su azione esplicita (apri chatbot + digita + invia) entro la finestra ~1-2s di autologin = praticamente impossibile; inoltre il `promptOneTap()` interno al gate è **già coperto** dal guard al sorgente. La sola UI residua (bottone Google nel modal) richiede il send esplicito. Deferito come non funnel-critical per questo scenario.
- **Flow `confirm_newsletter`**: usa `action=confirm_newsletter`+`token` (NON `ac`/`ne`) → il segnale lo esclude by-design. Quel flow mostra già l'overlay di benvenuto; nessun cambiamento di comportamento.
- **Dati generati**: `assemble-jobs-dataset` rigenera `data/*`/`public/data/expired-jobs.json` in locale per far girare i test; **non committati** (artifact, fuori scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)