### PR TITLE
feat(app): full-height desktop side rails on SPA content pages

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1725,6 +1725,13 @@ const App: React.FC = () => {
  setContactPrefill, glossaryTerm, setGlossaryTerm,
  }), [inputs, deferredResult, isResultStale, handleCalculate, showDeferredHomeWidgets, seoLanding, userProfile, authUser, authLoading, isPrivilegedAdmin, googleSignIn, facebookSignIn, adminGoogleButtonReady, taxReturnCountry, borderCrossing, blogArticle, jobSlug, navigateTo, glossaryTerm]);
 
+ // Desktop side-rail ads (≥1400px): wrap the SPA <main> in the 3-col rail grid
+ // on content tabs that have empty desktop gutters (index.css already reserves
+ // them for side-rails). Excludes tabs that own their rails (blog→BlogArticles,
+ // job-board→JobBoard) or are full-width (admin). Below xlw / on excluded tabs
+ // the wrapper is `display:contents`, so layout is byte-identical to before.
+ const sideRailEligible = !staticOverlay && !['admin', 'blog', 'job-board'].includes(activeTab);
+
  return (
  <ErrorBoundary>
  <TabContentContext.Provider value={tabContentValue}>
@@ -2316,6 +2323,12 @@ const App: React.FC = () => {
   * sitemap links, weekly employers teaser) regardless of overlay mode.
   */}
  {!staticOverlay && (
+ <div className={sideRailEligible ? 'contents xlw:grid xlw:flex-grow xlw:grid-cols-[300px_minmax(0,1fr)_300px] xlw:gap-6' : 'contents'}>
+ {sideRailEligible && (
+ <aside className="hidden xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>
+ </aside>
+ )}
  <main id="main-content" className={`flex-grow mx-auto py-4 lg:py-8 transition-[max-width,padding] duration-300 ease-out relative z-10 ${
  activeTab === 'admin' ? 'w-full px-3 sm:px-6' : '!max-w-[2400px] !w-[95%] px-3 sm:px-4'
  }`}>
@@ -2605,6 +2618,12 @@ const App: React.FC = () => {
  </p>
  )}
  </main>
+ {sideRailEligible && (
+ <aside className="hidden xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense>
+ </aside>
+ )}
+ </div>
  )}
 
  {/* Side-rail ads — on staticOverlay (static SEO landing) pages, portal the


### PR DESCRIPTION
## Implementato

- **Barre laterali a tutta altezza sulle pagine SPA** che hanno gli stessi spazi laterali desktop vuoti (es. `/guida-frontaliere/`, `/compara-servizi/cambio-franco-euro/`, `/fisco/…`, `/stats/…`, calcolatore, glossario, faq, …).
- Avvolto `<main id="main-content">` in `App.tsx` nella **stessa rail-grid 3-col `xlw`** (≥1400px) di article-detail / job-detail / static-landing: `<aside>` left/right con `ArticleRailAdStack` (riuso degli stessi GAM rail unit + kill-switch Remote Config).
- I gutter desktop erano **già riservati** da `index.css` (`main:not(.seo-static-content)…` → `calc(100vw-360px)` a ≥1400, `-420px` a ≥1800, "room for AdSense side-rail ads") ma **vuoti** sulle pagine SPA: ora ospitano le creatività half-page.
- Gating `sideRailEligible = !staticOverlay && !['admin','blog','job-board'].includes(activeTab)`: esclude i tab che hanno **già** i propri rail (`blog`→BlogArticles, `job-board`→JobBoard) e il full-width `admin`.
- **Zero impatto sotto xlw e sui tab esclusi**: il wrapper è `display:contents` (trasparente) → layout byte-identico; i rail si materializzano solo a `xlw` su tab eleggibili. Colonne riservate 300px → zero CLS. Mobile/tablet invariati.
- Nessun revert del CLS-fix `TopAutoAdReserve` (#2629): la modifica è puramente additiva (re-based su `origin/main`).

## Non implementato (ancora)

- **Tab esclusi per ora**: `blog`/`job-board` (rail propri) e `admin` (full-width). Eventuali altri tab app-like (`profile`, `publish`, `publisher-dashboard`, `forum`) restano inclusi come content-page; se si vuole escluderli è un one-liner sull'array.
- **Verifica live ≥1400px**: fill GPT effettivo + assenza CLS osservabili solo sul deploy reale a viewport `xlw`; non riproducibili pre-merge. Se a `xlw` i rail restano vuoti o introducono shift → follow-up reserve-space, non rimozione.
- **`count` adattivo alla lunghezza pagina**: default `2` (come le altre superfici); tuning rimandato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)