### PR TITLE
feat(ci): auto-close Workflow/Crawler Failure issues on recovery

### DIFF
--- a/.github/workflows/close-recovered-failure-issues.yml
+++ b/.github/workflows/close-recovered-failure-issues.yml
@@ -1,0 +1,53 @@
+name: Close Recovered Failure Issues
+
+# Zero-Claude reconciler: auto-closes the auto-generated `Workflow Failure: <name>` /
+# `Crawler Failure: <name>` issues once the workflow has recovered (its next run after
+# the failure is green again). Mirrors the inline `github-issue-creator.mjs --resolve`
+# step centrally so EVERY scheduled workflow — present and future — gets its failure
+# issue closed on recovery, without wiring a per-workflow step into ~300 YAML files.
+# See scripts/ci/close-recovered-failure-issues.mjs.
+
+on:
+  schedule:
+    # Hourly: failures recover within a workflow's own cadence (fuel ~2h, crawlers daily);
+    # an hourly sweep closes the recovered issue without hammering the API.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be closed without mutating'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: close-recovered-failure-issues
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Close recovered failure issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          ARGS=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="--dry-run"
+          fi
+          node scripts/ci/close-recovered-failure-issues.mjs $ARGS

--- a/scripts/ci/close-recovered-failure-issues.mjs
+++ b/scripts/ci/close-recovered-failure-issues.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * close-recovered-failure-issues.mjs — zero-Claude reconciler.
+ *
+ * Auto-closes the auto-generated `Workflow Failure: <name>` / `Crawler Failure: <name>`
+ * issues once the workflow has recovered — i.e. its NEXT run after the failure is green.
+ *
+ * WHY this is centralized (one reconciler, not 300 per-workflow steps):
+ * Every scheduled workflow already opens a stable-titled issue on `if: failure()` via
+ * scripts/lib/github-issue-creator.mjs. The mirror `--resolve` step (close on green) was
+ * only ever wired into ~5 workflows (deploy/lighthouse/post-deploy/watchdog), so the
+ * ~300 `update-jobs-*` crawlers, `update-fuel-prices`, `quality-alerts`, etc. left their
+ * failure issue OPEN even when the very next run went green (e.g. #2354: failed run
+ * 27646211111, then two green runs, issue stayed open). Wiring `--resolve` into every
+ * workflow file = 300-file churn that silently misses any future workflow. Instead this
+ * single cron job reconciles ALL of them — present and future — by construction.
+ *
+ * ALGORITHM (per open failure issue):
+ *   1. Parse the workflow display name out of the stable title prefix.
+ *   2. Ask GitHub for that workflow's most-recent COMPLETED run on `main`.
+ *   3. If that run is `success` AND started after the issue was opened (so it is a run
+ *      that happened *after* the reported failure, not a stale pre-failure green) →
+ *      close the issue via the same resolveGithubIssue() the inline `--resolve` uses
+ *      (posts the "✅ Auto-resolved — green again" comment; reopens automatically if the
+ *      same failure recurs).
+ *   4. Otherwise (latest completed run still red, or no completed run / renamed workflow)
+ *      → leave the issue open. Bias is conservative: never close while currently red.
+ *
+ * Best-effort and idempotent: safe to run on a schedule. `--dry-run` reports without
+ * mutating. Scope is strictly the two auto-generated failure-title prefixes; follow-up,
+ * tracker, validation-failure and other issues are never touched.
+ */
+import { execFileSync } from 'node:child_process';
+import { resolveGithubIssue } from '../lib/github-issue-creator.mjs';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+// Stable titles minted by github-issue-creator.mjs failure reporters. Group 2 is the
+// workflow display name, which equals `github.workflow` (and `gh run list -w <name>`).
+const TITLE_RE = /^(?:Workflow|Crawler) Failure: (.+)$/;
+const REPO = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
+
+function repoFlag() {
+  return REPO ? ['--repo', REPO] : [];
+}
+
+function gh(args, { allowFailure = false } = {}) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  } catch (err) {
+    if (allowFailure) return null;
+    throw err;
+  }
+}
+
+function listFailureIssues() {
+  const out = gh([
+    'issue', 'list', '--state', 'open', '--limit', '300',
+    '--json', 'number,title,createdAt', ...repoFlag(),
+  ]);
+  return JSON.parse(out)
+    .map((i) => ({ issue: i, m: TITLE_RE.exec(i.title) }))
+    .filter(({ m }) => m)
+    .map(({ issue, m }) => ({
+      number: issue.number,
+      title: issue.title,
+      createdAt: issue.createdAt,
+      workflow: m[1].trim(),
+    }));
+}
+
+// Most-recent COMPLETED run of the named workflow on main, or null if the workflow has
+// no runs (e.g. renamed/deleted) — in which case we conservatively leave the issue open.
+function latestCompletedRun(workflowName) {
+  const out = gh([
+    'run', 'list', '-w', workflowName, '-b', 'main', '-L', '20',
+    '--json', 'databaseId,conclusion,status,createdAt', ...repoFlag(),
+  ], { allowFailure: true });
+  if (out === null) return null;
+  let runs;
+  try {
+    runs = JSON.parse(out);
+  } catch {
+    return null;
+  }
+  return runs.find((r) => r.status === 'completed') || null;
+}
+
+function main() {
+  const issues = listFailureIssues();
+  console.log(`[close-recovered] ${issues.length} open Workflow/Crawler Failure issue(s)${DRY_RUN ? ' (dry-run)' : ''}`);
+  let closed = 0;
+  let kept = 0;
+  let skipped = 0;
+
+  for (const it of issues) {
+    const run = latestCompletedRun(it.workflow);
+    if (!run) {
+      console.log(`  #${it.number} "${it.workflow}" — no completed run on main (renamed/deleted?), keep open`);
+      skipped++;
+      continue;
+    }
+    const green = run.conclusion === 'success';
+    // The failing run that opened the issue started BEFORE the issue's createdAt (the
+    // reporter step runs after the job failed). So a green run created at/after the issue
+    // is necessarily a LATER run — the "next run is ok" the user asked for.
+    const afterFailure = Date.parse(run.createdAt) >= Date.parse(it.createdAt);
+
+    if (green && afterFailure) {
+      const runUrl = REPO ? `https://github.com/${REPO}/actions/runs/${run.databaseId}` : undefined;
+      if (DRY_RUN) {
+        console.log(`  #${it.number} WOULD CLOSE — recovered (run ${run.databaseId} success @ ${run.createdAt})`);
+      } else {
+        resolveGithubIssue(it.title, { workflow: it.workflow, runUrl });
+        console.log(`  #${it.number} CLOSED — recovered via run ${run.databaseId}`);
+      }
+      closed++;
+    } else if (green && !afterFailure) {
+      console.log(`  #${it.number} latest green run ${run.databaseId} predates issue — keep open`);
+      kept++;
+    } else {
+      console.log(`  #${it.number} still red (latest completed run ${run.databaseId}=${run.conclusion}) — keep open`);
+      kept++;
+    }
+  }
+
+  console.log(`[close-recovered] done: closed=${closed} kept=${kept} skipped=${skipped}`);
+}
+
+main();


