### PR TITLE
perf(loop): cut wasted Claude runs — turn-cap bumps, drainer zombie rescue, sibling surfacer

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -94,7 +94,12 @@ jobs:
              || echo "$body" | grep -qiE 'scripts/[a-z0-9_./-]*(backfill|migrate|assemble|sitemap|canonical|slug|structured-data|seo|index)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
             echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
-            echo "max_turns=40" >> "$GITHUB_OUTPUT"
+            # 40->50 (misurato 06-12): 44 run/7gg morti error_max_turns a
+            # num_turns=41 (es. run 27386343034) = run opus intera bruciata,
+            # 0 PR, issue ri-accodata -> retry = doppio burn. Il cap esiste
+            # anti-runaway, non come budget di lavoro: tenerlo sopra il p99
+            # osservato dei run sani.
+            echo "max_turns=50" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-body-contract.yml
+++ b/.github/workflows/pr-body-contract.yml
@@ -128,3 +128,83 @@ jobs:
 
             await upsert(parts.join('\n\n'));
             core.setFailed(`PR body contract: ${fails.join('; ')}`);
+
+  # Sibling-class surfacer (zero-Claude, advisory). Il finding reviewer più
+  # ricorrente dopo il body-contract è il 🔴 "stesso antipattern nel file
+  # gemello" (sibling-class-fix: 4/5 dei 🔴 campionati 2026-06-12, ~98 re-review
+  # + 37 round fixer extra in 7gg). check-sibling-patterns.mjs calcola la lista
+  # candidati in modo deterministico; questo job la posta come sticky comment a
+  # PR-open, così (a) l'autore (agent locale o fixer) la vede PRIMA della
+  # review, (b) il reviewer la consuma senza ricostruire la grep a mano (turni
+  # risparmiati). Heuristico → advisory: MAI setFailed (falsi positivi attesi),
+  # non blocca nulla. Skip su action=edited (il body non cambia il diff).
+  sibling-check:
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Storia completa: serve il merge-base con la base branch per il
+          # three-dot diff dello script (repo grande ma fetch ~40s, accettabile
+          # per un check che pre-empta un round review+fix da ~2 run Claude).
+          fetch-depth: 0
+      - name: Surface sibling candidates
+        id: sib
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --quiet || true
+          node scripts/ci/check-sibling-patterns.mjs --base "origin/$BASE_REF" --json > sibling-report.json
+          node -e "
+            const r = JSON.parse(require('fs').readFileSync('sibling-report.json','utf8'));
+            console.log('candidates=' + r.candidates.length);
+          " >> "$GITHUB_OUTPUT"
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const STICKY = '<!-- sibling-check -->';
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('sibling-report.json', 'utf8'));
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const prior = comments.find(c => (c.body || '').includes(STICKY));
+
+            if (!report.candidates.length) {
+              // All-clear: aggiorna lo sticky se esisteva (diff cambiato), mai crearne uno nuovo.
+              if (prior) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: prior.id,
+                  body: `${STICKY}\n✅ **Sibling-check OK** — nessun file gemello non toccato condivide i costrutti modificati da questo diff.`,
+                });
+              }
+              core.info('No sibling candidates.');
+              return;
+            }
+
+            const TOP = 10;
+            const rows = report.candidates.slice(0, TOP).map(c =>
+              `- \`${c.file}\` — costrutti condivisi: ${c.tokens.slice(0, 5).map(t => '\`' + t + '\`').join(', ')}`
+            ).join('\n');
+            const more = report.candidates.length > TOP
+              ? `\n…e altri ${report.candidates.length - TOP} candidati (run locale: \`node scripts/ci/check-sibling-patterns.mjs\`).`
+              : '';
+            const body = [
+              STICKY,
+              `⚠️ **Sibling-check** (advisory, euristico — AGENTS.md #6 / bucket \`sibling-class-fix\`): ` +
+              `${report.candidates.length} file NON toccati da questa PR condividono costrutti che il diff modifica. ` +
+              `Per ciascuno: stesso antipattern? → fix nella STESSA PR, oppure giustifica in \`## Non implementato\`.`,
+              rows + more,
+              `_Candidati ≠ verdetto: il token-match surfaca, non conferma. Ricalcolato a ogni push._`,
+            ].join('\n\n');
+
+            if (prior) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: prior.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -174,7 +174,11 @@ jobs:
           show_full_output: true
           # Le review/PR autonome sono di claude[bot] / github-actions[bot].
           allowed_bots: 'github-actions[bot], claude[bot]'
