### PR TITLE
fix(crawlers): real descriptions for coop (scale) + straumann (teaser→detail)

### DIFF
--- a/scripts/lib/straumann-job-parser.mjs
+++ b/scripts/lib/straumann-job-parser.mjs
@@ -12,7 +12,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, fetchJson } from './crawler-template.mjs';
+import { slugify, stripHtml, fetchJson, fetchHtml } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -236,6 +236,33 @@ async function fetchJobListings() {
 }
 
 /**
+ * Fetch the full schema.org JobPosting description (HTML) from a Straumann
+ * detail page. The Phenom listing widget only returns a short `descriptionTeaser`;
+ * the SSR detail page carries the full description in a JSON-LD <script>. Returns
+ * '' on any failure so the caller falls back to the teaser.
+ */
+async function fetchStraumannDetailDescription(url) {
+  if (!url || !/^https?:\/\//.test(url)) return '';
+  try {
+    const html = await fetchHtml(url, { timeoutMs: 15000 });
+    if (!html) return '';
+    const blocks = [...html.matchAll(/<script[^>]*application\/ld\+json[^>]*>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
+    for (const block of blocks) {
+      try {
+        const data = JSON.parse(block);
+        const arr = Array.isArray(data) ? data : [data];
+        for (const o of arr) {
+          if (String(o?.['@type'] || '').includes('JobPosting') && o.description) {
+            return String(o.description);
+          }
+        }
+      } catch { /* skip malformed JSON-LD block */ }
+    }
+  } catch { /* network/timeout → caller falls back to the teaser */ }
+  return '';
+}
+
+/**
  * Fetch all Straumann jobs.
  * Returns an array of ParsedJob objects (source-locale only).
  *
@@ -261,9 +288,13 @@ export async function fetchAllStraumannJobs() {
 
     const location = normalizeSpace(listing.location || listing.city || '') || HQ.city;
     const canton = inferSwissTargetCanton(location) || HQ.canton;
-    const descriptionHtml = listing.description || '';
-    const descriptionText = normalizeSpace(stripHtml(descriptionHtml));
     const publicUrl = listing.url || CAREER_URL;
+    // The Phenom listing only carries a short `descriptionTeaser`; fetch the FULL
+    // schema.org JobPosting description from the detail page (verified ~400 words)
+    // so jobs aren't thin → boilerplate-padded → boilerplate-guard failures.
+    const detailDescHtml = await fetchStraumannDetailDescription(publicUrl);
+    const descriptionHtml = detailDescHtml || listing.description || '';
+    const descriptionText = normalizeSpace(stripHtml(descriptionHtml));
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} straumann ch`);

--- a/scripts/update-coop-jobs.mjs
+++ b/scripts/update-coop-jobs.mjs
@@ -508,10 +508,35 @@ async function postProcessCoopJobs() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
   let repaired = 0;
 
+  // Detail-page fetch resilience at national scale: jobs.coopjobs.ch throttles
+  // bulk requests (1900+ jobs/run on one CI IP), so a single fetch returns empty
+  // for many jobs → the description stays blank and the pipeline then pads it
+  // with generic company boilerplate, which hard-fails the assemble
+  // boilerplate-guard. Retry with backoff + a small inter-request delay recovers
+  // the real JSON-LD description (the SSR detail page always carries the full
+  // 250-350-word text — verified live). Jobs that still resolve no real
+  // description are quarantined below (dropped, never published as boilerplate).
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  async function fetchCoopJsonLdResilient(url) {
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const ld = await fetchCoopJsonLd(url, timeoutMs);
+      if (ld) return ld; // got JSON-LD (description handled downstream)
+      await sleep(400 * (attempt + 1)); // backoff only when the fetch itself failed
+    }
+    return null;
+  }
+  const quarantineUrls = new Set();
+
   for (const job of coopJobs) {
     const descLen = (job.description || '').length;
-    const jsonLd = await fetchCoopJsonLd(job.url, timeoutMs);
-    if (!jsonLd) continue;
+    const jsonLd = await fetchCoopJsonLdResilient(job.url);
+    await sleep(60); // polite throttle to avoid tripping the bulk rate-limit
+    if (!jsonLd || String(jsonLd.description || '').trim().length < 80) {
+      // No real source description available → quarantine (don't publish a
+      // boilerplate-padded thin page).
+      if (descLen < 250) quarantineUrls.add(job.url);
+      if (!jsonLd) continue;
+    }
 
     let changed = false;
 
@@ -601,10 +626,23 @@ async function postProcessCoopJobs() {
     await new Promise((r) => setTimeout(r, 200));
   }
 
-  if (repaired > 0) {
+  // Quarantine: drop Coop jobs for which no real source description could be
+  // fetched (after retries) and whose own description is too thin — publishing a
+  // boilerplate-padded thin page violates the <50-word / boilerplate-guard
+  // contract. Better to ship fewer, well-described jobs than to fail the whole
+  // crawler (fail-per-record, not fail-the-batch).
+  let dropped = 0;
+  if (quarantineUrls.size > 0) {
+    const kept = allJobs.filter((j) => !(isCoopJob(j) && quarantineUrls.has(j.url)));
+    dropped = allJobs.length - kept.length;
+    allJobs.length = 0;
+    allJobs.push(...kept);
+  }
+
+  if (repaired > 0 || dropped > 0) {
     fs.writeFileSync(DATA_JOBS, JSON.stringify(allJobs, null, 2) + '\n');
     fs.writeFileSync(PUBLIC_JOBS, JSON.stringify(allJobs, null, 2) + '\n');
-    console.log(`  ✅ Repaired ${repaired}/${coopJobs.length} Coop jobs`);
+    console.log(`  ✅ Repaired ${repaired}/${coopJobs.length} Coop jobs` + (dropped ? ` · quarantined ${dropped} without a real source description` : ''));
   } else {
     console.log(`  ✅ All ${coopJobs.length} Coop jobs passed validation`);
   }


### PR DESCRIPTION
## Implementato

Fix delle 2 (uniche) failure post-orchestrator dei crawler che ho modificato — entrambe **boilerplate-guard** (qualità descrizioni), **non** la fonte né il parser.

**Verificato live (test su job reali):** i detail-page HANNO descrizioni complete (250-432 parole) e le nostre funzioni le estraggono correttamente in isolamento. Il fallimento era a valle.

**coop** (1347/1414 = 95% boilerplate): il broadening CH-wide (#1734) ha esposto un bug **di scala** — a ~1900 job/run i detail-fetch a coopjobs.ch vengono throttlati sull'IP CI → descrizione vuota → la pipeline la pad con company-boilerplate → guard fallisce. Fix in `postProcessCoopJobs`:
- `fetchCoopJsonLdResilient`: retry con backoff + throttle 60ms → recupera le descrizioni reali.
- **Quarantena** dei residui senza descrizione reale (droppati, non pubblicati boilerplate). NON abbassa soglie.

**straumann** (1/2 boilerplate): usava il `descriptionTeaser` del listing Phenom (snippet) come descrizione → thin. Aggiunto `fetchStraumannDetailDescription` — fetch del detail-page + estrazione JSON-LD JobPosting completa (verificato 432 parole), fallback al teaser su errore. Basso volume (~10 job).

## Non implementato (ancora)

- Stesso pattern teaser-vs-detail potenzialmente in altri crawler Phenom/SmartRecruiters nuovi (givaudan, audemars-piguet) — NON falliti il guard (teaser più lunghi/meno job), monitorati; se falliscono → stesso fix detail-fetch.

## Test plan
- [x] node --check OK (coop + straumann)
- [x] coop-crawler (44) + straumann-crawler (18) test verdi
- [x] test live: descrizioni complete presenti + estratte (coop 250-350, straumann 432 parole)
- [ ] post-merge: run `update-jobs-coop.yml` + `update-jobs-straumann.yml` → boilerplate-guard passa, descrizioni reali popolate
