### PR TITLE
fix(offerwall): inject FC snippet in ogPagesPlugin (real owner of article pages)

### DIFF
--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import type { Plugin } from 'vite';
-import { BASE_URL, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
+import { BASE_URL, GTAG_SNIPPET, ADSENSE_SNIPPET, OFFERWALL_FC_SNIPPET, FAVICON_LINKS, SEO_STATIC_CSS_LINK, CDN_PRECONNECT_HINT } from './constants';
 import { buildArticleSeoSections, cleanupArticleBodySections } from './articleSeoFallback';
 import { WriteCollector } from './batchWrite';
 import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS, clampMetaDescription } from './shared/titleSuffix';
@@ -1097,6 +1097,7 @@ ${headTags}
  ${SEO_STATIC_CSS_LINK}
  ${GTAG_SNIPPET}
  ${ADSENSE_SNIPPET}
+ ${OFFERWALL_FC_SNIPPET}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
  <div id="root"><main id="main-content"><article><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline s-L_lk4l">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -4623,7 +4623,7 @@ ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
  <noscript><meta http-equiv="refresh" content="0;url=/?p=${pp}"></noscript>
  ${SEO_STATIC_CSS_LINK}
- ${ANALYTICS_SNIPPET}
+ ${ANALYTICS_SNIPPET}${isBlogDetailPage ? `\n ${OFFERWALL_FC_SNIPPET}` : ''}
  </head>
  <body>
  <script type="application/ld+json">${breadcrumbJsonLd}</script>${seoData.sd ? `\n <script type="application/ld+json">${seoData.sd}</script>` : ''}${speakableLd}

--- a/tests/offerwall-static-fc-snippet.test.ts
+++ b/tests/offerwall-static-fc-snippet.test.ts
@@ -89,3 +89,25 @@ describe('OFFERWALL_FC_SNIPPET — parity with index.html (drift guard)', () => 
     expect(OFFERWALL_FC_SNIPPET).toContain(loaderUrl);
   });
 });
+
+describe('OFFERWALL_FC_SNIPPET — wired into the article-page owners', () => {
+  // The GAM Offerwall is scoped to the article sections. Those pages are emitted
+  // by ogPagesPlugin (canonicalPrefix '/articoli-frontaliere/') — NOT staticPagesPlugin,
+  // which skips them ("already exist"). The snippet MUST be injected by ogPagesPlugin
+  // or the Offerwall never renders on article pages (the 2026-06-16 miss).
+  const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8');
+
+  it('ogPagesPlugin imports and injects OFFERWALL_FC_SNIPPET into the article <head>', () => {
+    const src = read('build-plugins/ogPagesPlugin.ts');
+    expect(src, 'ogPagesPlugin must import the snippet').toMatch(
+      /import\s*\{[^}]*OFFERWALL_FC_SNIPPET[^}]*\}\s*from\s*['"]\.\/constants['"]/,
+    );
+    // Injected right before the article <body class="bg-surface-alt …"> template.
+    expect(src).toMatch(/\$\{OFFERWALL_FC_SNIPPET\}\s*\n\s*<\/head>\s*\n\s*<body class="bg-surface-alt/);
+  });
+
+  it('staticPagesPlugin keeps the isBlogDetailPage-gated fallback injection', () => {
+    const src = read('build-plugins/staticPagesPlugin.ts');
+    expect(src).toMatch(/isBlogDetailPage\s*\?\s*`\\n\s*\$\{OFFERWALL_FC_SNIPPET\}`/);
+  });
+});


### PR DESCRIPTION
## Implementato

- **Root cause (live-diagnosed) della mancata resa Offerwall.** PR #2353 iniettava `OFFERWALL_FC_SNIPPET` in `staticPagesPlugin`, ma la verifica live ha mostrato che NON arrivava mai alle pagine articolo: le pagine detail (`/articoli-frontaliere/<slug>/`) sono emesse da **`ogPagesPlugin`** (`canonicalPrefix '/articoli-frontaliere/'`, `<body class="bg-surface-alt…">`, JSON-LD `NewsArticle`), e `staticPagesPlugin` le **SALTA** (`already exist` — 2677 skipped nel build log) perché og-pages le genera prima. Quindi l'iniezione in `staticPagesPlugin` era dead-code per gli articoli e l'HTML deployato aveva GTAG + AdSense ma nessun registry/loader FC → Offerwall ancora non renderizzato.
- **Fix.** Iniettato `OFFERWALL_FC_SNIPPET` nel template articolo primario di `ogPagesPlugin` (subito dopo `ADSENSE_SNIPPET`, prima di `</head>`), **incondizionato** — ogni pagina di quel plugin È un articolo in-scope. Il template (`bg-surface-alt` body + `div#root>main>article`) è byte-identico all'HTML servito live.
- **Fallback mantenuto.** Conservata l'iniezione gated `isBlogDetailPage` in `staticPagesPlugin` (entrambi i branch template — il 2° da #2353, il 3° aggiunto qui) come difesa-in-profondità per eventuali articoli non posseduti da og-pages. Innocua (gated), nessun impatto sulle pagine non-articolo.
- **Test.** Nuovo assert in `tests/offerwall-static-fc-snippet.test.ts`: `ogPagesPlugin` DEVE importare + iniettare `OFFERWALL_FC_SNIPPET` prima del `<body class="bg-surface-alt…">`, e `staticPagesPlugin` mantiene il fallback gated. 23/23 verdi. `tsc` pulito.

## Non implementato (ancora)

- **Verifica rendering Offerwall: NON possibile pre-merge** (SSG OOM locale). **Revert-trigger:** se dopo il deploy l'HTML articolo servito (`curl /articoli-frontaliere/<slug>/ | grep customchoice`) NON contiene il snippet, o l'Offerwall ancora non appare con `?fc=alwaysshow&fctype=monetization`, allora la causa residua è lato Google/FC-delivery → escala a GAM support (bozza pronta). Snippet additivo/reversibile.
- **Dedup `index.html` ↔ `OFFERWALL_FC_SNIPPET`.** Invariato da #2353: `index.html` tiene la copia inline (pinnata da `tests/index-html-fc-loader.test.ts`); drift guardato dal cross-check di parità nel test. Follow-up non bloccante.
- **Dead-code staticPagesPlugin.** Le iniezioni in `staticPagesPlugin` restano come fallback intenzionale (non rimosse) — giustificate sopra; se il reviewer le ritiene puro dead-code, rimovibili in follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)