### PR TITLE
feat(followup): break the merge→follow-up self-feed (grandchild-suppression gate)

### DIFF
--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -49,8 +49,26 @@ jobs:
         with:
           node-version: '22'
 
+      # Grandchild-suppression gate (zero-Claude, deterministico). Una PR che
+      # FIXA un follow-up, se triagiata, può generare un follow-up NIPOTE (il
+      # reviewer lascia un 🟡 sul fix → nuovo follow-up) → self-feed infinito.
+      # Questo step salta interamente il triage Claude quando la PR mergiata
+      # chiude/supera una issue `follow-up`. Proceed-safe: nel dubbio emette
+      # false → triage gira (mai perdere un follow-up di PR organica).
+      # Vedi scripts/ci/is-followup-fix-pr.mjs + FOLLOWUP.md.
+      - name: Grandchild-suppression gate
+        id: gchild
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/is-followup-fix-pr.mjs
+
       - name: Run Claude follow-up triage
         id: followup
+        # Skip quando la PR è essa stessa un fix-di-follow-up (rompe il self-feed
+        # nipote + risparmia la run Claude sulla quota Max condivisa).
+        if: steps.gchild.outputs.is_followup_fix != 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -2,6 +2,16 @@
 
 Contratto operativo per `post-merge-followup.yml`. Triage automatico post-merge: estrae lavoro residuo da PR body + reviewer comments, lo raccoglie in **una sola issue aggregata** con label `follow-up` per evitare evaporazione dello scope deferred.
 
