### PR TITLE
fix(loop): watcher-of-the-watcher — PAT monitor crash fix, class-A review re-trigger, loop-health report

### DIFF
--- a/.github/workflows/gh-pat-expiry-monitor.yml
+++ b/.github/workflows/gh-pat-expiry-monitor.yml
@@ -98,6 +98,7 @@ jobs:
         run: node scripts/load-rc-env.mjs
 
       - name: Check PAT load-failure + expiry
+        id: patcheck
         env:
           WARN_DAYS: ${{ inputs.warn_days || '30' }}
           # GH_REPO is consumed by github-issue-creator.mjs for the --repo flag.
@@ -132,8 +133,13 @@ jobs:
             else
               echo "✅ PAT authenticates as '$LOGIN'."
               HEADERS="$(GH_TOKEN="$GITHUB_PAT" gh api -i / 2>/dev/null || true)"
+              # `|| true` obbligatorio: con `set -euo pipefail` un grep senza
+              # match (PAT classic SENZA header expiration = il caso normale)
+              # esce 1 e uccide lo script PRIMA di ogni alert/recovery — il
+              # monitor e' morto cosi' a OGNI run dal 2026-06-01 al 06-12,
+              # in silenzio (vedi fix + self-alert in fondo al workflow).
               EXPIRY="$(printf '%s\n' "$HEADERS" \
-                | grep -i '^github-authentication-token-expiration:' \
+                | { grep -i '^github-authentication-token-expiration:' || true; } \
                 | head -n1 \
                 | sed -E 's/^[^:]+:[[:space:]]*//' \
                 | tr -d '\r')"
@@ -176,6 +182,7 @@ jobs:
               --label automation \
               --workflow "GH_PAT Expiry Monitor"
 
+            echo "intentional_fail=true" >> "$GITHUB_OUTPUT"
             echo "::error::GITHUB_PAT load-failure detected — failing the run after filing the urgent alert."
             exit 1
           fi
@@ -252,6 +259,27 @@ jobs:
           node scripts/lib/github-issue-creator.mjs \
             --title "$EXPIRY_TITLE" \
             --description "$DESCRIPTION" \
+            --priority 2 \
+            --label automation \
+            --workflow "GH_PAT Expiry Monitor"
+
+      # Watcher-del-watcher: il monitor e' l'unico presidio del PAT-down, ma se
+      # CRASHA per un bug proprio (es. pipeline EXPIRY sotto pipefail, rotto
+      # in silenzio 2026-06-01->06-12) nessuno se ne accorge e tutta la
+      # rilevazione+recovery e' morta. Su failure NON intenzionale → issue
+      # dedup (titolo stabile, github-issue-creator) cosi' il loop issue-fix
+      # o l'owner la vedono subito. GH_TOKEN = GITHUB_TOKEN (il PAT potrebbe
+      # essere proprio la cosa rotta).
+      - name: Self-alert on monitor crash (dedup, zero-Claude)
+        if: failure() && steps.patcheck.outputs.intentional_fail != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "PAT monitor crashed: gh-pat-expiry-monitor failing" \
+            --description "Il run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} e' FALLITO senza passare dal path intenzionale di PAT-down ('intentional_fail' assente). Significa che il monitor stesso e' rotto: finche' non viene fixato, NESSUNO rileva un PAT-down ne' auto-chiude l'alert canonico. Storico: un bug pipefail l'ha tenuto rosso in silenzio dal 2026-06-01 al 06-12. Leggi il log del run e fixa la root cause." \
             --priority 2 \
             --label automation \
             --workflow "GH_PAT Expiry Monitor"

--- a/.github/workflows/gh-pat-expiry-monitor.yml
+++ b/.github/workflows/gh-pat-expiry-monitor.yml
@@ -271,7 +271,11 @@ jobs:
       # o l'owner la vedono subito. GH_TOKEN = GITHUB_TOKEN (il PAT potrebbe
       # essere proprio la cosa rotta).
       - name: Self-alert on monitor crash (dedup, zero-Claude)
