### PR TITLE
ci(lighthouse): stabilize Chrome on CI runner (--disable-dev-shm-usage)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,9 @@
     "collect": {
       "numberOfRuns": 3,
       "settings": {
-        "preset": "desktop"
+        "preset": "desktop",
+        "maxWaitForLoad": 60000,
+        "chromeFlags": "--disable-dev-shm-usage --no-sandbox --disable-gpu"
       }
     },
     "assert": {


### PR DESCRIPTION
## Implementato

- **`lighthouserc.json`**: aggiunti `chromeFlags: "--disable-dev-shm-usage --no-sandbox --disable-gpu"` + `maxWaitForLoad: 60000` a `collect.settings`.

### Perché
Follow-up del probe-gate (PR #2138, già su main). Con OTTO rimosso all'edge prod risponde **200**, quindi l'audit Lighthouse ora **gira davvero** — ma una delle 3 collection-run **crasha** sulla homepage pesante (ads + script funding-choices):
```
Protocol error (Runtime.evaluate): Target closed
LHCI 'collect' has encountered a problem
```
È il sintomo classico di Chrome che esaurisce il piccolo `/dev/shm` del runner GitHub Actions. Un solo crash fa cadere l'intero `collect` (e il job), quindi il check `lighthouse` su main è **ancora rosso** nonostante prod sia sano (run `27547180895` su merge commit `f941fda7` → `job=failure`).

`--disable-dev-shm-usage` forza Chrome a usare `/tmp` invece del mount di shared-memory minuscolo; `--no-sandbox` e `--disable-gpu` sono l'hardening headless-CI standard. `maxWaitForLoad` 60s dà più margine alle pagine ad-heavy.

## Non implementato (ancora)

- **Taratura budget Lighthouse**: ora che il collect è stabile, i budget (`perf>=0.85`, `LCP<2500`, `CLS<0.1`, `TBT<200`, `seo>=0.9`, `a11y>=0.9`) gireranno su prod reale per la prima volta; restano non-blocking (`continue-on-error` a livello job) finché non tarati su run misurati. Se un budget reale fallisce è segnale vero, non flakiness — follow-up di taratura.
- **Disconnessione OTTO lato SearchAtlas**: route CF cancellate manualmente, ma SearchAtlas può ri-crearle. Va disabilitata nel dashboard SearchAtlas — fuori repo (vedi contesto PR #2138).
- Nessun sibling: `chromeFlags`/`lighthouserc.json` è l'unico config LHCI del repo.