### PR TITLE
perf(ci-review): partial-clone checkout to cut review feedback latency

### DIFF
--- a/.github/workflows/pr-body-contract.yml
+++ b/.github/workflows/pr-body-contract.yml
@@ -145,10 +145,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # Storia completa: serve il merge-base con la base branch per il
-          # three-dot diff dello script (repo grande ma fetch ~40s, accettabile
-          # per un check che pre-empta un round review+fix da ~2 run Claude).
+          # Storia completa (commit-graph + merge-base con la base branch) serve
+          # per il three-dot diff dello script. `fetch-depth: 0` full però
+          # scaricava ~11GB di blob storici → 143s misurati (il commento "~40s"
+          # era ottimistico). `filter: blob:none`: commit-graph + blob HEAD, i
+          # blob storici lazy-fetch — il diff name-status usa solo i tree
+          # (presenti) e legge il contenuto dei soli file cambiati (pochi blob
+          # on-demand). La sticky `<!-- sibling-check -->` che il reviewer
+          # consuma arriva ~100s prima.
           fetch-depth: 0
+          filter: blob:none
       - name: Surface sibling candidates
         id: sib
         env:

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -35,7 +35,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # Partial clone: il checkout `fetch-depth: 0` full scaricava ~11GB di
+          # history (.git, repo a heavy churn su data/jobs) → 184s misurati, il
+          # 54% del run-time della review (Claude pass: ~150s). `filter:
+          # blob:none` prende solo commit-graph + blob HEAD (working tree per
+          # `rg`/`Read`), defer dei blob storici (lazy-fetch on-demand se mai
+          # servono `git blame`/`git log -L`/`git show` — strumenti opzionali,
+          # REVIEW.md non li richiede). Feedback review ~3min prima. fetch-depth
+          # resta 0: serve il commit-graph completo per la lazy-fetch.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Implementato

Velocizza il **feedback durante la review** riducendo il collo di bottiglia #1 misurato: il checkout.

Breakdown reale di un run `pr-review-loop` (run 27564341349):
- **Checkout: 184s** (`fetch-depth: 0` full → scarica ~11GB di `.git`; repo a heavy churn su `data/jobs/*.json`)
- Claude review: 150s
- resto: ~0s

Il checkout era il **54% del run-time della review**, più della review stessa.

Fix: checkout in **partial clone** (`filter: blob:none`) sui due workflow read-only del path review-feedback:
- `.github/workflows/pr-review-loop.yml` — la review Claude (Checkout 184s → ~30-40s stimati)
- `.github/workflows/pr-body-contract.yml` job `sibling-check` — posta la sticky `<!-- sibling-check -->` che il reviewer consuma per il cross-file probing (Checkout 143s → ~40s stimati; il commento diceva "~40s" ma il reale era 143s)

`filter: blob:none` prende commit-graph + blob HEAD (working tree, serve a `rg`/`Read`) e differisce i blob storici (lazy-fetch on-demand). `git blame`/`git log -L`/`git show` continuano a funzionare (lazy); REVIEW.md non li richiede comunque. `fetch-depth: 0` resta (serve il commit-graph completo per il three-dot diff del sibling-check e per la lazy-fetch). Nessun cambio di comportamento: stesso diff, stesso working tree, stessa logica review — solo i blob storici sono differiti.

Effetto atteso: ~3min di feedback in meno per PR.

## Non implementato (ancora)

- **`pr-redflag-fixer.yml`, `pr-autorebase.yml`, `issue-fix.yml`** (anch'essi `fetch-depth: 0`, sibling per costrutto): **out of scope** — classe di rischio diversa. Sono workflow che MUTANO (rebase/commit/push); con `blob:none` le operazioni di rebase/merge lazy-fetchano blob a metà operazione → possibile regressione di latenza o edge-case non misurati. Vanno validati separatamente con un run misurato prima di toccarli. I due workflow di questa PR sono read-only (solo review/diff) → win netto, rischio minimo.
- **Gate deterministici `cls-ad-slot-check` / `client-lookbehind-check`** (default depth-1, 33s/50s): il loro costo è il working tree HEAD (~1GB data/public), non la history → `blob:none` è un no-op lì. Ridurli richiederebbe `sparse-checkout` (escludere data/public), che rischia di rompere un blocking gate se lo script aggiunge path → posposto, win modesto.
- Misura post-merge del checkout reale (atteso ~30-40s): da verificare sulla prossima PR organica (non validabile pre-merge — il timing dipende dall'infra GitHub).

> ⚠️ Questa PR modifica `pr-review-loop.yml` → per la workflow-validation rule (AGENTS.md § Workflow) il reviewer GitHub App non posterà su un branch il cui review workflow diverge da `main`. **Merge manuale** previsto via `gh pr merge --squash --delete-branch`. Validazione del nuovo timing sulla prossima PR organica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)