### PR TITLE
feat(outreach): PostHog historical employer report + cold-email draft system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,8 @@ apm_modules/
 content-manifest.tsv
 prev-content-manifest.tsv
 __pycache__/
+
+# Employer outreach — local-only business contacts, traffic data, generated drafts
+data/employer-outreach/contacts.json
+data/employer-outreach/report.json
+data/employer-outreach/drafts/

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6886,6 +6886,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  onClick={(e) => {
  if (isInHouseApply) { e.preventDefault(); scrollToCandidatura(); }
  Analytics.trackSelectContent('job_board_apply_header_logo', `${selectedJob.company}_${selectedJob.title}`);
+ Analytics.trackJobApply(canonicalCompanyRouteSlug(selectedJob.company, selectedJob.companyKey), Boolean(selectedJob.featured), selectedJob.slug || selectedJob.id);
  trackPublisherApplyClick(selectedJob as { publisherJobId?: string | null });
  }}
  aria-label={`${t('jobBoard.apply')} ${selectedJob.company}`}
@@ -6914,6 +6915,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  onClick={(e) => {
  if (isInHouseApply) { e.preventDefault(); scrollToCandidatura(); }
  Analytics.trackSelectContent('job_board_apply_header_title', `${selectedJob.company}_${selectedJob.title}`);
+ Analytics.trackJobApply(canonicalCompanyRouteSlug(selectedJob.company, selectedJob.companyKey), Boolean(selectedJob.featured), selectedJob.slug || selectedJob.id);
  trackPublisherApplyClick(selectedJob as { publisherJobId?: string | null });
  }}
  className="hover:underline decoration-2 underline-offset-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"

--- a/data/employer-outreach/README.md
+++ b/data/employer-outreach/README.md
@@ -1,0 +1,50 @@
+# Employer outreach — convertire le aziende crawlate in inserzionisti sponsorizzati
+
+Sistema per il pitch commerciale alle aziende di cui crawliamo gli annunci. Leva
+centrale: **reciprocità misurata** — mandiamo loro candidati gratis ogni mese e
+possiamo dimostrarlo col numero reale. Gancio: click ≠ candidatura; lo
+sponsorizzato fa arrivare il CV diretto.
+
+## ⚠️ Nessun invio automatico
+
+Questo modulo **non invia email**. `generate-cold-emails.mjs` produce solo bozze
+markdown per revisione umana e non importa alcun provider di invio. L'invio
+resta un passo separato, manuale e deliberato.
+
+## Pipeline
+
+```bash
+# 1) Estrai la classifica candidati-per-azienda (storico, da PostHog)
+eval "$(GOOGLE_APPLICATION_CREDENTIALS=/path/sa.json node scripts/load-rc-env.mjs)"
+node scripts/employer-traffic-report.mjs --source posthog --days 90 \
+  --json data/employer-outreach/report.json
+
+# 2) (enrichment manuale) crea contacts.json dalle email HR delle aziende target
+cp data/employer-outreach/contacts.example.json data/employer-outreach/contacts.json
+#   …compila le email reali (pagine careers / LinkedIn)
+
+# 3) Genera le bozze personalizzate (4-touch) per i top target privati
+node scripts/generate-cold-emails.mjs \
+  --report data/employer-outreach/report.json --top 10
+#   → bozze in data/employer-outreach/drafts/*.md (una per azienda)
+```
+
+## File
+
+- `contacts.example.json` — template registry contatti (committato).
+- `contacts.json` — contatti reali (**untracked**, `.gitignore`).
+- `report.json` — output del report (**untracked**: contiene dati di traffico).
+- `drafts/` — bozze email generate (**untracked**).
+
+## Targeting
+
+Di default il generatore **esclude gli enti pubblici** (EOC, Città di Lugano,
+Amministrazione Cantonale, USI/SUPSI, FFS…): pubblicano concorsi obbligatori e
+difficilmente comprano sponsorizzati. I target sono i datori privati ad alto
+volume di candidati inviati. Usa `--include-public` per forzarne l'inclusione.
+
+## Prossimi step (non ancora implementati)
+
+- Enrichment automatico delle email HR dalle pagine careers crawlate.
+- Step di invio gated (provider via cascade esistente) — separato, con conferma.
+- Report in-prodotto per azienda (dashboard inserzionista).

