### PR TITLE
feat(cf): cache IT/apex HTML at the edge + purge on deploy

### DIFF
--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -176,6 +176,23 @@ jobs:
           echo "::error::[validate-live] propagation_timeout — deploy not live within window. Skipping smoke/gates; caller will NOT rollback (live is a valid earlier build)."
           exit 1
 
+      # Purge the Cloudflare edge cache now that the new build-id is confirmed
+      # LIVE at origin (propagation succeeded above). The it-apex-html-cache
+      # rule caches HTML for 24h with override_origin; GitHub Pages can't signal
+      # Cloudflare on republish, so without this the edge would serve the prior
+      # build's HTML until the TTL lapses. Gated on propagation success so we
+      # never purge while origin still serves the OLD build (which would just
+      # re-cache stale). Non-fatal: a purge hiccup must not fail validate-live.
+      - name: Purge Cloudflare edge cache (new build is live)
+        if: steps.propagation.outcome == 'success'
+        continue-on-error: true
+        run: |
+          # Force stdout export mode (GITHUB_ENV= ) so we can eval into THIS
+          # shell; GOOGLE_APPLICATION_CREDENTIALS was set by "Prepare Firebase
+          # credentials" above. No-op (exit 0) if CF_API_TOKEN is absent.
+          eval "$(GITHUB_ENV= node scripts/load-rc-env.mjs 2>/dev/null)" || true
+          node scripts/cf-purge-cache.mjs
+
       # Verify the offloaded JS/CSS bundle actually serves from the CDN on the
       # LIVE site. Moved here from the build job: the CDN Pages build lags the
       # push, so an inline build-time poll was a flaky false-negative that blocked

--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * cf-locale-failover-setup.mjs — idempotent Cloudflare config for the
- * locale-router over-cap failover. Run after EVERY `wrangler deploy` of the
- * Worker (deploy-worker.yml wires it in; manual deploys: run it yourself —
- * see LOCALE-SHARD-CLOUDFLARE-RUNBOOK §2.4).
+ * cf-locale-failover-setup.mjs — idempotent Cloudflare cache config for the
+ * apex zone. Run after EVERY `wrangler deploy` of the locale-router Worker
+ * (deploy-worker.yml wires it in; manual deploys: run it yourself — see
+ * LOCALE-SHARD-CLOUDFLARE-RUNBOOK §2.4). Safe to re-run any time; idempotent.
  *
  * What it asserts (and why it must re-run post-deploy):
  *
@@ -15,17 +15,19 @@
  *    `wrangler deploy` re-syncs routes from wrangler.toml, which cannot
  *    express this flag — so a deploy can silently reset it to fail closed.
  *
- * 2. CACHE RULE — zone rule (marker: RULE_DESCRIPTION) that makes the apex
- *    locale paths ELIGIBLE for cache. Extensionless HTML is not looked up in
- *    the edge cache by default, so without this rule the apex-keyed entries
- *    the Worker writes via cache.put() are unreachable exactly on the
- *    fail-open path they exist for. Write-side TTLs on this rule only matter
- *    for fail-open MISSes that reach the main GitHub Pages origin (which has
- *    no /en|/de|/fr content since the locale sharding): 3xx-5xx → value 0
- *    (no-cache) so a transient fail-open 404 never outlives the cap window.
- *    Scoped to http.host == apex so the Worker's own subrequests to the
- *    origin-{loc} shard hosts (already cached via cf.cacheEverything) are
- *    untouched.
+ * 2. CACHE RULES — the managed entries in MANAGED_CACHE_RULES (each keyed by
+ *    its `description` marker; foreign rules on the same entrypoint preserved):
+ *    a) locale-shard-failover-cache — makes the apex /en|/de|/fr paths
+ *       ELIGIBLE for cache so the apex-keyed entries the Worker writes via
+ *       cache.put() are reachable on the fail-open path. 3xx-5xx → TTL 0 so a
+ *       transient fail-open 404 never outlives the cap window.
+ *    b) it-apex-html-cache — caches the IT/apex HTML (the ~95% Worker-
+ *       passthrough bulk, previously cf-cache-status=DYNAMIC i.e. uncached).
+ *       Query-string requests bypass (no cache pollution); 3xx-5xx → TTL 0.
+ *    Both override Edge TTL to 24h; the deploy-time purge (scripts/
+ *    cf-purge-cache.mjs, wired in post-deploy-validate-live.yml) clears the
+ *    edge once a new build is confirmed live, so the long TTL never serves
+ *    stale content across deploys.
  *
  * Auth: CF_API_TOKEN — needs Zone→Workers Routes:Edit (already required by
  * deploy-worker.yml) + Zone→Zone Settings/Cache Rules:Edit + zone read.
