### PR TITLE
fix(seo): redirect Cloudflare-confirmed feature-page 404s to canonical

### DIFF
--- a/build-plugins/legacyRedirectsPlugin.ts
+++ b/build-plugins/legacyRedirectsPlugin.ts
@@ -242,6 +242,22 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  '/cerca-lavoro-ticino/nachwuchskader-verkauf-coop-grigioni/': '/cerca-lavoro-ticino/vendita-quadri-junior-coop-grigioni/',
  '/cerca-lavoro-ticino/galenica-amavita-pharma-assistent-w-m-d-ascona/': '/cerca-lavoro-ticino/assistente-farmaceutico-f-m-d-amavita-galenica-ascona/',
  '/cerca-lavoro-ticino/kundenbetreuer-in-customer-center-mit-begeisterungsfahigkeit-und-noch-viel-mehr-pioniergei/': '/cerca-lavoro-ticino/responsabile-dell-assistenza-clienti-nel-customer-center-con-entusiasmo-e-molto-piu-spirit/',
+ // ── Cloudflare-confirmed feature-page 404s (2026-06-17 edge sweep) ──
+ // Real-traffic 404s on renamed/section-root non-job pages. Destinations
+ // verified 200 live. Only the OBSERVED paths are mapped (not the full
+ // crossing list) — /tempi-attesa-confine/ and bare /traffico-dogane/.../oggi/
+ // were never our own emitted paths, so enumerating all 26 crossings would be
+ // speculative (AGENTS.md #6). Border-wait pages were renamed to
+ // /guida-frontaliere/tempi-attesa-dogana/<crossing>/ (cf. the section redirect
+ // at /statistiche/traffico-dogane/ above); the old slugs also dropped the
+ // d-hyphen (ditalia → d-italia, dintelvi → d-intelvi), normalized here.
+ '/tempi-attesa-confine/chiasso-brogeda/': '/guida-frontaliere/tempi-attesa-dogana/chiasso-brogeda/',
+ '/traffico-dogane/campione-ditalia-bissone/oggi/': '/guida-frontaliere/tempi-attesa-dogana/campione-d-italia-bissone/',
+ '/traffico-dogane/lanzo-dintelvi-arogno/oggi/': '/guida-frontaliere/tempi-attesa-dogana/lanzo-d-intelvi-arogno/',
+ // Fuel section-root (no index) → that fuel's localized "today" landing,
+ // keeping benzina↔benzina / diesel↔diesel (never cross fuels).
+ '/prezzi-benzina/': '/prezzi-benzina/oggi/',
+ '/prezzi-diesel/': '/prezzi-diesel/oggi/',
  };
 
  const normalize = (p: string): string => {


### PR DESCRIPTION
## Implementato

Cinque 404 a traffico reale dallo sweep Cloudflare edge del 2026-06-17 (apex, eyeball-only), aggiunte alla mappa `redirects` di `build-plugins/legacyRedirectsPlugin.ts` (emesse come bridge noindex 301-style, stessa meccanica delle ~100 entry esistenti). **Tutte le destinazioni verificate 200 live:**

- `/tempi-attesa-confine/chiasso-brogeda/` → `/guida-frontaliere/tempi-attesa-dogana/chiasso-brogeda/`
- `/traffico-dogane/campione-ditalia-bissone/oggi/` → `/guida-frontaliere/tempi-attesa-dogana/campione-d-italia-bissone/`
- `/traffico-dogane/lanzo-dintelvi-arogno/oggi/` → `/guida-frontaliere/tempi-attesa-dogana/lanzo-d-intelvi-arogno/`
  - (le border-wait page sono state rinominate in `tempi-attesa-dogana`; gli slug vecchi avevano perso il `d-` → `ditalia`→`d-italia`, `dintelvi`→`d-intelvi`, normalizzati qui)
- `/prezzi-benzina/` → `/prezzi-benzina/oggi/`
- `/prezzi-diesel/` → `/prezzi-diesel/oggi/` (section-root senza index → landing `/oggi/`, benzina↔benzina / diesel↔diesel preservato)

Test verdi: `redirect-page-builders`, `flat-html-redirect`, `canton-orphan-redirects`, `no-js-redirects-in-build` (17 test). Trailing-slash su ogni from/to. Sibling-pattern check: nessun costrutto da sweepare (solo literal dati).

## Non implementato (ancora)

- **Mappatura completa dei 26 crossing `tempi-attesa-confine/*`**: `tempi-attesa-confine` non è **mai** stato un nostro prefisso emesso (grep vuoto in codice/dati); solo `chiasso-brogeda` è stato realmente colpito. Enumerare tutti i 26 crossing = speculative abstraction (AGENTS.md #6). Se altri crossing compaiono nello sweep CF, si aggiungono allora.
- **Route SPA-only senza emit statico** (`/preferenze-newsletter/`, `/per-le-aziende/` + `/en/for-employers/` + `fuer-unternehmen`/`pour-les-entreprises`): lo slug canonico corretto **404 anche bare** → queste tab esistono nel router ma non hanno pagina statica emessa. Classe diversa (decidere se emettere SEO static o fallback SPA), non un rename → fuori scope di questa PR di redirect. ~2-3 hit/giorno ciascuna.
- **`/ricerca/<query>/` legacy** (search sub-path con slash, il resolver matcha solo `ricerca-` con trattino) e **`/lavoro-settimanale/lugano/`**: pattern non delimitato / nessun canonico chiaro (probabilmente URL esterni), basso valore (2-3 hit) → osservare, non mappare alla cieca.
- **Coda job scaduti**: coperta dalla PR #2383 (uncap bridge CF-hot 40k→250k), già mergiata.