### PR TITLE
fix(build): lazy-load data/slug-registry.json out of the Vite config bundle (same class as #2588)

### DIFF
--- a/build-plugins/shared/loadDataJson.ts
+++ b/build-plugins/shared/loadDataJson.ts
@@ -1,0 +1,46 @@
+/**
+ * Lazy runtime loader for a repo-relative `data/*.json` file.
+ *
+ * WHY THIS EXISTS — never `import data from '.../data/<file>.json'` from any
+ * module reachable by `vite.config.ts`. When Vite loads the config, esbuild
+ * bundles the config file *plus its entire static-import graph* into a single
+ * in-memory string. A static JSON import inlines the whole file as an escaped
+ * string literal inside that bundle; once the combined bundle crosses V8's hard
+ * 512 MB max-string-length the config can no longer be loaded:
+ *
+ *   Error: Cannot create a string longer than 0x1fffffe8 characters
+ *     at TextDecoder.decode (node:internal/encoding)
+ *     at bundleConfigFile (vite/dist/node/chunks/...)
+ *
+ * `data/jobs.json` (~150 MB) crossed that limit first and broke the monolith
+ * `build` job + the "AdSense Pre-Review Checklist" workflow (issue #2532).
+ * `data/slug-registry.json` (~12 MB and growing with every slug ever minted) is
+ * the same anti-pattern at smaller scale — a future time-bomb on the same line.
+ *
+ * Reading a data file lazily at plugin-runtime (inside `closeBundle`/`build`)
+ * keeps it OUT of esbuild's config bundle entirely, so the config stays small
+ * and bounded as the datasets keep growing. Defining the read path ONCE here
+ * makes the static-import anti-pattern impossible to reintroduce by copy-paste.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const cache = new Map<string, unknown>();
+
+/**
+ * Read and parse a repo-relative JSON data file. Cached per resolved absolute
+ * path so repeated calls within a single build don't re-read/re-parse the file.
+ *
+ * @param relPath Repo-root-relative path, e.g. `data/jobs.json`.
+ * @param rootDir Repo root to resolve `relPath` against. Defaults to
+ *   `process.cwd()`, which is the project root during a Vite build. Plugins that
+ *   already receive a `rootDir` should pass it for robustness.
+ */
+export function loadDataJson<T = unknown>(relPath: string, rootDir: string = process.cwd()): T {
+  const abs = path.resolve(rootDir, relPath);
+  const hit = cache.get(abs);
+  if (hit !== undefined) return hit as T;
+  const data = JSON.parse(fs.readFileSync(abs, 'utf-8')) as T;
+  cache.set(abs, data);
+  return data;
+}

--- a/build-plugins/shared/loadJobsJson.ts
+++ b/build-plugins/shared/loadJobsJson.ts
@@ -22,23 +22,19 @@
  * overhead). Defining the read path ONCE here makes the static-import
  * anti-pattern impossible to reintroduce by copy-paste.
  */
-import fs from 'node:fs';
-import path from 'node:path';
-
-let cache: { path: string; data: unknown[] } | null = null;
+import { loadDataJson } from './loadDataJson';
 
 /**
  * Read `data/jobs.json` from disk and parse it. Cached per resolved path so
  * repeated calls within a single build don't re-read/re-parse ~150 MB.
+ *
+ * Thin wrapper over the shared {@link loadDataJson} read-path so the lazy-load
+ * anti-pattern guard (see that module's header) lives in exactly one place.
  *
  * @param rootDir Repo root to resolve `data/jobs.json` against. Defaults to
  *   `process.cwd()`, which is the project root during a Vite build. Plugins
  *   that already receive a `rootDir` should pass it for robustness.
  */
 export function loadJobsJson<T = unknown>(rootDir: string = process.cwd()): T[] {
-  const jobsPath = path.resolve(rootDir, 'data/jobs.json');
-  if (cache && cache.path === jobsPath) return cache.data as T[];
-  const data = JSON.parse(fs.readFileSync(jobsPath, 'utf-8')) as unknown[];
-  cache = { path: jobsPath, data };
-  return data as T[];
+  return loadDataJson<T[]>('data/jobs.json', rootDir);
 }

