### PR TITLE
fix(publish): defeat ENOBUFS in rebase conflict resolvers (winners/fb/reddit/404-compat)

### DIFF
--- a/scripts/lib/git-show-stage.mjs
+++ b/scripts/lib/git-show-stage.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Shared reader for a conflicted file's index stage during `git rebase`.
+ *
+ * The in-place rebase resolvers (winners / fb-posted / reddit-posted /
+ * 404-compat registries) all read a conflict stage via
+ * `git show :<stage>:<path>`. Those registries are append-only accumulators
+ * kept unpruned in-repo, so they grow unbounded over time.
+ *
+ * `execFileSync`'s DEFAULT maxBuffer is 1 MiB. Once a registry crosses 1 MiB,
+ * the child's stdout overflows and the call throws `spawnSync git ENOBUFS`,
+ * failing the post-deploy publish rebase — exactly what killed run
+ * 27592889914 (data/previous-slug-winners.json had grown past 1 MiB). Setting
+ * a generous ceiling makes that whole class impossible by construction: the
+ * buffer only grows to the actual output size, the cap is just the limit.
+ */
+import { execFileSync } from 'node:child_process';
+
+// 256 MiB — orders of magnitude above any realistic registry size, while still
+// bounded. This is a ceiling, not a pre-allocation.
+export const GIT_SHOW_MAX_BUFFER = 256 * 1024 * 1024;
+
+/**
+ * `git show :<stage>:<target>` for the indexed (conflict-stage) version of a
+ * path, with a maxBuffer large enough for unbounded-growth registries.
+ *
+ * @param {number} stage - index stage (1 = base, 2 = ours/upstream, 3 = theirs/local)
+ * @param {string} target - repo-relative path
+ * @returns {string} file contents (utf-8)
+ */
+export function gitShowStage(stage, target) {
+  return execFileSync('git', ['show', `:${stage}:${target}`], {
+    encoding: 'utf-8',
+    maxBuffer: GIT_SHOW_MAX_BUFFER,
+  });
+}

--- a/scripts/lib/resolve-404-compat-conflict.mjs
+++ b/scripts/lib/resolve-404-compat-conflict.mjs
@@ -41,6 +41,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { assertCompatFloor } from './compat-paths-floor-guard.mjs';
+import { gitShowStage } from './git-show-stage.mjs';
 
 const TARGET = 'data/seo-404-compat-paths.json';
 const STATE_FILE = 'data/inspection-state.json';
