### PR TITLE
fix(traffic): cap HERE Time Aware Routing under the 5k/month free tier

### DIFF
--- a/.github/workflows/traffic-scheduler.yml
+++ b/.github/workflows/traffic-scheduler.yml
@@ -4,16 +4,23 @@ on:
   # ─── Scheduled runs (UTC) ──────────────────────────────────────────
   # Cron times are in UTC.  Europe/Rome is UTC+1 (CET) or UTC+2 (CEST).
   # The ranges below cover both winter and summer offsets.
+  #
+  # HERE bills 2 "Time Aware Routing" transactions per crossing (52/run for 26
+  # crossings); the free tier is 5 000/month. Frequency is concentrated at the
+  # two commute peaks (where wait times actually move) and thinned everywhere
+  # else so the month's runs spread evenly under budget. A hard in-code monthly
+  # cap (HERE_MONTHLY_BUDGET in trafficSchedulerCore.js) is the backstop that
+  # guarantees we never exceed the free tier regardless of scheduling variance.
   schedule:
     # ── Weekdays (Mon–Fri) ──
-    # Morning commute peak ≈ CET 04:00–10:00 → every 10 min
-    - cron: '*/15 3-8 * * 1-5'
-    # Midday off-peak ≈ CET 10:00–15:00 → every hour
-    - cron: '0 8-13 * * 1-5'
-    # Evening return peak ≈ CET 15:00–20:00 → every 15 min
-    - cron: '*/15 13-17 * * 1-5'
-    # ── Weekends (Sat–Sun) → every 2h to conserve HERE quota ──
-    - cron: '0 4,6,8,10,12,14,16,18 * * 0,6'
+    # Morning commute peak ≈ CET 05:00–09:00 → every 30 min
+    - cron: '*/30 4-7 * * 1-5'
+    # Midday off-peak sanity check ≈ CET 12:00
+    - cron: '0 11 * * 1-5'
+    # Evening return peak ≈ CET 15:00–19:00 → every 30 min
+    - cron: '*/30 14-17 * * 1-5'
+    # ── Weekends (Sat–Sun) → every 4h to conserve HERE quota ──
+    - cron: '0 6,10,14,18 * * 0,6'
   workflow_dispatch: {}
 
 concurrency:

--- a/functions/src/trafficSchedulerCore.js
+++ b/functions/src/trafficSchedulerCore.js
@@ -23,6 +23,14 @@ const TOMTOM_CALCULATE_ROUTE_URL = 'https://api.tomtom.com/routing/1/calculateRo
 const HERE_ROUTER_URL = 'https://router.hereapi.com/v8/routes';
 const TT_FLOW_URL = 'https://api.tomtom.com/traffic/services/4/flowSegmentData/relative0';
 const MAX_FLOW_DELAY_MIN = 45;
+// HERE "Time Aware Routing" free tier is 5 000 transactions / calendar month
+// (Base Plan v6.0 Tier 1, 0–5000 = €0; May 2026 over-ran to 8 962 → first
+// invoice). Each crossing costs 2 transactions (crossing segment +
+// approach segment), so a full run of 26 crossings = 52. We hard-cap monthly
+// HERE usage below the free tier and skip further runs once the budget is
+// exhausted — the deterministic guarantee that we never pay, independent of how
+// GitHub schedules the cron. Override via the HERE_MONTHLY_BUDGET env var.
+const HERE_MONTHLY_BUDGET = Number(process.env.HERE_MONTHLY_BUDGET || 4500);
 const WEBCAM_QUEUE_MIN_WAIT_MIN = 8;
 const WEBCAM_CLEAR_HIGH_WAIT_MIN = 30;
 const WEBCAM_CLEAR_APPROACH_MAX_MIN = 5;
@@ -333,6 +341,68 @@ export function ensureAdminApp() {
  return admin;
 }
 
