### PR TITLE
fix(seo): reach orphaned canton city hubs + fix canton title-length classifier leak

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -612,6 +612,18 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const distDir = np.resolve(rootDir, 'dist');
  const jobsPath = np.resolve(rootDir, 'data/jobs.json');
 
+ // BFS-depth closure (2026-06-11): the per-canton "Esplora" navigator only
+ // linked the top-8 cities by job count, leaving every OTHER emitted
+ // municipality city hub (`/cerca-lavoro-{canton}/{city}/`) BFS-orphaned in
+ // sitemap-jobs.xml (1715 offenders vs 1037 baseline on the failing
+ // post-deploy run). The per-canton city-hub emit (Phase 3.1 below) records
+ // the EXACT emitted city-hub set per canton here — same gate, same slugs —
+ // so the navigator can link all of them and bring every city page to BFS
+ // depth ≤ (canton hub + 1). Keyed by canton code; the slug is
+ // locale-independent (the navigator prefixes the locale section itself).
+ // Auto-covers every present and future canton with no per-canton wiring.
+ const emittedCantonCityHubs = new Map<string, Array<{ slug: string; label: string }>>();
+
  // Tiered emission filter (artifact-shrink Fase 1). Consults
  // data/evidence-index.json (90d GSC/GA4/PostHog) + the hourly
  // data/thin-page-promotions-active.json (self-healing feedback) +
@@ -6030,6 +6042,9 @@ ${staticAnalyticsHtml}
    if (ca !== cb) return cb - ca;
    return a.citySlug.localeCompare(b.citySlug);
  });
+ // Record the exact emitted city-hub set (job-desc + alpha order) so the
+ // canton-hub navigator links every one of them (BFS-depth closure above).
+ emittedCantonCityHubs.set(canton, cantonCityList.map((c) => ({ slug: c.citySlug, label: c.cityDisplay })));
  for (const { citySlug, cityDisplay: canonCityDisplay } of cantonCityList) {
  const cityJobs = byCity.get(citySlug) ?? ([] as typeof validJobs);
  const cityDisplay = cityDisplayByCantonCity.get(canton)?.get(citySlug) ?? canonCityDisplay;
@@ -8982,6 +8997,22 @@ ${staticAnalyticsHtml}
          seenCitySlugs.add(slug);
          topCityHubs.push({ slug, label: cityRaw });
        }
+       // BFS-depth closure (2026-06-11): every OTHER emitted municipality
+       // city hub for this canton (beyond the top-8 featured above). The
+       // per-canton city-hub emit (Phase 3.1) writes a static page for EVERY
+       // canon municipality — incl. 0-job ones — but the navigator only
+       // linked the top 8, leaving the long tail (e.g. argovia/suhr,
+       // argovia/wettingen) BFS-orphaned in sitemap-jobs.xml. Link the exact
+       // emitted set (recorded at emit time, same gate + same slugs → no
+       // 404 risk) so each city page reaches BFS depth ≤ (canton hub + 1).
+       // Deduped against the featured top-8 via the shared seenCitySlugs set
+       // so no URL is linked twice (Squirrel identical-links a11y).
+       const otherCityHubs: Array<{ slug: string; label: string }> = [];
+       for (const c of emittedCantonCityHubs.get(entry.key) ?? []) {
+         if (!c.slug || seenCitySlugs.has(c.slug)) continue;
+         seenCitySlugs.add(c.slug);
+         otherCityHubs.push(c);
+       }
        // Top categories by job count (max 6). Mirror the category slug
        // tables from the category-listing block (~line 5742-5752); kept
        // inline to avoid hoisting a nested scope across thousands of lines.
@@ -9143,6 +9174,10 @@ ${staticAnalyticsHtml}
          : entry.locale === 'de' ? 'Top-Städte'
          : entry.locale === 'fr' ? 'Villes principales'
          : 'Città principali';
+       const colAllCitiesLabel = entry.locale === 'en' ? `All municipalities in ${display}`
+         : entry.locale === 'de' ? `Alle Gemeinden in ${display}`
+         : entry.locale === 'fr' ? `Toutes les communes en ${display}`
+         : `Tutti i comuni in ${display}`;
        const colByCategoryLabel = entry.locale === 'en' ? 'Top sectors'
          : entry.locale === 'de' ? 'Top-Branchen'
          : entry.locale === 'fr' ? 'Secteurs principaux'
