### PR TITLE
perf(jobboard): render hero during loading so LCP paints on mount (#2350)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -5182,6 +5182,32 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </div>
  ) : null;
 
+ // Hero (badge + H1 + subtitle) for listing/search/location routes. Defined
+ // BEFORE the jobsLoading gate so it can render DURING loading too — otherwise
+ // this H1/subtitle (the LCP element) only paints after the ~1.9MB job index
+ // downloads + the 5564-job parse/normalize finishes (#2350: lab LCP 4.5s,
+ // render-delay 97%). Painting it on first mount (~2s) makes it the LCP; the
+ // later loaded re-render is the same element/size so LCP isn't pushed back,
+ // and the matching position keeps the hero shift-free (CLS).
+ const listingHero = (
+ <div className="text-center space-y-3">
+ <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-accent-subtle text-accent rounded-full text-xs font-medium">
+ <Briefcase className="w-4 h-4" />
+ {t('jobBoard.badge')}
+ </div>
+ <h1 className="text-2xl sm:text-3xl font-bold font-display text-heading">
+ {companyDisplayName
+ ? t('jobBoard.companyPageTitle', { company: companyDisplayName, ...cantonI18n })
+ : locationDisplayName
+ ? t('jobBoard.locationPageTitle', { location: locationDisplayName, ...cantonI18n })
+ : searchHeadingQuery
+ ? t('jobBoard.searchPageTitle', { query: searchHeadingQuery })
+ : t('jobBoard.title', cantonI18n)}
+ </h1>
+ <p className="text-sm sm:text-base text-subtle max-w-2xl mx-auto">{t('jobBoard.subtitle', cantonI18n)}</p>
+ </div>
+ );
+
  if (jobsLoading) {
  // Expired job pages with seeded data: render the expired view immediately
  // instead of a spinner. Google's WRS executes JS and would otherwise see
@@ -5212,6 +5238,25 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // synchronously above. (#1511)
  if (initialJobSlug && !companySlugFilter && !locationSlugFilter && !searchSlugFilter && !seeded) {
  return <SkeletonJobDetail />;
+ }
+ // Listing / search / location loading: paint the real hero (the LCP element,
+ // #2350) on first mount, above a list skeleton, instead of waiting for the
+ // full job-index fetch. Mirrors the loaded layout (hero → search → 10 cards)
+ // so the hero reconciles in place and the footer stays below the fold (CLS).
+ // Company-brand pages keep the generic skeleton — their loaded hero is the
+ // richer EmployerBrandHub, not this text hero.
+ if (!companySlugFilter) {
+ return (
+ <div className="space-y-6 min-h-[80vh]">
+ {listingHero}
+ <div className="h-14 rounded-2xl bg-surface-raised animate-pulse" />
+ <div className="space-y-3">
+ {Array.from({ length: 10 }).map((_, i) => (
+ <div key={i} className="h-24 sm:h-[120px] rounded-xl bg-surface-raised animate-pulse" />
+ ))}
+ </div>
+ </div>
+ );
  }
  return (
  // Reserve realistic page height during the async job fetch. Search/filter
@@ -7406,22 +7451,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  emitStructuredData={false}
  />
  ) : (
- <div className="text-center space-y-3">
- <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-accent-subtle text-accent rounded-full text-xs font-medium">
- <Briefcase className="w-4 h-4" />
- {t('jobBoard.badge')}
- </div>
- <h1 className="text-2xl sm:text-3xl font-bold font-display text-heading">
- {companyDisplayName
- ? t('jobBoard.companyPageTitle', { company: companyDisplayName, ...cantonI18n })
- : locationDisplayName
- ? t('jobBoard.locationPageTitle', { location: locationDisplayName, ...cantonI18n })
- : searchHeadingQuery
- ? t('jobBoard.searchPageTitle', { query: searchHeadingQuery })
- : t('jobBoard.title', cantonI18n)}
- </h1>
- <p className="text-sm sm:text-base text-subtle max-w-2xl mx-auto">{t('jobBoard.subtitle', cantonI18n)}</p>
- </div>
+ listingHero
  )}
 
  {/* ─── Search & Filters ─── */}


