### PR TITLE
fix(post-deploy-publish): stage master jobs.json so Google Indexing API job submit runs

### DIFF
--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -97,6 +97,22 @@ jobs:
           name: sitemaps-${{ inputs.deploy_run_id }}
           path: /tmp/sitemaps-bundle
 
+      # Master jobs.json (titleByLocale/slugByLocale) is GITIGNORED and
+      # stripped from the Pages artifact (jobsJsonDistCleanupPlugin, PR #712),
+      # so it is NOT present in this checkout. The Google Indexing API job
+      # submitter (submit-google-indexing-jobs.js) reads public/data/jobs.json
+      # to build per-job board URLs — without this it logs "Unable to read
+      # jobs.json" and silently skips submission on every deploy. Restore it
+      # from the same dedicated artifact post-deploy-validate-dist uses.
+      # continue-on-error: profile_sequential builds don't upload it, and the
+      # submitter already exits 0 gracefully when jobs.json is absent.
+      - name: Download master jobs.json (for indexing API)
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: jobs-master-${{ inputs.deploy_run_id }}
+          path: /tmp/jobs-master
+
       - name: Stage downloaded data files
         run: |
           if [ -f /tmp/sitemaps-bundle/pre-deploy-sitemap-urls.json ]; then
@@ -106,6 +122,15 @@ jobs:
           fi
           if [ -f /tmp/winners/previous-slug-winners.json ]; then
             cp /tmp/winners/previous-slug-winners.json data/previous-slug-winners.json
+          fi
+          # Expose master jobs.json to the indexing API submitter, which
+          # reads public/data/jobs.json (same staging as post-deploy-validate-dist).
+          if [ -f /tmp/jobs-master/jobs.json ]; then
+            mkdir -p public/data
+            cp -f /tmp/jobs-master/jobs.json public/data/jobs.json
+            echo "[jobs-master] staged public/data/jobs.json ($(wc -c < public/data/jobs.json) bytes)"
+          else
+            echo "[jobs-master] artifact not present — indexing API job submit will skip"
           fi
 
       - name: Sync previous-slug winners registry


### PR DESCRIPTION
## Implementato

- `post-deploy-publish.yml`: nuovo step `Download master jobs.json (for indexing API)` che scarica l'artifact `jobs-master-${{ inputs.deploy_run_id }}` (`continue-on-error: true`) in `/tmp/jobs-master`.
- Esteso lo step esistente `Stage downloaded data files`: copia `/tmp/jobs-master/jobs.json` → `public/data/jobs.json` (con `mkdir -p public/data` + log di byte/skip).

### Root cause

`scripts/submit-google-indexing-jobs.js` legge `public/data/jobs.json` per costruire le URL board per-job da inviare alla Google Indexing API. Quel file è **gitignored** (assemblato in build) e **rimosso dal Pages artifact** (`jobsJsonDistCleanupPlugin`, PR #712) → assente nel checkout di `post-deploy-publish`. Lo script logga `⚠️ Unable to read jobs.json — ENOENT ...` e fa `process.exit(0)`: la submission alla Indexing API per i job **veniva silenziosamente saltata a ogni deploy** (l'errore nel run #27929801749 è esattamente questo).

Fix = stessa staging già usata da `post-deploy-validate-dist.yml` (scarica `jobs-master-<run_id>` → `cp … public/data/jobs.json`). Sibling-class: `submit-google-indexing-jobs.js` è invocato SOLO da `post-deploy-publish`; l'unico sibling workflow che usa `jobs.json` (`post-deploy-validate-dist`) già la stagia. Gli altri script dello step indexing (`submit-indexnow.js`, `submit-google-indexing.js`) leggono i sitemap committati, non `jobs.json` → non impattati.

## Non implementato (ancora)

- Nessun cambio allo script `submit-google-indexing-jobs.js`: il suo path di fallback (`process.exit(0)` su jobs.json mancante) è corretto e va lasciato — i build `profile_sequential` non caricano l'artifact `jobs-master` e devono restare verdi senza submission.
- Verifica live dell'effettiva submission alla Indexing API: non validabile pre-merge (gira solo post-deploy su `main`); revert-trigger: se al prossimo deploy lo step `Post-deploy indexing` continua a loggare `Unable to read jobs.json`, la causa è altra (artifact non caricato) → investigare l'upload in `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)