--- a/data/employer-outreach/contacts.example.json
+++ b/data/employer-outreach/contacts.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Template registry contatti HR per l'outreach. Copia in contacts.json (untracked) e compila con le email reali raccolte in fase di enrichment. Chiave = employer key (slug) o nome esatto come appare nel report. Nessuna email reale va committata: contacts.json è in .gitignore.",
+  "casale-sa": {
+    "contactName": "",
+    "email": "",
+    "careersUrl": "",
+    "note": "es. trovata su pagina careers / LinkedIn"
+  },
+  "aldi-suisse": {
+    "contactName": "",
+    "email": "",
+    "careersUrl": "https://www.aldi.ch",
+    "note": ""
+  }
+}

--- a/scripts/employer-traffic-report.mjs
+++ b/scripts/employer-traffic-report.mjs
@@ -2,23 +2,37 @@
 /**
  * Employer traffic report — "candidati inviati per azienda".
  *
- * Conta gli eventi GA4 `job_apply` (click "Candidati" sugli annunci) raggruppati
- * per `employer_key`, distinguendo annunci sponsorizzati da quelli crawlati
- * (`is_sponsored`). È il dato che alimenta sia la prova in-prodotto sia
- * l'outreach commerciale ("vi abbiamo mandato N candidati il mese scorso, gratis").
+ * Conta i candidati che mandiamo (gratis) verso il sito di ogni azienda, cioè
+ * i click "Candidati" sugli annunci, distinguendo sponsorizzati da crawlati.
+ * È il dato che alimenta sia la prova in-prodotto sia l'outreach commerciale
+ * ("vi abbiamo mandato N candidati il mese scorso, gratis").
  *
- * I parametri `employer_key` / `is_sponsored` sono custom dimension GA4 registrate
- * (event-scope). NB: le custom dimension NON sono retroattive → il report copre
- * solo i click avvenuti dopo il deploy di `trackJobApply` + la registrazione.
+ * DUE SORGENTI (i touchpoint emettono entrambi gli eventi via analytics.ts):
  *
- * Auth: stessa Firebase SA usata da scripts/lib/evidence/ga4Fetcher.mjs.
+ *   --source posthog  (DEFAULT) — interroga lo STORICO via HogQL su PostHog.
+ *       Aggrega `select_content` con content_type IN (job_board_apply,
+ *       job_board_apply_header_logo, job_board_apply_header_title) — tutti i
+ *       punti da cui un candidato esce verso l'azienda (titolo, logo, bottone).
+ *       Azienda estratta dalla label `item_id = "<company>_<title>"`.
+ *       Vantaggio: HogQL legge le proprietà raw → dati RETROATTIVI, niente
+ *       custom dimension richieste. Usalo per partire subito.
+ *
+ *   --source ga4 — interroga l'evento pulito `job_apply` (employer_key +
+ *       is_sponsored, custom dimension registrate). Solo dati POST-deploy
+ *       (le custom dimension GA4 non sono retroattive).
+ *
+ * Metrica primaria = PERSONE DISTINTE (i candidati reali), non i click grezzi:
+ * un candidato che clicca logo+titolo+bottone è UNA persona, non tre.
+ *
+ * Auth: stessa Firebase SA / PostHog key caricate da scripts/load-rc-env.mjs:
  *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=/path/sa.json node scripts/load-rc-env.mjs)"
- *   node scripts/employer-traffic-report.mjs --days 30
+ *   node scripts/employer-traffic-report.mjs --days 90
  *
  * Flags:
- *   --days N     finestra in giorni (default 30)
- *   --min N      soglia minima di click per comparire (default 1)
- *   --json PATH  scrive il report completo come JSON (default: solo stdout)
+ *   --source posthog|ga4   sorgente dati (default posthog)
+ *   --days N               finestra in giorni (default 90)
+ *   --min N                soglia minima candidati per comparire (default 1)
+ *   --json PATH            scrive il report completo come JSON
  */
 
 import fs from 'node:fs';
