### PR TITLE
fix(offerwall): use semantic color tokens in OfferwallNewsletterGate (unblock main-red)

### DIFF
--- a/components/community/OfferwallNewsletterGate.tsx
+++ b/components/community/OfferwallNewsletterGate.tsx
@@ -218,36 +218,36 @@ const OfferwallNewsletterGate: React.FC = () => {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[2147483600] flex items-center justify-center bg-slate-900/70 px-4"
+      className="fixed inset-0 z-[2147483600] flex items-center justify-center bg-black/40 backdrop-blur-sm px-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="offerwall-gate-title"
     >
-      <div className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl dark:bg-slate-900">
+      <div className="relative w-full max-w-md rounded-2xl bg-surface p-6 shadow-2xl border border-edge">
         <button
           type="button"
           onClick={() => settle(false)}
-          className="absolute right-3 top-3 rounded-full p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+          className="absolute right-3 top-3 rounded-full p-1 text-muted hover:text-heading"
           aria-label={copy.dismiss}
         >
           <X className="h-5 w-5" aria-hidden="true" />
         </button>
 
-        <div className="mb-3 flex items-center gap-2 text-blue-600 dark:text-blue-400">
+        <div className="mb-3 flex items-center gap-2 text-info">
           <Mail className="h-6 w-6" aria-hidden="true" />
-          <h2 id="offerwall-gate-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <h2 id="offerwall-gate-title" className="text-lg font-semibold text-heading">
             {copy.title}
           </h2>
         </div>
 
         {status === 'success' ? (
           <div className="flex flex-col items-center gap-2 py-6 text-center">
-            <CheckCircle2 className="h-10 w-10 text-green-600 dark:text-green-400" aria-hidden="true" />
-            <p className="text-slate-700 dark:text-slate-200">{copy.success}</p>
+            <CheckCircle2 className="h-10 w-10 text-success" aria-hidden="true" />
+            <p className="text-body">{copy.success}</p>
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
-            <p className="text-sm text-slate-600 dark:text-slate-300">{copy.body}</p>
+            <p className="text-sm text-muted">{copy.body}</p>
 
             <EmailInput
               value={email}
@@ -256,7 +256,7 @@ const OfferwallNewsletterGate: React.FC = () => {
               required
             />
 
-            <label className="flex items-start gap-2 text-xs text-slate-600 dark:text-slate-300">
+            <label className="flex items-start gap-2 text-xs text-muted">
               <input
                 type="checkbox"
                 checked={consentChecked}
@@ -267,13 +267,13 @@ const OfferwallNewsletterGate: React.FC = () => {
             </label>
 
             {status === 'error' && errorMessage && (
-              <p className="text-sm text-red-600 dark:text-red-400" role="alert">{errorMessage}</p>
+              <p className="text-sm text-danger" role="alert">{errorMessage}</p>
             )}
 
             <button
               type="submit"
               disabled={status === 'loading'}
-              className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-info-strong px-4 py-2.5 font-semibold text-on-accent hover:bg-info-strong-hover disabled:opacity-60"
             >
               {status === 'loading' && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
               {copy.submit}
@@ -282,7 +282,7 @@ const OfferwallNewsletterGate: React.FC = () => {
             <button
               type="button"
               onClick={() => settle(false)}
-              className="w-full text-center text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              className="w-full text-center text-xs text-muted hover:text-heading"
             >
               {copy.dismiss}
             </button>


### PR DESCRIPTION
## Implementato

Root-cause fix per **main-red**: `tests/no-dark-color-classes.test.ts` falliva su entrambi i casi (`no dark: color utility classes` + `no hardcoded Tailwind color-scale classes`), bloccando l'auto-merge di TUTTE le PR (auto-merge richiede vitest verde). La causa erano le color-class hardcoded + `dark:` introdotte dal componente GAM Offerwall `components/community/OfferwallNewsletterGate.tsx`.

Rimappate tutte le color-class hardcoded e tutte le varianti `dark:` sui token semantici esistenti in `index.css` (stesso pattern del modale gemello `components/community/NewsletterPopup.tsx`). Nessuna modifica a layout, spacing, sizing, attributi ARIA o comportamento — solo classi di colore. Le varianti `dark:` sono state rimosse (i token semantici gestiscono già il dark mode via CSS var).

Mapping applicato (old → token):
- backdrop overlay `bg-slate-900/70` → `bg-black/40 backdrop-blur-sm` (pattern modale stabilito, NewsletterPopup/CalculatorPaywall)
- card `bg-white dark:bg-slate-900` → `bg-surface border border-edge`
- close btn `text-slate-400 hover:text-slate-600 dark:hover:text-slate-200` → `text-muted hover:text-heading`
- icon/accent `text-blue-600 dark:text-blue-400` → `text-info`
- heading `text-slate-900 dark:text-slate-100` → `text-heading`
- success icon `text-green-600 dark:text-green-400` → `text-success`
- success text `text-slate-700 dark:text-slate-200` → `text-body`
- body `text-slate-600 dark:text-slate-300` → `text-muted`
- consent label `text-slate-600 dark:text-slate-300` → `text-muted`
- error `text-red-600 dark:text-red-400` → `text-danger`
- primary button `bg-blue-600 text-white hover:bg-blue-700` → `bg-info-strong text-on-accent hover:bg-info-strong-hover`
- dismiss link `text-slate-400 hover:text-slate-600 dark:hover:text-slate-300` → `text-muted hover:text-heading`

Verifica:
- `npx vitest run tests/no-dark-color-classes.test.ts` → 3/3 verdi (entrambi i casi target passano)
- `npx vitest run tests/offerwall-custom-choice.test.ts` → 6/6 verdi (nessuna regressione)

## Non implementato (ancora)

- Nessun sibling da sweepare: l'antipattern color-scale/`dark:` era presente solo in questo file (unico flaggato dal test). Il candidate-surfacer `check-sibling-patterns.mjs` ha proposto solo file che condividono l'identificatore generico `errorMessage` (nome di state var comune) — falso-positivo, non condividono il bug delle color-class hardcoded, quindi non toccati.
- Nessuna modifica funzionale al flusso Offerwall (hook, double opt-in, analytics): fuori scope, il task è solo color-token.