### PR TITLE
fix(build): stable entry filename — decouple pages from bundle hash (kills ~80% deploy churn)

### DIFF
--- a/build-plugins/shared/spaBundleRx.ts
+++ b/build-plugins/shared/spaBundleRx.ts
@@ -3,8 +3,15 @@
  * entry-bundle filenames out of the built `dist/index.html`.
  *
  * Vite emits the root shell with quoted attributes:
- *   <script ... src="/assets/index-{hash}.js">                         (same-origin)
- *   <script ... src="https://cdn.frontaliereticino.ch/assets/index-…js"> (ASSET_CDN)
+ *   <script ... src="/assets/index-entry.js">                          (same-origin)
+ *   <script ... src="https://cdn.frontaliereticino.ch/assets/index-entry.js"> (ASSET_CDN)
+ *
+ * NB: the JS entry filename is now STABLE — `assets/index-entry.js`, NOT
+ * content-hashed (vite.config.ts `entryFileNames`), so the prerendered pages
+ * don't churn on every bundle rehash. The regex still matches it unchanged
+ * because `entry` ∈ the hash charset (`index-<hashchars>+.js`). The entry CSS
+ * stays content-hashed (`index-{hash}.css`) — its bytes change only on real
+ * style changes, so it doesn't drive the per-deploy churn.
  *
  * The `[^"]*` before `/assets/` tolerates an optional origin prefix so the
  * match works whether Vite emitted a same-origin path or an absolute CDN URL

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,13 @@
 # Cache headers for GitHub Pages
-# Static assets with hashed filenames — cache for 1 year
+# SPA entry has a STABLE name (assets/index-entry.js, see vite.config.ts) so the
+# ~1.28M prerendered pages don't churn on every bundle rehash. Its bytes DO change
+# per code-deploy (it imports the rotated App chunk), so it must REVALIDATE — must
+# come BEFORE the immutable /assets/* rule below (more-specific path wins).
+# (GitHub Pages ignores _headers today — Pages serves ~600s; this is honored once
+# the site moves to object storage / a CDN that reads _headers.)
+/assets/index-entry.js
+  Cache-Control: public, max-age=0, must-revalidate
+# Static assets with HASHED filenames (App-<hash>.js, *-<hash>.css, chunks) — 1 year immutable
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -413,6 +413,24 @@ export default defineConfig(({ mode }) => {
  },
  rollupOptions: {
  output: {
+ // STABLE entry filename (no content-hash). Every prerendered page embeds
+ // <script src=".../assets/index-entry.js">. When the entry was content-hashed
+ // (index-<hash>.js, Vite default) its name changed on ANY bundled-module
+ // change — and Vite chunk hashes are circularly interconnected (entry→App→
+ // leaf→App), so a change anywhere (a PR, but also auto-generated
+ // services/locales/blog-body/*.ts and regenerated locale files) cascaded to
+ // the entry hash → all ~1.28M prerendered pages re-referenced a new
+ // /assets/index-<hash>.js → ~80%/deploy churn (measured). A stable name keeps
+ // pages byte-identical across deploys; the entry's INTERNAL imports (hashed
+ // App/chunks) still rotate, but that's 1 file, not 1.28M pages.
+ // - Matches build-plugins/shared/spaBundleRx.ts (`index-<hashchars>+.js`):
+ //   "entry" ∈ the hash charset, so SPA_ENTRY_JS_RX picks it up unchanged.
+ // - Sub-chunks stay content-hashed (chunkFileNames default) for cache-busting.
+ // - CACHE: index-entry.js bytes change per code-deploy → it must REVALIDATE,
+ //   not be immutable — see public/_headers. Hashed chunks stay immutable.
+ // - CDN offload (deploy.yml) cp -r's all of dist/assets, and prune-cdn-assets
+ //   never prunes a file present in dist/assets → the stable entry ships + persists.
+ entryFileNames: 'assets/index-entry.js',
  manualChunks(id) {
  // Vendor chunks for node_modules
  if (id.includes('node_modules')) {


### PR DESCRIPTION
## Implementato
Risolve alla radice il churn ~80%/deploy: rende **stabile il nome dell'entry SPA** così le ~1,28M pagine prerenderizzate non cambiano a ogni re-hash del bundle.

**Causa (provata, non ipotizzata):** ogni pagina embedda `<script src=.../assets/index-<hash>.js>`. Gli hash dei chunk Vite sono **circolarmente interconnessi** (entry→App→leaf→App): qualunque cambio a un modulo bundlato — una PR, ma anche i `services/locales/blog-body/*.ts` auto-generati e i file locale rigenerati — cascata fino all'hash dell'entry → tutte le pagine ri-referenziano un nuovo `/assets/index-<hash>.js`. Misurato: **80% file / 97% byte** per deploy (run 27156381044, 27193422204). Sondando i bundle dal CDN: i diff mostrano SOLO riferimenti-hash che cambiano, nessun contenuto reale → conferma il cascade.

`#1592` (rimozione `__BUILD_ID__`/`__COMMIT_HASH__`) ha tolto solo il delta garantito-ogni-build; il cascade da cambio-codice restava.

**Modifica:**
- `vite.config.ts`: `rollupOptions.output.entryFileNames: 'assets/index-entry.js'` (entry **non** content-hashed). I sub-chunk restano hashati (default).
- `spaBundleRx.ts`: nessun cambio di regex — `SPA_ENTRY_JS_RX` (`index-<hashchars>+.js`) matcha `index-entry.js` perché `entry` ∈ charset hash. Solo doc-comment aggiornato.
- `public/_headers`: `/assets/index-entry.js` → `max-age=0, must-revalidate` (i suoi byte cambiano per deploy), PRIMA della regola `/assets/*` immutable (i chunk hashati restano immutable).

**Perché è sicuro lato CDN/cache:** l'offload (`deploy.yml`) fa `cp -r dist/assets` (intero) → `index-entry.js` arriva sul CDN; `prune-cdn-assets.mjs` non pota mai un file presente in `dist/assets` → l'entry stabile persiste. GitHub Pages ignora `_headers` (serve ~600s) → l'entry revalida entro 10min oggi; la regola vale per la futura migrazione a object storage.

**Verificato pre-merge:** `tsc` pulito sui file toccati; test verdi (`spa-bundle-resolver`, `related-search-clusters-shell`, `seo/audit-runner` — 33/33); match `index-entry.js` ↔ `SPA_ENTRY_JS_RX` confermato.

## Non implementato (ancora)
- **Conferma churn ~0 non verificabile pre-merge** (no full build locale / OOM). Si conferma post-merge: dopo 1 build, `curl https://frontaliereticino.ch/` deve referenziare `/assets/index-entry.js` e il CDN deve servirlo (`curl https://cdn.frontaliereticino.ch/assets/index-entry.js` → 200); poi su due deploy il churn deve crollare. **Revert-trigger:** se post-merge l'entry 404 sul CDN, o la SPA non idrata (pagina statica resta senza app), o il live si rompe → revert immediato.
- **Entry CSS** resta content-hashed: cambia solo su edit di stile reali (raro), non guida il churn → fuori scope.
- **Churn residuo da `dateModified`=build-time** sulle pagine-lista (es. `cerca-lavoro-ticino/tutti`, visto cambiare 07:07→09:18): separato, follow-up — derivare la data dal dato, non da `new Date()`.
- **Blocco deploy reale** (inode-count ~2,3M → object storage) resta separato: questo fix rende efficace il sync incrementale, non sblocca da solo Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)