### PR TITLE
feat(outreach): company domain finder (web search + MX + name-match)

### DIFF
--- a/scripts/enrich-employer-contacts.mjs
+++ b/scripts/enrich-employer-contacts.mjs
@@ -26,6 +26,7 @@ import dns from 'node:dns/promises';
 import { fileURLToPath } from 'node:url';
 import { classifySector, slugify } from './lib/employer-sectors.mjs';
 import { apexDomain, extractCompanyEmails, pickBestEmail, inferPatternEmail } from './lib/email-finder.mjs';
+import { extractDdgDomains, guessDomains, rankDomains } from './lib/domain-finder.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
@@ -61,6 +62,28 @@ async function fetchText(url, timeoutMs = 8000) {
 
 async function mxOk(domain) {
   try { const mx = await dns.resolveMx(domain); return Array.isArray(mx) && mx.length > 0; } catch { return false; }
+}
+
+// Find the employer's own domain when the registry lacks it: web search +
+// heuristic guesses, validated by MX + a name-token match (rejects directories).
+let _lastDdg = 0;
+async function findDomain(name) {
+  const wait = 2500 - (Date.now() - _lastDdg); // space DDG calls (avoid throttling)
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  _lastDdg = Date.now();
+  let candidates = [];
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 9000);
+    const r = await fetch('https://html.duckduckgo.com/html/?q=' + encodeURIComponent(name + ' sito ufficiale'),
+      { signal: ctrl.signal, headers: { 'User-Agent': 'Mozilla/5.0', 'Accept-Language': 'it' } });
+    clearTimeout(t);
+    if (r.ok) candidates = extractDdgDomains(await r.text());
+  } catch { /* search unavailable → fall back to guesses */ }
+  candidates.push(...guessDomains(name));
+  const valid = [];
+  for (const d of [...new Set(candidates)]) { if (!ATS_DOMAINS.has(d) && await mxOk(d)) valid.push(d); if (valid.length >= 6) break; }
+  return rankDomains(valid, name)[0] || '';
 }
 
 /**
@@ -144,9 +167,11 @@ async function run() {
     const prev = existing[key] || {};
     const role = roles.get(key)?.role || prev.topRole || '';
     const sector = classifySector(e.name);
-    // Domain: registry website (own domain, ATS-filtered) → fallback apex(careersUrl).
+    // Domain: registry website (own domain, ATS-filtered) → fallback apex(careersUrl)
+    // → web-search discovery (domain-finder) when still unknown.
     const careersApex = apexDomain(e.careersUrl || prev.careersUrl || '');
-    const domain = registryDomains.get(key) || prev.domain || (ATS_DOMAINS.has(careersApex) ? '' : careersApex);
+    let domain = registryDomains.get(key) || prev.domain || (ATS_DOMAINS.has(careersApex) ? '' : careersApex);
+    if (!domain) domain = await findDomain(e.name);
 
     // Never overwrite a manually-set email. Otherwise scrape the own domain.
     let email = prev.email || '';

--- a/scripts/lib/domain-finder.mjs
+++ b/scripts/lib/domain-finder.mjs
@@ -1,0 +1,74 @@
+// Company domain finder — fills the "no domain" gap so the email-finder can
+// scrape an employer's own site. Empirically (research 2026-06-17): a web search
+// ("<name> sito ufficiale") returns the real domain for most companies; a
+// slug.ch/.com guess covers single-word names. Both are validated by (a) an MX
+// record and (b) a name-token overlap (rejects directories like yellowpages /
+// help.ch that a raw search surfaces).
+//
+// Pure helpers are unit-tested; network (search fetch) + DNS live in the caller.
+
+import { apexDomain } from './email-finder.mjs';
+
+// Directories / social / ATS / search engines — never a company's own domain.
+const BLOCK = /(linkedin|facebook|instagram|xing|twitter|^x\.com$|youtube|wikipedia|indeed|lever\.co|greenhouse|workday|jobs\.ch|jobscout24|glassdoor|kununu|google\.|moneyhouse|local\.ch|search\.ch|zefix|yellowpages|help\.ch|dnb\.com|tel\.search|paginegialle|europages|north-data|companyhouse)/i;
+
+const STOPWORDS = new Set(['sa', 'sagl', 'ag', 'gmbh', 'srl', 'spa', 'the', 'group', 'international', 'holding', 'holdings', 'suisse', 'svizzera', 'schweiz', 'switzerland', 'di', 'e', 'la', 'il', 'lo', 'der', 'die', 'das', 'and', 'co']);
+
+/** Significant lowercased, accent-stripped name tokens (≥3 chars, no legal/stop words). */
+export function nameTokens(name) {
+  return String(name || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .split(/[^a-z0-9]+/).filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+/** True when the domain's label shares a ≥3-char token with the company name. */
+export function domainMatchesName(domain, name) {
+  const label = String(domain || '').split('.')[0].replace(/[^a-z0-9]/gi, '').toLowerCase();
+  if (!label) return false;
+  for (const tok of nameTokens(name)) {
+    if (label.includes(tok) || tok.includes(label)) return true;
+  }
+  return false;
+}
+
+/** Parse DuckDuckGo HTML results → candidate apex domains (blocklist-filtered). */
+export function extractDdgDomains(html) {
+  const out = [];
+  for (const m of String(html || '').matchAll(/uddg=([^&"']+)/g)) {
+    try {
+      const u = new URL(decodeURIComponent(m[1]));
+      const a = apexDomain(u.hostname.toLowerCase());
+      if (a && !BLOCK.test(a) && !out.includes(a)) out.push(a);
+    } catch { /* skip */ }
+    if (out.length >= 8) break;
+  }
+  return out;
+}
+
+/** Heuristic domain guesses for a company name (single-word + acronym). */
+export function guessDomains(name) {
+  const toks = nameTokens(name);
+  const out = [];
+  if (toks[0]) { out.push(`${toks[0]}.ch`, `${toks[0]}.com`); }
+  // acronym of first letters (e.g. "USI", "EOC") when 2–4 significant tokens
+  const allToks = String(name || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  if (allToks.length >= 2 && allToks.length <= 4) {
+    const acr = allToks.map((t) => t[0]).join('');
+    if (acr.length >= 2) out.push(`${acr}.ch`);
+  }
+  return [...new Set(out)];
+}
+
+/**
+ * Rank validated candidates: prefer .ch (Swiss employers), then name-match
+ * strength (shorter label = stronger), drop non-name-matching directories.
+ * `candidates` must already be MX-validated by the caller.
+ */
+export function rankDomains(candidates, name) {
+  const matched = [...new Set(candidates)].filter((d) => domainMatchesName(d, name));
+  return matched.sort((a, b) => {
+    const ch = (b.endsWith('.ch') ? 1 : 0) - (a.endsWith('.ch') ? 1 : 0);
+    if (ch) return ch;
+    return a.split('.')[0].length - b.split('.')[0].length;
+  });
+}

--- a/tests/domain-finder.test.ts
+++ b/tests/domain-finder.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { nameTokens, domainMatchesName, extractDdgDomains, guessDomains, rankDomains } from '../scripts/lib/domain-finder.mjs';
+
+describe('nameTokens', () => {
+  it('strips legal/stop words + accents, keeps ≥3-char tokens', () => {
+    expect(nameTokens('Fondazione La Fonte SA')).toEqual(['fondazione', 'fonte']);
+    expect(nameTokens('ALDI SUISSE')).toEqual(['aldi']); // suisse is a stopword
+    expect(nameTokens('Rapelli - ORIOR Food AG')).toEqual(['rapelli', 'orior', 'food']);
+  });
+});
+
+describe('domainMatchesName (rejects directories, keeps real domains)', () => {
+  it('matches when label shares a name token', () => {
+    expect(domainMatchesName('lafonte.ch', 'Fondazione La Fonte')).toBe(true);
+    expect(domainMatchesName('aldi-suisse.ch', 'ALDI SUISSE')).toBe(true);
+    expect(domainMatchesName('eoc.ch', 'EOC Ente Ospedaliero Cantonale')).toBe(true);
+    expect(domainMatchesName('rapelli.ch', 'Rapelli ORIOR')).toBe(true);
+  });
+  it('rejects unrelated directory domains', () => {
+    expect(domainMatchesName('yellowpages.swiss', 'Ticino Premium Properties')).toBe(false);
+    expect(domainMatchesName('help.ch', 'Ticino Premium Properties')).toBe(false);
+  });
+});
+
+describe('extractDdgDomains', () => {
+  it('parses uddg result links to apex domains, filters social/directories', () => {
+    const html = `
+      <a href="//duckduckgo.com/l/?uddg=${encodeURIComponent('https://www.lafonte.ch/chi-siamo')}">x</a>
+      <a href="//duckduckgo.com/l/?uddg=${encodeURIComponent('https://linkedin.com/company/lafonte')}">y</a>
+      <a href="//duckduckgo.com/l/?uddg=${encodeURIComponent('https://yellowpages.swiss/lafonte')}">z</a>`;
+    expect(extractDdgDomains(html)).toEqual(['lafonte.ch']); // linkedin + yellowpages dropped
+  });
+});
+
+describe('guessDomains', () => {
+  it('produces slug.ch/.com + acronym.ch', () => {
+    expect(guessDomains('USI Università della Svizzera italiana')).toContain('usi.ch');
+    expect(guessDomains('Rapelli AG')).toEqual(expect.arrayContaining(['rapelli.ch', 'rapelli.com']));
+  });
+});
+
+describe('rankDomains', () => {
+  it('keeps only name-matching, prefers .ch then shorter label', () => {
+    expect(rankDomains(['coop.it', 'coop.ch', 'help.ch'], 'Coop')).toEqual(['coop.ch', 'coop.it']);
+    expect(rankDomains(['yellowpages.swiss'], 'Ticino Premium Properties')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Contesto

Chiude il collo di bottiglia "no domain" che bloccava l'email-finder (#2470): per molte aziende il registry ha solo un URL ATS o nulla → nessun dominio su cui scrapare. Questo lo scopre.

## Verifica (empirica, sui target reali)

- **DuckDuckGo HTML search** ("<nome> sito ufficiale") restituisce il dominio reale per la maggior parte: Fondazione La Fonte→`lafonte.ch`, USI→`usi.ch`, ALDI→`aldi-suisse.ch`, Lidl→`lidl.ch`, Swisscom→`swisscom.ch`, EOC→`eoc.ch`.
- **Guess `slug.ch`/acronimo.ch** copre i nomi singoli (usi.ch, rapelli.ch).
- **MX-verify + name-token match** scarta le directory (yellowpages/help.ch) che la ricerca grezza fa emergere.

## Implementato

- **`scripts/lib/domain-finder.mjs`** (puro, **6 unit test**): `nameTokens` (droppa legal/stop words), `domainMatchesName` (overlap token → rifiuta directory), `extractDdgDomains`, `guessDomains`, `rankDomains` (solo name-match, preferisce `.ch` poi label più corta).
- **`enrich-employer-contacts.mjs`**: quando manca il dominio, `findDomain()` fa una ricerca DDG rate-limited + guess euristici, valida ogni candidato con MX + name-match, sceglie il migliore → poi parte il flusso esistente scrape/MX/pattern.

Live: **USI (`info@usi.ch`)** e **Fondazione La Fonte (`info@lafonte.ch`)** erano "no domain", ora risolvono + danno un'email scraped; email verificate da **2 → 5 su 16**.

## Non implementato (ancora)

- **Multinazionali/enti pubblici** (ALDI/Lidl/Coop/Swisscom/EOC/Lugano): dominio trovato ma niente email-contatto semplice (usano portali/form) → restano "no email". È il tetto realistico del metodo gratuito.
- **Ticino Premium Properties**: presenza web debole, dominio non trovato in modo affidabile.
- **Rate-limit DDG**: mitigato con spacing ~2.5s tra le richieste; per liste molto grandi servirebbe un backoff.

## Test plan

- [x] `npx vitest run` domain-finder (6) + email-finder (16 totali col precedente) verdi.
- [x] `node --check` enrich OK; run live 16 target → 5 email verificate (USI/La Fonte sbloccate dal domain-finder).
- [ ] Typecheck via CI.