### PR TITLE
fix(newsletter): shared delivery-doc-id helper + dedup webhook send docs

### DIFF
--- a/functions/src/lib/deliveryDocId.js
+++ b/functions/src/lib/deliveryDocId.js
@@ -1,0 +1,28 @@
+/**
+ * deliveryDocId.js — canonical id for a per-subscriber campaign delivery doc.
+ *
+ * Single source of truth for the SEND-path delivery doc id
+ * (`newsletter_subscribers/{email}/campaign_deliveries/{id}`). The send pipeline
+ * and the Resend webhook write here; the A/B report + lookupSentVariant read it.
+ * Centralized so the format can't drift across the 3+ places that built it by
+ * hand (a drift would make lookups silently return null).
+ *
+ * Note: the non-Resend ESP webhooks write their OWN delivery doc with a
+ * DIFFERENT, single-underscore id (`${campaignId}_${email}`); only the
+ * send-path / Resend docs use this double-underscore form. The report uses this
+ * builder to keep only the canonical send docs (dropping the webhook duplicates).
+ */
+
+/** Lowercase+trim — must match scripts/send-newsletter.mjs normalizeEmail. */
+function normalizeEmail(raw) {
+  return String(raw || '').trim().toLowerCase();
+}
+
+/**
+ * @param {string} campaignId e.g. "weekly_2026-06-15"
+ * @param {string} email
+ * @returns {string} sanitized canonical send-doc id
+ */
+export function buildDeliveryDocId(campaignId, email) {
+  return `${campaignId}__${normalizeEmail(email)}`.replace(/[^a-z0-9@._-]+/gi, '-');
+}

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -34,6 +34,7 @@
  */
 
 import { getRemoteConfigValue } from '../remoteConfigSecrets.js';
+import { buildDeliveryDocId } from './deliveryDocId.js';
 
 /** Canonical event names — single source of truth for emit + analysis. */
 export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
