### PR TITLE
fix(border-watchdog): start staleness window at 06:00 UTC to absorb morning-cron jitter (#2587)

### DIFF
--- a/scripts/check-border-data-health.mjs
+++ b/scripts/check-border-data-health.mjs
@@ -96,7 +96,16 @@ export function evaluateStaleness(doc, nowMs, staleHours = DEFAULT_STALE_HOURS) 
 // 00:00 UTC watchdog run pages a false "degraded" every night (worse over the
 // weekend), causing alert fatigue that buries real degradation. Webcam-health
 // and all-mock checks are time-independent and always run.
-const STALE_ACTIVE_START_UTC_HOUR = 5;
+//
+// START is 06:00 UTC (not 05:00): the first weekday morning scheduler cron is
+// 04:00 UTC (`*/30 4-7`), but GitHub Actions scheduled runs routinely lag
+// 30–60+ min or are silently dropped under load, so fresh morning data may not
+// land until ~05:30–06:00. Activating the backstop at 05:00 paged a false
+// "591 min stale" at 05:08 (#2587) on overnight data, before the morning peak
+// could refresh. Starting at 06:00 gives the 04:00–07:00 peak + cron jitter a
+// ~2h runway; a genuinely frozen pipeline (no run for 11h+) still trips at
+// 06:00 and the always-on all-mock/webcam checks catch hard failures any hour.
+const STALE_ACTIVE_START_UTC_HOUR = 6;
 const STALE_ACTIVE_END_UTC_HOUR = 20; // exclusive
 
 /**

--- a/tests/check-border-data-health.test.ts
+++ b/tests/check-border-data-health.test.ts
@@ -186,8 +186,11 @@ describe('isStalenessCheckActive (active-window gate)', () => {
     expect(isStalenessCheckActive(atUtcHour(0))).toBe(false);
   });
 
-  it('is INACTIVE before 05:00 UTC (scheduler idle overnight)', () => {
+  it('is INACTIVE before 06:00 UTC (overnight idle + morning-cron jitter runway, #2587)', () => {
     expect(isStalenessCheckActive(atUtcHour(4))).toBe(false);
+    // 05:00 UTC is now INACTIVE: the 04:00–07:00 morning peak + GitHub cron
+    // jitter needs runway to land fresh data before the backstop fires (#2587).
+    expect(isStalenessCheckActive(atUtcHour(5))).toBe(false);
   });
 
   it('is ACTIVE for the 06/12/18 UTC runs (scheduler operating hours)', () => {


### PR DESCRIPTION
## Implementato
- **Root cause (#2587)**: il watchdog `scripts/check-border-data-health.mjs` (cron 6-orario) ha paginato un falso `591 min stale` alle 05:08 UTC mentre **sorgenti e webcam erano tutte sane** (`0/25 mock`). Il backstop coarse di staleness apriva la finestra attiva alle **05:00 UTC**, ma il primo cron mattutino dello scheduler è **04:00 UTC** (`*/30 4-7`) e i run schedulati di GitHub Actions ritardano regolarmente 30-60+ min (o vengono droppati sotto carico): i dati freschi del mattino non erano ancora atterrati → il watchdog valutava dati notturni proprio sul confine della finestra.
- **Fix strutturale**: `STALE_ACTIVE_START_UTC_HOUR` 5 → **6**. Dà al picco mattutino 04:00-07:00 + jitter del cron un **runway di ~2h** prima che il backstop si attivi. La detection è **preservata**: una pipeline davvero congelata (nessun run da 11h+) trippa comunque alle 06:00, e i check sempre-attivi `all-mock` + webcam-health intercettano i guasti veri a qualunque ora.
- **Non è un abbassamento di soglia** (AGENTS #1): la soglia di staleness (6h) è invariata; si sposta solo il confine "quando aspettarsi i dati del mattino" per allinearlo alla realtà scheduler+jitter di GitHub.
- **Test**: aggiornato `tests/check-border-data-health.test.ts` — 05:00 UTC ora INACTIVE, 06:00 resta ACTIVE; 21/21 verdi.

Closes #2587

## Non implementato (ancora)
- **Affidabilità cron GitHub**: la causa a monte (run schedulati droppati/ritardati) è una limitazione di GitHub Actions non risolvibile dal codice. Mitigazione esistente: `traffic-data-freshness.yml` (orario, 90-min, peak-window) ri-dispatcha lo scheduler in self-heal. Allargare quel self-heal alla finestra mattutina presto è un follow-up separato se il false-trip dovesse ripresentarsi alle 06:00.
- **Correlato #2180** (PR #2601, HERE→TomTom primario): ortogonale ma sinergico — garantisce che ogni run produca dati freschi via TomTom invece di congelare lo snapshot a budget HERE esaurito; insieme riducono ulteriormente la staleness reale.
- **Sibling sweep**: la costante `STALE_ACTIVE_START_UTC_HOUR` vive solo in questo file; nessun gemello con la stessa finestra.