### PR TITLE
perf(jobboard): defer index load off detail critical path + bound detail caches (#1516)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -334,6 +334,26 @@ const jobDetailCache = new Map<string, Promise<Partial<JobListing>>>();
 const resolvedJobDetail = new Map<string, Partial<JobListing>>();
 
 /**
+ * Cap for the per-job detail caches. A long browsing session (many distinct
+ * detail views, cross-canton jumps) otherwise grows `jobDetailCache` and
+ * `resolvedJobDetail` without bound (#1516 item3). LRU-on-write: re-inserting a
+ * key moves it to newest, so the active/most-recent job is never evicted (it is
+ * read at the enrichment-loading check + the finalize re-enrich). Generous cap
+ * covers heavy sessions while bounding heap to ~50 small detail payloads.
+ */
+const DETAIL_CACHE_MAX = 50;
+
+function rememberInDetailCache<K, V>(map: Map<K, V>, key: K, value: V): void {
+  if (map.has(key)) {
+    map.delete(key); // re-insert below → moves to newest (LRU on write)
+  } else if (map.size >= DETAIL_CACHE_MAX) {
+    const oldest = map.keys().next().value; // Map preserves insertion order
+    if (oldest !== undefined) map.delete(oldest);
+  }
+  map.set(key, value);
+}
+
+/**
  * Fetch a single job's detail data (~15KB) instead of the full locale file (~11MB).
  * Per-job detail files are generated at build time by localeJobsSplitPlugin. (FRO-detail-split)
  */
@@ -343,11 +363,11 @@ function fetchJobDetail(jobId: string): Promise<Partial<JobListing>> {
  .then((res) => { if (!res.ok) throw new Error(`${res.status}`); return res.json(); })
  .then((data: unknown) => {
  const detail = (data && typeof data === 'object' ? data : {}) as Partial<JobListing>;
- if (Object.keys(detail).length > 0) resolvedJobDetail.set(jobId, detail);
+ if (Object.keys(detail).length > 0) rememberInDetailCache(resolvedJobDetail, jobId, detail);
  return detail;
  })
  .catch(() => ({} as Partial<JobListing>));
- jobDetailCache.set(jobId, promise);
+ rememberInDetailCache(jobDetailCache, jobId, promise);
  }
  return jobDetailCache.get(jobId)!;
 }
@@ -2174,6 +2194,25 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
  }
  };
+
+ // On a seeded detail page (window.__JOB_SEED__) the first paint already has its
+ // job, and the full canton index only powers below-the-fold related-jobs +
+ // counters. Defer that fetch/parse to idle so it never competes with the detail
+ // page's LCP/INP (#1516 item1). Listing routes have no seed → the index IS the
+ // above-the-fold content → load it immediately. Mirrors the requestIdleCallback+
+ // timeout fallback pattern used in hooks/useUIState.ts.
+ if (seededJob) {
+ const w = window as unknown as {
+ requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+ cancelIdleCallback?: (handle: number) => void;
+ };
+ if (typeof w.requestIdleCallback === 'function') {
+ const handle = w.requestIdleCallback(() => { if (!cancelled) void run(); }, { timeout: 3000 });
+ return () => { cancelled = true; w.cancelIdleCallback?.(handle); };
+ }
+ const timer = setTimeout(() => { if (!cancelled) void run(); }, 200);
+ return () => { cancelled = true; clearTimeout(timer); };
+ }
 
  void run();
  return () => {


### PR DESCRIPTION
## Implementato
- **item1 (pageload/INP)** — `components/community/JobBoard.tsx`: su una detail page con seed (`window.__JOB_SEED__`) il primo frame renderizza già il job reale (branch seeded-active-detail ~L5058, bypassa il loader a prescindere da `jobsLoading`). L'indice cantonale serve solo related-jobs + counters **sotto la fold**, ma veniva fetchato+parsato eager al mount, competendo con LCP/INP della detail. Ora, se c'è un seed, il load dell'indice è **deferito a `requestIdleCallback`** (fallback `setTimeout(200ms)`, cancellato su unmount) → fuori dal critical path. Le listing route (no seed) caricano subito (l'indice È il contenuto above-the-fold). Niente orphan-flash: `jobs` resta `[seededJob]` durante il defer e il cross-shard bridge in `finalize()` preserva il seed quando l'idle-load atterra.
- **item3 (memoria)** — `jobDetailCache` e `resolvedJobDetail` erano Map module-level **unbounded** (crescita illimitata in sessioni lunghe). Ora passano per un helper **LRU-on-write condiviso** (cap 50): il job attivo/più recente non viene mai evicato (è letto dal check enrichment-loading + dal re-enrich in finalize). Entrambe le map fixate (stessa classe, AGENTS #6).

### Non un bug (investigato)
- **item2 (cross-shard prepend in `finalize`)** — è il **bridge anti-orphan-flash intenzionale** (tiene il job seeded quando il suo shard non è caricato). Lasciato invariato.

Tests: **103 test JobBoard/seed verdi** (incl. `job-detail-seed`). Nessun type error introdotto (tsc pulito su JobBoard.tsx; gli errori tsc residui nel repo sono pre-esistenti — staticPagesPlugin/`data/jobs.json` non generato in worktree).

Closes #1516

## Non implementato (ancora)
- **Revert-trigger (perf non validabile pre-merge):** il comportamento "related-jobs/counters popolano all'idle invece che al mount" non è coperto da un test automatico di timing (i 103 test passano ma asseriscono shape/parsing, non la sequenza di fetch). Se post-deploy si osserva una regressione su related-jobs vuoti/lenti o sui counter nelle detail page → revert del solo item1 (l'idle-defer), tenendo item3. item3 è isolato e sicuro.
- Lazy-load on-scroll esplicito (vs idle-defer) non implementato: l'idle-defer è più semplice e a parità di funzionalità; lo scroll-trigger sarebbe un'ulteriore micro-ottimizzazione, deferita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)