### PR DESCRIPTION
## Implementato

Secondo intervento su #2350 (dopo PR #2498 che ha deferito PostHog). Diagnosi LCP completata sul build live (#2498 già deployato):

**Root cause trovato.** La route listing ritornava `<SkeletonJobBoard/>` durante `jobsLoading` (JobBoard.tsx:5185), quindi l'hero **H1+subtitle — che è l'elemento LCP** (pre-fix l'elemento LCP misurato era proprio il `<p>` dell'hero) — dipingeva solo DOPO che il job index da ~1.9MB era scaricato (~1.3s misurati: `1262→2534ms`) e i 5564 job normalizzati/dedupati. Risultato: lab LCP 4.5s, **render-delay 97%**.

**Fix.** Estratto l'hero in `listingHero` (definito prima del gate `jobsLoading`, tutte le dipendenze già disponibili) e renderizzato anche durante il loading, sopra uno skeleton-list che rispecchia il layout caricato (hero → search → 10 card). Stesso elemento riusato nella vista caricata.
- L'hero dipinge al primo mount (~2s) → diventa l'LCP.
- Il re-render caricato è lo **stesso elemento/dimensione** → l'LCP non viene spinto avanti (LCP aggiorna solo su paint *più grande*) e la posizione invariata lo tiene shift-free → **nessuna regressione CLS**.
- Le pagine azienda-brand (`companySlugFilter`) mantengono lo skeleton attuale: il loro hero caricato è il più ricco `EmployerBrandHub`, non questo hero testuale.

### Misurazioni (build #2498 live, mio Lighthouse desktop)
- TBT 630→270-440ms, TTI 6.3→4.5s, INP-proxy 580→270ms (da #2498, già live).
- LCP molto variabile lab (1.6-9s): è una **race** static-H1 vs swap React + rumore network locale + CF challenge intermittente. Field reale OK (desktop 186-696ms, mobile 1.4-1.9s — PostHog/CF RUM). Questo fix rende deterministico il paint precoce dell'hero.

## Non implementato (ancora)

- **Validazione perf non possibile pre-merge** (Lighthouse CI gira solo post-deploy + attualmente `skipped` per deploy-starvation; full SEO build locale OOM; lab locale troppo rumoroso, LCP 1.6-9s). **Revert-trigger**: se il prossimo audit post-deploy peggiora LCP/CLS su `/cerca-lavoro-ticino/` o regredisce il CLS (funnel AdSense), revertare questo commit. Validazione reale = field web-vitals (PostHog) nei giorni successivi + CI Lighthouse quando la starvation lo permette.
- **Deploy starvation** (13/15 deploy cancellati, dominio-owner): blocca la validazione CI ma fuori scope per decisione utente ("aspetta e valida").
- **Payload dati 1.9MB**: ridurlo (first-page slim) accelererebbe le *card* (non l'hero, ora già precoce) — follow-up separato, tocca data-layer + build plugin.
- **Sibling-check**: flaggati `*-core.ts` (chiavi i18n `companyPageTitle/locationPageTitle/searchPageTitle` che l'hero *usa*) e `EmployerBrandHub`/`employerBrands.ts` (componente *riusato*) — sono dipendenze, non antipattern duplicati. Nessuno sweep dovuto.

## Test
- [x] `tsc --noEmit`: zero errori in JobBoard.tsx
- [x] `vitest run tests/community/JobBoard.sticky-sidebar.test.tsx` → 9/9 pass
- [x] GitNexus detect_changes: 1 file, medium (JobBoard hub), cambio solo render-timing non logica
- [ ] Post-deploy: LCP `/cerca-lavoro-ticino/` ridotto + CLS invariato (~0) sul prossimo Lighthouse CI / field web-vitals

Closes #2350