### PR TITLE
fix(build): break ESM cycle that nulled CALC_HREF (main red)

### DIFF
--- a/build-plugins/shared/calculatorHref.ts
+++ b/build-plugins/shared/calculatorHref.ts
@@ -1,0 +1,23 @@
+/**
+ * Per-locale net-salary calculator landing paths. Same slugs as
+ * services/router.ts (kept inline so build plugins don't pull in the SPA
+ * router).
+ *
+ * LEAF MODULE — must not import any other build-plugins/shared module.
+ * PR #1938 put this table in jobBoardCommuterContext and imported it from
+ * cantonSeoProse, but commuterContext itself imports cantonSeoProse: the
+ * resulting ESM cycle left the const `undefined` during the production
+ * build's module evaluation order ("Cannot read properties of undefined
+ * (reading 'it')" in renderCantonSeoProse, deploy run 27402547466) while
+ * vitest's different entry order masked it. Keeping the table in a leaf
+ * module makes the cycle impossible by construction.
+ */
+
+export type CalculatorLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const CALC_HREF: Record<CalculatorLocale, string> = {
+  it: '/calcola-stipendio/',
+  en: '/en/calculate-salary/',
+  de: '/de/gehalt-berechnen/',
+  fr: '/fr/calculer-salaire/',
+};

--- a/build-plugins/shared/cantonSeoProse.ts
+++ b/build-plugins/shared/cantonSeoProse.ts
@@ -49,7 +49,7 @@
  *    page's FAQPage JSON-LD (avoiding GSC "duplicate FAQPage" warnings).
  */
 
-import { CALC_HREF } from './jobBoardCommuterContext';
+import { CALC_HREF } from './calculatorHref';
 
 export type CantonSeoLocale = 'it' | 'en' | 'de' | 'fr';
 

--- a/build-plugins/shared/jobBoardCommuterContext.ts
+++ b/build-plugins/shared/jobBoardCommuterContext.ts
@@ -29,6 +29,7 @@
  *  - Cross-references to calculator / FX / health-insurance comparator
  */
 
+import { CALC_HREF } from './calculatorHref';
 import {
   renderCantonSeoProse,
   type CantonSeoSlot,
@@ -193,18 +194,10 @@ const COPY: Record<CommuterLocale, CommuterCopy> = {
   },
 };
 
