### PR TITLE
fix(build): shard-aware sitemap keep for cluster cross-locale locs (#2477)

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -89,7 +89,7 @@ import {
   type RawJob,
 } from './relatedSearchClustersData';
 import { jobsSeoPagesFlushed } from './shared/buildSignals';
-import { shouldEmitLocale } from './shared/localeEmitFilter';
+import { shouldEmitLocale, EMIT_ALL_LOCALES, localeOfDistPath } from './shared/localeEmitFilter';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import {
   startTimer as profileStart,
@@ -2041,8 +2041,22 @@ function normalizeLocForCanonicalCmp(u: string): string {
  * (no counter); this path collapses both `existsSync` probes into the
  * `readFile` attempts and flags `DROP_MISSING` only for logging-skip — the
  * net output is identical (loc absent from result, no log line).
+ *
+ * Locale-shard awareness (BUILD_LOCALE, LOCALE-SHARD-BUILD-PLAN Fase 0):
+ * on a single-locale shard the render-skip branch pushes a complete
+ * cross-locale `sitemapLocs` set (cheap, string-only) so the it/main shard's
+ * `sitemap-search-clusters.xml` stays complete — but the EN/DE/FR cluster
+ * HTML for the non-owned locales is NEVER written to dist (WriteCollector.add
+ * gates it via shouldEmitPath). Without a guard the file-existence check below
+ * would flag every cross-shard loc as DROP_MISSING and silently truncate the
+ * sitemap to IT-only. So a loc whose OWNING locale this shard does not emit is
+ * KEPT unconditionally (it lives on another shard; the dist-file absence is
+ * expected, not a broken/overwritten URL). This mirrors hreflangGuard's
+ * `!shouldEmitLocale → keep` short-circuit (build-plugins/shared/hreflangGuard.ts).
+ * No-op in the default all-locale build (EMIT_ALL_LOCALES short-circuits to the
+ * unconditional file-existence path → byte-identical sitemap).
  */
-async function dropOverwrittenLocs(
+export async function dropOverwrittenLocs(
   distDir: string,
   locs: ReadonlyArray<string>,
 ): Promise<string[]> {
@@ -2069,6 +2083,14 @@ async function dropOverwrittenLocs(
       const i = cursor++;
       const loc = locs[i];
       const urlPath = new URL(loc).pathname.replace(/\/+$/, '');
+      // Cross-shard keep: when running a single-locale shard, a loc whose
+      // owning locale this shard does not emit has no HTML on disk by design —
+      // keep it so the it/main shard's sitemap stays complete. Skipped entirely
+      // in the default build (EMIT_ALL_LOCALES) so behaviour is byte-identical.
+      if (!EMIT_ALL_LOCALES && !shouldEmitLocale(localeOfDistPath(urlPath, ''))) {
+        flags[i] = KEEP;
+        continue;
+      }
       const indexPath = path.join(distDir, urlPath, 'index.html');
       const flatPath = path.join(distDir, urlPath + '.html');
       let html: string | null = null;

--- a/docs/LOCALE-SHARD-BUILD-PLAN.md
+++ b/docs/LOCALE-SHARD-BUILD-PLAN.md
@@ -52,11 +52,26 @@ prep (1 runner)                    build-locale (matrix ×4 paralleli)
 
 ## Fasi (1 PR ciascuna, gate misurabile)
 
-- **Fase 0 — Prototipo di misura** *(questa PR)*. Render-skip in
+- **Fase 0 — Prototipo di misura** *(PR #2473)*. Render-skip in
   `related-search-clusters` (1 loop, 264s, isolato). Preserva il bookkeeping
   cross-locale cheap (`sitemapLocs` + `crossSectionMirrorLocs` via
   `buildClusterPath`, senza render). Gate: clusters ~264→~70s su uno shard,
   validate verde, sitemap del main-shard completa.
+  - **Hardening consumer sitemap (follow-up #2477).** Il ramo skip alimenta
+    `sitemapLocs` con un set cross-locale completo, ma il consumer a valle
+    `writeSitemap → dropOverwrittenLocs` **rilegge l'HTML in `dist/`** di ogni
+    loc per droppare URL noindex/non-self-canonical. Su uno shard
+    `BUILD_LOCALE=it` l'HTML cluster EN/DE/FR non è mai scritto (gated da
+    `WriteCollector.add`→`shouldEmitPath`), quindi senza guard ogni loc
+    cross-shard verrebbe flaggato `DROP_MISSING` → `sitemap-search-clusters.xml`
+    troncato a IT-only. Fix: in `dropOverwrittenLocs` un loc il cui locale
+    *owner* non è emesso da questo shard viene **tenuto incondizionatamente**
+    (vive su un altro shard; assenza del file attesa, non URL rotto), come fa
+    `hreflangGuard` con `!shouldEmitLocale → keep`. Default build
+    (`EMIT_ALL_LOCALES`) byte-identico. Il consumer `crossSectionMirrorLocs` →
+    `dropMirrorLocsFromSitemapJobs` (patch #911) è invece già safe: è un drop
+    per-membership su `sitemap-jobs.xml` (file di un altro plugin), senza
+    rilettura dell'HTML cluster. Guard pinnato da `tests/sitemap-clusters-shard-keep.test.ts`.
 - **Fase 1 — `jobs-seo-pages` (856s, 34 loop)**. Render-skip per loop, ognuno
   dopo lo stato cross-locale (pattern `emittedActiveJobPaths`→sitemap r.8642;
   slug-map pre-loop hreflang). La parte grossa.

--- a/tests/sitemap-clusters-shard-keep.test.ts
+++ b/tests/sitemap-clusters-shard-keep.test.ts
@@ -1,0 +1,98 @@
+/**
+ * LOCALE-SHARD-BUILD-PLAN Fase 0 (follow-up #2477) — sitemap completeness on a
+ * single-locale shard build.
+ *
+ * `relatedSearchClustersPlugin` builds `sitemap-search-clusters.xml` by passing
+ * the full cross-locale loc set through `dropOverwrittenLocs`, which reads each
+ * loc's HTML in dist/ to drop noindex / non-self-canonical / overwritten URLs.
+ *
+ * On a `BUILD_LOCALE=<locale>` shard the render-skip branch pushes a COMPLETE
+ * cross-locale loc set (cheap, string-only) but the EN/DE/FR cluster HTML for
+ * the non-owned locales is never written to dist (WriteCollector gates it). The
+ * file-existence drop must therefore KEEP cross-shard locs unconditionally,
+ * otherwise the it/main shard ships an IT-only sitemap.
+ *
+ * Env is read once at module load (localeEmitFilter parses BUILD_LOCALE), so
+ * each scenario sets the var and re-imports via vi.resetModules().
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+async function loadPlugin(buildLocale: string | undefined) {
+  vi.resetModules();
+  const prev = process.env.BUILD_LOCALE;
+  if (buildLocale === undefined) delete process.env.BUILD_LOCALE;
+  else process.env.BUILD_LOCALE = buildLocale;
+  try {
+    return await import('../build-plugins/relatedSearchClustersPlugin');
+  } finally {
+    if (prev === undefined) delete process.env.BUILD_LOCALE;
+    else process.env.BUILD_LOCALE = prev;
+  }
+}
+
+const BASE = 'https://frontaliereticino.ch';
+const IT = `${BASE}/cerca-lavoro-ticino/ricerca-data-center-technician/`;
+const EN = `${BASE}/en/find-jobs-ticino/search-data-center-technician/`;
+const DE = `${BASE}/de/jobs-im-tessin/suche-data-center-technician/`;
+const FR = `${BASE}/fr/trouver-emploi-tessin/recherche-data-center-technician/`;
+
+// Self-canonical, indexable HTML — the KEEP case for a present file.
+const okHtml = (loc: string) =>
+  `<!doctype html><html><head><link rel="canonical" href="${loc}"></head><body></body></html>`;
+
+let dist: string;
+
+beforeEach(() => {
+  // dist with ONLY the IT cluster page on disk (simulates an it-shard build,
+  // where en/de/fr cluster HTML was gated out of the WriteCollector).
+  dist = fs.mkdtempSync(path.join(os.tmpdir(), 'cluster-sitemap-shard-'));
+  const itDir = path.join(dist, 'cerca-lavoro-ticino', 'ricerca-data-center-technician');
+  fs.mkdirSync(itDir, { recursive: true });
+  fs.writeFileSync(path.join(itDir, 'index.html'), okHtml(IT));
+});
+
+afterEach(() => {
+  fs.rmSync(dist, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe('dropOverwrittenLocs — default build (no BUILD_LOCALE) unchanged', () => {
+  it('drops cross-locale locs whose HTML is absent on disk', async () => {
+    const { dropOverwrittenLocs } = await loadPlugin(undefined);
+    const kept = await dropOverwrittenLocs(dist, [IT, EN, DE, FR]);
+    // Only IT exists on disk → en/de/fr dropped as DROP_MISSING (status quo).
+    expect(kept).toEqual([IT]);
+  });
+});
+
+describe('dropOverwrittenLocs — it shard keeps cross-shard cluster locs', () => {
+  it('keeps en/de/fr (other shards own them) + the present it self-ref', async () => {
+    const { dropOverwrittenLocs } = await loadPlugin('it');
+    const kept = await dropOverwrittenLocs(dist, [IT, EN, DE, FR]);
+    // it is real-checked (exists + self-canonical → kept); en/de/fr not emitted
+    // by this shard → kept unconditionally so the sitemap stays complete.
+    expect(kept).toEqual([IT, EN, DE, FR]);
+  });
+
+  it('preserves input order across the keep + check mix', async () => {
+    const { dropOverwrittenLocs } = await loadPlugin('it');
+    const kept = await dropOverwrittenLocs(dist, [EN, IT, FR, DE]);
+    expect(kept).toEqual([EN, IT, FR, DE]);
+  });
+});
+
+describe('dropOverwrittenLocs — en shard still real-checks its own locale', () => {
+  it('drops a missing en page it owns, keeps cross-shard it/de/fr', async () => {
+    // en-shard: en page is OWNED → subject to the file-existence check. Here the
+    // en HTML is absent on disk → must be dropped (genuine broken/missing URL),
+    // while it/de/fr (other shards) are kept unconditionally.
+    const { dropOverwrittenLocs } = await loadPlugin('en');
+    const kept = await dropOverwrittenLocs(dist, [IT, EN, DE, FR]);
+    expect(kept).toEqual([IT, DE, FR]); // EN dropped (owned + missing)
+    expect(kept).not.toContain(EN);
+  });
+});


### PR DESCRIPTION
## Contesto

Follow-up #2477 dell'adversarial check su PR #2473 (Fase 0 di `docs/LOCALE-SHARD-BUILD-PLAN.md`). L'item deferito chiedeva di **tracciare il consumer di `sitemapLocs`/`crossSectionMirrorLocs` a valle** (`writeSitemap` / patch issue #911) per escludere che dipenda da stato del collector che il ramo skip omette.

**Finding (confermato, era un rischio reale):** il consumer `writeSitemap → dropOverwrittenLocs` **rilegge l'HTML in `dist/`** di ogni loc per droppare URL noindex/non-self-canonical/overwritten. Su uno shard `BUILD_LOCALE` il ramo render-skip pusha un set `sitemapLocs` cross-locale completo, ma l'HTML cluster dei locali non-owned non viene mai scritto in `dist/` (gated da `WriteCollector.add → shouldEmitPath`). Senza guard ogni loc cross-shard veniva flaggato `DROP_MISSING` → `sitemap-search-clusters.xml` troncato a **IT-only** sull'it/main shard. È la stessa classe di bug già risolta da `hreflangGuard` (`!shouldEmitLocale → keep`), che però mancava nel path sitemap.

`crossSectionMirrorLocs → dropMirrorLocsFromSitemapJobs` (patch #911) è invece **già safe**: drop per-membership su `sitemap-jobs.xml` (file di un altro plugin), nessuna rilettura dell'HTML cluster.

## Implementato

- **`build-plugins/relatedSearchClustersPlugin.ts`**: in `dropOverwrittenLocs`, un loc il cui locale *owner* (`localeOfDistPath`) non è emesso da questo shard viene **tenuto incondizionatamente** (vive su un altro shard; assenza del file attesa). Short-circuit su `EMIT_ALL_LOCALES` → default build (`BUILD_LOCALE` unset) **byte-identico**. Esportata la funzione per il test.
- **`tests/sitemap-clusters-shard-keep.test.ts`**: pin del comportamento — default build droppa i loc cross-locale assenti (status quo); it-shard tiene en/de/fr + il self-ref it presente, preservando l'ordine; en-shard droppa una sua pagina owned ma mancante, tiene i cross-shard. 4 test, verdi.
- **`docs/LOCALE-SHARD-BUILD-PLAN.md`**: documentato l'hardening sotto Fase 0, con la distinzione safe/at-risk dei due consumer.

## Sibling-class check

Unico sibling con consumer sitemap che rilegge dist HTML per loc cross-locale. Verificati e NON affetti:
- `hreflangPostprocessPlugin.ts`: ha già il short-circuit shard-aware (`!EMIT_ALL_LOCALES && !shouldEmitLocale(ownerEmitLocale(locale)) → keep`).
- `jobsSeoPagesPlugin.ts`: costruisce la sitemap dal Set in-memory `emittedActiveJobPaths` (popolato per tutti i locali prima dello skip), non da un re-scan di `dist/`.

## Non implementato (ancora)

- **Estrazione del bookkeeping loc/mirror in helper condiviso**: deferita alla Fase 1/2 come da piano (`## Non implementato` di #2473). Questa PR fixa solo il consumer at-risk.
- **Render-skip di `jobs-seo-pages`/`orphan-query-landings` (Fasi 1-2) e wiring prod (`deploy.yml`)**: fuori scope, fasi successive del piano.
- **Misura wall-time live (`deploy-matrix-experiment`)**: claim non verificabile pre-merge (build SSG OOM-prone gira solo post-merge). Nessun claim di build green/memoria fabbricato; il guard è validato da unit test deterministici, non da una build completa.

## Test plan

- [x] `npx vitest run tests/sitemap-clusters-shard-keep.test.ts tests/sitemap-jobs-mirror-drop.test.ts tests/locale-emit-filter.test.ts tests/hreflang-guard-shard.test.ts` → 24 verdi
- [x] `tsc --noEmit` sui file toccati: nessun errore
- [x] `dropOverwrittenLocs` impact (GitNexus): LOW, unico caller `writeSitemap` (intra-plugin), contratto signature invariato

Closes #2477

🤖 Generated with [Claude Code](https://claude.com/claude-code)