-          claude_args: "--max-turns 30 --model ${{ steps.guard.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
+          # 30->45 (misurato 06-12): 25 fail vs 20 success in 7gg, TUTTI
+          # error_max_turns al cap 30 (run 27390252111/27375482475/27373263097)
+          # = peggior failure-rate del loop; ogni fail brucia ~8-14min di run
+          # opus senza commit e lascia il rosso alla escalation needs-human.
+          claude_args: "--max-turns 45 --model ${{ steps.guard.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di chiusura 🔴 per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.guard.outputs.tier }}. Round: ${{ steps.guard.outputs.round }}/2.
 

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -92,7 +92,10 @@ jobs:
         # che mutano/emettono dati indicizzati (crawler/parser/adapter, backfill,
         # migrate, assemble dataset, sitemap/canonical/slug/structured-data).
         # Bug in questi path = falso senso di sicurezza che si propaga su ogni
-        # merge, quindi probing opus paga. Tier normal (sonnet, max-turns 15) per
+        # merge, quindi probing opus paga. Tier normal 15->25 (misurato: 13
+        # run/7gg morti `error_max_turns` a num_turns=16 senza postare review,
+        # es. run 27345572135/27340191180 - review intera bruciata + PR ferma
+        # fino al rescuer). Tier normal (sonnet, max-turns 25) per
         # tutto il resto, inclusi gli script NON-funnel: `scripts/{ci,dev,evals}/`
         # (helper CI/dev) e gli audit/report read-only (`audit-*`, `analytics*`,
         # `*-report` — non mutano l'indice, verificano soltanto). Vedi REVIEW.md
@@ -126,7 +129,7 @@ jobs:
           # scatta.
           if [ -z "$files" ]; then
             echo "Empty file list (rebase-only or empty PR)."
-            set_tier normal claude-sonnet-4-6 15
+            set_tier normal claude-sonnet-4-6 25
             exit 0
           fi
           # Strip DATA/static: il tier si decide solo sul CODE.
@@ -156,7 +159,7 @@ jobs:
           if [ -n "$crit$scripts_crit" ]; then
             set_tier high claude-opus-4-8 40
           else
-            set_tier normal claude-sonnet-4-6 15
+            set_tier normal claude-sonnet-4-6 25
           fi
 
       - name: Run Claude review
