### PR TITLE
fix(build): stabilize entry stylesheet to assets/index.css (eliminate rotated-hash 404s)

### DIFF
--- a/build-plugins/shared/spaBundleRx.ts
+++ b/build-plugins/shared/spaBundleRx.ts
@@ -10,8 +10,11 @@
  * content-hashed (vite.config.ts `entryFileNames`), so the prerendered pages
  * don't churn on every bundle rehash. The regex still matches it unchanged
  * because `entry` ∈ the hash charset (`index-<hashchars>+.js`). The entry CSS
- * stays content-hashed (`index-{hash}.css`) — its bytes change only on real
- * style changes, so it doesn't drive the per-deploy churn.
+ * is now ALSO stabilized to `assets/index.css` (vite.config.ts assetFileNames)
+ * — content-hashing it meant a rotated hash 404'd from old cached HTML still
+ * referencing the superseded name; a stable name always resolves. Its bytes
+ * still change on real style changes, so like index-entry.js it must REVALIDATE
+ * (public/_headers), not be served immutable.
  *
  * The `[^"]*` before `/assets/` tolerates an optional origin prefix so the
  * match works whether Vite emitted a same-origin path or an absolute CDN URL
@@ -42,4 +45,8 @@ import { VITE_HASH_CHARS } from './viteAssetHashRx';
 
 const H = `[${VITE_HASH_CHARS}]`;
 export const SPA_ENTRY_JS_RX = new RegExp(`src="[^"]*\\/assets\\/(index-${H}+\\.js)"`);
-export const SPA_ENTRY_CSS_RX = new RegExp(`href="[^"]*\\/assets\\/(index-${H}+\\.css)"`);
+// The CSS hash is OPTIONAL: the entry stylesheet is stabilized to
+// `assets/index.css` (vite.config.ts assetFileNames), but HTML cached before
+// that change — or any future re-hashed asset — may still carry
+// `index-<hash>.css`, so match both shapes. Capture stays the bare filename.
+export const SPA_ENTRY_CSS_RX = new RegExp(`href="[^"]*\\/assets\\/(index(?:-${H}+)?\\.css)"`);

--- a/public/_headers
+++ b/public/_headers
@@ -14,6 +14,17 @@
 # the site moves to object storage / a CDN that reads _headers.)
 /assets/index-entry.js
   Cache-Control: public, max-age=0, must-revalidate
