### PR TITLE
fix(email): target=_blank rel=noopener su tutti i link email

### DIFF
--- a/functions/src/newsletterConfirmationEmail.js
+++ b/functions/src/newsletterConfirmationEmail.js
@@ -51,7 +51,7 @@ export function buildNewsletterConfirmationEmailHtml(confirmUrl, locale = 'it') 
  <tr><td align="center">
  <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;">
  <tr><td style="text-align:center;padding-bottom:24px;">
- <a href="${BASE_URL}" style="text-decoration:none;">
+ <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="text-decoration:none;">
  <img src="${BASE_URL}/icons/icon-192x192.png" alt="${t(lang, 'brandName')}" width="48" height="48" style="display:block;margin:0 auto 8px;border-radius:12px;" />
  <div style="font-size:22px;font-weight:800;color:${BRAND_BLUE};">${t(lang, 'brandName')}</div>
  <div style="font-size:12px;color:${MUTED_COLOR};letter-spacing:.04em;">${t(lang, 'brandTagline')}</div>
@@ -64,7 +64,7 @@ export function buildNewsletterConfirmationEmailHtml(confirmUrl, locale = 'it') 
  </div>
  <table width="100%" cellpadding="0" cellspacing="0" style="margin:24px 0;">
  <tr><td align="center">
- <a href="${escapeHtml(confirmUrl)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:16px 32px;border-radius:12px;font-size:16px;font-weight:700;letter-spacing:.02em;">
+ <a target="_blank" rel="noopener noreferrer" href="${escapeHtml(confirmUrl)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:16px 32px;border-radius:12px;font-size:16px;font-weight:700;letter-spacing:.02em;">
  ${t(lang, 'confirmButton')}
  </a>
  </td></tr>
@@ -93,7 +93,7 @@ export function buildNewsletterConfirmationEmailHtml(confirmUrl, locale = 'it') 
  <tr><td style="text-align:center;padding:20px 0 8px;">
  <div style="font-size:12px;color:${MUTED_COLOR};">
  ${t(lang, 'copyright', { year })} ·
- <a href="${BASE_URL}" style="color:${MUTED_COLOR};text-decoration:none;">frontaliereticino.ch</a>
+ <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="color:${MUTED_COLOR};text-decoration:none;">frontaliereticino.ch</a>
  </div>
  </td></tr>
  </table>

