### PR TITLE
feat(ai-models): add two verified-free NVIDIA NIM models to translation cascade

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -229,6 +229,13 @@ export const AI_MODELS = Object.freeze({
   // NV_NEMOTRON_49B removed — NVIDIA NIM HTTP 404 "Not Found for account" (2026-06-15, run 27544487773). No longer served on this NVIDIA account. Dropped from DEFAULT_CHAIN in the same change.
   NV_LLAMA_3_1_8B:   'nvidia/meta/llama-3.1-8b-instruct',
   // NV_PHI_3_MINI removed — NVIDIA NIM HTTP 404 "404 page not found" (2026-05-18)
+  // NV_MISTRAL_SM_4 / NV_NEMOTRON_NANO_9B added — verified translating de↔it 2026-06-15 via
+  // live integrate.api.nvidia.com calls (replacements for the NV_NEMOTRON_70B/49B that 404'd
+  // on this account in #2196). Neither matches NVIDIA_ALLOW_FAMILY_RE (no nemotron-at-slash /
+  // llama-3.x token), so dynamic discovery does NOT auto-inject them — the static pin is
+  // genuinely additive and survives a discovery timeout/outage. NVIDIA NIM = free tier.
+  NV_MISTRAL_SM_4:      'nvidia/mistralai/mistral-small-4-119b-2603',     // API: mistralai/mistral-small-4-119b-2603 — fast (<1s), clean it/de
+  NV_NEMOTRON_NANO_9B:  'nvidia/nvidia/nvidia-nemotron-nano-9b-v2',       // API: nvidia/nvidia-nemotron-nano-9b-v2 — correct it/de, slower (~29s)
   HF_MISTRAL_7B:   'hf/mistralai/Mistral-7B-Instruct-v0.3',
   HF_ZEPHYR_7B:    'hf/HuggingFaceH4/zephyr-7b-beta',
   HF_LLAMA_3_3_70B:'hf/meta-llama/Llama-3.3-70B-Instruct',
@@ -456,6 +463,8 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.CF_GLM_47_FLASH,    // 69. GLM 4.7 Flash           (Cloudflare Workers AI)
   // NV_NEMOTRON_49B removed — NVIDIA NIM HTTP 404 "Not Found for account" (2026-06-15, run 27544487773); no longer served on this NVIDIA account
   AI_MODELS.NV_LLAMA_3_1_8B,    // 71. Llama 3.1 8B           (NVIDIA NIM)
+  AI_MODELS.NV_MISTRAL_SM_4,     // 71b. Mistral Small 4 119B  (NVIDIA NIM — added, verified translating it↔de 2026-06-15; fast <1s)
+  AI_MODELS.NV_NEMOTRON_NANO_9B, // 71c. Nemotron Nano 9B v2   (NVIDIA NIM — added, verified translating it↔de 2026-06-15; slower ~29s)
   // AI_MODELS.NV_PHI_3_MINI removed — NVIDIA NIM HTTP 404 "404 page not found" (2026-05-18)
   // AI_MODELS.CF_DEEPSEEK_R1_32B removed — Cloudflare HTTP 400 "No such model @cf/deepseek/deepseek-r1-distill-qwen-32b" (2026-05-18)
   // CF_GRANITE_4_MICRO removed — "No such model @cf/ibm/granite-4.0-h-micro" (2026-04)


### PR DESCRIPTION
## Implementato

Replaced part of the NVIDIA capacity lost in #2196 (NV_NEMOTRON_70B / NV_NEMOTRON_49B 404'd "Not Found for account") with **two NVIDIA NIM chat models, each proven via live translation calls on 2026-06-15** against `integrate.api.nvidia.com`. NVIDIA NIM is a genuinely **free tier** ($0 — same provider the chain already trusts for `NV_LLAMA_3_1_8B`).

- **`NV_MISTRAL_SM_4`** = `nvidia/mistralai/mistral-small-4-119b-2603` — free, fast (<1s), clean de→it + it→de. Added to `AI_MODELS` and `DEFAULT_CHAIN` at slot 71b.
- **`NV_NEMOTRON_NANO_9B`** = `nvidia/nvidia/nvidia-nemotron-nano-9b-v2` — free, correct de→it + it→de, slower (~29s). Added to `AI_MODELS` and `DEFAULT_CHAIN` at slot 71c.

Why static (not discovery): neither id matches `NVIDIA_ALLOW_FAMILY_RE` (no `nemotron`-at-slash / `llama-3.x` token — verified), so dynamic discovery does **not** auto-inject them. The static pins are genuinely additive and survive a discovery timeout/outage. `DEFAULT_CHAIN` 102 → 104; no dupes; all entries carry `// added — verified translating it↔de 2026-06-15` comments per file convention.

Verified output (NV_MISTRAL_SM_4, full call, `finish_reason: stop`):
```
Cerchiamo per la nostra sede a Lugano un infermiere diplomato motivato. I suoi compiti
includono l'assistenza e la cura olistica dei nostri pazienti. Offriamo orari flessibili
e cinque settimane di ferie.
---
**TITOLO_DE:**
Vertriebsverantwortlicher Pharma-Bereich für die Grenzregion Tessin
```

Verified output (NV_NEMOTRON_NANO_9B, ~1.4K-char payload, it=true / de=true):
```
"Cerchiamo per il nostro sito a Lugano un'infermiera specializzata in cura infermieristica
(80-100%). Le tue responsabilità includeranno l'assistenza olistica e la cura dei nostri
pazienti, l'esecuzione di interventi medici prescritti dal medico e la documentazione del
processo di cura. Richiediamo un titolo di studio come infermiera specializzata in cura
infermieristica o FH, esperienza professionale nel settore acuto, buone conoscenze di
tedesco e italiano, spirito di squadra e resilienza. Offriamo una compensazione attraente,
orari di lavoro flessibili, cinque settimane di vacanza, opportun[…]
```

## Non implementato (ancora)

Tested-but-**rejected** candidates (live `/v1/models` discovery + real translation calls, 2026-06-15):

- **OpenRouter `:free` (richest free source) — could NOT live-test**: the per-key free-model **daily cap is already exhausted** today (`Daily request limit reached` on every `:free` id; key reports `is_free_tier:true`). Non-`:free` slugs DO charge credits — `qwen/qwen3-30b-a3b-instruct-2507` translated perfectly but has non-zero pricing (`prompt 4.8e-8 / completion 1.9e-7`), and `meta-llama/llama-4-maverick:free` now 404s "unavailable for free". **Not added** (would violate $0; unverifiable as free today). OR `:free` models still get runtime-validated by the existing discovery path when the cap resets — follow-up: re-run discovery on a day with free quota.
- **SambaNova** — all 6 listed ids (`Meta-Llama-3.3-70B-Instruct`, `DeepSeek-V3.1/V3.2`, `MiniMax-M2.7`, `gemma-4-31B-it`, `gpt-oss-120b`) return **HTTP 402 PAYMENT_METHOD_REQUIRED**. Not free; matches existing chain comments.
- **Fireworks** — `gpt-oss-120b` translated cleanly, but the account is **billed per-token** ($100 monthly-spend threshold configured; calls only succeed against depleting credit). Rejected to honor $0.
- **Cohere** `command-a-plus-05-2026` — **HTTP 429 trial-key** ("1000 API calls/month" cap hit); unverifiable now.
- **Cerebras** `gpt-oss-120b` (transient `queue_exceeded` overload) and `zai-glm-4.7` (reasoning model — emits to `message.reasoning`, leaves `content` empty → wrapper reads empty; `finish_reason:length`). Neither usable through the current wrapper.
- **Groq** `allam-2-7b` (Arabic-focused) — echoed German, produced no Italian.
- **NVIDIA** rejected: `llama-3.3-nemotron-super-49b-v1.5`, `openai/gpt-oss-120b`, `nemotron-3-nano-30b-a3b` (empty responses); `meta/llama-3.3-70b-instruct`, `qwen3-next-80b-a3b-instruct`, `gemma-4-31b-it`, `nemotron-nano-8b-v1` (timeouts); `llama-3.1-nemotron-51b-instruct` (404 not-for-account); `nemotron-3-super-120b-a12b` ("thinks out loud" / echoes prompt — not a clean translation).
- **Mistral / Together** `/v1/models` returned **HTTP 401** on this key set — could not list/test (statically curated + runtime-validated already; out of scope here).
- **No discovery/adapter change**: chose NOT to broaden `NVIDIA_ALLOW_FAMILY_RE` to cover `mistral-small`/`mistral-*` families — NVIDIA's listing mixes many dead legacy Mistral ids (`mistral-7b-instruct-v0.3`, `mixtral-8x7b`, etc.) that would re-flood the chain with 404s (the exact #1335/#1357 failure mode the allowlist exists to prevent). Pinned the one proven id statically instead.
- **Sibling-pattern check (`check-sibling-patterns.mjs`)** flagged 6 files sharing the `AI_MODELS` token (`backfill-ai-search-optimization.mjs`, `batch-add-faq-to-articles.mjs`, `create-article.mjs`, `enrich-related-search-clusters.mjs`, `send-newsletter.mjs`, `smoke-test-ai-models.mjs`). These are **consumers** of the catalog, not files sharing a bug class — this change is purely additive (two catalog entries), no regex/guard/pattern fix to mirror. No-op by design.
- **Effect at full scale not validatable pre-merge**: the two models were verified with single live calls, not under production crawl load. **Revert-trigger**: if either model starts returning sustained 404/402/empty in the live `smoke-test-ai-models` run after merge, drop it with the standard `// removed — HTTP NNN` comment.

## Test plan

- [x] `node --check scripts/lib/ai-models.mjs` → OK
- [x] Dynamic import smoke: both ids present in `AI_MODELS` + `DEFAULT_CHAIN`, chain 102 → 104, no dupes
- [x] `npx vitest run` ai-models/discovery/classifier suites → **30 passed** (6 files: nvidia-discovery-allowlist, discovery-shape-guard, content-failures, discovery-markstale, skip-error-capture, quota-exhausted-classifier)
- [x] `node scripts/ci/check-sibling-patterns.mjs` after `git add -A` → reviewed; flagged files are consumers, not antipattern siblings (see above)
- [x] Real translation calls confirming each kept model returns 200 + correct it↔de (outputs above)
- [ ] Live `smoke-test-ai-models` run on `main` post-merge confirms both ids hold 200 under the workflow harness (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)