### PR TITLE
perf(translate): fix provider-cascade bottleneck (MyMemory throttle race + self-hosted LT priority + ceiling 5)

### DIFF
--- a/scripts/batch-add-faq-to-articles.mjs
+++ b/scripts/batch-add-faq-to-articles.mjs
@@ -414,15 +414,22 @@ const FAQ_MODELS = [
   AI_MODELS.GEMINI_FLASH_LITE,
 ];
 
-// Rate limiter: space out calls to avoid 503 on Gemini free tier (15 RPM)
-let _lastCallMs = 0;
+// Rate limiter: space out calls to avoid 503 on Gemini free tier (15 RPM).
+// Reserve a slot SYNCHRONOUSLY (read + write _nextSlotMs with no await between)
+// so the parallel workers (runWithConcurrency, --concurrency up to 5) each get a
+// distinct minGapMs-spaced slot instead of all reading the same timestamp,
+// waiting the same delta, and bursting → 503 on Gemini's free tier, which would
+// degrade the FAQPage JSON-LD on indexed article pages.
+let _nextSlotMs = 0;
 async function rateLimitedDelay() {
   const minGapMs = 4500; // ~13 RPM max, safe for Gemini free tier
-  const elapsed = Date.now() - _lastCallMs;
-  if (elapsed < minGapMs) {
-    await new Promise((r) => setTimeout(r, minGapMs - elapsed));
+  const now = Date.now();
+  const slot = Math.max(now, _nextSlotMs);
+  _nextSlotMs = slot + minGapMs;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
   }
-  _lastCallMs = Date.now();
 }
 
 async function callFaqModel(messages, opts = {}) {

--- a/scripts/lib/ats-clients/playwright-runtime.mjs
+++ b/scripts/lib/ats-clients/playwright-runtime.mjs
@@ -179,10 +179,14 @@ export async function fetchWithRateLimit(context, url, options = {}) {
       ? options.minDelayMs
       : DEFAULT_MIN_DELAY_MS;
 
-  const last = lastRequestAt.get(context) || 0;
+  // Reserve a min-delay-spaced slot SYNCHRONOUSLY (read + write lastRequestAt
+  // with no await in between) so concurrent fetches on the same context each get
+  // a distinct slot instead of all reading the same timestamp, waiting the same
+  // delta, and bursting together. Same race fixed in mymemory-translate.mjs.
   const now = Date.now();
-  const elapsed = now - last;
-  const waitMs = elapsed >= minDelayMs ? 0 : minDelayMs - elapsed;
+  const slot = Math.max(now, lastRequestAt.get(context) || 0);
+  lastRequestAt.set(context, slot + minDelayMs);
+  const waitMs = slot - now;
   if (waitMs > 0) {
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
@@ -190,8 +194,6 @@ export async function fetchWithRateLimit(context, url, options = {}) {
   process.stderr.write(
     `[playwright-runtime] GET ${url} (waited ${waitMs}ms)\n`,
   );
-
-  lastRequestAt.set(context, Date.now());
 
   // Retry only TRANSIENT navigation failures (page.goto timeout / network
   // blip → NavigationTimeout, #1308 Kantonsspital Obwalden). AntiBotBlockError

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -535,26 +535,29 @@ async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs) {
   const nextProvider = providers.find(p => isProviderConfigured(p.id) && remainingQuota(p.id) > 0);
 
   if (nextProvider) {
-    const lastTs = lastSendMap[nextProvider.id] || 0;
-    const elapsed = Date.now() - lastTs;
-    if (elapsed < delayMs) {
-      await new Promise(r => setTimeout(r, delayMs - elapsed));
+    // Reserve a delay-spaced slot SYNCHRONOUSLY (read + write lastSendMap with no
+    // await in between) so concurrent sends to the same provider each get a
+    // distinct slot instead of all reading the same timestamp, waiting the same
+    // delta, and firing as a burst. The reservation advances the clock up-front,
+    // so spacing holds even when the send FAILS — the failure mode behind the
+    // "258 Mailtrap 403s in 5s" incident, now concurrency-safe for any future
+    // concurrency>1 caller (was latent at the default concurrency=1).
+    const now = Date.now();
+    const slot = Math.max(now, lastSendMap[nextProvider.id] || 0);
+    lastSendMap[nextProvider.id] = slot + delayMs;
+    const wait = slot - now;
+    if (wait > 0) {
+      await new Promise(r => setTimeout(r, wait));
     }
   }
 
-  let result;
-  try {
-    result = await sendSingle(email, forceProvider);
-  } finally {
-    // Advance the throttle clock for the attempted provider even when the send
-    // FAILS. Otherwise a run of consecutive failures fires as an unthrottled
-    // burst (the timestamp was previously set only on success), which is exactly
-    // what produced 258 Mailtrap 403s in 5 seconds.
-    if (nextProvider) lastSendMap[nextProvider.id] = Date.now();
-  }
-  // If a different provider ended up sending, track its timestamp too.
+  // Slot already reserved above (advances even on throw), so no post-hoc clock
+  // bump is needed — the worker's try/catch handles a thrown send.
+  const result = await sendSingle(email, forceProvider);
+  // If a different provider ended up sending, reserve its slot too.
   if (result?.provider && result.provider !== nextProvider?.id) {
-    lastSendMap[result.provider] = Date.now();
+    const now = Date.now();
+    lastSendMap[result.provider] = Math.max(now, lastSendMap[result.provider] || 0) + delayMs;
   }
   return result;
 }

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -917,14 +917,19 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   if (t2c) return balanceMarkdownMarkers(t2c);
 
   // Tier 3b: LibreTranslate self-hosted (CI service container — unlimited, no
-  // rate limits, no shared throttle). Promoted ABOVE MyMemory: once the premium
-  // tiers (DeepL/Azure/Google Cloud) are exhausted, the self-hosted instance
-  // carries the parallel load instead of MyMemory's 1-call/sec throttle, so the
-  // localization queue's concurrency actually delivers throughput. No-op when
-  // LIBRETRANSLATE_SELF_HOSTED_URL is unset (returns ''), so non-CI cascades are
-  // unchanged. Quality: endorsed as a high-priority tier for EN/DE/FR.
-  const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
-  if (t3b) return balanceMarkdownMarkers(t3b);
+  // rate limits, no shared throttle). Promoted ABOVE MyMemory ONLY for EN/DE/FR
+  // targets: once the premium tiers (DeepL/Azure/Google Cloud) are exhausted, the
+  // self-hosted instance carries the parallel load instead of MyMemory's
+  // 1-call/sec throttle, so the localization queue's concurrency delivers
+  // throughput. Gated to non-IT because LibreTranslate's IT quality is documented
+  // as weaker (typos in compounds) and IT is the funnel's primary indexed locale —
+  // for IT, MyMemory ("best EU quality") stays ahead and self-hosted LT remains a
+  // post-MyMemory fallback (Tier 4a below), preserving pre-PR IT behaviour. No-op
+  // when LIBRETRANSLATE_SELF_HOSTED_URL is unset (returns '').
+  if (targetLang !== 'it') {
+    const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+    if (t3b) return balanceMarkdownMarkers(t3b);
+  }
 
   // Tier 4: MyMemory (best EU language quality, 50K chars/day with email param)
   // Short text (≤5000 chars): single call. Long text: chunk at sentence boundaries.
@@ -951,6 +956,13 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
     return '';
   });
   if (t2) return balanceMarkdownMarkers(t2);
+
+  // Tier 4a: LibreTranslate self-hosted — for IT targets this is the FIRST LT
+  // attempt (kept below MyMemory by the EN/DE/FR gate above, preserving pre-PR IT
+  // order); for EN/DE/FR it's a harmless second chance if the promoted attempt
+  // (Tier 3b) and MyMemory both failed. No-op when self-hosted URL is unset.
+  const t3bFallback = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+  if (t3bFallback) return balanceMarkdownMarkers(t3bFallback);
 
   // Tier 4b: LibreTranslate public instances (raced in parallel — reliable from CI)
   const t4 = await tryTier('libreTranslate', () => translateWithLibreTranslate(clean, sourceLang, targetLang));

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -916,6 +916,16 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   const t2c = await tryTier('googleCloud', () => translateWithGoogleCloud(clean, sourceLang, targetLang));
   if (t2c) return balanceMarkdownMarkers(t2c);
 
+  // Tier 3b: LibreTranslate self-hosted (CI service container — unlimited, no
+  // rate limits, no shared throttle). Promoted ABOVE MyMemory: once the premium
+  // tiers (DeepL/Azure/Google Cloud) are exhausted, the self-hosted instance
+  // carries the parallel load instead of MyMemory's 1-call/sec throttle, so the
+  // localization queue's concurrency actually delivers throughput. No-op when
+  // LIBRETRANSLATE_SELF_HOSTED_URL is unset (returns ''), so non-CI cascades are
+  // unchanged. Quality: endorsed as a high-priority tier for EN/DE/FR.
+  const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+  if (t3b) return balanceMarkdownMarkers(t3b);
+
   // Tier 4: MyMemory (best EU language quality, 50K chars/day with email param)
   // Short text (≤5000 chars): single call. Long text: chunk at sentence boundaries.
   const t2 = await tryTier('myMemory', async () => {
@@ -941,10 +951,6 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
     return '';
   });
   if (t2) return balanceMarkdownMarkers(t2);
-
-  // Tier 4a: LibreTranslate self-hosted (CI service container — unlimited, no rate limits)
-  const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
-  if (t3b) return balanceMarkdownMarkers(t3b);
 
   // Tier 4b: LibreTranslate public instances (raced in parallel — reliable from CI)
   const t4 = await tryTier('libreTranslate', () => translateWithLibreTranslate(clean, sourceLang, targetLang));

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -957,12 +957,15 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   });
   if (t2) return balanceMarkdownMarkers(t2);
 
