### PR TITLE
fix(publisher): titleByLocale + slugByLocale for publisher ads (main-red: job-locale-completeness)

### DIFF
--- a/data/jobs/by-crawler/publisher-submitted.json
+++ b/data/jobs/by-crawler/publisher-submitted.json
@@ -50,6 +50,18 @@
           "maxValue": 50000,
           "unitText": "YEAR"
         }
+      },
+      "titleByLocale": {
+        "it": "Prompt engineer da remoto",
+        "en": "Prompt engineer da remoto",
+        "de": "Prompt engineer da remoto",
+        "fr": "Prompt engineer da remoto"
+      },
+      "slugByLocale": {
+        "it": "prompt-engineer-da-remoto-thun-frontaliere-ticino",
+        "en": "prompt-engineer-da-remoto-thun-frontaliere-ticino",
+        "de": "prompt-engineer-da-remoto-thun-frontaliere-ticino",
+        "fr": "prompt-engineer-da-remoto-thun-frontaliere-ticino"
       }
     },
     {
@@ -100,6 +112,18 @@
           "maxValue": 50000,
           "unitText": "YEAR"
         }
+      },
+      "titleByLocale": {
+        "it": "Prompt engineer da remoto",
+        "en": "Prompt engineer da remoto",
+        "de": "Prompt engineer da remoto",
+        "fr": "Prompt engineer da remoto"
+      },
+      "slugByLocale": {
+        "it": "prompt-engineer-da-remoto-remoto-frontaliere-ticino",
+        "en": "prompt-engineer-da-remoto-remoto-frontaliere-ticino",
+        "de": "prompt-engineer-da-remoto-remoto-frontaliere-ticino",
+        "fr": "prompt-engineer-da-remoto-remoto-frontaliere-ticino"
       }
     }
   ]

--- a/scripts/lib/publisherJobProjection.mjs
+++ b/scripts/lib/publisherJobProjection.mjs
@@ -111,6 +111,23 @@ export function publisherJobToRecords(pubJob, opts = {}) {
     descriptionByLocale.it = pubJob.description;
   }
 
+  // Same gap for titleByLocale (+ slugByLocale, built per-location below):
+  // publisher ads store only a flat `title`/`slug`, so once the ad is in the
+  // dataset `tests/job-locale-completeness` ("no job has a completely empty
+  // titleByLocale/slugByLocale object") fails. Populate every locale (source
+  // title; the /lavoro slug is locale-agnostic), merged with any real
+  // translations. en/de/fr defaulting to the IT title trips assemble's
+  // cross-locale-duplicate guard → needsRetranslation, so the "all-4-locales"
+  // gates skip the ad until translate-pending fills real translations.
+  const LOCALE_KEYS = ['it', 'en', 'de', 'fr'];
+  const flatTitle = String(pubJob.title || '').trim();
+  const titleByLocale = { ...(pubJob.titleByLocale || {}) };
+  if (flatTitle) {
+    for (const lk of LOCALE_KEYS) {
+      if (!String(titleByLocale[lk] || '').trim()) titleByLocale[lk] = pubJob.title;
+    }
+  }
+
   const company = pubJob.company || {};
   const companyName = String(company.name || '').trim();
   const companyKey = company.companyKey || slugifyPublisher(companyName);
