### PR TITLE
feat(a11y): skip-to-content link + pointer cursor (Google AI agent-readiness guide)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1745,6 +1745,19 @@ const App: React.FC = () => {
   *  - Per-page `disableAutoAds` in build-plugins/htmlTemplate.ts is preserved
   *    for "drive-by" SEO landings where bounce ≥97% (F8/F6/F2). */}
  <div className={`app-shell-col ${staticOverlay ? '' : 'min-h-screen'} relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
+ {/* Skip-to-content: first focusable element so keyboard users — and browser
+  * AI agents reading the accessibility tree — can bypass the nav/header chrome
+  * and jump straight to <main id="main-content"> (WCAG 2.4.1 Bypass Blocks;
+  * Google AI agent-readiness guidance). Rendered only on SPA routes where the
+  * React <main> is mounted, so the anchor target always resolves. */}
+ {!staticOverlay && (
+ <a
+ href="#main-content"
+ className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[300] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent focus:text-on-accent focus:text-sm focus:font-semibold focus:shadow-lg focus:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent"
+ >
+ {t('a11y.skipToContent')}
+ </a>
+ )}
  <div className="absolute inset-0 bg-surface-alt -z-20 [contain:strict]"></div>
 
  {/* LinkedIn OAuth2 callback processing overlay */}
@@ -2316,7 +2329,7 @@ const App: React.FC = () => {
   * sitemap links, weekly employers teaser) regardless of overlay mode.
   */}
  {!staticOverlay && (
- <main id="main-content" className={`flex-grow mx-auto py-4 lg:py-8 transition-[max-width,padding] duration-300 ease-out relative z-10 ${
+ <main id="main-content" tabIndex={-1} className={`flex-grow mx-auto py-4 lg:py-8 scroll-mt-20 focus:outline-none transition-[max-width,padding] duration-300 ease-out relative z-10 ${
  activeTab === 'admin' ? 'w-full px-3 sm:px-6' : '!max-w-[2400px] !w-[95%] px-3 sm:px-4'
  }`}>
  <Suspense fallback={<LazyFallback />}>

--- a/index.css
+++ b/index.css
@@ -183,6 +183,19 @@ button, a, [role="button"], input, select, textarea, label, summary {
   touch-action: manipulation;
 }
 
+/* Pointer cursor on interactive controls. Tailwind v4's Preflight no longer
+ * sets this, so a native <button> shows the default arrow cursor. Google's AI
+ * agent-readiness guidance calls cursor:pointer a strong signal that an element
+ * is interactive (for browser agents reading the rendered page as well as for
+ * humans). In @layer base so any explicit cursor-* utility (cursor-help on info
+ * triggers, cursor-not-allowed on disabled states, …) still overrides it.
+ * Disabled buttons are excluded so they keep the default cursor. */
+@layer base {
+  button:not(:disabled), summary, [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+}
+
 /* Tabular numbers for financial data alignment */
 .tabular-nums, [data-numeric], td, th, output, .font-mono {
   font-variant-numeric: tabular-nums;

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -3,6 +3,7 @@ const deCore: Record<string, string> = {
  'app.subtitle': 'Berechnen und vergleichen Sie Ihr Nettogehalt als Grenzgänger',
  'app.fullscreen': 'Vollbild',
  'app.exitFullscreen': 'Vollbild beenden',
+ 'a11y.skipToContent': 'Zum Hauptinhalt springen',
  'app.lightMode': 'Helles Design aktivieren',
  'app.resetConfirm': 'Cache, Cookies und lokale Daten löschen? Die Seite wird neu geladen, als wäre es Ihr erster Besuch.',
  'app.darkMode': 'Dunkles Design aktivieren',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -3,6 +3,7 @@ const enCore: Record<string, string> = {
  'app.subtitle': 'Calculate and compare your net salary as a cross-border worker',
  'app.fullscreen': 'Fullscreen',
  'app.exitFullscreen': 'Exit Fullscreen',
+ 'a11y.skipToContent': 'Skip to main content',
  'app.lightMode': 'Switch to light mode',
  'app.resetConfirm': 'Clear cache, cookies and local data? The site will reload as if it were your first visit.',
  'app.darkMode': 'Switch to dark mode',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -3,6 +3,7 @@ const frCore: Record<string, string> = {
  'app.subtitle': 'Calculez et comparez votre salaire net en tant que travailleur frontalier',
  'app.fullscreen': 'Plein écran',
  'app.exitFullscreen': 'Quitter le plein écran',
+ 'a11y.skipToContent': 'Aller au contenu principal',
  'app.lightMode': 'Activer le thème clair',
  'app.resetConfirm': 'Vider le cache, les cookies et les données locales ? Le site se rechargera comme lors de votre première visite.',
  'app.darkMode': 'Activer le thème sombre',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -4,6 +4,7 @@ const translations: Record<string, string> = {
  'app.subtitle': 'Calcola e confronta il tuo stipendio netto come lavoratore frontaliero',
  'app.fullscreen': 'Schermo intero',
  'app.exitFullscreen': 'Esci da Schermo intero',
+ 'a11y.skipToContent': 'Salta al contenuto principale',
  'app.lightMode': 'Attiva tema chiaro',
  'app.darkMode': 'Attiva tema scuro',
  'app.resetConfirm': 'Vuoi svuotare cache, cookie e dati locali? Il sito si ricaricherà come alla prima visita.',


### PR DESCRIPTION
## Implementato

Applica i due gap concreti emersi dall'audit del sito contro la guida Google **«Ottimizza il tuo sito web per le funzionalità di AI generativa nella Ricerca»** e la pagina correlata **«Creare siti web ottimizzati per gli agenti»** (web.dev). Il resto della guida è stato verificato ed è **già soddisfatto** (vedi sotto).

- **Skip-to-content link**: primo elemento focusabile dello shell app, salta a `<main id="main-content">` (WCAG 2.4.1 Bypass Blocks). Aiuta utenti da tastiera e browser-agent che leggono l'accessibility tree a raggiungere il contenuto principale bypassando nav/header. Reso solo su route SPA (`!staticOverlay`) dove il `<main>` React monta → l'ancora ha sempre un target valido. Il `<main>` riceve `tabIndex={-1}` + `scroll-mt-20` perché il focus atterri e scrolli sotto eventuali header fissi. Stile `sr-only` → visibile solo al focus.
- **Stringa `a11y.skipToContent`** aggiunta nei 4 locali (it/en/de/fr).
- **Regola base `cursor: pointer`** per `button:not(:disabled)`, `summary`, `[role="button"]`. Il Preflight di Tailwind v4 non la imposta più → i `<button>` nativi mostravano il cursore freccia di default; la guida agent-UX cita `cursor:pointer` come «indicatore forte di interattività» per agenti e utenti. In `@layer base` così le utility `cursor-*` esplicite (`cursor-help` sui trigger info, `cursor-not-allowed` sui disabled) continuano a vincere; bottoni disabled esclusi.

### Già soddisfatto (verificato, nessuna modifica necessaria)
- HTML semantico + `role`/`tabindex`/`onKeyDown`/`aria-expanded` su tutti i toggle (`SectionHeader`, accordion guide, ecc.).
- `aria-label` sugli input dei calcolatori (= nome nell'accessibility tree, equivalente a `label[for]`); `StepperInput` ha già `htmlFor`/`id`.
- `<html lang>` sincronizzato dinamicamente per locale (`i18n.ts`, `seoService.ts`).
- `<main id="main-content">` come landmark distinguibile; tutte le `<img>` con `alt`; icone decorative `aria-hidden`.
- Structured data esteso (JobPosting ecc.), SSG crawlable, lavoro CLS su Auto Ads, `prefers-reduced-motion` rispettato.
- «Miti» della guida (llms.txt, chunking, riscrittura per AI, dati strutturati speciali): nessuna azione richiesta — il sito non li insegue.

## Non implementato (ancora)
- **Skip-link sulle pagine SEO statiche** (`staticOverlay`): out of scope. Il `<main>` statico è emesso da ~20 build-plugin (`jobsSeoPagesPlugin`, hub, landing) ciascuno con classe propria e senza `id="main-content"`; aggiungere l'id a tutti = churn ampio su file SSG OOM-sensibili, sproporzionato. Le landing statiche sono già content-first (regola mobile-first) con chrome minimo sopra. Follow-up possibile se si vuole copertura completa.
- **`label[for]` esplicito sugli ~87 label calcolatrice**: deferito — gli input hanno già `aria-label` che fornisce il nome accessibile (la guida tratta `for` e aria-label come equivalenti per il naming). Refactor di 87 punti = anti-«chirurgico» senza guadagno funzionale per agenti/screen-reader.
- **WebMCP / Universal Commerce Protocol**: standard sperimentali in preview (richiedono iscrizione al programma), citati dalla guida come «esplora» — non azionabili ora.

## Test
- [x] `npx tsc --noEmit`: i miei file (App.tsx, index.css, *-core.ts) type-clean (errori residui sono pre-esistenti in file non toccati: apm_modules, tests/canary-rpm, PublisherDashboardPage).
- [x] `vitest run i18n-completeness + i18n-guard + i18n` → 28/28 pass (parità chiavi 4 locali OK).
- [x] `check-sibling-patterns.mjs` → nessun gemello non-toccato.
- [ ] Verifica live post-deploy: Tab da inizio pagina mostra «Salta al contenuto»; click sposta focus su `<main>`; cursore a manina sui bottoni; disabled resta freccia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)