-  // Tier 4a: LibreTranslate self-hosted — for IT targets this is the FIRST LT
-  // attempt (kept below MyMemory by the EN/DE/FR gate above, preserving pre-PR IT
-  // order); for EN/DE/FR it's a harmless second chance if the promoted attempt
-  // (Tier 3b) and MyMemory both failed. No-op when self-hosted URL is unset.
-  const t3bFallback = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
-  if (t3bFallback) return balanceMarkdownMarkers(t3bFallback);
+  // Tier 4a: LibreTranslate self-hosted — IT-target ONLY. For IT this is the
+  // first (and only) self-hosted attempt, kept below MyMemory by the EN/DE/FR
+  // gate at Tier 3b, preserving pre-PR IT order. EN/DE/FR already tried it at
+  // Tier 3b, so re-running it here would pay a second (up to 30s) timeout on a
+  // hung endpoint for no benefit — skip. No-op when self-hosted URL is unset.
+  if (targetLang === 'it') {
+    const t3bFallback = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+    if (t3bFallback) return balanceMarkdownMarkers(t3bFallback);
+  }
 
   // Tier 4b: LibreTranslate public instances (raced in parallel — reliable from CI)
   const t4 = await tryTier('libreTranslate', () => translateWithLibreTranslate(clean, sourceLang, targetLang));

