### PR TITLE
fix(seo): de-orphan per-canton profession landings (audit:max-bfs-depth)

### DIFF
--- a/build-plugins/professionCantonLandings.ts
+++ b/build-plugins/professionCantonLandings.ts
@@ -47,6 +47,7 @@ import {
   SALARY_STATS_FACTOR_CODE,
 } from './salaryStatsData';
 import { buildProfessionCantonPath, PROFESSION_CANTON_KEYS } from './professionCantonData';
+import { resolveProfessionCantonsFlushed } from './shared/buildSignals';
 import {
   HERO_EYEBROW_STYLE,
   H1_STYLE,
@@ -380,11 +381,19 @@ export function professionCantonLandings(rootDir: string): Plugin {
     apply: 'build',
     enforce: 'post',
     async closeBundle() {
-      if (process.env.SKIP_PROFESSION_CANTONS === '1') return;
+      if (process.env.SKIP_PROFESSION_CANTONS === '1') {
+        // Unblock the downstream links injector — nothing to link this build.
+        resolveProfessionCantonsFlushed([]);
+        return;
+      }
       const distDir = np.resolve(rootDir, 'dist');
       const res = await emitProfessionCantonPages({ rootDir, distDir });
       // eslint-disable-next-line no-console
       console.log(`[profession-cantons] emitted ${res.pagesWritten} pages (${res.pagesSkippedForJobs} pairs below job floor, ${res.pagesSkippedForWordCount} below word gate)`);
+      // Hand the emitted canonical paths to professionCantonLandingsLinksPlugin
+      // so it can de-orphan exactly the pages that shipped (CLAUDE.md regola #5:
+      // close orphans with real internal links, not by relaxing the gate).
+      resolveProfessionCantonsFlushed(res.emittedPaths);
     },
   };
 }

