### PR TITLE
feat(deploy): file-delta vs previous deploy in build summary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -419,6 +419,31 @@ jobs:
       # `data/jobs.json` assembly cache (next step above) stays — it's net
       # positive (~60s saved, ~28 MB tarball).
 
+      # Restore the PREVIOUS deploy's content manifest so the post-build
+      # "File delta vs previous deploy" step can diff in-place HTML changes.
+      # Keyed on run_id (always a miss → always saves the fresh manifest at
+      # post-job) with a constant restore-keys prefix that fetches the most
+      # recent prior manifest. The Build step overwrites content-manifest.tsv
+      # with THIS deploy's pages, so we copy the restored one aside first.
+      - name: Restore previous deploy content manifest
+        if: github.event.inputs.profile_sequential != 'true'
+        uses: actions/cache@v5
+        with:
+          path: content-manifest.tsv
+          key: deploy-content-manifest-${{ github.run_id }}
+          restore-keys: |
+            deploy-content-manifest-
+
+      - name: Stash previous content manifest before build overwrites it
+        if: github.event.inputs.profile_sequential != 'true'
+        run: |
+          if [ -f content-manifest.tsv ]; then
+            mv content-manifest.tsv prev-content-manifest.tsv
+            echo "[file-delta] previous manifest stashed ($(wc -l < prev-content-manifest.tsv) lines)"
+          else
+            echo "[file-delta] no previous manifest (first run after enabling / cache miss)"
+          fi
+
       - name: Build
         env:
           # UV_THREADPOOL_SIZE=64 was tested in commit 119475af96 (run
@@ -544,6 +569,12 @@ jobs:
           # when triaging a specific collision and you need the rendered
           # HTML. Saves ~100-200s/build on push events.
           WRITE_COLLISION_DUMP: ${{ github.event.inputs.write_collision_dump == 'true' && '1' || '' }}
+          # Emit `content-manifest.tsv` (path<TAB>sha1, one line per claim()'d
+          # page) so the post-build "File delta vs previous deploy" step can
+          # count in-place HTML changes. Reuses the sha1 claim() already
+          # computes — ZERO extra hashing, just a serialization walk. See
+          # build-plugins/writeRegistryLifecyclePlugin.ts + scripts/deploy-file-delta.mjs.
+          DEPLOY_CONTENT_MANIFEST: '1'
         shell: bash
         run: |
           set -o pipefail
@@ -1021,6 +1052,20 @@ jobs:
             --tar-size-bytes="${TAR_BYTES}" \
             --run-id="${GITHUB_RUN_ID}" \
             --sha="${GITHUB_SHA}"
+
+      # File delta vs previous deploy → GitHub Step Summary. Runs AFTER the
+      # audit step so signal 1 sees the row it just appended to
+      # data/dist-size-history.jsonl, and after Build so signal 2 has this
+      # deploy's content-manifest.tsv. Observability only — the script always
+      # exits 0 and never blocks the upload.
+      - name: File delta vs previous deploy (build summary)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: |
+          node scripts/deploy-file-delta.mjs \
+            --history=data/dist-size-history.jsonl \
+            --prev-manifest=prev-content-manifest.tsv \
+            --cur-manifest=content-manifest.tsv
 
       # Maintain data/url-first-seen.json — stamps every URL that
       # appears in dist sitemaps with today's date the first time we

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ data/adzuna-cache/
 
 # APM dependencies
 apm_modules/
+
+# Deploy file-delta manifests (emitted during build, persisted via actions/cache — never committed)
+content-manifest.tsv
+prev-content-manifest.tsv

