### PR TITLE
fix(ci): unblock main — reword comment tripping check-cls-ad-slots false positive

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10804,7 +10804,7 @@ ${staticAnalyticsHtml}
  // Bot-gated Auto Ads loader (meta + adsense-loader) ONLY on real-traffic
  // expired pages (__slKeepProse): immediate Auto Ads (anchor/vignette/in-page)
  // for the crawler-first-paint→quick-bounce window, instead of waiting for the
- // SPA's <AdSenseBanner> to load adsbygoogle.js post-hydration (a lost-impression
+ // SPA's <AdSenseBanner> to load the AdSense ads script post-hydration (a lost-impression
  // gap on dead-job-link bounces — same class as #1904). Loader is idempotent +
  // bot-gated, so it coexists with the SPA banner and never inflates AD_REQUESTS.
  // Gated to has-traffic so the ~250 B snippet only lands on pages with users.


### PR DESCRIPTION
## Implementato

**Main è rosso** (vitest `tests/check-cls-ad-slots.test.ts` live-repo gate) e blocca a cascata tutto l'auto-merge — **per un falso positivo**, non un ad-slot reale.

Causa: il guardrail zero-Claude `scripts/ci/check-cls-ad-slots.mjs` fa `git grep` del letterale `adsbygoogle` (`AD_MARKER`) in `build-plugins/` per stanare `<ins>` AdSense hand-rolled. Un commento recente in `build-plugins/jobsSeoPagesPlugin.ts` (riga 10807: "...to load **adsbygoogle**.js post-hydration...") contiene il token nudo → il gate lo conta come violazione, ma **non c'è alcun ad-slot hard-coded** (è solo prosa).

Fix: rewordo il commento (`adsbygoogle.js` → "the AdSense ads script"). **Nessun cambio funzionale, nessun cambio al comportamento AdSense, nessun tocco al guardrail.** Verificato: `node scripts/ci/check-cls-ad-slots.mjs` → exit 0 ("no hard-coded AdSense <ins>").

## Non implementato (ancora)

- **Hardening del guardrail** (root-cause della *classe* di falso positivo): `check-cls-ad-slots.mjs` dovrebbe ignorare i match nei commenti / richiedere un vero `<ins ... class="adsbygoogle">` invece del literal nudo, così future menzioni in prosa non rifanno rosso main. Non incluso qui per tenere l'unblock minimo e zero-rischio nell'area revenue-critical; va fatto a parte con update del test `tests/check-cls-ad-slots.test.ts` (che locka il comportamento). Apro/segnalo come follow-up.
- Out of scope: questo PR non tocca la pipeline di traduzione (#2106/#2117).

## Test plan

- [x] `node scripts/ci/check-cls-ad-slots.mjs` → exit 0, "no hard-coded AdSense <ins>".
- [x] `git grep adsbygoogle build-plugins/jobsSeoPagesPlugin.ts` → nessun match residuo.
- [x] Diff = 1 riga di commento, nessun codice eseguibile toccato.
- [ ] Post-merge: main vitest torna verde, l'auto-merge cascade riparte (sblocca #2117). (verifica post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)