### PR TITLE
feat(salary): canton selector in SalaryCompare stats page

### DIFF
--- a/components/community/WhatsNewModal.tsx
+++ b/components/community/WhatsNewModal.tsx
@@ -33,6 +33,19 @@ interface Release {
 
 export const RELEASES: Release[] = [
  {
+ version: '3.52.0',
+ date: '2026-06-15',
+ titleKey: 'whatsNew.v3520.title',
+ items: [
+ {
+ type: 'feature',
+ titleKey: 'whatsNew.v3520.cantonSalary.title',
+ descKey: 'whatsNew.v3520.cantonSalary.desc',
+ link: { tab: 'stats', subTab: 'salary-compare' },
+ },
+ ],
+ },
+ {
  version: '3.51.0',
  date: '2026-06-12',
  titleKey: 'whatsNew.v3510.title',

--- a/components/comparators/SalaryCompare.tsx
+++ b/components/comparators/SalaryCompare.tsx
@@ -12,6 +12,8 @@ import {
  type SalaryLevel,
 } from '@/data/salaryData';
 import { lazyRetry } from '@/services/lazyRetry';
+import { cantonGrossScale, SALARY_CANTON_CODES, NATIONAL_CANTON } from '@/services/cantonSalary';
+import { getCantonLabel, type CantonLocale } from '@/services/cantonList';
 
 const SalarySurvey = lazyRetry(() => import('@/components/community/SalarySurvey'));
 const RelatedTools = lazyRetry(() => import('@/components/shared/RelatedTools'));
@@ -59,10 +61,11 @@ function calcNetIT(gross: number): number {
 type InternalTab = 'sectors' | 'professions' | 'survey';
 
 export default function SalaryCompare() {
- const { t } = useTranslation();
+ const { t, locale } = useTranslation();
  const { rate: exchangeRate } = useExchangeRate();
  const [selectedSector, setSelectedSector] = useState<string | null>(null);
  const [selectedLevel, setSelectedLevel] = useState<SalaryLevel>('mid');
+ const [selectedCanton, setSelectedCanton] = useState<string>(NATIONAL_CANTON);
  const [activeTab, setActiveTab] = useState<InternalTab>('sectors');
  const [expandedSectors, setExpandedSectors] = useState<Set<string>>(new Set());
  const [profSearch, setProfSearch] = useState('');
@@ -71,13 +74,20 @@ export default function SalaryCompare() {
  const profName = (id: string) => t('salaryCompare.prof.' + id);
  const levelLabel = (level: SalaryLevel) => t('salaryCompare.' + level);
 
+ // Per-canton scaling: national-CH gross figures are scaled to the selected
+ // canton via the official BFS index. The national sentinel keeps scale 1.0,
+ // so the default view is unchanged.
+ const cantonScale = cantonGrossScale(selectedCanton);
+ const scaleCh = (v: number) => Math.round(v * cantonScale);
+ const cantonColLabel = selectedCanton === NATIONAL_CANTON ? 'CH' : selectedCanton;
+
  // ── Sector overview data ──
  const sectorTableData = useMemo(() => {
  const sectors = selectedSector
  ? SALARY_DATA.filter((s) => s.id === selectedSector)
  : SALARY_DATA;
  return sectors.map((s) => {
- const chGross = getSectorMedian(s, selectedLevel, 'ch');
+ const chGross = scaleCh(getSectorMedian(s, selectedLevel, 'ch'));
  const itGross = getSectorMedian(s, selectedLevel, 'it');
  const chNet = calcNetCH(chGross);
  const itNet = calcNetIT(itGross);
@@ -91,7 +101,7 @@ export default function SalaryCompare() {
  professions: s.professions,
  };
  });
- }, [selectedSector, selectedLevel, t, exchangeRate]);
+ }, [selectedSector, selectedLevel, t, exchangeRate, cantonScale]);
 
  // ── All professions flat for search tab ──
  const allProfessions = useMemo(() => {
@@ -167,11 +177,11 @@ export default function SalaryCompare() {
  startY: 28,
  head: [[
  t('salaryCompare.professions'),
- 'CH Min', 'CH ' + t('salaryCompare.median'), 'CH Max',
+ cantonColLabel + ' Min', cantonColLabel + ' ' + t('salaryCompare.median'), cantonColLabel + ' Max',
  'IT Min', 'IT ' + t('salaryCompare.median'), 'IT Max',
  ]],
  body: sector.professions.map((p) => {
- const ch = p.ch[selectedLevel];
+ const ch = p.ch[selectedLevel].map(scaleCh) as [number, number, number];
  const it = p.it[selectedLevel];
  return [
  profName(p.id),
@@ -284,6 +294,29 @@ export default function SalaryCompare() {
  </select>
  </div>
 
+ {/* Canton filter — scales national CH figures to the selected canton */}
+ <div className="flex-1 min-w-[180px]">
+ <label
+ htmlFor="sc-canton"
+ className="block text-sm font-medium text-body mb-1"
+ >
+ {t('salaryCompare.canton')}
+ </label>
+ <select
+ id="sc-canton"
+ value={selectedCanton}
+ onChange={(e) => setSelectedCanton(e.target.value)}
+ className="w-full rounded-lg border border-edge bg-surface-alt px-3 py-2 text-heading"
+ >
+ <option value={NATIONAL_CANTON}>{t('salaryCompare.cantonAll')}</option>
+ {SALARY_CANTON_CODES.map((code) => (
+ <option key={code} value={code}>
+ {getCantonLabel(code, locale as CantonLocale)}
+ </option>
+ ))}
+ </select>
+ </div>
+
  {activeTab === 'professions' && (
  <div className="flex-1 min-w-[180px]">
  <label
@@ -389,7 +422,7 @@ export default function SalaryCompare() {
  </div>
  </div>
  <div className="flex justify-between text-xs font-mono text-muted mt-0.5">
- <span>CH {'\u20AC'}{r.chNetEUR.toLocaleString()}</span>
+ <span>{cantonColLabel} {'\u20AC'}{r.chNetEUR.toLocaleString()}</span>
  <span>IT {'\u20AC'}{r.itNet.toLocaleString()}</span>
  </div>
  </div>
@@ -429,7 +462,7 @@ export default function SalaryCompare() {
  )}
  <div className="grid grid-cols-2 gap-2">
  {r.professions.map((p) => {
- const ch = p.ch[selectedLevel]; // [min, median, max]
+ const ch = p.ch[selectedLevel].map(scaleCh) as [number, number, number]; // [min, median, max]
  const it = p.it[selectedLevel]; // [min, median, max]
  const chNet = calcNetCH(ch[1]);
  const itNet = calcNetIT(it[1]);
@@ -572,7 +605,7 @@ export default function SalaryCompare() {
  </tr>
  )}
  {r.professions.map((p) => {
- const ch = p.ch[selectedLevel];
+ const ch = p.ch[selectedLevel].map(scaleCh) as [number, number, number];
  const it = p.it[selectedLevel];
  return (
  <tr
@@ -717,7 +750,7 @@ export default function SalaryCompare() {
  </p>
  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
  {filteredProfessions.map((p) => {
- const ch = p.ch[selectedLevel];
+ const ch = p.ch[selectedLevel].map(scaleCh) as [number, number, number];
  const it = p.it[selectedLevel];
  const chNetMedian = calcNetCH(ch[1]);
  const itNetMedian = calcNetIT(it[1]);

--- a/services/cantonSalary.ts
+++ b/services/cantonSalary.ts
@@ -1,0 +1,36 @@
+/**
+ * cantonSalary.ts — SPA-side per-canton salary scaling.
+ *
+ * The SalaryCompare stats page holds national-CH gross figures (SALARY_DATA).
+ * To show a single canton, the national figure is scaled by the canton's wage
+ * level relative to the national median, using the same official BFS index
+ * (data/swiss-canton-salary-index.json) that drives the pipeline estimator and
+ * the SEO prose. Reading the JSON keeps this in lock-step with that single
+ * source of truth (no duplicated constants).
+ */
+import index from '@/data/swiss-canton-salary-index.json';
+
+/** Sentinel for the national (all-Switzerland) view — scale 1.0. */
+export const NATIONAL_CANTON = 'CH';
+
+const CANTON_TO_REGION = index.cantonToGrossregion as Record<string, string>;
+const REGION_MEDIAN = index.grossregionMedianMonthly as Record<string, number>;
+const NATIONAL_MEDIAN = index.nationalMedianMonthly as number;
+
+/** BFS canton codes that have a salary mapping, in a stable order. */
+export const SALARY_CANTON_CODES: readonly string[] = Object.freeze(
+  Object.keys(CANTON_TO_REGION).sort(),
+);
+
+/**
+ * Scale a national-CH gross salary to a canton: grossregionMedian /
+ * nationalMedian. The national sentinel (or any unknown code) returns 1.0, so
+ * the default view is unchanged.
+ */
+export function cantonGrossScale(code: string | null | undefined): number {
+  const c = String(code || '').toUpperCase().trim();
+  if (!c || c === NATIONAL_CANTON) return 1;
+  const region = CANTON_TO_REGION[c];
+  const median = REGION_MEDIAN[region];
+  return region && median && NATIONAL_MEDIAN ? median / NATIONAL_MEDIAN : 1;
+}

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -292,6 +292,8 @@ const deCore: Record<string, string> = {
  'salaryCompare.tabProfessions': 'Nach Beruf',
  'salaryCompare.searchProfession': 'Beruf suchen...',
  'salaryCompare.allSectors': 'Alle Branchen',
+ 'salaryCompare.canton': 'Kanton',
+ 'salaryCompare.cantonAll': 'Schweiz (nationaler Durchschnitt)',
  'salaryCompare.salaryRange': 'Gehaltsspanne',
  'salaryCompare.median': 'Median',
  'salaryCompare.professions': 'Berufe',
@@ -3343,6 +3345,9 @@ Regeln:
  'publisher.published.publishAnother': 'Weiteres Inserat aufgeben',
 
  // ── What's New v3.50.0 (publisher portal redesign) ──
+ 'whatsNew.v3520.title': 'Löhne nach Kanton',
+ 'whatsNew.v3520.cantonSalary.title': 'Lohnvergleich Kanton für Kanton',
+ 'whatsNew.v3520.cantonSalary.desc': 'Der Lohnvergleich hat jetzt eine Kantonsauswahl: Wählen Sie einen Schweizer Kanton und die Brutto- und Nettowerte passen sich dem realen Lohnniveau dieser Region an, basierend auf offiziellen BFS-Medianen (Lohnstrukturerhebung). Standard: Schweizer Landesdurchschnitt.',
  'whatsNew.v3510.title': 'Gesponserte Inserate verbessert',
  'whatsNew.v3510.sponsoredUpgrade.title': 'Premium-Anzeigenseite, Logo und Direktbewerbung',
  'whatsNew.v3510.sponsoredUpgrade.desc': 'Gesponserte Inserate erscheinen jetzt ganz oben in den Suchergebnissen, zeigen das Firmenlogo und erhalten eine überarbeitete Seite mit formatierten Abschnitten und Listen. Neuer Editor mit Vorschau für Arbeitgeber und ein Bewerben-Button, der das Bewerbungsformular öffnet.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -289,6 +289,8 @@ const enCore: Record<string, string> = {
  'salaryCompare.tabProfessions': 'By Profession',
  'salaryCompare.searchProfession': 'Search profession...',
  'salaryCompare.allSectors': 'All sectors',
+ 'salaryCompare.canton': 'Canton',
+ 'salaryCompare.cantonAll': 'Switzerland (national average)',
  'salaryCompare.salaryRange': 'Salary Range',
  'salaryCompare.median': 'Median',
  'salaryCompare.professions': 'Professions',
@@ -3340,6 +3342,9 @@ Rules:
  'publisher.published.publishAnother': 'Post another ad',
 
  // ── What's New v3.50.0 (publisher portal redesign) ──
+ 'whatsNew.v3520.title': 'Salaries by canton',
+ 'whatsNew.v3520.cantonSalary.title': 'Canton-by-canton salary comparison',
+ 'whatsNew.v3520.cantonSalary.desc': 'The salary comparison now has a canton selector: pick a Swiss canton and the gross and net figures adapt to that region’s real wage level, based on official BFS medians (Swiss earnings structure survey). Default: Swiss national average.',
  'whatsNew.v3510.title': 'Sponsored listings upgraded',
  'whatsNew.v3510.sponsoredUpgrade.title': 'Premium ad page, logo and direct application',
  'whatsNew.v3510.sponsoredUpgrade.desc': 'Sponsored listings now rise to the top of search results, show the company logo and get a refreshed dedicated page with formatted sections and lists. New editor with preview for employers, and an Apply button that opens the application form.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -292,6 +292,8 @@ const frCore: Record<string, string> = {
  'salaryCompare.tabProfessions': 'Par Profession',
  'salaryCompare.searchProfession': 'Rechercher profession...',
  'salaryCompare.allSectors': 'Tous les secteurs',
+ 'salaryCompare.canton': 'Canton',
+ 'salaryCompare.cantonAll': 'Suisse (moyenne nationale)',
  'salaryCompare.salaryRange': 'Fourchette salariale',
  'salaryCompare.median': 'Médian',
  'salaryCompare.professions': 'Professions',
@@ -3343,6 +3345,9 @@ Règles :
  'publisher.published.publishAnother': 'Publier une autre annonce',
 
  // ── What's New v3.50.0 (publisher portal redesign) ──
+ 'whatsNew.v3520.title': 'Salaires par canton',
+ 'whatsNew.v3520.cantonSalary.title': 'Comparaison des salaires canton par canton',
+ 'whatsNew.v3520.cantonSalary.desc': 'La comparaison des salaires a désormais un sélecteur de canton : choisissez un canton suisse et les montants bruts et nets s’adaptent au niveau réel des salaires de cette région, sur la base des médianes officielles OFS (enquête sur la structure des salaires). Par défaut : moyenne nationale suisse.',
  'whatsNew.v3510.title': 'Annonces sponsorisées améliorées',
  'whatsNew.v3510.sponsoredUpgrade.title': 'Page d’annonce premium, logo et candidature directe',
  'whatsNew.v3510.sponsoredUpgrade.desc': 'Les annonces sponsorisées remontent désormais en tête des résultats de recherche, affichent le logo de l’entreprise et bénéficient d’une page dédiée repensée avec sections et listes mises en forme. Nouvel éditeur avec aperçu pour les employeurs et bouton Postuler qui ouvre le formulaire de candidature.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -308,6 +308,8 @@ const translations: Record<string, string> = {
  'salaryCompare.tabProfessions': 'Per Professione',
  'salaryCompare.searchProfession': 'Cerca professione...',
  'salaryCompare.allSectors': 'Tutti i settori',
+ 'salaryCompare.canton': 'Cantone',
+ 'salaryCompare.cantonAll': 'Svizzera (media nazionale)',
  'salaryCompare.salaryRange': 'Range salariale',
  'salaryCompare.median': 'Mediano',
  'salaryCompare.professions': 'Professioni',
@@ -3430,6 +3432,9 @@ Regole:
  'publisher.published.publishAnother': 'Pubblica un altro annuncio',
 
  // ── What's New v3.50.0 (publisher portal redesign) ──
+ 'whatsNew.v3520.title': 'Stipendi per cantone',
+ 'whatsNew.v3520.cantonSalary.title': 'Confronto stipendi cantone per cantone',
+ 'whatsNew.v3520.cantonSalary.desc': 'Il confronto stipendi ora ha un selettore per cantone: scegli un cantone svizzero e le cifre lorde e nette si adattano al livello salariale reale di quella regione, sulla base delle mediane ufficiali BFS (rilevazione struttura salari). Predefinito: media nazionale svizzera.',
  'whatsNew.v3510.title': 'Annunci sponsorizzati potenziati',
  'whatsNew.v3510.sponsoredUpgrade.title': 'Pagina annuncio premium, logo e candidatura diretta',
  'whatsNew.v3510.sponsoredUpgrade.desc': 'Gli annunci sponsorizzati ora salgono in cima ai risultati di ricerca, mostrano il logo aziendale e hanno una pagina dedicata rinnovata con sezioni ed elenchi formattati. Nuovo editor con anteprima per le aziende e bottone Candidati che apre il modulo di candidatura.',


### PR DESCRIPTION
## Implementato

Estende la pagina **Confronto Stipendi** (`/confronta-stipendi/`, tab Statistiche) con una dimensione **per-cantone**, completando il lato SPA del lavoro per-cantone iniziato in PR #2068.

- **Selettore cantone** in SalaryCompare — default **"Svizzera (media nazionale)"** → la vista esistente resta invariata byte-per-byte.
- Scegliendo un cantone, le cifre **lorde CH** (e le nette derivate) vengono scalate al livello salariale reale della regione tramite `factor = medianaGrossregion / medianaNazionale` dall'**index BFS ufficiale** `data/swiss-canton-salary-index.json` — stessa singola sorgente che guida l'estimatore della pipeline e la prose SEO (nessuna costante duplicata).
- **`services/cantonSalary.ts`** — modulo SPA-safe che legge il JSON ed espone `cantonGrossScale(code)`.
- Scaling applicato a **tutti** i punti CH: vista settori (`getSectorMedian`) + le 4 viste professioni (`p.ch[level]`) + export PDF; etichette colonna **CH → codice cantone** dinamiche quando un cantone è selezionato.
- **i18n** it/en/de/fr (`salaryCompare.canton`, `salaryCompare.cantonAll`) + entry **WhatsNew 3.52.0**.
- Verifiche: `tsc --noEmit` pulito sui file toccati; test i18n-completeness/guard/i18n verdi (parità chiavi tra i 4 locali).

## Non implementato (ancora)

- **Tassazione netta cantonale specifica:** il **lordo** è canton-scaled, ma il **netto** usa ancora l'approssimazione fiscale nazionale (`calcNetCH`) applicata al lordo scalato. Un modello d'imposta alla fonte per-cantone è **follow-up** (il netto reale varia per cantone oltre al lordo).
- **`data/salaryData.ts`** (`SECTOR_METADATA`, `getJobSalaryContext` nel dettaglio job SPA `JobBoard.tsx`) non ancora canton-scaled — **follow-up** (superficie UI separata).
- **Landing statistiche salari per-cantone dedicate** + **professionLandings per-cantone**: creano **nuove famiglie di SEO landing** → soggette al **moratorium SEO** (richiedono conferma owner che la posizione GSC 7-day avg sia ≤ 7.5). **Non in questa PR**; da sbloccare con la verifica del gate.

Nessun claim build/memoria non validabile (cambiamento SPA, typecheck + test unit verdi).
