### PR TITLE
experiment(build): render-skip clusters (Fase 0) + build-plan doc

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -89,6 +89,7 @@ import {
   type RawJob,
 } from './relatedSearchClustersData';
 import { jobsSeoPagesFlushed } from './shared/buildSignals';
+import { shouldEmitLocale } from './shared/localeEmitFilter';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import {
   startTimer as profileStart,
@@ -2614,6 +2615,28 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         }
         const __tRenderCluster = profileStart();
         const locale = ctx.candidate.locale;
+        // Locale-shard render-skip (BUILD_LOCALE, LOCALE-SHARD-BUILD-PLAN Fase 0):
+        // for a locale this shard is NOT emitting, skip the expensive
+        // renderClusterPage + collector writes (the bulk of this plugin's
+        // ~264s). Still record the canonical + legacy-mirror locs CHEAPLY
+        // (string-only via buildClusterPath, no render) so the it/main shard —
+        // which owns sitemap-search-clusters.xml and the sitemap-jobs.xml
+        // mirror-drop patch (issue #911) — keeps a complete cross-locale set.
+        // No-op in the default all-locale build (shouldEmitLocale always true).
+        if (!shouldEmitLocale(locale)) {
+          const __skUrlPath = buildClusterPath(locale, ctx.candidate.slug, ctx.cantonGroup);
+          sitemapLocs.push(`${BASE_URL}${__skUrlPath}`);
+          const __skMirror = new Set<string>();
+          for (const __skMc of [ctx.legacyCantonGroup, 'TI']) {
+            if (__skMc === AGGREGATE_KEY) continue;
+            __skMirror.add(buildClusterPath(locale, ctx.candidate.slug, __skMc));
+          }
+          const __skExtra = indexedClusterUrlsByKey.get(`${locale}::${ctx.candidate.slug}`);
+          if (__skExtra) for (const p of __skExtra) __skMirror.add(p);
+          __skMirror.delete(__skUrlPath);
+          for (const mp of __skMirror) crossSectionMirrorLocs.push(`${BASE_URL}${mp.replace(/\/+$/, '')}/`);
+          continue;
+        }
         // altKey was precomputed in the group-hreflang loop above and cached
         // on `altKeyByCtx` so we don't re-normalize ctx.keyword + ctx.city
         // here. Falls back to fresh compute for safety on the (impossible