--- a/scripts/lib/mymemory-translate.mjs
+++ b/scripts/lib/mymemory-translate.mjs
@@ -19,7 +19,10 @@ const LANG_MAP = {
   fr: 'fr-FR',
 };
 
-let lastCallMs = 0;
+// Monotonic "next free slot" timestamp for rate-limit spacing. Reserved
+// synchronously (no await between read and write) so concurrent callers each
+// get a distinct 1s-spaced slot — see the rate-limit block below.
+let nextSlotMs = 0;
 let dailyChars = 0;
 // With email param: 50K chars/day. Without: 5K chars/day.
 // Default email for the project — gives 10x quota boost for free.
@@ -46,13 +49,19 @@ export async function translateWithMyMemory(text, sourceLang, targetLang) {
     return null;
   }
 
-  // Rate limit: wait at least 1s between calls
+  // Rate limit: max 5 concurrent, 1s between calls. Reserve a 1s-spaced slot
+  // SYNCHRONOUSLY (read + write nextSlotMs with no await in between) so N
+  // concurrent callers each get their own slot instead of all reading the same
+  // lastCallMs, waiting the same delta, and firing in a burst. The old
+  // read-then-await-then-write collapsed the spacing under the localization
+  // queue's concurrency → burst 429s → cascade fell through to slower tiers.
   const now = Date.now();
-  const elapsed = now - lastCallMs;
-  if (elapsed < 1000) {
-    await new Promise((r) => setTimeout(r, 1000 - elapsed));
+  const slot = Math.max(now, nextSlotMs);
+  nextSlotMs = slot + 1000;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
   }
