### PR TITLE
feat(adsense): dedicated FT_DRIVEBY_ATF_DISPLAY registry entry for drive-by ATF slot (#1911)

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -512,14 +512,20 @@ export const OFFERWALL_FC_SNIPPET = `<script>(function(){var g=window.googlefc=w
  * fold (2026-06 revenue deep dive). A slot near the primary data area makes
  * the adsense lazy loader's IntersectionObserver fire at first paint, so
  * adsbygoogle.js loads immediately instead of waiting for the idle
- * fallback. Markup comes from adSlotHtml('HOMEPAGE_MID_DISPLAY') so format
- * (autorelaxed multiplex) and the CLS-reserving min-height stay driven by
- * the services/adsenseSlots registry — never hand-roll the <ins> here
- * (PR #1910 review). Reuses that ACTIVE unit because ad-unit creation via
- * API needs a write-scope OAuth token the automation does not hold.
+ * fallback. Markup comes from adSlotHtml('FT_DRIVEBY_ATF_DISPLAY') so format
+ * and the CLS-reserving min-height stay driven by the services/adsenseSlots
+ * registry — never hand-roll the <ins> here (PR #1910 review).
+ *
+ * The registry's FT_DRIVEBY_ATF_DISPLAY entry currently mirrors the ACTIVE
+ * HOMEPAGE_MID_DISPLAY slot id because the AdSense Management API forbids
+ * ad-unit creation (403 PERMISSION_DENIED, verified 2026-06-18 even with a
+ * full adsense write-scope token — console-only for this account). The owner
+ * isolates drive-by reporting from the homepage by creating the dedicated
+ * console unit and swapping that one slot id in services/adsenseSlots.ts —
+ * this snippet needs no further change (issue #1911 item 1).
  */
 export const DRIVEBY_AD_SNIPPET = `<div class="my-6">
-    ${adSlotHtml('HOMEPAGE_MID_DISPLAY')}
+    ${adSlotHtml('FT_DRIVEBY_ATF_DISPLAY')}
   </div>`;
 
 export const ADSENSE_SNIPPET = `<meta name="google-adsense-account" content="${ADSENSE_CLIENT_ID}">

--- a/services/adsenseSlots.ts
+++ b/services/adsenseSlots.ts
@@ -79,6 +79,32 @@ export const AD_SLOTS = {
  // 1100 reduces shift to ~66px; collapses to 0 when unfilled (offscreen guard).
  placeholderMinHeight: 1100,
  },
+ /** Drive-by SEO landings: above-the-fold display, right after the primary
+  *  data area (health premiums, fuel daily, border wait — DRIVEBY_AD_SNIPPET).
+  *
+  *  Dedicated unit so the drive-by RPM lift can be measured in isolation
+  *  instead of aggregated with the homepage placement (issue #1911 item 1).
+  *
+  *  Slot id currently MIRRORS HOMEPAGE_MID_DISPLAY ('2093992129') — the only
+  *  ACTIVE display unit the build can reference today. A dedicated
+  *  `FT_DRIVEBY_ATF_DISPLAY` ad unit CANNOT be created from this automation:
+  *  AdSense Management API v2 `adClients.adunits.create` returns 403
+  *  PERMISSION_DENIED even with a full `https://www.googleapis.com/auth/adsense`
+  *  write-scope token (verified 2026-06-18 with a valid 300x250/1x3 payload —
+  *  not a scope or format issue; ad-unit creation is console-only for this
+  *  account/OAuth client). Owner action to isolate reporting:
+  *    1. AdSense console → Ads → By ad unit → create a Display unit named
+  *       `FT_DRIVEBY_ATF_DISPLAY` (responsive).
+  *    2. Replace the `slot` below with the new data-ad-slot id — that single
+  *       edit re-points every drive-by landing; nothing else changes.
+  *  Config matches HOMEPAGE_MID_DISPLAY so the rendered <ins> and the
+  *  CLS-reserving min-height stay identical until the swap. */
+ FT_DRIVEBY_ATF_DISPLAY: {
+ slot: '2093992129',
+ format: 'autorelaxed',
+ fullWidthResponsive: false,
+ placeholderMinHeight: 1100,
+ },
  /** Job detail: between related jobs and related articles sections */
  JOBDETAIL_BETWEEN_SECTIONS: {
  slot: '7767335647',


### PR DESCRIPTION
## Implementato
- **Item 1 (#1911)** — `services/adsenseSlots.ts`: aggiunta voce dedicata `FT_DRIVEBY_ATF_DISPLAY` nel registry. Lo slot id **rispecchia** `HOMEPAGE_MID_DISPLAY` (`2093992129`) e la config è byte-identica (stesso `format: autorelaxed`, `placeholderMinHeight: 1100`, `fullWidthResponsive: false`) → l'`<ins>` renderizzato e lo spazio CLS riservato sono **invariati oggi**, ma lo slot drive-by ha ora una costante dedicata. L'owner isola il reporting RPM drive-by dal placement homepage creando un'unità Display in console e sostituendo **quel solo** slot id: nessun'altra modifica necessaria.
- **Item 1** — `build-plugins/constants.ts`: `DRIVEBY_AD_SNIPPET` ora passa per `adSlotHtml('FT_DRIVEBY_ATF_DISPLAY')` invece di `HOMEPAGE_MID_DISPLAY`. Docblock aggiornato (no riferimenti stale al vecchio meccanismo, AGENTS.md #6 rename-discipline).
- **Esito creazione unità (config-wired, NON API-created)**: la creazione via AdSense Management API v2 `adClients.adunits.create` risponde **403 PERMISSION_DENIED** anche con token full write-scope `https://www.googleapis.com/auth/adsense` (verificato 2026-06-18 con payload valido `300x250`/`1x3` — non è un problema di scope né di formato della request: la create di ad-unit è **console-only** per questo account/OAuth client). La PR #1910 attribuiva il 403 allo scope `adsense.readonly`; il token oggi ha lo scope write completo (usato da `adsense-archive-orphans.mjs`) ma la create resta bloccata a livello permessi. **Nessuno slot id fabbricato.**
- **Item 3 (#1911)** — verificato no-op su questo branch: i 3 template (`healthPremiumsLandingPlugin`, `fuelDailyPagesPlugin`, `borderWaitPagesPlugin`) renderizzano solo `ARTICLE_END_MULTIPLEX` (slot `5196931137`, distinto) diretto + `DRIVEBY_AD_SNIPPET` (slot `2093992129`). Due slot distinti co-presenti, nessun doppio `<ins data-ad-slot>` identico → soglia ad-density paventata inesistente.
- **Auto Ads intatte** (anchor/in-page/vignette) — questo è uno slot display manuale aggiuntivo. Tutto il markup ad resta registry-driven via `adSlotHtml()` → `check-cls-ad-slots` verde, zero CLS (min-height riservato).
- **Test**: 192 pass su 7 file (`check-cls-ad-slots`, `adsense-lazy-load`, `border-wait-pages`, `fuel-daily-pages`, `health-premiums-landing`, `article-ad-slots`, `calculator/inline-ads`). `tsc` pulito sui file toccati.

## Non implementato (ancora)
- **Creazione dell'unità AdSense via API**: bloccata a 403 PERMISSION_DENIED (console-only — vedi sopra). Azione owner: AdSense console → Annunci → Per unità → crea Display `FT_DRIVEBY_ATF_DISPLAY` (responsive), poi incolla il nuovo `data-ad-slot` nel campo `slot` di `FT_DRIVEBY_ATF_DISPLAY` in `services/adsenseSlots.ts`. Una riga, niente altro cambia.
- **Item 2 — estensione `DRIVEBY_AD_SNIPPET` ai 4 sibling marginali** (`weatherAlertPagesPlugin`/`weatherCityPagesPlugin`/`borderMunicipalityPagesPlugin`/`orphanQueryLandingPlugin`): **gated su misura** (giudizio umano). Il PR body #1910 lo rinvia esplicitamente a *post-conferma del lift* (rpm-canary/revenue-monitor checkpoint 15/6 e **22/6**, revert-trigger `<−25% RPM`). Oggi è 18/6: il secondo checkpoint non è arrivato e **nessun dato RPM/revenue è checked-in nel repo** → estendere ora l'ATF display a 4 template = cambio speculativo su revenue (AGENTS.md #6, no automation cieca su funnel) che allargherebbe il blast-radius ad-density **prima** che la misura di sicurezza chiuda. I 4 template esistono e non hanno lo snippet (verificato): riaccodabile dopo il 22/6 quando l'owner conferma il lift sui 3 template live.
- **Sibling-class check** (`check-sibling-patterns.mjs`): i file gemello flaggati (`AdSenseBanner.tsx`, `CalcolatoreTabContent`, `ConfrontiTabContent`, calculator/*, ecc.) condividono solo i costrutti generici del registry ad (`adSlotHtml`/`fullWidthResponsive`/`placeholderMinHeight`/`HOMEPAGE_MID_DISPLAY`) come consumer legittimi di slot diversi — **non** lo stesso antipattern. L'unica vera classe-sibling di questo cambio sono i 4 template drive-by marginali → coperti dall'item 2 deferred sopra.

Closes #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)