### PR TITLE
fix(job-alert): toast mobile-nav clearance as real CSS class (era arbitrary util non generata)

### DIFF
--- a/components/shared/mobileNavClearance.ts
+++ b/components/shared/mobileNavClearance.ts
@@ -8,10 +8,15 @@
  * controls. This clears the 3.5rem (h-14) nav + safe-area + a 1rem gap on `<md`,
  * and falls back to `bottom-4` at `md+` where the nav is hidden.
  *
- * Single source of truth: the `3.5rem` mirrors the nav's `h-14`. If the nav
- * height changes, update it here once instead of in each toast/banner.
+ * This is a real CSS class defined in `index.css` (`.above-mobile-nav`), NOT a
+ * Tailwind arbitrary-value utility. An earlier attempt put
+ * `bottom-[calc(...)] md:bottom-4` in this const, but the production Tailwind
+ * source scan did not pick up class literals living only in this shared `.ts`
+ * file, so the utility was never generated and the toast dropped to its in-flow
+ * position off-screen. A class defined in the entry stylesheet always ships, so
+ * referencing it by name here is scan-proof. The actual offsets (4.5rem mobile,
+ * 1rem at md+) live in index.css.
  *
  * Used by JobDetailAlertPrompt, JobAlertStickyBanner and the JobAlertForm toast.
  */
-export const ABOVE_MOBILE_NAV_BOTTOM =
-  'bottom-[calc(3.5rem+1rem+env(safe-area-inset-bottom,0px))] md:bottom-4';
+export const ABOVE_MOBILE_NAV_BOTTOM = 'above-mobile-nav';

--- a/index.css
+++ b/index.css
@@ -792,3 +792,16 @@ input[type=number] { -moz-appearance: textfield; }
   .ec-meta { @apply min-w-0 flex-1; }
   .ec-cmpct { @apply flex items-center gap-2.5 rounded-xl border border-edge bg-surface/50 p-3 hover:border-accent-border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent text-inherit no-underline; }
 }
+
+/* Lift a `fixed` bottom-anchored toast/banner above the mobile bottom nav
+   (App.tsx: <nav> fixed bottom-0 z-50 h-14 md:hidden + safe-area pad). Defined
+   as a real CSS class in this entry stylesheet — NOT a Tailwind arbitrary class
+   in a shared .ts const — because that const file was not picked up by the
+   production Tailwind source scan, so `bottom-[calc(...)]` never reached the CSS
+   and the toast dropped to its in-flow position off-screen. A plain class here
+   always ships. 4.5rem = 3.5rem nav (h-14) + 1rem gap; md+ falls back to 1rem
+   where the nav is hidden. Used via ABOVE_MOBILE_NAV_BOTTOM
+   (components/shared/mobileNavClearance.ts) by JobDetailAlertPrompt,
+   JobAlertStickyBanner and the JobAlertForm toast. */
+.above-mobile-nav { bottom: calc(4.5rem + env(safe-area-inset-bottom)); }
+@media (min-width: 768px) { .above-mobile-nav { bottom: 1rem; } }


### PR DESCRIPTION
## Implementato

**Regressione da #1748**: il toast/banner restava ancora dietro la nav mobile (anzi finiva **fuori schermo**). Causa: la clearance era una utility Tailwind arbitrary (`bottom-[calc(...)] md:bottom-4`) messa nel const condiviso `components/shared/mobileNavClearance.ts`, ma **la source-scan Tailwind di produzione NON raccoglie i literal di classe che vivono SOLO in quel file `.ts`** → l'utility non veniva mai emessa nel bundle CSS (verificato live: 0 match per `calc(...rem` in `index-*.css`).

Senza regola `bottom`, il toast `position: fixed` cadeva a `bottom: auto` → posizione in-flow in fondo all'articolo, fuori viewport (misurato live via Playwright: `bottom -5235px`, `top 5933` in viewport 844). Il chatbot-hide e gli altri pezzi di #1748 erano OK.

**Fix:** `.above-mobile-nav` definita come **vera classe CSS in `index.css`** (entry Tailwind, sempre processata): `bottom: calc(4.5rem + env(safe-area-inset-bottom))` su mobile, `bottom: 1rem` da `md+` (nav nascosta). Il const condiviso ora porta solo il **nome-classe** → scan-proof. Verificata l'emissione compilando `index.css` via `@tailwindcss/postcss` (2 regole: base + media query).

Nota diagnostica: in isolamento *entrambe* le versioni arbitrary (con e senza virgola env) generavano — quindi la virgola non era la causa; il problema era proprio lo scanning del file const, non la sintassi del valore.

## Non implementato (ancora)

- Non ho convertito gli altri toast del repo (`AiChatbot bottom-[5rem]`, `InputCard bottom-28`, ecc.) a `.above-mobile-nav`: quelli sono classi inline in file `.tsx` regolarmente scansionati e già funzionano; fuori scope.

## Test plan

- [ ] Mobile (≤767px): toast su pagina dettaglio con i bottoni interamente sopra la barra nav (post-deploy, verifica Playwright `toastClearsNav=true`).
- [ ] Desktop (≥768px): toast a `bottom: 1rem`.
- [ ] `index-*.css` live contiene `.above-mobile-nav`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)