### PR TITLE
ci(seo): disable SEMrush weekly cron (subscription ended)

### DIFF
--- a/.github/workflows/semrush-weekly-snapshot.yml
+++ b/.github/workflows/semrush-weekly-snapshot.yml
@@ -7,12 +7,19 @@ name: SEMrush Weekly Snapshot (F.1 / F.3 / H.10)
 #   • reports/site-audit-diff-YYYY-MM-DD.md
 #   • docs/seo-reports/week-YYYY-WW.md
 #
-# Runs every Monday 06:00 UTC. Commits+pushes with a rebase-retry loop so
-# concurrent scheduled workflows do not race each other.
-
+# Commits+pushes with a rebase-retry loop so concurrent scheduled workflows
+# do not race each other.
+#
+# CRON DISABLED (2026): the SEMrush subscription ended, so SEMRUSH_API_KEY is
+# dead. The weekly cron ran every Monday and failed on every run (the snapshot
+# scripts have no live API, and the commit step touched git-ignored reports/),
+# burning Actions minutes and spamming "Workflow Failure" issues. The schedule
+# trigger is removed to stop the recurring failures; workflow_dispatch is kept
+# so the workflow can be re-run manually if the subscription ever resumes.
+# To re-enable: restore the SEMRUSH_API_KEY secret and re-add the schedule:
+#   schedule:
+#     - cron: '0 6 * * 1' # Every Monday 06:00 UTC
 on:
-  schedule:
-    - cron: '0 6 * * 1' # Every Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Implementato

Disabilitato il trigger `schedule:` (cron `0 6 * * 1`) in `.github/workflows/semrush-weekly-snapshot.yml`. Il workflow NON viene più eseguito automaticamente ogni lunedì.

**Perché:** l'abbonamento SEMrush è terminato nel 2026 → `SEMRUSH_API_KEY` è morto. Il cron settimanale falliva a OGNI run (gli script snapshot non hanno API live + lo step di commit toccava la cartella git-ignored `reports/`), bruciando minuti Actions e generando issue ricorrenti "Workflow Failure" (#1575, 5+ fallimenti consecutivi).

**Scelta reversibile (preferita):** file mantenuto, `workflow_dispatch:` conservato → il workflow resta ri-eseguibile manualmente se l'abbonamento riprende. Commento in testa al file spiega il motivo e come ri-abilitare (ripristina il secret `SEMRUSH_API_KEY` + ri-aggiungi il blocco `schedule:`, già incluso commentato).

**Surgical class check:** `grep -rl SEMRUSH_API_KEY .github/workflows/` → solo `semrush-weekly-snapshot.yml` referenzia la chiave morta. Nessun altro workflow con cron dipende da SEMRUSH, quindi nessun sibling da trattare.

**Dati SEO preservati:** nessuna rimozione di `data/seo-snapshots/`, `reports/`, `docs/seo-reports/` né degli script (`scripts/seo/semrush-*.mjs`, `detect-cannibalization.mjs`, `generate-weekly-report.mjs`). Solo il trigger schedule rimosso.

Closes #1575

## Non implementato (ancora)

- **Cancellazione completa del workflow + script SEMrush:** scelta volutamente l'opzione reversibile (drop cron, keep dispatch) come da task. Se si decide che è dead weight permanente, la rimozione di file+script è un follow-up separato — out of scope qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)