### PR TITLE
fix(cls): hold #root floor until search-index SPA list catches up

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -115,6 +115,7 @@ const mountApp = async () => {
  // chunk — it is already loaded with App above, so this resolves from cache.
  // Gated on staticOverlay so true static landings keep their overlay; crawlers
  // (no JS) still get the fallback verbatim.
+ let movedTallFallback = false;
  try {
    const { parsePath } = await import('./services/router');
    if (!parsePath(window.location.pathname).route.staticOverlay) {
@@ -125,6 +126,9 @@ const mountApp = async () => {
        rootElement.appendChild(fallback);
        if (railWrap) railWrap.style.display = 'none';
        staticPage = hasStaticContent();
+       // Tall fallback (e.g. the search index): its SPA view fills progressively,
+       // so hold the #root floor until it catches up rather than releasing early.
+       movedTallFallback = fallback.offsetHeight > window.innerHeight;
      }
    }
  } catch {
@@ -191,13 +195,29 @@ const mountApp = async () => {
  // Safety timeout: if transitionend doesn't fire (prefers-reduced-motion,
  // DOM removal, browser quirk) the minHeight floor would persist for the
  // whole SPA session, pushing AdSense units off-viewport on shorter pages.
- const t = setTimeout(() => { rootElement.style.minHeight = ''; }, 200);
- rootElement.addEventListener('transitionend', () => {
- clearTimeout(t);
- rootElement.style.transition = '';
- rootElement.style.opacity = '';
- rootElement.style.minHeight = '';
- }, { once: true });
+ const clearFade = () => { rootElement.style.transition = ''; rootElement.style.opacity = ''; };
+ if (movedTallFallback) {
+   // SPA-takeover page whose moved fallback is taller than the viewport (the
+   // search index): its React view fills progressively, so releasing the #root
+   // floor at first paint lets the footer bounce UP while the list renders.
+   // Hold the floor until #root content REACHES the reserved height (list
+   // done) — or a 4s cap so a permanently-shorter render can't keep the floor
+   // for the whole session (the AdSense-off-viewport hazard the simple path guards).
+   rootElement.addEventListener('transitionend', clearFade, { once: true });
+   let released = false;
+   const release = () => { if (!released) { released = true; rootElement.style.minHeight = ''; ro.disconnect(); } };
+   const reserved = parseInt(rootElement.style.minHeight, 10) || 0;
+   const ro = new ResizeObserver(() => { if (rootElement.scrollHeight >= reserved - 4) release(); });
+   ro.observe(rootElement);
+   setTimeout(release, 4000);
+ } else {
+   const t = setTimeout(() => { rootElement.style.minHeight = ''; }, 200);
+   rootElement.addEventListener('transitionend', () => {
+     clearTimeout(t);
+     clearFade();
+     rootElement.style.minHeight = '';
+   }, { once: true });
+ }
  }
 
  document.getElementById('loading-shell')?.remove();


### PR DESCRIPTION
## Implementato

Terzo e ultimo residuo CLS, sul path #1 per volume `/cerca-lavoro-ticino/ricerca/` (search index thin). Dopo i fix rail (#2649) e handoff (#2689), la misura live mostrava un **footer bounce ~0.4**: il fallback static viene spostato in #root e il macchinario reserve+crossfade riserva l'altezza di #root, ma **rilascia il floor ~200ms dopo il primo paint**. La view SPA del search-index riempie la lista da 465 voci **progressivamente** (shift reali misurati a 1s e 5.7s) → rilasciato il floor, il footer salta su e giù mentre la lista renderizza.

- **`index.tsx`:** quando l'handoff move sposta un fallback **più alto del viewport** (pagina-indice di contenuto, non una lite-shell corta), tengo il floor `#root` finché il contenuto di #root **raggiunge l'altezza riservata** (`ResizeObserver`) — o un cap di 4s così un render permanentemente più corto non tiene il floor per tutta la sessione (l'hazard AdSense-off-viewport che il path a 200ms già evita). Fallback corti e tutte le altre static page mantengono il rilascio a 200ms invariato.
- Scoped al solo caso `movedTallFallback`: nessun cambio di comportamento per homepage o job-detail.

Verificato locale: `tsc` pulito su index.tsx, test `index-html-fc-loader`/`dom-reconciliation-guard`/`no-js-redirects-in-build` verdi.

## Non implementato (ancora)

- **Verifica CLS live post-deploy**: l'effetto (footer stabile durante il render progressivo) è misurabile solo live. **Revert-trigger**: se dopo il deploy `/ricerca/` desktop CLS NON scende sensibilmente (footer bounce eliminato), o se compaiono gap vuoti sotto contenuti più corti del previsto, → rivedere/revert. Misurerò via Playwright a 1440px su `/ricerca/` dopo il merge.
- **Reflow async-CSS della lista 67KB** (shift ~0.25 a t≈297ms quando `seo-static.css` async applica typography alla lista da 465 voci): residuo minore inerente al caricamento CSS non-render-blocking su una pagina content-heavy; non indirizzato qui (sarebbe critical-CSS della tipografia lista, fuori scope di questo fix di reservation).
