### PR TITLE
fix(ci): post vitest-wait comment only on review event (kill TOCTOU duplicate)

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -202,9 +202,15 @@ function main() {
   }
   if (conclusion !== 'success') {
     // Pending/missing (NON failure): l'## LGTM è già passato, manca solo vitest →
-    // notifica osservabile (deduped). Su 'failure' non notifichiamo "attendo" (è
-    // rosso, non in attesa).
-    if (conclusion !== 'failure') notifyAwaitingVitest(PR);
+    // notifica osservabile. Su 'failure' non notifichiamo "attendo" (è rosso).
+    // SOLO sul trigger `pull_request_review`: l'eval gira su DUE eventi (review +
+    // workflow_run) a ~1s di distanza; il dedup-by-listing è racy (TOCTOU →
+    // entrambi leggono "no marker" e postano → commento doppio, osservato su
+    // #1634). Il momento "## LGTM appena arrivato" è l'evento review: lì notifica
+    // una volta; l'evento workflow_run non posta (mergia se verde, o tace).
+    if (conclusion !== 'failure' && process.env.EVENT_NAME === 'pull_request_review') {
+      notifyAwaitingVitest(PR);
+    }
     return fail(`vitest gate conclusion='${conclusion || '<none/pending>'}' ≠ success — skip; il completamento di 'tests' ri-valuterà (no merge su pending/missing).`);
   }
   console.log('Gate vitest: success ✔');


### PR DESCRIPTION
## Implementato
Il commento vitest-wait osservabile (#1631) è stato postato **due volte** su #1634 (~1s di distanza). Root cause: `auto-merge-eval` gira su **entrambi** i trigger (`pull_request_review` + `workflow_run`); la dedup-via-marker è read-then-write → entrambe le invocazioni leggono "nessun marker" prima che l'altra posti → doppio post (race TOCTOU).

- `scripts/ci/auto-merge-eval.mjs`: posta la notifica SOLO sull'evento `pull_request_review` (`EVENT_NAME`, già passato da `auto-merge-on-lgtm.yml:104`). Il momento "## LGTM appena arrivato" è l'evento review → scatta una volta. L'evento `workflow_run` mergia se verde o tace, non ri-posta. Il marker-dedup resta come belt-and-suspenders per un retry del job.

**Nota:** #1634 NON era rotta — `vitest (unit + integration)` era `in_progress` sull'head, l'auto-merge attendeva **correttamente** (no merge su pending). Mergia da sé appena vitest è verde. Solo il commento duplicato era un difetto, fixato qui.

## Non implementato (ancora)
- Unit test: `notifyAwaitingVitest` è impuro (gh + env-gated) senza harness; il gate su `EVENT_NAME` è una guardia a una riga, validata live (il prossimo PR slow-CI posterà un solo commento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)