### PR TITLE
fix(build): stop baking commit/build id into bundle — kills ~100% deploy churn

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -207,6 +207,19 @@ const App: React.FC = () => {
  // failing <img> to its raw.githubusercontent fallback (same SHA).
  useEffect(() => { installBlogImageCdnFallback(); }, []);
 
+ // Version badge commit hash — fetched at runtime from /commit-hash.txt
+ // (emitted by buildIdPlugin) instead of a Vite `define`. Baking it into the
+ // bundle put a fresh value in the entry every build → ~100% deploy churn.
+ const [commitHash, setCommitHash] = useState('');
+ useEffect(() => {
+ let alive = true;
+ fetch('/commit-hash.txt')
+ .then((r) => (r.ok ? r.text() : ''))
+ .then((t) => { if (alive && t.trim()) setCommitHash(t.trim()); })
+ .catch(() => {});
+ return () => { alive = false; };
+ }, []);
+
  useEffect(() => {
  if (typeof window === 'undefined') return;
  const w = window as unknown as { __THIN_SHELL__?: number; __THIN_SHELL_REPORTED__?: number };
@@ -2556,14 +2569,14 @@ const App: React.FC = () => {
  {/* Version badge with GitHub link */}
  <div className="flex items-center justify-center mt-2 mb-2">
  <a
- href={`https://github.com/valerielinc-ops/frontaliere-si-o-no/commit/${typeof __COMMIT_HASH__ !== 'undefined' ? __COMMIT_HASH__ : 'unknown'}`}
+ href={`https://github.com/valerielinc-ops/frontaliere-si-o-no/commit/${commitHash || 'unknown'}`}
  target="_blank"
  rel="noopener noreferrer"
  className="text-sm font-mono text-muted hover:text-accent px-1 py-0.5 rounded transition-colors opacity-70 hover:opacity-100"
  title="Versione del sito: commit GitHub deploy"
  >
  <span>v</span>
- <span>{typeof __SHORT_COMMIT_HASH__ !== 'undefined' ? __SHORT_COMMIT_HASH__ : 'unknown'}</span>
+ <span>{commitHash ? commitHash.slice(0, 7) : 'unknown'}</span>
  </a>
  </div>
 

--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -1,10 +1,12 @@
 /**
  * Shared constants for Vite build plugins.
  *
- * BUILD_ID: timestamp injected as __BUILD_ID__ — used by BlogArticles
- * to detect stale caches.
- * COMMIT_HASH / SHORT_COMMIT_HASH: injected as __COMMIT_HASH__ /
- * __SHORT_COMMIT_HASH__ for the version badge and GitHub link.
+ * BUILD_ID: per-build timestamp. Emitted to dist/build-id.txt by buildIdPlugin
+ * and read at runtime (staleness checks). NOT injected as a Vite `define` —
+ * baking it into the bundle changed the entry hash every build → ~100% page
+ * churn (see vite.config define removal).
+ * COMMIT_HASH / SHORT_COMMIT_HASH: build commit. Emitted to dist/commit-hash.txt
+ * and read at runtime (version badge fetches it). Also NOT a `define`, same reason.
  * BASE_URL: canonical site origin used across all static-page generators.
  */
 

--- a/services/seo/blogImageCdn.ts
+++ b/services/seo/blogImageCdn.ts
@@ -26,14 +26,15 @@
 
 const REPO = 'valerielinc-ops/frontaliere-si-o-no';
 
-// raw fallback is pinned to the build commit. __COMMIT_HASH__ is injected by
-// Vite (vite.config.ts define, declared in vite-env.d.ts); falls back to `main`
-// when unavailable (e.g. dev server). The primary CDN base has no SHA — it's a
+// raw fallback ref. Previously pinned to the build commit via the __COMMIT_HASH__
+// Vite define, but that baked a per-build value into the SPA entry chunk → new
+// entry content hash every deploy → ~100% page churn (the entry filename is
+// referenced by every prerendered page). The raw fallback only fires when the
+// CDN image is briefly unreachable (rare), and the blog hero images are
+// git-tracked on `main`, so a stable `main` ref recovers them just fine without
+// making the bundle non-deterministic. The primary CDN base has no SHA — it's a
 // stable domain whose Fastly cache is purged on each CDN-repo deploy.
-const SHA =
-  typeof __COMMIT_HASH__ !== 'undefined' && __COMMIT_HASH__ && __COMMIT_HASH__ !== 'unknown'
-    ? __COMMIT_HASH__
-    : 'main';
+const SHA = 'main';
 
 export const CDN_BLOG_BASE = `https://cdn.frontaliereticino.ch/images/blog`;
 export const RAW_BLOG_BASE = `https://raw.githubusercontent.com/${REPO}/${SHA}/public/images/blog`;

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,11 +1,8 @@
 /// <reference types="vite/client" />
 
-/** Build timestamp injected by Vite define — used to detect stale caches. */
-declare const __BUILD_ID__: string;
-/** Full commit hash injected by Vite define — used for versioning and debugging. */
-declare const __COMMIT_HASH__: string;
-/** Short commit hash injected by Vite define — used for version badge in UI. */
-declare const __SHORT_COMMIT_HASH__: string;
+// Build id / commit hash are NOT injected via Vite `define` — that baked a fresh
+// value into the bundle every build → new entry content hash → ~100% deploy
+// churn. They are emitted as /build-id.txt + /commit-hash.txt and read at runtime.
 
 interface ImportMetaEnv {
  readonly MODE: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
 /* ── Build-time constants ────────────────────────────────────────── */
-import { BUILD_ID, COMMIT_HASH, SHORT_COMMIT_HASH } from './build-plugins/constants';
 
 /* ── Content-hash manifest disabled 2026-04-28 (see plugins block) ──── */
 // import { initManifest, saveManifest, getManifest } from './build-plugins/contentHash';
@@ -358,12 +357,12 @@ export default defineConfig(({ mode }) => {
  // resolved. No-op when BUILD_PROFILE=0.
  profileSummaryPlugin(),
  ],
- define: {
- // No secrets injected at build time — all sensitive keys come from Firebase Remote Config at runtime
- __BUILD_ID__: JSON.stringify(BUILD_ID),
- __COMMIT_HASH__: JSON.stringify(COMMIT_HASH),
- __SHORT_COMMIT_HASH__: JSON.stringify(SHORT_COMMIT_HASH),
- },
+ // No build-time `define`: nothing volatile is injected into the bundle.
+ // Build id / commit hash are emitted as dist/build-id.txt + commit-hash.txt
+ // (buildIdPlugin) and read at RUNTIME. Baking them via define put a fresh
+ // value into the entry chunk every build → new content hash → every one of
+ // ~1.28M prerendered pages re-referenced a new /assets/index-<hash>.js →
+ // ~100% deploy churn. Keep the bundle deterministic so incremental sync works.
  resolve: {
  alias: {
  '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Implementato
Rende il bundle Vite **deterministico** rimuovendo i valori volatili bakeizzati, che erano la **causa misurata del churn ~totale per deploy**.

**Diagnosi (provata, non ipotizzata):** il `define` di Vite iniettava `__BUILD_ID__` (`Date.now()`, cambia ogni build) e `__COMMIT_HASH__`/`__SHORT_COMMIT_HASH__` (git sha, cambia ogni commit) nel bundle JS. Ogni build → valore nuovo nell'entry chunk → nuovo content-hash → ognuna delle ~1,28M pagine prerenderizzate referenziava un nuovo `/assets/index-<hash>.js`. Misura via `measure-deploy-delta` (sample-diff, run 27159120612) su due build **data-only** (src identico, solo `data/` cambiato): **80% file / 97% byte cambiano**, e l'**unico frammento diverso in ogni pagina era l'hash dell'entry**.

**Modifiche:**
- `vite.config.ts`: rimosso il blocco `define` (+ import `constants` ora inutilizzato).
- `__BUILD_ID__`: era **dead** (nessun uso nel src) → eliminato.
- `App.tsx`: il version badge ora **fetcha `/commit-hash.txt` a runtime** invece del define (codice deterministico nell'entry).
- `services/seo/blogImageCdn.ts`: il raw fallback usa ref stabile `'main'` (era `__COMMIT_HASH__`); è un path raro (CDN-down) e le hero blog sono git-tracked su main.
- `build-plugins/constants.ts` + `vite-env.d.ts`: commenti/typedef aggiornati (no più define).
- `build-id.txt` / `commit-hash.txt` restano emessi da `buildIdPlugin` (sorgente runtime).

**Verificato pre-merge:** `tsc --noEmit` pulito; test mirati verdi (`blogImageCdn`, `no-secrets-in-build`, `spa-bundle-resolver` — 20/20). Il primary `cdnBlogImage` build-time non usava il commit (solo CDN base) → gli `<img>` delle pagine statiche non cambiano.

## Non implementato (ancora)
- **Verifica churn post-merge non possibile pre-merge** (no full build locale / OOM): il claim "data-only deploy → churn ~0%" si conferma SOLO post-merge eseguendo `measure-deploy-delta` su due build data-only consecutivi. **Revert-trigger:** se due deploy data-only post-merge mostrano ancora churn >~5% di file → l'entry ha un'altra sorgente di non-determinismo → investigare/revert.
- **Churn da merge di codice reale** resta (un cambio vero a JS/CSS ri-hasha l'entry → pagine cambiano). Atteso/legittimo; il fix mira ai deploy data-only (la maggioranza, orari). Decoupling completo (entry a nome stabile) = follow-up opzionale se servirà.
- **Caching dei `.txt`**: `/commit-hash.txt` fetchato a runtime; il badge mostra `unknown` finché non carica (footer, non funnel). Nessun impatto SEO/AdSense.
- **Blocco deploy reale** (inode-count ~2,3M → migrazione object storage) è separato: questo fix è prerequisito perché il sync incrementale paghi, non sblocca da solo il deploy su Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)