### PR TITLE
ci(seo-gates): shared composite action for deploy↔cathedral data-prep (anti-drift)

### DIFF
--- a/.github/actions/seo-build-data-prep/action.yml
+++ b/.github/actions/seo-build-data-prep/action.yml
@@ -1,0 +1,62 @@
+name: 'SEO build data-prep'
+description: >-
+  Page-shaping data-prep that MUST run before the full SEO build (`build:ci`)
+  in BOTH deploy.yml (the canonical dist that ships) and
+  cathedral-seo-gates-check.yml (the read-only gate that audits that dist).
+  The gate has to emit the SAME dist deploy ships, so it must apply the same
+  dedup + migration + cleanup the deploy build job does. Before this action,
+  the two workflows duplicated these steps and drifted: the cathedral run
+  skipped the dedup and built the raw assembled dataset (~12.1k jobs ×4
+  locales), which (a) audited a dist that never deploys (wrong gate inputs:
+  duplicate titles, stale sitemap entries, unmigrated canonicals) and
+  (b) pushed the full SEO build past the 16 GB runner RAM → OOM (exit 134)
+  before the gates step ran (issue #2121). deploy builds the deduped set
+  (~11.2k jobs) and fits.
+
+  This action is the single source of truth for that page-shaping subset:
+  add a new data-prep step here ONCE and both workflows pick it up — no
+  silent "Keep in sync with deploy.yml" drift (follow-up #2198).
+
+  Scope: runs the dedup + migration + sitemap-cleanup steps only. It does
+  NOT run `assemble-jobs-dataset.mjs` (callers run + cache that themselves
+  before invoking this action) nor the build itself. The two build OOM knobs
+  (POST_WALK_WORKERS / SEQUENTIAL_PROFILE) stay on each caller's `build:ci`
+  step env because deploy.yml gates SEQUENTIAL_PROFILE on its
+  `parallel_plugins` dispatch input (cathedral is always sequential), so they
+  are not byte-identical and cannot be a shared constant. None of these steps
+  require secrets.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Housekeeping (cross-crawler dedup + locale hardening)
+      shell: bash
+      env:
+        JOBS_SKIP_URL_VALIDATION: '1'
+      run: node scripts/cleanup-jobs.mjs
+
+    - name: Refresh weekly-employers footer link list (F5 link-graph closer)
+      # Regenerates data/weekly-employers-top-pairs.json from current jobs
+      # using the SAME logic the build plugin uses to materialise pages.
+      # Guarantees footer hrefs in WeeklyEmployersTeaser always point at
+      # static pages that exist in dist/, eliminating SPA-shell 404s.
+      shell: bash
+      run: node scripts/refresh-weekly-employers-top-pairs.mjs
+
+    - name: Mine all job slugs for comprehensive 404 coverage
+      shell: bash
+      run: node scripts/mine-all-job-slugs.mjs
+
+    - name: Canton-aware migration of slug registry
+      # mine-all-job-slugs writes every entry under the legacy TI section
+      # (LOCALE_PREFIXES hardcode). For non-TI jobs that stale path leaks
+      # into dist as soft-landing canonical/hreflang (selfUrl reads the
+      # registry verbatim) → gate:seo-source red post-merge. The build must
+      # consume the migrated registry, and the gates test the migrated copy,
+      # so gate and artifact see the same data.
+      shell: bash
+      run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+
+    - name: Cleanup stale news sitemap entries
+      shell: bash
+      run: node scripts/cleanup-news-sitemap.mjs

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -70,32 +70,21 @@ jobs:
       # ── Pre-build data prep — MUST mirror deploy.yml's build job ──────────
       # The gates audit `dist/`, so this workflow has to emit the SAME dist
       # deploy.yml ships. deploy dedups + migrates + cleans the dataset BEFORE
-      # build:ci; this workflow used to skip that and build the raw assembled
-      # dataset, which (a) audited a dist that never deploys — wrong gate
-      # inputs (duplicate job titles, stale sitemap entries, unmigrated
-      # canonicals) — and (b) emitted ~920 extra (cross-crawler duplicate /
-      # expired) job pages × 4 locales, pushing the full SEO build past the
-      # 16 GB runner's RAM → OOM (exit 134) before the gates step ran (issue
-      # #2121). deploy.yml builds the deduped set (≈11.2k jobs) and fits;
-      # building the raw set (≈12.1k) does not. Steps below are the
-      # page-shaping subset of deploy.yml's build job, in the same order.
-      # Keep in sync with deploy.yml. None require secrets.
-      - name: Housekeeping (cross-crawler dedup + locale hardening)
-        env:
-          JOBS_SKIP_URL_VALIDATION: '1'
-        run: node scripts/cleanup-jobs.mjs
-
-      - name: Refresh weekly-employers footer link list
-        run: node scripts/refresh-weekly-employers-top-pairs.mjs
-
-      - name: Mine all job slugs for comprehensive 404 coverage
-        run: node scripts/mine-all-job-slugs.mjs
-
-      - name: Canton-aware migration of slug registry
-        run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
-
-      - name: Cleanup stale news sitemap entries
-        run: node scripts/cleanup-news-sitemap.mjs
+      # build:ci; before this was shared, this workflow used to skip that and
+      # build the raw assembled dataset, which (a) audited a dist that never
+      # deploys — wrong gate inputs (duplicate job titles, stale sitemap
+      # entries, unmigrated canonicals) — and (b) emitted ~920 extra
+      # (cross-crawler duplicate / expired) job pages × 4 locales, pushing the
+      # full SEO build past the 16 GB runner's RAM → OOM (exit 134) before the
+      # gates step ran (issue #2121). deploy.yml builds the deduped set
+      # (≈11.2k jobs) and fits; building the raw set (≈12.1k) does not.
+      #
+      # These page-shaping steps now live in the shared composite action so
+      # deploy.yml and this gate can never drift apart again (follow-up
+      # #2198). Both reference the SAME action → adding a step there updates
+      # both workflows at once. None require secrets.
+      - name: SEO build data-prep (shared with deploy.yml)
+        uses: ./.github/actions/seo-build-data-prep
 
       - name: Build dist (full SEO output)
         env:
@@ -110,10 +99,13 @@ jobs:
           # 12288 — and 18 GB exceeds the 16 GB runner's RAM anyway.
           #
           # The two knobs below are deploy.yml's documented OOM controls
-          # (deploy.yml:481 + :532, build OOM #1290) — they cap the DOMINANT
-          # memory term, not the dataset size. deploy fits the full SEO build
-          # at 12288 BECAUSE of these; the dedup prep above is a smaller,
-          # complementary reduction. Keep both in sync with deploy.yml.
+          # (build OOM #1290) — they cap the DOMINANT memory term, not the
+          # dataset size. deploy fits the full SEO build at 12288 BECAUSE of
+          # these; the shared data-prep action above is a smaller,
+          # complementary reduction. These knobs stay inline (not in the
+          # shared action) because deploy.yml gates SEQUENTIAL_PROFILE on its
+          # `parallel_plugins` dispatch input, so the two are not
+          # byte-identical; this gate run is ALWAYS sequential.
           #
           # Cap the post-walk worker pool so it doesn't structured-clone the
           # full ~247K-path list into cpus()-many workers at once (the #1290

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -297,32 +297,20 @@ jobs:
         # commit required to lower (see CLAUDE.md rule #1).
         run: npm run audit:active-jobs-regression
 
-      - name: Housekeeping (cross-crawler dedup + locale hardening)
-        env:
-          JOBS_SKIP_URL_VALIDATION: '1'
-        run: node scripts/cleanup-jobs.mjs
-
-      - name: Refresh weekly-employers footer link list (F5 link-graph closer)
-        # Regenerates data/weekly-employers-top-pairs.json from current jobs
-        # using the SAME logic the build plugin uses to materialise pages.
-        # Guarantees footer hrefs in WeeklyEmployersTeaser always point at
-        # static pages that exist in dist/, eliminating SPA-shell 404s.
-        run: node scripts/refresh-weekly-employers-top-pairs.mjs
-
-      - name: Mine all job slugs for comprehensive 404 coverage
-        run: node scripts/mine-all-job-slugs.mjs
-
-      - name: Canton-aware migration of slug registry
-        # mine-all-job-slugs writes every entry under the legacy TI section
-        # (LOCALE_PREFIXES hardcode). For non-TI jobs that stale path leaks
-        # into dist as soft-landing canonical/hreflang (selfUrl reads the
-        # registry verbatim) → gate:seo-source red post-merge (run
-        # 27352608929: VD job canonicalised to /cerca-lavoro-ticino/).
-        # tests.yml + post-deploy-validate-dist.yml already run this script
-        # before vitest; without it HERE the build consumes the unmigrated
-        # registry while the gates test a migrated copy — gate and artifact
-        # must see the same data.
-        run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+      # Page-shaping data-prep BEFORE build:ci — the deduped + migrated +
+      # sitemap-cleaned dataset the canonical dist ships. Shared with
+      # cathedral-seo-gates-check.yml via a composite action so the gate
+      # audits the exact same page set deploy emits and the two can never
+      # drift (follow-up #2198; the #2121 OOM was caused by that drift).
+      # Steps inside (in order): cleanup-jobs (cross-crawler dedup + locale
+      # hardening, JOBS_SKIP_URL_VALIDATION=1), refresh-weekly-employers-top-pairs
+      # (footer link-graph closer), mine-all-job-slugs (404 coverage),
+      # migrate-all-known-job-slugs-canton-aware (non-TI canonical/hreflang —
+      # without it the build consumes the unmigrated registry while gates test
+      # a migrated copy, gate:seo-source red post-merge run 27352608929),
+      # cleanup-news-sitemap (stale news entries). None require secrets.
+      - name: SEO build data-prep (shared with cathedral-seo-gates-check.yml)
+        uses: ./.github/actions/seo-build-data-prep
 
       # Cluster-pages cache REMOVED (2026-05-09).
       # Build instrumentation on 5 recent deploys showed:
@@ -361,9 +349,6 @@ jobs:
 
       - name: Generate responsive image thumbnails
         run: node scripts/generate-image-thumbnails.mjs
-
-      - name: Cleanup stale news sitemap entries
-        run: node scripts/cleanup-news-sitemap.mjs
 
       - name: Cleanup stale job HTML (orphans from prior incremental builds)
         # vite.config.ts uses emptyOutDir:false to preserve admin data,


### PR DESCRIPTION
## Implementato

- **Nuova composite action `.github/actions/seo-build-data-prep/action.yml`** che racchiude i 5 step page-shaping di data-prep che DEVONO girare prima di `build:ci`, in ordine: `cleanup-jobs.mjs` (cross-crawler dedup + locale hardening, `JOBS_SKIP_URL_VALIDATION=1`), `refresh-weekly-employers-top-pairs.mjs`, `mine-all-job-slugs.mjs`, `migrate-all-known-job-slugs-canton-aware.mjs`, `cleanup-news-sitemap.mjs`. Nessuno richiede secret.
- **`deploy.yml` repointato**: i 4 step inline (housekeeping/refresh/mine/migrate) + lo step `cleanup-news-sitemap` (che era più in basso, dopo i thumbnail) sostituiti da un solo `uses: ./.github/actions/seo-build-data-prep`. Gli step thumbnail-cache/generate (indipendenti dai dati job — leggono solo `public/images/**`) restano dopo l'action; `cleanup-news-sitemap` ora gira dentro l'action prima dei thumbnail → riordino behavior-neutral (domini disgiunti: news-sitemap vs immagini).
- **`cathedral-seo-gates-check.yml` repointato**: i 5 step inline sostituiti dallo stesso `uses: ./.github/actions/seo-build-data-prep`. Era esattamente il drift che causò #2121 (cathedral buildava il dataset raw → OOM exit 134). Ora i due workflow referenziano la STESSA action → aggiungere uno step lì aggiorna entrambi by-construction.
- **Verifica nomi env knob (item 2 dell'issue, ❓ del reviewer)**: confermato che i due knob OOM NON sono no-op. `POST_WALK_WORKERS` è letto da `build-plugins/postWalkCoordinatorPlugin.ts` (`resolveWorkerCount`, L133 `process.env.POST_WALK_WORKERS`); `SEQUENTIAL_PROFILE` da `build-plugins/profilePlugin.ts` (L36 `process.env.SEQUENTIAL_PROFILE === '1'`). I nomi nei workflow matchano i plugin esattamente.
- I due knob restano inline sullo step `build:ci` di ciascun workflow (NON nell'action) perché `deploy.yml` gata `SEQUENTIAL_PROFILE` sull'input dispatch `parallel_plugins` (cathedral è sempre sequenziale) → i due non sono byte-identici e non possono diventare una costante condivisa senza cambiare il comportamento di deploy. Aggiornato il commento stale in cathedral (rimosso il riferimento a `deploy.yml:481/:532` per-numero-riga e il "Keep both in sync with deploy.yml").
- Sibling-class sweep: gli unici workflow con la sequenza completa dei 5 step prima di `build:ci` sono deploy.yml e cathedral (verificato su `origin/main`: 5 ref ciascuno; `post-build-matrix-test.yml` ne ha 0 — testa un dist già buildato). I ~400 `update-jobs-*.yml`/`tests.yml`/`translate-pending.yml` usano singoli script in contesti diversi (crawl/commit slice, non parità dist-SEO-gate pre-build) → fuori scope. Tutti e 3 i file YAML validati con `yaml.safe_load`.

## Non implementato (ancora)

- **Validazione memoria/wall-time del cathedral build post-merge**: il `build:ci` cathedral (OOM-prone, 16 GB runner) gira SOLO post-merge su `main` / schedule, non sul `pull_request`. Questa PR è un refactor byte-equivalente del set di step (stessi 5 script, stesso ordine, stessi env knob) → atteso nessun cambio di footprint memoria. **Revert-trigger esplicito**: se il prossimo run di `cathedral-seo-gates-check.yml` (schedule Mon 04:47 UTC o `gh workflow run --ref main`) va in OOM (exit 134) o un deploy regredisce in OOM/wall-time → revert di questa PR e ripristino degli step inline. Verifica live per `test_new_workflows_live`: `gh workflow run cathedral-seo-gates-check.yml --ref main` + osservare il run su `main` (non fixare su main; nuova PR se regredisce).
- **Estrazione dei knob OOM nella action**: non fatto di proposito (vedi sopra: non byte-identici per il gate `parallel_plugins` di deploy). Lasciati inline.

Closes #2198

🤖 Generated with [Claude Code](https://claude.com/claude-code)