### PR TITLE
feat(analytics): gate PostHog event capture on bot detection

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -356,13 +356,39 @@ export const GTAG_SNIPPET = `<script async crossorigin="anonymous" src="https://
  */
 export const POSTHOG_KEY = 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT';
 export const POSTHOG_HOST = 'https://t.frontaliereticino.ch';
+
+/**
+ * Client-side bot-detection literals shared by every static inline script.
+ *
+ * `BOT_PATTERNS_LITERAL` serialises services/botPatterns.ts `BOT_UA_PATTERNS`.
+ * `BOT_GATE_FN` is the inline-JS twin of services/botPatterns.ts `isLikelyBot()`
+ * — a function-expression string returning `true` for bot sessions. It is the
+ * SINGLE source for the bot gate in BOTH static inline scripts below
+ * (`ADSENSE_LOADER_CONTENT` + `POSTHOG_INIT_CONTENT`), so the logic is never
+ * copy-pasted. Behaviour is kept aligned with the TS `isLikelyBot()` by
+ * tests/bot-gate-parity.test.ts (same UA matrix, identical verdicts).
+ *
+ * Why a string and not the TS function: these run inside externalised plain-JS
+ * assets emitted at build time (no module graph), so the detection must be
+ * embedded literally. botPatterns.ts stays the source of truth for the pattern
+ * list; only the wrapper logic is necessarily re-expressed here.
+ */
+const BOT_PATTERNS_LITERAL = JSON.stringify(BOT_UA_PATTERNS);
+export const BOT_GATE_FN = `function(){var ua=(navigator.userAgent||'').toLowerCase();if(!ua||navigator.webdriver===true)return true;var P=${BOT_PATTERNS_LITERAL};for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return true;if(ua.indexOf('chrome')>=0&&!('chrome' in window))return true;if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){var L=navigator.languages;if(L&&L.length===0)return true;if(navigator.plugins&&navigator.plugins.length===0)return true;if(typeof navigator.permissions==='undefined')return true;}return false;}`;
+
 /**
  * Plain JS body for the PostHog snippet — written to dist/assets/posthog-init.js
  * by staticScriptsPlugin. The previous inline version was 1.2 KB embedded in every
  * static page using ANALYTICS_SNIPPET (~14k bridges + ~600 static-pages = ~17 MB).
  * After externalising, per-page cost drops from ~1.2 KB → ~80 B (the <script src> tag).
+ *
+ * BOT GATE: the entire stub-install + `posthog.init` runs only when `BOT_GATE_FN`
+ * reports a real user. On static pages this snippet sets `capture_pageview:true`,
+ * so without the gate every bot hit on a bridge/landing page fired a $pageview —
+ * a large slice of the free-tier 1M/mo event budget at zero analytics value.
+ * Mirrors the SPA gate in services/posthog.ts `ensurePostHog()`.
  */
-export const POSTHOG_INIT_CONTENT = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags identify setPersonProperties group resetGroups reset opt_in_capturing opt_out_capturing".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:true,capture_pageleave:true,autocapture:false,persistence:'localStorage'});`;
+export const POSTHOG_INIT_CONTENT = `if(!(${BOT_GATE_FN})()){!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags identify setPersonProperties group resetGroups reset opt_in_capturing opt_out_capturing".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:true,capture_pageleave:true,autocapture:false,persistence:'localStorage'});}`;
 export const POSTHOG_INIT_FILENAME = 'posthog-init.js';
 export const POSTHOG_SNIPPET = `<script src="/assets/${POSTHOG_INIT_FILENAME}"></script>`;
 
