### PR TITLE
fix(email): drop Maileroo from cascade — unauthenticated, lands in spam

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -44,7 +44,13 @@ const PROVIDERS = [
   { id: 'resend',   dailyLimit: 100, monthlyLimit: 3000  },
   { id: 'mailjet',  dailyLimit: 200, monthlyLimit: 6000  },
   { id: 'mailtrap', dailyLimit: 150, monthlyLimit: 4000  },
-  { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
+  // maileroo: DISABLED — its sending domain has no DKIM published for
+  // frontaliereticino.ch, so with DMARC at p=quarantine its mail fails
+  // authentication and lands in spam (Gmail "non autenticato"). Every other
+  // provider is DMARC-aligned (mailgun/resend/mailjet DKIM + mailtrap DKIM CNAMEs
+  // + cloudflare cf2024-1 DKIM). Re-enable only after publishing Maileroo's DKIM
+  // record for the domain (Maileroo dashboard → Domains → DNS).
+  // { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
   // Cloudflare Email Service: limit is MONTHLY (3000/mo included on Workers Paid),
   // there is no documented per-day cap. dailyLimit is the 3000/30 ≈ 100/day spread
   // so the in-memory guard keeps a single day from burning a disproportionate


### PR DESCRIPTION
## Problema

Le email job-alert/newsletter possono finire in **spam** quando inviate via un provider del cascade che non è **DMARC-allineato**. Con DMARC a `p=quarantine`, un provider senza DKIM pubblicato per `frontaliereticino.ch` fallisce l'autenticazione → Gmail "messaggio non autenticato" → spam. **Maileroo** è in questa condizione (nessun DKIM pubblicato) e il suo sending-key non espone un'API di gestione domini, quindi il record DKIM non è provisionabile da codice.

Contesto: questa è la chiusura dell'indagine deliverability partita dal test send finito in spam (DKIM Mailgun mancante). In questa sessione, lato DNS Cloudflare, sono stati già sistemati: DKIM Mailgun (`email._domainkey`), DKIM CNAMEs Mailtrap (`rwmt1/rwmt2._domainkey`), e `include:mailgun.org` aggiunto all'SPF root. Restava solo Maileroo non autenticabile.

## Implementato

- `scripts/lib/email-cascade.mjs`: disabilitato `maileroo` dal `PROVIDERS` (commentato, come già `unosend`), con commento che spiega il perché e come riabilitarlo (pubblicare il DKIM dal dashboard Maileroo). Il cascade resta interamente DMARC-allineato: **mailgun, resend, mailjet, mailtrap, cloudflare** (cf2024-1). Capacità ~550 email/giorno autenticate, sufficiente per il volume attuale. Webhook/attribution Maileroo restano intatti (gestiscono invii passati).

## Non implementato (ancora)

- **DKIM Maileroo**: richiede azione manuale nel dashboard Maileroo (Domains → DNS) per ottenere il record, poi ri-abilitare la riga. Fuori dalla portata code-only.
- **Modifiche DNS di questa sessione** (DKIM Mailgun/Mailtrap, SPF) applicate direttamente via Cloudflare API, non in questo repo (il DNS non è gestito da file qui).
- **Fix conflitto CNAME+TXT su `email.frontaliereticino.ch`**: lasciato — i TXT presenti includono verification record (yahoo/Mailgun) e toccarli rischia di rompere verifica/tracking; non impatta l'autenticazione (gestita da `email._domainkey`).