### PR TITLE
fix(rail-ads): widen content + fill side rails gap-free on every page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2343,14 +2343,14 @@ const App: React.FC = () => {
   * sitemap links, weekly employers teaser) regardless of overlay mode.
   */}
  {!staticOverlay && (
- <div className={sideRailEligible ? 'ft-rail-grid-spa contents xlw:grid xlw:flex-grow xlw:grid-cols-[160px_minmax(0,1fr)_160px] xlw:gap-6' : 'contents'}>
+ <div className={sideRailEligible ? 'ft-rail-grid-spa contents xlw:grid xlw:flex-grow xlw:grid-cols-[160px_minmax(0,1fr)_160px] xlw:gap-4' : 'contents'}>
  {sideRailEligible && (
  <aside className="ft-rail-aside hidden xlw:flex xlw:flex-col">
  <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>
  </aside>
  )}
  <main id="main-content" tabIndex={-1} className={`flex-grow mx-auto py-4 lg:py-8 scroll-mt-20 focus:outline-none transition-[max-width,padding] duration-300 ease-out relative z-10 ${
- activeTab === 'admin' ? 'w-full px-3 sm:px-6' : '!max-w-[2400px] !w-[95%] px-3 sm:px-4'
+ activeTab === 'admin' ? 'w-full px-3 sm:px-6' : `!max-w-[2400px] !w-[95%] px-3 sm:px-4${sideRailEligible ? ' xlw:!w-full' : ''}`
  }`}>
  <Suspense fallback={<LazyFallback />}>
  {notFoundPath ? (

--- a/App.tsx
+++ b/App.tsx
@@ -2346,7 +2346,7 @@ const App: React.FC = () => {
  <div className={sideRailEligible ? 'ft-rail-grid-spa contents xlw:grid xlw:flex-grow xlw:grid-cols-[160px_minmax(0,1fr)_160px] xlw:gap-4' : 'contents'}>
  {sideRailEligible && (
  <aside className="ft-rail-aside hidden xlw:flex xlw:flex-col">
- <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>
+ <Suspense fallback={null}><ArticleRailAdStack side="left" narrow /></Suspense>
  </aside>
  )}
  <main id="main-content" tabIndex={-1} className={`flex-grow mx-auto py-4 lg:py-8 scroll-mt-20 focus:outline-none transition-[max-width,padding] duration-300 ease-out relative z-10 ${
@@ -2646,7 +2646,7 @@ const App: React.FC = () => {
  </main>
  {sideRailEligible && (
  <aside className="ft-rail-aside hidden xlw:flex xlw:flex-col">
- <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense>
+ <Suspense fallback={null}><ArticleRailAdStack side="right" narrow /></Suspense>
  </aside>
  )}
  </div>

--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -332,7 +332,7 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  // pages (≥97% bounce) to honour their deliberate no-ad opt-out.
  const railsEnabled = seoContentOutsideRoot && !disableAutoAds;
  const railGridOpen = railsEnabled
-   ? ` <div class="ft-rail-grid xlw:grid xlw:grid-cols-[300px_minmax(0,1fr)_300px] xlw:gap-6 xlw:mx-auto xlw:max-w-[1768px]">
+   ? ` <div class="ft-rail-grid xlw:grid xlw:grid-cols-[300px_minmax(0,1fr)_300px] xlw:gap-4 xlw:mx-auto xlw:max-w-[1768px]">
  <aside id="rail-left-root" class="ft-rail-aside hidden xlw:flex xlw:flex-col" aria-hidden="true"></aside>`
    : '';
  const railGridClose = railsEnabled

--- a/build-plugins/shared/criticalCss.ts
+++ b/build-plugins/shared/criticalCss.ts
@@ -71,14 +71,14 @@ export const RAIL_RESERVE_CSS =
   '.ft-rail-aside-x{display:none}' +
   '.ft-rail-grid-spa{display:contents}' +
   '@media(min-width:1280px) and (max-width:1399.98px){' +
-  '.ft-rail-grid-x{display:grid;grid-template-columns:180px minmax(0,1fr) 180px;gap:1.5rem}' +
+  '.ft-rail-grid-x{display:grid;grid-template-columns:180px minmax(0,1fr) 180px;gap:1rem}' +
   '.ft-rail-aside-x{display:block}' +
   '}' +
   '@media(min-width:1400px){' +
   'main:not(.seo-static-content):not(.cluster-seo-prose){max-width:calc(100vw - 360px)}' +
-  '.ft-rail-grid{display:grid;grid-template-columns:300px minmax(0,1fr) 300px;gap:1.5rem;margin-inline:auto;max-width:1768px}' +
-  '.ft-rail-grid-spa{display:grid;grid-template-columns:300px minmax(0,1fr) 300px;gap:1.5rem}' +
-  '.ft-rail-grid-x{display:grid;grid-template-columns:300px minmax(0,1fr) 300px;gap:1.5rem}' +
+  '.ft-rail-grid{display:grid;grid-template-columns:300px minmax(0,1fr) 300px;gap:1rem;margin-inline:auto;max-width:1768px}' +
+  '.ft-rail-grid-spa{display:grid;grid-template-columns:160px minmax(0,1fr) 160px;gap:1rem}' +
+  '.ft-rail-grid-x{display:grid;grid-template-columns:300px minmax(0,1fr) 300px;gap:1rem}' +
   '.ft-rail-aside,.ft-rail-aside-x{display:flex;flex-direction:column;min-height:600px}' +
   '}' +
   '@media(min-width:1800px){main:not(.seo-static-content):not(.cluster-seo-prose){max-width:calc(100vw - 420px)}}';

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -1854,7 +1854,7 @@ function BlogArticles({
      letting `xl:` and `xlw:` both match ≥1400: in v4 the `xl:` rule emits
      after `xlw:` and would win the cascade, pinning the rails at 180px and
      making a 300px creative overflow the article (see index.css @theme). */}
- <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop only) ── */}
  <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6334,7 +6334,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
      at xlw (≥1400) and only serve there; below xl it's a single column.
      NOTE: overrides the FRO-2026-04-26 prune (rails earned €0.06–0.10 RPM on
      the gate) per explicit owner request. */}
- <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop xl only) ── */}
  <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">
@@ -7056,7 +7056,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
      half-page creatives — same full-height side-rail layout as the article
      detail (BlogArticles) and expired-job views. Rail creatives only
      materialise at xlw; the narrow xl tier shows empty gutters. */}
- <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop xl only) ── */}
  <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">

