### PR TITLE
fix(publisher): remove managed_payments — broke every per-ad checkout (400)

### DIFF
--- a/functions/src/stripePublisherCore.js
+++ b/functions/src/stripePublisherCore.js
@@ -218,7 +218,11 @@ export async function handleCreatePublisherCheckout(req) {
     customer: customerId,
     line_items: [{ price: priceId, quantity: units }],
     discounts: couponId ? [{ coupon: couponId }] : undefined,
-    managed_payments: { enabled: true },
+    // NB: `managed_payments` was removed — Stripe rejects it (400 "product tax
+    // code is missing") unless the price's product has an eligible tax_code, so
+    // it broke every per-ad checkout. Re-enable only after setting tax_code on
+    // the products (Managed Payments). Verified live 2026-06-18: without it the
+    // session creates 200 OK; with it, 400.
     success_url: successUrl,
     cancel_url: cancelUrl,
     client_reference_id: orderRef.id,


### PR DESCRIPTION
## 🔴 Bug critico (blocca i ricavi)

Il checkout per-annuncio sponsorizzato usava `managed_payments: { enabled: true }`. **Verificato live contro l'API Stripe:**
- Sessione **senza** il param → **200 OK** (checkout funziona).
- Sessione **con** il param → **400** `"the product tax code is missing. You must set the product's tax_code to one eligible for Managed Payments."`

Il prodotto del price ad-unit non ha `tax_code` → **ogni** checkout per-annuncio falliva: nessun cliente poteva comprare uno sponsorizzato. (Spiega perché non risultavano acquisti reali dopo il go-live Stripe.)

## Implementato

- Rimosso `managed_payments` dal checkout per-annuncio (`handleCreatePublisherCheckout`). Il checkout azienda (#2435) già non lo usa → ora i due path sono coerenti e funzionanti.
- Commento che documenta il motivo + la condizione per riabilitare Managed Payments (assegnare `tax_code` eleggibili ai prodotti).

## Non implementato (ancora)

- **Managed Payments vero** (gestione tax/compliance via Stripe): richiede `tax_code` sui prodotti — scelta deliberata, follow-up se desiderato. Per ora il checkout standard funziona.

## Test plan

- [x] Verifica live API Stripe: senza param 200, con param 400 (tax code missing).
- [x] `node --check` functions OK.
- [ ] Post-deploy (deploy-cloud-functions auto su functions/**): test reale di un checkout per-annuncio in Stripe → sessione creata + pagamento test completato.