@@ -27,27 +41,10 @@ import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCOPES = ['https://www.googleapis.com/auth/analytics.readonly'];
 
 function arg(name, def) {
   const i = process.argv.indexOf(name);
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
-}
-
-async function getToken() {
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-    throw new Error('no service-account credentials (set GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_JSON)');
-  }
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-    const tmp = path.join(os.tmpdir(), `firebase-sa-${process.pid}.json`);
-    fs.writeFileSync(tmp, process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = tmp;
-  }
-  const { GoogleAuth } = await import('google-auth-library');
-  const auth = new GoogleAuth({ scopes: SCOPES });
-  const client = await auth.getClient();
-  const { token } = await client.getAccessToken();
-  return token;
 }
 
 /** Slug normalizer (loose match to canonicalCompanyRouteSlug for display join). */
@@ -69,72 +66,111 @@ function loadCompanies() {
       const key = slugify(c.key || c.name);
       if (key) out.set(key, { name: c.name || c.key, careersUrl: c.careersUrl || c.website || '' });
     }
-  } catch { /* registry optional — report still works with raw keys */ }
+  } catch { /* registry optional */ }
   return out;
 }
 
-async function run() {
-  const days = Number(arg('--days', '30'));
-  const min = Number(arg('--min', '1'));
-  const jsonPath = arg('--json', '');
+// ───────────────────────── PostHog (HogQL, historical) ─────────────────────────
+async function fromPostHog(days) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+  if (!apiKey || !projectId) throw new Error('no POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID');
+  const query = `
+    SELECT splitByChar('_', coalesce(toString(properties.item_id), ''))[1] AS company,
+           count(DISTINCT person_id) AS candidates,
+           count() AS clicks
+    FROM events
+    WHERE event = 'select_content'
+      AND properties.content_type IN ('job_board_apply','job_board_apply_header_logo','job_board_apply_header_title')
+      AND coalesce(toString(properties.item_id), '') != ''
+      AND timestamp >= now() - interval ${days} day
+    GROUP BY company
+    ORDER BY candidates DESC
+    LIMIT 1000`.trim();
+  const r = await fetch(`${host}/api/projects/${projectId}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!r.ok) throw new Error(`posthog ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const rows = (await r.json()).results || [];
+  // PostHog non distingue sponsored vs free dalla label item_id → sponsored=0.
+  return rows.map(([company, candidates, clicks]) => ({
+    key: slugify(company), displayFromData: company, candidates: Number(candidates) || 0,
+    clicks: Number(clicks) || 0, sponsored: 0,
+  }));
+}
 
+// ───────────────────────── GA4 (job_apply, post-deploy) ─────────────────────────
+async function fromGa4(days) {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    const tmp = path.join(os.tmpdir(), `firebase-sa-${process.pid}.json`);
+    fs.writeFileSync(tmp, process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = tmp;
+  }
   const prop = process.env.GA4_PROPERTY_ID;
-  if (!prop) { console.error('NO GA4_PROPERTY_ID (load via scripts/load-rc-env.mjs)'); process.exit(2); }
+  if (!prop) throw new Error('no GA4_PROPERTY_ID');
   const property = prop.startsWith('properties/') ? prop : `properties/${prop}`;
-  const token = await getToken();
-
-  const body = {
-    dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
-    dimensions: [{ name: 'customEvent:employer_key' }, { name: 'customEvent:is_sponsored' }],
-    metrics: [{ name: 'eventCount' }],
-    dimensionFilter: { filter: { fieldName: 'eventName', stringFilter: { value: 'job_apply' } } },
-    orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
-    limit: 1000,
-  };
+  const { GoogleAuth } = await import('google-auth-library');
+  const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/analytics.readonly'] });
+  const { token } = await (await auth.getClient()).getAccessToken();
   const r = await fetch(`https://analyticsdata.googleapis.com/v1beta/${property}:runReport`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({
+      dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
+      dimensions: [{ name: 'customEvent:employer_key' }, { name: 'customEvent:is_sponsored' }],
+      metrics: [{ name: 'totalUsers' }, { name: 'eventCount' }],
+      dimensionFilter: { filter: { fieldName: 'eventName', stringFilter: { value: 'job_apply' } } },
+      orderBys: [{ metric: { metricName: 'totalUsers' }, desc: true }],
+      limit: 1000,
+    }),
   });
   const j = await r.json();
-  if (j.error) { console.error('GA4 error:', JSON.stringify(j.error).slice(0, 400)); process.exit(1); }
-
-  const companies = loadCompanies();
-  const byEmployer = new Map();
+  if (j.error) throw new Error(`GA4: ${JSON.stringify(j.error).slice(0, 200)}`);
+  const byKey = new Map();
   for (const row of (j.rows || [])) {
     const key = row.dimensionValues[0].value;
     const sponsored = row.dimensionValues[1].value === 'sponsored';
-    const count = Number(row.metricValues[0].value) || 0;
-    const e = byEmployer.get(key) || { key, free: 0, sponsored: 0 };
-    if (sponsored) e.sponsored += count; else e.free += count;
-    byEmployer.set(key, e);
+    const users = Number(row.metricValues[0].value) || 0;
+    const clicks = Number(row.metricValues[1].value) || 0;
+    const e = byKey.get(key) || { key, candidates: 0, clicks: 0, sponsored: 0 };
+    e.candidates += users; e.clicks += clicks; if (sponsored) e.sponsored += users;
+    byKey.set(key, e);
   }
+  return [...byKey.values()];
+}
 
