### PR TITLE
fix(job-alert): createAlert limit query missing orderBy → FAILED_PRECONDITION blocks every alert

### DIFF
--- a/services/jobAlertService.ts
+++ b/services/jobAlertService.ts
@@ -112,6 +112,7 @@ export async function createAlert(
     setDoc,
     query,
     where,
+    orderBy,
     getDocs,
     serverTimestamp,
   } = await import('firebase/firestore');
@@ -119,10 +120,20 @@ export async function createAlert(
   const normalizedEmail = normalizeEmail(email);
 
   // Enforce per-user limit across all subscriber docs.
+  // NOTE: the `orderBy('createdAt', 'desc')` is REQUIRED, not cosmetic — it makes
+  // this collectionGroup query reuse the deployed composite index
+  // (userId ASC, active ASC, createdAt DESC), identical to getUserAlerts below.
+  // Without it the equality-only query needs a separate (userId, active) index
+  // that was never deployed (firestore.indexes.json is not applied by CI —
+  // deploy-firestore-rules.yml ships `firestore:rules` only), so getDocs threw
+  // FAILED_PRECONDITION ("query requires an index") and createAlert aborted
+  // before writing — surfacing as the "Non sono riuscito a creare l'alert" toast
+  // for every newsletter/autologin user (the exact target of the job-detail prompt).
   const existingQ = query(
     collectionGroup(db, ALERTS_SUBCOLLECTION),
     where('userId', '==', userId),
     where('active', '==', true),
+    orderBy('createdAt', 'desc'),
   );
   const existing = await getDocs(existingQ);
   if (existing.size >= MAX_ALERTS_PER_USER) {


### PR DESCRIPTION
## Implementato

`createAlert()` falliva per **ogni utente newsletter/autologin** con il toast *"Non sono riuscito a creare l'alert"* — il target esatto del job-detail prompt (#1730).

**Root cause (riprodotta live, non sandbox):** la prima operazione di `createAlert` è la limit-query max-3:
```ts
collectionGroup(db, 'alerts'),
where('userId', '==', userId),
where('active', '==', true)   // ← nessun orderBy
```
Una collectionGroup query equality-only ordina implicitamente per `__name__`, quindi richiede un indice `(userId, active)`. Quell'indice **non è deployato**: l'unico composite `alerts` deployato è `(userId ASC, active ASC, createdAt DESC)`, che Firestore usa SOLO se la query ordina anche per `createdAt`. Quindi `getDocs()` lanciava `FAILED_PRECONDITION ("The query requires an index")` e `createAlert` abortiva **prima** di scrivere.

`firestore.indexes.json` non viene mai applicato dalla CI (`deploy-firestore-rules.yml` deploya solo `firestore:rules`), quindi l'indice 2-campi non è mai esistito su prod.

**Verifica live** (path reale, `exchange_auth_code` → `signInWithCustomToken` → REST):
- limit-query `runQuery` → **HTTP 400 FAILED_PRECONDITION** (l'errore).
- write alert (POST) → **HTTP 200** (regole + claim `email` del token OK — non era quello il problema).

**Fix:** aggiunto `orderBy('createdAt', 'desc')` alla limit-query, rendendola identica al sibling `getUserAlerts()` (riga ~205) che già funziona contro l'indice deployato `(userId, active, createdAt)`. **Zero deploy di indici richiesto.** Le due uniche collectionGroup query client sono in questo file; l'altra era già corretta → classe coperta.

## Non implementato (ancora)

- **Gap sistemico: `firestore.indexes.json` non è deployato da nessun workflow** (`deploy-firestore-rules.yml` fa solo `firestore:rules`). Il file è quindi config morta/drift. Follow-up: estendere il deploy a `firestore:indexes` + trigger su `firestore.indexes.json`, oppure rimuovere il file se non si usa. Out of scope qui: il fix elimina la dipendenza dall'indice non-deployato.
- **403 su `update`/`delete` alert per utente autologin** (osservato durante la verifica via REST: `token.uid == resource.data.userId` e `token.email == email`, eppure `PERMISSION_DENIED`). Potenziale bug "gestisci alert" per utenti newsletter, da investigare a parte. Il `create` non è impattato (provato 200).

## Test plan

- [ ] Post-deploy: utente autologin su pagina dettaglio → "Sì, attiva" → alert creato, niente toast "Errore", `job_alert_subscribers` +1.
- [ ] Console senza `FAILED_PRECONDITION` sul collectionGroup alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)