### PR TITLE
feat(seo): per-canton profession landing pages (data-driven employers)

### DIFF
--- a/build-plugins/professionCantonData.ts
+++ b/build-plugins/professionCantonData.ts
@@ -1,0 +1,93 @@
+/**
+ * professionCantonData.ts — routing + path data for the per-canton profession
+ * landings (e.g. IT `/lavoro-zurigo-infermiere/`, EN `/en/jobs-zurich-nurse/`,
+ * DE `/de/arbeit-zurich-krankenpfleger/`, FR `/fr/travail-zurich-infirmier/`).
+ *
+ * Imported by services/router.ts (SPA — no fs) and the build plugin. Routes are
+ * enumerated from the shared canton slug table (salaryStatsData) × the existing
+ * profession role keywords (professionLandingsData), so there is no new slug
+ * data to keep in sync.
+ *
+ * The emitter gates each (canton, profession) page on a real job-count floor,
+ * so not every enumerated route gets static HTML — the rest fall back to the
+ * SPA (job-board filtered view). The router therefore recognises the full set.
+ */
+
+import {
+  PROFESSION_IDS,
+  PROFESSION_LOCALES,
+  PROFESSION_LOCALE_PREFIX,
+  professionRoleKeyword,
+  type ProfessionId,
+  type ProfessionLocale,
+} from './professionLandingsData';
+import { SALARY_STATS_CANTON_KEYS, SALARY_STATS_CANTON_SLUGS } from './salaryStatsData';
+
+/**
+ * Cantons this family emits for: every URL canton key EXCEPT Ticino. TI keeps
+ * its dedicated legacy profession landings at the identical "lavoro-ticino-ROLE"
+ * slugs (professionLandingsData) — including TI here would collide with them.
+ */
+export const PROFESSION_CANTON_KEYS: readonly string[] = Object.freeze(
+  SALARY_STATS_CANTON_KEYS.filter((k) => k !== 'TI'),
+);
+
+/** Locale-natural "area" word that fronts every profession slug. */
+export const PROFESSION_CANTON_AREA_WORD: Record<ProfessionLocale, string> = {
+  it: 'lavoro',
+  en: 'jobs',
+  de: 'arbeit',
+  fr: 'travail',
+};
+
+/** Build the canonical path for a per-canton profession landing. */
+export function buildProfessionCantonPath(
+  locale: ProfessionLocale,
+  cantonKey: string,
+  id: ProfessionId,
+): string {
+  const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+  const role = professionRoleKeyword(locale, id);
+  return `${PROFESSION_LOCALE_PREFIX[locale]}/${PROFESSION_CANTON_AREA_WORD[locale]}-${cantonSlug}-${role}/`
+    .replace(/\/{2,}/g, '/');
+}
+
+export interface ProfessionCantonPath {
+  locale: ProfessionLocale;
+  cantonKey: string;
+  id: ProfessionId;
+  path: string;
+}
+
+export function listAllProfessionCantonPaths(): ProfessionCantonPath[] {
+  const out: ProfessionCantonPath[] = [];
+  for (const locale of PROFESSION_LOCALES) {
+    for (const cantonKey of PROFESSION_CANTON_KEYS) {
+      for (const id of PROFESSION_IDS) {
+        out.push({ locale, cantonKey, id, path: buildProfessionCantonPath(locale, cantonKey, id) });
+      }
+    }
+  }
+  return out;
+}
+
+export const PROFESSION_CANTON_ROUTES: readonly string[] = Object.freeze(
+  listAllProfessionCantonPaths().map((p) => p.path),
+);
+
+const PATH_INDEX: ReadonlyMap<string, ProfessionCantonPath> = new Map(
+  listAllProfessionCantonPaths().map((p) => [p.path, p]),
+);
+
+function normalizePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+export function parseProfessionCantonPath(urlPath: string): ProfessionCantonPath | null {
+  return PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}
+
+export function isProfessionCantonPath(urlPath: string): boolean {
+  return PATH_INDEX.has(normalizePath(urlPath));
+}