-        if: failure() && steps.patcheck.outputs.intentional_fail != 'true'
+        # Gate su patcheck.conclusion: un flake infra (npm ci, setup-node,
+        # load RC) farebbe failure()=true con patcheck SKIPPED → issue
+        # depistante "monitor crashed" per una causa transiente. Alert solo se
+        # e' davvero lo step di check a fallire in modo non-intenzionale.
+        if: failure() && steps.patcheck.conclusion == 'failure' && steps.patcheck.outputs.intentional_fail != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/loop-health-report.yml
+++ b/.github/workflows/loop-health-report.yml
@@ -1,0 +1,69 @@
+# Osservabilità deterministica del loop autonomo (ZERO-Claude).
+#
+# Il ciclo osserva→fixa→valida del loop (review/issue-fix/followup/rescuer)
+# finora richiedeva un'analisi manuale multi-ora per misurare failure-rate,
+# overhead review e zombie (fatta il 2026-06-12 → tuning #1919/#1926). Questo
+# cron la automatizza: report settimanale con soglie ⚠️, postato come commento
+# su una issue-tracker permanente — il lessons-harvester e l'owner hanno i
+# numeri senza spendere un token Claude.
+#
+# Validazione tuning: dopo un cambio ai cap/gate (es. turn-cap bump #1919) il
+# primo report dice se il failure-rate è sceso o se va revertato (revert-trigger
+# dichiarati nei PR body).
+name: Loop health report (zero-Claude)
+
+on:
+  schedule:
+    # Lunedì 05:45 UTC — dopo il lessons-harvester (05:17) così un harvest
+    # appena uscito è già visibile, prima del compress-docs (04:00 +1g).
+    - cron: '45 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Finestra di osservazione in giorni'
+        required: false
+        type: string
+        default: '7'
+      no_post:
+        description: 'Solo stdout, niente commento sulla issue tracker'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  # gh run list legge le Actions API: read è implicito nel GITHUB_TOKEN.
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: loop-health-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Compute and post loop health report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ARGS="--days ${{ github.event.inputs.days || '7' }}"
+          if [ "${{ github.event.inputs.no_post }}" = "true" ]; then
+            ARGS="$ARGS --no-post"
+          fi
+          node scripts/ci/loop-health-report.mjs $ARGS | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -303,7 +303,11 @@ jobs:
           SRC_PASS=0
           SRC_FAIL=0
           while IFS= read -r line; do
-            rc=$(printf '%s' "$line" | grep -oE 'rc=[0-9]+$' | sed 's/rc=//')
+            # `|| true`: riga malformata (senza rc=N) + set -euo pipefail
+            # ucciderebbe il summary a meta' loop (stessa classe del bug che ha
+            # tenuto rosso gh-pat-expiry-monitor 06-01->06-12); rc vuoto cade
+            # nel ramo FAIL ed e' visibile, niente crash.
+            rc=$(printf '%s' "$line" | { grep -oE 'rc=[0-9]+$' || true; } | sed 's/rc=//')
             if [ "$rc" = "0" ]; then
               printf "✅ PASS  %s\n" "$line"
               SRC_PASS=$((SRC_PASS + 1))
@@ -505,7 +509,11 @@ jobs:
           PB_PASS=0
           PB_FAIL=0
           while IFS= read -r line; do
-            rc=$(printf '%s' "$line" | grep -oE 'rc=[0-9]+$' | sed 's/rc=//')
+            # `|| true`: riga malformata (senza rc=N) + set -euo pipefail
+            # ucciderebbe il summary a meta' loop (stessa classe del bug che ha
+            # tenuto rosso gh-pat-expiry-monitor 06-01->06-12); rc vuoto cade
+            # nel ramo FAIL ed e' visibile, niente crash.
+            rc=$(printf '%s' "$line" | { grep -oE 'rc=[0-9]+$' || true; } | sed 's/rc=//')
             if [ "$rc" = "0" ]; then
               printf "✅ PASS  %s\n" "$line"
               PB_PASS=$((PB_PASS + 1))

--- a/.github/workflows/recycle-stale-prs.yml
+++ b/.github/workflows/recycle-stale-prs.yml
@@ -164,3 +164,33 @@ jobs:
             fi
           done
           echo "Recycle scan completo."
