### PR TITLE
fix(job-alerts): unsubscribe links on sending domain to clear spam filters

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -603,7 +603,13 @@ export const jobAlertUnsubscribe = onRequest(
  return;
  }
 
- const params = req.method === 'GET' ? req.query : req.body;
+ // RFC 8058 one-click POST carries alertId/email/token in the URI QUERY STRING
+ // (the body is only `List-Unsubscribe=One-Click`), so a POST must read the
+ // identifiers from the query too — not just req.body. Merge both (body wins on
+ // the rare key collision) so both the footer GET link and the header one-click
+ // POST resolve the same params. A POST that read body-only verified an empty
+ // email/token → 403 → never unsubscribed, which also hurts sender reputation.
+ const params = req.method === 'GET' ? req.query : { ...req.query, ...req.body };
  const alertId = String(params.alertId || '').trim();
  const email = String(params.email || '').trim();
  const token = String(params.token || '').trim();

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -69,6 +69,24 @@ const SHARD_ORIGIN = {
 // to these prefixes; this regex is the in-code guard.)
 const LOCALE_RE = /^\/(en|de|fr)(\/|$|\.html$)/;
 
+// Job-alert one-click unsubscribe proxy (RFC 8058). The unsubscribe links and
+// the List-Unsubscribe header in job-alert emails (scripts/send-job-alerts.mjs)
+// MUST live on the sending domain (frontaliereticino.ch) or the URL↔From-domain
+// mismatch trips spam filters. The actual handler is the jobAlertUnsubscribe
+// Cloud Function; this Worker transparently proxies the apex path to it so the
+// public URL never leaves the apex. The proxy preserves method + query + body so
+// the List-Unsubscribe-Post one-click POST reaches the function unchanged (a 301
+// would not be re-issued as a POST by mail clients). Tiny volume (a few
+// clicks/day); never cached (stateful, and links always carry a query string so
+// the it-apex-html-cache rule — query eq "" only — never matches anyway).
+const UNSUB_PROXY_PATH = '/disiscrivi-alert';
+const UNSUB_FUNCTION_ORIGIN =
+  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/jobAlertUnsubscribe';
+
+function isUnsubProxyPath(pathname) {
+  return pathname === UNSUB_PROXY_PATH || pathname === `${UNSUB_PROXY_PATH}/`;
+}
+
 // Edge-cache TTLs for shard pages. Two layers, deliberately different:
 //
 //   ORIGIN_CACHE_TTL (2h) — `cf.cacheTtl` on the origin fetch: CF caches the
@@ -292,6 +310,27 @@ async function serveStaleOnError(url, reason) {
 export default {
   async fetch(request, _env, ctx) {
     const url = new URL(request.url);
+
+    // Job-alert one-click unsubscribe: transparently proxy to the
+    // jobAlertUnsubscribe Cloud Function, preserving method + query + body so the
+    // RFC 8058 one-click POST works and the public URL stays on the sending
+    // domain. Runs BEFORE the locale logic (this path is not a locale prefix, so
+    // it would otherwise fall through to the apex passthrough → GitHub Pages 404).
+    if (isUnsubProxyPath(url.pathname)) {
+      const upstream = new URL(UNSUB_FUNCTION_ORIGIN);
+      upstream.search = url.search; // carry alertId/email/token/action
+      try {
+        // new Request(url, request) copies method/headers/body; the upstream host
+        // comes from `url` (the Cloud Function ignores the forwarded Host).
+        return await fetch(new Request(upstream.toString(), request));
+      } catch {
+        return new Response('Unsubscribe service temporarily unavailable', {
+          status: 503,
+          headers: { 'Retry-After': '30' },
+        });
+      }
+    }
+
     const match = url.pathname.match(LOCALE_RE);
 
     if (!match) {

--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -27,6 +27,16 @@ routes = [
   { pattern = "frontaliereticino.ch/fr/*",    zone_name = "frontaliereticino.ch" },
   { pattern = "frontaliereticino.ch/fr",      zone_name = "frontaliereticino.ch" },
   { pattern = "frontaliereticino.ch/fr.html", zone_name = "frontaliereticino.ch" },
+  # Job-alert one-click unsubscribe (RFC 8058). Deliberate non-locale exception to
+  # the "locale paths only" scoping above: the unsubscribe links + List-Unsubscribe
+  # header in job-alert emails MUST live on the sending domain (frontaliereticino.ch)
+  # or the URL↔From-domain mismatch trips spam filters. The Worker transparently
+  # proxies this apex path to the jobAlertUnsubscribe Cloud Function (in-code
+  # UNSUB_PROXY_PATH branch — method + query + body preserved for the one-click POST).
+  # Volume is tiny (a few clicks/day) so the extra Worker invocations are negligible.
+  # Both the trailing-slash and bare forms are routed so a POST never hits a 301.
+  { pattern = "frontaliereticino.ch/disiscrivi-alert/", zone_name = "frontaliereticino.ch" },
+  { pattern = "frontaliereticino.ch/disiscrivi-alert",  zone_name = "frontaliereticino.ch" },
   # NOTE: the /assets/* /data/* /og/* CDN-proxy routes were removed (2026-06-10).
   # Since #1665 the shard locale HTML references those static paths CDN-absolute
   # (cdn.frontaliereticino.ch/...), so the browser fetches them straight from the

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -52,8 +52,15 @@ if (TARGET_EMAIL_RAW) {
   console.log(`🎯 TARGET_EMAIL set — limiting send to: ${TARGET_EMAIL_RAW}`);
 }
 
-// Cloud Function URL for one-click unsubscribe (RFC 8058)
-const UNSUB_FUNCTION_URL = 'https://europe-west6-frontaliere-ticino.cloudfunctions.net/jobAlertUnsubscribe';
+// One-click unsubscribe endpoint (RFC 8058). MUST live on the sending domain
+// (frontaliereticino.ch) or the URL↔sending-domain mismatch trips spam filters —
+// the raw europe-west6-frontaliere-ticino.cloudfunctions.net/jobAlertUnsubscribe
+// host differs from the From domain (alerts@frontaliereticino.ch). This apex path
+// is transparently proxied to that Cloud Function by the locale-router Worker
+// (infra/cloudflare-worker/locale-router.js — method + query + body preserved, so
+// the List-Unsubscribe-Post one-click POST still reaches the function). Trailing
+// slash is canonical (site convention) and dodges a no-slash→slash 301 on POST.
+const UNSUB_URL = `${BASE_URL}/disiscrivi-alert/`;
 
 // Locale-aware job board URL paths (must match router.ts slug tables)
 const JOB_BOARD_PATHS = {
@@ -322,7 +329,7 @@ function makeAlertUnsubscribeUrl(alertId, email) {
   const token = createHmac('sha256', secret)
     .update(`job_alert_unsub:${alertId}:${email.toLowerCase().trim()}`)
     .digest('hex');
-  return `${UNSUB_FUNCTION_URL}?alertId=${encodeURIComponent(alertId)}&email=${encodeURIComponent(email)}&token=${token}`;
+  return `${UNSUB_URL}?alertId=${encodeURIComponent(alertId)}&email=${encodeURIComponent(email)}&token=${token}`;
 }
 
 function makeAllAlertsUnsubscribeUrl(email) {
@@ -331,7 +338,7 @@ function makeAllAlertsUnsubscribeUrl(email) {
   const token = createHmac('sha256', secret)
     .update(`job_alert_unsub_all:${email.toLowerCase().trim()}`)
     .digest('hex');
-  return `${UNSUB_FUNCTION_URL}?email=${encodeURIComponent(email)}&token=${token}&action=unsubscribe_all`;
+  return `${UNSUB_URL}?email=${encodeURIComponent(email)}&token=${token}&action=unsubscribe_all`;
 }
 
 // ── Autologin (reuse newsletter pattern) ────────────────────

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -730,6 +730,20 @@ describe('job alert email — unsubscribe links match the sending domain (anti-s
     );
   });
 
+  it('jobAlertUnsubscribe reads identifiers from the query on POST (one-click works)', () => {
+    // RFC 8058 one-click POST carries alertId/email/token in the query string,
+    // not the body — so the function MUST merge the query into POST params or the
+    // one-click verifies an empty token (403) and never unsubscribes.
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../functions/index.js'),
+      'utf8',
+    );
+    const handler = src.slice(src.indexOf('export const jobAlertUnsubscribe'));
+    expect(handler).toMatch(
+      /req\.method === 'GET' \? req\.query : \{\s*\.\.\.req\.query,\s*\.\.\.req\.body\s*\}/,
+    );
+  });
+
   it('the locale-router Worker proxies the same /disiscrivi-alert path (no drift)', () => {
     // Pairs the email path to the Worker proxy: if one changes without the other,
     // the apex link 404s. Lock both ends.

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   buildAlertEmail,
   mailerooMetaOnSent,
@@ -681,5 +681,68 @@ describe('job alert maileroo meta — open/click attribution writer (#1140)', ()
     expect(onSentWirings.length).toBeGreaterThanOrEqual(2);
     // Guard the retry call specifically.
     expect(src).toMatch(/sendEmailCascade\(retryEmails,\s*\{[^}]*onSent:\s*mailerooMetaOnSent/s);
+  });
+});
+
+describe('job alert email — unsubscribe links match the sending domain (anti-spam)', () => {
+  // Spam filters flag emails whose link host differs from the From domain
+  // (alerts@frontaliereticino.ch). The unsubscribe links + List-Unsubscribe
+  // header previously pointed at the raw Cloud Function host
+  // (europe-west6-frontaliere-ticino.cloudfunctions.net) — a hard mismatch. They
+  // now use an apex path (/disiscrivi-alert/) that the locale-router Worker
+  // proxies to the function. The real proxy path is only emitted when
+  // NEWSLETTER_SECRET is set (otherwise the builders return a canonical-domain
+  // fallback), so exercise the signed path here.
+  let prevSecret: string | undefined;
+  beforeEach(() => {
+    prevSecret = process.env.NEWSLETTER_SECRET;
+    process.env.NEWSLETTER_SECRET = 'test-secret-for-unsub-urls';
+  });
+  afterEach(() => {
+    if (prevSecret === undefined) delete process.env.NEWSLETTER_SECRET;
+    else process.env.NEWSLETTER_SECRET = prevSecret;
+  });
+
+  it('never links to the raw cloudfunctions.net host (HTML or plaintext)', () => {
+    const result = buildAlertEmail(fixtureAlert('it'), [fixtureJob()], true);
+    expect(result.html).not.toContain('cloudfunctions.net');
+    expect(result.text).not.toContain('cloudfunctions.net');
+    expect(result.unsubscribeUrl).not.toContain('cloudfunctions.net');
+  });
+
+  it('single-alert + all-alerts unsubscribe links use the apex /disiscrivi-alert/ path', () => {
+    const result = buildAlertEmail(fixtureAlert('it'), [fixtureJob()], true);
+    // Single-alert unsubscribe (also the List-Unsubscribe header value).
+    expect(result.html).toMatch(
+      /https:\/\/frontaliereticino\.ch\/disiscrivi-alert\/\?alertId=[^"]*&token=/,
+    );
+    // All-alerts unsubscribe.
+    expect(result.html).toMatch(
+      /https:\/\/frontaliereticino\.ch\/disiscrivi-alert\/\?email=[^"]*&action=unsubscribe_all/,
+    );
+    expect(result.text).toMatch(/https:\/\/frontaliereticino\.ch\/disiscrivi-alert\//);
+  });
+
+  it('the List-Unsubscribe header value (unsubscribeUrl) is on the sending domain', () => {
+    const result = buildAlertEmail(fixtureAlert('it'), [fixtureJob()], true);
+    expect(result.unsubscribeUrl).toMatch(
+      /^https:\/\/frontaliereticino\.ch\/disiscrivi-alert\//,
+    );
+  });
+
+  it('the locale-router Worker proxies the same /disiscrivi-alert path (no drift)', () => {
+    // Pairs the email path to the Worker proxy: if one changes without the other,
+    // the apex link 404s. Lock both ends.
+    const worker = fs.readFileSync(
+      path.resolve(__dirname, '../infra/cloudflare-worker/locale-router.js'),
+      'utf8',
+    );
+    expect(worker).toMatch(/UNSUB_PROXY_PATH\s*=\s*'\/disiscrivi-alert'/);
+    expect(worker).toContain('jobAlertUnsubscribe');
+    const wrangler = fs.readFileSync(
+      path.resolve(__dirname, '../infra/cloudflare-worker/wrangler.toml'),
+      'utf8',
+    );
+    expect(wrangler).toContain('frontaliereticino.ch/disiscrivi-alert/');
   });
 });


### PR DESCRIPTION
## Problema

Le email di job-alert avevano i link di disiscrizione (footer **e** header RFC 8058 `List-Unsubscribe`) puntati all'host grezzo della Cloud Function `https://europe-west6-frontaliere-ticino.cloudfunctions.net/jobAlertUnsubscribe`, mentre ogni altro link usa `https://frontaliereticino.ch`. Il mismatch URL↔dominio mittente (`alerts@frontaliereticino.ch`) è un trigger noto degli spam filter (segnalazione utente).

## Implementato

- `scripts/send-job-alerts.mjs`: l'endpoint di disiscrizione ora è `${BASE_URL}/disiscrivi-alert/` (canonico, trailing-slash) invece dell'host `cloudfunctions.net`. Rinominata la costante `UNSUB_FUNCTION_URL`→`UNSUB_URL` + commento aggiornato. Entrambi i builder (single-alert e all-alerts) → link HTML/plaintext + valore header `List-Unsubscribe` ereditano il dominio mittente.
- `infra/cloudflare-worker/locale-router.js`: nuovo branch early-return che proxa in modo trasparente `/disiscrivi-alert[/]` alla function `jobAlertUnsubscribe`, **preservando method + query + body** così il POST one-click (RFC 8058) raggiunge la function invariato (un 301 NON verrebbe re-inviato come POST dai mail client). Mai cachato (stateful; i link portano sempre query-string → `it-apex-html-cache` con `query eq ""` non matcha comunque).
- `infra/cloudflare-worker/wrangler.toml`: aggiunte 2 route (`/disiscrivi-alert/` + bare) come eccezione deliberata allo scoping "solo path locale", rationale inline. `cf-locale-failover-setup.mjs` itera tutte le route e imposta `request_limit_fail_open: true` da sé → nessuna modifica lì.
- `functions/index.js` (fix reviewer 🔴): `jobAlertUnsubscribe` ora legge gli identificativi dalla **query anche su POST** (`req.method === 'GET' ? req.query : { ...req.query, ...req.body }`). Il one-click RFC 8058 porta `alertId/email/token` nella query-string (il body è solo `List-Unsubscribe=One-Click`): leggendo body-only il POST verificava token vuoto → 403 → non disiscriveva mai, e un one-click non-200 peggiora la reputazione mittente (l'opposto dell'obiettivo anti-spam). Body vince sulla collisione → i POST SPA esistenti restano invariati.
- `tests/job-alert-email.test.ts`: 5 test di regressione — nessun link a `cloudfunctions.net` (HTML+plaintext+header), link single/all su `/disiscrivi-alert/`, path email accoppiato alla route Worker (anti-drift), e `jobAlertUnsubscribe` legge dalla query su POST. 75/75 verde in locale.

## Non implementato (ancora)

- **`newsletterManageSubscription` (`functions/index.js:L366`)**: condivide il costrutto `req.method === 'GET' ? req.query : req.body` ma NON è nella stessa classe di bug e resta intatto di proposito. NON è un endpoint one-click RFC 8058: l'header `List-Unsubscribe` della newsletter punta alla root SPA (`${BASE_URL}/?action=unsubscribe&…`), non a questa function; i suoi POST sono submission del form preferenze SPA con i parametri nel **body**. Un merge query-su-body lì sarebbe speculativo (nessun chiamante one-click che metta i parametri in query). Mantiene `req.body` per i POST.
- **`functions/src/jobAlertUnsubscribe.js`**: handler invariato — il fix è nel mapping req→params del wrapper `onRequest`, non nella logica di verifica/disiscrizione (corretta).
- **Verifica live** (post-deploy Worker): curl `https://frontaliereticino.ch/disiscrivi-alert/?alertId=…&token=…` → 200 dalla function; POST one-click (`-X POST` con `?…&token=…`) → 200. La eseguo dopo merge + `deploy-worker.yml`.
- **Edge over-cap Worker**: fail-open bypasserebbe il Worker → CDN → 404 (path non statico). Volume disiscrizioni minimo + account Workers Paid (cap ~moot) → accettabile; revert-trigger: ripristinare l'host `cloudfunctions.net` in `send-job-alerts.mjs`.