### PR TITLE
fix(traffic): prefer TomTom over HERE to eliminate HERE billing (#2180)

### DIFF
--- a/functions/src/trafficSchedulerCore.js
+++ b/functions/src/trafficSchedulerCore.js
@@ -73,9 +73,26 @@ export function estimateWaitFromCongestion(congestionScore) {
  return 30;
 }
 
-function resolveTrafficProvider({ hereApiKey, tomtomApiKey, googleApiKey }) {
- if (hereApiKey) return 'here';
+/**
+ * Pick the live-routing provider by preference order.
+ *
+ * TomTom is preferred over HERE (#2180): HERE bills every routing call as a
+ * "Time Aware Routing" transaction and the scheduled demand (~21k/month) is
+ * ~4.6× HERE's 4,500/month free tier, so HERE exhausts ~day 6 and the run
+ * already falls back to TomTom for the rest of the month — i.e. TomTom already
+ * serves the large majority of the month. TomTom's free tier (2,500 req/day ≈
+ * 75k/month) comfortably covers full demand and is unmetered here, so making it
+ * primary keeps live routing consistent ALL month at $0 and stops the real
+ * monthly HERE overage (6,350/4,500 billed in 2026-06). HERE stays as the
+ * fallback when no TomTom key is configured (its budget guard below still
+ * caps any spend). Google Maps is the last resort.
+ *
+ * @param {{hereApiKey?:string, tomtomApiKey?:string, googleApiKey?:string}} keys
+ * @returns {'tomtom'|'here'|'google-maps'|null}
+ */
+export function resolveTrafficProvider({ hereApiKey, tomtomApiKey, googleApiKey }) {
  if (tomtomApiKey) return 'tomtom';
+ if (hereApiKey) return 'here';
  if (googleApiKey) return 'google-maps';
  return null;
 }

--- a/tests/trafficScheduler.here-routing.test.ts
+++ b/tests/trafficScheduler.here-routing.test.ts
@@ -14,7 +14,9 @@
  *     the HERE Router v8 /routes response.
  *  2. getTomTomFlowSegmentData — computes congestion ratio from
  *     the TomTom Traffic Flow Segment /flowSegmentData response.
- *  3. resolveTrafficProvider priority: HERE > TomTom > Google Maps > null
+ *  3. resolveTrafficProvider priority: TomTom > HERE > Google Maps > null
+ *     (TomTom preferred over HERE since #2180 — HERE bills per call and its
+ *     free tier is exhausted ~day 6/month; TomTom's free tier covers full demand.)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -346,11 +348,26 @@ describe('computeHereBudgetDecision', () => {
 // ─── resolveTrafficProvider priority ─────────────────────────────
 
 describe('resolveTrafficProvider', () => {
-  // resolveTrafficProvider is currently private inside trafficSchedulerCore.js;
-  // we verify the priority indirectly through runTrafficCollection / fetchCrossingTraffic
-  // by inspecting which API URL gets called when multiple keys are present.
+  // Direct priority assertions (function exported since #2180) + indirect
+  // verification through fetchCrossingTraffic (which API URL is called).
   //
-  // Expected priority: HERE > TomTom > Google Maps > null
+  // Expected priority: TomTom > HERE > Google Maps > null
+
+  it('prefers TomTom over HERE when both keys are present (#2180 — avoids HERE billing)', async () => {
+    const { resolveTrafficProvider } = await import('../functions/src/trafficSchedulerCore.js');
+    expect(resolveTrafficProvider({ hereApiKey: 'h', tomtomApiKey: 't' })).toBe('tomtom');
+  });
+
+  it('falls back to HERE when only hereApiKey is set', async () => {
+    const { resolveTrafficProvider } = await import('../functions/src/trafficSchedulerCore.js');
+    expect(resolveTrafficProvider({ hereApiKey: 'h' })).toBe('here');
+  });
+
+  it('falls back to Google Maps when only googleApiKey is set; null when no keys', async () => {
+    const { resolveTrafficProvider } = await import('../functions/src/trafficSchedulerCore.js');
+    expect(resolveTrafficProvider({ googleApiKey: 'g' })).toBe('google-maps');
+    expect(resolveTrafficProvider({})).toBe(null);
+  });
 
   let fetchCrossingTraffic: (
     crossing: { name: string; lat: number; lng: number },
@@ -377,11 +394,11 @@ describe('resolveTrafficProvider', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses HERE when hereApiKey is provided alongside tomtomApiKey', async () => {
+  it('uses TomTom when tomtomApiKey is provided alongside hereApiKey (#2180 — HERE billing avoided)', async () => {
     // fetchCrossingTraffic calls two segments → mock fetch twice
     global.fetch = vi.fn()
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => hereRouteResponse, text: async () => '' } as unknown as Response)
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => hereRouteResponse, text: async () => '' } as unknown as Response);
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => tomtomRouteResponse, text: async () => '' } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => tomtomRouteResponse, text: async () => '' } as unknown as Response);
 
     const result = await fetchCrossingTraffic(fakeCrossing, {
       hereApiKey: 'here-key',
@@ -391,10 +408,12 @@ describe('resolveTrafficProvider', () => {
     const calledUrls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
       c => c[0] as string,
     );
-    // At least one call must be to the HERE Router endpoint, not TomTom Routing
+    // No call must hit the HERE Router endpoint; TomTom is now primary.
     const usedHere = calledUrls.some(url => url.includes('router.hereapi.com') || url.includes('here.com'));
-    expect(usedHere).toBe(true);
-    expect(result.source).toBe('here');
+    const usedTomTom = calledUrls.some(url => url.includes('tomtom.com'));
+    expect(usedHere).toBe(false);
+    expect(usedTomTom).toBe(true);
+    expect(result.source).toBe('tomtom');
   });
 
   it('uses TomTom when only tomtomApiKey is provided', async () => {


### PR DESCRIPTION
## Implementato
- **Root cause (#2180)**: HERE fattura **ogni** chiamata di routing come transazione "Time Aware Routing". La domanda schedulata (~21k/mese: `.github/workflows/traffic-scheduler.yml`, 52 transazioni/run × ~400 run) è **~4.6× il free tier HERE da 4.500/mese** → HERE si esaurisce intorno al **giorno 6** e il run **già** ripiega su TomTom per il resto del mese. La reconcile 2026-06 ha mostrato **6.350/4.500 realmente fatturato** = overage reale che viola il vincolo **$0**.
- **Fix strutturale**: riordinato `resolveTrafficProvider` (`functions/src/trafficSchedulerCore.js`) per **preferire TomTom** (free tier 2.500 req/giorno ≈ 75k/mese, non-metered in questo modulo, copre l'intera domanda) **su HERE**. HERE resta **fallback** quando non c'è una chiave TomTom configurata (e il suo budget-guard mensile continua a cappare qualunque spesa). Effetto netto: routing live **consistente tutto il mese a $0** e stop all'alert mensile ricorrente di overage HERE.
- **Behavior change minima**: TomTom era già il provider dominante (~80% del mese, dopo l'esaurimento HERE al giorno ~6); il cambio anticipa l'uso TomTom anche ai primi giorni. Il path HERE→TomTom su budget-exhausted resta intatto come backstop per deployment HERE-only.
- **Test**: esportato `resolveTrafficProvider` + aggiunti unit test diretti sulla priorità (TomTom>HERE>Google>null). Aggiornato il test di integrazione "both keys" (prima asseriva HERE sotto la vecchia priorità → ora asserisce TomTom + nessuna chiamata a `router.hereapi.com`). Aggiornati i commenti header del file di test (AGENTS #6). Suite traffic completa verde, incluso il test di fallback HERE-budget→TomTom (62+15 test).

Closes #2180

## Non implementato (ancora)
- **Deploy Cloud Functions**: la modifica è in `functions/` → richiede un deploy CF per andare live (CI auto-deploy esistente). Da osservare post-merge: alla prossima run dello scheduler il provider attivo dev'essere `tomtom` (log `🚦 ... via tomtom`) e la reconcile HERE non deve più incrementare.
- **Rimozione `HERE_API_KEY` da Remote Config**: alternativa config-only che azzererebbe HERE in modo ancora più netto; non fatta perché è un intervento operativo sui secret (non di codice) e il riordino la rende superflua (HERE non viene più scelto quando TomTom è presente). HERE resta utile come fallback se TomTom venisse rimosso.
- **Branch HERE-budget→TomTom interno (`runTrafficCollection` ~687)**: ora logicamente non raggiungibile quando entrambe le chiavi sono presenti (provider risolve già a `tomtom`); lasciato **deliberatamente** come backstop difensivo per deployment HERE-only (nessun costo, nessun rischio). Non rimosso per restare chirurgico.
- **Sibling sweep**: la preferenza provider vive solo in `resolveTrafficProvider`; nessun altro sito ricalcola l'ordine — `runTrafficCollection`/`fetchCrossingTraffic` consumano il valore risolto.