### PR TITLE
perf(ci): minimal review tier for data/docs-only PRs (token-lever)

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -132,8 +132,17 @@ jobs:
           # Strip DATA/static: il tier si decide solo sul CODE.
           code_files=$(echo "$files" | grep -vE '^(data/|public/|reports/|_newsletter_variants/|docs/)' || true)
           if [ -z "$code_files" ]; then
-            echo "Data/docs-only PR (no reviewable code touched)."
-            set_tier normal claude-sonnet-4-6 15
+            # Token-lever: una PR data/docs-only (zero code) non ha contributo
+            # code-reviewable — l'unica cosa da verificare è il completeness
+            # contract del body. Tier `minimal`: sonnet + max-turns 8 (da 15) +
+            # prompt corto che SALTA la lettura di REVIEW.md, il cross-file
+            # probing e l'adversarial check (tutti no-op senza code). Posta
+            # comunque `## LGTM` come claude-bot → auto-merge invariato.
+            # 8 turni bastano con margine per: leggi body+files, valida
+            # contract, posta review (~4-6 turni osservati). REVERT-TRIGGER: se
+            # compaiono `error_max_turns` sul tier minimal → bump 8→12.
+            echo "Data/docs-only PR (no reviewable code touched) → tier minimal."
+            set_tier minimal claude-sonnet-4-6 8
             exit 0
           fi
           # CODE funnel-critical → high. Match diretto su test/CI/build-plugin,
@@ -177,6 +186,8 @@ jobs:
           claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(rg:*),Bash(git:*),Read,Grep,Glob'"
           prompt: |
             Reviewer automatico PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.tier.outputs.tier }}.
+
+            **Tier `minimal` (PR data/docs-only, ZERO code) — percorso corto, ≤6 turni:** NON leggere `REVIEW.md` né `AGENTS.md`, NON fare cross-file probing né adversarial check (no-op senza code). Fai SOLO: (1) `gh pr view $PR_NUMBER --json title,body,files`; (2) verifica il completeness contract del body — `## Implementato` e `## Non implementato (ancora)` presenti, ogni bullet sensato, nessun placeholder vuoto/`TBD`; (3) se il body è a posto → posta `gh pr review $PR_NUMBER --comment --body` con una review breve che chiude con `## LGTM` (string esatta → auto-merge); se il contract è violato → `🟡` (o `🔴 Important` se grave) e NIENTE `## LGTM`. Non aprire/scorrere i file dati/static. FERMATI dopo aver postato. (Se il Tier NON è `minimal`, ignora questo paragrafo e segui il Bootstrap sotto.)
 
             **Bootstrap:**
             1. Leggi `REVIEW.md` — contratto operativo completo (tier, severity, filtro scopo, completeness contract, cross-file pattern repetition, test plan compliance, adversarial check, format).


### PR DESCRIPTION
## Implementato

Token-reduction audit of the 5 Claude-invoking workflows. Implements the one safe remaining lever; documents that the other two are already in place.

**Lever 1 (this PR) — `minimal` review tier for data/docs-only PRs.** When a PR’s file list is entirely non-reviewable (`data/ public/ reports/ _newsletter_variants/ docs/`), `pr-review-loop` now sets tier `minimal` (sonnet, `--max-turns 8` instead of 15) and the prompt takes a short path that **skips reading `REVIEW.md`/`AGENTS.md`, cross-file probing and the adversarial check** (all no-ops without code) — it only validates the body completeness contract, then posts `## LGTM` as claude-bot. Auto-merge is unchanged (still a claude-bot `## LGTM` review; `auto-merge-eval.mjs` untouched). On a data/docs-only PR this cuts turns ~15→8 **and** a large `REVIEW.md` read every run → less `cache_read`, which is 90%+ of these runs’ tokens.

Measured baseline (sampled run logs, 2026-06-10): pr-review-loop avg 962K tok/run, ~168 Claude runs/day; the data/docs-only subset previously paid a full sonnet@15 review.

## Non implementato (ancora)

- **Lever 2 (issue-fix aggregate split) — already implemented, no change.** `issue-fix.yml` already has the deterministic `already-resolved` zero-Claude gate + `is_aggregate` detection driving a one-item circuit-breaker. A deterministic per-item *split* was deliberately rejected by the authors (body parsing is freeform/fragile; they rely on the title COUNT) — re-implementing it would regress, not help.
- **Lever 3 (redflag anti-loop) — already implemented, no change.** `pr-redflag-fixer.yml` already caps at `MAX_ROUNDS=2` via the `REDFLAG_FIX_ROUND` marker + escalates to `needs-human` and STOPs without Claude. The observed ~11% failures are single attempts that error, not loop runaway — nothing to bound further.
- **No `auto-merge-eval.mjs` change / no full zero-Claude path** for data/docs PRs: the clean "skip Claude entirely + deterministic merge" form would require touching the merge brain (it accepts only claude-bot `## LGTM`) and depends on the `workflow_run: tests` trigger firing → risk of stuck PRs. Deferred as higher-risk-than-reward; the minimal-tier variant captures most of the saving with zero merge-path risk.

**REVERT-TRIGGER (claim not validatable pre-merge):** if `error_max_turns` appears on the `minimal` tier (data/docs review needing >8 turns), bump `8→12` in the tier step.

⚠️ Touches `.github/workflows/pr-review-loop.yml` → workflow-validation: the Claude reviewer will not post and auto-merge will not fire. Merge manually via `gh pr merge --squash --delete-branch` after CI.