### PR TITLE
feat(email): observe Cloudflare delivery events (pull-based)

### DIFF
--- a/scripts/check-email-quotas.mjs
+++ b/scripts/check-email-quotas.mjs
@@ -21,6 +21,7 @@ import {
   logProviderSummary,
   isProviderConfigured,
   fetchCloudflareUsage,
+  fetchCloudflareDeliveryStats,
 } from './lib/email-cascade.mjs';
 
 function todayUTC() {
@@ -51,9 +52,10 @@ async function main() {
   // above is in-memory only for this provider.
   if (isProviderConfigured('cloudflare')) {
     const monthlyCap = PROVIDERS.find(p => p.id === 'cloudflare')?.monthlyLimit ?? 3000;
-    const [today, mtd] = await Promise.all([
+    const [today, mtd, todayStats] = await Promise.all([
       fetchCloudflareUsage(todayUTC(), todayUTC()),
       fetchCloudflareUsage(firstOfMonthUTC(), todayUTC()),
+      fetchCloudflareDeliveryStats(todayUTC(), todayUTC()),
     ]);
     console.log('\n☁️  Cloudflare Email Service (GraphQL Analytics):');
     if (mtd === null) {
@@ -64,6 +66,15 @@ async function main() {
       console.log(`   Send events today:        ${today ?? 'n/a'}`);
       console.log(`   Send events month-to-date: ${mtd} / ${monthlyCap}  (≈${remaining} remaining this month)`);
       console.log('   Note: counts raw send EVENTS (queued/delivered/bounced), so it may exceed the email count.');
+      // Delivery-event observation. Cloudflare has no webhook and no open/click
+      // tracking — delivery STATUS via this pull dataset is the only event signal.
+      if (todayStats && Object.keys(todayStats.byStatus).length) {
+        const breakdown = Object.entries(todayStats.byStatus)
+          .sort((a, b) => b[1] - a[1])
+          .map(([s, n]) => `${s}=${n}`)
+          .join(', ');
+        console.log(`   Delivery status today:    ${breakdown}`);
+      }
     }
   }
 }

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -188,18 +188,20 @@ async function fetchMailerooDailyUsage() {
 }
 
 /**
- * Query Cloudflare Email Service usage via the GraphQL Analytics API
- * (dataset emailSendingAdaptiveGroups). Returns the raw count of send events in
- * [startDate, endDate] (inclusive, ISO yyyy-mm-dd), or null when the endpoint is
- * unreachable / unauthorized / unconfigured so callers can tell "0 sent" apart
- * from "couldn't verify". Requires the token to carry the Analytics Read scope.
+ * Low-level query against the Cloudflare Email Service GraphQL Analytics API
+ * (dataset emailSendingAdaptiveGroups). Returns the raw `groups` array for
+ * [startDate, endDate] (inclusive, ISO yyyy-mm-dd), optionally grouped by the
+ * given dimensions, or null when the endpoint is unreachable / unauthorized /
+ * unconfigured so callers can tell "0 events" apart from "couldn't verify".
+ * Requires the token to carry the Analytics Read scope.
  * Docs: https://developers.cloudflare.com/email-service/observability/metrics-analytics/
  */
-export async function fetchCloudflareUsage(startDate, endDate) {
+async function queryCloudflareEmailGroups(startDate, endDate, dimensions = []) {
   const accountId = process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID;
   const token = process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CF_EMAIL_API_TOKEN;
   if (!accountId || !token) return null;
-  const query = `query($acc:String!,$start:Date!,$end:Date!){viewer{accounts(filter:{accountTag:$acc}){emailSendingAdaptiveGroups(filter:{date_geq:$start,date_leq:$end},limit:10000){count}}}}`;
+  const dimFields = dimensions.length ? ` dimensions{${dimensions.join(' ')}}` : '';
+  const query = `query($acc:String!,$start:Date!,$end:Date!){viewer{accounts(filter:{accountTag:$acc}){emailSendingAdaptiveGroups(filter:{date_geq:$start,date_leq:$end},limit:10000){count${dimFields}}}}}`;
   try {
     const res = await fetch('https://api.cloudflare.com/client/v4/graphql', {
       method: 'POST',
@@ -209,9 +211,40 @@ export async function fetchCloudflareUsage(startDate, endDate) {
     if (!res.ok) return null;
     const data = await res.json().catch(() => null);
     if (!data || data.errors?.length) return null;
-    const groups = data?.data?.viewer?.accounts?.[0]?.emailSendingAdaptiveGroups || [];
-    return groups.reduce((sum, g) => sum + (Number(g.count) || 0), 0);
+    return data?.data?.viewer?.accounts?.[0]?.emailSendingAdaptiveGroups || [];
   } catch { return null; }
+}
+
+/**
+ * Total count of send events in [startDate, endDate], or null if unverifiable.
+ */
+export async function fetchCloudflareUsage(startDate, endDate) {
+  const groups = await queryCloudflareEmailGroups(startDate, endDate);
+  if (groups === null) return null;
+  return groups.reduce((sum, g) => sum + (Number(g.count) || 0), 0);
+}
+
+/**
+ * Delivery-event observation for Cloudflare Email Service. Unlike the cascade's
+ * other providers, Cloudflare exposes NO outbound webhook and does NOT track
+ * opens/clicks (it is a delivery-only relay) — engagement events simply do not
+ * exist there. The only observable signal is delivery STATUS (sent / delivered /
+ * failed / rejected / bounced + auth results), and it is PULL-only via this
+ * Analytics dataset. Returns { total, byStatus: { <status>: count } } for
+ * [startDate, endDate], or null if unverifiable.
+ */
+export async function fetchCloudflareDeliveryStats(startDate, endDate) {
+  const groups = await queryCloudflareEmailGroups(startDate, endDate, ['status']);
+  if (groups === null) return null;
+  const byStatus = {};
+  let total = 0;
+  for (const g of groups) {
+    const n = Number(g.count) || 0;
+    total += n;
+    const status = g.dimensions?.status || 'unknown';
+    byStatus[status] = (byStatus[status] || 0) + n;
+  }
+  return { total, byStatus };
 }
 
 /**

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -3,6 +3,8 @@ import {
   isRateLimitedError,
   sendEmailCascade,
   fetchMailtrapDailyUsage,
+  fetchCloudflareUsage,
+  fetchCloudflareDeliveryStats,
   PROVIDERS,
 } from '../scripts/lib/email-cascade.mjs';
 
@@ -215,5 +217,61 @@ describe('sendEmailCascade — cloudflare provider', () => {
     expect(sendCalls).toBe(1); // 429 → provider exhausted → rest skipped locally
     expect(sent.length).toBe(0);
     expect(failed.length).toBe(10);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Cloudflare delivery-event observation (GraphQL Analytics, pull)    */
+/* ------------------------------------------------------------------ */
+
+describe('fetchCloudflareUsage / fetchCloudflareDeliveryStats', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.CLOUDFLARE_EMAIL_API_TOKEN = 'cf-test-token';
+    process.env.CF_ACCOUNT_ID = 'acc-123';
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.CLOUDFLARE_EMAIL_API_TOKEN;
+    delete process.env.CF_ACCOUNT_ID;
+  });
+
+  function mockGraphQL(groups: any[]) {
+    globalThis.fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { viewer: { accounts: [{ emailSendingAdaptiveGroups: groups }] } } }),
+    })) as any;
+  }
+
+  it('sums total send events for fetchCloudflareUsage', async () => {
+    mockGraphQL([{ count: 12 }, { count: 8 }]);
+    expect(await fetchCloudflareUsage('2026-06-01', '2026-06-16')).toBe(20);
+  });
+
+  it('breaks down delivery status for fetchCloudflareDeliveryStats', async () => {
+    mockGraphQL([
+      { count: 40, dimensions: { status: 'delivered' } },
+      { count: 3, dimensions: { status: 'bounced' } },
+      { count: 1, dimensions: { status: 'failed' } },
+    ]);
+    const stats = await fetchCloudflareDeliveryStats('2026-06-16', '2026-06-16');
+    expect(stats).toEqual({ total: 44, byStatus: { delivered: 40, bounced: 3, failed: 1 } });
+  });
+
+  it('returns null (not 0) when unconfigured so callers can tell "couldn\'t verify"', async () => {
+    delete process.env.CLOUDFLARE_EMAIL_API_TOKEN;
+    expect(await fetchCloudflareUsage('2026-06-16', '2026-06-16')).toBeNull();
+    expect(await fetchCloudflareDeliveryStats('2026-06-16', '2026-06-16')).toBeNull();
+  });
+
+  it('returns null when the GraphQL response carries errors', async () => {
+    globalThis.fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ errors: [{ message: 'auth' }] }),
+    })) as any;
+    expect(await fetchCloudflareDeliveryStats('2026-06-16', '2026-06-16')).toBeNull();
   });
 });


