### PR TITLE
fix(ci): bump upload/download-artifact@v4→v7 in deploy-matrix-experiment (Node 24) — unblock main-red

### DIFF
--- a/.github/workflows/deploy-matrix-experiment.yml
+++ b/.github/workflows/deploy-matrix-experiment.yml
@@ -135,7 +135,7 @@ jobs:
             tar -czf /tmp/prepared-snapshot.tgz data
           ls -lh /tmp/prepared-snapshot.tgz
       - name: Upload prepared snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prepared-snapshot
           path: /tmp/prepared-snapshot.tgz
@@ -195,7 +195,7 @@ jobs:
       # every shard builds the IDENTICAL dataset. OG images are still rendered
       # per-shard during build:ci (og-jobs cache shared across runs).
       - name: Download prepared snapshot
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prepared-snapshot
           path: /tmp/snapshot


### PR DESCRIPTION
## Implementato
- `.github/workflows/deploy-matrix-experiment.yml` linee 138/198: `actions/upload-artifact@v4`→`@v7` e `actions/download-artifact@v4`→`@v7`. Erano i 2 first-party ref residui su Node 20 (introdotti da #2394/#2504) che facevano fallire il gate `lint-gha-node-runtime` → main rosso. `artifact@v4` e `@v5` sono **entrambi** Node 20; Node 24 parte da `@v6` → uso `@v7` per convenzione repo (38 upload + 11 download già `@v7`, pattern #779). Coppia upload/download allineata.
- Sibling sweep su origin/main: `grep` di tutti gli artifact/cache/checkout/setup-node/github-script deprecati → solo questi 2 reali; il match `download-artifact@v5` in `deploy.yml:2055` è un **commento**, non un `uses:` (linter lo ignora). Linter locale verde post-fix (`OK — 1184 ref Node ≥24`).

## Non implementato (ancora)
- Action third-party (skippate dal linter, runtime non noto) — fuori scope.

## Test plan
- [x] `node scripts/lint-gha-node-runtime.mjs` → `OK` (exit 0).
- [ ] `tests` verde su main post-merge.