### PR TITLE
fix(calc): widen form column to 4/12 — CHF income input clipped on small desktops

### DIFF
--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -161,14 +161,19 @@ export default function CalcolatoreTabContent() {
  </Suspense>
  </div>
 
- {/* Desktop: side-by-side layout */}
+ {/* Desktop: side-by-side layout. Form holds 4/12 (33%) across all desktop
+     tiers — it was xl:col-span-3 (25%), but on desktop the calculator now
+     always sits inside the side-rail grid (sideRailEligible), so 25% squeezed
+     the form below the width its CHF income input + steppers need and clipped
+     them on narrower desktops. 4/12 keeps the form usable; results take 8/12,
+     still ample for the dual Svizzera|Italia comparison. */}
  <div className="hidden md:grid grid-cols-12 gap-6 h-full">
- <div className="md:col-span-4 lg:col-span-4 xl:col-span-3 h-full">
+ <div className="md:col-span-4 lg:col-span-4 xl:col-span-4 h-full">
  <Suspense fallback={<SkeletonInputCard />}>
  <InputCard inputs={inputs} setInputs={setInputs} onCalculate={handleCalculate} result={result} />
  </Suspense>
  </div>
- <div className={`md:col-span-8 lg:col-span-8 xl:col-span-9 h-full transition-opacity duration-200${isResultStale ? ' opacity-50' : ''}`}>
+ <div className={`md:col-span-8 lg:col-span-8 xl:col-span-8 h-full transition-opacity duration-200${isResultStale ? ' opacity-50' : ''}`}>
  {result && (
  <Suspense fallback={<LazyFallback />}>
  <ResultsView result={result} inputs={inputs} />


### PR DESCRIPTION
## Implementato

- **Input "REDDITO LORDO ANNUO" del calcolatore non più tagliato su desktop piccoli.** `components/tabs/CalcolatoreTabContent.tsx`: la colonna form passa da `xl:col-span-3` (25%) a `xl:col-span-4` (33%) su tutti i tier desktop; i risultati da `xl:col-span-9` a `xl:col-span-8`. Su desktop il calcolatore vive sempre dentro la grid side-rail (`sideRailEligible`), quindi il 25% schiacciava il form a **~227px @1440px** e ritagliava l'input CHF + gli stepper +/− (segnalato live con screenshot). Con il form a 33% + le rail da 160px (#2663) il form è **~310px @1440px** → input CHF `75.000`, stepper, e preset 50k/75k/100k/120k entrano tutti; i risultati a ~645px reggono comodamente la doppia colonna Svizzera|Italia.

### Verifica
- [x] Preview live del fix completo (rail 160px + col-span-4) via DOM-injection @1440px: form 227→310px, results 728→645px, screenshot con input CHF + stepper completi e non tagliati.
- [ ] Verifica live post-deploy ≥1400px su `frontaliereticino.ch/` (form leggibile, input non clipped). Non verificabile pre-merge.

## Non implementato (ancora)

- **Mobile invariato.** Sotto `md` (768px) il calcolatore usa il layout stacked `MobileCalcLayout` (results-first), già corretto — il fix riguarda solo il side-by-side desktop.
- **Proporzioni results interne invariate.** A 8/12 la doppia colonna comparativa ha ~315px per lato @1440px, sufficiente; nessun ritocco ulteriore necessario.
- **Sibling `services/TabContentContext.ts` (flag check `isResultStale`)** non è lo stesso antipattern (è il provider del flag, non una grid col-span) → fuori scope.

Dipende da #2663 (rail SPA 160px, già merged): i due fix insieme danno la larghezza form comoda. Revert-trigger: se il prossimo deploy mostra il form calcolatore ancora clipped o i risultati comparativi cramped ≥1400px → rivedere le proporzioni col-span.