### PR TITLE
fix(crawlers): bypass publicjobs.ch + jobup 403 with realistic browser headers / Jina-first

### DIFF
--- a/scripts/lib/gzo-wetzikon-job-parser.mjs
+++ b/scripts/lib/gzo-wetzikon-job-parser.mjs
@@ -46,6 +46,7 @@ import { createHash } from 'node:crypto';
 import { assertJsonListShape } from './assert-json-list-shape.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
 import { fetchHtml, htmlToText } from './hospital-custom-html-helpers.mjs';
+import { fetchPastaHrWidgetPage } from './pastahr-widget-client.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -53,20 +54,14 @@ export const GZO_WETZIKON_KEY = 'gzo-wetzikon';
 export const GZO_WETZIKON_COMPANY_NAME = 'GZO Spital Wetzikon';
 export const GZO_WETZIKON_COMPANY_DOMAIN = 'gzo.ch';
 
-const PASTAHR_ENDPOINT = 'https://www.publicjobs.ch/widget';
 const PASTAHR_SEARCH_HASH = 'channela19f8a4ce869a1e524b201490cb11b6e';
-const PASTAHR_REFERER = 'https://www.gzo.ch/';
+const PASTAHR_REFERER = 'https://www.gzo.ch/karriere/offene-stellen';
+const PASTAHR_ORIGIN = 'https://www.gzo.ch';
 
 const PAGE_SIZE = 50;
 const MAX_PAGES = 10;
 
 const PUBLIC_CAREER_URL = 'https://www.gzo.ch/karriere/offene-stellen';
-
-// publicjobs.ch / Cloudflare started returning 403 for our bot UA
-// (run 26479966740). Mirror the IGS Bern parser — a realistic Chrome UA
-// + the same Accept-Language / Sec-Fetch-* shape the real widget sends.
-const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
-  || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36';
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -195,8 +190,6 @@ function extractPensum(title = '') {
 
 async function fetchPastaHrPage(page = 1) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   // PastaHR widget POST contract — keys are the same the in-browser
   // `buildRequestData()` sends. Empty fields are tolerated.
@@ -208,31 +201,14 @@ async function fetchPastaHrPage(page = 1) {
   params.set('dateFormat', 'DD.MM.YYYY');
   params.set('searchQuery', '');
 
-  try {
-    const res = await fetch(PASTAHR_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/javascript, */*; q=0.01',
-        'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
-        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-        'User-Agent': USER_AGENT,
-        'X-Requested-With': 'XMLHttpRequest',
-        Referer: PASTAHR_REFERER,
-        Origin: 'https://www.gzo.ch',
-        'Sec-Fetch-Dest': 'empty',
-        'Sec-Fetch-Mode': 'cors',
-        'Sec-Fetch-Site': 'cross-site',
-      },
-      body: params.toString(),
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`HTTP ${res.status} from ${PASTAHR_ENDPOINT}`);
-    return await res.json();
-  } catch (err) {
-    clearTimeout(timer);
-    throw err;
-  }
+  // Uses the shared PastaHR client: realistic Chrome 131 headers first, with
+  // an automatic Playwright POST fallback on 403 anti-bot blocks (#1679).
+  return fetchPastaHrWidgetPage(params, {
+    referer: PASTAHR_REFERER,
+    origin: PASTAHR_ORIGIN,
+    timeoutMs,
+    attempt: page - 1,
+  });
 }
 
 /**

--- a/scripts/lib/igs-bern-job-parser.mjs
+++ b/scripts/lib/igs-bern-job-parser.mjs
@@ -32,6 +32,7 @@ import {
   detectHealthcareEmploymentType,
   detectHealthcareExperienceLevel,
 } from './hospital-custom-html-helpers.mjs';
+import { fetchPastaHrWidgetPage } from './pastahr-widget-client.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -39,17 +40,14 @@ export const IGS_BERN_KEY = 'igs-bern';
 export const IGS_BERN_COMPANY_NAME = 'Interessengemeinschaft Sozialpsychiatrie Bern';
 export const IGS_BERN_COMPANY_DOMAIN = 'igsbern.ch';
 
-const PASTAHR_ENDPOINT = 'https://www.publicjobs.ch/widget';
 const PASTAHR_KD_NR = '104465';
 const PASTAHR_REFERER = 'https://www.igsbern.ch/jobs/offene-stellen/';
+const PASTAHR_ORIGIN = 'https://www.igsbern.ch';
 
 const PAGE_SIZE = 50;
 const MAX_PAGES = 6;
 
 const PUBLIC_CAREER_URL = 'https://www.igsbern.ch/jobs/offene-stellen/';
-
-const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
-  || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36';
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -97,8 +95,6 @@ export function isTrustedDomain(rawUrl = '') {
 
 async function fetchPastaHrPage(page = 1) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   const params = new URLSearchParams();
   params.set('kdNr', PASTAHR_KD_NR);
@@ -108,31 +104,14 @@ async function fetchPastaHrPage(page = 1) {
   params.set('dateFormat', 'DD.MM.YYYY');
   params.set('searchQuery', '');
 
-  try {
-    const res = await fetch(PASTAHR_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/javascript, */*; q=0.01',
-        'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
-        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-        'User-Agent': USER_AGENT,
-        'X-Requested-With': 'XMLHttpRequest',
-        Referer: PASTAHR_REFERER,
-        Origin: 'https://www.igsbern.ch',
-        'Sec-Fetch-Dest': 'empty',
-        'Sec-Fetch-Mode': 'cors',
-        'Sec-Fetch-Site': 'cross-site',
-      },
-      body: params.toString(),
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`HTTP ${res.status} from ${PASTAHR_ENDPOINT}`);
-    return await res.json();
-  } catch (err) {
-    clearTimeout(timer);
-    throw err;
-  }
+  // Uses the shared PastaHR client: realistic Chrome 131 headers first, with
+  // an automatic Playwright POST fallback on 403 anti-bot blocks (#1783).
+  return fetchPastaHrWidgetPage(params, {
+    referer: PASTAHR_REFERER,
+    origin: PASTAHR_ORIGIN,
+    timeoutMs,
+    attempt: page - 1,
+  });
 }
 
 async function fetchAllPastaHrJobs() {

--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -34,6 +34,7 @@ import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify } from './crawler-template.mjs';
 import { fetchWithRetry } from './transient-fetch.mjs';
 import { launchChromium } from './ensure-chromium.mjs';
