### PR TITLE
fix(generate-article): defer on transient free-model exhaustion instead of crashing

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -64,7 +64,7 @@ import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync, copyFile
 import { execSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
-import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess } from './lib/ai-models.mjs';
+import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess, isQuotaExhaustedError } from './lib/ai-models.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
@@ -8185,6 +8185,18 @@ async function generateAndValidateArticle(url, sourceContext = null) {
 }
 
 main().catch((e) => {
+  // Transient free-model pool exhaustion (every model in the fallback chain hit
+  // its daily quota / rate limit) is NOT a code bug — free-tier daily limits
+  // reset at 00:00 UTC, so the next scheduled run normally succeeds. Treat it as
+  // a clean deferral (exit 0, no file changes) so the workflow's self-trigger
+  // back-off retries later instead of marking the run failed and raising a
+  // false-positive "Workflow Failure: Generate Blog Article" Bug issue (#1652).
+  // Mirrors the graceful quota-exhausted handling in dedicated-crawler-common.mjs.
+  if (isQuotaExhaustedError(e)) {
+    finalizeRunReport('deferred', { notes: [...RUN_REPORT.notes, `Deferred (all free models exhausted): ${e.message}`] });
+    console.error(`\n⚠️  Differito: tutti i modelli AI gratuiti sono temporaneamente esauriti (quota giornaliera). Riprovo al prossimo run. ${e.message}`);
+    process.exit(0);
+  }
   finalizeRunReport('error', { notes: [...RUN_REPORT.notes, `Error: ${e.message}`] });
   console.error(`\n❌ Errore: ${e.message}`);
   process.exit(1);

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1748,26 +1748,30 @@ function isDailyLimitError(status, bodyText = '') {
 }
 
 /**
- * Single source of truth for "the whole free-model pool is transiently
- * unavailable" — i.e. every model in the fallback chain failed because of
- * daily-quota/rate-limit exhaustion, NOT a code/data bug.
+ * Single source of truth for "the whole free-model pool is TRANSIENTLY
+ * unavailable" — every model in the fallback chain failed because of
+ * daily-quota / rate-limit / cooldown / timeout exhaustion, NOT a persistent
+ * fault and NOT a code/data bug.
  *
  * This is a *transient external capacity* condition: free-tier daily limits
  * reset at 00:00 UTC, so the next scheduled run normally succeeds. Callers use
  * it to defer gracefully (skip this run, retry later) instead of crashing and
  * raising a false-positive "Workflow Failure" Bug issue.
  *
- * Detects both the structured `ALL_MODELS_EXHAUSTED` error code thrown by
- * `callLLM` and the legacy message substrings emitted by individual providers,
- * so a single helper replaces the literal substring list previously duplicated
- * across create-article.mjs and dedicated-crawler-common.mjs.
+ * IMPORTANT: `callLLM` throws `code = ALL_MODELS_EXHAUSTED` regardless of WHY
+ * the chain emptied — a persistent outage (all keys revoked 401, credits gone
+ * 402, models removed 404, prompt chronically too large 413, no API keys) also
+ * empties it. Deferring on the bare code would silence those real outages
+ * forever. So for a structured callLLM error we trust its dominant-cause flag
+ * (`transientExhaustion`); only a transient-dominant run defers. Non-callLLM
+ * errors (single provider call re-thrown without the code) fall back to the
+ * unambiguous quota/rate-limit message substrings.
  */
 export function isQuotaExhaustedError(err) {
   if (!err) return false;
-  if (err.code === 'ALL_MODELS_EXHAUSTED') return true;
+  if (err.code === 'ALL_MODELS_EXHAUSTED') return err.transientExhaustion === true;
   const msg = String(err.message || err || '').toLowerCase();
   return (
-    msg.includes('all ai models failed') ||
     msg.includes('daily request limit') ||
     msg.includes('daily limit') ||
     msg.includes('daily quota') ||
@@ -2745,5 +2749,37 @@ export async function callLLM(messages, opts = {}) {
   await flushScores();
   const err = new Error(`All AI models failed. Chain: [${chain.join(' → ')}]. Errors: ${summary}`);
   err.code = 'ALL_MODELS_EXHAUSTED';
+  // Classify the AGGREGATE cause so callers can distinguish a TRANSIENT pool
+  // exhaustion (daily quota / rate-limit / provider cooldown / timeout — self-
+  // heals at the next window) from a PERSISTENT fault (stale keys 401, depleted
+  // credits 402, removed models 404, chronically oversized payload 413, missing
+  // API keys) that needs a human alert. create-article.mjs defers (exit 0) only
+  // on a transient-dominant run; a persistent-dominant run still exits non-zero
+  // and raises the Workflow-Failure issue, so the safety net from #1652 stays
+  // intact for real outages (stale keys, provider down, prompt always too big).
+  err.exhaustionBreakdown = classifyExhaustionCause(errors);
+  err.transientExhaustion = err.exhaustionBreakdown.transient > 0
+    && err.exhaustionBreakdown.transient >= err.exhaustionBreakdown.persistent;
   throw err;
+}
+
+/**
+ * Tally per-model failure reasons collected by callLLM into transient vs
+ * persistent buckets. Transient = quota/rate/cooldown/timeout/5xx/overloaded
+ * (recovers on its own). Persistent = auth/credit/removed-model/payload/no-key
+ * (needs intervention). Reasons matching neither are ignored in the tally.
+ */
+function classifyExhaustionCause(errors) {
+  const persistentRe = /\b40[124]\b|tokens?_limit_reached|context.?length|maximum context|too many tokens|exceeds .*input cap|max output \d+ <|no API key|unknown.?model|no such model|does not exist|decommissioned|deprecated|no longer supported|payment|insufficient|credit/i;
+  const transientRe = /daily (request )?limit|daily quota|exceeded your current quota|plan and billing|free.?models.?per.?day|\b429\b|rate.?limit|resource.?exhausted|cooling down|timeout|aborted|overloaded|\b5\d\d\b|temporarily/i;
+  let transient = 0;
+  let persistent = 0;
+  for (const reason of errors) {
+    const isTransient = transientRe.test(reason);
+    const isPersistent = persistentRe.test(reason);
+    if (isTransient) transient += 1;
+    else if (isPersistent) persistent += 1;
+    // neither → ambiguous, left out of the tally
+  }
+  return { transient, persistent, total: errors.length };
 }

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1748,6 +1748,37 @@ function isDailyLimitError(status, bodyText = '') {
 }
 
 /**
+ * Single source of truth for "the whole free-model pool is transiently
+ * unavailable" — i.e. every model in the fallback chain failed because of
+ * daily-quota/rate-limit exhaustion, NOT a code/data bug.
+ *
+ * This is a *transient external capacity* condition: free-tier daily limits
+ * reset at 00:00 UTC, so the next scheduled run normally succeeds. Callers use
+ * it to defer gracefully (skip this run, retry later) instead of crashing and
+ * raising a false-positive "Workflow Failure" Bug issue.
+ *
+ * Detects both the structured `ALL_MODELS_EXHAUSTED` error code thrown by
+ * `callLLM` and the legacy message substrings emitted by individual providers,
+ * so a single helper replaces the literal substring list previously duplicated
+ * across create-article.mjs and dedicated-crawler-common.mjs.
+ */
+export function isQuotaExhaustedError(err) {
+  if (!err) return false;
+  if (err.code === 'ALL_MODELS_EXHAUSTED') return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return (
+    msg.includes('all ai models failed') ||
+    msg.includes('daily request limit') ||
+    msg.includes('daily limit') ||
+    msg.includes('daily quota') ||
+    msg.includes('exceeded your current quota') ||
+    msg.includes('plan and billing details') ||
+    msg.includes('free-models-per-day') ||
+    msg.includes('free models per day')
+  );
+}
+
+/**
  * Detect permanent client errors that should NOT be retried.
  * - unknown_model: model doesn't exist on the provider (mark exhausted)
  * - context length / too many tokens: prompt too large for this model

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -2788,13 +2788,13 @@ export async function enrichJobLocalesWithRetryDCC(job, crawlerConfig, ctx = {},
       return await enrichJobLocalesDCC(job, crawlerConfig, ctx);
     } catch (error) {
       lastError = error;
-      const msg = String(error?.message || '').toLowerCase();
-      const quotaExhausted =
-        msg.includes('all ai models failed') ||
-        msg.includes('daily request limit') ||
-        msg.includes('daily quota') ||
-        msg.includes('exceeded your current quota') ||
-        msg.includes('plan and billing details');
+      // Shared single source of truth for "whole free-model pool transiently
+      // exhausted" (see ai-models.mjs:isQuotaExhaustedError). Falls back to a
+      // minimal inline check only if ai-models failed to import (in which case
+      // no AI calls ran, so this branch is effectively unreachable).
+      const quotaExhausted = _aiModels?.isQuotaExhaustedError
+        ? _aiModels.isQuotaExhaustedError(error)
+        : String(error?.message || '').toLowerCase().includes('all ai models failed');
       if (quotaExhausted) break;
       if (attempt < maxAttempts) {
         // eslint-disable-next-line no-await-in-loop

--- a/tests/scripts/quota-exhausted-classifier.test.ts
+++ b/tests/scripts/quota-exhausted-classifier.test.ts
@@ -1,30 +1,49 @@
 import { describe, expect, it } from 'vitest';
 
 // Regression guard for the "Generate Blog Article" false-positive Bug spam
-// (Refs #1652). When every model in the fallback chain hits its daily quota,
-// callLLM throws `All AI models failed` with code ALL_MODELS_EXHAUSTED. That is
-// a TRANSIENT external-capacity condition (free-tier limits reset at 00:00 UTC),
-// NOT a code bug. create-article.mjs uses isQuotaExhaustedError to defer
-// gracefully (exit 0 → workflow self-trigger back-off retries later) instead of
-// crashing (exit 1 → raises a priority:high "Workflow Failure" Bug issue every
-// time the daily quota is briefly exhausted).
+// (Refs #1652) AND the reviewer's safety-net finding on PR #1671.
 //
-// The same helper is the single source of truth shared with
-// dedicated-crawler-common.mjs (was a duplicated literal substring list).
+// callLLM throws `All AI models failed` with code ALL_MODELS_EXHAUSTED whenever
+// the fallback chain empties — REGARDLESS of cause. A TRANSIENT cause (daily
+// quota / rate-limit, resets at 00:00 UTC) should defer (exit 0 → self-trigger
+// back-off retries later). A PERSISTENT cause (stale keys 401, depleted credits
+// 402, removed models 404, chronically oversized payload 413, missing API keys)
+// must still exit 1 and raise the Workflow-Failure issue — otherwise a real
+// outage silences article generation forever with zero alert.
+//
+// So isQuotaExhaustedError trusts the dominant-cause flag (`transientExhaustion`)
+// for structured callLLM errors, and the unambiguous quota substrings for
+// re-thrown single-provider errors. It is the single source of truth shared
+// with dedicated-crawler-common.mjs.
 const aiModels = await import('../../scripts/lib/ai-models.mjs');
 const { isQuotaExhaustedError } = aiModels;
 
 describe('isQuotaExhaustedError — transient pool exhaustion vs real bug', () => {
-  it('detects the structured ALL_MODELS_EXHAUSTED error code', () => {
-    const err = Object.assign(new Error('All AI models failed. Chain: [a → b]. Errors: HTTP 429'), {
+  it('defers a structured ALL_MODELS_EXHAUSTED error only when transient-dominant', () => {
+    const transient = Object.assign(new Error('All AI models failed. Chain: [a → b]. Errors: HTTP 429'), {
       code: 'ALL_MODELS_EXHAUSTED',
+      transientExhaustion: true,
     });
-    expect(isQuotaExhaustedError(err)).toBe(true);
+    expect(isQuotaExhaustedError(transient)).toBe(true);
   });
 
-  it('detects legacy provider quota/rate-limit message substrings', () => {
+  it('does NOT defer a persistent-dominant ALL_MODELS_EXHAUSTED outage (must still exit 1)', () => {
+    // All keys revoked (401) / credits gone (402) / models removed (404) →
+    // callLLM still throws ALL_MODELS_EXHAUSTED but flags it non-transient.
+    const persistent = Object.assign(new Error('All AI models failed. Chain: [a]. Errors: HTTP 401 invalid key'), {
+      code: 'ALL_MODELS_EXHAUSTED',
+      transientExhaustion: false,
+    });
+    expect(isQuotaExhaustedError(persistent)).toBe(false);
+
+    // Defensive: a structured error missing the flag entirely is treated as
+    // non-transient (surfaces the issue rather than silencing it).
+    const unflagged = Object.assign(new Error('All AI models failed.'), { code: 'ALL_MODELS_EXHAUSTED' });
+    expect(isQuotaExhaustedError(unflagged)).toBe(false);
+  });
+
+  it('detects legacy provider quota/rate-limit message substrings (re-thrown single calls)', () => {
     const transient = [
-      'All AI models failed. Chain: [x]. Errors: daily limit',
       'You have hit your daily request limit',
       'exceeded your current quota, check your plan and billing details',
       'OpenRouter free-models-per-day cap reached',
@@ -32,6 +51,11 @@ describe('isQuotaExhaustedError — transient pool exhaustion vs real bug', () =
     for (const msg of transient) {
       expect(isQuotaExhaustedError(new Error(msg)), msg).toBe(true);
     }
+  });
+
+  it('does NOT treat a bare "all ai models failed" message (no code) as transient', () => {
+    // Without the structured code+flag we cannot know the cause → do not silence.
+    expect(isQuotaExhaustedError(new Error('All AI models failed. Chain: [x]'))).toBe(false);
   });
 
   it('does NOT treat genuine code/data errors as transient (must still exit 1)', () => {
@@ -50,5 +74,43 @@ describe('isQuotaExhaustedError — transient pool exhaustion vs real bug', () =
   it('handles null/undefined defensively', () => {
     expect(isQuotaExhaustedError(null)).toBe(false);
     expect(isQuotaExhaustedError(undefined)).toBe(false);
+  });
+});
+
+describe('callLLM exhaustion cause classification (end-to-end)', () => {
+  it('flags a daily-limit-exhausted chain as transient → deferrable', async () => {
+    aiModels.resetState();
+    const model = 'mistral/ministral-8b-latest';
+    aiModels.markModelExhausted(model); // skip reason: "exhausted (daily limit …)"
+
+    let caught: any;
+    try {
+      await aiModels.callLLM([{ role: 'user', content: "Reply 'ok'." }], { chain: [model], retries: 0, maxTokens: 8 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.code).toBe('ALL_MODELS_EXHAUSTED');
+    expect(caught?.transientExhaustion).toBe(true);
+    expect(isQuotaExhaustedError(caught)).toBe(true);
+  });
+
+  it('flags a missing-API-key chain as persistent → NOT deferrable (raises issue)', async () => {
+    aiModels.resetState();
+    const prev = process.env.GROQ_API_KEY;
+    delete process.env.GROQ_API_KEY;
+    try {
+      const model = 'groq/llama-3.3-70b-versatile'; // skip reason: "no API key for provider groq"
+      let caught: any;
+      try {
+        await aiModels.callLLM([{ role: 'user', content: "Reply 'ok'." }], { chain: [model], retries: 0, maxTokens: 8 });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught?.code).toBe('ALL_MODELS_EXHAUSTED');
+      expect(caught?.transientExhaustion).toBe(false);
+      expect(isQuotaExhaustedError(caught)).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env.GROQ_API_KEY = prev;
+    }
   });
 });

--- a/tests/scripts/quota-exhausted-classifier.test.ts
+++ b/tests/scripts/quota-exhausted-classifier.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the "Generate Blog Article" false-positive Bug spam
+// (Refs #1652). When every model in the fallback chain hits its daily quota,
+// callLLM throws `All AI models failed` with code ALL_MODELS_EXHAUSTED. That is
+// a TRANSIENT external-capacity condition (free-tier limits reset at 00:00 UTC),
+// NOT a code bug. create-article.mjs uses isQuotaExhaustedError to defer
+// gracefully (exit 0 → workflow self-trigger back-off retries later) instead of
+// crashing (exit 1 → raises a priority:high "Workflow Failure" Bug issue every
+// time the daily quota is briefly exhausted).
+//
+// The same helper is the single source of truth shared with
+// dedicated-crawler-common.mjs (was a duplicated literal substring list).
+const aiModels = await import('../../scripts/lib/ai-models.mjs');
+const { isQuotaExhaustedError } = aiModels;
+
+describe('isQuotaExhaustedError — transient pool exhaustion vs real bug', () => {
+  it('detects the structured ALL_MODELS_EXHAUSTED error code', () => {
+    const err = Object.assign(new Error('All AI models failed. Chain: [a → b]. Errors: HTTP 429'), {
+      code: 'ALL_MODELS_EXHAUSTED',
+    });
+    expect(isQuotaExhaustedError(err)).toBe(true);
+  });
+
+  it('detects legacy provider quota/rate-limit message substrings', () => {
+    const transient = [
+      'All AI models failed. Chain: [x]. Errors: daily limit',
+      'You have hit your daily request limit',
+      'exceeded your current quota, check your plan and billing details',
+      'OpenRouter free-models-per-day cap reached',
+    ];
+    for (const msg of transient) {
+      expect(isQuotaExhaustedError(new Error(msg)), msg).toBe(true);
+    }
+  });
+
+  it('does NOT treat genuine code/data errors as transient (must still exit 1)', () => {
+    const realBugs = [
+      new Error('Campo body2 troppo corto per de'),
+      new Error('Articolo rigettato: fact-check fallito'),
+      new Error('Output JSON non valido dopo 3 tentativi con validazione jsonMode'),
+      new Error('topic-gate abort: 0 frontaliere keywords'),
+      new TypeError("Cannot read properties of undefined (reading 'it')"),
+    ];
+    for (const err of realBugs) {
+      expect(isQuotaExhaustedError(err), err.message).toBe(false);
+    }
+  });
+
+  it('handles null/undefined defensively', () => {
+    expect(isQuotaExhaustedError(null)).toBe(false);
+    expect(isQuotaExhaustedError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Risolve la causa radice di **#1652** ("Workflow Failure: Generate Blog Article", `bug` / `priority:high`, ricorrente).

**Diagnosi (run 27226674030):** lo step *Generate article* è crashato con
`❌ Errore: All AI models failed. Chain: [...]` → `exit 1`. La catena di fallback
ha bruciato tutti i modelli free perché **esauriti (daily limit, reset 00:00 UTC)**
+ alcuni `HTTP 413 Request too large` / `422` / `500`. È una condizione **transiente
di capacità esterna**, non un bug di codice — ma `create-article.mjs` la classificava
come "infrastructure error → propagate → exit 1", quindi:
- run marcato failed (rosso)
- step *Report failure to GitHub Issues* → crea una issue `Bug priority:high` ad **ogni**
  esaurimento giornaliero del pool free = spam di falsi positivi.

**Fix (chirurgico, single chokepoint):**
- `main().catch` ora distingue l'errore: se è esaurimento-quota transiente →
  `finalizeRunReport('deferred')` + **`exit 0`** (nessuna modifica file). Il workflow lo
  vede come `has_changes=false` → la self-trigger chain con back-off (no_changes streak)
  + il cron fallback ritentano più tardi, quando la quota giornaliera si resetta.
  Gli errori reali di codice/dati (validazione, fact-check, JSON parse, TypeError)
  continuano a fare `exit 1` e ad alzare la issue.
- Stesso comportamento già adottato graziosamente da `dedicated-crawler-common.mjs`
  (che fa `break` su quota-exhausted senza crashare il crawler).

**Anti-drift (AGENTS #6):** la detection quota-exhausted era una lista di substring
literal duplicata. Estratta in **`ai-models.mjs:isQuotaExhaustedError()`** come unica
source of truth (rileva sia il code strutturato `ALL_MODELS_EXHAUSTED` sia i messaggi
legacy dei provider) e consumata da **entrambi** i caller — niente più copie da tenere
allineate. `dedicated-crawler-common.mjs` ora la usa al posto della lista inline.

**Test:** nuovo `tests/scripts/quota-exhausted-classifier.test.ts` (4 test) locka la
classificazione funnel-critical: transiente→deferred(exit 0) vs bug reale→propagate(exit 1),
+ null-safety. Gate `npm run test:articles` verde (62/62) e `ai-models-skip-error-capture`
+ `create-article-gates` verdi.

## Non implementato (ancora)

- **Riduzione del consumo quota** (root cause sottostante: tutti i modelli free
  esauriti entro le 00:00 UTC). Out of scope qui — questa PR elimina solo il *falso
  positivo* di issue Bug; la capacità del pool free è una leva separata (rotazione
  provider / discovery, già in `ai-models.mjs`).
- **413 Request too large**: alcuni modelli rifiutano per payload troppo grande a fine
  catena. Non è la causa del crash (il crash è l'esaurimento dell'intera catena) → fuori
  scope; eventuale sub-chunking del prompt è follow-up separato.
- Non rimosse pagine né abbassate soglie qualità (rispetta AGENTS #1/#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)