### PR TITLE
feat(security): add RFC 9116 security.txt (CF Security Center)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,9 @@
+# security.txt for frontaliereticino.ch — RFC 9116
+# https://www.rfc-editor.org/rfc/rfc9116
+# Report a security issue via the contact channels below.
+
+Contact: https://frontaliereticino.ch/contattaci/
+Contact: mailto:info@frontaliereticino.ch
+Expires: 2027-06-01T00:00:00.000Z
+Preferred-Languages: it, en, de, fr
+Canonical: https://frontaliereticino.ch/.well-known/security.txt


### PR DESCRIPTION
## Implementato

- Aggiunto `public/.well-known/security.txt` (RFC 9116) servito a `https://frontaliereticino.ch/.well-known/security.txt` tramite il path di deploy `public/.well-known/` già usato da `llms.txt`/`ai-plugin.json` (verificato live: `llms.txt` → 200).
- Campi: `Contact` (URL pagina `/contattaci/` + `mailto:info@frontaliereticino.ch`, role-based, no PII personale), `Expires` (2027-06-01, < 1 anno), `Preferred-Languages: it, en, de, fr`, `Canonical`.
- Risolve l'insight Cloudflare Security Center `security_txt_not_enabled` per la zona `frontaliereticino.ch` (CF lo cancella al prossimo re-scan dopo il deploy).

## Non implementato (ancora)

Gli altri 24 insight del Security Center NON sono fixabili via codice e NON vanno "risolti" cambiando config (li romperebbe). Analisi e motivo per categoria:

- **`a_record_dangling` ×4 + `aaaa_record_dangling` ×4 (apex)** — FALSO POSITIVO: gli A/AAAA apex puntano agli IP GitHub Pages `185.199.108-111.153` / `2606:50c0:800x::153` (proxied=true), origin live del sito. L'euristica CF flagga l'ASN Fastly come potenziale takeover. Cancellarli = sito giù. → da **dismissare in dashboard** (accepted), non azionabile via API.
- **`cname_record_not_proxied` ×3 (`a.`/`auth.`/`email.`)** — INTENZIONALE: `a.`→Resend, `auth.`→Firebase Auth, `email.`→Mailgun. Devono restare DNS-only (grey); proxarli rompe email tracking, auth e SSL provider. → dismiss accepted.
- **`hsts_not_enabled` ×4 + `tls_not_enabled` ×4 (`email`, `origin-de/en/fr`)** — INERENTE: record grey-cloud (DNS-only); CF non può imporre TLS/HSTS su traffico che non transita dal proxy. → dismiss accepted.
- **`manage_bot_fight_mode`, `no_block_ai_bots`, `no_challenge_ai_bots` (AI Labyrinth)** — SCELTA STRATEGICA, non abilitare: Bot Fight Mode può sfidare Googlebot/AdSense (rischio ~95% revenue); gli AI bot sono deliberatamente allowlistati per visibilità SEO/AI-search. → richiede decisione esplicita owner (accept-risk), non auto-enable.
- **`skip_above_threshold`** — >30% delle security rule usano azione "skip"; va rivista manualmente in dashboard (regole WAF skip presumibilmente deliberate).
- **`no_challenge_ai_bots` su zona `16808133...`** — ORFANO: zona cancellata ("Invalid zone identifier"); l'insight si auto-pulisce, non azionabile.

Nota operativa: il token CF disponibile è read-only su Security Center (`code 10405: Method not allowed for this authentication scheme`) → i dismiss vanno fatti dall'owner in dashboard o con un token con scope Security Center write.
