### PR TITLE
perf(deploy): drop 3 redundant full-dist walks + gzip-size pass (fail-safe, ~-12min)

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -282,6 +282,20 @@ jobs:
             return 0   # never let a single fail short-circuit the chain (rc is in the result file)
           }
 
+          # Pre-seed every validator's result file as FAILED (rc=99). run_validator
+          # OVERWRITES it ("> $RESDIR/$name") with the real row on completion. If a
+          # validator's background subshell is signal-killed AFTER node exits but
+          # BEFORE the awk write (OOM-cgroup kill, runner timeout, /tmp full), the
+          # rc=99 seed survives → the validator counts as FAIL and the gate exits 1,
+          # instead of silently vanishing from the summary (the serial pre-PR code
+          # wrote the row inline, so this kill-window class did not exist — restoring
+          # the "gate exact" guarantee). Format matches the awk row so the summary
+          # parser (grep -oE 'rc=[0-9]+$') reads it.
+          for vn in validate:translation-completeness validate:crawler-summaries \
+                    validate:third-party-secrets gate:seo-source; do
+            printf '%-40s %7.2f rc=%d\n' "$vn" 0 99 > "$RESDIR/$vn"
+          done
+
           # These four validators are independent processes with no shared state
           # and no dist dependency, so run them CONCURRENTLY on the 4-vCPU runner.
           # Wall drops from sum(~6.8min serial) to the slowest single gate

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -256,14 +256,18 @@ jobs:
         # 26592389280).
         run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
 
-      - name: Run source validators sequentially
+      - name: Run source validators (parallel — 4 vCPU)
         run: |
-          : > /tmp/source-val-results.txt
+          RESDIR=/tmp/source-val-results.d
+          rm -rf "$RESDIR"; mkdir -p "$RESDIR"
 
-          # Run a single validator and append one row to
-          # /tmp/source-val-results.txt: "<name>  <wall_s>  rc=<code>".
-          # The summary block at the end reads this file to print the
-          # per-gate ✅/❌ table.
+          # Run ONE validator in the background and record its result row to its
+          # OWN file ("$RESDIR/<name>": "<name>  <wall_s>  rc=<code>"). Each
+          # validator writes a distinct file, so concurrent runs never interleave
+          # into a shared results file (which would corrupt the pass/fail summary
+          # and could MASK a failure — gate must stay exact). The summary below
+          # cats these files; a failing validator's full log is dumped (after the
+          # wait, sequentially) so parallel failures stay readable.
           run_validator() {
             local name=$1 logfile=$2; shift 2
             local start end rc
@@ -274,26 +278,46 @@ jobs:
             set -e
             end=$(date +%s.%N)
             awk -v n="$name" "BEGIN{printf \"%-40s %7.2f rc=%d\n\", n, $end-$start, $rc}" \
-              >> /tmp/source-val-results.txt
-            if [ "$rc" -ne 0 ]; then
-              echo "──── $name failed (rc=$rc) ────"
-              cat "$logfile"
-              echo "──── end $name ────"
-            fi
-            return 0   # never let a single fail short-circuit the chain
+              > "$RESDIR/$name"
+            return 0   # never let a single fail short-circuit the chain (rc is in the result file)
           }
 
-          # Order: cheap dist-readers first (they fail fast and surface a
-          # clean error), then the expensive source-only walk (gate:seo-source
-          # ~110s, no dist dependency).
+          # These four validators are independent processes with no shared state
+          # and no dist dependency, so run them CONCURRENTLY on the 4-vCPU runner.
+          # Wall drops from sum(~6.8min serial) to the slowest single gate
+          # (gate:seo-source ~110s). The old "cheap-first fail-fast" ordering is
+          # moot when all four run together.
+          pids=()
           run_validator validate:translation-completeness /tmp/v10.log \
-            node scripts/validate-translation-completeness.mjs
+            node scripts/validate-translation-completeness.mjs & pids+=("$!")
           run_validator validate:crawler-summaries        /tmp/v11.log \
-            npm run validate:crawler-summaries
+            npm run validate:crawler-summaries & pids+=("$!")
           run_validator validate:third-party-secrets      /tmp/v12.log \
-            npm run validate:third-party-secrets
+            npm run validate:third-party-secrets & pids+=("$!")
           run_validator gate:seo-source                   /tmp/v27.log \
