### PR TITLE
test(e2e-live): skip legacy-redirect stubs in live contract tests (fix validate-live false-fail)

### DIFF
--- a/tests/e2e/post-deploy-rendering-live.spec.ts
+++ b/tests/e2e/post-deploy-rendering-live.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type APIRequestContext } from 'playwright/test';
 import { resolveActiveJobDetailPath } from './lib/live-jobs';
+import { REDIRECT_STUB_MARKER } from '../../build-plugins/shared/redirectStubMarker.mjs';
 
 /**
  * Live post-deploy rendering smoke (regression guard for the 2026-04-30 incident).
@@ -114,6 +115,16 @@ for (const target of TARGETS) {
 
       if (fetched.status === 404 && target.tolerate404) {
         test.skip(true, `${url} returned 404 (content may have rotated)`);
+        return;
+      }
+
+      // A legacy-redirect stub (200 "Pagina spostata" carrying
+      // REDIRECT_STUB_MARKER, no SPA bundle) means the page intentionally
+      // moved to its canonical URL — same signal as a 404 here. Without this,
+      // adding a redirect for a tolerated path would trip the SPA-bundle
+      // assertion below and turn an intentional redirect into a false failure.
+      if (fetched.status === 200 && target.tolerate404 && fetched.body.includes(REDIRECT_STUB_MARKER)) {
+        test.skip(true, `${url} is a legacy-redirect stub (content moved to canonical)`);
         return;
       }
 

--- a/tests/e2e/spa-hydration-contract-live.spec.ts
+++ b/tests/e2e/spa-hydration-contract-live.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from 'playwright/test';
+import { REDIRECT_STUB_MARKER } from '../../build-plugins/shared/redirectStubMarker.mjs';
 
 // Mobile-first per CLAUDE.md rule #15 — 75% of traffic is mobile, so the
 // "is anything visible above the fold" assertion must measure a mobile viewport.
@@ -100,6 +101,24 @@ for (const target of TARGETS) {
       if (head.status() === 404 && target.tolerate404) {
         test.skip(true, `${url} returned 404 (content rotated)`);
         return;
+      }
+      // A legacy-redirect stub (legacyRedirectsPlugin emits a 200 "Pagina
+      // spostata" card carrying the `<!--REDIRECT_STUB-->` marker, with a
+      // canonical pointing at the moved URL) is the same signal as a 404 for
+      // this contract: the page intentionally MOVED, so the old path is no
+      // longer a hydrating SPA page. Without this the stub's ~150 visible
+      // chars trip the min-content assertion and turn an intentional redirect
+      // into a false validate-live failure (this is what the `tolerate404`
+      // escape-hatch already covered while the old URL still 404'd — adding a
+      // redirect for it must not silently re-arm the test). Treat it as a skip
+      // for tolerated targets; for a non-tolerated target a redirect stub IS a
+      // regression and should still fail below.
+      if (head.status() === 200 && target.tolerate404) {
+        const body = await head.text();
+        if (body.includes(REDIRECT_STUB_MARKER)) {
+          test.skip(true, `${url} is a legacy-redirect stub (content moved to canonical)`);
+          return;
+        }
       }
       expect(head.status(), `${url} should respond 200`).toBe(200);
 


### PR DESCRIPTION
## Implementato

- **Fix del false-fail `validate-live`** sul caso `border-wait per-crossing (chiasso)` → `/tempi-attesa-confine/chiasso-brogeda/` (errore: `largest visible <main> has 153 chars, min 400`). **Non è un bug di rendering né l'OOM**: la pagina del valico vive a `/guida-frontaliere/tempi-attesa-dogana/chiasso-brogeda/` (200, ~2.6k char); `/tempi-attesa-confine/` è uno schema URL **legacy**. PR #2389 ha (correttamente) aggiunto il redirect per quel 404 confermato-da-CF → `legacyRedirectsPlugin` emette uno stub 200 "Pagina spostata" (`REDIRECT_STUB_MARKER`, senza SPA bundle). Il target e2e stale puntava ancora al vecchio path: finché era 404 lo skip `tolerate404` lo copriva, ma lo stub-200 ha **riarmato** il test → fallimento falso.
- **Guard di classe**: per i target `tolerate404`, un 200 che contiene `REDIRECT_STUB_MARKER` è trattato come un 404 (contenuto **spostato intenzionalmente** → `test.skip`). Marker importato dal single-source condiviso `build-plugins/shared/redirectStubMarker.mjs` (la stessa costante usata da `scripts/audit-spa-bundle-injection.mjs`), niente literal duplicato.
- **Applicato a ENTRAMBI gli spec live che condividono il preflight `tolerate404`** (sibling-class, AGENTS.md §6):
  - `tests/e2e/spa-hydration-contract-live.spec.ts` — assert min visible-content (il caso che falliva).
  - `tests/e2e/post-deploy-rendering-live.spec.ts` — assert presenza SPA bundle (uno stub non ce l'ha → stesso false-fail latente).
- **Verificato live** (`npm run test:e2e:live`): il target chiasso ora **SKIPpa**; suite `spa-hydration-contract-live` completa = **8 passed / 5 skipped / 0 failed**. `tsc --noEmit` pulito.

## Non implementato (ancora)

- **Nessuna modifica alla pagina né al redirect**: la pagina valico è viva e corretta alla canonica, e il redirect di #2389 è SEO-corretto (pulisce 404 GSC/CF). Out of scope cambiarli — il difetto era solo il test stale.
- **Non aggiornato il path del target a quello canonico** (`/guida-frontaliere/tempi-attesa-dogana/chiasso-brogeda/`): lo skip-su-stub è più robusto (fixa l'intera classe per qualunque target che riceva un redirect futuro), non solo questo caso. Se in futuro si vuole coprire anche la pagina nuova, è un follow-up additivo (aggiungere il path canonico ai TARGETS), non un fix di questo bug.
- **Non guardati la nav-test né lo standalone "expired job soft-landing"** in `post-deploy-rendering-live.spec.ts`: non producono false-fail su uno stub (lo stub è 200, nessun redirect-loop, URL finale invariato → la nav-test passa; la soft-landing non è un target `tolerate404` ed è deliberatamente una pagina reale con SPA bundle). Guardarli sarebbe churn senza copertura di un fallimento reale.
- **Validazione live in CI**: i test live girano solo nel job `validate-live` post-deploy (richiede un deploy completato). Verificati qui localmente contro il sito live; confermerò il job verde al prossimo deploy non-cancellato.

Closes #2478
