### PR TITLE
feat(followups): two-tier auto-close for done-but-open reconcile — converge the backlog

### DIFF
--- a/.github/workflows/followup-reconcile.yml
+++ b/.github/workflows/followup-reconcile.yml
@@ -1,8 +1,11 @@
 name: Reconcile done-but-open follow-ups
 
-# Zero-Claude. Flags `follow-up` issues whose cited code tokens already exist in the
-# cited file (satisfied by a later PR with no `Closes #N`) → advisory comment +
-# `maybe-resolved` label. NEVER closes; human does the final close. See
+# Zero-Claude. Two-tier, double-confirm-across-time. First sight of a `follow-up` whose
+# cited code tokens already exist in the cited file (satisfied by a later PR with no
+# `Closes #N`) → advisory comment + `maybe-resolved` label (grace window). If a LATER run
+# still finds it resolved AND it already carries `maybe-resolved` AND it's single-item AND
+# unblocked → AUTO-CLOSE (`fu-resolved-auto`, reason completed). Reversible; reopens on
+# recurrence. Set repo/env `NO_AUTOCLOSE=1` to fall back to flag-only. See
 # scripts/ci/reconcile-followups.mjs + FOLLOWUP.md § Supersede detection.
 
 on:
@@ -11,7 +14,12 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Detect + print only, no comment/label writes.'
+        description: 'Detect + print only, no comment/label/close writes.'
+        required: false
+        default: 'false'
+        type: string
+      no_autoclose:
+        description: 'Force tier-1 only (flag, never auto-close).'
         required: false
         default: 'false'
         type: string
@@ -44,4 +52,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
+          # Repo-var kill switch (set vars.RECONCILE_NO_AUTOCLOSE=1) OR per-run input → flag-only.
+          NO_AUTOCLOSE: ${{ (github.event.inputs.no_autoclose == 'true' || vars.RECONCILE_NO_AUTOCLOSE == '1') && '1' || '' }}
         run: node scripts/ci/reconcile-followups.mjs

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -146,9 +146,16 @@ Se zero item sopravvivono al filtro+dedup (e nessuna voce live-verify) → posta
 
 ## Supersede detection → spostata su `followup-reconcile` (deterministica, zero-Claude)
 
-**2026-06-04:** la supersede detection è stata RIMOSSA dal prompt Claude di `post-merge-followup.yml`. Il flag grossolano su file-touch (comment-only, advisory) bruciava turni Claude + un `gh issue list --search` per-file a ogni merge, per una segnalazione che l'autore raramente azionava. La copertura è ora di `followup-reconcile.yml` (`scripts/ci/reconcile-followups.mjs`, cron daily, **zero-Claude**): per ogni issue `follow-up` aperta estrae i file/token citati e verifica se la fix è **presente verbatim** nel file → label `maybe-resolved` (check di risoluzione reale, più preciso del flag file-touch). La chiusura finale resta umana / `Closes #N`.
+**2026-06-04:** la supersede detection è stata RIMOSSA dal prompt Claude di `post-merge-followup.yml`. Il flag grossolano su file-touch (comment-only, advisory) bruciava turni Claude + un `gh issue list --search` per-file a ogni merge, per una segnalazione che l'autore raramente azionava. La copertura è ora di `followup-reconcile.yml` (`scripts/ci/reconcile-followups.mjs`, cron daily, **zero-Claude**): per ogni issue `follow-up` aperta estrae i file/token citati e verifica se la fix è **presente verbatim** nel file.
 
