### PR TITLE
fix(newsletter): drop 3rd hardcoded PostHog key + funnel attribution docs

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -43,8 +43,24 @@ carries `subject_variant` + `email_provider`) and the webhooks emit
 `email_opened` on open. Both share `distinct_id = email`, so in PostHog:
 
 1. Build a **Funnel**: step 1 `email_sent` → step 2 `email_opened`.
-2. **Breakdown by** `subject_variant` (and/or `email_provider`).
-3. PostHog reports conversion (= open rate) per arm with significance.
+2. **Filter the whole funnel to one `campaign_id`** (analyze one weekly campaign
+   at a time). This is required for correct attribution — see the box below.
+3. **Breakdown by** `subject_variant` (and/or `email_provider`).
+4. PostHog reports conversion (= open rate) per arm with significance.
+
+> **Attribution — must scope per campaign.** PostHog links step 1 → step 2 by
+> *person* within the conversion window, not by matching `campaign_id`. With
+> weekly campaigns, a conversion window longer than 7 days could let an
+> `email_opened` from a *later* campaign convert an earlier `email_sent`, and the
+> variant breakdown takes the value from step 1 → the open gets attributed to the
+> wrong campaign's variant. Two guards (do both):
+> - **Filter the funnel to a single `campaign_id`** (step 2 above) — both events
+>   carry it, so only same-campaign sent+open pairs enter the funnel.
+> - **Set the conversion window to ≤ 3 days** (well under the weekly cadence).
+>
+> Within one campaign a subscriber has exactly one variant (assignment is
+> `hash(email, campaignId)`), so once scoped per campaign the per-arm open rate
+> is exact.
 
 The variant is **not** assigned by a PostHog feature flag — our hash owns
 assignment, so the experiment keeps working even if PostHog is down/over-quota.
@@ -56,8 +72,11 @@ Set on both runtimes (off → no events emitted, zero PostHog volume):
 | Env | Where | Purpose |
 |-----|-------|---------|
 | `POSTHOG_EMAIL_EXPERIMENT=1` | send-newsletter CI env **and** Cloud Functions runtime | master switch |
-| `POSTHOG_PROJECT_KEY` | both (optional) | defaults to the public client key |
+| `POSTHOG_PROJECT_KEY` | both (**required to activate**) | PostHog project write key (`phc_…`); no hardcoded default |
 | `POSTHOG_HOST` | both (optional) | defaults to `https://eu.i.posthog.com` |
+
+Both `POSTHOG_EMAIL_EXPERIMENT=1` **and** `POSTHOG_PROJECT_KEY` must be set — if
+either is missing the capture is a no-op.
 
 ⚠️ **Quota**: the PostHog free tier (1M events/mo) is already tight and has
 caused outages. This emits only 2 events per subscriber per campaign, but keep

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -19,20 +19,21 @@
  * engagementScore.js) can share it without a cross-runtime import. Uses the
  * PostHog capture HTTP API via global fetch — no posthog-node dependency.
  *
- * Env:
- *   POSTHOG_EMAIL_EXPERIMENT  '1'|'true' to enable (default: disabled → no-op)
- *   POSTHOG_PROJECT_KEY       PostHog project write key (phc_…); defaults to the
- *                             public project key already shipped in the client.
+ * Env (BOTH required to activate; absent → no-op):
+ *   POSTHOG_EMAIL_EXPERIMENT  '1'|'true' to enable
+ *   POSTHOG_PROJECT_KEY       PostHog project write key (phc_…); no hardcoded
+ *                             default (avoids a 3rd copy of the key in the repo)
  *   POSTHOG_HOST              ingestion host (default EU cloud ingest).
  */
 
-// Public project key — identical to the one embedded client-side in
-// services/posthog.ts (a project write key is not a secret; it is shipped in the
-// browser bundle). Overridable via POSTHOG_PROJECT_KEY.
-const DEFAULT_PUBLIC_KEY = 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT';
-
+// The project key is read from POSTHOG_PROJECT_KEY only — we deliberately do NOT
+// hardcode a default copy here. The same phc_ key already lives in
+// services/posthog.ts and build-plugins/constants.ts; a third copy would make a
+// key rotation a 3-file manual edit. Since the experiment is off by default and
+// enabling it is an explicit ops action, requiring the env var alongside
+// POSTHOG_EMAIL_EXPERIMENT is no extra burden and removes the duplication.
 const POSTHOG_HOST = (process.env.POSTHOG_HOST || 'https://eu.i.posthog.com').replace(/\/$/, '');
