### PR TITLE
ci(worker): timing+origin regression check & auto-rollback in deploy-worker.yml

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -83,12 +83,62 @@ jobs:
           workingDirectory: infra/cloudflare-worker
           command: deploy
 
-      # Smoke-check the three locale roots through the public apex. Informative
-      # only (|| true): a transient non-200 here must not red the deploy job —
-      # the Worker itself already deployed in the step above.
-      - name: Smoke-check locale roots
+      # Live regression check: status AND timing. The previous 30s tee-deadlock
+      # (introduced in #1791, fixed in #1814) returned HTTP 200 but stalled
+      # ~30s, so a status-only smoke missed it entirely and it sat live ~1 day.
+      # Here each locale root is cache-busted (forcing a MISS so the
+      # cache-population path that deadlocked is exercised), timed, and compared
+      # to the DIRECT origin time. apex-via-Worker slow + origin fast = a Worker
+      # regression (the exact discriminator from the #1814 diagnosis) →
+      # auto-rollback. Both slow = an origin problem, not the Worker → warn only.
+      - name: Live regression check (status + timing)
+        id: regression
+        env:
+          STALL_THRESHOLD_S: '10'  # healthy ~0.3s; the deadlock was a constant ~30s
+          ORIGIN_FAST_S: '4'       # the gray-cloud shard origin normally answers in ~0.2s
         run: |
+          set -uo pipefail
+          regression=0
           for loc in en de fr; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "https://frontaliereticino.ch/$loc/" || echo "ERR")
-            echo "/$loc/ -> $code"
-          done || true
+            apex="https://frontaliereticino.ch/$loc/"
+            origin="https://origin-$loc.frontaliereticino.ch/$loc/"
+            # Two cache-busted apex attempts → take the FASTER, so a one-off cold
+            # fetch is ignored; a real deadlock is constant across both.
+            best=99; code=000
+            for n in 1 2; do
+              out=$(curl -s -o /dev/null -w '%{time_total} %{http_code}' --max-time 35 "${apex}?dwcheck=${RANDOM}${n}" || echo "99 000")
+              t=$(printf '%s' "$out" | awk '{print $1}')
+              code=$(printf '%s' "$out" | awk '{print $2}')
+              if awk "BEGIN{exit !($t < $best)}"; then best=$t; fi
+            done
+            otime=$(curl -s -o /dev/null -w '%{time_total}' --max-time 35 "$origin" || echo "99")
+            echo "/$loc/ apex=${best}s (http $code) | origin=${otime}s"
+            [ "$code" != "200" ] && echo "::warning::/$loc/ returned HTTP $code"
+            apex_slow=$(awk "BEGIN{print ($best > $STALL_THRESHOLD_S)?1:0}")
+            origin_fast=$(awk "BEGIN{print ($otime < $ORIGIN_FAST_S)?1:0}")
+            if [ "$apex_slow" = "1" ] && [ "$origin_fast" = "1" ]; then
+              echo "::error::/$loc/ via Worker ${best}s but origin ${otime}s — WORKER STALL REGRESSION"
+              regression=1
+            elif [ "$apex_slow" = "1" ]; then
+              echo "::warning::/$loc/ slow (${best}s) AND origin slow (${otime}s) — origin issue, not the Worker"
+            fi
+          done
+          echo "regression=$regression" >> "$GITHUB_OUTPUT"
+
+      # Auto-recover: roll the Worker back to the previous (good) deployment the
+      # moment a stall regression is detected, so prod doesn't sit broken waiting
+      # for a human. Only fires on the apex-slow + origin-fast verdict above.
+      - name: Auto-rollback Worker on stall regression
+        if: steps.regression.outputs.regression == '1'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ env.CF_API_TOKEN }}
+          accountId: ${{ env.CF_ACCOUNT_ID }}
+          workingDirectory: infra/cloudflare-worker
+          command: 'rollback --message "auto-rollback - deploy regression check detected a shard stall"'
+
+      - name: Fail the job on regression
+        if: steps.regression.outputs.regression == '1'
+        run: |
+          echo "::error::Worker rolled back — a shard stall regression was detected post-deploy. Investigate the diff before redeploying."
+          exit 1


### PR DESCRIPTION
## Implementato

Richiesto: quando deployamo il Worker, fare anche un **check live che le pagine non introducano regressioni** come il caso #1791 (stallo 30s).

Il tee-deadlock #1791→#1814 è rimasto live **~1 giorno** perché lo smoke-check del deploy controllava **solo lo status HTTP** — le pagine shard stallate rispondevano **200** (dopo ~30s), quindi un check status-only passava. Sostituito con un check che becca esattamente quella classe:

- **Cache-bust** di ogni root `/en /de /fr` (forza un MISS → esercita il path di popolamento cache che andava in deadlock), **timing** (best di 2 per ignorare un cold one-off), e **confronto col tempo dell'origin diretto** (`origin-{loc}.frontaliereticino.ch`).
- **apex lento (>10s) + origin veloce (<4s) = regressione del Worker** (il discriminatore esatto della diagnosi #1814) → **auto `wrangler rollback`** al deployment precedente buono + job rosso. **Entrambi lenti = problema origin**, non il Worker → solo warning, niente rollback (così un outage origin non scatena un rollback inutile).

Soglie: `STALL_THRESHOLD_S=10` (sano ~0.3s, deadlock ~30s), `ORIGIN_FAST_S=4` (origin shard ~0.2s).

**Testato in dry-run live** (post-#1814): apex 0.13–0.40s, origin ~0.35s, verdict **0 (sano)** — il check passa un deploy buono e conferma che lo stallo è sparito.

## Non implementato (ancora)

- **Test miniflare del Worker** (regressione a monte, pre-deploy): resta il follow-up dichiarato in #1814 — questo è il guard a valle (post-deploy, live). I due sono complementari: miniflare becca in CI sulla PR, questo becca sul deploy live.
- **Verifica del comportamento `wrangler rollback` in CI**: non eseguibile in dry-run (richiede un deploy reale + un secondo deployment a cui tornare). In CI non-TTY non dovrebbe promptare; se mai si bloccasse, il job timeout (30min) lo rende rosso. **Revert-trigger:** se un rollback automatico fallisce/blocca → rimuovere lo step auto-rollback e tenere solo il fail+alert.
- **Deep pages**: il check usa i 3 root locale (il deadlock colpiva l'intero shell-path, root inclusi). Estendere a una pagina profonda per locale è un possibile hardening successivo.

## Test plan

- [x] YAML lint OK
- [x] logica bash dry-run live: verdict 0 su deploy sano (apex/origin entrambi ~0.3s)
- [ ] Post-merge: prossimo deploy del Worker → step "Live regression check" verde
- [ ] (se mai regredisce) auto-rollback scatta e il job diventa rosso