--- a/build-plugins/professionCantonLandings.ts
+++ b/build-plugins/professionCantonLandings.ts
@@ -1,0 +1,361 @@
+/**
+ * professionCantonLandings.ts — per-canton profession landing pages.
+ *
+ * Emits `/lavoro-{canton}-{role}/` (+ /en/jobs-, /de/arbeit-, /fr/travail-) for
+ * each (canton, profession) pair that has at least MIN_JOBS real active jobs in
+ * the corpus. Each page is data-driven from data/jobs.json via
+ * aggregateProfessionJobsByCanton: REAL local top employers, real median salary
+ * (corpus), live counts — plus the canton-aware SEO prose. The job-count gate
+ * keeps thin/empty pages from being emitted (CLAUDE.md non-negotiable #4), so
+ * only profession×canton pairs with genuine local demand ship.
+ */
+import type { Plugin } from 'vite';
+import fs from 'node:fs';
+import np from 'node:path';
+
+import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import { WriteCollector } from './batchWrite';
+import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
+import { buildDayStampIso } from './shared/buildDayStamp';
+import { cleanSitemapFiles } from './shared/distNamespaceCleanup';
+import { getCantonDisplayName, type CantonDisplayLocale } from './shared/cantonDisplay';
+import {
+  renderCantonSeoProse,
+  buildCantonSeoProseFaqItems,
+  type CantonSeoLocale,
+} from './shared/cantonSeoProse';
+import {
+  GROSSREGION_MEDIAN_MONTHLY,
+  NATIONAL_MEDIAN_MONTHLY,
+  CANTON_TO_GROSSREGION,
+} from './shared/cantonSalaryIndex';
+import {
+  aggregateProfessionJobsByCanton,
+  type ProfessionJobsSnapshot,
+} from './professionJobsAggregate';
+import {
+  PROFESSION_IDS,
+  PROFESSION_LOCALES,
+  PROFESSION_LOCALE_PREFIX,
+  professionRoleKeyword,
+  type ProfessionId,
+  type ProfessionLocale,
+} from './professionLandingsData';
+import {
+  SALARY_STATS_CANTON_SLUGS,
+  SALARY_STATS_FACTOR_CODE,
+} from './salaryStatsData';
+import { buildProfessionCantonPath, PROFESSION_CANTON_KEYS } from './professionCantonData';
+import {
+  HERO_EYEBROW_STYLE,
+  H1_STYLE,
+  LEDE_STYLE,
+  BODY_STYLE,
+  H2_STYLE,
+  BREADCRUMB_STYLE,
+  BREADCRUMB_LINK_STYLE,
+} from './shared/seoContentTokens';
+
+/** Minimum real active jobs for a (canton, profession) page to be emitted. */
+const MIN_JOBS = 3;
+const SITEMAP_FILE = 'sitemap-profession-cantons.xml';
+
+const OG_LOCALE: Record<ProfessionLocale, string> = {
+  it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH',
+};
+
+/** Localised profession label (Title-cased role keyword is good enough). */
+function professionLabel(locale: ProfessionLocale, id: ProfessionId): string {
+  const role = professionRoleKeyword(locale, id).replace(/-/g, ' ');
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+interface Copy {
+  eyebrow: string;
+  h1: (role: string, canton: string) => string;
+  lede: (count: number, role: string, canton: string) => string;
+  tileLive: string;
+  tileFresh: string;
+  tileMedian: string;
+  employersHeading: (canton: string) => string;
+  noSalary: string;
+  cta: (canton: string) => string;
+  breadcrumbHome: string;
+  breadcrumbCh: string;
+  metaTitle: (role: string, canton: string) => string;
+  metaDesc: (count: number, role: string, canton: string) => string;
+  perYear: string;
+}
+
+const COPY: Record<ProfessionLocale, Copy> = {
+  it: {
+    eyebrow: 'Offerte di lavoro per professione',
+    h1: (r, c) => `Lavoro come ${r} nel Canton ${c}`,
+    lede: (n, r, c) => `${n} offerte attive per ${r} nel Canton ${c}, da datori di lavoro svizzeri reali.`,
+    tileLive: 'Offerte attive',
+    tileFresh: 'Pubblicate (30 gg)',
+    tileMedian: 'Stipendio mediano lordo/anno',
+    employersHeading: (c) => `Chi assume nel Canton ${c}`,
+    noSalary: 'n/d',
+    cta: (c) => `Vedi tutte le offerte nel Canton ${c}`,
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Svizzera',
+    metaTitle: (r, c) => `Lavoro ${r} Canton ${c} — offerte e stipendio`,
+    metaDesc: (n, r, c) => `${n} offerte per ${r} nel Canton ${c}: datori reali, stipendio mediano e candidatura diretta. Aggiornato ogni 12 ore.`,
+    perYear: '/anno',
+  },
+  en: {
+    eyebrow: 'Jobs by profession',
+    h1: (r, c) => `${r} jobs in Canton ${c}`,
+    lede: (n, r, c) => `${n} active ${r} openings in Canton ${c}, from real Swiss employers.`,
+    tileLive: 'Active openings',
+    tileFresh: 'Posted (30 days)',
+    tileMedian: 'Median gross salary/year',
+    employersHeading: (c) => `Who is hiring in Canton ${c}`,
+    noSalary: 'n/a',
+    cta: (c) => `See all openings in Canton ${c}`,
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Switzerland',
+    metaTitle: (r, c) => `${r} jobs Canton ${c} — openings and salary`,
+    metaDesc: (n, r, c) => `${n} ${r} openings in Canton ${c}: real employers, median salary and direct apply. Updated every 12 hours.`,
+    perYear: '/yr',
+  },
+  de: {
+    eyebrow: 'Stellen nach Beruf',
+    h1: (r, c) => `${r}-Stellen im Kanton ${c}`,
+    lede: (n, r, c) => `${n} aktive ${r}-Stellen im Kanton ${c}, von echten Schweizer Arbeitgebern.`,
+    tileLive: 'Aktive Stellen',
+    tileFresh: 'Veröffentlicht (30 Tage)',
+    tileMedian: 'Medianlohn brutto/Jahr',
+    employersHeading: (c) => `Wer im Kanton ${c} einstellt`,
+    noSalary: 'k.A.',
+    cta: (c) => `Alle Stellen im Kanton ${c} ansehen`,
+    breadcrumbHome: 'Home',
+    breadcrumbCh: 'Schweiz',
+    metaTitle: (r, c) => `${r} Stellen Kanton ${c} — Angebote und Lohn`,
+    metaDesc: (n, r, c) => `${n} ${r}-Stellen im Kanton ${c}: echte Arbeitgeber, Medianlohn und Direktbewerbung. Alle 12 Stunden aktualisiert.`,
+    perYear: '/Jahr',
+  },
+  fr: {
+    eyebrow: 'Emplois par profession',
+    h1: (r, c) => `Emploi ${r} dans le canton ${c}`,
+    lede: (n, r, c) => `${n} offres actives pour ${r} dans le canton ${c}, d'employeurs suisses réels.`,
+    tileLive: 'Offres actives',
+    tileFresh: 'Publiées (30 j)',
+    tileMedian: 'Salaire médian brut/an',
+    employersHeading: (c) => `Qui recrute dans le canton ${c}`,
+    noSalary: 'n/d',
+    cta: (c) => `Voir toutes les offres dans le canton ${c}`,
+    breadcrumbHome: 'Accueil',
+    breadcrumbCh: 'Suisse',
+    metaTitle: (r, c) => `Emploi ${r} canton ${c} — offres et salaire`,
+    metaDesc: (n, r, c) => `${n} offres ${r} dans le canton ${c} : employeurs réels, salaire médian et candidature directe. Mis à jour toutes les 12 heures.`,
+    perYear: '/an',
+  },
+};
+
+function esc(s: unknown): string {
+  return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function fmtChf(n: number, locale: ProfessionLocale): string {
+  const sep = locale === 'en' ? ',' : locale === 'fr' ? ' ' : "'";
+  return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+}
+
+function cantonAnnualMedian(cantonKey: string): number {
+  const code = SALARY_STATS_FACTOR_CODE[cantonKey] ?? cantonKey;
+  const region = CANTON_TO_GROSSREGION[code];
+  const monthly = region ? GROSSREGION_MEDIAN_MONTHLY[region] : NATIONAL_MEDIAN_MONTHLY;
+  return monthly * 12;
+}
+
+export function renderProfessionCantonPage(opts: {
+  locale: ProfessionLocale;
+  cantonKey: string;
+  id: ProfessionId;
+  snapshot: ProfessionJobsSnapshot;
+  distDir: string;
+}): { html: string; words: number } {
+  const { locale, cantonKey, id, snapshot, distDir } = opts;
+  const c = COPY[locale];
+  const cantonName = getCantonDisplayName(cantonKey, locale as CantonDisplayLocale);
+  const role = professionLabel(locale, id);
+  const canonicalPath = buildProfessionCantonPath(locale, cantonKey, id);
+  const homeHref = locale === 'it' ? '/' : `${PROFESSION_LOCALE_PREFIX[locale]}/`;
+
+  // Real corpus median for this canton+profession; fall back to the canton's
+  // BFS annual median when the matched jobs carry no salary data.
+  const median = snapshot.medianSalaryChf > 0 ? snapshot.medianSalaryChf : cantonAnnualMedian(cantonKey);
+  const medianStr = median > 0 ? `CHF ${fmtChf(median, locale)}` : c.noSalary;
+
+  const breadcrumb = `<nav aria-label="breadcrumb" class="${BREADCRUMB_STYLE}">
+  <a href="${homeHref}" class="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbHome)}</a>
+  <span aria-hidden="true">›</span>
+  <a href="${homeHref}" class="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbCh)}</a>
+  <span aria-hidden="true">›</span>
+  <span aria-current="page">${esc(role)} · ${esc(cantonName)}</span>
+</nav>`;
+
+  const tiles = `<div class="grid grid-cols-3 gap-3 my-4">
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">${snapshot.liveCount}</div><div class="text-xs text-subtle">${esc(c.tileLive)}</div></div>
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">${snapshot.fresh30Count}</div><div class="text-xs text-subtle">${esc(c.tileFresh)}</div></div>
+  <div class="rounded-xl bg-surface-alt p-3"><div class="text-2xl font-bold text-heading">${esc(medianStr)}${median > 0 ? `<span class="text-sm">${esc(c.perYear)}</span>` : ''}</div><div class="text-xs text-subtle">${esc(c.tileMedian)}</div></div>
+</div>`;
+
+  const employers = snapshot.topEmployers.length > 0
+    ? `<h2 class="${H2_STYLE}">${esc(c.employersHeading(cantonName))}</h2>
+<ul class="flex flex-wrap gap-2 my-2">${snapshot.topEmployers
+        .map((e) => `<li class="rounded-full bg-surface-alt px-3 py-1 text-sm">${esc(e.name)} <span class="text-subtle">(${e.count})</span></li>`)
+        .join('')}</ul>`
+    : '';
+
+  const roleKw = professionRoleKeyword(locale, id);
+  const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+  // Link to the per-canton salary stats landing (shipped in PR #2085) + the
+  // job board filtered by this role.
+  const ctaHref = `${PROFESSION_LOCALE_PREFIX[locale]}/${locale === 'it' ? 'stipendi' : locale === 'en' ? 'salaries' : locale === 'de' ? 'gehaelter' : 'salaires'}-${cantonSlug}/`.replace(/\/{2,}/g, '/');
+
+  const prose = renderCantonSeoProse({
+    locale: locale as CantonSeoLocale,
+    cantonDisplay: cantonName,
+    slot: 'canton-hub',
+    entityName: role,
+    countHint: snapshot.liveCount,
+    ctaHref,
+    ctaLabel: c.cta(cantonName),
+  });
+
+  const main = `${breadcrumb}
+<header><p class="${HERO_EYEBROW_STYLE}">${esc(c.eyebrow)}</p><h1 class="${H1_STYLE}">${esc(c.h1(role, cantonName))}</h1><p class="${LEDE_STYLE}">${esc(c.lede(snapshot.liveCount, role, cantonName))}</p></header>
+${tiles}
+${employers}
+<p class="${BODY_STYLE}"><a href="${esc(ctaHref)}" class="inline-block rounded-lg bg-info text-white px-4 py-2 font-medium">${esc(c.cta(cantonName))} →</a></p>
+${prose}`;
+
+  const breadcrumbLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: c.breadcrumbHome, item: `${BASE_URL}${homeHref}` },
+      { '@type': 'ListItem', position: 2, name: c.breadcrumbCh, item: `${BASE_URL}${homeHref}` },
+      { '@type': 'ListItem', position: 3, name: c.h1(role, cantonName), item: `${BASE_URL}${canonicalPath}` },
+    ],
+  };
+  const faqLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: buildCantonSeoProseFaqItems({ locale: locale as CantonSeoLocale, cantonDisplay: cantonName, slot: 'canton-hub' }),
+  };
+
+  const hreflangPaths = {
+    it: buildProfessionCantonPath('it', cantonKey, id),
+    en: buildProfessionCantonPath('en', cantonKey, id),
+    de: buildProfessionCantonPath('de', cantonKey, id),
+    fr: buildProfessionCantonPath('fr', cantonKey, id),
+  } as HreflangPaths;
+
+  const html = buildSeoPageHtml({
+    locale,
+    title: c.metaTitle(role, cantonName),
+    description: c.metaDesc(snapshot.liveCount, role, cantonName),
+    canonicalUrl: `${BASE_URL}${canonicalPath}`,
+    hreflangHtml: renderHreflangTags(hreflangPaths),
+    bodyHtml: main,
+    jsonLdScripts: [JSON.stringify(breadcrumbLd), JSON.stringify(faqLd)],
+    ogLocale: OG_LOCALE[locale],
+    robots: 'index,follow',
+    distDir,
+  });
+
+  return { html, words: countHtmlBodyWords(html) };
+}
+
+export interface ProfessionCantonEmitResult {
+  pagesWritten: number;
+  pagesSkippedForJobs: number;
+  pagesSkippedForWordCount: number;
+  emittedPaths: string[];
+}
+
+function buildSitemap(paths: readonly string[], dateStamp: string): string {
+  const entries = paths
+    .map((p) => `  <url>\n    <loc>${BASE_URL}${p}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`)
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+}
+
+function patchSitemapIndex(distDir: string, dateStamp: string): void {
+  const indexPath = np.join(distDir, 'sitemap.xml');
+  if (!fs.existsSync(indexPath)) return;
+  try {
+    let idx = fs.readFileSync(indexPath, 'utf-8');
+    if (!idx.includes(SITEMAP_FILE)) {
+      idx = idx.replace('</sitemapindex>', `  <sitemap>\n    <loc>${BASE_URL}/${SITEMAP_FILE}</loc>\n    <lastmod>${dateStamp}</lastmod>\n  </sitemap>\n</sitemapindex>`);
+    } else {
+      idx = idx.replace(
+        new RegExp(`(<loc>${BASE_URL.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}/${SITEMAP_FILE}</loc>\\s*<lastmod>)\\d{4}-\\d{2}-\\d{2}(</lastmod>)`),
+        `$1${dateStamp}$2`,
+      );
+    }
+    fs.writeFileSync(indexPath, idx, 'utf-8');
+  } catch (err) {
+    console.warn('[profession-cantons] failed to patch sitemap index', err);
+  }
+}
+
+export async function emitProfessionCantonPages(opts: { rootDir: string; distDir: string }): Promise<ProfessionCantonEmitResult> {
+  const result: ProfessionCantonEmitResult = { pagesWritten: 0, pagesSkippedForJobs: 0, pagesSkippedForWordCount: 0, emittedPaths: [] };
+  const byCanton = aggregateProfessionJobsByCanton(opts.rootDir);
+  const collector = new WriteCollector({ distDir: opts.distDir, pluginName: 'professionCantonLandings' });
+
+  for (const cantonKey of PROFESSION_CANTON_KEYS) {
+    const perProfession = byCanton[cantonKey];
+    if (!perProfession) continue;
+    for (const id of PROFESSION_IDS) {
+      const snapshot = perProfession[id];
+      if (!snapshot || snapshot.liveCount < MIN_JOBS) {
+        result.pagesSkippedForJobs++;
+        continue;
+      }
+      for (const locale of PROFESSION_LOCALES) {
+        const { html, words } = renderProfessionCantonPage({ locale, cantonKey, id, snapshot, distDir: opts.distDir });
+        if (words < MIN_INDEXABLE_WORDS) {
+          result.pagesSkippedForWordCount++;
+          continue;
+        }
+        const canonicalPath = buildProfessionCantonPath(locale, cantonKey, id);
+        const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+        collector.add(np.join(outDir, 'index.html'), html);
+        result.pagesWritten++;
+        result.emittedPaths.push(canonicalPath);
+      }
+    }
+  }
+
+  await collector.flush();
+
+  cleanSitemapFiles(opts.distDir, [SITEMAP_FILE]);
+  if (result.emittedPaths.length > 0) {
+    const dateStamp = buildDayStampIso();
+    fs.writeFileSync(np.join(opts.distDir, SITEMAP_FILE), buildSitemap(result.emittedPaths, dateStamp), 'utf-8');
+    patchSitemapIndex(opts.distDir, dateStamp);
+  }
+  return result;
+}
+
+export function professionCantonLandings(rootDir: string): Plugin {
+  return {
+    name: 'profession-canton-landings',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_PROFESSION_CANTONS === '1') return;
+      const distDir = np.resolve(rootDir, 'dist');
+      const res = await emitProfessionCantonPages({ rootDir, distDir });
+      // eslint-disable-next-line no-console
+      console.log(`[profession-cantons] emitted ${res.pagesWritten} pages (${res.pagesSkippedForJobs} pairs below job floor, ${res.pagesSkippedForWordCount} below word gate)`);
+    },
+  };
+}

