### PR TITLE
feat(diag): full newsletter-login → toast observability (attempt + no_auth)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -479,6 +479,11 @@ const App: React.FC = () => {
  if (!autologinCode && !legacyAuthToken) return;
  if (!email || !email.includes('@')) return;
 
+ // Emit an attempt marker before the async exchange so an aborted exchange
+ // (page reload mid-flight) stays countable: attempts − success − failed −
+ // error = aborted autologins.
+ Analytics.trackUIInteraction('newsletter', 'autologin', autologinCode ? 'hmac_code' : 'legacy_token', 'attempt');
+
  let user = null;
  if (autologinCode) {
  // New flow: exchange HMAC code for a fresh custom token via Cloud Function

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -82,6 +82,7 @@ import {
 import { type Locale, useLocale, useTranslation, getCantonI18nParams } from '@/services/i18n';
 import { loadBlogMeta } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
+import { wasNewsletterAutologinAttempted } from '@/services/newsletterAutologinSignal';
 import { buildPath, registerJobSlugMap, getJobMetaForSlug, ensureJobSlugMapLoaded, JOB_BOARD_CANTON_AGGREGATE } from '@/services/router';
 import { buildJobTitleWithLocation, buildTitleWithBrand } from '@/build-plugins/shared/titleSuffix';
 import { useNavigation } from '@/services/NavigationContext';
@@ -2352,7 +2353,17 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const userId = authUser?.uid || null;
  useEffect(() => {
  if (!isJobDetailView || !selectedJob) return;
- if (!enableJobAlerts || !userId || !userEmail) return;
+ if (!enableJobAlerts) return;
+ if (!userId || !userEmail) {
+ // Diagnostic: a visitor who arrived on a newsletter autologin link but is
+ // still anonymous here means the autologin never completed — the exact
+ // failure that silently drops the prompt. Scoped to that cohort (not every
+ // anonymous SEO view) so it stays a low-volume, high-signal event.
+ if (wasNewsletterAutologinAttempted()) {
+ Analytics.trackJobAlertCtaSkipped('job_detail_prompt', 'no_auth');
+ }
+ return;
+ }
  const categoryKey = categoryTranslationKey(selectedJob);
  const localizedCategory = (t(categoryKey) || '').trim();
  if (!localizedCategory) return;

--- a/services/newsletterAutologinSignal.ts
+++ b/services/newsletterAutologinSignal.ts
@@ -60,10 +60,23 @@ let inFlight = ((): boolean => {
  }
 })();
 
+// Captured once at module load and never reset (unlike `inFlight`, which
+// settles after the exchange). True for the whole SPA session when the user
+// arrived on a newsletter autologin link. Lets late-running consumers — e.g.
+// the job-alert prompt — distinguish "this visitor came from a newsletter but
+// is still anonymous" (autologin never completed) from organic anonymous
+// traffic, without emitting telemetry for every anonymous page view.
+const attemptedAtLoad = inFlight;
+
 const subscribers = new Set<() => void>();
 
 export function isNewsletterAutologinInFlight(): boolean {
  return inFlight;
+}
+
+/** True if this SPA session began on a newsletter autologin link. Never resets. */
+export function wasNewsletterAutologinAttempted(): boolean {
+ return attemptedAtLoad;
 }
 
 /** Subscribe to the moment newsletter autologin settles. No-op if already settled. */


### PR DESCRIPTION
## Contesto
Follow-up di #1634 (già merged: fix race autologin + skip post-auth). Mancava il pezzo che osserva **dove casca davvero il funnel click-newsletter → login → toast**: il caso "utente non loggato". In #1634 l'avevo omesso di proposito (un evento per ogni anonimo SEO = flood). Ma è proprio lì che muore il toast quando l'autologin fallisce. Questa PR lo copre, **scoped al solo cohort newsletter**.

## Implementato
- **`App.tsx`** — evento `newsletter:autologin:attempt` **prima** dell'exchange async. Un exchange abortito (reload a metà) non raggiunge mai success/failed, quindi `attempt − success − failed − error = autologin abortiti` → l'abort diventa misurabile in GA4.
- **`newsletterAutologinSignal.ts`** — `wasNewsletterAutologinAttempted()`: catturato al module-load, non si resetta, marca "questa sessione è arrivata da un link autologin newsletter".
- **`JobBoard.tsx`** — il guard auth del toast ora emette `job_alert_cta_skipped:no_auth` quando un visitatore da-newsletter è ancora anonimo su una job-detail (il fallimento che droppava il prompt in silenzio). Gated su quel cohort → low-volume, niente flood SEO.

Chain completa ora osservabile: `autologin:attempt` → `autologin:success|failed` → (se anonimo) `cta_skipped:no_auth` → (se loggato) `cta_skipped:{gating_capped|get_alerts_failed|already_subscribed|quota_full}` → `cta_shown`.

## Non implementato (ancora)
- `no_category` è nell'union ma non instrumentato (caso raro/non-funnel).
- **Custom dimension GA4** per `skip_reason` da registrare nell'Admin GA4 perché il breakdown sia queryabile (config, non codice) — i conteggi evento grezzi sono comunque visibili.
- Verifica live post-deploy (click reale newsletter + query GA4 della chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)