### PR TITLE
feat(loop): pre-flight skip workflow-scoped follow-ups before agent:fix (#1724)

### DIFF
--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -97,6 +97,52 @@ export function latestFixOutcomeFromComments(comments) {
   return latest;
 }
 
+// --- WORKFLOW-SCOPE PRE-FLIGHT (escalation #1724) ---------------------------
+// `fix-outcome:blocked-workflows-scope` ricorre 13×/14gg: ogni occorrenza è una
+// follow-up DISTINTA il cui fix tocca file `.github/workflows/**`, che il token
+// GitHub App di issue-fix NON può pushare (manca lo scope `workflows`). Il
+// drainer parka già quel verdetto a posteriori (NON_RETRYABLE), ma solo DOPO che
+// il primo run Claude ha bruciato ~1M token per scoprire il blocco. Questa
+// pre-flight deterministica lo rileva PRIMA della promozione a agent:fix.
+//
+// CONSERVATIVA (bias a PROMUOVERE — un falso park ritarda un fix reale): scatta
+// SOLO sul segnale forte «il fix è esclusivamente workflow-scoped» = il body cita
+// ≥1 path di workflow (`.github/workflows/x.yml` o un bare `x.yml`) E NESSUN path
+// di codice non-workflow (scripts/build-plugins/services/components/hooks/build/
+// src/...). Se cita anche un file di codice → il fix potrebbe vivere lì → PROMUOVI
+// (lascia decidere il fixer). Nessun path citato → PROMUOVI. Mirror del bias
+// dell'already-resolved gate (check-issue-already-resolved.mjs).
+const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/g;
+// Bare `<name>.yml` (un workflow è sempre .yml; in una follow-up un bare .yml
+// che non sia un file di config noto indica quasi sempre un workflow file).
+const BARE_YML_RE = /\b[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\b/g;
+// File di codice NON-workflow: se citati, il fix potrebbe vivere lì → non scoped.
+const CODE_PATH_RE = /\b(?:scripts|build-plugins|services|components|hooks|build|src)\/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+\b/g;
+// `.yml` di config che NON sono workflow (non implicano scope workflows).
+const NON_WORKFLOW_YML = new Set([
+  'lighthouserc.yml', 'pnpm-workspace.yml', 'docker-compose.yml',
+  '.prettierrc.yml', 'vitest.yml',
+]);
+
+/**
+ * Vero se il fix della follow-up è ESCLUSIVAMENTE workflow-scoped (richiede di
+ * editare `.github/workflows/**`), così la promozione a agent:fix brucerebbe
+ * quota in un run che il push bloccherebbe comunque. Pura → testabile.
+ * @param {string} text  title + body della issue
+ */
+export function detectWorkflowScoped(text) {
+  const s = String(text || '');
+  const wfFull = s.match(WORKFLOW_PATH_RE) || [];
+  const bareYml = (s.match(BARE_YML_RE) || []).filter(
+    (y) => !NON_WORKFLOW_YML.has(y.toLowerCase()),
+  );
+  const workflowRefs = [...new Set([...wfFull, ...bareYml])];
+  if (workflowRefs.length === 0) return false; // nessun riferimento a workflow → promuovi
+  const codeRefs = s.match(CODE_PATH_RE) || [];
+  if (codeRefs.length > 0) return false; // cita anche codice non-workflow → potrebbe fixarsi lì → promuovi
+  return true; // solo workflow → blocked-workflows-scope by-construction
+}
+
 /**
  * Un follow-up è eleggibile all'age-out close? Puro (niente gh) → testabile.
  * Vero se: è un `follow-up`, NON in lavorazione (né `agent:fix` né
@@ -311,9 +357,36 @@ function main() {
     .sort((a, b) => prioRank(a) - prioRank(b) || Date.parse(a.createdAt) - Date.parse(b.createdAt));
   if (!queued.length) { console.log('coda vuota → niente da promuovere.'); return; }
 
-  const pick = queued[0];
-  console.log(`PROMUOVO #${pick.number} (${has(pick, 'fu-prio:high') ? 'high' : 'low'}) → ${LBL_FIX} [coda residua: ${queued.length - 1}]`);
-  edit(pick.number, { add: [LBL_FIX], remove: [LBL_QUEUED] });
+  // Promuovi il primo candidato in coda, MA salta (parka) quelli il cui fix è
+  // esclusivamente workflow-scoped (#1724): promuoverli brucerebbe ~1M token in
+  // un run che il push GitHub-App bloccherebbe comunque (no scope `workflows`).
+  // Park preemptivo = stesso esito del NON_RETRYABLE post-hoc, senza il run. Il
+  // body serve solo per i candidati realmente considerati → fetch lazy, 1 alla volta.
+  for (const cand of queued) {
+    let body = '';
+    try {
+      const raw = gh(['issue', 'view', String(cand.number), '--repo', REPO, '--json', 'body'], { json: true });
+      body = String(raw?.body || '');
+    } catch { body = ''; } // body illeggibile → bias a promuovere (non parkare a vuoto)
+
+    if (body && detectWorkflowScoped(`${cand.title}\n${body}`)) {
+      const wfRefs = [...new Set((body.match(WORKFLOW_PATH_RE) || []).concat(
+        (body.match(BARE_YML_RE) || []).filter((y) => !NON_WORKFLOW_YML.has(y.toLowerCase())),
+      ))].slice(0, 5).join(', ');
+      console.log(`PARK #${cand.number} (workflow-scoped: ${wfRefs}) → no promozione, evito run bloccato`);
+      const note = `⏭️ **Pre-flight drainer (zero-Claude, #1724)**: il fix di questa follow-up tocca **esclusivamente** file \`.github/workflows/**\` (${wfRefs}), che il token GitHub App di \`issue-fix\` non può pushare (manca lo scope \`workflows\`). Promuoverla a \`agent:fix\` brucerebbe ~1M token in un run che finirebbe comunque \`blocked-workflows-scope\`. **Non promuovo**: serve un PAT abilitato o mano umana. Rimuovo \`agent:fix-queued\` e parko (riapribile: togli \`fu-parked\` se il contesto cambia).\n\n<!-- FIX_OUTCOME: blocked-workflows-scope -->`;
+      if (DRY) { console.log(`[dry] park #${cand.number} (workflow-scoped)`); continue; }
+      try { gh(['issue', 'comment', String(cand.number), '--repo', REPO, '--body', note], { json: false }); }
+      catch (e) { console.log(`::warning::comment #${cand.number} fallito: ${String(e).slice(0, 120)}`); }
+      edit(cand.number, { add: [LBL_PARKED], remove: [LBL_QUEUED, LBL_FIX] });
+      continue; // prova il prossimo in coda
+    }
+
+    console.log(`PROMUOVO #${cand.number} (${has(cand, 'fu-prio:high') ? 'high' : 'low'}) → ${LBL_FIX}`);
+    edit(cand.number, { add: [LBL_FIX], remove: [LBL_QUEUED] });
+    return; // una sola promozione per run (slot issue-fix)
+  }
+  console.log('coda esaurita (solo candidati workflow-scoped parkati) → niente da promuovere.');
 }
 
 // Esegui solo come CLI (non quando importato dai test → evita di lanciare gh).

--- a/tests/followup-drainer-workflow-scope.test.ts
+++ b/tests/followup-drainer-workflow-scope.test.ts
@@ -1,0 +1,56 @@
+/**
+ * followup-drainer — detectWorkflowScoped pre-flight (#1724).
+ *
+ * `fix-outcome:blocked-workflows-scope` ricorre 13×/14gg: ogni occorrenza è una
+ * follow-up distinta il cui fix tocca solo `.github/workflows/**`, che il token
+ * GitHub App di issue-fix non può pushare. Il drainer la parka già a posteriori
+ * (NON_RETRYABLE) ma solo dopo un run Claude da ~1M token. Questo detector la
+ * intercetta PRIMA della promozione. È CONSERVATIVO (bias a promuovere): scatta
+ * solo quando il body cita workflow path E nessun file di codice non-workflow.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — modulo .mjs senza tipi
+import { detectWorkflowScoped } from '../scripts/ci/followup-drainer.mjs';
+
+describe('detectWorkflowScoped — scoped (park preemptivo)', () => {
+  it('rileva il body reale #1607 (Suggested action: editare post-deploy-validate-dist.yml)', () => {
+    const body = [
+      '### 1. Guard rehydrate controlla solo `dist/$loc`',
+      'Original text: …`deploy.yml:L1148`…',
+      'Suggested action: in `.github/workflows/post-deploy-validate-dist.yml`, allargare il guard',
+    ].join('\n');
+    expect(detectWorkflowScoped(body)).toBe(true);
+  });
+
+  it('rileva un bare workflow .yml senza altri path di codice', () => {
+    expect(detectWorkflowScoped('Fix the rate-limit in orchestrate-crawlers.yml dispatch loop')).toBe(true);
+  });
+});
+
+describe('detectWorkflowScoped — NON scoped (promuovi)', () => {
+  it('non scatta se cita un file di codice non-workflow (il fix può vivere lì)', () => {
+    // body reale #1711: il fix è in build-plugins/shared/criticalCss.ts
+    expect(
+      detectWorkflowScoped('dedupe criticalCSS into `build-plugins/shared/criticalCss.ts` shared module'),
+    ).toBe(false);
+  });
+
+  it('non scatta se cita workflow .yml MA anche un path di codice (ambiguo → promuovi)', () => {
+    expect(
+      detectWorkflowScoped('deploy.yml calls `scripts/ci/foo.mjs` which has the bug'),
+    ).toBe(false);
+  });
+
+  it('non scatta senza alcun riferimento a workflow', () => {
+    expect(detectWorkflowScoped('Generic prose follow-up with no file paths at all')).toBe(false);
+  });
+
+  it('non scatta su un .yml di config non-workflow (lighthouserc.yml)', () => {
+    expect(detectWorkflowScoped('bump CLS budget in lighthouserc.yml')).toBe(false);
+  });
+
+  it('gestisce input vuoto/null senza throw', () => {
+    expect(detectWorkflowScoped('')).toBe(false);
+    expect(detectWorkflowScoped(undefined as unknown as string)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato
- **`scripts/ci/followup-drainer.mjs`**: nuova pre-flight `detectWorkflowScoped()` + integrazione nel DRAIN. Una follow-up in coda il cui fix è **esclusivamente workflow-scoped** viene **parkata prima della promozione a `agent:fix`** (rimuove `agent:fix-queued`, aggiunge `fu-parked`, posta commento advisory + marker `<!-- FIX_OUTCOME: blocked-workflows-scope -->`), e il drainer promuove il prossimo candidato non-scoped. Nessun run Claude sprecato.
- **`tests/followup-drainer-workflow-scope.test.ts`**: 7 test del predicato, calibrati su body reali (#1607 → scoped; #1711 → non-scoped). Suite drainer esistente verde (18 test totali).

### Root cause (escalation #1724, bucket `fix-outcome:blocked-workflows-scope` 13×/14gg)
Ogni occorrenza è una follow-up **distinta** il cui fix tocca solo `.github/workflows/**`, che il token GitHub App di `issue-fix` non può pushare (manca lo scope `workflows`). Il drainer parkava già quel verdetto **a posteriori** (`NON_RETRYABLE`), ma solo **dopo** che il primo run Claude aveva bruciato ~1M token per scoprire il blocco. Questa pre-flight lo rileva **prima** della promozione → elimina il burn del primo run.

### Sicurezza (bias a PROMUOVERE)
`detectWorkflowScoped` scatta SOLO sul segnale forte «fix esclusivamente workflow-scoped» = il body cita ≥1 workflow path (`.github/workflows/x.yml` o bare `x.yml`) **E nessun** path di codice non-workflow (`scripts`/`build-plugins`/`services`/`components`/`hooks`/`build`/`src`). Se cita anche un file di codice (il fix potrebbe vivere lì) o nessun workflow → **promuove**. `.yml` di config non-workflow (es. `lighthouserc.yml`) esclusi. Un falso park ritarda solo un fix reale (riapribile togliendo `fu-parked`), non droppa nulla. Mirror del bias di `check-issue-already-resolved.mjs`.

Closes #1724

## Non implementato (ancora)
- **Copertura parziale (conservativa):** intercetta solo le follow-up che citano il workflow path **esplicitamente** (come #1607). Quelle che descrivono il fix senza citare il `.yml` (es. #1697, che parla di `workflow_dispatch` senza path) restano coperte dal park **post-hoc** `NON_RETRYABLE` esistente (1 run sprecato, poi parcheggiate). Allargare il segnale aumenterebbe i falsi-positivi → non fatto by-design.
- Solo `scripts/ci/followup-drainer.mjs` toccato (nessun file workflow) → review + auto-merge normali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)