### PR TITLE
fix(canary): send User-Agent on live probe so Cloudflare stops 403ing (#1961)

### DIFF
--- a/scripts/canary-article-content.mjs
+++ b/scripts/canary-article-content.mjs
@@ -55,6 +55,12 @@ const DEFAULT_SAMPLES = 20;
 const MIN_BYTES = 5000;
 const FETCH_TIMEOUT_MS = 15000;
 const PROBE_CONCURRENCY = 5;
+// Cloudflare in front of the live site returns 403 to requests carrying
+// undici's default (empty) User-Agent from datacenter IPs (GitHub Actions
+// runners). A descriptive UA — same convention as probe-5xx.mjs and
+// check-sitemap-shard-size.mjs — clears the bot check so the probe reaches
+// the real origin instead of failing on the sitemap fetch.
+const USER_AGENT = "FrontaliereTicino-ContentCanary/1.0 (+https://frontaliereticino.ch)";
 
 const args = process.argv.slice(2);
 const samples = (() => {
@@ -74,7 +80,16 @@ async function fetchWithTimeout(url, init = {}) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
   try {
-    return await fetch(url, { ...init, signal: ctrl.signal });
+    return await fetch(url, {
+      ...init,
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        ...(init.headers || {}),
+      },
+      signal: ctrl.signal,
+    });
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
## Implementato
- `scripts/canary-article-content.mjs`: aggiunto `User-Agent` (`FrontaliereTicino-ContentCanary/1.0`) + `Accept` header, iniettati **centralmente** in `fetchWithTimeout` → coprono sia il fetch della sitemap sia il probe per-articolo by-construction (niente drift futuro).
- Verificato live: `node scripts/canary-article-content.mjs --samples=5` carica 2690 URL da `sitemap-blog.xml` e passa 5/5. Prima: crash su `sitemap fetch 403` prima di produrre JSON.

### Root cause
article-content-canary fallisce a ogni run dal ~2026-06-12 con `error: sitemap fetch 403` (#1961). Lo script fetchava il sito live **senza User-Agent**; Cloudflare ora ritorna 403 alle richieste con UA vuoto di undici da IP datacenter (runner GitHub Actions). I sibling probe live già impostano un UA descrittivo — `probe-5xx.mjs` (production-canary, verde) e `check-sitemap-shard-size.mjs` — perciò solo questo canary si rompeva. Un 403 è anti-bot non-retryable (`transient-fetch.mjs`), quindi il retry non avrebbe aiutato.

Closes #1961

## Non implementato (ancora)
- Nessun sibling da sweepare: `check-sibling-patterns.mjs` conferma che nessun file gemello non-toccato condivide il costrutto; tutti gli altri probe live (probe-5xx, check-sitemap-shard-size, audit-404-risk, audit-orphan-pages) già impostano un UA.
- Hardening lato infra (WAF allowlist per il canary via header segreto) non incluso: out of scope, l'UA descrittivo è sufficiente e coerente coi probe esistenti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)