+## Gate grandchild-suppression (zero-Claude, PRIMA del triage)
+
+`post-merge-followup.yml` gira su OGNI PR mergiata dall'owner — **incluse le PR che FIXANO un follow-up**. Senza guardia il loop è self-perpetuante by-construction:
+
+> follow-up #A → fix PR → merge → reviewer lascia un 🟡 → **nuovo follow-up #B (nipote)** → fix PR → … all'infinito.
+
+Con ~357 PR mergiate/7gg e ~156 follow-up auto-generate/7gg (×~3 run Claude l'una: triage → `issue-fix` → `pr-review-loop`), il treadmill brucia **~470 run Claude/sett** sulla quota Max OAuth **condivisa** con la sessione interattiva owner (vedi `AGENTS.md → Auth automazioni & frugalità quota`).
+
+Lo step deterministico `scripts/ci/is-followup-fix-pr.mjs` (zero-Claude) gira **prima** dello step Claude e lo **salta interamente** (`if: steps.gchild.outputs.is_followup_fix != 'true'`) quando la PR mergiata dichiara di chiudere/superare (`Closes`/`Fixes`/`Resolves`/`Supersedes #N`) almeno una issue con label `follow-up`. Effetto: niente nipote + run Claude risparmiata. Lo scope deferred di un fix-di-follow-up, se reale, appartiene alla issue follow-up **padre** (resta aperta finché non risolta del tutto) — non va mintato un nipote. Parsing close-keyword = `closedIssueRefs()` in `scripts/ci/followup-resolution-match.mjs`, **stessa** regex di `closingMergedPr` (single source, AGENTS.md #6). **Proceed-safe** (direzione opposta al gate already-resolved): body illeggibile / ref non parsati / `gh issue view` in errore → `false` → triage gira (mai perdere un follow-up di PR organica).
+
 ## Scopo
 
 Ogni 🟡 nit, ❓ q del reviewer bot e voce `## Non implementato` del PR body DEVE risultare in: (a) un item nella issue aggregata `follow-up` della PR, (b) drop motivato, o (c) — se è pura verifica del sito live senza file da editare — una voce nella checklist `Live-verification` batchata del commento di chiusura (nessuna issue, nessun fixer; vedi `## Filtro scopo → Hard-exclude: live-verification-only item`). Nessun silent ignore. Filtra via scopo progetto (vedi `REVIEW.md` → "Scopo progetto").

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -22,6 +22,15 @@ Non passa nessuno → drop. Non importante per questo progetto.
 | 🟣 Pre-existing | Bug già pre-PR. Solo se rilevante al diff |
 | ❓ q | Domanda genuina quando incerto (no speculazione) |
 
+### Disposizione 🟡 al review-time (anti-treadmill follow-up)
+
+Ogni 🟡 nit che sollevi **deve dichiarare la propria disposizione**, così `post-merge-followup` non deve indovinarla e non minta un follow-up di basso valore (il treadmill follow-up brucia ~470 run Claude/sett sulla quota Max condivisa — vedi `FOLLOWUP.md → Gate grandchild-suppression`):
+
+- **Nit non-funnel** (stile/leggibilità/naming/maintenance-debt senza impatto monetizzazione/traffico) → suffissa **`— deferred, non funnel-critical`**. `post-merge-followup` lo droppa senza issue (eccezione esistente in `AGENTS.md → Post-merge feedback handling`). NON diventa follow-up.
+- **Nit funnel-critical E azionabile** (cambia un comportamento su monetizzazione/traffico/correttezza) → resta candidate follow-up normale. Questi sono gli UNICI 🟡 che devono mintare. Se il fix è banale e isolato, preferisci dirlo come 🔴-soft "fixa in-PR prima di `## LGTM`" invece di deferirlo (un fix in-PR = zero run treadmill; un follow-up = ~3 run).
+
+Razionale: la disposizione esplicita sposta il triage del nit **a sinistra** (al review, gratis) invece che **a destra** (minting → `agent:fix` → `pr-review`). Non bloccare l'auto-merge sui nit non-funnel: bloccare ogni nit aggiungerebbe cicli `pr-review-loop` su 357 PR/sett (quota-shift, non quota-saving). Il blocco merge resta solo su 🔴 + process.
+
 ## IGNORA (anche se veri)
 
 - Security (XSS/injection/secret leak/path traversal) — out of scope

--- a/scripts/ci/followup-resolution-match.mjs
+++ b/scripts/ci/followup-resolution-match.mjs
@@ -146,24 +146,52 @@ export function citedTokens(body) {
  * @param {Array<{number?: number, title?: string, body?: string}>} mergedPrs
  * @returns {number|null}  the declaring PR number, or null
  */
+// Match a closing keyword IMMEDIATELY followed by a run of issue refs separated
+// ONLY by separators (whitespace / comma / `&` / "and") — the multi-issue
+// `Closes #a #b #c` (and `Closes #a, #b and #c`) shape. Requiring the ref to be
+// part of that unbroken keyword-anchored list (not merely on the same line)
+// rejects `Fixes #8 and touches #N`: the word "touches" breaks the run, so #N
+// is NOT in the closing list (reviewer adversarial #1/#2 — a same-line match
+// would have false-flagged it and dropped a legit agent:fix). Single source of
+// truth: `closedIssueRefs` (the grandchild-suppression gate) and `closingMergedPr`
+// (the already-resolved gate) MUST agree byte-for-byte on what a "closing ref" is
+// (AGENTS.md #6 — a regex duplicated literally in ≥2 files → ONE shared module).
+const CLOSE_KW_LIST = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|supersede[sd]?)\b\s*:?\s*((?:#\d+(?:[\s,&]+(?:and\s+)?)?)+)/ig;
+
+/**
+ * Every issue number declared closed/superseded by a closing-keyword list in `text`
+ * (PR title+body). Returns a deduped array of positive integers (the `#` numbers in
+ * each keyword-anchored run). Empty array on non-string / no match.
+ *
+ * Used by the post-merge-followup grandchild-suppression gate: a merged PR that
+ * closes a `follow-up`-labelled issue is itself a follow-up FIX → triaging it would
+ * mint a GRANDCHILD follow-up (self-feed). The gate reads these refs, checks their
+ * labels, and skips the Claude triage when any is a follow-up. Pure — no I/O.
+ *
+ * @param {string} text  PR title + body (or any prose)
+ * @returns {number[]}   deduped closed-issue numbers, in first-seen order
+ */
+export function closedIssueRefs(text) {
+  if (typeof text !== 'string' || !text) return [];
+  const out = [];
+  const seen = new Set();
+  for (const m of text.matchAll(CLOSE_KW_LIST)) {
+    for (const ref of (m[1] || '').match(/#\d+/g) || []) {
+      const n = Number(ref.slice(1));
+      if (Number.isInteger(n) && n > 0 && !seen.has(n)) { seen.add(n); out.push(n); }
+    }
+  }
+  return out;
+}
+
 export function closingMergedPr(issueNumber, mergedPrs) {
   const n = Number(issueNumber);
   if (!Number.isInteger(n) || n <= 0 || !Array.isArray(mergedPrs)) return null;
-  // Match a closing keyword IMMEDIATELY followed by a run of issue refs separated
-  // ONLY by separators (whitespace / comma / `&` / "and") — the multi-issue
-  // `Closes #a #b #c` (and `Closes #a, #b and #c`) shape. Requiring the ref to be
-  // part of that unbroken keyword-anchored list (not merely on the same line)
-  // rejects `Fixes #8 and touches #N`: the word "touches" breaks the run, so #N
-  // is NOT in the closing list (reviewer adversarial #1/#2 — a same-line match
-  // would have false-flagged it and dropped a legit agent:fix). The exact `#${n}`
-  // string compare also makes the `#2035` vs `#20350` guard fall out for free.
-  const kwList = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|supersede[sd]?)\b\s*:?\s*((?:#\d+(?:[\s,&]+(?:and\s+)?)?)+)/ig;
+  // The exact `#${n}` string compare also makes the `#2035` vs `#20350` guard fall
+  // out for free (closedIssueRefs returns parsed integers, compared exactly).
   for (const pr of mergedPrs) {
-    const text = `${pr?.title || ''}\n${pr?.body || ''}`;
-    for (const m of text.matchAll(kwList)) {
-      const refs = (m[1] || '').match(/#\d+/g) || [];
-      if (refs.includes(`#${n}`)) return pr?.number ?? null;
-    }
+    const refs = closedIssueRefs(`${pr?.title || ''}\n${pr?.body || ''}`);
+    if (refs.includes(n)) return pr?.number ?? null;
   }
   return null;
 }

--- a/scripts/ci/is-followup-fix-pr.mjs
+++ b/scripts/ci/is-followup-fix-pr.mjs
@@ -1,0 +1,130 @@
+/**
+ * is-followup-fix-pr.mjs — grandchild-suppression gate (zero-Claude, deterministico).
+ *
+ * Rompe il SELF-FEED del loop follow-up. `post-merge-followup.yml` gira su OGNI PR
+ * mergiata dall'owner — incluse le PR che FIXANO un follow-up. Quindi:
+ *
+ *     follow-up #A → fix PR → merge → reviewer lascia un 🟡 → nuovo follow-up #B (nipote)
+ *
+ * è self-perpetuante by-construction: il fix di un follow-up può sempre generarne un
+ * altro. Con ~357 PR mergiate / 7gg e ~156 follow-up/7gg auto-generate (×~3 run Claude
+ * l'una: triage → issue-fix → pr-review), il treadmill brucia ~470 run/sett sulla quota
+ * Max OAuth CONDIVISA con la sessione interattiva owner (AGENTS.md § frugalità).
+ *
+ * Questo gate, eseguito PRIMA dello step Claude di triage, emette `is_followup_fix=true`
+ * quando la PR mergiata dichiara di chiudere/superare (`Closes`/`Fixes`/`Resolves`/
+ * `Supersedes #N`) almeno una issue con label `follow-up`. Il workflow salta interamente
+ * il triage → niente nipote + run Claude risparmiata. Lo scope deferred di un fix-di-
+ * follow-up, se reale, appartiene alla issue follow-up PADRE (che resta aperta finché non
+ * risolta del tutto): non va mintato un nipote.
+ *
+ * PROCEED-SAFE (direzione opposta al gate already-resolved): nel dubbio NON skippare. Se
+ * il body PR è illeggibile, i ref non si parsano, o `gh issue view` fallisce → emetti
+ * `false` → il triage gira normalmente. Meglio over-mintare (un follow-up in più, drenato
+ * dai meccanismi di convergenza) che perdere un follow-up legittimo di una PR organica.
+ * Una sola label sbagliata costa una run; un follow-up perso costa scope funnel.
+ *
+ * Output (GITHUB_OUTPUT): `is_followup_fix=true|false`.
+ * Uso:  node scripts/ci/is-followup-fix-pr.mjs
+ * Env:  PR_NUMBER (richiesto), GH_REPO|GITHUB_REPOSITORY, GITHUB_OUTPUT (opzionale),
+ *       FOLLOWUP_LABEL (default `follow-up`). Richiede `gh` in PATH.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { closedIssueRefs } from './followup-resolution-match.mjs';
+
+const PR = process.env.PR_NUMBER;
+const FOLLOWUP_LABEL = process.env.FOLLOWUP_LABEL || 'follow-up';
+const repoArgs = (process.env.GH_REPO || process.env.GITHUB_REPOSITORY)
+  ? ['--repo', process.env.GH_REPO || process.env.GITHUB_REPOSITORY]
+  : [];
+
+function gh(args) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 });
+  } catch {
+    return ''; // proceed-safe: any gh fault → treated as "can't confirm" → false.
+  }
+}
+
+function setOutput(isFollowupFix) {
+  console.log(`is_followup_fix=${isFollowupFix}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `is_followup_fix=${isFollowupFix}\n`);
+  }
+}
+
+/** True if issue #n carries the follow-up label. Proceed-safe: unreadable → false. */
+function issueHasFollowupLabel(n) {
+  const raw = gh(['issue', 'view', String(n), ...repoArgs, '--json', 'labels']);
+  if (!raw) return false;
+  try {
+    const labels = JSON.parse(raw).labels || [];
+    return labels.some((l) => l.name === FOLLOWUP_LABEL);
+  } catch {
+    return false;
+  }
+}
+
+export function main() {
+  if (!PR || !/^\d+$/.test(String(PR).trim())) {
+    console.log('No valid PR_NUMBER — proceed-safe (run triage).');
+    return setOutput(false);
+  }
+
+  const raw = gh(['pr', 'view', String(PR), ...repoArgs, '--json', 'title,body']);
+  if (!raw) {
+    console.log(`PR #${PR}: body unreadable — proceed-safe (run triage).`);
+    return setOutput(false);
+  }
+
+  let title = '';
+  let body = '';
+  try {
+    const pr = JSON.parse(raw);
+    title = pr.title || '';
+    body = pr.body || '';
+  } catch {
+    console.log(`PR #${PR}: body unparseable — proceed-safe (run triage).`);
+    return setOutput(false);
+  }
+
+  const refs = closedIssueRefs(`${title}\n${body}`);
+  if (!refs.length) {
+    console.log(`PR #${PR}: no closing-keyword issue refs — organic PR, run triage.`);
+    return setOutput(false);
+  }
+
+  const followupRefs = refs.filter(issueHasFollowupLabel);
+  if (followupRefs.length) {
+    console.log(
+      `PR #${PR}: closes follow-up issue(s) ${followupRefs.map((n) => `#${n}`).join(', ')} ` +
+      `→ this is a follow-up FIX. Skipping triage to break the grandchild self-feed.`,
+    );
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      fs.appendFileSync(
+        process.env.GITHUB_STEP_SUMMARY,
+        `## Grandchild-suppression gate: PR #${PR} is a follow-up fix\n` +
+        `Closes follow-up ${followupRefs.map((n) => `#${n}`).join(', ')} → triage skipped ` +
+        `(no grandchild follow-up minted, 1 Claude run saved).\n`,
+      );
+    }
+    return setOutput(true);
+  }
+
+  console.log(`PR #${PR}: closes #${refs.join(', #')} but none are follow-up → organic PR, run triage.`);
+  return setOutput(false);
+}
+
+// CLI entrypoint only (importing for tests must not invoke gh). Proceed-safe: any
+// uncaught error → emit false (run triage), never strand a real follow-up.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (e) {
+    console.log(`is-followup-fix-pr: unexpected error (${e?.message || e}) — proceed-safe (run triage).`);
+    setOutput(false);
+  }
+}

--- a/tests/followup-resolution-match.test.ts
+++ b/tests/followup-resolution-match.test.ts
@@ -7,6 +7,7 @@ import {
   mostSpecificToken,
   detectAlreadyResolved,
   closingMergedPr,
+  closedIssueRefs,
 } from '../scripts/ci/followup-resolution-match.mjs';
 
 // Locks the conservative matcher shared by the issue-fix.yml pre-flight gate
@@ -303,5 +304,43 @@ describe('closingMergedPr (explicit done-but-open via merged PR cross-ref)', () 
     expect(closingMergedPr(7, null)).toBeNull();
     expect(closingMergedPr(0, [{ number: 9, body: 'Closes #0' }])).toBeNull();
     expect(closingMergedPr(NaN, [{ number: 9, body: 'Closes #5' }])).toBeNull();
+  });
+});
+
+// Powers the post-merge-followup grandchild-suppression gate
+// (is-followup-fix-pr.mjs): a merged PR closing a `follow-up` issue is a
+// follow-up FIX → skip triage so it can't mint a grandchild follow-up.
+// MUST agree with closingMergedPr on what a "closing ref" is (shared regex).
+describe('closedIssueRefs (closing-keyword issue refs in a PR body)', () => {
+  it('extracts a single closing ref', () => {
+    expect(closedIssueRefs('Fixes #1834')).toEqual([1834]);
+  });
+
+  it('extracts every ref in a multi-issue closing list (`Closes #a #b #c`)', () => {
+    expect(closedIssueRefs('Closes #100 #2035 #2036')).toEqual([100, 2035, 2036]);
+  });
+
+  it('extracts comma/`and`-separated lists and dedupes', () => {
+    expect(closedIssueRefs('Closes #5, #6 and #7\nCloses #6')).toEqual([5, 6, 7]);
+  });
+
+  it('handles all closing-keyword variants (close/fix/resolve/supersede)', () => {
+    expect(closedIssueRefs('Supersedes #2031')).toEqual([2031]);
+    expect(closedIssueRefs('Resolved #7 in passing')).toEqual([7]);
+    expect(closedIssueRefs('closed #9')).toEqual([9]);
+  });
+
+  it('ignores bare mentions without a closing keyword', () => {
+    expect(closedIssueRefs('Related: #7\nSee also #8 for context')).toEqual([]);
+  });
+
+  it('stops the run at a word break (`Fixes #8 and touches #N`) — only #8 closes', () => {
+    expect(closedIssueRefs('Fixes #8 and touches #2123 in passing')).toEqual([8]);
+  });
+
+  it('returns [] on non-string / empty input (proceed-safe)', () => {
+    expect(closedIssueRefs('')).toEqual([]);
+    expect(closedIssueRefs(null as unknown as string)).toEqual([]);
+    expect(closedIssueRefs(undefined as unknown as string)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Contesto

Diagnosi del loop \"ogni merge crea un follow-up\" (goal owner). I numeri (ultimi 7gg): **357 PR mergiate**, **156 follow-up auto-generate** (55% di tutte le nuove issue), 172 chiuse → standing backlog **bounded ~28**. Il problema **non è lo standing backlog** (i meccanismi di convergenza — drainer max-attempts→park→repark-gen-cap, age-out 21d — lo tengono basso) ma il **churn**: ~156 follow-up/sett × ~3 run Claude l'una (triage → \`issue-fix\` → \`pr-review-loop\`) = **~470 run Claude/sett** sulla quota Max OAuth **condivisa** con la sessione interattiva owner.

**Causa-radice strutturale:** \`post-merge-followup.yml\` gira su OGNI PR mergiata dall'owner, **incluse le PR che FIXANO un follow-up** → follow-up #A → fix PR → merge → reviewer 🟡 → **nuovo follow-up #B (nipote)** → … self-perpetuante by-construction. Nessuna esclusione esisteva.

## Implementato

- **Gate grandchild-suppression (zero-Claude)** — nuovo \`scripts/ci/is-followup-fix-pr.mjs\`: gira in \`post-merge-followup.yml\` **prima** dello step Claude e lo **salta** (\`if: steps.gchild.outputs.is_followup_fix != 'true'\`) quando la PR mergiata chiude/supera (\`Closes\`/\`Fixes\`/\`Resolves\`/\`Supersedes #N\`) una issue con label \`follow-up\`. Rompe il loop nipote by-construction + risparmia la run di triage. **Proceed-safe**: body illeggibile / ref non parsati / \`gh issue view\` in errore → \`false\` → triage gira (mai perdere un follow-up di PR organica).
- **Riuso single-source (AGENTS.md #6)** — estratto \`closedIssueRefs()\` in \`scripts/ci/followup-resolution-match.mjs\` come unica fonte del parsing close-keyword; \`closingMergedPr()\` rifattorizzato per usarlo (stessa regex, drift impossibile). Comportamento invariato: i consumer (\`check-issue-already-resolved\`, \`reconcile-followups\`) restano verdi.
- **Workflow wiring** — \`post-merge-followup.yml\`: nuovo step \`Grandchild-suppression gate\` (id \`gchild\`) + gate sullo step Claude. Lo step retry (\`if: failure()\`) non scatta sullo skip; usage-metrics (\`if: always()\`) tollera execution_file vuoto (smoke-test exit 0).
- **Nit-disposition rule al review-time (REVIEW.md)** — ogni 🟡 deve dichiarare la disposizione: non-funnel → suffisso \`— deferred, non funnel-critical\` (droppato, no issue, via eccezione esistente); solo funnel-critical+azionabile minta. Sposta il triage del nit a sinistra (al review, gratis) invece che a destra (minting → \`agent:fix\` → \`pr-review\`), **senza** bloccare l'auto-merge sui nit (bloccare ogni nit sposterebbe il burn in \`pr-review-loop\` su 357 PR/sett).
- **Doc** — FOLLOWUP.md § \"Gate grandchild-suppression\" documenta meccanismo + proceed-safe.
- **Test** — 7 casi \`closedIssueRefs\` (multi-issue, separatori, varianti keyword, word-break, dedup, proceed-safe); 62 test verdi sui moduli toccati. Gate validato **end-to-end su PR reali**: #2209 (closes follow-up #2190) → \`true\` (skip); #2181 (closes #2177) → \`true\`; #2205 (organica) → \`false\`.

## Non implementato (ancora)

- **Cleanup dei ~17 \`fu-parked\` + reparked deadweight** — out of scope: l'owner ha selezionato solo lo stop-minting + la nit-rule, non il cleanup backlog. L'age-out (21d) li chiude comunque automaticamente. Follow-up se l'owner lo richiede esplicitamente.
- **Lever 2 (no follow-up da soli reviewer-nit) e Lever 3 (no singleton low-prio)** — posposti: non selezionati. La nit-disposition rule copre già parzialmente lo scope di Lever 2 a monte.
- **Sibling-class sweep** — i file gemelli flaggati da \`check-sibling-patterns\` (\`check-issue-already-resolved.mjs\`, \`reconcile-followups.mjs\`, \`issue-fix.yml\`, \`pr-redflag-fixer.yml\`, \`pr-review-loop.yml\`) condividono solo **idiomi comuni** (\`repoArgs\`/\`setOutput\`/\`PR_NUMBER\`) o sono **consumer** del modulo condiviso già rifattorizzato — nessuno ha il costrutto nuovo (\`closedIssueRefs\`/gate). Nessun sibling-fix dovuto.
- **Effetto sul volume — non validabile pre-merge**: la riduzione reale di run Claude/sett si osserva solo post-merge sul trend di \`loop-health-report.mjs\`. Revert-trigger: se il gate dovesse skippare triage su PR organiche (follow-up persi) → revert. Atteso: il gate è proceed-safe verso il run-triage, quindi il rischio è zero-mancati, al più mancato-skip (over-mint = stato attuale).

## Note merge

Tocca \`post-merge-followup.yml\` + \`REVIEW.md\` + \`FOLLOWUP.md\` (workflow-validation special set) → il reviewer GitHub App non posta e l'auto-merge non scatta → **merge manuale** \`gh pr merge --squash --delete-branch\` previa conferma test/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)