### PR TITLE
fix(matrix-deploy): per-locale concurrency group on build-locale

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1764,7 +1764,19 @@ jobs:
     if: ${{ vars.LOCALE_MATRIX_BUILD == 'true' || github.event.inputs.force_matrix == 'true' }}
     needs: [matrix-setup, prep]
     runs-on: ubuntu-latest
-    # NO job-level concurrency: the matrix legs must NOT cancel each other.
+    # Per-LOCALE concurrency group: keyed on matrix.locale so the four legs of a
+    # SINGLE run (it/en/de/fr) get distinct groups and run concurrently, while the
+    # SAME locale across DIFFERENT runs serialises (cancel-in-progress: false →
+    # queue, never cancel). This restores the serialisation the monolith got from
+    # its single `pages-build` group: each shard repo (frontaliere-<loc>) and the
+    # IT-leg CDN push are force-push targets, so two concurrent matrix deploys
+    # would race/clobber them. Per-locale grouping prevents that cross-run race
+    # without serialising the within-run fan-out. (A single shared group would
+    # make the legs cancel/queue each other; a workflow-level group would be too
+    # coarse and also gate the monolith path.)
+    concurrency:
+      group: pages-shard-${{ matrix.locale }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION

The monolith serialised builds via the build job's single `pages-build`
concurrency group, so the CDN push and the en/de/fr shard pushes (all force-push
targets) never ran concurrently across deploys. The matrix build-locale job had
NO concurrency group (to keep the 4 legs from cancelling each other), so two
concurrent matrix deploys would race/clobber frontaliere-cdn and frontaliere-{en,
de,fr}. With LOCALE_MATRIX_BUILD default ON, every push triggers a matrix deploy,
so closely-spaced pushes (data commits are frequent) would race — a regression
vs the monolith.

Fix: key the build-locale concurrency group on matrix.locale
(`pages-shard-${{ matrix.locale }}`, cancel-in-progress: false). The four legs of
one run get distinct groups → still run concurrently; the SAME locale across
different runs queues (never cancels) → no cross-run race on that shard repo (and
the IT leg, which does the CDN push, serialises too). A single shared group would
serialise/cancel the legs; a workflow-level group would be too coarse.

## Implementato
- .github/workflows/deploy.yml: build-locale per-locale concurrency group.

## Non implementato (ancora)
- Required before flipping LOCALE_MATRIX_BUILD=true (matrix default) so concurrent
  matrix deploys serialise their force-push targets like the monolith did.