### PR TITLE
fix(ci): raise measure-deploy-delta timeout 30→90min to unblock samples>0 churn measurement (#1633 item 1)

### DIFF
--- a/.github/workflows/measure-deploy-delta.yml
+++ b/.github/workflows/measure-deploy-delta.yml
@@ -33,7 +33,12 @@ concurrency:
 jobs:
   delta:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # `samples>0` adds two extra full streaming passes over BOTH ~1.4GB tars
+    # (extract_members) on top of the two manifest sha1 passes — ~327k members
+    # ×2 archives overran the old 30-min cap (samples=0 fit; samples>0 timed
+    # out, blocking the post-fix churn measurement — #1633 item 1). Raised so
+    # the sample-diff path can complete; still bounded against a runaway job.
+    timeout-minutes: 90
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Implementato
Completa l'**Item 1** della follow-up #1633 (l'unico item ancora aperto: l'Item 2 — migrazione `dateModified`/`datePublished` → `buildDayStampIso()` su `healthPremiumsLandingPlugin.ts` + `weeklyEmployersPlugin.ts` — è già su `main` via #1640, MERGED).

- **`.github/workflows/measure-deploy-delta.yml`**: `timeout-minutes` 30 → **90**.
- **Perché**: il job esegue `scripts/measure-dist-delta.py` su due artifact `github-pages` (tar ~1.4GB ciascuno). Con `samples=0` fa due passate di streaming-sha1 (`manifest`) sui due tar e rientra nei 30 min. Con `samples>0` aggiunge **due ulteriori passate complete** sui due tar (`extract_members`, una per archivio) per estrarre i file campione da diffare → su ~327k member ×2 archivi sfora il cap di 30 min e il job veniva killato. Questo bloccava la **misura quantitativa post-merge** del taglio di churn introdotto da #1632 (l'unico modo per validare l'effetto SEO del fix). Il default `samples` è già `"10"`, quindi il path di sampling è già abilitato: ora ha tempo di completare.
- Cambiamento workflow-only, nessun simbolo applicativo toccato (no impact analysis necessaria). YAML validato (`yaml.safe_load` OK).

**Nota auth**: l'Item 1 era stato deferito in #1633 perché l'ambiente `issue-fix` (GitHub App `GH_TOKEN`) non ha lo scope `workflows` e non può pushare file sotto `.github/workflows/**`. Questo PR è creato in sessione interattiva con token che ha lo scope `workflows` → push del file workflow riuscito.

## Non implementato (ancora)
- **Run quantitativa effettiva post-merge**: alzato il timeout, ma la run vera e propria di `measure-deploy-delta` con `samples>0` su due build data-only va lanciata post-merge (`gh workflow run measure-deploy-delta.yml`); il risultato (delta file/byte) è osservabile solo a valle di due deploy. Non bloccante per questo PR (l'abilitazione è il deliverable; la misura è una run on-demand).
- **Riduzione costo `extract_members`** (le due passate extra sui tar): fuori scope — l'issue chiede esplicitamente di **alzare il timeout** per sbloccare la misura, non di riarchitettare lo script. Il cap 90min resta bounded contro un job runaway.
- **fuel/border/weather** (`fuelDailyPagesPlugin`, `borderWaitPagesPlugin`, `weather*PagesPlugin`): skip confermato dal reviewer di #1632 — churn dominato dai dati live, granularità del timestamp moot. Già documentato in #1640.

Closes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)