### PR TITLE
perf(build): pre-plumb RELATED_SEARCH_PREPASS_CONCURRENCY=1 safety cap in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -544,6 +544,21 @@ jobs:
           # path is short-circuited. Keeps local dev paths (where the cache IS
           # persisted) unchanged: unset this flag locally to re-enable.
           RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
+          # Max-safety cap (=1) for the related-search-clusters postings
+          # pre-pass worker pool (#2453/#2464). Each per-locale worker builds a
+          # full 2/3-gram index (~hundreds of MB for ~11k jobs) that stays
+          # resident until the worker exits. #2453 batched the spawns by
+          # RELATED_SEARCH_PREPASS_CONCURRENCY (code default 2) instead of the
+          # old uncapped Promise.all-over-all-locales (up to 4 indexes resident
+          # at once → systemd-oomd SIGTERM/exit 143 on the 16 GB runner, on top
+          # of the ~9.7 GB build baseline). CONC=2 is unverifiable on `pull_request`
+          # (full SSG build only runs post-merge on `main`), so we pre-plumb the
+          # emergency knob to 1 here: at most ONE gram-index resident, the worker
+          # exits and frees its memory before the next locale starts. Output is
+          # byte-identical (workers seed the same tokenIndex); the only cost is a
+          # few tens of seconds of pre-pass wall-time. Raise to '2' (or unset, code
+          # default 2) once a deploy is confirmed green with the lower memory peak.
+          RELATED_SEARCH_PREPASS_CONCURRENCY: '1'
           # POST_WALK_WORKERS rollback removed (commit 4b412bc8a + 36dfd0e9c
           # added explicit `.ts` extensions to the two extension-less local
           # imports the worker tree pulled in — `./blogContextualLinksData`


### PR DESCRIPTION
## Implementato

- **Pre-plumbing del cap di max-safety `RELATED_SEARCH_PREPASS_CONCURRENCY: '1'`** nell'env dello step **Build** di `.github/workflows/deploy.yml` (subito dopo `RELATED_SEARCH_CLUSTERS_NO_CACHE`). Nessun code change: il plugin `build-plugins/relatedSearchClustersPlugin.ts` già legge `process.env.RELATED_SEARCH_PREPASS_CONCURRENCY` (default codice 2) dopo #2453 — qui lo forziamo a `1`.
- **Effetto memoria:** con CONC=1 al massimo **UN** gram-index 2/3 per-locale (~centinaia di MB per ~11k job) resta residente alla volta. Ogni worker fa `exit` e libera la sua memoria **prima** che parta il worker del locale successivo, invece di impilarsi sopra la baseline di build ~9.7 GB. CONC=2 (default #2453) impila fino a 2 index → spike residuo non verificato a runtime; CONC=1 lo azzera.
- **Output byte-identico:** i worker seedano lo stesso `tokenIndex`, cambia solo lo scheduling (batch da 1 invece che 2). Unico costo: qualche decina di secondi di wall-time del pre-pass.
- Il commento inline nel YAML documenta il knob e il path di ripristino (`'2'` o unset → default codice 2) una volta che un deploy è confermato verde con il peak RAM più basso.

### Perché ORA (non "chiudo come resolved")
Per la regola di chiusura dell'issue: «se il prossimo deploy verde con CONC=2 già impostato → chiudi». Ma **nessun deploy con CONC=2 si è completato verde**: i run `deploy.yml` post-#2453 risultano `cancelled`/`in_progress` (starvation push-driven: ogni push su `main` cancella la build running — noto). Quindi CONC=2 resta **non verificato a runtime** e il pre-plumb di CONC=1 è l'azione deterministica e funnel-critica richiesta dall'issue (`deploy.yml` nominato esplicitamente come file target).

## Non implementato (ancora)

- **Validazione memoria pre-merge: impossibile.** `build:ci` (`--max-old-space-size=12288`, OOM-prone) gira SOLO post-merge su `main`; il `pull_request` non esegue la full SSG build → il claim "CONC=1 sta sotto il ceiling RAM" NON è verificabile su questa PR. **Revert/escalation-trigger:** se il prossimo deploy su `main` OOMa ANCORA a `related-search-clusters` (exit 143) → la baseline ~9.7 GB è il problema strutturale e serve una riduzione heap separata (fuori scope); se invece il deploy passa verde si può rialzare a `'2'` per recuperare i ~secondi di wall-time. Nessun claim verde fabbricato.
- **Sibling worker-pool:** `node scripts/ci/check-sibling-patterns.mjs` flagga solo `build-plugins/relatedSearchClustersPlugin.ts` perché condivide il TOKEN `RELATED_SEARCH_PREPASS_CONCURRENCY` — è il **consumer** di questo env var, NON un sibling con lo stesso antipattern (lì il batching è già implementato da #2453). Gli altri pool (`jobOgImagesPlugin`, `postWalkCoordinatorPlugin`, `jobsSeoPagesPlugin`) sono già cappati via env (`POST_WALK_WORKERS` ecc.) e #2453 ne ha confermato il completamento senza OOM nel run fallito. Nessun pool `Promise.all` non cappato residuo.
- **Riduzione baseline ~9.7 GB:** fuori scope — memoria accumulata su tutta la pipeline plugin, richiede analisi heap separata.

Closes #2464