### PR TITLE
fix(job-alerts): newsletter autologin survives mid-flight reload + instrument toast skips

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -449,6 +449,14 @@ const App: React.FC = () => {
  // Auto-login via HMAC autologin code or legacy custom token in newsletter URL
  useEffect(() => {
  let cancelled = false;
+ // Newsletter credential params (`ac`/`ne`/…) are stripped from the URL only
+ // AFTER the autologin exchange resolves (see `finally`) — never before the
+ // await — so a mid-flight reload (e.g. authService's lazyRetry chunk-reload)
+ // preserves them and the autologin retries on the next load instead of
+ // dropping the user as anonymous, which silently kills the job-alert toast
+ // (a logged-out visitor fails the prompt's `userId`/`userEmail` guard).
+ const NEWSLETTER_PARAMS = ['ac', 'at', 'ne', 'authToken', 'newsletter_email', 'newsletter_autologin', 'newsletter_source', 'subscriber_key'];
+ let shouldStripNewsletterParams = false;
  (async () => {
  try {
  const url = new URL(window.location.href);
@@ -458,23 +466,15 @@ const App: React.FC = () => {
  const { code: autologinCode, legacyToken: legacyAuthToken, email: rawEmail, action } =
  parseNewsletterAutologin(url.searchParams);
 
- // Always strip newsletter-specific query params from the URL immediately so
- // they don't persist during SPA navigation (privacy + cosmetics).
- const NEWSLETTER_PARAMS = ['ac', 'at', 'ne', 'authToken', 'newsletter_email', 'newsletter_autologin', 'newsletter_source', 'subscriber_key'];
- const hadNewsletterParams = NEWSLETTER_PARAMS.some(p => url.searchParams.has(p));
-
- // Skip if there's a newsletter action — the action handler owns auth in that case
+ // Skip if there's a newsletter action — the action handler owns auth + URL.
  if (action === 'unsubscribe' || action === 'resubscribe' || action === 'confirm_newsletter') return;
+
+ // From here this effect owns the URL cleanup; defer the strip to `finally`
+ // so it never races the async exchange below.
+ shouldStripNewsletterParams = NEWSLETTER_PARAMS.some(p => url.searchParams.has(p));
 
  // Normalize the recipient email read by the shared parser.
  const email = normalizeNewsletterEmail(rawEmail);
-
- // Strip newsletter params from URL right away
- if (hadNewsletterParams) {
- for (const p of NEWSLETTER_PARAMS) url.searchParams.delete(p);
- const cleanUrl = url.pathname + (url.search || '') + url.hash;
- window.history.replaceState(null, '', cleanUrl);
- }
 
  if (!autologinCode && !legacyAuthToken) return;
  if (!email || !email.includes('@')) return;
@@ -498,6 +498,17 @@ const App: React.FC = () => {
  reportCaughtError(error, 'app.newsletterAutologin');
  Analytics.trackUIInteraction('newsletter', 'autologin', 'error');
  } finally {
+ // Strip newsletter credential params now that the exchange has resolved
+ // (success or failure) — deferred from before the await so an interrupted
+ // load keeps `ac`/`ne` for a retry. No-op for excluded actions (flag stays
+ // false) and when the URL never carried them.
+ if (shouldStripNewsletterParams) {
+ try {
+ const u = new URL(window.location.href);
+ for (const p of NEWSLETTER_PARAMS) u.searchParams.delete(p);
+ window.history.replaceState(null, '', u.pathname + (u.search || '') + u.hash);
+ } catch { /* replaceState unavailable */ }
+ }
  // Re-enable sign-in affordances (One Tap, auth gates) once the exchange
  // resolves — success or failure. Idempotent + no-op when never in flight.
  settleNewsletterAutologin();

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2369,21 +2369,32 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  const state = loadGatingState();
  const normalized = normalizeKeyword(localizedCategory);
- if (!shouldShowPrompt(state, new Date(), normalized)) return;
+ if (!shouldShowPrompt(state, new Date(), normalized)) {
+ Analytics.trackJobAlertCtaSkipped('job_detail_prompt', 'gating_capped');
+ return;
+ }
 
  let existing: Awaited<ReturnType<typeof getUserAlerts>>;
  try {
  existing = await getUserAlerts(userId);
  } catch {
- // Fail closed — never badger users on a degraded network.
+ // Fail closed — never badger users on a degraded network. Emit a skip
+ // signal so this silent drop shows up in GA4 (was an invisible 0-impression).
+ Analytics.trackJobAlertCtaSkipped('job_detail_prompt', 'get_alerts_failed');
  return;
  }
  if (cancelled) return;
- if (findMatchingAlertForCategory(existing, localizedCategory)) return;
+ if (findMatchingAlertForCategory(existing, localizedCategory)) {
+ Analytics.trackJobAlertCtaSkipped('job_detail_prompt', 'already_subscribed');
+ return;
+ }
  // P2: don't prompt when the user is already at their alert quota — the
  // one-tap subscribe path would throw inside createAlert and surface as
  // a silent `error` event (3 such events on 2026-05-13 traced to this).
- if (existing.length >= MAX_ALERTS_PER_USER) return;
+ if (existing.length >= MAX_ALERTS_PER_USER) {
+ Analytics.trackJobAlertCtaSkipped('job_detail_prompt', 'quota_full');
+ return;
+ }
 
  // Leva B: a user who just authed via Google/FB to unlock THIS job is at
  // peak intent — show the one-tap alert offer immediately rather than

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1859,6 +1859,29 @@ export const Analytics = {
  cta_keyword: (keyword || '').slice(0, 80),
  });
  },
+
+ /**
+  * Diagnostic: the job-detail alert prompt was eligible to evaluate but was
+  * suppressed before becoming visible, with the reason. Lets us see in GA4
+  * exactly which guard drops the prompt (e.g. `no_auth` from a failed
+  * newsletter autologin, `get_alerts_failed` from a degraded Firestore read)
+  * instead of inferring it from a zero impression count.
+  */
+ trackJobAlertCtaSkipped: (
+ surface: 'job_detail_prompt',
+ reason:
+ | 'no_auth'
+ | 'no_category'
+ | 'gating_capped'
+ | 'get_alerts_failed'
+ | 'already_subscribed'
+ | 'quota_full',
+ ) => {
+ log('job_alert_cta_skipped', {
+ cta_surface: surface,
+ skip_reason: reason,
+ });
+ },
 };
 
 // ─── Protect Analytics methods from external modification ──────


### PR DESCRIPTION
## Contesto
Diagnosi live (browser sessione pulita + GA4 + Firestore): `job_alert_subscribers` fermo da **2026-04-25** (0 nuovi in 6 settimane) nonostante ~2500 signup auth/newsletter. Root cause sul percorso click-da-newsletter:

1. L'URL arriva con `?ac=<HMAC>&ne=<email>`.
2. `App.tsx` **toglie subito** `ac`/`ne` dall'URL (`history.replaceState`), **poi** (async) chiama `exchange_auth_code` → `signInWithCustomToken`.
3. Un reload a metà — osservato: chunk JS fallisce → `lazyRetry` fa `window.location.reload()` (`authService.ts:49`) — **aborta l'exchange** (`net::ERR_ABORTED`). Al reload l'URL non ha più `ac` → l'autologin **non può ritentare** → utente **anonimo**.
4. Il toast job-alert ha la guardia `if (!userId || !userEmail) return` → cade in silenzio → 0 iscrizioni.

Confermato a runtime: in sessione pulita `onAuthStateChanged → hasUser:false` e la GET `newsletterManageSubscription?action=exchange_auth_code` risulta `ERR_ABORTED`.

## Implementato
- **`App.tsx` (autologin effect):** lo strip di `ac`/`ne`/… è spostato dal *prima* dell'`await` al blocco **`finally`** (dopo che l'exchange si è risolto, success o fail). Così un reload a metà **preserva le credenziali** e l'autologin ritenta al load successivo (l'exchange è idempotente: `getUserByEmail`→stesso uid). Nessun cambio per le action `unsubscribe`/`resubscribe`/`confirm_newsletter` (flag resta `false`).
- **Diagnostica `job_alert_cta_skipped`** (`analytics.ts` + `JobBoard.tsx`): i guard **post-auth** del toast (`gating_capped`, `get_alerts_failed`, `already_subscribed`, `quota_full`) ora emettono un evento col motivo. Così in GA4 vediamo *dove* cade il prompt per utenti loggati, invece di un'invisibile 0-impression. Volume basso (solo utenti loggati su job-detail) → niente flood. Il lato auth è già coperto da `newsletter:autologin:success|failed` (`App.tsx`).

## Non implementato (ancora)
- **Trigger del reload (chunk-fail `lazyRetry`):** non risolto qui — la fix rende l'autologin *resiliente* al reload, non lo elimina. Il chunk-fail (`WhatsNewModal` ERR_FAILED) è legato al churn hash bundle del deploy; follow-up separato.
- **🔴 Secret in Remote Config client-readable** (`NEWSLETTER_SECRET`, `GITHUB_PAT`, ESP/AI keys, …): incidente di sicurezza separato e più grave — chiunque può forgiare `ac` per qualsiasi email. Va trattato a parte (rotazione + separare flag-client da secret-server). NON in questa PR.
- **PostHog dark:** dominio ingestion `t.frontaliereticino.ch` → `ERR_NAME_NOT_RESOLVED` (DNS). Va sistemato lato DNS (non codice).
- **Custom dimension GA4** per `skip_reason`/`cta_surface`/`cta_action`: da registrare nell'Admin GA4 perché i breakdown siano queryabili (config, non codice).
- **Verifica live:** post-merge, click reale da newsletter + query GA4 `newsletter:autologin success-rate` e `job_alert_cta_skipped` per confermare che il toast ora parte. Se non parte, il `skip_reason` dirà quale guardia resta.

## Test plan (post-merge, live)
- [ ] Click autologin da newsletter in sessione pulita → `onAuthStateChanged: hasUser:true` (no più ERR_ABORTED ricorrente).
- [ ] Su job-detail da loggato, toast "Vuoi alert per …" appare entro ~2s.
- [ ] GA4: comparsa di `job_alert_cta_skipped` con reason e ripresa di `job_alert_created`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)