### PR TITLE
fix(dedicated-crawler): defer translation issues when the free-translate cascade is down (#2536, #2570)

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { detectLanguage, detectLanguageWithConfidence } from './detect-language.mjs';
-import { freeTranslateWithRetry } from './free-translate.mjs';
+import { freeTranslateWithRetry, getCascadeStats } from './free-translate.mjs';
 import {
   translateTextWithLocalPipeline,
   localizeJobContentWithPipeline,
@@ -3791,6 +3791,39 @@ export async function runDedicatedBaseCrawler({
   await runSharedCrawlerInProcess({ root, env });
 }
 
+/**
+ * Decide whether the translation INFRASTRUCTURE (not an individual job's
+ * translation) is down, so untranslated descriptions should defer to
+ * translate-pending.yml instead of hard-failing the dedicated crawler.
+ *
+ * Two independent layers can fail:
+ *  - LLM model pool (ai-models.mjs): no model available, or ≥3 models exhausted;
+ *  - free-translate cascade (Azure/MyMemory/NLLB/Libre/Lingva/...): exercised
+ *    this run (`calls > 0`) but produced zero successes ⇒ every provider down.
+ *
+ * Pure + side-effect-free so the gate behaviour is unit-testable without the
+ * ai-models / free-translate module-global singletons.
+ *
+ * @param {Object} o
+ * @param {boolean} [o.aiModelsLoaded=false] whether ai-models.mjs was imported.
+ * @param {boolean|null} [o.aiModelsAvailable=null] `isAnyModelAvailable()` (null on error/unknown).
+ * @param {number} [o.aiExhaustedCount=0] number of exhausted LLM models.
+ * @param {{calls:number,successes:number}|null} [o.cascade=null] free-translate cascade stats.
+ * @returns {{ llmDown: boolean, cascadeDown: boolean, infraDown: boolean }}
+ */
+export function isTranslationInfraDown({
+  aiModelsLoaded = false,
+  aiModelsAvailable = null,
+  aiExhaustedCount = 0,
+  cascade = null,
+} = {}) {
+  const llmDown =
+    aiModelsLoaded && (aiModelsAvailable === false || (aiExhaustedCount ?? 0) >= 3);
+  const cascadeDown =
+    Boolean(cascade) && (cascade.calls ?? 0) > 0 && (cascade.successes ?? 0) === 0;
+  return { llmDown, cascadeDown, infraDown: llmDown || cascadeDown };
+}
+
 export function validateDedicatedLocaleCoverage({
   strictEnvVar,
   label,
@@ -3812,6 +3845,8 @@ export function validateDedicatedLocaleCoverage({
   sampleLimit = 30,
   minSourceDescriptionCharsForHardValidation = minDescriptionChars,
   maxToleratedMissingDescriptions = 0,
+  // Injectable for tests; defaults to the live free-translate cascade metrics.
+  getCascadeStatsFn = getCascadeStats,
 }) {
   const resolvedDataJobsPath = dataJobsPath || jobsPath;
 
@@ -3967,21 +4002,41 @@ export function validateDedicatedLocaleCoverage({
       'missing_title', 'untranslated_title',
     ]);
     let effectiveTolerance = maxToleratedMissingDescriptions;
-    let allAiExhausted = false;
-    let aiInfrastructureFailure = false;
+
+    // Detect whether the translation INFRASTRUCTURE is down (vs an individual
+    // job's translation being absent). Two independent layers can fail: the LLM
+    // model pool (ai-models.mjs) and the free-translate cascade (Azure / MyMemory
+    // / NLLB / Libre / Lingva / ...). Until #2536/#2570 the gate only inspected
+    // the LLM pool, so when every Azure key 401'd and the free tiers were
+    // off/empty — `_aiModels` reporting "0 exhausted" because it was never the
+    // bottleneck — untranslated descriptions hard-failed the dedicated crawler
+    // and discarded successfully-crawled jobs. `isTranslationInfraDown` now ORs
+    // in the cascade signal (exercised this run but zero successes ⇒ every
+    // provider down). Side-effect-free + injectable so the gate is unit-testable.
+    let aiModelStats = null;
+    let aiModelsAvailable = null;
     if (_aiModels) {
-      try {
-        const stats = _aiModels.getStats();
-        allAiExhausted = !_aiModels.isAnyModelAvailable();
-        aiInfrastructureFailure =
-          allAiExhausted || (stats.exhaustedModels && stats.exhaustedModels.length >= 3);
-        if (aiInfrastructureFailure) {
-          const translationIssueCount = blockingIssues.filter((i) => TRANSLATION_ISSUES.has(i.reason)).length;
-          console.warn(`⚠️  AI quota exhaustion detected (${stats.exhaustedModels?.length || 0} models exhausted). ` +
-            `${translationIssueCount} jobs have incomplete translations — saved with needsRetranslation flag. ` +
-            `Run translate-pending workflow before deploying.`);
-        }
-      } catch { /* stats not available */ }
+      try { aiModelStats = _aiModels.getStats(); } catch { /* stats not available */ }
+      try { aiModelsAvailable = _aiModels.isAnyModelAvailable(); } catch { /* not available */ }
+    }
+    let cascade = null;
+    try { cascade = getCascadeStatsFn(); } catch { /* cascade stats not available */ }
+
+    const infra = isTranslationInfraDown({
+      aiModelsLoaded: Boolean(_aiModels),
+      aiModelsAvailable,
+      aiExhaustedCount: aiModelStats?.exhaustedModels?.length ?? 0,
+      cascade,
+    });
+    const aiInfrastructureFailure = infra.infraDown;
+    if (aiInfrastructureFailure) {
+      const translationIssueCount = blockingIssues.filter((i) => TRANSLATION_ISSUES.has(i.reason)).length;
+      const detail = infra.cascadeDown && !infra.llmDown
+        ? `free-translate cascade exhausted (${cascade.calls} calls, 0 successes — all translation providers down)`
+        : `AI quota exhaustion (${aiModelStats?.exhaustedModels?.length || 0} models exhausted)`;
+      console.warn(`⚠️  Translation infrastructure failure: ${detail}. ` +
+        `${translationIssueCount} jobs have incomplete translations — saved with needsRetranslation flag. ` +
+        `Run translate-pending workflow before deploying.`);
     }
 
     // Treat SKIP_AI_TRANSLATION=1 and confirmed AI quota exhaustion as the same

--- a/tests/dedicated-crawler-translation-infra-gate.test.ts
+++ b/tests/dedicated-crawler-translation-infra-gate.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Translation-infrastructure gate — `isTranslationInfraDown`
+ * (issues #2536 Klinik Gut, #2570 ALTEN).
+ *
+ * The dedicated-crawler localization guard defers untranslated descriptions to
+ * translate-pending.yml (instead of hard-failing the run and discarding a
+ * successfully-crawled job) ONLY when the translation INFRASTRUCTURE is down —
+ * not when a single job merely happens to be untranslated.
+ *
+ * Before this fix the gate inspected only the LLM model pool (ai-models.mjs).
+ * When every Azure key 401'd and the free tiers were off/empty, the LLM pool
+ * reported "0 exhausted" (it was never the bottleneck), so the free-translate
+ * cascade dying went undetected and the crawler hard-failed. The gate now ORs
+ * in the cascade signal: exercised this run (`calls > 0`) but zero successes ⇒
+ * every translation provider is down.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isTranslationInfraDown } from '../scripts/lib/dedicated-crawler-common.mjs';
+
+describe('isTranslationInfraDown — translation infrastructure detection', () => {
+  it('healthy: LLM available + cascade producing successes → NOT down', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: true,
+      aiExhaustedCount: 0,
+      cascade: { calls: 12, successes: 12 },
+    });
+    expect(r).toEqual({ llmDown: false, cascadeDown: false, infraDown: false });
+  });
+
+  it('cascade exhausted (calls>0, 0 successes) while LLM "available" → down via cascade (the #2536/#2570 case)', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: true,
+      aiExhaustedCount: 0, // LLM pool reports healthy — it was never the bottleneck
+      cascade: { calls: 8, successes: 0 }, // Azure 401 + free tiers off → every call failed
+    });
+    expect(r.cascadeDown).toBe(true);
+    expect(r.llmDown).toBe(false);
+    expect(r.infraDown).toBe(true);
+  });
+
+  it('LLM pool unavailable → down via LLM (legacy behaviour preserved)', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: false,
+      aiExhaustedCount: 0,
+      cascade: { calls: 5, successes: 5 },
+    });
+    expect(r.llmDown).toBe(true);
+    expect(r.infraDown).toBe(true);
+  });
+
+  it('LLM pool ≥3 models exhausted → down via LLM (legacy behaviour preserved)', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: true,
+      aiExhaustedCount: 3,
+      cascade: { calls: 5, successes: 5 },
+    });
+    expect(r.llmDown).toBe(true);
+    expect(r.infraDown).toBe(true);
+  });
+
+  it('cascade with successes>0 (partially working) → NOT down: genuine per-job gaps stay subject to base tolerance', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: true,
+      aiExhaustedCount: 1, // below the ≥3 threshold
+      cascade: { calls: 20, successes: 4 },
+    });
+    expect(r.infraDown).toBe(false);
+  });
+
+  it('cascade never exercised (calls=0) → NOT cascade-down (avoids false defer before any translate call)', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: true,
+      aiModelsAvailable: true,
+      aiExhaustedCount: 0,
+      cascade: { calls: 0, successes: 0 },
+    });
+    expect(r.cascadeDown).toBe(false);
+    expect(r.infraDown).toBe(false);
+  });
+
+  it('ai-models not loaded but cascade exhausted → still down via cascade', () => {
+    const r = isTranslationInfraDown({
+      aiModelsLoaded: false,
+      aiModelsAvailable: null,
+      aiExhaustedCount: 0,
+      cascade: { calls: 6, successes: 0 },
+    });
+    expect(r.llmDown).toBe(false);
+    expect(r.cascadeDown).toBe(true);
+    expect(r.infraDown).toBe(true);
+  });
+
+  it('missing/null inputs → safe default (not down)', () => {
+    expect(isTranslationInfraDown({}).infraDown).toBe(false);
+    expect(isTranslationInfraDown().infraDown).toBe(false);
+    expect(isTranslationInfraDown({ aiModelsLoaded: true, cascade: null }).infraDown).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato
- **Root cause**: la gate di localizzazione `validateDedicatedLocaleCoverage` (in `scripts/lib/dedicated-crawler-common.mjs`, shared da **tutti** i dedicated crawler) deferiva le descrizioni non tradotte a `translate-pending.yml` **solo** quando il pool LLM (`ai-models.mjs`) era esaurito. Era **cieca all'altro layer di traduzione** — la cascade free-translate (Azure / MyMemory / NLLB / Libre / Lingva / ...). Quando tutte le chiavi Azure davano 401 e i free-tier erano off/empty, il pool LLM riportava `0 exhausted` (non era mai il collo di bottiglia) → la gate faceva **hard-fail** del run su descrizioni non tradotte e **scartava job già crawlati con successo** (Klinik Gut #2536: crawl OK 1 job, "validation failed (4 issues)"; ALTEN #2570: Azure 401 entrambe le chiavi → "validation failed (1 issue)").
- **Fix strutturale**: estratto un helper **puro e side-effect-free** `isTranslationInfraDown()` che fa l'OR dei due segnali di *infrastruttura giù* (non del singolo job):
  - LLM pool down: nessun modello disponibile **oppure** ≥3 modelli esauriti;
  - cascade down: esercitata in questo run (`calls > 0`) ma **zero successi** ⇒ ogni provider è giù.
  Un `successes > 0` (cascade parzialmente funzionante) **non** defera: i gap genuini per-job restano soggetti alla base-tolerance esistente → niente over-defer.
- Wiring in `validateDedicatedLocaleCoverage` via opzione iniettabile `getCascadeStatsFn` (default = metriche live di `free-translate.mjs`), così la gate è unit-testabile senza i singleton module-global.
- **8 unit test** (`tests/dedicated-crawler-translation-infra-gate.test.ts`) coprono la matrice: healthy / cascade-down (il caso #2536/#2570) / LLM-down / ≥3-exhausted / partial-working / cascade-non-esercitata / ai-models-assente / input nulli. Test esistenti (localization-coverage + thin-source-ratio gate) restano verdi (17/17 localmente).

Closes #2536
Closes #2570

## Non implementato (ancora)
- **Rotazione segreto Azure** (`AZURE_TRANSLATOR_KEY` / `AZURE_TRANSLATOR_KEY_2`): il 401 su entrambe le chiavi indica che sono scadute/revocate. È un intervento **operativo sui secret**, non un fix di codice — fuori scope di questa PR. Questo fix rende comunque il crawler resiliente a prescindere (defer invece di discard); la traduzione mancante viene recuperata da `translate-pending.yml` quando un provider torna disponibile.
- **Sibling sweep**: l'antipattern (check infra LLM-only, cieco alla cascade) vive **solo** in questa gate condivisa — tutti i ~40 dedicated crawler vi passano per costruzione, nessuna copia per-crawler da sweepare. `check-sibling-patterns.mjs` surface-a file che usano i token `free-translate`/`isAnyModelAvailable`/`getStats` (es. `create-article.mjs`, `relocalize-pending-jobs.mjs`), ma sono **consumer della libreria di traduzione**, non duplicati della logica di gate: non condividono l'antipattern, nessuno va toccato.