--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -702,7 +702,7 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
 
  {/* 3-column grid: left rail | content | right rail. 180px at xl (1280–1399),
      300px at xlw (≥1400) to host ArticleRailAd half-page creatives. */}
- <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop xl only) ── */}
  <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">

--- a/components/community/JobOrphanView.tsx
+++ b/components/community/JobOrphanView.tsx
@@ -530,7 +530,7 @@ export default function JobOrphanView({ slug, onBack, hasAccess: hasAccessProp, 
 
  {/* 3-column grid: left rail | content | right rail. 180px at xl (1280–1399),
      300px at xlw (≥1400) to host ArticleRailAd half-page creatives. */}
- <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-6 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
 
  {/* ── Left Rail (desktop xl only) ── */}
  <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">

--- a/components/shared/ArticleRailAd.tsx
+++ b/components/shared/ArticleRailAd.tsx
@@ -24,8 +24,13 @@ const RAIL_AD_UNIT_PATHS = {
 } as const;
 
 // Premium vertical display sizes first, box + fluid as fallback — must match
-// what the GAM ad unit allows (see scripts/gam-create-rail-units.mjs).
+// what the GAM ad unit allows (see scripts/gam-create-rail-units.mjs). Used on
+// the wide (300px) reading-page rails (blog / job / static SEO).
 const RAIL_SIZES: GptSize[] = [[300, 600], [160, 600], [300, 250], 'fluid'];
+// Narrow rail (160px SPA tool-page gutter): only 160-wide creatives + fluid, so
+// GAM can't serve a 300-wide creative that would overflow the 160px column into
+// the content/gap at ≥1400px.
+const RAIL_SIZES_NARROW: GptSize[] = [[160, 600], 'fluid'];
 
 export interface ArticleRailAdProps {
   side: keyof typeof RAIL_AD_UNIT_PATHS;
@@ -38,14 +43,20 @@ export interface ArticleRailAdProps {
    * 600px box down the gutter.
    */
   reserve?: boolean;
+  /**
+   * Narrow (160px) gutter — the SPA tool-page rail. Restricts requested sizes to
+   * 160-wide so no creative overflows the column. Reading-page rails (300px)
+   * omit this and keep the full premium size set.
+   */
+  narrow?: boolean;
 }
 
-const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true, reserve = true }) => {
+const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true, reserve = true, narrow = false }) => {
   const { articleRailAds: killed } = useKillSwitches();
   return (
     <GptAdSlot
       adUnitPath={RAIL_AD_UNIT_PATHS[side]}
-      sizes={RAIL_SIZES}
+      sizes={narrow ? RAIL_SIZES_NARROW : RAIL_SIZES}
       killed={killed}
       enabled={enabled}
       minHeight={reserve ? 600 : 0}

--- a/components/shared/ArticleRailAd.tsx
+++ b/components/shared/ArticleRailAd.tsx
@@ -31,9 +31,16 @@ export interface ArticleRailAdProps {
   side: keyof typeof RAIL_AD_UNIT_PATHS;
   /** Article-eligibility gate (long-enough body), wired from BlogArticles. */
   enabled?: boolean;
+  /**
+   * Reserve the 600px CLS placeholder. Only the first (near-fold) panel of the
+   * rail stack needs it; lower panels pass `false` so an unfilled slot collapses
+   * to zero (GptAdSlot drops empty slots from layout) instead of leaving a blank
+   * 600px box down the gutter.
+   */
+  reserve?: boolean;
 }
 
-const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true }) => {
+const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true, reserve = true }) => {
   const { articleRailAds: killed } = useKillSwitches();
   return (
     <GptAdSlot
@@ -41,12 +48,13 @@ const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true }) =
       sizes={RAIL_SIZES}
       killed={killed}
       enabled={enabled}
