### PR TITLE
fix(publisher): align CV-upload client size limit with storage.rules

### DIFF
--- a/components/community/PublisherApplyForm.tsx
+++ b/components/community/PublisherApplyForm.tsx
@@ -51,7 +51,7 @@ const PublisherApplyForm: React.FC<PublisherApplyFormProps> = ({ jobId, publishe
       file.type === 'application/pdf' ||
       /\.(pdf|docx?)$/i.test(file.name) ||
       /^application\/(pdf|msword|vnd\.openxmlformats-officedocument\.wordprocessingml\.document)$/.test(file.type);
-    const okSize = file.size <= 5 * 1024 * 1024;
+    const okSize = file.size < 5 * 1024 * 1024; // align with storage.rules (rejects exactly 5 MB)
     if (!okType || !okSize) {
       setCvUploadError(true);
       return;


### PR DESCRIPTION
## Implementato
Reviewer nit di #1764: il client accettava esattamente 5 MB (`<=`) mentre `storage.rules` lo rifiuta (`<`) → un file di 5'242'880 byte passava la validazione client poi falliva la scrittura su Storage con errore non spiegato. Allineato il client a `< 5 MB`.

## Non implementato (ancora)
Nessuno — fix mirato 1-riga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)