### PR TITLE
fix(alerts+newsletter): hard location filter on job alerts + parseable-date decay

### DIFF
--- a/services/jobAlertMatching.mjs
+++ b/services/jobAlertMatching.mjs
@@ -36,8 +36,11 @@ import { extractKeywords } from './newsletter-content.mjs';
  * @property {TokenSet}  hardKeywords  Explicit user keywords (hard filter when non-empty).
  * @property {TokenSet}  softTokens    Intent tokens from source job + newsletter profile.
  * @property {string}    company       Normalized company affinity token ('' when none).
- * @property {string[]}  locations     Lowercased location signals.
- * @property {string[]}  cantons       Lowercased canton codes (cantonFilter).
+ * @property {string[]}  locations     Lowercased location signals (soft — ranking only).
+ * @property {string[]}  alertLocations Lowercased locations the user explicitly set ON THE ALERT.
+ *                                       HARD filter when non-empty: a job outside these (and the
+ *                                       cantons) is dropped even if keywords match.
+ * @property {string[]}  cantons       Lowercased canton codes (cantonFilter) — HARD geo filter too.
  * @property {string[]}  sectors       Lowercased sector / category signals.
  * @property {string[]}  contractTypes Lowercased contract-type signals.
  * @property {string[]}  specificJobIds    Exact job ids this alert is pinned to (hard scope).
