### PR TITLE
fix(newsletter): align company-hub allow-set to emitter validJobs gate (#2608 item 2)

### DIFF
--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -422,7 +422,16 @@ export function companyPageUrl(companySlug, locale = 'it') {
 export function buildCompanyHubSlugSet(jobs) {
   const set = new Set();
   for (const j of jobs || []) {
-    if (j && j.company) {
+    // Mirror the emitter's `validJobs` gate (jobsSeoPagesPlugin.ts ~1255): a hub
+    // is emitted only for a company on a job that ALSO has title, location and a
+    // description. A company appearing only on description-/title-/location-less
+    // jobs gets no emitted primary hub, so it must not be allow-listed either —
+    // otherwise the gate still links a 404 (#2608 item 2). The company-slug
+    // algorithm here (slugifyCompanyName) is byte-identical to the emitter's
+    // slugifyCompanyBuild, and brand-alias raw slugs are covered by 200 bridges
+    // from companyHubBridgePlugin's crawler-known coverage (#2608 item 3), so the
+    // raw slug is the correct allow-set key.
+    if (j && j.title && j.company && j.location && (j.description || j.descriptionByLocale)) {
       const slug = slugifyCompanyName(j.company);
       if (slug) set.add(slug);
     }

--- a/tests/newsletter-company-hub-404.test.ts
+++ b/tests/newsletter-company-hub-404.test.ts
@@ -19,8 +19,8 @@ import {
 } from '../services/newsletter-content.mjs';
 
 const activeJobs = [
-  { title: 'Dev', slug: 'dev-acme', company: 'Acme SA', location: 'Lugano' },
-  { title: 'Ops', slug: 'ops-jumbo', company: 'Jumbo', location: 'Bellinzona' },
+  { title: 'Dev', slug: 'dev-acme', company: 'Acme SA', location: 'Lugano', description: 'Sviluppo software full-stack a Lugano.' },
+  { title: 'Ops', slug: 'ops-jumbo', company: 'Jumbo', location: 'Bellinzona', description: 'Addetto vendite a Bellinzona.' },
 ];
 
 describe('buildCompanyHubSlugSet', () => {
@@ -34,6 +34,22 @@ describe('buildCompanyHubSlugSet', () => {
   it('is empty for empty/missing input', () => {
     expect(buildCompanyHubSlugSet([]).size).toBe(0);
     expect(buildCompanyHubSlugSet(undefined).size).toBe(0);
+  });
+
+  it('excludes a company on a description-less / field-incomplete job — mirrors emitter validJobs gate (#2608 item 2)', () => {
+    const jobs = [
+      { title: 'Dev', company: 'Acme SA', location: 'Lugano', description: 'Ruolo completo.' },
+      { title: 'X', company: 'NoDesc SA', location: 'Lugano' },          // missing description → no hub emitted
+      { title: 'Y', company: 'NoLoc SA', description: 'ha desc' },        // missing location
+      { company: 'NoTitle SA', location: 'Lugano', description: 'd' },    // missing title
+      { title: 'Z', company: 'ByLocale SA', location: 'Chiasso', descriptionByLocale: { it: 'ok' } }, // descriptionByLocale counts
+    ];
+    const set = buildCompanyHubSlugSet(jobs);
+    expect(set.has('acme-sa')).toBe(true);
+    expect(set.has('bylocale-sa')).toBe(true); // descriptionByLocale satisfies the gate
+    expect(set.has('nodesc-sa')).toBe(false);
+    expect(set.has('noloc-sa')).toBe(false);
+    expect(set.has('notitle-sa')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Implementato
- **#2608 item 2 (allow-set vs validJobs mismatch → residual 404)**: `buildCompanyHubSlugSet` (da #2605) allow-listava qualunque azienda con nome non vuoto, ma il build emette un company-hub solo per i job che passano il gate `validJobs` (`jobsSeoPagesPlugin.ts ~1255`): `title && company && location && (description || descriptionByLocale)`. Un'azienda presente solo su job **senza descrizione/titolo/location** era quindi allow-listata ma **senza hub emesso → 404 residuo**. Applicato lo **stesso predicato** così l'allow-set combacia con l'emitter by-construction.
- **#2608 item 3 (alias-fold divergence) — VERIFICATO, nessun cambiamento necessario**: l'algoritmo di slug qui (`slugifyCompanyName`) è **byte-identico** all'emitter `slugifyCompanyBuild`; per i raw slug brand-alias che divergono dal canonical foldato, `companyHubBridgePlugin` emette **bridge 200** con copertura broad (ogni azienda crawler-known, sorgenti GSC+orphan+by-crawler) → il raw slug è la chiave allow-set corretta.
- **Test**: fixture aggiornate (con `description`) + nuovo test di esclusione (missing description/title/location, e accettazione di `descriptionByLocale`). Suite newsletter verde (44 test).

## Non implementato (ancora)
- **#2608 item 1 = #2530 Class B** (weeklyEmployersPlugin weekly company-city 404 + sitemap locale-shard guard): è un build-plugin funnel non buildabile localmente, già documentato con piano preciso su **#2530** e coordinato con il lavoro matrix-shard attivo. **Fuori scope di questa PR** (che tocca solo il newsletter allow-set): tracciato su #2530, non un nuovo follow-up.
- Nessun altro scope deferito: gli item 2 e 3 di #2608 sono entrambi indirizzati qui (item 2 fixato, item 3 verificato senza necessità di modifica).