### PR TITLE
perf(translate): fast-fail dead self-hosted LibreTranslate (30s→5s) to reclaim ~262min/run

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -178,6 +178,17 @@ jobs:
           # Self-hosted LibreTranslate from service container — unlimited, no API key needed
           JOBS_LIBRETRANSLATE_ENDPOINT: 'http://localhost:5000/translate'
           LIBRETRANSLATE_SELF_HOSTED_URL: 'http://localhost:5000'
+          # Fast-fail the self-hosted LibreTranslate fetch. Measured: on the 2-core
+          # GitHub runner the Argos /translate endpoint overwhelmingly times out — run
+          # 27459918472 (max-jobs 100, default concurrency) logged 525 self-hosted
+          # timeout errors vs only 73 jobs cleared, burning ~262min of a 329min run
+          # waiting out the 30s default bound (free-translate.mjs LIBRETRANSLATE_TIMEOUT_MS).
+          # LT self-hosted contributes ~nothing, so failing it in 5s instead of 30s
+          # reclaims ~85% of that wasted time for the tiers that actually work (premium
+          # + MyMemory + public LT). The cascade order is unchanged; jobs LT can't serve
+          # fall through exactly as before, just sooner. Bounded downside: the rare LT
+          # call that would have succeeded in 5-30s now falls to MyMemory (which works).
+          LIBRETRANSLATE_TIMEOUT_MS: '5000'
         run: node scripts/relocalize-pending-jobs.mjs --max-jobs ${{ inputs.max_jobs || '100' }} ${{ inputs.company_key && format('--company-key {0}', inputs.company_key) || '' }}
 
       - name: Log translation stats (after)
@@ -199,6 +210,10 @@ jobs:
         if: steps.hk.outputs.run == 'true' && inputs.dry_run != true
         env:
           LIBRETRANSLATE_SELF_HOSTED_URL: 'http://localhost:5000'
+          # Same fast-fail rationale as Phase 2 above — the self-hosted LT endpoint
+          # times out ~always on the 2-core runner; 5s instead of 30s avoids burning
+          # the step's budget on the dead tier before the working cascade tiers run.
+          LIBRETRANSLATE_TIMEOUT_MS: '5000'
         run: node scripts/fix-untranslated-titles.mjs
 
       - name: Commit title fixes


### PR DESCRIPTION
## Implementato

Misurato che il self-hosted LibreTranslate è **di fatto morto** sul runner GitHub 2-core ma la cascade lo prova per ogni job, bruciando l'80% del tempo del run sul timeout di 30s.

**Evidenza** (run `27459918472`, max-jobs 100, concurrency default, cascade ripristinata post-revert #2044):
- `525` errori `LibreTranslate self-hosted error: The operation was aborted due to timeout`
- solo `73` job tradotti, `32` suppressi
- 525 × ~30s = **~262min sprecati su un run da 329min** (~80%) ad aspettare il timeout default `LIBRETRANSLATE_TIMEOUT_MS=30000`.

**Fix**: settato `LIBRETRANSLATE_TIMEOUT_MS: '5000'` nello step "Phase 2: Translate pending jobs" (e nel sibling "Phase 2b: Fix untranslated titles" che usa lo stesso endpoint). Il LT rotto fallisce in 5s invece di 30s → recupera ~85% del tempo sprecato per i tier che traducono davvero (premium DeepL/Azure/GoogleCloud + MyMemory + public LT). Stesso run → drena molto più backlog.

Perché è sicuro (≠ regressione #2018):
- **Nessun cambio cascade/concurrency/crawler-condiviso/gate-qualità.** Solo un timeout più basso su un tier che già fallisce.
- LT self-hosted contribuisce ~nulla (525 timeout vs 73 clear) → fallire prima non perde traduzioni; i job ripiegano sui tier funzionanti esattamente come ora, solo prima.
- Downside limitato: la rara call LT che sarebbe riuscita in 5-30s ora ripiega su MyMemory (che funziona).
- IT non degradato: LT è solo Tier 3b (EN/DE/FR) + Tier 4a fallback IT, entrambi post-MyMemory/premium.
- Reversibile (1 env var). Env wiring verificato: `free-translate.mjs:124` usa il valore se finito e >0.

## Non implementato (ancora)

- **Claim perf non validabile pre-merge** (il run translate gira solo post-merge): se il prossimo run NON mostra meno timeout-time e più job tradotti/run → revert (1 env var). Atteso: tempo-su-LT da ~262min → ~`525×5s`≈44min, headroom per più job entro il timeout 350min.
- **Riparare LT self-hosted** (farlo funzionare davvero = OSS illimitato) NON fatto: causa del timeout sistematico (model-load/2-core/healthcheck) da diagnosticare a parte. Questo PR lo bypassa fast-fail, non lo ripara. Follow-up.
- **Bump `--max-jobs`** NON fatto in questo PR: prima misuro quanto headroom libera il fast-fail (il run a max-jobs 100 era già a 126-329min); un bump misurato è un follow-up separato (evito di combinare 2 claim non validati come in #2018).
- **Re-flag churn / coda-zero**: la radice del floor (`mark-locale-mismatched` ri-flagga ~4600/run, 82% EN/DE/FR) resta; questo PR accelera il drain ma non elimina la coda da solo.

## Test plan

- [x] YAML valido (`yaml.safe_load`).
- [x] Env wiring verificato (`free-translate.mjs:123-124` parse + usa se >0; 5000 valido).
- [x] Diff chirurgico: 1 file, +15 righe, solo env (nessun cambio logica/cascade).
- [ ] Post-merge: prossimo run mostra timeout-LT-time crollato e #job tradotti/run su, dentro il timeout 350min. (verifica post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)