### PR TITLE
revert(translate): #2018 regressed throughput to ~0 (LT overload on 2-core runner)

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
     inputs:
       max_jobs:
-        description: 'Max jobs to translate (drain-all default; lower it for targeted runs)'
-        default: '10000'
+        description: 'Max jobs to translate'
+        default: '100'
       company_key:
         description: 'Single company key to translate (e.g. a-group). Leave empty for all.'
         default: ''
@@ -63,11 +63,6 @@ jobs:
           LT_LOAD_ONLY: it,en,de,fr
           LT_SUGGESTIONS: "false"
           LT_DISABLE_WEB_UI: "true"
-          # Let the single self-hosted instance serve the localization queue's
-          # concurrency (JOBS_AI_LOCALIZATION_CONCURRENCY=6) in parallel instead
-          # of serialising requests on one worker. Argos is CPU-bound; the GitHub
-          # runner has 2-4 cores, so 4 threads saturates them without thrashing.
-          LT_THREADS: "4"
         options: >-
           --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/languages')\" || exit 1"
           --health-interval 15s
@@ -183,20 +178,7 @@ jobs:
           # Self-hosted LibreTranslate from service container — unlimited, no API key needed
           JOBS_LIBRETRANSLATE_ENDPOINT: 'http://localhost:5000/translate'
           LIBRETRANSLATE_SELF_HOSTED_URL: 'http://localhost:5000'
-          # Drive the localization pool at its max (clamped to [1,6] in
-          # shared-jobs-crawler.mjs). Without this, LOCALIZE_EXISTING_ONLY mode
-          # defaults to 2 — half the throughput. Closes #1696 (concurrency 2→6).
-          # Safe now that self-hosted LT (unlimited, parallel) is the workhorse:
-          # it replaces MyMemory's global 1-call/sec throttle that previously
-          # serialised every worker. See free-translate.mjs Tier 3b.
-          JOBS_AI_LOCALIZATION_CONCURRENCY: '6'
-        # --max-jobs fallback raised 100 → 10000 so a SINGLE successful run drains
-        # the entire pending backlog instead of nibbling 100/run while crawlers add
-        # more. The shared `jobs-data-pipeline` concurrency group means most queued
-        # runs get cancelled (queue-dedup) — harmless only if the one that DOES run
-        # clears everything. With self-hosted LT + concurrency 6 the full backlog
-        # fits well inside the 350-min timeout. Manual/dispatch runs can override.
-        run: node scripts/relocalize-pending-jobs.mjs --max-jobs ${{ inputs.max_jobs || '10000' }} ${{ inputs.company_key && format('--company-key {0}', inputs.company_key) || '' }}
+        run: node scripts/relocalize-pending-jobs.mjs --max-jobs ${{ inputs.max_jobs || '100' }} ${{ inputs.company_key && format('--company-key {0}', inputs.company_key) || '' }}
 
       - name: Log translation stats (after)
         if: always() && steps.checkout.outcome == 'success' && inputs.skip_translate != true

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -929,24 +929,19 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   if (t2c) return balanceMarkdownMarkers(t2c);
 
   // Tier 3b: LibreTranslate self-hosted (CI service container — unlimited, no
-  // rate limits, no shared throttle). Promoted ABOVE MyMemory for ALL target
-  // locales (incl. IT). Rationale: the premium tiers above (DeepL/Azure/Google
-  // Cloud) still run first, so the highest-quality engines handle every job while
-  // their daily quota lasts. Once those are exhausted — which happens after a
-  // few dozen jobs/run — the only realistic engines for a multi-thousand-job
-  // backlog are the unlimited ones. MyMemory cannot drain a backlog: it is capped
-  // at ~50K chars/day AND throttled to 1 call/sec GLOBALLY across all concurrent
-  // workers, so it serialises the whole localization queue at the slowest tier.
-  // The self-hosted instance has neither cap, so promoting it here lets the
-  // queue's concurrency actually deliver throughput. IT was previously kept below
-  // MyMemory (typos in compounds), but MyMemory's char-cap means it only ever
-  // handled the first ~30 IT jobs/day anyway — the rest already fell through to
-  // self-hosted LT (old Tier 4a). The downstream isIncomplete() quality gate
-  // still rejects thin/wrong-language output and re-queues the job, so quality is
-  // preserved while the queue drains. No-op when LIBRETRANSLATE_SELF_HOSTED_URL
-  // is unset (returns '').
-  const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
-  if (t3b) return balanceMarkdownMarkers(t3b);
+  // rate limits, no shared throttle). Promoted ABOVE MyMemory ONLY for EN/DE/FR
+  // targets: once the premium tiers (DeepL/Azure/Google Cloud) are exhausted, the
+  // self-hosted instance carries the parallel load instead of MyMemory's
+  // 1-call/sec throttle, so the localization queue's concurrency delivers
+  // throughput. Gated to non-IT because LibreTranslate's IT quality is documented
+  // as weaker (typos in compounds) and IT is the funnel's primary indexed locale —
+  // for IT, MyMemory ("best EU quality") stays ahead and self-hosted LT remains a
+  // post-MyMemory fallback (Tier 4a below), preserving pre-PR IT behaviour. No-op
+  // when LIBRETRANSLATE_SELF_HOSTED_URL is unset (returns '').
+  if (targetLang !== 'it') {
+    const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+    if (t3b) return balanceMarkdownMarkers(t3b);
+  }
 
   // Tier 4: MyMemory (best EU language quality, 50K chars/day with email param)
   // Short text (≤5000 chars): single call. Long text: chunk at sentence boundaries.
