### PR TITLE
fix(cls): scope #root min-height:100vh to SPA-owned pages (staticOverlay above-fold regression)

### DIFF
--- a/index.css
+++ b/index.css
@@ -286,10 +286,34 @@ a.seo-entity-card:focus-visible {
    the tall tree and drops it back down — a ~0.79–0.86 layout shift. Reserving
    at least one viewport keeps #root from collapsing below the fold, so the SEO
    block stays at/below the fold throughout the swap and its shift no longer
-   intersects the viewport. Gap-risk-free: the hydrated homepage is ~7300–8100px,
-   always far exceeding 100vh, so the reservation is never visible. */
+   intersects the viewport. On a normally-rendered (SPA-owned) page the hydrated
+   tree inside #root is ~7300–8100px, always far exceeding 100vh, so the
+   reservation is never visible.
+
+   SCOPING — the 100vh reservation MUST be gated to SPA-owned pages only.
+   This is the SAME class of bug that #1586 fixed for the first-paint critical
+   CSS (see tests/build-plugins/criticalCssRootHeight.test.ts + App.tsx:1582,
+   where the SPA wrapper drops `min-h-screen` when `staticOverlay` is true):
+   an UNCONDITIONAL `#root{min-height:100vh}` carves a ~770px empty band on
+   staticOverlay pages. #2162 reintroduced it here in index.css (out of that
+   test's scope) to fix the homepage flash, regressing staticOverlay above-fold.
+   On `staticOverlay` pages (company / sector / weekly / health / border hubs)
+   the SPA renders only the nav chrome inside #root (~57px) and the real
+   content is a visible static `<main class="seo-static-content">` sibling
+   AFTER #root. There, an unconditional 100vh on #root reserves a full empty
+   viewport above the content, pushing the H1 below the fold (live above-fold
+   regression caught by spa-hydration-contract-live.spec.ts after #2162).
+   The reservation only ever protects the prerendered footer SEO block
+   (`.seo-footer-block`, emitted solely on the SPA-owned homepage / calculator
+   / job-board pages — never on staticOverlay hubs), so gate it on the presence
+   of that block: pages without it have nothing to protect and must keep their
+   static content flowing right below the 57px header. `:has()` matches from
+   the initial prerendered HTML (the block is a static sibling), so the gate is
+   live before JS and the homepage flash protection is preserved. */
 #root {
   display: flow-root;
+}
+body:has(.seo-footer-block) #root {
   min-height: 100vh;
 }
 

--- a/tests/build-plugins/criticalCssRootHeight.test.ts
+++ b/tests/build-plugins/criticalCssRootHeight.test.ts
@@ -54,6 +54,41 @@ describe('critical CSS single source of truth (#1586)', () => {
     expect(CRITICAL_CSS).toMatch(/body\{[^}]*min-height:100vh\}/);
   });
 
