### PR TITLE
fix(data-refresh): shared httpFetchWithRetry kills the transient-fetch failure class (#1533, #1550)

### DIFF
--- a/scripts/cleanup-mailjet-contacts.mjs
+++ b/scripts/cleanup-mailjet-contacts.mjs
@@ -28,6 +28,8 @@
  * Flags mirror env: --dry-run, --keep N, --max-delete N.
  */
 
+import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
+
 const API_BASE = 'https://api.mailjet.com';
 const PAGE_SIZE = 1000; // Mailjet max Limit per page
 
@@ -73,7 +75,7 @@ async function fetchAllContacts(auth) {
   // be more"; a short page is the last one.
   for (;;) {
     const url = `${API_BASE}/v3/REST/contact?Limit=${PAGE_SIZE}&Offset=${offset}`;
-    const res = await fetchWithRetry(url, { headers: { Authorization: auth } });
+    const res = await httpFetchWithRetry(url, { headers: { Authorization: auth } }, { label: 'mailjet list contacts' });
     if (!res.ok) {
       const body = await res.text().catch(() => '');
       throw new Error(`List contacts failed ${res.status}: ${body.slice(0, 200)}`);
@@ -100,23 +102,11 @@ async function fetchAllContacts(auth) {
   return all;
 }
 
-/** fetch with exponential backoff on 429 / 5xx. */
-async function fetchWithRetry(url, opts, attempt = 0) {
-  const res = await fetch(url, opts);
-  if ((res.status === 429 || res.status >= 500) && attempt < 5) {
-    const wait = Math.min(30000, 1000 * 2 ** attempt);
-    console.warn(`   ⏳ ${res.status} on ${opts.method || 'GET'} — backoff ${wait}ms (retry ${attempt + 1}/5)`);
-    await sleep(wait);
-    return fetchWithRetry(url, opts, attempt + 1);
-  }
-  return res;
-}
-
 async function deleteContact(auth, id) {
-  const res = await fetchWithRetry(`${API_BASE}/v4/contacts/${id}`, {
+  const res = await httpFetchWithRetry(`${API_BASE}/v4/contacts/${id}`, {
     method: 'DELETE',
     headers: { Authorization: auth },
-  });
+  }, { label: `mailjet delete ${id}` });
   return res;
 }
 

--- a/scripts/fetch-health-premiums.mjs
+++ b/scripts/fetch-health-premiums.mjs
@@ -41,7 +41,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { fetchWithRetry, RETRYABLE_STATUS } from './lib/transient-fetch.mjs';
+import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -234,22 +234,16 @@ async function parseXLSX(buffer, sheetName) {
 // diagnosability. Returns the successful Response (body still unread).
 async function download(url, label, timeoutMs = 30000) {
   console.log(`📥 Downloading ${label}...`);
-  return fetchWithRetry(async () => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) {
-        const err = new Error(`Failed to download ${label}: ${res.status} ${res.statusText} (${url})`);
-        err.status = res.status;
-        err.retryable = RETRYABLE_STATUS.has(res.status);
-        throw err;
-      }
-      return res;
-    } finally {
-      clearTimeout(timer);
-    }
-  }, { label: `health-premiums ${label}` });
+  const res = await httpFetchWithRetry(url, {}, {
+    timeout: timeoutMs,
+    label: `health-premiums ${label}`,
+  });
+  // Transient statuses (429/5xx) are retried inside the helper; a persistent
+  // non-ok (e.g. 404 source moved) still fails fast here.
+  if (!res.ok) {
+    throw new Error(`Failed to download ${label}: ${res.status} ${res.statusText} (${url})`);
+  }
+  return res;
 }
 
 /**
@@ -279,29 +273,18 @@ async function fetchPremiumsCsv(targetYear) {
   const archiveUrl = buildHistoricalArchiveUrl(targetYear);
   let res;
   try {
-    res = await fetchWithRetry(async () => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 30000);
-      try {
-        const r = await fetch(archiveUrl, { signal: controller.signal });
-        if (!r.ok) {
-          const err = new Error(`${archiveUrl} responded ${r.status} ${r.statusText}`);
-          err.status = r.status;
-          err.retryable = RETRYABLE_STATUS.has(r.status);
-          throw err;
-        }
-        return r;
-      } finally {
-        clearTimeout(timer);
-      }
-    }, { label: `health-premiums archive ${targetYear}` });
+    res = await httpFetchWithRetry(archiveUrl, {}, {
+      timeout: 30000,
+      label: `health-premiums archive ${targetYear}`,
+    });
   } catch (err) {
-    // Persistent HTTP error (server responded non-ok) vs connection-level
-    // failure both degrade to NoArchiveError; the message keeps the detail.
-    if (Number.isFinite(err.status)) {
-      throw new NoArchiveError(targetYear, `${archiveUrl} responded ${err.status}`);
-    }
+    // Connection-level failure persisting after all retries → NoArchiveError.
     throw new NoArchiveError(targetYear, `network error fetching ${archiveUrl}: ${err.message}`);
+  }
+  // Persistent non-ok HTTP (e.g. 404 archive missing) → NoArchiveError. Transient
+  // 429/5xx were already retried inside the helper.
+  if (!res.ok) {
+    throw new NoArchiveError(targetYear, `${archiveUrl} responded ${res.status}`);
   }
   const contentType = res.headers.get('content-type') || '';
   if (!/zip/i.test(contentType)) {

--- a/scripts/fetch-thin-page-promotions.mjs
+++ b/scripts/fetch-thin-page-promotions.mjs
@@ -37,6 +37,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { appendFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -79,11 +80,11 @@ async function fetchPosthog(windowHours) {
     GROUP BY path
     LIMIT 100000
   `;
-  const r = await fetch(`${HOST}/api/projects/${PID}/query/`, {
+  const r = await httpFetchWithRetry(`${HOST}/api/projects/${PID}/query/`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
-  });
+  }, { label: 'posthog thin-page query' });
   if (!r.ok) throw new Error(`posthog ${r.status}: ${(await r.text()).slice(0, 200)}`);
   const data = await r.json();
   const urls = new Set();
@@ -138,11 +139,11 @@ async function fetchGa4(windowHours) {
     },
     limit: 100000,
   };
-  const r = await fetch(url, {
+  const r = await httpFetchWithRetry(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
-  });
+  }, { label: 'ga4 runReport' });
   if (r.status === 403) {
     throw new Error(`ga4 access denied (SA needs Viewer on property): ${(await r.text()).slice(0, 200)}`);
   }

--- a/scripts/lib/transient-fetch.mjs
+++ b/scripts/lib/transient-fetch.mjs
@@ -154,8 +154,15 @@ export async function fetchWithRetry(attemptFn, opts = {}) {
  *     `.arrayBuffer()`, inspects `.ok`/`.status`/`.headers` as before);
  *   - does NOT throw on a non-retryable non-ok status — the caller keeps its own
  *     `if (!res.ok) …` handling (e.g. graceful-degradation paths);
- *   - adds an `AbortSignal.timeout(timeout)` so a hung socket aborts instead of
- *     blocking the run forever (the abort is itself treated as transient).
+ *   - bounds the CONNECTION/HEADER phase with a per-attempt timeout (a stalled
+ *     DNS/TLS/handshake aborts instead of blocking the run forever, and the
+ *     abort is treated as transient) — but clears the timer the instant the
+ *     response headers arrive, so the body read the caller runs afterwards
+ *     (`.text()`/`.arrayBuffer()` on a multi-MB ZIP/XLSX) is NOT aborted
+ *     mid-stream. Keeping an `AbortSignal.timeout` armed through the body read
+ *     would abort a slow-but-healthy large download and throw an `AbortError`
+ *     at the caller's `.arrayBuffer()` (outside its try/catch) → the very
+ *     "Workflow Failure" crash this helper exists to prevent.
  *
  * Retryable HTTP statuses are surfaced as a thrown tagged error so the backoff
  * loop sees them; after the final attempt the real `Response` is returned so the
@@ -175,9 +182,26 @@ export async function httpFetchWithRetry(url, options = {}, opts = {}) {
   const label = opts.label || String(url);
   return fetchWithRetry(
     async () => {
-      // A caller-supplied signal takes precedence; otherwise apply our timeout.
-      const signal = options.signal ?? (timeout > 0 ? AbortSignal.timeout(timeout) : undefined);
-      const res = await fetch(url, { ...options, signal });
+      // Bound ONLY the connection/header phase, never the body read. We use a
+      // manual AbortController + a timer we clear the instant `fetch` resolves
+      // (response headers received) so a slow-but-healthy body stream — the
+      // multi-MB BAG archive ZIP / regions XLSX read later via
+      // `.arrayBuffer()`/`.text()` at the call site — is never aborted
+      // mid-stream. `AbortSignal.timeout(timeout)` would stay armed through the
+      // body read and crash the run on a legit large download. A caller-supplied
+      // signal still takes precedence (left as-is, no extra timer).
+      let res;
+      if (options.signal || !(timeout > 0)) {
+        res = await fetch(url, options);
+      } else {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+        try {
+          res = await fetch(url, { ...options, signal: controller.signal });
+        } finally {
+          clearTimeout(timer);
+        }
+      }
       // Retryable HTTP status → throw a tagged transient error so the backoff
       // loop retries it. On the FINAL attempt fetchWithRetry re-throws this, so
       // we attach the Response to let the caller still inspect it if it catches.

--- a/scripts/lib/transient-fetch.mjs
+++ b/scripts/lib/transient-fetch.mjs
@@ -138,3 +138,64 @@ export async function fetchWithRetry(attemptFn, opts = {}) {
   }
   throw lastErr;
 }
+
+/**
+ * Resilient `fetch` wrapper for one-shot data-refresh downloads (BAG/SECO/ISTAT/
+ * FSO/PostHog/exchange-history…). A SINGLE transient network blip (DNS hiccup,
+ * `UND_ERR_CONNECT_TIMEOUT`, `fetch failed`, socket reset) or a retryable HTTP
+ * status (429/408/425/5xx) used to crash the whole scheduled run and auto-file a
+ * priority:high "Workflow Failure" issue. This wraps the native `fetch` in the
+ * shared exponential-backoff-with-jitter loop so transient failures self-heal,
+ * while persistent errors (4xx other than 408/425/429, parse errors, a source
+ * that is genuinely unreachable after all retries) still fail loudly.
+ *
+ * Behaviour preserved vs a raw `fetch(url, options)`:
+ *   - returns the same `Response` object (caller still does `.text()`/`.json()`/
+ *     `.arrayBuffer()`, inspects `.ok`/`.status`/`.headers` as before);
+ *   - does NOT throw on a non-retryable non-ok status — the caller keeps its own
+ *     `if (!res.ok) …` handling (e.g. graceful-degradation paths);
+ *   - adds an `AbortSignal.timeout(timeout)` so a hung socket aborts instead of
+ *     blocking the run forever (the abort is itself treated as transient).
+ *
+ * Retryable HTTP statuses are surfaced as a thrown tagged error so the backoff
+ * loop sees them; after the final attempt the real `Response` is returned so the
+ * caller's own status handling runs unchanged.
+ *
+ * Env overrides (shared with fetchWithRetry):
+ *   JOBS_CRAWLER_RETRIES, JOBS_CRAWLER_RETRY_BASE_MS
+ *
+ * @param {string|URL} url
+ * @param {RequestInit} [options]  native fetch options (headers, method, body…)
+ * @param {Object} [opts] — { retries, retryBaseMs, timeout, label }
+ *   timeout: per-attempt abort timeout in ms (default 30000)
+ * @returns {Promise<Response>}
+ */
+export async function httpFetchWithRetry(url, options = {}, opts = {}) {
+  const timeout = Number.isFinite(opts.timeout) ? opts.timeout : 30000;
+  const label = opts.label || String(url);
+  return fetchWithRetry(
+    async () => {
+      // A caller-supplied signal takes precedence; otherwise apply our timeout.
+      const signal = options.signal ?? (timeout > 0 ? AbortSignal.timeout(timeout) : undefined);
+      const res = await fetch(url, { ...options, signal });
+      // Retryable HTTP status → throw a tagged transient error so the backoff
+      // loop retries it. On the FINAL attempt fetchWithRetry re-throws this, so
+      // we attach the Response to let the caller still inspect it if it catches.
+      if (RETRYABLE_STATUS.has(res.status)) {
+        const err = new Error(`HTTP ${res.status} ${res.statusText} for ${label}`);
+        err.status = res.status;
+        err.retryable = true;
+        err.response = res;
+        throw err;
+      }
+      return res;
+    },
+    { ...opts, label },
+  ).catch((err) => {
+    // If the last failure was a retryable HTTP status, hand the real Response
+    // back so the caller's own `if (!res.ok)` logic runs unchanged instead of
+    // forcing every call site to special-case our thrown error.
+    if (err && err.retryable === true && err.response) return err.response;
+    throw err;
+  });
+}

--- a/scripts/update-exchange-history.mjs
+++ b/scripts/update-exchange-history.mjs
@@ -12,6 +12,7 @@
  */
 
 import admin from 'firebase-admin';
+import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
 
 admin.initializeApp({
   credential: admin.credential.applicationDefault(),
@@ -59,7 +60,7 @@ async function fetchFromFrankfurter(startStr, endStr) {
         const cs = chunkStart.toISOString().slice(0, 10);
         const ce = chunkEnd.toISOString().slice(0, 10);
         const url = `${base}/v2/rates?base=CHF&quotes=EUR&from=${cs}&to=${ce}`;
-        const res = await fetch(url, { signal: AbortSignal.timeout(15000) });
+        const res = await httpFetchWithRetry(url, {}, { timeout: 15000, label: `exchange ${cs}..${ce}` });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         if (Array.isArray(data)) {

--- a/scripts/update-switzerland-unemployment-rate.mjs
+++ b/scripts/update-switzerland-unemployment-rate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { fetchWithRetry, RETRYABLE_STATUS } from './lib/transient-fetch.mjs';
+import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
 
 const SOURCE_URL = 'https://www.arbeit.swiss/secoalv/it/home.html';
 const OUT_FILE = path.resolve(process.cwd(), 'public/data/switzerland-unemployment-rate.json');
@@ -236,28 +236,18 @@ function generateSeoText(parsed, history) {
  * 4xx fail fast. On non-ok HTTP the status + URL are surfaced for diagnosability.
  */
 async function fetchSecoHtml(timeoutMs = 30000) {
-  return fetchWithRetry(async () => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const res = await fetch(SOURCE_URL, {
-        headers: {
-          'user-agent': 'FrontaliereTicinoBot/1.0 (+https://frontaliereticino.ch)',
-          accept: 'text/html,application/xhtml+xml',
-        },
-        signal: controller.signal,
-      });
-      if (!res.ok) {
-        const err = new Error(`HTTP ${res.status} ${res.statusText} from ${SOURCE_URL}`);
-        err.status = res.status;
-        err.retryable = RETRYABLE_STATUS.has(res.status);
-        throw err;
-      }
-      return await res.text();
-    } finally {
-      clearTimeout(timer);
-    }
-  }, { label: 'unemployment SECO page' });
+  const res = await httpFetchWithRetry(SOURCE_URL, {
+    headers: {
+      'user-agent': 'FrontaliereTicinoBot/1.0 (+https://frontaliereticino.ch)',
+      accept: 'text/html,application/xhtml+xml',
+    },
+  }, { timeout: timeoutMs, label: 'unemployment SECO page' });
+  // Transient 429/5xx + network blips were retried inside the helper; a
+  // persistent non-ok still fails fast so we never parse an error page.
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} from ${SOURCE_URL}`);
+  }
+  return await res.text();
 }
 
 async function main() {

--- a/tests/transient-fetch.test.ts
+++ b/tests/transient-fetch.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   isTransientFetchError,
   isConnectionLevelFetchError,
   fetchWithRetry,
+  httpFetchWithRetry,
   RETRYABLE_STATUS,
 } from '../scripts/lib/transient-fetch.mjs';
+
+const mkResponse = (status: number) =>
+  ({ ok: status >= 200 && status < 300, status, statusText: `S${status}` }) as Response;
 
 describe('isTransientFetchError', () => {
   it('classifies node "fetch failed" TypeError as transient', () => {
@@ -111,5 +115,59 @@ describe('fetchWithRetry', () => {
       fetchWithRetry(attempt, { retries: 1, retryBaseMs: 0, isTransient: () => true }),
     ).rejects.toThrow();
     expect(attempt).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('httpFetchWithRetry', () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('retries a transient network throw then returns the Response', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_CONNECT_TIMEOUT' } }),
+      )
+      .mockResolvedValueOnce(mkResponse(200)) as unknown as typeof fetch;
+    const res = await httpFetchWithRetry('https://x.test', {}, { retryBaseMs: 0 });
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a retryable HTTP status (503) then returns the recovered Response', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mkResponse(503))
+      .mockResolvedValueOnce(mkResponse(200)) as unknown as typeof fetch;
+    const res = await httpFetchWithRetry('https://x.test', {}, { retryBaseMs: 0 });
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the final retryable Response (no throw) after exhausting retries', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mkResponse(503)) as unknown as typeof fetch;
+    // Caller keeps its own res.ok handling — the helper must hand back the
+    // Response rather than throwing so graceful-degradation paths run.
+    const res = await httpFetchWithRetry('https://x.test', {}, { retries: 2, retryBaseMs: 0 });
+    expect(res.status).toBe(503);
+    expect(res.ok).toBe(false);
+    expect(global.fetch).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it('does NOT retry a persistent non-ok status (404) and returns it once', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mkResponse(404)) as unknown as typeof fetch;
+    const res = await httpFetchWithRetry('https://x.test', {}, { retryBaseMs: 0 });
+    expect(res.status).toBe(404);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 2xx Response on the first try without retrying', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mkResponse(200)) as unknown as typeof fetch;
+    const res = await httpFetchWithRetry('https://x.test', {}, { retryBaseMs: 0 });
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/transient-fetch.test.ts
+++ b/tests/transient-fetch.test.ts
@@ -170,4 +170,23 @@ describe('httpFetchWithRetry', () => {
     expect(res.status).toBe(200);
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
+
+  it('clears the connection-phase timer once headers arrive (body read not aborted)', async () => {
+    // Regression: the helper must bound only the connection/header phase, not
+    // the body read. An `AbortSignal.timeout` left armed through `.arrayBuffer()`
+    // on a multi-MB BAG ZIP/XLSX would abort mid-stream → AbortError outside the
+    // caller's try/catch → run crash (the very failure this helper prevents).
+    let captured: AbortSignal | undefined;
+    global.fetch = vi.fn((_url: unknown, options: { signal?: AbortSignal } = {}) => {
+      captured = options.signal;
+      return Promise.resolve(mkResponse(200));
+    }) as unknown as typeof fetch;
+    const res = await httpFetchWithRetry('https://x.test', {}, { timeout: 10, retryBaseMs: 0 });
+    expect(res.status).toBe(200);
+    // Wait past the 10ms connection-phase timeout. Because the timer was cleared
+    // the instant headers arrived, the request signal must NOT abort — a slow
+    // body read would survive instead of throwing AbortError.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(captured?.aborted ?? false).toBe(false);
+  });
 });


### PR DESCRIPTION
## Implementato

Resilienza fetch per i workflow di data-refresh schedulati che fallivano su un
SINGOLO blip di rete transiente (nessun retry) — facendo fallire l'intera run e
auto-aprendo una issue priority:high "Workflow Failure".

- **Helper condiviso UNICO** `httpFetchWithRetry(url, options, opts)` aggiunto a
  `scripts/lib/transient-fetch.mjs` (accanto al già esistente `fetchWithRetry`).
  Wrappa il `fetch` nativo nel loop di backoff esponenziale + jitter già presente:
  - retry su throw di rete transienti (`fetch failed`, `ECONNRESET`,
    `UND_ERR_CONNECT_TIMEOUT`, socket hang up, abort/timeout) e su status HTTP
    retryabili (408/425/429/5xx via `RETRYABLE_STATUS`);
  - `AbortSignal.timeout` per-attempt (default 30s) così un socket appeso aborta
    invece di bloccare la run all'infinito;
  - ritorna lo stesso `Response` nativo (il caller continua a fare
    `.text()`/`.json()`/`.arrayBuffer()` e a ispezionare `.ok`/`.status`) —
    NON throwa su non-ok non-retryabile, così i path di graceful-degradation
    (es. `NoArchiveError`, check `403`) restano invariati;
  - 3 tentativi default (env override `JOBS_CRAWLER_RETRIES` /
    `JOBS_CRAWLER_RETRY_BASE_MS`, condivisi con `fetchWithRetry`).

- **Intera CLASSE migrata al modulo condiviso** (no copy-paste inline → drift
  impossibile by-construction, AGENTS.md #6):
  - `scripts/fetch-health-premiums.mjs` (#1550) — `download()` + fetch archivio
    storico in `fetchPremiumsCsv` ora via helper; rimosso il blocco
    `controller/timer/err.retryable` duplicato 2x. Comportamento identico:
    current-year CSV, ZIP storico, `NoArchiveError` → exit 2 graceful.
  - `scripts/update-switzerland-unemployment-rate.mjs` (#1533, era
    `UND_ERR_CONNECT_TIMEOUT`) — `fetchSecoHtml` ora via helper; rimosso il
    terzo clone inline dello stesso blocco.
  - `scripts/update-exchange-history.mjs` — `fetch(url)` Frankfurter (throwava su
    transiente, zero retry) ora resiliente.
  - `scripts/fetch-thin-page-promotions.mjs` — POST PostHog HogQL + GA4 runReport
    (throwavano su transiente) ora resilienti; il check `403` GA4 preservato.
  - `scripts/cleanup-mailjet-contacts.mjs` — rimosso il `fetchWithRetry` inline
    (retryava SOLO 429/5xx, NON i throw di rete → proprio il buco che causava i
    fallimenti) e sostituito col condiviso (rete + status + timeout).

- **Test**: `tests/transient-fetch.test.ts` esteso con 5 casi per
  `httpFetchWithRetry` (retry su throw di rete, retry su 503→200, ritorno del
  Response 503 finale senza throw dopo esaurimento, no-retry su 404, 2xx
  immediato). Suite intera verde in locale.

Riferimento ombrello #1322 (structural fixes per i Workflow Failure ricorrenti):
questa PR chiude la classe "transient fetch senza retry" per gli script di
data-refresh.

Closes #1533
Closes #1550

## Non implementato (ancora)

- **Consecutive-failures gate** (fail-loud solo dopo N run consecutive fallite,
  non al primo): non esiste un pattern `consecutive`-gate riutilizzabile per
  questi script schedulati nel repo. Il retry-con-backoff copre già i blip
  transienti (il vero driver di #1533/#1550); il gate consecutivo resta come
  follow-up più profondo e fuori scope per questa PR di sola resilienza. Una
  fonte genuinamente irraggiungibile dopo tutti i retry continua a fallire
  rumorosamente (issue-creation preservata), come richiesto.
- **Script "best-effort probe"** (`fetch-fso-rental-medians.mjs`,
  `fetch-istat-cost-basket.mjs`, `fetch-mebeko-equivalence.mjs`,
  `fetch-sefri-equivalence.mjs`): NON migrati. Questi già catturano ogni errore
  e degradano su snapshot committato (un blip transiente NON fa fallire la run →
  fuori dalla classe di failure di #1533/#1550/#1322). Aggiungere retry lì è solo
  cosmetico (migliora il metadato `probe`) e tocca semantica di fallback
  delicata; deferito per mantenere il change chirurgico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
