### PR TITLE
chore(seo): trailing-slash rule in AGENTS + fix non-canonical link literals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ CI test gate: `npm ci`, `node scripts/assemble-jobs-dataset.mjs --stats`, `node 
 - React 19 + TypeScript + Vite + Tailwind.
 - No React Router. Routing hand-rolled in `services/router.ts`; `App.tsx` owns navigation state.
 - Canonical prod domain: `https://frontaliereticino.ch` (no `www`).
+- **Trailing slash obbligatorio su OGNI nuovo link/route/URL.** Convenzione canonica del sito: `buildPath()` (`finish()` in `services/router.ts`) e `joinPath()` (`build-plugins/weeklyEmployersData.ts`) lo forzano già; canonical/sitemap/og:url lo usano; CF Worker + GitHub Pages 301-redirectano no-slash→slash. Mai hardcodare URL senza slash finale (es. in email/CF/script/`trackPageView`) — preferisci `buildPath({activeTab:...}, locale)` invece di stringhe a mano (slash by-construction). Un href/URL letterale senza slash = doppione non-canonico (301 in più). Pre-PR: grep dei nuovi `href=`/URL string nel diff → verifica lo slash.
 - Primary locale Italian; EN/DE/FR via chunked locale files in `services/locales/`.
 - Nav caps: 6 top-level tabs, 8 sub-tabs/category.
 

--- a/components/pages/ForEmployersPage.tsx
+++ b/components/pages/ForEmployersPage.tsx
@@ -69,7 +69,7 @@ const ForEmployersPage: React.FC = () => {
  const contactPath = buildPath({ activeTab: 'contact' }, locale);
 
  useEffect(() => {
- Analytics.trackPageView('/per-le-aziende', 'For Employers Landing');
+ Analytics.trackPageView('/per-le-aziende/', 'For Employers Landing');
  Analytics.trackUIInteraction('publisher', 'page', 'for_employers', 'view');
  }, []);
 

--- a/components/pages/PublisherDashboardPage.tsx
+++ b/components/pages/PublisherDashboardPage.tsx
@@ -66,7 +66,7 @@ const PublisherDashboardPage: React.FC = () => {
   const [archivingId, setArchivingId] = useState<string | null>(null);
 
   useEffect(() => {
-    Analytics.trackPageView('/i-miei-annunci', 'Publisher Dashboard');
+    Analytics.trackPageView('/i-miei-annunci/', 'Publisher Dashboard');
   }, []);
 
   const handleManageBilling = async () => {

--- a/components/pages/PublisherPublishPage.tsx
+++ b/components/pages/PublisherPublishPage.tsx
@@ -352,7 +352,7 @@ const PublisherPublishPage: React.FC = () => {
  };
 
  useEffect(() => {
- Analytics.trackPageView('/pubblica-offerta', 'Publisher Publish Page');
+ Analytics.trackPageView('/pubblica-offerta/', 'Publisher Publish Page');
  Analytics.trackUIInteraction('publisher', 'page', 'publish_page', 'view');
  }, []);
 

--- a/functions/src/stripePublisherCore.js
+++ b/functions/src/stripePublisherCore.js
@@ -273,7 +273,7 @@ async function sendPublisherConfirmation(publisherUid, jobCount) {
         `<h2>Grazie, pagamento confermato</h2>` +
         `<p>${jobCount > 1 ? 'I tuoi annunci saranno online' : 'Il tuo annuncio sarà online'} entro 1–2 ore con pagina SEO dedicata.</p>` +
         `<p>Gestisci gli annunci e vedi le candidature dalla tua dashboard: ` +
-        `<a href="https://frontaliereticino.ch/i-miei-annunci">I miei annunci</a>.</p>` +
+        `<a href="https://frontaliereticino.ch/i-miei-annunci/">I miei annunci</a>.</p>` +
         `<p style="font-size:12px;color:#666">La ricevuta/fattura ti arriva separatamente da Stripe. Abbonamento rinnovato ogni 30 giorni; disdici quando vuoi dalla dashboard.</p>`,
     });
   } catch {


### PR DESCRIPTION
## Implementato

- **Regola in `AGENTS.md`** (richiesta owner): ogni nuovo link/route/URL deve terminare con lo slash finale (convenzione canonica del sito); preferire `buildPath()` alle stringhe a mano; vale anche per `trackPageView`. Documentato il perché (finish()/joinPath lo forzano, CF Worker + Pages 301-redirectano no-slash→slash) e il check pre-PR.
- **Fix dei literal non-canonici** che la violavano:
  - Email di conferma publisher: href `https://frontaliereticino.ch/i-miei-annunci` → `…/i-miei-annunci/` (il path nudo faceva 301 attraverso il redirect di click-tracking).
  - `Analytics.trackPageView` di dashboard publisher (`/i-miei-annunci/`), pagina pubblica-offerta (`/pubblica-offerta/`) e landing for-employers (`/per-le-aziende/`) → slash finale, così gli eventi analytics non si splittano tra due varianti mentre i canonical già usano lo slash.

## Non implementato (ancora)

- **Soft-404 delle pagine SPA `/pubblica-offerta/`, `/per-le-aziende/`, `/i-miei-annunci/`** (ritornano HTTP 404 perché GitHub Pages serve la 404.html=shell SPA; mancano gli stub statici a 200, a differenza di `/profilo/`). Richiesto dall'owner ("stub statici per tutte e tre") ma è un follow-up più ampio e a rischio (richiede individuare l'esatto emettitore dello stub `/profilo/` nel grafo dei build-plugin e generare stub locale-aware con SEO meta + `noindex` per la dashboard, senza rompere la build SSG OOM-prone né il gate SEO). Scopato come follow-up dedicato per non spedire un emit SSG affrettato.
- **Sibling sweep**: lo sweep dei `trackPageView` senza slash è limitato alle 3 pagine publisher/employer nuove (le altre pagine usano già `buildPath`/path canonici); nessun altro literal funnel-critical trovato nel diff-class.

## Test plan

- [x] `node --check` sul file functions modificato → OK.
- [x] Cambi puramente di stringa (slash) + doc; nessun impatto logico.
- [ ] Post-merge: deploy CF (email href) + verifica che il link email atterri direttamente su `/i-miei-annunci/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)