### PR TITLE
fix(loop): self-healing dead-ends — inline PAT-down alert + post-merge-followup self-retry

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # alert PAT-down (github-issue-creator)
 
 jobs:
   auto-merge:
@@ -89,6 +90,19 @@ jobs:
       - name: Load secrets from Remote Config
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
+
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       # ── Risolvi il PR number dall'evento ─────────────────────────────────
       # pull_request_review: PR = quella dell'evento.

--- a/.github/workflows/followup-drainer.yml
+++ b/.github/workflows/followup-drainer.yml
@@ -59,6 +59,19 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Drain follow-up queue (deterministic, no Claude)
         env:
           # PAT (owner) OBBLIGATORIO: il `labeled` agent:fix deve triggerare

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -63,6 +63,19 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Classify and route (deterministic, no Claude)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: write # self-retry via workflow_dispatch (vedi step "Retry once")
 
 jobs:
   followup:
@@ -110,6 +111,26 @@ jobs:
             - Mai chiudere/riaprire issue.
             - Incerto sul filtro → crea con rationale "needs triage".
             - Zero candidate → `## Post-merge follow-up triage: zero outstanding items.` e termina.
+
+
+      # Un run fallito (error_max_turns, 400 upstream, transient) = triage
+      # PERSO per sempre: i 🟡/❓ del reviewer e gli item `## Non implementato`
+      # evaporano senza retry ne' monitor (unico recupero era il dispatch
+      # manuale). Self-retry UNA volta via workflow_dispatch: l'eccezione
+      # anti-ricorsione di GitHub consente a GITHUB_TOKEN di creare run
+      # workflow_dispatch, e il gate `event_name == 'pull_request'` rende il
+      # retry non ricorsivo by-construction (il run di retry e' un dispatch:
+      # se fallisce anche lui, questo step e' skipped -> bounded a 1).
+      - name: Retry once on failure (self-dispatch)
+        if: failure() && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::warning::post-merge-followup fallito su PR #${{ github.event.pull_request.number }} — self-retry via workflow_dispatch (1 tentativo)."
+          gh workflow run post-merge-followup.yml --ref main \
+            -f pr_number="${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}"
 
       - name: Claude usage metrics
         if: always()

--- a/.github/workflows/pr-autorebase.yml
+++ b/.github/workflows/pr-autorebase.yml
@@ -38,6 +38,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # alert PAT-down (github-issue-creator)
 
 jobs:
   autorebase:
@@ -72,6 +73,19 @@ jobs:
       - name: Load secrets from Remote Config (GITHUB_PAT)
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
+
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Rebase near-merge PRs (deterministic, no Claude)
         env:

--- a/.github/workflows/pr-collision-detector.yml
+++ b/.github/workflows/pr-collision-detector.yml
@@ -27,6 +27,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write # alert PAT-down (github-issue-creator)
 
 jobs:
   detect:
@@ -61,6 +62,19 @@ jobs:
       - name: Load secrets from Remote Config (GITHUB_PAT)
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
+
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Detect funnel-critical collisions (deterministic, no Claude)
         env:

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -76,6 +76,19 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       # ── Round cap + capability guard (deterministico, prima di Claude) ────
       # Conta i marker `<!-- REDFLAG_FIX_ROUND: N -->` già sulla PR. A N>=2 →
       # escalation a needs-human, STOP senza Claude. Altrimenti incrementa.

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -69,6 +69,19 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
+      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # cascade, coda congelata, routing/re-queue inerti). Alert inline
+      # deterministico, dedup sul titolo canonico del monitor daily
+      # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
+      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Recycle deeply-stale stale-review PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/alert-pat-down.mjs
+++ b/scripts/ci/alert-pat-down.mjs
@@ -1,0 +1,65 @@
+/**
+ * alert-pat-down.mjs — inline alert deterministico (zero-Claude) per il
+ * degrado "GITHUB_PAT non caricato da Remote Config".
+ *
+ * Root cause: i workflow del loop autonomo (followup-drainer, auto-merge,
+ * issue-triage, pr-autorebase, recycle-stale-prs) a PAT mancante degradano
+ * SILENZIOSAMENTE — merge senza cascade deploy/followup, coda follow-up
+ * congelata, routing inerte, PR chiuse senza re-queue — con un semplice
+ * ::warning che nessuno legge. Il monitor daily `gh-pat-expiry-monitor.yml`
+ * copre il caso ma con latenza fino a ~24h (cron 06:30): un PAT-down alle
+ * 07:00 lascia il loop degradato quasi un giorno intero.
+ *
+ * Questo script chiude la finestra: ogni workflow consumer lo invoca inline
+ * nel momento in cui rileva `env.GITHUB_PAT` vuoto (unico segnale affidabile:
+ * `load-rc-env.mjs` esce SEMPRE 0 by-design). Il titolo è IDENTICO a quello
+ * del monitor → il dedup di github-issue-creator converge sull'issue canonica
+ * e l'auto-close-on-recovery del monitor resta l'unico punto di chiusura.
+ *
+ * ⚠ Tenere PAT_DOWN_TITLE in sync con LOAD_FAIL_TITLE in
+ * .github/workflows/gh-pat-expiry-monitor.yml (literal duplicato lì perché il
+ * monitor è bash-in-YAML; questo modulo è la copia canonica lato code).
+ *
+ * Uso (da workflow step, GH_TOKEN=GITHUB_TOKEN — NON il PAT: è la cosa rotta):
+ *   node scripts/ci/alert-pat-down.mjs --workflow "<nome>" --run-url "<url>"
+ *
+ * Mai label `follow-up` (il triage la instraderebbe in coda fixer: il fixer
+ * non può fixare un outage di Remote Config). Solo `automation` + urgent.
+ */
+import { createGithubIssue } from '../lib/github-issue-creator.mjs';
+
+export const PAT_DOWN_TITLE = 'Agent loop down: GITHUB_PAT failed to load';
+
+const argv = process.argv.slice(2);
+const opt = (flag) => {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : '';
+};
+
+if (process.argv[1]?.endsWith('alert-pat-down.mjs')) {
+  const workflow = opt('--workflow') || 'unknown-workflow';
+  const runUrl = opt('--run-url') || '';
+  const description =
+    `Rilevato INLINE da \`${workflow}\`${runUrl ? ` (${runUrl})` : ''}: ` +
+    '`env.GITHUB_PAT` vuoto dopo `scripts/load-rc-env.mjs` (che esce sempre 0 — ' +
+    'il segnale è solo l\'env vuoto). Il workflow ha degradato al suo percorso ' +
+    'inerte/fallback: cascade merge→deploy→followup, drain della coda follow-up, ' +
+    'routing triage e re-queue recycle sono FERMI finché il PAT non torna.\n\n' +
+    'Cause probabili: Remote Config outage · `FIREBASE_SERVICE_ACCOUNT_JSON` ' +
+    'assente/ruotato · param `GITHUB_PAT` cancellato da RC · PAT revocato.\n\n' +
+    'Recovery: l\'issue si auto-chiude al prossimo run verde di ' +
+    '`gh-pat-expiry-monitor.yml` (stesso titolo canonico → dedup).';
+  createGithubIssue({
+    title: PAT_DOWN_TITLE,
+    description,
+    priority: 1,
+    labels: ['automation'],
+    workflow,
+  }).then(
+    () => console.log('PAT-down alert emesso (o recurrence commentata sull\'issue canonica).'),
+    (e) => {
+      // Best-effort: l'alert non deve mai rompere il workflow chiamante.
+      console.log(`::warning::alert-pat-down fallito: ${String(e).slice(0, 200)}`);
+    },
+  );
+}