+
+      # Visibilita' needs-human: il 🔴-fixer al round-cap etichetta `needs-human`
+      # e STOPPA (by-design), ma NESSUN processo rilancia o segnala quelle PR —
+      # restano ferme finche' l'owner non guarda a mano la PR list (osservato
+      # #1526: 102h di latenza). Issue dedup giornaliera (titolo stabile, si
+      # aggiorna via recurrence-comment) finche' esistono PR needs-human aperte.
+      - name: Surface needs-human PRs (dedup, zero-Claude)
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          LIST=$(gh pr list --repo "$GH_REPO" --state open --label needs-human \
+            --json number,title,updatedAt \
+            --jq '.[] | "- #\(.number) \(.title) (ultimo update \(.updatedAt))"')
+          if [ -z "$LIST" ]; then
+            echo "Nessuna PR needs-human aperta."
+            exit 0
+          fi
+          COUNT=$(printf '%s\n' "$LIST" | wc -l | tr -d ' ')
+          echo "PR needs-human aperte: $COUNT"
+          DESC=$(printf 'Il fixer dei red-flag ha raggiunto il round-cap su queste PR e si e fermato (anti-loop): nessun processo automatico le sblocchera. Servono occhi umani:\n\n%s\n\n_Issue dedup giornaliera da recycle-stale-prs.yml (zero-Claude); si aggiorna con un commento di recurrence finche esistono PR needs-human. Chiudila quando la lista e vuota._' "$LIST")
+          node scripts/lib/github-issue-creator.mjs \
+            --title "needs-human: PR bloccate in attesa di revisione umana" \
+            --description "$DESC" \
+            --priority 2 \
+            --label automation \
+            --workflow "Recycle stale PRs"

--- a/scripts/ci/loop-health-report.mjs
+++ b/scripts/ci/loop-health-report.mjs
@@ -71,9 +71,13 @@ function mergedPrStats(since) {
   } catch { /* noop */ }
   const claudeReviews = (pr) => (pr.reviews || []).filter((r) => /^claude/i.test(r.author?.login || '')).length;
   const merged = prs.length;
-  const firstShot = prs.filter((p) => claudeReviews(p) <= 1).length;
+  // === 1 (non <=1): una PR mergiata con ZERO review claude (merge manuale,
+  // o reopen-path prima che la review atterri) non e' un "first-shot LGTM" —
+  // contarla gonfierebbe la metrica (adversarial check review #1930).
+  const firstShot = prs.filter((p) => claudeReviews(p) === 1).length;
+  const zeroReview = prs.filter((p) => claudeReviews(p) === 0).length;
   const totalReviews = prs.reduce((a, p) => a + claudeReviews(p), 0);