-      minHeight={600}
-      // Not sticky itself — it sits inside the rail's `sticky top-6` stack so it
-      // rides down the gutter. CSS-gated to the widened (≥1400px) rail via the
+      minHeight={reserve ? 600 : 0}
+      // One panel in the rail stack; the stack stacks several back-to-back to
+      // fill the gutter top-to-bottom (separation comes from the stack's flex
+      // gap, so no `mt-*` here). CSS-gated to the widened (≥1400px) rail via the
       // `xlw` breakpoint (the arbitrary `min-[1400px]:` variant lost the v4
       // cascade to `xl:`, so the rail never widened — see index.css @theme).
-      className="hidden xlw:block w-full text-center mt-3"
+      className="hidden xlw:block w-full text-center"
     />
   );
 };

--- a/components/shared/ArticleRailAdStack.tsx
+++ b/components/shared/ArticleRailAdStack.tsx
@@ -40,6 +40,12 @@ export interface ArticleRailAdStackProps {
    * is still height-driven — this is only the ceiling.
    */
   count?: number;
+  /**
+   * Narrow (160px) gutter — the SPA tool-page rail. Forwarded to ArticleRailAd
+   * so it requests only 160-wide creatives (no overflow). Reading-page rails
+   * (300px) omit this.
+   */
+  narrow?: boolean;
 }
 
 // Approx height of one half-page rail panel (600px creative + flex gap).
@@ -47,7 +53,7 @@ const PANEL_PX = 620;
 // Bound the number of same-unit requests; tall pages cap here, short pages get 1.
 const MAX_PANELS = 6;
 
-const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count }) => {
+const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count, narrow = false }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [panels, setPanels] = useState(1);
   const maxPanels = Math.max(1, count ?? MAX_PANELS);
@@ -75,7 +81,7 @@ const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled =
     // tier (1280–1399) shows no rail ads, exactly as before.
     <div ref={ref} className="hidden xlw:flex xlw:flex-col xlw:flex-1 xlw:min-h-0 gap-2">
       {Array.from({ length: panels }, (_, i) => (
-        <ArticleRailAd key={i} side={side} enabled={enabled} reserve={i === 0} />
+        <ArticleRailAd key={i} side={side} enabled={enabled} reserve={i === 0} narrow={narrow} />
       ))}
     </div>
   );

