### PR TITLE
fix(seo): remove non-standard rel attributes flagged on every page (SearchAtlas)

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,12 @@
     <meta name="citation_date" content="2026-03-03" />
     <meta name="citation_online_date" content="2024-01-01" />
     <meta name="citation_keywords" content="frontaliere, cross-border worker, Grenzgänger, imposta alla fonte, withholding tax, IRPEF, Canton Ticino, LAMal, AVS, LPP, Permit G, fiscal simulation, Swiss-Italian taxation 2026" />
-    <!-- AI-readable knowledge files -->
-    <link rel="ai-knowledge" href="/llms-full.txt" type="text/plain" />
-    <link rel="ai-plugin" href="/.well-known/ai-plugin.json" type="application/json" />
+    <!-- AI-readable knowledge files served at their conventional well-known paths:
+         /llms-full.txt and /.well-known/ai-plugin.json (auto-discovered, no <link> hint needed).
+         Removed the previous <link rel="ai-knowledge"> / rel="ai-plugin"> tags: those rel
+         values are not in the HTML link-relations registry, so validators/crawlers flag them
+         as an invalid rel attribute on every page. -->
+
     
     <!-- Hreflang for multilingual SEO -->
     <link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/" />


### PR DESCRIPTION
## Implementato

Removed the two custom-`rel` `<link>` tags from `index.html` head:
- `<link rel="ai-knowledge" href="/llms-full.txt">`
- `<link rel="ai-plugin" href="/.well-known/ai-plugin.json">`

`ai-knowledge` / `ai-plugin` are **not** registered HTML link relations, so a SearchAtlas site audit (id 141162) flags `invalid_rel_found` — "Invalid value in rel attribute present" — on **6,111 pages** (every crawled page; the single highest-coverage issue type in the audit). The tags lived in the global SPA shell `index.html`, hence the site-wide hit.

Both referenced files stay fully functional and discoverable at their conventional well-known paths (`/llms-full.txt`, `/.well-known/ai-plugin.json` — both return 200 live); those paths are auto-discovered by AI crawlers and need no `<link>` hint. No code or test references the removed rel values (verified by grep). Replaced with an explanatory comment so the intent isn't lost.

## Non implementato (ancora)

Triage of the rest of the SearchAtlas audit (97,556 raw issues). The following are **deliberate-by-design or false positives** under this project's hard rules and are intentionally NOT changed:

- **`twitter_*` missing (6,148 pages)** — committed gate `tests/seo/no-twitter-meta-dupes.test.ts` forbids Twitter Card tags (≈48 MB across 825k HTML pages; X is not a traffic source for this SEO funnel). Out of scope: would require deleting a quality gate.
- **`has_disallowed_outlink` (6,107)** — deliberate `?q=` sector outlinks; internal `nofollow` is a forbidden gate (PR #2128). By design.
- **`robots_is_noindex` (1,203)** — intentional SPA static-overlay noindex.
- **`inaccessible_sitemaps` / `sitemaps_not_readable` / `robots_inaccessible_sitemaps`** — false positive: all robots-referenced sitemaps verified HTTP 200 + valid XML live (SearchAtlas's own crawler was WAF rate-limited — see the 3,472 `403/429` rows in the same audit).
- **`page_not_in_sitemap` (3,871)** — these are `en/de/fr` locale shards that canonicalize to the IT primary; hreflang-alternate-only (not a separate sitemap `<loc>`) is the correct pattern. Adding them would contradict their canonical.
- **`non_unique_content` (2,948)** — false positive from locale variants + templated hubs (properly canonicalized + hreflang'd).
- **`meta_keywords` (6,007), `element_has_style_attribute` (6,126), `large_dom_size` (6,102)** — Google-ignored / structural; not actionable as SEO.
- **`blocking_llm_crawlers`** — deliberate GPTBot mitigation (CF Worker cap).

**Deferred to follow-up issues** (real wins, but heavier/needs more verification than this surgical PR — pinned root causes filed separately):
- `non_unique_meta_desc` (1,547) + missing `meta_desc` (51) — incomplete `SEO_SECTION_DESCRIPTION_KEY_MAP` in `services/seoService.ts` forces a generic fallback description on indexable SPA sections. Fix = unique localized description keys per section (×4 locales) — substantial i18n copy work.
- `non_unique_title` (231) — employer-hub title built with `count: 0` hardcoded (`build-plugins/jobsSeoPagesPlugin.ts:3290`); needs the per-URL dup list to confirm before changing the title builder.
- `no_self_ref_hreflang` (612) — some feature plugins bypass the canonical `buildHreflangEntries()` helper; needs pinning which plugins.
- OG title/description over-length (974/463) — questionable thresholds (truncating OG description to 65 chars would harm social previews); deliberately not auto-truncated.

## Test plan
- [x] Diff is `index.html` only (6 +/3 −); no symbol/function touched.
- [x] No test/code references `ai-knowledge` / `ai-plugin` / removed tags (grep).
- [x] `/llms-full.txt` and `/.well-known/ai-plugin.json` return 200 live (discovery unaffected).
- [ ] Post-deploy: re-run SearchAtlas audit → `invalid_rel_found` should drop from 6,111 to ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)