### PR TITLE
fix(job-alerts): show prompt immediately for newsletter-autologin arrivals (toast race)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2412,17 +2412,19 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // waiting out the dwell timer. Consume the ref so it fires only once.
  const justAuthed = justAuthedJobIdRef.current === selectedJob.id;
  if (justAuthed) justAuthedJobIdRef.current = null;
- // 1.5 s otherwise (was 4 s): the 4 s timer was further pushed back by the
- // detail enrichment fetch re-running this effect (selectedJob ref changes),
- // so eligible users — 75% mobile, short dwell — left before the prompt
- // showed (~4 `shown` events in 30 days). 1.5 s still avoids prompting on an
- // accidental tap while landing the impression while the user is engaged.
+ // Show immediately (0 s) for peak-intent arrivals; 1.5 s dwell otherwise.
+ // Newsletter-autologin visitors only become authenticated after a ~4 s token
+ // exchange, and the 1.5 s timer then races (and usually loses) against the
+ // AdSense/enrichment re-renders that re-run this effect — so the prompt often
+ // never fires (observed: hasUser:true at +4 s, then no toast). They clicked a
+ // job in an email = peak intent, so treat them like an in-app post-auth unlock.
+ const showImmediately = justAuthed || wasNewsletterAutologinAttempted();
  timerId = window.setTimeout(() => {
  if (cancelled) return;
  setJobDetailPromptCategory(localizedCategory);
  setJobDetailPromptVisible(true);
  Analytics.trackJobAlertCtaShown('job_detail_prompt', localizedCategory);
- }, justAuthed ? 0 : 1500);
+ }, showImmediately ? 0 : 1500);
  })();
 
  return () => {


### PR DESCRIPTION
## Contesto
Dopo i fix autologin (#1634) e regola collection-group (#1684), l'autologin da newsletter **funziona** (verificato live: `hasUser:true` ~4s dopo il landing) e `getUserAlerts` **non fallisce più**. Ma il toast **ancora non appare** per i click reali.

## Root cause (riprodotto live)
Il toast arma un timer **dwell 1.5s**, ma:
1. L'utente da newsletter diventa autenticato solo **dopo ~4s** (exchange token).
2. Il timer 1.5s parte dopo, e **perde la race** contro i re-render (AdSense + enrichment fetch che ri-runnano l'effetto: `selectedJob` cambia ref). **Osservato live**: l'URL è passata da `segretaria-legale-...` a `web-sviluppatore-...` a metà load → il timer viene annullato prima di scattare → toast mai mostrato.

(GA4 conferma il fix #1684 attivo: `cta_shown=2` in realtime — il toast appare *a volte*, ma è flaky per la race.)

## Implementato
Per chi arriva da **autologin newsletter** (`wasNewsletterAutologinAttempted()` — picco d'intenzione, ha cliccato un job in una mail) mostra il toast **immediatamente (0s)** come per l'unlock in-app post-auth, invece del dwell 1.5s che i re-render mangiano. L'impression scatta al primo effect-run eleggibile.

## Non implementato (ancora)
- Resta una finestra ~200ms (await `getUserAlerts`) in cui un churn di `selectedJob` può ancora annullare; se dopo deploy è ancora flaky, prossimo step = stabilizzare le deps dell'effetto su `selectedJob?.id` invece del ref. Il dwell 1.5s era la finestra dominante.

## Verifica post-deploy
Click reale da newsletter → il toast deve apparire ~subito dopo l'auth (~4s dal landing), e `job_alert_cta_shown` / `job_alert_created` risalire in GA4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)