### PR TITLE
fix(articles): 55-min wall budget for frontaliere section (stops Jun-18 stall)

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -105,6 +105,19 @@ jobs:
         env:
           CREATE_ARTICLE_REPORT_FILE: .tmp/create-article-run-report.json
           TARGET_SECTION: ${{ steps.section.outputs.section }}
+          # Section-aware wall-clock budget. The `frontaliere` pipeline is
+          # gate-heavier than `svizzera`: it carries the frontaliere-density
+          # relevance gate (>=8 keyword hits) on top of the shared fact-check /
+          # quality gates, so it needs several full-article attempts per run and
+          # each free-tier generation+fact-check pass is slow. The flat 30-min
+          # internal budget added 2026-06-16 starved it -- frontaliere fell to
+          # 0 articles/day Jun 19-21 while svizzera (no density gate, completes
+          # in minutes) kept producing, stalling the /articoli-frontaliere/
+          # revenue feed. Job `timeout-minutes` is 360 and runs already tolerate
+          # ~35min uncancelled (concurrency `cancel-in-progress: false`), so a
+          # 55-min frontaliere budget is safe and well under the hard cap.
+          # svizzera keeps the original 30-min cap (it never approaches it).
+          CREATE_ARTICLE_MAX_WALL_MS: ${{ steps.section.outputs.section == 'svizzera' && '1800000' || '3300000' }}
         run: |
           echo "📰 Generating blog article (section=$TARGET_SECTION)..."
           if [ -n "${{ inputs.url }}" ]; then


### PR DESCRIPTION
## Implementato

- **Root cause**: il budget interno wall-clock di generazione `CREATE_ARTICLE_MAX_WALL_MS` (introdotto il 2026-06-16, default piatto 30 min) **affama la sezione `frontaliere`**. La sua pipeline è più gate-heavy di `svizzera`: oltre ai gate condivisi (fact-check / qualità) porta il **gate frontaliere-density** (≥8 keyword frontalieri nel body). Servono più tentativi full-article per run e ogni passata generazione+fact-check su free-tier è lenta → la sezione **sfora i 30 min senza produrre articolo** (log run 27949428878: 56 candidati rilevanti, "Nessun duplicato rilevato", poi `⏱️ Budget wall-clock (30min) superato … nessun articolo`). `svizzera`, senza density gate, completa in pochi minuti → tutto l'output è finito lì e il feed revenue `/articoli-frontaliere/` si è fermato.
- **Evidenza**: registry `data/blog-articles-data.ts` sano 2-6 articoli/giorno fino al 15 giu, poi crollo subito dopo il commit del 16 giu: 17→3, 18→1, **19/20/21→0**, 22→1. Stesso periodo `data/swiss-articles-data.ts` continua 4-6/giorno.
- **Fix**: budget **section-aware** sullo step `Generate article` di `generate-article.yml` — `frontaliere` = 55 min (3 300 000 ms), `svizzera` = 30 min invariato. `timeout-minutes` del job è 360 e i run tollerano già ~35 min senza cancellazione (`concurrency: cancel-in-progress: false`), quindi 55 min è sicuro e ampiamente sotto il cap. Nessun gate di qualità/fact-check/rilevanza abbassato (Non-Negotiable #1 rispettato).

## Non implementato (ancora)

- **`scripts/create-article.mjs` non modificato** (segnalato da `check-sibling-patterns` perché condivide la costante `CREATE_ARTICLE_MAX_WALL_MS`): è il *consumer* che legge l'env; il suo fallback `|| 30*60_000` è il default corretto per qualunque chiamante senza env. Non è un antipattern gemello, nessun fix necessario.
- **Degradazione fact-check free-tier** (`checker giù/JSON invalido` su quasi ogni chiamata → 3 retry infra per tentativo): è il secondo fattore che gonfia il tempo/tentativo. Out of scope qui (riguarda il cascade modelli, rischio separato) → follow-up: riordinare `verificationModels` su un provider vivo per accelerare ogni tentativo e far rientrare frontaliere anche con budget più stretto.
- **Sourcing candidati frontaliere**: molti topic Ticino-generali falliscono il density gate (correttamente) causando churn; migliorare la discovery per far emergere più topic genuinamente frontaliere è un lavoro più profondo, posposto.

## Test plan

- [ ] Post-merge: osservare 2-3 run `generate-article.yml` con `section=frontaliere` → devono raggiungere `committed=true verified=true` invece di `Budget wall-clock superato`.
- [ ] Verificare nuove entry datate in `data/blog-articles-data.ts` e articoli live su `https://frontaliereticino.ch/articoli-frontaliere/` con data > 2026-06-22.