--- a/build-plugins/professionCantonLandingsLinksPlugin.ts
+++ b/build-plugins/professionCantonLandingsLinksPlugin.ts
@@ -1,0 +1,191 @@
+/**
+ * Per-canton profession landings — internal-links injector.
+ *
+ * {@link professionCantonLandings} emits `/lavoro-{canton}-{role}/` (+ /en/jobs-,
+ * /de/arbeit-, /fr/travail-) but nothing on a crawlable page links INTO them, so
+ * all 332 ship at BFS depth `unreachable` from `/` — `audit:max-bfs-depth` hard-
+ * fails the family as an entirely-buried new content tier (reached 0/332).
+ *
+ * This plugin closes that orphan tier the canonical way (CLAUDE.md regola #5 —
+ * real internal `<a href>` links from a hub reachable from `/`, never by
+ * relaxing the gate): after the canton emitter AND staticPagesPlugin flush, it
+ * injects one "Lavoro per cantone e professione" block into each locale's HTML
+ * sitemap page:
+ *
+ *   it → /mappa-del-sito/      (in the main nav → depth 1 from `/`)
+ *   en → /en/site-map/         (in the /en/ nav  → depth 2 from `/`)
+ *   de → /de/seitenplan/       (in the /de/ nav  → depth 2 from `/`)
+ *   fr → /fr/plan-du-site/     (in the /fr/ nav  → depth 2 from `/`)
+ *
+ * The sitemap page is on every page's nav, so each emitted canton landing lands
+ * at depth ≤ 3 (IT ≤ 2) — well inside the audit's MAX_DEPTH=4. The job-board
+ * hubs (/cerca-lavoro-ticino/ et al.) are NOT viable for the locales: they sit
+ * at apex depth 5 (measured), so a link there would leave the canton pages at
+ * depth 6 — still buried.
+ *
+ * Idempotent via the `data-profession-cantons-links` marker. Shares the pure
+ * insertion logic with the AE-3 injector (build-plugins/shared/injectAfterMain).
+ */
+
+import fs from 'node:fs';
+import np from 'node:path';
+import type { Plugin } from 'vite';
+import {
+  PROFESSION_LOCALES,
+  professionRoleKeyword,
+  type ProfessionId,
+  type ProfessionLocale,
+} from './professionLandingsData';
+import {
+  parseProfessionCantonPath,
+} from './professionCantonData';
+import { getCantonDisplayName, type CantonDisplayLocale } from './shared/cantonDisplay';
+import { staticPagesFlushed, professionCantonsFlushed } from './shared/buildSignals';
+import { injectBlockAfterMain } from './shared/injectAfterMain';
+
+const MARKER = 'data-profession-cantons-links';
+
+/** HTML sitemap page (relative dir under dist) per locale — main-nav reachable. */
+const SITEMAP_PAGE_DIR: Record<ProfessionLocale, string> = {
+  it: 'mappa-del-sito',
+  en: 'en/site-map',
+  de: 'de/seitenplan',
+  fr: 'fr/plan-du-site',
+};
+
+const BLOCK_COPY: Record<ProfessionLocale, { heading: string; intro: string }> = {
+  it: {
+    heading: 'Lavoro per cantone e professione',
+    intro: 'Offerte attive, datori reali e stipendio mediano per professione in ogni cantone svizzero.',
+  },
+  en: {
+    heading: 'Jobs by canton and profession',
+    intro: 'Active openings, real employers and median salary by profession in every Swiss canton.',
+  },
+  de: {
+    heading: 'Stellen nach Kanton und Beruf',
+    intro: 'Aktive Stellen, echte Arbeitgeber und Medianlohn nach Beruf in jedem Schweizer Kanton.',
+  },
+  fr: {
+    heading: 'Emplois par canton et profession',
+    intro: 'Offres actives, employeurs réels et salaire médian par métier dans chaque canton suisse.',
+  },
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Title-cased role keyword (mirror of professionCantonLandings.professionLabel). */
+function professionLabel(locale: ProfessionLocale, id: ProfessionId): string {
+  const role = professionRoleKeyword(locale, id).replace(/-/g, ' ');
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+interface LinkItem {
+  href: string;
+  label: string;
+}
+
+/** Build the injected block for one locale; '' when the locale has no links. */
+export function renderCantonLinksBlock(locale: ProfessionLocale, items: readonly LinkItem[]): string {
+  if (items.length === 0) return '';
+  const copy = BLOCK_COPY[locale];
+  const lis = items
+    .map((it) => `<li class="s-xu5DGK"><a class="s-U9K6Vf" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+    .join('');
+  return (
+    `<aside ${MARKER}>` +
+    `<h3 class="s-ghlfvV">${esc(copy.heading)}</h3>` +
+    `<p>${esc(copy.intro)}</p>` +
+    `<ul class="s--Vsbr1">${lis}</ul>` +
+    `</aside>`
+  );
+}
+
+/**
+ * Group emitted canonical paths into per-locale, sorted link items. Exported
+ * for unit testing the grouping/label derivation without touching disk.
+ */
+export function buildCantonLinkItems(
+  emittedPaths: readonly string[],
+): Record<ProfessionLocale, LinkItem[]> {
+  const byLocale: Record<ProfessionLocale, LinkItem[]> = { it: [], en: [], de: [], fr: [] };
+  for (const path of emittedPaths) {
+    const parsed = parseProfessionCantonPath(path);
+    if (!parsed) continue;
+    const { locale, cantonKey, id } = parsed;
+    const canton = getCantonDisplayName(cantonKey, locale as CantonDisplayLocale);
+    const role = professionLabel(locale, id);
+    byLocale[locale].push({ href: path, label: `${role} · ${canton}` });
+  }
+  for (const loc of PROFESSION_LOCALES) {
+    byLocale[loc].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return byLocale;
+}
+
+export function professionCantonLandingsLinksPlugin(rootDir: string): Plugin {
+  return {
+    name: 'profession-canton-landings-links',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_PROFESSION_CANTONS === '1') return;
+
+      const distDir = np.resolve(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      // Wait for the canton emitter (gives us the emitted paths) AND
+      // staticPagesPlugin (writes the sitemap pages we patch) so both producers
+      // have flushed to disk before we read+patch — mirrors the AE-3 race fix.
+      const [emittedPaths] = await Promise.all([
+        professionCantonsFlushed,
+        staticPagesFlushed,
+      ]);
+
+      const byLocale = buildCantonLinkItems(emittedPaths);
+
+      const failures: string[] = [];
+      let injected = 0;
+      for (const locale of PROFESSION_LOCALES) {
+        const items = byLocale[locale];
+        if (items.length === 0) continue; // nothing emitted for this locale
+        const indexPath = np.join(distDir, SITEMAP_PAGE_DIR[locale], 'index.html');
+        if (!fs.existsSync(indexPath)) {
+          failures.push(` - [missing-file] ${np.relative(distDir, indexPath)}`);
+          continue;
+        }
+        const html = fs.readFileSync(indexPath, 'utf-8');
+        const block = renderCantonLinksBlock(locale, items);
+        const { html: patched, outcome } = injectBlockAfterMain(html, block, MARKER);
+        if (outcome === 'inserted') {
+          fs.writeFileSync(indexPath, patched, 'utf-8');
+          injected++;
+        } else if (outcome === 'no-anchor') {
+          failures.push(` - [no-anchor] ${np.relative(distDir, indexPath)}`);
+        }
+        // 'duplicate' → already patched this build, no-op.
+      }
+
+      console.log(
+        `\x1b[36m[profession-canton-landings-links]\x1b[0m Injected per-canton links into ${injected} locale sitemap page(s).`,
+      );
+
+      // Hard-fail on any miss: an un-patched sitemap page re-opens the
+      // sitemap-profession-cantons.xml orphan tier the audit hard-fails on.
+      if (failures.length > 0) {
+        throw new Error(
+          `[profession-canton-landings-links] failed to inject into ${failures.length} target(s):\n${failures.join('\n')}\n\n` +
+            'This re-orphans sitemap-profession-cantons.xml (audit:max-bfs-depth). ' +
+            'The target sitemap page did not exist after staticPagesFlushed (race / slug drift) ' +
+            'or had no <main>/</main>/</body> anchor. See build-plugins/shared/injectAfterMain.ts.',
+        );
+      }
+    },
+  };
+}

--- a/build-plugins/professionLandingsLinksPlugin.ts
+++ b/build-plugins/professionLandingsLinksPlugin.ts
@@ -56,6 +56,13 @@ import {
   staticPagesFlushed,
   professionLandingsFlushed,
 } from './shared/buildSignals';
+import {
+  injectBlockAfterMain,
+  type InjectionOutcome,
+} from './shared/injectAfterMain';
+
+/** Idempotency marker for the AE-3 profession-links block. */
+const AE3_MARKER = 'data-ae3-profession-links';
 
 interface InjectionTarget {
   readonly indexPath: string;
@@ -147,38 +154,17 @@ function renderBlock(target: InjectionTarget): string {
  *
  * The third return tuple element reports `'inserted' | 'duplicate' | 'no-anchor'`
  * so the plugin can hard-fail on `'no-anchor'` and silently no-op on `'duplicate'`.
+ *
+ * Thin wrapper over the shared {@link injectBlockAfterMain} (the insertion logic
+ * is shared with the per-canton profession-links injector — CLAUDE.md regola #6).
  */
-export type InjectionOutcome = 'inserted' | 'duplicate' | 'no-anchor';
+export type { InjectionOutcome };
 
 export function injectAe3Block(
   html: string,
   block: string,
 ): { html: string; outcome: InjectionOutcome } {
-  if (html.includes('data-ae3-profession-links')) {
-    return { html, outcome: 'duplicate' };
-  }
-
-  const mainOpen = html.match(/<main\b[^>]*>/);
-  if (mainOpen && mainOpen.index !== undefined) {
-    const insertAt = mainOpen.index + mainOpen[0].length;
-    return {
-      html: html.slice(0, insertAt) + block + html.slice(insertAt),
-      outcome: 'inserted',
-    };
-  }
-  if (html.includes('</main>')) {
-    return {
-      html: html.replace('</main>', `${block}</main>`),
-      outcome: 'inserted',
-    };
-  }
-  if (html.includes('</body>')) {
-    return {
-      html: html.replace('</body>', `${block}</body>`),
-      outcome: 'inserted',
-    };
-  }
-  return { html, outcome: 'no-anchor' };
+  return injectBlockAfterMain(html, block, AE3_MARKER);
 }
 
 interface PatchResult {

--- a/build-plugins/shared/buildSignals.ts
+++ b/build-plugins/shared/buildSignals.ts
@@ -49,10 +49,28 @@ function makeSignal(): { promise: Promise<void>; resolve: () => void } {
   };
 }
 
+/** Like {@link makeSignal} but carries a value to the awaiting consumer. */
+function makeValueSignal<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolveFn: (v: T) => void = () => {};
+  const promise = new Promise<T>((resolve) => {
+    resolveFn = resolve;
+  });
+  let resolved = false;
+  return {
+    promise,
+    resolve: (v: T) => {
+      if (resolved) return;
+      resolved = true;
+      resolveFn(v);
+    },
+  };
+}
+
 const staticPagesSignal = makeSignal();
 const professionLandingsSignal = makeSignal();
 const salaryHubSignal = makeSignal();
 const jobsSeoPagesSignal = makeSignal();
+const professionCantonsSignal = makeValueSignal<readonly string[]>();
 
 /** Resolves when {@link staticPagesPlugin} has flushed all its queued writes. */
 export const staticPagesFlushed: Promise<void> = staticPagesSignal.promise;
@@ -93,4 +111,19 @@ export function resolveSalaryHubFlushed(): void {
 export const jobsSeoPagesFlushed: Promise<void> = jobsSeoPagesSignal.promise;
 export function resolveJobsSeoPagesFlushed(): void {
   jobsSeoPagesSignal.resolve();
+}
+
+/**
+ * Resolves with the list of canonical paths {@link professionCantonLandings}
+ * actually wrote this build (job-floor gated → a data-dependent subset of the
+ * enumerated routes). Consumed by {@link professionCantonLandingsLinksPlugin},
+ * which injects a "same role, other cantons" link block into the per-locale
+ * HTML sitemap pages so BFS-from-`/` reaches every emitted page at depth ≤ 3
+ * (closing the `sitemap-profession-cantons.xml` orphan tier flagged by
+ * `audit:max-bfs-depth`).
+ */
+export const professionCantonsFlushed: Promise<readonly string[]> =
+  professionCantonsSignal.promise;
+export function resolveProfessionCantonsFlushed(paths: readonly string[]): void {
+  professionCantonsSignal.resolve(paths);
 }

--- a/build-plugins/shared/injectAfterMain.ts
+++ b/build-plugins/shared/injectAfterMain.ts
@@ -1,0 +1,61 @@
+/**
+ * injectAfterMain.ts — shared, pure HTML block injector for post-build
+ * link-graph plugins.
+ *
+ * Several SEO link-injector plugins (AE-3 profession landings, per-canton
+ * profession landings, …) all need the identical operation: splice a
+ * contextual `<aside>`/`<ul>` block into an already-emitted static page so the
+ * BFS-from-`/` link graph reaches a family of otherwise-orphan landings. The
+ * insertion logic — find `<main …>`, fall back to `</main>` then `</body>`,
+ * idempotent on a per-plugin marker — was duplicated verbatim. Extracted here
+ * so the behaviour cannot drift between callers (CLAUDE.md regola #6).
+ *
+ * Pure (no I/O): the caller reads the file, calls this, and writes the result
+ * only when `outcome === 'inserted'`. The `marker` makes idempotency explicit
+ * per caller, so two different injectors can target the same page without
+ * clobbering each other.
+ */
+
+export type InjectionOutcome = 'inserted' | 'duplicate' | 'no-anchor';
+
+/**
+ * Inserts `block` immediately after the opening `<main …>` tag in `html`.
+ * Falls back to the position just before `</main>` and then `</body>` if
+ * neither exists. Returns the original string when:
+ *  - `marker` is already present in `html` (idempotent), OR
+ *  - none of `<main>`, `</main>`, `</body>` are found (caller treats as failure).
+ *
+ * The `outcome` is `'inserted' | 'duplicate' | 'no-anchor'` so the caller can
+ * hard-fail on `'no-anchor'` and silently no-op on `'duplicate'`.
+ */
+export function injectBlockAfterMain(
+  html: string,
+  block: string,
+  marker: string,
+): { html: string; outcome: InjectionOutcome } {
+  if (html.includes(marker)) {
+    return { html, outcome: 'duplicate' };
+  }
+
+  const mainOpen = html.match(/<main\b[^>]*>/);
+  if (mainOpen && mainOpen.index !== undefined) {
+    const insertAt = mainOpen.index + mainOpen[0].length;
+    return {
+      html: html.slice(0, insertAt) + block + html.slice(insertAt),
+      outcome: 'inserted',
+    };
+  }
+  if (html.includes('</main>')) {
+    return {
+      html: html.replace('</main>', `${block}</main>`),
+      outcome: 'inserted',
+    };
+  }
+  if (html.includes('</body>')) {
+    return {
+      html: html.replace('</body>', `${block}</body>`),
+      outcome: 'inserted',
+    };
+  }
+  return { html, outcome: 'no-anchor' };
+}

--- a/tests/seo/profession-canton-links-injection.test.ts
+++ b/tests/seo/profession-canton-links-injection.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the per-canton profession-links injector
+ * (build-plugins/professionCantonLandingsLinksPlugin.ts).
+ *
+ * Guards the pure grouping/render logic that de-orphans the ~332
+ * /lavoro-{canton}-{role}/ pages: they were shipping at BFS depth `unreachable`
+ * (audit:max-bfs-depth hard-fail, reached 0/332) because nothing on a crawlable
+ * page linked into them. The plugin injects a per-locale link block into each
+ * HTML sitemap page (main-nav reachable → canton pages at depth ≤ 3).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildCantonLinkItems,
+  renderCantonLinksBlock,
+} from '../../build-plugins/professionCantonLandingsLinksPlugin';
+import {
+  buildProfessionCantonPath,
+  PROFESSION_CANTON_KEYS,
+} from '../../build-plugins/professionCantonData';
+import { PROFESSION_IDS } from '../../build-plugins/professionLandingsData';
+
+const MARKER = 'data-profession-cantons-links';
+
+describe('buildCantonLinkItems — group emitted paths by locale', () => {
+  it('routes each emitted canonical path to its locale bucket with a derived label', () => {
+    const canton = PROFESSION_CANTON_KEYS[0];
+    const role = PROFESSION_IDS[0];
+    const paths = [
+      buildProfessionCantonPath('it', canton, role),
+      buildProfessionCantonPath('en', canton, role),
+      buildProfessionCantonPath('de', canton, role),
+      buildProfessionCantonPath('fr', canton, role),
+    ];
+
+    const byLocale = buildCantonLinkItems(paths);
+
+    expect(byLocale.it).toHaveLength(1);
+    expect(byLocale.en).toHaveLength(1);
+    expect(byLocale.de).toHaveLength(1);
+    expect(byLocale.fr).toHaveLength(1);
+    // href is the exact emitted canonical path (trailing slash preserved).
+    expect(byLocale.it[0].href).toBe(buildProfessionCantonPath('it', canton, role));
+    expect(byLocale.it[0].href.endsWith('/')).toBe(true);
+    // Label carries both role and canton for crawlable anchor text.
+    expect(byLocale.it[0].label).toContain('·');
+    expect(byLocale.it[0].label.length).toBeGreaterThan(3);
+  });
+
+  it('sorts items within a locale by label (deterministic output)', () => {
+    const role = PROFESSION_IDS[0];
+    const paths = PROFESSION_CANTON_KEYS.slice(0, 5).map((c) =>
+      buildProfessionCantonPath('it', c, role),
+    );
+    const byLocale = buildCantonLinkItems([...paths].reverse());
+    const labels = byLocale.it.map((i) => i.label);
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('ignores paths that are not per-canton profession landings', () => {
+    const byLocale = buildCantonLinkItems(['/not-a-canton-page/', '/en/random/']);
+    expect(byLocale.it).toHaveLength(0);
+    expect(byLocale.en).toHaveLength(0);
+  });
+});
+
+describe('renderCantonLinksBlock', () => {
+  it('returns an empty string when there are no links (locale skipped)', () => {
+    expect(renderCantonLinksBlock('it', [])).toBe('');
+  });
+
+  it('emits the idempotency marker, heading and one <a> per item', () => {
+    const html = renderCantonLinksBlock('it', [
+      { href: '/lavoro-argovia-infermiere/', label: 'Infermiere · Argovia' },
+      { href: '/lavoro-basilea-cuoco/', label: 'Cuoco · Basilea' },
+    ]);
+    expect(html).toContain(MARKER);
+    expect(html).toContain('href="/lavoro-argovia-infermiere/"');
+    expect(html).toContain('href="/lavoro-basilea-cuoco/"');
+    expect((html.match(/<a /g) ?? []).length).toBe(2);
+  });
+
+  it('escapes HTML-significant characters in labels and hrefs', () => {
+    const html = renderCantonLinksBlock('it', [
+      { href: '/x/?a=1&b=2', label: 'A & B <x>' },
+    ]);
+    expect(html).toContain('&amp;');
+    expect(html).not.toContain('<x>');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,7 @@ import { nursingLandingsPlugin } from './build-plugins/nursingLandingsPlugin';
 import { careerLandingsPlugin } from './build-plugins/careerLandingsPlugin';
 import { professionLandingsPlugin } from './build-plugins/professionLandingsPlugin';
 import { professionLandingsLinksPlugin } from './build-plugins/professionLandingsLinksPlugin';
+import { professionCantonLandingsLinksPlugin } from './build-plugins/professionCantonLandingsLinksPlugin';
 import { salaryHubIndexLinkPlugin } from './build-plugins/salaryHubIndexLinkPlugin';
 import { comparisonsHubPlugin } from './build-plugins/comparisonsHubPlugin';
 import { comparisonsHubLinksPlugin } from './build-plugins/comparisonsHubLinksPlugin';
@@ -279,6 +280,13 @@ export default defineConfig(({ mode }) => {
  // the target HTML files already exist on disk. Idempotent via
  // `data-ae3-profession-links` marker.
  professionLandingsLinksPlugin(__dirname),
+ // Per-canton profession landings orphan fix — inject a "jobs by canton and
+ // profession" block into each locale HTML sitemap page (main-nav reachable)
+ // so the ~332 /lavoro-{canton}-{role}/ pages reach BFS depth ≤ 3 instead of
+ // shipping unreachable (audit:max-bfs-depth hard-fail). Awaits explicit
+ // signals from professionCantonLandings (emitted paths) + staticPagesPlugin
+ // (sitemap-page HTML). Idempotent via `data-profession-cantons-links`.
+ professionCantonLandingsLinksPlugin(__dirname),
  // Salary-hub orphan fix — patch the calculator hub (/calcola-stipendio/
  // + 3 locale twins) with a single anchor to /calcola-stipendio/scenari/
  // (and locale variants) so BFS from `/` reaches every one of the 1 732


### PR DESCRIPTION
## Implementato

- **Fix `audit:max-bfs-depth` (validate-dist GATING failure).** Le 332 pagine `/lavoro-{canton}-{role}/` (`sitemap-profession-cantons.xml`, aggiunte da #2095) erano orfane totali — `reached 0/332`, nessun link inbound da pagina crawlabile → new-shard hard-fail (≥90% buried). Nuovo `build-plugins/professionCantonLandingsLinksPlugin.ts` inietta un blocco link per-locale "jobs by canton and profession" in ogni HTML sitemap page (main-nav reachable: `/mappa-del-sito/` depth 1; `/en/site-map/`, `/de/seitenplan/`, `/fr/plan-du-site/` depth 2) → ogni canton landing emessa raggiunge BFS depth ≤ 3 (dentro `MAX_DEPTH=4`).
- **Anchor scelto = sitemap page, NON job-board hub.** I job-board hub (`/cerca-lavoro-ticino/` + locale) sono stati misurati ad apex depth 5 → le canton page lì sarebbero depth 6 (ancora buried). Le sitemap page (footer/nav globale) sono depth 1/2 → canton depth 2/3.
- **Estratto injector condiviso** `build-plugins/shared/injectAfterMain.ts` (`injectBlockAfterMain(html, block, marker)`); `professionLandingsLinksPlugin.injectAe3Block` è ora un thin wrapper su di esso (regola #6 anti-duplicazione — i due injector non possono più divergere). Il test esistente `profession-links-injection-deterministic.test.ts` resta verde (behavior identico).
- **`buildSignals.ts`**: nuovo signal value-carrying `professionCantonsFlushed` (porta gli `emittedPaths` reali, job-floor gated) + `makeValueSignal<T>` helper.
- **`professionCantonLandings.ts`**: risolve il signal dopo `collector.flush()` (e nel ramo `SKIP_PROFESSION_CANTONS` con `[]` per non bloccare il consumer).
- **`vite.config.ts`**: wiring del nuovo plugin subito dopo `professionLandingsLinksPlugin` (awaita signal espliciti → no race parallel-flush).
- **Test** `tests/seo/profession-canton-links-injection.test.ts`: grouping per-locale, sort deterministico, derivazione label, marker idempotente, escaping. Full suite: 64088 passed (2 timeout-flake ambientali in `mine-topic-candidates.test.ts`, isolati passano — non toccati da questa PR).

Closes #2170

## Non implementato (ancora)

- **`validate-live` (`probe:5xx` su `/en/ /de/ /fr/` 404)** — fuori scope di questa PR perché è una root cause DISTINTA e non clean-fixable repo-side: il CF locale-router Worker ha sfondato il cap free-tier **100k invocazioni/giorno** (103k il 15/06, 0 errori) → `request_limit_fail_open` bypassa il Worker → la richiesta colpisce l'apex origin (che dopo lo strip deploy non ha `/en|/de|/fr`) → 404. Il deploy fa `purge_everything` (free-tier senza purge scoped) svuotando anche la fail-open cache apex-keyed → il probe subito dopo non trova nulla. **Il caching NON riduce le invocazioni** (commento nel worker, post-#1865: "a routed Worker runs before the cache on every request") → il Worker è già max-ottimizzato (negative-cache 404, fail-open 24h). Fix reale = portare le invocazioni sotto 100k: o regola CF **pre-Worker** (WAF/Redirect, gira prima del Worker) che scarica il traffico crawler su URL morti (~51k/day, l'84% degli hit `/en/` sono 404), oppure piano CF a pagamento (escluso, $0). È una **decisione infra/costo dell'owner**, già tracciata da #1867 ("cut invocations toward the 100k/day cap"); collegata al validation-failure #2169. Non chiudo né #2169 né #1867: nessun codice in questa PR li risolve.
- **Sibling stessa classe `sitemap-salary-stats.xml`** (#2085, nuovo orphan family, NON-gating WARNING) — non toccato direttamente: è de-orphanizzato **transitivamente** via il CTA `/stipendi-{canton}/` già presente in ogni canton-profession page (ora reachable a depth ≤3 → le salary-stats linkate scendono a depth ≤4). I cantoni senza alcuna professione sopra il job-floor (≥3) non hanno una canton-profession page che li linki: se il `validate-dist` post-deploy segnala ancora offender su `sitemap-salary-stats.xml`, follow-up dedicato (stesso pattern: injector nelle sitemap page). Tracciato da #2093.
- **Validazione BFS depth pre-merge**: impossibile (full SSG build OOM locale). La PR aggiunge SOLO link inbound (additiva, nessuna rimozione) → nessun revert-trigger distruttivo; se il post-deploy `validate-dist` mostra ancora offender su `sitemap-profession-cantons.xml` → iterare sull'anchor/label, non revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
