### PR TITLE
perf(locale-router): raise edge cache TTL 1h→2h (CF cap, already deployed)

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -42,10 +42,13 @@ const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 // keeps frontaliere-locale-router under the free-tier 100k/day cap once the
 // asset fan-out is gone (#1665 + route drop). Safe against stale-HTML 404s:
 // superseded CDN asset hashes are retained GRACE_DAYS=7 (prune-cdn-assets.mjs),
-// far longer than this TTL, so HTML served up to 1h stale still resolves every
+// far longer than this TTL, so HTML served up to 2h stale still resolves every
 // referenced /assets hash. Live job data is client-fetched fresh from the CDN at
-// runtime (not baked into this cached HTML), so a 1h-stale SEO shell is fine.
-const CACHE_MAX_AGE = 3600; // 1 h
+// runtime (not baked into this cached HTML), so a 2h-stale SEO shell is fine.
+// Bumped 3600->7200 (2026-06-10): on the free plan the Worker is mandatory for
+// the shard Host rewrite (Origin Rules' Host-header override is paid-only), so
+// edge caching is the only lever left to cut invocations under the 100k/day cap.
+const CACHE_MAX_AGE = 7200; // 2 h
 
 export default {
   async fetch(request, _env, ctx) {


### PR DESCRIPTION
## Implementato
Raised `CACHE_MAX_AGE` 3600→7200 (2h) in the locale-router Worker. **Already deployed via `npx wrangler deploy`** (fresh run: `cache-control: public, max-age=7200, s-maxage=7200`; en/de/fr 200).

### Why
On the **free plan the Worker is mandatory** for the shard Host rewrite — Cloudflare Origin Rules' Host-header override (which would serve en/de/fr without a Worker) is **paid-only** (`not entitled to use the HostHeader override`). So edge caching is the only lever left to cut `frontaliere-locale-router` invocations under the 100k/day account cap. A longer edge TTL means more repeat/overlapping hits are served as cf HITs that don't re-invoke the Worker.

### Safety
- 2h ≪ 7-day CDN asset-hash grace (`prune-cdn-assets.mjs`) → up-to-2h-stale HTML still resolves every `/assets/<hash>` (no 404).
- Live job data is client-fetched fresh from the CDN (`__CDN_DATA_BASE__`), not baked into the cached SEO shell → 2h-stale shell has no functional impact.

## Non implementato (ancora)
- Long-tail single-crawl floor remains (1 invocation per cold URL per 2h window). Origin-Rule de-worker is blocked on free (paid Host-header override). Durable removal would need Workers Paid ($5/mo) or a different proxy mechanism.
- posthog-proxy reduction tracked separately (under investigation).
- No CI test (Worker has no harness); verified live.