### PR TITLE
fix(email): Cloudflare uses default CF_API_TOKEN + zone-scoped analytics

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -25,10 +25,16 @@
  *   MAILTRAP_API_TOKEN       — Mailtrap API token (4000/mo, 150/day free tier)
  *   MAILEROO_API_KEY         — Maileroo sending key (3000/mo free tier)
  *   RESEND_API_KEY           — Resend API key (fallback only)
- *   CLOUDFLARE_EMAIL_API_TOKEN — Cloudflare Email Service token (Email Sending: Edit
- *                                + Analytics Read). 3000/mo included on the existing
- *                                Workers Paid plan (no extra $), then $0.35/1000.
+ *   CF_API_TOKEN             — Cloudflare token used by default for Email Service:
+ *                                it already carries Email Sending: Edit + Analytics
+ *                                Read (verified live). 3000/mo included on the
+ *                                existing Workers Paid plan (no extra $), then
+ *                                $0.35/1000. Override with CLOUDFLARE_EMAIL_API_TOKEN
+ *                                if a dedicated, narrower-scoped token is preferred.
  *   CF_ACCOUNT_ID            — Cloudflare account id (shared with the CDN/Workers config)
+ *   CF_ZONE_ID               — optional; zone id for the sending domain. Auto-resolved
+ *                                from CF_EMAIL_DOMAIN (default frontaliereticino.ch)
+ *                                when unset. Used only for analytics (zone-scoped).
  */
 
 // ── Provider daily quotas ────────────────────────────────────
@@ -187,31 +193,69 @@ async function fetchMailerooDailyUsage() {
   return 0;
 }
 
