### PR TITLE
fix(newsletter): stamp weekly_* campaign id on Mailjet/Mailtrap by tag name (#2080)

### DIFF
--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -43,11 +43,16 @@ function mapMailjetEvent(event) {
 // ── Extract campaign ID from Mailjet event data ──────────────
 
 function extractCampaignId(eventData) {
- // CustomID is set by our email-cascade when sending via Mailjet Send API
+ // CustomID is set by our email-cascade (campaignIdTag → the `weekly_*` id) when
+ // sending via the Mailjet Send API, and Mailjet echoes it back on every event
+ // (incl. open/click). Preferring it here is what makes Mailjet open events
+ // match the A/B report's `events where campaign_id == weekly_*` query — keep it
+ // FIRST so opens are never bucketed under Mailjet's internal numeric id.
  if (eventData.CustomID) return String(eventData.CustomID);
  // customcampaign is Mailjet's own campaign name field
  if (eventData.customcampaign) return String(eventData.customcampaign);
- // mj_campaign_id is Mailjet's internal campaign ID
+ // mj_campaign_id is Mailjet's internal numeric campaign id (last-resort fallback
+ // only — the A/B report cannot match opens carrying this instead of weekly_*).
  if (eventData.mj_campaign_id) return String(eventData.mj_campaign_id);
  return 'unknown';
 }

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -372,7 +372,7 @@ async function sendViaMailjet(email) {
         Subject: email.subject,
         HTMLPart: email.html,
         TextPart: email.text || undefined,
-        CustomID: email.tags?.[0]?.value || undefined,
+        CustomID: campaignIdTag(email),
       }],
     }),
   });
@@ -486,7 +486,7 @@ async function sendViaMailtrap(email) {
     html: email.html,
   };
   if (email.text) body.text = email.text;
