### PR TITLE
fix(cls): mount home mobile widgets in a stable wrapper to stop flip-remount shift

### DIFF
--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -204,7 +204,13 @@ export default function CalcolatoreTabContent() {
  </div>
  }>
  {showDeferredHomeWidgets ? (
- <>
+ /* Sole child = <div className="space-y-2"> mirroring the FALSE/skeleton branch
+    below, so the idle showDeferredHomeWidgets flip reconciles this wrapper IN
+    PLACE. The previous <>…</> fragment (different element at index 0 vs the
+    skeleton div) forced React to remove+add the container — a transient collapse
+    of this min-h-[192px] block ≈0.12 mobile CLS (Playwright MutationObserver:
+    REMOVE+ADD div.space-y-2 at the flip). Matches the desktop branch pattern. */
+ <div className="space-y-2">
  <Suspense fallback={<SkeletonNewsTicker />}>
  <NewsFeed onNavigate={(tab, article) => {
  setActiveTab(tab as ActiveTab);
@@ -230,7 +236,7 @@ export default function CalcolatoreTabContent() {
  <Suspense fallback={<div className="h-[34px]" />}>
  <DailyDialectPhrase />
  </Suspense>
- </>
+ </div>
  ) : (
  <div aria-hidden="true" className="space-y-2">
  <SkeletonNewsTicker />


### PR DESCRIPTION
## Contesto

Follow-up del fix dominante #2319 (`#root{min-height:100vh}`, già merged). Quello eliminava lo shift valore-1.0 del mount-reflow; questo aggredisce il **secondo contributore** alla CLS home@mobile.

Root cause **pinnata con MutationObserver Playwright throttled** sul container `.space-y-8`: il blocco mobile dei widget deferiti (`div.md:hidden.space-y-2.mt-6 min-h-[192px]`) collassa transitoriamente quando `showDeferredHomeWidgets` flippa `false→true` all'idle. Il branch FALSE/skeleton del `SilentErrorBoundary` renderizza un singolo `<div className="space-y-2">`, ma il branch TRUE renderizzava un fragment `<>…</>` il cui primo figlio (`<Suspense>`) è di **tipo/posizione diversi** rispetto al div skeleton → React non riconcilia in-place, **rimuove il container skeleton e monta un nuovo sottoalbero** (osservato: REMOVE+ADD di `div.space-y-2` esattamente al flip) → il blocco `min-h-[192px]` collassa a ~0 a metà viewport ≈ **0.12 CLS**.

## Implementato

- `components/tabs/CalcolatoreTabContent.tsx`: avvolto il branch TRUE del blocco mobile widget nello stesso `<div className="space-y-2">` usato dal branch FALSE/skeleton, così il figlio unico del boundary è l'**elemento identico** in entrambi gli stati → React riconcilia il container in-place e swappa solo i figli foglia, niente più remove+add del container, niente collasso. Pura nidificazione JSX: lo spacing è invariato (l'inner `div.space-y-2` di WeeklyFact+JobCTA è mantenuto → ritmo verticale a 3 gruppi identico).
- Specchia il branch **desktop** (stesso file, sopra) che già condivide il wrapper tra i due rami e non mostra shift equivalente.
- Verificato: `esbuild transform` (loader tsx) → PARSE OK.

## Non implementato (ancora)

- **`App.tsx:1947`** (sibling surfacing dal flag `showDeferredHomeWidgets`): ha lo stesso costrutto ternario MA entrambi i rami producono un box a **dimensione fissa `w-9 h-9` (36×36px)** (TRUE = `<Suspense fallback={<div className="w-9 h-9"/>}>`, FALSE = `<div className="w-9 h-9"/>`) → l'eventuale remount è dimensionalmente stabile, **zero layout shift**. Non è lo stesso antipattern dannoso → deliberatamente non toccato.
- **`services/TabContentContext.ts`** / **`router.ts`** (altri surfacing): il primo solo *definisce* il flag `showDeferredHomeWidgets` (non un duplicato del pattern di render); il secondo matcha solo la parola `MutationObserver` presente nel commento del diff (falso positivo euristico). Nessuna azione.
- **Verifica field pendente** (PostHog/CrUX lag ~3–5gg): la riduzione CLS reale non è misurabile pre-merge e questo è un cambio React non iniettabile in lab come il fix CSS di #2319. **Revert-trigger**: se la CLS field homepage mobile (PostHog `$web_vitals` p75) non migliora oltre il guadagno già atteso da #2319, o se compare un nuovo shift/regressione nei widget home mobile, → revert di questo commit.

## Test
- [x] `esbuild` parse-check del TSX → OK.
- [x] `check-sibling-patterns.mjs` eseguito; sibling surfacing analizzati e giustificati sopra.
- [ ] Re-misura CLS live post-deploy (Playwright MutationObserver: confermare assenza di REMOVE+ADD di div.space-y-2 al flip) — vedi revert-trigger.