### PR TITLE
fix(job-alerts): collection-group read rule — unblocks listing AND creating alerts (root cause of frozen subscribers)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -77,6 +77,20 @@ service cloud.firestore {
       allow read: if true;
     }
 
+    // Collection-group reads for `alerts` (getUserAlerts + createAlert's per-user
+    // limit check both run `collectionGroup('alerts').where('userId','==',uid)`).
+    // Firestore does NOT apply the nested
+    // `/job_alert_subscribers/{email}/alerts/{alertId}` rule to collection-group
+    // queries, so without this top-level `{path=**}` rule every such read is
+    // permission-denied — which silently broke BOTH listing and creating job
+    // alerts (job_alert_subscribers frozen since 2026-04-25, ~21 GA4
+    // `job_alert_cta_skipped:get_alerts_failed` events/day). Scoped to the
+    // caller's own alerts via the denormalized userId.
+    match /{path=**}/alerts/{alertId} {
+      allow read: if request.auth != null
+        && request.auth.uid == resource.data.userId;
+    }
+
     // Job alert subscribers — root doc per email, mirrors newsletter_subscribers.
     // Top-level doc is public-write (Cloud Functions + client init); engagement
     // counters are written by ESP webhooks via the Admin SDK.


### PR DESCRIPTION
## Root cause (riproduzione live)
`getUserAlerts` e il limit-check di `createAlert` eseguono entrambi `collectionGroup('alerts').where('userId','==',uid)`. Firestore **non applica** la regola nested `/job_alert_subscribers/{email}/alerts/{alertId}` alle query **collection-group** → ogni lettura era `permission-denied`.

Riprodotto dal vivo autenticato come valerielinc+1 (uid reale): `getUserAlerts → code: permission-denied`.

## Impatto (perché `job_alert_subscribers` è fermo dal 2026-04-25)
- Il prompt job-alert fa **fail-close** (`JobBoard catch { return }`) → il toast **non appare mai** (~21 eventi GA4/giorno `job_alert_cta_skipped:get_alerts_failed`, trovati oggi via la diagnostica #1638).
- `createAlert` lancia **prima** di scrivere (stessa query nel limit-check) → **nessun alert creabile**.

Questo è il motivo **strutturale** dello 0 iscritti, più fondamentale del bug autologin (già fixato #1634 e validato live).

## Implementato
Aggiunta la regola canonica top-level per le query collection-group:
```
match /{path=**}/alerts/{alertId} {
  allow read: if request.auth != null && request.auth.uid == resource.data.userId;
}
```
Scoped agli alert di proprietà (userId denormalizzato). `create`/`update`/`delete` mantengono la regola nested email-path.

## Verifica post-deploy
Dopo il deploy delle Firestore rules: ri-eseguo la riproduzione (`getUserAlerts` autenticato deve tornare OK), e in GA4 `get_alerts_failed` deve azzerarsi + ricomparire `job_alert_cta_shown` / `job_alert_created`.

## Non implementato
- Test unit rules (richiede emulator setup) — la verifica è via riproduzione live post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)