### PR TITLE
ci: skip onnxruntime-node CUDA download to kill recurring npm ci flake

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,16 @@
+# Salta il download del binario CUDA/GPU di onnxruntime-node da nuget.org.
+# Il binario CPU e' gia' bundlato nel pacchetto npm; i runner CI e la prod
+# (Cloudflare) sono CPU-only e nessun codice richiede l'execution provider CUDA
+# (embeddings via build-evidence-index.mjs girano su CPU). Il download GPU
+# (microsoft.ml.onnxruntime.gpu.linux) e' un flake ricorrente di nuget.org
+# (ETIMEDOUT) che faceva rosso il gate vitest e bloccava l'auto-merge (PR #2363).
+# Lo script onnxruntime legge process.env.npm_config_onnxruntime_node_install_cuda,
+# quindi questa chiave .npmrc copre OGNI `npm ci`/`npm install` (CI + locale)
+# by-construction, senza dover editare i ~40 workflow uno per uno.
+onnxruntime-node-install-cuda=skip
+
+# Irrobustisce npm contro i flake di rete transienti del registry durante npm ci.
+fetch-retries=5
+fetch-retry-mintimeout=20000
+fetch-retry-maxtimeout=120000
+fetch-timeout=300000


### PR DESCRIPTION
## Contesto

PR #2363 non era stata auto-mergiata: il gate \`vitest (unit + integration)\` era rosso, ma **non** per un test fallito. Lo **shard 3/8 moriva durante \`npm ci\`** con \`ETIMEDOUT\` mentre il postinstall di \`onnxruntime-node\` scaricava il pacchetto **GPU/CUDA** (\`microsoft.ml.onnxruntime.gpu.linux\`) da nuget.org. Flake di rete infra ricorrente → gate rosso → auto-merge (che richiede \`vitest == success\`) bloccato. Rilanciato lo shard, è passato e la PR si è mergiata da sola.

Questo PR rimuove la **causa di classe** così il flake non si ripresenta.

## Implementato

- Aggiunto \`.npmrc\` a root con \`onnxruntime-node-install-cuda=skip\`: lo script di install di onnxruntime-node legge \`process.env.npm_config_onnxruntime_node_install_cuda\` (verificato su install-utils.js v1.26.0), quindi npm espone la chiave .npmrc come \`npm_config_*\` e il download GPU da nuget.org **non parte più**. Verificato localmente: \`npm_config_onnxruntime_node_install_cuda = skip\` arriva agli script.
- Aggiunti a \`.npmrc\` \`fetch-retries=5\` + \`fetch-retry-mintimeout/maxtimeout\` + \`fetch-timeout\`: irrobustiscono npm contro i flake transienti di rete del **registry** durante \`npm ci\` (classe più ampia).
- **Fix di classe by-construction**: un solo \`.npmrc\` a root copre TUTTI i ~40 workflow che fanno \`npm ci\` + gli install locali, senza editare ogni workflow (niente copy-paste per-file di un env var → niente drift).

## Sicurezza del cambio

- Il binario **CPU** di onnxruntime-node è bundlato nel pacchetto npm (solo gli extra GPU/CUDA vengono scaricati a install-time perché troppo grandi per il registry) → skippare CUDA **non** rompe l'inferenza CPU.
- Nessun codice del repo richiede l'execution provider CUDA (\`grep\` di \`executionProviders\`/\`cuda\` in services/scripts/build-plugins → solo testo di articoli). onnxruntime serve agli embeddings (\`build-evidence-index.mjs\` ecc.), sempre CPU.
- Runner CI e prod (Cloudflare) sono CPU-only: il pacchetto GPU non sarebbe comunque mai usabile.

## Non implementato (ancora)

- **Deprecation warning npm**: la chiave custom \`onnxruntime-node-install-cuda\` emette \`npm warn Unknown project config\` ("stop working in next major version of npm"). Cosmetico (exit 0, npm la passa comunque come env; le chiavi \`fetch-*\` sono config valide e non warnano). Resta funzionante fino a un futuro major di npm; nessuna alternativa single-point altrettanto pulita oggi (l'env var richiederebbe di toccare ~40 workflow). Da rivalutare se/quando il repo aggiorna a un npm che rimuove il passthrough.
- **Retry-wrapper esplicito attorno a \`npm ci\` nei workflow**: non aggiunto — sarebbe l'approccio per-file che il fix di classe via \`.npmrc\` evita; \`fetch-retries\` copre già il caso registry e lo skip CUDA elimina il downloader custom che floppava.
- Verifica live del verde su un \`npm ci\` reale: il prossimo \`tests\` run su questo branch eserciterà l'install con la nuova config.

Closes nessuna issue (flake non tracciato da issue).