### PR TITLE
feat(ci): periodic auto-merge sweep closes the event-driven re-trigger gap

### DIFF
--- a/.github/workflows/auto-merge-sweep.yml
+++ b/.github/workflows/auto-merge-sweep.yml
@@ -1,0 +1,88 @@
+name: Auto-merge sweep (periodic safety-net)
+
+# Rete di sicurezza per il gap EVENT-DRIVEN di auto-merge-on-lgtm.yml: quello
+# valuta SOLO su pull_request_review o workflow_run(tests, conclusion==success).
+# Una PR che diventa mergeable senza che scatti nessuno dei due (es. run `tests`
+# concluso != success per un job collaterale cancellato MENTRE il check vitest è
+# verde — osservato #2428) resta ferma fino al recycle 24h. Questo cron
+# ri-valuta periodicamente OGNI PR open non-draft con la STESSA logica/gate
+# (auto-merge-eval.mjs, single source of truth): merge solo se ## LGTM +
+# vitest==success + collision ok; altrimenti exit 0 senza effetti.
+#
+# Zero-Claude (deterministico). NON modifica auto-merge-on-lgtm.yml (file
+# workflow-validation-sensitive): è un workflow nuovo e indipendente.
+
+on:
+  schedule:
+    # Nominale 15min, ma GitHub THROTTLA i cron ad alta frequenza (osservato su
+    # pr-autorebase: gira ogni 2-4h). Va bene come safety-net: cattura le PR
+    # ferme nel gap in ore, non in 24h. L'auto-merge event-driven resta il path
+    # primario (immediato); questo è solo la rete sotto.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+# Una sweep alla volta: evita due processi che tentano lo stesso merge insieme
+# (la race è comunque gestita da auto-merge-eval, ma serializzare è più pulito).
+concurrency:
+  group: auto-merge-sweep
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write # alert PAT-down (github-issue-creator)
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Stesso setup token di auto-merge-on-lgtm.yml: il PAT (da Remote Config)
+      # serve perché il merge triggeri il cascade deploy/followup; fallback su
+      # GITHUB_TOKEN se la RC non carica (merge senza cascade).
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna credenziale Firebase SA — GITHUB_PAT non verrà caricato; il merge ripiega su GITHUB_TOKEN (nessun cascade deploy/followup)."
+          fi
+
+      - name: Load secrets from Remote Config
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Alert PAT-down (dedup, zero-Claude)
+        if: env.GITHUB_PAT == ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/ci/alert-pat-down.mjs --workflow "${{ github.workflow }}" --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Re-evaluate every open PR (auto-merge-eval per PR)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MERGE_PRIMARY_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          MERGE_FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ env.GITHUB_PAT != '' }}
+        run: node scripts/ci/auto-merge-sweep.mjs
+
+      - name: Cleanup Firebase credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/scripts/ci/auto-merge-sweep.mjs
+++ b/scripts/ci/auto-merge-sweep.mjs
@@ -1,0 +1,91 @@
+/**
+ * auto-merge-sweep.mjs — rete di sicurezza periodica per l'auto-merge (zero-Claude).
+ *
+ * Perché esiste: `auto-merge-on-lgtm.yml` è puramente EVENT-DRIVEN — valuta solo
+ * su `pull_request_review` (## LGTM appena postato) o su `workflow_run` di `tests`
+ * concluso con `conclusion == 'success'`. Esiste una classe di PR che diventa
+ * mergeable SENZA che scatti nessuno dei due:
+ *   - il run `tests` chiude con conclusion ≠ success (es. un job collaterale
+ *     `cancelled`) MENTRE il check-run `vitest (unit + integration)` è verde →
+ *     il trigger `workflow_run` (gate `conclusion=='success'`) NON parte, ma il
+ *     gate vitest di auto-merge-eval (che guarda il check-run, non il run) sarebbe
+ *     soddisfatto (osservato 2026-06-17 su #2428: vitest aggregator success, PR
+ *     ferma perché nessun evento ri-valutava);
+ *   - race tra il completamento del check vitest e l'eval, o LGTM arrivato su un
+ *     commit poi superato senza un nuovo evento.
+ * Senza ri-valutazione, queste PR restano ferme fino al recycle 24h.
+ *
+ * Questo sweep gira su `schedule` (+ workflow_dispatch) e RI-VALUTA ogni PR open
+ * non-draft con `node scripts/ci/auto-merge-eval.mjs <n>` — STESSA logica e stessi
+ * gate dell'event-driven (single source of truth): merge SOLO se `## LGTM` (o
+ * drift-fallback) + vitest check == success + collision gate ok. Una PR non pronta
+ * → eval esce 0 senza mergiare (idempotente, nessun effetto). Le race col path
+ * event-driven sono già gestite da auto-merge-eval (confirmedMergedAfterRace).
+ *
+ * Uso:  node scripts/ci/auto-merge-sweep.mjs
+ * Env:  GH_TOKEN (read-only query), GITHUB_REPOSITORY, MERGE_PRIMARY_TOKEN,
+ *       MERGE_FALLBACK_TOKEN, HAS_PAT — passati invariati a ogni auto-merge-eval.
+ *       Richiede `gh` in PATH.
+ */
+import { execFileSync } from 'node:child_process';
+
+const REPO = process.env.GITHUB_REPOSITORY || '';
+
+function gh(args, { json = true } = {}) {
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return json ? JSON.parse(out) : out;
+}
+
+/**
+ * Dalla lista `gh pr list --json number,isDraft` ai numeri PR da ri-valutare:
+ * tutte le OPEN non-draft. Puro → testabile. L'eval per-PR fa già tutto il
+ * gating (LGTM/vitest/collision); pre-filtrare oltre il draft duplicherebbe la
+ * sua logica e rischierebbe di divergere → si delega all'eval (DRY).
+ */
+export function selectSweepCandidates(prs) {
+  if (!Array.isArray(prs)) return [];
+  return prs.filter((p) => p && p.isDraft === false && Number.isInteger(p.number)).map((p) => p.number);
+}
+
+function main() {
+  if (!REPO) {
+    console.error('GITHUB_REPOSITORY mancante — skip.');
+    process.exit(0);
+  }
+  let prs;
+  try {
+    prs = gh(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '100',
+      '--json', 'number,isDraft']);
+  } catch (e) {
+    console.error(`gh pr list fallito: ${String(e).slice(0, 160)} — skip.`);
+    process.exit(0);
+  }
+  const candidates = selectSweepCandidates(prs);
+  console.log(`auto-merge-sweep: ${candidates.length} PR open non-draft da ri-valutare → [${candidates.join(', ') || '—'}]`);
+
+  let merged = 0;
+  for (const n of candidates) {
+    try {
+      // auto-merge-eval esce 0 sia che mergi sia che non sia pronta; eredita
+      // l'env (token di merge) dal processo. Cattura lo stdout per loggare l'esito.
+      const out = execFileSync('node', ['scripts/ci/auto-merge-eval.mjs', String(n)],
+        { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024, env: process.env });
+      if (/mergiata/.test(out)) {
+        merged++;
+        console.log(`  #${n}: MERGIATA dallo sweep ✔`);
+      } else {
+        // logga solo l'ultima riga di esito dell'eval (gate non soddisfatto, atteso).
+        const last = out.trim().split('\n').pop() || '';
+        console.log(`  #${n}: no-merge — ${last.slice(0, 160)}`);
+      }
+    } catch (e) {
+      // auto-merge-eval esce !=0 solo su errore reale di merge (raro); non blocca lo sweep.
+      console.log(`  #${n}: eval errore (${String(e).slice(0, 120)}) — continuo.`);
+    }
+  }
+  console.log(`auto-merge-sweep completo: ${merged}/${candidates.length} mergiate.`);
+}
+
+if (process.argv[1]?.endsWith('auto-merge-sweep.mjs')) {
+  main();
+}

