### PR TITLE
fix(seo-static): prevent mobile horizontal overflow on static SEO pages

### DIFF
--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -82,7 +82,16 @@ main.seo-static-content h3:not([class]) {
   color: var(--color-heading);
 }
 main.seo-static-content h4:not([class]) { margin: 0; font-family: "Outfit", sans-serif; }
-main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
+main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr); gap: 12px; }
+/* Mobile overflow guard: the implicit grid column defaults to `auto`, which sizes
+   to the max-content of children. A direct child wrapper with `margin: 0 auto` +
+   a wide `max-width` (e.g. 56rem) then sizes to that max-width instead of the
+   viewport, overflowing horizontally on phones (text clipped by body overflow-x:hidden).
+   `grid-template-columns: minmax(0, 1fr)` pins the track to the container width;
+   `width: 100%` makes each child fill that track (their own max-width still caps the
+   reading width + centers via margin auto on desktop). AdSense rail injection sets its
+   own grid-template-columns / per-ins width inline, so this leaves Auto Ads untouched. */
+main.seo-static-content > * { min-width: 0; width: 100%; }
 .proposal {
   border: 1px solid var(--color-edge);
   background: var(--color-surface);


### PR DESCRIPTION
## Implementato

- `public/assets/seo-static.css`: `main.seo-static-content` è `display:grid` senza `grid-template-columns`, quindi la colonna implicita default `auto` si dimensiona al `max-content` dei figli. Il wrapper di contenuto (es. `.s-wWmcGm { max-width:56rem; margin:0 auto }`) si risolve così alla sua `max-width` piena (896px) invece che al viewport → su mobile il testo esce dal viewport (clippato da `body{overflow-x:hidden}`). Sintomo riportato su `/guida-frontaliere/lamal-frontalieri/` e pagine SEO statiche sibling.
- Fix: aggiunto `grid-template-columns: minmax(0, 1fr)` (vincola la track alla larghezza del container) + regola `main.seo-static-content > * { min-width: 0; width: 100% }` (ogni figlio diretto riempie la track; la loro `max-width` propria continua a cappare la reading-width e `margin:0 auto` centra su desktop). Class-wide: copre tutti i wrapper hashed `margin:0 auto` (`s-wWmcGm`, `s-it71Rt`, `s-haN35X`, …) che compaiono come figli diretti del grid.
- **Auto Ads safe (Non-Negotiable #7):** l'iniezione side-rail di AdSense imposta il proprio `grid-template-columns` / `width` per-`ins` inline (specificità inline > stylesheet), quindi questa regola si applica solo nello stato default senza rail e non sopprime/altera il sistema ad. `width:100%` sui container in-content migliora anzi il fill responsivo (reserve space, non soppressione).

## Verifica live (stylesheet iniettato sulla pagina live, pre-merge)

- 375px (mobile): `scrollWidth` 912→**367**, nessun overflow orizzontale; wrapper 896→**335px**. Testo ora a capo dentro il viewport.
- 1280px (desktop): wrapper **896px centrato** (cap reading-width preservato), `scrollWidth` 1272 (no overflow).
- Si applica sia all'HTML statico pre-hydration sia al DOM hydrated (stessa struttura `main.seo-static-content` + wrapper child).

## Non implementato (ancora)

- Sub-grid annidate senza template (`.s-bRaq8r`, `.s-fGW3CV`, `.s-i7j-Ox`, `.s-27J-ZF`): NON toccate — sono grid di stacking single-column i cui figli non usano il pattern `margin:0 auto`+`max-width` wide, quindi non sfondano (ereditano la width vincolata dal wrapper ora fixato). Fuori dalla classe del bug riportato.
- `main.cluster-seo-prose`: non è `display:grid` → non affetto; nessuna modifica.
- Container ad AdSense interni (`google-aiuf`, `goog-rentries`, iframe) che internamente eccedono il wrapper: lasciati intatti — gestiti da AdSense + `body{overflow-x:hidden}`, non causano scroll di pagina (verificato `scrollWidth` 367) e non sono testo. Toccarli violerebbe Non-Negotiable #7.