### PR TITLE
fix(jobboard): top up thin slug searches with OR-fill (no more hydrate-to-1 collapse)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2956,12 +2956,23 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  // In-canton OR-fallback: partial token matches ranked by hit count, capped
  // at MAX_FALLBACK_RESULTS. Mirrors the build plugin's two-phase matching at
- // build/relatedSearchClustersPlugin.ts so users landing on a slug URL see
- // the SAME job set the static cluster page would show.
+ // build/relatedSearchClustersPlugin.ts (AND first, then OR-fill up to
+ // MAX_JOBS_PER_PAGE) so users landing on a slug URL see the SAME job set the
+ // static cluster page would show.
+ //
+ // Fires whenever the strict AND tier is THIN (< BROADEN_BELOW), not only when
+ // it returns zero. The previous gate was `strict.length > 0`: a slug whose AND
+ // phase yielded a single job (e.g.
+ // /cerca-lavoro-svizzera/ricerca-responsabile-…-cure-infermieristiche-m-f/)
+ // stayed stuck at 1 result after hydration while the static HTML showed 30 —
+ // the OR-fill never ran. Now it tops up the strict matches with partial-token
+ // matches (excluding the strict ids, which `filteredJobs` lists first), so the
+ // hydrated page matches the static cluster page instead of collapsing to 1
+ // (which also removed the jarring static-30 → hydrated-1 layout shift).
  const MAX_FALLBACK_RESULTS = 30;
  const orFallbackInCantonJobs = useMemo<JobListing[]>(() => {
  const query = deferredSearchQuery.trim();
- if (!query || strictFilteredJobs.length > 0) return [];
+ if (!query || strictFilteredJobs.length >= BROADEN_BELOW) return [];
 
  // Score the boilerplate-stripped query so the matched tokens stay
  // consistent with the floor (`orFallbackMinScore`, which counts content
@@ -2976,8 +2987,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  };
  const cutoff = deferredSelectedDateRange === 'all' ? 0 : now - dateRangeMs[deferredSelectedDateRange];
 
+ // Exclude jobs already matched by the strict AND tier — this tier supplies
+ // only the OR-fill tail; `filteredJobs` lists the strict matches first.
+ const strictIds = new Set<string>();
+ for (const j of strictFilteredJobs) strictIds.add(j.id);
+
  const scored: { job: JobListing; score: number }[] = [];
  for (const job of sortedJobs) {
+ if (strictIds.has(job.id)) continue;
  if (!passingNonSearchFilters(job, now, cutoff)) continue;
  const haystack = searchIndex.get(job) ?? '';
  let score = 0;
@@ -3010,7 +3027,8 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // The in-canton result is whichever tier won: strict (AND) if it has any,
  // else the in-canton OR fallback. These are merged-with (not replaced) by the
  // consumer (`filteredJobs`), so this tier only supplies the broadened tail.
- const inCantonCount = strictFilteredJobs.length > 0 ? strictFilteredJobs.length : orFallbackInCantonJobs.length;
+ // strict + OR-fill tail (the fill excludes strict ids, so no double count).
+ const inCantonCount = strictFilteredJobs.length + orFallbackInCantonJobs.length;
  if (inCantonCount >= BROADEN_BELOW) return [];
  if (unscopedJobs.length === 0) return [];
 
@@ -3174,7 +3192,8 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (!deferredSearchQuery.trim()) return;
  if ((initialFilterCanton || getDefaultCantonForVisit()) === AGGREGATE_CANTON_CODE) return;
  if (unscopedJobs.length > 0) return; // pool already available
- const inCantonCount = strictFilteredJobs.length > 0 ? strictFilteredJobs.length : orFallbackInCantonJobs.length;
+ // strict + OR-fill tail (the fill excludes strict ids, so no double count).
+ const inCantonCount = strictFilteredJobs.length + orFallbackInCantonJobs.length;
  if (inCantonCount >= BROADEN_BELOW) return; // enough in-canton results already
  searchBroadenFetchAttempted.current = true;
  let cancelled = false;
@@ -3295,11 +3314,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (!list.some((j) => j.featured)) return list;
  return [...list.filter((j) => j.featured), ...list.filter((j) => !j.featured)];
  };
- const inCanton = strictFilteredJobs.length > 0
- ? strictFilteredJobs
- : orFallbackInCantonJobs.length > 0
- ? orFallbackInCantonJobs
- : [];
+ // Merge the strict AND matches (first) with the in-canton OR-fill tail
+ // (already excludes strict ids) so a thin strict tier is topped up to the
+ // static cluster page's job set instead of collapsing to a single result.
+ const seenInCanton = new Set<string>();
+ const inCanton: JobListing[] = [];
+ for (const j of strictFilteredJobs) { if (!seenInCanton.has(j.id)) { seenInCanton.add(j.id); inCanton.push(j); } }
+ for (const j of orFallbackInCantonJobs) { if (!seenInCanton.has(j.id)) { seenInCanton.add(j.id); inCanton.push(j); } }
  if (inCanton.length > 0) {
  if (crossCantonFallbackJobs.length === 0) return featuredFirst(inCanton);
  const seen = new Set<string>();


### PR DESCRIPTION
## Implementato

- **Causa radice del problema "1 risultato"**: le landing slug ruolo/keyword (`cerca-lavoro-svizzera/ricerca-…/`) emettono **30 job nell'HTML statico** ma dopo l'hydration la SPA collassava a **1 solo risultato**. Verificato live su `ricerca-responsabile-specializzato-a-di-cure-infermieristiche-m-f/`: HTML statico = 30 `<li>`, DOM idratato = "1 offerta".
- **Fix in `components/community/JobBoard.tsx`**: l'OR-fallback in-cantone (`orFallbackInCantonJobs`) partiva **solo quando il tier strict AND restituiva ZERO**. Uno slug il cui AND matchava esattamente 1 job restava bloccato a 1, perché l'OR-fill (che il build plugin statico usa per arrivare a `MAX_JOBS_PER_PAGE`) non girava mai. Ora:
  - L'OR-fill parte quando lo strict è **thin** (`strictFilteredJobs.length < BROADEN_BELOW`), non solo quando è 0 — stessa soglia `BROADEN_BELOW=10` già usata dal tier cross-cantone (coerenza).
  - L'OR-fill **esclude gli id già matchati dallo strict** → fornisce solo la coda di riempimento.
  - `filteredJobs` ora **fonde strict (primi) + coda OR-fill** (dedup per id) invece di scegliere l'uno o l'altro.
  - `inCantonCount` (gate cross-cantone + trigger `loadUnscopedPool`) ora conta `strict + OR-fill` (la coda esclude gli strict id → niente doppio conteggio).
- **Effetto**: la SPA idratata torna in lockstep con la cluster page statica (lockstep già promesso dai commenti circostanti). Per l'esempio: 1 strict + ~29 OR-fill = ~30 risultati.
- **Performance/UX**: elimina lo **shift statico-30 → idratato-1** al load (re-render sprecato + layout shift). Misurato live: FCP 544ms / load 633ms — la rete NON è il collo (363KB script di cui ~293KB AdSense, intoccabile, ~95% revenue); il "lento" percepito era proprio il collasso del contenuto, ora rimosso.
- Test verdi: `related-search-clusters{,-or-fill-floor,-shell}` + `jobboard-related-search-navigation` (95 test). `tsc --noEmit` pulito su `JobBoard.tsx`.

## Non implementato (ancora)

- **Sibling-pattern check (`check-sibling-patterns.mjs`)**: 8 file flaggati come euristici falsi-positivi e NON toccati con giustificazione:
  - `build-plugins/relatedSearchClustersPlugin.ts` e `build-plugins/jobsSeoPagesPlugin.ts` condividono `MAX_JOBS_PER_PAGE`/`inCanton` ma sono il **riferimento corretto** (AND→OR-fill fino a MAX): è il comportamento che questa PR replica nella SPA, non un antipattern da fixare.
  - `seoHubsPlugin.ts`, `shared/cantonHubEditorial.ts`, `shared/cantonNoindexRegistry.ts`, `shared/cantonSectorPageRegistry.ts`, `scripts/audit-jobs-source-match.mjs`, `scripts/profile-cluster-emission.mjs` condividono solo nomi generici (`inCanton`/`filteredJobs`) in contesti diversi — nessun gate `strict.length > 0`. L'antipattern esisteva **solo** in `JobBoard.tsx`.
- **GitNexus `detect_changes`**: bloccato da `ENOBUFS` (auto-diffa il local `main` dirty con migliaia di file foreign, non il worktree). Scope verificato via `git diff origin/main`: 1 file, soli hook interni, nessun simbolo esportato modificato.
- **Verifica live post-deploy**: il collasso è SPA-runtime, non verificabile sul `pull_request` (no build SSG locale, OOM). Da confermare in browser su `main` dopo il deploy che la pagina esempio mostri ~30 risultati idratati. Se regredisce → revert di questo commit.