### PR TITLE
fix(crawlers): real structured descriptions for givaudan + allianz-suisse (audit criticals)

### DIFF
--- a/scripts/lib/allianz-job-parser.mjs
+++ b/scripts/lib/allianz-job-parser.mjs
@@ -124,6 +124,148 @@ function isGenericTitle(title, siteName) {
   return false;
 }
 
+/* ── Detail body extraction ────────────────────────────────────
+ *
+ * The Umantis ATS is mid-migration between two detail-page templates:
+ *   - NEW template: the real role body lives in `.container.page-width` →
+ *     `.content` blocks (paragraphs + <ul><li> bullets + headings).
+ *   - OLD template: the body lives in `.showblock_textblock` blocks.
+ * In BOTH templates the page also carries chrome (skip-links, the
+ * "your browser cannot display embedded frames" notice, the
+ * "Kontakt / Keine Details erfasst / Aktionen / Ich bin interessiert" sidebar,
+ * the "Generalagentur <name> |" agency header).
+ *
+ * Crucially, a given vacancy is only published in ITS OWN language: the Italian
+ * `/Description/4` page for a German job returns a content-less shell, so the
+ * old parser (hardcoded `/Description/4`) grabbed the chrome for most jobs →
+ * dozens of vacancies ended up with the SAME body+title (the duplicate-listings
+ * audit critical). `pickRichestAllianzDescription` probes every language code
+ * and keeps the variant with the most real body text.
+ */
+
+const CHROME_LINE_RE = /^(Kontakt|Aktionen|Ich bin interessiert|Zurück|Keine Details erfasst|Ihr Browser kann|Zum Hauptinhalt|Springe zur|Jetzt Teil der Allianz|Bewerben|Drucken|Empfehlen|Merken|Teilen)\b/i;
+const AGENCY_HEADER_RE = /^(Generalagentur|Agence générale|Agenzia generale)[^.\n]{0,80}\|?\s*$/i;
+
+/**
+ * Extract the real job-body HTML from a Umantis detail page, chrome removed.
+ * Handles both the new (`.container.page-width`) and old (`.showblock_textblock`)
+ * templates and returns the richest candidate's inner HTML (so <ul>/<li>
+ * structure survives for downstream markdown conversion). Returns '' if no
+ * substantial body is present (e.g. the wrong-language shell page).
+ */
+export function extractAllianzBodyHtml(html = '') {
+  const doc = new JSDOM(html).window.document;
+  doc.querySelectorAll('script,style,noscript,header,footer,nav').forEach((n) => n.remove());
+
+  const candidates = [];
+
+  // NEW template — main content area.
+  const newMain = doc.querySelector('.container.page-width');
+  if (newMain) {
+    // Drop obvious chrome sub-blocks (apply CTA / share bar) by class hints.
+    for (const el of newMain.querySelectorAll('[class*="apply"],[class*="share"],[class*="action"],[class*="cta"],form')) {
+      el.remove();
+    }
+    candidates.push(newMain);
+  }
+
+  // OLD template — substantial showblock textblocks, chrome filtered out.
+  const oldBlocks = [...doc.querySelectorAll('.showblock_textblock')].filter((n) => {
+    const t = normalizeSpace(n.textContent || '');
+    if (t.length < 60) return false;
+    if (CHROME_LINE_RE.test(t)) return false;
+    if (AGENCY_HEADER_RE.test(t)) return false;
+    return true;
+  });
+  if (oldBlocks.length) {
+    candidates.push({ innerHTML: oldBlocks.map((n) => n.outerHTML).join('\n'), textContent: oldBlocks.map((n) => n.textContent).join(' ') });
+  }
+
+  let best = '';
+  let bestLen = 0;
+  for (const c of candidates) {
+    const len = normalizeSpace(c.textContent || '').length;
+    if (len > bestLen) {
+      bestLen = len;
+      best = c.innerHTML || '';
+    }
+  }
+  return best;
+}
+
+/**
+ * Convert an extracted Umantis body HTML into clean markdown, dropping any
+ * residual chrome lines. Walks the DOM so that <ul>/<li> nested inside content
+ * <div>s are preserved as `- ` bullets and <h*>/bold-only paragraphs as `## `
+ * headings — Umantis wraps its lists in <div class="content"> which a flat
+ * inline-flatten converter would collapse, so this walker handles lists
+ * explicitly wherever they appear in the tree.
+ */
+export function allianzBodyToMarkdown(bodyHtml = '') {
+  if (!bodyHtml || !bodyHtml.trim()) return '';
+  const doc = new JSDOM(`<body>${bodyHtml}</body>`).window.document;
+  const body = doc.body;
+  const lines = [];
+
+  const inlineText = (node) => normalizeSpace(node.textContent || '');
+
+  const walk = (node) => {
+    if (node.nodeType === 3) {
+      const t = normalizeSpace(node.textContent || '');
+      if (t) lines.push(t);
+      return;
+    }
+    if (node.nodeType !== 1) return;
+    const tag = node.tagName.toLowerCase();
+
+    if (tag === 'ul' || tag === 'ol') {
+      let idx = 0;
+      for (const li of node.children) {
+        if (li.tagName.toLowerCase() !== 'li') continue;
+        idx += 1;
+        const text = inlineText(li);
+        if (text) lines.push(node.tagName.toLowerCase() === 'ol' ? `${idx}. ${text}` : `- ${text}`);
+      }
+      return;
+    }
+
+    if (/^h[1-6]$/.test(tag)) {
+      const t = inlineText(node);
+      if (t) lines.push(`## ${t}`);
+      return;
+    }
+
+    if (tag === 'p') {
+      const t = inlineText(node);
+      if (t) lines.push(t);
+      return;
+    }
+
+    // Containers (div/section/article/etc): recurse so nested lists are reached.
+    for (const child of node.childNodes) walk(child);
+  };
+
+  for (const child of body.childNodes) walk(child);
+
+  const cleaned = lines
+    .map((l) => l.trim())
+    .filter((l) => {
+      if (!l) return false;
+      const bare = l.replace(/^[-*#\d.\s]+/, '').trim();
+      if (!bare) return false;
+      if (CHROME_LINE_RE.test(bare)) return false;
+      if (AGENCY_HEADER_RE.test(bare)) return false;
+      return true;
+    });
+
+  // De-dup consecutive identical lines (some templates repeat headings).
+  const out = [];
+  for (const l of cleaned) {
+    if (out[out.length - 1] !== l) out.push(l);
+  }
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim().slice(0, 5000);
+}
+
 /**
  * Parse a detail page (Italian) and extract rich metadata.
  *
@@ -193,36 +335,40 @@ export function parseAllianzDetailPage(html = '', fallbackTitle = '', fallbackLo
     }
   }
 
-  // Extract description text from the body
-  const bodyHtml = html;
-  let description = '';
+  // Extract the real job body, chrome stripped, as structured markdown. Handles
+  // both Umantis templates (new `.container.page-width`, old
+  // `.showblock_textblock`) and preserves <ul><li> bullets as `- ` lines so the
+  // descriptions aren't flat prose. Returns '' on the wrong-language shell page.
+  const bodyHtml = extractAllianzBodyHtml(html);
+  let description = allianzBodyToMarkdown(bodyHtml);
 
-  // Try to find the main content area (Allianz template uses table-based email-style HTML)
-  const contentMatch = bodyHtml.match(/<td[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/td>/i) ||
-    bodyHtml.match(/<div[^>]*class="[^"]*vacancy[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
-
-  if (contentMatch) {
-    description = stripHtml(contentMatch[1]);
-  } else {
-    // Fallback: extract all meaningful text between "Cosa ti proponiamo" and footer
-    const stripped = stripHtml(bodyHtml);
-    const startIdx = stripped.search(/Cosa ti (proponiamo|offriamo)|Was wir (dir bieten|Ihnen bieten)|What we offer/i);
-    if (startIdx > -1) {
-      const endIdx = stripped.indexOf('Ulteriori informazioni', startIdx);
-      description = (endIdx > -1 ? stripped.slice(startIdx, endIdx) : stripped.slice(startIdx, startIdx + 3000)).trim();
+  if (!description) {
+    // Legacy fallback for any remaining table/email-style template: pull the
+    // content cell or the "Was wir bieten / Cosa ti proponiamo" section.
+    // NOTE: deliberately NO chrome-grabbing "first N lines" last resort — a
+    // wrong-language shell page carries only chrome (skip-links, "Ihr Browser
+    // kann keine Frames anzeigen", the Kontakt/Aktionen sidebar). Returning ''
+    // for a shell is REQUIRED so fetchBestDetail keeps probing language codes
+    // and picks the variant that actually carries the role body. Grabbing the
+    // shell chrome here is what produced the duplicate-listings critical.
+    const contentMatch = html.match(/<td[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/td>/i) ||
+      html.match(/<div[^>]*class="[^"]*vacancy[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
+    if (contentMatch) {
+      description = stripHtml(contentMatch[1]);
     } else {
-      // Last resort: look for substantial text blocks
-      const lines = stripped.split('\n').filter((l) => l.trim().length > 40);
-      description = lines.slice(0, 15).join('\n').trim();
+      const stripped = stripHtml(html);
+      const startIdx = stripped.search(/Cosa ti (proponiamo|offriamo)|Was wir (dir bieten|Ihnen bieten)|What we offer/i);
+      if (startIdx > -1) {
+        const endIdx = stripped.indexOf('Ulteriori informazioni', startIdx);
+        description = (endIdx > -1 ? stripped.slice(startIdx, endIdx) : stripped.slice(startIdx, startIdx + 3000)).trim();
+      }
     }
+    description = description
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/^\s+|\s+$/gm, '')
+      .trim()
+      .slice(0, 5000);
   }
-
-  // Clean up description
-  description = description
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/^\s+|\s+$/gm, '')
-    .trim()
-    .slice(0, 5000);
 
   // Extract address from body (e.g. "Piazza del Sole\n6500 Bellinzona")
   let locationFromBody = '';

--- a/scripts/lib/givaudan-job-parser.mjs
+++ b/scripts/lib/givaudan-job-parser.mjs
@@ -12,7 +12,8 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, fetchJson } from './crawler-template.mjs';
+import { slugify, stripHtml, fetchJson, fetchHtml } from './crawler-template.mjs';
+import { htmlToMarkdown } from './axpo-job-parser.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import { assertJsonListShape } from './assert-json-list-shape.mjs';
 
@@ -226,6 +227,45 @@ async function fetchJobListings() {
 }
 
 /**
+ * Fetch the FULL structured description for one Givaudan job from its detail page.
+ *
+ * The Phenom listing widget only carries a short flat `descriptionTeaser`
+ * (1-2 sentences, no list structure) — publishing that leaves every job as flat
+ * prose with no <ul><li>, which the parser-quality audit flags as a
+ * "no structured content" critical. The SSR detail page (the same URL the
+ * listing builds) embeds the complete schema.org JobPosting description in a
+ * JSON-LD <script>, with real <ul>/<li> bullets and headings (verified live:
+ * 5000-8000 chars per job). We extract that HTML and convert it to markdown via
+ * the shared htmlToMarkdown so the bullets/headings survive as `- `/`## ` lines.
+ *
+ * Returns markdown on success, '' on any failure so the caller falls back to the
+ * listing teaser (never synthesises content).
+ */
+async function fetchGivaudanDetailDescription(url) {
+  if (!url || !/^https?:\/\//.test(url)) return '';
+  try {
+    const html = await fetchHtml(url, { timeoutMs: 15000 });
+    if (!html) return '';
+    const blocks = [...html.matchAll(/<script[^>]*application\/ld\+json[^>]*>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
+    for (const block of blocks) {
+      try {
+        const data = JSON.parse(block);
+        const arr = Array.isArray(data) ? data : [data];
+        for (const o of arr) {
+          if (String(o?.['@type'] || '').includes('JobPosting') && o.description) {
+            // o.description is entity-encoded HTML (e.g. &lt;ul&gt;&lt;li&gt;…);
+            // htmlToMarkdown decodes entities and preserves list/heading structure.
+            const { markdown } = htmlToMarkdown(String(o.description));
+            return markdown || '';
+          }
+        }
+      } catch { /* skip malformed JSON-LD block */ }
+    }
+  } catch { /* network/timeout → caller falls back to the teaser */ }
+  return '';
+}
+
+/**
  * Fetch all Givaudan jobs.
  * Returns an array of ParsedJob objects (source-locale only).
  *
@@ -254,12 +294,16 @@ export async function fetchAllGivaudanJobs() {
     const canton = inferSwissTargetCanton(location) || HQ.canton;
     // Locality = leading city token of the "City, Switzerland" string.
     const addressLocality = normalizeSpace(location.split(',')[0]) || HQ.city;
-    const descriptionText = stripHtml(listing.description || '');
     const publicUrl = listing.url || CAREER_URL;
     const applyUrl = listing.applyUrl || publicUrl;
 
     if (seen.has(listing.jobReqId || publicUrl)) continue;
     seen.add(listing.jobReqId || publicUrl);
+
+    // Prefer the FULL structured detail-page description (markdown with bullets)
+    // over the flat listing teaser. Falls back to the teaser on any fetch failure.
+    const detailMarkdown = await fetchGivaudanDetailDescription(publicUrl);
+    const descriptionText = detailMarkdown || stripHtml(listing.description || '');
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} givaudan ch`);

--- a/scripts/update-allianz-jobs.mjs
+++ b/scripts/update-allianz-jobs.mjs
@@ -206,6 +206,36 @@ async function fetchAllListings() {
   return allItems;
 }
 
+// Umantis publishes each vacancy only in its own language; the `/Description/4`
+// (Italian) URL returns a content-less shell for German/French jobs, so the old
+// hardcoded-`/4` fetch grabbed the page chrome → most jobs shared the same
+// body+title (the duplicate-listings audit critical). Probe every language code
+// and keep the variant whose parsed body carries the most real text.
+const DESCRIPTION_LANG_CODES = [4, 1, 3, 2]; // IT first (target locale), then DE/EN/FR
+
+async function fetchBestDetail(item) {
+  let best = null;
+  let bestLen = 0;
+  for (const code of DESCRIPTION_LANG_CODES) {
+    const url = `https://${COMPANY_HOST}/Vacancies/${item.vacancyId}/Description/${code}`;
+    let html;
+    try {
+      html = await fetchText(url);
+    } catch {
+      continue;
+    }
+    const detail = parseAllianzDetailPage(html, item.title, item.location);
+    const len = (detail.description || '').replace(/\s+/g, ' ').trim().length;
+    if (len > bestLen) {
+      bestLen = len;
+      best = detail;
+    }
+    // First sufficiently-rich variant wins — avoids probing all 4 codes per job.
+    if (bestLen >= 300) break;
+  }
+  return best || parseAllianzDetailPage('', item.title, item.location);
+}
+
 async function enrichWithDetails(listings) {
   const enriched = [];
   const toFetch = listings.slice(0, MAX_DETAIL_PAGES);
@@ -215,8 +245,7 @@ async function enrichWithDetails(listings) {
   for (let i = 0; i < toFetch.length; i++) {
     const item = toFetch[i];
     try {
-      const html = await fetchText(item.detailUrl);
-      const detail = parseAllianzDetailPage(html, item.title, item.location);
+      const detail = await fetchBestDetail(item);
       enriched.push({
         ...item,
         title: detail.title || item.title,
@@ -225,7 +254,7 @@ async function enrichWithDetails(listings) {
         description: detail.description || '',
         contractType: detail.contractType || '',
       });
-      console.log(`  ✅ [${i + 1}/${toFetch.length}] ${item.vacancyId}: ${detail.title || item.title} — ${inferLocation(item, detail)}`);
+      console.log(`  ✅ [${i + 1}/${toFetch.length}] ${item.vacancyId}: ${detail.title || item.title} — ${inferLocation(item, detail)} (${(detail.description || '').length} chars)`);
     } catch (err) {
       console.log(`  ⚠️ Detail fetch failed for ${item.vacancyId}: ${err.message}`);
       enriched.push({

--- a/tests/allianz-crawler.test.ts
+++ b/tests/allianz-crawler.test.ts
@@ -16,7 +16,57 @@ import {
   parseAllianzDetailPage,
   parseAllianzListingPage,
   inferAllianzCanton,
+  extractAllianzBodyHtml,
+  allianzBodyToMarkdown,
 } from '@/scripts/lib/allianz-job-parser.mjs';
+
+// New `.container.page-width` template (Umantis migration, tenant 2872): the
+// real role body lives in nested `.content` divs with <ul><li> bullets, and the
+// page also carries chrome (skip-links, frame notice, Kontakt/Aktionen sidebar).
+const FIXTURE_DETAIL_NEW_TEMPLATE = `<!DOCTYPE html>
+<html lang="de">
+<head><title>Kundenberater/in für die Agentur Murten 100% -- Allianz Bewerbermanagement</title></head>
+<body>
+  <div class="skip_navigation_links"><a href="#main">Zum Hauptinhalt springen</a> Springe zur Aktionsleiste</div>
+  <p>Ihr Browser kann leider keine eingebetteten Frames anzeigen</p>
+  <div class="container page-width">
+    <main>
+      <h1>Kundenberater/in für die Agentur Murten 100%</h1>
+      <div class="content">
+        <h2>Ihre Aufgaben</h2>
+        <ul>
+          <li>Du betreust und baust den dir anvertrauten Kundenstamm in der Region Murten aus.</li>
+          <li>Du berätst Privatkunden umfassend in allen Versicherungs- und Vorsorgefragen.</li>
+        </ul>
+      </div>
+      <div class="content">
+        <h2>Was Sie erwarten dürfen</h2>
+        <ul>
+          <li>Eine praxisnahe Grundausbildung und eine sorgfältige Einarbeitung in der Generalagentur.</li>
+          <li>Ein leistungsorientiertes Vergütungsmodell mit attraktiven Verdienstmöglichkeiten.</li>
+        </ul>
+      </div>
+    </main>
+  </div>
+  <div class="container_login"><span>Kontakt</span><span>Keine Details erfasst</span><span>Aktionen</span><span>Ich bin interessiert und möchte mich bewerben</span></div>
+</body>
+</html>`;
+
+// Wrong-language SHELL page: the Italian /Description/4 URL of a German job
+// renders ONLY chrome (no role body). MUST yield an empty description so the
+// caller keeps probing language codes (root cause of the duplicate-listings bug).
+const FIXTURE_DETAIL_SHELL = `<!DOCTYPE html>
+<html lang="it">
+<head><title>  | Allianz | Bewerbermanagement</title>
+  <meta property="og:site_name" content="Allianz Bewerbermanagement" /></head>
+<body>
+  <div class="skip_navigation_links">Zum Hauptinhalt springen Springe zur Aktionsleiste</div>
+  <p>Ihr Browser kann leider keine eingebetteten Frames anzeigen</p>
+  <div class="showblock_textblock">Generalagentur Fribourg, Daniel Eltschinger |</div>
+  <div class="showblock_textblock">Kontakt Keine Details erfasst</div>
+  <div class="showblock_textblock">Aktionen Ich bin interessiert und möchte mich bewerben</div>
+</body>
+</html>`;
 
 // ─── Fixtures: detail pages ────────────────────────────────────────────────
 
@@ -303,5 +353,48 @@ describe('inferAllianzCanton', () => {
 
   it('returns correct canton for non-TI/GR Swiss locations', () => {
     expect(inferAllianzCanton('Agenzia Berna', 'Bern')).toBe('BE');
+  });
+});
+
+// ─── New template + shell handling (duplicate-listings audit fix) ──────────
+
+describe('extractAllianzBodyHtml — new .container.page-width template', () => {
+  it('extracts the role body and preserves <ul><li> structure', () => {
+    const body = extractAllianzBodyHtml(FIXTURE_DETAIL_NEW_TEMPLATE);
+    expect(body).toContain('<li>');
+    expect(body).toContain('anvertrauten Kundenstamm');
+  });
+
+  it('returns empty string for a wrong-language shell page (chrome only)', () => {
+    // Required so fetchBestDetail keeps probing other language codes instead of
+    // publishing the shell chrome (which made every job a duplicate).
+    expect(extractAllianzBodyHtml(FIXTURE_DETAIL_SHELL).trim()).toBe('');
+  });
+});
+
+describe('allianzBodyToMarkdown', () => {
+  it('converts <ul><li> to "- " bullet lines (structured content)', () => {
+    const md = allianzBodyToMarkdown(extractAllianzBodyHtml(FIXTURE_DETAIL_NEW_TEMPLATE));
+    expect(/^- /m.test(md)).toBe(true);
+    expect(md).toContain('## Ihre Aufgaben');
+  });
+
+  it('drops chrome lines (skip-links, frame notice, Kontakt/Aktionen)', () => {
+    const md = allianzBodyToMarkdown(extractAllianzBodyHtml(FIXTURE_DETAIL_NEW_TEMPLATE));
+    expect(md).not.toMatch(/Zum Hauptinhalt|Ich bin interessiert|Keine Details erfasst/i);
+  });
+});
+
+describe('parseAllianzDetailPage — new template + shell', () => {
+  it('produces a bulleted description from the new template', () => {
+    const { description, title } = parseAllianzDetailPage(FIXTURE_DETAIL_NEW_TEMPLATE);
+    expect(title).toBe('Kundenberater/in für die Agentur Murten 100%');
+    expect(/^- /m.test(description)).toBe(true);
+    expect(description).toContain('anvertrauten Kundenstamm');
+  });
+
+  it('returns an empty description for the wrong-language shell page', () => {
+    const { description } = parseAllianzDetailPage(FIXTURE_DETAIL_SHELL, 'Listing fallback title');
+    expect(description.trim()).toBe('');
   });
 });

--- a/tests/givaudan-crawler.test.ts
+++ b/tests/givaudan-crawler.test.ts
@@ -6,6 +6,7 @@ import {
   isTrustedDomain,
 } from '../scripts/lib/givaudan-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
+import { htmlToMarkdown } from '../scripts/lib/axpo-job-parser.mjs';
 
 describe('Givaudan crawler parser', () => {
   // ── Constants ──
@@ -56,6 +57,36 @@ describe('Givaudan crawler parser', () => {
     it('handles invalid URLs', () => {
       expect(isTrustedDomain('')).toBe(false);
       expect(isTrustedDomain('not-a-url')).toBe(false);
+    });
+  });
+
+  // ── detail-page description → structured markdown ──
+  // The fix replaces the flat listing `descriptionTeaser` with the full
+  // schema.org JobPosting description from the detail page. That description is
+  // entity-encoded HTML (&lt;ul&gt;&lt;li&gt;…) and is converted via the shared
+  // htmlToMarkdown so bullets/headings survive — otherwise the parser-quality
+  // audit flags the crawler "no structured content (no bullets/lists)".
+  describe('detail description → structured markdown (no-structure audit fix)', () => {
+    // Mirrors the entity-encoded JSON-LD JobPosting.description Givaudan serves.
+    const JSONLD_DESC =
+      '&lt;p&gt;Join us and celebrate the beauty of human experience.&lt;/p&gt;' +
+      '&lt;p&gt;&lt;strong&gt;Your responsibilities&lt;/strong&gt;&lt;/p&gt;' +
+      '&lt;ul&gt;&lt;li&gt;Drive continuous improvement initiatives across production.&lt;/li&gt;' +
+      '&lt;li&gt;Analyse processes and propose data-driven optimisations.&lt;/li&gt;&lt;/ul&gt;';
+
+    it('decodes entities and preserves list structure as "- " bullets', () => {
+      const { markdown, bulletCount } = htmlToMarkdown(JSONLD_DESC);
+      expect(bulletCount).toBeGreaterThanOrEqual(2);
+      expect(/^- /m.test(markdown)).toBe(true);
+      expect(markdown).toContain('continuous improvement');
+    });
+
+    it('produces content the parser-quality structure check accepts', () => {
+      const { markdown } = htmlToMarkdown(JSONLD_DESC);
+      // Mirrors hasStructuredContent() in scripts/audit-parser-quality.mjs.
+      const hasStructure =
+        /<li[\s>]/i.test(markdown) || /^\s*[-•*]\s/m.test(markdown) || /^\s*\d+[.)]\s/m.test(markdown);
+      expect(hasStructure).toBe(true);
     });
   });
 


### PR DESCRIPTION
Clears **2 of the 4** critical crawlers flagged by the **Audit Parser Quality** gate (`scripts/audit-parser-quality.mjs --strict`, issue #1752). The other two (hirslanden, geberit) self-heal via already-merged/pending fixes.

## Implementato

### givaudan — `scripts/lib/givaudan-job-parser.mjs`
Was `29/29 no structured content (no bullets/lists) [NEW OFFENDER: flat]`. Root cause: the parser published the Phenom listing `descriptionTeaser` (a flat ~300-char snippet) as the description → flat prose, no `<ul><li>`.
- Added `fetchGivaudanDetailDescription(url)` (mirrors the #1790 straumann teaser→detail pattern): fetches the detail page (the same URL the parser already builds via `jobSeqNo`+slug), extracts the schema.org `JobPosting.description` from its JSON-LD `<script>` (entity-encoded HTML with real `<ul>/<li>` + headings), and converts it to markdown via the shared `htmlToMarkdown` (from `axpo-job-parser.mjs`) so bullets/headings survive as `- `/`## ` lines.
- Wired into the build loop: prefers the detail markdown, falls back to `stripHtml(teaser)` on any fetch failure. Never synthesises a description.
- **Live before/after:** flat teasers → **30/30 jobs structured**, descriptions 4000-7000 chars.

### allianz-suisse — `scripts/lib/allianz-job-parser.mjs` + `scripts/update-allianz-jobs.mjs`
Was `47/58 (81%) duplicate-listings` (jobs share BOTH title and description). Root cause (investigated live): Umantis tenant 2872 is mid-migration between two detail-page templates AND publishes each vacancy only in **its own language**. The parser hardcoded `/Description/4` (Italian), so for the German/French majority that URL returns a **content-less shell**; the old last-resort "first N lines" grab then scraped the page **chrome** ("Zum Hauptinhalt springen", "Kontakt / Keine Details erfasst", "Ich bin interessiert") → dozens of vacancies ended up with the SAME body and the generic chrome title `| Allianz | Bewerbermanagement`.
- `extractAllianzBodyHtml()` (new, exported): pulls the real role body from **both** templates (`.container.page-width` new / `.showblock_textblock` old), chrome stripped; returns `''` for a shell page.
- `allianzBodyToMarkdown()` (new, exported): DOM-walks the body so `<ul><li>` nested inside content `<div>`s survive as `- ` bullets and `<h*>` as `## ` headings (the flat axpo converter collapses div-nested lists, so this walker handles lists wherever they appear).
- `parseAllianzDetailPage()`: now extracts via the new body extractor; **dropped the chrome-grabbing last-resort** — a shell page now yields `''`, which is required so the fetcher keeps probing for the language that actually carries the body.
- `update-allianz-jobs.mjs` `fetchBestDetail()`: probes every language code (`/Description/4,1,3,2`, IT first) and keeps the variant whose parsed body carries the most real text.
- **Live before/after:** 33% distinct (title,description) → **100% distinct**; **10/10 structured**; **0 chrome contamination**; the chrome title `| Allianz | Bewerbermanagement` is gone (real h1 titles now).

### Tests (+8, full suite green)
- allianz: new-template body extraction preserves `<li>`; shell page → empty description; `allianzBodyToMarkdown` emits `- ` bullets + `## ` headings and drops chrome lines; `parseAllianzDetailPage` bulleted desc + shell→empty. Existing old-template ("Cosa ti proponiamo") fixtures still pass (legacy fallback retained).
- givaudan: entity-encoded JSON-LD `JobPosting.description` → markdown decodes entities and preserves list structure (mirrors the audit's `hasStructuredContent` check).

## Non implementato (ancora)
- **Shared `scripts/lib/umantis-detail-helpers.mjs` not modified.** The sibling-pattern check surfaces it (shared `vacancyId` token). It handles *other* Umantis tenants' layouts (expander `h2#expander-N`, `h3+padding`) and hardcodes `Description/1?lang=ger`; it does not recognise tenant 2872's two templates and is not the locus of Allianz's bug. The Allianz fix is bespoke to its tenant by design. Verified the other Umantis crawlers are not affected: `hoval` = 100% distinct; `axa`/`eoc` have no current slice. Out of scope to refactor the shared helper here.
- **#1850** (headless render for client-rendered Umantis listings: pdag, kispi-sg, paraplegie) — different tenants and a different failure (client-rendered *listings* needing a headless browser), not the duplicate/language-shell bug fixed here. Not closed.
- **#1826** (sweep ~30 `update-*-jobs` to use the connection-level Jina fallback) — Allianz's local `fetchText` is one of those; that cross-cutting sweep is its own follow-up, not in scope. Not closed.
- **#1752 not auto-closed** — this PR clears 2 of the 4 criticals; full resolution depends on the hirslanden/geberit self-heal. Referenced, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)