### PR DESCRIPTION
## Implementato

Follow-up di #2263 (Cloudflare Email Service come provider cascade). Aggiunge l'**osservazione degli eventi** per Cloudflare, nei limiti di ciò che la piattaforma espone.

**Differenza di piattaforma (importante):** a differenza di Mailgun/Resend/Mailjet/Mailtrap/Maileroo, **Cloudflare Email Service NON espone webhook in uscita e NON traccia open/click** — è un relay solo-consegna, gli eventi di engagement non esistono. L'unico segnale osservabile è lo **stato di consegna** (sent/delivered/failed/rejected/bounced + auth SPF/DKIM/DMARC), disponibile **solo in pull** via GraphQL Analytics (dataset `emailSendingAdaptiveGroups`). Quindi un `newsletterCloudflareWebhookCore.js` stile-altri-provider non è implementabile; questa PR fornisce la parità massima possibile via pull.

- **`scripts/lib/email-cascade.mjs`**:
  - Estratto helper `queryCloudflareEmailGroups(start, end, dimensions)` sul GraphQL Analytics API.
  - `fetchCloudflareUsage()` ora riusa l'helper (invariato nel comportamento: totale eventi).
  - Nuova `fetchCloudflareDeliveryStats(start, end)` → `{ total, byStatus: { delivered, bounced, failed, … } }`; fallback `null` (distingue "0 eventi" da "non verificabile").
- **`scripts/check-email-quotas.mjs`**: stampa il breakdown stato-consegna di oggi per Cloudflare oltre al consumo month-to-date.
- **`tests/email-cascade-burst.test.ts`**: somma totale, breakdown per status, `null` su non-configurato e su errori GraphQL.

Docs: [observability/logs](https://developers.cloudflare.com/email-service/observability/logs/), [metrics-analytics](https://developers.cloudflare.com/email-service/observability/metrics-analytics/).

## Non implementato (ancora)

- **Webhook inbound open/click/delivered**: non implementabile — Cloudflare Email Service non ha webhook in uscita né tracking open/click (vedi sopra). Nessun handler in `functions/index.js`.
- **Path transazionale diretto-Resend** (`sendCalculatorReport.js`, `newsletterConfirmationEmail.js`): usano l'SDK Resend direttamente, fuori dalla cascade → out of scope.

## Test
- [x] `tests/email-cascade-burst.test.ts` (16 test) — verde