### PR TITLE
refactor(auth): single parseNewsletterAutologin source of truth

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -131,7 +131,7 @@ import {
  consumeAuthJobContext,
 } from '@/services/authService';
 import type { AuthJobContext } from '@/services/authService';
-import { settleNewsletterAutologin } from '@/services/newsletterAutologinSignal';
+import { settleNewsletterAutologin, parseNewsletterAutologin } from '@/services/newsletterAutologinSignal';
 import { useNewsletterAutologinInFlight } from '@/hooks/useNewsletterAutologinInFlight';
 import {
  upsertNewsletterSubscriber as upsertNewsletterSubscriberRecord,
@@ -439,10 +439,11 @@ const App: React.FC = () => {
  (async () => {
  try {
  const url = new URL(window.location.href);
- // 'ac' = HMAC autologin code (never expires, exchanged for fresh token)
- // 'at'/'authToken' = legacy Firebase custom token (expires in 1h, direct sign-in)
- const autologinCode = url.searchParams.get('ac');
- const legacyAuthToken = url.searchParams.get('at') || url.searchParams.get('authToken');
+ // Shared parser owns the credential/email param names (ac, at/authToken,
+ // ne/newsletter_email/email) so this effect and the in-flight signal can
+ // never drift — see services/newsletterAutologinSignal.ts.
+ const { code: autologinCode, legacyToken: legacyAuthToken, email: rawEmail, action } =
+ parseNewsletterAutologin(url.searchParams);
 
  // Always strip newsletter-specific query params from the URL immediately so
  // they don't persist during SPA navigation (privacy + cosmetics).
@@ -450,12 +451,10 @@ const App: React.FC = () => {
  const hadNewsletterParams = NEWSLETTER_PARAMS.some(p => url.searchParams.has(p));
 
  // Skip if there's a newsletter action — the action handler owns auth in that case
- const action = url.searchParams.get('action');
  if (action === 'unsubscribe' || action === 'resubscribe' || action === 'confirm_newsletter') return;
 
- // Read email before stripping params (support short 'ne', legacy 'newsletter_email',
- // and 'email' fallback for confirmation links that share the 'email' param)
- const email = normalizeNewsletterEmail(url.searchParams.get('ne') || url.searchParams.get('newsletter_email') || url.searchParams.get('email') || '');
+ // Normalize the recipient email read by the shared parser.
+ const email = normalizeNewsletterEmail(rawEmail);
 
  // Strip newsletter params from URL right away
  if (hadNewsletterParams) {

--- a/App.tsx
+++ b/App.tsx
@@ -748,9 +748,10 @@ const App: React.FC = () => {
  return;
  }
 
- // Authenticate via autologin code or legacy custom token before processing
- const autologinCode = urlParams.get('ac');
- const legacyAuthToken = urlParams.get('at') || urlParams.get('authToken');
+ // Authenticate via autologin code or legacy custom token before processing.
+ // Same shared parser as the primary autologin effect — credential param names
+ // live only in services/newsletterAutologinSignal.ts (no drift).
+ const { code: autologinCode, legacyToken: legacyAuthToken } = parseNewsletterAutologin(urlParams);
  if (autologinCode) {
  // New flow: exchange HMAC code for fresh token
  const { exchangeNewsletterAuthCode } = await import('@/services/newsletterSubscribers');

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -12,7 +12,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { hasActiveSlot } from '@/services/popupQueue';
 import { reportCaughtError } from '@/services/errorReporter';
-import { isNewsletterAutologinInFlight } from '@/services/newsletterAutologinSignal';
+import { isNewsletterAutologinInFlight, parseNewsletterAutologin } from '@/services/newsletterAutologinSignal';
 
 // ─── Resilient Dynamic Import ────────────────────────────────
 // After a deploy, old chunk hashes no longer exist on the CDN.
@@ -94,11 +94,15 @@ function shouldStartAuthImmediately(): boolean {
  // appears logged in right away — no interaction required.
  if (hasPersistedAuthSession()) return true;
  const params = new URLSearchParams(window.location.search);
+ // Credential subset (ac/at/authToken) derives from the shared parser so the
+ // param names can't drift from the in-flight signal. The `ne`-only check and
+ // the broader newsletter/oobCode/confirm triggers stay local by design.
+ const autologin = parseNewsletterAutologin(params);
  return (
  window.location.pathname.includes('/gestione-contenuti-xk9mp2q')
  || (params.get('mode') === 'signIn' && Boolean(params.get('oobCode')))
  || params.get('newsletter_autologin') === '1'
- || Boolean(params.get('ac') || params.get('at') || params.get('authToken'))
+ || Boolean(autologin.code || autologin.legacyToken)
  || Boolean(params.get('ne'))
  || params.get('action') === 'confirm_newsletter'
  );

--- a/services/newsletterAutologinSignal.ts
+++ b/services/newsletterAutologinSignal.ts
@@ -16,15 +16,45 @@
  * unit-testable without the heavy authService import graph.
  */
 
+export interface NewsletterAutologin {
+ /** `ac` — HMAC autologin code (never expires, exchanged for a fresh token). */
+ code: string | null;
+ /** `at` / `authToken` — legacy Firebase custom token (expires in 1h). */
+ legacyToken: string | null;
+ /** Raw recipient email (`ne` / `newsletter_email` / `email`), not normalized. */
+ email: string;
+ /** `action` param, if any (unsubscribe / resubscribe / confirm_newsletter / …). */
+ action: string | null;
+ /**
+ * True when the URL carries an autologin credential + recipient email and is
+ * not an unsubscribe/resubscribe action — i.e. App.tsx's autologin effect will
+ * attempt a sign-in. `confirm_newsletter` naturally yields `false` (it carries
+ * a `token`, not `ac`/`at`).
+ */
+ isAutologin: boolean;
+}
+
+/**
+ * Single source of truth for "is this URL a newsletter autologin link, and what
+ * does it carry". Consumed by both this signal (module-load detection) and the
+ * App.tsx autologin effect, so the credential/email param names live in ONE
+ * place — adding a future code param (e.g. a `v2`) updates both by construction.
+ */
+export function parseNewsletterAutologin(search: string | URLSearchParams): NewsletterAutologin {
+ const p = typeof search === 'string' ? new URLSearchParams(search) : search;
+ const action = p.get('action');
+ const code = p.get('ac');
+ const legacyToken = p.get('at') || p.get('authToken');
+ const email = p.get('ne') || p.get('newsletter_email') || p.get('email') || '';
+ const isExcludedAction = action === 'unsubscribe' || action === 'resubscribe';
+ const isAutologin = !isExcludedAction && Boolean(code || legacyToken) && Boolean(email);
+ return { code, legacyToken, email, action, isAutologin };
+}
+
 let inFlight = ((): boolean => {
  if (typeof window === 'undefined') return false;
  try {
- const p = new URLSearchParams(window.location.search);
- const action = p.get('action');
- if (action === 'unsubscribe' || action === 'resubscribe') return false;
- const hasCode = Boolean(p.get('ac') || p.get('at') || p.get('authToken'));
- const hasEmail = Boolean(p.get('ne') || p.get('newsletter_email') || p.get('email'));
- return hasCode && hasEmail;
+ return parseNewsletterAutologin(window.location.search).isAutologin;
  } catch {
  return false;
  }

--- a/tests/newsletter-autologin-onetap-suppression.test.ts
+++ b/tests/newsletter-autologin-onetap-suppression.test.ts
@@ -75,6 +75,36 @@ describe('newsletter autologin → sign-in affordance suppression', () => {
  });
 });
 
+describe('parseNewsletterAutologin (shared source of truth)', () => {
+ it('extracts ac code + ne email and flags autologin', async () => {
+ const sig = await freshSignal();
+ const r = sig.parseNewsletterAutologin('?ne=a%40b.com&ac=deadbeef&utm_medium=newsletter');
+ expect(r.code).toBe('deadbeef');
+ expect(r.legacyToken).toBeNull();
+ expect(r.email).toBe('a@b.com');
+ expect(r.isAutologin).toBe(true);
+ });
+
+ it('accepts legacy at/authToken + newsletter_email/email fallbacks', async () => {
+ const sig = await freshSignal();
+ expect(sig.parseNewsletterAutologin('?at=tok&newsletter_email=x%40y.com').isAutologin).toBe(true);
+ expect(sig.parseNewsletterAutologin('?authToken=tok&email=x%40y.com').isAutologin).toBe(true);
+ });
+
+ it('is not autologin without a credential, without an email, or on unsubscribe', async () => {
+ const sig = await freshSignal();
+ expect(sig.parseNewsletterAutologin('?ne=a%40b.com').isAutologin).toBe(false);
+ expect(sig.parseNewsletterAutologin('?ac=deadbeef').isAutologin).toBe(false);
+ expect(sig.parseNewsletterAutologin('?ne=a%40b.com&ac=x&action=unsubscribe').isAutologin).toBe(false);
+ });
+
+ it('accepts a URLSearchParams instance as well as a string', async () => {
+ const sig = await freshSignal();
+ const r = sig.parseNewsletterAutologin(new URLSearchParams('ne=a%40b.com&ac=z'));
+ expect(r.isAutologin).toBe(true);
+ });
+});
+
 describe('promptOneTap suppression wiring', () => {
  it('promptOneTap bails out while a newsletter autologin is in flight', () => {
  const source = readFileSync(resolve(root, 'services/authService.ts'), 'utf8');


### PR DESCRIPTION
## Contesto

Follow-up al 🟡 nit della review di #1519: la detection dell'autologin newsletter (param credenziale `ac`/`at`/`authToken`, param email `ne`/`newsletter_email`/`email`, esclusione `action`) era duplicata tra il segnale in-flight (`newsletterAutologinSignal.ts`) e l'effect di autologin in `App.tsx` → **due fonti di verità**. Aggiungere un futuro param credenziale (es. `v2`) all'effect avrebbe **silenziosamente** smesso di essere rilevato dal segnale → ritorno del rumore One Tap senza fallimento di test.

## Implementato

- Estratto `parseNewsletterAutologin(search: string | URLSearchParams): NewsletterAutologin` nel modulo segnale (resta **dependency-free**, no Firebase). Ritorna `{ code, legacyToken, email, action, isAutologin }`.
- Il segnale (detection al module-load) e l'effect `App.tsx` consumano entrambi il parser. Le liste param-name vivono ora in **un solo posto** → drift impossibile by-construction (AGENTS rule 6).
- **Comportamento invariato**: stessi param, stessa logica; `App.tsx` continua a normalizzare l'email (`normalizeNewsletterEmail`), a strippare i `NEWSLETTER_PARAMS` e a escludere `confirm_newsletter`/unsubscribe/resubscribe come prima.
- Test estesi (+4): `parseNewsletterAutologin` su code/legacy/email-fallback, esclusione unsubscribe, input `URLSearchParams` vs stringa. Suite 10/10 verde + `app-smoke` verde (effect refactored); tsc pulito sui file toccati.

## Non implementato (ancora)

- Nessun cambiamento ai consumer (One Tap guard, JobBoard skeleton, hook) — già a posto da #1519.
- Le 3 osservazioni adversarial della review #1519 (settle-vs-authUser propagation, mount effect-436 su ogni route, backstop 8s vs cold-start) restano transienti/non funnel-critical e fuori scope di questo refactor di sola de-duplicazione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)