### PR TITLE
fix(crawlers): real Geberit descriptions via SuccessFactors RMK search API

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -5189,15 +5189,42 @@ export function mergePreserveLocaleData(existingJobs, freshJobs, opts = {}) {
   // the normalized full URL (legacy behaviour) — no regression.
   const matchKey = opts.matchKey || ((job) => extractStableJobId(job?.url));
 
+  // Guard against a non-injective matchKey (collisions). A bridge key that is
+  // not unique — e.g. a slug bridge where two distinct postings share
+  // slugify("<title> …") (Geberit's `…-geberit-ch` + `…-geberit-ch-2` collision
+  // pair) — would otherwise map several fresh jobs onto a single old record:
+  // the Map below silently keeps only the last existing per key, and every
+  // fresh sharing that key inherits the SAME old.id / previousSlugs / locale
+  // translations, cross-contaminating them onto the wrong job while the other
+  // old record is left unmatched and expired. For any key shared by >1 existing
+  // OR >1 fresh job we skip the bridge entirely and let those jobs re-index with
+  // their own fresh identity — correctness over equity-preservation for an
+  // inherently ambiguous set.
+  const ambiguousKeys = new Set();
+  const seenExistingKeys = new Set();
+  for (const job of existingJobs) {
+    const k = matchKey(job);
+    if (!k) continue;
+    if (seenExistingKeys.has(k)) ambiguousKeys.add(k);
+    seenExistingKeys.add(k);
+  }
+  const seenFreshKeys = new Set();
+  for (const job of freshJobs) {
+    const k = matchKey(job);
+    if (!k) continue;
+    if (seenFreshKeys.has(k)) ambiguousKeys.add(k);
+    seenFreshKeys.add(k);
+  }
+
   const existingByKey = new Map();
   for (const job of existingJobs) {
     const k = matchKey(job);
-    if (k) existingByKey.set(k, job);
+    if (k && !ambiguousKeys.has(k)) existingByKey.set(k, job);
   }
 
   return freshJobs.map((fresh) => {
     const k = matchKey(fresh);
-    const old = k ? existingByKey.get(k) : null;
+    const old = (k && !ambiguousKeys.has(k)) ? existingByKey.get(k) : null;
     if (!old) return fresh;
 
     // Preserve stable ID from existing job

--- a/scripts/lib/geberit-job-parser.mjs
+++ b/scripts/lib/geberit-job-parser.mjs
@@ -10,9 +10,7 @@
  *   - isTrustedDomain()           — Validate URLs belong to this company
  *   - slugify() / stripHtml()     — Re-exported from crawler-template.mjs
  */
-import { createHash } from 'node:crypto';
-import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, fetchHtml } from './crawler-template.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -22,7 +20,6 @@ export const GEBERIT_COMPANY_NAME = 'Geberit';
 export const GEBERIT_COMPANY_DOMAIN = 'geberit.com';
 
 const CAREER_URL = 'https://jobs.geberit.com/';
-const SITEMAP_URL = 'https://jobs.geberit.com/sitemap.xml';
 
 // HQ fallback (Rapperswil-Jona, SG) per recon.
 const HQ = {
@@ -36,22 +33,6 @@ const SECTOR = 'Industrial / Sanitary technology (manufacturing)';
 
 // Posting host of the SuccessFactors RMK tenant (branded CNAME).
 const ATS_HOST = 'jobs.geberit.com';
-
-/**
- * City tokens that mark a Swiss job slug per recon. Each entry maps the
- * slug-prefix token to a human-readable location + canton. Order matters:
- * longest/most-specific prefix first so 'Rapperswil-Jona' wins over 'Jona'.
- * German plants (Pfullendorf, Haldensleben, Lichtenstein/Saxony, …) are NOT
- * listed → they fall through the filter and are excluded.
- */
-const SWISS_CITY_TOKENS = [
-  { token: 'Rapperswil-Jona', location: 'Rapperswil-Jona', canton: 'SG' },
-  { token: 'Aussendienst-Schweiz', location: 'Aussendienst Schweiz', canton: null },
-  { token: 'Jona', location: 'Jona', canton: 'SG' },
-  { token: 'Pfaeffikon', location: 'Pfäffikon', canton: 'SZ' },
-  { token: 'Pfäffikon', location: 'Pfäffikon', canton: 'SZ' },
-  { token: 'Givisiez', location: 'Givisiez', canton: 'FR' },
-];
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -139,107 +120,107 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
-/* ── Sitemap listing fetcher ──────────────────────────────────
- * The Geberit careers site runs on a branded SAP SuccessFactors RMK
- * (jobs2web) tenant. Its search rows are AJAX-injected and the job-detail
- * pages are JS-rendered with NO server-side JSON-LD, so the only reliable
- * machine-readable source is the single sitemap.xml: one <url> block per
- * job, with <loc>.../job/{City-Slug}/{jobId}/</loc> and a <lastmod> date.
- * We derive the title from the slug and the location from the leading city
- * token, filtering to Swiss jobs by that token (recon chFilter).
+/* ── SuccessFactors RMK / Career Site Builder JSON API ─────────
+ * The Geberit careers site is a SAP SuccessFactors "Career Site Builder"
+ * SPA: search rows and job-detail bodies are rendered client-side from a
+ * JSON search API, and the server HTML carries NO JSON-LD and only ~500
+ * chars of chrome — the sitemap likewise exposes only title + URL. The SPA
+ * itself calls a public Azure-Search-backed endpoint with a publishable
+ * api-key embedded in the page; one POST returns the FULL job records
+ * (rich HTML description + structured address + dates + job type) for an
+ * OData filter, so we query Swiss jobs directly — no headless render, no
+ * per-job detail fetch, real descriptions that clear the boilerplate gate.
  */
+
+const SEARCH_API_URL = 'https://production.api.recruiting-solutions.org/search';
+// Publishable (pk_) frontend key — the SPA ships it in plain JS; not a secret.
+const SEARCH_API_KEY =
+  'pk_geberit-prod_wbymYncbyHVbHzffXBqsBBBGQsyWJQEAnbmrthowOTtUchrxCjEEKgKyJvsGlvcfMxGXJpNAbqPTXBgTZQKeldlzFKscNjWJ';
+const SEARCH_CUSTOMER_ID = 'geberit-prod';
+// OData filter: every job with at least one Swiss address (data label is German "Schweiz").
+const SWISS_FILTER = "addresses/any(a: a/country eq 'Schweiz')";
+const PAGE_SIZE = 100;
 
 const UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
-  '(KHTML, like Gecko) Chrome/126.0 Safari/537.36';
+  '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 
-/** Match a Swiss city token at the START of the slug path segment. */
-function matchSwissCityToken(slugSegment = '') {
-  const seg = String(slugSegment || '');
-  for (const entry of SWISS_CITY_TOKENS) {
-    if (seg.toLowerCase().startsWith(entry.token.toLowerCase() + '-') ||
-        seg.toLowerCase() === entry.token.toLowerCase()) {
-      return entry;
-    }
-  }
-  return null;
+/** Map a SuccessFactors locale code (de_DE, en_US, fr_FR, it_IT) → our 2-letter locale. */
+function localeToLang(code = '') {
+  const lc = String(code || '').slice(0, 2).toLowerCase();
+  return ['it', 'de', 'fr', 'en'].includes(lc) ? lc : 'de';
 }
 
 /**
- * Turn the remaining slug (after the city token) into a human title.
- * Slug words are dash-joined and may carry a trailing percentage band
- * (e.g. "...-(a)-80-100" / "...-100"). We keep those — they are part of
- * the real posting title — and just restore spaces.
+ * Convert the RMK description HTML (<h2>/<p>/<ul><li>) into markdown so the
+ * list/heading structure survives (the parser-quality audit flags flat prose
+ * with no bullets). Falls back to a plain-text strip for anything else.
  */
-function slugToTitle(rest = '') {
-  return rest
-    .split('-')
-    .filter(Boolean)
-    .join(' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+function htmlToMarkdown(html = '') {
+  let s = String(html || '');
+  s = s.replace(/<\s*(h[1-6])[^>]*>([\s\S]*?)<\/\s*\1\s*>/gi, (_m, _t, inner) => `\n\n## ${stripHtml(inner).trim()}\n`);
+  s = s.replace(/<\s*li[^>]*>([\s\S]*?)<\/\s*li\s*>/gi, (_m, inner) => `\n- ${stripHtml(inner).trim()}`);
+  s = s.replace(/<\s*\/\s*(p|div|ul|ol)\s*>/gi, '\n');
+  s = s.replace(/<\s*br\s*\/?\s*>/gi, '\n');
+  s = stripHtml(s);
+  s = s.replace(/&#13;/g, '').replace(/ /g, ' ');
+  s = s.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').replace(/[ \t]{2,}/g, ' ');
+  return s.trim();
 }
 
-/** Parse <url> blocks out of the sitemap XML. */
-function parseSitemap(xml = '') {
-  const out = [];
-  const blockRe = /<url>([\s\S]*?)<\/url>/g;
-  let m;
-  while ((m = blockRe.exec(xml)) !== null) {
-    const block = m[1];
-    const loc = (block.match(/<loc>([^<]+)<\/loc>/) || [])[1];
-    const lastmod = (block.match(/<lastmod>([^<]+)<\/lastmod>/) || [])[1];
-    if (loc) out.push({ loc: loc.trim(), lastmod: (lastmod || '').trim() });
-  }
-  return out;
-}
-
-async function fetchJobListings() {
-  let xml;
-  try {
-    xml = await fetchHtml(SITEMAP_URL, { headers: { 'User-Agent': UA, Accept: 'application/xml,text/xml,*/*' } });
-  } catch (err) {
-    console.error(`❌ Failed to fetch sitemap: ${err?.message || err}`);
-    return [];
-  }
-
-  const entries = parseSitemap(xml);
-  console.log(`  🗺️  Sitemap entries: ${entries.length}`);
-
-  const listings = [];
-  for (const { loc, lastmod } of entries) {
-    // Path shape: /job/{City-Slug}/{jobId}/
-    const pathMatch = loc.match(/\/job\/([^/]+)\/(\d+)\/?$/i);
-    if (!pathMatch) continue;
-
-    const rawSlug = pathMatch[1];
-    const jobReqId = pathMatch[2];
-    // Decode %28a%29 → (a), %C3%B6 → ö, etc.
-    let decoded;
+/** POST the search API with transient retry. Returns the parsed JSON or throws. */
+async function postSearch(body, { retries = 3 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      decoded = decodeURIComponent(rawSlug);
-    } catch {
-      decoded = rawSlug;
+      const res = await fetch(SEARCH_API_URL, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json;charset=UTF-8',
+          'x-api-key': SEARCH_API_KEY,
+          customerid: SEARCH_CUSTOMER_ID,
+          privatejobboard: 'false',
+          internal: 'false',
+          'User-Agent': UA,
+          Referer: CAREER_URL,
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status} from search API`);
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** attempt));
+      }
     }
-
-    const cityHit = matchSwissCityToken(decoded);
-    if (!cityHit) continue; // non-CH (German plants, Lichtenstein/Saxony, …)
-
-    // Strip the city token prefix to get the title remainder.
-    const rest = decoded.slice(cityHit.token.length).replace(/^-+/, '');
-    const title = slugToTitle(rest) || cityHit.location;
-
-    listings.push({
-      title,
-      location: cityHit.location,
-      cantonHint: cityHit.canton, // may be null → HQ fallback later
-      url: loc,
-      postedAt: lastmod || '',
-      jobReqId,
-    });
   }
+  throw lastErr;
+}
 
-  return listings;
+/** Fetch every Swiss Geberit job record (with full description) from the RMK API. */
+async function fetchSwissJobRecords() {
+  const collected = [];
+  let skip = 0;
+  let total = Infinity;
+  // Hard cap to avoid a runaway loop if the API ignores skip.
+  for (let page = 0; page < 50 && skip < total; page++) {
+    const data = await postSearch({
+      count: true,
+      facets: [],
+      search: '*',
+      filter: SWISS_FILTER,
+      skip,
+      top: PAGE_SIZE,
+    });
+    if (page === 0) total = Number(data?.['@odata.count'] ?? 0);
+    const value = Array.isArray(data?.value) ? data.value : [];
+    if (value.length === 0) break;
+    collected.push(...value);
+    skip += value.length;
+    if (collected.length >= total) break;
+  }
+  return collected;
 }
 
 /**
@@ -251,47 +232,71 @@ async function fetchJobListings() {
  */
 export async function fetchAllGeberitJobs() {
   console.log(`🔍 Fetching Geberit (Switzerland) jobs`);
-  console.log(`   Source: ${SITEMAP_URL}\n`);
+  console.log(`   Source: SuccessFactors RMK search API (filter: Swiss addresses)\n`);
 
-  const listings = await fetchJobListings();
-  if (!listings || listings.length === 0) {
-    console.warn('⚠️ No job listings returned.');
+  let records;
+  try {
+    records = await fetchSwissJobRecords();
+  } catch (err) {
+    console.error(`❌ Failed to fetch Geberit jobs from RMK API: ${err?.message || err}`);
     return [];
   }
-
-  console.log(`  📋 Listings found: ${listings.length}`);
+  console.log(`  📋 Swiss job records returned: ${records.length}`);
 
   const jobs = [];
-  const seenIds = new Set();
-  for (const listing of listings) {
-    const title = normalizeSpace(listing.title || '');
+  const seenInternal = new Set();
+  // Prefer one locale per physical job: de (CH primary) > it > fr > en.
+  const LANG_RANK = { de: 0, it: 1, fr: 2, en: 3 };
+  const sorted = [...records].sort(
+    (a, b) => (LANG_RANK[localeToLang(a.language)] ?? 9) - (LANG_RANK[localeToLang(b.language)] ?? 9),
+  );
+
+  for (const rec of sorted) {
+    const title = normalizeSpace(rec.title || '');
     if (!title || title.length < 3) continue;
 
-    const location = listing.location || HQ.city;
-    // Prefer the city-token canton; otherwise infer from the location string;
-    // otherwise fall back to the HQ canton (recon: SG).
-    const canton =
-      listing.cantonHint || inferSwissTargetCanton(location) || HQ.canton;
+    // jobId = "<internalId>-<locale>" (e.g. "1799-de_DE"). Dedup physical jobs
+    // across locale variants on the internal id.
+    const internalId = String(rec.jobId || '').split('-')[0] || String(rec.jobId || '');
+    if (!internalId) continue;
+    if (seenInternal.has(internalId)) continue;
 
-    // No server-side description available (JS-rendered detail pages, no
-    // JSON-LD) → derive a minimal description from the title. The AI pipeline
-    // enriches/localizes downstream.
-    const descriptionText = stripHtml(listing.description || '');
-    const description = descriptionText || `${title} — Geberit, ${location}`;
-    const publicUrl = listing.url || CAREER_URL;
+    // The OData filter `addresses/any(a: a/country eq 'Schweiz')` matches records
+    // with *at least one* Swiss address — the Swiss one is not guaranteed to be
+    // at index [0] (multi-site records can list a foreign plant first). Pick the
+    // Swiss address explicitly so location/postalCode/streetAddress never come
+    // from a foreign address and mis-tag a foreign job as CH/SG.
+    const addrs = Array.isArray(rec.addresses) ? rec.addresses : [];
+    const addr = addrs.find((a) => a && a.country === 'Schweiz') || addrs[0] || {};
+    const location = normalizeSpace(addr.city || HQ.city);
+    const canton = inferSwissTargetCanton(`${location} ${addr.postalCode || ''}`) || HQ.canton;
 
-    const sourceLang = detectLang(description || title, 'de');
+    const description = htmlToMarkdown(rec.description || '');
+    if (!description || description.length < 30) continue; // skip empties → never synthesise
+
+    seenInternal.add(internalId);
+
+    const sourceLang = localeToLang(rec.language);
+    // Keep the ORIGINAL slug formula (`${title} geberit ch`) so already-indexed
+    // Geberit URLs do not change — the source swap (sitemap → RMK API) must not
+    // re-slug the employer slice (reviewer 🔴 on #1857: a re-slug would orphan the
+    // previousSlugs redirect bridge and 404 the old `…-geberit-ch` URLs).
     const jobSlug = slugify(`${title} geberit ch`);
-    // Stable id from the SuccessFactors jobReqId when present, else URL hash.
-    const idSeed = listing.jobReqId || publicUrl;
-    const urlHash = createHash('sha1').update(String(idSeed)).digest('hex').slice(0, 12);
-    const id = `geberit-${urlHash}`;
-    if (seenIds.has(id)) continue;
-    seenIds.add(id);
+    const id = `geberit-${internalId}`;
 
-    // Normalize <lastmod> (YYYY-MM-DD or ISO) to a date-only string.
-    const postedDate = (listing.postedAt || '').slice(0, 10) ||
+    const publicUrl =
+      rec.link && /^https?:\/\//i.test(rec.link)
+        ? rec.link
+        : `https://${ATS_HOST}/job-invite/${internalId}/?locale=${rec.language || 'de_DE'}`;
+
+    const postedDate = String(rec.datePosted || '').slice(0, 10) ||
       new Date().toISOString().split('T')[0];
+
+    const empType = rec?.jobType?.code === 'Full-Time'
+      ? 'FULL_TIME'
+      : rec?.jobType?.code === 'Part-Time'
+        ? 'PART_TIME'
+        : detectEmploymentType(`${title} ${rec?.jobType?.label || ''}`);
 
     const job = {
       // ── Required fields ──
@@ -314,12 +319,13 @@ export async function fetchAllGeberitJobs() {
 
       // ── Recommended fields ──
       addressLocality: location,
-      postalCode: location === HQ.city ? HQ.postalCode : undefined,
+      postalCode: addr.postalCode || (location === HQ.city ? HQ.postalCode : undefined),
+      streetAddress: addr.street || undefined,
       addressRegion: canton === HQ.canton ? HQ.addressRegion : undefined,
       addressCountry: 'CH',
       country: 'CH',
       category: detectCategory(title),
-      employmentType: detectEmploymentType(title),
+      employmentType: empType,
       experienceLevel: detectExperienceLevel(title),
       sector: SECTOR,
       currency: 'CHF',

--- a/scripts/update-geberit-jobs.mjs
+++ b/scripts/update-geberit-jobs.mjs
@@ -27,6 +27,16 @@ runStandardCrawlerPipeline({
   isCompanyJob: isGeberitJob,
   isTrustedDomain,
   defaultSourceLang: 'de',
+  // Merge-continuity bridge across the source swap (sitemap → RMK API). The job
+  // `url` changes namespace — old sitemap URL `…/job/…/<jobReqId 10-digit>/`
+  // (extractStableJobId → `num:<id>`) vs new API `…/job-invite/<internalId 4-digit>/`
+  // (no ≥6-digit token → full-URL key). The default url-based matchKey would never
+  // match → every existing Geberit job dropped/expired and re-emitted fresh, losing
+  // previousSlugs / titleByLocale / descriptionByLocale / firstSeenAt (reviewer 🔴).
+  // The slug is the ONLY identity stable across both sources (both use
+  // `slugify("<title> geberit ch")`), so match on it to preserve SEO equity +
+  // translations. (No previousSlugs churn: the slug itself is unchanged.)
+  matchKey: (job) => String(job?.slug || '').trim().toLowerCase(),
 }).catch((err) => {
   console.error(`❌ Geberit crawler failed: ${err?.message || err}`);
   process.exit(1);

--- a/tests/dedicated-crawler-common.test.ts
+++ b/tests/dedicated-crawler-common.test.ts
@@ -504,4 +504,66 @@ describe('mergePreserveLocaleData URL matching', () => {
     expect(merged[0].slugByLocale.de).toBe('produktmanager-example-zurich');
     expect(merged[0].slugByLocale.fr).toBe('chef-de-produit-example-zurich');
   });
+
+  it('skips the bridge for a colliding (non-injective) matchKey instead of cross-contaminating', async () => {
+    const { mergePreserveLocaleData } = await import('../scripts/lib/dedicated-crawler-common.mjs');
+
+    // Two distinct postings that collapse to the same slug bridge key (the
+    // Geberit `…-geberit-ch` + `…-geberit-ch-2` collision pair). Each fresh job
+    // emits the RAW slug (no `-2` suffix) → identical matchKey. Binding both to
+    // one old record would duplicate `old.id` and cross-contaminate previousSlugs
+    // / translations onto the wrong job. The guard must let them re-index fresh.
+    const existing = [
+      {
+        id: 'geberit-OLD-A',
+        slug: 'talent-for-sales-management-a-100-geberit-ch',
+        url: 'https://jobs.geberit.com/job/X/1363323000/',
+        title: 'Talent for Sales Management a 100%',
+        previousSlugs: ['old-bridge-a'],
+        titleByLocale: { it: 'Talento Vendite A', de: 'Verkaufstalent A' },
+      },
+      {
+        id: 'geberit-OLD-B',
+        slug: 'talent-for-sales-management-a-100-geberit-ch-2',
+        url: 'https://jobs.geberit.com/job/Y/1363323999/',
+        title: 'Talent for Sales Management a 100%',
+        previousSlugs: ['old-bridge-b'],
+        titleByLocale: { it: 'Talento Vendite B', de: 'Verkaufstalent B' },
+      },
+    ];
+
+    const fresh = [
+      {
+        id: 'geberit-1799',
+        slug: 'talent-for-sales-management-a-100-geberit-ch',
+        url: 'https://jobs.geberit.com/job-invite/1799/',
+        title: 'Talent for Sales Management a 100%',
+        titleByLocale: { de: 'Verkaufstalent A' },
+        sourceLang: 'de',
+      },
+      {
+        id: 'geberit-1800',
+        slug: 'talent-for-sales-management-a-100-geberit-ch',
+        url: 'https://jobs.geberit.com/job-invite/1800/',
+        title: 'Talent for Sales Management a 100%',
+        titleByLocale: { de: 'Verkaufstalent B' },
+        sourceLang: 'de',
+      },
+    ];
+
+    const matchKey = (job: { slug?: string }) =>
+      String(job?.slug || '').trim().toLowerCase();
+    const merged = mergePreserveLocaleData(existing, fresh, { matchKey });
+
+    // Both fresh kept with their own distinct ids — no inheritance from a single
+    // old, no duplicate id, no cross-contaminated previousSlugs.
+    expect(merged).toHaveLength(2);
+    const ids = merged.map((j) => j.id).sort();
+    expect(ids).toEqual(['geberit-1799', 'geberit-1800']);
+    expect(new Set(ids).size).toBe(2);
+    for (const job of merged) {
+      expect(job.previousSlugs ?? []).not.toContain('old-bridge-a');
+      expect(job.previousSlugs ?? []).not.toContain('old-bridge-b');
+    }
+  });
 });

--- a/tests/geberit-crawler.test.ts
+++ b/tests/geberit-crawler.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   GEBERIT_KEY,
   GEBERIT_COMPANY_NAME,
   isGeberitJob,
   isTrustedDomain,
+  fetchAllGeberitJobs,
+  // @ts-expect-error mjs module, no type declarations
 } from '../scripts/lib/geberit-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -125,5 +127,72 @@ describe('Geberit crawler parser', () => {
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
     });
+  });
+});
+
+describe('fetchAllGeberitJobs (SuccessFactors RMK search API)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function apiRecord(over = {}) {
+    return {
+      jobId: '1799-de_DE',
+      language: 'de_DE',
+      title: 'Strategic Project Buyer (a) 100%',
+      datePosted: '2026-05-16T12:35:05Z',
+      jobType: { code: 'Full-Time', label: 'Vollzeit' },
+      link: 'https://jobs.geberit.com/job-invite/1799/?locale=de_DE',
+      description:
+        "<div><h2><b>HAUPTAUFGABEN</b></h2><p>Als Strategic Project Buyer bist du zuständig für die Bereitstellung der Einkaufsartikel.</p><ul><li>Evaluierung von Lieferanten im Rahmen der Entwicklungsprojekte</li><li>Verantwortung für die rechtzeitige Bereitstellung der Beschaffungsartikel</li></ul></div>",
+      addresses: [{ city: 'Rapperswil-Jona', postalCode: '8645', country: 'Schweiz', street: 'Schachenstrasse 77', countryCode: 'CHE' }],
+      ...over,
+    };
+  }
+
+  function mockSearch(records) {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ '@odata.count': records.length, value: records }),
+    });
+  }
+
+  it('maps an RMK record to a job with the REAL (non-synthetic) description', async () => {
+    mockSearch([apiRecord()]);
+    const jobs = await fetchAllGeberitJobs();
+    expect(jobs).toHaveLength(1);
+    const j = jobs[0];
+    expect(j.title).toBe('Strategic Project Buyer (a) 100%');
+    expect(j.location).toBe('Rapperswil-Jona');
+    expect(j.postalCode).toBe('8645');
+    expect(j.employmentType).toBe('FULL_TIME');
+    // real description: markdown with heading + bullets, NOT a "<title> — Geberit" stub
+    expect(j.description.length).toBeGreaterThan(100);
+    expect(j.description).toMatch(/HAUPTAUFGABEN/);
+    expect(j.description).toMatch(/(^|\n)- /);
+    expect(j.description).not.toMatch(/— Geberit,/);
+    expect(j.descriptionByLocale.de).toBe(j.description);
+  });
+
+  it('dedups locale variants of the same physical job by internal id', async () => {
+    mockSearch([
+      apiRecord({ jobId: '1799-de_DE', language: 'de_DE' }),
+      apiRecord({ jobId: '1799-en_US', language: 'en_US', title: 'Strategic Project Buyer (a) 100%' }),
+    ]);
+    const jobs = await fetchAllGeberitJobs();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].id).toBe('geberit-1799');
+    expect(jobs[0].sourceLang).toBe('de'); // de preferred over en
+  });
+
+  it('skips records whose description is empty instead of synthesising one', async () => {
+    mockSearch([apiRecord({ description: '' })]);
+    const jobs = await fetchAllGeberitJobs();
+    expect(jobs).toHaveLength(0);
+  });
+
+  it('returns [] (no throw) when the API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+    const jobs = await fetchAllGeberitJobs();
+    expect(jobs).toEqual([]);
   });
 });


