### PR TITLE
fix(build): break CALC_HREF circular import — unblock main build red since #1938

### DIFF
--- a/build-plugins/shared/calcHref.ts
+++ b/build-plugins/shared/calcHref.ts
@@ -1,0 +1,24 @@
+/**
+ * Per-locale net-salary calculator landing paths.
+ *
+ * LEAF MODULE on purpose — no imports. CALC_HREF used to live in
+ * jobBoardCommuterContext.ts, but cantonSeoProse.ts importing it from there
+ * created an ESM cycle (jobBoardCommuterContext → cantonSeoProse →
+ * jobBoardCommuterContext): under the vite.config bundle eval order the
+ * binding was still uninitialized when cantonSeoProse's module scope ran,
+ * so `CALCULATOR_HREF = CALC_HREF` captured undefined and the build died
+ * with "Cannot read properties of undefined (reading 'it')" in
+ * buildSlotCopy (run 27402547466). Keep this file import-free so it can
+ * never participate in a cycle.
+ *
+ * Same paths as CALCULATOR_URL in professionLandingsPlugin.ts. Previously
+ * pointed at the locale homepage ('/'), which made the "calcolatore
+ * stipendio netto frontaliere" cross-link land on the homepage instead of
+ * the calculator.
+ */
+export const CALC_HREF: Record<'it' | 'en' | 'de' | 'fr', string> = {
+  it: '/calcola-stipendio/',
+  en: '/en/calculate-salary/',
+  de: '/de/gehalt-berechnen/',
+  fr: '/fr/calculer-salaire/',
+};

--- a/build-plugins/shared/cantonSeoProse.ts
+++ b/build-plugins/shared/cantonSeoProse.ts
@@ -49,7 +49,7 @@
  *    page's FAQPage JSON-LD (avoiding GSC "duplicate FAQPage" warnings).
  */
 
-import { CALC_HREF } from './jobBoardCommuterContext';
+import { CALC_HREF } from './calcHref';
 
 export type CantonSeoLocale = 'it' | 'en' | 'de' | 'fr';
 
@@ -108,8 +108,9 @@ interface SlotCopy {
   crossLinks: string;
 }
 
-// Locale-aware calculator paths — single source in jobBoardCommuterContext
-// (the '/'-pointing local table sent users to the homepage, not the simulator).
+// Locale-aware calculator paths — single source in the import-free leaf
+// module calcHref.ts (importing via jobBoardCommuterContext created an ESM
+// cycle that left this binding undefined at build time, run 27402547466).
 const CALCULATOR_HREF: Record<CantonSeoLocale, string> = CALC_HREF;
 
 const FX_HREF: Record<CantonSeoLocale, string> = {

--- a/build-plugins/shared/jobBoardCommuterContext.ts
+++ b/build-plugins/shared/jobBoardCommuterContext.ts
@@ -33,6 +33,7 @@ import {
   renderCantonSeoProse,
   type CantonSeoSlot,
 } from './cantonSeoProse';
+import { CALC_HREF } from './calcHref';
 
 export type CommuterLocale = 'it' | 'en' | 'de' | 'fr';
 
@@ -193,18 +194,11 @@ const COPY: Record<CommuterLocale, CommuterCopy> = {
   },
 };
 
