### PR TITLE
feat(newsletter): auto-promote winning subject variant (epsilon-greedy, on by default)

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -21,6 +21,38 @@ two independent readouts: a **free Firestore report** and an optional
    send doc.
 4. **Measurement** — opens are recorded by the ESP webhooks. The winner is read
    two ways (below).
+5. **Auto-promotion** — the next send biases toward the recent winner (below).
+
+## Auto-promotion (on by default)
+
+`send-newsletter.mjs` resolves a *promoted variant* before assembling a campaign:
+it pools the open rates of the previous `NEWSLETTER_AB_LOOKBACK` campaigns
+(default 2) and, **only** if every arm cleared the sample gate
+(`DEFAULT_WINNER_GATES.minSendsPerArm`, default 200) **and** the best vs runner-up
+is significant (z-test, p<0.05), declares a winner.
+
+When a winner exists, assignment becomes **epsilon-greedy**: a `1-ε` share
+(ε=`DEFAULT_EPSILON`, 0.2 → 90% for two arms) is sent the winner, the rest still
+explores uniformly so the losing arm keeps getting traffic and the test stays
+live (and can flip if the winner changes). With no significant winner it is a
+pure even split — so "on by default" changes nothing until the data earns it.
+
+The promoted variant is decided **globally** (pooled across providers), because
+the variant is assigned *before* the cascade picks a provider — we can't route a
+subscriber to a provider, so per-provider promotion isn't actionable at
+assignment time. The per-provider report stays the analysis lens; true
+per-provider promotion (swapping the subject at send time once the provider is
+known) is a deeper follow-up that would touch the funnel-critical cascade.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `NEWSLETTER_AB_AUTOPROMOTE` | on | set `false` to force an even split (kill switch) |
+| `NEWSLETTER_AB_LOOKBACK` | `2` | how many prior campaigns to pool for the winner |
+
+The persisted `variant` on each send doc is authoritative — once promotion skews
+the split, the variant is no longer a pure function of `(email, campaignId)`, so
+the report and resolver both read the persisted value (recompute is a legacy
+fallback only).
 
 ## Reading the result
 

