### PR TITLE
fix(jobs): flag partial-titleByLocale jobs as needsRetranslation (main-red)

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1783,9 +1783,19 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
     // translate-pending pipeline fills the missing locales.
     let partialDescriptionFlags = 0;
     for (const job of assembled) {
-      // Skip already-flagged and jobs the pipeline gave up on (localeMismatchSuppressed)
-      // — re-flagging suppressed jobs keeps needsRetranslation set on them.
-      if (job.needsRetranslation || job.localeMismatchSuppressed) continue;
+      // Skip ONLY needsRetranslation — the SAME exemption the completeness test
+      // applies (tests/job-locale-completeness.test.ts skips needsRetranslation
+      // only). Do NOT also skip localeMismatchSuppressed: relocalize-pending-
+      // jobs.mjs can `delete needsRetranslation` then set
+      // localeMismatchSuppressed=true, leaving a {suppressed, flag-absent,
+      // missing-description} job that this guard would skip → never flagged →
+      // test-red AND indexed (jobsSeoPagesPlugin excludes only
+      // needsRetranslation===true). Aligning the skip-set to the test (matching
+      // the titleByLocale guard below) closes that latent class. Safe: a
+      // re-flagged suppressed job stays out of the translate work pool unless
+      // its source changed (relocalize-pending-jobs.mjs needsTranslation()), so
+      // this does not reopen the give-up loop the old skip guarded against.
+      if (job.needsRetranslation) continue;
       const descriptions = job.descriptionByLocale && typeof job.descriptionByLocale === 'object'
         ? job.descriptionByLocale
         : {};

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1800,6 +1800,40 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
       console.log(`  🌍 Locale completeness: flagged ${partialDescriptionFlags} jobs with partial descriptionByLocale`);
     }
 
+    // Same contract for titleByLocale: an unflagged job is treated as
+    // fully-translated and indexed in all 4 locales, and
+    // tests/job-locale-completeness.test.ts holds it to full titleByLocale
+    // coverage. A job whose titleByLocale lost a locale (e.g. de/en/fr present,
+    // `it` dropped — Coop / Two-Spice prospective slices, the #1920 deadlock
+    // class) can pass the descriptionByLocale guard above (its descriptions are
+    // complete) yet still be title-incomplete, turning the test red and getting
+    // indexed with a source-language title fallback. Mirror the description
+    // guard so it is flagged out of the indexable set until translate-pending
+    // fills the missing locale; render already falls back to `job.title`.
+    // NOTE: skip ONLY needsRetranslation here, NOT localeMismatchSuppressed.
+    // The completeness test exempts only needsRetranslation jobs, so a
+    // localeMismatchSuppressed job with an incomplete title (the pipeline gave
+    // up reconciling its locales but never set needsRetranslation) would stay
+    // test-red. Flagging it needsRetranslation is the truthful state and routes
+    // it out of the indexable set; translate-pending may retry, and if it
+    // re-suppresses, the flag persists — stable across re-assembly.
+    let partialTitleFlags = 0;
+    for (const job of assembled) {
+      if (job.needsRetranslation) continue;
+      const titles = job.titleByLocale && typeof job.titleByLocale === 'object'
+        ? job.titleByLocale
+        : {};
+      const missingTitle = ['it', 'en', 'de', 'fr']
+        .some((locale) => !String(titles[locale] || '').trim());
+      if (missingTitle) {
+        job.needsRetranslation = true;
+        partialTitleFlags++;
+      }
+    }
+    if (partialTitleFlags > 0) {
+      console.log(`  🌍 Locale completeness: flagged ${partialTitleFlags} jobs with partial titleByLocale`);
+    }
+
     // --- slugByLocale completeness backfill ---
     // Fixed-translation jobs (needsRetranslation:false) MUST expose a slug for
     // every locale. Some legacy crawlers populate only the source-language slug


### PR DESCRIPTION
## Contesto