--- a/build-plugins/shared/slugCantonIndex.ts
+++ b/build-plugins/shared/slugCantonIndex.ts
@@ -1,6 +1,7 @@
 /**
- * Slug → canton reverse index, built once at module load from
- * `data/slug-registry.json` + `data/jobs.json`.
+ * Slug → canton reverse index, built lazily on first lookup from
+ * `data/slug-registry.json` + `data/jobs.json` (both read at plugin-runtime via
+ * the shared lazy loader — never statically imported, see `loadDataJson.ts`).
  *
  * Used by jobOrphanBridgePlugin to infer which canton section a *matched/current*
  * job-slug should redirect to. (searchConsoleCompat no longer uses it: since
@@ -16,7 +17,7 @@
  *   itself is emitted by `jobsSeoPagesPlugin` on the correct section path.
  */
 
-import slugRegistryFile from '../../data/slug-registry.json';
+import { loadDataJson } from './loadDataJson';
 import { loadJobsJson } from './loadJobsJson';
 
 type RegistryEntry = {
@@ -35,7 +36,7 @@ let slugToCanton: Map<string, string> | null = null;
 
 function build(): Map<string, string> {
   const map = new Map<string, string>();
-  const registry = slugRegistryFile as Record<string, RegistryEntry>;
+  const registry = loadDataJson<Record<string, RegistryEntry>>('data/slug-registry.json');
   for (const entry of Object.values(registry)) {
     const canton = String(entry?.canton || 'TI').toUpperCase().trim() || 'TI';
     if (entry?.canonicalSlug) map.set(entry.canonicalSlug, canton);


### PR DESCRIPTION
## Implementato

Chiude **in maniera definitiva** la classe di failure dietro issue #2532 (workflow *AdSense Pre-Review Checklist*, run 27900957370): `Cannot create a string longer than 0x1fffffe8 characters` durante `bundleConfigFile`.

Causa-radice: build-plugin nel grafo import di `vite.config.ts` che importano **staticamente** un file `data/*.json` generato e crescente → esbuild lo inlina come literal nel config-bundle → superato il limite V8 di 512 MB max-string-length, la config non si carica più e ogni build muore prima ancora di partire.

#2588 ha lazy-loadato `data/jobs.json` (~150 MB, il colpevole immediato). **Ma `data/slug-registry.json` (~12 MB e in crescita con ogni slug mai coniato) era ancora importato staticamente** da `build-plugins/shared/slugCantonIndex.ts:19` → stessa identica time-bomb, sulla stessa riga, a scala minore. Questa PR la disinnesca:

- **Nuovo `build-plugins/shared/loadDataJson.ts`**: un unico reader lazy, path-cached, per qualunque `data/*.json`. Definire il read-path UNA volta rende l'antipattern static-import impossibile da reintrodurre per copy-paste (allinea il commento-guida già scritto in `loadJobsJson.ts`).
- **`slugCantonIndex.ts`** legge ora `slug-registry.json` via `loadDataJson()` a runtime di plugin (`build()` era già lazy) invece dell'import ESM statico; docblock aggiornato (non più "built once at module load").
- **`loadJobsJson.ts`** delega a `loadDataJson` → i due data-file condividono lo stesso read-path guardato, zero logica fs/JSON duplicata.

Comportamento **identico**: stesso JSON, stessa iterazione `Object.values`, fallback `TI` preservato. Verificato a runtime con vitest mirato: index costruito non-vuoto, slug noto → cantone corretto, slug ignoto → `TI`, loader cachato per path. `tsc -p tsconfig.json` pulito sui 3 file (i 26 errori pre-esistenti sono in file non correlati, già su `main`).

Closes #2532

## Non implementato (ancora)

- **Altri static `import … from '…json'` rimasti nel grafo config** (`canton-url-slugs.json` 4 KB curato, `canton-municipalities.json` 52 KB statico, `public/data/fuel-prices.json` 2.2 MB snapshot giornaliero a dimensione **bounded**): NON toccati perché piccoli e non a crescita illimitata → non sono time-bomb della classe 512 MB. Out of scope: convertirli sarebbe churn senza beneficio.
- **Sibling flaggati dal checker per token `jobsPath`/`TextDecoder`** (`jobsSeoPagesPlugin`, `relatedSearchClustersPlugin`, `nursingJobsAggregate`, ecc.): falsi positivi euristici — leggono già `data/jobs.json` via `fs.readFileSync(jobsPath)` a **runtime** (es. `relatedSearchClustersPlugin.ts:526/532`), NON static import → pattern corretto, nessun bundle bloat. Migrarli a `loadJobsJson` sarebbe cleanup deferibile (non funnel, non bug), fuori scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)