-  const rows = [...byEmployer.values()]
+async function run() {
+  const source = arg('--source', 'posthog');
+  const days = Number(arg('--days', '90'));
+  const min = Number(arg('--min', '1'));
+  const jsonPath = arg('--json', '');
+
+  const raw = source === 'ga4' ? await fromGa4(days) : await fromPostHog(days);
+  const companies = loadCompanies();
+  const rows = raw
     .map(e => {
       const meta = companies.get(e.key) || {};
-      return { ...e, total: e.free + e.sponsored, name: meta.name || e.key, careersUrl: meta.careersUrl || '' };
+      return { ...e, name: e.displayFromData || meta.name || e.key, careersUrl: meta.careersUrl || '' };
     })
-    .filter(e => e.total >= min)
-    .sort((a, b) => b.total - a.total);
+    .filter(e => e.candidates >= min)
+    .sort((a, b) => b.candidates - a.candidates);
 
-  const totalFree = rows.reduce((s, e) => s + e.free, 0);
-  const totalSpon = rows.reduce((s, e) => s + e.sponsored, 0);
+  const totCand = rows.reduce((s, e) => s + e.candidates, 0);
+  const totClick = rows.reduce((s, e) => s + e.clicks, 0);
 
-  console.log(`\n📊 Candidati inviati per azienda — ultimi ${days} giorni (property ${property})`);
-  console.log(`   ${rows.length} aziende · ${totalFree} click free · ${totalSpon} click sponsorizzati\n`);
-  console.log('  #  TOT   FREE  SPON  AZIENDA');
+  console.log(`\n📊 Candidati inviati per azienda — sorgente ${source}, ultimi ${days} giorni`);
+  console.log(`   ${rows.length} aziende · ${totCand} candidati distinti · ${totClick} click totali\n`);
+  console.log('  #  CAND  CLICK  AZIENDA');
   rows.forEach((e, i) => {
-    console.log(
-      `${String(i + 1).padStart(3)}  ${String(e.total).padStart(4)}  ${String(e.free).padStart(4)}  ${String(e.sponsored).padStart(4)}  ${e.name}${e.careersUrl ? '  ' + e.careersUrl : ''}`,
-    );
+    console.log(`${String(i + 1).padStart(3)}  ${String(e.candidates).padStart(4)}  ${String(e.clicks).padStart(5)}  ${e.name}${e.careersUrl ? '  ' + e.careersUrl : ''}`);
   });
-  if (!rows.length) {
-    console.log('  (nessun evento job_apply — atteso finché il deploy di trackJobApply non accumula dati; le custom dimension non sono retroattive)');
-  }
+  if (!rows.length) console.log('  (nessun dato per questa sorgente/finestra)');
 
   if (jsonPath) {
-    fs.writeFileSync(jsonPath, JSON.stringify({ generatedDays: days, property, totals: { free: totalFree, sponsored: totalSpon }, employers: rows }, null, 2));
+    fs.writeFileSync(jsonPath, JSON.stringify({ source, days, totals: { candidates: totCand, clicks: totClick }, employers: rows }, null, 2));
     console.log(`\n💾 JSON → ${jsonPath}`);
   }
 }

