### PR TITLE
fix(layout): narrow SPA tool side-rails to 160px — uncramp the desktop calculator

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1730,6 +1730,12 @@ const App: React.FC = () => {
  // them for side-rails). Excludes tabs that own their rails (blog→BlogArticles,
  // job-board→JobBoard) or are full-width (admin). Below xlw / on excluded tabs
  // the wrapper is `display:contents`, so layout is byte-identical to before.
+ // Rails here are NARROW (160px, 160x600 skyscraper) — not the 300px half-page
+ // rails of blog/job-detail. These tabs are wide interactive tools (calculator
+ // form | results), not single-column reading content, so a 300px×2 + gap
+ // reservation squeezed the centre cell to ~840px at 1500px and cramped the
+ // form/results columns (the calculator was unreadable on desktop). 160px keeps
+ // the centre ~1120px at 1500px while still serving side-rail ads ≥1400px.
  const sideRailEligible = !staticOverlay && !['admin', 'blog', 'job-board'].includes(activeTab);
 
  return (
@@ -2337,7 +2343,7 @@ const App: React.FC = () => {
   * sitemap links, weekly employers teaser) regardless of overlay mode.
   */}
  {!staticOverlay && (
- <div className={sideRailEligible ? 'ft-rail-grid-spa contents xlw:grid xlw:flex-grow xlw:grid-cols-[300px_minmax(0,1fr)_300px] xlw:gap-6' : 'contents'}>
+ <div className={sideRailEligible ? 'ft-rail-grid-spa contents xlw:grid xlw:flex-grow xlw:grid-cols-[160px_minmax(0,1fr)_160px] xlw:gap-6' : 'contents'}>
  {sideRailEligible && (
  <aside className="ft-rail-aside hidden xlw:flex xlw:flex-col">
  <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>


### PR DESCRIPTION
## Implementato

- **Calcolatore (e tab tool SPA) leggibili su desktop ≥1400px.** `App.tsx`: la grid side-rail SPA passa da `xlw:grid-cols-[300px_minmax(0,1fr)_300px]` a `xlw:grid-cols-[160px_minmax(0,1fr)_160px]`. Le due rail half-page da 300px + gap riservavano 648px, schiacciando il cell centrale a **~840px @1500px**: il calcolatore (UI wide `form | risultati`, non lettura monocolonna) collassava il pannello input a **~200px** e l'analisi comparativa (doppia colonna Svizzera/Italia) a **~530px** — illeggibile su desktop. Con rail da 160px (unit skyscraper 160x600) il centro resta **~1120px @1500px** → form **~241px**, risultati **~771px**, dual-comparison comoda. Le rail ad continuano a servire su ogni tab tool ≥1400px.
- Copre tutti i tab `sideRailEligible` (calcolatore, statistiche, guida, confronti, vita-quotidiana, ecc.), non solo il calcolatore — stessa classe di cramping.

### Verifica (live, dom-injection del fix prima del commit)
- [x] Diagnosi live `frontaliereticino.ch/calcola-stipendio/` @1500px: cell centrale 844px, form ~200px (cramped), confermato visivamente.
- [x] Preview del fix via override `grid-template-columns:160px...` sul DOM live: cell 1124px, form 241px, results 771px, screenshot con form + dual-comparison ben visualizzati.
- [x] `tests/regression/static-seo-rail-ads.test.ts`, `tests/article-ad-slots.test.ts`, `tests/app-no-blanket-no-auto-ads.test.ts`, `tests/adsense-lazy-load.test.ts` verdi.
- [ ] Verifica live post-deploy ≥1400px (calcolatore con rail 160px + creatività 160x600). Non verificabile pre-merge.

## Non implementato (ancora)

- **Rail blog/job-detail invariate a 300px.** `BlogArticles.tsx` e `JobBoard.tsx` ospitano contenuto di lettura (~770px) dove la half-page 300px premium non strozza nulla ed è il design voluto (#2584/#2592). Sibling giustificato: classe diversa (reading-content vs tool wide).
- **Grid SEO statica (`buildSeoPageHtml`/`htmlTemplate.ts`) invariata a 300px.** Pagine prose centrate ~1120px, non cramped; il test regression le presidia a 300px. Fuori scope.
- **Proporzioni interne del calcolatore (`col-span-3/9`) invariate.** Il root-cause era la larghezza del container (rail), non lo split form/risultati; allargando il centro le proporzioni esistenti rendono già bene. Toccarle = churn non necessario.
- **CPM 160x600 < 300x600.** Tradeoff accettato: usabilità del tool (richiesta esplicita utente) > CPM rail supplementari; AdSense Auto Ads (~95% revenue) intatte.

Revert-trigger: se il prossimo deploy mostra le rail tool che non servono creatività o regressione layout calcolatore ≥1400px → revert.