### PR TITLE
fix(job-detail): toast sopra la nav mobile + chatbot off su dettaglio + deploy indici Firestore in CI

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -50,14 +50,24 @@ jobs:
       - name: Load Remote Config secrets
         run: node scripts/load-rc-env.mjs
 
-      # Deploy rules AND composite indexes together. Before this, indexes in
-      # firestore.indexes.json were never shipped (only firestore:rules was),
-      # so the file was dead config and prod indexes drifted from it — a query
-      # relying on an undeployed index failed with FAILED_PRECONDITION at
-      # runtime. Index deploy is additive: in non-interactive CI the CLI creates
-      # missing indexes and does not delete backend indexes absent from the file.
-      - name: Deploy Firestore security rules and indexes
-        run: firebase deploy --only firestore:rules,firestore:indexes --project frontaliere-ticino
+      # Rules and indexes are deployed in SEPARATE steps on purpose: a missing
+      # index-admin permission (or an index build error) must not block the
+      # rules deploy, which governs createAlert and other security-critical
+      # paths. Rules first so they always ship even if the index step fails.
+      - name: Deploy Firestore security rules
+        run: firebase deploy --only firestore:rules --project frontaliere-ticino
+
+      # Before this, indexes in firestore.indexes.json were never shipped (only
+      # firestore:rules was), so the file was dead config and prod indexes
+      # drifted from it — a query relying on an undeployed index failed with
+      # FAILED_PRECONDITION at runtime (see createAlert fix #1746). Index deploy
+      # is additive: `firebase deploy --only firestore:indexes` creates indexes
+      # missing from the backend and, in the non-interactive CI runner (no TTY),
+      # does NOT delete backend indexes absent from the file — deletion needs an
+      # interactive confirmation that never fires here, so the step cannot hang
+      # or destroy live indexes. `--force` (which would auto-delete) is not used.
+      - name: Deploy Firestore composite indexes
+        run: firebase deploy --only firestore:indexes --project frontaliere-ticino
 
       - name: Report failure to GitHub Issues
         if: failure()

--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -1,4 +1,4 @@
-name: Deploy Firestore Rules
+name: Deploy Firestore Rules & Indexes
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'firestore.rules'
+      - 'firestore.indexes.json'
   workflow_dispatch:
 
 permissions:
@@ -49,8 +50,14 @@ jobs:
       - name: Load Remote Config secrets
         run: node scripts/load-rc-env.mjs
 
-      - name: Deploy Firestore security rules
-        run: firebase deploy --only firestore:rules --project frontaliere-ticino
+      # Deploy rules AND composite indexes together. Before this, indexes in
+      # firestore.indexes.json were never shipped (only firestore:rules was),
+      # so the file was dead config and prod indexes drifted from it — a query
+      # relying on an undeployed index failed with FAILED_PRECONDITION at
+      # runtime. Index deploy is additive: in non-interactive CI the CLI creates
+      # missing indexes and does not delete backend indexes absent from the file.
+      - name: Deploy Firestore security rules and indexes
+        run: firebase deploy --only firestore:rules,firestore:indexes --project frontaliere-ticino
 
       - name: Report failure to GitHub Issues
         if: failure()

--- a/App.tsx
+++ b/App.tsx
@@ -3423,6 +3423,9 @@ const App: React.FC = () => {
  )}
  </Suspense>
  <Suspense fallback={null}>
