### PR TITLE
fix(firestore): collectionGroup campaign_id indexes for newsletter A/B report

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -130,6 +130,20 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "campaign_deliveries",
+      "fieldPath": "campaign_id",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "fieldPath": "campaign_id",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Implementato
- Aggiunti 2 `fieldOverrides` COLLECTION_GROUP ASC in `firestore.indexes.json`:
  - `campaign_deliveries.campaign_id` (denominatore: sends)
  - `events.campaign_id` (numeratore: opens)
- Sblocca `scripts/newsletter-ab-report.mjs`, che fa due `collectionGroup(group).where('campaign_id','==',…)` (vedi `scripts/lib/newsletter-ab-data.mjs:43`). Senza questi index il report falliva con `9 FAILED_PRECONDITION` una volta che la SA ha ottenuto il read Firestore (il `7 PERMISSION_DENIED` precedente era IAM, risolto a monte con il grant `datastore` alla SA).
- Index già **deployati live** via `firebase deploy --only firestore:indexes` (additivo, no `--force`) → in build; `deploy-firestore-rules.yml` li riconcilia al merge (idempotente).

## Non implementato (ancora)
- Permessi IAM della SA: gestiti fuori-repo (grant `datastore` + ruoli viewer diagnostici applicati direttamente), non versionabili qui — out of scope per un file di index.
- Drift backend: `firebase deploy` ha segnalato 1 index presente in prod ma assente dal file; NON rimosso (no `--force`) e non in scope qui — eventuale riconciliazione separata.
- Permessi Firestore security rules: non toccati; l'Admin SDK bypassa le rules, il blocco era puramente IAM+index.