@@ -51,7 +52,7 @@ function readStage(stage, file) {
   // being applied). See scripts/lib/resolve-winners-conflict.mjs for the
   // same inverted-meaning explanation.
   try {
-    return execFileSync('git', ['show', `:${stage}:${file}`], { encoding: 'utf-8' });
+    return gitShowStage(stage, file);
   } catch {
     return null;
   }

--- a/scripts/lib/resolve-fb-posted-jobs-conflict.mjs
+++ b/scripts/lib/resolve-fb-posted-jobs-conflict.mjs
@@ -25,6 +25,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { gitShowStage } from './git-show-stage.mjs';
 
 const TARGET = 'data/fb-posted-jobs.json';
 const TRIM_LIMIT = 1000;
@@ -33,8 +34,7 @@ function readStage(stage) {
   // During `git rebase` (NOT plain merge):
   //   stage 2 = "ours"  = upstream (origin/main after the other commit)
   //   stage 3 = "theirs" = our local commit being replayed
-  const out = execFileSync('git', ['show', `:${stage}:${TARGET}`], { encoding: 'utf-8' });
-  return out;
+  return gitShowStage(stage, TARGET);
 }
 
 function parseOrEmpty(label, raw) {

--- a/scripts/lib/resolve-reddit-posted-jobs-conflict.mjs
+++ b/scripts/lib/resolve-reddit-posted-jobs-conflict.mjs
@@ -25,6 +25,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { gitShowStage } from './git-show-stage.mjs';
 
 const TARGET = 'data/reddit-posted-jobs.json';
 const TRIM_LIMIT = 1000;
@@ -33,8 +34,7 @@ function readStage(stage) {
   // During `git rebase` (NOT plain merge):
   //   stage 2 = "ours"  = upstream (origin/main after the other commit)
   //   stage 3 = "theirs" = our local commit being replayed
-  const out = execFileSync('git', ['show', `:${stage}:${TARGET}`], { encoding: 'utf-8' });
-  return out;
+  return gitShowStage(stage, TARGET);
 }
 
 function parseOrEmpty(label, raw) {

--- a/scripts/lib/resolve-winners-conflict.mjs
+++ b/scripts/lib/resolve-winners-conflict.mjs
@@ -24,6 +24,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { gitShowStage } from './git-show-stage.mjs';
 
 const TARGET = 'data/previous-slug-winners.json';
 
@@ -37,8 +38,7 @@ function readStage(stage) {
   //     exists on origin/main after the other deploy's sync commit landed)
   //   - stage 3 → our build's freshly computed file (the commit we are about
   //     to push). We want this version's keys to win on collision.
-  const out = execFileSync('git', ['show', `:${stage}:${TARGET}`], { encoding: 'utf-8' });
-  return out;
+  return gitShowStage(stage, TARGET);
 }
 
 function parseOrEmpty(label, raw) {


### PR DESCRIPTION
## Implementato
- **Root cause del post-deploy publish fallito** (run 27592889914, step _Sync previous-slug winners registry_; issue #2264): `scripts/lib/resolve-winners-conflict.mjs` lanciava `spawnSync git ENOBUFS` leggendo lo stage di conflitto via `execFileSync('git', ['show', ':<stage>:<path>'])`. Default `maxBuffer` di `execFileSync` = 1 MiB; `data/previous-slug-winners.json` ha superato 1 MiB → stdout overflow → throw → resolver fallisce → rebase del push abortisce → publish job rosso.
- Nuovo modulo condiviso `scripts/lib/git-show-stage.mjs` con `gitShowStage(stage, target)` + costante `GIT_SHOW_MAX_BUFFER = 256 MiB` (ceiling, non pre-alloc).
- **Fix di classe (AGENTS.md #6):** lo stesso costrutto `git show :<stage>:<path>` senza `maxBuffer` viveva in tutti e 4 i rebase conflict resolver su registry accumulator append-only non-prunati → ognuno avrebbe colpito lo stesso muro al crescere del file. Routati tutti e 4 attraverso il modulo condiviso, eliminando la classe by-construction:
  - `resolve-winners-conflict.mjs` (`data/previous-slug-winners.json`)
  - `resolve-fb-posted-jobs-conflict.mjs` (`data/fb-posted-jobs.json`)
  - `resolve-reddit-posted-jobs-conflict.mjs` (`data/reddit-posted-jobs.json`)
  - `resolve-404-compat-conflict.mjs` (`data/seo-404-compat-paths.json`, conserva il wrapper try/catch → `null`)
- Semantica di merge invariata: `gitShowStage` ritorna la stessa stringa del vecchio `execFileSync`, solo con buffer più grande. Output byte-identico per file <1 MiB, fixato per >1 MiB.
- Verifica deterministica: blob staged da 4.1 MiB → vecchio default 1 MiB `maxBuffer` lancia `ENOBUFS`, nuovo helper legge tutti i 4177782 byte. `node --check` su tutti i 5 file OK. `check-sibling-patterns.mjs` pulito (nessun twin non-toccato condivide il costrutto).

Closes #2264

## Non implementato (ancora)
- I `git diff --name-only --diff-filter=U` negli stessi resolver restano senza `maxBuffer`: emettono solo la lista (corta) dei filename in conflitto, non il contenuto del file → fuori dalla classe ENOBUFS, intoccati di proposito.
- `scripts/ci/guard-data-integrity.mjs` (`git cat-file -s`, output = dimensione) e `scripts/ci/check-issue-already-resolved.mjs` (`git cat-file -e`, `stdio:'ignore'`) non leggono contenuto file → non vulnerabili, fuori scope.
- Vitest non eseguito in locale (worktree senza `node_modules`, install pesante); la modifica non tocca la logica di merge coperta dai test esistenti → gate CI sul PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)