### PR TITLE
feat(social): automate posting jobs & articles to Reddit communities

### DIFF
--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -69,9 +69,9 @@ jobs:
           fi
 
       # Hydrate the runner env with secrets pulled from Firebase Remote
-      # Config so the social-media post steps below see FB / LinkedIn
-      # tokens as `process.env.*`.
-      - name: Load secrets from Remote Config (FB + LinkedIn tokens)
+      # Config so the social-media post steps below see FB / LinkedIn /
+      # Reddit tokens as `process.env.*`.
+      - name: Load secrets from Remote Config (FB + LinkedIn + Reddit tokens)
         run: node scripts/load-rc-env.mjs
 
       # Small JSON artifacts only — NO github-pages download here.
@@ -191,6 +191,27 @@ jobs:
           ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
         run: |
           node scripts/post-to-linkedin.mjs \
+            "$ARTICLE_ID" \
+            "$ARTICLE_URL" \
+            "$OG_TITLE" \
+            "$OG_DESCRIPTION" \
+            "$ARTICLE_CATEGORY"
+
+      - name: Post to Reddit Communities
+        if: |
+          success() &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
+          fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
+          steps.wait_live_meta.outcome == 'success'
+        continue-on-error: true
+        env:
+          ARTICLE_ID: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleId }}
+          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
+          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
+          OG_DESCRIPTION: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogDescription }}
+          ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
+        run: |
+          node scripts/post-to-reddit.mjs \
             "$ARTICLE_ID" \
             "$ARTICLE_URL" \
             "$OG_TITLE" \