### PR DESCRIPTION
## Implementato
- Riscritto `scripts/lib/geberit-job-parser.mjs`: sorgente = API JSON pubblica SuccessFactors CSB (`POST https://production.api.recruiting-solutions.org/search`, key pubblicabile `pk_`, filtro OData `addresses/any(a: a/country eq 'Schweiz')`). Ritorna record COMPLETI (descrizione HTML ricca, indirizzo strutturato, datePosted, jobType). Niente headless, niente detail-fetch per job.
- Dedup varianti per-lingua per internal id (de>it>fr>en); `htmlToMarkdown` preserva heading/bullet (no flag audit "no structured content"); skip descrizioni vuote (mai sintetizzare).
- Indirizzo svizzero scelto **esplicitamente** (un record multi-sito può listare un plant estero a [0]) → niente mis-tag canton.
- **Slug invariato** (`${title} geberit ch`) → URL già indicizzati non cambiano (no perdita bridge previousSlugs).
- **Merge-continuity bridge** via `matchKey:(job)=>job.slug` in `update-geberit-jobs.mjs` (ponte slug attraverso il source swap sitemap→API).
- **Collision-safe merge bridge** in `mergePreserveLocaleData` (`dedicated-crawler-common.mjs`): un matchKey non-iniettivo (chiave condivisa da >1 existing O >1 fresh) salta il bridge per il set ambiguo e lascia ri-indicizzare con id fresh distinti, invece di mappare più job sullo stesso old record (no id duplicato, no cross-contaminazione previousSlugs/translations). Fix nel modulo condiviso → protegge ogni crawler matchKey (geberit/pwc/spitex/vitrea) by-construction.
- +5 unit test (mapping descrizione reale, dedup, skip-empty, API-error→[], collision-pair re-index).

