### PR TITLE
fix(seo): restore /supporto/ /metodologia/ schema dropped by jsToJson parse breakers

### DIFF
--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -1476,11 +1476,14 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  ogTitle: 'Aiutaci a Migliorare | Frontaliere Ticino',
  ogDescription: '🐛 Segnala un problema o suggerisci una funzionalità per il simulatore fiscale frontalieri CH-IT. Contribuisci al miglioramento!',
  canonicalPath: '/supporto/',
+ // SearchAtlas "missing schema markup" (2026-06-15): the support/feedback page
+ // is a contact surface, so ContactPage (below) is the correct type, not a
+ // generic WebPage. NOTE: comments must stay OUTSIDE the structuredData literal
+ // — staticPagesPlugin's jsToJson text-parser does not strip `//` comments, so
+ // an inline comment makes JSON.parse throw and the whole SD block is silently
+ // dropped (regression that stripped this page's schema entirely).
  structuredData: {
  "@context": "https://schema.org",
- // SearchAtlas "missing schema markup" (2026-06-15): the support/feedback
- // page is a contact surface, so ContactPage is the correct type (the audit
- // expects ContactPage here, not a generic WebPage).
  "@type": "ContactPage",
  "name": "Aiutaci a Migliorare - Segnalazioni e Suggerimenti",
  "url": `${BASE_URL}/supporto`,
@@ -2634,8 +2637,6 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "keywords": "mappa confine italia svizzera, valichi ticino, comuni frontalieri 20 km, addizionali irpef frontiera",
  "speakable": SPEAKABLE_SECTION
  },