--- a/docs/LOCALE-SHARD-BUILD-PLAN.md
+++ b/docs/LOCALE-SHARD-BUILD-PLAN.md
@@ -1,0 +1,93 @@
+# Locale-Shard BUILD Plan — render-isolated per-locale build
+
+> Stato: **fase di studio / prototipo**. NON wira il deploy di produzione finché
+> il workflow esperimento non prova wall-time + correttezza.
+> Companion: `LOCALE-SHARD-DEPLOY-PLAN.md` (split dell'OUTPUT, già in prod).
+
+## Obiettivo
+
+Portare il build/deploy da **~23 min monolite → ~15 min** isolando il *render*
+per-locale su runner free paralleli, **senza perdere nulla**: build default
+byte-identico (`BUILD_LOCALE` unset), hreflang/sitemap completi, tutti i gate
+SEO verdi, **costo $0** (no runner a pagamento — usa la concorrenza free).
+
+### Perché (dato empirico, run 27684916473)
+
+La matrix per-locale (PR #2394/#2428/#2443, opt-in dormiente su main) è CORRETTA
+ma NON velocizza: ~39-46 min/shard vs ~23 min monolite, perché il *render*
+gira pieno (tutti e 4 i locali) su OGNI shard — il gate salta solo le scritture
+del collector + 1 loop. Timing per fase (shard en):
+
+| fase | tempo | natura |
+|---|---|---|
+| jobs-seo-pages | 856s | per-locale ×4 (render NON skippato) |
+| orphan-query-landings | 324s | per-locale ×4 |
+| related-search-clusters | 264s | per-locale ×4 (203k pagine) |
+| og-pages | 25s | locale-invariante (shared) |
+| vite bundle | 60s | locale-invariante (shared) |
+| data assembly | 15–195s | locale-invariante (shared) |
+
+→ **~1444s (24min) sono render per-locale fatto ×4 redondante.** Isolandolo a
+1/4 per shard: ~13-16min/shard, wall (4 paralleli) ~15min.
+
+## Metriche di successo (gate finale)
+
+- Deploy build-phase ≤ **16 min** (da ~23).
+- Dist **ricomposta** dai 4 shard passa **tutti i gate SEO** identici al monolite
+  (audit-hreflang, sitemap-integrity, broken-link, structured-data).
+- Ogni pagina: 4 locali + x-default.
+- Build default (`BUILD_LOCALE` unset) **byte-identico** (CI diff-check).
+- Zero runner a pagamento.
+
+## Architettura target
+
+```
+prep (1 runner)                    build-locale (matrix ×4 paralleli)
+─ data assembly        ──artifact──▶ restore artifact
+─ OG images (loc-inv)               ─ vite bundle (~60s)
+─ canton classification             ─ render+emit SOLO il proprio locale (render-skip)
+─ slug-map cross-locale             ─ prune → push shard repo
+                                     it: + root/shared/sitemaps → Pages + CDN
+```
+
+## Fasi (1 PR ciascuna, gate misurabile)
+
+- **Fase 0 — Prototipo di misura** *(questa PR)*. Render-skip in
+  `related-search-clusters` (1 loop, 264s, isolato). Preserva il bookkeeping
+  cross-locale cheap (`sitemapLocs` + `crossSectionMirrorLocs` via
+  `buildClusterPath`, senza render). Gate: clusters ~264→~70s su uno shard,
+  validate verde, sitemap del main-shard completa.
+- **Fase 1 — `jobs-seo-pages` (856s, 34 loop)**. Render-skip per loop, ognuno
+  dopo lo stato cross-locale (pattern `emittedActiveJobPaths`→sitemap r.8642;
+  slug-map pre-loop hreflang). La parte grossa.
+- **Fase 2 — restanti emitter per-locale** (`orphan-query-landings` 324s,
+  `weekly-employers` ×4, `job-market-snapshot` ×4, hub vari). Sitemap completa.
+- **Fase 3 — prep-job condiviso + artifact** (data+OG+bundle → artifact;
+  snapshot atomico; riusa la composite `seo-build-data-prep`).
+- **Fase 4 — hardening correttezza**: validator esteso (canonical/x-default/
+  robots/build-id/sitemap-alternates) + step **recompose+audit** (ricompone i 4
+  shard e gira i gate SEO esistenti) + guard-test anti-regressione (flagga nuovi
+  consumer che leggono esistenza-file cross-locale non shard-aware).
+- **Fase 5 — wiring prod (`deploy.yml`)**: sostituisce il build monolitico con
+  prep + matrix; ogni locale pusha il suo shard (elimina tree-split+strip).
+  Mantiene `LOCALE_SHARDS_LIVE`/fallback. Verifica live via build-id + curl.
+- **Fase 6 — decommissioning + monitoraggio** 1-2 settimane (wall-time, CWV,
+  hreflang GSC, 404 coverage). Revert-trigger documentato.
+
+## Rischi & mitigazioni
+
+| Rischio | Mitigazione |
+|---|---|
+| Regressione coupling cross-locale | audit per-loop + recompose+audit (gate bloccante, Fase 4) |
+| OOM jobs-seo | per-locale = 1/4 pagine → meno memoria, probabile beneficio |
+| Divergenza snapshot tra shard | prep-job + artifact atomico (Fase 3) |
+| Tassa manutenzione (codice nuovo ri-accoppia) | guard-test anti-regressione (Fase 4) |
+| Bookkeeping cheap che driftaa dal render | estrarre loc/mirror in helper condiviso (Fase 1/2) |
+
+**Rollback**: tutto opt-in (`BUILD_LOCALE`); wiring prod dietro flag → revert al
+build monolitico in 1 commit.
+
+## Stima
+
+F0 ½gg · F1 2-3gg (34 loop) · F2 1-2gg · F3 1gg · F4 1-2gg · F5 1gg+live · F6 ½gg.
+**~1,5-2 settimane**, collo = cicli CI lenti, ~6 PR sequenziali.


### PR DESCRIPTION
## Contesto

Fase 0 del piano `docs/LOCALE-SHARD-BUILD-PLAN.md` (build per-locale, obiettivo ~23→~15min a $0). Prototipo di **misura**: estende il locale-skip dal WRITE al RENDER nel loop dominante di `related-search-clusters` (~264s/shard, 203k pagine) per validare il delta reale prima del refactor pesante di `jobs-seo-pages` (856s, 34 loop).

**Non tocca `deploy.yml`.** Tutto opt-in (`BUILD_LOCALE`); default unset = byte-identico.

## Implementato

- **`build-plugins/relatedSearchClustersPlugin.ts`**: nel loop per-cluster, se `shouldEmitLocale(locale)` è false si salta `renderClusterPage` + le scritture del collector (canonical + flat + mirror). Si registrano comunque, **a buon mercato** (solo `buildClusterPath`, nessun render), il `loc` canonico in `sitemapLocs` e i mirror legacy in `crossSectionMirrorLocs` → il main/it shard mantiene completi `sitemap-search-clusters.xml` e il patch mirror-drop di `sitemap-jobs.xml` (issue #911) per tutti i locali.
- **`docs/LOCALE-SHARD-BUILD-PLAN.md`**: piano completo a 6 fasi.

## Non implementato (ancora)

- **Render-skip di `jobs-seo-pages` (856s) e `orphan-query-landings` (324s)**: Fasi 1-2. Questa PR isola solo i clusters per misurare il lever.
- **Prep-job condiviso + recompose+audit + wiring prod**: Fasi 3-5.
- **Bookkeeping cheap vs drift**: il calcolo loc/mirror nel ramo skip duplica la logica del path pieno; estrazione in helper condiviso prevista in Fase 1/2 (per ora prototipo, su branch, misurato).
- **Hub pages per-locale** (4 pagine, costo trascurabile): non skippate, restano write-gated.

## Test plan

- [ ] Run live `deploy-matrix-experiment` → misura: `related-search-clusters` deve scendere da ~264s a ~70s sugli shard non-it, validate verde, sitemap completa.
