### PR TITLE
feat(404): full-content 200 pages for IT canton-drift orphans

### DIFF
--- a/build-plugins/cfHot404BridgePlugin.ts
+++ b/build-plugins/cfHot404BridgePlugin.ts
@@ -154,6 +154,7 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
         .slice(0, MAX_EMIT);
 
       let emitted = 0;
+      let emittedFull = 0;
       let skippedExisting = 0;
       let skippedUnresolved = 0;
 
@@ -173,6 +174,39 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
 
         const to = withSlash(resolution.canonicalPath);
         const kind = resolution.kind;
+
+        // Canton-drift recovery as a REAL 200 page WITH the job's full content.
+        // For an IT canton-moved orphan (the apex is NOT behind the locale Worker,
+        // so without this it only ever gets a soft-404/JS redirect or a thin
+        // bridge), copy the slug's already-built canonical page HTML verbatim and
+        // force noindex. The copied HTML's own <link rel=canonical>/og:url/hreflang
+        // already point at the current canton, so ranking signals consolidate
+        // there while this URL serves a full 200 instead of a 404. en/de/fr are
+        // intentionally left to the thin bridge below: the locale Worker 301s them
+        // at the edge (strictly better than a duplicate 200). Falls through to the
+        // thin bridge if the canonical file isn't on disk (e.g. job pruned).
+        const isItPath = !/^\/(en|de|fr)\//.test(from);
+        if (kind === 'canton-moved' && isItPath) {
+          const canonFile = path.join(distDir, to.slice(1), 'index.html');
+          if (fs.existsSync(canonFile)) {
+            let canonHtml = fs.readFileSync(canonFile, 'utf-8');
+            canonHtml = /<meta\s+name=["']robots["']/i.test(canonHtml)
+              ? canonHtml.replace(
+                  /<meta\s+name=["']robots["'][^>]*>/i,
+                  '<meta name="robots" content="noindex,follow">',
+                )
+              : canonHtml.replace(
+                  /<head(\s[^>]*)?>/i,
+                  (m) => `${m}<meta name="robots" content="noindex,follow">`,
+                );
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(path.join(outDir, 'index.html'), canonHtml, 'utf-8');
+            emitted++;
+            emittedFull++;
+            continue;
+          }
+        }
+
         // canton-moved: the canonical IS the same job at its current canton path
         // (a real 200 page), so word the bridge as a relocation and point the CTA
         // straight at it. Other kinds land on a listing/landing.
@@ -198,7 +232,8 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
         const heapMb = Math.round(process.memoryUsage().heapUsed / 1048576);
         console.log(
           `\x1b[36m[cf-hot-404-bridge]\x1b[0m Recovered ${emitted} Cloudflare/GSC-confirmed 404s ` +
-            `(cap ${MAX_EMIT}; ${skippedExisting} already had richer pages, ${skippedUnresolved} unresolved). ` +
+            `(${emittedFull} full-content canton-moved copies, ${emitted - emittedFull} thin bridges; ` +
+            `cap ${MAX_EMIT}; ${skippedExisting} already had richer pages, ${skippedUnresolved} unresolved). ` +
             `[mem] heapUsed=${heapMb}MB after emit.`,
         );
       }


### PR DESCRIPTION
## Implementato

Trasforma il recupero dei **canton-drift orphan IT** da thin bridge / soft-404 JS in **vere pagine 200 con contenuto pieno**.

**Contesto:** dopo #2645 gli orfani TI entrano in `cf-hot-404s.json` e `cfHot404BridgePlugin` li recuperava, ma come **thin bridge noindex** (~2KB stub) — e l'apex IT non è dietro il Worker, quindi l'unica alternativa era il soft-redirect 404.html (status 404). L'utente vuole **vere pagine 200 con contenuto**.

**Fix (`build-plugins/cfHot404BridgePlugin.ts`):** per un orphan **IT** di kind `canton-moved` (lo slug ha una pagina canonica reale già emessa in dist), copio l'**HTML canonico pieno verbatim** sulla URL orfana e forzo `noindex`. La pagina copiata ha già `<link rel=canonical>`/og:url/hreflang verso il **cantone corrente** → i segnali SEO consolidano lì, mentre la URL orfana serve un **200 con contenuto reale** invece di un 404. Scelta scope utente: **tutti i ~65k orfani IT canton-moved catturati** (dist +~0.5-0.8GB su un sito già multi-GB).

**Perché copiare (non re-render):** la canonica è già stata renderizzata nello shard IT (gira prima, `enforce:'post'`) e ha **già passato tutti i gate SEO** (structured data, hreflang, ecc.) byte-per-byte → zero rischio gate, zero costo di render, **heap-safe** (un file in streaming alla volta). Bounded dal cap `MAX_EMIT` esistente.

**en/de/fr restano thin bridge** di proposito: il locale Worker li 301a all'edge (meglio di un 200 duplicato). Fallback al thin bridge se la canonica non è su disco (job pruned). Emettere il 200 statico **disattiva automaticamente** il path 404.html per quegli URL.

**REVERT-TRIGGER (mem/disco non validabili su `pull_request` — full SSG solo post-merge su `main`):** se il prossimo deploy OOMa (exit 143) o sfora i limiti dimensione Pages/wall-time → ripristina il thin bridge (rimuovi il branch `canton-moved && isItPath`) o abbassa `CF_HOT_404_MAX`.

## Non implementato (ancora)

- **Coda lunga non catturata**: orfani a bassissimo traffico ruotati fuori dalla CF query (non in `cf-hot-404s.json`) restano serviti dal 404.html JS (status 404). Non enumerabili staticamente; restano UX-ok via redirect dinamico.
- **Indicizzazione**: le pagine copiate sono `noindex` (scelta utente) → recuperano UX + status 200, non equity-index. Variante index+canonical disponibile come follow-up se si vuole spingere l'equity SEO.
- **en/de/fr full-content**: non implementato (Worker 301 è preferibile; emettere 200 duplicati li ombreggerebbe peggiorando la SEO).
- **Relazione #2626** (richer soft-landing TI via compat-merge, noindex): complementare. Per i path TI che #2626 emette prima (jobsSeoPagesPlugin, gap-fill `existsSync`), quelli vincono; questo PR copre il **non-TI** (404 dominante) + i TI non coperti da #2626. Nessun doppio-emit (gap-fill).
- **Sibling `MAX_EMIT`** (`deploy.yml` `CF_HOT_404_MAX`, `build-cf-hot-404s.mjs` `MAX_PATHS`): non modificato il valore (solo usato), nessun antipattern condiviso.
