### PR TITLE
fix(offerwall): modern GPT setConfig + drop redundant FC injection

### DIFF
--- a/components/community/OfferwallNewsletterGate.tsx
+++ b/components/community/OfferwallNewsletterGate.tsx
@@ -24,7 +24,6 @@ import { useTranslation } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
 import { reportCaughtError } from '@/services/errorReporter';
 import EmailInput, { validateEmailStrict } from '@/components/shared/EmailInput';
-import { AD_CLIENT } from '@/services/adsenseSlots';
 import {
   upsertNewsletterSubscriber,
   markNewsletterSubscribedLocally,
@@ -121,64 +120,45 @@ function normalizeLocale(code?: string | null, fallback?: string): OfferwallLoca
   return 'it';
 }
 
-// Funding Choices publisher id ('pub-8628054934855353'), derived from the shared
-// AdSense client to avoid a second hard-coded copy.
-const FC_PUB = AD_CLIENT.replace(/^ca-/, '');
-
 /**
- * Ensure the Offerwall custom-choice registry AND the Funding Choices loader are
- * present. On SPA routes index.html sets both inline; STATIC SSG pages (articles,
- * SEO landings) use a different shell whose <head> has NEITHER — so the Offerwall
- * could never render on exactly the pages we scope it to. This gate hydrates on
- * every page (SPA + static), so we set them here. Idempotent: no-op when already
- * present (SPA). Mirrors the index.html bootstrap; the registry's show() delegates
- * to window.__ftOfferwallSubscribe (installed by this component's effect below).
+ * Ensure the Offerwall custom-choice registry exists on `window.googlefc`. On SPA
+ * routes index.html sets it inline; STATIC SSG pages (articles, SEO landings) use
+ * a different shell whose <head> lacks it — and those are exactly the pages we
+ * scope the Offerwall to. This gate hydrates on every page (SPA + static), so we
+ * set it here. Idempotent: no-op when already present (SPA). The registry's show()
+ * delegates to window.__ftOfferwallSubscribe (installed by this component's effect).
+ *
+ * NOTE: we do NOT inject the Funding Choices (`fundingchoicesmessages`) loader —
+ * per Google Ad Manager support, the Offerwall (and consent, once upgraded to the
+ * GPT framework) is delivered via GPT, so no separate FC CMP script is needed
+ * alongside GPT. The page's GPT (GptPocSlot) provides the delivery surface.
  */
