### PR TITLE
fix(translate): unbreak Azure & DeepL free tiers (region fallback, 429 vs 456)

### DIFF
--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -319,17 +319,36 @@ async function _callDeepLWithKey(apiKey, text, srcCode, tgtCode) {
     body.append('preserve_formatting', '1');
     body.append('split_sentences', 'nonewlines');
 
-    const res = await fetch('https://api-free.deepl.com/v2/translate', {
-      method: 'POST',
-      headers: {
-        'Authorization': `DeepL-Auth-Key ${apiKey}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: body.toString(),
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (res.status === 456 || res.status === 429) {
-      throw Object.assign(new Error(`DeepL ${res.status}`), { quotaExhausted: true });
+    // 429 is a *transient* rate-limit, not a permanent quota wall — retry the
+    // same key a few times with a short backoff before giving up. 456 is the
+    // real monthly-quota-exceeded signal and must NOT be retried.
+    const MAX_429_RETRIES = 2;
+    let res;
+    for (let rl = 0; ; rl++) {
+      res = await fetch('https://api-free.deepl.com/v2/translate', {
+        method: 'POST',
+        headers: {
+          'Authorization': `DeepL-Auth-Key ${apiKey}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (res.status === 456) {
+        // Real monthly quota exhausted → mark key exhausted for the run.
+        throw Object.assign(new Error('DeepL 456'), { quotaExhausted: true });
+      }
+      if (res.status === 429) {
+        if (rl < MAX_429_RETRIES) {
+          console.warn(`[deepl] 429 rate-limited — backing off (retry ${rl + 1}/${MAX_429_RETRIES})`);
+          await delay(1000 * (rl + 1)); // ~1s, then ~2s
+          continue;
+        }
+        // Still rate-limited after retries → fall through to the next tier WITHOUT
+        // marking the key exhausted (it may recover for later jobs).
+        throw Object.assign(new Error('DeepL 429 rate-limited'), { rateLimited: true });
+      }
+      break;
     }
     if (!res.ok) return '';
     const data = await res.json();
@@ -369,6 +388,13 @@ async function translateWithDeepL(text, sourceLang, targetLang) {
         _cascadeStats.tierErrors.deepl = (_cascadeStats.tierErrors.deepl || 0) + 1;
         console.log(`🔑 DeepL key #${idx + 1} quota exhausted — rotating to next key`);
         continue;
+      }
+      if (err?.rateLimited) {
+        // Transient 429 after retries — do NOT exhaust the key (it may recover for
+        // later jobs). Fall through to the next tier for THIS job only.
+        _cascadeStats.tierErrors.deepl = (_cascadeStats.tierErrors.deepl || 0) + 1;
+        console.log(`⏳ DeepL key #${idx + 1} rate-limited (transient) — falling through to next tier, key NOT exhausted`);
+        return '';
       }
       return ''; // network error, don't retry with other keys
     }
@@ -623,23 +649,46 @@ async function translateWithAzure(text, sourceLang, targetLang) {
       const translated = [];
       for (const chunk of chunks) {
         const url = `https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=${sourceLang}&to=${targetLang}`;
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'Ocp-Apim-Subscription-Key': key,
-            'Ocp-Apim-Subscription-Region': AZURE_REGION,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify([{ Text: chunk }]),
-          signal: AbortSignal.timeout(TIMEOUT_MS),
-        });
+        // Region resilience: Azure "global"/multi-service resources require the
+        // region header to be `global`, while regional resources need their exact
+        // region. Try the configured region first; on a 401 (auth/region mismatch)
+        // retry ONCE with `global` before giving up. The warn-logging below reveals
+        // the true error/region in CI so the default never has to be guessed again.
+        const regionsToTry = AZURE_REGION === 'global' ? ['global'] : [AZURE_REGION, 'global'];
+        let res;
+        for (let r = 0; r < regionsToTry.length; r++) {
+          const region = regionsToTry[r];
+          res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'Ocp-Apim-Subscription-Key': key,
+              'Ocp-Apim-Subscription-Region': region,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([{ Text: chunk }]),
+            signal: AbortSignal.timeout(TIMEOUT_MS),
+          });
+          // Only the 401 case is worth retrying with a different region; any other
+          // status (ok / quota / 4xx / 5xx) is handled by the logic below.
+          if (res.status !== 401 || r === regionsToTry.length - 1) break;
+          console.warn(`[azure] 401 with region="${region}" — retrying once with region="global"`);
+        }
         if (res.status === 403 || res.status === 429) {
           _azureExhaustedKeys.add(key);
           _cascadeStats.tierErrors.azure = (_cascadeStats.tierErrors.azure || 0) + 1;
           console.log(`🔑 Azure key #${idx + 1} quota exhausted — rotating`);
           throw Object.assign(new Error('Azure quota'), { quotaExhausted: true });
         }