@@ -40,17 +42,15 @@
 const REST_BASE = 'https://api.cloudflare.com/client/v4';
 const ZONE_NAME = process.env.CF_ZONE_NAME || 'frontaliereticino.ch';
 const WORKER_SCRIPT = 'frontaliere-locale-router';
-const RULE_DESCRIPTION = 'locale-shard-failover-cache (managed by scripts/cf-locale-failover-setup.mjs)';
 const CACHE_PHASE = 'http_request_cache_settings';
 
-const RULE_EXPRESSION =
-  '(http.host eq "frontaliereticino.ch" and ' +
-  '(starts_with(http.request.uri.path, "/en/") or ' +
-  'starts_with(http.request.uri.path, "/de/") or ' +
-  'starts_with(http.request.uri.path, "/fr/") or ' +
-  'http.request.uri.path in {"/en" "/de" "/fr" "/en.html" "/de.html" "/fr.html"}))';
-
-const RULE_ACTION_PARAMETERS = {
+// Shared cache settings for both managed rules: make matching requests
+// eligible for the edge cache with a 24h Edge TTL (override_origin — the
+// origin sends max-age=600, which would otherwise cap edge entries; the
+// deploy-time purge in scripts/cf-purge-cache.mjs keeps them fresh). 3xx-5xx
+// responses get TTL 0 so a transient redirect/404 never outlives a build.
+// Browser TTL respects the origin so clients still revalidate per max-age.
+const CACHE_ACTION_PARAMETERS = {
   cache: true,
   edge_ttl: {
     mode: 'override_origin',
@@ -59,6 +59,43 @@ const RULE_ACTION_PARAMETERS = {
   },
   browser_ttl: { mode: 'respect_origin' },
 };
+
+// Every cache rule this script owns, keyed by description (the idempotency
+// marker — foreign rules sharing the entrypoint are preserved untouched).
+const MANAGED_CACHE_RULES = [
+  {
+    // Locale-shard over-cap failover: extensionless HTML is not edge-cache
+    // looked-up by default, so without this the apex-keyed entries the Worker
+    // writes via cache.put() are unreachable on the fail-open path.
+    description: 'locale-shard-failover-cache (managed by scripts/cf-locale-failover-setup.mjs)',
+    expression:
+      '(http.host eq "frontaliereticino.ch" and ' +
+      '(starts_with(http.request.uri.path, "/en/") or ' +
+      'starts_with(http.request.uri.path, "/de/") or ' +
+      'starts_with(http.request.uri.path, "/fr/") or ' +
+      'http.request.uri.path in {"/en" "/de" "/fr" "/en.html" "/de.html" "/fr.html"}))',
+    action_parameters: CACHE_ACTION_PARAMETERS,
+  },
+  {
+    // IT/apex HTML edge cache: the IT bulk (~95% traffic) is Worker-passthrough
+    // and was served cf-cache-status=DYNAMIC (every hit reached GitHub Pages).
+    // Cache GET page requests with NO query string (so ?q= search / ?debug=
+    // variations bypass and never pollute the cache), excluding the locale
+    // shards (handled above), /api/, and the shard root paths. Bundled JS/CSS
+    // live on the gray-cloud cdn.* host (Fastly) and never reach this zone, so
+    // no asset-extension exclusion is needed here.
+    description: 'it-apex-html-cache (managed by scripts/cf-locale-failover-setup.mjs)',
+    expression:
+      '(http.host eq "frontaliereticino.ch" and http.request.method eq "GET" ' +
+      'and http.request.uri.query eq "" ' +
+      'and not starts_with(http.request.uri.path, "/en/") ' +
+      'and not starts_with(http.request.uri.path, "/de/") ' +
+      'and not starts_with(http.request.uri.path, "/fr/") ' +
+      'and not starts_with(http.request.uri.path, "/api/") ' +
+      'and not http.request.uri.path in {"/en" "/de" "/fr" "/en.html" "/de.html" "/fr.html"})',
+    action_parameters: CACHE_ACTION_PARAMETERS,
+  },
+];
 
 const args = new Set(process.argv.slice(2));
 const DRY_RUN = args.has('--dry-run');
@@ -117,62 +154,75 @@ async function assertFailOpenRoutes(zoneId) {
 // API-added defaults, so a stringify comparison would flag drift on every
 // run and re-PUT the entrypoint forever (never converging to "in shape").
 // Extra/unknown fields CF adds are tolerated; only OUR contract is checked.
-function ruleInShape(current) {
+function ruleInShape(current, desired) {
   if (!current || current.enabled === false) return false;
-  if (current.expression !== RULE_EXPRESSION) return false;
+  if (current.expression !== desired.expression) return false;
   const p = current.action_parameters || {};
-  if (p.cache !== true) return false;
+  const want = desired.action_parameters;
+  if (p.cache !== want.cache) return false;
   const e = p.edge_ttl || {};
-  if (e.mode !== 'override_origin' || e.default !== 86400) return false;
-  const noCache3xx5xx = (e.status_code_ttl || []).find(
-    (s) => s.status_code_range && s.status_code_range.from === 300 && s.status_code_range.to === 599,
+  if (e.mode !== want.edge_ttl.mode || e.default !== want.edge_ttl.default) return false;
+  const wantStatus = want.edge_ttl.status_code_ttl[0];
+  const gotStatus = (e.status_code_ttl || []).find(
+    (s) =>
+      s.status_code_range &&
+      s.status_code_range.from === wantStatus.status_code_range.from &&
+      s.status_code_range.to === wantStatus.status_code_range.to,
   );
-  if (!noCache3xx5xx || noCache3xx5xx.value !== 0) return false;
-  if ((p.browser_ttl || {}).mode !== 'respect_origin') return false;
+  if (!gotStatus || gotStatus.value !== wantStatus.value) return false;
+  if ((p.browser_ttl || {}).mode !== want.browser_ttl.mode) return false;
   return true;
 }
 
-async function assertCacheRule(zoneId) {
+async function assertCacheRules(zoneId) {
   // The entrypoint ruleset may not exist yet on a zone with no cache rules —
   // GET then answers 404; PUT below creates it.
   const { status, json } = await cf('GET', `/zones/${zoneId}/rulesets/phases/${CACHE_PHASE}/entrypoint`);
   if (status !== 404 && !json?.success) bail(`Cannot read ${CACHE_PHASE} entrypoint: ${JSON.stringify(json?.errors)}`);
   const existing = status === 404 ? [] : (json.result.rules || []);
 
-  const desired = {
-    description: RULE_DESCRIPTION,
-    expression: RULE_EXPRESSION,
-    action: 'set_cache_settings',
-    action_parameters: RULE_ACTION_PARAMETERS,
-    enabled: true,
-  };
+  // Build the desired rule list IN PLACE: every foreign rule preserved at its
+  // position, each managed rule updated where present or appended otherwise.
+  // Strip read-only per-rule fields (id, ref, version, last_updated) — the PUT
+  // replaces the rule list wholesale and rejects unknown/read-only keys.
+  const rules = existing.map(({ id, ref, version, last_updated, ...rest }) => rest);
+  let drift = 0;
+  for (const spec of MANAGED_CACHE_RULES) {
+    const desired = {
+      description: spec.description,
+      expression: spec.expression,
+      action: 'set_cache_settings',
+      action_parameters: spec.action_parameters,
+      enabled: true,
+    };
+    const idx = rules.findIndex((r) => r.description === spec.description);
+    const current = idx >= 0 ? existing[idx] : null;
+    if (ruleInShape(current, desired)) {
+      console.log(`cache rule "${spec.description.split(' ')[0]}": already in shape`);
+      continue;
+    }
+    drift++;
+    console.log(
+      `cache rule "${spec.description.split(' ')[0]}": ${current ? 'drift — updating' : 'missing — creating'}${DRY_RUN ? ' (dry-run)' : ''}`,
+    );
+    if (idx >= 0) rules[idx] = desired;
+    else rules.push(desired);
+  }
 
-  const idx = existing.findIndex((r) => r.description === RULE_DESCRIPTION);
-  const current = idx >= 0 ? existing[idx] : null;
-
-  if (ruleInShape(current)) {
-    console.log('cache rule: already in shape');
+  if (drift === 0) {
+    console.log('cache rules: all in shape');
     return;
   }
-  console.log(`cache rule: ${current ? 'drift — updating' : 'missing — creating'}${DRY_RUN ? ' (dry-run)' : ''}`);
   if (DRY_RUN) return;
-
-  // Preserve every foreign rule untouched; replace/append only ours. Strip
-  // read-only per-rule fields (id, ref, version, last_updated) — the PUT
-  // replaces the rule list wholesale and rejects unknown/read-only keys.
-  const keep = existing
-    .filter((_, i) => i !== idx)
-    .map(({ id, ref, version, last_updated, ...rest }) => rest);
-  const rules = idx >= 0 ? [...keep.slice(0, idx), desired, ...keep.slice(idx)] : [...keep, desired];
 
   const { json: put } = await cf('PUT', `/zones/${zoneId}/rulesets/phases/${CACHE_PHASE}/entrypoint`, {
     rules,
   });
   if (!put?.success) bail(`PUT ${CACHE_PHASE} entrypoint failed: ${JSON.stringify(put?.errors)}`);
-  console.log('cache rule: applied');
+  console.log('cache rules: applied');
 }
 
 const zoneId = await resolveZoneId();
 if (DO_ROUTES) await assertFailOpenRoutes(zoneId);
-if (DO_RULE) await assertCacheRule(zoneId);
+if (DO_RULE) await assertCacheRules(zoneId);
 console.log(DRY_RUN ? 'dry-run complete' : 'failover config converged');

--- a/scripts/cf-purge-cache.mjs
+++ b/scripts/cf-purge-cache.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * cf-purge-cache.mjs — purge the Cloudflare edge cache after a deploy.
+ *
+ * WHY this exists: the apex HTML cache rule (it-apex-html-cache, managed by
+ * cf-locale-failover-setup.mjs) makes extensionless 200 pages ELIGIBLE for
+ * the edge cache with a long Edge TTL (override_origin 24h). GitHub Pages
+ * does NOT notify Cloudflare when a deploy republishes content, so without
+ * an explicit purge the edge would keep serving the PREVIOUS build's HTML
+ * for up to the Edge TTL. This script clears the zone cache so the next
+ * request re-fetches the freshly-deployed origin content.
+ *
+ * WHEN to run: ONLY after the new build is confirmed LIVE at origin
+ * (post-deploy-validate-live → "Wait for Pages propagation"). Purging BEFORE
+ * propagation would re-cache the OLD content (Pages still serving the prior
+ * build) and defeat the purpose. The validate-live wiring gates this on the
+ * propagation step succeeding.
+ *
+ * SCOPE: purge_everything. The site deploys as a whole (every HTML page can
+ * change per build), and the free plan's granular purge is capped at 30 URLs
+ * — far below the page count — so a full purge is the correct primitive.
+ * It also clears the locale-shard failover entries (they simply re-warm) and
+ * is harmless to the gray-cloud cdn.* assets (those are NOT in Cloudflare's
+ * cache — they serve from Fastly/GitHub Pages and bypass this zone's edge).
+ *
+ * Auth: CF_API_TOKEN — needs Zone→Cache Purge. Resolves zone by name unless
+ * CF_ZONE_ID is set. Hydrate locally via:
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/load-rc-env.mjs)" && node scripts/cf-purge-cache.mjs
+ *
+ * Exit: 0 = purged (or no-op when CF_API_TOKEN absent — non-fatal so a
+ * missing secret never fails the deploy), 1 = API/auth error.
+ */
+
+const REST_BASE = 'https://api.cloudflare.com/client/v4';
+const ZONE_NAME = process.env.CF_ZONE_NAME || 'frontaliereticino.ch';
+const token = process.env.CF_API_TOKEN;
+
+// Non-fatal when the secret is absent: callers wire this with
+// continue-on-error, but a clean exit 0 keeps logs quiet on env-less runs.
+if (!token) {
+  console.warn('⚠️  CF_API_TOKEN not set — skipping Cloudflare cache purge (non-fatal).');
+  process.exit(0);
+}
+
+async function cf(method, path, body) {
+  const res = await fetch(`${REST_BASE}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+async function resolveZoneId() {
+  if (process.env.CF_ZONE_ID) return process.env.CF_ZONE_ID;
+  const { json } = await cf('GET', `/zones?name=${encodeURIComponent(ZONE_NAME)}`);
+  if (!json?.success || !json.result?.length) {
+    console.error(`❌ Cannot resolve zone id for ${ZONE_NAME} (token scope?).`);
+    process.exit(1);
+  }
+  return json.result[0].id;
+}
+
+const zoneId = await resolveZoneId();
+const { json } = await cf('POST', `/zones/${zoneId}/purge_cache`, { purge_everything: true });
+if (!json?.success) {
+  console.error(`❌ purge_everything failed: ${JSON.stringify(json?.errors)}`);
+  process.exit(1);
+}
+console.log(`✅ Cloudflare edge cache purged (zone ${zoneId}).`);


### PR DESCRIPTION
## Implementato

Sfrutta il free tier Cloudflare per offload origin + TTFB globale sull'HTML, senza staleness.

- **Cache rule IT/apex HTML** (`scripts/cf-locale-failover-setup.mjs`): l'apex IT (~95% traffico, Worker-passthrough) era `cf-cache-status: DYNAMIC` — ogni richiesta colpiva l'origin GitHub Pages. Nuova managed rule `it-apex-html-cache` rende cacheable le GET di pagina **senza query string** (così `?q=` search / `?debug=` bypassano → no cache pollution), escludendo gli shard locale (già gestiti), `/api/` e i path root shard. Edge TTL 24h `override_origin`; 3xx-5xx → TTL 0 (no-cache errori). Browser TTL `respect_origin` (client revalidano per `max-age=600`). Gli asset JS/CSS sono sul host gray-cloud `cdn.*` (Fastly) e non passano da questa zona → nessuna esclusione per estensione necessaria.
- **Refactor a lista di regole** nello stesso script: `RULE_*` singolo → `MANAGED_CACHE_RULES` (failover-shard + it-apex), `ruleInShape(current, desired)` generico, `assertCacheRule`→`assertCacheRules`. UN solo PUT del cache entrypoint, preserva ogni regola foreign. DRY: niente duplicazione della macchina ruleset (AGENTS.md #6). Idempotente — verificato `--dry-run`: `it-apex-html-cache` già in shape live.
- **Purge-on-deploy** (`scripts/cf-purge-cache.mjs` nuovo + step in `post-deploy-validate-live.yml`): GitHub Pages non notifica CF al republish → senza purge l'edge servirebbe l'HTML del build precedente fino allo scadere del TTL. Lo step gira **solo se `propagation` ha successo** (nuovo build-id già live all'origin — purgare prima ri-cacherebbe il vecchio). `purge_everything` (il free plan granular cappa a 30 URL, sotto il page-count; il sito deploya as-a-whole). `continue-on-error` + no-op se `CF_API_TOKEN` assente → un purge fallito non rompe validate-live.

Live già applicato via API (rule attiva, verificato MISS→HIT su pagine 200, DYNAMIC su `?q=`, errori non cachati). Questa PR versiona la rule e aggiunge il purge automatico.

### Config Cloudflare correlate applicate live (fuori da questo diff, via API — non file di repo)
- Bot Fight Mode → **OFF** (eliminato challenge a crawler SEO/AI non-verificati).
- Tiered Cache (Smart) → **ON** (offload origin).
- Verificato già ottimale: Early Hints ON, HTTP/3/0-RTT/Brotli ON, Rocket Loader OFF (AdSense-safe), robots.txt pro-AI/SEO, CF AI/crawler protections tutte disabled.

## Non implementato (ancora)

- **Consolidamento boilerplate CF** (`resolveZoneId`/`cf()`/`CF_API_TOKEN` in `scripts/lib/cf-analytics.mjs`): `cf-purge-cache.mjs` è self-contained e rispecchia volutamente il sibling `cf-locale-failover-setup.mjs`. Il check sibling-patterns flagga 9 file (`cf-status-report.mjs`, `discover-404s-via-cloudflare.mjs`, `build-cf-hot-404s.mjs`, `lib/cf-analytics.mjs`, ecc.) che condividono `CF_API_TOKEN`/`resolveZoneId` — **non lo stesso antipattern**, è il pattern self-contained già stabilito in tutti gli script CF. Consolidare i 5 script nel lib condiviso = refactor a sé che tocca 4 file non in scope (drive-by vietato AGENTS.md #6) → follow-up.
- **cdn.\* → orange-cloud** (cache CF immutable 1y sugli asset hashed, oggi `max-age=600` su Fastly): cambio architetturale con rischi SSL/clobber, in attesa di decisione owner — fuori scope.
- **Web Analytics / Turnstile / Snippets / KV**: separati (provisioning token / wiring form / valutazione) — non in questa PR infra.

## Test plan

- [x] `node --check` su entrambi gli script
- [x] `--dry-run --rule-only`: `it-apex-html-cache` già in shape (idempotenza)
- [x] YAML `post-deploy-validate-live.yml` valido
- [x] Live: MISS→HIT pagine 200, `?q=` → DYNAMIC (bypass), 404 → non cachato
- [ ] Post-merge: prossimo deploy esegue lo step purge dopo propagation success (osservare log validate-live)