+ {/* Hide the floating AI assistant on the job-detail page: its bottom-right
+ bubble overlaps the job-alert prompt toast and the apply CTA. */}
+ {!(activeTab === 'job-board' && jobSlug) && (
  <AiChatbot
  isLoggedIn={!!authUser}
  onSignIn={chatbotGoogleSignIn}
@@ -3430,6 +3433,7 @@ const App: React.FC = () => {
  onContinueWithEmail={chatbotContinueWithEmail}
  hideOnMobile={activeTab === 'blog'}
  />
+ )}
  </Suspense>
  </div>
  </NavigationContext.Provider>

--- a/components/community/JobAlertForm.tsx
+++ b/components/community/JobAlertForm.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from '@/services/i18n';
 import { Bell, BellRing, Trash2, ChevronDown, ChevronUp, Loader2, Pencil } from 'lucide-react';
 import type { JobAlert, JobAlertConfig } from '@/services/jobAlertService';
 import { listCantonOptions, getCantonLabel, type CantonLocale } from '@/services/cantonList';
+import { ABOVE_MOBILE_NAV_BOTTOM } from '@/components/shared/mobileNavClearance';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -623,7 +624,7 @@ export default function JobAlertForm({ authUser, onRequireAuth, initialKeyword =
 
  {/* Toast */}
  {toast && (
- <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg bg-heading text-heading text-sm shadow-lg animate-fade-in">
+ <div className={`fixed ${ABOVE_MOBILE_NAV_BOTTOM} left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg bg-heading text-heading text-sm shadow-lg animate-fade-in`}>
  {toast}
  </div>
  )}

--- a/components/community/JobAlertStickyBanner.tsx
+++ b/components/community/JobAlertStickyBanner.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { BellRing, X } from 'lucide-react';
 import { useTranslation } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
+import { ABOVE_MOBILE_NAV_BOTTOM } from '@/components/shared/mobileNavClearance';
 
 const DISMISS_KEY = 'jobAlertStickyBanner:dismissedUntil';
 const DISMISS_DAYS = 7;
@@ -60,7 +61,7 @@ export default function JobAlertStickyBanner() {
  <div
  role="region"
  aria-label={t('jobAlert.stickyBannerAria') || 'Invito a iscriversi alle alert lavoro'}
- className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 w-[calc(100%-2rem)] max-w-md animate-slide-up"
+ className={`fixed ${ABOVE_MOBILE_NAV_BOTTOM} left-1/2 -translate-x-1/2 z-40 w-[calc(100%-2rem)] max-w-md animate-slide-up`}
  >
  <div className="flex items-center gap-3 p-3 rounded-xl border border-accent-border bg-surface shadow-lg shadow-accent/20">
  <span className="flex-shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-full bg-accent-subtle text-accent">

--- a/components/community/JobDetailAlertPrompt.tsx
+++ b/components/community/JobDetailAlertPrompt.tsx
@@ -116,11 +116,15 @@ export default function JobDetailAlertPrompt({
   const closeAriaLabel = t('common.close', 'Chiudi');
 
   return (
+    // Sit above the mobile bottom nav (App.tsx: fixed bottom-0 z-50 h-14 md:hidden
+    // + safe-area). At bottom-4 the toast's CTA buttons were hidden behind that bar
+    // on phones; clear the 3.5rem nav + safe-area + 1rem gap on <md, keep bottom-4
+    // on md+ where the nav is hidden.
     <div
       role="dialog"
       aria-modal="false"
       aria-labelledby={TITLE_ID}
-      className="fixed bottom-4 right-4 z-40 w-[calc(100%-2rem)] max-w-sm animate-slide-up"
+      className="fixed bottom-[calc(3.5rem+1rem+env(safe-area-inset-bottom,0px))] right-4 z-40 w-[calc(100%-2rem)] max-w-sm animate-slide-up md:bottom-4"
     >
       <div className="relative p-4 rounded-xl border border-accent-border bg-surface shadow-lg shadow-accent/20">
         <button

--- a/components/community/JobDetailAlertPrompt.tsx
+++ b/components/community/JobDetailAlertPrompt.tsx
@@ -3,6 +3,7 @@ import { BellRing, Loader2, X } from 'lucide-react';
 import { useTranslation } from '@/services/i18n';
 import type { Locale } from '@/services/i18n';
 import { subscribeJobAlertOneTap } from '@/services/jobAlertService';
+import { ABOVE_MOBILE_NAV_BOTTOM } from '@/components/shared/mobileNavClearance';
 
 export type JobDetailAlertPromptStatus = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -116,15 +117,12 @@ export default function JobDetailAlertPrompt({
   const closeAriaLabel = t('common.close', 'Chiudi');
 
   return (
-    // Sit above the mobile bottom nav (App.tsx: fixed bottom-0 z-50 h-14 md:hidden
-    // + safe-area). At bottom-4 the toast's CTA buttons were hidden behind that bar
-    // on phones; clear the 3.5rem nav + safe-area + 1rem gap on <md, keep bottom-4
-    // on md+ where the nav is hidden.
+    // ABOVE_MOBILE_NAV_BOTTOM keeps the CTA buttons clear of the mobile bottom nav.
     <div
       role="dialog"
       aria-modal="false"
       aria-labelledby={TITLE_ID}
-      className="fixed bottom-[calc(3.5rem+1rem+env(safe-area-inset-bottom,0px))] right-4 z-40 w-[calc(100%-2rem)] max-w-sm animate-slide-up md:bottom-4"
+      className={`fixed ${ABOVE_MOBILE_NAV_BOTTOM} right-4 z-40 w-[calc(100%-2rem)] max-w-sm animate-slide-up`}
     >
       <div className="relative p-4 rounded-xl border border-accent-border bg-surface shadow-lg shadow-accent/20">
         <button

--- a/components/shared/mobileNavClearance.ts
+++ b/components/shared/mobileNavClearance.ts
@@ -1,0 +1,17 @@
+/**
+ * Tailwind positioning fragment that lifts a `fixed` bottom-anchored element
+ * above the mobile bottom navigation bar.
+ *
+ * The mobile nav (App.tsx) is `fixed bottom-0 z-50 h-14 md:hidden` plus an
+ * `env(safe-area-inset-bottom)` pad. A plain `bottom-4` leaves bottom-anchored
+ * toasts/banners partially behind that bar on phones, hiding their CTA/dismiss
+ * controls. This clears the 3.5rem (h-14) nav + safe-area + a 1rem gap on `<md`,
+ * and falls back to `bottom-4` at `md+` where the nav is hidden.
+ *
+ * Single source of truth: the `3.5rem` mirrors the nav's `h-14`. If the nav
+ * height changes, update it here once instead of in each toast/banner.
+ *
+ * Used by JobDetailAlertPrompt, JobAlertStickyBanner and the JobAlertForm toast.
+ */
+export const ABOVE_MOBILE_NAV_BOTTOM =
+  'bottom-[calc(3.5rem+1rem+env(safe-area-inset-bottom,0px))] md:bottom-4';


### PR DESCRIPTION
## Implementato

Tre fix dal feedback sulla pagina dettaglio annuncio (screenshot: toast tagliato dalla barra + bolla chat sovrapposta):

1. **Toast alert finiva sotto la nav mobile.** \`JobDetailAlertPrompt\` era \`fixed bottom-4\`, ma la nav mobile è \`fixed bottom-0 z-50 h-14 md:hidden\` (+ safe-area) → su telefono i bottoni "Sì, attiva"/"Non ora" restavano dietro la barra. Ora \`bottom-[calc(3.5rem+1rem+env(safe-area-inset-bottom,0px))]\` su <md per scavalcare la nav, \`md:bottom-4\` dove la nav è nascosta.

2. **Chatbot AI sovrapposto al toast su dettaglio.** La bolla bottom-right dell'assistant copriva il prompt alert e la CTA candidatura. Nascosto sulla pagina dettaglio (\`activeTab === 'job-board' && jobSlug\`). Resta attivo su tutte le altre viste.

3. **Indici Firestore mai deployati dalla CI.** Verificato: \`deploy-firestore-rules.yml\` deployava SOLO \`firestore:rules\` → \`firestore.indexes.json\` era config morta e gli indici prod driftavano. È la classe-radice del \`FAILED_PRECONDITION\` di \`createAlert\` (#1746). Deploy rules e indexes ora separati in due step indipendenti (un errore sugli indici non blocca il deploy delle rules).

4. **Fix classe-completo clearance mobile nav (re-review 🔴).** Stessa classe di bug \`fixed bottom-4\` in \`JobAlertStickyBanner\` (CTA "Crea alert", funnel conversione) e \`JobAlertForm\` (toast transiente). Estratto in \`components/shared/mobileNavClearance.ts\` la costante \`ABOVE_MOBILE_NAV_BOTTOM\` — i 3 componenti la importano, il magic number \`3.5rem\` vive in un solo posto e non può driftare.

## Non implementato (ancora)

- **403 \`update\`/\`delete\` alert per utente autologin** (osservato durante la diagnosi di #1746): \`token.uid == resource.data.userId && token.email == email\` eppure \`PERMISSION_DENIED\`. Possibile bug "gestisci alert" per utenti newsletter, da investigare a parte; \`create\` non impattato. Tracciato come follow-up.
- Non ho aggiunto/rimosso indici in \`firestore.indexes.json\`: il fix #1746 ha già eliminato la dipendenza dall'indice mancante; questo workflow serve a tenere allineato il file d'ora in poi.

## Test plan

- [ ] Mobile: toast su pagina dettaglio mostra i bottoni interamente sopra la barra nav.
- [ ] Pagina dettaglio: nessuna bolla chatbot; chatbot presente sulle altre tab.
- [ ] Push futuro su \`firestore.indexes.json\` → workflow "Deploy Firestore Rules & Indexes" deploya gli indici (step separato dalle rules).
- [ ] \`JobAlertStickyBanner\` (CTA "Crea alert") visibile per intero sopra la nav mobile a scroll 60–98%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)