### PR TITLE
fix(newsletter): gate company-hub URL on emitted-hub allow-set — kill silent 404 (#2530 Class C)

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -32,7 +32,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildNewsletter, FEATURED_TOOLS, getFeaturedTools, nlNormLocale, directUrl } from '../services/newsletter-template.mjs';
-import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, companyPageUrl, isCompanyHubSlug } from '../services/newsletter-content.mjs';
+import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, isCompanyHubSlug } from '../services/newsletter-content.mjs';
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
 import { getVariantFallback, listVariantIds, DEFAULT_EPSILON } from '../services/newsletter-subject-variants.mjs';
 import { assignSubjectVariant } from '../services/newsletter-subject-assign.mjs';
@@ -276,9 +276,11 @@ function injectJobAndCompanyLinks(html, jobs, locale = 'it') {
 
   for (const j of jobs.slice(0, 3)) {
     const jobUrl = j.url ? `${BASE_URL}${j.url.startsWith('/') ? j.url : '/' + j.url}` : '';
-    // Company page slug is derived from company display name (mirrors build plugin logic)
-    const companySlug = j.company ? slugifyCompanyName(j.company) : '';
-    const companyUrl = companyPageUrl(companySlug, locale);
+    // Reuse the upstream-validated hub URL from matchJobsForSubscriber (gated on
+    // the emitted-hub allow-set, #2530) rather than re-deriving an UNGATED slug
+    // here — a company present only on expired jobs has no emitted hub and would
+    // 404. Absent companyUrl → omit the company link (safe).
+    const companyUrl = j.companyUrl || '';
 
     let foundTitle = false;
 

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -406,6 +406,50 @@ export function companyPageUrl(companySlug, locale = 'it') {
   return `${BASE_URL}/${boardPath}/${prefix}-${companySlug}/`;
 }
 
+/**
+ * Set of company-hub slugs the build actually emits — one per company that has
+ * ≥1 ACTIVE job (`data/jobs.json`). The build emits a company hub for every
+ * active company (and brand-alias slugs additionally get 200 bridge pages), so
+ * a company whose name exists ONLY on EXPIRED jobs has NO emitted hub: linking
+ * it silently 404s (#2530, e.g. `jumbo-divisione-di-coop-societa-cooperativa`,
+ * a name present only in `data/expired-jobs.json`). Built from the same active
+ * jobs array and the same `slugifyCompanyName` the link builder uses, so the
+ * allow-set matches the emitted set by construction.
+ *
+ * @param {object[]} jobs active jobs array (data/jobs.json)
+ * @returns {Set<string>} emitted company-hub slugs
+ */
+export function buildCompanyHubSlugSet(jobs) {
+  const set = new Set();
+  for (const j of jobs || []) {
+    if (j && j.company) {
+      const slug = slugifyCompanyName(j.company);
+      if (slug) set.add(slug);
+    }
+  }
+  return set;
+}
+
+/**
+ * Company-hub URL only when the build emitted that hub (company present in the
+ * active set); '' otherwise — defense-in-depth mirroring `validateJobUrls` so
+ * the newsletter never links a 404 company hub (#2530). When `emittedSlugs` is
+ * empty/missing the gate is skipped (returns the URL) to avoid silently
+ * dropping every company link on a bad/empty dataset, matching `validateJobUrls`.
+ *
+ * @param {string} company raw company name
+ * @param {string} locale
+ * @param {Set<string>} [emittedSlugs] from {@link buildCompanyHubSlugSet}
+ * @returns {string} hub URL or ''
+ */
+export function companyHubUrlIfEmitted(company, locale = 'it', emittedSlugs) {
+  if (!company) return '';
+  const slug = slugifyCompanyName(company);
+  if (!slug) return '';
+  if (emittedSlugs && emittedSlugs.size > 0 && !emittedSlugs.has(slug)) return '';
+  return companyPageUrl(slug, locale);
+}
+
 export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it', recentlyFeaturedSlugs = []) {
   if (!jobs || jobs.length === 0) return [];
 
@@ -542,6 +586,11 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
   }
 
   const boardPath = JOB_BOARD_PATH[locale] || JOB_BOARD_PATH.it;
+  // Company hubs are emitted only for companies present in the ACTIVE dataset.
+  // A matched job sourced from an expired posting can carry a company-name
+  // variant absent from active data → its hub is never emitted → 404 (#2530).
+  // Gate companyUrl on the emitted-hub allow-set built from `jobs`.
+  const emittedCompanyHubs = buildCompanyHubSlugSet(jobs);
 
   return finalJobs
     .slice(0, limit)
@@ -558,7 +607,7 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
         sector: job.sector || job.category || '',
         rawContract: job.contract || '',
         logoUrl: resolveLogoUrl(job),
-        companyUrl: job.company ? companyPageUrl(slugifyCompanyName(job.company), locale) : '',
+        companyUrl: companyHubUrlIfEmitted(job.company, locale, emittedCompanyHubs),
       };
     });
 }
