### PR TITLE
fix(embeddings): retry Gemini on 429 so the full re-embed completes (main-red follow-up)

### DIFF
--- a/scripts/lib/evidence/embeddingClient.mjs
+++ b/scripts/lib/evidence/embeddingClient.mjs
@@ -41,6 +41,23 @@ function l2normalize(vec) {
   return vec;
 }
 
+const realSleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+/**
+ * Extract the retry-after delay (ms) from a Gemini 429 body. Honors both the
+ * structured RetryInfo (`"retryDelay": "51s"`) and the prose form
+ * (`Please retry in 51.83s`). Falls back to 60s (the free-tier window is
+ * per-minute), clamped to [1s, 90s] so a malformed/huge value can't hang a run.
+ */
+export function parseGeminiRetryMs(bodyText = '') {
+  const m =
+    /"retryDelay"\s*:\s*"([\d.]+)s"/.exec(bodyText) ||
+    /retry in ([\d.]+)\s*s/i.exec(bodyText);
+  const sec = m ? parseFloat(m[1]) : 60;
+  const ms = Math.round((Number.isFinite(sec) ? sec : 60) * 1000) + 250; // +250ms cushion
+  return Math.min(Math.max(ms, 1000), 90_000);
+}
+
 /**
  * All providers whose API key is in env, in chain order. Empty if none.
  * @returns {Array<{id:string, model:string, dim:number, url:string, key:string}>}
@@ -113,27 +130,41 @@ async function callCohere({ provider, inputs, fetchImpl }) {
  * under `embeddings[].values`. outputDimensionality=1024 (MRL) matches the store;
  * truncated vectors are L2-normalized here (not unit-norm from the API).
  */
