### PR TITLE
fix(harvest): stop already-fixed feedback-loop + broaden pre-flight gate (#2123)

### DIFF
--- a/scripts/ci/check-issue-already-resolved.mjs
+++ b/scripts/ci/check-issue-already-resolved.mjs
@@ -238,11 +238,19 @@ ${OUTCOME}`;
   // cannot see (it reads file content, not PR cross-refs). Proceed-safe: if the PR list is
   // unreadable/unparseable we skip this signal and fall through to the token matcher.
   let closer = null;
+  const MERGED_PR_LIMIT = 50;
   try {
     const mergedPrs = JSON.parse(
-      gh(['pr', 'list', '--state', 'merged', '--search', `#${ISSUE}`, ...repoArgs,
-          '--json', 'number,title,body', '--limit', '30'], { allowFail: true }) || '[]',
+      gh(['pr', 'list', '--state', 'merged', '--search', `#${ISSUE} in:body,title`, ...repoArgs,
+          '--json', 'number,title,body', '--limit', String(MERGED_PR_LIMIT)], { allowFail: true }) || '[]',
     );
+    // Coverage cap (proceed-safe but worth surfacing): if the search saturates the
+    // limit, a declaring PR older than the 50 most-recent hits is missed → SIGNAL 1
+    // silently falls through to the token matcher / fixer. Direction is safe (never a
+    // false short-circuit), but log it so the cap isn't invisible (reviewer adv #3).
+    if (mergedPrs.length >= MERGED_PR_LIMIT) {
+      console.log(`Issue #${ISSUE}: merged-PR search hit the ${MERGED_PR_LIMIT}-result cap — a declaring PR beyond it would be missed by SIGNAL 1 (proceed-safe).`);
+    }
     closer = closingMergedPr(ISSUE, mergedPrs);
   } catch { closer = null; }
   if (closer) {

--- a/scripts/ci/check-issue-already-resolved.mjs
+++ b/scripts/ci/check-issue-already-resolved.mjs
@@ -54,7 +54,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { detectAlreadyResolved } from './followup-resolution-match.mjs';
+import { detectAlreadyResolved, closingMergedPr } from './followup-resolution-match.mjs';
 
 const DRY_RUN = process.env.DRY_RUN === '1';
 const ISSUE = process.env.ISSUE_NUMBER;
@@ -210,6 +210,52 @@ function main() {
     return;
   }
 
+  // Side-effects shared by every short-circuit path: advisory comment (with a
+  // signal-specific `reason` line), drop `agent:fix` (no re-dispatch), tag
+  // `maybe-resolved`. Never closes the issue — human confirms (FOLLOWUP.md).
+  function shortCircuit(reason, evidenceMd) {
+    if (!DRY_RUN) {
+      const comment = `${MARKER}
+${reason}
+${evidenceMd ? `\n${evidenceMd}\n` : ''}
+Rimossa la label \`agent:fix\` (no re-dispatch). **Non chiudo** la issue: verifica e chiudi a mano se lo scope è davvero coperto; se invece il fix serve ancora, ri-aggiungi \`agent:fix\`. Gate strutturale #1647.
+
+${OUTCOME}`;
+      gh(['issue', 'comment', ISSUE, ...repoArgs, '--body', comment], { allowFail: true });
+      // Remove agent:fix so the fixer is not re-dispatched; add maybe-resolved advisory.
+      gh(['issue', 'edit', ISSUE, ...repoArgs, '--remove-label', 'agent:fix'], { allowFail: true });
+      gh(['label', 'create', LABEL, '--color', 'c5def5',
+          '--description', 'Reconcile bot: cited code present in file — likely done-but-open',
+          ...repoArgs], { allowFail: true });
+      gh(['issue', 'edit', ISSUE, ...repoArgs, '--add-label', LABEL], { allowFail: true });
+    }
+    setOutput(true);
+  }
+
+  // SIGNAL 1 (explicit declaration): a MERGED PR names this issue with a closing/supersede
+  // keyword. Catches the multi-issue `Closes #a #b #c` gotcha (GitHub closes only #a → the
+  // rest stay open) and `Supersedes #N`, which the verbatim-token matcher structurally
+  // cannot see (it reads file content, not PR cross-refs). Proceed-safe: if the PR list is
+  // unreadable/unparseable we skip this signal and fall through to the token matcher.
+  let closer = null;
+  try {
+    const mergedPrs = JSON.parse(
+      gh(['pr', 'list', '--state', 'merged', '--search', `#${ISSUE}`, ...repoArgs,
+          '--json', 'number,title,body', '--limit', '30'], { allowFail: true }) || '[]',
+    );
+    closer = closingMergedPr(ISSUE, mergedPrs);
+  } catch { closer = null; }
+  if (closer) {
+    console.log(`Issue #${ISSUE}: MERGED PR #${closer} explicitly closes/supersedes it (done-but-open) → short-circuit, skip Claude fixer.`);
+    shortCircuit(
+      `⏭️ **Pre-flight (auto, zero-Claude)**: la PR **#${closer}** (già mergiata) dichiara esplicitamente di chiudere/superare questa issue (\`Closes\`/\`Supersedes #${ISSUE}\`) ma GitHub non l'ha auto-chiusa — probabile **done-but-open** (es. \`Closes #a #b\` multi-issue: chiude solo la prima). Salto il fixer autonomo per non sprecare quota Max OAuth.`,
+      `- dichiarata risolta da #${closer} (merged)`,
+    );
+    return;
+  }
+
+  // SIGNAL 2 (content match): every distinctive token prescribed in `Suggested action` is
+  // already present verbatim in a cited file on main.
   const { resolved, evidence } = detectAlreadyResolved(body, io);
   if (!resolved) {
     console.log('No strong already-resolved signal — proceeding (normal fixer runs).');
@@ -217,29 +263,12 @@ function main() {
     return;
   }
 
-  // STRONG signal: short-circuit.
   const ev = evidence.slice(0, 6).map((e) => `- \`${e.tok}\` già presente in \`${e.file}\``).join('\n');
   console.log(`Issue #${ISSUE}: STRONG already-resolved signal (${evidence.length} token match) → short-circuit, skip Claude fixer.`);
-
-  if (!DRY_RUN) {
-    const comment = `${MARKER}
-⏭️ **Pre-flight (auto, zero-Claude)**: i token prescritti da questa follow-up risultano **già presenti verbatim** nei file citati — probabile **already-fixed / done-but-open** (coperto da una PR successiva senza \`Closes #${ISSUE}\`). Salto il fixer autonomo per non sprecare quota Max OAuth.
-
-${ev}
-
-Rimossa la label \`agent:fix\` (no re-dispatch). **Non chiudo** la issue: verifica e chiudi a mano se lo scope è davvero coperto; se invece il fix serve ancora, ri-aggiungi \`agent:fix\`. Segnalazione deterministica (presenza verbatim del token nella regione \`Suggested action\`), gate strutturale #1647.
-
-${OUTCOME}`;
-    gh(['issue', 'comment', ISSUE, ...repoArgs, '--body', comment], { allowFail: true });
-    // Remove agent:fix so the fixer is not re-dispatched; add maybe-resolved advisory.
-    gh(['issue', 'edit', ISSUE, ...repoArgs, '--remove-label', 'agent:fix'], { allowFail: true });
-    gh(['label', 'create', LABEL, '--color', 'c5def5',
-        '--description', 'Reconcile bot: cited code present in file — likely done-but-open',
-        ...repoArgs], { allowFail: true });
-    gh(['issue', 'edit', ISSUE, ...repoArgs, '--add-label', LABEL], { allowFail: true });
-  }
-
-  setOutput(true);
+  shortCircuit(
+    `⏭️ **Pre-flight (auto, zero-Claude)**: i token prescritti da questa follow-up risultano **già presenti verbatim** nei file citati — probabile **already-fixed / done-but-open** (coperto da una PR successiva senza \`Closes #${ISSUE}\`). Salto il fixer autonomo per non sprecare quota Max OAuth.`,
+    ev,
+  );
 
   if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(

--- a/scripts/ci/followup-resolution-match.mjs
+++ b/scripts/ci/followup-resolution-match.mjs
@@ -122,6 +122,45 @@ export function citedTokens(body) {
 }
 
 /**
+ * Explicit cross-reference signal: is this issue declared resolved by a MERGED PR?
+ *
+ * Orthogonal to the token matcher (which reads file CONTENT). Here the signal is a human/
+ * agent DECLARATION: a merged PR whose title/body names this issue on a line that also
+ * carries a closing/supersede keyword (`Closes`/`Fixes`/`Resolves`/`Supersedes #N`). This
+ * catches two done-but-open classes the verbatim-token matcher structurally cannot:
+ *   1. The multi-issue `Closes #a #b #c` gotcha (AGENTS.md): GitHub auto-closes ONLY the
+ *      first issue after a closing keyword, so `#b`/`#c` stay OPEN despite being declared
+ *      done in the merged PR (PR #1320: 9 issues on one line → 8 left open, manual cleanup).
+ *   2. `Supersedes #N` — deliberately non-auto-closing by GitHub, but an explicit "this PR
+ *      makes the issue moot" declaration.
+ *
+ * SAFE / bias-to-PROCEED: this is an EXPLICIT author declaration, not a content heuristic —
+ * far stronger than a coincidental token hit, and the caller still only short-circuits to an
+ * advisory `maybe-resolved` (never auto-closes; human confirms). A merged PR is required
+ * (a closed-unmerged PR's `Closes` is void). The `#N(?!\d)` guard prevents `#2035` matching
+ * `#20350`; requiring a keyword on the SAME line avoids bare `Related: #N` mentions.
+ *
+ * Pure: the caller injects the merged-PR list (the gate fetches it via `gh pr list`).
+ *
+ * @param {number|string} issueNumber
+ * @param {Array<{number?: number, title?: string, body?: string}>} mergedPrs
+ * @returns {number|null}  the declaring PR number, or null
+ */
+export function closingMergedPr(issueNumber, mergedPrs) {
+  const n = Number(issueNumber);
+  if (!Number.isInteger(n) || n <= 0 || !Array.isArray(mergedPrs)) return null;
+  const ref = new RegExp(`#${n}(?!\\d)`);
+  const kw = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|supersede[sd]?)\b/i;
+  for (const pr of mergedPrs) {
+    const text = `${pr?.title || ''}\n${pr?.body || ''}`;
+    for (const line of text.split('\n')) {
+      if (ref.test(line) && kw.test(line)) return pr?.number ?? null;
+    }
+  }
+  return null;
+}
+
+/**
  * Core resolution check: does the cited file's CURRENT content already contain the
  * prescribed fix? Pure — the caller injects file access.
  *

--- a/scripts/ci/followup-resolution-match.mjs
+++ b/scripts/ci/followup-resolution-match.mjs
@@ -149,12 +149,20 @@ export function citedTokens(body) {
 export function closingMergedPr(issueNumber, mergedPrs) {
   const n = Number(issueNumber);
   if (!Number.isInteger(n) || n <= 0 || !Array.isArray(mergedPrs)) return null;
-  const ref = new RegExp(`#${n}(?!\\d)`);
-  const kw = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|supersede[sd]?)\b/i;
+  // Match a closing keyword IMMEDIATELY followed by a run of issue refs separated
+  // ONLY by separators (whitespace / comma / `&` / "and") — the multi-issue
+  // `Closes #a #b #c` (and `Closes #a, #b and #c`) shape. Requiring the ref to be
+  // part of that unbroken keyword-anchored list (not merely on the same line)
+  // rejects `Fixes #8 and touches #N`: the word "touches" breaks the run, so #N
+  // is NOT in the closing list (reviewer adversarial #1/#2 — a same-line match
+  // would have false-flagged it and dropped a legit agent:fix). The exact `#${n}`
+  // string compare also makes the `#2035` vs `#20350` guard fall out for free.
+  const kwList = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|supersede[sd]?)\b\s*:?\s*((?:#\d+(?:[\s,&]+(?:and\s+)?)?)+)/ig;
   for (const pr of mergedPrs) {
     const text = `${pr?.title || ''}\n${pr?.body || ''}`;
-    for (const line of text.split('\n')) {
-      if (ref.test(line) && kw.test(line)) return pr?.number ?? null;
+    for (const m of text.matchAll(kwList)) {
+      const refs = (m[1] || '').match(/#\d+/g) || [];
+      if (refs.includes(`#${n}`)) return pr?.number ?? null;
     }
   }
   return null;

--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -176,6 +176,19 @@ for (const { number } of fixIssues.slice(0, MAX_ISSUES)) {
     // Counting them inflates no-pr-unspecified → feedback loop: escalation keeps
     // re-firing even after the backstop fix (PR #1067) landed.
     if (String(c.body || '').includes('post-step deterministico')) continue;
+    // SAME feedback-loop, `already-fixed` flavour: the zero-Claude pre-flight gate
+    // (check-issue-already-resolved.mjs, structural fix #1647) and the scheduled
+    // reconciler (reconcile-followups.mjs) BOTH post `<!-- FIX_OUTCOME: already-fixed -->`
+    // when they short-circuit a done-but-open follow-up WITHOUT ever spending a Claude
+    // run. Counting those as burn makes the structural fix re-escalate ITSELF (#2123:
+    // bucket re-fired at 10/14d even though the gate had already shipped). Only a
+    // marker from a genuine Claude fixer run is recurring-burn signal → skip the
+    // deterministic short-circuit comments (carry the `<!-- reconcile-bot -->` marker
+    // and the "Pre-flight (auto, zero-Claude)" / "Reconcile (auto)" signature).
+    const cb = String(c.body || '');
+    if (cb.includes('reconcile-bot') ||
+        cb.includes('Pre-flight (auto, zero-Claude)') ||
+        cb.includes('Reconcile (auto)')) continue;
     const k = `fix-outcome:${code}`;
     if (seenThisIssue.has(k)) continue;
     seenThisIssue.add(k);

--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -281,6 +281,19 @@ async function main() {
       // Counting them inflates no-pr-unspecified → feedback loop: escalation keeps
       // re-firing even after the backstop fix (PR #1067) landed.
       if (String(c.body || '').includes('post-step deterministico')) continue;
+      // SAME feedback-loop, `already-fixed` flavour: the zero-Claude pre-flight gate
+      // (check-issue-already-resolved.mjs, structural fix #1647) and the scheduled
+      // reconciler (reconcile-followups.mjs) BOTH post `<!-- FIX_OUTCOME: already-fixed -->`
+      // when they short-circuit a done-but-open follow-up WITHOUT ever spending a Claude
+      // run. Counting those as burn makes the structural fix re-escalate ITSELF (#2123:
+      // bucket re-fired at 10/14d even though the gate had already shipped). Only a
+      // marker from a genuine Claude fixer run is recurring-burn signal → skip the
+      // deterministic short-circuit comments (carry the `<!-- reconcile-bot -->` marker
+      // and the "Pre-flight (auto, zero-Claude)" / "Reconcile (auto)" signature).
+      const cb = String(c.body || '');
+      if (cb.includes('reconcile-bot') ||
+          cb.includes('Pre-flight (auto, zero-Claude)') ||
+          cb.includes('Reconcile (auto)')) continue;
       const k = `fix-outcome:${code}`;
       if (seenThisIssue.has(k)) continue;
       seenThisIssue.add(k);

--- a/tests/followup-resolution-match.test.ts
+++ b/tests/followup-resolution-match.test.ts
@@ -281,12 +281,20 @@ describe('closingMergedPr (explicit done-but-open via merged PR cross-ref)', () 
     expect(closingMergedPr(7, [{ number: 9, title: 'closed #7', body: '' }])).toBe(9);
   });
 
+  it('flags a comma/`and`-separated closing list (`Closes #a, #b and #c`)', () => {
+    expect(closingMergedPr(7, [{ number: 9, body: 'Closes #5, #6 and #7' }])).toBe(9);
+  });
+
   it('does NOT flag a bare mention without a closing keyword (Related: #N)', () => {
     expect(closingMergedPr(7, [{ number: 9, body: 'Related: #7\nSee also #7 for context' }])).toBeNull();
   });
 
   it('does NOT flag when the keyword and ref are on DIFFERENT lines', () => {
     expect(closingMergedPr(7, [{ number: 9, body: 'Closes #8\nUnrelated note about #7' }])).toBeNull();
+  });
+
+  it('does NOT flag when a word breaks the ref-run (`Fixes #8 and touches #N`) — adv #2', () => {
+    expect(closingMergedPr(2123, [{ number: 9, body: 'Fixes #8 and touches #2123 in passing' }])).toBeNull();
   });
 
   it('guards against numeric prefix collisions — #2035 must not match #20350', () => {

--- a/tests/followup-resolution-match.test.ts
+++ b/tests/followup-resolution-match.test.ts
@@ -6,6 +6,7 @@ import {
   suggestedActionText,
   mostSpecificToken,
   detectAlreadyResolved,
+  closingMergedPr,
   // @ts-expect-error — plain .mjs module, no types
 } from '../scripts/ci/followup-resolution-match.mjs';
 
@@ -260,5 +261,44 @@ describe('detectAlreadyResolved (end-to-end matcher)', () => {
     expect(detectAlreadyResolved(body, {}).resolved).toBe(false);
     // @ts-expect-error — no io at all
     expect(() => detectAlreadyResolved(body, undefined)).not.toThrow();
+  });
+});
+
+describe('closingMergedPr (explicit done-but-open via merged PR cross-ref)', () => {
+  it('flags the multi-issue `Closes #a #b #c` gotcha — GitHub closed only #a, #b/#c stay open', () => {
+    const prs = [{ number: 1320, title: 'fix: x', body: 'Closes #100 #2035 #2036' }];
+    expect(closingMergedPr(2035, prs)).toBe(1320);
+    expect(closingMergedPr(2036, prs)).toBe(1320);
+  });
+
+  it('flags `Supersedes #N` (GitHub never auto-closes supersede)', () => {
+    expect(closingMergedPr(2031, [{ number: 2042, body: 'Supersedes #2031 — memory-safe retry' }])).toBe(2042);
+  });
+
+  it('accepts the closing-keyword variants on the same line as the ref', () => {
+    expect(closingMergedPr(7, [{ number: 9, body: 'Fixes #7' }])).toBe(9);
+    expect(closingMergedPr(7, [{ number: 9, body: 'Resolved #7 in passing' }])).toBe(9);
+    expect(closingMergedPr(7, [{ number: 9, title: 'closed #7', body: '' }])).toBe(9);
+  });
+
+  it('does NOT flag a bare mention without a closing keyword (Related: #N)', () => {
+    expect(closingMergedPr(7, [{ number: 9, body: 'Related: #7\nSee also #7 for context' }])).toBeNull();
+  });
+
+  it('does NOT flag when the keyword and ref are on DIFFERENT lines', () => {
+    expect(closingMergedPr(7, [{ number: 9, body: 'Closes #8\nUnrelated note about #7' }])).toBeNull();
+  });
+
+  it('guards against numeric prefix collisions — #2035 must not match #20350', () => {
+    expect(closingMergedPr(2035, [{ number: 9, body: 'Closes #20350' }])).toBeNull();
+    expect(closingMergedPr(35, [{ number: 9, body: 'Closes #2035' }])).toBeNull();
+  });
+
+  it('returns null on empty/invalid input (proceed-safe)', () => {
+    expect(closingMergedPr(7, [])).toBeNull();
+    // @ts-expect-error — non-array
+    expect(closingMergedPr(7, null)).toBeNull();
+    expect(closingMergedPr(0, [{ number: 9, body: 'Closes #0' }])).toBeNull();
+    expect(closingMergedPr(NaN, [{ number: 9, body: 'Closes #5' }])).toBeNull();
   });
 });


### PR DESCRIPTION
Verifica + fix dell'escalation harvester **#2123** (`fix-outcome:already-fixed` 10×/14d).

**Diagnosi:** il bucket re-escala nonostante il fix strutturale fosse GIÀ shippato (escalation #1647 → pre-flight gate `check-issue-already-resolved.mjs`). Su 5 esempi della escalation: 1/5 catturato a costo-zero dal gate, 4/5 hanno fatto girare Claude (burn reale, casi semantici done-but-open). Due cause radice, due leve.

## Implementato
- **A — feedback-loop sweep (`scripts/ci/harvest-agent-lessons.mjs`):** il pre-flight gate e il reconciler emettono `<!-- FIX_OUTCOME: already-fixed -->` quando short-circuitano una done-but-open **senza spendere Claude**. L'harvester li contava come burn → il fix strutturale ri-escalava sé stesso. Ora skippo i marker dei commenti deterministici (firma `reconcile-bot` / "Pre-flight (auto, zero-Claude)" / "Reconcile (auto)"), specchio dell'esclusione `post-step deterministico` già presente. Conta solo i miss di run Claude reali.
- **B — broadening del gate (`followup-resolution-match.mjs` + `check-issue-already-resolved.mjs`):** nuovo helper puro `closingMergedPr(issue, mergedPrs)` che rileva una **PR MERGED** che dichiara esplicitamente `Closes`/`Fixes`/`Resolves`/`Supersedes #N` ma che GitHub ha lasciato aperta — il gotcha documentato `Closes #a #b #c` (chiude solo `#a`; `Supersedes` mai auto-chiude). Wired nel gate **prima** del token-matcher. Segnale = dichiarazione esplicita d'autore (non euristica) → bias-to-proceed preservato: short-circuit solo ad advisory `maybe-resolved`, **mai** auto-close.
- **Test (`tests/followup-resolution-match.test.ts`):** 8 nuovi casi su `closingMergedPr` (multi-issue gotcha, Supersedes, varianti keyword, no-keyword bare-mention, keyword/ref su righe diverse, collisione prefisso numerico `#2035` vs `#20350`, input invalidi proceed-safe). 53/53 verdi nella suite matcher+gate+reconciler.

## Non implementato (ancora)
- **`reconcile-followups.mjs` (sibling #6):** advisory-only batch a zero Claude; un fetch merged-PR per-issue aggiungerebbe N chiamate gh a una sweep schedulata per **zero** risparmio quota → il segnale cross-ref lì è deferito (coverage nicety, non burn-lever). L'helper vive nel modulo condiviso, riusabile quando serve.
- **`followup-drainer.mjs` (sibling #6):** legge `already-fixed` come `NON_RETRYABLE` → parka, non ri-accoda. Corretto anche per i marker pre-flight (verdetto fermo) → **nessuna modifica necessaria** (scopo diverso dal conteggio-burn dell'harvest).
- **Casi semantici (#2093 mechanism-in-other-file, #1939 placement-already-correct):** non catturabili da un segnale esplicito né da un token verbatim; il bias-to-proceed li lascia deliberatamente girare per non droppare lavoro reale. Residuo accettato by-design.
- **Awareness "fix strutturale shippato" generica nell'harvester:** non implementata (richiederebbe un ledger); A rimuove l'auto-inflazione, il resto è chiuso a mano via #2123.

Closes #2123