### PR TITLE
fix(job-alert): 0px fallback in env() di .above-mobile-nav (nit #1758)

### DIFF
--- a/index.css
+++ b/index.css
@@ -803,5 +803,10 @@ input[type=number] { -moz-appearance: textfield; }
    where the nav is hidden. Used via ABOVE_MOBILE_NAV_BOTTOM
    (components/shared/mobileNavClearance.ts) by JobDetailAlertPrompt,
    JobAlertStickyBanner and the JobAlertForm toast. */
-.above-mobile-nav { bottom: calc(4.5rem + env(safe-area-inset-bottom)); }
+/* env() carries a `0px` fallback: if safe-area-inset-bottom were undefined the
+   calc() would be invalid and `bottom` would collapse to `auto` — re-triggering
+   the exact off-screen failure this class fixes. The comma fallback is plain,
+   valid CSS here (the earlier Tailwind-arbitrary-value scanning caveat does not
+   apply to a hand-written rule in this stylesheet). */
+.above-mobile-nav { bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px)); }
 @media (min-width: 768px) { .above-mobile-nav { bottom: 1rem; } }


### PR DESCRIPTION
## Implementato

Follow-up del 🟡 nit su #1758 (mergiata prima che il fix entrasse).

`.above-mobile-nav` usava `calc(4.5rem + env(safe-area-inset-bottom))` senza fallback: se `safe-area-inset-bottom` fosse undefined, il `calc()` sarebbe invalido e `bottom` collasserebbe a `auto` — ri-innescando esattamente il bug off-screen che la classe risolve. Aggiunto il fallback `0px`: `calc(4.5rem + env(safe-area-inset-bottom, 0px))`.

In CSS scritto a mano la virgola di fallback è valida (il caveat di scanning sui valori arbitrary Tailwind NON si applica qui). Verificato che `index.css` compila via `@tailwindcss/postcss`.

## Non implementato (ancora)

Niente — fix puntuale.

## Test plan

- [ ] `index-*.css` live contiene `.above-mobile-nav { bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px)); }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)