### PR TITLE
hardening(ci): auto-merge-eval skips DIRTY PRs with a clean message (no doomed merge attempt)

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -153,6 +153,16 @@ function main() {
   }
   if (pr.state !== 'OPEN') return fail(`PR #${PR} stato=${pr.state} (non OPEN) — skip.`);
   if (pr.isDraft) return fail(`PR #${PR} è draft — skip.`);
+  // Conflict gate: una PR DIRTY (merge-conflict — tipicamente una sibling che ha
+  // toccato lo stesso file dopo il branch) NON è mergiabile; `gh pr merge`
+  // fallirebbe comunque a fine valutazione. Skip esplicito (exit 0) con messaggio
+  // chiaro, invece di tentare il merge e produrre un run rosso rumoroso: la
+  // risoluzione è manuale (pr-autorebase ha già abortito + etichettato
+  // `stale-review`). Solo 'DIRTY' = conflitto certo; BEHIND/UNKNOWN/UNSTABLE
+  // proseguono ai gate normali (GitHub fa 3-way merge se non c'è conflitto).
+  if (pr.mergeStateStatus === 'DIRTY') {
+    return fail(`PR #${PR} mergeStateStatus=DIRTY (conflitto con main/sibling) — skip; va risolta a mano (vedi label stale-review), nessun tentativo di merge.`);
+  }
   const head = pr.headRefOid;
   const labels = (pr.labels || []).map((l) => l.name);
   console.log(`HEAD SHA: ${head} · labels: [${labels.join(', ') || '—'}]`);


### PR DESCRIPTION
## Implementato

Verifica richiesta: il sistema auto-merge/autorebase è **già sicuro** contro il revert silenzioso di una PR sibling — l'autorebase fa `git merge` + **abort-on-conflict** + label `stale-review` (mai `-X ours`), e `gh pr merge --squash` **rifiuta** una PR `DIRTY` (GitHub fa 3-way merge per i `BEHIND` senza conflitto → niente revert). Nessun bug.

Unica ruvidità: una PR `DIRTY` con `## LGTM` stale + vitest verde arrivava comunque al `gh pr merge --squash` finale, che **falliva** → workflow-run rosso rumoroso invece di uno skip pulito.

- **`scripts/ci/auto-merge-eval.mjs`**: aggiunto un gate esplicito subito dopo i check OPEN/draft — se `mergeStateStatus === 'DIRTY'` (conflitto, tipicamente una sibling che ha toccato lo stesso file dopo il branch) → `skip` (exit 0) con messaggio chiaro che punta alla risoluzione manuale (label `stale-review` già messa da `pr-autorebase`). **Solo `DIRTY`** è gated; `BEHIND`/`UNKNOWN`/`UNSTABLE` proseguono ai gate normali (GitHub fa 3-way merge pulito senza conflitto). Nessun cambio di comportamento per le PR mergiabili.

## Non implementato (ancora)

- **Test unit del gate**: `main()` non è unit-testabile senza mockare `gh`/`process.exit` (è CLI-guarded); gli altri gate (OPEN/draft/LGTM/vitest) sono anch'essi non-unit-testati — coerente non aggiungerne uno solo per questo. Il gate è una guardia banale (`=== 'DIRTY'`).
- **Risoluzione automatica del conflitto sibling**: fuori scope (richiederebbe un merge-resolver Claude-powered → costo quota; la scelta frugale è segnalare + risoluzione manuale).
- **File**: è uno *script* (`auto-merge-eval.mjs`), non un `.yml` di workflow → niente vincolo di workflow-validation byte-identica; reviewer + auto-merge normali.

## Test plan

- [x] `node --check scripts/ci/auto-merge-eval.mjs` → OK.
- [x] `vitest run tests/auto-merge-eval-fingerprint.test.ts` → 6/6 (helper invariato).
- [ ] Post-merge: alla prossima PR che va `DIRTY` per una sibling, l'auto-merge-eval logga lo skip "mergeStateStatus=DIRTY" invece di un run rosso da `gh pr merge` fallito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)