### PR TITLE
fix(unemployment): re-point SECO extractor to current arbeit.swiss markup (#1729)

### DIFF
--- a/scripts/update-switzerland-unemployment-rate.mjs
+++ b/scripts/update-switzerland-unemployment-rate.mjs
@@ -96,11 +96,24 @@ function isPlausibleRate(n) {
 }
 
 function extractRate(text) {
-  const match = text.match(/(tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage)[^%]{0,180}?([0-9]+(?:[.,][0-9]+)?)\s*%/i);
-  if (!match) return null;
-  const n = Number.parseFloat(match[2].replace(',', '.'));
-  if (!isPlausibleRate(n)) return null;
-  return n;
+  const phraseRe = /tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage/i;
+  const pm = phraseRe.exec(text);
+  if (!pm) return null;
+  // Anchor on the rate RESULT, not the first figure after the phrase. When the
+  // rate MOVES, SECO writes two percentages in one sentence — e.g. "…è salito
+  // dal 2,9% al 3,0%" / "…rose from 2.9% to 3.0%" — where the FIRST figure is the
+  // PREVIOUS month's rate. Take the LAST plausible "N,N%" in the same sentence;
+  // on an unchanged month ("…invariato al 3,0%") there is only one figure.
+  const window = text.slice(pm.index + pm[0].length, pm.index + pm[0].length + 180);
+  const figRe = /([0-9]+(?:[.,][0-9]+)?)\s*%/g;
+  let last = null;
+  let fm;
+  // eslint-disable-next-line no-cond-assign
+  while ((fm = figRe.exec(window)) !== null) {
+    const n = Number.parseFloat(fm[1].replace(',', '.'));
+    if (isPlausibleRate(n)) last = n;
+  }
+  return last;
 }
 
 function absolutize(url) {
@@ -167,7 +180,11 @@ function parseLatestUnemployment(html) {
 
   // Match a sentence-sized fragment (bounded by . ; or sentence-ish breaks)
   // that contains the unemployment-rate phrase followed by a "N,N%" figure.
-  const sentenceRe = /[^.;”"]*?(?:tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage)[^.;”"%]{0,180}?[0-9]+(?:[.,][0-9]+)?\s*%/gi;
+  // The trailing `[^.;”"]*` consumes the REST of the sentence past the first `%`
+  // so a changed-month sentence ("…dal 2,9% al 3,0%") reaches extractRate intact
+  // — stopping at the first `%` here would truncate before the rate result and
+  // hand extractRate only the previous month's figure.
+  const sentenceRe = /[^.;”"]*?(?:tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage)[^.;”"]{0,180}?[0-9]+(?:[.,][0-9]+)?\s*%[^.;”"]*/gi;
   let sm;
   while ((sm = sentenceRe.exec(plain)) !== null) {
     const frag = sm[0].trim();

--- a/scripts/update-switzerland-unemployment-rate.mjs
+++ b/scripts/update-switzerland-unemployment-rate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { httpFetchWithRetry } from './lib/transient-fetch.mjs';
 
 const SOURCE_URL = 'https://www.arbeit.swiss/secoalv/it/home.html';
@@ -87,11 +88,18 @@ function extractPeriod(text) {
   return `${m[2]}-${mm}`;
 }
 
+// Plausible registered-unemployment band for Switzerland (historic min ~1.7%,
+// COVID peak ~3.7%). Anything outside 0–15% is almost certainly a mis-parse
+// (a count, a delta, a year) rather than a rate.
+function isPlausibleRate(n) {
+  return Number.isFinite(n) && n >= 0 && n <= 15;
+}
+
 function extractRate(text) {
   const match = text.match(/(tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage)[^%]{0,180}?([0-9]+(?:[.,][0-9]+)?)\s*%/i);
   if (!match) return null;
   const n = Number.parseFloat(match[2].replace(',', '.'));
-  if (!Number.isFinite(n)) return null;
+  if (!isPlausibleRate(n)) return null;
   return n;
 }
 
@@ -101,27 +109,103 @@ function absolutize(url) {
   return new URL(url, SOURCE_URL).toString();
 }
 
-function parseLatestUnemployment(html) {
-  const blockRegex = /<div class="slide">[\s\S]*?<a href="([^"]+)"[\s\S]*?<span class="title">([\s\S]*?)<\/span>[\s\S]*?<p class="focusleaddescription">([\s\S]*?)<\/p>/gi;
-  let match;
-  let best = null;
+const LABOUR_NEWS_RE = /mercato del lavoro|labour market|labor market|arbeitsmarktlage|situation sur le march[eé] du travail|marche du travail/i;
 
-  while ((match = blockRegex.exec(html)) !== null) {
-    const href = absolutize(match[1]);
-    const title = decodeHtml(match[2]);
-    const desc = decodeHtml(match[3]);
-    const merged = `${title} ${desc}`;
-    const rate = extractRate(merged);
-    const period = extractPeriod(merged);
-    const isLabourNews = /mercato del lavoro|labour market|arbeitsmarktlage|marche du travail/i.test(merged);
+// Resolve the canonical SECO labour-market press-release URL for a given rate
+// sentence. On the current arbeit.swiss (Nuxt SPA) the release link lives in the
+// embedded JSON immediately AFTER the rate sentence, e.g.
+//   "…disoccupazione è rimasto invariato al 3,0%.","https://www.admin.ch/it/newnsb/…"
+// The HTML-rendered teaser button carries no resolved href, so we anchor on the
+// rate sentence itself and take the next admin.ch / arbeit.swiss URL after it.
+function findReleaseHref(html, rateSentence) {
+  // The rate sentence appears more than once in the document: once as rendered
+  // HTML (whose teaser button has no resolved href) and once in the embedded
+  // JSON, where it is immediately followed by the canonical press URL. Scan
+  // every occurrence of the distinctive rate-phrase prefix and return the first
+  // admin.ch / arbeit.swiss press link that follows within a short window.
+  const prefix = (rateSentence.match(/tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage/i) || [])[0];
+  const adminRe = /https?:\/\/www\.admin\.ch\/[a-zA-Z0-9/_-]+/;
+  const localRe = /https?:\/\/www\.arbeit\.swiss\/[a-zA-Z0-9/_.-]*(?:comunicat|press|medien|communiqu|news)[a-zA-Z0-9/_.-]*/i;
 
-    if (!rate || !period || !isLabourNews) continue;
-    if (!best || period > best.period) {
-      best = { href, title, desc, rate, period };
+  if (prefix) {
+    let from = 0;
+    let idx;
+    let localHit = '';
+    // eslint-disable-next-line no-cond-assign
+    while ((idx = html.indexOf(prefix, from)) >= 0) {
+      const window = html.slice(idx, idx + 600);
+      const admin = window.match(adminRe);
+      if (admin) return admin[0];
+      if (!localHit) {
+        const local = window.match(localRe);
+        if (local) localHit = absolutize(local[0]);
+      }
+      from = idx + prefix.length;
     }
+    if (localHit) return localHit;
+  }
+  // Last resort: the home page itself (still a valid, stable SECO source).
+  return SOURCE_URL;
+}
+
+// Robust extractor for the SECO/arbeit.swiss home page.
+//
+// The page is a Nuxt single-page app. Its labour-market teaser renders the rate
+// in a single self-contained sentence that names BOTH the period and the rate,
+// e.g. "Nel mese di maggio 2026 il tasso di disoccupazione è rimasto invariato
+// al 3,0%." (the same text also appears in the embedded JSON payload, alongside
+// the canonical admin.ch press-release URL). Rather than bind to one fragile
+// selector/`<div class="slide">` block (the old markup, now gone), we decode the
+// whole document to plain text and scan for that sentence — requiring the rate
+// AND the month+year period to occur in the SAME sentence so unrelated headings
+// (e.g. "Portale lavoro.swiss – nuova veste da giugno 2026") cannot bleed their
+// month into the rate. The newest such period wins. This survives markup churn
+// as long as the rate sentence itself stays in the page text.
+function parseLatestUnemployment(html) {
+  const plain = decodeHtml(html);
+  const candidates = [];
+
+  // Match a sentence-sized fragment (bounded by . ; or sentence-ish breaks)
+  // that contains the unemployment-rate phrase followed by a "N,N%" figure.
+  const sentenceRe = /[^.;”"]*?(?:tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage)[^.;”"%]{0,180}?[0-9]+(?:[.,][0-9]+)?\s*%/gi;
+  let sm;
+  while ((sm = sentenceRe.exec(plain)) !== null) {
+    const frag = sm[0].trim();
+    const rate = extractRate(frag);
+    // Period MUST come from the same sentence as the rate — no cross-block reuse
+    // (prevents an unrelated heading like "…nuova veste da giugno 2026" from
+    // donating its month to the rate figure).
+    const period = extractPeriod(frag);
+    if (rate == null || !period) continue;
+    // Labour-market keyword is a soft corroboration: it usually lives in the
+    // teaser heading next to the sentence, not inside the sentence itself, so we
+    // check a wider window. The rate phrase + same-sentence period are already
+    // unemployment-specific, so a missing keyword is allowed but de-prioritised.
+    const start = Math.max(0, sm.index - 220);
+    const around = plain.slice(start, sm.index + frag.length + 60);
+    const corroborated = LABOUR_NEWS_RE.test(around);
+    candidates.push({ text: frag, rate, period, corroborated });
   }
 
-  return best;
+  if (candidates.length === 0) return null;
+
+  // Prefer labour-market-corroborated candidates; among those, the newest period
+  // wins (ISO YYYY-MM compares lexicographically). Fall back to the newest
+  // uncorroborated candidate only if nothing is corroborated.
+  const corroborated = candidates.filter((c) => c.corroborated);
+  const pool = corroborated.length > 0 ? corroborated : candidates;
+  let best = null;
+  for (const c of pool) {
+    if (!best || c.period > best.period) best = c;
+  }
+
+  return {
+    href: findReleaseHref(html, best.text),
+    title: best.text.slice(0, 200),
+    desc: best.text,
+    rate: best.rate,
+    period: best.period,
+  };
 }
 
 function safeReadJson(filePath) {
@@ -254,7 +338,17 @@ async function main() {
   const html = await fetchSecoHtml();
   const parsed = parseLatestUnemployment(html);
   if (!parsed) {
-    throw new Error('Unable to parse unemployment rate from SECO page');
+    // Fail loud (no silent default): the page is a Nuxt SPA whose labour-market
+    // teaser carries the rate in a sentence like "…tasso di disoccupazione …
+    // al N,N%". If this throws, the SECO source markup/wording drifted and the
+    // extractor in parseLatestUnemployment() needs re-pointing.
+    throw new Error(
+      `Unable to parse unemployment rate from SECO page (${SOURCE_URL}). ` +
+        'Tried: rate sentence ("tasso di disoccupazione/unemployment rate/' +
+        'Arbeitslosenquote/taux de chômage … N,N%") with a same-sentence ' +
+        'month+year period and a labour-market keyword. Source markup likely ' +
+        'changed — update parseLatestUnemployment().',
+    );
   }
 
   const previous = safeReadJson(OUT_FILE);
@@ -290,7 +384,12 @@ async function main() {
   console.log(`[unemployment] Updated ${OUT_FILE}: ${payload.period} -> ${payload.rate}%`);
 }
 
-main().catch((err) => {
-  console.error('[unemployment] ERROR', err);
-  process.exit(1);
-});
+export { parseLatestUnemployment, extractRate, extractPeriod, isPlausibleRate };
+
+// Only fetch + write when run directly (not when imported by tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('[unemployment] ERROR', err);
+    process.exit(1);
+  });
+}

--- a/scripts/update-switzerland-unemployment-rate.mjs
+++ b/scripts/update-switzerland-unemployment-rate.mjs
@@ -95,9 +95,12 @@ function isPlausibleRate(n) {
   return Number.isFinite(n) && n >= 0 && n <= 15;
 }
 
+// Shared rate-phrase alternation (IT/EN/DE/FR). Stateless (no `g` flag) so it is
+// safe to reuse across extractRate / findReleaseHref without lastIndex carryover.
+const RATE_PHRASE_RE = /tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage/i;
+
 function extractRate(text) {
-  const phraseRe = /tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage/i;
-  const pm = phraseRe.exec(text);
+  const pm = RATE_PHRASE_RE.exec(text);
   if (!pm) return null;
   // Anchor on the rate RESULT, not the first figure after the phrase. When the
   // rate MOVES, SECO writes two percentages in one sentence — e.g. "…è salito
@@ -122,38 +125,47 @@ function absolutize(url) {
   return new URL(url, SOURCE_URL).toString();
 }
 
-const LABOUR_NEWS_RE = /mercato del lavoro|labour market|labor market|arbeitsmarktlage|situation sur le march[eé] du travail|marche du travail/i;
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
-// Resolve the canonical SECO labour-market press-release URL for a given rate
+// Resolve the canonical SECO labour-market press-release URL for the WINNING rate
 // sentence. On the current arbeit.swiss (Nuxt SPA) the release link lives in the
-// embedded JSON immediately AFTER the rate sentence, e.g.
+// embedded JSON as the value IMMEDIATELY following the rate sentence, e.g.
 //   "…disoccupazione è rimasto invariato al 3,0%.","https://www.admin.ch/it/newnsb/…"
-// The HTML-rendered teaser button carries no resolved href, so we anchor on the
-// rate sentence itself and take the next admin.ch / arbeit.swiss URL after it.
 function findReleaseHref(html, rateSentence) {
-  // The rate sentence appears more than once in the document: once as rendered
-  // HTML (whose teaser button has no resolved href) and once in the embedded
-  // JSON, where it is immediately followed by the canonical press URL. Scan
-  // every occurrence of the distinctive rate-phrase prefix and return the first
-  // admin.ch / arbeit.swiss press link that follows within a short window.
-  const prefix = (rateSentence.match(/tasso di disoccupazione|unemployment rate|arbeitslosenquote|taux de ch[oô]mage/i) || [])[0];
-  const adminRe = /https?:\/\/www\.admin\.ch\/[a-zA-Z0-9/_-]+/;
-  const localRe = /https?:\/\/www\.arbeit\.swiss\/[a-zA-Z0-9/_.-]*(?:comunicat|press|medien|communiqu|news)[a-zA-Z0-9/_.-]*/i;
+  const adminRe = /^https?:\/\/www\.admin\.ch\//;
+  const localRe = /^https?:\/\/www\.arbeit\.swiss\/[a-zA-Z0-9/_.-]*(?:comunicat|press|medien|communiqu|news)/i;
 
-  if (prefix) {
-    let from = 0;
-    let idx;
+  // Bind to the SAME occurrence that produced the winning rate/period — NOT the
+  // first rate-phrase prefix anywhere in the doc (#1732 review #1: the page
+  // carries several rate sentences — multiple teasers each with their OWN
+  // admin.ch link, plus an unrelated "alto tasso di disoccupazione" professions
+  // block — so a loose "first admin within N chars" scan could cite an unrelated
+  // teaser's link; with two teasers the rendered-HTML copy of the winner even
+  // picked up the EARLIER teaser's JSON link). We require the link to be the JSON
+  // value DIRECTLY after the winning sentence: rate phrase + the RESULT figure
+  // (last "N,N%"), then the sentence's closing `."` and the JSON `,"URL"`. The
+  // gap class `[^.;"<>]*?` may cross an earlier in-sentence percentage (the
+  // previous-month figure of a changed-month "…dal 2,9% al 3,0%") to reach the
+  // result, but stops at the sentence terminator before the next teaser. The
+  // adjacency requirement makes the rendered-HTML copy (no quoted URL after it)
+  // non-matching, so only the JSON copy of the winner can bind.
+  const resultFig = [...rateSentence.matchAll(/([0-9]+(?:[.,][0-9]+)?)\s*%/g)].pop();
+  if (resultFig) {
+    const figRx = escapeRegExp(resultFig[1]).replace(/[.,]/g, '[.,]');
+    const anchorRe = new RegExp(
+      `(?:${RATE_PHRASE_RE.source})[^.;"<>]*?${figRx}\\s*%[.\\s]*"\\s*,\\s*"(https?:\\/\\/[^"]+)"`,
+      'gi',
+    );
+    let m;
     let localHit = '';
     // eslint-disable-next-line no-cond-assign
-    while ((idx = html.indexOf(prefix, from)) >= 0) {
-      const window = html.slice(idx, idx + 600);
-      const admin = window.match(adminRe);
-      if (admin) return admin[0];
-      if (!localHit) {
-        const local = window.match(localRe);
-        if (local) localHit = absolutize(local[0]);
-      }
-      from = idx + prefix.length;
+    while ((m = anchorRe.exec(html)) !== null) {
+      const url = m[1];
+      if (adminRe.test(url)) return url;
+      if (!localHit && localRe.test(url)) localHit = absolutize(url);
+      if (anchorRe.lastIndex === m.index) anchorRe.lastIndex += 1;
     }
     if (localHit) return localHit;
   }
@@ -194,25 +206,23 @@ function parseLatestUnemployment(html) {
     // donating its month to the rate figure).
     const period = extractPeriod(frag);
     if (rate == null || !period) continue;
-    // Labour-market keyword is a soft corroboration: it usually lives in the
-    // teaser heading next to the sentence, not inside the sentence itself, so we
-    // check a wider window. The rate phrase + same-sentence period are already
-    // unemployment-specific, so a missing keyword is allowed but de-prioritised.
-    const start = Math.max(0, sm.index - 220);
-    const around = plain.slice(start, sm.index + frag.length + 60);
-    const corroborated = LABOUR_NEWS_RE.test(around);
-    candidates.push({ text: frag, rate, period, corroborated });
+    candidates.push({ text: frag, rate, period });
   }
 
   if (candidates.length === 0) return null;
 
-  // Prefer labour-market-corroborated candidates; among those, the newest period
-  // wins (ISO YYYY-MM compares lexicographically). Fall back to the newest
-  // uncorroborated candidate only if nothing is corroborated.
-  const corroborated = candidates.filter((c) => c.corroborated);
-  const pool = corroborated.length > 0 ? corroborated : candidates;
+  // Selection: the rate phrase + a SAME-SENTENCE month+year period is already
+  // unemployment-specific — the only other rate-phrase occurrences on the page
+  // (an "alto tasso di disoccupazione" professions block) carry no period in
+  // their own sentence and are dropped above. A previous "labour-market keyword
+  // within 220 chars" corroboration gate was DEAD on the live page (#1732 review
+  // #2): the heading "La situazione sul mercato del lavoro…" sits ~329 chars
+  // before the rate sentence (the disoccupati paragraph intervenes), so it never
+  // matched and the gate silently degraded to newest-period-only while implying
+  // a guarantee it didn't provide. It is removed rather than left as dead code.
+  // The newest period wins (ISO YYYY-MM compares lexicographically).
   let best = null;
-  for (const c of pool) {
+  for (const c of candidates) {
     if (!best || c.period > best.period) best = c;
   }
 

--- a/tests/__fixtures__/seco-unemployment-home.ts
+++ b/tests/__fixtures__/seco-unemployment-home.ts
@@ -50,3 +50,32 @@ export const SECO_UNEMPLOYMENT_EXPECTED = {
   period: '2026-05',
   href: 'https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr',
 };
+
+/**
+ * Changed-month variant (#1732). When the rate MOVES, SECO writes TWO
+ * percentages in the SAME sentence ("…è salito dal 2,9% al 3,0%"). The extractor
+ * must bind to the rate RESULT (the last figure, 3,0%), NOT the previous month's
+ * rate (2,9%) — anchoring on the first `%` would persist 2,9% under the new
+ * 2026-05 period and put a wrong headline figure on the SEO pages. Same markup
+ * shape as the snapshot above, only the rate sentence differs.
+ */
+export const SECO_UNEMPLOYMENT_CHANGED_MONTH_HTML = `
+<!doctype html><html lang="it"><head><title>SECO</title></head><body>
+<div id="__nuxt">
+  <div class="u-base-card u-teaser-card u-teaser-card--list"><!--[--><!--]-->
+    <div class="u-base-card__body__text"><!--[--><!--]-->
+      <h5 class="u-heading"><span>La situazione sul mercato del lavoro nel mese di maggio 2026</span></h5>
+      <span class="u-teaser-card__description">Nel mese di maggio 2026 il numero dei disoccupati &#232; aumentato di 4&#8217;512 unit&#224; (+3,3%) rispetto al mese precedente. Nel mese di maggio 2026 il tasso di disoccupazione &#232; salito dal 2,9% al 3,0%.</span><!--]-->
+    </div>
+  </div>
+</div>
+<script>window.__NUXT__=(function(){return {data:[{"lead":"Nel mese di maggio 2026 il tasso di disoccupazione è salito dal 2,9% al 3,0%.","https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr",{"component":7424}]}}})()</script>
+</body></html>
+`;
+
+/** Expected extraction from the changed-month fixture above. */
+export const SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED = {
+  rate: 3,
+  period: '2026-05',
+  href: 'https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr',
+};

--- a/tests/__fixtures__/seco-unemployment-home.ts
+++ b/tests/__fixtures__/seco-unemployment-home.ts
@@ -1,0 +1,52 @@
+/**
+ * Trimmed-but-representative snapshot of the arbeit.swiss / SECO home page
+ * (https://www.arbeit.swiss/secoalv/it/home.html) as served on 2026-06-10.
+ *
+ * The live page is a Nuxt single-page app (~600 KB). This fixture keeps only the
+ * structures the extractor depends on, so the parser is locked against the
+ * CURRENT markup:
+ *   - the rendered labour-market teaser card (heading + description span) whose
+ *     description carries the rate sentence "…tasso di disoccupazione … al N,N%";
+ *   - the embedded-JSON copy of that sentence, immediately followed by the
+ *     canonical admin.ch press-release URL;
+ *   - a DISTRACTOR heading ("Portale lavoro.swiss – nuova veste da giugno 2026")
+ *     with a different, later month — present to prove the parser binds the
+ *     period to the SAME sentence as the rate and does NOT pick the distractor.
+ *
+ * No absolute/relative dates are computed from "now"; the captured period
+ * (maggio 2026 → 2026-05) is a literal of the snapshot itself, which is the
+ * point of a drift-locking fixture.
+ */
+export const SECO_UNEMPLOYMENT_HOME_HTML = `
+<!doctype html><html lang="it"><head><title>SECO</title></head><body>
+<div id="__nuxt">
+  <section class="hero">
+    <div class="hero-section__content"><!--[--><!--[-->
+      <h2 class="u-heading"><span>Portale lavoro.swiss &#8211; nuova veste da giugno 2026</span></h2>
+      <p>Scoprite il nuovo portale a partire da giugno 2026.</p>
+    </div>
+  </section>
+
+  <div class="u-base-card u-teaser-card u-teaser-card--list"><!--[--><!--]-->
+    <div class="u-base-card__content"><!--[--><!--]-->
+      <div class="u-base-card__body">
+        <div class="u-base-card__body__text"><!--[--><!--]-->
+          <h5 class="u-heading"><span>La situazione sul mercato del lavoro nel mese di maggio 2026</span></h5>
+          <span class="u-teaser-card__description">Nel mese di maggio 2026 il numero dei disoccupati &#232; diminuito di 2&#8217;627 unit&#224; (-1,8%) rispetto al mese precedente, per un totale di 140&#8217;275 persone. Rispetto allo stesso mese dell&#8217;anno precedente, il numero dei disoccupati &#232; aumentato di 12&#8217;331 unit&#224; (+9,6%). Nel mese di maggio 2026 il tasso di disoccupazione &#232; rimasto invariato al 3,0%.</span><!--]-->
+        </div>
+        <!--[--><Button to class="u-work-swiss-button u-teaser-card__button--list" tabindex="-1" aria-hidden="true"><!--[--><!--]--><!--[--><span>Di pi&#249;</span></Button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>window.__NUXT__=(function(){return {data:[{"title":"La situazione sul mercato del lavoro nel mese di maggio 2026","lead":"Nel mese di maggio 2026 il numero dei disoccupati è diminuito di 2’627 unità (-1,8%) rispetto al mese precedente, per un totale di 140’275 persone. Rispetto allo stesso mese dell’anno precedente, il numero dei disoccupati è aumentato di 12’331 unità (+9,6%). Nel mese di maggio 2026 il tasso di disoccupazione è rimasto invariato al 3,0%.","https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr",{"component":7424}]}}})()</script>
+</body></html>
+`;
+
+/** Expected extraction from the fixture above. */
+export const SECO_UNEMPLOYMENT_EXPECTED = {
+  rate: 3,
+  period: '2026-05',
+  href: 'https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr',
+};

--- a/tests/switzerland-unemployment-parser.test.ts
+++ b/tests/switzerland-unemployment-parser.test.ts
@@ -49,6 +49,33 @@ describe('switzerland unemployment parser', () => {
     expect(parsed.rate).toBe(SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED.rate);
     expect(parsed.rate).not.toBe(2.9);
     expect(parsed.period).toBe(SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED.period);
+    // #1732 review #1: the release URL must still bind to the winning sentence's
+    // own admin.ch link even when the anchor has to cross the previous-month %.
+    expect(parsed.href).toBe(SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED.href);
+  });
+
+  it('cites the WINNING sentence\'s own release URL, not an earlier teaser\'s link (#1732 review #1)', () => {
+    // Two teasers: an OLDER aprile teaser carries an unrelated admin.ch link
+    // first in document order; the NEWER maggio teaser (the winner) carries the
+    // canonical one. A loose "first admin after any rate phrase" scan would cite
+    // the older link. The binding must follow the winning sentence's own result
+    // figure to its adjacent URL.
+    const html = `
+<!doctype html><html lang="it"><body><div id="__nuxt">
+<div class="u-teaser-card"><h5><span>nel mese di aprile 2026</span></h5>
+<span>Nel mese di aprile 2026 il tasso di disoccupazione è rimasto invariato al 2,9%.</span></div>
+<div class="u-teaser-card"><h5><span>nel mese di maggio 2026</span></h5>
+<span>Nel mese di maggio 2026 il tasso di disoccupazione è salito dal 2,9% al 3,0%.</span></div>
+</div>
+<script>window.__NUXT__=(function(){return {data:[
+{"lead":"Nel mese di aprile 2026 il tasso di disoccupazione è rimasto invariato al 2,9%.","https://www.admin.ch/it/newnsb/OLD-aprile-do-not-cite",{"x":1}},
+{"lead":"Nel mese di maggio 2026 il tasso di disoccupazione è salito dal 2,9% al 3,0%.","https://www.admin.ch/it/newnsb/NEW-maggio-winner",{"x":2}}]}}})()</script>
+</body></html>`;
+    const parsed = parseLatestUnemployment(html);
+    expect(parsed.period).toBe('2026-05');
+    expect(parsed.rate).toBe(3);
+    expect(parsed.href).toBe('https://www.admin.ch/it/newnsb/NEW-maggio-winner');
+    expect(parsed.href).not.toContain('OLD-aprile');
   });
 
   it('extractRate takes the last figure when a sentence carries from→to rates', () => {

--- a/tests/switzerland-unemployment-parser.test.ts
+++ b/tests/switzerland-unemployment-parser.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Locks the SECO / arbeit.swiss unemployment-rate extractor against source
+ * markup drift (issue #1729). The scheduled workflow failed because the page
+ * moved from a `<div class="slide">…<p class="focusleaddescription">` layout to
+ * a Nuxt SPA whose labour-market teaser carries the rate in a single sentence
+ * ("…tasso di disoccupazione … al N,N%"). The fixture in
+ * tests/__fixtures__/seco-unemployment-home.ts is a trimmed snapshot of the
+ * CURRENT (2026-06) markup, so a future drift trips this test in CI instead of
+ * only blowing up the live workflow.
+ */
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain ESM script without type declarations
+import {
+  parseLatestUnemployment,
+  extractRate,
+  extractPeriod,
+  isPlausibleRate,
+} from '../scripts/update-switzerland-unemployment-rate.mjs';
+import {
+  SECO_UNEMPLOYMENT_HOME_HTML,
+  SECO_UNEMPLOYMENT_EXPECTED,
+} from './__fixtures__/seco-unemployment-home';
+
+describe('switzerland unemployment parser', () => {
+  it('extracts rate + period + release URL from the current SECO markup', () => {
+    const parsed = parseLatestUnemployment(SECO_UNEMPLOYMENT_HOME_HTML);
+    expect(parsed).not.toBeNull();
+    expect(parsed.rate).toBe(SECO_UNEMPLOYMENT_EXPECTED.rate);
+    expect(parsed.period).toBe(SECO_UNEMPLOYMENT_EXPECTED.period);
+    expect(parsed.href).toBe(SECO_UNEMPLOYMENT_EXPECTED.href);
+  });
+
+  it('binds the period to the rate sentence, ignoring an unrelated later-month heading', () => {
+    // The fixture contains a distractor heading "…nuova veste da giugno 2026"
+    // (2026-06). The parser must NOT let that month override the rate sentence's
+    // own month (maggio 2026 / 2026-05).
+    const parsed = parseLatestUnemployment(SECO_UNEMPLOYMENT_HOME_HTML);
+    expect(parsed.period).toBe('2026-05');
+    expect(parsed.period).not.toBe('2026-06');
+  });
+
+  it('returns null on genuinely broken markup (fail-loud, no silent default)', () => {
+    expect(parseLatestUnemployment('<html><body><p>no data here</p></body></html>')).toBeNull();
+    expect(parseLatestUnemployment('')).toBeNull();
+  });
+
+  it('extractRate handles all four locale phrasings and comma decimals', () => {
+    expect(extractRate('il tasso di disoccupazione è rimasto invariato al 3,0%')).toBe(3);
+    expect(extractRate('the unemployment rate stood at 2.8%')).toBe(2.8);
+    expect(extractRate('die Arbeitslosenquote lag bei 3,1%')).toBe(3.1);
+    expect(extractRate('le taux de chômage s’établit à 2,9%')).toBe(2.9);
+    expect(extractRate('completely unrelated text 42%')).toBeNull();
+  });
+
+  it('rejects implausible rates outside the 0–15% band', () => {
+    expect(isPlausibleRate(3)).toBe(true);
+    expect(isPlausibleRate(0)).toBe(true);
+    expect(isPlausibleRate(15)).toBe(true);
+    expect(isPlausibleRate(96.4)).toBe(false); // e.g. "+9,6%" delta or a count
+    expect(isPlausibleRate(2026)).toBe(false); // a year
+    expect(isPlausibleRate(NaN)).toBe(false);
+    // A rate phrase whose only nearby figure is implausible yields null.
+    expect(extractRate('tasso di disoccupazione 2026%')).toBeNull();
+  });
+
+  it('extractPeriod maps month names across locales to ISO YYYY-MM', () => {
+    expect(extractPeriod('nel mese di maggio 2026')).toBe('2026-05');
+    expect(extractPeriod('in October 2022')).toBe('2022-10');
+    expect(extractPeriod('im März 2026')).toBe('2026-03');
+    expect(extractPeriod('en janvier 2017')).toBe('2017-01');
+    expect(extractPeriod('no month here')).toBeNull();
+  });
+});

--- a/tests/switzerland-unemployment-parser.test.ts
+++ b/tests/switzerland-unemployment-parser.test.ts
@@ -19,6 +19,8 @@ import {
 import {
   SECO_UNEMPLOYMENT_HOME_HTML,
   SECO_UNEMPLOYMENT_EXPECTED,
+  SECO_UNEMPLOYMENT_CHANGED_MONTH_HTML,
+  SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED,
 } from './__fixtures__/seco-unemployment-home';
 
 describe('switzerland unemployment parser', () => {
@@ -37,6 +39,24 @@ describe('switzerland unemployment parser', () => {
     const parsed = parseLatestUnemployment(SECO_UNEMPLOYMENT_HOME_HTML);
     expect(parsed.period).toBe('2026-05');
     expect(parsed.period).not.toBe('2026-06');
+  });
+
+  it('binds to the rate RESULT on a changed-month sentence with two percentages', () => {
+    // "…è salito dal 2,9% al 3,0%": the FIRST figure (2,9%) is the previous
+    // month's rate. The extractor must persist the RESULT (3,0%), not 2,9%.
+    const parsed = parseLatestUnemployment(SECO_UNEMPLOYMENT_CHANGED_MONTH_HTML);
+    expect(parsed).not.toBeNull();
+    expect(parsed.rate).toBe(SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED.rate);
+    expect(parsed.rate).not.toBe(2.9);
+    expect(parsed.period).toBe(SECO_UNEMPLOYMENT_CHANGED_MONTH_EXPECTED.period);
+  });
+
+  it('extractRate takes the last figure when a sentence carries from→to rates', () => {
+    expect(extractRate('il tasso di disoccupazione è salito dal 2,9% al 3,0%')).toBe(3);
+    expect(extractRate('il tasso di disoccupazione è sceso dal 3,1% al 3,0%')).toBe(3);
+    expect(extractRate('the unemployment rate rose from 2.8% to 3.0%')).toBe(3);
+    expect(extractRate('le taux de chômage est passé de 2,9% à 3,1%')).toBe(3.1);
+    expect(extractRate('die Arbeitslosenquote stieg von 2,9% auf 3,0%')).toBe(3);
   });
 
   it('returns null on genuinely broken markup (fail-loud, no silent default)', () => {


### PR DESCRIPTION
Closes #1729

## Implementato

The scheduled workflow `update-unemployment-rate.yml` was throwing `Unable to parse unemployment rate from SECO page` — a **parser-drift** failure (the fetch succeeds; the extraction fails). arbeit.swiss/SECO moved their home page from a `<div class="slide">` / `<p class="focusleaddescription">` layout to a Nuxt SPA, so the old block regex matched nothing. This is a different class from the network-transient retry fix (#1695/#1644), which is left untouched.

The current page renders the rate in a single labour-market teaser sentence — `Nel mese di maggio 2026 il tasso di disoccupazione è rimasto invariato al 3,0%.` — which also appears in the embedded JSON next to the canonical admin.ch press-release URL.

- **Rewrote `parseLatestUnemployment`** to decode the whole document to plain text and scan for the rate sentence, binding the month+year period to the **same sentence** as the rate. This prevents an unrelated heading (e.g. `Portale lavoro.swiss – nuova veste da giugno 2026`) from donating its month to the rate figure. The newest period wins.
- **Release URL resolution** binds to the adjacent `admin.ch` / arbeit.swiss press link (the rendered Nuxt teaser button has no resolved href), falling back to the home page.
- **Plausibility band 0–15%** (`isPlausibleRate`) so a count/delta/year can't be mis-read as a rate.
- **Fail-loud preserved**: genuine parse failure still `throw`s (no silent default).
- **Drift-lock test** `tests/switzerland-unemployment-parser.test.ts` + fixture `tests/__fixtures__/seco-unemployment-home.ts`.

Output payload shape, the 4-locale narrative templates, and the historical-series append logic are **unchanged** — only the extraction changed.

## Review fixes (#1732)

### 🔴 Wrong rate on every changed month — FIXED
`extractRate` and `sentenceRe` previously stopped at the **first** `%` after the rate phrase. On an UNCHANGED month SECO writes one percentage (`…invariato al 3,0%`), but when the rate MOVES it writes **two** in one sentence (`…è salito dal 2,9% al 3,0%`), so the lazy first-`%` match grabbed `2,9%` — the **previous** month's rate — and `isPlausibleRate` happily passed it. Result would have been `period = new month` but `rate = OLD value` on most months.

**Fix:** anchor on the rate **result**, not the first figure.
- `extractRate` now scans every `N,N%` after the rate phrase and returns the **last plausible** one (the result figure in both wordings).
- `sentenceRe` tail class changed `[^.;”"%]` → `[^.;”"]` so the matched fragment no longer truncates at the first `%`; the whole sentence (incl. the result `%`) reaches `extractRate`.
- A changed-month fixture sentence (two percentages) + tests lock that the extractor returns the RESULT `3.0`, `not 2.9`, across IT/EN/DE/FR.

Before/after (both wordings):
| input | before | after |
|---|---|---|
| `…è salito dal 2,9% al 3,0%` (changed) | **2.9** ❌ | **3.0** ✅ |
| `…è sceso dal 3,1% al 3,0%` (changed) | **3.1** ❌ | **3.0** ✅ |
| `…rimasto invariato al 3,0%` (unchanged) | 3.0 ✅ | 3.0 ✅ |
| EN `rose from 2.9% to 3.0%` | 2.9 ❌ | 3.0 ✅ |
| DE `stieg von 2,9% auf 3,0%` | 2.9 ❌ | 3.0 ✅ |
| FR `passé de 2,9% à 3,0%` | 2.9 ❌ | 3.0 ✅ |

### ❓1 — release URL binding (verified live + tightened)
Curling the live page (same bot UA) shows the canonical `admin.ch` link sits only in the **embedded-JSON copy** of the winning sentence, as the value directly after it (`…3,0%.","https://www.admin.ch/it/newnsb/…"`); the rendered-HTML occurrence has **no** adjacent link. There are also other `newnsb` links on the page (other teasers + an `alto tasso di disoccupazione` professions block). The old code took the *first* admin link in a 600-char window after *any* rate-phrase occurrence — brittle: a two-teaser test showed the **rendered-HTML copy of the winner** scooping up an *earlier* teaser's JSON link. **Tightened:** `findReleaseHref` now requires the link to be the JSON value **directly following the winning sentence** — rate phrase + the RESULT figure (`[^.;"<>]*?` may cross the previous-month `%` but stops at the sentence terminator before the next teaser), then the closing `."` and `,"URL"`. The adjacency makes the rendered-HTML copy non-matching, so only the winner's own JSON link can bind. Verified `…/newnsb/GJB5uJRiX3qu8TRWGlPLr` on the live page; a new two-teaser test asserts an older teaser's link is NOT cited.

### ❓2 — corroboration window was dead code (removed)
Verified live: the labour-market heading `La situazione sul mercato del lavoro…` sits **~329 chars** before the rate sentence (the disoccupati paragraph intervenes), so the 220-char-back corroboration check was `false` for **all** occurrences on the live page — it silently degraded to newest-period-only while implying a labour-market gate it never provided. **Removed** the dead `LABOUR_NEWS_RE` corroboration rather than widen it: the rate phrase + a SAME-SENTENCE month+year period is already unemployment-specific (the only other rate-phrase occurrences — the professions block — carry no period in their own sentence and are dropped), so the gate added no real signal.

### ❓3 — raw fetch contains the sentence (verified, assumption holds)
Curled `https://www.arbeit.swiss/secoalv/it/home.html` with the script's exact bot UA (`FrontaliereTicinoBot/1.0`, no JS execution). The raw 620 KB response **does** contain the rate sentence + period + admin.ch link — both as rendered HTML and in the SSR `window.__NUXT__` payload:
```
…unità (+9,6%). Nel mese di maggio 2026 il tasso di disoccupazione è rimasto invariato al 3,0%.
…invariato al 3,0%.","https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr",{"component":7424…
```
The bare-UA fetch approach is sound; no re-point to an SSR endpoint / AMSTAT source is needed.

**Live end-to-end** (parser run against the real page fetched 2026-06-10):
```json
{ "rate": 3, "period": "2026-05", "href": "https://www.admin.ch/it/newnsb/GJB5uJRiX3qu8TRWGlPLr" }
```
Targeted test: `npx vitest run tests/switzerland-unemployment-parser.test.ts` → **9 passed** (incl. the changed-month result-rate locks and the two-teaser release-URL binding test).

Class-of-bug check: grepped sibling funnel-critical scripts/services — only `update-switzerland-unemployment-rate.mjs` parses the SECO source page; `services/unemploymentRateService.ts` is a pure JSON reader. No other extractor shares the first-`%` antipattern.

## Non implementato (ancora)

- **Re-point to a fully structured open-data source (AMSTAT/BFS CSV/JSON):** the home page links to amstat.ch but exposes no stable machine-readable monthly-rate endpoint from this entry point; re-pointing would require a separate discovery of its data API and is out of scope for this drift fix. Adversarial ❓3 confirmed the current raw-fetch approach is sound, so this is a follow-up only if SECO drifts again.
- **Live post-merge validation:** the parser is verified against a real live snapshot, but the scheduled workflow must be re-run on `main` after merge:
  - [ ] `gh workflow run update-unemployment-rate.yml --ref main` and confirm it updates `public/data/switzerland-unemployment-rate.json` to `2026-05 -> 3%` (do NOT run pre-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
