### PR TITLE
fix(validate-live): guard CDN-asset grep against set -e false-fail

### DIFF
--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -203,7 +203,20 @@ jobs:
             echo "[validate-live] homepage fetch returned empty after 4 tries — inconclusive (transient); the e2e:live smoke below exercises boot end-to-end. Skipping CDN gate."
             exit 0
           fi
-          asset="$(printf '%s' "$html" | grep -oE 'https://cdn\.frontaliereticino\.ch/assets/[^"'"'"' )]+\.(js|css)' | head -1)"
+          # NOTE: trailing `|| true` is load-bearing. The step shell runs under
+          # `set -e` + `pipefail` (GitHub default `bash -eo pipefail {0}` plus the
+          # `set -uo pipefail` above). Without the guard the `asset=$(…)` ASSIGNMENT
+          # aborts the whole step (exit 1, zero stdout) in two real cases, BEFORE the
+          # `if [ -z "$asset" ]` "nothing to verify → pass" branch can run:
+          #   1. assets served same-origin this deploy (Guard B kept dist/assets) →
+          #      grep finds no cdn ref → grep exits 1 → pipefail → assignment fails.
+          #   2. grep matches but `grep | head -1` closes the pipe early → grep gets
+          #      SIGPIPE (141) → pipefail → assignment fails (intermittent race).
+          # Both are EXPECTED states, not boot breakage. The bare grep-pipe false-
+          # failed every same-origin-assets deploy (recurring "Validation Failure
+          # (live)" #1960), gating publish/IndexNow off on a perfectly healthy site.
+          # `|| true` normalises to asset="" so the graceful pass path is reached.
+          asset="$(printf '%s' "$html" | grep -oE 'https://cdn\.frontaliereticino\.ch/assets/[^"'"'"' )]+\.(js|css)' | head -1 || true)"
           if [ -z "$asset" ]; then
             echo "[validate-live] homepage (non-empty) references no cdn.frontaliereticino.ch/assets bundle — assets served same-origin this deploy; nothing to verify."
             exit 0


### PR DESCRIPTION
## Implementato

Fix definitivo del fallimento ricorrente di `validate-live` (job `validate-live` in `deploy.yml`, reusable `post-deploy-validate-live.yml`), issue #1960.

**Root cause (verificata sui log + repro locale):** lo step *"Verify CDN-offloaded bundle serves live"* gira sotto la default shell GitHub `bash -eo pipefail` + il suo `set -uo pipefail`. La riga

```bash
asset="$(printf '%s' "$html" | grep -oE '…cdn…/assets/…' | head -1)"
```

abortisce l'INTERO step (exit 1, **zero stdout**) PRIMA del branch `if [ -z "$asset" ]` "nothing to verify → pass", in due stati attesi e NON rotti:

1. **assets same-origin** questo deploy (Guard B tiene `dist/assets`) → `grep` non trova ref cdn → exit 1 → `pipefail` → l'assegnamento sotto `set -e` fallisce;
2. `grep` matcha ma `grep | head -1` chiude la pipe presto → `grep` riceve SIGPIPE (141) → `pipefail` → fallisce (intermittente).

Entrambi false-failano un deploy sano → ricorrenza issue #1960, publish/IndexNow gated off, e (con rollback abilitato) rollback di un build buono. Evidenza: runs `27497291997` / `27493363134` / `27490870897` falliscono allo stesso step in ~52ms con **0 righe di output** (nessun "attempt N", nessun "nothing to verify").

**Fix:** `|| true` in coda alla command substitution → normalizza a `asset=""` e il path di pass viene raggiunto. Quando un ref cdn È presente, l'asset viene comunque estratto e il check reale del 200 sul CDN gira INVARIATO (nessun abbassamento del gate: l'intento documentato "se c'è un asset cdn DEVE servire 200" resta intatto).

**Repro sotto `bash -eo pipefail`:**
- old line + homepage same-origin → exit 1, nessun output (riproduce il CI 52ms);
- new line + same-origin → `asset=""`, exit 0 (raggiunge "nothing to verify");
- new line + ref cdn presente → asset estratto, exit 0 → procede al loop 200.

Closes #1960

## Non implementato (ancora)

- **Sibling-class sweep (#6): nessun sibling da fixare.** Sweep su `.github/workflows/**` per la classe `VAR="$(… | grep … )"` non guardata sotto `set -e`/`pipefail`: l'unico altro `VAR=$(…grep…)` è `recover-prev-slugs.yml:87` che ha già `|| total_lost=0`; `issue-fix.yml:134` avvolge `grep` dentro args di `echo "…"` (echo esce 0, maschera il fallimento — non è la classe); `review.prompt.md:61` è testo di prompt, non uno step eseguito. Nessun altro condivide il bug dell'assegnamento non guardato.
- **Re-enable del job `rollback`** (oggi `if: false` per scelta utente esplicita, 2026-06-12): fuori scope — questa PR sistema solo il false-fail della classificazione.