### PR TITLE
fix(validate-dist): rehydrate locale shards so audits keep full coverage

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -194,6 +194,41 @@ jobs:
             cp /tmp/winners/previous-slug-winners.json data/previous-slug-winners.json
           fi
 
+      # When LOCALE_SHARDS_LIVE is on, the published github-pages artifact has the
+      # en/de/fr subtrees stripped (they're served from the frontaliere-{loc}
+      # shard repos via the Cloudflare Worker, same URLs). The sitemaps, however,
+      # still list /en /de /fr URLs — so the dist-walking audits (orphan-sitemap-
+      # pages, validate:content-quality, audit:hreflang, validate:sitemap-links …)
+      # would flag every locale URL as missing-in-dist. Rehydrate the stripped
+      # locale subtrees from their shard repos so dist/ is the COMPLETE logical
+      # site and every audit keeps FULL coverage (incl. thin-content / hreflang
+      # on locales) — no per-audit special-casing, no lowered gate. The shard was
+      # force-pushed THIS build (deploy.yml shard-push runs before the artifact
+      # upload), so its content matches what the sitemaps reference. Cloned shallow
+      # one-at-a-time and deleted right after the copy to bound peak disk. Only
+      # locales actually absent from the artifact are rehydrated (a locale whose
+      # shard push failed stays in the main artifact and is left untouched).
+      - name: Rehydrate locale shards into dist/ (when sharding active)
+        if: ${{ vars.LOCALE_SHARDS_LIVE == 'true' }}
+        run: |
+          set -euo pipefail
+          for loc in en de fr; do
+            if [ -d "dist/$loc" ]; then
+              echo "$loc present in artifact (not stripped this build) — skip rehydrate"
+              continue
+            fi
+            tmp="$RUNNER_TEMP/rehydrate-$loc"
+            rm -rf "$tmp"
+            git clone --depth 1 --single-branch --branch main \
+              "https://github.com/valerielinc-ops/frontaliere-$loc.git" "$tmp"
+            [ -d "$tmp/$loc" ] || { echo "::error::shard $loc has no $loc/ subtree"; exit 1; }
+            cp -r "$tmp/$loc" "dist/$loc"
+            if [ -f "$tmp/$loc.html" ]; then cp "$tmp/$loc.html" "dist/$loc.html"; fi
+            echo "rehydrated $loc: $(find "dist/$loc" -type f | wc -l) files"
+            rm -rf "$tmp"
+          done
+          echo "dist after rehydrate: $(du -sh dist | cut -f1)"
+
       - name: Migrate all-known-job-slugs to canton-aware paths
         # Phase 8c: the committed `data/all-known-job-slugs.json` accumulates
         # tracking entries from previous builds. The builder


### PR DESCRIPTION
## Contesto

Con `LOCALE_SHARDS_LIVE=true` (sharding per-locale dietro Cloudflare Worker, PR #1598), `deploy.yml` rimuove `en/de/fr` dal `github-pages` artifact pubblicato — quei locali sono serviti dai repo shard `frontaliere-{loc}`. Ma le sitemap restano nel main e listano `/en /de /fr` URL. Senza questo fix, gli audit dist-walking di `validate-dist` segnerebbero ogni URL locale come "missing-in-dist" e farebbero fallire il gate.

Audit che si romperebbero (verificato): `audit:orphan-sitemap-pages` (exit 1, baseline regredisce), `validate:content-quality` (exit 1, BLOCKING), `audit:hreflang` (exit 1, target mancante), potenzialmente `validate:sitemap-links` / `audit:max-bfs-depth`.

## Implementato

- **`post-deploy-validate-dist.yml`: re-idratazione degli shard in `dist/`** subito dopo l'estrazione dell'artifact (gated su `vars.LOCALE_SHARDS_LIVE == 'true'`). Clona shallow ogni repo shard e ripristina il sottoalbero `en/de/fr` (+ `{loc}.html`) in `dist/`, così gli audit vedono l'**albero logico completo**.
- **Fix a livello di artifact, non per-audit**: nessuno script di audit modificato → **coverage piena preservata** (thin-content, hreflang, orphan sui locali restano validati). Niente gate abbassato (AGENTS.md #1).
- Clone one-at-a-time + `rm` subito dopo la copia → picco disco limitato. Solo i locali effettivamente assenti dall'artifact vengono re-idratati (un locale il cui shard-push è fallito resta nel main e non viene toccato — coerente col self-healing dello strip).

## Non implementato (ancora)

- **validate-live**: nessuna modifica — già corretto. Crawla il sito live: `/en /de /fr` risolvono 200 via Worker→shard, `build-id.txt` è servito dal main. Verificato concettualmente; conferma live al primo deploy con sharding attivo.
- **Validazione dedicata sugli shard come Pages a sé**: non necessaria ora (la re-idratazione dà coverage piena nel gate esistente). Eventuale follow-up se si volesse auditare gli shard indipendentemente.
- Costo: la re-idratazione riscarica ~7.5GB/run da GitHub (rete interna, ~2-3min) — accettabile, non validabile come wall-time pre-merge; se un run desse ENOSPC sul runner → ottimizzare con `--filter=blob:none`.

## Sequenza operativa

Questa PR va mergiata **prima** di ri-attivare `LOCALE_SHARDS_LIVE=true` (ora a `false` per sicurezza). Dopo merge: flip a true → deploy → strip + validate-dist verde (albero re-idratato) → main <10GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