@@ -397,14 +423,15 @@ export const ADSENSE_SCRIPT_SRC = `https://pagead2.googlesyndication.com/pagead/
 /**
  * Inline lazy-loader injected at the bottom of every static page (and also
  * emitted from index.html). Runs once per page and:
- *  0. Bot gate: if the UA matches a BOT_UA_PATTERNS substring or
- *     navigator.webdriver === true, the loader returns immediately. This is
- *     the static-HTML counterpart to `<AdSenseBanner>`'s SKIP_FOR_BOT and
- *     extends the bot filter to Auto Ads (Anchor / In-page / Vignette) which
- *     are injected by adsbygoogle.js itself, bypassing the React component.
- *     ~95% of revenue comes from those Auto Ads formats — without this gate,
- *     bots still triggered the script load and inflated AD_REQUESTS at near-
- *     zero RPM. See services/botPatterns.ts for the shared pattern source.
+ *  0. Bot gate: `BOT_GATE_FN` (shared with POSTHOG_INIT_CONTENT, the inline-JS
+ *     twin of services/botPatterns.ts `isLikelyBot()`) returns true for bots —
+ *     the loader then returns immediately. This is the static-HTML counterpart
+ *     to `<AdSenseBanner>`'s SKIP_FOR_BOT and extends the bot filter to Auto Ads
+ *     (Anchor / In-page / Vignette) which are injected by adsbygoogle.js itself,
+ *     bypassing the React component. ~95% of revenue comes from those Auto Ads
+ *     formats — without this gate, bots still triggered the script load and
+ *     inflated AD_REQUESTS at near-zero RPM. See services/botPatterns.ts for the
+ *     shared pattern source.
  *  1. Watches every <ins class="adsbygoogle"> with IntersectionObserver
  *     (rootMargin 200px) — on first visible slot, loads adsbygoogle.js.
  *  2. Falls back to requestIdleCallback for pages without manual slots so Auto
@@ -421,14 +448,13 @@ export const ADSENSE_SCRIPT_SRC = `https://pagead2.googlesyndication.com/pagead/
  *     runs in a post-hydration effect (already after LCP), so it needs no gate.
  *  3. On script load, pushes {} for every slot currently in the DOM.
  */
-const BOT_PATTERNS_LITERAL = JSON.stringify(BOT_UA_PATTERNS);
 /**
  * Plain JS body for the AdSense lazy loader — written to dist/assets/adsense-loader.js
  * by staticScriptsPlugin. This was the LARGEST inline script in every static page:
  * ~2 KB minified × ~200k SEO pages = ~400 MB dist. Externalising drops per-page cost
  * from ~2200 B to ~90 B (the <script src=...> tag).
  */
-export const ADSENSE_LOADER_CONTENT = `(function(){var ua=(navigator.userAgent||'').toLowerCase();if(!ua||navigator.webdriver===true)return;var P=${BOT_PATTERNS_LITERAL};for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return;if(ua.indexOf('chrome')>=0&&!('chrome' in window))return;if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){var L=navigator.languages;if(L&&L.length===0)return;if(navigator.plugins&&navigator.plugins.length===0)return;if(typeof navigator.permissions==='undefined')return;}var loaded=false;function loadScript(){if(loaded)return;loaded=true;var s=document.createElement('script');s.async=true;s.crossOrigin='anonymous';s.src='${ADSENSE_SCRIPT_SRC}';s.setAttribute('data-overlays','bottom');s.setAttribute('data-ad-frequency-hint','60s');s.onload=function(){var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');for(var i=0;i<slots.length;i++){try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}}};document.head.appendChild(s);}function ricFb(cb){if(document.readyState==='complete'){setTimeout(cb,200);}else{window.addEventListener('load',function(){setTimeout(cb,200);},{once:true});}}function observe(){var EV=['scroll','touchstart','pointerdown','keydown','mousemove'];for(var e=0;e<EV.length;e++)document.addEventListener(EV[e],loadScript,{once:true,passive:true,capture:true});var slots=document.querySelectorAll('ins.adsbygoogle');if(!('IntersectionObserver' in window)||slots.length===0){(window.requestIdleCallback||ricFb)(loadScript,{timeout:1500});return;}var io=new IntersectionObserver(function(entries){for(var i=0;i<entries.length;i++){if(entries[i].isIntersecting){io.disconnect();loadScript();return;}}},{rootMargin:'200px 0px'});for(var j=0;j<slots.length;j++)io.observe(slots[j]);(window.requestIdleCallback||ricFb)(loadScript,{timeout:2500});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',observe,{once:true});}else{observe();}})();`;
+export const ADSENSE_LOADER_CONTENT = `(function(){if((${BOT_GATE_FN})())return;var loaded=false;function loadScript(){if(loaded)return;loaded=true;var s=document.createElement('script');s.async=true;s.crossOrigin='anonymous';s.src='${ADSENSE_SCRIPT_SRC}';s.setAttribute('data-overlays','bottom');s.setAttribute('data-ad-frequency-hint','60s');s.onload=function(){var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');for(var i=0;i<slots.length;i++){try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}}};document.head.appendChild(s);}function ricFb(cb){if(document.readyState==='complete'){setTimeout(cb,200);}else{window.addEventListener('load',function(){setTimeout(cb,200);},{once:true});}}function observe(){var EV=['scroll','touchstart','pointerdown','keydown','mousemove'];for(var e=0;e<EV.length;e++)document.addEventListener(EV[e],loadScript,{once:true,passive:true,capture:true});var slots=document.querySelectorAll('ins.adsbygoogle');if(!('IntersectionObserver' in window)||slots.length===0){(window.requestIdleCallback||ricFb)(loadScript,{timeout:1500});return;}var io=new IntersectionObserver(function(entries){for(var i=0;i<entries.length;i++){if(entries[i].isIntersecting){io.disconnect();loadScript();return;}}},{rootMargin:'200px 0px'});for(var j=0;j<slots.length;j++)io.observe(slots[j]);(window.requestIdleCallback||ricFb)(loadScript,{timeout:2500});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',observe,{once:true});}else{observe();}})();`;
 export const ADSENSE_LOADER_FILENAME = 'adsense-loader.js';
 export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/${ADSENSE_LOADER_FILENAME}"></script>`;
 