### PR DESCRIPTION
## Implementato

Wave 2 dell'ottimizzazione loop autonomo (segue #1919). Due dead-end a degrado silenzioso, entrambi NON auto-fixabili dal fixer CI (toccano `.github/workflows/**` = fuori capability scope, vedi park di #1821 `blocked-workflows-scope`):

- **Alert PAT-down inline** (`scripts/ci/alert-pat-down.mjs`, nuovo, zero-Claude): quando `env.GITHUB_PAT` è vuoto dopo `load-rc-env.mjs` (che esce sempre 0 — l'env vuoto è l'unico segnale), i 7 workflow loop-critical emettono issue dedup `priority:urgent` via `github-issue-creator.mjs` col titolo canonico del monitor daily (`Agent loop down: GITHUB_PAT failed to load`) → converge sull'issue canonica, auto-close resta al monitor. Chiude la finestra di ~24h del solo cron. Workflow: `followup-drainer`, `auto-merge-on-lgtm` (caso peggiore: prima degradava a merge-senza-cascade SENZA nemmeno un warning), `issue-triage`, `pr-autorebase`, `recycle-stale-prs`, `pr-collision-detector`, `pr-redflag-fixer`. Aggiunto `issues: write` ai 3 che non l'avevano (auto-merge, autorebase, collision-detector). Step `continue-on-error: true` + catch interno: l'alert non rompe mai il chiamante.
- **post-merge-followup self-retry** (1 volta): su `failure()` con evento `pull_request`, self-dispatch via `workflow_dispatch` (input `pr_number` già esistente). Bounded by-construction: il run di retry è un dispatch → il suo step di retry è skipped. Usa l'eccezione anti-ricorsione GitHub per `workflow_dispatch` (GITHUB_TOKEN basta, niente PAT). Aggiunto `actions: write`. Prima un fail = triage perso per sempre (🟡/❓ evaporati).

Item 3 di #1923 (policy sweep `fu-parked`): **già coperto by-design** — `isAgeOutEligible` nel drainer esclude solo `agent:fix`/`agent:fix-queued`, quindi le 19 `fu-parked` rientrano nell'age-out close (21gg età + 14gg idle, cap 20/run) e drenano da sole. Nessun code change necessario.

Closes #1923

## Non implementato (ancora)

- **Altri 10 consumer di GITHUB_PAT senza alert inline** (`batch-faq-articles`, `discover-404s*`, `generate-article`, `monitor-gsc-seo`, `refine-url-first-seen`, `refresh-bfs-stats`, `snapshot-jobs-weekly`, `sync-gsc-orphans`, `traffic-data-freshness`): non loop-critical — il degrado è locale al singolo run (contenuto/monitoring), visibile dal run stesso, e il monitor daily li copre comunque. Se il pattern si dimostra utile, sweep follow-up.
- **Caso "PAT presente ma revocato"**: l'inline check vede solo l'env vuoto; il revoked-but-set resta al monitor daily (`gh api user`), accettabile.
- **Validazione live del retry followup**: non triggerabile pre-merge (serve un fail reale di un run `pull_request`); osservazione sui prossimi fail organici (~1/7gg). Revert-trigger: se il retry produce doppio triage (issue duplicate sulla stessa PR) → revert dello step.

Nota merge: tocca `auto-merge-on-lgtm.yml` e `post-merge-followup.yml` → workflow-validation della GitHub App fallisce → reviewer non posta → merge manuale previsto (eccezione AGENTS.md § Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)