### PR TITLE
perf(review): skip Claude re-review when no code changed since last LGTM

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -42,8 +42,48 @@ jobs:
         with:
           node-version: '22'
 
+      # Re-review guard: su un `synchronize` il cui delta DALL'ULTIMA review
+      # claude-bot `## LGTM` tocca SOLO file non-code (data/public/reports/
+      # _newsletter_variants/docs) NON ri-eseguiamo Claude — è il token-lever #1:
+      # un crawler che rigenera `data/jobs/*.json` su una PR già LGTM'd faceva
+      # ripartire una review (anche sonnet) a vuoto. L'approvazione regge perché
+      # auto-merge-eval ora usa un fingerprint CODE-only → carry-forward; vitest
+      # gira comunque sull'head (tests.yml su synchronize) come safety net.
+      # Conservativo: opened/reopened, nessuna LGTM precedente, o compare
+      # vuoto/errore → review piena.
+      - name: Re-review guard (skip Claude when no code changed since last LGTM)
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ "$ACTION" != "synchronize" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Evento '$ACTION' → review piena."; exit 0
+          fi
+          last=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+            --jq '[.[] | select(.user.type=="Bot" and (.user.login|test("claude";"i")) and (.body|contains("## LGTM")))] | last | .commit_id // empty' 2>/dev/null || true)
+          if [ -z "$last" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Nessuna review LGTM precedente → review piena."; exit 0
+          fi
+          changed=$(gh api "repos/$REPO/compare/$last...$HEAD_SHA" --jq '.files[].filename' 2>/dev/null || true)
+          if [ -z "$changed" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Compare vuoto/errore → review piena (conservativo)."; exit 0
+          fi
+          code=$(echo "$changed" | grep -vE '^(data/|public/|reports/|_newsletter_variants/|docs/)' || true)
+          if [ -z "$code" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Delta dall'ultima LGTM = SOLO data/docs (nessun code) → skip Claude; LGTM carry-forward (fingerprint code-only), vitest gira comunque."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Code cambiato dall'ultima LGTM → review piena."
+          fi
+
       - name: Determine review tier
         id: tier
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -112,6 +152,7 @@ jobs:
 
       - name: Run Claude review
         id: claude_review
+        if: steps.guard.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,7 +205,9 @@ jobs:
             - Incerto → `❓ q:`, no speculazione.
 
       - name: Claude usage metrics
-        if: always()
+        # Solo se la review Claude è effettivamente girata (guard non-skip): a
+        # review skippata non c'è execution_file da riassumere.
+        if: always() && steps.guard.outputs.skip != 'true'
         # Exact token/cost for this run (replaces estimates). Writes a table to
         # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
         # Best-effort: never fails the job.

--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -75,9 +75,31 @@ function prContributionFingerprint(sha) {
   // compare API tronca a 300 file e omette `.patch` su file molto grandi: in
   // entrambi i casi non posso garantire l'identita' -> bail conservativo.
   if (cmp.files.length >= 300) return null;
+  return codeContributionFingerprint(cmp.files);
+}
+
+// File NON reviewabili come code (dati/static rigenerati): esclusi dal
+// fingerprint del contributo. Stessa lista del tier-gate di pr-review-loop.yml
+// e degli exclude del diff reviewer. Così un push che tocca SOLO questi (es. un
+// crawler che rigenera `data/jobs/*.json`) NON cambia il fingerprint CODE → il
+// carry-forward dell'LGTM regge senza ri-eseguire la review (zero Claude),
+// mentre il gate vitest resta sull'head fresco. Prima il carry-forward valeva
+// SOLO per i rebase di puro main-merge; ora anche per i push data/docs-only.
+export const NON_REVIEWABLE_FINGERPRINT_RE = /^(data|public|reports|_newsletter_variants|docs)\//;
+
+/**
+ * Costruisce il fingerprint del contributo CODE da `files` (l'array `.files`
+ * della compare API). Puro (niente gh) → testabile. Esclude i file non-code; un
+ * file dati con `.patch` omesso (troppo grande) viene scartato PRIMA del bail,
+ * così la churn dati non forza un bail conservativo. Bail (null) solo se un file
+ * CODE modificato non ha patch (binario/troppo grande → identità non garantita).
+ */
+export function codeContributionFingerprint(files) {
+  if (!Array.isArray(files)) return null;
   const parts = [];
-  for (const f of cmp.files) {
-    // `patch` assente (binario/troppo grande) su un file modificato -> bail.
+  for (const f of files) {
+    if (NON_REVIEWABLE_FINGERPRINT_RE.test(f.filename || '')) continue; // dati/static: non è contributo CODE
+    // `patch` assente (binario/troppo grande) su un file CODE modificato -> bail.
     if (f.patch === undefined && f.status !== 'removed' && f.status !== 'added') return null;
     // Tieni SOLO le righe di contenuto +/- (escludi header +++/--- e hunk @@):
     // il fingerprint resta invariante allo shift di contesto/numero-riga indotto
@@ -211,4 +233,7 @@ function main() {
   }
 }
 
-main();
+// Esegui solo come CLI (non quando importato dai test → evita gh/process.exit).
+if (process.argv[1]?.endsWith('auto-merge-eval.mjs')) {
+  main();
+}

--- a/tests/auto-merge-eval-fingerprint.test.ts
+++ b/tests/auto-merge-eval-fingerprint.test.ts
@@ -1,0 +1,56 @@
+/**
+ * auto-merge-eval — codeContributionFingerprint: il fingerprint del contributo
+ * della PR usato per il carry-forward dell'## LGTM. Reso CODE-only così un push
+ * che tocca SOLO file dati/static (data/public/reports/_newsletter_variants/docs)
+ * non cambia il fingerprint → l'approvazione regge senza ri-eseguire la review
+ * (token-lever #1). Un file dati grosso senza `.patch` NON deve forzare il bail.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — modulo .mjs senza tipi
+import { codeContributionFingerprint, NON_REVIEWABLE_FINGERPRINT_RE } from '../scripts/ci/auto-merge-eval.mjs';
+
+type F = { filename: string; status: string; patch?: string };
+
+describe('codeContributionFingerprint (code-only carry-forward)', () => {
+  const codeFile: F = { filename: 'scripts/foo.mjs', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new' };
+  const dataFile: F = { filename: 'data/jobs/by-crawler/x.json', status: 'modified', patch: '@@ -1 +1 @@\n-1\n+2' };
+
+  it('un push data-only NON cambia il fingerprint code (carry-forward regge)', () => {
+    const before = codeContributionFingerprint([codeFile]);
+    const after = codeContributionFingerprint([codeFile, dataFile]);
+    expect(after).toBe(before);
+  });
+
+  it('escludendo TUTTI i file non-code resta un fingerprint stabile (vuoto)', () => {
+    const fp = codeContributionFingerprint([
+      dataFile,
+      { filename: 'public/img/a.webp', status: 'added' },
+      { filename: 'docs/x.md', status: 'modified', patch: '@@\n+a' },
+    ]);
+    expect(fp).toBe(''); // nessun file code → stringa vuota, deterministica
+  });
+
+  it('un cambiamento CODE reale cambia il fingerprint', () => {
+    const a = codeContributionFingerprint([codeFile]);
+    const b = codeContributionFingerprint([{ ...codeFile, patch: '@@ -1 +1 @@\n-old\n+different' }]);
+    expect(b).not.toBe(a);
+  });
+
+  it('un file CODE senza patch (binario/troppo grande) → bail null', () => {
+    expect(codeContributionFingerprint([{ filename: 'build-plugins/x.ts', status: 'modified' }])).toBeNull();
+  });
+
+  it('un file DATI senza patch NON forza il bail (viene escluso prima)', () => {
+    const fp = codeContributionFingerprint([codeFile, { filename: 'data/big.json', status: 'modified' }]);
+    expect(fp).toBe(codeContributionFingerprint([codeFile])); // dati ignorato, non bail
+  });
+
+  it('NON_REVIEWABLE_FINGERPRINT_RE copre le directory non-code', () => {
+    for (const p of ['data/x', 'public/y', 'reports/z', '_newsletter_variants/v', 'docs/d']) {
+      expect(NON_REVIEWABLE_FINGERPRINT_RE.test(p)).toBe(true);
+    }
+    for (const p of ['scripts/x.mjs', 'build-plugins/y.ts', 'components/z.tsx']) {
+      expect(NON_REVIEWABLE_FINGERPRINT_RE.test(p)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato
Area "re-review guard" (token-lever #1 del piano di ottimizzazione). `pr-review-loop` ri-eseguiva una review Claude su **ogni** `synchronize`: un push data/docs-only (es. crawler che rigenera `data/jobs/*.json`) su una PR già `## LGTM` bruciava una review intera a vuoto (sonnet, o opus su PR funnel).

Due cambi **accoppiati** (devono atterrare insieme):
1. **`scripts/ci/auto-merge-eval.mjs`**: `prContributionFingerprint` ora esclude i path non-reviewabili (`data/public/reports/_newsletter_variants/docs`) via il puro `codeContributionFingerprint()` (estratto + esportato). Un push data-only **non cambia** il fingerprint CODE → l'`## LGTM` esistente fa **carry-forward** (prima il carry-forward copriva solo i rebase di puro main-merge). Un file dati grosso senza `.patch` non forza più il bail conservativo. Aggiunto CLI-guard così il modulo è importabile dai test.
2. **`.github/workflows/pr-review-loop.yml`**: nuovo step **Re-review guard** che salta la review Claude (e il suo step usage-metrics) quando, su un `synchronize`, il diff dall'ultima review claude-bot `## LGTM` tocca **solo** file non-code. Conservativo: opened/reopened, nessuna LGTM precedente, o compare vuoto/errore → review piena.

**Safety net invariato:** `vitest` gira comunque sull'head (tests.yml su synchronize); l'auto-merge resta gated su `vitest==success`. Si salta solo la *re-lettura Claude*, non il gate test.

Test: `auto-merge-eval-fingerprint` 6/6 (nuovo, unit del puro `codeContributionFingerprint`). Stima risparmio: −3÷8 invocazioni Claude/giorno (pesate opus sulle PR funnel) — la massa di token evitabile più grande sulla quota Max condivisa.

## Non implementato (ancora)
- **Carry-forward su rebase+data combinati**: se un push include sia un main-merge sia dati, il compare `last...HEAD` mostra anche il code di main → review piena (conservativo). Il caso target (push data-only senza rebase) è coperto.
- **Test del workflow YAML**: lo step guard è bash deterministico; validato via `python yaml.safe_load` + validazione live. Il puro fingerprint è unit-testato.

## ⚠️ Merge
Questa PR modifica `.github/workflows/pr-review-loop.yml` → **workflow-validation failure** (GitHub App reviewer non posta, auto-merge non scatta) per regola AGENTS.md → **merge manuale** richiesto: `gh pr merge 1624 --squash --delete-branch` dopo verifica. NON auto-mergerà.

🤖 Generated with [Claude Code](https://claude.com/claude-code)