### PR TITLE
fix(harvester): don't escalate max-turns/pr-body-contract false positives

### DIFF
--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -117,8 +117,70 @@ function fingerprintFinding(text) {
   const lead = words.slice(0, 4);
   return lead.length >= 3 ? `fp:${lead.join('-')}` : null; // too short → still drop
 }
+// ---- `pr-body-contract` false-positive guard (DETERMINISTIC) ----------------
+// The `pr-body-contract` regex matches the contract VOCABULARY (`## Implementato`,
+// `## Non implementato`, `completeness contract`, …), but a reviewer line mentions
+// that vocabulary in three distinct senses, only ONE of which is a recurring agent
+// mistake worth escalating:
+//   (a) GENUINE violation — a section is missing/empty/incomplete, or a `Closes`
+//       multi-issue line. This is the escalation target.
+//   (b) AFFIRMATION — the reviewer states the contract is fine ("sezioni presenti
+//       e sensate", "completeness contract OK", "## Implementato accurato"). NOT a
+//       defect; counting it inflates the bucket (#2397/#2396 examples).
+//   (c) LOCATION LABEL — the finding is about a DIFFERENT topic (sibling count,
+//       stale comment, CSS) and merely cites `PR body ## Implementato L2` /
+//       `## Non implementato L1` as the line address. Those findings belong to
+//       their own bucket (sibling-class-fix / stale-comment), reached via the
+//       fingerprint net or another taxonomy entry — not pr-body-contract (#2409/
+//       #2408 examples).
+// Crucially the deterministic gate `pr-body-contract.yml` ALREADY enforces section
+// PRESENCE (`hasImpl`/`hasNon`, multi-issue `Closes`) — the structural fix this
+// escalation would ask for already shipped. So a GENUINE missing-section violation
+// can barely reach the reviewer (the gate flags it first); the bucket's recurrence
+// is dominated by (b)/(c) false positives. Only count (a). Pure → unit-tested.
+//
+// Same false-positive class as the `❓`/per-line dedup fixes in tallyFindings and
+// the `already-fixed` avoidability classifier: don't escalate non-defects.
+// Explicit "the section/Closes is broken" language → a real violation. Negation-
+// aware on the affirmation side (below): "non rispettato" must NOT read as "ok".
+const PR_BODY_CONTRACT_VIOLATION_RE =
+  /\b(manca\w*|mancant\w*|assent\w*|vuot\w*|incomplet\w*|placeholder|tbd|stub|multi-?issue)\b|sezion\w*\s+obbligator\w*\s+(manca|assent)|non\s+(è\s+|e\s+)?(corrisponde|rispettat\w*|accurat\w*|coerent\w*|corrett\w*)|senza testo|n\/a|claim.*non.*(diff|reale)|una riga sola/i;
+// Positive contract-state words. Only an AFFIRMATION when NOT negated by a
+// preceding "non " (so "non rispettato" / "non accurato" are not swallowed here).
+const PR_BODY_CONTRACT_AFFIRM_RE =
+  /(?<!non\s)\b(ok|presenti|presente|sensate?|accurat\w*|coerent\w*|corrett\w*|completo|in regola|rispettat\w*)\b|nessun\w*\s+(problema|drift|violazione|scope drift)/i;
+// Location-label tell: the finding cites `## Implementato`/`## Non implementato`
+// (optionally prefixed "PR body", optionally with an L<n> line ref) only as the
+// ADDRESS of a finding about another topic. Tolerant of arrows/quotes between
+// "PR body" and the section, and of the section being quoted.
+const PR_BODY_CONTRACT_LOCATION_RE =
+  /pr body\b[^a-z]*#{0,3}\s*"?\s*(non\s+)?implementato\b|#{2,3}\s*(non\s+)?implementato\s+l?\d|"\s*#{2,3}\s*(non\s+)?implementato\s*"\s*l?\d/i;
+export function isGenuinePrBodyContractViolation(text) {
+  const s = String(text || '');
+  // (a) explicit violation language wins — a real missing/empty/mismatched section
+  //     or a multi-issue Closes, regardless of any affirming word nearby.
+  if (PR_BODY_CONTRACT_VIOLATION_RE.test(s)) return true;
+  // (b) the line AFFIRMS the contract is fine (un-negated positive) → not a defect.
+  if (PR_BODY_CONTRACT_AFFIRM_RE.test(s)) return false;
+  // (c) section name used only as a `PR body ## X (L<n>)` location label for a
+  //     finding about a different topic → not a contract defect.
+  if (PR_BODY_CONTRACT_LOCATION_RE.test(s)) return false;
+  // Default: no affirmation, no location-label tell, matched the contract
+  // vocabulary → conservative: keep as a genuine violation.
+  return true;
+}
+
 export function bucketFinding(text) {
-  for (const t of TAXONOMY) if (t.re.test(text)) return t.key;
+  for (const t of TAXONOMY) {
+    if (!t.re.test(text)) continue;
+    // pr-body-contract: drop affirmations / location-label false positives so the
+    // bucket counts only genuine contract violations (the deterministic gate
+    // pr-body-contract.yml already blocks missing sections). Falls through to the
+    // next matching taxonomy entry / fingerprint net so a co-mentioned real defect
+    // (sibling-class-fix, stale-comment) still clusters in its own bucket.
+    if (t.key === 'pr-body-contract' && !isGenuinePrBodyContractViolation(text)) continue;
+    return t.key;
+  }
   return fingerprintFinding(text); // unbucketed → fingerprint safety net (or null)
 }
 