@@ -113,9 +116,15 @@ export function buildAlertProfile(alert, subscriber = null) {
   // 3. Company affinity — same employer the user already engaged with.
   const company = normalizeCompanyToken(sub.job_company);
 
-  // 4. Location signals — alert filters + newsletter geo/interest + pref cities.
+  // 4. Location signals.
+  //    `alertLocations` = the locations the user explicitly picked ON THE ALERT
+  //    → HARD geo filter (see scoreJobForAlert). `locations` = that set PLUS
+  //    soft profile-derived signals (newsletter geo/interest + pref cities),
+  //    used only for the +2 ranking boost so a profile city never silently
+  //    constrains an alert the user scoped differently.
+  const alertLocations = uniq((a.locations || []).map((l) => String(l || '').toLowerCase()));
   const locations = uniq([
-    ...(a.locations || []).map((l) => String(l || '').toLowerCase()),
+    ...alertLocations,
     String(sub.location_interest || '').toLowerCase(),
     String(sub.job_location || '').toLowerCase(),
     String(sub.geo_city || '').toLowerCase(),
@@ -143,7 +152,7 @@ export function buildAlertProfile(alert, subscriber = null) {
   const specificCompanyKey = normalizeCompanyToken(a.specificCompanyKey);
 
   return {
-    hardKeywords, softTokens, company, locations, cantons, sectors, contractTypes,
+    hardKeywords, softTokens, company, locations, alertLocations, cantons, sectors, contractTypes,
     specificJobIds, specificCompanyKey,
   };
 }
@@ -213,6 +222,22 @@ export function scoreJobForAlert(job, profile) {
 
   // Location.
   const jobLoc = `${job.location || ''} ${job.addressLocality || ''} ${job.addressRegion || ''} ${job.canton || ''}`.toLowerCase();
+
+  // HARD geo filter: when the user scoped the alert to explicit locations and/or
+  // cantons, a job OUTSIDE that geography is dropped — even when keywords or
+  // company/sector match. Without this the location was only a +2 ranking nudge,
+  // so a "Lugano, Mendrisio, Bellinzona" alert still surfaced Basel/Lausanne jobs
+  // whose title matched the keyword. Only the alert's OWN locations/cantons are
+  // hard; soft profile-derived locations (geo_city, pref cities) still only rank.
+  const hasGeoScope = profile.alertLocations.length > 0 || profile.cantons.length > 0;
+  if (hasGeoScope) {
+    const jobCanton = String(job.canton || '').toLowerCase();
+    const geoHit =
+      profile.alertLocations.some((l) => l && jobLoc.includes(l)) ||
+      (profile.cantons.length > 0 && jobCanton && profile.cantons.includes(jobCanton));
+    if (!geoHit) return 0;
+  }
+
   const locationMatch = profile.locations.some((l) => jobLoc.includes(l));
   if (locationMatch) score += 2;
   const cantonMatch = profile.cantons.length > 0 && profile.cantons.includes(String(job.canton || '').toLowerCase());

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -88,9 +88,16 @@ function resolveLogoUrl(job) {
 // ─── Job matching ───────────────────────────────────────────
 
 function toDateValue(job) {
-  const raw = job?.postedDate || job?.crawledAt || job?.publishedAt || job?.firstSeenAt || '';
-  const ts = raw ? new Date(raw).getTime() : 0;
-  return Number.isFinite(ts) ? ts : 0;
+  // Pick the first field that PARSES, not the first truthy one: ~0.3% of jobs
+  // carry a malformed postedDate (e.g. "30/05/26", DD/MM/YY → Invalid Date)
+  // that would otherwise shadow a perfectly good firstSeenAt and force the job
+  // into decayFactor's neutral UNDATED branch (date present ≠ date usable).
+  for (const raw of [job?.postedDate, job?.crawledAt, job?.publishedAt, job?.firstSeenAt]) {
+    if (!raw) continue;
+    const ts = new Date(raw).getTime();
+    if (Number.isFinite(ts)) return ts;
+  }
+  return 0;
 }
 
 // ─── Popularity decay (anti-evergreen-freeze) ───────────────

--- a/tests/job-alert-matching.test.ts
+++ b/tests/job-alert-matching.test.ts
@@ -119,6 +119,47 @@ describe('jobAlertMatching — pure location/sector alerts (legacy contract)', (
   });
 });
 
+describe('jobAlertMatching — explicit location/canton is a HARD filter', () => {
+  // Regression: a "Lugano, Mendrisio, Bellinzona" alert surfaced Roche·Basel /
+  // EPFL·Lausanne because location was only a +2 ranking nudge while the keyword
+  // was the sole hard filter. With explicit alert locations, out-of-area jobs
+  // must be dropped even when the keyword matches.
+  it('drops a keyword-matching job OUTSIDE the alert locations', () => {
+    const baselJob = job({
+      title: 'Senior Scientist Neuroscience',
+      description: 'Computational biology, neuroscience and rare diseases.',
+      company: 'Roche', companyKey: 'roche',
+      location: 'Basel', addressLocality: 'Basel', addressRegion: 'BS', canton: 'BS',
+    });
+    expect(score(baselJob, { keywords: ['neuroscience'], locations: ['Lugano', 'Mendrisio', 'Bellinzona'] })).toBe(0);
+  });
+
+  it('keeps a keyword-matching job INSIDE the alert locations', () => {
+    const luganoJob = job({
+      title: 'Neuroscience Research Engineer',
+      location: 'Lugano', addressLocality: 'Lugano', addressRegion: 'TI', canton: 'TI',
+    });
+    expect(score(luganoJob, { keywords: ['neuroscience'], locations: ['Lugano', 'Mendrisio', 'Bellinzona'] })).toBeGreaterThan(0);
+  });
+
+  it('cantonFilter is a hard geo filter too: out-of-canton keyword job → 0', () => {
+    const geneva = job({ location: 'Geneva', addressLocality: 'Geneva', addressRegion: 'GE', canton: 'GE' });
+    expect(score(geneva, { keywords: ['engineer'], cantonFilter: ['TI'] })).toBe(0);
+  });
+
+  it('a matching canton satisfies the geo filter when alert locations are empty', () => {
+    expect(score(job(), { keywords: ['engineer'], cantonFilter: ['TI'] })).toBeGreaterThan(0);
+  });
+
+  it('soft profile location (pref city) does NOT hard-filter — only the alert\'s own locations do', () => {
+    // Alert has no explicit locations; subscriber pref city is Lugano. A
+    // keyword-matching job elsewhere must still surface (pref city only ranks).
+    const sub = { preferences: { lugano: true } };
+    const zurichJob = job({ location: 'Zurich', addressLocality: 'Zurich', addressRegion: 'ZH', canton: 'ZH' });
+    expect(score(zurichJob, { keywords: ['engineer'] }, sub)).toBeGreaterThan(0);
+  });
+});
+
 describe('jobAlertMatching — job-specific scope (per-job / per-employer alert)', () => {
   it('specificJobId: surfaces ONLY the pinned job', () => {
     const target = job({ id: 'pub-canary-owner-demo-lugano' });

--- a/tests/newsletter-template-tracking.test.ts
+++ b/tests/newsletter-template-tracking.test.ts
@@ -274,6 +274,14 @@ describe('popularity decay (anti-evergreen-freeze)', () => {
   it('never exceeds 1 for future-dated jobs (clamped age)', () => {
     expect(decayFactor({ postedDate: daysAgoIso(-10) }, NOW)).toBeLessThanOrEqual(1);
   });
+
+  it('falls through a malformed postedDate to a valid firstSeenAt (date present ≠ usable)', () => {
+    // ~0.3% of real jobs carry a DD/MM/YY postedDate that `new Date()` rejects.
+    // It must not shadow a good firstSeenAt and force the neutral 0.5 branch.
+    const job = { postedDate: '30/05/26', firstSeenAt: daysAgoIso(0) };
+    expect(decayFactor(job, NOW)).toBeCloseTo(1, 5);
+    expect(decayFactor({ postedDate: '30/05/26', firstSeenAt: daysAgoIso(30) }, NOW)).toBeCloseTo(0.5, 5);
+  });
 });
 
 describe('no-profile job blend + backfill-slug relevance', () => {


### PR DESCRIPTION
## Implementato

Due follow-up emersi durante la diagnosi della sezione job della newsletter (PR #2614).

### 1. Job alert: filtro località ora HARD (`services/jobAlertMatching.mjs`)
`scoreJobForAlert` trattava la location come segnale **soft (+2 al ranking)** mentre l'unico filtro hard era il keyword digitato → un alert `keywords:["Neuroscienze"]` + `locations:["Lugano","Mendrisio","Bellinzona"]` faceva comunque comparire Roche·Basel / EPFL·Lausanne (titolo matchava il keyword, la location non filtrava — bug osservato nell'email job-alert).
- Le **location/cantoni espliciti dell'alert** (`a.locations` / `a.cantonFilter`) diventano un **filtro geografico HARD**: un job fuori da quella geografia è droppato anche se i keyword matchano (`hasGeoScope` → `geoHit` → `return 0`).
- I segnali location **profile-derived** (`geo_city`, pref cities, `location_interest`) restano **soft (solo ranking)** → un alert senza location esplicite non viene silenziosamente vincolato da una città del profilo. Nuovo campo `alertLocations` nel profilo separa hard da soft.
- Centralizzato: `scripts/send-job-alerts.mjs` è il solo consumer e usa `scoreJobForAlert` come gate (nessun filtro location duplicato da toccare).

### 2. Decay newsletter: risoluzione data robusta (`services/newsletter-content.mjs`)
`toDateValue` prendeva il primo campo **truthy**, non il primo **parsabile** → ~0.3% dei job ha un `postedDate` malformato (`"30/05/26"` DD/MM/YY → Invalid Date) che scavalcava un `firstSeenAt` valido e forzava il branch neutro `UNDATED_DECAY_FACTOR` (0.5). Ora scorre i campi finché uno parsa.
- **Verifica empirica su `data/jobs.json` reale** (q adversarial del reviewer su PR #2614): **0/9869** job senza data usabile, **0/3656** dei job con popolarità>0 → `firstSeenAt` presente al 100% (garantito da `assemble-jobs-dataset.mjs`). Il decay **non è mai un no-op in produzione**; questo fix indurisce solo i ~30 casi con data malformata (la location-decay resta sempre age-based reale).

### Test
- `tests/job-alert-matching.test.ts`: +5 (drop keyword-match fuori-location, keep dentro, cantonFilter hard out-of-canton→0, canton soddisfa il geo-scope, pref-city NON hard-filtra).
- `tests/newsletter-template-tracking.test.ts`: +1 (postedDate malformato → fallback a firstSeenAt, non 0.5).
- Entrambe le suite verdi (52 test). GitNexus impact `scoreJobForAlert` LOW (1 caller, firma invariata; profilo additivo).

## Non implementato (ancora)

- **Normalizzazione location region-level**: il match geo è substring su `location/addressLocality/addressRegion/canton`; un alert con location "Ticino" (anziché città) si appoggia al `cantonFilter` per i job che espongono solo `canton:"TI"`. Pre-esistente, non introdotto qui; out of scope.
- **Job senza alcun campo location con alert location-scoped**: vengono droppati (non si può confermare l'area) — comportamento corretto di un filtro, ma nessun fallback canton-only se l'alert non ha cantonFilter. Accettato.
- **`publisherBlastMatch.mjs`**: NON modificato — direzione inversa (score subscriber-vs-annuncio), location soft è corretta lì (targeting per affinità, non esclusione). Non pertinente.
- **Newsletter `matchJobsForSubscriber` location pre-filter**: resta soft-graceful di proposito (`if (locationFiltered.length >= limit)`) — la newsletter deve sempre riempire 4 slot, contesto diverso dal filtro stretto dell'alert. Non è lo stesso bug.
- **Verifica live**: l'effetto del filtro hard è osservabile al prossimo invio job-alert schedulato; il decay sui malformed-date al prossimo deploy.
