### PR TITLE
feat(newsletter): PostHog funnel for subject A/B (per-provider winner)

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -1,0 +1,65 @@
+# Newsletter subject-line A/B test (per provider)
+
+Optimize newsletter **open rate per sending provider** by testing two
+subject-line styles. Variant assignment is ours (deterministic); measurement has
+two independent readouts: a **free Firestore report** and an optional
+**PostHog funnel**.
+
+## How it works
+
+1. **Variants** — `services/newsletter-subject-variants.mjs` defines two styles:
+   - `concreto` — number + location + concrete benefit
+   - `curioso` — curiosity gap / question hook
+2. **Assignment** — `assignSubjectVariant(email, campaignId)` hashes the email
+   (sha256) into a variant. Deterministic: stable within a weekly campaign,
+   rotates across campaigns. **Independent of the sending provider** (the cascade
+   picks the provider by quota at send time), so every provider sees a ~50/50
+   variant mix → the provider×variant comparison is unbiased.
+3. **Send** — `scripts/send-newsletter.mjs` generates one AI subject per
+   `(locale × variant)`, sends each subscriber their assigned variant, tags the
+   email (`tags.variant`) and persists `provider`/`variant`/`subject` on the
+   send doc.
+4. **Measurement** — opens are recorded by the ESP webhooks. The winner is read
+   two ways (below).
+
+## Reading the result
+
+### A. Firestore report (free, always on)
+
+```bash
+node scripts/newsletter-ab-report.mjs                       # latest weekly
+node scripts/newsletter-ab-report.mjs --campaign weekly_2026-06-15
+node scripts/newsletter-ab-report.mjs --json
+```
+
+Cross-tabs open rate by `provider × variant`, flags the per-provider winner and
+runs a two-proportion z-test. Source of truth = Firestore send docs + open
+events; immune to the per-provider webhook doc-id divergence.
+
+### B. PostHog funnel (optional, richer UI)
+
+Disabled by default. When enabled, the send path emits `email_sent` (exposure,
+carries `subject_variant` + `email_provider`) and the webhooks emit
+`email_opened` on open. Both share `distinct_id = email`, so in PostHog:
+
+1. Build a **Funnel**: step 1 `email_sent` → step 2 `email_opened`.
+2. **Breakdown by** `subject_variant` (and/or `email_provider`).
+3. PostHog reports conversion (= open rate) per arm with significance.
+
+The variant is **not** assigned by a PostHog feature flag — our hash owns
+assignment, so the experiment keeps working even if PostHog is down/over-quota.
+
+#### Enabling
+
+Set on both runtimes (off → no events emitted, zero PostHog volume):
+
+| Env | Where | Purpose |
+|-----|-------|---------|
+| `POSTHOG_EMAIL_EXPERIMENT=1` | send-newsletter CI env **and** Cloud Functions runtime | master switch |
+| `POSTHOG_PROJECT_KEY` | both (optional) | defaults to the public client key |
+| `POSTHOG_HOST` | both (optional) | defaults to `https://eu.i.posthog.com` |
+
+⚠️ **Quota**: the PostHog free tier (1M events/mo) is already tight and has
+caused outages. This emits only 2 events per subscriber per campaign, but keep
+it off until you actually need the PostHog UI — the Firestore report covers the
+decision for free.

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -1,0 +1,83 @@
+/**
+ * emailExperimentPostHog.js — server-side PostHog capture for the subject-line
+ * A/B experiment.
+ *
+ * The variant is assigned by our own deterministic hash (see
+ * services/newsletter-subject-variants.mjs) — NOT by a PostHog feature flag — so
+ * assignment stays robust even if PostHog is down/over-quota. PostHog is used
+ * ONLY for measurement: we emit two events per subscriber and read the result
+ * as a funnel `email_sent → email_opened` broken down by `subject_variant` and
+ * `email_provider`.
+ *
+ * Quota-conscious by design (PostHog free tier is tight — see the posthog quota
+ * outage history): it emits ONLY these two events, and is a NO-OP unless
+ * POSTHOG_EMAIL_EXPERIMENT is explicitly enabled. The free Firestore report
+ * (scripts/newsletter-ab-report.mjs) keeps working regardless.
+ *
+ * Lives under functions/src/lib so BOTH the Cloud Functions webhooks AND the
+ * send-newsletter script (which already imports from here, e.g.
+ * engagementScore.js) can share it without a cross-runtime import. Uses the
+ * PostHog capture HTTP API via global fetch — no posthog-node dependency.
+ *
+ * Env:
+ *   POSTHOG_EMAIL_EXPERIMENT  '1'|'true' to enable (default: disabled → no-op)
+ *   POSTHOG_PROJECT_KEY       PostHog project write key (phc_…); defaults to the
+ *                             public project key already shipped in the client.
+ *   POSTHOG_HOST              ingestion host (default EU cloud ingest).
+ */
+
+// Public project key — identical to the one embedded client-side in
+// services/posthog.ts (a project write key is not a secret; it is shipped in the
+// browser bundle). Overridable via POSTHOG_PROJECT_KEY.
+const DEFAULT_PUBLIC_KEY = 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT';
+
+const POSTHOG_HOST = (process.env.POSTHOG_HOST || 'https://eu.i.posthog.com').replace(/\/$/, '');
+const POSTHOG_KEY = process.env.POSTHOG_PROJECT_KEY || DEFAULT_PUBLIC_KEY;
+const ENABLED = ['1', 'true', 'yes'].includes(String(process.env.POSTHOG_EMAIL_EXPERIMENT || '').toLowerCase());
+
+/** Canonical event names — single source of truth for emit + analysis. */
+export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
+  SENT: 'email_sent',     // exposure: subscriber entered the experiment with a variant
+  OPENED: 'email_opened', // conversion: subscriber opened the email
+});
+
+/** @returns {boolean} whether server-side experiment capture is active. */
+export function isEmailExperimentEnabled() {
+  return ENABLED && !!POSTHOG_KEY;
+}
+
+/**
+ * Capture one experiment event in PostHog. Fire-and-forget safe: never throws,
+ * returns false on any failure so callers can ignore the result. No-op unless
+ * the experiment is enabled and an email (the distinct_id) is present.
+ *
+ * @param {string} event  one of EMAIL_EXPERIMENT_EVENTS
+ * @param {object} props  { email, variant?, provider?, campaignId?, locale? }
+ * @returns {Promise<boolean>} true if PostHog accepted the event
+ */
+export async function captureEmailEvent(event, props = {}) {
+  const { email, variant, provider, campaignId, locale } = props;
+  if (!isEmailExperimentEnabled() || !email) return false;
+  try {
+    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        api_key: POSTHOG_KEY,
+        event,
+        distinct_id: String(email).toLowerCase(),
+        properties: {
+          // distinct_id ties sent↔open; breakdown keys for the funnel readout.
+          subject_variant: variant || null,
+          email_provider: provider || null,
+          campaign_id: campaignId || null,
+          locale: locale || null,
+          $lib: 'email-ab-server',
+        },
+      }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 /**
  * Maileroo webhook handler — receives delivery events and stores them in Firestore.
@@ -211,6 +212,9 @@ export async function persistMailerooEvent(db, event) {
     occurred_at: occurredAt,
   });
 
+  if (type === 'open') {
+    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'maileroo', campaignId });
+  }
   return { processed: true, type, email, campaignId };
 }
 

--- a/functions/src/newsletterMailgunWebhookCore.js
+++ b/functions/src/newsletterMailgunWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 /**
  * Mailgun webhook handler — receives delivery events and stores them in Firestore.
@@ -169,6 +170,9 @@ async function persistMailgunEvent(db, eventData) {
  occurred_at: timestamp,
  });
 
+ if (type === 'open') {
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailgun', campaignId });
+ }
  return { processed: true, type, email, campaignId };
 }
 

--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -1,5 +1,6 @@
 import admin from 'firebase-admin';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 /**
  * Mailjet webhook handler — receives delivery events and stores them in Firestore.
@@ -169,6 +170,9 @@ export async function persistMailjetEvent(db, eventData) {
  occurred_at: timestamp,
  });
 
+ if (type === 'open') {
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailjet', campaignId });
+ }
  return { processed: true, type, email, campaignId };
 }
 

--- a/functions/src/newsletterMailtrapWebhookCore.js
+++ b/functions/src/newsletterMailtrapWebhookCore.js
@@ -1,5 +1,6 @@
 import admin from 'firebase-admin';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 /**
  * Mailtrap webhook handler — receives delivery events and stores them in Firestore.
@@ -157,6 +158,9 @@ async function persistMailtrapEvent(db, eventData) {
  occurred_at: occurredAt,
  });
 
+ if (type === 'open') {
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailtrap', campaignId });
+ }
  return { processed: true, type, email, campaignId };
 }
 

--- a/functions/src/newsletterResendWebhookCore.js
+++ b/functions/src/newsletterResendWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { Resend } from 'resend';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 function normalizeEmail(value) {
  return String(value || '').trim().toLowerCase();
@@ -289,6 +290,9 @@ export async function applyResendWebhookEvent(rawEvent, options = {}) {
  occurred_at: occurredAt,
  });
 
+ if (type === 'open') {
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'resend', campaignId, variant, locale });
+ }
  return { handled: true, email, type, campaignId };
 }
 

--- a/functions/src/newsletterUnosendWebhookCore.js
+++ b/functions/src/newsletterUnosendWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 
 /**
  * Unosend webhook handler — receives delivery events and stores them in Firestore.
@@ -196,6 +197,9 @@ async function persistUnosendEvent(db, eventType, eventData) {
  occurred_at: timestamp,
  });
 
+ if (type === 'open') {
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'unosend', campaignId });
+ }
  return { processed: true, type, email, campaignId };
 }
 

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -35,6 +35,7 @@ import { buildNewsletter, FEATURED_TOOLS, getFeaturedTools, nlNormLocale, direct
 import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, companyPageUrl, isCompanyHubSlug } from '../services/newsletter-content.mjs';
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
 import { assignSubjectVariant, getVariantFallback, listVariantIds } from '../services/newsletter-subject-variants.mjs';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib/emailExperimentPostHog.js';
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
@@ -1464,6 +1465,16 @@ async function persistDelivery(recipient, messageId, meta) {
     if (FieldValue) {
       await refreshEngagementScore(subRef, FieldValue);
     }
+    // A/B exposure event (no-op unless POSTHOG_EMAIL_EXPERIMENT enabled). Ties to
+    // the email_opened conversion in PostHog by distinct_id (email); carries the
+    // variant + provider for the funnel breakdown.
+    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.SENT, {
+      email,
+      variant: meta.variant,
+      provider: meta.provider,
+      campaignId: meta.campaignId,
+      locale: recipient.locale,
+    });
   } catch (e) {
     console.warn('\u26a0\ufe0f Delivery persist failed:', e?.message);
   }

--- a/tests/email-experiment-posthog.test.ts
+++ b/tests/email-experiment-posthog.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const MODULE = '@/functions/src/lib/emailExperimentPostHog.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('emailExperimentPostHog — disabled by default', () => {
+  it('exposes the two canonical event names', async () => {
+    const { EMAIL_EXPERIMENT_EVENTS } = await import(MODULE);
+    expect(EMAIL_EXPERIMENT_EVENTS.SENT).toBe('email_sent');
+    expect(EMAIL_EXPERIMENT_EVENTS.OPENED).toBe('email_opened');
+  });
+
+  it('is a no-op (no network) when POSTHOG_EMAIL_EXPERIMENT is unset', async () => {
+    vi.resetModules();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const { captureEmailEvent, isEmailExperimentEnabled } = await import(MODULE);
+    expect(isEmailExperimentEnabled()).toBe(false);
+    const ok = await captureEmailEvent('email_sent', { email: 'a@b.com', variant: 'curioso', provider: 'mailjet' });
+    expect(ok).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('emailExperimentPostHog — enabled', () => {
+  it('POSTs the event to PostHog with the expected payload', async () => {
+    vi.resetModules();
+    vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', '1');
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'phc_test_key');
+    vi.stubEnv('POSTHOG_HOST', 'https://ph.example.com');
+    const fetchSpy = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } = await import(MODULE);
+    const ok = await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, {
+      email: 'Mario@Example.com',
+      variant: 'concreto',
+      provider: 'mailgun',
+      campaignId: 'weekly_2026-06-15',
+      locale: 'it',
+    });
+
+    expect(ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://ph.example.com/capture/');
+    const body = JSON.parse(opts.body);
+    expect(body.api_key).toBe('phc_test_key');
+    expect(body.event).toBe('email_opened');
+    expect(body.distinct_id).toBe('mario@example.com'); // lowercased
+    expect(body.properties.subject_variant).toBe('concreto');
+    expect(body.properties.email_provider).toBe('mailgun');
+    expect(body.properties.campaign_id).toBe('weekly_2026-06-15');
+  });
+
+  it('still no-ops when email (distinct_id) is missing', async () => {
+    vi.resetModules();
+    vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', 'true');
+    const fetchSpy = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const { captureEmailEvent } = await import(MODULE);
+    expect(await captureEmailEvent('email_sent', { variant: 'curioso' })).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('never throws when fetch rejects', async () => {
+    vi.resetModules();
+    vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', '1');
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    const { captureEmailEvent } = await import(MODULE);
+    await expect(captureEmailEvent('email_opened', { email: 'x@y.com' })).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Lettura del vincitore A/B titoli **via PostHog** (come authgate), su richiesta esplicita. Misura come funnel `email_sent → email_opened` con breakdown per `subject_variant` × `email_provider`. **Spento di default** — zero impatto finché non abilitato.

- **`functions/src/lib/emailExperimentPostHog.js` (nuovo)** — helper condiviso server-side, capture via `fetch` sull'HTTP API di PostHog (nessuna dipendenza `posthog-node`). No-op a meno di `POSTHOG_EMAIL_EXPERIMENT` abilitato. Vive in `functions/src/lib` così che **sia le Cloud Functions sia lo script send-newsletter** lo importino (stesso precedente di `engagementScore.js`, ESM su entrambi i runtime — niente import cross-runtime services↔functions).
- **`scripts/send-newsletter.mjs`** — in `persistDelivery` emette `email_sent` (esposizione) con `subject_variant` + `email_provider` + `campaign_id`. `distinct_id = email`.
- **6 webhook ESP** (`Resend/Mailjet/Mailgun/Mailtrap/Maileroo/Unosend`) — emettono `email_opened` (conversione) sul branch open, con `email_provider` per-provider. Stesso `distinct_id` → il funnel lega sent↔open.
- **Assegnazione variante = nostro hash deterministico, NON un feature-flag PostHog** → resta robusta anche se PostHog è down/over-quota (assegnazione disaccoppiata dalla misura).
- **Quota-consapevole**: solo 2 eventi/iscritto/campagna; il report Firestore gratuito (`newsletter-ab-report.mjs`) resta il path di decisione di default.
- **`docs/NEWSLETTER-SUBJECT-AB.md` (nuovo)** — come abilitare (env su entrambi i runtime) + come costruire il funnel/breakdown in PostHog, con warning quota.
- **Test** (`tests/email-experiment-posthog.test.ts`): no-op da disabilitato (nessun fetch), payload corretto da abilitato (url/api_key/distinct_id lowercased/properties), no-op senza email, mai throw se fetch rigetta. 32/32 verde con i test varianti.

## Non implementato (ancora)

- **PostHog native Experiment object + feature-flag assignment** — di proposito NON usato: assegneremmo la variante via flag PostHog perdendo robustezza se PostHog è giù. Usiamo funnel+breakdown sui 2 eventi, che dà lo stesso readout (conversione+significatività per arm) mantenendo il nostro hash come owner dell'assegnazione.
- **Default ON** — lasciato OFF per la quota free-tier già sforata (storia outage). Va acceso a mano (`POSTHOG_EMAIL_EXPERIMENT=1`) su CI send + runtime Functions quando si vuole la UI PostHog. Senza accensione, comportamento invariato.
- **Promozione automatica del vincitore** — fuori scope: questa PR aggiunge solo la *misura* PostHog. La promozione (sbilanciare i nuovi invii verso il vincitore) resta manuale/follow-up.
- **Forward di delivered/click/bounce a PostHog** — non inoltrati di proposito (solo sent+open servono al funnel open-rate; meno volume = meno quota).
- **Sibling `campaignId` (6 file: backfill-newsletter-campaign-ids, email-cascade, newsletter-ab-report, analytics.ts, newsletter-subject-variants, newsletterSubscribers)** — flaggati dal sibling-check per il solo token condiviso, NON stesso antipattern (è wiring additivo PostHog). In particolare `newsletter-ab-report.mjs` è il readout Firestore complementare, lasciato invariato di proposito. Nessuna modifica necessaria.

## Test plan

- [x] `node --check` su helper + send-newsletter + 6 webhook
- [x] vitest helper + varianti → 32/32
- [x] sibling-check eseguito; sibling giustificati sopra
- [ ] Post-merge (solo se si abilita): `POSTHOG_EMAIL_EXPERIMENT=1`, invio reale, verificare in PostHog l'arrivo di `email_sent`/`email_opened` e costruire il funnel breakdown (verificabile solo live + con quota PostHog disponibile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)