### PR TITLE
perf(deploy): reuse offload assets-leak marker, skip redundant Drop grep (~-6min, supersedes #2241)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1001,10 +1001,36 @@ jobs:
             echo "::error::CDN push failed but dist/assets URLs are already rebased to the CDN (no fallback) — failing deploy (last good stays live)"; exit 1
           fi
           # Guard B: any surviving SAME-ORIGIN /assets/ reference in dist HTML?
-          # Extension/path coverage is a SUPERSET of the offload script's Phase 3
-          # (offloadAssetRefs ASSET_FILE) — else a same-origin ref of a type Phase 3
-          # misses would also evade this guard and 404 after delete.
-          if grep -rlE "[\"'(]/?assets/[^\"'() ]*\.(js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)" --include='*.html' dist 2>/dev/null | head -1 | grep -q .; then
+          # The offload step (which already read+rewrote every CONTENT html in a
+          # top-level-only walk) emitted its verdict to
+          # $RUNNER_TEMP/assets-same-origin.marker using the SAME superset regex
+          # (ASSETS_SAME_ORIGIN_RX, a 1:1 port of the ERE below) — covering every
+          # content *.html at ANY depth. Reuse it instead of re-reading the whole
+          # ~470k-file HTML corpus a second time (~6min). The marker does NOT cover
+          # the three TOP-LEVEL dist/{assets,data,images} dirs that walk skips
+          # (vite assets / *.json / binary — no *.html by construction), so belt-
+          # grep just those three roots here (cheap, near-empty) to keep coverage
+          # IDENTICAL to the original full-tree grep. FAIL-SAFE: a missing marker
+          # (offload crashed mid-walk) falls back to the original full-tree grep,
+          # so this guard is NEVER weaker than before.
+          ASSET_RX="[\"'(]/?assets/[^\"'() ]*\.(js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)"
+          marker="${RUNNER_TEMP:-/tmp}/assets-same-origin.marker"
+          if [ -f "$marker" ]; then
+            if [ "$(head -1 "$marker")" = "CLEAN" ]; then
+              # marker covered the content tree (any depth); belt-grep only the
+              # top-level roots walk skipped — normally zero *.html, so near-instant.
+              leak="$(grep -rlE "$ASSET_RX" --include='*.html' dist/assets dist/data dist/images 2>/dev/null | head -1)"
+              [ -n "$leak" ] && echo "marker=CLEAN but a top-level assets|data|images *.html still has a same-origin /assets/ ref: $leak"
+            else
+              leak="$(tail -n +2 "$marker" | head -1)"
+              echo "offload marker reports surviving same-origin /assets/ ref(s):"
+              tail -n +2 "$marker" | head -8
+            fi
+          else
+            echo "offload marker absent — falling back to full-tree grep (Guard B)"
+            leak="$(grep -rlE "$ASSET_RX" --include='*.html' dist 2>/dev/null | head -1)"
+          fi
+          if [ -n "$leak" ]; then
             echo "⚠️ some dist HTML still references same-origin /assets/ (not CDN-rebased) — KEEPING dist/assets (no breakage, no asset reduction this round)"
             exit 0
           fi

--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -54,23 +54,25 @@ const reLeak = new RegExp(
 // covers EVERY emitted file (no dir is skipped), so a stray /images/blog
 // reference anywhere (even in the job-board corpus, which today carries none)
 // is still caught before any image is deleted.
-function walk(dir: string, fn: (fp: string) => void): void {
+function walk(dir: string, fn: (fp: string) => void, root: string = dir): void {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
     if (e.isDirectory()) {
-      // Mirror postWalkCoordinatorPlugin.walkHtml(): never descend into the
-      // asset/data/image subtrees. They hold only JS/CSS/fonts (assets/),
-      // CDN-offloaded *.json job payloads (data/) and *.webp/*.png/og art
-      // (images/) — none carry .html/.xml/.txt, the only extensions in
-      // SCAN_EXT this pass rewrites. Descending them stat-walked ~1.4M dirents
+      // Skip ONLY the TOP-LEVEL dist/{assets,data,images} (vite JS/CSS/fonts,
+      // CDN-offloaded *.json payloads, *.webp/*.png/og art — none carry the
+      // .html/.xml/.txt in SCAN_EXT). Descending them stat-walked ~1.4M dirents
       // per build for zero rewrites (run 27528505424: 1.59M scanned → 21k
-      // rewritten, wall 811s with cpu 374s = ~54% pure I/O wait). Skipping
-      // them collapses the walk to the content tree without changing a single
-      // rewritten byte; the coordinator already ships this exact exclusion.
-      // The dist/images/blog deletion loop below is a separate explicit
-      // readdirSync of blogDir, so this skip does not affect it.
-      if (e.name === 'assets' || e.name === 'data' || e.name === 'images') continue;
-      walk(fp, fn);
+      // rewritten, wall 811s/cpu 374s = ~54% I/O wait). We gate on `dir === root`
+      // so a NESTED dir merely sharing the name (a content slug, e.g.
+      // dist/en/data/) is STILL walked — its *.html must be scanned because the
+      // leak-guard below deletes dist/images/blog only when NO walked file keeps
+      // a same-origin /images/blog ref; a content page hidden under a nested
+      // assets|data|images dir would otherwise evade the guard and 404 after the
+      // delete. Top-level-only restores the pre-#2237 full-coverage at any depth
+      // while keeping the (huge) top-level dist/data skip. The dist/images/blog
+      // deletion loop below is a separate explicit readdirSync of blogDir.
+      if (dir === root && (e.name === 'assets' || e.name === 'data' || e.name === 'images')) continue;
+      walk(fp, fn, root);
     } else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
   }
 }

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -97,23 +97,25 @@ function log(msg) {
   console.log(`[offload-generated-cdn] ${msg}`);
 }
 
-function walk(dir, fn) {
+function walk(dir, fn, root = dir) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, e.name);
     if (e.isDirectory()) {
-      // Same exclusion as postWalkCoordinatorPlugin.walkHtml() and
-      // blogImageCdnFinalizePlugin: never descend into assets/data/images for
-      // the CONTENT-rewrite pass. The CDN refs this pass rewrites (/assets/,
-      // /og/, /data/, /images/brands… , __CDN_DATA_BASE__) live in the page
-      // HTML of the content tree — NOT in files under those subtrees (assets/=
-      // JS/CSS/fonts, data/=*.json offload payloads, images/=binary art), none
-      // of which carry the .html/.xml/.txt in SCAN_EXT. dist/data alone is
-      // ~1.04M dirs (run note): descending it stat-walked the whole tree for
-      // zero rewrites. The data-delete pass below uses the separate walkAll(),
-      // so dist/data is still fully enumerated for unreferenced-JSON cleanup —
-      // this skip only affects the content-rewrite walk, byte-identically.
-      if (e.name === 'assets' || e.name === 'data' || e.name === 'images') continue;
-      walk(fp, fn);
+      // Skip ONLY the TOP-LEVEL dist/{assets,data,images} (vite JS/CSS/fonts,
+      // *.json offload payloads, binary art — none carry the .html/.xml/.txt in
+      // SCAN_EXT). dist/data alone is ~1.04M dirs, so descending it stat-walked
+      // the whole tree for zero rewrites. We gate on `dir === root` (the initial
+      // dist dir) so a NESTED dir that merely shares the name — a content slug
+      // such as dist/en/data/ — is STILL walked: its *.html must be seen so the
+      // same-origin /assets/ marker we emit (read by the deploy "Drop dist/assets"
+      // step) stays a faithful ANY-DEPTH superset of that step's old full-tree
+      // grep. Top-level-only here, unlike postWalk/blogImageCdn which skip by
+      // name at any depth — those are fail-safe (leak-guard / coordinator), but
+      // this pass's marker is the Drop step's delete authority so it must not
+      // miss a nested content page. The data-delete pass below uses the separate
+      // walkAll(), so top-level dist/data is still fully enumerated for cleanup.
+      if (dir === root && (e.name === 'assets' || e.name === 'data' || e.name === 'images')) continue;
+      walk(fp, fn, root);
     } else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
   }
 }
