### PR TITLE
perf(boot): defer PostHog init off the React-boot critical path (#2350)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -96,14 +96,18 @@ import { useNavigationState } from '@/hooks/useNavigationState';
 import { setDefaultConsent } from '@/services/consentService';
 import { prefetchTab } from '@/services/prefetch';
 import { installBlogImageCdnFallback } from '@/services/seo/blogImageCdn';
-import { initPostHog } from '@/services/posthog';
 import { useSeoPageTracking } from '@/hooks/useSeoPageTracking';
 import { useKillSwitches } from '@/hooks/useKillSwitches';
 // CookieBanner removed — consent is silently granted by default (see consentService.ts)
 // Set consent defaults ASAP (before any analytics/ad scripts load)
 setDefaultConsent();
-// Initialize PostHog EU Cloud analytics (async, non-blocking)
-initPostHog();
+// PostHog init is NOT eager here: firing it at module-eval pulled posthog-js +
+// the session-recorder onto the main thread DURING the React boot, competing with
+// vendor-react + the lazy JobBoard chunk in the LCP/TBT window (~336ms of recorder
+// + array.js main-thread work measured on /cerca-lavoro-ticino/, Lighthouse #2350).
+// It now runs in the deferred, consent-gated idle path in hooks/useUIState.ts
+// alongside Analytics/Clarity/webVitals (FRO-329) — queued captures still flush via
+// ensurePostHog(), so no events are lost.
 // SEO helpers live in hooks/seoHelpers.ts — shared between App.tsx and extracted hooks.
 import { updateMetaTags, trackSectionView } from '@/hooks/seoHelpers';
 import { useTranslation, getCantonI18nParams } from '@/services/i18n';

--- a/hooks/useUIState.ts
+++ b/hooks/useUIState.ts
@@ -16,6 +16,7 @@ import type { ActiveTab } from '@/services/router';
 import { enableRuntimeSeo } from '@/hooks/seoHelpers';
 
 import { Analytics, unlockAchievement, fireCalcEntryIfNeeded } from '@/services/analyticsProxy';
+import { initPostHog } from '@/services/posthog';
 
 export interface UIState {
  isDarkMode: boolean;
@@ -104,6 +105,13 @@ export function useUIState(activeTab: ActiveTab): UIState {
  // Idempotent via sessionStorage so it never double-fires.
  fireCalcEntryIfNeeded(`${window.location.pathname}${window.location.search}${window.location.hash}`);
  Analytics.initGlobalErrorTracking();
+ // PostHog (analytics + sampled session replay) moved here from App.tsx
+ // module-eval: eager init loaded posthog-js + the recorder onto the main
+ // thread during the React boot, competing with the LCP/TBT critical window
+ // on the heaviest SPA route (/cerca-lavoro-ticino/, Lighthouse #2350).
+ // Deferring it to this consent-gated idle path keeps it off the boot path;
+ // queued captures still flush via ensurePostHog() so no events are lost.
+ initPostHog();
  import('@/services/webVitals').then(m => m.initWebVitals()).catch(() => {});
  import('@/services/clarity').then(m => m.initClarity()).catch(() => {});
  };


### PR DESCRIPTION
## Implementato

Fix root-cause della regressione Lighthouse ricorrente (#2350). L'unico URL che sfora il budget perf è `/cerca-lavoro-ticino/` (score **0.46**, soglia 0.60): la route SPA più pesante. Report mediano del run #27737989065: **LCP 4.5s (render-delay 97%)**, **TBT 630ms**, TTI 6.3s, CLS 0.003 (ottimo → AdSense safe). Le altre 5 URL passano.

Diagnosi: l'hero (elemento LCP) non è gated dai dati e il chunk `JobBoard.js` è già `modulepreload`-ato → il ritardo è puramente **contesa main-thread durante il boot React**. `initPostHog()` girava a **module-eval di `App.tsx`**, tirando `posthog-js` + il session-recorder sul main thread durante il boot (misurati ~336ms: posthog-recorder 197ms + array.js 139ms) in competizione con `vendor-react` e il render dell'hero.

- `App.tsx`: rimosso l'`initPostHog()` eager dal module-eval (+ import).
- `hooks/useUIState.ts`: `initPostHog()` spostato nel path idle consent-gated esistente (`run()`, FRO-329), insieme a `Analytics`/`Clarity`/`webVitals`. I capture in coda continuano a fluire via `ensurePostHog()` → nessun evento perso; init idempotente.

Nessun impatto su SEO/CLS/Auto-Ads: la modifica tocca solo il timing di init di un tool di analytics, non rimuove nulla.

### Confronto lab vs utenti reali (richiesto)
Field p75 ultimi 14gg (PostHog `$web_vitals` + Cloudflare RUM GraphQL):
- **`/cerca-lavoro-ticino/` desktop**: LCP 186ms (PH) / 696ms (CF) — **~6-24× più veloce del lab 4.5s**. Il LCP lab è un artefatto cold-cache, non l'esperienza reale.
- **Mobile**: LCP 1.4-1.9s (< 2.5s, PASS).
- **INP**: 248ms desktop / **480ms mobile** (> 200ms) → è il **vero** problema di campo, coerente col segnale TBT/FID del lab. Questa fix riduce la contesa main-thread al boot → aiuta sia il TBT lab sia l'INP reale.
- **CLS**: borderline mobile (0.09-0.19), non su questa route nello specifico.

Verdetto: LCP lab = falso allarme vs campo; la leva utile è ridurre il main-thread work, che è esattamente ciò che fa questa PR.

## Non implementato (ancora)

- **Validazione perf pre-merge impossibile** (il Lighthouse CI gira solo post-deploy su `main`; build SEO locale OOM). **Revert-trigger**: se il prossimo audit post-deploy resta < 0.60 su `/cerca-lavoro-ticino/` o un deploy regredisce, questa PR va integrata/rivista con la leva successiva (sotto), non revertata da sola — è un miglioramento netto del boot a prescindere dal gate.
- **Yield del `finalize()` (normalize+dedupe di ~5564 job, ~810ms "Unattributable")**: secondo grande eater main-thread, ma è il data-path core di un componente da 8000 righe → fuori scope (rischio alto), follow-up dedicato per INP mobile.
- **INP mobile 480ms** (riduzione filtri/keystroke sul corpus completo): scope separato, non in questa PR.
- **Sibling-pattern check**: `check-sibling-patterns.mjs` ha segnalato `services/posthog.ts`/`constants.ts`/`botPatterns.ts` per i token `ensurePostHog`/`initPostHog`, ma sono le *definizioni*/reference della funzione, non altri call-site eager a module-eval. L'unico call-site eager era `App.tsx` (verificato via grep + GitNexus impact upstream: 1 solo dependent diretto). Nessun sibling da sweepare.

## Test
- [x] `vitest run tests/services/posthog.test.ts tests/hooks/useUIState.test.ts` → 10/10 pass
- [x] `tsc --noEmit`: zero errori nei file toccati (gli errori residui sono pre-esistenti in altri file/test)
- [x] GitNexus `detect_changes`: risk low, 0 processi affected
- [ ] Post-deploy: verifica perf score `/cerca-lavoro-ticino/` ≥ 0.60 sul prossimo Lighthouse CI (issue auto-chiude al pass)

Closes #2350