### PR TITLE
perf(build): scope blog-image-cdn full-dist walk to the shard's owned locale

### DIFF
--- a/build-plugins/blogImageCdnFinalizePlugin.ts
+++ b/build-plugins/blogImageCdnFinalizePlugin.ts
@@ -28,6 +28,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { CDN_BLOG_BASE } from './shared/blogImageCdn';
+import { shouldEmitPath } from './shared/localeEmitFilter';
 
 const ORIGIN = 'https://frontaliereticino.ch';
 const SCAN_EXT = new Set(['.html', '.xml', '.txt']);
@@ -72,8 +73,23 @@ function walk(dir: string, fn: (fp: string) => void, root: string = dir): void {
       // while keeping the (huge) top-level dist/data skip. The dist/images/blog
       // deletion loop below is a separate explicit readdirSync of blogDir.
       if (dir === root && (e.name === 'assets' || e.name === 'data' || e.name === 'images')) continue;
+      // Per-locale matrix shard (BUILD_LOCALE): skip a non-owned top-level locale
+      // subtree (e.g. dist/en on the `it` shard, or any non-`en` tree on the `en`
+      // shard). Those files are deleted post-build by prune-locale-shard.mjs, so
+      // they never ship from this shard — walking + rewriting + leak-scanning
+      // them is the bulk of this plugin's ~200s wasted I/O on each shard. The
+      // leak-guard's no-404 contract is preserved because every file this shard
+      // SHIPS (its owned locale + the root/`it`-classified shared tree) is still
+      // walked and scanned. shouldEmitPath returns true for ALL paths on the
+      // default all-locale build (EMIT_ALL_LOCALES) → no-op, full coverage.
+      if (dir === root && !shouldEmitPath(fp, root)) continue;
       walk(fp, fn, root);
-    } else if (SCAN_EXT.has(path.extname(e.name))) fn(fp);
+    } else if (SCAN_EXT.has(path.extname(e.name))) {
+      // Same shard-ownership gate for root-level files (e.g. dist/index.html on
+      // an en/de/fr shard) — pruned post-build, never shipped from here.
+      if (!shouldEmitPath(fp, root)) continue;
+      fn(fp);
+    }
   }
 }
 


### PR DESCRIPTION
## Implementato

`blogImageCdnFinalizePlugin.closeBundle()` walks the **full** `dist` HTML/XML/TXT tree to rewrite `/images/blog/<hero>` references to the CDN (and then deletes the full heroes from `dist/images/blog`). In the per-locale MATRIX build this runs inside every shard's vite build, **before** `scripts/ci/prune-locale-shard.mjs`, so each of the 4 shards walks + rewrites + leak-scans **all four locales'** pages and then 3/4 of that output is pruned. Measured `closeBundle` cost ~**208s on the `it` shard / ~186s on `en`** (deploy run `27929801749`) — near-identical across shards ⇒ the walk re-does every locale on every shard.

This PR gates the top-level directory descent and the root-level file scan in `walk()` on `shouldEmitPath(fp, distDir)`, so each shard walks only the subtree it owns:
- `it`/main shard: the root + the `it`-classified shared tree (en/de/fr subtrees skipped).
- `en`/`de`/`fr` shards: only their `/<locale>` subtree.

**Zero page loss / no 404 risk:**
- **Default all-locale build** (`BUILD_LOCALE` unset): `shouldEmitPath` returns `true` for every path (`EMIT_ALL_LOCALES`) → **literal no-op**, identical full-tree coverage. Dev/vitest unaffected.
- The leak-guard's contract — *delete `dist/images/blog` only if no walked file still references it same-origin* — is preserved: every file a shard **ships** (its owned locale + the shared root) is still walked and leak-scanned. The only files now skipped are non-owned-locale subtrees that `prune-locale-shard.mjs` deletes anyway, so they never ship from this shard and a stray ref in them cannot 404.
- The `dist/images/blog` deletion loop is a separate explicit `readdirSync(blogDir)`, unaffected by the walk gate.

**Saving:** ~120–150s off the `it` shard (the matrix wall-clock gate / time-to-live), proportional on en/de/fr.

## Non implementato (ancora)

- **Sibling files sharing `localeEmitFilter`/`shouldEmitPath`/`EMIT_ALL_LOCALES`** (flagged by `check-sibling-patterns`): `batchWrite.ts`, `relatedSearchClustersPlugin.ts`, `hreflangPostprocessPlugin.ts`, `jobOgImagesPlugin.ts`, `orphanQueryLandingPlugin.ts`, etc. **Not the same antipattern** — they already use the locale filter for their own emit/write gating; none performs an ungated full-`dist` walk like this plugin did. No change needed.
- **Other measured cross-shard redundancy** (separate concerns → separate PRs): related-search cluster prep recomputed 4× (`RELATED_SEARCH_CLUSTERS_NO_CACHE=1`, ~245s — hoist into `prep` job); `validate-dist` git-clone rehydrate (~14min — same-run artifact download). Per-locale render-gating of the small ungated plugins (fuel/health/etc.) is **deferred**: verified (fuel-daily) that several fuse their shared-sitemap push with the per-locale render (`countHtmlBodyWords` gate), so a naive loop gate would drop en/de/fr sitemap URLs — each needs individual restructuring and the payoff is small (≤27s each).

## Test plan

- [ ] vitest CI green (gate is a no-op without `BUILD_LOCALE`).
- [ ] Post-merge: next matrix deploy's `validate-dist` / `validate-live` confirm no `/images/blog/*` 404 on live `it`+shared and on en/de/fr shards (the leak-guard + CDN rewrite still cover every shipped file).
- [ ] Post-merge: `blog-image-cdn-finalize` step time drops on the build-locale (it) job log.