### PR TITLE
perf(build): cap related-search pre-pass worker concurrency to fix deploy OOM (exit 143)

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2454,29 +2454,50 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           company: j.company,
           location: j.location,
         }));
-        const results = await Promise.all(
-          localeKeys.map((workerLocale) => {
-            const localeTokens = Array.from(tokensByLocale.get(workerLocale) as Set<string>);
-            return new Promise<{ locale: Locale; entries: Array<{ token: string; list: number[] }> }>(
-              (resolve, reject) => {
-                const worker = new Worker(workerUrl, {
-                  workerData: { jobs: slimJobs, locale: workerLocale, tokens: localeTokens },
-                });
-                worker.once('message', resolve);
-                worker.once('error', reject);
-                worker.once('exit', (code) => {
-                  if (code !== 0) reject(new Error(`relatedSearchPostingsWorker exited with code ${code}`));
-                });
-              },
-            );
-          }),
+        // Concurrency cap on simultaneous workers. Each worker builds a FULL
+        // per-locale 2/3-gram inverted index (~hundreds of MB for ~11k jobs)
+        // that lives until the worker exits. Spawning all 4 locales at once
+        // (the old Promise.all) stacked 4 of those indexes on top of the
+        // already-~9.7 GB build heap → systemd-oomd SIGTERM (exit 143) on the
+        // 16 GB runner — a kernel-level OOM, no V8 "heap limit" line. Batching
+        // keeps at most PREPASS_CONCURRENCY worker indexes resident at a time;
+        // output is byte-identical (results are seeded into the same
+        // tokenIndex), the only cost is ~tens of seconds of pre-pass wall-time
+        // when locales run in batches instead of fully parallel. Env override
+        // RELATED_SEARCH_PREPASS_CONCURRENCY lets us drop to 1 (max safety) or
+        // raise it again if runner headroom returns, with no code change.
+        const PREPASS_CONCURRENCY = Math.max(
+          1,
+          Number(process.env.RELATED_SEARCH_PREPASS_CONCURRENCY) || 2,
         );
-        for (const r of results) {
-          tokenIndex.seedPostings(r.locale, r.entries);
+        const runPrepassWorker = (workerLocale: Locale) => {
+          const localeTokens = Array.from(tokensByLocale.get(workerLocale) as Set<string>);
+          return new Promise<{ locale: Locale; entries: Array<{ token: string; list: number[] }> }>(
+            (resolve, reject) => {
+              const worker = new Worker(workerUrl, {
+                workerData: { jobs: slimJobs, locale: workerLocale, tokens: localeTokens },
+              });
+              worker.once('message', resolve);
+              worker.once('error', reject);
+              worker.once('exit', (code) => {
+                if (code !== 0) reject(new Error(`relatedSearchPostingsWorker exited with code ${code}`));
+              });
+            },
+          );
+        };
+        let seededCount = 0;
+        for (let i = 0; i < localeKeys.length; i += PREPASS_CONCURRENCY) {
+          const batch = localeKeys.slice(i, i + PREPASS_CONCURRENCY);
+          const batchResults = await Promise.all(batch.map(runPrepassWorker));
+          // Seed per-batch so each worker's transient gram index is reclaimed
+          // (worker exit) before the next batch spawns.
+          for (const r of batchResults) {
+            tokenIndex.seedPostings(r.locale, r.entries);
+            seededCount += r.entries.length;
+          }
         }
-        const seededCount = results.reduce((s, r) => s + r.entries.length, 0);
         console.log(
-          `\x1b[36m[related-search-clusters]\x1b[0m postings pre-pass: ${localeKeys.length} worker(s) seeded ${seededCount} token postings`,
+          `\x1b[36m[related-search-clusters]\x1b[0m postings pre-pass: ${localeKeys.length} worker(s) seeded ${seededCount} token postings (concurrency ${PREPASS_CONCURRENCY})`,
         );
       }
       profileRecord('postings-prepass', __tPrePass);

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2477,10 +2477,28 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
               const worker = new Worker(workerUrl, {
                 workerData: { jobs: slimJobs, locale: workerLocale, tokens: localeTokens },
               });
-              worker.once('message', resolve);
+              // Resolve on 'exit', NOT 'message': the worker holds its full
+              // per-locale gram index (~hundreds of MB) in memory until it tears
+              // down. Resolving on 'message' would let the next batch spawn while
+              // this batch's workers are still resident → up to 2×concurrency
+              // indexes overlapping at the OOM ceiling (worst case = the original
+              // all-at-once spawn, defeating the cap). Gating on 'exit' makes the
+              // reclamation airtight: batch N is fully torn down before N+1
+              // allocates. The message payload is captured first, then surfaced
+              // once the worker has exited cleanly.
+              let payload: { locale: Locale; entries: Array<{ token: string; list: number[] }> } | null = null;
+              worker.once('message', (msg) => {
+                payload = msg;
+              });
               worker.once('error', reject);
               worker.once('exit', (code) => {
-                if (code !== 0) reject(new Error(`relatedSearchPostingsWorker exited with code ${code}`));
+                if (code !== 0) {
+                  reject(new Error(`relatedSearchPostingsWorker exited with code ${code}`));
+                } else if (!payload) {
+                  reject(new Error('relatedSearchPostingsWorker exited without posting a result'));
+                } else {
+                  resolve(payload);
+                }
               });
             },
           );


