### PR TITLE
fix(jobboard): resilient job-detail fetch falls back to slug→live-id on stale seed id

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -413,6 +413,30 @@ function fetchJobDetail(jobId: string): Promise<Partial<JobListing>> {
  return jobDetailCache.get(jobId)!;
 }
 
+/**
+ * Resilient variant of fetchJobDetail. window.__JOB_SEED__ bakes the job's
+ * stable id at build time, but that id is a hash of a URL-derived fingerprint
+ * (buildStableId) and is NOT carried forward when a crawled job's source URL
+ * rotates (e.g. Coop's UUID-keyed posting URLs). The already-deployed static
+ * page then carries an id that no longer exists in the regenerated dataset, so
+ * /data/job-detail/<seed-id>.json 404s and the detail view shows the generic
+ * "scovato nel monitoraggio" placeholder behind the unlock gate instead of the
+ * real description.
+ *
+ * The slug, unlike the id, IS bridged (previousSlugs) and the live
+ * jobs-slug-map.json maps it → the current id. So when the baked id misses,
+ * resolve the current id from the slug map and retry once — mirroring the
+ * slug→id bridge already used for cross-canton shard resolution.
+ */
+async function fetchJobDetailResilient(jobId: string, slug?: string | null): Promise<Partial<JobListing>> {
+ const primary = await fetchJobDetail(jobId);
+ if (Object.keys(primary).length > 0 || !slug) return primary;
+ await ensureJobSlugMapLoaded();
+ const liveId = getJobMetaForSlug(slug)?.id;
+ if (!liveId || liveId === jobId) return primary;
+ return fetchJobDetail(liveId);
+}
+
 const ARTICLE_STOP_WORDS = new Set(['2025', '2026', '2027', 'del', 'dei', 'per', 'con', 'sul', 'fra', 'tra', 'una', 'non', 'che', 'come', 'cosa', 'dal', 'the', 'and', 'for', 'with', 'von', 'und', 'les', 'des', 'pour', 'dans']);
 
 function slugTopicWordsJob(id: string): Set<string> {
@@ -2472,10 +2496,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // instead of fetching the full locale file (~11MB). Merges detail fields into
  // the jobs state so selectedJob recomputes with complete data automatically.
  const selectedJobId = selectedJob?.id ?? null;
+ const selectedJobSlug = selectedJob?.slug ?? null;
  useEffect(() => {
  if (!selectedJobId) return;
  setEnrichmentLoading(true);
- fetchJobDetail(selectedJobId).then((detail) => {
+ // Pass the slug so a stale seed id (URL-rotation drift between the baked
+ // __JOB_SEED__ and the regenerated detail files) falls back to slug→live-id
+ // resolution instead of leaving the body empty. See fetchJobDetailResilient.
+ fetchJobDetailResilient(selectedJobId, selectedJobSlug).then((detail) => {
  if (Object.keys(detail).length === 0) return;
  setJobs((prev) => prev.map((j) => (j.id === selectedJobId ? { ...j, ...detail } : j)));
  }).catch(() => {
@@ -2483,7 +2511,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }).finally(() => {
  setEnrichmentLoading(false);
  });
- }, [selectedJobId]);
+ }, [selectedJobId, selectedJobSlug]);
 
  // Job-detail alert prompt — gating + 1.5 s reveal timer.
  // Trigger: single-job-detail view, logged-in user with email, feature flag on,

--- a/tests/job-detail-seed.test.ts
+++ b/tests/job-detail-seed.test.ts
@@ -345,5 +345,28 @@ describe('Per-job detail seed (window.__JOB_SEED__)', () => {
       expect(guardIdx).toBeGreaterThan(0);
       expect(loaderIdx).toBeGreaterThan(guardIdx);
     });
+
+    it('falls back to slug→live-id resolution when the baked seed id 404s (stale __JOB_SEED__ id drift)', () => {
+      // A crawled job whose source URL rotates gets a fresh buildStableId, so the
+      // already-deployed page's window.__JOB_SEED__ carries an id that no longer
+      // exists in the regenerated /data/job-detail/<id>.json → 404 → empty body →
+      // the detail view shows the generic "scovato nel monitoraggio" placeholder
+      // behind the unlock gate. The resilient fetch must retry with the CURRENT id
+      // resolved from the live slug map (slug → id) before giving up.
+      expect(src).toMatch(/async function fetchJobDetailResilient\(jobId: string, slug\?: string \| null\)/);
+      // On a miss it loads the slug map and resolves the live id from the slug.
+      expect(src).toMatch(/await ensureJobSlugMapLoaded\(\)/);
+      expect(src).toMatch(/const liveId = getJobMetaForSlug\(slug\)\?\.id/);
+      // Only retries when the resolved id actually differs (avoids a redundant 404).
+      expect(src).toMatch(/if \(!liveId \|\| liveId === jobId\) return primary/);
+      expect(src).toMatch(/return fetchJobDetail\(liveId\)/);
+    });
+
+    it('the detail-enrichment effect uses the resilient fetch with the slug (not the bare seed id)', () => {
+      expect(src).toMatch(/const selectedJobSlug = selectedJob\?\.slug \?\? null/);
+      expect(src).toMatch(/fetchJobDetailResilient\(selectedJobId, selectedJobSlug\)/);
+      // slug must be in the effect deps so a slug change re-runs resolution.
+      expect(src).toMatch(/\}, \[selectedJobId, selectedJobSlug\]\)/);
+    });
   });
 });