-  return { merged, firstShot, totalReviews };
+  return { merged, firstShot, zeroReview, totalReviews };
 }
 
 /** Zombie: issue follow-up con agent:fix, ferma da >24h, senza PR fix APERTA
@@ -130,7 +134,7 @@ function main() {
   const fsRate = pr.merged ? pr.firstShot / pr.merged : 0;
   if (pr.merged >= 10 && fsRate < 0.5) warns.push(`first-shot LGTM rate ${(fsRate * 100).toFixed(0)}% (<50%)`);
   lines.push('');
-  lines.push(`**PR merged:** ${pr.merged} (${(pr.merged / DAYS).toFixed(1)}/g) · first-shot LGTM ${pr.firstShot}/${pr.merged} (${(fsRate * 100).toFixed(0)}%) · review Claude totali ${pr.totalReviews} (overhead ${pr.merged ? ((pr.totalReviews / Math.max(pr.merged, 1) - 1) * 100).toFixed(0) : 0}%).`);
+  lines.push(`**PR merged:** ${pr.merged} (${(pr.merged / DAYS).toFixed(1)}/g) · first-shot LGTM ${pr.firstShot}/${pr.merged} (${(fsRate * 100).toFixed(0)}%, zero-review ${pr.zeroReview}) · review Claude totali ${pr.totalReviews} (overhead ${pr.merged ? ((pr.totalReviews / Math.max(pr.merged, 1) - 1) * 100).toFixed(0) : 0}%).`);
 
   const zombies = zombieCount();
   if (zombies > 0) warns.push(`${zombies} issue agent:fix zombie (>24h, nessuna PR aperta)`);

--- a/scripts/ci/loop-health-report.mjs
+++ b/scripts/ci/loop-health-report.mjs
@@ -1,0 +1,177 @@
+/**
+ * loop-health-report.mjs — osservabilità DETERMINISTICA del loop autonomo
+ * (zero-Claude). Calcola le metriche di salute che altrimenti vanno raccolte
+ * a mano (fatto l'ultima volta il 2026-06-12, ~4 agent-ore): failure-rate per
+ * workflow Claude, first-shot LGTM rate, zombie agent:fix, backlog coda.
+ *
+ * Perché: il sistema si auto-ripara solo se l'osservazione è essa stessa
+ * automatica. Questo report chiude il ciclo osserva→fixa→valida: dopo ogni
+ * tuning (es. turn-cap bump #1919) il trend dei failure-rate dice se il fix
+ * performa o va revertato — senza sessione di analisi dedicata.
+ *
+ * Output: report markdown su stdout + commento su una issue-tracker dedup
+ * (titolo stabile, find-or-create) così lo storico resta consultabile in un
+ * posto solo. Soglie ⚠️ inline per le regressioni più care.
+ *
+ * Uso:  node scripts/ci/loop-health-report.mjs [--days 7] [--no-post]
+ * Env:  GH_TOKEN (GITHUB_TOKEN basta: sola lettura + issue comment),
+ *       GITHUB_REPOSITORY o GH_REPO.
+ */
+import { execFileSync } from 'node:child_process';
+
+const REPO = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
+const argv = process.argv.slice(2);
+const DAYS = Number(argv.includes('--days') ? argv[argv.indexOf('--days') + 1] : 7);
+const NO_POST = argv.includes('--no-post');
+const TRACKER_TITLE = '📊 Loop health report (tracker)';
+
+// Workflow Claude = i soli 5 che bruciano quota Max (AGENTS.md § frugalità).
+const CLAUDE_WORKFLOWS = [
+  'pr-review-loop.yml',
+  'issue-fix.yml',
+  'pr-redflag-fixer.yml',
+  'post-merge-followup.yml',
+  'lessons-harvester.yml',
+];
+// Failure-rate sopra questa soglia (sui run reali, esclusi skipped/cancelled)
+// = regressione da investigare (baseline post-#1919: redflag-fixer era al 56%).
+const FAIL_RATE_WARN = 0.2;
+
+function gh(args, { json = true } = {}) {
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return json ? JSON.parse(out) : out;
+}
+
+function isoDaysAgo(d) {
+  return new Date(Date.now() - d * 86_400_000).toISOString().slice(0, 10);
+}
+
+function runStats(workflow, since) {
+  let runs = [];
+  try {
+    runs = gh(['run', 'list', '--repo', REPO, '--workflow', workflow,
+      '--created', `>${since}`, '--limit', '1000', '--json', 'conclusion,status']);
+  } catch { /* workflow senza run nel periodo */ }
+  const total = runs.length;
+  const by = {};
+  for (const r of runs) {
+    const k = r.conclusion || r.status || 'unknown';
+    by[k] = (by[k] || 0) + 1;
+  }
+  const real = total - (by.cancelled || 0) - (by.skipped || 0); // run che hanno lavorato
+  const fail = by.failure || 0;
+  return { total, real, fail, ok: by.success || 0, cancelled: by.cancelled || 0, skipped: by.skipped || 0, rate: real ? fail / real : 0 };
+}
+
+function mergedPrStats(since) {
+  let prs = [];
+  try {
+    prs = gh(['pr', 'list', '--repo', REPO, '--state', 'merged',
+      '--search', `merged:>${since}`, '--limit', '300', '--json', 'number,reviews']);
+  } catch { /* noop */ }
+  const claudeReviews = (pr) => (pr.reviews || []).filter((r) => /^claude/i.test(r.author?.login || '')).length;
+  const merged = prs.length;
+  const firstShot = prs.filter((p) => claudeReviews(p) <= 1).length;
+  const totalReviews = prs.reduce((a, p) => a + claudeReviews(p), 0);
+  return { merged, firstShot, totalReviews };
+}
+
+/** Zombie: issue follow-up con agent:fix, ferma da >24h, senza PR fix APERTA
+ * (stessa semantica open-only del drainer post-#1919). */
+function zombieCount() {
+  let issues = [];
+  try {
+    issues = gh(['issue', 'list', '--repo', REPO, '--state', 'open',
+      '--label', 'agent:fix', '--label', 'follow-up',
+      '--json', 'number,updatedAt', '--limit', '100']);
+  } catch { /* noop */ }
+  const old = issues.filter((i) => Date.now() - Date.parse(i.updatedAt) > 24 * 3_600_000);
+  let z = 0;
+  for (const i of old) {
+    try {
+      const prs = gh(['pr', 'list', '--repo', REPO, '--head', `fix/issue-${i.number}`,
+        '--state', 'open', '--json', 'number', '--limit', '1']);
+      if (!Array.isArray(prs) || prs.length === 0) z++;
+    } catch { /* conservativo: non contare */ }
+  }
+  return z;
+}
+
+function labelCount(label) {
+  try {
+    const out = gh(['issue', 'list', '--repo', REPO, '--state', 'open',
+      '--label', label, '--json', 'number', '--limit', '200']);
+    return Array.isArray(out) ? out.length : 0;
+  } catch { return 0; }
+}
+
+function main() {
+  if (!REPO) { console.error('GITHUB_REPOSITORY/GH_REPO mancante'); process.exit(1); }
+  const since = isoDaysAgo(DAYS);
+  const lines = [];
+  const warns = [];
+
+  lines.push(`## Loop health — ultimi ${DAYS}gg (dal ${since})`);
+  lines.push('');
+  lines.push('| Workflow Claude | run reali | ok | fail | rate | canc | skip |');
+  lines.push('|---|---|---|---|---|---|---|');
+  let claudePerDay = 0;
+  for (const wf of CLAUDE_WORKFLOWS) {
+    const s = runStats(wf, since);
+    claudePerDay += s.real / DAYS;
+    const flag = s.rate > FAIL_RATE_WARN && s.real >= 5 ? ' ⚠️' : '';
+    if (flag) warns.push(`failure-rate ${(s.rate * 100).toFixed(0)}% su ${wf} (${s.fail}/${s.real} run reali)`);
+    lines.push(`| ${wf}${flag} | ${s.real} | ${s.ok} | ${s.fail} | ${(s.rate * 100).toFixed(0)}% | ${s.cancelled} | ${s.skipped} |`);
+  }
+  lines.push('');
+  lines.push(`**Invocazioni Claude ≈ ${claudePerDay.toFixed(0)}/giorno** (run reali, proxy token-burn).`);
+
+  const pr = mergedPrStats(since);
+  const fsRate = pr.merged ? pr.firstShot / pr.merged : 0;
+  if (pr.merged >= 10 && fsRate < 0.5) warns.push(`first-shot LGTM rate ${(fsRate * 100).toFixed(0)}% (<50%)`);
+  lines.push('');
+  lines.push(`**PR merged:** ${pr.merged} (${(pr.merged / DAYS).toFixed(1)}/g) · first-shot LGTM ${pr.firstShot}/${pr.merged} (${(fsRate * 100).toFixed(0)}%) · review Claude totali ${pr.totalReviews} (overhead ${pr.merged ? ((pr.totalReviews / Math.max(pr.merged, 1) - 1) * 100).toFixed(0) : 0}%).`);
+
+  const zombies = zombieCount();
+  if (zombies > 0) warns.push(`${zombies} issue agent:fix zombie (>24h, nessuna PR aperta)`);
+  const queued = labelCount('agent:fix-queued');
+  const parked = labelCount('fu-parked');
+  const needsHuman = labelCount('needs-human');
+  lines.push(`**Backlog:** agent:fix zombie ${zombies} · in coda ${queued} · fu-parked ${parked} · needs-human ${needsHuman}.`);
+
+  lines.push('');
+  lines.push(warns.length
+    ? `### ⚠️ Da investigare\n${warns.map((w) => `- ${w}`).join('\n')}`
+    : '### ✅ Nessuna soglia superata');
+  lines.push('');
+  lines.push('_Report deterministico da loop-health-report.yml (zero-Claude). Baseline 2026-06-12 pre-tuning: ~89 run/g, redflag-fail 56%, first-shot 69%._');
+
+  const report = lines.join('\n');
+  console.log(report);
+
+  if (NO_POST) return;
+  // Find-or-create issue tracker, poi commenta il report (storico in un posto).
+  let num = null;
+  try {
+    const found = gh(['issue', 'list', '--repo', REPO, '--state', 'open',
+      '--search', `in:title "${TRACKER_TITLE}"`, '--json', 'number,title', '--limit', '5']);
+    num = (found.find((i) => i.title === TRACKER_TITLE) || {}).number || null;
+  } catch { /* noop */ }
+  if (!num) {
+    try {
+      const url = gh(['issue', 'create', '--repo', REPO, '--title', TRACKER_TITLE,
+        '--label', 'automation',
+        '--body', 'Tracker permanente: il report settimanale di salute del loop autonomo atterra qui come commento (loop-health-report.yml, zero-Claude). NON chiudere: il prossimo run la ricreerebbe.'],
+        { json: false });
+      num = Number((url.match(/\/issues\/(\d+)/) || [])[1]) || null;
+    } catch (e) { console.log(`::warning::create tracker fallita: ${String(e).slice(0, 160)}`); }
+  }
+  if (num) {
+    try {
+      gh(['issue', 'comment', String(num), '--repo', REPO, '--body', report], { json: false });
+      console.log(`Report postato su #${num}.`);
+    } catch (e) { console.log(`::warning::comment fallito: ${String(e).slice(0, 160)}`); }
+  }
+}
+
+main();

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -110,15 +110,30 @@ function hasAnyClaudeReview(num) {
  * osservata, dead-end #4 della mappa loop 2026-06-12). */
 function reopenToRetrigger(num) {
   if (DRY) { console.log(`[dry] close+reopen #${num} (re-trigger review+tests)`); return true; }
-  const closed = gh(['pr', 'close', String(num), '--repo', REPO], { json: false, allowFail: true });
-  if (closed === null) { console.log(`PR #${num}: close fallito — skip reopen.`); return false; }
-  const reopened = gh(['pr', 'reopen', String(num), '--repo', REPO], { json: false, allowFail: true });
-  if (reopened === null) {
-    // Mai lasciare la PR chiusa: retry una volta, poi log forte.
-    const retry = gh(['pr', 'reopen', String(num), '--repo', REPO], { json: false, allowFail: true });
-    if (retry === null) { console.log(`::error::PR #${num} chiusa ma reopen FALLITO due volte — riaprire a mano!`); return false; }
+  // NIENTE allowFail qui: con `json:false` allowFail ritorna '' sia su successo
+  // (gh pr close/reopen confermano su stderr, stdout vuoto) sia su fallimento —
+  // l'unico segnale affidabile è l'eccezione (🔴 review #1930: i guard ===null
+  // non scattavano mai → rischio PR lasciata CHIUSA con falso successo).
+  try {
+    gh(['pr', 'close', String(num), '--repo', REPO], { json: false });
+  } catch (e) {
+    console.log(`PR #${num}: close fallito (${String(e).slice(0, 120)}) — skip reopen, PR intatta.`);
+    return false;
   }
-  return true;
+  // Da qui la PR È CHIUSA: mai uscire senza riaprirla. Retry una volta, poi
+  // ::error forte (visibile nel run) — invariante "mai lasciare la PR chiusa".
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      gh(['pr', 'reopen', String(num), '--repo', REPO], { json: false });
+      return true;
+    } catch (e) {
+      if (attempt === 2) {
+        console.log(`::error::PR #${num} chiusa ma reopen FALLITO due volte (${String(e).slice(0, 120)}) — riaprire a mano!`);
+        return false;
+      }
+    }
+  }
+  return false;
 }
 
 /** behind_by: commit di main non nella head. */

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -90,6 +90,37 @@ function hasLgtmReview(num) {
   );
 }
 
