### PR TITLE
fix(ads): fill desktop side-rail GPT ads — init GPT framework before display

### DIFF
--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -133,7 +133,16 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
     const defineAndDisplay = () => {
       if (defined) return;
       defined = true;
-      ensureGptScript();
+      // Queue the GPT framework (enableServices) BEFORE this slot's display().
+      // An above-the-fold slot (e.g. the article side-rails on ≥1400px) has its
+      // IntersectionObserver fire on mount — before the idle-deferred
+      // initGptFramework() above runs — so without this its display() would be
+      // queued ahead of enableServices() and pubads would never fetch: the slot
+      // stays empty with zero gampad/ads requests (observed live). initGptFramework
+      // is idempotent (guarded), so slots that intersect after the idle init are
+      // unaffected; this only repairs the early-intersect race. It also calls
+      // ensureGptScript() internally, so the script is still requested here.
+      initGptFramework();
       const gt = gtag();
       gt.cmd.push(() => {
         try {

--- a/index.html
+++ b/index.html
@@ -121,6 +121,12 @@
     <meta name="google-adsense-account" content="ca-pub-8628054934855353">
     <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
     <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com">
+    <!-- Google Publisher Tag (GPT) host — serves the desktop article side-rail
+         half-page ad units (components/shared/GptAdSlot.tsx loads gpt.js +
+         pubads_impl.js from here). Preconnect warms the TLS/DNS so the lazy,
+         idle-deferred rail ads fill faster once a rail scrolls into view. -->
+    <link rel="preconnect" href="https://securepubads.g.doubleclick.net" crossorigin>
+    <link rel="dns-prefetch" href="https://securepubads.g.doubleclick.net">
     <!-- Funding Choices ad-recovery messaging (loaded post-LCP via deferred script
          below). Preconnect saves ~150-300ms on mobile when the script is eventually
          fetched, without contributing to LCP blocking. -->


### PR DESCRIPTION
## Implementato

- **Root-cause fix delle rail ads laterali vuote (desktop ≥1400px).** `components/shared/GptAdSlot.tsx`: `defineAndDisplay()` ora chiama l'idempotente `initGptFramework()` **prima** di accodare `gt.display()`. Per uno slot above-the-fold (le side-rail articolo/job-detail su `xlw`) l'`IntersectionObserver` scatta su mount — **prima** dell'`initGptFramework()` deferito a `requestIdleCallback`/`setTimeout` — quindi `display()` finiva in coda `gt.cmd` **prima** di `enableServices()`, e pubads non faceva mai fetch. Verificato dal vivo: gpt.js + pubads_impl.js caricati, slot in viewport (top 221px), ma **zero richieste `gampad/ads`** e tutti i `gpt-slot-*` con `height:0`/nessun iframe dopo 4s. Ora `enableServices()` è garantito prima di `display()` a prescindere dal timing di intersect; fix nel motore GPT condiviso → copre rail + PoC slot. `initGptFramework()` chiama già `ensureGptScript()`, quindi lo script resta richiesto qui.
- **Preconnect al GPT host.** `index.html`: aggiunto `preconnect` + `dns-prefetch` a `https://securepubads.g.doubleclick.net` (host di `gpt.js` + `pubads_impl.js`), finora privo di preconnect. Scalda TLS/DNS → fill più rapido delle rail lazy una volta in viewport.

### Test
- [x] `tests/article-ad-slots.test.ts` + `tests/adsense-lazy-load.test.ts` verdi (22/22) nel worktree.
- [x] Diagnosi live su `frontaliereticino.ch/articoli-frontaliere/stipendio-netto-frontaliere-2026/` @1500px che ha provato la race (0 `gampad/ads`).
- [ ] Verifica live post-deploy ≥1400px: le side-rail devono mostrare creatività riempite (>1 `gampad/ads` request, iframe presenti). Non verificabile pre-merge (richiede il deploy del bundle).

## Non implementato (ancora)

- **Layout colonna centrale invariato.** Il problema visivo "pagina centrale" era causato dalle due gutter da 300px **vuote** (rail non riempite): il fix del caricamento ads le popola e risolve la presentazione. La struttura centrale (`main !w-[95%] max-w-[2400px]` + grid `[300px minmax(0,1fr) 300px]` in BlogArticles/JobBoard) è già correttamente vincolata e centrata (verificato: content column ~770px @1500px, leggibile); toccarla rischierebbe di regredire il layout appena spedito (#2584/#2592) → fuori scope, nessun cambiamento.
- **No-fill GAM residuo.** Se dopo questo fix una rail resta vuota è inventory/demand GAM (non più ordering), fuori dal controllo del codice; `collapseEmptyDivs(true)` già la collassa senza CLS.
- **Riduzione del timeout `requestIdleCallback` (3000ms) per l'init framework.** Posposto: il fix di ordering rende l'init immediato sul primo slot che interseca, quindi il timeout non gate più il fill above-fold; abbassarlo globalmente è un tradeoff CWV non necessario.

Revert-trigger: se il prossimo deploy mostra regressione CWV (LCP/INP) sulle pagine con rail o le rail restano vuote con `gampad/ads` falliti → revert.