### PR TITLE
feat(ci): cover 'CI Failure:' prefix in recovery auto-close

### DIFF
--- a/.github/workflows/close-recovered-failure-issues.yml
+++ b/.github/workflows/close-recovered-failure-issues.yml
@@ -1,7 +1,7 @@
 name: Close Recovered Failure Issues
 
 # Zero-Claude reconciler: auto-closes the auto-generated `Workflow Failure: <name>` /
-# `Crawler Failure: <name>` issues once the workflow has recovered (its next run after
+# `Crawler Failure: <name>` / `CI Failure: <name>` issues once the workflow has recovered (its next run after
 # the failure is green again). Mirrors the inline `github-issue-creator.mjs --resolve`
 # step centrally so EVERY scheduled workflow — present and future — gets its failure
 # issue closed on recovery, without wiring a per-workflow step into ~300 YAML files.

--- a/scripts/ci/close-recovered-failure-issues.mjs
+++ b/scripts/ci/close-recovered-failure-issues.mjs
@@ -2,8 +2,10 @@
 /**
  * close-recovered-failure-issues.mjs — zero-Claude reconciler.
  *
- * Auto-closes the auto-generated `Workflow Failure: <name>` / `Crawler Failure: <name>`
- * issues once the workflow has recovered — i.e. its NEXT run after the failure is green.
+ * Auto-closes the auto-generated `Workflow Failure: <name>` / `Crawler Failure: <name>` /
+ * `CI Failure: <name>` issues once the workflow has recovered — i.e. its NEXT run after
+ * the failure is green. These three are the only failure-title prefixes minted by the
+ * github-issue-creator.mjs reporters across all workflows (Crawler 439, Workflow 50, CI 8).
  *
  * WHY this is centralized (one reconciler, not 300 per-workflow steps):
  * Every scheduled workflow already opens a stable-titled issue on `if: failure()` via
@@ -27,8 +29,13 @@
  *      → leave the issue open. Bias is conservative: never close while currently red.
  *
  * Best-effort and idempotent: safe to run on a schedule. `--dry-run` reports without
- * mutating. Scope is strictly the two auto-generated failure-title prefixes; follow-up,
+ * mutating. Scope is strictly the three auto-generated failure-title prefixes; follow-up,
  * tracker, validation-failure and other issues are never touched.
+ *
+ * One known edge: a workflow whose `CI Failure:` title is a literal that does NOT equal
+ * its `name:` (only `persist-job-stats`: title "Persist Job Stats" vs name "Persist Job
+ * Stats History") won't resolve via `gh run list -w <title>` → its issue stays open
+ * (conservative/safe). Fixing that mismatch belongs in persist-job-stats.yml, not here.
  */
 import { execFileSync } from 'node:child_process';
 import { resolveGithubIssue } from '../lib/github-issue-creator.mjs';
@@ -36,7 +43,7 @@ import { resolveGithubIssue } from '../lib/github-issue-creator.mjs';
 const DRY_RUN = process.argv.includes('--dry-run');
 // Stable titles minted by github-issue-creator.mjs failure reporters. Group 2 is the
 // workflow display name, which equals `github.workflow` (and `gh run list -w <name>`).
-const TITLE_RE = /^(?:Workflow|Crawler) Failure: (.+)$/;
+const TITLE_RE = /^(?:Workflow|Crawler|CI) Failure: (.+)$/;
 const REPO = process.env.GH_REPO || process.env.GITHUB_REPOSITORY || '';
 
 function repoFlag() {
@@ -87,7 +94,7 @@ function latestCompletedRun(workflowName) {
 
 function main() {
   const issues = listFailureIssues();
-  console.log(`[close-recovered] ${issues.length} open Workflow/Crawler Failure issue(s)${DRY_RUN ? ' (dry-run)' : ''}`);
+  console.log(`[close-recovered] ${issues.length} open Workflow/Crawler/CI Failure issue(s)${DRY_RUN ? ' (dry-run)' : ''}`);
   let closed = 0;
   let kept = 0;
   let skipped = 0;


### PR DESCRIPTION
## Implementato

Follow-up di #2367 (🟡 nit del reviewer). Allarga `TITLE_RE` del reconciler `close-recovered-failure-issues.mjs` al **terzo** prefisso failure auto-generato `CI Failure:`, così tutti e tre i prefissi mintati dai reporter `github-issue-creator.mjs` sono riconciliati su recovery: `Crawler Failure:` (439), `Workflow Failure:` (50), `CI Failure:` (8).

- `scripts/ci/close-recovered-failure-issues.mjs`: `(?:Workflow|Crawler) → (?:Workflow|Crawler|CI)`; doc-comment + log-line aggiornati (disciplina rename).
- `.github/workflows/close-recovered-failure-issues.yml`: header aggiornato col terzo prefisso.

I 8 workflow con `CI Failure:`: send-job-alerts, persist-job-stats, refresh-bfs-stats, refresh-job-popularity, refresh-article-trending, cathedral-noindex-flip, deploy-cloud-functions, deploy-firestore-rules.

**Validato in dry-run live**: 7 failure-issue aperte, tutte ancora genuinamente rosse → 0 chiuse erroneamente (le 3 recuperate erano già chiuse da #2367). Nessuna `CI Failure:` issue aperta al momento, ma la regex le coprirà alla prossima.

## Non implementato (ancora)

- **`persist-job-stats`**: il suo `--title` è il letterale `"Persist Job Stats"` mentre il `name:` del workflow è `"Persist Job Stats History"` → `gh run list -w "Persist Job Stats"` non risolve e la sua issue resterebbe aperta (direzione conservativa/safe, mai chiusa-mentre-rossa). Il fix appartiene a `persist-job-stats.yml` (allineare titolo al `name:`/`${{ github.workflow }}`), non a questo reconciler: cambiarne il titolo qui orfanizzerebbe eventuali issue aperte col vecchio titolo. Documentato inline nello script.
- **Sibling-check**: falsi-positivi euristici come in #2367 (riuso di `resolveGithubIssue`/`repoFlag`; campo `databaseId` di `gh run list`). Nessun antipattern condiviso.
- Gli altri 7/8 titoli `CI Failure:` combaciano col `name:` del workflow (verificato) → risolvono correttamente.