### PR TITLE
feat(apply): suppress in-house apply form when candidate already applied

### DIFF
--- a/components/community/PublisherApplyForm.tsx
+++ b/components/community/PublisherApplyForm.tsx
@@ -17,7 +17,7 @@ import { recaptchaService } from '@/services/recaptchaService';
 import EmailInput, { validateEmailStrict } from '@/components/shared/EmailInput';
 import { Analytics } from '@/services/analytics';
 import { reportCaughtError } from '@/services/errorReporter';
-import { getFirestore, collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { getFirestore, collection, addDoc, serverTimestamp, query, where, limit, getDocs } from 'firebase/firestore';
 import { getApp } from '@/services/firebase';
 import { useAuth, getAuthEmail, getUserDisplayName } from '@/services/authService';
 import { trackPublisherApplyClick } from '@/services/publisherAnalyticsService';
@@ -55,6 +55,40 @@ const PublisherApplyForm: React.FC<PublisherApplyFormProps> = ({ jobId, publishe
   // getDownloadURL() would 403 here; we store the path and let the server sign.
   const [cvPath, setCvPath] = useState('');
   const [cvFileName, setCvFileName] = useState('');
+  // Whether the signed-in user has already applied to this job. A prior
+  // `applications` doc (denormalised candidateUid + jobId) means we suppress the
+  // form and show a "you already applied" notice instead of letting them
+  // re-submit. 'checking' avoids flashing the form before the lookup resolves;
+  // logged-out users stay 'none' (no uid to match → form always shown).
+  const [alreadyApplied, setAlreadyApplied] = useState<'checking' | 'applied' | 'none'>('none');
+
+  // Look up an existing application for (this user, this job). firestore.rules
+  // allow a candidate to read their own applications (candidateUid == uid); the
+  // two equality filters are served by single-field indexes (zigzag merge), so
+  // no composite index is needed. Best-effort: any failure leaves the form open.
+  useEffect(() => {
+    const uid = user?.uid;
+    if (!uid || !jobId) { setAlreadyApplied('none'); return; }
+    let cancelled = false;
+    setAlreadyApplied('checking');
+    (async () => {
+      try {
+        const db = getFirestore(await getApp());
+        const snap = await getDocs(
+          query(
+            collection(db, 'applications'),
+            where('candidateUid', '==', uid),
+            where('jobId', '==', jobId),
+            limit(1),
+          ),
+        );
+        if (!cancelled) setAlreadyApplied(snap.empty ? 'none' : 'applied');
+      } catch {
+        if (!cancelled) setAlreadyApplied('none');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user, jobId]);
 
   // Prefill name/email for a logged-in user (no clobber once they start typing).
   // Email is always reliable; name only from a real display name (never the
@@ -175,6 +209,27 @@ const PublisherApplyForm: React.FC<PublisherApplyFormProps> = ({ jobId, publishe
         </div>
       </div>
     );
+  }
+
+  // The signed-in user already applied to this job: suppress the form and show a
+  // notice instead so they don't submit a duplicate.
+  if (alreadyApplied === 'applied') {
+    return (
+      <div className="flex items-start gap-2 p-4 rounded-xl bg-success-subtle border border-success-border">
+        <CheckCircle className="w-5 h-5 text-success flex-shrink-0 mt-0.5" />
+        <div>
+          <p className="font-semibold text-strong">{t('publisherApply.alreadyTitle')}</p>
+          <p className="text-sm text-subtle">{t('publisherApply.alreadyMessage')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // While the lookup is in flight, reserve the form's footprint so we never
+  // flash the full form and then collapse it to the notice ([contain:layout]
+  // + matching min-height keep CLS at zero).
+  if (alreadyApplied === 'checking') {
+    return <div className="mt-4 min-h-[420px] [contain:layout]" aria-hidden="true" />;
   }
 
   return (

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -3297,6 +3297,8 @@ Regeln:
  'publisherApply.error': 'Senden fehlgeschlagen. Bitte später erneut versuchen.',
  'publisherApply.successTitle': 'Bewerbung gesendet!',
  'publisherApply.successMessage': 'Ihre Daten wurden an den Arbeitgeber weitergeleitet. Viel Erfolg!',
+ 'publisherApply.alreadyTitle': 'Sie haben sich bereits auf diese Stelle beworben',
+ 'publisherApply.alreadyMessage': 'Wir haben Ihre Bewerbung erfasst und an den Arbeitgeber weitergeleitet. Sie können sie in Ihrem Profil einsehen.',
  'publisher.error': 'Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.',
  'publisher.error.description': 'Die Beschreibung muss mindestens 50 Wörter enthalten.',
  'publisher.error.locations': 'Fügen Sie mindestens einen Arbeitsort hinzu.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -3294,6 +3294,8 @@ Rules:
  'publisherApply.error': 'Submission failed. Please try again later.',
  'publisherApply.successTitle': 'Application sent!',
  'publisherApply.successMessage': 'Your details were forwarded to the employer. Good luck!',
+ 'publisherApply.alreadyTitle': 'You have already applied for this position',
+ 'publisherApply.alreadyMessage': 'We have recorded your application and forwarded it to the employer. You can review it in your profile.',
  'publisher.error': 'Something went wrong. Please try again.',
  'publisher.error.description': 'The description must contain at least 50 words.',
  'publisher.error.locations': 'Add at least one work location.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -3297,6 +3297,8 @@ Règles :
  'publisherApply.error': 'Échec de l\'envoi. Réessayez plus tard.',
  'publisherApply.successTitle': 'Candidature envoyée !',
  'publisherApply.successMessage': 'Vos informations ont été transmises à l\'employeur. Bonne chance !',
+ 'publisherApply.alreadyTitle': 'Vous avez déjà postulé pour ce poste',
+ 'publisherApply.alreadyMessage': 'Nous avons enregistré votre candidature et l\'avons transmise à l\'employeur. Vous pouvez la consulter dans votre profil.',
  'publisher.error': 'Une erreur s\'est produite. Veuillez réessayer.',
  'publisher.error.description': 'La description doit contenir au moins 50 mots.',
  'publisher.error.locations': 'Ajoutez au moins un lieu de travail.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -3384,6 +3384,8 @@ Regole:
  'publisherApply.error': 'Invio non riuscito. Riprova più tardi.',
  'publisherApply.successTitle': 'Candidatura inviata!',
  'publisherApply.successMessage': 'I tuoi dati sono stati inoltrati al datore di lavoro. In bocca al lupo!',
+ 'publisherApply.alreadyTitle': 'Ti sei già candidato per questa posizione',
+ 'publisherApply.alreadyMessage': 'Abbiamo registrato la tua candidatura e l\'abbiamo inoltrata al datore di lavoro. Puoi rivederla nel tuo profilo.',
  'publisher.error': 'Si è verificato un errore. Riprova.',
  'publisher.error.description': 'La descrizione deve contenere almeno 50 parole.',
  'publisher.error.locations': 'Aggiungi almeno una sede di lavoro.',


### PR DESCRIPTION
## Implementato

- **Pagina annuncio — nascondi form se già candidato.** In `PublisherApplyForm` (componente usato da entrambi i render path di `JobBoard`: layout hybrid-ab e standard) aggiunto un lookup Firestore: per un utente loggato, query `applications` su `candidateUid == uid && jobId == jobId` (`limit(1)`). Se esiste già una candidatura per quel job, il form viene soppresso e si mostra un avviso "Ti sei già candidato per questa posizione" + messaggio, invece di lasciar inviare un duplicato.
- **Stato `checking` anti-CLS.** Mentre il lookup è in volo si renderizza un placeholder con `min-h-[420px] [contain:layout]` (stessa footprint del form) → niente flash del form che poi collassa nell'avviso.
- **Best-effort.** Qualsiasi errore di lettura (indice mancante, offline) lascia il form aperto: nessun blocco del funnel candidatura. Utenti loggati-out restano sempre con form visibile (nessun uid da matchare).
- **i18n 4 locali.** Aggiunte `publisherApply.alreadyTitle` + `publisherApply.alreadyMessage` in it/en/de/fr (`*-core.ts`). i18n-completeness verde.

Sicurezza: `firestore.rules` già permette al candidato di leggere le proprie `applications` (`request.auth.uid == resource.data.candidateUid`); i due filtri di uguaglianza sono serviti da single-field index (zigzag merge join) → nessun composite index da deployare. Le chiavi `jobId` lette/scritte sono coerenti (entrambe = `publisherJobId`).

## Non implementato (ancora)

- **Profilo "Le mie candidature": già esistente, nessuna modifica.** La prima metà del goal (mostrare nel profilo i job a cui l'utente si è candidato) è già live da PR #2207 (`UserProfile.tsx`, query `applications` su `candidateUid`, deep-link via `jobSlug`). Verificata funzionante in lettura del codice; non toccata in questa PR per non duplicare. Il sibling-check segnala `UserProfile.tsx` per il token condiviso `candidateUid` → è la metà complementare della stessa feature (lista vs dedup), non lo stesso antipattern: nessun fix da propagare lì.
- **Verifica live (utente loggato + candidatura reale).** Il path "già candidato → form nascosto" richiede un account autenticato con una candidatura esistente su un annuncio sponsorizzato in_house/forward_email; non riproducibile nei test unit (Firestore reale). Da verificare su deploy live post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)