### PR TITLE
fix(crawlers): SVAR template redesign, IP-WAF Jina fallback, jobup soft-fail

### DIFF
--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -153,6 +153,7 @@ import {
 import { archiveRemovedJobsToSlice } from './expired-jobs-archive.mjs';
 import {
   RETRYABLE_STATUS,
+  WAF_IP_BLOCK_STATUS,
   isTransientFetchError,
   isConnectionLevelFetchError,
   fetchWithRetry,
@@ -161,7 +162,7 @@ import { fetchHtmlViaJinaWithRetry, rescueHtmlIfChallenged } from './jina-proxy.
 
 // Re-export the shared transient-fetch primitives so existing importers of
 // crawler-template keep working and the ATS clients share one classifier.
-export { RETRYABLE_STATUS, isTransientFetchError, isConnectionLevelFetchError, fetchWithRetry };
+export { RETRYABLE_STATUS, WAF_IP_BLOCK_STATUS, isTransientFetchError, isConnectionLevelFetchError, fetchWithRetry };
 
 /* ── Shared Utilities (re-exported for parser convenience) ──────────── */
 
@@ -505,17 +506,27 @@ export async function fetchHtml(url, options = {}) {
     // Genuine pages pass through unchanged (zero cost).
     return await rescueHtmlIfChallenged(html, url, { timeoutMs });
   } catch (err) {
-    // Connection-level failure after retries: the runner's datacenter egress
-    // can't reach an otherwise-healthy site (~1-3% of fetches/wave; the sites
-    // return 200 from a clean IP). Fetch once through the Jina Reader proxy
-    // (reliable egress + real browser → raw HTML) so the data IS collected
-    // rather than failing. ONLY for connection-level failures (no HTTP response
-    // ever received) — a non-ok HTTP status (503/4xx/5xx) means the server DID
-    // respond, so the egress works and Jina cannot help; routing those through
-    // the proxy would just add a pointless request. HTTP/parse errors propagate.
+    // Route to the Jina Reader proxy (reliable egress + real browser → raw HTML)
+    // so the data IS collected rather than failing. Two distinct cases qualify:
+    //
+    //  1. Connection-level failure (no HTTP response ever received): the runner's
+    //     datacenter egress can't reach an otherwise-healthy site (~1-3% of
+    //     fetches/wave; sites return 200 from a clean IP).
+    //
+    //  2. IP-reputation WAF hard status (403/406/415/451): the server DID respond,
+    //     but with an anti-bot fence keyed on the DATACENTER egress IP, not on the
+    //     content — the same source returns a normal 200/301 to a residential/Jina
+    //     IP (observed: air-zermatt.ch/jobs → HTTP 415 from CI, 301→200 from a
+    //     clean IP, #2025). The earlier "a 4xx means egress works, Jina can't
+    //     help" reasoning does NOT hold for this class: Jina's clean IP clears the
+    //     fence. Genuine 4xx (404/410 gone, 401 auth) are NOT in the set — Jina
+    //     can't help there, so they propagate unchanged. If Jina also fails it
+    //     returns null and the ORIGINAL error re-throws, so behaviour for a real
+    //     break is unchanged (just one extra proxy attempt).
+    //
     // (fetchJson is intentionally NOT proxied — Jina returns HTML, which would
     // corrupt a JSON response.)
-    if (isConnectionLevelFetchError(err)) {
+    if (isConnectionLevelFetchError(err) || WAF_IP_BLOCK_STATUS.has(err?.status)) {
       // Retry the proxy itself: Jina's egress IP can be transiently 429'd or
       // WAF-blocked (200 challenge/empty body) — a retry lands on a different
       // Jina IP and usually succeeds. Returns null on exhaustion → safe-fail by
@@ -664,6 +675,18 @@ export async function runStandardCrawlerPipeline(config) {
     if (isConnectionLevelFetchError(err)) {
       console.log(
         `\n⚠️ ${companyLabel}: connection-level fetch failure after retries + proxy fallback (${err.message}). Keeping existing jobs.`,
+      );
+      return;
+    }
+    // Anti-bot fence exhausted across realistic-UA + Jina clean IP + Playwright
+    // (err.antiBotExhausted, set by the jobup feed client). The clean Jina IP
+    // being blocked too makes this an IP-reputation/WAF transient, not a source
+    // change — same soft-exit semantics as a connection-level failure: keep the
+    // existing slice, no de-index, no "Crawler Failure" issue every run. A
+    // persistent outage is still caught by the crawler-health monitor.
+    if (err?.antiBotExhausted) {
+      console.log(
+        `\n⚠️ ${companyLabel}: anti-bot fence exhausted (UA + Jina + Playwright) for ${err.message}. Keeping existing jobs.`,
       );
       return;
     }

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -30,7 +30,7 @@ import { createHash } from 'node:crypto';
 import { JSDOM } from 'jsdom';
 import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import { rescueHtmlIfChallenged, fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
-import { isConnectionLevelFetchError } from './transient-fetch.mjs';
+import { isConnectionLevelFetchError, WAF_IP_BLOCK_STATUS } from './transient-fetch.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import { stripContactPII } from './strip-contact-pii.mjs';
 
@@ -451,16 +451,24 @@ async function fetchPage(url, timeoutMs, userAgent) {
       redirect: 'follow',
     });
     clearTimeout(timer);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) {
+      const err = new Error(`HTTP ${res.status} from ${url}`);
+      err.status = res.status;
+      throw err;
+    }
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
   } catch (err) {
     clearTimeout(timer);
-    // Connection-level failure (no HTTP response received — datacenter egress
-    // IP blocked, DNS failure, socket reset): re-fetch via Jina clean-IP proxy.
-    // Root cause of #1680: careers.mediclinic.com unreachable from CI runner.
-    // HTTP errors (err.status set) are NOT proxied — the server did respond.
-    if (isConnectionLevelFetchError(err)) {
+    // Re-fetch via the Jina clean-IP proxy for two cases: (a) connection-level
+    // failure (no HTTP response received — datacenter egress IP blocked, DNS
+    // failure, socket reset; root cause of #1680: careers.mediclinic.com
+    // unreachable from CI), and (b) an IP-reputation WAF hard status
+    // (403/406/415/451, WAF_IP_BLOCK_STATUS) — the server DID respond but with
+    // an anti-bot fence keyed on the datacenter IP that Jina's clean IP clears
+    // (#2025). Genuine 4xx (404/410 gone, 401 auth) are NOT in the set and still
+    // propagate; if Jina also fails it returns null → original error re-throws.
+    if (isConnectionLevelFetchError(err) || WAF_IP_BLOCK_STATUS.has(err?.status)) {
       const html = await fetchHtmlViaJinaWithRetry(url, { timeoutMs });
       if (html != null) return html;
     }

--- a/scripts/lib/hospital-custom-html-helpers.mjs
+++ b/scripts/lib/hospital-custom-html-helpers.mjs
@@ -9,7 +9,7 @@
  * same. Keep this module DRY and importable from any hospital-specific parser.
  */
 
-import { fetchWithRetry, RETRYABLE_STATUS, isConnectionLevelFetchError } from './transient-fetch.mjs';
+import { fetchWithRetry, RETRYABLE_STATUS, WAF_IP_BLOCK_STATUS, isConnectionLevelFetchError } from './transient-fetch.mjs';
 import { fetchHtmlViaJinaWithRetry, rescueHtmlIfChallenged } from './jina-proxy.mjs';
 
 export const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
@@ -135,11 +135,15 @@ export async function fetchHtml(url, { timeoutMs } = {}) {
     // 200 from a clean IP). Rather than give up (or keep retrying the same flaky
     // egress), fetch this once through the Jina Reader proxy: a reliable egress +
     // real browser that returns the page's raw HTML, so the parsers are
-    // unchanged and the data IS collected. ONLY for connection-level failures
-    // (no HTTP response received) — a non-ok HTTP status (4xx/5xx) means the
-    // server DID respond, so the egress works and Jina cannot help; those (and
-    // parse errors) are real and still propagate.
-    if (isConnectionLevelFetchError(err)) {
+    // unchanged and the data IS collected. Two cases route to the proxy: (a)
+    // connection-level failures (no HTTP response received), and (b) an
+    // IP-reputation WAF hard status (403/406/415/451, WAF_IP_BLOCK_STATUS) — the
+    // server DID respond but with an anti-bot fence keyed on the datacenter
+    // egress IP, which Jina's clean IP clears (#2025). Genuine 4xx (404/410 gone,
+    // 401 auth) are NOT in the set and still propagate; if Jina also fails it
+    // returns null → the original error re-throws, so a real break is unchanged.
+    // (Parse errors are real and still propagate.)
+    if (isConnectionLevelFetchError(err) || WAF_IP_BLOCK_STATUS.has(err?.status)) {
       // Retry the proxy: Jina's egress IP can be transiently 429'd or WAF-blocked
       // (200 challenge/empty body) — a retry lands on a different Jina IP and
       // usually succeeds. Returns null on exhaustion → safe-fail by re-throwing

--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -257,6 +257,17 @@ async function fetchFeed(url) {
           console.warn(`[jobup] Playwright body did not parse as JSON: ${parseErr?.message || parseErr}`);
         }
       }
+      // Every layer (realistic-UA fetch → Jina clean IP → headless Playwright)
+      // hit the anti-bot fence. That the CLEAN Jina IP was also blocked makes
+      // this an IP-reputation/WAF mood transient, not a source removal — the
+      // same class as a connection-level egress failure. Mark it so the pipeline
+      // soft-exits (keep existing slice, no de-index, no "Crawler Failure" issue
+      // every run) instead of hard-failing on the raw HTTP status (#2029 ehnv:
+      // the jobup mask is ALSO empty — jobcount:0 — from a clean IP, so even a
+      // successful fetch yields 0 jobs; bricking the run on the 403 only spams
+      // issues). The crawler-health monitor (3 consecutive 0-job runs) still
+      // surfaces a persistent outage, so nothing is silently buried.
+      err.antiBotExhausted = true;
     }
     throw err;
   }

--- a/scripts/lib/solique-common.mjs
+++ b/scripts/lib/solique-common.mjs
@@ -408,6 +408,54 @@ export function extractSoliqueDetailContent(html = '', opts = {}) {
     if (ivSections.length) return ivSections.join('\n\n');
   }
 
+  // Template (v): the "section/tasks-profile" redesign (SVAR, 2026-06 — #2034).
+  // Solique rebuilt the detail page around `<section id="…">` blocks: the job
+  // body now lives in `<div class="tasks">` (Aufgaben) and `<div class="profile">`
+  // (Profil) inside `<section id="tasks-profile">`, each opened by an
+  // `<h4 class="sub-subtitle">` heading, with the perks list in
+  // `<section id="offer">`. NONE of templates (i)-(iv) match this layout, so
+  // before this handler every SVAR job extracted to '' → the thin-source guard
+  // saw 10/10 thin → hard-failed the whole run and filed a "Crawler Failure"
+  // issue every crawl.
+  //
+  // GATED on `sections.length === 0` so it is a pure FALLBACK: the established
+  // tenants (emmental/oberengadin/adullam/ipw) already populate `sections` from
+  // (i)-(iv) and never reach here, so their extraction stays byte-identical.
+  // This gate (not a structural exclusion) is what keeps them apart — note
+  // emmental ALSO wraps its body in `<div class="tasks">`, but that div nests
+  // `<div class="title-green">` blocks captured by (i), so emmental never
+  // arrives with an empty `sections`.
+  if (sections.length === 0) {
+    const vSections = [];
+    // `tasks`/`profile` divs: capture up to the next tasks/profile div or the
+    // enclosing </section>. Same bullet/`<br>` flattening as the other templates.
+    for (const cls of ['tasks', 'profile']) {
+      const m = cleaned.match(
+        new RegExp(`<div\\s+class="${cls}"[^>]*>([\\s\\S]*?)(?=<div\\s+class="(?:tasks|profile)"|<\\/section)`, 'i'),
+      );
+      if (!m) continue;
+      let body = m[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li\s*>/gi, '')
+        .replace(/<br\s*\/?>(?!\s*<)/gi, '\n')
+        .replace(/<[^>]+>/g, ' ');
+      body = normalizeSpace(decodeEntities(body)).replace(/\s*•\s*/g, '\n• ');
+      if (body && body.length > 5) vSections.push(body);
+    }
+    // Perks list (`<section id="offer">`) — short, optional.
+    const offerSec = cleaned.match(/<section\s+id="offer"[^>]*>([\s\S]*?)<\/section>/i);
+    if (offerSec) {
+      let body = offerSec[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li\s*>/gi, '')
+        .replace(/<br\s*\/?>(?!\s*<)/gi, '\n')
+        .replace(/<[^>]+>/g, ' ');
+      body = normalizeSpace(decodeEntities(body)).replace(/\s*•\s*/g, '\n• ');
+      if (body && body.length > 25) vSections.push(body);
+    }
+    if (vSections.length) return vSections.join('\n\n');
+  }
+
   return sections.join('\n\n');
 }
 

--- a/scripts/lib/transient-fetch.mjs
+++ b/scripts/lib/transient-fetch.mjs
@@ -29,6 +29,22 @@
  */
 export const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 
+/**
+ * HTTP statuses that signal an IP-reputation WAF / anti-bot fence keyed on the
+ * DATACENTER egress IP rather than on the request content — the same source
+ * returns a normal 200/301 to a residential / Jina clean IP. The HTML fetch
+ * helpers (`fetchHtml` in crawler-template + hospital-custom-html-helpers,
+ * `fetchPage` in hirslanden) route these through the Jina Reader proxy as a
+ * clean-IP fallback before giving up. Shared here (single source of truth) so
+ * the three fetch sites can't drift — AGENTS.md #6.
+ *
+ * 404/410 (gone) and 401 (auth) are deliberately EXCLUDED: those are genuine,
+ * content-level responses Jina cannot clear. 403 (forbidden/anti-bot), 406
+ * (not-acceptable UA gate), 415 (unsupported-media-type WAF reply, #2025) and
+ * 451 (legal block) are the observed IP-block class.
+ */
+export const WAF_IP_BLOCK_STATUS = new Set([403, 406, 415, 451]);
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**

--- a/tests/crawler-connection-level-guard.test.ts
+++ b/tests/crawler-connection-level-guard.test.ts
@@ -56,6 +56,31 @@ describe('runStandardCrawlerPipeline — connection-level fetch guard', () => {
       }),
     ).rejects.toThrow(/404/);
   });
+
+  it('preserves existing jobs when fetchJobs throws an anti-bot-exhausted error (#2029)', async () => {
+    // The jobup feed client marks err.antiBotExhausted=true after the full
+    // cascade (realistic UA → Jina clean IP → Playwright) all hit the WAF fence.
+    // The clean Jina IP being blocked too makes it an IP-reputation transient,
+    // not a source change → soft-exit (keep slice), same as connection-level.
+    const root = makeRoot();
+    const err = new Error('HTTP 403 from https://www.jobup.ch/masks/ehnv/list_ehnv.asp') as Error & {
+      status?: number;
+      antiBotExhausted?: boolean;
+    };
+    err.status = 403;
+    err.antiBotExhausted = true;
+    await expect(
+      runStandardCrawlerPipeline({
+        companyKey: 'test-co',
+        companyLabel: 'Test Co',
+        isCompanyJob: () => false,
+        fetchJobs: async () => {
+          throw err;
+        },
+        root,
+      }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe('exitCrawlerOnError — custom-main terminal catch', () => {

--- a/tests/crawler-egress-jina-fallback.test.ts
+++ b/tests/crawler-egress-jina-fallback.test.ts
@@ -59,6 +59,25 @@ describe('fetchHtml egress proxy fallback (gating + safe-fail)', () => {
     await expect(fetchHtml('https://example.test/jobs', { retries: 0 })).rejects.toThrow(/503/);
     expect(fetchHtmlViaJinaWithRetry).not.toHaveBeenCalled();
   });
+
+  // IP-reputation WAF class (#2025): a hard 4xx keyed on the datacenter egress
+  // IP (air-zermatt.ch → 415 from CI, 200 from a clean IP). Jina's clean IP
+  // clears it, so these route through the proxy.
+  for (const status of [403, 406, 415, 451]) {
+    it(`routes an IP-WAF HTTP ${status} through the proxy helper`, async () => {
+      global.fetch = vi.fn(async () => ({ ok: false, status, text: async () => '' })) as any;
+      fetchHtmlViaJinaWithRetry.mockResolvedValue(REAL_HTML);
+      const html = await fetchHtml('https://example.test/jobs', { retries: 0 });
+      expect(html).toContain('/job/Lugano-Nurse/123456/');
+      expect(fetchHtmlViaJinaWithRetry).toHaveBeenCalledOnce();
+    });
+  }
+
+  it('safe-fails (re-throws original WAF status) when the proxy helper returns null', async () => {
+    global.fetch = vi.fn(async () => ({ ok: false, status: 415, text: async () => '' })) as any;
+    fetchHtmlViaJinaWithRetry.mockResolvedValue(null);
+    await expect(fetchHtml('https://example.test/jobs', { retries: 0 })).rejects.toThrow(/415/);
+  });
 });
 
 describe('fetchHtmlViaJinaWithRetry', () => {

--- a/tests/solique-jsonld-parsers.test.ts
+++ b/tests/solique-jsonld-parsers.test.ts
@@ -195,6 +195,46 @@ describe('Solique listing parsers (consolidated solique-common)', () => {
     const text = extractSoliqueDetailContent(SOLIQUE_DETAIL);
     expect(text).toBe('');
   });
+
+  // Template (v): the "section/tasks-profile" redesign (SVAR, #2034). Before the
+  // handler the body extracted to '' for every job → thin-source guard saw 10/10
+  // thin → hard-failed the whole run.
+  const SVAR_REDESIGN_DETAIL = `<section id="intro"><h2 class="subtitle">Wir suchen</h2>
+<div>per sofort eine/n Administrative/n Mitarbeiter/in (m/w/d).</div></section>
+<section id="tasks-profile">
+  <div class="tasks"><h4 class="sub-subtitle">Ihre Aufgaben</h4>
+    <ul><li>Zentrale administrative und koordinative Unterstützung im Direktionsstab.</li>
+    <li>Terminorganisation und -koordination für den CEO.</li></ul></div>
+  <div class="profile"><h4 class="sub-subtitle">Ihr Profil</h4>
+    <ul><li>Mehrjährige Berufserfahrung in einer ähnlichen Position.</li>
+    <li>Hohes Engagement und Loyalität.</li></ul></div>
+</section>
+<section id="offer"><h4 class="sub-subtitle">Zusätzlich profitieren Sie von</h4>
+  <ul><li>Attraktive Anstellungsbedingungen und Weiterbildung.</li></ul></section>
+<section id="contacts"><div class="contact-name">Frau X</div></section>`;
+
+  it('extracts the section/tasks-profile redesign (Template v, SVAR #2034)', () => {
+    const text = extractSoliqueDetailContent(SVAR_REDESIGN_DETAIL);
+    expect(text).toContain('Ihre Aufgaben');
+    expect(text).toContain('• Zentrale administrative und koordinative Unterstützung');
+    expect(text).toContain('Ihr Profil');
+    expect(text).toContain('• Mehrjährige Berufserfahrung');
+    expect(text).toContain('• Attraktive Anstellungsbedingungen');
+    // Well above the thin-source threshold the guard checks.
+    expect(text.length).toBeGreaterThan(100);
+  });
+
+  it('Template (v) is a pure fallback — never fires when (i)-(iv) already matched', () => {
+    // A page carrying an established Template (i) `intro` block PLUS a stray
+    // tasks div must extract ONLY via the established template — Template (v) is
+    // gated on `sections.length === 0`, so the tasks div is never captured.
+    const HYBRID = `<div class="intro">Das Spital sorgt für die Region und ihre Menschen.</div>
+<div class="tasks"><h4 class="sub-subtitle">SHOULD-NOT-APPEAR</h4>
+<ul><li>body that must be ignored</li></ul></div>`;
+    const text = extractSoliqueDetailContent(HYBRID);
+    expect(text).toBe('Das Spital sorgt für die Region und ihre Menschen.');
+    expect(text).not.toContain('SHOULD-NOT-APPEAR');
+  });
 });
 
 // ─── JS-error-string sanitizer (issues #1682 / #1741) ────────────────────────


### PR DESCRIPTION
Clears the three open `crawler` "Crawler Failure" issues in the backlog. Each is a distinct failure class (thin-source parser break / IP-reputation anti-bot / dead-feed), diagnosed against the live sources.

Closes #2034
Closes #2025
Closes #2029

## Implementato

- **SVAR #2034 — parser break (thin-source).** The SVAR Solique detail page was redesigned around `<section id="…">` blocks: the body now lives in `<div class="tasks">` / `<div class="profile">` (with `<h4 class="sub-subtitle">` headings) + `<section id="offer">`, replacing the old `<div class="offer">` template. None of `extractSoliqueDetailContent`'s templates (i)-(iv) matched → every job extracted to `''` → the thin-source guard saw 10/10 thin → hard-failed the whole run every crawl. Adds **Template (v)** in `scripts/lib/solique-common.mjs`, **gated on `sections.length === 0`** so it is a pure fallback. Verified against 5 live SVAR jobs (0 → 1097–2391 chars) and confirmed the four other Solique tenants (emmental/oberengadin/adullam/ipw) extract byte-identically.
- **Air Zermatt #2025 — IP-reputation WAF.** `air-zermatt.ch/jobs` returns HTTP **415** to the CI datacenter egress IP while serving 200/301 to a clean IP. The HTML fetch helpers only routed *connection-level* errors through the Jina clean-IP proxy, not hard WAF statuses. Adds a shared **`WAF_IP_BLOCK_STATUS`** set (`403/406/415/451`) in `scripts/lib/transient-fetch.mjs` and routes those through Jina in **all three** HTML fetch sites — `crawler-template.mjs#fetchHtml`, `hospital-custom-html-helpers.mjs#fetchHtml`, `hirslanden-job-parser.mjs#fetchPage` — so the class can't drift (AGENTS.md #6). `404/410/401` stay excluded; if Jina also fails the original error re-throws unchanged. Verified Jina fetches the page (21 KB, listings present). Also fixes hirslanden's `fetchPage` throw to set `err.status` (was bare, so any status-aware guard was blind).
- **eHnv #2029 — anti-bot + dead feed.** The jobup mask feed now returns `jobcount:0` even from a clean IP, and **403s** the datacenter IP; the existing cascade (realistic UA → Jina → Playwright) was fully exhausted on the failing run. Marks the exhausted fence `err.antiBotExhausted` in `jobup-ch-feed-common.mjs` and **soft-exits** in `runStandardCrawlerPipeline` (keep existing slice, no de-index, no "Crawler Failure" issue every run) — the clean Jina IP being blocked too makes this an IP-reputation transient, not a source change. The crawler-health monitor (3 consecutive 0-job runs) still backstops a persistent outage.
- **Regression tests** for all three: Template (v) extraction + fallback gate (`tests/solique-jsonld-parsers.test.ts`), IP-WAF → Jina routing for 403/406/415/451 + safe-fail (`tests/crawler-egress-jina-fallback.test.ts`), and `antiBotExhausted` soft-exit (`tests/crawler-connection-level-guard.test.ts`).

Sibling-class sweep (`node scripts/ci/check-sibling-patterns.mjs`): the two remaining flags are false positives — `agie-charmilles` shares the substring `offerSec` via its unrelated `jobofferSection`, and `workday-client.mjs` shares `isTransientFetchError` but is a JSON API client with no HTML/Jina path (Jina returns HTML, cannot proxy JSON).

## Non implementato (ancora)

- **eHnv alternative source (`ehnv.ch/emplois`).** The parser's note suggests jobs may surface there directly, but the live page is a JS-driven app with only GTM/YouTube iframes — no findable feed/board. Out of scope: building a new source for it is a separate task; the soft-fail keeps the existing slice live in the meantime (the jobup feed is currently `jobcount:0` anyway, so no new jobs are being lost).
- **Live CI validation of the Air Zermatt Jina path and eHnv soft-exit.** Both depend on the CI datacenter egress IP hitting the WAF, which is only reproducible post-merge on the next scheduled dedicated-crawler run. Jina retrieval and the soft-exit logic are unit-tested and the Jina fetch was verified from a clean IP; if the next AZ run still fails on 415 (Jina IP also blocked) or eHnv still files an issue → revert-trigger to revisit. SVAR is fully validated (live extraction + tests), no CI dependency.
🤖 Generated with [Claude Code](https://claude.com/claude-code)