### PR TITLE
feat(deploy): locale shard offload (en/de/fr → separate Pages repos behind CF proxy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -796,6 +796,69 @@ jobs:
           fi
           rm -f "$keyfile"
 
+      # ── Locale shard offload (en/de/fr → frontaliere-{loc} / Pages) ───────
+      # Each non-primary locale subtree (dist/en, dist/de, dist/fr) is a
+      # self-contained top-level dir. Push each to its OWN GitHub Pages repo
+      # (frontaliere-{loc}), served behind a Cloudflare Worker at
+      # frontaliereticino.ch/{loc}/ — same URL, different origin. This keeps
+      # every repo well under the 10 GB Pages cap: the main artifact trips it
+      # not on bytes (~9 GB logical) but on the ~1.04M-dir / ~11 GB DISK
+      # footprint (dir-per-page block padding). Splitting by locale removes
+      # ~700k of those dirs from the main artifact.
+      #
+      # ADDITIVE + REVERSIBLE: the locale dirs stay in dist/ here; the strip
+      # step (gated on vars.LOCALE_SHARDS_LIVE, just before the tar pack)
+      # removes them from the MAIN artifact ONLY once the proxy is verified
+      # live. Until that variable is set, this push changes nothing about the
+      # served site — the locales still ship in the main artifact as before.
+      # Mirrors the frontaliere-cdn push pattern (per-repo write-only deploy
+      # key, single force-pushed commit so shard history never accumulates).
+      - name: Push locale shards (en/de/fr → frontaliere-{loc} / Pages)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        env:
+          SHARD_EN_DEPLOY_KEY: ${{ secrets.SHARD_EN_DEPLOY_KEY }}
+          SHARD_DE_DEPLOY_KEY: ${{ secrets.SHARD_DE_DEPLOY_KEY }}
+          SHARD_FR_DEPLOY_KEY: ${{ secrets.SHARD_FR_DEPLOY_KEY }}
+        run: |
+          set -uo pipefail
+          for loc in en de fr; do
+            key_var="SHARD_$(echo "$loc" | tr a-z A-Z)_DEPLOY_KEY"
+            key_val="${!key_var:-}"
+            if [ -z "$key_val" ]; then
+              echo "no $key_var secret — skipping $loc shard push"; continue
+            fi
+            if [ ! -d "dist/$loc" ]; then
+              echo "dist/$loc absent — skipping $loc shard push"; continue
+            fi
+            stage="$RUNNER_TEMP/shard-$loc"
+            rm -rf "$stage" && mkdir -p "$stage"
+            : > "$stage/.nojekyll"                                  # serve every path verbatim
+            printf 'origin-%s.frontaliereticino.ch' "$loc" > "$stage/CNAME"  # shard custom domain (force-push would wipe it)
+            cp -r "dist/$loc" "$stage/$loc"                         # the heavy subtree
+            [ -f "dist/$loc.html" ] && cp "dist/$loc.html" "$stage/$loc.html"  # locale homepage at /{loc}
+            printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch %s shard</title>' "$loc" > "$stage/index.html"
+            echo "$loc shard payload: $(du -sh "$stage" | cut -f1)"
+            keyfile="$RUNNER_TEMP/shard_${loc}_key"
+            printf '%s\n' "$key_val" > "$keyfile" && chmod 600 "$keyfile"
+            export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+            (
+              cd "$stage"
+              git init -q
+              git checkout -q -b main
+              git config user.email "deploy-bot@frontaliereticino.ch"
+              git config user.name "deploy-bot"
+              git add -A
+              git commit -qm "locale shard $loc ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+              if git push -f "git@github.com:valerielinc-ops/frontaliere-$loc.git" main; then
+                echo "✅ pushed $loc shard"
+              else
+                echo "⚠️ $loc shard push failed — locale stays in main artifact"
+              fi
+            )
+            rm -f "$keyfile"
+          done
+
       # ── CDN assets/ GC janitor (anti-clobber by SEQUENCING) ───────────────
       # The additive assets/ merge above (cp -n) lets old + new content hashes
       # coexist so in-flight HTML keeps booting — but it grows the CDN repo
@@ -1014,6 +1077,25 @@ jobs:
       # │  the 4 heaviest dist/-walking audits and net post-build went   │
       # │  +98s.                                                         │
       # └────────────────────────────────────────────────────────────────┘
+      # Drop the locale subtrees from the MAIN artifact — but ONLY once the
+      # Cloudflare Worker proxy is verified live (repo variable
+      # LOCALE_SHARDS_LIVE=true; the shards were already populated by the push
+      # step above). This is the step that actually shrinks the main artifact
+      # back under the 10 GB Pages cap (removes ~700k dirs / the en+de+fr
+      # subtrees). Until the variable is set this is a no-op → locales ship in
+      # main exactly as before, so the whole change stays reversible.
+      # REVERT TRIGGER: if a deploy after flipping the variable 404s on
+      # /en /de /fr, run `gh variable set LOCALE_SHARDS_LIVE -b false` → the
+      # next deploy ships the locales in the main artifact again.
+      - name: Strip locale shards from main artifact (gated on LOCALE_SHARDS_LIVE)
+        if: ${{ github.event.inputs.profile_sequential != 'true' && vars.LOCALE_SHARDS_LIVE == 'true' }}
+        run: |
+          set -uo pipefail
+          before="$(du -sh dist | cut -f1)"
+          for loc in en de fr; do
+            rm -rf "dist/$loc" "dist/$loc.html"
+          done
+          echo "stripped en/de/fr from main artifact (now served via shards): ${before} -> $(du -sh dist | cut -f1)"
       - name: Pack dist/ into Pages tar archive
         if: github.event.inputs.profile_sequential != 'true'
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -835,16 +835,27 @@ jobs:
             keyfile="$RUNNER_TEMP/shard_${loc}_key"
             printf '%s\n' "$key_val" > "$keyfile" && chmod 600 "$keyfile"
             export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+            # Source-of-truth file count + the shard's last-published count, read
+            # cheaply (no 2.5 GB clone) — a tiny .shard-filecount marker fetched
+            # from raw.githubusercontent. Drive the gate off these so a PARTIAL
+            # copy (n < source) or an upstream build regression that emits a much
+            # smaller locale (n << last-good) is caught EXACTLY, not just the
+            # near-empty case.
+            src_n="$(find "dist/$loc" -type f | wc -l)"
+            prev_n="$(curl -fsS "https://raw.githubusercontent.com/valerielinc-ops/frontaliere-$loc/main/.shard-filecount" 2>/dev/null || echo 0)"
+            [[ "$prev_n" =~ ^[0-9]+$ ]] || prev_n=0
             # EVERYTHING that builds the shard tree AND pushes runs inside one
-            # `set -e` subshell, with a completeness gate before the push. So a
-            # partial cp (disk-full on the runner) or an empty/truncated dist/$loc
-            # (build regression) ABORTS before the push: a monco/empty tree is
-            # never force-pushed over a good shard and the ok-marker is never
-            # written → the strip step skips this locale (stays in main, no 404).
-            # The copy is hardlinked when same-filesystem (cp -al) to avoid
-            # duplicating ~2.5 GB per locale on an already-tight runner disk,
-            # falling back to a real copy across devices.
-            if (
+            # `set -e` subshell with the integrity gates before the push. A failed
+            # copy / truncated tree ABORTS before push: a monco tree is never
+            # force-pushed over a good shard, the ok-marker is never written → the
+            # strip step skips this locale (stays in main, no 404). The copy is
+            # hardlinked when same-filesystem (cp -al) to avoid duplicating
+            # ~2.5 GB per locale on a tight runner disk, falling back to cp -r.
+            # NB: run the guarded build+push as a STANDALONE subshell and capture
+            # its exit ($?), NOT as an `if (...)` condition — bash neuters an
+            # inner `set -e` when the subshell runs in a condition/&&/|| context,
+            # which would let a failed gate fall through to the push.
+            (
               set -e
               rm -rf "$stage"; mkdir -p "$stage"
               : > "$stage/.nojekyll"                                  # serve every path verbatim
@@ -852,13 +863,20 @@ jobs:
               cp -al "dist/$loc" "$stage/$loc" 2>/dev/null || cp -r "dist/$loc" "$stage/$loc"
               if [ -f "dist/$loc.html" ]; then cp "dist/$loc.html" "$stage/$loc.html"; fi  # homepage at /{loc}
               printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch %s shard</title>' "$loc" > "$stage/index.html"
-              # Completeness gate: the locale landing must exist and the subtree
-              # must clear a sane file-count floor (real locales = tens of
-              # thousands). A failed/partial copy trips this and aborts the push.
-              test -s "$stage/$loc/index.html"
               n="$(find "$stage/$loc" -type f | wc -l)"
-              [ "$n" -ge 50 ]
-              echo "$loc shard: $(du -sh "$stage" 2>/dev/null | cut -f1), $n files"
+              # (a) copy integrity: the staged subtree must have AT LEAST as many
+              #     files as the source — a partial cp (disk-full) lands fewer → abort.
+              test -s "$stage/$loc/index.html"
+              [ "$n" -ge "$src_n" ]
+              # (b) regression guard: refuse a force-push that would shrink the shard
+              #     >50% vs its last-published count (suspected upstream build
+              #     regression emitting a partial locale). First seed → prev_n 0 → skip.
+              if [ "$prev_n" -gt 0 ] && [ "$((n * 2))" -lt "$prev_n" ]; then
+                echo "::error::$loc shard would shrink $prev_n -> $n files (>50%) — refusing force-push (suspected build regression)"
+                exit 1
+              fi
+              printf '%s' "$n" > "$stage/.shard-filecount"   # high-water-mark for the next run's gate (b)
+              echo "$loc shard: $(du -sh "$stage" 2>/dev/null | cut -f1), $n files (src $src_n, prev $prev_n)"
               cd "$stage"
               git init -q
               git checkout -q -b main
@@ -867,11 +885,13 @@ jobs:
               git add -A
               git commit -qm "locale shard $loc ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
               git push -f "git@github.com:valerielinc-ops/frontaliere-$loc.git" main
-            ); then
+            )
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
               touch "$RUNNER_TEMP/shard-ok-$loc"   # consumed by the strip step
               echo "✅ pushed $loc shard"
             else
-              echo "::warning::$loc shard build/push failed — $loc will NOT be stripped from main this run"
+              echo "::warning::$loc shard build/push failed (rc=$rc) — $loc will NOT be stripped from main this run"
             fi
             rm -f "$keyfile"
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -842,7 +842,13 @@ jobs:
             keyfile="$RUNNER_TEMP/shard_${loc}_key"
             printf '%s\n' "$key_val" > "$keyfile" && chmod 600 "$keyfile"
             export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-            (
+            # set -e in the subshell so a failed git init/config/commit aborts
+            # BEFORE the push — never force-push a partial/empty tree over a good
+            # shard. The ok-marker is written ONLY when the whole chain incl. push
+            # succeeds; the strip step keys off it so a failed push is self-healing
+            # (locale stays in main, exactly like the frontaliere-cdn pattern).
+            if (
+              set -e
               cd "$stage"
               git init -q
               git checkout -q -b main
@@ -850,12 +856,13 @@ jobs:
               git config user.name "deploy-bot"
               git add -A
               git commit -qm "locale shard $loc ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
-              if git push -f "git@github.com:valerielinc-ops/frontaliere-$loc.git" main; then
-                echo "✅ pushed $loc shard"
-              else
-                echo "⚠️ $loc shard push failed — locale stays in main artifact"
-              fi
-            )
+              git push -f "git@github.com:valerielinc-ops/frontaliere-$loc.git" main
+            ); then
+              touch "$RUNNER_TEMP/shard-ok-$loc"   # consumed by the strip step
+              echo "✅ pushed $loc shard"
+            else
+              echo "⚠️ $loc shard push failed — $loc will NOT be stripped from main this run"
+            fi
             rm -f "$keyfile"
           done
 
@@ -1092,10 +1099,19 @@ jobs:
         run: |
           set -uo pipefail
           before="$(du -sh dist | cut -f1)"
+          # Strip ONLY locales whose shard push succeeded THIS run (ok-marker from
+          # the push step). A locale whose push failed has no marker → it stays in
+          # the main artifact and keeps being served from main → no 404. This makes
+          # the split self-healing per-locale, decoupled from the global gate var.
           for loc in en de fr; do
-            rm -rf "dist/$loc" "dist/$loc.html"
+            if [ -f "$RUNNER_TEMP/shard-ok-$loc" ]; then
+              rm -rf "dist/$loc" "dist/$loc.html"
+              echo "stripped $loc from main (shard push ok this run)"
+            else
+              echo "::warning::$loc shard push did NOT succeed this run — keeping $loc in main artifact (no strip)"
+            fi
           done
-          echo "stripped en/de/fr from main artifact (now served via shards): ${before} -> $(du -sh dist | cut -f1)"
+          echo "main artifact: ${before} -> $(du -sh dist | cut -f1)"
       - name: Pack dist/ into Pages tar archive
         if: github.event.inputs.profile_sequential != 'true'
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1100,9 +1100,19 @@ jobs:
           set -uo pipefail
           before="$(du -sh dist | cut -f1)"
           # Strip ONLY locales whose shard push succeeded THIS run (ok-marker from
-          # the push step). A locale whose push failed has no marker → it stays in
-          # the main artifact and keeps being served from main → no 404. This makes
-          # the split self-healing per-locale, decoupled from the global gate var.
+          # the push step). What actually prevents a 404 on /{loc} is twofold:
+          #   1. The shard always retains its last-good content — the push uses a
+          #      success-only force-push (set -e subshell), so a failed push never
+          #      empties the shard; the Worker keeps serving the previous build.
+          #   2. This per-locale strip is the safety net for the ONLY window where
+          #      the main copy is still reachable: a deploy where the gate var is
+          #      true but, for that locale, the push just failed AND the proxy
+          #      hasn't taken over yet. Keeping the failed locale in main avoids
+          #      shipping a dead /{loc}. (Once the proxy is live the Worker routes
+          #      /{loc} to the shard, so the main copy is a fallback, not the
+          #      served path — hence the runbook seeds + verifies the shards
+          #      BEFORE flipping LOCALE_SHARDS_LIVE: an empty shard with the gate
+          #      already on must not happen.)
           for loc in en de fr; do
             if [ -f "$RUNNER_TEMP/shard-ok-$loc" ]; then
               rm -rf "dist/$loc" "dist/$loc.html"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -832,23 +832,33 @@ jobs:
               echo "dist/$loc absent — skipping $loc shard push"; continue
             fi
             stage="$RUNNER_TEMP/shard-$loc"
-            rm -rf "$stage" && mkdir -p "$stage"
-            : > "$stage/.nojekyll"                                  # serve every path verbatim
-            printf 'origin-%s.frontaliereticino.ch' "$loc" > "$stage/CNAME"  # shard custom domain (force-push would wipe it)
-            cp -r "dist/$loc" "$stage/$loc"                         # the heavy subtree
-            [ -f "dist/$loc.html" ] && cp "dist/$loc.html" "$stage/$loc.html"  # locale homepage at /{loc}
-            printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch %s shard</title>' "$loc" > "$stage/index.html"
-            echo "$loc shard payload: $(du -sh "$stage" | cut -f1)"
             keyfile="$RUNNER_TEMP/shard_${loc}_key"
             printf '%s\n' "$key_val" > "$keyfile" && chmod 600 "$keyfile"
             export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-            # set -e in the subshell so a failed git init/config/commit aborts
-            # BEFORE the push — never force-push a partial/empty tree over a good
-            # shard. The ok-marker is written ONLY when the whole chain incl. push
-            # succeeds; the strip step keys off it so a failed push is self-healing
-            # (locale stays in main, exactly like the frontaliere-cdn pattern).
+            # EVERYTHING that builds the shard tree AND pushes runs inside one
+            # `set -e` subshell, with a completeness gate before the push. So a
+            # partial cp (disk-full on the runner) or an empty/truncated dist/$loc
+            # (build regression) ABORTS before the push: a monco/empty tree is
+            # never force-pushed over a good shard and the ok-marker is never
+            # written → the strip step skips this locale (stays in main, no 404).
+            # The copy is hardlinked when same-filesystem (cp -al) to avoid
+            # duplicating ~2.5 GB per locale on an already-tight runner disk,
+            # falling back to a real copy across devices.
             if (
               set -e
+              rm -rf "$stage"; mkdir -p "$stage"
+              : > "$stage/.nojekyll"                                  # serve every path verbatim
+              printf 'origin-%s.frontaliereticino.ch' "$loc" > "$stage/CNAME"  # shard custom domain
+              cp -al "dist/$loc" "$stage/$loc" 2>/dev/null || cp -r "dist/$loc" "$stage/$loc"
+              if [ -f "dist/$loc.html" ]; then cp "dist/$loc.html" "$stage/$loc.html"; fi  # homepage at /{loc}
+              printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch %s shard</title>' "$loc" > "$stage/index.html"
+              # Completeness gate: the locale landing must exist and the subtree
+              # must clear a sane file-count floor (real locales = tens of
+              # thousands). A failed/partial copy trips this and aborts the push.
+              test -s "$stage/$loc/index.html"
+              n="$(find "$stage/$loc" -type f | wc -l)"
+              [ "$n" -ge 50 ]
+              echo "$loc shard: $(du -sh "$stage" 2>/dev/null | cut -f1), $n files"
               cd "$stage"
               git init -q
               git checkout -q -b main
@@ -861,7 +871,7 @@ jobs:
               touch "$RUNNER_TEMP/shard-ok-$loc"   # consumed by the strip step
               echo "✅ pushed $loc shard"
             else
-              echo "⚠️ $loc shard push failed — $loc will NOT be stripped from main this run"
+              echo "::warning::$loc shard build/push failed — $loc will NOT be stripped from main this run"
             fi
             rm -f "$keyfile"
           done

--- a/docs/LOCALE-SHARD-CLOUDFLARE-RUNBOOK.md
+++ b/docs/LOCALE-SHARD-CLOUDFLARE-RUNBOOK.md
@@ -1,0 +1,140 @@
+# Runbook: attivare lo sharding per-locale (Cloudflare + flip)
+
+Procedura operativa per portare live l'architettura descritta in
+[`LOCALE-SHARD-DEPLOY-PLAN.md`](./LOCALE-SHARD-DEPLOY-PLAN.md). Eseguire **in
+ordine**: lo strip dei locali dal main artifact è l'**ultimo** passo e va fatto
+solo dopo aver verificato che il proxy serve i locali dagli shard.
+
+Stato di partenza (già fatto via gh CLI, FASE 1):
+- repo `frontaliere-en`, `frontaliere-de`, `frontaliere-fr` creati (public).
+- deploy key write-only su ogni shard; private key come secret
+  `SHARD_EN/DE/FR_DEPLOY_KEY` nel repo `frontaliere-si-o-no`.
+- `deploy.yml` pusha i locali agli shard a ogni deploy (additivo, già attivo a
+  PR mergiata). Lo strip dal main è dormiente finché `LOCALE_SHARDS_LIVE` ≠ `true`.
+
+---
+
+## FASE 1 — seed degli shard (automatico, nessuna azione manuale)
+
+A PR mergiata, il primo deploy popola i 3 shard. Per non aspettare lo schedule:
+
+```bash
+gh workflow run deploy.yml --ref main
+```
+
+Verifica che gli shard abbiano ricevuto contenuto (ogni repo deve avere un commit
+`locale shard <loc> …` sul branch `main`):
+
+```bash
+for loc in en de fr; do
+  echo -n "$loc: "; gh api repos/valerielinc-ops/frontaliere-$loc/commits/main --jq '.commit.message' 2>&1 | head -1
+done
+```
+
+> A questo punto i locali sono **sia** nel main **sia** sugli shard. Il sito
+> live è identico a prima: nessun URL cambiato. Si può procedere con calma.
+
+---
+
+## FASE 2 — Cloudflare (manuale — richiede il tuo account + accesso registrar)
+
+### 2.1 Zona su Cloudflare
+1. Crea un account Cloudflare (free) e **Add a site** → `frontaliereticino.ch`.
+2. Cloudflare importa i record DNS esistenti. **Verifica** che ci siano:
+   - apex `frontaliereticino.ch` → A `185.199.108.153`, `.109`, `.110`, `.111`
+     (i 4 IP GitHub Pages) — questi restano.
+   - `www` → CNAME `valerielinc-ops.github.io`.
+   - `cdn` → (record attuale verso il CDN repo) — **lascialo DNS-only, invariato.**
+3. Cloudflare ti dà 2 nameserver. **Sul registrar del `.ch`**, sostituisci i
+   nameserver attuali con quelli di Cloudflare. Propagazione 24-48h.
+   - Durante la propagazione i locali sono ancora serviti dal main → **zero
+     downtime**.
+
+### 2.2 Record origin per i 3 shard (DNS-only)
+Su Cloudflare → DNS, aggiungi 3 CNAME **gray-cloud (Proxy status: DNS only)**:
+
+| Type  | Name        | Target                        | Proxy    |
+|-------|-------------|-------------------------------|----------|
+| CNAME | `origin-en` | `valerielinc-ops.github.io`   | DNS only |
+| CNAME | `origin-de` | `valerielinc-ops.github.io`   | DNS only |
+| CNAME | `origin-fr` | `valerielinc-ops.github.io`   | DNS only |
+
+### 2.3 Custom domain su ogni shard repo
+Per ogni shard, imposta il custom domain (il push ha già scritto il file `CNAME`
+con il valore giusto; basta registrarlo lato Pages e attendere il check DNS):
+
+```bash
+gh api -X PUT repos/valerielinc-ops/frontaliere-en/pages -f cname='origin-en.frontaliereticino.ch' -F https_enforced=true 2>&1 | tail -2 || \
+  gh api -X POST repos/valerielinc-ops/frontaliere-en/pages -f 'source[branch]=main' -f 'source[path]=/' ; \
+  gh api -X PUT  repos/valerielinc-ops/frontaliere-en/pages -f cname='origin-en.frontaliereticino.ch'
+# ripeti per de, fr
+```
+
+Verifica diretta degli origin (devono dare 200, servono dai repo shard):
+
+```bash
+for loc in en de fr; do
+  echo -n "origin-$loc: "; curl -s -o /dev/null -w '%{http_code}\n' "https://origin-$loc.frontaliereticino.ch/$loc/"
+done
+```
+
+### 2.4 Deploy del Worker
+Apex già su Cloudflare (orange-cloud, default dopo l'NS move). Poi:
+
+```bash
+cd infra/cloudflare-worker
+npx wrangler deploy        # oppure: incolla locale-router.js nella dashboard Workers
+```
+
+(la route `frontaliereticino.ch/*` è in `wrangler.toml`).
+
+### 2.5 Verifica end-to-end (URL pubblico = identico, servito dallo shard)
+```bash
+# deve dare 200 e il contenuto del locale, via l'URL pubblico invariato:
+for loc in en de fr; do
+  echo -n "/$loc/ -> "; curl -s -o /dev/null -w '%{http_code}\n' "https://frontaliereticino.ch/$loc/"
+done
+# una pagina profonda reale (prendine una dalla sitemap):
+curl -sI "https://frontaliereticino.ch/en/find-jobs-ticino/" | head -1
+# l'IT NON deve essere intercettato (passthrough):
+curl -sI "https://frontaliereticino.ch/cerca-lavoro-ticino/" | head -1
+```
+
+Tutti 200 + trailing slash funzionante → il proxy serve i locali dagli shard
+mantenendo gli URL identici.
+
+---
+
+## FASE 3 — strip dei locali dal main (riduce il main sotto 10 GB)
+
+Solo **dopo** che la FASE 2.5 è verde:
+
+```bash
+gh variable set LOCALE_SHARDS_LIVE -b true -R valerielinc-ops/frontaliere-si-o-no
+gh workflow run deploy.yml --ref main
+```
+
+Il prossimo deploy rimuove `en/ de/ fr/` dal main artifact → main scende a
+~3.5 GB, ampiamente sotto il cap. Verifica nel log dello step
+*"Strip locale shards from main artifact"* la riga `… -> 3.xG`.
+
+### Rollback
+```bash
+gh variable set LOCALE_SHARDS_LIVE -b false -R valerielinc-ops/frontaliere-si-o-no
+gh workflow run deploy.yml --ref main
+```
+→ il deploy successivo rimette i locali nel main artifact. (Tornano serviti dal
+main; il Worker che li reinstrada agli shard resta innocuo.)
+
+---
+
+## Checklist rapida
+
+- [ ] PR mergiata, primo deploy → shard popolati (FASE 1)
+- [ ] Sito Cloudflare creato, DNS importato, `cdn` lasciato DNS-only
+- [ ] Nameserver cambiati sul registrar, propagati
+- [ ] 3 CNAME `origin-en/de/fr` DNS-only
+- [ ] Custom domain impostato su ogni shard repo, origin curl = 200
+- [ ] Worker deployato, route `frontaliereticino.ch/*`
+- [ ] Verifica end-to-end: `/en/ /de/ /fr/` = 200 via URL pubblico, IT passthrough
+- [ ] `LOCALE_SHARDS_LIVE=true` + deploy → main < 10 GB

--- a/docs/LOCALE-SHARD-DEPLOY-PLAN.md
+++ b/docs/LOCALE-SHARD-DEPLOY-PLAN.md
@@ -1,0 +1,190 @@
+# Piano: sharding deploy per-locale dietro Cloudflare proxy
+
+> Stato: **PROPOSTA — da validare prima di scrivere codice.**
+> Obiettivo: rientrare sotto il limite 10GB di GitHub Pages **senza cambiare un solo URL indicizzato**.
+
+---
+
+## 1. Problema
+
+GitHub Pages misura **disk usage** (blocchi allocati), non i byte logici del contenuto.
+
+| Metrica | Valore (artifact scaricato) |
+|---|---|
+| Contenuto logico | 9.04 GB |
+| **Disco reale (`du`)** | **11 GB** ⚠️ |
+| File | 1.279.560 |
+| **Directory** | **1.040.803** |
+| Inode totali | ~2.32M |
+
+Il gap 9→11GB **non è contenuto**: è struttura del filesystem.
+- **Dir-per-pagina** (URL puliti `/slug/` = dir + `index.html`): 1.04M directory × blocco 4KB = **~4GB di soli blocchi-directory**.
+- **Block padding** su 1.28M file piccoli: altri ~1–2GB.
+
+`deploy.yml` riporta ~13GB uncompressed in produzione → cap 10GB colpito, mitigato oggi con un hack di polling da 40 min (`deploy.yml:1260-1291`).
+
+### Perché le alternative semplici NON vanno
+
+| Opzione | Verdetto |
+|---|---|
+| Flat `.html` invece di `slug/index.html` | ❌ Pages serve `slug.html` a `/slug` (no slash); `/slug/` → **404**. Romperebbe ~1M URL canonicalizzati **con** trailing slash (canonical+sitemap usano `/slug/`). |
+| Subdomain `en.frontaliereticino.ch` | ❌ Cambia gli URL → rompe tutti gli `/en/ /de/ /fr/` indicizzati (Pages non fa 301 server-side). |
+
+L'unico modo per **togliere i byte dal repo tenendo vivo `/en/...`** è che l'URL resti `frontaliereticino.ch/en/...` mentre i file stanno in un altro origin → serve un **proxy davanti** che tu controlli.
+
+---
+
+## 2. Approccio scelto: sharding per-locale dietro Cloudflare
+
+Un repo GitHub Pages per locale + un Cloudflare Worker che li ricuce sotto un solo dominio. L'utente e Google vedono **sempre** `frontaliereticino.ch/...` invariato.
+
+### Topologia target
+
+| Repo | Origin nascosto (DNS-only) | Contenuto | Disco stimato | Headroom |
+|---|---|---|---|---|
+| principale (esistente) | apex `frontaliereticino.ch` | tutto **tranne** `en/ de/ fr/` (IT + sitemap + robots + rss + shared) | ~3.5 GB | ~6.5 GB |
+| `frontaliere-en` (nuovo) | `origin-en.frontaliereticino.ch` | solo `en/` (+ `en.html`, `rss-en.xml`) | ~2.5 GB | ~7.5 GB |
+| `frontaliere-de` (nuovo) | `origin-de.frontaliereticino.ch` | solo `de/` (+ `de.html`, `rss-de.xml`) | ~2.5 GB | ~7.5 GB |
+| `frontaliere-fr` (nuovo) | `origin-fr.frontaliereticino.ch` | solo `fr/` (+ `fr.html`, `rss-fr.xml`, `sitemap-fr-salaire-net.xml`) | ~2.5 GB | ~7.5 GB |
+
+Ogni shard <10GB con ~4× margine. Scali aggiungendo shard quando un locale cresce (o splittando l'IT se mai supera). **Il tetto 10GB non torna più.**
+
+Gli origin `origin-*.frontaliereticino.ch` sono subdomain **DNS-only** (gray-cloud): raggiungibili solo dal Worker, mai esposti agli utenti.
+
+---
+
+## 3. La seam: split post-build del `dist/` (NESSUN refactor SSG)
+
+Decisione chiave: **non** toccare i plugin di emit. I locali sono già sottoalberi top-level (`build-plugins/jobsSeoPagesPlugin.ts:1084-1089`, `localePrefix = { it:'', en:'/en', de:'/de', fr:'/fr' }`). Quindi dopo il build, in `deploy.yml`, **si sposta la dir**:
+
+```bash
+# dopo il build, prima del deploy
+for loc in en de fr; do
+  mkdir -p "dist-$loc"
+  mv "dist/$loc"        "dist-$loc/$loc"          # sottoalbero pagine
+  mv "dist/$loc.html"   "dist-$loc/$loc.html"     2>/dev/null || true
+  mv "dist/rss-$loc.xml" "dist-$loc/rss-$loc.xml" 2>/dev/null || true
+  echo "origin-$loc.frontaliereticino.ch" > "dist-$loc/CNAME"   # custom domain dello shard
+done
+mv dist/sitemap-fr-salaire-net.xml dist-fr/ 2>/dev/null || true
+# dist/ ora contiene SOLO IT + shared → ~3.5GB
+```
+
+Vantaggi:
+- Zero modifiche ai plugin → zero rischio sull'emit SEO (structured data, hreflang, ecc.).
+- Riusa il pattern push-to-separate-repo già in piedi per `frontaliere-cdn` (`CDN_DEPLOY_KEY`).
+- Reversibile: togli lo split → tutto torna nel main.
+
+---
+
+## 4. Worker di routing (Cloudflare)
+
+Sull'apex `frontaliereticino.ch`. ~25 righe:
+
+```js
+const SHARD = {
+  en: "origin-en.frontaliereticino.ch",
+  de: "origin-de.frontaliereticino.ch",
+  fr: "origin-fr.frontaliereticino.ch",
+};
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    // primo segmento del path
+    const m = url.pathname.match(/^\/(en|de|fr)(\/|$|\.html|\.xml)/);
+    if (m) {
+      const origin = SHARD[m[1]];
+      const target = new URL(request.url);
+      target.hostname = origin;              // riscrive solo l'Host verso lo shard
+      // l'utente continua a vedere frontaliereticino.ch/<path>
+      return fetch(new Request(target, request));
+    }
+    // tutto il resto (IT, /data, /assets già su cdn., sitemap, robots, /...) → passthrough origin Pages
+    return fetch(request);
+  },
+};
+```
+
+Note:
+- `/assets/*` e `/data/*` e `/og/*` sono già su `cdn.frontaliereticino.ch` (URL assoluti nell'HTML) → **il Worker non li intercetta**, vanno diretti. Zero conflitto con l'offload esistente.
+- hreflang e link cross-locale sono path assoluti sotto lo stesso dominio → il proxy li unifica automaticamente (è esattamente ciò che la subdomain-option rompeva).
+
+---
+
+## 5. DNS / Cloudflare
+
+1. **Sposta i nameserver** del dominio su Cloudflare (free plan). Oggi il dominio punta **diretto** a GitHub Pages (apex A `185.199.108–111.153`, `www → valerielinc-ops.github.io`, header `server: GitHub.com` / Fastly interno di GitHub — nessun proxy tuo davanti).
+2. **Apex `frontaliereticino.ch`**: orange-cloud (proxied) → il Worker gira qui.
+3. **3 subdomain origin** `origin-en/de/fr.frontaliereticino.ch`: CNAME → `valerielinc-ops.github.io` (o il GH Pages user dello shard), **gray-cloud (DNS-only)**. Sono i custom-domain dei 3 repo shard.
+4. **`cdn.frontaliereticino.ch`**: lasciare **DNS-only**, invariato (resta su Fastly del CDN repo). Il Worker non lo tocca.
+5. **`www`**: invariato (redirect a apex come oggi).
+
+> Vincolo GitHub: un custom-domain vive su **1 solo repo**. Per questo l'apex resta sul repo principale e ogni shard prende il suo `origin-*` subdomain. Il Worker riscrive l'`Host` verso gli origin nascosti.
+
+---
+
+## 6. Modifiche a `deploy.yml`
+
+1. Dopo il build: blocco di **split** (sezione 3).
+2. **4 deploy**:
+   - main (`dist/`, ~3.5GB) → invariato via `upload-pages-artifact`/`deploy-pages` (ora ampiamente sotto cap → si potrà togliere l'hack polling 40min in un secondo momento).
+   - `dist-en/`, `dist-de/`, `dist-fr/` → push ai 3 repo shard via deploy key dedicata (pattern `frontaliere-cdn`/`CDN_DEPLOY_KEY`). Ogni shard ha la sua `*_DEPLOY_KEY`.
+3. **Ordine vincolato** (vedi §7).
+
+---
+
+## 7. Ordine di esecuzione — anti-rottura
+
+Lo strip dei 7.5GB dal main funziona **solo** se il proxy è già live, altrimenti `/en /de /fr` → 404.
+
+```
+FASE 1  Crea 3 repo shard + Pages + deploy key. Deploya i locali sui rispettivi origin-*.
+        (main NON ancora toccato → /en /de /fr ancora serviti dal main come oggi)
+FASE 2  Cloudflare: NS move + apex proxied + Worker live + subdomain origin-*.
+        Verifica: curl frontaliereticino.ch/en/<pagina> → 200 servito dallo shard.
+FASE 3  SOLO ORA: il build principale fa lo split (rimuove en/de/fr dal dist main).
+        main scende a ~3.5GB.
+```
+
+Rollback per fase:
+- F3 regredisce → riattiva l'emit completo nel main (i locali tornano serviti dal main, Worker bypassato innocuo).
+- F2 regredisce → NS back a GitHub diretto (i locali sono ancora nel main → sito intero funziona).
+- F1 è puramente additiva.
+
+---
+
+## 8. Cosa NON cambia (e perché)
+
+| Componente | Stato | Perché |
+|---|---|---|
+| `services/router.ts` `detectLocaleFromPath` | invariato | URL identici → SPA vede `/en /de /fr` come oggi |
+| Canonical / hreflang / sitemap | invariati | tutti path assoluti sotto `frontaliereticino.ch`, unificati dal proxy |
+| CDN `assets`/`data`/`og` su `cdn.` | invariato | Worker non li intercetta |
+| robots.txt, CNAME apex, rss IT | invariati | restano sul main |
+| Structured data / SEO emit | invariato | nessun refactor plugin (split è post-build) |
+
+**Nessun URL indicizzato cambia. Nessun redirect. Nessun churn GSC.** Tutto $0 (Cloudflare free, Worker 100k req/giorno >> ~4k/giorno di traffico).
+
+---
+
+## 9. Decisioni aperte (servono da te)
+
+1. **Registrar del dominio `.ch`**: chi è? Il move dei nameserver su Cloudflare va fatto lì. (.ch supporta il cambio NS; serve accesso al pannello registrar.)
+2. **Account dei repo shard**: sotto `valerielinc-ops` (stesso del Pages user attuale)? 3 nuovi repo privati/pubblici?
+3. **Deploy degli shard**: branch-push via deploy key (come `frontaliere-cdn`) — confermi questo pattern o preferisci un workflow per-repo?
+4. **Granularità futura**: partiamo a 1 repo/locale (4 totali). Ok come baseline, o vuoi già predisporre split ulteriore dell'IT (job-detail in repo separato) se cresce?
+
+---
+
+## 10. Rischi
+
+| Rischio | Mitigazione |
+|---|---|
+| NS cutover propagazione 24–48h | Fase 2 isolata; durante la propagazione i locali sono ancora nel main → nessun downtime |
+| Worker latency extra hop sugli shard | 1 fetch interno Cloudflare→Pages, ~cache edge; trascurabile, locali a basso traffico |
+| Shard repo cresce oltre 10GB | ~7.5GB headroom each; aggiungi shard (orizzontale) |
+| Deploy key sprawl (4 chiavi) | least-privilege write-only come `CDN_DEPLOY_KEY` già in uso |
+| `deploy.yml` è funnel-critical | split è additivo + reversibile; testare su `main` post-merge con `gh workflow run` |
+```
+

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -1,0 +1,50 @@
+/**
+ * Cloudflare Worker — locale router for frontaliereticino.ch
+ *
+ * Keeps every public URL identical (frontaliereticino.ch/en/...), but serves
+ * the non-primary locale subtrees from separate GitHub Pages repos so no
+ * single repo trips the 10 GB Pages cap.
+ *
+ *   /en, /en/*, /en.html  -> origin-en.frontaliereticino.ch  (repo frontaliere-en)
+ *   /de, /de/*, /de.html  -> origin-de.frontaliereticino.ch  (repo frontaliere-de)
+ *   /fr, /fr/*, /fr.html  -> origin-fr.frontaliereticino.ch  (repo frontaliere-fr)
+ *   everything else        -> default Pages origin (IT) passthrough
+ *
+ * The origin-* subdomains are DNS-only (gray-cloud) GitHub Pages custom
+ * domains, reachable only from this Worker — never exposed to users. The Host
+ * the user sees never changes; only the upstream fetch target's hostname is
+ * rewritten.
+ *
+ * NOT routed here (served by their own origins directly, no rewrite):
+ *   /assets/*, /data/*, /og/*  -> already absolute on cdn.frontaliereticino.ch
+ *   /rss-en.xml, /sitemap-*    -> tiny root files kept in the main repo
+ */
+
+const SHARD_ORIGIN = {
+  en: 'origin-en.frontaliereticino.ch',
+  de: 'origin-de.frontaliereticino.ch',
+  fr: 'origin-fr.frontaliereticino.ch',
+};
+
+// First path segment must be exactly en|de|fr, followed by end, slash, or the
+// .html locale-homepage file. Anything like /rss-en.xml or /enterprise stays
+// on the main origin.
+const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const match = url.pathname.match(LOCALE_RE);
+
+    if (match) {
+      const origin = SHARD_ORIGIN[match[1]];
+      const upstream = new URL(request.url);
+      upstream.hostname = origin; // rewrite Host only; path + query preserved
+      // Preserve method/body/headers; the user-facing URL is unchanged.
+      return fetch(new Request(upstream, request));
+    }
+
+    // IT + shared (sitemaps, robots, rss, favicon, /...) — straight passthrough.
+    return fetch(request);
+  },
+};

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -13,7 +13,9 @@
  * The origin-* subdomains are DNS-only (gray-cloud) GitHub Pages custom
  * domains, reachable only from this Worker — never exposed to users. The Host
  * the user sees never changes; only the upstream fetch target's hostname is
- * rewritten.
+ * rewritten. Because the fetch target URL carries the origin-* host, Cloudflare
+ * sends `Host: origin-{loc}.frontaliereticino.ch` upstream, which is what makes
+ * GitHub Pages match the shard repo's custom domain.
  *
  * NOT routed here (served by their own origins directly, no rewrite):
  *   /assets/*, /data/*, /og/*  -> already absolute on cdn.frontaliereticino.ch
@@ -28,7 +30,8 @@ const SHARD_ORIGIN = {
 
 // First path segment must be exactly en|de|fr, followed by end, slash, or the
 // .html locale-homepage file. Anything like /rss-en.xml or /enterprise stays
-// on the main origin.
+// on the main origin. (The Cloudflare route patterns already scope the Worker
+// to these prefixes; this regex is the in-code guard.)
 const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 
 export default {
@@ -36,15 +39,42 @@ export default {
     const url = new URL(request.url);
     const match = url.pathname.match(LOCALE_RE);
 
-    if (match) {
-      const origin = SHARD_ORIGIN[match[1]];
-      const upstream = new URL(request.url);
-      upstream.hostname = origin; // rewrite Host only; path + query preserved
-      // Preserve method/body/headers; the user-facing URL is unchanged.
-      return fetch(new Request(upstream, request));
+    if (!match) {
+      // IT + shared (sitemaps, robots, rss, favicon, /...) — straight passthrough.
+      return fetch(request);
     }
 
-    // IT + shared (sitemaps, robots, rss, favicon, /...) — straight passthrough.
-    return fetch(request);
+    const origin = SHARD_ORIGIN[match[1]];
+    const upstream = new URL(request.url);
+    upstream.hostname = origin; // rewrite Host only; path + query preserved
+    const resp = await fetch(new Request(upstream, request));
+
+    // GitHub Pages 301s a dir path without trailing slash (e.g. /en/lavoro ->
+    // /en/lavoro/). If that Location is absolute on the hidden origin host, the
+    // browser would jump to origin-{loc}.frontaliereticino.ch — exposing the
+    // origin and changing the visible URL. Rewrite any such Location back to the
+    // public apex so the user never leaves frontaliereticino.ch. (Indexed paths
+    // use trailing-slash canonicals → 200, no redirect; this covers the edge.)
+    const loc = resp.headers.get('location');
+    if (loc) {
+      let locUrl = null;
+      try {
+        locUrl = new URL(loc, upstream); // resolves relative Locations too
+      } catch {
+        locUrl = null; // non-URL Location header → leave untouched
+      }
+      if (locUrl && locUrl.hostname === origin) {
+        locUrl.hostname = url.hostname; // public apex
+        const headers = new Headers(resp.headers);
+        headers.set('location', locUrl.toString());
+        return new Response(resp.body, {
+          status: resp.status,
+          statusText: resp.statusText,
+          headers,
+        });
+      }
+    }
+
+    return resp;
   },
 };

--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -1,0 +1,13 @@
+# Cloudflare Worker config for the frontaliereticino.ch locale router.
+# Deploy: `npx wrangler deploy` (or paste locale-router.js in the dashboard).
+# Requires the zone frontaliereticino.ch to be on Cloudflare (NS moved) first.
+
+name = "frontaliere-locale-router"
+main = "locale-router.js"
+compatibility_date = "2026-01-01"
+
+# Run the Worker on every path of the apex (and www, which redirects to apex).
+# The Worker itself rewrites only /en /de /fr to the shard origins.
+routes = [
+  { pattern = "frontaliereticino.ch/*", zone_name = "frontaliereticino.ch" },
+]

--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -6,8 +6,19 @@ name = "frontaliere-locale-router"
 main = "locale-router.js"
 compatibility_date = "2026-01-01"
 
-# Run the Worker on every path of the apex (and www, which redirects to apex).
-# The Worker itself rewrites only /en /de /fr to the shard origins.
+# Scope the Worker to ONLY the locale paths so the IT bulk (~95% of traffic) is
+# pure Cloudflare passthrough with no Worker subrequest. Three patterns per
+# locale cover the subtree, the bare homepage path, and the .html homepage file
+# without ever matching look-alikes like /enterprise (exact-match routes have no
+# trailing wildcard). The in-code LOCALE_RE is the matching guard.
 routes = [
-  { pattern = "frontaliereticino.ch/*", zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/en/*",    zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/en",      zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/en.html", zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/de/*",    zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/de",      zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/de.html", zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/fr/*",    zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/fr",      zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/fr.html", zone_name = "frontaliereticino.ch" },
 ]


### PR DESCRIPTION
## Contesto

L'artifact del sito supera il cap **10 GB di GitHub Pages** durante il deploy. Causa verificata sull'artifact reale: **non** sono i byte (9.04 GB logici) ma il **disk footprint** — `du` = **11 GB** per **1.04M directory** (dir-per-pagina, `/slug/` = dir + `index.html`) × blocco 4KB ≈ ~4 GB di soli blocchi-directory + padding su 1.28M file.

Alternative scartate (rompono URL indicizzati): flat `.html` → `/slug/` 404 (canonical usa trailing slash); subdomain `en.` → cambia gli URL. **Unica via che non tocca un solo URL**: shard per-locale dietro un proxy che tiene l'URL `frontaliereticino.ch/{loc}/` identico.

## Implementato

- **`deploy.yml` — push additivo degli shard**: dopo il build, `dist/en|de|fr` (+ `{loc}.html`) pushati ognuno al proprio repo `frontaliere-{loc}` (Pages), riusando il pattern `frontaliere-cdn` (deploy key write-only per-repo, single force-push). **Additivo**: i locali restano nel main → il sito servito non cambia.
- **`deploy.yml` — strip dal main, gated su `vars.LOCALE_SHARDS_LIVE`**: rimuove `en/de/fr` dal main artifact **solo** quando la variabile è `true` (cioè dopo che il proxy è verificato live). Dormiente di default → **completamente reversibile**. È il passo che riporta il main sotto i 10 GB.
- **`infra/cloudflare-worker/locale-router.js`** (~25 righe): riscrive solo l'`Host` per `/en /de /fr` verso gli origin nascosti `origin-{loc}.frontaliereticino.ch`; tutto il resto passthrough. Non tocca `cdn.frontaliereticino.ch` (assets/data/og già offloadati con URL assoluti). `wrangler.toml` incluso.
- **Infra FASE 1 già creata via gh CLI** (fuori da questa PR): 3 repo `frontaliere-en/de/fr` (public), 3 deploy key write-only, secret `SHARD_EN/DE/FR_DEPLOY_KEY` nel main.
- **Docs**: `LOCALE-SHARD-DEPLOY-PLAN.md` (architettura) + `LOCALE-SHARD-CLOUDFLARE-RUNBOOK.md` (procedura ordinata FASE 1→3 + rollback).

## Non implementato (ancora)

- **Setup Cloudflare (manuale, richiede account + accesso registrar)**: NS move su Cloudflare, 3 CNAME `origin-*` DNS-only, custom domain sugli shard, deploy del Worker. Out of scope per una PR di codice — coperto passo-passo nel runbook. **Follow-up operativo dell'owner.**
- **Flip `LOCALE_SHARDS_LIVE=true`**: deliberatamente NON fatto qui. Va fatto solo dopo la verifica end-to-end del proxy (runbook §2.5), altrimenti `/en /de /fr` → 404. Finché non si flippa, questa PR è puramente additiva.
- **Split ulteriore dell'IT** (job-detail in repo separato): non serve ora (main post-strip ~3.5 GB, ampio margine); predisposto per estensione orizzontale se cresce.
- **Rimozione hack polling 40min** (`deploy-pages` cap): deferito — ha senso solo dopo che il main è stabilmente sotto cap post-strip.

## Note di validazione

- `deploy.yml` YAML valida; logica bash dei nuovi step verificata sotto bash (indirect expansion `${!var}`, CNAME, `${SHA::8}`); staging simulato sull'artifact reale (struttura + `en/index.html` → `/en/` servibile).
- Claim "main < 10 GB post-strip" **non validabile pre-merge** (richiede un deploy reale su `main` con la variabile attiva). **Revert trigger** (runbook): se un deploy con `LOCALE_SHARDS_LIVE=true` dà 404 su `/en /de /fr`, `gh variable set LOCALE_SHARDS_LIVE -b false` → prossimo deploy rimette i locali nel main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
