### PR TITLE
fix(build): bound flush backlog inside expired-soft-landing loop (deploy OOM root cause)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10888,6 +10888,16 @@ ${staticAnalyticsHtml}
  const lastmod = (safeIsoDate(ejData?.expiredAt) || '').slice(0, 10) || dateStamp;
  expiredSitemapEntries.push(` <url>\n <loc>${BASE_URL}${itPath}</loc>\n${altLinks}\n${xDefault}\n <lastmod>${lastmod}</lastmod>\n <changefreq>monthly</changefreq>\n <priority>0.3</priority>\n </url>`);
  }
+ // Bound the WriteCollector background-flush backlog INSIDE this
+ // ~150k-page expired-soft-landing loop. Previously the only
+ // awaitDrainSlot ran AFTER the whole loop, so _pendingFlushes
+ // accumulated unbounded during the emit (observed 65 in-flight ×
+ // 5000-entry batches of large soft-landing HTML ≈ 12 GB) and the
+ // deploy build OOM'd in this exact phase (run 27520709430,
+ // "Ineffective mark-compacts near heap limit"). Draining each
+ // iteration caps peak at ~7 batches (~1 GB); mirrors the
+ // awaitDrainSlot(6) the active-jobs emit loops already use.
+ await collector.awaitDrainSlot(6);
  }
 
  // Write expired jobs sitemap
@@ -10962,6 +10972,10 @@ ${staticAnalyticsHtml}
  _writtenPaths.add(indexFile);
  crossLocaleExpiredCount++;
  recordEmit('cross-locale-expired-bridge', __tCrossLocaleExpired);
+ // Sibling backpressure (AGENTS.md #6): same unbounded background-flush
+ // risk as the expired-soft-landing loop above — drain INSIDE the emit
+ // loop so _pendingFlushes can't balloon during the cross-locale sweep.
+ await collector.awaitDrainSlot(6);
  }
  }
  }


### PR DESCRIPTION
## Contesto — OOM deploy (causa reale)

Il full deploy build OOMa in `jobsSeoPagesPlugin` fase **expired-soft-landing**: `FATAL ERROR: Ineffective mark-compacts near heap limit` a heapUsed=12005MB (run 27520709430, e identicamente nell'OOM precedente #27512425607).

**Root cause:** il loop `for (const slug of expiredSlugs)` (~150k pagine) chiama `collector.add()` ma l'unico `awaitDrainSlot` era **dopo l'intero loop**. Ogni volta che il buffer supera la soglia auto-flush (5000) parte un flush in background; **senza drain per-iterazione si accumulano unbounded** in `_pendingFlushes` (osservato `inflightFlushes=65` al OOM). Ogni flush in-flight tiene una batch da 5000 pagine HTML grandi → ~65 × 5000 × ~30-100KB ≈ **12GB** → heap abort.

**Non causato dai plugin bridge** (#2000/#2040): girano a closeBundle DOPO questa fase, il build non li raggiunge mai. È un **cliff baseline pre-esistente** emerso con la crescita del dataset crawler (0 OOM nei 10 fallimenti pre-#2000, cancellati prima di raggiungere questa fase).

## Implementato

- **Drain DENTRO il loop expired-soft-landing**: `await collector.awaitDrainSlot(6)` per-slug, esattamente come fanno già i loop active-jobs. Bounda `_pendingFlushes` a ~7 batch (~1GB) invece di lasciarlo arrivare a 65.
- **Sibling fix (AGENTS.md #6)**: stesso drain per-iterazione aggiunto al loop **cross-locale-expired** (`for (const ej of expiredJobsData)`), che aveva l'identico pattern unbounded.
- Output **invariato** — `awaitDrainSlot` regola solo il ritmo della coda di flush in background, non cambia byte emessi. Test `jobs-seo-pages-plugin` (3) + `soft-landing-seo` (9) verdi.

## Non implementato (ancora)

- **Claim memoria non validabile pre-merge → trigger**: il build SSG `build:ci` (12GB heap su runner 16GB) OOMa solo post-merge su `main`. La riduzione (~12GB → ~1GB di backlog) è attesa ma non misurabile localmente (full SEO build OOMa in locale). **Se il prossimo full deploy OOMa ancora nella fase expired-soft-landing → la diagnosi backpressure è incompleta** (es. un altro held-object oltre `_pendingFlushes`); osservabile dai log `[mem] jobsSeoPages: after expired-softlandings inflightFlushes=N` (atteso N≤7, era 65).
- **Altri loop emit**: city/sector/company-hubs hanno già drain interni (verificato). Non toccati.
- **Bump heap non fattibile**: 12GB è tarato sotto il RAM ceiling del runner (rss picco 11.3GB); alzarlo rischia RAM-kill. Il fix giusto è ridurre il backlog, fatto qui.

## Test plan

- [x] `tests/jobs-seo-pages-plugin.test.ts` (3) + `tests/soft-landing-seo.test.ts` (9) verdi
- [x] esbuild parse OK
- [ ] post-merge: full deploy completa **senza OOM** in expired-soft-landing; log mostra `inflightFlushes` ≤7 (era 65)
- [ ] post-merge: una volta che il deploy passa, i bridge CF-hot di #2040 (già in main) vanno live → san-gallo 404→200
