### PR TITLE
feat(worker): enable Workers Logs observability (free tier)

### DIFF
--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -28,3 +28,18 @@ routes = [
   # only burned ~10 needless Worker subrequests per shard pageview against the
   # free-tier 100k/day cap (the in-code CDN_PATHS branch was already dropped).
 ]
+
+# Workers Logs (Observability) — free tier. Persists per-request logs +
+# console output + the request outcome (status, CPU, errors) to the dashboard
+# (Workers & Pages → frontaliere-locale-router → Logs) with a short retention.
+# Declared HERE (not via a one-off dashboard/API toggle) so every
+# `wrangler deploy` keeps it on — an API PATCH would be wiped on the next deploy.
+# head_sampling_rate = 1 logs 100% of invocations; the Worker only handles the
+# en/de/fr shard traffic (well under the free 100k/day invocation cap), so full
+# sampling stays within the free Workers Logs daily allowance and gives complete
+# visibility into the shard 504 path (whether the origin retry / last-known-good
+# fallback actually fires).
+[observability]
+enabled = true
+head_sampling_rate = 1
+


### PR DESCRIPTION
## Implementato

Abilita **Workers Logs (Observability)** sul Worker `frontaliere-locale-router` — parte "observability free" della richiesta di configurare gli analytics/observability gratuiti.

- `infra/cloudflare-worker/wrangler.toml`: blocco `[observability] enabled = true`, `head_sampling_rate = 1`.

Dichiarato in `wrangler.toml` (non via toggle dashboard/API una-tantum) così **ogni `wrangler deploy` lo mantiene attivo** — un PATCH API verrebbe sovrascritto al deploy successivo. `head_sampling_rate=1` logga il 100% delle invocazioni: il Worker serve solo il traffico shard en/de/fr (ben sotto il cap free 100k/giorno), quindi il full-sampling resta nell'allowance free dei Logs.

**Bonus diagnostico:** i Worker Logs danno visibilità completa sul path dei 504 shard — mostreranno se il retry origin e il fallback last-known-good (#1791) scattano davvero, sbloccando la diagnosi del perché i 504 non sono calati.

Mergiando, `deploy-worker.yml` ridepoloya il Worker e attiva i Logs (Workers & Pages → frontaliere-locale-router → Logs).

## Non implementato (ancora)

- **Web Analytics / RUM (`/cdn-cgi/rum` 404):** il beacon è auto-iniettato da Cloudflare ma l'endpoint RUM non è provisionato. È gestito dal prodotto **Web Analytics** (`rum/site_info` API, account-level) su cui il token è ancora **403** — il permesso NON è zone (`Analytics:Edit` zone non esiste, confermato). Vedi guida nel thread per abilitarlo (dashboard o permesso Account). Out of scope di questo PR repo-side.
- **Logpush:** non incluso (non free per il nostro uso).

## Test plan

- [x] `tomllib` valida il wrangler.toml
- [ ] Post-merge: `deploy-worker.yml` verde → Workers Logs attivi in dashboard
- [ ] Post-merge: i log mostrano il path 504 (retry/LKG) per la diagnosi