### PR TITLE
fix(publisher): disable all CV buttons while one is loading

### DIFF
--- a/components/pages/PublisherDashboardPage.tsx
+++ b/components/pages/PublisherDashboardPage.tsx
@@ -764,7 +764,7 @@ const PublisherDashboardPage: React.FC = () => {
                             <button
                               type="button"
                               onClick={() => { void handleOpenCv(a.id); }}
-                              disabled={cvOpeningId === a.id}
+                              disabled={!!cvOpeningId}
                               className="text-link hover:underline disabled:opacity-60 disabled:cursor-wait"
                             >
                               {cvOpeningId === a.id ? '…' : 'CV'}


### PR DESCRIPTION
## Implementato

- Indirizza il nit 🟡 della review di #2179: in `PublisherDashboardPage.tsx`, `handleOpenCv` ha il guard `if (!user || cvOpeningId) return;`, quindi mentre un CV si risolve un click su un bottone CV di un'altra candidatura veniva ingoiato silenziosamente senza feedback. Cambiato `disabled={cvOpeningId === a.id}` → `disabled={!!cvOpeningId}`: durante il caricamento tutti i bottoni CV sono disabilitati (il dead-click diventa visibile), mentre solo il bottone attivo mostra lo spinner (`cvOpeningId === a.id ? '…' : 'CV'`, invariato).

## Non implementato (ancora)

- Nessun altro scope: cambiamento di una sola riga, nessun sibling con lo stesso costrutto (il pattern `disabled={loadingId === item.id}` altrove in dashboard è corretto perché quelle azioni — archive/restore/checkout — non hanno un guard single-flight globale come `handleOpenCv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)