### PR TITLE
fix(ci): bump upload/download-artifact@v4→v7 (Node 24) — unblock main-red lint:gha-node-runtime

### DIFF
--- a/.github/workflows/deploy-matrix-experiment.yml
+++ b/.github/workflows/deploy-matrix-experiment.yml
@@ -135,7 +135,7 @@ jobs:
             tar -czf /tmp/prepared-snapshot.tgz data
           ls -lh /tmp/prepared-snapshot.tgz
       - name: Upload prepared snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prepared-snapshot
           path: /tmp/prepared-snapshot.tgz
@@ -195,7 +195,7 @@ jobs:
       # every shard builds the IDENTICAL dataset. OG images are still rendered
       # per-shard during build:ci (og-jobs cache shared across runs).
       - name: Download prepared snapshot
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prepared-snapshot
           path: /tmp/snapshot


### PR DESCRIPTION
## Implementato

- `deploy-matrix-experiment.yml`: bump `actions/upload-artifact@v4` (riga 138) e `actions/download-artifact@v4` (riga 198) → `@v7` (runtime Node 24).

Sblocca **main-red**: il gate `lint-gha-node-runtime` (in `npm test`) falliva con `FAIL — 2 first-party action ref(s) on a deprecated Node runtime (< 24)`. I due ref `@v4` (Node 20) erano stati introdotti da #2394/#2504 (`deploy-matrix-experiment.yml`, build study no-deploy). `@v7` è la major a runtime Node 24 (vedi `NODE_RUNTIME_BY_ACTION`) ed è la versione già prevalente nel repo (38× upload@v7, 11× download@v7). Lint locale ora verde (exit 0, "min Node 24").

## Non implementato (ancora)

- Nessun altro ref deprecato: il lint conferma 0 offender residui dopo questo bump. Il solo `download-artifact@v5` rimasto è in un **commento** di `deploy.yml` (non un `uses:`), correttamente ignorato dal linter.