### PR TITLE
fix(loop): detect sweep/batch issues as aggregate — stop opus burn on #1826-class

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -124,6 +124,21 @@ jobs:
           # falso negativo → circuit-breaker one-item no-op → error_max_turns su
           # aggregate (#1172-class, ~2M token). Cfr. #1201 item 1.
           N=$(printf '%s' "$body" | grep -oiE '[0-9]+ items? deferred' | head -1 | grep -oE '^[0-9]+' || true)
+          # Fallback SWEEP/BATCH (2026-06-14): le issue "sweep" multi-target NON
+          # usano il fraseggio "N items deferred" del template FOLLOWUP.md →
+          # is_aggregate=false → circuit-breaker one-item MUTO → il fixer tenta
+          # tutti i target e muore error_max_turns ANCHE a cap 50 (osservato
+          # #1826 "Sweep: ~30 ... crawlers": 7 run bruciati, fu-attempt:2). Una
+          # sweep e' multi-item by-definition: la cura e' decomposizione (fixa 1,
+          # deferisci il resto), non un cap piu' alto. Cattura la keyword
+          # sweep|batch|bulk + un conteggio ~?N di target plurali tipici; senza
+          # conteggio leggibile tratta come aggregate minimo (N=2). I target-noun
+          # sono ancorati (no match su "30 seconds"/"0 jobs" → niente falsi
+          # positivi su issue single, verificato sui titoli reali del backlog).
+          if [ -z "${N:-}" ] && printf '%s' "$body" | grep -qiE '\b(sweep|batch|bulk)\b'; then
+            N=$(printf '%s' "$body" | grep -oiE '~?[0-9]+ +([a-z*-]+ +)?(crawler|file|page|parser|script|adapter|component|endpoint|workflow|job|company|landing)s?' | head -1 | grep -oE '[0-9]+' | head -1 || true)
+            N=${N:-2}
+          fi
           if [ "${N:-0}" -ge 2 ] 2>/dev/null; then
             echo "is_aggregate=true" >> "$GITHUB_OUTPUT"
             echo "agg_count=${N}" >> "$GITHUB_OUTPUT"