-Gap residuo accettato: un refactor che rende moot un item SENZA aggiungere i token citati non viene flaggato da nessuno dei due (reconcile cerca i token verbatim). Trade-off scelto per ridurre la spesa Claude per-merge.
+**2026-06-10 — auto-close a due tier (drena la pila `maybe-resolved` senza perdere qualità).** Il vecchio "la chiusura resta umana" lasciava i `maybe-resolved` deterministicamente-rilevati a un umano che non arrivava → la coda non convergeva mai (driver #1 del treadmill). Ora `reconcile` chiude in autonomia, ma SOLO con **doppia conferma separata nel tempo** + più veti di sicurezza:
+
+1. **1ª detection** (issue non ancora `maybe-resolved`) → commento advisory + label `maybe-resolved`. **Finestra di grazia**: l'umano ha fino al run successivo per obiettare (rimuovere la label, aggiungere `keep-open`/`pinned`, riaprire lo scope).
+2. **2ª conferma** (la issue porta GIÀ `maybe-resolved` da un run precedente, è ANCORA risolta, ha il nostro commento-marker, è **single-item**, **non** ha label keep-open/strategica, e l'evidenza è **forte**) → **auto-close** `--reason completed` + label `fu-resolved-auto`.
+
+Veti all'auto-close (restano flag→umano): **multi-item aggregati** (`N item`, N≥2 — un sub-item prose-only non contribuisce token, "tutti i token presenti" non prova che ogni item sia fatto); label **keep-open/pinned/revenue/tracker/do-not-close**; **evidenza debole** (singolo token poco specifico tipo `meta.model`, 1 solo segno di punteggiatura — `isStrongAutoCloseEvidence` esige ≥2 token distinti OPPURE 1 token "ricco" con ≥2 segni). Rimozione della label dopo il flag = **obiezione umana** → il bot tace. La chiusura è **reversibile** (si riapre da sola se il segnale ricorre, titoli monitor dedup-stabili). Kill-switch: repo-var `RECONCILE_NO_AUTOCLOSE=1` o input `no_autoclose` → torna flag-only. Logica pura testata in `tests/reconcile-followups-decision.test.ts`; matcher condiviso con il pre-flight di `issue-fix` (`followup-resolution-match.mjs`, AGENTS.md #6).
+
+Gap residuo accettato: un refactor che rende moot un item SENZA aggiungere i token citati non viene flaggato (reconcile cerca i token verbatim). Trade-off scelto per ridurre la spesa Claude per-merge.
 
 ## Constraint
 

--- a/scripts/ci/reconcile-followups.mjs
+++ b/scripts/ci/reconcile-followups.mjs
@@ -14,25 +14,107 @@
  * whether those tokens are now present verbatim in the cited file. A hit means the
  * asserted behavior/symbol already exists → the item is likely done-but-open.
  *
- * SAFE BY DESIGN: it NEVER closes. It posts ONE idempotent advisory comment and adds
- * the `maybe-resolved` label. Final close stays human (FOLLOWUP.md philosophy: never
- * close on heuristic). Run on a schedule via followup-reconcile.yml.
+ * TWO-TIER, double-confirm-across-time (replaces the old never-close rule, which left
+ * the deterministically-detected `maybe-resolved` pile to a human who never came — the
+ * #1 reason the follow-up backlog never converged):
+ *   1. FIRST detection (issue not yet `maybe-resolved`): post ONE advisory comment + add
+ *      the `maybe-resolved` label. A grace window — the human has until the next scheduled
+ *      run to object (reopen scope / strip the label / add a keep-open signal).
+ *   2. SECOND confirmation (issue ALREADY carries `maybe-resolved` from a prior run, is
+ *      STILL resolved, is NOT a multi-item aggregate, and carries no keep-open/strategic
+ *      label): AUTO-CLOSE with a citation comment + `fu-resolved-auto`, `--reason completed`.
+ * Why this is safe (no quality loss): the close fires only on TWO independent deterministic
+ * confirmations separated in time, after a human grace window, on the hardened matcher
+ * (ALL distinctive prescribed code tokens present — the same bar that gates the issue-fix
+ * pre-flight, which DROPS work, a strictly higher-stakes action than a reversible close).
+ * Multi-item aggregates and keep-open/strategic issues never auto-close (a prose-only
+ * sub-item contributes no gating token, so "all tokens present" can't prove every item is
+ * done). A genuinely-pending fix recurs and reopens via the dedup-stable monitor title.
  *
  * Env:
- *   GH_TOKEN     required for gh writes (provided by Actions).
- *   GH_REPO      optional `owner/repo` (else gh infers from cwd).
- *   DRY_RUN      "1" → detect + print, no comment/label writes.
- *   MAX_ISSUES   cap issues scanned (default 100).
+ *   GH_TOKEN       required for gh writes (provided by Actions).
+ *   GH_REPO        optional `owner/repo` (else gh infers from cwd).
+ *   DRY_RUN        "1" → detect + print, no comment/label/close writes.
+ *   MAX_ISSUES     cap issues scanned (default 100).
+ *   NO_AUTOCLOSE   "1" → force tier-1 behavior only (flag, never close). Escape hatch.
  */
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { detectAlreadyResolved } from './followup-resolution-match.mjs';
 
 const DRY_RUN = process.env.DRY_RUN === '1';
+const NO_AUTOCLOSE = process.env.NO_AUTOCLOSE === '1';
 const MAX_ISSUES = Number(process.env.MAX_ISSUES || 100);
 const MARKER = '<!-- reconcile-bot -->';
+const CLOSE_MARKER = '<!-- reconcile-bot:autoclose -->';
 const LABEL = 'maybe-resolved';
+const CLOSED_LABEL = 'fu-resolved-auto';
+
+// Labels that VETO auto-close (the issue wants human eyes regardless of token match):
+// explicit keep-open pins + strategic trackers (revenue/tracker stay owner-gated).
+const KEEP_OPEN_LABELS = new Set(['pinned', 'keep-open', 'revenue', 'tracker', 'do-not-close']);
+
+/**
+ * A title like "follow-up(#X): 3 item deferred — …" with N≥2 → multi-item aggregate.
+ * These never auto-close: a prose-only sub-item contributes no gating code token, so the
+ * matcher's "ALL tokens present" can be true while that sub-item is still undone — closing
+ * would silently drop it. Single-item follow-ups (no count, or "1 item") are eligible.
+ * @param {string} title
+ * @returns {boolean}
+ */
+export function isAggregateTitle(title = '') {
+  const m = String(title).match(/\b(\d+)\s+items?\b/i);
+  return !!m && Number(m[1]) >= 2;
+}
+
+/** Count of code-punctuation marks in a token (specificity proxy). */
+function punctCount(t) {
+  return (String(t).match(/[(){}[\]'"`.:;=<>+\-*/!&|?]/g) || []).length;
+}
+
+/**
+ * Evidence strong enough to AUTO-CLOSE (vs merely flag). A single common dot-member like
+ * `meta.model` matches in countless unrelated files → too coincidental to close on. Require
+ * either MULTIPLE distinct prescribed tokens all present, OR a single RICH token (an actual
+ * expression carrying ≥2 punctuation marks, e.g. `displayCount = page === 1 ? a : b` or
+ * `window.__CDN_DATA_BASE__`), never a bare 1-dot member. Weak-but-resolved stays flagged
+ * for a human (never silently closed).
+ * @param {string[]} matchedTokens tokens that were found verbatim in a cited file
+ * @returns {boolean}
+ */
+export function isStrongAutoCloseEvidence(matchedTokens) {
+  const uniq = [...new Set((matchedTokens || []).map((t) => String(t)))];
+  if (uniq.length >= 2) return true;
+  if (uniq.length === 1) return punctCount(uniq[0]) >= 2;
+  return false;
+}
+
+/**
+ * Pure tier decision. Returns 'close' | 'flag' | 'none'.
+ *   - not resolved                                          → 'none'  (leave alone)
+ *   - human objection (we flagged before, label since gone) → 'none'  (respect, don't re-flag)
+ *   - eligible + strong + flagged-before + still labelled   → 'close' (second confirmation)
+ *   - resolved but not close-eligible, already flagged      → 'none'  (held, no dup comment)
+ *   - resolved but not close-eligible, first seen           → 'flag'  (grace / explain)
+ *
+ * Close-eligible = single-item, unblocked, auto-close on, AND strong evidence. `hasPriorFlag`
+ * = THIS bot already left its advisory comment on a prior run; auto-close requires BOTH that
+ * prior flag AND the `maybe-resolved` label still present (two confirmations across time +
+ * an un-rescinded grace window). Removing the label after a flag = human objection → quiet.
+ * @param {{resolved:boolean, hasMaybeResolved:boolean, hasPriorFlag:boolean,
+ *          isAggregate:boolean, blocked:boolean, noAutoclose?:boolean, strongEvidence?:boolean}} s
+ * @returns {'close'|'flag'|'none'}
+ */
+export function decideReconcileAction({ resolved, hasMaybeResolved, hasPriorFlag, isAggregate, blocked, noAutoclose, strongEvidence }) {
+  if (!resolved) return 'none';
+  if (hasPriorFlag && !hasMaybeResolved) return 'none'; // label rescinded after our flag = objection
+  const closeEligible = !noAutoclose && !blocked && !isAggregate && !!strongEvidence;
+  if (closeEligible && hasPriorFlag && hasMaybeResolved) return 'close'; // second confirmation
+  return hasPriorFlag ? 'none' : 'flag'; // held (already flagged) vs first detection
+}
 
 function gh(args, { allowFail = false } = {}) {
   try {
@@ -68,10 +150,17 @@ function alreadyCommented(number) {
   }
 }
 
+function evidenceLines(evidence) {
+  return evidence
+    .slice(0, 6)
+    .map((e) => `- \`${e.tok}\` già presente in \`${e.file}\``)
+    .join('\n');
+}
+
 function main() {
   const raw = gh([
     'issue', 'list', '--label', 'follow-up', '--state', 'open',
-    ...repoArgs, '--json', 'number,title,body', '--limit', String(MAX_ISSUES),
+    ...repoArgs, '--json', 'number,title,body,labels', '--limit', String(MAX_ISSUES),
   ]);
   const issues = JSON.parse(raw || '[]');
 
@@ -90,47 +179,92 @@ function main() {
   }
 
   if (!DRY_RUN) {
-    // Best-effort: ensure the advisory label exists (no-op if already there).
+    // Best-effort: ensure the advisory + auto-close labels exist (no-op if already there).
     gh(['label', 'create', LABEL, '--color', 'c5def5',
         '--description', 'Reconcile bot: cited code present in file — likely done-but-open',
+        ...repoArgs], { allowFail: true });
+    gh(['label', 'create', CLOSED_LABEL, '--color', '0e8a16',
+        '--description', 'Reconcile bot: auto-closed on second deterministic done-but-open confirmation',
         ...repoArgs], { allowFail: true });
   }
 
   const flagged = [];
+  const closed = [];
 
   for (const iss of issues) {
     if (inFlight(iss.number)) { console.log(`#${iss.number}: in-flight PR open, skip`); continue; }
     const { resolved, evidence } = detectAlreadyResolved(iss.body || '', diskIo);
     if (!resolved) continue;
-    if (alreadyCommented(iss.number)) { console.log(`#${iss.number}: already reconciled, skip`); continue; }
 
-    flagged.push({ number: iss.number, title: iss.title, evidence });
+    const labelNames = (iss.labels || []).map((l) => l.name);
+    const hasMaybeResolved = labelNames.includes(LABEL);
+    const blocked = labelNames.some((n) => KEEP_OPEN_LABELS.has(n));
+    const isAggregate = isAggregateTitle(iss.title);
+    const hasPriorFlag = alreadyCommented(iss.number);
+    const strongEvidence = isStrongAutoCloseEvidence(evidence.map((e) => e.tok));
+    const action = decideReconcileAction({
+      resolved, hasMaybeResolved, hasPriorFlag, isAggregate, blocked, noAutoclose: NO_AUTOCLOSE, strongEvidence,
+    });
+
+    if (action === 'close') {
+      closed.push({ number: iss.number, title: iss.title, evidence });
+    } else if (action === 'flag') {
+      const reason = blocked ? 'keep-open'
+        : isAggregate ? 'aggregate'
+        : NO_AUTOCLOSE ? 'no-autoclose'
+        : !strongEvidence ? 'weak-evidence'
+        : 'first-seen';
+      flagged.push({ number: iss.number, title: iss.title, evidence, reason });
+    } else { // 'none' — leave alone (not resolved / objection / held at tier-1)
+      if (hasPriorFlag) console.log(`#${iss.number}: held (objection / weak / tier-1), skip`);
+    }
   }
 
+  // Tier 1 — flag (grace window): comment + maybe-resolved label.
   for (const f of flagged) {
-    const lines = f.evidence
-      .slice(0, 6)
-      .map((e) => `- \`${e.tok}\` già presente in \`${e.file}\``)
-      .join('\n');
+    const note = f.reason === 'aggregate'
+      ? '\n\n⚠️ Multi-item: l\'auto-close non scatta (un sub-item prose-only potrebbe non essere coperto) — **chiusura umana**.'
+      : f.reason === 'keep-open'
+      ? '\n\n📌 Label keep-open/strategica: resta aperta per revisione umana, niente auto-close.'
+      : f.reason === 'weak-evidence'
+      ? '\n\nℹ️ Evidenza debole (singolo token poco specifico): **non** verrà auto-chiusa — verifica e chiudi a mano se lo scope è coperto.'
+      : '\n\nSe al prossimo run risulterà ancora risolta, verrà **auto-chiusa** (finestra di grazia: obietta rimuovendo `maybe-resolved` o aggiungendo `keep-open`).';
     const comment = `${MARKER}
 🤖 **Reconcile (auto)**: i token citati da questa issue risultano già presenti nei file citati — probabile **done-but-open** (coperto da una PR successiva senza \`Closes #${f.number}\`).
 
-${lines}
-
-Verifica e chiudi a mano se lo scope è davvero coperto. Segnalazione automatica deterministica (presenza verbatim del token), **non chiusura**.`;
-
-    console.log(`#${f.number} "${f.title}" → ${f.evidence.length} token match`);
+${evidenceLines(f.evidence)}${note}`;
+    console.log(`#${f.number} "${f.title}" → flag (${f.reason}, ${f.evidence.length} match)`);
     if (DRY_RUN) continue;
     gh(['issue', 'comment', String(f.number), ...repoArgs, '--body', comment], { allowFail: true });
     gh(['issue', 'edit', String(f.number), ...repoArgs, '--add-label', LABEL], { allowFail: true });
   }
 
-  const summary = `Reconcile follow-ups: scanned ${issues.length}, flagged ${flagged.length}${DRY_RUN ? ' (dry-run)' : ''}.`;
+  // Tier 2 — auto-close (second confirmation, grace window elapsed, eligible).
+  for (const c of closed) {
+    const comment = `${CLOSE_MARKER}
+✅ **Reconcile auto-close**: seconda conferma deterministica (\`maybe-resolved\` da un run precedente, finestra di grazia trascorsa senza obiezioni, ancora risolta, single-item, nessuna label keep-open). Tutti i token-codice prescritti sono presenti nei file citati:
+
+${evidenceLines(c.evidence)}
+
+Chiusa come **completed** (done-but-open). Si **riapre da sola** se il segnale sottostante ricorre (titoli monitor dedup-stabili) — o riapri a mano se lo scope non era davvero coperto.`;
+    console.log(`#${c.number} "${c.title}" → AUTO-CLOSE (${c.evidence.length} match)`);
+    if (DRY_RUN) continue;
+    gh(['issue', 'comment', String(c.number), ...repoArgs, '--body', comment], { allowFail: true });
+    gh(['issue', 'edit', String(c.number), ...repoArgs, '--add-label', CLOSED_LABEL], { allowFail: true });
+    gh(['issue', 'close', String(c.number), ...repoArgs, '--reason', 'completed'], { allowFail: true });
+  }
+
+  const summary = `Reconcile follow-ups: scanned ${issues.length}, flagged ${flagged.length}, auto-closed ${closed.length}${DRY_RUN ? ' (dry-run)' : ''}${NO_AUTOCLOSE ? ' (no-autoclose)' : ''}.`;
   console.log(summary);
   if (process.env.GITHUB_STEP_SUMMARY) {
-    const detail = flagged.map((f) => `- #${f.number} ${f.title} (${f.evidence.length} match)`).join('\n');
-    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## ${summary}\n${detail}\n`);
+    const fl = flagged.map((f) => `- 🟡 #${f.number} ${f.title} (flag: ${f.reason}, ${f.evidence.length} match)`).join('\n');
+    const cl = closed.map((c) => `- ✅ #${c.number} ${c.title} (auto-closed, ${c.evidence.length} match)`).join('\n');
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## ${summary}\n${[cl, fl].filter(Boolean).join('\n')}\n`);
   }
 }
 
-main();
+// Run only as a CLI entrypoint — importing for tests (pure decision helpers above) must
+// not trigger the gh-driven scan.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/reconcile-followups-decision.test.ts
+++ b/tests/reconcile-followups-decision.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Lock the two-tier auto-close decision of reconcile-followups.mjs
+ * (lever 1: drain the maybe-resolved pile deterministically without losing quality).
+ *
+ * The matcher (`detectAlreadyResolved`) is tested separately in
+ * followup-resolution-match.test.ts; here we only lock the TIER policy: when a
+ * deterministically-resolved follow-up flips to flag vs auto-close vs held, including
+ * the human-objection and multi-item-aggregate safety vetoes.
+ */
+import { describe, it, expect } from 'vitest';
+import { isAggregateTitle, decideReconcileAction, isStrongAutoCloseEvidence } from '../scripts/ci/reconcile-followups.mjs';
+
+describe('isAggregateTitle — multi-item follow-ups never auto-close', () => {
+  it('flags N≥2 "item(s)" titles as aggregate', () => {
+    expect(isAggregateTitle('follow-up(#1674): 3 item deferred — fix(seo): ...')).toBe(true);
+    expect(isAggregateTitle('follow-up(#1651): 2 items deferred — fix(data): ...')).toBe(true);
+  });
+  it('treats single-item / count-less titles as non-aggregate (eligible)', () => {
+    expect(isAggregateTitle('follow-up(#1685): 1 item deferred — perf(...): ...')).toBe(false);
+    expect(isAggregateTitle('fix(crawlers): extract shared assertJsonListShape guard')).toBe(false);
+    expect(isAggregateTitle('')).toBe(false);
+  });
+});
+
+describe('isStrongAutoCloseEvidence — weak single tokens never auto-close', () => {
+  it('≥2 distinct matched tokens → strong', () => {
+    expect(isStrongAutoCloseEvidence(['meta.model', 'CDN_BASE()'])).toBe(true);
+  });
+  it('single RICH token (≥2 punctuation = real expression) → strong', () => {
+    expect(isStrongAutoCloseEvidence(['displayCount = page === 1 ? a : b'])).toBe(true);
+    expect(isStrongAutoCloseEvidence(['foo(bar).baz'])).toBe(true); // ( ) . → 3 punct
+  });
+  it('single weak token (≤1 punctuation: bare dot-member / single op) → NOT strong (held for human)', () => {
+    expect(isStrongAutoCloseEvidence(['meta.model'])).toBe(false); // 1 dot
+    expect(isStrongAutoCloseEvidence(['injected > 0'])).toBe(false); // 1 op
+    expect(isStrongAutoCloseEvidence(['window.__CDN_DATA_BASE__'])).toBe(false); // 1 dot (underscores aren't punct)
+  });
+  it('empty → not strong', () => {
+    expect(isStrongAutoCloseEvidence([])).toBe(false);
+    expect(isStrongAutoCloseEvidence(undefined)).toBe(false);
+  });
+});
+
+describe('decideReconcileAction — two-tier, double-confirm-across-time', () => {
+  const base = { resolved: true, hasMaybeResolved: false, hasPriorFlag: false, isAggregate: false, blocked: false, strongEvidence: true };
+
+  it('does nothing when not resolved', () => {
+    expect(decideReconcileAction({ ...base, resolved: false })).toBe('none');
+  });
+
+  it('first detection → flag (grace window), never closes on first sight', () => {
+    expect(decideReconcileAction({ ...base })).toBe('flag');
+  });
+
+  it('second confirmation (prior flag + label still present, eligible) → close', () => {
+    expect(decideReconcileAction({ ...base, hasPriorFlag: true, hasMaybeResolved: true })).toBe('close');
+  });
+
+  it('human objection (we flagged before, label since removed) → none', () => {
+    expect(decideReconcileAction({ ...base, hasPriorFlag: true, hasMaybeResolved: false })).toBe('none');
+  });
+
+  it('multi-item aggregate never auto-closes (held after first flag)', () => {
+    expect(decideReconcileAction({ ...base, isAggregate: true })).toBe('flag');
+    expect(decideReconcileAction({ ...base, isAggregate: true, hasPriorFlag: true, hasMaybeResolved: true })).toBe('none');
+  });
+
+  it('keep-open / strategic label vetoes auto-close (held after first flag)', () => {
+    expect(decideReconcileAction({ ...base, blocked: true })).toBe('flag');
+    expect(decideReconcileAction({ ...base, blocked: true, hasPriorFlag: true, hasMaybeResolved: true })).toBe('none');
+  });
+
+  it('NO_AUTOCLOSE escape hatch forces tier-1 only', () => {
+    expect(decideReconcileAction({ ...base, noAutoclose: true, hasPriorFlag: true, hasMaybeResolved: true })).toBe('none');
+    expect(decideReconcileAction({ ...base, noAutoclose: true })).toBe('flag');
+  });
+
+  it('label present but no prior flag from us → flag (gets its own grace cycle, not an instant close)', () => {
+    expect(decideReconcileAction({ ...base, hasMaybeResolved: true, hasPriorFlag: false })).toBe('flag');
+  });
+
+  it('weak evidence never auto-closes: first seen → flag, already flagged → held (none)', () => {
+    expect(decideReconcileAction({ ...base, strongEvidence: false })).toBe('flag');
+    expect(decideReconcileAction({ ...base, strongEvidence: false, hasPriorFlag: true, hasMaybeResolved: true })).toBe('none');
+  });
+});


### PR DESCRIPTION
## Implementato

**Problema (osservato live):** il backlog follow-up non converge perché `reconcile-followups` rileva i done-but-open in modo deterministico ma — per la vecchia regola *never-close* — si limitava a etichettare `maybe-resolved` e aspettare un umano che non arriva. La pila si accumula in eterno (driver #1 del treadmill).

**Fix — auto-close a due tier, doppia-conferma-nel-tempo** (qualità invariata):
1. **1ª detection** → commento advisory + label `maybe-resolved` = **finestra di grazia** (l'umano può obiettare rimuovendo la label / aggiungendo `keep-open`).
2. **2ª conferma** (ancora risolta + ha già `maybe-resolved` + nostro commento-marker presente + **single-item** + non-blocked + **evidenza forte**) → **auto-close** `--reason completed` + label `fu-resolved-auto`.

**Veti di sicurezza** (restano flag→umano, mai chiusi):
- **multi-item aggregati** (`N item`, N≥2): un sub-item prose-only non contribuisce token → "tutti i token presenti" non prova che ogni item sia fatto.
- label **keep-open / pinned / revenue / tracker / do-not-close**.
- **evidenza debole**: singolo token poco specifico (es. `meta.model`, 1 punteggiatura). `isStrongAutoCloseEvidence` esige ≥2 token distinti **oppure** 1 token "ricco" (≥2 segni, es. `displayCount = page === 1 ? a : b`).
- **obiezione umana**: label rimossa dopo il flag → il bot tace.
- chiusura **reversibile** (si riapre da sola se il segnale ricorre, titoli monitor dedup-stabili).

**Perché non perde qualità:** chiude solo su DUE conferme deterministiche separate nel tempo, dopo finestra di grazia umana, sul matcher hardened (#1702: TUTTI i token-codice prescritti presenti — la stessa barra che gatekeepa il pre-flight di `issue-fix` che *droppa* lavoro, azione a rischio più alto di una chiusura reversibile). Un fix realmente pendente ricorre e riapre.

**Dry-run sul backlog reale (35 follow-up):** 1 auto-close forte (#1676, token `displayCount = page === 1 ? totalItems : pageItems.length` presente verbatim), tutti gli altri held (weak/aggregate/objection — es. #1322 `meta.model` correttamente trattenuto per umano).

**Files:** `scripts/ci/reconcile-followups.mjs` (logica + helper puri esportati + main() guardato dietro direct-run check per testabilità), `tests/reconcile-followups-decision.test.ts` (15 nuovi; 40 totali con la regressione matcher), `.github/workflows/followup-reconcile.yml` (env `NO_AUTOCLOSE` + input + repo-var kill-switch `RECONCILE_NO_AUTOCLOSE`), `FOLLOWUP.md` (contratto aggiornato).

Matcher condiviso con `check-issue-already-resolved.mjs` (AGENTS.md #6, drift-proof).

## Non implementato (ancora)

- **Leva 2 (age-out dei `fu-parked` non-ricorrenti)** — richiede infra di recurrence-detection (collegare monitor→issue via titolo dedup-stabile) per chiudere in sicurezza i parked che non si ripresentano. Questa PR copre solo la classe *done-but-open* (rilevabile deterministicamente). Follow-up separato.
- **Merge manuale atteso:** la PR tocca `FOLLOWUP.md` → workflow-validation della GitHub App reviewer (AGENTS.md → Workflow): il reviewer non posta e l'auto-merge non scatta. Merge via `gh pr merge --squash --delete-branch` dopo il check verde.
- Validazione live post-merge: il prossimo cron `followup-reconcile` (06:00 UTC) chiuderà la prima tranche di `maybe-resolved` forti; osservare il summary del run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)