### PR TITLE
fix(job-alerts): strip Pensum/gender markers + balance brackets in alert subject

### DIFF
--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -445,6 +445,15 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
     // If a sensible word boundary exists past 50% of the slot, cut there;
     // otherwise hard-cut to avoid producing a 2-character title.
     let cut = lastSpace > Math.floor(max * 0.5) ? slot.slice(0, lastSpace) : slot;
+    // Balance brackets: if the cut left an unmatched "(" / "[" \u2014 e.g. truncating
+    // inside a "(100%)" or "(m/w/d)" suffix produced "\u2026 Portafogli (100%" \u2014 drop
+    // the dangling fragment so the subject never emits an unbalanced "(100%\u2026".
+    const opens = (cut.match(/[([]/g) || []).length;
+    const closes = (cut.match(/[)\]]/g) || []).length;
+    if (opens > closes) {
+      const lastOpen = Math.max(cut.lastIndexOf('('), cut.lastIndexOf('['));
+      if (lastOpen > Math.floor(max * 0.4)) cut = cut.slice(0, lastOpen);
+    }
     // Drop trailing punctuation (commas, semicolons, dashes, periods, en/em dashes).
     cut = cut.replace(/[\s,;:.\-\u2013\u2014]+$/, '');
     return cut + '\u2026';
@@ -461,12 +470,30 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
     }
     return t || raw;
   };
+  // Strip Swiss workload (Pensum) and gender markers from a title for the SUBJECT
+  // line ONLY — "(100%)", "(80-100%)", "(m/w/d)", "(w/m)" carry no value in a
+  // space-constrained subject and used to overflow it and get truncated mid-token
+  // into a dangling "(100%…" (reported live). Job CARDS keep these (more room; the
+  // workload % is genuinely useful there).
+  const stripTitleNoise = (raw) => {
+    const original = String(raw || '').trim();
+    let t = original
+      // Workload: (100%), (80 %), (80-100%), (ca. 60–100 %).
+      .replace(/\s*\(\s*(?:ca\.?\s*)?\d{1,3}\s*(?:[–—-]\s*\d{1,3}\s*)?%\s*\)/gi, '')
+      // Gender markers: (m/w/d) (w/m) (f/h) (h/f) (m/f/d) (m/w/x) — slash/dash sep.
+      .replace(/\s*\(\s*[mwfdhx](?:\s*[/\-]\s*[mwfdhx])+\s*\)/gi, '')
+      // Collapse leftover double spaces and any dangling trailing separator.
+      .replace(/\s{2,}/g, ' ')
+      .replace(/\s*[-–—|·,]\s*$/, '')
+      .trim();
+    return t || original;
+  };
   let subject;
   if (matchedJobs.length === 0) {
     subject = `${s.subjectNew(matchedJobs.length)} ${s.subjectFor}: ${subjectLabel}`;
   } else {
     const topJob = matchedJobs[0];
-    const topTitle = cleanTitle(topJob.titleByLocale?.[locale] || topJob.titleByLocale?.it || topJob.title || s.fallbackTitle);
+    const topTitle = stripTitleNoise(cleanTitle(topJob.titleByLocale?.[locale] || topJob.titleByLocale?.it || topJob.title || s.fallbackTitle));
     const topCompany = (topJob.company || '').trim();
     const extra = matchedJobs.length - 1;
     const bell = '\ud83d\udd14';

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -248,6 +248,51 @@ describe('job alert email — subject truncation polish', () => {
   });
 });
 
