### PR TITLE
fix(seo): CollectionPage schema su canton-landing secondari + tipi About/Contact corretti (SearchAtlas)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9313,6 +9313,56 @@ ${staticAnalyticsHtml}
        cantonEditorialSection,
        `</main>`,
      ].join('\n');
+     // SearchAtlas "missing schema markup" audit (2026-06-15): secondary-canton
+     // landing pages shipped only a BreadcrumbList, while the Ticino landing
+     // (/cerca-lavoro-ticino/, owned by staticPagesPlugin via seo-pages.ts)
+     // ships CollectionPage + ItemList. Mirror TI here so every INDEXABLE canton
+     // landing carries a CollectionPage wrapping an ItemList of its most-recent
+     // jobs. Gated on `meetsThreshold` + jobs present: thin/noindex pages stay
+     // breadcrumb-only (CLAUDE.md #4 — no rich schema on thin content). Items
+     // are ListItem→url (not nested JobPosting): a partial JobPosting would
+     // violate NON-NEGOTIABLE #3 (all 9 mandatory fields), and the listing
+     // page's correct primary type is CollectionPage, exactly as TI. The list
+     // is rebuilt every deploy so the linked job URLs stay fresh (same jHref
+     // formula as the visible listing grid above).
+     const cantonCollectionLd = (meetsThreshold && cantonJobs.length > 0)
+       ? inlineScriptJson({
+           '@context': 'https://schema.org',
+           '@type': 'CollectionPage',
+           name: labels.title,
+           description: labels.lede,
+           url: canonicalUrl,
+           inLanguage: entry.locale,
+           isPartOf: { '@type': 'WebSite', name: 'Frontaliere Ticino', url: BASE_URL },
+           about: { '@type': 'Thing', name: display },
+           provider: { '@type': 'Organization', name: 'Frontaliere Ticino', url: BASE_URL },
+           mainEntity: {
+             '@type': 'ItemList',
+             numberOfItems: totalJobs,
+             itemListOrder: 'https://schema.org/ItemListOrderDescending',
+             itemListElement: cantonJobs.map((j, i) => {
+               const jt = j as {
+                 slugByLocale?: Record<string, string>;
+                 slug?: string;
+                 titleByLocale?: Record<string, string>;
+                 title?: string;
+                 canton?: string;
+                 location?: string;
+               };
+               const jslug = jt.slugByLocale?.[entry.locale] || jt.slug || '';
+               const jCanton = sharedResolveJobCanton({ canton: jt.canton, location: jt.location });
+               const jSection = buildCantonAwareSection(entry.locale, jCanton);
+               const jHref = `${BASE_URL}${withSlash(`${localePrefix[entry.locale]}/${jSection}/${jslug}`.replace(/\/+/g, '/'))}`;
+               return {
+                 '@type': 'ListItem',
+                 position: i + 1,
+                 url: jHref,
+                 name: jt.titleByLocale?.[entry.locale] || jt.title || display,
+               };
+             }),
+           },
+         })
+       : '';
      const html = buildSeoPageHtml({
        canonicalUrl,
        title: labels.title,
@@ -9320,7 +9370,7 @@ ${staticAnalyticsHtml}
        locale: entry.locale,
        bodyHtml,
        distDir,
-       jsonLdScripts: [cantonBreadcrumbLd],
+       jsonLdScripts: [cantonBreadcrumbLd, cantonCollectionLd].filter(Boolean),
        // T2.6 — robots set by MIN_JOBS gate above. Pages with ≥ 5 canonical
        // jobs from the cathedral flip to 'index,follow'; thin pages stay
        // 'noindex,follow' (CLAUDE.md #4 — no thin content gets indexed). The

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10869,10 +10869,34 @@ ${staticAnalyticsHtml}
  })}</script>`;
 
  const jobPostingLd = (() => {
- // Only emit JobPosting when we have real job data
- const realTitle = ejData?.titleByLocale?.[locale] || ejData?.title || '';
- const realExpiredAt = ejData?.expiredAt || '';
- if (!realTitle || !realExpiredAt || !jobCompany) return '';
+ // NON-NEGOTIABLE #3: "Source mancante → safe default, non rimozione check."
+ // SearchAtlas "missing schema" audit (2026-06-15) flagged ~50-80 indexable
+ // expired soft-landings emitting only BreadcrumbList. Emit JobPosting whenever
+ // the page has a REAL job identity — a real title AND a real employer from
+ // trustworthy crawl/search data (expired-jobs.json OR GSC). The optional
+ // fields (salary, address) are filled by buildJobPostingSchema's safe
+ // defaults; validThrough/datePosted are derived from the best real timestamp
+ // and always land in the PAST (this is an expired soft-landing) — Google's
+ // recommended handling for an expired posting, NOT a GSC error. Previously the
+ // gate required ejData.expiredAt to be present, dropping JobPosting (violating
+ // #3) for jobs whose expired entry carried only crawledAt/postedDate. Pure
+ // slug-derived orphans with no real employer stay breadcrumb-only:
+ // fabricating an employer identity would be spammy, low-quality markup.
+ // Revert-trigger (not validable pre-merge, SSG OOM): if the next deploy surfaces
+ // GSC "expired job posting" errors or a JobPosting-richness regression on these
+ // soft-landings → revert this gate to the strict `realExpiredAt`-required form.
+ const realTitle = ejData?.titleByLocale?.[locale] || ejData?.title
+ || gscInfo?.titleByLocale?.[locale] || gscInfo?.title || '';
+ const realCompany = String(ejData?.company || gscInfo?.company || '');
+ // Derive a past validThrough from the best real signal. No real date signal
+ // at all → stay breadcrumb-only (don't fabricate a posting window from nothing).
+ const realValidThrough = (() => {
+ for (const c of [ejData?.expiredAt, ejData?.crawledAt, ejData?.postedDate]) {
+ if (c) { const d = new Date(c); if (!isNaN(d.getTime())) return d.toISOString(); }
+ }
+ return '';
+ })();
+ if (!realTitle || !realValidThrough || !realCompany) return '';
  const finalDescription = jobDescription || (() => {
  const parts: string[] = [];
  parts.push(`<p><strong>${esc(copy.banner)}</strong></p>`);
@@ -10907,7 +10931,7 @@ ${staticAnalyticsHtml}
  streetAddress: ejData?.streetAddress,
  postedDate: ejData?.postedDate,
  crawledAt: ejData?.crawledAt,
- validThrough: realExpiredAt,
+ validThrough: realValidThrough,
  contract: ejData?.contract,
  salaryMin: typeof ejData?.salaryMin === 'number' ? ejData.salaryMin : null,
  salaryMax: typeof ejData?.salaryMax === 'number' ? ejData.salaryMax : null,
@@ -10926,12 +10950,12 @@ ${staticAnalyticsHtml}
  const expiredDatePosted = (() => {
  if (ejData?.postedDate) { const d = new Date(ejData.postedDate); if (!isNaN(d.getTime())) return d.toISOString(); }
  if (ejData?.crawledAt) { const d = new Date(ejData.crawledAt); if (!isNaN(d.getTime())) { d.setUTCDate(d.getUTCDate() - 30); return d.toISOString(); } }
- const d = new Date(realExpiredAt); d.setUTCDate(d.getUTCDate() - 30); return d.toISOString();
+ const d = new Date(realValidThrough); d.setUTCDate(d.getUTCDate() - 30); return d.toISOString();
  })();
  const jp: Record<string, unknown> = {
  ...expiredSchema,
  datePosted: expiredDatePosted,
- validThrough: new Date(realExpiredAt).toISOString(),
+ validThrough: new Date(realValidThrough).toISOString(),
  };
  return `<script type="application/ld+json">${inlineScriptJson(jp)}</script>`;
  })();

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1706,6 +1706,41 @@ function buildThinCantonHubHtml(args: {
     ],
   });
 
+  // SearchAtlas "missing schema markup" audit (2026-06-15): secondary-canton
+  // thin hubs (/cerca-lavoro-<canton>/tutti/page-N/, /settori/, /aziende/)
+  // shipped only a BreadcrumbList. These are index,follow self-canonical
+  // listing pages, so CollectionPage is the correct primary type (same fix as
+  // the canton landing in jobsSeoPagesPlugin). Emit a CollectionPage wrapping
+  // an ItemList of the page's items (job links for `tutti`, sector/company
+  // links for `settori`/`aziende`). The ItemList is CAPPED at 25 elements
+  // (numberOfItems still reports the real total) to bound bytes: `tutti/page-N`
+  // carries 100 items × ~2.8k pages, and the full list would breach the
+  // ~200 KB page-weight cap + add build-memory pressure on the OOM-prone SSG.
+  // Items are ListItem→url (not nested JobPosting): a partial JobPosting would
+  // violate NON-NEGOTIABLE #3 (all 9 mandatory fields). Empty pages emit no
+  // CollectionPage (breadcrumb-only), matching the thin-content guard.
+  const collectionLd = items.length === 0
+    ? ''
+    : inlineScriptJson({
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: h1,
+        description: intro,
+        url: canonicalUrl,
+        inLanguage: locale,
+        isPartOf: { '@type': 'WebSite', name: 'Frontaliere Ticino', url: BASE_URL },
+        mainEntity: {
+          '@type': 'ItemList',
+          numberOfItems: totalItems,
+          itemListElement: items.slice(0, 25).map((it, i) => ({
+            '@type': 'ListItem',
+            position: i + 1,
+            url: it.href.startsWith('http') ? it.href : `${BASE_URL}${it.href}`,
+            name: it.label,
+          })),
+        },
+      });
+
   return `<!doctype html>
 <html lang="${locale}">
   <head>
