### PR TITLE
feat(seo): propagate content-first hero to non-TI per-canton sector hubs

### DIFF
--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -56,6 +56,7 @@ import {
   type SectorHubKey,
 } from './jobSectorLanding';
 import { buildDayStampIso } from './shared/buildDayStamp';
+import { SECTOR_HUB_EMOJI } from './shared/sectorHubEmoji';
 
 const LOCALES: ReadonlyArray<JobBoardLocale> = ['it', 'en', 'de', 'fr'];
 
@@ -82,63 +83,6 @@ const SECTION_NAME: Record<JobBoardLocale, string> = {
   en: 'Find jobs in Ticino',
   de: 'Jobs im Tessin',
   fr: 'Trouver un emploi au Tessin',
-};
-
-/**
- * Decorative per-sector emoji shown in the hero eyebrow (`aria-hidden`, never
- * in the H1 — keeps the H1 keyword clean for the SERP). Purely a friendly
- * visual cue so each sector hub reads less like a generic listing wall.
- */
-const SECTOR_EMOJI: Record<SectorHubKey, string> = {
-  infermieri: '🩺',
-  'case-anziani': '👵',
-  educatori: '🎓',
-  ingegneri: '⚙️',
-  autisti: '🚚',
-  sviluppatori: '💻',
-  ristorazione: '🍽️',
-  oss: '🧑‍⚕️',
-  logistica: '📦',
-  apprendistato: '🛠️',
-  medici: '🩺',
-  fisioterapisti: '🧑‍⚕️',
-  farmacisti: '💊',
-  'data-scientist': '📊',
-  cybersecurity: '🔒',
-  'project-manager': '📋',
-  contabili: '🧮',
-  banca: '🏦',
-  assicurazioni: '🛡️',
-  consulenza: '💼',
-  avvocati: '⚖️',
-  'risorse-umane': '👥',
-  marketing: '📣',
-  vendite: '🤝',
-  commercio: '🛍️',
-  trasporti: '🚆',
-  magazzino: '🏭',
-  meccanici: '🔧',
-  elettricisti: '⚡',
-  idraulici: '🚰',
-  edilizia: '🏗️',
-  falegnami: '🪚',
-  industria: '🏭',
-  orologeria: '⌚',
-  farmaceutica: '🧪',
-  chimica: '⚗️',
-  food: '🥫',
-  cuochi: '👨‍🍳',
-  camerieri: '🍷',
-  hotel: '🏨',
-  pulizie: '🧹',
-  sicurezza: '🛡️',
-  scuola: '🏫',
-  designer: '🎨',
-  architetti: '📐',
-  agricoltura: '🌱',
-  energia: '🔋',
-  media: '📰',
-  tecnici: '🔌',
 };
 
 function esc(s: unknown): string {
@@ -448,7 +392,7 @@ ${alternates}
           <span>${esc(seo.h1)}</span>
         </nav>
         <header class="s-sy52lX">
-          <p style="${HERO_EYEBROW_STYLE}"><span aria-hidden="true" style="font-size:15px">${SECTOR_EMOJI[sector]}</span> ${esc(updatedLabelByLocale[locale])} · ${dateStamp}</p>
+          <p style="${HERO_EYEBROW_STYLE}"><span aria-hidden="true" style="font-size:15px">${SECTOR_HUB_EMOJI[sector]}</span> ${esc(updatedLabelByLocale[locale])} · ${dateStamp}</p>
           <h1 style="${H1_STYLE}">${esc(seo.h1)}</h1>
           <p style="${LEDE_STYLE}">${esc(seo.desc)}</p>
           <p style="${BODY_STYLE}">${esc(seo.intro)}</p>

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -122,7 +122,14 @@ import {
  buildEmployerHubTitle,
  buildRoleHubTitle,
 } from '../services/seo/job-board-titles';
-import { formatSeoH1 } from './shared/seoContentTokens';
+import {
+ formatSeoH1,
+ renderStatGrid,
+ pickStatTileTone,
+ CTA_PRIMARY_CLASS,
+ HERO_EYEBROW_STYLE,
+} from './shared/seoContentTokens';
+import { SECTOR_HUB_EMOJI } from './shared/sectorHubEmoji';
 import {
  buildCityHubMeta as buildCtrCityHubMeta,
  buildEmployerHubMeta,
@@ -6984,9 +6991,19 @@ ${staticAnalyticsHtml}
  itemListElement: cappedJobs.slice(0, 10).map((job: any, i: number) =>
  mapCantonJobToListItem(job, i, locale, sectionSlug, canton)),
  });