--- a/build-plugins/professionCantonLandings.ts
+++ b/build-plugins/professionCantonLandings.ts
@@ -305,6 +305,23 @@ function patchSitemapIndex(distDir: string, dateStamp: string): void {
   }
 }
 
+/** Drop the <sitemap> entry for this family from the index (zero-emit build). */
+function removeSitemapFromIndex(distDir: string): void {
+  const indexPath = np.join(distDir, 'sitemap.xml');
+  if (!fs.existsSync(indexPath)) return;
+  try {
+    const idx = fs.readFileSync(indexPath, 'utf-8');
+    if (!idx.includes(SITEMAP_FILE)) return;
+    const cleaned = idx.replace(
+      new RegExp(`\\s*<sitemap>\\s*<loc>[^<]*${SITEMAP_FILE}</loc>\\s*<lastmod>[^<]*</lastmod>\\s*</sitemap>`),
+      '',
+    );
+    fs.writeFileSync(indexPath, cleaned, 'utf-8');
+  } catch (err) {
+    console.warn('[profession-cantons] failed to prune sitemap index', err);
+  }
+}
+
 export async function emitProfessionCantonPages(opts: { rootDir: string; distDir: string }): Promise<ProfessionCantonEmitResult> {
   const result: ProfessionCantonEmitResult = { pagesWritten: 0, pagesSkippedForJobs: 0, pagesSkippedForWordCount: 0, emittedPaths: [] };
   const byCanton = aggregateProfessionJobsByCanton(opts.rootDir);
@@ -319,15 +336,23 @@ export async function emitProfessionCantonPages(opts: { rootDir: string; distDir
         result.pagesSkippedForJobs++;
         continue;
       }
-      for (const locale of PROFESSION_LOCALES) {
-        const { html, words } = renderProfessionCantonPage({ locale, cantonKey, id, snapshot, distDir: opts.distDir });
-        if (words < MIN_INDEXABLE_WORDS) {
-          result.pagesSkippedForWordCount++;
-          continue;
-        }
-        const canonicalPath = buildProfessionCantonPath(locale, cantonKey, id);
+      // Render all 4 locales first and emit ALL-OR-NOTHING: every emitted page
+      // links its 4-locale hreflang cluster, so a single locale dropping below
+      // the words gate while the others ship would dangle hreflang at a missing
+      // target. With liveCount≥MIN_JOBS the templated prose clears the gate on
+      // every locale in practice; this guard makes it safe regardless.
+      const rendered = PROFESSION_LOCALES.map((locale) => ({
+        locale,
+        ...renderProfessionCantonPage({ locale, cantonKey, id, snapshot, distDir: opts.distDir }),
+      }));
+      if (rendered.some((r) => r.words < MIN_INDEXABLE_WORDS)) {
+        result.pagesSkippedForWordCount += PROFESSION_LOCALES.length;
+        continue;
+      }
+      for (const r of rendered) {
+        const canonicalPath = buildProfessionCantonPath(r.locale, cantonKey, id);
         const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
-        collector.add(np.join(outDir, 'index.html'), html);
+        collector.add(np.join(outDir, 'index.html'), r.html);
         result.pagesWritten++;
         result.emittedPaths.push(canonicalPath);
       }
@@ -337,10 +362,14 @@ export async function emitProfessionCantonPages(opts: { rootDir: string; distDir
   await collector.flush();
 
   cleanSitemapFiles(opts.distDir, [SITEMAP_FILE]);
+  const dateStamp = buildDayStampIso();
   if (result.emittedPaths.length > 0) {
-    const dateStamp = buildDayStampIso();
     fs.writeFileSync(np.join(opts.distDir, SITEMAP_FILE), buildSitemap(result.emittedPaths, dateStamp), 'utf-8');
     patchSitemapIndex(opts.distDir, dateStamp);
+  } else {
+    // Zero pages this build: drop any dangling <loc> a prior build left in the
+    // sitemap index (the .xml itself was just removed by cleanSitemapFiles).
+    removeSitemapFromIndex(opts.distDir);
   }
   return result;
 }

--- a/build-plugins/professionJobsAggregate.ts
+++ b/build-plugins/professionJobsAggregate.ts
@@ -321,10 +321,66 @@ export function aggregateProfessionJobs(
   return out;
 }
 
+// ── Per-canton aggregation (profession × canton landings) ────────────────────
+
+/** Half-canton URL-group collapse: AI/AR -> APPENZELLO, BL/BS -> BASILEA. */
+const CANTON_URL_GROUP: Record<string, string> = { AI: 'APPENZELLO', AR: 'APPENZELLO', BL: 'BASILEA', BS: 'BASILEA' };
+
+function jobCantonUrlKey(job: JobRecord): string {
+  const code = resolveJobCanton(job as { canton?: string; location?: string });
+  if (!code) return '';
+  return CANTON_URL_GROUP[code] ?? code;
+}
+
+let _cantonSnapshotCache: Record<string, Record<ProfessionId, ProfessionJobsSnapshot>> | null = null;
+let _cantonCacheRootDir: string | null = null;
+
+/**
+ * Aggregate jobs.json into per-(canton, profession) snapshots — the data source
+ * for the per-canton profession landings. Unlike aggregateProfessionJobs (which
+ * pins to TI), this groups every active job by its canton (half-cantons collapse
+ * to the URL group) and builds a profession snapshot per canton from the REAL
+ * jobs in that canton: topEmployers, median salary and live counts are all
+ * corpus-derived, so each canton page shows genuine local employers.
+ *
+ * Returns `Record<cantonUrlKey, Record<ProfessionId, snapshot>>`. Cached per rootDir.
+ */
+export function aggregateProfessionJobsByCanton(
+  rootDir: string,
+  now: number = Date.now(),
+): Record<string, Record<ProfessionId, ProfessionJobsSnapshot>> {
+  if (_cantonSnapshotCache && _cantonCacheRootDir === rootDir) return _cantonSnapshotCache;
+
+  const allJobs = loadJobs(rootDir);
+  const byCanton = new Map<string, JobRecord[]>();
+  for (const job of allJobs) {
+    const key = jobCantonUrlKey(job);
+    if (!key) continue;
+    const list = byCanton.get(key);
+    if (list) list.push(job);
+    else byCanton.set(key, [job]);
+  }
+
+  const out: Record<string, Record<ProfessionId, ProfessionJobsSnapshot>> = {};
+  for (const [cantonKey, jobs] of byCanton.entries()) {
+    const perProfession = {} as Record<ProfessionId, ProfessionJobsSnapshot>;
+    for (const id of PROFESSION_IDS) {
+      perProfession[id] = buildSnapshotForProfession(jobs, PROFESSION_MATCHERS[id], now);
+    }
+    out[cantonKey] = perProfession;
+  }
+
+  _cantonSnapshotCache = out;
+  _cantonCacheRootDir = rootDir;
+  return out;
+}
+
 /** Test/CI helper — clear the module-level cache. */
 export function _resetProfessionJobsAggregateCache(): void {
   _snapshotCache = null;
   _cacheRootDir = null;
+  _cantonSnapshotCache = null;
+  _cantonCacheRootDir = null;
 }
 
 // ── Job-board URL builder ────────────────────────────────────────────────────

--- a/build-plugins/shared/cantonSalaryIndex.ts
+++ b/build-plugins/shared/cantonSalaryIndex.ts
@@ -152,6 +152,11 @@ reg('nordwest', [
 reg('ostschweiz', [
   'glarona', 'glarus', 'glaris',
   'sciaffusa', 'schaffhausen', 'schaffhouse',
+  // Bare half-canton-group display forms (AI+AR both Ostschweiz) — 'appenzello'
+  // (IT) was present but 'appenzell' (EN/DE/FR group display) was not, so those
+  // locale pages fell back to the national median in the prose/FAQ band while
+  // tiles used Ostschweiz. Twin of the BASILEA fix. See PR #2095 review.
+  'appenzell',
   'appenzello esterno', 'appenzell ausserrhoden', 'appenzell a.rh.', 'appenzell rhodes-extérieures', 'appenzello',
   'appenzello interno', 'appenzell innerrhoden', 'appenzell i.rh.',
   'san gallo', 'st. gallen', 'st.gallen', 'sankt gallen', 'saint-gall', 'saint gall',

--- a/build-plugins/shared/cantonSalaryIndex.ts
+++ b/build-plugins/shared/cantonSalaryIndex.ts
@@ -140,6 +140,11 @@ reg('mittelland', [
   'giura', 'jura',
 ]);
 reg('nordwest', [
+  // Bare half-canton-group display forms (BL+BS both Nordwest) — without these
+  // the localized group name "Basilea"/"Basel"/"Bâle" missed the table and the
+  // prose/FAQ salary band silently fell back to the national median while the
+  // page tiles used Nordwest (intra-page inconsistency). See PR #2085 review.
+  'basilea', 'basel', 'bâle', 'bale',
   'basilea città', 'basilea citta', 'basilea-città', 'basel-stadt', 'basel stadt', 'bâle-ville', 'bale-ville',
   'basilea campagna', 'basilea-campagna', 'basel-landschaft', 'basel landschaft', 'bâle-campagne', 'bale-campagne',
   'argovia', 'aargau', 'argovie',

--- a/services/router.ts
+++ b/services/router.ts
@@ -55,6 +55,7 @@ import { BORDER_WAIT_ROUTES, isBorderWaitPath, parseBorderWaitPath } from '../bu
 import { NURSING_LANDING_ROUTES, isNursingLandingPath, parseNursingLandingPath } from '../build-plugins/nursingLandingsData';
 import { CAREER_LANDING_ROUTES, isCareerLandingPath, parseCareerLandingPath } from '../build-plugins/careerLandingsData';
 import { PROFESSION_LANDING_ROUTES, isProfessionLandingPath, parseProfessionLandingPath } from '../build-plugins/professionLandingsData';
+import { isProfessionCantonPath, parseProfessionCantonPath } from '../build-plugins/professionCantonData';
 import {
   COST_OF_LIVING_LANDING_ROUTES,
   isCostOfLivingLandingPath,
@@ -2524,6 +2525,16 @@ export function parsePath(pathname: string): ParseResult {
      if (parsed) {
        return { route: { activeTab: 'job-board', staticOverlay: true }, locale: parsed.locale as Locale };
      }
+   }
+ }
+
+ // Per-canton profession landings (/lavoro-{canton}-{role}/ + locale variants).
+ // Build-time static HTML (gated on real job count); staticOverlay hydrates to
+ // the job board so the SPA doesn't replace the per-canton/profession content.
+ if (isProfessionCantonPath(pathname)) {
+   const parsed = parseProfessionCantonPath(pathname);
+   if (parsed) {
+     return { route: { activeTab: 'job-board', staticOverlay: true }, locale: parsed.locale as Locale };
    }
  }
 

--- a/tests/profession-canton-landings.test.ts
+++ b/tests/profession-canton-landings.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-canton profession landings — routing, enumeration and render invariants.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  PROFESSION_CANTON_ROUTES,
+  listAllProfessionCantonPaths,
+  parseProfessionCantonPath,
+  isProfessionCantonPath,
+  buildProfessionCantonPath,
+} from '../build-plugins/professionCantonData';
+import { renderProfessionCantonPage } from '../build-plugins/professionCantonLandings';
+import { parsePath } from '../services/router';
+
+const SNAP = {
+  liveCount: 12,
+  fresh30Count: 5,
+  medianSalaryChf: 84000,
+  featured: [],
+  topEmployers: [
+    { name: 'Ospedale Regionale', count: 6 },
+    { name: 'Clinica Privata SA', count: 3 },
+  ],
+};
+
+describe('professionCantonData — enumeration', () => {
+  it('enumerates 23 non-TI cantons × 10 professions × 4 locales = 920 routes', () => {
+    expect(PROFESSION_CANTON_ROUTES.length).toBe(920);
+  });
+  it('every route has a trailing slash and round-trips through parse', () => {
+    for (const p of PROFESSION_CANTON_ROUTES) {
+      expect(p).toMatch(/\/$/);
+      const parsed = parseProfessionCantonPath(p);
+      expect(parsed).toBeTruthy();
+      expect(parsed!.path).toBe(p);
+      expect(isProfessionCantonPath(p)).toBe(true);
+    }
+  });
+  it('builds the expected IT/EN slug shape', () => {
+    expect(buildProfessionCantonPath('it', 'ZH', 'infermiere')).toBe('/lavoro-zurigo-infermiere/');
+    expect(buildProfessionCantonPath('en', 'ZH', 'infermiere')).toBe('/en/jobs-zurich-nurse/');
+    expect(buildProfessionCantonPath('de', 'GE', 'ingegnere')).toBe('/de/arbeit-genf-ingenieur/');
+  });
+  it('rejects non-matching paths', () => {
+    expect(parseProfessionCantonPath('/lavoro-ticino-infermiere/')).toBeNull(); // legacy TI family
+    expect(isProfessionCantonPath('/lavoro-zurigo/')).toBe(false);
+  });
+});
+
+describe('professionCanton — router integration', () => {
+  it('parsePath returns job-board + staticOverlay for the family', () => {
+    for (const p of PROFESSION_CANTON_ROUTES.slice(0, 40)) {
+      const { route } = parsePath(p);
+      expect(route.staticOverlay).toBe(true);
+      expect(route.activeTab).toBe('job-board');
+    }
+  });
+});
+
+describe('professionCanton — render', () => {
+  it('renders an indexable page with real employers, salary and hreflang', () => {
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const { html, words } = renderProfessionCantonPage({
+        locale, cantonKey: 'ZH', id: 'infermiere', snapshot: SNAP, distDir: '',
+      });
+      expect(words).toBeGreaterThanOrEqual(50);
+      expect(html).toContain('Ospedale Regionale'); // real employer chip
+      expect(html).toContain('84'); // median salary
+      expect(html).toMatch(/hreflang=["']?x-default["']?/);
+      expect(html).not.toMatch(/\bdark:[a-z-]/);
+    }
+  });
+});

--- a/tests/profession-canton-landings.test.ts
+++ b/tests/profession-canton-landings.test.ts
@@ -11,6 +11,7 @@ import {
   buildProfessionCantonPath,
 } from '../build-plugins/professionCantonData';
 import { renderProfessionCantonPage } from '../build-plugins/professionCantonLandings';
+import { grossregionFromDisplay } from '../build-plugins/shared/cantonSalaryIndex';
 import { parsePath } from '../services/router';
 
 const SNAP = {
@@ -55,6 +56,13 @@ describe('professionCanton — router integration', () => {
       expect(route.staticOverlay).toBe(true);
       expect(route.activeTab).toBe('job-board');
     }
+  });
+});
+
+describe('half-canton group display names resolve to their region (no national fallback)', () => {
+  it('Basilea/Basel/Bâle → nordwest; Appenzello/Appenzell → ostschweiz', () => {
+    for (const d of ['Basilea', 'Basel', 'Bâle']) expect(grossregionFromDisplay(d)).toBe('nordwest');
+    for (const d of ['Appenzello', 'Appenzell']) expect(grossregionFromDisplay(d)).toBe('ostschweiz');
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,7 @@ import { weatherBorderWaitFusionPlugin } from './build-plugins/weatherBorderWait
 import { weeklyEmployersPlugin } from './build-plugins/weeklyEmployersPlugin';
 import { jobMarketSnapshotPlugin } from './build-plugins/jobMarketSnapshotPlugin';
 import { salaryStatsChCantonPages } from './build-plugins/salaryStatsChCantonPages';
+import { professionCantonLandings } from './build-plugins/professionCantonLandings';
 import { healthPremiumsLandingPlugin } from './build-plugins/healthPremiumsLandingPlugin';
 // blogContextualLinksPlugin import retained for tests / type re-exports.
 // Its plugin export is now consumed internally by `postWalkCoordinatorPlugin`.
@@ -154,6 +155,7 @@ export default defineConfig(({ mode }) => {
  weeklyEmployersPlugin(__dirname),
  jobMarketSnapshotPlugin(__dirname),
  salaryStatsChCantonPages(__dirname),
+ professionCantonLandings(__dirname),
  healthPremiumsLandingPlugin(__dirname),
  borderWaitPagesPlugin(__dirname),
  weatherBorderWaitFusionPlugin(__dirname),


### PR DESCRIPTION
## Implementato

Nuova famiglia SEO **landing professione × cantone**, data-driven dal corpus reale — completa l'ultima estensione per-cantone richiesta.

- **URL**: `/lavoro-{cantone}-{ruolo}/` + `/en/jobs-…`, `/de/arbeit-…`, `/fr/travail-…` per i **23 cantoni non-TI** × 10 professioni × 4 lingue (920 route enumerate). **TI escluso**: le sue landing legacy `lavoro-ticino-{ruolo}` possiedono già quegli slug (evitata collisione).
- **Datori reali per-cantone (non hardcoded):** nuova `aggregateProfessionJobsByCanton` raggruppa i job attivi del corpus (`data/jobs.json`) per cantone (half-cantoni → gruppo URL) e per professione, riusando i matcher title-regex esistenti → `topEmployers` + **mediana salariale reale** + conteggi live presi dai job effettivi di quel cantone. Accurato e unico per cantone.
- **Gate job-count (≥3 offerte reali)** per coppia (cantone, professione): solo le coppie con domanda reale vengono emesse → niente pagine thin/vuote/inventate (AGENTS #4). Il numero effettivo di pagine è guidato dai dati, non 920 fisse.
- Contenuto pagina: header professione+cantone, stat tile (offerte attive / pubblicate 30gg / stipendio mediano reale o scalato BFS in fallback), **chip datori reali**, prose canton-aware + FAQ (`renderCantonSeoProse`), CTA alla landing stipendi-cantone (#2085) + job board filtrato, hreflang cluster (4 locali + x-default), JSON-LD Breadcrumb+FAQPage, `index,follow`, **sitemap-profession-cantons.xml** registrato nell'index (come le sorelle).
- **Fix nit BASILEA di #2085**: aggiunte le forme bare `basilea`/`basel`/`bâle`/`bale` alla mappa display→region di `cantonSalaryIndex` → la prose/FAQ non cade più sul nazionale per le pagine BASILEA (migliora anche editorial + salary-stats già live).
- **Test**: enumerazione 920 route + trailing-slash + parse round-trip, esclusione TI/collisione legacy, integrazione router (job-board+staticOverlay), render con snapshot sintetico (datori reali, salario, hreflang, ≥50 parole, no `dark:`). 56 test verdi (+ router 483, sitemap-consistency, prose) + tsc pulito.

## Non implementato (ancora)

- **CCL/riferimenti contrattuali per-cantone**: le pagine non mostrano i riferimenti CCL/GAV per-cantone (le pagine TI legacy li hanno hardcoded). I CCL variano per cantone/settore e non esistono come dato strutturato → fuori scope; il salario mediano deriva dai job reali, non dal CCL.
- **Featured jobs nelle pagine**: lo snapshot espone `featured`, ma le pagine mostrano i datori aggregati (chip), non le singole offerte featured — follow-up se serve densità.
- **Validazione build/emit + conteggio pagine effettivo live**: l'emit SSG (e quante coppie superano il gate ≥3) non è validabile localmente (build SEO OOM); si osserva sul deploy post-merge (curl path live + sitemap-profession-cantons.xml + build-id). Se l'emit OOMa o il page-count regredisce il deploy → revert (gate `SKIP_PROFESSION_CANTONS=1` disponibile).
- **Moratorium SEO**: nuova famiglia di landing autorizzata dall'owner (posizione GSC 7gg ≤ 7.5 confermata).
