### PR TITLE
fix(border-watchdog): arm staleness backstop at 08:00 UTC to kill false overnight pages

### DIFF
--- a/scripts/check-border-data-health.mjs
+++ b/scripts/check-border-data-health.mjs
@@ -89,14 +89,30 @@ export function evaluateStaleness(doc, nowMs, staleHours = DEFAULT_STALE_HOURS) 
   return { stale: false, ageMinutes, timestamp: ts, reason: null };
 }
 
-// Active window (UTC) during which fresh wait-time data is EXPECTED, mirroring
-// the traffic-scheduler operating hours (weekday ~03:00–18:00 UTC, weekend
-// 04:00–18:00). Outside it the snapshot is naturally stale (scheduler idle
-// overnight), so the coarse staleness backstop must NOT fire — otherwise the
-// 00:00 UTC watchdog run pages a false "degraded" every night (worse over the
-// weekend), causing alert fatigue that buries real degradation. Webcam-health
-// and all-mock checks are time-independent and always run.
-const STALE_ACTIVE_START_UTC_HOUR = 5;
+// Active window (UTC) during which a fresh wait-time snapshot is GUARANTEED to
+// exist, so the coarse staleness backstop can page without false positives.
+// Outside it the snapshot is legitimately old (scheduler idle overnight), and
+// webcam-health + all-mock checks are time-independent so they always run.
+//
+// The START is deliberately LATER than the traffic-scheduler's first morning
+// cron, not aligned to it. The scheduler's morning ramp is `*/30 4-7` UTC
+// (weekday) / `0 6,…` (weekend), but two effects make data NOT reliably fresh
+// at 05:00:
+//   1. GitHub Actions delivers scheduled runs LATE (top-of-hour crons routinely
+//      lag 10–60+ min), so the 04:00/04:30 collections may not have LANDED yet.
+//   2. isStalenessCheckActive() is evaluated at EXECUTION time, not the nominal
+//      cron time — so a delayed *overnight* watchdog run (e.g. the 00:00 cron
+//      delivered at 05:05) leaks into the window while the freshest snapshot is
+//      still the prior evening's ~19:00 collection (>6h old → false page).
+// Both bit us in issue #2587 (00:00 run executed 05:05 Mon, snapshot 591 min
+// old). Arming at 08:00 clears the entire morning ramp + cron-lag margin: by
+// then the 04:00–07:30 weekday (or 06:00 weekend) collections have certainly
+// landed, so any snapshot older than the 6h threshold is a REAL freeze. The
+// fast 90-min freshness loop (traffic-data-freshness.yml) still covers the
+// commute window, and this backstop only needs to catch a fully-frozen pipeline
+// — which the 12:00/18:00 runs still detect. If the scheduler's morning cron
+// moves, revisit this constant.
+const STALE_ACTIVE_START_UTC_HOUR = 8;
 const STALE_ACTIVE_END_UTC_HOUR = 20; // exclusive
 
 /**

--- a/tests/check-border-data-health.test.ts
+++ b/tests/check-border-data-health.test.ts
@@ -186,12 +186,18 @@ describe('isStalenessCheckActive (active-window gate)', () => {
     expect(isStalenessCheckActive(atUtcHour(0))).toBe(false);
   });
 
-  it('is INACTIVE before 05:00 UTC (scheduler idle overnight)', () => {
+  it('is INACTIVE before 08:00 UTC — the morning scheduler ramp + GitHub cron-lag is not yet guaranteed landed (issue #2587)', () => {
     expect(isStalenessCheckActive(atUtcHour(4))).toBe(false);
+    // 05:00–07:00 is the danger zone: a delayed overnight watchdog run (00:00
+    // cron delivered at 05:05, issue #2587) must NOT arm while the prior
+    // evening's snapshot is still the freshest one.
+    expect(isStalenessCheckActive(atUtcHour(5))).toBe(false);
+    expect(isStalenessCheckActive(atUtcHour(6))).toBe(false);
+    expect(isStalenessCheckActive(atUtcHour(7))).toBe(false);
   });
 
-  it('is ACTIVE for the 06/12/18 UTC runs (scheduler operating hours)', () => {
-    expect(isStalenessCheckActive(atUtcHour(6))).toBe(true);
+  it('is ACTIVE for the 08/12/18 UTC runs (after the morning collection is guaranteed fresh)', () => {
+    expect(isStalenessCheckActive(atUtcHour(8))).toBe(true);
     expect(isStalenessCheckActive(atUtcHour(12))).toBe(true);
     expect(isStalenessCheckActive(atUtcHour(18))).toBe(true);
   });
@@ -199,5 +205,30 @@ describe('isStalenessCheckActive (active-window gate)', () => {
   it('is INACTIVE at/after 20:00 UTC', () => {
     expect(isStalenessCheckActive(atUtcHour(20))).toBe(false);
     expect(isStalenessCheckActive(atUtcHour(23))).toBe(false);
+  });
+});
+
+describe('staleness page-gate (issue #2587 regression)', () => {
+  // Reproduces the orchestration's `stale.stale && stalenessActive` page
+  // condition: the 00:00 UTC watchdog cron delivered late at 05:05 Mon, with the
+  // freshest snapshot being the prior Sunday 19:14 collection (591 min old).
+  // Before the fix this paged a false "degraded"; now the gate is inactive at
+  // 05:05 so it does NOT page, while a genuine daytime freeze still does.
+  const PAGE = (snapshotIso: string, nowMs: number): boolean => {
+    const stale = evaluateStaleness({ updatedAt: snapshotIso }, nowMs, 6);
+    return stale.stale && isStalenessCheckActive(nowMs);
+  };
+
+  it('does NOT page for the overnight-aged snapshot seen by a delayed 05:05 run', () => {
+    const now = Date.UTC(2026, 5, 22, 5, 5, 20); // Mon 05:05:20 UTC
+    const snapshot = '2026-06-21T19:14:05Z'; // Sun 19:14 — 591 min old
+    expect(evaluateStaleness({ updatedAt: snapshot }, now, 6).ageMinutes).toBe(591);
+    expect(PAGE(snapshot, now)).toBe(false);
+  });
+
+  it('DOES page for a genuine freeze during the active window (08:00+)', () => {
+    const now = Date.UTC(2026, 5, 22, 12, 0, 0); // Mon 12:00 UTC, in-window
+    const snapshot = '2026-06-22T02:00:00Z'; // 10h old — pipeline truly frozen
+    expect(PAGE(snapshot, now)).toBe(true);
   });
 });


### PR DESCRIPTION
## Implementato

Root-cause fix for the recurring false "Border live-data degraded" page (issue #2587).

**Diagnosi.** The 6-hourly watchdog paged with `STALE: snapshot 591 min old`. The chain:
1. GitHub delivered the **00:00 UTC** watchdog cron **5h late, at 05:05 Mon**.
2. `isStalenessCheckActive()` reads **execution** time → hour 5 → inside the old `05:00` active window → gate passed.
3. The morning `traffic-scheduler` crons (`*/30 4-7`) had not yet landed a fresh snapshot, so the freshest one was the prior **Sun 19:14** collection = **591 min** old > 360 → false page.

The webcam `UNREACHABLE` lines in #2587 were already non-paging (cloud-IP indeterminate); **STALE was the only paging cause.**

**Fix** (`scripts/check-border-data-health.mjs`):
- `STALE_ACTIVE_START_UTC_HOUR` **5 → 8**. By 08:00 the `04:00–07:30` weekday (or `06:00` weekend) collections have certainly landed even with GitHub cron-lag, so any snapshot older than the 6h threshold is a **real** freeze, not the overnight gap. A delayed overnight watchdog run can no longer leak into the window.
- Rewrote the constant's comment to document the cron-lag + execution-time-leak reasoning (the old comment claimed it "mirrors operating hours ~03:00", which was both stale and the wrong rationale).

**Tests** (`tests/check-border-data-health.test.ts`):
- Updated the active-window gate: `05/06/07` now INACTIVE (danger zone), `08` ACTIVE.
- Added a `#2587 regression` block reproducing the exact case — a 591-min snapshot at a 05:05 run does **NOT** page, while a genuine 10h freeze at 12:00 **does**. 23/23 pass locally.

The fast 90-min freshness loop (`traffic-data-freshness.yml`) still self-heals the commute window; the watchdog's `12:00`/`18:00` runs still catch a fully-frozen pipeline.

Closes #2587

## Non implementato (ancora)

- **`traffic-data-freshness.yml` window NOT changed (deliberate, not an oversight).** It shares the `05:00–20:00` window construct but has the **opposite intent**: its early `05:00` start is correct because a stale reading there **dispatches the scheduler (self-heal)** and only opens an auto-closing `[pending]` debounce issue — it never pages a high-priority bug. Aligning it to 08:00 would *delay* morning self-heal. So this is not a sibling-class fix; the two windows are intentionally divergent. (`check-sibling-patterns.mjs`: clean.)
- **GitHub cron-lag itself** is unfixable (platform behaviour); the fix makes the gate robust to it rather than trying to eliminate it.