--- a/components/shared/ArticleRailAdStack.tsx
+++ b/components/shared/ArticleRailAdStack.tsx
@@ -1,52 +1,81 @@
 /**
  * ArticleRailAdStack — full-length desktop side-rail ad chain.
  *
- * Replaces the single sticky half-page ad with a vertical chain of sticky ad
- * panels that span the ENTIRE article column height, so the wide desktop gutter
- * is monetised top-to-bottom instead of going empty below the first ad (the
- * complaint the screenshots show: one creative rides the top, the rest of the
- * tall gutter stays blank).
+ * Fills the tall desktop gutter top-to-bottom with a vertical chain of ad
+ * panels so the rail is *continuous* — no blank stretch below the first
+ * creative (the complaint the screenshots show: one ad rides the top, the rest
+ * of the gutter stays empty).
  *
- * Each panel is an equal-height (`flex-1`) flex child that forms its OWN sticky
- * containing block: its `sticky top-6` ad rides that panel's slice of the
- * column and hands off to the next as the reader scrolls. Because every panel
- * pins inside its own box (not the whole rail), the ads never overlap — one is
- * always in view, all the way down. The whole track only materialises at the
- * widened (≥1400px / `xlw`) rail, matching ArticleRailAd's own CSS gate.
+ * How the gap-free fill works:
+ *  - The stack measures its own rendered height (it `flex-1`-stretches to the
+ *    grid row = the article column height) and asks for ~one half-page panel per
+ *    ~620px of gutter, so a tall page gets more panels and a short one fewer.
+ *  - Panels flow naturally (NOT `flex-1`-stretched) and butt together with a
+ *    small flex gap — no panel is taller than its creative, so there's no empty
+ *    slack inside a panel.
+ *  - Only the first panel reserves the 600px CLS placeholder; the rest pass
+ *    `reserve={false}`. Combined with GptAdSlot collapsing any slot GPT reports
+ *    empty (`display:none`), unfilled panels vanish from layout instead of
+ *    leaving a blank box, so the filled panels stay flush.
+ *
+ * The whole track only materialises at the widened (≥1400px / `xlw`) rail,
+ * matching ArticleRailAd's own CSS gate.
  *
  * Renders multiple GPT slots of the same /23355151813/article-rail-{side} unit;
- * each GptAdSlot mints a unique div id, so multi-slot serving is fine.
- * `collapseEmptyDivs(true)` + the per-slot IntersectionObserver mean panels that
- * never fill (or are never scrolled into view) cost nothing. Same kill-switch as
- * ArticleRailAd (it owns the Remote Config gate).
+ * each GptAdSlot mints a unique div id, so multi-slot serving is fine. Same
+ * kill-switch as ArticleRailAd (it owns the Remote Config gate).
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ArticleRailAd from '@/components/shared/ArticleRailAd';
 
 export interface ArticleRailAdStackProps {
   side: 'left' | 'right';
   /** Article-eligibility gate (long-enough body), wired from BlogArticles. */
   enabled?: boolean;
-  /** How many sticky ad panels to distribute down the rail (clamped ≥1). */
+  /**
+   * Max panels cap. BlogArticles passes a length-gated value so long-form posts
+   * fill more of the gutter while short ones stay light; omitted elsewhere
+   * (tools / job-board / static), where we cap at MAX_PANELS. The actual count
+   * is still height-driven — this is only the ceiling.
+   */
   count?: number;
 }
 
