### PR TITLE
fix(deploy): offload CDN/data refs BEFORE locale-shard push (cut CF Worker req ~90%)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -796,6 +796,23 @@ jobs:
           fi
           rm -f "$keyfile"
 
+      # Rewrite dist HTML asset refs → CDN + inject window.__CDN_DATA_BASE__ BEFORE
+      # the locale-shard push below, NOT after. The shards (frontaliere-{en,de,fr})
+      # carry ONLY the locale HTML trees — no /assets /data /og dirs — so any
+      # same-origin /assets|/data|/og ref a shard page keeps would 404 on its shard
+      # origin and is salvaged only by an extra Cloudflare Worker subrequest per
+      # asset (~10/page) → burns the free-tier 100k req/day cap. Running this offload
+      # pass first bakes CDN-absolute URLs (+ __CDN_DATA_BASE__) into dist/en|de|fr so
+      # the shard HTML matches the IT artifact: the browser fetches assets straight
+      # from the CDN and the Worker only proxies the page HTML. It also lets Guard B
+      # below drop dist/assets (no surviving same-origin ref in dist/en|de|fr now),
+      # shrinking the main artifact. CDN_BASE was exported by the CDN push step above
+      # (env persists to later steps), so the rewrite targets are already live.
+      - name: Offload og refs + data base into dist (non-fatal)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: node scripts/offload-generated-images-cdn.mjs
+
       # ── Locale shard offload (en/de/fr → frontaliere-{loc} / Pages) ───────
       # Each non-primary locale subtree (dist/en, dist/de, dist/fr) is a
       # self-contained top-level dir. Push each to its OWN GitHub Pages repo
@@ -915,11 +932,6 @@ jobs:
         env:
           CDN_DEPLOY_KEY: ${{ secrets.CDN_DEPLOY_KEY }}
         run: node scripts/ci/prune-cdn-assets.mjs
-
-      - name: Offload og refs + data base into dist (non-fatal)
-        if: github.event.inputs.profile_sequential != 'true'
-        continue-on-error: true
-        run: node scripts/offload-generated-images-cdn.mjs
 
       # Boot-critical asset offload. The build already rebased Vite asset URLs to
       # the CDN (ASSET_CDN/renderBuiltUrl) → the artifact's HTML/JS point at


### PR DESCRIPTION
## Problem (live-diagnosed)

Cloudflare free Workers cap = **100k req/day**. The locale-router Worker proxies `/en /de /fr` to shard repos + has fallback routes `/assets|/data|/og`. Live checks:

| Page | same-origin `/assets` refs | CDN-absolute refs | `__CDN_DATA_BASE__` |
|------|---------------------------|-------------------|---------------------|
| IT `/` | **0** | 9 | yes |
| `/en/` `/de/` `/fr/` | **10** | 0 | **no** |

So every en/de/fr pageview = ~1 (HTML) + ~10 (`/assets/*` proxied to CDN) + runtime `/data` fetches = **~11–20 Worker invocations**, vs ~0 for IT (95% traffic). The asset fan-out on shard pages is what burns the cap.

## Root cause

`scripts/offload-generated-images-cdn.mjs` walks the **whole** `dist/` and rewrites `/assets→CDN` + injects `window.__CDN_DATA_BASE__`. It's also what makes the IT static pages CDN-correct (they start same-origin from `staticPagesPlugin`'s hardcoded `/assets/` prefix). But in `deploy.yml` it ran **after** the locale-shard push:

`Push generated assets to CDN (710)` → `Push locale shards (816)` → … → `Offload (922)`

→ shards were snapshotted **pre-rewrite** (same-origin, no `__CDN_DATA_BASE__`); the IT artifact, packed after offload, got CDN URLs. Pure step-ordering divergence.

## Implementato

- Moved the `Offload og refs + data base into dist` step to **before** the locale-shard push (now `710 → Offload(811) → shards(833)`). `dist/en|de|fr` now get the same CDN-absolute asset URLs + `__CDN_DATA_BASE__` as IT → browser fetches shard assets straight from the CDN, Worker only proxies page HTML (**~1 req/page vs ~11, ≈90% fewer Worker invocations**).
- **Bonus artifact shrink**: with no surviving same-origin `/assets` ref in `dist/en|de|fr`, Guard B in `Drop dist/assets` now drops `dist/assets` instead of keeping it every deploy.
- Added a comment block documenting the ordering invariant.
- `CDN_BASE` is exported by the CDN-push step (env persists to later steps) → offload's rewrite targets are already live when it runs.
- `continue-on-error: true` preserved → if offload fails, shards stay same-origin exactly as today (**no regression**; Worker fallback routes still catch them).

## Non implementato (ancora)

- **Remove the now-vestigial `/assets/* /data/* /og/*` Worker routes** + add `Cache-Control`/`caches.default` to `infra/cloudflare-worker/locale-router.js`. Deferred: the Worker is deployed **manually** (`npx wrangler deploy`, not CI), and removing the routes is only safe **after** a deploy with this fix has republished CDN-correct shard HTML live (else existing same-origin shard refs 404). Follow-up once `/en/` is verified referencing CDN absolute on the live site.
- **Source-level fix in `staticPagesPlugin.buildPage()`** (emit the SPA index's actual asset URL instead of hardcoding `/assets/${entry}`) — would make HTML CDN-correct at build time and remove the dependency on post-build rewrite ordering entirely. Out of scope here (larger blast radius on a funnel-critical emitter); this ordering fix is the minimal root-cause cure.
- No build/wall-time claim measurable pre-merge. Revert-trigger: if the next deploy's `/en/` still shows same-origin `/assets` refs (curl `https://frontaliereticino.ch/en/`) → ordering didn't take, revert.

## Test plan

- [ ] Post-merge deploy: `curl -s https://frontaliereticino.ch/en/ | grep -c 'cdn.frontaliereticino.ch'` > 0 and same-origin `/assets` refs == 0 (repeat de/fr).
- [ ] `/en/` HTML contains `__CDN_DATA_BASE__`.
- [ ] Cloudflare Workers daily request count drops sharply next day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)