### PR TITLE
feat(ads): desktop article side-rail half-page ads via GPT

### DIFF
--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -22,6 +22,7 @@ import type { LucideIcon } from 'lucide-react';
 import { PARTNERS, buildAffiliateUrl, type AffiliatePartner, type ComparatorContext } from '@/services/affiliateService';
 const AdSenseBanner = lazyRetry(() => import('@/components/shared/AdSenseBanner'));
 const GptPocSlot = lazyRetry(() => import('@/components/shared/GptPocSlot'));
+const ArticleRailAd = lazyRetry(() => import('@/components/shared/ArticleRailAd'));
 import { AD_SLOTS, isPlaceholderAdSlot } from '@/services/adsenseSlots';
 import Callout from '@/components/shared/Callout';
 import { resolveCompanyLogoUrl } from '@/services/jobDataNormalization';
@@ -1821,7 +1822,7 @@ function BlogArticles({
 
 
  return (
- <div className="max-w-3xl xl:max-w-6xl mx-auto">
+ <div className="max-w-3xl xl:max-w-6xl min-[1400px]:max-w-[1340px] 2xl:max-w-[1480px] mx-auto">
  {/* Reading progress bar */}
  <div
  className="fixed top-0 left-0 z-50 h-[3px] w-full bg-gradient-to-r from-accent-strong via-accent-strong to-accent-strong-hover transition-transform duration-150 ease-out origin-left [transform:var(--sx)]"
@@ -1843,8 +1844,9 @@ function BlogArticles({
  {t('blog.backToList')}
  </button>
 
- {/* 3-column grid: left rail | article | right rail */}
- <div className="xl:grid xl:grid-cols-[180px_1fr_180px] xl:gap-6">
+ {/* 3-column grid: left rail | article | right rail. Rails widen to 300px at
+     ≥1400px to host the half-page side-rail ads (ArticleRailAd). */}
+ <div className="xl:grid xl:grid-cols-[180px_1fr_180px] xl:gap-6 min-[1400px]:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop only) ── */}
  <aside className="hidden xl:block">
@@ -1853,7 +1855,8 @@ function BlogArticles({
  {t('affiliate.sectionTitle')}
  </p>
  {sidePartners.slice(0, 2).map((p, i) => <SideRailCard key={p.id} partner={p} idx={i} />)}
-
+ {/* Desktop half-page rail ad (≥1400px) — rides down the sticky gutter */}
+ <Suspense fallback={null}><ArticleRailAd side="left" enabled={adEligible} /></Suspense>
  </div>
  </aside>
 
@@ -2449,6 +2452,8 @@ function BlogArticles({
  <p className="text-sm text-muted leading-tight">
  {t('affiliate.disclosure')}
  </p>
+ {/* Desktop half-page rail ad (≥1400px) — rides down the sticky gutter */}
+ <Suspense fallback={null}><ArticleRailAd side="right" enabled={adEligible} /></Suspense>
  </div>
  </aside>
 

--- a/components/shared/ArticleRailAd.tsx
+++ b/components/shared/ArticleRailAd.tsx
@@ -1,0 +1,52 @@
+/**
+ * ArticleRailAd — desktop article side-rail GPT half-page ad (left or right).
+ *
+ * Fills the wide whitespace gutters beside the article column on large desktop
+ * viewports (the rails widen to 300px at ≥1400px — see BlogArticles). Serves a
+ * dedicated GAM ad unit (/23355151813/article-rail-{left,right}, sizes
+ * 300x600 / 160x600 / 300x250 + fluid, AdSense backfill on) via GPT, so AdSense
+ * Auto Ads keep serving untouched. Created programmatically by
+ * scripts/gam-create-rail-units.mjs.
+ *
+ * Lives inside the rail's existing `sticky top-6` stack, so the half-page ad
+ * rides down the gutter as the reader scrolls. Runtime kill-switch: Firebase
+ * Remote Config `KILL_ARTICLE_RAIL_ADS` (kills both rails, ~1 min, no redeploy;
+ * default-safe = shown). Visibility is also CSS-gated to ≥1400px by the caller.
+ */
+
+import React from 'react';
+import GptAdSlot, { type GptSize } from '@/components/shared/GptAdSlot';
+import { useKillSwitches } from '@/hooks/useKillSwitches';
+
+const RAIL_AD_UNIT_PATHS = {
+  left: '/23355151813/article-rail-left',
+  right: '/23355151813/article-rail-right',
+} as const;
+
+// Premium vertical display sizes first, box + fluid as fallback — must match
+// what the GAM ad unit allows (see scripts/gam-create-rail-units.mjs).
+const RAIL_SIZES: GptSize[] = [[300, 600], [160, 600], [300, 250], 'fluid'];
+
+export interface ArticleRailAdProps {
+  side: keyof typeof RAIL_AD_UNIT_PATHS;
+  /** Article-eligibility gate (long-enough body), wired from BlogArticles. */
+  enabled?: boolean;
+}
+
+const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true }) => {
+  const { articleRailAds: killed } = useKillSwitches();
+  return (
+    <GptAdSlot
+      adUnitPath={RAIL_AD_UNIT_PATHS[side]}
+      sizes={RAIL_SIZES}
+      killed={killed}
+      enabled={enabled}
+      minHeight={600}
+      // Not sticky itself — it sits inside the rail's `sticky top-6` stack so it
+      // rides down the gutter. CSS-gated to the widened (≥1400px) rail.
+      className="hidden min-[1400px]:block w-full text-center mt-3"
+    />
+  );
+};
+
+export default ArticleRailAd;

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -1,0 +1,182 @@
+/**
+ * GptAdSlot — generic Google Publisher Tag (GPT) display slot.
+ *
+ * Serves a GAM ad unit (via securepubads.g.doubleclick.net/tag/js/gpt.js) with
+ * AdSense dynamic-allocation backfilling unsold impressions. GPT (pubads) is
+ * independent of AdSense Auto Ads — this slot never touches adsbygoogle.js, so
+ * Auto Ads (~95% of revenue) keep serving untouched. See issue #2273.
+ *
+ * This is the shared engine behind both the PoC below-content slot
+ * ({@link GptPocSlot}) and the desktop article side-rail half-page units. The
+ * GPT framework (script load + enableServices) initialises once per page; each
+ * slot defines/displays into its own uniquely-id'd div, lazily via an
+ * IntersectionObserver so it stays off the LCP critical path.
+ *
+ * SAFETY: `GPT_ENABLED` is the master flag for the whole GPT stack. Each slot
+ * also takes a `killed` prop (wired to a Firebase Remote Config kill-switch by
+ * the caller) so a regressing surface can be turned off within ~1 min with no
+ * redeploy. Default-safe: renders `null` when inactive.
+ */
+
+import React, { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
+import { isLikelyBot } from '@/services/adAnalytics';
+
+// Master flag for the GPT stack (PoC activated in #2289). Flip to `false`
+// (one-line, then deploy) to disable every GPT slot if GPT serving regresses
+// AdSense Auto Ads / RPM / CWV.
+export const GPT_ENABLED = true;
+
+const GPT_SCRIPT_SRC = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
+
+const IS_PROD = typeof window !== 'undefined' && isAdSenseProductionHost(window.location.hostname);
+const SKIP_FOR_BOT = typeof window !== 'undefined' && isLikelyBot();
+
+/** A GPT slot size: a `[width, height]` pair or the responsive `'fluid'` token. */
+export type GptSize = [number, number] | 'fluid';
+
+let gptScriptRequested = false;
+let gptServicesEnabled = false;
+let slotSeq = 0;
+
+// Minimal GPT access — @types/google-publisher-tag is not a dependency, so we
+// reach googletag via an `any` view of window rather than a global type.
+const gtag = (): any => {
+  const w = window as any;
+  // Ensure `cmd` exists even when `window.googletag` was already created by
+  // another Google ad script WITHOUT a `cmd` queue — `|| { cmd: [] }` alone
+  // returns that partial object as-is and `gt.cmd.push` then throws
+  // "Cannot read properties of undefined (reading 'push')", so the slot never
+  // defines/serves (observed live on article pages).
+  const gt = (w.googletag = w.googletag || {});
+  gt.cmd = gt.cmd || [];
+  return gt;
+};
+
+function ensureGptScript(): void {
+  if (gptScriptRequested || typeof document === 'undefined') return;
+  gptScriptRequested = true;
+  gtag();
+  if (document.querySelector(`script[src="${GPT_SCRIPT_SRC}"]`)) return;
+  const s = document.createElement('script');
+  s.src = GPT_SCRIPT_SRC;
+  s.async = true;
+  s.crossOrigin = 'anonymous';
+  document.head.appendChild(s);
+}
+
+/** Initialise the GPT framework once (post-load idle, not on scroll): the GAM
+ *  Offerwall evaluates at page entry, so GPT must be present then. The ad slots
+ *  themselves stay lazy to protect CWV. */
+function initGptFramework(): void {
+  ensureGptScript();
+  const gt = gtag();
+  gt.cmd.push(() => {
+    try {
+      if (!gptServicesEnabled) {
+        gptServicesEnabled = true;
+        // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
+        gt.setConfig({ singleRequest: true });
+        gt.pubads().collapseEmptyDivs(true);
+        gt.enableServices();
+      }
+    } catch {
+      /* fail-soft */
+    }
+  });
+}
+
+export interface GptAdSlotProps {
+  /** Full GAM ad unit path, e.g. `/23355151813/article-rail-left`. */
+  adUnitPath: string;
+  /** Sizes to request; must match what the GAM ad unit allows. */
+  sizes: GptSize[];
+  /** Runtime kill-switch (caller wires it to Firebase Remote Config). */
+  killed?: boolean;
+  /** Extra eligibility gate (e.g. article long enough). Default `true`. */
+  enabled?: boolean;
+  /** Reserved min-height (px) to prevent CLS before the creative fills. */
+  minHeight?: number;
+  /** Wrapper classes (positioning / sizing). */
+  className?: string;
+  /** Inline wrapper style merged after the CLS-reserve defaults. */
+  style?: CSSProperties;
+}
+
+const GptAdSlot: React.FC<GptAdSlotProps> = ({
+  adUnitPath,
+  sizes,
+  killed = false,
+  enabled = true,
+  minHeight = 250,
+  className = 'mx-auto my-6 w-full max-w-[336px] text-center',
+  style,
+}) => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  // Stable, unique DOM id for this slot instance (GPT needs a real element id).
+  const divIdRef = useRef<string>(`gpt-slot-${++slotSeq}`);
+  const [rendered, setRendered] = useState(false);
+  const active = GPT_ENABLED && enabled && IS_PROD && !SKIP_FOR_BOT && !killed;
+
+  useEffect(() => {
+    if (!active) return;
+    const divId = divIdRef.current;
+
+    const ric: (cb: () => void) => void = (window as any).requestIdleCallback
+      ? (cb) => (window as any).requestIdleCallback(cb, { timeout: 3000 })
+      : (cb) => window.setTimeout(cb, 1200);
+    ric(initGptFramework);
+
+    const wrapper = wrapperRef.current;
+    if (!wrapper || typeof IntersectionObserver === 'undefined') return;
+    let defined = false;
+    const defineAndDisplay = () => {
+      if (defined) return;
+      defined = true;
+      ensureGptScript();
+      const gt = gtag();
+      gt.cmd.push(() => {
+        try {
+          const slot = gt.defineSlot(adUnitPath, sizes, divId)?.addService(gt.pubads());
+          if (!slot) return;
+          gt.display(divId);
+          setRendered(true);
+        } catch {
+          /* fail-soft: never let an ad break the page */
+        }
+      });
+    };
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            io.disconnect();
+            defineAndDisplay();
+            return;
+          }
+        }
+      },
+      { rootMargin: '200px 0px' },
+    );
+    io.observe(wrapper);
+    return () => io.disconnect();
+  }, [active, adUnitPath, sizes]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      ref={wrapperRef}
+      aria-hidden={!rendered}
+      // Reserve space to avoid CLS when the creative fills (mirrors
+      // placeholderMinHeight in services/adsenseSlots.ts).
+      style={{ minHeight, contain: 'layout', ...style }}
+      className={className}
+    >
+      <div id={divIdRef.current} />
+    </div>
+  );
+};
+
+export default GptAdSlot;

--- a/components/shared/GptPocSlot.tsx
+++ b/components/shared/GptPocSlot.tsx
@@ -1,161 +1,37 @@
 /**
- * GptPocSlot — proof-of-concept Google Publisher Tag (GPT) display slot.
+ * GptPocSlot — proof-of-concept GPT display slot below blog-article content.
  *
  * WHY: the GAM Offerwall (with the in-house newsletter custom choice) requires
- * the site to be tagged with GPT. Today the site serves via AdSense Auto Ads
- * (adsbygoogle.js) + Funding Choices only. This PoC validates that GPT can
- * serve a slot on a NON-funnel page (blog articles), with AdSense filling unsold
- * inventory (the linked AdSense account already backfills GAM ad units), WHILE
- * AdSense Auto Ads keep serving untouched. See issue #2273.
+ * the site to be tagged with GPT. This PoC validates that GPT can serve a slot
+ * on a NON-funnel page (blog articles), with AdSense filling unsold inventory,
+ * WHILE AdSense Auto Ads keep serving untouched. See issue #2273 / #2289.
  *
- * SAFETY: disabled by default (`GPT_POC_ENABLED = false`) → renders nothing, so
- * merging/deploying this file is a no-op for the live ad stack. To run the PoC,
- * flip the flag (and set a real ad unit path) and observe RPM / Auto Ads / CWV.
- * GPT (pubads) is independent of AdSense Auto Ads; this slot never touches
- * adsbygoogle.js. Lazy-loaded via IntersectionObserver (mirrors AdSenseBanner)
- * so it stays off the LCP critical path.
+ * Thin wrapper over the shared {@link GptAdSlot} engine (script load, framework
+ * init, lazy IntersectionObserver, prod/bot gating). Runtime kill-switch:
+ * Firebase Remote Config `KILL_GPT_POC_SLOT` (resolves `false` / shown on RC
+ * failure). The master GPT flag lives in GptAdSlot (`GPT_ENABLED`).
  */
 
-import React, { useEffect, useRef, useState } from 'react';
-import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
-import { isLikelyBot } from '@/services/adAnalytics';
+import React from 'react';
+import GptAdSlot, { type GptSize } from '@/components/shared/GptAdSlot';
 import { useKillSwitches } from '@/hooks/useKillSwitches';
 
-// ── PoC switches ────────────────────────────────────────────
-// PoC ACTIVATED (issue #2273): GPT now serves one display slot on blog articles
-// to validate GPT serving + AdSense backfill while AdSense Auto Ads keep serving.
-// Revert this to `false` (one-line, then deploy) if Auto Ads / RPM / CWV regress.
-const GPT_POC_ENABLED = true;
 // Full GAM ad unit path — the display ad unit created for this PoC in GAM
 // Inventory (ad unit id 23356816306, sizes 300x250 + fluid, AdSense backfill on).
 const GPT_POC_AD_UNIT_PATH = '/23355151813/gpt-poc-articoli';
 // Match the sizes the GAM ad unit actually allows (300x250 + fluid/responsive).
-const GPT_POC_SIZES = [[300, 250], 'fluid'];
-const GPT_SCRIPT_SRC = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
-
-const IS_PROD = typeof window !== 'undefined' && isAdSenseProductionHost(window.location.hostname);
-const SKIP_FOR_BOT = typeof window !== 'undefined' && isLikelyBot();
-
-let gptScriptRequested = false;
-let gptServicesEnabled = false;
-
-// Minimal GPT access — @types/google-publisher-tag is not a dependency, so we
-// reach googletag via an `any` view of window rather than a global type.
-const gtag = (): any => {
-  const w = window as any;
-  // Ensure `cmd` exists even when `window.googletag` was already created by
-  // another Google ad script WITHOUT a `cmd` queue — `|| { cmd: [] }` alone
-  // returns that partial object as-is and `gt.cmd.push` then throws
-  // "Cannot read properties of undefined (reading 'push')", so the slot never
-  // defines/serves (observed live on article pages).
-  const gt = w.googletag = w.googletag || {};
-  gt.cmd = gt.cmd || [];
-  return gt;
-};
-
-function ensureGptScript(): void {
-  if (gptScriptRequested || typeof document === 'undefined') return;
-  gptScriptRequested = true;
-  gtag();
-  if (document.querySelector(`script[src="${GPT_SCRIPT_SRC}"]`)) return;
-  const s = document.createElement('script');
-  s.src = GPT_SCRIPT_SRC;
-  s.async = true;
-  s.crossOrigin = 'anonymous';
-  document.head.appendChild(s);
-}
-
-let slotSeq = 0;
+const GPT_POC_SIZES: GptSize[] = [[300, 250], 'fluid'];
 
 const GptPocSlot: React.FC = () => {
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  // Stable, unique DOM id for this slot instance (GPT needs a real element id).
-  const divIdRef = useRef<string>(`gpt-poc-slot-${++slotSeq}`);
-  const [rendered, setRendered] = useState(false);
-  // Runtime kill-switch (Firebase Remote Config KILL_GPT_POC_SLOT). Flip to
-  // `true` in the RC console to stop serving the GPT slot within ~1 min — no
-  // redeploy — if it regresses AdSense Auto Ads / RPM / CWV. Default-safe:
-  // resolves `false` (slot shown) on RC failure.
   const { gptPocSlot: killed } = useKillSwitches();
-  const active = GPT_POC_ENABLED && IS_PROD && !SKIP_FOR_BOT && !killed;
-
-  useEffect(() => {
-    if (!active) return;
-    const divId = divIdRef.current;
-
-    // Initialise the GPT framework EARLY (post-load idle, not on scroll): the GAM
-    // Offerwall evaluates at page entry, so GPT must be present then or the wall
-    // never shows. The ad slot itself stays lazy (IntersectionObserver below) to
-    // protect CWV — only the lightweight gpt.js load + enableServices runs early.
-    const initGptFramework = () => {
-      ensureGptScript();
-      const gt = gtag();
-      gt.cmd.push(() => {
-        try {
-          if (!gptServicesEnabled) {
-            gptServicesEnabled = true;
-            // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
-            gt.setConfig({ singleRequest: true });
-            gt.pubads().collapseEmptyDivs(true);
-            gt.enableServices();
-          }
-        } catch { /* fail-soft */ }
-      });
-    };
-    const ric: (cb: () => void) => void =
-      (window as any).requestIdleCallback
-        ? (cb) => (window as any).requestIdleCallback(cb, { timeout: 3000 })
-        : (cb) => window.setTimeout(cb, 1200);
-    ric(initGptFramework);
-
-    const wrapper = wrapperRef.current;
-    if (!wrapper || typeof IntersectionObserver === 'undefined') return;
-    let defined = false;
-    const defineAndDisplay = () => {
-      if (defined) return;
-      defined = true;
-      ensureGptScript();
-      const gt = gtag();
-      gt.cmd.push(() => {
-        try {
-          const slot = gt
-            .defineSlot(GPT_POC_AD_UNIT_PATH, GPT_POC_SIZES, divId)
-            ?.addService(gt.pubads());
-          if (!slot) return;
-          gt.display(divId);
-          setRendered(true);
-        } catch {
-          /* fail-soft: never let a PoC ad break the page */
-        }
-      });
-    };
-
-    const io = new IntersectionObserver((entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          io.disconnect();
-          defineAndDisplay();
-          return;
-        }
-      }
-    }, { rootMargin: '200px 0px' });
-    io.observe(wrapper);
-    return () => io.disconnect();
-  }, [active]);
-
-  if (!active) return null;
-
   return (
-    <div
-      ref={wrapperRef}
-      aria-hidden={!rendered}
-      // Reserve space to avoid CLS when the creative fills (mirrors
-      // placeholderMinHeight in services/adsenseSlots.ts).
-      style={{ minHeight: 250, contain: 'layout' }}
+    <GptAdSlot
+      adUnitPath={GPT_POC_AD_UNIT_PATH}
+      sizes={GPT_POC_SIZES}
+      killed={killed}
+      minHeight={250}
       className="mx-auto my-6 w-full max-w-[336px] text-center"
-    >
-      <div id={divIdRef.current} />
-    </div>
+    />
   );
 };
 

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -28,7 +28,8 @@ export type KillSwitchKey =
   | 'jobMarket'
   | 'weeklyEmployers'
   | 'orphanLandings'
-  | 'gptPocSlot';
+  | 'gptPocSlot'
+  | 'articleRailAds';
 
 export type KillSwitchState = Readonly<Record<KillSwitchKey, boolean>>;
 
@@ -44,6 +45,7 @@ export const KILL_SWITCH_RC_KEYS: Readonly<Record<KillSwitchKey, string>> = {
   weeklyEmployers: 'KILL_WEEKLY_EMPLOYERS_LINKS',
   orphanLandings: 'KILL_ORPHAN_LANDINGS_LINKS',
   gptPocSlot: 'KILL_GPT_POC_SLOT',
+  articleRailAds: 'KILL_ARTICLE_RAIL_ADS',
 } as const;
 
 const DEFAULT_STATE: KillSwitchState = {
@@ -53,6 +55,7 @@ const DEFAULT_STATE: KillSwitchState = {
   weeklyEmployers: false,
   orphanLandings: false,
   gptPocSlot: false,
+  articleRailAds: false,
 } as const;
 
 function parseBooleanFlag(value: string | undefined | null): boolean {

--- a/scripts/gam-create-rail-units.mjs
+++ b/scripts/gam-create-rail-units.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Create (or reuse) the desktop article side-rail ad units in Google Ad Manager,
+ * then print the GPT ad-unit paths to wire into the front-end.
+ *
+ * WHY GAM (not AdSense): the original AdSense rail units were archived in the
+ * 2026-04-26 prune, and the AdSense Management API v2 cannot create ad units
+ * for this account (POST adunits → 403 PERMISSION_DENIED) nor reactivate an
+ * archived one (state is read-only). The site already serves a GPT slot
+ * (/23355151813/gpt-poc-articoli, issue #2273/#2289) via Google Ad Manager with
+ * AdSense backfill, and the service account IS a user on GAM network
+ * 23355151813 — so the supported programmatic path is GAM InventoryService
+ * .createAdUnits + serve via GPT. AdSense dynamic-allocation backfills unsold
+ * impressions, so fill stays comparable to a plain AdSense unit while Auto Ads
+ * keep serving untouched.
+ *
+ * Each rail unit allows the premium vertical display sizes (300x600 half-page,
+ * 160x600 wide skyscraper) plus 300x250 + fluid as a fallback, mirroring the
+ * PoC unit's BROWSER/fluid/AdSense-enabled config. AdSense settings are
+ * inherited from the network root (already AdSense-enabled).
+ *
+ * Auth: service-account JSON with GAM (dfp) access on the network.
+ *   GOOGLE_APPLICATION_CREDENTIALS=./mcp-gsc-main/service_account_credentials.json
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/gam-create-rail-units.mjs            # create/reuse
+ *   ... node scripts/gam-create-rail-units.mjs --dry-run  # list only, no writes
+ */
+import { readFileSync } from 'node:fs';
+import { createSign } from 'node:crypto';
+
+const VER = 'v202511';
+const NETWORK_CODE = '23355151813';
+const APP_NAME = 'frontaliere-rail';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const TARGETS = [
+  { adUnitCode: 'article-rail-left', name: 'Article rail — left (desktop)' },
+  { adUnitCode: 'article-rail-right', name: 'Article rail — right (desktop)' },
+];
+// Premium vertical display sizes first, box + fluid as fallback.
+const SIZES = [[300, 600], [160, 600], [300, 250]];
+
+const saPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (!saPath) { console.error('✗ set GOOGLE_APPLICATION_CREDENTIALS to the GAM service-account JSON'); process.exit(1); }
+const sa = JSON.parse(readFileSync(saPath, 'utf8'));
+
+const b64url = (b) => Buffer.from(b).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+
+async function getToken() {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const claim = b64url(JSON.stringify({
+    iss: sa.client_email,
+    scope: 'https://www.googleapis.com/auth/dfp',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now, exp: now + 3600,
+  }));
+  const signer = createSign('RSA-SHA256'); signer.update(`${header}.${claim}`); signer.end();
+  const jwt = `${header}.${claim}.${b64url(signer.sign(sa.private_key))}`;
+  const r = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    body: new URLSearchParams({ grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer', assertion: jwt }),
+  });
+  const j = await r.json();
+  if (!r.ok) throw new Error('SA token failed: ' + JSON.stringify(j));
+  return j.access_token;
+}
+
+function escapeXml(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+async function soap(token, service, bodyXml) {
+  const env = `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
+    `<soap:Header><ns1:RequestHeader xmlns:ns1="https://www.google.com/apis/ads/publisher/${VER}">` +
+    `<ns1:networkCode>${NETWORK_CODE}</ns1:networkCode><ns1:applicationName>${APP_NAME}</ns1:applicationName>` +
+    `</ns1:RequestHeader></soap:Header><soap:Body>${bodyXml}</soap:Body></soap:Envelope>`;
+  const r = await fetch(`https://ads.google.com/apis/ads/publisher/${VER}/${service}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/xml; charset=utf-8', Authorization: `Bearer ${token}`, SOAPAction: '' },
+    body: env,
+  });
+  const text = await r.text();
+  const fault = (text.match(/<faultstring>([^<]+)<\/faultstring>/) || [])[1];
+  if (!r.ok || fault) throw new Error(`${service} → ${r.status} ${fault || text.slice(0, 300)}`);
+  return text;
+}
+
+async function findByCode(token, adUnitCode) {
+  const xml = `<getAdUnitsByStatement xmlns="https://www.google.com/apis/ads/publisher/${VER}">` +
+    `<filterStatement><query>WHERE adUnitCode = '${adUnitCode}'</query></filterStatement></getAdUnitsByStatement>`;
+  const res = await soap(token, 'InventoryService', xml);
+  if (/<totalResultSetSize>0<\/totalResultSetSize>/.test(res)) return null;
+  return (res.match(/<id>(\d+)<\/id>/) || [])[1] || null;
+}
+
+function adUnitXml(parentId, t) {
+  const sizesXml = SIZES.map(([w, h]) =>
+    `<adUnitSizes><size><width>${w}</width><height>${h}</height><isAspectRatio>false</isAspectRatio></size>` +
+    `<environmentType>BROWSER</environmentType></adUnitSizes>`).join('');
+  // Element order must follow the AdUnit XSD: parentId, name, targetWindow,
+  // adUnitCode, adUnitSizes, isFluid.
+  return `<adUnits>` +
+    `<parentId>${parentId}</parentId>` +
+    `<name>${escapeXml(t.name)}</name>` +
+    `<targetWindow>TOP</targetWindow>` +
+    `<adUnitCode>${escapeXml(t.adUnitCode)}</adUnitCode>` +
+    sizesXml +
+    `<isFluid>true</isFluid>` +
+    `</adUnits>`;
+}
+
+async function main() {
+  const token = await getToken();
+
+  // Network root (parent for new units).
+  const net = await soap(token, 'NetworkService', `<getCurrentNetwork xmlns="https://www.google.com/apis/ads/publisher/${VER}"/>`);
+  const rootId = (net.match(/<effectiveRootAdUnitId>(\d+)<\/effectiveRootAdUnitId>/) || [])[1];
+  if (!rootId) throw new Error('could not resolve effectiveRootAdUnitId');
+  console.log(`network ${NETWORK_CODE} root adUnit ${rootId}`);
+
+  const results = {};
+  const toCreate = [];
+  for (const t of TARGETS) {
+    const existing = await findByCode(token, t.adUnitCode);
+    if (existing) {
+      results[t.adUnitCode] = existing;
+      console.log(`= reuse  ${t.adUnitCode.padEnd(20)} id=${existing}  →  /${NETWORK_CODE}/${t.adUnitCode}`);
+    } else {
+      toCreate.push(t);
+    }
+  }
+
+  if (toCreate.length && !DRY_RUN) {
+    const xml = `<createAdUnits xmlns="https://www.google.com/apis/ads/publisher/${VER}">` +
+      toCreate.map((t) => adUnitXml(rootId, t)).join('') + `</createAdUnits>`;
+    const res = await soap(token, 'InventoryService', xml);
+    // Each created AdUnit is a <results>… block; its own id is the FIRST <id>
+    // inside the block (a later <parentPath><id> holds the root id — don't grab
+    // that). Response order matches request order.
+    const ids = res.split('<results>').slice(1)
+      .map((block) => (block.match(/<id>(\d+)<\/id>/) || [])[1]);
+    toCreate.forEach((t, i) => {
+      results[t.adUnitCode] = ids[i];
+      console.log(`+ create ${t.adUnitCode.padEnd(20)} id=${ids[i]}  →  /${NETWORK_CODE}/${t.adUnitCode}`);
+    });
+  } else if (toCreate.length) {
+    for (const t of toCreate) console.log(`+ would create ${t.adUnitCode.padEnd(18)} →  /${NETWORK_CODE}/${t.adUnitCode}`);
+  }
+
+  console.log('\nGPT ad-unit paths (wire into the front-end rail slots):');
+  for (const t of TARGETS) console.log(`  ${t.adUnitCode.padEnd(20)} /${NETWORK_CODE}/${t.adUnitCode}`);
+}
+
+main().catch((e) => { console.error('\n✗ failed:', e.message); process.exit(1); });

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -78,6 +78,10 @@ const REMOTE_CONFIG_DEFAULTS: Record<string, string> = {
  // SHOWN. Flip to 'true' in the Remote Config console to kill the GPT slot
  // within ~1 min (no redeploy) if it regresses AdSense Auto Ads / RPM / CWV.
  KILL_GPT_POC_SLOT: 'false',
+ // Desktop article side-rail GPT half-page ad units (left + right). Default
+ // 'false' = rails SHOWN. Flip to 'true' in the Remote Config console to kill
+ // both rail ads within ~1 min (no redeploy) if they regress Auto Ads / RPM / CWV.
+ KILL_ARTICLE_RAIL_ADS: 'false',
  // E3: Inline consulting CTA on calculator results view.
  // Default 'true' so the CTA is visible until explicitly disabled via Firebase
  // Remote Config console. Flip to 'false' to hide the CTA without a redeploy.

--- a/tests/use-kill-switches.test.ts
+++ b/tests/use-kill-switches.test.ts
@@ -24,6 +24,7 @@ describe('useKillSwitches', () => {
       weeklyEmployers: false,
       orphanLandings: false,
       gptPocSlot: false,
+      articleRailAds: false,
     });
   });
 
@@ -43,6 +44,7 @@ describe('useKillSwitches', () => {
     expect(result.current.weeklyEmployers).toBe(false);
     expect(result.current.orphanLandings).toBe(false);
     expect(result.current.gptPocSlot).toBe(false);
+    expect(result.current.articleRailAds).toBe(false);
   });
 
   it('reads each RC parameter name and returns true when the flag is "true"', async () => {
@@ -69,6 +71,7 @@ describe('useKillSwitches', () => {
       weeklyEmployers: false,
       orphanLandings: true,
       gptPocSlot: true,
+      articleRailAds: false,
     });
   });
 
@@ -78,7 +81,7 @@ describe('useKillSwitches', () => {
     renderHook(() => useKillSwitches());
 
     await waitFor(() => {
-      expect(rcMock).toHaveBeenCalledTimes(6);
+      expect(rcMock).toHaveBeenCalledTimes(7);
     });
 
     const callArgs = rcMock.mock.calls.map(([arg]) => arg);
@@ -88,5 +91,6 @@ describe('useKillSwitches', () => {
     expect(callArgs).toContain('KILL_WEEKLY_EMPLOYERS_LINKS');
     expect(callArgs).toContain('KILL_ORPHAN_LANDINGS_LINKS');
     expect(callArgs).toContain('KILL_GPT_POC_SLOT');
+    expect(callArgs).toContain('KILL_ARTICLE_RAIL_ADS');
   });
 });


### PR DESCRIPTION
## Implementato

Riempie i grandi spazi bianchi laterali degli articoli su desktop con ad **half-page verticali**, solo su viewport larghi, **senza toccare AdSense Auto Ads** (~95% revenue).

**Scelta tecnica — GPT + GAM (non AdSense):** i vecchi rail-unit AdSense erano stati archiviati nel prune 2026-04-26 e **non sono ricreabili via AdSense Management API** (`POST adunits` → `403 PERMISSION_DENIED`; gli archiviati sono read-only su `state`). Il service account `gsc-service-account@frontaliere-ticino` **è utente sulla rete GAM 23355151813**, quindi gli ad unit sono creati **programmaticamente in Google Ad Manager** (`InventoryService.createAdUnits`) e serviti via **GPT con backfill AdSense dynamic-allocation** — stessa pipeline già live per il PoC slot (#2289). Auto Ads restano intatte (GPT/pubads è indipendente da `adsbygoogle.js`).

- **`scripts/gam-create-rail-units.mjs`**: creatore idempotente di ad unit GAM (sizes `300x600` half-page / `160x600` skyscraper / `300x250` + fluid, AdSense backfill ereditato dalla root). **Già eseguito** → `/23355151813/article-rail-left` e `/23355151813/article-rail-right` ACTIVE, `adSenseEnabled=true` (verificato via API).
- **`components/shared/GptAdSlot.tsx`**: engine GPT generico (load script, init framework once, lazy `IntersectionObserver`, gating prod/bot). `GptPocSlot` ora è un thin wrapper su di esso → **niente duplicazione** della logica `gtag`/`ensureGptScript` (AGENTS.md #6).
- **`components/shared/ArticleRailAd.tsx`**: ad half-page left/right, vive dentro lo stack `sticky top-6` del rail → **scende lungo il gutter** mentre si scrolla ("fino a fondo pagina").
- **`components/community/BlogArticles.tsx`**: i rail si allargano da 180px → **300px a ≥1400px** (grid `[300px_minmax(0,1fr)_300px]`, container `1340px`/`1480px@2xl`) per ospitare gli ad; gating su `adEligible` (articolo lungo) + `hidden min-[1400px]:block` (nessuna richiesta sotto 1400px → no inflation della coverage come i vecchi rail skinny).
- **Kill-switch `KILL_ARTICLE_RAIL_ADS`** (Firebase Remote Config, ~1 min, no redeploy; default-safe = mostrato): `hooks/useKillSwitches.ts` + `services/firebase.ts` + test aggiornato.
- **CLS**: `minHeight:600` + `contain:layout` riservano lo spazio prima del fill; `collapseEmptyDivs(true)` collassa se non riempito.

## Non implementato (ancora)

- **Verifica fill live**: gli ad unit sono nuovi; il serving GPT+backfill AdSense è verificabile solo sul dominio prod (gate `IS_PROD`) post-deploy — i nuovi unit possono impiegare poco a diventare eligibili al backfill. **Revert-trigger**: se post-deploy le Auto Ads / RPM / CWV regrediscono o gli unit non riempiono → flip `KILL_ARTICLE_RAIL_ADS=true` (istantaneo) o `GPT_ENABLED=false` in `GptAdSlot.tsx`. Da osservare su `main` post-merge (non validabile su `pull_request`).
- **Ultra-wide (>1536px)**: container cappato a `1480px@2xl` per leggibilità; su monitor molto larghi resta margine esterno. Out of scope (trade-off readability vs riempimento) — eventuale follow-up con rail più larghi/centro più ampio.
- **Mobile**: invariato (rail `hidden xl:block`, ad `hidden min-[1400px]:block`); il task riguarda solo il whitespace desktop.
- **Sibling sweep** (AGENTS.md #6): l'infra GPT è centralizzata in `GptAdSlot`; nessun altro consumer GPT da aggiornare oltre `GptPocSlot` (già migrato). Nessun pattern duplicato funnel-critical introdotto.