### PR TITLE
fix(matrix-deploy): validate-live/publish gate on needs.result not bare success()

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2378,9 +2378,13 @@ jobs:
   # ───────────────────────────────────────────────────────────────────────
   validate-live:
     needs: deploy
-    if: |
-      success() &&
-      github.event.inputs.profile_sequential != 'true'
+    # Explicit needs.<job>.result + !cancelled() instead of bare success():
+    # in the MATRIX path the monolith `build` job is skipped, and bare success()
+    # is tripped by a skipped job anywhere in the transitive needs graph
+    # (deploy needs [build, build-locale]) → validate-live would be wrongly
+    # skipped, taking publish (last_known_good / indexing / winners sync) down
+    # with it. Gate strictly on the deploy result, like deploy/validate-dist.
+    if: ${{ !cancelled() && needs.deploy.result == 'success' && github.event.inputs.profile_sequential != 'true' }}
     uses: ./.github/workflows/post-deploy-validate-live.yml
     with:
       deploy_run_id: ${{ github.run_id }}
@@ -2413,9 +2417,12 @@ jobs:
   # ───────────────────────────────────────────────────────────────────────
   publish:
     needs: [deploy, validate-dist, validate-live]
-    if: |
-      success() &&
-      github.event.inputs.profile_sequential != 'true'
+    # Explicit result checks (not bare success()) for the same reason as
+    # validate-live: the skipped monolith `build` in the transitive needs graph
+    # trips success() under the MATRIX path. Require all three real producers to
+    # have SUCCEEDED — preserves the original gate (deploy+validate-dist+
+    # validate-live all green before the irreversible publish side-effects).
+    if: ${{ !cancelled() && needs.deploy.result == 'success' && needs.validate-dist.result == 'success' && needs.validate-live.result == 'success' && github.event.inputs.profile_sequential != 'true' }}
     uses: ./.github/workflows/post-deploy-publish.yml
     with:
       deploy_run_id: ${{ github.run_id }}


### PR DESCRIPTION

Final force_matrix run from main (27923956556): deploy SUCCEEDED but validate-live
and publish were SKIPPED. Root cause: both used `if: success()` (bare). In the
MATRIX path the monolith `build` job is skipped, and bare success() is tripped by
a skipped job anywhere in the transitive needs graph (deploy/validate-dist need
[build, build-locale]) → every downstream `success()` job is wrongly skipped.
deploy and validate-dist already dodged this with explicit
`!cancelled() && needs.X.result == 'success'`; validate-live and publish did not.

Without this, the matrix deploy never runs the irreversible post-deploy phase:
build-id propagation check, last_known_good marking (rollback target), Google/
IndexNow/GSC indexing, previous-slug-winners sync — an incomplete deploy.

Fix: gate validate-live on `needs.deploy.result == 'success'` and publish on all
three producers' results, with `!cancelled()`. Preserves the original ordering
contract (deploy+validate-dist+validate-live all green before publish side-effects).

## Implementato
- .github/workflows/deploy.yml: validate-live + publish use explicit result checks.

## Non implementato (ancora)
- validate-dist still fails on audit:hreflang (3 search pages en/de/fr with 2
  hreflang entries) — under investigation (matrix cross-locale coupling vs
  pre-existing); tracked separately, not addressed here.