### PR TITLE
fix(i18n): scope glossary to titles, article-aware preps, fix UUID-prefix slug collision (#2330)

### DIFF
--- a/data/jobs/by-crawler/gz-dielsdorf.json
+++ b/data/jobs/by-crawler/gz-dielsdorf.json
@@ -833,11 +833,11 @@
     },
     {
       "id": "gz-dielsdorf-1f252d1fc6a5",
-      "slug": "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal",
+      "slug": "nachtwache-gesundheitszentrum-dielsdorf-regensdorf",
       "slugByLocale": {
-        "it": "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal",
+        "it": "guardia-notturna-gesundheitszentrum-dielsdorf-regensdorf",
         "en": "night-watch-gesundheitszentrum-dielsdorf-regensdorf",
-        "de": "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal",
+        "de": "nachtwache-gesundheitszentrum-dielsdorf-regensdorf",
         "fr": "garde-de-nuit-gesundheitszentrum-dielsdorf-regensdorf"
       },
       "company": "Gesundheitszentrum Dielsdorf",
@@ -883,12 +883,14 @@
       "previousSlugsByLocale": {
         "de": [
           "nachtwache-gz-dielsdorf-regensdorf",
-          "nachtwache-gesundheitszentrum-dielsdorf-regensdorf"
+          "nachtwache-gesundheitszentrum-dielsdorf-regensdorf",
+          "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal"
         ],
         "it": [
           "nachtwache-gz-dielsdorf-regensdorf",
           "nachtwache-gesundheitszentrum-dielsdorf-regensdorf",
-          "orologio-notturno-gesundheitszentrum-dielsdorf-regensdorf"
+          "orologio-notturno-gesundheitszentrum-dielsdorf-regensdorf",
+          "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal"
         ],
         "en": [
           "nachtwache-gesundheitszentrum-dielsdorf-regensdorf"
@@ -902,7 +904,9 @@
         "nachtwache-gz-dielsdorf-regensdorf",
         "nachtwache-gesundheitszentrum-dielsdorf-regensdorf",
         "orologio-notturno-gesundheitszentrum-dielsdorf-regensdorf",
-        "montre-de-nuit-gesundheitszentrum-dielsdorf-regensdorf"
+        "montre-de-nuit-gesundheitszentrum-dielsdorf-regensdorf",
+        "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal",
+        "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal"
       ],
       "firstSeenAt": "2026-05-29T12:33:18.356Z",
       "salaryMin": 73500,

--- a/data/slug-registry.json
+++ b/data/slug-registry.json
@@ -101213,17 +101213,6 @@
     "createdAt": "2026-05-23",
     "canton": "BE"
   },
-  "id|prospective.ch|69": {
-    "canonicalSlug": "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal",
-    "slugByLocale": {
-      "de": "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal",
-      "it": "ernahrungsberater-in-bsc-60-zentrum-per-essstorungen-e-adipositas-zesa-sro-ag-spital-region-oberaargau-langenthal",
-      "en": "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal",
-      "fr": "ernahrungsberater-in-bsc-60-zentrum-fur-essstorungen-und-adipositas-zesa-sro-langenthal"
-    },
-    "createdAt": "2026-05-23",
-    "canton": "BE"
-  },
   "id|spitexjobs.ch|j975354": {
     "canonicalSlug": "dipl-pflegefachperson-hf-o-fh-60-80-con-interesse-an-palliative-care-spitex-rothenburg",
     "slugByLocale": {

--- a/scripts/fix-untranslated-descriptions.mjs
+++ b/scripts/fix-untranslated-descriptions.mjs
@@ -99,6 +99,7 @@ async function main() {
           text: sourceDesc,
           sourceLang: sl,
           targetLang: locale,
+          fieldType: 'description',
           maxRetries: 1,
         });
 

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -48,6 +48,11 @@ async function translateJobFieldWithFallback({
     text,
     sourceLang,
     targetLang,
+    // Forward the field kind so the glossary's broad single-word fallbacks
+    // (/\borologio\b/→a ciclo, /\bclock\b/→cycle) stay title-only on this
+    // cascade-fallback path too — otherwise a description body's legitimate
+    // "orologio"/"clock" prose would be rewritten (#2330 item 2).
+    fieldType: kind === 'title' ? 'title' : 'description',
     maxRetries: 2,
   });
   if (translated) return translated;

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -4579,7 +4579,7 @@ export function extractJobIdentityFromUrl(rawUrl = '') {
     if (val) return `${registrableDomain(host)}|${val.toLowerCase()}`;
   }
 
-  // A full UUID anywhere in the URL is the globally-unique per-job id — prefer it
+  // A per-job UUID in the LEAF path segment is the globally-unique id — prefer it
   // BEFORE the numeric/path heuristics below. The `\/jobs\/(\d+)` etc. rules
   // would otherwise latch onto the LEADING DIGITS of a UUID slug
   // (`…/jobs/69b0fccf-bb38-…` → captures `69`), collapsing every prospective.ch
@@ -4587,9 +4587,18 @@ export function extractJobIdentityFromUrl(rawUrl = '') {
   // (`prospective.ch|69`). That cross-job collision force-pins the wrong
   // slugByLocale via registryPinnedLocaleSlug — e.g. a Gesundheitszentrum
   // Dielsdorf "Nachtwache" vacancy adopting an unrelated SRO-Langenthal dietician
-  // slug (#2330 item 1). Matches mergeUrlKey's UUID-first priority.
-  const uuid = extractUuidLikeId(full);
-  if (uuid) return `${registrableDomain(host)}|${uuid}`;
+  // slug (#2330 item 1).
+  //
+  // Scope the UUID extraction to the LEAF segment — NOT the whole URL — to match
+  // mergeUrlKey Rule B (scripts/lib/job-url-key.mjs). A blind first-UUID scan of
+  // the full URL would grab a SHARED ANCESTOR uuid for shapes like cseb's
+  // `…/job-advertisement/<board-uuid>/<job-uuid>`, re-introducing the very
+  // ancestor-collapse this fix removes (every cseb job → one `cseb.ch|<board-uuid>`
+  // key). Vendors put the per-job reference in the rightmost segment; board/site
+  // uuids live in ancestor segments.
+  const leafSeg = u.pathname.split('/').filter(Boolean).pop() || '';
+  const leafUuid = extractUuidLikeId(leafSeg);
+  if (leafUuid) return `${registrableDomain(host)}|${leafUuid}`;
 
   const coopPathMatch = full.match(/\/(?:offene-stellen|posti-vacanti)\/[^/?#]+\/([^/?#]+)/i);
   if (coopPathMatch?.[1]) {
@@ -4597,6 +4606,20 @@ export function extractJobIdentityFromUrl(rawUrl = '') {
     const coopUuid = extractUuidLikeId(coopIdCandidate) || extractUuidLikeId(full);
     if (coopUuid) return `${registrableDomain(host)}|${coopUuid}`;
     if (coopIdCandidate) return `${registrableDomain(host)}|${coopIdCandidate.toLowerCase()}`;
+  }
+
+  // Guard against the digit-prefix-of-a-UUID collapse for UUIDs the strict
+  // RFC4122 leaf check above misses (e.g. a non-conforming version/variant
+  // nibble). If the leaf is UUID-SHAPED (loose: 8-4-4-4-12 hex, any
+  // version/variant), the numeric `\/jobs\/(\d+)` rules below would capture only
+  // its leading digits (`…/jobs/69b0fccf-…` → `69`), re-collapsing distinct jobs
+  // onto the digit-prefix key (#2330). Key on the whole UUID-shaped leaf instead.
+  // This does NOT touch numeric-then-text ids (teamtailor `7887338-projektleiter`,
+  // hilti `17627-fr`) — those are not UUID-shaped, so the numeric rules still
+  // capture the real id.
+  const LOOSE_UUID_LEAF_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (LOOSE_UUID_LEAF_RE.test(leafSeg)) {
+    return `${registrableDomain(host)}|${leafSeg.toLowerCase()}`;
   }
 
   const inPath = [

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -2047,7 +2047,7 @@ export async function aiTranslateJobDescriptionDCC({ description, locale, source
     const fromCache = getCachedAiResponse(cacheKey);
     if (typeof fromCache === 'string') {
       if (fromCache !== AI_CACHE_RAW_SENTINEL) return fromCache;
-      const sentinelFallback = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale });
+      const sentinelFallback = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale, fieldType: 'description' });
       if (sentinelFallback && sentinelFallback.length >= floor && sentinelFallback.toLowerCase() !== cleanDesc.toLowerCase()) {
         setCachedAiResponse(cacheKey, sentinelFallback);
         return sentinelFallback;
@@ -2055,7 +2055,7 @@ export async function aiTranslateJobDescriptionDCC({ description, locale, source
       return '';
     }
     // DeepL first
-    const deepl = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale });
+    const deepl = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale, fieldType: 'description' });
     if (deepl && deepl.length >= floor) {
       setCachedAiResponse(cacheKey, deepl);
       return deepl;
@@ -2083,7 +2083,7 @@ export async function aiTranslateJobDescriptionDCC({ description, locale, source
         }
       } catch { /* fallback below */ }
     }
-    const fallback = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale });
+    const fallback = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale, fieldType: 'description' });
     if (fallback && fallback.length >= floor && fallback.toLowerCase() !== cleanDesc.toLowerCase()) {
       setCachedAiResponse(cacheKey, fallback);
       return fallback;
@@ -2093,7 +2093,7 @@ export async function aiTranslateJobDescriptionDCC({ description, locale, source
   }
 
   // No cache — simple free-translate fallback
-  const simple = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale });
+  const simple = await freeTranslateWithRetry({ text: cleanDesc, sourceLang, targetLang: locale, fieldType: 'description' });
   return (simple && simple.length >= floor) ? simple : '';
 }
 
