### PR TITLE
fix(ci): centralize vitest check-name in shared const (#1602)

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -33,6 +33,7 @@
  * atteso (l'altro trigger ri-valuterà), non un errore di workflow.
  */
 import { execFileSync } from 'node:child_process';
+import { VITEST_CHECK_NAME } from './lib/constants.mjs';
 
 const REPO = process.env.GITHUB_REPOSITORY || '';
 const PR = process.argv[2];
@@ -172,7 +173,7 @@ function main() {
   let conclusion = '';
   try {
     conclusion = gh(['api', `repos/${REPO}/commits/${head}/check-runs?per_page=100`,
-      '--jq', '[.check_runs[] | select(.name == "vitest (unit + integration)")][0].conclusion // ""'],
+      '--jq', `[.check_runs[] | select(.name == ${JSON.stringify(VITEST_CHECK_NAME)})][0].conclusion // ""`],
       { json: false }).trim();
   } catch (e) {
     return fail(`Impossibile leggere check-runs HEAD ${head}: ${String(e).slice(0, 160)} — skip.`);

--- a/scripts/ci/lib/constants.mjs
+++ b/scripts/ci/lib/constants.mjs
@@ -1,0 +1,15 @@
+/**
+ * constants.mjs — costanti CI condivise tra gli script di auto-merge/rebase.
+ *
+ * `VITEST_CHECK_NAME` è il nome del check-run su cui gattano sia
+ * `auto-merge-eval.mjs` (gate 3: HEAD vitest == success) sia `pr-autorebase.mjs`
+ * (rilevamento head "orfani" a 0 check-run vitest da heal-dispatchare). DEVE
+ * matchare byte-per-byte il `name:` del job in `.github/workflows/tests.yml`
+ * (source of truth: lo YAML non può importare una const JS). Se i tre punti
+ * divergono, `headHasVitestCheck` / il gate vitest leggono length 0 / conclusion
+ * "" in silenzio → heal ri-dispatcha all'infinito e nessuna PR mergia. Tenendo
+ * i due script `.mjs` su questa singola const, l'unico drift residuo possibile è
+ * rinominare il job in tests.yml senza aggiornare qui — coperto dal guard test
+ * `tests/ci-vitest-check-name.test.ts`.
+ */
+export const VITEST_CHECK_NAME = 'vitest (unit + integration)';

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -39,6 +39,7 @@
  *       GITHUB_REPOSITORY. Richiede `gh` + `git` in un checkout full-history.
  */
 import { execFileSync } from 'node:child_process';
+import { VITEST_CHECK_NAME } from './lib/constants.mjs';
 
 const DRY = process.argv.includes('--dry-run');
 const REPO = process.env.GITHUB_REPOSITORY || '';
@@ -114,7 +115,7 @@ function headPushedMinutesAgo(head) {
 function headHasVitestCheck(head) {
   const out = gh(
     ['api', `repos/${REPO}/commits/${head}/check-runs?per_page=100`,
-      '--jq', '[.check_runs[] | select(.name == "vitest (unit + integration)")] | length'],
+      '--jq', `[.check_runs[] | select(.name == ${JSON.stringify(VITEST_CHECK_NAME)})] | length`],
     { json: false, allowFail: true });
   return (parseInt((out || '0').trim(), 10) || 0) > 0;
 }

--- a/tests/ci-vitest-check-name.test.ts
+++ b/tests/ci-vitest-check-name.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+// @ts-expect-error — modulo .mjs senza tipi
+import { VITEST_CHECK_NAME } from '../scripts/ci/lib/constants.mjs';
+
+/**
+ * Guard per il drift descritto in #1602: il nome del check-run vitest è la
+ * source-of-truth in `.github/workflows/tests.yml` (`name:` del job), ma due
+ * script CI lo consumano in un filtro `jq` — `auto-merge-eval.mjs` (gate 3:
+ * HEAD vitest == success) e `pr-autorebase.mjs` (rileva head orfani a 0 vitest).
+ * Se il job viene rinominato senza aggiornare la const, entrambi leggono in
+ * silenzio length 0 / conclusion "" → heal ri-dispatcha all'infinito e nessuna
+ * PR mergia. Questo test fa fallire la suite (= il gate vitest stesso) prima che
+ * il drift raggiunga main, e verifica che gli script usino la const condivisa
+ * invece di un literal copy-pasted.
+ */
+
+const ROOT = resolve(import.meta.dirname, '..');
+const TESTS_YML = readFileSync(resolve(ROOT, '.github/workflows/tests.yml'), 'utf-8');
+const AUTOREBASE = readFileSync(resolve(ROOT, 'scripts/ci/pr-autorebase.mjs'), 'utf-8');
+const AUTO_MERGE_EVAL = readFileSync(resolve(ROOT, 'scripts/ci/auto-merge-eval.mjs'), 'utf-8');
+
+describe('VITEST_CHECK_NAME (#1602 drift guard)', () => {
+  it('matcha byte-per-byte il name: del job vitest in tests.yml', () => {
+    // Estrae il `name:` del job `vitest:` (può essere quotato o no).
+    const m = TESTS_YML.match(/^\s*vitest:\s*\n\s*name:\s*(.+?)\s*$/m);
+    expect(m, 'job `vitest:` con `name:` non trovato in tests.yml').toBeTruthy();
+    const jobName = (m![1] || '').replace(/^['"]|['"]$/g, '');
+    expect(jobName).toBe(VITEST_CHECK_NAME);
+  });
+
+  it('è il valore atteso (cattura un rename involontario della const stessa)', () => {
+    expect(VITEST_CHECK_NAME).toBe('vitest (unit + integration)');
+  });
+
+  it('entrambi gli script importano la const invece di un literal nel filtro jq', () => {
+    for (const [name, src] of [
+      ['pr-autorebase.mjs', AUTOREBASE],
+      ['auto-merge-eval.mjs', AUTO_MERGE_EVAL],
+    ] as const) {
+      expect(src, `${name} non importa VITEST_CHECK_NAME`).toContain(
+        "import { VITEST_CHECK_NAME } from './lib/constants.mjs'",
+      );
+      // Nessun literal hardcoded dentro un `select(.name == "...")` (eseguibile).
+      expect(
+        src.includes('select(.name == "vitest (unit + integration)")'),
+        `${name} usa ancora il literal hardcoded in jq invece della const`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato
- Estratta la const condivisa `VITEST_CHECK_NAME = 'vitest (unit + integration)'` in **`scripts/ci/lib/constants.mjs`**.
- `scripts/ci/auto-merge-eval.mjs` (gate 3: HEAD vitest == success) e `scripts/ci/pr-autorebase.mjs` (`headHasVitestCheck`, rilevamento head orfani a 0 check-run) ora **importano la const** e la embeddano nel filtro `jq` via `JSON.stringify(VITEST_CHECK_NAME)` — behavior-preserving: il filtro produce lo stesso literal `select(.name == "vitest (unit + integration)")` di prima.
- Guard test **`tests/ci-vitest-check-name.test.ts`**: asserisce che la const matchi byte-per-byte il `name:` del job `vitest:` in `.github/workflows/tests.yml` (source-of-truth) e che nessuno dei due script usi più il literal hardcoded nel filtro jq. Un rename del job senza aggiornare la const → suite rossa **prima** che il drift raggiunga main.

Il silent failure mode descritto in #1602 (job rinominato → `headHasVitestCheck` legge length 0 / il gate vitest legge conclusion `""` → heal ri-dispatcha all'infinito e nessuna PR auto-mergia) è ora reso impossibile per i due `.mjs` (single const) e i drift verso `tests.yml` sono catturati dal guard test.

Closes #1602

## Non implementato (ancora)
- `tests.yml:38` (`name:`) resta volutamente la source-of-truth e **non** importa la const: lo YAML non può eseguire JS. Il guard test è il bridge che lega i due lati.
- Le occorrenze residue della stringa nei **docblock** di `auto-merge-eval.mjs` / `pr-autorebase.mjs` (commenti descrittivi, non eseguibili) sono lasciate inline come prosa — non sono filtri jq e non causano il failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)