### PR TITLE
ci(deploy): disable post-deploy rollback job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1774,29 +1774,35 @@ jobs:
       issues: write     # github-issue-creator on publish failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
 
   # ───────────────────────────────────────────────────────────────────────
-  # rollback: revert Pages to last_known_good if either validate fails for a
-  # reason that means the LIVE SITE IS BAD.
-  # Still-live guard: skip rollback if a newer deploy has already replaced
-  # ours on Pages — the bad version is gone, no need to clobber the new
-  # good one.
+  # rollback: DISABLED (2026-06-12, explicit user request).
+  # The job is gated off with `if: false`; a failed validate now leaves the
+  # live site as-is and relies on the next deploy (or manual intervention)
+  # instead of auto-reverting Pages to last_known_good. last_known_good
+  # bookkeeping in post-deploy-publish is untouched, so re-enabling restores
+  # full behavior.
   #
-  # NOT a rollback trigger: validate-live `propagation_timeout`. That means our
-  # build-id never went live within the window (Pages publish backlog under
-  # deploy congestion) — but the live site is an OLDER VALID build the whole
-  # time, not broken. Rolling back to an even-older last_known_good would only
-  # regress the site and add another publish to the backlog (the thrash that
-  # wedged every deploy during the 2026-05-30 dispatch storm). So we gate
-  # rollback OFF when validate-live's ONLY failure reason is propagation_timeout;
-  # the next deploy lands normally once Pages drains. A genuine live-broken
-  # failure (5xx / e2e / CLS / visual) leaves failure_kind empty → rollback fires.
+  # To re-enable, replace `if: false` with the original condition:
+  #   if: |
+  #     always() &&
+  #     (needs.validate-dist.result == 'failure' ||
+  #      (needs.validate-live.result == 'failure' && needs.validate-live.outputs.failure_kind != 'propagation_timeout')) &&
+  #     needs.deploy.result == 'success'
+  #
+  # Original semantics (kept for the re-enable case): revert Pages to
+  # last_known_good if either validate fails for a reason that means the
+  # LIVE SITE IS BAD. Still-live guard: skip rollback if a newer deploy has
+  # already replaced ours on Pages.
+  # NOT a rollback trigger: validate-live `propagation_timeout` — our
+  # build-id never went live within the window (Pages publish backlog), but
+  # the live site is an OLDER VALID build, not broken. Rolling back would
+  # only regress the site and add another publish to the backlog (the thrash
+  # that wedged every deploy during the 2026-05-30 dispatch storm). A genuine
+  # live-broken failure (5xx / e2e / CLS / visual) left failure_kind empty →
+  # rollback fired.
   # ───────────────────────────────────────────────────────────────────────
   rollback:
     needs: [deploy, validate-dist, validate-live]
-    if: |
-      always() &&
-      (needs.validate-dist.result == 'failure' ||
-       (needs.validate-live.result == 'failure' && needs.validate-live.outputs.failure_kind != 'propagation_timeout')) &&
-      needs.deploy.result == 'success'
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -5,6 +5,12 @@ name: Post-deploy Validate (live)
 # GitHub Pages. READ-ONLY by design: live smoke (probe 5xx + e2e:live)
 # fetched directly from the deployed site.
 #
+# NOTE (2026-06-12): the `rollback` job in deploy.yml is currently DISABLED
+# (`if: false`, explicit user request). References below to rollback firing
+# describe the failure-classification contract (`failure_kind` output), which
+# is unchanged and still consumed by the (gated-off) rollback condition — kept
+# intact so re-enabling rollback needs no changes here.
+#
 # Side-effects (Facebook/LinkedIn post, IndexNow/GSC submission, winners
 # git push, mark last_known_good) used to live here but were extracted
 # to `post-deploy-publish.yml` because they fired BEFORE validate-dist


### PR DESCRIPTION
## Implementato
- `deploy.yml`: job `rollback` disabilitato con `if: false` su richiesta esplicita dell'utente. La condizione originale (validate-dist failure / validate-live failure non-propagation_timeout) è conservata in commento per re-enable in un passo.
- `post-deploy-validate-live.yml`: nota in header che chiarisce che i riferimenti a rollback descrivono il contratto `failure_kind` (invariato) mentre il job chiamante è gated off — evita comment-drift senza riscrivere ogni commento.

## Non implementato (ancora)
- Auto-rollback del Worker in `deploy-worker.yml` (step "Auto-rollback Worker on stall regression"): NON toccato — meccanismo separato (Cloudflare Worker, non il deploy Pages); la richiesta riguarda il rollback del deploy. Issue follow-up #1821 copre quell'area.
- Bookkeeping `last_known_good` in `post-deploy-publish.yml`: lasciato attivo di proposito — costa nulla e tiene il target di rollback fresco per quando/se il job verrà riabilitato.
- Rimozione del corpo del job rollback (~270 righe ora dead code): posposto — tenerlo rende il re-enable un one-liner; rimuoverlo sarebbe scope oltre la richiesta.

## Test plan
- [x] YAML parse OK (python yaml.safe_load, 6 jobs, `rollback.if == false`)
- [x] Nessun job `needs: rollback` → nessun dependent skippato a cascata
- [x] `check-sibling-patterns.mjs`: nessuna classe da sweepare
- [ ] Primo deploy su main post-merge: job `rollback` deve risultare skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)