\`main\` è **rosso**: \`tests/job-locale-completeness.test.ts > every job has titleByLocale for all 4 locales\` fallisce nel gate vitest (shard 3/4), bloccando a cascata l'auto-merge di ogni PR aperta (es. #1984). Non è causato da una PR specifica — è un buco nel data-pipeline.

**Causa radice:** il contratto del progetto è che un job NON flaggato \`needsRetranslation\` è considerato pienamente tradotto → il test lo tiene a copertura \`titleByLocale\` completa su tutte 4 le locale, e \`jobsSeoPagesPlugin\` lo indicizza in tutte 4. \`assemble-jobs-dataset.mjs\` applica già questo invariante per \`descriptionByLocale\` e \`slugByLocale\`, ma **non per \`titleByLocale\`**. Così un job che ha perso una locale nel titolo (de/en/fr presenti, \`it\` droppato — slice prospective Coop / Two-Spice, la classe deadlock #1920) ma con descrizioni complete **sfugge a ogni guard**: translate-pending riprocessa solo i job flaggati → il gap non si auto-guarisce, e il job non-flaggato-ma-incompleto manda rosso il test mentre viene indicizzato con fallback al titolo in lingua sorgente.

8 job nel dataset corrente (7 Coop + 1 Two-Spice, tutti Svizzera tedesca — non-Ticino).

## Implementato

- In \`scripts/assemble-jobs-dataset.mjs\`, subito dopo il guard \`descriptionByLocale\` esistente, aggiunto un guard **\`titleByLocale\`** che lo **rispecchia esattamente**: per ogni job non-flaggato con un \`titleByLocale\` cui manca una qualsiasi delle 4 locale → \`needsRetranslation = true\`.
- **Skip solo \`needsRetranslation\`**, NON \`localeMismatchSuppressed\` (a differenza del guard description): il test esenta solo \`needsRetranslation\`, e un job \`localeMismatchSuppressed\` con titolo incompleto restava rosso. Skippare solo ciò che il test skippa allinea guard e gate.
- Flagga esattamente i **8** job residui (verificato: \`🌍 Locale completeness: flagged 8 jobs with partial titleByLocale\`) → \`job-locale-completeness\` **verde**.
- **Guard \`descriptionByLocale\` allineato** (sibling class fix, 🔴 review round 1): rimossa l'esenzione \`localeMismatchSuppressed\` dal guard description per renderlo identico al guard title — skip solo \`needsRetranslation\`, come fa il test. Un job \`{localeMismatchSuppressed:true, needsRetranslation:absent, missing-descriptionByLocale}\` era skippato dal guard → mai flaggato → test-red AND indicizzato; ora viene flaggato \`needsRetranslation = true\` e rimosso dall'index. \`needsTranslation()\` (relocalize-pending L103) lo mantiene fuori dal work pool se la source non cambia → nessun reopen del give-up loop. Validato: flagga 1092 job suppressed con description incompleta, tutti e 6 i test \`job-locale-completeness\` verdi.

**Perché NON è masking / abbassamento del gate** (AGENTS.md #1/#5): il test continua a esigere copertura completa da OGNI job non-flaggato; flaggo solo quelli realmente incompleti, che è il loro stato veritiero (attendono ritraduzione). Conseguenze corrette: esclusi dall'index finché translate-pending non riempie la locale mancante; il render ha già fallback a \`job.title\` (\`titleByLocale?.[locale] || job.title\`), quindi nessuna pagina va vuota.

**Validazione:** \`node scripts/assemble-jobs-dataset.mjs --stats\` + suite completa → **74228 test verdi**. Le 2 "failure" locali (\`no-twitter-meta-dupes\`, \`no-inlanguage-on-forbidden-schemas\`) sono **timeout da contention full-suite** (scan-FS pesanti: ~58s standalone), provate verdi eseguendole isolate — non data-driven, non toccate da questo change.

## Non implementato (ancora)

- **Traduzione reale del titolo \`it\` mancante** per gli 8 job: non generata qui (richiederebbe la cascata free-translate / \`repair-job-locales.mjs\`). Il flag \`needsRetranslation\` instrada i job verso translate-pending, che genererà il titolo \`it\` reale al prossimo giro; nel frattempo sono fuori dall'index (corretto). Follow-up naturale se translate-pending non li copre.
- **Solo lo script è committato**, non i dati rigenerati (\`data/jobs.json\` è gitignored; \`public/data/expired-jobs.json\` ecc. li rigenera il gate CI con \`assemble-jobs-dataset.mjs\` prima di vitest).
- **\`localeMismatchSuppressed\` come esenzione del test**: non modificato il test per esentare i job suppressed (sarebbe cambiare la tolleranza del gate, AGENTS.md #5). Il fix sta dalla parte del dato/flag, non del test.