### PR TITLE
experiment(build): render-skip jobs-seo big levers (Fase 1a)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2323,6 +2323,12 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  for (const job of validJobs) {
   await collector.awaitDrainSlot(6); // bound flush backlog (#1290)
  for (const locale of localeList) {
+ // Per-locale shard build (BUILD_LOCALE): the cleaned canonical
+ // description/requirements are consumed ONLY when rendering that locale's
+ // pages (JSON-LD/body content) — which this shard skips for non-emitted
+ // locales. So only enumerate tuples for the emitted locale → the worker
+ // pool processes ~1/4 the tuples. No-op in the default all-locale build.
+ if (!shouldEmitLocale(locale)) continue;
  const description = String(job?.descriptionByLocale?.[locale] || job.description || '');
  if (!description) continue;
  const requirements: string[] = Array.isArray(job?.requirementsByLocale?.[locale])
@@ -10677,6 +10683,12 @@ ${staticAnalyticsHtml}
  // actually-emitted paths, not just attempted ones.
  const __slPathKey = relPath.replace(/^\//, '').replace(/\/+$/, '');
  if (emittedSoftLandingPaths.has(__slPathKey)) continue;
+ // Per-locale shard build (BUILD_LOCALE): skip the expensive soft-landing
+ // render/emit for locales this shard isn't responsible for (this loop is
+ // ~57% of jobs-seo wall, 319k pages). The expired sitemap (it/main-owned,
+ // built below from `paths` + _writtenPaths(IT) + cross-locale alternates)
+ // is unaffected. No-op in the default all-locale build.
+ if (!shouldEmitLocale(locale)) continue;
  const __tExpiredSoftLanding = startTimer();
  const __tEjpTitle = phaseTimer();
  const selfUrl = `${BASE_URL}${withSlash(relPath)}`;


### PR DESCRIPTION
## Contesto

Fase 1a del `docs/LOCALE-SHARD-BUILD-PLAN.md`. Il profiler ha mostrato che jobs-seo-pages (856s) è dominato da 2 lever: **expired-soft-landing 274s (57.6%)** + **canonical-fallback pre-pass 199s** (worker pool). Questa PR fa il render-skip mirato di entrambi (basso rischio, ~355s di valore) invece dei 15 loop minori.

**Non tocca `deploy.yml`.** Opt-in (`BUILD_LOCALE` unset = byte-identico).

## Implementato

- **`jobsSeoPagesPlugin.ts`**:
  - **soft-landing** (loop ~10666): `if (!shouldEmitLocale(locale)) continue;` dopo il dedup-check `emittedSoftLandingPaths`, prima del render. La expired-sitemap (it/main-owned, ~11270) usa `paths` + `_writtenPaths(IT)` + alternates cross-locale → non toccata. `itBodyWordCount` hoisted a 0, settato solo nell'iter IT → no crash negli shard non-it.
  - **canonical-fallback enum** (~2325): skip dei locali non-emessi → il worker pool pulisce ~1/4 dei tuple. Le description cleaned servono solo al render del proprio locale.

## Non implementato (ancora)

- **Loop minori** (company-landing 15s, company-city-canton-hub 14s, previous-slug-bridge 13s, self-healing 12s, sector-canton 9s, editorial, pagination, ecc. ~100s totali): Fase 1b, dopo che questa misura conferma il pattern + validate verde.
- **Manifest cross-locale + prep-job condiviso**: Fase 3.
- **recompose+audit, wiring deploy.yml**: Fase 4-5.

## Test plan

- [ ] Run `deploy-matrix-experiment` → jobs-seo da ~856s a ~500s sugli shard; validate verde (sitemap+hreflang completi nel main/it shard).
