### PR TITLE
fix(functions): add stripe to package-lock (unblocks CF deploy)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,7 +9,8 @@
         "@google-cloud/recaptcha-enterprise": "^6.4.0",
         "firebase-admin": "^13.6.1",
         "firebase-functions": "^7.1.1",
-        "resend": "^6.9.2"
+        "resend": "^6.9.2",
+        "stripe": "^17.5.0"
       },
       "engines": {
         "node": "20"
@@ -3157,6 +3158,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/strnum": {


### PR DESCRIPTION
## Implementato
Il deploy Cloud Functions dopo #1736 è **fallito**: `npm ci` in `functions/` → `Missing: stripe@17.7.0 from lock file`. `stripe` era stato aggiunto a `functions/package.json` ma il lockfile non rigenerato → **nessuna delle 8 publisher CF è stata deployata** (checkout/webhook/billing-portal/domain-verify/forward-application/purge/renewal-reminder/free-cap). Rigenerato `functions/package-lock.json` (stripe@17.7.0) → `npm ci` torna in sync → il deploy può completare.

## Non implementato (ancora)
Nessuno — fix di sblocco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)