### PR TITLE
fix(crawlers): Hirslanden tile-layout parser + thin/migrated crawler health exempts

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -127,6 +127,26 @@ const EMPTY_OK_CRAWLERS = new Set([
   // correctly filters them as non-Swiss; same legitimately-empty regional-filter
   // case as manor and alten-switzerland. Re-arms when a CH listing appears.
   'fusalp',
+  // Bracco Suisse S.A.: the Workday API (bracco.wd103.myworkdayjobs.com) returns
+  // 100+ jobs globally but currently 0 at the two Swiss sites the crawler is
+  // scoped to (Cadempino TI + Plan-les-Ouates GE — location facets verified
+  // returning total:0). A small medical-imaging subsidiary legitimately has no
+  // Swiss openings for weeks; parser is healthy and re-arms when a CH role
+  // appears. Same regional-filter case as manor/alten-switzerland.
+  'bracco',
+  // Schweizer Paraplegiker-Gruppe (Umantis tenant 2782) and Universitäre
+  // Psychiatrische Dienste Bern / UPD (Umantis tenant 2908): both listing
+  // endpoints (/Jobs/All) still return ~10 jobs, but the per-job detail URLs
+  // (/Vacancies/{id}/Description/*) now 3xx-redirect cross-host — the tenants
+  // migrated their job descriptions off Umantis (issue #1245). The shared
+  // umantis parser correctly QUARANTINES every dead-detail job (it refuses to
+  // synthesise boilerplate that would trip the dataset boilerplate-guard) and
+  // emits 0 — the accepted degraded state for a migrated source, NOT a parser
+  // break. Re-arms automatically if the tenant restores Umantis detail pages.
+  // Real fix (per-tenant public-site description extraction) is deferred in
+  // #1245 as fragile/per-tenant.
+  'paraplegie',
+  'upd',
 ]);
 
 /** Read JSON file, return null on any error. */

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -117,12 +117,30 @@ export function parseLocation(raw = '') {
 /* ── Listing page parser ──────────────────────────────────── */
 
 /**
- * Parse the SuccessFactors / j2w search-results HTML table.
- * Each row links to a detail page at /Hirslanden/job/.../{jobId}/.
+ * Parse the SuccessFactors / j2w search-results page.
+ *
+ * Hirslanden's careers.mediclinic.com instance has migrated from the legacy
+ * `<tr>/<td>` table layout to the newer div-based "tile" layout where each
+ * listing is an `<a class="jobTitle-link" href="/Hirslanden/job/.../{jobId}/">`
+ * with the location in a sibling `section-customfield5-value` block. We parse
+ * the table layout first (older j2w skins still emit it) and, when no table
+ * rows yield a job, fall back to the tile layout so a SF skin swap does not
+ * silently zero the crawler.
+ *
  * Returns array of { title, url, location, postedDate, jobId }.
  */
 export function parseSearchResults(html) {
   if (!html || typeof html !== 'string') return [];
+  const fromTable = parseSearchResultsTable(html);
+  if (fromTable.length > 0) return fromTable;
+  return parseSearchResultsTiles(html);
+}
+
+/**
+ * Legacy table-row layout: each job is a `<tr>` with a `/Hirslanden/job/...`
+ * link plus Title | Location | Date cells.
+ */
+function parseSearchResultsTable(html) {
   const jobs = [];
   const seen = new Set();
 
@@ -166,6 +184,52 @@ export function parseSearchResults(html) {
       url: fullUrl,
       location,
       postedDate,
+      jobId,
+    });
+  }
+  return jobs;
+}
+
+/**
+ * Newer div-based "tile" layout (current careers.mediclinic.com skin):
+ *   <a class="jobTitle-link" ... href="/Hirslanden/job/{slug}/{jobId}/"> Title </a>
+ *   ... <div id="job-{jobId}-...-customfield5-value"> Ort </div>
+ * Each job repeats across desktop/tablet/mobile tile variants, so dedup by
+ * jobId. The location lives in a `customfield5-value` div keyed by the jobId.
+ */
+function parseSearchResultsTiles(html) {
+  const jobs = [];
+  const seen = new Set();
+
+  const linkRe =
+    /<a[^>]+class="[^"]*jobTitle-link[^"]*"[^>]*href="(\/Hirslanden\/job\/[^"]+\/(\d+)\/?)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = linkRe.exec(html)) !== null) {
+    const relUrl = m[1].replace(/&amp;/g, '&');
+    const jobId = m[2];
+    if (seen.has(jobId)) continue;
+    seen.add(jobId);
+
+    const rawTitle = normalizeSpace(stripHtml(m[3]));
+    const title = rawTitle
+      .replace(/^(?:Title|Titre|Bezeichnung|Titolo|Titulo)\s*:\s*/i, '')
+      .trim();
+    if (!title || title.length < 3) continue;
+
+    // Location: `customfield5-value` div keyed by this jobId ("Ort" field).
+    let location = '';
+    const locRe = new RegExp(
+      `<div[^>]+id="job-${jobId}-[^"]*customfield5-value"[^>]*>([\\s\\S]*?)<\\/div>`,
+      'i',
+    );
+    const locMatch = html.match(locRe);
+    if (locMatch) location = normalizeSpace(stripHtml(locMatch[1]));
+
+    jobs.push({
+      title,
+      url: `${BASE_URL}${relUrl}`,
+      location,
+      postedDate: '',
       jobId,
     });
   }

