### PR TITLE
perf(locale-router): raise edge cache TTL 5min→1h (CF cap headroom, already deployed)

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -36,10 +36,16 @@ const SHARD_ORIGIN = {
 // to these prefixes; this regex is the in-code guard.)
 const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 
-// TTL for locale pages cached in the Workers Cache API. Short enough that a
-// fresh deploy (new asset fingerprints) is visible within 5 min without manual
-// cache purge.
-const CACHE_MAX_AGE = 300; // 5 min
+// TTL for locale pages cached in the Workers Cache API + Cloudflare edge
+// (s-maxage). Raised 300s -> 3600s (2026-06-10) to absorb far more repeat/
+// overlapping hits as cf HITs that DON'T re-invoke the Worker — the lever that
+// keeps frontaliere-locale-router under the free-tier 100k/day cap once the
+// asset fan-out is gone (#1665 + route drop). Safe against stale-HTML 404s:
+// superseded CDN asset hashes are retained GRACE_DAYS=7 (prune-cdn-assets.mjs),
+// far longer than this TTL, so HTML served up to 1h stale still resolves every
+// referenced /assets hash. Live job data is client-fetched fresh from the CDN at
+// runtime (not baked into this cached HTML), so a 1h-stale SEO shell is fine.
+const CACHE_MAX_AGE = 3600; // 1 h
 
 export default {
   async fetch(request, _env, ctx) {


### PR DESCRIPTION
## Implementato

Raised `CACHE_MAX_AGE` in the locale-router Worker from `300s` (5 min) to `3600s` (1 h). **Already deployed via `npx wrangler deploy`** (Worker is not CI-deployed). Live: `cache-control: public, max-age=3600, s-maxage=3600`; en/de/fr 200 + 11 CDN refs; 9 triggers intact.

### Why
After the asset fan-out was removed (#1665 + dead-route drop #1683), the residual `frontaliere-locale-router` load is en/de/fr HTML navigation + crawler long-tail — each a cache-cold Worker invocation. Measured 2026-06-10: **~2.4k invocations / 54 min** (~64k/day projected), uncomfortably close to the free-tier **100k/day** account cap on peak days. A longer edge TTL means a far larger share of repeat/overlapping hits (hot pages; multiple bots hitting the same URL within the window) are served from the Cloudflare edge as **cf HITs that do not re-invoke the Worker**.

### Safety (no stale-HTML 404)
- Superseded CDN asset hashes are retained **GRACE_DAYS=7** (`scripts/ci/prune-cdn-assets.mjs`) — far longer than this 1 h TTL — so HTML served up to 1 h stale still resolves every referenced `/assets/<hash>` file (no 404).
- Live job data is **client-fetched fresh from the CDN at runtime** (`__CDN_DATA_BASE__`), not baked into the cached SEO shell → a 1 h-stale locale HTML shell has no functional impact.
- Deploys run ~every 1–2 h; worst-case content staleness on a locale SEO page is ≤1 h.

## Non implementato (ancora)

- **Long-tail single-crawl floor remains**: a URL crawled exactly once per window is still 1 Worker invocation regardless of TTL. If the account still trends toward the cap after this, the durable zero-cost option is a **Cloudflare Origin Rule** routing `/en /de /fr` to the shard origins *without* a Worker (eliminates locale-router invocations entirely) — needs validating the 301-trailing-slash Location rewrite the Worker currently does. Flagged, not done here.
- Could go higher than 1 h (asset hashes are safe for 7 days), but 1 h is the conservative first step; raise further if peak-day usage still pressures the cap.
- No CI test (Worker has no harness); verified live (`node --check` + curl headers + 200s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)