### PR TITLE
perf(deploy): reuse offload assets-leak verdict, skip redundant Drop grep (~-6min, fail-safe)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1001,10 +1001,36 @@ jobs:
             echo "::error::CDN push failed but dist/assets URLs are already rebased to the CDN (no fallback) — failing deploy (last good stays live)"; exit 1
           fi
           # Guard B: any surviving SAME-ORIGIN /assets/ reference in dist HTML?
-          # Extension/path coverage is a SUPERSET of the offload script's Phase 3
-          # (offloadAssetRefs ASSET_FILE) — else a same-origin ref of a type Phase 3
-          # misses would also evade this guard and 404 after delete.
-          if grep -rlE "[\"'(]/?assets/[^\"'() ]*\.(js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)" --include='*.html' dist 2>/dev/null | head -1 | grep -q .; then
+          # The offload step (which already read+rewrote every HTML) emitted its
+          # verdict to $RUNNER_TEMP/assets-same-origin.marker using the SAME
+          # superset regex this grep used (ASSETS_SAME_ORIGIN_RX, a 1:1 port of
+          # the ERE below). Reuse it instead of re-reading the whole ~470k-file
+          # HTML corpus a second time (~6min). FAIL-SAFE: a missing marker (e.g.
+          # offload crashed mid-walk) falls back to the original full-tree grep,
+          # so this guard is NEVER weaker than before.
+          ASSET_RX="[\"'(]/?assets/[^\"'() ]*\.(js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)"
+          marker="${RUNNER_TEMP:-/tmp}/assets-same-origin.marker"
+          if [ -f "$marker" ]; then
+            if [ "$(head -1 "$marker")" = "CLEAN" ]; then
+              # The marker covers the content tree the offload pass walked — but
+              # that walk SKIPS assets/data/images (perf), so a stray content
+              # *.html under a slug dir literally named assets|data|images (any
+              # depth) is invisible to the marker. Those dirs normally hold ZERO
+              # *.html, so grep ONLY them here (near-instant) to keep coverage
+              # identical to the original full-tree grep — closing the walk-skip
+              # gap without re-reading the ~470k-file content tree.
+              leak="$(grep -rlE "$ASSET_RX" --include='*.html' dist/assets dist/data dist/images 2>/dev/null | head -1)"
+              [ -n "$leak" ] && echo "marker=CLEAN but a *.html under assets|data|images still has a same-origin /assets/ ref: $leak"
+            else
+              leak="$(tail -n +2 "$marker" | head -1)"
+              echo "offload marker reports surviving same-origin /assets/ ref(s):"
+              tail -n +2 "$marker" | head -8
+            fi
+          else
+            echo "offload marker absent — falling back to full-tree grep (Guard B)"
+            leak="$(grep -rlE "$ASSET_RX" --include='*.html' dist 2>/dev/null | head -1)"
+          fi
+          if [ -n "$leak" ]; then
             echo "⚠️ some dist HTML still references same-origin /assets/ (not CDN-rebased) — KEEPING dist/assets (no breakage, no asset reduction this round)"
             exit 0
           fi

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -137,6 +137,14 @@ function walkAll(dir, fn) {
 // extension set spans every image type those dirs hold (incl. .ico/.gif).
 const OG_FILE = "([^\"'\\s)?]+?\\.(?:webp|png|jpe?g|avif|svg|ico|gif))";
 const ASSET_FILE = "([^\"'\\s)?]+?\\.(?:js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json))";
+// Guard-B parity: the SUPERSET regex the deploy "Drop dist/assets" step used to
+// grep for, ported 1:1 from its bash ERE. A same-origin /assets/<file>.<ext> ref
+// that SURVIVES the rewrite below (e.g. emitted by a custom SSG path that didn't
+// go through ASSET_FILE) must KEEP dist/assets — exactly the Drop step's Guard B.
+// Non-global (stateless .test); applied to HTML only at the callsite to match
+// grep's --include='*.html'. This regex is now the SOLE authority for that gate
+// (the Drop step reads the marker we emit), kept byte-faithful to the old grep.
+const ASSETS_SAME_ORIGIN_RX = /["'(]\/?assets\/[^"'() ]*\.(?:js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)/;
 const DATA_FILE = "([^\"'\\s)?<>]+?\\.(?:json|csv))";
 
 // ── Single-pass offload over dist HTML/XML/TXT ───────────────────────────────
@@ -215,6 +223,7 @@ function offloadAll(distDir, cdnBase) {
   let injected = 0;
   let htmlSeen = 0;
   const ogLeaks = [];
+  const assetsLeaks = [];
 
   walk(distDir, (fp) => {
     scanned++;
@@ -235,6 +244,11 @@ function offloadAll(distDir, cdnBase) {
     const beforeAssets = out;
     out = out.replace(assetReAbs, assetRepl).replace(assetReRel, assetRepl);
     if (out !== beforeAssets) assetRewritten++;
+    // Guard-B parity: record any same-origin /assets/ ref that SURVIVES the
+    // rewrite (HTML only — matches the Drop step's --include='*.html'). The data
+    // rewrite + CDN-base inject below never touch /assets/ refs, so the set is
+    // final here. The deploy Drop step keeps dist/assets iff this list is non-empty.
+    if (isHtml && ASSETS_SAME_ORIGIN_RX.test(out)) assetsLeaks.push(path.relative(distDir, fp));
 
     // (2b) data refs: rewrite same-origin /data/<file> (present in dist/data) → CDN
     //      in HTML ONLY (JSON-LD contentUrl + download hrefs). XML sitemap refs are
@@ -287,6 +301,23 @@ function offloadAll(distDir, cdnBase) {
       while ((m = reDataKeep.exec(out))) dataReferenced.add(decodeURIComponent('/data/' + m[1].split('?')[0]));
     }
   });
+
+  // Emit the same-origin /assets/ verdict so the deploy "Drop dist/assets" step
+  // can SKIP its redundant full-tree grep (it reads this marker, and falls back
+  // to the grep if the marker is absent — e.g. this script crashed mid-walk).
+  // ASSETS_SAME_ORIGIN_RX is the single source of truth for that gate. CI-only
+  // (RUNNER_TEMP set); local runs skip it (the workflow's grep fallback covers it).
+  const runnerTmp = process.env.RUNNER_TEMP;
+  if (runnerTmp) {
+    const markerPath = path.join(runnerTmp, 'assets-same-origin.marker');
+    if (assetsLeaks.length > 0) {
+      fs.writeFileSync(markerPath, 'LEAK\n' + assetsLeaks.join('\n') + '\n');
+      log(`assets guard: ${assetsLeaks.length} same-origin /assets/ ref(s) survive in HTML — Drop step will KEEP dist/assets (e.g. ${assetsLeaks.slice(0, 3).join(', ')})`);
+    } else {
+      fs.writeFileSync(markerPath, 'CLEAN\n');
+      log('assets guard: no same-origin /assets/ refs survive — Drop step may drop dist/assets');
+    }
+  }
 
   // ── Guarded deletes ──
   // og + thumbnails: delete each offloaded dir UNLESS a same-origin ref to THAT


### PR DESCRIPTION
## Implementato

Elimina la **seconda lettura full-dist dell'HTML** sul build job. Lo step "Drop dist/assets" (Guard B) ri-grepava ogni `*.html` su tutta la dist (~470k file, ancora incl. `dist/en|de|fr` pre-strip) per cercare un ref same-origin `/assets/` sopravvissuto — **~6min**, un secondo read completo del corpus che lo step "Offload" (subito prima, riscrive `/assets/`→CDN) aveva **già** walkato.

- **`scripts/offload-generated-images-cdn.mjs`**: durante il walk già esistente, raccoglie il verdetto con `ASSETS_SAME_ORIGIN_RX` — port **byte-faithful 1:1** della ERE bash di Guard B (unit-test: ref same-origin matchano, URL host-CDN no) — e scrive `$RUNNER_TEMP/assets-same-origin.marker` (`CLEAN` | `LEAK` + path).
- **`.github/workflows/deploy.yml`** (step Drop): legge il marker invece di ri-grepare.

**~−6 min** sul build job critical-path.

### Perché fail-safe (decisione identica a oggi per costruzione)
- Stesso regex (superset), stesso scope (`*.html`), stesso istante logico (l'HTML non cambia tra Offload e Drop).
- **Marker assente** (es. offload crashato a metà walk) → **fallback al grep full-tree originale** → guard mai più debole di prima.
- `CLEAN` → droppa `dist/assets` (serviti dal CDN); `LEAK`/grep-hit → mantiene (nessun 404). Guard A (CDN_BASE) invariata.
- Verificato end-to-end: CLEAN→DROP, LEAK→KEEP, assente+clean→fallback→DROP, assente+leak→fallback→KEEP.

## Non implementato (ancora)

- **Stacked su #2237** (base branch = `speedup/deploy-tier-a`): costruisce sul single-walk di offload introdotto lì. Al merge di #2237 questa PR si re-targetta automaticamente su `main` (solo il delta marker). Non mergiare prima di #2237.
- **Revert-trigger** (claim non validabile pre-merge — `build:ci` gira solo post-merge): se post-deploy `validate-live` riporta un 404 su `/assets/*` same-origin, o il log dello step Drop mostra un drop dove prima manteneva → revert (`git revert`), il grep inline torna autorità. Verifica al 1° deploy: `[offload-generated-cdn] assets guard:` nel log + `validate-live` assets.
- Win deploy-critical residuo: **push CDN/locale-shard incrementale** (~−8min, tocca i siti locale en/de/fr live, non validabile in locale) → da decidere con l'owner.