@@ -202,7 +205,7 @@ jobs:
             - **Escalation ❓ funnel-critical (REVIEW.md Verification):** un ❓ q (incluso quelli nell'adversarial check) il cui soggetto impatta monetizzazione/traffico (writeJson/persistenza dataset indicizzato, canonical/redirect/previousSlugs, structured data, sitemap, AdSense) → promuovi a 🔴 o apri follow-up issue + linkala. Mai ❓ funnel-critical passivo accanto a `## LGTM`.
             - **No missing-test findings (REVIEW.md → IGNORA → test coverage):** NON sollevare "manca un test" / "aggiungi coverage" / "pinna con un test" come 🟡 nit né come voce `## Adversarial check`, nemmeno su path funnel-critici. Nell'adversarial check elenca rischi di COMPORTAMENTO/correttezza non verificati, mai assenza di test. Eccezione (resta in scope): un BUG in un test ESISTENTE (assertion/regex/guard leaky, fixture date assolute).
 
-            **Cross-file pattern probing (REVIEW.md step 5):** quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. **Scopa la ricerca al CODE** — `rg <pattern> scripts build-plugins components services functions server hooks tests` (oppure `rg <pattern> -g '!data/**' -g '!public/**' -g '!reports/**'`): cercare dentro `data/`/`public/` matcha migliaia di blob dati rigenerati = turni e token sprecati senza segnale. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
+            **Cross-file pattern probing (REVIEW.md step 5):** prima di costruire grep a mano, controlla se sulla PR esiste il commento sticky `<!-- sibling-check -->` (postato dal job zero-Claude di pr-body-contract): contiene già i file gemelli candidati che condividono i costrutti modificati dal diff — parti da quella lista (verifica i candidati, non fidarti ciecamente: è token-match euristico). Se assente o insufficiente, quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. **Scopa la ricerca al CODE** — `rg <pattern> scripts build-plugins components services functions server hooks tests` (oppure `rg <pattern> -g '!data/**' -g '!public/**' -g '!reports/**'`): cercare dentro `data/`/`public/` matcha migliaia di blob dati rigenerati = turni e token sprecati senza segnale. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
 
             **Posta UNA review:**
             `gh pr review $PR_NUMBER --comment --body "<markdown formato REVIEW.md>"`

--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -170,11 +170,17 @@ function edit(num, { add = [], remove = [] }) {
   catch (e) { console.log(`::warning::edit #${num} fallito: ${String(e).slice(0, 120)}`); }
 }
 
-/** Esiste una PR fix aperta o mergiata per questa issue? (head fix/issue-N) */
+/** Esiste una PR fix APERTA per questa issue? (head fix/issue-N).
+ * Solo `--state open`: una PR MERGED/CLOSED con la issue ancora aperta NON è
+ * "in lavorazione" — è il caso aggregate "PR parziale mergiata senza Closes"
+ * (#1049/#1707/#1824: agent:fix zombie per giorni perché `--state all`
+ * contava la PR mergiata come in-flight per sempre → mai rescue né park).
+ * Issue aperta + PR chiusa + vecchia = orfana: re-queue; il pre-flight
+ * already-resolved di issue-fix protegge dal re-run inutile se è done. */
 function hasFixPR(num) {
   for (const branch of [`fix/issue-${num}`]) {
     try {
-      const prs = gh(['pr', 'list', '--repo', REPO, '--head', branch, '--state', 'all', '--json', 'number', '--limit', '1']);
+      const prs = gh(['pr', 'list', '--repo', REPO, '--head', branch, '--state', 'open', '--json', 'number', '--limit', '1']);
       if (Array.isArray(prs) && prs.length) return true;
     } catch { /* ignore */ }
   }


### PR DESCRIPTION
## Implementato

Osservazione misurata 7gg (2026-06-05→06-12) del loop autonomo: ~89 invocazioni Claude/giorno, con tre classi di spreco. Questa PR le attacca tutte e tre.

- **Turn-cap bumps sopra il punto di morte osservato** (`error_max_turns` = failure class dominante; un run morto al cap brucia tutto il budget con zero output, poi viene ritentato = doppio burn):
  - `pr-review-loop.yml` tier normal 15→25 — 13 fail/7gg a num_turns=16 (run 27345572135, 27340191180), review intera bruciata + PR ferma fino al rescuer.
  - `issue-fix.yml` tier high (opus) 40→50 — 44 fail/7gg a num_turns=41 (run 27386343034).
  - `pr-redflag-fixer.yml` 30→45 — 25 fail vs 20 success/7gg, TUTTI al cap (run 27390252111/27375482475/27373263097): peggior failure-rate del loop.
- **Fix zombie `agent:fix` nel drainer** (`scripts/ci/followup-drainer.mjs`): `hasFixPR` usava `--state all`, quindi una PR fix MERGED parziale (senza `Closes`) contava come in-flight per sempre → issue mai rescued né parked. Casi reali: #1049 (11 giorni), #1707, #1824. Ora conta solo PR OPEN; il pre-flight already-resolved di issue-fix protegge dai re-run inutili.
- **Sibling-check deterministico a PR-open**: nuovo job zero-Claude in `pr-body-contract.yml` che esegue `check-sibling-patterns.mjs` e posta sticky comment `<!-- sibling-check -->` con i file gemelli candidati. Il 🔴 `sibling-class-fix` è il finding reviewer dominante (4/5 dei 🔴 campionati; ~98 re-review + 37 round fixer extra/7gg). Advisory, mai `setFailed` (euristico).
- **Reviewer consuma la lista**: il prompt di `pr-review-loop.yml` (step cross-file probing) ora parte dallo sticky sibling-check invece di ricostruire le grep a mano → turni risparmiati per review.

## Non implementato (ancora)

- **Tier non bumpati** (stessa classe, ma zero `error_max_turns` osservati → claim non misurato, niente bump speculativo): review-loop high 40 e minimal 8 (revert-trigger 8→12 già documentato nel file), issue-fix sonnet 30, post-merge-followup 20, lessons-harvester 20. Se compaiono fail al cap → stessa ricetta.
- **Sibling candidates su questo diff** (`lessons-harvester.yml`/`post-merge-followup.yml` via `allowedTools`, `FuelPriceStats.tsx` via `setFailed`, `check-seo-moratorium.mjs` via `BASE_REF`): ispezionati, token-match senza antipattern condiviso — nessuno ha cap con fail osservati né usa `hasFixPR`.
- **PAT-down = degrado silenzioso a catena** (auto-merge senza deploy, drainer congelato, triage inerte — solo ::warning, nessuna issue auto-aperta): follow-up, prossima wave.
- **post-merge-followup senza retry** (1 fail/7gg, 🟡/❓ evaporano): impatto basso, follow-up.
- **Policy sweep `fu-parked`** (19 issue, 28% backlog, crescita silenziosa): follow-up, prossima wave.
- **Effetto dei bump non validabile pre-merge** (i fail si osservano solo su run live): revert-trigger esplicito — se nei prossimi 7gg il failure-rate `error_max_turns` di review-loop/issue-fix/redflag-fixer non scende, o compaiono run runaway vicini ai nuovi cap, revert del bump corrispondente.

Nota merge: questa PR tocca `pr-review-loop.yml` → workflow-validation della GitHub App fallisce → reviewer non posta → merge manuale previsto (eccezione AGENTS.md § Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)