### PR TITLE
fix(ci): harden aggregate-detection plural + recycle empty-commit guard (#1201)

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -81,7 +81,12 @@ jobs:
           # one-item nel prompt (R3-A): il prompt-only R2-A non sempre teneva
           # (#1172 error_max_turns post-merge). is_aggregate guida l'istruzione
           # forte "fixa 1 item poi STOP".
-          N=$(printf '%s' "$body" | grep -oiE '[0-9]+ item deferred' | head -1 | grep -oE '^[0-9]+' || true)
+          # `items?` (not just `item`): il titolo è LLM-generated dal template
+          # FOLLOWUP.md; per N>=2 il fraseggio naturale è il plurale "2 items
+          # deferred". Senza la `s?` opzionale il match fallisce → is_aggregate
+          # falso negativo → circuit-breaker one-item no-op → error_max_turns su
+          # aggregate (#1172-class, ~2M token). Cfr. #1201 item 1.
+          N=$(printf '%s' "$body" | grep -oiE '[0-9]+ items? deferred' | head -1 | grep -oE '^[0-9]+' || true)
           if [ "${N:-0}" -ge 2 ] 2>/dev/null; then
             echo "is_aggregate=true" >> "$GITHUB_OUTPUT"
             echo "agg_count=${N}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -104,10 +104,14 @@ jobs:
 
             # Gate 2: nessun commit nuovo da >MAXAGE (lavoro davvero abbandonato).
             LASTCOMMIT=$(gh pr view "$N" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // empty' 2>/dev/null || true)
-            if [ -n "$LASTCOMMIT" ]; then
-              LCS=$(date -u -d "$LASTCOMMIT" +%s 2>/dev/null || echo 0)
-              if [ $((NOW - LCS)) -lt "$MAXAGE" ]; then echo "PR #$N ha commit recenti — skip (lavoro attivo)"; continue; fi
-            fi
+            # LASTCOMMIT vuoto = PR senza commit o head fork inaccessibile: NON
+            # ricicliamo (il close --delete-branch su un head fork può fallire
+            # silenziosamente lasciando il ref, e "0 commit" non è il lavoro
+            # abbandonato che R3-B mira a riciclare). Skip difensivo. Cfr. #1201
+            # item 3.
+            if [ -z "$LASTCOMMIT" ]; then echo "PR #$N: nessun commit/head fork inaccessibile — skip recycle"; continue; fi
+            LCS=$(date -u -d "$LASTCOMMIT" +%s 2>/dev/null || echo 0)
+            if [ $((NOW - LCS)) -lt "$MAXAGE" ]; then echo "PR #$N ha commit recenti — skip (lavoro attivo)"; continue; fi
 
             # Source issue: "(#N)" nel titolo o "Closes #N" nel body.
             ISSUE=$(printf '%s' "$TITLE" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)


### PR DESCRIPTION
Indirizza 2 dei 3 item deferiti in #1201 (item 1 + item 3) — entrambi hardening one-liner sulla pipeline issue-autonoma, deterministici e verificabili.

## Implementato
- **`.github/workflows/issue-fix.yml`** (#1201 item 1): l'`is_aggregate` deriva il count dal titolo via `grep -oiE '[0-9]+ item deferred'`. Il titolo è LLM-generated dal template `FOLLOWUP.md`; per N≥2 il fraseggio naturale è il **plurale** `2 items deferred` → la regex singolare non matcha → `is_aggregate` falso negativo → circuit-breaker one-item no-op → `error_max_turns` su aggregate (#1172-class, ~2M token). Fix: `[0-9]+ items? deferred` (`s?` opzionale copre singolare e plurale). Verificato: `3 item deferred`→3, `2 items deferred`→2, `1 item deferred`→1.
- **`.github/workflows/recycle-stale-prs.yml`** (#1201 item 3): gate-2 leggeva `LASTCOMMIT` e — se vuoto (PR senza commit, o head **fork** inaccessibile) — **proseguiva** al recycle. `gh pr close --delete-branch` su un head fork può fallire silenziosamente lasciando il ref → push fresco di `issue-fix` (branch `fix/issue-N` deterministico) bloccato. Fix: skip difensivo quando `LASTCOMMIT` è vuoto.

Entrambe le YAML validate con `yaml.safe_load`. Nessun sibling con lo stesso pattern singolare `item deferred` eseguibile altrove (grep su `.github/workflows` + `scripts/` → solo questa occorrenza + i commenti descrittivi).

## Non implementato (ancora)
- **#1201 item 2** (parsing per-item deterministico del body dell'issue aggregata): la selezione del singolo item resta a giudizio dell'agent guidato dal circuit-breaker one-item. È esplicitamente dichiarato nel PR body originale (#1193) come **follow-up condizionato alla ricorrenza** di #1172-class; non è un one-liner ma una modifica al prompt/parsing del fixer con blast radius maggiore. Fuori scope per questo bundle di hardening. Resta tracciato in #1201.
- Test harness: non esiste un test per `issue-fix.yml`/`recycle-stale-prs.yml` (sono shell-in-YAML CI glue); non aggiungo coverage (REVIEW.md → test coverage non è un finding). Il comportamento della regex è verificato in PR body sopra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)