### PR TITLE
perf(cluster): paint static body at first paint on related-search landings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -274,13 +274,20 @@ const App: React.FC = () => {
  // every SPA-route page that has a static fallback. Measured CLS = 0.59 on
  // /cerca-lavoro-ticino/ (2026-05-27 desktop). On the server pass useLayoutEffect
  // falls back to a no-op, which is fine — the toggle is purely a client concern.
+ // `main.cluster-seo-prose` is the same handoff for the related-search
+ // cluster family (relatedSearchClustersPlugin) and the bridge prose pages:
+ // its body is now visible pre-hydration (the #1249 clip-rect hid it from
+ // users entirely, leaving these landings blank until the SPA painted —
+ // FCP ~4s on a fast desktop), so it must join the same pre-paint toggle
+ // or it would duplicate the hydrated JobBoard below the SPA view.
  useLayoutEffect(() => {
-   const staticMain = document.querySelector<HTMLElement>('main.seo-static-content');
-   if (!staticMain) return;
-   if (staticOverlay) {
-     staticMain.style.removeProperty('display');
-   } else {
-     staticMain.style.display = 'none';
+   const staticMains = document.querySelectorAll<HTMLElement>('main.seo-static-content, main.cluster-seo-prose');
+   for (const staticMain of staticMains) {
+     if (staticOverlay) {
+       staticMain.style.removeProperty('display');
+     } else {
+       staticMain.style.display = 'none';
+     }
    }
  }, [staticOverlay]);
 

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1527,16 +1527,19 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
   </details>`;
 
   // ── Body ────────────────────────────────────────────────────────
-  // 100% crawler-only. The SPA's hydrated JobBoard renders all visible
-  // chrome for users (sub-nav, breadcrumb, search-query header, JobCard
-  // grid, footer) inside `#root`. This static body holds the H1 + ~9KB
-  // prose ONLY for crawlers + screen readers — wrapped in an off-screen
-  // (clip-rect) container so sighted users see absolutely nothing from
-  // the static layer. No `hubChrome` is passed below either, so the
+  // Visible PRE-hydration, hidden at hydration. The SPA's hydrated JobBoard
+  // renders all visible chrome for users (sub-nav, breadcrumb, search-query
+  // header, JobCard grid, footer) inside `#root`; until those chunks arrive
+  // this static body (H1 + job links + prose) is the ONLY paintable content
+  // on the page, so it renders in normal flow — the former clip-rect
+  // recipe (#1249) blanked these landings until SPA paint (FCP ~4s desktop).
+  // App.tsx's pre-paint useLayoutEffect flips `main.cluster-seo-prose` to
+  // display:none on hydration, so it never duplicates the JobBoard.
+  // No `hubChrome` is passed below either, so the
   // sub-nav strip we previously emitted as a static sibling is gone.
   // SEO content stays in DOM (Googlebot indexes it with the same weight
   // as standard `<details>` accordion content per Search Central docs).
-  // Crawler-indexable job list. Always emitted (off-screen, no visual impact)
+  // Job list is always emitted
   // so the static HTML carries cross-canton job references even when the
   // SPA's canton-scoped grid would render zero — mirrors the SPA's Tier 3
   // cross-canton fallback at the build layer. Each link points to the job's
@@ -1560,11 +1563,11 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
     : '';
 
   // The `.related-search-cluster` class in `public/assets/seo-static.css`
-  // carries the same `position:absolute;width:1px;...;border:0` recipe that
-  // used to live inline on `style=` here. Dropping the inline form saves
+  // carries the visible-pre-hydration layout (max-width, padding, job-list
+  // styling). Keeping it class-based (not inline `style=`) saves
   // ~132 B × 180k cluster pages = ~24 MB on the dist artifact. The class
   // is loaded by the shared `seoStaticCssLink` that every cluster page
-  // already imports — no extra request, identical computed style.
+  // already imports — no extra request.
   const bodyHtml = `<div class="related-search-cluster">
     <h1>${esc(headlineH1)}</h1>
     ${jobLinksHtml}

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -1701,35 +1701,49 @@ aside.seo-footer-block .seo-fb-section-body a:hover,
 }
 
 /*
- * Related-search cluster crawler body (build-plugins/relatedSearchClustersPlugin.ts).
+ * Related-search cluster static body (build-plugins/relatedSearchClustersPlugin.ts).
  *
- * The plugin emits `<div class="related-search-cluster">` (H1 + ~9 KB unique
- * AI intro + cross-link graph + cross-canton job links) as the page body. It
- * is 100% crawler-only: the hydrated SPA renders all visible chrome inside
- * `#root`, so this static layer MUST be off-screen for sighted users while
- * staying in the DOM for crawlers + screen readers (Googlebot indexes
- * off-screen content with the same weight as standard accordion content).
- *
- * The recipe used to live inline on `style=` in the plugin; it was moved here
- * to save ~24 MB across ~180k cluster pages (the plugin comment at
- * relatedSearchClustersPlugin.ts:1561 documents this), but the rule went
- * missing from this file in the move — so the block rendered fully visible
- * in normal flow, duplicating the SPA's job listing below it. This is the
- * standard visually-hidden recipe; restoring it puts the block back off-screen
- * without dropping the SEO payload. Only relatedSearchClustersPlugin emits
- * this class, so the rule is safely scoped.
+ * The plugin emits `<div class="related-search-cluster">` (H1 + job links +
+ * prose + cross-link graph) as the page body. It is VISIBLE pre-hydration:
+ * these landings carry no other paintable content (the SPA renders inside
+ * `#root` only after ~60 chunks arrive), so the former clip-rect recipe
+ * (#1249) left users on a blank page until the SPA painted — FCP ~4s on a
+ * fast desktop, far worse on the 75% mobile share. The duplication bug that
+ * motivated #1249 (static body visible BELOW the hydrated JobBoard) is now
+ * fixed at the root: App.tsx's pre-paint useLayoutEffect toggles
+ * `main.cluster-seo-prose` to display:none together with
+ * `main.seo-static-content` — same choreography as every other static
+ * handoff, and the same behaviour the thin cluster variant
+ * (clusterThinShell.ts, class `seo-static-content static-cluster`) always
+ * had. tests/seo/seo-static-css.test.ts locks this contract.
  */
 .related-search-cluster {
-  position: absolute;
-  width: 1px;
-  height: 1px;
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 24px 16px;
+  color: var(--color-body);
+  line-height: 1.65;
+}
+.related-search-cluster h1 {
+  color: var(--color-heading);
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 16px;
+}
+.related-search-cluster .cluster-seo-jobs {
+  list-style: none;
+  margin: 0 0 24px;
   padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
+}
+.related-search-cluster .cluster-seo-jobs li {
+  margin: 0;
+  border-bottom: 1px solid var(--color-edge);
+}
+.related-search-cluster .cluster-seo-jobs a {
+  display: block;
+  padding: 12px 4px;
+  color: var(--color-heading);
+  text-decoration: none;
 }
 
 /* ── Fuel daily / station pages (fuelDailyPagesPlugin) ───────────────────

--- a/services/router.ts
+++ b/services/router.ts
@@ -1696,7 +1696,21 @@ if (typeof window !== 'undefined') {
  // "trouver-emploi-*" (FR) — see SLUG_TABLES and getJobBoardSlug.
  if (!/^(cerca-lavoro|find-jobs|jobs-in|trouver-emploi)/.test(candidate)) return false;
  // Must have at least one more segment (the job slug or city/sector)
- return segments.length > start + 1;
+ if (segments.length <= start + 1) return false;
+ // Static SEO families under the job-board hub are NOT job-detail pages:
+ // related-search clusters (ricerca-/search-/suche-/recherche-, ~517k pages),
+ // company hubs (azienda-/company-/unternehmen-/entreprise-), category
+ // listings (categoria-/category-/kategorie-/categorie-) and pagination
+ // (pagina-N/page-N/seite-N). None of them renders a single job detail, so
+ // the eager slug-map fetch (~1.1 MB gzip) only competes with the SPA
+ // chunks for bandwidth on those landings — measured +3s to JobBoard
+ // chunk arrival on /fr/.../recherche-* pages. Fall through to the
+ // idle-time load instead; worst case (a real job slug starting with one
+ // of these prefixes) degrades softly: JobBoard registers the map later
+ // and the bridge-in-flight guard covers the gap.
+ const second = segments[start + 1];
+ if (/^(ricerca|search|suche|recherche|azienda|company|unternehmen|entreprise|categoria|category|kategorie|categorie|pagina|page|seite)-/.test(second)) return false;
+ return true;
  } catch {
  return false;
  }
@@ -2945,8 +2959,9 @@ export function parsePath(pathname: string): ParseResult {
  // `parseSearchSlugFilter` (services/relatedSearchClusters.ts) detects the
  // `ricerca-`/`search-`/`suche-`/`recherche-` prefix and populates the search
  // bar + result grid. Returning `staticOverlay: true` here breaks the page
- // because the static body is intentionally sr-only (crawler-only) — the
- // SPA must hydrate the interactive search view for users.
+ // because the SPA must hydrate the interactive search view for users —
+ // the static body is only the pre-hydration first paint (App.tsx hides
+ // `main.cluster-seo-prose` at hydration).
  //
  // Build-time static SEO pages emitted under /cerca-lavoro-ticino/:
  // company hubs (azienda-/company-/unternehmen-/entreprise-), category

--- a/tests/bridge-orphan-flicker-guard.test.ts
+++ b/tests/bridge-orphan-flicker-guard.test.ts
@@ -115,7 +115,17 @@ describe('Bridge orphan-flicker guard (2026-05-22 regression)', () => {
 
     it('requires at least two segments after locale stripping (board + job-slug-or-city)', () => {
       // A bare /cerca-lavoro-ticino/ is the LISTING, not a detail page.
-      expect(routerSrc).toMatch(/segments\.length > start \+ 1/);
+      expect(routerSrc).toMatch(/segments\.length <= start \+ 1\) return false/);
+    });
+
+    it('excludes static SEO families (search clusters, company hubs, categories, pagination) from the eager load', () => {
+      // /fr/trouver-emploi-suisse/recherche-*/ and friends are NOT job-detail
+      // pages: the eager ~1.1MB-gzip slug-map fetch only competed with the
+      // SPA chunks for bandwidth there (measured +3s to JobBoard chunk
+      // arrival). They must fall through to the idle-time load.
+      expect(routerSrc).toMatch(
+        /ricerca\|search\|suche\|recherche\|azienda\|company\|unternehmen\|entreprise\|categoria\|category\|kategorie\|categorie\|pagina\|page\|seite/,
+      );
     });
 
     it('fires ensureJobSlugMapLoaded eagerly (NOT through requestIdleCallback) when on a job-detail URL', () => {

--- a/tests/seo/seo-static-css.test.ts
+++ b/tests/seo/seo-static-css.test.ts
@@ -25,60 +25,61 @@ describe('seo-static.css', () => {
     expect(selectors.has('.s-zzuqwx')).toBe(true);
   });
 
-  // Regression guard: relatedSearchClustersPlugin emits the crawler-only
-  // `<div class="related-search-cluster">` body and relies on THIS file
-  // carrying the off-screen (visually-hidden) recipe — the inline `style=`
-  // was dropped to save ~24 MB across ~180k cluster pages. When the rule
-  // went missing the block rendered fully visible in normal flow, duplicating
-  // the SPA's hydrated job listing below it. Keep the rule (and its
-  // off-screen positioning) so the SEO payload stays in the DOM for crawlers
-  // without being visible to sighted users.
-  it('keeps the .related-search-cluster crawler body off-screen (visually hidden)', () => {
+  // Regression guard (inverted from the #1249 clip-rect lock): the cluster
+  // static body must be VISIBLE pre-hydration. These landings have no other
+  // paintable content — `#root` is empty until the SPA chunks arrive — so an
+  // off-screen/hidden recipe here means users stare at a blank page until
+  // hydration (measured FCP ~4s desktop, worse on the 75% mobile share).
+  // The duplication bug #1249 worked around (static body visible BELOW the
+  // hydrated JobBoard) is fixed at the root in App.tsx, whose pre-paint
+  // useLayoutEffect hides `main.cluster-seo-prose` on hydration — asserted
+  // by the companion test below.
+  it('keeps the .related-search-cluster body visible pre-hydration (no off-screen recipe)', () => {
     const css = fs.readFileSync(CSS_PATH, 'utf8');
     const root = postcss.parse(css, { from: CSS_PATH });
 
     let rule: postcss.Rule | undefined;
     root.walkRules('.related-search-cluster', (r) => {
-      rule = r;
+      if (rule === undefined) rule = r;
     });
     expect(rule, '.related-search-cluster rule must exist in seo-static.css').toBeDefined();
 
     const decls = new Map<string, string>();
-    rule!.walkDecls((d) => decls.set(d.prop, d.value));
+    rule!.walkDecls((d) => decls.set(d.prop.toLowerCase(), d.value));
 
-    // The off-screen recipe: out of flow + clipped to 1px so sighted users
-    // see nothing while the content stays in the DOM for crawlers.
-    expect(decls.get('position')).toBe('absolute');
-    expect(decls.get('width')).toBe('1px');
-    expect(decls.get('height')).toBe('1px');
-    expect(decls.get('overflow')).toBe('hidden');
-    expect(decls.get('clip')).toMatch(/rect\(\s*0/);
+    // No hide vector may reappear: any single one of these blanks the page
+    // pre-hydration again.
+    expect(decls.get('display')).not.toBe('none');
+    expect(decls.get('visibility')).not.toBe('hidden');
+    expect(decls.get('position')).not.toBe('absolute');
+    expect(decls.get('width')).not.toBe('1px');
+    expect(decls.get('height')).not.toBe('1px');
+    expect(decls.has('clip')).toBe(false);
+    expect(decls.has('clip-path')).toBe(false);
+  });
+
+  // Companion contract: App.tsx must hide `main.cluster-seo-prose` in the
+  // same pre-paint useLayoutEffect that handles `main.seo-static-content`.
+  // Without it, the now-visible static body duplicates the hydrated
+  // JobBoard below the SPA view — the exact regression #1249 was papering
+  // over with the clip-rect.
+  it('App.tsx pre-paint toggle covers main.cluster-seo-prose', () => {
+    const appSrc = fs.readFileSync(path.resolve(process.cwd(), 'App.tsx'), 'utf8');
+    expect(appSrc).toMatch(/main\.seo-static-content,\s*main\.cluster-seo-prose/);
   });
 });
 
-// Cascade-source guard (follow-up #1257, deferred from #1249 review).
+// Cascade-source guard (inverted by the visible-pre-hydration contract).
 //
-// #1249 restored the off-screen `.related-search-cluster` recipe in
-// `seo-static.css`, but that file is only ONE layer of the cascade: every
-// cluster page also loads the hashed SPA bundle compiled from `index.css`
-// (`index-*.css`). If `index.css` later defines a more-specific or
-// later-source `.related-search-cluster` rule that resets `position` away
-// from `absolute`, the seo-static.css recipe is neutralised post-hydration
-// and the ~9 KB crawler-only body reflows VISIBLE on ~180k cluster pages —
-// re-opening the exact regression #1249 fixed, but invisible to the
+// Every cluster page loads BOTH `seo-static.css` and the hashed SPA bundle
+// compiled from `index.css`. With the static body now visible pre-hydration,
+// the failure mode flipped: a later-source `.related-search-cluster` (or
+// `.cluster-seo-prose`) rule in `index.css` that re-hides the block —
+// display:none, visibility:hidden, the old clip-rect recipe — silently
+// blanks ~180k cluster landings until the SPA paints, re-opening the
+// blank-page regression this PR fixed without failing the
 // seo-static.css-only guard above.
-//
-// Symmetrically, the wrapper `<main class="cluster-seo-prose">` (the plugin
-// keeps it OFF `seo-static-content` on purpose, relatedSearchClustersPlugin
-// line ~1602, so it dodges the SPA lite-shell detector). Its only child is
-// `position:absolute`, so the wrapper collapses to 0 height — UNLESS a
-// `cluster-seo-prose` rule in `index.css` adds `padding`/`min-height`,
-// which would leave a visible whitespace gap (added CLS → depressed Auto
-// Ads RPM) even with the child off-screen.
-//
-// This guard fails the build if either competing rule appears in the SPA
-// bundle source, locking the verification both review items deferred.
-describe('index.css (SPA bundle source) cascade does not un-hide the cluster', () => {
+describe('index.css (SPA bundle source) cascade does not re-hide the cluster body', () => {
   const collectRules = (selectorPart: string): postcss.Rule[] => {
     const css = fs.readFileSync(SPA_CSS_PATH, 'utf8');
     const root = postcss.parse(css, { from: SPA_CSS_PATH });
@@ -89,54 +90,33 @@ describe('index.css (SPA bundle source) cascade does not un-hide the cluster', (
     return matches;
   };
 
-  // The off-screen recipe hides the body with SIX co-operating properties
-  // (`seo-static.css:1722`): position:absolute; width:1px; height:1px;
-  // overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%). Resetting ANY
-  // single one to its visible value un-hides the ~9 KB body — e.g.
-  // `width:auto`, `overflow:visible`, `clip:auto`, `clip-path:none` reflow it
-  // WITHOUT touching `position`. A position-only guard locks 1 vector of 6;
-  // `width` is the most likely culprit. So assert every hide-critical decl
-  // that `index.css` defines on `.related-search-cluster` keeps a hidden
-  // value (matchers mirror the recipe).
-  const HIDE_DECL_GUARDS: Record<string, RegExp> = {
+  // Any single one of these declarations hides the body pre-hydration.
+  const HIDE_VECTORS: Record<string, RegExp> = {
+    display: /^none$/i,
+    visibility: /^hidden$/i,
     position: /^absolute$/i,
     width: /^1px$/i,
     height: /^1px$/i,
-    overflow: /^hidden$/i,
-    clip: /^rect\(\s*0/i,
+    clip: /^rect\(/i,
     'clip-path': /^inset\(/i,
+    opacity: /^0$/,
   };
 
-  it('does not reset any .related-search-cluster hide property out of the off-screen recipe', () => {
-    for (const rule of collectRules('.related-search-cluster')) {
-      rule.walkDecls((d) => {
-        const prop = d.prop.toLowerCase();
-        const expected = HIDE_DECL_GUARDS[prop];
-        if (!expected) return;
-        expect(
-          expected.test(d.value.trim()),
-          `index.css rule "${rule.selector}" sets ${d.prop}:${d.value} on ` +
-            `.related-search-cluster — this un-hides the crawler-only body ` +
-            `(reflows VISIBLE on ~180k cluster pages post-hydration, re-opening ` +
-            `the #1249 regression). Keep the off-screen recipe value or drop the ` +
-            `override.`,
-        ).toBe(true);
-      });
-    }
-  });
-
-  it('does not give .cluster-seo-prose wrapper a visible footprint (padding/min-height/height/border)', () => {
-    for (const rule of collectRules('cluster-seo-prose')) {
-      rule.walkDecls(/^(padding|min-height|height|border)/, (d) => {
-        const collapses = /^(0|0px|0em|0rem|none)$/i.test(d.value.trim());
-        expect(
-          collapses,
-          `index.css rule "${rule.selector}" sets ${d.prop}:${d.value} on the ` +
-            `cluster wrapper — its child is position:absolute, so this leaves a ` +
-            `visible whitespace gap (added CLS) on ~180k cluster pages. Keep the ` +
-            `wrapper collapsible (no padding / min-height / height / border).`,
-        ).toBe(true);
-      });
+  it('does not hide .related-search-cluster or .cluster-seo-prose pre-hydration', () => {
+    for (const selectorPart of ['.related-search-cluster', 'cluster-seo-prose']) {
+      for (const rule of collectRules(selectorPart)) {
+        rule.walkDecls((d) => {
+          const hideMatcher = HIDE_VECTORS[d.prop.toLowerCase()];
+          if (!hideMatcher) return;
+          expect(
+            hideMatcher.test(d.value.trim()),
+            `index.css rule "${rule.selector}" sets ${d.prop}:${d.value} — this ` +
+              `re-hides the cluster static body pre-hydration, blanking ~180k ` +
+              `cluster landings until the SPA paints. Hiding-on-hydration is ` +
+              `App.tsx's job (pre-paint useLayoutEffect), not the stylesheet's.`,
+          ).toBe(false);
+        });
+      }
     }
   });
 });


### PR DESCRIPTION
## Implementato

Diagnosi su `https://frontaliereticino.ch/fr/trouver-emploi-suisse/recherche-inconnus-lausanne/` (misure Playwright): TTFB 113ms ma **FCP 3.97s** su desktop veloce — la pagina resta bianca finché la SPA non idrata, perché il body statico era clip-rect off-screen (#1249) e `#root` è vuoto fino all'arrivo di ~60 chunk. In parallelo il fetch eager di `jobs-slug-map.json` (~1.1MB gzip, misurato 31.9s nella run) saturava la banda ritardando il chunk JobBoard di ~3s.

- **`public/assets/seo-static.css`** — `.related-search-cluster` da off-screen (clip-rect) a layout visibile (max-width 860px, padding, styling lista job con token semantici). Il contenuto reale (H1 + 30 link job) painta a ~0.7s, appena il CSS render-blocking si sblocca.
- **`App.tsx`** — il `useLayoutEffect` pre-paint che nasconde `main.seo-static-content` a hydration ora copre anche `main.cluster-seo-prose`: fixa alla radice la duplicazione (statico visibile SOTTO il JobBoard idratato) che il clip-rect di #1249 aveva solo nascosto. Stessa coreografia già in produzione sulle varianti thin (`clusterThinShell.ts` emette `seo-static-content static-cluster` visibile).
- **`services/router.ts`** — `isJobDetailUrl()` non classifica più come job-detail i secondi segmenti delle famiglie statiche (`ricerca-/search-/suche-/recherche-`, `azienda-/company-/unternehmen-/entreprise-`, `categoria-/category-/kategorie-/categorie-`, `pagina-/page-/seite-`): su quelle landing lo slug-map passa al path idle (requestIdleCallback) invece di competere con i chunk SPA. Degradazione soft nel worst case (slug job reale con quei prefissi): JobBoard registra la mappa più tardi, copre il bridge-in-flight guard esistente.
- **Test** — `tests/seo/seo-static-css.test.ts`: lock #1249 invertito al nuovo contratto (visibile pre-hydration; guard che `index.css` non lo ri-nasconda; companion test sul toggle App.tsx). `tests/bridge-orphan-flicker-guard.test.ts`: aggiornato il source-contract e aggiunto il caso esclusioni.
- Commenti stale aggiornati in `relatedSearchClustersPlugin.ts` e `router.ts` (descrivevano il body come "crawler-only/sr-only").

Vitest: suite mirate verdi (seo 40909, router 483, flicker-guard 12, related-search-clusters 76). Full run locale: uniche failure = ENOENT `data/jobs.json` (dataset assemblato solo nel CI gate) + 2 timeout 15s ambientali su `article-*` sotto carico parallelo — nessuna legata al diff.

## Non implementato (ancora)

- **Riduzione/sharding di `jobs-slug-map.json` (1.1MB gzip)** — il file resta pesante anche a idle-load; pattern slim-seed già tracciato in #1516. Follow-up.
- **Appiattimento waterfall chunk SPA** (entry → vendor-react → App → locale → JobBoard, 4 livelli sequenziali ≈3s prima che JobBoard parta; possibile `modulepreload` nelle pagine SSG) — out of scope, follow-up perf separato.
- **Sibling flaggati da `check-sibling-patterns` (`bridgeThinShell.ts`, `gscKeywordThinShell.ts`)** — condividono solo il riferimento (in commento) allo stesso `useLayoutEffect` di App.tsx; usano già il pattern corretto (`seo-static-content` visibile + hide a hydration). Nessun fix necessario.
- **Verifica CWV live post-deploy** — FCP/CLS sulle pagine cluster non validabili pre-merge (serve deploy). Revert-trigger esplicito: se post-deploy le pagine cluster mostrano duplicazione contenuto o CLS field in regressione (baseline PR #1902: landing 0.019), revert di questa PR.

## Test plan

- [x] vitest suite mirate (seo / router / flicker-guard / cluster)
- [ ] post-deploy: FCP < 1.5s su `/fr/trouver-emploi-suisse/recherche-inconnus-lausanne/` (Playwright)
- [ ] post-deploy: nessuna duplicazione statico+SPA dopo hydration
- [ ] post-deploy: slug-map non più nel critical path (fetch a idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
