### PR TITLE
chore(deploy): remove dead vestigial github-pages env from build job (cleanup — NOT a starvation fix, see body)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,9 +149,13 @@ jobs:
     # rendering ~2100 PNGs from scratch) don't fail on the default 6 h
     # ceiling and the failure mode is obvious in the logs if it happens.
     timeout-minutes: 360
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
+    # The `build` job intentionally has NO `environment: github-pages`: it only
+    # uploads the `github-pages` artifact (actions/upload-artifact@v7, for
+    # compression-level control) — the actual actions/deploy-pages runs in the
+    # separate `deploy` job below, which keeps the environment. The env block here
+    # was dead code: its `url:` referenced steps.deployment / steps.deployment_first
+    # that exist only in the deploy job (leftover from the reverted branch-based-
+    # deploy experiment #966/#986). Removing it is a no-op for the deploy flow.
     steps:
       # Free ~25-30 GB on the ubuntu-latest runner before any cache restore
       # or build output lands on disk. Without this the runner ships with


### PR DESCRIPTION
## Implementato

Rimuove il blocco `environment: github-pages` (3 righe) dal **build job** di `deploy.yml`, sostituito da un commento. È **codice vestigiale**: il build job non deploya (fa solo `actions/upload-artifact@v7` name `github-pages`), e l'`url:` dell'environment referenziava `steps.deployment`/`steps.deployment_first` che esistono solo nel **deploy job** separato (residuo dell'esperimento branch-based-deploy revertato #966/#986). Il deploy job mantiene il suo `environment: github-pages` + `actions/deploy-pages`.

**Verificato SAFE** (verifica adversarial 3-agenti, alta confidenza): non rompe il flusso build→deploy→publish (upload-artifact non richiede environment; il deploy job trova l'artifact by-name + deploya indipendentemente; permessi id-token/pages dal blocco `permissions:` job-level; nessun consumer dell'env/url/deployment-record del build job; rollback è `if:false`); YAML valido; il 3-way merge su main corrente **preserva l'hotfix #2253** (`|| true` sul Drop step) applicando solo questa rimozione.

## Non implementato (ancora)

- **⚠️ Questo NON è un fix della starvation (premessa della draft originale falsificata).** La verifica ha smentito empiricamente che l'env causi la cancellazione dei build:
  - Il build del run **27588870295 è girato ~104min fino al completamento CON l'environment presente** → gli env non cancellano job running.
  - Il build "cancellato a 10m22s" citato (27579075877) aveva **`steps_count=0`**: era PENDING in coda `pages-build` ed **evicted** dal push successivo, non un running ucciso.
  - Doc GitHub: `environment:` e `concurrency:` indipendenti; protection-rule mettono in WAIT, non cancellano. Solo il deploy job crea deployment-record (task=deploy).
- **Vera causa starvation:** push-frequency > build-duration → il cap 1-running+1-pending fa evicting dei build PENDING durante l'auto-merge churn. Il running completa (come 27588870295 in finestra quieta). **Vera leva = ridurre/batchare i push-to-main o queue diverso**, fuori scope di questo PR (decisione owner).
- **Revert-trigger:** nessun rischio noto (cleanup di dead-code); se un deploy fallisse al post-merge, `git revert`.

Mergiabile come **cleanup innocuo** che documenta l'analisi. NON aspettarsi che renda i deploy affidabili.