--- a/scripts/lib/newsletter-ab-data.mjs
+++ b/scripts/lib/newsletter-ab-data.mjs
@@ -1,0 +1,114 @@
+/**
+ * newsletter-ab-data.mjs — shared Firestore loader for the subject A/B test.
+ *
+ * Single source of truth for turning a campaign's Firestore records into
+ * per-(provider × variant) send/open totals. Used by BOTH the report
+ * (scripts/newsletter-ab-report.mjs) and the send pipeline's auto-promotion
+ * resolver, so the open-detection logic can't drift between them.
+ *
+ * Open detection ORs three signals (immune to the per-provider delivery-doc-id
+ * divergence): `opened_at` on the send doc, plus a per-campaign `open` event
+ * matched by email or message_id.
+ *
+ * The variant is taken from the PERSISTED `variant` field on the send doc
+ * (authoritative — written at send time for every provider), falling back to a
+ * deterministic recompute only for legacy docs predating persistence. Recompute
+ * alone is NOT sufficient once auto-promotion biases the split, because the
+ * assigned variant is then no longer a pure function of (email, campaignId).
+ */
+
+import { assignSubjectVariant } from '../../services/newsletter-subject-variants.mjs';
+
+/** Thrown when the single-field collectionGroup index is missing. */
+export class MissingIndexError extends Error {
+  constructor(group, original) {
+    super(`Missing Firestore collectionGroup index for "${group}.campaign_id"`);
+    this.name = 'MissingIndexError';
+    this.group = group;
+    this.original = original;
+  }
+}
+
+/**
+ * Load per-(provider × variant) totals for one campaign.
+ * @param {FirebaseFirestore.Firestore} db
+ * @param {string} campaignId
+ * @returns {Promise<{cells:object, byVariant:object, totalSends:number, mismatchVariant:number}>}
+ */
+export async function loadCampaignVariantTotals(db, campaignId) {
+  const runQuery = async (group) => {
+    try {
+      return await db.collectionGroup(group).where('campaign_id', '==', campaignId).get();
+    } catch (e) {
+      if (String(e?.message || '').includes('index')) throw new MissingIndexError(group, e);
+      throw e;
+    }
+  };
+
+  const sendSnap = await runQuery('campaign_deliveries');
+  const openSnap = await runQuery('events');
+
+  const openedEmails = new Set();
+  const openedMsgIds = new Set();
+  for (const doc of openSnap.docs) {
+    const d = doc.data();
+    if (d.event_type !== 'open') continue; // refine in memory (no composite index)
+    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
+    if (email) openedEmails.add(email);
+    if (d.message_id) openedMsgIds.add(String(d.message_id));
+  }
+
+  const cells = {}; // cells[provider][variant] = { sends, opens }
+  const byVariant = {}; // pooled across providers
+  const ensure = (provider, variant) => {
+    cells[provider] ??= {};
+    cells[provider][variant] ??= { sends: 0, opens: 0 };
+    byVariant[variant] ??= { sends: 0, opens: 0 };
+    return cells[provider][variant];
+  };
+
+  let totalSends = 0;
+  let mismatchVariant = 0;
+  for (const doc of sendSnap.docs) {
+    const d = doc.data();
+    if (!d.sent_at) continue; // only count real sends
+    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
+    if (!email) continue;
+    const provider = d.provider || 'unknown';
+    // Persisted variant is authoritative; recompute only as a legacy fallback.
+    const variant = d.variant || assignSubjectVariant(email, campaignId);
+    if (d.variant && d.variant !== assignSubjectVariant(email, campaignId)) mismatchVariant++;
+
+    const cell = ensure(provider, variant);
+    cell.sends++;
+    byVariant[variant].sends++;
+    const opened = !!d.opened_at || openedEmails.has(email) || (d.message_id && openedMsgIds.has(String(d.message_id)));
+    if (opened) {
+      cell.opens++;
+      byVariant[variant].opens++;
+    }
+    totalSends++;
+  }
+
+  return { cells, byVariant, totalSends, mismatchVariant };
+}
+
+/**
+ * The `weekly_YYYY-MM-DD` campaign ids for the `count` Mondays BEFORE the given
+ * campaign (most recent first). Used to pool recent history for promotion.
+ * @param {string} campaignId e.g. "weekly_2026-06-15"
+ * @param {number} count
+ * @returns {string[]}
+ */
+export function previousCampaignIds(campaignId, count) {
+  const m = /^weekly_(\d{4})-(\d{2})-(\d{2})$/.exec(String(campaignId || ''));
+  if (!m) return [];
+  const base = new Date(`${m[1]}-${m[2]}-${m[3]}T00:00:00Z`);
+  const ids = [];
+  for (let k = 1; k <= count; k++) {
+    const d = new Date(base);
+    d.setUTCDate(base.getUTCDate() - 7 * k);
+    ids.push(`weekly_${d.toISOString().slice(0, 10)}`);
+  }
+  return ids;
+}

--- a/scripts/newsletter-ab-report.mjs
+++ b/scripts/newsletter-ab-report.mjs
@@ -10,10 +10,10 @@
  * Design — immune to the per-provider webhook inconsistencies:
  *  - DENOMINATOR (sends) comes from the send-time `campaign_deliveries` docs,
  *    where `provider` is authoritative for every cascade provider.
- *  - VARIANT is RE-COMPUTED deterministically via assignSubjectVariant(email,
- *    campaignId) — so it never depends on what a given provider's webhook stored
- *    (only Resend reads tags.variant). The persisted `variant` is used only as a
- *    cross-check.
+ *  - VARIANT comes from the PERSISTED `variant` on the send doc (authoritative,
+ *    written at send time for every provider), recomputed deterministically only
+ *    as a legacy fallback. Persisted-first is required once auto-promotion biases
+ *    the split (the variant is then no longer a pure function of email+campaign).
  *  - NUMERATOR (opens) is an OR of signals so no provider is under-counted:
  *      (a) `opened_at` on the send doc (Resend + any same-doc provider), plus
  *      (b) an 'open' event in the subscriber `events` subcollection for this
@@ -29,7 +29,9 @@
  * Read-only — never writes to Firestore.
  */
 
-import { assignSubjectVariant, listVariantIds } from '../services/newsletter-subject-variants.mjs';
+import { listVariantIds } from '../services/newsletter-subject-variants.mjs';
+import { twoProportionTest } from '../services/newsletter-ab-stats.mjs';
+import { loadCampaignVariantTotals, MissingIndexError } from './lib/newsletter-ab-data.mjs';
 
 const args = process.argv.slice(2);
 const JSON_OUT = args.includes('--json');
