### PR TITLE
feat(newsletter): activate PostHog subject A/B (RC-driven config + funnel setup)

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -99,18 +99,38 @@ assignment, so the experiment keeps working even if PostHog is down/over-quota.
 
 #### Enabling
 
-Set on both runtimes (off → no events emitted, zero PostHog volume):
+Config resolves **env first, then Remote Config** (RC is the single source for
+both runtimes; the send CI hydrates env from RC via `load-rc-env.mjs`, the Cloud
+Functions read RC directly). Both the flag and the key must resolve, else it's a
+no-op.
 
-| Env | Where | Purpose |
-|-----|-------|---------|
-| `POSTHOG_EMAIL_EXPERIMENT=1` | send-newsletter CI env **and** Cloud Functions runtime | master switch |
-| `POSTHOG_PROJECT_KEY` | both (**required to activate**) | PostHog project write key (`phc_…`); no hardcoded default |
-| `POSTHOG_HOST` | both (optional) | defaults to `https://eu.i.posthog.com` |
+| Param | RC key | env (send CI) | Purpose |
+|-------|--------|---------------|---------|
+| master switch | `SERVER_POSTHOG_EMAIL_EXPERIMENT` | `POSTHOG_EMAIL_EXPERIMENT` | `1` = on |
+| capture key | `SERVER_POSTHOG_PROJECT_KEY` | `POSTHOG_PROJECT_KEY` | public `phc_…` project key |
+| host | `SERVER_POSTHOG_HOST` | `POSTHOG_HOST` | default `https://eu.i.posthog.com` |
 
-Both `POSTHOG_EMAIL_EXPERIMENT=1` **and** `POSTHOG_PROJECT_KEY` must be set — if
-either is missing the capture is a no-op.
+To turn it on:
+
+```bash
+# 1. publish the RC params (flag + capture key) — needs the Firebase SA
+GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+  node scripts/set-posthog-rc.mjs
+
+# 2. redeploy Cloud Functions so the webhooks pick up the RC-aware helper
+#    (deploy-cloud-functions.yml runs on push to main touching functions/**)
+
+# 3. create the funnel insights (idempotent)
+eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+  node scripts/load-rc-env.mjs | grep POSTHOG)" \
+  && node scripts/setup-posthog-email-funnel.mjs
+```
+
+The next scheduled send then emits `email_sent`; opens emit `email_opened`.
+Kill switch: set `SERVER_POSTHOG_EMAIL_EXPERIMENT=0` in RC (re-run step 1 after
+editing the value, or flip it in the Firebase console).
 
 ⚠️ **Quota**: the PostHog free tier (1M events/mo) is already tight and has
-caused outages. This emits only 2 events per subscriber per campaign, but keep
-it off until you actually need the PostHog UI — the Firestore report covers the
-decision for free.
+caused outages. This emits only 2 events per subscriber per campaign, but it
+still adds volume — watch the PostHog billing usage after enabling. The Firestore
+report + auto-promotion decide the winner for free regardless.

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -19,22 +19,21 @@
  * engagementScore.js) can share it without a cross-runtime import. Uses the
  * PostHog capture HTTP API via global fetch — no posthog-node dependency.
  *
- * Env (BOTH required to activate; absent → no-op):
- *   POSTHOG_EMAIL_EXPERIMENT  '1'|'true' to enable
- *   POSTHOG_PROJECT_KEY       PostHog project write key (phc_…); no hardcoded
- *                             default (avoids a 3rd copy of the key in the repo)
- *   POSTHOG_HOST              ingestion host (default EU cloud ingest).
+ * Config resolution (env first, then Remote Config) — BOTH the flag and the key
+ * must resolve, else it is a no-op:
+ *   POSTHOG_EMAIL_EXPERIMENT / RC SERVER_POSTHOG_EMAIL_EXPERIMENT  '1'|'true'
+ *   POSTHOG_PROJECT_KEY      / RC SERVER_POSTHOG_PROJECT_KEY       phc_… (public)
+ *   POSTHOG_HOST             / RC SERVER_POSTHOG_HOST              ingest host
+ *
+ * The send-newsletter CI run hydrates process.env from Remote Config via
+ * load-rc-env.mjs, so it never touches RC here. The Cloud Functions runtime has
+ * no such env, so it falls back to reading Remote Config directly — the same
+ * idiom as recaptchaVerification.js. The project key is public (already shipped
+ * client-side), so storing it in RC is not a secret leak and keeps a single
+ * source of truth (no hardcoded copy in this file).
  */
 
