### PR TITLE
fix(seo): redirect SPA-only 404 routes to existing 200 pages (#1823, #2386)

### DIFF
--- a/build-plugins/legacyRedirectsPlugin.ts
+++ b/build-plugins/legacyRedirectsPlugin.ts
@@ -258,6 +258,44 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  // keeping benzina↔benzina / diesel↔diesel (never cross fuels).
  '/prezzi-benzina/': '/prezzi-benzina/oggi/',
  '/prezzi-diesel/': '/prezzi-diesel/oggi/',
+
+ // ── SPA-only tab routes that hard-404 at the edge (2026-06-17 Googlebot sweep, #2386/#1823) ──
+ // These tabs exist only in the SPA router; no build-plugin emits static HTML for
+ // them, so GitHub Pages serves 404.html → hard-404 for crawlers and direct hits.
+ // Owner decision: do NOT emit noindex SPA shells — REDIRECT each to the correct
+ // EXISTING page that already returns 200 (verified live, all 4 locales). The whole
+ // class is swept here (AGENTS.md #6): publish/dashboard/employer → live job board;
+ // partner-services (thin utility) → home; press-kit → about; newsletter-prefs
+ // (token-gated, no standalone content) → the live morning/newsletter landing.
+ // Publish-a-job + my-listings + for-employers → the live job board (the product
+ // these funnel into; where published jobs appear).
+ '/pubblica-offerta/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
+ '/i-miei-annunci/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
+ '/per-le-aziende/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
+ '/en/post-a-job/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
+ '/en/my-listings/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
+ '/en/for-employers/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
+ '/de/stelle-aufgeben/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
+ '/de/meine-anzeigen/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
+ '/de/fuer-unternehmen/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
+ '/fr/publier-une-offre/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
+ '/fr/mes-annonces/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
+ '/fr/pour-les-entreprises/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
+ // Partner services (thin utility tab) → locale home.
+ '/servizi-partner/': '/',
+ '/en/partner-services/': '/en/',
+ '/de/partner-dienste/': '/de/',
+ '/fr/services-partenaires/': '/fr/',
+ // Press kit → the about page (same org-info class).
+ '/stampa/': '/chi-siamo/',
+ '/en/press-kit/': '/en/about-us/',
+ '/de/pressekit/': '/de/ueber-uns/',
+ '/fr/kit-presse/': '/fr/a-propos/',
+ // Newsletter preferences (token-gated, no standalone content) → live morning landing.
+ '/preferenze-newsletter/': '/buongiorno-frontaliere/',
+ '/en/newsletter-preferences/': '/en/good-morning/',
+ '/de/newsletter-einstellungen/': '/de/guten-morgen/',
+ '/fr/preferences-newsletter/': '/fr/bonjour-frontalier/',
  };
 
  const normalize = (p: string): string => {


### PR DESCRIPTION
## Implementato

Sei route SPA-only facevano **hard-404 all'edge** (GitHub Pages serve `404.html` perché nessun build-plugin emette HTML statico per loro), confermato live come Googlebot in tutti e 4 i locali. Decisione owner: **niente noindex SPA shell — redirigi ogni route alla pagina ESISTENTE corretta che già ritorna 200** (verificato live).

Aggiunto al `redirects` map di `build-plugins/legacyRedirectsPlugin.ts` (meccanismo bridge 301-style noindex già usato per i legacy rename). Spazzata l'intera classe gemella (AGENTS.md #6), tutti e 4 i locali:

| route (404) | target (200 esistente) | metodo |
|---|---|---|
| `/pubblica-offerta/` · `/i-miei-annunci/` · `/per-le-aziende/` | `/cerca-lavoro-ticino/` | 301 bridge |
| `/en/post-a-job/` · `/en/my-listings/` · `/en/for-employers/` | `/en/find-jobs-ticino/` | 301 bridge |
| `/de/stelle-aufgeben/` · `/de/meine-anzeigen/` · `/de/fuer-unternehmen/` | `/de/jobs-im-tessin/` | 301 bridge |
| `/fr/publier-une-offre/` · `/fr/mes-annonces/` · `/fr/pour-les-entreprises/` | `/fr/trouver-emploi-tessin/` | 301 bridge |
| `/servizi-partner/` (+ en/de/fr) | locale home (`/`, `/en/`, `/de/`, `/fr/`) | 301 bridge |
| `/stampa/` (+ en/de/fr) | about (`/chi-siamo/`, `/en/about-us/`, `/de/ueber-uns/`, `/fr/a-propos/`) | 301 bridge |
| `/preferenze-newsletter/` (+ en/de/fr) | morning landing (`/buongiorno-frontaliere/`, `/en/good-morning/`, `/de/guten-morgen/`, `/fr/bonjour-frontalier/`) | 301 bridge |

Razionale target:
- **publish / my-listings / for-employers** → job board: è il prodotto live verso cui queste tab fanno funnel (dove gli annunci pubblicati compaiono).
- **partner-services** → home: tab utility thin, nessun contenuto standalone.
- **press-kit** → about: stessa classe org-info.
- **newsletter-preferences** → morning landing: token-gated senza contenuto standalone; la landing newsletter live è la morning page.

Tutti i target verificati **200 live** (`curl -L`) in tutti e 4 i locali; tutti gli URL con trailing slash (eccetto le home `/`, `/en/`, `/de/`, `/fr/` corrette). #1823 base item (regola trailing-slash in AGENTS.md) già presente da PR #1822 merged; nessun link literal non-canonico nel diff.

Test mirati verdi: `redirect-page-builders`, `flat-html-redirect`, `no-js-redirects-in-build`, `router-trailing-slash`, `router-locale-slugs` (29 passed). GitNexus impact `legacyRedirectsPlugin` = LOW (solo `vite.config.ts` lo registra). Sibling-pattern check: nessun costrutto da sweepare (solo data entries in un map esistente).

Closes #1823
Closes #2386

## Non implementato (ancora)

- **Landing SEO indexable per `for-employers`** (proposta (A) nel comment owner su #2386): la decisione owner per QUESTA PR è redirect-al-200, non costruire una nuova landing indexable con seoMap 4-locali + sitemap + prosa. Se in futuro si vuole indicizzare `/per-le-aziende/` come funnel acquisition, è una PR dedicata separata (rimuovere il redirect + aggiungere entry seoMap + prosa reale per non violare AGENTS.md #4 thin-content).
- **Verifica live post-deploy** dei 200/301 (le route 404→redirect): osservabile solo dopo deploy su `main` (build SSG OOM-prone non eseguibile in locale); verificherò via `curl` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)