### PR TITLE
fix(harvester): tighten i18n-naming bucket to stop phantom escalations

### DIFF
--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -65,7 +65,18 @@ const TAXONOMY = [
   { key: 'auto-ads', re: /auto ?ads|adsense|anchor ad|vignette|in-page ad/i, docKeys: ['auto ads', 'adsense'] },
   { key: 'canonical-sitemap', re: /canonical|sitemap|noindex|cross-section/i, docKeys: ['canonical', 'sitemap', 'noindex'] },
   { key: 'workflow-scope-creds', re: /workflows? scope|github_pat|\bpat\b|credential|secret|branch protection|push.*workflow/i, docKeys: ['workflows`', 'capability-guard', 'github_pat'] },
-  { key: 'i18n-naming', re: /locale|i18n|translat|canton-?aware|naming|brand/i, docKeys: ['locale', 'i18n', 'canton-aware'] },
+  // i18n-NAMING: genuine naming/i18n defects only — locale URL segments, translated
+  // brand names, canton-aware slug naming, missing/untranslated keys. The old regex
+  // `/locale|i18n|translat|canton-?aware|naming|brand/i` was far too loose: the bare
+  // `translat` swallowed the ENTIRE translate pipeline (a high-volume active area),
+  // `naming` matched any "naming" (e.g. ad-container naming), `brand` matched
+  // "branded"/"branding" — so heterogeneous, unrelated findings false-clustered here
+  // and tripped a phantom `recurringDespiteRule` escalation (issue #2122, 15 hits / 0
+  // real naming defects). Deliberately NO replacement topic-bucket for the translate
+  // pipeline: those findings are genuine process-failures (unvalidated-claim,
+  // sibling-class-fix, pr-body-contract) and now route to THOSE buckets, or fall to
+  // the fingerprint safety-net — which clusters only on truly-repeated lead-phrases.
+  { key: 'i18n-naming', re: /locale segment|locale-?prefix|canton-?aware (slug|naming|url)|translated? brand|brand.*translat|translation key|missing (locale|translation)|untranslated/i, docKeys: ['locale', 'i18n', 'canton-aware'] },
   { key: 'router-nav', re: /router|parsepath|staticoverlay|window\.location/i, docKeys: ['router', 'staticoverlay', 'parsepath'] },
   // PROCESS-failure-mode buckets (see family note above):
   { key: 'pr-body-contract', re: /implementato|non implementato|completeness contract|sezioni? (obbligatori|mancant)|## fix\b|## verify\b/i, docKeys: ['completeness contract', 'non implementato'] },


### PR DESCRIPTION
## Implementato

- Ristretto il regex del bucket `i18n-naming` in `scripts/ci/harvest-agent-lessons.mjs` da `/locale|i18n|translat|canton-?aware|naming|brand/i` (troppo largo) a difetti naming/i18n genuini: `locale segment`, `locale-prefix`, `canton-aware (slug|naming|url)`, `translated brand`, `brand…translat`, `translation key`, `missing (locale|translation)`, `untranslated`.
- Aggiunto commento esplicativo che documenta il perché del restringimento e la scelta deliberata di NON introdurre un bucket-topic sostitutivo per la translate pipeline.

### Root cause (verificata)
Escalation #2122 (`reviewer-finding/i18n-naming` ricorre nonostante regola) è un **falso positivo**. Le alternative bare `translat`/`naming`/`brand` ingoiavano l'intera pipeline di traduzione e ogni finding che menzionasse "naming" (es. ad-container naming) o "branded". Riproducendo il bucketer sui review delle PR merged nella finestra: **15 finding classificati `i18n-naming`, 0 sono difetti i18n-naming reali** (distribuzione trigger: `translat`×8, `locale`×6, `brand`×1). Cluster eterogeneo → falso `recurringDespiteRule` (count ≥ soglia×fattore) che chiedeva un gate strutturale per un pattern inesistente.

### Validazione
Replay del bucketer con la nuova taxonomy sugli stessi review:
- `i18n-naming`: **15 → 0**.
- I finding translate si ridistribuiscono nei bucket di processo genuini (`pr-body-contract` 9→11, `sibling-class-fix` 5→6, `unvalidated-claim`) — quei bucket hanno già automazione strutturale (`pr-body-contract.yml`, `check-sibling-patterns.mjs`).
- I residui cadono nel fingerprint safety-net e **non** clusterizzano (max 2 < soglia 3) → nessun nuovo escalation spurio.
- I difetti i18n-naming REALI restano coperti: il regex ristretto mantiene `locale segment`/`canton-aware slug` ecc.; il gate strutturale dedicato `check-hardcoded-locale-segments.mjs` (da escalation passata #1529) è già attivo.
- `node --check` OK.

## Non implementato (ancora)

- `.github/workflows/lessons-harvester.yml` (flaggato da `check-sibling-patterns` per il token condiviso `recurringDespiteRule`): **non toccato di proposito** — il file cita `recurringDespiteRule` solo nella prosa del prompt che descrive l'output del harvester, NON duplica il regex/taxonomy né la logica di bucketing. Falso positivo del candidate-surfacer euristico (token condiviso ≠ stesso antipattern); nessun antipattern gemello da sweepare.
- Nessun bucket-topic `translate-pipeline` aggiunto: un catch-all per `relocalize|deepl|retranslat|…` ricreerebbe lo stesso problema di over-clustering (10 finding eterogenei) e farebbe scattare un nuovo `recurringDespiteRule` falso. I finding translate sono process-failure genuini e vanno nei loro bucket.

Closes #2122

🤖 Generated with [Claude Code](https://claude.com/claude-code)