@@ -1723,7 +1758,7 @@ function buildThinCantonHubHtml(args: {
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <link rel="canonical" href="${canonicalUrl}">
     ${SEO_STATIC_CSS_LINK}
-    <script type="application/ld+json">${breadcrumbLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
+    <script type="application/ld+json">${breadcrumbLd}</script>${collectionLd ? `\n    <script type="application/ld+json">${collectionLd}</script>` : ''}${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin>` : ''}
     ${ADSENSE_SNIPPET}
   </head>
   <body class="bg-surface-alt text-heading overflow-x-hidden">

--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -1478,7 +1478,10 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  canonicalPath: '/supporto/',
  structuredData: {
  "@context": "https://schema.org",
- "@type": "WebPage",
+ // SearchAtlas "missing schema markup" (2026-06-15): the support/feedback
+ // page is a contact surface, so ContactPage is the correct type (the audit
+ // expects ContactPage here, not a generic WebPage).
+ "@type": "ContactPage",
  "name": "Aiutaci a Migliorare - Segnalazioni e Suggerimenti",
  "url": `${BASE_URL}/supporto`,
  "description": "Segnala bug e suggerisci funzionalità per il simulatore fiscale frontalieri Svizzera-Italia su GitHub",
@@ -9179,7 +9182,11 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  structuredData: [
  {
  "@context": "https://schema.org",
- "@type": "WebPage",
+ // SearchAtlas "missing schema markup" (2026-06-15): this editorial-process
+ // page is an About page (mirrors the /about/ alias which already uses
+ // AboutPage), not a generic WebPage. AboutPage is the correct type for a
+ // methodology/about-us page and is what the audit expects.
+ "@type": "AboutPage",
  "name": "Metodologia editoriale — Come scriviamo gli articoli",
  "url": `${BASE_URL}/metodologia/`,
  "description": "Come utilizziamo l'IA generativa, le fonti primarie e il processo di revisione editoriale per garantire accuratezza e trasparenza.",


### PR DESCRIPTION
## Contesto

Audit SearchAtlas **\"Schema Type\"** (`download/Schema Type.xls`, 3605 URL) ha segnalato pagine come prive di schema markup. Ho verificato **tutte** le 8 famiglie (`JobPosting`, `Article`, `Service`, `CollectionPage`, `ProfilePage`, `Product`, `AboutPage`, `ContactPage`) curlando i 3605 URL live e seguendo i redirect, separando i **gap reali** dai **falsi positivi**.

Esito misurato: 2018/3605 URL hanno già lo schema atteso. La gran parte dei "missing" è **mismatch di tipo** (SearchAtlas indovina un tipo, la pagina emette un tipo valido diverso) o **crawl di varianti non-canoniche** (URL senza trailing-slash che servono lo SPA shell). I **gap reali** (pagine indicizzabili con solo `BreadcrumbList`) sono ~204, fixati qui sotto.

## Implementato

- **`build-plugins/jobsSeoPagesPlugin.ts`** — i **landing dei cantoni secondari** (`/cerca-lavoro-vaud/`, `/berna/`, `/zurigo/`, …) emettevano solo `BreadcrumbList`, mentre il Ticino (via `seo-pages.ts`) emette `CollectionPage`+`ItemList`. Ora ogni canton-landing **indicizzabile** emette `CollectionPage`+`ItemList` dei job recenti. Gate `meetsThreshold && cantonJobs.length>0`: thin/`noindex` restano breadcrumb-only (CLAUDE.md #4).
- **`build-plugins/seoHubsPlugin.ts`** (`buildThinCantonHubHtml`) — i **thin-hub secondari** (`/cerca-lavoro-<canton>/tutti/page-N/`, `/settori/`, `/aziende/`), pagine `index,follow` self-canonical, emettevano solo `BreadcrumbList`. Ora emettono `CollectionPage`+`ItemList` (cap 25 elementi, `numberOfItems` = totale reale) per restare sotto il page-weight cap ~200 KB e limitare la memoria del build SSG OOM-prone. Hub vuoti restano breadcrumb-only.
- **`build-plugins/jobsSeoPagesPlugin.ts`** — i **job-detail soft-landing di offerte scadute** (~50-80 URL, slug `1-apprendista...`/`1-chef...`) emettevano solo `BreadcrumbList`: il gate richiedeva `ejData.expiredAt`, **rimuovendo** `JobPosting` quando l'entry scaduta aveva solo crawledAt/postedDate — rimozione che **viola NON-NEGOTIABLE #3** (\"Source mancante → safe default, non rimozione check\"). Ora `JobPosting` viene emesso quando la pagina ha **identità reale** (titolo + azienda reali da expired-jobs.json O GSC), derivando `validThrough` dal miglior timestamp reale (expiredAt → crawledAt → postedDate); il risultato cade sempre nel passato (gestione Google corretta per offerta scaduta, non un errore GSC). Orphan puri da slug (senza azienda o senza segnale-data) restano breadcrumb-only: fabbricare identità/finestra sarebbe markup spam.
- **`services/seo/seo-pages.ts`** — `/metodologia/`: `WebPage` → **`AboutPage`** (l'alias `/about/` già usa `AboutPage`); varianti `/en/methodology/`, `/fr/methodologie/` ereditano. `/supporto/` (key `feedback`): `WebPage` → **`ContactPage`**; variante `/fr/assistance/` eredita.

Gli `ItemList` usano `ListItem→url`, **non** `JobPosting` parziali (NON-NEGOTIABLE #3: tutti i 9 campi obbligatori); per una pagina-elenco il tipo primario corretto è `CollectionPage`.

## Non implementato (ancora)

- **Falsi positivi di mismatch di tipo (corretto NON toccarli)**: articoli `/articoli-frontaliere/...` emettono `NewsArticle` dove SearchAtlas si aspetta `Article` — `NewsArticle` **è** sottotipo valido di `Article`; downgradare sarebbe una regressione. La famiglia `Service` è pura euristica SearchAtlas: quelle pagine (calcolatori/guide) emettono `FAQPage`/`CollectionPage`/`ClaimReview` validi e **non sono** servizi → aggiungere `@type:Service` sarebbe semanticamente errato. Non sono schema mancanti.
- **URL senza trailing-slash che servono SPA shell** (~7, es. `/calcola-stipendio`): la versione canonica con slash ha schema ricco; fix = canonicalizzazione trailing-slash a livello edge (Cloudflare), **infra out of scope**.
- **Pagine search `ricerca-*`** (`/cerca-lavoro-ticino/ricerca-basel/`): SPA-shell senza meta statici → richiederebbero prerender SSG dedicato. Out of scope.
- **9 URL 404** (offerte/aziende rimosse): dead URL, non un fix di schema.

## Verifica

- [x] `tests/seo/no-inlanguage-on-forbidden-schemas.test.ts` verde — `CollectionPage`/`AboutPage`/`ContactPage` non FORBIDDEN; `ItemList` nidificati senza `inLanguage`.
- [x] `tests/jobposting-jsonld`, `tests/seo/jobposting-schema`, `structured-salary`, `tests/seo/seo-hubs-pagination-bfs`, `cathedral-no-ti-hardcodes`, `half-canton-merge`, `page/entity/article-schema-translators`, `jobs-seo-pages-plugin`, `search-console-compat` — verdi (plugin si importano → edit TS compilano).
- [ ] `breadcrumb-coverage`, `dist-duplicate-structured-data` (dist-dependent) + emissione live osservati post-merge su `main` (build SEO locale OOM-prone). **Revert-trigger**: deploy OOM o page-weight cap superato su `tutti/page-N` → ridurre cap ItemList; GSC "expired job posting" error → revert al gate expired stretto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)