-const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count = 2 }) => {
-  const panels = Math.max(1, count);
+// Approx height of one half-page rail panel (600px creative + flex gap).
+const PANEL_PX = 620;
+// Bound the number of same-unit requests; tall pages cap here, short pages get 1.
+const MAX_PANELS = 6;
+
+const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [panels, setPanels] = useState(1);
+  const maxPanels = Math.max(1, count ?? MAX_PANELS);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const measure = () => {
+      const h = el.getBoundingClientRect().height;
+      // Match the gutter height as closely as possible: round so the chain
+      // neither under-fills (blank tail) nor badly over-fills (pushes the row).
+      const next = Math.max(1, Math.min(maxPanels, Math.round(h / PANEL_PX)));
+      setPanels((prev) => (prev === next ? prev : next));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [maxPanels]);
+
   return (
-    // Fills the remaining gutter height below the rail's top content. Only the
-    // widened rail (`xlw`, ≥1400px) hosts the half-page chain — the narrow xl
+    // `flex-1` stretches the stack to the full gutter height so the measurement
+    // reflects the article column. Panels flow top-to-bottom with a tight gap.
+    // Only the widened rail (`xlw`, ≥1400px) hosts the chain — the narrow xl
     // tier (1280–1399) shows no rail ads, exactly as before.
-    <div className="hidden xlw:flex xlw:flex-col xlw:flex-1 xlw:min-h-0">
+    <div ref={ref} className="hidden xlw:flex xlw:flex-col xlw:flex-1 xlw:min-h-0 gap-2">
       {Array.from({ length: panels }, (_, i) => (
-        // Each panel is its own sticky containing block so the ads form a
-        // hand-off chain (no two pin at top-6 at once → no overlap).
-        <div key={i} className="flex-1 min-h-0">
-          <div className="sticky top-6">
-            <ArticleRailAd side={side} enabled={enabled} />
-          </div>
-        </div>
+        <ArticleRailAd key={i} side={side} enabled={enabled} reserve={i === 0} />
       ))}
     </div>
   );

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -113,6 +113,10 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   style,
 }) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  // GPT slot + its slotRenderEnded handler, kept so unmount can tear both down
+  // (remove the global pubads listener and destroy the slot).
+  const slotRef = useRef<any>(null);
+  const slotHandlerRef = useRef<((event: any) => void) | null>(null);
   // Stable, unique DOM id for this slot instance (GPT needs a real element id).
   const divIdRef = useRef<string>(`gpt-slot-${++slotSeq}`);
   const [rendered, setRendered] = useState(false);
@@ -155,12 +159,17 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
         try {
           const slot = gt.defineSlot(adUnitPath, sizes, divId)?.addService(gt.pubads());
           if (!slot) return;
+          slotRef.current = slot;
           // Collapse this wrapper to zero when GPT renders the slot empty (no
           // creative AND no AdSense backfill) so the reserved placeholder never
           // shows as a blank box. Scoped to this slot via identity match.
-          gt.pubads().addEventListener('slotRenderEnded', (event: any) => {
+          // Held in a ref so unmount can remove it — otherwise every slot leaks
+          // a global pubads listener that re-fires for every other slot.
+          const handler = (event: any) => {
             if (event?.slot === slot) setEmpty(!!event.isEmpty);
-          });
+          };
+          slotHandlerRef.current = handler;
+          gt.pubads().addEventListener('slotRenderEnded', handler);
           gt.display(divId);
           setRendered(true);
         } catch {
@@ -182,7 +191,24 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
       { rootMargin: '200px 0px' },
     );
     io.observe(wrapper);
-    return () => io.disconnect();
+    return () => {
+      io.disconnect();
+      // Tear down the slot + its listener so SPA navigations don't accumulate
+      // global pubads listeners (each would re-fire for every other slot).
+      try {
+        const gt = gtag();
+        if (slotHandlerRef.current) {
+          gt.pubads().removeEventListener('slotRenderEnded', slotHandlerRef.current);
+          slotHandlerRef.current = null;
+        }
+        if (slotRef.current) {
+          gt.destroySlots?.([slotRef.current]);
+          slotRef.current = null;
+        }
+      } catch {
+        /* fail-soft */
+      }
+    };
   }, [active, adUnitPath, sizes]);
 
   if (!active) return null;

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -116,6 +116,13 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   // Stable, unique DOM id for this slot instance (GPT needs a real element id).
   const divIdRef = useRef<string>(`gpt-slot-${++slotSeq}`);
   const [rendered, setRendered] = useState(false);
