### PR TITLE
fix(ci): bump last actions/cache@v4→v5 (Node 24 runtime) — unblocks main-red

### DIFF
--- a/.github/workflows/build-evidence-and-tune.yml
+++ b/.github/workflows/build-evidence-and-tune.yml
@@ -23,7 +23,7 @@ jobs:
       # build-article-embeddings.mjs doesn't re-download it every run (~5 min).
       # No API key involved — purely a CDN artifact cache.
       - name: Cache local embedding model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cache/transformers
           key: transformers-multilingual-e5-small-v1


### PR DESCRIPTION
## Implementato
- `.github/workflows/build-evidence-and-tune.yml:26`: `actions/cache@v4` → `actions/cache@v5`. Era l'**unico** first-party action ref rimasto su Node 20: il gate `lint-gha-node-runtime` (eseguito in `tests.yml`) falliva → tutti i vitest shard rossi su `main` (run 06:03) e su ogni branch rebasato (es. PR #2494 head `69c0fc02`). GitHub sposta il default runtime Actions a Node 24 (2026-06-02) e rimuove node20 (2026-09-16); il linter floora i first-party ref a Node ≥24. `cache@v5` = Node 24 (da `NODE_RUNTIME_BY_ACTION`).
- Sibling sweep: `grep -rn 'actions/cache@v[0-9]'` su `.github/workflows/` → tutti gli altri ref già `@v5`. Classe intera = questa singola riga. Linter locale verde post-fix (`OK — 1177 first-party ref on Node ≥24`).

## Non implementato (ancora)
- Bump di action third-party (8 ref skippati dal linter: runtime non staticamente noto, owned da Dependabot/review manuale) — fuori scope, non flaggati.
- Auto-recovery dell'auto-merge sulla race "Head branch is out of date" (causa del rerun manuale su PR #2494) — concern separato, PR dedicata a seguire.

## Test plan
- [x] `node scripts/lint-gha-node-runtime.mjs` locale → exit 0 (`OK`).
- [ ] `tests` verde sulla PR (lint+vitest) → main verde post-merge.