### PR TITLE
fix(seo): substitute {canton} in JobBoard ItemList JSON-LD name

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4023,14 +4023,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  const listName = companyDisplayName
- ? `${companyDisplayName} — ${t('jobBoard.title')}`
+ ? `${companyDisplayName} — ${t('jobBoard.title', cantonI18n)}`
  : searchHeadingQuery
  ? t('jobBoard.searchPageTitle', { query: searchHeadingQuery })
  : selectedSector !== 'all'
- ? `${selectedSector} — ${t('jobBoard.title')}`
+ ? `${selectedSector} — ${t('jobBoard.title', cantonI18n)}`
  : selectedLocation !== 'all'
- ? `${selectedLocation} — ${t('jobBoard.title')}`
- : t('jobBoard.title');
+ ? `${selectedLocation} — ${t('jobBoard.title', cantonI18n)}`
+ : t('jobBoard.title', cantonI18n);
 
  const itemList = {
  '@context': 'https://schema.org',
@@ -4049,7 +4049,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  document.head.appendChild(script);
 
  return cleanup;
- }, [filteredJobs, locale, selectedJob, initialJobSlug, selectedSector, selectedLocation, companyDisplayName, searchSlugFilter, companySlugFilter, locationSlugFilter, editorialLandingDescriptor, searchHeadingQuery, t]);
+ }, [filteredJobs, locale, selectedJob, initialJobSlug, selectedSector, selectedLocation, companyDisplayName, searchSlugFilter, companySlugFilter, locationSlugFilter, editorialLandingDescriptor, searchHeadingQuery, cantonI18n, t]);
 
  const formatSalary = (job: JobListing) => {
  if (!job.salaryMin) return null;


### PR DESCRIPTION
## Implementato
- Le 4 chiamate `t('jobBoard.title')` che compongono `listName` nel `useEffect` che inietta lo schema **ItemList JSON-LD** lato client (`components/community/JobBoard.tsx` ~L4025-4033) ora passano `cantonI18n` → il placeholder `{canton}` viene sostituito. Prima veniva shippato a Google il literal `"Offerte di Lavoro in {canton}"` (confermato **live** sul DOM hydrated di `/cerca-lavoro-ticino/`).
- Aggiunto `cantonI18n` alla dependency array del `useEffect` così lo schema si rigenera al cambio di cantone.
- Stesso valore (`cantonI18n`) già usato correttamente per l'H1 visibile a ~L7207: il fix allinea lo schema all'H1.

**Origine:** crawl schema di SearchAtlas OTTO. Verifica class-wide (AGENTS.md #6): grep di TUTTe le i18n key contenenti `{canton}` (25 key) → zero altri caller paramless nel repo; `seoService.translateIfExists` (L1042) e `RelatedTools` (L223/226) passano già `getCantonI18nParams()`. Questi 4 erano gli unici.

## Non implementato (ancora)
- **Altri "bug" OTTO risultati falsi positivi su `origin/main`** (l'analisi era su un checkout locale 4514 commit indietro): (a) title "Pagina spostata" su ~22 URL → live sono `noindex,follow` + canonical valido (redirect-bridge intenzionali, non indicizzati); (b) meta description boilerplate duplicate → già risolto da #2228 (`GENERIC_DESC` ora prefissa il titolo unico per-pagina); (c) H1 leak `companies.title`/"🌙 Buonanotte!" → live gli H1 statici sono corretti ("Aziende che assumono in Ticino…", "Buongiorno Frontaliere — Meteo…"). Nessuna azione: out of scope / già risolto.
- **Adozione suggerimenti OTTO (title/meta/OG/twitter/keywords/canonical/schema)** → REJECT deliberato: i rewrite regrediscono i voti AI di OTTO stesso (OG −9/−11), strippano brand/fatti, e il sito è SSG (il pixel non deploya). Documentato, niente da implementare.
- **Sibling-checker (7 file flaggati: JobAlertForm, jobsSeoPagesPlugin, slimJobIndex, SalaryCompare, TicinoCompanies, audit-jobs-source-match, relatedSearchClusters)** → falsi candidati: condividono solo nomi di variabile generici (`selectedSector`, `selectedJob`, `filteredJobs`, ecc.), NON l'antipattern i18n-paramless `{canton}`, che è già verificato a zero altrove. Nessun fix dovuto.

## Test
- [ ] CI gate (vitest + assemble-jobs-dataset + migrate-slugs) — i test girano in CI (worktree senza node_modules; nessun build locale per policy). Cambio type-safe: `cantonI18n` ha la stessa forma dell'uso già presente a L7207.
- [ ] Post-deploy: verificare sul DOM hydrated di `/cerca-lavoro-ticino/` che lo schema ItemList `name` = "Offerte di Lavoro in Ticino" (no `{canton}`).