### PR TITLE
fix(generate-article): one bad translation JSON no longer discards the whole article

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -4330,6 +4330,17 @@ ${terminologyByLang[targetLang] || ''}`;
         })
       : Promise.resolve({});
 
+    // Per-call resilience: a single malformed-JSON / quota-exhausted translation
+    // call must NOT reject the whole Promise.all and discard the entire article
+    // (run 27924137758: de:meta JSON parse failure after 3 retries hard-threw and
+    // killed an otherwise-fine article). Each call falls back to `{}`; the
+    // downstream missing-field validation loop (#1266) then re-translates the
+    // affected field in isolation or falls back to the IT source — same
+    // graceful-degradation philosophy already used for FAQ below.
+    const onTranslateFail = (label) => (err) => {
+      console.error(`  ⚠️  ${label} translation failed: ${err.message} — fallback al recupero per-campo`);
+      return {};
+    };
     const [partMeta, partB1, partB2, partB3, partFaq] = await Promise.all([
       // Call 1: title + excerpt (small, ~300 tokens output)
       // VINCOLO TITOLO: il title tradotto DEVE restare ≤ 60 caratteri (gate SEO Semrush).
@@ -4338,11 +4349,11 @@ ${terminologyByLang[targetLang] || ''}`;
       callWithRetry(makePrompt(
         `CONTENUTO ITALIANO DA TRADURRE:\n- title: ${sourceContent.title}\n- excerpt: ${sourceContent.excerpt}\n\nVINCOLI OBBLIGATORI per il title tradotto:\n- MASSIMO 60 caratteri totali (target 50-55).\n- NON includere "| Frontaliere Ticino" (aggiunto automaticamente).\n- Mantieni la keyword principale; abbrevia o riformula se necessario per restare entro 60 caratteri.`,
         '{"title": "...", "excerpt": "..."}',
-      ), 1000, `${targetLang}:meta`),
+      ), 1000, `${targetLang}:meta`).catch(onTranslateFail(`${targetLang}:meta`)),
       // Call 2-4: body fields with dynamic sizing + sub-chunking safety
-      translateBodyField('body1', sourceContent.body1, targetLang),
-      translateBodyField('body2', sourceContent.body2, targetLang),
-      translateBodyField('body3', sourceContent.body3, targetLang),
+      translateBodyField('body1', sourceContent.body1, targetLang).catch(onTranslateFail(`${targetLang}:body1`)),
+      translateBodyField('body2', sourceContent.body2, targetLang).catch(onTranslateFail(`${targetLang}:body2`)),
+      translateBodyField('body3', sourceContent.body3, targetLang).catch(onTranslateFail(`${targetLang}:body3`)),
       // Call 5: FAQ (optional)
       faqTranslation,
     ]);


### PR DESCRIPTION
## Implementato

Root cause del fallimento di **Generate Blog Article** run [27924137758](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/27924137758) (issue auto-aperta #2573):

```
❌ Retry 2 fallito (de:meta): Expected ',' or '}' after property value in JSON at position 1895
❌ Errore: JSON non valido dalla traduzione de:meta: ...
##[error]Process completed with exit code 1.
```

La traduzione `de:meta` (title+excerpt) ha restituito JSON malformato che `repairLlmJson` non ha riparato dopo 3 retry. `callWithRetry` ha fatto **hard-throw dentro il `Promise.all` per-locale** in `translateContent`, rigettando l'intera traduzione e **scartando un articolo altrimenti valido** (sorgente IT + EN/FR già completati). Condizione contribuente: pressione quota (gemini Daily quota reached, nvidia 429) che aveva spinto la catena scored verso modelli che producono JSON più sporco.

Fix: le chiamate `:meta` e `body1/2/3` nel `Promise.all` ora hanno un `.catch()` che ritorna `{}` (helper `onTranslateFail`), **specchiando il fallback FAQ già presente nello stesso `Promise.all`**. Il loop di validazione campi-mancanti a valle (introdotto per #1266) recupera ogni campo vuoto con una re-traduzione mirata single-field, e solo come ultima risorsa fa fallback al valore IT — stessa filosofia graceful-degradation già usata per campi identici/over-long e FAQ. Nessun articolo viene più scartato per il fallimento JSON di una singola sotto-chiamata di traduzione.

Audit ultimi 20 run: 18 success, 1 failure (questo, fixato), 1 cancelled (run schedulato, concurrency-cancel, benigno). Quota/429 presenti in alcuni run ma assorbiti dalla catena di fallback (quei run hanno avuto successo). Nessun'altra anomalia.

`Closes #2573`

## Non implementato (ancora)

- **Sibling-pattern sweep**: `check-sibling-patterns.mjs` segnala 15 file gemelli che condividono i token `targetLang`/`sourceContent` (utility di traduzione job: `free-translate.mjs`, `job-localization-pipeline.mjs`, `re-localize-jobs.mjs`, ecc.). Verificati a mano: **classe diversa** — nessuno di quei file orchestra un `Promise.all` multi-locale che scarta un *articolo intero* sul throw di una sotto-chiamata. L'antipattern qui è specifico dell'orchestrazione di `translateArticle`; il sibling reale (FAQ) era già guardato e ora meta+body sono coerenti. Token-match coincidente, non stesso bug → non toccati.
- **Robustezza di `repairLlmJson`**: non esteso per riparare il caso specifico (quote interna non-escaped al position 1895). Concern separato e più rischioso; la resilienza per-chiamata rende già non-fatale qualsiasi JSON non riparabile, che è il fix di root cause per "un locale rompe tutto l'articolo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)