-  if (email.tags?.length) body.category = email.tags[0].value;
+  if (email.tags?.length) body.category = campaignIdTag(email);
   if (email.headers && typeof email.headers === 'object') body.headers = email.headers;
 
   const res = await fetch('https://send.api.mailtrap.io/api/send', {
@@ -883,6 +883,25 @@ function parseEmailAddress(from) {
 }
 
 /**
+ * The campaign id to stamp on providers that carry a single opaque tracking
+ * token (Mailjet `CustomID`, Mailtrap `category`). Looks the tag up BY NAME
+ * (`campaign_id`) rather than by position: the newsletter pipeline builds the
+ * `tags` array with `campaign_id` first, but that order is incidental, and a
+ * positional `tags[0]` silently stamps the wrong token if the order ever
+ * changes — breaking the A/B report's `events where campaign_id == weekly_*`
+ * match for Mailjet opens (those open events echo back this CustomID). Falls
+ * back to the first tag for non-newsletter callers that pass a single tag.
+ * @param {{ tags?: Array<{name?: string, value?: string}> }} email
+ * @returns {string|undefined}
+ */
+function campaignIdTag(email) {
+  const tags = email?.tags;
+  if (!Array.isArray(tags) || tags.length === 0) return undefined;
+  const named = tags.find((t) => t?.name === 'campaign_id');
+  return (named ?? tags[0])?.value || undefined;
+}
+
+/**
  * Total theoretical daily send capacity across the whole cascade —
  * the sum of every provider's daily limit (currently mailgun 100 + resend 100
  * + mailjet 200 + mailtrap 150 + maileroo 100 + cloudflare 100 = 750). Single
@@ -893,4 +912,4 @@ export function getCascadeDailyCapacity() {
   return PROVIDERS.reduce((sum, p) => sum + p.dailyLimit, 0);
 }
 
-export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs, isRateLimitedError };
+export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs, isRateLimitedError, campaignIdTag };

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -5,6 +5,7 @@ import {
   fetchMailtrapDailyUsage,
   fetchCloudflareUsage,
   fetchCloudflareDeliveryStats,
+  campaignIdTag,
   PROVIDERS,
 } from '../scripts/lib/email-cascade.mjs';
 
@@ -323,5 +324,43 @@ describe('fetchCloudflareUsage / fetchCloudflareDeliveryStats', () => {
       json: async () => ({ errors: [{ message: 'auth' }] }),
     })) as any;
     expect(await fetchCloudflareDeliveryStats('2026-06-16', '2026-06-16')).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  campaignIdTag — single-token providers stamp the weekly_* id       */
+/* ------------------------------------------------------------------ */
+
+describe('campaignIdTag', () => {
+  it('resolves the campaign_id tag BY NAME regardless of position', () => {
+    // Order intentionally NOT campaign-id-first → positional tags[0] would be wrong.
+    const email = {
+      tags: [
+        { name: 'subscriber_locale', value: 'it' },
+        { name: 'variant', value: 'b' },
+        { name: 'campaign_id', value: 'weekly_2026-06-15' },
+      ],
+    };
+    expect(campaignIdTag(email)).toBe('weekly_2026-06-15');
+  });
+
+  it('matches the newsletter pipeline order (campaign_id first)', () => {
+    const email = {
+      tags: [
+        { name: 'campaign_id', value: 'weekly_2026-06-15' },
+        { name: 'subscriber_locale', value: 'de' },
+      ],
+    };
+    expect(campaignIdTag(email)).toBe('weekly_2026-06-15');
+  });
+
+  it('falls back to the first tag for single-tag callers', () => {
+    expect(campaignIdTag({ tags: [{ name: 'job-alert', value: 'job-alert' }] })).toBe('job-alert');
+  });
+
+  it('returns undefined when there are no tags', () => {
+    expect(campaignIdTag({})).toBeUndefined();
+    expect(campaignIdTag({ tags: [] })).toBeUndefined();
+    expect(campaignIdTag(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Follow-up su #2080 (deferred items di #2075 — subject-line A/B test + open-rate report). Verificato lo stato di tutti e 4 gli item; fixato l'unico realmente azionabile e non già risolto a monte.

## Implementato
- **Item 4 (Mailjet opens non contati):** nuovo helper condiviso `campaignIdTag(email)` in `scripts/lib/email-cascade.mjs` che risolve il tag `campaign_id` **per nome** invece che per posizione. Prima `sendViaMailjet` (`CustomID`) e `sendViaMailtrap` (`category`) leggevano `email.tags?.[0]?.value`: la pipeline newsletter mette `campaign_id` come primo tag ma quell'ordine è incidentale → un reorder avrebbe stampato il token sbagliato, rompendo il match `events where campaign_id == weekly_*` del report A/B per gli open Mailjet (gli open echo-ano indietro il `CustomID`). Entrambi i call-site ora usano `campaignIdTag` (fix dell'intera classe, non solo Mailjet — Mailtrap è il sibling con lo stesso costrutto posizionale).
- **Item 4 (webhook side):** hardening del commento di `extractCampaignId` in `functions/src/newsletterMailjetWebhookCore.js` per documentare il contratto `weekly_*` e il motivo per cui `CustomID` resta FIRST (la logica era già corretta — `CustomID` preferito a `mj_campaign_id`).
- **Test:** 4 nuovi casi `campaignIdTag` in `tests/email-cascade-burst.test.ts` (lookup by-name con ordine non-canonico, ordine canonico, fallback single-tag, no-tags → undefined). `npx vitest run tests/email-cascade-burst.test.ts tests/newsletter-mailjet-webhook-core.test.ts` → 39 passed.

## Non implementato (ancora)
- **Item 2 (divergenza domenica `currentWeeklyCampaignId`):** già risolto su `main` — `scripts/newsletter-ab-report.mjs:50` usa `now.getDate() - ((now.getDay() + 6) % 7)`, identico a `send-newsletter.mjs:1896`. Nessun diff necessario.
- **Item 3 (legacy `sendEmailBatchResend` -> provider null):** già risolto su `main` — `scripts/send-newsletter.mjs:1587` chiama `persistDelivery(item.recipient, msgId, { ...item.meta, provider: 'resend' })`. Nessun diff necessario.
- **Item 1 (divergenza delivery-doc-id `__` vs `_`):** non corretto — è immune by design. Il report (`scripts/lib/newsletter-ab-data.mjs`) conta gli open via OR di segnali (events-query + `opened_at`) e filtra al solo doc canonico `buildDeliveryDocId` (`__`), scartando i duplicati dei 5 webhook (`_`). Unificare il formato richiederebbe un migration script che riscrive 6 webhook + i doc storici = drive-by ampio, fuori scope chirurgico; il modulo condiviso `functions/src/lib/deliveryDocId.js` già documenta la divergenza come intenzionale. Candidato follow-up solo se in futuro un path analytics leggerà i delivery-doc per id.
- **Sibling-check:** `node scripts/ci/check-sibling-patterns.mjs` flagga `scripts/check-email-quotas.mjs` per i token condivisi `isProviderConfigured`/`syncQuotasFromAPIs` (helper di quota che ho solo ri-elencato nell'export), NON per l'antipattern posizionale `tags[0]` — verificato: il file non contiene `tags[0]`/`CustomID`/`category`. Nessun sibling-fix dovuto.

Closes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)