### PR TITLE
fix(ci): precise collision auto-merge gate — block only on unincorporated merged peers (#2424)

### DIFF
--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -22,9 +22,11 @@
  *      l'unico caso di merge MANUALE residuo). Un `🔴` reale blocca comunque.
  *   3. check-run `vitest (unit + integration)` sulla HEAD == `success`
  *      (NON solo != failure: richiede success → niente merge su pending/missing).
- *   4. Collision gate (P3): se la PR ha label `collision-risk` ED è behind
- *      origin/main → NON mergiare (va prima rebasata oltre la PR collidente;
- *      pr-autorebase la rebasa). `collision-risk` ma 0 behind → consentito.
+ *   4. Collision gate (P3, preciso #2424): se la PR ha label `collision-risk`
+ *      ED è behind origin/main, blocca SOLO se un peer collidente già MERGIATO
+ *      (dai marker `<!-- COLLISION:N -->`) non è ancora incluso in head — il
+ *      vero hazard #1454. Behind per soli commit main NON correlati → consentito
+ *      (evita starvation/livelock sotto main trafficato). 0 behind → consentito.
  *
  * Se tutti i gate passano → squash-merge con PAT (stesso meccanismo di prima:
  * PRIMARY_TOKEN=GITHUB_PAT per il cascade deploy/followup, fallback GITHUB_TOKEN).
@@ -188,6 +190,58 @@ const PR_BODY_NONIMPL_RE = /^\s{0,3}#{2,3}\s+Non implementato\b/im;
 export function prBodyContractOk(body = '') {
   if (!PR_BODY_IMPL_RE.test(body) || !PR_BODY_NONIMPL_RE.test(body)) return false;
   return checkClosesLines(body).ok;
+}
+
+/**
+ * Estrae i numeri delle PR collidenti registrate da `pr-collision-detector.mjs`
+ * come marker `<!-- COLLISION:N -->` nel flusso commenti di una PR.
+ * @param {string} commentsText concatenazione dei body dei commenti.
+ * @returns {number[]} numeri di PR peer (dedup, ordine di apparizione).
+ */
+export function parseCollisionPeers(commentsText = '') {
+  const peers = [];
+  const seen = new Set();
+  const re = /<!-- COLLISION:(\d+) -->/g;
+  let m;
+  while ((m = re.exec(commentsText)) !== null) {
+    const n = parseInt(m[1], 10);
+    if (!seen.has(n)) { seen.add(n); peers.push(n); }
+  }
+  return peers;
+}
+
+/**
+ * Gate collision PRECISO (#2424). Una PR `collision-risk` dietro main è sicura
+ * da mergiare sse OGNI peer collidente GIÀ MERGIATO è incluso in head — l'unico
+ * vero hazard #1454 — invece di esigere 0-behind rispetto a TUTTO main (che
+ * sotto main trafficato causa starvation/livelock: un merge non correlato
+ * riporta la PR behind>0 → re-rebase → re-vitest all'infinito).
+ *
+ * I peer ancora OPEN non portano hazard: se questa PR mergia per prima, il
+ * detector forza loro il rebase (flow esistente). I peer CLOSED-non-merged
+ * idem. Solo i peer MERGIATI il cui commit non è ancora in head bloccano.
+ *
+ * Puro e side-effect-free → unit-testabile senza `gh`. Il caller calcola
+ * `includedInHead` per ogni peer mergiato via compare API (ancestry).
+ *
+ * @param {{ behind?: number, mergedPeers?: {number:number, includedInHead:boolean}[] }} o
+ * @returns {{ allow: boolean, reason: string }}
+ */
+export function collisionGateDecision({ behind = 0, mergedPeers = [] } = {}) {
+  if (behind <= 0) return { allow: true, reason: '0 dietro main' };
+  const missing = mergedPeers.filter((p) => !p.includedInHead);
+  if (missing.length > 0) {
+    return {
+      allow: false,
+      reason: `peer collidenti mergiati non ancora inclusi in head: ${missing.map((p) => `#${p.number}`).join(', ')} — serve rebase oltre quei peer (pr-autorebase la gestisce)`,
+    };
+  }
+  return {
+    allow: true,
+    reason: mergedPeers.length > 0
+      ? `behind ${behind} commit ma tutti i ${mergedPeers.length} peer collidenti mergiati sono inclusi in head → hazard #1454 assente`
+      : `behind ${behind} commit ma nessun peer collidente mergiato (solo commit main non correlati) → hazard #1454 assente`,
+  };
 }
 
 /**
@@ -383,9 +437,54 @@ function main() {
       return fail(`collision-risk PR #${PR}: impossibile calcolare behind_by (${String(e).slice(0, 120)}) — skip conservativo.`);
     }
     if (behind > 0) {
-      return fail(`collision-risk PR #${PR} è ${behind} commit dietro main — skip; va rebasata oltre la PR collidente prima del merge (pr-autorebase la gestisce).`);
+      // Gate PRECISO (#2424): blocca SOLO se un peer collidente già MERGIATO non
+      // è ancora incluso in head (il vero hazard #1454) — non per il semplice
+      // fatto che head sia dietro commit di main NON correlati (causa di
+      // starvation/livelock sotto main trafficato). Recupera i peer dai marker
+      // `<!-- COLLISION:N -->` lasciati da pr-collision-detector, e per ogni peer
+      // MERGIATO verifica via compare API che il suo merge-commit sia antenato di
+      // head (status ahead/identical).
+      let peers = [];
+      try {
+        const comments = gh(['api', `repos/${REPO}/issues/${PR}/comments`, '--paginate',
+          '--jq', '[.[].body] | join("\\n")'], { json: false }) || '';
+        peers = parseCollisionPeers(comments);
+      } catch (e) {
+        return fail(`collision-risk PR #${PR}: impossibile leggere i commenti per i peer collidenti (${String(e).slice(0, 120)}) — skip conservativo.`);
+      }
+      const mergedPeers = [];
+      for (const peer of peers) {
+        let pv;
+        try {
+          pv = gh(['pr', 'view', String(peer), '--repo', REPO, '--json', 'state,mergeCommit']);
+        } catch {
+          // Peer non leggibile: non posso escludere sia un hazard mergiato →
+          // conservativo, trattalo come non-incluso (blocca, pr-autorebase risolve).
+          mergedPeers.push({ number: peer, includedInHead: false });
+          continue;
+        }
+        // Solo i peer MERGIATI portano hazard; OPEN / CLOSED-non-merged no.
+        if (!pv || pv.state !== 'MERGED' || !pv.mergeCommit?.oid) continue;
+        const oid = pv.mergeCommit.oid;
+        let included = false;
+        try {
+          const status = gh(['api', `repos/${REPO}/compare/${oid}...${head}`, '--jq', '.status'],
+            { json: false }).trim();
+          included = status === 'ahead' || status === 'identical';
+        } catch {
+          // Inclusione indeterminabile → conservativo: non-incluso (blocca).
+          included = false;
+        }
+        mergedPeers.push({ number: peer, includedInHead: included });
+      }
+      const decision = collisionGateDecision({ behind, mergedPeers });
+      if (!decision.allow) {
+        return fail(`collision-risk PR #${PR}: ${decision.reason}.`);
+      }
+      console.log(`Gate collision (#2424 preciso): ${decision.reason} → consentito ✔`);
+    } else {
+      console.log(`Gate collision: collision-risk ma 0 dietro main → consentito ✔`);
     }
-    console.log(`Gate collision: collision-risk ma 0 dietro main → consentito ✔`);
   }
 
   // Tutti i gate passano → squash-merge.

--- a/tests/auto-merge-collision-gate.test.ts
+++ b/tests/auto-merge-collision-gate.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Precise collision gate — `collisionGateDecision` + `parseCollisionPeers`
+ * (issue #2424).
+ *
+ * The collision gate used to block a `collision-risk` PR whenever it was behind
+ * main by any amount (`behind_by > 0`). Under fast-moving main that starves the
+ * PR: an UNRELATED merge pushes it behind again between rebase and re-eval →
+ * re-rebase → re-vitest, forever (livelock). The real #1454 hazard is narrower:
+ * a colliding PEER that already merged must be incorporated into head. This gate
+ * blocks ONLY on that, while tolerating unrelated main commits.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  collisionGateDecision,
+  parseCollisionPeers,
+} from '../scripts/ci/auto-merge-eval.mjs';
+
+describe('parseCollisionPeers', () => {
+  it('extracts peer PR numbers from COLLISION markers', () => {
+    const comments = [
+      '<!-- COLLISION:2415 -->\nshared build-plugins/foo.ts',
+      'some unrelated comment',
+      '<!-- COLLISION:2420 -->\nshared scripts/lib/bar.mjs',
+    ].join('\n');
+    expect(parseCollisionPeers(comments)).toEqual([2415, 2420]);
+  });
+
+  it('dedups repeated markers and preserves first-seen order', () => {
+    const comments = '<!-- COLLISION:99 -->\nx\n<!-- COLLISION:7 -->\n<!-- COLLISION:99 -->';
+    expect(parseCollisionPeers(comments)).toEqual([99, 7]);
+  });
+
+  it('returns [] when no markers / empty input', () => {
+    expect(parseCollisionPeers('no markers here')).toEqual([]);
+    expect(parseCollisionPeers('')).toEqual([]);
+    expect(parseCollisionPeers()).toEqual([]);
+  });
+});
+
+describe('collisionGateDecision — precise #1454 hazard gate', () => {
+  it('0 behind → always allowed (unchanged base case)', () => {
+    const d = collisionGateDecision({ behind: 0, mergedPeers: [] });
+    expect(d.allow).toBe(true);
+  });
+
+  it('behind unrelated commits, NO merged peers → allowed (kills the starvation case)', () => {
+    // The whole point of #2424: behind>0 purely from unrelated main traffic must
+    // not block when no colliding peer has actually merged.
+    const d = collisionGateDecision({ behind: 12, mergedPeers: [] });
+    expect(d.allow).toBe(true);
+    expect(d.reason).toMatch(/nessun peer collidente mergiato/);
+  });
+
+  it('behind, merged peer NOT yet in head → blocked (preserves invariant #1454)', () => {
+    const d = collisionGateDecision({
+      behind: 3,
+      mergedPeers: [{ number: 2415, includedInHead: false }],
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toMatch(/#2415/);
+  });
+
+  it('behind, merged peer ALREADY in head → allowed (rebased past the peer)', () => {
+    const d = collisionGateDecision({
+      behind: 5,
+      mergedPeers: [{ number: 2415, includedInHead: true }],
+    });
+    expect(d.allow).toBe(true);
+    expect(d.reason).toMatch(/tutti i 1 peer/);
+  });
+
+  it('mixed peers: one incorporated, one not → blocked, names only the missing one', () => {
+    const d = collisionGateDecision({
+      behind: 8,
+      mergedPeers: [
+        { number: 2415, includedInHead: true },
+        { number: 2420, includedInHead: false },
+      ],
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain('#2420');
+    expect(d.reason).not.toContain('#2415');
+  });
+
+  it('all merged peers incorporated despite large behind → allowed', () => {
+    const d = collisionGateDecision({
+      behind: 40,
+      mergedPeers: [
+        { number: 1, includedInHead: true },
+        { number: 2, includedInHead: true },
+      ],
+    });
+    expect(d.allow).toBe(true);
+  });
+
+  it('safe defaults (no args) → allowed (0 behind)', () => {
+    expect(collisionGateDecision().allow).toBe(true);
+    expect(collisionGateDecision({}).allow).toBe(true);
+  });
+});


### PR DESCRIPTION
## Implementato
- **Problema (latente, #2424)**: il gate collision in `scripts/ci/auto-merge-eval.mjs` (gate 4) bloccava una PR `collision-risk` ogni volta che `behind_by > 0` rispetto a main. È **più stretto** del requisito di sicurezza reale dell'invariante #1454: la PR deve solo includere il **merge del peer collidente**, non ogni commit non correlato di main. Sotto main trafficato → **starvation/livelock**: un merge non correlato riporta la PR behind>0 tra il push dell'autorebase e l'evento `tests → workflow_run` che ri-valuta l'auto-merge → re-rebase → re-vitest all'infinito.
- **Fix strutturale (Opzione B, la raccomandazione dell'issue)**: quando `behind > 0`, recupero i peer collidenti dai marker `<!-- COLLISION:N -->` lasciati da `pr-collision-detector.mjs`, e per ogni peer **già MERGIATO** verifico via **compare API** (`repos/.../compare/<peerMergeOid>...<head>` → status `ahead`/`identical`) che il suo merge-commit sia **antenato di head**. Blocco **solo** se un peer mergiato non è ancora incluso. Peer **OPEN**/CLOSED-non-merged → nessun hazard (se questa PR mergia per prima, il detector forza loro il rebase — flow esistente).
- **Conservativo per costruzione**: peer non leggibile o ancestry indeterminabile (compare API fallisce) → trattato come **non-incluso → blocca** (mai indebolisce il gate sotto #1454). Nessun `git checkout` necessario: tutto via API, coerente col calcolo `behind_by` già presente.
- **Testabilità**: estratti due helper **puri ed esportati** — `parseCollisionPeers` (marker → numeri) e `collisionGateDecision({behind, mergedPeers})` (decisione allow/reason). **10 unit test** (`tests/auto-merge-collision-gate.test.ts`): 0-behind, behind+nessun-peer-mergiato (il caso starvation → ora consentito), peer-mergiato-non-incluso (bloccato, #1454 preservato), peer-incluso (consentito), mix, safe-default. Test esistenti (`auto-merge-drift-fallback`, `auto-merge-eval-fingerprint`) verdi → 28/28.
- Aggiornato il docblock di testa (descrizione gate 4) per riflettere il gate preciso (AGENTS #6: commenti in sync col meccanismo).

Closes #2424

## Non implementato (ancora)
- **Opzione A/C (anti-thrash autorebase a priorità leader / rebase minimale)**: l'issue raccomanda **B da solo** come fix della starvation; A è un complemento opzionale solo se il churn di rebase resta alto. `pr-autorebase.mjs` continua a rebasare a 0-behind, ma con il gate preciso il livelock è già eliminato (una volta incluso il peer mergiato, il merge è consentito a prescindere dal movimento successivo di main non correlato). Deferito: nessun incident attivo, valore marginale, scope separato.
- **Validazione live end-to-end del gate**: il path `workflow_run`/auto-merge non è esercitabile sul `pull_request`; la logica decisionale è coperta dagli unit test deterministici e le chiamate `gh`/compare API sono side-effect isolate dietro gli helper puri. Verifica reale alla prossima coppia collision-risk live post-merge.
- **Sibling sweep**: la logica del gate vive solo in `auto-merge-eval.mjs`; `pr-collision-detector.mjs` (produce i marker) e `pr-autorebase.mjs` (rebase) restano invariati e compatibili — nessun costrutto duplicato da sweepare.