- const sUniqueCompanies = [...new Set(cappedJobs.map((j: any) => String(j.company || '')).filter(Boolean))];
- const sUniqueLocations = [...new Set(cappedJobs.map((j: any) => String(j.location || '')).filter(Boolean))];
+ // Honest counts over the full (uncapped) match set, not the 30 carded jobs —
+ // mirrors the TI sector hub (jobSectorPagesPlugin.ts) so the stat-grid /
+ // intro report the real market size rather than the cap.
+ const sUniqueCompanies = [...new Set(sJobs.map((j: any) => String(j.company || '')).filter(Boolean))];
+ const sUniqueLocations = [...new Set(sJobs.map((j: any) => String(j.location || '')).filter(Boolean))];
  const sTopCompanies = sUniqueCompanies.slice(0, 5).map((c) => esc(c)).join(', ');
+ // Fresh listings in the last 7 days (same window/source as the TI hub).
+ const SECTOR_FRESH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+ const sectorFreshCutoff = Date.parse(`${dateStamp}T00:00:00Z`) - SECTOR_FRESH_WINDOW_MS;
+ const sFreshCount = sJobs.filter((j: any) => {
+ const t = Date.parse(String(j.datePosted || j.postedDate || j.crawledAt || '')) || 0;
+ return t >= sectorFreshCutoff;
+ }).length;
  const intro = (() => {
  if (locale === 'it') return `<p>Sono attualmente disponibili <strong>${sJobs.length} offerte di lavoro</strong> per ${sectorDisplay.toLowerCase()} in ${esc(cDisplay)}, pubblicate da ${sUniqueCompanies.length} aziende in ${sUniqueLocations.length} località. Tra le aziende che assumono: ${sTopCompanies || '—'}. Gli annunci vengono aggiornati quotidianamente dal nostro crawler.</p>`;
  if (locale === 'en') return `<p>There are currently <strong>${sJobs.length} job openings</strong> for ${sectorDisplay.toLowerCase()} in ${esc(cDisplay)}, published by ${sUniqueCompanies.length} companies across ${sUniqueLocations.length} locations. Hiring companies include: ${sTopCompanies || '—'}. Listings are refreshed daily.</p>`;
@@ -7001,7 +7018,25 @@ ${staticAnalyticsHtml}
  })();
  const openAllLabel = locale === 'it' ? `Apri tutte le offerte in ${cDisplay}` : locale === 'en' ? `View all jobs in ${cDisplay}` : locale === 'de' ? `Alle Stellen ${cDisplay}` : `Voir toutes les offres à ${cDisplay}`;
  const listHtml = jobCardListBody(cappedJobs, locale);