@@ -172,7 +187,7 @@ jobs:
             - Se la issue è categoria `revenue` o `tracker` (strategica) → posta "Richiede giudizio umano, non auto-fixabile. Rimuovere `agent:fix`." e TERMINA.
             - **Capability guard (valuta SUBITO, prima di implementare — risparmio token):** questo ambiente ha solo `GH_TOKEN` (GitHub App) che NON ha lo scope `workflows` e NON ha PAT/Firebase SA. Dai path target estratti dal body: se il fix richiederebbe di modificare file in `.github/workflows/**` → il `git push` fallirebbe sempre (push di workflow rifiutato senza scope `workflows`) → niente PR. Allora NON implementare: posta un commento col diff/azione proposta + "blocco scope `workflows`: serve PAT abilitato o mano umana" e TERMINA SUBITO. Lo stesso vale se il fix è puramente una repo-setting/branch-protection/admin-API (es. `gh api .../branches/main/protection` → 403) o richiede segreti non in CI: documenta e TERMINA senza implementare. Razionale: fare il fix completo per poi scoprire il blocco al push spreca ~1M token/run (vedi #983); il blocco è deterministico dallo scope, va rilevato a turno 1.
 
-            - **Follow-up aggregata multi-item — is_aggregate=${{ steps.tier.outputs.is_aggregate }} (count=${{ steps.tier.outputs.agg_count }}):** se `is_aggregate=true` questa issue ha ${{ steps.tier.outputs.agg_count }} item distinti e tentarli TUTTI in un run sfora il turn budget → `error_max_turns` → 0 PR, ~2M token persi (osservato #1095/#1101/#1172). **REGOLA FERREA (circuit-breaker):** fixa **ESATTAMENTE UN item** poi FERMATI. Procedura: (a) capability guard **PER-ITEM** — salta gli item che toccano `.github/workflows/**`/admin/secret (NON abortire l'intera issue), (b) scegli il PRIMO item in-capability a massimo valore funnel, (c) implementa SOLO quello, (d) **appena la PR per quell'unico item è aperta → STOP IMMEDIATO, non iniziare un secondo item** (anche se hai turni residui), (e) elenca tutti gli altri item in `## Non implementato` (motivo `follow-up`/`blocked`) → `post-merge-followup` li ri-accoda come nuova follow-up (re-queue esistente; ogni ciclo chiude ≥1 item → converge). Se `is_aggregate=false`: issue singola, comportamento invariato (capability guard whole-issue come sopra). Razionale: il budget di turni basta per 1 item con margine; 2+ item lo bruciano.
+            - **Follow-up aggregata multi-item — is_aggregate=${{ steps.tier.outputs.is_aggregate }} (count=${{ steps.tier.outputs.agg_count }}):** se `is_aggregate=true` questa issue ha ${{ steps.tier.outputs.agg_count }} item distinti e tentarli TUTTI in un run sfora il turn budget → `error_max_turns` → 0 PR, ~2M token persi (osservato #1095/#1101/#1172). **REGOLA FERREA (circuit-breaker):** fixa **ESATTAMENTE UN item** poi FERMATI (per una issue *sweep/batch* "item" = UN singolo target/file: es. "~30 crawlers" → fixa 1 crawler, deferisci gli altri 29). Procedura: (a) capability guard **PER-ITEM** — salta gli item che toccano `.github/workflows/**`/admin/secret (NON abortire l'intera issue), (b) scegli il PRIMO item in-capability a massimo valore funnel, (c) implementa SOLO quello, (d) **appena la PR per quell'unico item è aperta → STOP IMMEDIATO, non iniziare un secondo item** (anche se hai turni residui), (e) elenca tutti gli altri item in `## Non implementato` (motivo `follow-up`/`blocked`) → `post-merge-followup` li ri-accoda come nuova follow-up (re-queue esistente; ogni ciclo chiude ≥1 item → converge). Se `is_aggregate=false`: issue singola, comportamento invariato (capability guard whole-issue come sopra). Razionale: il budget di turni basta per 1 item con margine; 2+ item lo bruciano.
 
             **Fix flow (vedi ISSUES.md):**
             1. Branch isolato: `git checkout -b fix/issue-$ISSUE_NUMBER`.


### PR DESCRIPTION
## Implementato

- `issue-fix.yml` aggregate detection estesa a coprire le issue **sweep/batch**. Root-cause del tail residuo di `error_max_turns` che i cap bump (#1919/#1952) hanno solo mascherato: il circuit-breaker one-item scatta solo sul fraseggio `N items deferred` (template FOLLOWUP.md). Le sweep non lo usano → `#1826 "Sweep: ~30 update-*-jobs crawlers"` veniva letta `is_aggregate=false` → il fixer tentava tutti i 30 target e moriva `error_max_turns` **anche a cap 50** (7 run bruciati nella sola finestra post-tuning, ancora `fu-attempt:2`). Una sweep è multi-item by-definition: la cura è decomposizione (fixa 1, deferisci il resto), non un cap più alto.
- Detection: mantiene `N items deferred` come primario, aggiunge keyword `sweep|batch|bulk` + conteggio `~?N` di target-noun ancorati (crawler/file/page/parser/script/adapter/component/endpoint/workflow/job/company/landing). Noun ancorati = niente falsi positivi su issue single ("30 seconds", "returned 0 jobs" → verificati single sui titoli reali del backlog).
- Prompt: chiarito che per una sweep "un item" = un singolo target/file (es. ~30 crawler → fixa 1, deferisci 29).

Rilevato dalla verifica dati consolidati 2gg post-tuning: review-loop 100%, issue-fix failure 38%→~17%, zombie 0 stabile — ma 2 failure residue erano entrambe aggregate/sweep al cap 50; questa ne chiude la classe.

## Non implementato (ancora)

- **redflag-fixer 53%**: è dato pre-tuning (bump 30→45 di #1919 ha solo ~1 run organico post-tuning per via del calo volume PR); le failure pre-tuning erano tutte `error_max_turns@31` → il bump le copre, serve solo più traffico per confermare nel loop-health-report.
- **Test unit della detection**: la logica è bash inline nel workflow (come l'originale `N items deferred`); validata con harness locale sui titoli reali (#1826, #1042, 4 single) — nessun mock CLI disponibile per il path workflow.
- **Revert-trigger**: se la detection sweep produce falsi positivi (issue single trattate come aggregate → fix parziale + follow-up spuria) → restringere i target-noun o richiedere keyword+count entrambi obbligatori.

Nota merge: tocca `issue-fix.yml` → workflow-validation della GitHub App fallisce → reviewer non posta → merge manuale (eccezione AGENTS.md § Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)