+  it('forbids an UNSCOPED #root{min-height:100vh} in index.css (#2162 regression)', () => {
+    // #2162 reintroduced the #1586 bug in the main stylesheet (out of the
+    // CRITICAL_CSS scope above): a bare `#root{...min-height:100vh}` rule
+    // carves a ~770px empty band on staticOverlay pages, pushing the H1 below
+    // the fold (caught live by spa-hydration-contract-live.spec.ts). A 100vh
+    // reservation on #root is allowed ONLY when scoped to SPA-owned pages
+    // (e.g. `body:has(.seo-footer-block) #root{min-height:100vh}`), so the
+    // staticOverlay hubs — which have no footer block — keep their static
+    // content flowing right below the chrome.
+    const indexCss = readFileSync(resolve(ROOT, 'index.css'), 'utf-8');
+    // Match a rule whose selector list ENDS in a bare `#root` (no descendant
+    // combinator prefix like `body:has(...) #root`) and whose body forces a
+    // full-viewport min-height. We strip comments first so the documentation
+    // block above the rule (which legitimately mentions the pattern) is ignored.
+    const cssNoComments = indexCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    const unscopedRootBlocks = [...cssNoComments.matchAll(/([^{};]+)\{([^}]*)\}/g)].filter(
+      (m) => {
+        const selectors = m[1].split(',').map((s) => s.trim());
+        const body = m[2];
+        const forcesFullViewport = /min-height\s*:\s*100(vh|dvh|svh|lvh)/i.test(body);
+        if (!forcesFullViewport) return false;
+        // A selector is "unscoped #root" when its last compound is exactly
+        // `#root` AND nothing precedes it (no descendant/child combinator).
+        return selectors.some((sel) => /^#root$/.test(sel));
+      },
+    );
+    expect(
+      unscopedRootBlocks.length,
+      'index.css must not force min-height:100vh on a bare `#root` selector. ' +
+        'Scope it to SPA-owned pages instead, e.g. ' +
+        '`body:has(.seo-footer-block) #root{min-height:100vh}` (see #1586/#2162 ' +
+        'and the comment above the #root rule).',
+    ).toBe(0);
+  });
+
   it('carries the @font-face metric overrides (CLS stabilization)', () => {
     // These were missing from the old ogPagesPlugin copy; the shared constant
     // must keep them so OG/article pages get the same font-metric CLS guard as


### PR DESCRIPTION
## Implementato

- **`index.css`**: la riserva `min-height:100vh` su `#root` (aggiunta da #2162 per il flash della homepage) ora è scopata a `body:has(.seo-footer-block) #root`. Il blocco SEO footer (`.seo-footer-block`) è emesso solo sulle pagine SPA-owned (homepage / calcolatore / job-board) — proprio quelle il cui flash la riserva protegge — e mai sugli hub staticOverlay. `#root` mantiene solo `display:flow-root` (BFC) globale.
- **`tests/build-plugins/criticalCssRootHeight.test.ts`**: nuovo gate che vieta un `#root{min-height:100vh}` **unscoped** in `index.css` (regex su selettore `#root` nudo, commenti strippati). Il gate #1586 esistente copriva solo `CRITICAL_CSS`, non `index.css`, dove #2162 ha reintrodotto il bug.

### Root cause
#2162 ha riaggiunto `#root{min-height:100vh}` in `index.css` — la stessa classe di bug che #1586 aveva risolto per il critical CSS (cfr. `App.tsx:1582`, dove il wrapper SPA droppa `min-h-screen` se `staticOverlay`). Sulle pagine staticOverlay (company / sector / weekly / health / border hub) la SPA rende solo i ~57px di chrome dentro `#root`; il contenuto reale è un `<main class="seo-static-content">` sibling **dopo** `#root`. La riserva 100vh incondizionata carica un viewport vuoto sopra il contenuto → H1 spinto da ~57px a ~844px, sotto la piega.

### Verifica live (deploy attuale)
- KSW + amministrazione-cantonale-ticino company hub: solo ~22–55 char visibili nei primi 800px (h1 a top:844) → 2 failure in `spa-hydration-contract-live.spec.ts` (run [27566737760](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/27566737760)).
- health/sector/weekly hub condividono lo stesso stato rotto (il test ne cattura 2, gli altri sono 404-tolerated o borderline sull'header).
- Simulazione del fix nel browser live (mobile 390×844): company hub **22 → 805 char** above-fold, h1 risale a top:57; homepage (footer-block presente) mantiene la riserva invariata.

### Revert-trigger (claim CLS non validabile pre-merge)
Il fix preserva la riserva flash homepage per costruzione (footer-block presente → regola applicata). Se il prossimo deploy mostra una regressione CLS sulla homepage (`$web_vitals` field / Lighthouse) → revert e si valuta una riserva flash alternativa pre-hydration. Le pagine staticOverlay perdono la dead-band: shift residuo atteso ≤57px (altezza header), nettamente migliore del contenuto-sotto-la-piega.

## Non implementato (ancora)

- **Fallimento settori `/cerca-lavoro-ticino/settori/` (<40 funnel link)**: causa indipendente (rimozione deliberata dei link `?q=` in #2128 → 43 settori collassano sul canton root, solo ~10 hanno pagina dedicata crawlable). Fuori scope di questa PR (regressione layout CLS distinta). Bloccato da decisione utente in corso: l'opzione "creare le pagine mancanti" scontra il moratorium SEO (GSC avg position 8.76 > 7.5) e il `SECTOR_HUB_FIRE_THRESHOLD=30` rende comunque irraggiungibili 40 pagine. Da risolvere separatamente.
- Riserva flash pre-hydration nel `CRITICAL_CSS` (first-paint): non toccata — `CRITICAL_CSS` usa già `body{min-height:100vh}` (#1586), corretto per staticOverlay; questa PR allinea solo `index.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)