## Verifica (live, da CI)
Crawler eseguito dal runner GitHub: 40 record CH → **20 job deduplicati**, descrizioni 1374–2096 char con bullet, **0% boilerplate** post-localizzazione. Test geberit 22/22 verdi.

## Non implementato (ancora)
- **Ricreazione branch**: questo PR sostituisce #1857 (stesso diff 2-file), il cui branch era CI-wedged dopo un rebase di 122 commit (i workflow `pull_request` non si innescavano più → reviewer non poteva girare). Diff identico + fix indirizzo-svizzero del 🔴-fixer.
- **Revert-risk (id re-key)**: l'`id` passa a `geberit-${internalId}` (l'API non espone il vecchio jobReqId sitemap). Interno; URL=slug stabile. Se dopo deploy un URL Geberit 404a → revert.
- en/de/fr/it diversi dal source li riempie translate-pending (campi source-locale only).

Closes #1721
Supersedes #1857

---
**Update (reviewer 🔴 risolto — merge-continuity, non solo slug):** il finding era corretto — non churna la slug-formula ma la **merge-key URL** (`extractStableJobId`): vecchio `/job/…/<jobReqId 10-cifre>/` → `num:…` vs nuovo `/job-invite/<internalId 4-cifre>/` → full-URL key, namespace disgiunti → i 20 job esistenti verrebbero droppati+expired e ri-emessi, perdendo previousSlugs/translations/firstSeenAt. **Fix**: `matchKey:(job)=>job.slug` nel runner (`update-geberit-jobs.mjs`) — lo slug `slugify('<title> geberit ch')` è l'unica identità stabile su entrambe le sorgenti (il vecchio crawler usava la stessa formula), quindi il merge fa da ponte old↔new e preserva SEO equity + traduzioni. Lo slug resta invariato (nessun previousSlugs churn). Ritiro quindi il claim "id cosmetico": la regressione era sul campo `url`, ora neutralizzata dal matchKey-slug.

