### PR TITLE
fix(ci): bump actions/cache@v4 → @v5 in build-evidence-and-tune (Node 24)

### DIFF
--- a/.github/workflows/build-evidence-and-tune.yml
+++ b/.github/workflows/build-evidence-and-tune.yml
@@ -23,7 +23,7 @@ jobs:
       # build-article-embeddings.mjs doesn't re-download it every run (~5 min).
       # No API key involved — purely a CDN artifact cache.
       - name: Cache local embedding model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cache/transformers
           key: transformers-multilingual-e5-small-v1


### PR DESCRIPTION
## Implementato

- `.github/workflows/build-evidence-and-tune.yml`: bump `actions/cache@v4` → `actions/cache@v5`.

PR #2497 (`feat(embeddings): local ONNX embeddings`) ha aggiunto questo workflow con `actions/cache@v4` (runtime Node 20). Il gate `lint-gha-node-runtime` (girato dentro il job vitest) **fallisce** su qualsiasi action first-party su Node < 24 → `main` è rosso da quel commit e ogni branch lo eredita (vitest rosso a cascata, blocca auto-merge anche per PR LGTM-ate, es. #2500). `@v5` gira su Node 24, allineato a ogni altro ref first-party del repo (`checkout@v5`, `setup-node@v5`, `upload-artifact@v7`).

Verifica locale: `node scripts/lint-gha-node-runtime.mjs` → `OK — 1177 first-party action ref(s) on Node ≥ 24`, exit 0 (prima: `FAIL — 1 first-party action ref(s)`).

## Non implementato (ancora)

- Nessun altro ref stale da bumpare: il lint segnalava **1 sola** ref first-party; `git grep` di `actions/(checkout|setup-node|upload-artifact|download-artifact|cache)@v[1-4]` su tutti i 552 workflow → solo questa occorrenza. Classe interamente coperta.
- Le 8 ref third-party che il lint salta (runtime non staticamente noto) restano gestite da Dependabot / review manuale, fuori scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)