-        if (!res.ok) return '';
+        if (!res.ok) {
+          // Surface the exact failure (e.g. 401 region mismatch, 400 bad lang) so a
+          // region-misconfigured key no longer looks "active" while translating
+          // nothing. Bump the tier error counter, then preserve cascade flow by
+          // returning '' (do not throw).
+          const snippet = (await res.text().catch(() => '')).slice(0, 200);
+          _cascadeStats.tierErrors.azure = (_cascadeStats.tierErrors.azure || 0) + 1;
+          console.warn(`[azure] HTTP ${res.status} (key #${idx + 1}, region="${regionsToTry[regionsToTry.length - 1]}"): ${snippet}`);
+          return '';
+        }
         const data = await res.json();
         const t = data?.[0]?.translations?.[0]?.text || '';
         if (!t) return '';


### PR DESCRIPTION
## Implementato

Tutte le modifiche sono in `scripts/lib/free-translate.mjs` (cascade condivisa), chirurgiche.

**Azure (`translateWithAzure`)**
- `!res.ok` non è più swallow silenzioso: ora logga `console.warn` con prefisso `[azure]`, HTTP status, region usata e i primi ~200 char del body (`await res.text()`), e bumpa `_cascadeStats.tierErrors.azure`. Una key con region mismatch non sembra più "active" mentre traduce zero. Mantiene il `return ''` (non throw) per preservare il flusso del cascade.
- Region resilience: la chiamata prova prima `AZURE_TRANSLATOR_REGION` (default `westeurope`), e su 401 ritenta UNA volta con region `global` (necessaria per le resource multi-service/"global"). Default non cambiato alla cieca — è il logging a rivelare la region vera dal prossimo run live.

**DeepL (`_callDeepLWithKey` + `translateWithDeepL`)**
- Separato 429 (rate-limit transiente) da 456 (quota mensile reale). 456 → `quotaExhausted:true` (comportamento invariato, key esaurita per il run).
- 429 → backoff ~1s poi ~2s e retry della stessa key fino a 2 volte; se ancora 429 lancia un marker distinto `rateLimited:true`. `translateWithDeepL` su `rateLimited` cade al tier successivo per QUEL job soltanto, **senza** aggiungere la key a `_deeplExhaustedKeys` — un burst 429 transiente non uccide più la key per tutto il processo.

## Non implementato (ancora)

- **Validazione dell'unlock reale: non possibile pre-merge.** Se Azure inizia a tradurre e quale sia il vero errore HTTP (es. 401 region mismatch vs 400 bad lang) si vedrà SOLO nel prossimo run live `translate-pending`. **Revert-trigger:** se il prossimo run mostra ancora Azure con 0 tier-hits (controllare il `[azure] HTTP ...` snippet nel log per la causa reale) o DeepL che si insta-esaurisce, iterare sul fix (region corretta / soglia retry) o revertare.
- **Sibling check (`node scripts/ci/check-sibling-patterns.mjs`): 2 candidati, entrambi falsi positivi, nessun fix necessario.**
  - `scripts/batch-add-faq-to-articles.mjs` condivide il token `rateLimited` ma solo come helper di pacing generico `rateLimitedDelay()` — nessuna relazione con la logica DeepL 429/456.
  - `scripts/lib/dedicated-crawler-common.mjs` condivide `quotaExhausted` ma riferito al layer LLM (`_aiModels.isQuotaExhaustedError`); per la traduzione consuma `freeTranslateWithRetry` (questo stesso modulo), non duplica la logica HTTP Azure/DeepL. La logica del cascade Azure/DeepL vive SOLO in `free-translate.mjs`.

## Test plan

- [x] `node --check scripts/lib/free-translate.mjs` → syntax OK
- [x] `node -e "import('./scripts/lib/free-translate.mjs')..."` → import OK
- [x] `npx vitest run tests/free-translate-markdown-balancer.test.ts` → 9/9 passed
- [x] `node scripts/ci/check-sibling-patterns.mjs` → 2 candidati, verificati falsi positivi (vedi sopra)
- [ ] Prossimo run live `translate-pending`: verificare Azure tier-hits > 0 (o leggere il `[azure] HTTP ...` snippet per la causa) e che DeepL non risulti `0/2 keys active` su un singolo 429. Non verificabile pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
