### PR TITLE
feat(seo): drop city from SERP job titles on non-colliding pages (#1932)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -242,8 +242,9 @@ export function composeJobPageTitle(
  city: string,
  locale: string,
  disambiguator?: string,
+ cityOptional?: boolean,
 ): string {
- return composeSerpJobTitle(jobTitle, company, city, locale, { disambiguator });
+ return composeSerpJobTitle(jobTitle, company, city, locale, { disambiguator, cityOptional });
 }
 
 /**
@@ -2201,6 +2202,18 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const titleCollisionByLocale: Record<'it' | 'en' | 'de' | 'fr', Map<string, number>> = {
  it: new Map(), en: new Map(), de: new Map(), fr: new Map(),
  };
+ // ── No-city title-collision map (#1932) ──
+ // Parallel map keyed on the CITY-LESS composed title ("role — company", no
+ // city tail). Used to decide whether the city is safe to DROP on a
+ // non-colliding page: the city may only be omitted when the role+company
+ // headline is ALSO unique within the locale, otherwise dropping it would
+ // collapse two multi-sede pages (same role+company × different cities) into
+ // one <title> and trip the hard audit:title-uniqueness gate. Keyed on the
+ // no-disambiguator probe (cityOptional=true) so the count reflects exactly
+ // the string that would be emitted once the city is gone.
+ const noCityTitleCollisionByLocale: Record<'it' | 'en' | 'de' | 'fr', Map<string, number>> = {
+ it: new Map(), en: new Map(), de: new Map(), fr: new Map(),
+ };
  for (const job of validJobs) {
   await collector.awaitDrainSlot(6); // bound flush backlog (#1290)
  for (const locale of localeList) {
@@ -2209,6 +2222,9 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const baseTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale);
  const bucket = titleCollisionByLocale[locale];
  bucket.set(baseTitle, (bucket.get(baseTitle) || 0) + 1);
+ const noCityTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale, undefined, true);
+ const noCityBucket = noCityTitleCollisionByLocale[locale];
+ noCityBucket.set(noCityTitle, (noCityBucket.get(noCityTitle) || 0) + 1);
  }
  }
 
@@ -2496,6 +2512,15 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // 1 call per page always, 2 when no collision (the common case).
  const baseTitleProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale);
  const collidesInLocale = (titleCollisionByLocale[locale].get(baseTitleProbe) || 0) > 1;
+ // City-drop decision (#1932): drop the city ONLY when this page does not
+ // collide on the full (with-city) title AND its city-less "role — company"
+ // headline is itself unique in the locale — so removing the city cannot
+ // collapse two multi-sede pages into a duplicate <title> (audit:title-
+ // uniqueness). On the residual mid-`…` pages (role+city > 66 char) this lets
+ // the bare role fill the budget verbatim instead of truncating mid-word.
+ const noCityProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, undefined, true);
+ const cityIsDroppable = !collidesInLocale
+  && (noCityTitleCollisionByLocale[locale].get(noCityProbe) || 0) <= 1;
  // Build a HUMAN-READABLE disambiguator from the job's metadata (cascade:
  // workHours/percentage → employmentType label → salary range → posted
  // month → job-id reference). Replaces the previous opaque
@@ -2505,9 +2530,11 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const disambiguatorToken = collidesInLocale
  ? pickJobDisambiguator(job as Record<string, unknown>, locale, baseTitleProbe)
  : '';
+ // `cityIsDroppable` only ever holds when the page does NOT collide, so
+ // `disambiguatorToken` is empty here and the droppable branch is `noCityProbe`.
  let title = disambiguatorToken
  ? composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, disambiguatorToken)
- : baseTitleProbe;
+ : (cityIsDroppable ? noCityProbe : baseTitleProbe);
  // <title> must differ from the <h1> (audit:h1-title-duplicates). With the
  // role>city>company cascade the title normally carries the city or brand
  // and differs structurally; the residual case is a city-less job whose
@@ -2519,17 +2546,21 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  title = composeJobPageTitle(
   localizedTitle, String(job.company || ''), jobLocation, locale,
   h1AvoidToken || `${REF_LABEL[locale] || REF_LABEL.it} ${fnv8(String(job.slug || job.id || localizedTitle))}`,
+  cityIsDroppable,
  );
  }
  // Cross-corpus uniqueness net (see claimUniqueTitle above): guarantees no
  // two emitted pages in this locale — active OR expired — share a <title>.
+ // The recompose preserves the city-drop decision so a clash falls back to a
+ // disambiguator on the SAME (city-less or city-bearing) headline shape.
  title = claimUniqueTitle(locale, title, `${String(job.slug || job.id || '')}::${locale}`,
- (d) => composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, d));
- // Clean variant for og:title — same as `title` minus the trailing
- // " · {disambiguator}". The disambig is needed in the HTML <title>
- // for SEO uniqueness, but the social cards look better without the
- // trailing extra metadata. With no disambiguator `title === probe`,
- // so `ogTitle` is structurally identical to the no-disamb probe.
+ (d) => composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, d, cityIsDroppable));
+ // Clean variant for og:title — the city-bearing probe minus any trailing
+ // " · {disambiguator}". The disambig is needed in the HTML <title> for SEO
+ // uniqueness, but social cards look better without the trailing metadata.
+ // og:title deliberately KEEPS the city even when the <title> drops it
+ // (#1932): social cards have no SERP width cap, so the richer location-
+ // bearing headline is preferred there.
  const ogTitle = baseTitleProbe;
  recordPhase('title', __tPh_title);
  // stripLeadingSectionLabel: crawlers flatten the source page's
@@ -10621,9 +10652,22 @@ ${staticAnalyticsHtml}
  // Note: we work on the RAW headline (no HTML-escape) so `&` / `<` are not
  // expanded into multi-char entities that fool the length-based budget;
  // esc() is applied ONCE at the <title> call site downstream.
+ // City-drop on expired soft-landings (#1932): the city is droppable when the
+ // city-less "role — company" headline is unique among ACTIVE pages in this
+ // locale (noCityTitleCollisionByLocale). The shared claimUniqueTitle registry
+ // is the backstop — if the city-less title still clashes with another emitted
+ // page it recomposes with a `rif.` disambiguator, so dropping the city can
+ // never break audit:title-uniqueness, it only avoids the mid-`…` truncation
+ // on the non-colliding majority (22.8 % of expired titles overflowed at
+ // role+city > 66 char).
+ const __expiredNoCityProbe = hasRealTitle
+  ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { cityOptional: true })
+  : composeSerpJobTitle(copy.title, '', jobLocation, locale, { cityOptional: true });
+ const __expiredCityDroppable = hasRealTitle
+  && (noCityTitleCollisionByLocale[locale].get(__expiredNoCityProbe) || 0) <= 1;
  const __expiredCompose = (disambiguator?: string): string =>
   hasRealTitle
-   ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { disambiguator })
+   ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { disambiguator, cityOptional: __expiredCityDroppable })
    : composeSerpJobTitle(copy.title, '', jobLocation, locale, { disambiguator });
  let pageTitleRaw = __expiredCompose();
  // <h1> equality guard (audit:h1-title-duplicates): the static H1 below is

--- a/build-plugins/shared/titleSuffix.ts
+++ b/build-plugins/shared/titleSuffix.ts
@@ -155,6 +155,25 @@ export interface SerpJobTitleOptions {
   disambiguator?: string;
   brand?: string;
   maxChars?: number;
+  /**
+   * When `true`, the city is treated as DROPPABLE: it is included only when the
+   * full "{role} — {company} {conn} {city}" headline fits the budget verbatim;
+   * the moment that candidate would overflow (forcing the cascade to drop the
+   * company or truncate the role) the city is omitted so the role can occupy the
+   * whole budget without a mid-word `…`.
+   *
+   * Default `false` — city is mandatory (the standard cascade keeps it while it
+   * fits because it carries local-query intent AND guarantees multi-sede title
+   * uniqueness). Callers may opt in ONLY when they have proven, at the corpus
+   * level, that "{role} — {company}" (no city) is unique in the locale, so
+   * dropping the city cannot collapse two pages into a duplicate <title>
+   * (audit:title-uniqueness is a hard deploy gate). See the SSG plugin's
+   * `noCityTitleCollisionByLocale` guard (build-plugins/jobsSeoPagesPlugin.ts).
+   *
+   * Closes the #1931 follow-up #1932: cuts the residual mid-`…` titles
+   * (17.8 % active / 22.8 % expired) on non-colliding role+company pages.
+   */
+  cityOptional?: boolean;
 }
 
 /**
@@ -181,6 +200,13 @@ export interface SerpJobTitleOptions {
  * first token sacrificed: it already appears in the H1, meta description
  * and JSON-LD `hiringOrganization`.
  *
+ * EXCEPTION — `options.cityOptional` (#1932): for pages the caller has proven
+ * non-colliding without the city, the city is droppable. It then survives only
+ * inside the full "role — company a city" candidate; the moment that overflows
+ * the cascade skips the "role a city" and city-tail-truncation steps and lets
+ * the bare role fill the budget verbatim — eliminating the residual mid-`…`
+ * titles (17.8 % active / 22.8 % expired) where role+city blew the 66-char cap.
+ *
  * The brand suffix is appended only when the final headline still fits
  * (buildTitleWithBrand policy). The optional disambiguator is budgeted
  * BEFORE the cascade so it always lands inside the cap.
@@ -205,16 +231,24 @@ export function composeSerpJobTitle(
   const disambToken = String(options.disambiguator || '').trim().replace(/\s+/g, ' ');
   const disamb = disambToken ? ` · ${disambToken}` : '';
   const budget = Math.max(1, maxChars - disamb.length);
+  const cityOptional = options.cityOptional === true;
 
+  // When the city is droppable, it survives ONLY in the full
+  // "role — company a city" candidate: once that overflows we fall straight to
+  // the city-less "role — company" / "role" path so the role takes the whole
+  // budget without a mid-word `…`. Otherwise the city is mandatory and stays
+  // while it fits (the standard cascade below).
   const candidates = [
     cleanCompany && cleanCity ? `${role} — ${cleanCompany} ${connector} ${cleanCity}` : '',
-    cleanCity ? `${role} ${connector} ${cleanCity}` : '',
+    !cityOptional && cleanCity ? `${role} ${connector} ${cleanCity}` : '',
     cleanCompany ? `${role} — ${cleanCompany}` : '',
     role,
   ].filter(Boolean);
   let headline = candidates.find((c) => c.length <= budget);
   if (!headline) {
-    const cityTail = cleanCity ? ` ${connector} ${cleanCity}` : '';
+    // The city tail is preserved during truncation only when the city is
+    // mandatory; a droppable city is sacrificed before the role is truncated.
+    const cityTail = !cityOptional && cleanCity ? ` ${connector} ${cleanCity}` : '';
     const roleBudget = budget - cityTail.length;
     // Preserve the city tail while a meaningful role fragment (≥12 chars)
     // still fits; a malformed/oversized `city` (crawler body-text leak)
@@ -231,9 +265,12 @@ export function composeSerpJobTitle(
  * brand suffix. Thin wrapper over {@link composeSerpJobTitle} (no
  * disambiguator) kept for the SPA call sites (services/seoService.ts,
  * components/community/JobBoard.tsx) — the SSG composer additionally appends
- * a collision disambiguator, so SPA and static titles match for all
- * non-colliding jobs and diverge only by the ` · token` suffix on colliding
- * ones. Callers must apply their own multi-location guard before passing
+ * a collision disambiguator AND may drop the city on non-colliding pages
+ * (`cityOptional`, #1932), so SPA and static titles match for most
+ * non-colliding jobs and diverge by the ` · token` suffix on colliding ones
+ * or by a dropped city on overflow-prone unique ones. The indexed <title> is
+ * the static SSG HTML; the SPA keeps the city (no corpus map at runtime).
+ * Callers must apply their own multi-location guard before passing
  * `city` (the blob "ganz Schweiz" etc. must not become a city token).
  */
 export function buildJobTitleWithLocation(

--- a/build-plugins/shared/titleSuffix.ts
+++ b/build-plugins/shared/titleSuffix.ts
@@ -201,11 +201,16 @@ export interface SerpJobTitleOptions {
  * and JSON-LD `hiringOrganization`.
  *
  * EXCEPTION — `options.cityOptional` (#1932): for pages the caller has proven
- * non-colliding without the city, the city is droppable. It then survives only
- * inside the full "role — company a city" candidate; the moment that overflows
- * the cascade skips the "role a city" and city-tail-truncation steps and lets
- * the bare role fill the budget verbatim — eliminating the residual mid-`…`
- * titles (17.8 % active / 22.8 % expired) where role+city blew the 66-char cap.
+ * non-colliding without the city, the city is droppable. WHEN a company exists,
+ * the city survives only inside the full "role — company a city" candidate; the
+ * moment that overflows the cascade skips the "role a city" and city-tail-
+ * truncation steps and falls to the city-less "role — company" / "role" path so
+ * the role fills the budget without a mid-`…`. WHEN there is no company,
+ * "role a city" is the sole city-bearing candidate and is KEPT — so the city is
+ * dropped only on OVERFLOW (via the empty `cityTail` in the truncation branch),
+ * never when it would otherwise fit. This eliminates the residual mid-`…` titles
+ * (17.8 % active / 22.8 % expired) where role+city blew the 66-char cap without
+ * stripping the geo keyword from titles that had room for it.
  *
  * The brand suffix is appended only when the final headline still fits
  * (buildTitleWithBrand policy). The optional disambiguator is budgeted
@@ -235,12 +240,18 @@ export function composeSerpJobTitle(
 
   // When the city is droppable, it survives ONLY in the full
   // "role — company a city" candidate: once that overflows we fall straight to
-  // the city-less "role — company" / "role" path so the role takes the whole
-  // budget without a mid-word `…`. Otherwise the city is mandatory and stays
-  // while it fits (the standard cascade below).
+  // the city-less "role — company" path so the role takes the whole budget
+  // without a mid-word `…`. Otherwise the city is mandatory and stays while it
+  // fits (the standard cascade below).
+  //
+  // The "role a city" candidate is skipped only when the city is droppable AND
+  // a company exists to carry the city-less fallback — for a no-company job
+  // "role a city" is the ONLY candidate bearing the city, so keeping it ensures
+  // the city is dropped on OVERFLOW (via the `cityTail` logic below), never when
+  // it would otherwise fit. (#1932 reviewer 🔴.)
   const candidates = [
     cleanCompany && cleanCity ? `${role} — ${cleanCompany} ${connector} ${cleanCity}` : '',
-    !cityOptional && cleanCity ? `${role} ${connector} ${cleanCity}` : '',
+    (!cityOptional || !cleanCompany) && cleanCity ? `${role} ${connector} ${cleanCity}` : '',
     cleanCompany ? `${role} — ${cleanCompany}` : '',
     role,
   ].filter(Boolean);

--- a/tests/jobs-seo-title-h1-datemodified.test.ts
+++ b/tests/jobs-seo-title-h1-datemodified.test.ts
@@ -172,6 +172,16 @@ describe('composeSerpJobTitle cityOptional (#1932: drop city on non-colliding pa
  expect(out).toContain(' · 80%');
  expect(out.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
  });
+
+ it('KEEPS the city for a no-company job when "role a city" fits (reviewer 🔴)', () => {
+ // No company → "role a city" is the only city-bearing candidate. cityOptional
+ // must NOT strip the geo keyword when it fits the cap; the city is dropped
+ // ONLY on overflow (covered by the long-role test above). Regression for the
+ // #1932 reviewer finding (drop-when-fits geo regression).
+ const out = composeSerpJobTitle('Operaio', '', 'Lugano', 'it', { cityOptional: true });
+ expect(out).toBe('Operaio a Lugano | Frontaliere Ticino');
+ expect(out).toContain('Lugano');
+ });
 });
 
 describe('truncateHeadline', () => {

--- a/tests/jobs-seo-title-h1-datemodified.test.ts
+++ b/tests/jobs-seo-title-h1-datemodified.test.ts
@@ -117,6 +117,63 @@ describe('composeSerpJobTitle (role > city > company > brand cascade)', () => {
  });
 });
 
+describe('composeSerpJobTitle cityOptional (#1932: drop city on non-colliding pages)', () => {
+ it('still keeps the city when the full "role — company a city" headline fits', () => {
+ // cityOptional only changes behaviour on OVERFLOW; a fitting title is unchanged.
+ const out = composeSerpJobTitle('Sviluppatore', 'Acme', 'Lugano', 'it', { cityOptional: true });
+ expect(out).toBe('Sviluppatore — Acme a Lugano | Frontaliere Ticino');
+ });
+
+ it('drops the city tail during role truncation when the role itself overflows', () => {
+ // role(75) > 66: even the bare role must be truncated. Mandatory-city keeps a
+ // " a {city}" tail (shrinking the role further); cityOptional gives the whole
+ // budget to the role so more of the keyword-rich role survives.
+ const role = 'Specialista Senior Pianificazione Controllo Produzione Industriale Avanzata';
+ const withCity = composeSerpJobTitle(role, '', 'Lugano', 'it');
+ const dropped = composeSerpJobTitle(role, '', 'Lugano', 'it', { cityOptional: true });
+ // Mandatory: truncated role + preserved city tail.
+ expect(withCity).toMatch(/… a Lugano$/);
+ expect(withCity.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ // Optional: truncated role, NO city tail, ending in a bare ellipsis.
+ expect(dropped).toMatch(/…$/);
+ expect(dropped).not.toContain('Lugano');
+ expect(dropped.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ // The role fragment gets at least as much budget without the reserved tail.
+ expect(dropped.length).toBeGreaterThanOrEqual(withCity.replace(' a Lugano', '').length);
+ });
+
+ it('keeps the full role verbatim (no "…") when role+city overflows but role fits', () => {
+ // role(56) + " a Mendrisio"(12) = 68 > 66 but role alone (56) fits. The
+ // standard mandatory cascade already drops to bare role here; cityOptional
+ // produces the same clean, ellipsis-free role.
+ const role = 'Responsabile Pianificazione e Controllo della Produzione';
+ const dropped = composeSerpJobTitle(role, '', 'Mendrisio', 'it', { cityOptional: true });
+ expect(dropped).toBe(role);
+ expect(dropped).not.toContain('…');
+ expect(dropped).not.toContain('Mendrisio');
+ });
+
+ it('prefers role — company over role a city when the city would overflow', () => {
+ // "role — company"(54) fits, "role — company a city"(74) overflows, and
+ // "role a city"(66) also fits. Mandatory-city keeps the city (drops company);
+ // cityOptional keeps the company tail and drops the city instead.
+ const role = 'Impiegato amministrativo logistica e magazzino';
+ const mandatory = composeSerpJobTitle(role, 'Alpha', 'Castel San Pietro', 'it');
+ const optional = composeSerpJobTitle(role, 'Alpha', 'Castel San Pietro', 'it', { cityOptional: true });
+ expect(mandatory).toContain('Castel San Pietro');
+ expect(mandatory).not.toContain('Alpha');
+ expect(optional).toContain(`${role} — Alpha`);
+ expect(optional).not.toContain('Castel San Pietro');
+ expect(optional.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ });
+
+ it('budgets a disambiguator before the optional-city cascade', () => {
+ const out = composeSerpJobTitle('Sviluppatore', 'Acme', 'Lugano', 'it', { cityOptional: true, disambiguator: '80%' });
+ expect(out).toContain(' · 80%');
+ expect(out.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ });
+});
+
 describe('truncateHeadline', () => {
  it('returns input verbatim when within budget', () => {
  expect(truncateHeadline('Short core', 40)).toBe('Short core');


### PR DESCRIPTION
## Implementato
- `composeSerpJobTitle` (`build-plugins/shared/titleSuffix.ts`): nuova opzione opt-in `cityOptional` su `SerpJobTitleOptions`. Quando attiva e la pagina HA company, la città sopravvive solo nel candidato completo `role — company a city`; appena questo sfora il cap (66 char) la cascata salta i passi `role a city` e il city-tail nella troncatura, lasciando che il role riempia il budget verbatim senza `…` a metà parola. Quando NON c'è company, `role a city` è l'unico candidato city-bearing → viene MANTENUTO, così la città cade solo su overflow (via il `cityTail` vuoto nel ramo di troncatura), mai quando ci starebbe. Default `false` → comportamento invariato (città mandatory finché entra).
- `composeJobPageTitle` (`build-plugins/jobsSeoPagesPlugin.ts`): nuovo parametro `cityOptional` inoltrato al composer condiviso.
- SSG plugin: nuova mappa `noCityTitleCollisionByLocale` (keyed sul titolo city-less `role — company`, probe `cityOptional=true`), popolata accanto a `titleCollisionByLocale` nello stesso pre-pass.
- Pagine ATTIVE: la città è droppata solo quando la pagina NON collide sul titolo full (with-city) E il suo titolo city-less è unico nel locale (`cityIsDroppable`). I closure di H1-equality e `claimUniqueTitle` propagano la decisione così un eventuale clash ripiega su disambiguatore sulla stessa forma.
- Pagine EXPIRED (soft-landing): `__expiredCompose` passa `cityOptional` quando il titolo city-less è unico tra le pagine attive del locale; `claimUniqueTitle` (registry cross-corpus condiviso) resta il backstop di unicità.
- `og:title` mantiene deliberatamente la città anche quando il `<title>` la droppa (le card social non hanno cap di larghezza SERP) — commento aggiornato.
- **Review 🔴 (round 1)**: fix del drop-when-fits sui job SENZA company. Il candidato `role a city` non era più rimosso incondizionatamente sotto `cityOptional` (`(!cityOptional || !cleanCompany) && cleanCity`): per un job no-company quello è l'unico candidato che porta la città, quindi un titolo `role a city` che ENTRAVA nel cap non perde più il keyword geo dal `<title>` indicizzato (regressione di rilevanza sulle query locali `[ruolo] [città]`). Docblock e commenti aggiornati.
- Test: 6 casi in `tests/jobs-seo-title-h1-datemodified.test.ts` (`composeSerpJobTitle cityOptional`): no-op quando il full title entra; drop città su overflow `role+city` con role che entra; troncatura role senza city-tail quando il role stesso sfora; preferenza `role — company` su `role a city`; disambiguatore budgetato prima della cascata; **regressione no-company city-fits** (la città resta quando `role a city` entra senza company). Suite intera verde (54), più job-board/title sibling suites (85 pass).

## Non implementato (ancora)
- **SPA runtime (`services/seoService.ts`, `components/community/JobBoard.tsx`)**: continuano a tenere la città (chiamano `buildJobTitleWithLocation` senza `cityOptional`). Motivo: a runtime non esiste la mappa di collisione corpus-wide necessaria per decidere il drop in sicurezza; il `<title>` indicizzato da Google è l'HTML statico SSG, quindi la divergenza è intenzionale e documentata nel docblock di `buildJobTitleWithLocation`.
- **Sibling-class check** (`node scripts/ci/check-sibling-patterns.mjs`): 10 file segnalati per token condivisi (`cleanCity`, `jobCompany`, `baseTitleProbe`, `collidesInLocale`) — tutti falsi positivi euristici. `build-plugins/ogPagesPlugin.ts` usa `buildTitleWithBrand` per articoli OG (nessun concetto di città); i `scripts/lib/*-job-parser.mjs` estraggono una città dall'HTML (non compongono titoli); gli altri (`personalizationScoring.ts`, `jobAlertMatching.mjs`, `newsletter-content.mjs`, ecc.) consumano `jobCompany` in contesti non-title. Nessuno condivide l'antipattern city-in-SERP-title → niente da sweepare.
- **Backfill/verifica live**: l'effetto sui titoli emessi (riduzione mid-`…`) è verificabile solo post-deploy (build SSG OOM-prone gira solo su `main`); la metrica CTR GSC si osserva a 2-4 settimane.

Closes #1932
