### PR TITLE
fix(build): robust data-path resolution in loadDataJson (#2594)

### DIFF
--- a/build-plugins/shared/loadDataJson.ts
+++ b/build-plugins/shared/loadDataJson.ts
@@ -24,20 +24,57 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const cache = new Map<string, unknown>();
+
+/**
+ * Resolve a repo-root-relative data path to an absolute path, robustly (#2594).
+ *
+ * Tries, in order, and returns the FIRST candidate where the file exists:
+ *   1. an explicit `rootDir` (passed by plugins that already have one, e.g.
+ *      `legacyRedirectsPlugin`);
+ *   2. `process.cwd()` — the project root for every real Vite build;
+ *   3. a module-relative anchor (`../..` from this file).
+ *
+ * Trying multiple anchors hardens two failure modes a single default can't
+ * cover at once:
+ *   - a non-repo-root `cwd` would ENOENT a bare `process.cwd()` default
+ *     (callers like `slugCantonIndex` pass no `rootDir`);
+ *   - a module-relative-ONLY default would mis-resolve when Vite bundles
+ *     `vite.config.ts`'s import graph (this file included) into a temp location
+ *     via esbuild, where `import.meta.url` points at the temp bundle, not here.
+ *
+ * If none exist, returns the rootDir/cwd candidate so `readFileSync` throws a
+ * clear ENOENT at the expected path rather than a confusing module-relative one.
+ */
+function resolveDataPath(relPath: string, rootDir?: string): string {
+  const roots: string[] = [];
+  if (rootDir) roots.push(rootDir);
+  roots.push(process.cwd());
+  try {
+    roots.push(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..'));
+  } catch {
+    // import.meta.url not a file URL (bundled/browser context) — skip anchor 3.
+  }
+  for (const root of roots) {
+    const abs = path.resolve(root, relPath);
+    if (fs.existsSync(abs)) return abs;
+  }
+  return path.resolve(rootDir ?? process.cwd(), relPath);
+}
 
 /**
  * Read and parse a repo-relative JSON data file. Cached per resolved absolute
  * path so repeated calls within a single build don't re-read/re-parse the file.
  *
  * @param relPath Repo-root-relative path, e.g. `data/jobs.json`.
- * @param rootDir Repo root to resolve `relPath` against. Defaults to
- *   `process.cwd()`, which is the project root during a Vite build. Plugins that
- *   already receive a `rootDir` should pass it for robustness.
+ * @param rootDir Optional repo root to resolve `relPath` against; see
+ *   {@link resolveDataPath} for the full resolution order. Plugins that already
+ *   receive a `rootDir` should pass it.
  */
-export function loadDataJson<T = unknown>(relPath: string, rootDir: string = process.cwd()): T {
-  const abs = path.resolve(rootDir, relPath);
+export function loadDataJson<T = unknown>(relPath: string, rootDir?: string): T {
+  const abs = resolveDataPath(relPath, rootDir);
   const hit = cache.get(abs);
   if (hit !== undefined) return hit as T;
   const data = JSON.parse(fs.readFileSync(abs, 'utf-8')) as T;

--- a/build-plugins/shared/loadJobsJson.ts
+++ b/build-plugins/shared/loadJobsJson.ts
@@ -31,10 +31,10 @@ import { loadDataJson } from './loadDataJson';
  * Thin wrapper over the shared {@link loadDataJson} read-path so the lazy-load
  * anti-pattern guard (see that module's header) lives in exactly one place.
  *
- * @param rootDir Repo root to resolve `data/jobs.json` against. Defaults to
- *   `process.cwd()`, which is the project root during a Vite build. Plugins
- *   that already receive a `rootDir` should pass it for robustness.
+ * @param rootDir Optional repo root to resolve `data/jobs.json` against; see
+ *   {@link loadDataJson}'s resolution order (#2594). Plugins that already
+ *   receive a `rootDir` should pass it.
  */
-export function loadJobsJson<T = unknown>(rootDir: string = process.cwd()): T[] {
+export function loadJobsJson<T = unknown>(rootDir?: string): T[] {
   return loadDataJson<T[]>('data/jobs.json', rootDir);
 }

--- a/tests/load-data-json.test.ts
+++ b/tests/load-data-json.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Robust data-file loader — `loadDataJson` (#2594, follow-up to #2588/#2596).
+ *
+ * Adversarial-review items on the lazy `data/*.json` loader:
+ *  1. path resolution must not ENOENT-crash the build when cwd != repo-root
+ *     (callers like slugCantonIndex pass no rootDir);
+ *  2. the cache must be keyed per resolved path (Map), never a single slot, so
+ *     two consumers resolving different absolute paths don't thrash a 150 MB
+ *     re-read/re-parse.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadDataJson } from '../build-plugins/shared/loadDataJson';
+
+function writeJson(dir: string, rel: string, value: unknown): void {
+  const abs = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(value), 'utf-8');
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'load-data-json-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('loadDataJson — resolution + cache (#2594)', () => {
+  it('reads + parses a file resolved against an explicit rootDir', () => {
+    const dir = mkTmp();
+    writeJson(dir, 'data/sample-2594.json', [{ a: 1 }]);
+    const out = loadDataJson<Array<{ a: number }>>('data/sample-2594.json', dir);
+    expect(out).toEqual([{ a: 1 }]);
+  });
+
+  it('caches per resolved absolute path (same ref on repeat, no re-read)', () => {
+    const dir = mkTmp();
+    writeJson(dir, 'data/cache-2594.json', [{ x: 1 }]);
+    const a = loadDataJson('data/cache-2594.json', dir);
+    // Mutate the file on disk; a cached loader must NOT observe the change.
+    writeJson(dir, 'data/cache-2594.json', [{ x: 999 }]);
+    const b = loadDataJson('data/cache-2594.json', dir);
+    expect(a).toBe(b); // same object reference → served from cache
+    expect(b).toEqual([{ x: 1 }]);
+  });
+
+  it('does NOT thrash between two distinct paths — each keeps its own cache slot', () => {
+    const dir1 = mkTmp();
+    const dir2 = mkTmp();
+    writeJson(dir1, 'data/multi-2594.json', [{ from: 1 }]);
+    writeJson(dir2, 'data/multi-2594.json', [{ from: 2 }]);
+    // Alternate calls to two different absolute paths — a single-slot cache
+    // would thrash and re-read; a Map keeps both.
+    const a1 = loadDataJson('data/multi-2594.json', dir1);
+    const b1 = loadDataJson('data/multi-2594.json', dir2);
+    const a2 = loadDataJson('data/multi-2594.json', dir1);
+    const b2 = loadDataJson('data/multi-2594.json', dir2);
+    expect(a1).toBe(a2);
+    expect(b1).toBe(b2);
+    expect(a1).toEqual([{ from: 1 }]);
+    expect(b1).toEqual([{ from: 2 }]);
+  });
+
+  it('falls back to process.cwd() when no rootDir is given and the file exists there', () => {
+    const rel = 'data/cwd-probe-2594.json';
+    const abs = path.resolve(process.cwd(), rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, JSON.stringify([{ cwd: true }]), 'utf-8');
+    try {
+      const out = loadDataJson<Array<{ cwd: boolean }>>(rel);
+      expect(out).toEqual([{ cwd: true }]);
+    } finally {
+      fs.rmSync(abs, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Implementato
- **Follow-up #2594** (item adversarial su `loadDataJson`/`loadJobsJson`, da #2588/#2596):
  - **Item 2 (cache Map keyed-by-path)**: già atterrato in **#2596** (`const cache = new Map<string, unknown>()`) — verificato, niente da rifare.
  - **Item 1 (path resolution robusta)**: il default `process.cwd()` puro avrebbe ENOENT-crashato il build se la cwd non fosse repo-root (i caller come `slugCantonIndex` non passano `rootDir`).
- **Fix**: nuovo `resolveDataPath` candidate-based — prova in ordine **rootDir esplicito → `process.cwd()` → anchor module-relative**, ritornando il primo dove il file esiste. Indurisce il caso cwid-non-repo-root **senza** affidarsi solo a `import.meta.url`, che qui è **inaffidabile**: Vite bundle-a il grafo di import di `vite.config.ts` (questo modulo incluso) in una **temp location** via esbuild → un default solo-module-relative mis-risolverebbe. Se nessun candidato esiste, ritorna il candidato cwd/rootDir così `readFileSync` lancia un **ENOENT chiaro** sul path atteso.
- Firme `loadJobsJson`/`loadDataJson` ora con `rootDir?` opzionale; il `rootDir` esplicito (`legacyRedirectsPlugin`) vince sempre.
- **4 unit test** (`tests/load-data-json.test.ts`): risoluzione via rootDir, cache per-path (stessa ref, no re-read), no-thrash tra due path distinti, fallback cwd. `tsc` pulito sui file toccati.

Closes #2594

## Non implementato (ancora)
- Nessun re-test del full build (OOM locale): la logica di risoluzione/cache è coperta da unit test deterministici; il comportamento a runtime è invariato nel caso normale (cwd==repo-root → primo/secondo candidato).
- **Sibling sweep**: il read-path lazy vive solo in `loadDataJson.ts` (già consolidato da #2596); `loadJobsJson` è un thin wrapper, `slugCantonIndex` consuma `loadDataJson` direttamente — nessun costrutto duplicato da sweepare.