-const POSTHOG_KEY = process.env.POSTHOG_PROJECT_KEY || DEFAULT_PUBLIC_KEY;
+const POSTHOG_KEY = process.env.POSTHOG_PROJECT_KEY || '';
 const ENABLED = ['1', 'true', 'yes'].includes(String(process.env.POSTHOG_EMAIL_EXPERIMENT || '').toLowerCase());
 
 /** Canonical event names — single source of truth for emit + analysis. */

--- a/tests/email-experiment-posthog.test.ts
+++ b/tests/email-experiment-posthog.test.ts
@@ -61,6 +61,7 @@ describe('emailExperimentPostHog — enabled', () => {
   it('still no-ops when email (distinct_id) is missing', async () => {
     vi.resetModules();
     vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', 'true');
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'phc_test_key');
     const fetchSpy = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchSpy);
     const { captureEmailEvent } = await import(MODULE);
@@ -68,9 +69,21 @@ describe('emailExperimentPostHog — enabled', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('no-ops when the key is missing even if the flag is on', async () => {
+    vi.resetModules();
+    vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', '1'); // no POSTHOG_PROJECT_KEY
+    const fetchSpy = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const { captureEmailEvent, isEmailExperimentEnabled } = await import(MODULE);
+    expect(isEmailExperimentEnabled()).toBe(false);
+    expect(await captureEmailEvent('email_opened', { email: 'x@y.com' })).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('never throws when fetch rejects', async () => {
     vi.resetModules();
     vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', '1');
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'phc_test_key');
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
     const { captureEmailEvent } = await import(MODULE);
     await expect(captureEmailEvent('email_opened', { email: 'x@y.com' })).resolves.toBe(false);


### PR DESCRIPTION
## Implementato

Fix dei 2 rilievi reviewer su PR #2088 (wiring PostHog A/B).

- **🟡 Terza copia hardcoded della key** — `emailExperimentPostHog.js` non hardcoda più la `phc_` project key (era la 3ª copia oltre a `services/posthog.ts` e `build-plugins/constants.ts` → rotazione = 3 edit a mano). Ora la key arriva **solo** da `POSTHOG_PROJECT_KEY`; assente → capture no-op. Abilitare l'esperimento richiede già `POSTHOG_EMAIL_EXPERIMENT`, quindi pretendere anche la key non aggiunge attrito e rimuove la duplicazione. Import cross-runtime da `build-plugins` (scartato dal reviewer come indesiderato) evitato by-design.
- **❓ Attribuzione funnel cross-campagna** — `docs/NEWSLETTER-SUBJECT-AB.md` ora avverte che PostHog lega `email_sent`→`email_opened` **per persona dentro la conversion window, non per `campaign_id`**: con campagne settimanali e window >7gg un open di campagna successiva può convertire il sent precedente → variante attribuita alla campagna sbagliata. Due guard documentate (entrambe): **filtrare il funnel su un solo `campaign_id`** (entrambi gli eventi lo portano) **e** **conversion window ≤ 3gg**. Nota: dentro una campagna l'iscritto ha esattamente una variante (`hash(email, campaignId)`), quindi scoping per-campagna → open-rate per arm esatta.
- **Test** aggiornati per il comportamento key-required + nuovo caso "flag ON ma key mancante = no-op". 6/6 verde.

## Non implementato (ancora)

- **Estrarre la `phc_` key in un modulo condiviso unico** tra `services/posthog.ts` (frontend) e `build-plugins/constants.ts` (build) — fuori scope: sono runtime diversi (SPA vs build), un 4° punto di import attraverserebbe i confini di bundle. Questa PR rimuove solo la copia che avevo aggiunto io (functions), riportando il conteggio a 2 pre-esistenti. Consolidamento delle 2 copie storiche = follow-up separato.
- **Filtro `campaign_id` automatico nel funnel** — PostHog non supporta scoping automatico via SDK; resta istruzione operativa nella doc (off-by-default tool di misura).

## Test plan

- [x] `node --check` helper
- [x] vitest helper → 6/6 (incl. nuovo caso key-missing no-op)
- [ ] Post-merge (solo se abilitato): impostare `POSTHOG_PROJECT_KEY` oltre al flag, verificare arrivo eventi in PostHog con funnel scoped per `campaign_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)