### PR TITLE
fix(404): recover cross-canton Ticino drift orphans via hit-ranked hot-list

### DIFF
--- a/scripts/build-cf-hot-404s.mjs
+++ b/scripts/build-cf-hot-404s.mjs
@@ -55,11 +55,77 @@ const MAX_PATHS = Number(process.env.CF_HOT_404_MAX) || 250000;
 // Google + returning visitors.
 const MIN_HITS = 2;
 
-// Ticino + nationwide sections are owned by jobsSeoPagesPlugin; never include.
+// Ticino + nationwide sections are owned by jobsSeoPagesPlugin; never include —
+// EXCEPT cross-canton drift orphans (see isCrossCantonTicinoOrphan below). A job
+// whose URL section re-derives away from Ticino (sharedResolveJobCanton, e.g.
+// the pre-pin default-to-TI fallback) leaves its old `/cerca-lavoro-ticino/<slug>/`
+// indexed URL orphaned; jobsSeoPagesPlugin's compat-merge drops it (it skips a
+// slug whose `tracking[slug][locale]` is already set to the now-active non-TI
+// canton), so it 404s with no soft-landing. Those ARE in scope here.
 const TICINO_RE =
   /^\/(cerca-lavoro-ticino|en\/(find-jobs?|job-search)-ticino|de\/(jobs-im|jobsuche|stellenangebote)-tessin|fr\/(trouver-emploi|recherche-emploi|emplois)-tessin)\//;
 const AGGREGATE_RE =
   /^\/(cerca-lavoro-svizzera|en\/find-jobs-switzerland|de\/jobs-in-schweiz|fr\/trouver-emploi-suisse)\//;
+
+// Slug → per-locale CURRENT canonical section prefix, from the committed ledger
+// data/all-known-job-slugs.json (same source jobCanonRedirectMapPlugin shards for
+// the 404.html runtime resolver). Used ONLY to tell a genuine cross-canton Ticino
+// orphan (slug's canonical now lives under a DIFFERENT section) from a legit
+// Ticino job (canonical IS Ticino → already emitted by the main loop) or an
+// expired/unknown slug (handled by the seo-404-compat-paths.json compat-merge).
+// Best-effort: a missing/unreadable ledger leaves Ticino fully excluded (the
+// historical behaviour), never throws.
+const slugCanonicalSection = (() => {
+  const map = new Map();
+  try {
+    const ledger = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'data', 'all-known-job-slugs.json'), 'utf8'),
+    );
+    for (const key of Object.keys(ledger)) {
+      const entry = ledger[key];
+      if (!entry || typeof entry !== 'object') continue;
+      for (const loc of ['it', 'en', 'de', 'fr']) {
+        const p = entry[loc];
+        if (typeof p !== 'string' || !p.startsWith('/')) continue;
+        const norm = p.replace(/\/+$/, '');
+        const cut = norm.lastIndexOf('/');
+        if (cut <= 0) continue;
+        const slug = norm.slice(cut + 1);
+        const section = norm.slice(0, cut); // e.g. /cerca-lavoro-berna, /de/jobs-in-bern
+        if (slug && !map.has(slug)) map.set(slug, {});
+        const rec = map.get(slug);
+        if (rec && !(loc in rec)) rec[loc] = section;
+      }
+    }
+  } catch {
+    /* no ledger → Ticino stays fully excluded (historical behaviour) */
+  }
+  return map;
+})();
+
+// Locale (it default) + section prefix + slug for a normalized job-detail path.
+function parseJobPath(p) {
+  const segs = p.replace(/\/+$/, '').split('/').filter(Boolean);
+  if (segs.length < 2) return null;
+  const locale = segs[0] === 'en' || segs[0] === 'de' || segs[0] === 'fr' ? segs[0] : 'it';
+  const slug = segs[segs.length - 1];
+  const section = '/' + segs.slice(0, -1).join('/');
+  return { locale, slug, section };
+}
+
+// A Ticino-section path is in scope ONLY when its slug is a known job whose
+// CURRENT canonical (for that locale) lives under a DIFFERENT section — i.e. a
+// real canton-drift orphan with a live 200 page elsewhere. Legit Ticino jobs
+// (canonical == this section) and expired/unknown slugs stay excluded.
+function isCrossCantonTicinoOrphan(p) {
+  const parsed = parseJobPath(p);
+  if (!parsed) return false;
+  const rec = slugCanonicalSection.get(parsed.slug);
+  if (!rec) return false;
+  const canon = rec[parsed.locale];
+  return Boolean(canon) && canon !== parsed.section;
+}
+
 // A non-Ticino per-canton job-detail path: optional locale prefix, a job-board
 // section stem + canton slug, then exactly ONE slug segment.
 const JOB_DETAIL_RE =
