### PR TITLE
fix(seo): restore cluster reachability via orphan-hub page index — unblock bfs-depth gate

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -51,6 +51,7 @@ import { BASE_URL } from './constants';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { stripLiteralMarkdown } from './shared/stripLiteralMarkdown';
+import { ORPHAN_LANDING_SECTION } from './orphanQueryData';
 import { buildTitleWithBrand, TITLE_MAX_CHARS } from './shared/titleSuffix';
 import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
 import { buildClusterThinHtml } from './shared/clusterThinShell';
@@ -1894,6 +1895,56 @@ function injectHubLinkIntoSectionLanding(
   }
 }
 
+/**
+ * Inject the FULL hub page-N index into the per-locale orphan-query hub
+ * (/ricerca/, /en/search/, /de/suche/, /fr/recherche/ — emitted by
+ * orphanQueryLandingPlugin and linked from the depth-1 site index). PR #1915
+ * truncated the job-board paginator to head+tail for the page-weight
+ * budget, which orphaned every cluster page reachable only through hub
+ * pages 22..N (max-bfs-depth: +134k unreachable, deploy 27393621559
+ * rolled back). This block restores reachability on a page with ample
+ * byte headroom (~79 KB of 220 KB): site index (1) -> orphan hub (2) ->
+ * hub page-N (3) -> cluster page (4) stays within the depth-4 gate.
+ * Idempotent via the data marker; missing hub file -> warn and skip.
+ */
+function injectPageIndexIntoOrphanHub(distDir: string, locale: Locale): void {
+  const prefix = LOCALE_PREFIX[locale];
+  const section = ORPHAN_LANDING_SECTION[locale];
+  const hubPath = path.join(distDir, prefix.replace(/^\//, ''), section, 'index.html');
+  if (!fs.existsSync(hubPath)) {
+    console.warn(`\x1b[33m[related-search-clusters]\x1b[0m orphan-query hub missing at ${hubPath} — skipping page-index injection.`);
+    return;
+  }
+  let html: string;
+  try {
+    html = fs.readFileSync(hubPath, 'utf-8');
+  } catch (err) {
+    console.warn('\x1b[33m[related-search-clusters]\x1b[0m failed to read orphan-query hub:', err);
+    return;
+  }
+  if (html.includes('data-related-search-pages-index="1"')) return;
+  const hubPagePaths = listEmittedHubPagePaths(distDir, locale);
+  if (hubPagePaths.length === 0) return;
+  const copy = COPY[locale];
+  const links = hubPagePaths.map((urlPath, idx) =>
+    `<a href="${esc(urlPath)}">${idx + 1}</a>`,
+  ).join(' ');
+  const block = `<nav data-related-search-pages-index="1" aria-label="${esc(copy.pageNavigatorLabel)}"><details><summary>${esc(copy.pageNavigatorLabel)} (${hubPagePaths.length})</summary><p>${links}</p></details></nav>`;
+  let patched: string | null = null;
+  if (html.includes('</main>')) {
+    patched = html.replace('</main>', `${block}\n</main>`);
+  }
+  if (!patched) {
+    console.warn(`\x1b[33m[related-search-clusters]\x1b[0m no insertion anchor in ${hubPath} — skipping page-index injection.`);
+    return;
+  }
+  try {
+    fs.writeFileSync(hubPath, patched);
+  } catch (err) {
+    console.warn('\x1b[33m[related-search-clusters]\x1b[0m failed to write orphan-query hub:', err);
+  }
+}
+
 function listEmittedHubPagePaths(distDir: string, locale: Locale): string[] {
   const rootPath = buildHubPath(locale, 1);
   const rootDir = path.join(distDir, rootPath.replace(/^\/+/, ''));
@@ -2278,6 +2329,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           const __tCacheHitPatch = profileStart();
           for (const { locale, url } of restored.hubs) {
             injectHubLinkIntoSectionLanding(distDir, locale, url, COPY[locale]);
+            injectPageIndexIntoOrphanHub(distDir, locale);
           }
           // Discover whatever shards the cache restored (legacy single-file
           // or sharded) and re-advertise them in the master sitemap.
@@ -2709,6 +2761,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       const __tHubInject = profileStart();
       for (const { locale, url } of cachedHubs) {
         injectHubLinkIntoSectionLanding(distDir, locale, url, COPY[locale]);
+        injectPageIndexIntoOrphanHub(distDir, locale);
       }
       profileRecord('inject-hub-link', __tHubInject);
       const __tSitemap = profileStart();


### PR DESCRIPTION
## Implementato
- `build-plugins/relatedSearchClustersPlugin.ts`: nuova `injectPageIndexIntoOrphanHub(distDir, locale)` — inietta nell'hub orphan-query di ogni locale (`/ricerca/`, `/en/search/`, `/de/suche/`, `/fr/recherche/`, sezioni da `ORPHAN_LANDING_SECTION`) l'indice COMPLETO delle hub page /ricerca/page-N (details collassato, marker idempotente `data-related-search-pages-index`, warn-and-skip su file mancante — stesso contratto di `injectHubLinkIntoSectionLanding`). Chiamata in entrambi i path (fresh + cache-restore).
- Matematica depth: site index (depth 1, già linka gli orphan hub — `ORPHAN_LANDING_HUB_LINKS` in staticPagesPlugin) → orphan hub (2) → hub page-N (3) → cluster page (4) = entro il gate `max-bfs-depth ≤4`. Byte: orphan hub IT = 78,6 KB live + ~15 KB di indice → ~94 KB, ampiamente sotto il budget 220 KB.

**Root cause:** il run 27393621559 (primo col fix page-weight #1915) è fallito su `max-bfs-depth`: +134.800 offender 'unreachable' nei 5 shard sitemap-search-clusters (artifact `audit-reports-27393621559-1`); pre-#1915 erano 0. Il troncamento head/tail del paginatore job-board ha rimosso l'unico genitore delle hub page 22..N: il navigator completo SULLE hub page non basta perché passarci aggiunge un livello (cluster a depth 5). Questa PR ripristina la reachability su una pagina con margine byte, mantenendo il troncamento page-weight di #1915.

- Test: `tests/seo/related-search-clusters-emitted.test.ts` verde; tsc pulito.

## Non implementato (ancora)
- **Verifica end-to-end dei due gate insieme (page-weight + bfs-depth) non possibile pre-merge**: `build:ci` completo solo post-merge. Revert-trigger: se il prossimo deploy fallisce ancora `max-bfs-depth` sui search-clusters → revert di QUESTA PR e di #1915 insieme (ripristino full paginator sul job board) e si riparte dal trim dei blocchi per-cantone per page-weight.
- **Baseline bfs-depth preesistente (~14,8k offender sitemap-jobs-\*/fuel-italian-stations)**: presente già nel run 00:22 pre-#1915, entro ratchet, non in scope.
- **Helper condiviso paginator head/tail** (cantonHubEditorial + injectHubLink): deferito, markup divergente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)