### PR TITLE
fix(loop): cap error_max_turns retries at 2 — close the rescue-burn residual

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -225,6 +225,46 @@ jobs:
         # Best-effort: never fails the job.
         run: node scripts/ci/claude-usage-summary.mjs "${{ steps.claude_review.outputs.execution_file }}" "issue-fix"
 
+      - name: Mark error_max_turns (granular telemetry, pre-backstop)
+        # Quando la run Claude muore `error_max_turns` (turn budget esaurito) NON
+        # lascia un marker FIX_OUTCOME del fixer → il backstop sotto posta un
+        # generico `no-pr-unspecified` che il drainer IGNORA (BACKSTOP_MARKER) →
+        # l'item viene trattato come orfano ri-tentabile e ri-accodato fino a
+        # MAX_ATTEMPTS, bruciando ~3 run opus su un item che esaurisce il budget
+        # in modo DETERMINISTICO (ri-tentarlo lo riproduce). Questo step rileva
+        # SPECIFICAMENTE il subtype `error_max_turns` dall'execution file e posta
+        # un marker granulare `max-turns` (senza BACKSTOP_MARKER → il drainer lo
+        # VEDE) così il drainer può parkare dopo 2 occorrenze (vedi
+        # followup-drainer.mjs). Subtype-gated: i fail transienti (altro subtype)
+        # NON ricevono il marker → restano ri-tentabili (nessuna falsa
+        # escalation). Gira PRIMA del backstop così quest'ultimo trova il marker
+        # e si salta. Best-effort, mai fa fallire il job.
+        if: always() && steps.claude_review.outcome == 'failure' && steps.preflight.outputs.already_resolved != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          EXEC_FILE: ${{ steps.claude_review.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+          if [ -z "${EXEC_FILE:-}" ] || [ ! -f "$EXEC_FILE" ]; then echo "no execution file → skip"; exit 0; fi
+          SUBTYPE=$(node -e "
+            const fs=require('fs');
+            try {
+              const raw=fs.readFileSync(process.env.EXEC_FILE,'utf8').trim();
+              let msgs;
+              try { msgs=JSON.parse(raw); } catch { msgs=raw.split(/\r?\n/).filter(Boolean).map((l)=>{try{return JSON.parse(l);}catch{return null;}}).filter(Boolean); }
+              if (!Array.isArray(msgs)) msgs=[msgs];
+              const r=[...msgs].reverse().find((m)=>m&&m.type==='result');
+              process.stdout.write(String((r&&r.subtype)||''));
+            } catch { process.stdout.write(''); }
+          " 2>/dev/null || true)
+          echo "claude result subtype: '${SUBTYPE:-<none>}'"
+          if [ "$SUBTYPE" = "error_max_turns" ]; then
+            # Marker granulare SENZA la stringa BACKSTOP_MARKER ('post-step
+            # deterministico') → latestFixOutcomeFromComments del drainer lo legge.
+            gh issue comment "$ISSUE" --body "$(printf '<!-- FIX_OUTCOME: max-turns -->\n_Run terminata error_max_turns (turn budget esaurito) — telemetria granulare per il drainer._')" || true
+          fi
+
       - name: Emit FIX_OUTCOME telemetry (deterministic backstop)
         # Skip on short-circuit: the pre-flight gate already posted the granular
         # `<!-- FIX_OUTCOME: already-fixed -->` marker; this coarse backstop would

--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -441,6 +441,19 @@ function main() {
       edit(iss.number, { add: [LBL_PARKED], remove: [LBL_FIX, LBL_QUEUED] });
       continue;
     }
+    // error_max_turns = turn-budget esaurito in modo DETERMINISTICO: ri-tentare
+    // lo stesso item lo riproduce. Non è non-ri-tentabile al PRIMO colpo (un cap
+    // borderline può farcela al retry), ma alla SECONDA occorrenza consecutiva
+    // (attemptOf>=1, cioè già ri-accodato una volta dopo un max-turns) è
+    // too-large → park come needs-human SUBITO, niente 3° attempt sprecato
+    // (~1 run opus). Marker `max-turns` emesso da issue-fix.yml SOLO sul subtype
+    // error_max_turns (i fail transienti hanno altro subtype → restano
+    // ri-tentabili: nessuna falsa escalation). Cap effettivo: 2 attempt invece di 3.
+    if (outcome === 'max-turns' && attemptOf(iss) >= 1) {
+      console.log(`PARK #${iss.number} → needs-human (2× error_max_turns = too-large deterministico; stop al 3° attempt sprecato)`);
+      edit(iss.number, { add: [LBL_PARKED, 'needs-human'], remove: [LBL_FIX, LBL_QUEUED] });
+      continue;
+    }
     // rescue/park per età-tentativi (run davvero morta, nessun verdetto)
     const attempt = attemptOf(iss) + 1;
     const prevAttemptLabel = attemptOf(iss) ? `fu-attempt:${attemptOf(iss)}` : null;


### PR DESCRIPTION
## Implementato

Chiude l'ultimo residuo documentato (rescue-burn): un item too-large che muore `error_max_turns` non lasciava marker del fixer → il backstop postava `no-pr-unspecified` (che il drainer ignora via BACKSTOP_MARKER) → trattato come orfano ri-tentabile → ri-accodato fino a MAX_ATTEMPTS (3), bruciando ~3 run opus su un item che esaurisce il budget in modo deterministico.

- **`issue-fix.yml`**: nuovo step `if: failure()` che legge l'execution file e, SOLO se `result.subtype === 'error_max_turns'`, posta un marker granulare `<!-- FIX_OUTCOME: max-turns -->` (senza la stringa BACKSTOP_MARKER → il drainer lo vede). **Subtype-gated**: i fail transienti (altro subtype) non ricevono marker → restano ri-tentabili (nessuna falsa escalation). Gira prima del backstop.
- **`followup-drainer.mjs`**: in rescue, `outcome === 'max-turns' && attempt>=1` (2ª occorrenza consecutiva) → park come `needs-human` subito, saltando il 3° attempt sprecato. Cap effettivo 2 invece di 3.

Combinato con wave 13, un item genuinamente too-large si stabilizza a needs-human in **~2 attempt invece di ~6**. Il PRIMO max-turns ottiene comunque un retry (un cap borderline può farcela); solo la ripetizione è trattata come deterministica.

## Non implementato (ancora)

- **Detection multi-occorrenza più fine**: uso `attemptOf>=1` come proxy della 2ª occorrenza (semplice, riusa il counter esistente); un counter max-turns-specifico sarebbe più preciso ma aggiunge stato per guadagno marginale.
- **Revert-trigger**: se item fixabili vengono parkati needs-human per un singolo max-turns spurio → il gate `attemptOf>=1` (richiede 2 occorrenze) lo previene; se emergono falsi positivi, alzare a 2 retry prima del park.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
