### PR TITLE
fix(loop): autorebase skips merge-ready PRs — stop breaking LGTM'd greens

### DIFF
--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -254,6 +254,22 @@ async function processPR(pr) {
     }
     return;
   }
+  // SKIP rebase delle PR già pronte al merge (2026-06-15): main NON richiede
+  // branch up-to-date (branch protection `strict=false`, required_checks=[]),
+  // quindi una PR LGTM'd + vitest verde sull'head viene squash-mergiata da
+  // auto-merge ANCHE se dietro main — il rebase è inutile e DANNOSO: il merge
+  // di origin/main crea un nuovo head, il synchronize del push-PAT va
+  // `action_required`/non ricrea il check-run, il vitest verde sparisce e
+  // auto-merge-eval (gate vitest==success) si blocca per sempre (circolo vizioso
+  // osservato 00:30Z: #2026/#2028/#855 LGTM'd rebasati → action_required → stuck;
+  // più la PR aspetta, più l'autorebase la rompe). Tocchiamo solo le PR che il
+  // rebase serve DAVVERO: collision-risk (il gate collisione esige il rebase
+  // oltre l'altra PR) e stale-review (drift/conflitto). Una LGTM'd+verde senza
+  // collisione → lasciala ad auto-merge.
+  if (lgtm && headHasVitestCheck(head) && !labels.includes('collision-risk')) {
+    console.log(`PR #${num} LGTM + vitest verde sull'head, no collision, ${behind} dietro main → SKIP rebase (main non-strict: auto-merge la mergia così com'è; rebasarla romperebbe il check).`);
+    return;
+  }
   console.log(`PR #${num} (${branch}) è ${behind} dietro main, near-merge → valuto rebase.`);
 
   // Activity-guard: se l'head è stato pushato pochi minuti fa, un contributor/


### PR DESCRIPTION
## Implementato

Il blocco di convergenza trovato alle 00:30Z durante il monitoraggio 12h: i merge si sono quasi fermati dopo le 21:00 con 4 PR LGTM'd stuck. Root-cause: la branch protection di main NON è strict (`strict=false`, `required_checks=[]`), quindi una PR LGTM'd + vitest verde si squash-mergia anche se dietro main. Ma l'autorebase rebasava comunque quelle PR LGTM'd dietro-main; il merge di origin/main crea un nuovo head, il synchronize del push-PAT va `action_required` (non produce un check-run vitest leggibile), il verde sparisce e il gate `vitest==success` di auto-merge-eval si blocca per sempre. Peggio: più una PR aspetta, più il cron-throttlato autorebase la rebasa in questo stato → circolo vizioso che congela la convergenza (#2026/#2028/#855 colpite; mergiate a mano per sbloccare).

- `scripts/ci/pr-autorebase.mjs`: SKIP del rebase per una PR LGTM'd + vitest verde sull'head + non collision-risk → auto-merge la squash-mergia così com'è (nessun requisito up-to-date); rebasarla la romperebbe soltanto.
- Restano rebasate le PR che lo richiedono DAVVERO: `collision-risk` (il gate collisione esige il rebase oltre l'altra PR) e `stale-review` (drift/conflitto). L'orphan-heal (LGTM'd ma senza check vitest) è invariato.

Validato live: branch protection confermata non-strict via API; #2028 (fix di #855, stranded 2 settimane) e #2026 (il fix SETTLE_MIN del drain) avevano head = merge-commit di autorebase + synchronize action_required → sbloccate manualmente. Questo fix elimina la causa.

## Non implementato (ancora)

- **Caso collision-risk + rebase rompe il check**: stessa classe ma più raro; se emerge, il rescuer→recycle lo recupera (24h). Follow-up se ricorre.
- **Causa precisa di `action_required`** sul synchronize del push-PAT: non pienamente diagnosticata (run 404 alla verifica; approve-API esclude fork-gating). Irrilevante per il fix: eliminando il rebase non necessario, il synchronize problematico non viene più generato.
- **Revert-trigger**: se PR LGTM'd+verde+dietro-main NON vengono mergiate da auto-merge (es. una regola di merge che dopotutto richiede up-to-date) → ripristinare il rebase per loro. Monitoro nella finestra 12h residua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)