-// The project key is read from POSTHOG_PROJECT_KEY only — we deliberately do NOT
-// hardcode a default copy here. The same phc_ key already lives in
-// services/posthog.ts and build-plugins/constants.ts; a third copy would make a
-// key rotation a 3-file manual edit. Since the experiment is off by default and
-// enabling it is an explicit ops action, requiring the env var alongside
-// POSTHOG_EMAIL_EXPERIMENT is no extra burden and removes the duplication.
-const POSTHOG_HOST = (process.env.POSTHOG_HOST || 'https://eu.i.posthog.com').replace(/\/$/, '');
-const POSTHOG_KEY = process.env.POSTHOG_PROJECT_KEY || '';
-const ENABLED = ['1', 'true', 'yes'].includes(String(process.env.POSTHOG_EMAIL_EXPERIMENT || '').toLowerCase());
+import { getRemoteConfigValue } from '../remoteConfigSecrets.js';
 
 /** Canonical event names — single source of truth for emit + analysis. */
 export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
@@ -42,9 +41,46 @@ export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
   OPENED: 'email_opened', // conversion: subscriber opened the email
 });
 
-/** @returns {boolean} whether server-side experiment capture is active. */
-export function isEmailExperimentEnabled() {
-  return ENABLED && !!POSTHOG_KEY;
+const truthy = (v) => ['1', 'true', 'yes'].includes(String(v || '').toLowerCase());
+
+let _configPromise = null;
+/**
+ * Resolve { enabled, key, host }. env wins; missing pieces fall back to Remote
+ * Config (Cloud Functions runtime). Cached after the first resolution.
+ */
+async function resolveConfig() {
+  if (_configPromise) return _configPromise;
+  _configPromise = (async () => {
+    let flag = process.env.POSTHOG_EMAIL_EXPERIMENT || '';
+    let key = process.env.POSTHOG_PROJECT_KEY || '';
+    let host = process.env.POSTHOG_HOST || '';
+    if (!flag || !key) {
+      // Functions runtime: no env → read Remote Config (recaptcha idiom).
+      try {
+        if (!flag) flag = await getRemoteConfigValue('SERVER_POSTHOG_EMAIL_EXPERIMENT').catch(() => '');
+        if (!key) key = await getRemoteConfigValue('SERVER_POSTHOG_PROJECT_KEY').catch(() => '');
+        if (!host) host = await getRemoteConfigValue('SERVER_POSTHOG_HOST').catch(() => '');
+      } catch {
+        // RC unavailable → stay disabled.
+      }
+    }
+    return {
+      enabled: truthy(flag) && !!key,
+      key,
+      host: (host || 'https://eu.i.posthog.com').replace(/\/$/, ''),
+    };
+  })();
+  return _configPromise;
+}
+
+/** Reset the cached config (tests only). */
+export function _resetEmailExperimentConfig() {
+  _configPromise = null;
+}
+
+/** @returns {Promise<boolean>} whether capture is active (env or Remote Config). */
+export async function isEmailExperimentEnabled() {
+  return (await resolveConfig()).enabled;
 }
 
 /**
@@ -58,13 +94,15 @@ export function isEmailExperimentEnabled() {
  */
 export async function captureEmailEvent(event, props = {}) {
   const { email, variant, provider, campaignId, locale } = props;
-  if (!isEmailExperimentEnabled() || !email) return false;
+  if (!email) return false;
+  const { enabled, key, host } = await resolveConfig();
+  if (!enabled) return false;
   try {
-    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+    const res = await fetch(`${host}/capture/`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        api_key: POSTHOG_KEY,
+        api_key: key,
         event,
         distinct_id: String(email).toLowerCase(),
         properties: {

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -80,6 +80,10 @@ const RC_TO_ENV = {
   SERVER_POSTHOG_PERSONAL_API_KEY: ['POSTHOG_PERSONAL_API_KEY'],
   SERVER_POSTHOG_PROJECT_ID:       ['POSTHOG_PROJECT_ID'],
   SERVER_POSTHOG_HOST:             ['POSTHOG_HOST'],
+  // PostHog server-side capture for the subject A/B email experiment
+  // (send-newsletter CI emits email_sent; Cloud Functions read RC directly).
+  SERVER_POSTHOG_PROJECT_KEY:      ['POSTHOG_PROJECT_KEY'],
+  SERVER_POSTHOG_EMAIL_EXPERIMENT: ['POSTHOG_EMAIL_EXPERIMENT'],
 
   // LinkedIn auto-posting (Company Page articles)
   LINKEDIN_POST_CLIENT_ID:        ['LINKEDIN_POST_CLIENT_ID'],

--- a/scripts/set-posthog-rc.mjs
+++ b/scripts/set-posthog-rc.mjs
@@ -5,7 +5,7 @@
  * CI runs of `articles-performance-snapshot.yml` (and any other PostHog-aware
  * workflow). Companion to scripts/set-adsense-rc.mjs.
  *
- * Safe to re-run: writes/overwrites only the two SERVER_POSTHOG_* params and
+ * Safe to re-run: writes/overwrites only the SERVER_POSTHOG_* params and
  * publishes a new RC template version.
  *
  * Auth:
@@ -21,9 +21,15 @@
  * the project gets re-keyed.
  */
 
+// value + description per param. None are secrets: project ids and the EU host
+// are discoverable from the dashboard URL, and the phc_ project key is a public
+// write key already shipped in the browser bundle (services/posthog.ts).
 const RC_PARAMS = {
-  SERVER_POSTHOG_PROJECT_ID: '157802',
-  SERVER_POSTHOG_HOST: 'https://eu.posthog.com',
+  SERVER_POSTHOG_PROJECT_ID: { value: '157802', description: 'PostHog project ID for HogQL queries (set 2026-05-07)' },
+  SERVER_POSTHOG_HOST: { value: 'https://eu.posthog.com', description: 'PostHog API host (eu | us). Default eu (set 2026-05-07)' },
+  // Subject A/B email experiment — server-side capture (functions + send CI).
+  SERVER_POSTHOG_PROJECT_KEY: { value: 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT', description: 'PostHog public project (capture) key for server-side email_sent/email_opened events (set 2026-06-15)' },
+  SERVER_POSTHOG_EMAIL_EXPERIMENT: { value: '1', description: 'Master switch for the subject A/B PostHog capture; "1" = on (set 2026-06-15)' },
 };
 
 function bail(msg) {
@@ -46,22 +52,19 @@ async function main() {
   template.parameters = template.parameters || {};
 
   let changed = 0;
-  for (const [key, value] of Object.entries(RC_PARAMS)) {
+  for (const [key, { value, description }] of Object.entries(RC_PARAMS)) {
     const existing = template.parameters[key]?.defaultValue?.value;
     if (existing === value) continue;
     template.parameters[key] = {
       defaultValue: { value },
       valueType: 'STRING',
-      description:
-        key === 'SERVER_POSTHOG_PROJECT_ID'
-          ? 'PostHog project ID for HogQL queries (set 2026-05-07)'
-          : 'PostHog API host (eu | us). Default eu (set 2026-05-07)',
+      description,
     };
     changed++;
   }
 
   if (changed === 0) {
-    console.log('ℹ️  Both SERVER_POSTHOG_* params already up-to-date. Nothing to publish.');
+    console.log('ℹ️  All SERVER_POSTHOG_* params already up-to-date. Nothing to publish.');
     return;
   }
 

--- a/scripts/setup-posthog-email-funnel.mjs
+++ b/scripts/setup-posthog-email-funnel.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * setup-posthog-email-funnel.mjs — create the subject A/B funnel insights in
+ * PostHog (idempotent by name). Companion to the server-side capture wired in
+ * functions/src/lib/emailExperimentPostHog.js (events `email_sent` →
+ * `email_opened`, tied by distinct_id = email).
+ *
+ * Creates two saved Funnel insights:
+ *   1. "Email subject A/B — open rate by variant"   (breakdown subject_variant)
+ *   2. "Email subject A/B — open rate by provider"  (breakdown email_provider)
+ *
+ * Both use a 3-day conversion window (well under the weekly cadence) so a later
+ * campaign's open can't be mis-attributed to an earlier campaign's variant. For
+ * exact per-campaign attribution, open the insight and add a `campaign_id`
+ * property filter for the week you're analyzing.
+ *
+ * Auth (same as scripts/query-authgate-experiment.mjs):
+ *   POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/load-rc-env.mjs | grep POSTHOG)" \
+ *     && node scripts/setup-posthog-email-funnel.mjs
+ *
+ * The personal API key needs `insight:write` scope. Re-runnable: skips an
+ * insight whose name already exists.
+ */
+
+const key = process.env.POSTHOG_PERSONAL_API_KEY;
+const project = process.env.POSTHOG_PROJECT_ID;
+const host = (process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+
+if (!key || !project) {
+  console.error('❌ Missing POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID. See header for auth.');
+  process.exit(1);
+}
+
+const headers = { Authorization: `Bearer ${key}`, 'content-type': 'application/json' };
+
+function funnelFilters(breakdown) {
+  return {
+    insight: 'FUNNELS',
+    events: [
+      { id: 'email_sent', name: 'email_sent', type: 'events', order: 0 },
+      { id: 'email_opened', name: 'email_opened', type: 'events', order: 1 },
+    ],
+    breakdown,
+    breakdown_type: 'event',
+    funnel_viz_type: 'steps',
+    funnel_window_interval: 3,
+    funnel_window_interval_unit: 'day',
+    date_from: '-60d',
+  };
+}
+
+const INSIGHTS = [
+  { name: 'Email subject A/B — open rate by variant', filters: funnelFilters('subject_variant') },
+  { name: 'Email subject A/B — open rate by provider', filters: funnelFilters('email_provider') },
+];
+
+async function findByName(name) {
+  const url = `${host}/api/projects/${project}/insights/?search=${encodeURIComponent(name)}&limit=100`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`list insights ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json();
+  return (data.results || []).find((i) => i.name === name) || null;
+}
+
+async function createInsight({ name, filters }) {
+  const existing = await findByName(name);
+  if (existing) {
+    console.log(`↩︎  Exists: "${name}" → ${host}/project/${project}/insights/${existing.short_id}`);
+    return existing;
+  }
+  const res = await fetch(`${host}/api/projects/${project}/insights/`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ name, filters, saved: true }),
+  });
+  if (!res.ok) throw new Error(`create "${name}" ${res.status}: ${(await res.text()).slice(0, 400)}`);
+  const created = await res.json();
+  console.log(`✅ Created: "${name}" → ${host}/project/${project}/insights/${created.short_id}`);
+  return created;
+}
+
+async function main() {
+  for (const insight of INSIGHTS) {
+    await createInsight(insight);
+  }
+  console.log('\nDone. Open one insight and add a `campaign_id` filter to read a single week exactly.');
+}
+
+main().catch((err) => {
+  console.error('❌ setup-posthog-email-funnel failed:', err?.message || err);
+  process.exit(1);
+});

--- a/tests/email-experiment-posthog.test.ts
+++ b/tests/email-experiment-posthog.test.ts
@@ -20,7 +20,7 @@ describe('emailExperimentPostHog — disabled by default', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     const { captureEmailEvent, isEmailExperimentEnabled } = await import(MODULE);
-    expect(isEmailExperimentEnabled()).toBe(false);
+    expect(await isEmailExperimentEnabled()).toBe(false);
     const ok = await captureEmailEvent('email_sent', { email: 'a@b.com', variant: 'curioso', provider: 'mailjet' });
     expect(ok).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('emailExperimentPostHog — enabled', () => {
     const fetchSpy = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchSpy);
     const { captureEmailEvent, isEmailExperimentEnabled } = await import(MODULE);
-    expect(isEmailExperimentEnabled()).toBe(false);
+    expect(await isEmailExperimentEnabled()).toBe(false);
     expect(await captureEmailEvent('email_opened', { email: 'x@y.com' })).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Implementato

Accende l'esperimento PostHog A/B titoli (richiesta esplicita user "accendilo ora"), usando l'**idioma Remote Config** del progetto invece di env per-runtime.

- **`functions/src/lib/emailExperimentPostHog.js`** — config risolta **env-first poi Remote Config**: il CI di send idrata env da RC (via `load-rc-env`), le Cloud Functions (senza quell'env) leggono RC direttamente (stesso pattern di `recaptchaVerification.js`). La `phc_` key pubblica vive in RC → single source, **nessuna copia hardcoded**. `isEmailExperimentEnabled()`/`captureEmailEvent()` ora async config-aware + cache; `_resetEmailExperimentConfig()` per i test.
- **`scripts/set-posthog-rc.mjs`** — pubblica anche `SERVER_POSTHOG_PROJECT_KEY` (capture key pubblica) e `SERVER_POSTHOG_EMAIL_EXPERIMENT` (master switch). Refactor `RC_PARAMS` a `{value, description}`.
- **`scripts/load-rc-env.mjs`** — mappa i 2 nuovi RC param a `POSTHOG_PROJECT_KEY`/`POSTHOG_EMAIL_EXPERIMENT` → lo step esistente "Load secrets from Remote Config" del workflow di send li propaga a `$GITHUB_ENV`. **Nessun edit a `send-newsletter.yml`**.
- **`scripts/setup-posthog-email-funnel.mjs` (nuovo)** — crea 2 Funnel insight (`email_sent`→`email_opened`, breakdown `subject_variant` / `email_provider`), **conversion window 3gg** (anti mis-attribuzione cross-campagna), idempotente per nome.
- **`docs/NEWSLETTER-SUBJECT-AB.md`** — runbook completo di accensione (publish RC → redeploy functions → crea funnel) + kill switch.
- Test aggiornati per il check async. 46/46 verde.

## Attivazione (post-merge, manuale con Firebase SA)

1. `node scripts/set-posthog-rc.mjs` (scrive RC: flag=1 + capture key).
2. Redeploy Functions (auto via `deploy-cloud-functions.yml` al merge, tocca `functions/**`).
3. `node scripts/setup-posthog-email-funnel.mjs` (crea i funnel).
Poi il prossimo invio schedulato emette `email_sent`, le aperture `email_opened`.

## Non implementato (ancora)

- **Accensione effettiva di RC + creazione funnel** — sono azioni runtime (servono Firebase SA + redeploy + scope `insight:write` della personal API key), le eseguo dopo il merge, non nel diff. Documentate sopra.
- **Test unit del fallback Remote Config** — saltato: mockare l'import ESM di `remoteConfigSecrets` in vitest è fragile; il path env è testato, il path RC lo valido live all'accensione.
- **Sibling-check** (`getRemoteConfigValue`/`remoteConfigSecrets` in `stripePublisherCore`/`set-stripe-rc`; `RC_PARAMS` in `set-adsense-rc`; `POSTHOG_KEY` in `build-plugins/constants.ts`+`services/posthog.ts`) — **stesso idioma condiviso, non antipattern**; in particolare NON aggiungo una 3ª copia della key (l'helper la legge da RC). Nessuna modifica necessaria.
- **Riduzione quota PostHog** — non in questo PR; l'esperimento aggiunge ~2 eventi/iscritto/settimana su quota già sotto pressione → da monitorare il billing dopo l'accensione (warning in doc).

## Test plan

- [x] `node --check` su tutti gli script + helper
- [x] vitest posthog + varianti + promotion → 46/46
- [x] sibling-check; match idiomatici giustificati
- [ ] Post-merge: eseguo set-posthog-rc + setup-funnel con SA; verifico arrivo eventi su PostHog dopo il prossimo invio (live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)