### PR TITLE
fix(test): Denner previousSlugs selection robust to crawler rotation (main-red)

### DIFF
--- a/tests/bridge-canton-aware.test.ts
+++ b/tests/bridge-canton-aware.test.ts
@@ -141,15 +141,21 @@ describe('Bridge page canton-aware UX', () => {
       previousSlugsByLocale?: Record<string, string[] | undefined>;
     }>;
     // Prefer a job that has multi-locale previousSlugsByLocale buckets (the
-    // original failure mode). Fall back to any job with non-empty previousSlugs.
+    // original failure mode), then any job with at least one non-empty locale
+    // bucket, then any job with non-empty previousSlugs. The middle tier matters
+    // because the live Denner slice rotates: when no active job currently carries
+    // ≥2 buckets, a single-bucket job (e.g. only `it`) still exercises the
+    // partition guard below. Without it the selection would fall through to a
+    // job whose previousSlugsByLocale is empty and the partition assertion would
+    // fail on pure crawler rotation rather than a real regression.
+    const nonEmptyBuckets = (j: { previousSlugsByLocale?: Record<string, string[] | undefined> }) =>
+      Object.values(j.previousSlugsByLocale ?? {}).filter(
+        (arr) => Array.isArray(arr) && arr.length > 0,
+      ).length;
     const targetJob =
-      allDennerJobs.find((j) => {
-        const byLocale = j.previousSlugsByLocale ?? {};
-        const localesWithEntries = Object.values(byLocale).filter(
-          (arr) => Array.isArray(arr) && arr.length > 0,
-        ).length;
-        return localesWithEntries >= 2;
-      }) ?? allDennerJobs.find((j) => Array.isArray(j.previousSlugs) && j.previousSlugs.length > 0);
+      allDennerJobs.find((j) => nonEmptyBuckets(j) >= 2) ??
+      allDennerJobs.find((j) => nonEmptyBuckets(j) >= 1) ??
+      allDennerJobs.find((j) => Array.isArray(j.previousSlugs) && j.previousSlugs.length > 0);
 
     it('Denner slice has at least one job exercising previousSlugs backfill', () => {
       expect(allDennerJobs.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Implementato
- **Fix main-red** su `tests/bridge-canton-aware.test.ts:174` (`AssertionError: expected 0 to be greater than 0`, shard vitest 4/4). La suite `tests.yml` era verde alle 07:55 (SHA 8d6d4d10); commit dati successivi (`fix(assemble) #2258`, auto-translate) hanno ruotato la slice Denner attiva senza triggerare `tests.yml` → main rosso non sorvegliato (classe "data-refresh bot-direct-to-main").
- **Root cause:** il test sceglie un `targetJob` Denner per asserire il guard di partizione `previousSlugsByLocale`. Preferiva un job con ≥2 bucket locale non-vuoti, altrimenti fallback su QUALSIASI job con `previousSlugs` non-vuoto. La slice attiva non ha più alcun job con ≥2 bucket → il fallback pescava `filialleiter-in-in-ausbildung-denner` con `previousSlugsByLocale: {}` → assert riga 174 falliva su pura rotazione crawler, non su una regressione reale.
- **Fix:** tier di selezione intermedio — ≥2 bucket → **≥1 bucket** → qualsiasi `previousSlugs`. La slice attiva ha ancora `responsabile-di-filiale-denner-schluein` (`byLocale {it:[...]}`), quindi il guard resta significativo (bucketing su locale noti + non-vuoto) senza dipendere dalla shape ≥2-bucket volatile.
- Verificato: simulazione sulla slice `data/jobs/by-crawler/denner.json` di `origin/main` → tutte e 3 le `it()` PASS (target = `responsabile-di-filiale-denner-schluein`). Transpile TS + `node --check` OK.

Sblocca l'auto-merge di #2274 (fix ENOBUFS resolver), che ereditava questo main-red.

## Non implementato (ancora)
- Nessun fix lato dati: la rotazione della slice Denner è legittima (job scaduti). Il guard non deve dipendere dalla presenza di un job ≥2-bucket nello snapshot attivo.
- Non esteso ad altri test data-coupled su slice crawler: nessun sibling con lo stesso costrutto di selezione `targetJob` emerso (test specifico Denner). Se altri test mostrano lo stesso pattern di fragilità-da-rotazione vanno trattati separatamente.
- Non aperta issue follow-up sul commit dati #2258: la rotazione non è un bug del suo scope, è il test a essere accoppiato a dati volatili.

🤖 Generated with [Claude Code](https://claude.com/claude-code)