### PR TITLE
feat(publisher): pre-fill salary from crawled listing on claim (#2427)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6910,12 +6910,19 @@ const JobBoard: React.FC<JobBoardProps> = ({
                       const employmentType = CONTRACT_TO_EMPLOYMENT_TYPE[
                         normalizeJobContract(selectedJob.contract, selectedJob.title, selectedJob.description)
                       ];
+                      // The publish form's salary inputs are CHF-only (submit hard-codes
+                      // currency: 'CHF'). Only seed salary from CHF crawled listings — an
+                      // EUR amount injected into a CHF field would be wrong, so leave it
+                      // blank for EUR and let the employer fill it.
+                      const salaryIsChf = selectedJob.currency !== 'EUR';
                       try {
                         sessionStorage.setItem('claimJobPrefill', JSON.stringify({
                           company: cj.company, title: cj.title, description: cj.description,
                           category: cj.category, sector: cj.sector, employmentType,
                           contractType: cj.contract, location: cj.location, canton: cj.canton,
                           applyUrl: cj.applyUrl || cj.url,
+                          ...(salaryIsChf && cj.salaryMin != null ? { salaryMin: cj.salaryMin } : {}),
+                          ...(salaryIsChf && cj.salaryMax != null ? { salaryMax: cj.salaryMax } : {}),
                         }));
                       } catch { /* storage blocked — publish page just won't prefill */ }
                       Analytics.trackSelectContent('job_board_claim_cta', `${selectedJob.company}_${selectedJob.title}`);

--- a/components/pages/PublisherPublishPage.tsx
+++ b/components/pages/PublisherPublishPage.tsx
@@ -595,6 +595,9 @@ const PublisherPublishPage: React.FC = () => {
  if (d.employmentType) setEmploymentType(String(d.employmentType));
  if (d.contractType) setContractType(String(d.contractType));
  if (d.applyUrl) setApplyUrl(String(d.applyUrl));
+ // Salary is stashed CHF-only by the claim CTA (the form submits currency: 'CHF').
+ if (d.salaryMin != null) setSalaryMin(String(d.salaryMin));
+ if (d.salaryMax != null) setSalaryMax(String(d.salaryMax));
  if (d.location) {
  setLocations([{ label: String(d.location), postalCode: '', canton: String(d.canton || 'TI'), street: '' }]);
  }


### PR DESCRIPTION
## Contesto

Follow-up di #2427 (deferred items di #2417 "claim/pre-fill publish form from crawled listing"). #2442 (merged) ha già coperto **Item 2 — employmentType** e chiuso #2427 con `Closes`, ma lasciava scoperti: **Item 2 — salary** e **Item 1 — deep-link cold-open**. Riaperta #2427; questa PR completa la salary portion.

## Implementato

- **Salary nel claim pre-fill (Item 2 — salary portion):** la "Sei l'azienda?" claim CTA in `components/community/JobBoard.tsx` stashava company/title/employmentType/contractType/location ma **non** il salario, quindi un datore che rivendica un annuncio crawlato con salario noto doveva ridigitarlo. `JobListing` espone già `salaryMin`/`salaryMax`: ora vengono inclusi nello stash `claimJobPrefill`.
- **Read side** in `components/pages/PublisherPublishPage.tsx`: lo stesso `useEffect` one-shot del claim-prefill ora legge `d.salaryMin`/`d.salaryMax` e popola i campi `salaryMin`/`salaryMax` del form (con guardia `!= null`, edit-mode `?edit` ha sempre precedenza, stash rimosso dopo la lettura — invariato).
- **Gate CHF-only:** il salario è incluso nello stash solo se `currency !== 'EUR'`. Il form di pubblicazione ha input salario CHF-only (il submit hard-coda `currency: 'CHF'`): iniettare un importo EUR in un campo CHF sarebbe un dato errato → per annunci EUR il campo resta vuoto e lo compila il datore. Nessun campo currency aggiunto (il form non ne ha).
- Nessun testo user-facing nuovo → nessuna nuova key locale (riusa i campi salario esistenti del form, già tradotti in 4 locali).

## Non implementato (ancora)

- **Item 1 — deep-link `?claim=<slug>` cold-open:** non implementato di proposito. Indagata la fattibilità: i job crawlati vivono nei CDN locale-index JSON (`/data/jobs-<locale>-index.json`, ~5-11MB) e nei per-job detail (`/data/job-detail/<id>.json`, keyed by **id** non slug), **non in Firestore** — quindi la premessa "fetch single-job da Firestore" del follow-up non si applica. Non esiste un lookup slug→job economico: un cold-open `?claim=<slug>` richiederebbe il fetch dell'intero index multi-MB, esattamente ciò che #2417 aveva deliberatamente evitato ("rischioso/da validare live"). Il valore è speculativo (dipende dal volume di outreach non ancora stabilito). Resta tracciato su #2427 (riaperta) come gap documentato; non chiudo l'issue con questa PR.
- **Currency mapping nel form:** il form pubblica solo CHF; nessun campo currency, quindi salari EUR crawlati non sono pre-compilati (vedi gate sopra). Aggiungere un selettore currency al form è scope separato (cambia il submit + i 4 locali) → out of scope.
- **Sibling sweep:** `node scripts/ci/check-sibling-patterns.mjs` segnala `build-plugins/jobsSeoPagesPlugin.ts` e `build-plugins/shared/slimJobIndex.ts` per il solo token condiviso `selectedJob` — sono SEO build-plugin che iterano i job, **classe diversa** dal bug "lo stash claim omette un campo che il read side si aspetta". L'unico writer di `claimJobPrefill` è `JobBoard.tsx` e l'unico reader è `PublisherPublishPage.tsx`, entrambi toccati qui. Nessun sibling con lo stesso antipattern.

## Test plan

- [x] `npx vitest run tests/publisher-supersede.test.ts tests/jobboard-detail-apply-links.test.ts` → 13 passed.
- [x] Diff verificato surgicale (10 righe, 2 file); `salaryMin`/`salaryMax`/`currency` esistono su `JobListing`.
- [ ] Typecheck/build via CI (full tsc locale = OOM per norma progetto).
- [ ] Post-deploy: claim CTA su annuncio crawlato CHF con salario → form salario pre-compilato; annuncio EUR → salario vuoto; `?edit` ha precedenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)