### PR TITLE
feat(newsletter): subject-line A/B test + per-provider open-rate report

### DIFF
--- a/scripts/newsletter-ab-report.mjs
+++ b/scripts/newsletter-ab-report.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+/**
+ * newsletter-ab-report.mjs — Subject-line A/B open-rate report, per provider.
+ *
+ * Answers the goal: "which subject-line variant wins the open rate, broken down
+ * by sending provider?" Cross-tabulates open rate by (provider × variant) for a
+ * weekly campaign and flags the per-provider winner with a significance note.
+ *
+ * Design — immune to the per-provider webhook inconsistencies:
+ *  - DENOMINATOR (sends) comes from the send-time `campaign_deliveries` docs,
+ *    where `provider` is authoritative for every cascade provider.
+ *  - VARIANT is RE-COMPUTED deterministically via assignSubjectVariant(email,
+ *    campaignId) — so it never depends on what a given provider's webhook stored
+ *    (only Resend reads tags.variant). The persisted `variant` is used only as a
+ *    cross-check.
+ *  - NUMERATOR (opens) is an OR of signals so no provider is under-counted:
+ *      (a) `opened_at` on the send doc (Resend + any same-doc provider), plus
+ *      (b) an 'open' event in the subscriber `events` subcollection for this
+ *          campaign (matched by email or message_id) — every provider writes
+ *          these, sidestepping the send-doc id divergence between providers.
+ *
+ * Usage:
+ *   node scripts/newsletter-ab-report.mjs                       # latest weekly campaign
+ *   node scripts/newsletter-ab-report.mjs --campaign weekly_2026-06-16
+ *   node scripts/newsletter-ab-report.mjs --json               # machine-readable
+ *
+ * Env: GOOGLE_APPLICATION_CREDENTIALS (Firebase SA), GCLOUD_PROJECT.
+ * Read-only — never writes to Firestore.
+ */
+
+import { assignSubjectVariant, listVariantIds } from '../services/newsletter-subject-variants.mjs';
+
+const args = process.argv.slice(2);
+const JSON_OUT = args.includes('--json');
+function argValue(flag) {
+  const i = args.indexOf(flag);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
+}
+
+/** Default campaign id = current week's Monday, matching send-newsletter.mjs. */
+function currentWeeklyCampaignId() {
+  const now = new Date();
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - now.getDay() + 1);
+  return `weekly_${monday.toISOString().slice(0, 10)}`;
+}
+
+async function initFirebase() {
+  const admin = await import('firebase-admin');
+  const a = admin.default || admin;
+  if (!a.apps?.length) {
+    a.initializeApp({
+      credential: a.credential.applicationDefault(),
+      projectId: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || 'frontaliere-ticino',
+    });
+  }
+  return a.firestore();
+}
+
+/** Standard normal CDF (Abramowitz–Stegun erf approximation). */
+function normalCdf(z) {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989423 * Math.exp(-z * z / 2);
+  const p = d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  return z > 0 ? 1 - p : p;
+}
+
+/**
+ * Two-proportion z-test (two-sided). Returns { z, pValue } or null if either
+ * sample is empty.
+ */
+function twoProportionTest(a, b) {
+  if (!a.sends || !b.sends) return null;
+  const p1 = a.opens / a.sends;
+  const p2 = b.opens / b.sends;
+  const pPool = (a.opens + b.opens) / (a.sends + b.sends);
+  const se = Math.sqrt(pPool * (1 - pPool) * (1 / a.sends + 1 / b.sends));
+  if (se === 0) return { z: 0, pValue: 1 };
+  const z = (p1 - p2) / se;
+  const pValue = 2 * (1 - normalCdf(Math.abs(z)));
+  return { z, pValue };
+}
+
+const pct = (n, d) => (d > 0 ? (100 * n / d) : 0);
+
+async function main() {
+  const campaignId = argValue('--campaign') || currentWeeklyCampaignId();
+  const variantIds = listVariantIds();
+  if (!JSON_OUT) {
+    console.log(`\n📊 Newsletter subject A/B report — campaign ${campaignId}`);
+    console.log(`   Variants: ${variantIds.join(', ')}\n`);
+  }
+
+  const db = await initFirebase();
+
+  // Both queries filter on `campaign_id` only (single-field collectionGroup
+  // index) and refine in memory — avoids requiring a composite index. If the
+  // single-field collectionGroup index is missing, Firestore returns a
+  // FAILED_PRECONDITION with a one-click creation URL, surfaced below.
+  const runQuery = async (group, label) => {
+    try {
+      return await db.collectionGroup(group).where('campaign_id', '==', campaignId).get();
+    } catch (e) {
+      if (String(e?.message || '').includes('index')) {
+        console.error(`❌ Missing Firestore collectionGroup index for "${group}.campaign_id".`);
+        console.error(`   Create it via the link in this error, then re-run:\n   ${e.message}`);
+        process.exit(2);
+      }
+      throw e;
+    }
+  };
+
+  // ── 1. Sends (denominator) + same-doc opens ──
+  const sendSnap = await runQuery('campaign_deliveries', 'sends');
+
+  // ── 2. Opens (numerator) from the events subcollection for this campaign ──
+  // Every provider writes an 'open' event with provider + campaign_id, even when
+  // its delivery-doc id diverges from the send doc.
+  const openSnap = await runQuery('events', 'opens');
+
+  const openedEmails = new Set();
+  const openedMsgIds = new Set();
+  for (const doc of openSnap.docs) {
+    const d = doc.data();
+    if (d.event_type !== 'open') continue; // refine in memory (no composite index)
+    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
+    if (email) openedEmails.add(email);
+    if (d.message_id) openedMsgIds.add(String(d.message_id));
+  }
+
+  // cells[provider][variant] = { sends, opens }
+  const cells = {};
+  const ensure = (provider, variant) => {
+    cells[provider] ??= {};
+    cells[provider][variant] ??= { sends: 0, opens: 0 };
+    return cells[provider][variant];
+  };
+
+  let totalSends = 0;
+  let mismatchVariant = 0;
+  for (const doc of sendSnap.docs) {
+    const d = doc.data();
+    if (!d.sent_at) continue; // only count real sends
+    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
+    if (!email) continue;
+    const provider = d.provider || 'unknown';
+    // Variant is recomputed (source of truth); cross-check against persisted.
+    const variant = assignSubjectVariant(email, campaignId);
+    if (d.variant && d.variant !== variant) mismatchVariant++;
+
+    const cell = ensure(provider, variant);
+    cell.sends++;
+    const opened = !!d.opened_at || openedEmails.has(email) || (d.message_id && openedMsgIds.has(String(d.message_id)));
+    if (opened) cell.opens++;
+    totalSends++;
+  }
+
+  if (totalSends === 0) {
+    console.log(`⚠️  No sends found for campaign "${campaignId}".`);
+    console.log(`   Check the campaign id (--campaign weekly_YYYY-MM-DD) or that this run sent emails.`);
+    process.exit(0);
+  }
+
+  // ── 3. Aggregate + winners ──
+  const providers = Object.keys(cells).sort();
+  const report = { campaignId, generatedAt: new Date().toISOString(), totalSends, providers: {}, byVariant: {} };
+
+  // Per-variant totals across providers
+  for (const v of variantIds) report.byVariant[v] = { sends: 0, opens: 0 };
+
+  for (const provider of providers) {
+    const variants = {};
+    for (const v of variantIds) {
+      const c = cells[provider]?.[v] || { sends: 0, opens: 0 };
+      variants[v] = { sends: c.sends, opens: c.opens, openRate: pct(c.opens, c.sends) };
+      report.byVariant[v].sends += c.sends;
+      report.byVariant[v].opens += c.opens;
+    }
+    // Winner = highest open rate among variants with ≥1 send.
+    let winner = null;
+    for (const v of variantIds) {
+      if (variants[v].sends > 0 && (!winner || variants[v].openRate > variants[winner].openRate)) winner = v;
+    }
+    let significance = null;
+    if (variantIds.length === 2) {
+      significance = twoProportionTest(
+        { sends: variants[variantIds[0]].sends, opens: variants[variantIds[0]].opens },
+        { sends: variants[variantIds[1]].sends, opens: variants[variantIds[1]].opens },
+      );
+    }
+    report.providers[provider] = { variants, winner, significance };
+  }
+
+  for (const v of variantIds) report.byVariant[v].openRate = pct(report.byVariant[v].opens, report.byVariant[v].sends);
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  // ── 4. Human-readable table ──
+  for (const provider of providers) {
+    const p = report.providers[provider];
+    console.log(`▸ ${provider}`);
+    for (const v of variantIds) {
+      const cell = p.variants[v];
+      const flag = p.winner === v && cell.sends > 0 ? '  ◀ winner' : '';
+      console.log(`    ${v.padEnd(10)} sends=${String(cell.sends).padStart(5)}  opens=${String(cell.opens).padStart(5)}  open-rate=${cell.openRate.toFixed(1).padStart(5)}%${flag}`);
+    }
+    if (p.significance) {
+      const sig = p.significance.pValue < 0.05 ? '✅ significant (p<0.05)' : `not yet significant (p=${p.significance.pValue.toFixed(2)})`;
+      const minSends = Math.min(...variantIds.map(v => p.variants[v].sends));
+      const note = minSends < 100 ? ' — small sample, keep collecting' : '';
+      console.log(`    → ${sig}${note}`);
+    }
+    console.log('');
+  }
+
+  console.log('Σ by variant (all providers):');
+  for (const v of variantIds) {
+    const b = report.byVariant[v];
+    console.log(`    ${v.padEnd(10)} sends=${String(b.sends).padStart(5)}  opens=${String(b.opens).padStart(5)}  open-rate=${b.openRate.toFixed(1).padStart(5)}%`);
+  }
+  if (mismatchVariant > 0) {
+    console.log(`\n⚠️  ${mismatchVariant} send docs had a persisted variant ≠ recomputed (assignment logic changed since send; report uses recomputed).`);
+  }
+  console.log('');
+}
+
+main().catch((e) => {
+  console.error('❌ Report failed:', e?.message || e);
+  process.exit(1);
+});

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -34,6 +34,7 @@ import { fileURLToPath } from 'node:url';
 import { buildNewsletter, FEATURED_TOOLS, getFeaturedTools, nlNormLocale, directUrl } from '../services/newsletter-template.mjs';
 import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, companyPageUrl, isCompanyHubSlug } from '../services/newsletter-content.mjs';
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
+import { assignSubjectVariant, getVariantFallback, listVariantIds } from '../services/newsletter-subject-variants.mjs';
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
@@ -1422,12 +1423,19 @@ async function persistDelivery(recipient, messageId, meta) {
     const deliveryDocId = `${meta.campaignId}__${email}`.replace(/[^a-z0-9@._-]+/gi, '-');
     // Store delivery as a subcollection under the subscriber doc
     await subRef.collection('campaign_deliveries').doc(deliveryDocId).set({
+      email,
       campaign_id: meta.campaignId,
       message_id: messageId || null,
       locale: recipient.locale || 'it',
       source_channel: recipient.sourceChannel || null,
       location_interest: recipient.locationInterest || null,
       sector_interest: recipient.sectorInterest || null,
+      // A/B subject test attribution — provider is authoritative here (every
+      // cascade provider), variant/subject mirror the sent email so the
+      // open-rate-by-provider×variant report has a self-contained send record.
+      provider: meta.provider || null,
+      variant: meta.variant || null,
+      subject: meta.subject || null,
       sent_at: new Date(),
     }, { merge: true });
     // Maileroo's open/click webhooks carry only message_reference_id (no recipient,
@@ -1994,15 +2002,20 @@ async function main() {
   }
   console.log(`  ✓ ${aiSuccessCount} AI briefings, ${aiFallbackCount} fallbacks`);
 
-  // ── Phase 3: Generate 1 AI subject per locale ──
-  console.log('✏️  Phase 3: AI subjects (1 per locale)...');
+  // ── Phase 3: Generate 1 AI subject per locale × A/B variant ──
+  // Subject-line A/B test: one subject per (locale, variant) so each subscriber
+  // gets the subject for their deterministically-assigned variant (Phase 5).
+  // Still cohort-cheap: at most locales × variants AI calls (≤8), not per-sub.
+  const variantIds = listVariantIds();
+  const subjectKey = (loc, variant) => `${loc}::${variant}`;
+  console.log(`✏️  Phase 3: AI subjects (${variantIds.length} variants/locale: ${variantIds.join(', ')})...`);
   const locales = [...new Set(subscriberData.map(d => d.locale))];
   const subjectMap = new Map();
 
   if (subjectOverride) {
-    for (const loc of locales) subjectMap.set(loc, subjectOverride);
+    for (const loc of locales) for (const v of variantIds) subjectMap.set(subjectKey(loc, v), subjectOverride);
   } else if (noAI) {
-    for (const loc of locales) subjectMap.set(loc, FALLBACK_SUBJECT[loc] || FALLBACK_SUBJECT.it);
+    for (const loc of locales) for (const v of variantIds) subjectMap.set(subjectKey(loc, v), getVariantFallback(v, loc));
   } else {
     // Pick a representative cohort per locale (the one with most members)
     const localeRepresentatives = new Map();
@@ -2014,7 +2027,9 @@ async function main() {
       }
     }
 
-    await pMap(locales, async (loc) => {
+    const localeVariantPairs = [];
+    for (const loc of locales) for (const variant of variantIds) localeVariantPairs.push({ loc, variant });
+    await pMap(localeVariantPairs, async ({ loc, variant }) => {
       const rep = localeRepresentatives.get(loc);
       const briefingText = rep?.briefing?.replace(/<[^>]+>/g, '').slice(0, 100) || '';
       const subject = await generateAISubject({
@@ -2022,11 +2037,12 @@ async function main() {
         exchangeRate,
         matchedJobs: rep?.matchedJobs || [],
         briefingSummary: briefingText,
+        variant,
       });
-      subjectMap.set(loc, subject || FALLBACK_SUBJECT[loc] || FALLBACK_SUBJECT.it);
-    }, locales.length); // All locale subjects in parallel (max 4)
+      subjectMap.set(subjectKey(loc, variant), subject || getVariantFallback(variant, loc));
+    }, Math.min(localeVariantPairs.length, AI_CONCURRENCY)); // bounded parallel AI calls
   }
-  console.log(`  ✓ ${subjectMap.size} subjects: ${[...subjectMap.entries()].map(([l, s]) => `${l}="${s}"`).join(', ')}`);
+  console.log(`  ✓ ${subjectMap.size} subjects: ${[...subjectMap.entries()].map(([k, s]) => `${k}="${s}"`).join(', ')}`);
 
   // ── Phase 4: Generate autologin codes (deterministic HMAC, no async needed) ──
   console.log('🔑 Phase 4: Autologin codes (HMAC)...');
@@ -2049,7 +2065,13 @@ async function main() {
 
   for (const { subscriber, locale, matchedJobs, cohortKey } of subscriberData) {
     const briefing = briefingMap.get(cohortKey);
-    const subject = subjectMap.get(locale);
+    // A/B test: deterministic per-subscriber variant (stable for this campaign).
+    // Fall back to the first variant's subject, then the variant fallback, so a
+    // missing (locale,variant) entry can never leave subject undefined.
+    const variant = assignSubjectVariant(subscriber.email, campaignId);
+    const subject = subjectMap.get(subjectKey(locale, variant))
+      || subjectMap.get(subjectKey(locale, variantIds[0]))
+      || getVariantFallback(variant, locale);
 
     const html = buildNewsletter({
       aiBriefing: briefing,
@@ -2074,7 +2096,7 @@ async function main() {
 
     emails.push({
       recipient: subscriber,
-      meta: { campaignId },
+      meta: { campaignId, subject, variant },
       payload: {
         from: FROM_EMAIL,
         to: [subscriber.email],
@@ -2086,6 +2108,9 @@ async function main() {
           { name: 'subscriber_locale', value: locale },
           { name: 'source_channel', value: subscriber.sourceChannel || 'newsletter_page' },
           { name: 'version', value: 'v2-ai-cohort' },
+          // A/B subject variant — read by the Resend webhook (tags.variant) and
+          // recomputed deterministically by scripts/newsletter-ab-report.mjs.
+          { name: 'variant', value: variant },
         ],
       },
     });

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -8,6 +8,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getVariantStyleDirective } from './newsletter-subject-variants.mjs';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 
@@ -778,6 +779,10 @@ export function buildSubjectPrompt(ctx) {
     fr: `Use "tu" voice, never "nous"`,
   };
 
+  // A/B test: bias the subject toward the assigned variant's style (concrete vs
+  // curious). Empty string when ctx.variant is unset/unknown → prompt unchanged.
+  const variantDirective = getVariantStyleDirective(ctx.variant, locale);
+
   const system = [
     `You are a world-class email copywriter for "Frontaliere Ticino", a fintech app for Swiss-Italian cross-border workers.`,
     `Write ONE email subject line in ${langName}. STRICTLY 35-50 characters including emoji. Count carefully.`,
@@ -785,6 +790,7 @@ export function buildSubjectPrompt(ctx) {
     ``,
     `PROVEN PATTERNS (pick one and adapt — stay in ${langName}):`,
     examples,
+    ...(variantDirective ? [``, variantDirective] : []),
     ``,
     `RULES:`,
     `- Start with ONE emoji (⚡💰📊🔥🤔📰🏦💼)`,

--- a/services/newsletter-subject-variants.mjs
+++ b/services/newsletter-subject-variants.mjs
@@ -1,0 +1,130 @@
+/**
+ * newsletter-subject-variants.mjs — Subject-line A/B test definitions.
+ *
+ * Goal: optimize newsletter open-rate PER SENDING PROVIDER by trying different
+ * subject-line styles. Each subscriber is deterministically assigned a variant
+ * for a given campaign (stable across the daily cron re-runs of the same weekly
+ * campaign, rotating across campaigns). The cascade then picks a provider by
+ * quota — independent of the variant — so every provider sees a ~50/50 mix of
+ * variants, making the provider×variant open-rate cross-tab valid.
+ *
+ * IMPORTANT — variant assignment is DETERMINISTIC, so the reporting script
+ * (`scripts/newsletter-ab-report.mjs`) can RE-COMPUTE the variant for any
+ * (email, campaignId) without relying on what was persisted. That makes the
+ * report immune to the per-provider divergence in webhook delivery-doc ids /
+ * campaign-id extraction. The variant is still persisted at send time + tagged
+ * on the outgoing email for observability and for the Resend webhook that reads
+ * `tags.variant`.
+ *
+ * Single source of truth: both `buildSubjectPrompt` (AI prompt biasing) and the
+ * send pipeline (fallback subjects) import from here — no copy-pasted variant
+ * text that could drift.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Lowercase+trim — must match scripts/send-newsletter.mjs normalizeEmail. */
+export function normalizeEmail(raw) {
+  return String(raw || '').trim().toLowerCase();
+}
+
+/**
+ * The two A/B variants. Two is the statistically-cheapest contrast and maps to
+ * the two dominant subject-line schools:
+ *   - `concreto`  → specificity-forward: numbers, locations, concrete benefit.
+ *   - `curioso`   → curiosity-forward: question / curiosity-gap / FOMO.
+ *
+ * `styleDirective[locale]` is injected into the AI subject prompt (kept in the
+ * target language to prevent the model drifting to Italian). `fallback[locale]`
+ * is used when AI generation fails — each MUST satisfy the inlineQaCheck gate
+ * (10..60 chars, no trailing "..."/"…", ≥1 three-letter word). Validated by
+ * tests/newsletter-subject-variants.test.ts.
+ */
+export const SUBJECT_VARIANTS = [
+  {
+    id: 'concreto',
+    label: 'Concrete / number-and-benefit',
+    styleDirective: {
+      it: 'STILE A/B "concreto": punta su numero + luogo + beneficio tangibile. Forme tipo "📊 3 aziende assumono a Lugano" o "💰 Simula il netto 2026 in 30 sec". Specifico e diretto, niente mistero.',
+      en: 'A/B STYLE "concrete": lead with a number + location + tangible benefit. Forms like "📊 3 companies hiring in Lugano" or "💰 Simulate your 2026 net pay in 30 sec". Specific and direct, no mystery.',
+      de: 'A/B-STIL "konkret": Zahl + Ort + greifbarer Nutzen. Formen wie "📊 3 Firmen stellen in Lugano ein" oder "💰 Nettolohn 2026 in 30 Sek berechnen". Konkret und direkt, kein Rätsel.',
+      fr: 'STYLE A/B "concret" : un chiffre + un lieu + un bénéfice tangible. Formes comme "📊 3 entreprises recrutent à Lugano" ou "💰 Simule ton net 2026 en 30 sec". Précis et direct, pas de mystère.',
+    },
+    fallback: {
+      it: '📊 Frontaliere: cambio, lavori e netto 2026',
+      en: '📊 Frontaliere: rates, jobs & 2026 net pay',
+      de: '📊 Grenzgänger: Kurs, Jobs & Netto 2026',
+      fr: '📊 Frontalier : taux, emplois & net 2026',
+    },
+  },
+  {
+    id: 'curioso',
+    label: 'Curiosity / question hook',
+    styleDirective: {
+      it: 'STILE A/B "curioso": apri un curiosity gap o una domanda che il lettore DEVE risolvere aprendo. Forme tipo "⚡ Il tasso CHF scende: quanto perdi?" o "🤔 Permesso G o B? Il calcolo che conta". Crea tensione, non svelare la risposta.',
+      en: 'A/B STYLE "curious": open a curiosity gap or a question the reader MUST resolve by opening. Forms like "⚡ The CHF rate is dropping: how much are you losing?" or "🤔 Permit G or B? The calc that matters". Build tension, do not reveal the answer.',
+      de: 'A/B-STIL "neugierig": eine Neugier-Lücke oder Frage, die der Leser nur durch Öffnen löst. Formen wie "⚡ CHF-Kurs fällt: wie viel verlierst du?" oder "🤔 Bewilligung G oder B? Die Rechnung zählt". Spannung aufbauen, die Antwort nicht verraten.',
+      fr: 'STYLE A/B "curieux" : ouvre un manque de curiosité ou une question que le lecteur DOIT résoudre en ouvrant. Formes comme "⚡ Le taux CHF baisse : combien tu perds ?" ou "🤔 Permis G ou B ? Le calcul qui compte". Crée la tension, ne révèle pas la réponse.',
+    },
+    fallback: {
+      it: '🤔 Frontaliere: quanto stai perdendo ora?',
+      en: '🤔 Frontaliere: how much are you losing now?',
+      de: '🤔 Grenzgänger: wie viel verlierst du gerade?',
+      fr: '🤔 Frontalier : combien perds-tu en ce moment ?',
+    },
+  },
+];
+
+/** Default variant id — used when none can be assigned. */
+export const DEFAULT_VARIANT_ID = SUBJECT_VARIANTS[0].id;
+
+/** @returns {string[]} ordered list of variant ids. */
+export function listVariantIds() {
+  return SUBJECT_VARIANTS.map((v) => v.id);
+}
+
+/** @returns {object|null} the variant config for `id`, or null. */
+export function getSubjectVariant(id) {
+  return SUBJECT_VARIANTS.find((v) => v.id === id) || null;
+}
+
+/**
+ * Deterministically assign a variant id for (email, campaignId).
+ * Stable for the lifetime of a campaign (so a subscriber never flip-flops across
+ * the daily cron re-runs of one weekly campaign) and rotates across campaigns
+ * (so the same subscriber isn't always in the same bucket).
+ *
+ * @param {string} email
+ * @param {string} campaignId
+ * @param {Array}  [variants=SUBJECT_VARIANTS]
+ * @returns {string} variant id
+ */
+export function assignSubjectVariant(email, campaignId, variants = SUBJECT_VARIANTS) {
+  const list = variants?.length ? variants : SUBJECT_VARIANTS;
+  const key = `${normalizeEmail(email)}|${String(campaignId || '')}`;
+  const digest = createHash('sha256').update(key).digest();
+  // Use a 4-byte unsigned int for a clean modulo with no first-byte skew.
+  const n = digest.readUInt32BE(0);
+  return list[n % list.length].id;
+}
+
+/**
+ * Variant-specific fallback subject for a locale, with safe degradation:
+ * unknown variant/locale → first variant's IT fallback.
+ * @returns {string}
+ */
+export function getVariantFallback(variantId, locale) {
+  const variant = getSubjectVariant(variantId) || SUBJECT_VARIANTS[0];
+  return variant.fallback[locale] || variant.fallback.it;
+}
+
+/**
+ * Style directive for the AI subject prompt. Empty string for unknown variant
+ * so callers can unconditionally concatenate.
+ * @returns {string}
+ */
+export function getVariantStyleDirective(variantId, locale) {
+  const variant = getSubjectVariant(variantId);
+  if (!variant) return '';
+  return variant.styleDirective[locale] || variant.styleDirective.it || '';
+}

--- a/tests/newsletter-subject-variants.test.ts
+++ b/tests/newsletter-subject-variants.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+const {
+  SUBJECT_VARIANTS,
+  DEFAULT_VARIANT_ID,
+  listVariantIds,
+  getSubjectVariant,
+  assignSubjectVariant,
+  getVariantFallback,
+  getVariantStyleDirective,
+  normalizeEmail,
+} = await import('@/services/newsletter-subject-variants.mjs');
+
+const { buildSubjectPrompt } = await import('@/services/newsletter-content.mjs');
+
+const LOCALES = ['it', 'en', 'de', 'fr'] as const;
+
+describe('SUBJECT_VARIANTS', () => {
+  it('defines at least two distinct variants', () => {
+    expect(SUBJECT_VARIANTS.length).toBeGreaterThanOrEqual(2);
+    const ids = listVariantIds();
+    expect(new Set(ids).size).toBe(ids.length); // unique ids
+  });
+
+  it('DEFAULT_VARIANT_ID is a real variant', () => {
+    expect(getSubjectVariant(DEFAULT_VARIANT_ID)).not.toBeNull();
+  });
+
+  for (const variant of SUBJECT_VARIANTS) {
+    describe(`variant ${variant.id}`, () => {
+      for (const loc of LOCALES) {
+        it(`fallback[${loc}] passes inline-QA gates`, () => {
+          const subject: string = variant.fallback[loc];
+          expect(subject, `missing fallback ${variant.id}/${loc}`).toBeDefined();
+          expect(subject.length).toBeGreaterThanOrEqual(10);
+          expect(subject.length).toBeLessThanOrEqual(60);
+          expect(subject.endsWith('...')).toBe(false);
+          expect(subject.endsWith('…')).toBe(false);
+          expect(/[\p{L}]{3,}/u.test(subject)).toBe(true);
+        });
+        it(`styleDirective[${loc}] is non-empty`, () => {
+          expect(getVariantStyleDirective(variant.id, loc).length).toBeGreaterThan(10);
+        });
+      }
+    });
+  }
+});
+
+describe('assignSubjectVariant', () => {
+  it('is deterministic for the same (email, campaign)', () => {
+    const a = assignSubjectVariant('User@Example.com', 'weekly_2026-06-16');
+    const b = assignSubjectVariant('user@example.com', 'weekly_2026-06-16'); // normalized
+    const c = assignSubjectVariant(' user@example.com ', 'weekly_2026-06-16');
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('only ever returns a known variant id', () => {
+    const ids = new Set(listVariantIds());
+    for (let i = 0; i < 200; i++) {
+      expect(ids.has(assignSubjectVariant(`u${i}@example.com`, 'weekly_2026-06-16'))).toBe(true);
+    }
+  });
+
+  it('splits the audience across variants (~balanced, no empty bucket)', () => {
+    const counts: Record<string, number> = {};
+    const N = 4000;
+    for (let i = 0; i < N; i++) {
+      const v = assignSubjectVariant(`subscriber${i}@frontaliereticino.ch`, 'weekly_2026-06-16');
+      counts[v] = (counts[v] || 0) + 1;
+    }
+    for (const id of listVariantIds()) {
+      const share = (counts[id] || 0) / N;
+      // 2 variants → ~0.5 each; allow generous tolerance, just no degenerate split.
+      expect(share).toBeGreaterThan(0.30);
+      expect(share).toBeLessThan(0.70);
+    }
+  });
+
+  it('rotates buckets across campaigns for at least some subscribers', () => {
+    let flipped = 0;
+    for (let i = 0; i < 500; i++) {
+      const e = `rot${i}@example.com`;
+      if (assignSubjectVariant(e, 'weekly_2026-06-09') !== assignSubjectVariant(e, 'weekly_2026-06-16')) flipped++;
+    }
+    expect(flipped).toBeGreaterThan(50); // not pinned to one bucket forever
+  });
+});
+
+describe('getVariantFallback', () => {
+  it('degrades safely on unknown variant/locale', () => {
+    expect(getVariantFallback('does-not-exist', 'it')).toBe(SUBJECT_VARIANTS[0].fallback.it);
+    expect(getVariantFallback(SUBJECT_VARIANTS[0].id, 'xx')).toBe(SUBJECT_VARIANTS[0].fallback.it);
+  });
+});
+
+describe('getVariantStyleDirective', () => {
+  it('returns empty string for unknown variant (callers concat unconditionally)', () => {
+    expect(getVariantStyleDirective('nope', 'it')).toBe('');
+  });
+});
+
+describe('buildSubjectPrompt variant injection', () => {
+  const baseCtx = { subscriber: { locale: 'it' }, exchangeRate: { rate: 0.94 }, matchedJobs: [] };
+
+  it('injects the variant directive into the system prompt', () => {
+    const variantId = SUBJECT_VARIANTS[0].id;
+    const { system } = buildSubjectPrompt({ ...baseCtx, variant: variantId });
+    expect(system).toContain(getVariantStyleDirective(variantId, 'it'));
+  });
+
+  it('leaves the prompt directive-free when no variant is given', () => {
+    const { system } = buildSubjectPrompt(baseCtx);
+    for (const v of SUBJECT_VARIANTS) {
+      expect(system).not.toContain(getVariantStyleDirective(v.id, 'it'));
+    }
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmail('  Foo@Bar.COM ')).toBe('foo@bar.com');
+    expect(normalizeEmail(null)).toBe('');
+  });
+});


### PR DESCRIPTION
## Implementato

Ottimizzazione open-rate newsletter **per provider di send** via A/B test sui titoli (subject line).

- **`services/newsletter-subject-variants.mjs` (nuovo)** — single source of truth dell'A/B:
  - 2 varianti subject: `concreto` (numero+luogo+beneficio) vs `curioso` (curiosity-gap/domanda) — i due "school" dominanti, contrasto statisticamente più efficiente.
  - `assignSubjectVariant(email, campaignId)` — assegnazione **deterministica** (sha256), stabile entro la campagna (no flip-flop tra i cron daily dello stesso `weekly_*`), ruota tra campagne. Indipendente dal provider → ogni provider vede ~50/50 → cross-tab provider×variant valido.
  - fallback per locale (it/en/de/fr) per ogni variante, conformi ai gate inlineQaCheck (10..60 char, no `...`, ≥1 parola).
- **`services/newsletter-content.mjs`** — `buildSubjectPrompt(ctx)` accetta `ctx.variant` opzionale e inietta la style-directive nel system prompt. **Backward-compatible**: senza `variant` il prompt è invariato (verificato: l'altro caller `generatePreviewSubject` non passa variant → nessun break, GitNexus impact LOW).
- **`scripts/send-newsletter.mjs`**:
  - Phase 3: genera 1 subject AI per `(locale × variante)` (≤8 call AI, resta cohort-cheap, non per-subscriber).
  - Phase 5: ogni subscriber riceve il subject della sua variante assegnata; aggiunto tag `variant` sull'email (letto dal webhook Resend `tags.variant`).
  - `persistDelivery()`: salva `provider` (autoritativo per ogni provider del cascade), `variant`, `subject`, `email` sul send doc → record di invio self-contained.
- **`scripts/newsletter-ab-report.mjs` (nuovo)** — report open-rate per `provider × variante`, winner per-provider + z-test two-proportion + flag campione piccolo. Robusto by-design:
  - denominatore (sends) dai send-doc; **variante ricalcolata** deterministicamente (non si fida dello storage webhook, che solo Resend popola);
  - numeratore (opens) = OR di `opened_at` sul send-doc **e** open-event per-campagna (match email/message_id) → **immune alla divergenza del delivery-doc-id tra provider** (`__` vs `_`);
  - query per `campaign_id` only + refine in memoria (single-field index) con gestione errore index mancante.
- **`tests/newsletter-subject-variants.test.ts` (nuovo)** — 27 test: determinismo, split bilanciato (~50/50, no bucket vuoto), rotazione tra campagne, QA gate dei fallback, injection del prompt, degradazione safe. Suite: 40/40 verde (con `newsletter-fallback-subjects`).

## Non implementato (ancora)

- **6 webhook core (`newsletter{Resend,Mailjet,Mailgun,Mailtrap,Maileroo,Unosend}WebhookCore.js`)** — flaggati dal sibling-check perché condividono il token `campaignId`. **Non è lo stesso antipattern**: è una feature additiva, non un fix di pattern. Solo Resend legge `tags.variant`; gli altri 5 non lo leggono — *by design* il report **ricalcola** la variante e non dipende da quel campo, quindi non serve toccarli. Lasciati invariati di proposito.
- **Divergenza pre-esistente del delivery-doc-id** (`${campaignId}__${email}` in Resend/send vs `${campaignId}_${email}` negli altri 5 webhook) — bug latente separato dallo scope A/B; **non corretto** per evitare drive-by su path di open-tracking. Il report è progettato immune (open via events). Candidato follow-up.
- **`services/newsletterPreview.ts`** (condivide `FALLBACK_SUBJECT`) — path preview-only (admin/QA), non guida l'invio reale. Mostrare la variante nel preview è nice-to-have, fuori scope. Follow-up.
- **`scripts/lib/email-cascade.mjs`, `services/analytics.ts`, `services/newsletterSubscribers.ts`, `scripts/backfill-newsletter-campaign-ids.mjs`** — condividono solo il token `campaignId`, nessuna relazione con l'A/B subject. Nessuna modifica necessaria.
- **Decisione automatica del winner / promozione variante** — il report misura e flagga significatività; la promozione del subject vincente resta manuale (serve ≥1 settimana di dati per cella provider×variant). Follow-up dopo raccolta dati.
- **Indice Firestore collectionGroup `campaign_id`** — il primo run del report può richiedere la creazione dell'indice (Firestore restituisce URL one-click); gestito con messaggio esplicito, non un crash.

## Test plan

- [x] `node --check` su tutti i file mjs toccati
- [x] vitest: `newsletter-subject-variants` + `newsletter-fallback-subjects` → 40/40
- [x] GitNexus impact su `buildSubjectPrompt` → LOW, backward-compatible
- [x] sibling-pattern check eseguito; sibling non toccati giustificati sopra
- [ ] Post-merge: invio reale → `node scripts/newsletter-ab-report.mjs` dopo ≥1 ciclo per leggere open-rate provider×variant (verificabile solo live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)