### PR TITLE
fix(cwv): eliminate field-CLS drivers on job listing + detail pages

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -5946,8 +5946,11 @@ const JobBoard: React.FC<JobBoardProps> = ({
  ).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 220);
  // True while the slim index gave us no description but the per-job detail
  // fetch hasn't settled yet (cache miss on first render, or in flight).
- // Drives an equal-height teaser skeleton so the late-arriving text doesn't
- // push the auth gate down (~92px, measured 0.054 CLS per detail view).
+ // Switches the always-mounted teaser box from static bars to a pulsing
+ // skeleton; the box itself never mounts/unmounts after first paint (its
+ // height is fixed by the svh clamp), so neither the text arriving late
+ // (~92px push, 0.054 CLS/view) nor a detail that settles WITHOUT a
+ // description (reverse ~80px collapse) can shift the auth gate.
  const teaserPending = !descriptionPreview
  && (enrichmentLoading || (!resolvedJobDetail.has(selectedJob.id) && !jobDetailCache.has(selectedJob.id)));
  const gateCompanySlug = buildCompanySearchSlug(selectedJob.company, selectedJob.companyKey, locale);
@@ -6027,29 +6030,42 @@ const JobBoard: React.FC<JobBoardProps> = ({
  {/* Readable description teaser — shows first ~200 chars to create information
  scent and an "open loop" that motivates signup. Fades out at the bottom.
  On very short viewports (landscape phones) we hide it entirely so the gate CTAs
- land above the fold; on normal phones the clamp still bounds it to ≤80px.
+ land above the fold.
  CLS guards: (a) svh, NOT dvh — dvh re-resolves every time the mobile URL bar
- collapses/expands, oscillating maxHeight 0↔80px and shifting the gate and
+ collapses/expands, oscillating the box 0↔80px and shifting the gate and
  everything below it on every scroll direction change; svh is static.
- (b) While the slim index has no description yet but the per-job detail
- enrichment is in flight, render an equal-height skeleton so the gate isn't
- pushed down ~92px when the teaser text arrives (measured 0.054/view). */}
- {(descriptionPreview || teaserPending) && (
- <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ maxHeight: 'clamp(0px, calc(100svh - 540px), 80px)' }}>
+ (b) The box is ALWAYS mounted at a FIXED clamp height (height, not
+ maxHeight, so short text / skeleton / settled-empty all produce the exact
+ same container height frame-to-frame). Contents only cross-fade between
+ text, a pulsing skeleton (detail fetch pending) and static redacted bars
+ (detail settled with no description — keeping the reserve, never
+ collapsing). This kills both the ~92px gate push when the late teaser
+ text arrived (0.054 CLS/view) and the reverse collapse for
+ description-less jobs. */}
+ <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ height: 'clamp(0px, calc(100svh - 540px), 80px)' }}>
  {descriptionPreview ? (
  <p className="px-3 py-2 text-sm text-body leading-relaxed sm:py-3">
  {descriptionPreview}...
  </p>
- ) : (
+ ) : teaserPending ? (
  <div className="px-3 py-2 sm:py-3 space-y-2" aria-hidden="true">
  <SkeletonLine height="h-4" />
  <SkeletonLine height="h-4" />
  <SkeletonLine height="h-4" width="w-3/4" />
  </div>
+ ) : (
+ // Detail settled with no description: static redacted-style bars (no
+ // pulse — nothing is loading) keep the reserved height instead of
+ // collapsing the box, which would yank the gate up by the same ~80px
+ // the late-teaser push used to move it down.
+ <div className="px-3 py-2 sm:py-3 space-y-2 opacity-60" aria-hidden="true">
+ <div className="bg-surface-raised rounded-lg w-full h-4" />
+ <div className="bg-surface-raised rounded-lg w-full h-4" />
+ <div className="bg-surface-raised rounded-lg w-3/4 h-4" />
+ </div>
  )}
  <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-surface to-transparent" />
  </div>
- )}
 
  {/* Auth gate — embedded inline for all viewports (no extra click needed) */}
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -92,7 +92,7 @@ import { buildJobTitleWithLocation, buildTitleWithBrand } from '@/build-plugins/
 import { useNavigation } from '@/services/NavigationContext';
 import AdSenseBanner from '@/components/shared/AdSenseBanner';
 import Callout from '@/components/shared/Callout';
-import { SkeletonJobDetail } from '@/components/shared/Skeletons';
+import { SkeletonJobDetail, SkeletonJobBoard, SkeletonLine } from '@/components/shared/Skeletons';
 import { useExpiredJob, hasSeededExpiredData, seededJobMatchesSlug } from '@/hooks/useExpiredJob';
 import { useKillSwitches } from '@/hooks/useKillSwitches';
 import JobExpiredView from '@/components/community/JobExpiredView';
