### PR TITLE
perf(deploy): push en/de/fr locale shards concurrently (~13min → ~5min to live)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -839,18 +839,27 @@ jobs:
           SHARD_FR_DEPLOY_KEY: ${{ secrets.SHARD_FR_DEPLOY_KEY }}
         run: |
           set -uo pipefail
-          for loc in en de fr; do
+          # Build + force-push ONE locale shard. Factored into a function so the
+          # three locales can run CONCURRENTLY (below) — they target independent
+          # repos / deploy keys / stage dirs, so wall-clock drops from
+          # sum(en+de+fr) (~13 min serial) to the slowest single locale (~5 min).
+          push_shard() {
+            local loc="$1"
+            local key_var key_val stage keyfile src_n prev_n rc
             key_var="SHARD_$(echo "$loc" | tr a-z A-Z)_DEPLOY_KEY"
             key_val="${!key_var:-}"
             if [ -z "$key_val" ]; then
-              echo "no $key_var secret — skipping $loc shard push"; continue
+              echo "no $key_var secret — skipping $loc shard push"; return 0
             fi
             if [ ! -d "dist/$loc" ]; then
-              echo "dist/$loc absent — skipping $loc shard push"; continue
+              echo "dist/$loc absent — skipping $loc shard push"; return 0
             fi
             stage="$RUNNER_TEMP/shard-$loc"
             keyfile="$RUNNER_TEMP/shard_${loc}_key"
             printf '%s\n' "$key_val" > "$keyfile" && chmod 600 "$keyfile"
+            # GIT_SSH_COMMAND is exported inside this function — and each locale
+            # runs in its OWN background subshell (the `&` below), so the three
+            # deploy keys never clobber one another when run concurrently.
             export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
             # Source-of-truth file count + the shard's last-published count, read
             # cheaply (no 2.5 GB clone) — a tiny .shard-filecount marker fetched
@@ -911,7 +920,19 @@ jobs:
               echo "::warning::$loc shard build/push failed (rc=$rc) — $loc will NOT be stripped from main this run"
             fi
             rm -f "$keyfile"
+          }
+          # Push all three locales CONCURRENTLY. Each runs in its own background
+          # subshell (isolated GIT_SSH_COMMAND / stage dir) and writes its own
+          # shard-ok-$loc marker on success, so one locale failing can never let
+          # the strip step drop a missing shard. continue-on-error keeps a degraded
+          # round (e.g. disk pressure) from failing the deploy — the locale just
+          # stays in the main artifact this run.
+          pids=()
+          for loc in en de fr; do
+            push_shard "$loc" &
+            pids+=("$!")
           done
+          for p in "${pids[@]}"; do wait "$p" || true; done
 
       # ── CDN assets/ GC janitor (anti-clobber by SEQUENCING) ───────────────
       # The additive assets/ merge above (cp -n) lets old + new content hashes


### PR DESCRIPTION
## Implementato

Quick win sul **time-to-live** del deploy. Misurato su run reali `deploy.yml`:
critical-path-to-live = `build` (81min) + `deploy` (2.6min) ≈ **84min**
(il sito va live al job `deploy`; `validate-dist` 38min e `publish` girano DOPO
e NON ritardano il live — solo side-effect IndexNow/social + safety rollback).

Dentro il job `build`, ~31min sono push/offload **seriali** post-build prima
dell'upload artifact. Il singolo più pesante = **"Push locale shards (en/de/fr)"
= 13.5min**, un loop `for loc in en de fr` che pusha ogni locale al suo repo
Pages separato in sequenza.

I tre target sono **completamente indipendenti** (repo, deploy key e
`$RUNNER_TEMP` stage dir distinti) → parallelizzabili senza rischio:

- per-locale build+push estratto in funzione `push_shard()`;
- i tre locali girano come **background subshell** (`push_shard "$loc" &`) poi `wait`;
- `GIT_SSH_COMMAND` esportato **dentro** la funzione → ogni subshell tiene la
  propria deploy key, nessuna race;
- **invariati**: gate integrità/regressione per-locale, i marker `shard-ok-$loc`
  consumati dallo strip step, e `continue-on-error` (un locale che fallisce non
  blocca il deploy né fa strippare uno shard mancante).

Wall-clock dello step scende da somma(en+de+fr) al locale più lento:
**~13.5min → ~5min, ~8min risparmiati sul critical-path-to-live** (≈84→76min).

### Verificato
- `bash -n` sul blocco `run:` estratto → OK
- `yaml.safe_load` su `deploy.yml` → OK
- Confermato che l'offload (`offload-generated-images-cdn.mjs`) walka **tutto**
  `dist/` incl. `dist/{en,de,fr}` → lo shard push DEVE restare dopo l'offload
  (#1665): non ho riordinato cross-step, solo parallelizzato intra-step.

## Non implementato (ancora)

- **Strip step `for loc in en de fr` (rm -rf dist/$loc, ~2min)**: classe diversa
  (cleanup locale IO-bound, non git-push di rete); parallelizzare `rm -rf` sullo
  stesso disco dà guadagno marginale → out of scope, non vale la churn.
- **`build` SSG 43.7min** e **offload 7.5min**: i veri colli rimanenti, ma sono
  memory/perf-sensitive (path OOM-prone) e non validabili pre-merge → fuori da un
  "quick win". Se il prossimo deploy regredisce su wall-time → nessun revert
  necessario qui (questo cambio è additivo/parallelizzante, fallback intatto).
- Loop `for loc` in `post-deploy-validate-dist.yml`/`inspect-dist-composition.yml`:
  fuori dal path time-to-live (girano in parallelo/diagnostici), non toccati.

## Test plan
- [ ] Post-merge: osservare `deploy.yml` run su `main` → step "Push locale shards"
      < ~6min (era ~13.5min) e i 3 shard-ok marker presenti → strip regolare.
- [ ] `curl https://frontaliereticino.ch/build-id.txt` avanza (live ok).
- [ ] `/en` `/de` `/fr` servono dietro il Worker (shard pushati correttamente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)