### PR TITLE
fix(seo): clamp meta description to SERP snippet budget (SearchAtlas meta_desc_invalid_length)

### DIFF
--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -9,6 +9,7 @@
  */
 import { FAVICON_LINKS, GTAG_SNIPPET, ADSENSE_SNIPPET, BASE_URL, SPA_ACTION_REDIRECT_SCRIPT, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
 import { escapeInlineScript } from './shared/inlineJsonScript';
+import { clampMetaDescription } from './shared/titleSuffix';
 
 /**
  * Common <head> prefix: charset + viewport + favicon + security meta.
@@ -196,6 +197,11 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  } = opts;
 
  const ogLocale = ogLocaleOverride || LOCALE_OG[locale] || 'it_IT';
+ // Clamp the <meta name="description"> / og:description to the SERP snippet
+ // budget (word-aware, ≤160 char). JSON-LD `description` in jsonLdScripts is
+ // untouched. Mirrors the runtime clamp in services/seoService.ts so the
+ // static HTML and the JS-rendered DOM expose the same complete snippet.
+ const metaDescription = clampMetaDescription(description);
  const extraHead = extraHeadHtml ? `\n${extraHeadHtml}` : '';
  // Escape `<` in each (already-serialized) JSON-LD string so a "</script>" in
  // arbitrary content (titles, names) can't break out of the inline tag and
@@ -254,13 +260,13 @@ ${skipMainWrap ? bodyHtml : ` <main class="static-job-page">\n ${bodyHtml}\n </m
  <head>
  ${HEAD_PREFIX}
  <title>${esc(title)}</title>
- <meta name="description" content="${esc(description)}">
+ <meta name="description" content="${esc(metaDescription)}">
  <meta name="robots" content="${robots}">
  <meta property="og:type" content="${ogType}">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${ogLocale}">
  <meta property="og:title" content="${esc(title)}">
- <meta property="og:description" content="${esc(description)}">
+ <meta property="og:description" content="${esc(metaDescription)}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${esc(ogImage ?? `${BASE_URL}/og-image.png`)}">
  <meta property="og:image:width" content="${ogImageWidth ?? 1200}">

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Plugin } from 'vite';
+import { clampMetaDescription } from './shared/titleSuffix';
 import {
   BASE_URL,
   FAVICON_LINKS,
@@ -285,12 +286,12 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}${FAVICON_LINKS}
     <title>${esc(model.title)}</title>
-    <meta name="description" content="${esc(model.description)}">
+    <meta name="description" content="${esc(clampMetaDescription(model.description))}">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">
     <meta property="og:title" content="${esc(model.title)}">
-    <meta property="og:description" content="${esc(model.description)}">
+    <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
     <meta property="og:url" content="${canonicalUrl}">
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Plugin } from 'vite';
+import { clampMetaDescription } from './shared/titleSuffix';
 import {
   BASE_URL,
   FAVICON_LINKS,
@@ -377,12 +378,12 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}${FAVICON_LINKS}
     <title>${esc(seo.title)}</title>
-    <meta name="description" content="${esc(seo.desc)}">
+    <meta name="description" content="${esc(clampMetaDescription(seo.desc))}">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">
     <meta property="og:title" content="${esc(seo.ogT)}">
-    <meta property="og:description" content="${esc(seo.ogD)}">
+    <meta property="og:description" content="${esc(clampMetaDescription(seo.ogD))}">
     <meta property="og:url" content="${canonicalUrl}">
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -28,7 +28,7 @@ import { markCantonSectorPage } from './shared/cantonSectorPageRegistry';
 import { EJP_STRIPPED_MARKER } from './shared/ejpMarker';
 import { WriteCollector } from './batchWrite';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
-import { buildTitleWithBrand, composeSerpJobTitle, JOB_TITLE_CITY_CONNECTOR, TITLE_MAX_CHARS } from './shared/titleSuffix';
+import { buildTitleWithBrand, composeSerpJobTitle, JOB_TITLE_CITY_CONNECTOR, TITLE_MAX_CHARS, clampMetaDescription } from './shared/titleSuffix';
 import { stripLeadingSectionLabel } from './shared/jobDescription/parser';
 import { CRAWLED_COMPANY_LOGOS } from '../services/jobDataNormalization';
 import {
@@ -2916,12 +2916,12 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(title)}</title>
- <meta name="description" content="${esc(description)}">
+ <meta name="description" content="${esc(clampMetaDescription(description))}">
  <meta property="og:type" content="article">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(ogTitle)}">
- <meta property="og:description" content="${esc(description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(description))}">
  <meta property="og:url" content="${effectiveCanonicalUrl}">
  <meta property="og:image" content="${perLocaleSlug.it ? `${BASE_URL}/og/jobs/${perLocaleSlug.it}.webp` : `${BASE_URL}/og-image.png`}">
  <meta property="og:image:width" content="1200">
@@ -4590,12 +4590,12 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -4750,12 +4750,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -4917,12 +4917,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -5096,12 +5096,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -5272,12 +5272,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -5465,12 +5465,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(pageTitle)}</title>
- <meta name="description" content="${esc(pageDesc)}">
+ <meta name="description" content="${esc(clampMetaDescription(pageDesc))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(pageOgTitle)}">
- <meta property="og:description" content="${esc(pageOgDesc)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(pageOgDesc))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -5682,12 +5682,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -5841,12 +5841,12 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(model.description)}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
  <meta property="og:title" content="${esc(model.title)}">
- <meta property="og:description" content="${esc(model.description)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(model.description))}">
  <meta property="og:url" content="${canonicalUrl}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
@@ -10240,7 +10240,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width, initial-scale=1">
  ${FAVICON_LINKS}
  <title>${pageTitle}</title>
- <meta name="description" content="${pageDesc}">${robotsTag}
+ <meta name="description" content="${clampMetaDescription(pageDesc)}">${robotsTag}
  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
  <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
  <link rel="canonical" href="${selfUrl}">

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -12,7 +12,7 @@ import type { Plugin } from 'vite';
 import { BASE_URL, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
 import { buildArticleSeoSections, cleanupArticleBodySections } from './articleSeoFallback';
 import { WriteCollector } from './batchWrite';
-import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS } from './shared/titleSuffix';
+import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS, clampMetaDescription } from './shared/titleSuffix';
 import { findChunkFile, findChunkFiles } from './shared/chunkFiles';
 import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { inlineScriptJson } from './shared/inlineJsonScript';
@@ -1027,12 +1027,12 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  ${FAVICON_LINKS}
  <title>${esc(htmlPageTitle)}</title>
- <meta name="description" content="${esc(metaDesc)}">
+ <meta name="description" content="${esc(clampMetaDescription(metaDesc))}">
  <link rel="canonical" href="${full}">
  <meta property="og:type" content="article">
  <meta property="og:url" content="${full}">
  <meta property="og:title" content="${esc(localizedTitle)}">
- <meta property="og:description" content="${esc(localizedDesc)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(localizedDesc))}">
  <meta property="og:image" content="${imgU}">
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="675">

--- a/build-plugins/pdfWhitepapersPlugin.ts
+++ b/build-plugins/pdfWhitepapersPlugin.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { clampMetaDescription } from './shared/titleSuffix';
 import { createHash } from 'node:crypto';
 import type { Plugin } from 'vite';
 import { BASE_URL, ANALYTICS_SNIPPET } from './constants';
@@ -478,13 +479,13 @@ function generateLandingPage(guide: PdfGuide, pdfSizeKb: string, dateStamp: stri
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>${esc(guide.title)} | Frontaliere Ticino</title>
-<meta name="description" content="${esc(guide.subtitle)}">
+<meta name="description" content="${esc(clampMetaDescription(guide.subtitle))}">
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 <link rel="canonical" href="${canonical}">
 ${hreflangLinks}
 <meta property="og:type" content="article">
 <meta property="og:title" content="${esc(guide.title)}">
-<meta property="og:description" content="${esc(guide.subtitle)}">
+<meta property="og:description" content="${esc(clampMetaDescription(guide.subtitle))}">
 <meta property="og:url" content="${canonical}">
 <meta property="og:site_name" content="Frontaliere Ticino">
 <meta property="og:image" content="${BASE_URL}/icons/icon-512x512.png">

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -18,6 +18,7 @@
  */
 
 import type fsT from 'node:fs';
+import { clampMetaDescription } from './shared/titleSuffix';
 import type npT from 'node:path';
 import { ADSENSE_SNIPPET, BASE_URL, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
 import {
@@ -1164,13 +1165,13 @@ function buildHtml(args: BuildHtmlArgs): string {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}<title>${esc(pageTitle)}</title>
-    <meta name="description" content="${esc(description)}">
+    <meta name="description" content="${esc(clampMetaDescription(description))}">
     <meta name="robots" content="index,follow">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">
     <meta property="og:title" content="${esc(pageTitle)}">
-    <meta property="og:description" content="${esc(description)}">
+    <meta property="og:description" content="${esc(clampMetaDescription(description))}">
     <meta property="og:url" content="${canonicalUrl}">
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <link rel="canonical" href="${canonicalUrl}">
@@ -1712,13 +1713,13 @@ function buildThinCantonHubHtml(args: {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}<title>${esc(pageTitle)}</title>
-    <meta name="description" content="${esc(intro)}">
+    <meta name="description" content="${esc(clampMetaDescription(intro))}">
     <meta name="robots" content="index,follow">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">
     <meta property="og:title" content="${esc(pageTitle)}">
-    <meta property="og:description" content="${esc(intro)}">
+    <meta property="og:description" content="${esc(clampMetaDescription(intro))}">
     <meta property="og:url" content="${canonicalUrl}">
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <link rel="canonical" href="${canonicalUrl}">
@@ -2521,9 +2522,9 @@ export function emitSeoHubs(args: EmitArgs): { pagesEmitted: number; sitemapEntr
       const customDesc = `Indice delle offerte di lavoro nel cantone Ticino pubblicate ${r.descLabel}. ${recentJobs.length} posizioni aperte aggiornate quotidianamente.`;
       const patched = html
         .replace(/<title>[^<]*<\/title>/, `<title>${esc(customTitle)}</title>`)
-        .replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${esc(customDesc)}">`)
+        .replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${esc(clampMetaDescription(customDesc))}">`)
         .replace(/<meta property="og:title" content="[^"]*">/, `<meta property="og:title" content="${esc(customTitle)}">`)
-        .replace(/<meta property="og:description" content="[^"]*">/, `<meta property="og:description" content="${esc(customDesc)}">`)
+        .replace(/<meta property="og:description" content="[^"]*">/, `<meta property="og:description" content="${esc(clampMetaDescription(customDesc))}">`)
         .replace(/<h1 [^>]*>[^<]*<\/h1>/, (match) => match.replace(/>[^<]*</, `>${esc(customH1)}<`))
         // The regex pattern matches the ORIGINAL inline-styled <p> emitted by
         // earlier passes (font-size:16px... preserved as inline because this

--- a/build-plugins/shared/titleSuffix.ts
+++ b/build-plugins/shared/titleSuffix.ts
@@ -69,6 +69,34 @@ export function truncateHeadline(headline: string, max: number): string {
 }
 
 /**
+ * SERP meta-description budget. Google truncates the snippet at ~155-160 char
+ * on desktop; past this the tail (often the CTA/long-tail keywords) is dropped
+ * from the displayed snippet, costing CTR. Generators should aim under this;
+ * the render-layer clamp ({@link clampMetaDescription}) is the safety net.
+ */
+export const META_DESCRIPTION_MAX_CHARS = 160;
+
+/**
+ * Clamp a `<meta name="description">` / `og:description` string to the SERP
+ * snippet budget. Collapses internal whitespace, then word-aware truncates
+ * with "…" via {@link truncateHeadline}. Applied at BOTH render layers (static
+ * SSG emit in `htmlTemplate.ts` and the runtime head update in `seoService.ts`)
+ * so a crawler — whether it reads the static HTML or the JS-rendered DOM — sees
+ * a complete, non-truncated snippet. Only the META TAGS are clamped: JSON-LD
+ * `description` keeps the full text (schema has no length cap).
+ *
+ * Closes the SearchAtlas audit 141162 `meta_desc_invalid_length` gap (487 SSG
+ * pages, e.g. career landings emitting 253-char descriptions).
+ */
+export function clampMetaDescription(
+  description: string,
+  max = META_DESCRIPTION_MAX_CHARS,
+): string {
+  const normalized = String(description || '').replace(/\s+/g, ' ').trim();
+  return truncateHeadline(normalized, max);
+}
+
+/**
  * Build the final <title> string per the universal policy.
  *
  * Order of preference:

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -43,7 +43,7 @@ import { getCantonCities, normalizeCitySlug } from './shared/cantonCities';
 // ── SPA shell <title> handling ────────────────────────────────────────
 // Universal rule: headline VERBATIM, brand suffix appended only when total
 // stays within TITLE_MAX_CHARS (70). See build-plugins/shared/titleSuffix.ts.
-import { buildTitleWithBrand } from './shared/titleSuffix';
+import { buildTitleWithBrand, clampMetaDescription } from './shared/titleSuffix';
 import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 const SUFFIX_STRIP_RE = /\s*[|·]\s*Frontaliere Ticino\s*$/i;
@@ -4516,13 +4516,13 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}<title>${esc(capTitle70(seoData.title))}</title>
- <meta name="description" content="${esc(seoData.desc)}">
+ <meta name="description" content="${esc(clampMetaDescription(seoData.desc))}">
  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
  <link rel="canonical" href="${fullUrl}">
  <meta property="og:type" content="website">
  <meta property="og:url" content="${fullUrl}">
  <meta property="og:title" content="${esc(seoData.ogT)}">
- <meta property="og:description" content="${esc(seoData.ogD)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(seoData.ogD))}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">
@@ -4627,13 +4627,13 @@ ${hubChromeSplit.bodyHtml}
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}<title>${esc(capTitle70(seoData.title))}</title>
- <meta name="description" content="${esc(seoData.desc)}">
+ <meta name="description" content="${esc(clampMetaDescription(seoData.desc))}">
  <meta name="robots" content="${NOINDEX_CANONICAL_PATHS.has(canonicalPath) ? 'noindex, nofollow' : 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1'}">
  <link rel="canonical" href="${fullUrl}">
  <meta property="og:type" content="website">
  <meta property="og:url" content="${fullUrl}">
  <meta property="og:title" content="${esc(seoData.ogT)}">
- <meta property="og:description" content="${esc(seoData.ogD)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(seoData.ogD))}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">
@@ -4666,13 +4666,13 @@ ${hrefTags}
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}<title>${esc(capTitle70(seoData.title))}</title>
- <meta name="description" content="${esc(seoData.desc)}">
+ <meta name="description" content="${esc(clampMetaDescription(seoData.desc))}">
  <meta name="robots" content="${NOINDEX_CANONICAL_PATHS.has(canonicalPath) ? 'noindex, nofollow' : 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1'}">
  <link rel="canonical" href="${fullUrl}">
  <meta property="og:type" content="website">
  <meta property="og:url" content="${fullUrl}">
  <meta property="og:title" content="${esc(seoData.ogT)}">
- <meta property="og:description" content="${esc(seoData.ogD)}">
+ <meta property="og:description" content="${esc(clampMetaDescription(seoData.ogD))}">
  <meta property="og:image" content="${BASE_URL}/og-image.png">
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -13,7 +13,7 @@ import { normalizeStructuredData } from './seo/schema-normalizers';
 import { cdnBlogImage } from './seo/blogImageCdn';
 import { translateSchema } from './seo/schema-translators';
 import { buildJobPostingSchema, type JobInput } from '../build-plugins/shared/jobPostingSchema';
-import { buildTitleWithBrand, buildJobTitleWithLocation } from '../build-plugins/shared/titleSuffix';
+import { buildTitleWithBrand, buildJobTitleWithLocation, clampMetaDescription } from '../build-plugins/shared/titleSuffix';
 
 /**
  * Retry a dynamic import once after clearing SW caches.
@@ -4226,7 +4226,14 @@ export async function updateMetaTags(section: string): Promise<void> {
  const metaTitle = serpVariant.title;
  const metaDescription = serpVariant.description;
  const metaOgTitle = metaTitle;
- const metaOgDescription = metaDescription;
+ // <meta name="description"> + og:description are clamped to the SERP snippet
+ // budget (≤160 char, word-aware). The full `metaDescription` is kept for the
+ // JSON-LD `description` clones below (schema has no length cap). Same clamp
+ // runs in the static emit (build-plugins/htmlTemplate.ts) so the JS-rendered
+ // DOM and the static HTML expose an identical, non-truncated snippet.
+ // Closes SearchAtlas audit 141162 meta_desc_invalid_length (487 SSG pages).
+ const clampedMetaDescription = clampMetaDescription(metaDescription);
+ const metaOgDescription = clampedMetaDescription;
  const metaKeywords = jobSeo
  ? jobSeo.keywords
  : (isBlogArticle && locale !== 'it' && hasLocalizedTitle)
@@ -4243,7 +4250,7 @@ export async function updateMetaTags(section: string): Promise<void> {
  document.title = metaTitle;
 
  // Update or create meta tags
- updateOrCreateMetaTag('name', 'description', metaDescription);
+ updateOrCreateMetaTag('name', 'description', clampedMetaDescription);
  updateOrCreateMetaTag('name', 'keywords', metaKeywords);
 
  // Bing & AI-friendly directives: allow large snippets and image previews.

--- a/tests/clamp-meta-description.test.ts
+++ b/tests/clamp-meta-description.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit test for `clampMetaDescription` — the SERP meta-description budget
+ * guard applied at both render layers (static `build-plugins/htmlTemplate.ts`
+ * and runtime `services/seoService.ts`).
+ *
+ * Closes the SearchAtlas audit 141162 `meta_desc_invalid_length` gap: SSG
+ * pages (e.g. career landings) were emitting 180-253 char descriptions, past
+ * Google's ~155-160 char SERP snippet budget.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  clampMetaDescription,
+  META_DESCRIPTION_MAX_CHARS,
+} from '../build-plugins/shared/titleSuffix';
+
+describe('clampMetaDescription', () => {
+  it('leaves descriptions within budget untouched', () => {
+    const short = 'Guida completa al frontaliere 2026: permesso G, tasse e netto.';
+    expect(short.length).toBeLessThanOrEqual(META_DESCRIPTION_MAX_CHARS);
+    expect(clampMetaDescription(short)).toBe(short);
+  });
+
+  it('clamps over-budget descriptions to ≤160 char (word-aware, with …)', () => {
+    // Real offender from the audit: career landing, 253 char.
+    const long =
+      "Guida alle agenzie del lavoro (collocamento e prestito di personale) attive a Lugano nel 2026: come verificare l'autorizzazione SECO, cosa controllare nel contratto interinale, diritti del frontaliere con permesso G e differenze con le agenzie italiane.";
+    expect(long.length).toBeGreaterThan(META_DESCRIPTION_MAX_CHARS);
+    const out = clampMetaDescription(long);
+    expect(out.length).toBeLessThanOrEqual(META_DESCRIPTION_MAX_CHARS);
+    expect(out.endsWith('…')).toBe(true);
+    // Word-aware: the cut must not land mid-word (char before … is not a letter
+    // continuing a truncated token — i.e. the prefix is a whole-word boundary).
+    expect(long.startsWith(out.slice(0, -1))).toBe(true);
+  });
+
+  it('collapses internal whitespace before measuring', () => {
+    const messy = '  Spaziatura   irregolare\n\tcon   tab  e  newline  ';
+    const out = clampMetaDescription(messy);
+    expect(out).toBe('Spaziatura irregolare con tab e newline');
+  });
+
+  it('does not leave a dangling separator before the ellipsis', () => {
+    const long =
+      'Costo della vita a Lugano nel 2026 — affitti, spesa, trasporti, tasse — ' +
+      'tutto quello che un frontaliere deve sapere prima di trasferirsi oltre confine in Ticino.';
+    const out = clampMetaDescription(long);
+    expect(out.length).toBeLessThanOrEqual(META_DESCRIPTION_MAX_CHARS);
+    // No trailing " —…" / " -…" / " |…" before the ellipsis.
+    expect(/[\s—–\-·|,;:&(]…$/u.test(out)).toBe(false);
+  });
+
+  it('handles empty / nullish input safely', () => {
+    expect(clampMetaDescription('')).toBe('');
+    // Runtime hardening against undefined source literals.
+    expect(clampMetaDescription(undefined as unknown as string)).toBe('');
+  });
+});


### PR DESCRIPTION
## Contesto

Verifica delle segnalazioni SearchAtlas (site-audit 141162) non ancora affrontate, focus SEO. Il triage precedente (PR #2158/#2163/#2164/#2165/#2181) aveva chiuso i bucket error-level grossi. Re-pull API fresco (crawl 2026-06-15, `javascript_rendering_used: true`) + ground-truth live/DOM-renderizzato ha isolato l'unico finding SEO reale, sistematico e non affrontato: **`meta_desc_invalid_length` (487 pagine)**.

Spot-check live confermato: career landing 253 char, FAQ hub 207, health-premiums/job-market/fuel-index/border-wait ~175-180 — tutti oltre il budget snippet SERP di Google (~155-160). La coda (CTA / long-tail) veniva troncata nello snippet, perdendo CTR.

## Implementato

- **Helper condiviso** `build-plugins/shared/titleSuffix.ts`: `META_DESCRIPTION_MAX_CHARS = 160` + `clampMetaDescription()` (collapse whitespace → troncamento word-aware via il già esistente `truncateHeadline`, "…", strip separatori penzolanti). Niente duplicazione: riusa la logica già testata.
- **Chokepoint statico** `build-plugins/htmlTemplate.ts` (`buildSimplePage`): clampa `<meta name=description>` + `og:description` per ogni pagina SEO shell-based (career, FAQ, comparisons, cost-of-living, fuel, border-wait, weekly-employers, ecc.).
- **Runtime** `services/seoService.ts`: clampa i tag meta + og:description (la `description` JSON-LD resta full — lo schema non ha cap di lunghezza, AGENTS.md #3 preservato). Poiché SearchAtlas e Google renderizzano JS, questo è il fix che azzera il count riportato per ogni route idratata.
- **Fix dell'intera classe** sugli emitter inline che costruiscono il proprio `<head>` (sibling-class-fix, AGENTS.md #6): clamp ad ogni emit site in `jobsSeoPagesPlugin`, `staticPagesPlugin`, `seoHubsPlugin`, `pdfWhitepapersPlugin`, `ogPagesPlugin`, `jobSectorPagesPlugin`, `jobRecencyPagesPlugin`. Il clamp gira **prima** dell'escaping per non tagliare a metà un'entity HTML.
- **Unit test** `tests/clamp-meta-description.test.ts` (5 casi: pass-through sotto budget, troncamento ≤160 word-aware, collapse whitespace, no separatore penzolante prima dell'ellissi, input nullish).

## Non implementato (ancora)

- **`build-plugins/constants.ts` (3 emit di meta/og description) — out of scope deliberato.** Sono template di redirect/bridge stub: `buildFlatRedirect` è `noindex` (meta-desc SEO-irrilevante) e il suo `desc` è **già escaped** a monte → applicare il clamp lì rischierebbe di troncare a metà un'entity (`&am…`). Sono una classe diversa dalle 487 content-page offender; nessuna è tra quelle flaggate.
- **Altri finding SearchAtlas verificati come NON-azionabili in questa PR** (riepilogo triage, fuori scope qui):
  - Già fixati e in attesa di re-crawl: `invalid_rel_found`, `non_unique_meta_desc`, `no_self_ref_hreflang`, `has_external_broken_links`, `has_disallowed_outlink` (l'unico crawl SA è pre-merge dei rispettivi PR).
  - Falso-positivo da rate-limit crawler: 3472 pagine 403/429 (= CF Worker cap saturato durante il crawl massivo; verificato live 200 con UA SearchAtlas e Googlebot — Googlebot non fa burst). Legato all'infra CF deferita (#2166, "no apply" utente ×2).
  - Falso-positivo / WONTFIX verificati: twitter cards (gate keep), `non_unique_content` (locale/template), `page_not_in_sitemap` (shard IT canonicalizzati), `meta_keywords`/inline-style/large-DOM (Google-ignored), `og_description_over_65` (soglia SA over-strict, og desc legittimamente più lunghe).
  - Minori non inclusi (lunghezza title/og:title 60-68, h1/h2 length, duplicate-h1 job = overlay statico nascosto + CMP Google fc-dialog): notice-level, separati da questo scope; CMP h1 non editabile (markup Google).

## Note di verifica

- `npm test` mirato verde: clamp (5), format-seo-title (24), jobs-seo-title-h1 (48), seo-localization (2), oltre a title-length/h1-not-equal.
- Build SSG completa non validabile in locale (OOM, per AGENTS.md) → la parità statica si osserva sul prossimo deploy su `main`. Revert-trigger: se il prossimo deploy OOMa o emette snippet vuoti/troncati malformati, revert.
- `data/jobs.json` assente in worktree fresh causa 2 errori tsc pre-esistenti (`legacyRedirectsPlugin`, `slugCantonIndex`) generati da `assemble-jobs-dataset.mjs` in CI — non correlati a questo diff (nessun file toccato compare negli errori).