### PR TITLE
fix(translate): standard 'Workflow Failure:' issue title so reconciler auto-closes (#2538)

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -283,8 +283,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Title MUST use the standard "Workflow Failure: <name>" prefix so the
+          # central reconciler (close-recovered-failure-issues.mjs, TITLE_RE
+          # ^(?:Workflow|Crawler|CI) Failure:) auto-closes it once the next run is
+          # green. The old literal "Translation Pipeline Failure" never matched →
+          # the failure issue stayed open forever on recovery (e.g. #2538). The
+          # <name> here equals `name:` so `gh run list -w` resolves the run.
           node scripts/lib/github-issue-creator.mjs \
-            --title "Translation Pipeline Failure" \
+            --title "Workflow Failure: Translate Pending Jobs" \
             --description "## Pipeline fallita
 
           **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Implementato

- `translate-pending.yml`: il reporter `if: failure()` ora apre l'issue col titolo standard **`Workflow Failure: Translate Pending Jobs`** invece del letterale `Translation Pipeline Failure`.
  - Il reconciler centrale `scripts/ci/close-recovered-failure-issues.mjs` matcha solo `^(?:Workflow|Crawler|CI) Failure: (.+)$` → il titolo vecchio non veniva **mai** chiuso al recupero (issue orfana anche dopo run verde).
  - `--workflow "Translate Pending Jobs"` è già uguale a `name:` → `gh run list -w` risolve il run, così open+close sono gestiti centralmente senza step per-workflow.
- `Closes #2538` — failure da malformed-slice del 2026-06-18; pipeline verde da allora (run 27865894339→27904625275 tutti success). Recuperata: si chiude al merge.

### Diagnosi pipeline (nessun bug residuo)
- Coda translate **scoda** ogni run (es. run 27904625275: Complete 92%→93%, incomplete 1448→1266, Argos mop-up 2364 tradotti / 0 falliti). Backlog = throughput, **non strutturale** (0 job con descrizione sorgente <120 char).
- Deploy skippato dal translate-workflow è **comportamento corretto**: `validate-translation-completeness` è all-or-nothing e ci sono job attivi genuinamente incompleti; il deploy gira via altri path.
- Cascade AI: il timeout-circuit-breaker (`markModelExhausted`) + persistenza Firestore (`exhaustedUntil` = mezzanotte UTC) funzionano — i modelli morti pagano la timeout-tax ~1 volta/giorno poi sono skippati (run 05:18 ha caricato 23 modelli ancora exhausted).

## Non implementato (ancora)

- **Tuning throughput cascade vs mop-up**: non riordino le fasi (cascade-prima è deliberato per qualità; `concurrency=2` intoccabile per memory). La coda già scoda → out of scope, richiederebbe misurazione live e rischia regressione qualità.
- **Sibling con titoli failure custom** (`Lighthouse regression`, `RPM canary`, `BAZG back online`, `Border live-data`, `Traffic data stale`, ecc.): NON toccati — sono **condition-monitor/canary** con resolve logic propria (classe diversa dal crash-reporter `if: failure()`), non gestiti dal reconciler by-design. translate-pending era l'unico crash-reporter con titolo non-standard.
- **Deploy starvation odierna** (deploy.yml failure/cancelled 2026-06-21): causa nota separata (dominio owner), fuori scope di questa PR.