### PR TITLE
fix(watchdog): treat cloud-IP webcam blocks (403/429/451) as indeterminate

### DIFF
--- a/scripts/check-border-data-health.mjs
+++ b/scripts/check-border-data-health.mjs
@@ -38,6 +38,15 @@ const DEFAULT_STALE_HOURS = 6;
 // few-KB placeholder. Anything under this is treated as a broken feed.
 const MIN_WEBCAM_BYTES = 10 * 1024;
 const WEBCAM_FETCH_TIMEOUT_MS = 15000;
+// HTTP statuses that an access-control / rate-limit / geo-block layer returns and
+// that commonly DISCRIMINATE BY CLIENT IP — a residential browser (the real
+// frontaliere user) gets 200 while a cloud/datacenter runner gets blocked. Seeing
+// one of these from the monitor's single cloud vantage is INDETERMINATE, exactly
+// like a TCP-level failure (see `networkError` below): it does not prove the feed
+// is broken FOR END USERS, so it must not page. A feed that is genuinely gone
+// returns 404/410, a server fault returns 5xx, and a stub returns a tiny body —
+// all of which remain confirmed-broken signals that DO page.
+const IP_DISCRIMINATING_STATUSES = new Set([401, 403, 407, 429, 451]);
 
 // ── Pure logic (unit-tested; NO network/IO) ─────────────────────────
 
@@ -140,6 +149,13 @@ export function evaluateWebcamResult(result, minBytes = MIN_WEBCAM_BYTES) {
   // are confirmed-broken signals.
   if (result && result.networkError === true) {
     return { broken: false, indeterminate: true, reason: `unreachable from monitor (${result.status}) — not confirmed broken` };
+  }
+  // An access-control / rate-limit / geo-block status (401/403/407/429/451) from
+  // the monitor's single cloud IP is INDETERMINATE for the same reason a TCP
+  // failure is: such layers routinely block datacenter ranges while serving
+  // residential browsers (the real users) a healthy 200. Don't page; report it.
+  if (result && result.ok !== true && IP_DISCRIMINATING_STATUSES.has(result.status)) {
+    return { broken: false, indeterminate: true, reason: `blocked from monitor (HTTP ${result.status}) — likely cloud-IP block, not confirmed broken` };
   }
   if (!result || result.ok !== true) {
     return { broken: true, reason: `HTTP ${result?.status ?? 'error'}` };

--- a/tests/check-border-data-health.test.ts
+++ b/tests/check-border-data-health.test.ts
@@ -109,10 +109,26 @@ describe('evaluateWebcamResult', () => {
     expect(r.broken).toBe(false);
   });
 
-  it('flags a non-200 response as broken', () => {
-    const r = evaluateWebcamResult({ ok: false, status: 403, bytes: 0 });
-    expect(r.broken).toBe(true);
-    expect(r.reason).toMatch(/HTTP 403/);
+  it('treats an IP-discriminating block (403/401/429/451) as INDETERMINATE, not broken', () => {
+    // A 403 from the monitor's single cloud IP does NOT prove the feed is broken
+    // for end users: access-control / geo / rate-limit layers routinely block
+    // datacenter ranges while serving residential browsers a healthy 200.
+    // (lagomaggiorexperience.it canneroriviera case, issue #2336: 200/147KB from a
+    // residential IP, stable 403 from the GitHub Actions runner.)
+    for (const status of [401, 403, 407, 429, 451]) {
+      const r = evaluateWebcamResult({ ok: false, status, bytes: 0 });
+      expect(r.broken, `status ${status}`).toBe(false);
+      expect(r.indeterminate, `status ${status}`).toBe(true);
+      expect(r.reason).toMatch(/cloud-IP block|blocked from monitor/i);
+    }
+  });
+
+  it('flags a genuinely-gone (404/410) or server-fault (5xx) response as broken', () => {
+    for (const status of [404, 410, 500, 502, 503]) {
+      const r = evaluateWebcamResult({ ok: false, status, bytes: 0 });
+      expect(r.broken, `status ${status}`).toBe(true);
+      expect(r.reason).toMatch(new RegExp(`HTTP ${status}`));
+    }
   });
 
   it('flags a tiny body (error/placeholder page) as broken', () => {


### PR DESCRIPTION
## Implementato

Risolve il false-positive ricorrente del **Border Live-Data Watchdog** (`scripts/check-border-data-health.mjs`) che paginava la webcam di **Luino-Fornasette** (`lagomaggiorexperience.it/.../canneroriviera.jpg`) come `WEBCAM BROKEN: HTTP 403` a ogni run da 2 giorni (issue #2336).

Root cause: la cam ritorna **200 / ~147KB da un IP residenziale** (il vero utente frontaliere, browser in IT/CH) ma **403 stabile dall'IP datacenter del runner GitHub Actions** — classico blocco access-control/geo/rate-limit per range cloud. Il watchdog trattava *qualunque* status non-OK come "confirmed broken" e paginava, mentre la sua **stessa logica** già tratta i fallimenti TCP come *indeterminate* proprio perché "publisher blocks cloud IPs". Un 403 da un singolo vantaggio cloud è lo stesso fenomeno al layer HTTP.

- `evaluateWebcamResult`: gli status che **discriminano per IP client** (`401/403/407/429/451`) ora sono **`indeterminate` (non paga, ma riporta)**, coerente con il ramo `networkError` già esistente. La cam mostra `⚠️ blocked from monitor (HTTP 403) — likely cloud-IP block` invece di `❌ BROKEN`.
- `404/410/5xx` e body troppo piccolo (placeholder) **restano confirmed-broken** e continuano a paginare: una feed davvero sparita o un server rotto colpisce *tutti* i client allo stesso modo, quindi il gate resta onesto.
- Test aggiornati (`tests/check-border-data-health.test.ts`): 403/401/407/429/451 → indeterminate; 404/410/500/502/503 → broken. Suite verde (21/21).

Nessuna modifica a `data/borderCrossings.ts`: la webcam **funziona per gli utenti reali**, quindi non va sostituita né rimossa (sarebbe perdita di contenuto live a fronte di un falso allarme di monitoraggio).

## Non implementato (ancora)

- **Sostituzione fonte webcam Luino**: non fatta di proposito — la cam serve correttamente i browser residenziali; sostituirla introdurrebbe rischio senza beneficio (Luino non ha camera A2 ufficiale TI). Out of scope.
- **Header `Referer` per-host nel fetch del watchdog**: oggi manda sempre `Referer: https://www4.ti.ch/` anche per cam non-ti.ch. Innocuo qui (il blocco è IP-based, non referer-based: `curl` senza referer ottiene 200), non toccato — follow-up cosmetico se mai una cam richiedesse referer corretto.

Closes #2336
