### PR TITLE
feat(worker): over-cap failover — fail-open routes + apex-keyed edge cache

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -83,6 +83,14 @@ jobs:
           workingDirectory: infra/cloudflare-worker
           command: deploy
 
+      # Over-cap failover config. wrangler re-syncs routes from wrangler.toml,
+      # which cannot express request_limit_fail_open — a deploy can silently
+      # reset routes to the fail-closed default (error 1027 on everything over
+      # the free 100k/day cap). Re-assert fail-open + the zone cache rule that
+      # lets the CDN serve the Worker's apex-keyed cached pages while bypassed.
+      - name: Assert fail-open routes + failover cache rule
+        run: node scripts/cf-locale-failover-setup.mjs
+
       # Live regression check: status AND timing. The previous 30s tee-deadlock
       # (introduced in #1791, fixed in #1814) returned HTTP 200 but stalled
       # ~30s, so a status-only smoke missed it entirely and it sat live ~1 day.

--- a/docs/LOCALE-SHARD-CLOUDFLARE-RUNBOOK.md
+++ b/docs/LOCALE-SHARD-CLOUDFLARE-RUNBOOK.md
@@ -84,9 +84,19 @@ Apex già su Cloudflare (orange-cloud, default dopo l'NS move). Poi:
 ```bash
 cd infra/cloudflare-worker
 npx wrangler deploy        # oppure: incolla locale-router.js nella dashboard Workers
+node ../../scripts/cf-locale-failover-setup.mjs   # SEMPRE dopo il deploy (vedi sotto)
 ```
 
-(la route `frontaliereticino.ch/*` è in `wrangler.toml`).
+(le route sono SCOPED ai soli path locale in `wrangler.toml` — mai regredire a
+`frontaliereticino.ch/*`, conterebbe anche l'IT nel cap 100k/day.)
+
+Il deploy può resettare il flag `request_limit_fail_open` delle route al
+default fail-closed (errore 1027 su tutto sopra il cap free 100k/day).
+`scripts/cf-locale-failover-setup.mjs` (idempotente, CF_API_TOKEN da
+`load-rc-env.mjs`) ri-asserisce fail-open + la cache rule di zona che permette
+alla CDN di servire le pagine apex-keyed scritte dal Worker (`cache.put`)
+quando il Worker è bypassato. `deploy-worker.yml` lo esegue da solo; solo i
+deploy manuali devono ricordarselo.
 
 ### 2.5 Verifica end-to-end (URL pubblico = identico, servito dallo shard)
 ```bash

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -18,21 +18,31 @@
  * GitHub Pages match the shard repo's custom domain.
  *
  * Caching: shard responses are cached by Cloudflare's NATIVE edge cache via
- * `cf: { cacheEverything, cacheTtl }` on the origin fetch — NOT the Workers
- * Cache API. The previous caches.default/last-known-good machinery was removed
- * (2026-06-11) because:
- *   1. Every Cache API operation is logged in zone analytics as a synthetic
- *      `requestSource: edgeWorkerCacheAPI` row — cache.match() MISSes show up
- *      as edgeResponseStatus **504** (~124k/day) and cache.put()s as 204
- *      (~80k/day). Those phantom 504s (User-Agent empty, protocol UNK,
- *      originResponseDurationMs 0, zero eyeball rows) were repeatedly misread
- *      as a real outage ("26% of requests fail") and burned three PR cycles
- *      (#1791 regression, #1814 hotfix, #1830 no-op). Real client traffic on
- *      the shards is clean: zero eyeball 504s/day, ~50×503/day zone-wide.
- *   2. caches.default is per-colo and ephemeral; cf-native caching is tiered
- *      (upper-tier colos shared), so origin fetches drop further.
- * Do NOT reintroduce caches.default here without filtering monitoring to
- * `requestSource: "eyeball"` first (scripts/lib/cf-analytics.mjs does this).
+ * `cf: { cacheEverything, cacheTtl }` on the origin fetch — keyed on the
+ * origin-{loc} URL, tiered across colos.
+ *
+ * Cache API (caches.default): WRITE-ONLY, apex-keyed, for the over-cap
+ * failover. A routed Worker is invoked on EVERY matching request — the edge
+ * cache cannot answer in front of it ("Workers run before the cache"), so on
+ * the free plan nothing here reduces the 100k/day invocation count. What CAN
+ * answer without the Worker is the fail-open path: when the daily cap is
+ * exceeded and the route is configured `request_limit_fail_open: true`,
+ * Cloudflare bypasses the Worker and the request flows through the normal CDN
+ * pipeline. cache.put() below stores every shard 200 under its PUBLIC apex
+ * URL so that pipeline finds it (a zone Cache Rule marks /en|/de|/fr eligible
+ * for cache lookup — see scripts/cf-locale-failover-setup.mjs, re-run by
+ * deploy-worker.yml after every deploy). Net effect over cap: warm pages keep
+ * serving 200 (stale ≤24h) instead of error 1027 on everything.
+ *
+ * Cache API history (#1791/#1814/#1830/#1842): every Cache API op is logged in
+ * zone analytics as a synthetic `requestSource: edgeWorkerCacheAPI` row —
+ * cache.match() MISSes as phantom 504s (misread as an outage, three PR cycles
+ * burned) and cache.put()s as 204s. This Worker therefore: (a) never calls
+ * cache.match() — the request path stays single-consumer, no tee (the put copy
+ * is built from an explicit arrayBuffer, not a stream tee, so the #1791
+ * deadlock class is structurally impossible); (b) tolerates the returning 204
+ * put rows because monitoring filters `requestSource: "eyeball"` since #1842
+ * (scripts/lib/cf-analytics.mjs). Keep both properties when touching this.
  *
  * Asset/data/og refs in shard HTML are CDN-absolute (since #1665), so those
  * requests bypass this Worker entirely.
@@ -62,17 +72,26 @@ const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 //   land 2-3×/day — 2h bounds that staleness window.
 //
 //   CACHE_MAX_AGE (6h) — `max-age`/`s-maxage` stamped on the 200 responses we
-//   return: CF caches the WORKER response eyeball-side, so repeat hits don't
-//   re-invoke the Worker at all — the lever that keeps frontaliere-locale-router
-//   under the free-tier 100k/day cap (measured 2026-06-11: ~144k inv/day,
-//   ~63% AI crawlers re-crawling; raised 2h→6h to absorb more repeats).
+//   return. CORRECTION (2026-06-11, vs the #1865 rationale): this does NOT
+//   stop re-invocations — a routed Worker runs before the cache on every
+//   request (confirmed by docs and by flat invocation counts post-#1865). It
+//   still helps browsers and downstream proxies hold the page, and it is the
+//   Cache-Control crawl-side fetchers see.
 //   Safe against stale-HTML 404s: superseded CDN asset hashes are retained
 //   GRACE_DAYS=7 (prune-cdn-assets.mjs), far longer than this TTL, so HTML
 //   served up to 6h stale still resolves every referenced /assets hash. Live
 //   job data is client-fetched fresh from the CDN at runtime (not baked into
 //   this cached HTML), so a 6h-stale SEO shell is fine.
+//
+//   FAIL_OPEN_CACHE_TTL (24h) — s-maxage on the apex-keyed cache.put copy:
+//   how long the fail-open path can serve a page once the Worker is over the
+//   daily cap. 24h spans the worst case (cap hit right after a put, reset at
+//   00:00 UTC). Staleness is bounded by the same CDN-asset GRACE_DAYS=7
+//   argument above. Browser max-age stays short (300) so humans who get a
+//   fail-open HIT revalidate soon after.
 const CACHE_MAX_AGE = 21600; // 6 h — eyeball-side (Worker response)
 const ORIGIN_CACHE_TTL = 7200; // 2 h — origin-fetch side (cf.cacheTtl)
+const FAIL_OPEN_CACHE_TTL = 86400; // 24 h — apex-keyed Cache API copy (fail-open failover)
 
 // Cache-Control stamped on shard 404s. ~51k/day of shard traffic is crawlers
 // re-fetching DEAD job URLs from memory (old canton/slug variants, pruned
@@ -129,7 +148,7 @@ async function fetchOriginWithRetry(upstream, request, cfOpts) {
 }
 
 export default {
-  async fetch(request) {
+  async fetch(request, _env, ctx) {
     const url = new URL(request.url);
     const match = url.pathname.match(LOCALE_RE);
 
@@ -194,15 +213,31 @@ export default {
       }
     }
 
-    // Stamp Cache-Control on successful GETs so browsers and Cloudflare's
-    // eyeball-side edge cache (s-maxage) can serve repeats without re-invoking
-    // the Worker. Single body consumer — no buffering or stream tee needed
-    // (the multi-consumer tee deadlock of #1791/#1814 is structurally gone
-    // along with the Cache API writes that required it).
+    // Stamp Cache-Control on successful GETs, and store an APEX-KEYED copy in
+    // the colo cache for the over-cap fail-open path (see header comment).
+    // The body is buffered ONCE via arrayBuffer and reused for both responses
+    // — deliberately no resp.clone()/stream tee, which is the #1791/#1814
+    // deadlock class (a slow eyeball consumer stalls the cache.put branch).
+    // Shard pages are small HTML (~50-200KB), well within Worker memory.
+    // Query-string URLs are skipped: not canonical, would only pollute the
+    // per-colo cache (e.g. deploy-worker.yml's ?dwcheck= cache-busters).
     if (request.method === 'GET' && resp.status === 200) {
       const headers = new Headers(resp.headers);
       headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`);
-      return new Response(resp.body, { status: 200, statusText: resp.statusText, headers });
+      const body = await resp.arrayBuffer();
+      if (ctx && !url.search) {
+        const cacheHeaders = new Headers(resp.headers);
+        cacheHeaders.set('Cache-Control', `public, max-age=300, s-maxage=${FAIL_OPEN_CACHE_TTL}`);
+        ctx.waitUntil(
+          caches.default
+            .put(
+              new Request(url.toString(), { method: 'GET' }),
+              new Response(body, { status: 200, statusText: resp.statusText, headers: cacheHeaders }),
+            )
+            .catch(() => {}), // best-effort failover warmup — never fail the live response
+        );
+      }
+      return new Response(body, { status: 200, statusText: resp.statusText, headers });
     }
 
     // Stamp Cache-Control on 404s too: see NOT_FOUND_CACHE_CONTROL. GitHub