--- a/scripts/generate-cold-emails.mjs
+++ b/scripts/generate-cold-emails.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Cold-email DRAFT generator — sistema di outreach per convertire le aziende
+ * crawlate in inserzionisti sponsorizzati.
+ *
+ * ⚠️  NON INVIA NULLA. Genera solo BOZZE su file per revisione umana.
+ *     Nessun provider email viene importato o chiamato. L'invio resterà un
+ *     passo separato, manuale e gated (vedi `## Non implementato` nella PR).
+ *
+ * Pipeline:
+ *   1) node scripts/employer-traffic-report.mjs --source posthog --days 90 \
+ *        --json data/employer-outreach/report.json
+ *   2) (enrichment manuale) compila data/employer-outreach/contacts.json con le
+ *      email HR delle aziende target — vedi contacts.example.json.
+ *   3) node scripts/generate-cold-emails.mjs --report data/employer-outreach/report.json \
+ *        --out data/employer-outreach/drafts --top 10
+ *
+ * La leva: ogni email parte col numero REALE di candidati che abbiamo già
+ * mandato gratis a quell'azienda (reciprocità misurata). Il gancio: click ≠
+ * candidatura — lo sponsorizzato fa arrivare il CV diretto.
+ *
+ * Flags:
+ *   --report PATH    JSON prodotto da employer-traffic-report.mjs (richiesto)
+ *   --contacts PATH  registry email HR (default data/employer-outreach/contacts.json)
+ *   --out DIR        cartella bozze (default data/employer-outreach/drafts)
+ *   --top N          genera per le prime N aziende per candidati (default 10)
+ *   --min N          soglia minima candidati (default 10)
+ *   --include-public includi anche enti pubblici (default: esclusi — concorsi
+ *                    obbligatori, non comprano sponsorizzati)
+ *   --days-label STR etichetta periodo nelle email (default "negli ultimi 90 giorni")
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return def;
+  const next = process.argv[i + 1];
+  return next && !next.startsWith('--') ? next : true; // boolean flags
+}
+
+// Enti pubblici / para-pubblici ticinesi: pubblicano concorsi obbligatori,
+// improbabili acquirenti di annunci sponsorizzati → esclusi di default.
+const PUBLIC_SECTOR = [
+  /ente ospedaliero|^eoc\b/i, /città di|comune di|municipio/i, /amministrazione cantonale/i,
+  /università|^usi\b|supsi/i, /istituti sociali|^lis\b/i, /ferrovie|^ffs\b|officine/i,
+  /pro senectute/i, /cantonal|repubblica e cantone/i,
+];
+const isPublic = (name) => PUBLIC_SECTOR.some((re) => re.test(name));
+
+const PRICE = 'CHF 49 al mese per annuncio';
+
+/** Le 4 email della sequenza. Tutte personalizzate col numero reale di candidati. */
+function buildSequence({ company, candidates, periodLabel, contactName }) {
+  const hi = contactName ? `Ciao ${contactName},` : 'Buongiorno,';
+  return [
+    {
+      touch: 1, gapDays: 0, subject: 'candidati inviati',
+      body: `${hi}
+
+${periodLabel} abbiamo mandato ${candidates} persone alla vostra pagina lavoro da frontaliereticino.ch — gratis, dai vostri annunci che pubblichiamo.
+
+Possiamo mandarvene di più, e stavolta far arrivare le candidature (CV incluso) direttamente a voi invece che farle rimbalzare sul vostro sito. Vi interessa vedere come?
+
+Valerie`,
+    },
+    {
+      touch: 2, gapDays: 4, subject: 'di quei click',
+      body: `${hi}
+
+Di quei ${candidates} candidati che vi abbiamo mandato ${periodLabel}, quanti si sono poi candidati davvero da voi?
+
+Con l'annuncio sponsorizzato la candidatura arriva diretta nella vostra casella — niente form esterni, niente dispersione. Vi mando un esempio reale?
+
+Valerie`,
+    },
+    {
+      touch: 3, gapDays: 5, subject: '49 vs migliaia',
+      body: `${hi}
+
+Diverse aziende ticinesi hanno già reso sponsorizzati i loro ruoli da noi. Costa ${PRICE} — contro la fee di un recruiter (migliaia di CHF a ruolo) o un singolo posting su jobs.ch.
+
+Se vi aiuta a coprire anche un solo ruolo, si ripaga da solo. Provo a mostrarvelo sul vostro annuncio più visto?
+
+Valerie`,
+    },
+    {
+      touch: 4, gapDays: 7, subject: 'chiudo',
+      body: `${hi}
+
+Non vi disturbo oltre. In ogni caso vi lascio il riepilogo dei candidati che vi abbiamo mandato finora — usatelo come volete.
+
+Se più avanti volete amplificarlo, sapete dove trovarmi.
+
+Valerie`,
+    },
+  ];
+}
+
+function loadJson(p, def) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return def; }
+}
+
+function run() {
+  const reportPath = arg('--report');
+  if (!reportPath || reportPath === true) { console.error('--report PATH richiesto (output di employer-traffic-report.mjs --json)'); process.exit(2); }
+  const contactsPath = arg('--contacts', path.join(ROOT, 'data/employer-outreach/contacts.json'));
+  const outDir = arg('--out', path.join(ROOT, 'data/employer-outreach/drafts'));
+  const top = Number(arg('--top', '10'));
+  const min = Number(arg('--min', '10'));
+  const includePublic = arg('--include-public', false) === true;
+  const periodLabel = typeof arg('--days-label', 0) === 'string' ? arg('--days-label') : 'negli ultimi 90 giorni';
+
+  const report = loadJson(path.resolve(reportPath), null);
+  if (!report || !Array.isArray(report.employers)) { console.error(`report illeggibile: ${reportPath}`); process.exit(1); }
+  const contacts = loadJson(path.resolve(contactsPath), {});
+
+  let targets = report.employers.filter((e) => e.candidates >= min);
+  if (!includePublic) targets = targets.filter((e) => !isPublic(e.name));
+  targets = targets.slice(0, top);
+
+  fs.mkdirSync(outDir, { recursive: true });
+  console.log('═════════════════════════════════════════════════════════════');
+  console.log(' ⚠️  DRY-RUN — SOLO BOZZE, NESSUN INVIO');
+  console.log('═════════════════════════════════════════════════════════════');
+  console.log(`Report: ${reportPath} (${report.source}, ${report.days}gg)`);
+  console.log(`Target: ${targets.length} aziende (top ${top}, min ${min} candidati, pubblici ${includePublic ? 'inclusi' : 'esclusi'})\n`);
+
+  let withContact = 0;
+  for (const e of targets) {
+    const c = contacts[e.key] || contacts[e.name] || {};
+    const email = c.email || null;
+    if (email) withContact++;
+    const seq = buildSequence({ company: e.name, candidates: e.candidates, periodLabel, contactName: c.contactName });
+    const slug = e.key || e.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const lines = [
+      `# Cold email — ${e.name}`,
+      ``,
+      `- Candidati inviati (${periodLabel}): **${e.candidates}** · click totali: ${e.clicks}`,
+      `- Pagina careers: ${e.careersUrl || '(da arricchire)'}`,
+      `- Email contatto: ${email || '⚠️ MANCANTE — arricchire contacts.json'}`,
+      `- Stato: BOZZA, non inviata`,
+      ``,
+      `---`,
+      ``,
+    ];
+    for (const m of seq) {
+      lines.push(`## Touch ${m.touch}${m.gapDays ? ` (+${m.gapDays} giorni)` : ''} — oggetto: ${m.subject}`);
+      lines.push('');
+      lines.push(m.body);
+      lines.push('');
+      lines.push('---');
+      lines.push('');
+    }
+    const file = path.join(outDir, `${String(targets.indexOf(e) + 1).padStart(2, '0')}-${slug}.md`);
+    fs.writeFileSync(file, lines.join('\n'));
+    console.log(`  ✏️  ${e.name} — ${e.candidates} candidati ${email ? '✓ email' : '⚠ no email'} → ${path.relative(ROOT, file)}`);
+  }
+  console.log(`\n${targets.length} bozze scritte in ${path.relative(ROOT, outDir)}/ (${withContact} con email, ${targets.length - withContact} da arricchire).`);
+  console.log('Nessun invio eseguito. Revisiona le bozze prima di qualunque step di invio.');
+}
+
+run();