-// Per-locale net-salary calculator landing. Same paths as CALCULATOR_URL in
-// professionLandingsPlugin.ts — exported so host plugins (e.g. the
-// care-variant CTA in jobsSeoPagesPlugin) reuse one source of truth instead
-// of duplicating the table. Previously pointed at the locale homepage ('/'),
-// which made the "calcolatore stipendio netto frontaliere" cross-link land
-// on the homepage instead of the calculator.
-export const CALC_HREF: Record<CommuterLocale, string> = {
-  it: '/calcola-stipendio/',
-  en: '/en/calculate-salary/',
-  de: '/de/gehalt-berechnen/',
-  fr: '/fr/calculer-salaire/',
-};
+// Calculator paths live in the leaf module calculatorHref.ts (this module
+// imports cantonSeoProse, so hosting the table here created an ESM cycle —
+// see calculatorHref.ts header). Re-exported for existing consumers.
+export { CALC_HREF } from './calculatorHref';
 const FX_HREF: Record<CommuterLocale, string> = {
   it: '/comparatori/cambio-valuta/',
   en: '/en/comparators/currency-exchange/',

--- a/build-plugins/shared/jobListingProse.ts
+++ b/build-plugins/shared/jobListingProse.ts
@@ -23,7 +23,7 @@
  * works in both light and dark mode.
  */
 
-import { CALC_HREF as SHARED_CALC_HREF } from './jobBoardCommuterContext';
+import { CALC_HREF as SHARED_CALC_HREF } from './calculatorHref';
 
 export type ListingProseLocale = 'it' | 'en' | 'de' | 'fr';
 

--- a/tests/build-plugins/calculator-href-no-cycle.test.ts
+++ b/tests/build-plugins/calculator-href-no-cycle.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Guard: build-plugins/shared/calculatorHref.ts must stay a LEAF module and
+ * cantonSeoProse must never import from jobBoardCommuterContext.
+ *
+ * jobBoardCommuterContext imports cantonSeoProse; when PR #1938 made
+ * cantonSeoProse import CALC_HREF back from commuterContext, the ESM cycle
+ * left the const `undefined` in the production build's evaluation order
+ * ("Cannot read properties of undefined (reading 'it')" in
+ * renderCantonSeoProse — deploy run 27402547466) while vitest's different
+ * entry order masked it. Module-graph shape is the only deterministic way
+ * to pin this, so the test asserts the import structure itself.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SHARED = path.resolve(__dirname, '../../build-plugins/shared');
+
+function read(name: string): string {
+  return fs.readFileSync(path.join(SHARED, name), 'utf-8');
+}
+
+describe('calculatorHref module graph', () => {
+  it('calculatorHref.ts is a leaf (no relative imports)', () => {
+    const src = read('calculatorHref.ts');
+    expect(src).not.toMatch(/^import .*from '\.\.?\//m);
+  });
+
+  it('cantonSeoProse does not import from jobBoardCommuterContext (ESM cycle)', () => {
+    const src = read('cantonSeoProse.ts');
+    expect(src).not.toContain("from './jobBoardCommuterContext'");
+  });
+
+  it('CALC_HREF resolves with real values through the re-export', async () => {
+    const mod = await import('../../build-plugins/shared/jobBoardCommuterContext');
+    expect(mod.CALC_HREF.it).toBe('/calcola-stipendio/');
+    const leaf = await import('../../build-plugins/shared/calculatorHref');
+    expect(leaf.CALC_HREF).toEqual(mod.CALC_HREF);
+  });
+});


### PR DESCRIPTION
Main è rosso: il deploy run 27402547466 fallisce in `closeBundle` con `TypeError: Cannot read properties of undefined (reading 'it')` in `renderCantonSeoProse`. Causa: PR #1938 ha messo la tabella `CALC_HREF` in `jobBoardCommuterContext` e l'ha importata da `cantonSeoProse` — ma `jobBoardCommuterContext` importa già `cantonSeoProse`, quindi il ciclo ESM lascia la const `undefined` nell'ordine di valutazione del build di produzione (vitest ha un entry-order diverso e non lo manifestava).

## Implementato

- `build-plugins/shared/calculatorHref.ts` nuovo modulo FOGLIA (zero import relativi) con la tabella `CALC_HREF` per-locale.
- `jobBoardCommuterContext` importa la foglia per uso interno e la ri-esporta (`export { CALC_HREF } from './calculatorHref'`) — i consumer esistenti (`jobsSeoPagesPlugin`) non cambiano.
- `cantonSeoProse` e `jobListingProse` importano direttamente la foglia (ciclo impossibile by-construction).
- Guard-test strutturale `tests/build-plugins/calculator-href-no-cycle.test.ts`: pinna che la foglia resti senza import relativi, che `cantonSeoProse` non importi mai da `jobBoardCommuterContext`, e che i valori risolvano attraverso la ri-esportazione (l'unico modo deterministico di coprire un bug da eval-order che vitest maschera).
- Verificato anche con smoke tsx nell'ordine di valutazione incriminato (cantonSeoProse → commuterContext): `CALC_HREF.it = /calcola-stipendio/`.

## Non implementato (ancora)

- **Validazione full-build pre-merge impossibile** (il `build:ci` gira solo post-merge; full build locale OOM): il crash era deterministico al primo `renderCantonSeoProse` del build e il fix rimuove strutturalmente il ciclo. Revert-trigger: se il prossimo deploy fallisce ancora in `buildSlotCopy`/`renderCantonSeoProse` → revert di questa PR + #1938 hunk cantonSeoProse.
- Nessun altro scope: fix chirurgico del solo ciclo. Gli altri contenuti di #1938 restano invariati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
