### PR TITLE
feat(publisher): auto-preselect azienda tier on new ad (follow-up #2455 item 1)

### DIFF
--- a/components/pages/PublisherPublishPage.tsx
+++ b/components/pages/PublisherPublishPage.tsx
@@ -614,7 +614,12 @@ const PublisherPublishPage: React.FC = () => {
  const { getFirestore: gf, doc: fDoc, getDoc: fGet } = await import('firebase/firestore');
  const snap = await fGet(fDoc(gf(await getApp()), 'publishers', user.uid));
  if (cancelled || !snap.exists()) return;
- const c = (snap.data() as { company?: Record<string, unknown> }).company;
+ const data = snap.data() as { company?: Record<string, unknown>; tier?: string };
+ // Auto-tier: an active azienda publisher inherits tier='azienda' by default
+ // so a new ad lands featured without re-picking the card. Only nudges the
+ // untouched default ('sponsored') — a manual switch (e.g. to 'free') wins.
+ if (data.tier === 'azienda') setTier((v) => (v === 'sponsored' ? 'azienda' : v));
+ const c = data.company;
  if (!c) return;
  if (c.name) setCompanyName((v) => v || String(c.name));
  if (c.legalForm) setLegalForm(c.legalForm as PublisherLegalForm);


### PR DESCRIPTION
## Contesto

Ultimo item deferred di #2435 (Piano Azienda checkout + lifecycle), tracciato in #2455. L'altro item (dashboard renewal display) è già stato shippato da #2463 (merged, ha chiuso #2455). Questa PR completa l'auto-tier dei nuovi annunci, ora sbloccato: era parcheggiato in #2463 perché #2458 toccava lo stesso file `PublisherPublishPage.tsx`, ma #2458 è MERGED.

## Implementato

- **Auto-tier nuovi annunci** (`components/pages/PublisherPublishPage.tsx`): l'effetto di profile-prefill (non-edit mode) che già legge `publishers/{uid}` ora legge anche `tier`. Se `tier === 'azienda'`, preseleziona la card Piano Azienda nel selettore. Così un publisher già azienda che pubblica un nuovo annuncio non deve ri-cliccare la card → l'annuncio parte `tier='azienda'` (featured) invece di restare non-featured, preservando il valore del piano CHF 299.
- **Guardia non-distruttiva**: usa `setTier((v) => v === 'sponsored' ? 'azienda' : v)` — nudge solo del default intatto `'sponsored'`; uno switch manuale (es. a `'free'`) vince. Edit-mode (`?edit`) carica il tier dal doc dell'annuncio in un effetto separato già `isEdit`-guarded → non toccato.
- Lettura aggiunta nello STESSO `getDoc` esistente (zero round-trip Firestore extra). `tier` letto prima del `if (!c) return`, così un publisher azienda senza company salvata eredita comunque il tier.

## Non implementato (ancora)

- **Styling card premium**: la card azienda usa lo stile accent (non il gold sponsored) per non mostrare il badge "Sponsored" errato — polish cosmetico, fuori scope (già deferito in #2435, non funnel-critical).
- Nessuna modifica al checkout/webhook/lifecycle: già completi in #2435 (checkout `plan='azienda'`, webhook `tier='azienda'`, revert su cancel) e #2412 (proiezione always-featured). Niente price id fabbricati — `STRIPE_PRICE_AZIENDA` resta owner-configured in RC.

## Sibling check

- `node scripts/ci/check-sibling-patterns.mjs` → nessun costrutto distintivo estratto (riuso del setter `setTier` esistente, nessun nuovo helper/costante/modulo) → nessuna classe di pattern da sweepare.
- Il tier `publishers/{uid}.tier` è scritto solo dal webhook `functions/src/stripePublisherCore.js` (`set({tier:'azienda'})` su `checkout.session.completed`); la lettura per preselect è il complemento naturale, nessun altro reader da allineare.

## Test plan

- [x] `npx vitest run tests/publisher-supersede.test.ts tests/publisher-job-projection.test.ts` → 46 passed.
- [x] Diff surgicale (6 righe, 1 file); typecheck progetto senza errori su `PublisherPublishPage.tsx`.
- [ ] Typecheck/build via CI.
- [ ] Post-deploy: login come publisher con `tier='azienda'` → apri `/pubblica-offerta` (nuovo annuncio) → card Piano Azienda preselezionata; switch manuale a Gratuito → resta Gratuito; `?edit` di un annuncio sponsored → tier dal doc (sponsored), non sovrascritto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)