### PR TITLE
fix(deploy): serialise at job boundary so next build doesn't wait for prior deploy/validate/publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,19 +102,27 @@ permissions:
   id-token: write
   issues: write     # for github-issue-creator on build/deploy failure
 
-# Workflow-level serialisation: ONE deploy run at a time, newest-wins.
-# GitHub cancels any previously *pending* run in this group when a newer one
-# queues, while the in-progress run finishes (cancel-in-progress: false). So
-# while a build is running no other deploy starts, and when it finishes only the
-# LATEST queued run proceeds (intermediate queued runs are superseded). This
-# restores the monolith's pages-build behaviour for the MATRIX path, which is a
-# 3-job sub-pipeline (matrix-setup → prep → build-locale ×4) that a per-job
-# concurrency group cannot serialise without the matrix legs cancelling each
-# other. It also removes the race on the CDN / frontaliere-<loc> force-push
-# targets by construction (no two deploys ever overlap).
-concurrency:
-  group: deploy-to-github-pages
-  cancel-in-progress: false
+# NO workflow-level concurrency on purpose. A workflow-level group
+# (`deploy-to-github-pages`, cancel-in-progress: false) used to serialise the
+# WHOLE run, but that blocked a new push from even starting its build until the
+# previous run had finished EVERY step — including the deploy job's up-to-40-min
+# server-side Pages poll, validate-live and publish. The next build sat idle for
+# ~1h ("This workflow is waiting for Deploy to GitHub Pages #N to complete before
+# running"), even though nothing it does conflicts with the prior run's
+# post-build steps.
+#
+# Serialisation is instead applied at the JOB boundary, exactly where a race can
+# happen, so a new run can build while the previous run is still deploying /
+# validating / publishing:
+#   - monolith `build`        → group `pages-build`               (one build at a time)
+#   - matrix `build-locale`   → group `pages-build-locale-<loc>`  (per-locale: the 4
+#       legs of ONE run never collide — distinct groups — but the SAME locale
+#       serialises across runs, so two runs never race the same CDN / frontaliere-<loc>
+#       force-push target; the CDN push lives only in the `it` leg)
+#   - `deploy`                → group `pages-deploy`              (one Pages publish at a time)
+# Each group is newest-wins (cancel-in-progress: false → GitHub's 1 running + 1
+# pending cap drops the superseded middle run), which is correct for a cumulative
+# cron-driven site where the latest build already contains the intermediate ones.
 
 jobs:
   build:
@@ -1778,10 +1786,18 @@ jobs:
     if: ${{ vars.LOCALE_MATRIX_BUILD == 'true' || github.event.inputs.force_matrix == 'true' }}
     needs: [matrix-setup, prep]
     runs-on: ubuntu-latest
-    # NO job-level concurrency: the matrix legs must NOT cancel each other, and
-    # cross-run serialisation (no two deploys racing the CDN / frontaliere-<loc>
-    # force-push targets) is now handled by the WORKFLOW-LEVEL concurrency group
-    # at the top of this file (one deploy run at a time, newest-wins).
+    # Per-LOCALE concurrency: the group is keyed on matrix.locale, so the 4 legs
+    # of ONE run get 4 distinct groups and never cancel each other, while the
+    # SAME locale serialises ACROSS runs. That prevents two runs racing the same
+    # CDN / frontaliere-<loc> force-push target (the CDN push lives only in the
+    # `it` leg → `pages-build-locale-it` serialises it) WITHOUT a workflow-level
+    # lock that would otherwise stall the next build behind the prior run's
+    # deploy/validate/publish tail. newest-wins (cancel-in-progress: false →
+    # 1 running + 1 pending, superseded middle dropped) — the cumulative build
+    # makes the latest a superset of any dropped intermediate.
+    concurrency:
+      group: pages-build-locale-${{ matrix.locale }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
## Implementato

- Rimossa la concurrency **workflow-level** `group: deploy-to-github-pages` (`cancel-in-progress: false`) in `.github/workflows/deploy.yml`. Quel group serializzava l'**intero run**: un nuovo push su `main` non poteva nemmeno iniziare il build finché il run precedente non completava **ogni** step — incluso il poll server-side fino a 40 min del job `deploy`, `validate-live` e `publish`. Da qui il messaggio *"This workflow is waiting for Deploy to GitHub Pages #N to complete before running"* (run 27951940323 in coda dietro #12621), con il build successivo fermo ~1h.
- Spostata la serializzazione al **confine di job**, dove le race accadono davvero:
  - `build-locale` (matrix) → nuovo group **per-locale** `pages-build-locale-${{ matrix.locale }}`: le 4 leg dello **stesso** run hanno group distinti → non si cancellano a vicenda; la **stessa** locale serializza **cross-run** → due run non fanno mai race sullo stesso target force-push CDN / `frontaliere-<loc>` (il push CDN vive solo nella leg `it` → lo serializza `pages-build-locale-it`).
  - `deploy` → invariato, mantiene il suo group `pages-deploy` (un solo publish Pages alla volta).
  - monolith `build` → invariato, group `pages-build`.
- Aggiornati i commenti (top-file + `build-locale`) che descrivevano il design vecchio (rimosso il riferimento stale a "WORKFLOW-LEVEL concurrency group").

Risultato: il run nuovo builda mentre il precedente è ancora in deploy/validate/publish; resta serial **solo** il confine deploy/Pages-publish. Allineato al design già documentato nei commenti del job `deploy` ("the lock is acquired only at the publish boundary; multiple builds progress in parallel"), che la concurrency workflow-level contraddiceva.

## Non implementato (ancora)

- **`deploy-matrix-experiment.yml`** (sibling con `build-locale` analogo): NON toccato. Ha un group workflow-level isolato `deploy-matrix-experiment`, è **dispatch-only** (esperimento, non triggerato da push) e non gateifica il deploy di produzione → non causa lo stall. Out of scope; il path matrix di produzione vive ora in `deploy.yml`.
- **Skew transitorio shard↔Pages durante burst**: senza il lock globale, in un burst il group `pages-deploy` può droppare il deploy "middle" (newest-wins, 1 running + 1 pending) mentre le sue shard en/de/fr sono già pushate → breve divergenza shard vs Pages. Auto-risolto al run successivo (build cumulativo = superset). Tradeoff accettato e intrinseco al newest-wins già in uso; revert-trigger: se emergesse divergenza shard↔Pages persistente live, ripristinare la serializzazione globale.
- Verifica live del comportamento (build del run N+1 che parte durante deploy/poll del run N) osservabile solo post-merge sul prossimo burst di push su `main`.