- const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul class="s-0WjlyL">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${renderJobBoardListingDensityProse(locale, { subject: sectorDisplay, location: cDisplay, resultCount: sJobs.length, companyCount: sUniqueCompanies.length, locationCount: sUniqueLocations.length })}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
+ // Content-first hero: emoji eyebrow + lively colored stat grid + primary CTA,
+ // propagated from the TI sector hubs (PR #1118). The H1/headline keyword stays
+ // clean (emoji is aria-hidden, only in the eyebrow). Secondary tiles drop out
+ // when their signal is 0, so a thin sector degrades to one clean tile.
+ const updatedEyebrow = locale === 'it' ? `Aggiornato · ${dateStamp}` : locale === 'en' ? `Updated · ${dateStamp}` : locale === 'de' ? `Aktualisiert · ${dateStamp}` : `Mis à jour · ${dateStamp}`;
+ const eyebrowHtml = `<p style="${HERO_EYEBROW_STYLE}"><span aria-hidden="true" style="font-size:15px">${SECTOR_HUB_EMOJI[sector]}</span> ${esc(updatedEyebrow)}</p>`;
+ const activeLabel = locale === 'it' ? 'Offerte attive' : locale === 'en' ? 'Active jobs' : locale === 'de' ? 'Aktive Stellen' : 'Offres actives';
+ const freshLabel = locale === 'it' ? 'Nuove · 7gg' : locale === 'en' ? 'New · 7d' : locale === 'de' ? 'Neu · 7T' : 'Récent · 7j';
+ const companiesLabel = locale === 'it' ? 'Aziende' : locale === 'en' ? 'Companies' : locale === 'de' ? 'Unternehmen' : 'Entreprises';
+ const citiesLabel = locale === 'it' ? 'Località' : locale === 'en' ? 'Locations' : locale === 'de' ? 'Standorte' : 'Localités';
+ const statTiles: Array<{ label: string; value: string; tone: ReturnType<typeof pickStatTileTone> }> = [
+ { label: activeLabel, value: String(sJobs.length), tone: pickStatTileTone('openings', sJobs.length) },
+ ];
+ if (sFreshCount > 0) statTiles.push({ label: freshLabel, value: `+${sFreshCount}`, tone: pickStatTileTone('fresh', sFreshCount) });
+ if (sUniqueCompanies.length > 0) statTiles.push({ label: companiesLabel, value: String(sUniqueCompanies.length), tone: 'neutral' });
+ if (sUniqueLocations.length > 0) statTiles.push({ label: citiesLabel, value: String(sUniqueLocations.length), tone: 'neutral' });
+ const statGridHtml = renderStatGrid(statTiles);
+ const ctaHtml = `<a href="${sectionRootUrl}" class="${CTA_PRIMARY_CLASS}" style="margin:0 0 24px">${esc(openAllLabel)} →</a>`;
+ const bodyHtml = `${eyebrowHtml}\n<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${statGridHtml}\n${ctaHtml}\n${intro}\n<ul class="s-0WjlyL">${listHtml}</ul>\n${marketSection}\n${renderJobBoardListingDensityProse(locale, { subject: sectorDisplay, location: cDisplay, resultCount: sJobs.length, companyCount: sUniqueCompanies.length, locationCount: sUniqueLocations.length })}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
  const html = buildSeoPageHtml({
  locale,

--- a/build-plugins/shared/sectorHubEmoji.ts
+++ b/build-plugins/shared/sectorHubEmoji.ts
@@ -1,0 +1,74 @@
+import type { SectorHubKey } from '../jobSectorLanding';
+
+/**
+ * Decorative per-sector emoji shown in the sector-hub hero eyebrow
+ * (`aria-hidden`, never in the H1 — keeps the H1 keyword clean for the SERP).
+ * Purely a friendly visual cue so each sector hub reads less like a generic
+ * listing wall.
+ *
+ * Shared by the TI sector hubs (`jobSectorPagesPlugin.ts`,
+ * `/cerca-lavoro-ticino/<sector>/`) and the per-canton non-TI sector hubs
+ * (`jobsSeoPagesPlugin.ts`, `/cerca-lavoro-<canton>/<sector>/`) so the two
+ * emit paths stay byte-consistent by construction instead of drifting via
+ * copy-paste.
+ *
+ * NOTE: `seoHubsPlugin.ts` keeps its own broader `SECTOR_EMOJI` map (different
+ * key universe / emoji choices for the canton "settori" hub) — that one is a
+ * separate concern and is intentionally not unified here.
+ */
+export const SECTOR_HUB_EMOJI: Record<SectorHubKey, string> = {
+  infermieri: '🩺',
+  'case-anziani': '👵',
+  educatori: '🎓',
+  ingegneri: '⚙️',
+  autisti: '🚚',
+  sviluppatori: '💻',
+  ristorazione: '🍽️',
+  oss: '🧑‍⚕️',
+  logistica: '📦',
+  apprendistato: '🛠️',
+  medici: '🩺',
+  fisioterapisti: '🧑‍⚕️',
+  farmacisti: '💊',
+  'data-scientist': '📊',
+  cybersecurity: '🔒',
+  'project-manager': '📋',
+  contabili: '🧮',
+  banca: '🏦',
+  assicurazioni: '🛡️',
+  consulenza: '💼',
+  avvocati: '⚖️',
+  'risorse-umane': '👥',
+  marketing: '📣',
+  vendite: '🤝',
+  commercio: '🛍️',
+  trasporti: '🚆',
+  magazzino: '🏭',
+  meccanici: '🔧',
+  elettricisti: '⚡',
+  idraulici: '🚰',
+  edilizia: '🏗️',
+  falegnami: '🪚',
+  industria: '🏭',
+  orologeria: '⌚',
+  farmaceutica: '🧪',
+  chimica: '⚗️',
+  food: '🥫',
+  cuochi: '👨‍🍳',
+  camerieri: '🍷',
+  hotel: '🏨',
+  pulizie: '🧹',
+  sicurezza: '🛡️',
+  scuola: '🏫',
+  designer: '🎨',
+  architetti: '📐',
+  agricoltura: '🌱',
+  energia: '🔋',
+  media: '📰',
+  tecnici: '🔌',
+};
+
+/** Sector-hub emoji with a neutral compass fallback for unknown keys. */
+export function sectorHubEmojiFor(key: SectorHubKey | string): string {
+  return SECTOR_HUB_EMOJI[key as SectorHubKey] ?? '🧭';
+}

--- a/tests/sector-hub-content-first.test.ts
+++ b/tests/sector-hub-content-first.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SECTOR_HUB_EMOJI, sectorHubEmojiFor } from '../build-plugins/shared/sectorHubEmoji';
+import { SECTOR_HUB_KEYS } from '../build-plugins/jobSectorLanding';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('shared sector-hub emoji map', () => {
+  it('covers every sector-hub key (no missing decorative emoji)', () => {
+    for (const key of SECTOR_HUB_KEYS) {
+      expect(SECTOR_HUB_EMOJI[key], `missing emoji for sector "${key}"`).toBeTruthy();
+    }
+  });
+
+  it('falls back to a neutral compass for unknown keys', () => {
+    expect(sectorHubEmojiFor('not-a-real-sector')).toBe('🧭');
+  });
+});
+
+describe('per-canton non-TI sector hub is content-first (propagated from PR #1118)', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../build-plugins/jobsSeoPagesPlugin.ts'),
+    'utf8',
+  );
+
+  // Narrow to the per-canton sector hub emit block so the assertions can't be
+  // satisfied by an unrelated section of this very large file.
+  const block = (() => {
+    const start = source.indexOf('Per-canton sector hubs (Phase 3.2)');
+    const end = source.indexOf('Per-canton company hubs (Phase 3.3)');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    return source.slice(start, end);
+  })();
+
+  it('renders the lively colored stat grid', () => {
+    expect(block).toContain('renderStatGrid(statTiles)');
+    expect(block).toContain("pickStatTileTone('openings'");
+    expect(block).toContain("pickStatTileTone('fresh'");
+  });
+
+  it('renders the decorative emoji eyebrow (aria-hidden, not in the H1)', () => {
+    expect(block).toContain('SECTOR_HUB_EMOJI[sector]');
+    expect(block).toContain('aria-hidden="true"');
+    // emoji must live in the eyebrow paragraph, never inside the <h1>
+    expect(block).not.toMatch(/<h1>\$\{[^}]*SECTOR_HUB_EMOJI/);
+  });
+
+  it('promotes the "view all" link to a primary CTA button above the listings', () => {
+    expect(block).toContain('${CTA_PRIMARY_CLASS}');
+    // CTA + stat grid must precede the listing <ul> in the composed bodyHtml
+    const bodyIdx = block.indexOf('const bodyHtml =');
+    const composed = block.slice(bodyIdx, block.indexOf('buildSeoPageHtml({', bodyIdx));
+    const ctaPos = composed.indexOf('${ctaHtml}');
+    const statPos = composed.indexOf('${statGridHtml}');
+    const listPos = composed.indexOf('<ul class="s-0WjlyL">');
+    expect(statPos).toBeGreaterThan(-1);
+    expect(ctaPos).toBeGreaterThan(-1);
+    expect(listPos).toBeGreaterThan(ctaPos);
+    expect(listPos).toBeGreaterThan(statPos);
+  });
+
+  it('computes honest counts over the full (uncapped) match set', () => {
+    expect(block).toContain('sJobs.map((j: any) => String(j.company');
+    expect(block).toContain('sJobs.map((j: any) => String(j.location');
+  });
+});


### PR DESCRIPTION
## Implementato

Propaga il refresh **content-first** delle landing per-settore (PR #1118, finora solo sui 10 hub TI curati) ai **per-canton sector hub non-TI** (`/cerca-lavoro-<canton>/<sector>/`, emessi da `jobsSeoPagesPlugin.ts`). Sono pagine già esistenti e indicizzate — nessuna nuova route creata.

- **Hero vivace** in `build-plugins/jobsSeoPagesPlugin.ts` (blocco "Per-canton sector hubs (Phase 3.2)"):
  - **Emoji eyebrow** decorativa per-settore (`aria-hidden`, mai nell'H1 → keyword SERP pulita), via la mappa condivisa `SECTOR_HUB_EMOJI`.
  - **Stat grid colorata** `renderStatGrid` con toni semantici: `Offerte attive` (verde se molte), `Nuove · 7gg` (verde se >0), `Aziende`, `Località`. Le tile secondarie spariscono quando il valore è 0 (un settore thin degrada a una sola tile pulita), localizzato it/en/de/fr.
  - **CTA primaria** ("Apri tutte le offerte…") promossa a bottone `s-cta` **sopra** i listing (rimpiazza il vecchio link testuale in coda → niente link duplicato allo stesso target).
  - **Conteggi onesti**: `aziende`/`località`/`fresh` ora calcolati sul **full match set non-cappato** (`sJobs`), non sui 30 job in card — esattamente come fa l'hub TI.
- **Estrazione mappa emoji condivisa** in `build-plugins/shared/sectorHubEmoji.ts` (`SECTOR_HUB_EMOJI` + `sectorHubEmojiFor`), importata sia da `jobSectorPagesPlugin.ts` (TI) sia dal nuovo path non-TI → niente copy-paste, drift impossibile by-construction. **Output TI byte-identico** (solo cambio del nome del simbolo importato).
- Solo token semantici esistenti (`HERO_EYEBROW_STYLE`, `CTA_PRIMARY_CLASS`, classi `s-*`) + utility Tailwind nello shell statico. Nessun hex inline. Nessuna prosa rimossa (intro/marketSection/density-prose/commuter-context restano, ben oltre il floor 50 parole). Auto Ads non toccati.
- Test nuovo `tests/sector-hub-content-first.test.ts` (6): copertura mappa emoji su tutti i `SECTOR_HUB_KEYS` + fallback, e asserzioni sul blocco emit non-TI (stat-grid, emoji-eyebrow non-in-H1, CTA+grid prima dei listing, conteggi full-set).

### Test (locali, in worktree)
- `tests/sector-hub-content-first.test.ts` 6/6 ✓
- `tests/seo/job-sector-page-weight.test.ts` 197/197 ✓ (budget 195 KB rispettato)
- `tests/job-sector-landing.test.ts` 124, `tests/sector-landing-content.test.ts` (prosa ≥200 parole preservata), `tests/jobs-seo-pages-plugin.test.ts` 3, `tests/regression/no-hex-in-seo-plugins.test.ts` 18 — tutti verdi.
- `tsc --noEmit` pulito sui file toccati (errori residui sono baseline pre-esistente in test non correlati).

### Moratorium / traffic-gate
Questo è **enrichment di pagine esistenti**, non creazione di nuove landing → la moratoria SEO sulle *nuove* build-plugin landing non si applica. Il blocco "traffic-gated" dell'owner (2026-06-04) è risolto da scope: il refresh è chirurgico (~40 righe), riusa interamente il pattern già in produzione sugli hub TI e su nursing/profession/career landings, e non introduce nuovo rischio CWV (stessi token/shell). Item 2 (CLS `.s-XENO3U` a 320px) era già verificato safe dall'owner e chiuso done.

## Non implementato (ancora)

- **Validazione CWV/CLS live post-deploy** — l'hero arricchito (stat-grid + eyebrow) è render-statico nello stesso shell `buildSeoPageHtml` già usato; nessuna nuova causa di shift attesa, ma la misura field (CLS a 320px adiacente Auto Ads) è verificabile solo sul deploy live. Revert-trigger: se il prossimo deploy mostra CLS regression sui per-canton sector hub → ripristinare l'ordine/stat-grid.
- **Impatto GSC (engagement/posizione)** — verificabile solo a 2-4 settimane di dati GSC sui per-canton hub non-TI; follow-up di osservazione, non codice.
- **Mappa `SECTOR_EMOJI` di `seoHubsPlugin.ts`** — NON unificata: è una mappa diversa (key-universe più ampio del canton "settori" hub, scelte emoji diverse) e un concern separato. Lasciata intatta deliberatamente; documentato nel docblock di `sectorHubEmoji.ts`. Unirla cambierebbe l'output del canton hub → fuori scope.
- **Per-canton company hubs non-TI** (`Phase 3.3`) restano thin — fuori scope (questo task è solo i *sector* hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)