### PR TITLE
feat(publisher): match crawled "free candidates" across all publisher companies (#2450)

### DIFF
--- a/components/pages/PublisherDashboardPage.tsx
+++ b/components/pages/PublisherDashboardPage.tsx
@@ -380,14 +380,42 @@ const PublisherDashboardPage: React.FC = () => {
 
         // Crawled "free traffic" we already send this employer (proof + upsell):
         // match the publisher's company name → slug → employer_crawled_traffic doc.
+        // A publisher can post under several ragioni sociali (multi-company), so we
+        // try EVERY distinct company name across its ads (not just the first one)
+        // and sum the matched docs — exact-key lookups stay precise, so there is no
+        // risk of attributing another company's crawled traffic. Unmatched keys are
+        // logged for alias/fuzzy diagnostics (follow-up #2450).
         let crawledCandidates = 0;
         try {
-          const firstCompany = snap.docs.map((d) => (d.data() as Record<string, unknown>)?.company as { name?: string } | undefined)
-            .map((c) => c?.name).find(Boolean);
-          const companyKey = slugifyCompanyName(String(firstCompany || ''));
-          if (companyKey) {
-            const ct = await getDoc(doc(db, 'employer_crawled_traffic', companyKey));
-            if (ct.exists()) crawledCandidates = Number((ct.data() as Record<string, unknown>)?.candidates) || 0;
+          const companyKeys = Array.from(
+            new Set<string>(
+              snap.docs
+                .map((d) => (d.data() as Record<string, unknown>)?.company as { name?: string } | undefined)
+                .map((c) => slugifyCompanyName(String(c?.name || '')))
+                .filter((k): k is string => Boolean(k)),
+            ),
+          );
+          if (companyKeys.length) {
+            const lookups = await Promise.all(
+              companyKeys.map(async (key) => {
+                try {
+                  const ct = await getDoc(doc(db, 'employer_crawled_traffic', key));
+                  return { key, candidates: ct.exists() ? Number((ct.data() as Record<string, unknown>)?.candidates) || 0 : null };
+                } catch {
+                  return { key, candidates: null };
+                }
+              }),
+            );
+            crawledCandidates = lookups.reduce((sum, l) => sum + (l.candidates ?? 0), 0);
+            const unmatched = lookups.filter((l) => l.candidates === null).map((l) => l.key);
+            if (unmatched.length) {
+              // Diagnostic only (no PII): which lookup keys had no crawled-traffic doc.
+              // Surfaces name-variant mismatches that an alias map could later resolve.
+              reportCaughtError(
+                new Error(`publisherDashboard.crawled: no employer_crawled_traffic doc for keys [${unmatched.join(', ')}]`),
+                'publisherDashboard.crawled.unmatched',
+              );
+            }
           }
         } catch {
           // optional — panel just stays hidden if no match / not yet populated


### PR DESCRIPTION
## Contesto

Follow-up di #2425 (issue #2450). Il pannello dashboard publisher "vi mandiamo già N candidati gratis" — il vettore centrale del pitch di upgrade a piano a pagamento (#6) — usava un matching best-effort: prendeva il **primo** nome azienda degli annunci del publisher (`find(Boolean)`), lo slugificava e leggeva **un solo** doc `employer_crawled_traffic`. Un publisher con più ragioni sociali vedeva quindi il conteggio di una sola azienda (o niente), e il pitch non veniva consegnato.

## Implementato

- **`components/pages/PublisherDashboardPage.tsx`**: il lookup del traffico crawlato ora raccoglie **OGNI nome azienda distinto** degli annunci del publisher (non più solo il primo), slugifica ognuno e **somma** i doc `employer_crawled_traffic` combacianti. Risolve il sub-caso multi-ragione-sociale sollevato dall'adversarial check del reviewer su #2425.
- I lookup restano **per-chiave-esatta**: nessun fuzzy/Levenshtein → zero rischio di attribuire a un publisher il traffico crawlato di un'altra azienda (direzione safe come l'originale).
- **Diagnostica mismatch**: le chiavi che non risolvono alcun doc vengono loggate via `reportCaughtError` (tag `publisherDashboard.crawled.unmatched`, **nessun PII** — solo slug di nomi azienda già pubblici come route slug). Soddisfa la "action alternativa" suggerita dall'issue (loggare chiave-lookup vs chiavi presenti) e dà la base dati per una eventuale alias-map.
- Lookup eseguiti in parallelo (`Promise.all`), niente regressione di latenza; pannello mostrato solo se totale > 0 (graceful invariato).

## Non implementato (ancora)

- **Alias-map / fuzzy-match (Levenshtein) normalizzato**: deliberatamente non implementato. Il fuzzy-match tra nomi azienda arbitrari rischia di attribuire il traffico crawlato di un'azienda al publisher sbagliato (hazard di correttezza dati / privacy sul vettore di pitch monetizzazione). La diagnostica dei mismatch introdotta qui è il prerequisito misurato per costruire una alias-map curata in un follow-up: prima si osservano le chiavi reali non risolte in produzione, poi si mappa solo dove serve. Lasciato come follow-up a basso rischio.
- **Deploy regole + secret cron / popolamento collection**: invariato da #2425 (out of scope — già coperto dal cron `employer-traffic-refresh.yml`).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` → 0 errori nel file toccato (16 errori pre-esistenti su `main` in test file non correlati, identici al baseline).
- [x] `npx vitest run tests/write-employer-traffic.test.ts` → 3/3 (logica di scrittura invariata).
- [ ] Post-deploy: login publisher multi-ragione-sociale con ≥2 aziende matchate → pannello somma i conteggi; verifica log `publisherDashboard.crawled.unmatched` per nomi-variante.

Closes #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)