### PR TITLE
chore(robots): block no-value bots on value grounds (cap moot under Workers Paid)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -107,13 +107,18 @@ Allow: /
 User-agent: PerplexityBot
 Allow: /
 
-# Amazon / Alexa — welcome, but rate-limited: Amazonbot honors Crawl-delay
-# (per Amazon's crawler docs) and was fetching ~24k locale-shard pages/day,
-# each one a Cloudflare Worker invocation against the free-tier 100k/day cap.
-# 10s ≈ max 8.6k fetches/day, plenty for Alexa/Rufus freshness on this site.
+# Amazon / Alexa (Rufus) — blocked. Not an organic-search, AI-search, or
+# referral channel for an Italian cross-border-worker audience: brings no SEO
+# traffic, no clicks, no monetizable traffic, only ~15-24k fetches/day of load
+# (was the biggest non-search chunk per #1867). The free-tier Worker cap that
+# first forced a Crawl-delay is now moot (Workers Paid), but the block stays on
+# value grounds. Enforced for the /en /de /fr shards by a Cloudflare WAF rule
+# (scripts/cf-locale-failover-setup.mjs) since Amazonbot honors this directive
+# site-wide anyway. AI-search/citation crawlers (GPTBot, ClaudeBot, OAI-
+# SearchBot, PerplexityBot, Google-Extended) stay welcomed above — they DO feed
+# the visibility channel.
 User-agent: Amazonbot
-Allow: /
-Crawl-delay: 10
+Disallow: /
 
 # Apple
 User-agent: Applebot
@@ -122,9 +127,14 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
-# Bytedance
+# Bytedance (TikTok / Doubao) — blocked. Training/scraper crawler with no
+# organic-search, AI-search, or referral visibility for this audience: no SEO
+# traffic, no clicks, no monetizable traffic. Bytespider commonly ignores
+# robots.txt, so this directive is best-effort; hard enforcement on the
+# /en /de /fr shards is via the Cloudflare WAF rule
+# (scripts/cf-locale-failover-setup.mjs).
 User-agent: Bytespider
-Allow: /
+Disallow: /
 
 # Cohere
 User-agent: cohere-ai
@@ -195,11 +205,12 @@ Allow: /
 
 # ─── SEO-tool crawlers — blocked ──────────────────────────────────────────
 # Backlink/keyword-tool crawlers bring zero search or AI visibility and no
-# referral traffic; on the /en /de /fr locale shards every fetch is a
-# Cloudflare Worker invocation that counts against the free-tier 100k/day cap
-# (AhrefsBot alone: ~10k fetches/day measured 2026-06-11). All of these honor
-# robots.txt. Ad-verification crawlers (IAS, proximic) stay ALLOWED — they
-# validate inventory for AdSense advertisers (~95% of revenue).
+# referral traffic — no SEO, no clicks, no monetizable traffic — and they
+# expose our backlink profile to competitors. Blocked on value grounds
+# regardless of the Worker cap (now moot under Workers Paid; AhrefsBot alone was
+# ~10k fetches/day measured 2026-06-11). All of these honor robots.txt. Ad-
+# verification crawlers (IAS, proximic) stay ALLOWED — they validate inventory
+# for AdSense advertisers (~95% of revenue).
 
 User-agent: AhrefsBot
 Disallow: /

--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -32,12 +32,13 @@
  * 3. FIREWALL RULES — the managed entries in MANAGED_FIREWALL_RULES (keyed by
  *    `description`; foreign rules on the entrypoint preserved). Currently one:
  *    locale-bot-throttle-noindex-scrapers — blocks non-search scraper bots
