### PR TITLE
feat(ci): route Claude workflow agents through Headroom compression proxy

### DIFF
--- a/.github/actions/setup-headroom/action.yml
+++ b/.github/actions/setup-headroom/action.yml
@@ -1,0 +1,61 @@
+name: "Setup Headroom compression proxy"
+description: >-
+  Install Headroom and start the local compression proxy in the runner, then
+  route Claude Code through it via ANTHROPIC_BASE_URL. Fail-open by design: if
+  the proxy cannot install or become ready, ANTHROPIC_BASE_URL is left unset so
+  Claude talks directly to Anthropic (uncompressed) and the review/fix gate is
+  NEVER blocked by a compression-layer problem.
+inputs:
+  port:
+    description: "Local proxy port."
+    default: "8787"
+  extras:
+    description: "headroom-ai pip extras to install (no heavy ML model in CI)."
+    default: "proxy,code"
+runs:
+  using: "composite"
+  steps:
+    - name: Install Headroom
+      shell: bash
+      run: |
+        set -eo pipefail
+        # pipx is preinstalled on GitHub-hosted runners; fall back to pip --user
+        # for self-hosted/externally-managed environments.
+        if pipx install "headroom-ai[${{ inputs.extras }}]"; then
+          :
+        else
+          python3 -m pip install --user --break-system-packages "headroom-ai[${{ inputs.extras }}]" || true
+        fi
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Start Headroom proxy
+      shell: bash
+      run: |
+        set -eo pipefail
+        export PATH="$HOME/.local/bin:$PATH"
+        if ! command -v headroom >/dev/null 2>&1; then
+          echo "::warning::headroom not installed — skipping compression (Claude runs direct)."
+          exit 0
+        fi
+        nohup headroom proxy --port "${{ inputs.port }}" --stateless \
+          > "$RUNNER_TEMP/headroom-proxy.log" 2>&1 &
+        for _ in $(seq 1 30); do
+          if curl -sf "http://127.0.0.1:${{ inputs.port }}/readyz" >/dev/null 2>&1; then
+            echo "Headroom proxy ready on port ${{ inputs.port }}."
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::warning::Headroom proxy did not become ready in 30s — skipping compression."
+        cat "$RUNNER_TEMP/headroom-proxy.log" 2>/dev/null || true
+
+    - name: Route Claude through Headroom
+      shell: bash
+      run: |
+        set -eo pipefail
+        if curl -sf "http://127.0.0.1:${{ inputs.port }}/readyz" >/dev/null 2>&1; then
+          echo "ANTHROPIC_BASE_URL=http://127.0.0.1:${{ inputs.port }}" >> "$GITHUB_ENV"
+          echo "Claude routed through Headroom (http://127.0.0.1:${{ inputs.port }})."
+        else
+          echo "::notice::Headroom proxy unavailable — ANTHROPIC_BASE_URL left unset; Claude talks directly to Anthropic."
+        fi

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -154,6 +154,10 @@ jobs:
           git config user.name "Valerie Linc"
           git config user.email "valerielinc@gmail.com"
 
+      - name: Setup Headroom compression proxy
+        if: steps.preflight.outputs.already_resolved != 'true'
+        uses: ./.github/actions/setup-headroom
+
       - name: Run Claude fix
         id: claude_review
         if: steps.preflight.outputs.already_resolved != 'true'

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -72,6 +72,10 @@ jobs:
           HARVEST_EMIT_ESCALATIONS: 'true'
         run: node scripts/ci/harvest-agent-lessons.mjs
 
+      - name: Setup Headroom compression proxy
+        if: steps.guard.outputs.open_proposals == '0' && steps.harvest.outputs.has_novel == 'true'
+        uses: ./.github/actions/setup-headroom
+
       - name: Draft doc-rule proposal (Claude — only if NOVEL patterns)
         # Escalations are auto-filed by the harvest step above → Claude is spent
         # ONLY when a genuinely-new (novel) recurring pattern needs a doc rule.

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -64,6 +64,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: node scripts/ci/is-followup-fix-pr.mjs
 
