### PR TITLE
fix(autorebase): unstick rebased PRs without re-running Claude (token-frugal)

### DIFF
--- a/.github/workflows/pr-autorebase.yml
+++ b/.github/workflows/pr-autorebase.yml
@@ -2,11 +2,16 @@ name: PR auto-rebase (near-merge only, no-Claude)
 
 # Esegue davvero il rebase che stale-pr-rescuer si limita a SUGGERIRE: una PR a
 # un passo dal merge ma dietro main resta ferma perché nessuno fa
-# `git merge origin/main`. Qui lo facciamo, ma FRUGALMENTE — un push di rebase
-# ri-triggera pr-review-loop (= quota Claude Max condivisa), quindi tocchiamo
-# SOLO le PR "near-merge" (LGTM già dato, oppure label collision-risk/
-# stale-review). Tutto deterministico (scripts/ci/pr-autorebase.mjs + gh + git).
-# ZERO Claude.
+# `git merge origin/main`. Qui lo facciamo, ma FRUGALMENTE e ZERO Claude: dopo
+# il rebase NON ri-eseguiamo la review — dispatchiamo SOLO tests.yml sull'head
+# (vitest cheap) e auto-merge-eval porta avanti l'`## LGTM` esistente (contributo
+# PR invariato su un rebase di solo main-merge). Tocchiamo SOLO le PR
+# "near-merge" (LGTM già dato, oppure label collision-risk/stale-review).
+# Tutto deterministico (scripts/ci/pr-autorebase.mjs + gh + git).
+#
+# Perché dispatchiamo tests invece di affidarci al push: un push PAT su un branch
+# PR NON ri-triggera in modo affidabile i workflow `pull_request` (osservato:
+# head rebasati di #1587/#1526 con zero check-run). Il dispatch è deterministico.
 
 on:
   schedule:
@@ -63,15 +68,17 @@ jobs:
 
       - name: Rebase near-merge PRs (deterministic, no Claude)
         env:
