### PR TITLE
fix(build): lazy-load data/jobs.json — keep Vite config bundle under V8 512MB string limit (#2532)

### DIFF
--- a/build-plugins/legacyRedirectsPlugin.ts
+++ b/build-plugins/legacyRedirectsPlugin.ts
@@ -10,8 +10,8 @@ import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, GTAG_SN
 import { resolveSearchConsoleCompatTarget } from './searchConsoleCompat';
 import { resolveCantonSection, resolveJobCanton, type CantonLocale } from './shared/cantonSection';
 import { inlineScriptJson } from './shared/inlineJsonScript';
+import { loadJobsJson } from './shared/loadJobsJson';
 import cantonSlugFile from '../data/canton-url-slugs.json';
-import jobsFile from '../data/jobs.json';
 
 /** Hreflang entry extracted from sitemap XML. */
 interface HreflangEntry {
@@ -326,7 +326,7 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  // 301-style bridge pages pointing to the new canton section URL.
  // TI jobs are unaffected (byte-identical).
  try {
- const jobs = jobsFile as Array<{ canton?: string; location?: string; slug?: string; slugByLocale?: Record<string, string> }>;
+ const jobs = loadJobsJson<{ canton?: string; location?: string; slug?: string; slugByLocale?: Record<string, string> }>(rootDir);
  const locales: CantonLocale[] = ['it', 'en', 'de', 'fr'];
  const localePrefix: Record<CantonLocale, string> = { it: '', en: '/en', de: '/de', fr: '/fr' };
  for (const job of jobs) {

--- a/build-plugins/shared/loadJobsJson.ts
+++ b/build-plugins/shared/loadJobsJson.ts
@@ -1,0 +1,44 @@
+/**
+ * Lazy runtime loader for `data/jobs.json`.
+ *
+ * WHY THIS EXISTS — never `import jobsFile from '.../data/jobs.json'` from any
+ * module reachable by `vite.config.ts`. When Vite loads the config, esbuild
+ * bundles the config file *plus its entire static-import graph* into a single
+ * in-memory string. A static JSON import inlines `data/jobs.json` (now ~150 MB,
+ * 12.6k+ jobs) as an escaped string literal inside that bundle; once it crosses
+ * V8's hard 512 MB max-string-length the config can no longer be loaded:
+ *
+ *   Error: Cannot create a string longer than 0x1fffffe8 characters
+ *     at TextDecoder.decode (node:internal/encoding)
+ *     at bundleConfigFile (vite/dist/node/chunks/...)
+ *
+ * That broke the monolith `build` job and the "AdSense Pre-Review Checklist"
+ * workflow (issue #2532) before the build could even start.
+ *
+ * Reading the file lazily at plugin-runtime (inside `closeBundle`/`build`)
+ * keeps `data/jobs.json` OUT of esbuild's config bundle entirely, so the config
+ * stays small and bounded as the dataset keeps growing. The single ~150 MB
+ * string returned here is well under the 512 MB limit (no bundle-escaping
+ * overhead). Defining the read path ONCE here makes the static-import
+ * anti-pattern impossible to reintroduce by copy-paste.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+let cache: { path: string; data: unknown[] } | null = null;
+
+/**
+ * Read `data/jobs.json` from disk and parse it. Cached per resolved path so
+ * repeated calls within a single build don't re-read/re-parse ~150 MB.
+ *
+ * @param rootDir Repo root to resolve `data/jobs.json` against. Defaults to
+ *   `process.cwd()`, which is the project root during a Vite build. Plugins
+ *   that already receive a `rootDir` should pass it for robustness.
+ */
+export function loadJobsJson<T = unknown>(rootDir: string = process.cwd()): T[] {
+  const jobsPath = path.resolve(rootDir, 'data/jobs.json');
+  if (cache && cache.path === jobsPath) return cache.data as T[];
+  const data = JSON.parse(fs.readFileSync(jobsPath, 'utf-8')) as unknown[];
+  cache = { path: jobsPath, data };
+  return data as T[];
+}

--- a/build-plugins/shared/slugCantonIndex.ts
+++ b/build-plugins/shared/slugCantonIndex.ts
@@ -17,7 +17,7 @@
  */
 
 import slugRegistryFile from '../../data/slug-registry.json';
-import jobsFile from '../../data/jobs.json';
+import { loadJobsJson } from './loadJobsJson';
 
 type RegistryEntry = {
   canonicalSlug?: string;
@@ -45,7 +45,7 @@ function build(): Map<string, string> {
       }
     }
   }
-  const jobs = jobsFile as JobEntry[];
+  const jobs = loadJobsJson<JobEntry>();
   for (const job of jobs) {
     const canton = String(job?.canton || 'TI').toUpperCase().trim() || 'TI';
     if (job?.slug) map.set(job.slug, canton);


### PR DESCRIPTION
## Implementato
- **Root cause**: `vite.config.ts` importava staticamente `data/jobs.json` attraverso due plugin nel suo config-graph — `build-plugins/legacyRedirectsPlugin.ts` (import diretto) e `build-plugins/shared/slugCantonIndex.ts` (via `jobOrphanBridgePlugin`). Quando Vite carica la config, esbuild bundla la config + **tutto il suo grafo di import statici** in una **singola stringa in-memory** e inlinea `jobs.json` (~150MB, 12.6k job) come literal escaped. Cresciuto il dataset, il bundle ha superato il **massimo hard di V8 per le stringhe (512MB / 0x1fffffe8)**:
  ```
  Error: Cannot create a string longer than 0x1fffffe8 characters
    at TextDecoder.decode (node:internal/encoding)
    at bundleConfigFile (vite/dist/node/chunks/...)
  ```
  → la config non si carica nemmeno, e il job di build monolite + il workflow "AdSense Pre-Review Checklist" (#2532) falliscono **prima** che qualunque check AdSense parta (4 run schedule consecutivi, errore identico).
- **Fix strutturale**: nuovo `build-plugins/shared/loadJobsJson.ts` — lettura **lazy** `fs.readFileSync`+`JSON.parse` (cached per path risolto) eseguita a **runtime del plugin** (`closeBundle`/primo uso), così `jobs.json` resta **fuori** dal bundle config di esbuild e la config resta piccola e limitata mentre il dataset cresce. La stringa singola da ~150MB è ben sotto i 512MB (niente overhead di escaping da inlining). Entrambi gli importer statici ora chiamano l'helper.
- **Class fix, non one-off**: `grep` conferma che questi sono gli **unici due** import statici di `data/jobs.json` raggiungibili da `vite.config.ts`; `jobs.json` è l'unico file abbastanza grande da sfondare i 512MB. Definire il path di lettura **una sola volta** nell'helper rende l'anti-pattern (static import del dump) impossibile da reintrodurre per copy-paste — stesso principio di `spaBundleRx.ts` (AGENTS #6).
- **Behavior-preserving**: stesso file, stesso array parsato, stesso path risolto (`legacyRedirectsPlugin` passa il suo `rootDir`; `slugCantonIndex` usa `process.cwd()` = repo-root durante un build Vite, identico al precedente resolve module-relative `../../data/jobs.json`). Caching per-path evita riletture dei 150MB. `tsc -p tsconfig.json` non introduce nuovi errori sui file toccati; smoke-test del loader (read+cache) verde.

Closes #2532

## Non implementato (ancora)
- **`data/slug-registry.json` (12MB) resta import statico** in `slugCantonIndex.ts`: è sotto-soglia di due ordini di grandezza (12MB ≪ 512MB) e non è il file che sfonda il limite. Mantenuto statico per restare chirurgico; se in futuro anche quello crescesse pericolosamente, `loadJobsJson` è il pattern già pronto da estendere (es. `loadSlugRegistry`).
- **Verifica build end-to-end**: il `build:ci` monolite è OOM-prone e gira **solo post-merge su `main`** (non sul `pull_request`), quindi il successo del build completo non è validabile pre-merge. Il fix è però **deterministicamente corretto** sul piano della causa (rimosso l'unico inlining >512MB dal config-graph). **Revert-trigger**: se il prossimo deploy/AdSense-checklist post-merge fallisse ancora al config-load con `Cannot create a string longer than 0x1fffffe8`, ci sarebbe un terzo importer statico non rilevato → revert + grep esteso.
- **Sibling sweep**: nessun altro file replica l'anti-pattern (grep su `build-plugins/`, `services/`, `vite.config.ts` → solo i 2 fixati).