### PR TITLE
feat(publisher): claim/pre-fill publish form from crawled listing (#4)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6855,7 +6855,28 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </a>
  )}
 
- {salaryEstimateWidget && (
+ {!(selectedJob as unknown as { publisherJobId?: string }).publisherJobId && (
+                  <a
+                    href={buildPath({ activeTab: 'publish' }, locale) + '?claim=1'}
+                    className="mt-3 inline-block text-xs font-medium text-muted hover:text-accent underline underline-offset-2"
+                    onClick={() => {
+                      const cj = selectedJob as unknown as Record<string, unknown>;
+                      try {
+                        sessionStorage.setItem('claimJobPrefill', JSON.stringify({
+                          company: cj.company, title: cj.title, description: cj.description,
+                          category: cj.category, sector: cj.sector, employmentType: cj.employmentType,
+                          contractType: cj.contract, location: cj.location, canton: cj.canton,
+                          applyUrl: cj.applyUrl || cj.url,
+                        }));
+                      } catch { /* storage blocked — publish page just won't prefill */ }
+                      Analytics.trackSelectContent('job_board_claim_cta', `${selectedJob.company}_${selectedJob.title}`);
+                    }}
+                  >
+                    {t('jobBoard.claimCta')}
+                  </a>
+                )}
+
+                {salaryEstimateWidget && (
  <div className="mt-4">{salaryEstimateWidget}</div>
  )}
  {sectorContextWidget && (

--- a/components/pages/PublisherPublishPage.tsx
+++ b/components/pages/PublisherPublishPage.tsx
@@ -563,6 +563,36 @@ const PublisherPublishPage: React.FC = () => {
  return () => { cancelled = true; };
  }, [user]);
 
+ // ── Claim / pre-fill from a crawled listing ─────────────────
+ // The "Sei l'azienda?" link on a crawled job stashes its fields in
+ // sessionStorage and routes here with `?claim=1`. We seed the per-ad fields
+ // once (company stays editable, tier/payment unaffected) so the employer
+ // doesn't retype their own posting. Edit-mode (`?edit`) always wins; the
+ // stash is one-shot (removed after read) and purely client-side (no fetch).
+ useEffect(() => {
+ if (!user) return;
+ const sp = new URLSearchParams(window.location.search);
+ if (sp.get('edit') || !sp.get('claim')) return;
+ let raw: string | null = null;
+ try { raw = sessionStorage.getItem('claimJobPrefill'); } catch { /* storage blocked */ }
+ if (!raw) return;
+ try { sessionStorage.removeItem('claimJobPrefill'); } catch { /* ignore */ }
+ let d: Record<string, unknown>;
+ try { d = JSON.parse(raw) as Record<string, unknown>; } catch { return; }
+ if (!d || typeof d !== 'object') return;
+ if (d.company) setCompanyName(String(d.company));
+ if (d.title) setTitle(String(d.title).slice(0, 200));
+ if (d.description) setDescription(String(d.description));
+ if (d.category) setCategory(String(d.category));
+ if (d.sector) setSector(String(d.sector).slice(0, 80));
+ if (d.employmentType) setEmploymentType(String(d.employmentType));
+ if (d.contractType) setContractType(String(d.contractType));
+ if (d.applyUrl) setApplyUrl(String(d.applyUrl));
+ if (d.location) {
+ setLocations([{ label: String(d.location), postalCode: '', canton: String(d.canton || 'TI'), street: '' }]);
+ }
+ }, [user]);
+
  // Prefill the company section from a saved publisher profile (repeat posters
  // shouldn't re-type their company on every ad). Skipped in edit mode — the
  // edited ad's own company snapshot is the source of truth there.

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -692,6 +692,7 @@ const deCore: Record<string, string> = {
  'jobBoard.descriptionHeading': 'Stellenbeschreibung',
  'jobBoard.requirementsHeading': 'Erforderliche Kompetenzen',
  'jobBoard.apply': 'Bewerben',
+  'jobBoard.claimCta': 'Sind Sie das Unternehmen? Dieses Inserat sponsern',
  'jobBoard.backToList': 'Zurück zu allen Stellen',
  'jobBoard.notFoundTitle': 'Stelle nicht gefunden',
  'jobBoard.notFoundDescription': 'Diese Stelle ist nicht mehr verfügbar oder wurde entfernt.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -689,6 +689,7 @@ const enCore: Record<string, string> = {
  'jobBoard.descriptionHeading': 'Job description',
  'jobBoard.requirementsHeading': 'Required skills',
  'jobBoard.apply': 'Apply',
+  'jobBoard.claimCta': 'Are you the employer? Sponsor this listing',
  'jobBoard.backToList': 'Back to all listings',
  'jobBoard.notFoundTitle': 'Job not found',
  'jobBoard.notFoundDescription': 'This listing is no longer available or has been removed.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -692,6 +692,7 @@ const frCore: Record<string, string> = {
  'jobBoard.descriptionHeading': 'Description du poste',
  'jobBoard.requirementsHeading': 'Compétences requises',
  'jobBoard.apply': 'Postuler',
+  'jobBoard.claimCta': 'Vous êtes l\'entreprise ? Sponsorisez cette annonce',
  'jobBoard.backToList': 'Retour à toutes les offres',
  'jobBoard.notFoundTitle': 'Offre introuvable',
  'jobBoard.notFoundDescription': 'Cette offre n’est plus disponible ou a été supprimée.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -729,6 +729,7 @@ const translations: Record<string, string> = {
  'jobBoard.descriptionHeading': 'Descrizione posizione',
  'jobBoard.requirementsHeading': 'Competenze richieste',
  'jobBoard.apply': 'Candidati',
+  'jobBoard.claimCta': 'Sei l\'azienda? Rendi sponsorizzato questo annuncio',
  'jobBoard.backToList': 'Torna a tutti gli annunci',
  'jobBoard.notFoundTitle': 'Annuncio non trovato',
  'jobBoard.notFoundDescription': 'Questo annuncio non è più disponibile oppure è stato rimosso.',


### PR DESCRIPTION
## Contesto

Seconda metà di #4 (la prima — dedup publisher-supersede — è la PR #2408). Riduce l'attrito di conversione: un'azienda crawlata può "rivendicare" il proprio annuncio e renderlo sponsorizzato senza ridigitare tutto.

## Implementato

- **JobBoard (dettaglio)**: link CTA "Sei l'azienda? Rendi sponsorizzato questo annuncio", mostrato **solo per annunci crawlati** (`!publisherJobId`). Al click salva i campi dell'annuncio in `sessionStorage` e naviga a `/pubblica-offerta?claim=1`. Usa il pattern esistente `buildPath({activeTab:'publish'})` + query (identico a `PublisherDashboardPage ?edit=`).
- **PublisherPublishPage**: `useEffect` guardato che, quando `?claim` è presente e NON è edit-mode, legge lo stash e pre-compila i campi per-annuncio (title, description, category, sector, employmentType, contractType, location, applyUrl, company). One-shot (rimosso dopo la lettura), **puramente client-side (nessun fetch → nessun rischio CDN-path)**. Edit-mode (`?edit`) ha sempre precedenza.
- **`jobBoard.claimCta`** in tutti e 4 i locali (it/en/de/fr).

## Non implementato (ancora)

- **Lookup server-side / deep-link diretto**: il pre-fill funziona dal click sul dettaglio (job già in memoria → sessionStorage). Un `?claim=<slug>` aperto a freddo (senza passare dal dettaglio) non pre-compila — scelta deliberata per evitare il fetch del job index CDN (rischioso/da validare live). Follow-up se serve il deep-link.
- **Mapping campi mancanti**: i crawlati non hanno `employmentType`/`contractType`/salario → restano ai default, l'azienda li completa.

## Test plan

- [x] Verificato che `activeTab:'publish'` è un `ActiveTab` valido e che il pattern `buildPath(...)+?query` è già in uso (PublisherDashboardPage `?edit=`).
- [x] Pre-fill è client-side (sessionStorage), nessun fetch dati → nessun rischio 404 CDN.
- [ ] Typecheck/build via CI (full tsc locale = OOM per norma progetto).
- [ ] Post-deploy: cliccare il CTA su un annuncio crawlato → form pre-compilato; verificare che `?edit` abbia precedenza.