-async function callGemini({ provider, inputs, fetchImpl }) {
+async function callGemini({ provider, inputs, fetchImpl, sleepImpl = realSleep, maxRetries = 6 }) {
   const model = `models/${provider.model}`;
-  const res = await fetchImpl(provider.url, {
-    method: 'POST',
-    headers: {
-      'x-goog-api-key': provider.key,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      requests: inputs.map((text) => ({
-        model,
-        content: { parts: [{ text }] },
-        outputDimensionality: provider.dim,
-        taskType: 'RETRIEVAL_DOCUMENT',
-      })),
-    }),
+  const body = JSON.stringify({
+    requests: inputs.map((text) => ({
+      model,
+      content: { parts: [{ text }] },
+      outputDimensionality: provider.dim,
+      taskType: 'RETRIEVAL_DOCUMENT',
+    })),
   });
-  if (!res.ok) throw new Error(`gemini embeddings ${res.status}: ${await res.text()}`);
-  const data = await res.json();
-  const rows = data?.embeddings || [];
-  return rows.map((r) => l2normalize(Float32Array.from(r.values || [])));
+  // Free tier is 100 embed requests / MINUTE / model and a 100-input batch
+  // consumes the whole window in one call, so the one-time full re-embed
+  // (~2700 articles) 429s on every batch after the first. The limit is
+  // per-minute (not daily) → wait out the window and retry. Subsequent
+  // incremental runs (~tens of new articles/day) stay well under the cap.
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetchImpl(provider.url, {
+      method: 'POST',
+      headers: { 'x-goog-api-key': provider.key, 'Content-Type': 'application/json' },
+      body,
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const rows = data?.embeddings || [];
+      return rows.map((r) => l2normalize(Float32Array.from(r.values || [])));
+    }
+    const text = await res.text();
+    if (res.status === 429 && attempt < maxRetries) {
+      const waitMs = parseGeminiRetryMs(text);
+      console.error(`gemini embeddings 429 (rate limit) — waiting ${Math.round(waitMs / 1000)}s then retrying (attempt ${attempt + 1}/${maxRetries})`);
+      await sleepImpl(waitMs);
+      continue;
+    }
+    throw new Error(`gemini embeddings ${res.status}: ${text}`);
+  }
 }
 
 /**
@@ -167,7 +198,7 @@ export function lastUsedEmbeddingModel() {
   return _lastUsedModel;
 }
 
-export async function embedBatch({ inputs, fetchImpl = fetch } = {}) {
+export async function embedBatch({ inputs, fetchImpl = fetch, sleepImpl } = {}) {
   if (!Array.isArray(inputs) || inputs.length === 0) return [];
 
   const providers = selectProviders();
@@ -182,7 +213,7 @@ export async function embedBatch({ inputs, fetchImpl = fetch } = {}) {
       } else if (provider.id === 'cohere') {
         vectors = await callCohere({ provider, inputs, fetchImpl });
       } else if (provider.id === 'gemini') {
-        vectors = await callGemini({ provider, inputs, fetchImpl });
+        vectors = await callGemini({ provider, inputs, fetchImpl, ...(sleepImpl ? { sleepImpl } : {}) });
       } else {
         throw new Error(`unknown embedding provider: ${provider.id}`);
       }

--- a/tests/embedding-client-gemini.test.ts
+++ b/tests/embedding-client-gemini.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EMBEDDING_DIM, EMBEDDING_PROVIDERS } from '../scripts/lib/evidence/constants.mjs';
-import { embedBatch, lastUsedEmbeddingModel } from '../scripts/lib/evidence/embeddingClient.mjs';
+import { embedBatch, lastUsedEmbeddingModel, parseGeminiRetryMs } from '../scripts/lib/evidence/embeddingClient.mjs';
 
 const ENV_KEYS = ['MISTRAL_API_KEY', 'COHERE_API_KEY', 'GEMINI_API_KEY'];
 const saved: Record<string, string | undefined> = {};
@@ -107,5 +107,60 @@ describe('embeddingClient — Gemini adapter', () => {
     const wrongDim = [Array(EMBEDDING_DIM - 1).fill(0.1)];
     const fetchImpl = vi.fn(async () => geminiResponse(wrongDim) as unknown as Response);
     await expect(embedBatch({ inputs: ['x'], fetchImpl })).rejects.toThrow(/all embedding providers failed/);
+  });
+});
+
+describe('parseGeminiRetryMs', () => {
+  it('reads the structured RetryInfo retryDelay', () => {
+    expect(parseGeminiRetryMs('... "retryDelay": "51s" ...')).toBe(51_250);
+  });
+  it('reads the prose "retry in Ns" form', () => {
+    expect(parseGeminiRetryMs('Please retry in 51.83248591s.')).toBe(52_082);
+  });
+  it('defaults to ~60s when absent and clamps to [1s, 90s]', () => {
+    expect(parseGeminiRetryMs('')).toBe(60_250);
+    expect(parseGeminiRetryMs('"retryDelay": "0s"')).toBe(1_000); // clamped up
+    expect(parseGeminiRetryMs('"retryDelay": "999s"')).toBe(90_000); // clamped down
+  });
+});
+
+describe('embeddingClient — Gemini 429 retry (one-time backfill throttle)', () => {
+  it('waits out a 429 then succeeds on retry (free-tier 100 req/min window)', async () => {
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+    const unit = Array(EMBEDDING_DIM).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () => '{"error":{"message":"Quota exceeded ... Please retry in 2s","details":[{"retryDelay":"2s"}]}}',
+          json: async () => ({}),
+        } as unknown as Response;
+      }
+      return geminiResponse([unit]) as unknown as Response;
+    });
+    const sleeps: number[] = [];
+    const sleepImpl = vi.fn(async (ms: number) => { sleeps.push(ms); });
+
+    const out = await embedBatch({ inputs: ['x'], fetchImpl, sleepImpl });
+    expect(out).toHaveLength(1);
+    expect(out[0].length).toBe(EMBEDDING_DIM);
+    expect(fetchImpl).toHaveBeenCalledTimes(2); // 429 then 200
+    expect(sleepImpl).toHaveBeenCalledTimes(1);
+    expect(sleeps[0]).toBe(2_250); // 2s + 250ms cushion
+    expect(lastUsedEmbeddingModel()).toBe('gemini-embedding-001');
+  });
+
+  it('gives up after maxRetries of persistent 429 (no infinite loop)', async () => {
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+    const fetchImpl = vi.fn(async () => ({
+      ok: false, status: 429, text: async () => '"retryDelay": "1s"', json: async () => ({}),
+    } as unknown as Response));
+    const sleepImpl = vi.fn(async () => {});
+    await expect(embedBatch({ inputs: ['x'], fetchImpl, sleepImpl })).rejects.toThrow(/all embedding providers failed/);
+    // 1 initial + 6 retries = 7 attempts (maxRetries=6).
+    expect(fetchImpl).toHaveBeenCalledTimes(7);
   });
 });


### PR DESCRIPTION
## Contesto
Follow-up del provider Gemini (#2437). Il run live `build-evidence-and-tune` ha confermato che **Gemini funziona** (`embedBatch: recovered on 'gemini'`, model-drift rilevato → full re-embed innescato), MA il backfill one-time di ~2700 articoli ha fatto **429**: `gemini-embedding-001` free tier = **100 requests/MINUTO/model**, e una `batchEmbedContents` da 100 input consuma l'intera finestra → ogni batch dopo il primo: `Quota exceeded ... embed_content_free_tier_requests, limit 100, Please retry in ~52s`. Il loop all-or-nothing scartava tutto il progresso e scriveva meta-only → store ancora congelato. (mistral=401 morta, cohere=429 trial 1000/mese esaurito.)

## Implementato
- **Retry-on-429 in `callGemini`** (`scripts/lib/evidence/embeddingClient.mjs`): il limite è PER-MINUTO (non giornaliero), quindi su 429 aspetta la finestra e ritenta, onorando il `retryDelay` del server (`"retryDelay":"51s"` o prosa `retry in Ns`), default 60s, clamp [1s, 90s], max 6 retry. Il backfill one-time macina ~28 batch a ~1/min (~28 min, sotto il timeout default 6h del workflow); i run incrementali quotidiani (decine di articoli/giorno) restano sotto il cap e non aspettano mai.
- **`parseGeminiRetryMs`** helper esportato (parsing robusto del delay, +250ms cushion, clamp).
- **`sleepImpl` iniettabile** in `embedBatch`/`callGemini` → i test restano istantanei (no sleep reale).
- **Test** estesi (`tests/embedding-client-gemini.test.ts`): parseGeminiRetryMs (structured + prosa + default/clamp), 429-then-200 retry success, max-retries give-up (no loop infinito). 13 test verdi + build-evidence-index spec-lock verde.

## Effetto atteso
Prossimo `build-evidence-and-tune`: il full re-embed via Gemini completa in un run (~28 min) → store copre ~2707 articoli → gap `B.6` ≤ 50 → alert clear → monitor "Quality alerts" verde. Poi incrementale normale.

## Non implementato (ancora)
- **Rotazione chiavi mistral/cohere**: non fatta (ops; mistral 401, cohere trial esaurito). Gemini le rende non necessarie per il funzionamento.
- **Write parziale del progresso embeddings**: il loop resta all-or-nothing per-run; col retry non serve (il run completa in una volta sotto le 6h). Se in futuro il corpus crescesse oltre ciò che sta in un run, valutare checkpoint parziali — follow-up.

## Revert-trigger
Validazione live = prossimo `build-evidence-and-tune` (triggererò post-merge): atteso `EMBEDDINGS_BUILD batch N done` ripetuti + `count` meta → ~2707 + run "Quality alerts" verde. Se il re-embed non completa (timeout/quota diversa dal previsto) → rivedere throttle/batch-size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)