### PR TITLE
fix(traffic-freshness): gate stale issue on ≥08:00 UTC, end #2617 false page

### DIFF
--- a/.github/workflows/traffic-data-freshness.yml
+++ b/.github/workflows/traffic-data-freshness.yml
@@ -24,13 +24,35 @@ jobs:
         id: check
         run: |
           CURRENT_HOUR=$(date -u +%H)
-          # Active window 05:00-20:00 UTC (covers morning commute ≈ 07:00 CEST).
-          # Overnight is intentionally skipped to conserve HERE quota.
+          # SELF-HEAL window 05:00-20:00 UTC (covers morning commute ≈ 07:00 CEST):
+          # a stale snapshot here re-dispatches the scheduler so commuters still get
+          # fresh data. Overnight is intentionally skipped to conserve HERE quota.
           if [ "$CURRENT_HOUR" -lt 5 ] || [ "$CURRENT_HOUR" -ge 20 ]; then
             echo "Outside peak hours, skipping freshness check"
             echo "STALE=false" >> "$GITHUB_OUTPUT"
             echo "AGE_MINUTES=0" >> "$GITHUB_OUTPUT"
+            echo "PAGEABLE=false" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # ISSUE-PAGEABLE window: only ≥08:00 UTC is a stale reading GUARANTEED to
+          # be a real freeze. Before 08:00 the scheduler's morning ramp (*/30 4-7)
+          # may not have LANDED yet (GitHub delivers crons 10-60+ min late), so a
+          # stale snapshot is expected lag — NOT a bug. In that window we self-heal
+          # silently and never open an issue (the cause of the #2617 false page:
+          # 674-min "stale" at 06:30 Mon after the weekend gap, before the lagged
+          # morning collection arrived). Single source of truth: isStalenessCheckActive()
+          # in scripts/check-border-data-health.mjs — the sibling watchdog was fixed
+          # the same way at 08:00 (#2587/#2599). Reusing it keeps the 08:00 boundary
+          # drift-proof by-construction (no duplicated hour literal). If the gate
+          # errors, it fails CLOSED (PAGEABLE=false) — safe: no false page, and the
+          # 6h border-watchdog backstop still catches a truly frozen pipeline.
+          if node -e "import('./scripts/check-border-data-health.mjs').then(m => process.exit(m.isStalenessCheckActive(Date.now()) ? 0 : 1)).catch(() => process.exit(1))"; then
+            echo "PAGEABLE=true" >> "$GITHUB_OUTPUT"
+            echo "In issue-pageable window (≥08:00 UTC) — a stale reading is a real freeze."
+          else
+            echo "PAGEABLE=false" >> "$GITHUB_OUTPUT"
+            echo "In commute self-heal window (05:00-08:00 UTC) — stale self-heals silently, no issue."
           fi
 
           FILE="data/border-wait-current.json"
@@ -154,8 +176,11 @@ jobs:
           done
 
       # Debounced opener: first stale reading → pending. Second consecutive → promote to confirmed.
+      # Gated on PAGEABLE so we only ever open/promote an issue ≥08:00 UTC, once the
+      # morning collection ramp has certainly landed — staleness before then is
+      # expected cron-lag, already self-healed above, and must NOT raise a page.
       - name: Open / debounce stale issue
-        if: steps.check.outputs.STALE == 'true'
+        if: steps.check.outputs.STALE == 'true' && steps.check.outputs.PAGEABLE == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REASON: ${{ steps.check.outputs.REASON }}


### PR DESCRIPTION
## Implementato

Risolve alla radice il falso-positivo `#2617` ("[pending] Traffic data freshness — 674 min stale" alle 06:30 di lunedì, auto-risanato pochi minuti dopo dal self-heal ma rimasto aperto perché il run di auto-close è stato anch'esso droppato da GitHub).

**Causa radice** = lo stesso *execution-time active-window leak* che `#2587/#2599` hanno corretto sul watchdog gemello `border-live-data-watchdog` armandolo alle 08:00 UTC. Il loop di freshness era rimasto a 05:00 per coprire il self-heal del commute mattutino (intento corretto), ma così la finestra 05:00-08:00 lasciava aprire **issue rumorose**: la rampa mattutina dello scheduler (`*/30 4-7`) viene consegnata in ritardo da GitHub (cron lag 10-60+ min), quindi lo snapshot è legittimamente vecchio finché la collection ritardata non atterra — specie al primo run dopo il gap del weekend.

**Fix** in `.github/workflows/traffic-data-freshness.yml` — separati i due concern:
- **SELF-HEAL window 05:00-20:00 UTC invariata**: uno snapshot stale ridispatcha comunque `traffic-scheduler`, i pendolari ottengono dati freschi.
- **ISSUE-PAGEABLE window ≥08:00 UTC**: lo step "Open / debounce stale issue" ora è gated su un nuovo output `PAGEABLE` → si apre/promuove un'issue solo quando la rampa mattutina è certamente atterrata, cioè quando lo stale è un *vero* freeze.
- Il confine 08:00 **riusa `isStalenessCheckActive()`** da `scripts/check-border-data-health.mjs` via `node -e import()` → unica sorgente di verità, nessun literal d'ora duplicato (AGENTS.md #6), e **fail-closed** in caso di errore (`PAGEABLE=false` → nessun falso page; il backstop 6h del border-watchdog resta a coprire i freeze reali).

Verificato in locale:
- `python3 yaml.safe_load` → YAML valido.
- Gate sotto `bash -eo pipefail`: 06:30 UTC → `PAGEABLE=false` (no page), 08:30 UTC → `PAGEABLE=true` (page); l'`if` consuma l'exit di node → `set -e` non aborta.
- `npx vitest run check-border-data-health` → 23/23 verdi (`isStalenessCheckActive` invariata).

Closes #2617

## Non implementato (ancora)

- **`scripts/check-border-data-health.mjs` e `border-live-data-watchdog.yml`** (flaggati da `check-sibling-patterns.mjs` come gemelli sui token `check-border-data-health` / `isStalenessCheckActive`): **non toccati di proposito** — sono la *sorgente di verità* che questa PR riusa, non un antipattern duplicato. Lo script è già armato a 08:00 (#2599) e il watchdog vi delega; modificarli reintrodurrebbe il drift che questa PR elimina.
- **Auto-close dell'issue `#2617` già aperta**: chiusa manualmente in questo turno (il run di freshness era droppato); il nuovo gate previene la *riapertura*, non richiede modifiche allo step di auto-close (resta su `STALE=='false'`, corretto).
- **Affidabilità dello scheduling cron di GitHub** (cron droppati/laggati): fuori scope — non correggibile lato repo; il fix rende il watchdog *robusto* al lag invece di tentare di eliminarlo.