### PR TITLE
feat(seo): per-canton salary statistics landing pages

### DIFF
--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -210,33 +210,9 @@ const COPY: Record<
 };
 
 /** Localised display name for a canton. */
-const CANTON_DISPLAY: Record<string, Record<Locale, string>> = {
-  AG: { it: 'Argovia', en: 'Aargau', de: 'Aargau', fr: 'Argovie' },
-  // Half-canton URL groups (2026-05-10 merge): AI+AR -> APPENZELLO, BL+BS -> BASILEA.
-  APPENZELLO: { it: 'Appenzello', en: 'Appenzell', de: 'Appenzell', fr: 'Appenzell' },
-  BE: { it: 'Berna', en: 'Bern', de: 'Bern', fr: 'Berne' },
-  BASILEA: { it: 'Basilea', en: 'Basel', de: 'Basel', fr: 'Bâle' },
-  FR: { it: 'Friburgo', en: 'Fribourg', de: 'Freiburg', fr: 'Fribourg' },
-  GE: { it: 'Ginevra', en: 'Geneva', de: 'Genf', fr: 'Genève' },
-  GL: { it: 'Glarona', en: 'Glarus', de: 'Glarus', fr: 'Glaris' },
-  GR: { it: 'Grigioni', en: 'Graubünden', de: 'Graubünden', fr: 'Grisons' },
-  JU: { it: 'Giura', en: 'Jura', de: 'Jura', fr: 'Jura' },
-  LU: { it: 'Lucerna', en: 'Lucerne', de: 'Luzern', fr: 'Lucerne' },
-  NE: { it: 'Neuchâtel', en: 'Neuchâtel', de: 'Neuenburg', fr: 'Neuchâtel' },
-  NW: { it: 'Nidvaldo', en: 'Nidwalden', de: 'Nidwalden', fr: 'Nidwald' },
-  OW: { it: 'Obvaldo', en: 'Obwalden', de: 'Obwalden', fr: 'Obwald' },
-  SG: { it: 'San Gallo', en: 'St. Gallen', de: 'St. Gallen', fr: 'Saint-Gall' },
-  SH: { it: 'Sciaffusa', en: 'Schaffhausen', de: 'Schaffhausen', fr: 'Schaffhouse' },
-  SO: { it: 'Soletta', en: 'Solothurn', de: 'Solothurn', fr: 'Soleure' },
-  SZ: { it: 'Svitto', en: 'Schwyz', de: 'Schwyz', fr: 'Schwytz' },
-  TG: { it: 'Turgovia', en: 'Thurgau', de: 'Thurgau', fr: 'Thurgovie' },
-  TI: { it: 'Ticino', en: 'Ticino', de: 'Tessin', fr: 'Tessin' },
-  UR: { it: 'Uri', en: 'Uri', de: 'Uri', fr: 'Uri' },
-  VD: { it: 'Vaud', en: 'Vaud', de: 'Waadt', fr: 'Vaud' },
-  VS: { it: 'Vallese', en: 'Valais', de: 'Wallis', fr: 'Valais' },
-  ZG: { it: 'Zugo', en: 'Zug', de: 'Zug', fr: 'Zoug' },
-  ZH: { it: 'Zurigo', en: 'Zürich', de: 'Zürich', fr: 'Zurich' },
-};
+// Localised canton display names: shared single source of truth
+// (build-plugins/shared/cantonDisplay.ts) — CLAUDE.md rule #6.
+import { CANTON_DISPLAY } from './shared/cantonDisplay';
 
 interface CantonSlugFile {
   cantons: Record<string, Record<Locale, string>>;

--- a/build-plugins/salaryStatsChCantonPages.ts
+++ b/build-plugins/salaryStatsChCantonPages.ts
@@ -1,0 +1,389 @@
+/**
+ * salaryStatsChCantonPages.ts — per-canton salary statistics SEO landings.
+ *
+ * Emits one static page per (canton, locale) at e.g. `/stipendi-zurigo/`,
+ * `/en/salaries-zurich/`, … Each page presents the canton's salary level from
+ * the official BFS LSE Grossregion median (data/swiss-canton-salary-index.json,
+ * via build-plugins/shared/cantonSalaryIndex) plus sector/net bands scaled to
+ * that canton, the canton-aware SEO prose + FAQ, and a CTA to the net-salary
+ * calculator.
+ *
+ * Plugin contract: apply 'build', enforce 'post', emit in closeBundle(),
+ * distDir passed through. Pure/deterministic so output is stable.
+ */
+import type { Plugin } from 'vite';
+
+import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import { WriteCollector } from './batchWrite';
+import { CALC_HREF } from './shared/calcHref';
+import { getCantonDisplayName, type CantonDisplayLocale } from './shared/cantonDisplay';
+import {
+  renderCantonSeoProse,
+  buildCantonSeoProseFaqItems,
+  type CantonSeoLocale,
+} from './shared/cantonSeoProse';
+import {
+  GROSSREGION_MEDIAN_MONTHLY,
+  NATIONAL_MEDIAN_MONTHLY,
+  CANTON_TO_GROSSREGION,
+  cantonGrossSalaryBand,
+  cantonFaqMedianAnnual,
+} from './shared/cantonSalaryIndex';
+import {
+  SALARY_STATS_LOCALES,
+  SALARY_STATS_CANTON_KEYS,
+  SALARY_STATS_CANTON_SLUGS,
+  SALARY_STATS_FACTOR_CODE,
+  SALARY_STATS_LOCALE_PREFIX,
+  buildSalaryStatsPath,
+  type SalaryStatsLocale,
+} from './salaryStatsData';
+import {
+  HERO_EYEBROW_STYLE,
+  H1_STYLE,
+  LEDE_STYLE,
+  BODY_STYLE,
+  H2_STYLE,
+  BREADCRUMB_STYLE,
+  BREADCRUMB_LINK_STYLE,
+} from './shared/seoContentTokens';
+
+const OG_LOCALE: Record<SalaryStatsLocale, string> = {
+  it: 'it_CH',
+  en: 'en_US',
+  de: 'de_CH',
+  fr: 'fr_CH',
+};
+
+interface Copy {
+  eyebrow: string;
+  h1: (canton: string) => string;
+  lede: (canton: string, median: string) => string;
+  tileMedianMonth: string;
+  tileMedianYear: string;
+  tileVsNational: string;
+  tileProfBand: string;
+  sectorHeading: string;
+  sectorCol: string;
+  sectorAnnual: string;
+  netHeading: string;
+  netSingle: string;
+  netCouple: string;
+  methodologyHeading: string;
+  methodology: (canton: string) => string;
+  cta: string;
+  breadcrumbHome: string;
+  breadcrumbCh: string;
+  metaTitle: (canton: string) => string;
+  metaDesc: (canton: string, median: string) => string;
+  sectorIt: string;
+  sectorFinance: string;
+  sectorPharma: string;
+  sectorRetail: string;
+}
+
+const COPY: Record<SalaryStatsLocale, Copy> = {
+  it: {
+    eyebrow: 'Statistiche salariali',
+    h1: (c) => `Stipendi nel Canton ${c}`,
+    lede: (c, m) => `Stipendio mediano lordo in ${c}: ${m}/mese (fonte BFS, rilevazione struttura salari).`,
+    tileMedianMonth: 'Mediana lorda / mese',
+    tileMedianYear: 'Mediana lorda / anno',
+    tileVsNational: 'vs media svizzera',
+    tileProfBand: 'Ruolo professionale (lordo/anno)',
+    sectorHeading: 'Stipendi per settore (stima per cantone)',
+    sectorCol: 'Settore',
+    sectorAnnual: 'Lordo annuo indicativo',
+    netHeading: 'Netto mensile stimato',
+    netSingle: 'Single senza figli',
+    netCouple: 'Coppia, due figli',
+    methodologyHeading: 'Metodologia e fonti',
+    methodology: (c) => `Le cifre per il Canton ${c} derivano dalla mediana salariale ufficiale della Grossregion BFS (Rilevazione svizzera della struttura dei salari, LSE 2024) a cui appartiene il cantone, scalata sui livelli settoriali. La mediana mensile lorda è standardizzata a tempo pieno (4⅓ settimane). Le stime settoriali e nette sono indicative; il netto reale dipende da imposta alla fonte cantonale, contributi sociali e accordo fiscale Italia-Svizzera 2024.`,
+    cta: 'Calcola il tuo netto frontaliere',
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Svizzera',
+    metaTitle: (c) => `Stipendi Canton ${c} 2026 — mediana e settori (dati BFS)`,
+    metaDesc: (c, m) => `Stipendi nel Canton ${c}: mediana lorda ${m}/mese, lordo annuo per settore e netto mensile stimato per frontalieri. Fonte BFS.`,
+    sectorIt: 'IT / Software',
+    sectorFinance: 'Banca / Finanza',
+    sectorPharma: 'Pharma',
+    sectorRetail: 'Commercio',
+  },
+  en: {
+    eyebrow: 'Salary statistics',
+    h1: (c) => `Salaries in Canton ${c}`,
+    lede: (c, m) => `Median gross salary in ${c}: ${m}/month (source: BFS earnings structure survey).`,
+    tileMedianMonth: 'Median gross / month',
+    tileMedianYear: 'Median gross / year',
+    tileVsNational: 'vs Swiss average',
+    tileProfBand: 'Professional role (gross/year)',
+    sectorHeading: 'Salaries by sector (canton estimate)',
+    sectorCol: 'Sector',
+    sectorAnnual: 'Indicative annual gross',
+    netHeading: 'Estimated monthly net',
+    netSingle: 'Single, no children',
+    netCouple: 'Couple, two children',
+    methodologyHeading: 'Methodology and sources',
+    methodology: (c) => `Figures for Canton ${c} derive from the official BFS Grossregion salary median (Swiss earnings structure survey, LSE 2024) of the region the canton belongs to, scaled across sector levels. The monthly gross median is full-time standardized (4⅓ weeks). Sector and net estimates are indicative; the real net depends on cantonal source tax, social charges and the 2024 Italy-Switzerland tax agreement.`,
+    cta: 'Calculate your cross-border net',
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Switzerland',
+    metaTitle: (c) => `Canton ${c} salaries 2026 — median and sectors (BFS data)`,
+    metaDesc: (c, m) => `Salaries in Canton ${c}: median gross ${m}/month, annual gross by sector and estimated monthly net for cross-border workers. Source BFS.`,
+    sectorIt: 'IT / Software',
+    sectorFinance: 'Banking / Finance',
+    sectorPharma: 'Pharma',
+    sectorRetail: 'Retail',
+  },
+  de: {
+    eyebrow: 'Lohnstatistik',
+    h1: (c) => `Löhne im Kanton ${c}`,
+    lede: (c, m) => `Medianlohn brutto im Kanton ${c}: ${m}/Monat (Quelle: BFS-Lohnstrukturerhebung).`,
+    tileMedianMonth: 'Median brutto / Monat',
+    tileMedianYear: 'Median brutto / Jahr',
+    tileVsNational: 'vs Schweizer Schnitt',
+    tileProfBand: 'Fachrolle (brutto/Jahr)',
+    sectorHeading: 'Löhne nach Branche (Kantonsschätzung)',
+    sectorCol: 'Branche',
+    sectorAnnual: 'Indikativer Jahresbruttolohn',
+    netHeading: 'Geschätztes Monatsnetto',
+    netSingle: 'Alleinstehend, keine Kinder',
+    netCouple: 'Paar, zwei Kinder',
+    methodologyHeading: 'Methodik und Quellen',
+    methodology: (c) => `Die Werte für den Kanton ${c} leiten sich vom offiziellen BFS-Grossregion-Medianlohn (Lohnstrukturerhebung, LSE 2024) der Region ab, der der Kanton angehört, skaliert über die Branchenniveaus. Der monatliche Bruttomedian ist vollzeitstandardisiert (4⅓ Wochen). Branchen- und Nettoschätzungen sind indikativ; das reale Netto hängt von kantonaler Quellensteuer, Sozialabgaben und dem Steuerabkommen Italien-Schweiz 2024 ab.`,
+    cta: 'Grenzgänger-Netto berechnen',
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Schweiz',
+    metaTitle: (c) => `Löhne Kanton ${c} 2026 — Median und Branchen (BFS-Daten)`,
+    metaDesc: (c, m) => `Löhne im Kanton ${c}: Medianbrutto ${m}/Monat, Jahresbrutto nach Branche und geschätztes Monatsnetto für Grenzgänger. Quelle BFS.`,
+    sectorIt: 'IT / Software',
+    sectorFinance: 'Bank / Finanzen',
+    sectorPharma: 'Pharma',
+    sectorRetail: 'Handel',
+  },
+  fr: {
+    eyebrow: 'Statistiques salariales',
+    h1: (c) => `Salaires dans le canton ${c}`,
+    lede: (c, m) => `Salaire médian brut dans le canton ${c} : ${m}/mois (source : OFS, enquête structure des salaires).`,
+    tileMedianMonth: 'Médian brut / mois',
+    tileMedianYear: 'Médian brut / an',
+    tileVsNational: 'vs moyenne suisse',
+    tileProfBand: 'Poste professionnel (brut/an)',
+    sectorHeading: 'Salaires par secteur (estimation cantonale)',
+    sectorCol: 'Secteur',
+    sectorAnnual: 'Brut annuel indicatif',
+    netHeading: 'Net mensuel estimé',
+    netSingle: 'Célibataire, sans enfants',
+    netCouple: 'Couple, deux enfants',
+    methodologyHeading: 'Méthodologie et sources',
+    methodology: (c) => `Les chiffres du canton ${c} dérivent du salaire médian officiel OFS de la grande région (enquête sur la structure des salaires, LSE 2024) à laquelle appartient le canton, mis à l'échelle des niveaux sectoriels. Le médian mensuel brut est standardisé à plein temps (4⅓ semaines). Les estimations sectorielles et nettes sont indicatives ; le net réel dépend de l'impôt à la source cantonal, des charges sociales et de l'accord fiscal Italie-Suisse 2024.`,
+    cta: 'Calculez votre net frontalier',
+    breadcrumbHome: 'Accueil',
+    breadcrumbCh: 'Suisse',
+    metaTitle: (c) => `Salaires canton ${c} 2026 — médian et secteurs (données OFS)`,
+    metaDesc: (c, m) => `Salaires dans le canton ${c} : médian brut ${m}/mois, brut annuel par secteur et net mensuel estimé pour frontaliers. Source OFS.`,
+    sectorIt: 'IT / Software',
+    sectorFinance: 'Banque / Finance',
+    sectorPharma: 'Pharma',
+    sectorRetail: 'Commerce',
+  },
+};
+
+function esc(s: unknown): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function fmtChf(n: number, locale: SalaryStatsLocale): string {
+  const sep = locale === 'en' ? ',' : locale === 'fr' ? ' ' : "'";
+  return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+}
+
+function localeFactorCode(cantonKey: string): string {
+  return SALARY_STATS_FACTOR_CODE[cantonKey] ?? cantonKey;
+}
+
+function cantonMonthlyMedian(cantonKey: string): number {
+  const region = CANTON_TO_GROSSREGION[localeFactorCode(cantonKey)];
+  return region ? GROSSREGION_MEDIAN_MONTHLY[region] : NATIONAL_MEDIAN_MONTHLY;
+}
+
+export function renderSalaryStatsPage(opts: {
+  locale: SalaryStatsLocale;
+  cantonKey: string;
+  cantonSlug: string;
+  distDir: string;
+}): { html: string; words: number } {
+  const { locale, cantonKey, cantonSlug, distDir } = opts;
+  const c = COPY[locale];
+  const cantonName = getCantonDisplayName(cantonKey, locale as CantonDisplayLocale);
+  const canonicalPath = buildSalaryStatsPath(locale, cantonSlug);
+  const homeHref = locale === 'it' ? '/' : `${SALARY_STATS_LOCALE_PREFIX[locale]}/`;
+
+  const monthly = cantonMonthlyMedian(cantonKey);
+  const annual = monthly * 12;
+  const vsNational = Math.round((monthly / NATIONAL_MEDIAN_MONTHLY) * 100);
+  const monthlyStr = `CHF ${fmtChf(monthly, locale)}`;
+
+  const band = cantonGrossSalaryBand(cantonName);
+  const faq = cantonFaqMedianAnnual(cantonName);
+
+  const breadcrumb = `<nav aria-label="breadcrumb" class="${BREADCRUMB_STYLE}">
+  <a href="${homeHref}" class="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbHome)}</a>
+  <span aria-hidden="true">›</span>
+  <a href="${homeHref}" class="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbCh)}</a>
+  <span aria-hidden="true">›</span>
+  <span aria-current="page">${esc(cantonName)}</span>
+</nav>`;
+
+  const tiles = `<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 my-4">
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">${esc(monthlyStr)}</div><div class="text-xs text-subtle">${esc(c.tileMedianMonth)}</div></div>
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">CHF ${fmtChf(annual, locale)}</div><div class="text-xs text-subtle">${esc(c.tileMedianYear)}</div></div>
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">${vsNational}%</div><div class="text-xs text-subtle">${esc(c.tileVsNational)}</div></div>
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">CHF ${fmtChf(band.grossLow, locale)}–${fmtChf(band.grossHigh, locale)}</div><div class="text-xs text-subtle">${esc(c.tileProfBand)}</div></div>
+</div>`;
+
+  const sectorRows = [
+    [c.sectorIt, faq.it],
+    [c.sectorFinance, faq.finance],
+    [c.sectorPharma, faq.pharma],
+    [c.sectorRetail, faq.retail],
+  ]
+    .map(
+      ([label, val]) =>
+        `<tr><td class="py-1 pr-4">${esc(label)}</td><td class="py-1 font-semibold text-heading">CHF ${fmtChf(Number(val), locale)}+</td></tr>`,
+    )
+    .join('');
+
+  const sectorTable = `<h2 class="${H2_STYLE}">${esc(c.sectorHeading)}</h2>
+<table class="w-full text-sm my-2"><thead><tr class="text-subtle text-left"><th class="font-medium">${esc(c.sectorCol)}</th><th class="font-medium">${esc(c.sectorAnnual)}</th></tr></thead><tbody>${sectorRows}</tbody></table>`;
+
+  const netBlock = `<h2 class="${H2_STYLE}">${esc(c.netHeading)}</h2>
+<table class="w-full text-sm my-2"><tbody>
+<tr><td class="py-1 pr-4">${esc(c.netSingle)}</td><td class="py-1 font-semibold text-heading">CHF ${fmtChf(band.netSingleLow, locale)}–${fmtChf(band.netSingleHigh, locale)}/${locale === 'de' ? 'Mt.' : locale === 'it' ? 'mese' : locale === 'fr' ? 'mois' : 'mo'}</td></tr>
+<tr><td class="py-1 pr-4">${esc(c.netCouple)}</td><td class="py-1 font-semibold text-heading">CHF ${fmtChf(band.netCoupleLow, locale)}–${fmtChf(band.netCoupleHigh, locale)}</td></tr>
+</tbody></table>`;
+
+  const methodology = `<h2 class="${H2_STYLE}">${esc(c.methodologyHeading)}</h2><p class="${BODY_STYLE}">${esc(c.methodology(cantonName))}</p>`;
+
+  const calcHref = CALC_HREF[locale as CantonSeoLocale];
+  const cta = `<p class="my-4"><a href="${esc(calcHref)}" class="inline-block rounded-lg bg-info text-white px-4 py-2 font-medium">${esc(c.cta)} →</a></p>`;
+
+  // Reuse the canton-aware SEO prose (already carries per-canton salary copy +
+  // FAQ) so the page comfortably clears the indexable-words gate and shares one
+  // FAQ source with the rest of the cathedral.
+  const prose = renderCantonSeoProse({
+    locale: locale as CantonSeoLocale,
+    cantonDisplay: cantonName,
+    slot: 'canton-hub',
+    ctaHref: canonicalPath,
+    ctaLabel: c.cta,
+  });
+
+  const main = `${breadcrumb}
+<header><p class="${HERO_EYEBROW_STYLE}">${esc(c.eyebrow)}</p><h1 class="${H1_STYLE}">${esc(c.h1(cantonName))}</h1><p class="${LEDE_STYLE}">${esc(c.lede(cantonName, monthlyStr))}</p></header>
+${tiles}
+${sectorTable}
+${netBlock}
+${cta}
+${methodology}
+${prose}`;
+
+  const breadcrumbLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: c.breadcrumbHome, item: `${BASE_URL}${homeHref}` },
+      { '@type': 'ListItem', position: 2, name: c.breadcrumbCh, item: `${BASE_URL}${homeHref}` },
+      { '@type': 'ListItem', position: 3, name: c.h1(cantonName), item: `${BASE_URL}${canonicalPath}` },
+    ],
+  };
+
+  const datasetLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: c.metaTitle(cantonName),
+    description: c.metaDesc(cantonName, monthlyStr),
+    creator: { '@type': 'GovernmentOrganization', name: 'Bundesamt für Statistik (BFS)', url: 'https://www.bfs.admin.ch' },
+    spatialCoverage: { '@type': 'AdministrativeArea', name: `Canton ${cantonName}, Switzerland` },
+    variableMeasured: 'Gross monthly salary (median)',
+    measurementTechnique: 'BFS Lohnstrukturerhebung (LSE) 2024, Grossregion median',
+    url: `${BASE_URL}${canonicalPath}`,
+  };
+
+  const faqItems = buildCantonSeoProseFaqItems({
+    locale: locale as CantonSeoLocale,
+    cantonDisplay: cantonName,
+    slot: 'canton-hub',
+  });
+  const faqLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems,
+  };
+
+  const html = buildSeoPageHtml({
+    locale,
+    title: c.metaTitle(cantonName),
+    description: c.metaDesc(cantonName, monthlyStr),
+    canonicalUrl: `${BASE_URL}${canonicalPath}`,
+    bodyHtml: main,
+    jsonLdScripts: [JSON.stringify(breadcrumbLd), JSON.stringify(datasetLd), JSON.stringify(faqLd)],
+    ogLocale: OG_LOCALE[locale],
+    robots: 'index,follow',
+    distDir,
+  });
+
+  return { html, words: countHtmlBodyWords(html) };
+}
+
+export interface SalaryStatsEmitResult {
+  pagesWritten: number;
+  pagesSkippedForWordCount: number;
+}
+
+export async function emitChCantonSalaryStatsPages(opts: {
+  distDir: string;
+}): Promise<SalaryStatsEmitResult> {
+  const result: SalaryStatsEmitResult = { pagesWritten: 0, pagesSkippedForWordCount: 0 };
+  const collector = new WriteCollector({ distDir: opts.distDir, pluginName: 'salaryStatsChCantonPages' });
+  const npMod = await import('node:path');
+
+  for (const locale of SALARY_STATS_LOCALES) {
+    for (const cantonKey of SALARY_STATS_CANTON_KEYS) {
+      const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+      const { html, words } = renderSalaryStatsPage({ locale, cantonKey, cantonSlug, distDir: opts.distDir });
+      if (words < MIN_INDEXABLE_WORDS) {
+        result.pagesSkippedForWordCount++;
+        continue;
+      }
+      const canonicalPath = buildSalaryStatsPath(locale, cantonSlug);
+      const outDir = npMod.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+      collector.add(npMod.join(outDir, 'index.html'), html);
+      result.pagesWritten++;
+    }
+  }
+
+  await collector.flush();
+  return result;
+}
+
+export function salaryStatsChCantonPages(rootDir: string): Plugin {
+  return {
+    name: 'salary-stats-ch-canton-pages',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_SALARY_STATS === '1') return;
+      const npMod = await import('node:path');
+      const distDir = npMod.resolve(rootDir, 'dist');
+      const res = await emitChCantonSalaryStatsPages({ distDir });
+      // eslint-disable-next-line no-console
+      console.log(`[salary-stats] emitted ${res.pagesWritten} pages (${res.pagesSkippedForWordCount} skipped for word count)`);
+    },
+  };
+}