### PR DESCRIPTION
## Implementato

Reconciler centralizzato **zero-Claude** che chiude automaticamente le issue auto-generate `Workflow Failure: <name>` / `Crawler Failure: <name>` quando il workflow è recuperato — cioè il suo **run successivo alla failure è di nuovo verde**.

- `scripts/ci/close-recovered-failure-issues.mjs`: per ogni issue aperta con quel prefisso titolo, estrae il nome-workflow, interroga `gh run list -w <name> -b main` per l'ultimo run **completato**; se è `success` **e** partito dopo l'apertura della issue (quindi un run *posteriore* alla failure riportata) → chiude via `resolveGithubIssue()` (lo stesso closer dell'inline `--resolve`, posta il commento "✅ Auto-resolved — green again" e riapre da solo se la failure ricorre). Se l'ultimo run completato è ancora rosso → lascia aperta (bias conservativo). `--dry-run` per report senza mutazioni.
- `.github/workflows/close-recovered-failure-issues.yml`: cron orario (`17 * * * *`) + `workflow_dispatch` (con input `dry_run`). Solo `GH_TOKEN`, nessuna credenziale Firebase.

**Perché centralizzato e non per-workflow:** il closer inline `github-issue-creator.mjs --resolve` era cablato solo in ~5 workflow (deploy/lighthouse/post-deploy/watchdog). I ~300 `update-jobs-*`, `update-fuel-prices`, `quality-alerts`, ecc. aprivano la failure-issue ma non la chiudevano mai su recovery (es. #2354: fuel fallito run 27646211111, poi due run verdi, issue rimasta aperta). Cablare `--resolve` in ogni file = churn su 300 YAML che mancherebbe comunque ogni workflow futuro. Un solo cron li riconcilia **tutti, presenti e futuri**, by-construction.

**Validato in dry-run live** sulle 10 failure-issue aperte: chiude le 3 recuperate (**#2354 — l'esempio dell'utente —**, #2351, #2316), lascia aperte le 7 il cui ultimo run completato è ancora `failure`. Scope ristretto ai due prefissi auto-generati: follow-up, tracker strategici, validation-failure non vengono mai toccati.

## Non implementato (ancora)

- **Non rimosso** l'inline `--resolve` dai 5 workflow che già ce l'hanno (deploy/lighthouse/post-deploy-validate-{live,dist}/border-live-data-watchdog): l'overlap col reconciler è idempotente e innocuo (entrambi chiudono per title-prefix); rimuoverli sarebbe churn fuori scope.
- **Sibling-check** (`check-sibling-patterns.mjs`) segnala 6 file gemello: falsi-positivi euristici — `github-issue-creator.mjs` condivide `resolveGithubIssue`/`repoFlag`/`allowFailure` perché il nuovo script li **riusa/specchia** (boilerplate `gh()` triviale già duplicato in molti `scripts/ci/*`, non un antipattern); gli altri 5 condividono solo il nome-campo JSON `databaseId` di `gh run list`. Nessun antipattern condiviso da sweepare.
- Cadenza oraria scelta come compromesso frugale; non parametrizzata.