### PR TITLE
fix(loop): treat concurrent-merge race as success in auto-merge-eval

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -255,17 +255,44 @@ function main() {
     ? `Tutti i gate OK → squash-merge PR #${PR} via GITHUB_PAT (cascade atteso: deploy + followup).`
     : `::warning::Tutti i gate OK → squash-merge PR #${PR} via GITHUB_TOKEN (PAT assente, nessun cascade deploy/followup).`);
 
+  // Race benigna tra i due trigger del workflow (review submitted + tests
+  // workflow_run, nessuna concurrency per design): entrambi valutano gli
+  // stessi gate e tentano il merge quasi insieme — il perdente riceve
+  // "Merge already in progress" / "already merged" e usciva ROSSO con un
+  // ::warning depistante "scope insufficiente?" (osservato run 27405822440 su
+  // PR #1952, gia' mergiata dall'altro run). Se la PR risulta MERGED, e' un
+  // successo: il cascade lo gestisce il run vincitore. Poll breve perche'
+  // "in progress" significa che il vincitore sta finendo proprio ora.
+  const confirmedMergedAfterRace = () => {
+    for (let i = 0; i < 3; i++) {
+      try {
+        const st = gh(['pr', 'view', PR, '--repo', REPO, '--json', 'state'], { token: primary });
+        if (st && st.state === 'MERGED') return true;
+      } catch { /* tentativo successivo */ }
+      try { execFileSync('sleep', ['3']); } catch { /* noop */ }
+    }
+    return false;
+  };
+
   const mergeArgs = ['pr', 'merge', PR, '--squash', '--delete-branch', '--repo', REPO];
   try {
     gh(mergeArgs, { json: false, token: primary });
     console.log(`PR #${PR} mergiata.`);
   } catch (e) {
+    if (confirmedMergedAfterRace()) {
+      console.log(`PR #${PR} gia' mergiata da un run concorrente (race trigger review/tests) — successo, nessun retry.`);
+      return;
+    }
     if (hasPat && fallback) {
       console.log(`::warning::Merge col GITHUB_PAT fallito (scope insufficiente?) — retry con GITHUB_TOKEN, nessun cascade.`);
       try {
         gh(mergeArgs, { json: false, token: fallback });
         console.log(`PR #${PR} mergiata (fallback GITHUB_TOKEN).`);
       } catch (e2) {
+        if (confirmedMergedAfterRace()) {
+          console.log(`PR #${PR} gia' mergiata da un run concorrente (race trigger review/tests) — successo.`);
+          return;
+        }
         console.error(`::error::Merge fallito anche col fallback: ${String(e2).slice(0, 200)}`);
         process.exit(1);
       }


### PR DESCRIPTION
## Implementato

- `scripts/ci/auto-merge-eval.mjs`: il run perdente della race tra i due trigger di auto-merge (review submitted + tests workflow_run, senza concurrency by design) usciva ROSSO con `GraphQL: Merge already in progress`, warning depistante "scope insufficiente?" e tentativo fallback inutile — osservato live run 27405822440 su PR #1952, già mergiata dal run gemello. Ora su merge fallito: poll dello stato PR (3×3s, "in progress" = il vincitore sta finendo); `MERGED` → exit 0 con log chiaro, il cascade resta al vincitore. Applicato a entrambi i catch (primary e fallback).

Rilevato dal ciclo di validazione organica post-merge (unico rosso non-spiegato della finestra 06:00–09:00Z; tutti gli altri loop-workflow 100% verdi).

## Non implementato (ancora)

- **Concurrency group sul workflow auto-merge** (eliminerebbe la race alla radice): toccherebbe `auto-merge-on-lgtm.yml` (protetto, merge manuale) e il doppio trigger è by-design per coprire entrambi gli ordini di arrivo LGTM/vitest — il poll nel perdente è più economico e non rischia di cancellare il run vincitore. Se la race diventasse frequente con esiti non-MERGED → rivalutare.
- **Test unit del ramo race**: richiederebbe mock di gh/process.exit nel CLI path (il modulo testato esporta solo gli helper fingerprint); la validazione è osservazionale sul prossimo run perdente (log "gia' mergiata da un run concorrente").

🤖 Generated with [Claude Code](https://claude.com/claude-code)