### PR TITLE
fix(seo-gates): mirror deploy data-prep so cathedral build fits runner RAM (#2121)

### DIFF
--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -67,13 +67,48 @@ jobs:
       - name: Assemble jobs dataset
         run: node scripts/assemble-jobs-dataset.mjs --stats
 
+      # ── Pre-build data prep — MUST mirror deploy.yml's build job ──────────
+      # The gates audit `dist/`, so this workflow has to emit the SAME dist
+      # deploy.yml ships. deploy dedups + migrates + cleans the dataset BEFORE
+      # build:ci; this workflow used to skip that and build the raw assembled
+      # dataset, which (a) audited a dist that never deploys — wrong gate
+      # inputs (duplicate job titles, stale sitemap entries, unmigrated
+      # canonicals) — and (b) emitted ~920 extra (cross-crawler duplicate /
+      # expired) job pages × 4 locales, pushing the full SEO build past the
+      # 16 GB runner's RAM → OOM (exit 134) before the gates step ran (issue
+      # #2121). deploy.yml builds the deduped set (≈11.2k jobs) and fits;
+      # building the raw set (≈12.1k) does not. Steps below are the
+      # page-shaping subset of deploy.yml's build job, in the same order.
+      # Keep in sync with deploy.yml. None require secrets.
+      - name: Housekeeping (cross-crawler dedup + locale hardening)
+        env:
+          JOBS_SKIP_URL_VALIDATION: '1'
+        run: node scripts/cleanup-jobs.mjs
+
+      - name: Refresh weekly-employers footer link list
+        run: node scripts/refresh-weekly-employers-top-pairs.mjs
+
+      - name: Mine all job slugs for comprehensive 404 coverage
+        run: node scripts/mine-all-job-slugs.mjs
+
+      - name: Canton-aware migration of slug registry
+        run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+
+      - name: Cleanup stale news sitemap entries
+        run: node scripts/cleanup-news-sitemap.mjs
+
       - name: Build dist (full SEO output)
         env:
           # Critical: this workflow MUST run with every SEO plugin enabled.
           # Inheriting FAST_BUILD=1 from .claude/settings.json would silently
           # skip half the SEO landings (see CLAUDE.md "FAST_BUILD trap").
           FAST_BUILD: ''
-          NODE_OPTIONS: '--max-old-space-size=18432'
+          # No NODE_OPTIONS override here: `build:ci` sets its own inline
+          # `--max-old-space-size=12288 --expose-gc`, which REPLACES any value
+          # exported from the workflow env (npm-script inline assignment wins).
+          # The previous `18432` here was dead config — silently overridden to
+          # 12288 — and 18 GB exceeds the 16 GB runner's RAM anyway. deploy.yml
+          # builds the same dist at 12288 with no override; matching that.
         run: |
           set -euo pipefail
           npm run build:ci &

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -107,8 +107,22 @@ jobs:
           # `--max-old-space-size=12288 --expose-gc`, which REPLACES any value
           # exported from the workflow env (npm-script inline assignment wins).
           # The previous `18432` here was dead config — silently overridden to
-          # 12288 — and 18 GB exceeds the 16 GB runner's RAM anyway. deploy.yml
-          # builds the same dist at 12288 with no override; matching that.
+          # 12288 — and 18 GB exceeds the 16 GB runner's RAM anyway.
+          #
+          # The two knobs below are deploy.yml's documented OOM controls
+          # (deploy.yml:481 + :532, build OOM #1290) — they cap the DOMINANT
+          # memory term, not the dataset size. deploy fits the full SEO build
+          # at 12288 BECAUSE of these; the dedup prep above is a smaller,
+          # complementary reduction. Keep both in sync with deploy.yml.
+          #
+          # Cap the post-walk worker pool so it doesn't structured-clone the
+          # full ~247K-path list into cpus()-many workers at once (the #1290
+          # blowup). Output-identical — only fewer parallel workers.
+          POST_WALK_WORKERS: '2'
+          # Force sequential plugin closeBundle: peak heap = max(single plugin)
+          # instead of Σ(overlap) → eliminates the parallel-build OOM. Always
+          # sequential here (scheduled/dispatch gate run, never parallel).
+          SEQUENTIAL_PROFILE: '1'
         run: |
           set -euo pipefail
           npm run build:ci &


### PR DESCRIPTION
Closes #2121

## Implementato
- \`cathedral-seo-gates-check.yml\`: aggiunti 5 step di **pre-build data prep** tra "Assemble jobs dataset" e "Build dist", che rispecchiano la build job di \`deploy.yml\` (stesso ordine): \`cleanup-jobs.mjs\` (dedup cross-crawler, \`JOBS_SKIP_URL_VALIDATION=1\`), \`refresh-weekly-employers-top-pairs.mjs\`, \`mine-all-job-slugs.mjs\`, \`migrate-all-known-job-slugs-canton-aware.mjs\`, \`cleanup-news-sitemap.mjs\`. → gate auditano lo stesso dist deployato (no titoli job duplicati, sitemap stale, canonical non migrati).
- **Aggiunti i due controlli OOM di build-env di \`deploy.yml\` allo step Build**: \`POST_WALK_WORKERS: '2'\` (deploy.yml:481 — evita di clonare la lista ~247K path in cpus()-many worker, build OOM #1290) e \`SEQUENTIAL_PROFILE: '1'\` (deploy.yml:532 — closeBundle sequenziale → peak heap = max(single plugin) invece di Σ(overlap)). **Questi cappano il termine di memoria DOMINANTE** — la dedup (−920 job) è una riduzione complementare minore.
- Rimosso il \`NODE_OPTIONS: '--max-old-space-size=18432'\` morto dallo step Build: \`build:ci\` imposta inline \`--max-old-space-size=12288 --expose-gc\`, che **sostituisce** qualsiasi NODE_OPTIONS dell'env del workflow (assegnazione inline npm-script vince); 18 GB superano comunque i 16 GB di RAM del runner.

### Root cause (issue #2121)
Lo step "Build dist (full SEO output)" andava in **OOM (exit 134, JS heap)** prima dello step gates → nessun verdict file → workflow rosso → auto-issue. Fallito a OGNI run recente (05-25 ×4, 06-01, 06-15).

\`deploy.yml\` builda lo stesso dist sullo stesso \`ubuntu-latest\` senza OOM perché (a) deduplica/migra il dataset prima della build **e** (b) setta \`POST_WALK_WORKERS=2\` + \`SEQUENTIAL_PROFILE=1\` nell'env di Build (i controlli OOM documentati di #1290). Cathedral non replicava **né** (a) né (b) → buildava il dataset grezzo (~12.1k job vs ~11.2k) con worker-pool e closeBundle paralleli → picco heap oltre i 16 GB. Era anche un **bug di correttezza**: i gate auditavano un dist mai deployato.

Fix: replicare sia la data-prep sia i controlli build-env di deploy → cathedral builda lo **stesso identico input + stessa build-env** che deploy prova a far stare in RAM con successo.

### Validazione
- Misurato delta dedup locale: \`assemble\` → 12101 job; dopo \`cleanup-jobs.mjs\` → 11181 (−920).
- I 5 script eseguiti in locale: tutti exit 0, **nessun credential Firebase nell'env** → smentisce empiricamente il rischio "init segreto transitivo" (adversarial #1). Conferma statica: i loro import lib (\`validate-job-url\`, \`dedicated-crawler-common\`, \`compat-paths-floor-guard\`, \`auditReport\`) NON sono tra i moduli che usano firebase-admin/Firestore; e \`JOBS_SKIP_URL_VALIDATION=1\` salta del tutto il path \`validate-job-url\`.
- YAML valido.

## Non implementato (ancora)
- **OOM-fit non validabile pre-merge** (la full SEO build OOMa/è troppo lenta in locale; non riproducibile sul \`pull_request\`; nessun peak-RSS misurato sul runner cathedral — adversarial #2/#3). L'argomento è ora strutturale e completo: cathedral replica **input + build-env** di \`deploy.yml\` (data-prep dedup **+** \`POST_WALK_WORKERS=2\` + \`SEQUENTIAL_PROFILE=1\`), la stessa combinazione con cui deploy fitta a 12288 (run 27528505424 success oggi). **Revert-trigger:** se il prossimo run di \`cathedral-seo-gates-check\` OOMa ancora (exit 134 nello step Build) → revert + escalation (ridurre ulteriormente il working set o spostare i gate su replay da artifact). Live test post-merge: \`gh workflow run cathedral-seo-gates-check.yml --ref main\`.
- **\`generate-image-thumbnails.mjs\` NON aggiunto** (deploy lo ha): non cambia né il conteggio pagine né gli input dei 6 gate (\`image-object-license\` legge lo structured-data nell'HTML, non i file thumbnail). Out of scope.
- **\`audit:active-jobs-regression\` / wipe-stale-trees / Free disk space NON aggiunti**: gate di deploy (active-jobs ha baseline propria), no-op su runner fresco (wipe), o problema di disco non osservato (free-disk; il fallimento è RAM non ENOSPC). Out of scope.
- **Sibling \`JOBS_SKIP_URL_VALIDATION\`** (\`cleanup-stale-jobs.yml\`, \`deploy.yml\`, \`cleanup-jobs.mjs\`, \`shared-jobs-crawler.mjs\`): flaggati da \`check-sibling-patterns.mjs\` come token condiviso, **non** antipattern condiviso — uso la flag esattamente come deploy.yml/cleanup-stale-jobs.yml. Nessun fix necessario.
- **Estrazione del data-prep + build-env in step/script condiviso** (anti-drift deploy↔cathedral): posposta — i 5 step + i 2 knob sono documentati con "Keep in sync with deploy.yml"; un'estrazione toccherebbe \`deploy.yml\` (workflow più critico) ed è un refactor a sé. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)