### PR TITLE
fix(ci): make check-cls-ad-slots comment-aware (stop full-tree false fails)

### DIFF
--- a/scripts/ci/check-cls-ad-slots.mjs
+++ b/scripts/ci/check-cls-ad-slots.mjs
@@ -13,12 +13,19 @@
  * never prevented it. This gate makes the antipattern impossible by construction.
  *
  * INVARIANT: across all tracked build-plugins TS/TSX files, the ONLY one
- * allowed to contain the raw `adsbygoogle` ins literal is the sanctioned emitter
- * `build-plugins/lib/adSlotHtml.ts`. Every other plugin MUST call
+ * allowed to contain the raw `adsbygoogle` ins literal IN CODE is the sanctioned
+ * emitter `build-plugins/lib/adSlotHtml.ts`. Every other plugin MUST call
  * `adSlotHtml('SLOT_KEY')`, whose `min-height`/`data-ad-format` come from the
  * canonical registry `services/adsenseSlots.ts` (each slot's `placeholderMinHeight`
  * reserves exactly the real ad height → zero CLS). New slots are added to the
  * registry, not hand-rolled in a plugin.
+ *
+ * Comment-aware (PR #2127): the marker is matched only after comments are
+ * stripped, so a plugin that merely *names* adsbygoogle in a comment (e.g. a
+ * `// …load adsbygoogle.js…` note) is NOT a violation. The bare-substring grep
+ * used to flag those, failing the full-tree gate on every PR until each branch
+ * reworded prose — whack-a-mole with no CLS impact. Mirrors the comment-awareness
+ * in the sibling gate check-client-lookbehind.mjs.
  *
  * This is a full-tree invariant (not diff-scoped): the baseline is already clean
  * (only adSlotHtml.ts matches today), so any future hard-coded `<ins>` — whether
@@ -33,6 +40,7 @@
  * Zero dependencies (git in PATH only); inspects tracked files via `git grep`.
  */
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isGitGrepNoMatch } from './lib/git-grep.mjs';
@@ -89,8 +97,59 @@ function gitGrepFiles(marker, pathspec) {
 }
 
 /**
+ * Strip JS/TS comments so the gate matches the `adsbygoogle` literal only in real
+ * CODE, never in prose that merely *mentions* it. THE recurring false positive
+ * (PR #2127): a plain `// …load adsbygoogle.js post-hydration` note in
+ * jobsSeoPagesPlugin.ts tripped the bare-substring grep on PRs that never touched
+ * ad markup — and because the gate is full-tree, EVERY open PR branched off that
+ * main failed until each one reworded the comment. Whack-a-mole, not a real CLS
+ * regression. Comment-awareness kills the whole class; mirrors the same defense
+ * already in check-client-lookbehind.mjs.
+ *
+ * Block comments are removed first (multiline C-style), then the `//` tail of
+ * each line. Pure → unit-testable. NB: like the sibling gate it splits on `//`, so a
+ * literal `//` inside a same-line string can over-strip — acceptable: a hard-coded
+ * `<ins class="adsbygoogle">` template carries no `//`, so no false NEGATIVE.
+ *
+ * @param {string} src file contents
+ * @returns {string} src with comments blanked out
+ */
+export function stripComments(src) {
+  const noBlock = String(src ?? '').replace(/\/\*[\s\S]*?\*\//g, '');
+  return noBlock
+    .split(/\r?\n/)
+    .map((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) return ''; // whole-line comment
+      return line.split('//')[0]; // drop trailing line comment
+    })
+    .join('\n');
+}
+
+/**
+ * True iff a candidate file's CODE (comments stripped) still contains the
+ * `adsbygoogle` literal — i.e. a genuinely hard-coded ad slot, not a comment that
+ * names it. Reading is cheap: only files that already grep-hit the marker reach
+ * here. A tracked-but-unreadable file (race) is treated as a hit so the gate fails
+ * loud rather than silently clearing a file it could not inspect (mirrors the
+ * #2010 no-false-clean discipline).
+ *
+ * @param {string} file repo-relative path
+ * @returns {boolean}
+ */
+function fileHasMarkerInCode(file) {
+  let src;
+  try {
+    src = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return true;
+  }
+  return stripComments(src).includes(AD_MARKER);
+}
+
+/**
  * Tracked build-plugin TS/TSX files that contain the raw `adsbygoogle` ins
- * literal but are NOT the sanctioned emitter — i.e. hard-coded ad slots.
+ * literal IN CODE but are NOT the sanctioned emitter — i.e. hard-coded ad slots.
  * Returns a sorted, de-duplicated list (empty = clean).
  */
 export function findViolations() {
@@ -119,8 +178,17 @@ export function findViolations() {
     );
   }
 
