### PR TITLE
fix(crawler-health): empty-OK for wuerth-international, suchtfachstelle-zuerich, moncucco

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -184,6 +184,28 @@ const EMPTY_OK_CRAWLERS = new Set([
   // #1245 as fragile/per-tenant.
   'paraplegie',
   'upd',
+  // Würth International (Chur, GR): the careers listing
+  // (https://www.wurth-international.com/web/en/wurthinternational/jobs_career/jobs/Jobs.php)
+  // returns HTTP 200 with its unchanged structure but currently shows "Keine
+  // Stellen" (no positions) and zero job-detail links. The Würth holding's Chur
+  // HQ legitimately has stretches with no open roles; the parser correctly
+  // returns 0 and re-arms when a vacancy reappears. Same legitimately-empty
+  // small-employer case as linnea and banca-raiffeisen-vedeggio-cassarate.
+  'wuerth-international',
+  // Suchtfachstelle Zürich: the careers page
+  // (https://www.suchtfachstelle.zuerich/ueber-uns/offene-stellen) returns
+  // HTTP 200 with the employer section intact but currently lists zero
+  // "/stellenausschreibung-*" openings. A single addiction-counselling NGO
+  // legitimately has no vacancies for weeks; the parser/regex is healthy and
+  // re-arms when an opening is published.
+  'suchtfachstelle-zuerich',
+  // Clinica Moncucco (Lugano, TI): the careers page
+  // (https://www.moncucco.ch/lavora-con-noi.php) returns HTTP 200 and its
+  // ".listing-job" container explicitly states "Nessun annuncio presente al
+  // momento" with zero ".item-job" children. The hospital legitimately has no
+  // open competitions right now; the selector is healthy and re-arms when a
+  // listing reappears.
+  'moncucco',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Implementato
- Aggiunti `wuerth-international`, `suchtfachstelle-zuerich`, `moncucco` a `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs`, ciascuno con commento che documenta la sorgente verificata live (HTTP 200, struttura intatta, zero offerte pubblicate al momento).
- Diagnosi live confermata per ciascuno: Würth International → "Keine Stellen" + 0 link job-detail; Suchtfachstelle Zürich → 0 link `/stellenausschreibung-*`; Moncucco → `.listing-job` = "Nessun annuncio presente al momento". I parser/selettori sono sani: il risultato vuoto è lo stato reale della sorgente, non un break.
- Effetto: `emptyOk=true` azzera `consecutiveEmptyRuns` (logica esistente a `nextCrawlerState`, riga 334-336) → la prossima run di health-check riporta i 3 crawler a `healthy`. Stesso pattern dei 12 ingressi legittimamente-vuoti già presenti (manor, linnea, ail-lugano, ...).

Closes #2562
Closes #2561
Closes #2533

## Non implementato (ancora)
- Nessun reset manuale di `data/crawler-health.json`: il file è rigenerato dal workflow di health-check, che ricalcola `status` alla prossima run con `emptyOk=true` → non serve toccare il dump generato.
- Nessuna modifica ai parser: verificato che selettori/regex matchano ancora l'HTML live corrente delle 3 sorgenti; non c'è HTML-drift da patchare.
- Sibling-sweep: la modifica è in un unico set condiviso (`EMPTY_OK_CRAWLERS`); nessun costrutto duplicato in file gemelli (`node scripts/ci/check-sibling-patterns.mjs` non applicabile — singolo set, nessun helper/costante estratta).