### PR TITLE
feat(adsense): drive-by ATF slot on health-premiums canton hub

### DIFF
--- a/build-plugins/healthPremiumsLandingPlugin.ts
+++ b/build-plugins/healthPremiumsLandingPlugin.ts
@@ -2657,6 +2657,7 @@ function renderCantonHubPage(inp: CantonHubInputs): string {
     <h2 id="ageGrid" style="${H2_STYLE}">${esc(copy.ageGridTitle(cantonLabel))}</h2>
     ${ageGridHtml}
   </section>
+  ${DRIVEBY_AD_SNIPPET}
   ${yoyHubHtml}
   ${triYearHubHtml}
   <section class="s-ziawP1" aria-labelledby="cantonContext">


### PR DESCRIPTION
## Implementato
- `build-plugins/healthPremiumsLandingPlugin.ts` (`renderCantonHubPage`): inserito `${DRIVEBY_AD_SNIPPET}` (registry-driven, stesso di #1910) dopo la sezione age-grid (data-area primaria), prima dei blocchi YoY/contesto.
- Motivo: #1910 ha coperto solo `renderLeafPage`, ma la pagina drive-by ad alto traffico in GA4 è il CANTON HUB `/premi-cassa-malati/ticino/` (3,6k pv/28d, sessione mediana 7s) — verificato live post-deploy: hub senza slot ATF mentre diesel/dogane ce l'hanno.
- Test: `tests/regression/seo-static-ad-slots.test.ts` + `tests/build-plugins` verdi (192). tsc pulito.

## Non implementato (ancora)
- `renderRootHubPage` (`/premi-cassa-malati/`): traffico marginale in GA4 (non nelle top page) → non toccato, stessa giustificazione blast-radius dei sibling in #1910.
- Uplift = proiezione, non validabile pre-merge; coperto dallo stesso revert-trigger di #1910 (rpm-canary giornaliero + revenue-monitor 15/6 + routine cloud 19/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)