--- a/.github/workflows/reddit-jobs-daily-schedule.yml
+++ b/.github/workflows/reddit-jobs-daily-schedule.yml
@@ -1,0 +1,95 @@
+name: Reddit Jobs Daily Schedule
+
+on:
+  schedule:
+    # 13:45 UTC = 14:45 CET / 15:45 CEST. Offset by +15 min from the FB job
+    # schedule (30 13 * * *) so the two ledger-committing workflows don't race
+    # on a push to main, and so it lands AFTER the daily crawl→translate
+    # pipeline that primes today's job set (same upstream cushion as FB).
+    # Reddit has NO server-side scheduling, so the script posts IMMEDIATELY at
+    # a conservative low volume (default 2/run, with a delay between posts) to
+    # respect each community's anti-spam rules.
+    - cron: '45 13 * * *'
+  workflow_dispatch:
+    inputs:
+      volume:
+        description: 'Posts to publish this run (Reddit is rate-limited/anti-spam — keep low)'
+        required: false
+        default: '2'
+        type: choice
+        options: ['1', '2', '5']
+      dry_run:
+        description: 'Skip Reddit API call (preview only)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['true', 'false']
+
+permissions:
+  contents: write  # to commit reddit-posted-jobs.json
+  issues: write
+
+jobs:
+  schedule:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with: { node-version: 22, cache: npm }
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from RC
+        run: node scripts/load-rc-env.mjs
+
+      - name: Assemble jobs dataset
+        run: node scripts/assemble-jobs-dataset.mjs --stats
+
+      - name: Schedule Reddit jobs
+        env:
+          REDDIT_JOB_VOLUME: ${{ github.event.inputs.volume || '2' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: node scripts/schedule-reddit-jobs-daily.mjs
+
+      - name: Commit posted-jobs tracking
+        if: success() && github.event.inputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          if git diff --quiet data/reddit-posted-jobs.json; then
+            echo "no changes"; exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/reddit-posted-jobs.json
+          git commit -m "chore(reddit): track posted jobs [skip ci]"
+          # In-place resolver merges by job-id when another commit lands
+          # on main mid-run (e.g. a concurrent article workflow or a
+          # parallel orchestrator's ledger reset). Without this the
+          # workflow exits 1 and the ledger goes out-of-sync with what
+          # was actually posted to the Reddit communities.
+          bash scripts/lib/git-push-with-retry.sh \
+            --in-place-resolver-cmd "node scripts/lib/resolve-reddit-posted-jobs-conflict.mjs && git add -A"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/data/reddit-posted-jobs.json
+++ b/data/reddit-posted-jobs.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "posted": []
+}

--- a/data/reddit-subreddits.json
+++ b/data/reddit-subreddits.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "subreddits": {
+    "Ticino": { "displayName":"r/Ticino", "topics":["jobs","articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/Ticino/about/rules/", "minPostIntervalHours": 24, "notes":"Local Ticino community. Self-promo/job spam restricted — requires manual mod approval before enabling automation." },
+    "italiansinswitzerland": { "displayName":"r/italiansinswitzerland", "topics":["jobs","articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/italiansinswitzerland/about/rules/", "minPostIntervalHours": 24, "notes":"Italian-speaking expats in CH — strong audience fit. Confirm self-promo policy with mods first." },
+    "Svizzera": { "displayName":"r/Svizzera", "topics":["articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/Svizzera/about/rules/", "minPostIntervalHours": 48, "notes":"General Swiss-Italian sub. Articles only; no job dumping." },
+    "frontalieri": { "displayName":"r/frontalieri", "topics":["jobs","articles"], "allowsAutomation": true, "flairId": null, "flairText": null, "rulesUrl":"", "minPostIntervalHours": 6, "notes":"OWN community to create/control (see docs). Safe default automation target since we set the rules. Create it if it does not exist." }
+  },
+  "routing": { "jobs": ["frontalieri","Ticino","italiansinswitzerland"], "articles": ["frontalieri","Ticino","italiansinswitzerland","Svizzera"] }
+}

--- a/docs/REDDIT-POSTING.md
+++ b/docs/REDDIT-POSTING.md
@@ -1,0 +1,155 @@
+# Reddit Posting
+
+Automazione della pubblicazione su Reddit di **offerte di lavoro** e **articoli del blog**, in parallelo all'esistente automazione Facebook e LinkedIn.
+
+## Panoramica
+
+Il sistema pubblica automaticamente due tipi di contenuto su community Reddit:
+
+- **Offerte di lavoro** — un workflow giornaliero (`reddit-jobs-daily-schedule.yml`) seleziona alcune offerte non ancora pubblicate e le posta su Reddit a basso volume.
+- **Articoli del blog** — al termine di un deploy `workflow_dispatch` che ha generato un nuovo articolo, lo step "Post to Reddit Communities" in `post-deploy-publish.yml` pubblica l'articolo, esattamente come fanno gli step Facebook e LinkedIn (stessa condizione `if:`, stessi argomenti posizionali).
+
+Si rapporta al workflow Facebook così: condivide lo stesso punto di ancoraggio (post-deploy per gli articoli, schedule giornaliero per i job), lo stesso meccanismo di caricamento segreti (`load-rc-env.mjs` da Firebase Remote Config) e lo stesso pattern di ledger committato su `main` con resolver dei conflitti. La differenza fondamentale è che **Reddit non ha scheduling lato server**: mentre Facebook accoda fino a 144 post programmati nelle 24 h successive, Reddit pubblica subito e quindi il volume è deliberatamente basso (default 2/run) per rispettare le regole anti-spam delle community.
+
+## Architettura / file coinvolti
+
+| File | Ruolo |
+|------|-------|
+| `scripts/lib/reddit-client.mjs` | Client OAuth2 di Reddit: grant via refresh-token (preferito) con fallback al password-grant per "script app"; token endpoint in Basic-auth; header `User-Agent` obbligatorio. |
+| `scripts/lib/reddit-templates.mjs` | Builder dei post in italiano (titolo + corpo markdown per le offerte, titolo + link per gli articoli). |
+| `data/reddit-subreddits.json` | Configurazione dei subreddit: `displayName`, `topics`, `allowsAutomation`, `flairId`, `flairText`, `rulesUrl`, `minPostIntervalHours`, `notes`, più `routing` per `jobs`/`articles`. Solo `frontalieri` ha `allowsAutomation: true` di default. |
+| `scripts/post-to-reddit.mjs` | Pubblicazione di un singolo **articolo**. CLI: `node scripts/post-to-reddit.mjs <article-id> <article-url> <og-title> <og-description> [category] [--dry-run]`. Soft-fail (exit 0). |
+| `scripts/schedule-reddit-jobs-daily.mjs` | Pubblicazione giornaliera delle **offerte**. Env: `REDDIT_JOB_VOLUME` (default 2), `REDDIT_POST_DELAY_MS` (default 5000), `DRY_RUN`. Aggiorna `data/reddit-posted-jobs.json`. |
+| `scripts/lib/resolve-reddit-posted-jobs-conflict.mjs` | Merge-driver per risolvere i conflitti git sul ledger (unione per job id). |
+| `.github/workflows/reddit-jobs-daily-schedule.yml` | Cron giornaliero (`45 13 * * *`) + `workflow_dispatch` che lancia lo scheduler dei job. |
+| `.github/workflows/post-deploy-publish.yml` | Contiene lo step "Post to Reddit Communities" per gli articoli (dopo lo step LinkedIn). |
+| `data/reddit-posted-jobs.json` | Ledger dei job già pubblicati (dedup per id). |
+
+## Setup OAuth Reddit (passi manuali)
+
+1. Vai su <https://www.reddit.com/prefs/apps> ed esegui il login con l'account che pubblicherà.
+2. Crea una nuova app:
+   - **script app** — più semplice, adatta al password-grant; ottieni `client_id` (la stringa sotto il nome dell'app) e `client_secret`.
+   - **web app** — necessaria se vuoi usare il refresh-token grant (consigliato per non memorizzare la password).
+3. Annota `client_id` e `client_secret`.
+
+### Due modalità di autenticazione
+
+- **Refresh token (preferito).** Esegui una volta il flusso OAuth2 di una "web app" per ottenere un `refresh_token` con gli scope `submit` + `identity`. Il client lo usa per ottenere access token freschi senza esporre la password.
+- **Password grant (fallback per "script app").** Il client autentica con `REDDIT_USERNAME` + `REDDIT_PASSWORD`. Funziona solo per le "script app" e con account senza 2FA (o usando una app-password).
+
+### Header User-Agent (OBBLIGATORIO)
+
+Reddit **rifiuta** le richieste senza un `User-Agent` descrittivo e univoco. Formato richiesto:
+
+```
+platform:appid:version (by /u/username)
+```
+
+Esempio:
+
+```
+node:frontaliereticino-poster:1.0.0 (by /u/iltuousername)
+```
+
+### Parametri Remote Config da impostare
+
+Imposta questi parametri in Firebase Remote Config (i secret con prefisso `SERVER_` non vengono mai esposti al client; vedi `scripts/load-rc-env.mjs`):
+
+| Parametro RC | Env var | Tipo |
+|--------------|---------|------|
+| `REDDIT_CLIENT_ID` | `REDDIT_CLIENT_ID` | client-visible |
+| `SERVER_REDDIT_CLIENT_SECRET` | `REDDIT_CLIENT_SECRET` | secret |
+| `REDDIT_USERNAME` | `REDDIT_USERNAME` | client-visible |
+| `SERVER_REDDIT_PASSWORD` | `REDDIT_PASSWORD` | secret |
+| `SERVER_REDDIT_REFRESH_TOKEN` | `REDDIT_REFRESH_TOKEN` | secret |
+| `REDDIT_USER_AGENT` | `REDDIT_USER_AGENT` | client-visible |
+
+## Regole delle community & anti-spam
+
+- **Regola 9:1 di Reddit.** L'autopromozione deve restare minoritaria: per ogni post promozionale dovresti avere ~9 contributi non promozionali (commenti, risposte, contenuti utili). Spammare offerte/link viola questa regola e porta a shadowban o ban.
+- **La maggior parte dei subreddit vieta lo spam di offerte.** Community come r/Ticino, r/Svizzera, r/italiansinswitzerland proibiscono il posting automatico di annunci e richiedono l'**approvazione dei moderatori**. Per questo `allowsAutomation` è `false` di default su tutti i subreddit tranne il nostro **r/frontalieri** (safe-by-default: si auto-pubblica solo sulla nostra community finché un umano non ottiene il permesso dei mod altrove).
+- **Nessuno scheduling lato server.** Reddit non offre code di pubblicazione programmata: lo script pubblica **subito**, a basso volume (default 2/run) e con un `REDDIT_POST_DELAY_MS` (default 5000 ms) tra un post e l'altro.
+
+### Abilitare un subreddit di terze parti (passi manuali)
+
+1. Contatta i moderatori del subreddit e chiedi il permesso esplicito di pubblicare offerte in automatico.
+2. Ottieni l'eventuale **flair** richiesto dal subreddit (molte community impongono un flair specifico per gli annunci di lavoro).
+3. Recupera il `flairId` (e l'eventuale `flairText`): di solito va scoperto manualmente tramite l'API dei flair del subreddit o chiedendolo ai mod.
+4. In `data/reddit-subreddits.json` imposta `allowsAutomation: true` per quel subreddit e compila `flairId`/`flairText` e `rulesUrl`.
+5. Aggiungi il subreddit alle liste `routing.jobs` e/o `routing.articles` secondo i `topics`.
+
+## Gestire una community propria (r/frontalieri)
+
+Il canale sicuro e controllato è un subreddit di nostra proprietà:
+
+1. Crea il subreddit (es. r/frontalieri) dal tuo account; diventi automaticamente moderatore.
+2. Definisci regole e flair coerenti con i contenuti (offerte + articoli).
+3. Poiché ne sei mod, l'automazione è consentita senza dipendere dall'approvazione di terzi: è l'unico subreddit con `allowsAutomation: true` di default.
+4. Mantieni un rapporto sano contenuti utili / promozioni anche qui, per far crescere la community e non scoraggiare gli iscritti.
+
+## Logging / tracking
+
+- **Ledger `data/reddit-posted-jobs.json`.** Tiene traccia dei job già pubblicati per dedup **per job id**: un'offerta viene pubblicata una sola volta. Ogni entry registra il subreddit di destinazione e il **reddit post id** restituito dall'API.
+- **Resolver dei conflitti.** `scripts/lib/resolve-reddit-posted-jobs-conflict.mjs` è un merge-driver che unisce le entry per id quando un altro commit aggiorna il ledger su `main` mentre il workflow è in corso (es. un workflow articoli concorrente). Senza di esso il push fallirebbe e il ledger andrebbe fuori sincrono rispetto a ciò che è stato realmente pubblicato. Il workflow lo invoca via `git-push-with-retry.sh --in-place-resolver-cmd`.
+
+## Esecuzione
+
+**Esegui sempre prima un dry-run.**
+
+Offerte (scheduler):
+
+```bash
+DRY_RUN=1 node scripts/schedule-reddit-jobs-daily.mjs
+# volume personalizzato e delay:
+DRY_RUN=1 REDDIT_JOB_VOLUME=1 REDDIT_POST_DELAY_MS=5000 node scripts/schedule-reddit-jobs-daily.mjs
+```
+
+Articolo singolo:
+
+```bash
+node scripts/post-to-reddit.mjs <article-id> <article-url> "<og-title>" "<og-description>" <category> --dry-run
+```
+
+Come li lanciano i workflow GitHub Actions:
+
+- **Offerte** — `reddit-jobs-daily-schedule.yml` gira ogni giorno alle `45 13 * * *` (UTC) e si può lanciare a mano via `workflow_dispatch` scegliendo `volume` (1/2/5) e `dry_run` (true/false). Esegue `load-rc-env.mjs` → `assemble-jobs-dataset.mjs --stats` → `schedule-reddit-jobs-daily.mjs`, poi committa `data/reddit-posted-jobs.json`.
+- **Articoli** — lo step "Post to Reddit Communities" in `post-deploy-publish.yml` parte solo dopo un deploy `workflow_dispatch` con un nuovo articolo e metadata live verificati (stesse condizioni di FB/LinkedIn). È `continue-on-error: true`: un errore Reddit non blocca il deploy.
+
+## Template di esempio (italiano)
+
+**Post-offerta** (titolo + corpo markdown), come generato dal builder:
+
+```
+Titolo:
+[Lavoro] Operatore di produzione — Chiasso (TI) | Frontalieri Ticino
+
+Corpo:
+**Operatore di produzione** a **Chiasso (TI)**.
+
+- 💼 Contratto: tempo pieno
+- 📍 Sede: Chiasso, Canton Ticino
+- 💰 Salario indicativo: da definire con l'azienda
+
+Dettagli e candidatura 👉 https://frontaliereticino.ch/offerte/operatore-di-produzione-chiasso
+
+*Annuncio pubblicato per i lavoratori frontalieri in Ticino.*
+```
+
+**Post-articolo** (titolo + link), come generato dal builder:
+
+```
+Titolo:
+Richiesta Permesso G passo dopo passo nel 2026 — guida aggiornata
+
+Link:
+https://frontaliereticino.ch/blog/richiesta-permesso-g-step-by-step-2026
+```
+
+## Limitazioni note
+
+- **Access token a vita breve (~1 h).** Il client deve rinnovarlo a ogni run; con il password-grant questo richiede credenziali valide, con il refresh-token grant richiede un `REDDIT_REFRESH_TOKEN` non revocato.
+- **Rischio anti-spam / ban.** Volume alto, mancato rispetto della regola 9:1 o posting in subreddit non consenzienti possono portare a shadowban o ban dell'account.
+- **Nessuno scheduling nativo.** A differenza di Facebook, Reddit pubblica subito: il throttling è solo client-side (volume basso + delay).
+- **Dipendenza dall'approvazione dei mod.** L'espansione oltre r/frontalieri richiede il permesso esplicito dei moderatori di ogni subreddit.
+- **Flair id da scoprire manualmente.** I `flairId`/`flairText` richiesti da molte community vanno recuperati a mano e inseriti in `data/reddit-subreddits.json`.

--- a/scripts/lib/reddit-client.mjs
+++ b/scripts/lib/reddit-client.mjs
@@ -1,0 +1,204 @@
+/**
+ * Thin Reddit API client shared by the Reddit schedulers.
+ *
+ * Reddit specifics honored here:
+ *   • OAuth2 token endpoint requires HTTP Basic auth (client_id:client_secret)
+ *     and a NON-default User-Agent header — Reddit blocks generic UAs.
+ *   • Two auth modes, preferred first: (1) refresh-token grant,
+ *     (2) script-app password grant. Access tokens last ~1h.
+ *   • Submit endpoint posts form-urlencoded with `api_type=json`; Reddit's
+ *     JSON envelope `{json:{errors,data}}` carries per-request errors that
+ *     must be treated as failure even on HTTP 200.
+ *
+ * Soft, defensive style mirroring scripts/post-to-facebook.mjs: concise
+ * console logs, never throw — callers (schedulers) should never be blocked
+ * by a transient API hiccup.
+ */
+
+// Reddit hard limit on submission `title` length.
+export const REDDIT_TITLE_MAX = 300;
+
+const TOKEN_ENDPOINT = 'https://www.reddit.com/api/v1/access_token';
+const SUBMIT_ENDPOINT = 'https://oauth.reddit.com/api/submit';
+
+/**
+ * Return the User-Agent to send on every Reddit request. Reddit requires a
+ * descriptive, app-specific UA (generic ones like the default fetch UA are
+ * rate-limited / blocked). Override via REDDIT_USER_AGENT.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {string}
+ */
+export function userAgent(env = process.env) {
+  return env.REDDIT_USER_AGENT || 'web:frontaliereticino:v1.0 (by /u/frontaliereticino)';
+}
+
+/**
+ * Obtain a Reddit OAuth2 access token. Tries the refresh-token grant first,
+ * then falls back to the script-app password grant. Returns null (never
+ * throws) when credentials are missing or the call fails.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @param {typeof fetch} [fetchImpl]
+ * @returns {Promise<string|null>}
+ */
+export async function getAccessToken(env = process.env, fetchImpl = globalThis.fetch) {
+  const clientId = env.REDDIT_CLIENT_ID;
+  const clientSecret = env.REDDIT_CLIENT_SECRET;
+  const refreshToken = env.REDDIT_REFRESH_TOKEN;
+  const username = env.REDDIT_USERNAME;
+  const password = env.REDDIT_PASSWORD;
+  const ua = userAgent(env);
+
+  if (typeof fetchImpl !== 'function') {
+    console.warn('⚠️  Reddit: no fetch impl available — cannot get access token');
+    return null;
+  }
+  if (!clientId || !clientSecret) {
+    console.warn('⚠️  Reddit: REDDIT_CLIENT_ID / REDDIT_CLIENT_SECRET not set — skipping');
+    return null;
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+  // Helper: run one token grant and return access_token | null.
+  const requestToken = async (body, label) => {
+    try {
+      const res = await fetchImpl(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${basic}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': ua,
+        },
+        body,
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.access_token) {
+        console.log(`✅ Reddit access token via ${label} (expires in ${data.expires_in || '?'}s)`);
+        return data.access_token;
+      }
+      console.warn(`⚠️  Reddit token ${label} failed (HTTP ${res.status}): ${JSON.stringify(data).slice(0, 200)}`);
+      return null;
+    } catch (err) {
+      console.warn(`⚠️  Reddit token ${label} error: ${err.message}`);
+      return null;
+    }
+  };
+
+  // Mode 1 — refresh token (preferred; refresh tokens are long-lived).
+  if (refreshToken) {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+    const token = await requestToken(body, 'refresh_token');
+    if (token) return token;
+    console.warn('ℹ️  Reddit: refresh-token grant failed — trying password grant');
+  }
+
+  // Mode 2 — script-app password grant (fallback).
+  if (username && password) {
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      username,
+      password,
+    });
+    const token = await requestToken(body, 'password');
+    if (token) return token;
+  }
+
+  console.warn('⚠️  Reddit: no usable auth mode (set REDDIT_REFRESH_TOKEN or REDDIT_USERNAME/REDDIT_PASSWORD) — skipping');
+  return null;
+}
+
+/**
+ * Submit a post to Reddit. Builds the form body, parses the Reddit JSON
+ * envelope, and maps a non-empty `errors` array to a failure. Never throws —
+ * catches and returns `{ok:false, error}`.
+ *
+ * @param {object} opts
+ * @param {string} opts.token — Bearer access token from getAccessToken().
+ * @param {string} opts.subreddit — subreddit name without the `r/` prefix.
+ * @param {'self'|'link'} [opts.kind] — 'self' (text/markdown) or 'link'.
+ * @param {string} opts.title — submission title (≤300 chars).
+ * @param {string} [opts.url] — link URL (kind='link').
+ * @param {string} [opts.text] — markdown body (kind='self').
+ * @param {string} [opts.flairId]
+ * @param {string} [opts.flairText]
+ * @param {boolean} [opts.sendReplies]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {string} [opts.ua]
+ * @returns {Promise<{ok:boolean, id:string|null, name:string|null, url:string|null, error:string|null}>}
+ */
+export async function submitPost({
+  token,
+  subreddit,
+  kind = 'self',
+  title,
+  url,
+  text,
+  flairId,
+  flairText,
+  sendReplies = false,
+  fetchImpl = globalThis.fetch,
+  ua,
+} = {}) {
+  const fail = (error) => ({ ok: false, id: null, name: null, url: null, error });
+
+  if (typeof fetchImpl !== 'function') return fail('no fetch impl available');
+  if (!token) return fail('missing access token');
+  if (!subreddit) return fail('missing subreddit');
+  if (!title) return fail('missing title');
+  if (kind === 'link' && !url) return fail('kind=link requires url');
+  if (kind === 'self' && !text) return fail('kind=self requires text');
+
+  const userAgentHeader = ua || userAgent();
+
+  const body = new URLSearchParams({
+    api_type: 'json',
+    sr: subreddit,
+    kind,
+    title,
+    sendreplies: sendReplies ? 'true' : 'false',
+  });
+  if (kind === 'link' && url) body.append('url', url);
+  if (kind === 'self' && text) body.append('text', text);
+  if (flairId) body.append('flair_id', flairId);
+  if (flairText) body.append('flair_text', flairText);
+
+  try {
+    const res = await fetchImpl(SUBMIT_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': userAgentHeader,
+      },
+      body,
+    });
+    const data = await res.json().catch(() => null);
+
+    // Reddit nests per-request errors under json.errors even on HTTP 200.
+    const errors = data?.json?.errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+      // errors are arrays like ["SUBREDDIT_NOTALLOWED", "you ...", "sr"].
+      const msg = errors.map((e) => (Array.isArray(e) ? e.slice(0, 2).join(': ') : String(e))).join('; ');
+      return fail(`reddit errors: ${msg}`);
+    }
+    if (!res.ok) {
+      return fail(`HTTP ${res.status}: ${JSON.stringify(data).slice(0, 200)}`);
+    }
+
+    const result = data?.json?.data || {};
+    return {
+      ok: true,
+      id: result.id || null,
+      name: result.name || null,
+      url: result.url || null,
+      error: null,
+    };
+  } catch (err) {
+    return fail(err.message);
+  }
+}