-function ensureOfferwallRegistryAndFc(): void {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+function ensureOfferwallRegistry(): void {
+  if (typeof window === 'undefined') return;
   const w = window as any;
   const g = (w.googlefc = w.googlefc || {});
   const ow = (g.offerwall = g.offerwall || {});
   const cc = (ow.customchoice = ow.customchoice || {});
-  if (!cc.registry) {
-    cc.registry = {
-      initialize(params: { offerwallLanguageCode?: string } | undefined) {
-        const E = cc.InitializeResponseEnum || {};
-        try {
-          if (w.localStorage.getItem('newsletter_subscribed') === 'true') {
-            return Promise.resolve(E.ACCESS_GRANTED || 'ACCESS_GRANTED');
-          }
-        } catch { /* ignore */ }
-        w.__ftOfferwallLang = (params && params.offerwallLanguageCode) || null;
-        return Promise.resolve(E.ACCESS_NOT_GRANTED || 'ACCESS_NOT_GRANTED');
-      },
-      show() {
-        const fn = w.__ftOfferwallSubscribe;
-        if (typeof fn !== 'function') return Promise.resolve(false);
-        try {
-          return Promise.resolve(fn(w.__ftOfferwallLang)).then((ok: unknown) => !!ok);
-        } catch { return Promise.resolve(false); }
-      },
-    };
-  }
-  // Inject the Funding Choices messaging tag if absent (needed for the Offerwall
-  // to serve). index.html marks its loader with data-fc-loader; skip if present.
-  if (!document.querySelector('script[data-fc-loader]') &&
-      !document.querySelector('script[src*="fundingchoicesmessages.google.com"]')) {
-    const s = document.createElement('script');
-    s.async = true;
-    // No crossOrigin: the /i/pub-XXX endpoint serves no ACAO header (see
-    // tests/index-html-fc-loader.test.ts rationale).
-    s.src = `https://fundingchoicesmessages.google.com/i/${FC_PUB}?ers=1`;
-    s.setAttribute('data-fc-loader', '1');
-    document.head.appendChild(s);
-    if (!w.frames['googlefcPresent'] && document.body) {
-      const iframe = document.createElement('iframe');
-      iframe.style.cssText = 'width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;display:none';
-      iframe.name = 'googlefcPresent';
-      document.body.appendChild(iframe);
-    }
-  }
+  if (cc.registry) return;
+  cc.registry = {
+    initialize(params: { offerwallLanguageCode?: string } | undefined) {
+      const E = cc.InitializeResponseEnum || {};
+      try {
+        if (w.localStorage.getItem('newsletter_subscribed') === 'true') {
+          return Promise.resolve(E.ACCESS_GRANTED || 'ACCESS_GRANTED');
+        }
+      } catch { /* ignore */ }
+      w.__ftOfferwallLang = (params && params.offerwallLanguageCode) || null;
+      return Promise.resolve(E.ACCESS_NOT_GRANTED || 'ACCESS_NOT_GRANTED');
+    },
+    show() {
+      const fn = w.__ftOfferwallSubscribe;
+      if (typeof fn !== 'function') return Promise.resolve(false);
+      try {
+        return Promise.resolve(fn(w.__ftOfferwallLang)).then((ok: unknown) => !!ok);
+      } catch { return Promise.resolve(false); }
+    },
+  };
 }
 
 const OfferwallNewsletterGate: React.FC = () => {
@@ -224,7 +204,7 @@ const OfferwallNewsletterGate: React.FC = () => {
     // Ensure the registry + FC loader exist (esp. on static SSG pages whose head
     // lacks index.html's inline versions). Runs after the hook is installed so
     // the registry's show() can delegate to it.
-    ensureOfferwallRegistryAndFc();
+    ensureOfferwallRegistry();
     return () => {
       if ((window as any).__ftOfferwallSubscribe === hook) {
         delete (window as any).__ftOfferwallSubscribe;

--- a/components/shared/GptPocSlot.tsx
+++ b/components/shared/GptPocSlot.tsx
@@ -81,12 +81,36 @@ const GptPocSlot: React.FC = () => {
 
   useEffect(() => {
     if (!active) return;
+    const divId = divIdRef.current;
+
+    // Initialise the GPT framework EARLY (post-load idle, not on scroll): the GAM
+    // Offerwall evaluates at page entry, so GPT must be present then or the wall
+    // never shows. The ad slot itself stays lazy (IntersectionObserver below) to
+    // protect CWV — only the lightweight gpt.js load + enableServices runs early.
+    const initGptFramework = () => {
+      ensureGptScript();
+      const gt = gtag();
+      gt.cmd.push(() => {
+        try {
+          if (!gptServicesEnabled) {
+            gptServicesEnabled = true;
+            // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
+            gt.setConfig({ singleRequest: true });
+            gt.pubads().collapseEmptyDivs(true);
+            gt.enableServices();
+          }
+        } catch { /* fail-soft */ }
+      });
+    };
+    const ric: (cb: () => void) => void =
+      (window as any).requestIdleCallback
+        ? (cb) => (window as any).requestIdleCallback(cb, { timeout: 3000 })
+        : (cb) => window.setTimeout(cb, 1200);
+    ric(initGptFramework);
+
     const wrapper = wrapperRef.current;
     if (!wrapper || typeof IntersectionObserver === 'undefined') return;
-
-    const divId = divIdRef.current;
     let defined = false;
-
     const defineAndDisplay = () => {
       if (defined) return;
       defined = true;
@@ -98,13 +122,6 @@ const GptPocSlot: React.FC = () => {
             .defineSlot(GPT_POC_AD_UNIT_PATH, GPT_POC_SIZES, divId)
             ?.addService(gt.pubads());
           if (!slot) return;
-          if (!gptServicesEnabled) {
-            gptServicesEnabled = true;
-            // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
-            gt.setConfig({ singleRequest: true });
-            gt.pubads().collapseEmptyDivs(true);
-            gt.enableServices();
-          }
           gt.display(divId);
           setRendered(true);
         } catch {

--- a/components/shared/GptPocSlot.tsx
+++ b/components/shared/GptPocSlot.tsx
@@ -100,7 +100,8 @@ const GptPocSlot: React.FC = () => {
           if (!slot) return;
           if (!gptServicesEnabled) {
             gptServicesEnabled = true;
-            gt.pubads().enableSingleRequest();
+            // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
+            gt.setConfig({ singleRequest: true });
             gt.pubads().collapseEmptyDivs(true);
             gt.enableServices();
           }


### PR DESCRIPTION
Tre fix dal test live (l'Offerwall serviva via GPT ma il wall non renderizzava).

## Implementato
1. **`GptPocSlot`**: `pubads().enableSingleRequest()` → **`googletag.setConfig({ singleRequest: true })`** (rimuove il warning di deprecazione GPT).
2. **`OfferwallNewsletterGate`**: rimossa l'**iniezione del loader Funding Choices** sulle pagine statiche. Per il **support Google Ad Manager**, l'Offerwall (e il consenso su framework GPT) si servono **via GPT** → nessuno script FC separato serve accanto a GPT. Resta solo il bootstrap del **registry custom-choice**. Rimosso import `AD_CLIENT` inutilizzato.
3. **`GptPocSlot` init GPT early**: il GAM Offerwall valuta al **page-entry**; caricando GPT solo lazy (allo scroll sullo slot) GPT era assente alla valutazione → il wall non si mostrava. Ora `gpt.js` + `enableServices` girano su un **`requestIdleCallback` post-load** (CWV-safe), mentre lo **slot ad resta lazy** via IntersectionObserver.

Verificato: tsc pulito; `offerwall-custom-choice` + `index-html-fc-loader` test verdi (11).

## Non implementato (ancora)
- **Offerwall visibile**: questi fix mirano a farlo apparire (init GPT early), ma resta possibile una componente di **propagazione/delivery lato Google** dopo la ripubblicazione del messaggio. Da verificare live post-deploy; se persiste, follow-up col support GAM.
- Verifica live solo post-deploy. Revert-trigger: kill-switch RC `KILL_GPT_POC_SLOT`.