### PR TITLE
ci(lighthouse): truthful budget text + reopen-within-hours on regression issue

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -3,12 +3,11 @@ name: Lighthouse CI
 # Post-deploy performance gate on the 6 representative page templates flagged
 # by Semrush Site Audit (2026-04-24) as "slow" pages.
 #
-# Budgets enforced (lighthouserc.json):
-#   - Performance score >= 0.85
-#   - LCP  < 2500ms
-#   - CLS  < 0.1
-#   - TBT  < 200ms
-#   - SEO / a11y category scores
+# Budgets are defined in lighthouserc.json (assert.assertions) — the single
+# source of truth. Do NOT duplicate the numeric thresholds here: they drift
+# (the old copy claimed perf>=0.85 / CLS<0.1 / TBT<200 while the file actually
+# enforces perf>=0.60 / CLS<2.0 / TBT<700) and a stale copy misleads whoever
+# triages a regression. Read the file for the live numbers.
 #
 # Audits PRODUCTION live (https://frontaliereticino.ch). The audit measures the
 # DEPLOYED site, so it only makes sense to run it AFTER a deploy has propagated
@@ -154,6 +153,11 @@ jobs:
       # strategic — owner/agent triages it manually (AGENTS.md: only crawler /
       # follow-up are auto-routable). Labelled funnel-monetization (CLS gates
       # AdSense RPM) + funnel-seo (category SEO score gates indexability).
+      # --reopen-within-hours 6: prod CWV are noisy and every deploy re-audits,
+      # so the gate flaps (fail → recovery closes → fail again). Without it the
+      # second fail finds no OPEN issue and coins a duplicate; 6h lets it reopen
+      # the canonical issue instead (matches the other post-deploy reporters in
+      # deploy.yml / post-deploy-validate-*.yml). Paired with the resolve step.
       - name: Open issue on regression
         if: steps.probe.outputs.run_audit == 'true' && steps.lhci.outcome == 'failure'
         run: |
@@ -166,11 +170,12 @@ jobs:
             --label funnel-monetization \
             --label funnel-seo \
             --workflow "Lighthouse CI" \
+            --reopen-within-hours 6 \
             --description "Post-deploy Lighthouse audit exceeded a budget on https://frontaliereticino.ch.
 
-          **Budgets** (lighthouserc.json): Performance ≥ 0.85 · LCP < 2500ms · CLS < 0.1 · TBT < 200ms · SEO/a11y category scores.
+          **Budgets:** defined in lighthouserc.json (assert.assertions) — read the file for the live thresholds; they are deliberately not duplicated here to avoid drift.
 
-          **Why it matters (funnel):** CLS < 0.1 gates AdSense RPM (layout shift → revenue loss); the SEO category score gates organic indexability.
+          **Why it matters (funnel):** the CLS budget guards AdSense RPM (layout shift → revenue loss); the SEO category score gates organic indexability.
 
           **Audit run:** $RUN_URL (Lighthouse reports artifact attached to the run; public HTML report linked in the LHCI step log).
           **Triggering deploy:** ${DEPLOY_URL:-manual dispatch}


### PR DESCRIPTION
## Implementato
Follow-up ai 2 🟡 nit della review di #2342 (codice nuovo che pubblicava soglie false).

- **Testo budget veritiero**: header comment + body della issue auto-aperta dichiaravano `perf>=0.85 / CLS<0.1 / TBT<200ms` attribuendoli a `lighthouserc.json`, ma il file enforce `perf>=0.60 / CLS<2.0 / TBT<700ms` (solo LCP 2500 coincideva). Rimossi i numeri hardcoded da entrambi i punti e rimandato a `lighthouserc.json` come single source of truth (anti-drift, AGENTS.md: niente literal duplicati). Chi triagia una regressione monetization ora non legge più soglie inesistenti.
- **`--reopen-within-hours 6`** sullo step `Open issue on regression`: i CWV su prod live sono rumorosi e ogni deploy ri-audita → il gate flappa (fail → recovery chiude → fail di nuovo). Senza il flag il secondo fail non trova issue OPEN e conia un duplicato; con 6h riapre la canonica via `findRecentlyClosedIssueByTitlePrefix`. Allineato agli altri reporter post-deploy (`deploy.yml`, `post-deploy-validate-*.yml` usano tutti `6`). Commento che documenta il pairing con lo step resolve.

## Adversarial check (dalla review di #2342) — risolti
- **Exit-code action su breach (#1)**: confermato che `treosh/lighthouse-ci-action@v12` propaga un assertion-failure come step-failure → `steps.lhci.outcome == 'failure'`. Evidenza: il workflow pre-esistente aveva `continue-on-error` a livello job *proprio* perché un breach di budget rendeva rosso lo step. L'assunzione portante regge.
- **Buco CLS 0.1–2.0 (#3)**: reale ma è esattamente lo scope di #2142 (taratura soglie). Il testo del body non promette più `CLS<0.1` (vedi sopra), quindi non pubblicizza un segnale non catturabile. La stretta della soglia resta su #2142.

## Non implementato (ancora)
- **Taratura soglie `lighthouserc.json`** (#2142 item 2): out of scope. Questo PR rende il testo veritiero rispetto alle soglie *attuali*, non le cambia. Relates #2142, non `Closes`.
- **Attribuzione deploy sotto burst (#2 adversarial)**: con `cancel-in-progress: false` un audit accodato misura prod al proprio tempo, quindi `workflow_run.html_url` nel body potrebbe puntare a un deploy diverso da quello che ha causato la regressione. Edge-case raro (deploy ravvicinati), non funnel-critical; il run URL dell'audit resta corretto. Deferito.
