### PR TITLE
fix(seo): ensure SSR hreflang on all staticOverlay families (#2177)

### DIFF
--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -32,6 +32,7 @@ import fs from 'node:fs';
 import np from 'node:path';
 import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
 import { WriteCollector } from './batchWrite';
 import {
   H1_STYLE,
@@ -387,6 +388,8 @@ interface RenderInputs {
   topCities: RankedCity[];
   topSectors: RankedSector[];
   hiringHubHref: string;
+  /** Absolute path per locale for the same canton (self-ref + 4 locales + x-default). */
+  hreflangPaths: HreflangPaths;
   distDir?: string;
 }
 
@@ -519,6 +522,7 @@ function renderSnapshotPage(inp: RenderInputs): string {
     title,
     description,
     canonicalUrl: `${BASE_URL}${inp.canonicalPath}`,
+    hreflangHtml: renderHreflangTags(inp.hreflangPaths),
     bodyHtml: main,
     jsonLdScripts: [breadcrumbLd],
     ogLocale: OG_LOCALE[inp.locale],
@@ -650,9 +654,27 @@ export async function emitChCantonSnapshotPages(
     }
     result.cantonsEmitted.push({ code: cantonCode, jobsCount: cantonJobs.length });
 
+    // Build the 4-locale path map ONCE per canton so every emitted locale
+    // page ships a complete, self-referential hreflang block (self-ref + 4
+    // locales + x-default via the shared renderHreflangTags helper). Each
+    // locale uses its own canton slug; fall back to the IT path for any
+    // locale whose slug is missing so HreflangPaths is always complete.
+    const itSlug = getCantonUrlSlugLocal(slugFile, cantonCode, 'it');
+    const hreflangPaths: HreflangPaths | null = itSlug
+      ? (() => {
+          const itPath = buildCantonSnapshotPath('it', itSlug);
+          const paths = { it: itPath, en: itPath, de: itPath, fr: itPath };
+          for (const loc of LOCALES) {
+            const slug = getCantonUrlSlugLocal(slugFile, cantonCode, loc);
+            if (slug) paths[loc] = buildCantonSnapshotPath(loc, slug);
+          }
+          return paths;
+        })()
+      : null;
+
     for (const locale of LOCALES) {
       const cantonSlug = getCantonUrlSlugLocal(slugFile, cantonCode, locale);
-      if (!cantonSlug) continue;
+      if (!cantonSlug || !hreflangPaths) continue;
       const cantonName = getCantonDisplayName(cantonCode, locale);
       const canonicalPath = buildCantonSnapshotPath(locale, cantonSlug);
 
@@ -677,6 +699,7 @@ export async function emitChCantonSnapshotPages(
         topCities: stats.topCities,
         topSectors: stats.topSectors,
         hiringHubHref,
+        hreflangPaths,
         distDir: opts.distDir,
       });
 

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -25,6 +25,7 @@ import np from 'node:path';
 import fs from 'node:fs';
 import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
 import { WriteCollector } from './batchWrite';
 import {
   H1_STYLE,
@@ -294,6 +295,8 @@ interface RenderInputs {
   totalJobs: number;
   topEmployers: RankedEmployer[];
   searchHref: string;
+  /** Absolute path per locale for the same canton (self-ref + 4 locales + x-default). */
+  hreflangPaths: HreflangPaths;
   distDir?: string;
 }
 
@@ -415,6 +418,7 @@ function renderEmployersPage(inp: RenderInputs): string {
     title,
     description,
     canonicalUrl: `${BASE_URL}${inp.canonicalPath}`,
+    hreflangHtml: renderHreflangTags(inp.hreflangPaths),
     bodyHtml: main,
     jsonLdScripts: [breadcrumbLd, faqLd],
     ogLocale: OG_LOCALE[inp.locale],
@@ -517,9 +521,27 @@ export async function emitChCantonEmployersPages(
 
     const topEmployers = rankEmployers(bucket.byEmployer, 15);
 
+    // Build the 4-locale path map ONCE per canton so every emitted locale
+    // page ships a complete, self-referential hreflang block (self-ref + 4
+    // locales + x-default via the shared renderHreflangTags helper). Each
+    // locale uses its own canton slug; fall back to the IT path for any
+    // locale whose slug is missing so HreflangPaths is always complete.
+    const itSlug = getCantonUrlSlugLocal(slugFile, cantonCode, 'it');
+    const hreflangPaths: HreflangPaths | null = itSlug
+      ? (() => {
+          const itPath = buildCantonEmployersPath('it', itSlug);
+          const paths = { it: itPath, en: itPath, de: itPath, fr: itPath };
+          for (const loc of LOCALES) {
+            const slug = getCantonUrlSlugLocal(slugFile, cantonCode, loc);
+            if (slug) paths[loc] = buildCantonEmployersPath(loc, slug);
+          }
+          return paths;
+        })()
+      : null;
+
     for (const locale of LOCALES) {
       const cantonSlug = getCantonUrlSlugLocal(slugFile, cantonCode, locale);
-      if (!cantonSlug) continue;
+      if (!cantonSlug || !hreflangPaths) continue;
       const cantonName = getCantonDisplayName(cantonCode, locale);
       const canonicalPath = buildCantonEmployersPath(locale, cantonSlug);
       const searchHref = `${LOCALE_PREFIX[locale]}/${JOB_BOARD_PREFIX[locale]}-${cantonSlug}/`.replace(/\/{2,}/g, '/');
@@ -534,6 +556,7 @@ export async function emitChCantonEmployersPages(
         totalJobs: bucket.activeJobsCount,
         topEmployers,
         searchHref,
+        hreflangPaths,
         distDir: opts.distDir,
       });
 

--- a/tests/ch-canton-hreflang.test.ts
+++ b/tests/ch-canton-hreflang.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression test for issue #2177 — SSR hreflang on the CH-wide per-canton
+ * staticOverlay families.
+ *
+ * Background
+ * ----------
+ * PR #2164 made the SPA runtime `updateHreflangTags` skip `staticOverlay`
+ * routes so the server-rendered hreflang block survives hydration. That fix
+ * only holds if the build plugin for each staticOverlay family actually
+ * EMITS a server-rendered hreflang block. The audit found two emitters that
+ * called `buildSeoPageHtml` WITHOUT `hreflangHtml`:
+ *
+ *   - build-plugins/weeklyEmployersChCantonPages.ts  (per-canton companies-hiring hub)
+ *   - build-plugins/jobMarketSnapshotChCantonPages.ts (per-canton job-market snapshot)
+ *
+ * Post-#2164 those pages would have shipped ZERO hreflang (pre-#2164 they at
+ * least had the collapsed-root block from the SPA). This test locks in that
+ * every emitted CH-canton page now carries a complete, self-referential
+ * hreflang block: the page's own URL, all 4 locales, and x-default.
+ *
+ * Drives the real emit functions against a tmp dist with a synthetic ZH
+ * job bucket above MIN_JOBS_FOR_CANTON_PAGE, then reads the emitted HTML.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { emitChCantonEmployersPages } from '../build-plugins/weeklyEmployersChCantonPages';
+import { emitChCantonSnapshotPages } from '../build-plugins/jobMarketSnapshotChCantonPages';
+
+const ROOT = path.resolve(__dirname, '..');
+const BASE = 'https://frontaliereticino.ch';
+
+// 50+ word IT description so jobIsActive() / word-count gates pass.
+const DESC =
+  'Posizione aperta a tempo pieno presso una primaria azienda con sede ' +
+  'nel cantone di Zurigo. Il candidato ideale possiede esperienza nel ' +
+  'settore di riferimento, ottime capacita organizzative e di lavoro in ' +
+  'team, conoscenza delle lingue e disponibilita immediata. Offriamo un ' +
+  'contratto stabile, formazione continua, ambiente dinamico e prospettive ' +
+  'di crescita professionale concrete per chi vuole costruire una carriera ' +
+  'duratura in Svizzera con condizioni economiche competitive e benefit.';
+
+/** Six distinct ZH employers — above the 5-job MIN_JOBS_FOR_CANTON_PAGE gate. */
+function syntheticZhJobs(): Array<Record<string, unknown>> {
+  return Array.from({ length: 6 }, (_, i) => ({
+    slug: `zh-job-${i}`,
+    title: `Impiegato ${i}`,
+    company: `Azienda Zurigo ${i}`,
+    companyKey: `azienda-zurigo-${i}`,
+    canton: 'ZH',
+    location: 'Zürich',
+    addressLocality: 'Zürich',
+    description: DESC,
+    descriptionByLocale: { it: DESC, en: DESC, de: DESC, fr: DESC },
+  }));
+}
+
+/**
+ * Collect every emitted `<link rel="alternate" hreflang>` from a dist tree.
+ * Returns a map of file → array of {locale, href}.
+ */
+function readHreflangByFile(distDir: string): Map<string, Array<{ locale: string; href: string }>> {
+  // Tolerate minified output: attribute values may be unquoted (rel=alternate)
+  // while href stays quoted. Match both quoted and unquoted rel/hreflang.
+  const RX =
+    /<link\s+rel=(?:"alternate"|alternate)\s+hreflang=(?:"([^"]+)"|([^\s>]+))\s+href="([^"]+)"\s*\/?>/g;
+  const out = new Map<string, Array<{ locale: string; href: string }>>();
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.html')) {
+        const html = fs.readFileSync(p, 'utf-8');
+        const tags: Array<{ locale: string; href: string }> = [];
+        RX.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = RX.exec(html)) !== null) {
+          tags.push({ locale: m[1] ?? m[2], href: m[3] });
+        }
+        out.set(p, tags);
+      }
+    }
+  };
+  walk(distDir);
+  return out;
+}
+
+function assertCompleteHreflang(
+  byFile: Map<string, Array<{ locale: string; href: string }>>,
+): void {
+  expect(byFile.size).toBeGreaterThan(0);
+  for (const [file, tags] of byFile) {
+    const locales = tags.map((t) => t.locale);
+    // 4 locales + x-default.
+    for (const expected of ['it', 'en', 'de', 'fr', 'x-default']) {
+      expect(locales, `${file} must emit hreflang="${expected}"`).toContain(expected);
+    }
+    // Every href is absolute on the canonical host (trailing-slash policy).
+    for (const t of tags) {
+      expect(t.href.startsWith(`${BASE}/`), `${file} hreflang href absolute: ${t.href}`).toBe(true);
+      expect(t.href.endsWith('/'), `${file} hreflang href trailing slash: ${t.href}`).toBe(true);
+    }
+    // x-default must mirror the IT href byte-for-byte (shared-helper invariant).
+    const xDefault = tags.find((t) => t.locale === 'x-default');
+    const itTag = tags.find((t) => t.locale === 'it');
+    expect(xDefault?.href, `${file} x-default mirrors IT`).toBe(itTag?.href);
+  }
+}
+
+describe('CH-canton staticOverlay families emit SSR hreflang (#2177)', () => {
+  let distEmployers: string;
+  let distSnapshot: string;
+
+  beforeAll(async () => {
+    distEmployers = fs.mkdtempSync(path.join(os.tmpdir(), 'dist-emp-'));
+    distSnapshot = fs.mkdtempSync(path.join(os.tmpdir(), 'dist-snap-'));
+    await emitChCantonEmployersPages({
+      rootDir: ROOT,
+      distDir: distEmployers,
+      jobs: syntheticZhJobs() as never,
+    });
+    await emitChCantonSnapshotPages({
+      rootDir: ROOT,
+      distDir: distSnapshot,
+      jobs: syntheticZhJobs() as never,
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(distEmployers, { recursive: true, force: true });
+    fs.rmSync(distSnapshot, { recursive: true, force: true });
+  });
+
+  it('weeklyEmployersChCantonPages: every page has self-ref + 4 locales + x-default', () => {
+    const byFile = readHreflangByFile(distEmployers);
+    assertCompleteHreflang(byFile);
+  });
+
+  it('jobMarketSnapshotChCantonPages: every page has self-ref + 4 locales + x-default', () => {
+    const byFile = readHreflangByFile(distSnapshot);
+    assertCompleteHreflang(byFile);
+  });
+});


### PR DESCRIPTION
Audit + fix for the residual-confidence concern in #2177: after PR #2164 made the SPA runtime `updateHreflangTags` skip `staticOverlay` routes, any `staticOverlay` family whose build plugin does NOT emit a server-rendered hreflang block would ship ZERO hreflang post-fix (pre-fix it had the collapsed-root block). I mapped every `staticOverlay` route family in `services/router.ts` to its emitter and grepped each for hreflang emission.

## Implementato

- **Audited all ~40 `staticOverlay` route families** against their build-plugin emitters. Result: only TWO emitters called `buildSeoPageHtml` without `hreflangHtml` → ZERO hreflang:
  - `build-plugins/weeklyEmployersChCantonPages.ts` (per-canton "aziende che assumono" hub, CH-wide ex-TI)
  - `build-plugins/jobMarketSnapshotChCantonPages.ts` (per-canton job-market snapshot, CH-wide ex-TI)
- **Fixed both**: build a complete 4-locale `HreflangPaths` map ONCE per canton (each locale uses its own canton slug via `getCantonUrlSlugLocal` + `buildCantonEmployersPath`/`buildCantonSnapshotPath`; falls back to the IT path for any locale whose slug is missing so the map is always complete), then pass `hreflangHtml: renderHreflangTags(hreflangPaths)` to `buildSeoPageHtml`. Uses the shared `build-plugins/shared/hreflang.ts` helper → self-ref + 4 locales + x-default, trailing-slash absolute URLs. This is byte-for-byte the same pattern their direct twins `salaryStatsChCantonPages.ts` and `professionCantonLandings.ts` already use.
- **Added `tests/ch-canton-hreflang.test.ts`**: drives both real emit functions against a tmp dist with a synthetic ZH job bucket (above `MIN_JOBS_FOR_CANTON_PAGE`) and asserts every emitted page carries it/en/de/fr/x-default, all hrefs absolute on the canonical host with trailing slash, and x-default mirrors the IT href. Fails on `main`, passes here.
- Did NOT touch the `hreflangPostprocessPlugin` safety net (it only strips broken alternates; it never injects missing ones — which is exactly why these two pages were unprotected).

### Full family-by-family audit (family → emitter → verdict)

| Family | Emitter | Hreflang |
|---|---|---|
| weather city / alerts | weatherCityPagesPlugin / weatherAlertPagesPlugin | OK |
| fuel-daily | fuelDailyPagesPlugin | OK |
| health-premiums | healthPremiumsLandingPlugin | OK |
| salary-stats per-canton | salaryStatsChCantonPages | OK |
| weekly-employers (TI hub/city/top-hub/company-city) | weeklyEmployersPlugin | OK |
| **weekly-employers CH per-canton** | **weeklyEmployersChCantonPages** | **MISSING → FIXED** |
| publisher ad detail | publisherAdPagesPlugin | OK |
| job-market snapshot (TI) | jobMarketSnapshotPlugin | OK |
| **job-market snapshot CH per-canton** | **jobMarketSnapshotChCantonPages** | **MISSING → FIXED** |
| border-wait pages / map hub | borderWaitPagesPlugin / borderWaitMapPlugin | OK |
| annual report / market report | annualReportPlugin / marketReportPlugin | OK |
| tassazione-hub pillar + SEMRUSH + salary landings | staticPagesPlugin (consumes editorialContent.ts data) | OK |
| border-municipality | borderMunicipalityPagesPlugin | OK |
| FR salaire-net landing | frSalaireNetLandingPlugin | OK |
| salary-hub articles / index / scenarios | salaryHubArticles / salaryHubIndex / salaryHubPlugin | OK |
| nursing / career / cost-of-living / profession landings | nursing/career/costOfLiving/professionLandingsPlugin | OK |
| profession-canton | professionCantonLandings | OK |
| comparisons hub | comparisonsHubPlugin | OK |
| SEO hubs (jobs/sectors/companies/articles) | seoHubsPlugin | OK |
| FAQ hub | faqHubPlugin | OK |
| orphan-query clusters | orphanQueryLandingPlugin | OK |
| recency/today + editorial job landings | jobsSeoPagesPlugin / jobRecencyPagesPlugin (consume jobEditorialLanding.ts data) | OK |
| sector hubs | jobSectorPagesPlugin | OK |
| related-search clusters | relatedSearchClustersPlugin | OK |

`editorialContent.ts` and `jobEditorialLanding.ts` showed 0 hreflang matches but are data/models modules (no emission) — their pages are emitted by `staticPagesPlugin`/`jobsSeoPagesPlugin`/`jobRecencyPagesPlugin`, all of which emit hreflang. Non-findings.

### Sibling-class-fix note (AGENTS.md #6)

`node scripts/ci/check-sibling-patterns.mjs` flags marketReportPlugin, professionCantonLandings, salaryStatsChCantonPages, weeklyEmployersPlugin, annualReportPlugin as sharing `HreflangPaths`/`hreflangPaths`. Verified manually: every one of them ALREADY passes `hreflangHtml: renderHreflangTags(...)`. They share the token precisely because they implement the correct pattern — not the antipattern. No additional sibling needs the fix.

## Non implementato (ancora)

- Refactor of the hand-built inline hreflang in `jobRecencyPagesPlugin.ts` / `jobSectorPagesPlugin.ts` to the shared `renderHreflangTags` helper: out of scope. They DO emit a correct self-ref + 4-locale + x-default block (string-concatenated, not via the helper), so there is no regression — only a stylistic divergence. Deferred (non funnel-critical).
- Live curl verification of an emitted CH-canton URL: not possible pre-merge (the full SEO build OOMs locally and is forbidden per AGENTS.md). Verified instead via the new unit test driving the real emit functions to a tmp dist. Will confirm live post-deploy (see Test plan).

## Test plan

- [x] `npx vitest run tests/ch-canton-hreflang.test.ts` — 2 passed (fails on main, passes here)
- [x] `npx vitest run tests/hreflang-no-broken.test.ts tests/seo-static-overlay-hreflang-selfref.test.ts` — pass (dist-walk skips without local build, as expected)
- [x] Related plugin suites: weekly-employers, weekly-employers-company-city, job-market-snapshot, job-location-snapshot, multi-canton-seo, half-canton-merge, profession-canton-landings, swiss-canton-salary-parity — all pass
- [x] `npx tsc --noEmit` clean for both touched files
- [ ] Post-deploy: `curl` a sample `/cerca-lavoro-zurigo/aziende-che-assumono/` and `/cerca-lavoro-zurigo/snapshot/` and grep for `<link rel="alternate" hreflang=` (4 locales + x-default)

Closes #2177