### PR TITLE
fix(loop): escalate too-large follow-ups to human instead of burning opus

### DIFF
--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -271,6 +271,20 @@ function hasFixPR(num) {
   return false;
 }
 
+/** La issue ha MAI prodotto una fix PR (open|merged|closed)? Distingue un
+ * follow-up che il fixer ha almeno parzialmente lavorato (PR creata) da uno che
+ * non ha MAI prodotto nulla in N attempt = pattern pure-run-death (error_max_turns
+ * ripetuto / too-large). Questi ultimi non vanno ri-tentati all'infinito: ~9 run
+ * opus bruciati (3 attempt × 3 generation parked-retry) senza UNA PR (#1801/
+ * #1734/#1822 osservati 2026-06-15). fail-safe: errore gh → true (non escalare
+ * per un glitch). */
+function hasFixPREver(num) {
+  try {
+    const prs = gh(['pr', 'list', '--repo', REPO, '--head', `fix/issue-${num}`, '--state', 'all', '--json', 'number', '--limit', '1']);
+    return Array.isArray(prs) && prs.length > 0;
+  } catch { return true; }
+}
+
 function minutesSince(iso) {
   const then = Date.parse(iso);
   if (Number.isNaN(then)) return Number.POSITIVE_INFINITY;
@@ -324,17 +338,35 @@ function main() {
     const reparkable = listIssues(LBL_PARKED)
       .filter((iss) => has(iss, 'follow-up'))
       .filter((iss) => !has(iss, LBL_FIX) && !has(iss, LBL_QUEUED)) // non già in lavoro/coda
+      .filter((iss) => !has(iss, 'needs-human'))                    // già escalato (too-large) → fuori dal retry
       .filter((iss) => reparkGenOf(iss) < MAX_REPARK_GEN)            // generation-cap
       .filter((iss) => minutesSince(iss.updatedAt) >= RETRY_COOLDOWN_DAYS * 1440) // cooldown
       .sort((a, b) => prioRank(a) - prioRank(b) || Date.parse(a.updatedAt) - Date.parse(b.updatedAt));
     let retried = 0;
     let skippedWf = 0;
+    let escalatedTooLarge = 0;
     for (const iss of reparkable) {
       if (retried >= RETRY_MAX_PER_RUN) {
-        console.log(`parked-retry: cap ${RETRY_MAX_PER_RUN}/run raggiunto, ${reparkable.length - retried - skippedWf} rinviati al prossimo tick (no silent cap).`);
+        console.log(`parked-retry: cap ${RETRY_MAX_PER_RUN}/run raggiunto, ${reparkable.length - retried - skippedWf - escalatedTooLarge} rinviati al prossimo tick (no silent cap).`);
         break;
       }
       if (isWorkflowScoped(iss.number)) { skippedWf++; continue; } // capability-guard → resta parked
+      // TOO-LARGE: un follow-up che ha GIÀ avuto un giro di parked-retry (gen≥1)
+      // col fixer migliorato e NON ha ancora MAI prodotto una PR = pure-run-death
+      // (error_max_turns ripetuto / too-large). Ri-tentarlo per la generazione
+      // residua = altri ~3 run opus bruciati per nulla (#1801/#1734/#1822 falliti
+      // ai cap GIÀ bumpati 40/50). Escala a needs-human (visibile, escluso dai
+      // retry futuri perché needs-human esce dal filtro reparkable) invece di
+      // ri-accodare. gen≥1: la PRIMA parkata ottiene comunque una chance col
+      // fixer migliorato (potrebbe essere parkato pre-improvement); si escala
+      // solo se ANCHE quella chance non ha prodotto nulla.
+      if (reparkGenOf(iss) >= 1 && !hasFixPREver(iss.number)) {
+        if (DRY) { console.log(`[dry] too-large #${iss.number} (gen ${reparkGenOf(iss)}, 0 PR) → needs-human, no re-queue`); escalatedTooLarge++; continue; }
+        edit(iss.number, { add: ['needs-human'], remove: [] });
+        console.log(`TOO-LARGE #${iss.number} → needs-human (gen ${reparkGenOf(iss)}, mai una PR = error_max_turns/too-large; stop al burn opus, escala a umano) — "${iss.title?.slice(0, 45)}"`);
+        escalatedTooLarge++;
+        continue;
+      }
       const gen = reparkGenOf(iss) + 1;
       const prevGen = reparkGenOf(iss) ? `fu-reparked:${reparkGenOf(iss)}` : null;
       const prevAttempt = attemptOf(iss) ? `fu-attempt:${attemptOf(iss)}` : null;
@@ -351,6 +383,7 @@ function main() {
       retried++;
     }
     if (skippedWf) console.log(`parked-retry: ${skippedWf} skip WF-scope (capability-guard → restano parked/age-out).`);
+    if (escalatedTooLarge) console.log(`parked-retry: ${escalatedTooLarge} escalati needs-human (too-large: 0 PR mai prodotta → stop al burn opus).`);
   }
 
   // Tutto (rescue + drain) gira SOLO a slot issue-fix libero: così il rescue non


### PR DESCRIPTION
## Implementato

Il long-tail bounded emerso nel monitoraggio 12h: follow-up il cui fix muore `error_max_turns` anche uno-item-alla-volta ai cap GIÀ bumpati (#1801/#1734/#1822, num_turns 41/51) non producono mai una PR, ma il cap-attempt (3) + le generazioni parked-retry (2) li ritentavano ~9 volte = ~9 run opus sprecati prima di fermarsi parked. Puro burn di token su item che il fixer autonomo genuinamente non riesce a one-shot.

- `scripts/ci/followup-drainer.mjs`: nel parked-retry, un follow-up che ha GIÀ avuto una generazione di retry (`reparkGen>=1`) e NON ha ancora MAI prodotto una fix PR (`hasFixPREver` via `--state all`) è classificato too-large → etichettato `needs-human` (escalation visibile, escluso dai retry futuri) invece di essere ri-accodato.
- La PRIMA parked-retry dà comunque una chance col fixer migliorato (l'item poteva essere parkato pre-improvement); l'escalation scatta solo se anche quella non ha prodotto nulla.
- `needs-human` filtrato fuori da `reparkable` → mai più ri-bruciato.

Effetto: costo per-item da ~9 attempt a ~6, e gli hard-item vanno a un umano subito invece di ciclare. Allineato col goal "minimo token".

## Non implementato (ancora)

- **Detection error_max_turns-specifica in issue-fix.yml**: avrei potuto marcare il fail subtype direttamente, ma il proxy "0 PR mai prodotta dopo un retry" è più robusto (non dipende dal parsing dell'output dell'action) e drainer-only (no rischio sul hot-path issue-fix). 
- **Surfacing dedicato delle issue needs-human**: sono etichettate e visibili (`gh issue list --label needs-human`); il surfacer di recycle-stale-prs copre le PR needs-human. Aggiungere il surfacing issue è follow-up se il volume cresce.
- **Revert-trigger**: se `needs-human` viene applicato a item che il fixer POTREBBE risolvere (falsa escalation osservabile: issue needs-human che poi un umano fixa banalmente) → alzare la soglia a reparkGen>=2 (dare 2 chance prima di escalare). Monitoro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)