### PR TITLE
fix(job-alerts): stabilize prompt effect deps on selectedJob?.id (residual toast flake)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2356,6 +2356,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const userEmail = authUser?.email || null;
  const userId = authUser?.uid || null;
  useEffect(() => {
+ try { console.log('[AlertDebug] enter', { detail: isJobDetailView, flag: enableJobAlerts, uid: !!userId, email: !!userEmail, inFlight: newsletterAutologinInFlight, jobId: selectedJob?.id }); } catch { /* noop */ }
  if (!isJobDetailView || !selectedJob) return;
  if (!enableJobAlerts) return;
  if (!userId || !userEmail) {
@@ -2427,8 +2428,10 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // never fires (observed: hasUser:true at +4 s, then no toast). They clicked a
  // job in an email = peak intent, so treat them like an in-app post-auth unlock.
  const showImmediately = justAuthed || wasNewsletterAutologinAttempted();
+ try { console.log('[AlertDebug] arm timer', { delayMs: showImmediately ? 0 : 1500, existing: existing.length, category: localizedCategory }); } catch { /* noop */ }
  timerId = window.setTimeout(() => {
- if (cancelled) return;
+ if (cancelled) { try { console.log('[AlertDebug] timer cancelled before fire'); } catch { /* noop */ } return; }
+ try { console.log('[AlertDebug] FIRE — prompt visible'); } catch { /* noop */ }
  setJobDetailPromptCategory(localizedCategory);
  setJobDetailPromptVisible(true);
  Analytics.trackJobAlertCtaShown('job_detail_prompt', localizedCategory);

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2439,7 +2439,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  cancelled = true;
  if (timerId !== null) window.clearTimeout(timerId);
  };
- }, [isJobDetailView, selectedJob, enableJobAlerts, newsletterAutologinInFlight, userId, userEmail, t]);
+ // Depend on selectedJob?.id, not the object: the detail enrichment fetch
+ // replaces selectedJob with a new ref for the SAME job, which re-ran this
+ // effect and cancelled the reveal timer before it could fire — the residual
+ // flake after the 0 s change. A real navigation changes the id and still
+ // re-runs / re-arms.
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [isJobDetailView, selectedJob?.id, enableJobAlerts, newsletterAutologinInFlight, userId, userEmail, t]);
 
  // Auto-unmount the prompt if the user logs out or leaves the detail view.
  useEffect(() => {


### PR DESCRIPTION
## Contesto
Dopo il fix immediate-fire #1686 il prompt job-alert **fira per la maggioranza** (GA4: ~14 `cta_shown`/30min, **0 skip**) ma resta **flaky**: in alcune sessioni il toast non appare (riprodotto live: loggato, `getUserAlerts` OK, **nessun skip in GA4**, eppure niente toast → cancellazione **silenziosa** del timer).

## Root cause
Il fetch di enrichment del dettaglio **rimpiazza `selectedJob` con un nuovo ref per lo STESSO job** → l'effetto del prompt si ri-runna → la cleanup annulla il reveal-timer prima che scatti. È la finestra residua dopo il passaggio a 0s.

## Implementato
- Dipendenza dell'effetto su **`selectedJob?.id`** invece dell'oggetto `selectedJob`: il churn di ref sullo stesso job non ri-runna più l'effetto (timer sopravvive). Una **navigazione reale** cambia l'id e ri-arma comunque.
- `// eslint-disable-next-line react-hooks/exhaustive-deps` perché il body usa ancora `selectedJob` (stesso job → category invariata, sicuro).

## Non implementato (ancora)
- **Sibling sweep (`build-plugins/jobsSeoPagesPlugin.ts`, `build-plugins/shared/slimJobIndex.ts`)**: i file condividono il token `selectedJob` solo in commenti SSG (seed del record slim per l'SPA al primo render); nessun `useEffect` dep-array → non affetti dall'antipattern. Nessun fix necessario.
- **Verifica post-deploy** (post-merge, live): click reale da newsletter → toast deve apparire affidabilmente subito dopo l'auth, e in GA4 `cta_shown` salire senza buchi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)