### PR TITLE
fix(publisher): stop legacy-redirecting the active publisher section

### DIFF
--- a/build-plugins/legacyRedirectsPlugin.ts
+++ b/build-plugins/legacyRedirectsPlugin.ts
@@ -267,20 +267,12 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  // class is swept here (AGENTS.md #6): publish/dashboard/employer → live job board;
  // partner-services (thin utility) → home; press-kit → about; newsletter-prefs
  // (token-gated, no standalone content) → the live morning/newsletter landing.
- // Publish-a-job + my-listings + for-employers → the live job board (the product
- // these funnel into; where published jobs appear).
- '/pubblica-offerta/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
- '/i-miei-annunci/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
- '/per-le-aziende/': '/cerca-lavoro-ticino/', // cathedral-allow: TI legacy section (it)
- '/en/post-a-job/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
- '/en/my-listings/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
- '/en/for-employers/': '/en/find-jobs-ticino/', // cathedral-allow: TI legacy section (en)
- '/de/stelle-aufgeben/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
- '/de/meine-anzeigen/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
- '/de/fuer-unternehmen/': '/de/jobs-im-tessin/', // cathedral-allow: TI legacy section (de)
- '/fr/publier-une-offre/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
- '/fr/mes-annonces/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
- '/fr/pour-les-entreprises/': '/fr/trouver-emploi-tessin/', // cathedral-allow: TI legacy section (fr)
+ // NB: the publisher section — publish (/pubblica-offerta/, /en/post-a-job/, …),
+ // my-listings (/i-miei-annunci/, …) and for-employers (/per-le-aziende/, …) in
+ // all 4 locales — is the ACTIVE monetization funnel (Piano Azienda checkout,
+ // dashboard, employer landing). It must NOT be legacy-redirected: those routes
+ // are served live by the SPA (services/router.ts). The Cathedral-era redirects
+ // to the job board were removed — re-adding them takes the publish form offline.
  // Partner services (thin utility tab) → locale home.
  '/servizi-partner/': '/',
  '/en/partner-services/': '/en/',


### PR DESCRIPTION
## 🔴 Trovato in verifica live

Verificando `/pubblica-offerta/` sul sito live: serviva uno stub **"Pagina spostata"** → redirect a `/cerca-lavoro-ticino/`. Il form di pubblicazione (e tutto il funnel publisher) era **irraggiungibile**.

**Causa**: `legacyRedirectsPlugin.ts` rediregeva l'intera sezione publisher (publish / my-listings / for-employers, 4 locali) al job board — decisione epoca Cathedral, da quando quelle pagine erano considerate legacy.

Ora sono il **funnel di monetizzazione attivo** (checkout Piano Azienda, dashboard inserzionista, landing /per-le-aziende/) e il router le serve (`publish='pubblica-offerta'`, ecc.). `/per-le-aziende/` funzionava solo perché la sua pagina SSG sovrascriveva lo stub; publish + dashboard (SPA-only) no → lo stub vinceva e le rompeva.

## Implementato

- Rimosse le **12 voci** publisher-section dai redirect legacy (it/en/de/fr × publish/my-listings/for-employers). Le rotte ora sono servite dalla SPA via `public/404.html` (stesso fallback che serve `/profilo/`). Nota anti-regressione lasciata nel plugin.

## Verifica

- Live: `/pubblica-offerta/` serviva `<title>Pagina spostata</title>` canonical→/cerca-lavoro-ticino/ (stub); `/profilo/` (SPA-only) serve regolarmente la SPA → conferma che il 404-fallback regge le rotte non-SSG.
- Test verdi: `cathedral-no-ti-hardcodes` (33), `router-locale-slugs`, `redirect-page-builders`, `no-js-redirects-in-build`, `noindex-builders`, `flat-html-redirect`.

## Non implementato (ancora)

- Verifica post-deploy live che `/pubblica-offerta/` renda il form (+ `?tier=azienda` preselezioni) e `/i-miei-annunci/` la dashboard — da fare a deploy concluso.