+/** Esiste ALMENO una review claude-bot (LGTM o 🔴, qualunque esito)? Serve a
+ * distinguere la classe-A "review mai postata" (workflow-validation drift 401:
+ * run review fallita, body vuoto) da "review postata con 🔴" (gestita dal
+ * redflag-fixer, NON va ri-triggerata qui). */
+function hasAnyClaudeReview(num) {
+  const reviews = gh(['api', `repos/${REPO}/pulls/${num}/reviews`, '--paginate'], { allowFail: true });
+  if (!Array.isArray(reviews)) return true; // fail-safe: su errore API assumi review esistente (no reopen)
+  return reviews.some(
+    (r) => r.user && r.user.type === 'Bot' && /^claude/i.test(r.user.login || '')
+  );
+}
+
+/** Re-trigger DETERMINISTICO di review+tests per una PR classe-A: il push PAT
+ * non ri-triggera `pull_request` in modo affidabile e pr-review-loop non ha
+ * workflow_dispatch — ma un close+reopen via PAT emette `reopened`, che
+ * triggera SIA pr-review-loop SIA tests.yml. Senza questo, una PR rebasata ma
+ * senza review resta senza LGTM fino al recycle 24h (finestra morta ~22h
+ * osservata, dead-end #4 della mappa loop 2026-06-12). */
+function reopenToRetrigger(num) {
+  if (DRY) { console.log(`[dry] close+reopen #${num} (re-trigger review+tests)`); return true; }
+  const closed = gh(['pr', 'close', String(num), '--repo', REPO], { json: false, allowFail: true });
+  if (closed === null) { console.log(`PR #${num}: close fallito — skip reopen.`); return false; }
+  const reopened = gh(['pr', 'reopen', String(num), '--repo', REPO], { json: false, allowFail: true });
+  if (reopened === null) {
+    // Mai lasciare la PR chiusa: retry una volta, poi log forte.
+    const retry = gh(['pr', 'reopen', String(num), '--repo', REPO], { json: false, allowFail: true });
+    if (retry === null) { console.log(`::error::PR #${num} chiusa ma reopen FALLITO due volte — riaprire a mano!`); return false; }
+  }
+  return true;
+}
+
 /** behind_by: commit di main non nella head. */
 function behindMain(head) {
   const out = gh(['api', `repos/${REPO}/compare/main...${head}`, '--jq', '.behind_by // 0'],
@@ -173,10 +204,11 @@ async function processPR(pr) {
   const labels = (pr.labels || []).map((l) => l.name);
 
   // GATE frugalità: solo near-merge.
+  const lgtm = hasLgtmReview(num);
   const nearMerge =
     labels.includes('collision-risk') ||
     labels.includes('stale-review') ||
-    hasLgtmReview(num);
+    lgtm;
   if (!nearMerge) {
     console.log(`PR #${num} non near-merge (no LGTM/collision-risk/stale-review) — skip.`);
     return;
@@ -193,8 +225,15 @@ async function processPR(pr) {
     // appena un run è queued, headHasVitestCheck torna true → niente
     // ri-dispatch. Nessun rebase, nessuna review Claude.
     if (!headHasVitestCheck(head)) {
-      console.log(`PR #${num} 0 dietro main ma head ${head.slice(0, 8)} SENZA check-run vitest → dispatch tests.yml (heal, no rebase).`);
-      dispatchTests(num, branch);
+      if (!lgtm && !hasAnyClaudeReview(num)) {
+        // Classe-A: nemmeno la review esiste (drift 401) — il solo vitest non
+        // sblocca (auto-merge esige LGTM). Reopen = review+tests insieme.
+        console.log(`PR #${num} 0 dietro main, NESSUNA review claude e niente vitest → close+reopen (re-trigger review+tests).`);
+        reopenToRetrigger(num);
+      } else {
+        console.log(`PR #${num} 0 dietro main ma head ${head.slice(0, 8)} SENZA check-run vitest → dispatch tests.yml (heal, no rebase).`);
+        dispatchTests(num, branch);
+      }
     } else {
       console.log(`PR #${num} 0 dietro main, vitest già presente sull'head — skip.`);
     }
@@ -272,6 +311,17 @@ async function processPR(pr) {
   // auto-merge-eval (contributo PR invariato su un rebase di solo main-merge),
   // quindi NESSUNA review Opus/Sonnet gira di nuovo. Best-effort: se il
   // dispatch fallisce (PAT senza scope actions:write) lo logghiamo soltanto.
+  if (!lgtm && !hasAnyClaudeReview(num)) {
+    // Classe-A (review mai postata per drift 401): ora il branch è allineato a
+    // main → la workflow-validation passa, ma serve ri-triggerare la review.
+    // Un dispatch non esiste per pr-review-loop → close+reopen (= reopened
+    // event: review + tests insieme). Costa UNA review Claude, che è comunque
+    // dovuta: la PR non ne ha mai avuta una.
+    if (reopenToRetrigger(num)) {
+      console.log(`✅ PR #${num}: rebasata, pushata e ri-aperta (classe-A senza review) → review+tests ri-triggerati.`);
+    }
+    return;
+  }
   if (dispatchTests(num, branch)) {
     console.log(`✅ PR #${num}: rebasata su origin/main, pushata (${branch}) e dispatchato tests.yml → vitest sull'head; LGTM carry-forward, zero Claude.`);
   }


### PR DESCRIPTION
## Implementato

Wave 3 dell'ottimizzazione loop autonomo (segue #1919, #1926). Chiude i dead-end residui della mappa trigger e automatizza l'osservazione.

- **Fix crash gh-pat-expiry-monitor** (rosso a OGNI run dal 2026-06-01, in silenzio): sotto `set -euo pipefail` il `grep` dell'header `github-authentication-token-expiration` esce 1 quando il PAT è classic senza scadenza (caso normale) → script morto PRIMA di ogni alert/recovery. Guard `{ grep … || true; }`. Diagnosi: log run 27397887462 — `✅ PAT authenticates` poi exit 1 immediato, echo successivo mai stampato.
- **Self-alert sul monitor** (watcher del watcher): step `if: failure()` fuori dal path intenzionale di PAT-down (marker `intentional_fail` su `$GITHUB_OUTPUT`) → issue dedup `PAT monitor crashed`. Senza, un bug del monitor = rilevazione+auto-close morti per giorni (successo 11 giorni).
- **Stessa classe in `post-deploy-validate-dist.yml`** (2 occorrenze): `rc=$(… | grep -oE 'rc=[0-9]+$' …)` sotto pipefail — riga malformata avrebbe ucciso il summary a metà loop. Guard identico; rc vuoto cade nel ramo FAIL visibile.
- **Re-trigger review classe-A in autorebase** (`scripts/ci/pr-autorebase.mjs`): PR rebasata che NON ha NESSUNA review claude (drift 401 → review mai postata) → `close`+`reopen` via PAT: l'evento `reopened` ri-triggera pr-review-loop E tests insieme (pr-review-loop non ha workflow_dispatch; il push PAT non ri-triggera `pull_request`). Chiude la finestra morta ~22h tra rescuer-label e recycle-24h. Gate `hasAnyClaudeReview`: PR con review 🔴 postata NON toccate (territorio redflag-fixer); fail-safe su errore API = no reopen; reopen fallito → retry + `::error` (mai PR lasciata chiusa). Costa 1 review Claude che è comunque dovuta (la PR non ne ha mai avuta).
- **Visibilità needs-human** (`recycle-stale-prs.yml`, step daily): PR con label `needs-human` (round-cap del 🔴-fixer) → issue dedup giornaliera con la lista. Prima erano invisibili (osservato #1526: 102h di latenza).
- **`loop-health-report.yml` + `scripts/ci/loop-health-report.mjs`** (weekly lunedì 05:45 + dispatch, zero-Claude): failure-rate per i 5 workflow Claude con soglia ⚠️ 20%, invocazioni/giorno, first-shot LGTM rate, overhead review, zombie/coda/parked/needs-human. Posta su issue-tracker permanente (find-or-create). Automatizza l'osservazione manuale che ha prodotto #1919/#1926 e valida ogni tuning contro il suo revert-trigger. Dry-run locale eseguito: output corretto, già flagga redflag-fixer 69% e issue-fix 38% sulla finestra 2gg pre-bump.

## Non implementato (ancora)

- **workflow_dispatch su pr-review-loop** (alternativa pulita al close+reopen): richiede refactor di 10 reference `github.event.pull_request.*` nel workflow più caldo del sistema → rischio/beneficio sfavorevole ora; se il close+reopen mostra side-effect (notifiche, timeline noise), follow-up con il refactor.
- **Effetto dei fix non validabile pre-merge per classe-A/needs-human** (servono occorrenze organiche): il prossimo run di recycle (daily 06:40) e il primo PR classe-A reale li esercitano. Revert-trigger: se il close+reopen genera doppia review sulla stessa PR (race con re-review guard) → revert del ramo `reopenToRetrigger`.
- **Sibling candidates su questo diff** (`pr-collision-detector.mjs`, `reconcile-followups.mjs`, `github-issue-creator.mjs`, `prune-merged-worktrees.mjs` via token `allowFail`): ispezionati — è il nome di un'opzione helper condivisa, non la classe pipefail-grep; la classe vera è stata sweepata su tutti i workflow con `set -euo pipefail` (2 hit reali fixati in validate-dist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)