+      - name: Setup Headroom compression proxy
+        if: steps.gchild.outputs.is_followup_fix != 'true'
+        uses: ./.github/actions/setup-headroom
+
       - name: Run Claude follow-up triage
         id: followup
         # Skip quando la PR è essa stessa un fix-di-follow-up (rompe il self-feed

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -249,6 +249,10 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Headroom compression proxy
+        if: steps.guard.outputs.proceed == 'true'
+        uses: ./.github/actions/setup-headroom
+
       - name: Run Claude 🔴-fix
         id: claude_review
         if: steps.guard.outputs.proceed == 'true'

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -184,6 +184,10 @@ jobs:
             set_tier normal claude-sonnet-4-6 25
           fi
 
+      - name: Setup Headroom compression proxy
+        if: steps.guard.outputs.skip != 'true'
+        uses: ./.github/actions/setup-headroom
+
       - name: Run Claude review
         id: claude_review
         if: steps.guard.outputs.skip != 'true'


### PR DESCRIPTION
## Implementato

- Nuova **composite action condivisa** `.github/actions/setup-headroom/action.yml`: installa Headroom (`headroom-ai[proxy,code]` — niente modello ML pesante in CI), avvia il proxy di compressione locale nel runner e routa Claude Code via `ANTHROPIC_BASE_URL=http://127.0.0.1:8787`. Modulo unico riusato → niente copy-paste in 5 file (anti sibling-class drift).
- Wirata in tutti e 5 i workflow che invocano `anthropics/claude-code-action@v1`: `pr-review-loop`, `issue-fix`, `pr-redflag-fixer`, `post-merge-followup`, `lessons-harvester`. Lo step setup è inserito **prima** dello step Claude e **rispecchia il suo `if:`** → il proxy parte solo quando Claude gira davvero (zero spreco install ~2min sulle run skippate).
- **Fail-open by design**: se il proxy non si installa o non diventa `/readyz` in 30s, lo step NON setta `ANTHROPIC_BASE_URL` → Claude parla diretto ad Anthropic (non compresso) e il **gate review/fix non viene MAI bloccato** da un problema del layer di compressione. Worst-case = "niente compressione", mai "gate rotto".
- Auth invariata: `claude_code_oauth_token` (subscription Max) resta; il proxy inoltra l'header Authorization a `api.anthropic.com` trasparentemente.

## Non implementato (ancora)

- **Validazione live del routing proxy-in-CI: non verificabile pre-merge.** `claude-code-action@v1` onora `ANTHROPIC_BASE_URL` settato via `GITHUB_ENV` nel job: confermato localmente che il proxy inoltra `/v1/messages`→Anthropic, ma il comportamento esatto dell'action nel runner (token-exchange OAuth + KV-cache attraverso il proxy) si vede solo post-merge su una run reale. **Revert-trigger esplicito:** se dopo il merge una run di `pr-review-loop`/`issue-fix`/`redflag-fixer` fallisce con auth/401 o body review vuoto attribuibile al proxy → revert di questa PR (il fail-open dovrebbe già degradare a diretto, ma se l'action non rispetta il fail-open, revert). Da osservare live su `main` (regola: test new workflows live).
- **Compressione lossy sul gate (rischio accettato dall'owner).** Il reviewer/fixer leggerà diff compressi (AST CodeCompressor + SmartCrusher) → possibile miss di un bug. CCR consente retrieve on-demand ma dipende dall'agent. Scelta deliberata dell'owner per ridurre context/session-limit; su Max il risparmio in $ è zero (forfait).
- **Output-shaper / verbosity steering: NON abilitato.** `HEADROOM_OUTPUT_SHAPER` resta off (è il pezzo che taglia il "thinking" del modello → più rischio qualità, e su Max nessun guadagno $). Solo input-compression.
- **Cache del modello/binari headroom in CI: non implementata.** Ogni run reinstalla (`pipx`) → ~1-3min overhead per run. Follow-up possibile: `actions/cache` sui binari ast-grep/pip se l'overhead pesa.
- **Monitor `dmarc-monitor`/`gh-pat-expiry-monitor`: non toccati** — non usano `claude-code-action` (matchavano la grep solo per riferimenti al token/commenti).