+describe('job alert email — subject title noise (Pensum / gender markers)', () => {
+  // Live regression: "🔔 Senior Technical Product Manager - Portafogli (100%… (+48 altre offerte)"
+  // — the "(100%)" Pensum overflowed the cap and was truncated mid-token, leaving
+  // a dangling unbalanced "(100%…". The subject must drop the Pensum entirely.
+  it('strips a trailing workload "(100%)" from the subject title (no dangling paren)', () => {
+    const job = { ...fixtureJob(), title: 'Senior Technical Product Manager - Portafogli (100%)', company: 'Helvetia' };
+    const jobs = [job, ...Array.from({ length: 48 }, () => fixtureJob({ title: 'Filler' }))];
+    const result = buildAlertEmail(fixtureAlert('it'), jobs, true);
+    expect(result.subject.length).toBeLessThanOrEqual(78);
+    expect(result.subject).not.toContain('100%');
+    expect(result.subject).not.toContain('(100%');
+    // No unbalanced "(" left anywhere in the subject.
+    expect((result.subject.match(/\(/g) || []).length).toBe((result.subject.match(/\)/g) || []).length);
+    expect(result.subject).toContain('Senior Technical Product Manager - Portafogli');
+    expect(result.subject).toContain('(+48 altre offerte)');
+  });
+
+  it('strips range Pensum "(80-100%)" and gender markers "(m/w/d)"', () => {
+    const a = buildAlertEmail(fixtureAlert('de'), [{ ...fixtureJob(), title: 'Pflegefachfrau HF (80-100%)' }], true);
+    expect(a.subject).not.toContain('%');
+    expect(a.subject).toContain('Pflegefachfrau HF');
+    const b = buildAlertEmail(fixtureAlert('de'), [{ ...fixtureJob(), title: 'Projektleiter (m/w/d)' }], true);
+    expect(b.subject).not.toMatch(/\(m\/w\/d\)/i);
+    expect(b.subject).toContain('Projektleiter');
+  });
+
+  it('truncateAtWord never leaves an unbalanced bracket even without Pensum stripping', () => {
+    // A long parenthetical that is NOT a Pensum/gender marker (so stripTitleNoise
+    // leaves it) must still not be cut mid-paren into a dangling "(".
+    const job = {
+      ...fixtureJob(),
+      title: 'Responsabile Vendite Area Nord (Lombardia, Piemonte e Valle d Aosta region)',
+      company: 'Distribuzione SA',
+    };
+    const result = buildAlertEmail(fixtureAlert('it'), [job, fixtureJob()], true);
+    expect(result.subject.length).toBeLessThanOrEqual(78);
+    expect((result.subject.match(/\(/g) || []).length).toBe((result.subject.match(/\)/g) || []).length);
+  });
+
+  it('leaves a clean title untouched (no false positives)', () => {
+    const result = buildAlertEmail(fixtureAlert('it'), [{ ...fixtureJob(), title: 'Data Analyst', company: 'Tiny Co' }], true);
+    expect(result.subject).toBe('🔔 Data Analyst presso Tiny Co');
+  });
+});
+
 describe('job alert email — UTM hygiene', () => {
   it('utm_medium is "email" (not "job_alert" duplicating utm_source)', () => {
     const result = buildAlertEmail(fixtureAlert('it'), [fixtureJob()], true);


### PR DESCRIPTION
## Implementato

Segnalazione live: una job-alert è arrivata col subject
`🔔 Senior Technical Product Manager - Portafogli (100%… (+48 altre offerte)` — il suffisso pensum `(100%)` ha sforato il cap di 78 char ed è stato troncato **dentro la parentesi**, lasciando un `(100%…` sbilanciato.

Euristica del titolo migliorata, **solo per il subject** (le card email restano invariate: hanno spazio e la `%` di pensum lì è utile):
- **`stripTitleNoise()`**: rimuove dal titolo-lead i marker pensum svizzeri (`(100%)`, `(80-100%)`, `(ca. 60–100%)`) e di genere (`(m/w/d)`, `(w/m)`, `(h/f)`). Non aggiungono valore in un subject a spazio limitato ed erano la causa dell'overflow. Normalizza anche doppi spazi/separatori pendenti residui.
- **`truncateAtWord()`**: bilanciamento parentesi — se un taglio lascia una `(`/`[` non chiusa, scarta il frammento pendente → il subject non emette mai `(100%…` per **qualsiasi** parentetica, non solo il pensum.

Risultato sull'esempio reale: `🔔 Senior Technical Product Manager - Portafogli (+48 altre offerte)` (68 char, parentesi bilanciate).

4 nuovi test in `tests/job-alert-email.test.ts` (70 totali verdi): strip `(100%)` + no dangling paren, strip `(80-100%)`/`(m/w/d)`, bilanciamento parentesi su parentetica non-pensum, nessun falso positivo su titolo pulito.

## Non implementato (ancora)

- **Card email**: non strippano pensum/gender (scelta deliberata — più spazio, info `%` utile; lo strip è solo display-subject, non normalizzazione dati).
- **Crawler / titoli salvati**: i `cleanTitle` nei crawler (`scripts/update-*-jobs.mjs`, `services/seoService.ts`) NON sono toccati — il titolo memorizzato deve conservare `(100%)` come dato; lo strip è un concern di display del subject, non sibling antipattern.
- **Conteggio "+48 altre offerte"**: fuori scope qui (riguarda l'ampiezza del match dell'alert, non l'euristica del titolo segnalata). Eventuale follow-up se 48 risultano troppo poco targettizzati.
- **Gender marker rari/locale-specific** (es. `(tutti i generi)`, `(all genders)` testuali non fra parentesi a slash) non coperti — solo i pattern a sigle slash/dash più comuni.