### PR TITLE
feat(outreach): HR-contact enrichment + role-personalized cold-email drafts

### DIFF
--- a/data/employer-outreach/PLAN.md
+++ b/data/employer-outreach/PLAN.md
@@ -1,0 +1,51 @@
+# Piano: convertire le aziende crawlate in inserzionisti sponsorizzati
+
+Obiettivo: aumentare la monetizzazione trasformando il traffico gratuito che già
+mandiamo alle aziende crawlate in annunci sponsorizzati pagati.
+
+## Leva centrale
+**Reciprocità misurata** — mandiamo candidati gratis a ~100 aziende ogni mese e
+possiamo dimostrarlo col numero reale per azienda. Gancio: *click ≠ candidatura*;
+lo sponsorizzato fa arrivare il CV diretto (apply form in-house).
+
+## Stato
+
+| # | Attività | Stato |
+|---|----------|-------|
+| — | Misura candidati/azienda (PostHog storico + GA4 `job_apply` futuro) | ✅ live (PR #2375, #2382) |
+| — | Tutti i touchpoint apply tracciati (bottone+logo+titolo) | ✅ |
+| — | Generatore bozze cold-email 4-touch (zero invio) | ✅ |
+| 1 | **Enrichment email HR dei target** | 🔜 in corso |
+| 2 | Generazione + revisione bozze (dipende da 1) | ⏳ |
+| 3 | Sistema invio gated (mai automatico, solo su OK) | ⏳ |
+| 4 | Verifica funnel upgrade annuncio-crawlato → sponsor | ⏳ |
+| 5 | Tetto tier free (no cattura-candidato sui crawlati) | ⏳ |
+| 6 | Prova in-prodotto / dashboard inserzionista | ⏳ |
+| 7 | Pricing Piano Azienda/Brand bundle | ⏳ |
+| 8 | Verifica post-deploy GA4 nuovi touchpoint | ⏳ |
+| 9 | Misurazione campagna (reply/conversione/ARPU) + social proof | ⏳ |
+
+## Targeting
+**Nessuna azienda esclusa** (decisione owner): si contattano tutte le prime per
+candidati inviati. Ogni contatto è etichettato col settore (`pubblico` /
+`multinazionale` / `pmi`) solo come contesto per calibrare il tono a mano — non
+filtra. Nota: per pubblici (concorsi) e multinazionali (HR globale) il tasso di
+conversione atteso è più basso, ma restano nel target.
+
+## Dati reali (candidati distinti, 90gg, da PostHog)
+Top privati: Casale SA 88 · Sintetica SA 86 · ALDI 62* · Lidl 43* · TSMG 36 ·
+PEMSA 22 · Coop 20* · Swisscom 20* · Ticino Premium Properties 19 · Centiel 10 ·
+Medacta 11 · Rapelli 16. (* = multinazionale, deprioritizzato)
+
+## Email — principi applicati (skill cold-email)
+- Subject 2-4 parole, minuscole, "interna" (no salesy/urgency, no nome proprio).
+- Personalizzazione Livello 4: numero reale + ruolo più cliccato, connessi al
+  problema (click che si perdono). Il dato È la personalizzazione.
+- Tono da pari, una sola call-to-action a basso attrito.
+- Sequenza 4-touch: reciprocità+numero → gap click/candidatura → social proof +
+  ancora vs recruiter → breakup che lascia il report.
+
+## Pricing (proposta)
+Free (crawlato, ancora) · Sponsor CHF 49/annuncio · **Piano Azienda** bundle
+~CHF 199–299/mese ruoli illimitati, ancorato vs fee recruiter (15-25% stipendio).
+Tetto free obbligatorio: niente cattura-candidato sui crawlati.

--- a/data/employer-outreach/README.md
+++ b/data/employer-outreach/README.md
@@ -38,10 +38,20 @@ node scripts/generate-cold-emails.mjs \
 
 ## Targeting
 
-Di default il generatore **esclude gli enti pubblici** (EOC, Città di Lugano,
-Amministrazione Cantonale, USI/SUPSI, FFS…): pubblicano concorsi obbligatori e
-difficilmente comprano sponsorizzati. I target sono i datori privati ad alto
-volume di candidati inviati. Usa `--include-public` per forzarne l'inclusione.
+**Nessuna azienda è esclusa**: i target sono le prime `--top` per candidati
+inviati. Ogni contatto è etichettato col settore (`pubblico` /
+`multinazionale` / `pmi`) come contesto per calibrare il tono a mano — il tag
+non filtra nulla.
+
+## Enrichment contatti
+
+```bash
+node scripts/enrich-employer-contacts.mjs --report data/employer-outreach/report.json --top 15
+```
+
+Trova il ruolo più cliccato per azienda (PostHog) e prova a estrarre un'email HR
+dalle pagine careers/contatti (best-effort). Le email non trovate vanno
+completate a mano in `contacts.json` (LinkedIn / form).
 
 ## Prossimi step (non ancora implementati)
 

--- a/scripts/enrich-employer-contacts.mjs
+++ b/scripts/enrich-employer-contacts.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Enrichment contatti HR per l'outreach (passo #1 del piano).
+ *
+ * Per ogni azienda target del report candidati-per-azienda:
+ *   1) trova il RUOLO più cliccato (PostHog) → personalizzazione Livello 4 email;
+ *   2) prova a estrarre un'email di contatto HR dalle pagine careers/contatti
+ *      (best-effort, public pages) con priorità hr@/lavoro@/candidature@/jobs@.
+ * Scrive/aggiorna `data/employer-outreach/contacts.json` (untracked, gitignored)
+ * SENZA sovrascrivere le email inserite a mano.
+ *
+ * NON invia nulla. Solo arricchimento dati locali.
+ *
+ * Nessuna azienda esclusa: prende le prime `--top` per candidati inviati. Ogni
+ * contatto è etichettato col settore (pubblico/multinazionale/pmi) come contesto
+ * per calibrare il messaggio a mano, ma il tag NON filtra.
+ *
+ * Uso:
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=/path/sa.json node scripts/load-rc-env.mjs)"
+ *   node scripts/enrich-employer-contacts.mjs --report data/employer-outreach/report.json --top 15
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifySector, slugify } from './lib/employer-sectors.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return def;
+  const n = process.argv[i + 1];
+  return n && !n.startsWith('--') ? n : true;
+}
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
+const EMAIL_BAD = /(noreply|no-reply|example|sentry|wixpress|\.png|\.jpg|\.webp|@2x|domain\.|email\.com|yourcompany)/i;
+const EMAIL_PRIORITY = [/^(hr|risorseumane|risorse-umane|lavoro|lavora|candidature|recruiting|recruitment|jobs|career|personal)/i, /^(info|contact|contatto|amministrazione|segreteria)/i];
+
+async function fetchText(url, timeoutMs = 8000) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    const r = await fetch(url, { signal: ctrl.signal, redirect: 'follow', headers: { 'User-Agent': 'Mozilla/5.0 (compatible; frontaliereticino-enrichment/1.0)' } });
+    clearTimeout(t);
+    if (!r.ok) return '';
+    return (await r.text()).slice(0, 500_000);
+  } catch { return ''; }
+}
+
+function pickEmail(emails) {
+  const clean = [...new Set(emails.map((e) => e.toLowerCase()))].filter((e) => !EMAIL_BAD.test(e));
+  for (const re of EMAIL_PRIORITY) { const hit = clean.find((e) => re.test(e.split('@')[0])); if (hit) return hit; }
+  return clean[0] || null;
+}
+
+async function findEmail(careersUrl, website) {
+  const bases = [careersUrl, website].filter(Boolean);
+  const paths = ['', '/contatti', '/contatti/', '/contact', '/contact/', '/chi-siamo', '/lavora-con-noi', '/lavora-con-noi/', '/jobs', '/careers'];
+  const seen = new Set();
+  const found = [];
+  for (const base of bases) {
+    let origin = '';
+    try { origin = new URL(base).origin; } catch { continue; }
+    const urls = [base, ...paths.map((p) => origin + p)];
+    for (const u of urls) {
+      if (seen.has(u) || found.length > 12) continue;
+      seen.add(u);
+      const html = await fetchText(u);
+      if (!html) continue;
+      const m = html.match(EMAIL_RE);
+      if (m) found.push(...m);
+      const pick = pickEmail(found);
+      if (pick && EMAIL_PRIORITY[0].test(pick.split('@')[0])) return pick; // strong match → stop early
+    }
+  }
+  return pickEmail(found);
+}
+
+async function topRoles(targets, days) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY, projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+  if (!apiKey || !projectId) return new Map();
+  const q = `
+    SELECT splitByChar('_', coalesce(toString(properties.item_id),''))[1] AS company,
+           arrayStringConcat(arraySlice(splitByChar('_', coalesce(toString(properties.item_id),'')), 2), '_') AS role,
+           count() AS c
+    FROM events
+    WHERE event='select_content'
+      AND properties.content_type IN ('job_board_apply','job_board_apply_header_logo','job_board_apply_header_title')
+      AND timestamp >= now() - interval ${days} day
+    GROUP BY company, role ORDER BY c DESC LIMIT 2000`.trim();
+  const r = await fetch(`${host}/api/projects/${projectId}/query/`, { method: 'POST', headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ query: { kind: 'HogQLQuery', query: q } }) });
+  if (!r.ok) return new Map();
+  const out = new Map();
+  for (const [company, role, c] of ((await r.json()).results || [])) {
+    const key = slugify(company);
+    if (!out.has(key) && role) out.set(key, { role, clicks: Number(c) || 0 }); // first = top (ordered desc)
+  }
+  return out;
+}
+
+async function run() {
+  const reportPath = arg('--report', path.join(ROOT, 'data/employer-outreach/report.json'));
+  const top = Number(arg('--top', '15'));
+  const days = Number(arg('--days', '90'));
+  const contactsPath = path.join(ROOT, 'data/employer-outreach/contacts.json');
+
+  const report = JSON.parse(fs.readFileSync(path.resolve(reportPath), 'utf8'));
+  // Nessuna azienda esclusa: prendi le prime `top` per candidati inviati.
+  const targets = (report.employers || []).slice(0, top);
+
+  const existing = fs.existsSync(contactsPath) ? JSON.parse(fs.readFileSync(contactsPath, 'utf8')) : {};
+  const roles = await topRoles(targets, days);
+
+  console.log(`Enrichment: ${targets.length} aziende target (nessuna esclusa)\n`);
+  for (const e of targets) {
+    const key = e.key || slugify(e.name);
+    const prev = existing[key] || {};
+    const role = roles.get(key)?.role || prev.topRole || '';
+    const sector = classifySector(e.name);
+    let email = prev.email || null; // never overwrite manual email
+    if (!email) email = await findEmail(e.careersUrl, prev.website);
+    existing[key] = { name: e.name, candidates: e.candidates, sector, topRole: role, careersUrl: e.careersUrl || prev.careersUrl || '', website: prev.website || '', contactName: prev.contactName || '', email: email || '' };
+    console.log(`  ${e.candidates.toString().padStart(3)}  [${sector.padEnd(13)}]  ${email ? '✓ ' + email : '⚠ no email'}  ${e.name}${role ? `  · ruolo top: ${role.slice(0, 46)}` : ''}`);
+  }
+
+  fs.mkdirSync(path.dirname(contactsPath), { recursive: true });
+  fs.writeFileSync(contactsPath, JSON.stringify(existing, null, 2));
+  const withEmail = Object.values(existing).filter((c) => c.email).length;
+  console.log(`\n${Object.keys(existing).length} contatti in contacts.json (${withEmail} con email). Email mancanti: completale a mano (LinkedIn / form).`);
+  console.log('Nessun invio. Prossimo: node scripts/generate-cold-emails.mjs --report <report.json>');
+}
+
+run().catch((e) => { console.error(e.message || e); process.exit(1); });