### PR DESCRIPTION
## Implementato

Risolto il caso "job senza contenuto" su pagine job-detail attive (segnalato su `/cerca-lavoro-berna/assistente-alle-vendite-alimentari-coop-genossenschaft-thun/`).

**Causa all'origine.** L'`id` stabile di un job (`buildStableId` = hash di un fingerprint URL-based) NON è durevolmente stabile tra crawl: quando l'azienda crawlata ruota l'URL sorgente del posting (es. Coop usa URL UUID-keyed: `jobs.coopjobs.ch/.../6f37be47-…`), il fingerprint cambia → nuovo id. La pagina HTML già deployata continua però a portare il **vecchio** id nel `window.__JOB_SEED__`. La SPA fetchava `/data/job-detail/<seed-id>.json` con quell'id stantio e, sul 404 inevitabile, lasciava il corpo vuoto → la pagina mostrava il placeholder generico *"Frontaliere Ticino ha scovato questa opportunità nel monitoraggio aziende"* dietro il gate di sblocco, invece della descrizione reale.
  - Verificato live: seed id `company-mj6ym4` → detail JSON **404**; id corrente `company-uwv3ve` (dalla slug-map live) → detail JSON **200** con descrizione (2142 char). Lo slug è uno solo nei dati live e mappa a `company-uwv3ve`. L'id `company-mj6ym4` è un *ghost* assente dal dataset corrente.

**Fix (chirurgico).** Lo slug, a differenza dell'id, è già bridged via `previousSlugs` e la `jobs-slug-map.json` live lo mappa all'id corrente. Nuovo helper `fetchJobDetailResilient(jobId, slug)`: quando il fetch col seed-id torna vuoto, carica la slug-map (`ensureJobSlugMapLoaded`) e risolve l'id corrente (`getJobMetaForSlug(slug).id`), poi ritenta una volta — riusando il bridge slug→id già caricato per gli shard cross-canton. L'effect di enrichment passa ora lo slug e lo include nelle deps. Robusto verso QUALSIASI drift dell'id / skew di deploy, senza ricostruire ogni pagina statica.

- `components/community/JobBoard.tsx`: aggiunto `fetchJobDetailResilient`; l'effect FRO-detail-split usa l'helper con `selectedJobSlug`.
- `tests/job-detail-seed.test.ts`: 2 regression (source-assertion, stile esistente del file) che bloccano il wiring del fallback + lo slug nelle deps.

Verifica: `vitest run tests/job-detail-seed.test.ts` 23/23 verde; batch JobBoard correlato 47/47 verde; `tsc --noEmit` nessun nuovo errore in `JobBoard.tsx`; impact analysis LOW (unico consumer di `fetchJobDetail` è l'effect).

## Non implementato (ancora)

- **Stabilizzazione dell'`id` all'origine (carry-forward dell'id come `previousSlugs`)** — follow-up. La fix vera-vera del drift sarebbe far sì che l'assembler propaghi il vecchio id quando riconosce lo stesso job sotto un URL ruotato (analogo a `trackSlugHistoryDrift` per gli slug), così il `company-<hash>` non diventa mai un ghost. È più invasivo (tocca la logica di dedup/merge identity in `scripts/assemble-jobs-dataset.mjs` + `buildStableId` in `scripts/lib/dedicated-crawler-common.mjs`/`shared-jobs-crawler.mjs`) e rischioso; il bridge slug→id già garantisce la continuità utente e questa PR chiude il gap di contenuto in modo difensivo. Posposto come hardening dedicato.
- **Sibling `buildStableId` (assemble-jobs-dataset / dedicated-crawler-common / shared-jobs-crawler)** segnalati da `check-sibling-patterns`: sono i siti di *generazione* dell'id (= il root cause profondo deferito sopra), non l'antipattern qui fixato ("fetch detail by baked id senza fallback"). L'unico sito di quell'antipattern è il caller di `fetchJobDetail`, già corretto. Gli altri sibling (`getJobMetaForSlug`/`ensureJobSlugMapLoaded` in `router.ts`/`UserProfile.tsx`/`LanguageSelector.tsx`, `selectedJob` nei build-plugin) sono definitore o consumer di concern diverso, non fetchano job-detail by-id.
