### PR TITLE
perf(validate-dist): bounded read-ahead in audit:all (~-2min, fail-safe, 20 tests pass)

### DIFF
--- a/scripts/lib/audit-runner.mjs
+++ b/scripts/lib/audit-runner.mjs
@@ -208,10 +208,29 @@ export async function runAudits({ distDir, auditors, verbose = true, writeReport
   const progressInterval = Math.max(1, Math.floor(files.length / 20));
 
   let scanned = 0;
-  for (const file of files) {
-    let html;
-    try { html = await readFile(file, 'utf8'); }
-    catch (err) {
+  // Bounded read-ahead: overlap each file's disk read with the previous file's
+  // (CPU-bound, single-threaded) collect pass. We keep READAHEAD reads in flight
+  // and await them in order. This is a PURE I/O-scheduling change — collect()
+  // still runs on every file's exact html string in the SAME order, so every
+  // auditor's accumulator and report() verdict is byte-identical to the serial
+  // loop. Read promises settle to {html} | {err} so a read that rejects while
+  // waiting its turn in the queue never becomes an unhandled rejection; the
+  // ENOENT-skip / non-ENOENT-throw behaviour is preserved at await time.
+  const READAHEAD = 8;
+  const inflight = [];
+  let nextIdx = 0;
+  const fillQueue = () => {
+    while (inflight.length < READAHEAD && nextIdx < files.length) {
+      const file = files[nextIdx++];
+      inflight.push({ file, p: readFile(file, 'utf8').then((html) => ({ html }), (err) => ({ err })) });
+    }
+  };
+  fillQueue();
+  while (inflight.length > 0) {
+    const { file, p } = inflight.shift();
+    fillQueue(); // keep the next read pre-issued while we process this one
+    const { html, err } = await p;
+    if (err) {
       if (err.code !== 'ENOENT') throw err;
       continue;
     }
@@ -220,9 +239,9 @@ export async function runAudits({ distDir, auditors, verbose = true, writeReport
       const beforeHtml = strict ? html : null;
       try {
         auditor.collect(file, html);
-      } catch (err) {
-        console.error(`[audit-runner] ${auditor.name} threw on ${file}: ${err.message}`);
-        throw err;
+      } catch (e) {
+        console.error(`[audit-runner] ${auditor.name} threw on ${file}: ${e.message}`);
+        throw e;
       }
       if (strict && html !== beforeHtml) {
         throw new Error(`[audit-runner] auditor ${auditor.name} mutated html for ${file}`);


### PR DESCRIPTION
## Implementato

Sovrappone le letture I/O al collect CPU-bound nello step più pesante di validate-dist (`audit:all`, ~21min). `runAudits()` (`scripts/lib/audit-runner.mjs`) leggeva ogni HTML poi eseguiva i 12 auditor in **serie** — ogni `readFile` bloccava senza overlap col collect (single-thread). Su ~132k+ file = ~132k round-trip I/O serializzati.

- **Read-ahead bounded (READAHEAD=8)**: tiene 8 `readFile` in volo, le attende **in ordine**, esegue il `collect()` invariato su ciascuna. Le promise si risolvono a `{html}|{err}` così una read che fallisce in coda non diventa mai unhandled-rejection; lo skip ENOENT / throw non-ENOENT è preservato.

**~−2 min** sullo step audit:all (la fetta sicura; il bottleneck CPU resta — vedi sotto).

### Perché output-byte-identico + fail-safe
- Solo scheduling I/O: `collect()` gira su **ogni** file, con l'**html esatto**, nello **stesso ordine** → ogni accumulatore + `report()` + verdetto gate identico.
- validate-dist è un **gate**: un'eventuale regressione fa fallire il gate → niente publish → last-good resta live.
- **Validato localmente**: `tests/seo/audit-runner.test.ts` (20 test) passa; test funzionale conferma tutti i file visti, contenuto corretto, ordine preservato; nessuna unhandled-rejection sotto `--unhandled-rejections=strict`; sibling-check pulito.

## Non implementato (ancora)

- **`audit:all` worker_threads (~−9min): deliberatamente NON fatto.** Diversi auditor (`h1-title-duplicates`, `title-no-disambig-hash`) rilevano duplicati **cross-file**: shardare la lista file tra worker mancherebbe i duplicati cross-shard → **gate indebolito silenziosamente** (vietato da AGENTS.md "mai abbassare validation"). Richiederebbe un merge globale per-auditor degli accumulatori, non shippabile senza riprogettare l'interfaccia auditor. Questo PR è la fetta sicura (overlap I/O, no sharding).
- **Revert-trigger** (claim perf non misurabile pre-merge — `build:ci`/validate-dist girano solo post-merge): se il prossimo validate-dist OOMa o un audit cambia verdetto vs il run pre-PR → `READAHEAD=1` (torna seriale) o revert.
- Indipendente da #2237/#2241 (file diverso, nessun conflitto).
