### PR TITLE
fix(reddit): align subreddit config to real owned communities (frontaliere)

### DIFF
--- a/data/reddit-subreddits.json
+++ b/data/reddit-subreddits.json
@@ -1,10 +1,11 @@
 {
   "schemaVersion": 1,
   "subreddits": {
+    "frontaliere": { "displayName":"r/frontaliere", "topics":["jobs","articles"], "allowsAutomation": true, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/frontaliere/about/rules/", "minPostIntervalHours": 6, "notes":"OWN community (moderated by us). Primary automation target since we set the rules." },
+    "FrontaliereTicino": { "displayName":"r/FrontaliereTicino", "topics":["jobs","articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/FrontaliereTicino/about/rules/", "minPostIntervalHours": 6, "notes":"OWN community (moderated by us). Secondary channel — flip allowsAutomation to true to also post here." },
     "Ticino": { "displayName":"r/Ticino", "topics":["jobs","articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/Ticino/about/rules/", "minPostIntervalHours": 24, "notes":"Local Ticino community. Self-promo/job spam restricted — requires manual mod approval before enabling automation." },
     "italiansinswitzerland": { "displayName":"r/italiansinswitzerland", "topics":["jobs","articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/italiansinswitzerland/about/rules/", "minPostIntervalHours": 24, "notes":"Italian-speaking expats in CH — strong audience fit. Confirm self-promo policy with mods first." },
-    "Svizzera": { "displayName":"r/Svizzera", "topics":["articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/Svizzera/about/rules/", "minPostIntervalHours": 48, "notes":"General Swiss-Italian sub. Articles only; no job dumping." },
-    "frontalieri": { "displayName":"r/frontalieri", "topics":["jobs","articles"], "allowsAutomation": true, "flairId": null, "flairText": null, "rulesUrl":"", "minPostIntervalHours": 6, "notes":"OWN community to create/control (see docs). Safe default automation target since we set the rules. Create it if it does not exist." }
+    "Svizzera": { "displayName":"r/Svizzera", "topics":["articles"], "allowsAutomation": false, "flairId": null, "flairText": null, "rulesUrl":"https://www.reddit.com/r/Svizzera/about/rules/", "minPostIntervalHours": 48, "notes":"General Swiss-Italian sub. Articles only; no job dumping." }
   },
-  "routing": { "jobs": ["frontalieri","Ticino","italiansinswitzerland"], "articles": ["frontalieri","Ticino","italiansinswitzerland","Svizzera"] }
+  "routing": { "jobs": ["frontaliere","FrontaliereTicino","Ticino","italiansinswitzerland"], "articles": ["frontaliere","FrontaliereTicino","Ticino","italiansinswitzerland","Svizzera"] }
 }

--- a/docs/REDDIT-POSTING.md
+++ b/docs/REDDIT-POSTING.md
@@ -17,7 +17,7 @@ Si rapporta al workflow Facebook così: condivide lo stesso punto di ancoraggio 
 |------|-------|
 | `scripts/lib/reddit-client.mjs` | Client OAuth2 di Reddit: grant via refresh-token (preferito) con fallback al password-grant per "script app"; token endpoint in Basic-auth; header `User-Agent` obbligatorio. |
 | `scripts/lib/reddit-templates.mjs` | Builder dei post in italiano (titolo + corpo markdown per le offerte, titolo + link per gli articoli). |
-| `data/reddit-subreddits.json` | Configurazione dei subreddit: `displayName`, `topics`, `allowsAutomation`, `flairId`, `flairText`, `rulesUrl`, `minPostIntervalHours`, `notes`, più `routing` per `jobs`/`articles`. Solo `frontalieri` ha `allowsAutomation: true` di default. |
+| `data/reddit-subreddits.json` | Configurazione dei subreddit: `displayName`, `topics`, `allowsAutomation`, `flairId`, `flairText`, `rulesUrl`, `minPostIntervalHours`, `notes`, più `routing` per `jobs`/`articles`. Solo `frontaliere` (community propria) ha `allowsAutomation: true` di default; `FrontaliereTicino` è un secondo canale proprio pronto da attivare. |
 | `scripts/post-to-reddit.mjs` | Pubblicazione di un singolo **articolo**. CLI: `node scripts/post-to-reddit.mjs <article-id> <article-url> <og-title> <og-description> [category] [--dry-run]`. Soft-fail (exit 0). |
 | `scripts/schedule-reddit-jobs-daily.mjs` | Pubblicazione giornaliera delle **offerte**. Env: `REDDIT_JOB_VOLUME` (default 2), `REDDIT_POST_DELAY_MS` (default 5000), `DRY_RUN`. Aggiorna `data/reddit-posted-jobs.json`. |
 | `scripts/lib/resolve-reddit-posted-jobs-conflict.mjs` | Merge-driver per risolvere i conflitti git sul ledger (unione per job id). |
@@ -68,7 +68,7 @@ Imposta questi parametri in Firebase Remote Config (i secret con prefisso `SERVE
 ## Regole delle community & anti-spam
 
 - **Regola 9:1 di Reddit.** L'autopromozione deve restare minoritaria: per ogni post promozionale dovresti avere ~9 contributi non promozionali (commenti, risposte, contenuti utili). Spammare offerte/link viola questa regola e porta a shadowban o ban.
-- **La maggior parte dei subreddit vieta lo spam di offerte.** Community come r/Ticino, r/Svizzera, r/italiansinswitzerland proibiscono il posting automatico di annunci e richiedono l'**approvazione dei moderatori**. Per questo `allowsAutomation` è `false` di default su tutti i subreddit tranne il nostro **r/frontalieri** (safe-by-default: si auto-pubblica solo sulla nostra community finché un umano non ottiene il permesso dei mod altrove).
+- **La maggior parte dei subreddit vieta lo spam di offerte.** Community come r/Ticino, r/Svizzera, r/italiansinswitzerland proibiscono il posting automatico di annunci e richiedono l'**approvazione dei moderatori**. Per questo `allowsAutomation` è `false` di default su tutti i subreddit tranne la nostra community **r/frontaliere** (safe-by-default: si auto-pubblica solo sulla nostra community finché un umano non ottiene il permesso dei mod altrove). Anche **r/FrontaliereTicino** è di nostra proprietà ed è già presente nel routing come secondo canale, ma lasciato `allowsAutomation: false` finché non si decide di usarlo.
 - **Nessuno scheduling lato server.** Reddit non offre code di pubblicazione programmata: lo script pubblica **subito**, a basso volume (default 2/run) e con un `REDDIT_POST_DELAY_MS` (default 5000 ms) tra un post e l'altro.
 
 ### Abilitare un subreddit di terze parti (passi manuali)
@@ -79,11 +79,11 @@ Imposta questi parametri in Firebase Remote Config (i secret con prefisso `SERVE
 4. In `data/reddit-subreddits.json` imposta `allowsAutomation: true` per quel subreddit e compila `flairId`/`flairText` e `rulesUrl`.
 5. Aggiungi il subreddit alle liste `routing.jobs` e/o `routing.articles` secondo i `topics`.
 
-## Gestire una community propria (r/frontalieri)
+## Gestire una community propria (r/frontaliere)
 
 Il canale sicuro e controllato è un subreddit di nostra proprietà:
 
-1. Crea il subreddit (es. r/frontalieri) dal tuo account; diventi automaticamente moderatore.
+1. Il subreddit **r/frontaliere** è già stato creato dal nostro account, che ne è moderatore (esiste anche **r/FrontaliereTicino**, secondo canale).
 2. Definisci regole e flair coerenti con i contenuti (offerte + articoli).
 3. Poiché ne sei mod, l'automazione è consentita senza dipendere dall'approvazione di terzi: è l'unico subreddit con `allowsAutomation: true` di default.
 4. Mantieni un rapporto sano contenuti utili / promozioni anche qui, per far crescere la community e non scoraggiare gli iscritti.
@@ -151,5 +151,6 @@ https://frontaliereticino.ch/blog/richiesta-permesso-g-step-by-step-2026
 - **Access token a vita breve (~1 h).** Il client deve rinnovarlo a ogni run; con il password-grant questo richiede credenziali valide, con il refresh-token grant richiede un `REDDIT_REFRESH_TOKEN` non revocato.
 - **Rischio anti-spam / ban.** Volume alto, mancato rispetto della regola 9:1 o posting in subreddit non consenzienti possono portare a shadowban o ban dell'account.
 - **Nessuno scheduling nativo.** A differenza di Facebook, Reddit pubblica subito: il throttling è solo client-side (volume basso + delay).
-- **Dipendenza dall'approvazione dei mod.** L'espansione oltre r/frontalieri richiede il permesso esplicito dei moderatori di ogni subreddit.
+- **Dipendenza dall'approvazione dei mod.** L'espansione oltre r/frontaliere richiede il permesso esplicito dei moderatori di ogni subreddit.
+- **Approvazione Data API (Responsible Builder Policy, dal 11-nov-2025).** Reddit richiede l'approvazione preventiva di una *Data Access Request* prima di poter creare l'app API (anche script/personale). Finché non è approvata, gli script restano in soft-skip.
 - **Flair id da scoprire manualmente.** I `flairId`/`flairText` richiesti da molte community vanno recuperati a mano e inseriti in `data/reddit-subreddits.json`.

--- a/tests/scripts/schedule-reddit-jobs-daily.test.ts
+++ b/tests/scripts/schedule-reddit-jobs-daily.test.ts
@@ -113,7 +113,7 @@ function hoursAgo(n: number, base: Date = NOW): string {
 const CONFIG: RedditConfig = {
   schemaVersion: 1,
   subreddits: {
-    frontalieri: {
+    frontaliere: {
       allowsAutomation: true,
       minPostIntervalHours: 6,
       flairId: null,
@@ -128,7 +128,7 @@ const CONFIG: RedditConfig = {
       topics: ['jobs', 'articles'],
     },
   },
-  routing: { jobs: ['frontalieri', 'Ticino'], articles: ['frontalieri', 'Ticino'] },
+  routing: { jobs: ['frontaliere', 'Ticino'], articles: ['frontaliere', 'Ticino'] },
 };
 
 function makeJob(id: string, ageDays: number, overrides: Partial<JobLike> = {}): JobLike {
@@ -184,7 +184,7 @@ function makeFetchMock() {
         JSON.stringify({
           json: {
             errors: [],
-            data: { id: 'abc', name: 't3_abc', url: 'https://reddit.com/r/frontalieri/comments/abc/' },
+            data: { id: 'abc', name: 't3_abc', url: 'https://reddit.com/r/frontaliere/comments/abc/' },
           },
         }),
         { status: 200 },
@@ -207,7 +207,7 @@ const CREDS = {
 describe('eligibleSubsForTopic', () => {
   it('returns only allowsAutomation:true subs routed for the topic', () => {
     const out = eligibleSubsForTopic(CONFIG, 'jobs');
-    expect(out.map((s) => s.name)).toEqual(['frontalieri']);
+    expect(out.map((s) => s.name)).toEqual(['frontaliere']);
     expect(out[0].config.allowsAutomation).toBe(true);
   });
 
@@ -230,39 +230,39 @@ describe('eligibleSubsForTopic', () => {
 describe('isRateLimited', () => {
   it('is true when the last post is within minIntervalHours of now', () => {
     const posted: PostedEntry[] = [
-      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(2) },
+      { id: 'x', url: 'u', subreddit: 'frontaliere', ts: hoursAgo(2) },
     ];
-    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(true);
+    expect(isRateLimited(posted, 'frontaliere', 6, NOW)).toBe(true);
   });
 
   it('is false when the last post is older than minIntervalHours', () => {
     const posted: PostedEntry[] = [
-      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(10) },
+      { id: 'x', url: 'u', subreddit: 'frontaliere', ts: hoursAgo(10) },
     ];
-    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(false);
+    expect(isRateLimited(posted, 'frontaliere', 6, NOW)).toBe(false);
   });
 
   it('is false when the sub was never posted to', () => {
     const posted: PostedEntry[] = [
       { id: 'x', url: 'u', subreddit: 'other', ts: hoursAgo(1) },
     ];
-    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(false);
+    expect(isRateLimited(posted, 'frontaliere', 6, NOW)).toBe(false);
   });
 
   it('is false when minIntervalHours is 0/undefined (limit disabled)', () => {
     const posted: PostedEntry[] = [
-      { id: 'x', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(0.1) },
+      { id: 'x', url: 'u', subreddit: 'frontaliere', ts: hoursAgo(0.1) },
     ];
-    expect(isRateLimited(posted, 'frontalieri', 0, NOW)).toBe(false);
-    expect(isRateLimited(posted, 'frontalieri', undefined, NOW)).toBe(false);
+    expect(isRateLimited(posted, 'frontaliere', 0, NOW)).toBe(false);
+    expect(isRateLimited(posted, 'frontaliere', undefined, NOW)).toBe(false);
   });
 
   it('uses the most recent entry when several exist', () => {
     const posted: PostedEntry[] = [
-      { id: 'old', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(20) },
-      { id: 'new', url: 'u', subreddit: 'frontalieri', ts: hoursAgo(1) },
+      { id: 'old', url: 'u', subreddit: 'frontaliere', ts: hoursAgo(20) },
+      { id: 'new', url: 'u', subreddit: 'frontaliere', ts: hoursAgo(1) },
     ];
-    expect(isRateLimited(posted, 'frontalieri', 6, NOW)).toBe(true);
+    expect(isRateLimited(posted, 'frontaliere', 6, NOW)).toBe(true);
   });
 });
 
@@ -275,10 +275,10 @@ describe('run() — DRY_RUN', () => {
     const cfg: RedditConfig = {
       schemaVersion: 1,
       subreddits: {
-        frontalieri: { allowsAutomation: true, minPostIntervalHours: 0 },
+        frontaliere: { allowsAutomation: true, minPostIntervalHours: 0 },
         Ticino: { allowsAutomation: false, minPostIntervalHours: 24 },
       },
-      routing: { jobs: ['frontalieri', 'Ticino'], articles: ['frontalieri'] },
+      routing: { jobs: ['frontaliere', 'Ticino'], articles: ['frontaliere'] },
     };
     const tmp = setupTmp({ jobs: [makeJob('A', 1), makeJob('B', 2)], config: cfg });
     const fetchSpy = vi.fn<typeof fetch>();
@@ -297,7 +297,7 @@ describe('run() — DRY_RUN', () => {
     expect(result.payloads).toHaveLength(2);
     // Recency: A (1 day ago) before B (2 days ago).
     expect(result.payloads[0].jobId).toBe('A');
-    expect(result.payloads[0].subreddit).toBe('frontalieri');
+    expect(result.payloads[0].subreddit).toBe('frontaliere');
     expect(result.payloads[0].kind).toBe('self');
 
     expect(loadLedger(tmp).posted).toHaveLength(0);
@@ -326,7 +326,7 @@ describe('run() — real posting', () => {
     const ledger = loadLedger(tmp);
     expect(ledger.posted).toHaveLength(1);
     expect(ledger.posted[0].id).toBe('A');
-    expect(ledger.posted[0].subreddit).toBe('frontalieri');
+    expect(ledger.posted[0].subreddit).toBe('frontaliere');
     expect(ledger.posted[0].redditPostId).toBe('t3_abc');
   });
 
@@ -335,7 +335,7 @@ describe('run() — real posting', () => {
     const tmp = setupTmp({
       jobs: [makeJob('A', 1), makeJob('B', 2)],
       posted: [
-        { id: 'A', url: 'u', subreddit: 'frontalieri', ts: daysAgo(5) },
+        { id: 'A', url: 'u', subreddit: 'frontaliere', ts: daysAgo(5) },
       ],
     });
     const fetchSpy = makeFetchMock();
@@ -394,7 +394,7 @@ describe('re-exported helpers', () => {
   it('loadSubreddits reads the controlled config from a temp repoRoot', () => {
     const tmp = setupTmp({ jobs: [] });
     const cfg = loadSubreddits(tmp);
-    expect(cfg.routing.jobs).toEqual(['frontalieri', 'Ticino']);
-    expect(cfg.subreddits.frontalieri.allowsAutomation).toBe(true);
+    expect(cfg.routing.jobs).toEqual(['frontaliere', 'Ticino']);
+    expect(cfg.subreddits.frontaliere.allowsAutomation).toBe(true);
   });
 });


### PR DESCRIPTION
Allinea la config Reddit ai subreddit realmente esistenti e moderati dall'account. Il placeholder `frontalieri` non è mai esistito; le community proprie sono **r/frontaliere** (primaria) e **r/FrontaliereTicino**.

## Implementato
- `data/reddit-subreddits.json`: rinominata la chiave automation-enabled `frontalieri` → **`frontaliere`** (`allowsAutomation: true`, target primario) con `rulesUrl` reale.
- Aggiunta **`FrontaliereTicino`** come secondo canale proprio, `allowsAutomation: false` di default (basta metterlo a `true` per pubblicare anche lì).
- Aggiornate `routing.jobs` e `routing.articles` con i nuovi nomi.
- `docs/REDDIT-POSTING.md`: riferimenti `r/frontalieri` → `r/frontaliere`, documentato il secondo canale e il gate di approvazione Data API (Responsible Builder Policy, in vigore 11-nov-2025).
- Allineato il nome-sub nella fixture self-contained di `tests/scripts/schedule-reddit-jobs-daily.test.ts` per coerenza.
- Test: **75/75 verdi** (reddit-templates 12 + schedule-reddit 14 + schedule-fb 49).

## Non implementato (ancora)
- **`flairId`/`flairText` reali**: restano `null` — vanno scoperti per ogni sub che richiede flair (passo manuale documentato). Follow-up.
- **Attivazione di r/FrontaliereTicino e dei sub di terze parti**: lasciati `allowsAutomation: false` di proposito (scelta umana / permesso mod).
- **Credenziali OAuth Reddit**: non incluse — l'app Data API è in attesa di approvazione Reddit (Data Access Request inoltrata 2026-06-15). Finché i secret RC non esistono, gli script restano in soft-skip. Nessun trigger di revert: cambiamento solo dati/doc, nessun impatto runtime.

La parola comune italiana "frontalieri" (lavoratori frontalieri) altrove nel codice è intenzionalmente lasciata invariata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)