### PR TITLE
fix(rpm-canary): gate alert on earnings + never measure the open UTC day (#2176)

### DIFF
--- a/.github/workflows/rpm-canary.yml
+++ b/.github/workflows/rpm-canary.yml
@@ -4,15 +4,22 @@ name: rpm-canary
 # `article-content-canary.yml` (which watches the cause).
 #
 # Runs once a day, pulls daily PAGE_VIEWS_RPM via the AdSense API, and
-# opens a deduplicated GitHub issue if yesterday's RPM is below either
-# of:
-#   - 65% of the trailing 7-day baseline (T-10..T-4), OR
-#   - 1.00 CHF absolute floor
+# opens a deduplicated GitHub issue only when the latest fully-closed
+# day's RPM is down AND earnings confirm it:
+#   - RPM < 65% of the trailing 7-day baseline (T-9..T-3) OR < 1.00 CHF, AND
+#   - earnings < 65% of the baseline earnings.
+#
+# The earnings gate kills false alarms from page-view spikes: RPM is
+# earnings ÷ page views, so a traffic spike with healthy earnings halves
+# RPM without losing a cent (issue #2176, 2026-06-15..17). A real incident
+# collapses earnings too, so the catch is preserved. The still-open current
+# UTC day is never measured (its earnings aren't settled). See
+# scripts/lib/canaryRpmClassify.mjs for the unit-tested classifier.
 #
 # Catches ANY revenue-affecting regression within ~24h — article stubs,
 # ads.txt issues, AdSense policy hits, ad slot misconfig, demand drops.
 # Incident 2026-05-28 (3.04 → 1.74 CHF/day) would have triggered the
-# morning of 2026-05-28 with the ratio fired at 56% of baseline.
+# morning of 2026-05-28: both RPM and earnings cratered (stubs served no ads).
 #
 # Why daily (not hourly): AdSense daily data is only available ~10h
 # after UTC midnight. Hourly cadence would burn API quota on identical
@@ -33,6 +40,11 @@ on:
         description: 'Alert if RPM < absolute_floor CHF. Default 1.0.'
         required: false
         default: '1.0'
+        type: string
+      earnings_floor:
+        description: 'Only alert if earnings also < (earnings_floor × baseline earnings). Default 0.65.'
+        required: false
+        default: '0.65'
         type: string
 
 concurrency:
@@ -86,12 +98,14 @@ jobs:
         env:
           RATIO_FLOOR: ${{ github.event.inputs.ratio_floor || '0.65' }}
           ABSOLUTE_FLOOR: ${{ github.event.inputs.absolute_floor || '1.0' }}
+          EARNINGS_FLOOR: ${{ github.event.inputs.earnings_floor || '0.65' }}
         run: |
           set -o pipefail
           node scripts/canary-rpm.mjs \
             --json \
             --ratio-floor="$RATIO_FLOOR" \
             --absolute-floor="$ABSOLUTE_FLOOR" \
+            --earnings-floor="$EARNINGS_FLOOR" \
             > rpm-canary-result.json 2> rpm-canary.log
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 

--- a/scripts/build-rpm-canary-issue-body.mjs
+++ b/scripts/build-rpm-canary-issue-body.mjs
@@ -59,8 +59,21 @@ lines.push(`| PV-RPM (CHF) | **${r.current.rpm.toFixed(2)}** | ${r.baseline.rpm.
 lines.push(`| Earnings (CHF) | ${r.current.earnings.toFixed(2)} | ${r.baseline.earnings.toFixed(2)} |`);
 lines.push(`| Page views | ${r.current.pageViews} | — |`);
 lines.push("");
-lines.push(`**Ratio current/baseline:** ${(r.ratio * 100).toFixed(0)}%`);
-lines.push(`**Thresholds:** ratio < ${(r.floors.ratio * 100).toFixed(0)}% OR absolute < ${r.floors.absoluteCHF.toFixed(2)} CHF`);
+lines.push(`**RPM ratio current/baseline:** ${(r.ratio * 100).toFixed(0)}%`);
+if (typeof r.earningsRatio === "number") {
+  lines.push(`**Earnings ratio current/baseline:** ${(r.earningsRatio * 100).toFixed(0)}%`);
+}
+const earningsFloorTxt =
+  r.floors && typeof r.floors.earnings === "number"
+    ? ` AND earnings < ${(r.floors.earnings * 100).toFixed(0)}% of baseline`
+    : "";
+lines.push(
+  `**Thresholds:** (RPM ratio < ${(r.floors.ratio * 100).toFixed(0)}% OR absolute < ${r.floors.absoluteCHF.toFixed(2)} CHF)${earningsFloorTxt}`,
+);
+lines.push("");
+lines.push(
+  "> This alert fires only when earnings are ALSO down — a low RPM with healthy earnings is a benign page-view spike (bot/AI crawl or a Discover hit), not lost revenue. Because earnings are confirmed down here, treat it as a real revenue regression and work the checklist below.",
+);
 lines.push("");
 lines.push("### Triggered conditions");
 for (const reason of r.reasons || []) {

--- a/scripts/canary-rpm.mjs
+++ b/scripts/canary-rpm.mjs
@@ -3,14 +3,26 @@
  * canary-rpm.mjs — AdSense RPM crash detector.
  *
  * Pulls daily AdSense PAGE_VIEWS_RPM for the last 14 days, computes a
- * trailing 7-day baseline (days T-10..T-4), compares yesterday (T-1)
- * against it, and exits non-zero if yesterday's RPM is below either of:
- *   - `--ratio-floor` × baseline (default 0.65 → alert when RPM < 65% of baseline)
- *   - `--absolute-floor` CHF (default 1.0 CHF, regardless of baseline)
+ * trailing 7-day baseline (days T-9..T-3), compares the latest fully-closed
+ * day against it, and exits non-zero only when BOTH hold:
+ *   - the RPM signal fires — RPM below `--ratio-floor` × baseline
+ *     (default 0.65) OR below `--absolute-floor` CHF (default 1.0), AND
+ *   - earnings confirm it — current-day earnings below `--earnings-floor`
+ *     × baseline earnings (default 0.65).
+ *
+ * The earnings gate exists because RPM is a ratio (earnings ÷ page views):
+ * a page-view spike with healthy earnings halves RPM without losing a
+ * cent (issue #2176, 2026-06-15..17 — earnings ~5.5 CHF/day while PV
+ * spiked to 3625, so RPM "crashed" to 1.51 with zero lost revenue). A
+ * REAL incident collapses earnings, so gating on earnings keeps the catch
+ * while silencing benign traffic spikes. The classification (and the
+ * "never measure the still-open current UTC day" rule) lives in the
+ * unit-tested lib scripts/lib/canaryRpmClassify.mjs.
  *
  * Why exists: incident 2026-05-28 — AdSense RPM crashed 3.04 → 1.74
  * CHF/day in 48h because ~2,540 of ~2,607 articles started serving a
- * 1.7 KB infinite-redirect stub (no SPA bundle, no ad slots). The
+ * 1.7 KB infinite-redirect stub (no SPA bundle, no ad slots) — earnings
+ * cratered alongside RPM, so the earnings gate still fires. The
  * upstream cause is caught at dist-time by `audit:no-dotfile-html` and
  * at content-time by `article-content-canary.yml`. This RPM canary is
  * the LAST line of defense: catches ANY revenue-affecting regression
@@ -30,10 +42,11 @@
  * Usage:
  *   node scripts/canary-rpm.mjs
  *   node scripts/canary-rpm.mjs --json
- *   node scripts/canary-rpm.mjs --ratio-floor=0.7 --absolute-floor=1.5
+ *   node scripts/canary-rpm.mjs --ratio-floor=0.7 --absolute-floor=1.5 --earnings-floor=0.6
  */
 
 import process from "node:process";
+import { classifyRpm } from "./lib/canaryRpmClassify.mjs";
 
 const args = process.argv.slice(2);
 const wantsJson = args.includes("--json");
@@ -46,9 +59,7 @@ const parseFlag = (name, fallback) => {
 
 const RATIO_FLOOR = parseFlag("ratio-floor", 0.65);
 const ABSOLUTE_FLOOR = parseFlag("absolute-floor", 1.0);
-const BASELINE_DAYS = 7;
-const BASELINE_LAG_DAYS = 3; // baseline ends at T-4 (skips noisy last 3 days)
-const REQUIRED_BASELINE_SAMPLES = 5; // need at least 5 days of baseline data
+const EARNINGS_FLOOR = parseFlag("earnings-floor", 0.65);
 
 const log = (line) => {
   if (wantsJson) console.error(line);
@@ -124,76 +135,17 @@ async function fetchDailyRpm() {
   return { account, rows };
 }
 
-function classify(rows) {
-  if (rows.length < BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES) {
-    return {
-      verdict: "insufficient-data",
-      reason: `need ≥${BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES} days of data, got ${rows.length}`,
-    };
-  }
-  // Latest fully-closed day = the most recent row whose pageViews looks
-  // "complete" (≥ 60% of the prior day's PV). AdSense daily data is
-  // sometimes truncated for the current UTC day until ~10am UTC the next
-  // day, so we drop trailing rows whose PV looks incomplete.
-  let latestClosedIdx = rows.length - 1;
-  if (rows.length >= 2) {
-    const prior = rows[rows.length - 2].pageViews;
-    const last = rows[rows.length - 1].pageViews;
-    if (prior > 0 && last < prior * 0.5) {
-      // The last row is probably still being collected — skip it.
-      latestClosedIdx = rows.length - 2;
-    }
-  }
-  const currentRow = rows[latestClosedIdx];
-  const baselineEnd = latestClosedIdx - (BASELINE_LAG_DAYS - 1);
-  const baselineStart = baselineEnd - BASELINE_DAYS;
-  if (baselineStart < 0 || baselineEnd <= baselineStart) {
-    return { verdict: "insufficient-data", reason: "baseline window underflowed" };
-  }
-  const baselineRows = rows.slice(baselineStart, baselineEnd);
-  if (baselineRows.length < REQUIRED_BASELINE_SAMPLES) {
-    return {
-      verdict: "insufficient-data",
-      reason: `baseline window has ${baselineRows.length} samples, need ${REQUIRED_BASELINE_SAMPLES}`,
-    };
-  }
-  const baselineRpm =
-    baselineRows.reduce((s, r) => s + (r.rpm || 0), 0) / baselineRows.length;
-  const baselineEarnings =
-    baselineRows.reduce((s, r) => s + (r.earnings || 0), 0) / baselineRows.length;
-  const ratio = baselineRpm > 0 ? currentRow.rpm / baselineRpm : 1;
-
-  const reasons = [];
-  if (currentRow.rpm < ABSOLUTE_FLOOR) {
-    reasons.push(`RPM ${currentRow.rpm.toFixed(2)} < absolute floor ${ABSOLUTE_FLOOR.toFixed(2)}`);
-  }
-  if (baselineRpm > 0 && ratio < RATIO_FLOOR) {
-    reasons.push(
-      `RPM ${currentRow.rpm.toFixed(2)} = ${(ratio * 100).toFixed(0)}% of baseline ${baselineRpm.toFixed(2)} (floor ${(RATIO_FLOOR * 100).toFixed(0)}%)`,
-    );
-  }
-  return {
-    verdict: reasons.length > 0 ? "regression" : "healthy",
-    current: { date: currentRow.date, rpm: currentRow.rpm, earnings: currentRow.earnings, pageViews: currentRow.pageViews },
-    baseline: {
-      from: baselineRows[0].date,
-      to: baselineRows[baselineRows.length - 1].date,
-      rpm: Number(baselineRpm.toFixed(3)),
-      earnings: Number(baselineEarnings.toFixed(2)),
-      samples: baselineRows.length,
-    },
-    ratio: Number((ratio || 0).toFixed(3)),
-    floors: { ratio: RATIO_FLOOR, absoluteCHF: ABSOLUTE_FLOOR },
-    reasons,
-  };
-}
-
 async function main() {
   let result;
   try {
     const { account, rows } = await fetchDailyRpm();
     log(`[canary-rpm] account=${account}, ${rows.length} daily rows`);
-    result = classify(rows);
+    result = classifyRpm(rows, {
+      ratioFloor: RATIO_FLOOR,
+      absoluteFloor: ABSOLUTE_FLOOR,
+      earningsFloor: EARNINGS_FLOOR,
+      todayUtc: fmtDate(new Date()),
+    });
     result.account = account;
     result.rows = rows;
   } catch (err) {
@@ -211,19 +163,25 @@ async function main() {
     }
     if (result.baseline) {
       log(`baseline ${result.baseline.from}..${result.baseline.to}: RPM=${result.baseline.rpm.toFixed(2)} earnings=${result.baseline.earnings.toFixed(2)} (${result.baseline.samples} samples)`);
-      log(`ratio=${(result.ratio * 100).toFixed(0)}%   floors: ratio=${(RATIO_FLOOR * 100).toFixed(0)}%, absolute=${ABSOLUTE_FLOOR.toFixed(2)} CHF`);
+      log(`RPM ratio=${(result.ratio * 100).toFixed(0)}%   earnings ratio=${((result.earningsRatio || 0) * 100).toFixed(0)}%   floors: rpm=${(RATIO_FLOOR * 100).toFixed(0)}%, absolute=${ABSOLUTE_FLOOR.toFixed(2)} CHF, earnings=${(EARNINGS_FLOOR * 100).toFixed(0)}%`);
     }
     for (const r of result.reasons || []) log(`  ALERT: ${r}`);
+    if (result.note) log(`  NOTE: ${result.note}`);
   }
   if (result.verdict === "regression") {
-    console.error(`\x1b[31m[canary-rpm]\x1b[0m FAIL — RPM regression`);
+    console.error(`\x1b[31m[canary-rpm]\x1b[0m FAIL — RPM regression (RPM + earnings both below floor)`);
     process.exit(1);
   }
   if (result.verdict === "insufficient-data") {
     console.error(`\x1b[33m[canary-rpm]\x1b[0m SKIP — ${result.reason}`);
     process.exit(0);
   }
-  console.log(`\x1b[32m[canary-rpm]\x1b[0m PASS — RPM healthy`);
+  // Use stderr so --json keeps stdout as pure parseable JSON.
+  console.error(
+    result.note
+      ? `\x1b[32m[canary-rpm]\x1b[0m PASS — RPM dip is benign (earnings healthy)`
+      : `\x1b[32m[canary-rpm]\x1b[0m PASS — RPM healthy`,
+  );
   process.exit(0);
 }
 

--- a/scripts/lib/canaryRpmClassify.mjs
+++ b/scripts/lib/canaryRpmClassify.mjs
@@ -1,0 +1,171 @@
+/**
+ * canaryRpmClassify.mjs — pure RPM-regression classifier for the AdSense
+ * RPM canary (scripts/canary-rpm.mjs). Extracted into a lib so it can be
+ * unit-tested without the AdSense API / OAuth round-trip.
+ *
+ * Two correctness properties this encodes — both born from real false
+ * alarms (issue #2176, 2026-06-15..17):
+ *
+ *   1. NEVER measure the still-open current UTC day. AdSense reports a row
+ *      for "today" the moment it has any data, but that day's EARNINGS are
+ *      far from final, so its RPM reads artificially low. The old PV-only
+ *      "is the last row complete?" heuristic (drop if PV < 50% of prior)
+ *      failed on high-traffic mornings: on 2026-06-15 the still-open day's
+ *      partial PV already exceeded half of the prior day, so the canary
+ *      compared TODAY (incomplete) against the baseline and cried wolf.
+ *      Fix: when `todayUtc` is known, any row dated >= today is dropped
+ *      outright, then the PV-completeness guard still trims a yesterday
+ *      that looks like it is still settling.
+ *
+ *   2. RPM is a RATIO (earnings ÷ page views). A page-view SPIKE with
+ *      perfectly healthy earnings halves RPM mechanically — that is benign
+ *      traffic (often bot/AI crawl or a Discover hit), NOT a revenue
+ *      incident. On 2026-06-15 earnings were normal (5.46 CHF, in line with
+ *      4.4–5.7 the surrounding days) while PV spiked to 3625 (~2.4×), so
+ *      RPM "crashed" to 1.51 with zero lost revenue. A real incident
+ *      (the 2026-05-28 stub regression that birthed this canary) instead
+ *      collapses EARNINGS because no ads serve. Fix: only declare a
+ *      regression when the RPM signal fires AND current-day earnings are
+ *      also materially below the baseline earnings. This preserves the
+ *      2026-05-28 catch (earnings cratered) while silencing PV-spike dips.
+ */
+
+export const DEFAULT_RATIO_FLOOR = 0.65;
+export const DEFAULT_ABSOLUTE_FLOOR = 1.0;
+export const DEFAULT_EARNINGS_FLOOR = 0.65;
+export const BASELINE_DAYS = 7;
+export const BASELINE_LAG_DAYS = 3; // baseline ends at T-3 (skips noisy last days)
+export const REQUIRED_BASELINE_SAMPLES = 5; // need at least 5 days of baseline data
+
+/**
+ * @typedef {{ date: string, rpm: number, earnings: number, pageViews: number }} DailyRow
+ */
+
+/**
+ * Pick the latest fully-closed day. The current UTC day (`todayUtc`) is
+ * never closed — drop it and anything after it. Then, defensively, if the
+ * resulting candidate's page views look truncated (< 50% of the day
+ * before), step back one more in case AdSense hasn't settled yesterday yet.
+ *
+ * @param {DailyRow[]} rows ascending by date
+ * @param {string|undefined} todayUtc YYYY-MM-DD of the current UTC day
+ * @returns {number} index of the latest closed row (may be -1 if none)
+ */
+export function latestClosedIndex(rows, todayUtc) {
+  let idx = rows.length - 1;
+  // 1. Never treat the open current UTC day (or any future-dated row) as closed.
+  if (todayUtc) {
+    while (idx >= 0 && rows[idx].date >= todayUtc) idx -= 1;
+  }
+  // 2. PV-completeness guard: a candidate whose PV is < 50% of the prior
+  //    day's PV is probably still being collected — step back one.
+  if (idx >= 1) {
+    const prior = rows[idx - 1].pageViews;
+    const cand = rows[idx].pageViews;
+    if (prior > 0 && cand < prior * 0.5) idx -= 1;
+  }
+  return idx;
+}
+
+/**
+ * Classify the daily RPM rows into healthy / regression / insufficient-data.
+ *
+ * @param {DailyRow[]} rows ascending by date
+ * @param {{ ratioFloor?: number, absoluteFloor?: number, earningsFloor?: number, todayUtc?: string }} [opts]
+ */
+export function classifyRpm(rows, opts = {}) {
+  const ratioFloor = opts.ratioFloor ?? DEFAULT_RATIO_FLOOR;
+  const absoluteFloor = opts.absoluteFloor ?? DEFAULT_ABSOLUTE_FLOOR;
+  const earningsFloor = opts.earningsFloor ?? DEFAULT_EARNINGS_FLOOR;
+  const todayUtc = opts.todayUtc;
+
+  if (rows.length < BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES) {
+    return {
+      verdict: "insufficient-data",
+      reason: `need ≥${BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES} days of data, got ${rows.length}`,
+    };
+  }
+
+  const latestClosedIdx = latestClosedIndex(rows, todayUtc);
+  if (latestClosedIdx < 0) {
+    return { verdict: "insufficient-data", reason: "no fully-closed day available" };
+  }
+
+  const currentRow = rows[latestClosedIdx];
+  const baselineEnd = latestClosedIdx - (BASELINE_LAG_DAYS - 1);
+  const baselineStart = baselineEnd - BASELINE_DAYS;
+  if (baselineStart < 0 || baselineEnd <= baselineStart) {
+    return { verdict: "insufficient-data", reason: "baseline window underflowed" };
+  }
+  const baselineRows = rows.slice(baselineStart, baselineEnd);
+  if (baselineRows.length < REQUIRED_BASELINE_SAMPLES) {
+    return {
+      verdict: "insufficient-data",
+      reason: `baseline window has ${baselineRows.length} samples, need ${REQUIRED_BASELINE_SAMPLES}`,
+    };
+  }
+
+  const baselineRpm =
+    baselineRows.reduce((s, r) => s + (r.rpm || 0), 0) / baselineRows.length;
+  const baselineEarnings =
+    baselineRows.reduce((s, r) => s + (r.earnings || 0), 0) / baselineRows.length;
+  const ratio = baselineRpm > 0 ? currentRow.rpm / baselineRpm : 1;
+  const earningsRatio =
+    baselineEarnings > 0 ? currentRow.earnings / baselineEarnings : 1;
+
+  // RPM signal — sensitive trigger (a ratio drop or an absolute-floor breach).
+  const rpmReasons = [];
+  if (currentRow.rpm < absoluteFloor) {
+    rpmReasons.push(`RPM ${currentRow.rpm.toFixed(2)} < absolute floor ${absoluteFloor.toFixed(2)}`);
+  }
+  if (baselineRpm > 0 && ratio < ratioFloor) {
+    rpmReasons.push(
+      `RPM ${currentRow.rpm.toFixed(2)} = ${(ratio * 100).toFixed(0)}% of baseline ${baselineRpm.toFixed(2)} (floor ${(ratioFloor * 100).toFixed(0)}%)`,
+    );
+  }
+  const rpmLow = rpmReasons.length > 0;
+
+  // Earnings confirmation — a real revenue incident depresses absolute
+  // earnings; a page-view spike with healthy earnings does not. Treat a
+  // zero/absent baseline as "can't confirm" → fall back to the RPM signal
+  // (better a rare false alarm than a missed real incident with no baseline).
+  const earningsLow =
+    baselineEarnings > 0 ? earningsRatio < earningsFloor : true;
+
+  const isRegression = rpmLow && earningsLow;
+
+  const reasons = [];
+  let note;
+  if (isRegression) {
+    reasons.push(...rpmReasons);
+    reasons.push(
+      `Earnings ${currentRow.earnings.toFixed(2)} = ${(earningsRatio * 100).toFixed(0)}% of baseline ${baselineEarnings.toFixed(2)} (floor ${(earningsFloor * 100).toFixed(0)}%)`,
+    );
+  } else if (rpmLow && !earningsLow) {
+    // Benign: RPM dipped but earnings held — almost always a page-view spike.
+    note =
+      `RPM dip is benign: earnings ${currentRow.earnings.toFixed(2)} = ${(earningsRatio * 100).toFixed(0)}% of baseline ${baselineEarnings.toFixed(2)} (≥ ${(earningsFloor * 100).toFixed(0)}% floor) — the low RPM is a page-view spike (pv=${currentRow.pageViews}), not lost revenue.`;
+  }
+
+  return {
+    verdict: isRegression ? "regression" : "healthy",
+    current: {
+      date: currentRow.date,
+      rpm: currentRow.rpm,
+      earnings: currentRow.earnings,
+      pageViews: currentRow.pageViews,
+    },
+    baseline: {
+      from: baselineRows[0].date,
+      to: baselineRows[baselineRows.length - 1].date,
+      rpm: Number(baselineRpm.toFixed(3)),
+      earnings: Number(baselineEarnings.toFixed(2)),
+      samples: baselineRows.length,
+    },
+    ratio: Number((ratio || 0).toFixed(3)),
+    earningsRatio: Number((earningsRatio || 0).toFixed(3)),
+    floors: { ratio: ratioFloor, absoluteCHF: absoluteFloor, earnings: earningsFloor },
+    reasons,
+    ...(note ? { note } : {}),
+  };
+}

--- a/tests/canary-rpm-classify.test.ts
+++ b/tests/canary-rpm-classify.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyRpm,
+  latestClosedIndex,
+  DEFAULT_EARNINGS_FLOOR,
+} from '../scripts/lib/canaryRpmClassify.mjs';
+
+interface Row {
+  date: string;
+  rpm: number;
+  earnings: number;
+  pageViews: number;
+}
+
+const mk = (date: string, rpm: number, earnings: number, pageViews: number): Row => ({
+  date,
+  rpm,
+  earnings,
+  pageViews,
+});
+
+// A calm 7-day-ish baseline: ~5 CHF RPM, ~8 CHF/day earnings, ~1600 PV/day.
+function baselineDays(): Row[] {
+  return [
+    mk('2026-06-01', 5.0, 8.0, 1600),
+    mk('2026-06-02', 5.1, 8.1, 1588),
+    mk('2026-06-03', 4.9, 7.9, 1612),
+    mk('2026-06-04', 5.2, 8.2, 1577),
+    mk('2026-06-05', 5.0, 8.0, 1600),
+    mk('2026-06-06', 4.8, 7.7, 1604),
+    mk('2026-06-07', 5.0, 8.0, 1600),
+    mk('2026-06-08', 5.1, 8.1, 1588),
+    mk('2026-06-09', 5.0, 8.0, 1600),
+  ];
+}
+
+describe('latestClosedIndex — never measure the still-open current UTC day', () => {
+  it('drops the row dated today even when its partial PV beats half of yesterday', () => {
+    const spike = [
+      mk('2026-06-13', 5.0, 8.0, 1600),
+      mk('2026-06-14', 5.0, 8.0, 1600),
+      mk('2026-06-15', 1.9, 4.0, 2081), // today, high-traffic morning — partial PV > 50% of prior
+    ];
+    // Old PV-only heuristic kept this row; the date guard must drop it.
+    expect(latestClosedIndex(spike, '2026-06-15')).toBe(1); // → 2026-06-14
+  });
+
+  it('keeps the last row when it is genuinely yesterday (date < today)', () => {
+    const settled = [
+      mk('2026-06-13', 5.0, 8.0, 1600),
+      mk('2026-06-14', 5.0, 8.0, 1600),
+      mk('2026-06-15', 5.0, 8.0, 1600), // fully-settled yesterday
+    ];
+    expect(latestClosedIndex(settled, '2026-06-16')).toBe(2); // → 2026-06-15 is closed
+  });
+
+  it('still steps back when the closed candidate looks truncated (< 50% of prior PV)', () => {
+    const truncated = [
+      mk('2026-06-13', 5.0, 8.0, 1600),
+      mk('2026-06-14', 5.0, 8.0, 1600),
+      mk('2026-06-15', 5.0, 8.0, 600), // < 50% of prior → still settling
+    ];
+    expect(latestClosedIndex(truncated, '2026-06-16')).toBe(1); // → 2026-06-14
+  });
+});
+
+describe('classifyRpm — earnings gate distinguishes incidents from PV spikes', () => {
+  it('a page-view spike with healthy earnings is benign (no alert, emits a note)', () => {
+    // current day: RPM cut by a 2.4× PV spike, but earnings are normal.
+    const rows = [
+      ...baselineDays(),
+      mk('2026-06-10', 5.0, 8.0, 1600),
+      mk('2026-06-11', 2.1, 8.0, 3800), // PV spike, earnings unchanged
+    ];
+    const res = classifyRpm(rows, { todayUtc: '2026-06-12' });
+    expect(res.verdict).toBe('healthy');
+    expect(res.current?.date).toBe('2026-06-11');
+    expect(res.ratio).toBeLessThan(0.65); // RPM signal DID fire
+    expect(res.earningsRatio).toBeGreaterThanOrEqual(DEFAULT_EARNINGS_FLOOR); // earnings held
+    expect(res.note).toMatch(/benign/i);
+    expect(res.reasons).toHaveLength(0);
+  });
+
+  it('a real revenue incident (earnings crater) still fires — the 2026-05-28 stub signature', () => {
+    // Stubs serve no ads → both RPM and earnings collapse together.
+    const rows = [
+      ...baselineDays(),
+      mk('2026-06-10', 5.0, 8.0, 1600),
+      mk('2026-06-11', 1.7, 1.5, 880), // earnings cratered
+    ];
+    const res = classifyRpm(rows, { todayUtc: '2026-06-12' });
+    expect(res.verdict).toBe('regression');
+    expect(res.current?.date).toBe('2026-06-11');
+    expect(res.earningsRatio).toBeLessThan(DEFAULT_EARNINGS_FLOOR);
+    // Reasons must cite BOTH the RPM signal and the earnings confirmation.
+    expect(res.reasons.join(' ')).toMatch(/RPM/);
+    expect(res.reasons.join(' ')).toMatch(/Earnings/);
+  });
+
+  it('the absolute RPM floor alone does not page when earnings are healthy', () => {
+    const rows = [
+      ...baselineDays(),
+      mk('2026-06-10', 5.0, 8.0, 1600),
+      mk('2026-06-11', 0.8, 8.0, 10000), // RPM < 1.0 absolute, but earnings normal (huge PV spike)
+    ];
+    const res = classifyRpm(rows, { todayUtc: '2026-06-12' });
+    expect(res.verdict).toBe('healthy');
+    expect(res.note).toBeTruthy();
+  });
+});
+
+// Regression lock for issue #2176 (2026-06-15..17): finalized AdSense rows.
+describe('classifyRpm — issue #2176 finalized data', () => {
+  const FINALIZED: Row[] = [
+    mk('2026-06-04', 6.22, 9.18, 1475),
+    mk('2026-06-05', 5.75, 10.24, 1780),
+    mk('2026-06-06', 6.21, 6.85, 1102),
+    mk('2026-06-07', 7.67, 8.64, 1126),
+    mk('2026-06-08', 6.87, 12.39, 1803),
+    mk('2026-06-09', 4.73, 9.91, 2094),
+    mk('2026-06-10', 4.1, 9.4, 2292),
+    mk('2026-06-11', 3.25, 6.66, 2047),
+    mk('2026-06-12', 3.82, 6.59, 1725),
+    mk('2026-06-13', 5.18, 4.41, 851),
+    mk('2026-06-14', 3.23, 4.42, 1367),
+    mk('2026-06-15', 1.51, 5.46, 3625), // PV spike, earnings normal
+    mk('2026-06-16', 2.24, 5.43, 2424), // PV spike, earnings normal
+    mk('2026-06-17', 3.55, 5.68, 1599),
+    mk('2026-06-18', 4.09, 1.07, 262), // today, still open
+  ];
+
+  it("the jun-17 run's low RPM on jun-16 is a benign PV spike (was a false urgent alert)", () => {
+    const res = classifyRpm(FINALIZED.slice(0, 13), { todayUtc: '2026-06-17' });
+    expect(res.current?.date).toBe('2026-06-16');
+    expect(res.ratio).toBeLessThan(0.65); // the old logic alerted here
+    expect(res.verdict).toBe('healthy'); // the earnings gate now suppresses it
+    expect(res.note).toMatch(/page-view spike/i);
+  });
+
+  it('the current finalized run is healthy (issue resolves)', () => {
+    const res = classifyRpm(FINALIZED, { todayUtc: '2026-06-18' });
+    expect(res.current?.date).toBe('2026-06-17'); // jun-18 (open) is never measured
+    expect(res.verdict).toBe('healthy');
+  });
+
+  it('never measures the still-open current day even mid-spike (jun-15 16:00 run)', () => {
+    // On 2026-06-15 the canary used to measure jun-15 (a partial, high-PV day).
+    const res = classifyRpm(FINALIZED.slice(0, 12), { todayUtc: '2026-06-15' });
+    expect(res.current?.date).toBe('2026-06-14'); // closed day, not today
+  });
+});
+
+describe('classifyRpm — insufficient data', () => {
+  it('returns insufficient-data below the minimum window', () => {
+    const res = classifyRpm(baselineDays().slice(0, 5), { todayUtc: '2026-06-06' });
+    expect(res.verdict).toBe('insufficient-data');
+  });
+});


### PR DESCRIPTION
Closes #2176

## Implementato

Diagnosi (verità a terra dai dati AdSense **finalizzati** — il run di oggi è `healthy`/PASS): **nessuna regressione ad-serving**. Gli earnings giornalieri sono normali (4.4–5.7 CHF) ogni giorno; `article-content-canary` è verde durante tutto il periodo; nessun cambio di codice ad-related è andato live prima del calo (GPT PoC/offerwall/FC sono tutti del 16 giu, *dopo* l'onset del 15). L'RPM "crash" del 15-16 giu è un **page-view spike** (jun15 PV 3625 ≈ 2.4× il ~1500 tipico) con earnings invariati → RPM = earnings/PV crolla meccanicamente, **zero revenue persa** (probabile traffico bot/AI o Discover).

L'errore stava nel **canary stesso**, che generava issue urgenti `revenue` false. Due fix root-cause in `scripts/lib/canaryRpmClassify.mjs` (classificatore estratto, puro, unit-testato):

- **Mai misurare il giorno UTC ancora aperto.** La vecchia guardia "ultima riga completa?" (scarta se `PV < 50%` del giorno prima) falliva nelle mattine ad alto traffico: il 15 giu i PV parziali superavano già metà del giorno prima → il canary confrontava OGGI (earnings non finalizzati) con la baseline. Ora ogni riga datata `>= today` viene scartata, poi la guardia PV rifina comunque uno "ieri" non ancora assestato. (`latestClosedIndex`)
- **Earnings-gate.** RPM è `earnings ÷ page views`: un PV-spike con earnings sani dimezza l'RPM senza perdere un centesimo. Ora l'alert scatta **solo** se il segnale RPM scatta **E** gli earnings del giorno corrente sono sotto `--earnings-floor` (default `0.65 ×` baseline). I cali RPM benigni passano con una `note` esplicativa. **Il catch dell'incidente reale 2026-05-28 è preservato** (lì gli earnings erano crollati con l'RPM → unit test dedicato).
- `scripts/canary-rpm.mjs`: usa il lib, passa `todayUtc`, nuovo flag `--earnings-floor`; la riga PASS va su **stderr** così `--json` mantiene stdout JSON puro (prima inquinava il file artifact).
- `.github/workflows/rpm-canary.yml`: input `earnings_floor` + env + commento aggiornato al nuovo meccanismo.
- `scripts/build-rpm-canary-issue-body.mjs`: mostra earnings-ratio + soglia, e nota che l'alert ora implica earnings confermati giù.
- Test `tests/canary-rpm-classify.test.ts` (10 casi): PV-spike benigno, incidente reale (crater earnings), absolute-floor con earnings sani, mai-misurare-oggi, PV-guard, insufficient-data, + le righe **finalizzate reali di #2176** come regression-lock.

## Non implementato (ancora)

- **Sibling sweep (AGENTS #6): nessun sibling da fixare, giustificato.** L'unico gemello che calcola RPM/revenue vs baseline è `scripts/revenue-monitor.mjs`, già **immune** a entrambi i bug: usa un lag di 2 giorni (`end.setUTCDate(-2)`, riga 135) quindi non misura mai il giorno aperto, e aggrega su finestra 7-giorni quindi un PV-spike singolo si diluisce. `canary-article-content`/`production-canary` non toccano RPM. Il checker `check-sibling-patterns.mjs` surfacea solo token generici (`pageViews`/`exitCode`) — falsi positivi.
- **Indagine demand-side del calo earnings mid-giugno (9→5 CHF/giorno).** È un calo reale moderato (~35%) ma *non* code-fixable (stagionalità/CPC/traffic-mix; la baseline trailing lo riassorbe e il canary è già di nuovo verde). Fuori scope per questa PR (monitor-correctness); semmai follow-up analytics.
- **Reindex GitNexus** (`npx gitnexus analyze --skip-agents-md --embeddings`): step post-merge per convenzione.