--- a/tests/auto-merge-sweep.test.ts
+++ b/tests/auto-merge-sweep.test.ts
@@ -1,0 +1,37 @@
+/**
+ * selectSweepCandidates — quali PR il sweep periodico ri-valuta: tutte le OPEN
+ * non-draft. Il gating fine (LGTM/vitest/collision) è delegato ad auto-merge-eval
+ * (DRY), quindi il filtro qui è solo "non-draft + numero valido".
+ */
+import { describe, it, expect } from 'vitest';
+import { selectSweepCandidates } from '../scripts/ci/auto-merge-sweep.mjs';
+
+describe('selectSweepCandidates (auto-merge periodic sweep)', () => {
+  it('tiene le PR open non-draft, scarta i draft', () => {
+    const prs = [
+      { number: 1, isDraft: false },
+      { number: 2, isDraft: true },
+      { number: 3, isDraft: false },
+    ];
+    expect(selectSweepCandidates(prs)).toEqual([1, 3]);
+  });
+
+  it('scarta entry senza numero intero valido', () => {
+    const prs = [
+      { number: 10, isDraft: false },
+      { isDraft: false },
+      { number: 'x', isDraft: false },
+      null,
+    ] as unknown as { number: number; isDraft: boolean }[];
+    expect(selectSweepCandidates(prs)).toEqual([10]);
+  });
+
+  it('input non-array o vuoto → []', () => {
+    expect(selectSweepCandidates(undefined as unknown as [])).toEqual([]);
+    expect(selectSweepCandidates([])).toEqual([]);
+  });
+
+  it('tutti draft → [] (niente da ri-valutare)', () => {
+    expect(selectSweepCandidates([{ number: 1, isDraft: true }, { number: 2, isDraft: true }])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Contesto

`auto-merge-on-lgtm.yml` è puramente **event-driven**: valuta SOLO su `pull_request_review` o `workflow_run(tests, conclusion=='success')`. Esiste una classe di PR che diventa mergeable senza che scatti nessuno dei due → resta ferma fino al recycle 24h.

**Prova live (2026-06-17, #2428):** il run `tests` ha concluso `!= success` (un job collaterale `cancelled` durante l'ondata di rebase) MENTRE il check-run `vitest (unit + integration)` era **verde** → il trigger `workflow_run` (gate `conclusion=='success'`) non è partito, ma il gate vitest di `auto-merge-eval` (che legge il *check-run*, non il *run*) sarebbe passato. La PR aveva LGTM + vitest success + behind=0 + no collision → mergeable, ma è rimasta OPEN perché nessun evento la ri-valutava. (Scoperto osservando la coda dopo il fix #2415.)

## Implementato

- **`.github/workflows/auto-merge-sweep.yml`** (nuovo, zero-Claude): `schedule` (cron `*/15`, throttlato da GitHub a ore — ok come safety-net) + `workflow_dispatch`, `concurrency: auto-merge-sweep`. Stesso setup token di `auto-merge-on-lgtm.yml` (Firebase SA → `load-rc-env` → `GITHUB_PAT`, fallback `GITHUB_TOKEN`; alert PAT-down).
- **`scripts/ci/auto-merge-sweep.mjs`**: lista le PR open non-draft e ri-valuta ognuna con `node scripts/ci/auto-merge-eval.mjs <n>` — **stessa logica e stessi gate** dell'event-driven (single source of truth). Una PR non pronta → l'eval esce 0 senza effetti (idempotente). Helper puro esportato `selectSweepCandidates(prs)`.
- **`tests/auto-merge-sweep.test.ts`**: 4 test sul filtro candidati (non-draft, numero valido, input vuoto/non-array).

Le race col path event-driven sono già gestite da `auto-merge-eval` (`confirmedMergedAfterRace`). Il merge resta gated identico: solo `## LGTM` (o drift-fallback) + `vitest==success` + collision-ok.

## Non implementato (ancora)

- **NON modifico `auto-merge-on-lgtm.yml`**: è workflow-validation-sensitive (richiede byte-identità con main → merge manuale). Lo sweep è un workflow nuovo e indipendente → review/merge normali. Il path event-driven resta primario (immediato); questo è solo la rete sotto.
- **Cadenza reale**: GitHub throttla i cron ad alta frequenza (osservato su `pr-autorebase`: 2-4h invece di 30min). Lo sweep cattura le PR nel gap in ore, non immediatamente — accettabile per una safety-net (vs 24h del recycle). Validazione live post-merge: `gh workflow run auto-merge-sweep.yml --ref main`.
- **#2438** (cancelled-shards→failure heal) e **#2424** (collision starvation): hardening separati, fuori scope qui.
- Driver `auto-merge-sweep.mjs` orchestration (gh/subprocess) non unit-testabile oltre il filtro puro; validato live al primo run.