### PR TITLE
feat(analytics): per-employer apply-click attribution + traffic report

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4813,6 +4813,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  const handleApply = (job: JobListing) => {
  Analytics.trackSelectContent('job_board_apply', `${job.company}_${job.title}`);
+ Analytics.trackJobApply(canonicalCompanyRouteSlug(job.company, job.companyKey), Boolean(job.featured), job.slug || job.id);
  // In-house / forward-email publisher ads apply via the on-page
  // PublisherApplyForm (#candidatura), NOT an external URL. For these,
  // applyUrl/url point back at the ad's own /lavoro/<slug> page, so opening
@@ -6842,6 +6843,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  rel="nofollow noopener noreferrer"
  onClick={() => {
  Analytics.trackSelectContent('job_board_apply', `${selectedJob.company}_${selectedJob.title}`);
+ Analytics.trackJobApply(canonicalCompanyRouteSlug(selectedJob.company, selectedJob.companyKey), Boolean(selectedJob.featured), selectedJob.slug || selectedJob.id);
  trackPublisherApplyClick(selectedJob as { publisherJobId?: string | null });
  }}
  >

--- a/scripts/employer-traffic-report.mjs
+++ b/scripts/employer-traffic-report.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Employer traffic report — "candidati inviati per azienda".
+ *
+ * Conta gli eventi GA4 `job_apply` (click "Candidati" sugli annunci) raggruppati
+ * per `employer_key`, distinguendo annunci sponsorizzati da quelli crawlati
+ * (`is_sponsored`). È il dato che alimenta sia la prova in-prodotto sia
+ * l'outreach commerciale ("vi abbiamo mandato N candidati il mese scorso, gratis").
+ *
+ * I parametri `employer_key` / `is_sponsored` sono custom dimension GA4 registrate
+ * (event-scope). NB: le custom dimension NON sono retroattive → il report copre
+ * solo i click avvenuti dopo il deploy di `trackJobApply` + la registrazione.
+ *
+ * Auth: stessa Firebase SA usata da scripts/lib/evidence/ga4Fetcher.mjs.
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=/path/sa.json node scripts/load-rc-env.mjs)"
+ *   node scripts/employer-traffic-report.mjs --days 30
+ *
+ * Flags:
+ *   --days N     finestra in giorni (default 30)
+ *   --min N      soglia minima di click per comparire (default 1)
+ *   --json PATH  scrive il report completo come JSON (default: solo stdout)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCOPES = ['https://www.googleapis.com/auth/analytics.readonly'];
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+async function getToken() {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    throw new Error('no service-account credentials (set GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_JSON)');
+  }
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    const tmp = path.join(os.tmpdir(), `firebase-sa-${process.pid}.json`);
+    fs.writeFileSync(tmp, process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = tmp;
+  }
+  const { GoogleAuth } = await import('google-auth-library');
+  const auth = new GoogleAuth({ scopes: SCOPES });
+  const client = await auth.getClient();
+  const { token } = await client.getAccessToken();
+  return token;
+}
+
+/** Slug normalizer (loose match to canonicalCompanyRouteSlug for display join). */
+function slugify(s) {
+  return String(s || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/** Load crawled-employer registry for display name + careers URL enrichment. */
+function loadCompanies() {
+  const out = new Map();
+  const file = path.join(__dirname, '..', 'data', 'crawler-companies-auto.json');
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const list = Array.isArray(raw) ? raw : Array.isArray(raw.companies) ? raw.companies : Object.values(raw);
+    for (const c of list) {
+      if (!c || typeof c !== 'object') continue;
+      const key = slugify(c.key || c.name);
+      if (key) out.set(key, { name: c.name || c.key, careersUrl: c.careersUrl || c.website || '' });
+    }
+  } catch { /* registry optional — report still works with raw keys */ }
+  return out;
+}
+
+async function run() {
+  const days = Number(arg('--days', '30'));
+  const min = Number(arg('--min', '1'));
+  const jsonPath = arg('--json', '');
+
+  const prop = process.env.GA4_PROPERTY_ID;
+  if (!prop) { console.error('NO GA4_PROPERTY_ID (load via scripts/load-rc-env.mjs)'); process.exit(2); }
+  const property = prop.startsWith('properties/') ? prop : `properties/${prop}`;
+  const token = await getToken();
+
+  const body = {
+    dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
+    dimensions: [{ name: 'customEvent:employer_key' }, { name: 'customEvent:is_sponsored' }],
+    metrics: [{ name: 'eventCount' }],
+    dimensionFilter: { filter: { fieldName: 'eventName', stringFilter: { value: 'job_apply' } } },
+    orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+    limit: 1000,
+  };
+  const r = await fetch(`https://analyticsdata.googleapis.com/v1beta/${property}:runReport`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const j = await r.json();
+  if (j.error) { console.error('GA4 error:', JSON.stringify(j.error).slice(0, 400)); process.exit(1); }
+
+  const companies = loadCompanies();
+  const byEmployer = new Map();
+  for (const row of (j.rows || [])) {
+    const key = row.dimensionValues[0].value;
+    const sponsored = row.dimensionValues[1].value === 'sponsored';
+    const count = Number(row.metricValues[0].value) || 0;
+    const e = byEmployer.get(key) || { key, free: 0, sponsored: 0 };
+    if (sponsored) e.sponsored += count; else e.free += count;
+    byEmployer.set(key, e);
+  }
+
+  const rows = [...byEmployer.values()]
+    .map(e => {
+      const meta = companies.get(e.key) || {};
+      return { ...e, total: e.free + e.sponsored, name: meta.name || e.key, careersUrl: meta.careersUrl || '' };
+    })
+    .filter(e => e.total >= min)
+    .sort((a, b) => b.total - a.total);
+
+  const totalFree = rows.reduce((s, e) => s + e.free, 0);
+  const totalSpon = rows.reduce((s, e) => s + e.sponsored, 0);
+
+  console.log(`\n📊 Candidati inviati per azienda — ultimi ${days} giorni (property ${property})`);
+  console.log(`   ${rows.length} aziende · ${totalFree} click free · ${totalSpon} click sponsorizzati\n`);
+  console.log('  #  TOT   FREE  SPON  AZIENDA');
+  rows.forEach((e, i) => {
+    console.log(
+      `${String(i + 1).padStart(3)}  ${String(e.total).padStart(4)}  ${String(e.free).padStart(4)}  ${String(e.sponsored).padStart(4)}  ${e.name}${e.careersUrl ? '  ' + e.careersUrl : ''}`,
+    );
+  });
+  if (!rows.length) {
+    console.log('  (nessun evento job_apply — atteso finché il deploy di trackJobApply non accumula dati; le custom dimension non sono retroattive)');
+  }
+
+  if (jsonPath) {
+    fs.writeFileSync(jsonPath, JSON.stringify({ generatedDays: days, property, totals: { free: totalFree, sponsored: totalSpon }, employers: rows }, null, 2));
+    console.log(`\n💾 JSON → ${jsonPath}`);
+  }
+}
+
+run().catch(e => { console.error(e.message || e); process.exit(1); });

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1405,6 +1405,22 @@ export const Analytics = {
  },
 
  /**
+ * Candidatura su un annuncio — emette `job_apply` con attribuzione per-azienda
+ * pulita. `employer_key` è una stable slug (companyKey o derivata dal nome) e
+ * `is_sponsored` distingue annunci sponsorizzati (featured) da quelli crawlati.
+ * Entrambi i parametri sono custom dimension GA4 registrate, così il report
+ * "candidati inviati per azienda" è interrogabile via Data API. Affianca (non
+ * sostituisce) lo `select_content('job_board_apply', …)` esistente.
+ */
+ trackJobApply: (employerKey: string, isSponsored: boolean, jobSlug?: string) => {
+ log('job_apply', {
+ employer_key: employerKey || 'unknown',
+ is_sponsored: isSponsored ? 'sponsored' : 'free',
+ job_slug: jobSlug || '',
+ });
+ },
+
+ /**
  * Interazione grafico — single event, no double-fire with select_content
  */
  trackChartInteraction: (chartType: string, action: string) => {


### PR DESCRIPTION
## Contesto

Primo passo eseguibile della strategia per convertire le aziende crawlate in inserzionisti sponsorizzati. La leva centrale dell'outreach è la **reciprocità misurata**: "vi mandiamo già N candidati al mese, gratis". Ma quel numero, prima di questa PR, non era estraibile per-azienda.

Verifica fatta su GA4 (property 524485296): sul click "Candidati" parte già `select_content('job_board_apply', '{company}_{title}')`, ma con l'azienda dentro una label testo libero **non interrogabile per-azienda** via Data API (`content_type`/`item_id` non sono custom dimension registrate). 123k `select_content`/90gg raccolti ma non segmentabili per datore.

## Implementato

- `Analytics.trackJobApply(employerKey, isSponsored, jobSlug)` in `services/analytics.ts`: emette un evento `job_apply` con attribuzione pulita — `employer_key` (stable slug via `canonicalCompanyRouteSlug`, robusto anche senza `companyKey`) e `is_sponsored` (featured vs crawlato). Affianca, non sostituisce, lo `select_content` esistente.
- Chiamata aggiunta a **entrambi** i punti di apply in `components/community/JobBoard.tsx`: `handleApply` (lista) e l'anchor CTA del dettaglio. Sono gli unici due siti che emettono `job_board_apply` (grep verificato).
- `scripts/employer-traffic-report.mjs`: interroga GA4 `job_apply` raggruppato per `employer_key`, distingue click free vs sponsorizzati, fa join con `data/crawler-companies-auto.json` per nome/careersUrl, emette report ordinato (stdout + `--json`). Riusa l'auth Firebase SA di `ga4Fetcher.mjs`. Validato end-to-end (auth OK, query ben formata, 0 righe atteso pre-deploy).
- Custom dimension GA4 `employer_key` e `is_sponsored` (EVENT scope) **registrate** via Admin API (SA Firebase ha i permessi). Non retroattive: il report accumula da quando l'evento gira live.

## Non implementato (ancora)

- **Dati storici per-azienda**: le custom dimension GA4 non sono retroattive → il report parte vuoto e si popola post-deploy. Nessun recupero dei 123k eventi storici possibile senza export BigQuery (non collegato, a costo). Atteso e dichiarato.
- **52 file gemello segnalati da `check-sibling-patterns.mjs`**: condividono solo idiomi generici della GA4 Data API (`GoogleAuth`, `runReport`, `dateRanges`, `dimensionFilter`…) e identificatori comuni (`byEmployer`, `employerKey`, `canonicalCompanyRouteSlug`, `careersUrl`). Non è un antipattern corretto e replicato: questa PR **aggiunge** un evento + un report, non fixa un pattern. Nessun sibling da modificare.
- **Outreach (cold email + enrichment email HR + report in-prodotto)**: scope successivo della strategia, fuori da questa PR infrastrutturale. Doc strategia completa salvata a parte.
- **Piano Azienda/Brand (pricing bundle)**: decisione di packaging, follow-up.

## Test plan

- [x] Report script gira end-to-end (auth GA4, query, join registry) — 0 righe pre-deploy, atteso.
- [x] `customEvent:employer_key` accettato dalla Data API (dimension registrata) — nessun 400.
- [ ] Post-deploy: verificare che `job_apply` arrivi in GA4 con `employer_key`/`is_sponsored` valorizzati (DebugView), poi `node scripts/employer-traffic-report.mjs --days 7` mostra le prime aziende.

GitNexus impact su `handleApply`: LOW (solo `JobBoard` lo chiama, modifica additiva).