### PR TITLE
fix(cluster): hide static body with inline !important — beaten by AdSense main guard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -280,13 +280,18 @@ const App: React.FC = () => {
  // users entirely, leaving these landings blank until the SPA painted —
  // FCP ~4s on a fast desktop), so it must join the same pre-paint toggle
  // or it would duplicate the hydrated JobBoard below the SPA view.
+ // The hide MUST be inline `!important`: index.css carries
+ // `main:not(...) { display: block !important; }` (AdSense side-rail layout
+ // guard) and any !important display rule silently beats a plain inline
+ // `display:none` — observed live on /fr/.../recherche-* (static body
+ // visible below the hydrated JobBoard despite the inline style being set).
  useLayoutEffect(() => {
    const staticMains = document.querySelectorAll<HTMLElement>('main.seo-static-content, main.cluster-seo-prose');
    for (const staticMain of staticMains) {
      if (staticOverlay) {
        staticMain.style.removeProperty('display');
      } else {
-       staticMain.style.display = 'none';
+       staticMain.style.setProperty('display', 'none', 'important');
      }
    }
  }, [staticOverlay]);

--- a/index.css
+++ b/index.css
@@ -217,17 +217,21 @@ html { scrollbar-gutter: stable; }
 body { overflow-x: hidden; }
 
 /* Prevent Google AdSense side-rail auto-ads from overriding page layout.
-   AdSense injects display:grid + max-width:1120px on <main> for side-rail ads. */
-main:not(.seo-static-content) { display: block !important; }
+   AdSense injects display:grid + max-width:1120px on <main> for side-rail ads.
+   Both static-handoff mains are excluded: `display:block !important` here
+   beats App.tsx's plain inline `display:none` hide-at-hydration toggle, so
+   without the :not() the static body stays visible BELOW the hydrated SPA
+   (duplication observed live on /fr/.../recherche-* after PR #1918). */
+main:not(.seo-static-content):not(.cluster-seo-prose) { display: block !important; }
 
 /* Leave room for AdSense side-rail ads (160px wide, placed ~130px from viewport edge).
    On wide screens, shrink main so side-rails sit outside the content area.
    Scoped to non-SEO pages so static feature pages retain their natural width. */
 @media (min-width: 1400px) {
-  main:not(.seo-static-content) { max-width: calc(100vw - 360px) !important; }
+  main:not(.seo-static-content):not(.cluster-seo-prose) { max-width: calc(100vw - 360px) !important; }
 }
 @media (min-width: 1800px) {
-  main:not(.seo-static-content) { max-width: calc(100vw - 420px) !important; }
+  main:not(.seo-static-content):not(.cluster-seo-prose) { max-width: calc(100vw - 420px) !important; }
 }
 
 /* Static SEO feature pages — centered, fluid container aligned with the

--- a/tests/seo/seo-static-css.test.ts
+++ b/tests/seo/seo-static-css.test.ts
@@ -67,6 +67,17 @@ describe('seo-static.css', () => {
     const appSrc = fs.readFileSync(path.resolve(process.cwd(), 'App.tsx'), 'utf8');
     expect(appSrc).toMatch(/main\.seo-static-content,\s*main\.cluster-seo-prose/);
   });
+
+  // The toggle must hide with INLINE !important: index.css carries
+  // `main:not(...) { display: block !important }` (AdSense side-rail layout
+  // guard) and any !important display rule beats a plain inline
+  // `style.display = 'none'`. Observed live post-#1918: inline display:none
+  // set, computed display still block → static body duplicated below the
+  // hydrated JobBoard.
+  it("App.tsx hides via setProperty('display','none','important')", () => {
+    const appSrc = fs.readFileSync(path.resolve(process.cwd(), 'App.tsx'), 'utf8');
+    expect(appSrc).toMatch(/setProperty\(\s*'display',\s*'none',\s*'important'\s*\)/);
+  });
 });
 
 // Cascade-source guard (inverted by the visible-pre-hydration contract).
@@ -118,5 +129,31 @@ describe('index.css (SPA bundle source) cascade does not re-hide the cluster bod
         });
       }
     }
+  });
+
+  // Miss-class the substring guard above cannot see: a broad `main`/
+  // `main:not(...)` selector that does NOT name the static classes but
+  // forces `display` with !important (e.g. the AdSense side-rail guard
+  // `main:not(.seo-static-content) { display:block !important }`) overrides
+  // App.tsx's hide on every <main> it still matches. Any such rule must
+  // exclude BOTH static-handoff mains.
+  it('broad main display:!important rules exclude both static-handoff classes', () => {
+    const css = fs.readFileSync(SPA_CSS_PATH, 'utf8');
+    const root = postcss.parse(css, { from: SPA_CSS_PATH });
+    root.walkRules((rule) => {
+      if (!/(^|[,\s])main(:not\(|\s*\{|\s*,|$)/.test(rule.selector) && !rule.selector.startsWith('main:not(')) return;
+      rule.walkDecls('display', (d) => {
+        if (!d.important) return;
+        for (const cls of ['.seo-static-content', '.cluster-seo-prose']) {
+          expect(
+            rule.selector.includes(`:not(${cls})`),
+            `index.css rule "${rule.selector}" forces display:${d.value} !important ` +
+              `on <main> without :not(${cls}) — it beats App.tsx's ` +
+              `hide-at-hydration inline style and re-shows the static body below ` +
+              `the hydrated SPA (live duplication observed post-#1918).`,
+          ).toBe(true);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Implementato

Validazione live post-merge di #1918 su `/fr/trouver-emploi-suisse/recherche-inconnus-lausanne/`: FCP 3972ms → **320ms** e slug-map fuori dal critical path, MA il body statico restava **visibile sotto il JobBoard idratato** (duplicazione). Diagnosi: App.tsx imposta correttamente l'inline `display:none`, però `index.css` ha il guard anti-AdSense-side-rail `main:not(.seo-static-content) { display: block !important; }` che in cascade batte un inline style non-important (verificato live: `style.display === 'none'`, computed `block`).

- **`App.tsx`** — hide via `style.setProperty('display','none','important')`: vince su qualunque regola `!important`, presente o futura. Il ramo restore (`removeProperty`) invariato.
- **`index.css`** — le tre regole del side-rail guard (`display:block` + 2 `max-width`) escludono anche `.cluster-seo-prose`, coerente con l'esclusione esistente di `.seo-static-content`. La protezione Auto Ads sul `<main>` SPA resta intatta (nessun gating/disable di Auto Ads).
- **`tests/seo/seo-static-css.test.ts`** — nuova guard per la miss-class: regole broad `main`/`main:not(...)` con `display !important` devono escludere entrambe le classi static-handoff; companion test che App.tsx usa l'hide `!important`. (La guard di #1918 controllava solo selettori contenenti i nomi classe — questa regola non li nomina, per questo è sfuggita.)

Vitest mirato: `tests/seo/seo-static-css.test.ts` 6/6 verdi.

## Non implementato (ancora)

- **Verifica live post-deploy della scomparsa duplicazione** — non validabile pre-merge (serve deploy); la rifaccio a deploy avvenuto con Playwright (computed display:none su `main.cluster-seo-prose` + un solo `<main>` visibile). Revert-trigger: se post-deploy la duplicazione persiste o Auto Ads side-rail risulta rotto sulle pagine SPA, revert.
- **Audit altri inline-style vs regole `!important` nel codebase** — fuori scope; nessun altro caso noto con lo stesso conflitto.

## Test plan

- [x] vitest tests/seo/seo-static-css.test.ts (6/6)
- [ ] post-deploy: `main.cluster-seo-prose` computed display:none dopo hydration
- [ ] post-deploy: un solo `<main>` visibile sulla pagina cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)
