### PR TITLE
ci(equivalence): matrix it-shard ≡ live monolith it+shared check

### DIFF
--- a/.github/workflows/matrix-equivalence-check.yml
+++ b/.github/workflows/matrix-equivalence-check.yml
@@ -1,0 +1,111 @@
+# Matrix ≡ Monolith equivalence check (no deploy modification).
+#
+# Implements the "reuse the live monolith artifact" idea: instead of rebuilding
+# the monolith, download the github-pages artifact (it + shared, en/de/fr
+# stripped) that a real deploy.yml run already produced, then build the MATRIX
+# it-shard FROM THE SAME COMMIT and diff them byte-for-byte (sha256).
+#
+# Why it+shared only: the live en/de/fr shard repos are force-pushed per deploy
+# and drift across runs (no coherent same-commit all-4 snapshot exists). The
+# github-pages artifact IS a coherent single-commit snapshot of it + ALL shared
+# files — which is exactly the cross-locale risk surface: every sitemap (with
+# 4-locale xhtml:link alternates), hreflang, assets, /data, /og, build-id.
+#
+# Same commit ⇒ same committed crawler slices ⇒ deterministic assemble ⇒ same
+# data/jobs.json ⇒ pages must be byte-identical. Any diff is a real matrix bug.
+name: Matrix Equivalence Check (it+shared vs live monolith)
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA the live deploy was built from (matches the artifact)'
+        required: true
+      deploy_run_id:
+        description: 'deploy.yml run id whose github-pages artifact to compare against'
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: matrix-equivalence-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  equivalence:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_LOCALE: it
+      SEQUENTIAL_PROFILE: '1'
+      RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
+    steps:
+      - name: Checkout the equivalence tooling (this branch)
+        uses: actions/checkout@v5
+        with:
+          path: tooling
+      - name: Checkout the BUILD commit (must match the live artifact)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.sha }}
+          path: build
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        working-directory: build
+        run: npm ci
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+      - name: Load secrets from Remote Config
+        working-directory: build
+        run: node scripts/load-rc-env.mjs || echo "⚠️ load-rc-env failed (non-fatal)"
+      - name: Reproduce the deploy data snapshot (deterministic from committed slices)
+        working-directory: build
+        env:
+          JOBS_SKIP_URL_VALIDATION: '1'
+        run: |
+          set -eo pipefail
+          node scripts/assemble-jobs-dataset.mjs --stats
+          node scripts/cleanup-jobs.mjs
+          node scripts/refresh-weekly-employers-top-pairs.mjs
+          node scripts/mine-all-job-slugs.mjs
+          node scripts/migrate-all-known-job-slugs-canton-aware.mjs
+          node scripts/generate-image-thumbnails.mjs
+          node scripts/cleanup-news-sitemap.mjs
+      - name: Build matrix it-shard (BUILD_LOCALE=it) from the commit
+        working-directory: build
+        run: npm run build:ci
+      - name: Prune to it shard (root + shared, drop en/de/fr) — mirrors deploy strip
+        run: node tooling/scripts/ci/prune-locale-shard.mjs build/dist
+      - name: Manifest the matrix it-shard
+        run: node tooling/scripts/ci/dist-hash-manifest.mjs build/dist /tmp/matrix-it.txt
+      - name: Download the live github-pages artifact (monolith it + shared)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eo pipefail
+          mkdir -p /tmp/live
+          gh run download "${{ github.event.inputs.deploy_run_id }}" \
+            -R "${{ github.repository }}" -n github-pages -D /tmp/live
+          # The github-pages artifact is a single artifact.tar inside.
+          if [ -f /tmp/live/artifact.tar ]; then
+            mkdir -p /tmp/live/dist && tar -xf /tmp/live/artifact.tar -C /tmp/live/dist
+          fi
+          find /tmp/live -maxdepth 2 -type d | head
+      - name: Manifest the live monolith it+shared
+        run: |
+          set -eo pipefail
+          LIVE_DIST=/tmp/live/dist
+          [ -d "$LIVE_DIST" ] || LIVE_DIST=/tmp/live
+          node tooling/scripts/ci/dist-hash-manifest.mjs "$LIVE_DIST" /tmp/live-it.txt
+      - name: Compare matrix it-shard ≡ live monolith it+shared
+        run: node tooling/scripts/ci/compare-dist-manifests.mjs /tmp/live-it.txt /tmp/matrix-it.txt

