### PR TITLE
fix(router): centralize canton fallback in buildPath + profile apply links

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4140,9 +4140,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (!path) return { slug: '' };
  const r = parsePath(path).route;
  const hasInner = !!(r.jobSlug || r.jobBoardCity || r.jobBoardSector);
+ // Build never emits a 2+-level hub path under a canton section (every
+ // canonicalPath is `${section}/${slug}`), so the terminal segment is the
+ // slug. Uppercase the canton for parity with buildJobPath / getJobMetaForSlug
+ // (parsePath already returns uppercase ISO keys; this just makes it explicit).
  const parts = path.split('/').filter(Boolean);
  const slug = hasInner && parts.length ? parts[parts.length - 1] : '';
- return { canton: r.jobBoardCanton, slug };
+ return { canton: r.jobBoardCanton ? String(r.jobBoardCanton).toUpperCase() : undefined, slug };
  };
 
  // Anchor href for an editorial hub link, canton-aware. Falls back to the

--- a/components/pages/UserProfile.tsx
+++ b/components/pages/UserProfile.tsx
@@ -22,7 +22,7 @@ import {
  Clock, FileCheck, Mail, ExternalLink,
 } from 'lucide-react';
 import { useTranslation, type Locale, setLocale as setGlobalLocale, getLocale, LOCALE_LABELS } from '@/services/i18n';
-import { buildPath } from '@/services/router';
+import { buildPath, ensureJobSlugMapLoaded } from '@/services/router';
 import SubscriptionPreferencesController from '@/components/preferences/SubscriptionPreferencesController';
 import { useAuth, getUserDisplayName, getUserPhotoURL, promptOneTap, renderGoogleButton, cancelOneTap, deleteCurrentUser, signInWithFacebook, reAuthFacebook, getLinkedProviders, getAuthEmail, consumeFacebookProfilePrefill, eagerAuth, isLinkedInSignInAvailable, signInWithLinkedIn } from '@/services/authService';
 import { Analytics } from '@/services/analytics';
@@ -499,6 +499,13 @@ const UserProfile: React.FC = () => {
    })();
    return () => { cancelled = true; };
  }, [user]);
+ // The "my applications" links resolve their canton section from the job slug
+ // map (buildPath → getJobMetaForSlug). Ensure it is loaded so an applied
+ // non-TI job links to /cerca-lavoro-<canton>/… instead of the legacy TI
+ // default; the state bump re-renders once the map is in. Falls back to TI
+ // for jobs no longer in the map (expired), preserving prior behaviour.
+ const [, setSlugMapReady] = useState(false);
+ useEffect(() => { void ensureJobSlugMapLoaded().then(() => setSlugMapReady(true)); }, []);
  const [profile, setProfile] = useState<UserProfileData>(DEFAULT_PROFILE);
  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
  const [showFamily, setShowFamily] = useState(false);

--- a/services/router.ts
+++ b/services/router.ts
@@ -3372,10 +3372,23 @@ export function buildPath(route: AppRoute, locale?: Locale): string {
  // when canton not set, preserving backward-compat for all existing
  // /cerca-lavoro-ticino/{slug} URLs.
  const jobBoardLocale = lang as 'it' | 'en' | 'de' | 'fr';
- const jobBoardBase = route.jobBoardCanton
- ? (route.jobBoardCanton === JOB_BOARD_CANTON_AGGREGATE
+ // Canton-aware section resolution. Precedence:
+ //   1. explicit route.jobBoardCanton (set by the parser, JobBoard, hub links);
+ //   2. by-construction fallback — when no explicit canton but the jobSlug
+ //      maps to a KNOWN job, use that job's canton. This keeps every per-job
+ //      link canton-correct across ALL buildPath callers (blog teasers,
+ //      profile applications, salary/board leaders, chatbot, sitemap, …)
+ //      without per-call-site plumbing, so the link-canton class can't drift;
+ //   3. legacy TI default (table.jobBoard) — when the slug map isn't loaded
+ //      or the slug isn't a known job (company/location/search/city slugs),
+ //      preserving backward-compat for all existing /cerca-lavoro-ticino/{slug}.
+ const resolvedJobBoardCanton =
+ route.jobBoardCanton
+ || (route.jobSlug ? getJobMetaForSlug(route.jobSlug)?.canton : undefined);
+ const jobBoardBase = resolvedJobBoardCanton
+ ? (resolvedJobBoardCanton === JOB_BOARD_CANTON_AGGREGATE
  ? getAggregatorJobBoardSlug(jobBoardLocale)
- : getJobBoardSlugForCanton(route.jobBoardCanton, jobBoardLocale))
+ : getJobBoardSlugForCanton(resolvedJobBoardCanton, jobBoardLocale))
  : table.jobBoard;
  // When a sector hub is set, emit the clean canonical URL
  // (e.g. /cerca-lavoro-ticino/infermieri/). Precedes jobSlug so

--- a/tests/jobboard-canton-section-link.test.ts
+++ b/tests/jobboard-canton-section-link.test.ts
@@ -66,3 +66,33 @@ describe('job-board canton section links', () => {
     expect(path).toBe(`/cerca-lavoro-zurigo/${ZH_JOB.slug}/`);
   });
 });
