### PR TITLE
fix(seo): day-granularity dateModified on listing/hub pages — cut residual per-build churn

### DIFF
--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -39,6 +39,7 @@ import {
 import { renderRecencyHubProse } from './shared/jobListingProse';
 import { renderJobBoardCommuterContext } from './shared/jobBoardCommuterContext';
 import { windowDaysForVariant } from './jobRecencyLanding';
+import { buildDayStampIso } from './shared/buildDayStamp';
 
 const LOCALES: ReadonlyArray<JobLandingLocale> = ['it', 'en', 'de', 'fr'];
 
@@ -255,7 +256,9 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
             description: model.description,
             inLanguage: locale,
             isPartOf: sectionRootUrl,
-            dateModified: new Date().toISOString(),
+            // Day-granularity, not a full build timestamp — see
+            // build-plugins/shared/buildDayStamp.ts (per-build churn fix).
+            dateModified: buildDayStampIso(),
           });
 
           const faqLd = model.faq.length > 0

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -52,6 +52,7 @@ import {
   type SectorCountableJob,
   type SectorHubKey,
 } from './jobSectorLanding';
+import { buildDayStampIso } from './shared/buildDayStamp';
 
 const LOCALES: ReadonlyArray<JobBoardLocale> = ['it', 'en', 'de', 'fr'];
 
@@ -288,7 +289,9 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
     description: seo.desc,
     inLanguage: locale,
     isPartOf: sectionRootUrl,
-    dateModified: new Date().toISOString(),
+    // Day-granularity, not a full build timestamp — see
+    // build-plugins/shared/buildDayStamp.ts (per-build churn fix).
+    dateModified: buildDayStampIso(),
   });
 
   const faqLd = seo.faq.length > 0

--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -72,6 +72,7 @@ import {
 } from './orphanQueryData';
 import { generateRelatedLinksBlock } from './shared/relatedLinks';
 import { adSlotHtml } from './lib/adSlotHtml';
+import { buildDayStampIso } from './shared/buildDayStamp';
 
 const MIN_MATCHING_JOBS = 3;
 const DEFAULT_MAX_LANDINGS = 500;
@@ -968,7 +969,9 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
           url: canonicalUrl,
           description: copy.description,
           inLanguage: loc,
