### PR TITLE
feat(locale-router): stale-if-error — serve last-good copy on origin 5xx/timeout

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -21,28 +21,35 @@
  * `cf: { cacheEverything, cacheTtl }` on the origin fetch — keyed on the
  * origin-{loc} URL, tiered across colos.
  *
- * Cache API (caches.default): WRITE-ONLY, apex-keyed, for the over-cap
- * failover. A routed Worker is invoked on EVERY matching request — the edge
- * cache cannot answer in front of it ("Workers run before the cache"), so on
- * the free plan nothing here reduces the 100k/day invocation count. What CAN
- * answer without the Worker is the fail-open path: when the daily cap is
- * exceeded and the route is configured `request_limit_fail_open: true`,
- * Cloudflare bypasses the Worker and the request flows through the normal CDN
- * pipeline. cache.put() below stores every shard 200 under its PUBLIC apex
- * URL so that pipeline finds it (a zone Cache Rule marks /en|/de|/fr eligible
- * for cache lookup — see scripts/cf-locale-failover-setup.mjs, re-run by
- * deploy-worker.yml after every deploy). Net effect over cap: warm pages keep
- * serving 200 (stale ≤24h) instead of error 1027 on everything.
+ * Cache API (caches.default): apex-keyed. WRITTEN on every happy-path shard
+ * 200 (below); READ only when the origin fails (5xx / timeout / network) to
+ * serve a stale copy — see serveStaleOnError + the cache.match() note below.
+ * The stored copy does double duty: (1) stale-if-error (serve last-good 200
+ * instead of propagating an origin 5xx to crawlers/users), and (2) the over-cap
+ * fail-open path on the free plan — when the daily cap is exceeded and the
+ * route is configured `request_limit_fail_open: true`, Cloudflare bypasses the
+ * Worker and the request flows through the normal CDN pipeline, which finds
+ * this apex-keyed copy (a zone Cache Rule marks /en|/de|/fr eligible for cache
+ * lookup — see scripts/cf-locale-failover-setup.mjs, re-run by deploy-worker.yml
+ * after every deploy). A routed Worker is invoked on EVERY matching request —
+ * the edge cache cannot answer in front of it ("Workers run before the cache")
+ * — so this never reduces invocation count; it only changes WHAT is served on
+ * error (last-good 200 vs an error page).
  *
  * Cache API history (#1791/#1814/#1830/#1842): every Cache API op is logged in
  * zone analytics as a synthetic `requestSource: edgeWorkerCacheAPI` row —
  * cache.match() MISSes as phantom 504s (misread as an outage, three PR cycles
- * burned) and cache.put()s as 204s. This Worker therefore: (a) never calls
- * cache.match() — the request path stays single-consumer, no tee (the put copy
- * is built from an explicit arrayBuffer, not a stream tee, so the #1791
- * deadlock class is structurally impossible); (b) tolerates the returning 204
- * put rows because monitoring filters `requestSource: "eyeball"` since #1842
- * (scripts/lib/cf-analytics.mjs). Keep both properties when touching this.
+ * burned) and cache.put()s as 204s. This Worker therefore: (a) calls
+ * cache.match() ONLY on the origin-error path (serveStaleOnError), never on the
+ * happy path — there the origin has already failed, so there is no live origin
+ * body to tee: the request path stays single-consumer and the #1791 deadlock
+ * class (a slow eyeball consumer stalling a tee'd cache branch) remains
+ * structurally impossible; the happy-path put copy is likewise built from an
+ * explicit arrayBuffer, not a stream tee. The extra phantom-504 match rows are
+ * bounded by the origin failure rate (~0.02%, ~50/day zone-wide) and filtered
+ * out by the `requestSource: "eyeball"` monitoring since #1842
+ * (scripts/lib/cf-analytics.mjs); (b) tolerates the returning 204 put rows for
+ * the same reason. Keep both properties when touching this.
  *
  * Asset/data/og refs in shard HTML are CDN-absolute (since #1665), so those
  * requests bypass this Worker entirely.
@@ -147,6 +154,39 @@ async function fetchOriginWithRetry(upstream, request, cfOpts) {
   throw lastErr;
 }
 
+// Stale-if-error. When the shard origin fails (5xx after retries, or a thrown
+// timeout/network error), serve the last-good apex-keyed copy that the happy
+// path stored in caches.default — instead of propagating the error to a
+// crawler (SEO) or user (revenue). This is the ONLY place the Worker reads the
+// Cache API; the header cache.match() note explains why doing so here is free
+// of the #1791 deadlock class (no live origin body to tee on the error path).
+//
+// "while-revalidate" half: the returned copy carries short Cache-Control so it
+// is re-checked soon, and because the Worker runs on every request the NEXT
+// request re-fetches the origin and, on recovery, re-stores a fresh copy via
+// the happy-path cache.put — no explicit background revalidation needed.
+//
+// Returns a 200 Response on HIT, or null on MISS / cache error so the caller
+// falls back to surfacing the origin error. Only meaningful for GET (the cache
+// holds GET 200s); callers guard on method.
+async function serveStaleOnError(url, reason) {
+  try {
+    const cached = await caches.default.match(
+      new Request(url.toString(), { method: 'GET' }),
+    );
+    if (cached) {
+      const headers = new Headers(cached.headers);
+      // Short TTLs: a stale page must be re-checked soon, not held for hours.
+      headers.set('Cache-Control', 'public, max-age=60, s-maxage=120');
+      headers.set('X-Served-Stale', reason);
+      return new Response(cached.body, { status: 200, statusText: 'OK', headers });
+    }
+  } catch {
+    // caches.default unavailable / match threw — treat as a MISS.
+  }
+  return null;
+}
+
 export default {
   async fetch(request, _env, ctx) {
     const url = new URL(request.url);
@@ -178,13 +218,26 @@ export default {
         cacheTtl: ORIGIN_CACHE_TTL,
       });
     } catch {
-      // Every attempt timed out / threw — no origin response. Short Retry-After:
+      // Every attempt timed out / threw — no origin response. Prefer a last-good
+      // stale copy (stale-if-error) over an error page. Short Retry-After:
       // measured failure rate at this layer is ~0.02% (50×503/day zone-wide),
       // and CF's tiered cache absorbs repeats, so a transient blip self-heals.
+      if (request.method === 'GET') {
+        const stale = await serveStaleOnError(url, 'origin-timeout');
+        if (stale) return stale;
+      }
       return new Response('Shard origin unavailable', {
         status: 503,
         headers: { 'Retry-After': '30' },
       });
+    }
+
+    // Stale-if-error: origin answered but with a 5xx after retries. Serve the
+    // last-good cached copy instead of propagating the error to crawler/user.
+    // Falls through to return the 5xx as-is on a cache MISS.
+    if (request.method === 'GET' && resp.status >= 500) {
+      const stale = await serveStaleOnError(url, `origin-${resp.status}`);
+      if (stale) return stale;
     }
 
     // GitHub Pages 301s a dir path without trailing slash (e.g. /en/lavoro ->

--- a/tests/locale-router-stale-if-error.test.ts
+++ b/tests/locale-router-stale-if-error.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Stale-if-error behaviour of the Cloudflare locale-router Worker.
+ *
+ * When a shard origin fails (5xx after retries, or a thrown timeout/network
+ * error) the Worker must serve the last-good apex-keyed copy stored in
+ * caches.default — instead of propagating the error to a crawler (SEO) or a
+ * user (revenue). On a cache MISS it falls back to surfacing the origin error.
+ *
+ * The Worker uses Web-platform globals (fetch, caches, Request, Response, URL,
+ * Headers, AbortController). jsdom/Node provide all but `caches`, which we mock
+ * here together with `fetch`. No miniflare harness needed: we import the
+ * module's default export and call its fetch() directly.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error — plain JS Worker module, no type declarations.
+import worker from '../infra/cloudflare-worker/locale-router.js';
+
+const APEX = 'https://frontaliereticino.ch';
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+
+let cacheStore: Map<string, Response>;
+
+beforeEach(() => {
+  cacheStore = new Map();
+  // Minimal Cache API shim keyed by request URL.
+  const cache = {
+    match: vi.fn(async (req: Request) => {
+      const key = typeof req === 'string' ? req : req.url;
+      const hit = cacheStore.get(key);
+      return hit ? hit.clone() : undefined;
+    }),
+    put: vi.fn(async (req: Request, res: Response) => {
+      const key = typeof req === 'string' ? req : req.url;
+      cacheStore.set(key, res.clone());
+    }),
+  };
+  (globalThis as unknown as { caches: { default: typeof cache } }).caches = { default: cache };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as unknown as { caches?: unknown }).caches;
+});
+
+function seedCache(url: string, body: string): void {
+  cacheStore.set(
+    url,
+    new Response(body, { status: 200, headers: { 'Cache-Control': 'public, max-age=300, s-maxage=86400' } }),
+  );
+}
+
+describe('locale-router stale-if-error', () => {
+  it('serves the stale cached copy when the shard origin returns 5xx', async () => {
+    const path = `${APEX}/en/jobs/`;
+    seedCache(path, '<html>last-good EN</html>');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 503 }));
+
+    const res = await worker.fetch(new Request(path), {}, ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Served-Stale')).toBe('origin-503');
+    expect(res.headers.get('Cache-Control')).toContain('max-age=60');
+    expect(await res.text()).toBe('<html>last-good EN</html>');
+  });
+
+  it('serves the stale cached copy when the shard origin throws (timeout/network)', async () => {
+    const path = `${APEX}/de/lavoro/`;
+    seedCache(path, '<html>last-good DE</html>');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const res = await worker.fetch(new Request(path), {}, ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Served-Stale')).toBe('origin-timeout');
+    expect(await res.text()).toBe('<html>last-good DE</html>');
+  });
+
+  it('propagates the origin 5xx when there is no cached copy', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 502 }));
+
+    const res = await worker.fetch(new Request(`${APEX}/fr/emploi/`), {}, ctx);
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get('X-Served-Stale')).toBeNull();
+  });
+
+  it('returns 503 on origin throw when there is no cached copy', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const res = await worker.fetch(new Request(`${APEX}/en/missing/`), {}, ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Retry-After')).toBe('30');
+  });
+
+  it('does not serve stale for a healthy 200 (happy path unaffected)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html>fresh</html>', { status: 200 }),
+    );
+
+    const res = await worker.fetch(new Request(`${APEX}/en/ok/`), {}, ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Served-Stale')).toBeNull();
+    expect(await res.text()).toBe('<html>fresh</html>');
+  });
+});


