### PR TITLE
feat(seo): wire the Cloudflare edge 404 sweep into discover-404s.yml

### DIFF
--- a/.github/workflows/discover-404s.yml
+++ b/.github/workflows/discover-404s.yml
@@ -10,6 +10,12 @@ name: Discover 404s via URL Inspection
 # programmatic way to discover unknown 404 URLs would be via the UI CSV
 # export. By rotating through our known URL universe we catch every
 # 404 transition without manual intervention.
+#
+# A second, complementary producer runs in the same job: the Cloudflare edge
+# 404 sweep (discover-404s-via-cloudflare.mjs), which surfaces 404 URLs we DON'T
+# already track — every real edge hit, human + bot, locale shards included,
+# zero GSC quota. Both producers append to the same accumulator and share the
+# prune + commit steps below.
 
 on:
   schedule:
@@ -82,6 +88,24 @@ jobs:
           MIN_AGE_DAYS: ${{ inputs.min_age_days || '14' }}
         run: |
           node scripts/discover-404s-via-inspection.mjs \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}
+
+      - name: Run Cloudflare edge 404 sweep
+        # Third producer (#1803 — script merged but never wired to CI until
+        # now). CF edge analytics records EVERY real 404 at the edge (human +
+        # bot, /en /de /fr shards included, no GSC quota), unlike URL
+        # Inspection which only re-checks URLs we already track. The script
+        # only APPENDS candidates (assets/infra filtered, min-count 2); the
+        # prune step below drops whatever the resolver can't map, keeping
+        # tests/search-console-compat.test.ts green. The CF analytics lib
+        # filters requestSource=eyeball by default (#1842), so Worker-internal
+        # phantom rows (edgeWorkerCacheAPI) can never reach the accumulator.
+        # continue-on-error: best-effort enrichment — a CF API hiccup must not
+        # kill the GSC sweep's commit. CF_API_TOKEN arrives from the
+        # "Load RC secrets" step above (Firebase Remote Config → GITHUB_ENV).
+        continue-on-error: true
+        run: |
+          node scripts/discover-404s-via-cloudflare.mjs \
             ${{ inputs.dry_run == true && '--dry-run' || '' }}
 
       - name: Prune non-resolving 404-compat paths (keep test invariant green)


### PR DESCRIPTION
## Implementato

- **Cablato `scripts/discover-404s-via-cloudflare.mjs` in `.github/workflows/discover-404s.yml`** (run giornaliero 02:15 UTC + workflow_dispatch). Lo script era stato mergiato in #1803 come terzo producer dell'accumulatore `data/seo-404-compat-paths.json`, ma **nessun workflow lo eseguiva** (verificato: zero riferimenti in `.github/workflows/*`). Ora gira nello stesso job dello sweep URL Inspection, PRIMA degli step condivisi prune+commit:
  - CF edge analytics vede ogni 404 reale all'edge (umani + bot, shard /en /de /fr inclusi, zero quota GSC) → scopre URL che NON tracciamo già (es. varianti vecchio-cantone in memoria dei crawler, ~51k hit/giorno misurati 2026-06-11), mentre la URL Inspection ri-controlla solo URL noti.
  - Lo script si limita ad APPEND (filtra asset/infra, `min-count=2` anti one-shot bot); il prune esistente (`prune-404-compat-paths.ts`) droppa ciò che il resolver non mappa → `tests/search-console-compat.test.ts` resta verde (stesso gate degli altri due producer).
  - La lib `cf-analytics.mjs` filtra `requestSource: "eyeball"` di default (#1842) → le righe fantasma `edgeWorkerCacheAPI` non possono entrare nell'accumulatore.
  - `continue-on-error: true`: arricchimento best-effort, un hiccup API CF non uccide il commit dello sweep GSC. `CF_API_TOKEN` arriva dallo step "Load RC secrets" già esistente (verificato in `scripts/load-rc-env.mjs` riga 109).
  - Supporta il `dry_run` input come lo step gemello.
- Header del workflow aggiornato per documentare il secondo producer.

Correlato: #1807 (item deferred di #1803 = monitorare il primo run live del producer CF + esito prune). Questa PR abilita esattamente quel primo run live: lo triggero post-merge (`gh workflow run discover-404s.yml`) e se prune+test verdi chiudo #1807 con citazione.

## Non implementato (ancora)

- **Validazione live**: non verificabile pre-merge (serve il run schedulato/dispatch su `main` con secrets RC). Post-merge: trigger manuale del workflow (regola AGENTS per workflow nuovi/modificati) + verifica esito prune e test. Revert-trigger: se il primo run live manda rosso `tests/search-console-compat.test.ts` o gonfia l'accumulatore oltre il cap anti-bloat, rimuovere lo step o restringere i candidati (come da #1807).
- **Sibling `scripts/load-rc-env.mjs`** (flaggato da check-sibling-patterns per il token condiviso `CF_API_TOKEN`): falso positivo — è la SORGENTE della variabile, nessuna modifica necessaria.
- **Emissione soft-landing per i path CF-scoperti**: invariata — resta gated dal traffic-evidence (#1210, anti dist-bloat). Questa PR popola la CONOSCENZA dei 404 (accumulatore + riconciliazione slug), non forza pagine nuove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)