+# SPA entry STYLESHEET has a STABLE name too (assets/index.css, see
+# vite.config.ts assetFileNames) for the same reason — a stable name never
+# 404s from old cached HTML referencing a rotated hash. Its bytes DO change on
+# real style changes, so it must REVALIDATE and override the immutable
+# /assets/* rule. Placed AFTER /assets/* so it wins under both precedence
+# semantics, exactly like index-entry.js above. (GitHub Pages ignores _headers
+# today; honored once the site serves from a _headers-reading CDN. If the
+# Fastly/CDN layer pins /assets/* immutable independently of _headers, add the
+# same revalidate override there — else a style change serves stale CSS.)
+/assets/index.css
+  Cache-Control: public, max-age=0, must-revalidate
 
 # Icons — cache for 1 month
 /icons/*

--- a/tests/spa-bundle-resolver.test.ts
+++ b/tests/spa-bundle-resolver.test.ts
@@ -56,6 +56,35 @@ describe('resolveSpaBundle', () => {
     expect(info.hasSpaBundle).toBe(true);
   });
 
+  it('extracts the STABLE entry filenames (index-entry.js + hashless index.css)', () => {
+    // Production output after the entry JS + CSS stabilization (vite.config.ts
+    // entryFileNames + assetFileNames): the JS entry is `index-entry.js` and
+    // the CSS entry is the hashless `index.css`. The resolver must extract both
+    // — the CSS hash is optional in SPA_ENTRY_CSS_RX.
+    const html = `<!doctype html>
+<html><head>
+<link rel="stylesheet" href="/assets/index.css">
+<script type="module" crossorigin src="/assets/index-entry.js"></script>
+</head><body><div id="root"></div></body></html>`;
+    fs.writeFileSync(path.join(distDir, 'index.html'), html, 'utf-8');
+    const info = resolveSpaBundle(distDir);
+    expect(info.entryJs).toBe('index-entry.js');
+    expect(info.entryCss).toBe('index.css');
+    expect(info.hasSpaBundle).toBe(true);
+  });
+
+  it('extracts the stable hashless index.css from an absolute CDN URL too', () => {
+    const html = `<!doctype html>
+<html><head>
+<link rel="stylesheet" href="https://cdn.frontaliereticino.ch/assets/index.css">
+<script type="module" crossorigin src="https://cdn.frontaliereticino.ch/assets/index-entry.js"></script>
+</head><body><div id="root"></div></body></html>`;
+    fs.writeFileSync(path.join(distDir, 'index.html'), html, 'utf-8');
+    const info = resolveSpaBundle(distDir);
+    expect(info.entryCss).toBe('index.css');
+    expect(info.hasSpaBundle).toBe(true);
+  });
+
   it('caches per distDir — second call does not re-read', () => {
     writeIndexHtml(distDir, 'AAA', 'BBB');
     const first = resolveSpaBundle(distDir);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -431,6 +431,21 @@ export default defineConfig(({ mode }) => {
  // - CDN offload (deploy.yml) cp -r's all of dist/assets, and prune-cdn-assets
  //   never prunes a file present in dist/assets → the stable entry ships + persists.
  entryFileNames: 'assets/index-entry.js',
+ // STABLE entry stylesheet (no content-hash), same rationale as the JS entry
+ // above. When the CSS was content-hashed (index-<hash>.css, Vite default for
+ // assets), a rotated hash 404'd from any HTML still cached referencing the
+ // superseded name (old browser/CDN copy) → unstyled page. Pinning it to
+ // assets/index.css makes the reference always resolve. ONLY the entry sheet
+ // is stabilized; every other asset keeps [hash] for cache-busting.
+ // - Matches build-plugins/shared/spaBundleRx.ts SPA_ENTRY_CSS_RX (hash now
+ //   optional) → resolver/seoPageShell pick up `index.css` unchanged.
+ // - CACHE: index.css bytes change on real style changes → it must REVALIDATE,
+ //   not be served immutable — see public/_headers (mirrors index-entry.js).
+ assetFileNames: (assetInfo) => {
+ const n = assetInfo.name || (assetInfo.names && assetInfo.names[0]) || '';
+ if (n === 'index.css') return 'assets/index.css';
+ return 'assets/[name]-[hash][extname]';
+ },
  manualChunks(id) {
  // Vendor chunks for node_modules
  if (id.includes('node_modules')) {


### PR DESCRIPTION
## Implementato

L'entry CSS dello SPA era content-hashed (`assets/index-<hash>.css`, default Vite). Quando l'hash ruotava su un cambio di stile reale, l'HTML ancora in cache che referenziava il nome superato dava **404** sull'apex (osservato live: `/assets/index-Cz2K6jW9.css`, ~33/giorno). Solo il **JS entry** era stato stabilizzato (`index-entry.js`); il CSS era lasciato hashed di proposito. Questa PR completa il lavoro per il CSS, **rispecchiando esattamente il precedente del JS entry** (già in produzione, funzionante).

- **`vite.config.ts`**: `assetFileNames` fissa l'entry sheet a `assets/index.css`; ogni altro asset mantiene `[hash]` per il cache-busting.
- **`build-plugins/shared/spaBundleRx.ts`**: in `SPA_ENTRY_CSS_RX` l'hash è ora **opzionale** (`index(?:-<hash>)?.css`) → matcha sia il nome stabile sia l'HTML legacy in cache. Definizione **condivisa unica** → `spaBundleResolver` + `seoPageShell` si muovono insieme (entrambi la **importano**, zero copy-paste).
- **`public/_headers`**: `/assets/index.css` riceve `max-age=0, must-revalidate`, posizionato DOPO la regola immutable `/assets/*`, **identico a `index-entry.js`** — un nome stabile DEVE rivalidare o un cambio di stile servirebbe CSS stale.
- **`tests/spa-bundle-resolver.test.ts`**: +2 casi che bloccano l'estrazione del `index.css` hashless (same-origin + CDN-absolute). File intero verde (**12/12**, eseguito in locale).

**Ripple più piccolo del previsto:** `asyncCssPlugin.ts` è già hash-agnostic (`/assets/*.css`) e `audit-spa-bundle-injection.mjs` matcha solo il JS entry → nessun cambio. Tutti i consumer (`jobsSeoPagesPlugin`, `staticPagesPlugin`, `seoPageShell`) usano la var `entryCss` dal resolver → ricevono `index.css` automaticamente.

**Transizione sicura:** il CDN offload è additivo (`cp -n`, deploy.yml) → il nuovo `index.css` viene pushato e i vecchi hash restano fino al prune-grace → **nessun 404 in transizione**.

## Non implementato (ancora)

- **Header del repo CDN / Fastly (RISCHIO CHIAVE — revert-trigger):** GitHub Pages ignora `_headers`; il `must-revalidate` è onorato solo da un CDN che legge `_headers`. Se il layer **Fastly/CDN** che serve `cdn.frontaliereticino.ch/assets/*` pinna `/assets/*` come **immutable** indipendentemente da `_headers`, un cambio di stile servirebbe **CSS stale a vita** su quel path. **Non verificabile/controllabile da questo repo.** Mitigante: il **precedente `index-entry.js`** è servito identico (stesso path CDN+apex, stesso `must-revalidate`) e **funziona** — i suoi byte cambiano ad ogni deploy e non resta stale, quindi il serving layer già rivalida i nomi stabili in `/assets/`. **Revert-trigger:** se dopo un cambio CSS il sito appare non-stilizzato/stale → il CDN serve `index.css` immutable → aggiungere lì la stessa override revalidate (o revert).
- **Verifica build emit pre-merge:** il nome emesso (`assets/index.css`) è verificabile solo da un build Vite completo (OOM-prone in locale → gira solo post-merge su `main`). Confermato indirettamente: il `SPA_ENTRY_CSS_RX` attuale matcha `index-<hash>.css` → l'asset name è `index.css` → il matcher `assetFileNames` (`n === 'index.css'`) lo intercetta. **Revert-trigger:** se il primo deploy post-merge emette ancora `index-<hash>.css` (assetInfo.name diverso) → il match non scatta; aggiustare la condizione.
- **Sibling-pattern (AGENTS #6):** `check-sibling-patterns.mjs` segnala `seoPageShell.ts` + `spaBundleResolver.ts` per `SPA_ENTRY_CSS_RX` — **falsi positivi corretti by-design**: entrambi **importano** la regex dal modulo condiviso `spaBundleRx.ts`, quindi l'edit della definizione unica li copre (è il pattern anti-drift, non duplicazione).

## Test plan

- [x] `tests/spa-bundle-resolver.test.ts` (12/12) + `css-asset-hash.test.ts` verdi in locale
- [x] regex verificata: matcha `index.css` + legacy `index-<hash>.css`, same-origin + CDN-abs, ignora il JS
- [ ] Post-merge: il primo deploy emette `assets/index.css` (no hash) — verifica `curl -I https://frontaliereticino.ch/assets/index.css` → 200
- [ ] Post-merge: nessuna regressione di stile (pagine stilizzate, hydration ok) su SPA + statiche
- [ ] Dopo un futuro cambio CSS: `index.css` si aggiorna entro la finestra di revalidate (no stale) — se stale → Fastly immutable, vedi revert-trigger