### PR TITLE
feat(newsletter): per-provider subject promotion (swap subject at send time)

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -37,12 +37,23 @@ explores uniformly so the losing arm keeps getting traffic and the test stays
 live (and can flip if the winner changes). With no significant winner it is a
 pure even split — so "on by default" changes nothing until the data earns it.
 
-The promoted variant is decided **globally** (pooled across providers), because
-the variant is assigned *before* the cascade picks a provider — we can't route a
-subscriber to a provider, so per-provider promotion isn't actionable at
-assignment time. The per-provider report stays the analysis lens; true
-per-provider promotion (swapping the subject at send time once the provider is
-known) is a deeper follow-up that would touch the funnel-critical cascade.
+Promotion is **per provider**, applied in two stages so it survives the fact
+that the cascade only picks a provider at send time:
+
+1. **Assembly time** — each subscriber is assigned the *global* winner (pooled
+   across providers) as the default, baked into the email subject. We can't route
+   a subscriber to a provider, so this is the best variant we can pre-commit.
+2. **Send time** — once the cascade chooses the provider, a `finalizeForProvider`
+   hook swaps the subject to **that provider's** winner (epsilon-greedy), falling
+   back to the global winner when a provider has no significant winner yet. The
+   body HTML is variant-independent, so only the subject + the `variant` tag
+   change; the final variant is read back from the payload for the delivery
+   record + PostHog event. The hook is opt-in and never throws — on any issue the
+   assembly-time global variant is sent unchanged (job-alert sends pass no hook).
+
+So `byProvider[p] ?? global` decides each email's variant, and the per-provider
+report measures whether the per-provider split actually beats the global one.
+(The legacy Resend-only fallback path keeps the assembly-time global variant.)
 
 | Env | Default | Purpose |
 |-----|---------|---------|

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -496,7 +496,7 @@ function isRateLimitedError(msg) {
   return false;
 }
 