+import { fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import { assertJsonListShape } from './assert-json-list-shape.mjs';
 
@@ -123,6 +124,28 @@ function parseFeedBody(text) {
   return JSON.parse(jsonText);
 }
 
+/**
+ * When Jina Reader fetches a JSON endpoint, Chromium renders the response
+ * through its built-in JSON viewer: the JSON payload appears as the text
+ * content of a `<pre>` element inside an `<html>` page. Extract the raw JSON
+ * text so `parseFeedBody` can parse it — otherwise `looksLikeJsonFeedBody`
+ * correctly rejects the HTML-wrapped body as non-JSON.
+ *
+ * Returns the extracted JSON string if found, or null if the body does not
+ * look like a Jina/Chromium JSON-viewer page.
+ */
+function extractJsonFromJinaHtmlWrapper(body) {
+  const trimmed = String(body || '').trim();
+  // Fast path: already raw JSON (no HTML wrapper).
+  if (looksLikeJsonFeedBody(trimmed)) return trimmed;
+  // Chromium JSON viewer: <html>...<body><pre ...>{...}</pre></body></html>
+  const preMatch = trimmed.match(/<pre[^>]*>([\s\S]*?)<\/pre>/i);
+  if (!preMatch) return null;
+  const candidate = preMatch[1].trim();
+  if (!looksLikeJsonFeedBody(candidate)) return null;
+  return candidate;
+}
+
 const NAMED_ENTITIES = {
   amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
   agrave: 'à', acirc: 'â', auml: 'ä', aring: 'å', atilde: 'ã', aacute: 'á',
@@ -203,10 +226,29 @@ async function fetchFeed(url) {
     }, { label: `jobup ${url}` });
     return parseFeedBody(text);
   } catch (err) {
-    // Persistent anti-bot fence (403/406): retry once via a real headless
-    // browser, which jobup's WAF treats as a genuine visitor.
+    // Persistent anti-bot fence (403/406): the feed is a plain GET so we can
+    // route it through the Jina Reader proxy (clean egress IP, real browser
+    // fetch) as a cheaper intermediate step before spinning up a full headless
+    // Chromium. Jina succeeds in the common case (IP-reputation block only);
+    // Playwright is the final resort when jobup's WAF demands a full JS session
+    // (#1745). Fallback order: Jina → Playwright → re-throw original error.
     if (isAntiBotStatus(err?.status)) {
-      console.warn(`[jobup] HTTP ${err.status} from ${url} — trying Playwright anti-bot fallback`);
+      console.warn(`[jobup] HTTP ${err.status} from ${url} — trying Jina proxy fallback`);
+      const jinaRaw = await fetchHtmlViaJinaWithRetry(url, { timeoutMs: 30000 });
+      // Jina renders JSON endpoints through Chromium's JSON viewer → the JSON
+      // is wrapped in an HTML page; extract it before parsing.
+      const jinaJson = jinaRaw ? extractJsonFromJinaHtmlWrapper(jinaRaw) : null;
+      if (jinaJson) {
+        try {
+          return parseFeedBody(jinaJson);
+        } catch (parseErr) {
+          console.warn(`[jobup] Jina body did not parse as JSON: ${parseErr?.message || parseErr}`);
+        }
+      } else if (jinaRaw) {
+        console.warn(`[jobup] Jina returned a non-JSON body for ${url} — escalating to Playwright`);
+      }
+      // Jina unavailable / challenge body / parse error — escalate to Playwright.
+      console.warn(`[jobup] Trying Playwright anti-bot fallback for ${url}`);
       const body = await fetchFeedViaPlaywright(url);
       if (body) {
         try {

--- a/scripts/lib/pastahr-widget-client.mjs
+++ b/scripts/lib/pastahr-widget-client.mjs
@@ -1,0 +1,207 @@
+/**
+ * Shared PastaHR / publicjobs.ch widget client.
+ *
+ * Multiple Swiss hospitals (IGS Bern, GZO Spital Wetzikon, …) embed a
+ * PastaHR career widget that POSTs to https://www.publicjobs.ch/widget. The
+ * endpoint enforces a Cloudflare WAF that rejects requests from GitHub Actions
+ * datacenter IPs when the UA or request fingerprint looks like a bot (#1679,
+ * #1783). This module centralises the anti-bot workarounds:
+ *
+ *   1. Realistic Chrome 131 UA (within publicjobs.ch's accepted window) and
+ *      the full browser-fingerprinting header set (`Sec-CH-UA-*`, `Sec-Fetch-*`,
+ *      `Accept`, `Accept-Language`, `Referer`, `Origin`, `X-Requested-With`)
+ *      that the in-page widget JS actually sends. In the common CI case this is
+ *      enough to clear the WAF.
+ *
+ *   2. Playwright POST fallback: when the widget endpoint still returns 403
+ *      (IP-reputation block that no header tweak can fix), we replay the same
+ *      POST request through a real headless Chromium. The browser presents an
+ *      authentic TLS fingerprint + JS execution environment that the WAF accepts.
+ *      Returns null if Playwright is unavailable or the request fails; the
+ *      caller then re-throws the original error (prior data preserved).
+ *
+ * Why not Jina? Jina Reader only supports GET; a POST payload cannot be
+ * replayed through it, so the Playwright browser path is the correct
+ * last-resort for this endpoint.
+ *
+ * Exported surface:
+ *   makePastaHrBrowserHeaders(referer, origin) — build the full header set
+ *   fetchPastaHrWidgetPage(params, opts)        — fetch one page (with fallback)
+ */
+import { launchChromium } from './ensure-chromium.mjs';
+
+/* ── Browser UA pool (within the publicjobs.ch / Cloudflare accepted window) ── */
+
+export const PASTAHR_BROWSER_USER_AGENTS = [
+  // Rotate across OS/platform to reduce fingerprint correlation between runs.
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+];
+
+const PASTAHR_ENDPOINT = 'https://www.publicjobs.ch/widget';
+
+/**
+ * Build the full browser-fingerprinting header set for a publicjobs.ch
+ * widget POST. These are the headers the in-page widget JS actually sends;
+ * missing any of them increases the WAF bot-score.
+ *
+ * @param {string} referer  — the employer's career page URL (e.g. 'https://www.igsbern.ch/jobs/offene-stellen/')
+ * @param {string} origin   — the employer domain origin   (e.g. 'https://www.igsbern.ch')
+ * @param {string} [ua]     — User-Agent override; defaults to round-robin from PASTAHR_BROWSER_USER_AGENTS
+ * @param {number} [attempt] — used for UA rotation
+ */
+export function makePastaHrBrowserHeaders(referer, origin, { ua, attempt = 0 } = {}) {
+  const userAgent = ua || PASTAHR_BROWSER_USER_AGENTS[attempt % PASTAHR_BROWSER_USER_AGENTS.length];
+  return {
+    Accept: 'application/json, text/javascript, */*; q=0.01',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+    'User-Agent': userAgent,
+    // Client-hint UA headers that Cloudflare uses to validate the UA string.
+    // Without these a desktop Chrome UA paired with no sec-ch-ua raises the
+    // bot score because real Chrome always sends these.
+    'Sec-CH-UA': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+    'Sec-CH-UA-Mobile': '?0',
+    'Sec-CH-UA-Platform': '"Windows"',
+    'X-Requested-With': 'XMLHttpRequest',
+    Referer: referer,
+    Origin: origin,
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'cross-site',
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+  };
+}
+
+/**
+ * Whether an HTTP status looks like the publicjobs.ch / Cloudflare anti-bot
+ * fence. 429 is NOT here — it is routed as retryable-transient (backoff +
+ * retry), not as an anti-bot block.
+ */
+function isAntiBotStatus(status) {
+  return status === 403 || status === 401 || status === 406;
+}
+
+/**
+ * Last-resort replay of the publicjobs.ch widget POST through a real headless
+ * Chromium. The browser presents an authentic TLS fingerprint + JS execution
+ * environment that the Cloudflare WAF accepts when a plain Node fetch (even
+ * with realistic headers) is still blocked by IP-reputation rules.
+ *
+ * Uses Playwright's `page.route` + `page.evaluate` pattern: navigate to the
+ * employer's career page (establishing the correct Referer/Origin context),
+ * then replay the POST from within the page's JS execution context. This
+ * makes the request indistinguishable from the in-page widget XHR.
+ *
+ * Returns the parsed JSON response, or null if Playwright is unavailable /
+ * navigation fails / the response is not valid JSON.
+ */
+async function fetchPastaHrPageViaPlaywright(params, { referer, origin, ua, timeoutMs }) {
+  let browser;
+  try {
+    browser = await launchChromium({ headless: true });
+    const context = await browser.newContext({
+      userAgent: ua || PASTAHR_BROWSER_USER_AGENTS[0],
+      locale: 'de-CH',
+      extraHTTPHeaders: {
+        'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+        'Sec-CH-UA': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+        'Sec-CH-UA-Mobile': '?0',
+        'Sec-CH-UA-Platform': '"Windows"',
+      },
+    });
+    const page = await context.newPage();
+
+    // Navigate to the employer's career page first to establish the correct
+    // Referer/Origin context — the widget POST is an XHR from that page.
+    await page.goto(referer, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+
+    // Replay the widget POST from within the page's JS context.
+    const bodyString = params.toString();
+    const result = await page.evaluate(
+      async ({ endpoint, body }) => {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/javascript, */*; q=0.01',
+            'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body,
+        });
+        if (!res.ok) return { __error: res.status };
+        return res.json();
+      },
+      { endpoint: PASTAHR_ENDPOINT, body: bodyString },
+    );
+    if (result && result.__error) {
+      console.warn(`[pastahr-pw] Playwright POST returned HTTP ${result.__error} from ${PASTAHR_ENDPOINT}`);
+      return null;
+    }
+    return result;
+  } catch (err) {
+    console.warn(`[pastahr-pw] Playwright fallback failed: ${err?.message || err}`);
+    return null;
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Fetch one page from the publicjobs.ch widget API with full anti-bot
+ * hardening.
+ *
+ * Steps:
+ *   1. Attempt a plain Node fetch with realistic Chrome 131 headers.
+ *   2. On 403 / 401 / 406 anti-bot fence: replay via a real headless Chromium
+ *      (the browser's TLS fingerprint + JS context clears IP-reputation blocks).
+ *   3. On null from Playwright (unavailable / timed out): re-throw the original
+ *      error so the caller's safe-fail / prior-data-preserved path runs.
+ *
+ * @param {URLSearchParams} params   — POST body (caller builds the full payload)
+ * @param {Object} opts
+ * @param {string} opts.referer      — employer's career page URL
+ * @param {string} opts.origin       — employer's origin (scheme+host)
+ * @param {number} [opts.timeoutMs]  — per-attempt timeout (default 20 000 ms)
+ * @param {number} [opts.attempt]    — UA rotation index (optional)
+ * @returns {Promise<Object>}        — parsed JSON from the widget API
+ */
+export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutMs = 20000, attempt = 0 } = {}) {
+  const ua = process.env.JOBS_CRAWLER_USER_AGENT
+    || PASTAHR_BROWSER_USER_AGENTS[attempt % PASTAHR_BROWSER_USER_AGENTS.length];
+  const headers = makePastaHrBrowserHeaders(referer, origin, { ua, attempt });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let firstStatus = null;
+  try {
+    const res = await fetch(PASTAHR_ENDPOINT, {
+      method: 'POST',
+      headers,
+      body: params.toString(),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (res.ok) return await res.json();
+    firstStatus = res.status;
+    const err = new Error(`HTTP ${res.status} from ${PASTAHR_ENDPOINT}`);
+    err.status = res.status;
+    throw err;
+  } catch (err) {
+    clearTimeout(timer);
+    // Anti-bot fence (403/401/406): retry once via headless browser, which
+    // the WAF treats as a genuine visitor.
+    const status = firstStatus ?? err?.status;
+    if (isAntiBotStatus(status)) {
+      console.warn(`[pastahr] HTTP ${status} from ${PASTAHR_ENDPOINT} — trying Playwright anti-bot fallback`);
+      const result = await fetchPastaHrPageViaPlaywright(params, { referer, origin, ua, timeoutMs: 45000 });
+      if (result !== null) return result;
+      // Playwright unavailable or also blocked — re-throw original HTTP error.
+    }
+    throw err;
+  }
+}

--- a/scripts/lib/pastahr-widget-client.mjs
+++ b/scripts/lib/pastahr-widget-client.mjs
@@ -42,6 +42,19 @@ export const PASTAHR_BROWSER_USER_AGENTS = [
 const PASTAHR_ENDPOINT = 'https://www.publicjobs.ch/widget';
 
 /**
+ * Derive the `Sec-CH-UA-Platform` client-hint value from the chosen UA string.
+ * Cloudflare cross-checks the platform hint against the UA: a desktop UA that
+ * says macOS/Linux paired with a `"Windows"` hint is a *mismatched* fingerprint
+ * (worse than a missing hint) and raises the bot score — defeating the purpose
+ * of this client. Always pair the hint with the actual UA platform.
+ */
+export function platformHintForUserAgent(ua) {
+  if (/Mac OS X|Macintosh/i.test(ua)) return '"macOS"';
+  if (/Linux|X11/i.test(ua)) return '"Linux"';
+  return '"Windows"';
+}
+
+/**
  * Build the full browser-fingerprinting header set for a publicjobs.ch
  * widget POST. These are the headers the in-page widget JS actually sends;
  * missing any of them increases the WAF bot-score.
@@ -64,7 +77,7 @@ export function makePastaHrBrowserHeaders(referer, origin, { ua, attempt = 0 } =
     // bot score because real Chrome always sends these.
     'Sec-CH-UA': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
     'Sec-CH-UA-Mobile': '?0',
-    'Sec-CH-UA-Platform': '"Windows"',
+    'Sec-CH-UA-Platform': platformHintForUserAgent(userAgent),
     'X-Requested-With': 'XMLHttpRequest',
     Referer: referer,
     Origin: origin,
@@ -103,14 +116,15 @@ async function fetchPastaHrPageViaPlaywright(params, { referer, origin, ua, time
   let browser;
   try {
     browser = await launchChromium({ headless: true });
+    const playwrightUa = ua || PASTAHR_BROWSER_USER_AGENTS[0];
     const context = await browser.newContext({
-      userAgent: ua || PASTAHR_BROWSER_USER_AGENTS[0],
+      userAgent: playwrightUa,
       locale: 'de-CH',
       extraHTTPHeaders: {
         'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
         'Sec-CH-UA': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
         'Sec-CH-UA-Mobile': '?0',
-        'Sec-CH-UA-Platform': '"Windows"',
+        'Sec-CH-UA-Platform': platformHintForUserAgent(playwrightUa),
       },
     });
     const page = await context.newPage();


### PR DESCRIPTION
## Implementato

- **`scripts/lib/pastahr-widget-client.mjs`** (new): Shared PastaHR / publicjobs.ch widget client extracted from per-crawler copies. Sends Chrome 131 UA + full client-hint headers (`Sec-CH-UA`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform`, `Cache-Control`, `Pragma`) that the in-page widget XHR actually sends — Cloudflare raises the bot score when these are missing. On 403 anti-bot block, falls back to Playwright: navigates to the employer career page (establishes Referer/Origin context), then replays the POST from within the page's JS context, which the WAF accepts as a genuine browser XHR. Jina cannot proxy POST requests, so Playwright is the correct last resort here.
- **`Sec-CH-UA-Platform` now derived from the chosen UA** (`platformHintForUserAgent()` helper): the UA pool rotates Windows/macOS/Linux by `attempt%3`, but the platform client-hint was hardcoded `"Windows"`. On `attempt>=1` (page>=2) the UA said macOS/Linux while the hint said Windows — a self-contradictory fingerprint Cloudflare scores worse than a missing hint, defeating the anti-bot purpose and silently truncating pagination for the largest employers. Both the direct-fetch header builder (was L67) and the Playwright `extraHTTPHeaders` (was L113) now compute the hint from the actual UA. (review 🔴)
- **`scripts/lib/igs-bern-job-parser.mjs`**: Removed inline `fetchPastaHrPage` implementation; delegates to `fetchPastaHrWidgetPage` from the new shared client. Fixes #1783.
- **`scripts/lib/gzo-wetzikon-job-parser.mjs`**: Same refactor — removed inline POST fetch + old Chrome/121 UA; delegates to the shared client. Fixes #1679.
- **`scripts/lib/jobup-ch-feed-common.mjs`**: Added Jina Reader proxy as intermediate fallback before Playwright on 403 (`fetchHtmlViaJinaWithRetry` import). Added `extractJsonFromJinaHtmlWrapper` to recover raw JSON from Jina's Chromium JSON-viewer HTML wrapper (Jina renders `application/json` through its built-in viewer → body is `<html>...<pre>{...}</pre>`). Fallback order: browser UA rotation → Jina (clean IP, no Playwright overhead) → Playwright (full JS session). Fixes #1745.
- **Sibling sweep**: all `publicjobs.ch` POST widget consumers in the codebase are IGS Bern and GZO Wetzikon — both fixed. Other `XMLHttpRequest` header users hit different endpoints (not publicjobs.ch). `Sec-CH-UA-Platform` hardcode swept across the whole repo: only the two occurrences in `pastahr-widget-client.mjs` existed; both fixed via the shared helper.

## Non implementato (ancora)

- Jina proxy for publicjobs.ch POST: Jina only proxies GET requests; Playwright is the correct last resort for POST endpoints. No alternative available.
- Claim "Playwright fallback verified in CI": the Playwright path activates only when the direct fetch 403s, which requires GitHub Actions IPs to be blocked. Verified locally that the direct fetch succeeds with the new Chrome 131 headers + client-hints (returns 2 IGS Bern jobs, 10 GZO jobs). The Playwright path is structurally correct but cannot be triggered from a residential IP.
- Other jobup.ch mask consumers (`ehnv`, `hpe`, `institution-lavigny`, `rsbj`, `clinique-cic`, `fondation-domus`): all use `jobup-ch-feed-common.mjs` → receive the Jina+Playwright improvement automatically. No per-file changes needed.

Closes #1783
Closes #1679
Closes #1745
