### PR TITLE
fix(adsense-prereview,cathedral): free disk before the full SSG build (No space left on device)

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -39,6 +39,29 @@ jobs:
     timeout-minutes: 180
 
     steps:
+      # Free ~25-30 GB before the full SSG build emits dist/ (33k+ pages × 4
+      # locales). ubuntu-latest ships ~14 GB free on / — the monolith build
+      # fills it mid-Vite-emit and dies with "No space left on device", and the
+      # worker dies before logs flush so the Build step log vanishes from the
+      # archive (scheduled run 27952579135). deploy.yml's build job already does
+      # this; mirror it here. Deletes only toolchains this repo never uses.
+      - name: Free disk space (remove unused toolchains)
+        shell: bash
+        run: |
+          echo "::group::Disk usage BEFORE cleanup"
+          df -h /
+          echo "::endgroup::"
+          sudo rm -rf /usr/local/lib/android &
+          sudo rm -rf /usr/share/dotnet &
+          sudo rm -rf /opt/ghc &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /opt/hostedtoolcache/CodeQL &
+          sudo rm -rf /usr/share/swift &
+          wait
+          echo "::group::Disk usage AFTER cleanup"
+          df -h /
+          echo "::endgroup::"
+
       - name: Checkout
         uses: actions/checkout@v5
 

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -54,6 +54,29 @@ jobs:
       github.event_name != 'pull_request' ||
       (github.event.pull_request.state == 'open' && github.event.pull_request.draft == false)
     steps:
+      # Free ~25-30 GB before the full SSG build emits dist/ (33k+ pages × 4
+      # locales). ubuntu-latest ships ~14 GB free on / — the monolith build
+      # fills it mid-Vite-emit and dies with "No space left on device", and the
+      # worker dies before logs flush so the Build step log vanishes from the
+      # archive. deploy.yml's build job already does this; mirror it here.
+      # Deletes only toolchains this repo never uses.
+      - name: Free disk space (remove unused toolchains)
+        shell: bash
+        run: |
+          echo "::group::Disk usage BEFORE cleanup"
+          df -h /
+          echo "::endgroup::"
+          sudo rm -rf /usr/local/lib/android &
+          sudo rm -rf /usr/share/dotnet &
+          sudo rm -rf /opt/ghc &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /opt/hostedtoolcache/CodeQL &
+          sudo rm -rf /usr/share/swift &
+          wait
+          echo "::group::Disk usage AFTER cleanup"
+          df -h /
+          echo "::endgroup::"
+
       - name: Checkout
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Implementato

Ultimo failure-mode emerso da **verifica live**: la run **schedule** `27952579135` (post-#2654) è fallita a 35 min con **`System.IO.IOException: No space left on device`** nei diagnostics del runner — il Build step muore a metà Vite-emit e il worker crasha prima di flushare i log (ecco perché il log del Build step spariva dall'archivio).

Causa: il monolith full SSG emette `dist/` per **33k+ pagine × 4 locali**, che riempie i **~14 GB liberi** di `ubuntu-latest`. `deploy.yml` lo evita liberando ~25-30 GB (rimozione toolchain inutilizzate: Android SDK, .NET, Haskell, Boost, CodeQL, Swift) **prima** del build — ma i due workflow audit che girano lo **stesso** build non avevano lo step.

Fix: aggiunto lo step **"Free disk space (remove unused toolchains)"** verbatim da `deploy.yml` come **primo step** in:
- `adsense-prereview.yml`
- `cathedral-seo-gates-check.yml` (sibling stessa classe, stesso build, stesso rischio)

Il mio dispatch precedente (`27948467588`) era passato solo perché borderline sul disco; lo schedule no → fix deterministico.

Closes #2532

## Non implementato (ancora)

- **3 workflow matrix con `build:ci` senza disk-cleanup** (`deploy-matrix-experiment`, `matrix-equivalence-check`, `post-build-matrix-test`): **non toccati** — sono `workflow_dispatch`-only (manuali, mai schedulati) e fanno build **per-locale** (`BUILD_LOCALE`, ~1/4 del dist), quindi non raggiungono il ceiling disco del monolith. Diversa sotto-classe; aggiungere lo step sarebbe churn su esperimenti manuali.
- **Claim disco non validabile a priori al 100%**: lo step libera ~25-30 GB (misurato da `deploy.yml` che builda lo stesso dist e fitta). Revert-trigger: se un prossimo run sfora ancora il disco → valutare `runs-on` con disco maggiore o pruning dist incrementale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)