### PR TITLE
fix(cls): reserve #root height across createRoot re-mount (homepage CLS #886/#855)

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -108,6 +108,17 @@ const mountApp = async () => {
  // 1. Fade out the static HTML content quickly
  // 2. Let React render (which replaces the content)
  // 3. Fade the new React content back in
+ //
+ // CLS fix (#886/#855): createRoot().render() momentarily EMPTIES #root before
+ // the React tree paints, collapsing its height. Static SEO blocks injected as
+ // siblings AFTER #root (hp-seo-block / hp-related-guides / hp-lang-switch /
+ // hp-canton-nav) then jump UP to Y=0 (measured dY up to −914px ≈ 0.8 CLS) and
+ // back down once React re-renders. The opacity crossfade hid the FLASH but not
+ // the layout SHIFT. Reserve #root's prerendered height as a min-height floor so
+ // its transient collapse can't move the blocks below; released after the React
+ // content paints (heights match — same page — so the release is shift-free).
+ const reservedRootHeight = rootElement.offsetHeight;
+ if (reservedRootHeight > 0) rootElement.style.minHeight = `${reservedRootHeight}px`;
  rootElement.style.transition = 'opacity 80ms ease-out';
  rootElement.style.opacity = '0';
 
@@ -137,10 +148,13 @@ const mountApp = async () => {
  // Fade the React content back in
  rootElement.style.transition = 'opacity 120ms ease-in';
  rootElement.style.opacity = '1';
- // Clean up inline styles after the transition completes
+ // Clean up inline styles after the transition completes. Release the
+ // reserved min-height now that the React content has painted and set its
+ // own height (same page → heights match → no shift on release).
  rootElement.addEventListener('transitionend', () => {
  rootElement.style.transition = '';
  rootElement.style.opacity = '';
+ rootElement.style.minHeight = '';
  }, { once: true });
  }
 


### PR DESCRIPTION
## Implementato
Fix della CLS homepage residua (la tua priorità #1). Misurato live post-#2028: CLS ancora **~1.23** nonostante #2028 avesse fixato lo shift dell'ad. Lo shift dominante residuo (~0.8) sono i **blocchi SEO statici iniettati come sibling DOPO `#root`** (`hp-seo-block`/`hp-related-guides`/`hp-lang-switch`/`hp-canton-nav`) che **saltano su a Y=0** (dY fino a −914px) a ~1.2s e tornano giù a ~1.6s.

**Root cause:** su pagine SSG `index.tsx` usa `ReactDOM.createRoot().render()` (deliberato — evita hydration-mismatch col DOM prerenderizzato, vedi L68) che **svuota momentaneamente `#root`** prima che l'albero React dipinga → `#root` collassa in altezza → i blocchi sotto saltano su → React ri-renderizza → ritornano giù. Il crossfade opacity esistente nascondeva il FLASH visivo ma non lo SHIFT di layout.

**Fix:** nel branch `staticPage` di `mountApp`, snapshot dell'altezza prerenderizzata di `#root` come `min-height` floor PRIMA di `render()` → il collasso transitorio non può muovere i blocchi sotto; rilascio del floor sul `transitionend` del fade-in (stessa pagina → altezze combaciano → rilascio shift-free).

Scope: solo pagine SSG statiche (gate `staticPage`); le pagine SPA-nav (loading-shell) non toccate. Set/clear di stile additivo — render path invariato. esbuild OK.

## Non implementato (ancora)
- **Revert-trigger (CWV non validabile pre-merge — niente build+serve locale):** se la CLS lab/field post-deploy NON migliora, o appare uno shift al rilascio su pagine la cui altezza React < prerenderizzata → revert (o passare il rilascio a keep-floor). Verifica via `audit-cls-live` + Playwright post-deploy.
- Fix alternativo "vero" (passare a `hydrateRoot` per evitare il re-mount) NON fatto: il team usa `createRoot` deliberatamente (mismatch SSG), cambiarlo è ad alto rischio. Questo fix lavora COL createRoot esistente.
- #2028 (reserve ad) restava il pezzo già live; questo è il pezzo hydration-collapse rimanente di #886/#855.

Riferimento #886 #855 (verifica live post-deploy prima di chiudere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)