### PR DESCRIPTION
## Contesto

Secondo passo della strategia di conversione aziende crawlate → inserzionisti sponsorizzati (segue PR #2375). Scoperta chiave: `analytics.ts` inoltra ogni evento anche a **PostHog**, che via HogQL interroga le proprietà raw **senza** custom dimension e **senza limite di retroattività**. Quindi lo storico apply-per-azienda (90gg) è già disponibile: **non serve aspettare** l'accumulo della custom dimension GA4 per partire con l'outreach.

Inoltre: i candidati escono verso l'azienda da **più touchpoint** (bottone Candidati + logo header + titolo header), non solo i 2 bottoni già strumentati → senza questa PR il conteggio per-azienda era sottostimato.

## Implementato

- **`scripts/employer-traffic-report.mjs` — sorgente PostHog (default)**: aggrega via HogQL i content_type `job_board_apply` + `job_board_apply_header_logo` + `job_board_apply_header_title`, raggruppa per azienda (da `item_id`), conta **persone distinte** (candidati reali, non click grezzi: un candidato che clicca logo+titolo+bottone = 1 persona). Retroattivo. Validato su dati reali: 69 aziende, 1553 candidati distinti, 2281 click/90gg. Sorgente GA4 `job_apply` mantenuta dietro `--source ga4` (post-deploy).
- **`components/community/JobBoard.tsx`**: aggiunto `Analytics.trackJobApply(...)` ai due touchpoint apply mancanti — header logo (L6888) e header titolo (L6916) — coerente con `handleApply` e l'anchor CTA già strumentati in #2375. Così l'attribuzione GA4 futura copre tutti i punti di uscita.
- **`scripts/generate-cold-emails.mjs` — generatore SOLO BOZZE**: produce la sequenza 4-touch IT personalizzata col numero reale di candidati per azienda, esclude di default gli enti pubblici (concorsi obbligatori), flagga le email mancanti. **Non invia nulla, nessun provider email importato** (guard esplicito). Validato: 8 bozze generate sui top privati (Casale 88, Sintetica 86, ALDI 62…).
- **`data/employer-outreach/`**: README pipeline + `contacts.example.json` template. `.gitignore` per i dati local-only (contacts.json, report.json, drafts/).

## Non implementato (ancora)

- **Invio email**: deliberatamente fuori scope. Il sistema genera solo bozze per revisione; l'invio sarà uno step separato, manuale e gated (cascade provider esistente), su richiesta esplicita.
- **Enrichment email HR**: i contatti vanno raccolti (pagine careers/LinkedIn) e messi in `contacts.json`; l'automazione dell'enrichment è follow-up. Il crawl non cattura email HR (gap noto).
- **75 file gemello da `check-sibling-patterns.mjs`**: condividono solo idiomi generici GA4 Data API / HogQL (`GoogleAuth`, `dateRanges`, `dimensionFilter`, `customEvent`, `eventCount`…) e identificatori comuni. Non è un antipattern corretto e replicato: questa PR aggiunge una sorgente dati + un generatore, non fixa un pattern. Nessun sibling da modificare.
- **Sponsored vs free split nella sorgente PostHog**: la label `item_id` non porta il flag featured → `sponsored=0` su quella sorgente. Il dato sponsored arriva dalla sorgente GA4 (`is_sponsored`) post-deploy. Dichiarato.

## Test plan

- [x] Report PostHog gira su dati reali (69 aziende, persone distinte) — query HogQL valida.
- [x] Generatore bozze: 8 bozze personalizzate scritte, pubblici esclusi, no-email flaggate, zero invio.
- [x] PII/home-path scan diff pulito.
- [ ] Post-deploy: verificare che i nuovi touchpoint (logo/titolo) emettano `job_apply` in GA4 DebugView.

GitNexus impact su `handleApply`/touchpoint apply: LOW (modifica additiva, già validata in #2375).