-  const matches = raw.filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
-  return [...new Set(matches)].filter((f) => !ALLOWED.has(f)).sort();
+  // Candidates: tracked build-plugin TS/TSX that grep-hit the marker, minus the
+  // sanctioned infra. The grep is a coarse first pass (it matches comments too);
+  // the precise test is `fileHasMarkerInCode` below — the marker must survive
+  // comment-stripping to count, so a comment naming adsbygoogle no longer fails the
+  // gate (PR #2127). The full-tree positive control above still uses the coarse
+  // `raw`, so the no-false-clean canary (#2010) is unaffected.
+  const candidates = raw.filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
+  return [...new Set(candidates)]
+    .filter((f) => !ALLOWED.has(f))
+    .filter(fileHasMarkerInCode)
+    .sort();
 }
 
 function main() {

--- a/tests/check-cls-ad-slots.test.ts
+++ b/tests/check-cls-ad-slots.test.ts
@@ -18,7 +18,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findViolations, ALLOWED, AD_MARKER } from '../scripts/ci/check-cls-ad-slots.mjs';
+import { findViolations, ALLOWED, AD_MARKER, stripComments } from '../scripts/ci/check-cls-ad-slots.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'ci', 'check-cls-ad-slots.mjs');
@@ -67,5 +67,50 @@ describe('check-cls-ad-slots — CLI gate', () => {
     } finally {
       execFileSync('git', ['rm', '-f', '--quiet', file], { cwd: ROOT });
     }
+  });
+
+  it('does NOT flag a build-plugin that names adsbygoogle only in a comment (#2127)', () => {
+    // The recurring false positive: a plain comment mentioning the loader script
+    // (`// …load adsbygoogle.js post-hydration`) tripped the bare-substring grep on
+    // PRs that never touched ad markup, failing the full-tree gate until each branch
+    // reworded prose. Comment-awareness must let this through.
+    const file = path.join(ROOT, 'build-plugins', '_clsgate_commentonly.ts');
+    fs.writeFileSync(
+      file,
+      [
+        '// Loader note: the SPA <AdSenseBanner> loads adsbygoogle.js post-hydration.',
+        '/* block comment also naming adsbygoogle should not count */',
+        'export const Y = `<div class="ad-wrap"></div>`; // trailing note: adsbygoogle',
+        '',
+      ].join('\n'),
+    );
+    try {
+      execFileSync('git', ['add', '-f', file], { cwd: ROOT });
+      expect(findViolations()).not.toContain('build-plugins/_clsgate_commentonly.ts');
+    } finally {
+      execFileSync('git', ['rm', '-f', '--quiet', file], { cwd: ROOT });
+    }
+  });
+});
+
+describe('check-cls-ad-slots — stripComments', () => {
+  it('blanks line, trailing, and block comments but keeps code', () => {
+    const src = [
+      '// pure adsbygoogle comment',
+      'const a = `<ins class="adsbygoogle">`; // trailing adsbygoogle',
+      '/* block adsbygoogle */',
+      ' * jsdoc-body adsbygoogle line',
+    ].join('\n');
+    const out = stripComments(src);
+    expect(out).toContain('<ins class="adsbygoogle">'); // real code survives
+    expect(out).not.toMatch(/pure adsbygoogle comment/);
+    expect(out).not.toMatch(/trailing adsbygoogle/);
+    expect(out).not.toMatch(/block adsbygoogle/);
+    expect(out).not.toMatch(/jsdoc-body adsbygoogle/);
+  });
+
+  it('tolerates nullish input', () => {
+    expect(stripComments(undefined)).toBe('');
+    expect(stripComments('')).toBe('');
   });
 });


