### PR TITLE
feat(newsletter): decay job popularity + recency blend for no-profile subscribers

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1272,7 +1272,10 @@ function buildJobContextIndex(jobs) {
 }
 
 function enrichSubscriberJobContext(subscriber, jobIndex) {
-  const savedSlug = subscriber?.job_slug;
+  // Resolve the source job from the saved slug, falling back to the slug the
+  // backfill recovered (scripts/backfill-newsletter-job-context.mjs) for
+  // subscribers whose original job_slug expired or was never captured.
+  const savedSlug = subscriber?.job_slug || subscriber?.job_context_backfill_slug;
   const sourceJob = savedSlug ? jobIndex.get(savedSlug) : null;
   if (!sourceJob) return subscriber;
   return {
@@ -1303,6 +1306,7 @@ function subscriberFromFirestoreRow(row) {
     job_location: row.job_location || null,
     job_category: row.job_category || null,
     job_search_query: row.job_search_query || null,
+    job_context_backfill_slug: row.job_context_backfill_slug || null,
     source: row.source || null,
     preferences: row.preferences || {},
     type: row.type || null,

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -88,9 +88,39 @@ function resolveLogoUrl(job) {
 // ─── Job matching ───────────────────────────────────────────
 
 function toDateValue(job) {
-  const raw = job?.postedDate || job?.crawledAt || '';
+  const raw = job?.postedDate || job?.crawledAt || job?.publishedAt || job?.firstSeenAt || '';
   const ts = raw ? new Date(raw).getTime() : 0;
   return Number.isFinite(ts) ? ts : 0;
+}
+
+// ─── Popularity decay (anti-evergreen-freeze) ───────────────
+// Raw job_views are cumulative all-time (scripts/fetch-job-popularity.mjs),
+// so a handful of big-employer evergreens stay frozen at the top of every
+// newsletter. We decay the view count by job age at read time so stale
+// popular jobs stop crowding out fresher listings. Half-life 30d: a 30-day
+// old job counts half, 60d a quarter, 90d an eighth.
+const POPULARITY_HALFLIFE_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Jobs with no parseable date can't be aged, so we apply a neutral mid-life
+// dampening (~1 half-life) instead of trusting their raw all-time count.
+const UNDATED_DECAY_FACTOR = 0.5;
+// No-profile subscribers get 2 popular (decayed) + 2 fresh slots so the
+// section visibly rotates week-over-week instead of collapsing onto the
+// all-time most-viewed jobs.
+const NO_PROFILE_POPULAR_SLOTS = 2;
+
+export function decayFactor(job, now) {
+  const ts = toDateValue(job);
+  if (!ts) return UNDATED_DECAY_FACTOR;
+  const ageDays = Math.max(0, (now - ts) / DAY_MS);
+  return Math.pow(0.5, ageDays / POPULARITY_HALFLIFE_DAYS);
+}
+
+/** Age-decayed popularity: cumulative views damped by job freshness. */
+function decayedPopularity(job, popularity, now) {
+  const views = getJobPopularityCount(job, popularity);
+  if (views <= 0) return 0;
+  return views * decayFactor(job, now);
 }
 
 function normalizeLocation(location) {
@@ -323,8 +353,8 @@ function parseSourceField(source) {
  * Score a job against a set of subscriber interest keywords.
  * Returns 0–10 relevance score.
  */
-function keywordRelevanceScore(job, subscriberKeywords, subscriberCompany) {
-  if (subscriberKeywords.size === 0 && !subscriberCompany) return 0;
+function keywordRelevanceScore(job, subscriberKeywords, subscriberCompany, subscriberLocation = '') {
+  if (subscriberKeywords.size === 0 && !subscriberCompany && !subscriberLocation) return 0;
   let score = 0;
   const jobTitle = String(job.titleByLocale?.it || job.title || '').toLowerCase();
   const jobCategory = String(job.category || job.sector || '').toLowerCase();
@@ -349,6 +379,16 @@ function keywordRelevanceScore(job, subscriberKeywords, subscriberCompany) {
     if (subscriberKeywords.size > 0 && overlap > 0) {
       score += Math.min(6, Math.round((overlap / subscriberKeywords.size) * 6));
     }
+  }
+
+  // Location match: the job's town/canton matches the subscriber's saved job
+  // location/interest. Location is also used as a pre-filter, but ranking it
+  // here lets same-town jobs win over far ones when the pre-filter is skipped
+  // (too few in-location results to fill the limit).
+  if (subscriberLocation) {
+    const subLoc = subscriberLocation.toLowerCase();
+    const jobLoc = `${String(job.location || '')} ${String(job.addressLocality || '')} ${String(job.addressRegion || '')} ${String(job.canton || '')}`.toLowerCase();
+    if (jobLoc.includes(subLoc)) score += 2;
   }
 
   return score;
@@ -498,6 +538,11 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
   const slugKeywords = extractKeywords(jobSlug);
   const categoryKeywords = extractKeywords(jobCategory);
   const searchKeywords = extractKeywords(jobSearchQuery);
+  // Slug recovered retroactively by scripts/backfill-newsletter-job-context.mjs
+  // for subscribers who signed up before job context was captured (or from a
+  // job page whose source slug since expired). It carries the same job
+  // signal as job_slug, so feed it into the keyword profile too.
+  const backfillSlugKeywords = extractKeywords(subscriber?.job_context_backfill_slug || '');
   const sourceJobTitleKeywords = sourceJob?.title ? extractKeywords(sourceJob.title) : new Set();
   const sourceJobCategoryKeywords = sourceJob?.category || sourceJob?.sector
     ? extractKeywords(`${sourceJob.category || ''} ${sourceJob.sector || ''}`)
@@ -510,6 +555,7 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
     ...slugKeywords,
     ...categoryKeywords,
     ...searchKeywords,
+    ...backfillSlugKeywords,
     ...sourceJobTitleKeywords,
     ...sourceJobCategoryKeywords,
     ...sourceTitleKeywords,
@@ -549,28 +595,61 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
     if (sectorFiltered.length >= limit) candidates = sectorFiltered;
   }
 
-  // Sort: keyword relevance first, then popularity, then recency
-  const scored = candidates.map((job) => {
-    const relevance = hasInterestProfile ? keywordRelevanceScore(job, subscriberKeywords, subscriberCompany) : 0;
-    const views = hasPopularity ? getJobPopularityCount(job, popularity) : 0;
-    return { job, relevance, views, date: toDateValue(job) };
-  });
+  // Score each candidate: keyword/company/location relevance, age-decayed
+  // popularity (anti-evergreen-freeze), and recency.
+  const now = Date.now();
+  const scored = candidates.map((job) => ({
+    job,
+    relevance: hasInterestProfile
+      ? keywordRelevanceScore(job, subscriberKeywords, subscriberCompany, location)
+      : 0,
+    decayedViews: hasPopularity ? decayedPopularity(job, popularity, now) : 0,
+    date: toDateValue(job),
+  }));
 
-  scored.sort((a, b) => {
-    // Primary: relevance score (keyword + company match)
-    if (b.relevance !== a.relevance) return b.relevance - a.relevance;
-    // Secondary: popularity
-    if (b.views !== a.views) return b.views - a.views;
-    // Tertiary: recency
-    return b.date - a.date;
-  });
-
-  // Company diversity: max 1 job per company (by companyKey or normalized company name)
   const companyKey = (j) => (j.companyKey || j.company || '').toLowerCase();
-  const companyDiverse = dedupeBy(
-    scored.map((s) => s.job),
-    companyKey,
-  );
+
+  let ordered;
+  if (hasInterestProfile) {
+    // Relevance-first: keyword/company/location match, then age-decayed
+    // popularity, then recency.
+    ordered = [...scored]
+      .sort((a, b) =>
+        (b.relevance - a.relevance) ||
+        (b.decayedViews - a.decayedViews) ||
+        (b.date - a.date))
+      .map((s) => s.job);
+  } else {
+    // No interest profile (the common case): reserve the first
+    // NO_PROFILE_POPULAR_SLOTS slots for age-decayed popularity leaders, then
+    // fill the rest with the freshest listings — company-diverse, no repeats.
+    // This stops the section collapsing onto the all-time most-viewed jobs and
+    // guarantees visible week-over-week rotation.
+    const byPopular = [...scored].sort((a, b) => (b.decayedViews - a.decayedViews) || (b.date - a.date));
+    const byFresh = [...scored].sort((a, b) => (b.date - a.date) || (b.decayedViews - a.decayedViews));
+    const picked = [];
+    const usedCompanies = new Set();
+    const usedSlugs = new Set();
+    const take = (list, max) => {
+      for (const s of list) {
+        if (picked.length >= max) break;
+        const ck = companyKey(s.job);
+        if (s.job.slug && usedSlugs.has(s.job.slug)) continue;
+        if (ck && usedCompanies.has(ck)) continue;
+        picked.push(s.job);
+        if (s.job.slug) usedSlugs.add(s.job.slug);
+        if (ck) usedCompanies.add(ck);
+      }
+    };
+    take(byPopular, Math.min(NO_PROFILE_POPULAR_SLOTS, limit)); // popular leaders
+    take(byFresh, limit);                                       // fill with fresh
+    take(byPopular, limit);                                     // backfill leftovers
+    ordered = picked;
+  }
+
+  // Company diversity: max 1 job per company (defensive — the no-profile blend
+  // already dedupes by company, but the relevance-first path does not).
+  const companyDiverse = dedupeBy(ordered, companyKey);
 
   // Backfill: if location/sector filtering left too few diverse companies,
   // fill remaining slots from the full pool (excluding already-selected companies)
@@ -579,8 +658,8 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
     const usedCompanies = new Set(companyDiverse.map(companyKey));
     const backfillScored = pool
       .filter((j) => !usedCompanies.has(companyKey(j)))
-      .map((job) => ({ job, views: hasPopularity ? getJobPopularityCount(job, popularity) : 0, date: toDateValue(job) }))
-      .sort((a, b) => b.views - a.views || b.date - a.date);
+      .map((job) => ({ job, decayedViews: hasPopularity ? decayedPopularity(job, popularity, now) : 0, date: toDateValue(job) }))
+      .sort((a, b) => b.decayedViews - a.decayedViews || b.date - a.date);
     const backfill = dedupeBy(backfillScored.map((s) => s.job), companyKey);
     finalJobs = [...companyDiverse, ...backfill];
   }

--- a/tests/newsletter-template-tracking.test.ts
+++ b/tests/newsletter-template-tracking.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 const { buildNewsletter, FEATURED_TOOLS, directUrl } = await import('@/services/newsletter-template.mjs');
-const { matchJobsForSubscriber, validateJobUrls, getFallbackBriefing, FALLBACK_SUBJECT } = await import('@/services/newsletter-content.mjs');
+const { matchJobsForSubscriber, validateJobUrls, getFallbackBriefing, FALLBACK_SUBJECT, decayFactor } = await import('@/services/newsletter-content.mjs');
 
 const SAMPLE_EXCHANGE = { rate: 1.0942, previousRate: 1.0885 };
 const SAMPLE_FACT = { text: 'Oltre 78.000 frontalieri lavorano nel Canton Ticino.', source: 'USTAT' };
@@ -252,6 +252,65 @@ describe('validateJobUrls resilience', () => {
     const result = validateJobUrls(mixed, ALL_JOBS);
     expect(result).toHaveLength(2);
     expect(result.find((j) => j.title === 'Ghost')).toBeUndefined();
+  });
+});
+
+describe('popularity decay (anti-evergreen-freeze)', () => {
+  const NOW = new Date('2026-06-22T00:00:00.000Z').getTime();
+  const daysAgoIso = (n: number) => new Date(NOW - n * 86400000).toISOString();
+
+  it('halves the popularity weight every 30 days of job age', () => {
+    expect(decayFactor({ postedDate: daysAgoIso(0) }, NOW)).toBeCloseTo(1, 5);
+    expect(decayFactor({ postedDate: daysAgoIso(30) }, NOW)).toBeCloseTo(0.5, 5);
+    expect(decayFactor({ postedDate: daysAgoIso(60) }, NOW)).toBeCloseTo(0.25, 5);
+    expect(decayFactor({ postedDate: daysAgoIso(90) }, NOW)).toBeCloseTo(0.125, 5);
+  });
+
+  it('applies a neutral mid-life factor to jobs with no parseable date', () => {
+    expect(decayFactor({}, NOW)).toBe(0.5);
+    expect(decayFactor({ postedDate: 'not-a-date' }, NOW)).toBe(0.5);
+  });
+
+  it('never exceeds 1 for future-dated jobs (clamped age)', () => {
+    expect(decayFactor({ postedDate: daysAgoIso(-10) }, NOW)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('no-profile job blend + backfill-slug relevance', () => {
+  // No interest profile: the newest jobs must be represented, not just the
+  // all-time popular ones — this is what makes the section rotate.
+  it('represents the freshest jobs for a no-profile subscriber', () => {
+    const jobs = Array.from({ length: 8 }, (_, i) => ({
+      title: `Job ${i}`,
+      company: `Co ${i}`,
+      location: 'Lugano',
+      slug: `job-${i}-co-${i}`,
+      postedDate: new Date(Date.now() - i * 86400000).toISOString(),
+    }));
+    const matched = matchJobsForSubscriber({ locationInterest: null, sectorInterest: null }, jobs, 4);
+    // job-0 is the newest; with all views=0 the blend orders by recency, so the
+    // newest listing must appear.
+    expect(matched.map((j) => j.slug)).toContain('job-0-co-0');
+    expect(matched).toHaveLength(4);
+    // Company diversity preserved.
+    const companies = matched.map((j) => j.company);
+    expect(new Set(companies).size).toBe(companies.length);
+  });
+
+  // A subscriber whose ONLY job signal is the retroactively-recovered
+  // job_context_backfill_slug must still get a relevance-ranked match.
+  it('ranks a matching job first using job_context_backfill_slug', () => {
+    const jobs = [
+      { title: 'Sviluppatore software backend', company: 'TechCo', location: 'Lugano', slug: 'sviluppatore-software-techco', category: 'IT', sector: 'IT' },
+      { title: 'Infermiere reparto medicina', company: 'Clinica', location: 'Lugano', slug: 'infermiere-medicina-clinica', category: 'Sanita', sector: 'Sanita' },
+    ];
+    const matched = matchJobsForSubscriber(
+      { locationInterest: null, sectorInterest: null, job_context_backfill_slug: 'infermiere-pediatria-ospedale-lugano' },
+      jobs,
+      2,
+    );
+    // The nurse job shares keywords with the backfill slug → ranks first.
+    expect(matched[0].slug).toBe('infermiere-medicina-clinica');
   });
 });
 


### PR DESCRIPTION
## Implementato

Risolve la causa per cui la sezione "annunci" della newsletter settimanale mandava sempre gli stessi job: per gli iscritti **senza profilo d'interesse** (la maggioranza) la selezione collassava sui job più visti di sempre, e `data/job-popularity.json` è cumulativo all-time **senza decay** → il top restava congelato. La rotation (finestra 100 slug) ritardava un evergreen solo ~3-4 settimane prima che tornasse.

- **Decay popolarità (half-life 30gg)** a read-time in `services/newsletter-content.mjs` (`decayFactor`/`decayedPopularity`): un job di 30gg pesa metà, 60gg un quarto. Gli evergreen stravisti smettono di occupare la top fissa. Sostituisce il sort per `views` grezze con `decayedViews` sia nel path relevance-first sia nel backfill.
- **Boost recency per no-profile**: per chi non ha profilo, i 4 slot = **2 leader popolarità-decaduta + 2 più freschi** (company-diverse, no duplicati slug/azienda) → rotazione visibile garantita ogni settimana.
- **Relevance estesa**: `job_context_backfill_slug` (recuperato da `backfill-newsletter-job-context.mjs`) ora alimenta il profilo keyword; `keywordRelevanceScore` aggiunge un bonus +2 per match di location; `enrichSubscriberJobContext` (`scripts/send-newsletter.mjs`) risolve il source job anche via backfill slug; il projection subscriber espone `job_context_backfill_slug`.
- **`toDateValue`** considera anche `publishedAt`/`firstSeenAt` → la recency funziona per più job.
- **Test**: +5 casi in `tests/newsletter-template-tracking.test.ts` (curva decay 30gg, factor neutro per job senza data, clamp future-dated, rappresentazione dei job freschi per no-profile, ranking via backfill-slug). Suite newsletter completa verde (106 test).

GitNexus impact su `matchJobsForSubscriber`: **LOW** (3 caller diretti — send/qa/preview —, firma invariata).

## Non implementato (ancora)

- **Decay rolling-window vero (per-view timestamp)**: il decay è age-based a read-time (proxy sull'età del job), non un conteggio view a finestra temporale — `job_views` non memorizza timestamp per-evento, solo il cumulativo. Out of scope: richiederebbe modificare lo schema `trackJobView` + `fetch-job-popularity.mjs`. Follow-up possibile.
- **Sibling `services/jobAlertMatching.mjs`**: verificato — NON ha l'antipattern. Gli alert sono sempre personalizzati (score da keyword/location/sector dell'alert, nessun sort per views cumulative), quindi il freeze da popolarità non si applica. Nessun fix necessario.
- **Sibling `services/publisherBlastMatch.mjs`**: direzione inversa (score di subscriber contro un annuncio), nessun job-popularity sort. Non pertinente.
- **Bug separato job-alert location-filter**: nell'email job-alert d'esempio comparivano Roche·Basel / EPFL·Lausanne per un alert filtrato "Lugano, Mendrisio, Bellinzona" → il filtro località dell'alert non filtra. È un sistema diverso (`jobAlertMatching` + CF), fuori scope di questa PR sulla newsletter. Da affrontare in follow-up dedicato.
- **Verifica live**: l'effetto reale sulla rotazione è osservabile solo sull'invio settimanale schedulato (no full send locale). Da validare al prossimo invio.