@@ -141,6 +158,12 @@ export function publisherJobToRecords(pubJob, opts = {}) {
     const id = `pub-${pubJob.id}-${slugifyPublisher(locationLabel)}`;
     const url = `${SITE_ORIGIN}/lavoro/${baseSlug}`;
     const applyUrl = apply.mode === 'external_url' && apply.url ? apply.url : url;
+    // The /lavoro/<slug> path is locale-agnostic → the same slug in every
+    // locale (merged with any real per-locale slug already present).
+    const slugByLocale = { ...(pubJob.slugByLocale || {}) };
+    for (const lk of LOCALE_KEYS) {
+      if (!String(slugByLocale[lk] || '').trim()) slugByLocale[lk] = baseSlug;
+    }
 
     return {
       title: pubJob.title,
@@ -167,7 +190,8 @@ export function publisherJobToRecords(pubJob, opts = {}) {
       contractType: pubJob.contractType || null,
       validThrough: validThroughIso,
       description: pubJob.description || '',
-      titleByLocale: pubJob.titleByLocale || undefined,
+      titleByLocale: Object.keys(titleByLocale).length ? titleByLocale : undefined,
+      slugByLocale: Object.keys(slugByLocale).length ? slugByLocale : undefined,
       descriptionByLocale: Object.keys(descriptionByLocale).length ? descriptionByLocale : undefined,
       id,
       salaryMin: pubJob.salaryMin ?? null,

--- a/tests/publisher-job-projection.test.ts
+++ b/tests/publisher-job-projection.test.ts
@@ -69,6 +69,29 @@ describe('publisherJobToRecords', () => {
     expect(r.descriptionByLocale.it).toBe(existing);
   });
 
+  it('populates titleByLocale + slugByLocale for all 4 locales (job-locale-completeness gate)', () => {
+    const [r] = publisherJobToRecords(paidJob(), { nowIso: NOW });
+    expect(r.titleByLocale).toBeDefined();
+    expect(r.slugByLocale).toBeDefined();
+    for (const lk of ['it', 'en', 'de', 'fr']) {
+      expect(String(r.titleByLocale[lk] || '').length).toBeGreaterThan(0);
+      expect(String(r.slugByLocale[lk] || '').length).toBeGreaterThan(0);
+    }
+    // The /lavoro/<slug> path is locale-agnostic → same slug across locales.
+    expect(r.slugByLocale.en).toBe(r.slug);
+    expect(r.titleByLocale.it).toBe('Fisioterapista diplomato/a');
+  });
+
+  it('preserves a real per-locale title/slug instead of overwriting with the source', () => {
+    const [r] = publisherJobToRecords(
+      paidJob({ titleByLocale: { en: 'Certified physiotherapist' }, slugByLocale: { en: 'certified-physiotherapist-lugano' } }),
+      { nowIso: NOW },
+    );
+    expect(r.titleByLocale.en).toBe('Certified physiotherapist');
+    expect(r.slugByLocale.en).toBe('certified-physiotherapist-lugano');
+    expect(String(r.titleByLocale.de || '').length).toBeGreaterThan(0); // still backfilled from source
+  });
+
   it('produces stable deterministic ids per (job, location)', () => {
     const a = publisherJobToRecords(paidJob(), { nowIso: NOW });
     const b = publisherJobToRecords(paidJob(), { nowIso: NOW });


### PR DESCRIPTION
## Implementato

**main era rosso** (`tests` su main = failure dalle 08:06): appena l'annuncio pagato è entrato nel dataset (via #1811 + il `publisher-jobs-sync`), ha fatto fallire `tests/job-locale-completeness` → *"no job has a completely empty titleByLocale / slugByLocale object"*. Gli annunci publisher salvano solo `title`/`slug` piatti, quindi la projection emetteva `titleByLocale:undefined` e nessun `slugByLocale`.

- **Fix projection** (`scripts/lib/publisherJobProjection.mjs`, stessa classe del `descriptionByLocale` di #1811): `publisherJobToRecords` ora popola `titleByLocale` per tutti e 4 i locali dal titolo sorgente (merge con eventuali traduzioni reali) e `slugByLocale` per tutti e 4 dallo slug `/lavoro` (locale-agnostico). en/de/fr che defaultano al titolo IT fanno scattare il guard cross-locale-duplicate di assemble → `needsRetranslation`, quindi i gate "all-4-locales" skippano l'annuncio finché translate-pending non mette le traduzioni reali; i gate "empty-object" passano perché gli oggetti ora esistono.
- **Bridge dati**: ho patchato a mano il `publisher-submitted.json` già committato (i 2 record live) con gli stessi campi, così il dataset assemblato è valido **ora**, prima che il prossimo sync rigeneri lo slice con la projection fixata. (Non posso rigenerare lo slice in locale: `build-publisher-jobs` richiede Firestore.)
- **Test**: assertano titleByLocale/slugByLocale popolati per i 4 locali + che un valore per-locale reale venga preservato.

**Validato in locale**: `node scripts/assemble-jobs-dataset.mjs --stats` + `vitest run tests/job-locale-completeness.test.ts` → **6/6 verde** (prima 2 falliti).

## Non implementato (ancora)

- **Terzo fallimento `embeddingStoreBinary.test.ts`** (`expected 'object' to be 'string'`): **flaky** (fallisce ~1 run su 2, non correlato ai publisher) → non in scope qui; passa al retry. Se diventasse consistente va trattato a parte.
- **Sibling sweep**: il gap è specifico della projection publisher (unico slice che salva title/slug piatti senza i byLocale); i crawler li popolano già. Nessun sibling.

## Test plan

- [x] `assemble-jobs-dataset --stats` + `job-locale-completeness` → 6/6.
- [x] `publisher-job-projection` → 30/30 (incl. nuovi test title/slug byLocale).
- [ ] Post-merge: `main` torna verde; al prossimo `publisher-jobs-sync` lo slice viene rigenerato dalla projection fixata (campi identici al bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)