@@ -974,10 +969,17 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   });
   if (t2) return balanceMarkdownMarkers(t2);
 
-  // Tier 4a: LibreTranslate public instances (raced in parallel — reliable from CI).
-  // Self-hosted LT already ran for every locale at Tier 3b above, so there is no
-  // IT-only self-hosted retry here (it would pay a second up-to-30s timeout on a
-  // hung endpoint for no benefit).
+  // Tier 4a: LibreTranslate self-hosted — IT-target ONLY. For IT this is the
+  // first (and only) self-hosted attempt, kept below MyMemory by the EN/DE/FR
+  // gate at Tier 3b, preserving pre-PR IT order. EN/DE/FR already tried it at
+  // Tier 3b, so re-running it here would pay a second (up to 30s) timeout on a
+  // hung endpoint for no benefit — skip. No-op when self-hosted URL is unset.
+  if (targetLang === 'it') {
+    const t3bFallback = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
+    if (t3bFallback) return balanceMarkdownMarkers(t3bFallback);
+  }
+
+  // Tier 4b: LibreTranslate public instances (raced in parallel — reliable from CI)
   const t4 = await tryTier('libreTranslate', () => translateWithLibreTranslate(clean, sourceLang, targetLang));
   if (t4) return balanceMarkdownMarkers(t4);
 


### PR DESCRIPTION
## Implementato

Revert completo di #2018 (`perf(translate): drain pending-jobs queue at the root`). Il merge ha **regredito il throughput a ~0** e congelato il pipeline di traduzione su `main`.

**Evidenza live** (run `27511093627`, stats da `data/translation-stats-history.json`):
| run | before needsRetransl | after | complete Δ |
|---|---|---|---|
| 06-13 (pre-#2018, max-jobs 100) | 9612 | 4591 | +183 |
| 06-14 AM (pre-#2018, max-jobs 100) | 9255 | 4549 | +137 |
| **06-14 PM (#2018, max-jobs 10000)** | **4883** | **5686** | **+1** |

Il run con #2018 è girato **347min fino al timeout job (350min)** traducendo **~0 job netti** (complete +1, needsRetranslation cresciuto), poi ucciso → deploy skippato. Il log è inondato di `LibreTranslate self-hosted error: The operation was aborted due to timeout`.

**Causa**: le tre modifiche di #2018 si sono rivelate dannose sul runner GitHub 2-core:
- `JOBS_AI_LOCALIZATION_CONCURRENCY=6` + `LT_THREADS=4` → la singola istanza LibreTranslate (CPU-bound, 2 core) va in **overload** → ogni chiamata muore al timeout 30s.
- Cascade **LT-first per IT** → ogni job IT brucia 30s sul timeout LT prima di ripiegare su MyMemory → throughput per-job crollato da ~1-2s a >30s.
- `--max-jobs 100→10000` → il run non termina mai entro il timeout 350min → ucciso **prima** che il commit fosse l'unica cosa a salvarsi (il commit `always()` ha committato solo il parziale ~nullo).
- Premessa errata in #2018/review: si assumeva un "time-budget interno 320min" in `relocalize-pending-jobs.mjs` che **non esiste** (nessun guard temporale nel codice) → niente break prima del timeout.

Il revert ripristina: gate `targetLang !== 'it'` (MyMemory-first per IT, qualità+throughput provati), `--max-jobs 100`, rimozione `JOBS_AI_LOCALIZATION_CONCURRENCY`/`LT_THREADS`.

## Non implementato (ancora)

- **Obiettivo originale (drenare la coda a zero) NON risolto da questo revert** — torna allo stato funzionante che oscilla ~9600→~4600 needsRetranslation/run senza raggiungere 0. Il revert ferma solo la regressione. La vera radice del backlog persistente è duplice e va affrontata con un approccio misurato (non speculativo): (a) `mark-locale-mismatched-jobs.mjs` ri-flagga ogni run ~4600 job le cui traduzioni il detector rifiuta; (b) self-hosted LT non scala oltre concurrency ~1-2 su runner 2-core. Una futura PR dovrà: aggiungere un **vero time-budget** allo script (stop a ~300min → commit parziale garantito), abbassare `LIBRETRANSLATE_TIMEOUT_MS` per fail-fast, e tenere concurrency bassa — il tutto validato con un run misurato prima di alzare `--max-jobs`. Follow-up da aprire.
- Issue #1696 (concurrency 2→6) che #2018 dichiarava `Closes`: riaperta di fatto dal revert — andrà ri-valutata nella futura PR con misura reale, non chiusa su claim.

## Test plan

- [x] `git revert` pulito dei 2 soli file di codice (workflow + free-translate.mjs); commit dati successivi non in conflitto.
- [x] Verificato post-revert: gate `targetLang !== 'it'` ripristinato (`free-translate.mjs:941`), `--max-jobs || '100'` ripristinato, `JOBS_AI_LOCALIZATION_CONCURRENCY`/`LT_THREADS` rimossi dal workflow.
- [ ] Post-merge: prossimo run `translate-pending` torna a completare entro il timeout e a drenare (needsRetranslation cala, complete +100+, deploy triggerato). (verifica post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)