### PR TITLE
fix(test): restore main green — cover 6th kill-switch (gptPocSlot)

### DIFF
--- a/tests/use-kill-switches.test.ts
+++ b/tests/use-kill-switches.test.ts
@@ -23,6 +23,7 @@ describe('useKillSwitches', () => {
       jobMarket: false,
       weeklyEmployers: false,
       orphanLandings: false,
+      gptPocSlot: false,
     });
   });
 
@@ -41,6 +42,7 @@ describe('useKillSwitches', () => {
     expect(result.current.jobMarket).toBe(false);
     expect(result.current.weeklyEmployers).toBe(false);
     expect(result.current.orphanLandings).toBe(false);
+    expect(result.current.gptPocSlot).toBe(false);
   });
 
   it('reads each RC parameter name and returns true when the flag is "true"', async () => {
@@ -50,6 +52,7 @@ describe('useKillSwitches', () => {
       if (key === KILL_SWITCH_RC_KEYS.jobMarket) return 'TRUE'; // case-insensitive
       if (key === KILL_SWITCH_RC_KEYS.weeklyEmployers) return '';
       if (key === KILL_SWITCH_RC_KEYS.orphanLandings) return 'true';
+      if (key === KILL_SWITCH_RC_KEYS.gptPocSlot) return 'true';
       return '';
     });
 
@@ -65,6 +68,7 @@ describe('useKillSwitches', () => {
       jobMarket: true,
       weeklyEmployers: false,
       orphanLandings: true,
+      gptPocSlot: true,
     });
   });
 
@@ -74,7 +78,7 @@ describe('useKillSwitches', () => {
     renderHook(() => useKillSwitches());
 
     await waitFor(() => {
-      expect(rcMock).toHaveBeenCalledTimes(5);
+      expect(rcMock).toHaveBeenCalledTimes(6);
     });
 
     const callArgs = rcMock.mock.calls.map(([arg]) => arg);
@@ -83,5 +87,6 @@ describe('useKillSwitches', () => {
     expect(callArgs).toContain('KILL_JOB_MARKET_LINKS');
     expect(callArgs).toContain('KILL_WEEKLY_EMPLOYERS_LINKS');
     expect(callArgs).toContain('KILL_ORPHAN_LANDINGS_LINKS');
+    expect(callArgs).toContain('KILL_GPT_POC_SLOT');
   });
 });


### PR DESCRIPTION
## Contesto

`main` è **rosso**: `hooks/useKillSwitches.ts` espone 6 kill-switch (il 6° `gptPocSlot` → `KILL_GPT_POC_SLOT` aggiunto da #2295) ma `tests/use-kill-switches.test.ts` ne asserisce ancora 5. #2295 è stata **mergiata manualmente**, bypassando il gate vitest di `auto-merge-on-lgtm`, quindi il test rotto è atterrato su `main`. Ogni PR auto-rebasata eredita il rosso (es. #2302, vittima pura non-correlata) → drain congelato (cascade main-red, non-negotiable AGENTS.md).

## Implementato

- `tests/use-kill-switches.test.ts`: allineato il test ai 6 switch dell'hook:
  - aggiunto `gptPocSlot: false` all'oggetto atteso di "defaults … false before RC resolves";
  - aggiunto `expect(result.current.gptPocSlot).toBe(false)` al fallback su RC reject;
  - aggiunto il branch mock `KILL_SWITCH_RC_KEYS.gptPocSlot → 'true'` e `gptPocSlot: true` all'oggetto atteso di "reads each RC parameter … true";
  - "queries Remote Config with exactly the documented parameter names": `toHaveBeenCalledTimes(5) → (6)` + `expect(callArgs).toContain('KILL_GPT_POC_SLOT')`.
- Verificato in locale: `npx vitest run tests/use-kill-switches.test.ts` → 4/4 verdi.

## Non implementato (ancora)

- Nessuna modifica all'hook `hooks/useKillSwitches.ts` (è già corretto a 6 switch; il bug era solo nel test mancato di #2295) — out of scope.
- #2302 NON toccata: è vittima pura del main-red, mergerà da sola al prossimo auto-rebase una volta che main è verde — out of scope.
- Nessun sibling da sweepare: il pattern (conteggio param hardcoded nel test) è isolato a questo singolo file di test; nessun altro test referenzia `KILL_SWITCH_RC_KEYS` con un conteggio fisso (verificato).