### PR TITLE
perf(ci): partial-clone checkout for refine-url-first-seen (no history needed)

### DIFF
--- a/.github/workflows/refine-url-first-seen.yml
+++ b/.github/workflows/refine-url-first-seen.yml
@@ -28,7 +28,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # Nessun uso della git history: il job legge solo il working tree
+          # (`git diff --quiet data/url-first-seen.json`), poi `checkout -b`
+          # + commit + push di un branch FRESCO (PR, mai push su main, nessun
+          # rebase né `git show <commit>:<file>`). Il `fetch-depth: 0` qui era
+          # cargo-cult: scaricava ~11GB di `.git` per nulla. `filter:
+          # blob:none` prende commit-graph + blob HEAD e differisce i blob
+          # storici (lazy) → checkout molto più rapido senza perdere capacità.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Implementato

Follow-up dell'analisi "estendere `filter: blob:none` ai workflow che fanno checkout ma non usano la git history" (dopo PR #2206 sui workflow di review).

Ho analizzato **tutti i 17 workflow rimanenti con `fetch-depth: 0`** (4 agent paralleli + verifica diretta dei 3 helper-script chiave `git-push-with-retry.sh`, `git-commit-data.sh`, `scan-prev-slug-losses.mjs`). Risultato: **un solo** workflow è puramente sicuro → questa PR lo cambia.

- `.github/workflows/refine-url-first-seen.yml`: il `fetch-depth: 0` era cargo-cult. Il job legge solo il working tree (`git diff --quiet data/url-first-seen.json`), poi `checkout -b` + commit + push di un **branch fresco** + `gh pr create`. **Nessun** rebase, **nessun** push su main, **nessun** `git show <commit>:<file>`. → `filter: blob:none` sicuro (commit-graph + blob HEAD, blob storici lazy).

## Non implementato (ancora)

Gli altri 16 `fetch-depth: 0` **NON sono sicuri** per blob:none — verificato, non assunto:

- **Data-writer che fanno rebase-on-push** (`update-jobs-avaloq`, `update-jobs-livingcircle`, `snapshot-jobs-weekly`, `update-unemployment-rate`, `semrush-weekly-snapshot`, `ai-visibility-check`, `verify-company-logos-weekly`, `seo-serp-autopilot`, `refresh-thin-promotions`, `crawler-health-monitor`, `guard-data-integrity`, `batch-faq-articles`): tutti rebasano su `origin/main` (via `git-push-with-retry.sh` riga 71 `git rebase`, o `git-commit-data.sh` righe 694/815, o `git pull --rebase` inline) per sopravvivere a push concorrenti su main. Il commit-graph serve. `blob:none` lo **mantiene** (anzi risolverebbe i loro errori shallow-horizon, che sono un problema di `fetch-depth:1` non di blob:none), ma lazy-fetcha i blob dei file in conflitto a metà rebase → rischio non misurato su job **non presidiati** ad alta conseguenza (push diretto su main, dati crawler). Valore latenza ~zero: nessun umano aspetta questi job schedulati. → **esperimento misurato** prima di toccarli (vedi sotto), non claim speculativo (AGENTS.md § "claim build/perf non validabile pre-merge").
- **`recover-prev-slugs`**: `scan-prev-slug-losses.mjs` fa `git show <commit>:<file>` in loop su una finestra di 24h → con blob:none ogni read è un lazy-fetch di rete = **regressione** (più lento del full clone). → KEEP `fetch-depth: 0`.

## Esperimento proposto (follow-up, non in questa PR)

Per il prize grosso (i ~12 data-writer rebase, ognuno clona ~11GB): cambiare **UN** workflow rebase (es. `update-jobs-livingcircle`) a `blob:none`, triggerarlo live, confermare che il rebase-on-push riesce e il checkout cala da ~180s a ~30-40s. Se passa → rollout agli altri. Misurato, non assunto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)