### PR TITLE
chore(seo): offline auditor for inline <style> blocks in built artifact

### DIFF
--- a/scripts/audit-inline-style-blocks.mjs
+++ b/scripts/audit-inline-style-blocks.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Audit a built artifact for inline `<style>...</style>` blocks in emitted
+ * static HTML — the dist-bloat class the PR #454 `.s-*` codemod does NOT cover
+ * (that codemod only extracted inline `style="..."` ATTRIBUTES into hashed
+ * classes; whole `<style>` blocks injected via `extraHeadHtml` are still
+ * shipped per-page by hand-written build plugins).
+ *
+ * This is an OFFLINE diagnostic, not a build-time plugin. Run it against a
+ * local artifact to find which plugins still inline a `<style>` block, fix the
+ * offenders at the source (move the CSS into `public/assets/seo-static.css`,
+ * renaming root selectors when two page types share one), and re-run to
+ * confirm the block is gone. No need to run it every build.
+ *
+ * Usage:
+ *   node scripts/audit-inline-style-blocks.mjs [distDir] [--json] [--min-bytes N]
+ *     distDir       artifact root to scan (default: download/artifact, else dist)
+ *     --json        emit machine-readable JSON instead of the text report
+ *     --min-bytes N ignore unique blocks whose total shipped bytes < N (default 0)
+ *
+ * For each UNIQUE block (deduped by normalized content hash) it reports:
+ *   - shipped bytes = block length × page count  (≈ what externalizing saves)
+ *   - page count + a sample page path
+ *   - distinctive selectors found in the block
+ *   - best-guess SOURCE plugin (grep of build-plugins/ for a distinctive selector)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const minBytesArg = args.indexOf('--min-bytes');
+const minBytes = minBytesArg >= 0 ? Number(args[minBytesArg + 1]) || 0 : 0;
+const positional = args.filter((a, i) => !a.startsWith('--') && !(args[i - 1] === '--min-bytes'));
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+function resolveDistDir() {
+  if (positional[0]) return path.resolve(positional[0]);
+  for (const c of ['download/artifact', 'dist']) {
+    const abs = path.join(repoRoot, c);
+    if (fs.existsSync(abs)) return abs;
+  }
+  console.error('No artifact dir found. Pass one explicitly, e.g.:\n  node scripts/audit-inline-style-blocks.mjs download/artifact');
+  process.exit(2);
+}
+
+const distDir = resolveDistDir();
+
+/** Fast candidate list: only HTML files that contain `<style`. Falls back to a
+ *  Node walk if ripgrep is unavailable. */
+function listCandidateFiles() {
+  try {
+    const out = execFileSync('rg', ['-l', '--glob', '*.html', '<style', distDir], {
+      encoding: 'utf8',
+      maxBuffer: 256 * 1024 * 1024,
+    });
+    return out.split('\n').filter(Boolean);
+  } catch (err) {
+    if (err.status === 1) return []; // rg: no matches
+    // rg missing or other failure → Node walk (slower).
+    const acc = [];
+    const walk = (dir) => {
+      for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, ent.name);
+        if (ent.isDirectory()) walk(p);
+        else if (ent.name.endsWith('.html')) {
+          if (fs.readFileSync(p, 'utf8').includes('<style')) acc.push(p);
+        }
+      }
+    };
+    walk(distDir);
+    return acc;
+  }
+}
+
+const STYLE_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+/** Normalize a block's inner CSS for hashing: collapse whitespace so cosmetic
+ *  differences don't split otherwise-identical blocks. */
+function normalize(css) {
+  return css.replace(/\s+/g, ' ').trim();
+}
+
+/** Pull a few distinctive selectors out of a CSS block for display + source
+ *  mapping. Only looks at the selector prelude BEFORE each `{` rule body (so
+ *  value-internal noise like `rgba(0,0,0,.1)` or `#533afd` is never mistaken
+ *  for a selector), and keeps only class/id selectors that are valid CSS
+ *  identifiers (start with a letter or `_` — excludes `.1`, `.15`, …). */
+function selectorsOf(css) {
+  const set = new Set();
+  for (const m of css.matchAll(/([^{}]+)\{/g)) {
+    for (const part of m[1].split(',')) {
+      const first = part.trim().split(/[\s>+~]/)[0];
+      const cm = first.match(/[.#][A-Za-z_][\w-]*/);
+      if (cm) set.add(cm[0]);
+    }
+  }
+  return [...set];
+}
+
+/** Best-guess source plugin: grep build-plugins/ for a distinctive selector
+ *  literal from the block. Cached per selector. */
+const sourceCache = new Map();
+function findSource(selectors) {
+  // Prefer the longest/most distinctive class selector.
+  const candidates = selectors
+    .filter((s) => s.startsWith('.'))
+    .sort((a, b) => b.length - a.length);
+  for (const sel of candidates) {
+    if (sourceCache.has(sel)) {
+      const hit = sourceCache.get(sel);
+      if (hit) return { selector: sel, files: hit };
+      continue;
+    }
+    let files = [];
+    try {
+      const out = execFileSync(
+        'rg',
+        ['-l', '-F', sel, path.join(repoRoot, 'build-plugins')],
+        { encoding: 'utf8' },
+      );
+      files = out.split('\n').filter(Boolean).map((f) => path.relative(repoRoot, f));
+    } catch {
+      files = [];
+    }
+    sourceCache.set(sel, files.length ? files : null);
+    if (files.length) return { selector: sel, files };
+  }
+  return { selector: candidates[0] || selectors[0] || '?', files: [] };
+}
+
+const files = listCandidateFiles();
+
+/** hash → { len, count, pages:[sample paths], css } */
+const blocks = new Map();
+for (const file of files) {
+  let html;
+  try {
+    html = fs.readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+  for (const m of html.matchAll(STYLE_RE)) {
+    const css = normalize(m[1]);
+    if (!css) continue;
+    const h = createHash('sha256').update(css).digest('hex').slice(0, 12);
+    let rec = blocks.get(h);
+    if (!rec) {
+      rec = { len: m[0].length, count: 0, pages: [], css };
+      blocks.set(h, rec);
+    }
+    rec.count++;
+    if (rec.pages.length < 3) rec.pages.push(path.relative(distDir, file));
+  }
+}
+
+const ranked = [...blocks.entries()]
+  .map(([hash, r]) => {
+    const shipped = r.len * r.count;
+    const selectors = selectorsOf(r.css);
+    return { hash, shipped, ...r, selectors };
+  })
+  .filter((r) => r.shipped >= minBytes)
+  .sort((a, b) => b.shipped - a.shipped);
+
+// Source mapping only for the ranked set (cheap: one rg per unique block).
+for (const r of ranked) r.source = findSource(r.selectors);
+
+const totalShipped = ranked.reduce((s, r) => s + r.shipped, 0);
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        distDir,
+        filesScanned: files.length,
+        uniqueBlocks: ranked.length,
+        totalShippedBytes: totalShipped,
+        blocks: ranked.map((r) => ({
+          hash: r.hash,
+          blockBytes: r.len,
+          pages: r.count,
+          shippedBytes: r.shipped,
+          selectors: r.selectors,
+          sourcePlugins: r.source.files,
+          matchedSelector: r.source.selector,
+          samplePages: r.pages,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
+
+const mb = (n) => (n / 1024 / 1024).toFixed(2) + ' MB';
+const kb = (n) => (n / 1024).toFixed(1) + ' KB';
+
+console.log(`\nInline <style> block audit — ${path.relative(repoRoot, distDir) || distDir}`);
+console.log(`HTML files with a <style> block: ${files.length}`);
+console.log(`Unique blocks: ${ranked.length}   Potential dedup savings: ~${mb(totalShipped)}\n`);
+
+let i = 0;
+for (const r of ranked) {
+  i++;
+  const src = r.source.files.length
+    ? r.source.files.join(', ') + `  (matched ${r.source.selector})`
+    : `UNKNOWN (tried ${r.source.selector})`;
+  console.log(
+    `#${i}  ${kb(r.len)}/page × ${r.count} pages = ~${mb(r.shipped)}  [${r.hash}]`,
+  );
+  console.log(`    source : ${src}`);
+  console.log(`    sel    : ${r.selectors.slice(0, 8).join(' ')}${r.selectors.length > 8 ? ' …' : ''}`);
+  console.log(`    sample : ${r.pages[0]}`);
+}
+console.log('');


### PR DESCRIPTION
## Implementato

`scripts/audit-inline-style-blocks.mjs` — diagnostico **offline** (non un plugin build-time) che gira sull'artifact locale e trova quali plugin spediscono ancora un blocco `<style>` inline per-pagina. È la classe di bloat che il codemod `.s-*` (PR #454) **non** copre: quel codemod ha estratto solo gli **attributi** `style="..."`, mai i blocchi `<style>` interi.

Cosa fa:
- Lista candidati via `rg -l '<style' <dist>` (veloce: 14.4k file su ~800k), legge solo quelli.
- Dedupa ogni blocco per hash del contenuto normalizzato, **ranka per byte spediti** (dimensione blocco × n. pagine ≈ risparmio se esternalizzato).
- Mappa ogni blocco al **plugin sorgente** via `rg` di un selettore distintivo in `build-plugins/`.
- Estrazione selettori solo dal prelude prima di `{` + identificatori CSS validi → niente falsi positivi da `rgba(0,0,0,.1)` / `#hex` nei valori.
- `--json` per output machine-readable, `--min-bytes N` per filtrare il rumore.

Uso: `node scripts/audit-inline-style-blocks.mjs download/artifact`

## Risultati sull'artifact locale (11G, pre-#1582)

16 blocchi unici, **~11.48 MB** di potenziale dedup. Top offender:

| # | byte/pag × pagine | ~tot | plugin sorgente |
|---|---|---|---|
| 1 | 0.7 KB × 10600 | **7.36 MB** | `staticPagesPlugin` / `ogPagesPlugin` (`.bg-surface-alt/.text-heading/.dark`) |
| 2 | 1.8 KB × 1728 | 2.96 MB | salary-hub content — **già fixato in #1582** (UNKNOWN = non più nel source) |
| 3 | 0.8 KB × 918 | 0.72 MB | `staticPagesPlugin` / `ogPagesPlugin` |
| 4 | 0.3 KB × 887 | 0.25 MB | `seoHubsPlugin` (`.hp .hc`) |
| 6 | 0.2 KB × 197 | 0.05 MB | `jobsSeoPagesPlugin` (`.jf .js .ja`) |
| 7 | 0.9 KB × 24 | 0.02 MB | `costOfLivingLandingsPlugin` |
| 9–10 | ~2 KB × 4 | ~0.01 MB | `borderWaitMapPlugin`, `faqHubPlugin` |

Le voci salary-hub (#2, #5, #12) risultano **UNKNOWN** perché l'artifact è pre-#1592 ma il source è già stato sistemato → il tool conferma che il fix ha rimosso il blocco all'origine (sparirà al prossimo build).

## Non implementato (ancora)

- **Fix degli offender** trovati: questa PR è solo lo strumento. Il prossimo target è il **#1 da 7.36 MB** (`staticPagesPlugin`/`ogPagesPlugin`, 10600 pagine) — più grande di salary-hub. Va spostato in `seo-static.css` con la stessa attenzione alle collisioni di selettore (verificare che i due plugin non emettano lo stesso selettore con regole diverse). Follow-up dedicato per ogni sorgente.
- Nessun test: è uno script diagnostico offline non-funnel (come gli altri `scripts/audit-*`), nessun output di build.

## Test
- Lanciato live sull'artifact locale 11G → report corretto, mapping sorgente verificato (es. `.salary-hub-page` → UNKNOWN coerente col fix #1582 già mergiato; `.fh-*` → faqHubPlugin; `.jf` → jobsSeoPagesPlugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)