### PR TITLE
fix(loop): redflag-fixer skips already-resolved PRs instead of failing

### DIFF
--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -27,15 +27,16 @@ permissions:
   id-token: write
 
 jobs:
-  redflag-fix:
-    # Gate evento (tutti necessari):
-    #   - review autore = claude-bot (user.type=='Bot' + startsWith 'claude').
-    #   - review body contiene `🔴 Important` (finding important reale; NON il
-    #     bare 🔴 che può comparire in prosa/legenda anche in una review LGTM
-    #     pulita → falso trigger che brucerebbe un round Claude. Simmetrico col
-    #     gate di blocco in auto-merge-eval.mjs).
-    #   - PR autonoma: autore Bot OPPURE head ref `fix/*`. MAI su PR umane.
-    #   - PR non draft.
+  # Preflight (no checkout, solo gh): porta i gate evento + verifica che la PR
+  # sia ancora AZIONABILE. Race benigna — tra il `review submitted` che triggera
+  # e il checkout del job di fix, la PR può essere stata mergiata/chiusa e il suo
+  # branch auto-cancellato (delete_branch_on_merge) → il `Checkout ref: head.ref`
+  # fallirebbe secco ("branch could not be found"), run ROSSO su una PR già
+  # risolta (osservato 2026-06-14 run 27509046723, fix/crawler-source-rewrites
+  # già merged). Stessa classe della race auto-merge (#1953): un workflow su una
+  # PR già risolta esce PULITO, non fallisce. actionable=false → redflag-fix
+  # skippato (verde no-op, nessun round consumato).
+  preflight:
     if: |
       github.event.review.user.type == 'Bot' &&
       startsWith(github.event.review.user.login, 'claude') &&
@@ -43,6 +44,34 @@ jobs:
       github.event.pull_request.draft == false &&
       (github.event.pull_request.user.type == 'Bot' ||
        startsWith(github.event.pull_request.head.ref, 'fix/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      actionable: ${{ steps.pre.outputs.actionable }}
+    steps:
+      - name: PR still actionable?
+        id: pre
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -uo pipefail
+          state=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo UNKNOWN)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR #$PR_NUMBER non più OPEN (state=$state) → già risolta, skip 🔴-fix (no-op)."
+            echo "actionable=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if ! gh api "repos/$REPO/branches/$HEAD_REF" --jq '.name' >/dev/null 2>&1; then
+            echo "Branch '$HEAD_REF' sparito (PR risolta + delete_branch_on_merge) → skip 🔴-fix (no-op)."
+            echo "actionable=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "actionable=true" >> "$GITHUB_OUTPUT"
+
+  redflag-fix:
+    needs: preflight
+    if: needs.preflight.outputs.actionable == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Implementato

L'unica failure post-tuning del redflag-fixer NON dovuta al cap (run 27509046723) era una **race di checkout benigna**: la PR è stata mergiata e il suo branch auto-cancellato (`delete_branch_on_merge`) tra il `review submitted` che triggera e il `Checkout ref: head.ref` del job → fallimento secco "branch could not be found", run ROSSO su una PR già risolta. Stessa classe della race auto-merge chiusa in #1953: un workflow che parte su una PR già risolta deve uscire pulito, non fallire.

- Nuovo job `preflight` (no checkout, solo `gh`) che porta i gate evento esistenti + verifica `state==OPEN` e branch esistente. `redflag-fix` ora `needs: preflight` e gira solo se `actionable==true`.
- PR risolta → `actionable=false` → `redflag-fix` skippato (verde no-op, **nessun round consumato**: la guard del round-cap gira dentro il job ora saltato).

Dato consolidato che motiva la chiusura: redflag-fixer real-run failure **54% pre-tuning** (25/46) → dopo il bump 30→45 (#1919) le morti al cap spariscono → questa race era l'**unico** residuo post-tuning (1/6), ora no-op. Post-fix il failure-rate atteso ≈ 0 sulle PR azionabili.

## Non implementato (ancora)

- **Stessa race teoricamente su pr-autorebase** (checkout di branch PR): l'autorebase già gestisce branch mancante via `allowFail` su fetch/checkout (ritorna null → skip), quindi non fallisce secco; non serve preflight lì. Verificato nel codice (`git(['checkout'...], {allowFail:true})`).
- **Validazione live**: si esercita alla prossima PR risolta-durante-review (race rara); il preflight è verificabile anche via il path normale (PR aperta → actionable=true → fix procede come oggi).
- **Revert-trigger**: se il preflight desse falsi negativi (PR OPEN azionabile marcata non-actionable → 🔴 non fixato) → allentare il check branch-exists (tenere solo state==OPEN).

Nota merge: tocca `pr-redflag-fixer.yml` (non un workflow di review) → reviewer gira regolarmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)