@@ -9178,6 +9213,25 @@ ${staticAnalyticsHtml}
            `<div class="s-h0CoDf" data-explore-categories>` +
            `<h3 class="s-8S_vke">${esc(colByCategoryLabel)}</h3>` +
            `<div>${renderLinks(topCategoryHubs)}</div>` +
+           `</div>`,
+         );
+       }
+       // BFS-depth closure (2026-06-11): link every remaining emitted
+       // municipality city hub so the long tail is no longer BFS-orphaned.
+       // Rendered as a lightweight comma-free wrapped link list (NOT the
+       // per-link pill style above) because a big canton (Bern ~334
+       // municipalities) would otherwise add ~90 KB of repeated inline-style
+       // bytes to the hub and crowd the flat 215 KB page-weight cap. Plain
+       // anchors inherit the seo-static link color; one container style does
+       // the spacing for the whole block.
+       if (otherCityHubs.length > 0) {
+         const cityIndexLinks = otherCityHubs
+           .map((it) => `<a href="${exploreSectionBase}${it.slug}/">${esc(it.label)}</a>`)
+           .join(' · ');
+         blocks.push(
+           `<div class="s-h0CoDf" data-explore-all-cities>` +
+           `<h3 class="s-8S_vke">${esc(colAllCitiesLabel)}</h3>` +
+           `<div style="font-size:14px;line-height:1.9;color:var(--color-link)">${cityIndexLinks}</div>` +
            `</div>`,
          );
        }

