### PR TITLE
perf(worker): cut invocations toward the 100k/day cap — 404 edge caching, 6h TTL, crawler rate limits

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -52,21 +52,37 @@ const SHARD_ORIGIN = {
 // to these prefixes; this regex is the in-code guard.)
 const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 
-// Edge-cache TTL for shard pages, applied twice: as `cf.cacheTtl` on the
-// origin fetch (CF caches the ORIGIN response, tiered/cross-colo, so repeat
-// misses don't re-contact GitHub Pages) and as `s-maxage` on the response we
-// return (CF caches the WORKER response eyeball-side, so repeat hits don't
-// re-invoke the Worker at all — the lever that keeps frontaliere-locale-router
-// under the free-tier 100k/day cap). Safe against stale-HTML 404s: superseded
-// CDN asset hashes are retained GRACE_DAYS=7 (prune-cdn-assets.mjs), far
-// longer than this TTL, so HTML served up to 2h stale still resolves every
-// referenced /assets hash. Live job data is client-fetched fresh from the CDN
-// at runtime (not baked into this cached HTML), so a 2h-stale SEO shell is
-// fine. Tradeoff accepted: with cacheEverything a shard 404 can also be edge-
-// cached up to 2h, so a page that flips 404→200 on deploy may serve a cached
-// 404 from an already-poisoned colo for up to 2h — negligible for crawlers,
-// which revisit on a much longer cadence.
-const CACHE_MAX_AGE = 7200; // 2 h
+// Edge-cache TTLs for shard pages. Two layers, deliberately different:
+//
+//   ORIGIN_CACHE_TTL (2h) — `cf.cacheTtl` on the origin fetch: CF caches the
+//   ORIGIN response (tiered/cross-colo) so repeat misses don't re-contact
+//   GitHub Pages. Kept at 2h because with cacheEverything it also negative-
+//   caches origin 404s: a page that flips 404→200 on deploy may serve a
+//   cached 404 from an already-probed colo for up to this TTL, and deploys
+//   land 2-3×/day — 2h bounds that staleness window.
+//
+//   CACHE_MAX_AGE (6h) — `max-age`/`s-maxage` stamped on the 200 responses we
+//   return: CF caches the WORKER response eyeball-side, so repeat hits don't
+//   re-invoke the Worker at all — the lever that keeps frontaliere-locale-router
+//   under the free-tier 100k/day cap (measured 2026-06-11: ~144k inv/day,
+//   ~63% AI crawlers re-crawling; raised 2h→6h to absorb more repeats).
+//   Safe against stale-HTML 404s: superseded CDN asset hashes are retained
+//   GRACE_DAYS=7 (prune-cdn-assets.mjs), far longer than this TTL, so HTML
+//   served up to 6h stale still resolves every referenced /assets hash. Live
+//   job data is client-fetched fresh from the CDN at runtime (not baked into
+//   this cached HTML), so a 6h-stale SEO shell is fine.
+const CACHE_MAX_AGE = 21600; // 6 h — eyeball-side (Worker response)
+const ORIGIN_CACHE_TTL = 7200; // 2 h — origin-fetch side (cf.cacheTtl)
+
+// Cache-Control stamped on shard 404s. ~51k/day of shard traffic is crawlers
+// re-fetching DEAD job URLs from memory (old canton/slug variants, pruned
+// jobs) — 404 is the correct status (no page can exist for them: the
+// traffic-evidence gate caps soft-landing emission, and 391k bridge pages
+// would blow the Pages 10 GB cap), but without Cache-Control every repeat hit
+// re-invokes the Worker. s-maxage lets the edge absorb repeats; short
+// browser max-age so a human who lands on a just-published URL that
+// transiently 404'd retries fresh soon after.
+const NOT_FOUND_CACHE_CONTROL = 'public, max-age=300, s-maxage=7200';
 
 // Per-attempt upstream timeout + one retry. A healthy shard origin answers in
 // ~0.1-0.2s, so 6s is generous for a slow-but-ok fetch yet fails a hung
@@ -140,7 +156,7 @@ export default {
     try {
       resp = await fetchOriginWithRetry(upstream, request, {
         cacheEverything: true,
-        cacheTtl: CACHE_MAX_AGE,
+        cacheTtl: ORIGIN_CACHE_TTL,
       });
     } catch {
       // Every attempt timed out / threw — no origin response. Short Retry-After:
@@ -187,6 +203,15 @@ export default {
       const headers = new Headers(resp.headers);
       headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`);
       return new Response(resp.body, { status: 200, statusText: resp.statusText, headers });
+    }
+
+    // Stamp Cache-Control on 404s too: see NOT_FOUND_CACHE_CONTROL. GitHub
+    // Pages sends no Cache-Control on its 404 page, so without this every
+    // crawler re-fetch of a dead URL re-invokes the Worker.
+    if (request.method === 'GET' && resp.status === 404) {
+      const headers = new Headers(resp.headers);
+      headers.set('Cache-Control', NOT_FOUND_CACHE_CONTROL);
+      return new Response(resp.body, { status: 404, statusText: resp.statusText, headers });
     }
 
     return resp;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -107,9 +107,13 @@ Allow: /
 User-agent: PerplexityBot
 Allow: /
 
-# Amazon / Alexa
+# Amazon / Alexa — welcome, but rate-limited: Amazonbot honors Crawl-delay
+# (per Amazon's crawler docs) and was fetching ~24k locale-shard pages/day,
+# each one a Cloudflare Worker invocation against the free-tier 100k/day cap.
+# 10s ≈ max 8.6k fetches/day, plenty for Alexa/Rufus freshness on this site.
 User-agent: Amazonbot
 Allow: /
+Crawl-delay: 10
 
 # Apple
 User-agent: Applebot
@@ -188,3 +192,32 @@ Allow: /
 # Kagi AI Search
 User-agent: KagiBot
 Allow: /
+
+# ─── SEO-tool crawlers — blocked ──────────────────────────────────────────
+# Backlink/keyword-tool crawlers bring zero search or AI visibility and no
+# referral traffic; on the /en /de /fr locale shards every fetch is a
+# Cloudflare Worker invocation that counts against the free-tier 100k/day cap
+# (AhrefsBot alone: ~10k fetches/day measured 2026-06-11). All of these honor
+# robots.txt. Ad-verification crawlers (IAS, proximic) stay ALLOWED — they
+# validate inventory for AdSense advertisers (~95% of revenue).
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: serpstatbot
+Disallow: /


### PR DESCRIPTION
## Implementato

Analisi dati CF GraphQL 24h (2026-06-11), post-#1842 (analytics ora pulite, solo eyeball):

**Misure.** ~144k invocazioni/giorno del Worker `frontaliere-locale-router` vs cap free-tier 100k. Mix traffico shard: ~63% AI crawler verificati (GPTBot 10.6k/giorno su /en, ClaudeBot 9.5k, Amazonbot 8k, ChatGPT-User 3.9k), ~18% search engine (Googlebot 6.7k, Bing 2.3k), SEO-tool ~4k (Ahrefs 3.2k), umani ~3%. **~51.5k/giorno = richieste a URL job MORTI** (memoria crawler di vecchie varianti cantone/slug e job pruned): 404 è lo status corretto (le soft-landing per i 291k path shard del registry compat sono escluse by design dal traffic-evidence gate #1210 — 391k bridge sforerebbero il cap 10GB Pages), ma ogni hit ripetuto re-invocava il Worker.

- **`infra/cloudflare-worker/locale-router.js`**:
  - Cache-Control sui 404 shard (`max-age=300, s-maxage=7200`): l'edge assorbe i repeat sugli URL morti senza invocare il Worker (GH Pages non manda Cache-Control sulla sua 404).
  - s-maxage dei 200 alzato 2h→6h (`CACHE_MAX_AGE=21600`): più repeat crawl assorbiti eyeball-side. Sicuro: asset CDN con grace 7gg, dati job client-fetched live.
  - Nuova `ORIGIN_CACHE_TTL=7200` separata per `cf.cacheTtl` (lato origin-fetch invariato a 2h), così la finestra 404→200 post-deploy resta limitata a 2h.
- **`public/robots.txt`**:
  - Disallow SEO-tool crawler (AhrefsBot ~10k fetch/giorno, SemrushBot, DotBot, MJ12bot, BLEXBot, DataForSeoBot, serpstatbot): zero valore search/AI/referral, tutti onorano robots.txt. I bot ad-verification (IAS/proximic) restano AMMESSI (validano inventory AdSense).
  - `Crawl-delay: 10` per Amazonbot (~24k/giorno → max ~8.6k; onora la direttiva per docs Amazon). Nessun blocco di AI crawler: sono strategia di visibilità.

**Verifiche fatte sui 4xx/3xx** (contesto, nessun code-change necessario):
- 301 (~18k/giorno): canonicalizzazione corretta (https + trailing-slash GH Pages), ultra-long-tail — non bug.
- 404 brand-image (`/images/brands/*.png` ~1.8k/giorno): transitorio post-offload CDN #1705/#1709 — le pagine live emettono già URL CDN (verificato su company-hub/job/RSS: zero ref locali residui), i 404 sono memoria crawler pre-offload e decadono da soli. Correlato: #1744 (build-time vs post-build rewrite, resta valido come hardening).
- Sitemap sana: gli hreflang shard correnti rispondono 200 (verificato campione).

## Non implementato (ancora)

- **Sotto 100k/giorno GARANTITO non è raggiungibile con sole leve free**: stima post-merge ~105-120k/giorno (−10k SEO-tool, −15k Amazonbot, −5-15k caching 404/6h — i numeri crawler variano). Il grosso del traffico è AI/search crawl di long-tail UNICA (1.3M pagine): non cacheabile al primo hit e strategicamente voluto. Opzioni rimanenti = decisione user: (a) bloccare/limitare altri AI crawler (sconsigliato, sono il canale di visibilità), (b) Workers Paid $5/mese (10M req incluse) — contro vincolo zero-cost. Nota: a 144k/giorno non si osserva NESSUN throttling/1027 oggi (invocations status=success), quindi il cap potrebbe già essere non-enforced sull'account; il token Analytics non può leggere il piano (endpoint subscriptions → auth error).
- **Redirect algoritmici per i 51k/giorno di 404 crawler-memory** (vecchio-cantone → cantone corrente): richiederebbe la mappa slug→canton nel Worker (sfora il limite 1MB free) o pagine bridge (sfora 10GB Pages). 404 resta la risposta HTTP corretta; il volume decade naturalmente man mano che i crawler digeriscono.
- **Verifica live post-merge**: efficacia misurabile solo su finestre 24-48h (Amazonbot deve ri-leggere robots.txt, cache edge deve riempirsi). Revert-trigger esplicito: se il 404→200 di nuove pagine post-deploy risulta visibilmente ritardato oltre le 2h attese, o se le invocazioni AUMENTANO, revert del worker-change (`deploy-worker.yml` ha già auto-rollback su stallo).
- **#1744** (emit CDN brand-logo a build-time invece del post-build regex): non toccato — outcome live già corretto, resta hardening valido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)