-// Per-locale net-salary calculator landing. Same paths as CALCULATOR_URL in
-// professionLandingsPlugin.ts — exported so host plugins (e.g. the
-// care-variant CTA in jobsSeoPagesPlugin) reuse one source of truth instead
-// of duplicating the table. Previously pointed at the locale homepage ('/'),
-// which made the "calcolatore stipendio netto frontaliere" cross-link land
-// on the homepage instead of the calculator.
-export const CALC_HREF: Record<CommuterLocale, string> = {
-  it: '/calcola-stipendio/',
-  en: '/en/calculate-salary/',
-  de: '/de/gehalt-berechnen/',
-  fr: '/fr/calculer-salaire/',
-};
+// CALC_HREF lives in the import-free leaf module ./calcHref.ts (moved there
+// to break the ESM cycle with cantonSeoProse.ts — see that file's docblock);
+// re-exported here so existing importers (jobsSeoPagesPlugin, jobListingProse)
+// keep working.
+export { CALC_HREF };
 const FX_HREF: Record<CommuterLocale, string> = {
   it: '/comparatori/cambio-valuta/',
   en: '/en/comparators/currency-exchange/',

--- a/build-plugins/shared/jobListingProse.ts
+++ b/build-plugins/shared/jobListingProse.ts
@@ -23,7 +23,7 @@
  * works in both light and dark mode.
  */
 
-import { CALC_HREF as SHARED_CALC_HREF } from './jobBoardCommuterContext';
+import { CALC_HREF as SHARED_CALC_HREF } from './calcHref';
 
 export type ListingProseLocale = 'it' | 'en' | 'de' | 'fr';
 
@@ -68,7 +68,7 @@ const LABELS: Record<ListingProseLocale, ListingProseLabels> = {
 // Mirror of services/router.ts slug tables — kept inline here so the
 // build plugin doesn't pull in the SPA router. If router slugs ever drift
 // these strings need to follow.
-// Re-exported single source (jobBoardCommuterContext) — the old local table
+// Single source: import-free leaf module calcHref.ts — the old local table
 // pointed at '/' and sent users to the homepage instead of the simulator.
 const CALC_HREF: Record<ListingProseLocale, string> = SHARED_CALC_HREF;
 const FX_HREF: Record<ListingProseLocale, string> = {


### PR DESCRIPTION
## Implementato
- **Sblocco del build rosso su `main`** (run 27402547466, `TypeError: Cannot read properties of undefined (reading 'it')` in `buildSlotCopy` ← `renderCantonSeoProse` ← `renderJobBoardCommuterContext` in `closeBundle`): PR #1938 ha introdotto un **ciclo ESM** — `cantonSeoProse.ts` importa `CALC_HREF` da `jobBoardCommuterContext.ts`, che a sua volta importa `renderCantonSeoProse` da `cantonSeoProse.ts`. Nell'ordine di valutazione del bundle vite.config il binding `CALC_HREF` non è ancora inizializzato quando gira il module scope di `cantonSeoProse`, quindi `const CALCULATOR_HREF = CALC_HREF` cattura `undefined` → ogni build muore → **nessun deploy parte** (i fix #1921/#1936 non raggiungono mai validate-dist).
- Fix strutturale: `CALC_HREF` estratto nel **leaf module senza import** `build-plugins/shared/calcHref.ts` (docblock spiega il vincolo "import-free", così il modulo non può mai entrare in un ciclo). `jobBoardCommuterContext` lo importa e ri-esporta (API invariata per `jobsSeoPagesPlugin` e altri importer); `cantonSeoProse.ts` e `jobListingProse.ts` importano direttamente il leaf (jobListingProse non era nel ciclo ma condivideva lo stesso path a rischio — stessa classe, stessa PR).
- Commenti aggiornati nei 3 punti che citavano la vecchia provenienza ("single source in jobBoardCommuterContext").
- Verifica: riproduzione dell'ordine ciclico via `tsx` (import di `jobBoardCommuterContext` per primo, poi `renderJobBoardCommuterContext({locale:'it',…})`) → render OK, href `/calcola-stipendio/` presente, nessun `undefined`. Test verdi: `canton-seo-prose` (84), `job-board-text-ratio-regression`, `job-sector-page-weight` (88 totali). tsc: zero errori nuovi.

## Non implementato (ancora)
- **Verifica build completa solo post-merge**: il `build:ci` OOM-prone gira solo su `main`. Revert-trigger esplicito: se il prossimo build su `main` fallisce ancora in `closeBundle` con lo stesso TypeError, il ciclo ha un secondo arco non individuato → revert e analisi con `madge --circular`.
- **Audit sistematico dei cicli import in build-plugins/shared/** (es. gate CI `madge --circular` o eslint `import/no-cycle`): fuori scope per questo unblock urgente; sarebbe il guard strutturale che previene la classe intera. Follow-up candidato.

## Test plan
- [ ] Post-merge: build verde su `main` (closeBundle completa)
- [ ] Deploy raggiunge validate-dist; page-weight verde (~120 KB su cerca-lavoro-ticino, #1921+#1936) e max-bfs-depth torna a baseline (#1936)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