+// ─── HERE monthly budget guard ─────────────────────────────────
+
+/**
+ * Pure budget-decision logic (no I/O — unit-testable).
+ *
+ * Given the persisted `{ storedMonth, storedCount }`, the current `month`, the
+ * number of calls this run wants, and the monthly `budget`, decides whether the
+ * run may proceed and what the new running count should be. A month change
+ * resets the count to 0. The reservation is rejected when it would push the
+ * month total *over* the budget (`>`), so a run that lands exactly on the budget
+ * is still allowed.
+ *
+ * @param {{ storedMonth?: string, storedCount?: number, month: string, callsThisRun: number, budget: number }} input
+ * @returns {{ allowed: boolean, count: number }}
+ */
+export function computeHereBudgetDecision({ storedMonth, storedCount, month, callsThisRun, budget }) {
+ const current = storedMonth === month ? Number(storedCount || 0) : 0;
+ if (current + callsThisRun > budget) {
+ return { allowed: false, count: current };
+ }
+ return { allowed: true, count: current + callsThisRun };
+}
+
+/**
+ * Atomically reserves `callsThisRun` HERE transactions against the current
+ * calendar month's budget (Firestore doc `meta/hereTransactionBudget`).
+ *
+ * Returns `{ allowed, count, month }`. When `allowed` is false the caller MUST
+ * NOT issue HERE requests this run — the free-tier budget is exhausted. The
+ * reservation is conservative (counts attempted calls, not billed ones) so we
+ * always land *under* the real HERE meter.
+ *
+ * @param {number} callsThisRun
+ * @returns {Promise<{ allowed: boolean, count: number, month: string }>}
+ */
+export async function reserveHereTransactionBudget(callsThisRun) {
+ const adm = ensureAdminApp();
+ const db = adm.firestore();
+ const ref = db.collection('meta').doc('hereTransactionBudget');
+ // Calendar month in Europe/Rome (en-CA gives YYYY-MM-DD → slice to YYYY-MM).
+ const month = new Date()
+ .toLocaleDateString('en-CA', { timeZone: 'Europe/Rome', year: 'numeric', month: '2-digit', day: '2-digit' })
+ .slice(0, 7);
+
+ return db.runTransaction(async (tx) => {
+ const snap = await tx.get(ref);
+ const data = snap.exists ? snap.data() : {};
+ const { allowed, count } = computeHereBudgetDecision({
+ storedMonth: data.month,
+ storedCount: data.count,
+ month,
+ callsThisRun,
+ budget: HERE_MONTHLY_BUDGET,
+ });
+
+ if (allowed) {
+ tx.set(ref, { month, count, updatedAt: adm.firestore.Timestamp.now() });
+ }
+ return { allowed, count, month };
+ });
+}
+
 // ─── Firestore persistence ─────────────────────────────────────
 
 /**
@@ -400,6 +470,34 @@ export async function runTrafficCollection(options = {}) {
  if (!provider) {
  console.warn('⚠️ No routing API key set (HERE_API_KEY, TOMTOM_API_KEY, or GOOGLE_MAPS_API_KEY) – skipping traffic collection');
  return { collected: 0, errors: 0 };
+ }
+
+ // HERE bills every routing call as a "Time Aware Routing" transaction. Reserve
+ // this run's calls against the monthly free-tier budget before issuing any —
+ // if the month is exhausted, skip the run entirely so we never get billed.
+ // Other providers (TomTom/Google) have their own free tiers and are unmetered here.
+ if (provider === 'here') {
+ const callsThisRun = BORDER_CROSSINGS.length * 2; // crossing + approach segment per crossing
+ let budget;
+ try {
+ budget = await reserveHereTransactionBudget(callsThisRun);
+ } catch (err) {
+ // Budget bookkeeping is a backstop, not the primary control (the cron is
+ // also throttled). On a transient Firestore error, proceed rather than
+ // freeze live data — the next run re-checks.
+ console.warn(`⚠️ HERE budget check failed (${err.message}) — proceeding without reservation`);
+ budget = null;
+ }
+ if (budget && !budget.allowed) {
+ console.warn(
+ `🛑 HERE monthly budget reached (${budget.count}/${HERE_MONTHLY_BUDGET} transactions for ${budget.month}) ` +
+ `— skipping run to stay in the free tier. Live data keeps the last snapshot.`,
+ );
+ return { collected: 0, errors: 0, skipped: 'here-budget' };
+ }
+ if (budget) {
+ console.log(`💳 HERE budget: ${budget.count}/${HERE_MONTHLY_BUDGET} transactions reserved for ${budget.month}`);
+ }
  }
 
  console.log(`🚦 Starting traffic collection for ${BORDER_CROSSINGS.length} crossings via ${provider}…`);

--- a/tests/trafficScheduler.here-routing.test.ts
+++ b/tests/trafficScheduler.here-routing.test.ts
@@ -270,6 +270,79 @@ describe('applyWebcamTrafficSanity', () => {
   });
 });
 
+// ─── HERE monthly budget guard ───────────────────────────────────
+
+describe('computeHereBudgetDecision', () => {
+  let computeHereBudgetDecision: (input: {
+    storedMonth?: string;
+    storedCount?: number;
+    month: string;
+    callsThisRun: number;
+    budget: number;
+  }) => { allowed: boolean; count: number };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ computeHereBudgetDecision } = await import(
+      '../functions/src/trafficSchedulerCore.js'
+    ));
+  });
+
+  it('allows the first run of a fresh month (no stored doc)', () => {
+    expect(
+      computeHereBudgetDecision({ month: '2026-06', callsThisRun: 52, budget: 4500 }),
+    ).toEqual({ allowed: true, count: 52 });
+  });
+
+  it('accumulates within the same month', () => {
+    expect(
+      computeHereBudgetDecision({
+        storedMonth: '2026-06',
+        storedCount: 4000,
+        month: '2026-06',
+        callsThisRun: 52,
+        budget: 4500,
+      }),
+    ).toEqual({ allowed: true, count: 4052 });
+  });
+
+  it('resets the count when the month rolls over', () => {
+    expect(
+      computeHereBudgetDecision({
+        storedMonth: '2026-05',
+        storedCount: 4490,
+        month: '2026-06',
+        callsThisRun: 52,
+        budget: 4500,
+      }),
+    ).toEqual({ allowed: true, count: 52 });
+  });
+
+  it('rejects a run that would push the month total over budget', () => {
+    expect(
+      computeHereBudgetDecision({
+        storedMonth: '2026-06',
+        storedCount: 4490,
+        month: '2026-06',
+        callsThisRun: 52,
+        budget: 4500,
+      }),
+    ).toEqual({ allowed: false, count: 4490 });
+  });
+
+  it('allows a run that lands exactly on the budget', () => {
+    expect(
+      computeHereBudgetDecision({
+        storedMonth: '2026-06',
+        storedCount: 4448,
+        month: '2026-06',
+        callsThisRun: 52,
+        budget: 4500,
+      }),
+    ).toEqual({ allowed: true, count: 4500 });
+  });
+});
+
 // ─── resolveTrafficProvider priority ─────────────────────────────
 
 describe('resolveTrafficProvider', () => {


### PR DESCRIPTION
## Contesto

HERE ha fatturato **€11,26** per maggio 2026 (invoice allegata dall'utente): **8 962** transazioni *Time Aware Routing* contro il free tier di **5 000/mese** (Base Plan v6.0, Tier 1 0–5000 = €0). Il collector `traffic-scheduler.yml` è l'**unico** path che chiama HERE: 26 valichi × 2 chiamate routing (segmento valico + segmento approccio) = **52 transazioni/run**, **204 run** a maggio → 204×~44 ≈ 8 962. Nessun Cloud Function `onSchedule` né `services/trafficService.ts` (legge solo Firestore) chiama HERE → classe coperta interamente.

## Implementato

- **Guard di budget mensile hard** in `functions/src/trafficSchedulerCore.js`: contatore Firestore `meta/hereTransactionBudget` che **prenota** le 52 chiamate del run *prima* di emetterle; se il totale del mese di calendario supererebbe `HERE_MONTHLY_BUDGET` (default **4 500** < 5 000), il run viene **saltato** e i dati live mantengono l'ultimo snapshot. Garanzia deterministica di non sforare il free tier indipendentemente dalla varianza di scheduling di GitHub.
- **Logica di decisione pura** estratta in `computeHereBudgetDecision` (no I/O) → **5 unit test** nuovi (primo run mese fresco, accumulo intra-mese, reset su cambio mese, reject oltre budget, allow esatto-su-budget).
- **Reset mensile** via chiave `YYYY-MM` in timezone Europe/Rome.
- **Fail-open su errore Firestore transiente** (procede invece di congelare i dati live; la cron è comunque throttlata come controllo primario).
- **Riduzione cron** in `.github/workflows/traffic-scheduler.yml`: picchi `*/15` → `*/30`, range ristretti, weekend da 8→4 run/giorno (~34% della frequenza weekday precedente), concentrando i run sui due picchi pendolari così il budget si spalma uniforme sul mese invece di front-loadare.
- Tutti i **26 valichi** e **entrambi i segmenti** preservati: zero perdita di qualità dato, solo minore frequenza off-peak.
- Suite `tests/trafficScheduler.here-routing.test.ts`: **24/24 verde** in locale.

## Non implementato (ancora)

- **Switch di provider via HERE → TomTom/Google**: il codice già supporta TomTom (free tier 2 500/giorno) e Google come fallback, ma `resolveTrafficProvider` preferisce HERE quando la key è presente in Remote Config. Non rimosso qui perché richiede decisione strategica dell'utente sullo stato/funding delle altre key e cambierebbe la fonte dati. *(out of scope — decisione utente)*
- **Allineamento esatto al ciclo di fatturazione HERE** (l'invoice copre 03–31/05, non mese di calendario): il guard usa il mese di calendario con budget 4 500 (margine 500) + spread uniforme via cron come protezione contro lo straddle di ciclo. Sufficiente con i margini attuali; un contatore rolling-30-giorni sarebbe più preciso ma non necessario. *(posposto — over-engineering)*
- **Verifica live del guard**: la prenotazione Firestore gira solo nel path CI (`collect-traffic.mjs` con SA). Da osservare al prossimo run schedulato su `main` post-merge (log `💳 HERE budget: N/4500`). *(follow-up post-merge)*

## Test plan

- [x] `npx vitest run tests/trafficScheduler.here-routing.test.ts` → 24/24
- [x] `node --check functions/src/trafficSchedulerCore.js`
- [x] YAML cron sintatticamente valido
- [ ] Post-merge: prossimo run schedulato logga `💳 HERE budget: …/4500` e committa snapshot (verifica su `main`)
- [ ] Fine mese: dashboard HERE mostra ≤ 4 500 transazioni → €0