### PR TITLE
fix(cls): size header lazy-widget fallbacks (LanguageSelector/WhatsNewBell)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1997,12 +1997,13 @@ const App: React.FC = () => {
  </div>
  )}
 
- {/* Language selector — always visible */}
- <Suspense fallback={null}><LanguageSelector /></Suspense>
+ {/* Language selector — always visible. Sized fallback reserves the 44x44
+  * button box so the lazy chunk mounting doesn't shift the header row (CLS). */}
+ <Suspense fallback={<div className="min-w-[44px] min-h-[44px]" aria-hidden="true" />}><LanguageSelector /></Suspense>
 
  {/* WhatsNew bell — desktop only */}
  <div className="hidden md:block">
- <Suspense fallback={null}><WhatsNewBellLazy onClick={() => setShowWhatsNew(true)} /></Suspense>
+ <Suspense fallback={<div className="min-w-[44px] min-h-[44px]" aria-hidden="true" />}><WhatsNewBellLazy onClick={() => setShowWhatsNew(true)} /></Suspense>
  </div>
 
  {/* Dark mode toggle — desktop only */}


### PR DESCRIPTION
## Implementato

Follow-up diretto di #2629 (auto-ad top reserve, già live: homepage desktop 0.24→0.07 **green**, mobile 0.43→0.11). Con lo shift dominante eliminato, la **misurazione live** ha mostrato come prossimo contributore ogni-load la riga azioni dell'header (`div.flex.items-center`, ~0.036 mobile).

**Causa:** `<LanguageSelector>` (sempre visibile) e `<WhatsNewBell>` (desktop) sono lazy con `fallback={null}` → il loro box bottone 44×44 compare solo dopo il caricamento del chunk e spinge lateralmente gli elementi adiacenti (es. hamburger su mobile).

**Fix:** placeholder dimensionato nei due `<Suspense>`, `min-w-[44px] min-h-[44px]` = identico al floor del bottone reso (entrambi i componenti usano `min-w-[44px] min-h-[44px]`). Stesso pattern già usato da `<SiteSearch>` (`fallback w-9 h-9`). Slot riservato dal first paint → montare il widget non causa shift. Cambio puramente additivo (placeholder al posto di `null`), nessun impatto su comportamento/monetizzazione.

## Non implementato (ancora)

- **Coda lunga residua mobile** (non in scope qui): NewsletterPopup intermittente (~0.042, re-centering flex del pannello modal — appare solo a una frazione di load) + shift `body` ~16px (reset margine/scrollbar pre-esistente, già inline-critical). Da valutare separatamente se la metrica field RUM non scende sotto 0.1.
- **Articolo cold-load CLS ~0.5** (causa diversa: font-swap Space Grotesk senza metric-override + render SPA progressivo) — follow-up separato, non toccato qui.

## Test plan

- [x] Cambio JSX trivialmente tipizzato (placeholder div), pattern identico a SiteSearch esistente.
- [ ] Post-deploy: rimisurare CLS live homepage mobile, confermare riduzione del contributo header `div.flex.items-center` e mobile sotto/vicino 0.1.