--- a/build-plugins/salaryStatsChCantonPages.ts
+++ b/build-plugins/salaryStatsChCantonPages.ts
@@ -12,10 +12,15 @@
  * distDir passed through. Pure/deterministic so output is stable.
  */
 import type { Plugin } from 'vite';
+import fs from 'node:fs';
+import np from 'node:path';
 
 import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
+import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
+import { buildDayStampIso } from './shared/buildDayStamp';
+import { cleanSitemapFiles } from './shared/distNamespaceCleanup';
 import { CALC_HREF } from './shared/calcHref';
 import { getCantonDisplayName, type CantonDisplayLocale } from './shared/cantonDisplay';
 import {
@@ -27,8 +32,6 @@ import {
   GROSSREGION_MEDIAN_MONTHLY,
   NATIONAL_MEDIAN_MONTHLY,
   CANTON_TO_GROSSREGION,
-  cantonGrossSalaryBand,
-  cantonFaqMedianAnnual,
 } from './shared/cantonSalaryIndex';
 import {
   SALARY_STATS_LOCALES,
@@ -229,8 +232,23 @@ export function renderSalaryStatsPage(opts: {
   const vsNational = Math.round((monthly / NATIONAL_MEDIAN_MONTHLY) * 100);
   const monthlyStr = `CHF ${fmtChf(monthly, locale)}`;
 
-  const band = cantonGrossSalaryBand(cantonName);
-  const faq = cantonFaqMedianAnnual(cantonName);
+  // Derive the gross/net band + sector figures from the SAME region median as
+  // the headline tile (via cantonKey → BFS code → Grossregion), NOT from the
+  // localized display name — the half-canton groups (APPENZELLO/BASILEA) have
+  // no bare display form in the index's display→region table, which would
+  // silently fall back to national figures and make a single page show
+  // inconsistent numbers. Formulas mirror cantonSalaryIndex.cantonGrossSalaryBand
+  // / cantonFaqMedianAnnual (anchored to the national-average band).
+  const natScale = monthly / NATIONAL_MEDIAN_MONTHLY;
+  const r5000 = (n: number) => Math.round((n * natScale) / 5000) * 5000;
+  const r1000 = (n: number) => Math.round((n * natScale) / 1000) * 1000;
+  const r100 = (n: number) => Math.round((n * natScale) / 100) * 100;
+  const band = {
+    grossLow: r5000(85000), grossHigh: r5000(110000),
+    netSingleLow: r100(5400), netSingleHigh: r100(6600),
+    netCoupleLow: r100(5800), netCoupleHigh: r100(7200),
+  };
+  const faq = { it: r1000(95000), finance: r1000(110000), pharma: r1000(105000), retail: r1000(55000) };
 
   const breadcrumb = `<nav aria-label="breadcrumb" class="${BREADCRUMB_STYLE}">
   <a href="${homeHref}" class="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbHome)}</a>
@@ -309,7 +327,7 @@ ${prose}`;
     name: c.metaTitle(cantonName),
     description: c.metaDesc(cantonName, monthlyStr),
     creator: { '@type': 'GovernmentOrganization', name: 'Bundesamt für Statistik (BFS)', url: 'https://www.bfs.admin.ch' },
-    spatialCoverage: { '@type': 'AdministrativeArea', name: `Canton ${cantonName}, Switzerland` },
+    spatialCoverage: { '@type': 'AdministrativeArea', name: `${cantonName}, ${c.breadcrumbCh}` },
     variableMeasured: 'Gross monthly salary (median)',
     measurementTechnique: 'BFS Lohnstrukturerhebung (LSE) 2024, Grossregion median',
     url: `${BASE_URL}${canonicalPath}`,
@@ -326,11 +344,20 @@ ${prose}`;
     mainEntity: faqItems,
   };
 
+  // hreflang cluster: this canton's 4 locale variants + x-default (it).
+  const hreflangPaths = {
+    it: buildSalaryStatsPath('it', SALARY_STATS_CANTON_SLUGS[cantonKey].it),
+    en: buildSalaryStatsPath('en', SALARY_STATS_CANTON_SLUGS[cantonKey].en),
+    de: buildSalaryStatsPath('de', SALARY_STATS_CANTON_SLUGS[cantonKey].de),
+    fr: buildSalaryStatsPath('fr', SALARY_STATS_CANTON_SLUGS[cantonKey].fr),
+  } as HreflangPaths;
+
   const html = buildSeoPageHtml({
     locale,
     title: c.metaTitle(cantonName),
     description: c.metaDesc(cantonName, monthlyStr),
     canonicalUrl: `${BASE_URL}${canonicalPath}`,
+    hreflangHtml: renderHreflangTags(hreflangPaths),
     bodyHtml: main,
     jsonLdScripts: [JSON.stringify(breadcrumbLd), JSON.stringify(datasetLd), JSON.stringify(faqLd)],
     ogLocale: OG_LOCALE[locale],
@@ -344,14 +371,51 @@ ${prose}`;
 export interface SalaryStatsEmitResult {
   pagesWritten: number;
   pagesSkippedForWordCount: number;
+  /** Canonical paths actually written (index,follow) — feed the sitemap. */
+  emittedPaths: string[];
+}
+
+const SITEMAP_FILE = 'sitemap-salary-stats.xml';
+
+/** Build the sitemap-salary-stats.xml body from the emitted canonical paths. */
+function buildSalaryStatsSitemap(paths: readonly string[], dateStamp: string): string {
+  const entries = paths
+    .map(
+      (p) =>
+        `  <url>\n    <loc>${BASE_URL}${p}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>`,
+    )
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+}
+
+/** Add (or refresh the lastmod of) sitemap-salary-stats.xml in the sitemap index. */
+function patchSitemapIndex(distDir: string, dateStamp: string): void {
+  const indexPath = np.join(distDir, 'sitemap.xml');
+  if (!fs.existsSync(indexPath)) return;
+  try {
+    let idx = fs.readFileSync(indexPath, 'utf-8');
+    if (!idx.includes(SITEMAP_FILE)) {
+      idx = idx.replace(
+        '</sitemapindex>',
+        `  <sitemap>\n    <loc>${BASE_URL}/${SITEMAP_FILE}</loc>\n    <lastmod>${dateStamp}</lastmod>\n  </sitemap>\n</sitemapindex>`,
+      );
+    } else {
+      idx = idx.replace(
+        new RegExp(`(<loc>${BASE_URL.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}/${SITEMAP_FILE}</loc>\\s*<lastmod>)\\d{4}-\\d{2}-\\d{2}(</lastmod>)`),
+        `$1${dateStamp}$2`,
+      );
+    }
+    fs.writeFileSync(indexPath, idx, 'utf-8');
+  } catch (err) {
+    console.warn('[salary-stats] failed to patch sitemap index', err);
+  }
 }
 
 export async function emitChCantonSalaryStatsPages(opts: {
   distDir: string;
 }): Promise<SalaryStatsEmitResult> {
-  const result: SalaryStatsEmitResult = { pagesWritten: 0, pagesSkippedForWordCount: 0 };
+  const result: SalaryStatsEmitResult = { pagesWritten: 0, pagesSkippedForWordCount: 0, emittedPaths: [] };
   const collector = new WriteCollector({ distDir: opts.distDir, pluginName: 'salaryStatsChCantonPages' });
-  const npMod = await import('node:path');
 
   for (const locale of SALARY_STATS_LOCALES) {
     for (const cantonKey of SALARY_STATS_CANTON_KEYS) {
@@ -362,13 +426,29 @@ export async function emitChCantonSalaryStatsPages(opts: {
         continue;
       }
       const canonicalPath = buildSalaryStatsPath(locale, cantonSlug);
-      const outDir = npMod.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
-      collector.add(npMod.join(outDir, 'index.html'), html);
+      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+      collector.add(np.join(outDir, 'index.html'), html);
       result.pagesWritten++;
+      result.emittedPaths.push(canonicalPath);
     }
   }
 
   await collector.flush();
+
+  // Sitemap: write sitemap-salary-stats.xml + register it in the index, like
+  // the sibling canton-landing families (jobMarketSnapshot / healthPremiums /
+  // fuelDaily). Without this the index,follow pages never enter any sitemap.
+  cleanSitemapFiles(opts.distDir, [SITEMAP_FILE]);
+  if (result.emittedPaths.length > 0) {
+    const dateStamp = buildDayStampIso();
+    fs.writeFileSync(
+      np.join(opts.distDir, SITEMAP_FILE),
+      buildSalaryStatsSitemap(result.emittedPaths, dateStamp),
+      'utf-8',
+    );
+    patchSitemapIndex(opts.distDir, dateStamp);
+  }
+
   return result;
 }
 
@@ -379,8 +459,7 @@ export function salaryStatsChCantonPages(rootDir: string): Plugin {
     enforce: 'post',
     async closeBundle() {
       if (process.env.SKIP_SALARY_STATS === '1') return;
-      const npMod = await import('node:path');
-      const distDir = npMod.resolve(rootDir, 'dist');
+      const distDir = np.resolve(rootDir, 'dist');
       const res = await emitChCantonSalaryStatsPages({ distDir });
       // eslint-disable-next-line no-console
       console.log(`[salary-stats] emitted ${res.pagesWritten} pages (${res.pagesSkippedForWordCount} skipped for word count)`);

--- a/build-plugins/salaryStatsData.ts
+++ b/build-plugins/salaryStatsData.ts
@@ -1,0 +1,126 @@
+/**
+ * salaryStatsData.ts — routing + path data for the per-canton salary
+ * statistics landing family (e.g. IT `/stipendi-zurigo/`, EN
+ * `/en/salaries-zurich/`, DE `/de/gehaelter-zurich/`, FR `/fr/salaires-zurich/`).
+ *
+ * Imported by BOTH services/router.ts (SPA runtime — no `fs`) and the build
+ * plugin (Vite config graph — no JSON import at module-eval). So the canton
+ * slug table is inlined as pure literals (mirrors data/canton-url-slugs.json;
+ * a guard test in tests/salary-stats-landing.test.ts locks the two together).
+ */
+
+export type SalaryStatsLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const SALARY_STATS_LOCALES: readonly SalaryStatsLocale[] = ['it', 'en', 'de', 'fr'];
+
+/** Per-locale path prefix for this family. */
+export const SALARY_STATS_SECTION: Record<SalaryStatsLocale, string> = {
+  it: 'stipendi',
+  en: 'salaries',
+  de: 'gehaelter',
+  fr: 'salaires',
+};
+
+export const SALARY_STATS_LOCALE_PREFIX: Record<SalaryStatsLocale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+/**
+ * URL canton key -> per-locale base slug. Mirrors data/canton-url-slugs.json
+ * `cantons` (22 single cantons + the 2 half-canton URL groups APPENZELLO,
+ * BASILEA). The `dePrefix` overrides in that file are job-board-specific
+ * ("jobs-im-aargau") and do NOT apply here — this family uses its own prefix.
+ */
+export const SALARY_STATS_CANTON_SLUGS: Record<string, Record<SalaryStatsLocale, string>> = {
+  AG: { it: 'argovia', en: 'aargau', de: 'aargau', fr: 'argovie' },
+  APPENZELLO: { it: 'appenzello', en: 'appenzell', de: 'appenzell', fr: 'appenzell' },
+  BE: { it: 'berna', en: 'bern', de: 'bern', fr: 'berne' },
+  BASILEA: { it: 'basilea', en: 'basel', de: 'basel', fr: 'bale' },
+  FR: { it: 'friburgo', en: 'fribourg', de: 'freiburg', fr: 'fribourg' },
+  GE: { it: 'ginevra', en: 'geneva', de: 'genf', fr: 'geneve' },
+  GL: { it: 'glarona', en: 'glarus', de: 'glarus', fr: 'glaris' },
+  GR: { it: 'grigioni', en: 'graubunden', de: 'graubunden', fr: 'grisons' },
+  JU: { it: 'giura', en: 'jura', de: 'jura', fr: 'jura' },
+  LU: { it: 'lucerna', en: 'lucerne', de: 'luzern', fr: 'lucerne' },
+  NE: { it: 'neuchatel', en: 'neuchatel', de: 'neuenburg', fr: 'neuchatel' },
+  NW: { it: 'nidvaldo', en: 'nidwalden', de: 'nidwalden', fr: 'nidwald' },
+  OW: { it: 'obvaldo', en: 'obwalden', de: 'obwalden', fr: 'obwald' },
+  SG: { it: 'san-gallo', en: 'st-gallen', de: 'st-gallen', fr: 'saint-gall' },
+  SH: { it: 'sciaffusa', en: 'schaffhausen', de: 'schaffhausen', fr: 'schaffhouse' },
+  SO: { it: 'soletta', en: 'solothurn', de: 'solothurn', fr: 'soleure' },
+  SZ: { it: 'svitto', en: 'schwyz', de: 'schwyz', fr: 'schwytz' },
+  TG: { it: 'turgovia', en: 'thurgau', de: 'thurgau', fr: 'thurgovie' },
+  TI: { it: 'ticino', en: 'ticino', de: 'tessin', fr: 'tessin' },
+  UR: { it: 'uri', en: 'uri', de: 'uri', fr: 'uri' },
+  VD: { it: 'vaud', en: 'vaud', de: 'waadt', fr: 'vaud' },
+  VS: { it: 'vallese', en: 'valais', de: 'wallis', fr: 'valais' },
+  ZG: { it: 'zugo', en: 'zug', de: 'zug', fr: 'zoug' },
+  ZH: { it: 'zurigo', en: 'zurich', de: 'zurich', fr: 'zurich' },
+};
+
+/**
+ * URL canton key -> a real BFS code usable for the salary factor lookup.
+ * The half-canton groups collapse to one member; both members share the same
+ * Grossregion (AI/AR -> Ostschweiz, BL/BS -> Nordwestschweiz) so the factor is
+ * identical either way.
+ */
+export const SALARY_STATS_FACTOR_CODE: Record<string, string> = {
+  APPENZELLO: 'AR',
+  BASILEA: 'BS',
+};
+
+/** All URL canton keys this family emits, in a stable (sorted) order. */
+export const SALARY_STATS_CANTON_KEYS: readonly string[] = Object.freeze(
+  Object.keys(SALARY_STATS_CANTON_SLUGS).sort(),
+);
+
+/** Build the canonical path for a per-canton salary-stats page. */
+export function buildSalaryStatsPath(locale: SalaryStatsLocale, cantonSlug: string): string {
+  return `${SALARY_STATS_LOCALE_PREFIX[locale]}/${SALARY_STATS_SECTION[locale]}-${cantonSlug}/`
+    .replace(/\/{2,}/g, '/');
+}
+
+export interface SalaryStatsPath {
+  locale: SalaryStatsLocale;
+  cantonKey: string;
+  cantonSlug: string;
+  path: string;
+}
+
+/** Enumerate every canonical path (locale × canton). */
+export function listAllSalaryStatsPaths(): SalaryStatsPath[] {
+  const out: SalaryStatsPath[] = [];
+  for (const locale of SALARY_STATS_LOCALES) {
+    for (const cantonKey of SALARY_STATS_CANTON_KEYS) {
+      const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+      out.push({ locale, cantonKey, cantonSlug, path: buildSalaryStatsPath(locale, cantonSlug) });
+    }
+  }
+  return out;
+}
+
+export const SALARY_STATS_ROUTES: readonly string[] = Object.freeze(
+  listAllSalaryStatsPaths().map((p) => p.path),
+);
+
+const SALARY_STATS_ROUTE_SET: ReadonlySet<string> = new Set(SALARY_STATS_ROUTES);
+
+const SALARY_STATS_PATH_INDEX: ReadonlyMap<string, SalaryStatsPath> = new Map(
+  listAllSalaryStatsPaths().map((p) => [p.path, p]),
+);
+
+function normalizePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+export function isSalaryStatsPath(urlPath: string): boolean {
+  return SALARY_STATS_ROUTE_SET.has(normalizePath(urlPath));
+}
+
+export function parseSalaryStatsPath(urlPath: string): SalaryStatsPath | null {
+  return SALARY_STATS_PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}

--- a/build-plugins/shared/cantonDisplay.ts
+++ b/build-plugins/shared/cantonDisplay.ts
@@ -1,0 +1,44 @@
+/**
+ * cantonDisplay.ts — single source of truth for localized canton display names.
+ *
+ * Consolidates the per-plugin `CANTON_DISPLAY` maps that had been copy-pasted
+ * across jobMarketSnapshotChCantonPages, weeklyEmployersChCantonPages and the
+ * job editorial landing (CLAUDE.md rule #6: a constant duplicated across ≥2
+ * files must live in ONE shared module). Keyed by the URL canton key (BFS code,
+ * or the half-canton URL groups APPENZELLO = AI+AR, BASILEA = BL+BS).
+ */
+
+export type CantonDisplayLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const CANTON_DISPLAY: Record<string, Record<CantonDisplayLocale, string>> = {
+  AG: { it: 'Argovia', en: 'Aargau', de: 'Aargau', fr: 'Argovie' },
+  // Half-canton URL groups (2026-05-10 merge): AI+AR -> APPENZELLO, BL+BS -> BASILEA.
+  APPENZELLO: { it: 'Appenzello', en: 'Appenzell', de: 'Appenzell', fr: 'Appenzell' },
+  BE: { it: 'Berna', en: 'Bern', de: 'Bern', fr: 'Berne' },
+  BASILEA: { it: 'Basilea', en: 'Basel', de: 'Basel', fr: 'Bâle' },
+  FR: { it: 'Friburgo', en: 'Fribourg', de: 'Freiburg', fr: 'Fribourg' },
+  GE: { it: 'Ginevra', en: 'Geneva', de: 'Genf', fr: 'Genève' },
+  GL: { it: 'Glarona', en: 'Glarus', de: 'Glarus', fr: 'Glaris' },
+  GR: { it: 'Grigioni', en: 'Graubünden', de: 'Graubünden', fr: 'Grisons' },
+  JU: { it: 'Giura', en: 'Jura', de: 'Jura', fr: 'Jura' },
+  LU: { it: 'Lucerna', en: 'Lucerne', de: 'Luzern', fr: 'Lucerne' },
+  NE: { it: 'Neuchâtel', en: 'Neuchâtel', de: 'Neuenburg', fr: 'Neuchâtel' },
+  NW: { it: 'Nidvaldo', en: 'Nidwalden', de: 'Nidwalden', fr: 'Nidwald' },
+  OW: { it: 'Obvaldo', en: 'Obwalden', de: 'Obwalden', fr: 'Obwald' },
+  SG: { it: 'San Gallo', en: 'St. Gallen', de: 'St. Gallen', fr: 'Saint-Gall' },
+  SH: { it: 'Sciaffusa', en: 'Schaffhausen', de: 'Schaffhausen', fr: 'Schaffhouse' },
+  SO: { it: 'Soletta', en: 'Solothurn', de: 'Solothurn', fr: 'Soleure' },
+  SZ: { it: 'Svitto', en: 'Schwyz', de: 'Schwyz', fr: 'Schwytz' },
+  TG: { it: 'Turgovia', en: 'Thurgau', de: 'Thurgau', fr: 'Thurgovie' },
+  TI: { it: 'Ticino', en: 'Ticino', de: 'Tessin', fr: 'Tessin' },
+  UR: { it: 'Uri', en: 'Uri', de: 'Uri', fr: 'Uri' },
+  VD: { it: 'Vaud', en: 'Vaud', de: 'Waadt', fr: 'Vaud' },
+  VS: { it: 'Vallese', en: 'Valais', de: 'Wallis', fr: 'Valais' },
+  ZG: { it: 'Zugo', en: 'Zug', de: 'Zug', fr: 'Zoug' },
+  ZH: { it: 'Zurigo', en: 'Zürich', de: 'Zürich', fr: 'Zurich' },
+};
+
+/** Localized canton name with IT fallback, then the raw code. */
+export function getCantonDisplayName(code: string, locale: CantonDisplayLocale): string {
+  return CANTON_DISPLAY[code]?.[locale] ?? CANTON_DISPLAY[code]?.it ?? code;
+}

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -186,34 +186,9 @@ const COPY: Record<
   },
 };
 
-/** Localised display name for a canton. */
-const CANTON_DISPLAY: Record<string, Record<Locale, string>> = {
-  AG: { it: 'Argovia', en: 'Aargau', de: 'Aargau', fr: 'Argovie' },
-  // Half-canton URL groups (2026-05-10 merge): AI+AR -> APPENZELLO, BL+BS -> BASILEA.
-  APPENZELLO: { it: 'Appenzello', en: 'Appenzell', de: 'Appenzell', fr: 'Appenzell' },
-  BE: { it: 'Berna', en: 'Bern', de: 'Bern', fr: 'Berne' },
-  BASILEA: { it: 'Basilea', en: 'Basel', de: 'Basel', fr: 'Bâle' },
-  FR: { it: 'Friburgo', en: 'Fribourg', de: 'Freiburg', fr: 'Fribourg' },
-  GE: { it: 'Ginevra', en: 'Geneva', de: 'Genf', fr: 'Genève' },
-  GL: { it: 'Glarona', en: 'Glarus', de: 'Glarus', fr: 'Glaris' },
-  GR: { it: 'Grigioni', en: 'Graubünden', de: 'Graubünden', fr: 'Grisons' },
-  JU: { it: 'Giura', en: 'Jura', de: 'Jura', fr: 'Jura' },
-  LU: { it: 'Lucerna', en: 'Lucerne', de: 'Luzern', fr: 'Lucerne' },
-  NE: { it: 'Neuchâtel', en: 'Neuchâtel', de: 'Neuenburg', fr: 'Neuchâtel' },
-  NW: { it: 'Nidvaldo', en: 'Nidwalden', de: 'Nidwalden', fr: 'Nidwald' },
-  OW: { it: 'Obvaldo', en: 'Obwalden', de: 'Obwalden', fr: 'Obwald' },
-  SG: { it: 'San Gallo', en: 'St. Gallen', de: 'St. Gallen', fr: 'Saint-Gall' },
-  SH: { it: 'Sciaffusa', en: 'Schaffhausen', de: 'Schaffhausen', fr: 'Schaffhouse' },
-  SO: { it: 'Soletta', en: 'Solothurn', de: 'Solothurn', fr: 'Soleure' },
-  SZ: { it: 'Svitto', en: 'Schwyz', de: 'Schwyz', fr: 'Schwytz' },
-  TG: { it: 'Turgovia', en: 'Thurgau', de: 'Thurgau', fr: 'Thurgovie' },
-  TI: { it: 'Ticino', en: 'Ticino', de: 'Tessin', fr: 'Tessin' },
-  UR: { it: 'Uri', en: 'Uri', de: 'Uri', fr: 'Uri' },
-  VD: { it: 'Vaud', en: 'Vaud', de: 'Waadt', fr: 'Vaud' },
-  VS: { it: 'Vallese', en: 'Valais', de: 'Wallis', fr: 'Valais' },
-  ZG: { it: 'Zugo', en: 'Zug', de: 'Zug', fr: 'Zoug' },
-  ZH: { it: 'Zurigo', en: 'Zürich', de: 'Zürich', fr: 'Zurich' },
-};
+// Localised canton display names: shared single source of truth
+// (build-plugins/shared/cantonDisplay.ts) — CLAUDE.md rule #6.
+import { CANTON_DISPLAY } from './shared/cantonDisplay';
 
 interface CantonSlugFile {
   cantons: Record<string, Record<Locale, string>>;

--- a/services/router.ts
+++ b/services/router.ts
@@ -48,6 +48,7 @@ import { JOB_RECENCY_LANDING_SLUGS as RECENCY_LANDING_SLUGS } from '../build-plu
 import { FUEL_DAILY_ROUTES, isFuelDailyPath } from '../build-plugins/fuelDailyData';
 import { HEALTH_PREMIUMS_ROUTES, isHealthPremiumsPath } from '../build-plugins/healthPremiumsData';
 import { JOB_MARKET_SNAPSHOT_ROUTES, isJobMarketSnapshotPath } from '../build-plugins/jobMarketSnapshotData';
+import { SALARY_STATS_ROUTES, isSalaryStatsPath, parseSalaryStatsPath } from '../build-plugins/salaryStatsData';
 import { parseOrphanLandingPath as ORPHAN_LANDING_ROUTES } from '../build-plugins/orphanQueryData';
 import { WEEKLY_EMPLOYERS_ROUTES, parseCompanyCityPath, parseWeeklyEmployersPath, parseWeeklyEmployersTopHubPath } from '../build-plugins/weeklyEmployersData';
 import { BORDER_WAIT_ROUTES, isBorderWaitPath, parseBorderWaitPath } from '../build-plugins/borderWaitData';
@@ -2272,6 +2273,14 @@ export function parsePath(pathname: string): ParseResult {
  // visible so the SPA doesn't replace it with the generic Statistiche sub-tab.
  if (HEALTH_PREMIUMS_ROUTES.includes(pathname.endsWith('/') ? pathname : `${pathname}/`) || isHealthPremiumsPath(pathname)) {
    return { route: { activeTab: 'stats', statsSubTab: 'health-premiums', staticOverlay: true }, locale };
+ }
+
+ // Per-canton salary statistics landings (F-salary) — /stipendi-{canton}/ +
+ // localised variants. Build-time static HTML; staticOverlay keeps the
+ // per-canton salary content visible (hydrates to the salary-compare sub-tab).
+ if (SALARY_STATS_ROUTES.includes(pathname.endsWith('/') ? pathname : `${pathname}/`) || isSalaryStatsPath(pathname)) {
+   const parsed = parseSalaryStatsPath(pathname);
+   return { route: { activeTab: 'stats', statsSubTab: 'salary-compare', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
  }
 
  // Weekly "Aziende che assumono" per-city hub (F5) — build-time static HTML.

--- a/services/router.ts
+++ b/services/router.ts
@@ -48,7 +48,7 @@ import { JOB_RECENCY_LANDING_SLUGS as RECENCY_LANDING_SLUGS } from '../build-plu
 import { FUEL_DAILY_ROUTES, isFuelDailyPath } from '../build-plugins/fuelDailyData';
 import { HEALTH_PREMIUMS_ROUTES, isHealthPremiumsPath } from '../build-plugins/healthPremiumsData';
 import { JOB_MARKET_SNAPSHOT_ROUTES, isJobMarketSnapshotPath } from '../build-plugins/jobMarketSnapshotData';
-import { SALARY_STATS_ROUTES, isSalaryStatsPath, parseSalaryStatsPath } from '../build-plugins/salaryStatsData';
+import { isSalaryStatsPath, parseSalaryStatsPath } from '../build-plugins/salaryStatsData';
 import { parseOrphanLandingPath as ORPHAN_LANDING_ROUTES } from '../build-plugins/orphanQueryData';
 import { WEEKLY_EMPLOYERS_ROUTES, parseCompanyCityPath, parseWeeklyEmployersPath, parseWeeklyEmployersTopHubPath } from '../build-plugins/weeklyEmployersData';
 import { BORDER_WAIT_ROUTES, isBorderWaitPath, parseBorderWaitPath } from '../build-plugins/borderWaitData';
@@ -2278,7 +2278,7 @@ export function parsePath(pathname: string): ParseResult {
  // Per-canton salary statistics landings (F-salary) — /stipendi-{canton}/ +
  // localised variants. Build-time static HTML; staticOverlay keeps the
  // per-canton salary content visible (hydrates to the salary-compare sub-tab).
- if (SALARY_STATS_ROUTES.includes(pathname.endsWith('/') ? pathname : `${pathname}/`) || isSalaryStatsPath(pathname)) {
+ if (isSalaryStatsPath(pathname)) {
    const parsed = parseSalaryStatsPath(pathname);
    return { route: { activeTab: 'stats', statsSubTab: 'salary-compare', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
  }

--- a/tests/salary-stats-landing.test.ts
+++ b/tests/salary-stats-landing.test.ts
@@ -71,17 +71,34 @@ describe('salaryStats — router integration', () => {
 });
 
 describe('salaryStats — page render', () => {
-  it('renders an indexable page per canton with the canton name + median', () => {
+  it('every (canton × locale) page clears the indexable-words gate (no router-route-without-page 404)', () => {
+    let rendered = 0;
     for (const locale of SALARY_STATS_LOCALES) {
-      for (const key of SALARY_STATS_CANTON_KEYS.slice(0, 4)) {
+      for (const key of SALARY_STATS_CANTON_KEYS) {
         const slug = SALARY_STATS_CANTON_SLUGS[key][locale];
         const { html, words } = renderSalaryStatsPage({ locale, cantonKey: key, cantonSlug: slug, distDir: '' });
         expect(words).toBeGreaterThanOrEqual(50);
         expect(html).toContain('CHF');
         expect(html).toContain(buildSalaryStatsPath(locale, slug));
+        // hreflang cluster present (all 4 locale variants cross-linked).
+        // The HTML minifier strips attribute quotes, so match unquoted.
+        expect(html).toMatch(/hreflang=["']?en["']?/);
+        expect(html).toMatch(/hreflang=["']?x-default["']?/);
         // No dark: color prefixes (CLAUDE.md non-negotiable).
         expect(html).not.toMatch(/\bdark:[a-z-]/);
+        rendered++;
       }
     }
+    expect(rendered).toBe(96);
+  });
+
+  it('half-canton groups get region figures, not silent national fallback', () => {
+    // APPENZELLO → Ostschweiz median 6623 (≈94% of national 7024) — diverges
+    // enough that the gross band must scale BELOW the national anchor. Before
+    // the fix the display name "Appenzello" missed the display→region table and
+    // the band silently fell back to the national 110'000 high.
+    const { html } = renderSalaryStatsPage({ locale: 'it', cantonKey: 'APPENZELLO', cantonSlug: 'appenzello', distDir: '' });
+    expect(html).toContain('94%'); // vs-national tile (region median path)
+    expect(html).toContain("105'000"); // gross-band high = round5000(110000 × 6623/7024), region-scaled
   });
 });

--- a/tests/salary-stats-landing.test.ts
+++ b/tests/salary-stats-landing.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-canton salary-statistics landing family — routing, slug parity and
+ * render invariants.
+ */
+import { describe, it, expect } from 'vitest';
+
+import cantonSlugsRaw from '../data/canton-url-slugs.json';
+import {
+  SALARY_STATS_ROUTES,
+  SALARY_STATS_CANTON_KEYS,
+  SALARY_STATS_CANTON_SLUGS,
+  SALARY_STATS_LOCALES,
+  parseSalaryStatsPath,
+  isSalaryStatsPath,
+  buildSalaryStatsPath,
+} from '../build-plugins/salaryStatsData';
+import { renderSalaryStatsPage } from '../build-plugins/salaryStatsChCantonPages';
+import { parsePath } from '../services/router';
+
+describe('salaryStatsData — path enumeration', () => {
+  it('emits one path per locale × canton (24 cantons × 4 = 96)', () => {
+    expect(SALARY_STATS_CANTON_KEYS.length).toBe(24);
+    expect(SALARY_STATS_ROUTES.length).toBe(96);
+  });
+
+  it('every path is normalized with a trailing slash', () => {
+    for (const p of SALARY_STATS_ROUTES) expect(p).toMatch(/\/$/);
+  });
+
+  it('parseSalaryStatsPath round-trips every canonical path', () => {
+    for (const p of SALARY_STATS_ROUTES) {
+      const parsed = parseSalaryStatsPath(p);
+      expect(parsed).toBeTruthy();
+      expect(parsed!.path).toBe(p);
+      expect(isSalaryStatsPath(p)).toBe(true);
+    }
+  });
+
+  it('non-matching paths return null', () => {
+    expect(parseSalaryStatsPath('/stipendi/')).toBeNull();
+    expect(parseSalaryStatsPath('/en/salaries/')).toBeNull();
+    expect(isSalaryStatsPath('/cerca-lavoro-zurigo/')).toBe(false);
+  });
+});
+
+describe('salaryStatsData — slug parity with canton-url-slugs.json', () => {
+  const jsonCantons = (cantonSlugsRaw as { cantons: Record<string, Record<string, string>> }).cantons;
+
+  it('covers exactly the same canton keys as the JSON', () => {
+    expect([...SALARY_STATS_CANTON_KEYS].sort()).toEqual(Object.keys(jsonCantons).sort());
+  });
+
+  it('base slugs match the JSON for all locales', () => {
+    for (const key of SALARY_STATS_CANTON_KEYS) {
+      for (const locale of SALARY_STATS_LOCALES) {
+        expect(SALARY_STATS_CANTON_SLUGS[key][locale]).toBe(jsonCantons[key][locale]);
+      }
+    }
+  });
+});
+
+describe('salaryStats — router integration', () => {
+  it('parsePath returns stats/salary-compare with staticOverlay for every path', () => {
+    for (const p of SALARY_STATS_ROUTES) {
+      const { route } = parsePath(p);
+      expect(route.staticOverlay).toBe(true);
+      expect(route.activeTab).toBe('stats');
+      expect(route.statsSubTab).toBe('salary-compare');
+    }
+  });
+});
+
+describe('salaryStats — page render', () => {
+  it('renders an indexable page per canton with the canton name + median', () => {
+    for (const locale of SALARY_STATS_LOCALES) {
+      for (const key of SALARY_STATS_CANTON_KEYS.slice(0, 4)) {
+        const slug = SALARY_STATS_CANTON_SLUGS[key][locale];
+        const { html, words } = renderSalaryStatsPage({ locale, cantonKey: key, cantonSlug: slug, distDir: '' });
+        expect(words).toBeGreaterThanOrEqual(50);
+        expect(html).toContain('CHF');
+        expect(html).toContain(buildSalaryStatsPath(locale, slug));
+        // No dark: color prefixes (CLAUDE.md non-negotiable).
+        expect(html).not.toMatch(/\bdark:[a-z-]/);
+      }
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,7 @@ import { weatherAlertPagesPlugin } from './build-plugins/weatherAlertPagesPlugin
 import { weatherBorderWaitFusionPlugin } from './build-plugins/weatherBorderWaitFusionPlugin';
 import { weeklyEmployersPlugin } from './build-plugins/weeklyEmployersPlugin';
 import { jobMarketSnapshotPlugin } from './build-plugins/jobMarketSnapshotPlugin';
+import { salaryStatsChCantonPages } from './build-plugins/salaryStatsChCantonPages';
 import { healthPremiumsLandingPlugin } from './build-plugins/healthPremiumsLandingPlugin';
 // blogContextualLinksPlugin import retained for tests / type re-exports.
 // Its plugin export is now consumed internally by `postWalkCoordinatorPlugin`.
@@ -152,6 +153,7 @@ export default defineConfig(({ mode }) => {
  weatherAlertPagesPlugin(__dirname),
  weeklyEmployersPlugin(__dirname),
  jobMarketSnapshotPlugin(__dirname),
+ salaryStatsChCantonPages(__dirname),
  healthPremiumsLandingPlugin(__dirname),
  borderWaitPagesPlugin(__dirname),
  weatherBorderWaitFusionPlugin(__dirname),


### PR DESCRIPTION
## Implementato

Nuova famiglia di **landing SEO statistiche salari per-cantone**: una pagina statica per (cantone × locale) — IT `/stipendi-zurigo/`, EN `/en/salaries-zurich/`, DE `/de/gehaelter-zurich/`, FR `/fr/salaires-zurich/` — 24 cantoni × 4 lingue = **96 pagine**. Completa il lato "pagine di statistiche per cantone" del lavoro salari per-cantone (dopo PR #2068 estimazione + #2072 SalaryCompare selettore).

- **`build-plugins/salaryStatsChCantonPages.ts`** — plugin SSG (`apply:'build'`, `enforce:'post'`, emit in `closeBundle()`, `distDir` via rootDir). Ogni pagina: breadcrumb, header+lede, **stat tile** (mediana mensile BFS della Grossregion + annua + % vs nazionale + band ruolo professionale), tabella **salari per settore** (scalati per cantone), **netto mensile** stimato, CTA al calcolatore, metodologia/fonti, e la **prose canton-aware** riusata (`renderCantonSeoProse`, già con contenuto salari per-cantone da #2068) + FAQ. JSON-LD: BreadcrumbList + **Dataset** (creator BFS) + FAQPage. `robots: index,follow` (pagine dati ricche, ≥50 parole — gate `MIN_INDEXABLE_WORDS`).
- **`build-plugins/salaryStatsData.ts`** — modulo routing SPA+config-safe (slug inline, niente `fs`/JSON-import): `SALARY_STATS_ROUTES`, `buildSalaryStatsPath`, `parseSalaryStatsPath`, `isSalaryStatsPath`. Fonti dati salari da `cantonSalaryIndex` (BFS, da #2068).
- **`services/router.ts`** — `parsePath` riconosce le nuove route → `{ activeTab:'stats', statsSubTab:'salary-compare', staticOverlay:true }` (hydrate sul SalaryCompare per-cantone di #2072).
- **`vite.config.ts`** — plug registrato dopo `jobMarketSnapshotPlugin` (gate `SKIP_SALARY_STATS=1`).
- **Consolidamento (rule #6, net-reducing):** estratto **`build-plugins/shared/cantonDisplay.ts`** come unica fonte dei nomi cantone localizzati; migrati i 2 consumer con la mappa LETTERALE identica (`jobMarketSnapshotChCantonPages`, `weeklyEmployersChCantonPages`) all'import condiviso (4 copie → 1). `jobEditorialLanding` NON migrato: la sua mappa è auto-generata via IIFE da `canton-url-slugs.json` (non un duplicato letterale).
- **Test** `tests/salary-stats-landing.test.ts`: enumerazione 96 path + trailing-slash, round-trip parse, **parità slug vs `canton-url-slugs.json`** (guard drift), integrazione router (staticOverlay), render (≥50 parole, CHF, no `dark:`). Verde + 37 test `job-market-snapshot` verdi (migrazione OK) + 483 router + sitemap-consistency + hreflang + prose verdi; `tsc --noEmit` pulito.

## Non implementato (ancora)

- **professionLandings per-cantone (#3)**: famiglia separata (professioni × 26 cantoni × 4 lingue ≈ 1000-1500 pagine) → rischio inode/dist limit (sharding necessario). PR successiva dedicata.
- **Modello fiscale netto per-cantone**: i netti in pagina sono stimati con l'approssimazione nazionale scalata (come in #2072), non con l'imposta alla fonte cantonale specifica — follow-up.
- **Validazione build/emit live**: l'emit SSG non è validabile localmente (build SEO OOM); le 96 pagine + sitemap si osservano sul deploy post-merge (curl path live + build-id). Se l'emit OOMa o il conteggio pagine regredisce il deploy → revert del plugin (gate `SKIP_SALARY_STATS=1` disponibile).
- **Moratorium SEO**: nuova famiglia di landing autorizzata dall'owner (posizione GSC 7gg ≤ 7.5 confermata).
