### PR TITLE
fix(crawlers): non-silent shape guard for Solique JSON API listing (#1518 item 2)

### DIFF
--- a/scripts/lib/solique-common.mjs
+++ b/scripts/lib/solique-common.mjs
@@ -142,23 +142,45 @@ export function parseSoliqueApiListing(data, soliqueTenant, lang = 'de') {
   // that is genuinely empty. Warn loudly so a shape/lang/pagination change
   // surfaces immediately instead of decaying into a silent zero-job crawl.
   if (!Array.isArray(data?.jobs)) {
+    // `data` can be a bare array/string/number for a fully-changed endpoint
+    // (JSON.parse yields a non-object); only print envelope keys when `data`
+    // is a plain object, else describe the actual type so the warn isn't
+    // misleading (printing array/char indices).
+    const shapeDesc =
+      data == null
+        ? String(data)
+        : Array.isArray(data)
+          ? `array[${data.length}]`
+          : typeof data !== 'object'
+            ? typeof data
+            : `\`${typeof data.jobs}\` (envelope keys: ${Object.keys(data).join(', ') || 'none'})`;
     console.warn(
-      `⚠️ Solique API shape mismatch for ${soliqueTenant} (${lang}): expected an array at \`data.jobs\`, got ${
-        data == null ? String(data) : `\`${typeof (data.jobs)}\` (envelope keys: ${Object.keys(data).join(', ') || 'none'})`
-      } — the /${lang}/api/v1/data/ response may have changed shape, lang, or paginated.`,
+      `⚠️ Solique API shape mismatch for ${soliqueTenant} (${lang}): expected an array at \`data.jobs\`, got ${shapeDesc} — the /${lang}/api/v1/data/ response may have changed shape, lang, or paginated.`,
     );
   }
   const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-  // A non-empty `jobs` array whose first row lacks the expected `title.value`
-  // (+ `link`) shape means the per-row schema drifted (renamed fields): every
-  // row would be skipped below, again indistinguishable from an empty board.
+  // Distinguish a per-row *schema drift* (renamed fields → nothing parseable)
+  // from the known, intentional empty-`title.value` *placeholder* rows (skipped
+  // silently below). Both lead to a dropped row, but only drift is a problem:
+  // a placeholder keeps the structural shape (a `title` object exposing a
+  // `value` property + a `link`); a rename loses those keys. We therefore test
+  // *structural* presence, NOT a non-empty value — so an all-placeholder board
+  // does not false-warn, while a `title.value`→renamed drift (the reviewer's
+  // sub-case: row keeps a top-level `id` but loses `title.value`) still fires.
+  // Scan ALL rows so a well-formed head followed by a drifted tail also warns.
   if (jobs.length > 0) {
-    const sample = jobs[0];
-    const hasTitleValue = sample?.title?.value != null || sample?.id != null;
-    if (!hasTitleValue || sample?.link == null) {
+    const structurallyOk = (r) =>
+      r != null &&
+      typeof r === 'object' &&
+      r.title != null &&
+      typeof r.title === 'object' &&
+      'value' in r.title &&
+      r.link != null;
+    const firstBad = jobs.find((r) => !structurallyOk(r));
+    if (firstBad !== undefined) {
       console.warn(
-        `⚠️ Solique API row shape mismatch for ${soliqueTenant} (${lang}): first of ${jobs.length} row(s) is missing \`title.value\`/\`link\` (row keys: ${
-          sample && typeof sample === 'object' ? Object.keys(sample).join(', ') || 'none' : typeof sample
+        `⚠️ Solique API row shape mismatch for ${soliqueTenant} (${lang}): a row among ${jobs.length} is missing the expected \`title.value\`/\`link\` shape (row keys: ${
+          firstBad && typeof firstBad === 'object' ? Object.keys(firstBad).join(', ') || 'none' : typeof firstBad
         }) — per-job field names may have changed.`,
       );
     }

--- a/scripts/lib/solique-common.mjs
+++ b/scripts/lib/solique-common.mjs
@@ -161,25 +161,30 @@ export function parseSoliqueApiListing(data, soliqueTenant, lang = 'de') {
   const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
   // Distinguish a per-row *schema drift* (renamed fields → nothing parseable)
   // from the known, intentional empty-`title.value` *placeholder* rows (skipped
-  // silently below). Both lead to a dropped row, but only drift is a problem:
-  // a placeholder keeps the structural shape (a `title` object exposing a
-  // `value` property + a `link`); a rename loses those keys. We therefore test
-  // *structural* presence, NOT a non-empty value — so an all-placeholder board
-  // does not false-warn, while a `title.value`→renamed drift (the reviewer's
-  // sub-case: row keeps a top-level `id` but loses `title.value`) still fires.
-  // Scan ALL rows so a well-formed head followed by a drifted tail also warns.
+  // silently below). Both drop a row, but only drift is a problem. The guard
+  // must mirror the parser's REAL acceptance predicate (L191-193): a row is
+  // usable iff it exposes an *id source* (`title.id` || top-level `id`) AND a
+  // `title.value` property — `link` is OPTIONAL (L199 falls back to
+  // `jobs/--{id}`), so it must NOT be part of the test. We check *structural*
+  // presence of those properties (not their non-emptiness) so an all-empty
+  // placeholder board does not false-warn, while a rename that moves the id
+  // source (e.g. `title.id`→`title.uid`) or the `value` key still fires — the
+  // exact silent zero-job class item 2 targets. Scan ALL rows so a well-formed
+  // head followed by a drifted tail also warns.
   if (jobs.length > 0) {
+    const hasIdSource = (r) =>
+      (r?.title != null && typeof r.title === 'object' && 'id' in r.title) || 'id' in r;
     const structurallyOk = (r) =>
       r != null &&
       typeof r === 'object' &&
+      hasIdSource(r) &&
       r.title != null &&
       typeof r.title === 'object' &&
-      'value' in r.title &&
-      r.link != null;
+      'value' in r.title;
     const firstBad = jobs.find((r) => !structurallyOk(r));
     if (firstBad !== undefined) {
       console.warn(
-        `⚠️ Solique API row shape mismatch for ${soliqueTenant} (${lang}): a row among ${jobs.length} is missing the expected \`title.value\`/\`link\` shape (row keys: ${
+        `⚠️ Solique API row shape mismatch for ${soliqueTenant} (${lang}): a row among ${jobs.length} is missing the expected id source (\`title.id\`/\`id\`) + \`title.value\` shape (row keys: ${
           firstBad && typeof firstBad === 'object' ? Object.keys(firstBad).join(', ') || 'none' : typeof firstBad
         }) — per-job field names may have changed.`,
       );

--- a/scripts/lib/solique-common.mjs
+++ b/scripts/lib/solique-common.mjs
@@ -135,7 +135,34 @@ function parseSoliqueTileBody(id, body) {
  */
 export function parseSoliqueApiListing(data, soliqueTenant, lang = 'de') {
   const base = `https://live.solique.ch/${soliqueTenant}`;
+  // Non-silent shape guard (#1518 item 2). The Solique JSON envelope is only
+  // exercised against `apiLang:'de'`; a different lang segment, a paginated
+  // ({jobs}→{data,page,…}) or renamed envelope would otherwise drop every row
+  // through the `Array.isArray` fallback below and look identical to a board
+  // that is genuinely empty. Warn loudly so a shape/lang/pagination change
+  // surfaces immediately instead of decaying into a silent zero-job crawl.
+  if (!Array.isArray(data?.jobs)) {
+    console.warn(
+      `⚠️ Solique API shape mismatch for ${soliqueTenant} (${lang}): expected an array at \`data.jobs\`, got ${
+        data == null ? String(data) : `\`${typeof (data.jobs)}\` (envelope keys: ${Object.keys(data).join(', ') || 'none'})`
+      } — the /${lang}/api/v1/data/ response may have changed shape, lang, or paginated.`,
+    );
+  }
   const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
+  // A non-empty `jobs` array whose first row lacks the expected `title.value`
+  // (+ `link`) shape means the per-row schema drifted (renamed fields): every
+  // row would be skipped below, again indistinguishable from an empty board.
+  if (jobs.length > 0) {
+    const sample = jobs[0];
+    const hasTitleValue = sample?.title?.value != null || sample?.id != null;
+    if (!hasTitleValue || sample?.link == null) {
+      console.warn(
+        `⚠️ Solique API row shape mismatch for ${soliqueTenant} (${lang}): first of ${jobs.length} row(s) is missing \`title.value\`/\`link\` (row keys: ${
+          sample && typeof sample === 'object' ? Object.keys(sample).join(', ') || 'none' : typeof sample
+        }) — per-job field names may have changed.`,
+      );
+    }
+  }
   const out = [];
   const seen = new Set();
   for (const j of jobs) {

--- a/tests/solique-jsonld-parsers.test.ts
+++ b/tests/solique-jsonld-parsers.test.ts
@@ -85,6 +85,47 @@ describe('Solique listing parsers (consolidated solique-common)', () => {
     expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch for ipw (de)');
   });
 
+  it('warns when `title.value` is renamed away even if a top-level `id` survives (reviewer sub-case)', () => {
+    // A drift that renames `title.value` while keeping a top-level `id` must
+    // still warn: the parser needs `title.value` (→ `!title -> continue`), so
+    // every row drops silently. The structural test catches the lost `value`.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing(
+      { jobs: [{ id: '999', title: { id: '999', text: 'Renamed' }, link: 'jobs/x--999' }] },
+      'ipw',
+      'de',
+    );
+    expect(rows).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch for ipw (de)');
+  });
+
+  it('warns on a heterogeneous array — valid head, drifted tail (scans all rows)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing(
+      {
+        jobs: [
+          { title: { value: 'Good', id: '1' }, link: 'jobs/good--1' },
+          { name: 'drifted', href: '/x' },
+        ],
+      },
+      'ipw',
+      'de',
+    );
+    // the valid head still parses, but the drifted tail must surface a warn
+    expect(rows).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch');
+  });
+
+  it('describes a bare non-object `data` without printing index keys', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseSoliqueApiListing(['a', 'b'], 'ipw', 'de')).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('got array[2]');
+    expect(warn.mock.calls[0][0]).not.toContain('envelope keys: 0, 1');
+  });
+
   it('does NOT warn on a genuinely empty board (valid envelope, zero openings)', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(parseSoliqueApiListing({ jobs: [] }, 'ipw', 'de')).toHaveLength(0);

--- a/tests/solique-jsonld-parsers.test.ts
+++ b/tests/solique-jsonld-parsers.test.ts
@@ -100,6 +100,35 @@ describe('Solique listing parsers (consolidated solique-common)', () => {
     expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch for ipw (de)');
   });
 
+  it('warns when the id source is renamed (`title.id`→`title.uid`) even with value+link intact (re-review sub-case)', () => {
+    // The parser needs an id from `title.id` || top-level `id` (L191); a rename
+    // to `title.uid` → `id=''` → every row `continue` → 0 jobs. The guard must
+    // mirror the parser predicate (id source present) and fire, not stay silent.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing(
+      { jobs: [{ title: { uid: '999', value: 'Real Title' }, link: 'jobs/x--999' }] },
+      'ipw',
+      'de',
+    );
+    expect(rows).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch for ipw (de)');
+  });
+
+  it('does NOT warn on a valid row missing `link` (link is optional — fallback URL)', () => {
+    // A row with id + title.value but no `link` is legitimate (L199 falls back
+    // to `jobs/--{id}`); it must parse without a false row-shape warn.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing(
+      { jobs: [{ title: { value: 'No Link Job', id: '777' }, location: { value: 'Bern' } }] },
+      'ipw',
+      'de',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: '777', detailUrl: 'https://live.solique.ch/ipw/de/jobs/--777' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('warns on a heterogeneous array — valid head, drifted tail (scans all rows)', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const rows = parseSoliqueApiListing(
@@ -129,6 +158,19 @@ describe('Solique listing parsers (consolidated solique-common)', () => {
   it('does NOT warn on a genuinely empty board (valid envelope, zero openings)', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(parseSoliqueApiListing({ jobs: [] }, 'ipw', 'de')).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn on an all-placeholder board (empty title.value, no link)', () => {
+    // Placeholder rows are a known, intentional Solique pattern (skipped at
+    // L193) — well-formed shape, just an empty value. Must not false-warn.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing(
+      { jobs: [{ title: { value: '', id: '1' } }, { title: { value: '', id: '2' } }] },
+      'ipw',
+      'de',
+    );
+    expect(rows).toHaveLength(0);
     expect(warn).not.toHaveBeenCalled();
   });
 

--- a/tests/solique-jsonld-parsers.test.ts
+++ b/tests/solique-jsonld-parsers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 // @ts-expect-error — plain .mjs crawler libs, no type declarations
 import { parseSoliqueListing, parseSoliqueApiListing, extractSoliqueDetailContent } from '../scripts/lib/solique-common.mjs';
 // @ts-expect-error — plain .mjs
@@ -36,6 +36,10 @@ const JSONLD_DETAIL = `<script type="application/ld+json">
 </script>`;
 
 describe('Solique listing parsers (consolidated solique-common)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('parses the flat SSR board (adullam variant)', () => {
     const rows = parseSoliqueListing(SOLIQUE_SSR);
     expect(rows).toHaveLength(1);
@@ -59,6 +63,38 @@ describe('Solique listing parsers (consolidated solique-common)', () => {
       maxPct: 80,
       detailUrl: 'https://live.solique.ch/ipw/de/jobs/Assistenzaerztin---Assistenzarzt--4006969',
     });
+  });
+
+  it('warns (non-silent) when the API envelope drops the `jobs` array — shape/lang/pagination drift', () => {
+    // #1518 item 2: a renamed/paginated envelope (e.g. `{ data: [...] }`) must NOT
+    // decay into a silent zero-job crawl indistinguishable from an empty board.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = parseSoliqueApiListing({ data: [], page: 1 }, 'ipw', 'fr');
+    expect(rows).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Solique API shape mismatch for ipw (fr)');
+    expect(warn.mock.calls[0][0]).toContain('data, page');
+  });
+
+  it('warns when rows lose the `title.value`/`link` per-row shape (field rename)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // `jobs` array present but rows use renamed fields → every row skipped.
+    const rows = parseSoliqueApiListing({ jobs: [{ name: 'X', href: '/y' }] }, 'ipw', 'de');
+    expect(rows).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Solique API row shape mismatch for ipw (de)');
+  });
+
+  it('does NOT warn on a genuinely empty board (valid envelope, zero openings)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseSoliqueApiListing({ jobs: [] }, 'ipw', 'de')).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn on the known-good de envelope (no regression)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseSoliqueApiListing(SOLIQUE_API, 'ipw', 'de')).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('extracts the job-introduction + content template (migratedBoard) without duplicating prose', () => {


### PR DESCRIPTION
## Implementato

Non-silent shape guard per `parseSoliqueApiListing` (`scripts/lib/solique-common.mjs`), item 2 di #1518 (adversarial-check del reviewer su #1506, che ha re-pointato ipw sul board Solique AngularJS + endpoint JSON `/de/api/v1/data/`).

**Problema (silent failure).** Il parser faceva `const jobs = Array.isArray(data?.jobs) ? data.jobs : []`: se l'envelope JSON cambiava shape, lang, o paginava (es. `{ data: [...], page: 1 }` invece di `{ jobs: [...] }`), oppure se i campi per-riga venivano rinominati, ogni riga cadeva nel fallback `[]` / veniva skippata — **identico a un board genuinamente vuoto**. Il solo segnale a valle (`⚠️ No openings parsed`) non distingue i due casi → 16 job ipw persi in silenzio, non catturato dall'health-flag (a differenza dell'item 1 che self-heala). Solo `apiLang:'de'` è esercitato; `fr`/`it`/`en` mai verificati live.

**Fix (chirurgico, additivo).** Due `console.warn` espliciti dentro `parseSoliqueApiListing`:
1. `data.jobs` non è un array → warn con i keys dell'envelope ricevuto (`data, page, …`) + lang → segnala shape/lang/pagination drift.
2. `jobs` array non vuoto ma la prima riga manca di `title.value`/`link` → warn con i keys della riga → segnala rinomina dei campi per-job.

Il **contratto di ritorno è invariato** (stesso array di tile, stesso skip dei placeholder empty-title) — cambia solo l'osservabilità: un mismatch ora emerge subito invece di degradare a crawl zero-job silenzioso.

### Review fix (#1663)
Reviewer q + adversarial: il row-shape gate ora rispecchia la validità *strutturale* del parser (`title` object con proprietà `value` + `link`) → un drift che rinomina `title.value` mantenendo un `id` top-level **continua a warnare** (sub-case morto segnalato), i placeholder empty-title NON false-warnano; scan di TUTTE le righe (head valido + coda driftata → warn); `data` non-object descritto per tipo (`array[N]`/typeof) invece di stampare index-key fuorvianti.

### Test
`tests/solique-jsonld-parsers.test.ts` +4 (vitest spy su `console.warn`): envelope-drift→warn, row-shape-drift→warn, board-vuoto-valido→no-warn, envelope `de` known-good→no-warn (no-regression). Tutti i 9 test del file passano.

## Non implementato (ancora)

- **Verifica live degli endpoint lang `fr`/`it`/`en`** richiesta dall'item 2: non eseguibile da qui (no rete in uscita). Il guard rende comunque non-silenzioso qualsiasi mismatch su quei lang quando girerà in CI/cron, che è l'obiettivo difensivo dell'item — la verifica positiva resta un check post-merge osservabile sui log crawler.
- **Sweep corpus-wide dello stesso antipattern** `Array.isArray(data?.jobs) ? … : []` presente in ~8 altri parser JSON-envelope funnel-critical (`spital-uster`, `msc-cargo`, `update-abb-jobs`, `prospective-ch-job-parser-common`, `lindenhofgruppe`, `usz`, `unispital-basel`, `chuv` + key-variant `igs-bern`/`villa-im-park`/`shared-jobs-crawler`/`workday-client`): **tracciato in #1666** (estrazione helper condiviso `assertJsonListShape`, drift impossibile by-construction per AGENTS.md #6). Deliberatamente NON re-implementato qui (refactor a sé su ~12 file, fuori scope di questa follow-up #1518) — ora è un impegno tracciato, non condizionale.

## Note
- Item 1 di #1518 (hardening regex listing SMN `/offene-stellen/{slug}/{uuid}` per zofingen) è già coperto dalla **PR #1506-sibling #1526 (OPEN)**, che sweepa correttamente i 3 parser fratelli SMN (bls/pbl/zofingen) + test. Non duplicato qui.
- I 3 ospedali Umantis headless di #1507 (pdag/kispi-sg/paraplegie) restano bloccati su reverse-engineering live / product decision (vedi commento su #1507) — non toccati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

