### PR TITLE
feat(newsletter): exclude mailtrap from A/B + tag email_opened with variant

### DIFF
--- a/docs/NEWSLETTER-SUBJECT-AB.md
+++ b/docs/NEWSLETTER-SUBJECT-AB.md
@@ -83,7 +83,16 @@ events; immune to the per-provider webhook doc-id divergence.
 
 Disabled by default. When enabled, the send path emits `email_sent` (exposure,
 carries `subject_variant` + `email_provider`) and the webhooks emit
-`email_opened` on open. Both share `distinct_id = email`, so in PostHog:
+`email_opened` on open — also carrying `subject_variant` (non-Resend providers
+don't have it in their webhook payload, so it's looked up from the send doc via
+`lookupSentVariant`) so the breakdown works on either step. Both share
+`distinct_id = email`, so in PostHog:
+
+> **Excluded providers.** `mailtrap` (sandbox/testing ESP, reports ~0 real opens)
+> is excluded from the experiment — see `EXPERIMENT_EXCLUDED_PROVIDERS`. Its sends
+> emit no events and the Firestore report drops its data, so it can't deflate the
+> open-rate comparison. (Note: if mailtrap is also a non-delivering sandbox in the
+> live cascade, that's a separate deliverability concern, out of scope here.)
 
 1. Build a **Funnel**: step 1 `email_sent` → step 2 `email_opened`.
 2. **Filter the whole funnel to one `campaign_id`** (analyze one weekly campaign

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -41,6 +41,35 @@ export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
   OPENED: 'email_opened', // conversion: subscriber opened the email
 });
 
+/**
+ * Providers excluded from the A/B experiment. `mailtrap` is a sandbox/testing
+ * ESP that reports ~0 opens (it doesn't track real opens / may not deliver), so
+ * its data would pollute the open-rate comparison. Excluded both from event
+ * capture (no email_sent/email_opened) and from the Firestore winner resolution
+ * (see scripts/lib/newsletter-ab-data.mjs). Single source of truth.
+ */
+export const EXPERIMENT_EXCLUDED_PROVIDERS = new Set(['mailtrap']);
+
+/**
+ * Read the variant persisted on the SEND doc for (email, campaignId). The send
+ * pipeline writes it at `${campaignId}__${email}` (double underscore); the ESP
+ * webhooks write their own delivery doc at a different id, so non-Resend opens
+ * have no variant of their own — look it up here so email_opened carries it.
+ * Never throws.
+ * @param {FirebaseFirestore.DocumentReference} subscriberRef  newsletter_subscribers/{email}
+ * @returns {Promise<string|null>}
+ */
+export async function lookupSentVariant(subscriberRef, campaignId, email) {
+  try {
+    if (!subscriberRef || !campaignId || !email) return null;
+    const docId = `${campaignId}__${email}`.replace(/[^a-z0-9@._-]+/gi, '-');
+    const snap = await subscriberRef.collection('campaign_deliveries').doc(docId).get();
+    return snap.exists ? (snap.data()?.variant || null) : null;
+  } catch {
+    return null;
+  }
+}
+
 const truthy = (v) => ['1', 'true', 'yes'].includes(String(v || '').toLowerCase());
 
 let _configPromise = null;
