### PR TITLE
fix(cloudflare-worker): stale-while-error fallback for shard 504s + edge status report tool

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -10,10 +10,14 @@
 # HTML pushed to the frontaliere-{loc} repos) is deployed separately by
 # deploy.yml on every site deploy — unchanged.
 #
-# Secrets (already configured as repo Actions secrets):
-#   CLOUDFLARE_API_TOKEN   — token scoped Account→Workers Scripts:Edit
-#                            + Zone→Workers Routes:Edit on frontaliereticino.ch
-#   CLOUDFLARE_ACCOUNT_ID  — Cloudflare account id
+# Credentials come from Firebase Remote Config (repo convention — same as
+# deploy.yml), hydrated by scripts/load-rc-env.mjs:
+#   CF_API_TOKEN   — Cloudflare API token. MUST carry, beyond the existing
+#                    Zone→Analytics:Read used by cf-status-report.mjs, the scopes
+#                    Account→Workers Scripts:Edit + Zone→Workers Routes:Edit
+#                    (frontaliereticino.ch) or this deploy fails on auth.
+#   CF_ACCOUNT_ID  — Cloudflare account id.
+# FIREBASE_SERVICE_ACCOUNT_JSON (repo secret) authenticates the RC read.
 name: Deploy Cloudflare Worker
 
 on:
