### PR TITLE
fix(router): carry companyKey in route so private insights link survives locale-boot canonicalization

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -622,6 +622,14 @@ export interface AppRoute {
  /** Job detail slug under job-board route (e.g. /cerca-lavoro-ticino/software-engineer-...). */
  jobSlug?: string;
  /**
+  * Company key path segment for the private per-company insights page
+  * (`/azienda/<companyKey>/?t=<token>`). Carried in the route so locale-boot
+  * canonicalization (updatePathForLocale, pushRoute) reconstructs the segment
+  * instead of collapsing the URL to the empty-key `/azienda/` — which made the
+  * page read an empty key and render "Link non valido o scaduto".
+  */
+ companyKey?: string;
+ /**
   * Canonical geo-hub key when the URL matches a city-hub path
   * (e.g. /cerca-lavoro-ticino/lugano/ → `jobBoardCity: 'lugano'`).
   * When set, {@link jobSlug} is also populated with the corresponding
@@ -2242,7 +2250,7 @@ export function parsePath(pathname: string): ParseResult {
  // not in site nav. The companyKey is a path segment; EmployerInsightsPage reads
  // it + the token itself. Any non-empty second segment is a valid company key.
  if (parts[0] === 'azienda' && parts[1]) {
-   return { route: { activeTab: 'employer-insights' }, locale };
+   return { route: { activeTab: 'employer-insights', companyKey: decodeURIComponent(parts[1]) }, locale };
  }
 
  // Fuel-daily static SEO pages (F6) — /prezzi-diesel/oggi/, /en/diesel-price-switzerland/today/, etc.
@@ -3369,9 +3377,11 @@ export function buildPath(route: AppRoute, locale?: Locale): string {
  return finish(`${prefix}/${table.forEmployers}${hashSuffix}`);
  case 'employer-insights':
  // Per-company stats page; the real per-company link (with ?t=token) is
- // generated server-side (scripts/lib/employer-insights-token.mjs). buildPath
- // only needs the base for exhaustiveness/soft-nav.
- return finish(`${prefix}/azienda/${hashSuffix}`);
+ // generated server-side (scripts/lib/employer-insights-token.mjs). The
+ // companyKey segment MUST be re-emitted so locale-boot canonicalization
+ // (updatePathForLocale → buildPath) doesn't collapse the URL to the
+ // empty-key `/azienda/` and break the token-gated read.
+ return finish(`${prefix}/azienda/${route.companyKey ? `${encodeURIComponent(route.companyKey)}/` : ''}${hashSuffix}`);
  case 'partners':
  return finish(`${prefix}/${table.partners}${hashSuffix}`);
  case 'consulting':

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -365,6 +365,40 @@ describe('Router — locale-aware job detail updates', () => {
   });
 });
 
+/* ─────────── Employer insights (private per-company page) ─────────── */
+
+describe('Router — employer insights companyKey segment', () => {
+  const companyKey = 'eoc-ente-ospedaliero-cantonale';
+  const token = 'e10bb7f63d0c2d9c972fb4a5658ff42000cb6333689cc11fca4b2e97f1cff621';
+
+  it('parsePath captures the companyKey path segment', () => {
+    const { route } = parsePath(`/azienda/${companyKey}/`);
+    expect(route.activeTab).toBe('employer-insights');
+    expect(route.companyKey).toBe(companyKey);
+  });
+
+  it('buildPath round-trips the companyKey segment', () => {
+    expect(buildPath({ activeTab: 'employer-insights', companyKey })).toBe(`/azienda/${companyKey}/`);
+  });
+
+  it('locale-boot canonicalization preserves companyKey + ?t= token (no collapse to /azienda/)', () => {
+    // Repro of the live bug: updatePathForLocale rebuilt the URL from the
+    // route model, which dropped the companyKey → /azienda/?t=… → empty key →
+    // "Link non valido o scaduto". With companyKey carried in the route, the
+    // segment (and the private token in the query) survive the rewrite.
+    window.history.replaceState(
+      { route: parsePath(`/azienda/${companyKey}/`).route },
+      '',
+      `/azienda/${companyKey}/?t=${token}`,
+    );
+
+    updatePathForLocale('it');
+
+    expect(window.location.pathname).toBe(`/azienda/${companyKey}/`);
+    expect(window.location.search).toBe(`?t=${token}`);
+  });
+});
+
 /* ─────────── Backward compatibility ─────────── */
 
 describe('Router — backward compatibility', () => {


### PR DESCRIPTION
## Implementato

- **Fix root cause** del bug "Link non valido o scaduto" sulla pagina insights privata per-azienda (`/azienda/<companyKey>/?t=<token>`, linkata dall'admin e dalle email cold-outreach).
- `services/router.ts`:
  - Aggiunto `companyKey?: string` al modello `AppRoute`.
  - `parsePath('/azienda/<key>/')` ora cattura `companyKey` (prima lo scartava, restituendo solo `{ activeTab: 'employer-insights' }`).
  - `buildPath` per `employer-insights` ri-emette il segmento `/azienda/<key>/` (prima emetteva il bare `/azienda/`).
- `tests/router.test.ts`: 3 test di regressione — capture in parsePath, round-trip in buildPath, e il repro esatto del bug (`updatePathForLocale` preserva `companyKey` + `?t=` invece di collassare a `/azienda/?t=`).

### Root cause
Su locale-boot, `updatePathForLocale` ricostruisce l'URL via `buildPath(parsePath(currentPath).route)` e fa `history.replaceState`. Siccome il modello route non portava il `companyKey`, l'URL veniva riscritto da `/azienda/<key>/?t=…` a `/azienda/?t=…`. Il `companyKeyFromPath()` della pagina leggeva quindi una key vuota → `fetchInsights('', token)` → `invalid-token` → stato d'errore. La Cloud Function, la CORS e il token erano tutti corretti (verificato HTTP 200 live con la key+token reali). Il fix porta `companyKey` nel route model (stesso pattern di `jobSlug`) così **ogni** round-trip di `buildPath` (locale boot, pushRoute, replaceRoute) ricostruisce il segmento by-construction.

## Non implementato (ancora)

- **Sibling `pushRoute`/`updatePathForLocale` non toccati** (9 file segnalati da `check-sibling-patterns.mjs`: `hooks/useNavigationState.ts`, `components/**`, `services/NavigationContext.ts`, ecc.): sono **consumer** delle funzioni del router, non duplicano l'antipattern. Il fix è centralizzato nel route model di `services/router.ts` (single source) → tutti i consumer beneficiano automaticamente. Toccarli sarebbe drive-by churn.
- **Nessun cambio a `EmployerInsightsPage.tsx`/`services/employerInsights.ts`/CF**: già corretti — leggono key+token da `window.location`, che ora resta intatto. Verificato live che l'endpoint CF risponde 200 con i dati reali.
