### PR TITLE
feat(security): browser fetches only an RC allowlist, not the full template

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -16,8 +16,33 @@ import { handleChatbotInference } from './src/chatbotInference.js';
 import { handleLinkedInCallback } from './src/linkedinAuthCallback.js';
 import { handleJobAlertUnsubscribe } from './src/jobAlertUnsubscribe.js';
 import { handleRecaptchaVerification } from './src/recaptchaVerification.js';
+import { getPublicConfigValues } from './src/publicConfig.js';
 
 ensureAdminApp();
+
+// Browser-safe Remote Config: returns ONLY the allowlisted client params
+// (see functions/src/publicConfig.js) so the full RC template — with all server
+// secrets — never reaches the browser. Cached at the edge; fails open to the
+// client's built-in defaults.
+export const getPublicConfig = onRequest(
+ {
+ region: 'europe-west6',
+ memory: '256MiB',
+ timeoutSeconds: 30,
+ cors: true,
+ },
+ async (req, res) => {
+ try {
+ const config = await getPublicConfigValues();
+ res.set('Cache-Control', 'public, max-age=300, s-maxage=300');
+ res.status(200).json(config);
+ } catch (error) {
+ console.error('[getPublicConfig]', error instanceof Error ? error.message : String(error));
+ // Fail open: empty object → client uses its built-in defaults.
+ res.status(200).json({});
+ }
+ },
+);
 
 export const newsletterResendWebhook = onRequest(
  {

--- a/functions/src/publicConfig.js
+++ b/functions/src/publicConfig.js
@@ -1,0 +1,30 @@
+/**
+ * publicConfig.js — the browser-safe allowlist of Remote Config parameters.
+ *
+ * The Firebase client SDK's `fetchAndActivate` downloads the ENTIRE Remote
+ * Config template into every visitor's browser (readable in IndexedDB), which
+ * leaked all server secrets (ESP keys, AdSense/GSC tokens, AI provider keys…).
+ * Instead the client now fetches ONLY this allowlist via `getPublicConfig`
+ * (functions/index.js), read server-side. Everything not listed here never
+ * reaches the browser — default-deny, so a new RC secret can't leak by accident.
+ *
+ * Keys tagged PHASE-2 are still read by client code (chatbot, exchange rates,
+ * feedback issue creation) and stay until those calls are proxied server-side;
+ * removing them from this list is what finishes de-secreting the browser.
+ */
+
+import { getRemoteConfigValue } from './remoteConfigSecrets.js';
+import { PUBLIC_CONFIG_KEYS } from './publicConfigKeys.js';
+
+export { PUBLIC_CONFIG_KEYS };
+
+/**
+ * Resolve the allowlisted RC params to a `{ KEY: value }` object. Empty values
+ * are dropped so the client falls back to its built-in defaults for them.
+ */
+export async function getPublicConfigValues() {
+  const entries = await Promise.all(
+    PUBLIC_CONFIG_KEYS.map(async (key) => [key, await getRemoteConfigValue(key)]),
+  );
+  return Object.fromEntries(entries.filter(([, value]) => value !== ''));
+}

--- a/functions/src/publicConfigKeys.js
+++ b/functions/src/publicConfigKeys.js
@@ -1,0 +1,36 @@
+/**
+ * publicConfigKeys.js — the ONLY Remote Config params exposed to the browser.
+ *
+ * Pure data (no imports) so it can be unit-tested without the firebase-admin
+ * graph. The browser fetches exactly these via `getPublicConfig`; everything
+ * else in Remote Config (ESP keys, AdSense/GSC tokens, AI provider keys…) stays
+ * server-only. Default-deny: a new RC secret cannot leak unless added here, and
+ * `tests/public-config-allowlist.test.ts` fails if an obvious secret is.
+ *
+ * Keys tagged PHASE-2 are still read by client code and drop once those calls
+ * are proxied server-side (chatbot, exchange rates, feedback issue creation).
+ */
+export const PUBLIC_CONFIG_KEYS = [
+  'CLARITY_PROJECT_ID',
+  'ENABLE_CALCULATOR_CONSULTING_CTA',
+  'ENABLE_CALCULATOR_PAYWALL',
+  'ENABLE_JOB_ALERTS',
+  'ENABLE_JOB_PERSONALIZATION',
+  'GEMINI_API_KEY', // PHASE-2: AiChatbot / newsletterPreview / FeedbackSection
+  'GITHUB_PAT', // PHASE-2: FeedbackSection / AdminPanel / ApiStatus
+  'GITHUB_REPO_NAME',
+  'GITHUB_REPO_OWNER',
+  'GOOGLE_OAUTH_CLIENT_ID',
+  'KILL_FUEL_DAILY_LINKS',
+  'KILL_HEALTH_PREMIUMS_LINKS',
+  'KILL_JOB_MARKET_LINKS',
+  'KILL_ORPHAN_LANDINGS_LINKS',
+  'KILL_WEEKLY_EMPLOYERS_LINKS',
+  'LINKEDIN_SIGNIN_CLIENT_ID',
+  'RECAPTCHA_SITE_KEY',
+  'SEO_SERP_EXPERIMENT_ENABLED',
+  'SEO_SERP_EXPERIMENT_TARGETS',
+  'SEO_SERP_EXPERIMENT_VARIANT',
+  'SEO_SERP_EXPERIMENT_YEAR',
+  'TWELVEDATA_API_KEY', // PHASE-2: exchangeRateService
+];

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -12,7 +12,6 @@ import type { FirebaseApp } from "firebase/app";
 import type { Analytics as FirebaseAnalytics } from "firebase/analytics";
 import type { FirebasePerformance, PerformanceTrace } from "firebase/performance";
 import type { AppCheck } from "firebase/app-check";
-import type { RemoteConfig } from "firebase/remote-config";
 import { reportCaughtError } from '@/services/errorReporter';
 import { isRecaptchaClientReady, type RecaptchaLikeWindow } from '@/services/recaptchaReady';
 
@@ -449,13 +448,19 @@ async function initAppCheck(): Promise<void> {
 }
 
 // Inizializza Remote Config
-let remoteConfig: RemoteConfig | null = null;
+// Browser-safe Remote Config: the client fetches only an allowlisted subset of
+// params from the `getPublicConfig` Cloud Function (functions/src/publicConfig.js)
+// instead of Firebase Remote Config's `fetchAndActivate`, which downloaded the
+// ENTIRE template — every server secret included — into the browser.
+const PUBLIC_CONFIG_ENDPOINT =
+ 'https://europe-west6-frontaliere-ticino.cloudfunctions.net/getPublicConfig';
+
+let publicConfig: Record<string, string> | null = null;
 let rcInitPromise: Promise<void> | null = null;
 
 /**
- * Inizializza Remote Config con valori di default (fallback)
- * Uses a singleton promise to prevent concurrent callers from triggering
- * multiple initializations (race condition that caused 4× log messages).
+ * Carica la configurazione pubblica (allowlist) dalla Cloud Function.
+ * Singleton promise: callers concorrenti condividono un solo fetch.
  */
 function initRemoteConfig(): Promise<void> {
  if (rcInitPromise) return rcInitPromise;
@@ -466,53 +471,30 @@ function initRemoteConfig(): Promise<void> {
 
 async function doInitRemoteConfig(): Promise<void> {
  try {
- const rcMod = await import("firebase/remote-config");
- const supported = await rcMod.isSupported();
- if (!supported) {
- firebaseWarn('⚠️ Remote Config non supportato in questo ambiente');
- return;
+ const res = await fetch(PUBLIC_CONFIG_ENDPOINT, { credentials: 'omit' });
+ if (res.ok) {
+ publicConfig = (await res.json()) as Record<string, string>;
+ console.log('✅ Public config (allowlist) caricata');
+ } else {
+ firebaseWarn(`⚠️ getPublicConfig HTTP ${res.status} — uso default locali`);
  }
-
- remoteConfig = rcMod.getRemoteConfig(await getAppInstance());
- 
- // Valori di default (fallback se Remote Config non disponibile)
- // NO hardcoded secrets here — they must come from Firebase Remote Config
- remoteConfig.defaultConfig = REMOTE_CONFIG_DEFAULTS;
-
- // Impostazioni cache: fetch ogni ora in produzione, ogni 5 minuti in dev
- remoteConfig.settings = {
- minimumFetchIntervalMillis: import.meta.env.MODE === 'production' ? 3600000 : 300000,
- fetchTimeoutMillis: 60000
- };
-
- // Fetch e attiva le configurazioni remote
- await rcMod.fetchAndActivate(remoteConfig);
- console.log('✅ Firebase Remote Config inizializzato e attivato');
  } catch (error) {
- firebaseWarn('⚠️ Errore inizializzazione Remote Config:', error);
+ firebaseWarn('⚠️ Errore caricamento public config:', error);
  reportCaughtError(error, 'firebase.initRemoteConfig');
  console.log('📌 Utilizzo valori di default locali');
  }
 }
 
 /**
- * Ottiene un valore da Remote Config
+ * Ottiene un valore di configurazione dall'allowlist pubblica (o dai default).
  * @param key Nome del parametro da recuperare
  * @returns Valore string del parametro
  */
 export async function getConfigValue(key: string): Promise<string> {
- // Inizializza Remote Config se non ancora fatto
  await initRemoteConfig();
 
- try {
- if (remoteConfig) {
- const { getValue } = await import("firebase/remote-config");
- const value = getValue(remoteConfig, key);
- return value.asString();
- }
- } catch (error) {
- firebaseWarn(`⚠️ Errore recupero config "${key}":`, error);
- reportCaughtError(error, 'firebase.getConfigValue');
+ if (publicConfig && Object.prototype.hasOwnProperty.call(publicConfig, key)) {
+ return publicConfig[key];
  }
 
  if (Object.prototype.hasOwnProperty.call(REMOTE_CONFIG_DEFAULTS, key)) {
@@ -520,7 +502,7 @@ export async function getConfigValue(key: string): Promise<string> {
  if (fallback !== '') {
  return fallback;
  }
- firebaseWarn(`⚠️ Config key "${key}" not available from Remote Config (using empty fallback)`);
+ firebaseWarn(`⚠️ Config key "${key}" not available from public config (using empty fallback)`);
  return '';
  }
 
@@ -529,28 +511,26 @@ export async function getConfigValue(key: string): Promise<string> {
 }
 
 /**
- * Forza il refresh delle configurazioni remote
- * Utile per testing o dopo aggiornamenti critici
+ * Forza il refresh della configurazione pubblica (bypassa la cache edge).
  */
 export async function refreshRemoteConfig(): Promise<boolean> {
  try {
- if (!remoteConfig) {
- await initRemoteConfig();
- }
- if (remoteConfig) {
- const { fetchAndActivate } = await import("firebase/remote-config");
- await fetchAndActivate(remoteConfig);
- console.log('✅ Remote Config aggiornato');
+ const res = await fetch(`${PUBLIC_CONFIG_ENDPOINT}?t=${Date.now()}`, {
+ credentials: 'omit',
+ cache: 'no-store',
+ });
+ if (res.ok) {
+ publicConfig = (await res.json()) as Record<string, string>;
+ console.log('✅ Public config aggiornata');
  return true;
  }
  return false;
  } catch (error) {
- firebaseError('❌ Errore refresh Remote Config:', error);
+ firebaseError('❌ Errore refresh public config:', error);
  reportCaughtError(error, 'firebase.refreshRemoteConfig');
  return false;
  }
 }
-
 /**
  * Verifica se App Check è attivo e funzionante
  */
@@ -568,7 +548,7 @@ export async function ensureAppCheck(): Promise<void> {
 }
 
 // Esporta istanze Firebase
-export { app, analytics, appCheck, remoteConfig };
+export { app, analytics, appCheck };
 
 // Auto-inizializza Remote Config al caricamento del modulo
 // Defer to avoid blocking main thread during page load

--- a/tests/public-config-allowlist.test.ts
+++ b/tests/public-config-allowlist.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { PUBLIC_CONFIG_KEYS } from '../functions/src/publicConfigKeys.js';
+
+/**
+ * Remote Config params that must NEVER reach the browser. `getPublicConfig`
+ * only returns `PUBLIC_CONFIG_KEYS`, so if a refactor adds one of these to the
+ * allowlist this test fails before the secret ships to every visitor.
+ *
+ * (GITHUB_PAT / GEMINI_API_KEY / TWELVEDATA_API_KEY are intentionally still in
+ * the allowlist — PHASE-2 client usage — so they are NOT listed here yet.)
+ */
+const SERVER_ONLY_SECRETS = [
+  'NEWSLETTER_SECRET',
+  'RESEND_API_KEY', 'RESEND_WEBHOOK_SECRET',
+  'MAILGUN_API_KEY', 'MAILGUN_WEBHOOK_SIGNING_KEY',
+  'MAILJET_API_KEY', 'MAILJET_SECRET_KEY',
+  'MAILEROO_API_KEY', 'MAILEROO_WEBHOOK_SECRET',
+  'UNOSEND_API_KEY', 'UNOSEND_WEBHOOK_SECRET',
+  'MAILTRAP_API_TOKEN', 'MAILTRAP_WEBHOOK_SECRET',
+  'CF_API_TOKEN',
+  'SERVER_ADSENSE_CLIENT_SECRET', 'SERVER_ADSENSE_REFRESH_TOKEN',
+  'SERVER_GSC_CLIENT_SECRET', 'SERVER_GSC_REFRESH_TOKEN',
+  'SERVER_FB_PAGE_ACCESS_TOKEN',
+  'SERVER_POSTHOG_PERSONAL_API_KEY',
+  'OPENROUTER_API_KEY', 'GROQ_API_KEY', 'NVIDIA_API_KEY', 'CEREBRAS_API_KEY',
+  'FIREWORKS_API_KEY', 'SAMBANOVA_API_KEY', 'COHERE_API_KEY', 'MISTRAL_API_KEY',
+  'DEEPSEEK_API_KEY', 'TOGETHER_API_KEY', 'FAL_KEY', 'ZAI_API_KEY', 'CHUTES_API_KEY',
+  'HF_TOKEN', 'HUGGINGFACE_API_KEY',
+  'DEEPL_API_KEY', 'DEEPL_API_KEY_2', 'AZURE_TRANSLATOR_KEY', 'AZURE_TRANSLATOR_KEY_2',
+  'LINKEDIN_POST_CLIENT_SECRET', 'LINKEDIN_POST_REFRESH_TOKEN', 'LINKEDIN_POST_ACCESS_TOKEN',
+  'LINKEDIN_SIGNIN_CLIENT_SECRET', 'LINKEDIN_SIGNIN_REFRESH_TOKEN', 'LINKEDIN_SIGNIN_ACCESS_TOKEN',
+  'GOOGLE_MAPS_API_KEY', 'PAGESPEED_API_KEY', 'BING_API_KEY',
+  'TOMTOM_API_KEY', 'HERE_API_KEY', 'PEXELS_API_KEY', 'SERVER_PIXABAY_API_KEY',
+];
+
+describe('public config allowlist', () => {
+  it('exposes no server-only secret to the browser', () => {
+    const leaked = PUBLIC_CONFIG_KEYS.filter((k) => SERVER_ONLY_SECRETS.includes(k));
+    expect(leaked).toEqual([]);
+  });
+
+  it('has no duplicate keys', () => {
+    expect(new Set(PUBLIC_CONFIG_KEYS).size).toBe(PUBLIC_CONFIG_KEYS.length);
+  });
+});


### PR DESCRIPTION
## Contesto
Il client Firebase SDK (`fetchAndActivate`) scaricava l'**intero template Remote Config** nel browser di ogni visitatore (leggibile in IndexedDB), esponendo **~59 secret server** (ESP keys, AdSense/GSC tokens, AI provider keys, CF token, webhook secrets…). Fase 1 di 2: **niente rotazione, RC invariato** — il browser ora scarica **solo una allowlist**.

## Implementato
- **`functions/getPublicConfig`** — HTTP function che ritorna **solo `PUBLIC_CONFIG_KEYS`**, letti server-side via l'esistente `getRemoteConfigValue`. Edge-cached (5 min), **fail-open** (se errore → `{}` → il client usa i suoi default).
- **`functions/src/publicConfigKeys.js`** — l'allowlist (22 param realmente usati dal client), dato puro → unit-testabile.
- **`services/firebase.ts`** — `getConfigValue`/`refreshRemoteConfig` ora leggono l'allowlist da `getPublicConfig`; rimosso l'SDK `firebase/remote-config` (il download dell'intero template). `REMOTE_CONFIG_DEFAULTS` restano come fallback. Bonus: bundle più piccolo (SDK RC non più incluso).
- **`tests/public-config-allowlist.test.ts`** — fallisce se un secret server-only entra nell'allowlist (guard default-deny anti-regressione; validato: 22 chiavi, 0 leak).

**Remote Config, `load-rc-env.mjs` e tutti i ~50 workflow sono INVARIATI** — i secret restano in RC, semplicemente smettono di essere spediti ai browser.

## Non implementato (ancora) — Fase 2
- `GITHUB_PAT` / `GEMINI_API_KEY` / `TWELVEDATA_API_KEY` restano nell'allowlist perché il client li **usa** (feedback→issue GitHub, chatbot Gemini, cambi TwelveData). La Fase 2 proxa quelle chiamate dentro Cloud Functions (il proxy chatbot `handleChatbotInference` esiste già) e le **rimuove dall'allowlist** → browser a zero secret. `GITHUB_PAT` (accesso repo nel browser) è il più urgente.

## Note deploy
- **Ordine**: `getPublicConfig` deve essere live prima/insieme al client. Le Functions auto-deployano in CI. Nella finestra di deploy, se la CF è irraggiungibile, `getConfigValue` usa i default (`ENABLE_JOB_ALERTS='false'` ecc.) → degradazione transiente fail-safe, non errore.
- Verifica live post-deploy: `curl https://europe-west6-frontaliere-ticino.cloudfunctions.net/getPublicConfig` deve ritornare i 22 param (nessun secret), e in IndexedDB non deve più comparire il template RC completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)