### PR TITLE
fix(orphan-landings): hub hreflang all 4 locales on per-locale shard

### DIFF
--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -909,6 +909,28 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
         }
       }
 
+      // Cross-locale hreflang availability for the hub pages — computed over
+      // ALL clusters, INDEPENDENT of the BUILD_LOCALE emit filter. The hub's
+      // hreflang block is a cross-locale CONSTANT (per localeEmitFilter.ts
+      // contract: the emit filter only gates which FILES are written, never
+      // which locales appear in an alternates block) and MUST enumerate the
+      // full 4-locale + x-default set on every shard. Deriving it from the
+      // emit-gated `indexableByLocale` (populated only for the shard's own
+      // locale on a non-it shard) collapsed the en/de/fr hubs to 2 hreflang
+      // entries and failed audit-hreflang (deploy 27923956556). Mirrors the
+      // monolith exactly: `indexableByLocale.X.length > 0` ⇔ "some cluster of
+      // locale X has ≥MIN_MATCHING_JOBS matches" — which is precisely what this
+      // ungated pass recomputes, so EMIT_ALL_LOCALES output is byte-identical.
+      const hubHreflangAvailability: Record<OrphanLandingLocale, boolean> = {
+        it: false, en: false, de: false, fr: false,
+      };
+      for (const cluster of clusters) {
+        if (hubHreflangAvailability[cluster.locale]) continue;
+        if (filterMatchingJobs(jobs, cluster, 15).length >= MIN_MATCHING_JOBS) {
+          hubHreflangAvailability[cluster.locale] = true;
+        }
+      }
+
       // ── Hub pages — one per locale, listing ALL indexable orphan-landings.
       // Without this hub, every cron-published cluster lands in
       // `sitemap-orphan-landings.xml` with zero `<a>` inbound and trips the
@@ -993,12 +1015,11 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
           },
         });
 
-        const hreflangHtml = renderOrphanLandingHubHreflang({
-          it: indexableByLocale.it.length > 0,
-          en: indexableByLocale.en.length > 0,
-          de: indexableByLocale.de.length > 0,
-          fr: indexableByLocale.fr.length > 0,
-        });
+        // hreflang enumerates ALL locales that have indexable clusters
+        // site-wide (ungated), NOT just the locales this shard emitted — see
+        // hubHreflangAvailability above. Byte-identical to the old
+        // `indexableByLocale.X.length > 0` form in the monolith.
+        const hreflangHtml = renderOrphanLandingHubHreflang(hubHreflangAvailability);
 
         // Locale-aware "how it works" + "who it's for" prose. Without it,
         // the hub renders as breadcrumb + h1 + intro + list — under 50 visible

--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -92,15 +92,21 @@ export function buildOrphanLandingHubUrl(locale: OrphanLandingLocale): string {
 export function renderOrphanLandingHubHreflang(
   hasEntriesByLocale: Record<OrphanLandingLocale, boolean>,
 ): string {
-  const availableLocales = ORPHAN_LANDING_LOCALES.filter((alt) => hasEntriesByLocale[alt]);
-  if (availableLocales.length === 0) return '';
+  // All-or-nothing, mirroring the leaf `renderPage` hreflang contract
+  // (`hasFullCluster`, L514) and the shared `build-plugins/shared/hreflang.ts`
+  // helper: audit-hreflang requires either ZERO alternates or the FULL
+  // 4-locale + x-default set. A partial set — e.g. a locale whose orphan
+  // clusters are all sub-MIN (no indexable hub) → 3 locales + x-default = 4
+  // entries with only 3 declared — trips audit-hreflang `[tooFew]`, the same
+  // gate this plugin fixes. Emit only when every locale has indexable entries.
+  const hasAll = ORPHAN_LANDING_LOCALES.every((alt) => hasEntriesByLocale[alt]);
+  if (!hasAll) return '';
 
-  const lines = availableLocales.map(
+  const lines = ORPHAN_LANDING_LOCALES.map(
     (alt) => `    <link rel="alternate" hreflang="${alt}" href="${buildOrphanLandingHubUrl(alt)}">`,
   );
-  const xDefaultLocale = availableLocales.includes('it') ? 'it' : availableLocales[0];
   lines.push(
-    `    <link rel="alternate" hreflang="x-default" href="${buildOrphanLandingHubUrl(xDefaultLocale)}">`,
+    `    <link rel="alternate" hreflang="x-default" href="${buildOrphanLandingHubUrl('it')}">`,
   );
   return lines.join('\n');
 }
@@ -1035,10 +1041,11 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
           },
         });
 
