### PR TITLE
chore(infra): version PostHog proxy worker + auto-deploy

### DIFF
--- a/.github/workflows/deploy-posthog-proxy.yml
+++ b/.github/workflows/deploy-posthog-proxy.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Deploy worker
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-posthog-proxy.yml
+++ b/.github/workflows/deploy-posthog-proxy.yml
@@ -1,0 +1,29 @@
+name: Deploy PostHog proxy worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/cloudflare/posthog-proxy/**'
+      - '.github/workflows/deploy-posthog-proxy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-posthog-proxy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: infra/cloudflare/posthog-proxy
+          command: deploy

--- a/infra/cloudflare/posthog-proxy/README.md
+++ b/infra/cloudflare/posthog-proxy/README.md
@@ -1,0 +1,34 @@
+# PostHog first-party proxy (Cloudflare Worker)
+
+Reverse-proxies PostHog EU Cloud under `https://t.frontaliereticino.ch` so
+analytics requests are same-origin and survive ad-blockers. The web client
+points `api_host` at this domain in [`services/posthog.ts`](../../../services/posthog.ts).
+
+- `/static/*` → `eu-assets.i.posthog.com` (posthog-js bundle)
+- everything else → `eu.i.posthog.com` (ingestion, flags, …)
+
+## Background
+
+On 2026-06-09 `t.frontaliereticino.ch` resolved to NXDOMAIN (no DNS record), so
+100% of PostHog events failed — the analytics blackout was a broken proxy, not
+just a quota issue. This Worker + its custom domain restore it.
+
+## Deploy
+
+Automatic: any push to `main` touching `infra/cloudflare/posthog-proxy/**`
+runs [`.github/workflows/deploy-posthog-proxy.yml`](../../../.github/workflows/deploy-posthog-proxy.yml).
+
+Manual:
+
+```bash
+cd infra/cloudflare/posthog-proxy
+npx wrangler deploy        # OAuth (wrangler login) or CLOUDFLARE_API_TOKEN
+```
+
+The first deploy creates the `t.frontaliereticino.ch` custom domain (proxied DNS
+record + edge TLS cert) automatically; later deploys only update the script.
+
+## CI secrets
+
+- `CLOUDFLARE_API_TOKEN` — token with the *Edit Cloudflare Workers* permission set.
+- `CLOUDFLARE_ACCOUNT_ID` — `a426452d1d2987ac744c6feff20dd8b3`.

--- a/infra/cloudflare/posthog-proxy/src/index.js
+++ b/infra/cloudflare/posthog-proxy/src/index.js
@@ -1,0 +1,34 @@
+// First-party reverse proxy for PostHog EU Cloud.
+//
+// Served on https://t.frontaliereticino.ch (Cloudflare Worker custom domain) so
+// analytics requests are same-origin and bypass ad-blockers that block
+// *.posthog.com. The client points `api_host` at this domain (see
+// services/posthog.ts). Without this proxy the host is NXDOMAIN and every
+// PostHog event fails (observed 2026-06-09).
+//
+//   /static/*  -> eu-assets.i.posthog.com   (posthog-js bundle, cacheable)
+//   everything -> eu.i.posthog.com          (event ingestion / flags / etc.)
+const API_HOST = 'eu.i.posthog.com';
+const ASSET_HOST = 'eu-assets.i.posthog.com';
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith('/static/')) {
+      const cache = caches.default;
+      let response = await cache.match(request);
+      if (!response) {
+        response = await fetch(`https://${ASSET_HOST}${url.pathname}${url.search}`, {
+          headers: request.headers,
+        });
+      }
+      return response;
+    }
+
+    // Strip cookies so PostHog never receives first-party cookies for this domain.
+    const originRequest = new Request(request);
+    originRequest.headers.delete('cookie');
+    return fetch(`https://${API_HOST}${url.pathname}${url.search}`, originRequest);
+  },
+};

--- a/infra/cloudflare/posthog-proxy/wrangler.toml
+++ b/infra/cloudflare/posthog-proxy/wrangler.toml
@@ -1,0 +1,11 @@
+name = "posthog-proxy"
+main = "src/index.js"
+compatibility_date = "2024-11-01"
+workers_dev = false
+
+# Custom domain: Cloudflare provisions the DNS record (proxied) + edge TLS cert
+# for t.frontaliereticino.ch on first deploy. Subsequent deploys only update the
+# script. `api_host` in services/posthog.ts must stay in sync with this host.
+routes = [
+  { pattern = "t.frontaliereticino.ch", custom_domain = true }
+]


### PR DESCRIPTION
## Contesto
`t.frontaliereticino.ch` — il reverse-proxy PostHog a cui `services/posthog.ts` punta `api_host` — il 2026-06-09 **non aveva alcun record DNS** (NXDOMAIN) → **100% degli eventi PostHog falliva**. Il blackout analytics era un proxy rotto, non solo la quota. Ripristinato come Cloudflare Worker custom domain (deployato a mano, verificato live: `/static/array.js`→200, `/flags`→200, cert TLS valido, mascheramento first-party preservato).

## Implementato
- `infra/cloudflare/posthog-proxy/` — sorgente del Worker versionato (`src/index.js` + `wrangler.toml` + `README.md`), così smette di essere un artefatto orfano non tracciato.
- `.github/workflows/deploy-posthog-proxy.yml` — **auto-deploy** ad ogni push su `main` che tocca `infra/cloudflare/posthog-proxy/**` (via `cloudflare/wrangler-action@v3`). Concurrency serializzata, `workflow_dispatch` per run manuali.

## Non implementato (ancora)
- **Secret `CLOUDFLARE_API_TOKEN`**: `CLOUDFLARE_ACCOUNT_ID` già impostato come secret; il token va creato a mano (login Cloudflare ha CAPTCHA → non automatizzabile, e l'OAuth wrangler non ha `api_tokens:write`). Finché il secret non c'è, il workflow fallirebbe — ma il Worker è già live (deploy manuale), quindi nessun impatto finché non si modifica il Worker.
- **Nessun cambio a `services/posthog.ts`** (già corretto su `t.frontaliereticino.ch`).
- Il Worker non gira test app (è infra isolata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)