### PR TITLE
refactor(ci): simplify RC mask gate + add unit test

### DIFF
--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -25,6 +25,8 @@
  *     so workflows that don't have Firebase configured still work.
  */
 
+import { pathToFileURL } from 'node:url';
+
 // ─── RC Param → Env Var Mapping ──────────────────────────────────────────
 // Maps Remote Config parameter names to the environment variable names
 // that scripts expect.  One RC param may map to multiple env vars.
@@ -150,6 +152,19 @@ function getRcValue(template, key) {
   return template?.parameters?.[key]?.defaultValue?.value ?? null;
 }
 
+/**
+ * Whether an RC value is too trivial to be worth masking in CI logs.
+ *
+ * GitHub Actions redacts EVERY literal occurrence of a masked value, so masking
+ * a short/common value poisons unrelated output: a secret of `1` turns ANSI
+ * codes (`36;1m`), counts, and `bash -e {0}` into `***`. Values shorter than 6
+ * chars (booleans, short ints, short codes) are not sensitive — every real
+ * secret (API key, PAT, SA JSON) is longer — so we skip masking them.
+ */
+export function isTrivialSecret(value) {
+  return typeof value !== 'string' || value.length < 6;
+}
+
 
 
 // ─── Main ────────────────────────────────────────────────────────────────
@@ -216,13 +231,9 @@ async function main() {
       // For CI: write to $GITHUB_ENV
       // For local: output as export statement
       if (isCI) {
-        // Mask the value so GitHub Actions redacts it from all logs.
-        // Skip trivial values (booleans, short ints, very short strings): they
-        // are not sensitive and masking them poisons unrelated log output —
-        // GitHub redacts EVERY occurrence of the literal, so a secret of `1`
-        // turns ANSI codes (`36;1m`), counts, and `bash -e {0}` into `***`.
-        const isTrivial = /^(true|false|\d{1,5})$/i.test(value) || value.length < 6;
-        if (!isTrivial) {
+        // Mask the value so GitHub Actions redacts it from all logs, but skip
+        // trivial values that would poison unrelated output (see isTrivialSecret).
+        if (!isTrivialSecret(value)) {
           process.stdout.write(`::add-mask::${value}\n`);
         }
         // Use delimiter syntax for multi-line safety
@@ -251,8 +262,11 @@ async function main() {
   statusLog(`✅ RC secrets loaded: ${loaded} set, ${skipped} already in env, ${missing} not in RC`);
 }
 
-main().catch((err) => {
-  console.warn(`⚠️  load-rc-env failed: ${err?.message || 'Unknown error'}`);
-  console.warn('   Falling back to environment variables / GH Secrets.');
-  process.exit(0); // Non-blocking — never break the workflow
-});
+// Only run when executed directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.warn(`⚠️  load-rc-env failed: ${err?.message || 'Unknown error'}`);
+    console.warn('   Falling back to environment variables / GH Secrets.');
+    process.exit(0); // Non-blocking — never break the workflow
+  });
+}

--- a/tests/load-rc-env-mask-gate.test.ts
+++ b/tests/load-rc-env-mask-gate.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { isTrivialSecret } from '../scripts/load-rc-env.mjs';
+
+// Gate that decides whether an RC value is masked in CI logs.
+// Trivial (short/common) values must NOT be masked — masking them poisons
+// unrelated output, because GitHub redacts every literal occurrence. Real
+// secrets must be masked.
+describe('load-rc-env isTrivialSecret', () => {
+  it('treats short / common values as trivial (not masked)', () => {
+    for (const v of ['0', '1', '36', '12345', 'true', 'false', 'no']) {
+      expect(isTrivialSecret(v), `${v} should be trivial`).toBe(true);
+    }
+  });
+
+  it('treats real secrets (>= 6 chars) as non-trivial (masked)', () => {
+    for (const v of [
+      'AIzaSyAbcdEfGhExampleKey123', // Google API key
+      're_xxxxxxxxxxxx',            // Resend key
+      'ghp_aaaaaaaaaaaa',           // GitHub PAT
+      'G-XXXXXXX',                  // GA measurement id
+      '123456',                     // 6-digit id (e.g. long FB_PAGE_ID)
+    ]) {
+      expect(isTrivialSecret(v), `${v} should be masked`).toBe(false);
+    }
+  });
+
+  it('treats non-string / nullish values as trivial (nothing to mask)', () => {
+    expect(isTrivialSecret(null as unknown as string)).toBe(true);
+    expect(isTrivialSecret(undefined as unknown as string)).toBe(true);
+    expect(isTrivialSecret(42 as unknown as string)).toBe(true);
+  });
+
+  it('uses a strict length boundary at 6 chars', () => {
+    expect(isTrivialSecret('abcde')).toBe(true);  // 5 chars → trivial
+    expect(isTrivialSecret('abcdef')).toBe(false); // 6 chars → masked
+  });
+});


### PR DESCRIPTION
## Implementato
- Follow-up del 🟡 nit su #2326: il gate usava `/^(true|false|\d{1,5})$/i || value.length < 6`, ma la regex è interamente sussunta dal length check (`true`=4, `false`=5, `\d{1,5}`≤5 → tutti <6). Rimossa la regex ridondante.
- Estratto helper esportato `isTrivialSecret(value)` (`length < 6`, non-string → trivial) con docblock che spiega perché si salta il mask (GitHub redige ogni occorrenza letterale → un secret `1` avvelena ANSI/count/`bash -e {0}`).
- `main()` ora gira solo da entrypoint (`import.meta.url === pathToFileURL(process.argv[1]).href`), così il modulo è importabile dai test senza eseguire il loader/`process.exit`.
- Aggiunto `tests/load-rc-env-mask-gate.test.ts` (4 test, verde locale): valori banali non mascherati, secret reali (API key/PAT/id ≥6 char) mascherati, boundary a 6 char, non-string/nullish trivial.

## Non implementato (ancora)
- Nessun sibling da sweepare: `::add-mask::`/`isTrivialSecret` esistono solo in `scripts/load-rc-env.mjs` in tutto il repo.
- Soglia `length < 6` resta euristica: un secret realmente sensibile lungo ≤5 char resterebbe in chiaro. Nessuno noto rientra (API key/PAT/SA tutti lunghi); se in futuro se ne aggiunge uno corto sensibile, va introdotta una whitelist per-chiave.

Supersedes nit deferred su #2326.