### PR TITLE
fix(seo): global job count only on hub page-1 — kill paginated-archive churn

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1057,6 +1057,13 @@ interface ArticleSectionOverride {
 
 function buildHtml(args: BuildHtmlArgs): string {
   const { locale, hubKey, basePath, page, totalPages, pageItems, totalItems, hasSpaBundle, entryJs, entryCss, sectionOverride } = args;
+  // Global total (`totalItems`) only on page 1; on page ≥2 use this page's own
+  // slice size (stable per page, JOBS_PAGE_SIZE for full pages). The global
+  // count changes by ±1 on nearly every crawl, so embedding it on every
+  // paginated page made a single job add/remove rewrite ALL ~860 pages of the
+  // `tutti` archive (measured top byte churner, ~110 MB/deploy). Page-1 keeps
+  // the headline total; deep pages report their own slice → no count churn.
+  const displayCount = page === 1 ? totalItems : pageItems.length;
   const title = sectionOverride ? sectionOverride.title : HUB_TITLES[locale][hubKey];
   const description = sectionOverride ? sectionOverride.description : HUB_DESCRIPTIONS[locale][hubKey];
   // Title ≤60 char (Semrush W2): drop "| Frontaliere Ticino" suffix when adding it
@@ -1131,7 +1138,7 @@ function buildHtml(args: BuildHtmlArgs): string {
     dateModified: buildDayStampIso(),
     mainEntity: {
       '@type': 'ItemList',
-      numberOfItems: totalItems,
+      numberOfItems: displayCount,
       itemListElement: pageItems.slice(0, 25).map((it, idx) => ({
         '@type': 'ListItem',
         position: (page - 1) * 100 + idx + 1,
@@ -1191,7 +1198,7 @@ function buildHtml(args: BuildHtmlArgs): string {
     de: { count: HUB_KEY_TILE_LABELS.de[hubKey], pagina: 'Seite', aggiornato: 'Aktualisiert' },
     fr: { count: HUB_KEY_TILE_LABELS.fr[hubKey], pagina: 'Page', aggiornato: 'Mis à jour' },
   }[locale];
-  const statTilesHtml = `<section class="s-iQjIAb" aria-label="${esc({ it: 'Numeri chiave', en: 'Key numbers', de: 'Kennzahlen', fr: 'Chiffres clés' }[locale])}"><div class="s-tacc"><div class="s-tlbl">${esc(tileLabelsGlobal.count)}</div><div class="s-tval">${esc(totalItems.toLocaleString(locale))}</div></div><div class="s-tok"><div class="s-tlbl">${esc(tileLabelsGlobal.pagina)}</div><div class="s-tval">${esc(`${page} / ${totalPages}`)}</div></div><div class="s-tbase"><div class="s-tlbl">${esc(tileLabelsGlobal.aggiornato)}</div><div class="s-tval" style="font-size:18px">${esc(dateStamp)}</div></div></section>`;
+  const statTilesHtml = `<section class="s-iQjIAb" aria-label="${esc({ it: 'Numeri chiave', en: 'Key numbers', de: 'Kennzahlen', fr: 'Chiffres clés' }[locale])}"><div class="s-tacc"><div class="s-tlbl">${esc(tileLabelsGlobal.count)}</div><div class="s-tval">${esc(displayCount.toLocaleString(locale))}</div></div><div class="s-tok"><div class="s-tlbl">${esc(tileLabelsGlobal.pagina)}</div><div class="s-tval">${esc(`${page} / ${totalPages}`)}</div></div><div class="s-tbase"><div class="s-tlbl">${esc(tileLabelsGlobal.aggiornato)}</div><div class="s-tval" style="font-size:18px">${esc(dateStamp)}</div></div></section>`;
 
   const ctaPathGlobal = locale === 'it' ? '/calcola-stipendio/'
     : locale === 'de' ? '/de/gehalt-berechnen/'
@@ -1251,9 +1258,9 @@ ${hreflangs}${xDefault}${prevLink}${nextLink}
         <span>${esc(sectionLabel)}</span>
       </nav>
       <header class="s-S1RSUf">
-        <h1 class="s-e3gkVi">${esc(sectionOverride ? (page > 1 ? `${sectionOverride.h1} — ${pageLabel(locale, page)}` : sectionOverride.h1) : buildHubH1(locale, hubKey, totalItems, page))}</h1>
+        <h1 class="s-e3gkVi">${esc(sectionOverride ? (page > 1 ? `${sectionOverride.h1} — ${pageLabel(locale, page)}` : sectionOverride.h1) : buildHubH1(locale, hubKey, displayCount, page))}</h1>
         <p class="s-OPPwy-">${esc(description)}</p>
-        <p class="s-Sn0UIv">${esc(countLabel(locale, totalItems))} · ${esc(updatedLabel(locale))} ${dateStamp}</p>
+        <p class="s-Sn0UIv">${esc(countLabel(locale, displayCount))} · ${esc(updatedLabel(locale))} ${dateStamp}</p>
       </header>
       ${statTilesHtml}
       ${ctaHtmlGlobal}

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1058,11 +1058,16 @@ interface ArticleSectionOverride {
 function buildHtml(args: BuildHtmlArgs): string {
   const { locale, hubKey, basePath, page, totalPages, pageItems, totalItems, hasSpaBundle, entryJs, entryCss, sectionOverride } = args;
   // Global total (`totalItems`) only on page 1; on page ≥2 use this page's own
-  // slice size (stable per page, JOBS_PAGE_SIZE for full pages). The global
-  // count changes by ±1 on nearly every crawl, so embedding it on every
-  // paginated page made a single job add/remove rewrite ALL ~860 pages of the
-  // `tutti` archive (measured top byte churner, ~110 MB/deploy). Page-1 keeps
-  // the headline total; deep pages report their own slice → no count churn.
+  // slice size (`pageItems.length` = JOBS_PAGE_SIZE for full pages, stable; the
+  // last partial page still tracks its remainder, bounded to 1 page). The
+  // global count changes by ±1 on nearly every crawl, so embedding it on every
+  // paginated page made the count the *only-or-main* per-page delta on the deep
+  // pages of the `tutti` archive (the dir is the top byte churner at ~110 MB/
+  // deploy, of which the count is one component — the rest is the alphabetical
+  // pagination-boundary shift, NOT addressed here). This change only REMOVES a
+  // volatile value (→ can only reduce churn, never add a regression vector);
+  // the realized reduction is a fraction of 110 MB, measured post-merge via
+  // measure-deploy-delta, not pre-merge.
   const displayCount = page === 1 ? totalItems : pageItems.length;
   const title = sectionOverride ? sectionOverride.title : HUB_TITLES[locale][hubKey];
   const description = sectionOverride ? sectionOverride.description : HUB_DESCRIPTIONS[locale][hubKey];


### PR DESCRIPTION
## Implementato
Taglia il churn della dir più pesante misurata (`cerca-lavoro-ticino/tutti` = ~110MB/deploy, top byte churner post-#1632): la hub aggregata `/{section}/tutti/` (e `/settori/`, `/aziende/`) incorporava il **totale globale** (`totalItems`) in 4 punti — H1, tile "Numeri chiave", riga "N risorse", `numberOfItems` JSON-LD — su **ogni pagina paginata**. Il totale cambia di ±1 a quasi ogni crawl → su molte pagine profonde era l'**unica (o principale) differenza** per-deploy, facendo riscrivere pagine il cui slice di job era invariato.

**Fix**: `displayCount = page === 1 ? totalItems : pageItems.length`. Page-1 mantiene il totale headline; page ≥2 riporta la dimensione del proprio slice (`pageItems.length` = `JOBS_PAGE_SIZE`=100 per le pagine piene → stabile). `numberOfItems` = item della pagina è anche schema-corretto per una CollectionPage paginata. Scope: `buildHtml`.

**Verificato pre-merge:** `tsc` pulito; **99 test hub verdi** (`seo-hubs-pagination-bfs`, `cathedral-canton-hub-parity`, `footer-canton-scoped-seo-hubs`, `half-canton-merge`).

## Non implementato (ancora)
- **Magnitudine della riduzione NON misurata pre-merge** (no build data-only post-fix disponibile; problema noto di sopravvivenza-artifact). **MA nessun revert-trigger necessario**: il fix sostituisce un **valore variabile con uno costante** → per costruzione **NON ha vettore di regressione, può solo RIDURRE il churn, mai aumentarlo** (confermato anche dalla review). La componente count è una frazione dei 110MB (il resto = shift dei confini di paginazione, sotto). Misura pre/post via `measure-deploy-delta` (samples=0) **post-merge** sul churn-by-dir di `tutti`.
- **Churn da shift di paginazione**: l'ordine alfabetico per slug fa sì che un job aggiunto/rimosso sposti i confini delle pagine successive → quelle pagine cambiano contenuto reale (legittimo, NON toccato da questo fix). Quindi il fix recupera la parte count, non l'intero churn della dir.
- **Ultima pagina parziale**: `pageItems.length` = resto → continua a count-churnare quando il totale attraversa un confine `JOBS_PAGE_SIZE` (bounded a 1 pagina, accettabile).
- **Canton-thin hub** (`buildThinCantonHubHtml` / `buildPageNCompactProse`): la prose "L'archivio raccoglie {totalItems} annunci" + riga risorse embeddano ancora il totale su page-N → stesso churn, superficie minore. Follow-up (prose indicizzata = cambio SEO più delicato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)