### PR TITLE
chore(locale-router): drop dead /assets /data /og Worker routes (CF cap fix, already deployed)

### DIFF
--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -21,7 +21,10 @@ routes = [
   { pattern = "frontaliereticino.ch/fr/*",    zone_name = "frontaliereticino.ch" },
   { pattern = "frontaliereticino.ch/fr",      zone_name = "frontaliereticino.ch" },
   { pattern = "frontaliereticino.ch/fr.html", zone_name = "frontaliereticino.ch" },
-  { pattern = "frontaliereticino.ch/assets/*", zone_name = "frontaliereticino.ch" },
-  { pattern = "frontaliereticino.ch/data/*",   zone_name = "frontaliereticino.ch" },
-  { pattern = "frontaliereticino.ch/og/*",     zone_name = "frontaliereticino.ch" },
+  # NOTE: the /assets/* /data/* /og/* CDN-proxy routes were removed (2026-06-10).
+  # Since #1665 the shard locale HTML references those static paths CDN-absolute
+  # (cdn.frontaliereticino.ch/...), so the browser fetches them straight from the
+  # CDN — they no longer hit the apex and need no Worker proxy. Keeping the routes
+  # only burned ~10 needless Worker subrequests per shard pageview against the
+  # free-tier 100k/day cap (the in-code CDN_PATHS branch was already dropped).
 ]


### PR DESCRIPTION
## Implementato

Removed the `/assets/*`, `/data/*`, `/og/*` route patterns from the locale-router Worker's `wrangler.toml`. **Already deployed via `npx wrangler deploy`** (this Worker is not CI-deployed) — the live Worker now exposes only the 9 `en/de/fr` triggers.

### Why
After #1665 the shard locale HTML references those static paths **CDN-absolute** (`cdn.frontaliereticino.ch/...`), so the browser fetches them straight from the CDN — they never hit the apex and need no Worker proxy. The `/assets|/data|/og` routes were the **~90% multiplier** on Worker invocations: each en/de/fr pageview proxied ~10 asset sub-resources through the Worker (`frontaliere-locale-router` = 91.3k of the 102k req/102k account cap on 2026-06-09). The in-code `CDN_PATHS` branch was already dropped in a prior commit; this removes the now-orphan route patterns so the Worker is never invoked for them.

### Verified live (post-deploy)
- `wrangler deploy` output: only 9 triggers (`/en /en/* /en.html` ×{en,de,fr}); `/assets /data /og` gone.
- `/en/ /de/ /fr/` → HTTP 200, 11 CDN refs each, 0 same-origin `/assets`, `__CDN_DATA_BASE__` present.
- Deep page `/en/find-jobs-ticino/` → 200.
- `/assets/<old>` via apex → 404 (expected; no page references same-origin assets anymore).
- IT `/` passthrough → 200 (unchanged).
- Locale HTML now edge-cached: real GET `/de/` → `cf-cache-status: HIT` (served from edge, Worker not re-invoked → further cuts invocations).

## Non implementato (ancora)

- Worker `locale-router.js` body unchanged here (caching + `CDN_PATHS`-removal already landed in a prior commit; this PR is config-only).
- This is config aligning the repo with the **already-live** Worker — no build/test impact. The Worker has no CI test harness; behavior verified live as above.
- Today's already-consumed request count (102k) is not recoverable; the cap resets 00:00 UTC. This change is the durable fix so tomorrow's count stays low (expected locale-router ≈10–15k vs 91k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)