--- a/scripts/generate-cold-emails.mjs
+++ b/scripts/generate-cold-emails.mjs
@@ -33,6 +33,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { classifySector } from './lib/employer-sectors.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
@@ -44,28 +45,28 @@ function arg(name, def) {
   return next && !next.startsWith('--') ? next : true; // boolean flags
 }
 
-// Enti pubblici / para-pubblici ticinesi: pubblicano concorsi obbligatori,
-// improbabili acquirenti di annunci sponsorizzati → esclusi di default.
-const PUBLIC_SECTOR = [
-  /ente ospedaliero|^eoc\b/i, /città di|comune di|municipio/i, /amministrazione cantonale/i,
-  /università|^usi\b|supsi/i, /istituti sociali|^lis\b/i, /ferrovie|^ffs\b|officine/i,
-  /pro senectute/i, /cantonal|repubblica e cantone/i,
-];
-const isPublic = (name) => PUBLIC_SECTOR.some((re) => re.test(name));
-
 const PRICE = 'CHF 49 al mese per annuncio';
 
-/** Le 4 email della sequenza. Tutte personalizzate col numero reale di candidati. */
-function buildSequence({ company, candidates, periodLabel, contactName }) {
+/**
+ * Le 4 email della sequenza. Personalizzazione Livello 4 (skill cold-email):
+ * numero REALE di candidati + RUOLO più cliccato, connessi al problema (i click
+ * si perdono). Tono da pari, una sola call-to-action a basso attrito per touch.
+ */
+function buildSequence({ company, candidates, periodLabel, contactName, topRole }) {
   const hi = contactName ? `Ciao ${contactName},` : 'Buongiorno,';
+  // Ruolo accorciato per leggibilità; fallback neutro se assente.
+  const role = (topRole || '').replace(/\s+/g, ' ').trim();
+  const pagina = role ? `pagina di "${role.slice(0, 48)}"` : 'pagina lavoro';
   return [
     {
       touch: 1, gapDays: 0, subject: 'candidati inviati',
       body: `${hi}
 
-${periodLabel} abbiamo mandato ${candidates} persone alla vostra pagina lavoro da frontaliereticino.ch — gratis, dai vostri annunci che pubblichiamo.
+${periodLabel} vi abbiamo mandato ${candidates} persone alla vostra ${pagina} da frontaliereticino.ch — gratis, dagli annunci che pubblichiamo per voi.
 
-Possiamo mandarvene di più, e stavolta far arrivare le candidature (CV incluso) direttamente a voi invece che farle rimbalzare sul vostro sito. Vi interessa vedere come?
+Il punto è che quei click arrivano sul vostro sito e spesso si perdono. Possiamo farveli arrivare come candidature dirette, CV incluso, nella vostra casella.
+
+Ha senso che vi mostri come, sul vostro annuncio più visto?
 
 Valerie`,
     },
@@ -113,35 +114,36 @@ function run() {
   const outDir = arg('--out', path.join(ROOT, 'data/employer-outreach/drafts'));
   const top = Number(arg('--top', '10'));
   const min = Number(arg('--min', '10'));
-  const includePublic = arg('--include-public', false) === true;
-  const periodLabel = typeof arg('--days-label', 0) === 'string' ? arg('--days-label') : 'negli ultimi 90 giorni';
+  const periodLabel = typeof arg('--days-label', 0) === 'string' ? arg('--days-label') : 'negli ultimi 3 mesi';
 
   const report = loadJson(path.resolve(reportPath), null);
   if (!report || !Array.isArray(report.employers)) { console.error(`report illeggibile: ${reportPath}`); process.exit(1); }
   const contacts = loadJson(path.resolve(contactsPath), {});
 
-  let targets = report.employers.filter((e) => e.candidates >= min);
-  if (!includePublic) targets = targets.filter((e) => !isPublic(e.name));
-  targets = targets.slice(0, top);
+  // Nessuna azienda esclusa: top `top` per candidati, sopra la soglia `min`.
+  const targets = report.employers.filter((e) => e.candidates >= min).slice(0, top);
 
   fs.mkdirSync(outDir, { recursive: true });
   console.log('═════════════════════════════════════════════════════════════');
   console.log(' ⚠️  DRY-RUN — SOLO BOZZE, NESSUN INVIO');
   console.log('═════════════════════════════════════════════════════════════');
   console.log(`Report: ${reportPath} (${report.source}, ${report.days}gg)`);
-  console.log(`Target: ${targets.length} aziende (top ${top}, min ${min} candidati, pubblici ${includePublic ? 'inclusi' : 'esclusi'})\n`);
+  console.log(`Target: ${targets.length} aziende (top ${top}, min ${min} candidati, nessuna esclusa)\n`);
 
   let withContact = 0;
   for (const e of targets) {
     const c = contacts[e.key] || contacts[e.name] || {};
     const email = c.email || null;
     if (email) withContact++;
-    const seq = buildSequence({ company: e.name, candidates: e.candidates, periodLabel, contactName: c.contactName });
+    const sector = c.sector || classifySector(e.name);
+    const seq = buildSequence({ company: e.name, candidates: e.candidates, periodLabel, contactName: c.contactName, topRole: c.topRole });
     const slug = e.key || e.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
     const lines = [
       `# Cold email — ${e.name}`,
       ``,
       `- Candidati inviati (${periodLabel}): **${e.candidates}** · click totali: ${e.clicks}`,
+      `- Settore: ${sector} (calibra il tono a mano se serve)`,
+      `- Ruolo più cliccato: ${c.topRole || '(da arricchire)'}`,
       `- Pagina careers: ${e.careersUrl || '(da arricchire)'}`,
       `- Email contatto: ${email || '⚠️ MANCANTE — arricchire contacts.json'}`,
       `- Stato: BOZZA, non inviata`,

--- a/scripts/lib/employer-sectors.mjs
+++ b/scripts/lib/employer-sectors.mjs
@@ -1,0 +1,33 @@
+// Classificazione settore datori per l'outreach — modulo condiviso (single
+// source of truth, evita drift tra enrich-employer-contacts.mjs e
+// generate-cold-emails.mjs).
+//
+// NB: serve solo come ETICHETTA di contesto nelle bozze (es. "pubblico",
+// "multinazionale", "pmi") — NON esclude nessuna azienda. Tutti i datori sono
+// target validi; il tag aiuta solo a calibrare il messaggio a mano.
+
+export const PUBLIC_SECTOR = [
+  /ente ospedaliero|^eoc\b/i, /città di|comune di|municipio/i, /amministrazione cantonale/i,
+  /università|^usi\b|supsi/i, /istituti sociali|^lis\b/i, /ferrovie|^ffs\b|officine/i,
+  /pro senectute/i, /cantonal|repubblica e cantone/i,
+];
+
+export const MULTINATIONAL = [
+  /aldi/i, /lidl/i, /\bcoop\b/i, /swisscom/i, /sunrise/i, /mcdonald/i, /marriott/i,
+  /heineken/i, /kempinski/i, /capri holdings|michael kors|versace/i, /prada/i,
+  /\bvf\b|north face|timberland/i, /manor\b/i, /efg international/i, /galenica|amavita/i,
+  /läderach|laderach/i, /volg|fenaco/i,
+];
+
+/** Etichetta di contesto (non filtra): 'pubblico' | 'multinazionale' | 'pmi'. */
+export function classifySector(name) {
+  if (PUBLIC_SECTOR.some((re) => re.test(name || ''))) return 'pubblico';
+  if (MULTINATIONAL.some((re) => re.test(name || ''))) return 'multinazionale';
+  return 'pmi';
+}
+
+export function slugify(s) {
+  return String(s || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Contesto

Passo #1 del piano outreach (segue #2375, #2382): arricchire i contatti delle aziende target e personalizzare le email coi dati reali. Salvato il piano completo in `data/employer-outreach/PLAN.md`.

**Decisione owner: nessuna azienda è esclusa** dal targeting (richiesta esplicita). Il settore resta solo come etichetta di contesto.

## Implementato

- **`scripts/enrich-employer-contacts.mjs`**: per ogni azienda del report trova il **ruolo più cliccato** (HogQL PostHog) e prova a **estrarre un'email HR** dalle pagine careers/contatti (best-effort, priorità `hr@`/`lavoro@`/`candidature@`/`jobs@`). Scrive `data/employer-outreach/contacts.json` (untracked) senza sovrascrivere le email inserite a mano. Validato su dati reali: 24 contatti, ruolo top per tutti, 3 email trovate via scraping (PEMSA, Centiel, Swiss Medical Network); le altre restano da completare a mano (form/ATS).
- **`scripts/generate-cold-emails.mjs`** — personalizzazione **Livello 4** (skill `cold-email`): numero reale di candidati **+ ruolo più cliccato**, copy più da pari, una sola CTA a basso attrito per touch. Aggiunge tag settore + ruolo nell'header della bozza. Rimosso il filtro di esclusione: **genera per tutte** le aziende.
- **`scripts/lib/employer-sectors.mjs`** (nuovo, condiviso): classificatore settore (`pubblico`/`multinazionale`/`pmi`) + `slugify`, usato da entrambi gli script → niente regex duplicate (AGENTS.md #6, single source of truth). È solo un'**etichetta di contesto**, non filtra.
- **`PLAN.md`** + refresh `README.md`.

Resta tutto **DRAFT-ONLY**: nessun provider email importato, nessun invio.

## Non implementato (ancora)

- **Email mancanti**: la maggior parte delle aziende espone solo form/ATS → email da completare a mano in `contacts.json` (LinkedIn/diretto). L'enrichment è best-effort, non garantisce l'email.
- **Invio**: deliberatamente fuori scope (step separato, gated, su OK esplicito).
- **Ruolo "generico"**: per alcune aziende il titolo più cliccato è una pagina generica (es. "Lavora con noi") invece di un ruolo specifico — la bozza si revisiona a mano comunque.
- **Sibling-check**: eventuali match sono idiomi GA4/HogQL generici condivisi; questa PR estrae già il classificatore settore in un modulo condiviso per evitare drift. Nessun antipattern replicato.

## Test plan

- [x] Enrichment gira su dati reali (ruolo top per 24 aziende, 3 email via scraping).
- [x] Generatore: 12 bozze personalizzate con numero+ruolo, settore etichettato, zero invio.
- [x] Nessun dato reale committato (contacts/report/drafts gitignored); nessun riferimento orfano ai filtri rimossi.