### PR TITLE
ci(worker): add timeout-minutes: 30 to deploy-worker job (#1821)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -39,6 +39,13 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Bounds the job (default is 6h): if `wrangler rollback` blocks on a non-TTY
+    # confirmation prompt, the step would otherwise hang up to 6h while
+    # concurrency: { cancel-in-progress: false } holds the deploy-cloudflare-worker
+    # group, blocking every subsequent Worker deploy — including a hotfix for the
+    # regression that triggered the rollback. Makes the declared 30-min safety net
+    # real (#1821; matches update-jobs-*/production-canary convention).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Implementato
- `.github/workflows/deploy-worker.yml`: aggiunto `timeout-minutes: 30` al job `deploy` (livello `runs-on`).

### Root cause (#1821, reviewer 🟡 nit di #1820)
Senza timeout il job eredita il default di 360 min (6h). Se `wrangler rollback` (lo step auto-rollback) si blocca su un prompt di conferma non-TTY, lo step resta appeso fino a 6h mentre `concurrency: { cancel-in-progress: false }` tiene occupato il gruppo `deploy-cloudflare-worker` → blocca **ogni** deploy successivo del Worker, incluso un hotfix per la regressione che ha innescato il rollback. Questo rende reale la "rete di sicurezza 30 min" che il body di #1820 già dichiarava (allinea alla convenzione `update-jobs-*`/`production-canary`).

Closes #1821

## Non implementato (ancora)
- Nessuno: fix single-line as-specified.
- **Nota merge**: tocca un file `.github/workflows/**` → la GitHub App reviewer non può fare auto-merge (workflow-validation); merge manuale `gh pr merge --squash --delete-branch`. È esattamente la classe `blocked-workflows-scope` che il CI fixer non può gestire (e che il nuovo gate #2006 ora parka per mano umana).

🤖 Generated with [Claude Code](https://claude.com/claude-code)