### PR DESCRIPTION
## Implementato

- **Cap concorrenza worker del postings pre-pass** in `build-plugins/relatedSearchClustersPlugin.ts`. Prima i worker venivano spawnati uno **per locale tutti insieme** (`Promise.all` su `localeKeys`, fino a 4). Ogni worker costruisce un **gram-index 2/3 per-locale completo** (~centinaia di MB per ~11k job) che resta residente fino all'`exit` del worker. Impilare 4 di questi sopra l'heap di build già a ~9.7 GB faceva scattare **systemd-oomd** sul runner da 16 GB → **SIGTERM (exit 143)**, un OOM kernel-level (nessuna riga V8 "Reached heap limit" nel log).
- Ora i worker girano in **batch di `PREPASS_CONCURRENCY`** (default 2, override env `RELATED_SEARCH_PREPASS_CONCURRENCY`), con **seeding per-batch** prima che parta il batch successivo → al massimo N gram-index residenti contemporaneamente. Il batch precedente libera la memoria del worker (exit) prima del successivo.
- **Output byte-identico**: i risultati vengono seedati nello stesso `tokenIndex`; cambia solo lo scheduling. Unico costo: qualche decina di secondi di wall-time del pre-pass quando i locale vanno in batch invece che in pieno parallelo.

### Diagnosi (run 27680110873)
- Build OOM-killed dopo 50min al plugin `related-search-clusters` (`203568 candidates`), RSS già **~9.7 GB** di baseline prima del plugin. Morte ~60s dopo l'ultimo log del plugin, durante la fase pre-pass (4 worker simultanei). Exit **143 = SIGTERM = systemd-oomd**, non heap-limit V8.
- Ultimo deploy verde 07:03; OOM alle 09:43 dopo molti merge che hanno alzato la baseline → il build vive sul ceiling RAM, lo spike dei 4 worker lo tippa.

### Verifica
- `tsc --noEmit`: pulito.
- `vitest` su `related-search-clusters.test.ts` + `-or-fill-floor` + `-shell`: **91/91 pass**.

## Non implementato (ancora)

- **Validazione memoria pre-merge: impossibile.** `build:ci` (OOM-prone, `--max-old-space-size=12288`) gira SOLO post-merge su `main`; il `pull_request` non esegue la full SSG build. Il claim "il pre-pass batchato sta sotto il ceiling RAM" NON è verificabile su PR. **Revert/escalation-trigger:** se il prossimo deploy su `main` OOMa ancora a `related-search-clusters` → impostare `RELATED_SEARCH_PREPASS_CONCURRENCY=1` (max safety, nessun code change) nello step Build di `deploy.yml`; se OOMa altrove → la baseline ~9.7 GB è il problema strutturale e serve una riduzione heap separata (fuori scope di questa PR chirurgica).
- **Sibling worker-pool**: gli altri spawn (`jobOgImagesPlugin`, `postWalkCoordinatorPlugin`, `jobsSeoPagesPlugin`) usano già pool a concorrenza bounded (env `POST_WALK_WORKERS` ecc.) e sono completati senza OOM nel run fallito → non toccati (non è la stessa classe di bug: lì la concorrenza è già cappata, qui era `Promise.all` non cappato). Nessun altro sibling con spawn all-at-once non cappato trovato.
- **Riduzione della baseline ~9.7 GB**: fuori scope — è memoria accumulata su tutta la pipeline di plugin, richiede analisi separata.