@@ -36,13 +40,46 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # load-rc-env.mjs only needs firebase-admin — install it standalone
+      # instead of a full `npm ci` (the repo's install is heavy and unneeded
+      # for a Worker deploy).
+      - name: Install firebase-admin (for RC read)
+        run: npm install --no-save firebase-admin
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON not set — cannot read CF creds from Remote Config."
+            exit 1
+          fi
+
+      - name: Load Cloudflare creds from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Verify creds present
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "::error::CF_API_TOKEN / CF_ACCOUNT_ID not hydrated from Remote Config."
+            exit 1
+          fi
 
       - name: Deploy locale-router Worker
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CF_API_TOKEN }}
+          accountId: ${{ env.CF_ACCOUNT_ID }}
           workingDirectory: infra/cloudflare-worker
           command: deploy
 

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,57 @@
+# Deploy the Cloudflare locale-router Worker.
+#
+# Until now the Worker (infra/cloudflare-worker/locale-router.js) was a manual
+# `npx wrangler deploy` from the runbook (LOCALE-SHARD-CLOUDFLARE-RUNBOOK §2.4) —
+# no workflow re-deployed it, so any edit to the Worker sat in the repo without
+# going live. This closes that gap: every push to main that touches the Worker
+# directory deploys it via cloudflare/wrangler-action.
+#
+# Note: only the WORKER SCRIPT is deployed here. The shard *content* (en/de/fr
+# HTML pushed to the frontaliere-{loc} repos) is deployed separately by
+# deploy.yml on every site deploy — unchanged.
+#
+# Secrets (already configured as repo Actions secrets):
+#   CLOUDFLARE_API_TOKEN   — token scoped Account→Workers Scripts:Edit
+#                            + Zone→Workers Routes:Edit on frontaliereticino.ch
+#   CLOUDFLARE_ACCOUNT_ID  — Cloudflare account id
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/cloudflare-worker/**'
+  workflow_dispatch: {}
+
+# Never cancel an in-flight deploy: a half-applied Worker/route change is worse
+# than waiting. Serialize so concurrent merges deploy in order.
+concurrency:
+  group: deploy-cloudflare-worker
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy locale-router Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: infra/cloudflare-worker
+          command: deploy
+
+      # Smoke-check the three locale roots through the public apex. Informative
+      # only (|| true): a transient non-200 here must not red the deploy job —
+      # the Worker itself already deployed in the step above.
+      - name: Smoke-check locale roots
+        run: |
+          for loc in en de fr; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "https://frontaliereticino.ch/$loc/" || echo "ERR")
+            echo "/$loc/ -> $code"
+          done || true

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -141,6 +141,14 @@ export default {
         if (lkg) {
           const headers = new Headers(lkg.headers);
           headers.set('X-Shard-Fallback', 'lkg'); // stale-while-error marker
+          // The stored LKG copy carries Cache-Control: max-age=LKG_MAX_AGE (7d)
+          // — that governs ITS retention in caches.default. We must NOT leak that
+          // TTL to the CDN edge on the served fallback: otherwise Cloudflare would
+          // cache the stale shell edge-side for 7d, never re-invoke the Worker
+          // after the origin recovers, and the shard would stay stale for a week.
+          // no-store keeps the fallback out of the edge so every request during
+          // the outage re-enters the Worker and recovers the instant origin heals.
+          headers.set('Cache-Control', 'no-store');
           return new Response(lkg.body, { status: 200, statusText: 'OK', headers });
         }
       }

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -50,6 +50,58 @@ const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 // edge caching is the only lever left to cut invocations under the 100k/day cap.
 const CACHE_MAX_AGE = 7200; // 2 h
 
+// Per-attempt upstream timeout + one retry. The shard origins are gray-cloud
+// GitHub Pages; under the Worker's aggregate cache-miss fan-out they
+// intermittently drop/stall the connection, so a single naked fetch surfaces a
+// user-facing 504 (observed ~107k/day, edgeResponseStatus=504 with
+// originResponseStatus=0 = no origin response). An AbortController bounds each
+// attempt; one retry rides out a transient stall without hanging toward CF's
+// 100s gateway ceiling.
+const ORIGIN_TIMEOUT_MS = 12000;
+const ORIGIN_RETRIES = 1; // total attempts = ORIGIN_RETRIES + 1
+
+// Last-known-good retention. On EVERY successful 200 we also stash a copy under
+// a private cache key with a long TTL; when a later origin fetch fails or 5xxes
+// we serve that copy (stale-while-error) instead of a 504. Shard pages are SEO
+// shells whose live job data is client-fetched fresh at runtime, so a stale
+// shell served only during an origin outage is strictly better than an error.
+const LKG_MAX_AGE = 604800; // 7 d
+
+// Private cache key for the last-known-good copy of a URL. A synthetic host
+// keeps it from ever colliding with real request URLs (incl. look-alike query
+// strings), so genuine traffic can neither read nor poison the fallback slot.
+function lkgKey(publicUrl) {
+  return new Request(`https://lkg.invalid/${encodeURIComponent(publicUrl)}`);
+}
+
+// Single upstream attempt bounded by an AbortController timeout.
+async function fetchOriginOnce(upstream, request) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ORIGIN_TIMEOUT_MS);
+  try {
+    return await fetch(new Request(upstream, request), { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fetch the shard origin with one retry. Retries only on a thrown error
+// (timeout/network) or a 5xx — a 4xx (e.g. a real Pages 404) is returned as-is.
+// Throws only if every attempt threw.
+async function fetchOriginWithRetry(upstream, request) {
+  let lastErr;
+  for (let attempt = 0; attempt <= ORIGIN_RETRIES; attempt++) {
+    try {
+      const resp = await fetchOriginOnce(upstream, request);
+      if (resp.status < 500 || attempt === ORIGIN_RETRIES) return resp;
+    } catch (err) {
+      lastErr = err;
+      if (attempt === ORIGIN_RETRIES) throw err;
+    }
+  }
+  throw lastErr;
+}
+
 export default {
   async fetch(request, _env, ctx) {
     const url = new URL(request.url);
@@ -73,7 +125,29 @@ export default {
     const origin = SHARD_ORIGIN[match[1]];
     const upstream = new URL(request.url);
     upstream.hostname = origin; // rewrite Host only; path + query preserved
-    const resp = await fetch(new Request(upstream, request));
+
+    let resp;
+    try {
+      resp = await fetchOriginWithRetry(upstream, request);
+    } catch {
+      resp = null; // every attempt timed out / threw — no origin response
+    }
+
+    // Origin produced nothing usable (timeout/network) or a 5xx → fall back to
+    // the last-known-good copy so the user gets a stale page, not a 504.
+    if (!resp || resp.status >= 500) {
+      if (request.method === 'GET') {
+        const lkg = await cache.match(lkgKey(url.toString()));
+        if (lkg) {
+          const headers = new Headers(lkg.headers);
+          headers.set('X-Shard-Fallback', 'lkg'); // stale-while-error marker
+          return new Response(lkg.body, { status: 200, statusText: 'OK', headers });
+        }
+      }
+      // No fallback available. Surface 503 if we never got a response at all,
+      // otherwise let the genuine origin 5xx through unchanged.
+      if (!resp) return new Response('Shard origin unavailable', { status: 503 });
+    }
 
     // GitHub Pages 301s a dir path without trailing slash (e.g. /en/lavoro ->
     // /en/lavoro/). If that Location is absolute on the hidden origin host, the
@@ -104,6 +178,11 @@ export default {
     // Cache successful GET responses and stamp Cache-Control so Cloudflare CDN
     // can also serve from edge without re-entering the Worker.
     if (request.method === 'GET' && resp.status === 200) {
+      // Clone the origin response up front so we can write two cache entries
+      // (short-TTL serving copy + long-TTL last-known-good) plus the returned
+      // body from one upstream read.
+      const lkgSource = resp.clone();
+
       const headers = new Headers(resp.headers);
       headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`);
       const cacheable = new Response(resp.body, {
@@ -113,6 +192,17 @@ export default {
       });
       const toReturn = cacheable.clone();
       ctx.waitUntil(cache.put(cacheKey, cacheable));
+
+      // Refresh the long-lived fallback copy on every successful fetch.
+      const lkgHeaders = new Headers(lkgSource.headers);
+      lkgHeaders.set('Cache-Control', `public, max-age=${LKG_MAX_AGE}`);
+      ctx.waitUntil(
+        cache.put(
+          lkgKey(url.toString()),
+          new Response(lkgSource.body, { status: 200, statusText: 'OK', headers: lkgHeaders }),
+        ),
+      );
+
       return toReturn;
     }
 

--- a/scripts/cf-status-report.mjs
+++ b/scripts/cf-status-report.mjs
@@ -58,7 +58,9 @@ const MAX_HOURS = 23.9;
 
 function parseArgs(argv) {
   const opts = {
-    hours: 24,
+    // Default just under the free-plan 1-day cap so the common no-arg run
+    // doesn't emit the "clamped" note every time.
+    hours: 23,
     minStatus: 300,
     statusClass: null, // 3 | 4 | 5
     host: null,

--- a/scripts/cf-status-report.mjs
+++ b/scripts/cf-status-report.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * cf-status-report.mjs — Cloudflare edge status-code report by page.
+ *
+ * Answers "which pages went 3xx / 4xx / 5xx" by querying the Cloudflare
+ * GraphQL Analytics API (dataset `httpRequestsAdaptiveGroups`) for the
+ * frontaliereticino.ch zone. Free-plan friendly: no Logpush, no paid
+ * features — just the always-on adaptive analytics every zone has.
+ *
+ * Two queries per run:
+ *   1. SUMMARY — group by edgeResponseStatus only → exact count per status
+ *      code (path dimension would cap rows and truncate totals).
+ *   2. DETAIL  — top-N (status, host, path) rows for every non-2xx status,
+ *      so you see the actual offending URLs.
+ *
+ * Covers the WHOLE zone, not just the locale Worker: the IT bulk passes
+ * through Cloudflare untouched (no Worker), so only zone-level adaptive
+ * analytics sees its status codes. The /en /de /fr shard pages handled by
+ * `frontaliere-locale-router` show up here too (look for 5xx = Worker
+ * upstream timeouts to the origin-{loc} GitHub Pages shards).
+ *
+ * ─── Auth ────────────────────────────────────────────────────────────────
+ *   Needs CF_API_TOKEN (scope: Zone → Analytics → Read on the zone).
+ *   Already stored in Firebase Remote Config, so locally:
+ *
+ *     eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *       node scripts/load-rc-env.mjs)" && node scripts/cf-status-report.mjs
+ *
+ *   In CI: run `node scripts/load-rc-env.mjs` first (populates $GITHUB_ENV).
+ *   CF_ZONE_ID is optional — resolved from the zone name via the REST API
+ *   when absent.
+ *
+ * ─── Free-plan limits (baked in) ───────────────────────────────────────────
+ *   • httpRequestsAdaptiveGroups accepts a time range of AT MOST 1 day per
+ *     query → --hours is clamped to <24h with a small safety margin.
+ *   • Retention on the free plan is short (~3 days). Older windows return
+ *     empty; the script warns rather than failing silently.
+ *
+ * ─── Usage ─────────────────────────────────────────────────────────────────
+ *   node scripts/cf-status-report.mjs                 # last 24h, all non-2xx
+ *   node scripts/cf-status-report.mjs --hours=6       # last 6h
+ *   node scripts/cf-status-report.mjs --min-status=400 # 4xx+5xx only (skip 3xx)
+ *   node scripts/cf-status-report.mjs --class=5        # only 5xx
+ *   node scripts/cf-status-report.mjs --host=frontaliereticino.ch
+ *   node scripts/cf-status-report.mjs --limit=50       # rows per detail query
+ *   node scripts/cf-status-report.mjs --json           # machine-readable
+ *
+ * Exit codes: 0 = ran OK (even if errors found — it's a report, not a gate);
+ *             1 = bad config / API error.
+ */
+
+const GRAPHQL_ENDPOINT = 'https://api.cloudflare.com/client/v4/graphql';
+const REST_BASE = 'https://api.cloudflare.com/client/v4';
+const ZONE_NAME = process.env.CF_ZONE_NAME || 'frontaliereticino.ch';
+// Free plan hard-caps the adaptive-groups window at 1 day. Stay safely under
+// it (clock skew once tripped "1d96ms > 1d") and leave headroom.
+const MAX_HOURS = 23.9;
+
+function parseArgs(argv) {
+  const opts = {
+    hours: 24,
+    minStatus: 300,
+    statusClass: null, // 3 | 4 | 5
+    host: null,
+    limit: 30,
+    json: false,
+  };
+  for (const arg of argv) {
+    const m = arg.match(/^--([^=]+)(?:=(.*))?$/);
+    if (!m) continue;
+    const [, key, val] = m;
+    switch (key) {
+      case 'hours': opts.hours = Number(val); break;
+      case 'min-status': opts.minStatus = Number(val); break;
+      case 'class': opts.statusClass = Number(val); break;
+      case 'host': opts.host = val; break;
+      case 'limit': opts.limit = Number(val); break;
+      case 'json': opts.json = true; break;
+      case 'help':
+        console.log('See header comment for usage.');
+        process.exit(0);
+        break;
+      default: break;
+    }
+  }
+  return opts;
+}
+
+function bail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+async function cfGraphQL(token, query, variables) {
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json().catch(() => null);
+  if (!json) bail(`GraphQL returned non-JSON (HTTP ${res.status}).`);
+  if (json.errors && json.errors.length) {
+    bail(`GraphQL error: ${json.errors.map((e) => e.message).join('; ')}`);
+  }
+  return json.data;
+}
+
+async function resolveZoneId(token) {
+  if (process.env.CF_ZONE_ID) return process.env.CF_ZONE_ID;
+  const res = await fetch(
+    `${REST_BASE}/zones?name=${encodeURIComponent(ZONE_NAME)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  const json = await res.json().catch(() => null);
+  if (!json || !json.success || !json.result?.length) {
+    bail(`Could not resolve zone id for ${ZONE_NAME} (check token scope).`);
+  }
+  return json.result[0].id;
+}
+
+// Build the edgeResponseStatus filter from --min-status / --class.
+function statusFilter(opts) {
+  if (opts.statusClass) {
+    const lo = opts.statusClass * 100;
+    return { edgeResponseStatus_geq: lo, edgeResponseStatus_lt: lo + 100 };
+  }
+  return { edgeResponseStatus_geq: opts.minStatus };
+}
+
+const SUMMARY_QUERY = `
+query($zone:String!,$since:Time!,$until:Time!,$filter:ZoneHttpRequestsAdaptiveGroupsFilter_InputObject){
+  viewer{ zones(filter:{zoneTag:$zone}){
+    httpRequestsAdaptiveGroups(limit:100,filter:$filter,orderBy:[count_DESC]){
+      count dimensions{ edgeResponseStatus }
+    }
+  }}
+}`;
+
+const DETAIL_QUERY = `
+query($zone:String!,$since:Time!,$until:Time!,$limit:Int!,$filter:ZoneHttpRequestsAdaptiveGroupsFilter_InputObject){
+  viewer{ zones(filter:{zoneTag:$zone}){
+    httpRequestsAdaptiveGroups(limit:$limit,filter:$filter,orderBy:[count_DESC]){
+      count dimensions{ edgeResponseStatus clientRequestHTTPHost clientRequestPath }
+    }
+  }}
+}`;
+
+function classOf(status) {
+  if (status >= 500) return '5xx';
+  if (status >= 400) return '4xx';
+  if (status >= 300) return '3xx';
+  return '2xx';
+}
+
+const ICON = { '3xx': '↪', '4xx': '⚠', '5xx': '🔥', '2xx': '·' };
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const token = process.env.CF_API_TOKEN;
+  if (!token) {
+    bail(
+      'CF_API_TOKEN not set. Run:\n' +
+        '  eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json node scripts/load-rc-env.mjs)"\n' +
+        'then re-run this script.',
+    );
+  }
+
+  if (!Number.isFinite(opts.hours) || opts.hours <= 0) opts.hours = 24;
+  let clampedNote = '';
+  if (opts.hours > MAX_HOURS) {
+    clampedNote = ` (clamped from ${opts.hours}h — free plan max 1 day/query)`;
+    opts.hours = MAX_HOURS;
+  }
+
+  const until = new Date();
+  const since = new Date(until.getTime() - opts.hours * 3600 * 1000);
+  const sinceISO = since.toISOString();
+  const untilISO = until.toISOString();
+
+  const zoneId = await resolveZoneId(token);
+
+  const baseFilter = {
+    datetime_geq: sinceISO,
+    datetime_leq: untilISO,
+    ...statusFilter(opts),
+  };
+  if (opts.host) baseFilter.clientRequestHTTPHost = opts.host;
+
+  const vars = { zone: zoneId, since: sinceISO, until: untilISO, filter: baseFilter };
+
+  const [summaryData, detailData] = await Promise.all([
+    cfGraphQL(token, SUMMARY_QUERY, vars),
+    cfGraphQL(token, DETAIL_QUERY, { ...vars, limit: opts.limit }),
+  ]);
+
+  const summaryRows = summaryData.viewer.zones[0]?.httpRequestsAdaptiveGroups || [];
+  const detailRows = detailData.viewer.zones[0]?.httpRequestsAdaptiveGroups || [];
+
+  // Aggregate summary by status code and by class.
+  const byStatus = new Map();
+  const byClass = { '3xx': 0, '4xx': 0, '5xx': 0 };
+  for (const r of summaryRows) {
+    const s = r.dimensions.edgeResponseStatus;
+    byStatus.set(s, (byStatus.get(s) || 0) + r.count);
+    byClass[classOf(s)] = (byClass[classOf(s)] || 0) + r.count;
+  }
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          zone: ZONE_NAME,
+          window: { since: sinceISO, until: untilISO, hours: opts.hours },
+          summaryByStatus: Object.fromEntries(byStatus),
+          summaryByClass: byClass,
+          detail: detailRows.map((r) => ({
+            status: r.dimensions.edgeResponseStatus,
+            url: r.dimensions.clientRequestHTTPHost + r.dimensions.clientRequestPath,
+            count: r.count,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  // ─── Human report ────────────────────────────────────────────────────────
+  console.log(`\nCloudflare status report — ${ZONE_NAME}`);
+  console.log(
+    `Window: ${sinceISO} → ${untilISO} (${opts.hours}h)${clampedNote}`,
+  );
+  if (opts.host) console.log(`Host filter: ${opts.host}`);
+  console.log(
+    `Filter: ${opts.statusClass ? `${opts.statusClass}xx only` : `status >= ${opts.minStatus}`}`,
+  );
+
+  const total = byClass['3xx'] + byClass['4xx'] + byClass['5xx'];
+  if (total === 0) {
+    console.log(
+      '\nNo matching requests in window. ' +
+        'On the free plan adaptive analytics retains only ~3 days — older windows return empty.',
+    );
+    return;
+  }
+
+  console.log('\n── Summary by class ──');
+  for (const cls of ['3xx', '4xx', '5xx']) {
+    if (byClass[cls]) console.log(`  ${ICON[cls]} ${cls}  ${String(byClass[cls]).padStart(8)}`);
+  }
+
+  console.log('\n── By status code ──');
+  [...byStatus.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .forEach(([status, count]) =>
+      console.log(`  ${ICON[classOf(status)]} ${status}  ${String(count).padStart(8)}`),
+    );
+
+  console.log(`\n── Top ${opts.limit} offending URLs ──`);
+  console.log('  STATUS    COUNT  URL');
+  for (const r of detailRows) {
+    const s = r.dimensions.edgeResponseStatus;
+    const url = r.dimensions.clientRequestHTTPHost + r.dimensions.clientRequestPath;
+    console.log(
+      `  ${ICON[classOf(s)]} ${String(s).padEnd(5)} ${String(r.count).padStart(7)}  ${url}`,
+    );
+  }
+  console.log('');
+}
+
+main().catch((err) => bail(err?.message || String(err)));


### PR DESCRIPTION
## Implementato

**Diagnosi (dati live, GraphQL adaptive-groups, 24h):** le pagine shard `/en /de /fr` generano **~107k `504`/giorno** — `edgeResponseStatus=504`, `originResponseStatus=0`, `cacheStatus=miss` (l'origin GitHub Pages non produce risposta sul fetch del Worker), distribuiti su tutte le 24h (2k–10k/h), **non un episodio transitorio**. Causa: il Worker faceva `fetch(upstream)` singolo, **senza timeout/retry/fallback** → ogni connessione origin droppata/stallata diventava un 504 utente.

**Fix Worker (`infra/cloudflare-worker/locale-router.js`):**
- `fetchOriginOnce` con **AbortController timeout 12s** per tentativo.
- `fetchOriginWithRetry`: **1 retry** su errore/throw o 5xx; un 4xx (es. 404 reale di Pages) ritorna as-is, niente retry inutile.
- **Last-known-good (stale-while-error):** ogni `200` riuscito salva anche una copia 7gg sotto una cache key sintetica privata (`https://lkg.invalid/<url>`, niente collisione col traffico reale). Su fallimento/5xx dell'origin si serve quella copia (header `X-Shard-Fallback: lkg`) **invece di un 504**. Le pagine shard sono shell SEO con dati live client-fetched a runtime → una shell stale durante un outage origin è meglio di un errore. Freshness happy-path (`max-age=7200`, 2h) **invariata**.
- Su origin morto senza LKG disponibile: `503` esplicito (non più 504 ambiguo).

**Auto-deploy Worker (`.github/workflows/deploy-worker.yml`):** chiude la lacuna del runbook §2.4 (deploy Worker era manuale). Un push su `main` che tocca `infra/cloudflare-worker/**` deploya il Worker via `cloudflare/wrangler-action`. Le credenziali arrivano da **Remote Config** (convenzione repo, come `deploy.yml`): `CF_API_TOKEN` + `CF_ACCOUNT_ID` idratati da `load-rc-env.mjs` (firebase-admin standalone, `FIREBASE_SERVICE_ACCOUNT_JSON` autentica la read). → **Mergiare questa PR mette live il fix 504 da solo** (il merge tocca `locale-router.js`, il path-filter scatta). Include smoke-check non-bloccante dei tre locale root.

**Tool osservabilità (`scripts/cf-status-report.mjs`):** interroga la **Cloudflare GraphQL Analytics API free-plan** (`httpRequestsAdaptiveGroups`) e stampa 3xx/4xx/5xx per status code e per URL colpevole, **zona-wide** (IT passthrough + Worker shard). Legge `CF_API_TOKEN` da Remote Config (già mappato in `load-rc-env.mjs`). Flag: `--class=3|4|5`, `--host`, `--hours` (cappato <24h, limite free), `--min-status`, `--limit`, `--json`. È il tool che ha rivelato i 504. Testato live.

## Non implementato (ancora)

- **Scope del token RC `CF_API_TOKEN`:** non verificabile in PR. Oggi ha solo `Zone→Analytics:Read` (usato da `cf-status-report.mjs`); per il deploy deve guadagnare **Account→Workers Scripts:Edit** + **Zone→Workers Routes:Edit** (`frontaliereticino.ch`) — un solo token superset. Senza, il job `deploy-worker` fallisce su auth. **Revert-trigger:** job `deploy-worker` rosso per auth o 504 shard non in calo post-merge → estendi scope token / `wrangler rollback`.
- **Validazione behaviorale del Worker pre-merge:** non eseguibile in CI (serve `wrangler dev` + origin reali); verificata via `node --check` + control-flow. Test plan live sotto.
- **Root cause upstream (perché GitHub Pages droppa il fetch):** non risolta — throttling/instabilità Pages sotto il fan-out. Questo fix è **difensivo** (assorbe il sintomo); mitigazione strutturale = follow-up se i 504 persistono.
- **404 brand logos (~95k/giorno: `/images/brands/*.png`, `/images/logos/*.svg`):** rilevati dal tool ma **out of scope** (asset mancanti, non Worker). Separabile in issue follow-up.
- **Sibling-pattern (AGENTS #6):** `check-sibling-patterns.mjs` segnala 6 file per token condivisi `CF_API_TOKEN`/`detailData`/`baseFilter` — **tutti falsi positivi** (nomi var generici / stesso env var canonico, nessun antipattern condiviso). Nessun sibling da sweepare.

## Test plan

- [x] `node --check` su worker + script; YAML lint su deploy-worker.yml
- [x] `cf-status-report.mjs` testato live (24h, `--class=5`, `--host`, `--json`)
- [ ] Post-merge: job `deploy-worker` verde (dipende dallo scope del token)
- [ ] Post-merge: ri-run `cf-status-report.mjs --class=5` → i 504 shard calano
- [ ] Post-merge: spot-check `curl -I` su `/en/ /de/ /fr/` durante cache-miss