-            npm run gate:seo-source
+            npm run gate:seo-source & pids+=("$!")
+          for p in "${pids[@]}"; do wait "$p" || true; done
+
+          # Merge the per-validator result files into the single results file the
+          # summary block consumes (order-independent; sorted below).
+          cat "$RESDIR"/* > /tmp/source-val-results.txt 2>/dev/null || true
+
+          # Dump each FAILED validator's full log sequentially (readable — no
+          # parallel interleave), keyed off the recorded rc.
+          for rf in "$RESDIR"/*; do
+            grep -q 'rc=0$' "$rf" && continue
+            vname=$(basename "$rf")
+            case "$vname" in
+              validate:translation-completeness) vlog=/tmp/v10.log ;;
+              validate:crawler-summaries)        vlog=/tmp/v11.log ;;
+              validate:third-party-secrets)      vlog=/tmp/v12.log ;;
+              gate:seo-source)                   vlog=/tmp/v27.log ;;
+              *)                                 vlog="" ;;
+            esac
+            echo "──── $vname failed ────"
+            [ -n "$vlog" ] && cat "$vlog" 2>/dev/null || true
+            echo "──── end $vname ────"
+          done
 
           # ── 3. Print summary table + decide pass/fail ──
           echo ""
@@ -482,8 +506,13 @@ jobs:
           # (see scripts/audit-all.mjs REGISTRY). Single dist walk, in-process
           # JSON-LD parse — removes 34 s of standalone wall time from the
           # parallel pool. Removed from spawn pool.
+          # `-- --json` makes the gate ALSO emit the baseline-candidate JSON
+          # into g19.log (printed by audit-bfs-depth.mjs MODE_JSON branch BEFORE
+          # the baseline gate's exit, so the gate semantics are unchanged). The
+          # informational dump step below reuses that JSON instead of paying a
+          # second full dist BFS walk (~4min). The gate still ratchets identically.
           spawn_capped audit:max-bfs-depth           /tmp/g19.log \
-            npm run audit:max-bfs-depth
+            npm run audit:max-bfs-depth -- --json
           # audit:footer-root-presence + audit:jsonld-no-nested-scripts +
           # audit:salary-landing-template all migrated into `npm run audit:all`
           # above (single Node process, single dist walk). Removed from the
@@ -563,15 +592,27 @@ jobs:
           echo "the gate after a deliberate improvement. Counts must only"
           echo "ever DECREASE — this gate is a ratchet."
           echo "──────────────────────────────────────────────────────────────"
-          node scripts/audit-bfs-depth.mjs --max-depth=4 --dist=dist --json || true
+          # Reuse the JSON the audit:max-bfs-depth gate already emitted into
+          # /tmp/g19.log (it now runs with `-- --json`). The JSON is the
+          # contiguous `{ … }` block printed before any gate stderr — extract it
+          # instead of paying a second full dist BFS walk (~4min saved). The
+          # gate runs --max-depth defaulting to the baseline's maxDepth=4, so the
+          # emitted counts match the old standalone `--max-depth=4` dump exactly.
+          if [ -f /tmp/g19.log ] && grep -q '^{$' /tmp/g19.log; then
+            sed -n '/^{$/,/^}$/p' /tmp/g19.log
+          else
+            echo "(bfs gate JSON not found in /tmp/g19.log — gate may have crashed before emit)"
+          fi
           echo "══════════════════════════════════════════════════════════════"
 
       - name: Build size summary
         run: |
           echo "=== Recovered dist size summary ==="
           du -sh dist/
-          echo "HTML files (top 10 by size):"
-          find dist -name "*.html" -exec du -sh {} + | sort -rh | head -10 || true
+          # The per-HTML `find … -exec du -sh {} +` over ~132k+ files (top-10 by
+          # size) was ~2min of pure stat-walk for observability that nothing
+          # consumes — dropped. Per-plugin byte attribution already lives in the
+          # build job's "Audit dist bytes" step. Keep the cheap sitemap listing.
           echo "Sitemaps:"
           find dist -name "sitemap*.xml" -exec du -sh {} + | sort -rh || true
 

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -57,8 +57,21 @@ const reLeak = new RegExp(
 function walk(dir: string, fn: (fp: string) => void): void {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
-    if (e.isDirectory()) walk(fp, fn);
-    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+    if (e.isDirectory()) {
+      // Mirror postWalkCoordinatorPlugin.walkHtml(): never descend into the
+      // asset/data/image subtrees. They hold only JS/CSS/fonts (assets/),
+      // CDN-offloaded *.json job payloads (data/) and *.webp/*.png/og art
+      // (images/) — none carry .html/.xml/.txt, the only extensions in
+      // SCAN_EXT this pass rewrites. Descending them stat-walked ~1.4M dirents
+      // per build for zero rewrites (run 27528505424: 1.59M scanned → 21k
+      // rewritten, wall 811s with cpu 374s = ~54% pure I/O wait). Skipping
+      // them collapses the walk to the content tree without changing a single
+      // rewritten byte; the coordinator already ships this exact exclusion.
+      // The dist/images/blog deletion loop below is a separate explicit
+      // readdirSync of blogDir, so this skip does not affect it.
+      if (e.name === 'assets' || e.name === 'data' || e.name === 'images') continue;
+      walk(fp, fn);
+    } else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
   }
 }
 

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -100,8 +100,21 @@ function log(msg) {
 function walk(dir, fn) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
-    if (e.isDirectory()) walk(fp, fn);
-    else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+    if (e.isDirectory()) {
+      // Same exclusion as postWalkCoordinatorPlugin.walkHtml() and
+      // blogImageCdnFinalizePlugin: never descend into assets/data/images for
+      // the CONTENT-rewrite pass. The CDN refs this pass rewrites (/assets/,
+      // /og/, /data/, /images/brands… , __CDN_DATA_BASE__) live in the page
+      // HTML of the content tree — NOT in files under those subtrees (assets/=
+      // JS/CSS/fonts, data/=*.json offload payloads, images/=binary art), none
+      // of which carry the .html/.xml/.txt in SCAN_EXT. dist/data alone is
+      // ~1.04M dirs (run note): descending it stat-walked the whole tree for
+      // zero rewrites. The data-delete pass below uses the separate walkAll(),
+      // so dist/data is still fully enumerated for unreferenced-JSON cleanup —
+      // this skip only affects the content-rewrite walk, byte-identically.
+      if (e.name === 'assets' || e.name === 'data' || e.name === 'images') continue;
+      walk(fp, fn);
+    } else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -394,6 +394,11 @@ export default defineConfig(({ mode }) => {
  emptyOutDir: false,
  // No error tracking service (Sentry etc.) — sourcemaps not needed
  sourcemap: false,
+ // Rollup's default reportCompressedSize gzip-compresses EVERY emitted JS/CSS
+ // chunk purely to print the "gzip: NN kB" console column. With the many vendor
+ // splits + per-locale data chunks that's pure wall-time on the build job for
+ // zero emitted bytes (console output only). Disable it.
+ reportCompressedSize: false,
  // seo-blog-N.ts chunks are pure data objects (~600kB raw, ~66kB gzip).
  // They exceed the default 500kB warning but gzip well and load lazily.
  // This limit acknowledges that data chunks behave differently from code chunks.


### PR DESCRIPTION
## Implementato

Ottimizzazioni **output-byte-preserving** e **fail-safe** sul percorso build → validate-dist. Nessuna pagina SEO persa, nessun byte emesso cambiato (toccano solo lavoro ridondante / output di console). Bottleneck dal deploy success `27528505424` (**0 deploy success negli ultimi 100 run** = la lentezza causa starvation, ogni push cancella la build → velocizzare sblocca anche i deploy live).

**Tre walk full-dist ridondanti rimossi** — tre plugin/script walkavano l'intera dist (≈1.59M dirent) descendendo `dist/assets`, `dist/data`, `dist/images` per lavoro che tocca solo `.html/.xml/.txt`, **assenti** in quei subtree. Mirror dell'esclusione che `postWalkCoordinatorPlugin.walkHtml()` già spedisce:

1. **`build-plugins/blogImageCdnFinalizePlugin.ts`** — rewrite blog-image→CDN (`enforce:'post'`, ultimo → vede la dist piena). Profilo: wall 811s, cpu 374s ⇒ ~54% I/O wait su dirent mai riscrivibili (1.59M scanned → 21k rewritten). **~−6 min**.
2. **`scripts/offload-generated-images-cdn.mjs` `walk()`** — rewrite ref CDN (`/assets/`,`/og/`,`/data/`,`/images/brands…`) + inject `__CDN_DATA_BASE__`. `dist/data` da solo ≈1.04M dir di `*.json`. La cancellazione dati usa il walker **separato** `walkAll()`, quindi `dist/data` resta interamente enumerata per il cleanup; lo skip tocca solo il walk di rewrite, byte-identico. **Chiude la sibling-class del fix blog-cdn (AGENTS.md #6).**

**validate-dist (gate-only → fail-safe, gate-a `publish` sulla coda critica):**

3. **bfs-depth: eliminato il 2° walk full-dist**. Lo step informativo "Dump bfs-depth baseline candidate" rieseguiva un walk BFS identico al gate `audit:max-bfs-depth`. Ora il gate gira con `-- --json` (emette il JSON **prima** del suo `exit` — `MODE_JSON` non fa early-return, ratchet invariato) e il dump **riusa** quel JSON da `/tmp/g19.log`. **~−4 min**.
4. **source validator in parallelo (4 vCPU)**. I 4 validator (`translation-completeness`, `crawler-summaries`, `third-party-secrets`, `gate:seo-source` ~110s) giravano in **serie**; ora concorrenti → wall da ~6.8min a ~max single gate (~110s). Ciascuno scrive il **proprio** file-result (no append concorrente → nessun fallimento mascherato); summary pass/fail + dump log invariati. Verificato: il gate fa `exit 1` su qualsiasi singolo fallimento. **~−5 min**.
5. **size-summary trim**: rimosso `find dist -name "*.html" -exec du -sh {} +` (~2min stat-walk su 132k+ file) — osservabilità che nessuno consuma (attribuzione byte per-plugin già nello step "Audit dist bytes"). **~−2 min**.

**Più:**
6. **`vite.config.ts` — `reportCompressedSize: false`**: Rollup gzip-comprime ogni chunk solo per la colonna console "gzip:". Zero byte emessi, pura wall. **~−0.3 min+**.

**Totale atteso: ~−19 min** sul wall-clock deploy (~164min → ~145min), primo step del piano (vedi sotto).

### Perché fail-safe (nessun rischio per il sito live)
- blog-cdn / offload: se un ref same-origin sopravvivesse, il leak-guard **aborta l'offload** (file tenuti in dist, nessun 404); cancellazione solo a `leaks.length===0`.
- validate-dist: un regression fa **fallire il gate** → `publish` non parte → last-good resta live.
- vite: cambia solo l'output console del bundler.

## Non implementato (ancora)

- **Revert-trigger (claim perf non validabili pre-merge — SSG build OOMa in locale, `build:ci` gira solo post-merge su `main`):**
  - blog-cdn / offload skip → revert se post-deploy compare un 404 su hero/RSS blog-image, su `/assets|/og|/data|/images`, o i log `[blog-image-cdn]`/`[offload-generated-cdn]` mostrano leak-abort/freed-MB crollati. Verifica: `validate-live` + `curl` asset/og/blog-image dopo il 1° deploy.
  - bfs `--json` → revert se il log del gate non mostra più il blocco JSON baseline-candidate.
  - source-validator parallel → revert (riga `for loc`→seq) se il summary perde righe o un fallimento non emerge.
  - size-summary / vite flag → revert se un size-budget grep su stdout dipendesse da quelle righe.
- **Sibling-class (AGENTS.md #6) — altri walker ispezionati, NON stessa classe, giustificati:**
  - `webpPlugin.ts`: `findImages()` walka full-dist ma il `closeBundle` gira early (prima che jobs-seo+offload popolino la dist) → profilo `webp-conversion=0.00s`; inoltre NECESSITA `images/` → skip cieco errato.
  - `llmsTxtPlugin.ts`/`blogContextualLinksPlugin.ts`: walkano subdir specifiche, non la dist intera.
  - `flatHtmlRedirectPlugin.ts`/`hreflangPostprocessPlugin.ts`: già foldati in `postWalkCoordinatorPlugin`.
- **Win più grandi (PR successive):**
  - Offload Drop-assets **marker**: offload emette il verdetto leak → lo step "Drop dist/assets" salta il re-grep full-tree ridondante (~−6min). Richiede il regex Guard-B esatto condiviso (404-risk se diverge) → PR dedicata con modulo condiviso.
  - Push CDN/locale-shard **incrementale** (~−8min): **deploy-critical** (push dei siti locale en/de/fr live, non validabile in locale, rischio tree corrotto silenzioso). Da decidere con l'owner prima di shippare.
  - `audit:all` worker_threads (~−9min): **scartata** — gli auditor accumulano stato in closure private e alcuni (`h1-title-duplicates`, `title-no-disambig-hash`) rilevano duplicati **cross-file**; shardare romperebbe il rilevamento cross-shard = gate indebolito (vietato).
