### PR TITLE
feat(gpt): RC kill-switch for GPT PoC slot (instant off, no deploy)

### DIFF
--- a/components/shared/GptPocSlot.tsx
+++ b/components/shared/GptPocSlot.tsx
@@ -19,6 +19,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
 import { isLikelyBot } from '@/services/adAnalytics';
+import { useKillSwitches } from '@/hooks/useKillSwitches';
 
 // ── PoC switches ────────────────────────────────────────────
 // PoC ACTIVATED (issue #2273): GPT now serves one display slot on blog articles
@@ -65,9 +66,15 @@ const GptPocSlot: React.FC = () => {
   // Stable, unique DOM id for this slot instance (GPT needs a real element id).
   const divIdRef = useRef<string>(`gpt-poc-slot-${++slotSeq}`);
   const [rendered, setRendered] = useState(false);
+  // Runtime kill-switch (Firebase Remote Config KILL_GPT_POC_SLOT). Flip to
+  // `true` in the RC console to stop serving the GPT slot within ~1 min — no
+  // redeploy — if it regresses AdSense Auto Ads / RPM / CWV. Default-safe:
+  // resolves `false` (slot shown) on RC failure.
+  const { gptPocSlot: killed } = useKillSwitches();
+  const active = GPT_POC_ENABLED && IS_PROD && !SKIP_FOR_BOT && !killed;
 
   useEffect(() => {
-    if (!GPT_POC_ENABLED || !IS_PROD || SKIP_FOR_BOT) return;
+    if (!active) return;
     const wrapper = wrapperRef.current;
     if (!wrapper || typeof IntersectionObserver === 'undefined') return;
 
@@ -110,9 +117,9 @@ const GptPocSlot: React.FC = () => {
     }, { rootMargin: '200px 0px' });
     io.observe(wrapper);
     return () => io.disconnect();
-  }, []);
+  }, [active]);
 
-  if (!GPT_POC_ENABLED || !IS_PROD || SKIP_FOR_BOT) return null;
+  if (!active) return null;
 
   return (
     <div

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -27,7 +27,8 @@ export type KillSwitchKey =
   | 'healthPremiums'
   | 'jobMarket'
   | 'weeklyEmployers'
-  | 'orphanLandings';
+  | 'orphanLandings'
+  | 'gptPocSlot';
 
 export type KillSwitchState = Readonly<Record<KillSwitchKey, boolean>>;
 
@@ -42,6 +43,7 @@ export const KILL_SWITCH_RC_KEYS: Readonly<Record<KillSwitchKey, string>> = {
   jobMarket: 'KILL_JOB_MARKET_LINKS',
   weeklyEmployers: 'KILL_WEEKLY_EMPLOYERS_LINKS',
   orphanLandings: 'KILL_ORPHAN_LANDINGS_LINKS',
+  gptPocSlot: 'KILL_GPT_POC_SLOT',
 } as const;
 
 const DEFAULT_STATE: KillSwitchState = {
@@ -50,6 +52,7 @@ const DEFAULT_STATE: KillSwitchState = {
   jobMarket: false,
   weeklyEmployers: false,
   orphanLandings: false,
+  gptPocSlot: false,
 } as const;
 
 function parseBooleanFlag(value: string | undefined | null): boolean {

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -74,6 +74,10 @@ const REMOTE_CONFIG_DEFAULTS: Record<string, string> = {
  KILL_JOB_MARKET_LINKS: 'false',
  KILL_WEEKLY_EMPLOYERS_LINKS: 'false',
  KILL_ORPHAN_LANDINGS_LINKS: 'false',
+ // GPT PoC display slot on blog articles (issue #2273). Default 'false' = slot
+ // SHOWN. Flip to 'true' in the Remote Config console to kill the GPT slot
+ // within ~1 min (no redeploy) if it regresses AdSense Auto Ads / RPM / CWV.
+ KILL_GPT_POC_SLOT: 'false',
  // E3: Inline consulting CTA on calculator results view.
  // Default 'true' so the CTA is visible until explicitly disabled via Firebase
  // Remote Config console. Flip to 'false' to hide the CTA without a redeploy.


### PR DESCRIPTION
Aggiunge un kill-switch Remote Config per lo slot GPT PoC (issue #2273), così si può spegnere il tag GPT live **in ~1 min senza redeploy** se regredisce Auto Ads/RPM/CWV — invece del revert-via-deploy (30-90min) di #2289.

## Implementato
- `services/firebase.ts`: `KILL_GPT_POC_SLOT: 'false'` in `REMOTE_CONFIG_DEFAULTS` (default-safe = slot mostrato).
- `hooks/useKillSwitches.ts`: nuova key `gptPocSlot` → RC `KILL_GPT_POC_SLOT` (tipo + mapping + default, in sync con firebase.ts).
- `components/shared/GptPocSlot.tsx`: consuma `useKillSwitches()`; `active = GPT_POC_ENABLED && IS_PROD && !bot && !killed`. Gate su effetto (deps `[active]`) e render. Flip RC `KILL_GPT_POC_SLOT=true` → slot smette di servire al prossimo render (~1 min cache RC), nessun deploy.
- Default-safe: RC fail → `false` (slot mostrato), coerente con `GPT_POC_ENABLED=true`.
- tsc pulito sui file toccati.

## Non implementato (ancora)
- **Sibling-check** ha segnalato `services/locales/{en,fr,it}-core.ts` per il token condiviso `orphanLandings`: **falso positivo** — quei file contengono la stringa `orphanLandings` (key kill-switch esistente) ed è entrata nel context del diff perché ho aggiunto `gptPocSlot` accanto. Non modifico il pattern `orphanLandings`; la nuova key è indipendente e consumata solo da `GptPocSlot`. Nessun sibling da sweepare.
- **Verifica live non pre-merge**: che il flip RC spenga davvero lo slot live si osserva solo post-deploy in prod (RC cache ~1min). Revert-trigger resta `GPT_POC_ENABLED=false` (#2289) come fallback hard.