@@ -191,6 +253,40 @@ export function isAvoidableAlreadyFixed(title, labels) {
   if (m && Number(m[1]) >= 2) return false; // aggregate by explicit count
   if (/\b(?:sweep|batch|bulk)\b/i.test(String(title || ''))) return false; // aggregate by keyword
   return true; // single-item follow-up → the gate's real target → countable
+}
+
+// ---- `max-turns` avoidability classifier (DETERMINISTIC) --------------------
+// A `fix-outcome:max-turns` marker (issue-fix.yml granular telemetry: a fixer run
+// that died `error_max_turns`) is recurring-BURN worth escalating ONLY when the
+// run hit the cap on a task the automation COULD have completed in budget — i.e. a
+// genuinely-fixable loop. Two whole classes hit the cap DETERMINISTICALLY by their
+// own structure, and for them the structural fix ALREADY shipped (followup-drainer
+// pre-flight #2291 + the per-item circuit-breaker in issue-fix.yml). Re-tentando
+// li riproduce; raising max-turns is explicitly forbidden (AGENTS.md, reverts
+// #795/#802). Counting them re-fires escalation #2439 with no actionable fix left:
+//   1. AGGREGATE follow-ups ("N item deferred", N≥2, or sweep/batch/bulk): doing
+//      ALL items in one run blows the budget by construction (#2332 = 5 items). The
+//      circuit-breaker already caps the run at ONE item; a death here is the
+//      multi-item attempt the breaker is meant to stop, not a fixable loop.
+//   2. Issues the drainer has ALREADY PARKED `needs-human` (malformed body / network
+//      -audit / repeated-death too-large): the deterministic pre-flight detected the
+//      structural non-fixability and stopped re-queueing. The lingering marker is the
+//      run that triggered the park, expected — not preventable burn.
+// Single-item, still-routable follow-ups that die at the cap (no `needs-human`) are
+// the genuine signal — a fixable loop the budget should have covered → countable.
+// Same feedback-loop class as isAvoidableAlreadyFixed. Pure → unit-tested.
+// `labels` is an array of label-name strings.
+export function isAvoidableMaxTurns(title, labels) {
+  const names = Array.isArray(labels) ? labels : [];
+  const t = String(title || '');
+  // (2) drainer already parked it as structurally non-fixable → expected death.
+  if (names.includes('needs-human')) return false;
+  // (1) aggregate multi-item → over-budget by construction (circuit-breaker target),
+  //     not a fixable loop. Same detection as isAvoidableAlreadyFixed.
+  const m = t.match(/(\d+)\s+items?\s+deferred/i);
+  if (m && Number(m[1]) >= 2) return false; // aggregate by explicit count
+  if (/\b(?:sweep|batch|bulk)\b/i.test(t)) return false; // aggregate by keyword
+  return true; // single-item, still-routable → fixable loop → countable
 }
 
 // ---- 2. Recurring issue classes (created in window) ----
