### PR TITLE
fix(firestore): restore COLLECTION-scope index on alerts.active for test sends

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -128,6 +128,7 @@
       "collectionGroup": "alerts",
       "fieldPath": "active",
       "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
     },


### PR DESCRIPTION
## Problema

Un invio di test job-alert (`send-job-alerts.yml` con `target_email`) verso un'email reale fallisce con:

```
9 FAILED_PRECONDITION: The query requires a COLLECTION_ASC index for collection `alerts` and field `active`.
```

→ **nessuna email inviata** sul path di test. La causa: il `fieldOverride` su `alerts.active` dichiara solo lo scope `COLLECTION_GROUP`, e un fieldOverride **disabilita** l'auto-index single-field di default → lo scope `COLLECTION` non è più indicizzato.

Il path **di produzione** (cron giornaliero) NON è impattato: usa `collectionGroup('alerts').where('active','==',true)` (scope COLLECTION_GROUP, coperto) → gli ultimi 12 run schedulati sono verdi e ci sono 57 alert attive che ricevono email regolarmente.

Il path **di test** (`TARGET_EMAIL`) interroga la singola subcollection `job_alert_subscribers/{email}/alerts.where('active','==',true)` — scope **COLLECTION** — che non ha più indice.

## Implementato

- `firestore.indexes.json`: aggiunto lo scope `COLLECTION` al fieldOverride `alerts.active` (additivo — `COLLECTION_GROUP` mantenuto). Ripristina l'index single-field per le query COLLECTION-scoped su `alerts.active`, sbloccando l'invio di test mirato senza scansionare l'intera collectionGroup. Deploy automatico via `deploy-firestore-rules.yml` (trigger su `firestore.indexes.json`). Index additivo e non distruttivo; build immediata (collezione piccola).

## Non implementato (ancora)

- **Nessun cambio al path di produzione**: già funzionante via COLLECTION_GROUP, non toccato.
- **Verifica post-deploy**: dopo merge + deploy index, ri-lancio `send-job-alerts.yml` con `target_email=valerielinc@gmail.com` (2 alert attive presenti) → atteso 1 email con i link `/disiscrivi-alert/` nuovi.