@@ -61,30 +63,6 @@ async function initFirebase() {
   return a.firestore();
 }
 
-/** Standard normal CDF (Abramowitz–Stegun erf approximation). */
-function normalCdf(z) {
-  const t = 1 / (1 + 0.2316419 * Math.abs(z));
-  const d = 0.3989423 * Math.exp(-z * z / 2);
-  const p = d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-  return z > 0 ? 1 - p : p;
-}
-
-/**
- * Two-proportion z-test (two-sided). Returns { z, pValue } or null if either
- * sample is empty.
- */
-function twoProportionTest(a, b) {
-  if (!a.sends || !b.sends) return null;
-  const p1 = a.opens / a.sends;
-  const p2 = b.opens / b.sends;
-  const pPool = (a.opens + b.opens) / (a.sends + b.sends);
-  const se = Math.sqrt(pPool * (1 - pPool) * (1 / a.sends + 1 / b.sends));
-  if (se === 0) return { z: 0, pValue: 1 };
-  const z = (p1 - p2) / se;
-  const pValue = 2 * (1 - normalCdf(Math.abs(z)));
-  return { z, pValue };
-}
-
 const pct = (n, d) => (d > 0 ? (100 * n / d) : 0);
 
 async function main() {
@@ -97,66 +75,21 @@ async function main() {
 
   const db = await initFirebase();
 
-  // Both queries filter on `campaign_id` only (single-field collectionGroup
-  // index) and refine in memory — avoids requiring a composite index. If the
-  // single-field collectionGroup index is missing, Firestore returns a
-  // FAILED_PRECONDITION with a one-click creation URL, surfaced below.
-  const runQuery = async (group, label) => {
-    try {
-      return await db.collectionGroup(group).where('campaign_id', '==', campaignId).get();
-    } catch (e) {
-      if (String(e?.message || '').includes('index')) {
-        console.error(`❌ Missing Firestore collectionGroup index for "${group}.campaign_id".`);
-        console.error(`   Create it via the link in this error, then re-run:\n   ${e.message}`);
-        process.exit(2);
-      }
-      throw e;
+  // Shared loader (same logic the auto-promotion resolver uses). Open detection
+  // ORs send-doc opened_at with per-campaign open events → immune to the
+  // per-provider delivery-doc-id divergence.
+  let cells;
+  let totalSends;
+  let mismatchVariant;
+  try {
+    ({ cells, totalSends, mismatchVariant } = await loadCampaignVariantTotals(db, campaignId));
+  } catch (e) {
+    if (e instanceof MissingIndexError) {
+      console.error(`❌ ${e.message}.`);
+      console.error(`   Create the single-field collectionGroup index via the link in this error, then re-run:\n   ${e.original?.message || ''}`);
+      process.exit(2);
     }
-  };
-
-  // ── 1. Sends (denominator) + same-doc opens ──
-  const sendSnap = await runQuery('campaign_deliveries', 'sends');
-
-  // ── 2. Opens (numerator) from the events subcollection for this campaign ──
-  // Every provider writes an 'open' event with provider + campaign_id, even when
-  // its delivery-doc id diverges from the send doc.
-  const openSnap = await runQuery('events', 'opens');
-
-  const openedEmails = new Set();
-  const openedMsgIds = new Set();
-  for (const doc of openSnap.docs) {
-    const d = doc.data();
-    if (d.event_type !== 'open') continue; // refine in memory (no composite index)
-    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
-    if (email) openedEmails.add(email);
-    if (d.message_id) openedMsgIds.add(String(d.message_id));
-  }
-
-  // cells[provider][variant] = { sends, opens }
-  const cells = {};
-  const ensure = (provider, variant) => {
-    cells[provider] ??= {};
-    cells[provider][variant] ??= { sends: 0, opens: 0 };
-    return cells[provider][variant];
-  };
-
-  let totalSends = 0;
-  let mismatchVariant = 0;
-  for (const doc of sendSnap.docs) {
-    const d = doc.data();
-    if (!d.sent_at) continue; // only count real sends
-    const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
-    if (!email) continue;
-    const provider = d.provider || 'unknown';
-    // Variant is recomputed (source of truth); cross-check against persisted.
-    const variant = assignSubjectVariant(email, campaignId);
-    if (d.variant && d.variant !== variant) mismatchVariant++;
-
-    const cell = ensure(provider, variant);
-    cell.sends++;
-    const opened = !!d.opened_at || openedEmails.has(email) || (d.message_id && openedMsgIds.has(String(d.message_id)));
-    if (opened) cell.opens++;
-    totalSends++;
+    throw e;
   }
 
   if (totalSends === 0) {

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -34,7 +34,9 @@ import { fileURLToPath } from 'node:url';
 import { buildNewsletter, FEATURED_TOOLS, getFeaturedTools, nlNormLocale, directUrl } from '../services/newsletter-template.mjs';
 import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, companyPageUrl, isCompanyHubSlug } from '../services/newsletter-content.mjs';
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
-import { assignSubjectVariant, getVariantFallback, listVariantIds } from '../services/newsletter-subject-variants.mjs';
+import { assignSubjectVariant, getVariantFallback, listVariantIds, DEFAULT_EPSILON } from '../services/newsletter-subject-variants.mjs';
+import { pickWinner } from '../services/newsletter-ab-stats.mjs';
+import { loadCampaignVariantTotals, previousCampaignIds } from './lib/newsletter-ab-data.mjs';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib/emailExperimentPostHog.js';
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
@@ -1413,6 +1415,46 @@ async function persistCampaignSends(campaignId, newlySentEmails) {
   }
 }
 
+// ─── Subject A/B auto-promotion ─────────────────────────────
+// On by default (kill switch: NEWSLETTER_AB_AUTOPROMOTE=false). Safe: a no-op
+// until a recent campaign has a statistically significant winner with enough
+// sample (pickWinner gates), in which case the assignment biases toward it
+// epsilon-greedily while still exploring the other arm.
+const AB_AUTOPROMOTE = process.env.NEWSLETTER_AB_AUTOPROMOTE !== 'false';
+const AB_PROMOTE_LOOKBACK = Math.max(1, Number(process.env.NEWSLETTER_AB_LOOKBACK || 2));
+
+/**
+ * Resolve the variant to auto-promote for this campaign by pooling the open
+ * rates of the previous `AB_PROMOTE_LOOKBACK` campaigns. Returns the winning
+ * variant id, or null to keep an even split. Never throws → failure = no promo.
+ */
+async function resolvePromotedVariant(database, campaignId) {
+  if (!AB_AUTOPROMOTE || !database) return null;
+  try {
+    const ids = previousCampaignIds(campaignId, AB_PROMOTE_LOOKBACK);
+    const pooled = {};
+    for (const cid of ids) {
+      const { byVariant } = await loadCampaignVariantTotals(database, cid);
+      for (const [v, t] of Object.entries(byVariant)) {
+        pooled[v] ??= { sends: 0, opens: 0 };
+        pooled[v].sends += t.sends;
+        pooled[v].opens += t.opens;
+      }
+    }
+    const { winner, openRates, pValue, reason } = pickWinner(pooled);
+    const rates = Object.fromEntries(Object.entries(openRates).map(([k, v]) => [k, `${(v * 100).toFixed(1)}%`]));
+    if (winner) {
+      console.log(`🏆 Auto-promote "${winner}" (p=${pValue?.toFixed(3)}, ε=${DEFAULT_EPSILON}) from last ${ids.length} campaign(s); rates=${JSON.stringify(rates)}`);
+    } else {
+      console.log(`⚖️  Auto-promote: even split (${reason}); rates=${JSON.stringify(rates)}`);
+    }
+    return winner;
+  } catch (e) {
+    console.warn('⚠️ Auto-promote skipped:', e?.message);
+    return null;
+  }
+}
+
 // ─── Resend API ─────────────────────────────────────────────
 
 async function persistDelivery(recipient, messageId, meta) {
@@ -2076,12 +2118,17 @@ async function main() {
   const metrics = loadDashboardMetrics();
   const emails = [];
 
+  // Auto-promotion: bias the variant split toward the recent winner (on by
+  // default; null = even split until a significant winner exists).
+  const promotedVariant = await resolvePromotedVariant(db, campaignId);
+
   for (const { subscriber, locale, matchedJobs, cohortKey } of subscriberData) {
     const briefing = briefingMap.get(cohortKey);
-    // A/B test: deterministic per-subscriber variant (stable for this campaign).
-    // Fall back to the first variant's subject, then the variant fallback, so a
-    // missing (locale,variant) entry can never leave subject undefined.
-    const variant = assignSubjectVariant(subscriber.email, campaignId);
+    // A/B test: deterministic per-subscriber variant (stable for this campaign),
+    // epsilon-greedy when a winner is promoted. Fall back to the first variant's
+    // subject, then the variant fallback, so a missing (locale,variant) entry
+    // can never leave subject undefined.
+    const variant = assignSubjectVariant(subscriber.email, campaignId, { promotedVariant, epsilon: DEFAULT_EPSILON });
     const subject = subjectMap.get(subjectKey(locale, variant))
       || subjectMap.get(subjectKey(locale, variantIds[0]))
       || getVariantFallback(variant, locale);

--- a/services/newsletter-ab-stats.mjs
+++ b/services/newsletter-ab-stats.mjs
@@ -1,0 +1,77 @@
+/**
+ * newsletter-ab-stats.mjs — pure statistics for the subject-line A/B test.
+ *
+ * No I/O, no Firestore, no dependencies → safe to import anywhere (the send
+ * script, the report, the Cloud Functions, tests). Shared single source of
+ * truth for the significance test + winner selection so the report's readout
+ * and the send pipeline's auto-promotion can never drift apart.
+ */
+
+/** Standard normal CDF (Abramowitz–Stegun erf approximation). */
+export function normalCdf(z) {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989423 * Math.exp(-z * z / 2);
+  const p = d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  return z > 0 ? 1 - p : p;
+}
+
+/**
+ * Two-proportion z-test (two-sided).
+ * @param {{sends:number,opens:number}} a
+ * @param {{sends:number,opens:number}} b
+ * @returns {{z:number,pValue:number}|null} null if either sample is empty.
+ */
+export function twoProportionTest(a, b) {
+  if (!a?.sends || !b?.sends) return null;
+  const p1 = a.opens / a.sends;
+  const p2 = b.opens / b.sends;
+  const pPool = (a.opens + b.opens) / (a.sends + b.sends);
+  const se = Math.sqrt(pPool * (1 - pPool) * (1 / a.sends + 1 / b.sends));
+  if (se === 0) return { z: 0, pValue: 1 };
+  const z = (p1 - p2) / se;
+  const pValue = 2 * (1 - normalCdf(Math.abs(z)));
+  return { z, pValue };
+}
+
+export const openRate = (cell) => (cell && cell.sends > 0 ? cell.opens / cell.sends : 0);
+
+/** Default gates for declaring an auto-promotable winner. Conservative on
+ * purpose: never promote on thin data or a noisy difference. */
+export const DEFAULT_WINNER_GATES = Object.freeze({
+  minSendsPerArm: 200, // each variant must have at least this many sends
+  alpha: 0.05,         // two-sided significance threshold
+});
+
+/**
+ * Decide the winning variant from pooled per-variant totals.
+ *
+ * Only returns a winner when EVERY arm has ≥ minSendsPerArm sends AND the best
+ * vs the runner-up is significant at `alpha`. Otherwise winner is null (caller
+ * should fall back to an even split). Currently expects exactly two arms; with
+ * other counts it returns the best by open rate only if significant vs the
+ * runner-up (and all arms meet the sample gate).
+ *
+ * @param {Record<string,{sends:number,opens:number}>} byVariant
+ * @param {{minSendsPerArm?:number, alpha?:number}} [gates]
+ * @returns {{winner:string|null, openRates:Record<string,number>, pValue:number|null, reason:string}}
+ */
+export function pickWinner(byVariant, gates = {}) {
+  const { minSendsPerArm, alpha } = { ...DEFAULT_WINNER_GATES, ...gates };
+  const ids = Object.keys(byVariant || {});
+  const openRates = {};
+  for (const id of ids) openRates[id] = openRate(byVariant[id]);
+
+  if (ids.length < 2) return { winner: null, openRates, pValue: null, reason: 'need ≥2 arms' };
+  if (ids.some((id) => (byVariant[id]?.sends || 0) < minSendsPerArm)) {
+    return { winner: null, openRates, pValue: null, reason: 'insufficient sample' };
+  }
+
+  const ranked = [...ids].sort((a, b) => openRates[b] - openRates[a]);
+  const best = ranked[0];
+  const runnerUp = ranked[1];
+  const test = twoProportionTest(byVariant[best], byVariant[runnerUp]);
+  if (!test || test.pValue >= alpha) {
+    return { winner: null, openRates, pValue: test?.pValue ?? null, reason: 'not significant' };
+  }
+  return { winner: best, openRates, pValue: test.pValue, reason: 'significant' };
+}

--- a/services/newsletter-subject-variants.mjs
+++ b/services/newsletter-subject-variants.mjs
@@ -88,24 +88,42 @@ export function getSubjectVariant(id) {
   return SUBJECT_VARIANTS.find((v) => v.id === id) || null;
 }
 
+/** Default exploration rate for epsilon-greedy auto-promotion: with a promoted
+ * winner, a (1-epsilon) share is exploited and epsilon is explored uniformly (so
+ * the losing arm keeps getting traffic and the test stays live). */
+export const DEFAULT_EPSILON = 0.2;
+
 /**
  * Deterministically assign a variant id for (email, campaignId).
  * Stable for the lifetime of a campaign (so a subscriber never flip-flops across
  * the daily cron re-runs of one weekly campaign) and rotates across campaigns
  * (so the same subscriber isn't always in the same bucket).
  *
+ * Without a `promotedVariant` the split is uniform (the pure A/B baseline). With
+ * one, it is epsilon-greedy: a deterministic (1-epsilon) share is sent the
+ * winner, the rest explores uniformly — so auto-promotion biases toward the
+ * winner while still measuring every arm.
+ *
  * @param {string} email
  * @param {string} campaignId
- * @param {Array}  [variants=SUBJECT_VARIANTS]
+ * @param {{variants?:Array, promotedVariant?:string|null, epsilon?:number}|Array} [opts]
+ *        (an array is accepted for backward compat = the variants list)
  * @returns {string} variant id
  */
-export function assignSubjectVariant(email, campaignId, variants = SUBJECT_VARIANTS) {
+export function assignSubjectVariant(email, campaignId, opts = {}) {
+  const o = Array.isArray(opts) ? { variants: opts } : (opts || {});
+  const { variants = SUBJECT_VARIANTS, promotedVariant = null, epsilon = DEFAULT_EPSILON } = o;
   const list = variants?.length ? variants : SUBJECT_VARIANTS;
   const key = `${normalizeEmail(email)}|${String(campaignId || '')}`;
   const digest = createHash('sha256').update(key).digest();
-  // Use a 4-byte unsigned int for a clean modulo with no first-byte skew.
-  const n = digest.readUInt32BE(0);
-  return list[n % list.length].id;
+  // Independent digest slices: one for the uniform pick, one for the explore/
+  // exploit draw — both deterministic so a subscriber is stable within a campaign.
+  const uniformPick = list[digest.readUInt32BE(0) % list.length].id;
+
+  const promoted = list.find((v) => v.id === promotedVariant);
+  if (!promoted) return uniformPick; // no promotion → pure A/B split
+  const draw = digest.readUInt32BE(4) / 0xffffffff; // [0,1)
+  return draw >= epsilon ? promoted.id : uniformPick; // exploit vs explore
 }
 
 /**

--- a/tests/newsletter-ab-promotion.test.ts
+++ b/tests/newsletter-ab-promotion.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+const { pickWinner, twoProportionTest, DEFAULT_WINNER_GATES } = await import('@/services/newsletter-ab-stats.mjs');
+const { assignSubjectVariant, DEFAULT_EPSILON, listVariantIds } = await import('@/services/newsletter-subject-variants.mjs');
+const { previousCampaignIds } = await import('@/scripts/lib/newsletter-ab-data.mjs');
+
+describe('pickWinner', () => {
+  it('returns no winner when a sample is below the gate', () => {
+    const r = pickWinner({ concreto: { sends: 50, opens: 30 }, curioso: { sends: 50, opens: 10 } });
+    expect(r.winner).toBeNull();
+    expect(r.reason).toBe('insufficient sample');
+  });
+
+  it('returns no winner when the difference is not significant', () => {
+    // 300 vs 300 sends, 90 vs 96 opens → close rates, not significant
+    const r = pickWinner({ concreto: { sends: 300, opens: 90 }, curioso: { sends: 300, opens: 96 } });
+    expect(r.winner).toBeNull();
+    expect(r.reason).toBe('not significant');
+  });
+
+  it('picks the higher-open-rate arm when significant and well-sampled', () => {
+    // 1000 each: 320 vs 200 opens → 32% vs 20%, clearly significant
+    const r = pickWinner({ concreto: { sends: 1000, opens: 320 }, curioso: { sends: 1000, opens: 200 } });
+    expect(r.winner).toBe('concreto');
+    expect(r.pValue).toBeLessThan(0.05);
+  });
+
+  it('honors custom gates', () => {
+    const tight = pickWinner({ a: { sends: 100, opens: 40 }, b: { sends: 100, opens: 20 } }, { minSendsPerArm: 500 });
+    expect(tight.winner).toBeNull(); // 100 < 500
+  });
+});
+
+describe('twoProportionTest', () => {
+  it('is null when an arm has no sends', () => {
+    expect(twoProportionTest({ sends: 0, opens: 0 }, { sends: 10, opens: 5 })).toBeNull();
+  });
+});
+
+describe('assignSubjectVariant epsilon-greedy promotion', () => {
+  const N = 6000;
+  const ids = listVariantIds();
+  const promoted = ids[0];
+
+  it('stays a ~even split with no promotion (baseline)', () => {
+    const counts: Record<string, number> = {};
+    for (let i = 0; i < N; i++) {
+      const v = assignSubjectVariant(`b${i}@x.com`, 'weekly_2026-06-15');
+      counts[v] = (counts[v] || 0) + 1;
+    }
+    expect(counts[promoted] / N).toBeGreaterThan(0.4);
+    expect(counts[promoted] / N).toBeLessThan(0.6);
+  });
+
+  it('biases toward the promoted variant (~1-epsilon+epsilon/k) but still explores', () => {
+    const counts: Record<string, number> = {};
+    for (let i = 0; i < N; i++) {
+      const v = assignSubjectVariant(`p${i}@x.com`, 'weekly_2026-06-15', { promotedVariant: promoted, epsilon: DEFAULT_EPSILON });
+      counts[v] = (counts[v] || 0) + 1;
+    }
+    const share = counts[promoted] / N;
+    const expected = (1 - DEFAULT_EPSILON) + DEFAULT_EPSILON / ids.length; // k=2 → 0.9
+    expect(share).toBeGreaterThan(expected - 0.05);
+    expect(share).toBeLessThan(expected + 0.05);
+    // the losing arm still gets meaningful traffic (test stays live)
+    const loser = ids.find((x) => x !== promoted)!;
+    expect(counts[loser] / N).toBeGreaterThan(0.04);
+  });
+
+  it('is deterministic with promotion (stable per subscriber within a campaign)', () => {
+    const a = assignSubjectVariant('Same@x.com', 'weekly_2026-06-15', { promotedVariant: promoted });
+    const b = assignSubjectVariant('same@x.com', 'weekly_2026-06-15', { promotedVariant: promoted });
+    expect(a).toBe(b);
+  });
+
+  it('ignores an unknown promoted variant (falls back to even split)', () => {
+    const counts: Record<string, number> = {};
+    for (let i = 0; i < N; i++) {
+      const v = assignSubjectVariant(`u${i}@x.com`, 'weekly_2026-06-15', { promotedVariant: 'nope' });
+      counts[v] = (counts[v] || 0) + 1;
+    }
+    expect(counts[promoted] / N).toBeGreaterThan(0.4);
+    expect(counts[promoted] / N).toBeLessThan(0.6);
+  });
+
+  it('epsilon=0 promotes the winner to (almost) everyone', () => {
+    let promotedCount = 0;
+    for (let i = 0; i < N; i++) {
+      if (assignSubjectVariant(`z${i}@x.com`, 'weekly_2026-06-15', { promotedVariant: promoted, epsilon: 0 }) === promoted) promotedCount++;
+    }
+    expect(promotedCount).toBe(N);
+  });
+
+  it('backward compatible: a plain 2-arg call is the uniform baseline', () => {
+    expect(typeof assignSubjectVariant('x@y.com', 'weekly_2026-06-15')).toBe('string');
+  });
+});
+
+describe('previousCampaignIds', () => {
+  it('returns the prior Mondays, most recent first', () => {
+    expect(previousCampaignIds('weekly_2026-06-15', 2)).toEqual(['weekly_2026-06-08', 'weekly_2026-06-01']);
+  });
+  it('returns [] for a malformed campaign id', () => {
+    expect(previousCampaignIds('not-a-campaign', 2)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Implementato

Chiude il loop dell'A/B titoli: la prossima campagna **sbilancia automaticamente** verso la variante vincente, invece di restare 50/50 fisso che un umano deve leggere e applicare. **On by default** ma **safe**: no-op finché non c'è un vincitore significativo e ben campionato.

- **`services/newsletter-ab-stats.mjs` (nuovo)** — stat pure (z-test + `pickWinner`) con gate conservativi: ogni arm ≥200 invii **e** best-vs-runnerup significativo (p<0.05), altrimenti `winner=null`. Single source of truth condivisa tra report e pipeline d'invio → la logica di significatività non può divergere.
- **`scripts/lib/newsletter-ab-data.mjs` (nuovo)** — loader Firestore condiviso (totali per `provider×variante`, open-detection via OR immune alla divergenza doc-id). Il report ora lo usa → **rimossa la duplicazione** del blocco query/aggregazione (report −~100 righe). La variante è letta dal campo **persistito** (autoritativo una volta che lo split è sbilanciato); il recompute è solo fallback legacy.
- **`assignSubjectVariant`** — promozione epsilon-greedy opzionale: con `promotedVariant`, una quota deterministica `(1-ε)` riceve il vincitore, `ε` (default 0.2 → 90% su 2 arm) esplora uniforme così l'arm perdente resta misurato (e il test può ribaltarsi). Senza promozione → uniforme (comportamento precedente, **backward-compatible**).
- **`scripts/send-newsletter.mjs`** — risolve il `promotedVariant` prima di assemblare la campagna, poolando le precedenti `NEWSLETTER_AB_LOOKBACK` (default 2) campagne. On by default (kill switch `NEWSLETTER_AB_AUTOPROMOTE=false`); mai throw → fallimento = nessuna promozione.
- **`docs/NEWSLETTER-SUBJECT-AB.md`** — sezione auto-promozione + env + razionale "globale non per-provider".
- **Test** (`tests/newsletter-ab-promotion.test.ts`, 13): gate di `pickWinner` (sample/significatività/gate custom), distribuzione epsilon-greedy (~90% vincitore + arm perdente vivo), determinismo, variante ignota → even split, ε=0 → 100% vincitore, backward-compat, `previousCampaignIds`. 46/46 con varianti+posthog.

## Non implementato (ancora)

- **Promozione PER-PROVIDER** — la promozione è decisa **globalmente** (poolata su tutti i provider) perché la variante è assegnata **prima** che il cascade scelga il provider (per quota): non possiamo instradare un iscritto su un provider, quindi a tempo-assegnazione la promozione per-provider non è azionabile. Il report per-provider resta la lente d'analisi. La promozione per-provider vera (swap del subject al send-time, una volta noto il provider) toccherebbe l'hot-path funnel-critical del cascade → follow-up dichiarato, non forzato.
- **Sibling-check** flagga `runQuery`/`pickWinner`/`collectionGroup`/`campaignId` in moduli scollegati (`fuel-station-dedup`, `posthogFetcher`, `query-authgate`, `revenue-monitor`, `send-job-alerts`, `migrate-job-alerts`, `email-cascade`, `analytics.ts`, `newsletterSubscribers.ts`): **nomi coincidenti, non stesso antipattern**. Anzi questa PR **elimina** la duplicazione `runQuery`/aggregazione estraendo il loader condiviso. `newsletter-content.mjs` "condivide" `newsletter-subject-variants` = il normale import. Nessuna modifica necessaria.
- **Cron separato per il calcolo del winner** — non serve: il resolver gira inline all'avvio dell'invio (una query/run), nessun workflow nuovo.

## Test plan

- [x] `node --check` su tutti i file toccati
- [x] vitest: promotion + varianti + posthog → 46/46 (incl. backward-compat 2-arg)
- [x] sibling-check eseguito; match coincidenti giustificati; duplicazione rimossa
- [ ] Post-merge live: dopo ≥2 campagne con dati, il log d'invio mostra `🏆 Auto-promote "<variant>"` o `⚖️ even split (<reason>)`; verificabile solo a runtime con dati reali

🤖 Generated with [Claude Code](https://claude.com/claude-code)