@@ -137,6 +139,15 @@ function walkAll(dir, fn) {
 // extension set spans every image type those dirs hold (incl. .ico/.gif).
 const OG_FILE = "([^\"'\\s)?]+?\\.(?:webp|png|jpe?g|avif|svg|ico|gif))";
 const ASSET_FILE = "([^\"'\\s)?]+?\\.(?:js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json))";
+// Guard-B parity: the SUPERSET regex the deploy "Drop dist/assets" step greps
+// for, ported 1:1 from its bash ERE. A same-origin /assets/<file>.<ext> ref that
+// SURVIVES the rewrite below (e.g. a custom SSG path that didn't go through
+// ASSET_FILE) must KEEP dist/assets — exactly that step's Guard B. Non-global
+// (stateless .test); applied to HTML only at the callsite to match grep's
+// --include='*.html'. Since walk() above is now top-level-only, this marker sees
+// every content *.html at any depth, so it is the authoritative gate (the Drop
+// step reads our marker), kept byte-faithful to the old grep.
+const ASSETS_SAME_ORIGIN_RX = /["'(]\/?assets\/[^"'() ]*\.(?:js|mjs|css|woff2?|ttf|otf|eot|png|jpe?g|webp|avif|gif|svg|ico|json)/;
 const DATA_FILE = "([^\"'\\s)?<>]+?\\.(?:json|csv))";
 
 // ── Single-pass offload over dist HTML/XML/TXT ───────────────────────────────
@@ -215,6 +226,7 @@ function offloadAll(distDir, cdnBase) {
   let injected = 0;
   let htmlSeen = 0;
   const ogLeaks = [];
+  const assetsLeaks = [];
 
   walk(distDir, (fp) => {
     scanned++;
@@ -235,6 +247,11 @@ function offloadAll(distDir, cdnBase) {
     const beforeAssets = out;
     out = out.replace(assetReAbs, assetRepl).replace(assetReRel, assetRepl);
     if (out !== beforeAssets) assetRewritten++;
+    // Guard-B parity: record any same-origin /assets/ ref that SURVIVES the
+    // rewrite (HTML only — matches the Drop step's --include='*.html'). The data
+    // rewrite + CDN-base inject below never touch /assets/ refs, so the set is
+    // final here. The deploy Drop step keeps dist/assets iff this list is non-empty.
+    if (isHtml && ASSETS_SAME_ORIGIN_RX.test(out)) assetsLeaks.push(path.relative(distDir, fp));
 
     // (2b) data refs: rewrite same-origin /data/<file> (present in dist/data) → CDN
     //      in HTML ONLY (JSON-LD contentUrl + download hrefs). XML sitemap refs are
@@ -287,6 +304,25 @@ function offloadAll(distDir, cdnBase) {
       while ((m = reDataKeep.exec(out))) dataReferenced.add(decodeURIComponent('/data/' + m[1].split('?')[0]));
     }
   });
+
+  // Emit the same-origin /assets/ verdict so the deploy "Drop dist/assets" step
+  // can SKIP its redundant full-tree grep (it reads this marker, and falls back
+  // to the grep if the marker is absent — e.g. this script crashed mid-walk).
+  // walk() is top-level-only, so this covers every content *.html at ANY depth;
+  // the Drop step still belt-greps the top-level dist/{assets,data,images} for
+  // the last gap. ASSETS_SAME_ORIGIN_RX is the single source of truth. CI-only
+  // (RUNNER_TEMP set); local runs skip it (the workflow's grep fallback covers it).
+  const runnerTmp = process.env.RUNNER_TEMP;
+  if (runnerTmp) {
+    const markerPath = path.join(runnerTmp, 'assets-same-origin.marker');
+    if (assetsLeaks.length > 0) {
+      fs.writeFileSync(markerPath, 'LEAK\n' + assetsLeaks.join('\n') + '\n');
+      log(`assets guard: ${assetsLeaks.length} same-origin /assets/ ref(s) survive in HTML — Drop step will KEEP dist/assets (e.g. ${assetsLeaks.slice(0, 3).join(', ')})`);
+    } else {
+      fs.writeFileSync(markerPath, 'CLEAN\n');
+      log('assets guard: no same-origin /assets/ refs survive — Drop step may drop dist/assets');
+    }
+  }
 
   // ── Guarded deletes ──
   // og + thumbnails: delete each offloaded dir UNLESS a same-origin ref to THAT


### PR DESCRIPTION
## Implementato

Elimina la **seconda lettura full-dist dell'HTML** sul build job. Lo step "Drop dist/assets" (Guard B) ri-grepava ogni `*.html` su tutta la dist (~470k file) per un ref same-origin `/assets/` sopravvissuto — **~6min**, un secondo read completo del corpus che lo step "Offload" (subito prima, riscrive `/assets/`→CDN) aveva **già** walkato.

- **`scripts/offload-generated-images-cdn.mjs`**: durante il walk raccoglie il verdetto con `ASSETS_SAME_ORIGIN_RX` (port **1:1** della ERE bash di Guard B) e scrive `$RUNNER_TEMP/assets-same-origin.marker` (`CLEAN` | `LEAK`+path).
- **`.github/workflows/deploy.yml`** (step Drop): legge il marker invece di ri-grepare il content tree.

**~−6 min** sul build job.

### 🔴 di #2241 (chiusa) risolto + sibling-class
La #2241 chiusa aveva un 🔴: il belt-grep di compensazione copriva solo i 3 dir **top-level**, ma la walk skippava quei nomi **a ogni profondità** → un `*.html` sotto una dir annidata chiamata `assets|data|images` (es. `dist/en/data/`) era blind-spot → marker=CLEAN → drop → 404.

**Fix:** entrambe le walk post-emit il cui risultato guida una **cancellazione** ora skippano **solo il top-level** `dist/{assets,data,images}` (`dir === root`), così le dir annidate omonime sono scansionate:
- `offload…walk()` → guida la cancellazione di `dist/assets`.
- `blogImageCdnFinalizePlugin.walk()` → guida la cancellazione di `dist/images/blog` (stesso rischio latente nested-leak→404 introdotto dallo skip by-name-at-depth di #2237).

Lo step Drop belt-grepa solo i 3 root top-level (nessun `*.html` lì per costruzione → near-instant) → copertura **identica** al grep full-tree originale a **ogni profondità**. Verificato: una `dist/en/data/page.html` annidata viene walkata; il top-level `data/` resta skippato (perf win ~1.04M-dir mantenuto).

### Perché fail-safe
- Stesso regex (superset), stesso scope (`*.html`), stesso istante logico. **Marker assente** (offload crashato) → **fallback al grep full-tree originale** → mai più debole.
- `CLEAN` → droppa `dist/assets` (serviti dal CDN); `LEAK`/grep-hit → mantiene (no 404). Guard A (CDN_BASE) invariata.
- Validato: round-trip marker (CLEAN→drop, LEAK→keep, assente→fallback), walk top-level-only (nested walkato / top-level skippato), syntax/YAML/bash.

## Non implementato (ancora)

- **Sibling-class (AGENTS.md #6):** la famiglia `postWalkCoordinatorPlugin` / `flatHtmlRedirectPlugin` / `hreflangPostprocessPlugin` / `blogContextualLinksPlugin` skippa anch'essa by-name-at-depth, ma **NON guida cancellazioni** (fa hreflang/bridge/blog-link): un blind-spot annidato = hreflang mancante su una pagina ipotetica = **degrado SEO, non 404**. È inoltre il pattern pre-esistente. Out of scope (severità diversa, no delete).
- **Revert-trigger** (claim non validabile pre-merge — `build:ci` gira solo post-merge): se post-deploy `validate-live` riporta un 404 su `/assets/*` o `/images/blog/*` same-origin, o il log Drop droppa dove prima manteneva → `git revert`, il grep inline torna autorità.
- Indipendente da #2244. Win deploy-critical residuo (push CDN/locale-shard incrementale ~−8min): richiede commit parented + squash-janitor + test su repo shard reali → decisione owner.
