### PR TITLE
perf(translate): drop 100%-dead self-hosted LibreTranslate (reclaim ~124min/run)

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -47,42 +47,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 350
 
-    # Self-hosted LibreTranslate — unlimited free translations with no external API dependency.
-    # Argos Translate models load on first request (~30s), subsequent calls are <500ms.
-    # Known limitation: quality is lower than DeepL/Azure for IT translations (e.g. typos
-    # in compound words). Use as high-priority tier for EN/DE/FR, free cascade handles IT.
-    services:
-      libretranslate:
-        # Pinned to v1.9.6 (was :latest). Last-known-good as of 2026-05-28.
-        # `:latest` caused a flaky-healthcheck failure even on the same v1.9.6 build;
-        # explicit pin avoids upstream drift on every cron run.
-        image: libretranslate/libretranslate:v1.9.6
-        ports:
-          - 5000:5000
-        env:
-          LT_LOAD_ONLY: it,en,de,fr
-          LT_SUGGESTIONS: "false"
-          LT_DISABLE_WEB_UI: "true"
-        options: >-
-          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/languages')\" || exit 1"
-          --health-interval 15s
-          --health-timeout 10s
-          --health-retries 20
-          --health-start-period 300s
+    # NOTE: the self-hosted LibreTranslate service container was REMOVED (2026-06-15).
+    # Measured on run 27521648869: the Argos /translate endpoint on the 2-core runner
+    # was 100% dead — 1483 timeouts, ZERO successful translations (tier hits:
+    # libreTranslateSelfHosted=0) — while burning ~124min/run waiting it out and
+    # OOM-pressuring the node process. The real work is done by the PUBLIC LibreTranslate
+    # instances (tier hits: libreTranslate=107) + MyMemory, which the cascade reaches
+    # anyway. Dropping the dead container reclaims that time and memory. To restore
+    # self-hosted LT, re-add the service + LIBRETRANSLATE_SELF_HOSTED_URL after fixing
+    # why Argos times out on the runner (model-load/2-core/memory).
 
     steps:
-      - name: Wait for LibreTranslate service
-        run: |
-          echo "⏳ Waiting for LibreTranslate to load language models..."
-          for i in $(seq 1 40); do
-            if curl -sf http://localhost:5000/languages > /dev/null 2>&1; then
-              echo "✅ LibreTranslate ready (attempt $i)"
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "⚠️  LibreTranslate not ready after 200s — translations will use other providers"
-
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
@@ -175,20 +150,9 @@ jobs:
         if: inputs.skip_translate != true
         env:
           JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
-          # Self-hosted LibreTranslate from service container — unlimited, no API key needed
-          JOBS_LIBRETRANSLATE_ENDPOINT: 'http://localhost:5000/translate'
-          LIBRETRANSLATE_SELF_HOSTED_URL: 'http://localhost:5000'
-          # Fast-fail the self-hosted LibreTranslate fetch. Measured: on the 2-core
-          # GitHub runner the Argos /translate endpoint overwhelmingly times out — run
-          # 27459918472 (max-jobs 100, default concurrency) logged 525 self-hosted
-          # timeout errors vs only 73 jobs cleared, burning ~262min of a 329min run
-          # waiting out the 30s default bound (free-translate.mjs LIBRETRANSLATE_TIMEOUT_MS).
-          # LT self-hosted contributes ~nothing, so failing it in 5s instead of 30s
-          # reclaims ~85% of that wasted time for the tiers that actually work (premium
-          # + MyMemory + public LT). The cascade order is unchanged; jobs LT can't serve
-          # fall through exactly as before, just sooner. Bounded downside: the rare LT
-          # call that would have succeeded in 5-30s now falls to MyMemory (which works).
-          LIBRETRANSLATE_TIMEOUT_MS: '5000'
+          # Self-hosted LibreTranslate removed (see note above the steps): it was 100%
+          # dead on the runner. The cascade now uses premium tiers + MyMemory + PUBLIC
+          # LibreTranslate, which were already doing all the real work.
         run: node scripts/relocalize-pending-jobs.mjs --max-jobs ${{ inputs.max_jobs || '100' }} ${{ inputs.company_key && format('--company-key {0}', inputs.company_key) || '' }}
 
       - name: Log translation stats (after)
