### PR TITLE
chore(probe-bazg): add Nuxt-era candidate endpoints for faster re-detection

### DIFF
--- a/scripts/probe-bazg-waiting-times.mjs
+++ b/scripts/probe-bazg-waiting-times.mjs
@@ -25,6 +25,15 @@ const CANDIDATES = [
   'https://www.bazg.admin.ch/dam/bazg/it/dokumente/abgaben/zollanmeldung/wartezeiten.json',
   'https://www.udsc.admin.ch/api/waiting-times',
   'https://api.udsc.admin.ch/waiting-times',
+  // Nuxt-era candidates: BAZG migrated to a Nuxt SPA (~2026-04; confirmed via
+  // /_nuxt/builds/latest.json → 200). A Nuxt app serves per-route data as
+  // `<route>/_payload.json` and content via `/api/_content/*`. These are
+  // best-effort guesses at where a republished waiting-times feed would live —
+  // the probe flips green (exit 0) the moment ANY of them returns JSON.
+  'https://www.bazg.admin.ch/api/_content/query',
+  'https://www.bazg.admin.ch/it/tempi-di-attesa/_payload.json',
+  'https://www.bazg.admin.ch/de/grenzwartezeiten/_payload.json',
+  'https://www.bazg.admin.ch/api/v1/waiting-times',
 ];
 
 const UA = 'FrontaliereTicino-Probe/1.0 (contact: info@frontaliereticino.ch)';


### PR DESCRIPTION
## Implementato
- `scripts/probe-bazg-waiting-times.mjs`: aggiunti 4 candidati Nuxt-era (`/api/_content/query`, `<route>/_payload.json` IT/DE, `/api/v1/waiting-times`) alla lista probe. BAZG è migrato a Nuxt SPA (~2026-04, confermato da `/_nuxt/builds/latest.json` → 200); questi path coprono dove un feed tempi-attesa ripubblicato vivrebbe nell'architettura Nuxt. Il workflow `probe-bazg.yml` (lunedì 06:00 UTC) apre l'issue "BAZG API is back online" appena uno restituisce JSON → rilevamento più rapido del ritorno.
- Logica invariata (exit 0 sse ≥1 candidato JSON 2xx). Verificato in locale: 0/12 oggi (nessun falso verde; i nuovi candidati 404).

## Non implementato (ancora)
- Endpoint Nuxt-era reali sconosciuti (BAZG non ha ripubblicato il feed): i path sono best-effort. Quando BAZG pubblica, l'issue auto-generata conterrà lo status per-URL → si aggiusta il path esatto allora.
- Nessuna fonte live di coda doganale gratuita esiste oggi (ricerca dedicata: BAZG/TCS/viasuisse/OASI/autostrade/opendata.swiss tutte verificate negative) → il probe resta un watchdog di ritorno, non una fonte attiva.