---
**Update 2 (merge-continuity — re-index dichiarato come costo accettato):** verificato che gli slug committati in `data/jobs/by-crawler/geberit.json` sono **già localizzati/riconciliati** (es. `…-geberit-rapperswil-jona` tradotto IT; altri `…-geberit-ch`), NON il raw `slugify('<title> geberit ch')`. Quindi — come nota il reviewer — non esiste una chiave perfetta tra i namespace disgiunti (sitemap jobReqId 10-cifre ↔ API internalId 4-cifre). Il `matchKey:(job)=>job.slug` aggiunto fa da **ponte best-effort** (preserva i job il cui slug raw è sopravvissuto), ma una migrazione 1:1 completa richiederebbe una mappa jobReqId→internalId costruita per title-match (heavy, sproporzionata).

**Decisione (alternativa esplicita del reviewer): re-index accettato come costo una-tantum.** Razionale: è UNA employer-slice (~20 job) di un crawler che falliva al **100% boilerplate** (descrizioni sintetiche finte) — i vecchi URL erano già a bassa qualità/in deindex; i nuovi hanno contenuto REALE (2000+ char). I record droppati diventano **expired soft-landing (non 404)** (`crawler-template.mjs:655-658`), quindi nessun hard-break. Trade-off: perdita di SEO-equity su ≤20 pagine sintetiche vs guadagno di 20 pagine con contenuto reale indicizzabile. **Revert-trigger:** se post-deploy il traffico Geberit cala materialmente o emergono canonical duplicati → revert + migrazione 1:1.
Ritiro il claim precedente "preserva SEO equity": è un re-index parziale dichiarato, non una continuità piena.