--- a/tests/hirslanden-crawler.test.ts
+++ b/tests/hirslanden-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   HIRSLANDEN_COMPANY_NAME,
   isHirslandenJob,
   isTrustedDomain,
+  parseSearchResults,
 } from '../scripts/lib/hirslanden-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -124,6 +125,55 @@ describe('Hirslanden Klinik crawler parser', () => {
 
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  // ── parseSearchResults: layout handling ──
+  describe('parseSearchResults', () => {
+    it('parses the legacy <tr>/<td> table layout', () => {
+      const html = `
+        <table>
+          <tr>
+            <td><a href="/Hirslanden/job/Some-Role-Zurich-8008/111/">Dipl. Pflegefachfrau</a></td>
+            <td>Zürich</td>
+            <td>2026-06-01</td>
+          </tr>
+        </table>`;
+      const jobs = parseSearchResults(html);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].jobId).toBe('111');
+      expect(jobs[0].title).toBe('Dipl. Pflegefachfrau');
+      expect(jobs[0].location).toBe('Zürich');
+      expect(jobs[0].url).toContain('/Hirslanden/job/Some-Role-Zurich-8008/111/');
+    });
+
+    it('falls back to the div-based tile layout (current SF skin)', () => {
+      // careers.mediclinic.com migrated away from <tr> rows to job tiles.
+      const html = `
+        <div class="job-row">
+          <span class="section-title title" role="heading">
+            <a class="jobTitle-link fontcolorc63bfd23" data-focus-tile=".job-id-1293595201"
+               href="/Hirslanden/job/Hirslanden-Klinik-St_-Anna-Luze-6003/1293595201/">
+               Dipl. Expertin / Experte Anästhesiepflege NDS (a) 80-100%
+            </a>
+          </span>
+          <div id="job-1293595201-desktop-section-customfield5-value">Luzern</div>
+          <!-- tablet variant repeats the same job -->
+          <a class="jobTitle-link" href="/Hirslanden/job/Hirslanden-Klinik-St_-Anna-Luze-6003/1293595201/">
+            Dipl. Expertin / Experte Anästhesiepflege NDS (a) 80-100%
+          </a>
+        </div>`;
+      const jobs = parseSearchResults(html);
+      expect(jobs).toHaveLength(1); // deduped across tile variants
+      expect(jobs[0].jobId).toBe('1293595201');
+      expect(jobs[0].title).toContain('Anästhesiepflege');
+      expect(jobs[0].location).toBe('Luzern');
+      expect(jobs[0].url).toContain('/Hirslanden/job/');
+    });
+
+    it('returns empty array for HTML with no job links', () => {
+      expect(parseSearchResults('<div>Keine Ergebnisse</div>')).toEqual([]);
+      expect(parseSearchResults('')).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Implementato

Resolves 4 of the 5 open broken-crawler issues. Per-crawler triage with live evidence:

### Hirslanden #1500 — real selector break, FIXED
`careers.mediclinic.com` (SuccessFactors j2w) migrated its search results from the legacy `<tr>/<td>` table to a **div-based "tile" layout** (`<a class="jobTitle-link" href="/Hirslanden/job/.../{jobId}/">` + location in a `section-customfield5-value` div). The table-only `parseSearchResults` matched 0 rows → 0 jobs even though the page serves ~50 live listings/page (the CI `fetch failed` was a separate transient runner-network blip; the source returns HTTP 200 and the parse was the real failure once connectivity worked).

- Refactored `parseSearchResults` → tries `parseSearchResultsTable` (legacy), then falls back to new `parseSearchResultsTiles` when the table yields nothing.
- **Live-verified:** 50 unique jobs/page with correct titles + locations (Luzern, Zürich, Aarau, Genève, Bern); end-to-end run reached detail-page enrichment with real DE/FR descriptions extracted.
- Added 3 vitest cases (table layout, tile layout w/ dedup across desktop/tablet variants, empty HTML).

**Class-fix grep (AGENTS.md #6):** grepped all SF-j2w siblings (`jobTitle-link` / shared `successfactors-shared-job-parser-common.mjs` users). All other SF crawlers still emit the `<tr>` table layout and are health-confirmed with jobs (bachem 93, hoch-health 219, usz 202, tertianum 239, etc.). Only Hirslanden's `careers.mediclinic.com` skin swapped to tiles, so the fix is correctly scoped to its own parser; the shared parser's working behavior is untouched.

### bracco #1534 — thin-source, working-as-intended → EMPTY_OK exempt
Workday API returns 109 jobs globally but **0 at the 2 Swiss sites** the crawler is scoped to (Cadempino TI + Plan-les-Ouates GE — verified by POSTing the exact location facets the crawler uses → `total: 0`). Legitimately-empty regional filter, same class as the existing `manor`/`alten-switzerland` exempts. Added to `EMPTY_OK_CRAWLERS`.

### paraplegie #1493 & upd #1535 — Umantis migration (#1245), accepted degraded state → EMPTY_OK exempt
Both Umantis listings (`/Jobs/All`) still return ~10 jobs, but **all per-job detail URLs now 3xx-redirect cross-host** (tenants migrated descriptions off Umantis). Ran both parsers in isolation: `Quarantined 10/10 job(s): detail URL deprecated ... Emitting 0 jobs (no hard failure)`. This is the shared umantis parser working exactly as designed by #1245 — it refuses to synthesise boilerplate that would trip the dataset boilerplate-guard. Not a parser break; it re-arms automatically if the tenants restore Umantis detail pages. Added both to `EMPTY_OK_CRAWLERS` (paraplegie 2782, upd 2908) so they stop re-flagging as broken.

Tests: `tests/hirslanden-crawler.test.ts` + `tests/scripts/check-crawler-health.test.ts` → 34 passed.

## Non implementato (ancora)

- **giardino #1578** — NOT in this PR. It is **recovered** (no code change needed): running the parser live now returns 2 in-scope Ticino jobs (Commis/Chef de Rang, classified Ascona/TI). The 0-job streak was a transient WordPress-API blip. Closed directly via `gh issue close` with evidence rather than carrying a no-op code change.
- **Umantis per-tenant public-site description extraction (#1245 real fix)** — deferred there as fragile/per-tenant; out of scope. paraplegie/upd are exempted from the health gate, not functionally restored. Revert-trigger: if either tenant restores Umantis detail pages, remove the exempt so the empty-streak gate re-arms.

Closes #1500
Closes #1534
Closes #1493
Closes #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)