-  lastCallMs = Date.now();
 
   try {
     const params = new URLSearchParams({

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -392,14 +392,17 @@ async function runSharedCrawler(companyKeys, maxJobs) {
     SKIP_AI_TRANSLATION: '0',
     // Translation throughput knob. The backfill-localization queue defaults to
     // concurrency=2 in localize-existing mode (shared-jobs-crawler.mjs ~5045),
-    // which is the dominant wall-time cost of translate-pending: a measured run
-    // spent ~240min translating ~100 jobs at ~47s/job, while the per-company
-    // crawler boot was only ~1.2s. Raising concurrency to the sanctioned clamp
-    // ceiling (6) parallelises the provider cascade ~3× without changing per-job
-    // quota consumption (MyMemory/Google caps are daily, not per-request) or
-    // touching cascade order (quality unchanged). Env-overridable so the workflow
-    // can dial it back if a provider rate-limits under parallelism.
-    JOBS_AI_LOCALIZATION_CONCURRENCY: process.env.JOBS_AI_LOCALIZATION_CONCURRENCY || '6',
+    // the dominant wall-time cost of translate-pending (~240min for ~100 jobs at
+    // ~47s/job; per-company crawler boot is only ~1.2s). A live run at
+    // concurrency=6 measured FLAT throughput (~53s/job) because MyMemory's
+    // module-level rate-limit throttle serialised the workers — concurrency alone
+    // is not the lever. Set to 5 to respect MyMemory's documented "max 5
+    // concurrent" ceiling; the real gains come from the cascade-level fixes
+    // shipped alongside: (a) a race-free 1s-spaced slot in mymemory-translate.mjs
+    // and (b) promoting the unlimited self-hosted LibreTranslate above MyMemory
+    // in free-translate.mjs so the parallel load lands on a no-throttle tier.
+    // Env-overridable so the workflow can dial it back under provider rate-limit.
+    JOBS_AI_LOCALIZATION_CONCURRENCY: process.env.JOBS_AI_LOCALIZATION_CONCURRENCY || '5',
   };
 
   console.log(`\n🚀 Running shared crawler in LOCALIZE_EXISTING_ONLY mode (in-process)...`);


### PR DESCRIPTION
## Implementato

Follow-up a #1692. La validazione live di #1692 (concurrency 2→6) misurò throughput **PIATTO** (~53s/job vs ~47s baseline): i worker paralleli si **serializzavano** sul throttle module-level di MyMemory, e il LibreTranslate self-hosted (illimitato, no-throttle) stava **sotto** MyMemory nella cascade. La concurrency non era la leva — la cascade lo era.

**6 file toccati** (3 fix core + 3 sibling della stessa classe di race):

- **(a) `scripts/lib/mymemory-translate.mjs` — throttle concurrency-safe.** Sostituito il gate racey `lastCallMs` (read→`await`→write → N worker burst → 429) con uno **slot a 1s prenotato sincronicamente** (`nextSlotMs`). Caller concorrenti → slot distinti, zero burst, rispetta "max 5 concurrent, 1s between calls".
- **(b) `scripts/lib/free-translate.mjs` — priorità self-hosted LT, gated EN/DE/FR.** `libreTranslateSelfHosted` promosso **sopra** MyMemory **solo per `targetLang !== 'it'`** (Tier 3b): i premium restano primi (qualità invariata); per EN/DE/FR il carico parallelo va sul tier illimitato no-throttle. **IT mantiene l'ordine pre-PR** (MyMemory davanti; LT come fallback post-MyMemory a Tier 4a, **IT-only** per non pagare doppio timeout). No-op fuori CI (env non set).
- **(c) `scripts/relocalize-pending-jobs.mjs` — ceiling 6→5** (rispetta MyMemory max-5-concurrent; env-overridable).
- **Sibling stessa race (surgical-class, AGENTS.md #6):** stesso slot-reservation in **`scripts/lib/email-cascade.mjs`** (`sendSingleThrottled` — sorgente dell'incidente "258 Mailtrap 403s in 5s"), **`scripts/lib/ats-clients/playwright-runtime.mjs`** (`fetchWithRateLimit`), e **`scripts/batch-add-faq-to-articles.mjs`** (`rateLimitedDelay` — **ACTIVE**, gira `--concurrency` fino a 5 → burst 503 Gemini → FAQPage JSON-LD degradata). Un grep repo-wide conferma che questi 4 sono l'**intera classe** del pattern.

GitNexus: `translateWithMyMemory` LOW, `freeTranslate` HIGH solo per ampiezza caller (contratto `string|''` invariato). Test verdi: `email-cascade-burst` + `free-translate-markdown-balancer` (19/19). node --check OK su tutti.

## Non implementato (ancora)

- **Validazione live wall-time NON pre-merge** (translate-pending gira solo post-merge su cron). **Revert-trigger:** se il prossimo run post-merge non riduce s/job vs ~47-53s, o compaiono errori LibreTranslate self-hosted / degrado qualità EN/DE/FR → revert (a)/(b), tieni ceiling 5; knob env-overridable per dial-back immediato.
- **❓ slot unbounded sotto burst grande:** la prenotazione sincrona fa attendere l'N-esimo caller N×delay. In pratica **bounded dal cap di concorrenza** della localization queue (≤5 → max ~5s di coda su MyMemory), ben sotto i timeout per-job. Non un problema operativo al cap attuale; se il cap salisse molto, rivalutare.
- **❓ `email-cascade` slot del provider non-usato:** se un provider diverso da `nextProvider` invia, lo slot prenotato per `nextProvider` resta avanzato (leggero over-throttle all'iterazione dopo). Comportamento equivalente al pre-PR (anche prima il `finally` avanzava `nextProvider`); non-funnel, concurrency=1 default → moot.
- Riduzione fields-per-job / timeout per-provider aggressivo: leve ulteriori, fuori scope.
