### PR TITLE
perf(pr-review): shallow checkout kills 11-min lazy-fetch stall + token trims

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -35,16 +35,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Partial clone: il checkout `fetch-depth: 0` full scaricava ~11GB di
-          # history (.git, repo a heavy churn su data/jobs) → 184s misurati, il
-          # 54% del run-time della review (Claude pass: ~150s). `filter:
-          # blob:none` prende solo commit-graph + blob HEAD (working tree per
-          # `rg`/`Read`), defer dei blob storici (lazy-fetch on-demand se mai
-          # servono `git blame`/`git log -L`/`git show` — strumenti opzionali,
-          # REVIEW.md non li richiede). Feedback review ~3min prima. fetch-depth
-          # resta 0: serve il commit-graph completo per la lazy-fetch.
-          fetch-depth: 0
-          filter: blob:none
+          # Shallow checkout: il reviewer NON usa MAI la git-history. Tutto il suo
+          # lavoro è `gh pr view`/`gh pr diff` (GitHub API) + `rg`/`Read`/`Grep`
+          # sul working tree HEAD (cross-file probing scopato al CODE, REVIEW.md
+          # step 5). I soli strumenti che richiedono history — `git blame`,
+          # `git log -L`, `git show <hist-sha>` — REVIEW.md non li invoca.
+          #
+          # Storia: `fetch-depth: 0 + filter: blob:none` (partial clone) prendeva
+          # commit-graph completo + blob HEAD e deferiva i blob storici a una
+          # lazy-fetch on-demand. Due costi: (1) il commit-graph di un repo a
+          # heavy churn (data/jobs, ~11GB .git) è grande di suo → 58-94s baseline
+          # di Checkout; (2) la lazy-fetch del partial clone occasionalmente
+          # STALLAVA — osservato Checkout da 11 MINUTI (run 27672265799, PR #2394)
+          # che mangiava il budget del timeout 15min → la Claude review partiva
+          # con ~4min, veniva uccisa a metà pass → nessuna review postata → PR in
+          # idle/stallo (auto-merge mai triggerato). Causa #1 di "review idle".
+          #
+          # `fetch-depth: 1` elimina ENTRAMBI: niente commit-graph history (non
+          # scarica gli ~11GB di .git), niente partial clone → niente lazy-fetch
+          # → niente stallo. Working tree HEAD interamente presente (Read di un
+          # campione `data/**` funziona ancora). Checkout atteso ~10-20s. Se mai
+          # servisse la history per un caso futuro, ripristinare depth:0 — ma
+          # allora SENZA `filter: blob:none` (è il partial clone a stallare).
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -206,8 +219,8 @@ jobs:
 
             **Bootstrap:**
             1. Leggi `REVIEW.md` — contratto operativo completo (tier, severity, filtro scopo, completeness contract, cross-file pattern repetition, test plan compliance, adversarial check, format).
-            2. `AGENTS.md` solo come contesto progetto (non-negotiables, architettura) — opzionale, leggi solo se serve.
-            3. Carica PR: `gh pr view $PR_NUMBER --json title,body,labels`, `gh pr view $PR_NUMBER --json files`, poi il diff del SOLO code: `gh pr diff $PR_NUMBER -- ':(exclude)data/**' ':(exclude)public/**' ':(exclude)reports/**' ':(exclude)_newsletter_variants/**'`. I file dati/static rigenerati (`data/**` job JSON, snapshot, translation-cache, blog-articles; `public/**` immagini/asset) NON sono code: NON revieware il loro contenuto riga-per-riga né contarli come finding — valuta solo se il CODE che li genera è corretto. Se serve un campione di output dati, aprilo mirato con `Read`, non scorrere l'intero blob nel diff.
+            2. `AGENTS.md` è grande: NON leggerlo salvo necessità specifica esplicita (un finding richiede di citare un non-negotiable preciso). REVIEW.md basta da solo per il workflow di review — leggere AGENTS.md a ogni run è token sprecato.
+            3. Carica PR in UNA call: `gh pr view $PR_NUMBER --json title,body,labels,files`, poi il diff del SOLO code: `gh pr diff $PR_NUMBER -- ':(exclude)data/**' ':(exclude)public/**' ':(exclude)reports/**' ':(exclude)_newsletter_variants/**' ':(exclude)docs/**'`. I file dati/static rigenerati (`data/**` job JSON, snapshot, translation-cache, blog-articles; `public/**` immagini/asset) NON sono code: NON revieware il loro contenuto riga-per-riga né contarli come finding — valuta solo se il CODE che li genera è corretto. Se serve un campione di output dati, aprilo mirato con `Read`, non scorrere l'intero blob nel diff.
 
             **Esegui workflow di review come specificato in REVIEW.md:**
             - completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → cross-file pattern repetition (step 5) → test plan compliance (step 6) → claim perf non validato (step 7) → output.

--- a/.github/workflows/refine-url-first-seen.yml
+++ b/.github/workflows/refine-url-first-seen.yml
@@ -31,12 +31,13 @@ jobs:
           # Nessun uso della git history: il job legge solo il working tree
           # (`git diff --quiet data/url-first-seen.json`), poi `checkout -b`
           # + commit + push di un branch FRESCO (PR, mai push su main, nessun
