### PR TITLE
feat(ci): vitest-wait observability comment + generalized check-name drift guard

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -50,6 +50,28 @@ function fail(msg) {
   process.exit(0); // esito atteso, non errore di workflow
 }
 
+// Osservabilità (feedback backlog-agent): quando l'## LGTM è presente ma il
+// merge ATTENDE vitest, postiamo UN commento (deduped via marker) così il
+// comportamento "held for vitest" è visibile sulla PR senza dover pollare i
+// check. Best-effort: serve un token write (riusa MERGE_PRIMARY_TOKEN); se manca
+// o l'API fallisce, si logga e si prosegue — mai bloccare la valutazione.
+const AWAITING_VITEST_MARKER = '<!-- AWAITING_VITEST -->';
+function notifyAwaitingVitest(pr) {
+  const token = process.env.MERGE_PRIMARY_TOKEN || '';
+  if (!token) return;
+  try {
+    const existing = gh(['api', `repos/${REPO}/issues/${pr}/comments`, '--paginate',
+      '--jq', '[.[] | .body] | join("\\n")'], { json: false, token }) || '';
+    if (existing.includes(AWAITING_VITEST_MARKER)) return; // già notificato
+    gh(['issue', 'comment', String(pr), '--repo', REPO, '--body',
+      `${AWAITING_VITEST_MARKER}\n🟡 \`## LGTM\` ricevuto — l'auto-merge ATTENDE che il check \`${VITEST_CHECK_NAME}\` concluda con success prima di mergiare (nessun merge su pending). Mergia in automatico appena vitest è verde.`,
+    ], { json: false, token });
+    console.log(`Commento "attendo vitest" postato su #${pr}.`);
+  } catch (e) {
+    console.log(`notifyAwaitingVitest best-effort fallito: ${String(e).slice(0, 120)}`);
+  }
+}
+
 /**
  * Fingerprint del CONTRIBUTO PROPRIO della PR a un dato commit `sha` =
  * il diff vs il merge-base con main (3-dot), indipendente dalla churn di main.
@@ -179,6 +201,10 @@ function main() {
     return fail(`Impossibile leggere check-runs HEAD ${head}: ${String(e).slice(0, 160)} — skip.`);
   }
   if (conclusion !== 'success') {
+    // Pending/missing (NON failure): l'## LGTM è già passato, manca solo vitest →
+    // notifica osservabile (deduped). Su 'failure' non notifichiamo "attendo" (è
+    // rosso, non in attesa).
+    if (conclusion !== 'failure') notifyAwaitingVitest(PR);
     return fail(`vitest gate conclusion='${conclusion || '<none/pending>'}' ≠ success — skip; il completamento di 'tests' ri-valuterà (no merge su pending/missing).`);
   }
   console.log('Gate vitest: success ✔');

--- a/tests/ci-vitest-check-name.test.ts
+++ b/tests/ci-vitest-check-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 // @ts-expect-error — modulo .mjs senza tipi
 import { VITEST_CHECK_NAME } from '../scripts/ci/lib/constants.mjs';
@@ -48,5 +48,27 @@ describe('VITEST_CHECK_NAME (#1602 drift guard)', () => {
         `${name} usa ancora il literal hardcoded in jq invece della const`,
       ).toBe(false);
     }
+  });
+
+  // Generalizzazione (feedback backlog-agent #3): non solo i 2 consumer noti —
+  // NESSUN nuovo script sotto scripts/ci/ deve reintrodurre il literal. Coglie
+  // un futuro helper che copia-incolla "vitest (unit + integration)" invece di
+  // importare la const, all'author-time invece che in una follow-up issue.
+  it('nessuno script in scripts/ci/ hardcoda il literal vitest check-name (oltre constants.mjs)', () => {
+    const CI_DIR = resolve(ROOT, 'scripts/ci');
+    // Comment-aware: il literal nei docstring/commenti (es. che DESCRIVONO il
+    // check name) è legittimo — solo l'uso ESEGUIBILE è drift. Salta le righe
+    // che sono commenti (`//`, `*`, `/*`).
+    const isCommentLine = (l: string) => /^\s*(\/\/|\*|\/\*)/.test(l);
+    const offenders: string[] = [];
+    for (const entry of readdirSync(CI_DIR, { recursive: true, encoding: 'utf-8' })) {
+      if (!entry.endsWith('.mjs')) continue;
+      if (entry.replace(/\\/g, '/').endsWith('lib/constants.mjs')) continue; // la source-of-truth
+      const src = readFileSync(resolve(CI_DIR, entry), 'utf-8');
+      const hit = src.split('\n').some((l) => l.includes('vitest (unit + integration)') && !isCommentLine(l));
+      if (hit) offenders.push(entry);
+    }
+    expect(offenders, `script con literal hardcoded ESEGUIBILE (devono importare VITEST_CHECK_NAME): ${offenders.join(', ')}`)
+      .toEqual([]);
   });
 });


### PR DESCRIPTION
## Implementato
Due voci di hardening processo CI dal **feedback del backlog-fixer agent**:

1. **(suggerimento #2) Commento vitest-wait osservabile** — `scripts/ci/auto-merge-eval.mjs`: quando `## LGTM` è presente ma il merge è in attesa perché vitest è pending/missing, posta **UN** commento deduped (`🟡 LGTM ricevuto — attendo vitest…`) così il comportamento "held-for-vitest" è visibile sulla PR senza pollare `statusCheckRollup`. Best-effort (riusa il token write `MERGE_PRIMARY_TOKEN`, dedup via marker, non blocca mai l'eval); **non** postato su vitest `failure` (è rosso, non in attesa).
2. **(suggerimento #3) Guard drift generalizzato** — `tests/ci-vitest-check-name.test.ts`: estende il guard di #1602 oltre i 2 consumer noti con uno scan **comment-aware** che asserisce che NESSUNO script sotto `scripts/ci/` reintroduca il literal ESEGUIBILE `vitest (unit + integration)` (docstring esclusi). Coglie un futuro helper che copia il magic-string all'author-time invece che in una follow-up.

Test: `ci-vitest-check-name` + `auto-merge-eval-fingerprint` 10/10 verde (lo scan comment-aware evita il falso positivo sui docstring legittimi dei 2 script esistenti).

## Non implementato (ancora)
- **(suggerimento #1) Auto-sync del local `main` checkout / forzare Bash cwd al worktree**: è **harness-level** (non un repo-fix) e l'auto-reset di `main` **confligge con AGENTS.md** (mai toccare il local `main` = foreign work). La mitigazione corretta resta procedurale (mai `cd`, path assoluti worktree) — già in memory. Non implementato come repo-change di proposito.
- Unit test del `notifyAwaitingVitest` (impuro, gh-dipendente, gated da token) → validato live al prossimo PR che resta in attesa di vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)