@@ -95,6 +124,7 @@ export async function isEmailExperimentEnabled() {
 export async function captureEmailEvent(event, props = {}) {
   const { email, variant, provider, campaignId, locale } = props;
   if (!email) return false;
+  if (provider && EXPERIMENT_EXCLUDED_PROVIDERS.has(provider)) return false; // e.g. mailtrap sandbox
   const { enabled, key, host } = await resolveConfig();
   if (!enabled) return false;
   try {

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -1,7 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
-import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 
 /**
  * Maileroo webhook handler — receives delivery events and stores them in Firestore.
@@ -213,7 +213,8 @@ export async function persistMailerooEvent(db, event) {
   });
 
   if (type === 'open') {
-    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'maileroo', campaignId });
+    const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'maileroo', campaignId, variant });
   }
   return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterMailgunWebhookCore.js
+++ b/functions/src/newsletterMailgunWebhookCore.js
@@ -1,7 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
-import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 
 /**
  * Mailgun webhook handler — receives delivery events and stores them in Firestore.
@@ -171,7 +171,8 @@ async function persistMailgunEvent(db, eventData) {
  });
 
  if (type === 'open') {
- await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailgun', campaignId });
+ const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailgun', campaignId, variant });
  }
  return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -1,6 +1,6 @@
 import admin from 'firebase-admin';
 import { refreshEngagementScore } from './lib/engagementScore.js';
-import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 
 /**
  * Mailjet webhook handler — receives delivery events and stores them in Firestore.
@@ -171,7 +171,8 @@ export async function persistMailjetEvent(db, eventData) {
  });
 
  if (type === 'open') {
- await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailjet', campaignId });
+ const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailjet', campaignId, variant });
  }
  return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterUnosendWebhookCore.js
+++ b/functions/src/newsletterUnosendWebhookCore.js
@@ -1,7 +1,7 @@
 import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
-import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 
 /**
  * Unosend webhook handler — receives delivery events and stores them in Firestore.
@@ -198,7 +198,8 @@ async function persistUnosendEvent(db, eventType, eventData) {
  });
 
  if (type === 'open') {
- await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'unosend', campaignId });
+ const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+ await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'unosend', campaignId, variant });
  }
  return { processed: true, type, email, campaignId };
 }

--- a/scripts/lib/newsletter-ab-data.mjs
+++ b/scripts/lib/newsletter-ab-data.mjs
@@ -18,6 +18,7 @@
  */
 
 import { assignSubjectVariant } from '../../services/newsletter-subject-assign.mjs';
+import { EXPERIMENT_EXCLUDED_PROVIDERS } from '../../functions/src/lib/emailExperimentPostHog.js';
 
 /** Thrown when the single-field collectionGroup index is missing. */
 export class MissingIndexError extends Error {
@@ -75,6 +76,7 @@ export async function loadCampaignVariantTotals(db, campaignId) {
     const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
     if (!email) continue;
     const provider = d.provider || 'unknown';
+    if (EXPERIMENT_EXCLUDED_PROVIDERS.has(provider)) continue; // e.g. mailtrap sandbox — untracked opens pollute the rate
     // Persisted variant is authoritative; recompute only as a legacy fallback.
     const variant = d.variant || assignSubjectVariant(email, campaignId);
     if (d.variant && d.variant !== assignSubjectVariant(email, campaignId)) mismatchVariant++;

--- a/tests/email-experiment-posthog.test.ts
+++ b/tests/email-experiment-posthog.test.ts
@@ -58,6 +58,21 @@ describe('emailExperimentPostHog — enabled', () => {
     expect(body.properties.campaign_id).toBe('weekly_2026-06-15');
   });
 
+  it('no-ops for an excluded provider (e.g. mailtrap sandbox) even when enabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', '1');
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'phc_test_key');
+    const fetchSpy = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, EXPERIMENT_EXCLUDED_PROVIDERS } = await import(MODULE);
+    expect(EXPERIMENT_EXCLUDED_PROVIDERS.has('mailtrap')).toBe(true);
+    const ok = await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.SENT, {
+      email: 'a@b.com', variant: 'concreto', provider: 'mailtrap', campaignId: 'weekly_2026-06-15',
+    });
+    expect(ok).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('still no-ops when email (distinct_id) is missing', async () => {
     vi.resetModules();
     vi.stubEnv('POSTHOG_EMAIL_EXPERIMENT', 'true');


### PR DESCRIPTION
## Implementato

Due pulizie emerse dalla verifica dati live (mailtrap ≈0% aperture; `email_opened` senza variante su 4/5 provider).

**(a) Esclusione mailtrap dall'esperimento** — è un ESP sandbox/testing che riporta ~0 aperture reali → inquinava il confronto open-rate. Nuovo set `EXPERIMENT_EXCLUDED_PROVIDERS` (single source in `emailExperimentPostHog.js`):
- `captureEmailEvent` → no-op se `provider` escluso (niente `email_sent`/`email_opened`).
- `loadCampaignVariantTotals` (report + resolver) → salta le celle del provider escluso, così non deflaziona neanche il tasso globale.

**(b) `email_opened` ora porta `subject_variant` per ogni provider** — i webhook non-Resend non hanno la variante nel payload, quindi nuovo helper `lookupSentVariant(subscriberRef, campaignId, email)` la legge dal **send doc** autoritativo (`${campaignId}__${email}`) prima di emettere l'evento open. Wirato in mailgun/maileroo/unosend/mailjet (Resend la passa già). Rende il breakdown del funnel PostHog corretto su **entrambi** gli step invece di dipendere dalla first-touch attribution.

- Test: `captureEmailEvent` no-op per provider escluso (+ asserzione che `mailtrap` è nel set). 7/7 posthog verde.
- Docs aggiornate (esclusione + variante su open).

## Non implementato (ancora)

- **mailtrap come provider di invio** — resta nel cascade (capacità d'invio); escluso solo dalla *misura* A/B. Se mailtrap è un sandbox che **non consegna** ai destinatari reali, è un problema di **deliverability separato** (fuori scope): da indagare a parte.
- **Backfill variante sugli `email_opened` storici** — non fatto; vale solo da qui in avanti. Lo storico resta leggibile via first-touch/HogQL join lato `email_sent`.
- **Sibling-check** (`subscriberRef`/`DocumentReference`/`FirebaseFirestore`/`emailExperimentPostHog` in moduli vari) — termini Firestore generici / import legittimo del funnel-script, non stesso antipattern.

## Test plan

- [x] `node --check` helper + loader + 4 webhook
- [x] vitest posthog (7, incl. esclusione)
- [x] sibling-check; match coincidenti giustificati
- [ ] Post-merge: funzioni rideployate → i prossimi `email_opened` portano `subject_variant`; mailtrap sparisce dal funnel/report (verificabile live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)