--- a/build-plugins/writeRegistryLifecyclePlugin.ts
+++ b/build-plugins/writeRegistryLifecyclePlugin.ts
@@ -90,6 +90,16 @@ export function writeRegistryReportPlugin(opts: LifecycleOptions): Plugin {
  sequential: true,
  handler: async () => {
  const distDir = path.resolve(opts.rootDir, 'dist');
+
+ // Deploy file-delta observability: when DEPLOY_CONTENT_MANIFEST=1, dump a
+ // `path<TAB>sha1` manifest of every claim()'d page so the post-build step
+ // can diff this deploy against the previous one (scripts/deploy-file-delta).
+ // The sha1 is the hash claim() already computed for collision detection, so
+ // this adds ZERO hashing — only a serialization walk of getPathHistory().
+ // Runs BEFORE the zero-collisions early return below so clean builds still
+ // emit the manifest. Best-effort: failures never break the build.
+ emitDeployContentManifest(opts.rootDir, distDir);
+
  const records = getCollisions();
  const mode = (process.env.WRITE_COLLISION_MODE || 'report').toLowerCase();
 
@@ -158,6 +168,46 @@ function collectCollidingPaths(): Array<{
  // — useful when eyeballing the JSON.
  out.sort((a, b) => b.versions.length - a.versions.length);
  return out;
+}
+
+/**
+ * Emit `<rootDir>/content-manifest.tsv` — one `relPath\tsha1` line per page
+ * the registry saw, using each path's latest claimed content hash. Consumed by
+ * `scripts/deploy-file-delta.mjs` to count in-place HTML changes vs the
+ * previous deploy. Gated on `DEPLOY_CONTENT_MANIFEST` so local/dev builds skip
+ * the ~1.2M-line write. Paths are POSIX-normalised and dist-relative for
+ * cross-run stability. Streamed + chunked to bound memory on the large map.
+ * Best-effort: any failure is logged and swallowed (observability, not a gate).
+ */
+function emitDeployContentManifest(rootDir: string, distDir: string): void {
+ const flag = (process.env.DEPLOY_CONTENT_MANIFEST || '').toLowerCase();
+ if (flag !== '1' && flag !== 'true' && flag !== 'yes') return;
+
+ const outPath = path.resolve(rootDir, 'content-manifest.tsv');
+ try {
+ const stream = fs.createWriteStream(outPath, { encoding: 'utf-8' });
+ let buf = '';
+ let count = 0;
+ for (const [absPath, versions] of getPathHistory()) {
+ if (versions.length === 0) continue;
+ const rel = path.relative(distDir, absPath).split(path.sep).join('/');
+ // Skip anything that escaped dist (defensive — shouldn't happen).
+ if (rel.startsWith('..')) continue;
+ buf += `${rel}\t${versions[versions.length - 1].contentHash}\n`;
+ count += 1;
+ if (count % 50000 === 0) {
+ stream.write(buf);
+ buf = '';
+ }
+ }
+ if (buf) stream.write(buf);
+ stream.end();
+ // eslint-disable-next-line no-console
+ console.log(`\x1b[36m[write-registry]\x1b[0m deploy content manifest → ${outPath} (${count} paths)`);
+ } catch (err) {
+ // eslint-disable-next-line no-console
+ console.error(`[write-registry] content manifest emit failed (non-fatal): ${(err as Error)?.message ?? err}`);
+ }
 }
 
 interface CollisionSummary {

--- a/scripts/deploy-file-delta.mjs
+++ b/scripts/deploy-file-delta.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * deploy-file-delta.mjs — "what changed in the artifact vs the previous deploy?"
+ *
+ * Writes a Markdown section to $GITHUB_STEP_SUMMARY (and stdout) summarising
+ * how the freshly-built dist/ differs from the previous deploy. Two independent
+ * signals, each robust on its own:
+ *
+ *   Signal 1 — net add/remove per plugin bucket (ALWAYS available).
+ *     Source: the last two rows of data/dist-size-history.jsonl. That file is
+ *     committed every deploy by `report-dist-bytes-by-plugin.mjs`, so the
+ *     second-to-last row is the previous deploy and the last row is this one.
+ *     Gives `+added / -removed` file counts per plugin (and totals). It is a
+ *     stat-only signal: it cannot see a file that was rewritten in place
+ *     (same path, new content) — that's what signal 2 is for.
+ *
+ *   Signal 2 — in-place CHANGED HTML pages (best-effort, claim-based).
+ *     Source: two `content-manifest.tsv` files (`path<TAB>sha1`), the previous
+ *     deploy's (restored from actions/cache) and this build's (emitted during
+ *     the Vite build by writeRegistryReportPlugin from getPathHistory()). The
+ *     sha1 is the one claim() already computes for collision detection, so this
+ *     signal adds ZERO hashing to the build. Coverage = every HTML page routed
+ *     through WriteCollector/claim() (the ~1.2M job-SEO pages + static pages);
+ *     binary assets (og PNGs) and direct fs.writeFile emits are NOT covered
+ *     here — their churn shows up in signal 1 as add/remove instead. The hash
+ *     is captured at claim() time, i.e. BEFORE any deterministic post-walk
+ *     mutation; it is therefore a reliable change-DETECTOR as long as the
+ *     post-walk logic is unchanged between the two deploys, not a byte-image of
+ *     the shipped file. When either manifest is missing (first deploy after
+ *     enabling this, or cache miss) the section degrades gracefully to a note.
+ *
+ * Usage:
+ *   node scripts/deploy-file-delta.mjs \
+ *     [--history=data/dist-size-history.jsonl] \
+ *     [--prev-manifest=prev-content-manifest.tsv] \
+ *     [--cur-manifest=content-manifest.tsv] \
+ *     [--top=15]
+ *
+ * Never fails the deploy: any error is caught and reported as a note in the
+ * summary (exit 0). This is observability, not a gate.
+ */
+import { readFileSync, existsSync, appendFileSync } from 'node:fs';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+function parseArgs(argv) {
+  const out = {
+    history: 'data/dist-size-history.jsonl',
+    prevManifest: 'prev-content-manifest.tsv',
+    curManifest: 'content-manifest.tsv',
+    top: 15,
+  };
+  for (const arg of argv) {
+    if (arg.startsWith('--history=')) out.history = arg.slice('--history='.length);
+    else if (arg.startsWith('--prev-manifest=')) out.prevManifest = arg.slice('--prev-manifest='.length);
+    else if (arg.startsWith('--cur-manifest=')) out.curManifest = arg.slice('--cur-manifest='.length);
+    else if (arg.startsWith('--top=')) out.top = Math.max(1, Number(arg.slice('--top='.length)) || 15);
+  }
+  return out;
+}
+
+/** Read the last two non-empty JSONL rows without loading the whole file. */
+function lastTwoRows(historyPath) {
+  if (!existsSync(historyPath)) return { prev: null, cur: null };
+  const lines = readFileSync(historyPath, 'utf-8').split('\n').filter((l) => l.trim().length > 0);
+  const parse = (l) => {
+    try {
+      return JSON.parse(l);
+    } catch {
+      return null;
+    }
+  };
+  const cur = lines.length >= 1 ? parse(lines[lines.length - 1]) : null;
+  const prev = lines.length >= 2 ? parse(lines[lines.length - 2]) : null;
+  return { prev, cur };
+}
+
+function fmtSigned(n) {
+  return n > 0 ? `+${n.toLocaleString('en-US')}` : n.toLocaleString('en-US');
+}
+
+/** Signal 1: per-plugin file-count delta between two dist-size-history rows. */
+function buildSignal1(prev, cur) {
+  if (!cur) return { lines: ['_Nessuna riga in dist-size-history.jsonl — niente baseline._'] };
+  if (!prev) {
+    return {
+      lines: [
+        `Primo deploy registrato (run \`${cur.runId}\`): **${(cur.totalFiles || 0).toLocaleString('en-US')}** file totali, nessun deploy precedente con cui confrontare.`,
+      ],
+    };
+  }
+
+  const prevByPlugin = prev.byPlugin || {};
+  const curByPlugin = cur.byPlugin || {};
+  const names = new Set([...Object.keys(prevByPlugin), ...Object.keys(curByPlugin)]);
+
+  const rows = [];
+  for (const name of names) {
+    const p = prevByPlugin[name]?.files || 0;
+    const c = curByPlugin[name]?.files || 0;
+    const d = c - p;
+    if (d !== 0) rows.push({ name, prev: p, cur: c, delta: d });
+  }
+  rows.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+
+  const totalPrev = prev.totalFiles || 0;
+  const totalCur = cur.totalFiles || 0;
+  const totalDelta = totalCur - totalPrev;
+
+  const lines = [];
+  lines.push(
+    `Totale file: **${totalCur.toLocaleString('en-US')}** (${fmtSigned(totalDelta)} vs run precedente \`${prev.runId}\` → \`${cur.runId}\`)`,
+  );
+  lines.push('');
+  if (rows.length === 0) {
+    lines.push('_Nessun bucket plugin ha cambiato numero di file (possibili solo modifiche in-place → vedi sotto)._');
+  } else {
+    lines.push('| Bucket plugin | Prima | Dopo | Δ file |');
+    lines.push('| --- | ---: | ---: | ---: |');
+    for (const r of rows.slice(0, 30)) {
+      lines.push(`| \`${r.name}\` | ${r.prev.toLocaleString('en-US')} | ${r.cur.toLocaleString('en-US')} | ${fmtSigned(r.delta)} |`);
+    }
+    if (rows.length > 30) lines.push(`| _…+${rows.length - 30} altri bucket_ | | | |`);
+  }
+  return { lines };
+}
+
+/** Load a path<TAB>sha1 manifest into a Map. Streamed to bound memory. */
+async function loadManifest(file) {
+  const map = new Map();
+  if (!existsSync(file)) return null;
+  const rl = createInterface({ input: createReadStream(file, 'utf-8'), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line) continue;
+    const tab = line.indexOf('\t');
+    if (tab === -1) continue;
+    map.set(line.slice(0, tab), line.slice(tab + 1));
+  }
+  return map;
+}
+
+/** Signal 2: added / removed / changed HTML pages between two claim manifests. */
+async function buildSignal2(prevFile, curFile, top) {
+  const cur = await loadManifest(curFile);
+  if (!cur) {
+    return { lines: ['_Manifest contenuti di questo build assente (signal 2 non emesso) — solo add/remove sopra._'] };
+  }
+  const prev = await loadManifest(prevFile);
+  if (!prev) {
+    return {
+      lines: [
+        `_Nessun manifest del deploy precedente (cache miss / primo run). Baseline registrata: **${cur.size.toLocaleString('en-US')}** pagine HTML tracciate._`,
+      ],
+    };
+  }
+
+  let added = 0;
+  let removed = 0;
+  let changed = 0;
+  let unchanged = 0;
+  const changedSample = [];
+  for (const [path, hash] of cur) {
+    const prevHash = prev.get(path);
+    if (prevHash === undefined) added += 1;
+    else if (prevHash !== hash) {
+      changed += 1;
+      if (changedSample.length < top) changedSample.push(path);
+    } else unchanged += 1;
+  }
+  for (const path of prev.keys()) {
+    if (!cur.has(path)) removed += 1;
+  }
+
+  const lines = [];
+  lines.push(
+    `Pagine HTML tracciate (claim-based): **${cur.size.toLocaleString('en-US')}**`,
+  );
+  lines.push('');
+  lines.push('| | Conteggio |');
+  lines.push('| --- | ---: |');
+  lines.push(`| ✏️ Modificate in-place | **${changed.toLocaleString('en-US')}** |`);
+  lines.push(`| ➕ Aggiunte | ${added.toLocaleString('en-US')} |`);
+  lines.push(`| ➖ Rimosse | ${removed.toLocaleString('en-US')} |`);
+  lines.push(`| ⏸️ Invariate | ${unchanged.toLocaleString('en-US')} |`);
+  if (changedSample.length > 0) {
+    lines.push('');
+    lines.push('<details><summary>Esempio pagine modificate</summary>');
+    lines.push('');
+    for (const p of changedSample) lines.push(`- \`${p}\``);
+    lines.push('');
+    lines.push('</details>');
+  }
+  return { lines };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const out = [];
+  out.push('## 📦 File delta vs deploy precedente');
+  out.push('');
+
+  try {
+    const { prev, cur } = lastTwoRows(args.history);
+    out.push('### Net add/remove per bucket (stat-based, sempre disponibile)');
+    out.push('');
+    out.push(...buildSignal1(prev, cur).lines);
+  } catch (err) {
+    out.push(`_Signal 1 fallito: ${err?.message || err}_`);
+  }
+
+  out.push('');
+  try {
+    out.push('### Modifiche in-place HTML (claim-based, best-effort)');
+    out.push('');
+    const s2 = await buildSignal2(args.prevManifest, args.curManifest, args.top);
+    out.push(...s2.lines);
+  } catch (err) {
+    out.push(`_Signal 2 fallito: ${err?.message || err}_`);
+  }
+
+  out.push('');
+  out.push(
+    '<sub>Signal 1 = differenza di numero file per bucket (non vede i file riscritti a parità di path). '
+    + 'Signal 2 = pagine HTML il cui contenuto è cambiato, hash sha1 calcolato da claim() al momento della scrittura '
+    + '(copre le pagine via WriteCollector; asset binari/og non inclusi → compaiono nel Signal 1).</sub>',
+  );
+
+  const block = out.join('\n') + '\n';
+  // eslint-disable-next-line no-console
+  console.log(block);
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    try {
+      appendFileSync(summaryFile, block);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[deploy-file-delta] could not append to step summary: ${err?.message || err}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  // Observability only — never fail the deploy.
+  // eslint-disable-next-line no-console
+  console.error(`[deploy-file-delta] non-fatal error: ${err?.stack || err}`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Implementato

Risponde alla domanda «ad ogni deploy, quanti file sono cambiati nell'artifact rispetto al deploy precedente?» aggiungendo una sezione **📦 File delta vs deploy precedente** al **GitHub Step Summary** del job di deploy. Due segnali complementari:

**Signal 1 — net add/remove per bucket plugin (sempre disponibile).** Diff delle ultime 2 righe di `data/dist-size-history.jsonl` (già committato a ogni deploy da `report-dist-bytes-by-plugin.mjs`). Mostra `+aggiunti / -rimossi` per bucket + totale. Stat-based: **non** vede i file riscritti a parità di path → è ciò che copre il Signal 2. Zero costo nuovo.

**Signal 2 — pagine HTML modificate in-place (best-effort, claim-based).** Durante il build, `writeRegistryLifecyclePlugin` emette `content-manifest.tsv` (`path<TAB>sha1`, una riga per pagina `claim()`'d) da `getPathHistory()`. L'sha1 è **quello che `claim()` calcola già** per la collision detection → **zero hashing aggiuntivo**, solo una walk di serializzazione. Il manifest del deploy precedente è persistito via `actions/cache` (key `run_id` + restore-keys prefix, idiom già usato in deploy.yml); lo step post-build diffa prev↔cur → conta `modificate / aggiunte / rimosse / invariate` + esempio path.

**Sicurezza/scope:**
- Observability pura: `scripts/deploy-file-delta.mjs` esce **sempre 0**, mai blocca l'upload (`continue-on-error: true`).
- Emit manifest **env-gated** (`DEPLOY_CONTENT_MANIFEST`) → build locali/dev saltano la scrittura ~1.2M righe.
- `content-manifest.tsv` / `prev-content-manifest.tsv` in `.gitignore` (mai committati; vivono solo come artifact di cache).
- Gate `if: profile_sequential != 'true'` su tutti gli step nuovi (coerente con gli step audit/url-first-seen vicini).

**File:** nuovo `scripts/deploy-file-delta.mjs` · `build-plugins/writeRegistryLifecyclePlugin.ts` (helper additivo env-gated) · `.github/workflows/deploy.yml` (env + cache restore/stash + step diff) · `.gitignore`.

**Verifica:** script testato locale su fixtures (changed/added/removed/unchanged corretti) + tutti i path degradati (no prev manifest, no history, no manifest). Type-check: zero errori sul file modificato (gli 84 errori tsc sono baseline pre-esistenti — `data/jobs.json` generato assente + comparazioni loose in `staticPagesPlugin`, non toccato). GitNexus impact su `writeRegistryReportPlugin`: **LOW**, unico d=1 = `vite.config.ts` (registrazione), modifica additiva senza cambio firma.

## Non implementato (ancora)

- **NON riattivato il content-hash manifest** (`ContentHashManifest`, disabilitato dal 2026-04-28 per +30-60s/build di SHA256 su 220k file, ROI negativo). Il Signal 2 usa invece l'hash `claim()` già pagato → nessuna regressione perf. *Out of scope* riattivarlo.
- **Signal 2 = HTML claim-based, non byte-image del file shippato.** L'hash è catturato al momento del `claim()`, **prima** di eventuali mutazioni post-walk deterministiche; resta un change-DETECTOR affidabile finché la logica post-walk è invariata tra i due deploy. Asset binari/og PNG (non `claim()`'d) non sono nel Signal 2 → la loro churn compare nel Signal 1 come add/remove. *Documentato nel footer del summary.*
- **Costo build Signal 2 non validabile su `pull_request`** (`build:ci` gira solo post-merge su `main`): la walk di `getPathHistory()` + scrittura ~1.2M righe (~100MB) è O(pagine), nessun hashing nuovo; cache save/restore ~30MB gz. *Revert-trigger:* se il prossimo deploy post-merge regredisce wall-time in modo misurabile o OOMa → revert. Atteso impatto trascurabile (la map esiste già in memoria; nessuna SHA aggiuntiva).
- Prima esecuzione: Signal 2 mostra solo «baseline registrata» (nessun manifest precedente in cache); il diff vero parte dal secondo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)