- // B.2 — Place schema per valico principale con geo coordinates (Ticino-Italia).
- // Source: data/borderCrossings.ts (lat/lng/hours/customsPresent).
  {
  "@context": "https://schema.org",
  "@type": "Place",
@@ -9188,18 +9189,20 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  ogTitle: 'Metodologia editoriale — Come scriviamo gli articoli | Frontaliere Ticino',
  ogDescription: 'Come usiamo IA generativa, fonti primarie e revisione redazionale per garantire accuratezza e trasparenza.',
  canonicalPath: '/metodologia/',
+ // SearchAtlas "missing schema markup" (2026-06-15): this editorial-process
+ // page is an About page (mirrors the /about/ alias which already uses
+ // AboutPage), so AboutPage (below) is the correct type, not a generic WebPage.
+ // NOTE: comments must stay OUTSIDE the structuredData literal — jsToJson does
+ // not strip `//`, so an inline comment makes JSON.parse throw and the SD is
+ // silently dropped.
  structuredData: [
  {
  "@context": "https://schema.org",
- // SearchAtlas "missing schema markup" (2026-06-15): this editorial-process
- // page is an About page (mirrors the /about/ alias which already uses
- // AboutPage), not a generic WebPage. AboutPage is the correct type for a
- // methodology/about-us page and is what the audit expects.
  "@type": "AboutPage",
  "name": "Metodologia editoriale — Come scriviamo gli articoli",
  "url": `${BASE_URL}/metodologia/`,
  "description": "Come utilizziamo l'IA generativa, le fonti primarie e il processo di revisione editoriale per garantire accuratezza e trasparenza.",
- "lastReviewed": BUILD_DATE_ISO.slice(0, 10),
+ "lastReviewed": BUILD_DATE_ISO,
  "inLanguage": "it",
  "isPartOf": { "@id": `${BASE_URL}/#website` },
  "about": {

--- a/tests/static-pages-seo-entry-lookup.test.ts
+++ b/tests/static-pages-seo-entry-lookup.test.ts
@@ -203,17 +203,19 @@ describe('seo source files parse contract (real files)', () => {
     // BASE_URL — any `."identifier"(` that is not a schema key. The leading
     // `.` after a value is the tell (e.g. `.slice(`, `.replace(`, `.toLowerCase(`).
     const methodCallRx = /\.[a-zA-Z_$][\w$]*\s*\(/;
-    const lineCommentRx = /(^|[^:'"])\/\/[^\n]*/m; // `//` not preceded by `:` (avoid https://)
+    // `//` anywhere in the SD (leading OR trailing comment). Both break
+    // jsToJson→JSON.parse identically. Run on the string-stripped form so
+    // `https://` inside string values is already gone (no false positives).
+    const lineCommentRx = /\/\//;
     const offenders: string[] = [];
     for (const [cp, { sd }] of entries) {
       if (!sd) continue;
-      if (/(^|\n)\s*\/\//.test(sd)) offenders.push(`${cp}: inline // comment in structuredData`);
-      // Strip string literals before scanning for method calls (URLs contain `(` rarely, but be safe).
+      // Strip string literals first; whatever `//` or `.method(` survives is real code.
       const noStrings = sd.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`/g, '""');
+      if (lineCommentRx.test(noStrings)) offenders.push(`${cp}: inline // comment in structuredData`);
       if (methodCallRx.test(noStrings)) offenders.push(`${cp}: JS method-call in structuredData`);
     }
     expect(offenders, `structuredData parse-breakers (jsToJson would silently drop these):\n${offenders.join('\n')}`).toEqual([]);
-    expect(lineCommentRx).toBeTruthy(); // keep ref used; documents the `//` shape we guard
   });
 
   it('/supporto/ and /metodologia/ structuredData parse to their declared @type', () => {

--- a/tests/static-pages-seo-entry-lookup.test.ts
+++ b/tests/static-pages-seo-entry-lookup.test.ts
@@ -187,4 +187,61 @@ describe('seo source files parse contract (real files)', () => {
     // for entries without a single-quoted title (template-literal titles).
     expect(entries.size).toBeGreaterThanOrEqual(Math.floor(cpCount * 0.95));
   });
+
+  // Regression gate (PR #2229 → live regression): staticPagesPlugin's jsToJson
+  // text-parser does NOT strip `//` comments and cannot evaluate JS method calls
+  // (e.g. `BUILD_DATE_ISO.slice(0, 10)`). Either one makes the downstream
+  // JSON.parse throw, and the parser's silent `catch { /* skip SD */ }` then
+  // DROPS the whole structuredData block — the page ships with no schema and no
+  // build error. This silently stripped /supporto/ (lost its WebPage→ContactPage)
+  // and /metodologia/ (AboutPage). Forbid both constructs inside any
+  // structuredData literal so the class can never silently recur.
+  it('no structuredData literal contains a // comment or JS method-call (jsToJson breakers)', () => {
+    const src = readFileSync(path.resolve(ROOT, 'services', 'seo', 'seo-pages.ts'), 'utf-8');
+    const entries = parseEntries(src);
+    // Method calls jsToJson leaves intact after substituting BUILD_DATE_ISO /
+    // BASE_URL — any `."identifier"(` that is not a schema key. The leading
+    // `.` after a value is the tell (e.g. `.slice(`, `.replace(`, `.toLowerCase(`).
+    const methodCallRx = /\.[a-zA-Z_$][\w$]*\s*\(/;
+    const lineCommentRx = /(^|[^:'"])\/\/[^\n]*/m; // `//` not preceded by `:` (avoid https://)
+    const offenders: string[] = [];
+    for (const [cp, { sd }] of entries) {
+      if (!sd) continue;
+      if (/(^|\n)\s*\/\//.test(sd)) offenders.push(`${cp}: inline // comment in structuredData`);
+      // Strip string literals before scanning for method calls (URLs contain `(` rarely, but be safe).
+      const noStrings = sd.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`/g, '""');
+      if (methodCallRx.test(noStrings)) offenders.push(`${cp}: JS method-call in structuredData`);
+    }
+    expect(offenders, `structuredData parse-breakers (jsToJson would silently drop these):\n${offenders.join('\n')}`).toEqual([]);
+    expect(lineCommentRx).toBeTruthy(); // keep ref used; documents the `//` shape we guard
+  });
+
+  it('/supporto/ and /metodologia/ structuredData parse to their declared @type', () => {
+    const src = readFileSync(path.resolve(ROOT, 'services', 'seo', 'seo-pages.ts'), 'utf-8');
+    const entries = parseEntries(src);
+    // Mirror jsToJson's value substitutions + JSON.parse to prove the SD survives.
+    const toJson = (js: string): string => {
+      let s = js
+        .replace(/\bBUILD_DATE_ISO\b/g, '"2026-01-01T00:00:00.000Z"')
+        .replace(/\$\{BASE_URL\}/g, 'https://frontaliereticino.ch')
+        .replace(/\bBASE_URL\b/g, '"https://frontaliereticino.ch"')
+        .replace(/`([^`]*)`/g, (_, c: string) => JSON.stringify(c));
+      let out = '', i = 0;
+      while (i < s.length) {
+        if (s[i] === '"') { let j = i + 1; while (j < s.length) { if (s[j] === '\\') { j += 2; continue; } if (s[j] === '"') { j++; break; } j++; } out += s.substring(i, j); i = j; continue; }
+        if (s[i] === "'") { let j = i + 1, c = ''; while (j < s.length) { if (s[j] === '\\' && j + 1 < s.length) { const n = s[j + 1]; if (n === "'") { c += "'"; j += 2; continue; } c += s[j] + n; j += 2; continue; } if (s[j] === "'") { j++; break; } c += s[j]; j++; } out += `"${c.replace(/"/g, '\\"')}"`; i = j; continue; }
+        const prev = i > 0 ? s[i - 1] : '\n';
+        if (/[{,[\s]/.test(prev)) { const m = s.substring(i).match(/^([a-zA-Z_$][\w$]*)(\s*:\s*)/); if (m) { out += `"${m[1]}"${m[2]}`; i += m[0].length; continue; } }
+        out += s[i]; i++;
+      }
+      return out.replace(/,(\s*[}\]])/g, '$1');
+    };
+    const typesFor = (cp: string): string[] => {
+      const sd = entries.get(cp)?.sd ?? '';
+      const parsed = JSON.parse(toJson(sd));
+      return (Array.isArray(parsed) ? parsed : [parsed]).map((x: Record<string, unknown>) => String(x['@type'] ?? ''));
+    };
+    expect(typesFor('/supporto/')).toContain('ContactPage');
+    expect(typesFor('/metodologia/')).toContain('AboutPage');
+  });
 });


### PR DESCRIPTION
## Contesto

Durante la **verifica live** di #2229 ho scoperto una **regressione live**: `/supporto/` e `/metodologia/` non emettevano lo schema atteso (`/supporto/` aveva addirittura **perso** il suo `WebPage` preesistente).

Causa: il text-parser `jsToJson` di `staticPagesPlugin` (legge `seo-pages.ts` come stringa, non come modulo) **non rimuove i commenti `//`** e **non valuta chiamate-metodo JS**. Quando il `JSON.parse` a valle fallisce, il `catch { /* skip SD */ }` silenzioso **scarta l'intero blocco structuredData** — la pagina va live senza schema e senza errore di build. I fix canton/thin-hub di #2229 funzionano (usano `inlineScriptJson` a runtime, non il text-parser) ed erano già verificati live.

## Implementato

- **`/supporto/` (ContactPage) e `/metodologia/` (AboutPage)**: i commenti di rationale aggiunti da #2229 **dentro** gli oggetti structuredData rompevano `jsToJson` → spostati **fuori** dal literal. Ora entrambe le pagine parsano e emettono il tipo corretto.
- **`/metodologia/`**: `"lastReviewed": BUILD_DATE_ISO.slice(0, 10)` — `jsToJson` sostituisce `BUILD_DATE_ISO` con una stringa quotata ma lascia `.slice(0, 10)`, rompendo il parse (bug **pre-esistente**, indipendente da #2229). Sostituito con `BUILD_DATE_ISO` puro (ISO completo, valido per `lastReviewed`).
- **Sibling trovato dal nuovo guard test** — `/guida-frontaliere/mappa-confine/`: commento inline `// B.2 …` dentro l'array structuredData (schema Place/Article/FAQ scartato silenziosamente). Rimosso.
- **Guard test** (`tests/static-pages-seo-entry-lookup.test.ts`): vieta commenti `//` e chiamate-metodo JS dentro qualsiasi literal structuredData, e verifica che `/supporto/`→`ContactPage` e `/metodologia/`→`AboutPage` parsino davvero. Chiude la classe di fallimento silenzioso (il `catch` di jsToJson la nascondeva).

## Non implementato (ancora)

- Hardening del parser `jsToJson` per **strippare** i commenti `//` (renderebbe i commenti inline innocui by-construction): out of scope qui — tocca un build-plugin funnel-critical; il guard test previene già la ricorrenza a monte (più sicuro e a costo zero). Possibile follow-up.

## Verifica

- [x] Simulazione `jsToJson` + `JSON.parse` su seo-pages.ts: `/supporto/`→`ContactPage`, `/metodologia/`→`AboutPage` (prima fallivano).
- [x] `tests/static-pages-seo-entry-lookup.test.ts` (9 test, incl. nuovo guard), `page-schema-translators`, `static-pages-blog-skip` — 36 test verdi.
- [ ] Emissione live osservata post-deploy su `main` (deploy SSG OOM-prone + attualmente in starvation da alto volume commit crawler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)