--- a/scripts/audit-dist-multi.mjs
+++ b/scripts/audit-dist-multi.mjs
@@ -37,6 +37,7 @@ import { join, relative, sep, isAbsolute, dirname, extname, basename } from 'nod
 import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { TYPES_ACCEPT_IN_LANGUAGE_LIST } from '../services/seo/inlanguage-whitelist.data.mjs';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -314,7 +315,7 @@ function classifyFeatureRatio(relPath) {
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\//.test(p)) {
     return 'weekly-employers-hub';
   }
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board'; // canton-aware (shared matcher)
   if (/(?:^|\/)(?:premi-cassa-malati|health-insurance-premiums|health-premiums|krankenkassenpraemien|krankenkassen-praemien|primes-assurance-maladie|primes-assurance-maladie-communes|primi-cassa-malati-comuni)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|tessin-arbeitsmarkt|marche-travail-tessin|tessin-marche-emploi|mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
   if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';
@@ -329,7 +330,7 @@ function classifyFeatureTitle(relPath) {
   if (/(?:^|\/)(prezzi-benzina-svizzera|prezzi-carburante-svizzera|prix-essence-suisse|fuel-prices-switzerland|benzinpreise?-schweiz|prezzi-benzina|prezzi-diesel|gasoline-price|diesel-price|benzinpreis|dieselpreis|prix-essence|prix-gasoil|prix-diesel)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\/(?:azienda|company|unternehmen|entreprise)-/.test(p)) return 'weekly-employers';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|firmen-die-einstellen|unternehmen-die-einstellen|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers-hub';
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board'; // canton-aware (shared matcher)
   if (/(?:^|\/)(?:premi-cassa-malati|cassa-malati|health-premiums|health-insurance|krankenkassen-praemien|krankenkasse|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
   if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier)\//.test(p)) return 'blog';
@@ -343,7 +344,7 @@ function classifyFeatureH1(relPath) {
   const p = '/' + relPath.replace(/\\/g, '/').replace(/^dist\//, '').replace(/index\.html$/, '');
   if (/(?:^|\/)(prezzi-benzina-svizzera|prezzi-carburante-svizzera|prix-essence-suisse|fuel-prices-switzerland|benzinpreise?-schweiz)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\/(?:azienda|company|unternehmen|entreprise)-/.test(p)) return 'weekly-employers';
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board'; // canton-aware (shared matcher)
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|firmen-die-einstellen|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers-hub';
   if (/(?:^|\/)(?:premi-cassa-malati|health-premiums|krankenkassen-praemien|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';

--- a/scripts/audit-page-weight.mjs
+++ b/scripts/audit-page-weight.mjs
@@ -16,6 +16,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { relative } from 'node:path';
 import { writeAuditReport } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 // 215 KB cap (was 200 KB). The TI job-board landing
 // /cerca-lavoro-ticino/index.html crossed the original 200 KB cap on run
@@ -53,7 +54,10 @@ function budgetForPath(relPath) {
 
 function featureForPath(relPath) {
   const p = '/' + relPath.replace(/\\/g, '/').replace(/^dist\//, '').replace(/index\.html$/, '');
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  // Canton-aware job-board sections (TI legacy, every canton, + svizzera
+  // aggregator) → shared matcher. Report-grouping only here (the gate is a
+  // flat per-page byte cap), but kept consistent with the audit classifiers.
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers';
   if (/(?:^|\/)(?:prezzi-benzina|prezzi-diesel|prezzi-carburante-svizzera|gasoline-price-switzerland|diesel-price-switzerland|prix-essence-suisse|prix-diesel-suisse|prix-gasoil-suisse|fuel-prices-switzerland|benzinpreis-schweiz|dieselpreis-schweiz|benzinpreise-schweiz)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -21,6 +21,7 @@ import { join, relative, isAbsolute } from 'node:path';
 import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { EJP_STRIPPED_MARKER } from '../build-plugins/shared/ejpMarker.mjs';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
@@ -71,7 +72,9 @@ function classifyFeature(relPath) {
   if (/(?:^|\/)(prezzi-benzina-svizzera|prezzi-benzina|prezzi-diesel|prezzi-carburante-svizzera|gasoline-price-switzerland|diesel-price-switzerland|prix-essence-suisse|prix-diesel-suisse|prix-gasoil-suisse|fuel-prices-switzerland|benzinpreis-schweiz|dieselpreis-schweiz|benzinpreise-schweiz)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\/[^/]+\/[^/]+\//.test(p)) return 'weekly-employers';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers-hub';
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  // Canton-aware job-board sections (TI legacy, every canton, + svizzera
+  // aggregator) → shared matcher. See scripts/lib/jobBoardSections.mjs.
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:premi-cassa-malati|health-insurance-premiums|health-premiums|krankenkassenpraemien|krankenkassen-praemien|primes-assurance-maladie|primes-assurance-maladie-communes|primi-cassa-malati-comuni)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|tessin-arbeitsmarkt|marche-travail-tessin|tessin-marche-emploi|mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
   if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -33,6 +33,7 @@ import { join, relative, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
@@ -64,7 +65,10 @@ export function classifyFeature(relPath) {
   if (/(?:^|\/)(prezzi-benzina-svizzera|prezzi-carburante-svizzera|prix-essence-suisse|fuel-prices-switzerland|benzinpreise?-schweiz|prezzi-benzina|prezzi-diesel|gasoline-price|diesel-price|benzinpreis|dieselpreis|prix-essence|prix-gasoil|prix-diesel)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\/(?:azienda|company|unternehmen|entreprise)-/.test(p)) return 'weekly-employers';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|firmen-die-einstellen|unternehmen-die-einstellen|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers-hub';
-  if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
+  // Canton-aware job-board sections (TI legacy, every canton, + svizzera
+  // aggregator) → shared matcher. Was TI-only, which leaked non-TI canton
+  // job pages into spa-locale/spa-other (2026-06-11 post-deploy failure).
+  if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:premi-cassa-malati|cassa-malati|health-premiums|health-insurance|krankenkassen-praemien|krankenkasse|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
   if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier)\//.test(p)) return 'blog';

--- a/scripts/lib/jobBoardSections.mjs
+++ b/scripts/lib/jobBoardSections.mjs
@@ -1,0 +1,62 @@
+/**
+ * Shared canton-aware job-board section matcher.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Single source of truth for "is this dist path under a job-board section?",
+ * used by the audit feature-classifiers (audit-title-length,
+ * audit-text-html-ratio, audit-dist-multi). Extracted per CLAUDE.md
+ * non-negotiable #6 (a regex duplicated literally in ≥2 files → one shared
+ * module) so the TI-vs-canton-aware drift that caused the 2026-06-11
+ * post-deploy title-length failure cannot happen again.
+ *
+ * Why this is broad (all cantons, not just TI).
+ *   The old literal was TI-only:
+ *     /(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//
+ *   Cathedral migration (#1275+) shipped canton-aware job-board sections for
+ *   every Swiss canton — `cerca-lavoro-argovia`, `find-jobs-geneva`,
+ *   `jobs-in-aargau`, `trouver-emploi-vaud`, the `cerca-lavoro-svizzera`
+ *   aggregator, German `jobs-in-der-…` prefixes, … — but the classifier kept
+ *   matching ONLY the four TI legacy slugs. Every NON-TI canton job page
+ *   (hub, city hub, category hub, editorial slot AND each job-detail page)
+ *   therefore fell through to the generic `spa-locale` (en/de/fr) /
+ *   `spa-other` (it) buckets. Long, externally-sourced job-detail titles
+ *   (e.g. `/en/find-jobs-geneva/head-of-clinic-with-or-without-specialty-…/`)
+ *   then drifted the volatile spa-locale ratchet over its cap on a normal
+ *   daily crawl, with no real SEO change. Classifying them under `job-board`
+ *   — where they belong, and which carries generous organic-growth headroom —
+ *   removes the false positive and auto-covers any future canton (the prefix
+ *   set is fixed; the canton slug is matched generically).
+ *
+ * Section-slug shape (data/canton-url-slugs.json → resolveCantonSection):
+ *   it:  cerca-lavoro-{slug}      (TI legacy: cerca-lavoro-ticino)
+ *   en:  find-jobs-{slug}         (TI legacy: find-jobs-ticino)
+ *   de:  jobs-in-{slug} | jobs-in-der-{slug} | jobs-im-{slug}  (TI: jobs-im-tessin)
+ *   fr:  trouver-emploi-{slug}    (TI legacy: trouver-emploi-tessin)
+ *   aggregator: cerca-lavoro-svizzera / find-jobs-switzerland /
+ *               jobs-in-schweiz / trouver-emploi-suisse
+ * The canton slug may itself contain a hyphen (e.g. `san-gallo`), so the
+ * trailing run allows `[a-z-]`. The match anchors on a path boundary and
+ * stops at the next `/`, so it only ever classifies the SECTION segment —
+ * deeper, more specific buckets (blog, fuel, health, …) are checked before
+ * this in every classifier and still win.
+ */
+
+/**
+ * Matches the leading job-board section segment of a normalised dist path
+ * (a path beginning with `/`, optionally locale-prefixed `/en|/de|/fr`).
+ * Examples that match: `/cerca-lavoro-ticino/…`, `/cerca-lavoro-argovia/…`,
+ * `/cerca-lavoro-svizzera/…`, `/en/find-jobs-geneva/…`, `/de/jobs-im-tessin/…`,
+ * `/de/jobs-in-aargau/…`, `/de/jobs-in-der-waadt/…`, `/fr/trouver-emploi-vaud/…`.
+ */
+export const JOB_BOARD_SECTION_RX =
+  /(?:^|\/)(?:cerca-lavoro|find-jobs|trouver-emploi|jobs-in|jobs-im)-[a-z][a-z-]*\//;
+
+/**
+ * @param {string} normalisedPath path that already starts with `/` and has had
+ *   the `dist/` prefix and trailing `index.html` stripped (the form the audit
+ *   classifiers build before bucketing).
+ * @returns {boolean} true when the path is under any canton-aware job-board
+ *   section (TI legacy, any canton, or the Switzerland aggregator).
+ */
+export function isJobBoardSectionPath(normalisedPath) {
+  return JOB_BOARD_SECTION_RX.test(normalisedPath);
+}

--- a/scripts/lib/jobBoardSections.mjs
+++ b/scripts/lib/jobBoardSections.mjs
@@ -1,12 +1,22 @@
 /**
  * Shared canton-aware job-board section matcher.
  * ─────────────────────────────────────────────────────────────────────────
- * Single source of truth for "is this dist path under a job-board section?",
- * used by the audit feature-classifiers (audit-title-length,
- * audit-text-html-ratio, audit-dist-multi). Extracted per CLAUDE.md
- * non-negotiable #6 (a regex duplicated literally in ≥2 files → one shared
- * module) so the TI-vs-canton-aware drift that caused the 2026-06-11
- * post-deploy title-length failure cannot happen again.
+ * Shared "is this dist path under a job-board section?" matcher, extracted
+ * per CLAUDE.md non-negotiable #6 (a regex duplicated literally in ≥2 files →
+ * one shared module) so the TI-vs-canton-aware drift that caused the
+ * 2026-06-11 post-deploy title-length failure stops recurring.
+ *
+ * Consumers (all the job-board SECTION detectors): the audit
+ * feature-classifiers audit-title-length (re-exported to
+ * audit-h1-title-duplicates + audit-title-no-disambig-hash),
+ * audit-text-html-ratio, audit-page-weight, audit-dist-multi; and the
+ * funnel validators validate-content-quality.isJobPage +
+ * validate-sitemap-pages.isJobPage (both non-blocking uses of the match).
+ * NOT yet wired: validate-structured-data-completeness.classifyPage — it
+ * feeds a BLOCKING sampler (process.exit on incomplete JobPosting schema),
+ * so broadening its stratification on the pages this change promotes is a
+ * behavioural change that can't be validated until the post-deploy dist
+ * exists; deferred to a verified follow-up (see PR ## Non implementato).
  *
  * Why this is broad (all cantons, not just TI).
  *   The old literal was TI-only:

--- a/scripts/validate-content-quality.mjs
+++ b/scripts/validate-content-quality.mjs
@@ -14,6 +14,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, extname } from 'path';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 const DIST = 'dist';
 const DOMAIN = 'https://frontaliereticino.ch/';
@@ -56,7 +57,13 @@ function hasJobPostingSchema(html) {
 }
 
 function isJobPage(path) {
-  return /\/(cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test('/' + path);
+  // Canton-aware job-board sections (TI legacy + every canton + svizzera
+  // aggregator) via the shared matcher — was TI-only, which made non-TI
+  // canton job pages invisible to the JobPosting-schema warning and the
+  // thin-bridge exemption below. Both downstream uses are non-blocking for
+  // these pages (jobsNoSchema is a warning; the exemption only ever removes
+  // a thin-content error), so broadening cannot turn the gate red.
+  return JOB_BOARD_SECTION_RX.test('/' + path);
 }
 
 function isIndividualJobPage(path) {

--- a/scripts/validate-sitemap-pages.mjs
+++ b/scripts/validate-sitemap-pages.mjs
@@ -100,6 +100,7 @@ import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
 import { join, dirname, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeAuditReport } from './lib/auditReport.mjs';
+import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -161,9 +162,12 @@ function hasJobPostingSchema(html) {
   return html.includes('"JobPosting"') || html.includes("'JobPosting'");
 }
 
-/** validate-content-quality.isIndividualJobPage — preserved verbatim. */
+/** Mirror of validate-content-quality.isJobPage — shared canton-aware matcher
+ *  (TI legacy + every canton + svizzera aggregator). Both downstream uses
+ *  (jobsNoSchema warning, thin-bridge exemption) are non-blocking for the
+ *  newly-covered non-TI canton pages, so broadening cannot turn the gate red. */
 function isJobPage(path) {
-  return /\/(cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test('/' + path);
+  return JOB_BOARD_SECTION_RX.test('/' + path);
 }
 
 const EDITORIAL_JOB_SLUGS = new Set([

--- a/tests/seo/job-board-section-classifier.test.ts
+++ b/tests/seo/job-board-section-classifier.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Guard for the canton-aware job-board section matcher
+ * (scripts/lib/jobBoardSections.mjs) and the audit feature classifier that
+ * consumes it (scripts/audit-title-length.mjs → also imported by
+ * audit-h1-title-duplicates + audit-title-no-disambig-hash).
+ *
+ * Regression context (2026-06-11 post-deploy validate-dist failure):
+ * the classifier matched ONLY the four TI legacy job-board slugs, so every
+ * NON-TI canton job page (hub, city hub, AND each job-detail page) fell into
+ * the volatile `spa-locale` / `spa-other` buckets. Long externally-sourced
+ * job titles then drifted the spa-locale ratchet over its cap with no real
+ * SEO change. These must classify as `job-board` (high organic-growth
+ * headroom) and auto-cover every present and future canton.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyFeature } from '../../scripts/audit-title-length.mjs';
+import { isJobBoardSectionPath, JOB_BOARD_SECTION_RX } from '../../scripts/lib/jobBoardSections.mjs';
+
+// classifyFeature takes a dist-relative path (with `dist/` prefix + index.html).
+const rel = (p: string) => `dist${p}index.html`;
+
+describe('job-board section matcher', () => {
+  const jobBoardPaths = [
+    // TI legacy (regression guard — must keep matching)
+    '/cerca-lavoro-ticino/',
+    '/en/find-jobs-ticino/',
+    '/de/jobs-im-tessin/',
+    '/fr/trouver-emploi-tessin/',
+    // Non-TI cantons, every locale prefix
+    '/cerca-lavoro-argovia/',
+    '/cerca-lavoro-argovia/wettingen/',
+    '/en/find-jobs-geneva/',
+    '/de/jobs-in-aargau/',
+    '/de/jobs-in-der-waadt/',
+    '/fr/trouver-emploi-vaud/',
+    // Multi-word canton slug (San Gallo) must not be truncated by the matcher
+    '/cerca-lavoro-san-gallo/',
+    '/cerca-lavoro-san-gallo/rapperswil/',
+    // Switzerland aggregator
+    '/cerca-lavoro-svizzera/',
+    '/en/find-jobs-switzerland/',
+    '/de/jobs-in-schweiz/',
+    '/fr/trouver-emploi-suisse/',
+    // Job-detail page under a non-TI canton section (the exact leak case)
+    '/en/find-jobs-geneva/head-of-clinic-with-or-without-specialty-title-80-to-100-hug-puplinge/',
+  ];
+
+  it.each(jobBoardPaths)('classifies %s as job-board', (p) => {
+    expect(isJobBoardSectionPath(p)).toBe(true);
+    expect(classifyFeature(rel(p))).toBe('job-board');
+  });
+
+  const nonJobBoardPaths = [
+    // Locale landing / guides must NOT be swallowed by the broadened matcher
+    '/en/guide-cross-border-taxation-2026/',
+    '/de/steuern-und-rente/quellensteuersaetze-tessin-2026/',
+    '/fr/guide-frontalier/lamal-frontaliers/',
+    '/glossario-frontaliere/',
+    // Job-market snapshot uses a different prefix and must stay distinct
+    '/de/arbeitsmarkt/',
+    '/mercato-lavoro-ticino/',
+  ];
+
+  it.each(nonJobBoardPaths)('does NOT classify %s as job-board', (p) => {
+    expect(isJobBoardSectionPath(p)).toBe(false);
+    expect(classifyFeature(rel(p))).not.toBe('job-board');
+  });
+
+  it('regex is anchored on a path boundary (no mid-segment false match)', () => {
+    // A path whose segment merely contains "find-jobs" mid-word must not match.
+    expect(JOB_BOARD_SECTION_RX.test('/blog/how-to-find-jobs-in-switzerland/')).toBe(false);
+  });
+
+  it('TI weekly-employer company hubs still win over job-board', () => {
+    expect(classifyFeature(rel('/cerca-lavoro-ticino/azienda-eoc/'))).toBe('weekly-employers');
+  });
+});

--- a/tests/seo/job-board-section-classifier.test.ts
+++ b/tests/seo/job-board-section-classifier.test.ts
@@ -74,4 +74,16 @@ describe('job-board section matcher', () => {
   it('TI weekly-employer company hubs still win over job-board', () => {
     expect(classifyFeature(rel('/cerca-lavoro-ticino/azienda-eoc/'))).toBe('weekly-employers');
   });
+
+  // The funnel validators (validate-content-quality / validate-sitemap-pages
+  // isJobPage) call `JOB_BOARD_SECTION_RX.test('/' + path)` where `path` is a
+  // dist-relative file path with the `index.html` leaf — cover that exact form.
+  it.each([
+    'cerca-lavoro-ticino/some-job/index.html',
+    'cerca-lavoro-argovia/wettingen/index.html',
+    'en/find-jobs-geneva/head-of-clinic-100-hug/index.html',
+    'de/jobs-in-aargau/index.html',
+  ])('validator form: "/" + %s matches the job-board section', (p) => {
+    expect(isJobBoardSectionPath('/' + p)).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes the two failing checks on post-deploy **validate-dist** (deploy run 27316219765): `audit:max-bfs-depth` and `audit:all → title-length`. Both have the same root: **non-TI cantons aren't wired into the funnel "like the others"**, so the user's ask was a structural, automatic mechanism that covers every present and future canton — not a one-off rebaseline.

## Implementato

### 1. bfs-depth — orphaned canton city hubs now reachable
- The per-canton **"Esplora" navigator** (in `build-plugins/jobsSeoPagesPlugin.ts`) linked only the **top-8 cities by job count**, while the Phase-3.1 emit writes a static page for **every** canon municipality (incl. 0-job ones, for SPA-404 safety). The long tail (`/cerca-lavoro-{canton}/{city}/`, e.g. `argovia/suhr`, `argovia/wettingen`) was therefore **BFS-orphaned** → `sitemap-jobs.xml` 1715 URLs at depth>4 vs 1037 baseline (rate 23.7% > allowed 21.8%).
- Phase 3.1 now records the **exact emitted city-hub set per canton** (`emittedCantonCityHubs`, same gate + same slugs → no 404 risk); the navigator links **all of them** in a lightweight below-fold "all municipalities" block, deduped against the featured top-8. Every emitted city page now reaches BFS depth ≤ (canton hub + 1).
- Verified on the deployed dist that the *linked* top cities (aarau/baden/bellikon/leuggern) are already reachable while the *unlinked* ones (suhr/wettingen) are the offenders — so linking them resolves the gate. **Data-driven → future cantons auto-covered, no per-canton wiring.**
- Lightweight render (plain anchors, one container style) instead of per-link pills: a big canton (Bern ~334 municipalities) would otherwise add ~90 KB of repeated inline-style bytes and crowd the flat 215 KB page-weight cap.

### 2. title-length — canton job pages no longer leak into the volatile spa-locale ratchet
- The audit feature-classifier's `job-board` regex matched **only the four TI legacy slugs**, so every **non-TI canton job page** (hub, city hub, AND each externally-sourced long-titled job-detail page, e.g. `/en/find-jobs-geneva/head-of-clinic-with-or-without-specialty-title-…/`) fell into the volatile **`spa-locale`** bucket and drifted it over cap (**103 > 90**) on a normal daily crawl — with no real SEO change.
- Extracted a shared **canton-aware section matcher** (`scripts/lib/jobBoardSections.mjs`, per non-negotiable #6) and wired it into **every** audit classifier that buckets `job-board`: `audit-title-length` (also imported by `audit-h1-title-duplicates` + `audit-title-no-disambig-hash`), `audit-text-html-ratio`, `audit-page-weight`, `audit-dist-multi`. Canton job pages now land in the high-headroom `job-board` bucket (cap 53462 vs current 71) where they belong.
- **Per-page 66-char threshold unchanged** (no gate loosened) — the fix only **moves** pages into the high-headroom `job-board` bucket; the `spa-*` buckets can only shrink. Added unit test `tests/seo/job-board-section-classifier.test.ts` (29 cases: TI legacy, every-canton prefixes, San-Gallo hyphen slug, `jobs-in-der-`, the svizzera aggregator, the exact job-detail leak case, validator-form paths, and no-over-match guards).
- **Verification:** ran old-vs-new classifier over the deployed IT dist — all 6 non-TI canton pages with title>66 move `spa-other → job-board` (0 stay). Scaling those 6 by the per-locale title-offender ratios (de 1.47×, fr 1.82×, en 1.11×) estimates ≈27 `spa-locale → job-board` moves → spa-locale ≈ 103 − 27 ≈ 76 ≤ 90. (Exact en/de/fr count not confirmable pre-merge: the locale shards are partial-clone promisor repos that won't serve blobs locally; the unified audit only sees them post-deploy after shard rehydration — see adjust-trigger below.)

### 3. Sibling-class follow-up (reviewer 🔴) — funnel validators
- The same TI-only job-page anti-pattern survived in the funnel validators for the exact non-TI canton pages this PR promotes. Wired the shared matcher into **`validate-content-quality.isJobPage`** and **`validate-sitemap-pages.isJobPage`**. Both downstream uses are **non-blocking** for the newly-covered pages: `jobsNoSchema` is a warning (now *surfaces* non-TI canton job pages missing `JobPosting` schema — previously silent → lost Google Jobs eligibility), and the thin-content path only *gains* the thin-bridge exemption (can only remove a blocking error, never add one) — so the gate cannot flip green→red.

## Non implementato (ancora)
- **bfs-depth pass not verifiable pre-merge** — `build:ci` is OOM-prone and only runs post-merge, and the new links only exist in a fresh dist. **Revert-trigger:** if the next post-deploy `audit:max-bfs-depth` still reports `sitemap-jobs.xml` regressed, revert this PR's navigator change and reopen. (The classifier change is independently verified — see below.)
- **Homepage SEO block absence** — separate latent regression: the deployed `/` is missing its entire injected SEO block (`hp-seo-block`, canton nav, orphan-pillar + related-guides links), so canton hubs sit at depth 3 (via TI→svizzera) instead of depth 1. This PR makes the gate pass without it (cities reach depth ≤4), but restoring it would add headroom. Out of scope here → follow-up.
- **title-length residual** — if the next post-deploy `audit:all → title-length` still reports `spa-locale > 90` after this reclassification, the remainder is genuine organic localized cathedral/section landings (the documented spa-locale growth class), not the canton-job leak: **adjust-trigger** = bump only the `spa-locale` feature ratchet to the observed count with the standard organic-growth note, per the explicit-user-override precedent already recorded in `data/title-length-baseline.json` (25→41→48→65→90). Per-page 66-char threshold stays.
- **`validate-structured-data-completeness.classifyPage`** deliberately left TI-scoped (reviewer 🔴 option B). Unlike the two `isJobPage` validators, it feeds a **BLOCKING** sampler (`process.exit(1)` on incomplete `JobPosting` schema). Broadening its stratification would change *which* non-TI canton job pages get sampled and could surface JobPosting-completeness failures that are **unverifiable pre-merge** (the strict postalCode/streetAddress/addressRegion/baseSalary checks need the rehydrated post-deploy dist). Non-TI canton JobPosting pages are **still validated via the `other` stratum** (the validators key off the page's real `@type`, not `classifyPage`), so coverage isn't lost — only stratification weighting. **Follow-up:** first audit non-TI canton JobPosting completeness on a real dist, then wire the matcher here.
- **~5 TI `categoria-*` hubs** (`/cerca-lavoro-ticino/categoria-finanza/` …) remain BFS-orphaned but are within gate tolerance; not the failing class. Follow-up.
- **`scripts/measure-l2-distribution.mjs`** left untouched — non-gate measurement tool, outside the failing class. (Correction to an earlier claim: its IT branch is `cerca-lavoro-*`-broad, but its **DE branch matches only `de/jobs-im` (TI)**, not `jobs-in-*`, so German non-TI canton pages are mis-bucketed there too — harmless since it's not a gate; fold into the same follow-up.)

### Adversarial checks (reviewer)
- **Page-weight on the largest cantons — measured.** Using the deployed IT dist + `data/canton-municipalities.json`: the biggest canton hub (Bern, 334 municipalities → 326 extra plain-anchor links) grows ~41.3 KB → **~65 KB**; Zürich ~56 KB, Vaud ~61 KB, Argovia ~54 KB — all far under the flat **215 KB** `audit-page-weight` cap. The lightweight plain-anchor render (no per-link pill style) is what keeps this bounded.
- **`JOB_BOARD_SECTION_RX` over-match** — anchored on a path boundary and limited to the five reserved job-section prefixes (`cerca-lavoro`/`find-jobs`/`trouver-emploi`/`jobs-in`/`jobs-im`), which are used exclusively for job-board sections in `resolveCantonSection`. Unit test asserts non-job locale paths (`/de/steuern-und-rente/…`, guides, glossary) and mid-word `find-jobs` do **not** match; `jobs-in-der-*` and the aggregator **do**.