@@ -62,7 +63,7 @@ export const EXPERIMENT_EXCLUDED_PROVIDERS = new Set(['mailtrap']);
 export async function lookupSentVariant(subscriberRef, campaignId, email) {
   try {
     if (!subscriberRef || !campaignId || !email) return null;
-    const docId = `${campaignId}__${email}`.replace(/[^a-z0-9@._-]+/gi, '-');
+    const docId = buildDeliveryDocId(campaignId, email);
     const snap = await subscriberRef.collection('campaign_deliveries').doc(docId).get();
     return snap.exists ? (snap.data()?.variant || null) : null;
   } catch {

--- a/functions/src/newsletterResendWebhookCore.js
+++ b/functions/src/newsletterResendWebhookCore.js
@@ -2,6 +2,7 @@ import admin from 'firebase-admin';
 import { Resend } from 'resend';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { buildDeliveryDocId as buildCanonicalDeliveryDocId } from './lib/deliveryDocId.js';
 
 function normalizeEmail(value) {
  return String(value || '').trim().toLowerCase();
@@ -100,7 +101,8 @@ function extractTagMap(tags) {
 }
 
 function buildDeliveryDocId(email, campaignId) {
- return `${campaignId}__${normalizeEmail(email)}`.replace(/[^a-z0-9@._-]+/gi, '-');
+ // Delegate to the shared canonical builder (single source of truth).
+ return buildCanonicalDeliveryDocId(campaignId, email);
 }
 
 function buildSubscriberUpdate(eventType, data, currentStatus) {

--- a/scripts/lib/newsletter-ab-data.mjs
+++ b/scripts/lib/newsletter-ab-data.mjs
@@ -19,6 +19,7 @@
 
 import { assignSubjectVariant } from '../../services/newsletter-subject-assign.mjs';
 import { EXPERIMENT_EXCLUDED_PROVIDERS } from '../../functions/src/lib/emailExperimentPostHog.js';
+import { buildDeliveryDocId } from '../../functions/src/lib/deliveryDocId.js';
 
 /** Thrown when the single-field collectionGroup index is missing. */
 export class MissingIndexError extends Error {
@@ -75,6 +76,11 @@ export async function loadCampaignVariantTotals(db, campaignId) {
     if (!d.sent_at) continue; // only count real sends
     const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
     if (!email) continue;
+    // Count ONLY the canonical send-path doc. Non-Resend webhooks write their
+    // own delivery doc (single-underscore id) and stamp sent_at on the provider
+    // 'send' event → without this filter every such subscriber is double-counted
+    // (and the webhook doc has no variant → mis-attributed).
+    if (doc.id !== buildDeliveryDocId(campaignId, email)) continue;
     const provider = d.provider || 'unknown';
     if (EXPERIMENT_EXCLUDED_PROVIDERS.has(provider)) continue; // e.g. mailtrap sandbox — untracked opens pollute the rate
     // Persisted variant is authoritative; recompute only as a legacy fallback.

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -38,6 +38,7 @@ import { getVariantFallback, listVariantIds, DEFAULT_EPSILON } from '../services
 import { assignSubjectVariant } from '../services/newsletter-subject-assign.mjs';
 import { pickWinner, resolveWinnersByProvider } from '../services/newsletter-ab-stats.mjs';
 import { loadCampaignVariantTotals, previousCampaignIds } from './lib/newsletter-ab-data.mjs';
+import { buildDeliveryDocId } from '../functions/src/lib/deliveryDocId.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib/emailExperimentPostHog.js';
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
@@ -1470,7 +1471,7 @@ async function persistDelivery(recipient, messageId, meta) {
   try {
     const email = normalizeEmail(recipient.email);
     const subRef = db.collection('newsletter_subscribers').doc(email);
-    const deliveryDocId = `${meta.campaignId}__${email}`.replace(/[^a-z0-9@._-]+/gi, '-');
+    const deliveryDocId = buildDeliveryDocId(meta.campaignId, email);
     // Store delivery as a subcollection under the subscriber doc
     await subRef.collection('campaign_deliveries').doc(deliveryDocId).set({
       email,

--- a/tests/newsletter-ab-promotion.test.ts
+++ b/tests/newsletter-ab-promotion.test.ts
@@ -4,6 +4,19 @@ const { pickWinner, twoProportionTest, DEFAULT_WINNER_GATES, resolveWinnersByPro
 const { DEFAULT_EPSILON, listVariantIds } = await import('@/services/newsletter-subject-variants.mjs');
 const { assignSubjectVariant } = await import('@/services/newsletter-subject-assign.mjs');
 const { previousCampaignIds } = await import('@/scripts/lib/newsletter-ab-data.mjs');
+const { buildDeliveryDocId } = await import('@/functions/src/lib/deliveryDocId.js');
+
+describe('buildDeliveryDocId', () => {
+  it('builds the canonical double-underscore send-doc id (email lowercased)', () => {
+    expect(buildDeliveryDocId('weekly_2026-06-15', 'User@Example.com')).toBe('weekly_2026-06-15__user@example.com');
+  });
+  it('differs from a webhook single-underscore id (so the report can dedup)', () => {
+    const canonical = buildDeliveryDocId('weekly_2026-06-15', 'a@b.com');
+    const webhookId = 'weekly_2026-06-15_a@b.com'; // single underscore (non-Resend webhook form)
+    expect(canonical).not.toBe(webhookId);
+    expect(canonical.includes('__')).toBe(true);
+  });
+});
 
 describe('pickWinner', () => {
   it('returns no winner when a sample is below the gate', () => {


### PR DESCRIPTION
## Implementato

Follow-up dei rilievi reviewer su #2175 (1 🟡 + ❓ verificati).

**🟡 + ❓1 — formato doc-id duplicato a mano + parità email**: nuovo `functions/src/lib/deliveryDocId.js` con `buildDeliveryDocId(campaignId, email)` canonico (`${campaignId}__${email}`, email **lowercased**). Single source of truth usata da `send-newsletter` persistDelivery, `lookupSentVariant`, e il webhook Resend (wrapper a 2 arg mantenuto). Il lowercase risolve anche il gap di normalizzazione email (un caller con email non-lowercased non manca più il doc).

**❓3 — doppio conteggio dei send (verificato REALE)**: tutti e 4 i webhook non-Resend mappano `accepted/sent → 'send'` e scrivono `sent_at` sul **loro** delivery doc (id single-underscore `${campaignId}_${email}`). Senza filtro, `loadCampaignVariantTotals` (conta i doc con `sent_at`) contava OGNI iscritto non-Resend **due volte** (doc canonico + doc webhook senza variante → mis-attribuito). Fix: conto **solo** il send doc canonico (`if (doc.id !== buildDeliveryDocId(campaignId, email)) continue`).

- Test: `buildDeliveryDocId` (forma canonica + diversa dall'id webhook). 65/65 verde sui test newsletter/AB.

## Non implementato (ancora)

- **`services/newsletterSubscribers.ts:411`** (5ª copia del formato, citata dal reviewer) — **non unificata di proposito**: è un file **client-side** (window/localStorage/Firestore client SDK) nel bundle SPA. Nessun modulo è raggiungibile sia dal **deploy functions** sia dal **bundle SPA** (vincolo cross-runtime: functions non può importare `services/`, e importare `functions/` nello SPA è fragile). Il formato è identico e ora ha una home canonica server-side; il copy client resta self-contained. Consolidamento totale richiederebbe un modulo SPA-safe condiviso → follow-up separato.
- **❓2 (race/assenza send doc all'apertura)** — inerente: se il send doc manca quando arriva l'open, `variant=null` e l'open non è taggato (raro; il funnel first-touch compensa via `email_sent`). Accettato.
- **Divergenza doc-id webhook (`__` vs `_`)** — non unificata (toccherebbe l'open-tracking di 4 webhook, rischioso); il filtro la rende innocua per il report.
- **Sibling** `normalizeEmail` (jobAlertService/subject-assign/variants) — coincidenza di nome.

## Test plan

- [x] `node --check` 5 file; behavior check builder/filtro (canonico `__` vs webhook `_`)
- [x] vitest newsletter/AB → 65/65 (incl. nuovi test buildDeliveryDocId)
- [x] sibling-check; `newsletterSubscribers.ts` giustificato
- [ ] Post-merge: il report/resolver non doppio-conta più i non-Resend (verificabile live col prossimo invio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)