### PR TITLE
fix(seo): truncate related-search hub paginator on job board — unblock page-weight gate

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1822,9 +1822,28 @@ function injectHubLinkIntoSectionLanding(
   if (html.includes('data-related-search-hub-link="1"')) return;
 
   const hubPagePaths = listEmittedHubPagePaths(distDir, locale);
-  const pageLinks = hubPagePaths.slice(1).map((urlPath, idx) =>
-    `<a href="${esc(urlPath)}">${idx + 2}</a>`,
-  ).join(' ');
+  // Head+tail truncation, mirroring the cantonHubEditorial.ts archive
+  // paginator: the full list grew ~55 B per hub page (265 pages = ~15 KB)
+  // on the job-board landing and tipped dist/cerca-lavoro-ticino/index.html
+  // over the audit:page-weight budget (220 KB) on 2026-06-12. Crawler reach
+  // to every /ricerca/page-N/ is preserved by renderPageNavigator(), which
+  // links EVERY page on the hub pages themselves (root → job board → hub
+  // page 1 → page-N stays within the BFS depth gate), so the job-board
+  // injection only needs head+tail anchors.
+  const PAGINATOR_HEAD = 20;
+  const PAGINATOR_TAIL = 5;
+  const tailPaths = hubPagePaths.slice(1); // pages 2..N
+  const pageAnchor = (urlPath: string, pageNum: number): string =>
+    `<a href="${esc(urlPath)}">${pageNum}</a>`;
+  let pageLinks: string;
+  if (tailPaths.length <= PAGINATOR_HEAD + PAGINATOR_TAIL) {
+    pageLinks = tailPaths.map((urlPath, idx) => pageAnchor(urlPath, idx + 2)).join(' ');
+  } else {
+    const headLinks = tailPaths.slice(0, PAGINATOR_HEAD).map((urlPath, idx) => pageAnchor(urlPath, idx + 2));
+    const tailLinks = tailPaths.slice(-PAGINATOR_TAIL).map((urlPath, idx) =>
+      pageAnchor(urlPath, tailPaths.length - PAGINATOR_TAIL + idx + 2));
+    pageLinks = [...headLinks, '<span aria-hidden="true">…</span>', ...tailLinks].join(' ');
+  }
   const pageLinkBlock = pageLinks
     ? `<details><summary>${esc(copy.pageNavigatorLabel)}</summary><p>${pageLinks}</p></details>`
     : '';


### PR DESCRIPTION
## Implementato
- `build-plugins/relatedSearchClustersPlugin.ts` (`injectHubLink`): la lista pagine hub /ricerca/ iniettata nella job-board landing passa da TUTTE le pagine (oggi 265 link ≈ 15 KB, +~55 B per ogni nuova pagina cluster) a head(20)+tail(5)+ellipsis — stesso pattern del paginatore archivio in `build-plugins/shared/cantonHubEditorial.ts` (troncato per lo stesso budget il 28/5). Stessa funzione copre tutti e 4 i locali.
- Reachability invariata: `renderPageNavigator()` linka OGNI page-N sulle pagine hub stesse (commento esplicito 'BFS depth gate'); percorso root → job board → hub page 1 → page-N resta nel max-depth 4. Nessuna pagina rimossa, nessun contenuto tagliato (regola ferma never-cut-pages rispettata: solo byte-trim di un nav duplicato).

**Root cause del main-red di deploy:** `validate-dist` fallisce da run 27386112992 (2026-06-12 00:22) con `page-weight: dist/cerca-lavoro-ticino/index.html = 228.838 B > 220.160 B` (artifact `audit-reports-27386112992-1`, `page-weight.json`). La pagina live era già al 99,6% del budget; i ~15 commit crawler notturni hanno aggiunto job → +pagine cluster → +link nel paginatore full-list → sforamento. Ogni deploy fallito esegue rollback: prod è ferma a un build pre-#1904/#1910 — questa PR sblocca il drain dei deploy.

- Test: `tests/seo/related-search-clusters-emitted.test.ts` + `tests/seo/job-sector-page-weight.test.ts` verdi (44 passed). tsc pulito.

## Non implementato (ancora)
- **Risparmio atteso ~13 KB (228,8→~215,5 KB) non validabile pre-merge**: il `build:ci` completo gira solo post-merge. Revert-trigger esplicito: se il prossimo deploy fallisce ancora `page-weight` su `cerca-lavoro-ticino/index.html`, servono trim aggiuntivi (vedi punto sotto) — non alzare MAI il budget (non-negotiable 1).
- **Trim strutturale dei 20 blocchi per-cantone (~135 KB, anch'essi data-driven)**: i `<details>` 'Esplora i cantoni in dettaglio' crescono coi crawler e restano il prossimo driver di sforamento; deferito perché richiede decisione di design (collassare in link agli hub cantonali?) — follow-up dopo che questo unblock è verificato.
- **Dedup head-anchor**: il blocco troncato di `cantonHubEditorial.ts` e questo condividono ora il pattern head/tail ma non un helper comune (markup diverso: details+nav vs nav-in-details); estrazione in modulo condiviso valutabile nel follow-up sopra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)