### PR DESCRIPTION
## Implementato

- **Root cause del \"fallisce quasi sempre nello step cls\":** il job `cls-ad-slot-check` in `pr-body-contract.yml` esegue `node scripts/ci/check-cls-ad-slots.mjs`, che fa `git grep -lF adsbygoogle` su **tutto** l'albero `build-plugins/` e segnala qualsiasi `.ts/.tsx` (fuori dai 3 file allowed) contenente la **parola** `adsbygoogle` — **anche nei commenti**. Essendo un gate full-tree, un commento che nomina `adsbygoogle` (es. PR #2127: `// …load adsbygoogle.js post-hydration`, non vero markup ad) faceva fallire **ogni PR** branchata da quel main finché ciascuna non riformulava la prosa. Whack-a-mole, zero impatto CLS.
- **Fix della classe:** `scripts/ci/check-cls-ad-slots.mjs` ora **strippa i commenti** (block C-style + tail `//` per riga) prima di cercare il marker, via nuovo helper esportato `stripComments()`. Solo un `<ins class=\"adsbygoogle\">` hard-coded **nel CODICE** fa fallire il gate. Rispecchia la comment-awareness già presente nel gate gemello `check-client-lookbehind.mjs`.
- Il grep coarse e il **positive-control no-false-clean (#2010)** restano invariati: la canary usa ancora `raw` (grezzo), il pass preciso è il nuovo filtro comment-stripped `fileHasMarkerInCode`. L'invariante reale (nessun `<ins>` ad hand-rolled che bypassa `adSlotHtml()` registry-driven → no CLS) è **interamente preservato**.
- Header docstring + commenti inline aggiornati per descrivere il nuovo comportamento (no stale-comment drift).
- **Test (`tests/check-cls-ad-slots.test.ts`):** regression che un mention solo-in-commento **non** viene flaggato (#2127), + unit test del nuovo `stripComments()` (commenti riga/trailing/block azzerati, codice reale preservato, input nullish). Suite locale verde (7/7); CLI exit 0 su albero pulito, exit 1 sul fixture `<ins>` reale.

## Non implementato (ancora)

- **Nessun altro gate da fixare per questa classe:** verificato che `check-client-lookbehind.mjs` è già comment-aware (modello copiato), `check-hardcoded-locale-segments.mjs` richiede già contesto stringa+path (prose-safe), `check-sibling-patterns.mjs` è un token-surfacer (candidati, non verdetti). La classe \"grep gate che fallisce su marker in commento\" era unica di `check-cls-ad-slots.mjs`.
- **Candidati sibling-check non toccati** (`healthPremiumsLandingPlugin.ts`, `jobMarketSnapshotPlugin.ts`, `marketReportPlugin.ts`, `orphanQueryLandingPlugin.ts`, `salaryHubArticles.ts`, `salaryHubContent.ts`, `weeklyEmployersPlugin.ts`, ecc.): falsi positivi per token-overlap (`adSlotHtml`/`trimStart`) — sono **consumer corretti** di `adSlotHtml()`, non l'antipattern. Out of scope.
- **Design full-tree del gate mantenuto** (non diff-scoped): è l'invariante documentata (cattura violazioni trascinate da refactor). Rimosso il driver di instabilità (falsi positivi da commenti), non l'invariante.
- Edge case noto e accettato: come il gate gemello, lo split su `//` può over-strippare un `//` letterale in una stringa same-line → mai un falso **negativo** per un `<ins class=\"adsbygoogle\">` (un template di markup non contiene `//`). Documentato inline.