@@ -337,6 +433,14 @@ async function main() {
       // (root cause of #2290: bucket re-fired at 9/14d, all 5 examples aggregate or
       // non-follow-up). Single-item follow-ups — the gate's real target — still count.
       if (code === 'already-fixed' && !isAvoidableAlreadyFixed(issue.title, labelNames)) continue;
+      // `max-turns` on an aggregate multi-item issue (over-budget by construction,
+      // the per-item circuit-breaker's target) or on an issue the drainer has already
+      // parked `needs-human` (structurally non-fixable: malformed body / network-audit
+      // / repeated-death) is an EXPECTED deterministic death, not a fixable loop → no
+      // actionable structural fix beyond what shipped (#2291 + circuit-breaker), so
+      // don't escalate it (root cause of #2439: bucket re-fired at 14/14d, examples
+      // dominated by aggregate / parked runs). Single-item still-routable deaths count.
+      if (code === 'max-turns' && !isAvoidableMaxTurns(issue.title, labelNames)) continue;
       const k = `fix-outcome:${code}`;
       if (seenThisIssue.has(k)) continue;
       seenThisIssue.add(k);

--- a/tests/harvest-escalation-avoidable.test.ts
+++ b/tests/harvest-escalation-avoidable.test.ts
@@ -1,0 +1,114 @@
+/**
+ * lessons-harvester — spegne i FALSI POSITIVI che fanno ricorrere in eterno due
+ * escalation senza fix strutturale possibile (stessa classe di #2290/#2433):
+ *
+ *   - #2439 `fix-outcome:max-turns`: un run-death `error_max_turns` è burn-fixabile
+ *     SOLO su una follow-up single-item ancora instradabile. Aggregate multi-item
+ *     (over-budget by construction, target del circuit-breaker) e issue già parkate
+ *     `needs-human` dal drainer (#2291: malformed body / network-audit) muoiono al
+ *     cap DETERMINISTICAMENTE → niente loop fixabile → non contabili.
+ *   - #2440 `reviewer-finding/pr-body-contract`: la regex matcha il VOCABOLARIO del
+ *     contratto, ma una violazione GENUINA (sezione mancante/vuota, Closes multi-issue)
+ *     è già bloccata dal gate deterministico pr-body-contract.yml. Il bucket ricorre
+ *     per affermazioni ("sezioni presenti e sensate") ed etichette-di-posizione
+ *     ("PR body ## Implementato L2" su un finding di altro tipo). Conta solo (a).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isAvoidableMaxTurns,
+  isGenuinePrBodyContractViolation,
+  bucketFinding,
+} from '../scripts/ci/harvest-agent-lessons.mjs';
+
+describe('isAvoidableMaxTurns — non escalare la morte al cap che è deterministica/inerente', () => {
+  it('follow-up single-item ancora instradabile → contabile (loop fixabile, vero target)', () => {
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2388): 1 item deferred — feat(traffic): webcam warmup gating',
+      ['follow-up', 'agent:triaged', 'fu-prio:low'],
+    )).toBe(true);
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2383): fix(seo): raise CF-hot 404 bridge cap',
+      ['follow-up', 'funnel-seo', 'agent:triaged'],
+    )).toBe(true);
+  });
+
+  it('issue parkata needs-human dal drainer → NON contabile (#2291: morte deterministica)', () => {
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2388): 1 item deferred — feat(traffic): webcam warmup gating',
+      ['follow-up', 'agent:triaged', 'fu-parked', 'needs-human'],
+    )).toBe(false);
+  });
+
+  it('aggregate "N item deferred" (N≥2) → NON contabile (over-budget by construction, #2332)', () => {
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2331): 5 item deferred — fix(jobboard): canton-aware section',
+      ['follow-up', 'funnel-ux', 'agent:fix', 'agent:triaged'],
+    )).toBe(false);
+    expect(isAvoidableMaxTurns('follow-up(#x): 2 items deferred — perf', ['follow-up'])).toBe(false);
+  });
+
+  it('aggregate per keyword (sweep/batch/bulk) → NON contabile', () => {
+    expect(isAvoidableMaxTurns('follow-up: Sweep ~30 crawler thin-source guard', ['follow-up'])).toBe(false);
+    expect(isAvoidableMaxTurns('follow-up: batch redirect cleanup', ['follow-up'])).toBe(false);
+    expect(isAvoidableMaxTurns('follow-up: bulk slug migration', ['follow-up'])).toBe(false);
+  });
+
+  it('"1 item deferred" NON è aggregate (boundary N=1) → contabile se non parkata', () => {
+    expect(isAvoidableMaxTurns('follow-up(#9): 1 item deferred — fix(x)', ['follow-up'])).toBe(true);
+  });
+
+  it('input degeneri → contabile-safe non gonfia (proceed: solo le esclusioni esplicite scartano)', () => {
+    // nessuna label needs-human, nessun marcatore aggregate → resta contabile,
+    // ma in pratica un titolo vuoto non fa scattare nulla a valle (count basso).
+    expect(isAvoidableMaxTurns(undefined as unknown as string, undefined as unknown as string[])).toBe(true);
+    expect(isAvoidableMaxTurns('', null as unknown as string[])).toBe(true);
+    // labels non-array trattate come [] → nessuna needs-human → contabile
+    expect(isAvoidableMaxTurns('follow-up: x', 'follow-up' as unknown as string[])).toBe(true);
+  });
+});
+
+describe('isGenuinePrBodyContractViolation — conta solo la violazione reale, non affermazioni/etichette', () => {
+  it('sezione mancante/vuota/incompleta → violazione (contabile)', () => {
+    expect(isGenuinePrBodyContractViolation('🔴 process: manca la sezione `## Non implementato`')).toBe(true);
+    expect(isGenuinePrBodyContractViolation('🟡 nit: `## Non implementato` ha un bullet vuoto (`- ` senza testo)')).toBe(true);
+    expect(isGenuinePrBodyContractViolation('🔴 `## Implementato` incompleto: non corrisponde al diff')).toBe(true);
+    expect(isGenuinePrBodyContractViolation('🟡 Closes multi-issue su una riga sola → chiude solo la prima')).toBe(true);
+    expect(isGenuinePrBodyContractViolation('🟡 il bullet dichiara X ma il diff non lo mostra')).toBe(true);
+  });
+
+  it('affermazione "il contratto è ok" → NON violazione (#2397/#2396)', () => {
+    expect(isGenuinePrBodyContractViolation(
+      'Il resto del contratto è ok: sezioni `## Implementato` / `## Non implementato` presenti e sensate',
+    )).toBe(false);
+    expect(isGenuinePrBodyContractViolation('completeness contract OK, sezioni obbligatorie presenti')).toBe(false);
+    expect(isGenuinePrBodyContractViolation('`## Non implementato` accurato, nessun drift')).toBe(false);
+  });
+
+  it('etichetta-di-posizione "PR body ## Implementato L2" per un finding di altro tipo → NON violazione (#2409/#2408)', () => {
+    expect(isGenuinePrBodyContractViolation(
+      '`PR body ## Implementato L2`: 🟡 Nit: descrive il match come "stesso companyKey + titolo"',
+    )).toBe(false);
+    expect(isGenuinePrBodyContractViolation(
+      '`PR body → "## Non implementato" L1`: 🟡 Nit: dichiara 10 match ma la sticky ne elenca 12',
+    )).toBe(false);
+  });
+
+  it('vocabolario contratto senza affermazione né etichetta → conservativo: violazione', () => {
+    expect(isGenuinePrBodyContractViolation('🔴 il completeness contract non è rispettato qui')).toBe(true);
+  });
+});
+
+describe('bucketFinding — pr-body-contract scarta i falsi positivi e lascia ricadere il vero topic', () => {
+  it('affermazione contratto non finisce in pr-body-contract', () => {
+    expect(bucketFinding('🟡 sezioni `## Implementato` / `## Non implementato` presenti e sensate')).not.toBe('pr-body-contract');
+  });
+
+  it('etichetta-di-posizione con finding sibling cade in sibling-class-fix, non pr-body-contract', () => {
+    const b = bucketFinding('`PR body ## Non implementato L1`: 🟡 Nit: stesso antipattern nel file gemello non toccato');
+    expect(b).toBe('sibling-class-fix');
+  });
+
+  it('violazione genuina di sezione mancante resta pr-body-contract', () => {
+    expect(bucketFinding('🔴 process: manca la sezione `## Implementato`')).toBe('pr-body-contract');
+  });
+});


### PR DESCRIPTION
## Implementato

Spegne i FALSI POSITIVI che fanno ricorrere in eterno due escalation senza fix strutturale possibile — **stessa classe di #2290/#2433** (`already-fixed`): il fix strutturale già esiste, l'harvester conta istanze NON-azionabili.

- **`scripts/ci/harvest-agent-lessons.mjs` — nuovo helper puro esportato `isAvoidableMaxTurns(title, labels)`** (#2439): un marker `fix-outcome:max-turns` (telemetria granulare di `issue-fix.yml`, run morto `error_max_turns`) è burn-fixabile DA ESCALARE solo su una follow-up **single-item ancora instradabile**. Due classi muoiono al cap DETERMINISTICAMENTE e hanno già il fix strutturale shippato (`followup-drainer` pre-flight #2291 + circuit-breaker per-item in `issue-fix.yml`):
  1. **aggregate multi-item** (`N item deferred` N≥2, o `sweep`/`batch`/`bulk`) — fare tutti gli item in un run sfora il budget by construction (#2332 = 5 item; è esattamente ciò che il circuit-breaker deve fermare);
  2. **issue già parkate `needs-human`** dal drainer (malformed body / network-audit #2291) — il pre-flight ha rilevato la non-fixabilità strutturale e fermato il ri-accodo; il marker residuo è il run che ha innescato il park, atteso.
  - Wired nel loop FIX_OUTCOME: `if (code === 'max-turns' && !isAvoidableMaxTurns(issue.title, labelNames)) continue;` — stessa classe di guard degli skip già presenti (`reconcile-bot`, `post-step deterministico`, `already-fixed`).
- **`scripts/ci/harvest-agent-lessons.mjs` — nuovo helper puro esportato `isGenuinePrBodyContractViolation(text)` + guard in `bucketFinding`** (#2440): la regex `pr-body-contract` matcha il VOCABOLARIO del contratto, ma una violazione GENUINA (sezione mancante/vuota, `Closes` multi-issue) è **già bloccata dal gate deterministico `pr-body-contract.yml`** (`hasImpl`/`hasNon`) — il fix strutturale che l'escalation chiederebbe esiste. La ricorrenza è dominata da:
  - (b) **affermazioni** che il contratto è OK (`sezioni presenti e sensate`, `completeness contract OK`) — #2397/#2396;
  - (c) **etichette-di-posizione** (`PR body ## Implementato L2`, `## Non implementato L1`) che indirizzano un finding su altro topic (sibling-count, stale-comment, CSS) — #2409/#2408.
  - `bucketFinding` ora scarta (b)/(c) e lascia ricadere il finding nel bucket corretto (sibling-class-fix / stale-comment / fingerprint). Affirmation negation-aware (`non rispettato` resta violazione).
- **`tests/harvest-escalation-avoidable.test.ts`** — 13 test sui due helper puri + `bucketFinding`: single-item contabile; aggregate per count/keyword e parked `needs-human` NON contabili; boundary N=1; violazione genuina vs affermazione vs etichetta-di-posizione; fall-through a sibling-class-fix.
- **Verifica live (re-run harvester su dati reali, finestra 14gg)**:
  - `fix-outcome:max-turns` **14 → 3** (`[ESCALATE]` → `[documented]`, sotto soglia 6 = THRESHOLD×EFFICACY_FACTOR);
  - `reviewer-finding/pr-body-contract` **7 → 5** (`[ESCALATE]` → `[documented]`);
  - **escalations totali = 0**. Al prossimo run live su `main` la logica SELF-HEAL (bucket non più tra i `liveKeys`) auto-chiude #2439 e #2440 con commento.

Closes #2439
Closes #2440

## Non implementato (ancora)

- **NON modificato alcun max-turns budget** di workflow agentici (`issue-fix`/`pr-review-loop`/`post-merge-followup`) — vietato da AGENTS.md (claim non misurato, revert #795/#802). Il fix è sul routing/dedup dell'harvester, non sul budget turni.
- **NON estratto un modulo condiviso** per la detection aggregate (`isAvoidableMaxTurns` ↔ `isAvoidableAlreadyFixed` ↔ `isAggregate` in `check-issue-already-resolved.mjs`): condividono solo la regex `\b(?:sweep|batch|bulk)\b` + `N items deferred`, ma firme/scope divergono (`isAvoidableMaxTurns` aggiunge il gate `needs-human`; `isAvoidableAlreadyFixed` il gate scope `follow-up`; `isAggregate` legge title+body). Estrarre un modulo unico forzerebbe una firma artificiosa. Se la sola semantica "aggregate" diverge in futuro, consolidare quella regex in un helper condiviso.
- **Sibling-class (`scripts/ci/check-sibling-patterns.mjs`)**: l'unico gemello segnalato è `scripts/ci/reconcile-followups.mjs` per il token condiviso `labelNames` — NON lo stesso antipattern: lì `labelNames` legge le label per il proprio gate di reconcile (`hasMaybeResolved`/`blocked`), nessun costrutto di bucketing/avoidability-classifier dell'harvester. Nessun fix da propagare.
- **NON reso il gate `pr-body-contract.yml` più severo** (es. validare che ogni bullet di `## Implementato` corrisponda al diff): fuori scope, e richiederebbe parsing semantico non deterministico. I 5 residui restano contati: se tornano sopra soglia, l'escalation riemergerà su un gap reale e azionabile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)