### PR TITLE
fix(publisher): paid ads blocked from live slice by boilerplate guard (descriptionByLocale.it)

### DIFF
--- a/scripts/lib/publisherJobProjection.mjs
+++ b/scripts/lib/publisherJobProjection.mjs
@@ -91,6 +91,26 @@ export function publisherJobToRecords(pubJob, opts = {}) {
   const nowIso = opts.nowIso || null;
   const validDays = Number.isFinite(opts.validDays) ? opts.validDays : 30;
 
+  // Mirror the (already ≥50-word, validated) description into the source-locale
+  // key of descriptionByLocale. Publisher ads store only the flat `description`
+  // string — they never populate `descriptionByLocale`. Downstream the
+  // boilerplate guard (assemble-jobs-dataset detectBoilerplateDescriptions)
+  // reads `job.descriptionByLocale?.it`, so an absent map looks like an EMPTY
+  // description → every publisher ad is flagged `empty_description` → the
+  // publisher-jobs-sync FATALs at the 50% threshold and a PAID ad never reaches
+  // the live slice. Filling the source locale (IT for the IT-primary site) with
+  // the same text the page already renders fixes the false positive without
+  // changing any content or lowering the thin-content gate above.
+  const sourceLang = pubJob.sourceLang || 'it';
+  const descriptionByLocale = { ...(pubJob.descriptionByLocale || {}) };
+  const flatDescription = String(pubJob.description || '').trim();
+  if (flatDescription && !String(descriptionByLocale[sourceLang] || '').trim()) {
+    descriptionByLocale[sourceLang] = pubJob.description;
+  }
+  if (flatDescription && !String(descriptionByLocale.it || '').trim()) {
+    descriptionByLocale.it = pubJob.description;
+  }
+
   const company = pubJob.company || {};
   const companyName = String(company.name || '').trim();
   const companyKey = company.companyKey || slugifyPublisher(companyName);
@@ -148,7 +168,7 @@ export function publisherJobToRecords(pubJob, opts = {}) {
       validThrough: validThroughIso,
       description: pubJob.description || '',
       titleByLocale: pubJob.titleByLocale || undefined,
-      descriptionByLocale: pubJob.descriptionByLocale || undefined,
+      descriptionByLocale: Object.keys(descriptionByLocale).length ? descriptionByLocale : undefined,
       id,
       salaryMin: pubJob.salaryMin ?? null,
       salaryMax: pubJob.salaryMax ?? null,

--- a/tests/publisher-job-projection.test.ts
+++ b/tests/publisher-job-projection.test.ts
@@ -8,6 +8,10 @@ import {
   PUBLISHER_SOURCE_KEY,
   // @ts-expect-error mjs module, no type declarations
 } from '../scripts/lib/publisherJobProjection.mjs';
+import {
+  detectBoilerplateDescriptions,
+  // @ts-expect-error mjs module, no type declarations
+} from '../scripts/assemble-jobs-dataset.mjs';
 
 const NOW = '2026-06-10T10:00:00.000Z';
 
@@ -47,6 +51,22 @@ describe('publisherJobToRecords', () => {
     expect(r.source).toBe(PUBLISHER_SOURCE_KEY);
     expect(r.publisherUid).toBe('pub1');
     expect(r.publisherJobId).toBe('job1');
+  });
+
+  it('mirrors the flat description into descriptionByLocale.it (boilerplate-guard input)', () => {
+    const desc = 'parola '.repeat(60).trim();
+    const [r] = publisherJobToRecords(paidJob({ description: desc }), { nowIso: NOW });
+    expect(r.descriptionByLocale).toBeDefined();
+    expect(r.descriptionByLocale.it).toBe(desc);
+  });
+
+  it('preserves an existing descriptionByLocale.it instead of overwriting it', () => {
+    const existing = 'testo italiano gia tradotto con tante parole diverse qui '.repeat(4).trim();
+    const [r] = publisherJobToRecords(
+      paidJob({ descriptionByLocale: { it: existing } }),
+      { nowIso: NOW },
+    );
+    expect(r.descriptionByLocale.it).toBe(existing);
   });
 
   it('produces stable deterministic ids per (job, location)', () => {
@@ -237,5 +257,30 @@ describe('applyMode projection', () => {
       { nowIso: NOW },
     );
     expect(r.applyMode).toBe('external_url');
+  });
+});
+
+describe('publisher slice does not trip the boilerplate guard', () => {
+  // Regression for the publisher-jobs-sync FATAL: publisher ads store only the
+  // flat `description`, so before the descriptionByLocale.it mirror the guard
+  // read an empty IT description and flagged every paid ad as boilerplate
+  // (`empty_description`) → 100% ratio → the whole sync aborted and the paid ad
+  // never reached the live slice.
+  it('flags 0 records as boilerplate when ads have real ≥50-word descriptions', () => {
+    const realDesc =
+      'Cerchiamo una figura motivata e qualificata da inserire stabilmente nel nostro ' +
+      'team clinico multidisciplinare in forte crescita. COMPITI: gestione quotidiana ' +
+      'dei pazienti, valutazione funzionale completa, redazione dei piani di trattamento ' +
+      'personalizzati, monitoraggio dei progressi e stretta collaborazione con il ' +
+      'personale medico e amministrativo della struttura. PROFILO: diploma riconosciuto, ' +
+      'esperienza pregressa nel settore, ottime capacita relazionali e comunicative, ' +
+      'autonomia organizzativa, precisione e disponibilita al lavoro su turni flessibili. ' +
+      'Offriamo un ambiente moderno e ben attrezzato, formazione continua, possibilita ' +
+      'concrete di crescita professionale e un pacchetto retributivo competitivo.';
+    const recs = publisherJobsToSlice([paidJob({ description: realDesc })], { nowIso: NOW });
+    expect(recs.length).toBeGreaterThan(0);
+    const report = detectBoilerplateDescriptions(recs, PUBLISHER_SOURCE_KEY);
+    expect(report.boilerplateCount).toBe(0);
+    expect(report.ratio).toBe(0);
   });
 });


### PR DESCRIPTION
## Implementato

- **Root cause di un bug funnel: gli annunci publisher PAGATI non raggiungono lo slice live.** Gli annunci salvano solo il `description` piatto (il form/CF non popolano mai `descriptionByLocale`). La projection `publisherJobToRecords` passava `descriptionByLocale: undefined`, ma il boilerplate guard a valle (`assemble-jobs-dataset` → `detectBoilerplateDescriptions`) legge `job.descriptionByLocale?.it`: una mappa assente sembra una descrizione **vuota** → ogni annuncio pagato viene flaggato `empty_description` → ratio 100% → `publisher-jobs-sync` va in FATAL al threshold 50% e l'annuncio pagato non arriva mai al listing (osservato live: run fallito "2/2 jobs have boilerplate-only descriptions", `publisher-submitted.json` a 0 record).
- **Fix** (`scripts/lib/publisherJobProjection.mjs`): in `publisherJobToRecords` rispecchia il `description` (già validato ≥50 parole) nella chiave del source-locale (IT per il sito IT-primary) di `descriptionByLocale` quando assente, preservando qualsiasi mappa localizzata pre-esistente. **Nessun cambio di contenuto** (la pagina già renderizza quel testo) e **nessun quality gate abbassato** — il thin-content gate `MIN_DESCRIPTION_WORDS=50` resta intatto (AGENTS #1/#4).
- **Test**: regressione end-to-end che proietta un annuncio reale e asserisce che il boilerplate guard flagga 0 record; + unit test per il mirror e per la preservazione di una mappa esistente. 54/54 test publisher verdi.

## Non implementato (ancora)

- **Robustezza del guard per slice human-submitted a basso volume**: il threshold 50% + FATAL-abort è pensato per i crawler (boilerplate = parser rotto sistemico). Per lo slice publisher (pochi annunci scritti a mano) un singolo annuncio genuinamente thin potrebbe ancora abortire l'intero deploy invece di essere semplicemente droppato. Out of scope qui (questo PR risolve il falso-positivo che blocca annunci validi); follow-up: drop per-record invece di FATAL per `publisher-submitted`.
- **Sibling sweep**: il falso-positivo è specifico della projection publisher (unico slice che salva `description` piatto senza `descriptionByLocale`); i crawler popolano già `descriptionByLocale`. Nessun sibling da toccare.
- **Verifica live**: post-merge, ri-triggerare `publisher-jobs-sync.yml` su main e confermare che `publisher-submitted.json` contenga gli annunci pagati e che il listing live li mostri.

## Test plan

- [x] `vitest run tests/publisher-job-projection.test.ts` → 28/28 (incl. regressione guard).
- [x] Suite publisher completa (blast-match, projection, pricing, pricing-mirror) → 54/54.
- [ ] Post-merge: `gh workflow run publisher-jobs-sync.yml --ref main` → verde, `publisher-submitted.json` non vuoto, annuncio visibile su `/cerca-lavoro-ticino/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)