### PR TITLE
fix(harvester): count only confirmed findings, dedup per-PR (closes #2124)

### DIFF
--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -14,6 +14,11 @@
 //   - appends `has_novel=<bool>` and `novel_count=<n>` to $GITHUB_OUTPUT
 //
 // Env knobs: WINDOW_DAYS (14), THRESHOLD (3), MAX_PRS (40), MAX_ISSUES (120).
+//
+// Pure helpers (detectSeverity / tallyFindings / bucketFinding / issueClass /
+// severityLabelForCount / parseEscalationKey) are exported and unit-tested; the
+// gh-scanning + escalation-emit side effects live in main(), run only when this
+// file is invoked as a script (guard at bottom) so importing it is free.
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -24,6 +29,10 @@ const THRESHOLD = Number(process.env.THRESHOLD || 3);
 const MAX_PRS = Number(process.env.MAX_PRS || 40);
 const MAX_ISSUES = Number(process.env.MAX_ISSUES || 120);
 const OUT = process.env.HARVEST_OUT || 'harvest-clusters.json';
+// EFFICACY_FACTOR: a documented pattern that STILL recurs at ≥ THRESHOLD×factor
+// is evidence the prose rule isn't preventing the mistake → escalate to a
+// structural fix instead of writing another line nobody follows.
+const EFFICACY_FACTOR = Number(process.env.EFFICACY_FACTOR || 2);
 
 const sinceMs = Date.now() - WINDOW_DAYS * 86_400_000;
 const sinceDay = new Date(sinceMs).toISOString().slice(0, 10);
@@ -97,35 +106,54 @@ function fingerprintFinding(text) {
   const lead = words.slice(0, 4);
   return lead.length >= 3 ? `fp:${lead.join('-')}` : null; // too short → still drop
 }
-function bucketFinding(text) {
+export function bucketFinding(text) {
   for (const t of TAXONOMY) if (t.re.test(text)) return t.key;
   return fingerprintFinding(text); // unbucketed → fingerprint safety net (or null)
 }
 
-// ---- 1. Reviewer findings on recently-merged PRs ----
-const findingExamples = {}; // bucket -> [{pr, severity, snippet}]
-const findingCounts = {};
-const mergedPrs = ghJson(['pr', 'list', '--state', 'merged', '--search', `merged:>=${sinceDay}`,
-  '--limit', String(MAX_PRS), '--json', 'number']) || [];
-for (const { number } of mergedPrs) {
-  const data = ghJson(['pr', 'view', String(number), '--json', 'reviews']);
-  const reviews = data?.reviews || [];
-  for (const r of reviews) {
-    if (r.author?.login !== 'claude') continue;
-    const lines = String(r.body || '').split('\n');
-    for (const line of lines) {
-      const sev = line.includes('🔴') ? '🔴' : line.includes('🟡') ? '🟡' : line.includes('❓') ? '❓' : null;
-      if (!sev) continue;
-      const bucket = bucketFinding(line);
-      if (!bucket) continue;
-      findingCounts[bucket] = (findingCounts[bucket] || 0) + 1;
-      (findingExamples[bucket] ||= []).push({ pr: number, severity: sev, snippet: line.trim().slice(0, 160) });
+// Severities that count as a CONFIRMED recurring mistake. `❓` is an
+// adversarial-uncertainty note ("couldn't verify X") — the reviewer doing due
+// diligence on a PR that legitimately touches the topic, NOT the agent
+// repeating a documented error. Counting `❓` (and counting every matching LINE
+// rather than every distinct PR) inflated TOPIC buckets with non-defects and
+// mis-fired escalations: `auto-ads` reached 7 from a negation substring match
+// ("non SEO/AdSense", #2114) plus the three `❓` adversarial lines of a single
+// PR (#2086) — none of them a rule violation (#2124). So: count only confirmed
+// severities, at most once per (PR, bucket).
+const COUNTABLE_SEVERITIES = new Set(['🔴', '🟡']);
+export function detectSeverity(line) {
+  return line.includes('🔴') ? '🔴' : line.includes('🟡') ? '🟡' : line.includes('❓') ? '❓' : null;
+}
+
+// Pure tally: reviewer-PRs → { counts, examples } per bucket. Mirrors the
+// per-issue dedup already used for fix-outcome markers below: one PR with N
+// matching lines in the same bucket counts ONCE (the lesson is "N distinct PRs
+// got <topic> wrong", not "N lines"). `❓`/uncountable severities are skipped.
+// `bucketOf` is injectable for testing.
+export function tallyFindings(prs, { bucketOf = bucketFinding } = {}) {
+  const counts = {};
+  const examples = {};
+  for (const { number, reviews } of prs || []) {
+    const seenBuckets = new Set(); // per-PR dedup across all its reviews
+    for (const r of reviews || []) {
+      if (r.author?.login !== 'claude') continue;
+      for (const line of String(r.body || '').split('\n')) {
+        const sev = detectSeverity(line);
+        if (!sev || !COUNTABLE_SEVERITIES.has(sev)) continue;
+        const bucket = bucketOf(line);
+        if (!bucket) continue;
+        if (seenBuckets.has(bucket)) continue;
+        seenBuckets.add(bucket);
+        counts[bucket] = (counts[bucket] || 0) + 1;
+        (examples[bucket] ||= []).push({ pr: number, severity: sev, snippet: line.trim().slice(0, 160) });
+      }
     }
   }
+  return { counts, examples };
 }
 
 // ---- 2. Recurring issue classes (created in window) ----
-function issueClass(title, labels) {
+export function issueClass(title, labels) {
   const t = title || '';
   if (/^Crawler Failure/i.test(t)) return 'issue:crawler-failure';
   if (/Validation Failure|Publish post-deploy/i.test(t)) return 'issue:validation-failure';
@@ -135,60 +163,10 @@ function issueClass(title, labels) {
   if (names.includes('revenue') || names.includes('rpm-canary')) return 'issue:revenue';
   return null;
 }
-const issueCounts = {};
-const issueExamples = {};
-const allIssues = ghJson(['issue', 'list', '--state', 'all', '--search', `created:>=${sinceDay}`,
-  '--limit', String(MAX_ISSUES), '--json', 'number,title,labels']) || [];
-for (const it of allIssues) {
-  const cls = issueClass(it.title, it.labels);
-  if (!cls) continue;
-  issueCounts[cls] = (issueCounts[cls] || 0) + 1;
-  (issueExamples[cls] ||= []).push({ issue: it.number, title: (it.title || '').slice(0, 80) });
-}
-
-// ---- 3. issue-fix outcomes via FIX_OUTCOME markers in issue comments ----
-// Marker contract (issue-fix.yml prompt): the fixer's terminal comment starts
-// with `<!-- FIX_OUTCOME: <code> -->`. We bucket the blocked/no-pr codes since
-// those are the recurring-burn signal; `pr-created` is the healthy path.
-const outcomeCounts = {};
-const outcomeExamples = {};
-const fixIssues = ghJson(['issue', 'list', '--search', `label:agent:triaged updated:>=${sinceDay}`,
-  '--state', 'all', '--limit', String(MAX_ISSUES), '--json', 'number']) || [];
-for (const { number } of fixIssues.slice(0, MAX_ISSUES)) {
-  const data = ghJson(['issue', 'view', String(number), '--json', 'comments']);
-  const comments = data?.comments || [];
-  // Dedup PER-ISSUE: una stessa issue ri-accodata dal followup-drainer (rescue
-  // a 3 tentativi) può postare lo STESSO marker N volte. Contarli tutti gonfia
-  // il bucket (3 run di UNA issue → conta 3) e fa scattare l'escalation su una
-  // soglia di issue-distinte falsata — è esattamente ciò che ha prodotto #1478.
-  // La lezione cercata è «N issue DISTINTE bloccate da questo esito», non «N
-  // commenti» → conta ogni codice al più una volta per issue. (Il re-queue è
-  // ora fermato alla sorgente in followup-drainer.mjs, ma il dedup rende il
-  // conteggio robusto anche allo storico e a ri-tentativi manuali.)
-  const seenThisIssue = new Set();
-  for (const c of comments) {
-    const m = String(c.body || '').match(/<!--\s*FIX_OUTCOME:\s*([a-z0-9-]+)\s*-->/i);
-    if (!m) continue;
-    const code = m[1].toLowerCase();
-    if (code === 'pr-created') continue; // healthy
-    // Backstop-emitted fallbacks (issue-fix.yml "post-step deterministico") tag
-    // crashed/max_turns runs — expected catch-all, not a doc-rule violation.
-    // Counting them inflates no-pr-unspecified → feedback loop: escalation keeps
-    // re-firing even after the backstop fix (PR #1067) landed.
-    if (String(c.body || '').includes('post-step deterministico')) continue;
-    const k = `fix-outcome:${code}`;
-    if (seenThisIssue.has(k)) continue;
-    seenThisIssue.add(k);
-    outcomeCounts[k] = (outcomeCounts[k] || 0) + 1;
-    (outcomeExamples[k] ||= []).push({ issue: number });
-  }
-}
 
 // ---- Dedup vs existing doc-contracts ----
 const DOC_FILES = ['AGENTS.md', 'ISSUES.md', 'REVIEW.md', 'FOLLOWUP.md'];
-let corpus = '';
-for (const f of DOC_FILES) { try { corpus += '\n' + fs.readFileSync(f, 'utf-8').toLowerCase(); } catch { /* ignore */ } }
-function alreadyDocumented(bucketKey) {
+export function alreadyDocumented(bucketKey, corpus) {
   const tax = TAXONOMY.find((t) => t.key === bucketKey);
   if (tax) return tax.docKeys.some((k) => corpus.includes(k.toLowerCase()));
   // Non-taxonomy keys (issue-class / fix-outcome codes): check hyphen, space
@@ -198,66 +176,7 @@ function alreadyDocumented(bucketKey) {
   return variants.some((v) => corpus.includes(v));
 }
 
-// ---- Assemble clusters above threshold + novel ----
-// EFFICACY_FACTOR: a documented pattern that STILL recurs at ≥ THRESHOLD×factor
-// is evidence the prose rule isn't preventing the mistake → escalate to a
-// structural fix instead of writing another line nobody follows.
-const EFFICACY_FACTOR = Number(process.env.EFFICACY_FACTOR || 2);
-const clusters = [];
-// `driver`: clusters that can drive a doc-rule proposal (an agent repeating a
-// mistake or hitting a wall). issue-class counts are operational VOLUME handled
-// by triage/monitors, not instruction signal → included as context, never a
-// proposal driver (novel stays false for them).
-function consider(source, counts, examples, { driver }) {
-  for (const [key, count] of Object.entries(counts)) {
-    if (count < THRESHOLD) continue;
-    const documented = alreadyDocumented(key);
-    // Documented + still recurring hard = the rule exists but isn't working.
-    const recurringDespiteRule = driver && documented && count >= THRESHOLD * EFFICACY_FACTOR;
-    clusters.push({ source, key, count, driver, novel: driver && !documented,
-      recurringDespiteRule, alreadyDocumented: documented,
-      examples: (examples[key] || []).slice(0, 5) });
-  }
-}
-consider('reviewer-finding', findingCounts, findingExamples, { driver: true });
-consider('fix-outcome', outcomeCounts, outcomeExamples, { driver: true });
-consider('issue-class', issueCounts, issueExamples, { driver: false });
-
-clusters.sort((a, b) => b.count - a.count);
-const novel = clusters.filter((c) => c.novel);
-const escalations = clusters.filter((c) => c.recurringDespiteRule);
-
-const result = { generatedForWindowDays: WINDOW_DAYS, threshold: THRESHOLD,
-  efficacyFactor: EFFICACY_FACTOR, since: sinceDay, totalClusters: clusters.length,
-  novelClusters: novel.length, escalationClusters: escalations.length, clusters };
-fs.writeFileSync(OUT, JSON.stringify(result, null, 2));
-
-// ---- Human summary ----
-console.log(`Lessons harvest — window ${WINDOW_DAYS}d (since ${sinceDay}), threshold ≥${THRESHOLD}`);
-console.log(`Merged PRs scanned: ${mergedPrs.length} · issues scanned: ${allIssues.length} · fix-issues: ${fixIssues.length}`);
-if (!clusters.length) console.log('No recurring clusters above threshold.');
-for (const c of clusters) {
-  const tag = c.novel ? 'NOVEL' : c.recurringDespiteRule ? 'ESCALATE' : 'documented';
-  console.log(`  [${tag}] ${c.source}/${c.key} ×${c.count}` +
-    (c.examples?.length ? `  e.g. ${c.examples.map((e) => '#' + (e.pr || e.issue)).join(',')}` : ''));
-}
-console.log(`\n→ novel recurring clusters: ${novel.length} · escalations (documented-but-recurring): ${escalations.length}`);
-
-if (process.env.GITHUB_OUTPUT) {
-  fs.appendFileSync(process.env.GITHUB_OUTPUT,
-    `has_novel=${novel.length > 0}\nnovel_count=${novel.length}\n` +
-    `has_escalation=${escalations.length > 0}\nescalation_count=${escalations.length}\n`);
-}
-
-// ---- Escalation issues: DETERMINISTIC + dedup-by-construction (zero Claude) ----
-// Previously the Claude step was told to open one escalation issue per
-// `recurringDespiteRule` cluster and dedup by re-searching the title. That
-// soft, LLM-driven dedup drifted (same bucket filed under `source/key` AND
-// `source:key`) and re-fired every run → duplicate escalations piled up
-// (i18n-naming ×4, blocked-workflows-scope ×5, …). Emit them from code with a
-// SINGLE canonical title + the hardened code-level dedup in
-// github-issue-creator.mjs (comments on the open canonical instead of
-// duplicating). The Claude step now handles ONLY novel doc-rule proposals.
+// ---- Escalation issue title/body helpers (DETERMINISTIC, see emit note) ----
 function escalationTitle(c) {
   return `escalation(harvester): ${c.source}/${c.key} ricorre nonostante regola`;
 }
@@ -296,57 +215,188 @@ function escalationBody(c) {
   ].join('\n');
 }
 
-// Gate: emit only when explicitly enabled (the workflow sets this). Keeps local
-// dry-runs and tests from minting real GitHub issues.
-if (process.env.HARVEST_EMIT_ESCALATIONS === 'true') {
-  // 1. EMIT/UPDATE: una issue canonica per bucket attivo. createGithubIssue
-  //    dedupa (commenta sul canonico se esiste). Poi bump SEVERITÀ in base al
-  //    count (recidiva → severity sale, non si accumula un'altra issue).
-  for (const c of escalations) {
-    try {
-      const res = await createGithubIssue({
-        title: escalationTitle(c),
-        description: escalationBody(c),
-        priority: 2,
-        labels: ['follow-up'],
-        workflow: 'Lessons harvester',
-      });
-      const num = res?.number;
-      if (num) {
-        const sev = severityLabelForCount(c.count);
-        const drop = sev === 'severity:high' ? 'severity:medium' : 'severity:high';
-        try {
-          gh(['label', 'create', sev, '--color', sev === 'severity:high' ? 'B60205' : 'D93F0B', '-f']);
-        } catch { /* label esiste già */ }
-        try {
-          gh(['issue', 'edit', String(num), '--add-label', sev, '--remove-label', drop]);
-        } catch (e) { process.stderr.write(`sev bump #${num} fallito: ${e.message}\n`); }
-      }
-    } catch (err) {
-      process.stderr.write(`escalation emit failed for ${c.source}/${c.key}: ${err.message}\n`);
+async function main() {
+  // ---- 1. Reviewer findings on recently-merged PRs ----
+  const mergedPrs = ghJson(['pr', 'list', '--state', 'merged', '--search', `merged:>=${sinceDay}`,
+    '--limit', String(MAX_PRS), '--json', 'number']) || [];
+  const prReviews = [];
+  for (const { number } of mergedPrs) {
+    const data = ghJson(['pr', 'view', String(number), '--json', 'reviews']);
+    prReviews.push({ number, reviews: data?.reviews || [] });
+  }
+  const { counts: findingCounts, examples: findingExamples } = tallyFindings(prReviews);
+
+  // ---- 2. Recurring issue classes (created in window) ----
+  const issueCounts = {};
+  const issueExamples = {};
+  const allIssues = ghJson(['issue', 'list', '--state', 'all', '--search', `created:>=${sinceDay}`,
+    '--limit', String(MAX_ISSUES), '--json', 'number,title,labels']) || [];
+  for (const it of allIssues) {
+    const cls = issueClass(it.title, it.labels);
+    if (!cls) continue;
+    issueCounts[cls] = (issueCounts[cls] || 0) + 1;
+    (issueExamples[cls] ||= []).push({ issue: it.number, title: (it.title || '').slice(0, 80) });
+  }
+
+  // ---- 3. issue-fix outcomes via FIX_OUTCOME markers in issue comments ----
+  // Marker contract (issue-fix.yml prompt): the fixer's terminal comment starts
+  // with `<!-- FIX_OUTCOME: <code> -->`. We bucket the blocked/no-pr codes since
+  // those are the recurring-burn signal; `pr-created` is the healthy path.
+  const outcomeCounts = {};
+  const outcomeExamples = {};
+  const fixIssues = ghJson(['issue', 'list', '--search', `label:agent:triaged updated:>=${sinceDay}`,
+    '--state', 'all', '--limit', String(MAX_ISSUES), '--json', 'number']) || [];
+  for (const { number } of fixIssues.slice(0, MAX_ISSUES)) {
+    const data = ghJson(['issue', 'view', String(number), '--json', 'comments']);
+    const comments = data?.comments || [];
+    // Dedup PER-ISSUE: una stessa issue ri-accodata dal followup-drainer (rescue
+    // a 3 tentativi) può postare lo STESSO marker N volte. Contarli tutti gonfia
+    // il bucket (3 run di UNA issue → conta 3) e fa scattare l'escalation su una
+    // soglia di issue-distinte falsata — è esattamente ciò che ha prodotto #1478.
+    // La lezione cercata è «N issue DISTINTE bloccate da questo esito», non «N
+    // commenti» → conta ogni codice al più una volta per issue. (Il re-queue è
+    // ora fermato alla sorgente in followup-drainer.mjs, ma il dedup rende il
+    // conteggio robusto anche allo storico e a ri-tentativi manuali.)
+    // Lo stesso principio dedup-per-sorgente vale per i reviewer-finding sopra,
+    // dove la chiave è la PR (vedi tallyFindings).
+    const seenThisIssue = new Set();
+    for (const c of comments) {
+      const m = String(c.body || '').match(/<!--\s*FIX_OUTCOME:\s*([a-z0-9-]+)\s*-->/i);
+      if (!m) continue;
+      const code = m[1].toLowerCase();
+      if (code === 'pr-created') continue; // healthy
+      // Backstop-emitted fallbacks (issue-fix.yml "post-step deterministico") tag
+      // crashed/max_turns runs — expected catch-all, not a doc-rule violation.
+      // Counting them inflates no-pr-unspecified → feedback loop: escalation keeps
+      // re-firing even after the backstop fix (PR #1067) landed.
+      if (String(c.body || '').includes('post-step deterministico')) continue;
+      const k = `fix-outcome:${code}`;
+      if (seenThisIssue.has(k)) continue;
+      seenThisIssue.add(k);
+      outcomeCounts[k] = (outcomeCounts[k] || 0) + 1;
+      (outcomeExamples[k] ||= []).push({ issue: number });
     }
   }
 
-  // 2. SELF-HEAL CLOSE: un'escalation aperta il cui bucket NON è più tra quelli
-  //    attivi (sceso sotto soglia per un'intera finestra) → il pattern si è
-  //    fermato: chiudila (drena il ratchet; riapribile, riemerge se ricorre).
-  //    Search via la frase senza parentesi (le `(` rompono gh search → era il
-  //    blind-spot del monitoring) e filtro per titolo esatto.
-  const liveKeys = new Set(escalations.map((c) => `${c.source}/${c.key}`));
-  const openEsc = (ghJson([
-    'issue', 'list', '--state', 'open', '--search', 'ricorre nonostante regola in:title',
-    '--json', 'number,title', '--limit', '100',
-  ]) || []).filter((i) => parseEscalationKey(i.title));
-  for (const iss of openEsc) {
-    const key = parseEscalationKey(iss.title);
-    if (liveKeys.has(key)) continue; // ancora attivo → lascia aperta
-    try {
-      gh(['issue', 'comment', String(iss.number), '--body',
-        `🌱 Self-heal: il bucket \`${key}\` non ricorre più sopra soglia nella finestra ${WINDOW_DAYS}gg (dal ${sinceDay}) → il pattern si è fermato. Chiusa dal lessons-harvester. Riemergerà in automatico se torna a ricorrere.`]);
-      gh(['issue', 'close', String(iss.number), '--reason', 'completed']);
-      console.log(`SELF-HEAL close #${iss.number} — bucket ${key} quiet`);
-    } catch (e) {
-      process.stderr.write(`self-heal close #${iss.number} fallito: ${e.message}\n`);
+  // ---- Dedup vs existing doc-contracts ----
+  let corpus = '';
+  for (const f of DOC_FILES) { try { corpus += '\n' + fs.readFileSync(f, 'utf-8').toLowerCase(); } catch { /* ignore */ } }
+
+  // ---- Assemble clusters above threshold + novel ----
+  const clusters = [];
+  // `driver`: clusters that can drive a doc-rule proposal (an agent repeating a
+  // mistake or hitting a wall). issue-class counts are operational VOLUME handled
+  // by triage/monitors, not instruction signal → included as context, never a
+  // proposal driver (novel stays false for them).
+  function consider(source, counts, examples, { driver }) {
+    for (const [key, count] of Object.entries(counts)) {
+      if (count < THRESHOLD) continue;
+      const documented = alreadyDocumented(key, corpus);
+      // Documented + still recurring hard = the rule exists but isn't working.
+      const recurringDespiteRule = driver && documented && count >= THRESHOLD * EFFICACY_FACTOR;
+      clusters.push({ source, key, count, driver, novel: driver && !documented,
+        recurringDespiteRule, alreadyDocumented: documented,
+        examples: (examples[key] || []).slice(0, 5) });
     }
   }
+  consider('reviewer-finding', findingCounts, findingExamples, { driver: true });
+  consider('fix-outcome', outcomeCounts, outcomeExamples, { driver: true });
+  consider('issue-class', issueCounts, issueExamples, { driver: false });
+
+  clusters.sort((a, b) => b.count - a.count);
+  const novel = clusters.filter((c) => c.novel);
+  const escalations = clusters.filter((c) => c.recurringDespiteRule);
+
+  const result = { generatedForWindowDays: WINDOW_DAYS, threshold: THRESHOLD,
+    efficacyFactor: EFFICACY_FACTOR, since: sinceDay, totalClusters: clusters.length,
+    novelClusters: novel.length, escalationClusters: escalations.length, clusters };
+  fs.writeFileSync(OUT, JSON.stringify(result, null, 2));
+
+  // ---- Human summary ----
+  console.log(`Lessons harvest — window ${WINDOW_DAYS}d (since ${sinceDay}), threshold ≥${THRESHOLD}`);
+  console.log(`Merged PRs scanned: ${mergedPrs.length} · issues scanned: ${allIssues.length} · fix-issues: ${fixIssues.length}`);
+  if (!clusters.length) console.log('No recurring clusters above threshold.');
+  for (const c of clusters) {
+    const tag = c.novel ? 'NOVEL' : c.recurringDespiteRule ? 'ESCALATE' : 'documented';
+    console.log(`  [${tag}] ${c.source}/${c.key} ×${c.count}` +
+      (c.examples?.length ? `  e.g. ${c.examples.map((e) => '#' + (e.pr || e.issue)).join(',')}` : ''));
+  }
+  console.log(`\n→ novel recurring clusters: ${novel.length} · escalations (documented-but-recurring): ${escalations.length}`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT,
+      `has_novel=${novel.length > 0}\nnovel_count=${novel.length}\n` +
+      `has_escalation=${escalations.length > 0}\nescalation_count=${escalations.length}\n`);
+  }
+
+  // ---- Escalation issues: DETERMINISTIC + dedup-by-construction (zero Claude) ----
+  // Previously the Claude step was told to open one escalation issue per
+  // `recurringDespiteRule` cluster and dedup by re-searching the title. That
+  // soft, LLM-driven dedup drifted (same bucket filed under `source/key` AND
+  // `source:key`) and re-fired every run → duplicate escalations piled up
+  // (i18n-naming ×4, blocked-workflows-scope ×5, …). Emit them from code with a
+  // SINGLE canonical title + the hardened code-level dedup in
+  // github-issue-creator.mjs (comments on the open canonical instead of
+  // duplicating). The Claude step now handles ONLY novel doc-rule proposals.
+  // Gate: emit only when explicitly enabled (the workflow sets this). Keeps local
+  // dry-runs and tests from minting real GitHub issues.
+  if (process.env.HARVEST_EMIT_ESCALATIONS === 'true') {
+    // 1. EMIT/UPDATE: una issue canonica per bucket attivo. createGithubIssue
+    //    dedupa (commenta sul canonico se esiste). Poi bump SEVERITÀ in base al
+    //    count (recidiva → severity sale, non si accumula un'altra issue).
+    for (const c of escalations) {
+      try {
+        const res = await createGithubIssue({
+          title: escalationTitle(c),
+          description: escalationBody(c),
+          priority: 2,
+          labels: ['follow-up'],
+          workflow: 'Lessons harvester',
+        });
+        const num = res?.number;
+        if (num) {
+          const sev = severityLabelForCount(c.count);
+          const drop = sev === 'severity:high' ? 'severity:medium' : 'severity:high';
+          try {
+            gh(['label', 'create', sev, '--color', sev === 'severity:high' ? 'B60205' : 'D93F0B', '-f']);
+          } catch { /* label esiste già */ }
+          try {
+            gh(['issue', 'edit', String(num), '--add-label', sev, '--remove-label', drop]);
+          } catch (e) { process.stderr.write(`sev bump #${num} fallito: ${e.message}\n`); }
+        }
+      } catch (err) {
+        process.stderr.write(`escalation emit failed for ${c.source}/${c.key}: ${err.message}\n`);
+      }
+    }
+
+    // 2. SELF-HEAL CLOSE: un'escalation aperta il cui bucket NON è più tra quelli
+    //    attivi (sceso sotto soglia per un'intera finestra) → il pattern si è
+    //    fermato: chiudila (drena il ratchet; riapribile, riemerge se ricorre).
+    //    Search via la frase senza parentesi (le `(` rompono gh search → era il
+    //    blind-spot del monitoring) e filtro per titolo esatto.
+    const liveKeys = new Set(escalations.map((c) => `${c.source}/${c.key}`));
+    const openEsc = (ghJson([
+      'issue', 'list', '--state', 'open', '--search', 'ricorre nonostante regola in:title',
+      '--json', 'number,title', '--limit', '100',
+    ]) || []).filter((i) => parseEscalationKey(i.title));
+    for (const iss of openEsc) {
+      const key = parseEscalationKey(iss.title);
+      if (liveKeys.has(key)) continue; // ancora attivo → lascia aperta
+      try {
+        gh(['issue', 'comment', String(iss.number), '--body',
+          `🌱 Self-heal: il bucket \`${key}\` non ricorre più sopra soglia nella finestra ${WINDOW_DAYS}gg (dal ${sinceDay}) → il pattern si è fermato. Chiusa dal lessons-harvester. Riemergerà in automatico se torna a ricorrere.`]);
+        gh(['issue', 'close', String(iss.number), '--reason', 'completed']);
+        console.log(`SELF-HEAL close #${iss.number} — bucket ${key} quiet`);
+      } catch (e) {
+        process.stderr.write(`self-heal close #${iss.number} fallito: ${e.message}\n`);
+      }
+    }
+  }
+}
+
+// Run only as a script, never on import (lets the test import the pure helpers
+// above without firing gh / writing files). Same guard convention as
+// auto-merge-eval.mjs.
+if (process.argv[1]?.endsWith('harvest-agent-lessons.mjs')) {
+  await main();
 }

--- a/tests/harvest-agent-lessons-tally.test.ts
+++ b/tests/harvest-agent-lessons-tally.test.ts
@@ -1,0 +1,108 @@
+/**
+ * lessons-harvester — tallyFindings: precisione del conteggio reviewer-finding
+ * che alimenta l'escalation `recurringDespiteRule`. Due regressioni di FALSO
+ * POSITIVO chiuse qui (#2124, bucket `auto-ads` escalato a torto):
+ *   1. `❓` = adversarial-uncertainty del reviewer ("non verificato X"), NON un
+ *      errore confermato dell'agent → non deve contare.
+ *   2. conteggio per-RIGA → una PR con N righe nello stesso bucket gonfiava il
+ *      count; la lezione è "N PR DISTINTE", quindi dedup per (PR, bucket).
+ * Il segnale legittimo (🔴/🟡 ricorrente su PR distinte) resta intatto.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — modulo .mjs senza tipi
+import { tallyFindings, detectSeverity, bucketFinding } from '../scripts/ci/harvest-agent-lessons.mjs';
+
+type Review = { author: { login: string }; body: string };
+type PR = { number: number; reviews: Review[] };
+const claudeReview = (body: string): Review => ({ author: { login: 'claude' }, body });
+
+describe('detectSeverity', () => {
+  it('riconosce 🔴/🟡/❓ e null', () => {
+    expect(detectSeverity('🔴 q: bug')).toBe('🔴');
+    expect(detectSeverity('🟡 nit: foo')).toBe('🟡');
+    expect(detectSeverity('❓ q: non verificato')).toBe('❓');
+    expect(detectSeverity('plain line')).toBeNull();
+  });
+});
+
+describe('tallyFindings — ❓ non conta (adversarial-uncertainty ≠ errore)', () => {
+  it('una riga ❓ che menziona adsense NON incrementa il bucket', () => {
+    const prs: PR[] = [{ number: 1, reviews: [claudeReview('❓ q: non verificato che Auto Ads serva da first paint')] }];
+    const { counts } = tallyFindings(prs);
+    expect(counts['auto-ads']).toBeUndefined();
+  });
+
+  it('match in negazione su riga ❓ ("non SEO/AdSense") NON conta (era #2114)', () => {
+    const prs: PR[] = [{ number: 2114, reviews: [claudeReview('❓ q: tool interno di lettura A/B, non funnel-critical (non SEO/AdSense) → resta ❓')] }];
+    const { counts } = tallyFindings(prs);
+    expect(counts['auto-ads']).toBeUndefined();
+  });
+});
+
+describe('tallyFindings — dedup per (PR, bucket)', () => {
+  it('una PR con 3 righe ❓/🟡 nello stesso bucket conta al massimo 1', () => {
+    const prs: PR[] = [{
+      number: 2086,
+      reviews: [claudeReview([
+        '❓ q: gli Auto Ads in-page cadono dentro #root',
+        '❓ q: non verificato AdSense fuori da #root',
+        '🟡 nit: adsense loader iniettato due volte',
+      ].join('\n'))],
+    }];
+    const { counts } = tallyFindings(prs);
+    // solo la riga 🟡 è countable, e comunque dedup per-PR → 1
+    expect(counts['auto-ads']).toBe(1);
+  });
+
+  it('più review della STESSA PR (re-review) restano 1 per bucket', () => {
+    const prs: PR[] = [{
+      number: 42,
+      reviews: [
+        claudeReview('🟡 nit: adsense config precedence'),
+        claudeReview('🟡 nit: adsense config precedence (ancora)'),
+      ],
+    }];
+    const { counts } = tallyFindings(prs);
+    expect(counts['auto-ads']).toBe(1);
+  });
+});
+
+describe('tallyFindings — scenario #2124 sotto la soglia di escalation', () => {
+  it('PR ispirate a #2086/#2114/#2102 NON raggiungono soglia×fattore (3×2=6)', () => {
+    const prs: PR[] = [
+      { number: 2086, reviews: [claudeReview('❓ q: AdSense in-page dentro #root\n❓ q: non verificato fuori #root')] },
+      { number: 2114, reviews: [claudeReview('❓ q: non funnel-critical, non SEO/AdSense → resta ❓')] },
+      { number: 2102, reviews: [claudeReview('🟡 nit: adsense loader doppio, idempotenza non verificata')] },
+    ];
+    const { counts } = tallyFindings(prs);
+    // solo #2102 (🟡) conta → 1, ben sotto 6 → niente escalation
+    expect(counts['auto-ads'] ?? 0).toBe(1);
+    expect(counts['auto-ads'] ?? 0).toBeLessThan(3 * 2);
+  });
+});
+
+describe('tallyFindings — il segnale legittimo resta intatto', () => {
+  it('🔴/🟡 confermati su PR DISTINTE contano (1 per PR)', () => {
+    const prs: PR[] = [
+      { number: 1, reviews: [claudeReview('🔴 Important: structured data manca baseSalary')] },
+      { number: 2, reviews: [claudeReview('🟡 jobPosting senza postalCode')] },
+      { number: 3, reviews: [claudeReview('🔴 hiringOrganization.name assente nel json-ld')] },
+    ];
+    const { counts } = tallyFindings(prs);
+    expect(counts['structured-data']).toBe(3); // raggiunge THRESHOLD reale
+  });
+
+  it('ignora review non di claude', () => {
+    const prs: PR[] = [
+      { number: 1, reviews: [{ author: { login: 'someone-else' }, body: '🔴 adsense disabilitato' }] },
+    ];
+    const { counts } = tallyFindings(prs);
+    expect(counts['auto-ads']).toBeUndefined();
+  });
+});
+
+describe('bucketFinding — invariato', () => {
+  it('mappa il topic adsense sul bucket auto-ads', () => {
+    expect(bucketFinding('🟡 adsense loader doppio')).toBe('auto-ads');
+  });
+});


### PR DESCRIPTION
## Implementato
- **Diagnosi #2124 = falso positivo del lessons-harvester.** Il bucket `auto-ads` è stato escalato (count 7 ≥ soglia×fattore 3×2=6) ma **nessuna** delle PR citate viola la regola Auto Ads: #2102 *aggiunge* il loader Auto Ads a più pagine, #2086 *protegge* il DOM AdSense da React reconcile, #2114 non riguarda AdSense (match su negazione "non SEO/AdSense"). Le "7 occorrenze" erano finding-LINE, non PR distinte, e per lo più `❓`.
- **`scripts/ci/harvest-agent-lessons.mjs`** — estratte le funzioni pure `detectSeverity` + `tallyFindings` (e esportate `bucketFinding`/`issueClass`/`alreadyDocumented`). Il tally ora:
  - conta **solo severità confermate** `🔴`/`🟡` — `❓` è adversarial-uncertainty del reviewer ("non verificato X"), non un errore ricorrente dell'agent;
  - **dedup per (PR, bucket)**: una PR con N righe nello stesso bucket conta 1 — stesso principio già applicato al path `fix-outcome` per-issue (cross-ref aggiunto nel commento).
- **Modulo importabile senza side-effect**: il flusso gh-scanning + escalation-emit è avvolto in `main()` dietro guard `process.argv[1]?.endsWith('harvest-agent-lessons.mjs')` (stessa convenzione di `auto-merge-eval.mjs`), così i test importano gli helper puri senza eseguire `gh` né scrivere file. `EFFICACY_FACTOR` spostato tra le const di testa (usato dal default-param di `severityLabelForCount`).
- **`tests/harvest-agent-lessons-tally.test.ts`** (nuovo, 9 test, verde): `❓` escluso, match-in-negazione su `❓` non conta (#2114), dedup per-PR e multi-review della stessa PR (#2086), scenario #2124 resta sotto soglia×fattore, ricorrenza legittima `🔴`/`🟡` su PR distinte preservata, review non-claude ignorate.

Closes #2124

## Non implementato (ancora)
- **Guard anti-negazione esplicito su righe `🔴`/`🟡`**: il match-in-negazione che ha colpito #2114 era su una riga `❓` (ora esclusa), quindi il falso positivo dimostrato è già risolto. Un rilevatore di negazione su righe confermate è euristico e fragile (rischio falsi negativi su finding reali) → deferito come follow-up, non funnel-critical.
- **Backfill dello storico**: il fix corregge i conteggi futuri; non riapre/ricalcola escalation già emesse. La self-heal-close esistente chiuderà #2124 al merge via `Closes`, e i bucket non più sopra soglia verranno chiusi al prossimo run del harvester.
- Sibling sweep: unico altro file che itera review (`scripts/ci/loop-health-report.mjs`) conta il *numero* di review di claude per PR (metrica operativa), **non** fa bucket per severità/topic → nessun antipattern condiviso, niente da sweepare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)