@@ -208,12 +172,7 @@ jobs:
       # every run. New jobs from crawlers will have source-copy titles that 2b fixes.
       - name: "Phase 2b: Fix untranslated titles (free cascade)"
         if: steps.hk.outputs.run == 'true' && inputs.dry_run != true
-        env:
-          LIBRETRANSLATE_SELF_HOSTED_URL: 'http://localhost:5000'
-          # Same fast-fail rationale as Phase 2 above — the self-hosted LT endpoint
-          # times out ~always on the 2-core runner; 5s instead of 30s avoids burning
-          # the step's budget on the dead tier before the working cascade tiers run.
-          LIBRETRANSLATE_TIMEOUT_MS: '5000'
+        # Self-hosted LibreTranslate removed (see note above the steps) — was 100% dead.
         run: node scripts/fix-untranslated-titles.mjs
 
       - name: Commit title fixes


### PR DESCRIPTION
## Implementato

Misurato che il self-hosted LibreTranslate è **morto al 100%** sul runner e va rimosso del tutto (il fast-fail di #2047 era solo un palliativo).

**Evidenza** (run `27521648869`, max-jobs 100, cascade ripristinata + fast-fail 5s):
- **`libreTranslateSelfHosted` tier hits = 0** (zero traduzioni riuscite), **1483 timeout**.
- Il vero workhorse è il **LibreTranslate PUBBLICO**: `libreTranslate` tier hits = **107**; + MyMemory=16, google=7.
- Il run ha bruciato ~124min (1483×5s) sul tier morto ed è stato **cancellato a 347min/350min SENZA committare** (nessun nuovo commit `🌐 Auto-translate`, stats-history ferma).

**Fix**: rimosso il service container `libretranslate`, il suo wait-step, e gli env `LIBRETRANSLATE_SELF_HOSTED_URL` / `LIBRETRANSLATE_TIMEOUT_MS` (aggiunti da #2047, ora inutili). Con l'URL unset, `translateWithLibreTranslateSelfHosted()` ritorna `''` istantaneamente → il tier morto viene saltato a costo zero. Recupera ~124min/run + la memoria del container (Argos su 2-core/7GB metteva pressione sul processo node).

Perché è sicuro:
- **Perde zero traduzioni** (provato: 0 hit). Il lavoro lo fa già il LibreTranslate pubblico + MyMemory, che la cascade raggiunge comunque.
- Nessun cambio di ordine cascade/concurrency/gate-qualità. IT non toccato.
- Reversibile (re-add service + env). Comment nel workflow spiega come e perché.

Atteso: un run max-jobs 100 ora **completa e committa entro il timeout** (~265min stimati senza i 124min di spreco) invece di cancellarsi → drena davvero ~100 job/run.

## Non implementato (ancora)

- **Riparare** il self-hosted LT (sarebbe l'unica OSS davvero illimitata) NON fatto: causa del timeout sistematico (Argos model-load / 2-core / memoria) da diagnosticare a parte. Questo PR lo rimuove perché morto; un follow-up può reintrodurlo funzionante (commento nel workflow dice come).
- **Claim perf non validabile pre-merge**: se il prossimo run NON completa+committa entro il timeout → il collo è altrove (premium esauriti + MyMemory 1s + public LT lento), e servirà ridurre il lavoro/run o sistemare il re-flag churn. Revert = re-add 3 righe.
- **Coda-zero piena**: resta legata al re-flag churn (`mark-locale-mismatched` ~4600/run, 82% EN/DE/FR) — fuori scope di questo PR, che rende solo i run capaci di committare.

## Test plan

- [x] YAML valido (`yaml.safe_load`; `services` block assente).
- [x] Nessun riferimento residuo a `localhost:5000`/`LIBRETRANSLATE_SELF_HOSTED_URL` (solo nel commento esplicativo).
- [x] `translateWithLibreTranslateSelfHosted` ritorna `''` quando l'URL è unset (guard `if (!LIBRETRANSLATE_SELF_HOSTED) return ''`).
- [ ] Post-merge: prossimo run completa+committa entro 350min, stats-history mostra needsRetranslation in calo, tier hits senza self-hosted. (verifica post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)