### PR TITLE
feat(outreach): per-company stats proof page + admin insights panel

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -50,6 +50,7 @@ const ContactPage = lazyRetry(() => import('@/components/pages/ContactPage'));
 const PublisherPublishPage = lazyRetry(() => import('@/components/pages/PublisherPublishPage'));
 const PublisherDashboardPage = lazyRetry(() => import('@/components/pages/PublisherDashboardPage'));
 const ForEmployersPage = lazyRetry(() => import('@/components/pages/ForEmployersPage'));
+const EmployerInsightsPage = lazyRetry(() => import('@/components/pages/EmployerInsightsPage'));
 const PartnerServices = lazyRetry(() => import('@/components/pages/PartnerServices'));
 const DonationBanner = lazyRetry(() => import('@/components/shared/DonationBanner'));
 const ConsultingPage = lazyRetry(() => import('@/components/pages/ConsultingPage'));
@@ -2459,6 +2460,8 @@ const App: React.FC = () => {
  <div className="max-w-7xl mx-auto">
  <ForEmployersPage />
  </div>
+ ) : activeTab === 'employer-insights' ? (
+ <EmployerInsightsPage />
  ) : activeTab === 'partners' ? (
  <div className="max-w-7xl mx-auto">
  <PartnerServices />

--- a/components/insights/TopAdsChart.tsx
+++ b/components/insights/TopAdsChart.tsx
@@ -1,0 +1,67 @@
+/**
+ * TopAdsChart — horizontal animated bar chart of an employer's top ads by views.
+ *
+ * Pure CSS/flex bars (no charting lib, no new deps). Bars grow from 0 → their
+ * share-of-max width when the chart scrolls into view (`useReveal`). Each row is
+ * an accessible group: title + view count are real text (not just visual), and
+ * the bar carries an aria-label so screen-reader users get the same data.
+ *
+ * Colour: semantic chart tokens only (`--color-chart-area` / `--color-chart-line`).
+ * Reduced-motion users get bars at full width instantly (transition is disabled
+ * globally via the prefers-reduced-motion media query in index.css, and reveal
+ * fires immediately).
+ */
+import React from 'react';
+import type { EmployerAd } from '@/services/employerInsights';
+import { useReveal } from './useReveal';
+
+interface TopAdsChartProps {
+  ads: EmployerAd[];
+  /** How many top rows to show. Default 10. */
+  limit?: number;
+}
+
+const nf = new Intl.NumberFormat('it-IT');
+
+export function TopAdsChart({ ads, limit = 10 }: TopAdsChartProps): React.ReactElement | null {
+  const { ref, inView } = useReveal<HTMLDivElement>();
+  const rows = ads.slice(0, limit);
+  if (rows.length === 0) return null;
+
+  const max = Math.max(...rows.map((a) => a.views), 1);
+
+  return (
+    <div ref={ref}>
+      <ul className="space-y-3" aria-label="Annunci più visti">
+        {rows.map((ad, i) => {
+          const pct = Math.max((ad.views / max) * 100, 2); // floor so tiny bars stay visible
+          return (
+            <li key={ad.slug || ad.path || i} className="group">
+              <div className="flex items-baseline justify-between gap-3 mb-1">
+                <span className="text-sm font-medium text-body truncate">{ad.title}</span>
+                <span className="text-sm font-bold text-strong tabular-nums shrink-0">
+                  {nf.format(ad.views)}
+                </span>
+              </div>
+              <div
+                className="h-3 w-full rounded-full bg-surface-alt overflow-hidden"
+                role="img"
+                aria-label={`${ad.title}: ${nf.format(ad.views)} visualizzazioni`}
+              >
+                <div
+                  className="h-full rounded-full bg-accent transition-[width] duration-1000 ease-out"
+                  style={{
+                    width: inView ? `${pct}%` : '0%',
+                    transitionDelay: `${i * 70}ms`,
+                  }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default TopAdsChart;

--- a/components/insights/TrendSparkline.tsx
+++ b/components/insights/TrendSparkline.tsx
@@ -1,0 +1,112 @@
+/**
+ * TrendSparkline — animated weekly-views area + line chart, hand-rolled SVG
+ * (no charting lib, no new deps).
+ *
+ * "Wow" detail: the line path "draws in" left→right via stroke-dasharray /
+ * stroke-dashoffset, and the area gradient fades up, both triggered when the
+ * chart scrolls into view (`useReveal`). A pulsing end dot marks the latest
+ * week so the eye lands on "now".
+ *
+ * Responsive: the SVG uses a viewBox + preserveAspectRatio="none" so it scales
+ * full-width on mobile. Colours come from semantic chart tokens
+ * (`--color-chart-line` / `--color-chart-area` / `--color-chart-dot`) — no hex.
+ *
+ * Accessibility: role="img" + a descriptive aria-label summarising the trend
+ * (first→last week, direction); reduced-motion users see the final drawn path
+ * instantly (dashoffset 0 + reveal fires immediately, transitions disabled in CSS).
+ */
+import React, { useId } from 'react';
+import type { EmployerInsights } from '@/services/employerInsights';
+import { useReveal } from './useReveal';
+
+interface TrendSparklineProps {
+  trend: EmployerInsights['trend'];
+  /** SVG coordinate height. Width is a fixed 100-unit viewBox (scales to container). */
+  height?: number;
+}
+
+const nf = new Intl.NumberFormat('it-IT');
+
+export function TrendSparkline({ trend, height = 48 }: TrendSparklineProps): React.ReactElement | null {
+  const { ref, inView } = useReveal<HTMLDivElement>();
+  const gradId = useId();
+
+  if (!trend || trend.length < 2) return null;
+
+  const W = 100;
+  const H = height;
+  const pad = 4;
+  const values = trend.map((p) => p.views);
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const span = Math.max(max - min, 1);
+
+  const x = (i: number) => pad + (i / (trend.length - 1)) * (W - pad * 2);
+  const y = (v: number) => H - pad - ((v - min) / span) * (H - pad * 2);
+
+  const linePts = trend.map((p, i) => `${x(i).toFixed(2)},${y(p.views).toFixed(2)}`);
+  const linePath = `M ${linePts.join(' L ')}`;
+  const areaPath = `${linePath} L ${x(trend.length - 1).toFixed(2)},${H - pad} L ${x(0).toFixed(2)},${H - pad} Z`;
+
+  const first = trend[0].views;
+  const last = trend[trend.length - 1].views;
+  const dir = last > first ? 'in crescita' : last < first ? 'in calo' : 'stabile';
+  const ariaLabel = `Andamento visualizzazioni settimanali, ${dir}: da ${nf.format(first)} a ${nf.format(last)} nell'ultima settimana.`;
+
+  const endX = x(trend.length - 1);
+  const endY = y(last);
+
+  return (
+    <div ref={ref} className="w-full">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        className="w-full h-16 sm:h-20"
+        role="img"
+        aria-label={ariaLabel}
+      >
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--color-chart-area)" stopOpacity="0.55" />
+            <stop offset="100%" stopColor="var(--color-chart-area)" stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        {/* Area fill — fades up on reveal */}
+        <path
+          d={areaPath}
+          fill={`url(#${gradId})`}
+          style={{ opacity: inView ? 1 : 0, transition: 'opacity 900ms ease-out 250ms' }}
+        />
+        {/* Line — draws in left→right */}
+        <path
+          d={linePath}
+          fill="none"
+          stroke="var(--color-chart-line)"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          pathLength={1}
+          style={{
+            strokeDasharray: 1,
+            strokeDashoffset: inView ? 0 : 1,
+            transition: 'stroke-dashoffset 1200ms cubic-bezier(0.16, 1, 0.3, 1)',
+          }}
+        />
+        {/* End dot — pulses to draw the eye to "now" */}
+        <circle
+          cx={endX}
+          cy={endY}
+          r={2.4}
+          fill="var(--color-chart-dot)"
+          vectorEffect="non-scaling-stroke"
+          style={{ opacity: inView ? 1 : 0, transition: 'opacity 400ms ease-out 1100ms' }}
+        >
+          <animate attributeName="r" values="2.4;3.6;2.4" dur="1.8s" repeatCount="indefinite" />
+        </circle>
+      </svg>
+    </div>
+  );
+}
+
+export default TrendSparkline;

--- a/components/insights/useReveal.ts
+++ b/components/insights/useReveal.ts
@@ -1,0 +1,54 @@
+/**
+ * useReveal — IntersectionObserver-based scroll-reveal + "in-view" trigger.
+ *
+ * Returns a ref to attach to the element and a boolean that flips to `true` the
+ * first time the element scrolls into view (once; it never flips back). Used to
+ * (a) fade/slide elements in and (b) start chart / count-up animations only
+ * when the element is actually visible — cheaper and more "wow" than animating
+ * everything on mount.
+ *
+ * Honours `prefers-reduced-motion`: reduced-motion users (or browsers without
+ * IntersectionObserver) get `inView = true` immediately, so they see the final
+ * state with no animation and no waiting.
+ *
+ * Shared by every insights sub-component so reveal behaviour stays identical.
+ */
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export function useReveal<T extends HTMLElement = HTMLDivElement>(
+  { rootMargin = '0px 0px -10% 0px', threshold = 0.15 }: { rootMargin?: string; threshold?: number } = {},
+): { ref: RefObject<T | null>; inView: boolean } {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // No observer or reduced motion → show final state immediately.
+    if (prefersReducedMotion() || typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin, threshold },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootMargin, threshold]);
+
+  return { ref, inView };
+}

--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -8,11 +8,13 @@ import { getSerpExperimentDiagnostics } from '@/services/seoService';
 import { useAuth } from '@/services/authService';
 import { buildNewsletterPreviewHtml } from '@/services/newsletterPreview';
 import { cdnDataUrl } from '@/services/cdnDataBase';
+import { fetchAdminEmployerInsights, type EmployerInsightsRow } from '@/services/adminInsights';
 import {
  Shield, Copy, Check, ExternalLink,
  AlertTriangle, CheckCircle2, Eye,
  Mail, Users, Send, RefreshCw, ToggleLeft, ToggleRight, Database, Activity, Calendar, Terminal,
- Play, Loader2, Clock3, ListChecks, FileText, ArrowUp, ArrowDown, Search, ChevronDown, ChevronRight, RotateCcw, Zap
+ Play, Loader2, Clock3, ListChecks, FileText, ArrowUp, ArrowDown, Search, ChevronDown, ChevronRight, RotateCcw, Zap,
+ Building2, TrendingDown, UserCheck
 } from 'lucide-react';
 
 /* ─── Types ─── */
@@ -101,6 +103,7 @@ interface CrawlerSummaryRow {
 }
 
 type CrawlerSortColumn = 'title' | 'schedule' | 'lastRun' | 'total' | 'newCount' | 'updatedCount' | 'removedCount' | 'unchangedCount' | 'duration' | 'status' | 'quality';
+type InsightsSortColumn = 'companyName' | 'views' | 'candidates' | 'lost' | 'adsCount' | 'conversionRate' | 'generatedAt';
 type CrawlerSortDirection = 'asc' | 'desc';
 
 type WorkflowContext = 'jobs' | 'content' | 'seo' | 'analytics';
@@ -272,7 +275,7 @@ export default function AdminPanel() {
  const { user } = useAuth();
  const hasPreloadedWorkflowSnapshots = useRef(false);
  const [copiedCmd, setCopiedCmd] = useState(false);
- const [activeSection, setActiveSection] = useState<'newsletter' | 'owner' | WorkflowContext>('jobs');
+ const [activeSection, setActiveSection] = useState<'newsletter' | 'owner' | 'insights' | WorkflowContext>('jobs');
  const [ownerTab] = useState<'overview'>('overview');
  const [workflowStates, setWorkflowStates] = useState<Record<string, WorkflowRunState>>({});
  const [copiedAiPromptFor, setCopiedAiPromptFor] = useState<string | null>(null);
@@ -327,6 +330,15 @@ export default function AdminPanel() {
  const [parserApplyConfig, setParserApplyConfig] = useState(false);
  const [parserDispatchLoading, setParserDispatchLoading] = useState(false);
  const [parserDispatchMessage, setParserDispatchMessage] = useState<string | null>(null);
+ // Insights Aziende (employer traffic) state
+ const [insightsRows, setInsightsRows] = useState<EmployerInsightsRow[]>([]);
+ const [insightsLoading, setInsightsLoading] = useState(false);
+ const [insightsError, setInsightsError] = useState<string | null>(null);
+ const [insightsFilter, setInsightsFilter] = useState('');
+ const [insightsSort, setInsightsSort] = useState<{ column: InsightsSortColumn; direction: 'asc' | 'desc' }>({
+ column: 'views',
+ direction: 'desc',
+ });
  // Crawler table filters & expansion
  const [crawlerNameFilter, setCrawlerNameFilter] = useState('');
  const [crawlerChangeFilter, setCrawlerChangeFilter] = useState<'all' | 'new' | 'updated' | 'removed' | 'none'>('all');
@@ -493,6 +505,26 @@ export default function AdminPanel() {
  }
  })();
  return () => { cancelled = true; };
+ }, [activeSection]);
+
+ // Load employer insights when the "Insights Aziende" tab is opened.
+ const loadEmployerInsights = async () => {
+ setInsightsLoading(true);
+ setInsightsError(null);
+ try {
+ const rows = await fetchAdminEmployerInsights(user);
+ setInsightsRows(rows);
+ } catch (err) {
+ setInsightsError(err instanceof Error ? err.message : 'Errore sconosciuto');
+ } finally {
+ setInsightsLoading(false);
+ }
+ };
+
+ useEffect(() => {
+ if (activeSection !== 'insights') return;
+ loadEmployerInsights();
+ // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [activeSection]);
 
  useEffect(() => {
@@ -2710,6 +2742,68 @@ export default function AdminPanel() {
  }
  };
 
+ // ── Insights Aziende: derived rows (filter + sort) + totals ──
+ const toggleInsightsSort = (column: InsightsSortColumn) => {
+ setInsightsSort(prev =>
+ prev.column === column
+ ? { column, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+ : { column, direction: column === 'companyName' ? 'asc' : 'desc' },
+ );
+ };
+
+ const insightsFiltered = useMemo(() => {
+ const q = insightsFilter.trim().toLowerCase();
+ const filtered = q
+ ? insightsRows.filter(r =>
+ r.companyName.toLowerCase().includes(q) || r.companyKey.toLowerCase().includes(q))
+ : insightsRows;
+ const { column, direction } = insightsSort;
+ const dir = direction === 'asc' ? 1 : -1;
+ const sorted = [...filtered].sort((a, b) => {
+ switch (column) {
+ case 'companyName':
+ return a.companyName.localeCompare(b.companyName) * dir;
+ case 'generatedAt':
+ return String(a.generatedAt || '').localeCompare(String(b.generatedAt || '')) * dir;
+ case 'views':
+ return (a.totals.views - b.totals.views) * dir;
+ case 'candidates':
+ return (a.totals.candidates - b.totals.candidates) * dir;
+ case 'lost':
+ return (a.totals.lost - b.totals.lost) * dir;
+ case 'adsCount':
+ return (a.totals.adsCount - b.totals.adsCount) * dir;
+ case 'conversionRate':
+ return (a.totals.conversionRate - b.totals.conversionRate) * dir;
+ default:
+ return 0;
+ }
+ });
+ return sorted;
+ }, [insightsRows, insightsFilter, insightsSort]);
+
+ const insightsTotals = useMemo(() => insightsRows.reduce(
+ (acc, r) => {
+ acc.views += r.totals.views;
+ acc.candidates += r.totals.candidates;
+ acc.lost += r.totals.lost;
+ return acc;
+ },
+ { views: 0, candidates: 0, lost: 0 },
+ ), [insightsRows]);
+
+ const formatInsightsDate = (iso: string | null): string => {
+ if (!iso) return '—';
+ const d = new Date(iso);
+ if (Number.isNaN(d.getTime())) return '—';
+ return d.toLocaleDateString('it-IT', { day: 'numeric', month: 'short', year: 'numeric' });
+ };
+
+ const insightsSortIndicator = (column: InsightsSortColumn): 'ascending' | 'descending' | 'none' =>
+ insightsSort.column === column
+ ? (insightsSort.direction === 'asc' ? 'ascending' : 'descending')
+ : 'none';
+
  return (
  <div className="space-y-6">
  {/* Header */}
@@ -2732,6 +2826,7 @@ export default function AdminPanel() {
  { id: 'content' as const, label: 'Contenuti', icon: FileText },
  { id: 'seo' as const, label: 'SEO/Qualità', icon: Shield },
  { id: 'analytics' as const, label: 'Dati', icon: Database },
+ { id: 'insights' as const, label: 'Insights Aziende', icon: Building2 },
  { id: 'newsletter' as const, label: 'Newsletter', icon: Mail },
  ].map(tab => {
  const summary = ['jobs', 'content', 'seo', 'analytics'].includes(tab.id)
@@ -2918,6 +3013,187 @@ export default function AdminPanel() {
 
  {(['jobs', 'content', 'seo', 'analytics'] as WorkflowContext[]).includes(activeSection as WorkflowContext) &&
  renderWorkflowControlRoom(activeSection as WorkflowContext)}
+
+ {/* Insights Aziende section */}
+ {activeSection === 'insights' && (
+ <div className="space-y-4">
+ <div className="flex items-center justify-between gap-3 flex-wrap">
+ <h2 className="text-lg font-bold font-display text-strong flex items-center gap-2">
+ <Building2 size={20} className="text-accent" />
+ Insights Aziende
+ </h2>
+ <button
+ onClick={loadEmployerInsights}
+ disabled={insightsLoading}
+ className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-accent hover:bg-accent-hover text-on-accent text-sm font-medium transition-colors disabled:opacity-60"
+ >
+ {insightsLoading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+ Aggiorna
+ </button>
+ </div>
+
+ <div className="bg-surface rounded-xl border border-edge px-4 py-2">
+ <p className="text-sm text-muted">
+ Traffico reale per azienda crawlata. Usa &laquo;Apri come azienda&raquo; per vedere la pagina
+ prova-statistiche esattamente come la riceve l&apos;azienda (link tokenizzato privato).
+ </p>
+ </div>
+
+ {insightsError && (
+ <div className="bg-danger-subtle border border-danger-border rounded-lg px-3 py-2 text-sm text-danger">
+ {insightsError}
+ </div>
+ )}
+
+ {/* Totals overview */}
+ <div className="grid grid-cols-3 gap-3">
+ <div className="bg-surface rounded-xl border border-edge p-4">
+ <div className="flex items-center gap-2 text-subtle text-sm mb-1">
+ <Eye size={16} /> Visualizzazioni
+ </div>
+ <div className="text-2xl font-bold text-strong">
+ {insightsLoading ? '…' : insightsTotals.views.toLocaleString('it-IT')}
+ </div>
+ </div>
+ <div className="bg-surface rounded-xl border border-edge p-4">
+ <div className="flex items-center gap-2 text-subtle text-sm mb-1">
+ <UserCheck size={16} /> Candidati
+ </div>
+ <div className="text-2xl font-bold text-strong">
+ {insightsLoading ? '…' : insightsTotals.candidates.toLocaleString('it-IT')}
+ </div>
+ </div>
+ <div className="bg-surface rounded-xl border border-edge p-4">
+ <div className="flex items-center gap-2 text-subtle text-sm mb-1">
+ <TrendingDown size={16} /> Persi
+ </div>
+ <div className="text-2xl font-bold text-strong">
+ {insightsLoading ? '…' : insightsTotals.lost.toLocaleString('it-IT')}
+ </div>
+ </div>
+ </div>
+
+ {/* Filter */}
+ <div className="relative">
+ <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
+ <input
+ type="text"
+ value={insightsFilter}
+ onChange={e => setInsightsFilter(e.target.value)}
+ placeholder="Cerca azienda…"
+ aria-label="Cerca azienda per nome"
+ className="w-full pl-9 pr-3 py-2 rounded-lg border border-edge bg-surface text-strong text-sm"
+ />
+ </div>
+
+ <p className="text-[11px] text-muted">
+ {insightsLoading
+ ? 'Caricamento…'
+ : `${insightsFiltered.length} aziende${insightsFilter ? ` (di ${insightsRows.length})` : ''}`}
+ </p>
+
+ {/* Desktop table */}
+ <div className="hidden md:block overflow-x-auto rounded-xl border border-edge">
+ <table className="w-full text-sm">
+ <caption className="sr-only">Insights di traffico per azienda crawlata</caption>
+ <thead className="bg-surface-alt text-subtle">
+ <tr>
+ {([
+ { col: 'companyName' as const, label: 'Azienda', align: 'left' },
+ { col: 'views' as const, label: 'Visualizzazioni', align: 'right' },
+ { col: 'candidates' as const, label: 'Candidati', align: 'right' },
+ { col: 'lost' as const, label: 'Persi', align: 'right' },
+ { col: 'adsCount' as const, label: '#Annunci', align: 'right' },
+ { col: 'conversionRate' as const, label: 'Conversione', align: 'right' },
+ { col: 'generatedAt' as const, label: 'Data', align: 'right' },
+ ]).map(h => (
+ <th
+ key={h.col}
+ scope="col"
+ aria-sort={insightsSortIndicator(h.col)}
+ className={`px-3 py-2 font-semibold ${h.align === 'right' ? 'text-right' : 'text-left'}`}
+ >
+ <button
+ type="button"
+ onClick={() => toggleInsightsSort(h.col)}
+ className={`inline-flex items-center gap-1 hover:text-strong transition-colors ${h.align === 'right' ? 'flex-row-reverse' : ''}`}
+ >
+ {h.label}
+ {insightsSort.column === h.col && (
+ insightsSort.direction === 'asc'
+ ? <ArrowUp size={12} aria-hidden="true" />
+ : <ArrowDown size={12} aria-hidden="true" />
+ )}
+ </button>
+ </th>
+ ))}
+ <th scope="col" className="px-3 py-2 text-right font-semibold">Azione</th>
+ </tr>
+ </thead>
+ <tbody>
+ {insightsFiltered.map(row => (
+ <tr key={row.companyKey} className="border-t border-edge hover:bg-surface-alt/50">
+ <td className="px-3 py-2 text-strong font-medium">{row.companyName}</td>
+ <td className="px-3 py-2 text-right text-body">{row.totals.views.toLocaleString('it-IT')}</td>
+ <td className="px-3 py-2 text-right text-body">{row.totals.candidates.toLocaleString('it-IT')}</td>
+ <td className="px-3 py-2 text-right text-body">{row.totals.lost.toLocaleString('it-IT')}</td>
+ <td className="px-3 py-2 text-right text-body">{row.totals.adsCount.toLocaleString('it-IT')}</td>
+ <td className="px-3 py-2 text-right text-body">{(row.totals.conversionRate * 100).toFixed(1)}%</td>
+ <td className="px-3 py-2 text-right text-muted whitespace-nowrap">{formatInsightsDate(row.generatedAt)}</td>
+ <td className="px-3 py-2 text-right">
+ <a
+ href={row.insightsUrl}
+ target="_blank"
+ rel="noopener noreferrer"
+ className="inline-flex items-center gap-1 px-2 py-1 rounded bg-accent-subtle text-accent hover:bg-accent-subtle/80 text-xs font-medium transition-colors"
+ aria-label={`Apri la pagina statistiche di ${row.companyName} come azienda`}
+ >
+ Apri come azienda <ExternalLink size={12} aria-hidden="true" />
+ </a>
+ </td>
+ </tr>
+ ))}
+ {!insightsLoading && insightsFiltered.length === 0 && (
+ <tr>
+ <td colSpan={8} className="px-3 py-6 text-center text-muted">
+ Nessuna azienda trovata.
+ </td>
+ </tr>
+ )}
+ </tbody>
+ </table>
+ </div>
+
+ {/* Mobile cards */}
+ <div className="md:hidden space-y-3">
+ {insightsFiltered.map(row => (
+ <div key={row.companyKey} className="bg-surface rounded-xl border border-edge p-4 space-y-2">
+ <div className="font-semibold text-strong">{row.companyName}</div>
+ <div className="grid grid-cols-3 gap-2 text-xs">
+ <div><span className="block text-muted">Views</span><span className="text-body">{row.totals.views.toLocaleString('it-IT')}</span></div>
+ <div><span className="block text-muted">Candidati</span><span className="text-body">{row.totals.candidates.toLocaleString('it-IT')}</span></div>
+ <div><span className="block text-muted">Persi</span><span className="text-body">{row.totals.lost.toLocaleString('it-IT')}</span></div>
+ <div><span className="block text-muted">#Annunci</span><span className="text-body">{row.totals.adsCount.toLocaleString('it-IT')}</span></div>
+ <div><span className="block text-muted">Conv.</span><span className="text-body">{(row.totals.conversionRate * 100).toFixed(1)}%</span></div>
+ <div><span className="block text-muted">Data</span><span className="text-body">{formatInsightsDate(row.generatedAt)}</span></div>
+ </div>
+ <a
+ href={row.insightsUrl}
+ target="_blank"
+ rel="noopener noreferrer"
+ className="inline-flex items-center gap-1 px-3 py-2 rounded-lg bg-accent text-on-accent text-sm font-medium w-full justify-center"
+ aria-label={`Apri la pagina statistiche di ${row.companyName} come azienda`}
+ >
+ Apri come azienda <ExternalLink size={14} aria-hidden="true" />
+ </a>
+ </div>
+ ))}
+ {!insightsLoading && insightsFiltered.length === 0 && (
+ <p className="text-center text-muted py-6">Nessuna azienda trovata.</p>
+ )}
+ </div>
+ </div>
+ )}
 
  {/* Newsletter section */}
  {activeSection === 'newsletter' && (

--- a/components/pages/EmployerInsightsPage.tsx
+++ b/components/pages/EmployerInsightsPage.tsx
@@ -1,0 +1,467 @@
+/**
+ * EmployerInsightsPage — the cold-outreach conversion centrepiece.
+ *
+ * A private, per-company "wow" traffic report: we give companies free job-board
+ * traffic on frontaliereticino.ch, and this page PROVES it with their real
+ * numbers, then pushes them to claim a paid plan. It is reached from an outreach
+ * link of the form `/azienda/<companyKey>/?t=<token>` (private, noindex).
+ *
+ * This file exports TWO things:
+ *  1. `EmployerInsightsReport` — the pure presentational component. It takes the
+ *     already-fetched `data: EmployerInsights` and renders the whole report.
+ *     Use this directly if you fetch in a parent (the prompt's wrapper).
+ *  2. `EmployerInsightsPage` (default) — the route-level wrapper. It reads the
+ *     companyKey from the path and the `t` token from the query, calls
+ *     `fetchInsights`, and renders loading / error / empty / report states.
+ *
+ * Styling: semantic Tailwind tokens only (no inline hex, no raw `dark:` color
+ * classes), mobile-first, one <h1>. Animations honour prefers-reduced-motion
+ * (count-up + reveal both no-op under reduced motion; CSS transitions are
+ * globally neutralised by the media query in index.css). No new npm deps:
+ * count-up via the shared `useCountUp` hook, charts hand-rolled in SVG/CSS.
+ *
+ * SEO: per-company data is PRIVATE → the page forces `<meta name="robots"
+ * content="noindex, nofollow">` (overriding the global indexable meta) for its
+ * lifetime and restores the previous value on unmount. Title is set to
+ * "{companyName} — i tuoi dati su Frontaliere Ticino".
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  ArrowRight,
+  Eye,
+  Users,
+  Briefcase,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  Sparkles,
+  Target,
+  Loader2,
+  Home,
+} from 'lucide-react';
+import { useCountUp } from '@/hooks/useCountUp';
+import {
+  fetchInsights,
+  type EmployerInsights,
+  type FetchInsightsResult,
+} from '@/services/employerInsights';
+import { useReveal } from '@/components/insights/useReveal';
+import { TopAdsChart } from '@/components/insights/TopAdsChart';
+import { TrendSparkline } from '@/components/insights/TrendSparkline';
+
+// Claim/publish flow target — trailing slash per site convention.
+const CLAIM_HREF = '/pubblica-offerta/?claim=1&tier=azienda';
+
+const nf = new Intl.NumberFormat('it-IT');
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Small building blocks                                                        */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** Animated count-up number that only starts once it scrolls into view. */
+function CountStat({
+  value,
+  decimals = 0,
+  suffix = '',
+}: {
+  value: number;
+  decimals?: number;
+  suffix?: string;
+}): React.ReactElement {
+  const { ref, inView } = useReveal<HTMLSpanElement>();
+  const display = useCountUp(value, { active: inView, decimals, durationMs: 1600 });
+  const text =
+    decimals > 0 ? display.toLocaleString('it-IT', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) : nf.format(Math.round(display));
+  return (
+    <span ref={ref} className="tabular-nums">
+      {text}
+      {suffix}
+    </span>
+  );
+}
+
+/** A hero KPI tile: big animated number + icon + label. */
+function HeroStat({
+  icon,
+  value,
+  label,
+}: {
+  icon: React.ReactNode;
+  value: number;
+  label: string;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col items-center text-center rounded-2xl border border-edge bg-surface-raised px-4 py-5">
+      <span className="text-accent mb-2" aria-hidden="true">
+        {icon}
+      </span>
+      <span className="text-3xl sm:text-4xl font-bold font-display text-strong">
+        <CountStat value={value} />
+      </span>
+      <span className="text-xs sm:text-sm text-subtle mt-1">{label}</span>
+    </div>
+  );
+}
+
+/** Generic scroll-reveal section wrapper (fade + slide up). */
+function RevealSection({
+  children,
+  className = '',
+  ariaLabelledby,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  ariaLabelledby?: string;
+}): React.ReactElement {
+  const { ref, inView } = useReveal<HTMLElement>();
+  return (
+    <section
+      ref={ref}
+      aria-labelledby={ariaLabelledby}
+      className={`transition-all duration-700 ease-out ${inView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'} ${className}`}
+    >
+      {children}
+    </section>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* The report (presentational — takes already-fetched data)                     */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export function EmployerInsightsReport({ data }: { data: EmployerInsights }): React.ReactElement {
+  const { totals, trend, ads, periodDays } = data;
+
+  const conversionPct = totals.conversionRate * 100;
+  const trendUp =
+    trend.length >= 2 ? trend[trend.length - 1].views >= trend[0].views : true;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 sm:py-10 space-y-12 sm:space-y-16">
+      {/* ── Hero ────────────────────────────────────────────────────────── */}
+      <header className="text-center animate-fade-in-up">
+        <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold text-link bg-accent-subtle border border-accent-border mb-4">
+          <Sparkles className="w-3.5 h-3.5" aria-hidden="true" />
+          Report gratuito · Frontaliere Ticino
+        </span>
+        <h1 className="text-3xl sm:text-5xl font-bold font-display text-heading leading-tight text-balance">
+          {data.companyName} è già visibile sui frontalieri
+        </h1>
+        <p className="mt-3 text-base sm:text-lg text-subtle max-w-xl mx-auto text-pretty">
+          Negli ultimi {periodDays} giorni, <strong className="text-body">gratis</strong>, da
+          frontaliereticino.ch
+        </p>
+
+        <div className="mt-8 grid grid-cols-3 gap-3 sm:gap-4">
+          <HeroStat
+            icon={<Users className="w-5 h-5" />}
+            value={totals.candidates}
+            label="candidati inviati"
+          />
+          <HeroStat
+            icon={<Eye className="w-5 h-5" />}
+            value={totals.views}
+            label="visualizzazioni"
+          />
+          <HeroStat
+            icon={<Briefcase className="w-5 h-5" />}
+            value={totals.adsCount}
+            label="annunci pubblicati"
+          />
+        </div>
+      </header>
+
+      {/* ── Loss-aversion hammer ────────────────────────────────────────── */}
+      <RevealSection
+        ariaLabelledby="insights-loss-heading"
+        className="rounded-3xl border border-danger-border bg-danger-subtle px-5 py-8 sm:px-8 sm:py-10 text-center"
+      >
+        <span
+          className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-surface text-danger-strong mb-4 mx-auto"
+          aria-hidden="true"
+        >
+          <AlertTriangle className="w-6 h-6" />
+        </span>
+        <p
+          id="insights-loss-heading"
+          className="text-sm sm:text-base font-semibold uppercase tracking-wide text-danger-strong"
+        >
+          Persone interessate che NON sono diventate candidature
+        </p>
+        <p className="mt-3 text-6xl sm:text-7xl font-bold font-display text-danger-strong leading-none">
+          <CountStat value={totals.lost} />
+        </p>
+        <p className="mt-4 text-base text-body max-w-md mx-auto text-pretty">
+          Hanno visto i tuoi annunci ma se ne sono andati senza candidarsi. Sono{' '}
+          <strong>candidati lasciati sul tavolo</strong> — possiamo recuperarli.
+        </p>
+      </RevealSection>
+
+      {/* ── Top ads bar chart ───────────────────────────────────────────── */}
+      {ads.length > 0 && (
+        <RevealSection ariaLabelledby="insights-topads-heading">
+          <h2
+            id="insights-topads-heading"
+            className="text-xl sm:text-2xl font-bold font-display text-strong mb-1"
+          >
+            Gli annunci che lavorano per te
+          </h2>
+          <p className="text-sm text-subtle mb-5">
+            I più visti{data.topAd ? `, guidati da «${data.topAd.title}»` : ''}.
+          </p>
+          <TopAdsChart ads={ads} limit={10} />
+        </RevealSection>
+      )}
+
+      {/* ── Trend sparkline ─────────────────────────────────────────────── */}
+      {trend.length >= 2 && (
+        <RevealSection
+          ariaLabelledby="insights-trend-heading"
+          className="rounded-3xl border border-edge bg-surface-raised px-5 py-6 sm:px-7 sm:py-7"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <span className={trendUp ? 'text-success' : 'text-warning-strong'} aria-hidden="true">
+              {trendUp ? <TrendingUp className="w-5 h-5" /> : <TrendingDown className="w-5 h-5" />}
+            </span>
+            <h2
+              id="insights-trend-heading"
+              className="text-xl sm:text-2xl font-bold font-display text-strong"
+            >
+              Visualizzazioni settimana per settimana
+            </h2>
+          </div>
+          <p className="text-sm text-subtle mb-4">
+            {trendUp
+              ? 'Il tuo interesse è in crescita — è il momento di trasformarlo.'
+              : 'C’è un pubblico attivo da riattivare con annunci in evidenza.'}
+          </p>
+          <TrendSparkline trend={trend} />
+        </RevealSection>
+      )}
+
+      {/* ── Conversion-rate stat ────────────────────────────────────────── */}
+      <RevealSection
+        ariaLabelledby="insights-conv-heading"
+        className="rounded-3xl border border-accent-border bg-accent-subtle px-5 py-8 sm:px-8 sm:py-10"
+      >
+        <div className="flex flex-col sm:flex-row sm:items-center gap-5">
+          <div className="flex items-center gap-4">
+            <span
+              className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-surface text-accent shrink-0"
+              aria-hidden="true"
+            >
+              <Target className="w-6 h-6" />
+            </span>
+            <span className="text-5xl sm:text-6xl font-bold font-display text-strong leading-none">
+              <CountStat value={conversionPct} decimals={conversionPct < 10 ? 1 : 0} suffix="%" />
+            </span>
+          </div>
+          <div>
+            <h2
+              id="insights-conv-heading"
+              className="text-lg sm:text-xl font-bold font-display text-strong"
+            >
+              diventa candidatura oggi
+            </h2>
+            <p className="mt-1 text-sm sm:text-base text-body text-pretty">
+              Con annunci in evidenza, newsletter mirata e candidatura diretta possiamo{' '}
+              <strong>alzarlo</strong>. Ogni punto in più sono candidati reali nella tua casella.
+            </p>
+          </div>
+        </div>
+      </RevealSection>
+
+      {/* ── CTA ─────────────────────────────────────────────────────────── */}
+      <RevealSection
+        ariaLabelledby="insights-cta-heading"
+        className="rounded-3xl bg-surface-inverted px-6 py-10 sm:px-10 sm:py-12 text-center"
+      >
+        <h2
+          id="insights-cta-heading"
+          className="text-2xl sm:text-3xl font-bold font-display text-on-accent text-balance"
+        >
+          Trasforma questi {nf.format(totals.views)} click in candidature dirette
+        </h2>
+        <p className="mt-3 text-sm sm:text-base text-on-accent/80 max-w-md mx-auto text-pretty">
+          Rivendica il profilo di {data.companyName}, metti gli annunci in evidenza e ricevi le
+          candidature direttamente. Setup in pochi minuti.
+        </p>
+        <a
+          href={CLAIM_HREF}
+          className="mt-7 inline-flex items-center justify-center gap-2 px-7 py-3.5 text-base font-semibold text-on-accent bg-accent hover:bg-accent-hover rounded-xl shadow-sm transition-colors no-underline"
+        >
+          Rivendica i tuoi annunci
+          <ArrowRight className="w-5 h-5" aria-hidden="true" />
+        </a>
+      </RevealSection>
+
+      <p className="text-center text-xs text-muted">
+        Dati relativi a {data.companyName} generati il{' '}
+        {new Date(data.generatedAt).toLocaleDateString('it-IT')} · pagina privata, non indicizzata.
+      </p>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* States: loading / error / empty                                              */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+function CenteredMessage({
+  title,
+  body,
+  showHome = true,
+}: {
+  title: string;
+  body: string;
+  showHome?: boolean;
+}): React.ReactElement {
+  return (
+    <div className="max-w-md mx-auto px-4 py-20 text-center">
+      <h1 className="text-2xl font-bold font-display text-strong mb-3">{title}</h1>
+      <p className="text-base text-subtle text-pretty">{body}</p>
+      {showHome && (
+        <a
+          href="/"
+          className="mt-6 inline-flex items-center justify-center gap-2 px-5 py-2.5 text-sm font-semibold text-link border border-edge rounded-xl hover:bg-surface-alt transition-colors no-underline"
+        >
+          <Home className="w-4 h-4" aria-hidden="true" />
+          Vai alla home
+        </a>
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton(): React.ReactElement {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10" aria-busy="true" aria-live="polite">
+      <span className="sr-only">Caricamento del report in corso…</span>
+      <div className="flex justify-center mb-8" aria-hidden="true">
+        <Loader2 className="w-7 h-7 text-accent animate-spin" />
+      </div>
+      <div className="space-y-6" aria-hidden="true">
+        <div className="h-10 rounded-xl bg-surface-alt animate-pulse mx-auto w-3/4" />
+        <div className="grid grid-cols-3 gap-3">
+          <div className="h-24 rounded-2xl bg-surface-alt animate-pulse" />
+          <div className="h-24 rounded-2xl bg-surface-alt animate-pulse" />
+          <div className="h-24 rounded-2xl bg-surface-alt animate-pulse" />
+        </div>
+        <div className="h-40 rounded-3xl bg-surface-alt animate-pulse" />
+        <div className="h-32 rounded-3xl bg-surface-alt animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Route wrapper — reads companyKey from path + token from query, fetches       */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** Pull `companyKey` from the path (`/azienda/<companyKey>/`) if not provided. */
+function companyKeyFromPath(): string {
+  if (typeof window === 'undefined') return '';
+  const segs = window.location.pathname.split('/').filter(Boolean);
+  const idx = segs.indexOf('azienda');
+  return idx >= 0 && segs[idx + 1] ? decodeURIComponent(segs[idx + 1]) : '';
+}
+
+function tokenFromQuery(): string {
+  if (typeof window === 'undefined') return '';
+  return new URLSearchParams(window.location.search).get('t') ?? '';
+}
+
+/**
+ * Set document.title and force noindex robots meta for the lifetime of the
+ * report page; restore on unmount. Centralised so every state (and the wrapper)
+ * keeps the page out of the index.
+ */
+function usePrivatePageHead(title: string): void {
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = title;
+
+    const meta = document.querySelector('meta[name="robots"]');
+    const prevRobots = meta?.getAttribute('content') ?? null;
+    let created = false;
+    let el = meta as HTMLMetaElement | null;
+    if (el) {
+      el.setAttribute('content', 'noindex, nofollow');
+    } else {
+      el = document.createElement('meta');
+      el.setAttribute('name', 'robots');
+      el.setAttribute('content', 'noindex, nofollow');
+      document.head.appendChild(el);
+      created = true;
+    }
+
+    return () => {
+      document.title = prevTitle;
+      if (created && el) {
+        el.remove();
+      } else if (el && prevRobots != null) {
+        el.setAttribute('content', prevRobots);
+      }
+    };
+  }, [title]);
+}
+
+export interface EmployerInsightsPageProps {
+  /** Override companyKey (else read from path). */
+  companyKey?: string;
+  /** Override token (else read from query `t`). */
+  token?: string;
+}
+
+export function EmployerInsightsPage({
+  companyKey: companyKeyProp,
+  token: tokenProp,
+}: EmployerInsightsPageProps = {}): React.ReactElement {
+  const companyKey = companyKeyProp ?? companyKeyFromPath();
+  const token = tokenProp ?? tokenFromQuery();
+
+  const [result, setResult] = useState<FetchInsightsResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setResult(null);
+    fetchInsights(companyKey, token)
+      .then((r) => {
+        if (!cancelled) setResult(r);
+      })
+      .catch(() => {
+        if (!cancelled) setResult({ status: 'error', reason: 'network' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [companyKey, token]);
+
+  const companyName =
+    result?.status === 'ok' ? result.data.companyName : 'La tua azienda';
+  usePrivatePageHead(`${companyName} — i tuoi dati su Frontaliere Ticino`);
+
+  if (result === null) return <LoadingSkeleton />;
+
+  if (result.status === 'error') {
+    return (
+      <CenteredMessage
+        title="Link non valido o scaduto"
+        body="Questo report è privato e raggiungibile solo dal link che ti abbiamo inviato. Il link potrebbe essere scaduto: scrivici e te ne mandiamo uno nuovo."
+      />
+    );
+  }
+
+  if (result.status === 'not-found') {
+    return (
+      <CenteredMessage
+        title="Report in preparazione"
+        body="Stiamo ancora raccogliendo i dati di traffico per la tua azienda. Riprova tra poco — nel frattempo puoi già pubblicare e mettere in evidenza i tuoi annunci."
+      />
+    );
+  }
+
+  return <EmployerInsightsReport data={result.data} />;
+}
+
+export default EmployerInsightsPage;

--- a/functions/index.js
+++ b/functions/index.js
@@ -16,11 +16,13 @@ import { handleChatbotInference } from './src/chatbotInference.js';
 import { handleLinkedInCallback } from './src/linkedinAuthCallback.js';
 import { handleJobAlertUnsubscribe } from './src/jobAlertUnsubscribe.js';
 import { handleOutreachUnsubscribe } from './src/outreachUnsubscribe.js';
+import { handleEmployerInsights } from './src/employerInsights.js';
 import { handleRecaptchaVerification } from './src/recaptchaVerification.js';
 import { getPublicConfigValues } from './src/publicConfig.js';
 import { handleGeminiGenerate } from './src/geminiGenerate.js';
 import { handleGetExchangeRate } from './src/exchangeRate.js';
 import { handleCreateFeedbackIssue, handleGetAdminGithubToken } from './src/githubProxy.js';
+import { handleAdminEmployerInsights } from './src/adminEmployerInsights.js';
 import { handleCreatePublisherCheckout, handleStripeWebhook, handleCreateBillingPortal, handleArchivePublisherAd, handleRestorePublisherAd } from './src/stripePublisherCore.js';
 import { reapStalePendingPayments } from './src/publisherPendingReapCore.js';
 import { onDocumentCreated } from 'firebase-functions/v2/firestore';
@@ -115,6 +117,29 @@ export const getAdminGithubToken = onRequest(
  res.status(500).json({ ok: false, error: 'internal_error' });
  }
  },
+);
+
+// Admin-only employer traffic insights list. Returns the lean per-company
+// totals + the tokenized "open as company" stats-proof URL for every
+// employer_insights doc, gated by the admin's Firebase ID token (same
+// allowlist as getAdminGithubToken). Powers the dashboard's "Insights
+// Aziende" section. The private per-company data never reaches non-admins.
+export const adminEmployerInsights = onRequest(
+  {
+    region: 'europe-west6',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true,
+  },
+  async (req, res) => {
+    try {
+      const { status, body } = await handleAdminEmployerInsights(req);
+      res.status(status).json(body);
+    } catch (error) {
+      console.error('[adminEmployerInsights]', error instanceof Error ? error.message : String(error));
+      res.status(500).json({ ok: false, error: 'internal_error' });
+    }
+  },
 );
 
 // Browser-safe Remote Config: returns ONLY the allowlisted client params
@@ -678,6 +703,36 @@ export const outreachUnsubscribe = onRequest(
  } catch (error) {
  console.error('[outreachUnsubscribe] Error:', error);
  res.status(500).type('html').send('<h1>Errore interno</h1><p>Riprova più tardi.</p>');
+ }
+ },
+);
+
+/**
+ * employerInsights — HMAC-gated JSON read API for the per-company stats page
+ * (/azienda/<companyKey>/). GET ?c=<companyKey>&t=<token> → returns the
+ * employer_insights/{companyKey} doc. cors:true so the SPA can fetch it.
+ */
+export const employerInsights = onRequest(
+ {
+ region: 'europe-west6',
+ memory: '256MiB',
+ timeoutSeconds: 30,
+ cors: true,
+ },
+ async (req, res) => {
+ if (req.method !== 'GET') {
+ res.status(405).json({ error: 'method_not_allowed' });
+ return;
+ }
+ const companyKey = String(req.query.c || '').trim();
+ const token = String(req.query.t || '').trim();
+ try {
+ const { newsletterSecret } = await getNewsletterSecrets();
+ const result = await handleEmployerInsights({ companyKey, token, secret: newsletterSecret });
+ res.status(result.status).json(result.body);
+ } catch (error) {
+ console.error('[employerInsights] Error:', error);
+ res.status(500).json({ error: 'internal' });
  }
  },
 );

--- a/functions/src/adminEmployerInsights.js
+++ b/functions/src/adminEmployerInsights.js
@@ -1,0 +1,103 @@
+/**
+ * adminEmployerInsights.js — ADMIN-only listing of employer traffic insights.
+ *
+ * Backs the admin dashboard's "Insights Aziende" section. The data in
+ * `employer_insights/{companyKey}` is PRIVATE (real per-company traffic we email
+ * to companies as a paid teaser), so this endpoint is gated by a Firebase ID
+ * token + admin email allowlist — mirroring `githubProxy.js` (handleGetAdminGithubToken).
+ *
+ * GET (list mode) → { ok, insights: [{ companyKey, companyName, totals,
+ * generatedAt, insightsUrl }] } sorted by totals.views desc, with the big
+ * `ads` / `trend` arrays stripped to keep the payload lean.
+ *
+ * `insightsUrl` is the real tokenized "open as company" link the company
+ * receives: https://frontaliereticino.ch/azienda/<companyKey>/?t=<token>
+ * token = HMAC-SHA256(NEWSLETTER_SECRET, `employer_insights:${companyKey}`) hex.
+ *
+ * NOTE: `generateInsightsToken` below MUST stay byte-identical to the same
+ * helper in functions/src/employerInsights.js (added in parallel — the
+ * per-company stats page verifies the token with it). Dedupe at integration:
+ * import it from employerInsights.js once both land.
+ */
+
+import { getAuth } from 'firebase-admin/auth';
+import { getAdminDb } from './newsletterResendWebhookCore.js';
+import { getNewsletterSecrets } from './remoteConfigSecrets.js';
+// Single source of truth for the stats-page token (no local HMAC copy → no drift).
+import { generateInsightsToken } from './employerInsights.js';
+
+const ADMIN_EMAIL_ALLOWLIST = new Set(['valerielinc@gmail.com']);
+const BASE_URL = 'https://frontaliereticino.ch';
+const INSIGHTS_COLLECTION = 'employer_insights';
+
+/** Build the tokenized "open as company" URL (trailing slash, canonical). */
+function buildInsightsUrl(companyKey, secret) {
+  const token = generateInsightsToken(companyKey, secret);
+  return `${BASE_URL}/azienda/${encodeURIComponent(companyKey)}/?t=${token}`;
+}
+
+// ── Admin gate (mirrors githubProxy.js assertAdmin) ─────────────────────────
+async function assertAdmin(req) {
+  const header = req.get ? req.get('Authorization') : req.headers?.authorization;
+  const idToken = typeof header === 'string' && header.startsWith('Bearer ')
+    ? header.slice(7).trim()
+    : '';
+  if (!idToken) return { ok: false, status: 401, error: 'missing_id_token' };
+  try {
+    const decoded = await getAuth().verifyIdToken(idToken);
+    const email = (decoded.email || '').toLowerCase();
+    if (!decoded.email_verified || !ADMIN_EMAIL_ALLOWLIST.has(email)) {
+      return { ok: false, status: 403, error: 'not_admin' };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, status: 401, error: 'invalid_id_token' };
+  }
+}
+
+/**
+ * List all employer insights (lean) for the verified admin only.
+ * GET only. Returns insights sorted by totals.views desc.
+ */
+export async function handleAdminEmployerInsights(req) {
+  if (req.method !== 'GET') {
+    return { status: 405, body: { ok: false, error: 'method_not_allowed' } };
+  }
+
+  const auth = await assertAdmin(req);
+  if (!auth.ok) {
+    return { status: auth.status, body: { ok: false, error: auth.error } };
+  }
+
+  const { newsletterSecret } = await getNewsletterSecrets();
+  if (!newsletterSecret) {
+    return { status: 503, body: { ok: false, error: 'secret_not_configured' } };
+  }
+
+  const db = getAdminDb();
+  const snap = await db.collection(INSIGHTS_COLLECTION).get();
+
+  const insights = snap.docs.map((doc) => {
+    const d = doc.data() || {};
+    const companyKey = String(d.companyKey || doc.id);
+    const t = d.totals || {};
+    return {
+      companyKey,
+      companyName: String(d.companyName || companyKey),
+      generatedAt: d.generatedAt ? String(d.generatedAt) : null,
+      totals: {
+        views: Number(t.views || 0),
+        visitors: Number(t.visitors || 0),
+        candidates: Number(t.candidates || 0),
+        adsCount: Number(t.adsCount || 0),
+        lost: Number(t.lost || 0),
+        conversionRate: Number(t.conversionRate || 0),
+      },
+      insightsUrl: buildInsightsUrl(companyKey, newsletterSecret),
+    };
+  });
+
+  insights.sort((a, b) => b.totals.views - a.totals.views);
+
+  return { status: 200, body: { ok: true, insights } };
+}

--- a/functions/src/employerInsights.js
+++ b/functions/src/employerInsights.js
@@ -1,0 +1,54 @@
+/**
+ * employerInsights.js — HMAC-gated read API for the per-company "stats proof"
+ * page (/azienda/<companyKey>/) linked from cold-outreach emails.
+ *
+ * GET ?c=<companyKey>&t=<token> → verifies the HMAC token, then returns the
+ * employer_insights/{companyKey} document as JSON. The token gate keeps each
+ * company's data private (a company can only see its own stats via its emailed
+ * link); the Firestore collection is not publicly readable.
+ *
+ * Token scheme MUST stay byte-identical to scripts/lib/employer-insights-token.mjs:
+ *   token = HMAC-SHA256(secret, `employer_insights:${companyKey}`) hex digest,
+ *   secret = NEWSLETTER_SECRET. Distinct prefix avoids replay as an unsubscribe
+ *   token (which uses `outreach_unsub:`).
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { getAdminDb } from './newsletterResendWebhookCore.js';
+
+const INSIGHTS_COLLECTION = 'employer_insights';
+
+export function generateInsightsToken(companyKey, secret) {
+  return createHmac('sha256', secret)
+    .update(`employer_insights:${String(companyKey).trim()}`)
+    .digest('hex');
+}
+
+export function verifyInsightsToken(companyKey, token, secret) {
+  if (!secret || !companyKey || !token) return false;
+  const expected = generateInsightsToken(companyKey, secret);
+  try {
+    return timingSafeEqual(Buffer.from(token, 'hex'), Buffer.from(expected, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Core handler — `db` injectable for unit tests. Returns { status, body } where
+ * body is a plain object (the caller JSON-serializes).
+ */
+export async function handleEmployerInsights({ companyKey, token, secret, db: injectedDb }) {
+  const key = String(companyKey || '').trim();
+  if (!key) return { status: 400, body: { error: 'missing_company' } };
+  if (!verifyInsightsToken(key, token, secret)) return { status: 403, body: { error: 'invalid_token' } };
+
+  const db = injectedDb || getAdminDb();
+  const snap = await db.collection(INSIGHTS_COLLECTION).doc(key).get();
+  if (!snap.exists) return { status: 404, body: { error: 'not_found', companyKey: key } };
+
+  const data = snap.data() || {};
+  // Drop the server-side updatedAt sentinel (not JSON-serializable / not needed client-side).
+  delete data.updatedAt;
+  return { status: 200, body: data };
+}

--- a/scripts/build-employer-insights.mjs
+++ b/scripts/build-employer-insights.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * build-employer-insights.mjs — rich per-company traffic insights for the
+ * cold-outreach "proof page" (/azienda/<companyKey>/).
+ *
+ * Joins PostHog (historical, HogQL) with data/jobs.json to compute, per company:
+ *   - views + distinct visitors PER AD ($pageview on the /cerca-lavoro-<canton>/<slug>/ pages)
+ *   - applies PER AD (job_apply event, properties.job_slug) — recent (event is new)
+ *   - total candidates (select_content job_board_apply, distinct persons) — historical
+ *   - "lost" = views − candidates (interested-but-not-converted) — loss-aversion hook
+ *   - weekly views trend
+ * Writes one doc per company to Firestore `employer_insights/{companyKey}`.
+ *
+ * Few BIG queries + local aggregation (not N×queries). Path→company mapping uses
+ * the slug (incl. previousSlugs) so URL-rotated ads still attribute correctly.
+ *
+ * Usage:
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=<sa> node scripts/load-rc-env.mjs)"
+ *   node scripts/build-employer-insights.mjs                  # dry-run, prints sample
+ *   node scripts/build-employer-insights.mjs --company eoc-…  # single company
+ *   node scripts/build-employer-insights.mjs --apply          # write Firestore
+ *
+ * Env: POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST,
+ *      GOOGLE_APPLICATION_CREDENTIALS (for --apply).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const arg = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? argv[i + 1] : d; };
+const PERIOD_DAYS = Number(arg('--days', '90'));
+const ONLY = arg('--company', null);
+const APPLY = has('--apply');
+
+// ───────────────────────── PostHog (HogQL) ─────────────────────────
+async function hogql(query) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+  if (!apiKey || !projectId) throw new Error('no POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID');
+  const r = await fetch(`${host}/api/projects/${projectId}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!r.ok) throw new Error(`posthog ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return (await r.json()).results || [];
+}
+
+// ───────────────────────── jobs.json mapping ─────────────────────────
+function loadJobMaps() {
+  const p = ['data/jobs.json', 'public/data/jobs.json'].map((x) => path.join(ROOT, x)).find(fs.existsSync);
+  if (!p) throw new Error('jobs.json not found');
+  const raw = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const jobs = Array.isArray(raw) ? raw : raw.jobs || [];
+  const slugToCompany = new Map();   // slug (current+previous) → companyKey
+  const slugToTitle = new Map();
+  const companyName = new Map();     // companyKey → display name
+  for (const j of jobs) {
+    const ck = j.companyKey;
+    if (!ck) continue;
+    if (j.company) companyName.set(ck, j.company);
+    const slugs = new Set([j.slug, ...(j.previousSlugs || [])].filter(Boolean));
+    for (const s of slugs) { slugToCompany.set(s, ck); if (j.title && !slugToTitle.has(s)) slugToTitle.set(s, j.title); }
+    if (j.slug && j.title) slugToTitle.set(j.slug, j.title);
+  }
+  return { slugToCompany, slugToTitle, companyName };
+}
+
+// last non-empty path segment, e.g. /cerca-lavoro-ticino/<slug>/ → <slug>
+const slugFromPath = (p) => String(p || '').split('?')[0].split('#')[0].replace(/\/+$/, '').split('/').pop() || '';
+
+// Derive a human title from a slug when the ad has expired out of jobs.json:
+// strip the trailing "-<companyKey>-<location>" and title-case the lead tokens.
+function deriveTitle(slug, companyKey) {
+  let s = String(slug || '');
+  const i = s.indexOf(companyKey);
+  if (i > 0) s = s.slice(0, i - 1); // keep the part before "-<companyKey>"
+  s = s.replace(/-+$/, '').replace(/-/g, ' ').trim();
+  if (!s) return slug;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+async function main() {
+  const { slugToCompany, slugToTitle, companyName } = loadJobMaps();
+  const period = `INTERVAL ${PERIOD_DAYS} DAY`;
+  // companyKeys longest-first so a substring match picks the most specific key
+  // (the key is embedded in every ad slug: "<title>-<companyKey>-<location>").
+  const companyKeys = [...companyName.keys()].sort((a, b) => b.length - a.length);
+  const keyFromSlug = (slug) => {
+    const s = String(slug || '');
+    for (const k of companyKeys) if (s.includes(k)) return k;
+    return null;
+  };
+
+  // Q1 — views + visitors per job-page path (one row per path).
+  const viewsRows = await hogql(
+    `SELECT properties.$pathname AS path, count() AS views, count(DISTINCT person_id) AS visitors
+     FROM events WHERE event='$pageview' AND properties.$pathname LIKE '%cerca-lavoro-%'
+     AND timestamp > now() - ${period} GROUP BY path LIMIT 100000`,
+  );
+  // Q2 — applies per ad (job_apply, recent event).
+  const applyRows = await hogql(
+    `SELECT properties.job_slug AS slug, count() AS applies, count(DISTINCT person_id) AS persons
+     FROM events WHERE event='job_apply' AND coalesce(toString(properties.job_slug),'') != ''
+     AND timestamp > now() - ${period} GROUP BY slug LIMIT 100000`,
+  );
+  // Q3 — historical total candidates per company (select_content job_board_apply).
+  const candRows = await hogql(
+    `SELECT splitByChar('_', coalesce(toString(properties.item_id),''))[1] AS company,
+            count(DISTINCT person_id) AS persons, count(DISTINCT properties.$session_id) AS sessions
+     FROM events WHERE event='select_content'
+     AND properties.content_type IN ('job_board_apply','job_board_apply_header_logo','job_board_apply_header_title')
+     AND timestamp > now() - ${period} GROUP BY company`,
+  );
+  // Q4 — weekly views trend per path.
+  const trendRows = await hogql(
+    `SELECT toStartOfWeek(timestamp) AS wk, properties.$pathname AS path, count() AS views
+     FROM events WHERE event='$pageview' AND properties.$pathname LIKE '%cerca-lavoro-%'
+     AND timestamp > now() - INTERVAL 84 DAY GROUP BY wk, path LIMIT 200000`,
+  );
+
+  // Index applies by slug.
+  const appliesBySlug = new Map();
+  for (const [slug, applies, persons] of applyRows) appliesBySlug.set(slug, { applies: +applies, persons: +persons });
+  // Candidate totals: company token from item_id is a loose slug of the name; map via companyName slug match.
+  const slugifyName = (s) => String(s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const nameTokenToKey = new Map();
+  for (const [ck, name] of companyName) nameTokenToKey.set(slugifyName(name), ck);
+  const candByKey = new Map();
+  for (const [company, persons, sessions] of candRows) {
+    const ck = nameTokenToKey.get(slugifyName(company)) || company;
+    const v = Math.min(+persons, +sessions); // conservative (matches employer-traffic-report)
+    candByKey.set(ck, (candByKey.get(ck) || 0) + v);
+  }
+
+  // Aggregate per company.
+  const companies = new Map(); // ck → { ads:Map<slug,{title,views,visitors,applies}>, hubViews, trendByWeek:Map }
+  const attribute = (pathStr, views, visitors, wk) => {
+    const slug = slugFromPath(pathStr);
+    let isHub = false;
+    let ck = slugToCompany.get(slug);
+    if (!ck && slug.startsWith('azienda-')) { ck = slug.replace(/^azienda-/, ''); isHub = true; }
+    if (!ck) ck = keyFromSlug(slug); // capture expired ads (slug no longer in jobs.json)
+    if (!ck) return;
+    if (ONLY && ck !== ONLY) return;
+    if (!companies.has(ck)) companies.set(ck, { ads: new Map(), hubViews: 0, trendByWeek: new Map() });
+    const c = companies.get(ck);
+    if (wk != null) { c.trendByWeek.set(wk, (c.trendByWeek.get(wk) || 0) + (+views || 0)); return; }
+    if (isHub) { c.hubViews += +views || 0; return; }
+    const a = c.ads.get(slug) || { slug, title: slugToTitle.get(slug) || deriveTitle(slug, ck), views: 0, visitors: 0, applies: 0 };
+    a.views += +views || 0; a.visitors += +visitors || 0;
+    c.ads.set(slug, a);
+  };
+  for (const [p, views, visitors] of viewsRows) attribute(p, views, visitors, null);
+  for (const [wk, p, views] of trendRows) attribute(p, views, 0, String(wk).slice(0, 10));
+
+  // Build docs.
+  const docs = [];
+  for (const [ck, c] of companies) {
+    let totViews = c.hubViews, totVisitors = 0, totApplies = 0;
+    const ads = [];
+    for (const a of c.ads.values()) {
+      const ap = appliesBySlug.get(a.slug)?.applies || 0;
+      const lost = Math.max(0, a.views - ap);
+      ads.push({ slug: a.slug, title: a.title, path: `/cerca-lavoro-ticino/${a.slug}/`, views: a.views, visitors: a.visitors, applies: ap, lost });
+      totViews += a.views; totVisitors += a.visitors; totApplies += ap;
+    }
+    ads.sort((x, y) => y.views - x.views);
+    const candidates = candByKey.get(ck) || totApplies;
+    const lost = Math.max(0, totViews - candidates);
+    const trend = [...c.trendByWeek.entries()].sort((a, b) => a[0] < b[0] ? -1 : 1).map(([week, views]) => ({ week, views }));
+    docs.push({
+      companyKey: ck,
+      companyName: companyName.get(ck) || ck,
+      generatedAt: new Date().toISOString(),
+      periodDays: PERIOD_DAYS,
+      totals: {
+        views: totViews,
+        visitors: totVisitors,
+        candidates,
+        adsCount: ads.length,
+        lost,
+        conversionRate: totViews ? +(candidates / totViews).toFixed(4) : 0,
+      },
+      topAd: ads[0] ? { slug: ads[0].slug, title: ads[0].title, views: ads[0].views } : null,
+      ads: ads.slice(0, 100),
+      trend,
+    });
+  }
+  docs.sort((a, b) => b.totals.views - a.totals.views);
+
+  console.log(`Built insights for ${docs.length} companies (period ${PERIOD_DAYS}d).`);
+  const sample = ONLY ? docs.find((d) => d.companyKey === ONLY) : docs[0];
+  if (sample) console.log('SAMPLE:', JSON.stringify(sample, null, 1).slice(0, 1400));
+
+  if (!APPLY) { console.log('\n(dry-run — pass --apply to write Firestore employer_insights/*)'); return; }
+
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath || !fs.existsSync(credPath)) throw new Error('GOOGLE_APPLICATION_CREDENTIALS required for --apply');
+  const { initializeApp, cert, getApps } = await import('firebase-admin/app');
+  const { getFirestore, FieldValue } = await import('firebase-admin/firestore');
+  if (getApps().length === 0) initializeApp({ credential: cert(JSON.parse(fs.readFileSync(credPath, 'utf8'))) });
+  const db = getFirestore();
+  let written = 0;
+  for (let i = 0; i < docs.length; i += 400) {
+    const batch = db.batch();
+    for (const d of docs.slice(i, i + 400)) {
+      batch.set(db.collection('employer_insights').doc(d.companyKey), { ...d, updatedAt: FieldValue.serverTimestamp() });
+      written++;
+    }
+    await batch.commit();
+  }
+  console.log(`✅ Wrote ${written} docs to employer_insights/.`);
+}
+
+main().catch((e) => { console.error(e.message || e); process.exit(1); });

--- a/scripts/generate-cold-emails.mjs
+++ b/scripts/generate-cold-emails.mjs
@@ -79,7 +79,7 @@ ${periodLabel} vi abbiamo mandato ${candidates} persone alla vostra ${pagina} da
 
 Il punto è che quei click arrivano sul vostro sito e spesso si perdono. Possiamo farveli arrivare come candidature dirette, CV incluso, nella vostra casella.
 
-Ha senso che vi mostri come, sul vostro annuncio più visto?
+Ho preparato i vostri dati reali (annunci, visite, candidati) qui: {{INSIGHTS_URL}}
 
 Valerie`,
     },

--- a/scripts/lib/employer-insights-token.mjs
+++ b/scripts/lib/employer-insights-token.mjs
@@ -1,0 +1,39 @@
+/**
+ * employer-insights-token.mjs — shared HMAC token + URL builder for the
+ * per-company "stats proof" landing page linked from cold-outreach emails.
+ *
+ * Mirrors the outreach-unsubscribe scheme (scripts/lib/outreach-unsubscribe-token.mjs):
+ * same secret (NEWSLETTER_SECRET), same algo (HMAC-SHA256 hex), distinct
+ * domain-separation prefix `employer_insights:<companyKey>` so a stats token can
+ * never be replayed as an unsubscribe token (or vice-versa).
+ *
+ * The Cloud Function functions/src/employerInsights.js MUST verify against the
+ * IDENTICAL scheme — keep the prefix in sync. Any drift breaks the page gate.
+ */
+
+import { createHmac } from 'node:crypto';
+
+export const BASE_URL = 'https://frontaliereticino.ch';
+// Trailing slash: site canonical convention (AGENTS.md). The SPA route
+// /azienda/<companyKey>/ renders the insights page; ?t=<token> gates the data.
+export const INSIGHTS_PATH = '/azienda/';
+
+export function makeInsightsToken(companyKey, secret = process.env.NEWSLETTER_SECRET) {
+  if (!secret) throw new Error('NEWSLETTER_SECRET not set — cannot sign employer insights token');
+  return createHmac('sha256', secret)
+    .update(`employer_insights:${String(companyKey).trim()}`)
+    .digest('hex');
+}
+
+/**
+ * Public stats-page URL for a company key:
+ *   https://frontaliereticino.ch/azienda/<enc-key>/?t=<token>
+ * Returns the site home as a safe fallback if the secret is missing (parity with
+ * buildUnsubUrl — never emit an unsigned/forgeable link).
+ */
+export function buildInsightsUrl(companyKey, secret = process.env.NEWSLETTER_SECRET) {
+  if (!secret) return `${BASE_URL}/`;
+  const key = String(companyKey).trim();
+  const token = makeInsightsToken(key, secret);
+  return `${BASE_URL}${INSIGHTS_PATH}${encodeURIComponent(key)}/?t=${token}`;
+}

--- a/scripts/send-cold-emails.mjs
+++ b/scripts/send-cold-emails.mjs
@@ -40,6 +40,7 @@ import { fileURLToPath } from 'node:url';
 import { buildSequence, OPTOUT_EMAIL } from './generate-cold-emails.mjs';
 import { classifySector } from './lib/employer-sectors.mjs';
 import { buildUnsubUrl } from './lib/outreach-unsubscribe-token.mjs';
+import { buildInsightsUrl } from './lib/employer-insights-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
@@ -261,8 +262,12 @@ async function run() {
     // anche secret mancante con fallback alla home). Sostituisce il placeholder
     // {{UNSUB_URL}} iniettato nel footer da generate-cold-emails.mjs.
     const unsubUrl = buildUnsubUrl(m.key || m.company);
-    const html = String(m.html).split('{{UNSUB_URL}}').join(unsubUrl);
-    const text = String(m.text).split('{{UNSUB_URL}}').join(unsubUrl);
+    // Per-company stats "proof" page link ({{INSIGHTS_URL}}) — the primary CTA,
+    // HMAC-gated (employerInsights CF). Same secret-missing→home fallback.
+    const insightsUrl = buildInsightsUrl(m.key || m.company);
+    const sub = (s) => String(s).split('{{UNSUB_URL}}').join(unsubUrl).split('{{INSIGHTS_URL}}').join(insightsUrl);
+    const html = sub(m.html);
+    const text = sub(m.text);
     // List-Unsubscribe (RFC 8058 + RFC 2369): HTTPS one-click PRIMA, mailto come
     // fallback. List-Unsubscribe-Post abilita il vero one-click (POST). Il
     // subject del mailto porta la company key così l'opt-out resta tracciabile.

--- a/services/adminInsights.ts
+++ b/services/adminInsights.ts
@@ -1,0 +1,59 @@
+/**
+ * adminInsights.ts — client for the ADMIN-only employer traffic insights list.
+ *
+ * Calls the `adminEmployerInsights` Cloud Function with the admin's Firebase ID
+ * token in the Authorization header (same auth idiom as AdminPanel's
+ * getGitHubConnection → getAdminGithubToken). The endpoint is admin-gated
+ * server-side; this module never exposes the data to non-admins.
+ */
+
+const ADMIN_INSIGHTS_ENDPOINT =
+  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/adminEmployerInsights';
+
+export interface EmployerInsightsTotals {
+  views: number;
+  visitors: number;
+  candidates: number;
+  adsCount: number;
+  lost: number;
+  conversionRate: number;
+}
+
+export interface EmployerInsightsRow {
+  companyKey: string;
+  companyName: string;
+  generatedAt: string | null;
+  totals: EmployerInsightsTotals;
+  /** Tokenized "open as company" stats-proof URL the company receives. */
+  insightsUrl: string;
+}
+
+/** Minimal Firebase user shape — only getIdToken is needed. */
+interface AuthLike {
+  getIdToken: () => Promise<string>;
+}
+
+/**
+ * Fetch all employer insights (lean) for the authenticated admin.
+ * Throws on auth failure or non-OK response — callers surface the message.
+ */
+export async function fetchAdminEmployerInsights(
+  user: AuthLike | null | undefined,
+): Promise<EmployerInsightsRow[]> {
+  if (!user) {
+    throw new Error('Devi essere autenticato come admin per vedere le insights aziende.');
+  }
+  const idToken = await user.getIdToken();
+  const res = await fetch(ADMIN_INSIGHTS_ENDPOINT, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) {
+    if (data.error === 'not_admin') {
+      throw new Error('Accesso negato: questo account non è autorizzato alle insights aziende.');
+    }
+    throw new Error(`Impossibile caricare le insights (${data.error || res.status}).`);
+  }
+  return Array.isArray(data.insights) ? (data.insights as EmployerInsightsRow[]) : [];
+}

--- a/services/employerInsights.ts
+++ b/services/employerInsights.ts
@@ -1,0 +1,89 @@
+/**
+ * employerInsights — typed data contract + fetch stub for the per-company
+ * "wow" traffic report (cold-outreach conversion centrepiece).
+ *
+ * The data lives in Firestore `employer_insights/{companyKey}` and is served
+ * through a Cloud Function (token-gated, per-company). This module is the SPA
+ * boundary: `EmployerInsightsPage` imports `fetchInsights` and the types from
+ * here, so the page never talks to Firestore/HTTP directly.
+ *
+ * NOTE: `fetchInsights` is intentionally a STUB. The real implementation
+ * (CF endpoint URL + token validation + Firestore read) is wired separately —
+ * see the TODO below. Keep the signature stable: the page depends on it.
+ */
+
+/** A single live ad row for the employer. `lost` = interested visitors who did NOT apply. */
+export interface EmployerAd {
+  slug: string;
+  title: string;
+  path: string;
+  views: number;
+  visitors: number;
+  applies: number;
+  lost: number;
+}
+
+/** Aggregate totals across all of the company's ads for the report window. */
+export interface EmployerInsightsTotals {
+  views: number;
+  visitors: number;
+  candidates: number;
+  adsCount: number;
+  /** Interested visitors who did NOT become candidates (the loss-aversion hook). */
+  lost: number;
+  /** Fraction (0–1), e.g. 0.0138 = 1.38%. */
+  conversionRate: number;
+}
+
+/** The full per-company report payload. */
+export interface EmployerInsights {
+  companyKey: string;
+  companyName: string;
+  /** ISO timestamp the report was generated. */
+  generatedAt: string;
+  periodDays: number;
+  totals: EmployerInsightsTotals;
+  topAd: { slug: string; title: string; views: number } | null;
+  /** Sorted by views desc, up to 100. */
+  ads: EmployerAd[];
+  /** Weekly buckets, oldest → newest. */
+  trend: { week: string; views: number }[];
+}
+
+/**
+ * Outcome of a fetch. The page renders one of: loading | ok | not-found | error.
+ * - `ok`        → data present, render the report.
+ * - `not-found` → companyKey/token valid but no data yet (graceful empty state).
+ * - `error`     → invalid/expired token, network failure, etc. (friendly IT message).
+ */
+export type FetchInsightsResult =
+  | { status: 'ok'; data: EmployerInsights }
+  | { status: 'not-found' }
+  | { status: 'error'; reason?: 'invalid-token' | 'expired' | 'network' | 'unknown' };
+
+// HMAC-gated read API. Token scheme lives server-side
+// (functions/src/employerInsights.js) + scripts/lib/employer-insights-token.mjs;
+// the client only forwards the `t` token it received in the cold-email link.
+const FUNCTIONS_BASE = 'https://europe-west6-frontaliere-ticino.cloudfunctions.net';
+
+/**
+ * Fetch a company's insights by key + access token via the employerInsights
+ * Cloud Function. Never throws — returns a discriminated result the page renders.
+ */
+export async function fetchInsights(
+  companyKey: string,
+  token: string,
+): Promise<FetchInsightsResult> {
+  if (!companyKey || !token) return { status: 'error', reason: 'invalid-token' };
+  try {
+    const url = `${FUNCTIONS_BASE}/employerInsights?c=${encodeURIComponent(companyKey)}&t=${encodeURIComponent(token)}`;
+    const res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (res.status === 401 || res.status === 403) return { status: 'error', reason: 'invalid-token' };
+    if (res.status === 404) return { status: 'not-found' };
+    if (!res.ok) return { status: 'error', reason: 'network' };
+    const data = (await res.json()) as EmployerInsights;
+    return data?.totals ? { status: 'ok', data } : { status: 'not-found' };
+  } catch {
+    return { status: 'error', reason: 'network' };
+  }
+}

--- a/services/router.ts
+++ b/services/router.ts
@@ -171,7 +171,7 @@ const SALARY_HUB_ARTICLE_PATHS = new Set([
 
 // ── Route types ──────────────────────────────────────────────
 
-export type ActiveTab = 'calculator' | 'confronti' | 'fisco' | 'guida' | 'vita' | 'stats' | 'feedback' | 'privacy' | 'terms' | 'data-deletion' | 'api-status' | 'gamification' | 'forum' | 'contact' | 'partners' | 'consulting' | 'press-kit' | 'job-board' | 'profile' | 'morning' | 'blog' | 'admin' | 'glossario' | 'faq' | 'sitemap' | 'dialetto' | 'contracts' | 'tfr-calculator' | 'permit-quiz' | 'tredicesima' | 'weekly-digest' | 'tool-of-week' | 'email-confirmed' | 'newsletter-preferences' | 'sindacati' | 'chi-siamo' | 'correzioni' | 'metodologia' | 'tassazione-hub' | 'autore' | 'publish' | 'publisher-dashboard' | 'for-employers';
+export type ActiveTab = 'calculator' | 'confronti' | 'fisco' | 'guida' | 'vita' | 'stats' | 'feedback' | 'privacy' | 'terms' | 'data-deletion' | 'api-status' | 'gamification' | 'forum' | 'contact' | 'partners' | 'consulting' | 'press-kit' | 'job-board' | 'profile' | 'morning' | 'blog' | 'admin' | 'glossario' | 'faq' | 'sitemap' | 'dialetto' | 'contracts' | 'tfr-calculator' | 'permit-quiz' | 'tredicesima' | 'weekly-digest' | 'tool-of-week' | 'email-confirmed' | 'newsletter-preferences' | 'sindacati' | 'chi-siamo' | 'correzioni' | 'metodologia' | 'tassazione-hub' | 'autore' | 'publish' | 'publisher-dashboard' | 'for-employers' | 'employer-insights';
 
 export type CalcolatoreSubTab = 'calculator' | 'whatif' | 'payslip' | 'ral' | 'bonus' | 'parental-leave' | 'residency' | 'salary-quiz';
 export type ConfrontiSubTab = 'exchange' | 'banks' | 'health' | 'mobile' | 'shopping' | 'cost-of-living' | 'jobs' | 'renovation';
@@ -2237,6 +2237,14 @@ export function parsePath(pathname: string): ParseResult {
  const table = SLUG_TABLES[locale];
  const revTop = REVERSE_TOP[locale];
 
+ // Per-company "stats proof" page (/azienda/<companyKey>/) — private, reached
+ // only via the HMAC-tokenized link in cold-outreach emails (?t=…), noindex,
+ // not in site nav. The companyKey is a path segment; EmployerInsightsPage reads
+ // it + the token itself. Any non-empty second segment is a valid company key.
+ if (parts[0] === 'azienda' && parts[1]) {
+   return { route: { activeTab: 'employer-insights' }, locale };
+ }
+
  // Fuel-daily static SEO pages (F6) — /prezzi-diesel/oggi/, /en/diesel-price-switzerland/today/, etc.
  // These are build-time static HTML rendered OUTSIDE `#root` (see
  // build-plugins/htmlTemplate.ts seoContentOutsideRoot). Soft-nav still
@@ -3359,6 +3367,11 @@ export function buildPath(route: AppRoute, locale?: Locale): string {
  return finish(`${prefix}/${table.publisherDashboard}${hashSuffix}`);
  case 'for-employers':
  return finish(`${prefix}/${table.forEmployers}${hashSuffix}`);
+ case 'employer-insights':
+ // Per-company stats page; the real per-company link (with ?t=token) is
+ // generated server-side (scripts/lib/employer-insights-token.mjs). buildPath
+ // only needs the base for exhaustiveness/soft-nav.
+ return finish(`${prefix}/azienda/${hashSuffix}`);
  case 'partners':
  return finish(`${prefix}/${table.partners}${hashSuffix}`);
  case 'consulting':

--- a/tests/employer-insights-token.test.ts
+++ b/tests/employer-insights-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { makeInsightsToken, buildInsightsUrl } from '../scripts/lib/employer-insights-token.mjs';
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { generateInsightsToken, verifyInsightsToken } from '../functions/src/employerInsights.js';
+
+// The stats-page gate works only if the link generator (scripts/lib) and the
+// verifier (Cloud Function) sign IDENTICALLY. Any drift silently 403s every
+// emailed link — a load-bearing invariant, not a nit.
+describe('employer-insights token: generator ↔ verifier parity', () => {
+  const SECRET = 'test-secret-123';
+  const KEY = 'eoc-ente-ospedaliero-cantonale';
+
+  it('client helper and Cloud Function produce the same token', () => {
+    expect(makeInsightsToken(KEY, SECRET)).toBe(generateInsightsToken(KEY, SECRET));
+  });
+
+  it('Cloud Function verifies a valid token and rejects a tampered one', () => {
+    const t = makeInsightsToken(KEY, SECRET);
+    expect(verifyInsightsToken(KEY, t, SECRET)).toBe(true);
+    expect(verifyInsightsToken(KEY, t.slice(0, -1) + (t.endsWith('0') ? '1' : '0'), SECRET)).toBe(false);
+    expect(verifyInsightsToken('other-company', t, SECRET)).toBe(false);
+  });
+
+  it('builds a canonical tokenized URL (trailing slash, ?t=)', () => {
+    const url = buildInsightsUrl(KEY, SECRET);
+    expect(url).toMatch(/^https:\/\/frontaliereticino\.ch\/azienda\/eoc-ente-ospedaliero-cantonale\/\?t=[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
## Implementato
- **Data layer** `scripts/build-employer-insights.mjs`: genera insight per-azienda da PostHog (views per annuncio via `$pageview` sul path, candidati via `job_apply`, trend settimanale) joinati con `jobs.json`; attribuzione per substring del `companyKey` (cattura anche annunci scaduti); scrive Firestore `employer_insights/{companyKey}`. **502 aziende popolate live.**
- **CF `employerInsights`** (`functions/src/employerInsights.js`): read API HMAC-gated, `GET ?c=&t=` → JSON; token manomesso → 403, assente → 404.
- **CF `adminEmployerInsights`** (`functions/src/adminEmployerInsights.js`): admin-gated (stesso allowlist/pattern di `githubProxy`), ritorna lista lean + URL tokenizzato "apri come azienda".
- **Pagina `/azienda/<companyKey>/`** (`EmployerInsightsPage.tsx` + `components/insights/*`): report animato "wow" — count-up KPI, hammer loss-aversion (`lost`), bar chart top annunci, sparkline trend, CTA → `/pubblica-offerta/?claim=1&tier=azienda`. **noindex** (pagina privata, route client-only), `prefers-reduced-motion` aware, solo token semantici.
- **Pannello admin "Insights Aziende"** (`AdminPanel.tsx` + `services/adminInsights.ts`): lista 502 aziende ordinabile/filtrabile + "apri come azienda ↗".
- **Token condiviso** `scripts/lib/employer-insights-token.mjs` (prefix `employer_insights:`, no replay come unsubscribe); `adminEmployerInsights` importa `generateInsightsToken` da `employerInsights.js` (no duplicazione HMAC).
- **Routing**: `parsePath`/`buildPath` per `/azienda/<key>/` + render in `App.tsx`; `services/employerInsights.ts` fetch reale dal CF.
- **CTA email**: cold-email touch 1 ora linka la pagina stats (`{{INSIGHTS_URL}}`, HMAC-gated).
- **Test** `tests/employer-insights-token.test.ts`: parità generator↔verifier (drift = gate rotto).

## Non implementato (ancora)
- **Tracking visita/conversione attribuita**: la visita alla pagina è un segnale di interesse ma non è ancora loggata a Firestore né attribuita a signup/upgrade — follow-up.
- **Rigenerazione schedulata** di `employer_insights`: oggi run manuale (`build-employer-insights.mjs --apply`); workflow cron = follow-up.
- **Trend per-annuncio degli applies**: `job_apply` è nuovo (~1 settimana di storia); le **views** hanno storia piena. Il trend mostrato è sulle views.
- **noindex solo client-side**: corretto perché la route è privata/tokenizzata e non SSG'd (non in sitemap, raggiunta solo via link email).
- **Verifica claim→companyKey end-to-end** (il link claim porta `tier=azienda` ma il binding traffico↔account resta euristico per-nome): follow-up separato.