--- a/scripts/ci/compare-dist-manifests.mjs
+++ b/scripts/ci/compare-dist-manifests.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Matrix-vs-monolith equivalence gate.
+ *
+ * Recompose the per-locale shard manifests into ONE set (their union = what the
+ * sharded deploy ships across all repos) and diff it, byte-for-byte (sha256),
+ * against the monolith manifest built from the SAME commit + SAME data snapshot.
+ *
+ * They MUST be identical: same source + same jobs.json + same templates ⇒ same
+ * pages. Any difference is either a real cross-locale-coupling bug in the matrix
+ * render-skip, or undeclared non-determinism — both worth failing on.
+ *
+ * Usage:
+ *   node scripts/ci/compare-dist-manifests.mjs <monolith.txt> <shard1.txt> [shard2.txt ...]
+ *
+ * Exit 0 only when recomposed === monolith. Exit 1 + a categorized report
+ * (only-in-monolith / only-in-matrix / content-mismatch) otherwise.
+ */
+import fs from 'node:fs';
+
+const [monolithFile, ...shardFiles] = process.argv.slice(2);
+if (!monolithFile || shardFiles.length === 0) {
+  console.error('usage: compare-dist-manifests.mjs <monolith.txt> <shard1.txt> [shard2.txt ...]');
+  process.exit(2);
+}
+
+/** Parse a manifest file → Map<relpath, sha256>. */
+function load(file) {
+  const m = new Map();
+  const txt = fs.readFileSync(file, 'utf-8');
+  for (const line of txt.split('\n')) {
+    if (!line) continue;
+    const sp = line.indexOf('  ');
+    if (sp < 0) continue;
+    m.set(line.slice(sp + 2), line.slice(0, sp));
+  }
+  return m;
+}
+
+const monolith = load(monolithFile);
+
+// Recompose: union of all shard manifests. A path SHOULD appear in exactly one
+// shard (the it/main shard owns root+shared; en/de/fr own their subtree). If the
+// same path appears in 2 shards with DIFFERENT hashes, that's itself a bug.
+const matrix = new Map();
+const dupConflicts = [];
+for (const f of shardFiles) {
+  for (const [rel, hash] of load(f)) {
+    const prev = matrix.get(rel);
+    if (prev !== undefined && prev !== hash) {
+      dupConflicts.push(rel);
+    }
+    matrix.set(rel, hash);
+  }
+}
+
+const onlyMonolith = [];
+const onlyMatrix = [];
+const mismatch = [];
+
+for (const [rel, h] of monolith) {
+  const mh = matrix.get(rel);
+  if (mh === undefined) onlyMonolith.push(rel);
+  else if (mh !== h) mismatch.push(rel);
+}
+for (const rel of matrix.keys()) {
+  if (!monolith.has(rel)) onlyMatrix.push(rel);
+}
+
+const sample = (arr, n = 25) => arr.slice(0, n).map((x) => `    ${x}`).join('\n');
+
+console.log(`Equivalence check — monolith ${monolith.size} files vs recomposed matrix ${matrix.size} files`);
+console.log(`  only-in-monolith: ${onlyMonolith.length}`);
+console.log(`  only-in-matrix:   ${onlyMatrix.length}`);
+console.log(`  content-mismatch: ${mismatch.length}`);
+console.log(`  cross-shard dup-conflicts: ${dupConflicts.length}`);
+
+const summary = (process.env.GITHUB_STEP_SUMMARY ? [] : null);
+function emit(line) { console.log(line); if (summary) summary.push(line); }
+
+const total = onlyMonolith.length + onlyMatrix.length + mismatch.length + dupConflicts.length;
+if (total === 0) {
+  emit('\n✅ PIXEL/BYTE-PERFECT: recomposed matrix === monolith (every file sha256-identical).');
+} else {
+  emit('\n✖ MATRIX ≠ MONOLITH — divergences found:');
+  if (onlyMonolith.length) emit(`\n--- only in MONOLITH (${onlyMonolith.length}) ---\n${sample(onlyMonolith)}`);
+  if (onlyMatrix.length) emit(`\n--- only in MATRIX (${onlyMatrix.length}) ---\n${sample(onlyMatrix)}`);
+  if (mismatch.length) emit(`\n--- CONTENT MISMATCH (${mismatch.length}) ---\n${sample(mismatch)}`);
+  if (dupConflicts.length) emit(`\n--- cross-shard dup w/ different hash (${dupConflicts.length}) ---\n${sample(dupConflicts)}`);
+}
+
+if (summary && process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+    `\n### Matrix ≡ Monolith equivalence\n\n` +
+    `| metric | count |\n|---|---|\n` +
+    `| monolith files | ${monolith.size} |\n| recomposed matrix files | ${matrix.size} |\n` +
+    `| only-in-monolith | ${onlyMonolith.length} |\n| only-in-matrix | ${onlyMatrix.length} |\n` +
+    `| content-mismatch | ${mismatch.length} |\n| dup-conflicts | ${dupConflicts.length} |\n\n` +
+    (total === 0 ? '✅ **byte-perfect identical**\n' : `✖ **${total} divergences** (see job log)\n`));
+}
+
+process.exit(total === 0 ? 0 : 1);

