### PR TITLE
fix(embeddings): sub-batch Gemini calls (≤16) so the free-tier backfill completes

### DIFF
--- a/scripts/lib/evidence/embeddingClient.mjs
+++ b/scripts/lib/evidence/embeddingClient.mjs
@@ -128,10 +128,21 @@ async function callCohere({ provider, inputs, fetchImpl }) {
  * `{ requests: [{ model, content:{parts:[{text}]}, outputDimensionality, taskType }] }`
  * with the key in the `x-goog-api-key` header. Embeddings come back in order
  * under `embeddings[].values`. outputDimensionality=1024 (MRL) matches the store;
- * truncated vectors are L2-normalized here (not unit-norm from the API).
+ * truncated vectors are L2-normalized here (not unit-norm from the API). Inputs
+ * are split into ≤GEMINI_MAX_BATCH sub-batches (free-tier per-minute cap) and
+ * concatenated in order; each sub-batch retries on 429.
  */
-async function callGemini({ provider, inputs, fetchImpl, sleepImpl = realSleep, maxRetries = 6 }) {
-  const model = `models/${provider.model}`;
+// Gemini free tier is 100 embed requests / MINUTE / model and each input in a
+// batchEmbedContents call counts as one request, so a single 100-input call
+// consumes (or exceeds) the whole window and 429s — observed even on a fresh
+// minute during the one-time full re-embed (~2700 articles). Sub-batch well
+// under the cap so each call fits comfortably; the per-chunk 429-retry then
+// self-throttles total throughput to ~the per-minute budget. Incremental runs
+// (tens of new articles/day) finish in a chunk or two without ever waiting.
+const GEMINI_MAX_BATCH = 16;
+
+/** One gemini batchEmbedContents call (≤GEMINI_MAX_BATCH inputs) with 429-retry. */
+async function geminiEmbedChunk({ provider, inputs, fetchImpl, sleepImpl, maxRetries, model }) {
   const body = JSON.stringify({
     requests: inputs.map((text) => ({
       model,
@@ -140,11 +151,6 @@ async function callGemini({ provider, inputs, fetchImpl, sleepImpl = realSleep, 
       taskType: 'RETRIEVAL_DOCUMENT',
     })),
   });
-  // Free tier is 100 embed requests / MINUTE / model and a 100-input batch
-  // consumes the whole window in one call, so the one-time full re-embed
-  // (~2700 articles) 429s on every batch after the first. The limit is
-  // per-minute (not daily) → wait out the window and retry. Subsequent
-  // incremental runs (~tens of new articles/day) stay well under the cap.
   for (let attempt = 0; ; attempt++) {
     const res = await fetchImpl(provider.url, {
       method: 'POST',
@@ -159,12 +165,23 @@ async function callGemini({ provider, inputs, fetchImpl, sleepImpl = realSleep, 
     const text = await res.text();
     if (res.status === 429 && attempt < maxRetries) {
       const waitMs = parseGeminiRetryMs(text);
-      console.error(`gemini embeddings 429 (rate limit) — waiting ${Math.round(waitMs / 1000)}s then retrying (attempt ${attempt + 1}/${maxRetries})`);
+      console.error(`gemini embeddings 429 (rate limit) — waiting ${Math.round(waitMs / 1000)}s then retrying chunk (attempt ${attempt + 1}/${maxRetries})`);
       await sleepImpl(waitMs);
       continue;
     }
     throw new Error(`gemini embeddings ${res.status}: ${text}`);
   }
+}
+
+async function callGemini({ provider, inputs, fetchImpl, sleepImpl = realSleep, maxRetries = 8 }) {
+  const model = `models/${provider.model}`;
+  const out = [];
+  for (let i = 0; i < inputs.length; i += GEMINI_MAX_BATCH) {
+    const chunk = inputs.slice(i, i + GEMINI_MAX_BATCH);
+    const vecs = await geminiEmbedChunk({ provider, inputs: chunk, fetchImpl, sleepImpl, maxRetries, model });
+    out.push(...vecs);
+  }
+  return out;
 }
 
 /**

--- a/tests/embedding-client-gemini.test.ts
+++ b/tests/embedding-client-gemini.test.ts
@@ -160,7 +160,23 @@ describe('embeddingClient — Gemini 429 retry (one-time backfill throttle)', ()
     } as unknown as Response));
     const sleepImpl = vi.fn(async () => {});
     await expect(embedBatch({ inputs: ['x'], fetchImpl, sleepImpl })).rejects.toThrow(/all embedding providers failed/);
-    // 1 initial + 6 retries = 7 attempts (maxRetries=6).
-    expect(fetchImpl).toHaveBeenCalledTimes(7);
+    // 1 initial + 8 retries = 9 attempts (maxRetries=8) on the single chunk.
+    expect(fetchImpl).toHaveBeenCalledTimes(9);
+  });
+
+  it('sub-batches inputs over GEMINI_MAX_BATCH (16) into multiple calls', async () => {
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+    const unit = (n: number) => Array.from({ length: n }, () =>
+      Array(EMBEDDING_DIM).fill(0).map((_, i) => (i === 0 ? 1 : 0)));
+    // 40 inputs → ceil(40/16) = 3 chunks (16 + 16 + 8).
+    const sizes: number[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const reqs = JSON.parse(init.body as string).requests;
+      sizes.push(reqs.length);
+      return geminiResponse(unit(reqs.length)) as unknown as Response;
+    });
+    const out = await embedBatch({ inputs: Array.from({ length: 40 }, (_, i) => `t${i}`), fetchImpl });
+    expect(out).toHaveLength(40);
+    expect(sizes).toEqual([16, 16, 8]);
   });
 });


### PR DESCRIPTION
## Contesto
Terzo step del fix main-red (monitor "Quality alerts" / embedding store congelato). Il run live ha mostrato che il **retry-429 da solo non basta**: una singola `batchEmbedContents` da 100 input consuma/eccede l'intera finestra free-tier Gemini (100 embed req/min/model) e fa **429 anche su un minuto fresco**, esaurendo il budget retry sul PRIMO batch → il loop all-or-nothing scrive zero progresso.

## Implementato
- **Sub-batching in `callGemini`** (`scripts/lib/evidence/embeddingClient.mjs`): ogni input conta come 1 request, quindi gli input vengono splittati in sotto-batch da **≤16** (ben sotto il cap/minuto); ogni sotto-batch ritenta su 429 → il throughput totale si auto-throttla a ~quota/minuto. Il full re-embed one-time (~2700) ora macina sotto il timeout 6h del workflow; i run incrementali (decine/giorno) finiscono in 1-2 chunk senza attese. `maxRetries` per-chunk 6→8.
- **Test** (`tests/embedding-client-gemini.test.ts`): nuovo caso sub-batch (40 input → chunk [16,16,8], 40 vettori in ordine) + give-up aggiornato (9 attempts). 10 test verdi.

## Non implementato (ancora)
- **Write parziale del progresso**: il loop resta all-or-nothing (col sub-batching il run completa in una volta sotto le 6h, quindi non serve; un partial-write toccherebbe il path .bin/meta funnel-relevant con wipe-risk → evitato).
- **Rotazione chiavi mistral/cohere**: mistral 401, cohere trial 1000/mese esaurito; Gemini le rende non necessarie. Refresh chiave = fast-path alternativo (ops).

## Revert-trigger
Validazione live = prossimo `build-evidence-and-tune` (triggererò post-merge): atteso molti `gemini embeddings 429 ... retrying chunk` + completamento, `EMBEDDINGS_BUILD_DONE count=~2707`, meta model=gemini-embedding-001, e run "Quality alerts" verde. Se non completa entro 6h → ridurre GEMINI_MAX_BATCH o aggiungere partial-progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)