### PR TITLE
fix(jobboard): widen rail'd job-detail so central content stays readable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2471,7 +2471,13 @@ const App: React.FC = () => {
  <PressKit />
  </div>
  ) : activeTab === 'job-board' ? (
- <div className="max-w-7xl mx-auto">
+ // Widen past max-w-7xl (1280) at ≥1400px so the job-detail view's 3-column
+ // rail grid (300px | content | 300px) gets room for BOTH rails AND a readable
+ // centre — otherwise the 600px of rails collapse the content column to ~630px
+ // inside the 1280 cap (measured live). Mutually-exclusive ranges (`max-xlw:` <
+ // 1400, `xlw:` ≥ 1400) so the v4 cascade can't pin it to 7xl. Inner list view
+ // self-caps (max-w-6xl), so only the rail'd detail/gate views use the width.
+ <div className="max-xlw:max-w-7xl xlw:max-w-[1900px] mx-auto">
  <JobBoard
  initialJobSlug={jobSlug || undefined}
  initialFilterParams={jobBoardFilterParams}


### PR DESCRIPTION
## Implementato

- **Contenuto centrale della job-detail non più super-compresso** dai rail laterali. Il tab `job-board` cappava il contenuto a `max-w-7xl` (1280px); con la rail-grid 3-col (`300px | content | 300px`) i 600px di rail collassavano la colonna centrale a **~630px** dentro quel cap, mentre ~270px di spazio laterale restavano vuoti per lato (misurato live a 1920px).
- Wrapper allargato a `max-xlw:max-w-7xl xlw:max-w-[1900px] mx-auto`: a `xlw` (≥1400px) i rail si spostano nei gutter prima vuoti e la colonna centrale torna leggibile (**centro 632px → ~1140px**, verificato live via override DOM + re-measure Playwright). Range `max-xlw`/`xlw` mutuamente esclusivi (breakpoint nominato) per evitare il cascade Tailwind v4; stesso pattern già usato dal tab `blog`.
- La **list view** interna si auto-cappa a `max-w-6xl`, quindi solo le viste detail/gate con i rail usano la larghezza extra.

## Non implementato (ancora)

- **Altre superfici rail già OK** (verificato live/misura): pagine SPA content (#2635, centro ~1200px) e static landing (#2592, grid cap 1768 → centro 1120px) NON sono compresse → nessuna modifica. La compressione era specifica del cap `max-w-7xl` del tab job-board.
- **Verifica live ≥1400px post-deploy**: la larghezza finale del centro e l'assenza di regressioni a viewport intermedi (1400–1600) vanno riconfermate sul deploy reale.
- **CLS dei rail**: regressione CLS separata (rail stilizzati dal foglio Tailwind async) è in lavorazione a parte (`criticalCss.ts` reserve) — fuori scope di questa PR width-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)