-async function sendSingle(email, forceProvider) {
+async function sendSingle(email, forceProvider, finalizeForProvider) {
   const errors = [];
   const providers = forceProvider
     ? PROVIDERS.filter(p => p.id === forceProvider)
@@ -507,6 +507,12 @@ async function sendSingle(email, forceProvider) {
     if (remainingQuota(provider.id) <= 0) continue;
 
     try {
+      // Optional hook: let the caller finalize the payload for the provider that
+      // is actually about to send (e.g. swap the subject to that provider's A/B
+      // winner). Must never throw — on error we send the payload unchanged.
+      if (typeof finalizeForProvider === 'function') {
+        try { finalizeForProvider(email, provider.id); } catch { /* send as-is */ }
+      }
       const result = await SEND_FNS[provider.id](email);
       incrementCounter(provider.id, 1);
       return result;
@@ -527,7 +533,7 @@ async function sendSingle(email, forceProvider) {
  * Waits until at least `delayMs` has elapsed since the last send to the same provider,
  * then delegates to the provider loop in sendSingle.
  */
-async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs) {
+async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs, finalizeForProvider) {
   // Determine which provider will be tried first (the one with remaining quota)
   const providers = forceProvider
     ? PROVIDERS.filter(p => p.id === forceProvider)
@@ -553,7 +559,7 @@ async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs) {
 
   // Slot already reserved above (advances even on throw), so no post-hoc clock
   // bump is needed — the worker's try/catch handles a thrown send.
-  const result = await sendSingle(email, forceProvider);
+  const result = await sendSingle(email, forceProvider, finalizeForProvider);
   // If a different provider ended up sending, reserve its slot too.
   if (result?.provider && result.provider !== nextProvider?.id) {
     const now = Date.now();
@@ -576,10 +582,13 @@ async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs) {
  * @param {number} [opts.delayMs=1000] - Delay in ms between sends to the same provider
  * @param {string} [opts.forceProvider] - Force a specific provider (skip cascade)
  * @param {Function} [opts.onSent] - Called after each successful send: (item, result) => void
+ * @param {Function} [opts.finalizeForProvider] - Called just before sending, once
+ *   the provider is chosen: (payload, providerId) => void. May mutate the payload
+ *   (e.g. swap the subject for that provider). Must not throw.
  * @returns {{ sent: Array, failed: Array }}
  */
 export async function sendEmailCascade(emails, opts = {}) {
-  const { concurrency = 1, delayMs = 1000, forceProvider, onSent } = opts;
+  const { concurrency = 1, delayMs = 1000, forceProvider, onSent, finalizeForProvider } = opts;
   const sent = [];
   const failed = [];
 
@@ -608,7 +617,7 @@ export async function sendEmailCascade(emails, opts = {}) {
       const i = idx++;
       const item = emails[i];
       try {
-        const result = await sendSingleThrottled(item.payload, forceProvider, _lastSend, delayMs);
+        const result = await sendSingleThrottled(item.payload, forceProvider, _lastSend, delayMs, finalizeForProvider);
         sent.push({ ...item, ...result });
         if (onSent) await onSent(item, result);
       } catch (err) {

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -36,7 +36,7 @@ import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubj
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
 import { getVariantFallback, listVariantIds, DEFAULT_EPSILON } from '../services/newsletter-subject-variants.mjs';
 import { assignSubjectVariant } from '../services/newsletter-subject-assign.mjs';
-import { pickWinner } from '../services/newsletter-ab-stats.mjs';
+import { pickWinner, resolveWinnersByProvider } from '../services/newsletter-ab-stats.mjs';
 import { loadCampaignVariantTotals, previousCampaignIds } from './lib/newsletter-ab-data.mjs';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib/emailExperimentPostHog.js';
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
@@ -1425,34 +1425,40 @@ const AB_AUTOPROMOTE = process.env.NEWSLETTER_AB_AUTOPROMOTE !== 'false';
 const AB_PROMOTE_LOOKBACK = Math.max(1, Number(process.env.NEWSLETTER_AB_LOOKBACK || 2));
 
 /**
- * Resolve the variant to auto-promote for this campaign by pooling the open
- * rates of the previous `AB_PROMOTE_LOOKBACK` campaigns. Returns the winning
- * variant id, or null to keep an even split. Never throws → failure = no promo.
+ * Resolve auto-promotion winners for this campaign by pooling the previous
+ * `AB_PROMOTE_LOOKBACK` campaigns. Returns a per-provider winner map plus a
+ * global fallback: the send pipeline promotes `byProvider[p] ?? global` for the
+ * provider that actually sends. Never throws → failure = no promotion.
+ *
+ * @returns {Promise<{byProvider:Record<string,string|null>, global:string|null}>}
  */
-async function resolvePromotedVariant(database, campaignId) {
-  if (!AB_AUTOPROMOTE || !database) return null;
+async function resolveWinnersForCampaign(database, campaignId) {
+  if (!AB_AUTOPROMOTE || !database) return { byProvider: {}, global: null };
   try {
     const ids = previousCampaignIds(campaignId, AB_PROMOTE_LOOKBACK);
-    const pooled = {};
+    const pooledCells = {};
     for (const cid of ids) {
-      const { byVariant } = await loadCampaignVariantTotals(database, cid);
-      for (const [v, t] of Object.entries(byVariant)) {
-        pooled[v] ??= { sends: 0, opens: 0 };
-        pooled[v].sends += t.sends;
-        pooled[v].opens += t.opens;
+      const { cells } = await loadCampaignVariantTotals(database, cid);
+      for (const [provider, variants] of Object.entries(cells)) {
+        pooledCells[provider] ??= {};
+        for (const [v, c] of Object.entries(variants)) {
+          pooledCells[provider][v] ??= { sends: 0, opens: 0 };
+          pooledCells[provider][v].sends += c.sends;
+          pooledCells[provider][v].opens += c.opens;
+        }
       }
     }
-    const { winner, openRates, pValue, reason } = pickWinner(pooled);
-    const rates = Object.fromEntries(Object.entries(openRates).map(([k, v]) => [k, `${(v * 100).toFixed(1)}%`]));
-    if (winner) {
-      console.log(`🏆 Auto-promote "${winner}" (p=${pValue?.toFixed(3)}, ε=${DEFAULT_EPSILON}) from last ${ids.length} campaign(s); rates=${JSON.stringify(rates)}`);
+    const { byProvider, global } = resolveWinnersByProvider(pooledCells);
+    const perProvider = Object.entries(byProvider).filter(([, w]) => w).map(([p, w]) => `${p}:${w}`);
+    if (global || perProvider.length) {
+      console.log(`🏆 Auto-promote (ε=${DEFAULT_EPSILON}) from last ${ids.length} campaign(s): global=${global || 'none'}${perProvider.length ? `, per-provider=${perProvider.join(',')}` : ''}`);
     } else {
-      console.log(`⚖️  Auto-promote: even split (${reason}); rates=${JSON.stringify(rates)}`);
+      console.log('⚖️  Auto-promote: even split (no significant winner yet)');
     }
-    return winner;
+    return { byProvider, global };
   } catch (e) {
     console.warn('⚠️ Auto-promote skipped:', e?.message);
-    return null;
+    return { byProvider: {}, global: null };
   }
 }
 
@@ -1590,7 +1596,15 @@ async function sendEmailBatchResend(emails, apiKey) {
 }
 
 
-async function sendEmailBatch(emails, apiKey) {
+async function sendEmailBatch(emails, apiKey, finalizeForProvider) {
+  // After a per-provider subject swap, the final variant/subject live on the
+  // payload (the source of truth for what was actually sent) — read them there
+  // so the delivery record + PostHog event reflect the provider's variant.
+  const persistSent = async (item, res) => {
+    const variant = item.payload?.tags?.find((t) => t.name === 'variant')?.value || item.meta?.variant;
+    const subject = item.payload?.subject || item.meta?.subject;
+    await persistDelivery(item.recipient, res.messageId, { ...item.meta, provider: res.provider, variant, subject });
+  };
   // Single provider mode: force a specific provider via cascade
   if (IS_SINGLE_PROVIDER) {
     console.log(`📧 Sending via ${EMAIL_PROVIDER} only (${emails.length} emails)`);
@@ -1599,9 +1613,8 @@ async function sendEmailBatch(emails, apiKey) {
       concurrency: 1,
       delayMs: 1000,
       forceProvider: EMAIL_PROVIDER,
-      onSent: async (item, res) => {
-        await persistDelivery(item.recipient, res.messageId, { ...item.meta, provider: res.provider });
-      },
+      finalizeForProvider,
+      onSent: persistSent,
     });
     logProviderSummary();
     return result;
@@ -1613,9 +1626,8 @@ async function sendEmailBatch(emails, apiKey) {
     const result = await sendEmailCascade(emails, {
       concurrency: 1,
       delayMs: 1000,
-      onSent: async (item, res) => {
-        await persistDelivery(item.recipient, res.messageId, { ...item.meta, provider: res.provider });
-      },
+      finalizeForProvider,
+      onSent: persistSent,
     });
     logProviderSummary();
     return result;
@@ -2120,8 +2132,11 @@ async function main() {
   const emails = [];
 
   // Auto-promotion: bias the variant split toward the recent winner (on by
-  // default; null = even split until a significant winner exists).
-  const promotedVariant = await resolvePromotedVariant(db, campaignId);
+  // default; null/empty = even split until a significant winner exists). The
+  // global winner is the assembly-time default; the per-provider winner is
+  // applied at send time once the provider is known (finalizeForProvider below).
+  const winners = await resolveWinnersForCampaign(db, campaignId);
+  const promotedVariant = winners.global;
 
   for (const { subscriber, locale, matchedJobs, cohortKey } of subscriberData) {
     const briefing = briefingMap.get(cohortKey);
@@ -2230,7 +2245,29 @@ async function main() {
     process.exit(1);
   }
 
-  const { sent, failed } = await sendEmailBatch(cappedEmails, apiKey);
+  // Per-provider auto-promotion: once the cascade picks the provider, swap the
+  // subject to that provider's winning variant (epsilon-greedy). The body HTML is
+  // variant-independent, so only the subject + the `variant` tag change. Reads
+  // everything from the self-describing payload so it can run inside the generic
+  // cascade. Never throws → on any issue the assembly-time (global) variant stays.
+  const finalizeForProvider = (payload, provider) => {
+    try {
+      const email = payload?.to?.[0];
+      if (!email) return;
+      const promoted = winners.byProvider[provider] ?? winners.global;
+      if (!promoted) return; // nothing significant for this provider → keep default
+      const loc = payload.tags?.find((t) => t.name === 'subscriber_locale')?.value || 'it';
+      const variant = assignSubjectVariant(email, campaignId, { promotedVariant: promoted, epsilon: DEFAULT_EPSILON });
+      payload.subject = subjectMap.get(subjectKey(loc, variant))
+        || subjectMap.get(subjectKey(loc, variantIds[0]))
+        || getVariantFallback(variant, loc);
+      const vtag = payload.tags?.find((t) => t.name === 'variant');
+      if (vtag) vtag.value = variant;
+      else payload.tags?.push({ name: 'variant', value: variant });
+    } catch { /* leave payload unchanged */ }
+  };
+
+  const { sent, failed } = await sendEmailBatch(cappedEmails, apiKey, finalizeForProvider);
 
   // ── Track only confirmed-sent emails for resume ──
   const sentEmailList = sent.map(e => normalizeEmail(e.recipient.email));

--- a/services/newsletter-ab-stats.mjs
+++ b/services/newsletter-ab-stats.mjs
@@ -75,3 +75,30 @@ export function pickWinner(byVariant, gates = {}) {
   }
   return { winner: best, openRates, pValue: test.pValue, reason: 'significant' };
 }
+
+/**
+ * Resolve a winning variant per provider plus a global fallback, from a
+ * provider × variant cell map (`cells[provider][variant] = {sends,opens}`).
+ *
+ * Each provider gets its own significant winner (or null); `global` is the
+ * winner across all providers pooled. The send pipeline promotes
+ * `byProvider[p] ?? global` for the provider that actually sends — so a provider
+ * with thin data still benefits from the global signal instead of going even.
+ *
+ * @param {Record<string,Record<string,{sends:number,opens:number}>>} cells
+ * @param {{minSendsPerArm?:number, alpha?:number}} [gates]
+ * @returns {{byProvider:Record<string,string|null>, global:string|null}}
+ */
+export function resolveWinnersByProvider(cells, gates = {}) {
+  const byProvider = {};
+  const globalByVariant = {};
+  for (const [provider, variants] of Object.entries(cells || {})) {
+    byProvider[provider] = pickWinner(variants, gates).winner;
+    for (const [v, c] of Object.entries(variants)) {
+      globalByVariant[v] ??= { sends: 0, opens: 0 };
+      globalByVariant[v].sends += c.sends;
+      globalByVariant[v].opens += c.opens;
+    }
+  }
+  return { byProvider, global: pickWinner(globalByVariant, gates).winner };
+}

--- a/tests/newsletter-ab-promotion.test.ts
+++ b/tests/newsletter-ab-promotion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-const { pickWinner, twoProportionTest, DEFAULT_WINNER_GATES } = await import('@/services/newsletter-ab-stats.mjs');
+const { pickWinner, twoProportionTest, DEFAULT_WINNER_GATES, resolveWinnersByProvider } = await import('@/services/newsletter-ab-stats.mjs');
 const { DEFAULT_EPSILON, listVariantIds } = await import('@/services/newsletter-subject-variants.mjs');
 const { assignSubjectVariant } = await import('@/services/newsletter-subject-assign.mjs');
 const { previousCampaignIds } = await import('@/scripts/lib/newsletter-ab-data.mjs');
@@ -29,6 +29,42 @@ describe('pickWinner', () => {
   it('honors custom gates', () => {
     const tight = pickWinner({ a: { sends: 100, opens: 40 }, b: { sends: 100, opens: 20 } }, { minSendsPerArm: 500 });
     expect(tight.winner).toBeNull(); // 100 < 500
+  });
+});
+
+describe('resolveWinnersByProvider', () => {
+  it('picks a winner per provider and a global fallback', () => {
+    const cells = {
+      // mailjet: curioso clearly wins (significant, well sampled)
+      mailjet: { concreto: { sends: 1000, opens: 200 }, curioso: { sends: 1000, opens: 320 } },
+      // mailgun: concreto clearly wins
+      mailgun: { concreto: { sends: 1000, opens: 340 }, curioso: { sends: 1000, opens: 210 } },
+      // mailtrap: thin → no per-provider winner
+      mailtrap: { concreto: { sends: 30, opens: 12 }, curioso: { sends: 25, opens: 6 } },
+    };
+    const { byProvider, global } = resolveWinnersByProvider(cells);
+    expect(byProvider.mailjet).toBe('curioso');
+    expect(byProvider.mailgun).toBe('concreto');
+    expect(byProvider.mailtrap).toBeNull(); // insufficient sample
+    // global pools everything; both arms are close once pooled → may be null,
+    // but must be one of the known values or null (never throws / undefined)
+    expect([null, 'concreto', 'curioso']).toContain(global);
+  });
+
+  it('returns empty winners for empty cells', () => {
+    expect(resolveWinnersByProvider({})).toEqual({ byProvider: {}, global: null });
+  });
+
+  it('global fallback covers a provider with no significant winner', () => {
+    const cells = {
+      // global signal: concreto wins big when pooled
+      mailjet: { concreto: { sends: 2000, opens: 700 }, curioso: { sends: 2000, opens: 400 } },
+      // thin provider → null locally, should rely on global at send time
+      maileroo: { concreto: { sends: 10, opens: 5 }, curioso: { sends: 10, opens: 1 } },
+    };
+    const { byProvider, global } = resolveWinnersByProvider(cells);
+    expect(byProvider.maileroo).toBeNull();
+    expect(global).toBe('concreto'); // the send pipeline uses byProvider[p] ?? global
   });
 });
 


### PR DESCRIPTION
## Implementato

Rende la promozione **azionabile per-provider** (non solo globale). La variante è assegnata **prima** che il cascade scelga il provider, quindi la promozione ora agisce in 2 stadi:

- **Assembly time**: il vincitore **globale** è il default (miglior subject pre-committabile senza sapere il provider).
- **Send time**: scelto il provider dal cascade, un nuovo hook opt-in `finalizeForProvider(payload, providerId)` **scambia il subject** col vincitore epsilon-greedy **di quel provider**, con fallback al globale se il provider non ha ancora un vincitore significativo. Il body HTML è variant-independent → cambiano solo subject + tag `variant`; la variante finale è riletta dal payload per delivery record + evento PostHog.

Dettagli:
- **`scripts/lib/email-cascade.mjs`** — threading di `finalizeForProvider` opzionale `sendEmailCascade → sendSingleThrottled → sendSingle`, chiamato **subito prima** dell'invio al provider scelto. **Guardato (mai throw) e opt-in**: i job-alert non passano l'hook → path invariato. Su retry verso un altro provider, ri-finalizza per quello effettivo.
- **`services/newsletter-ab-stats.mjs`** — `resolveWinnersByProvider(cells)` → `{byProvider, global}` (winner per provider + fallback globale poolato).
- **`scripts/send-newsletter.mjs`** — `resolveWinnersForCampaign` poola le celle delle campagne precedenti; il finalizer usa `byProvider[p] ?? global`. Persist delivery + evento PostHog leggono la variante/subject **finali dal payload** (source of truth dopo lo swap).
- **`docs/NEWSLETTER-SUBJECT-AB.md`** — sezione aggiornata (2 stadi).
- **Test** (`resolveWinnersByProvider`): winner per-provider, fallback globale su provider con dati scarsi, celle vuote. 16/16 promotion + 27 varianti verde.

## Non implementato (ancora)

- **Path legacy Resend-only** (`sendEmailBatchResend`, non-cascade) — mantiene la variante globale di assembly-time (niente swap per-provider). È il fallback raro; documentato.
- **Determinismo cross-provider** — la variante finale dipende dal provider effettivamente scelto (quota/ordine), non deterministica tra run; corretto per il bandit (ogni iscritto inviato una volta, persistito il valore reale). Non un problema.
- **Sibling-check** (`providerId`/`pickWinner`/`messageId` in `auth-only-by-day`, `fuel-station-dedup`, `analytics.ts`, `authService.ts`, `newsletterSubscribers.ts`) — nomi coincidenti, non stesso antipattern. Nessuna modifica.

## Test plan

- [x] `node --check` cascade + send + stats
- [x] vitest promotion (16, incl. per-provider) + varianti (27)
- [x] sibling-check; match coincidenti giustificati
- [ ] Post-merge live: log d'invio mostra `per-provider=<prov>:<variant>`; verificabile solo con ≥2 campagne di dati reali

🤖 Generated with [Claude Code](https://claude.com/claude-code)