### PR TITLE
fix(newsletter): serve offloaded company logos from CDN, not origin

### DIFF
--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -28,6 +28,31 @@ try {
 
 // ─── Company logo resolution ─────────────────────────────────
 
+// The self-hosted brand/logo images are offloaded out of the origin artifact to
+// the dedicated CDN at deploy (#1705, scripts/offload-generated-images-cdn.mjs):
+// the manifest stores same-origin `/images/{brands,logos}/…` paths, but those
+// paths 404 at the origin once offloaded, so an email <img> pointing there shows
+// a broken icon. Rewrite offloaded paths to the stable CDN host — same fix already
+// shipped for the job-alert emails (scripts/send-job-alerts.mjs IMAGE_CDN_BASE).
+// MUST stay in sync with CDN_OFFLOADED_IMAGE_PREFIXES in services/cdnImageBase.ts.
+const IMAGE_CDN_BASE = 'https://cdn.frontaliereticino.ch';
+const CDN_OFFLOADED_IMAGE_PREFIXES = [
+  '/images/brands/',
+  '/images/insurers/',
+  '/images/providers/',
+  '/images/logos/',
+  '/images/authors/',
+  '/images/publisher/',
+];
+
+/** Absolute URL for a same-origin image path: CDN host if offloaded, else origin. */
+function imageUrl(p) {
+  for (const prefix of CDN_OFFLOADED_IMAGE_PREFIXES) {
+    if (p.startsWith(prefix)) return `${IMAGE_CDN_BASE}${p}`;
+  }
+  return `${BASE_URL}${p}`;
+}
+
 let _logoManifest = null;
 function loadLogoManifest() {
   if (_logoManifest) return _logoManifest;
@@ -51,10 +76,10 @@ function resolveLogoUrl(job) {
   const manifest = loadLogoManifest();
   const key = job.companyKey || '';
 
-  // Self-hosted logo from manifest → absolute URL. Anything else → null
-  // (template falls back to the coloured initial-letter avatar).
+  // Self-hosted logo from manifest → absolute URL (CDN host if offloaded).
+  // Anything else → null (template falls back to the coloured initial-letter avatar).
   if (key && manifest[key]) {
-    return `${BASE_URL}${manifest[key]}`;
+    return imageUrl(manifest[key]);
   }
 
   return null;

--- a/tests/newsletter-template-tracking.test.ts
+++ b/tests/newsletter-template-tracking.test.ts
@@ -119,6 +119,24 @@ describe('newsletter content v2', () => {
     expect(matched.length).toBe(2);
   });
 
+  // Regression: company logos for the manifest's self-hosted brand/logo images
+  // are offloaded out of the origin artifact to the CDN at deploy
+  // (scripts/offload-generated-images-cdn.mjs), so the origin
+  // /images/{brands,logos}/… path 404s and the email <img> shows a broken icon.
+  // matchJobsForSubscriber MUST emit the CDN host for those paths (mirrors the
+  // job-alert email fix #1705).
+  it('matchJobsForSubscriber resolves manifest logos to the CDN host, not the origin', () => {
+    const jobs = [
+      { title: 'Engineer', company: 'Tether Operations', companyKey: 'tether', location: 'Lugano', slug: 'engineer-tether', publishedAt: new Date().toISOString() },
+    ];
+
+    const [matched] = matchJobsForSubscriber({ locationInterest: null, sectorInterest: null }, jobs, 1);
+    // tether → /images/brands/tether.png in data/company-logos-manifest.json
+    expect(matched.logoUrl).toBe('https://cdn.frontaliereticino.ch/images/brands/tether.png');
+    // never the bare origin (which 404s post-offload)
+    expect(matched.logoUrl.startsWith('https://frontaliereticino.ch/images/')).toBe(false);
+  });
+
   // Regression: recentlyFeaturedSlugs must never displace fresh candidates
   // just because the fresh pool is shorter than `limit`. Older logic
   // (freshPool.length >= limit ? freshPool : fullPool) wholesale fell back to


### PR DESCRIPTION
## Implementato

- **Fix loghi aziendali rotti nella newsletter weekly.** `services/newsletter-content.mjs` → `resolveLogoUrl()` risolveva i loghi a URL same-origin `https://frontaliereticino.ch/images/{brands,logos}/…` letti dal manifest. Quei path sono **offloadati** fuori dall'artifact GitHub Pages verso il CDN al deploy (`scripts/offload-generated-images-cdn.mjs`, `CDN_OFFLOADED_IMAGE_PREFIXES`), quindi l'URL origin **404a** e l'`<img>` dell'email mostra l'icona rotta (segnalato live: email weekly del 15 giu).
- Aggiunto helper `imageUrl(path)` + costante `IMAGE_CDN_BASE = 'https://cdn.frontaliereticino.ch'` e lista `CDN_OFFLOADED_IMAGE_PREFIXES` (in sync con `services/cdnImageBase.ts`): i path sotto i prefissi offloadati vengono riscritti sul CDN, gli altri restano su origin. `resolveLogoUrl` ora ritorna `imageUrl(manifest[key])`.
- Stesso fix già in produzione per le **email job-alert** (`scripts/send-job-alerts.mjs` `IMAGE_CDN_BASE`, #1705) e per il **render SPA** (`services/cdnImageBase.ts`): la newsletter era il sibling email-render non ancora sistemato.
- Regression test in `tests/newsletter-template-tracking.test.ts`: un job con `companyKey: 'tether'` (manifest → `/images/brands/tether.png`) deve produrre `logoUrl = https://cdn.frontaliereticino.ch/images/brands/tether.png` e mai l'origin bare.
- Verificato live: il CDN serve i loghi `200 image/*` (`cdn.frontaliereticino.ch/images/brands/tsmg.png`, `tether.png`, `logos/efg-international.svg`), l'origin no.

## Non implementato (ancora)

- **Sibling sweep completato, niente altro da toccare.** Verificato che gli altri path email-render non hanno lo stesso bug: `scripts/send-job-alerts.mjs` già fixato (#1705); `services/publisherBlastEmail.mjs` usa URL assoluti forniti dal publisher (validati `https://`), non path da manifest; il render SPA passa già per `cdnImageUrl()`. Gli script `download-*/crawl-*/generate-*/offload-*` referenziano path origin/locali legittimamente (tooling, non render email).
- **`onerror` fallback nelle email:** non aggiunto perché i client email strippano il JS — il fallback reale resta l'`alt` text + la catena resolver. Out of scope.
