### PR TITLE
fix(issue-fix): job color = work-done (PR opened), not CLI exit (#1951)

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -157,6 +157,19 @@ jobs:
       - name: Run Claude fix
         id: claude_review
         if: steps.preflight.outputs.already_resolved != 'true'
+        # Non far fallire il job sull'exit non-zero della CLI: lo step finale
+        # `Classify outcome` decide il colore in base al LAVORO reale (PR aperta
+        # per la issue), non al subtype della CLI. Un `error_max_turns` DOPO che
+        # l'agent ha gia' aperto la PR (passo 7) NON e' un fallimento del run:
+        # campione 7gg (#1951) = 4/11 fail issue-fix avevano una PR creata (3
+        # gia' MERGED) ma la CLI moriva al cap turni DOPO `gh pr create` → job
+        # RED = false-failure che gonfia il failure-rate del loop-health. Stessa
+        # filosofia di #2514 (redflag-fixer): colore = work-done, non CLI exit.
+        # I fail genuini (nessuna PR) restano RED via il classify → segnale
+        # preservato per loop-health + followup-drainer. `outcome` resta
+        # 'failure' (pre-continue-on-error) → i due step di telemetria sotto
+        # (Mark error_max_turns / FIX_OUTCOME backstop) continuano a firare.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -290,3 +303,41 @@ jobs:
           if [ -n "${PR:-}" ]; then OUT=pr-created; else OUT=no-pr-unspecified; fi
           echo "FIX_OUTCOME issue=$ISSUE outcome=$OUT (deterministic backstop)"
           gh issue comment "$ISSUE" --body "$(printf '<!-- FIX_OUTCOME: %s -->\n_Outcome rilevato dal post-step deterministico (telemetria lessons-harvester)._' "$OUT")" || true
+
+      # Colore del job = LAVORO reale del run, non l'exit della CLI Claude.
+      #  • PR aperta o gia' MERGED per la issue (`fix/issue-<N>`)  → run SUCCESS
+      #    (la PR e' in pr-review-loop / gia' mergiata). Vale ANCHE se la CLI e'
+      #    morta `error_max_turns` DOPO `gh pr create` (false-failure: #1951 = 4/11
+      #    fail avevano una PR, 3 gia' MERGED).
+      #  • nessuna PR + CLI FAILED  → non-delivery reale (budget esaurito senza PR,
+      #    oppure branch pushato ma PR mai aperta) → RED (segnale preservato per
+      #    loop-health-report + followup-drainer). NON mascherato: il run non ha
+      #    consegnato una PR.
+      #  • nessuna PR + CLI SUCCESS → terminale pulito (capability-guard / overlap
+      #    / already-fixed / no-root-cause: l'agent ha deciso di NON aprire PR) →
+      #    GREEN, comportamento invariato vs oggi.
+      # I fail infra a monte (npm ci, setup, pre-flight) restano RED da soli:
+      # quegli step non hanno continue-on-error. Nessun gate abbassato: la PR
+      # passa comunque dal reviewer (cfr. #2514 / #2288 — disambigua intenzionale
+      # vs crash, colore != gate).
+      - name: Classify outcome (work-done, not CLI exit)
+        if: always() && steps.preflight.outputs.already_resolved != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          CLAUDE_OUTCOME: ${{ steps.claude_review.outcome }}
+        run: |
+          set -uo pipefail
+          # PR aperta o gia' mergiata sul branch di questa issue (head esatto).
+          PR_STATE=$(gh pr list --head "fix/issue-$ISSUE" --state all --json number,state \
+            --jq '[.[] | select(.state=="OPEN" or .state=="MERGED")] | .[0].number // empty' 2>/dev/null || true)
+          echo "issue=$ISSUE pr(head fix/issue-$ISSUE, open|merged)=${PR_STATE:-<none>} claude=$CLAUDE_OUTCOME"
+          if [ -n "${PR_STATE:-}" ]; then
+            echo "✓ PR #$PR_STATE esiste (open/merged) per la issue → run SUCCESS. Job verde anche se la CLI e' uscita '$CLAUDE_OUTCOME' (false-failure: lavoro consegnato)."
+            exit 0
+          fi
+          if [ "$CLAUDE_OUTCOME" = "failure" ]; then
+            echo "::error::issue-fix #$ISSUE: nessuna PR aperta/mergiata e la CLI e' fallita ('$CLAUDE_OUTCOME') → non-delivery reale. Job RED (segnale preservato per loop-health + drainer)."
+            exit 1
+          fi
+          echo "Nessuna PR ma la CLI e' uscita pulita ('$CLAUDE_OUTCOME') → terminale legittimo (blocked/already-fixed/no-root-cause). Job verde."


### PR DESCRIPTION
## Implementato

Indagine del warning «da investigare» del tracker loop-health **#1951**: `issue-fix.yml` flaggato con failure-rate ~25-28% (soglia warn 20%).

**Diagnosi (11 fail reali, finestra 7gg, log-zip per-run):** tutti `error_max_turns`, ma il colore del job era legato all'exit della CLI Claude, non al lavoro prodotto:
- **4/11 — PR già creata** (issue 2476/2462/2455 → PR #2479/#2471/#2463 **MERGED**; issue 2560 mergiata da run successiva): la CLI moriva al cap turni **dopo** `gh pr create` → job RED = **false-failure**.
- **3/11 — branch pushato, PR mai aperta** (2580/2533 orfani sul remoto, 2391): non-delivery reale → resta RED.
- **4/11 — nessun output** (budget esaurito): genuino → resta RED.

Root cause identica a **#2514** (redflag-fixer: «colore = work-done, non CLI exit»), mai applicata a issue-fix.

**Fix (mirror di #2514):**
- `continue-on-error: true` sul Claude step.
- Nuovo step `Classify outcome (work-done, not CLI exit)`:
  - PR aperta **o già MERGED** per `fix/issue-<N>` → job **GREEN** (anche se la CLI è uscita `error_max_turns` dopo `gh pr create`).
  - nessuna PR + CLI failed → **RED** (segnale non-delivery preservato per loop-health + `followup-drainer`).
  - nessuna PR + CLI success → **GREEN** (terminale legittimo: capability-guard / already-fixed / no-root-cause; invariato).
- `steps.claude_review.outcome` resta `failure` (pre-continue-on-error) → i due step di telemetria (`Mark error_max_turns`, `FIX_OUTCOME backstop`) firano invariati.

Effetto atteso: failure-rate da ~28% → ~18% (solo i 7 non-delivery reali contano). **Nessun gate abbassato**: la PR passa comunque dal reviewer (colore ≠ gate, cfr. #2288/#2514). Bucket C (nessun output) e B (branch senza PR) restano RED → segnale genuino intatto.

## Non implementato (ancora)

- **Recupero bucket B (branch pushato senza PR → 2580/2533/2391, orfani):** auto-creare la PR mancante richiede un PAT — una PR creata in uno step `run:` con `GITHUB_TOKEN` è autorata da `github-actions[bot]` e **non triggera `pr-review-loop`** (anti-ricorsione GitHub; verificato: zero PR `github-actions[bot]` mai mergiate nel repo) → stallerebbe. `issue-fix.yml` non ha wiring PAT/Firebase. **Out of scope** (nuova dipendenza-segreto + fallback PAT-down); restano RED onesti, i branch orfani li spazza il `worktree-branch-janitor`. Follow-up possibile: aggiungere `load-rc-env` come fa il redflag-fixer.
- **Sibling `check-sibling-patterns`:** `pr-redflag-fixer.yml` (condivide `CLAUDE_OUTCOME`) **ha già** questo pattern (#2514) — è il template, non un sibling rotto. `check-issue-already-resolved.mjs` / `followup-drainer.mjs` / `harvest-agent-lessons.mjs` (condividono `FIX_OUTCOME`) sono **consumer** dei marker telemetria: il fix ne preserva l'emissione (`outcome` resta `failure`) → nessuna modifica necessaria.
- **Turn-budget (bucket C):** non toccato — è l'unica leva sui genuini, non validabile pre-merge.

Riferimento: #1951 (tracker permanente — NON va chiuso, il prossimo run lo ricrea).