---
**Update 3 (reviewer 🔴 round 2 risolto — collision-safe matchKey):** il finding `update-geberit-jobs.mjs:L39` era corretto — uno slug-matchKey **non-iniettivo** collide quando due posting distinti producono lo stesso `slugify('<title> geberit ch')` (il dataset committato ha già la coppia `…-geberit-ch` + `…-geberit-ch-2`, titolo identico). Il parser emette lo slug RAW → due fresh con stesso titolo condividono la chiave → `existingByKey` (Map) li mappava entrambi sullo stesso old record (id duplicato + previousSlugs/translations cross-contaminate sul job sbagliato, l'altro old expired). **Fix (commit `4b5373a`, `mergePreserveLocaleData`):** pre-scan che marca `ambiguousKeys` = ogni chiave condivisa da >1 existing **o** >1 fresh; per quel set il bridge è saltato (`old=null`) e i job ri-indicizzano con la loro identità fresh distinta (`geberit-<internalId>`). Correttezza > equity-preservation su un set intrinsecamente ambiguo. Fix nel **modulo condiviso** → class-complete: protegge ogni crawler matchKey (geberit/pwc/spitex/vitrea) by-construction; per i matchKey iniettivi (url-based legacy) il comportamento è byte-identico (la guardia non scatta). +1 unit test riproduce la collision-pair.