--- a/services/adAnalytics.ts
+++ b/services/adAnalytics.ts
@@ -20,64 +20,12 @@
  */
 
 import { captureEvent as posthogCapture } from './posthog';
-import { BOT_UA_PATTERNS } from './botPatterns';
 
-/**
- * Layered bot detection. Each layer cuts a different population:
- *  1. SSR / no UA      — never an ad-eligible session.
- *  2. webdriver flag   — Playwright/Selenium/Puppeteer base.
- *  3. UA substring     — known crawler / AI / monitoring strings.
- *  4. Chrome-without-chrome-object — old headless Chrome stealth.
- *  5. Inconsistent navigator props — modern stealth-puppeteer signals
- *     (empty languages, missing plugins on a real Chrome UA, missing
- *     `permissions` API). False-positive risk on iframes / restricted
- *     contexts is bounded by REQUIRING the UA to claim a "real" browser.
- *
- * On purpose NOT here: WebGL renderer / canvas fingerprint / TLS JA3.
- * Those add weight but are bypassable by `puppeteer-extra-plugin-stealth`
- * and other anti-detect kits — false confidence at high bundle cost. We'd
- * spend ~25KB to catch a rounding error in invalid traffic. The honest
- * structural fix is a Cloudflare gray-cloud edge filter; until then this
- * client-side gate stays purposely lightweight.
- */
-export function isLikelyBot(): boolean {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') return true;
-  // navigator.webdriver is set true by Selenium/Playwright/Puppeteer (most cases)
-  if ((navigator as Navigator & { webdriver?: boolean }).webdriver === true) return true;
-  const ua = (navigator.userAgent || '').toLowerCase();
-  if (!ua) return true;
-  for (const pattern of BOT_UA_PATTERNS) {
-    if (ua.includes(pattern)) return true;
-  }
-  // Headless Chrome variants without "headlesschrome" in UA
-  if (ua.includes('chrome') && !('chrome' in window)) return true;
-
-  // ── Modern stealth signals — only fire when UA claims a real desktop browser ──
-  // (otherwise we'd reject restricted iframes, IGNORE preview bots Google wants
-  // through, and other legit edge cases.)
-  const claimsDesktopChrome = ua.includes('chrome') && !ua.includes('mobile');
-  if (claimsDesktopChrome) {
-    // Real Chrome ships ≥1 language; headless defaults to [].
-    const langs = navigator.languages;
-    if (Array.isArray(langs) && langs.length === 0) return true;
-
-    // Real Chrome on desktop ships ≥1 plugin (PDF Viewer at minimum since
-    // Chrome 87). Headless Chrome reports plugins.length === 0 by default.
-    const plugins = (navigator as Navigator & { plugins?: { length: number } }).plugins;
-    if (plugins && plugins.length === 0) {
-      // Don't reject mobile — mobile Chrome reports 0 plugins legitimately.
-      return true;
-    }
-
-    // The Permissions API exists in all real Chrome ≥ 43. Missing on the
-    // claimed-Chrome UA = stealth.
-    if (typeof (navigator as Navigator & { permissions?: unknown }).permissions === 'undefined') {
-      return true;
-    }
-  }
-
-  return false;
-}
+// `isLikelyBot()` lives in services/botPatterns.ts (the shared, dependency-free
+// home alongside BOT_UA_PATTERNS) so services/posthog.ts can gate its init on it
+// without a circular import through this module. Re-exported here to preserve the
+// historical `@/services/adAnalytics` import path used by <AdSenseBanner> + tests.
+export { isLikelyBot } from './botPatterns';
 
 export type AdEvent = 'ad_request' | 'ad_filled' | 'ad_unfilled' | 'ad_collapsed' | 'ad_bot_skip';
 

