### PR TITLE
fix(jobboard): canton-aware section in per-job + city links (no TI collapse)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1655,7 +1655,7 @@ const App: React.FC = () => {
 
  // Navigation context value — shared with child components via useNavigation()
  // navigateTo() is the canonical one-call navigation: sets tab + sub-tab + pushes URL.
- const navigateTo = useCallback((tab: ActiveTab, subTab?: string) => {
+ const navigateTo = useCallback((tab: ActiveTab, subTab?: string, canton?: string) => {
  setActiveTab(tab);
  if (tab === 'calculator' && subTab) setCalcolatoreSubTab(subTab as CalcolatoreSubTab);
  else if (tab === 'confronti' && subTab) setConfrontiSubTab(subTab as ConfrontiSubTab);
@@ -1677,6 +1677,7 @@ const App: React.FC = () => {
  if (tab === 'stats') route.statsSubTab = (subTab || statsSubTab) as StatsSubTab;
  if (tab === 'blog' && subTab) route.blogArticle = subTab as BlogArticleId;
  if (tab === 'job-board' && subTab) route.jobSlug = subTab;
+ if (tab === 'job-board' && canton) route.jobBoardCanton = canton;
  if (tab === 'autore') {
  const slug = subTab || author || undefined;
  if (slug) route.author = slug;
@@ -2437,10 +2438,14 @@ const App: React.FC = () => {
  onRequireAuth={() => {
  navigateTo('profile' as any);
  }}
- onJobRouteChange={(slug) => {
+ onJobRouteChange={(slug, canton) => {
  setStaticOverlay(false);
  setJobSlug(slug || null);
- pushRoute({ activeTab: 'job-board' as any, ...(slug ? { jobSlug: slug } : {}) });
+ // Canton-aware: carry the job/hub canton so the pushed URL stays on the
+ // correct section (/cerca-lavoro-zurigo/…) instead of collapsing onto the
+ // legacy TI default (table.jobBoard). staticOverlay stays false so the
+ // React view keeps rendering on this soft-nav.
+ pushRoute({ activeTab: 'job-board' as any, ...(canton ? { jobBoardCanton: canton } : {}), ...(slug ? { jobSlug: slug } : {}) });
  // Scroll to top when entering a job detail; JobBoard handles list restoration.
  if (slug) window.scrollTo({ top: 0, behavior: 'instant' });
  }}

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -3,6 +3,7 @@ import { lazyRetry } from '@/services/lazyRetry';
 import { useTranslation, useLocale, loadBlogMeta, loadArticleBody, getCantonI18nParams } from '@/services/i18n';
 import type { Locale } from '@/services/i18n';
 import { buildPath } from '@/services/router';
+import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
 import type { BlogArticleId, AppRoute } from '@/services/router';
 import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
@@ -2159,8 +2160,8 @@ function BlogArticles({
  return (
  <a
  key={job.id}
- href={buildPath({ activeTab: 'job-board', jobSlug: job.slugByLocale?.[locale] ?? job.slug ?? job.id })}
- onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('job-board', job.slugByLocale?.[locale] ?? job.slug ?? job.id); Analytics.trackUIInteraction('blog_inline_jobs', 'card', 'click', job.id); }}
+ href={buildPath({ activeTab: 'job-board', jobBoardCanton: resolveJobCanton(job), jobSlug: job.slugByLocale?.[locale] ?? job.slug ?? job.id })}
+ onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('job-board', job.slugByLocale?.[locale] ?? job.slug ?? job.id, resolveJobCanton(job)); Analytics.trackUIInteraction('blog_inline_jobs', 'card', 'click', job.id); }}
  className="flex items-center gap-3 p-2.5 bg-surface/70 rounded-lg hover:bg-surface/50 transition-colors group"
  >
  <div className="w-8 h-8 rounded-lg bg-accent-subtle flex items-center justify-center shrink-0 overflow-hidden">
@@ -2353,8 +2354,8 @@ function BlogArticles({
  return (
  <a
  key={job.id}
- href={buildPath({ activeTab: 'job-board', jobSlug })}
- onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('job-board', jobSlug); }}
+ href={buildPath({ activeTab: 'job-board', jobBoardCanton: resolveJobCanton(job), jobSlug })}
+ onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('job-board', jobSlug, resolveJobCanton(job)); }}
  className="flex items-start gap-3 p-3 bg-accent-subtle/60 rounded-xl hover:bg-accent-subtle transition-colors text-left border border-accent-border"
  >
  <div className="w-10 h-10 rounded-lg bg-surface flex items-center justify-center border border-edge shrink-0 overflow-hidden">

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -88,7 +88,10 @@ import { type Locale, useLocale, useTranslation, getCantonI18nParams } from '@/s
 import { loadBlogMeta } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
 import { wasNewsletterAutologinAttempted } from '@/services/newsletterAutologinSignal';
-import { buildPath, registerJobSlugMap, getJobMetaForSlug, ensureJobSlugMapLoaded, isJobSlugMapReady, JOB_BOARD_CANTON_AGGREGATE } from '@/services/router';
+import { buildPath, parsePath, registerJobSlugMap, getJobMetaForSlug, ensureJobSlugMapLoaded, isJobSlugMapReady, JOB_BOARD_CANTON_AGGREGATE } from '@/services/router';
+import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
+import { isKnownCityHub } from '@/build-plugins/cityJobsHub';
+import { normalizeCitySlug } from '@/build-plugins/shared/cantonCities';
 import { buildJobTitleWithLocation, buildTitleWithBrand } from '@/build-plugins/shared/titleSuffix';
 import { useNavigation } from '@/services/NavigationContext';
 import AdSenseBanner from '@/components/shared/AdSenseBanner';
@@ -505,7 +508,7 @@ interface JobBoardProps {
  initialFilterParams?: JobBoardFilterParams | null;
  /** Called after filter params have been consumed so they aren't re-applied */
  onFilterParamsConsumed?: () => void;
- onJobRouteChange?: (slug?: string) => void;
+ onJobRouteChange?: (slug?: string, canton?: string) => void;
  isLoggedIn?: boolean;
  authUser?: any | null;
  authLoading?: boolean;
@@ -4102,7 +4105,55 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // Defense-in-depth: if no slug resolved, return current pathname
  // instead of the listing page URL to preserve static HTML canonical.
  if (!localizedSlug) return window.location.pathname;
- return buildPath({ activeTab: 'job-board' as any, ...(localizedSlug ? { jobSlug: localizedSlug } : {}) }, locale);
+ // Canton-aware section: the per-job static page is emitted under the job's
+ // OWN canton (/cerca-lavoro-zurigo/<slug>/), NOT the legacy TI default.
+ // Without jobBoardCanton, buildPath() falls back to table.jobBoard
+ // ('cerca-lavoro-ticino') and every non-TI job link collapses onto the TI
+ // section — the SPA was overwriting the (correct) static card hrefs with
+ // TI ones on hydration. Object branch resolves from the job exactly like
+ // the build emitter (renderJobCardLi → resolveJobCanton); string branch
+ // looks the canton up in the registered slug map (_canton).
+ const jobCanton =
+ typeof jobOrSlug === 'string'
+ ? getJobMetaForSlug(jobOrSlug.trim())?.canton
+ : jobOrSlug
+ ? resolveJobCanton(jobOrSlug)
+ : undefined;
+ return buildPath({
+ activeTab: 'job-board' as any,
+ ...(jobCanton ? { jobBoardCanton: String(jobCanton).toUpperCase() } : {}),
+ ...(localizedSlug ? { jobSlug: localizedSlug } : {}),
+ }, locale);
+ };
+
+ // Editorial hub links (city / sector / type lists rendered on a canton
+ // landing) carry their canton in the build-provided href's section segment.
+ // The previous `href.split('/').filter(Boolean).pop()` + buildPath() WITHOUT
+ // a canton stripped that section and rebuilt every link under the legacy TI
+ // default. Recover the canton via the router's parsePath() (single source of
+ // truth) so href + SPA nav stay on the right section. We deliberately keep
+ // driving navigation through onJobRouteChange (jobSlug, NO staticOverlay) —
+ // a city/sector hub URL parses to staticOverlay:true, and App skips the
+ // React <main> on staticOverlay, so a soft-nav there would blank the page.
+ const hubLinkRoute = (rawHref?: string): { canton?: string; slug: string } => {
+ const path = String(rawHref || '').replace(/^https?:\/\/[^/]+/, '').split('?')[0];
+ if (!path) return { slug: '' };
+ const r = parsePath(path).route;
+ const hasInner = !!(r.jobSlug || r.jobBoardCity || r.jobBoardSector);
+ const parts = path.split('/').filter(Boolean);
+ const slug = hasInner && parts.length ? parts[parts.length - 1] : '';
+ return { canton: r.jobBoardCanton, slug };
+ };
+
+ // Anchor href for an editorial hub link, canton-aware. Falls back to the
+ // job-board root when the href has no inner slug.
+ const buildHubHref = (rawHref?: string): string => {
+ const { canton, slug } = hubLinkRoute(rawHref);
+ return buildPath({
+ activeTab: 'job-board' as any,
+ ...(canton ? { jobBoardCanton: canton } : {}),
+ ...(slug ? { jobSlug: slug } : {}),
+ }, locale);
  };
 
  useEffect(() => {
@@ -4392,7 +4443,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const nextSlug = deriveLocalizedJobSlug(unlockedJob, locale);
  setPendingJob(null);
  if (!selectedJob || selectedJob.id !== unlockedJob.id || initialJobSlug !== nextSlug) {
- onJobRouteChange?.(nextSlug);
+ onJobRouteChange?.(nextSlug, resolveJobCanton(unlockedJob));
  }
  }, [authResolved, authUser, initialJobSlug, isLoggedIn, locale, onJobRouteChange, pendingJob, selectedJob]);
 
@@ -4409,7 +4460,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  releaseSlot('job-auth-gate');
 
  if (initialJobSlug === redirectSlug) return;
- onJobRouteChange?.(redirectSlug);
+ onJobRouteChange?.(redirectSlug, getJobMetaForSlug(redirectSlug)?.canton);
  }, [authResolved, hasAccess, initialJobSlug, onJobRouteChange]);
 
  // When the inline auth gate is visible (job detail + not logged in),
@@ -4435,7 +4486,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // unauthenticated users with a blurred preview + sign-in form,
  // giving more context than a modal popup and boosting conversion.
  savedListState.current = { page, scrollY: window.scrollY };
- onJobRouteChange?.(deriveLocalizedJobSlug(job, locale));
+ onJobRouteChange?.(deriveLocalizedJobSlug(job, locale), resolveJobCanton(job));
  window.scrollTo({ top: 0, behavior: 'instant' });
  Analytics.trackSelectContent('job_board_open_detail', `${job.company}_${job.title}`);
  };
@@ -4502,7 +4553,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (jobToOpen) {
  // Leva B: offer the one-tap job alert immediately on this just-unlocked job.
  justAuthedJobIdRef.current = jobToOpen.id;
- onJobRouteChange?.(deriveLocalizedJobSlug(jobToOpen, locale));
+ onJobRouteChange?.(deriveLocalizedJobSlug(jobToOpen, locale), resolveJobCanton(jobToOpen));
  Analytics.trackSelectContent('job_board_open_detail', `${jobToOpen.company}_${jobToOpen.title}`);
  }
  } catch {
@@ -4536,7 +4587,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const jobToOpen = pendingJob;
  setPendingJob(null);
  if (jobToOpen) {
- onJobRouteChange?.(deriveLocalizedJobSlug(jobToOpen, locale));
+ onJobRouteChange?.(deriveLocalizedJobSlug(jobToOpen, locale), resolveJobCanton(jobToOpen));
  Analytics.trackSelectContent('job_board_open_detail', `${jobToOpen.company}_${jobToOpen.title}`);
  }
  } catch {
@@ -4793,7 +4844,10 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const navigateToRelatedSearch = useCallback((keyword: string) => {
  const searchSlug = buildSearchSlug(keyword, locale);
  setSearchQuery(keyword);
- onJobRouteChange?.(searchSlug);
+ // Keyword search hubs are Switzerland-wide (aggregate), mirroring the
+ // related-search anchor hrefs (jobBoardCanton: JOB_BOARD_CANTON_AGGREGATE);
+ // without it the SPA nav would collapse onto the legacy TI section.
+ onJobRouteChange?.(searchSlug, JOB_BOARD_CANTON_AGGREGATE);
  }, [locale, onJobRouteChange]);
 
  // ── Salary estimate widgets (frontaliere vs CH resident) ───────────────
@@ -5255,14 +5309,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </div>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
  {editorialJobTodayLanding.sections.cities.map((city) => {
- const citySlug = city.href.split('/').filter(Boolean).pop() || '';
+ const { canton: cityCanton, slug: citySlug } = hubLinkRoute(city.href);
  return (
  <a
  key={city.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: citySlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(cityCanton ? { jobBoardCanton: cityCanton } : {}), jobSlug: citySlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(citySlug);
+ onJobRouteChange?.(citySlug, cityCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5328,6 +5382,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const localParts = localPath.split('/').filter(Boolean);
  const isBoardRoot = localParts.length <= (locale === 'it' ? 1 : 2);
  const slug = !isBoardRoot && localParts.length > 0 ? localParts[localParts.length - 1] : '';
+ const linkCanton = hubLinkRoute(link.href).canton;
  if (!localPath) {
  return (
  <a
@@ -5342,10 +5397,10 @@ const JobBoard: React.FC<JobBoardProps> = ({
  return (
  <a
  key={link.href}
- href={slug ? buildPath({ activeTab: 'job-board', jobSlug: slug }, locale) : buildPath({ activeTab: 'job-board' }, locale)}
+ href={slug ? buildPath({ activeTab: 'job-board', ...(linkCanton ? { jobBoardCanton: linkCanton } : {}), jobSlug: slug }, locale) : buildPath({ activeTab: 'job-board' }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(slug || '');
+ onJobRouteChange?.(slug || '', linkCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="inline-flex items-center rounded-full bg-accent-subtle px-3 py-1.5 text-xs font-bold text-accent no-underline hover:underline"
@@ -5444,14 +5499,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <h2 className="text-lg font-bold font-display text-heading mb-4">{editorialNursesHubLanding.variantTitle}</h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
  {editorialNursesHubLanding.variants.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5522,7 +5577,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  if (editorialCareVariantLanding) {
- const parentSlug = editorialCareVariantLanding.parentHubHref.split('/').filter(Boolean).pop() || '';
+ const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialCareVariantLanding.parentHubHref);
  return (
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
@@ -5541,7 +5596,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <button
  type="button"
  onClick={() => {
- onJobRouteChange?.(parentSlug);
+ onJobRouteChange?.(parentSlug, parentCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="mt-4 inline-flex items-center gap-2 rounded-full border border-accent-border px-4 py-2 min-h-[44px] text-sm font-bold text-accent"
@@ -5565,14 +5620,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
  {editorialCareVariantLanding.siblingLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5650,14 +5705,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
  {editorialLocationLanding.relatedTypeLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5678,14 +5733,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
  {editorialLocationLanding.relatedSectorLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5733,7 +5788,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  if (editorialLocationTypeLanding) {
- const parentSlug = editorialLocationTypeLanding.parentLocationHref.split('/').filter(Boolean).pop() || '';
+ const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialLocationTypeLanding.parentLocationHref);
  return (
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
@@ -5752,7 +5807,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <button
  type="button"
  onClick={() => {
- onJobRouteChange?.(parentSlug);
+ onJobRouteChange?.(parentSlug, parentCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="mt-4 inline-flex items-center gap-2 rounded-full border border-accent-border px-4 py-2 min-h-[44px] text-sm font-bold text-accent"
@@ -5775,14 +5830,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
  {editorialLocationTypeLanding.siblingTypeLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5830,7 +5885,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  if (editorialLocationSectorLanding) {
- const parentSlug = editorialLocationSectorLanding.parentLocationHref.split('/').filter(Boolean).pop() || '';
+ const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialLocationSectorLanding.parentLocationHref);
  return (
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
@@ -5849,7 +5904,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <button
  type="button"
  onClick={() => {
- onJobRouteChange?.(parentSlug);
+ onJobRouteChange?.(parentSlug, parentCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="mt-4 inline-flex items-center gap-2 rounded-full border border-accent-border px-4 py-2 min-h-[44px] text-sm font-bold text-accent"
@@ -5872,14 +5927,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
  {editorialLocationSectorLanding.siblingSectorLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -5969,14 +6024,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </h2>
  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
  {editorialSectorRegionLanding.siblingSectorLinks.map((link) => {
- const targetSlug = link.href.split('/').filter(Boolean).pop() || '';
+ const { canton: targetCanton, slug: targetSlug } = hubLinkRoute(link.href);
  return (
  <a
  key={link.href}
- href={buildPath({ activeTab: 'job-board', jobSlug: targetSlug }, locale)}
+ href={buildPath({ activeTab: 'job-board', ...(targetCanton ? { jobBoardCanton: targetCanton } : {}), jobSlug: targetSlug }, locale)}
  onClick={(e) => {
  e.preventDefault();
- onJobRouteChange?.(targetSlug);
+ onJobRouteChange?.(targetSlug, targetCanton);
  window.scrollTo({ top: 0, behavior: 'smooth' });
  }}
  className="flex items-center justify-between gap-3 rounded-2xl border border-edge px-4 py-3 no-underline hover:border-accent transition-colors"
@@ -6061,7 +6116,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  totalActiveJobs={jobs.length}
  onNavigateToCompany={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
  onNavigateToLocation={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
- onNavigateToJob={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
+ onNavigateToJob={(slug) => { onJobRouteChange?.(slug, getJobMetaForSlug(slug)?.canton); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
  />
  );
  }
@@ -6074,7 +6129,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  totalActiveJobs={jobs.length}
  onNavigateToCompany={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
  onNavigateToLocation={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
- onNavigateToJob={(slug) => { onJobRouteChange?.(slug); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
+ onNavigateToJob={(slug) => { onJobRouteChange?.(slug, getJobMetaForSlug(slug)?.canton); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
  />
  );
  }
@@ -6112,8 +6167,21 @@ const JobBoard: React.FC<JobBoardProps> = ({
  && (enrichmentLoading || (!resolvedJobDetail.has(selectedJob.id) && !jobDetailCache.has(selectedJob.id)));
  const gateCompanySlug = buildCompanySearchSlug(selectedJob.company, selectedJob.companyKey, locale);
  const gateCompanyHref = buildPath({ activeTab: 'job-board' as any, jobSlug: gateCompanySlug }, locale);
+ const gateJobCanton = resolveJobCanton(selectedJob);
+ // Non-TI jobs: link the city to its canton-aware city hub
+ // (/cerca-lavoro-zurigo/zurigo/) instead of the legacy TI location filter,
+ // which emits no static page outside TI and can't round-trip under a non-TI
+ // section (parses back as a jobSlug). TI keeps the existing location-search
+ // filter verbatim — isKnownCityHub matches every TI municipality but only
+ // 5 TI city hubs are emitted, so gating TI here would 404.
+ const gateCitySlug = gateJobCanton !== 'TI' && jobLocation && !isMultiLocation(jobLocation)
+ ? normalizeCitySlug(selectedJob.addressLocality || jobLocation)
+ : '';
+ const gateCityHub = !!(gateCitySlug && isKnownCityHub(gateCitySlug, gateJobCanton));
  const gateLocationSlug = jobLocation ? buildLocationSearchSlug(selectedJob.addressLocality || jobLocation, locale) : '';
- const gateLocationHref = gateLocationSlug ? buildPath({ activeTab: 'job-board' as any, jobSlug: gateLocationSlug }, locale) : '';
+ const gateLocationHref = gateCityHub
+ ? buildPath({ activeTab: 'job-board' as any, jobBoardCanton: gateJobCanton, jobSlug: gateCitySlug }, locale)
+ : (gateLocationSlug ? buildPath({ activeTab: 'job-board' as any, jobSlug: gateLocationSlug }, locale) : '');
  const openGateCompanyFilter = (e: React.MouseEvent<HTMLAnchorElement>) => {
  e.preventDefault();
  e.stopPropagation();
@@ -6166,8 +6234,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  onClick={(e) => {
  e.preventDefault();
  setSearchQuery('');
+ if (gateCityHub) {
+ // City hub renders via React on soft-nav (staticOverlay would blank it).
+ onJobRouteChange?.(gateCitySlug, gateJobCanton);
+ } else {
  window.history.pushState({ route: { activeTab: 'job-board', jobSlug: gateLocationSlug } }, '', gateLocationHref.split('?')[0]);
  window.dispatchEvent(new PopStateEvent('popstate'));
+ }
  window.scrollTo({ top: 0, behavior: 'smooth' });
  Analytics.trackSelectContent('job_board_location_filter_open', jobLocation);
  }}
@@ -6581,8 +6654,18 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const detailPageUrl = `${PUBLIC_SITE_URL}${buildJobPath(selectedJob)}`;
  const companySearchSlug = buildCompanySearchSlug(selectedJob.company, selectedJob.companyKey, locale);
  const companySearchHref = buildPath({ activeTab: 'job-board' as any, jobSlug: companySearchSlug }, locale);
+ const detailJobCanton = resolveJobCanton(selectedJob);
+ // Non-TI jobs: link the city to its canton-aware city hub
+ // (/cerca-lavoro-zurigo/zurigo/), not the TI location filter. TI unchanged
+ // (see gate-block note: only 5 TI city hubs are emitted).
+ const detailCitySlug = detailJobCanton !== 'TI' && !isMultiLocation(selectedJob.location)
+ ? normalizeCitySlug(selectedJob.addressLocality || selectedJob.location || '')
+ : '';
+ const detailCityHub = !!(detailCitySlug && isKnownCityHub(detailCitySlug, detailJobCanton));
  const detailLocationSlug = buildLocationSearchSlug(selectedJob.addressLocality || selectedJob.location || '', locale);
- const detailLocationHref = detailLocationSlug ? buildPath({ activeTab: 'job-board' as any, jobSlug: detailLocationSlug }, locale) : '';
+ const detailLocationHref = detailCityHub
+ ? buildPath({ activeTab: 'job-board' as any, jobBoardCanton: detailJobCanton, jobSlug: detailCitySlug }, locale)
+ : (detailLocationSlug ? buildPath({ activeTab: 'job-board' as any, jobSlug: detailLocationSlug }, locale) : '');
  const openCompanyFilter = (e: React.MouseEvent<HTMLAnchorElement>) => {
  e.preventDefault();
  e.stopPropagation();
@@ -6847,8 +6930,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  onClick={(e) => {
  e.preventDefault();
  setSearchQuery('');
+ if (detailCityHub) {
+ // City hub renders via React on soft-nav (staticOverlay would blank it).
+ onJobRouteChange?.(detailCitySlug, detailJobCanton);
+ } else {
  window.history.pushState({ route: { activeTab: 'job-board', jobSlug: detailLocationSlug } }, '', detailLocationHref.split('?')[0]);
  window.dispatchEvent(new PopStateEvent('popstate'));
+ }
  window.scrollTo({ top: 0, behavior: 'smooth' });
  Analytics.trackSelectContent('job_board_location_filter_open', selectedJob.location);
  }}

--- a/services/NavigationContext.ts
+++ b/services/NavigationContext.ts
@@ -37,8 +37,10 @@ export interface NavigationActions {
  * Navigate to a tab (and optional sub-tab) in one call.
  * Sets activeTab + matching sub-tab state + pushes the URL.
  * Use this instead of manually calling setActiveTab + set*SubTab + pushRoute.
+ * `canton` (job-board only): emit the canton-aware section
+ * (/cerca-lavoro-zurigo/…) instead of the legacy TI default.
  */
- navigateTo: (tab: ActiveTab, subTab?: string) => void;
+ navigateTo: (tab: ActiveTab, subTab?: string, canton?: string) => void;
 }
 
 export type NavigationContextType = NavigationState & NavigationActions;

--- a/services/chatbotTools.ts
+++ b/services/chatbotTools.ts
@@ -17,6 +17,7 @@
  */
 
 import { buildPath } from '@/services/router';
+import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
 import { cdnDataUrl } from '@/services/cdnDataBase';
 
 // ─── Types ────────────────────────────────────────────────────────────────
@@ -242,7 +243,9 @@ export function scoreJob(
 export function buildJobUrl(job: JobRecord, locale: Locale): string {
  const localisedSlug = job.slugByLocale?.[locale];
  const slug = localisedSlug && localisedSlug.length > 0 ? localisedSlug : job.slug;
- return buildPath({ activeTab: 'job-board', jobSlug: slug }, locale);
+ // Canton-aware section so a non-TI job links to /cerca-lavoro-zurigo/…
+ // instead of collapsing onto the legacy TI default (table.jobBoard).
+ return buildPath({ activeTab: 'job-board', jobBoardCanton: resolveJobCanton(job), jobSlug: slug }, locale);
 }
 
 // ─── Main entrypoint ──────────────────────────────────────────────────────

--- a/tests/jobboard-canton-section-link.test.ts
+++ b/tests/jobboard-canton-section-link.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildPath, parsePath, registerJobSlugMap, getJobMetaForSlug } from '@/services/router';
+import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
+
+/**
+ * Regression: job-board links must use the job's OWN canton section, not the
+ * legacy TI default. Bug report: on /cerca-lavoro-zurigo/ the per-job links
+ * pointed to /cerca-lavoro-ticino/<slug>/. Root cause was the SPA building
+ * job-board paths via buildPath() WITHOUT jobBoardCanton, collapsing every
+ * non-TI link onto table.jobBoard ('cerca-lavoro-ticino').
+ *
+ * These tests lock the two ingredients the fix relies on:
+ *  - buildPath() emits the canton-aware section when jobBoardCanton is set;
+ *  - the canton can be recovered from the job (resolveJobCanton, used in the
+ *    object branch of buildJobPath) and from the slug map (getJobMetaForSlug,
+ *    used in the string branch + cross-component sibling fixes).
+ */
+describe('job-board canton section links', () => {
+  const ZH_JOB = {
+    canton: 'ZH',
+    location: 'Zürich',
+    slug: 'dipl-pflegefachperson-hf-fh-privatklinik-bethanien-zurich',
+  };
+
+  it('buildPath emits the job canton section for a non-TI job', () => {
+    const path = buildPath(
+      { activeTab: 'job-board', jobBoardCanton: 'ZH', jobSlug: ZH_JOB.slug },
+      'it',
+    );
+    expect(path).toBe(`/cerca-lavoro-zurigo/${ZH_JOB.slug}/`);
+    // …and round-trips back to the ZH canton (no collapse to TI).
+    expect(parsePath(path).route.jobBoardCanton).toBe('ZH');
+  });
+
+  it('without jobBoardCanton it falls back to the legacy TI section (documents the old bug)', () => {
+    const path = buildPath({ activeTab: 'job-board', jobSlug: ZH_JOB.slug }, 'it');
+    expect(path).toBe(`/cerca-lavoro-ticino/${ZH_JOB.slug}/`);
+  });
+
+  it('resolveJobCanton drives the object branch of buildJobPath', () => {
+    const canton = resolveJobCanton(ZH_JOB);
+    expect(canton).toBe('ZH');
+    const path = buildPath(
+      { activeTab: 'job-board', jobBoardCanton: canton, jobSlug: ZH_JOB.slug },
+      'it',
+    );
+    expect(path).toBe(`/cerca-lavoro-zurigo/${ZH_JOB.slug}/`);
+  });
+
+  it('TI jobs keep the legacy TI section unchanged', () => {
+    const tiPath = buildPath(
+      { activeTab: 'job-board', jobBoardCanton: resolveJobCanton({ canton: 'TI', location: 'Lugano' }), jobSlug: 'capo-progetto-lugano' },
+      'it',
+    );
+    expect(tiPath).toBe('/cerca-lavoro-ticino/capo-progetto-lugano/');
+  });
+
+  it('getJobMetaForSlug exposes the canton for the slug-map (string) branch', () => {
+    registerJobSlugMap([{ id: 'zh1', canton: 'ZH', slug: ZH_JOB.slug, slugByLocale: { it: ZH_JOB.slug } }]);
+    expect(getJobMetaForSlug(ZH_JOB.slug)?.canton).toBe('ZH');
+    const canton = getJobMetaForSlug(ZH_JOB.slug)?.canton;
+    const path = buildPath(
+      { activeTab: 'job-board', ...(canton ? { jobBoardCanton: canton } : {}), jobSlug: ZH_JOB.slug },
+      'it',
+    );
+    expect(path).toBe(`/cerca-lavoro-zurigo/${ZH_JOB.slug}/`);
+  });
+});

--- a/tests/jobboard-mobile-google-redirect.test.ts
+++ b/tests/jobboard-mobile-google-redirect.test.ts
@@ -14,6 +14,6 @@ describe('JobBoard mobile Google redirect flow', () => {
     expect(source).toContain("const redirectProvider = (() => {");
     expect(source).toContain("if (redirectProvider === provider) {");
     expect(source).toContain("if (initialJobSlug === redirectSlug) return;");
-    expect(source).toContain('onJobRouteChange?.(redirectSlug);');
+    expect(source).toContain('onJobRouteChange?.(redirectSlug, getJobMetaForSlug(redirectSlug)?.canton);');
   });
 });


### PR DESCRIPTION
## Implementato

Bug: su una canton-landing non-TI (es. `/cerca-lavoro-zurigo/`) i link ai singoli job puntavano a `/cerca-lavoro-ticino/<slug>/` invece della sezione del cantone del job. L'HTML statico emetteva gli href corretti (canton-aware), ma la SPA li sovrascriveva in hydration costruendo i path via `buildPath()` **senza** `jobBoardCanton` → fallback al default legacy TI (`table.jobBoard = 'cerca-lavoro-ticino'`).

Il fix propaga il canton su **tutte** le superfici di link/navigazione job-board:

- **`buildJobPath()`** (`components/community/JobBoard.tsx`): risolve il canton dal job (`resolveJobCanton`, ramo oggetto) o dalla slug-map (`getJobMetaForSlug`, ramo stringa) e lo passa a `buildPath`. Fixa tutti i link delle job-card (canton landing, related, ecc.).
- **`onJobRouteChange` allargato a `(slug, canton)`**: `App.pushRoute` e i call-site job-open in JobBoard ora portano `jobBoardCanton`. `staticOverlay` resta `false` (soft-nav renderizza React).
- **`NavigationContext.navigateTo(tab, subTab?, canton?)`** (param opzionale, backward-compatible) → `App` setta `route.jobBoardCanton` per il job-board.
- **Link editoriali hub** (city list, sibling nurses/care/location/sector, parent, official-gazette internalLinks): recuperano il canton dall'href canton-aware fornito dal build via `parsePath()` (helper `hubLinkRoute`/`buildHubHref`) invece di strippare l'ultima sezione e ricostruire su TI.
- **Link città nel job-detail** (e versione auth-gate): per job **non-TI** punta alla city-hub canton-aware (`/cerca-lavoro-zurigo/zurigo/`) quando la città è una municipalità nota del cantone (`isKnownCityHub`); naviga via `onJobRouteChange` (no `staticOverlay`, altrimenti App salta il `<main>` React e la soft-nav resterebbe bianca). TI invariato (solo 5 city-hub TI emesse → gating TI 404eggerebbe).
- **Sibling per-job fuori da JobBoard**: teaser inline nel blog (`BlogArticles.tsx`) e URL job del chatbot (`chatbotTools.ts` `buildJobUrl`) ora passano il canton del job.
- **Keyword/related search** (`navigateToRelatedSearch`): passa `JOB_BOARD_CANTON_AGGREGATE` per allinearsi agli href aggregate già esistenti.
- **Test**: nuovo `tests/jobboard-canton-section-link.test.ts` (regressione: `buildPath` canton-aware + round-trip `parsePath` + ramo slug-map; TI invariato). Aggiornata l'asserzione source-string in `tests/jobboard-mobile-google-redirect.test.ts` (riga `redirectSlug` ora porta il canton).

Verifiche: `tsc --noEmit` 0 errori sui file toccati; `tests/router.test.ts` (483) + `city-jobs-hub` (62) + `jobboard-*` + `canton-*` + nuovo test → tutti verdi.

## Non implementato (ancora)

- **Centralizzare il fallback canton in `buildPath()`** (lookup slug-map quando manca `jobBoardCanton`): sarebbe il fix by-construction per l'intera classe, ma GitNexus impact su `buildPath` = **CRITICAL** (44 caller diretti, processi SEO/hreflang/breadcrumb) → per regola CLAUDE.md ("HIGH/CRITICAL → warn user, no proceed") non applicato senza OK esplicito. In più non aiuterebbe le pagine dove la slug-map non è caricata (JobBoard non montato). Proposto come follow-up previa approvazione.
- **Leader job in `JobsSalaryObservatory` / `JobBoardStatsOverview`** (`leaderHref`): il tipo `JobBoardLeader` (`services/jobBoardStatsService.ts`) non porta il `canton`, e quelle pagine non montano JobBoard (slug-map non caricata) → fix affidabile richiede denormalizzare il canton nel JSON stats. Follow-up.
- **Applicazioni utente in `UserProfile`** (`app.jobSlug`): il doc `applications` denormalizza solo `jobSlug`/`jobTitle`, non il canton → fix richiede aggiungere il canton al doc. Follow-up.
- **Company/location search hub** (`azienda-*` / `localita-*`): lasciati su TI/aggregate **di proposito** — il build emette queste pagine solo sotto TI (aggregate-by-design) e il router non fa round-trip di `localita-*`/`azienda-*` sotto una sezione non-TI (parserebbe come jobSlug). Non è la stessa classe di bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)