--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -6,6 +6,12 @@ name = "frontaliere-locale-router"
 main = "locale-router.js"
 compatibility_date = "2026-01-01"
 
+# NOTE: routes carry a `request_limit_fail_open` flag that wrangler.toml CANNOT
+# express (API-only). It MUST be true (over the free 100k/day cap the Worker is
+# bypassed and the CDN cache serves apex-keyed pages instead of error 1027) —
+# scripts/cf-locale-failover-setup.mjs asserts it after every deploy
+# (deploy-worker.yml runs it; after a MANUAL `npx wrangler deploy`, run it too).
+#
 # Scope the Worker to ONLY the locale paths so the IT bulk (~95% of traffic) is
 # pure Cloudflare passthrough with no Worker subrequest. Three patterns per
 # locale cover the subtree, the bare homepage path, and the .html homepage file

--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * cf-locale-failover-setup.mjs — idempotent Cloudflare config for the
+ * locale-router over-cap failover. Run after EVERY `wrangler deploy` of the
+ * Worker (deploy-worker.yml wires it in; manual deploys: run it yourself —
+ * see LOCALE-SHARD-CLOUDFLARE-RUNBOOK §2.4).
+ *
+ * What it asserts (and why it must re-run post-deploy):
+ *
+ * 1. ROUTES — `request_limit_fail_open: true` on every route bound to the
+ *    `frontaliere-locale-router` script. Over the free 100k invocations/day
+ *    cap, fail-open BYPASSES the Worker (the request flows through the normal
+ *    CDN pipeline: WAF → cache → DNS origin) instead of answering Cloudflare
+ *    error 1027 on every /en /de /fr request (the fail-closed default).
+ *    `wrangler deploy` re-syncs routes from wrangler.toml, which cannot
+ *    express this flag — so a deploy can silently reset it to fail closed.
+ *
+ * 2. CACHE RULE — zone rule (marker: RULE_DESCRIPTION) that makes the apex
+ *    locale paths ELIGIBLE for cache. Extensionless HTML is not looked up in
+ *    the edge cache by default, so without this rule the apex-keyed entries
+ *    the Worker writes via cache.put() are unreachable exactly on the
+ *    fail-open path they exist for. Write-side TTLs on this rule only matter
+ *    for fail-open MISSes that reach the main GitHub Pages origin (which has
+ *    no /en|/de|/fr content since the locale sharding): 3xx-5xx → value 0
+ *    (no-cache) so a transient fail-open 404 never outlives the cap window.
+ *    Scoped to http.host == apex so the Worker's own subrequests to the
+ *    origin-{loc} shard hosts (already cached via cf.cacheEverything) are
+ *    untouched.
+ *
+ * Auth: CF_API_TOKEN — needs Zone→Workers Routes:Edit (already required by
+ * deploy-worker.yml) + Zone→Zone Settings/Cache Rules:Edit + zone read.
+ * Locally:
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/load-rc-env.mjs)" && node scripts/cf-locale-failover-setup.mjs
+ *
+ * Flags: --dry-run (report drift, change nothing) · --routes-only · --rule-only
+ * Exit: 0 = converged (or already in shape), 1 = API/auth error.
+ */
+
+const REST_BASE = 'https://api.cloudflare.com/client/v4';
+const ZONE_NAME = process.env.CF_ZONE_NAME || 'frontaliereticino.ch';
+const WORKER_SCRIPT = 'frontaliere-locale-router';
+const RULE_DESCRIPTION = 'locale-shard-failover-cache (managed by scripts/cf-locale-failover-setup.mjs)';
+const CACHE_PHASE = 'http_request_cache_settings';
+
+const RULE_EXPRESSION =
+  '(http.host eq "frontaliereticino.ch" and ' +
+  '(starts_with(http.request.uri.path, "/en/") or ' +
+  'starts_with(http.request.uri.path, "/de/") or ' +
+  'starts_with(http.request.uri.path, "/fr/") or ' +
+  'http.request.uri.path in {"/en" "/de" "/fr" "/en.html" "/de.html" "/fr.html"}))';
+
+const RULE_ACTION_PARAMETERS = {
+  cache: true,
+  edge_ttl: {
+    mode: 'override_origin',
+    default: 7200, // 2h — only reachable by fail-open 2xx from the apex origin (none today)
+    status_code_ttl: [{ status_code_range: { from: 300, to: 599 }, value: 0 }], // 0 = no-cache
+  },
+  browser_ttl: { mode: 'respect_origin' },
+};
+
+const args = new Set(process.argv.slice(2));
+const DRY_RUN = args.has('--dry-run');
+const DO_ROUTES = !args.has('--rule-only');
+const DO_RULE = !args.has('--routes-only');
+
+function bail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+const token = process.env.CF_API_TOKEN;
+if (!token) bail('CF_API_TOKEN not set (hydrate via scripts/load-rc-env.mjs).');
+
+async function cf(method, path, body) {
+  const res = await fetch(`${REST_BASE}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+async function resolveZoneId() {
+  if (process.env.CF_ZONE_ID) return process.env.CF_ZONE_ID;
+  const { json } = await cf('GET', `/zones?name=${encodeURIComponent(ZONE_NAME)}`);
+  if (!json?.success || !json.result?.length) bail(`Cannot resolve zone id for ${ZONE_NAME} (token scope?).`);
+  return json.result[0].id;
+}
+
+async function assertFailOpenRoutes(zoneId) {
+  const { json } = await cf('GET', `/zones/${zoneId}/workers/routes`);
+  if (!json?.success) bail(`Cannot list worker routes: ${JSON.stringify(json?.errors)}`);
+  const routes = json.result.filter((r) => r.script === WORKER_SCRIPT);
+  if (!routes.length) bail(`No routes found for script ${WORKER_SCRIPT} — deploy the Worker first.`);
+
+  let flipped = 0;
+  for (const r of routes) {
+    if (r.request_limit_fail_open === true) continue;
+    console.log(`route ${r.pattern}: fail_open=false → true${DRY_RUN ? ' (dry-run)' : ''}`);
+    if (DRY_RUN) { flipped++; continue; }
+    const { json: put } = await cf('PUT', `/zones/${zoneId}/workers/routes/${r.id}`, {
+      pattern: r.pattern,
+      script: r.script,
+      request_limit_fail_open: true,
+    });
+    if (!put?.success) bail(`PUT route ${r.pattern} failed: ${JSON.stringify(put?.errors)}`);
+    flipped++;
+  }
+  console.log(`routes: ${routes.length} on ${WORKER_SCRIPT}, ${flipped} flipped to fail-open, ${routes.length - flipped} already ok`);
+}
+
+async function assertCacheRule(zoneId) {
+  // The entrypoint ruleset may not exist yet on a zone with no cache rules —
+  // GET then answers 404; PUT below creates it.
+  const { status, json } = await cf('GET', `/zones/${zoneId}/rulesets/phases/${CACHE_PHASE}/entrypoint`);
+  if (status !== 404 && !json?.success) bail(`Cannot read ${CACHE_PHASE} entrypoint: ${JSON.stringify(json?.errors)}`);
+  const existing = status === 404 ? [] : (json.result.rules || []);
+
+  const desired = {
+    description: RULE_DESCRIPTION,
+    expression: RULE_EXPRESSION,
+    action: 'set_cache_settings',
+    action_parameters: RULE_ACTION_PARAMETERS,
+    enabled: true,
+  };
+
+  const idx = existing.findIndex((r) => r.description === RULE_DESCRIPTION);
+  const current = idx >= 0 ? existing[idx] : null;
+  const inShape =
+    current &&
+    current.enabled !== false &&
+    current.expression === RULE_EXPRESSION &&
+    JSON.stringify(current.action_parameters) === JSON.stringify(RULE_ACTION_PARAMETERS);
+
+  if (inShape) {
+    console.log('cache rule: already in shape');
+    return;
+  }
+  console.log(`cache rule: ${current ? 'drift — updating' : 'missing — creating'}${DRY_RUN ? ' (dry-run)' : ''}`);
+  if (DRY_RUN) return;
+
+  // Preserve every foreign rule untouched; replace/append only ours. Strip
+  // read-only per-rule fields (id, ref, version, last_updated) — the PUT
+  // replaces the rule list wholesale and rejects unknown/read-only keys.
+  const keep = existing
+    .filter((_, i) => i !== idx)
+    .map(({ id, ref, version, last_updated, ...rest }) => rest);
+  const rules = idx >= 0 ? [...keep.slice(0, idx), desired, ...keep.slice(idx)] : [...keep, desired];
+
+  const { json: put } = await cf('PUT', `/zones/${zoneId}/rulesets/phases/${CACHE_PHASE}/entrypoint`, {
+    rules,
+  });
+  if (!put?.success) bail(`PUT ${CACHE_PHASE} entrypoint failed: ${JSON.stringify(put?.errors)}`);
+  console.log('cache rule: applied');
+}
+
+const zoneId = await resolveZoneId();
+if (DO_ROUTES) await assertFailOpenRoutes(zoneId);
+if (DO_RULE) await assertCacheRule(zoneId);
+console.log(DRY_RUN ? 'dry-run complete' : 'failover config converged');

--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -112,6 +112,26 @@ async function assertFailOpenRoutes(zoneId) {
   console.log(`routes: ${routes.length} on ${WORKER_SCRIPT}, ${flipped} flipped to fail-open, ${routes.length - flipped} already ok`);
 }
 
+// Field-by-field canonical check instead of a JSON.stringify equality:
+// Cloudflare re-emits action_parameters with normalized key order and
+// API-added defaults, so a stringify comparison would flag drift on every
+// run and re-PUT the entrypoint forever (never converging to "in shape").
+// Extra/unknown fields CF adds are tolerated; only OUR contract is checked.
+function ruleInShape(current) {
+  if (!current || current.enabled === false) return false;
+  if (current.expression !== RULE_EXPRESSION) return false;
+  const p = current.action_parameters || {};
+  if (p.cache !== true) return false;
+  const e = p.edge_ttl || {};
+  if (e.mode !== 'override_origin' || e.default !== 7200) return false;
+  const noCache3xx5xx = (e.status_code_ttl || []).find(
+    (s) => s.status_code_range && s.status_code_range.from === 300 && s.status_code_range.to === 599,
+  );
+  if (!noCache3xx5xx || noCache3xx5xx.value !== 0) return false;
+  if ((p.browser_ttl || {}).mode !== 'respect_origin') return false;
+  return true;
+}
+
 async function assertCacheRule(zoneId) {
   // The entrypoint ruleset may not exist yet on a zone with no cache rules —
   // GET then answers 404; PUT below creates it.
@@ -129,13 +149,8 @@ async function assertCacheRule(zoneId) {
 
   const idx = existing.findIndex((r) => r.description === RULE_DESCRIPTION);
   const current = idx >= 0 ? existing[idx] : null;
-  const inShape =
-    current &&
-    current.enabled !== false &&
-    current.expression === RULE_EXPRESSION &&
-    JSON.stringify(current.action_parameters) === JSON.stringify(RULE_ACTION_PARAMETERS);
 
-  if (inShape) {
+  if (ruleInShape(current)) {
     console.log('cache rule: already in shape');
     return;
   }


### PR DESCRIPTION
## Implementato

> Config CF applicata live 2026-06-11 (9/9 route fail-open verificate via GET API, cache rule creata, convergenza idempotente provata al secondo run — vedi commento con evidenza).

- **`infra/cloudflare-worker/locale-router.js`**: il branch 200 ora bufferizza il body (`arrayBuffer`, niente stream tee — classe deadlock #1791 strutturalmente impossibile) e scrive in `ctx.waitUntil` una copia **apex-keyed** in `caches.default` con `s-maxage=86400` (`FAIL_OPEN_CACHE_TTL`). Write-only: nessuna `cache.match()` nel request path → in analytics tornano solo le righe sintetiche 204 (put), MAI i 504 fantasma; il monitoring è già eyeball-filtered da #1842. Skip per URL con query string (non canonici, eviterebbe pollution da `?dwcheck=`). Firma handler `fetch(request, _env, ctx)`.
- **Correzione commento #1865**: la claim "s-maxage evita la re-invocazione del Worker" era errata — un Worker su route gira PRIMA della cache a ogni richiesta (docs CF + conteggi invocazioni piatti post-#1865: 13:00=8.5k, 14:00=13.8k dopo il deploy 12:02). Header e commenti riscritti per riflettere la meccanica reale: sotto cap la cache riduce solo i fetch origin; sopra cap (fail-open) è l'unica cosa che risponde.
- **`scripts/cf-locale-failover-setup.mjs`** (nuovo, idempotente, `--dry-run`/`--routes-only`/`--rule-only`): (1) flippa `request_limit_fail_open=true` su tutte le route del Worker — oggi sono TUTTE fail-closed (verificato via API), cioè sopra il cap 100k/day Cloudflare risponderebbe errore 1027 su tutto en/de/fr; (2) upserta la Cache Rule di zona (marker nel description) che rende i path locale apex *eligible for cache* — senza, l'HTML senza estensione non viene nemmeno cercato in cache e le entry apex-keyed sarebbero irraggiungibili proprio nel percorso fail-open; 3xx-5xx fail-open mai cachati (un 404 transiente dall'origin main non sopravvive alla finestra di cap). Dry-run eseguito contro la zona reale: 9 route da flippare, rule mancante, zero errori auth.
- **`.github/workflows/deploy-worker.yml`**: step post-deploy che esegue lo script — `wrangler deploy` risincronizza le route da `wrangler.toml`, che NON può esprimere il flag, quindi un deploy può resettare silenziosamente a fail-closed.
- **`wrangler.toml` + runbook §2.4**: documentato il flag API-only e il comando post-deploy manuale; corretto il riferimento stale alla route `frontaliereticino.ch/*` (le route sono scoped dal 2026-06-10).

Supersedes #1867 — il rischio "enforcement inizia → downtime funnel" è mitigato dal failover; la decisione Workers Paid resta aperta solo se l'hit-rate sopra cap si rivelasse insufficiente.

## Non implementato (ancora)

- **Verifica live del percorso fail-open**: non testabile pre-enforcement (oggi a 123k/100k Cloudflare non bypassa ancora il Worker — nessun 1027 osservato, cap soft). Claim non validabile pre-merge → trigger di osservazione/revert TRACCIATO in #1888 (include i due adversarial check della review): al primo giorno di enforcement osservato, se le pagine shard calde NON servono 200 dalla cache (tutto 404/1027), aprire issue e rivedere il design (candidate: cache rule read-path, chiave Cache API vs pipeline). Verificabile indirettamente post-merge: righe 204 `edgeWorkerCacheAPI` in zone analytics = i put avvengono.
- **Hit-rate sopra cap parziale by-design**: la copia apex è per-colo e i crawler battono long-tail unica (~43% delle hit bot odierne è già 404) — sopra cap le pagine calde servono 200 stale, la coda fredda resta 404 da GitHub Pages apex. Alternativa strutturale (shard su sottodomini orange-cloud, zero Worker) = migrazione URL completa, fuori scope e SEO-pesante.
- **Tuning TTL cache rule** (default 2h sui 2xx fail-open dall'origin apex): oggi quel ramo non ha contenuti (locali strippati dal main artifact) — rivedere solo se si fa rollback dello sharding.