+  // GPT reported this slot as unfilled (no creative / no backfill). We then
+  // collapse the wrapper to zero so the reserved `minHeight` placeholder never
+  // leaves a blank box — the cause of the empty gaps down the side-rail stack
+  // (collapseEmptyDivs only collapses GPT's inner div, not this CLS-reserve
+  // wrapper). Stacked rail slots that don't fill simply vanish, so the filled
+  // ones butt together with no whitespace.
+  const [empty, setEmpty] = useState(false);
   const active = GPT_ENABLED && enabled && IS_PROD && !SKIP_FOR_BOT && !killed;
 
   useEffect(() => {
@@ -148,6 +155,12 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
         try {
           const slot = gt.defineSlot(adUnitPath, sizes, divId)?.addService(gt.pubads());
           if (!slot) return;
+          // Collapse this wrapper to zero when GPT renders the slot empty (no
+          // creative AND no AdSense backfill) so the reserved placeholder never
+          // shows as a blank box. Scoped to this slot via identity match.
+          gt.pubads().addEventListener('slotRenderEnded', (event: any) => {
+            if (event?.slot === slot) setEmpty(!!event.isEmpty);
+          });
           gt.display(divId);
           setRendered(true);
         } catch {
@@ -177,10 +190,13 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   return (
     <div
       ref={wrapperRef}
-      aria-hidden={!rendered}
+      aria-hidden={!rendered || empty}
       // Reserve space to avoid CLS when the creative fills (mirrors
-      // placeholderMinHeight in services/adsenseSlots.ts).
-      style={{ minHeight, contain: 'layout', ...style }}
+      // placeholderMinHeight in services/adsenseSlots.ts). Once GPT reports the
+      // slot empty we drop it from layout entirely (`display:none`) so it adds
+      // neither reserved height nor a flex-gap slot — keeping the side-rail
+      // stack gapless.
+      style={empty ? { display: 'none' } : { minHeight, contain: 'layout', ...style }}
       className={className}
     >
       <div id={divIdRef.current} />

--- a/index.html
+++ b/index.html
@@ -280,14 +280,14 @@
       .ft-rail-aside, .ft-rail-aside-x { display: none; }
       .ft-rail-grid-spa { display: contents; }
       @media (min-width: 1280px) and (max-width: 1399.98px) {
-        .ft-rail-grid-x { display: grid; grid-template-columns: 180px minmax(0,1fr) 180px; gap: 1.5rem; }
+        .ft-rail-grid-x { display: grid; grid-template-columns: 180px minmax(0,1fr) 180px; gap: 1rem; }
         .ft-rail-aside-x { display: block; }
       }
       @media (min-width: 1400px) {
         main:not(.seo-static-content):not(.cluster-seo-prose) { max-width: calc(100vw - 360px); }
-        .ft-rail-grid { display: grid; grid-template-columns: 300px minmax(0,1fr) 300px; gap: 1.5rem; margin-inline: auto; max-width: 1768px; }
-        .ft-rail-grid-spa { display: grid; grid-template-columns: 300px minmax(0,1fr) 300px; gap: 1.5rem; }
-        .ft-rail-grid-x { display: grid; grid-template-columns: 300px minmax(0,1fr) 300px; gap: 1.5rem; }
+        .ft-rail-grid { display: grid; grid-template-columns: 300px minmax(0,1fr) 300px; gap: 1rem; margin-inline: auto; max-width: 1768px; }
+        .ft-rail-grid-spa { display: grid; grid-template-columns: 160px minmax(0,1fr) 160px; gap: 1rem; }
+        .ft-rail-grid-x { display: grid; grid-template-columns: 300px minmax(0,1fr) 300px; gap: 1rem; }
         .ft-rail-aside, .ft-rail-aside-x { display: flex; flex-direction: column; min-height: 600px; }
       }
       @media (min-width: 1800px) {


### PR DESCRIPTION
## Implementato

Fix dei due bug delle barre ads laterali desktop (≥1400px / `xlw`) segnalati negli screenshot, applicato a **tutte** le superfici con rail: pagine-strumento SPA, landing SEO statiche, blog, job-board + **auth-gate**, job-detail/orphan/expired.

**Bug 1 — spazio bianco laterale tra contenuto e ads / contenuto stretto.**
- Ridotto il gap del rail-grid 24px→16px (`gap-6`→`gap-4`) su tutti i grid: `App.tsx` (`ft-rail-grid-spa`), `JobBoard.tsx` ×2, `JobOrphanView`, `JobExpiredView`, `BlogArticles` (`ft-rail-grid-x`), `htmlTemplate.ts` (`ft-rail-grid` statico).
- `main` ora riempie la sua cella centrale a `xlw` (`xlw:!w-full`) sulle pagine con rail, invece di stare a `!w-[95%]` centrato (eliminati ~21px di margine morto per lato).
- **Root cause del rail SPA ancora a 300px:** la critical-CSS hand-maintained in `index.html` (e in `criticalCss.ts`) diceva ancora `300px` per `ft-rail-grid-spa`, sovrascrivendo la classe Tailwind 160px introdotta da #2663 → #2663 era di fatto inerte. Allineate entrambe a 160px.
- Verificato in dev a 1500px: contenuto **802→1140px**, gap laterale **45→16px**, nessun overflow-x (homepage + fisco).

**Bug 2 — rail con un solo ad in alto poi vuoto ("Spazio NON fillato").**
- `GptAdSlot` non gestiva `slotRenderEnded`: il placeholder CLS da 600px restava riservato anche quando lo slot rendeva vuoto (`collapseEmptyDivs` collassa solo il div interno di GPT, non il wrapper) → box bianco. Ora al `slotRenderEnded` con `isEmpty` il wrapper passa a `display:none` (esce dal layout, niente flex-gap residuo).
- `ArticleRailAdStack` riscritto: misura l'altezza del gutter (ResizeObserver) e impila ~un pannello half-page ogni ~620px (flowing, **non** più `flex-1` stretchato + sticky). I creativi riempiti si toccano top-to-bottom; quelli non riempiti collassano. Solo il primo pannello riserva i 600px CLS (`reserve` prop su `ArticleRailAd`).
- `BlogArticles` continua a passare `count` length-gated, ora usato come **tetto** massimo dei pannelli (densità ads per-articolo preservata).

Test: `static-seo-rail-ads` + `app-no-blanket-no-auto-ads` verdi (6/6); `tsc` pulito sui file toccati; sibling-pattern checker eseguito (solo match euristici di token su AdSense slot ≠ stesso costrutto GPT). AdSense Auto Ads e tutti gli ad-slot intatti (nessuna soppressione).

## Non implementato (ancora)

- **Verifica visiva del fill verticale reale degli ads**: non riproducibile in locale — `GptAdSlot` è prod-gated (`IS_PROD`), su localhost rende `null`. La geometria del grid (gap/larghezza/cella) è verificata in dev; il fill+collapse degli slot va confermato post-deploy sul live a ≥1400px. Revert-trigger: se il live mostra ancora gap verticali o il contenuto non si allarga → rivedere `slotRenderEnded`/conteggio pannelli.
- **Larghezza rail su blog/job/static lasciata a 300px** (non ridotta come lo SPA a 160px): scelta deliberata — sono pagine di lettura dove l'half-page 300x600 rende più del skyscraper 160x600 (monetizzazione). Out-of-scope il restringimento: il bug era il gap+fill, non la larghezza, e #2663 aveva ristretto a 160px solo lo strumento-SPA (calcolatore cramped).
- **Cap pre-hydration `main{max-width:calc(100vw-360px/-420px)}`** lasciati invariati: sono riserve FCP condivise tra superfici 160px e 300px; post-hydration Tailwind (`!max-w-[2400px] !w-full`) li sovrascrive col valore corretto. Splittarli per-superficie sarebbe churn extra a rischio overlap-FCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update (review fix)
- 🔴 **Overflow del creativo nel rail SPA 160px risolto**: nuova prop `narrow` (App SPA rail → `ArticleRailAdStack` → `ArticleRailAd`) che restringe il size-set richiesto a `[[160,600],'fluid']` sulla cella 160px → GAM non può più servire un 300-wide che sfora. Le reading-page (blog/job/static, 300px) tengono il set premium pieno invariato. (Questo supera il rischio "serve-mix" dell'adversarial check: il 300-wide non è più richiesto sulla cella stretta.)
- 🟡 **Listener `slotRenderEnded` ora rimosso**: slot+handler tenuti in ref, `removeEventListener` + `destroySlots` nel cleanup dell'effect → niente accumulo di listener globali sulle navigazioni SPA.
