### PR TITLE
seo(vacanze): lead title/meta with "Calendario Scolastico" to recover CTR

### DIFF
--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -9618,12 +9618,12 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  },
 
  'vacanze-scolastiche-ticino-2026': {
- title: 'Vacanze Scolastiche Ticino 2026-2027: Date DECS',
+ title: 'Calendario Scolastico Ticino 2026-2027: Vacanze e Date DECS',
  h1: 'Vacanze scolastiche Ticino 2026-2027 — calendario ufficiale DECS, ferie, carnevale, estate',
- description: 'Vacanze scolastiche Ticino 2026-2027: date ufficiali DECS per Carnevale, Pasqua, estate, autunno e Natale. Calendario rapido per genitori frontalieri.',
- keywords: 'calendario scolastico ticino 2026, calendario scolastico ticino 2026/27, calendario scolastico ticino 2027, vacanze scolastiche ticino 2026, vacanze scolastiche ticino 2027, DECS ticino, carnevale ticino 2027, estate scuole ticino, vacanze pasqua ticino',
- ogTitle: 'Vacanze Scolastiche Ticino 2026-2027: Date DECS',
- ogDescription: 'Date ufficiali DECS per Carnevale, Pasqua, estate, autunno e Natale. Calendario rapido per famiglie frontaliere.',
+ description: 'Calendario scolastico Ticino 2026-2027: date ufficiali DECS, inizio e fine scuola, vacanze di Carnevale, Pasqua, estate, autunno e Natale.',
+ keywords: 'calendario scolastico ticino 2026, calendario scolastico ticino 2026/27, calendario scolastico ticino 2027, vacanze scolastiche ticino 2026, vacanze scolastiche ticino 2027, fine scuola ticino 2026, DECS ticino, carnevale ticino 2027, estate scuole ticino, vacanze pasqua ticino',
+ ogTitle: 'Calendario Scolastico Ticino 2026-2027: Vacanze e Date DECS',
+ ogDescription: 'Date ufficiali DECS: inizio e fine scuola, vacanze di Carnevale, Pasqua, estate, autunno e Natale per famiglie frontaliere.',
  canonicalPath: '/vita-in-ticino/vacanze-scolastiche-ticino-2026/',
  structuredData: [
  {


### PR DESCRIPTION
## Implementato

Tuning CTR data-driven sulla pagina **#1 per impression GSC** (`/vita-in-ticino/vacanze-scolastiche-ticino-2026/` — 9471 impr/7d, pos media 5.9, **CTR 0.4%**).

Diagnosi (GSC per-query, ultimi 7g):
- `calendario scolastico 2026/27` → pos **4.7**, **0.0% CTR**, 435 impr
- `fine scuola ticino 2026` → pos **5.8**, 0.2% CTR, 473 impr
- `vacanze scolastiche ticino 2026` → pos 5.3, 1.4% CTR, 587 impr

Il `<title>` apriva con "Vacanze Scolastiche" ma i termini ad alto volume `calendario scolastico` e `fine scuola` non comparivano in title/description → Google bolda meno e l'utente salta il risultato pur ben posizionato.

Modifiche (solo `services/seo/seo-pages.ts`, entry `vacanze-scolastiche-ticino-2026`):
- `title` + `ogTitle`: `Calendario Scolastico Ticino 2026-2027: Vacanze e Date DECS` (59 char ≤ 66 cap) — apre con il cluster a 0% CTR, mantiene "Vacanze" e l'authority signal "DECS".
- `description` + `ogDescription`: aggiunto `calendario scolastico`, `inizio e fine scuola` (138 char).
- `keywords`: aggiunto `fine scuola ticino 2026`.
- Date/contenuto/struttura **invariati**.

Test: `clamp-meta-description` verde; `title-length` (≤66) e `h1-not-equal-title` soddisfatti by-construction (title 59 char; h1 resta `Vacanze scolastiche Ticino 2026-2027 — calendario ufficiale DECS…` ≠ title). Verifica reale = CTR field GSC a ~1-2 settimane post-deploy.

Contesto (master tracker #272): dei 3 target ancora sotto-soglia, **CLS desktop (0.094) e AdSense (6.05 CHF/g) sono già rientrati**; resta solo GSC avg position (10.4), che è **diluizione da crescita coverage** (impression 157k→366k, click +80% in 6 settimane), non decadimento. La leva codice residua è la CTR per-pagina: questa PR aggredisce l'unico caso con vero title-gap.

## Non implementato (ancora)

- **Altre pagine low-CTR/high-rank NON ritoccate** (`aliquote-imposta-alla-fonte-ticino-2026`, `prezzi-benzina/oggi`, `domande-frequenti-frontalieri`, fuel EN): l'analisi per-query mostra che i loro title sono **già corretti** (es. `Prezzo Benzina Svizzera oggi — Ticino (2026-06-18)` con data odierna; `Imposta alla Fonte Ticino 2026: Tabelle A B C H`) e il basso CTR aggregato è **diluizione long-tail** (impression sparse su decine di query marginali 1-9 impr), non deficit di title → ritoccarle sarebbe churn senza base dati. Out of scope per assenza di title-gap.
- **GSC avg position ≤7.5**: non chiudibile via codice in-sessione (lagged settimane + diluizione coverage + moratoria SEO-landing attiva). Non un title-fix.
- **Locale EN/DE/FR**: la pagina è IT-only (varianti localizzate → 404 live), nessun title localizzato da aggiornare.

Revert-trigger: se a 2 settimane post-deploy la CTR field della pagina non sale (resta ≤1%), il gap è strutturale (SERP dominata da fonte ufficiale ti.ch/DECS) e il title può tornare alla forma "Vacanze Scolastiche".