@@ -676,8 +725,12 @@ export function buildBriefingPrompt(ctx) {
       const postedInfo = j.postedDate || j.crawledAt || j.createdAt
         ? ` (posted: ${new Date(j.postedDate || j.crawledAt || j.createdAt).toLocaleDateString('it-CH')})`
         : '';
-      const companySlug = j.company ? slugifyCompanyName(j.company) : '';
-      const companyUrl = companyPageUrl(companySlug, locale);
+      // Reuse the upstream-validated hub URL from matchJobsForSubscriber (gated
+      // on the emitted-hub allow-set, #2530) instead of re-deriving an UNGATED
+      // slug here — re-deriving was the duplicate path that re-introduced the
+      // 404 (a company present only on expired jobs has no emitted hub). Absent
+      // companyUrl → omit the link (safe: the AI just won't reference a hub).
+      const companyUrl = j.companyUrl || '';
       return `- ${j.title} at ${j.company} (${j.location})${postedInfo} → JOB_URL: ${url}${companyUrl ? ` | COMPANY_URL: ${companyUrl}` : ''}`;
     })
     .filter(Boolean)

--- a/tests/newsletter-company-hub-404.test.ts
+++ b/tests/newsletter-company-hub-404.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Newsletter company-hub existence gate (#2530, Class C).
+ *
+ * The build emits a company hub for every company with >=1 ACTIVE job
+ * (data/jobs.json); brand-alias slugs additionally get 200 bridge pages. A
+ * company whose name exists ONLY on EXPIRED jobs (e.g.
+ * `jumbo-divisione-di-coop-societa-cooperativa`) therefore has NO emitted hub —
+ * linking it from the newsletter silently 404s. The newsletter now gates the
+ * company URL on an allow-set built from the active jobs with the SAME
+ * slugifier the link builder uses, mirroring the existing `validateJobUrls` net.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildCompanyHubSlugSet,
+  companyHubUrlIfEmitted,
+  slugifyCompanyName,
+  matchJobsForSubscriber,
+} from '../services/newsletter-content.mjs';
+
+const activeJobs = [
+  { title: 'Dev', slug: 'dev-acme', company: 'Acme SA', location: 'Lugano' },
+  { title: 'Ops', slug: 'ops-jumbo', company: 'Jumbo', location: 'Bellinzona' },
+];
+
+describe('buildCompanyHubSlugSet', () => {
+  it('contains one slug per active company, using slugifyCompanyName', () => {
+    const set = buildCompanyHubSlugSet(activeJobs);
+    expect(set.has(slugifyCompanyName('Acme SA'))).toBe(true);
+    expect(set.has('jumbo')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it('is empty for empty/missing input', () => {
+    expect(buildCompanyHubSlugSet([]).size).toBe(0);
+    expect(buildCompanyHubSlugSet(undefined).size).toBe(0);
+  });
+});
+
+describe('companyHubUrlIfEmitted', () => {
+  const emitted = buildCompanyHubSlugSet(activeJobs);
+
+  it('returns a hub URL for a company present in the active set', () => {
+    const url = companyHubUrlIfEmitted('Acme SA', 'it', emitted);
+    expect(url).toContain('acme-sa');
+    expect(url.endsWith('/')).toBe(true);
+  });
+
+  it('returns "" for a company present ONLY on expired jobs (the #2530 404 class)', () => {
+    // This long Jumbo variant exists only on expired postings; no hub is emitted.
+    expect(
+      companyHubUrlIfEmitted('Jumbo, Divisione di Coop Società Cooperativa', 'it', emitted),
+    ).toBe('');
+  });
+
+  it('returns "" for empty company', () => {
+    expect(companyHubUrlIfEmitted('', 'it', emitted)).toBe('');
+  });
+
+  it('skips the gate (returns URL) when the allow-set is empty — never drops every link on a bad dataset', () => {
+    const url = companyHubUrlIfEmitted('Some Company', 'it', new Set());
+    expect(url).toContain('some-company');
+  });
+});
+
+describe('matchJobsForSubscriber — companyUrl is gated end-to-end', () => {
+  it('does not attach a companyUrl for an expired-only company variant', () => {
+    const subscriber = { locale: 'it', sourceJob: {
+      title: 'Cassiere', slug: 'cassiere-jumbo-exp', location: 'Bellinzona',
+      company: 'Jumbo, Divisione di Coop Società Cooperativa',
+    } };
+    const matched = matchJobsForSubscriber(subscriber, activeJobs, 3, 'it');
+    // Any card whose company is the expired-only variant must carry empty companyUrl.
+    for (const card of matched) {
+      if (card.company === 'Jumbo, Divisione di Coop Società Cooperativa') {
+        expect(card.companyUrl).toBe('');
+      }
+    }
+  });
+
+  it('attaches a companyUrl for an active company', () => {
+    const subscriber = { locale: 'it' };
+    const matched = matchJobsForSubscriber(subscriber, activeJobs, 3, 'it');
+    const acme = matched.find((c) => c.company === 'Acme SA');
+    if (acme) expect(acme.companyUrl).toContain('acme-sa');
+  });
+});


### PR DESCRIPTION
## Implementato
- **Root cause (#2530 Class C)**: la newsletter linkava gli hub aziendali via `companyPageUrl(slugifyCompanyName(company))` **senza existence check**. Il build emette un company-hub solo per le aziende con ≥1 job **ATTIVO** (gli slug brand-alias ricevono in più bridge 200), quindi un'azienda il cui nome esiste **solo su job scaduti** — es. `Jumbo, Divisione di Coop Società Cooperativa`, presente solo in `data/expired-jobs.json` → slug `jumbo-divisione-di-coop-societa-cooperativa` — **non ha hub emesso** e il link **404**.
- **Fix strutturale (mirror di `validateJobUrls`)**: nuovi helper esportati `buildCompanyHubSlugSet(jobs)` + `companyHubUrlIfEmitted(company, locale, set)`. La allow-set è costruita dai job **attivi** con **lo stesso `slugifyCompanyName`** del link builder → matcha l'emitted-set by construction. Allow-set vuota → gate saltato (mai droppare tutti i link su dataset corrotto, stessa resilienza di `validateJobUrls`).
- `matchJobsForSubscriber` ora gate-a `companyUrl` attraverso la allow-set (ha `jobs` = dataset attivo in scope).
- **Sibling sweep (AGENTS #6)**: le due **ri-derivazioni duplicate NON gated** — `buildBriefingPrompt` (prompt AI) e `scripts/send-newsletter.mjs` fallback linkify — ora **riusano `j.companyUrl`** già validato a monte invece di ri-slugificare. Rimosso import `companyPageUrl` ora inutilizzato in send-newsletter.
- **8 unit test** (`tests/newsletter-company-hub-404.test.ts`): allow-set build, hub-presente→URL, expired-only→'' (il caso #2530), empty-set skip, end-to-end via `matchJobsForSubscriber`. Suite newsletter verde (48+ test).

## Non implementato (ancora)
- **#2530 Class B** (weekly company-city `current-week` de-qualificato → 404 + sitemap weekly che bypassa il filtro locale-shard): tocca `build-plugins/weeklyEmployersPlugin.ts`/`weeklyEmployersData.ts` (emit redirect/bridge per pagine sotto-soglia + guard IT-owner sulla scrittura sitemap). È in un funnel build-plugin non buildabile localmente (OOM) e indipendente da Class C → **follow-up separato**; questa PR **non chiude #2530** (resta aperta per B).
- **#2530 Class A** (alternate sitemap `/en|/fr` per job St.Gallen): per l'analisi, il leg job-alternate è **corretto-by-merge** (gating su `emittedActiveJobPaths`, modificarlo regredirebbe la reciprocità hreflang); il leg St.Gallen/current-week ricade in Class B. Inoltre #2589 (merged) ha aggiunto recovery 200-bridge per gli orfani canton-drift, che copre parte delle URL sitemap.
- **Porting brand-fold in .mjs**: non necessario — gli slug brand-alias sono già emessi come bridge 200, quindi il 404 reale è solo il caso active-vs-expired, coperto dalla allow-set sui job attivi. Documentato per evitare over-engineering.