+
+/**
+ * Centralized by-construction fallback in buildPath(): when no explicit
+ * jobBoardCanton is given but the jobSlug maps to a known job, the canton
+ * section is resolved from the slug map. Fixes every per-job link caller
+ * (profile applications, blog teasers, chatbot, sitemap, …) at one point —
+ * without canton plumbing at each call site.
+ */
+describe('buildPath canton fallback from the slug map', () => {
+  const SLUG = 'export-manager-zurich-acme';
+
+  it('non-TI job slug with NO explicit canton resolves to the job canton section', () => {
+    registerJobSlugMap([{ id: 'j1', canton: 'ZH', slug: SLUG, slugByLocale: { it: SLUG } }]);
+    const path = buildPath({ activeTab: 'job-board', jobSlug: SLUG }, 'it');
+    expect(path).toBe(`/cerca-lavoro-zurigo/${SLUG}/`);
+  });
+
+  it('an explicit canton still wins over the slug-map lookup', () => {
+    registerJobSlugMap([{ id: 'j1', canton: 'ZH', slug: SLUG, slugByLocale: { it: SLUG } }]);
+    const path = buildPath({ activeTab: 'job-board', jobBoardCanton: 'TI', jobSlug: SLUG }, 'it');
+    expect(path).toBe(`/cerca-lavoro-ticino/${SLUG}/`);
+  });
+
+  it('a non-job slug (company / search hub) is left on the legacy TI section', () => {
+    registerJobSlugMap([{ id: 'j1', canton: 'ZH', slug: SLUG, slugByLocale: { it: SLUG } }]);
+    // azienda-* / ricerca-* hubs are aggregate/TI by design — not in the job map.
+    const company = buildPath({ activeTab: 'job-board', jobSlug: 'azienda-acme' }, 'it');
+    expect(company).toBe('/cerca-lavoro-ticino/azienda-acme/');
+  });
+});


### PR DESCRIPTION
Follow-up a #2331 — completa la classe "link job-board canton-aware" by-construction. **Closes #2332**.

## Implementato

- **Centralizzazione in `buildPath()`** (`services/router.ts`, case `job-board`): quando manca `jobBoardCanton` esplicito ma il `jobSlug` mappa a un **job noto** (`getJobMetaForSlug`), la sezione canton è risolta dalla slug-map. Tutti i caller di link per-job (sitemap, candidature profilo, teaser blog, chatbot, …) diventano canton-corretti in **un solo punto**, senza plumbing per call-site → la classe non può più driftare. Slug non-job (company/location/search) e slug-map non caricata → fallback al default legacy TI ⇒ URL `/cerca-lavoro-ticino/{slug}` esistenti invariati. Applicato col tuo OK esplicito nonostante il blast-radius **CRITICAL** di `buildPath` (44 caller): la modifica è puramente additiva (precedenza all'esplicito, fallback identico al comportamento attuale).
- **`UserProfile` "Le mie candidature"**: carico la slug-map (`ensureJobSlugMapLoaded` + state-bump per re-render) così un job applicato non-TI linka alla sua sezione canton via il fallback sopra. Job non più in mappa (scaduti) → fallback TI (comportamento precedente).
- **`hubLinkRoute`** (`JobBoard.tsx`): uppercase del canton da `parsePath` per parità esplicita con `buildJobPath`/`getJobMetaForSlug` (item 5 #2332). Verificato e documentato che il build non emette mai path hub a 2+ livelli sotto una sezione → il segmento terminale è sempre lo slug (item 4 #2332: nessun impatto).
- **Test di regressione** (`tests/jobboard-canton-section-link.test.ts`): fallback slug-map (slug non-TI senza canton → sezione canton); l'esplicito vince sul lookup; slug hub non-job resta su TI.

Verifiche: `tsc --noEmit` 0 errori (file toccati); 634 test verdi (router 483 + city-jobs-hub 62 + jobboard + nuovi 8).

## Non implementato (ancora)

- **Leader salary/stats** (`JobsSalaryObservatory` / `JobBoardStatsOverview`, item 2 di #2332): **non è un bug** — ogni `leader.url` è un hub company (`azienda-*`) o search (`ricerca-*`), **mai** uno slug per-job (verificato in `scripts/lib/job-board-stats.mjs`), quindi TI/aggregate è corretto **by-design**. Nessuna modifica (il falso-deferral è chiuso con questa spiegazione, non con codice).
- **Company/location search hub** (`azienda-*`/`localita-*`): restano TI/aggregate by-design (il build li emette solo sotto TI; il router non fa round-trip sotto sezioni non-TI). Fuori dalla classe del bug.
- **Denormalizzazione canton nei dati** (JSON stats / doc `applications`): non necessaria — la risoluzione client-side via slug-map centralizzata copre i job attivi senza migrazione dati né cambi di schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)