### PR TITLE
feat(articles): translate via free MT cascade, not generation LLM (frees ~60% quota)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -65,6 +65,13 @@ import { execSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
 import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess, isQuotaExhaustedError } from './lib/ai-models.mjs';
+// Quota-free MT cascade (DeepL-free / Google / MyMemory / LibreTranslate /
+// local Opus-MT) — the SAME translator the job crawlers + FAQ batch use
+// (scripts/lib/dedicated-crawler-common.mjs, batch-add-faq-to-articles.mjs).
+// Routing article translation through it instead of the generation LLM frees
+// ~60% of per-article LLM calls for actual generation (the quota bottleneck).
+import { freeTranslateWithRetry, balanceMarkdownMarkers } from './lib/free-translate.mjs';
+import { translateFieldFreeMt } from './lib/article-free-mt.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
@@ -4189,6 +4196,69 @@ ISTRUZIONI:
  * Translate article content from Italian to EN/DE/FR.
  * Called AFTER duplicate check to avoid wasting API calls on duplicates.
  */
+// ── Quota-free article translation (2026-06-22) ──────────────────────────
+// Route per-field translation through the dedicated free MT cascade
+// (freeTranslateWithRetry) instead of the generation LLM, so the LLM daily
+// quota is spent on GENERATION, not translation (~60% of per-article calls).
+// Opt-out: ARTICLE_TRANSLATE_FREE_MT=0 falls back to the legacy LLM path.
+// Masking / per-field logic lives in ./lib/article-free-mt.mjs (unit-testable;
+// this script runs main() on import so its internals can't be imported).
+const ARTICLE_TRANSLATE_FREE_MT = String(process.env.ARTICLE_TRANSLATE_FREE_MT ?? '1') !== '0';
+
+// Thin in-script wrapper: bind the lib field-translator to the prod MT cascade,
+// markdown repair, and logger. Returns '' on any failure so the caller's
+// per-field recovery (LLM retry → IT fallback) takes over.
+function freeMtField(text, sourceLang, targetLang, fieldType) {
+  return translateFieldFreeMt({
+    text,
+    sourceLang,
+    targetLang,
+    fieldType,
+    translate: freeTranslateWithRetry,
+    balanceMarkdown: balanceMarkdownMarkers,
+    onWarn: (msg) => console.error(`  ⚠️  ${msg} — recupero per-campo`),
+  });
+}
+
+// Free-MT replacement for translateContent: same return shape ({title, excerpt,
+// body1..3, faq?}) but each field via the quota-free cascade. Missing/failed
+// fields are simply omitted → the existing missing-field recovery loop in
+// translateArticle re-translates them (LLM) or falls back to IT.
+async function translateContentFreeMt(sourceLang, targetLang, targetLabel, sourceContent) {
+  console.error(`🌍 [${targetLabel}] Traduzione ${targetLang.toUpperCase()} via cascade MT gratuita (no quota LLM)...`);
+  const [title, excerpt, body1, body2, body3] = await Promise.all([
+    freeMtField(sourceContent.title, sourceLang, targetLang, 'title'),
+    freeMtField(sourceContent.excerpt, sourceLang, targetLang, 'description'),
+    freeMtField(sourceContent.body1, sourceLang, targetLang, 'description'),
+    freeMtField(sourceContent.body2, sourceLang, targetLang, 'description'),
+    freeMtField(sourceContent.body3, sourceLang, targetLang, 'description'),
+  ]);
+
+  let faq;
+  if (Array.isArray(sourceContent.faq) && sourceContent.faq.length > 0) {
+    try {
+      faq = await Promise.all(sourceContent.faq.map(async (item) => {
+        const q = await freeMtField(item?.q, sourceLang, targetLang, 'title');
+        const a = await freeMtField(item?.a, sourceLang, targetLang, 'description');
+        return { q: q || item?.q || '', a: a || item?.a || '' };
+      }));
+    } catch (err) {
+      console.error(`  ⚠️  free-MT ${targetLang}:faq fallita (${err?.message || err}) — fallback IT`);
+      faq = sourceContent.faq;
+    }
+  }
+
+  const out = {};
+  if (title) out.title = title;
+  if (excerpt) out.excerpt = excerpt;
+  if (body1) out.body1 = sanitizeBodyText(body1);
+  if (body2) out.body2 = sanitizeBodyText(body2);
+  if (body3) out.body3 = sanitizeBodyText(body3);
+  if (faq) out.faq = faq;
+  console.error(`  ✅ ${targetLang.toUpperCase()} (MT gratuita) completato`);
+  return out;
+}
+
 async function translateArticle(data) {
   async function callWithRetry(prompt, maxTokens, label) {
     const raw = await callLLM(
@@ -4233,6 +4303,13 @@ async function translateArticle(data) {
   }
 
   async function translateContent(sourceLang, targetLang, targetLabel, sourceContent) {
+    // Quota-free path: route through the dedicated free MT cascade so the LLM
+    // daily quota is reserved for generation. Per-field failures are omitted and
+    // recovered downstream (LLM retry → IT fallback), so this never degrades
+    // below the legacy path's worst case. Opt-out via ARTICLE_TRANSLATE_FREE_MT=0.
+    if (ARTICLE_TRANSLATE_FREE_MT) {
+      return translateContentFreeMt(sourceLang, targetLang, targetLabel, sourceContent);
+    }
     // Use scored chain (no model pinning) — falls back through all models automatically
     const langName = targetLang === 'en' ? 'inglese' : targetLang === 'de' ? 'tedesco' : 'francese';
     console.error(`🤖 [${targetLabel}] Traduzione ${targetLang.toUpperCase()} tramite catena AI...`);

--- a/scripts/lib/article-free-mt.mjs
+++ b/scripts/lib/article-free-mt.mjs
@@ -1,0 +1,99 @@
+/**
+ * Quota-free article translation helpers (2026-06-22).
+ *
+ * Article translation historically went through the generation LLM cascade
+ * (callLLM), consuming ~60% of the per-article LLM calls — the daily free-tier
+ * quota bottleneck that starves GENERATION. These helpers route translation
+ * through the dedicated free MT cascade instead (the same `freeTranslateWithRetry`
+ * the job crawlers + FAQ batch already use), so the LLM quota is reserved for
+ * generation.
+ *
+ * Extracted into a lib module so the logic is unit-testable: scripts/create-article.mjs
+ * runs `main()` on import, so its internals can't be imported directly.
+ */
+
+const NAV_LINK_RE = /\[[^\]]+\]\(nav:[^)]+\)/g;
+const NAV_SENTINEL_RE = /0NAVLINK(\d+)0/g;
+
+/**
+ * Mask internal `[testo](nav:azione)` CTA links so machine translation passes
+ * them through verbatim (the `nav:azione` target is a router action, not prose).
+ *
+ * The sentinel `0NAVLINK<n>0` is digit-delimited ASCII — MT engines reorder /
+ * translate / strip bracketed or word-like placeholders, but leave this token
+ * intact in practice. `restore()` reports `ok:false` if the restored count does
+ * not match the masked count, letting the caller drop a mangled field rather
+ * than ship a body with a broken internal link.
+ *
+ * @param {string} text
+ * @returns {{ masked: string, expected: number, restore: (s: string) => { text: string, ok: boolean } }}
+ */
+export function maskNavLinks(text) {
+  const store = [];
+  const masked = String(text ?? '').replace(NAV_LINK_RE, (m) => {
+    const token = `0NAVLINK${store.length}0`;
+    store.push(m);
+    return token;
+  });
+  const restore = (s) => {
+    let n = 0;
+    const out = String(s ?? '').replace(NAV_SENTINEL_RE, (_, i) => {
+      const original = store[Number(i)];
+      if (original === undefined) return '';
+      n += 1;
+      return original;
+    });
+    return { text: out, ok: n === store.length };
+  };
+  return { masked, expected: store.length, restore };
+}
+
+/**
+ * Translate a single article text field via the injected free MT translator,
+ * preserving internal nav-links. Returns '' on any failure (empty input, MT
+ * error, empty output, or a mangled nav-link sentinel) so the caller's per-field
+ * recovery (LLM retry → IT fallback) takes over — free MT can only IMPROVE
+ * coverage, never produce broken output.
+ *
+ * @param {object} args
+ * @param {string} args.text                source text
+ * @param {string} args.sourceLang
+ * @param {string} args.targetLang
+ * @param {string} args.fieldType           'title' | 'description'
+ * @param {(a: { text: string, sourceLang: string, targetLang: string, fieldType: string }) => Promise<string>} args.translate
+ *        the MT call (freeTranslateWithRetry in prod, a stub in tests)
+ * @param {(s: string) => string} [args.balanceMarkdown]  optional markdown repair
+ * @param {(msg: string) => void} [args.onWarn]
+ * @returns {Promise<string>}
+ */
+export async function translateFieldFreeMt({
+  text,
+  sourceLang,
+  targetLang,
+  fieldType,
+  translate,
+  balanceMarkdown = (s) => s,
+  onWarn = () => {},
+}) {
+  const src = String(text ?? '').trim();
+  if (!src) return '';
+  const { masked, expected, restore } = maskNavLinks(src);
+  let out;
+  try {
+    out = await translate({ text: masked, sourceLang, targetLang, fieldType });
+  } catch (err) {
+    onWarn(`free-MT ${targetLang}:${fieldType} failed (${err?.message || err})`);
+    return '';
+  }
+  if (!out || !String(out).trim()) return '';
+  let restored = String(out);
+  if (expected > 0) {
+    const r = restore(restored);
+    if (!r.ok) {
+      onWarn(`free-MT ${targetLang}:${fieldType} nav-link sentinel mangled (expected ${expected})`);
+      return '';
+    }
+    restored = r.text;
+  }
+  return balanceMarkdown(restored);
+}

--- a/tests/scripts/article-free-mt.test.ts
+++ b/tests/scripts/article-free-mt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { maskNavLinks, translateFieldFreeMt } from '../../scripts/lib/article-free-mt.mjs';
+
+// Pins the quota-free article translation helpers (2026-06-22). Article
+// translation moved off the generation LLM cascade onto the free MT cascade
+// (freeTranslateWithRetry) to free LLM daily quota for generation. These
+// helpers must (a) preserve internal [text](nav:action) CTA links across MT,
+// and (b) fail SAFE (return '') so the downstream IT/LLM recovery never ships
+// a body with a broken link.
+
+describe('maskNavLinks', () => {
+  it('masks every nav-link to a digit-delimited sentinel and restores verbatim', () => {
+    const src = 'Vedi il [calcolatore](nav:calculator) e le [scadenze](nav:calendar) qui.';
+    const { masked, expected, restore } = maskNavLinks(src);
+    expect(expected).toBe(2);
+    expect(masked).not.toContain('nav:');
+    expect(masked).toContain('0NAVLINK0');
+    expect(masked).toContain('0NAVLINK1');
+    // MT returns the sentinels intact (typical case)
+    const { text, ok } = restore(masked);
+    expect(ok).toBe(true);
+    expect(text).toBe(src);
+  });
+
+  it('reports ok:false when MT drops/mangles a sentinel', () => {
+    const src = 'Apri il [calcolatore](nav:calculator).';
+    const { masked, restore } = maskNavLinks(src);
+    // Simulate MT stripping the sentinel
+    const mangled = masked.replace('0NAVLINK0', '');
+    expect(restore(mangled).ok).toBe(false);
+  });
+
+  it('is a no-op (expected 0) when there are no nav-links', () => {
+    const { masked, expected, restore } = maskNavLinks('Testo senza link.');
+    expect(expected).toBe(0);
+    expect(masked).toBe('Testo senza link.');
+    expect(restore('Texte sans lien.')).toEqual({ text: 'Texte sans lien.', ok: true });
+  });
+});
+
+describe('translateFieldFreeMt', () => {
+  const passthroughBalance = (s: string) => s;
+
+  it('translates and restores nav-links around the translated prose', async () => {
+    const src = 'Apri il [calcolatore](nav:calculator) ora.';
+    const translate = async ({ text }: { text: string }) =>
+      // stub MT: "translate" prose, keep the sentinel
+      text.replace('Apri il', 'Open the').replace(' ora.', ' now.');
+    const out = await translateFieldFreeMt({
+      text: src, sourceLang: 'it', targetLang: 'en', fieldType: 'description', translate, balanceMarkdown: passthroughBalance,
+    });
+    expect(out).toBe('Open the [calcolatore](nav:calculator) now.');
+  });
+
+  it('returns "" (fail-safe) when MT mangles the nav-link sentinel', async () => {
+    const src = 'Apri il [calcolatore](nav:calculator) ora.';
+    const translate = async () => 'Open the now.'; // sentinel lost
+    const out = await translateFieldFreeMt({
+      text: src, sourceLang: 'it', targetLang: 'en', fieldType: 'description', translate,
+    });
+    expect(out).toBe('');
+  });
+
+  it('returns "" when MT throws or returns empty', async () => {
+    const throwing = async () => { throw new Error('all instances down'); };
+    expect(await translateFieldFreeMt({ text: 'Ciao', sourceLang: 'it', targetLang: 'en', fieldType: 'title', translate: throwing })).toBe('');
+    const empty = async () => '';
+    expect(await translateFieldFreeMt({ text: 'Ciao', sourceLang: 'it', targetLang: 'en', fieldType: 'title', translate: empty })).toBe('');
+  });
+
+  it('returns "" for blank input without calling MT', async () => {
+    let called = false;
+    const translate = async () => { called = true; return 'x'; };
+    expect(await translateFieldFreeMt({ text: '   ', sourceLang: 'it', targetLang: 'en', fieldType: 'title', translate })).toBe('');
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Leva volume per "molti contenuti senza limiti", su direzione utente ("usa lo stesso metodo del translate dei job che non spreca quota").

- **Causa del tetto al volume**: `translateArticle`/`translateContent` (scripts/create-article.mjs) traducevano OGNI campo via il cascade LLM di generazione (`callLLM`) = ~15 su ~25 chiamate LLM/articolo (~60%). Quella quota è il collo: il limite giornaliero free condiviso si esaurisce a metà pomeriggio UTC (22 giu: `esauriti (quota)` da ~13:33), dopodiché NESSUN articolo (di nessuna sezione) si genera.
- **Fix**: gli articoli ora traducono via lo **stesso cascade MT gratuito dei job/crawler/FAQ-batch** — `freeTranslateWithRetry` (DeepL-free / Google / MyMemory / LibreTranslate / Opus-MT locale), che **non tocca la quota LLM**. La quota LLM resta per la generazione → ~10 chiamate/articolo invece di ~25 → la quota giornaliera produce molti più articoli prima dell'esaurimento.
- **Nuovo `scripts/lib/article-free-mt.mjs`** (unit-testabile; `create-article.mjs` esegue `main()` all'import, quindi i suoi interni non sono importabili):
  - `maskNavLinks` preserva i link interni `[testo](nav:azione)` attraverso l'MT via sentinel ASCII a delimitazione numerica, con verifica di conteggio al restore.
  - `translateFieldFreeMt` **fail-safe** (ritorna `''`) su errore MT / output vuoto / sentinel mangled → il recupero per-campo esistente (retry LLM → fallback IT) subentra. Free MT può solo MIGLIORARE la copertura, mai produrre output rotto.
- `translateContent` delega al path free-MT quando `ARTICLE_TRANSLATE_FREE_MT` (default on); `=0` ripristina il path LLM legacy.
- 7 nuovi unit test (`tests/scripts/article-free-mt.test.ts`); test articoli esistenti verdi (124 passati).

Complementa i fix già mergiati: #2672 (budget frontaliere 55min) e #2681 (prune modelli morti cascade).

## Non implementato (ancora)

- **Claim quota/qualità non validabile pre-merge** (la quota free è esaurita oggi; il comportamento reale dell'MT sui body articolo è osservabile solo nella prossima finestra-quota post-merge). **Revert-trigger**: se la qualità EN/DE/FR regredisce in modo inaccettabile o la copertura cala → `ARTICLE_TRANSLATE_FREE_MT=0` (istantaneo, no redeploy). Spot-check live consigliato post-merge.
- **Sibling flaggati da `check-sibling-patterns`** (`mymemory-translate.mjs`, `repair-job-locales.mjs`, `update-supsi-jobs.mjs`, `local-mt-translate.py`): sono già consumer del cascade free MT (il pattern TARGET a cui sto allineando gli articoli), non antipattern da convertire. `services/seo/article-translations.ts` (`translateArticleSchema`) è mappatura statica di label JSON-LD build-time (no LLM/MT runtime) → non correlato.
- **Qualità MT-grade**: la traduzione passa da LLM-grade a MT-grade (come i job). Il fallback per-campo cattura solo campi vuoti/mangled, non "validi ma mediocri" — tradeoff accettato per il guadagno di quota (i job girano MT-grade in produzione).

## Test plan

- [x] `npx vitest run tests/scripts/article-free-mt.test.ts` → 7 passati (locale).
- [x] Test articoli esistenti (schema-translators, sanitizers, headline, duplicate) → 124 passati.
- [ ] Post-merge (prossima finestra-quota): un run `generate-article.yml` deve mostrare `Traduzione … via cascade MT gratuita` e committare articoli con meno chiamate LLM; spot-check qualità EN/DE/FR su un articolo nuovo.