@@ -4994,18 +4994,17 @@ const JobBoard: React.FC<JobBoardProps> = ({
  return <SkeletonJobDetail />;
  }
  return (
- // Reserve ~viewport height during the async job fetch. Search/filter URLs
- // (e.g. /cerca-lavoro-ticino/concorsi-…, ricerca-*) render this JobBoard
- // WITHOUT staticOverlay, so App.tsx display:none's the full-height static
- // SEO body on hydration. A short `py-20` spinner then collapsed the page to
- // ~116px and it jumped back to N×72px when jobs resolved → CLS p75 0.87
- // (jobs_filter_concorsi). min-h-[80vh] (same reserve convention as
- // SkeletonComparator) keeps height stable through static→spinner→list so
- // the lab CLS drops <0.25 and the audit-cls-live lab_post_fix override clears
- // the gate without waiting weeks for CrUX to roll forward.
- <div className="flex items-center justify-center min-h-[80vh]">
- <Loader2 className="w-9 h-9 text-accent animate-spin" />
- </div>
+ // Reserve realistic page height during the async job fetch. Search/filter
+ // URLs (e.g. /cerca-lavoro-ticino/concorsi-…, ricerca-*) render this
+ // JobBoard WITHOUT staticOverlay, so App.tsx display:none's the full-height
+ // static SEO body on hydration. The previous centered spinner reserved only
+ // 80vh: the footer sat just inside the viewport during the fetch, then got
+ // pushed below the fold when the ~10-card list resolved → 0.064 CLS on
+ // every landing (field p75 0.58 on /cerca-lavoro-ticino/). The skeleton
+ // list approximates the final list height (header + search bar + 10×112px
+ // cards, min-h-[80vh] floor inside SkeletonJobBoard) so the footer never
+ // enters the viewport mid-load.
+ <SkeletonJobBoard />
  );
  }
  }
@@ -5945,6 +5944,12 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const descriptionPreview = String(
  selectedJob.descriptionByLocale?.[locale] ?? selectedJob.description ?? ''
  ).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 220);
+ // True while the slim index gave us no description but the per-job detail
+ // fetch hasn't settled yet (cache miss on first render, or in flight).
+ // Drives an equal-height teaser skeleton so the late-arriving text doesn't
+ // push the auth gate down (~92px, measured 0.054 CLS per detail view).
+ const teaserPending = !descriptionPreview
+ && (enrichmentLoading || (!resolvedJobDetail.has(selectedJob.id) && !jobDetailCache.has(selectedJob.id)));
  const gateCompanySlug = buildCompanySearchSlug(selectedJob.company, selectedJob.companyKey, locale);
  const gateCompanyHref = buildPath({ activeTab: 'job-board' as any, jobSlug: gateCompanySlug }, locale);
  const gateLocationSlug = jobLocation ? buildLocationSearchSlug(selectedJob.addressLocality || jobLocation, locale) : '';
@@ -6022,12 +6027,26 @@ const JobBoard: React.FC<JobBoardProps> = ({
  {/* Readable description teaser — shows first ~200 chars to create information
  scent and an "open loop" that motivates signup. Fades out at the bottom.
  On very short viewports (landscape phones) we hide it entirely so the gate CTAs
- land above the fold; on normal phones the clamp still bounds it to ≤80px. */}
- {descriptionPreview && (
- <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ maxHeight: 'clamp(0px, calc(100dvh - 540px), 80px)' }}>
+ land above the fold; on normal phones the clamp still bounds it to ≤80px.
+ CLS guards: (a) svh, NOT dvh — dvh re-resolves every time the mobile URL bar
+ collapses/expands, oscillating maxHeight 0↔80px and shifting the gate and
+ everything below it on every scroll direction change; svh is static.
+ (b) While the slim index has no description yet but the per-job detail
+ enrichment is in flight, render an equal-height skeleton so the gate isn't
+ pushed down ~92px when the teaser text arrives (measured 0.054/view). */}
+ {(descriptionPreview || teaserPending) && (
+ <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ maxHeight: 'clamp(0px, calc(100svh - 540px), 80px)' }}>
+ {descriptionPreview ? (
  <p className="px-3 py-2 text-sm text-body leading-relaxed sm:py-3">
  {descriptionPreview}...
  </p>
+ ) : (
+ <div className="px-3 py-2 sm:py-3 space-y-2" aria-hidden="true">
+ <SkeletonLine height="h-4" />
+ <SkeletonLine height="h-4" />
+ <SkeletonLine height="h-4" width="w-3/4" />
+ </div>
+ )}
  <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-surface to-transparent" />
  </div>
  )}
@@ -7519,8 +7538,10 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  </div>
 
