### PR TITLE
fix(ci): don't mask trivial RC values poisoning Actions logs

### DIFF
--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -216,8 +216,15 @@ async function main() {
       // For CI: write to $GITHUB_ENV
       // For local: output as export statement
       if (isCI) {
-        // Mask the value so GitHub Actions redacts it from all logs
-        process.stdout.write(`::add-mask::${value}\n`);
+        // Mask the value so GitHub Actions redacts it from all logs.
+        // Skip trivial values (booleans, short ints, very short strings): they
+        // are not sensitive and masking them poisons unrelated log output —
+        // GitHub redacts EVERY occurrence of the literal, so a secret of `1`
+        // turns ANSI codes (`36;1m`), counts, and `bash -e {0}` into `***`.
+        const isTrivial = /^(true|false|\d{1,5})$/i.test(value) || value.length < 6;
+        if (!isTrivial) {
+          process.stdout.write(`::add-mask::${value}\n`);
+        }
         // Use delimiter syntax for multi-line safety
         lines.push(`${envKey}=${value}`);
       } else {


### PR DESCRIPTION
## Implementato
- `scripts/load-rc-env.mjs`: gate al `::add-mask::` — salta i valori RC banali (`/^(true|false|\d{1,5})$/i` o lunghezza < 6 char) prima di registrarli come secret da mascherare.
- Risolve i `***` cosmetici che comparivano in **tutte** le pipeline su numeri/ANSI innocui (`36;1m`→`36;***m`, `DEP0169`→`DEP0***69`, `bash -e {0}`→`bash -e ***0***`, count `RC secrets loaded`): erano causati dal mask di valori RC tipo `0`/`1`/`true`, che GitHub redige in ogni occorrenza letterale ovunque nel log.
- Validato che i secret reali restano mascherati: API key (`AIza…`, `re_…`, `G-…`), PAT (`ghp_…`), Firebase SA e ID lunghi (≥6 char) continuano a passare `::add-mask::`.

## Non implementato (ancora)
- Nessun sibling da sweepare: `::add-mask::`/`core.setSecret` esistono solo in `scripts/load-rc-env.mjs` in tutto il repo (grep `scripts build-plugins services .github`).
- Nessun test dedicato aggiunto: lo script non ha una suite esistente e il branch `data/jobs` gate non lo copre; la logica del gate è verificata via check ad-hoc nel PR (banali non-mascherati, segreti mascherati). Follow-up possibile: unit test su un helper estratto `isTrivialSecret`.
- Soglia `<6 char` / `\d{1,5}` è euristica: un secret realmente sensibile lungo ≤5 char resterebbe in chiaro. Nessun secret noto rientra (le API key/PAT/SA sono tutte lunghe); se in futuro si aggiunge un secret corto sensibile, va estesa la whitelist per-chiave.