### PR TITLE
fix(ai-models): prune dead models (NVIDIA 404, CF Gemma-3 deprecated) + filter wrong-type NVIDIA discovery

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -225,8 +225,8 @@ export const AI_MODELS = Object.freeze({
   FW_MIXTRAL_8X7B: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
 
   // ── NVIDIA NIM (OpenAI-compatible, free tier inference) ──
-  NV_NEMOTRON_70B:   'nvidia/nvidia/llama-3.1-nemotron-70b-instruct',   // API: nvidia/llama-3.1-nemotron-70b-instruct
-  NV_NEMOTRON_49B:   'nvidia/nvidia/llama-3.3-nemotron-super-49b-v1',   // API: nvidia/llama-3.3-nemotron-super-49b-v1
+  // NV_NEMOTRON_70B removed — NVIDIA NIM HTTP 404 "Not Found for account" (2026-06-15, run 27544487773). No longer served on this NVIDIA account; was already out of DEFAULT_CHAIN (see "NV_NEMOTRON_70B removed" comment in the chain). The bare-"nemotron" token in NVIDIA_ALLOW_FAMILY_RE was re-injecting it via discovery, so a dead static id here is moot, but removing it keeps the catalog honest.
+  // NV_NEMOTRON_49B removed — NVIDIA NIM HTTP 404 "Not Found for account" (2026-06-15, run 27544487773). No longer served on this NVIDIA account. Dropped from DEFAULT_CHAIN in the same change.
   NV_LLAMA_3_1_8B:   'nvidia/meta/llama-3.1-8b-instruct',
   // NV_PHI_3_MINI removed — NVIDIA NIM HTTP 404 "404 page not found" (2026-05-18)
   HF_MISTRAL_7B:   'hf/mistralai/Mistral-7B-Instruct-v0.3',
@@ -261,7 +261,7 @@ export const AI_MODELS = Object.freeze({
   CF_QWEN3_30B:        'cf/@cf/qwen/qwen3-30b-a3b-fp8',
   CF_GPT_OSS_120B:     'cf/@cf/openai/gpt-oss-120b',
   CF_GPT_OSS_20B:      'cf/@cf/openai/gpt-oss-20b',
-  CF_GEMMA_3_12B:      'cf/@cf/google/gemma-3-12b-it',
+  // CF_GEMMA_3_12B removed — Cloudflare Workers AI HTTP 400 "Model has been deprecated: This model was deprecated on 2026-05-30." (2026-06-15, run 27544487773). OpenRouter mirror OR_GEMMA_3_12B remains available.
   CF_GLM_47_FLASH:     'cf/@cf/zai-org/glm-4.7-flash',
   // CF_DEEPSEEK_R1_32B removed — Cloudflare HTTP 400 "No such model @cf/deepseek/deepseek-r1-distill-qwen-32b" (2026-05-18)
   // CF_GEMMA_4_26B removed — returns empty responses (model loads but won't generate, 2026-04)
@@ -446,7 +446,7 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.MISTRAL_8B,         // 65. Ministral 8B latest    (Mistral AI direct)
   AI_MODELS.OR_DOLPHIN_24B,     // 66. Dolphin Mistral 24B     (OpenRouter free — replaces Mistral Nemo)
   // OR_MISTRAL_NEMO removed from OpenRouter free list (2026-04)
-  AI_MODELS.CF_GEMMA_3_12B,     // 67. Gemma 3 12B             (Cloudflare Workers AI)
+  // CF_GEMMA_3_12B removed — Cloudflare Workers AI HTTP 400 "Model has been deprecated: This model was deprecated on 2026-05-30." (2026-06-15, run 27544487773); OR_GEMMA_3_12B mirror still in chain
   AI_MODELS.CB_LLAMA_3_1_8B,    // 68. Llama 3.1 8B           (Cerebras - ultra fast)
   // TGT_QWEN_2_5_7B removed — Together AI HTTP 401 (account unauthorized 2026-03)
   // TGT_MISTRAL_7B removed — Together AI HTTP 401 (account unauthorized 2026-03)
@@ -454,7 +454,7 @@ export const DEFAULT_CHAIN = [
   // FW_MIXTRAL_8X7B removed — Fireworks AI HTTP 404 (model not found 2026-03)
   // NV_NEMOTRON_70B removed — NVIDIA NIM HTTP 404 (model not found 2026-03)
   AI_MODELS.CF_GLM_47_FLASH,    // 69. GLM 4.7 Flash           (Cloudflare Workers AI)
-  AI_MODELS.NV_NEMOTRON_49B,     // 70. Nemotron 49B           (NVIDIA NIM direct)
+  // NV_NEMOTRON_49B removed — NVIDIA NIM HTTP 404 "Not Found for account" (2026-06-15, run 27544487773); no longer served on this NVIDIA account
   AI_MODELS.NV_LLAMA_3_1_8B,    // 71. Llama 3.1 8B           (NVIDIA NIM)
   // AI_MODELS.NV_PHI_3_MINI removed — NVIDIA NIM HTTP 404 "404 page not found" (2026-05-18)
   // AI_MODELS.CF_DEEPSEEK_R1_32B removed — Cloudflare HTTP 400 "No such model @cf/deepseek/deepseek-r1-distill-qwen-32b" (2026-05-18)
@@ -978,7 +978,13 @@ function _decayScore(score, lastUsedISO) {
  * and isolates providers so one failure can't block the others.
  * Call from initScoreStore() (or before the first callLLM()).
  */
-const NON_CHAT_MODEL_RE = /whisper|tts|text-to-speech|\bspeech\b|\baudio\b|embed|moderation|guard|\bocr\b|playai|rerank|reranking|stable-diffusion|sdxl|\bflux\b|nemoretriever/i;
+// `reward` / `parse` added 2026-06-15 (run 27544487773): NVIDIA discovery was
+// auto-injecting nvidia/nemotron-4-340b-reward (a REWARD model → HTTP 404 + wrong
+// type) and nvidia/nemotron-parse (a DOCUMENT PARSER → HTTP 400 "Content cannot be
+// a plain string. The model does not support text input."). Both matched the bare
+// "nemotron" token in NVIDIA_ALLOW_FAMILY_RE but are not chat models. `embed` /
+// `rerank` (the other non-chat types) were already covered above.
+const NON_CHAT_MODEL_RE = /whisper|tts|text-to-speech|\bspeech\b|\baudio\b|embed|moderation|guard|\bocr\b|playai|rerank|reranking|\breward\b|\bparse\b|stable-diffusion|sdxl|\bflux\b|nemoretriever/i;
 
 // NVIDIA's /v1/models lists its ENTIRE historical NIM catalog with no
 // free/served flag, and the bulk of it (legacy + vision + code-only families:


### PR DESCRIPTION
## Implementato

Pruned genuinely-DEAD models from the multi-provider cascade in `scripts/lib/ai-models.mjs`, following the file's established `// NAME removed — <reason> (date, run)` convention. All errors observed live in translate-pending run **27544487773** (relocalize-pending-jobs → shared-jobs-crawler AI localization). These dead models wasted a fallback attempt per job before falling through to the MT cascade.

- **`NV_NEMOTRON_70B`** (`nvidia/nvidia/llama-3.1-nemotron-70b-instruct`) — NVIDIA NIM HTTP 404 "Not Found for account". Static entry → removal comment. (Was already out of `DEFAULT_CHAIN`.)
- **`NV_NEMOTRON_49B`** (`nvidia/nvidia/llama-3.3-nemotron-super-49b-v1`) — NVIDIA NIM HTTP 404 "Not Found for account". Removed both the static entry AND its `DEFAULT_CHAIN` slot (#70).
- **`CF_GEMMA_3_12B`** (`cf/@cf/google/gemma-3-12b-it`) — Cloudflare Workers AI HTTP 400 "Model has been deprecated: This model was deprecated on 2026-05-30." Removed both the static entry AND its `DEFAULT_CHAIN` slot (#67). The OpenRouter mirror `OR_GEMMA_3_12B` remains in the chain.
- **Discovery filter fix** — added `\breward\b` and `\bparse\b` to `NON_CHAT_MODEL_RE` so NVIDIA auto-discovery no longer re-injects wrong-TYPE models that match the bare `nemotron` token in `NVIDIA_ALLOW_FAMILY_RE`:
  - `nvidia/nemotron-parse` (a DOCUMENT PARSER → HTTP 400 "Content cannot be a plain string. The model does not support text input.")
  - `nvidia/nemotron-4-340b-reward` (a REWARD model → HTTP 404 + wrong type)
  - `*-embed*` / `*-rerank*` were already covered by `NON_CHAT_MODEL_RE`; this completes the wrong-type exclusion set requested.

No external references to the removed constants exist (grep across `scripts/`, `services/`, `build-plugins/` → only `ai-models.mjs` itself referenced them; consumers use the centralized `AI_MODELS`/`DEFAULT_CHAIN` exports, so removal propagates automatically). The `NON_CHAT_MODEL_RE` / `NVIDIA_ALLOW_FAMILY_RE` regexes live only in `ai-models.mjs` (single source of truth, no copy-paste sibling to keep in sync).

## Non implementato (ancora)

- **Live effect is unvalidatable pre-merge.** The win (fewer wasted retries per job → faster localization) only shows on the next `relocalize-pending-jobs` / `translate-pending` run against the live providers; the `pull_request` cannot exercise the real NVIDIA/Cloudflare endpoints. No revert-trigger needed — this is a pure dead-id prune (the removed models already 404/400'd), so worst case is the prior behaviour minus the dead attempts.
- **Payload-size failures NOT addressed (out of scope).** Models that fail only on TPM "Request too large" / context-length-too-small (groq `qwen3-32b`, `gpt-oss-20b`, `nemotron-mini-4b`) are left in the chain — they work for normal-size inputs and removing them would lose capacity. A safe oversized-payload skip for small-context models is plausible but would be its own change (needs per-model context-window metadata wiring); not over-engineered here.
- **`nvidia/nemotron-4-340b-instruct` / `nemotron-ultra-253b-v1` left discoverable.** These are valid CHAT-type ids that currently 404 ("Not Found for account"); they are NOT static entries, only discovery-injected, and the runtime 404/skip path handles them. If NVIDIA re-serves them on this account they'll work — so filtering them by name would be wrong (they're the right type, just unavailable today).
- **Azure invalid-key + DeepL-exhaustion are SEPARATE issues, out of scope** for this dead-model prune.
- **Sibling sweep:** `node scripts/ci/check-sibling-patterns.mjs` surfaced 10 candidates sharing `AI_MODELS`/`DEFAULT_CHAIN`/`OpenRouter` tokens (smoke-test, create-article, shared-jobs-crawler, etc.). Confirmed by grep that none hardcode the removed constants or their raw model ids — they all consume the centralized exports, so there is no sibling antipattern to fix.

## Test plan

- [x] `node --check scripts/lib/ai-models.mjs` — syntax OK
- [x] Dynamic import smoke test: `NV_NEMOTRON_70B` / `NV_NEMOTRON_49B` / `CF_GEMMA_3_12B` absent from `AI_MODELS`; their ids absent from `DEFAULT_CHAIN` (length 102)
- [x] NVIDIA `pick()` filter: rejects `nemotron-parse`, `nemotron-4-340b-reward`, `nemotron-embed-1b`, `nv-rerankqa-*`; keeps `llama-3.3-nemotron-super-49b-v1` and `nemotron-4-340b-instruct`
- [x] `npx vitest run` on all 7 ai-models / discovery / classifier tests → **53 passed** (incl. `ai-models-nvidia-discovery-allowlist.test.ts`)
- [x] `node scripts/ci/check-sibling-patterns.mjs` → candidates reviewed, none share the antipattern (see Non implementato)
- [ ] Post-merge: next `relocalize-pending-jobs` / `translate-pending` run shows fewer dead-model fallback attempts per job (live-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)