### PR TITLE
fix(post-deploy-publish): standard 'Workflow Failure:' issue title (sibling of #2566)

### DIFF
--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -262,11 +262,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Standard "Workflow Failure: <name>" prefix so the central reconciler
+          # (close-recovered-failure-issues.mjs) auto-closes on recovery; <name> equals
+          # name: so gh run list -w resolves the run. (Was the non-standard literal
+          # "Publish post-deploy fallita" -> failure issue stayed orphan on green.)
           node scripts/lib/github-issue-creator.mjs \
-            # Standard "Workflow Failure: <name>" prefix so the central reconciler
-            # (close-recovered-failure-issues.mjs) auto-closes on recovery; <name> equals
-            # name: so gh run list -w resolves the run. (Was the non-standard literal
-            # "Publish post-deploy fallita" → failure issue stayed orphan on green.)
             --title "Workflow Failure: Post-deploy Publish (side-effects + mark good)" \
             --description "## Publish post-deploy fallita
           **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}

--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -263,7 +263,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
-            --title "Publish post-deploy fallita" \
+            # Standard "Workflow Failure: <name>" prefix so the central reconciler
+            # (close-recovered-failure-issues.mjs) auto-closes on recovery; <name> equals
+            # name: so gh run list -w resolves the run. (Was the non-standard literal
+            # "Publish post-deploy fallita" → failure issue stayed orphan on green.)
+            --title "Workflow Failure: Post-deploy Publish (side-effects + mark good)" \
             --description "## Publish post-deploy fallita
           **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
           **Publish run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -274,4 +278,4 @@ jobs:
           Il deploy resta live (validate-dist + validate-live già passati)." \
             --priority 2 \
             --label Bug \
-            --workflow "Post-deploy Publish"
+            --workflow "Post-deploy Publish (side-effects + mark good)"


### PR DESCRIPTION
## Implementato

- `post-deploy-publish.yml`: il reporter `if: failure()` ora apre l'issue col titolo standard **`Workflow Failure: Post-deploy Publish (side-effects + mark good)`** invece del letterale `Publish post-deploy fallita`.
  - Stessa classe del fix in #2566: il reconciler centrale `scripts/ci/close-recovered-failure-issues.mjs` matcha solo `^(?:Workflow|Crawler|CI) Failure: (.+)$`; il titolo letterale non matchava mai → la failure-issue restava orfana al recupero (identico a #2538). Questo step **non** ha un mirror `--resolve`, quindi dipendeva interamente dal reconciler.
  - Il suffisso del titolo usa il **nome completo** del workflow (`name:` = `Post-deploy Publish (side-effects + mark good)`) così `gh run list -w "<name>"` risolve davvero il run. `--workflow` allineato allo stesso nome completo (prima era troncato a `Post-deploy Publish`).
- Origine: 🟡 nit della review di #2566 (reviewer ha individuato il sibling con lo stesso antipattern). Chiude la classe per i crash-reporter `if: failure()` con titolo non-standard senza `--resolve`.

## Non implementato (ancora)

- **Altri titoli failure custom** (`Lighthouse regression`, `RPM canary`, `BAZG back online`, `Border live-data`, `Traffic data stale`, `needs-human`, ecc.): NON toccati — sono **condition-monitor/canary** con resolve logic propria, classe diversa dal crash-reporter `if: failure()`.
- **`deploy.yml`** (`CI Failure (build/deploy):`): titolo non-standard ma con **proprio step `--resolve`** → non orfano, lasciato com'è (confermato in review #2566).