- {/* Mobile: infinite scroll sentinel */}
- <div className="min-h-[48px] sm:hidden">
+ {/* Mobile: infinite scroll sentinel. min-h matches the spinner row's real
+ height (py-6 + h-5 = 68px) so the container doesn't shrink by 20px when
+ hasMoreMobileJobs flips false at end-of-list (in-viewport layout shift). */}
+ <div className="min-h-[68px] sm:hidden">
  {hasMoreMobileJobs && (
  <div ref={jobSentinelRef} className="flex justify-center items-center py-6">
  <div className="h-5 w-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />

--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -711,9 +711,11 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
 
  {/* Readable description teaser — shows first ~200 chars to create information
  scent and an "open loop" that motivates signup. Fades out at the bottom.
- Hidden on landscape phones (≤540dvh) so the gate CTAs land above the fold. */}
+ Hidden on landscape phones (≤540px viewport) so the gate CTAs land above the fold.
+ svh, NOT dvh: dvh re-resolves on mobile URL-bar collapse/expand, oscillating
+ maxHeight 0↔80px and shifting the gate below on every scroll direction change. */}
  {descriptionPreview && (
- <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ maxHeight: 'clamp(0px, calc(100dvh - 540px), 80px)' }}>
+ <div className="relative mt-3 w-full overflow-hidden rounded-stripe [@media(max-height:540px)]:hidden" style={{ maxHeight: 'clamp(0px, calc(100svh - 540px), 80px)' }}>
  <p className="px-3 py-2 text-sm text-body leading-relaxed sm:py-3">
  {descriptionPreview}...
  </p>

--- a/components/shared/Skeletons.tsx
+++ b/components/shared/Skeletons.tsx
@@ -343,9 +343,12 @@ export const SkeletonJobBoard: React.FC = () => (
  <SkeletonLine width="flex-1" height="h-10" className="rounded-xl" />
  <SkeletonLine width="w-24" height="h-10" className="rounded-xl" />
  </div>
- {/* Job cards */}
- {Array.from({ length: 6 }).map((_, i) => (
- <div key={i} className={`${pulse} h-[72px] rounded-xl`} />
+ {/* Job cards — 10 per page, ~112px each: total skeleton height tracks the
+ final list so the footer doesn't jump into/out of the viewport when the
+ async job fetch resolves (field CLS p75 0.58 on /cerca-lavoro-ticino/,
+ footer collapse measured at 0.064/landing). */}
+ {Array.from({ length: 10 }).map((_, i) => (
+ <div key={i} className={`${pulse} h-28 rounded-xl`} />
  ))}
  </div>
 );

--- a/tests/bridge-orphan-flicker-guard.test.ts
+++ b/tests/bridge-orphan-flicker-guard.test.ts
@@ -77,20 +77,21 @@ describe('Bridge orphan-flicker guard (2026-05-22 regression)', () => {
       );
     });
 
-    it('places the cold-load skeleton INSIDE the jobsLoading block, before the generic spinner', () => {
+    it('places the cold-load skeleton INSIDE the jobsLoading block, before the generic listing fallback', () => {
       // Reachability is the whole point: `if (jobsLoading)` returns in every
-      // branch, so the guard must precede the generic spinner AND sit after the
-      // `if (jobsLoading) {` opener — otherwise it is dead code.
+      // branch, so the guard must precede the generic listing fallback (the
+      // <SkeletonJobBoard /> that replaced the old min-h-[80vh] spinner) AND
+      // sit after the `if (jobsLoading) {` opener — otherwise it is dead code.
       const jobsLoadingIdx = jobBoardSrc.indexOf('if (jobsLoading) {');
       const coldGuardIdx = jobBoardSrc.indexOf('!searchSlugFilter && !seeded');
-      const spinnerIdx = jobBoardSrc.indexOf("min-h-[80vh]");
+      const listingFallbackIdx = jobBoardSrc.indexOf('<SkeletonJobBoard />');
       const orphanIdx = jobBoardSrc.indexOf('<JobOrphanView');
       expect(jobsLoadingIdx).toBeGreaterThan(0);
       expect(coldGuardIdx).toBeGreaterThan(0);
-      expect(spinnerIdx).toBeGreaterThan(0);
+      expect(listingFallbackIdx).toBeGreaterThan(0);
       expect(orphanIdx).toBeGreaterThan(0);
       expect(coldGuardIdx).toBeGreaterThan(jobsLoadingIdx);
-      expect(coldGuardIdx).toBeLessThan(spinnerIdx);
+      expect(coldGuardIdx).toBeLessThan(listingFallbackIdx);
       expect(coldGuardIdx).toBeLessThan(orphanIdx);
     });
 

--- a/tests/job-detail-seed.test.ts
+++ b/tests/job-detail-seed.test.ts
@@ -339,7 +339,9 @@ describe('Per-job detail seed (window.__JOB_SEED__)', () => {
       // so a seeded active detail falls through to the real render.
       expect(src).toMatch(/const seededActiveDetail = selectedJob && initialJobSlug/);
       const guardIdx = src.indexOf('if (!seededActiveDetail) {');
-      const loaderIdx = src.indexOf('<Loader2 className="w-9 h-9 text-accent animate-spin" />');
+      // Generic listing fallback (<SkeletonJobBoard /> — replaced the old
+      // centered Loader2 spinner) must stay gated behind !seededActiveDetail.
+      const loaderIdx = src.indexOf('<SkeletonJobBoard />');
       expect(guardIdx).toBeGreaterThan(0);
       expect(loaderIdx).toBeGreaterThan(guardIdx);
     });


### PR DESCRIPTION
## Implementato

Dati field CrUX (28gg): CLS p75 **0.58** su `/cerca-lavoro-ticino/` (45% utenti in fascia poor), **0.38** origin mobile, **0.53** desktop — vs lab 0.06-0.16. Attribution con browser reale (PerformanceObserver layout-shift, mobile viewport, scroll + navigazione SPA): ~0.09 per atterraggio + ~0.10 per ogni navigazione SPA. Quattro driver in-repo, tutti fixati qui:

- **Listing loading swap** (`JobBoard.tsx` branch `jobsLoading`): lo spinner centrato `min-h-[80vh]` lasciava il footer dentro il viewport durante il fetch; all'arrivo della lista (~10 card) il footer veniva sbalzato sotto il fold → **0.064 misurato a ogni atterraggio**. Sostituito con `<SkeletonJobBoard />`, portato a 10 card × 112px (≈ altezza lista finale) in `Skeletons.tsx`.
- **Teaser descrizione job-detail in ritardo**: lo slim index non ha `description`; l'enrichment per-job (~15KB) la aggiunge dopo → il teaser appariva tardi spingendo `#job-auth-gate` giù di 92px (**0.054 misurato per vista**, più shift a catena sul form email interno). Ora `teaserPending` (cache detail + `enrichmentLoading`, decidibile al primo render) riserva un box skeleton di pari altezza.
- **`100dvh` nel clamp del teaser**: `dvh` si ri-risolve a ogni collapse/expand della barra URL mobile → maxHeight oscilla 0↔80px e shifta gate + contenuto sottostante a ogni cambio direzione di scroll (75% traffico mobile; invisibile in lab). → `100svh` (stabile). Stesso fix nel sibling `JobExpiredView.tsx` (stesso costrutto, sweep AGENTS.md #6 via `check-sibling-patterns.mjs`).
- **Sentinel infinite-scroll mobile**: riservava 48px ma la riga spinner è 68px → shrink di 20px in viewport a fine lista. `min-h` allineato a 68px.
- Test marker aggiornati (`bridge-orphan-flicker-guard`, `job-detail-seed`): ancoravano l'ordering sul vecchio spinner Loader2/`min-h-[80vh]`; ora ancorano su `<SkeletonJobBoard />` con le stesse garanzie di ordine/reachability.

Test: suite completa verde in locale (63k test; 6 file FAIL iniziali erano mancanza dei data-prep script del gate CI — verdi dopo `assemble-jobs-dataset` + `migrate-all-known-job-slugs`; `mine-topic-candidates` skip env-dependent, estraneo al diff).

## Non implementato (ancora)

- **INP mobile p75 316ms**: dominato dal tap sul dialog consenso Google Funding Choices (prima interazione obbligata per utenti EEA/CH, 168ms su desktop potente) e da task di hydration React (232ms desktop). Leve in-repo limitate e non chirurgiche (split del chunk JobBoard ~7500 righe); il dialog/anchor ads sono territorio Google/revenue (AGENTS.md #7) — follow-up separato se il CLS fix non basta a riportare INP sotto 200ms (meno layout-thrash nei frame di interazione).
- **Home CLS 0.18 (needs-improvement, non poor)**: blocco `div.md:hidden` che appare post-hydration (0.19 lab). Fuori scope: template diverso (calculator), pattern di fix identico applicabile in follow-up.
- **AdSenseBanner collapse animato su no-fill** (`maxHeight→0` con transition): micro-shift se avviene in viewport; macchina a stati delicata (FRO-299), non toccata qui.
- **Shift interni al dialog Funding Choices** (0.018/atterraggio): markup servito da Google, non controllabile.
- **Claim CLS field**: non validabile pre-merge (CrUX rolla su 28gg). Trigger di verifica: lab `audit-cls-live` post-deploy + trend CrUX p75 listing nelle prossime 2-4 settimane; se il p75 listing non scende sotto 0.25 → ulteriore attribution round, nessun revert necessario (le modifiche sono pure reserve-space, non riducono contenuto/ads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)