### PR TITLE
fix(publisher): blast card city uses the CTA's location label

### DIFF
--- a/scripts/blast-publisher-ads.mjs
+++ b/scripts/blast-publisher-ads.mjs
@@ -124,6 +124,8 @@ async function main() {
         locale,
         adUrl: adUrlFor(locale),
         unsubscribeUrl: `${SITE}/?action=unsubscribe&email=${encodeURIComponent(r.email)}`,
+        // Same label the CTA slug is built from → card city and linked page agree.
+        locationLabel: firstLocationLabel,
       });
       try {
         const { error } = await resend.emails.send({ from: FROM_EMAIL, to: r.email, subject, html });

--- a/services/publisherBlastEmail.mjs
+++ b/services/publisherBlastEmail.mjs
@@ -113,15 +113,24 @@ function chip(label) {
  * @param {string} [args.locale]       it|en|de|fr (defaults to it).
  * @param {string} args.adUrl          absolute URL to the specific /lavoro/<slug>/ page (with UTM).
  * @param {string} args.unsubscribeUrl absolute unsubscribe URL.
+ * @param {string} [args.locationLabel] the SAME location the CTA slug is built from
+ *   (caller passes the distinctLocations-derived label). Keeps the card's city and
+ *   the CTA's target page consistent for bare-string / empty-first location shapes.
  * @returns {{ subject: string, html: string }}
  */
-export function buildBlastEmail({ ad, recipientEmail, locale = 'it', adUrl, unsubscribeUrl }) {
+export function buildBlastEmail({ ad, recipientEmail, locale = 'it', adUrl, unsubscribeUrl, locationLabel }) {
   const loc = LOCALES.includes(locale) ? locale : 'it';
   const s = STR[loc];
   const title = String(ad?.title || '').trim();
   const company = String(ad?.company?.name || '').trim();
-  const firstLoc = Array.isArray(ad?.locations) && ad.locations[0]
-    ? String(ad.locations[0].label || '').trim() : '';
+  // Prefer the caller-provided label (derived via distinctLocations, identical to
+  // the CTA slug) so the card city never diverges from the linked page; fall back
+  // to the raw first-location label only when not supplied.
+  const firstLoc = String(
+    locationLabel != null && String(locationLabel).trim()
+      ? locationLabel
+      : (Array.isArray(ad?.locations) && ad.locations[0] ? (ad.locations[0].label ?? ad.locations[0]) : ''),
+  ).trim();
   const logoUrl = String(ad?.company?.logoUrl || '').trim();
   const logoOk = /^https:\/\/\S+$/i.test(logoUrl);
   const initial = (company || title || '?')[0].toUpperCase();

--- a/tests/publisher-blast-email.test.ts
+++ b/tests/publisher-blast-email.test.ts
@@ -92,6 +92,20 @@ describe('buildBlastEmail', () => {
     const { html } = buildBlastEmail({ ...ARGS, ad: { ...AD, salaryMin: null, salaryMax: null } });
     expect(html).not.toContain('Retribuzione:');
   });
+
+  it('uses the caller-provided locationLabel for the card city (matches CTA slug)', () => {
+    // Degenerate shapes where ad.locations[0].label is empty but the CTA slug
+    // (and thus locationLabel) resolves to a real city — card must show it.
+    const bareString = buildBlastEmail({ ...ARGS, ad: { ...AD, locations: ['Lugano'] }, locationLabel: 'Lugano' });
+    expect(bareString.html).toContain('Lugano');
+    const emptyFirst = buildBlastEmail({ ...ARGS, ad: { ...AD, locations: [{ label: '  ' }, { label: 'Bellinzona' }] }, locationLabel: 'Bellinzona' });
+    expect(emptyFirst.html).toContain('Bellinzona');
+  });
+
+  it('falls back to the raw first location when no locationLabel passed', () => {
+    const { html } = buildBlastEmail({ ...ARGS, locationLabel: undefined });
+    expect(html).toContain('Lugano');
+  });
 });
 
 // Regression for the reviewer 🔴 (#2084): the CTA slug must match the emitted


### PR DESCRIPTION
## Implementato

Follow-up del 🟡 Nit della review #2084. La card dell'email blast derivava la città (`firstLoc`) da `ad.locations[0].label` grezzo, mentre lo slug del CTA usa `distinctLocations()[0].text` — divergono sulle shape degenerate (location bare-string `['Lugano']`, primo entry vuoto `[{label:'  '},{label:'Bellinzona'}]`): la card mostrava città vuota mentre il CTA puntava alla pagina di quella città.

- `services/publisherBlastEmail.mjs`: `buildBlastEmail` accetta `locationLabel`; quando fornito lo usa per la città della card (fallback al raw first-location quando assente).
- `scripts/blast-publisher-ads.mjs`: passa `firstLocationLabel` (già derivato via `distinctLocations`, identico allo slug del CTA) → card e pagina linkata concordano by-construction.
- `tests/publisher-blast-email.test.ts`: +3 test (bare-string, empty-first, fallback senza label).

## Non implementato (ancora)

- Nessuno scope ulteriore: chiude interamente il 🟡. Le altre note adversarial della review #2084 (trailing-slash+UTM redirect, ICU `de-CH` grouping) sono cosmetiche/runtime-dipendenti e già documentate lì come non-funnel-breaking.

## Test plan
- [x] `tests/publisher-blast-email.test.ts` 15 test verdi; `node --check` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)