### PR TITLE
fix(newsletter): A/B report Sunday campaign id + resend-path provider attribution

### DIFF
--- a/scripts/newsletter-ab-report.mjs
+++ b/scripts/newsletter-ab-report.mjs
@@ -42,7 +42,10 @@ function argValue(flag) {
 function currentWeeklyCampaignId() {
   const now = new Date();
   const monday = new Date(now);
-  monday.setDate(now.getDate() - now.getDay() + 1);
+  // (getDay()+6)%7 = days since Monday — identical to send-newsletter.mjs. The
+  // naive `getDate()-getDay()+1` resolves to NEXT Monday on Sundays, which would
+  // pick a campaign id that was never sent → "No sends found" on Sunday runs.
+  monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
   return `weekly_${monday.toISOString().slice(0, 10)}`;
 }
 

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1520,7 +1520,9 @@ async function sendEmailBatchResend(emails, apiKey) {
 
       if (msgId) {
         sent.push(item);
-        await persistDelivery(item.recipient, msgId, item.meta);
+        // Legacy Resend-only path: stamp provider so the A/B report buckets these
+        // under 'resend' instead of 'unknown' (cascade paths spread res.provider).
+        await persistDelivery(item.recipient, msgId, { ...item.meta, provider: 'resend' });
       } else {
         // Resend returned no ID for this email — treat as failed
         failed.push(item);


### PR DESCRIPTION
## Implementato

Fix dei 2 🟡 nit del reviewer su PR #2075 (subject A/B + report per-provider).

- **`scripts/newsletter-ab-report.mjs`** — `currentWeeklyCampaignId()` usava `getDate() - getDay() + 1`, che **di domenica** (`getDay()===0`) risolve al lunedì della settimana *successiva* → un campaign id mai inviato → "No sends found" su run domenicali. Ora usa `(getDay()+6)%7` (giorni dal lunedì), **identico** a `send-newsletter.mjs:1826`. Verificato: dom 2026-06-14 → `weekly_2026-06-08` (settimana corretta), lun→sab tutti mappano al lunedì della loro settimana.
- **`scripts/send-newsletter.mjs`** — il path legacy Resend-only (`sendEmailBatchResend`, L1523) chiamava `persistDelivery(...item.meta)` **senza** `provider` → send-doc con `provider:null` → bucketato `unknown` nel report. Ora passa `{ ...item.meta, provider: 'resend' }`, coerente con i path cascade/single-provider (L1547/L1561). Basso impatto (cascade è il default), ma ripristina l'attribuzione per il fallback.

## Non implementato (ancora)

- **Test unit per `currentWeeklyCampaignId()`** — funzione non esportata e dipendente da `new Date()` (non iniettabile) → testarla richiederebbe export + clock injection, scope-creep oltre il nit. Parità di formula verificata a mano (output domenica sopra) e via parità byte con `send-newsletter.mjs`.
- **Sibling**: la formula `(getDay()+6)%7` ora vive in 2 punti (`send-newsletter.mjs` + report). Non estratta in helper condiviso in questa PR per evitare drive-by su `send-newsletter` (hot path invio); le due copie sono ora byte-identiche e il commento le linka. Candidato follow-up se compare un terzo uso.

## Test plan

- [x] `node --check` su entrambi i file
- [x] parità formula lun-mapping per Sun→Sat (output nel diff)
- [x] vitest `newsletter-subject-variants` → 27/27 (nessuna regressione)
- [ ] Post-merge: `node scripts/newsletter-ab-report.mjs` in un run domenicale risolve il campaign id corretto (verificabile solo live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)