### PR TITLE
feat(adsense): above-the-fold display slot on drive-by SEO landings

### DIFF
--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -41,6 +41,7 @@ import {
   BASE_URL,
   MIN_INDEXABLE_WORDS,
   countHtmlBodyWords,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags } from './shared/hreflang';
@@ -1712,6 +1713,7 @@ function renderLeafPage(inp: LeafInputs): string {
   ${weeklyHtml}
   ${infoHtml}
   ${alternativeRoutesHtml}
+  ${DRIVEBY_AD_SNIPPET}
   ${faqHtml}
   ${renderCommuterContextProse(locale, crossingDisplay, region, bestHour, worstHour)}
   ${renderLeafLivePlanningProse(

--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -15,6 +15,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { BOT_UA_PATTERNS } from '../services/botPatterns';
+import { AD_SLOTS } from '../services/adsenseSlots';
 import { REDIRECT_STUB_MARKER } from './shared/redirectStubMarker';
 
 export const BUILD_ID = String(Date.now());
@@ -401,6 +402,23 @@ const BOT_PATTERNS_LITERAL = JSON.stringify(BOT_UA_PATTERNS);
 export const ADSENSE_LOADER_CONTENT = `(function(){var ua=(navigator.userAgent||'').toLowerCase();if(!ua||navigator.webdriver===true)return;var P=${BOT_PATTERNS_LITERAL};for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return;if(ua.indexOf('chrome')>=0&&!('chrome' in window))return;if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){var L=navigator.languages;if(L&&L.length===0)return;if(navigator.plugins&&navigator.plugins.length===0)return;if(typeof navigator.permissions==='undefined')return;}var loaded=false;function loadScript(){if(loaded)return;loaded=true;var s=document.createElement('script');s.async=true;s.crossOrigin='anonymous';s.src='${ADSENSE_SCRIPT_SRC}';s.setAttribute('data-overlays','bottom');s.setAttribute('data-ad-frequency-hint','60s');s.onload=function(){var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');for(var i=0;i<slots.length;i++){try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}}};document.head.appendChild(s);}function observe(){var EV=['scroll','touchstart','pointerdown','keydown','mousemove'];for(var e=0;e<EV.length;e++)document.addEventListener(EV[e],loadScript,{once:true,passive:true,capture:true});var slots=document.querySelectorAll('ins.adsbygoogle');if(!('IntersectionObserver' in window)||slots.length===0){(window.requestIdleCallback||function(cb){return setTimeout(cb,800);})(loadScript,{timeout:1500});return;}var io=new IntersectionObserver(function(entries){for(var i=0;i<entries.length;i++){if(entries[i].isIntersecting){io.disconnect();loadScript();return;}}},{rootMargin:'200px 0px'});for(var j=0;j<slots.length;j++)io.observe(slots[j]);(window.requestIdleCallback||function(cb){return setTimeout(cb,1200);})(loadScript,{timeout:2500});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',observe,{once:true});}else{observe();}})();`;
 export const ADSENSE_LOADER_FILENAME = `adsense-loader-${shortContentHash(ADSENSE_LOADER_CONTENT)}.js`;
 export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/${ADSENSE_LOADER_FILENAME}"></script>`;
+
+/**
+ * Above-the-fold manual display slot for drive-by SEO landings (health
+ * premiums, fuel daily, border wait) — pages with 7-11s median sessions and
+ * no manual <ins> slots, where Auto Ads alone arrived too late to serve
+ * (2026-06 revenue deep dive). A visible slot makes the adsense lazy loader's
+ * IntersectionObserver fire at first paint, so adsbygoogle.js loads
+ * immediately instead of waiting for the idle fallback. Reuses the existing
+ * ACTIVE responsive display unit HOMEPAGE_MID_DISPLAY (2093992129) — ad unit
+ * creation needs a write-scope OAuth token the automation does not hold.
+ * Wrapper reserves min-h-[280px] so an async fill causes zero CLS (AGENTS.md
+ * non-negotiable 7: reserve space, never suppress the ad system).
+ */
+export const DRIVEBY_ATF_AD_SLOT_ID = AD_SLOTS.HOMEPAGE_MID_DISPLAY.slot;
+export const DRIVEBY_AD_SNIPPET = `<div class="my-6 min-h-[280px]">
+    <ins class="adsbygoogle" style="display:block" data-ad-client="${ADSENSE_CLIENT_ID}" data-ad-slot="${DRIVEBY_ATF_AD_SLOT_ID}" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  </div>`;
 
 export const ADSENSE_SNIPPET = `<meta name="google-adsense-account" content="${ADSENSE_CLIENT_ID}">
  <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>

--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -15,7 +15,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { BOT_UA_PATTERNS } from '../services/botPatterns';
-import { AD_SLOTS } from '../services/adsenseSlots';
+import { adSlotHtml } from './lib/adSlotHtml';
 import { REDIRECT_STUB_MARKER } from './shared/redirectStubMarker';
 
 export const BUILD_ID = String(Date.now());
@@ -404,20 +404,20 @@ export const ADSENSE_LOADER_FILENAME = `adsense-loader-${shortContentHash(ADSENS
 export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/${ADSENSE_LOADER_FILENAME}"></script>`;
 
 /**
- * Above-the-fold manual display slot for drive-by SEO landings (health
- * premiums, fuel daily, border wait) — pages with 7-11s median sessions and
- * no manual <ins> slots, where Auto Ads alone arrived too late to serve
- * (2026-06 revenue deep dive). A visible slot makes the adsense lazy loader's
- * IntersectionObserver fire at first paint, so adsbygoogle.js loads
- * immediately instead of waiting for the idle fallback. Reuses the existing
- * ACTIVE responsive display unit HOMEPAGE_MID_DISPLAY (2093992129) — ad unit
- * creation needs a write-scope OAuth token the automation does not hold.
- * Wrapper reserves min-h-[280px] so an async fill causes zero CLS (AGENTS.md
- * non-negotiable 7: reserve space, never suppress the ad system).
+ * Above-the-fold manual slot for drive-by SEO landings (health premiums,
+ * fuel daily, border wait) — pages with 7-11s median sessions whose only
+ * manual unit was the end-of-page ARTICLE_END_MULTIPLEX, far below the
+ * fold (2026-06 revenue deep dive). A slot near the primary data area makes
+ * the adsense lazy loader's IntersectionObserver fire at first paint, so
+ * adsbygoogle.js loads immediately instead of waiting for the idle
+ * fallback. Markup comes from adSlotHtml('HOMEPAGE_MID_DISPLAY') so format
+ * (autorelaxed multiplex) and the CLS-reserving min-height stay driven by
+ * the services/adsenseSlots registry — never hand-roll the <ins> here
+ * (PR #1910 review). Reuses that ACTIVE unit because ad-unit creation via
+ * API needs a write-scope OAuth token the automation does not hold.
  */
-export const DRIVEBY_ATF_AD_SLOT_ID = AD_SLOTS.HOMEPAGE_MID_DISPLAY.slot;
-export const DRIVEBY_AD_SNIPPET = `<div class="my-6 min-h-[280px]">
-    <ins class="adsbygoogle" style="display:block" data-ad-client="${ADSENSE_CLIENT_ID}" data-ad-slot="${DRIVEBY_ATF_AD_SLOT_ID}" data-ad-format="auto" data-full-width-responsive="true"></ins>
+export const DRIVEBY_AD_SNIPPET = `<div class="my-6">
+    ${adSlotHtml('HOMEPAGE_MID_DISPLAY')}
   </div>`;
 
 export const ADSENSE_SNIPPET = `<meta name="google-adsense-account" content="${ADSENSE_CLIENT_ID}">

--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -29,6 +29,7 @@ import {
   FUEL_CHART_SCRIPT_TAG,
   MIN_INDEXABLE_WORDS,
   countHtmlBodyWords,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags } from './shared/hreflang';
@@ -1816,6 +1817,7 @@ function renderPage(inp: PageInputs): string {
     ${trendTableHtml}
     ${periodAvgNoteHtml}
   </section>
+  ${DRIVEBY_AD_SNIPPET}
   ${faqHtml}
   ${renderFuelTodayFrontalierContext({ locale, fuelLabel, zoneLabel, priceFmt, deltaYestFmt, delta7Fmt, isZone: !!zone })}
   <section class="s-GCEyQg" aria-label="${esc(copy.faqTitle)}">

--- a/build-plugins/healthPremiumsLandingPlugin.ts
+++ b/build-plugins/healthPremiumsLandingPlugin.ts
@@ -30,6 +30,7 @@ import {
   BASE_URL,
   MIN_INDEXABLE_WORDS,
   countHtmlBodyWords,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { buildDayStampIso } from './shared/buildDayStamp';
@@ -2356,6 +2357,7 @@ function renderLeafPage(inp: LeafInputs): string {
   </section>
   ${yoyHtml}
   ${triYearHtml}
+  ${DRIVEBY_AD_SNIPPET}
   <section class="s-ziawP1" aria-labelledby="editorial">
     <h2 id="editorial" style="${H2_STYLE}">${esc(copy.editorialTitle)}</h2>
     <p class="s-KwuhOL">${esc(copy.editorial(cantonLabel, ageLabel, medFmt, year))}</p>


### PR DESCRIPTION
## Implementato
- `build-plugins/constants.ts`: nuovo `DRIVEBY_AD_SNIPPET` condiviso (display responsive, `data-ad-format=auto`, wrapper `min-h-[280px]` → zero CLS per AGENTS non-negotiable 7) + `DRIVEBY_ATF_AD_SLOT_ID` che importa lo slot dal registry `services/adsenseSlots.ts` (`AD_SLOTS.HOMEPAGE_MID_DISPLAY.slot`, unità ACTIVE riusabile) — nessun literal duplicato, import relativo (regola config-graph).
- Inserito `${DRIVEBY_AD_SNIPPET}` subito dopo la data-area primaria (prima della prose lunga, mobile-first) in: `healthPremiumsLandingPlugin.ts` (leaf premi-cassa-malati), `fuelDailyPagesPlugin.ts` (pagine prezzi-{benzina,diesel}/{loc}/oggi), `borderWaitPagesPlugin.ts` (leaf traffico-dogane). Un edit per template copre tutti e 4 i locali.
- Effetto secondario voluto: uno slot `<ins>` visibile fa scattare l'IntersectionObserver del lazy-loader al primo paint → `adsbygoogle.js` (e con lui le Auto Ads anchor/vignette) carica subito su queste pagine, senza aspettare l'idle fallback. Complementare a #1904.
- Test: 28 file / 244 test verdi (border-wait-pages, fuel-daily, adsense-lazy-load, build-plugin-order, build-plugins/*, app-no-blanket-no-auto-ads). tsc pulito.

**Razionale (deep-dive 28d):** queste landing portano ~10.6k pv/28d di traffico drive-by ad alto CPC svizzero (premi-cassa-malati 3.6k pv/7s sessione, prezzi-diesel 3.4k pv/7s, traffico-dogane 3.7k pv/40s) e non avevano NESSUNO slot manuale.

## Non implementato (ancora)
- **Creazione di una ad unit dedicata via API**: tentata (`adunits.create`), risponde 403 — il refresh token OAuth è scope `adsense.readonly`; servirebbe re-consent interattivo dell'owner. Riuso di HOMEPAGE_MID_DISPLAY = reporting aggregato col placement homepage; se l'owner crea in console un'unità `FT_DRIVEBY_ATF_DISPLAY`, basta aggiornare lo slot id nel registry.
- **Sibling template non toccati con motivo**: `weatherAlertPagesPlugin`/`weatherCityPagesPlugin`/`borderMunicipalityPagesPlugin`/`orphanQueryLandingPlugin` condividono la classe drive-by ma non compaiono nelle top pagine GA4 28d (traffico marginale) → rapporto blast-radius/beneficio sfavorevole; estensione eventuale dopo misura su queste 3.
- **Claim revenue non validabile pre-merge**: uplift atteso = proiezione (display manual RPM osservato 0.24–0.69 + load anticipato Auto Ads). Revert-trigger: se rpm-canary o revenue-monitor (cron 15/6 e 22/6, più routine cloud one-time del 19/6 già armata per #1904) mostrano coverage/AD_REQUESTS inflation senza revenue o RPM in calo >25% → revert di questa PR insieme alla valutazione di #1904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)