### PR TITLE
feat(publisher): owner-only download for canonical CV deep-links

### DIFF
--- a/components/pages/PublisherDashboardPage.tsx
+++ b/components/pages/PublisherDashboardPage.tsx
@@ -33,6 +33,7 @@ import {
 import { useTranslation } from '@/services/i18n';
 import { useAuth } from '@/services/authService';
 import { buildPath } from '@/services/router';
+import { CV_URL_ENDPOINT } from '@/services/publisherCvEndpoint';
 import { Analytics } from '@/services/analytics';
 import { reportCaughtError } from '@/services/errorReporter';
 import { getApp } from '@/services/firebase';
@@ -83,8 +84,6 @@ const RESTORE_ENDPOINT =
   'https://europe-west6-frontaliere-ticino.cloudfunctions.net/restorePublisherAd';
 const CHECKOUT_ENDPOINT =
   'https://europe-west6-frontaliere-ticino.cloudfunctions.net/createPublisherCheckout';
-const CV_URL_ENDPOINT =
-  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/getPublisherApplicationCvUrl';
 
 /** A pasted public link is used as-is; an uploaded CV is a Storage object path
  *  (client-read-denied) that must be exchanged for a signed URL server-side. */

--- a/functions/src/publisherApplicationsCore.js
+++ b/functions/src/publisherApplicationsCore.js
@@ -157,10 +157,40 @@ async function verifyCaller(req) {
 }
 
 /**
- * Mint a download link for an application's uploaded CV, for the authenticated
- * publisher who owns the target application. The client never reads cv-uploads/**
- * directly (storage.rules denies client reads), so the dashboard CV link cannot
- * be the raw object path — it calls this endpoint to obtain a server-signed URL.
+ * Resolve the publisher who owns a CV reference, and the CV object path/link, for
+ * an authenticated caller. Two addressing modes:
+ *   - { appId }: look up the application; owner is application.publisherUid.
+ *   - { cvPath: 'cv-uploads/<jobId>/<file>' }: owner is the publisher of <jobId>
+ *     (publisher_jobs/<jobId>.publisherUid). Lets a canonical CV deep-link
+ *     (/i-miei-annunci/cv-uploads/…) resolve without first knowing the appId.
+ * Returns { ownerUid, cvRef } or { error }.
+ */
+async function resolveCvOwnerAndRef({ appId, cvPath }) {
+  if (appId) {
+    const appSnap = await db().collection('applications').doc(appId).get();
+    if (!appSnap.exists) return { error: 'application_not_found' };
+    const appData = appSnap.data();
+    return { ownerUid: appData.publisherUid, cvRef: appData.cvUrl };
+  }
+  if (cvPath) {
+    // Strict shape: cv-uploads/<jobId>/<file> with no traversal. The <jobId>
+    // segment is the ownership authority (same job that the upload was scoped to).
+    const m = /^cv-uploads\/([^/]+)\/([^/]+)$/.exec(cvPath);
+    if (!m || cvPath.includes('..')) return { error: 'bad_cv_path' };
+    const jobId = m[1];
+    const jobSnap = await db().collection('publisher_jobs').doc(jobId).get();
+    if (!jobSnap.exists) return { error: 'job_not_found' };
+    return { ownerUid: jobSnap.data().publisherUid, cvRef: cvPath };
+  }
+  return { error: 'no_target' };
+}
+
+/**
+ * Mint a download link for an uploaded CV, for the authenticated publisher who
+ * owns it. The client never reads cv-uploads/** directly (storage.rules denies
+ * client reads), so neither the dashboard CV link nor the canonical CV deep-link
+ * can be the raw object path — both call this endpoint for a server-signed URL.
+ * Accepts { appId } (dashboard) or { cvPath } (deep-link interceptor).
  * @param {import('express').Request} req
  * @returns {Promise<{status:number, body:object}>}
  */
@@ -170,18 +200,21 @@ export async function handleGetApplicationCvUrl(req) {
   if (!decoded) return { status: 401, body: { ok: false, error: 'unauthenticated' } };
 
   const appId = String((req.body && req.body.appId) || '').trim();
-  if (!appId) return { status: 400, body: { ok: false, error: 'no_app_id' } };
+  const cvPath = String((req.body && req.body.cvPath) || '').trim();
+  if (!appId && !cvPath) return { status: 400, body: { ok: false, error: 'no_target' } };
 
-  const appSnap = await db().collection('applications').doc(appId).get();
-  if (!appSnap.exists) return { status: 404, body: { ok: false, error: 'application_not_found' } };
-  const appData = appSnap.data();
-  // Only the publisher who owns the application may read the candidate's CV
-  // (mirrors firestore.rules `applications` read guard: uid == publisherUid).
-  if (appData.publisherUid !== decoded.uid) {
+  const { ownerUid, cvRef, error } = await resolveCvOwnerAndRef({ appId, cvPath });
+  if (error) {
+    const status = error === 'bad_cv_path' || error === 'no_target' ? 400 : 404;
+    return { status, body: { ok: false, error } };
+  }
+  // Only the owning publisher may read the candidate's CV (mirrors the
+  // firestore.rules `applications` read guard: uid == publisherUid).
+  if (ownerUid !== decoded.uid) {
     return { status: 403, body: { ok: false, error: 'forbidden' } };
   }
 
-  const url = await resolveCvLink(appData.cvUrl);
+  const url = await resolveCvLink(cvRef);
   if (!url) return { status: 404, body: { ok: false, error: 'cv_unavailable' } };
   return { status: 200, body: { ok: true, url } };
 }

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import { installDomReconciliationGuard } from './services/domReconciliationGuard';
+import { maybeHandleCvDownload } from './services/cvDownloadIntercept';
 
 // Harden the DOM against third-party mutation (Google Translate, extensions)
 // crashing React's reconciler with NotFoundError on insertBefore/removeChild.
@@ -166,6 +167,14 @@ const mountApp = async () => {
  document.getElementById('loading-shell')?.remove();
 };
 
-// Mount React immediately on all paths for better LCP.
-// The loading shell provides instant visual feedback while JS loads.
-void mountApp();
+// Canonical CV deep-links (/…/cv-uploads/<jobId>/<file>) are not real assets and
+// are not handled by the SPA router; intercept them here to resolve a signed,
+// owner-only download before mounting the app. On any other path this is a cheap
+// regex test that returns false and the app mounts normally.
+if (maybeHandleCvDownload()) {
+ // Handled (redirecting to the signed URL or the dashboard) — do not mount.
+} else {
+ // Mount React immediately on all paths for better LCP.
+ // The loading shell provides instant visual feedback while JS loads.
+ void mountApp();
+}

--- a/services/cvDownloadIntercept.ts
+++ b/services/cvDownloadIntercept.ts
@@ -1,0 +1,100 @@
+/**
+ * Canonical CV deep-link interceptor.
+ *
+ * Candidate CVs are stored at a client-read-denied Storage path
+ * (`cv-uploads/<jobId>/<file>`, see storage.rules) and surfaced to the owning
+ * publisher only through a server-signed URL. A link of the canonical shape
+ *   /<locale?>/<dashboard-segment>/cv-uploads/<jobId>/<file>
+ * (e.g. the path a stale pre-fix dashboard link or a forwarded reference
+ * resolves to) is NOT a real static asset — GitHub Pages serves the SPA shell
+ * with a 404 status, so the raw path is not downloadable on its own.
+ *
+ * This module runs before the React app mounts: if the current path is such a
+ * deep-link, it exchanges the object path for a signed URL via the authenticated
+ * `getPublisherApplicationCvUrl` Cloud Function (which verifies the caller owns
+ * the job) and redirects to the file. Unauthenticated or non-owner visitors are
+ * sent to the dashboard (login gate) — CVs stay private, never publicly served.
+ */
+
+import { CV_URL_ENDPOINT } from '@/services/publisherCvEndpoint';
+
+// Localised publisher-dashboard URL segments (services/router.ts table) + the
+// optional en/de/fr locale prefix (Italian is unprefixed).
+const CV_DEEPLINK_RE =
+  /^\/(?:(?:en|de|fr)\/)?(?:i-miei-annunci|my-listings|meine-anzeigen|mes-annonces)\/(cv-uploads\/[^/]+\/[^/?#]+)(?=[?#]|$)/;
+
+/** Minimal full-screen status message shown while resolving / before redirect. */
+function renderStatus(message: string): void {
+  const root = document.getElementById('root');
+  if (!root) return;
+  root.innerHTML = `<div style="min-height:100dvh;display:flex;align-items:center;justify-content:center;padding:24px;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#334155;text-align:center">${message}</div>`;
+  document.getElementById('loading-shell')?.remove();
+}
+
+/** Dashboard root for the current path's locale (drops the cv-uploads tail). */
+function dashboardFallbackPath(pathname: string): string {
+  const idx = pathname.indexOf('/cv-uploads/');
+  return idx >= 0 ? `${pathname.slice(0, idx)}/` : '/i-miei-annunci/';
+}
+
+async function runCvDownload(cvPath: string): Promise<void> {
+  renderStatus('Recupero del CV in corso…');
+  const fallback = dashboardFallbackPath(window.location.pathname);
+  try {
+    const [{ getApp }, authModule] = await Promise.all([
+      import('@/services/firebase'),
+      import('firebase/auth'),
+    ]);
+    const auth = authModule.getAuth(await getApp());
+
+    // Wait for the first definitive auth state (restored session or signed-out).
+    const user = await new Promise<import('firebase/auth').User | null>((resolve) => {
+      const unsub = authModule.onAuthStateChanged(auth, (u) => {
+        unsub();
+        resolve(u);
+      });
+    });
+
+    if (!user) {
+      // Not logged in → dashboard login gate (CV is private, never served here).
+      window.location.replace(fallback);
+      return;
+    }
+
+    const idToken = await user.getIdToken();
+    const res = await fetch(CV_URL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+      body: JSON.stringify({ cvPath }),
+    });
+    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string };
+    if (data.ok && data.url) {
+      window.location.replace(data.url);
+      return;
+    }
+    if (res.status === 403) {
+      renderStatus('Questo CV non appartiene al tuo account.');
+      return;
+    }
+    if (res.status === 404) {
+      renderStatus('CV non più disponibile.');
+      return;
+    }
+    // Transient/other → bounce to the dashboard rather than dead-end here.
+    window.location.replace(fallback);
+  } catch {
+    window.location.replace(fallback);
+  }
+}
+
+/**
+ * If the current location is a canonical CV deep-link, start the authenticated
+ * download flow and return true (caller must skip mounting the React app).
+ * Returns false for every other path.
+ */
+export function maybeHandleCvDownload(): boolean {
+  const match = CV_DEEPLINK_RE.exec(window.location.pathname);
+  if (!match) return false;
+  void runCvDownload(match[1]);
+  return true;
+}

--- a/services/publisherCvEndpoint.ts
+++ b/services/publisherCvEndpoint.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for the authenticated CV-download Cloud Function URL.
+ * Consumed by both the publisher dashboard (CV button) and the canonical CV
+ * deep-link interceptor — keep the literal in one place so the two callers can
+ * never drift (region/name change touches only here).
+ */
+export const CV_URL_ENDPOINT =
+  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/getPublisherApplicationCvUrl';


### PR DESCRIPTION
## Implementato

Rende scaricabile l'URL canonico del CV `/<locale?>/<segmento-dashboard>/cv-uploads/<jobId>/<file>` (es. `https://frontaliereticino.ch/i-miei-annunci/cv-uploads/<jobId>/<file>.pdf`) **per il solo publisher proprietario**, mantenendo i CV privati. Quel path non è un asset reale: GitHub Pages serve la shell SPA con status 404, quindi il path grezzo non era scaricabile da solo e finiva in dead-end anche per l'owner.

- **Interceptor pre-mount** (`services/cvDownloadIntercept.ts`, wired in `index.tsx`): se il path è un CV deep-link, scambia l'object path per un URL firmato via la CF autenticata `getPublisherApplicationCvUrl` e fa redirect al file. Visitatori non loggati o non proprietari → gate login della dashboard. Su ogni altro path è un test regex a costo zero che ritorna `false` e l'app monta normalmente. La guard DOM (`installDomReconciliationGuard`, top-level) resta invariata.
- **Backend `handleGetApplicationCvUrl`** ora accetta `{ cvPath }` oltre a `{ appId }`: valida la forma stretta `^cv-uploads/<jobId>/<file>$` (rifiuta traversal `..`), deriva il publisher proprietario da `publisher_jobs/<jobId>.publisherUid`, e firma l'URL **solo** per quell'owner. Stessa autorità del path `appId`; fail-closed (400/403/404). Estratto helper `resolveCvOwnerAndRef`.
- **Estratta la costante endpoint** in `services/publisherCvEndpoint.ts`, condivisa tra dashboard (#2179) e interceptor → niente duplicazione letterale (AGENTS.md #6, sibling-check segnalava `CV_URL_ENDPOINT` in 2 file).

**Sicurezza/privacy:** l'URL canonico diventa scaricabile per il **solo** publisher proprietario; l'oggetto resta client-read-denied (`storage.rules` `read:false`) e non è mai servito a richieste anonime o non-proprietarie. Nessuna esposizione pubblica (coerente con la scelta owner "tieni sicuro").

## Verificato pre-merge
- Regex interceptor testato: matcha l'URL reale + varianti locale (it/en/de/fr), no-match su dashboard root / path multi-segmento / `..` (e il backend ri-valida comunque).
- `tsc --noEmit` full-project: zero errori sui file toccati.
- Backend `node --check` OK. Sibling-check + PII scan puliti.

## Non implementato (ancora)

- **Verifica live end-to-end del redirect**: richiede deploy (Cloud Functions per il `cvPath` mode + Pages per l'interceptor) e login owner; la CF era già live dal merge #2179, il `cvPath` mode va col deploy di questa PR. Da osservare post-merge: aprire l'URL canonico da loggati deve scaricare il PDF. Il file è già verificato scaricabile via il meccanismo (token URL, HTTP 200, PDF 511KB) in #2179.
- **i18n**: i pochi messaggi di stato dell'interceptor ("Recupero del CV in corso…", ecc.) sono in italiano fisso — è un overlay tecnico transitorio pre-redirect, non una pagina indicizzata né navigazione SPA; traduzione full-locale deferita (basso valore, non funnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)