### PR TITLE
feat(border-wait): hydrate 'Fonte' source badge live (no more stale 'Dati statistici')

### DIFF
--- a/build-plugins/borderWaitHydrationScript.ts
+++ b/build-plugins/borderWaitHydrationScript.ts
@@ -83,6 +83,7 @@ const RAW_HYDRATION_JS = `
       else if(key==="totalCrossingMinutes"&&d.total!=null)f.textContent=d.total+" min";
       else if(key==="status"&&d.status)f.textContent=statusWord(d.status);
       else if(key==="lastUpdate"&&d.lastUpdate)f.textContent=fmtClock(d.lastUpdate);
+      else if(key==="source"&&d.source){var lm;try{lm=JSON.parse(f.getAttribute("data-bw-source-labels")||"{}")}catch(e){lm={}}if(lm[d.source])f.textContent=lm[d.source];}
     }
     el.setAttribute("data-bw-hydrated","true");
     if(el.classList)el.classList.add("bw-live");
@@ -116,6 +117,7 @@ const RAW_HYDRATION_JS = `
           wait:pickInt(f.waitTimeMinutes),
           total:pickInt(f.totalCrossingMinutes),
           status:pickStr(f.status),
+          source:pickStr(f.source),
           lastUpdate:lu
         };
       }

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -1388,6 +1388,21 @@ function renderLeafPage(inp: LeafInputs): string {
 
   // Current-status card
   const sourceText = sourceLabel(liveSource, copy);
+  // Localized source→label map so the hydration script can update the "Fonte"
+  // badge in-place from the LIVE Firestore source (otherwise it stays on the
+  // build-time label, e.g. showing "Dati statistici" even when live data is fresh).
+  // Only LIVE sources — hydration runs against fresh Firestore data, whose
+  // source is always one of these (never 'static'/'mock', which are the
+  // build-time/SPA fallbacks). Omitting 'static' also keeps the "Dati statistici"
+  // string out of the page HTML so it never appears for a live-sourced reading.
+  const sourceLabelMap = JSON.stringify({
+    bazg: copy.sourceBazg,
+    here: copy.sourceHere,
+    tomtom: copy.sourceTomtom,
+    google: copy.sourceGoogle,
+    'google-maps': copy.sourceGoogle,
+    webcam: copy.sourceWebcam,
+  });
   const staticBannerHtml = staticFallback
     ? `<div class="s-rUEUjv">${esc(copy.staticFallbackBanner)}</div>`
     : '';
@@ -1415,7 +1430,7 @@ function renderLeafPage(inp: LeafInputs): string {
       </div>
       <div class="s-Zv0TZw">
         <div class="s-QHHL-d">${esc(copy.sourceLabel)}</div>
-        <div class="s-iUCmjg">${esc(sourceText)}</div>
+        <div class="s-iUCmjg" data-bw-field="source" data-bw-source-labels="${esc(sourceLabelMap)}">${esc(sourceText)}</div>
       </div>
       <div class="s-Zv0TZw">
         <div class="s-QHHL-d">${esc(copy.updatedLabel)}</div>

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -1866,7 +1866,18 @@ function renderHubPage(inp: HubInputs): string {
 
   // Build live table of all crossings in scope. Each <tr> carries the
   // data-bw-crossing attribute so the inline hydration IIFE can swap the
-  // pre-rendered minute count with the fresh Firestore value at runtime.
+  // pre-rendered minute count AND the source label with the fresh Firestore
+  // values at runtime. The source→label map is locale-invariant → build once
+  // here, not per row. Live sources only (no 'static' → "Dati statistici" copy
+  // never lands in the HTML).
+  const hubSourceLabelMap = JSON.stringify({
+    bazg: copy.sourceBazg,
+    here: copy.sourceHere,
+    tomtom: copy.sourceTomtom,
+    google: copy.sourceGoogle,
+    'google-maps': copy.sourceGoogle,
+    webcam: copy.sourceWebcam,
+  });
   const rows = crossingsInScope.map((c) => {
     const snap = current.perCrossing[c];
     const wait = snap?.totalCrossingMinutes ?? snap?.waitTimeMinutes ?? null;
@@ -1880,7 +1891,7 @@ function renderHubPage(inp: HubInputs): string {
       <td class="s-tcl" style="text-align:right">
         <span data-bw-field="totalCrossingMinutes" style="display:inline-block;padding:4px 10px;border-radius:9999px;font-size:13px;font-weight:700;background:${sc.bg};color:${sc.text};border:1px solid ${sc.border}">${esc(waitFmt)}</span>
       </td>
-      <td class="s-tcl" style="font-size:12px;color:var(--color-subtle)">${esc(sourceLabel(src, copy))}</td>
+      <td class="s-tcl" data-bw-field="source" data-bw-source-labels="${esc(hubSourceLabelMap)}" style="font-size:12px;color:var(--color-subtle)">${esc(sourceLabel(src, copy))}</td>
     </tr>`;
   });
 


### PR DESCRIPTION
## Contesto
Anche con i dati live, il badge "Fonte" mostrava la label del build ("Dati statistici — tempo reale non disponibile") perché — a differenza del numero (`data-bw-field=totalCrossingMinutes`, già idratato) — il label sorgente non aveva hook di hydration. Causa diretta del "vedo ancora Dati statistici" segnalato dall'owner.

## Implementato
- `build-plugins/borderWaitPagesPlugin.ts`: il div "Fonte" ora porta `data-bw-field="source"` + `data-bw-source-labels` (mappa localizzata sorgente→label, SOLO sorgenti live: bazg/here/tomtom/google/webcam — NON 'static', così la stringa "Dati statistici" non viene mai embeddata).
- `build-plugins/borderWaitHydrationScript.ts`: parsa `source` dal documento Firestore e, per `data-bw-field=source`, mappa la sorgente live → label localizzata e la sostituisce in-place.
- Effetto: una lettura live mostra "Stima TomTom"/"Stima percorso live (HERE)"/"Stima da webcam" senza attendere un rebuild → il label è live sempre, indipendente dalla starvation deploy. 41 test verdi (border-wait-pages + border-wait-hydration).

## Non implementato (ancora)
- La label pre-hydration (zero-JS / pre-fetch) resta il valore di build (corretto: honest fallback). Se il build-time snapshot è 'static'/stale mostra ancora "Dati statistici" finché l'hydration non risolve — invariato e atteso.
- Il numero di build resta finché l'hydration non sostituisce (già così).