-          # PAT OBBLIGATORIO: il push del rebase deve ri-triggerare pr-review-loop
-          # + tests (GITHUB_TOKEN no, anti-ricorsione → review/vitest non
-          # ripartirebbero e la PR resterebbe comunque ferma).
+          # PAT OBBLIGATORIO: serve per pushare il rebase E per `gh workflow run
+          # tests.yml` (scope actions:write). NON ci affidiamo più al push per
+          # ri-triggerare i workflow (un push PAT su branch PR non triggera
+          # `pull_request` in modo affidabile) — vitest viene dispatchato
+          # esplicitamente; l'LGTM lo porta avanti auto-merge-eval. Zero Claude.
           GH_TOKEN: ${{ env.GITHUB_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::GITHUB_PAT assente → autorebase inerte (push non ri-triggererebbe review/vitest)."
+            echo "::warning::GITHUB_PAT assente → autorebase inerte (serve per push + dispatch tests.yml)."
             exit 0
           fi
           if [ "${DRY_RUN:-false}" = "true" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,15 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Dispatchable so pr-autorebase.yml can re-run vitest on a freshly-rebased PR
+  # head: a PAT push to a PR branch does NOT reliably re-trigger `pull_request`
+  # workflows (observed: rebased heads of #1587/#1526 got zero check-runs), so
+  # the autorebase explicitly dispatches this on the branch ref. The run's
+  # `vitest (unit + integration)` check-run lands on the branch head SHA (= PR
+  # head), satisfying auto-merge-eval gate 3, and its `workflow_run: completed`
+  # re-fires auto-merge-on-lgtm. No Claude review is re-run (auto-merge-eval
+  # carries the existing ## LGTM forward across a pure main-merge rebase).
+  workflow_dispatch:
 
 # Cancel in-progress runs for the same ref so superseded commits don't waste
 # the runner pool (matches deploy.yml's behaviour).

--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -49,6 +49,50 @@ function fail(msg) {
   process.exit(0); // esito atteso, non errore di workflow
 }
 
+/**
+ * Fingerprint del CONTRIBUTO PROPRIO della PR a un dato commit `sha` =
+ * il diff vs il merge-base con main (3-dot), indipendente dalla churn di main.
+ * Usato per il carry-forward dell'LGTM su un rebase di solo-merge-di-main:
+ * se il contributo a `sha` è byte-identico a quello su cui claude[bot] aveva
+ * dato `## LGTM`, il codice approvato non è cambiato → l'approvazione regge,
+ * SENZA ri-eseguire la review (zero Claude). Tutto via compare API (nessun
+ * git locale → nessuna modifica al checkout di auto-merge-on-lgtm.yml).
+ * Conservativo: qualunque incertezza (compare troncato, patch mancanti su file
+ * grossi, errore API) → ritorna null → niente carry-forward (stale come prima).
+ */
+function prContributionFingerprint(sha) {
+  let mb;
+  try {
+    mb = gh(['api', `repos/${REPO}/compare/main...${sha}`, '--jq', '.merge_base_commit.sha'],
+      { json: false }).trim();
+  } catch { return null; }
+  if (!mb) return null;
+  let cmp;
+  try {
+    cmp = gh(['api', `repos/${REPO}/compare/${mb}...${sha}`]);
+  } catch { return null; }
+  if (!cmp || !Array.isArray(cmp.files)) return null;
+  // compare API tronca a 300 file e omette `.patch` su file molto grandi: in
+  // entrambi i casi non posso garantire l'identita' -> bail conservativo.
+  if (cmp.files.length >= 300) return null;
+  const parts = [];
+  for (const f of cmp.files) {
+    // `patch` assente (binario/troppo grande) su un file modificato -> bail.
+    if (f.patch === undefined && f.status !== 'removed' && f.status !== 'added') return null;
+    // Tieni SOLO le righe di contenuto +/- (escludi header +++/--- e hunk @@):
+    // il fingerprint resta invariante allo shift di contesto/numero-riga indotto
+    // dalla churn di main attorno al diff della PR (un merge pulito di main NON
+    // cambia il contenuto proprio +/- della PR).
+    const changed = (f.patch || '')
+      .split('\n')
+      .filter((l) => (l.startsWith('+') || l.startsWith('-')) && !l.startsWith('+++') && !l.startsWith('---'))
+      .join('\n');
+    parts.push([f.filename, f.status, changed].join('\t'));
+  }
+  parts.sort();
+  return parts.join('\n--FILE--\n');
+}
+
 function main() {
   if (!REPO) fail('GITHUB_REPOSITORY mancante — skip.');
   if (!PR || !/^\d+$/.test(PR)) fail(`PR number mancante/invalido ('${PR}') — skip.`);
@@ -81,12 +125,26 @@ function main() {
   const lastBot = botReviews.length ? botReviews[botReviews.length - 1] : null;
   if (!lastBot) return fail(`Nessuna review claude-bot su PR #${PR} — skip.`);
   const body = lastBot.body || '';
-  if (lastBot.commit_id && lastBot.commit_id !== head) {
-    return fail(`Ultima review claude-bot riferita a ${lastBot.commit_id} ≠ HEAD ${head} (stale) — skip; un push nuovo ri-attiverà il review.`);
-  }
+  // Valuta PRIMA il contenuto (vale a qualunque commit): LGTM + niente 🔴.
   if (!body.includes('## LGTM')) return fail(`Ultima review claude-bot senza '## LGTM' — skip.`);
   if (body.includes('🔴 Important')) return fail(`Ultima review claude-bot contiene '🔴 Important' — skip (no merge).`);
-  console.log('Gate review: ## LGTM presente, nessun 🔴 Important ✔');
+  // L'LGTM deve valere per l'HEAD corrente. Se è su un commit precedente,
+  // accettalo SOLO se l'head è un rebase di solo-merge-di-main: il contributo
+  // proprio della PR è byte-identico a quello approvato → carry-forward, ZERO
+  // Claude (no re-review). Altrimenti è davvero stale → un push nuovo
+  // ri-attiverà la review. (Il gate vitest qui sotto resta sull'head fresco:
+  // pr-autorebase ri-esegue i test sull'head rebasato, così un conflitto
+  // semantico con la nuova main viene comunque colto.)
+  if (lastBot.commit_id && lastBot.commit_id !== head) {
+    const fpHead = prContributionFingerprint(head);
+    const fpLgtm = prContributionFingerprint(lastBot.commit_id);
+    if (fpHead === null || fpLgtm === null || fpHead !== fpLgtm) {
+      return fail(`Ultima review claude-bot riferita a ${lastBot.commit_id} ≠ HEAD ${head} e il diff della PR è cambiato (o non comparabile) — skip; un push nuovo ri-attiverà il review.`);
+    }
+    console.log(`Gate review: ## LGTM su ${lastBot.commit_id} ≠ HEAD ${head} ma contributo PR invariato (rebase di solo main-merge) → carry-forward ✔`);
+  } else {
+    console.log('Gate review: ## LGTM presente, nessun 🔴 Important ✔');
+  }
 
   // 3. vitest check-run == success (NON solo != failure).
   let conclusion = '';

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -3,9 +3,16 @@
  *
  * stale-pr-rescuer.yml oggi LABELLA + commenta "fai git merge origin/main", ma
  * nessuno lo esegue → le PR restano ferme. Qui lo automatizziamo, ma con
- * FRUGALITÀ: un push di rebase ri-triggera pr-review-loop (= quota Claude Max
- * condivisa), quindi tocchiamo SOLO le PR già "near-merge". Le altre verranno
- * rebasate quando il loro autore pusha.
+ * FRUGALITÀ (zero Claude): dopo il rebase NON ri-eseguiamo la review — ri-
+ * eseguiamo SOLO vitest (dispatch di tests.yml) e lasciamo che auto-merge-eval
+ * porti avanti l'`## LGTM` esistente (il contributo proprio della PR è invariato
+ * su un rebase di solo main-merge). Tocchiamo solo le PR "near-merge".
+ *
+ * NB sul trigger: un push PAT su un branch PR NON ri-triggera in modo
+ * affidabile i workflow `pull_request` (osservato: head rebasati di #1587/#1526
+ * con zero check-run) — per questo dispatchiamo tests.yml esplicitamente invece
+ * di affidarci al push. Questo evita anche di bruciare quota Claude: nessuna
+ * review Opus/Sonnet riparte sul rebase.
  *
  * Per ogni PR OPEN non-draft:
  *   GATE (frugalità): procedi solo se "near-merge" =
@@ -16,14 +23,15 @@
  *   - mergeable (gh pr view --json mergeable; UNKNOWN → poll una volta dopo una
  *     breve attesa; se ancora UNKNOWN → skip questo run).
  *   - MERGEABLE → fetch + checkout branch + `git merge origin/main` (identity
- *     canonica). Clean → push via PAT (ri-attiva review + vitest). Log.
+ *     canonica). Clean → push via PAT + dispatch tests.yml sul branch (vitest
+ *     sull'head; LGTM portato avanti da auto-merge-eval). Log.
  *   - CONFLITTO (CONFLICTING o merge nonzero) → `git merge --abort`; assicura
  *     label `stale-review` (così rescuer/recycle gestiscono); commenta UNA volta
  *     (dedup via marker `<!-- AUTOREBASE_CONFLICT -->`). Niente loop.
  *   Cap: ~10 PR/run; logga le skippate per cap (AGENTS.md no-silent-cap).
  *
  * Uso:  node scripts/ci/pr-autorebase.mjs [--dry-run]
- * Env:  GH_TOKEN (PAT, per push/label che ri-triggerano i workflow),
+ * Env:  GH_TOKEN (PAT, per push + dispatch tests.yml; serve scope actions:write),
  *       GITHUB_REPOSITORY. Richiede `gh` + `git` in un checkout full-history.
  */
 import { execFileSync } from 'node:child_process';
@@ -168,20 +176,37 @@ async function processPR(pr) {
     return;
   }
 
-  // Push via PAT (ri-attiva review + vitest). TOCTOU: tra mergeable-check e push
-  // un nuovo commit potrebbe essere arrivato → push non-fast-forward fallisce
-  // (no --force): semplicemente skip, il prossimo tick ricalcola.
+  // Push via PAT. TOCTOU: tra mergeable-check e push un nuovo commit potrebbe
+  // essere arrivato → push non-fast-forward fallisce (no --force): skip, il
+  // prossimo tick ricalcola.
   const pushed = git(['push', authedUrl(), `${branch}:${branch}`], { allowFail: true });
   if (pushed === null) {
     console.log(`PR #${num}: push fallito (probabile non-fast-forward / TOCTOU) — skip, riprova al prossimo tick.`);
     return;
   }
-  console.log(`✅ PR #${num}: rebasata su origin/main e pushata (${branch}) → review + vitest ri-partono.`);
+
+  // Ri-esegui SOLO i test sull'head rebasato — NON la review Claude (frugalità
+  // quota). Un push PAT su un branch PR NON ri-triggera in modo affidabile i
+  // workflow `pull_request` (osservato: head rebasati di #1587/#1526 con ZERO
+  // check-run), quindi dispatchiamo esplicitamente `tests.yml` sul branch: il
+  // check-run `vitest (unit + integration)` atterra sull'head (= gate 3 di
+  // auto-merge-eval) e il suo `workflow_run: completed` ri-valuta
+  // auto-merge-on-lgtm. L'LGTM esistente viene portato avanti da
+  // auto-merge-eval (contributo PR invariato su un rebase di solo main-merge),
+  // quindi NESSUNA review Opus/Sonnet gira di nuovo. Best-effort: se il
+  // dispatch fallisce (PAT senza scope actions:write) lo logghiamo soltanto.
+  const dispatched = gh(['workflow', 'run', 'tests.yml', '--ref', branch],
+    { json: false, allowFail: true });
+  if (dispatched === null) {
+    console.log(`::warning::PR #${num}: rebasata+pushata ma 'gh workflow run tests.yml --ref ${branch}' fallito — vitest potrebbe non ripartire sull'head; verifica scope actions:write del PAT.`);
+  } else {
+    console.log(`✅ PR #${num}: rebasata su origin/main, pushata (${branch}) e dispatchato tests.yml → vitest sull'head; LGTM carry-forward, zero Claude.`);
+  }
 }
 
 async function main() {
   if (!REPO) { console.error('GITHUB_REPOSITORY mancante'); process.exit(1); }
-  if (!TOKEN) { console.error('::warning::GH_TOKEN (PAT) assente → autorebase inerte (push non ri-triggererebbe i workflow).'); process.exit(0); }
+  if (!TOKEN) { console.error('::warning::GH_TOKEN (PAT) assente → autorebase inerte (serve per push + dispatch tests.yml).'); process.exit(0); }
   console.log(`pr-autorebase${DRY ? ' [DRY-RUN]' : ''} repo=${REPO}`);
 
   let prs;


### PR DESCRIPTION
## Implementato

**Root cause** (confermata su #1587 e #1526): `pr-autorebase` mergia `main` in una PR near-merge e pusha via PAT **assumendo** che il push ri-triggeri `pr-review-loop` + `tests`. Non lo fa: un push PAT su un branch PR **non ha ri-triggerato alcun workflow `pull_request`** (entrambi gli head rebasati con **zero check-run**). Risultato: la PR si blocca — `auto-merge-eval` richiede `## LGTM` + vitest success **sull'head corrente**, e il rebase invalida entrambi. E ri-triggerare la review Opus ad ogni rebase **brucerebbe la quota Max condivisa** — ciò che vogliamo evitare.

**Fix (zero Claude sul rebase):**
1. **`scripts/ci/auto-merge-eval.mjs`** — *carry-forward* dell'`## LGTM` di claude[bot] quando l'head è un rebase di **solo merge-di-main**: il **contributo proprio** della PR (righe +/- vs merge-base con main, invariante al contesto) è byte-identico al commit che aveva ricevuto l'LGTM. Calcolato via **compare API** (niente git locale → **nessuna modifica al gated `auto-merge-on-lgtm.yml`**). **Conservativo**: qualunque incertezza (compare troncato a 300 file, `.patch` mancante, diff cambiato) → niente carry-forward (stale come prima). Il **gate vitest resta sull'head fresco**, quindi un conflitto semantico con la nuova main viene comunque colto.
2. **`.github/workflows/tests.yml`** — aggiunto `workflow_dispatch` per poter ri-eseguire vitest sull'head rebasato.
3. **`scripts/ci/pr-autorebase.mjs`** — dopo un rebase pulito: `gh workflow run tests.yml --ref <branch>` (cheap, deterministico) invece di affidarsi al push. **Nessun dispatch di pr-review-loop** → nessuna review Opus/Sonnet ri-eseguita.

**Flusso risultante:** PR near-merge dietro main → rebase → vitest ri-gira sull'head nuovo → `auto-merge-eval` porta avanti l'LGTM + vede vitest verde fresco → merge. **Nessuna review Claude ri-eseguita** per un puro merge-di-main.

Nessun file nella lista workflow-validation gated (pr-review-loop / auto-merge-on-lgtm / post-merge-followup / REVIEW / FOLLOWUP) è toccato → il reviewer gira normalmente.

## Non implementato (ancora)

- **Causa GitHub del mancato re-trigger del push PAT**: non l'ho risolta alla radice (probabile token-App/anti-ricorsione, o il "GITHUB_PAT" non è un user-PAT che triggera `synchronize`). Aggiro via dispatch esplicito di `tests.yml`, che è deterministico. Se in futuro si volesse anche la review automatica su rebase con cambi reali, servirebbe un PAT che triggeri `pull_request` (infra) — qui fuori scope.
- **Carry-forward su file sovrapposti**: se main ha modificato le **stesse righe** che la PR tocca, il fingerprint +/- differisce → niente carry-forward → la PR torna a richiedere una review reale (corretto e sicuro, ma in quel caso il re-trigger resta manuale finché non si risolve il punto sopra). Per i casi comuni (PR su file che main non tocca) il carry-forward funziona.
- **Re-affirm visibile**: l'LGTM portato avanti è loggato in `auto-merge-eval` ma non ri-postato come nuova review (postare come claude[bot] richiede l'app-token, disponibile solo dentro la claude-action). Il merge resta tracciato nei log del workflow.

## Test
- `node --check` su entrambi gli script ✔ · YAML valido ✔
- `npm run audit:no-merge-markers` ✔ · `npm run lint:gha-node-runtime` ✔
- Logica fingerprint conservativa (bail → stale) verificata a lettura; nessun merge errato possibile (un diff cambiato non produce mai carry-forward).
- Validazione live end-to-end del carry-forward: osservabile al prossimo rebase di una PR LGTM'd dietro main (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)