### PR TITLE
fix(worker): wildcard unsubscribe route so query-string links proxy

### DIFF
--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -34,9 +34,14 @@ routes = [
   # proxies this apex path to the jobAlertUnsubscribe Cloud Function (in-code
   # UNSUB_PROXY_PATH branch — method + query + body preserved for the one-click POST).
   # Volume is tiny (a few clicks/day) so the extra Worker invocations are negligible.
-  # Both the trailing-slash and bare forms are routed so a POST never hits a 301.
-  { pattern = "frontaliereticino.ch/disiscrivi-alert/", zone_name = "frontaliereticino.ch" },
-  { pattern = "frontaliereticino.ch/disiscrivi-alert",  zone_name = "frontaliereticino.ch" },
+  # WILDCARD is REQUIRED: a Cloudflare route WITHOUT a trailing `*` matches only the
+  # exact URL with NO query string — but every emitted unsubscribe link carries
+  # `?alertId=…&token=…`, so the bare/slash exact routes (#2611) silently missed all
+  # real traffic (verified live: `/disiscrivi-alert/` → 400 from the function, but
+  # `/disiscrivi-alert/?…` → apex 404). `…/disiscrivi-alert*` covers the bare + slash
+  # forms with or without a query string; look-alike paths (e.g. /disiscrivi-alertX)
+  # are rejected by the in-code isUnsubProxyPath guard → harmless passthrough.
+  { pattern = "frontaliereticino.ch/disiscrivi-alert*", zone_name = "frontaliereticino.ch" },
   # NOTE: the /assets/* /data/* /og/* CDN-proxy routes were removed (2026-06-10).
   # Since #1665 the shard locale HTML references those static paths CDN-absolute
   # (cdn.frontaliereticino.ch/...), so the browser fetches them straight from the

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -757,6 +757,8 @@ describe('job alert email — unsubscribe links match the sending domain (anti-s
       path.resolve(__dirname, '../infra/cloudflare-worker/wrangler.toml'),
       'utf8',
     );
-    expect(wrangler).toContain('frontaliereticino.ch/disiscrivi-alert/');
+    // Route MUST be a wildcard (`*`): an exact route does not match URLs with a
+    // query string, and every emitted unsub link carries `?alertId=…&token=…`.
+    expect(wrangler).toContain('frontaliereticino.ch/disiscrivi-alert*');
   });
 });


### PR DESCRIPTION
## Problema

Le route `/disiscrivi-alert` aggiunte in #2611 erano pattern **esatti**. In Cloudflare una route senza `*` finale matcha SOLO l'URL con **nessuna query string**. Ma ogni link di disiscrizione emesso porta `?alertId=…&token=…` (o `?email=…&action=unsubscribe_all`), quindi **tutto il traffico reale mancava la route** e cadeva sull'apex (GitHub Pages 404) invece di essere proxato alla Cloud Function. La disiscrizione one-click + link footer erano di fatto rotti, pur con il dominio corretto nel link.

Verificato live dopo il deploy di #2611:
- `https://frontaliereticino.ch/disiscrivi-alert/` (no query) → **400 "Parametri mancanti"** dalla function → **il proxy funziona**.
- `https://frontaliereticino.ch/disiscrivi-alert/?alertId=…&token=…` → **404** shell SPA (apex) → route non matchata.

## Implementato

- `infra/cloudflare-worker/wrangler.toml`: sostituite le due route esatte (`/disiscrivi-alert/` + bare) con un'unica route **wildcard** `frontaliereticino.ch/disiscrivi-alert*`, che matcha sia la forma con slash sia quella bare, **con o senza query string**. I path look-alike (es. `/disiscrivi-alertX`) restano respinti dal guard in-code `isUnsubProxyPath` → passthrough innocuo.
- `tests/job-alert-email.test.ts`: aggiornato l'assert anti-drift per esigere il pattern wildcard `…/disiscrivi-alert*` (un ritorno alla route esatta ri-romperebbe il query-matching). 75/75 verde in locale.

## Non implementato (ancora)

- **Rimozione delle 2 route esatte residue dalla zona**: `wrangler deploy` aggiunge la wildcard; se le vecchie route esatte `/disiscrivi-alert/` + `/disiscrivi-alert` restano sulla zona sono innocue (sottoinsieme della wildcard, stesso script). Se persistono dopo il deploy le cancello via CF API come cleanup (non bloccante).
- **Verifica live post-deploy**: dopo `deploy-worker.yml` ri-curlo `…/disiscrivi-alert/?alertId=…&token=bad` → atteso 403/400 dalla function (non 404 apex), + POST one-click. La eseguo dopo il merge.