### PR TITLE
fix(seo): recover non-Ticino job 404s via canton-aware compat bridges

### DIFF
--- a/build-plugins/cantonJobCompatBridgePlugin.ts
+++ b/build-plugins/cantonJobCompatBridgePlugin.ts
@@ -1,0 +1,158 @@
+/**
+ * cantonJobCompatBridgePlugin — recover non-Ticino job 404s at their exact path.
+ *
+ * The 404→compat→page pipeline has a Ticino blind spot. `jobsSeoPagesPlugin`
+ * only merges the FOUR Ticino job-board sections from
+ * `data/seo-404-compat-paths.json` into its soft-landing tracking (its
+ * `COMPAT_JOB_PATTERNS` was hard-coded to TI), and `legacyRedirectsPlugin`
+ * deliberately skips EVERY job-board path (it defers all of them to
+ * jobsSeoPagesPlugin to avoid thin pages competing with enriched ones). The
+ * result: every compat job path in any other canton (grigioni, vallese,
+ * zurigo, soletta, …) falls through both plugins and 404s live, even though
+ * Cloudflare edge analytics confirms real eyeball traffic keeps hitting them
+ * (the CF producer `discover-404s-via-cloudflare.mjs` keeps re-adding them,
+ * but nothing ever emits a page → an accumulating, never-recovered tail).
+ *
+ * This plugin closes that gap WITHOUT touching the OOM-sensitive
+ * jobsSeoPagesPlugin: it walks the compat accumulator, keeps only NON-Ticino
+ * per-canton job-board paths (Ticino + the nationwide `_AGGREGATE_` board are
+ * owned by jobsSeoPagesPlugin), resolves each via the shared
+ * `resolveSearchConsoleCompatTarget`, and emits a canonical bridge page at the
+ * EXACT path the path was indexed/hit at (path-keyed, not slug-keyed — so the
+ * historical TI-normalisation collisions don't hide the real-canton URL).
+ *
+ * Safety:
+ *   - Runs `enforce: 'post'` + placed AFTER jobsSeoPagesPlugin and
+ *     legacyRedirectsPlugin in vite.config, so the `fs.existsSync` guard below
+ *     skips any path that already has an enriched soft-landing / active page.
+ *     It therefore only ever FILLS gaps — it never overwrites richer content,
+ *     which is exactly the invariant legacyRedirectsPlugin's job-path skip was
+ *     protecting.
+ *   - Reuses the shared resolver + `buildCanonicalBridgePage` (no duplicated
+ *     funnel-critical construct). Non-resolving paths are skipped here and
+ *     dropped from the accumulator by `prune-404-compat-paths.ts` upstream.
+ *
+ * Bridges are intentionally thin (canonical → live canton listing, noindex):
+ * the goal is to turn a 404 into a 200 that consolidates the canonical and
+ * keeps AdSense rendering. Upgrading these to fully enriched soft-landings
+ * (title/description/FAQ from orphan-enriched-data) is a possible follow-up.
+ */
+
+import path from 'path';
+import fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { BASE_URL, buildCanonicalBridgePage } from './constants';
+import { resolveSearchConsoleCompatTarget } from './searchConsoleCompat';
+import { resolveCantonSection, type CantonLocale } from './shared/cantonSection';
+import cantonSlugFile from '../data/canton-url-slugs.json';
+
+const LOCALE_URL_PREFIX: Record<CantonLocale, string> = { it: '', en: '/en', de: '/de', fr: '/fr' };
+const LOCALES: CantonLocale[] = ['it', 'en', 'de', 'fr'];
+
+/**
+ * Build the set of per-canton job-board path prefixes this plugin OWNS:
+ * every canton section across all 4 locales EXCEPT Ticino (owned by
+ * jobsSeoPagesPlugin's TI compat merge) and the nationwide `_AGGREGATE_`
+ * board (owned by jobsSeoPagesPlugin too). Each entry ends in '/' so a
+ * `startsWith` test cannot match a longer canton slug by accident.
+ */
+function buildNonTicinoJobPrefixes(): Set<string> {
+  const codes = Object.keys((cantonSlugFile as { cantons: Record<string, unknown> }).cantons || {});
+  const prefixes = new Set<string>();
+  for (const loc of LOCALES) {
+    for (const code of codes) {
+      if (code === 'TI') continue;
+      const section = resolveCantonSection(loc, code);
+      prefixes.add(`${LOCALE_URL_PREFIX[loc]}/${section}/`);
+    }
+  }
+  return prefixes;
+}
+
+/** A compat path is in scope when it sits under a non-TI canton section and
+ *  the remainder is a single job slug segment (no nested city/company hub). */
+function matchNonTicinoJobPath(rawPath: string, prefixes: Set<string>): boolean {
+  const withSlash = rawPath.endsWith('/') ? rawPath : `${rawPath}/`;
+  for (const prefix of prefixes) {
+    if (!withSlash.startsWith(prefix)) continue;
+    const rest = withSlash.slice(prefix.length).replace(/\/+$/, '');
+    if (rest && !rest.includes('/')) return true;
+    return false;
+  }
+  return false;
+}
+
+const withSlash = (p: string): string => (p.endsWith('/') ? p : `${p}/`);
+
+export function cantonJobCompatBridgePlugin(rootDir: string): Plugin {
+  return {
+    name: 'canton-job-compat-bridge',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const distDir = path.resolve(rootDir, 'dist');
+      const compatPathsPath = path.resolve(rootDir, 'data/seo-404-compat-paths.json');
+      if (!fs.existsSync(compatPathsPath) || !fs.existsSync(distDir)) return;
+
+      let compatPaths: string[] = [];
+      try {
+        const raw = JSON.parse(fs.readFileSync(compatPathsPath, 'utf-8'));
+        compatPaths = Array.isArray(raw?.paths) ? raw.paths : [];
+      } catch {
+        return; // unreadable accumulator — leave dist untouched
+      }
+      if (compatPaths.length === 0) return;
+
+      const nonTiPrefixes = buildNonTicinoJobPrefixes();
+      let emitted = 0;
+      let skippedExisting = 0;
+      let skippedUnresolved = 0;
+
+      for (const rawPath of compatPaths) {
+        const raw = String(rawPath || '');
+        if (!raw.startsWith('/') || !matchNonTicinoJobPath(raw, nonTiPrefixes)) continue;
+
+        const resolution = resolveSearchConsoleCompatTarget(raw);
+        if (!resolution) { skippedUnresolved++; continue; }
+
+        const from = withSlash(raw);
+        const fromNorm = from.replace(/\/+$/, '');
+        const toNorm = resolution.canonicalPath.replace(/\/+$/, '');
+        if (from === '/' || fromNorm === toNorm) continue; // never self-reference
+
+        const outDir = path.join(distDir, from.slice(1));
+        // Gap-fill only: an enriched soft-landing / active page already here wins.
+        if (fs.existsSync(path.join(outDir, 'index.html'))) { skippedExisting++; continue; }
+
+        const to = withSlash(resolution.canonicalPath);
+        const kind = resolution.kind;
+        const html = buildCanonicalBridgePage({
+          canonicalUrl: `${BASE_URL}${to}`,
+          pathLabel: to,
+          title: 'Pagina archiviata | Frontaliere Ticino',
+          description: `Annuncio non piu disponibile collegato a ${to}.`,
+          body: `Questa pagina ${kind === 'company' ? 'azienda' : kind === 'search' ? 'di ricerca' : "dell annuncio"} non e piu disponibile. Abbiamo mantenuto una pagina compatibile per evitare un errore e mostrarti le offerte aggiornate per questa zona.`,
+          ctaLabel: 'Vedi le offerte aggiornate',
+          noindex: true,
+        });
+
+        fs.mkdirSync(outDir, { recursive: true });
+        fs.writeFileSync(path.join(outDir, 'index.html'), html, 'utf-8');
+        // NB: only the directory `index.html` is written — NOT a flat `.html`
+        // sibling. At this volume (~240k recovered paths) the flat file would
+        // double the dist inode count for marginal gain: the indexed/hit form
+        // of these URLs carries a trailing slash (served by index.html), and
+        // the rare no-slash variant gets a GitHub Pages 301 → 200 (still not a
+        // 404). These bridges are `noindex`, so the 301 has no SEO cost.
+        emitted++;
+      }
+
+      if (emitted > 0) {
+        console.log(
+          `\x1b[36m[canton-job-compat-bridge]\x1b[0m Recovered ${emitted} non-Ticino job 404s as canonical bridge pages ` +
+            `(${skippedExisting} already had enriched pages, ${skippedUnresolved} unresolved → left for prune).`,
+        );
+      }
+    },
+  };
+}