--- a/scripts/lib/reddit-templates.mjs
+++ b/scripts/lib/reddit-templates.mjs
@@ -1,0 +1,168 @@
+/**
+ * Build Italian Reddit post content for jobs and blog articles.
+ *
+ * Reddit has NO hashtag culture: discovery happens via subreddit + flair, not
+ * inline tags. So posts are natural Italian prose; flair is applied by the
+ * caller (the scheduler reads flair from data/reddit-subreddits.json). Job
+ * posts are SELF posts — they keep the user on Reddit and carry the apply link
+ * in the body, which is gentler on anti-spam than a bare link post.
+ *
+ * Generic text sanitizers (stripHtml, stripLeadingSectionLabel, truncateBody)
+ * and URL building live in ./social-post-utils.mjs and are REUSED here — they
+ * are never re-implemented (project rule: a helper duplicated in ≥2 files must
+ * live in one shared module). Salary number formatting matches the FB
+ * scheduler (Swiss apostrophe thousands separator).
+ */
+
+import {
+  stripHtml,
+  stripLeadingSectionLabel,
+  truncateBody,
+  buildJobUrl,
+} from './social-post-utils.mjs';
+import { REDDIT_TITLE_MAX } from './reddit-client.mjs';
+
+// employmentType → Italian user-facing label. Mirrors the FB scheduler.
+const EMPLOYMENT_TYPE_LABEL = {
+  FULL_TIME: 'Tempo pieno',
+  PART_TIME: 'Part-time',
+  CONTRACTOR: 'Contratto',
+  TEMPORARY: 'Temporaneo',
+};
+
+// ── Number / salary formatting (consistent with schedule-fb-jobs-daily) ──
+
+function formatNum(n) {
+  const num = Number(n);
+  if (!Number.isFinite(num)) return String(n);
+  // Thousand separator with apostrophe (Swiss style).
+  return Math.round(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, "'");
+}
+
+function formatSalary(job) {
+  const min = job?.baseSalary?.value?.minValue ?? job?.salaryMin;
+  const max = job?.baseSalary?.value?.maxValue ?? job?.salaryMax;
+  const currency = job?.baseSalary?.currency || 'CHF';
+  if (!min && !max) return '';
+  if (min && max && min !== max) {
+    return `${currency} ${formatNum(min)}–${formatNum(max)}`;
+  }
+  const v = min || max;
+  return `${currency} ${formatNum(v)}`;
+}
+
+// ── Title helper ─────────────────────────────────────────────
+
+/** Truncate a title to ≤ REDDIT_TITLE_MAX, ellipsizing cleanly. */
+function clampTitle(s) {
+  const t = (s || '').trim();
+  if (t.length <= REDDIT_TITLE_MAX) return t;
+  return truncateBody(t, REDDIT_TITLE_MAX);
+}
+
+// ── Job builders ─────────────────────────────────────────────
+
+/**
+ * Build a Reddit job submission title in Italian, e.g.
+ *   💼 Sviluppatore Frontend · Acme SA — Lugano (CHF 90'000–110'000)
+ * Absent chunks are omitted. Always ≤ REDDIT_TITLE_MAX.
+ *
+ * @param {object} job
+ * @returns {string}
+ */
+export function buildJobTitle(job) {
+  const title = (job?.titleByLocale?.it || job?.title || '').trim();
+  const company = (job?.hiringOrganization?.name || job?.company || '').trim();
+  const city = (job?.jobLocation?.address?.addressLocality || job?.location || '').trim();
+  const salary = formatSalary(job);
+
+  let out = `💼 ${title}`;
+  if (company) out += ` · ${company}`;
+  if (city) out += ` — ${city}`;
+  if (salary) out += ` (${salary})`;
+
+  return clampTitle(out);
+}
+
+/**
+ * Build the markdown self-post body in Italian: a cleaned 1-2 sentence
+ * excerpt, a bullet meta line, the apply link, and an automated-listing
+ * disclosure.
+ *
+ * @param {object} job
+ * @returns {string}
+ */
+export function buildJobBody(job) {
+  const rawBody = job?.descriptionByLocale?.it || job?.description || '';
+  const excerpt = truncateBody(stripLeadingSectionLabel(stripHtml(rawBody)), 300);
+
+  // Meta bullet line — only present chunks.
+  const city = (job?.jobLocation?.address?.addressLocality || job?.location || '').trim();
+  const salary = formatSalary(job);
+  const empLabel = EMPLOYMENT_TYPE_LABEL[job?.employmentType];
+  const metaChunks = [];
+  if (city) metaChunks.push(`📍 ${city}`);
+  if (salary) metaChunks.push(`💰 ${salary}`);
+  if (empLabel) metaChunks.push(`📋 ${empLabel}`);
+
+  const url = buildJobUrl(job);
+
+  const parts = [];
+  if (excerpt) parts.push(excerpt);
+  if (metaChunks.length) parts.push(`- ${metaChunks.join(' · ')}`);
+  if (url) parts.push(`**[Vedi l'offerta e candidati →](${url})**`);
+  parts.push('---');
+  parts.push('_Annuncio pubblicato automaticamente da Frontaliere Ticino._');
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Build a complete Reddit job post descriptor.
+ * Self-post keeps the user on Reddit and carries the apply link in the body.
+ *
+ * @param {object} job
+ * @returns {{title:string, kind:'self', text:string, topic:'jobs'}}
+ */
+export function buildJobPost(job) {
+  return {
+    title: buildJobTitle(job),
+    kind: 'self',
+    text: buildJobBody(job),
+    topic: 'jobs',
+  };
+}
+
+// ── Article builders ─────────────────────────────────────────
+
+/**
+ * Build a Reddit article submission title from the article's og:title.
+ * No emoji prefix needed; just trim cleanly to ≤ REDDIT_TITLE_MAX.
+ *
+ * @param {string} ogTitle
+ * @returns {string}
+ */
+export function buildArticleTitle(ogTitle) {
+  return clampTitle(ogTitle);
+}
+
+/**
+ * Build a complete Reddit article post descriptor. Articles are link posts:
+ * Reddit renders the og:* preview from the article URL.
+ *
+ * @param {object} opts
+ * @param {string} [opts.id]
+ * @param {string} opts.url
+ * @param {string} opts.ogTitle
+ * @param {string} [opts.ogDescription]
+ * @param {string} [opts.category]
+ * @returns {{title:string, kind:'link', url:string, topic:'articles'}}
+ */
+export function buildArticlePost({ id, url, ogTitle, ogDescription, category } = {}) {
+  return {
+    title: buildArticleTitle(ogTitle),
+    kind: 'link',
+    url,
+    topic: 'articles',
+  };
+}

--- a/scripts/lib/resolve-reddit-posted-jobs-conflict.mjs
+++ b/scripts/lib/resolve-reddit-posted-jobs-conflict.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * In-place rebase resolver for `data/reddit-posted-jobs.json`.
+ *
+ * The reddit-jobs-daily-schedule workflow's "Commit posted-jobs tracking"
+ * step appends the just-posted jobs to the ledger and pushes. If another
+ * commit landed on main between our read-and-post and our push (e.g. an
+ * article workflow, a translate-pending sync, or even a concurrent
+ * reddit-jobs run), the rebase fails with a content conflict on this
+ * file. Without a resolver the workflow exits 1 and the ledger ends up
+ * out-of-sync with what we actually posted to Reddit — leading the next
+ * run to post duplicate jobs for the same IDs.
+ *
+ * Resolution semantics: UNION the `posted` arrays by a STABLE composite
+ * key of `id + subreddit` (so the same job posted to two different subs
+ * BOTH survive), dedup on collision keeping the locally-staged entry
+ * (freshest ts + redditPostId — those are authoritative because they came
+ * from our Reddit API call). The schemaVersion is taken from local; if
+ * missing falls back to upstream's, then 1.
+ *
+ * Same shape as `resolve-fb-posted-jobs-conflict.mjs` — runs INSIDE the
+ * rebase, leaves the file resolved + staged, then
+ * `git rebase --continue` closes the cycle.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TARGET = 'data/reddit-posted-jobs.json';
+const TRIM_LIMIT = 1000;
+
+function readStage(stage) {
+  // During `git rebase` (NOT plain merge):
+  //   stage 2 = "ours"  = upstream (origin/main after the other commit)
+  //   stage 3 = "theirs" = our local commit being replayed
+  const out = execFileSync('git', ['show', `:${stage}:${TARGET}`], { encoding: 'utf-8' });
+  return out;
+}
+
+function parseOrEmpty(label, raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray(parsed.posted)
+    ) {
+      return parsed;
+    }
+    process.stderr.write(
+      `[resolve-reddit-posted] ${label} version is not a valid ledger object; treating as empty\n`,
+    );
+    return { schemaVersion: 1, posted: [] };
+  } catch (err) {
+    process.stderr.write(
+      `[resolve-reddit-posted] ${label} JSON parse failed: ${err.message}\n`,
+    );
+    return { schemaVersion: 1, posted: [] };
+  }
+}
+
+// Stable composite key: a job posted to two subreddits is two distinct
+// ledger rows, so both must survive the union.
+function entryKey(entry) {
+  return `${entry.id} ${entry.subreddit ?? ''}`;
+}
+
+const conflicted = execFileSync('git', ['diff', '--name-only', '--diff-filter=U'], {
+  encoding: 'utf-8',
+})
+  .split('\n')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+if (!conflicted.includes(TARGET)) {
+  process.stdout.write(`[resolve-reddit-posted] no conflict on ${TARGET}\n`);
+  process.exit(0);
+}
+
+if (conflicted.length > 1) {
+  process.stderr.write(
+    `[resolve-reddit-posted] unexpected conflicted files: ${conflicted.filter((f) => f !== TARGET).join(', ')}\n`,
+  );
+  process.exit(1);
+}
+
+const upstream = parseOrEmpty('upstream', readStage(2));
+const local = parseOrEmpty('local', readStage(3));
+
+// Union by composite (id + subreddit). Local wins on collision (it carries
+// the fresh redditPostId + ts that we just got from the Reddit API).
+const seen = new Set();
+const merged = [];
+let localOverlay = 0;
+
+// Walk upstream first so its entries occupy the index, then overlay
+// local (newer entries replace, novel local entries appended).
+for (const entry of upstream.posted) {
+  if (!entry || !entry.id) continue;
+  const key = entryKey(entry);
+  if (seen.has(key)) continue;
+  seen.add(key);
+  merged.push(entry);
+}
+for (const entry of local.posted) {
+  if (!entry || !entry.id) continue;
+  const key = entryKey(entry);
+  if (seen.has(key)) {
+    // Replace: find the existing index and overwrite with local's authoritative copy.
+    const idx = merged.findIndex((e) => entryKey(e) === key);
+    if (idx >= 0) merged[idx] = entry;
+    localOverlay += 1;
+  } else {
+    seen.add(key);
+    merged.push(entry);
+  }
+}
+
+// Mirror the trim-on-write behaviour of appendLedger in
+// scripts/schedule-reddit-jobs-daily.mjs (POSTED_TRIM_LIMIT = 1000).
+const trimmed = merged.slice(-TRIM_LIMIT);
+
+const out = {
+  schemaVersion: local.schemaVersion ?? upstream.schemaVersion ?? 1,
+  posted: trimmed,
+};
+
+const outPath = path.resolve(process.cwd(), TARGET);
+fs.writeFileSync(outPath, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+
+process.stdout.write(
+  `[resolve-reddit-posted] merged ${upstream.posted.length} upstream + ${local.posted.length} local → ${trimmed.length} entries (${localOverlay} local-overlays win)\n`,
+);
+
+execFileSync('git', ['add', TARGET]);

--- a/scripts/lib/social-post-utils.mjs
+++ b/scripts/lib/social-post-utils.mjs
@@ -1,0 +1,211 @@
+/**
+ * Channel-agnostic helpers shared by the social job schedulers.
+ *
+ * These utilities are deliberately free of any Facebook / Reddit / channel
+ * specifics: they sanitize job text, pick the most-recent never-posted jobs,
+ * build the canonical IT job-board URL, and read/write a JSON "posted" ledger
+ * parameterized by file path so any social channel can keep its own dedup
+ * state. They are imported by both `schedule-fb-jobs-daily.mjs` and
+ * `schedule-reddit-jobs-daily.mjs` so the same logic is never duplicated
+ * across schedulers (project rule: a regex/constant/helper duplicated
+ * literally in ≥2 files MUST live in ONE shared module).
+ *
+ * Channel-specific formatting (FB captions/hashtags, Reddit titles/markdown,
+ * place-id lookup, API run loops) stays in the per-channel scripts.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+// ── Constants ───────────────────────────────────────────────
+
+export const SITE_URL = 'https://frontaliereticino.ch';
+export const JOB_BOARD_PREFIX_IT = '/cerca-lavoro-ticino/';
+
+// ── Sanitization helpers ────────────────────────────────────
+
+export function stripHtml(s) {
+  if (!s || typeof s !== 'string') return '';
+  return s
+    .replace(/<[^>]+>/g, ' ')                  // HTML tags
+    // Markdown headings — match at line start (multiline) AND inline
+    // (after whitespace) so leftovers from HTML→text flattening like
+    // "Avviare... ## Tasks - Si installa..." are also cleaned.
+    .replace(/(^|\s)#{1,6}\s+/gm, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')         // markdown bold
+    .replace(/\*([^*]+)\*/g, '$1')             // markdown italic
+    .replace(/(^|\s)[-*+]\s+/gm, '$1')         // markdown list bullets
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Section labels that often leak into the body when a job description
+// uses HTML headings/lists. Stripped only when they appear at the very start
+// of the body, optionally followed by `:` or `-`.
+const LEADING_SECTION_LABELS = [
+  'descrizione',
+  'description',
+  'descrição',
+  'beschreibung',
+  'beschrijving',
+  'mansioni',
+  'compiti',
+  'profilo',
+  'profile',
+  'profil',
+  'requisiti',
+  'requirements',
+  'about us',
+  'chi siamo',
+  'who we are',
+  'job description',
+  'about the job',
+  'company description',
+  "l'offerta",
+  'l offerta',
+  'la posizione',
+  'le tue mansioni',
+  'i tuoi compiti',
+  'le tue responsabilità',
+];
+
+export function stripLeadingSectionLabel(s) {
+  if (!s) return '';
+  const sorted = [...LEADING_SECTION_LABELS].sort((a, b) => b.length - a.length);
+  const escaped = sorted.map(l => l.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const re = new RegExp(`^(?:${escaped.join('|')})\\s*[:\\-–—]?\\s+`, 'i');
+  return s.replace(re, '').trim();
+}
+
+export function stripDiacritics(s) {
+  if (!s) return '';
+  // Strip U+0300–U+036F (Combining Diacritical Marks) after NFD decomposition.
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '');
+}
+
+export function truncateBody(text, maxLen) {
+  if (!text) return '';
+  if (text.length <= maxLen) return text;
+  // Try to truncate at last sentence break before maxLen.
+  const window = text.slice(0, maxLen);
+  const lastSentence = Math.max(
+    window.lastIndexOf('.'),
+    window.lastIndexOf('!'),
+    window.lastIndexOf('?'),
+  );
+  if (lastSentence >= Math.floor(maxLen * 0.5)) {
+    return window.slice(0, lastSentence + 1).trim();
+  }
+  // Fall back to last space.
+  const lastSpace = window.lastIndexOf(' ');
+  if (lastSpace >= Math.floor(maxLen * 0.5)) {
+    return window.slice(0, lastSpace).trim() + '…';
+  }
+  // Reserve one char for the ellipsis so the result never exceeds maxLen.
+  // Matters for hard-limited fields (e.g. Reddit's 300-char title cap):
+  // appending '…' to a full maxLen window would yield maxLen+1 and be
+  // rejected at submit time.
+  return window.slice(0, maxLen - 1).trim() + '…';
+}
+
+// ── Job selection ───────────────────────────────────────────
+
+export function recencyTs(job) {
+  const candidates = [job?.firstSeenAt, job?.crawledAt, job?.postedDate];
+  for (const c of candidates) {
+    if (!c) continue;
+    const t = Date.parse(c);
+    if (Number.isFinite(t)) return t;
+  }
+  return 0;
+}
+
+/**
+ * Filter never-posted jobs from `jobs`, sort by recency descending, take
+ * top `limit`. Mirrors the selection rule of submit-google-indexing-jobs.
+ *
+ * @param {Array<object>} jobs
+ * @param {Set<string>} postedSet — set of jobIds already posted
+ * @param {number} limit
+ */
+export function selectUnpostedJobs(jobs, postedSet, limit) {
+  if (!Array.isArray(jobs)) return [];
+  const list = jobs.filter((j) => {
+    if (!j || !j.id) return false;
+    if (postedSet.has(j.id)) return false;
+    // Skip jobs flagged by the translate-pending workflow as still
+    // needing translation. Without this, the scheduler picks up
+    // German/French source titles and emits e.g. "Verkäufer*in" or
+    // "Transportdisponent*in" as the post headline — wrong language
+    // for an Italian audience. CLAUDE.md documents this same flag for
+    // locale-completeness checks.
+    if (j.needsRetranslation === true) return false;
+    return true;
+  });
+  list.sort((a, b) => recencyTs(b) - recencyTs(a));
+  return list.slice(0, Math.max(0, limit | 0));
+}
+
+// ── URL building ────────────────────────────────────────────
+
+/**
+ * Build the canonical IT-locale job-board URL for a job. The site's
+ * Italian-language job pages live under `JOB_BOARD_PREFIX_IT`. Slug source
+ * order: slugByLocale.it → slug. Returns null when the job has no slug.
+ */
+export function buildJobUrl(job) {
+  const slug = job?.slugByLocale?.it || job?.slug;
+  if (!slug) return null;
+  return `${SITE_URL}${JOB_BOARD_PREFIX_IT}${slug}/`;
+}
+
+// ── Posted-jobs ledger I/O ──────────────────────────────────
+
+/**
+ * Read a posted-jobs ledger from `filePath`. Returns
+ * `{schemaVersion:1, posted:[]}` on missing file, malformed JSON, or shape
+ * mismatch — never throws. Channel-agnostic: each scheduler passes its own
+ * ledger path.
+ *
+ * @param {string} filePath
+ */
+export function loadLedger(filePath) {
+  try {
+    if (!existsSync(filePath)) return { schemaVersion: 1, posted: [] };
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.posted)) {
+      return { schemaVersion: 1, posted: [] };
+    }
+    return {
+      schemaVersion: Number(parsed.schemaVersion) || 1,
+      posted: parsed.posted,
+    };
+  } catch {
+    return { schemaVersion: 1, posted: [] };
+  }
+}
+
+/**
+ * Append entries to the ledger at `filePath` and write it back. Trims to the
+ * last `trimLimit` entries. No-op (and never throws) when `entries` is empty
+ * or not an array. Channel-agnostic: each scheduler passes its own ledger
+ * path and trim cap.
+ *
+ * @param {string} filePath
+ * @param {Array<object>} entries
+ * @param {number} [trimLimit=1000]
+ */
+export function appendLedger(filePath, entries, trimLimit = 1000) {
+  if (!Array.isArray(entries) || entries.length === 0) return;
+  const current = loadLedger(filePath);
+  const merged = current.posted.concat(entries);
+  const trimmed = merged.slice(Math.max(0, merged.length - trimLimit));
+  const out = { schemaVersion: 1, posted: trimmed };
+  writeFileSync(filePath, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+}

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -94,6 +94,14 @@ const RC_TO_ENV = {
   LINKEDIN_SIGNIN_ACCESS_TOKEN:   ['LINKEDIN_SIGNIN_ACCESS_TOKEN'],
   LINKEDIN_SIGNIN_REFRESH_TOKEN:  ['LINKEDIN_SIGNIN_REFRESH_TOKEN'],
 
+  // Reddit auto-posting (jobs + articles to communities)
+  REDDIT_CLIENT_ID:               ['REDDIT_CLIENT_ID'],
+  REDDIT_USERNAME:                ['REDDIT_USERNAME'],
+  REDDIT_USER_AGENT:              ['REDDIT_USER_AGENT'],
+  SERVER_REDDIT_CLIENT_SECRET:    ['REDDIT_CLIENT_SECRET'],
+  SERVER_REDDIT_PASSWORD:         ['REDDIT_PASSWORD'],
+  SERVER_REDDIT_REFRESH_TOKEN:    ['REDDIT_REFRESH_TOKEN'],
+
   // Linear API (issue creation on CI failure)
 
   // LLM providers (AI model chain for articles + crawlers)

--- a/scripts/post-to-reddit.mjs
+++ b/scripts/post-to-reddit.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Post a new blog article to Reddit.
+ *
+ * Mirrors scripts/post-to-facebook.mjs but for Reddit. Reddit has no
+ * server-side scheduled-publish, so the article is submitted IMMEDIATELY
+ * to every automation-enabled subreddit routed for the "articles" topic,
+ * with a small delay between subs to respect Reddit rate limits.
+ *
+ * Usage:
+ *   node scripts/post-to-reddit.mjs <article-id> <article-url> <og-title> <og-description> [category] [--dry-run]
+ *
+ * Environment variables (consumed by scripts/lib/reddit-client.mjs):
+ *   REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_USERNAME,
+ *   REDDIT_PASSWORD, REDDIT_USER_AGENT — OAuth "script" app credentials.
+ *
+ * Exit code is always 0 (soft failure) — this script should never block CI.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getAccessToken, submitPost, userAgent } from './lib/reddit-client.mjs';
+import { buildArticlePost } from './lib/reddit-templates.mjs';
+
+// Delay between subreddit submissions (ms). Conservative to respect
+// Reddit anti-spam / rate limits.
+const INTER_SUB_DELAY_MS = 3000;
+
+function defaultRepoRoot() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  return resolve(__dirname, '..');
+}
+
+function subredditsPath(repoRoot) {
+  return resolve(repoRoot, 'data', 'reddit-subreddits.json');
+}
+
+/**
+ * Read `data/reddit-subreddits.json`. Returns a config object with empty
+ * `subreddits`/`routing` on missing file or malformed JSON — never throws.
+ */
+function loadSubreddits(repoRoot) {
+  const file = subredditsPath(repoRoot);
+  try {
+    if (!existsSync(file)) return { schemaVersion: 1, subreddits: {}, routing: {} };
+    const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object') {
+      return { schemaVersion: 1, subreddits: {}, routing: {} };
+    }
+    return {
+      schemaVersion: Number(parsed.schemaVersion) || 1,
+      subreddits: parsed.subreddits && typeof parsed.subreddits === 'object' ? parsed.subreddits : {},
+      routing: parsed.routing && typeof parsed.routing === 'object' ? parsed.routing : {},
+    };
+  } catch {
+    return { schemaVersion: 1, subreddits: {}, routing: {} };
+  }
+}
+
+/**
+ * Resolve the automation-enabled subreddit names routed for a topic.
+ * Pure: takes a config object + topic, returns an array of names whose
+ * `subreddits[name].allowsAutomation === true`.
+ */
+function automationSubsForTopic(config, topic) {
+  const routed = Array.isArray(config?.routing?.[topic]) ? config.routing[topic] : [];
+  return routed.filter((name) => config?.subreddits?.[name]?.allowsAutomation === true);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const positional = args.filter((a) => !a.startsWith('--'));
+
+  const [articleId, articleUrl, ogTitle, ogDescription, category] = positional;
+
+  if (!articleId || !articleUrl || !ogTitle) {
+    console.error('Usage: post-to-reddit.mjs <id> <url> <og-title> <og-description> [category] [--dry-run]');
+    process.exit(0); // soft failure
+  }
+
+  const repoRoot = defaultRepoRoot();
+  const config = loadSubreddits(repoRoot);
+  const targets = automationSubsForTopic(config, 'articles');
+
+  if (targets.length === 0) {
+    console.log('ℹ️  no automation-enabled article subreddits — skipping');
+    process.exit(0);
+  }
+
+  // Build the post payload.
+  const post = buildArticlePost({
+    id: articleId,
+    url: articleUrl,
+    ogTitle,
+    ogDescription,
+    category,
+  });
+
+  console.log('─── Reddit Article Post ───');
+  console.log(`Article: ${articleId}`);
+  console.log(`URL:     ${post.url || articleUrl}`);
+  console.log(`Title:   ${post.title}`);
+  console.log(`Targets: ${targets.join(', ')}`);
+  console.log('───────────────────────────');
+
+  if (dryRun) {
+    for (const name of targets) {
+      const sub = config.subreddits[name] || {};
+      console.log(`🏃 [dry] would submit link to r/${name}`
+        + (sub.flairText ? ` [flair=${sub.flairText}]` : ''));
+    }
+    console.log('🏃 Dry run — not posting to Reddit');
+    process.exit(0);
+  }
+
+  const ua = userAgent(process.env);
+  const token = await getAccessToken(process.env);
+  if (!token) {
+    console.log('⚠️  Reddit access token unavailable (missing credentials?) — skipping Reddit post');
+    process.exit(0);
+  }
+
+  for (let i = 0; i < targets.length; i++) {
+    const name = targets[i];
+    const sub = config.subreddits[name] || {};
+    try {
+      const res = await submitPost({
+        token,
+        subreddit: name,
+        kind: 'link',
+        title: post.title,
+        url: post.url || articleUrl,
+        flairId: sub.flairId,
+        flairText: sub.flairText,
+        ua,
+      });
+      if (res?.ok) {
+        console.log(`✅ Posted to r/${name}! ${res.url || res.name || res.id || ''}`.trim());
+      } else {
+        console.error(`⚠️  Reddit submit error for r/${name}: ${res?.error || 'unknown error'}`);
+      }
+    } catch (err) {
+      console.error(`⚠️  Failed to post to r/${name}: ${err.message}`);
+    }
+    // Self-pace between subs (skip after the last one).
+    if (i < targets.length - 1) await sleep(INTER_SUB_DELAY_MS);
+  }
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('⚠️ post-to-reddit crashed:', err?.message || err);
+  process.exit(0); // soft-fail
+});

