### PR TITLE
fix(quality-alerts): stop filing spurious "Workflow Failure" bug for intentional alerts (#2288)

### DIFF
--- a/.github/workflows/quality-alerts.yml
+++ b/.github/workflows/quality-alerts.yml
@@ -17,7 +17,21 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: node scripts/quality-alerts.mjs
+      - name: Run quality alerts
+        id: alerts
+        run: |
+          # quality-alerts.mjs exits with a DISTINCT code (8 = ALERT_SIGNAL_EXIT)
+          # when a fresh P0/P1 alert is active. That non-zero exit turns the job
+          # red on purpose so GitHub's native workflow-failure email reaches the
+          # maintainer — it is the alert delivery channel, NOT an infra bug.
+          # Capture the code so the "Report failure" step can tell that
+          # intentional signal apart from a genuine crash (exit 1) and avoid
+          # filing a spurious "Workflow Failure" bug issue for every alert (#2288).
+          set +e
+          node scripts/quality-alerts.mjs
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit "$code"
       - name: Commit alert state
         if: always()
         run: |
@@ -62,7 +76,11 @@ jobs:
           exit 1
 
       - name: Report failure to GitHub Issues
-        if: failure()
+        # Skip when the failure is an intentional quality alert (exit code 8 =
+        # ALERT_SIGNAL_EXIT): the red job + native email are the alert channel,
+        # not an infra bug. Any other failure (genuine crash = 1, or an earlier
+        # step like npm ci where exit_code is unset) still files the bug issue.
+        if: failure() && steps.alerts.outputs.exit_code != '8'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/quality-alerts.mjs
+++ b/scripts/quality-alerts.mjs
@@ -4,8 +4,18 @@
 // Phase 5 — quality-alerts daily runner. Loads evidence, quota state, the
 // last N article sidecars and embedding meta, dispatches the four detector
 // categories, applies snoozer logic, writes the GitHub job summary, and
-// exits 1 when any P0/P1 alert is active (so the workflow fails and
+// exits non-zero when any P0/P1 alert is active (so the workflow fails and
 // GitHub's native email goes out).
+//
+// Exit codes:
+//   0                   — healthy / only snoozed alerts.
+//   ALERT_SIGNAL_EXIT   — an active P0/P1 alert fired. This is an INTENTIONAL
+//                         signal, not a crash: the red job triggers the
+//                         maintainer email, and the workflow's failure-report
+//                         step skips this code so it does NOT file a spurious
+//                         "Workflow Failure" bug issue (#2288).
+//   1                   — genuine crash (unhandled throw in main()). The
+//                         workflow DOES file an infra-bug issue for this.
 //
 // Spec: docs/superpowers/specs/2026-05-07-traffic-quality-algorithm-design.md § 8
 
@@ -232,10 +242,20 @@ export async function run(opts = {}) {
   };
 }
 
+// Distinct from the crash code (1) so the workflow can tell an intentional
+// quality alert apart from an infrastructure failure. Any non-zero code turns
+// the job red and fires GitHub's native failure email — only the bug-issue
+// filing is gated on this value. See header + .github/workflows/quality-alerts.yml.
+export const ALERT_SIGNAL_EXIT = 8;
+
 async function main() {
   const result = await run();
   console.error(`QUALITY_ALERTS active=${result.activeAlerts.length} snoozed=${result.snoozedAlerts.length} exit=${result.exitCode}`);
-  process.exit(result.exitCode);
+  // run() returns exitCode 1 only for an active P0/P1 alert (a genuine crash
+  // throws and is caught below). Remap that intentional signal to a distinct
+  // process code so the workflow surfaces the red job + email WITHOUT filing a
+  // spurious "Workflow Failure" bug issue (#2288).
+  process.exit(result.exitCode === 1 ? ALERT_SIGNAL_EXIT : result.exitCode);
 }
 
 const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];


### PR DESCRIPTION
## Cosa è / perché si presenta

L'issue #2288 (\"Workflow Failure: Quality alerts\", ricorrente) **non è un bug d'infrastruttura**. Lo script `scripts/quality-alerts.mjs` esce con codice non-zero **by design** quando un alert P0/P1 fresco è attivo: il job rosso fa partire l'email nativa di GitHub sul fallimento workflow — *quella* è il canale di notifica dell'alert. Lo snoozer fa sì che gli alert noti/persistenti (es. `B.5.cluster-stats-degenerate`, snoozato da 38gg) NON falliscano il workflow; va rosso solo quando un alert nuovo non-snoozato compare.

Il problema: lo step generico `Report failure to GitHub Issues` (`if: failure()`) interpretava quell'exit-1 *intenzionale* come un crash → apriva una bug-issue \"Workflow Failure\" a ogni alert nuovo. Run incriminato 2026-06-17 (`active=1`): l'alert attivo era `B.6.embedding-store-outdated` (embedding store fermo a 2642 vs 2707 live, gap 65 > 50). Oggi B.6 è snoozato (fino al 2026-06-24) → `active=0 exit=0`, ecco perché l'issue \"si auto-guarisce\" e poi ricompare al prossimo alert fresco.

## Implementato

- `scripts/quality-alerts.mjs`: `main()` rimappa l'exit dell'alert attivo (run() ritorna 1) a un codice distinto `ALERT_SIGNAL_EXIT=8`. Un crash reale passa ancora dal catch handler → exit 1. Header del file aggiornato con la tabella exit-code (no comment stale, NN#6).
- `.github/workflows/quality-alerts.yml`: lo step `node scripts/quality-alerts.mjs` (ora con `id: alerts`) cattura `$?` in `steps.alerts.outputs.exit_code` (`set +e` + `exit $code`); lo step `Report failure to GitHub Issues` è gated su `failure() && steps.alerts.outputs.exit_code != '8'`. Risultato: un alert tiene job rosso + email (canale preservato) ma NON apre bug-issue; un crash reale (exit 1) o un fallimento upstream (es. `npm ci`, `exit_code` non settato) apre ancora l'issue d'infra.
- Contratto di `run()` invariato (exitCode 1 su P0/P1) → i 5 test di `tests/scripts/quality-alerts.test.ts` restano verdi.

Verifica locale: vitest 5/5 verde; harness con temp-paths conferma alert→exit 8; CLI su dati reali odierni → exit 0 (healthy); YAML parse OK + `if` corretto.

## Non implementato (ancora)

- **Backfill embedding store (B.6)**: lo store è fermo a 2642 articoli (provider refresh era rotto, fix Gemini #2437) e ri-firerà come P1 dopo lo snooze del 2026-06-24. È un problema di pipeline dati separato dal fix workflow di questa PR (scope: notification-conflation) → follow-up, non in scope qui.
- **Sibling sweep**: nessun sibling da fixare. `quality-alerts.mjs` è l'unico script con semantica exit-1-come-segnale (grep design-comment = singleton); i monitor vicini (`dmarc-monitor`, `gh-pat-expiry-monitor`) aprono issue direttamente, non via `failure()`. Le ~12 occorrenze del token `exitCode` segnalate da `check-sibling-patterns.mjs` sono falsi positivi (gestione exit-code generica, non lo stesso antipattern).

Closes #2288

🤖 Generated with [Claude Code](https://claude.com/claude-code)