### PR TITLE
fix(translate): self-heal Azure tier — exhaust key on first 401/403, drop region double-try

### DIFF
--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -669,44 +669,52 @@ async function translateWithAzure(text, sourceLang, targetLang) {
       const translated = [];
       for (const chunk of chunks) {
         const url = `https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=${sourceLang}&to=${targetLang}`;
-        // Region resilience: Azure "global"/multi-service resources require the
-        // region header to be `global`, while regional resources need their exact
-        // region. Try the configured region first; on a 401 (auth/region mismatch)
-        // retry ONCE with `global` before giving up. The warn-logging below reveals
-        // the true error/region in CI so the default never has to be guessed again.
-        const regionsToTry = AZURE_REGION === 'global' ? ['global'] : [AZURE_REGION, 'global'];
-        let res;
-        for (let r = 0; r < regionsToTry.length; r++) {
-          const region = regionsToTry[r];
-          res = await fetch(url, {
-            method: 'POST',
-            headers: {
-              'Ocp-Apim-Subscription-Key': key,
-              'Ocp-Apim-Subscription-Region': region,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify([{ Text: chunk }]),
-            signal: AbortSignal.timeout(TIMEOUT_MS),
-          });
-          // Only the 401 case is worth retrying with a different region; any other
-          // status (ok / quota / 4xx / 5xx) is handled by the logic below.
-          if (res.status !== 401 || r === regionsToTry.length - 1) break;
-          console.warn(`[azure] 401 with region="${region}" — retrying once with region="global"`);
+        // Single call with the configured region. A 401/403 is an auth/credential
+        // failure (bad or revoked key) — NOT something a different region header can
+        // fix (live run 27544487773 proved BOTH westeurope AND global return 401 for
+        // an invalid key), so we no longer waste a second `global` retry on auth
+        // failures. The key is exhausted for the rest of the run instead (see below),
+        // making this self-healing: a VALID key returns 200, is never exhausted, and
+        // a renewed key in Remote Config re-enables Azure with zero code change.
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Ocp-Apim-Subscription-Key': key,
+            'Ocp-Apim-Subscription-Region': AZURE_REGION,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify([{ Text: chunk }]),
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+        if (res.status === 401 || res.status === 403) {
+          // Auth failure: invalid/missing/revoked credentials. Exhaust this key for
+          // the rest of the process run (mirrors the DeepL `_deeplExhaustedKeys`
+          // pattern) so every remaining job skips it instead of burning a failed
+          // HTTP call. Log the status + body snippet ONCE — on the first exhaustion
+          // of a given key (the #2106 [azure] diagnostic is preserved for a future
+          // bad key) — but never spam it for subsequent skipped jobs.
+          if (!_azureExhaustedKeys.has(key)) {
+            const snippet = (await res.text().catch(() => '')).slice(0, 200);
+            console.warn(`[azure] HTTP ${res.status} (key #${idx + 1}, region="${AZURE_REGION}"): ${snippet}`);
+            console.log(`🔑 Azure key #${idx + 1} auth failure (${res.status}) — exhausting for the rest of the run`);
+          }
+          _azureExhaustedKeys.add(key);
+          _cascadeStats.tierErrors.azure = (_cascadeStats.tierErrors.azure || 0) + 1;
+          throw Object.assign(new Error('Azure auth'), { quotaExhausted: true });
         }
-        if (res.status === 403 || res.status === 429) {
+        if (res.status === 429) {
           _azureExhaustedKeys.add(key);
           _cascadeStats.tierErrors.azure = (_cascadeStats.tierErrors.azure || 0) + 1;
           console.log(`🔑 Azure key #${idx + 1} quota exhausted — rotating`);
           throw Object.assign(new Error('Azure quota'), { quotaExhausted: true });
         }
         if (!res.ok) {
-          // Surface the exact failure (e.g. 401 region mismatch, 400 bad lang) so a
-          // region-misconfigured key no longer looks "active" while translating
-          // nothing. Bump the tier error counter, then preserve cascade flow by
-          // returning '' (do not throw).
+          // Other failure (e.g. 400 bad lang). Bump the tier error counter, then
+          // preserve cascade flow by returning '' (do not throw, do not exhaust —
+          // a 400 is request-specific, not a dead key).
           const snippet = (await res.text().catch(() => '')).slice(0, 200);
           _cascadeStats.tierErrors.azure = (_cascadeStats.tierErrors.azure || 0) + 1;
-          console.warn(`[azure] HTTP ${res.status} (key #${idx + 1}, region="${regionsToTry[regionsToTry.length - 1]}"): ${snippet}`);
+          console.warn(`[azure] HTTP ${res.status} (key #${idx + 1}, region="${AZURE_REGION}"): ${snippet}`);
           return '';
         }
         const data = await res.json();


### PR DESCRIPTION
## Implementato

- `scripts/lib/free-translate.mjs` → `translateWithAzure`: una chiave Azure che restituisce **401 o 403** (credenziali invalide/mancanti/revocate) viene ora **esausta per il resto del run** via il set `_azureExhaustedKeys` già esistente (mirror del pattern DeepL `_deeplExhaustedKeys`). Dopo il primo auth-failure di una chiave, ogni job successivo la salta (`if (_azureExhaustedKeys.has(key)) continue;` già al loop) — niente più chiamata HTTP fallita sprecata per ogni job. **Self-healing**: una chiave VALIDA risponde 200 e non viene mai esausta, quindi rinnovare la chiave in Remote Config riabilita Azure a codice invariato.
- **Rimosso il region double-try sul 401**: il loop `regionsToTry = [AZURE_REGION, 'global']` con `console.warn('[azure] 401 ... retrying once with region="global"')` è eliminato. La live run 27544487773 ha provato che la chiave invalida dà 401 su ENTRAMBE le region, quindi il retry `global` non può sanare un problema di credenziali. Ora una sola `fetch` con la region configurata; sul 401/403 si registra l'auth-failure e si esaurisce la chiave (via `throw {quotaExhausted:true}` → rotazione/skip), senza seconda chiamata sprecata.
- **Logging diagnostico #2106 preservato ma non spammoso**: il `[azure] HTTP <status> (key #N, region=...): <snippet>` + un nuovo `🔑 Azure key #N auth failure (<status>) — exhausting for the rest of the run` vengono loggati **una sola volta**, alla prima esaustione della chiave (`if (!_azureExhaustedKeys.has(key))`); i job successivi che la saltano non riloggano. Una futura chiave morta resta quindi visibile in CI senza inondare i log.
- **429 resta quota transitoria/rotazione** (comportamento invariato: esausta + `quotaExhausted`); altri `!res.ok` (es. 400 bad-lang) loggano e ritornano `''` senza esaurire (errore request-specific, non chiave morta).

Nessun env-flag di hard-disable, nessuna rimozione del tier: lo skip è guidato solo dalla risposta HTTP.

Verifica: `node --check` OK; dynamic import smoke OK (`freeTranslate`/`freeTranslateWithRetry` esportati); `npx vitest run` su `free-translate-markdown-balancer`, `email-cascade-burst`, `translation-length-ratio-gate` → **27 passed**. `node scripts/ci/check-sibling-patterns.mjs` → vedi sotto.

## Non implementato (ancora)

- **Rinnovo della chiave Azure in Remote Config**: azione del proprietario, fuori scope. Il fix è proprio progettato perché basti aggiornare la chiave: nessun codice da ritoccare.
- **Effetto non validabile pre-merge**: il tier Azure si esercita solo in CI/run di traduzione reale (non nei test). Atteso al prossimo run: Azure esausto dopo **1 chiamata fallita per chiave** (non più 2 chiamate per ogni job) e **zero tempo Azure** una volta esausto. Se un run futuro mostrasse ancora il doppio-try o l'assenza di esaustione → revert-trigger.
- **Sibling `scripts/lib/dedicated-crawler-common.mjs`** (flaggato da `check-sibling-patterns` per il token condiviso `quotaExhausted`): NON è lo stesso antipattern. Lì `quotaExhausted` è il check di esaurimento quota dei modelli AI (`_aiModels.isQuotaExhaustedError`), senza alcuna logica Azure 401/403 né region double-try. Token coincidente, classe di bug diversa → nessuna modifica.

## Test plan

- [x] `node --check scripts/lib/free-translate.mjs`
- [x] Dynamic import smoke test del modulo
- [x] `npx vitest run` test cascade/traduzione → 27 passed
- [x] `node scripts/ci/check-sibling-patterns.mjs` (1 sibling, giustificato sopra)
- [ ] (post-merge, owner) prossimo run di traduzione: log mostra Azure esausto dopo 1 chiamata/chiave e nessun tempo Azure successivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
