### PR TITLE
fix(app): guard React reconciler against Google Translate DOM mutation crash

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import { installDomReconciliationGuard } from './services/domReconciliationGuard';
+
+// Harden the DOM against third-party mutation (Google Translate, extensions)
+// crashing React's reconciler with NotFoundError on insertBefore/removeChild.
+// Must run before any React render. See services/domReconciliationGuard.ts.
+installDomReconciliationGuard();
 
 // Auto-reload once when a deploy replaces JS/CSS chunks while user has stale index.html.
 // Vite fires this event before the error reaches React ErrorBoundary.

--- a/services/domReconciliationGuard.ts
+++ b/services/domReconciliationGuard.ts
@@ -1,0 +1,63 @@
+/**
+ * Defensive guard against third-party DOM mutation crashing React's reconciler.
+ *
+ * Browser-native Google Translate (and the extension), Grammarly, and similar
+ * tools rewrite text nodes inside React-managed DOM — e.g. wrapping a text node
+ * in a <font> element so the original node's parent silently changes. When React
+ * later reconciles those nodes it calls Node.insertBefore / Node.removeChild with
+ * a reference/child whose parent is no longer `this`, throwing:
+ *
+ *   NotFoundError: Failed to execute 'insertBefore' on 'Node':
+ *   The node before which the new node is to be inserted is not a child of this node.
+ *   NotFoundError: Failed to execute 'removeChild' on 'Node':
+ *   The node to be removed is not a child of this node.
+ *
+ * The throw escapes React, unmounts the whole tree via the top-level
+ * ErrorBoundary and shows the white "ERRORE / Ricarica Pagina" screen. Observed
+ * in the field on the job auth-gate (PostHog replay, French-translated page +
+ * Google CMP) where conditional text siblings re-render on sign-in interaction.
+ *
+ * The standard mitigation (facebook/react#11538) makes both methods a no-op when
+ * the reference/child node is not actually a child of `this`, instead of throwing.
+ * React's next render re-synchronises the tree from the VDOM. For well-formed
+ * callers this is a zero-behaviour-change patch: it only intercepts the
+ * cross-parent case that would otherwise crash.
+ */
+
+interface GuardedNodePrototype extends Node {
+  __domReconciliationGuardInstalled?: boolean;
+}
+
+export function installDomReconciliationGuard(): void {
+  if (typeof Node !== 'function' || !Node.prototype) return;
+
+  const proto = Node.prototype as GuardedNodePrototype;
+  if (proto.__domReconciliationGuardInstalled) return;
+  proto.__domReconciliationGuardInstalled = true;
+
+  const originalRemoveChild = proto.removeChild;
+  proto.removeChild = function removeChild<T extends Node>(this: Node, child: T): T {
+    if (child.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[domGuard] removeChild skipped: node is not a child of this parent', child, this);
+      }
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = proto.insertBefore;
+  proto.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null,
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[domGuard] insertBefore fell back to append: reference node is not a child of this parent', referenceNode, this);
+      }
+      return originalInsertBefore.call(this, newNode, null) as T;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/tests/dom-reconciliation-guard.test.ts
+++ b/tests/dom-reconciliation-guard.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installDomReconciliationGuard } from '../services/domReconciliationGuard';
+
+/**
+ * Reproduces the field crash (PostHog replay, French-translated job auth-gate):
+ *   NotFoundError: Failed to execute 'insertBefore'/'removeChild' on 'Node'.
+ * Google Translate reparents a text node (wraps it in a <font>), so when React
+ * calls removeChild/insertBefore with the original node the parent no longer
+ * matches and the DOM throws, crashing the whole app via the ErrorBoundary.
+ *
+ * The guard must (a) make the cross-parent case a no-op instead of throwing and
+ * (b) leave well-formed same-parent calls behaving exactly as native.
+ */
+describe('installDomReconciliationGuard', () => {
+  beforeEach(() => {
+    installDomReconciliationGuard();
+  });
+
+  it('does not throw when removeChild is called for a node reparented by Translate', () => {
+    const reactParent = document.createElement('div');
+    const text = document.createTextNode('Coordinatore BIM CVSE');
+    reactParent.appendChild(text);
+
+    // Simulate Google Translate wrapping the text node in a <font>.
+    const font = document.createElement('font');
+    reactParent.appendChild(font);
+    font.appendChild(text); // text.parentNode is now `font`, not `reactParent`
+
+    // React still believes `text` is a child of `reactParent`.
+    expect(() => reactParent.removeChild(text)).not.toThrow();
+    // The node was left where it actually lives; nothing was wrongly detached.
+    expect(text.parentNode).toBe(font);
+  });
+
+  it('does not throw when insertBefore reference node was reparented by Translate', () => {
+    const reactParent = document.createElement('div');
+    const reference = document.createElement('span');
+    reactParent.appendChild(reference);
+
+    // Translate moves the reference node out from under reactParent.
+    const font = document.createElement('font');
+    reactParent.appendChild(font);
+    font.appendChild(reference);
+
+    const newNode = document.createElement('em');
+    // Would throw NotFoundError natively; guard appends instead of crashing.
+    expect(() => reactParent.insertBefore(newNode, reference)).not.toThrow();
+    expect(newNode.parentNode).toBe(reactParent);
+  });
+
+  it('preserves native behaviour for well-formed same-parent calls', () => {
+    const parent = document.createElement('div');
+    const a = document.createElement('span');
+    const b = document.createElement('span');
+    parent.appendChild(b);
+
+    parent.insertBefore(a, b);
+    expect(parent.firstChild).toBe(a);
+    expect(parent.lastChild).toBe(b);
+
+    parent.removeChild(a);
+    expect(parent.contains(a)).toBe(false);
+    expect(parent.firstChild).toBe(b);
+  });
+
+  it('is idempotent — installing twice does not double-wrap', () => {
+    installDomReconciliationGuard();
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+    expect(() => parent.removeChild(child)).not.toThrow();
+    expect(parent.contains(child)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Contesto

Crash live osservato su PostHog replay (`replay-019ec983…`): l'utente, partito da "Calcola Stipendio Netto Frontaliere", apre l'offerta "Coordinatore BIM CVSE (M/F)" di Rolex a Ginevra (`/cerca-lavoro-ginevra/coordinatore-bim-…`), viene messo davanti all'auth-gate per leggere l'annuncio completo, accetta il CMP cookie **in francese** (Google TCF, CMP 300) → la pagina è tradotta dal browser → schermata bianca con:

```
NotFoundError: Failed to execute 'insertBefore' on 'Node':
The node before which the new node is to be inserted is not a child of this node.
```

## Causa radice

Google Translate (nativo browser / estensione) riscrive i nodi di testo dentro il DOM gestito da React — avvolge un text node in un `<font>`, quindi il `parentNode` originale cambia silenziosamente. Quando React riconcilia i **fratelli di testo condizionali** dell'auth-gate (`JobBoard.tsx` gate headline/trust-signals, `JobDetailAlertPrompt`, ecc.) sull'interazione di sign-in, chiama `insertBefore`/`removeChild` con un reference node il cui parent non è più `this` → il DOM lancia `NotFoundError` → l'eccezione esce da React e l'`ErrorBoundary` top-level smonta tutta l'app (white screen). Nessun guard difensivo esisteva, nessun `translate="no"`.

## Implementato

- Nuovo modulo `services/domReconciliationGuard.ts` con `installDomReconciliationGuard()`: patch difensiva standard (facebook/react#11538) di `Node.prototype.removeChild` (no-op se il child non è figlio di `this`) e `Node.prototype.insertBefore` (fallback ad `appendChild` se il reference node è stato reparentato). React ri-sincronizza dal VDOM al render successivo. Idempotente (flag `__domReconciliationGuardInstalled`).
- `index.tsx`: chiama il guard **prima di qualsiasi render React** (subito dopo gli import, prima di `createRoot().render`).
- `tests/dom-reconciliation-guard.test.ts`: 4 test che riproducono il reparenting di Translate e verificano (a) niente throw nel caso cross-parent, (b) comportamento nativo invariato per chiamate same-parent ben formate, (c) idempotenza.
- **Fix di classe, non del singolo sito**: copre Translate, Grammarly e qualsiasi estensione che muta il DOM React-managed, su tutte le route — non solo l'auth-gate.

## Non implementato (ancora)

- **`translate="no"` / `class="notranslate"` sull'`<html>`**: scartato di proposito — disabiliterebbe la traduzione del browser che l'utente vuole esplicitamente (il replay mostra un utente francofono); il sito serve solo parzialmente FR per il corpo annuncio. Il guard risolve il crash senza togliere la traduzione.
- **Sibling `check-sibling-patterns` (18 candidati: `services/clarity.ts`, `services/firebase.ts`, `components/**` con `insertBefore`/`removeChild`/`parentNode`/`ErrorBoundary`)**: ispezionati, NON è lo stesso antipattern — usano i metodi nativi in modo ben formato su nodi che possiedono (`parentNode === this`), caso che il guard lascia identico. Sono già coperti dalla patch globale dei prototype; nessun fix per-file necessario.
- **Verifica live**: il crash dipende dalla traduzione runtime del browser, non riproducibile in build CI; da confermare sul deploy `main` (Playwright con `Accept-Language: fr` + simulazione translate, o osservazione PostHog post-deploy che il fingerprint `NotFoundError:insertBefore` sparisce).

## Test plan

- [x] `npx vitest run tests/dom-reconciliation-guard.test.ts` → 4/4 verdi
- [x] `tsc --noEmit` → nessun errore nei file toccati (gli errori residui sono pre-esistenti su `origin/main`: `data/jobs.json` artifact mancante, direttive `@ts-expect-error` nei test)
- [ ] Post-deploy: il fingerprint errore `NotFoundError … insertBefore/removeChild` non ricompare nelle replay PostHog (verifica live post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)