### PR TITLE
fix(test): skip cf-hot-404 bridges when sampling real job pages (validate-dist red)

### DIFF
--- a/tests/seo/_bridgeMarker.ts
+++ b/tests/seo/_bridgeMarker.ts
@@ -1,0 +1,17 @@
+// Shared marker for dist-sampling SEO tests.
+//
+// A "bridge" page is the lightweight canonical-bridge HTML emitted by
+// buildCanonicalBridgePage (cfHot404BridgePlugin, cantonOrphanRedirectsPlugin,
+// legacy redirect emitters). It links the dedicated `bridge.css` stylesheet
+// (BRIDGE_CSS_FILENAME in build-plugins/constants.ts) and carries NO hreflang
+// alternates and NO JobPosting schema — it is a noindex archived/redirect stub,
+// not a real content page.
+//
+// Dist-sampling tests that pick "any slug with an index.html" under a canton
+// job-detail dir and then assert real-job-page invariants (hreflang round-trip,
+// canton routing, listing grids) MUST skip bridges: the cf-hot-404 recovery set
+// legitimately emits bridges under those same dirs, and as that set grows it
+// will otherwise be sampled and fail the assertion (cf. validate-dist break when
+// the bridge cap was raised 12k→40k). Marker kept in ONE place so the sampler
+// tests can never silently drift apart.
+export const isBridgePageHtml = (html: string): boolean => html.includes('bridge.css');

--- a/tests/seo/cathedral-flip-simulation.spec.ts
+++ b/tests/seo/cathedral-flip-simulation.spec.ts
@@ -1,17 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isBridgePageHtml } from './_bridgeMarker';
 
 const DIST = path.resolve(__dirname, '../../dist');
 
+// Count only REAL job-detail pages — skip cf-hot-404 / canton-orphan bridges,
+// which legitimately live under the same canton dirs (noindex archived stubs).
+// Without this, a bridge emitted at /cerca-lavoro-zurigo/<slug>/ where <slug> is
+// also a real TI job would register as a cross-canton "leak" below, and the
+// growing cf-hot-404 recovery set would make that a flaky false failure.
 function listJobHtmlUnder(cantonSection: string): string[] {
   const dir = path.join(DIST, cantonSection);
   if (!fs.existsSync(dir)) return [];
   const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.isDirectory() && fs.existsSync(path.join(dir, entry.name, 'index.html'))) {
-      out.push(entry.name);
-    }
+    if (!entry.isDirectory()) continue;
+    const file = path.join(dir, entry.name, 'index.html');
+    if (!fs.existsSync(file)) continue;
+    if (isBridgePageHtml(fs.readFileSync(file, 'utf8'))) continue;
+    out.push(entry.name);
   }
   return out;
 }

--- a/tests/seo/cathedral-hreflang-cross-locale.test.ts
+++ b/tests/seo/cathedral-hreflang-cross-locale.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isBridgePageHtml } from './_bridgeMarker';
 
 const DIST = path.resolve(__dirname, '../../dist');
 
@@ -14,9 +15,22 @@ describe('hreflang round-trip non-TI canton (P3-B)', () => {
       .readdirSync(zhDir, { withFileTypes: true })
       .filter((e) => e.isDirectory())
       .map((e) => e.name);
-    const sample = slugs.find((s) => fs.existsSync(path.join(zhDir, s, 'index.html')));
+    // Sample a REAL ZH job page, not a cf-hot-404 / canton-orphan bridge: those
+    // legitimately live under this same dir, are noindex, and carry no hreflang
+    // alternates — sampling one would fail the round-trip assertion below for a
+    // page that is not supposed to have hreflang at all.
+    let sample: string | undefined;
+    let html = '';
+    for (const s of slugs) {
+      const f = path.join(zhDir, s, 'index.html');
+      if (!fs.existsSync(f)) continue;
+      const candidate = fs.readFileSync(f, 'utf8');
+      if (isBridgePageHtml(candidate)) continue;
+      sample = s;
+      html = candidate;
+      break;
+    }
     if (!sample) return;
-    const html = fs.readFileSync(path.join(zhDir, sample, 'index.html'), 'utf8');
     // Quote-flexible: scripts/dist-shrink.mjs strips attribute quotes.
     // `hreflang="en" href="…"` is DOM-equivalent to `hreflang=en href=…`.
     expect(html, 'EN alt missing').toMatch(


### PR DESCRIPTION
## Contesto

Il raise del cap bridge cf-hot-404 12k→40k (#2266) ha emesso ~36.6k bridge di recupero, molti sotto le dir job-detail dei canton non-TI (es. `/cerca-lavoro-zurigo/<slug>/`). Il deploy post-merge è andato (build success, **no OOM**, deploy+validate-live success) ma il gate **validate-dist** è andato rosso: due test che campionano `dist/` pescavano una pagina **bridge** (noindex, senza hreflang) trattandola come job-page reale.

## Implementato

- **`tests/seo/cathedral-hreflang-cross-locale.test.ts`** (il test che ha rotto validate-dist): campionava il primo slug con `index.html` in `cerca-lavoro-zurigo/` → pescava un bridge ZH → `EN alt missing` (i bridge giustamente non hanno hreflang). Ora **skippa i bridge** e campiona una job-page reale; l'invariante hreflang round-trip resta invariato.
- **`tests/seo/cathedral-flip-simulation.spec.ts`** (fragilità latente): `listJobHtmlUnder` contava i bridge come job-page → un bridge a `/cerca-lavoro-zurigo/<slug>/` con slug uguale a un job TI reale avrebbe registrato un falso "leak" cross-canton. Ora **esclude i bridge** dal conteggio.
- **`tests/seo/_bridgeMarker.ts`** (nuovo): helper condiviso `isBridgePageHtml(html)` basato sul marker stabile `bridge.css` (`BRIDGE_CSS_FILENAME`, emesso da `buildCanonicalBridgePage` per ogni bridge cf-hot/canton-orphan/legacy). Single source — i due sampler non possono divergere (non-negoziabile #6).

Validato contro una fixture `dist/` sintetica (bridge ordinato primo → il fix campiona la job-page reale → pass). Typecheck pulito sui 3 file.

Closes #2293

## Non implementato (ancora)

- **Validazione full su dist reale: solo post-merge.** Questi test fanno early-return senza un build SSG locale (che OOMa), quindi girano davvero solo nel gate post-deploy `validate-dist`. Niente revert-trigger necessario: la modifica è puramente test-side e l'invariante reale resta invariato; se per ipotesi un canton avesse SOLO bridge e nessuna job-page reale, il test fa skip (return) invece di fallire — degradazione safe, non un buco di copertura introdotto qui.
- **Altri sibling dist-sampling: verificati, non toccati.** `cathedral-job-detail-canton` (data-driven, già skip-bridge), `legacy-city-hub-hreflang` (path TI hardcoded, esclusi dal sweep non-TI), `jobposting-description-guard`/`h1-not-equal-title`/`company-landing-content` (già skippano archived/noindex). Nessuna modifica necessaria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)