### PR TITLE
feat(loop): backlog convergence — drift-heal reopen + parked-retry drain

### DIFF
--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -207,6 +207,34 @@ const attemptOf = (iss) => {
 };
 const prioRank = (iss) => (has(iss, 'fu-prio:high') ? 0 : 1); // high prima
 
+// --- PARKED-RETRY: ri-accoda i parked ritentabili (convergenza backlog) -------
+// Un follow-up va `fu-parked` dopo MAX_ATTEMPTS fix falliti. Molti fallirono per
+// cause ORA risolte (cap turni #1919/#1952, aggregate-sweep #1979, drift #2007):
+// restano un pool stagnante che NON drena fino all'age-out 21gg. Questo ri-prova
+// i parked con il fixer migliorato, BOUNDED (no loop infinito):
+//   - skip WF-scope (capability-guard: il fixer CI non può toccare workflows →
+//     re-fail garantito; restano umani/age-out);
+//   - cooldown: solo parked fermi da ≥ RETRY_COOLDOWN_DAYS (non i freschi);
+//   - generation-cap: `fu-reparked:N` ≤ MAX_REPARK_GEN (poi resta parked stabile);
+//   - cap/run anti-burst.
+const RETRY_COOLDOWN_DAYS = Number(process.env.FOLLOWUP_RETRY_COOLDOWN_DAYS || 2);
+const MAX_REPARK_GEN = Number(process.env.FOLLOWUP_MAX_REPARK_GEN || 2);
+const RETRY_MAX_PER_RUN = Number(process.env.FOLLOWUP_RETRY_MAX_PER_RUN || 5);
+const reparkGenOf = (iss) => {
+  const m = names(iss).map((n) => /^fu-reparked:(\d+)$/.exec(n)).find(Boolean);
+  return m ? parseInt(m[1], 10) : 0;
+};
+/** WF-scope = il fix toccherebbe .github/workflows (capability-guard) → non
+ * auto-fixabile. Best-effort sul body+titolo; null/errore → conservativo (skip
+ * retry, non rischiare un re-fail garantito). */
+function isWorkflowScoped(num) {
+  try {
+    const d = gh(['issue', 'view', String(num), '--repo', REPO, '--json', 'title,body']);
+    const t = `${d?.title || ''}\n${d?.body || ''}`;
+    return /\.github\/workflows|\bworkflow(s)?\b/i.test(t);
+  } catch { return true; }
+}
+
 function edit(num, { add = [], remove = [] }) {
   const args = ['issue', 'edit', String(num), '--repo', REPO];
   for (const l of add) args.push('--add-label', l);
@@ -277,6 +305,42 @@ function main() {
         console.log(`age-out: close #${iss.number} fallita (${e.message}) — continuo col batch.`);
       }
     }
