### PR TITLE
fix(offerwall): parse-time FC messaging loader + registry on static article pages

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -464,6 +464,48 @@ export const ADSENSE_LOADER_FILENAME = 'adsense-loader.js';
 export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/${ADSENSE_LOADER_FILENAME}"></script>`;
 
 /**
+ * Publisher id (no `ca-` prefix) for the Funding Choices endpoints, derived
+ * from {@link ADSENSE_CLIENT_ID} so it never drifts from the AdSense account.
+ */
+export const FC_PUBLISHER_ID = ADSENSE_CLIENT_ID.replace(/^ca-/, ''); // pub-8628054934855353
+
+/**
+ * Offerwall custom-choice registry + Funding Choices MESSAGING loader, injected
+ * PARSE-TIME into the <head> of in-scope STATIC article pages.
+ *
+ * WHY THIS EXISTS (2026-06-16): the GAM Offerwall is scoped to the article
+ * sections, which are emitted as static SSG HTML (staticPagesPlugin) whose head
+ * does NOT carry index.html's inline Offerwall block. On those pages the only
+ * Funding Choices loader that ever runs is the network-code one pulled in by
+ * adsbygoogle.js AFTER hydration — it fetches the Offerwall /f/ message (200,
+ * incl. our custom choice) but never instantiates the overlay. The publisher-id
+ * MESSAGING loader (`/i/pub-XXX`) — the one index.html uses on SPA roots and the
+ * one that actually renders FC messages — is absent. Injecting the registry +
+ * pub-id loader at PARSE TIME (before hydration and before adsbygoogle's
+ * network-code loader claims the singleton FC instance) brings article pages to
+ * parity with index.html's proven render path. (#2312 injected the same loader
+ * POST-hydration via the React gate and it never rendered, because FC was
+ * already singleton-initialised by the network-code loader — parse-time is the
+ * differentiator.)
+ *
+ * MUST stay byte-aligned with index.html's loadFc()/registry on the essentials
+ * (same pub-id loader URL, `data-fc-loader` dedup marker, NO crossOrigin — see
+ * tests/index-html-fc-loader.test.ts for the CORS rationale — googlefcPresent
+ * signal, requestIdleCallback/DOMContentLoaded deferral for LCP). The drift
+ * guard lives in tests/offerwall-static-fc-snippet.test.ts. The registry's
+ * behaviour mirrors components/community/OfferwallNewsletterGate.tsx
+ * (ensureOfferwallRegistry), which is idempotent (`if (cc.registry) return`) and
+ * so no-ops when this parse-time copy already set it — the gate still installs
+ * the window.__ftOfferwallSubscribe hook this registry delegates to.
+ *
+ * The anti-adblock fallback IIFE that index.html also runs from loadFc() is
+ * deliberately NOT included here — it is a separate feature, out of scope for
+ * the Offerwall render fix.
+ */
+export const OFFERWALL_FC_SNIPPET = `<script>(function(){var g=window.googlefc=window.googlefc||{};var ow=g.offerwall=g.offerwall||{};var cc=ow.customchoice=ow.customchoice||{};if(cc.registry)return;function subscribed(){try{return window.localStorage.getItem('newsletter_subscribed')==='true';}catch(e){return false;}}cc.registry={initialize:function(params){var E=cc.InitializeResponseEnum||{};if(subscribed()){return Promise.resolve(E.ACCESS_GRANTED||'ACCESS_GRANTED');}window.__ftOfferwallLang=(params&&params.offerwallLanguageCode)||null;return Promise.resolve(E.ACCESS_NOT_GRANTED||'ACCESS_NOT_GRANTED');},show:function(){var fn=window.__ftOfferwallSubscribe;if(typeof fn!=='function')return Promise.resolve(false);try{return Promise.resolve(fn(window.__ftOfferwallLang)).then(function(ok){return !!ok;});}catch(e){return Promise.resolve(false);}}};})();</script>
+ <script>(function(){function loadFc(){if(!document.querySelector('script[data-fc-loader]')){var s=document.createElement('script');s.async=true;s.src='https://fundingchoicesmessages.google.com/i/${FC_PUBLISHER_ID}?ers=1';s.setAttribute('data-fc-loader','1');document.head.appendChild(s);}(function sig(){if(!window.frames['googlefcPresent']){if(document.body){var f=document.createElement('iframe');f.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';f.style.display='none';f.name='googlefcPresent';document.body.appendChild(f);}else{setTimeout(sig,0);}}})();}function ricFb(cb){if(document.readyState==='complete'){setTimeout(cb,200);}else{window.addEventListener('load',function(){setTimeout(cb,200);},{once:true});}}function schedule(){(window.requestIdleCallback||ricFb)(loadFc,{timeout:4000});}if(document.readyState==='loading'){window.addEventListener('DOMContentLoaded',schedule,{once:true});}else{schedule();}})();</script>`;
+
+/**
  * Above-the-fold manual slot for drive-by SEO landings (health premiums,
  * fuel daily, border wait) — pages with 7-11s median sessions whose only
  * manual unit was the end-of-page ARTICLE_END_MULTIPLEX, far below the

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Plugin } from 'vite';
-import { BASE_URL, ANALYTICS_SNIPPET, DARK_MODE_SCRIPT, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
+import { BASE_URL, ANALYTICS_SNIPPET, OFFERWALL_FC_SNIPPET, DARK_MODE_SCRIPT, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
 import { WriteCollector } from './batchWrite';
 import { resolveSpaBundle } from './spaBundleResolver';
 import { resolveStaticPagesFlushed } from './shared/buildSignals';
@@ -4588,7 +4588,7 @@ ${hrefTags}
  ${stylesheetMarkup}${preloadTag}${getPagePreloads(urlPath, locale)}
  ${SEO_STATIC_CSS_LINK}
  <style>${skeletonAnim}</style>
- ${ANALYTICS_SNIPPET}
+ ${ANALYTICS_SNIPPET}${isBlogDetailPage ? `\n ${OFFERWALL_FC_SNIPPET}` : ''}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
  <script type="application/ld+json">${breadcrumbJsonLd}</script>${seoData.sd ? `\n <script type="application/ld+json">${seoData.sd}</script>` : ''}${speakableLd}

--- a/tests/offerwall-static-fc-snippet.test.ts
+++ b/tests/offerwall-static-fc-snippet.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Offerwall FC snippet for STATIC article pages — regression + drift guard.
+ *
+ * The GAM Offerwall is scoped to the article sections, which are emitted as
+ * static SSG HTML by build-plugins/staticPagesPlugin.ts. That HTML head does
+ * NOT carry index.html's inline Offerwall block, so on those pages the only
+ * Funding Choices loader that runs is the network-code one pulled in by
+ * adsbygoogle.js AFTER hydration — it fetches the Offerwall message but never
+ * renders the overlay. OFFERWALL_FC_SNIPPET injects the registry + the
+ * publisher-id MESSAGING loader at PARSE TIME so article pages reach parity
+ * with index.html's proven render path.
+ *
+ * This test pins the snippet contract and asserts it cannot drift from the
+ * index.html loader essentials (same pub-id loader URL, data-fc-loader marker,
+ * no crossOrigin — see tests/index-html-fc-loader.test.ts — googlefcPresent
+ * signal, deferred for LCP). index.html keeps its own inline copy because
+ * tests/index-html-fc-loader.test.ts pins the SOURCE file; the two copies are
+ * kept honest by cross-checking the loader URL here.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { OFFERWALL_FC_SNIPPET, FC_PUBLISHER_ID } from '../build-plugins/constants';
+
+const indexHtml = readFileSync(resolve(__dirname, '..', 'index.html'), 'utf8');
+
+describe('OFFERWALL_FC_SNIPPET — registry', () => {
+  it('creates the registry additively on window.googlefc.offerwall.customchoice', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/offerwall\s*=\s*g\.offerwall\s*\|\|\s*\{\}/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/customchoice\s*=\s*ow\.customchoice\s*\|\|\s*\{\}/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/if\s*\(\s*cc\.registry\s*\)\s*return/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/cc\.registry\s*=\s*\{/);
+  });
+
+  it('initialize() resolves ACCESS_GRANTED/NOT_GRANTED synchronously and stores the language', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/initialize\s*:\s*function/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/ACCESS_GRANTED/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/ACCESS_NOT_GRANTED/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/__ftOfferwallLang/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/Promise\.resolve/);
+  });
+
+  it('show() delegates to the React hook window.__ftOfferwallSubscribe', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/show\s*:\s*function/);
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/window\.__ftOfferwallSubscribe/);
+  });
+});
+
+describe('OFFERWALL_FC_SNIPPET — Funding Choices messaging loader', () => {
+  it('injects the publisher-id messaging loader (not the network-code one)', () => {
+    expect(OFFERWALL_FC_SNIPPET).toContain(
+      `fundingchoicesmessages.google.com/i/${FC_PUBLISHER_ID}?ers=1`,
+    );
+    // FC_PUBLISHER_ID is derived from the AdSense client id (no `ca-` prefix).
+    expect(FC_PUBLISHER_ID).toBe('pub-8628054934855353');
+  });
+
+  it('does NOT set crossOrigin on the FC loader <script> (would trigger CORS rejection)', () => {
+    expect(OFFERWALL_FC_SNIPPET).not.toMatch(/\.crossOrigin\s*=/);
+    expect(OFFERWALL_FC_SNIPPET).not.toMatch(/setAttribute\(\s*['"]crossorigin['"]/i);
+  });
+
+  it('marks the injected loader with data-fc-loader so we never double-inject', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/data-fc-loader/);
+  });
+
+  it('signals the googlefcPresent iframe so FC knows the loader ran', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/googlefcPresent/);
+  });
+
+  it('keeps the loader deferred (requestIdleCallback or DOMContentLoaded) — LCP safeguard', () => {
+    expect(OFFERWALL_FC_SNIPPET).toMatch(/requestIdleCallback|DOMContentLoaded/);
+  });
+
+  it('does NOT bundle the anti-adblock fallback IIFE (out of scope for the render fix)', () => {
+    // The obfuscated anti-adblock recovery in index.html registers a uniquely
+    // named global; it must not leak into this offerwall-only snippet.
+    expect(OFFERWALL_FC_SNIPPET).not.toContain('__h82AlnkH6D91__');
+  });
+});
+
+describe('OFFERWALL_FC_SNIPPET — parity with index.html (drift guard)', () => {
+  it('uses the same publisher-id FC loader URL that index.html injects', () => {
+    const loaderUrl = `fundingchoicesmessages.google.com/i/${FC_PUBLISHER_ID}`;
+    expect(indexHtml, 'index.html must still inject the pub-id FC loader').toContain(loaderUrl);
+    expect(OFFERWALL_FC_SNIPPET).toContain(loaderUrl);
+  });
+});


### PR DESCRIPTION
## Implementato

- **Root cause (live-diagnosed).** Caricando una pagina articolo in-scope con `?fc=alwaysshow&fctype=monetization`: `fundingchoices.../i/23355151813` → 200, poi `/f/AGSKW...` → 200 con payload ~99KB che contiene il renderer Offerwall **e** la nostra custom choice (`"Subscribe to the newsletter for free"`). Il messaggio Offerwall **arriva** al browser ma non viene mai istanziato nel DOM (nessun `.fc-message-root`). Sulle pagine articolo (HTML statico emesso da `staticPagesPlugin`) parte SOLO il loader FC **network-code** `/i/23355151813` (tirato da `adsbygoogle.js` post-hydration), NON il loader **publisher-id** `/i/pub-8628054934855353` — quello che `index.html` usa sulle SPA root e che renderizza davvero i messaggi FC.
- **Fix.** `OFFERWALL_FC_SNIPPET` (nuovo, in `build-plugins/constants.ts`): registry inline (sync) + loader FC publisher-id deferito (`requestIdleCallback`/`DOMContentLoaded`) + segnale `googlefcPresent`. Iniettato **parse-time** nell'`<head>` delle sole pagine **articolo detail** (`isBlogDetailPage`) in `staticPagesPlugin.ts`, accanto a `ANALYTICS_SNIPPET`. Parse-time = prima della hydration e prima che il loader network-code di adsbygoogle reclami l'istanza singleton di FC. Parità con il render-path già provato di `index.html`.
- **Perché non un re-add di #2312/#2337.** #2312 iniettava lo stesso loader pub-id **post-hydration** via il gate React e non renderizzava mai (FC già inizializzato dal loader network-code). Il differenziatore è il **parse-time**, non il loader in sé. Il gate (`ensureOfferwallRegistry`, idempotente `if (cc.registry) return`) continua a installare l'hook `__ftOfferwallSubscribe` e fa no-op sul registry già impostato parse-time.
- **No-drift (Non-negotiable #6).** `FC_PUBLISHER_ID` derivato da `ADSENSE_CLIENT_ID` (niente literal duplicato dell'id). Nuovo test `tests/offerwall-static-fc-snippet.test.ts` (10 test) pinna il contratto dello snippet **e** cross-checka che l'URL del loader pub-id sia identico a quello iniettato da `index.html`. `tests/index-html-fc-loader.test.ts` + `tests/offerwall-custom-choice.test.ts` restano verdi (21/21).
- **Sicurezza funnel.** Nessun `crossOrigin` sul loader FC (la regressione CORS pinnata da `index-html-fc-loader.test.ts`); loader deferito (LCP safeguard); Auto Ads e GTAG invariati; scope limitato alle pagine articolo (guard `isBlogDetailPage`).

## Non implementato (ancora)

- **Verifica del rendering Offerwall: NON possibile pre-merge.** Il fix non è verificabile sul `pull_request` — richiede un deploy SSG (OOM-prone locale) e poi un caricamento live di una pagina articolo. **Revert-trigger esplicito:** se dopo il deploy l'Offerwall ancora non renderizza su una pagina articolo in-scope (con `?fc=alwaysshow&fctype=monetization`), allora la causa è lato Google/FC-delivery, non l'integrazione → si escala a GAM support (bozza follow-up già pronta) e questo snippet va valutato per revert (è additivo/reversibile). Se invece appare → era il loader pub-id mancante parse-time, risolto.
- **Dedup totale con `index.html`.** `index.html` mantiene la propria copia inline del registry+loader perché `tests/index-html-fc-loader.test.ts` pinna il file SORGENTE; unificare richiederebbe un refactor del test + un `transformIndexHtml` (rischioso sul path revenue-critical). Le due copie sono tenute allineate dal cross-check di parità nel nuovo test. Follow-up possibile, non bloccante.
- **Anti-adblock fallback IIFE.** Escluso di proposito dallo snippet (feature separata, fuori scope dal fix di rendering Offerwall). Le pagine articolo non lo avevano nemmeno prima (loader pub-id assente del tutto).
- **Lingua default Offerwall en-US.** Il `/f/` torna in `en-US` benché la pagina sia `lang="it"`: è config console GAM (owner imposta IT default), non codice. Secondario, non bloccante.
- **Sibling sweep (#6).** `check-sibling-patterns.mjs` ha surfacato solo token generici (`ADSENSE_CLIENT_ID`, `crossOrigin`, `requestIdleCallback`) in file non correlati (analytics/loader vari) — nessuno condivide il costrutto offerwall/FC-loader. L'unico vero sibling è `index.html`, coperto da `FC_PUBLISHER_ID` condiviso + test di parità.

🤖 Generated with [Claude Code](https://claude.com/claude-code)