+// ── Cloudflare Email Service shared config ───────────────────
+// One token covers the whole integration: the existing default CF_API_TOKEN in
+// Remote Config already carries Email Sending: Edit + Analytics Read (verified
+// live), so no dedicated token is required. CLOUDFLARE_EMAIL_API_TOKEN /
+// CF_EMAIL_API_TOKEN remain as optional overrides for a narrower-scoped token.
+const CLOUDFLARE_EMAIL_DOMAIN = process.env.CF_EMAIL_DOMAIN || 'frontaliereticino.ch';
+let _cfZoneIdCache;
+
+function cloudflareToken() {
+  return process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CF_EMAIL_API_TOKEN || process.env.CF_API_TOKEN;
+}
+function cloudflareAccountId() {
+  return process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID;
+}
+
+/**
+ * Resolve the zone id for the sending domain (the emailSendingAdaptiveGroups
+ * analytics dataset is ZONE-scoped, not account-scoped). Prefers CF_ZONE_ID,
+ * else looks it up by domain once and caches it. Returns null if unresolvable
+ * (token missing Zone Read, domain not on the account, network error).
+ */
+async function resolveCloudflareZoneId() {
+  if (process.env.CF_ZONE_ID) return process.env.CF_ZONE_ID;
+  if (_cfZoneIdCache !== undefined) return _cfZoneIdCache;
+  const token = cloudflareToken();
+  if (!token) { _cfZoneIdCache = null; return null; }
+  try {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(CLOUDFLARE_EMAIL_DOMAIN)}&status=active`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) { _cfZoneIdCache = null; return null; }
+    const data = await res.json().catch(() => null);
+    _cfZoneIdCache = data?.result?.[0]?.id || null;
+    return _cfZoneIdCache;
+  } catch { _cfZoneIdCache = null; return null; }
+}
+
 /**
  * Low-level query against the Cloudflare Email Service GraphQL Analytics API
- * (dataset emailSendingAdaptiveGroups). Returns the raw `groups` array for
- * [startDate, endDate] (inclusive, ISO yyyy-mm-dd), optionally grouped by the
- * given dimensions, or null when the endpoint is unreachable / unauthorized /
- * unconfigured so callers can tell "0 events" apart from "couldn't verify".
- * Requires the token to carry the Analytics Read scope.
+ * (dataset emailSendingAdaptiveGroups, ZONE-scoped). Returns the raw `groups`
+ * array for [startDate, endDate] (inclusive, ISO yyyy-mm-dd), optionally grouped
+ * by the given dimensions, or null when the endpoint is unreachable /
+ * unauthorized / unconfigured so callers can tell "0 events" apart from
+ * "couldn't verify". Requires the token to carry the Analytics Read scope.
  * Docs: https://developers.cloudflare.com/email-service/observability/metrics-analytics/
  */
 async function queryCloudflareEmailGroups(startDate, endDate, dimensions = []) {
-  const accountId = process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID;
-  const token = process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CF_EMAIL_API_TOKEN;
-  if (!accountId || !token) return null;
+  const token = cloudflareToken();
+  const zoneId = await resolveCloudflareZoneId();
+  if (!token || !zoneId) return null;
   const dimFields = dimensions.length ? ` dimensions{${dimensions.join(' ')}}` : '';
-  const query = `query($acc:String!,$start:Date!,$end:Date!){viewer{accounts(filter:{accountTag:$acc}){emailSendingAdaptiveGroups(filter:{date_geq:$start,date_leq:$end},limit:10000){count${dimFields}}}}}`;
+  const query = `query($zone:String!,$start:Date!,$end:Date!){viewer{zones(filter:{zoneTag:$zone}){emailSendingAdaptiveGroups(filter:{date_geq:$start,date_leq:$end},limit:10000){count${dimFields}}}}}`;
   try {
     const res = await fetch('https://api.cloudflare.com/client/v4/graphql', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ query, variables: { acc: accountId, start: startDate, end: endDate } }),
+      body: JSON.stringify({ query, variables: { zone: zoneId, start: startDate, end: endDate } }),
     });
     if (!res.ok) return null;
     const data = await res.json().catch(() => null);
     if (!data || data.errors?.length) return null;
-    return data?.data?.viewer?.accounts?.[0]?.emailSendingAdaptiveGroups || [];
+    return data?.data?.viewer?.zones?.[0]?.emailSendingAdaptiveGroups || [];
   } catch { return null; }
 }
 
@@ -300,8 +344,7 @@ function isProviderConfigured(providerId) {
     case 'maileroo':   return !!process.env.MAILEROO_API_KEY;
     case 'unosend':    return !!process.env.UNOSEND_API_KEY;
     case 'resend':     return !!process.env.RESEND_API_KEY;
-    case 'cloudflare': return !!((process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CF_EMAIL_API_TOKEN) &&
-                                 (process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID));
+    case 'cloudflare': return !!(cloudflareToken() && cloudflareAccountId());
     default: return false;
   }
 }
@@ -545,14 +588,16 @@ async function sendViaResend(email) {
 
 // ── Cloudflare Email Service REST API ─────────────────────────
 // Docs: https://developers.cloudflare.com/email-service/api/send-emails/rest-api/
-// Auth: Bearer token (Email Sending: Edit). `from`/`to`/`cc`/`bcc`/`replyTo`
-// accept either a plain string or { email, name } (named recipients, 2026-05-28),
-// and `to` may be an array mixing both. Free outbound requires the Workers Paid
-// plan; 3000/mo are included before per-email pricing kicks in.
+// Auth: Bearer token (Email Sending: Edit) — the default CF_API_TOKEN already has
+// it. `from`/`to`/`cc`/`bcc`/`replyTo` accept either a plain string or
+// { email, name } (named recipients, 2026-05-28), and `to` may be an array mixing
+// both. Free outbound requires the Workers Paid plan; 3000/mo are included before
+// per-email pricing kicks in. Response is the standard client/v4 envelope:
+// { success, errors, result: { message_id, delivered, queued, permanent_bounces } }.
 
 async function sendViaCloudflare(email) {
-  const accountId = process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID;
-  const token = process.env.CLOUDFLARE_EMAIL_API_TOKEN || process.env.CF_EMAIL_API_TOKEN;
+  const accountId = cloudflareAccountId();
+  const token = cloudflareToken();
   const fromParsed = parseEmailAddress(email.from);
 
   const body = {
@@ -588,17 +633,19 @@ async function sendViaCloudflare(email) {
   if (data?.success === false) {
     throw new Error(`Cloudflare error: ${JSON.stringify(data.errors || []).slice(0, 200)}`);
   }
-  // Response groups recipients into delivered / queued / permanent_bounces.
-  // It may be wrapped in the standard client/v4 envelope (data.result) or raw.
+  // Standard client/v4 envelope; result groups recipients into
+  // delivered / queued / permanent_bounces and carries a top-level message_id.
+  // An accepted send returns success:true + result.message_id even when both
+  // delivered and queued are still empty (delivery is async), so the message_id
+  // — not the per-recipient arrays — is the success signal.
   const result = data?.result || data;
   const accepted = [].concat(result?.delivered || [], result?.queued || []);
   const bounced = result?.permanent_bounces || [];
-  if (accepted.length === 0 && bounced.length > 0) {
+  const messageId = result?.message_id || result?.id || accepted[0]?.id || accepted[0]?.message_id;
+  if (!messageId && bounced.length > 0) {
     throw new Error(`Cloudflare permanent_bounce: ${JSON.stringify(bounced).slice(0, 200)}`);
   }
-  const first = accepted[0];
-  const messageId = (first && (first.id || first.message_id || first.email)) || `cf-${Date.now()}`;
-  return { messageId: String(messageId), provider: 'cloudflare' };
+  return { messageId: String(messageId || `cf-${Date.now()}`), provider: 'cloudflare' };
 }
 
 // ── Provider dispatch ────────────────────────────────────────

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -159,7 +159,7 @@ describe('sendEmailCascade — cloudflare provider', () => {
     delete process.env.CF_ACCOUNT_ID;
   });
 
-  it('sends via the account-scoped REST endpoint and reports provider=cloudflare', async () => {
+  it('sends via the account-scoped REST endpoint and returns the real message_id', async () => {
     let sendUrl = '';
     globalThis.fetch = (async (url: string, opts?: any) => {
       if (String(url).includes(CF_SEND)) {
@@ -168,10 +168,11 @@ describe('sendEmailCascade — cloudflare provider', () => {
         // from with a display name → { email, name }; to → array of strings.
         expect(body.from).toEqual({ email: 'a@b.ch', name: 'Frontaliere' });
         expect(body.to).toEqual(['x@y.com']);
+        // Real envelope: success + result.message_id even when delivered/queued empty.
         return {
           ok: true,
           status: 200,
-          json: async () => ({ result: { delivered: [], queued: [{ email: 'x@y.com' }], permanent_bounces: [] } }),
+          json: async () => ({ success: true, errors: [], result: { message_id: '<abc@frontaliereticino.ch>', delivered: [], queued: [], permanent_bounces: [] } }),
           text: async () => '{}',
         } as any;
       }
@@ -187,6 +188,33 @@ describe('sendEmailCascade — cloudflare provider', () => {
     expect(failed.length).toBe(0);
     expect(sent.length).toBe(1);
     expect(sent[0].provider).toBe('cloudflare');
+    expect(sent[0].messageId).toBe('<abc@frontaliereticino.ch>');
+  });
+
+  it('falls back to the default CF_API_TOKEN when no dedicated token is set', async () => {
+    delete process.env.CLOUDFLARE_EMAIL_API_TOKEN;
+    process.env.CF_API_TOKEN = 'default-cf-token';
+    let auth = '';
+    globalThis.fetch = (async (url: string, opts?: any) => {
+      if (String(url).includes(CF_SEND)) {
+        auth = opts.headers.Authorization;
+        return {
+          ok: true, status: 200,
+          json: async () => ({ success: true, result: { message_id: '<m@frontaliereticino.ch>' } }),
+          text: async () => '{}',
+        } as any;
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' } as any;
+    }) as any;
+
+    const { sent } = await sendEmailCascade(
+      [{ payload: { from: 'a@b.ch', to: ['x@y.com'], subject: 's', html: '<p>h</p>' }, recipient: { email: 'x@y.com' }, meta: {} }],
+      { forceProvider: 'cloudflare', delayMs: 0 },
+    );
+
+    expect(auth).toBe('Bearer default-cf-token');
+    expect(sent.length).toBe(1);
+    delete process.env.CF_API_TOKEN;
   });
 
   it('retires cloudflare after a 429 throttle (no burst across a batch)', async () => {
@@ -230,18 +258,23 @@ describe('fetchCloudflareUsage / fetchCloudflareDeliveryStats', () => {
   beforeEach(() => {
     process.env.CLOUDFLARE_EMAIL_API_TOKEN = 'cf-test-token';
     process.env.CF_ACCOUNT_ID = 'acc-123';
+    process.env.CF_ZONE_ID = 'zone-123'; // skip the zone-lookup network call
   });
   afterEach(() => {
     globalThis.fetch = realFetch;
     delete process.env.CLOUDFLARE_EMAIL_API_TOKEN;
+    delete process.env.CF_EMAIL_API_TOKEN;
+    delete process.env.CF_API_TOKEN;
     delete process.env.CF_ACCOUNT_ID;
+    delete process.env.CF_ZONE_ID;
   });
 
+  // emailSendingAdaptiveGroups is ZONE-scoped → response shape is viewer.zones[].
   function mockGraphQL(groups: any[]) {
     globalThis.fetch = (async () => ({
       ok: true,
       status: 200,
-      json: async () => ({ data: { viewer: { accounts: [{ emailSendingAdaptiveGroups: groups }] } } }),
+      json: async () => ({ data: { viewer: { zones: [{ emailSendingAdaptiveGroups: groups }] } } }),
     })) as any;
   }
 
@@ -260,8 +293,24 @@ describe('fetchCloudflareUsage / fetchCloudflareDeliveryStats', () => {
     expect(stats).toEqual({ total: 44, byStatus: { delivered: 40, bounced: 3, failed: 1 } });
   });
 
+  it('resolves the zone id by domain when CF_ZONE_ID is unset', async () => {
+    delete process.env.CF_ZONE_ID;
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      urls.push(String(url));
+      if (String(url).includes('/zones?')) {
+        return { ok: true, status: 200, json: async () => ({ result: [{ id: 'zone-resolved' }] }) } as any;
+      }
+      return { ok: true, status: 200, json: async () => ({ data: { viewer: { zones: [{ emailSendingAdaptiveGroups: [{ count: 5 }] }] } } }) } as any;
+    }) as any;
+    expect(await fetchCloudflareUsage('2026-06-16', '2026-06-16')).toBe(5);
+    expect(urls.some(u => u.includes('/zones?name='))).toBe(true);
+  });
+
   it('returns null (not 0) when unconfigured so callers can tell "couldn\'t verify"', async () => {
     delete process.env.CLOUDFLARE_EMAIL_API_TOKEN;
+    delete process.env.CF_API_TOKEN;
+    delete process.env.CF_EMAIL_API_TOKEN;
     expect(await fetchCloudflareUsage('2026-06-16', '2026-06-16')).toBeNull();
     expect(await fetchCloudflareDeliveryStats('2026-06-16', '2026-06-16')).toBeNull();
   });


### PR DESCRIPTION
## Implementato

Fix di 2 bug nel provider Cloudflare (introdotto in #2263/#2265), emersi dalla **verifica live** con il token reale.

1. **Token = `CF_API_TOKEN` di default (non un token dedicato).** Il token Cloudflare già in Remote Config porta entrambi gli scope necessari — verificato live: test send `HTTP 200 success:true`, query analytics OK. Il codice ora fa fallback su `CF_API_TOKEN` (`CLOUDFLARE_EMAIL_API_TOKEN` / `CF_EMAIL_API_TOKEN` restano override opzionali per un token a scope ristretto). Niente nuovo secret da creare.
2. **Analytics zone-scoped.** Il dataset `emailSendingAdaptiveGroups` è **zone-level**, non account-level: la query account-level dava `unknown field "emailSendingAdaptiveGroups"` → osservazione/verifica sempre `null`. Ora interroga `viewer.zones` con lo zone id (`CF_ZONE_ID`, altrimenti auto-risolto dal dominio `CF_EMAIL_DOMAIN`, default `frontaliereticino.ch`).
3. **`message_id` reale.** La response è l'envelope `{ success, result: { message_id, delivered, queued, permanent_bounces } }`: un invio accettato ha `success:true` + `message_id` anche con `delivered`/`queued` vuoti (consegna asincrona). `sendViaCloudflare` ora ritorna `result.message_id` invece di un id sintetico, e usa il `message_id` come segnale di successo.

Helper condivisi: `cloudflareToken()` / `cloudflareAccountId()` / `resolveCloudflareZoneId()` (zone id cached, risolto via `GET /zones?name=` una volta).

### Verifica live (end-to-end, token reale)
`eval "$(node scripts/load-rc-env.mjs)" && node scripts/check-email-quotas.mjs`:
```
cloudflare   | ✅ Configured | ...
☁️  Cloudflare Email Service (GraphQL Analytics):
   Send events today:        1
   Send events month-to-date: 1 / 3000  (≈2999 remaining this month)
   Delivery status today:    delivered=1
```
(Il `delivered=1` è un'email di test realmente inviata e consegnata durante la verifica.)

## Non implementato (ancora)

- **Account id in RC**: `CF_ACCOUNT_ID` già presente e verificato live (`a426452d…`) = match con l'Email Service → nessuna modifica.
- Nessun cambiamento al path transazionale diretto-Resend (out of scope, come #2263).

## Test
- [x] `tests/email-cascade-burst.test.ts` (18 test): send con `message_id` reale, fallback `CF_API_TOKEN`, analytics zone-scoped, auto-risoluzione zone id, `null` su non-configurato/errori GraphQL — verde
- [x] Verifica live end-to-end (sopra)