+  }
+
+  // --- PARKED-RETRY: ri-accoda i parked ritentabili --------------------------
+  // Ortogonale allo slot (sposta solo fu-parked→queued; il drain promuove dopo).
+  if (RETRY_COOLDOWN_DAYS > 0) {
+    const now = Date.now();
+    const reparkable = listIssues(LBL_PARKED)
+      .filter((iss) => has(iss, 'follow-up'))
+      .filter((iss) => !has(iss, LBL_FIX) && !has(iss, LBL_QUEUED)) // non già in lavoro/coda
+      .filter((iss) => reparkGenOf(iss) < MAX_REPARK_GEN)            // generation-cap
+      .filter((iss) => minutesSince(iss.updatedAt) >= RETRY_COOLDOWN_DAYS * 1440) // cooldown
+      .sort((a, b) => prioRank(a) - prioRank(b) || Date.parse(a.updatedAt) - Date.parse(b.updatedAt));
+    let retried = 0;
+    let skippedWf = 0;
+    for (const iss of reparkable) {
+      if (retried >= RETRY_MAX_PER_RUN) {
+        console.log(`parked-retry: cap ${RETRY_MAX_PER_RUN}/run raggiunto, ${reparkable.length - retried - skippedWf} rinviati al prossimo tick (no silent cap).`);
+        break;
+      }
+      if (isWorkflowScoped(iss.number)) { skippedWf++; continue; } // capability-guard → resta parked
+      const gen = reparkGenOf(iss) + 1;
+      const prevGen = reparkGenOf(iss) ? `fu-reparked:${reparkGenOf(iss)}` : null;
+      const prevAttempt = attemptOf(iss) ? `fu-attempt:${attemptOf(iss)}` : null;
+      if (DRY) { console.log(`[dry] parked-retry #${iss.number} → un-park, gen ${gen} (reset attempts)`); retried++; continue; }
+      // un-park: rimuovi fu-parked + attempt counter, ri-accoda con generation
+      // bump. Reset attempts → il fixer migliorato ha tentativi freschi; se
+      // rifallisce MAX_ATTEMPTS torna parked, ma a gen MAX_REPARK_GEN resta
+      // parked stabile (no loop infinito).
+      edit(iss.number, {
+        add: [LBL_QUEUED, `fu-reparked:${gen}`],
+        remove: [LBL_PARKED, prevGen, prevAttempt].filter(Boolean),
+      });
+      console.log(`PARKED-RETRY #${iss.number} → agent:fix-queued (gen ${gen}/${MAX_REPARK_GEN}, attempts reset) — "${iss.title?.slice(0, 50)}"`);
+      retried++;
+    }
+    if (skippedWf) console.log(`parked-retry: ${skippedWf} skip WF-scope (capability-guard → restano parked/age-out).`);
   }
 
   // Tutto (rescue + drain) gira SOLO a slot issue-fix libero: così il rescue non

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -326,14 +326,25 @@ async function processPR(pr) {
   // auto-merge-eval (contributo PR invariato su un rebase di solo main-merge),
   // quindi NESSUNA review Opus/Sonnet gira di nuovo. Best-effort: se il
   // dispatch fallisce (PAT senza scope actions:write) lo logghiamo soltanto.
-  if (!lgtm && !hasAnyClaudeReview(num)) {
-    // Classe-A (review mai postata per drift 401): ora il branch è allineato a
-    // main → la workflow-validation passa, ma serve ri-triggerare la review.
-    // Un dispatch non esiste per pr-review-loop → close+reopen (= reopened
-    // event: review + tests insieme). Costa UNA review Claude, che è comunque
-    // dovuta: la PR non ne ha mai avuta una.
+  // !lgtm dopo un rebase = la PR NON è pronta al merge (manca l'LGTM): o non ha
+  // mai avuto review (classe-A, drift 401), o ne ha una con 🔴/❓ non chiuso. In
+  // ENTRAMBI i casi il rebase ha appena allineato i workflow a main (drift
+  // workflow-validation risolto), ma serve ri-triggerare review+redflag: un
+  // semplice dispatch tests NON rilancia pr-review-loop/redflag-fixer (triggerano
+  // su review submitted), quindi il 🔴+drift resterebbe stuck fino al recycle
+  // 24h. close+reopen emette `reopened` → review gira drift-free → (se 🔴)
+  // redflag-fixer riparte. ECCEZIONE needs-human: già escalata (round-cap),
+  // reopen riavvierebbe review inutilmente → skip (il round-cap marker persiste,
+  // niente loop, ma evitiamo la review-quota su una PR che aspetta un umano).
+  if (!lgtm) {
+    if (labels.includes('needs-human')) {
+      console.log(`PR #${num}: rebasata ma needs-human (round-cap) → no reopen (attende umano); solo dispatch tests.`);
+      dispatchTests(num, branch);
+      return;
+    }
+    const why = hasAnyClaudeReview(num) ? '🔴/❓ non chiuso + drift sanato' : 'classe-A senza review';
     if (reopenToRetrigger(num)) {
-      console.log(`✅ PR #${num}: rebasata, pushata e ri-aperta (classe-A senza review) → review+tests ri-triggerati.`);
+      console.log(`✅ PR #${num}: rebasata, pushata e ri-aperta (${why}) → review+redflag ri-triggerati drift-free.`);
     }
     return;
   }


### PR DESCRIPTION
## Implementato

Obiettivo (decisione user): il backlog issue cresce senza convergere; il fixer deve portare al merge quante più issue possibile. Due meccanismi che attaccano i due pool stagnanti:

- **(A) Drift-heal reopen** (`scripts/ci/pr-autorebase.mjs`): una PR con 🔴 che resta indietro rispetto a main ha i file workflow di review stale → il redflag-fixer prende `workflow-validation 401` e il 🔴 resta stuck fino al recycle 24h (osservato run su PR 404-recovery). Dopo che il rebase allinea i workflow, l'autorebase ora fa close+reopen di **ogni PR non-LGTM** (prima: solo le classe-A senza review) → review+redflag ripartono drift-free → converge in ~2h non 24h. Skip `needs-human` (già escalata; il round-cap marker persiste → niente loop).
- **(B) Parked-retry** (`scripts/ci/followup-drainer.mjs`): i follow-up parkati dopo 3 tentativi falliti formano un pool stagnante (21 su 39 open) che non drena fino all'age-out 21gg. Quasi tutti fallirono per cause ORA risolte (cap turni #1919/#1952, sweep-aggregate #1979, drift #2007). Nuova fase: ri-accoda i parked col fixer migliorato, **bounded contro re-park infinito** — skip WF-scope (capability-guard → re-fail garantito; restano umani/age-out), cooldown (≥2gg parked), generation-cap (`fu-reparked:N` ≤ 2), cap/run (5), attempts reset all'un-park. Un'issue che rifallisce torna parked; a gen 2 resta parked stabile.

Insieme drenano sia le PR stuck (drift) sia le issue stuck (parked) verso il merge.

## Non implementato (ancora)

- **WF-scope parked** (6/21): restano parked per design (il fixer CI non può toccare `.github/workflows` — tua policy di sicurezza); age-out o mano umana.
- **Validazione live**: il parked-retry si esercita al prossimo run drainer (cron */20m + on issue-fix done); il drift-reopen alla prossima PR drifted con 🔴. Monitoro per le prossime 12h (richiesta user) il drain effettivo del backlog.
- **Revert-trigger**: se il parked-retry causa churn (stesse issue re-parkate ogni 2gg senza progresso) → alzare RETRY_COOLDOWN_DAYS o abbassare MAX_REPARK_GEN; se il drift-reopen ri-triggera review-quota su PR che ricevono subito un altro 🔴 identico (loop) → gate aggiuntivo sul round-cap marker prima del reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)