### PR TITLE
fix(validate-dist): rehydrate guard checks dir AND locale homepage (#1607)

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -213,8 +213,15 @@ jobs:
         run: |
           set -euo pipefail
           for loc in en de fr; do
-            if [ -d "dist/$loc" ]; then
-              echo "$loc present in artifact (not stripped this build) — skip rehydrate"
+            # Skip rehydrate only when BOTH the locale dir AND its homepage
+            # `dist/$loc.html` (= `/{loc}`) are present. Checking just the dir
+            # couples this guard to the implicit assumption that the strip in
+            # deploy.yml always removes dir + homepage together (true today). If
+            # a future strip refactor decoupled them, a dir-only check would skip
+            # rehydrate while `/{loc}` stayed missing → locale homepage 404 = SEO
+            # loss. Verifying both decouples the guard from that assumption (#1607).
+            if [ -d "dist/$loc" ] && [ -f "dist/$loc.html" ]; then
+              echo "$loc present in artifact (dir + homepage, not stripped this build) — skip rehydrate"
               continue
             fi
             tmp="$RUNNER_TEMP/rehydrate-$loc"
@@ -222,6 +229,12 @@ jobs:
             git clone --depth 1 --single-branch --branch main \
               "https://github.com/valerielinc-ops/frontaliere-$loc.git" "$tmp"
             [ -d "$tmp/$loc" ] || { echo "::error::shard $loc has no $loc/ subtree"; exit 1; }
+            # Remove any partial pre-existing dir first: with the dir+homepage
+            # guard above, we can reach here with `dist/$loc` already present
+            # (dir kept, homepage stripped). `cp -r src existing-dir` would nest
+            # as `dist/$loc/$loc` instead of replacing — so clear it for a clean
+            # rehydrate. No-op in the common case (dir was fully stripped).
+            rm -rf "dist/$loc"
             cp -r "$tmp/$loc" "dist/$loc"
             if [ -f "$tmp/$loc.html" ]; then cp "$tmp/$loc.html" "dist/$loc.html"; fi
             echo "rehydrated $loc: $(find "dist/$loc" -type f | wc -l) files"


### PR DESCRIPTION
## Implementato
- **`.github/workflows/post-deploy-validate-dist.yml`**: il guard di skip-rehydrate dei locale shard testava solo la directory (`if [ -d "dist/$loc" ]`), appoggiandosi all'assunzione implicita che lo strip in `deploy.yml` rimuova **sempre** dir + homepage `dist/$loc.html` (= `/{loc}`) insieme — vero oggi (`deploy.yml:L1148` → `rm -rf "dist/$loc" "dist/$loc.html"`). Se un futuro refactor dello strip li disaccoppiasse, il rehydrate verrebbe **saltato** con la dir presente ma la homepage `/{loc}` mancante → 404 homepage locale = SEO/traffic loss silenzioso. Fix: skip solo se **ENTRAMBI** dir e homepage sono presenti.
- **Idempotenza** del copy nel caso ora raggiungibile (dir presente, homepage strippata): `cp -r src dir-esistente` anniderebbe `dist/$loc/$loc` invece di rimpiazzare → aggiunto `rm -rf "dist/$loc"` prima del `cp` (no-op nel caso comune dir-completamente-strippata).

Closes #1607

## Non implementato (ancora)
- Lo strip in `deploy.yml:L1148` resta coupled (rimuove dir+html insieme): è corretto oggi e fuori scope — questa PR rende il *consumer* (validate-dist) robusto al drift, che è esattamente l'azione suggerita nell'issue.
- Sibling grep (`rehydrate`/`dist/$loc` su `.github/workflows/`): le altre occorrenze (`inspect-dist-composition.yml` read-only sizing; `deploy.yml:831` shard-push presence-guard; `deploy.yml:1148` lo strip stesso) non sono lo stesso skip-rehydrate-su-dir-only → nessun sibling da fixare nella stessa classe.
- Test harness: non esiste un test per questo workflow (shell-in-YAML CI glue), non aggiungo coverage (REVIEW.md → test coverage non è un finding). YAML validato con `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)