- *    (Amazonbot + SEO tools) on the /en|/de|/fr paths ONLY. The
- *    WAF runs BEFORE the Worker, so a challenged request never invokes it —
- *    the only free lever to keep daily invocations under the now-ENFORCED 100k
- *    cap (Origin Rules host-override, the no-Worker alternative, is Enterprise-
- *    only). Real search + AI-search crawlers are deliberately NOT matched, so
- *    the visibility channel keeps getting live locale content (#1867).
+ *    (Amazonbot + Bytespider) on the /en|/de|/fr paths ONLY. Kept on value
+ *    grounds: these bring no SEO traffic, no clicks, no monetizable traffic.
+ *    (It also kept Worker invocations under the old free 100k/day cap — now moot
+ *    under Workers Paid — since the WAF runs BEFORE the Worker; that's a bonus,
+ *    no longer the reason.) Real search + AI-search crawlers are deliberately
+ *    NOT matched, so the visibility channel keeps getting live locale content
+ *    (#1867).
  *
  * Auth: CF_API_TOKEN — needs Zone→Workers Routes:Edit (already required by
  * deploy-worker.yml) + Zone→Zone Settings/Cache Rules:Edit + Zone→Firewall
@@ -57,10 +58,14 @@ const WORKER_SCRIPT = 'frontaliere-locale-router';
 const CACHE_PHASE = 'http_request_cache_settings';
 const FIREWALL_PHASE = 'http_request_firewall_custom';
 
-// Non-visibility crawlers throttled on the locale paths ONLY. The Worker's free
-// 100k invocations/day cap is now ENFORCED (observed flat at ~103k, locale 404
-// over-cap — see locale-router.js header + issue #1867); the WAF runs BEFORE the
-// Worker, so blocking a request here means it never invokes the Worker.
+// Non-visibility crawlers blocked on the locale paths ONLY. These bring no SEO
+// traffic, no clicks, and no monetizable traffic for this audience (owner value
+// policy), so they stay blocked. The block originally also relieved the free
+// Worker 100k invocations/day cap (see locale-router.js header + issue #1867);
+// that cap is now moot (account moved to Workers Paid), but the WAF rule is kept
+// purely on value grounds. The WAF runs BEFORE the Worker, so blocking a request
+// here also means it never invokes the Worker — a free bonus, no longer the
+// reason.
 //
 // Scope = exactly the two crawlers the owner approved carving out of the verified
 // crawler allowlist (the foreign skip rule "Allowlist verified SEO + AI crawlers"


### PR DESCRIPTION
## Contesto

L'account è passato a **Workers Paid** → il cap free 100k invocazioni/giorno (motivo originale dei throttle bot) è **moot** (verificato live: subscription `workers_paid` state `Paid`; `default_usage_model: standard`).

Il goal iniziale era "riattiva i bot", ma su domanda esplicita il criterio scelto dall'owner è il **valore**: bloccare i crawler che non portano **traffico SEO, click, o traffico monetizzabile**. Applicato qui — quindi NON riattivo Amazonbot/Bytespider/scraper-SEO; li allineo alla regola valore.

## Implementato

- **robots.txt — Amazonbot**: `Allow: /` + `Crawl-delay: 10` → `Disallow: /`. Amazonbot rispetta robots.txt → blocco effettivo site-wide. Niente SEO/click/revenue per l'audience frontaliera (Alexa/Rufus).
- **robots.txt — Bytespider**: `Allow: /` (era nella sezione "welcome") → `Disallow: /`. Training crawler ByteDance/TikTok, zero visibilità organica/AI/referral. Best-effort (Bytespider spesso ignora robots.txt → enforcement vero via WAF, sotto).
- **robots.txt — scraper SEO** (Ahrefs/Semrush/MJ12bot/DotBot/BLEXBot/DataForSeoBot/serpstatbot): restano `Disallow: /`; commento riformulato da cap-driven a value-driven (zero valore + leak profilo backlink ai competitor).
- **robots.txt — crawler di visibilità** (GPTBot, ClaudeBot, OAI-SearchBot, PerplexityBot, Google-Extended, Googlebot, Bingbot, ad-verification IAS/proximic): **intatti** — alimentano il canale visibilità/citazioni/revenue.
- **cf-locale-failover-setup.mjs — solo commenti**: la regola WAF managed che fa 403 su Amazonbot+Bytespider su `/en|/de|/fr` è **invariata** (`description`/`expression`/constants byte-identici → `deploy-worker.yml` ri-asserisce la stessa regola). Commenti riformulati da "alleggerire il cap 100k" a "value policy (cap ora moot sotto Paid)"; corretta anche una imprecisione preesistente ("Amazonbot + SEO tools" → "Amazonbot + Bytespider", la regola non tocca gli SEO-tool che sono solo in robots.txt).

Verifiche: live pre-change (Amazonbot/Bytespider → 403 su /en/, 200 su IT; Googlebot 200 ovunque); `node --check` sullo script OK; sibling-pattern check pulito (nessun costrutto distintivo); nessun test asserisce le righe robots.txt cambiate.

## Non implementato (ancora)

- **Enforcement WAF su Bytespider per le path IT (apex)**: la regola WAF resta locale-scoped (`/en|/de|/fr`), com'era. Bytespider ignora robots.txt → su IT continua a scrapare (nessun WAF lì). Lasciato fuori scope per restare chirurgico e non allargare il blast-radius sulla allowlist owner delle path IT; estendibile in follow-up con un one-liner (rimuovere il vincolo `LOCALE_PATH_MATCH` dalla regola) se vuoi enforcement hard ovunque. Amazonbot invece è già coperto site-wide perché onora robots.txt.
- **Caching/TTL del Worker** (#1865/#2064/#1886): non toccati — non bloccano bot, restano benefici perf anche sotto Paid.
- **Re-audit dell'intera allowlist AI** (CCBot, cohere-ai, DeepSeekBot, MistralBot, ecc.): fuori scope. La regola valore è applicata ai bot in discussione (Amazonbot/Bytespider/scraper-SEO); la strategia citation dell'owner per gli altri AI crawler resta invariata. Da rivedere separatamente se vuoi applicare lo stesso filtro click/monetizzabile a tutta la lista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)