### PR TITLE
🚨 hotfix(worker): buffer body once instead of 3-way tee — kills 30s stall on ALL shard pages (#1791 regression)

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -195,32 +195,37 @@ export default {
     // Cache successful GET responses and stamp Cache-Control so Cloudflare CDN
     // can also serve from edge without re-entering the Worker.
     if (request.method === 'GET' && resp.status === 200) {
-      // Clone the origin response up front so we can write two cache entries
-      // (short-TTL serving copy + long-TTL last-known-good) plus the returned
-      // body from one upstream read.
-      const lkgSource = resp.clone();
+      // Buffer the body ONCE, then build independent Responses from the bytes:
+      // the serving copy + the two cache entries (short-TTL cacheKey + long-TTL
+      // last-known-good). Do NOT tee/clone the live stream. A nested resp.clone()
+      // feeding two `ctx.waitUntil(cache.put(...))` consumers plus the client
+      // deadlocked on backpressure — the CF runtime never drained the 3-way tee,
+      // stalling the client ~30s on EVERY shard page and never completing
+      // cache.put (edge cache dead → every hit re-invoked the Worker and
+      // re-stalled). Regression from PR #1791; fixed here. These SEO shells are
+      // ~9–100 KB so buffering is trivial (Worker has 128 MB) and removes the
+      // stream — and therefore the backpressure — entirely. Reusing one
+      // ArrayBuffer across `new Response(buf, …)` is safe: the constructor copies
+      // the bytes, it doesn't detach the buffer.
+      const bodyBuf = await resp.arrayBuffer();
 
       const headers = new Headers(resp.headers);
       headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`);
-      const cacheable = new Response(resp.body, {
-        status: resp.status,
-        statusText: resp.statusText,
-        headers,
-      });
-      const toReturn = cacheable.clone();
-      ctx.waitUntil(cache.put(cacheKey, cacheable));
+      const servingInit = { status: 200, statusText: resp.statusText, headers };
+
+      ctx.waitUntil(cache.put(cacheKey, new Response(bodyBuf, servingInit)));
 
       // Refresh the long-lived fallback copy on every successful fetch.
-      const lkgHeaders = new Headers(lkgSource.headers);
+      const lkgHeaders = new Headers(resp.headers);
       lkgHeaders.set('Cache-Control', `public, max-age=${LKG_MAX_AGE}`);
       ctx.waitUntil(
         cache.put(
           lkgKey(url.toString()),
-          new Response(lkgSource.body, { status: 200, statusText: 'OK', headers: lkgHeaders }),
+          new Response(bodyBuf, { status: 200, statusText: 'OK', headers: lkgHeaders }),
         ),
       );
 
-      return toReturn;
+      return new Response(bodyBuf, servingInit);
     }
 
     return resp;


### PR DESCRIPTION
## Implementato

**HOTFIX di una regressione attiva in produzione.** Ogni pagina shard `/en /de /fr` stalla **~30 secondi** (poi serve 200). Origin GitHub Pages sano (0.23s); lo stallo è **tutto nel Worker**.

**Causa esatta (trace byte-level):** PR #1791 ha aggiunto un **terzo tee** nel blocco cache-200 — `const lkgSource = resp.clone()` sopra la coppia `cacheable`/`toReturn` — alimentando **due** consumer `ctx.waitUntil(cache.put(...))` + il client. Il runtime CF non draina il tee annidato a 3 → **deadlock backpressure**: ~2KB di head arrivano subito, poi stallo esatto di 30s a metà body, poi il resto. Inoltre `cache.put` non completa mai → **edge cache morta** → ogni richiesta è MISS + ri-stalla 30s (e brucia il budget free 100k/giorno di invocazioni, lo scopo stesso del Worker).

**Fix — buffer-once:** leggo il body **una volta** in `ArrayBuffer`, poi costruisco **3 Response indipendenti** dagli stessi byte (serving + `cacheKey` + `lkgKey`). Niente stream, niente tee, niente backpressure. Le shell SEO sono ~9–100 KB → bufferizzare è banale (Worker 128 MB), e `cache.put` ora completa → edge-cache e fallback last-known-good **funzionano davvero**. Riusare un `ArrayBuffer` su più `new Response(buf, …)` è sicuro: il costruttore copia i byte, non detacha il buffer.

`AbortController`/timeout/retry **invariati** — il timer si clappa all'arrivo degli header (~0.2s), non scatta mai sul body, non era la causa.

Al merge `deploy-worker.yml` ridepoloya → stallo eliminato + edge-cache ripristinata.

## Non implementato (ancora)

- **Test miniflare/workerd:** `infra/cloudflare-worker/` non ha test e questa è la 2ª regressione Worker. Il deadlock è **runtime-CF-specifico** (backpressure su tee + `waitUntil`): un unit test Node/vitest NON lo riproduce (undici bufferizza i clone) → darebbe falsa sicurezza. Il guard giusto è un test `miniflare`/`unstable_dev` che misura total-time + cache-HIT al 2° hit — ma miniflare non è installato (dep pesante, fuori scope di un hotfix). **Follow-up:** aggiungere miniflare + test di regressione (no-stall + 2°-hit-HIT).
- **Verifica live pre-merge:** non possibile (il Worker si deploya solo post-merge). **Test plan live sotto.** Revert-trigger: se post-deploy le pagine shard restano a 30s → revert.

## Test plan

- [x] `node --check` OK; nessun `.clone()`/tee residuo nel path cache (solo `arrayBuffer()`)
- [ ] Post-deploy: `curl -w '%{time_total}' https://frontaliereticino.ch/de/gehalt-berechnen/...` → ~0.3s (non 30s)
- [ ] Post-deploy: 2° hit back-to-back → `cf-cache-status: HIT`, age>0 (edge-cache ripristinata)
- [ ] Post-deploy: `cf-status-report.mjs --class=5` → crollo dei 504