-          dateModified: new Date().toISOString(),
+          // Day-granularity, not a full build timestamp — see
+          // build-plugins/shared/buildDayStamp.ts (per-build churn fix).
+          dateModified: buildDayStampIso(),
           mainEntity: {
             '@type': 'ItemList',
             numberOfItems: sorted.length,

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1701,7 +1701,12 @@ function renderHubPage(input: HubPageInput): { urlPath: string; html: string; lo
     url: canonicalUrl,
     description: copy.hubDescription,
     inLanguage: locale,
-    dateModified: new Date().toISOString(),
+    // Day-granularity (matches the visible `dateStamp` rendered on the page),
+    // NOT a full build timestamp: a sub-second `new Date().toISOString()` here
+    // made every search-cluster/listing page churn on every deploy. Stable
+    // within the UTC day → same-day deploys no longer rewrite these pages from
+    // dateModified alone. See build-plugins/shared/buildDayStamp.ts.
+    dateModified: `${dateStamp}T00:00:00.000Z`,
     mainEntity: {
       '@type': 'ItemList',
       // numberOfItems reports the full list size; itemListElement is a sample.

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -46,6 +46,7 @@ import { ALL_CANTON_CODES, resolveCantonSection, resolveJobCanton, legacyTiSecti
 import { MIN_JOBS_FOR_CANTON_PAGE } from './weeklyEmployersData';
 import { isCantonNoindex } from './shared/cantonNoindexRegistry';
 import { renderCantonSeoProse, type CantonSeoLocale, type CantonSeoSlot } from './shared/cantonSeoProse';
+import { buildDayStampIso } from './shared/buildDayStamp';
 
 const LOCALE_OG: Record<HubLocale, string> = {
   it: 'it_IT',
@@ -1124,7 +1125,9 @@ function buildHtml(args: BuildHtmlArgs): string {
     url: canonicalUrl,
     description,
     inLanguage: locale,
-    dateModified: new Date().toISOString(),
+    // Day-granularity, not a full build timestamp — see
+    // build-plugins/shared/buildDayStamp.ts (per-build churn fix).
+    dateModified: buildDayStampIso(),
     mainEntity: {
       '@type': 'ItemList',
       numberOfItems: totalItems,

--- a/build-plugins/shared/buildDayStamp.ts
+++ b/build-plugins/shared/buildDayStamp.ts
@@ -1,0 +1,21 @@
+/**
+ * Day-granularity build timestamp for JSON-LD `dateModified` on listing/hub/
+ * collection pages.
+ *
+ * WHY day-granularity and not `new Date().toISOString()`: a full-precision
+ * build timestamp changes on EVERY build (sub-second), so every prerendered
+ * page that embeds it churns on every ~hourly deploy even when its content is
+ * unchanged. Measured: with the SPA entry hash now stable (#1615), the residual
+ * per-deploy churn (~30% files) is dominated by listing/hub pages whose only
+ * (or main) delta is this build-time `dateModified`. Truncating to the UTC day
+ * makes it stable across all same-day deploys → those pages stop churning until
+ * the calendar day rolls over (and a daily roll is legitimate freshness, still
+ * a valid recent `dateModified` for SEO).
+ *
+ * Returns e.g. `2026-06-09T00:00:00.000Z`. Mirrors the pattern already used by
+ * jobMarketSnapshotPlugin (`${todayIso}T00:00:00.000Z`), centralized here so
+ * the collection-page generators share one source of truth.
+ */
+export function buildDayStampIso(): string {
+  return `${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`;
+}


### PR DESCRIPTION
## Implementato
Riduce il churn residuo per-deploy (misurato **29,6% file / 58,9% byte** dopo #1615, run 27217554014): le pagine **listing/hub/collection** avevano `CollectionPage.dateModified` = `new Date().toISOString()` **pieno (sub-secondo, build-time)** → ogni pagina riscritta a OGNI deploy orario anche a contenuto invariato (nel sample-diff il timestamp dateModified era l'unica/principale differenza su `cerca-lavoro-ticino/tutti`, `aziende-che-assumono`, ecc.).

Troncato a **granularità giornaliera UTC** (`YYYY-MM-DDT00:00:00.000Z`) via helper condiviso → quelle pagine diventano byte-stabili su tutti i deploy dello stesso giorno (il roll giornaliero è freshness legittima, dateModified resta valido/recente per SEO). Stesso pattern già usato da `jobMarketSnapshotPlugin`.

- **new** `build-plugins/shared/buildDayStamp.ts` (`buildDayStampIso`) — un'unica source-of-truth (AGENTS.md #6: costrutto in ≥2 file → modulo condiviso).
- `relatedSearchClustersPlugin` (`cerca-lavoro-ticino/tutti`·`ricerca`): riusa il `dateStamp` day-granularity già renderizzato sulla pagina (dateModified == data visibile).
- `jobRecencyPagesPlugin`, `jobSectorPagesPlugin`, `seoHubsPlugin` (`aziende-che-assumono/*`), `orphanQueryLandingPlugin`: `buildDayStampIso()`.

**Fix dell'intera classe**: `grep` conferma zero `dateModified: new Date().toISOString()` full-timestamp residui nei build-plugins. (Weather/fuel/border già usano data-derived o `T00:00:00`; `relatedSearch:449 generatedAt` non è renderizzato in pagina.)

**Verificato pre-merge:** `tsc` pulito sui file toccati; 263/264 test verdi (`related-search-clusters`, `job-recency-landing`, `job-sector-landing`, `orphan-query-landings`, `footer-canton-scoped-seo-hubs`, `dist-duplicate-structured-data`).

## Non implementato (ancora)
- **Conferma quantitativa post-merge**: il calo del churn si misura post-merge con `measure-deploy-delta` su due build data-only post-fix (samples=0; il job sfora `timeout-minutes:30` con samples>0 su ~327k file ×2 — alzare il timeout è un follow-up workflow).
- **Churn da conteggio job (NON toccato, scelta di prodotto)**: le pagine-lista mostrano "85.358 annunci" / `numberOfItems` = totale → **1 job che cambia riscrive tutte le N pagine paginate** (amplificazione reale, es. i 110MB di `cerca-lavoro-ticino/tutti`). Ridurlo richiede una decisione di prodotto (arrotondare il conteggio, o mostrarlo solo su page-1) che tocca contenuto user-facing → fuori scope, serve OK esplicito.
- **prezzi-benzina/diesel**: churn legittimo (dati giornalieri), non toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)