--- a/scripts/newsletter-template.mjs
+++ b/scripts/newsletter-template.mjs
@@ -267,7 +267,7 @@ function renderHero({ campaign, exchangeRate, locale }) {
           </table>
           <table width="100%" cellpadding="0" cellspacing="0">
             <tr><td align="left">
-              <a href="${utmUrl('/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:13px 18px;border-radius:12px;font-size:15px;font-weight:700;">${nlT(locale, 'heroCta')}</a>
+              <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:13px 18px;border-radius:12px;font-size:15px;font-weight:700;">${nlT(locale, 'heroCta')}</a>
             </td></tr>
           </table>
         </td>
@@ -309,7 +309,7 @@ function renderExchangeRate({ rate, previousRate, campaign, locale }) {
         </table>
         <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:16px;">
           <tr><td align="left">
-            <a href="${utmUrl('/compara-servizi/cambio-franco-euro', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
+            <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/compara-servizi/cambio-franco-euro', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
               ${nlT(locale, 'exchangeCta')}
             </a>
           </td></tr>
@@ -354,7 +354,7 @@ function renderMarketOutlook({ insight, campaign, locale }) {
 
         <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px;">
           <tr><td align="left">
-            <a href="${utmUrl('/compara-servizi/cambio-franco-euro', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
+            <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/compara-servizi/cambio-franco-euro', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
               ${nlT(locale, 'outlookCta')}
             </a>
           </td></tr>
@@ -372,7 +372,7 @@ function renderTopArticles({ articles, campaign, locale }) {
           <tr>
             <td style="width:28px;vertical-align:top;font-size:20px;font-weight:bold;color:${BRAND_BLUE};">${i + 1}</td>
             <td style="vertical-align:top;">
-              <a href="${utmUrl(a.url, campaign)}" style="font-size:15px;font-weight:600;color:${BRAND_DARK};text-decoration:none;">${escapeHtml(a.title)}</a>
+              <a target="_blank" rel="noopener noreferrer" href="${utmUrl(a.url, campaign)}" style="font-size:15px;font-weight:600;color:${BRAND_DARK};text-decoration:none;">${escapeHtml(a.title)}</a>
               <div style="font-size:12px;color:${MUTED_COLOR};margin-top:2px;">${a.views} ${nlT(locale, 'articleReads')} · ${a.readingMinutes || 5} ${nlT(locale, 'articleMin')}</div>
             </td>
           </tr>
@@ -387,7 +387,7 @@ function renderTopArticles({ articles, campaign, locale }) {
         <table width="100%" cellpadding="0" cellspacing="0">${rows}</table>
         <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px;">
           <tr><td align="left">
-            <a href="${utmUrl('/articoli-frontaliere', campaign)}" style="display:inline-block;color:${BRAND_BLUE};text-decoration:none;font-size:14px;font-weight:700;">${nlT(locale, 'articlesCta')}</a>
+            <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/articoli-frontaliere', campaign)}" style="display:inline-block;color:${BRAND_BLUE};text-decoration:none;font-size:14px;font-weight:700;">${nlT(locale, 'articlesCta')}</a>
           </td></tr>
         </table>
       </td></tr>
@@ -415,7 +415,7 @@ function renderLatestArticle({ title, excerpt, imageUrl, articleUrl, campaign, l
           <div style="font-size:15px;color:${TEXT_COLOR};line-height:1.6;padding-bottom:16px;">${escapeHtml(excerpt)}</div>
           <table width="100%" cellpadding="0" cellspacing="0">
             <tr><td align="left">
-              <a href="${utmUrl(articleUrl, campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
+              <a target="_blank" rel="noopener noreferrer" href="${utmUrl(articleUrl, campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
                 ${nlT(locale, 'latestCta')}
               </a>
             </td></tr>
@@ -432,7 +432,7 @@ function renderFeaturedTool({ title, description, buttonText, toolUrl, campaign,
         <div style="font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:${MUTED_COLOR};padding-bottom:8px;font-weight:700;">${nlT(locale, 'toolLabel')}</div>
         <div style="font-size:24px;line-height:1.25;font-weight:800;color:${BRAND_DARK};padding-bottom:8px;">${escapeHtml(title)}</div>
         <div style="font-size:15px;color:${TEXT_COLOR};line-height:1.6;padding-bottom:16px;">${escapeHtml(description)}</div>
-        <a href="${utmUrl(toolUrl, campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
+        <a target="_blank" rel="noopener noreferrer" href="${utmUrl(toolUrl, campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-size:15px;font-weight:700;">
           ${escapeHtml(buttonText)}
         </a>
       </td></tr>
@@ -465,7 +465,7 @@ function renderJobSection({ jobs, campaign, locale }) {
     return `
       <tr>
         <td style="padding:10px 0;border-bottom:1px solid ${BORDER_COLOR};">
-          <a href="${jobUrl}" style="text-decoration:none;">
+          <a target="_blank" rel="noopener noreferrer" href="${jobUrl}" style="text-decoration:none;">
             <div style="font-size:14px;font-weight:700;color:${BRAND_DARK};line-height:1.3;">${title}</div>
             <div style="font-size:12px;color:${TEXT_COLOR};margin-top:2px;">${company}${location ? ` · ${location}` : ''}</div>
           </a>
@@ -483,7 +483,7 @@ function renderJobSection({ jobs, campaign, locale }) {
           </table>
           <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px;">
             <tr><td align="center">
-              <a href="${utmUrl('/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:11px 20px;border-radius:10px;font-size:14px;font-weight:700;">${JOB_CTA[locale] || JOB_CTA.it}</a>
+              <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/', campaign)}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:11px 20px;border-radius:10px;font-size:14px;font-weight:700;">${JOB_CTA[locale] || JOB_CTA.it}</a>
             </td></tr>
           </table>
         </td>
@@ -505,7 +505,7 @@ function renderAffiliatePartners({ campaign, locale }) {
     return `
       <tr>
         <td style="padding:10px 0;border-bottom:1px solid ${BORDER_COLOR};">
-          <a href="${utmUrl(p.goUrl, campaign)}" style="text-decoration:none;">
+          <a target="_blank" rel="noopener noreferrer" href="${utmUrl(p.goUrl, campaign)}" style="text-decoration:none;">
             <div style="font-size:14px;font-weight:700;color:${BRAND_DARK};line-height:1.3;">${p.emoji} ${escapeHtml(p.name)}</div>
             <div style="font-size:12px;color:${TEXT_COLOR};margin-top:2px;">${escapeHtml(desc)}</div>
           </a>
@@ -607,7 +607,7 @@ export function buildNewsletter(data) {
         <tr><td class="outer-card" style="background:${LIGHT_BG};padding:24px;">
           <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:16px;">
             <tr><td style="text-align:center;">
-              <a href="${BASE_URL}" style="text-decoration:none;">
+              <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="text-decoration:none;">
                 <img src="${BASE_URL}/icons/icon-192x192.png" alt="Frontaliere Ticino" width="40" height="40" style="display:inline-block;vertical-align:middle;border-radius:10px;margin-right:8px;" />
                 <span style="font-size:18px;font-weight:800;color:${BRAND_BLUE};vertical-align:middle;">Frontaliere Ticino</span>
               </a>
@@ -619,11 +619,11 @@ export function buildNewsletter(data) {
         <tr><td style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:16px;padding:18px;text-align:center;">
           <div style="font-size:13px;color:${MUTED_COLOR};line-height:1.6;">${nlT(locale, 'footerReason')}</div>
           <div style="margin-top:12px;font-size:12px;color:${MUTED_COLOR};line-height:1.8;">
-            <a href="${data.unsubscribeUrl || '#'}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerUnsub')}</a>
+            <a target="_blank" rel="noopener noreferrer" href="${data.unsubscribeUrl || '#'}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerUnsub')}</a>
             <span style="color:${MUTED_COLOR};font-size:11px;"> · </span>
-            <a href="${data.resubscribeUrl || '{{RESUBSCRIBE_URL}}'}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerResub')}</a>
+            <a target="_blank" rel="noopener noreferrer" href="${data.resubscribeUrl || '{{RESUBSCRIBE_URL}}'}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerResub')}</a>
             <span style="color:${MUTED_COLOR};font-size:11px;"> · </span>
-            <a href="${utmUrl('/privacy', campaign)}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerPrivacy')}</a>
+            <a target="_blank" rel="noopener noreferrer" href="${utmUrl('/privacy', campaign)}" style="font-size:11px;color:${MUTED_COLOR};text-decoration:underline;">${nlT(locale, 'footerPrivacy')}</a>
           </div>
         </td></tr>
       </table>

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -633,7 +633,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
 
     return `
         <tr><td style="padding:0 0 10px;">
-          <a href="${url}" style="text-decoration:none;display:block;">
+          <a target="_blank" rel="noopener noreferrer" href="${url}" style="text-decoration:none;display:block;">
             <table width="100%" cellpadding="0" cellspacing="0" style="background:${DARK_CARD};border-radius:12px;">
               <tr>
                 <td width="58" style="padding:16px 0 16px 18px;vertical-align:middle;">
@@ -687,7 +687,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
                 <span style="color:${BRAND_ORANGE};">\u25cf</span> Frontaliere Ticino
               </td>
               <td align="right" style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:1px;">
-                <a href="${manageUrl}" style="color:${BRAND_ORANGE};text-decoration:none;">${s.manageAlerts}</a>
+                <a target="_blank" rel="noopener noreferrer" href="${manageUrl}" style="color:${BRAND_ORANGE};text-decoration:none;">${s.manageAlerts}</a>
               </td>
             </tr>
           </table>
@@ -711,7 +711,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
           <table width="100%" cellpadding="0" cellspacing="0">
             ${jobCards}
             <tr><td style="text-align:center;padding-top:14px;">
-              <a href="${allJobsUrl}" style="display:inline-block;background:transparent;border:2px solid ${BRAND_ORANGE};color:${BRAND_ORANGE};font-weight:700;font-size:13px;text-decoration:none;padding:11px 28px;border-radius:8px;">${s.viewAll}</a>
+              <a target="_blank" rel="noopener noreferrer" href="${allJobsUrl}" style="display:inline-block;background:transparent;border:2px solid ${BRAND_ORANGE};color:${BRAND_ORANGE};font-weight:700;font-size:13px;text-decoration:none;padding:11px 28px;border-radius:8px;">${s.viewAll}</a>
             </td></tr>
           </table>
         </td></tr>
@@ -730,18 +730,18 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
             ${s.intendedFor(escHtml(alert.email), filterSummary)}
           </div>
           <div style="margin-bottom:12px;">
-            <a href="https://www.facebook.com/profile.php?id=61588174947294" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcd8</a>
-            <a href="https://www.linkedin.com/company/frontaliere-ticino" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcbc</a>
-            <a href="${BASE_URL}" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83c\udf10</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/profile.php?id=61588174947294" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcd8</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/company/frontaliere-ticino" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcbc</a>
+            <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83c\udf10</a>
           </div>
           <div style="font-size:12px;color:${MUTED};margin:4px 0;">
-            <a href="${manageUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;font-weight:600;">${s.manageAlerts}</a>
+            <a target="_blank" rel="noopener noreferrer" href="${manageUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;font-weight:600;">${s.manageAlerts}</a>
           </div>
           <div style="font-size:12px;color:${MUTED};margin:4px 0;">
-            ${s.unsubThis(filterLabel)} <a href="${unsubscribeUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;">${s.unsubThisLink}</a>
+            ${s.unsubThis(filterLabel)} <a target="_blank" rel="noopener noreferrer" href="${unsubscribeUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;">${s.unsubThisLink}</a>
           </div>
           <div style="font-size:12px;color:${MUTED};margin:4px 0;">
-            <a href="${unsubAllUrl}" style="color:#94a3b8;text-decoration:underline;">${s.unsubAll}</a> ${s.unsubJoke}
+            <a target="_blank" rel="noopener noreferrer" href="${unsubAllUrl}" style="color:#94a3b8;text-decoration:underline;">${s.unsubAll}</a> ${s.unsubJoke}
           </div>
           <div style="font-size:12px;color:#475569;margin-top:12px;">\u00a9 ${new Date().getFullYear()} Frontaliere Ticino \u00b7 0% spam, 100% frontaliere</div>
         </td></tr>

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -281,7 +281,7 @@ function injectJobAndCompanyLinks(html, jobs, locale = 'it') {
       html = html.replace(new RegExp(`<a[^>]*>\\s*(${titleEsc})\\s*</a>`, 'gi'), '$1');
       html = html.replace(new RegExp(`<strong>(${titleEsc})</strong>`, 'gi'), '$1');
       if (jobUrl && appearsInText(html, titleEsc)) {
-        html = replaceOutsideTags(html, titleEsc, 'i', (m) => `<a href="${jobUrl}" style="${linkStyle}">${m}</a>`);
+        html = replaceOutsideTags(html, titleEsc, 'i', (m) => `<a target="_blank" rel="noopener noreferrer" href="${jobUrl}" style="${linkStyle}">${m}</a>`);
         foundTitle = true;
       }
     }
@@ -297,7 +297,7 @@ function injectJobAndCompanyLinks(html, jobs, locale = 'it') {
         html = html.replace(new RegExp(`<a[^>]*>\\s*(${nameEsc})\\s*</a>`, 'gi'), '$1');
         html = html.replace(new RegExp(`<strong>(${nameEsc})</strong>`, 'gi'), '$1');
         if (companyUrl && appearsInText(html, nameEsc)) {
-          html = replaceOutsideTags(html, nameEsc, 'i', (m) => `<a href="${companyUrl}" style="${linkStyle}">${m}</a>`);
+          html = replaceOutsideTags(html, nameEsc, 'i', (m) => `<a target="_blank" rel="noopener noreferrer" href="${companyUrl}" style="${linkStyle}">${m}</a>`);
           companyLinked = true;
         }
       }
@@ -305,9 +305,9 @@ function injectJobAndCompanyLinks(html, jobs, locale = 'it') {
 
     // Collect snippet for fallback paragraph if title wasn't found in AI text
     if (!foundTitle && jobUrl && j.title) {
-      const titleLink = `<a href="${jobUrl}" style="${linkStyle}">${j.title}</a>`;
+      const titleLink = `<a target="_blank" rel="noopener noreferrer" href="${jobUrl}" style="${linkStyle}">${j.title}</a>`;
       const companyPart = j.company && companyUrl
-        ? ` ${i18n.at} <a href="${companyUrl}" style="${linkStyle}">${j.company}</a>`
+        ? ` ${i18n.at} <a target="_blank" rel="noopener noreferrer" href="${companyUrl}" style="${linkStyle}">${j.company}</a>`
         : j.company ? ` ${i18n.at} ${j.company}` : '';
       const locationPart = j.location ? ` ${i18n.in} ${j.location}` : '';
       linkedSnippets.push(`${titleLink}${companyPart}${locationPart}`);
@@ -353,7 +353,7 @@ function injectToolLinks(html, locale = 'it') {
       const closeAnchors = (before.match(/<\/a>/gi) || []).length;
       if (openAnchors > closeAnchors) return match; // inside an existing <a>
       const absUrl = `${BASE_URL}${url}`;
-      return `<a href="${absUrl}" style="${linkStyle}">${match}</a>`;
+      return `<a target="_blank" rel="noopener noreferrer" href="${absUrl}" style="${linkStyle}">${match}</a>`;
     });
   }
   return html;

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -677,10 +677,10 @@ export function buildBriefingPrompt(ctx) {
   // "dai un'occhiata al ruolo di ... presso ... a Chiasso" verbatim into an
   // English/German/French email.
   const briefingExamplesByLocale = {
-    it: `dai un'occhiata al ruolo di <a href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> presso <a href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> a Chiasso`,
-    en: `take a look at the <a href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> role at <a href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> in Chiasso`,
-    de: `schau dir die Stelle als <a href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> bei <a href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> in Chiasso an`,
-    fr: `jetez un œil au poste de <a href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> chez <a href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> à Chiasso`,
+    it: `dai un'occhiata al ruolo di <a target="_blank" rel="noopener noreferrer" href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> presso <a target="_blank" rel="noopener noreferrer" href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> a Chiasso`,
+    en: `take a look at the <a target="_blank" rel="noopener noreferrer" href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> role at <a target="_blank" rel="noopener noreferrer" href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> in Chiasso`,
+    de: `schau dir die Stelle als <a target="_blank" rel="noopener noreferrer" href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> bei <a target="_blank" rel="noopener noreferrer" href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> in Chiasso an`,
+    fr: `jetez un œil au poste de <a target="_blank" rel="noopener noreferrer" href="JOB_URL" style="color:#2563eb;text-decoration:underline;">Software Engineer</a> chez <a target="_blank" rel="noopener noreferrer" href="COMPANY_URL" style="color:#2563eb;text-decoration:underline;">Board International</a> à Chiasso`,
   };
   const briefingExample = briefingExamplesByLocale[locale] || briefingExamplesByLocale.it;
 
@@ -688,7 +688,7 @@ export function buildBriefingPrompt(ctx) {
     `You write the opening section of a weekly email newsletter for "Frontaliere Ticino", a platform for cross-border workers (frontalieri) between Italy and Switzerland.`,
     `Write in ${langName}. Be warm, conversational, and practical. Like a knowledgeable friend sharing useful updates.`,
     `ABSOLUTE LANGUAGE RULE: Every word in your output MUST be in ${langName}. ${locale === 'it' ? '' : `NEVER copy Italian phrasings from any reference material into your ${langName} output — use only natural ${langName} prepositions and verbs to introduce job mentions, company names, and city names. `}Tool names, brand names, and proper nouns are the only exceptions.`,
-    `Output 2-3 short paragraphs. Use simple HTML ONLY: <p> tags for paragraphs, <strong> for emphasis, <a href="URL" style="color:#2563eb;text-decoration:underline;"> for links. No greetings, no sign-offs, no subject line.`,
+    `Output 2-3 short paragraphs. Use simple HTML ONLY: <p> tags for paragraphs, <strong> for emphasis, <a target="_blank" rel="noopener noreferrer" href="URL" style="color:#2563eb;text-decoration:underline;"> for links. No greetings, no sign-offs, no subject line.`,
     `CRITICAL: NEVER use Markdown syntax. Do NOT use **bold**, *italic*, [text](link), or any asterisks for emphasis. Always use the HTML tags above. Asterisks will render as literal characters in the email.`,
     `STRUCTURE RULE: First paragraph MUST mention 1-2 specific job opportunities with clickable hyperlinks. Second paragraph covers exchange rate context. Keep jobs EARLY — never push them to the end.`,
     `CRITICAL JOB LINKING RULE: Every job mention MUST have TWO hyperlinks: (1) the job title linked to JOB_URL, and (2) the company name linked to COMPANY_URL. Copy URLs exactly from the data. NEVER use <strong> for job titles or company names — ALWAYS use <a>. If a job has no URL, do NOT mention it. Example (in ${langName}): "${briefingExample}".`,

--- a/services/newsletter-template.mjs
+++ b/services/newsletter-template.mjs
@@ -402,7 +402,7 @@ function renderHeroExchangeRate({ rate, previousRate, locale }) {
       <div style="font-size:14px;color:#94a3b8;margin:0 0 20px;">${nlT(locale, 'greetingSub')}</div>
 
       <!--[if mso]><table cellpadding="0" cellspacing="0" align="center"><tr><td style="background:#1e293b;border-radius:16px;padding:20px 36px;"><![endif]-->
-      <a href="${localizedUrl('/compara-servizi/cambio-franco-euro', locale)}" style="text-decoration:none;display:inline-block;">
+      <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/compara-servizi/cambio-franco-euro', locale)}" style="text-decoration:none;display:inline-block;">
       <div class="rate-box" style="display:inline-block;background:linear-gradient(135deg,#1e293b,#334155);border-radius:16px;padding:20px 36px;margin:8px 0 16px;">
         <div style="font-size:12px;color:#94a3b8;text-transform:uppercase;letter-spacing:1px;">${nlT(locale, 'rateLabel')}</div>
         <div class="hero-rate" style="font-size:52px;font-weight:900;color:${BRAND_ORANGE};letter-spacing:-1px;line-height:1.1;">${rate.toFixed(4)}</div>
@@ -419,7 +419,7 @@ function renderHeroExchangeRate({ rate, previousRate, locale }) {
       <div style="margin-top:12px;font-size:14px;color:#e2e8f0;line-height:1.5;">${compareHtml}</div>
 
       <div style="margin-top:16px;">
-        <a href="${localizedUrl('/compara-servizi/cambio-franco-euro', locale)}" style="display:inline-block;background:${BRAND_ORANGE};color:#fff;font-weight:700;font-size:14px;text-decoration:none;padding:12px 28px;border-radius:8px;">${nlT(locale, 'rateCta')}</a>
+        <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/compara-servizi/cambio-franco-euro', locale)}" style="display:inline-block;background:${BRAND_ORANGE};color:#fff;font-weight:700;font-size:14px;text-decoration:none;padding:12px 28px;border-radius:8px;">${nlT(locale, 'rateCta')}</a>
       </div>
     </td></tr>`;
 }
@@ -455,7 +455,7 @@ function renderMetrics(totalJobs, metrics, locale) {
       <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0"><tr><td width="33%" valign="top"><![endif]-->
       <table width="100%" cellpadding="0" cellspacing="0"><tr class="metric-row">
         <td width="33%" style="padding:0 4px 0 0;">
-          <a href="${localizedUrl('/cerca-lavoro-ticino', locale)}" style="text-decoration:none;display:block;">
+          <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/cerca-lavoro-ticino', locale)}" style="text-decoration:none;display:block;">
             <div style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:12px;padding:14px 12px;text-align:center;">
               <div style="font-size:22px;margin-bottom:4px;">\ud83d\udcbc</div>
               <div style="font-size:20px;font-weight:800;color:${BRAND_DARK};">${totalJobs || '200+'}</div>
@@ -465,7 +465,7 @@ function renderMetrics(totalJobs, metrics, locale) {
         </td>
         <!--[if mso]></td><td width="33%" valign="top"><![endif]-->
         <td width="33%" style="padding:0 4px;">
-          <a href="${localizedUrl('/statistiche', locale)}" style="text-decoration:none;display:block;">
+          <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/statistiche', locale)}" style="text-decoration:none;display:block;">
             <div style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:12px;padding:14px 12px;text-align:center;">
               <div style="font-size:22px;margin-bottom:4px;">\ud83d\udcca</div>
               <div style="font-size:20px;font-weight:800;color:${BRAND_DARK};">${unemploymentRate}</div>
@@ -475,7 +475,7 @@ function renderMetrics(totalJobs, metrics, locale) {
         </td>
         <!--[if mso]></td><td width="33%" valign="top"><![endif]-->
         <td width="33%" style="padding:0 0 0 4px;">
-          <a href="${localizedUrl('/compara-servizi/confronta-casse-malati', locale)}" style="text-decoration:none;display:block;">
+          <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/compara-servizi/confronta-casse-malati', locale)}" style="text-decoration:none;display:block;">
             <div style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:12px;padding:14px 12px;text-align:center;">
               <div style="font-size:22px;margin-bottom:4px;">\ud83c\udfe5</div>
               <div style="font-size:20px;font-weight:800;color:${BRAND_DARK};">${lamalPremium}</div>
@@ -506,7 +506,7 @@ function renderJobs(matchedJobs, locale, totalJobs) {
 
     return `
       <tr><td style="padding:0 0 10px;">
-        <a href="${directUrl(job.url)}" style="text-decoration:none;display:block;">
+        <a target="_blank" rel="noopener noreferrer" href="${directUrl(job.url)}" style="text-decoration:none;display:block;">
           <table width="100%" cellpadding="0" cellspacing="0" style="background:${BRAND_DARK};border-radius:12px;">
             <tr>
               <td width="58" style="padding:16px 0 16px 18px;vertical-align:middle;">
@@ -519,7 +519,7 @@ function renderJobs(matchedJobs, locale, totalJobs) {
               </td>
               <td style="padding:16px 18px 16px 14px;vertical-align:middle;">
                 <div class="job-title" style="font-size:14px;font-weight:700;color:#f1f5f9;margin:0;line-height:1.3;">${escapeHtml(truncatedTitle)}</div>
-                <div style="font-size:12px;color:#94a3b8;margin-top:2px;">${job.companyUrl ? `<a href="${directUrl(job.companyUrl)}" style="color:#94a3b8;text-decoration:underline;">${escapeHtml(job.company)}</a>` : escapeHtml(job.company)}${job.location ? ' \u00b7 ' + escapeHtml(job.location) : ''}</div>
+                <div style="font-size:12px;color:#94a3b8;margin-top:2px;">${job.companyUrl ? `<a target="_blank" rel="noopener noreferrer" href="${directUrl(job.companyUrl)}" style="color:#94a3b8;text-decoration:underline;">${escapeHtml(job.company)}</a>` : escapeHtml(job.company)}${job.location ? ' \u00b7 ' + escapeHtml(job.location) : ''}</div>
                 ${tags.length > 0 ? `<div style="margin-top:4px;">${tags.join(' ')}</div>` : ''}
               </td>
             </tr>
@@ -535,7 +535,7 @@ function renderJobs(matchedJobs, locale, totalJobs) {
       <table width="100%" cellpadding="0" cellspacing="0">
         ${jobCards}
         <tr><td style="text-align:center;padding-top:14px;">
-          <a href="${localizedUrl('/cerca-lavoro-ticino', locale)}" style="display:inline-block;background:transparent;border:2px solid ${BRAND_ORANGE};color:${BRAND_ORANGE};font-weight:700;font-size:13px;text-decoration:none;padding:11px 28px;border-radius:8px;">${ctaText}</a>
+          <a target="_blank" rel="noopener noreferrer" href="${localizedUrl('/cerca-lavoro-ticino', locale)}" style="display:inline-block;background:transparent;border:2px solid ${BRAND_ORANGE};color:${BRAND_ORANGE};font-weight:700;font-size:13px;text-decoration:none;padding:11px 28px;border-radius:8px;">${ctaText}</a>
         </td></tr>
       </table>
     </td></tr>`;
@@ -592,7 +592,7 @@ function renderArticle(article, locale) {
   const emoji = deriveArticleEmoji(article);
   return `
     <tr><td class="section-pad" style="background:${WHITE};padding:0 28px 8px;">
-      <a href="${directUrl(article.url)}" style="text-decoration:none;display:block;">
+      <a target="_blank" rel="noopener noreferrer" href="${directUrl(article.url)}" style="text-decoration:none;display:block;">
         <div style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:14px;overflow:hidden;">
           <div style="width:100%;height:200px;background:linear-gradient(135deg,#1e293b 0%,${BRAND_DARK} 50%,${BRAND_ORANGE} 100%);text-align:center;line-height:200px;">
             <span style="font-size:56px;letter-spacing:8px;">${emoji}</span>
@@ -618,7 +618,7 @@ function renderTools(locale) {
     const popular = isFeatured ? `<span style="font-size:9px;background:${BRAND_ORANGE};color:#fff;padding:2px 6px;border-radius:4px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;margin-left:4px;vertical-align:middle;">\u2605 #1</span>` : '';
     return `
       <td width="50%" class="tool-cell" style="padding:${i % 2 === 0 ? '0 5px 10px 0' : '0 0 10px 5px'};vertical-align:top;">
-        <a href="${localizedUrl(tool.toolUrl, locale)}" style="text-decoration:none;display:block;">
+        <a target="_blank" rel="noopener noreferrer" href="${localizedUrl(tool.toolUrl, locale)}" style="text-decoration:none;display:block;">
           <div style="background:${bg};border:1px solid ${border};border-radius:12px;padding:16px 14px;">
             <div style="font-size:24px;margin-bottom:6px;">${tool.icon}</div>
             <div style="font-size:13px;font-weight:700;color:${nameColor};margin:0 0 4px;">${escapeHtml(tool.title)}${popular}</div>
@@ -651,19 +651,19 @@ function renderCloser(locale) {
 }
 
 function renderFooter(locale, unsubscribeUrl, preferencesUrl) {
-  const unsubLink = `<a href="${unsubscribeUrl || '{{UNSUBSCRIBE_URL}}'}" style="color:${BRAND_ORANGE};text-decoration:underline;">${nlT(locale, 'unsubLink')}</a>`;
+  const unsubLink = `<a target="_blank" rel="noopener noreferrer" href="${unsubscribeUrl || '{{UNSUBSCRIBE_URL}}'}" style="color:${BRAND_ORANGE};text-decoration:underline;">${nlT(locale, 'unsubLink')}</a>`;
   const unsubLine = nlT(locale, 'unsubText').replace('{link}', unsubLink);
   const prefsLine = preferencesUrl
-    ? `<div style="font-size:12px;color:${MUTED_COLOR};margin:4px 0;"><a href="${preferencesUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;">${nlT(locale, 'prefsLink')}</a></div>`
+    ? `<div style="font-size:12px;color:${MUTED_COLOR};margin:4px 0;"><a target="_blank" rel="noopener noreferrer" href="${preferencesUrl}" style="color:${BRAND_ORANGE};text-decoration:underline;">${nlT(locale, 'prefsLink')}</a></div>`
     : '';
   return `
     <tr><td class="footer-pad" style="background:${BRAND_DARK};padding:28px;text-align:center;">
       <div style="margin-bottom:12px;">
-        <a href="https://www.facebook.com/profile.php?id=61588174947294" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcd8</a>
-        <a href="https://www.linkedin.com/company/frontaliere-ticino" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcbc</a>
-        <a href="${BASE_URL}" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83c\udf10</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/profile.php?id=61588174947294" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcd8</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/company/frontaliere-ticino" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83d\udcbc</a>
+        <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="display:inline-block;margin:0 6px;font-size:18px;text-decoration:none;">\ud83c\udf10</a>
       </div>
-      <div style="font-size:12px;color:${MUTED_COLOR};margin:4px 0;">${nlT(locale, 'footerReason')} <a href="${BASE_URL}" style="color:${BRAND_ORANGE};text-decoration:underline;">frontaliereticino.ch</a></div>
+      <div style="font-size:12px;color:${MUTED_COLOR};margin:4px 0;">${nlT(locale, 'footerReason')} <a target="_blank" rel="noopener noreferrer" href="${BASE_URL}" style="color:${BRAND_ORANGE};text-decoration:underline;">frontaliereticino.ch</a></div>
       <div style="font-size:12px;color:${MUTED_COLOR};margin:4px 0;">${unsubLine}</div>
       ${prefsLine}
       <div style="font-size:12px;color:#475569;margin-top:12px;">\u00a9 ${new Date().getFullYear()} Frontaliere Ticino \u00b7 ${nlT(locale, 'copyright')}</div>


### PR DESCRIPTION
## Implementato

Aggiunti `target="_blank" rel="noopener noreferrer"` a **tutti** gli anchor dei template email (fix di classe, 44 anchor su 4 file):

- `services/newsletter-template.mjs` (LIVE, invio) — 16 anchor
- `scripts/send-job-alerts.mjs` (LIVE, job alerts) — 9 anchor
- `scripts/send-newsletter.mjs` (LIVE, auto-link prosa) — 5 anchor template-literal
- `scripts/newsletter-template.mjs` (dead code, nessun import) — 14 anchor, fixato per non lasciare antipattern gemello/drift

**Perché:** i link email erano plain `<a href>` senza target/rel. In webmail (Gmail nel browser) un click può sostituire la tab della mail; da una **preview email sandboxed** (Resend) la navigazione same-frame carica il sito sotto il sandbox del parent → `Blocked script execution ... frame is sandboxed and 'allow-scripts' not set`. `target="_blank" rel="noopener noreferrer"` è l'igiene corretta per i link email ed evita il caso peggiore in preview.

**Validazione:**
- `node --check` OK su tutti i 4 file
- Smoke render `buildNewsletter` (template live): 12/12 anchor con `target="_blank"` + `rel="noopener noreferrer"`, 0 anchor senza target
- Commento-esempio `send-newsletter.mjs:389` (HTML malformato illustrativo) **non toccato** (pattern `<a href="${` salta i non-template-literal)
- PII scan clean, diff = solo 4 file (44 ins / 44 del, 1 riga per anchor)

## Non implementato (ancora)

- **Non risolve in modo garantito la preview sandboxed di Resend.** Un sandbox imposto dal frame genitore non è rimovibile dall'interno (garanzia browser): se la preview Resend apre il popup senza `allow-popups-to-escape-sandbox`, il popup eredita comunque il sandbox. Questo PR riduce il rischio (evita la nav same-frame) ma il sintomo in preview dipende dai flag di Resend, fuori dal nostro controllo. **Utenti reali (Gmail/Outlook/Apple Mail) non erano comunque colpiti.**
- **Non estratto un helper anchor condiviso.** L'attributo è una stringa statica (no drift logico) e i template email devono essere string-built inline per compat client; i 2 `newsletter-template.mjs` (services vs scripts) sono già divergenti per altri motivi (localizedUrl vs utmUrl) — merge dei due = refactor fuori scope.
- **Non aggiunto `frame-ancestors`/`X-Frame-Options`**: non c'entra con questo caso (sandbox del parent, non embedding nostro) e andrebbe valutato a parte come anti-clickjacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)