### PR TITLE
fix(offerwall): make gate email input visible against modal card

### DIFF
--- a/components/community/OfferwallNewsletterGate.tsx
+++ b/components/community/OfferwallNewsletterGate.tsx
@@ -364,7 +364,7 @@ const OfferwallNewsletterGate: React.FC = () => {
               onChange={setEmail}
               ariaLabel={copy.title}
               required
-              className="w-full px-4 py-2.5 bg-surface border border-edge rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-accent text-strong text-sm"
+              className="w-full px-4 py-2.5 bg-surface-alt border border-edge rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:border-transparent text-strong text-sm"
             />
 
             <label className="flex items-start gap-2 text-xs text-muted">


### PR DESCRIPTION
## Implementato

Follow-up al merge #2472. Test live Playwright sul gate servito ha rivelato che l'EmailInput del modal **si confondeva col fondo**: la card del modal è `bg-surface` (bianco) e l'input usava anch'esso `bg-surface`; il `border border-edge` risolve a **width 0px** nel nostro setup Tailwind → input invisibile a riposo (solo il focus-ring lo suggeriva quando attivo — esattamente il "non è perfetta" segnalato).

- **Fix:** l'EmailInput del gate passa a **`bg-surface-alt`** (grigio chiaro) — il pattern di contrasto già usato e funzionante dagli input di `PublisherApplyForm` — così è chiaramente visibile su card bianca. Aggiunto `focus-visible:border-transparent` per coerenza con quel pattern.

Prova live pre-fix (Playwright, modal `aria-labelledby="offerwall-gate-title"`): `inputBg === cardBg` (entrambi `rgb(255,255,255)`) e `border-top-width: 0px`.

Verifica della logica di bypass (separata, già live da #2472) confermata PASS nello stesso test: `initialize()` → anonimo `ACCESS_NOT_GRANTED`, loggato (`firebase:authUser:`) `ACCESS_GRANTED`, iscritto `ACCESS_GRANTED`.

## Non implementato (ancora)

- **Root cause del `border border-edge` width 0:** non investigata oltre — è un comportamento del setup Tailwind che riguarda anche altri input (PublisherApplyForm lo aggira con `bg-surface-alt`, stessa strada presa qui). Allargare l'indagine sarebbe drive-by fuori scope; il contrasto via background risolve il sintomo per l'utente.
- **Path rewarded (AdSense RRM):** fuori scope, in attesa risposta Luca.

## Test plan

- [x] Diff one-line, build invariata (solo className utility Tailwind, token semantici esistenti)
- [ ] Post-deploy: riaprire il gate (hook `__ftOfferwallSubscribe`) su pagina articolo → EmailInput visibile a riposo (sfondo grigio chiaro su card bianca), non solo in focus