### PR TITLE
fix(traffic): parse real HERE Usage API `items` shape in reconcile

### DIFF
--- a/scripts/reconcile-here-usage.mjs
+++ b/scripts/reconcile-here-usage.mjs
@@ -146,13 +146,19 @@ async function getHereAccessToken({ keyId, keySecret }) {
  * Sums "Transactions" usage across routing services from a Usage API payload.
  * Pure — unit-testable. Prefers billableValue (what HERE charges) and falls
  * back to usageValue.
+ *
+ * The live v2 Usage API returns rows under `items` (verified against
+ * org899238099: `{total, limit, items:[{name, valueDriver, billableValue,…}]}`).
+ * `usage` / bare-array shapes are also accepted for forward/back-compat.
  */
 export function sumRoutingTransactions(usagePayload) {
-  const rows = Array.isArray(usagePayload?.usage)
-    ? usagePayload.usage
-    : Array.isArray(usagePayload)
-      ? usagePayload
-      : [];
+  const rows = Array.isArray(usagePayload?.items)
+    ? usagePayload.items
+    : Array.isArray(usagePayload?.usage)
+      ? usagePayload.usage
+      : Array.isArray(usagePayload)
+        ? usagePayload
+        : [];
   let total = 0;
   const breakdown = [];
   for (const row of rows) {

--- a/tests/reconcileHereUsage.test.ts
+++ b/tests/reconcileHereUsage.test.ts
@@ -51,6 +51,38 @@ describe('sumRoutingTransactions', () => {
     expect(sumRoutingTransactions(null).total).toBe(0);
     expect(sumRoutingTransactions({ usage: [] }).total).toBe(0);
   });
+
+  it('parses the real v2 Usage API `items` shape and excludes non-routing rows', () => {
+    // Verbatim shape returned by GET /v2/usage/realms/org899238099 (June 2026):
+    // a Data IO (DataStorage / GB) row that must be ignored + the routing row.
+    const payload = {
+      total: 2,
+      limit: 100,
+      nextOffset: 0,
+      items: [
+        {
+          realmId: 'org899238099',
+          category: 'DataStorage',
+          name: 'Data IO',
+          valueDriver: 'GB',
+          usageValue: 3497,
+          billableValue: 0,
+        },
+        {
+          realmId: 'org899238099',
+          category: 'LocationServices',
+          featureId: 'hrn:here:service::olp-here:routing-8:traffic',
+          name: 'Time Aware Routing',
+          valueDriver: 'Transactions',
+          usageValue: 6350,
+          billableValue: 6350,
+        },
+      ],
+    };
+    const { total, breakdown } = sumRoutingTransactions(payload);
+    expect(total).toBe(6350);
+    expect(breakdown).toEqual([{ name: 'Time Aware Routing', value: 6350 }]);
+  });
 });
 
 describe('buildHereOAuthHeader', () => {


### PR DESCRIPTION
## Contesto

Verifica **live** della Usage API (richiesta dall'owner) contro il realm reale `org899238099`: la v2 ritorna le righe sotto **`items`**, non `usage`:
\`\`\`json
{"total":2,"limit":100,"items":[
  {"category":"DataStorage","name":"Data IO","valueDriver":"GB","billableValue":0},
  {"category":"LocationServices","name":"Time Aware Routing","valueDriver":"Transactions","usageValue":6350,"billableValue":6350}
]}
\`\`\`
`sumRoutingTransactions` (PR #2174) leggeva solo `usage`/array → in live mode avrebbe sommato **0**. Il seed conservativo `max(realBilled, liveCount)` mascherava il bug (non abbassava il contatore), ma il valore reale dell'API non veniva mai letto → la riconciliazione live era di fatto inerte.

## Implementato

- `sumRoutingTransactions`: legge **`items`** per primo, mantenendo `usage`/bare-array per retro/forward-compat. Il filtro driver (`Transactions`) + nome (`routing`/`time aware`) esclude correttamente la riga **Data IO** (GB) → somma **6350**.
- Unit test nuovo col **payload live verbatim** (Data IO da escludere + Time Aware Routing) → atteso 6350. Suite `reconcileHereUsage` **9/9 verde**.

## Verifica live già fatta (fuori PR)

- ✅ Token OAuth HTTP 200 (firma OAuth1.0a corretta).
- ✅ `GET /v2/usage/realms/org899238099` → **HTTP 200**, `billableValue: 6350` (identico al dato dashboard).
- ✅ `HERE_OAUTH_KEY_ID` / `HERE_OAUTH_KEY_SECRET` / `HERE_REALM_ID=org899238099` salvati su Remote Config (v94).
- ✅ Freeze giugno attivo: contatore Firestore a 6350, guard verificato che salta i run HERE.

## Non implementato (ancora)

- **Paginazione Usage API** (`nextOffset`/`lastOffset`): la risposta è single-page (default limit 100) e per questo account i servizi totali sono <10 → il routing è sempre nella prima pagina. Se in futuro i servizi superano 100 righe servirà seguire `nextOffset`. *(posposto — non raggiungibile ai volumi attuali)*
- **Permesso usage sull'access key**: la lettura live ha funzionato con queste credenziali; se l'owner ruota la key dovrà ri-concedere il permesso Cost Management/Usage. *(nota operativa)*

## Test plan

- [x] `npx vitest run tests/reconcileHereUsage.test.ts` → 9/9
- [x] Parser verificato contro il payload reale → total 6350
- [x] Chiamata Usage API live → 200 con billableValue 6350