### PR TITLE
perf(loop): bump issue-fix normal tier 30→40 — post-#1919 organic data shows sonnet deaths too

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -103,7 +103,13 @@ jobs:
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
-            echo "max_turns=30" >> "$GITHUB_OUTPUT"
+            # 30->40 (misurato 2026-06-12 post-#1919): 3 run tier=normal morti
+            # error_max_turns al cap nella sola finestra 06:00-07:30Z (run
+            # 27397873962/27399888568/27400421268, follow-up #1918/#1931) —
+            # il bump #1919 copriva solo il tier high (40->50); il campione
+            # 7gg aveva mostrato solo morti opus (bias). Stessa regola: cap
+            # anti-runaway sopra il p99 dei run sani, non budget di lavoro.
+            echo "max_turns=40" >> "$GITHUB_OUTPUT"
           fi
           echo "Fix tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
           # Aggregate detection (deterministic, da titolo "N item deferred", N>=2).

--- a/.github/workflows/loop-health-report.yml
+++ b/.github/workflows/loop-health-report.yml
@@ -14,9 +14,12 @@ name: Loop health report (zero-Claude)
 
 on:
   schedule:
-    # Lunedì 05:45 UTC — dopo il lessons-harvester (05:17) così un harvest
-    # appena uscito è già visibile, prima del compress-docs (04:00 +1g).
-    - cron: '45 5 * * 1'
+    # Daily 05:45 UTC (era weekly): una regressione del loop (failure-rate,
+    # zombie) a cadenza settimanale brucerebbe quota per giorni prima della
+    # detection. Il report è zero-Claude e costa ~1min di runner → daily è
+    # gratis e chiude il ciclo misura→correggi entro 24h. Dopo il
+    # lessons-harvester (05:17) così l'harvest è già visibile.
+    - cron: '45 5 * * *'
   workflow_dispatch:
     inputs:
       days:


### PR DESCRIPTION
## Implementato

- `issue-fix.yml` tier normal (sonnet) `max_turns` 30→40. Il bump #1919 copriva solo il tier high (opus 40→50) perché il campione 7gg mostrava solo morti opus al cap — bias di campionamento: nelle sole prime ore organiche post-#1919 (06:00–07:30Z di oggi) sono morti `error_max_turns` 3 run **tier=normal** (run 27397873962/27399888568/27400421268, follow-up #1918/#1931), di cui uno ri-accodato dal drainer e bruciato due volte. Stessa regola dichiarata in #1919: il cap è anti-runaway sopra il p99 dei run sani, non un budget di lavoro.

- `loop-health-report.yml` cron weekly → **daily** 05:45 UTC: una regressione a cadenza settimanale brucia quota fino a 6 giorni prima della detection; il report è zero-Claude (~1min runner) → daily gratis, ciclo misura→correggi entro 24h. Il report di domattina valida TUTTI i bump (#1919, #1930, questa PR) sui dati organici.

Rilevato dal ciclo di validazione post-merge (misura organica, non attesa del report settimanale): review-loop post-bump 20/20 verde, redflag-fixer 1/1 — issue-fix era l'unico ancora rosso, e la causa era il tier non coperto.

## Non implementato (ancora)

- **Altri cap non toccati** (review high 40 e minimal 8, redflag 45, followup 20, harvester 20): zero `error_max_turns` osservati post-#1919 su quei tier — stesso criterio misurato, niente bump speculativi.
- **Revert-trigger**: se compaiono run normal-tier vicini a 40 in modo sistematico (runaway) o il failure-rate non scende nel prossimo loop-health-report → rivalutare (split aggregate più aggressivo invece di cap più alto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