@@ -2313,7 +2313,7 @@ export async function aiLocalizeJobContentDCC({ title, company, location, descri
     };
     for (const locale of targetLocales) {
       // eslint-disable-next-line no-await-in-loop
-      const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale });
+      const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale, fieldType: 'description' });
       if (desc && desc.length >= floor && isAcceptableTranslation(cleanedSource, desc)) {
         // eslint-disable-next-line no-await-in-loop
         const localizedTitle = await freeTranslateWithRetry({ text: title, sourceLang: sourceLang || 'en', targetLang: locale });
@@ -2369,7 +2369,7 @@ export async function aiLocalizeJobContentDCC({ title, company, location, descri
     };
     for (const locale of targetLocales) {
       // eslint-disable-next-line no-await-in-loop
-      const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale });
+      const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale, fieldType: 'description' });
       if (desc && desc.length >= floor && isAcceptableTranslation(cleanedSource, desc)) {
         // eslint-disable-next-line no-await-in-loop
         const localizedTitle = await freeTranslateWithRetry({ text: title, sourceLang: sourceLang || 'en', targetLang: locale });
@@ -2424,7 +2424,7 @@ export async function aiLocalizeJobContentDCC({ title, company, location, descri
     if (missingLocales.length > 0 && cleanedSource.length >= floor) {
       for (const locale of missingLocales) {
         // eslint-disable-next-line no-await-in-loop
-        const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale });
+        const desc = await freeTranslateWithRetry({ text: cleanedSource, sourceLang: sourceLang || 'en', targetLang: locale, fieldType: 'description' });
         if (desc && desc.length >= floor && isAcceptableTranslation(cleanedSource, desc)) {
           // eslint-disable-next-line no-await-in-loop
           const localizedTitle = await freeTranslateWithRetry({ text: title, sourceLang: sourceLang || 'en', targetLang: locale });
@@ -2448,7 +2448,7 @@ export async function aiLocalizeJobContentDCC({ title, company, location, descri
       };
       for (const locale of targetLocales) {
         // eslint-disable-next-line no-await-in-loop
-        const desc = await freeTranslateWithRetry({ text: cleanedFallback, sourceLang: sourceLang || 'en', targetLang: locale });
+        const desc = await freeTranslateWithRetry({ text: cleanedFallback, sourceLang: sourceLang || 'en', targetLang: locale, fieldType: 'description' });
         if (desc && desc.length >= floor && isAcceptableTranslation(cleanedFallback, desc)) {
           // eslint-disable-next-line no-await-in-loop
           const localizedTitle = await freeTranslateWithRetry({ text: title, sourceLang: sourceLang || 'en', targetLang: locale });
@@ -4578,6 +4578,18 @@ export function extractJobIdentityFromUrl(rawUrl = '') {
     const val = normalizeSpace(u.searchParams.get(key));
     if (val) return `${registrableDomain(host)}|${val.toLowerCase()}`;
   }
+
+  // A full UUID anywhere in the URL is the globally-unique per-job id — prefer it
+  // BEFORE the numeric/path heuristics below. The `\/jobs\/(\d+)` etc. rules
+  // would otherwise latch onto the LEADING DIGITS of a UUID slug
+  // (`…/jobs/69b0fccf-bb38-…` → captures `69`), collapsing every prospective.ch
+  // UUID job whose id starts with the same digit run onto ONE registry key
+  // (`prospective.ch|69`). That cross-job collision force-pins the wrong
+  // slugByLocale via registryPinnedLocaleSlug — e.g. a Gesundheitszentrum
+  // Dielsdorf "Nachtwache" vacancy adopting an unrelated SRO-Langenthal dietician
+  // slug (#2330 item 1). Matches mergeUrlKey's UUID-first priority.
+  const uuid = extractUuidLikeId(full);
+  if (uuid) return `${registrableDomain(host)}|${uuid}`;
 
   const coopPathMatch = full.match(/\/(?:offene-stellen|posti-vacanti)\/[^/?#]+\/([^/?#]+)/i);
   if (coopPathMatch?.[1]) {

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -980,7 +980,7 @@ export function balanceMarkdownMarkers(s) {
   return out.trim();
 }
 
-export async function freeTranslate({ text, sourceLang, targetLang }) {
+export async function freeTranslate({ text, sourceLang, targetLang, fieldType = 'title' }) {
   const clean = normalizeSpace(text);
   if (!clean) return '';
   if (sourceLang === targetLang) return clean;
@@ -990,11 +990,15 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
   // Single exit transform: balance markdown markers, then apply the
   // protected-term glossary so meaning-inverted MT output (e.g. German
   // "Nachtwache" → IT "orologio notturno") is corrected regardless of which
-  // tier produced it.
+  // tier produced it. `fieldType` defaults to 'title' (preserving the original
+  // behaviour for the short-text/title path); description callers pass
+  // 'description' so broad single-word fallback rules are skipped and legitimate
+  // body prose ("nel nostro orologio") is never rewritten.
   const finalize = (out) => applyGlossaryCorrections({
     sourceText: clean,
     translatedText: balanceMarkdownMarkers(out),
     targetLang,
+    fieldType,
   });
 
   /** Try a tier: track success/error, return result or '' */
@@ -1124,16 +1128,18 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
  * @param {string} options.text - Text to translate
  * @param {string} options.sourceLang - Source language
  * @param {string} options.targetLang - Target language
+ * @param {('title'|'description')} [options.fieldType='title'] - Field kind; forwarded
+ *   to the glossary so broad single-word fallbacks run on titles only.
  * @param {number} [options.maxRetries=2] - Max retry attempts after first failure
  * @returns {Promise<string>} Translated text or ''
  */
-export async function freeTranslateWithRetry({ text, sourceLang, targetLang, maxRetries = 2 }) {
-  const result = await freeTranslate({ text, sourceLang, targetLang });
+export async function freeTranslateWithRetry({ text, sourceLang, targetLang, fieldType = 'title', maxRetries = 2 }) {
+  const result = await freeTranslate({ text, sourceLang, targetLang, fieldType });
   if (result) return result;
 
   for (let i = 1; i <= maxRetries; i++) {
     await delay(i * 1000);
-    const retry = await freeTranslate({ text, sourceLang, targetLang });
+    const retry = await freeTranslate({ text, sourceLang, targetLang, fieldType });
     if (retry) return retry;
   }
 

--- a/scripts/lib/job-localization-pipeline.mjs
+++ b/scripts/lib/job-localization-pipeline.mjs
@@ -340,8 +340,11 @@ export async function translateTextWithLocalPipeline({
   // Protected-term glossary: corrects meaning-inverted MT output (e.g. German
   // "Nachtwache" → IT "orologio notturno") that passes every language gate.
   // Applied to every accepted candidate, including memoized ones written before
-  // this guard existed.
-  const fixGlossary = (out) => applyGlossaryCorrections({ sourceText: clean, translatedText: out, targetLang });
+  // this guard existed. `fieldType` scopes broad single-word fallback rules to
+  // titles only, so a description body's legitimate "orologio"/"clock" prose is
+  // never rewritten (only the narrow compound rules run on bodies).
+  const fieldType = kind === 'title' ? 'title' : 'description';
+  const fixGlossary = (out) => applyGlossaryCorrections({ sourceText: clean, translatedText: out, targetLang, fieldType });
   const key = buildMemoryKey({ text: clean, sourceLang, targetLang, kind, context });
   const memoized = getMemoryEntry(key);
   if (memoized && passesQualityGate({ sourceText: clean, candidate: memoized, kind, minChars })) {

--- a/scripts/lib/translation-glossary.mjs
+++ b/scripts/lib/translation-glossary.mjs
@@ -38,26 +38,46 @@ function matchCase(sample, replacement) {
 }
 
 /**
+ * @typedef {[RegExp, string]} BodySafeRule  A narrow [badPattern, correctTerm]
+ *           pair that only ever matches the specific mistranslated COMPOUND
+ *           (e.g. "orologio notturno"), so it is safe to apply to description
+ *           bodies as well as titles.
+ * @typedef {[RegExp, string, { titleOnly: true }]} TitleOnlyRule  A broad
+ *           single-word fallback (e.g. /\borologio\b/) that must NOT run over
+ *           description bodies — a legitimate "nel nostro orologio" in prose
+ *           would be corrupted into "nel nostro a ciclo". Applied to titles only.
+ * @typedef {BodySafeRule | TitleOnlyRule} GlossaryRule
+ *
  * @typedef {Object} GlossaryEntry
  * @property {RegExp} trigger  Matched against the SOURCE text (German).
- * @property {Record<string, Array<[RegExp, string]>>} fixes  Per target locale:
- *           [badPattern, correctTerm] pairs applied to the translated output.
+ * @property {Record<string, GlossaryRule[]>} fixes  Per target locale: rules
+ *           applied to the translated output, in order.
  */
+
+/** Marks a rule as title-only (skipped on description-body fields). */
+const TITLE_ONLY = { titleOnly: true };
 
 /** @type {GlossaryEntry[]} */
 export const TRANSLATION_GLOSSARY = [
   {
     // Nursing night-shift duty (Pflege "Nachtwache" / "Dauernachtwache").
-    // Article-aware rules run first so a preceding "l'"/"les" is absorbed into a
-    // grammatical "la guardia"/"la garde" instead of leaving "l'guardia"/"les garde".
+    // Article-aware rules run first so a preceding article / contracted
+    // preposition ("l'"/"dell'"/"nell'"/"les"/"du") is absorbed into a
+    // grammatical "la guardia"/"la garde" instead of leaving "dell'guardia".
     trigger: /nachtwache/i,
     fixes: {
       it: [
-        [/\b(?:l['’]|lo|la|il)\s*orolog\w*\s+notturn\w*/gi, 'la guardia notturna'],
+        // Contracted prepositions (dell'/nell'/all'/sull'/dall') + articles
+        // (l'/lo/la/il) + "col"/"con il". The whole preposition+timepiece span
+        // collapses to the canonical "la guardia notturna" (grammatical regardless
+        // of the original contraction) instead of leaving a dangling apostrophe.
+        [/\b(?:dell['’]|nell['’]|all['’]|sull['’]|dall['’]|l['’]|lo|la|il|con\s+il|col)\s*orolog\w*\s+notturn\w*/gi, 'la guardia notturna'],
         [/orolog\w*\s+notturn\w*/gi, 'guardia notturna'],
       ],
       fr: [
-        [/\b(?:les|la|l['’])\s*montres?\s+de\s+nuit/gi, 'la garde de nuit'],
+        // Articles (les/la/l') + contracted prepositions (du/des/aux) before the
+        // mistranslated "montre de nuit".
+        [/\b(?:les|la|l['’]|du|des|aux)\s*montres?\s+de\s+nuit/gi, 'la garde de nuit'],
         [/montres?\s+de\s+nuit/gi, 'garde de nuit'],
       ],
     },
@@ -68,11 +88,14 @@ export const TRANSLATION_GLOSSARY = [
     fixes: {
       it: [
         [/montaggio\s+meccanico\s+orologio/gi, 'meccanico montaggio a ciclo'],
-        [/\borologio\b/gi, 'a ciclo'],
+        // Bare-word fallback: title-only. In a description body "il nostro
+        // orologio" (a legit timepiece reference) must not become "a ciclo".
+        [/\borologio\b/gi, 'a ciclo', TITLE_ONLY],
       ],
       en: [
         [/mechanical\s+clock\s+assembly/gi, 'cycle assembly mechanic'],
-        [/\bclock\b/gi, 'cycle'],
+        // Bare-word fallback: title-only (same body-corruption risk as IT).
+        [/\bclock\b/gi, 'cycle', TITLE_ONLY],
       ],
       fr: [[/montage\s+m[eé]canique\s+de\s+l['’\s]?horloge/gi, 'montage à la chaîne']],
     },
@@ -98,16 +121,25 @@ export const TRANSLATION_GLOSSARY = [
  * @param {string} args.sourceText      The original (source-language) text.
  * @param {string} args.translatedText  The machine-translated output to correct.
  * @param {string} args.targetLang      Target locale (it/en/de/fr).
+ * @param {('title'|'description')} [args.fieldType='title']  Which field is being
+ *           corrected. Defaults to 'title' so existing title call sites are
+ *           unchanged. For 'description', broad single-word fallback rules
+ *           (flagged `titleOnly`) are skipped so legitimate prose containing the
+ *           target word (e.g. "il nostro orologio") is never rewritten — only the
+ *           narrow compound rules, which can only match the mistranslated phrase,
+ *           run on bodies.
  * @returns {string} The corrected translation (unchanged when no rule fires).
  */
-export function applyGlossaryCorrections({ sourceText, translatedText, targetLang }) {
+export function applyGlossaryCorrections({ sourceText, translatedText, targetLang, fieldType = 'title' }) {
   let out = String(translatedText || '');
   if (!out || !sourceText || !targetLang) return out;
+  const isTitle = fieldType === 'title';
   for (const entry of TRANSLATION_GLOSSARY) {
     if (!entry.trigger.test(sourceText)) continue;
     const rules = entry.fixes[targetLang];
     if (!rules) continue;
-    for (const [pattern, replacement] of rules) {
+    for (const [pattern, replacement, opts] of rules) {
+      if (!isTitle && opts && opts.titleOnly) continue;
       out = out.replace(pattern, (m) => matchCase(m, replacement));
     }
   }

--- a/scripts/update-sbb-jobs.mjs
+++ b/scripts/update-sbb-jobs.mjs
@@ -893,6 +893,7 @@ async function parseSbbJobFromDetailUrl(detailUrl, apiMetaByUrl, apiMetaByTitle 
         text: localeDescriptions[resolvedSourceLocale],
         sourceLang: resolvedSourceLocale,
         targetLang: locale,
+        fieldType: 'description',
         maxRetries: 2,
       });
       // Keep the explicit >=120 floor alongside the ratio gate: isAcceptableTranslation's

--- a/tests/registry-key-and-uniqueness.test.ts
+++ b/tests/registry-key-and-uniqueness.test.ts
@@ -56,6 +56,26 @@ describe('fingerprintJob → registry key', () => {
     expect(fingerprintJob({ url: 'https://example.com/jobs/123456' }))
       .toBe('id|example.com|123456');
   });
+
+  it('keys a numeric-then-text id by the leading number (not collapsed by the UUID guard)', () => {
+    // teamtailor `7887338-projektleiter`, hilti `17627-fr` — the digits ARE the
+    // stable id; the leaf is not UUID-shaped so the numeric path rule still wins.
+    expect(fingerprintJob({ url: 'https://ckw.teamtailor.com/jobs/7887338-projektleiter-in' }))
+      .toBe('id|teamtailor.com|7887338');
+    expect(fingerprintJob({ url: 'https://careers.hilti.group/en/jobs/17627-fr/conseiller' }))
+      .toBe('id|hilti.group|17627');
+  });
+
+  it('keys an ancestor+leaf double-UUID URL by the LEAF (per-job) UUID, not the shared ancestor', () => {
+    // cseb shape `…/job-advertisement/<board-uuid>/<job-uuid>`: a blind first-UUID
+    // scan of the whole URL would grab the shared board uuid and collapse every
+    // cseb job onto one key. Leaf-scoped extraction keeps siblings distinct.
+    const a = fingerprintJob({ url: 'https://www.cseb.ch/job-advertisement/aaaaaaaa-1111-4111-8111-111111111111/bbbbbbbb-2222-4222-8222-222222222222' });
+    const b = fingerprintJob({ url: 'https://www.cseb.ch/job-advertisement/aaaaaaaa-1111-4111-8111-111111111111/cccccccc-3333-4333-8333-333333333333' });
+    expect(a).toBe('id|cseb.ch|bbbbbbbb-2222-4222-8222-222222222222');
+    expect(b).toBe('id|cseb.ch|cccccccc-3333-4333-8333-333333333333');
+    expect(a).not.toBe(b);
+  });
 });
 
 describe('registerJobSlug', () => {

--- a/tests/registry-key-and-uniqueness.test.ts
+++ b/tests/registry-key-and-uniqueness.test.ts
@@ -35,6 +35,27 @@ describe('fingerprintJob → registry key', () => {
     const fp = fingerprintJob({ url: '', title: 'Nurse', location: 'Bern', company: 'X' });
     expect(fp.startsWith('tl|')).toBe(true);
   });
+
+  // #2330 item 1: a full UUID slug must NOT collapse onto its leading-digit
+  // prefix. Previously `/\/jobs\/(\d+)/` captured `69` from
+  // `…/jobs/69b0fccf-…`, collapsing every prospective.ch UUID job sharing that
+  // digit run onto ONE registry key (`prospective.ch|69`) — cross-job slug
+  // contamination via registryPinnedLocaleSlug.
+  it('keys a /jobs/<uuid> URL by the full UUID, not its leading digit prefix', () => {
+    const a = fingerprintJob({ url: 'https://ohws.prospective.ch/public/v1/jobs/69b0fccf-bb38-4f6a-b75d-1f4b21e776a0' });
+    const b = fingerprintJob({ url: 'https://ohws.prospective.ch/public/v1/jobs/69a1b2c3-1111-4f6a-b75d-aaaaaaaaaaaa' });
+    expect(a).toBe('id|prospective.ch|69b0fccf-bb38-4f6a-b75d-1f4b21e776a0');
+    expect(a).not.toBe('id|prospective.ch|69');
+    // Two distinct UUID jobs sharing a leading-digit prefix stay distinct.
+    expect(a).not.toBe(b);
+  });
+
+  it('still keys a plain numeric vacancy id (no UUID present) by that number', () => {
+    expect(fingerprintJob({ url: 'https://recruitingapp-2908.umantis.com/Vacancies/3164/Description/1' }))
+      .toBe('id|umantis.com|3164');
+    expect(fingerprintJob({ url: 'https://example.com/jobs/123456' }))
+      .toBe('id|example.com|123456');
+  });
 });
 
 describe('registerJobSlug', () => {

--- a/tests/translation-glossary.test.ts
+++ b/tests/translation-glossary.test.ts
@@ -70,4 +70,74 @@ describe('translation glossary — protected-term corrections', () => {
     expect(applyGlossaryCorrections({ sourceText: '', translatedText: 'x', targetLang: 'it' })).toBe('x');
     expect(applyGlossaryCorrections({ sourceText: 'Nachtwache', translatedText: '', targetLang: 'it' })).toBe('');
   });
+
+  // ── #2330 item 3: article-aware regex covers contracted prepositions ──────────
+  it('absorbs contracted prepositions before the IT timepiece term (no dangling apostrophe)', () => {
+    for (const [contracted, translated] of [
+      ["dell'", "Responsabile dell'orologio notturno"],
+      ["nell'", "Turni nell'orologio notturno"],
+      ["all'", "Assegnato all'orologio notturno"],
+      ["sull'", "Report sull'orologio notturno"],
+    ] as const) {
+      const out = applyGlossaryCorrections({
+        sourceText: 'Pflegefachperson Nachtwache',
+        translatedText: translated,
+        targetLang: 'it',
+      });
+      // The corrected term is the canonical "la guardia notturna"; crucially no
+      // broken "dell'guardia" / "nell'guardia" is produced.
+      expect(out).toContain('la guardia notturna');
+      expect(out).not.toContain(`${contracted}guardia`);
+      expect(out).not.toMatch(/orolog/i);
+    }
+  });
+
+  it('absorbs FR contracted prepositions before "montre de nuit"', () => {
+    expect(applyGlossaryCorrections({
+      sourceText: 'Pflegefachperson Nachtwache',
+      translatedText: 'Responsable du montre de nuit',
+      targetLang: 'fr',
+    })).toBe('Responsable la garde de nuit');
+  });
+
+  // ── #2330 item 2: glossary scoped to titles; description bodies preserved ─────
+  it('applies broad single-word fallback to TITLES (default fieldType)', () => {
+    expect(applyGlossaryCorrections({
+      sourceText: 'Mechaniker Taktmontage',
+      translatedText: 'Montaggio orologio',
+      targetLang: 'it',
+    })).toBe('Montaggio a ciclo');
+  });
+
+  it('does NOT apply broad single-word fallback to DESCRIPTION bodies', () => {
+    // A legit "nel nostro orologio" in a long description must survive even when
+    // the SOURCE contains the Taktmontage trigger (the bare /\borologio\b/ rule
+    // is title-only).
+    const body = 'Lavorerai nel nostro orologio aziendale e nella catena di montaggio.';
+    expect(applyGlossaryCorrections({
+      sourceText: 'Mechaniker Taktmontage in der Fabrik',
+      translatedText: body,
+      targetLang: 'it',
+      fieldType: 'description',
+    })).toBe(body);
+    // EN clock fallback is likewise title-only on bodies.
+    const enBody = 'You will work near the factory clock during your shift.';
+    expect(applyGlossaryCorrections({
+      sourceText: 'Mechaniker Taktmontage',
+      translatedText: enBody,
+      targetLang: 'en',
+      fieldType: 'description',
+    })).toBe(enBody);
+  });
+
+  it('STILL corrects the narrow compound mistranslation in DESCRIPTION bodies', () => {
+    // The narrow "orologio notturno" compound can only mean the mistranslation,
+    // so it is corrected in bodies too (body-safe rule, not title-only).
+    expect(applyGlossaryCorrections({
+      sourceText: 'Wir suchen für die Nachtwache eine Pflegefachperson.',
+      translatedText: "Cerchiamo una persona per l'orologio notturno nel reparto.",
+      targetLang: 'it',
+      fieldType: 'description',
+    })).toBe('Cerchiamo una persona per la guardia notturna nel reparto.');
+  });
 });


### PR DESCRIPTION
## Implementato

Chiude i 3 item deferred di #2330 (follow-up del glossario timepiece #2329).

### Item 1 — gz-dielsdorf slug IT/DE corrotto (root cause trovata e fixata)
- **Causa**: `extractJobIdentityFromUrl` (`scripts/lib/dedicated-crawler-common.mjs`) intercettava le **cifre iniziali di uno slug UUID** — la regex `/\/jobs\/(\d+)/` su `…/jobs/69b0fccf-bb38-…` catturava `69`. Tutti i job prospective.ch con UUID che inizia con lo stesso run di cifre collassavano su UNA chiave registry (`prospective.ch|69`). `registryPinnedLocaleSlug` quindi force-pinava lo slug sbagliato → il record "Nachtwache" di Gesundheitszentrum Dielsdorf ereditava lo slug di un'offerta dietista SRO-Langenthal (canton BE, scaduta).
- **Fix codice**: estraggo un UUID completo dall'URL **prima** delle euristiche numeriche/path (stessa priorità di `mergeUrlKey`). I job UUID restano distinti; i casi numerici puri (umantis `/Vacancies/3164/`) invariati.
- **Fix dati committati**: corretto `data/jobs/by-crawler/gz-dielsdorf.json` (slug IT→`guardia-notturna-…`, DE→`nachtwache-…`, derivati dal titolo; slug corrotto demotato in `previousSlugs`/`previousSlugsByLocale` → **bridge 301** sull'URL indicizzato sbagliato). Rimossa la entry registry avvelenata `id|prospective.ch|69` da `data/slug-registry.json` (il prossimo crawl ri-registra con chiave full-UUID corretta).
- Test: `tests/registry-key-and-uniqueness.test.ts` (UUID non collassa sul prefisso-cifre; numerico puro preservato).

### Item 2 — over-correction glossario sui description body
- `applyGlossaryCorrections` ora accetta `fieldType` (default `'title'`, back-compat). I fallback bare-word larghi (`/\borologio\b/`→`a ciclo`, `/\bclock\b/`→`cycle`) sono flaggati `titleOnly` e **saltati sui body**, così prose legittima ("nel nostro orologio") non viene riscritta. Le regole compound strette restano body-safe.
- Threading `fieldType`: `freeTranslate`/`freeTranslateWithRetry` (`scripts/lib/free-translate.mjs`), pipeline locale via `kind` (`scripts/lib/job-localization-pipeline.mjs`), e i call site di description (`dedicated-crawler-common.mjs`, `fix-untranslated-descriptions.mjs`, `update-sbb-jobs.mjs`) passano `fieldType:'description'`.
- **Fallback helper (round-2 review #2374)**: `translateJobFieldWithFallback` (helper centrale del cascade DCC) chiamava `freeTranslateWithRetry` SENZA `fieldType` → sul path di cascade-fallback (quando `translateTextWithLocalPipeline` ritorna `''`) un campo `kind:'description'` defaultava a `'title'` e le bare-word rule giravano sul body. Ora forwarda `kind`→`fieldType` (`'title'` solo per i titoli), chiudendo l'ultima over-correction sui body.
- Test: glossario corregge titoli ma preserva body; compound stretto corretto anche su body.

### Item 3 — regex article-aware preposizioni contratte
- Regola IT assorbe `dell'`/`nell'`/`all'`/`sull'`/`dall'`/`col`/`con il` (e FR `du`/`des`/`aux`) davanti al termine timepiece → niente `dell'guardia` sgrammaticato; collassa al canonico `la guardia notturna`.
- Test: tutte le forme contratte verificate, nessun apostrofo penzolante.

### Item 4 — leaf-scoped UUID identity (🔴 review #2374, ancestor+leaf collision)
- **Causa**: la `extractUuidLikeId(full)` introdotta nell'Item 1 usava un `.match()` non-globale → ritornava la **prima** occorrenza UUID nell'INTERA URL. Per le shape con UUID ancestor condiviso + UUID per-job nel leaf — cseb `…/job-advertisement/<board-uuid>/<job-uuid>` — catturava il **board-uuid condiviso**, collassando tutti i job cseb su una sola chiave `cseb.ch|<board-uuid>` → cross-job slug-pin contamination via `registryPinnedLocaleSlug` (esattamente la collisione che la PR rimuove per prospective.ch, reintrodotta su un'altra source live: `scripts/update-cseb-jobs.mjs`, 21 entry).
- **Fix**: l'estrazione UUID è ora **scoped al segmento leaf** (allineata a `mergeUrlKey` Rule B in `scripts/lib/job-url-key.mjs`), così l'UUID per-job nel leaf batte l'UUID ancestor condiviso. Aggiunto un **loose-UUID-leaf guard** (8-4-4-4-12 hex, qualsiasi version/variant) prima delle regole numeriche `/jobs/(\d+)`: un leaf UUID non-RFC4122 (es. nibble di variant fuori da `[89ab]`, come i leaf cseb reali) non ricade più sul prefisso-cifre. Il commento inaccurato "Matches mergeUrlKey's UUID-first priority" è corretto.
- Numeric-then-text id (teamtailor `7887338-projektleiter`, hilti `17627-fr`) e prospective single-leaf-UUID invariati.
- Corpus check (9869 job): 1015 chiavi cambiano, **0 newly-empty** (URL prima senza identità — jobup/pinpointhq/axa detail page — ora keyate sul leaf uuid; net dedup/pin improvement, nessuna regressione).
- Test: `tests/registry-key-and-uniqueness.test.ts` aggiunge il caso double-UUID ancestor+leaf (leaf vince, sibling distinti) e numeric-then-text.

Tutti i test mirati verdi: `tests/translation-glossary.test.ts` (12), `tests/registry-key-and-uniqueness.test.ts` (11), `tests/job-url-key.test.ts` (34) — 57 passed.

## Non implementato (ancora)

- **FAQ translator scripts** (`scripts/batch-add-faq-to-articles.mjs`, `scripts/fix-faq-locales.mjs`): traducono FAQ q&a da sorgente **italiana**; i trigger del glossario sono parole composte **tedesche** (`nachtwache`/`taktmontage`/`wachstation`) → `entry.trigger.test(sourceText)` (source-gating) non matcha mai su sorgente IT, quindi le bare-word `titleOnly` sono irraggiungibili lì (nessuna over-correction possibile). `fieldType` non threadato by-design su questi call site — fuori dalla classe del 🔴 (path job-description, source DE). Non toccati per evitare scope-drift in dominio blog-FAQ.
- **Sibling UUID-extractor per-source** (`extractViewkey` in `update-confederazione-jobs.mjs`, `extractPostJobIdFromUrl` in `postch-job-parser.mjs`): usano anch'essi un `.match()` first-in-URL, ma le loro URL hanno **una sola** UUID (rispettivamente `…/{slug}/{uuid}` last-segment e `…/job-vacancies/{slug}/{uuid}`) — nessun UUID ancestor condiviso → non è la stessa collisione realizzata. Gli altri parser (`axa`/`ems-chemie`/`srg-ssr`/`engelvoelkers`) ancorano già l'UUID a un path-prefix/`$`. Non toccati.
- **Re-key migration completa registry prospective.ch**: esistono ~70 altre chiavi `id|prospective.ch|<cifre>` legacy (stesso bug del prefisso-UUID). Non rimosse perché ognuna pinna attualmente UN job legittimo senza collisione live (verificato: 0 collisioni multi-job nel corpus oltre a `|69`); rimuoverle in massa rischierebbe slug-churn non gated. Il fix codice impedisce nuove collisioni; le entry legacy diventano dead-weight inerte. Follow-up: migrazione gated dedicata (sulla falsariga di `scripts/migrate-collapsed-job-ids.mjs`) per ri-keyare le entry registry prospective.ch a full-UUID.
- **Verifica live del 301-bridge** sull'URL `…/ernahrungsberater-…-langenthal` corrotto → va confermata post-deploy (i dati `jobs.json` sono rigenerati in CI). (post-merge, live)

Closes #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
