### PR TITLE
fix(adsense-prereview): build:ci + 90 min timeout so the full SSG audit build can finish

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -48,13 +48,44 @@ jobs:
       - name: Assemble jobs dataset from per-crawler slices
         run: node scripts/assemble-jobs-dataset.mjs --stats
 
-      - name: Build
-        # Use build:ci (12 GB heap, fits the 16 GB runner) — the same full-SSG
-        # build the deploy pipeline runs. build:prod's 18 GB heap exceeds the
-        # runner's physical RAM and was OOM-prone; it only ever "passed" here by
-        # crashing earlier at config-load. Full SSG (no FAST_BUILD skips) so the
-        # AdSense audit still inspects every production page type.
-        run: npm run build:ci
+      # ── Pre-build data prep — MUST mirror deploy.yml's build job ──────────
+      # The audit reads `dist/`, so this workflow must emit the SAME dist
+      # deploy.yml ships. deploy dedups + migrates + cleans the dataset BEFORE
+      # build:ci; building the RAW assembled set (~12.1k jobs × 4 locales)
+      # OOMs the 16 GB runner (exit 134) before the audit runs (issue #2121).
+      # The shared composite action keeps this in lockstep with deploy.yml and
+      # cathedral-seo-gates-check.yml (the read-only sibling that audits the
+      # same dist). None of its steps require secrets.
+      - name: SEO build data-prep (shared with deploy.yml)
+        uses: ./.github/actions/seo-build-data-prep
+
+      - name: Build dist (full SEO output)
+        # Mirror cathedral-seo-gates-check.yml: same full-SSG build the deploy
+        # pipeline runs, so the AdSense audit inspects production-identical
+        # pages. build:ci sets its own inline `--max-old-space-size=12288
+        # --expose-gc` (fits the 16 GB runner); build:prod's 18 GB exceeds
+        # physical RAM. The two env knobs are deploy.yml's documented OOM
+        # controls (build OOM #1290) — they cap the dominant memory term so the
+        # full SEO build fits at 12 GB alongside the data-prep reduction above.
+        env:
+          # Override any inherited FAST_BUILD=1, which would silently skip half
+          # the SEO landings and shrink audit coverage (CLAUDE.md FAST_BUILD trap).
+          FAST_BUILD: ''
+          # Cap the post-walk worker pool so it doesn't structured-clone the full
+          # path list into cpus()-many workers at once (the #1290 blowup).
+          POST_WALK_WORKERS: '2'
+          # Force sequential plugin closeBundle: peak heap = max(single plugin)
+          # instead of Σ(overlap). Always sequential here (scheduled/dispatch).
+          SEQUENTIAL_PROFILE: '1'
+        run: |
+          set -euo pipefail
+          npm run build:ci &
+          build_pid=$!
+          while kill -0 "$build_pid" 2>/dev/null; do
+            sleep 60
+            echo "[build keepalive] still running at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          done
+          wait "$build_pid"
 
       - name: Run AdSense pre-review audit
         run: |

--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -27,7 +27,10 @@ permissions:
 jobs:
   adsense-prereview:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Full SSG build (~43 min) + npm ci + dataset assemble + 140-page audit.
+    # The old 45 min ceiling cancelled the build mid-SSG once it stopped failing
+    # fast at config-load (see Build step note). 90 min leaves comfortable slack.
+    timeout-minutes: 90
 
     steps:
       - name: Checkout
@@ -46,7 +49,12 @@ jobs:
         run: node scripts/assemble-jobs-dataset.mjs --stats
 
       - name: Build
-        run: npm run build:prod
+        # Use build:ci (12 GB heap, fits the 16 GB runner) — the same full-SSG
+        # build the deploy pipeline runs. build:prod's 18 GB heap exceeds the
+        # runner's physical RAM and was OOM-prone; it only ever "passed" here by
+        # crashing earlier at config-load. Full SSG (no FAST_BUILD skips) so the
+        # AdSense audit still inspects every production page type.
+        run: npm run build:ci
 
       - name: Run AdSense pre-review audit
         run: |


### PR DESCRIPTION
## Implementato

Secondo (e ultimo) tassello per chiudere **definitivamente** la issue del workflow *AdSense Pre-Review Checklist* (#2532, run 27900957370).

Con il crash al config-load 512 MB risolto (#2588 `jobs.json`, #2596 `slug-registry.json`), il **Build step gira finalmente il full SSG vero** invece di morire in ~2 min — esponendo due problemi latenti che il crash veloce mascherava: timeout troppo stretto e build OOM-prone sul dataset raw.

Fix — allineo il workflow al sibling read-only `cathedral-seo-gates-check.yml` (che già builda + audita lo **stesso `dist/`**) e al build job di `deploy.yml`:

- **Build `build:prod` → `build:ci`** (heap inline 12 GB `--expose-gc`, sta nei 16 GB del runner; build:prod = 18 GB > RAM fisica, OOM-prone, "passava" solo crashando prima al config-load).
- **Aggiunta `- uses: ./.github/actions/seo-build-data-prep`** dopo l'assemble: dedup + migrate + clean del dataset (≈12.1k → ≈11.2k job × 4 locali) — senza, il set raw OOMma il runner a 12 GB (exit 134, issue #2121).
- **Env sul Build step**: `FAST_BUILD=''` (copertura SEO piena, no skip landing → audit fedele), `POST_WALK_WORKERS='2'` + `SEQUENTIAL_PROFILE='1'` (controlli OOM documentati di deploy.yml, #1290, che cappano il termine di memoria dominante) + keepalive loop come il sibling.
- **`timeout-minutes: 45 → 90`** (come cathedral): slack su `npm ci` + assemble + data-prep + build full SSG (~43 min) + audit 140 pagine + upload.

Risultato: l'audit builda un `dist/` production-identical, deploy-fidelity, entro i 90 min, senza OOM/timeout.

Closes #2532

## Non implementato (ancora)

- **`generate-article.yml`** (unico altro file che cita `build:prod`): è solo un **commento** (`# Do not run npm run build:prod here…`) — non lo esegue, dispatcha `deploy.yml`, timeout già 360. Non è la stessa classe.
- **Redesign audit-su-dist-deployato** (riusare il dist dell'ultimo deploy via `audit-dist-from-run.yml` invece di rebuildare ogni giorno): più efficiente ma re-architecting del workflow, fuori scope. Possibile follow-up per ridurre il costo runner giornaliero.
- **Claim memoria/wall-time non validabile pre-merge** (OOM/timeout girano solo su runner reale): revert-trigger esplicito — se il prossimo run schedulato/dispatch OOMa (exit 134/143) o sfora i 90 min → rivalutare (matrix per-locale o audit-replay). La configurazione qui è però byte-allineata a un build che già passa quotidianamente (cathedral + deploy), quindi il rischio è basso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)