### PR DESCRIPTION
## Implementato

- **Stale-if-error nel locale-router Worker** (`infra/cloudflare-worker/locale-router.js`): quando l'origin shard (`origin-{en,de,fr}.frontaliereticino.ch` su GitHub Pages) torna un **5xx dopo i retry** o **lancia** (timeout/network), il Worker serve l'ultima copia buona apex-keyed da `caches.default` invece di propagare l'errore a crawler (SEO) o utenti (revenue). Su **cache MISS** fallback al comportamento precedente (5xx as-is, o 503 sul throw).
- Nuovo helper `serveStaleOnError(url, reason)` — ritorna 200 con header `X-Served-Stale` + `Cache-Control` corto (`max-age=60, s-maxage=120`) così la pagina si rivalida presto; la metà "while-revalidate" avviene naturalmente alla richiesta successiva (il Worker gira su ogni request, ri-fetch origin, e sul recupero ri-salva fresh via il `cache.put` dell'happy path). Nessuna scrittura cache nuova: riusa la copia che l'happy path già memorizza per il fail-open over-cap.
- Wiring nei **due** path d'errore del ramo shard: dopo il throw (catch) e sul `resp.status >= 500`. Guardato su `GET` (la cache contiene solo GET 200).
- **Docblock header aggiornato** (obbligo no-stale-comment): la nota "Cache API WRITE-ONLY / never calls cache.match()" ora riflette la lettura sul solo error-path — `cache.match()` chiamato SOLO dove l'origin ha già fallito (nessun body live da tee → classe deadlock #1791 resta strutturalmente impossibile; le phantom-504 row sono bounded dal ~0.02% failure rate e filtrate dal monitoring `requestSource: "eyeball"` dal #1842).
- **Test** `tests/locale-router-stale-if-error.test.ts` (5 casi: 5xx+HIT→stale, throw+HIT→stale, 5xx+MISS→propaga, throw+MISS→503, 200 sano→intatto). Mock di `caches`+`fetch`, nessun harness miniflare. Verde locale.

Deploy: `deploy-worker.yml` ridi­spiega il Worker su push a `main` che tocca `infra/cloudflare-worker/**`. Verifica live post-merge.

## Non implementato (ancora)

- **Blocco hard bot no-value sull'apex IT** — follow-up: l'analisi traffico (Jun-14) mostra **Amazonbot ancora a ~330/campione** nonostante il `Disallow` in `robots.txt`; il blocco WAF in `cf-locale-failover-setup.mjs` copre **solo gli shard `/en/de/fr`**, non l'apex IT (best-effort robots). Inoltre il bucket UA più grande è **"(nessun UA)" ~776** (ignoto, probabile OTTO-internal/scraper). Estendere il WAF all'apex IT + challenge no-UA è scope separato (cfr. #2195). Out of scope qui: questa PR è solo resilienza cache, non bot-management.
- **Stale-if-error sul ramo IT passthrough** — non applicato: quel ramo non scrive copie apex-keyed (nessun `cache.put`) ed è comunque irraggiungibile (wrangler scope = solo locale). Niente da servire stale.
- **Background revalidation esplicita** — non necessaria: la rivalidazione avviene alla request successiva (Worker gira su ogni request). Aggiungere un `ctx.waitUntil(fetch())` rivaliderebbe verso un origin già in errore → inutile.

## Note su issue correlate
- #1867 / #1688 ("taglio invocazioni *verso il cap 100k/day*") sono **moot** dopo il passaggio a Workers Paid (cap 100k/day rimosso, ora 10M/mese). Non chiuse qui (decisione separata), segnalate per triage.
- #2195 (throttle Amazonbot/Bytespider) confermata dall'analisi bot sopra ma non risolta qui (scope bot-management ≠ resilienza cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)