--- a/scripts/schedule-fb-jobs-daily.mjs
+++ b/scripts/schedule-fb-jobs-daily.mjs
@@ -30,14 +30,30 @@
  * git untouched.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  stripHtml,
+  stripLeadingSectionLabel,
+  stripDiacritics,
+  truncateBody,
+  selectUnpostedJobs,
+  buildJobUrl,
+  loadLedger,
+  appendLedger,
+} from './lib/social-post-utils.mjs';
+
+// Re-export the channel-agnostic helpers so existing importers (e.g. the FB
+// scheduler test) can keep importing them directly from this module.
+export {
+  selectUnpostedJobs,
+  buildJobUrl,
+} from './lib/social-post-utils.mjs';
+
 // ── Constants ───────────────────────────────────────────────
 
-const SITE_URL = 'https://frontaliereticino.ch';
-const JOB_BOARD_PREFIX_IT = '/cerca-lavoro-ticino/';
 const GRAPH_API_VERSION = 'v21.0';
 const GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
@@ -118,71 +134,8 @@ function placeIdsPath(repoRoot) {
 }
 
 // ── Sanitization helpers ────────────────────────────────────
-
-function stripHtml(s) {
-  if (!s || typeof s !== 'string') return '';
-  return s
-    .replace(/<[^>]+>/g, ' ')                  // HTML tags
-    // Markdown headings — match at line start (multiline) AND inline
-    // (after whitespace) so leftovers from HTML→text flattening like
-    // "Avviare... ## Tasks - Si installa..." are also cleaned.
-    .replace(/(^|\s)#{1,6}\s+/gm, '$1')
-    .replace(/\*\*([^*]+)\*\*/g, '$1')         // markdown bold
-    .replace(/\*([^*]+)\*/g, '$1')             // markdown italic
-    .replace(/(^|\s)[-*+]\s+/gm, '$1')         // markdown list bullets
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-// Section labels that often leak into the body when a job description
-// uses HTML headings/lists. Stripped only when they appear at the very start
-// of the body, optionally followed by `:` or `-`.
-const LEADING_SECTION_LABELS = [
-  'descrizione',
-  'description',
-  'descrição',
-  'beschreibung',
-  'beschrijving',
-  'mansioni',
-  'compiti',
-  'profilo',
-  'profile',
-  'profil',
-  'requisiti',
-  'requirements',
-  'about us',
-  'chi siamo',
-  'who we are',
-  'job description',
-  'about the job',
-  'company description',
-  "l'offerta",
-  'l offerta',
-  'la posizione',
-  'le tue mansioni',
-  'i tuoi compiti',
-  'le tue responsabilità',
-];
-
-function stripLeadingSectionLabel(s) {
-  if (!s) return '';
-  const sorted = [...LEADING_SECTION_LABELS].sort((a, b) => b.length - a.length);
-  const escaped = sorted.map(l => l.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const re = new RegExp(`^(?:${escaped.join('|')})\\s*[:\\-–—]?\\s+`, 'i');
-  return s.replace(re, '').trim();
-}
-
-function stripDiacritics(s) {
-  if (!s) return '';
-  // Strip U+0300–U+036F (Combining Diacritical Marks) after NFD decomposition.
-  return s.normalize('NFD').replace(/[̀-ͯ]/g, '');
-}
+// Generic sanitizers (stripHtml, stripLeadingSectionLabel, stripDiacritics)
+// live in ./lib/social-post-utils.mjs. FB-specific helpers stay below.
 
 function sanitizeHashtagWord(s) {
   if (!s) return '';
@@ -230,42 +183,6 @@ export function pickNextSlots(volume, occupied, now) {
     }
   }
   return slots;
-}
-
-/**
- * Filter never-posted jobs from `jobs`, sort by recency descending, take
- * top `limit`. Mirrors the selection rule of submit-google-indexing-jobs.
- *
- * @param {Array<object>} jobs
- * @param {Set<string>} postedSet — set of jobIds already posted
- * @param {number} limit
- */
-export function selectUnpostedJobs(jobs, postedSet, limit) {
-  if (!Array.isArray(jobs)) return [];
-  const list = jobs.filter((j) => {
-    if (!j || !j.id) return false;
-    if (postedSet.has(j.id)) return false;
-    // Skip jobs flagged by the translate-pending workflow as still
-    // needing translation. Without this, the FB scheduler picks up
-    // German/French source titles and emits e.g. "Verkäufer*in" or
-    // "Transportdisponent*in" as the post headline — wrong language
-    // for an Italian audience. CLAUDE.md documents this same flag for
-    // locale-completeness checks.
-    if (j.needsRetranslation === true) return false;
-    return true;
-  });
-  list.sort((a, b) => recencyTs(b) - recencyTs(a));
-  return list.slice(0, Math.max(0, limit | 0));
-}
-
-function recencyTs(job) {
-  const candidates = [job?.firstSeenAt, job?.crawledAt, job?.postedDate];
-  for (const c of candidates) {
-    if (!c) continue;
-    const t = Date.parse(c);
-    if (Number.isFinite(t)) return t;
-  }
-  return 0;
 }
 
 /**
@@ -343,27 +260,6 @@ function formatNum(n) {
   return Math.round(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, "'");
 }
 
-function truncateBody(text, maxLen) {
-  if (!text) return '';
-  if (text.length <= maxLen) return text;
-  // Try to truncate at last sentence break before maxLen.
-  const window = text.slice(0, maxLen);
-  const lastSentence = Math.max(
-    window.lastIndexOf('.'),
-    window.lastIndexOf('!'),
-    window.lastIndexOf('?'),
-  );
-  if (lastSentence >= Math.floor(maxLen * 0.5)) {
-    return window.slice(0, lastSentence + 1).trim();
-  }
-  // Fall back to last space.
-  const lastSpace = window.lastIndexOf(' ');
-  if (lastSpace >= Math.floor(maxLen * 0.5)) {
-    return window.slice(0, lastSpace).trim() + '…';
-  }
-  return window.trim() + '…';
-}
-
 /**
  * Up to 5 hashtags. Always ends with #frontalieri #lavoroticino. Adds
  * #[Role] (if a role keyword matches the title), #[City] (first word of
@@ -424,38 +320,15 @@ export function buildJobHashtags(job) {
   return deduped.join(' ');
 }
 
-/**
- * Build the URL pointed at by the FB post. IT locale only, since the FB
- * Page is Italian-language. Slug source order: slugByLocale.it → slug.
- */
-export function buildJobUrl(job) {
-  const slug = job?.slugByLocale?.it || job?.slug;
-  if (!slug) return null;
-  return `${SITE_URL}${JOB_BOARD_PREFIX_IT}${slug}/`;
-}
-
 // ── Posted-jobs ledger I/O ──────────────────────────────────
 
 /**
  * Read `data/fb-posted-jobs.json`. Returns `{schemaVersion:1, posted:[]}`
  * on missing file, malformed JSON, or shape mismatch — never throws.
+ * Fixed-path wrapper around the generic `loadLedger`.
  */
 export function loadPosted(repoRoot) {
-  const file = postedPath(repoRoot);
-  try {
-    if (!existsSync(file)) return { schemaVersion: 1, posted: [] };
-    const raw = readFileSync(file, 'utf-8');
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.posted)) {
-      return { schemaVersion: 1, posted: [] };
-    }
-    return {
-      schemaVersion: Number(parsed.schemaVersion) || 1,
-      posted: parsed.posted,
-    };
-  } catch {
-    return { schemaVersion: 1, posted: [] };
-  }
+  return loadLedger(postedPath(repoRoot));
 }
 
 /**
@@ -567,15 +440,10 @@ export function lookupPlaceId(location, placeIds) {
 /**
  * Append entries to the ledger and write it back. Trims to last
  * POSTED_TRIM_LIMIT entries. Each entry: {id, url, ts, fbPostId}.
+ * Fixed-path wrapper around the generic `appendLedger`.
  */
 export function appendPosted(repoRoot, entries) {
-  if (!Array.isArray(entries) || entries.length === 0) return;
-  const file = postedPath(repoRoot);
-  const current = loadPosted(repoRoot);
-  const merged = current.posted.concat(entries);
-  const trimmed = merged.slice(Math.max(0, merged.length - POSTED_TRIM_LIMIT));
-  const out = { schemaVersion: 1, posted: trimmed };
-  writeFileSync(file, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  appendLedger(postedPath(repoRoot), entries, POSTED_TRIM_LIMIT);
 }
 
 // ── Pre-flight: occupied scheduled-posts ────────────────────

--- a/scripts/schedule-reddit-jobs-daily.mjs
+++ b/scripts/schedule-reddit-jobs-daily.mjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+/**
+ * Daily Reddit poster for Ticino job listings.
+ *
+ * Mirrors the STRUCTURE of scripts/schedule-fb-jobs-daily.mjs, but Reddit
+ * has NO server-side scheduled-publish: posts go out IMMEDIATELY, a small
+ * conservative batch per run, self-paced with a delay between posts to
+ * respect Reddit rate limits & anti-spam. Default volume is LOW.
+ *
+ * Each job is posted ONCE (to the first eligible, not-rate-limited
+ * subreddit). Posted jobs are tracked in `data/reddit-posted-jobs.json`
+ * to dedup across runs.
+ *
+ * Usage:
+ *   node scripts/schedule-reddit-jobs-daily.mjs
+ *
+ * Env:
+ *   REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_USERNAME,
+ *     REDDIT_PASSWORD, REDDIT_USER_AGENT — OAuth credentials (consumed by
+ *     scripts/lib/reddit-client.mjs; required for non-dry-run mode).
+ *   REDDIT_JOB_VOLUME=N      — posts PER RUN, default 2 (conservative).
+ *   REDDIT_POST_DELAY_MS=N   — delay between posts, default 5000 (0 in tests).
+ *   DRY_RUN=1                — log payloads, no API call.
+ *
+ * Soft-fail: every error path logs and `process.exit(0)`. The workflow's
+ * commit step is gated on the data file mutating, so a no-op run leaves
+ * git untouched.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  selectUnpostedJobs,
+  buildJobUrl,
+  loadLedger,
+  appendLedger,
+} from './lib/social-post-utils.mjs';
+
+import { getAccessToken, submitPost, userAgent } from './lib/reddit-client.mjs';
+import { buildJobPost } from './lib/reddit-templates.mjs';
+
+// Re-export the channel-agnostic helpers so tests can import them from
+// this module directly (mirrors the FB scheduler).
+export {
+  selectUnpostedJobs,
+  buildJobUrl,
+} from './lib/social-post-utils.mjs';
+
+// ── Constants ───────────────────────────────────────────────
+
+// Conservative default: posts PER RUN (not 144 like FB). Low volume keeps
+// us well under Reddit's anti-spam thresholds.
+const DEFAULT_VOLUME = 2;
+
+// Default delay between posts within a run (ms).
+const DEFAULT_POST_DELAY_MS = 5000;
+
+// Posted-jobs ledger trim cap.
+const POSTED_TRIM_LIMIT = 1000;
+
+// ── Path helpers ────────────────────────────────────────────
+
+function defaultRepoRoot() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  return resolve(__dirname, '..');
+}
+
+function jobsPath(repoRoot) {
+  // Prefer public/data, fall back to data/ (the agent worktree only has the
+  // latter for tests). Same precedence as the FB scheduler.
+  const pub = resolve(repoRoot, 'public', 'data', 'jobs.json');
+  if (existsSync(pub)) return pub;
+  return resolve(repoRoot, 'data', 'jobs.json');
+}
+
+function postedPath(repoRoot) {
+  return resolve(repoRoot, 'data', 'reddit-posted-jobs.json');
+}
+
+function subredditsPath(repoRoot) {
+  return resolve(repoRoot, 'data', 'reddit-subreddits.json');
+}
+
+// ── jobs.json loader ────────────────────────────────────────
+
+function loadJobs(repoRoot, log) {
+  const file = jobsPath(repoRoot);
+  try {
+    if (!existsSync(file)) {
+      log('⚠️', `jobs.json not found at ${file}`);
+      return [];
+    }
+    const raw = readFileSync(file, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    log('⚠️', `failed to read jobs.json: ${err.message}`);
+    return [];
+  }
+}
+
+// ── Subreddit config loader ─────────────────────────────────
+
+/**
+ * Read `data/reddit-subreddits.json`. Returns a config object with empty
+ * `subreddits`/`routing` on missing file or malformed JSON — never throws.
+ */
+export function loadSubreddits(repoRoot) {
+  const file = subredditsPath(repoRoot);
+  try {
+    if (!existsSync(file)) return { schemaVersion: 1, subreddits: {}, routing: {} };
+    const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object') {
+      return { schemaVersion: 1, subreddits: {}, routing: {} };
+    }
+    return {
+      schemaVersion: Number(parsed.schemaVersion) || 1,
+      subreddits: parsed.subreddits && typeof parsed.subreddits === 'object' ? parsed.subreddits : {},
+      routing: parsed.routing && typeof parsed.routing === 'object' ? parsed.routing : {},
+    };
+  } catch {
+    return { schemaVersion: 1, subreddits: {}, routing: {} };
+  }
+}
+
+// ── Pure utilities (exported for tests) ─────────────────────
+
+/**
+ * Resolve the automation-enabled subreddit names routed for a topic.
+ * Returns an array of `{ name, config }` for subs whose
+ * `subreddits[name].allowsAutomation === true`, preserving routing order.
+ *
+ * @param {object} config — parsed reddit-subreddits.json
+ * @param {string} topic — e.g. 'jobs' | 'articles'
+ * @returns {Array<{ name: string, config: object }>}
+ */
+export function eligibleSubsForTopic(config, topic) {
+  const routed = Array.isArray(config?.routing?.[topic]) ? config.routing[topic] : [];
+  const out = [];
+  for (const name of routed) {
+    const sub = config?.subreddits?.[name];
+    if (sub && sub.allowsAutomation === true) {
+      out.push({ name, config: sub });
+    }
+  }
+  return out;
+}
+
+/**
+ * Determine whether a subreddit is rate-limited right now, given the
+ * ledger's `posted` entries. Looks at the most recent entry for that
+ * subreddit and compares the gap to `now` against `minIntervalHours`.
+ * Pure: no I/O.
+ *
+ * @param {Array<object>} ledgerPosted — ledger `posted` array
+ * @param {string} subreddit
+ * @param {number} minIntervalHours — 0/undefined disables the limit
+ * @param {Date|number} now
+ * @returns {boolean} true when the sub posted too recently
+ */
+export function isRateLimited(ledgerPosted, subreddit, minIntervalHours, now) {
+  const minHours = Number(minIntervalHours);
+  if (!Number.isFinite(minHours) || minHours <= 0) return false;
+  const nowMs = now instanceof Date ? now.getTime() : Number(now);
+  if (!Number.isFinite(nowMs)) return false;
+
+  let lastMs = 0;
+  for (const entry of Array.isArray(ledgerPosted) ? ledgerPosted : []) {
+    if (!entry || entry.subreddit !== subreddit) continue;
+    const t = Date.parse(entry.ts);
+    if (Number.isFinite(t) && t > lastMs) lastMs = t;
+  }
+  if (lastMs === 0) return false; // never posted there → not limited
+  const gapHours = (nowMs - lastMs) / 3_600_000;
+  return gapHours < minHours;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Main entry ──────────────────────────────────────────────
+
+/**
+ * @param {object} opts
+ * @param {Record<string, string|undefined>} [opts.env]
+ * @param {Date} [opts.now]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {string} [opts.repoRoot]
+ * @param {(...a: unknown[]) => void} [opts.log]
+ * @param {(...a: unknown[]) => void} [opts.warn]
+ */
+export async function run(opts = {}) {
+  const env = opts.env || process.env;
+  const now = opts.now || new Date();
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const repoRoot = opts.repoRoot || defaultRepoRoot();
+  const log = opts.log || console.log;
+  const warn = opts.warn || console.warn;
+
+  const dryRun = env.DRY_RUN === '1' || env.DRY_RUN === 'true';
+  const volumeRaw = Number(env.REDDIT_JOB_VOLUME);
+  const volume = Number.isFinite(volumeRaw) && volumeRaw > 0 ? Math.floor(volumeRaw) : DEFAULT_VOLUME;
+  const delayRaw = Number(env.REDDIT_POST_DELAY_MS);
+  const postDelayMs = Number.isFinite(delayRaw) && delayRaw >= 0 ? delayRaw : DEFAULT_POST_DELAY_MS;
+
+  log('🗓️', `Reddit jobs daily poster — volume=${volume}, dry=${dryRun}`);
+
+  // 1. Load jobs
+  const jobs = loadJobs(repoRoot, log);
+  if (jobs.length === 0) {
+    log('ℹ️', 'no jobs available, exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+
+  // 2. Ledger → postedSet (a job is "posted" if its id appears for ANY sub).
+  const path = postedPath(repoRoot);
+  const ledger = loadLedger(path);
+  const postedSet = new Set(ledger.posted.map((e) => e?.id).filter(Boolean));
+
+  // 3. Pick top-N never-posted jobs.
+  const candidates = selectUnpostedJobs(jobs, postedSet, volume);
+  if (candidates.length === 0) {
+    log('ℹ️', 'no unposted jobs eligible, exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+  log('ℹ️', `selected ${candidates.length}/${volume} candidate jobs`);
+
+  // 4. Eligible job subreddits (automation-enabled, routed for "jobs").
+  const config = loadSubreddits(repoRoot);
+  const eligible = eligibleSubsForTopic(config, 'jobs');
+  if (eligible.length === 0) {
+    log('ℹ️', 'no automation-enabled job subreddits — exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+
+  // Track per-sub last-post time so we don't hammer the same sub within one
+  // run. Seed from the ledger so cross-run rate-limiting is consistent.
+  // Map<name, ms>
+  const lastPostMs = new Map();
+
+  /** Find the first eligible sub that is not rate-limited right now. */
+  function pickSub() {
+    for (const { name, config: subCfg } of eligible) {
+      const minHours = subCfg?.minPostIntervalHours;
+      // Cross-run limit from the persisted ledger.
+      if (isRateLimited(ledger.posted, name, minHours, now)) continue;
+      // In-run limit from this run's own posts.
+      const inRunLast = lastPostMs.get(name);
+      if (inRunLast != null && Number(minHours) > 0) {
+        const gapHours = (now.getTime() - inRunLast) / 3_600_000;
+        if (gapHours < Number(minHours)) continue;
+      }
+      return { name, config: subCfg };
+    }
+    return null;
+  }
+
+  // Early exit if nothing is postable right now.
+  if (!pickSub()) {
+    log('ℹ️', 'all eligible subreddits rate-limited right now — exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+
+  // 5/6. Build + post (or plan) per candidate.
+  const payloads = [];
+  let posted = 0;
+  let acquiredToken = null;
+
+  for (const job of candidates) {
+    const target = pickSub();
+    if (!target) {
+      log('ℹ️', 'no eligible subreddit available for remaining candidates — stopping');
+      break;
+    }
+    const url = buildJobUrl(job);
+    if (!url) {
+      log('⚠️', `skipping job ${job.id} — no slug`);
+      continue;
+    }
+    const post = buildJobPost(job);
+    const payload = {
+      jobId: job.id,
+      url,
+      subreddit: target.name,
+      title: post.title,
+      kind: post.kind || 'self',
+      text: post.text,
+    };
+    payloads.push(payload);
+
+    if (dryRun) {
+      log('  •', `[dry] ${job.id} → r/${target.name} → "${post.title}"`);
+      // Mark in-run so dry-run planning also respects per-sub spacing.
+      lastPostMs.set(target.name, now.getTime());
+      continue;
+    }
+
+    // Lazily acquire the token on the first real post.
+    if (!acquiredToken) {
+      acquiredToken = await getAccessToken(env, fetchImpl);
+      if (!acquiredToken) {
+        warn('⚠️', 'Reddit access token unavailable (missing credentials?) — skipping');
+        return { ok: false, posted, dryRun, payloads };
+      }
+    }
+
+    const ua = userAgent(env);
+    let res = null;
+    try {
+      res = await submitPost({
+        token: acquiredToken,
+        subreddit: target.name,
+        kind: payload.kind,
+        title: payload.title,
+        url: payload.url,
+        text: payload.text,
+        flairId: target.config?.flairId,
+        flairText: target.config?.flairText,
+        fetchImpl,
+        ua,
+      });
+    } catch (err) {
+      warn('⚠️', `submit failed for ${job.id} → r/${target.name}: ${err.message}`);
+      res = null;
+    }
+
+    if (res?.ok) {
+      posted += 1;
+      // Append to the ledger IMMEDIATELY so a partial failure still records.
+      appendLedger(path, [{
+        id: job.id,
+        url,
+        subreddit: target.name,
+        ts: new Date().toISOString(),
+        redditPostId: res.name || res.id,
+        redditUrl: res.url,
+      }], POSTED_TRIM_LIMIT);
+      lastPostMs.set(target.name, now.getTime());
+      log('✅', `${job.id} → r/${target.name} → ${res.url || res.name || res.id || ''}`.trim());
+    } else {
+      warn('⚠️', `Reddit submit error for ${job.id} → r/${target.name}: ${res?.error || 'unknown error'}`);
+    }
+
+    // Self-pace between posts.
+    if (postDelayMs > 0) await sleep(postDelayMs);
+  }
+
+  if (dryRun) {
+    log('🏃', `DRY_RUN=1 — would post ${payloads.length} jobs`);
+    return { ok: true, posted: 0, dryRun: true, payloads };
+  }
+
+  log('🏁', `posted ${posted}/${payloads.length} jobs`);
+  return { ok: posted > 0, posted, dryRun, payloads };
+}
+
+// ── CLI ─────────────────────────────────────────────────────
+
+const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectInvocation) {
+  run().then(
+    () => process.exit(0),
+    (err) => {
+      console.error('⚠️ reddit poster crashed:', err?.message || err);
+      process.exit(0); // soft-fail
+    },
+  );
+}

--- a/tests/scripts/reddit-templates.test.ts
+++ b/tests/scripts/reddit-templates.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+
+// Pure-ESM module; side-effect-free to import.
+import * as templates from '../../scripts/lib/reddit-templates.mjs';
+
+interface JobLike {
+  id?: string;
+  title?: string;
+  titleByLocale?: Record<string, string>;
+  hiringOrganization?: { name?: string };
+  company?: string;
+  location?: string;
+  jobLocation?: { address?: { addressLocality?: string } };
+  description?: string;
+  descriptionByLocale?: Record<string, string>;
+  baseSalary?: {
+    currency?: string;
+    value?: { minValue?: number; maxValue?: number };
+  };
+  salaryMin?: number;
+  salaryMax?: number;
+  employmentType?: string;
+  slug?: string;
+  slugByLocale?: Record<string, string>;
+}
+
+interface JobPost {
+  title: string;
+  kind: 'self';
+  text: string;
+  topic: 'jobs';
+}
+
+interface ArticlePost {
+  title: string;
+  kind: 'link';
+  url: string;
+  topic: 'articles';
+}
+
+const {
+  buildJobTitle,
+  buildJobBody,
+  buildJobPost,
+  buildArticleTitle,
+  buildArticlePost,
+} = templates as unknown as {
+  buildJobTitle: (job: JobLike) => string;
+  buildJobBody: (job: JobLike) => string;
+  buildJobPost: (job: JobLike) => JobPost;
+  buildArticleTitle: (ogTitle: string) => string;
+  buildArticlePost: (opts: {
+    id?: string;
+    url: string;
+    ogTitle: string;
+    ogDescription?: string;
+    category?: string;
+  }) => ArticlePost;
+};
+
+const REDDIT_TITLE_MAX = 300;
+
+// ── buildJobTitle ─────────────────────────────────────────
+
+describe('buildJobTitle', () => {
+  const fullJob: JobLike = {
+    id: 'job-1',
+    title: 'Sviluppatore Frontend',
+    titleByLocale: { it: 'Sviluppatore Frontend IT', en: 'Frontend Developer' },
+    hiringOrganization: { name: 'Acme SA' },
+    jobLocation: { address: { addressLocality: 'Lugano' } },
+    baseSalary: { currency: 'CHF', value: { minValue: 90000, maxValue: 110000 } },
+  };
+
+  it('includes IT title, company and city', () => {
+    const t = buildJobTitle(fullJob);
+    expect(t).toContain('Sviluppatore Frontend IT');
+    expect(t).toContain('Acme SA');
+    expect(t).toContain('Lugano');
+  });
+
+  it('prefers titleByLocale.it over title', () => {
+    const t = buildJobTitle(fullJob);
+    expect(t).toContain('Sviluppatore Frontend IT');
+    // The plain `title` would have been "Sviluppatore Frontend" (no "IT" suffix).
+    expect(t).not.toMatch(/Sviluppatore Frontend ·/);
+  });
+
+  it('falls back to title when titleByLocale.it is missing', () => {
+    const j: JobLike = { ...fullJob, titleByLocale: undefined };
+    const t = buildJobTitle(j);
+    expect(t).toContain('Sviluppatore Frontend');
+  });
+
+  it('respects the ≤300 char limit and ellipsizes a very long title', () => {
+    const j: JobLike = {
+      id: 'huge',
+      title: 'X'.repeat(500),
+      hiringOrganization: { name: 'Acme SA' },
+      jobLocation: { address: { addressLocality: 'Lugano' } },
+    };
+    const t = buildJobTitle(j);
+    expect(t.length).toBeLessThanOrEqual(REDDIT_TITLE_MAX);
+    // Long title gets truncated, so company/city suffix is cut off.
+    expect(t).not.toContain('Acme SA');
+  });
+});
+
+// ── buildJobBody ──────────────────────────────────────────
+
+describe('buildJobBody', () => {
+  const fullJob: JobLike = {
+    id: 'job-1',
+    title: 'Sviluppatore Frontend',
+    slugByLocale: { it: 'sviluppatore-frontend-lugano' },
+    jobLocation: { address: { addressLocality: 'Lugano' } },
+    baseSalary: { currency: 'CHF', value: { minValue: 90000, maxValue: 110000 } },
+    employmentType: 'FULL_TIME',
+    descriptionByLocale: {
+      it: '<p>Cerchiamo uno <strong>sviluppatore</strong> per progetto a Lugano.</p>',
+    },
+  };
+
+  it('is Italian markdown that contains the apply link with trailing slash', () => {
+    const body = buildJobBody(fullJob);
+    expect(body).toContain(
+      'https://frontaliereticino.ch/cerca-lavoro-ticino/sviluppatore-frontend-lugano/',
+    );
+    // Italian markdown CTA.
+    expect(body).toContain("Vedi l'offerta e candidati");
+  });
+
+  it('strips HTML from the description', () => {
+    const body = buildJobBody(fullJob);
+    expect(body).not.toContain('<p>');
+    expect(body).not.toContain('<strong>');
+    expect(body).toContain('sviluppatore');
+  });
+
+  it('includes the automated-listing disclosure line', () => {
+    const body = buildJobBody(fullJob);
+    expect(body).toContain('Annuncio pubblicato automaticamente da Frontaliere Ticino');
+  });
+});
+
+// ── buildJobPost ──────────────────────────────────────────
+
+describe('buildJobPost', () => {
+  const job: JobLike = {
+    id: 'job-1',
+    title: 'Sviluppatore Frontend',
+    slugByLocale: { it: 'sviluppatore-frontend-lugano' },
+    jobLocation: { address: { addressLocality: 'Lugano' } },
+    descriptionByLocale: { it: 'Cerchiamo uno sviluppatore.' },
+  };
+
+  it('returns a self post for the jobs topic with non-empty title and text', () => {
+    const post = buildJobPost(job);
+    expect(post.kind).toBe('self');
+    expect(post.topic).toBe('jobs');
+    expect(post.title.length).toBeGreaterThan(0);
+    expect(post.text.length).toBeGreaterThan(0);
+    expect(post.title.length).toBeLessThanOrEqual(REDDIT_TITLE_MAX);
+  });
+});
+
+// ── buildArticleTitle / buildArticlePost ──────────────────
+
+describe('buildArticleTitle', () => {
+  it('trims and preserves a short title', () => {
+    expect(buildArticleTitle('  Permesso G: guida 2026  ')).toBe('Permesso G: guida 2026');
+  });
+
+  it('clamps a very long title to the 300-char limit', () => {
+    // A no-break run still respects the hard cap: truncateBody reserves one
+    // char for the appended '…' so the result never exceeds maxLen.
+    expect(buildArticleTitle('A'.repeat(500)).length).toBeLessThanOrEqual(REDDIT_TITLE_MAX);
+  });
+});
+
+describe('buildArticlePost', () => {
+  it('returns a link post for the articles topic with url preserved and title ≤300', () => {
+    const url = 'https://frontaliereticino.ch/blog/permesso-g-2026/';
+    const post = buildArticlePost({
+      id: 'art-1',
+      url,
+      ogTitle: 'Richiesta Permesso G Step by Step 2026',
+      ogDescription: 'Guida completa.',
+      category: 'permessi',
+    });
+    expect(post.kind).toBe('link');
+    expect(post.topic).toBe('articles');
+    expect(post.url).toBe(url);
+    expect(post.title).toBe('Richiesta Permesso G Step by Step 2026');
+    expect(post.title.length).toBeLessThanOrEqual(REDDIT_TITLE_MAX);
+  });
+
+  it('clamps a long og:title in the link post', () => {
+    const post = buildArticlePost({
+      url: 'https://frontaliereticino.ch/blog/x/',
+      ogTitle: 'B'.repeat(400),
+    });
+    expect(post.title.length).toBeLessThanOrEqual(REDDIT_TITLE_MAX);
+  });
+});

--- a/tests/scripts/schedule-reddit-jobs-daily.test.ts
+++ b/tests/scripts/schedule-reddit-jobs-daily.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Pure-ESM script. The CLI block is gated on `import.meta.url ===
+// file://${process.argv[1]}`, so importing is side-effect-free.
+import * as scheduler from '../../scripts/schedule-reddit-jobs-daily.mjs';
+
+interface JobLike {
+  id: string;
+  title?: string;
+  titleByLocale?: Record<string, string>;
+  slug?: string;
+  slugByLocale?: Record<string, string>;
+  jobLocation?: { address?: { addressLocality?: string } };
+  description?: string;
+  descriptionByLocale?: Record<string, string>;
+  employmentType?: string;
+  firstSeenAt?: string;
+  crawledAt?: string;
+}
+
+interface SubConfig {
+  allowsAutomation: boolean;
+  minPostIntervalHours?: number;
+  flairId?: string | null;
+  flairText?: string | null;
+  topics?: string[];
+}
+
+interface RedditConfig {
+  schemaVersion: number;
+  subreddits: Record<string, SubConfig>;
+  routing: Record<string, string[]>;
+}
+
+interface PostedEntry {
+  id: string;
+  url: string;
+  subreddit: string;
+  ts: string;
+  redditPostId?: string;
+}
+
+interface PostedLedger {
+  schemaVersion: number;
+  posted: PostedEntry[];
+}
+
+interface Payload {
+  jobId: string;
+  url: string;
+  subreddit: string;
+  title: string;
+  kind: string;
+  text: string;
+}
+
+const {
+  eligibleSubsForTopic,
+  isRateLimited,
+  loadSubreddits,
+  selectUnpostedJobs,
+  buildJobUrl,
+  run,
+} = scheduler as unknown as {
+  eligibleSubsForTopic: (
+    config: RedditConfig,
+    topic: string,
+  ) => Array<{ name: string; config: SubConfig }>;
+  isRateLimited: (
+    ledgerPosted: PostedEntry[],
+    subreddit: string,
+    minIntervalHours: number | undefined,
+    now: Date | number,
+  ) => boolean;
+  loadSubreddits: (repoRoot: string) => RedditConfig;
+  selectUnpostedJobs: (
+    jobs: JobLike[],
+    postedSet: Set<string>,
+    limit: number,
+  ) => JobLike[];
+  buildJobUrl: (job: JobLike) => string | null;
+  run: (opts: {
+    env?: Record<string, string | undefined>;
+    now?: Date;
+    repoRoot?: string;
+    fetchImpl?: typeof fetch;
+    log?: (...a: unknown[]) => void;
+    warn?: (...a: unknown[]) => void;
+  }) => Promise<{
+    ok: boolean;
+    posted: number;
+    dryRun: boolean;
+    payloads: Payload[];
+  }>;
+};
+
+// ── Fixtures helpers ──────────────────────────────────────
+
+// CRITICAL project rule: never hardcode absolute dates in fixtures. All
+// timestamps are relative to a fixed `now` we pass into run()/helpers.
+const NOW = new Date('2026-06-15T12:00:00Z');
+function daysAgo(n: number, base: Date = NOW): string {
+  return new Date(base.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+function hoursAgo(n: number, base: Date = NOW): string {
+  return new Date(base.getTime() - n * 60 * 60 * 1000).toISOString();
+}
+
+// A controlled subreddit config: one automation-enabled sub, one disabled.
+const CONFIG: RedditConfig = {
+  schemaVersion: 1,
+  subreddits: {
+    frontalieri: {
+      allowsAutomation: true,
+      minPostIntervalHours: 6,
+      flairId: null,
+      flairText: null,
+      topics: ['jobs', 'articles'],
+    },
+    Ticino: {
+      allowsAutomation: false,
+      minPostIntervalHours: 24,
+      flairId: null,
+      flairText: null,
+      topics: ['jobs', 'articles'],
+    },
+  },
+  routing: { jobs: ['frontalieri', 'Ticino'], articles: ['frontalieri', 'Ticino'] },
+};
+
+function makeJob(id: string, ageDays: number, overrides: Partial<JobLike> = {}): JobLike {
+  return {
+    id,
+    title: `Lavoro ${id}`,
+    slugByLocale: { it: `lavoro-${id}` },
+    jobLocation: { address: { addressLocality: 'Lugano' } },
+    descriptionByLocale: { it: `Descrizione per ${id}.` },
+    employmentType: 'FULL_TIME',
+    crawledAt: daysAgo(ageDays),
+    ...overrides,
+  };
+}
+
+function setupTmp(opts: {
+  jobs: JobLike[];
+  posted?: PostedEntry[];
+  config?: RedditConfig;
+}): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'reddit-jobs-'));
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+  writeFileSync(join(tmp, 'data', 'jobs.json'), JSON.stringify(opts.jobs));
+  writeFileSync(
+    join(tmp, 'data', 'reddit-subreddits.json'),
+    JSON.stringify(opts.config ?? CONFIG),
+  );
+  writeFileSync(
+    join(tmp, 'data', 'reddit-posted-jobs.json'),
+    JSON.stringify({ schemaVersion: 1, posted: opts.posted ?? [] }),
+  );
+  return tmp;
+}
+
+function loadLedger(repoRoot: string): PostedLedger {
+  return JSON.parse(
+    readFileSync(join(repoRoot, 'data', 'reddit-posted-jobs.json'), 'utf-8'),
+  );
+}
+
+// A fetch mock that emulates Reddit's token + submit endpoints.
+function makeFetchMock() {
+  return vi.fn(async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes('access_token')) {
+      return new Response(
+        JSON.stringify({ access_token: 'tok', expires_in: 3600 }),
+        { status: 200 },
+      );
+    }
+    if (u.includes('/api/submit')) {
+      return new Response(
+        JSON.stringify({
+          json: {
+            errors: [],
+            data: { id: 'abc', name: 't3_abc', url: 'https://reddit.com/r/frontalieri/comments/abc/' },
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected fetch to ${u}`);
+  });
+}
+
+const CREDS = {
+  REDDIT_CLIENT_ID: 'cid',
+  REDDIT_CLIENT_SECRET: 'csecret',
+  REDDIT_USERNAME: 'bot',
+  REDDIT_PASSWORD: 'pw',
+  REDDIT_USER_AGENT: 'web:test:v1.0 (by /u/test)',
+};
+
+// ── eligibleSubsForTopic ──────────────────────────────────
+
+describe('eligibleSubsForTopic', () => {
+  it('returns only allowsAutomation:true subs routed for the topic', () => {
+    const out = eligibleSubsForTopic(CONFIG, 'jobs');
+    expect(out.map((s) => s.name)).toEqual(['frontalieri']);
+    expect(out[0].config.allowsAutomation).toBe(true);
+  });
+
+  it('returns [] for a topic with no routing', () => {
+    expect(eligibleSubsForTopic(CONFIG, 'nope')).toEqual([]);
+  });
+
+  it('returns [] when no routed sub is automation-enabled', () => {
+    const cfg: RedditConfig = {
+      ...CONFIG,
+      subreddits: { Ticino: { allowsAutomation: false } },
+      routing: { jobs: ['Ticino'] },
+    };
+    expect(eligibleSubsForTopic(cfg, 'jobs')).toEqual([]);
+  });
+});
+
+// ── isRateLimited ─────────────────────────────────────────
+
+describe('isRateLimited', () => {
+  it('is true when the last post is within minIntervalHours of now', () => {
+    const posted: PostedEntry[] = [
+      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(2) },
+    ];
+    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(true);
+  });
+
+  it('is false when the last post is older than minIntervalHours', () => {
+    const posted: PostedEntry[] = [
+      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(10) },
+    ];
+    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(false);
+  });
+
+  it('is false when the sub was never posted to', () => {
+    const posted: PostedEntry[] = [
+      { id: 'x', url: 'u', subreddit: 'other', ts: hoursAgo(1) },
+    ];
+    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(false);
+  });
+
+  it('is false when minIntervalHours is 0/undefined (limit disabled)', () => {
+    const posted: PostedEntry[] = [
+      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(0.1) },
+    ];
+    expect(isRateLimited(posted, 'frontalieri', 0, NOW)).toBe(false);
+    expect(isRateLimited(posted, 'frontalieri', undefined, NOW)).toBe(false);
+  });
+
+  it('uses the most recent entry when several exist', () => {
+    const posted: PostedEntry[] = [
+      { id: 'old', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(20) },
+      { id: 'new', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(1) },
+    ];
+    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(true);
+  });
+});
+
+// ── run() — DRY_RUN ───────────────────────────────────────
+
+describe('run() — DRY_RUN', () => {
+  it('does not call fetch, returns payloads, leaves the ledger unchanged', async () => {
+    // Use a 0-interval sub so multiple jobs can target the same sub in one run
+    // (the scheduler enforces minPostIntervalHours per-sub even within a run).
+    const cfg: RedditConfig = {
+      schemaVersion: 1,
+      subreddits: {
+        frontalieri: { allowsAutomation: true, minPostIntervalHours: 0 },
+        Ticino: { allowsAutomation: false, minPostIntervalHours: 24 },
+      },
+      routing: { jobs: ['frontalieri', 'Ticino'], articles: ['frontalieri'] },
+    };
+    const tmp = setupTmp({ jobs: [makeJob('A', 1), makeJob('B', 2)], config: cfg });
+    const fetchSpy = vi.fn<typeof fetch>();
+    const result = await run({
+      env: { ...CREDS, DRY_RUN: '1', REDDIT_JOB_VOLUME: '2', REDDIT_POST_DELAY_MS: '0' },
+      now: NOW,
+      repoRoot: tmp,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.dryRun).toBe(true);
+    expect(result.posted).toBe(0);
+    expect(result.payloads).toHaveLength(2);
+    // Recency: A (1 day ago) before B (2 days ago).
+    expect(result.payloads[0].jobId).toBe('A');
+    expect(result.payloads[0].subreddit).toBe('frontalieri');
+    expect(result.payloads[0].kind).toBe('self');
+
+    expect(loadLedger(tmp).posted).toHaveLength(0);
+  });
+});
+
+// ── run() — real (mocked network) ─────────────────────────
+
+describe('run() — real posting', () => {
+  it('posts up to volume and writes ledger entries with subreddit + redditPostId', async () => {
+    const tmp = setupTmp({ jobs: [makeJob('A', 1), makeJob('B', 2), makeJob('C', 3)] });
+    const fetchSpy = makeFetchMock();
+    const result = await run({
+      env: { ...CREDS, REDDIT_JOB_VOLUME: '1', REDDIT_POST_DELAY_MS: '0' },
+      now: NOW,
+      repoRoot: tmp,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.posted).toBe(1); // volume cap = 1
+    expect(result.payloads).toHaveLength(1);
+
+    const ledger = loadLedger(tmp);
+    expect(ledger.posted).toHaveLength(1);
+    expect(ledger.posted[0].id).toBe('A');
+    expect(ledger.posted[0].subreddit).toBe('frontalieri');
+    expect(ledger.posted[0].redditPostId).toBe('t3_abc');
+  });
+
+  it('dedups jobs already in the ledger', async () => {
+    // A is already posted; only B should be picked.
+    const tmp = setupTmp({
+      jobs: [makeJob('A', 1), makeJob('B', 2)],
+      posted: [
+        { id: 'A', url: 'u', subreddit: 'frontalieri', ts: daysAgo(5) },
+      ],
+    });
+    const fetchSpy = makeFetchMock();
+    const result = await run({
+      env: { ...CREDS, REDDIT_JOB_VOLUME: '5', REDDIT_POST_DELAY_MS: '0' },
+      now: NOW,
+      repoRoot: tmp,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(result.posted).toBe(1);
+    expect(result.payloads.map((p) => p.jobId)).toEqual(['B']);
+
+    const ledger = loadLedger(tmp);
+    // Original A entry plus the new B entry.
+    expect(ledger.posted.map((e) => e.id).sort()).toEqual(['A', 'B']);
+  });
+
+  it('posts 0 and leaves the ledger unchanged when no sub is automation-enabled', async () => {
+    const cfg: RedditConfig = {
+      schemaVersion: 1,
+      subreddits: { Ticino: { allowsAutomation: false, minPostIntervalHours: 24 } },
+      routing: { jobs: ['Ticino'] },
+    };
+    const tmp = setupTmp({ jobs: [makeJob('A', 1)], config: cfg });
+    const fetchSpy = makeFetchMock();
+    const result = await run({
+      env: { ...CREDS, REDDIT_JOB_VOLUME: '2', REDDIT_POST_DELAY_MS: '0' },
+      now: NOW,
+      repoRoot: tmp,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(result.posted).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(loadLedger(tmp).posted).toHaveLength(0);
+  });
+});
+
+// ── re-exported helpers smoke test ────────────────────────
+
+describe('re-exported helpers', () => {
+  it('selectUnpostedJobs and buildJobUrl are re-exported and work', () => {
+    const jobs = [makeJob('A', 1), makeJob('B', 2)];
+    const out = selectUnpostedJobs(jobs, new Set(['A']), 10);
+    expect(out.map((j) => j.id)).toEqual(['B']);
+    expect(buildJobUrl(jobs[0])).toBe(
+      'https://frontaliereticino.ch/cerca-lavoro-ticino/lavoro-A/',
+    );
+  });
+
+  it('loadSubreddits reads the controlled config from a temp repoRoot', () => {
+    const tmp = setupTmp({ jobs: [] });
+    const cfg = loadSubreddits(tmp);
+    expect(cfg.routing.jobs).toEqual(['frontalieri', 'Ticino']);
+    expect(cfg.subreddits.frontalieri.allowsAutomation).toBe(true);
+  });
+});


### PR DESCRIPTION
Replica del workflow di pubblicazione Facebook per Reddit. Closes #1265

## Implementato
- **Modulo condiviso `scripts/lib/social-post-utils.mjs`**: estratti da `schedule-fb-jobs-daily.mjs` gli helper channel-agnostic (`selectUnpostedJobs`, `buildJobUrl`, `stripHtml`/`stripLeadingSectionLabel`/`stripDiacritics`/`truncateBody`, `recencyTs`, ledger I/O `loadLedger`/`appendLedger`, costanti `SITE_URL`/`JOB_BOARD_PREFIX_IT`). Lo scheduler FB ora li importa → **zero duplicazione** (rispetta la regola sibling-class). Comportamento FB invariato: test 49/49 verdi.
- **`scripts/lib/reddit-client.mjs`**: client OAuth2 Reddit — refresh-token (preferito) con fallback al password grant per script-app, `User-Agent` obbligatorio, `submitPost()` che parsa l'envelope `{json:{errors,data}}`. Soft-fail, non lancia mai.
- **`scripts/lib/reddit-templates.mjs`**: builder italiani per post offerta (self-post markdown con link candidatura + disclosure) e articolo (link post). Titoli ≤300 char.
- **`data/reddit-subreddits.json`**: routing + regole per subreddit. `allowsAutomation:false` su tutti i subreddit di terze parti (r/Ticino, r/Svizzera, r/italiansinswitzerland) — auto-post abilitato di default **solo** su r/frontalieri (community propria). Safe-by-default anti-ban.
- **`scripts/post-to-reddit.mjs`** (articoli) + **`scripts/schedule-reddit-jobs-daily.mjs`** (offerte): Reddit NON ha scheduling lato server → pubblicazione immediata a volume basso (`REDDIT_JOB_VOLUME` default 2/run), delay tra i post, rate-limit per-subreddit via `minPostIntervalHours`. Soft-fail `exit(0)`.
- **Tracking**: `data/reddit-posted-jobs.json` (dedup per job id) + `scripts/lib/resolve-reddit-posted-jobs-conflict.mjs` (resolver di rebase, union per chiave `id+subreddit`), mirror dello FB.
- **Infra**: mapping `REDDIT_*` in `scripts/load-rc-env.mjs` (secret con prefisso `SERVER_`); workflow cron `.github/workflows/reddit-jobs-daily-schedule.yml` (`45 13 * * *`, +15min dallo slot FB); step "Post to Reddit Communities" in `post-deploy-publish.yml` (stesse condizioni di FB/LinkedIn).
- **Documentazione**: `docs/REDDIT-POSTING.md` — setup OAuth, regole community & anti-spam (regola 9:1), passi manuali per abilitare un subreddit di terze parti, gestione r/frontalieri, ledger, comandi dry-run, template di esempio, limitazioni.
- **Fix root-cause**: `truncateBody` non supera più `maxLen` (riserva 1 char per l'ellissi) → rispetta il cap rigido di 300 char dei titoli Reddit. Innocuo per FB (body 140 vs limite 5000).
- **Test**: `tests/scripts/reddit-templates.test.ts` (12) + `tests/scripts/schedule-reddit-jobs-daily.test.ts` (14), date relative (`daysAgo`). Totale **75/75 verdi** incl. la suite FB.

## Non implementato (ancora)
- **Flair id reali dei subreddit**: i campi `flairId`/`flairText` sono `null` — vanno scoperti manualmente per ogni sub che richiede flair (motivo: richiede credenziali/ispezione live del subreddit; documentato in `docs/REDDIT-POSTING.md`). Follow-up post-approvazione mod.
- **Abilitazione auto-post su r/Ticino / r/Svizzera / r/italiansinswitzerland**: lasciato `allowsAutomation:false` di proposito — richiede contatto e permesso dei moderatori prima di attivare (out of scope automatico, è un passo umano).
- **Creazione effettiva di r/frontalieri + impostazione secret Remote Config** (`REDDIT_CLIENT_ID`, `SERVER_REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `SERVER_REDDIT_PASSWORD`, `SERVER_REDDIT_REFRESH_TOKEN`, `REDDIT_USER_AGENT`): passo operativo manuale (documentato). Finché i secret non ci sono, gli script soft-skip senza errori.
- **Validazione live end-to-end** della pubblicazione reale su Reddit: non verificabile in CI senza credenziali; i workflow girano live su `main` post-merge (dry-run prima). Revert-trigger: se il submit reale fallisce per scope OAuth/anti-spam → iterare su client/templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)