### PR TITLE
feat(outreach): opt-out footer + List-Unsubscribe on cold emails

### DIFF
--- a/scripts/generate-cold-emails.mjs
+++ b/scripts/generate-cold-emails.mjs
@@ -46,6 +46,8 @@ function arg(name, def) {
 }
 
 const PRICE = 'CHF 49 al mese per annuncio';
+// Indirizzo opt-out: chi risponde qui (o "STOP") va messo `suppressed` nel send-log.
+export const OPTOUT_EMAIL = 'valerie@frontaliereticino.ch';
 
 /**
  * Le 4 email della sequenza. Personalizzazione Livello 4 (skill cold-email):
@@ -61,7 +63,10 @@ export function buildSequence({ company, candidates, periodLabel, contactName, t
   const role = (topRole || '').replace(/\s+/g, ' ').trim();
   const GENERIC_ROLE = /lavora con noi|lavorare con noi|concors|careers?|^jobs?$|offerte di lavoro|posizioni aperte|unsolicited|spontane/i;
   const pagina = role && !GENERIC_ROLE.test(role) ? `pagina di "${role.slice(0, 48)}"` : 'pagina lavoro';
-  return [
+  // Opt-out obbligatorio su ogni touch (norma cold-email B2B + deliverability).
+  // Footer leggibile dall'umano; l'header List-Unsubscribe lo aggiunge il sender.
+  const footer = `\n\n—\nSe non volete più ricevere queste email, rispondete con "STOP" (o scrivete a ${OPTOUT_EMAIL}) e vi rimuoviamo subito.`;
+  const seq = [
     {
       touch: 1, gapDays: 0, subject: 'candidati inviati',
       body: `${hi}
@@ -105,6 +110,8 @@ Se più avanti volete amplificarlo, sapete dove trovarmi.
 Valerie`,
     },
   ];
+  // Append the opt-out footer to every touch so drafts and real sends match.
+  return seq.map((m) => ({ ...m, body: m.body + footer }));
 }
 
 function loadJson(p, def) {

--- a/scripts/send-cold-emails.mjs
+++ b/scripts/send-cold-emails.mjs
@@ -37,7 +37,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildSequence } from './generate-cold-emails.mjs';
+import { buildSequence, OPTOUT_EMAIL } from './generate-cold-emails.mjs';
 import { classifySector } from './lib/employer-sectors.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -206,6 +206,10 @@ function run() {
       if (!to) { console.warn(`↷ skip ${m.company}: nessuna email verificata (inferita "${m.inferred}" non usata)`); continue; }
     }
     const subjectPrefix = isTest ? `[TEST → ${m.company}] ` : '';
+    // List-Unsubscribe (RFC 2369): abilita il pulsante "Annulla iscrizione" nativo
+    // di Gmail/Outlook. Solo mailto (niente One-Click: nessun endpoint HTTPS); il
+    // subject porta la company key così l'opt-out è tracciabile alla sorgente.
+    const unsubKey = encodeURIComponent(m.key || m.company);
     queue.push({
       payload: {
         from,
@@ -213,6 +217,7 @@ function run() {
         subject: subjectPrefix + m.subject,
         html: m.html,
         text: m.text,
+        headers: { 'List-Unsubscribe': `<mailto:${OPTOUT_EMAIL}?subject=unsubscribe%20${unsubKey}>` },
         tags: [{ name: 'type', value: 'cold-outreach' }, { name: 'company', value: (m.key || m.company).slice(0, 40) }],
       },
       recipient: { email: to },

--- a/tests/cold-email-optout.test.ts
+++ b/tests/cold-email-optout.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { buildSequence, OPTOUT_EMAIL } from '../scripts/generate-cold-emails.mjs';
+
+// Compliance guard: cold B2B outreach MUST carry an opt-out on every touch
+// (Swiss nDSG/GDPR norm + deliverability). Regressing this risks the sending
+// domain's reputation, so it's a hard invariant — not a stylistic nit.
+describe('cold-email opt-out invariant', () => {
+  const seq = buildSequence({
+    company: 'Casale SA',
+    candidates: 88,
+    periodLabel: 'negli ultimi 3 mesi',
+    contactName: 'Denise Rossi',
+    topRole: 'Magazziniere',
+  });
+
+  it('builds the full 4-touch sequence', () => {
+    expect(seq.map((m: any) => m.touch)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('every touch includes a working opt-out footer', () => {
+    expect(OPTOUT_EMAIL).toMatch(/@frontaliereticino\.ch$/);
+    for (const m of seq) {
+      expect(m.body, `touch ${m.touch} opt-out instruction`).toMatch(/rispondete con "STOP"/);
+      expect(m.body, `touch ${m.touch} opt-out address`).toContain(OPTOUT_EMAIL);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato
- **Footer opt-out su ogni touch** in `buildSequence` (`scripts/generate-cold-emails.mjs`): riga IT "rispondete con STOP o scrivete a <opt-out>". Applicato via `.map()` su tutte e 4 le touch → identico in bozze (`generate-cold-emails`) e invii reali (`send-cold-emails`).
- **Header `List-Unsubscribe` (mailto)** sul payload di invio (`scripts/send-cold-emails.mjs`): abilita il pulsante "Annulla iscrizione" nativo di Gmail/Outlook. Subject `unsubscribe <companyKey>` → opt-out tracciabile alla sorgente. Solo mailto (niente One-Click: nessun endpoint HTTPS ancora).
- **Costante esportata `OPTOUT_EMAIL`** condivisa tra generatore e sender (no drift).
- **Test compliance** `tests/cold-email-optout.test.ts`: invariante "ogni touch ha l'opt-out" — è un requisito legale/deliverability, non un nit.
- La cascade già inoltra `email.headers` su tutti i provider (Mailgun/Resend/Unosend/Cloudflare) → nessuna modifica lato cascade.

## Non implementato (ancora)
- **List-Unsubscribe One-Click (HTTPS POST)**: richiede un endpoint `/opt-out` che scriva la suppression. Follow-up — per ora il mailto è valido e onorato dai mail client.
- **Suppression automatica da reply "STOP"**: l'operatore mette `suppressed:true` nel send-log a mano (il sender già onora la suppression pre-invio). Auto-detect reply = follow-up (richiede inbox monitor).
- **Dominio outreach isolato (P0-2)**: spostare l'invio su `outreach.frontaliereticino.ch` con SPF/DKIM proprio + DMARC `p=none` è DNS Cloudflare, fuori da questa PR di codice. Resta blocker per il primo invio reale insieme alla verifica della mailbox.