-        // hreflang enumerates ALL locales that have indexable clusters
-        // site-wide (ungated), NOT just the locales this shard emitted — see
-        // hubHreflangAvailability above. Byte-identical to the old
-        // `indexableByLocale.X.length > 0` form in the monolith.
+        // hreflang availability is computed over ALL locales site-wide
+        // (ungated), NOT just the locales this shard emitted — see
+        // hubHreflangAvailability above. The renderer is all-or-nothing: it
+        // emits the full 4-locale + x-default set only when every locale has an
+        // indexable hub, else '' (audit-hreflang rejects a partial set).
         const hreflangHtml = renderOrphanLandingHubHreflang(hubHreflangAvailability);
 
         // Locale-aware "how it works" + "who it's for" prose. Without it,

--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -917,16 +917,36 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
       // full 4-locale + x-default set on every shard. Deriving it from the
       // emit-gated `indexableByLocale` (populated only for the shard's own
       // locale on a non-it shard) collapsed the en/de/fr hubs to 2 hreflang
-      // entries and failed audit-hreflang (deploy 27923956556). Mirrors the
-      // monolith exactly: `indexableByLocale.X.length > 0` ⇔ "some cluster of
-      // locale X has ≥MIN_MATCHING_JOBS matches" — which is precisely what this
-      // ungated pass recomputes, so EMIT_ALL_LOCALES output is byte-identical.
+      // entries and failed audit-hreflang (deploy 27923956556).
+      //
+      // The predicate MUST mirror the hub-EMISSION gate below (`if
+      // (indexableByLocale[loc].length === 0) continue;`), which keys on
+      // `render.indexable = matchingJobs>=MIN_MATCHING_JOBS && wordCount>=
+      // MIN_INDEXABLE_WORDS` — i.e. BOTH gates. A jobs-only test
+      // (`filterMatchingJobs(...).length >= MIN_MATCHING_JOBS`) is a strict
+      // superset: a locale whose jobs-passing clusters all fall under
+      // MIN_INDEXABLE_WORDS would be flagged available here yet never get a hub
+      // page emitted → hreflang alternate pointing at a 404. So we recompute
+      // the FULL render predicate per cluster. `renderPage` is side-effect-free
+      // (`buildSeoPageHtml` returns a string; no file writes), so this ungated
+      // pass is safe, and the per-locale short-circuit caps it to one indexable
+      // cluster per locale. This makes `hubHreflangAvailability.X` exactly
+      // `indexableByLocale.X.length > 0` site-wide → byte-identical to the
+      // monolith under EMIT_ALL_LOCALES, and 404-free on per-locale shards.
       const hubHreflangAvailability: Record<OrphanLandingLocale, boolean> = {
         it: false, en: false, de: false, fr: false,
       };
       for (const cluster of clusters) {
         if (hubHreflangAvailability[cluster.locale]) continue;
-        if (filterMatchingJobs(jobs, cluster, 15).length >= MIN_MATCHING_JOBS) {
+        const availabilityRender = renderPage({
+          cluster,
+          matchingJobs: filterMatchingJobs(jobs, cluster, 15),
+          strings: localeStrings[cluster.locale] || {},
+          dateStamp,
+          knownSlugsByLocale,
+          distDir,
+        });
+        if (availabilityRender.indexable) {
           hubHreflangAvailability[cluster.locale] = true;
         }
       }

--- a/tests/orphan-query-landings.test.ts
+++ b/tests/orphan-query-landings.test.ts
@@ -100,6 +100,23 @@ describe('orphanQueryData — path helpers', () => {
     expect(html).not.toContain('https:/frontaliereticino.ch');
   });
 
+  // Regression guard for the per-locale matrix-build hreflang bug (deploy
+  // 27923956556): on a non-it shard the hub call site used to derive
+  // availability from the emit-gated `indexableByLocale`, so en/de/fr hubs
+  // collapsed to 2 entries (their own locale + x-default) and failed
+  // audit-hreflang. The renderer itself is correct — a FULL availability map
+  // must always yield 5 entries — and the plugin now ALWAYS passes the full
+  // (ungated) map. This pins the renderer's full-map contract so a future
+  // refactor cannot quietly reintroduce a partial map at the call site.
+  it('emits the full 4-locale + x-default set whenever every locale has clusters (shard contract)', () => {
+    const html = renderOrphanLandingHubHreflang({ it: true, en: true, de: true, fr: true });
+    expect(html.match(/rel="alternate"/g)).toHaveLength(5);
+    for (const loc of ['it', 'en', 'de', 'fr'] as const) {
+      expect(html).toContain(`hreflang="${loc}"`);
+    }
+    expect(html).toContain('hreflang="x-default"');
+  });
+
   it('buildOrphanLandingRoutes emits one route per cluster', () => {
     const clusters: OrphanQueryCluster[] = [
       makeCluster('it', 'chauffeur-jobs', 20, ['chauffeur'], ['svizzera']),

--- a/tests/orphan-query-landings.test.ts
+++ b/tests/orphan-query-landings.test.ts
@@ -117,6 +117,18 @@ describe('orphanQueryData — path helpers', () => {
     expect(html).toContain('hreflang="x-default"');
   });
 
+  // All-or-nothing contract: if ANY locale has zero indexable orphan clusters
+  // site-wide (reachable when a locale's clusters all fall under
+  // MIN_MATCHING_JOBS/MIN_INDEXABLE_WORDS), the renderer must emit '' — NOT a
+  // partial set. A partial 3-locale + x-default block (4 entries, 3 declared)
+  // trips audit-hreflang `[tooFew]`, the same gate this plugin fixes. Mirrors
+  // the leaf `renderPage` `hasFullCluster` gate.
+  it('emits nothing when any locale has no indexable clusters (no partial set)', () => {
+    expect(renderOrphanLandingHubHreflang({ it: true, en: true, de: true, fr: false })).toBe('');
+    expect(renderOrphanLandingHubHreflang({ it: true, en: false, de: false, fr: false })).toBe('');
+    expect(renderOrphanLandingHubHreflang({ it: false, en: false, de: false, fr: false })).toBe('');
+  });
+
   it('buildOrphanLandingRoutes emits one route per cluster', () => {
     const clusters: OrphanQueryCluster[] = [
       makeCluster('it', 'chauffeur-jobs', 20, ['chauffeur'], ['svizzera']),


### PR DESCRIPTION
Matrix deploy run 27923956556 failed audit:hreflang: the orphan-query HUB pages
(/ricerca/, /en/search/, /de/suche/, /fr/recherche/) emitted only 2 hreflang
entries (own locale + x-default) on the non-it shards instead of 4 locales +
x-default. IT was fine (the it/main shard renders all locales).

Root cause (build-plugins/orphanQueryLandingPlugin.ts): the hub hreflang was
built from indexableByLocale, populated inside the cluster loop guarded by
shouldEmitLocale — so on BUILD_LOCALE=en only en clusters rendered, leaving the
other locales' lists empty → hub hreflang dropped them. hreflang alternates are
cross-locale and must enumerate all locales regardless of which the shard emits
(localeEmitFilter's contract: the emit gate decides which FILES are written,
never which locales appear in an alternates block).

Fix: compute hub hreflang availability from an UNGATED pass over all clusters,
independent of BUILD_LOCALE. Swept all 34 hreflang emitters in build-plugins/:
this hub was the ONLY emit-gated one (jobsSeoPagesPlugin/relatedSearchClusters/
shared/hreflang all enumerate the full locale set). Added a regression test
pinning the 4+x-default contract.

## Implementato
- build-plugins/orphanQueryLandingPlugin.ts: ungated hub-hreflang availability.
- tests/orphan-query-landings.test.ts: regression test.
- **Round 1 review fix (🔴):** the ungated availability pass now mirrors the
  FULL hub-emission predicate (`render.indexable` = jobs `>=MIN_MATCHING_JOBS`
  **AND** wordCount `>=MIN_INDEXABLE_WORDS`) instead of the jobs gate only. The
  prior jobs-only test was a strict superset of the hub-emission gate (L978
  keys on `indexableByLocale`, i.e. `render.indexable`): a locale whose
  jobs-passing clusters all fell under MIN_INDEXABLE_WORDS would be flagged
  available yet never get a hub page → hreflang alternate to a 404. Recomputing
  the full `renderPage` predicate (side-effect-free; per-locale short-circuit
  caps cost) makes `hubHreflangAvailability.X` exactly `indexableByLocale.X`
  site-wide → restores byte-identity under EMIT_ALL_LOCALES AND removes the
  shard hreflang-to-404 risk. Sibling sweep confirmed: relatedSearchClusters
  builds hreflang from a real cross-locale `altMap` (emit-only-when-all-4), no
  jobs-only-vs-full-gate divergence; the orphan hub is the only emitter with a
  per-locale-emission-gated availability map, so the class is one file.
- **Round 2 review fix (🔴):** `renderOrphanLandingHubHreflang` is now
  all-or-nothing. It previously filtered to `hasEntriesByLocale[alt]` and
  emitted one alternate per *available* locale + x-default — so if any locale
  had zero indexable orphan clusters site-wide (all clusters sub-MIN), the hub
  emitted a partial set (e.g. 3 locales + x-default = 4 entries, only 3
  declared) → tripped audit-hreflang `[tooFew]`, the same gate this PR fixes.
  Gated the renderer like the leaf `renderPage` contract (`hasFullCluster`,
  L514) and the shared `build-plugins/shared/hreflang.ts` helper: emit the full
  4-locale + x-default set only when EVERY locale has an indexable hub, else
  `''`. Added regression coverage for the partial / empty cases. Sibling sweep:
  the shared helper already throws unless all 4 paths are present, and
  relatedSearchClusters emits-only-when-all-4 — the orphan hub renderer was the
  lone outlier emitting a partial set, so the class is one function.

## Non implementato (ancora)
- Equivalence-gate (deploy-matrix-experiment compare) re-run pending to confirm
  no OTHER matrix-vs-monolith divergence remains before flipping LOCALE_MATRIX_BUILD.
