### PR TITLE
fix(ci): canton-aware slug-registry migration in deploy build + GSC sync (gate:seo-source red, run 27352608929)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,6 +308,18 @@ jobs:
       - name: Mine all job slugs for comprehensive 404 coverage
         run: node scripts/mine-all-job-slugs.mjs
 
+      - name: Canton-aware migration of slug registry
+        # mine-all-job-slugs writes every entry under the legacy TI section
+        # (LOCALE_PREFIXES hardcode). For non-TI jobs that stale path leaks
+        # into dist as soft-landing canonical/hreflang (selfUrl reads the
+        # registry verbatim) → gate:seo-source red post-merge (run
+        # 27352608929: VD job canonicalised to /cerca-lavoro-ticino/).
+        # tests.yml + post-deploy-validate-dist.yml already run this script
+        # before vitest; without it HERE the build consumes the unmigrated
+        # registry while the gates test a migrated copy — gate and artifact
+        # must see the same data.
+        run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+
       # Cluster-pages cache REMOVED (2026-05-09).
       # Build instrumentation on 5 recent deploys showed:
       #   - cache MISS (4/5 runs, jobs.json invalidates daily via cron):

--- a/.github/workflows/sync-gsc-orphans.yml
+++ b/.github/workflows/sync-gsc-orphans.yml
@@ -90,6 +90,16 @@ jobs:
         if: ${{ inputs.dry_run != true }}
         run: node scripts/mine-all-job-slugs.mjs
 
+      - name: Canton-aware migration of slug registry (keep registry invariant pre-commit)
+        if: ${{ inputs.dry_run != true }}
+        # mine-all-job-slugs writes every entry under the legacy TI section.
+        # Rewrite entries attributable to live non-TI jobs to their canton-aware
+        # paths BEFORE committing to main (bot-direct-to-main gate, same
+        # rationale as the prune step below): an unmigrated registry bakes
+        # TI canonicals into dist soft-landings and turns gate:seo-source red
+        # post-merge (run 27352608929). Needs data/jobs.json (assembled above).
+        run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+
       - name: Prune non-resolving 404-compat paths (keep test invariant green)
         if: ${{ inputs.dry_run != true }}
         # Gate bot-direct-to-main against the committed-snapshot invariant


### PR DESCRIPTION
## Implementato

- **`deploy.yml`**: nuovo step `Canton-aware migration of slug registry` subito dopo `mine-all-job-slugs.mjs` e prima della build — il build plugin ora legge `data/all-known-job-slugs.json` con path canton-aware per i job non-TI, quindi i soft-landing non incorporano più canonical/hreflang `/cerca-lavoro-ticino/` per job di altri cantoni (root cause del rosso `gate:seo-source` su run 27352608929: job VD `devops-ingegnere-…-vaudoise-assurances-lausanne` con canonical TI).
- **`sync-gsc-orphans.yml`**: stesso step di migrazione prima del commit bot-direct-to-main (stessa logica del gate `prune-404-compat-paths` già presente) — il registry su `main` resta canton-aware invece di accumulare entry TI scritte da `mine-all-job-slugs.mjs`.

Difetto sistemico chiuso: `tests.yml` e `post-deploy-validate-dist.yml` giravano già la migrazione nel proprio checkout prima di vitest, quindi la PR-CI testava una copia migrata mentre il build di deploy consumava il registry NON migrato → il rosso emergeva solo post-merge in validate-dist. Ora gate e artifact vedono gli stessi dati.

Verifica: la pagina live `/cerca-lavoro-ticino/devops-engineer-h-f-x-80-a-100-vaudoise-ch/` mostra oggi il canonical TI errato (soft-landing da registry stale); con la migrazione in build il path `tracking[slug]` coincide con i path attivi canton-aware → il soft-landing viene skippato (`activeJobDirs`) e l'URL TI resta coperto dal mirror legacy full-content con canonical canton-aware (già emesso oggi, vedi `/cerca-lavoro-ticino/ingenieur-ingenieure-devops-h-f-x-80-a-100-vaudoise-ch/`).

## Non implementato (ancora)

- **Commit one-time del registry migrato** (~166k righe): ridondante — il prossimo run di `sync-gsc-orphans` committerà il file migrato con il proprio gate, e il build di deploy migra comunque prima dell'emit. Evitato churn da 332k righe in questa PR.
- **`scripts/mine-all-job-slugs.mjs` resta TI-writer** (sibling check: condivide `LOCALE_PREFIXES`): renderlo canton-aware duplicherebbe il resolver cantonale già incapsulato in `migrate-all-known-job-slugs-canton-aware.mjs`; entrambe le pipeline che lo eseguono ora applicano la migrazione subito dopo. Stesso ragionamento per `scripts/sync-gsc-orphans.mjs` (scrive URL TI osservati in GSC, legittimi come input).
- **`scripts/audit-cannibalization.mjs` / `audit-content-duplicates.mjs` / `audit-dist-multi.mjs` / `discover-404s-via-inspection.mjs`** (altri candidati sibling): usano `LOCALE_PREFIXES` solo in lettura/parsing, non scrivono il registry — non è lo stesso antipattern.
- **Cross-locale bridge emit TI-only** (`jobsSeoPagesPlugin.ts` ~11452 e ~11029 usano `sectionByLocale[baseLocale]` come *path di scrittura*): classe diversa (copertura sezione legacy, non pollution di canonical — il canonical dentro l'HTML riusato è già canton-aware). Eventuale estensione all'emit canton-aware = follow-up separato, tocca il page-set.

Test plan:
- [x] `tests/seo/cathedral-previous-slug-canton.test.ts` verde in locale (source-guard; behavioural skippa senza dist)
- [x] YAML lint dei due workflow
- [ ] Post-merge: deploy su `main` verde con `gate:seo-source` PASS (verificabile solo sul prossimo run di deploy)
- [ ] Post-merge: run live `sync-gsc-orphans.yml` committa registry migrato senza rosso

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1887