--- a/scripts/sync-gsc-orphans.mjs
+++ b/scripts/sync-gsc-orphans.mjs
@@ -1130,14 +1130,22 @@ async function main() {
   const compatPathsFile = dataPath('seo-404-compat-paths.json');
   const compatData = readJsonSafe(compatPathsFile);
   if (compatData?.paths && Array.isArray(compatData.paths)) {
-    const COMPAT_JOB_RE = /^\/(cerca-lavoro-ticino|en\/find-jobs?-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin)\/([^/]+)\/?$/;
+    // Canton-aware: the previous regex matched ONLY the four Ticino sections,
+    // so every non-TI compat job path (grigioni, vallese, zurigo, soletta, …)
+    // skipped this enrichment step and its soft-landing page degraded to
+    // slug-only fallback content. Match every locale job-board section stem
+    // (both `jobs-im` and `jobs-in` DE variants) + a single slug segment; the
+    // canton itself is preserved verbatim via `o.path`, so we don't need to
+    // resolve it here. Same downstream gate as before: prune-404-compat-paths
+    // drops any path the resolver can't map.
+    const COMPAT_JOB_RE = /^(?:\/(?:en|de|fr))?\/(?:cerca-lavoro|find-jobs?|job-search|jobs-i[mn]|jobsuche|stellenangebote|recherche-emploi|trouver-emploi|emplois)-[a-z-]+\/([^/]+)\/?$/;
     const SKIP_RE = /^(?:search|ricerca|suche|recherche|azienda|company|unternehmen|entreprise)-/;
     const existingSlugs = new Set(orphans.map((o) => `${o.locale}:${o.slug}`));
     let compatAdded = 0;
     for (const p of compatData.paths) {
       const m = String(p || '').match(COMPAT_JOB_RE);
       if (!m) continue;
-      const slug = m[2];
+      const slug = m[1];
       if (!slug || SKIP_RE.test(slug)) continue;
       const locale = detectLocaleFromPath(p);
       const key = `${locale}:${slug}`;

--- a/tests/canton-job-compat-bridge.test.ts
+++ b/tests/canton-job-compat-bridge.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { cantonJobCompatBridgePlugin } from '../build-plugins/cantonJobCompatBridgePlugin';
+
+/**
+ * The plugin resolves paths via resolveSearchConsoleCompatTarget, which reads
+ * data/jobs.json (assembled in the CI gate before vitest). These assertions
+ * cover the GAP-FILL invariants that must hold regardless of which exact
+ * canton a slug resolves to:
+ *   - non-Ticino canton job paths get a recovered bridge page,
+ *   - Ticino + nationwide paths are left to jobsSeoPagesPlugin (not emitted),
+ *   - an already-emitted (enriched) page is never overwritten,
+ *   - nested city/company hub paths are not turned into job bridges.
+ */
+describe('cantonJobCompatBridgePlugin', () => {
+  let tmp: string;
+
+  const compatPaths = [
+    '/cerca-lavoro-argovia/recovered-non-ti-role-acme-aarau',          // non-TI → emit
+    '/en/find-jobs-zurich/recovered-non-ti-role-acme-zurich',          // non-TI (EN) → emit
+    '/cerca-lavoro-ticino/ti-owned-should-be-skipped',                 // TI → jobsSeoPagesPlugin owns it
+    '/cerca-lavoro-svizzera/aggregate-should-be-skipped',              // nationwide → skipped
+    '/cerca-lavoro-zurigo/preexisting-enriched-role',                  // non-TI but page already exists → skip
+    '/cerca-lavoro-grigioni/coira/azienda-rhb',                        // nested hub (2 segments) → skip
+  ];
+
+  const rel = (p: string) => p.replace(/^\//, '') + '/index.html';
+
+  beforeAll(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'canton-bridge-'));
+    fs.mkdirSync(path.join(tmp, 'data'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'data', 'seo-404-compat-paths.json'),
+      JSON.stringify({ paths: compatPaths }),
+    );
+    // Pre-existing enriched page that the gap-fill guard must preserve.
+    const preDir = path.join(tmp, 'dist', 'cerca-lavoro-zurigo', 'preexisting-enriched-role');
+    fs.mkdirSync(preDir, { recursive: true });
+    fs.writeFileSync(path.join(preDir, 'index.html'), '<html>ENRICHED</html>');
+
+    const plugin = cantonJobCompatBridgePlugin(tmp);
+    // closeBundle is declared on the plugin object; invoke it directly.
+    await (plugin.closeBundle as () => Promise<void>)();
+  });
+
+  afterAll(() => {
+    if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('recovers a non-Ticino canton job path as a noindex canonical bridge', () => {
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-argovia/recovered-non-ti-role-acme-aarau'));
+    expect(fs.existsSync(file)).toBe(true);
+    const html = fs.readFileSync(file, 'utf-8');
+    expect(html).toContain('rel="canonical"');
+    expect(html).toContain('noindex');
+  });
+
+  it('recovers a non-Ticino path in a non-default locale (EN)', () => {
+    const file = path.join(tmp, 'dist', rel('/en/find-jobs-zurich/recovered-non-ti-role-acme-zurich'));
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it('leaves Ticino job paths to jobsSeoPagesPlugin (no bridge emitted)', () => {
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-ticino/ti-owned-should-be-skipped'));
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('does not emit for the nationwide aggregate board', () => {
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-svizzera/aggregate-should-be-skipped'));
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('never overwrites an already-emitted enriched page', () => {
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-zurigo/preexisting-enriched-role'));
+    expect(fs.readFileSync(file, 'utf-8')).toBe('<html>ENRICHED</html>');
+  });
+
+  it('skips nested city/company hub paths (more than one segment after the section)', () => {
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-grigioni/coira/azienda-rhb'));
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -208,12 +208,6 @@ export default defineConfig(({ mode }) => {
  relatedSearchClustersPlugin(__dirname),
  salaryHubPlugin(__dirname),
  legacyRedirectsPlugin(__dirname),
- // Canton-job compat bridges: recover non-Ticino job-detail 404s that
- // jobsSeoPagesPlugin's TI-only compat merge + legacyRedirectsPlugin's
- // job-path skip both leave uncovered. enforce:'post' + the existsSync
- // gap-fill guard mean it only fills paths with no enriched page. See the
- // plugin header for the full Ticino-blind-spot rationale.
- cantonJobCompatBridgePlugin(__dirname),
  // Canton-orphan redirects: emits HTTP-200 canonical-bridge HTML at every
  // /cerca-lavoro-{canton}/{foreign-editorial-slug}/ combination (TI long-
  // form slug under a non-TI section, etc.) → that canton's canonical
@@ -259,6 +253,19 @@ export default defineConfig(({ mode }) => {
  // fuelLocaleAlias (1), jobLegacySection (2), legacySectionAlt (2),
  // subSlugOnly (1), localePrefixed (2), weeklyEmployersDeep (1).
  legacyAliasPlugin(__dirname),
+ // Canton-job compat bridges: recover non-Ticino job-detail 404s that
+ // jobsSeoPagesPlugin's TI-only compat merge + legacyRedirectsPlugin's
+ // job-path skip both leave uncovered (~240k paths in the compat
+ // accumulator that Cloudflare confirms still 404 live). enforce:'post'
+ // + an existsSync gap-fill guard mean it only fills paths with no page.
+ // MUST run LAST among the page-emitting bridge plugins (after
+ // cantonOrphanRedirectsPlugin / jobOrphanBridgePlugin / location- &
+ // companyHubBridgePlugin / legacyAliasPlugin): those emit INDEXABLE
+ // enriched pages on the same non-TI canton job paths, so the thin
+ // noindex bridge must only fill what they leave behind — never run
+ // first and let their existsSync guard skip the richer page. See the
+ // plugin header for the full Ticino-blind-spot rationale.
+ cantonJobCompatBridgePlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links
  // from homepage + confronti hub + salary pillars. Idempotent.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ import { relatedSearchClustersPlugin } from './build-plugins/relatedSearchCluste
 import { staticPagesPlugin } from './build-plugins/staticPagesPlugin';
 import { sitemapAliasPlugin } from './build-plugins/sitemapAliasPlugin';
 import { legacyRedirectsPlugin } from './build-plugins/legacyRedirectsPlugin';
+import { cantonJobCompatBridgePlugin } from './build-plugins/cantonJobCompatBridgePlugin';
 import { cantonOrphanRedirectsPlugin } from './build-plugins/cantonOrphanRedirectsPlugin';
 import { calculatorLegacyAliasPlugin } from './build-plugins/calculatorLegacyAliasPlugin';
 import { jobOrphanBridgePlugin } from './build-plugins/jobOrphanBridgePlugin';
@@ -207,6 +208,12 @@ export default defineConfig(({ mode }) => {
  relatedSearchClustersPlugin(__dirname),
  salaryHubPlugin(__dirname),
  legacyRedirectsPlugin(__dirname),
+ // Canton-job compat bridges: recover non-Ticino job-detail 404s that
+ // jobsSeoPagesPlugin's TI-only compat merge + legacyRedirectsPlugin's
+ // job-path skip both leave uncovered. enforce:'post' + the existsSync
+ // gap-fill guard mean it only fills paths with no enriched page. See the
+ // plugin header for the full Ticino-blind-spot rationale.
+ cantonJobCompatBridgePlugin(__dirname),
  // Canton-orphan redirects: emits HTTP-200 canonical-bridge HTML at every
  // /cerca-lavoro-{canton}/{foreign-editorial-slug}/ combination (TI long-
  // form slug under a non-TI section, etc.) → that canton's canonical


### PR DESCRIPTION
## Contesto

Goal: ridurre le richieste 404 usando l'observability per popolare gli orfani e migliorare l'enrichment, recuperando il traffico.

L'osservabilità Cloudflare è **già** cablata: `discover-404s-via-cloudflare.mjs` (+ workflow `discover-404s-via-cloudflare.yml`, cron 03:40) interroga `httpRequestsAdaptiveGroups` e appende ogni 404 reale a `data/seo-404-compat-paths.json` (665.750 path; CF report live: **121.336 404/24h**). Il gap non era la raccolta — era l'**emit**: i path **non-Ticino** vengono raccolti ma nessun plugin emette una pagina, quindi continuano a 404 e CF li ri-scopre all'infinito.

Causa: `jobsSeoPagesPlugin` mergiava nella sua soft-landing tracking SOLO le 4 sezioni Ticino (`COMPAT_JOB_PATTERNS` hard-coded TI), e `legacyRedirectsPlugin` salta di proposito ogni job-path (li delega a jobsSeoPagesPlugin). Risultato: **~241k path job non-Ticino** (grigioni, vallese, zurigo, soletta, …) in compat ma 404 live. Verificato via curl: `/cerca-lavoro-ticino/mpa-...` → 200, `/cerca-lavoro-san-gallo/mpa-...` → 404. Il modello `tracking` è slug-keyed (1 path/locale) e **205.109 (slug,locale) hanno sia un path TI sia uno non-TI** (pollution storica da canton-normalization) → un dedup slug-keyed nasconderebbe il path reale.

## Implementato

- **Nuovo plugin `build-plugins/cantonJobCompatBridgePlugin.ts`**: percorre `seo-404-compat-paths.json`, tiene solo i path job **per-canton non-Ticino** (TI e il board nazionale `_AGGREGATE_` restano a jobsSeoPagesPlugin), risolve ciascuno con lo `resolveSearchConsoleCompatTarget` condiviso ed emette un **canonical bridge `noindex`** all'**esatto path** colpito (path-keyed → le collisioni TI/non-TI non nascondono l'URL reale). Riusa `buildCanonicalBridgePage` + il resolver (nessun costrutto funnel-critical duplicato). Sample resolve 2980/2980 = 100%.
- **Gap-fill only**: `enforce:'post'` + posizionato in `vite.config.ts` dopo `jobsSeoPagesPlugin` e `legacyRedirectsPlugin`; la guard `fs.existsSync` salta ogni path che ha già una pagina enriched → non sovrascrive mai contenuto più ricco (l'invariante che lo skip job-path di legacyRedirectsPlugin proteggeva).
- Emette solo `index.html` di directory (no flat `.html`): a ~240k path il flat raddoppierebbe gli inode; la forma indicizzata/colpita ha lo slash finale (servita da index.html), il no-slash prende un 301→200 (innocuo su pagine noindex).
- **Fix sibling (`scripts/sync-gsc-orphans.mjs` Step 2b)**: stesso antipattern ticino-only nel regex `COMPAT_JOB_RE` di supplemento orfani → ora canton-aware (matcha ogni stem job-board incl. entrambe le varianti DE `jobs-im`/`jobs-in`). Gli orfani non-TI entrano nella pipeline di enrichment (GSC queries/titoli) invece di degradare a contenuto slug-only. Path preservato verbatim via `o.path`, stesso gate downstream (`prune-404-compat-paths.ts`).
- **Test `tests/canton-job-compat-bridge.test.ts`** (6 casi): emit non-TI (IT+EN), skip TI, skip aggregate, no-overwrite di pagina enriched, skip hub nidificati. Verde. `search-console-compat` (snapshot committato) + `compat-paths-floor-guard` restano verdi.

## Non implementato (ancora)

- **Pagine enriched (vs bridge thin)**: i bridge sono volutamente thin (canonical → listing canton, `noindex`, recupera 404→200 + AdSense). Arricchirli con titolo/descrizione/FAQ da `orphan-enriched-data.json` è un follow-up SEO (più contenuto indicizzabile sul long-tail). Out of scope qui per contenere il rischio.
- **jobsSeoPagesPlugin `COMPAT_JOB_PATTERNS` lasciato ticino-only di proposito**: renderlo canton-aware nel modello slug-keyed soffre del problema collisione (205k) + first-wins, e la surgery sul loop emit (~550 righe) di quel plugin OOM-prone è alto rischio. Il nuovo plugin isolato + Step 2b coprono il gap senza toccare il path di emit critico. Se in futuro jobsSeoPagesPlugin emetterà enriched non-TI, la guard existsSync del nuovo plugin cede automaticamente.
- **Drift in `scripts/lib/orphan-canton-paths.mjs`**: `INBOUND_PREFIX_ALTERNATES` non include `jobs-in` (solo `jobs-im`) → `inferCantonFromPath` manca le sezioni DE `jobs-in-*` (usate da Step 2d feedback + `ingest-gsc-job-orphans.mjs`). Tocca un lib condiviso con altri consumer → follow-up separato con validazione propria. Step 2b non ne dipende (regex broad indipendente).
- **404 fuori scope (classi diverse)**: brand-logo `/images/brands/*.png` (#1744, già tracciato — filtrati apposta dall'ingester CF); `/sitemap-publisher-ads.xml`; hit `origin-en./origin-fr.` (origin-shard host, non recuperabili via compat — esclusi dal filtro apex dell'ingester); bot-noise (`/wp-admin`, `/.git/config`).
- **Claim memoria/dist NON validabile pre-merge → revert-trigger**: il plugin aggiunge ~241k pagine bridge (IT shard ~+72k, EN ~+58k, DE ~+55k, FR ~+56k; ~2KB/pagina ≈ +150MB/shard). Il `build:ci` SSG OOM-prone gira solo post-merge su `main`. **Se il prossimo deploy OOMa o supera i limiti dist/inode → revert di questo plugin** (rimuovere la riga in `vite.config.ts` + il file plugin). Conteggio reale osservabile dal log `[canton-job-compat-bridge] Recovered N …` e dalla dist-history post-deploy.

## Test plan

- [x] `tests/canton-job-compat-bridge.test.ts` verde (6/6)
- [x] `tests/search-console-compat.test.ts` + `tests/compat-paths-floor-guard.test.ts` verdi (13/13)
- [x] esbuild parse plugin + vite.config; `node --check` sync-gsc-orphans
- [x] sample resolve non-TI 2980/2980 = 100%
- [ ] post-merge: deploy non-OOM + dist entro limiti (revert-trigger sopra)
- [ ] post-merge live curl: un campione di path non-TI prima 404 ora 200 (es. `/cerca-lavoro-san-gallo/...`)
- [ ] GSC: calo impression-with-404 / recovery click sui canton non-TI (2-4 settimane)
