### PR TITLE
feat(jobboard): full-height side rails on the auth-gate view too

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6327,7 +6327,21 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  {authPendingNoticeJsx}
 
- {/* Single-column gate body — desktop rails earned €0.06–0.10 RPM (FRO-2026-04-26 prune). */}
+ {/* 3-column rail grid: left rail | gate body | right rail. Re-enables the
+     full-height desktop side rails on the auth-gate view (matching the active
+     job-detail + expired/orphan layouts), shrinking the central gate content
+     on desktop (xl+) to host the half-page creatives. Rails widen 180px→300px
+     at xlw (≥1400) and only serve there; below xl it's a single column.
+     NOTE: overrides the FRO-2026-04-26 prune (rails earned €0.06–0.10 RPM on
+     the gate) per explicit owner request. */}
+ <div className="xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+
+ {/* ── Left Rail (desktop xl only) ── */}
+ <aside className="hidden xl:max-xlw:block xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>
+ </aside>
+
+ {/* ── Center gate content ── */}
  <div className="space-y-4">
 
  {/* Job header — always visible */}
@@ -6550,6 +6564,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  fullWidthResponsive={AD_SLOTS.JOBDETAIL_AUTH_GATE.fullWidthResponsive}
  />
  )}
+ </div>
+
+ {/* ── Right Rail (desktop xl only) ── */}
+ <aside className="hidden xl:max-xlw:block xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense>
+ </aside>
+
  </div>
 
  {/* AdSense — end multiplex below gate */}


### PR DESCRIPTION
## Implementato

- **Barre laterali a tutta altezza anche sull'auth-gate** della job detail (ramo `!hasAccess` in `JobBoard.tsx`): il corpo del gate viene avvolto nella stessa rail-grid 3-col di active job-detail (#2584), expired e orphan — `<aside>` left/right con `ArticleRailAdStack`.
- **Contenuto centrale ridotto su desktop** (xl+): la colonna centrale passa a `minmax(0,1fr)` con rail `180px` a xl (1280–1399) e `300px` a xlw (≥1400). Sotto xl resta singola colonna (mobile/tablet invariati).
- Le creatività GPT (`/23355151813/article-rail-{side}`) si materializzano solo a `xlw`; riuso degli stessi ad unit + kill-switch Remote Config (`KILL_ARTICLE_RAIL_ADS`), nessuna duplicazione.

## Non implementato (ancora)

- **Override deliberato del prune FRO-2026-04-26**: quel prune aveva reso il gate single-column perché i rail desktop rendevano €0.06–0.10 RPM. Questa PR li ri-abilita **su richiesta esplicita owner** per coerenza con tutti gli altri stati job-detail. Se il RPM resta marginale è un candidato A/B / revert-trigger post-deploy (osservabile solo live).
- **Verifica live ≥1400px**: fill GPT effettivo + assenza CLS osservabili solo sul deploy reale a viewport `xlw`; non riproducibili pre-merge.
- **Modal auth-gate** (`authGateModalJsx`, overlay fixed): fuori scope — è un overlay separato, non la colonna di contenuto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)