### PR TITLE
feat(seo-static): full-height left+right rail ads on all static SEO landings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ const OfferwallNewsletterGate = lazyRetry(() => import('@/components/community/O
 const NewsletterInline = lazyRetry(() => import('@/components/community/Newsletter'));
 const NewsletterMount = lazyRetry(() => import('@/components/community/NewsletterMount'));
 const LanguageSelector = lazyRetry(() => import('@/components/shared/LanguageSelector'));
+const ArticleRailAdStack = lazyRetry(() => import('@/components/shared/ArticleRailAdStack'));
 const SiteSearch = lazyRetry(() => import('@/components/shared/SiteSearch'));
 // WhatsNewModal/Bell are non-critical UI; use React.lazy (not lazyRetry) so a
 // post-deploy chunk-hash miss silently degrades via SilentErrorBoundary instead
@@ -2593,6 +2594,25 @@ const App: React.FC = () => {
  )}
  </main>
  )}
+
+ {/* Side-rail ads — on staticOverlay (static SEO landing) pages, portal the
+   * full-height GPT half-page rail chain into the #rail-left-root /
+   * #rail-right-root gutter asides emitted by build-plugins/htmlTemplate.ts
+   * (same portal mechanism as the footer below). Reuses ArticleRailAdStack so
+   * the GAM rail units + Remote Config kill-switch match the article/job rails.
+   * Both the static aside and the stack itself are CSS-gated to ≥1400px (xlw),
+   * so narrower viewports render a single unchanged column. */}
+ {staticOverlay && (() => {
+   const leftTarget = document.getElementById('rail-left-root');
+   const rightTarget = document.getElementById('rail-right-root');
+   if (!leftTarget && !rightTarget) return null;
+   return (
+ <Suspense fallback={null}>
+ {leftTarget && createPortal(<ArticleRailAdStack side="left" />, leftTarget)}
+ {rightTarget && createPortal(<ArticleRailAdStack side="right" />, rightTarget)}
+ </Suspense>
+   );
+ })()}
 
  {/* Footer — on staticOverlay pages it is portalled into #footer-root which
    * lives AFTER <main class="seo-static-content"> in the DOM, so the footer

--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -320,11 +320,32 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  //    Caller's bodyHtml gets wrapped in `<main class="static-job-page">`
  //    inside `<div id="root">` — legacy job SEO pages.
  const preMainSection = preMainHtml ? `\n${preMainHtml}` : '';
+ // Full-height left/right side-rail gutters for the static SEO content, mirroring
+ // the article-detail / job-detail rail layout (BlogArticles, JobBoard). The
+ // <main> becomes the centre column of a 3-col grid that only materialises at
+ // `xlw` (≥1400px) — below that the page is an unchanged single column. The two
+ // <aside> elements are PORTAL TARGETS: App.tsx mounts <ArticleRailAdStack> into
+ // `#rail-left-root` / `#rail-right-root` on staticOverlay pages (same pattern as
+ // the `#footer-root` portal), so the GPT half-page ads reuse the React slot and
+ // its Remote Config kill-switch instead of duplicating GPT in static HTML.
+ // Reserved 300px columns mean zero CLS. Suppressed on `disableAutoAds` drive-by
+ // pages (≥97% bounce) to honour their deliberate no-ad opt-out.
+ const railsEnabled = seoContentOutsideRoot && !disableAutoAds;
+ const railGridOpen = railsEnabled
+   ? ` <div class="xlw:grid xlw:grid-cols-[300px_minmax(0,1fr)_300px] xlw:gap-6 xlw:mx-auto xlw:max-w-[1768px]">
+ <aside id="rail-left-root" class="hidden xlw:flex xlw:flex-col" aria-hidden="true"></aside>`
+   : '';
+ const railGridClose = railsEnabled
+   ? `
+ <aside id="rail-right-root" class="hidden xlw:flex xlw:flex-col" aria-hidden="true"></aside>
+ </div>`
+   : '';
  const bodySection = seoContentOutsideRoot
    ? ` <div id="root"></div>${preMainSection}
+${railGridOpen}
  <main class="${seoMainClass}">
 ${bodyHtml}
- </main>
+ </main>${railGridClose}
  <div id="footer-root"></div>`
    : ` <div id="root">
 ${skipMainWrap ? bodyHtml : ` <main class="static-job-page">\n ${bodyHtml}\n </main>`}

--- a/tests/regression/static-seo-rail-ads.test.ts
+++ b/tests/regression/static-seo-rail-ads.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeoPageHtml } from '../../build-plugins/shared/seoPageShell';
+
+/**
+ * Full-height left/right side-rail ad gutters on static SEO landing pages.
+ *
+ * buildSeoPageHtml emits (seoContentOutsideRoot mode) a 3-column rail grid that
+ * wraps <main seo-static-content> with two <aside> portal targets
+ * (#rail-left-root / #rail-right-root). App.tsx mounts <ArticleRailAdStack> into
+ * them on staticOverlay pages — same portal pattern as the #footer-root.
+ *
+ * The grid is CSS-gated to xlw (≥1400px) so narrower viewports keep a single,
+ * unchanged column; drive-by pages (disableAutoAds) opt out of the rails.
+ */
+describe('static SEO landing pages — full-height side-rail ad gutters', () => {
+  const baseOpts = {
+    locale: 'en',
+    title: 'Lidl jobs in Ticino',
+    description: 'Open Lidl positions for cross-border workers in Ticino.',
+    canonicalUrl: 'https://frontaliereticino.ch/en/find-jobs-ticino/company-lidl/',
+    bodyHtml: '<h1>Lidl jobs</h1><p>Listings…</p>',
+  };
+
+  it('wraps the static <main> in the xlw rail grid with both portal targets', () => {
+    const html = buildSeoPageHtml(baseOpts);
+
+    expect(html).toContain('rail-left-root');
+    expect(html).toContain('rail-right-root');
+    // The reserved 3-column grid only materialises at the xlw (≥1400px) tier.
+    expect(html).toMatch(/xlw:grid-cols-\[300px_minmax\(0,1fr\)_300px\]/);
+    // <main> stays present (lite-shell detection hook depends on it) and the
+    // footer portal target still follows the content.
+    expect(html).toContain('seo-static-content');
+    expect(html).toContain('footer-root');
+  });
+
+  it('orders the rails around the centre <main>: left | main | right', () => {
+    const html = buildSeoPageHtml(baseOpts);
+    const left = html.indexOf('rail-left-root');
+    const main = html.indexOf('seo-static-content');
+    const right = html.indexOf('rail-right-root');
+    const footer = html.indexOf('footer-root');
+
+    expect(left).toBeGreaterThan(-1);
+    expect(left).toBeLessThan(main);
+    expect(main).toBeLessThan(right);
+    expect(right).toBeLessThan(footer);
+  });
+
+  it('suppresses the rails on drive-by pages (disableAutoAds opt-out)', () => {
+    const html = buildSeoPageHtml({ ...baseOpts, disableAutoAds: true });
+
+    expect(html).not.toContain('rail-left-root');
+    expect(html).not.toContain('rail-right-root');
+    // Static content + footer portal remain intact.
+    expect(html).toContain('seo-static-content');
+    expect(html).toContain('footer-root');
+  });
+});


### PR DESCRIPTION
## Implementato

- **Barre laterali a tutta altezza** (rail ad GPT half-page) a sinistra e destra su **tutte le pagine SEO statiche** (es. `/en/find-jobs-ticino/company-lidl/`), stesso layout di article-detail (`BlogArticles`), job-detail (`JobBoard`) ed expired/orphan.
- Fix **class-wide nel choke point condiviso**: `buildSimplePage` (`build-plugins/htmlTemplate.ts`, modalità `seoContentOutsideRoot`) avvolge `<main class="seo-static-content">` in una **rail-grid a 3 colonne** con due `<aside>` portal target (`#rail-left-root` / `#rail-right-root`) che fiancheggiano la colonna centrale. Tutti i plugin di landing (company, sector, city, career, profession, nursing, cost-of-living, weekly-employers, comparisons/faq hub, …) passano per questo shell → rail **by construction**, nessuna modifica per-plugin.
- `App.tsx` monta `<ArticleRailAdStack side="left/right">` nei due target via `createPortal` **solo su pagine `staticOverlay`**, identico al pattern del `#footer-root` portal già esistente. Riusa lo slot GPT React + il kill-switch Remote Config (`KILL_ARTICLE_RAIL_ADS`) invece di duplicare GPT in HTML statico.
- **Zero CLS**: la grid riserva colonne fisse da `300px`; gating CSS a `xlw` (≥1400px, breakpoint nominato `--breakpoint-xlw`). Sotto i 1400px la pagina resta una singola colonna invariata (mobile/tablet, ~75% del traffico, intoccati).
- Grid centrata (`max-w-[1768px]`) così i rail fiancheggiano il contenuto anche su ultrawide invece di incollarsi ai bordi.
- Regression test `tests/regression/static-seo-rail-ads.test.ts`: presenza/ordine `left | main | right | footer` + opt-out su `disableAutoAds`.

## Non implementato (ancora)

- **Pagine drive-by `disableAutoAds`** (fuel-daily, health-premiums, border-wait, orphan-query — bounce ≥97%): rail **deliberatamente soppressi** per rispettare l'opt-out monetizzazione documentato (frequency cap / qualità AdSense). Se si vuole monetizzarle comunque, è un follow-up esplicito (one-liner: rimuovere il gate `!disableAutoAds`).
- **Verifica live a ≥1400px**: il render effettivo delle creatività GPT (`/23355151813/article-rail-{side}`) e l'assenza di CLS sono osservabili solo sul deploy reale a viewport `xlw`; non riproducibili pre-merge. Se a `xlw` i rail restano vuoti o introducono shift → follow-up reserve-space, non rimozione.
- **Pagine SSG legacy dentro `#root`** (modalità non-`seoContentOutsideRoot`, es. job-detail SSG): fuori scope qui — la loro variante SPA ha già i rail (PR #2584).
- **`count` adattivo alla lunghezza pagina** (come `BlogArticles` scala `railAdCount`): qui si usa il default `2`; tuning rimandato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)