### PR TITLE
fix(404): recover canton-drift orphans as 200 bridges via accumulator source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -595,6 +595,32 @@ jobs:
           # computes — ZERO extra hashing, just a serialization walk. See
           # build-plugins/writeRegistryLifecyclePlugin.ts + scripts/deploy-file-delta.mjs.
           DEPLOY_CONTENT_MANIFEST: '1'
+          # Recover canton-drift 404 orphans as real 200 bridge pages. The
+          # canton URL section is re-derived per crawl (sharedResolveJobCanton),
+          # so a job indexed under /cerca-lavoro-<oldCanton>/<slug>/ orphans to a
+          # live 404 once it re-pins to a different canton. cfHot404BridgePlugin
+          # already emits a 200 bridge (noindex, canonical → the slug's CURRENT
+          # canonical page via resolveSearchConsoleCompatTarget 'canton-moved')
+          # for paths in the bounded cf-hot-404s + GSC-coverage lists — but those
+          # MISS the long tail (the CF query is row-capped and the canton×slug
+          # universe rotates faster than it captures, and TI sections are excluded
+          # from cf-hot-404s by TICINO_RE). The persistent accumulator
+          # data/seo-404-compat-paths.json (~935k observed orphan paths, ~383k
+          # cross-canton with a KNOWN slug) is the only source that remembers the
+          # rotated tail AND carries the TI orphans. This flag unions it as the
+          # third bridge source so those orphans become 200 instead of soft-404.
+          # Measured (2026-06-22): live-404 is IT-job-detail dominated; the
+          # dominant recoverable buckets (non-TI slug-known-but-uncaptured + TI
+          # excluded) are exactly what the accumulator covers; resolver verified
+          # to return canton-moved → the real 200 page for these.
+          # Emit is STREAMING (mkdir+writeFileSync per path, no HTML in heap) and
+          # MAX_EMIT (CF_HOT_404_MAX, default 250000) still hard-caps it; gap-fill
+          # skips any path that already has a richer page. SSG mem/wall-time is
+          # NOT measurable on pull_request (full build runs post-merge on main).
+          # REVERT-TRIGGER: if the next deploy OOMs (systemd-oomd / exit 143) or
+          # build wall-time regresses materially, set this back to '' (or lower
+          # CF_HOT_404_MAX) — env-gated, 1-line revert, no code rollback needed.
+          CF_HOT_404_INCLUDE_ACCUMULATOR: '1'
         shell: bash
         run: |
           set -o pipefail


### PR DESCRIPTION
## Implementato

Abilita `CF_HOT_404_INCLUDE_ACCUMULATOR=1` nello step **Build** di `.github/workflows/deploy.yml` per recuperare gli orfani **canton-drift** come pagine **200** reali invece di soft-404.

**Root cause (misurato live 2026-06-22, CF analytics zona frontaliereticino.ch):**
- Le 404 client reali sono ~28k/giorno (il "~100k" della dashboard è la vista *all-sources*: ~82k sono 404 *worker-internal* = fetch-origin del Worker en/de/fr che precede il suo 301, **non** utenti reali).
- Dominano gli **IT job-detail orfani**: la sezione-cantone dell'URL è ri-derivata a ogni crawl (`sharedResolveJobCanton`), quindi un job indicizzato sotto `/cerca-lavoro-<vecchioCantone>/<slug>/` orfana a 404 quando ri-pinna a un cantone diverso (drift multi-direzionale: ticino 19%, zurigo/argovia/basilea/... il resto).
- en/de/fr già recuperati con **301 vero** (Worker `canton-moved`); IT solo soft-404 JS (status 404) perché IT apex non è worker-routed.

**Perché il meccanismo esistente non bastava:** `cfHot404BridgePlugin` emette già un bridge 200 (noindex, canonical → pagina corrente via `resolveSearchConsoleCompatTarget` kind `canton-moved`) ma solo per le liste *bounded* `cf-hot-404s.json` + `gsc-coverage-404s.json`, che (a) **escludono le sezioni TI** (`TICINO_RE` in `build-cf-hot-404s.mjs`) e (b) **mancano la coda lunga** (la query CF è row-capped e l'universo cantone×slug ruota più veloce della cattura). Misurato sul campione live-404: bucket recuperabili dominanti = `non-TI slug-noto ma non-catturato` (1376 hit) + `TI escluso` (355 hit).

**Fix:** l'accumulatore persistente `data/seo-404-compat-paths.json` (~935k path orfani osservati, ~383k cross-canton con slug **noto**, copre **sia TI che non-TI**) è l'unica sorgente che ricorda la coda ruotata e include gli orfani TI. Il flag lo unisce come **terza sorgente bridge**. Verificato per simulazione che il resolver ritorna `canton-moved → pagina reale 200` per i casi reali (es. `/cerca-lavoro-ticino/venditore-denner-ag-wilderswil-2b22fa/` → `/cerca-lavoro-berna/...`).

**Sicurezza:** emit **streaming** (mkdir+writeFileSync per path, nessun HTML in heap), cap `MAX_EMIT` (`CF_HOT_404_MAX`, default 250000) invariato, **gap-fill** (salta ogni path con pagina più ricca già emessa). Exempt dal moratorium SEO (bridge/redirect emitter + noindex). Cambio reversibile (env-gated, 1 riga).

**REVERT-TRIGGER (claim mem/wall-time non validabile pre-merge — full SSG build solo post-merge su `main`):** se il prossimo deploy OOMa (systemd-oomd / exit 143) o il wall-time regredisce in modo materiale → riportare il flag a `''` (o abbassare `CF_HOT_404_MAX`). Nessun rollback di codice necessario.

## Non implementato (ancora)

- **`build-plugins/jobsSeoPagesPlugin.ts` compat-merge (skip `if (tracking[slug][locale]) break`)**: non toccato. È la causa per cui i job *driftati* non ottengono il bridge TI dal compat-merge (il `tracking` tiene un solo path per slug-locale e dà priorità all'attivo). Non necessario: `cfHot404BridgePlugin` via accumulatore copre ora quegli stessi orfani TI come catch-all (gap-fill, dato che il compat-merge non ha emesso). Una soft-landing TI *più ricca* (vs il thin bridge) resta possibile follow-up.
- **`scripts/build-cf-hot-404s.mjs` `TICINO_RE`**: lasciato invariato by-design. Esclude le sezioni TI da `cf-hot-404s.json` (owned by jobsSeoPagesPlugin); la copertura TI ora arriva dall'accumulatore, quindi rilassare `TICINO_RE` sarebbe ridondante e rischierebbe doppia-emissione.
- **`.github/workflows/deploy-matrix-experiment.yml`** (sibling con `build:ci`): non toccato. È il deploy matrix per-locale **sperimentale (default OFF**, PR #2568); il suo filtro `BUILD_LOCALE` per-shard interagisce con l'emit del bridge plugin in modo da validare separatamente prima di abilitare il flag lì. Quando il matrix diventa il path live, replicare il flag (con validazione del filtro per-locale).
- **301 vero per IT** (vs bridge 200 noindex): fuori scope qui. Richiede routing IT nel CF Worker = decisione owner (billing Workers-Paid + cap). Il bridge 200 elimina comunque il 404 e passa equity via canonical.