@@ -86,7 +152,11 @@ function readExisting() {
 function isHotCandidate(p) {
   if (typeof p !== 'string' || !p.startsWith('/')) return false;
   if (!JOB_DETAIL_RE.test(p)) return false;
-  if (TICINO_RE.test(p) || AGGREGATE_RE.test(p)) return false;
+  if (AGGREGATE_RE.test(p)) return false;
+  // Ticino sections are normally owned by jobsSeoPagesPlugin, but cross-canton
+  // drift orphans (slug's canonical now under a different section) fall through
+  // its compat-merge → recover them here too.
+  if (TICINO_RE.test(p)) return isCrossCantonTicinoOrphan(p);
   return true;
 }
 


### PR DESCRIPTION
## Implementato

Recupera gli **orfani canton-drift della sezione Ticino** facendoli entrare nella hot-list `data/cf-hot-404s.json`, così `cfHot404BridgePlugin` (già attivo sul path di build live) emette un **bridge 200** (`canton-moved` → pagina reale) invece di un 404.

**Perché serviva (verificato live, 2026-06-22):** dopo che PR #2589 è andata live (build `cc5fea2`), gli orfani TI restavano 404 (es. `/cerca-lavoro-ticino/venditore-denner-ag-wilderswil-2b22fa/`). Causa duplice:
1. `build-cf-hot-404s.mjs` escludeva **tutte** le sezioni Ticino (`TICINO_RE`), assumendo che il compat-merge di `jobsSeoPagesPlugin` le coprisse. Ma quel merge **scarta** uno slug il cui `tracking[slug][locale]` è già settato al cantone non-TI ora attivo (canton drift) → l'URL `/cerca-lavoro-ticino/<slug>/` orfano resta senza soft-landing **e** fuori dalla hot-list → nessun bridge.
2. Il flag accumulatore di #2589 era nel job `build` **monolith**, che è **skippato** sul path live (repo var `LOCALE_MATRIX_BUILD=true` → gira `build-locale` per-locale) → inerte; e comunque cap-troncato (accumulatore 935k, synthetic hits=1, oltre il taglio `MAX_EMIT`).

**Fix (`scripts/build-cf-hot-404s.mjs`):** carico il ledger committato `all-known-job-slugs.json` in un indice `slug → sezione-canonica per-locale` e lascio passare un path Ticino in `isHotCandidate` **solo** quando lo slug è noto **e** la sua canonica vive ora sotto una sezione **diversa** (vero orfano cross-canton con pagina 200 reale altrove). I job Ticino legittimi (canonica == TI) e gli slug scaduti/ignoti restano esclusi. Così entrano in `cf-hot-404s.json` con i **conteggi hit reali della CF** → si classificano dentro il cap (niente troncamento) → `cfHot404BridgePlugin` li emette come bridge 200.

**Verificato:** il classificatore contro il ledger live — wilderswil/interlaken (TI it+de) → INCLUDE; `responsabile-...-ubs-ticino` (canonica TI legittima) → exclude; slug ignoto → exclude. Linchpin: `worb-zurigo` (bridge `canton-moved`) è già **200 live sul build matrix** → conferma che `cfHot404BridgePlugin` gira nello shard `build-locale` ed emette i bridge da `cf-hot-404s.json`.

**Sicurezza/scala:** solo orfani cross-canton con slug noto + hit reali (≠ i 312k soft-landing TI completi che OOM'arono #2000/#2031) → bounded, hit-ranked, cap invariato. Plugin emit streaming. Ledger letto best-effort (mancante → comportamento storico, niente throw).

## Non implementato (ancora)

- **`jobsSeoPagesPlugin.ts` compat-merge skip (`if (tracking[slug][locale]) break`)**: non toccato (file 12k righe, rischioso). È la *causa a monte* per cui i TI driftati non hanno soft-landing; lo aggiro recuperandoli via `cf-hot-404s.json`. Una soft-landing TI *più ricca* nel plugin resta follow-up.
- **Flag accumulatore di #2589 in `deploy.yml`** (job `build` monolith): lasciato com'è — **inerte** sul path matrix live (job skippato), innocuo. Va rimosso/spostato in `build-locale` in un cleanup separato; non incluso qui per tenere la PR su un solo file/concern. La copertura **long-tail** (orfani a basso traffico ruotati fuori dalla CF query) resterebbe scoperta finché l'accumulatore non è cablato sul path live — follow-up.
- **Sibling `TICINO_RE`**: `scripts/lib/swiss-medical-network-job-parser.mjs` e `scripts/update-swiss-medical-network-jobs.mjs` hanno un `TICINO_RE` proprio per la **classificazione canton del crawler** (scopo diverso dal filtro cattura-404) → non è lo stesso antipattern, non toccati. `deploy.yml`/`jobCanonRedirectMapPlugin.ts` condividono solo nomi citati nei commenti.

Relativo a #2530 (sitemap/newsletter 404 self-inflitte): classe diversa, parzialmente mitigata dai bridge; root sitemap-consistency resta scope di #2530.
