### PR TITLE
fix(generate-article): locale-boundary catch so a translateContent throw can't discard all 3 locales (#2586)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -4366,10 +4366,27 @@ ${terminologyByLang[targetLang] || ''}`;
   }
 
   const itContent = data.content.it;
+  // Outer-level resilience (#2586): translateContent can still throw from a path
+  // OUTSIDE the per-call wrapped translations above — the chunking loop,
+  // makePrompt, a malformed `sourceContent`, or translateBodyField's own
+  // per-chunk Promise.all (line ~4308, no inner catch). Such a throw would reject
+  // THIS Promise.all and discard ALL three locales + the whole otherwise-fine
+  // article. Catch at the locale boundary and return {} so the downstream
+  // missing-field validation (#1266) re-translates each field in isolation or
+  // falls back to the IT source — the same graceful-degradation contract as
+  // onTranslateFail, applied one level up.
+  const translateLocaleSafe = async (target, label) => {
+    try {
+      return await translateContent('it', target, label, itContent);
+    } catch (err) {
+      console.error(`  ⚠️  ${target.toUpperCase()} translation aborted (${err?.message || err}) — recupero per-campo downstream (#1266)`);
+      return {};
+    }
+  };
   const [enContent, deContent, frContent] = await Promise.all([
-    translateContent('it', 'en', '2/5', itContent),
-    translateContent('it', 'de', '3/5', itContent),
-    translateContent('it', 'fr', '4/5', itContent),
+    translateLocaleSafe('en', '2/5'),
+    translateLocaleSafe('de', '3/5'),
+    translateLocaleSafe('fr', '4/5'),
   ]);
   console.error(`  ✅ Tutte le traduzioni completate`);
 


### PR DESCRIPTION
## Implementato
- **Root cause (#2586, adversarial follow-up di #2582)**: #2582 ha aggiunto `.catch` per-call alle sotto-chiamate di traduzione, ma `translateContent` può ancora **lanciare da un path FUORI** da quelle call wrappate — il loop di chunking, `makePrompt`, un `sourceContent` malformato, o il `Promise.all` per-chunk interno di `translateBodyField` (riga ~4308, senza catch interno). Un throw del genere **rigetta il `Promise.all([en, de, fr]` esterno** e **scarta tutti e 3 i locali + l'intero articolo** altrimenti valido.
- **Fix strutturale**: wrap di ogni chiamata `translateContent` al **confine del locale** (`translateLocaleSafe`): su throw logga e ritorna `{}`, così la validazione downstream dei campi mancanti (#1266) ri-traduce ogni campo in isolamento o fa fallback al sorgente IT — **stesso contratto di graceful-degradation di `onTranslateFail`, un livello più su**. L'articolo viene sempre prodotto.

Closes #2586

## Non implementato (ancora)
- **Nessun unit test**: `translateContent` è una closure annidata accoppiata all'API AI, **non esportata** dallo script `create-article.mjs`; testarla richiederebbe estrarre+esportare l'orchestrazione (scope creep su un file molto attivo). La modifica è un `try/catch` minimale che rispecchia il fallback per-call già in produzione (#2582) e i cui effetti downstream (#1266) sono già coperti. Sanity: i test gate/template di create-article restano verdi.
- **Sibling sweep**: il pattern `Promise.all` di traduzione multi-locale vive solo qui; `onTranslateFail` (per-call) e questo catch (per-locale) sono i due livelli dello stesso contratto, nessun gemello da sweepare.