-          # rebase né `git show <commit>:<file>`). Il `fetch-depth: 0` qui era
-          # cargo-cult: scaricava ~11GB di `.git` per nulla. `filter:
-          # blob:none` prende commit-graph + blob HEAD e differisce i blob
-          # storici (lazy) → checkout molto più rapido senza perdere capacità.
-          fetch-depth: 0
-          filter: blob:none
+          # rebase né `git show <commit>:<file>`). `fetch-depth: 1` (shallow):
+          # solo il working tree HEAD, niente commit-graph history (~11GB .git
+          # mai scaricati) e niente partial clone → niente lazy-fetch che possa
+          # stallare (stessa classe del Checkout di `pr-review-loop.yml`, dove un
+          # lazy-fetch da 11min mangiava il timeout). Prima era `fetch-depth: 0 +
+          # filter: blob:none` (cargo-cult: nessuna capacità history serviva).
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Contesto (dati reali, ultimi 30 run success di `pr-review-loop`)

| Tier | Run | Turni (med/max) | Output tok (med) | Input tot (med) | Durata Claude (med) | Costo (med) |
|------|-----|-----------------|------------------|-----------------|---------------------|-------------|
| normal (sonnet) | 5 | 7/8 | 3k | 208k | **65s** | $0.23 |
| high (opus) | **25** | 20/34 | 21k | 975k | **294s** | $1.59 |

Mediana run totale ~390s = **~85s Checkout + ~294s Claude pass**. Nessun run vicino al cap turni (no `error_max_turns` risk → c'è margine).

**Root cause dell'"idle/stuck"** (run linkato `27672265799`, PR #2394): lo step **Checkout** col partial clone (`fetch-depth: 0` + `filter: blob:none`) ha fatto una **lazy-fetch da 11 MINUTI** → ha mangiato il timeout 15min → la Claude review è partita con ~4min, uccisa a metà pass → **nessuna review postata → PR in stallo** (auto-merge mai triggerato). Oltre a una tassa baseline 58-94s su OGNI run.

## Implementato
- **`pr-review-loop.yml` Checkout `fetch-depth: 0` + `filter: blob:none` → `fetch-depth: 1`.** Il reviewer NON usa mai la git-history (REVIEW.md: tutto `gh pr view`/`gh pr diff` via API + `rg`/`Read`/`Grep` sul working tree HEAD; cross-file probing scopato al CODE). Shallow elimina sia il commit-graph history (~11GB .git mai scaricati) sia il partial clone → **niente lazy-fetch → niente stallo**. Working tree HEAD interamente presente (il `Read` di un campione `data/**` funziona ancora). Checkout atteso ~10-20s.
- **Sibling-class fix (`refine-url-first-seen.yml`):** stessa identica classe — il suo commento già dichiarava "Nessun uso della git history... `fetch-depth: 0` era cargo-cult", ma era su `depth:0 + blob:none`. Portato a `fetch-depth: 1` nello stesso PR (AGENTS.md #6).
- **Token trim del prompt di review (zero impatto qualità):** (a) i due `gh pr view --json title,body,labels` + `--json files` uniti in UNA call; (b) `docs/**` aggiunto agli exclude del `gh pr diff` del code (allinea allo strip del tier, che già esclude docs); (c) AGENTS.md (file grande) non più letto a ogni run — istruzione esplicita "non leggere salvo necessità specifica": REVIEW.md è il contratto completo da solo.

## Impatto atteso
- **"idle/stuck" eliminato**: niente più partial-clone lazy-fetch → niente Checkout da 11min → la review ha sempre il budget pieno (~14min) per postare. Sui run patologici (cancelled/timed-out a 793-1390s osservati) la riduzione è **>50%**.
- **Run sani**: Checkout ~85s → ~15s (−70s, ~18% wall) + meno turni/token per call.
- **Token**: −1 turno bootstrap/run; niente AGENTS.md letto; diff più piccolo su PR doc-heavy.

## Non implementato (ancora)
- **`pr-body-contract.yml` lasciato su `depth:0 + blob:none`**: serve davvero la history (commit-graph + merge-base per il **three-dot diff** dello script sibling-check). Non può andare shallow; togliere `blob:none` lì = full 11GB = 143s (peggio). Out of scope — non è il path di review che stalla, è zero-Claude e veloce.
- **`refresh-shard-weights.yml` non toccato**: ha solo `filter: blob:none` SENZA `fetch-depth: 0` → è già shallow (depth 1 default) e non accede alla history → nessun rischio di stall. Niente da fixare.
- **Speedup 50% sul Claude pass dei run sani (high/opus)**: NON perseguito. Il 294s è inferenza opus a 20 turni; tagliarlo del 50% richiederebbe abbassare model/turni/scope = leva di QUALITÀ vietata dai non-negotiable (AGENTS.md #1; #795/#802 revertati). Il 50% qui è onesto solo sui run stallati (eliminati). Il tier routing (83% va high) NON è toccato: decidere quali PR "non meritano opus" è una call di qualità che non faccio senza OK owner.
- **sparse-checkout (escludere `data/`/`public/` dal working tree)** per tagliare il Checkout ulteriormente: deferito — rischia di rompere il `Read` di un campione `data/**` che REVIEW.md consente. Follow-up se serve.

## Revert-trigger (claim wall-time non validabile pre-merge)
Il Checkout gira su `main`, non sul `pull_request` di questo PR. Misura post-merge sul prossimo run organico di `pr-review-loop`: se il Checkout NON scende sotto ~25s o compare un `error_max_turns`/review mancante → revert. Atteso: Checkout 58-94s → ~10-20s, zero stalli >2min.

## Nota merge
Questo PR modifica `.github/workflows/pr-review-loop.yml` → workflow-validation drift della GitHub App del reviewer (reviewer non posta, auto-merge non scatta). **Merge manuale richiesto** via `gh pr merge --squash --delete-branch` (eccezione documentata in AGENTS.md → Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)