### PR TITLE
feat(job-detail): gate offer dead-status reveal behind auth

### DIFF
--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -376,7 +376,9 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
  {jobLocation}
  </a>
  )}
- {expiredDate && (
+ {/* Expiry date reveals the "no longer active" status → show only after sign-in.
+     Logged-out users hit the gate first; status surfaces once authenticated. */}
+ {alreadySignedIn && expiredDate && (
  <span className="inline-flex items-center gap-1">
  <Calendar size={14} />
  {EXPIRED_AT_COPY[locale] ?? EXPIRED_AT_COPY.it} {expiredDate}
@@ -694,7 +696,8 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
  return (
  <div className="space-y-5" data-no-auto-ads="inside">
  {backButton}
- {expiredBanner}
+ {/* Status banner ("no longer active") deferred until sign-in: a logged-out
+     visitor sees the gate, not the dead-job notice. Shown in the logged-in view. */}
 
  {/* 3-column grid: left rail | content | right rail (desktop xl only) */}
  <div className="xl:grid xl:grid-cols-[180px_1fr_180px] xl:gap-6">

--- a/components/community/JobOrphanView.tsx
+++ b/components/community/JobOrphanView.tsx
@@ -359,13 +359,16 @@ export default function JobOrphanView({ slug, onBack, hasAccess: hasAccessProp, 
 
  const jobHeaderCard = (
  <div className="rounded-xl border border-edge bg-surface/80 overflow-hidden">
- {/* Amber status bar */}
+ {/* Amber status bar — reveals the "no longer available" status. Deferred until
+     sign-in: a logged-out visitor sees the gate first, the notice only after login. */}
+ {alreadySignedIn && (
  <div className="bg-warning-subtle border-b border-warning-border px-5 py-2.5 flex items-center gap-2">
  <Briefcase size={14} className="text-warning shrink-0" />
  <span className="text-sm text-warning">
  {BANNER_COPY[locale] ?? BANNER_COPY.it}
  </span>
  </div>
+ )}
  {/* Title + metadata */}
  <div className="px-4 py-3 sm:px-5 sm:py-4">
  <h1 className="text-xl font-bold font-display text-heading leading-snug">

--- a/tests/job-status-gated-behind-auth.test.tsx
+++ b/tests/job-status-gated-behind-auth.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Offer status is gated behind the auth-gate.
+ *
+ * Goal: a user who is NOT logged in (auth-gate level) must not see that an offer
+ * is "no longer active" (JobExpiredView) or "no longer available / archived"
+ * (JobOrphanView). That status is revealed only once the user signs in. The
+ * auth gate itself stays fully visible to drive sign-up.
+ *
+ * Logged-in coverage lives in job-expired-view-logged-in.test.tsx; this file
+ * locks the logged-out (gated) behavior for both sibling views.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import JobExpiredView from '@/components/community/JobExpiredView';
+import JobOrphanView from '@/components/community/JobOrphanView';
+import type { ExpiredJob } from '@/hooks/useExpiredJob';
+
+// Avoid pulling the Google Identity Services script / network in jsdom, while
+// keeping the rest of authService (e.g. useAuth, used by JobAlertSection) real.
+vi.mock(import('@/services/authService'), async (importOriginal) => ({
+ ...(await importOriginal()),
+ renderGoogleButton: vi.fn().mockResolvedValue(undefined),
+ isLinkedInSignInAvailable: vi.fn().mockResolvedValue(false),
+ signInWithLinkedIn: vi.fn().mockResolvedValue(undefined),
+ saveAuthJobContext: vi.fn(),
+}));
+
+const expiredJob: ExpiredJob = {
+ slug: 'demo-expired-job',
+ title: 'Software Engineer Frontaliere',
+ titleByLocale: { it: 'Software Engineer Frontaliere' },
+ company: 'Acme SA',
+ companyKey: 'acme-sa',
+ location: 'Lugano',
+ addressLocality: 'Lugano',
+ descriptionByLocale: {
+  it: '<p>Ruolo ibrido a Lugano con mansioni di sviluppo frontend.</p>',
+ },
+ sector: 'IT & Software',
+ expiredAt: '2025-11-15T00:00:00.000Z',
+};
+
+describe('Offer status gated behind auth (logged-out)', () => {
+ afterEach(() => {
+  cleanup();
+  localStorage.clear();
+ });
+
+ it('JobExpiredView hides "no longer active" banner and expiry until sign-in', () => {
+  render(<JobExpiredView job={expiredJob} />);
+
+  // Status reveal must be deferred for logged-out visitors.
+  expect(screen.queryByText(/non è più attiva/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Scaduta il/i)).not.toBeInTheDocument();
+
+  // The auth gate is still presented to drive sign-up.
+  expect(screen.getByRole('region', { name: /Continua per vedere/i })).toBeInTheDocument();
+
+  // The job title still renders (information scent), just not the dead-status.
+  expect(
+   screen.getByRole('heading', { level: 1, name: /Software Engineer Frontaliere/i }),
+  ).toBeInTheDocument();
+ });
+
+ it('JobOrphanView hides "no longer available" banner until sign-in', () => {
+  render(<JobOrphanView slug="software-engineer-acme-sa-lugano" />);
+
+  // Status reveal must be deferred for logged-out visitors.
+  expect(screen.queryByText(/non è più disponibile/i)).not.toBeInTheDocument();
+
+  // The auth gate is still presented.
+  expect(screen.getByRole('region', { name: /Continua per vedere/i })).toBeInTheDocument();
+ });
+});


### PR DESCRIPTION
## Implementato

Quando un utente **non è ancora loggato** (livello auth-gate), le viste di dettaglio offerta non rivelano più che l'offerta non è attiva / è archiviata. Lo status viene mostrato **solo dopo il login**. L'auth-gate, i metodi di sign-in, il teaser descrizione e gli annunci correlati restano pienamente visibili per non rompere il funnel di sign-up.

- `components/community/JobExpiredView.tsx`: il banner "Questa posizione non è più attiva" e la riga "Scaduta il &lt;data&gt;" nell'header sono ora gated su `alreadySignedIn` (mostrati solo da loggati). La vista 2-colonne loggata è invariata (banner + data restano).
- `components/community/JobOrphanView.tsx`: la barra di stato ambra "Questo annuncio non è più disponibile o non è stato trovato" nell'header card è gated su `alreadySignedIn`; il titolo + metadata della card restano visibili anche da sloggati.
- `tests/job-status-gated-behind-auth.test.tsx` (nuovo): locka il comportamento logged-out per entrambe le viste sibling (banner/data assenti pre-login, auth-gate presente). La copertura logged-in esiste già in `tests/job-expired-view-logged-in.test.tsx` (invariata, verde).

Test: i 4 test (2 nuovi gated + 2 logged-in esistenti) passano; suite correlate `bridge-orphan-flicker-guard`, `crawler-archive-removed-to-expired`, `jobboard-dedup-by-id`, `jobboard-related-search-navigation` verdi (30/30). `tsc --noEmit` non produce errori nei file toccati.

## Non implementato (ancora)

- **`build-plugins/jobsSeoPagesPlugin.ts`** (sibling flaggato da `check-sibling-patterns` per `expiredBanner`/`expiredDate`): **out of scope, intenzionale.** È l'emit SSG statico servito ai crawler e come first-paint pre-hydration; non ha alcun concetto di auth-gate (non sa se l'utente è loggato) ed è contenuto SEO necessario per l'indicizzazione delle pagine expired. Rimuoverlo violerebbe i non-negotiable SEO. Dopo l'hydration React monta `JobExpiredView`/`JobOrphanView` che applicano il gate. Nessuna modifica.
- **`components/community/JobBridgeView.tsx`** (sibling flaggato per `alreadySignedIn`): **out of scope.** Il suo banner ("Questo annuncio è stato aggiornato — ti portiamo alla versione corrente") riguarda un'offerta **attiva** spostata su un nuovo slug, non un'offerta non-attiva/archiviata. Semantica diversa: non è lo stesso antipattern, condivide solo il pattern comune dell'auth-gate.
- Pagine job detail attive (`JobBoard.tsx` `selectedJob`): nessun cambiamento — non mostrano alcun messaggio di status morto (le offerte attive non hanno banner not-active/archived).