### PR TITLE
fix(rail-ads): keep desktop side-rails filled via sticky cluster (overflow-x:clip unbreaks sticky)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1758,7 +1758,14 @@ const App: React.FC = () => {
   *    churn during SPA navigation (AdSenseBanner.tsx:141).
   *  - Per-page `disableAutoAds` in build-plugins/htmlTemplate.ts is preserved
   *    for "drive-by" SEO landings where bounce ≥97% (F8/F6/F2). */}
- <div className={`app-shell-col ${staticOverlay ? '' : 'min-h-screen'} relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
+ {/* overflow-x-clip (not overflow-hidden): still clips horizontal overflow from
+     3rd-party widgets/auto-ads, but — unlike `hidden` — does NOT turn this into
+     a scroll container, so window-relative `position: sticky` keeps working for
+     the desktop side-rail ad chain below. `hidden` here silently broke every
+     sticky descendant (the rails went blank past the first screenful on long
+     articles). overflow-y stays visible (the min-h-screen column grows with
+     content, so nothing vertical was ever clipped). */}
+ <div className={`app-shell-col ${staticOverlay ? '' : 'min-h-screen'} relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-x-clip`}>
  {/* Skip-to-content: first focusable element so keyboard users — and browser
   * AI agents reading the accessibility tree — can bypass the nav/header chrome
   * and jump straight to <main id="main-content"> (WCAG 2.4.1 Bypass Blocks;

--- a/components/shared/ArticleRailAdStack.tsx
+++ b/components/shared/ArticleRailAdStack.tsx
@@ -1,22 +1,28 @@
 /**
- * ArticleRailAdStack — full-length desktop side-rail ad chain.
+ * ArticleRailAdStack — desktop side-rail ad chain that stays in view.
  *
- * Fills the tall desktop gutter top-to-bottom with a vertical chain of ad
- * panels so the rail is *continuous* — no blank stretch below the first
- * creative (the complaint the screenshots show: one ad rides the top, the rest
- * of the gutter stays empty).
+ * Keeps the tall desktop gutter monetised top-to-bottom WITHOUT trying to
+ * physically tile the whole column (which an article can outgrow — a 12k-px post
+ * left ~10k px of blank rail below the first few ads, the complaint the
+ * screenshots show). Instead a small cluster of half-page panels is pinned with
+ * `position: sticky`, so it rides the viewport for the entire scroll and the
+ * gutter never goes blank.
  *
- * How the gap-free fill works:
- *  - The stack measures its own rendered height (it `flex-1`-stretches to the
- *    grid row = the article column height) and asks for ~one half-page panel per
- *    ~620px of gutter, so a tall page gets more panels and a short one fewer.
- *  - Panels flow naturally (NOT `flex-1`-stretched) and butt together with a
- *    small flex gap — no panel is taller than its creative, so there's no empty
- *    slack inside a panel.
+ * How it works:
+ *  - The outer `flex-1` div claims the full gutter height (so the cluster has
+ *    room to travel and layout/CLS is reserved); the inner `sticky top-6` div
+ *    holds the panels and pins to the viewport top as the column scrolls.
+ *  - Panel count is VIEWPORT-driven: just enough half-page panels (~620px each)
+ *    to cover the visible viewport — more would sit below the fold, pinned and
+ *    never seen (wasted ad requests). A short gutter caps it lower.
  *  - Only the first panel reserves the 600px CLS placeholder; the rest pass
  *    `reserve={false}`. Combined with GptAdSlot collapsing any slot GPT reports
- *    empty (`display:none`), unfilled panels vanish from layout instead of
- *    leaving a blank box, so the filled panels stay flush.
+ *    empty (`display:none`), unfilled panels vanish instead of leaving a blank
+ *    box, so the filled panels stay flush.
+ *
+ * Sticky requires no overflow-clipping scroll ancestor: the app shell uses
+ * `overflow-x: clip` (NOT `overflow: hidden`, which would make it a scroll
+ * container and silently break this) — see App.tsx app-shell-col.
  *
  * The whole track only materialises at the widened (≥1400px / `xlw`) rail,
  * matching ArticleRailAd's own CSS gate.
@@ -53,13 +59,14 @@ const PANEL_PX = 620;
 // Minimum gutter height to render any panel — below this, even one 600px
 // creative would overflow or reserve an unfilled CLS slot.
 const MIN_FILL_PX = 600;
-// Bound the number of same-unit requests; tall pages cap here, short pages get 1.
+// Bound the number of same-unit requests (ceiling; the real count is the lower
+// of "panels that cover the viewport" and "panels the gutter holds").
 const MAX_PANELS = 6;
 
 const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count, narrow = false }) => {
   const ref = useRef<HTMLDivElement>(null);
-  // Start at 0 — ResizeObserver sets the correct count after mount, avoiding
-  // a premature 600px CLS reservation on pages whose gutter is below MIN_FILL_PX.
+  // Start at 0 — measurement sets the correct count after mount, avoiding a
+  // premature 600px CLS reservation on pages whose gutter is below MIN_FILL_PX.
   const [panels, setPanels] = useState(0);
   const maxPanels = Math.max(1, count ?? MAX_PANELS);
 
@@ -67,28 +74,46 @@ const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled =
     const el = ref.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
     const measure = () => {
-      const h = el.getBoundingClientRect().height;
+      const gutter = el.getBoundingClientRect().height;
       // Below MIN_FILL_PX there is no room for even one 600px creative: skip all
       // panels so no CLS slot is reserved on ultra-short tool pages.
-      const next =
-        h < MIN_FILL_PX ? 0 : Math.max(1, Math.min(maxPanels, Math.round(h / PANEL_PX)));
+      if (gutter < MIN_FILL_PX) {
+        setPanels((prev) => (prev === 0 ? prev : 0));
+        return;
+      }
+      // The cluster is sticky, so it only needs enough panels to cover the
+      // VIEWPORT — extra panels would sit below the fold (pinned, never seen).
+      // Cap by the caller's ceiling and by what the gutter physically holds.
+      const byViewport = Math.ceil(window.innerHeight / PANEL_PX);
+      const byGutter = Math.round(gutter / PANEL_PX);
+      const next = Math.max(1, Math.min(maxPanels, byViewport, byGutter));
       setPanels((prev) => (prev === next ? prev : next));
     };
     measure();
     const ro = new ResizeObserver(measure);
     ro.observe(el);
-    return () => ro.disconnect();
+    // Viewport height changes (window resize) don't always change the gutter el,
+    // so re-measure on resize too.
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
   }, [maxPanels]);
 
   return (
-    // `flex-1` stretches the stack to the full gutter height so the measurement
-    // reflects the article column. Panels flow top-to-bottom with a tight gap.
-    // Only the widened rail (`xlw`, ≥1400px) hosts the chain — the narrow xl
-    // tier (1280–1399) shows no rail ads, exactly as before.
-    <div ref={ref} className="hidden xlw:flex xlw:flex-col xlw:flex-1 xlw:min-h-0 gap-2">
-      {Array.from({ length: panels }, (_, i) => (
-        <ArticleRailAd key={i} side={side} enabled={enabled} reserve={i === 0} narrow={narrow} />
-      ))}
+    // Outer `flex-1` claims the full gutter height so the sticky cluster has room
+    // to travel and the layout/CLS slot is reserved. Only the widened rail
+    // (`xlw`, ≥1400px) hosts the chain — the narrow xl tier (1280–1399) shows no
+    // rail ads, exactly as before.
+    <div ref={ref} className="hidden xlw:flex xlw:flex-col xlw:flex-1 xlw:min-h-0">
+      {/* Inner cluster pins to the viewport top and rides the whole scroll, so a
+          tall article's gutter never goes blank below the physical ads. */}
+      <div className="sticky top-6 flex flex-col gap-2">
+        {Array.from({ length: panels }, (_, i) => (
+          <ArticleRailAd key={i} side={side} enabled={enabled} reserve={i === 0} narrow={narrow} />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Implementato

- **Rail laterali desktop ora riempite per TUTTO lo scroll (articoli/job/tool).** Su articoli lunghi (~12k px) la rail restava vuota per ~10k px sotto i primi ad: la rail tentava il fill fisico ma era cappata a ~4 pannelli, e `position: sticky` (il fix corretto) era **silenziosamente morto** perché il wrapper `app-shell-col` usava `overflow: hidden` → diventa scroll-container → rompe lo sticky window-relative di ogni discendente.
  - **`App.tsx`**: `app-shell-col` `overflow-hidden` → **`overflow-x-clip`**. Clippa ancora l'overflow orizzontale di widget/auto-ad ma NON è uno scroll-container → lo sticky torna a funzionare. `overflow-y` resta `visible` (la colonna `min-h-screen` cresce col contenuto; nulla di verticale era mai clippato). Verificato live: nessuno scroll orizzontale compare.
  - **`components/shared/ArticleRailAdStack.tsx`**: il cluster di ad ora è **`sticky top-6`** dentro il gutter `flex-1`, dimensionato per coprire il **viewport** (non l'intera colonna). Pochi ad cavalcano lo scroll e restano sempre in vista → gutter mai vuoto. Conteggio viewport-driven = MENO request del vecchio chain tiled-in-cima, e tutte viewable.

### Verifica (live, DOM-injection prima del commit)
- [x] Riprodotto il bug live su `articoli-frontaliere/erba-sintetica-scuole-ticino-rischi/` @1500px: rail sinistra coverage **0px** da scroll 2800 in giù (articolo 12243px, solo 3 ad in cima).
- [x] Causa isolata: `app-shell-col` `overflow: hidden hidden` rompe sticky (scan ancestor).
- [x] Fix provato live: con `overflow-x:clip` + stack sticky, a scroll 5000 lo stack si pinna a `top:24` e copre **868px** della rail (prima 0); nessun h-scroll (`scrollW==clientW`).
- [x] `static-seo-rail-ads`, `article-ad-slots`, `app-no-blanket-no-auto-ads`, `adsense-lazy-load` verdi (28/28).
- [ ] Verifica live post-deploy ≥1400px: rail piena per tutto lo scroll su articolo lungo + job-detail. Non verificabile pre-merge.

## Non implementato (ancora)

- **`body { overflow-x: hidden }` (index.css) invariato.** È su `<body>` (lo scroller del documento), non rompe lo sticky window-relative (il breaker era solo l'`app-shell-col` div); resta come anti-overflow di base.
- **Nessun cambio a CLS reserve.** Il primo pannello mantiene `reserve` (placeholder 600px); gli altri collassano se unfilled. Invariato.
- **Sibling `overflow-hidden` altrove** (componenti con clipping intenzionale tipo carousel/modal) non toccati: lì l'overflow è voluto e non ospita rail sticky. Match euristici (`ResizeObserver`/`innerHeight`) sono generici, non l'antipattern.

Revert-trigger: se il prossimo deploy mostra scroll orizzontale, regressione CLS sulle rail, o auto-ad anchor/vignette che sfuggono il clipping → revert del cambio overflow.