### PR TITLE
fix(audit): recognize externalized redirect stubs in spa-bundle-injection (REDIRECT_STUB marker, run 27371848400)

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -15,6 +15,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { BOT_UA_PATTERNS } from '../services/botPatterns';
+import { REDIRECT_STUB_MARKER } from './shared/redirectStubMarker';
 
 export const BUILD_ID = String(Date.now());
 
@@ -194,7 +195,7 @@ export function buildCanonicalBridgePage(options: {
 
  return `<!DOCTYPE html>
 <html lang="${lang}">
- <head>
+ <head>${REDIRECT_STUB_MARKER}
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>${title}</title>

--- a/build-plugins/shared/redirectStubMarker.mjs
+++ b/build-plugins/shared/redirectStubMarker.mjs
@@ -1,0 +1,23 @@
+// redirectStubMarker.mjs
+//
+// Canonical audit:spa-bundle-injection skip marker — the SINGLE source of
+// truth for the `<!--REDIRECT_STUB-->` literal. Every page built by
+// `buildCanonicalBridgePage` (legacy redirects, cathedral migration stubs,
+// canton orphan redirects, jobsSeoPages self-healing tombstones) embeds this
+// comment so scripts/audit-spa-bundle-injection.mjs knows the missing SPA
+// bundle is intentional: the page is a deliberate noindex redirect bridge.
+//
+// Why a marker instead of the old `location.replace(` sniff: the redirect
+// behaviour was externalised into `/assets/early-boot-{hash}.js`
+// (constants.ts EARLY_BOOT_SCRIPT, ~150 B/page saved across ~822k pages),
+// so the literal no longer appears inline and the audit's REDIRECT_SHAPE_RX
+// stopped recognising these stubs (run 27371848400: +32k "missing bundle"
+// false regressions, all "Pagina spostata" stubs at legacy-TI job paths).
+//
+// Uppercase so it survives HTML minification (same lesson as
+// EJP_STRIPPED_MARKER: lowercase comments get stripped). Plain `.mjs` so the
+// Node-run auditor (scripts/, no tsx loader) can import it directly; the TS
+// build-plugins import it via ./redirectStubMarker.ts which re-exports this
+// value. The literal must stay byte-identical everywhere — define it ONCE,
+// here.
+export const REDIRECT_STUB_MARKER = '<!--REDIRECT_STUB-->';

--- a/build-plugins/shared/redirectStubMarker.ts
+++ b/build-plugins/shared/redirectStubMarker.ts
@@ -1,0 +1,10 @@
+// redirectStubMarker.ts
+//
+// TS-facing re-export of the canonical audit:spa-bundle-injection skip
+// marker. The literal lives once in ./redirectStubMarker.mjs (plain JS so
+// the Node-run auditor in scripts/ can import it without a tsx loader on
+// CI Node 20/22). TS build-plugins import REDIRECT_STUB_MARKER from here
+// (extensionless, resolved by Vite / moduleResolution:bundler). The marker
+// VALUE must stay byte-identical everywhere — see redirectStubMarker.mjs
+// for the single definition.
+export { REDIRECT_STUB_MARKER } from './redirectStubMarker.mjs';

--- a/scripts/audit-spa-bundle-injection.mjs
+++ b/scripts/audit-spa-bundle-injection.mjs
@@ -58,6 +58,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { REDIRECT_STUB_MARKER } from '../build-plugins/shared/redirectStubMarker.mjs';
+
 const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 const DIST = path.resolve(process.cwd(), 'dist');
 const BASELINE_PATH = path.resolve(ROOT, 'data', 'spa-bundle-injection-baseline.json');
@@ -165,7 +167,12 @@ for (const { absPath, relDir } of walkIndexHtml(DIST)) {
   // shape is a deliberate redirect (no SPA needed by design). Counted
   // separately so a regression that adds redirects in unexpected places
   // is still visible in the breakdown.
-  if (REDIRECT_SHAPE_RX.test(html)) {
+  // Deliberate redirect stubs built by buildCanonicalBridgePage embed the
+  // REDIRECT_STUB_MARKER comment: their redirect behaviour lives in the
+  // externalised /assets/early-boot-{hash}.js, so the inline
+  // location.replace( sniff above never matches them (run 27371848400:
+  // +32k false "missing bundle" regressions, all "Pagina spostata" stubs).
+  if (REDIRECT_SHAPE_RX.test(html) || html.includes(REDIRECT_STUB_MARKER)) {
     skippedRedirect++;
     continue;
   }


### PR DESCRIPTION
## Implementato

- **`build-plugins/shared/redirectStubMarker.{mjs,ts}`**: nuovo marker canonico `<!--REDIRECT_STUB-->` (stesso pattern di `ejpMarker`: literal definito UNA volta in `.mjs` per l'auditor Node, re-export `.ts` per i build-plugin; uppercase+underscore → preservato dalla mask `<!--[A-Z][A-Z0-9_]*-->` di `htmlMinify`).
- **`build-plugins/constants.ts` → `buildCanonicalBridgePage`**: embedda il marker in `<head>` — TUTTI i caller (legacyRedirectsPlugin incl. cathedral migration map, cantonOrphanRedirectsPlugin, self-healing tombstones di jobsSeoPagesPlugin) lo ereditano senza altri touch.
- **`scripts/audit-spa-bundle-injection.mjs`**: skip (conteggiato in `skippedRedirect`) delle pagine col marker, accanto al check `REDIRECT_SHAPE_RX` esistente.

**Root cause** (run 27371848400, `audit:spa-bundle-injection` rosso con +32.084 sopra baseline 10.800): il carve-out dell'audit per i redirect-stub deliberati cerca `location.replace(` *inline*, ma quel codice è stato esternalizzato in `/assets/early-boot-{hash}.js` → gli stub "Pagina spostata" non matchano più. Il volume (+32k) viene dalla cathedral migration map di legacyRedirectsPlugin che fan-outa sugli slug per-locale appena tradotti in massa (#1714); l'audit non girava da stamattina perché `gate:seo-source` bloccava validate-dist più a monte (fix in #1889). Gli stub sono pagine noindex senza contenuto la cui UNICA funzione è il redirect: per design non devono spedire il bundle SPA — il fix ripristina il carve-out già previsto dall'audit, non abbassa la soglia.

Verifica detector stale sui sibling che usano `location.replace(`: `validate-sitemap.mjs` skippa già su noindex prima del check (non affetto); `canary-article-content.mjs` cerca self-redirect-loop inline (scopo diverso); `analyze-write-collisions.mjs` è diagnostica non-gate; `schedule-fb-jobs-daily.mjs` è uno `String.replace` su variabile `location` (unrelated).

## Non implementato (ancora)

- **Rebaseline di `data/spa-bundle-injection-baseline.json`**: non necessario per sbloccare (pass = `current <= baseline`; col fix il count scende sotto 10.800). Il prossimo run loggherà "Progress! run rebaseline" — follow-up opzionale.
- **Gate di merito sui 32k stub della cathedral map**: gli stub per slug tradotti *oggi* coprono URL legacy-TI mai esistiti/indicizzati (lo slug è nato con la traduzione) = dist bloat potenziale (~64k file). Valutare evidence-gate GSC sull'emit della cathedral map = scope separato (tocca il page-set, moratorium-sensitive), non incluso in questo fix chirurgico del detector.
- **Claim non validabile pre-merge**: l'effetto sull'audit è osservabile solo nel `validate-dist` post-merge (l'audit gira solo su dist completo). Trigger di revert: se il prossimo deploy mostra `audit:spa-bundle-injection` ancora rosso con violations ≠ stub-class → revert e ri-analisi.

Test plan:
- [x] `node --check` audit script + import runtime del marker `.mjs`
- [x] `tests/noindex-builders.test.ts` + `tests/spa-bundle-resolver.test.ts` verdi in locale
- [x] Marker conforme alla mask placeholder del minifier (`<!--[A-Z][A-Z0-9_]*-->`)
- [ ] Post-merge: `audit:spa-bundle-injection` PASS nel prossimo validate-dist (osservazione su main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