--- a/services/botPatterns.ts
+++ b/services/botPatterns.ts
@@ -1,17 +1,26 @@
 /**
- * Shared user-agent patterns identifying low-RPM, high-volume bot traffic.
+ * Shared user-agent patterns + `isLikelyBot()` identifying low-RPM,
+ * high-volume bot traffic.
  *
  * Imported by:
- *  - services/adAnalytics.ts (browser-side `isLikelyBot()` for `<AdSenseBanner>` slots)
- *  - build-plugins/constants.ts (build-time inline gate in `ADSENSE_LAZY_LOADER`
- *    so adsbygoogle.js never loads for bots — extends the filter to Auto Ads
- *    formats which bypass the React component)
+ *  - services/adAnalytics.ts (re-exports `isLikelyBot()` for `<AdSenseBanner>` slots)
+ *  - services/posthog.ts (gates `ensurePostHog()` so bot sessions never init
+ *    PostHog — no $pageview / $pageleave / session-replay / explicit captures
+ *    fire, keeping event volume under the free-tier 1M/mo cap)
+ *  - build-plugins/constants.ts (build-time inline gate `BOT_GATE_FN`, the JS
+ *    twin of `isLikelyBot()`, embedded in `ADSENSE_LAZY_LOADER` +
+ *    `POSTHOG_INIT_CONTENT` so neither adsbygoogle.js nor PostHog loads for bots
+ *    on static pages — extends the filter to surfaces the React component never
+ *    mounts on)
  *
  * Match strategy: lowercased substring match against `navigator.userAgent`.
  * Search-engine bots (Googlebot, Bingbot) are NOT in this list — they don't
  * execute JS, so the AdSense lazy loader never runs for them anyway.
  *
- * Keep the two consumers in sync by editing here, never by duplicating.
+ * Keep all consumers in sync by editing here, never by duplicating. The build
+ * inline gate (`BOT_GATE_FN` in build-plugins/constants.ts) is the one place
+ * the logic is necessarily re-expressed as a string — it is kept byte-aligned
+ * with `isLikelyBot()` and covered by tests/bot-gate-parity.test.ts.
  */
 export const BOT_UA_PATTERNS: readonly string[] = [
   // Headless browsers / automation
@@ -88,3 +97,65 @@ export const BOT_UA_PATTERNS: readonly string[] = [
   'neevabot',
   'diffbot',
 ];
+
+/**
+ * Layered bot detection. Each layer cuts a different population:
+ *  1. SSR / no UA      — never an ad-eligible session.
+ *  2. webdriver flag   — Playwright/Selenium/Puppeteer base.
+ *  3. UA substring     — known crawler / AI / monitoring strings.
+ *  4. Chrome-without-chrome-object — old headless Chrome stealth.
+ *  5. Inconsistent navigator props — modern stealth-puppeteer signals
+ *     (empty languages, missing plugins on a real Chrome UA, missing
+ *     `permissions` API). False-positive risk on iframes / restricted
+ *     contexts is bounded by REQUIRING the UA to claim a "real" browser.
+ *
+ * On purpose NOT here: WebGL renderer / canvas fingerprint / TLS JA3.
+ * Those add weight but are bypassable by `puppeteer-extra-plugin-stealth`
+ * and other anti-detect kits — false confidence at high bundle cost. We'd
+ * spend ~25KB to catch a rounding error in invalid traffic. The honest
+ * structural fix is a Cloudflare gray-cloud edge filter; until then this
+ * client-side gate stays purposely lightweight.
+ *
+ * Consumed by both AdSense slot gating (services/adAnalytics.ts) and the
+ * PostHog init gate (services/posthog.ts) so bot traffic neither requests ads
+ * nor emits analytics events. The static-HTML twin is `BOT_GATE_FN` in
+ * build-plugins/constants.ts — keep the two in sync (tests/bot-gate-parity).
+ */
+export function isLikelyBot(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return true;
+  // navigator.webdriver is set true by Selenium/Playwright/Puppeteer (most cases)
+  if ((navigator as Navigator & { webdriver?: boolean }).webdriver === true) return true;
+  const ua = (navigator.userAgent || '').toLowerCase();
+  if (!ua) return true;
+  for (const pattern of BOT_UA_PATTERNS) {
+    if (ua.includes(pattern)) return true;
+  }
+  // Headless Chrome variants without "headlesschrome" in UA
+  if (ua.includes('chrome') && !('chrome' in window)) return true;
+
+  // ── Modern stealth signals — only fire when UA claims a real desktop browser ──
+  // (otherwise we'd reject restricted iframes, IGNORE preview bots Google wants
+  // through, and other legit edge cases.)
+  const claimsDesktopChrome = ua.includes('chrome') && !ua.includes('mobile');
+  if (claimsDesktopChrome) {
+    // Real Chrome ships ≥1 language; headless defaults to [].
+    const langs = navigator.languages;
+    if (Array.isArray(langs) && langs.length === 0) return true;
+
+    // Real Chrome on desktop ships ≥1 plugin (PDF Viewer at minimum since
+    // Chrome 87). Headless Chrome reports plugins.length === 0 by default.
+    const plugins = (navigator as Navigator & { plugins?: { length: number } }).plugins;
+    if (plugins && plugins.length === 0) {
+      // Don't reject mobile — mobile Chrome reports 0 plugins legitimately.
+      return true;
+    }
+
+    // The Permissions API exists in all real Chrome ≥ 43. Missing on the
+    // claimed-Chrome UA = stealth.
+    if (typeof (navigator as Navigator & { permissions?: unknown }).permissions === 'undefined') {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/services/posthog.ts
+++ b/services/posthog.ts
@@ -11,6 +11,7 @@
  */
 
 import { createExceptionFilter } from './posthog-error-filter';
+import { isLikelyBot } from './botPatterns';
 
 const POSTHOG_KEY = 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT';
 const POSTHOG_HOST = 'https://t.frontaliereticino.ch';
@@ -20,6 +21,13 @@ let _loading: Promise<void> | null = null;
 
 async function ensurePostHog(): Promise<any> {
  if (_posthog) return _posthog;
+ // Bot gate: never init PostHog for bot sessions. Returning before _loading is
+ // set means no $pageview / $pageleave / session-replay / explicit captures ever
+ // fire for bots — the single biggest lever on event volume against the
+ // free-tier 1M/mo cap. The check is cheap and only runs until a real user's
+ // _posthog instance is cached (after which the early `if (_posthog)` returns).
+ // captureEvent / capturePageView call through here, so they become no-ops too.
+ if (isLikelyBot()) return null;
  if (_loading) {
  await _loading;
  return _posthog;

--- a/tests/bot-gate-parity.test.ts
+++ b/tests/bot-gate-parity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Bot-gate parity — guards that the inline-JS bot gate embedded in static pages
+ * (`BOT_GATE_FN` in build-plugins/constants.ts, reused by ADSENSE_LOADER_CONTENT
+ * and POSTHOG_INIT_CONTENT) stays behaviourally identical to the TS
+ * `isLikelyBot()` in services/botPatterns.ts used by the SPA.
+ *
+ * The two MUST agree: the SPA gates PostHog/AdSense via `isLikelyBot()`, the
+ * externalised static scripts gate the same surfaces via the string twin. If a
+ * pattern or stealth heuristic is added to one and not the other, bot traffic
+ * leaks back onto one surface. This test evals `BOT_GATE_FN` and asserts it
+ * returns the same verdict as `isLikelyBot()` across the full UA matrix.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isLikelyBot } from '@/services/botPatterns';
+import { BOT_GATE_FN } from '@/build-plugins/constants';
+
+// Eval the inline gate string into a callable. It reads the global `navigator`
+// / `window` (jsdom), exactly as it would in a real browser static page.
+const inlineGate = new Function(`return (${BOT_GATE_FN});`)() as () => boolean;
+
+const ORIGINAL_UA = window.navigator.userAgent;
+const ORIGINAL_WEBDRIVER = (window.navigator as Navigator & { webdriver?: boolean }).webdriver;
+
+function setUserAgent(ua: string): void {
+  Object.defineProperty(window.navigator, 'userAgent', { configurable: true, get: () => ua });
+}
+
+function setWebdriver(value: boolean | undefined): void {
+  Object.defineProperty(window.navigator, 'webdriver', { configurable: true, get: () => value });
+}
+
+/** Make navigator look like a real desktop Chrome so stealth signals don't fire. */
+function setRealBrowserNavigator(): () => void {
+  const restorers: Array<() => void> = [];
+  const overrides: Array<readonly [string, unknown]> = [
+    ['languages', ['en-US', 'en']],
+    ['plugins', { length: 3 }],
+    ['permissions', { query: () => Promise.resolve({ state: 'prompt' }) }],
+  ];
+  for (const [key, value] of overrides) {
+    const original = (navigator as unknown as Record<string, unknown>)[key];
+    Object.defineProperty(window.navigator, key, { configurable: true, get: () => value });
+    restorers.push(() => Object.defineProperty(window.navigator, key, { configurable: true, get: () => original }));
+  }
+  return () => restorers.forEach((r) => r());
+}
+
+describe('bot-gate parity: BOT_GATE_FN ≡ isLikelyBot()', () => {
+  beforeEach(() => {
+    setWebdriver(false);
+  });
+
+  afterEach(() => {
+    setUserAgent(ORIGINAL_UA);
+    setWebdriver(ORIGINAL_WEBDRIVER);
+  });
+
+  const botUserAgents: ReadonlyArray<readonly [string, string]> = [
+    ['ChatGPT user', 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot'],
+    ['ClaudeBot', 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)'],
+    ['PerplexityBot', 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot'],
+    ['GPTBot', 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot'],
+    ['Google-Extended', 'Mozilla/5.0 (compatible; Google-Extended/1.0)'],
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['curl', 'curl/8.4.0'],
+    ['python-requests', 'python-requests/2.31.0'],
+  ];
+
+  for (const [name, ua] of botUserAgents) {
+    it(`both flag ${name} as bot`, () => {
+      setUserAgent(ua);
+      expect(inlineGate()).toBe(true);
+      expect(inlineGate()).toBe(isLikelyBot());
+    });
+  }
+
+  it('both pass real desktop Chrome', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36');
+    const hadChrome = 'chrome' in window;
+    if (!hadChrome) Object.defineProperty(window, 'chrome', { configurable: true, value: {} });
+    const restoreNav = setRealBrowserNavigator();
+    try {
+      expect(inlineGate()).toBe(false);
+      expect(inlineGate()).toBe(isLikelyBot());
+    } finally {
+      restoreNav();
+      if (!hadChrome) delete (window as unknown as Record<string, unknown>).chrome;
+    }
+  });
+
+  it('both pass desktop Firefox', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0');
+    expect(inlineGate()).toBe(false);
+    expect(inlineGate()).toBe(isLikelyBot());
+  });
+
+  it('both flag navigator.webdriver === true regardless of UA', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36');
+    setWebdriver(true);
+    expect(inlineGate()).toBe(true);
+    expect(inlineGate()).toBe(isLikelyBot());
+  });
+
+  it('both flag empty navigator.languages on a claimed desktop Chrome', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36');
+    Object.defineProperty(window, 'chrome', { configurable: true, value: {} });
+    Object.defineProperty(window.navigator, 'languages', { configurable: true, get: () => [] });
+    Object.defineProperty(window.navigator, 'plugins', { configurable: true, get: () => ({ length: 3 }) });
+    Object.defineProperty(window.navigator, 'permissions', { configurable: true, get: () => ({}) });
+    try {
+      expect(inlineGate()).toBe(true);
+      expect(inlineGate()).toBe(isLikelyBot());
+    } finally {
+      delete (window as unknown as Record<string, unknown>).chrome;
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Ferma l'invio di eventi PostHog dal traffico bot — riduce il volume contro il cap free-tier 1M/mese (sforato il 2026-05-31, analytics andata dark). I bot eseguono JS e finora sparavano `$pageview` / `$pageleave` / session-replay / capture espliciti a valore analitico zero.

Due superfici, entrambe gattate dalla bot detection a strati già esistente (`BOT_UA_PATTERNS` + euristiche stealth):

- **SPA** (`services/posthog.ts`): `ensurePostHog()` fa early-return `null` quando `isLikelyBot()` → PostHog non si inizializza mai per i bot, quindi ogni wrapper (`captureEvent`/`capturePageView`/`identify`/feature flags) diventa no-op. Il gate sta sull'unico chokepoint di init, così **tutti** i call-site (analytics.ts, analytics-seo.ts, authGateExperiment.ts, adAnalytics.ts) sono coperti senza toccarli.
- **Pagine statiche** (`build-plugins/constants.ts`): `POSTHOG_INIT_CONTENT` (che usa `capture_pageview:true`) ora avvolge stub-install + `posthog.init` in un guard bot → bridge/landing statiche non emettono più `$pageview` per i bot.

Anti-duplicazione (regola sibling-class):
- Il bot-gate inline-JS è estratto in **una sola** costante condivisa `BOT_GATE_FN`, riusata sia dall'AdSense loader (`ADSENSE_LOADER_CONTENT`) sia dallo snippet PostHog — niente copy-paste di una terza copia.
- `isLikelyBot()` spostata nel suo modulo shared dependency-free `services/botPatterns.ts` (re-export da `adAnalytics.ts` per preservare il path d'import storico usato da `<AdSenseBanner>` + test) così `posthog.ts` può gattarci sopra senza import circolare posthog↔adAnalytics.
- Nuovo `tests/bot-gate-parity.test.ts`: asserisce che `BOT_GATE_FN` (inline) e `isLikelyBot()` (TS) ritornano verdetti identici sulla stessa matrice UA → impedisce drift tra le due espressioni.

Test: `bot-gate-parity` (12), `ad-analytics` (13), `adsense-lazy-load` (14), `analytics-seo` (55), `authGateExperiment` (5), `useSeoPageTracking` (8) — tutti verdi. Nessun nuovo errore tsc nei file toccati (i 124 errori tsc esistenti sono baseline pre-esistente, es. `data/jobs.json` generato a build-time).

## Non implementato (ancora)

- **Stima quantitativa della riduzione eventi**: non misurabile pre-merge. Va verificata post-deploy sul dashboard PostHog (calo `$pageview`/eventi totali e ritorno sotto il cap 1M/mese). Trigger di follow-up: se il volume eventi non cala dopo il deploy, investigare se i bot principali bypassano `BOT_UA_PATTERNS` (UA spoofate).
- **Server-side / edge bot filtering**: fuori scope. Il fix strutturale onesto (Cloudflare gray-cloud edge filter) resta deferito — questo gate è client-side e volutamente leggero, coerente col commento in `botPatterns.ts`. Bot che non eseguono JS già non triggerano nulla.
- **AdSense behaviour**: invariato. Il refactor di `ADSENSE_LOADER_CONTENT` estrae il gate identico in `BOT_GATE_FN` senza cambiare la logica (coperto da `adsense-lazy-load.test.ts` + parity test). Auto Ads non toccati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)