--- a/scripts/ci/dist-hash-manifest.mjs
+++ b/scripts/ci/dist-hash-manifest.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Produce a deterministic sha256 manifest of a dist/ tree for the
+ * matrix-vs-monolith equivalence check.
+ *
+ * Output: one line per file, `<sha256>  <dist-relative-path>`, sorted by path.
+ * Excludes files that legitimately differ between two builds of the SAME commit
+ * (per-build timestamps / build-internal bookkeeping) — NOT page content.
+ *
+ * Usage: node scripts/ci/dist-hash-manifest.mjs <distDir> <outFile>
+ *
+ * Uses `find | xargs sha256sum` for speed on ~1M-file trees, then applies the
+ * exclude filter + stable sort in JS so the exclude list stays maintainable.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.resolve(process.argv[2] || 'dist');
+const outFile = process.argv[3] || 'dist-manifest.txt';
+
+if (!fs.existsSync(distDir)) {
+  console.error(`[dist-hash-manifest] dist dir not found: ${distDir}`);
+  process.exit(1);
+}
+
+// Files/paths that differ between two builds of the same commit for reasons
+// UNRELATED to page content. Matched against the dist-relative path.
+const EXCLUDE = [
+  /^build-id\.txt$/,
+  /^commit-hash(-short)?\.txt$/,
+  /^\.write-collisions\.json$/,
+  /(^|\/)\.contenthash[^/]*\.json$/,
+  /(^|\/)\.vite-temp(\/|$)/,
+  /(^|\/)\.cache(\/|$)/,
+];
+
+function excluded(rel) {
+  return EXCLUDE.some((re) => re.test(rel));
+}
+
+// `find . -type f -print0 | xargs -0 sha256sum` from inside distDir → paths are
+// `./relpath`. Parallelism via xargs -P for speed.
+let raw;
+try {
+  raw = execFileSync(
+    'bash',
+    ['-eo', 'pipefail', '-c',
+      `cd "${distDir}" && find . -type f -print0 | xargs -0 -P4 -n256 sha256sum`],
+    { maxBuffer: 1024 * 1024 * 1024, encoding: 'utf-8' },
+  );
+} catch (e) {
+  console.error(`[dist-hash-manifest] hashing failed: ${String(e).slice(0, 200)}`);
+  process.exit(1);
+}
+
+const lines = [];
+for (const line of raw.split('\n')) {
+  if (!line) continue;
+  // sha256sum format: "<hash>  ./<relpath>"  (two spaces)
+  const sp = line.indexOf('  ');
+  if (sp < 0) continue;
+  const hash = line.slice(0, sp);
+  let rel = line.slice(sp + 2).replace(/^\.\//, '');
+  if (excluded(rel)) continue;
+  lines.push(`${hash}  ${rel}`);
+}
+// Stable sort by relpath (the part after the 2-space separator).
+lines.sort((a, b) => {
+  const pa = a.slice(a.indexOf('  ') + 2);
+  const pb = b.slice(b.indexOf('  ') + 2);
+  return pa < pb ? -1 : pa > pb ? 1 : 0;
+});
+
+fs.writeFileSync(outFile, lines.join('\n') + '\n');
+console.log(`[dist-hash-manifest] ${lines.length} files hashed → ${outFile} (excluded build-id/commit-hash/collision/manifest)`);


### PR DESCRIPTION
Workflow standalone (workflow_dispatch) — scarica il github-pages artifact (it+shared) da un run deploy.yml, builda il matrix it-shard dallo STESSO commit (assemble deterministico = stessi dati), diffa byte-per-byte sha256. + script dist-hash-manifest.mjs + compare-dist-manifests.mjs (testati). No deploy mod. it+shared = superficie coerente (en/de/fr live shard driftano).