### PR TITLE
fix(test): short-circuit hreflang-x-default dist walk to stop the validate-dist timeout

### DIFF
--- a/tests/seo/breadcrumb-coverage.test.ts
+++ b/tests/seo/breadcrumb-coverage.test.ts
@@ -64,24 +64,26 @@ function walkHtml(dir: string): string[] {
   const stack: string[] = [dir];
   while (stack.length) {
     const cur = stack.pop() as string;
-    let entries: string[];
+    let entries: import('node:fs').Dirent[];
     try {
-      entries = readdirSync(cur);
+      // withFileTypes → one readdir syscall per dir instead of readdir + a
+      // statSync per entry. validate-dist rehydrates the locale shards into
+      // dist (~2M files); the old per-entry statSync doubled the syscall count
+      // on the whole tree and was the heaviest unbounded full-dist walk in
+      // gate:seo-source. This test must read EVERY indexable page (it asserts
+      // breadcrumb coverage across all of dist), so it cannot be sampled like
+      // cathedral-hreflang-x-default — the win here is a leaner walk, not a
+      // smaller sample. Coverage is byte-for-byte unchanged.
+      entries = readdirSync(cur, { withFileTypes: true });
     } catch {
       continue;
     }
-    for (const name of entries) {
-      const full = join(cur, name);
-      let st;
-      try {
-        st = statSync(full);
-      } catch {
-        continue;
-      }
-      if (st.isDirectory()) {
-        if (name === 'assets' || name === 'node_modules') continue;
+    for (const ent of entries) {
+      const full = join(cur, ent.name);
+      if (ent.isDirectory()) {
+        if (ent.name === 'assets' || ent.name === 'node_modules') continue;
         stack.push(full);
-      } else if (st.isFile() && full.endsWith('.html')) {
+      } else if (ent.isFile() && full.endsWith('.html')) {
         out.push(full);
       }
     }

--- a/tests/seo/cathedral-hreflang-x-default.test.ts
+++ b/tests/seo/cathedral-hreflang-x-default.test.ts
@@ -4,26 +4,36 @@ import * as path from 'node:path';
 
 const DIST = path.resolve(__dirname, '../../dist');
 
-function walkHtml(dir: string, out: string[] = []): string[] {
-  if (!fs.existsSync(dir)) return out;
+// Bounded sample size — large enough to catch regressions across the early
+// emitters without walking the whole tree.
+const SAMPLE_LIMIT = 1500;
+
+// Walk dist for .html files but STOP as soon as `limit` are collected. The
+// previous impl walked the ENTIRE tree and only THEN sliced to 1500 — fine when
+// dist was small, but after the cathedral + locale-shard expansion dist holds
+// ~2M files (locale shards are rehydrated into dist for validate-dist), so
+// enumerating all of them blew the 60s ceiling and the test TIMED OUT (gate:
+// seo-source red, no assertion ever reached). Short-circuiting yields the SAME
+// first-N depth-first sample without the full-tree enumeration — O(limit)
+// readdir/reads instead of O(all files).
+function walkHtml(dir: string, out: string[] = [], limit = SAMPLE_LIMIT): string[] {
+  if (out.length >= limit || !fs.existsSync(dir)) return out;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (out.length >= limit) break;
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) walkHtml(full, out);
+    if (entry.isDirectory()) walkHtml(full, out, limit);
     else if (entry.name.endsWith('.html')) out.push(full);
   }
   return out;
 }
 
 describe('every page with hreflang ALSO emits x-default', () => {
-  // 60s ceiling: cathedral expansion → ~200k dist files; reading 1k of
-  // them I/O-bound takes 8-15s on cold cache. Tight default (15s) would
-  // race on slower CI runners.
+  // 60s ceiling kept as a safety margin; with the short-circuited walk the test
+  // reads only SAMPLE_LIMIT files (~seconds) regardless of total dist size.
   it('checks dist for hreflang completeness', { timeout: 60_000 }, () => {
     if (!fs.existsSync(DIST)) return;
-    // Bounded sample — large enough to catch regressions across all
-    // emitters (job-detail, hubs, landings, bridges) without walking
-    // the whole tree, which would dominate the test wall time.
-    const sample = walkHtml(DIST).slice(0, 1500);
+    // Bounded sample — the walk already stops at SAMPLE_LIMIT (see walkHtml).
+    const sample = walkHtml(DIST);
     const offenders: string[] = [];
     for (const file of sample) {
       const html = fs.readFileSync(file, 'utf-8');


### PR DESCRIPTION
## Implementato

- **Fix the `gate:seo-source` timeout that fails validate-dist** (observed in deploy run 27552065054). `tests/seo/cathedral-hreflang-x-default.test.ts` walked the **entire** dist tree and only *then* sliced the sample to 1500 files. After the cathedral + locale-shard expansion, validate-dist rehydrates the locale shards into `dist/` (~2M files), so enumerating the whole tree exceeded the 60s ceiling → the test **timed out** (`Test timed out in 60000ms`) → `gate:seo-source` red, with the assertion never reached.
- **Fix**: `walkHtml` now stops as soon as `SAMPLE_LIMIT` (1500) files are collected — O(limit) instead of O(all files). Verified (synthetic 6000-file tree) that the short-circuited walk returns a **byte-identical** first-1500 depth-first sample to the old `slice(0, 1500)`, so test coverage is unchanged; only the wasted full-tree enumeration is removed. Wall time is now ~seconds regardless of dist size; the 60s ceiling stays as a safety margin.
- Not a real hreflang regression: `renderHreflangTags` / `buildHreflangEntries` always append an `x-default` entry, so the emitters (incl. the per-canton landings) are compliant — the failure was purely the timeout.

This is the second, distinct validate-dist failure (the first — `audit:max-bfs-depth` orphan hard-fail — was fixed in #2178). Together they cover the validate-dist gate.

## Non implementato (ancora)

- **Cannot validate against the real 2M-file dist locally** (full SSG build OOMs per repo policy). The fix is verified on a synthetic tree (sample identity + short-circuit) and via `node --check`; the real assertion runs in CI vitest on this PR and post-merge in validate-dist. **If** the now-reachable assertion surfaces genuine `x-default` offenders in the first-1500 sample (none expected — all emitters use `renderHreflangTags`), that is a separate content fix, not a regression from this change.
- No revert-trigger: the change only removes wasted I/O; it cannot alter which pages are flagged (sample is identical), so it cannot mask a real regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — addressing the 🔴 on the sibling walker (`breadcrumb-coverage.test.ts`)

Reviewer correctly flagged that `breadcrumb-coverage.test.ts` runs the **same unbounded full-dist walk** in `gate:seo-source` (heavier — it `readFileSync`s every indexable page). Resolution in the latest commit:

- **It cannot be sampled** like `cathedral-hreflang` (it must assert breadcrumb coverage across *all* indexable pages — sampling would let a missing-breadcrumb page slip the gate). Instead its **walk is made lean**: `readdirSync({ withFileTypes: true })` drops the per-entry `statSync` (1 syscall/entry instead of 2 across ~2M files). Coverage byte-for-byte unchanged.
- **Measured-run confirmation it completes under the 2M dist**: in the exact `gate:seo-source` run this PR targets (deploy **27552065054**), `breadcrumb-coverage` was among the **734 passing** tests — the *only* failure was `cathedral-hreflang-x-default` (full walk inside a 60s `it()`). 
- **No other time-bomb**: audited the remaining unguarded `tests/seo/` full-dist walkers — none walk inside a tight `it()` timeout (only `cathedral-hreflang` did), and all passed in that same run. So `cathedral-hreflang` was the sole gate-blocker; this PR + the lean breadcrumb walk make `gate:seo-source` green without weakening any check.
