### PR TITLE
ci(pr-review): fail loudly when the reviewer aborts on a transient API error

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Run Claude review
         id: claude_review
         if: steps.guard.outputs.skip != 'true'
+        # Don't let a hard action failure abort the job before the guard below
+        # can classify it — the guard decides whether to fail loudly.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -226,6 +229,34 @@ jobs:
             - 🔴 aperto → NON scrivere `## LGTM`.
             - ❓ funnel-critical non escalato (né 🔴 né follow-up issue) → NON scrivere `## LGTM`.
             - Incerto → `❓ q:`, no speculazione.
+
+      - name: Fail on transient API error (no review posted)
+        # claude-code-action can exit 0 even when the model run ABORTED on a
+        # transient Anthropic API error (500/502/503/529/429, "overloaded",
+        # "server_error") WITHOUT posting a review. The job then looks green but
+        # no `## LGTM`/finding was ever written → the PR silently stalls (no
+        # auto-merge, no failure signal; observed PR #2340, API 500 mid-run).
+        # Classify that case from the execution log and FAIL LOUDLY so the run
+        # is visibly red + re-runnable instead of masquerading as a clean pass.
+        # `set -uo pipefail` (NOT -e): grep in conditionals must not abort.
+        if: always() && steps.guard.outputs.skip != 'true'
+        env:
+          REVIEW_OUTCOME: ${{ steps.claude_review.outcome }}
+          EXEC_FILE: ${{ steps.claude_review.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+          if [ "${REVIEW_OUTCOME}" = "failure" ]; then
+            echo "::error::Claude review action failed (outcome=failure) — re-run this job."
+            exit 1
+          fi
+          if [ -n "${EXEC_FILE:-}" ] && [ -f "${EXEC_FILE}" ]; then
+            if grep -qE '"is_error"[[:space:]]*:[[:space:]]*true' "${EXEC_FILE}" \
+               && grep -qiE '"api_error_status"[[:space:]]*:[[:space:]]*(429|5[0-9][0-9])|overloaded|server_error|internal server error|api error: 5' "${EXEC_FILE}"; then
+              echo "::error::Claude review aborted on a transient Anthropic API error without posting a review — re-run this job."
+              exit 1
+            fi
+          fi
+          echo "Review step completed without an unrecovered transient API error."
 
       - name: Claude usage metrics
         # Solo se la review Claude è effettivamente girata (guard non-skip): a


### PR DESCRIPTION
## Implementato

`anthropics/claude-code-action@v1` può uscire con **exit 0 anche quando il run del modello abortisce a metà review su un errore transitorio dell'API Anthropic** (500/502/503/529/429, "overloaded", "server_error") **senza postare nessuna review**. Il job risulta allora SUCCESS ma senza `## LGTM` né finding → la PR si blocca in silenzio: niente auto-merge, nessun segnale di fallimento.

Osservato su **PR #2340**: API 500 a metà run (`"is_error": true, "api_error_status": 500`), check `review` verde, 0 review postate, merge fermo.

- Nuovo step **"Fail on transient API error (no review posted)"** in `.github/workflows/pr-review-loop.yml`: classifica il caso dal log di esecuzione dell'action (`is_error` + `api_error_status` transitorio, oppure outcome `failure` dello step) ed esce `1` → il run diventa **rosso e ri-runnabile** invece di mascherarsi da pass pulito.
- `claude_review` ottiene `continue-on-error: true` così il guard può classificare anche un hard-failure.
- Bash robusto: `set -uo pipefail` (NON `-e`), `grep` solo dentro condizionali → un no-match non aborta mai lo step (cfr. regola GHA set-e/cmdsub in AGENTS.md).
- Testato il guard su 4 casi (errore 500 → exit 1; pulito → exit 0; outcome failure → exit 1; exec-file mancante → exit 0) + YAML parse OK.

## Non implementato (ancora)

- **Retry/auto-recovery in-workflow**: duplicherebbe il prompt inline della review (~40 righe) → drift hazard (AGENTS.md rule 6). Scelto fail-loud + re-run esplicito (ora ovvio grazie al run rosso). Auto-retry possibile follow-up se i 500 transitori diventano frequenti.

> Nota merge: questa PR modifica `pr-review-loop.yml` → il reviewer GitHub App non valida/posta (workflow-validation), quindi va **mergiata manualmente** (`gh pr merge --squash`), come da eccezione in AGENTS.md. Si valida sulla prossima PR organica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)