### PR TITLE
fix(test): skip cross-section-canonical drift copies in canton hreflang sampler (#2679)

### DIFF
--- a/tests/seo/_bridgeMarker.ts
+++ b/tests/seo/_bridgeMarker.ts
@@ -40,3 +40,29 @@ export const isNoindexHtml = (html: string): boolean =>
 // noindex archived/redirect stubs, not real indexable job pages.
 export const isArchivedStubHtml = (html: string): boolean =>
   isBridgePageHtml(html) || isNoindexHtml(html);
+
+// The `rel=canonical` href of a page, or '' if absent. Two-step (find the
+// canonical <link> tag, then its href) so attribute order rel/href doesn't
+// matter; quote-flexible because dist-shrink may strip attribute quotes.
+export const canonicalHref = (html: string): string => {
+  const tag = html.match(/<link\b[^>]*\brel=["']?canonical["']?[^>]*>/i);
+  if (!tag) return '';
+  const href = tag[0].match(/\bhref=["']?([^"'\s>]+)/i);
+  return href ? href[1] : '';
+};
+
+// A relocation/drift copy a canton-round-trip sampler MUST skip even if it
+// somehow escaped the noindex marker (isArchivedStubHtml): its rel=canonical
+// points OUTSIDE the section dir it lives under (e.g. a /cerca-lavoro-zurigo/
+// <slug>/ copy whose canonical is /cerca-lavoro-ticino/<slug>/ — a #2661/#2676
+// IT canton-drift orphan that legitimately carries the SOURCE canton's
+// hreflang). A genuine section page is self-canonical under its own section, so
+// its canonical href contains `/<sectionPath>/`. Belt-and-suspenders next to
+// isNoindexHtml: the copy is *meant* to be noindex, but a build that emits it
+// index,follow (validate-dist flake #2679) would otherwise be sampled and fail
+// the round-trip assertion for hreflang it isn't supposed to declare.
+export const isCrossSectionCanonical = (html: string, sectionPath: string): boolean => {
+  const href = canonicalHref(html);
+  if (!href) return false; // no canonical → don't over-skip a real page
+  return !href.includes(`/${sectionPath}/`);
+};

--- a/tests/seo/cathedral-flip-simulation.spec.ts
+++ b/tests/seo/cathedral-flip-simulation.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { isArchivedStubHtml } from './_bridgeMarker';
+import { isArchivedStubHtml, isCrossSectionCanonical } from './_bridgeMarker';
 
 const DIST = path.resolve(__dirname, '../../dist');
 
@@ -19,7 +19,12 @@ function listJobHtmlUnder(cantonSection: string): string[] {
     if (!entry.isDirectory()) continue;
     const file = path.join(dir, entry.name, 'index.html');
     if (!fs.existsSync(file)) continue;
-    if (isArchivedStubHtml(fs.readFileSync(file, 'utf8'))) continue;
+    const html = fs.readFileSync(file, 'utf8');
+    if (isArchivedStubHtml(html)) continue;
+    // Skip relocation copies whose canonical points outside this section dir
+    // (canton-drift orphans that escaped the noindex marker) so they don't
+    // register as a real job of `cantonSection` (validate-dist flake #2679).
+    if (isCrossSectionCanonical(html, cantonSection)) continue;
     out.push(entry.name);
   }
   return out;

--- a/tests/seo/cathedral-hreflang-cross-locale.test.ts
+++ b/tests/seo/cathedral-hreflang-cross-locale.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { isArchivedStubHtml } from './_bridgeMarker';
+import { isArchivedStubHtml, isCrossSectionCanonical } from './_bridgeMarker';
 
 const DIST = path.resolve(__dirname, '../../dist');
 
@@ -28,6 +28,11 @@ describe('hreflang round-trip non-TI canton (P3-B)', () => {
       if (!fs.existsSync(f)) continue;
       const candidate = fs.readFileSync(f, 'utf8');
       if (isArchivedStubHtml(candidate)) continue;
+      // Also skip canton-drift relocation copies that escaped the noindex
+      // marker: a page whose rel=canonical points outside this ZH section is a
+      // TI/other-canton orphan carrying the SOURCE canton's hreflang, not a real
+      // ZH-canonical page (validate-dist flake #2679).
+      if (isCrossSectionCanonical(candidate, 'cerca-lavoro-zurigo')) continue;
       sample = s;
       html = candidate;
       break;


### PR DESCRIPTION
## Implementato
- Aggiunto `isCrossSectionCanonical(html, sectionPath)` + `canonicalHref(html)` condivisi in `tests/seo/_bridgeMarker.ts` (quote-flexible, ordine attributi rel/href indifferente).
- `cathedral-hreflang-cross-locale.test.ts` (il test che falliva in validate-dist): il sampler ora salta, oltre agli stub archiviati, anche le pagine il cui `rel=canonical` punta **fuori** dalla sezione `/cerca-lavoro-zurigo/` — copie canton-drift (#2661/#2676) che portano l'hreflang del canton SORGENTE e non sono pagine ZH-canoniche.
- Stessa guardia applicata al sibling `cathedral-flip-simulation.spec.ts` (`listJobHtmlUnder`) per non far driftare la classe.

### Perché
La pagina drift è *intesa* come noindex (skippata da `isNoindexHtml`); ma se un build la emette `index,follow` finiva campionata e faceva fallire l'assertion ZH per hreflang che non dichiara. La verifica live conferma che le migliaia di pagine ZH reali (`/de/jobs-in-zurich/`, da sitemap) hanno hreflang corretti — solo le copie drift vanno saltate. È una correzione di logica del sampler, non un allentamento: le pagine ZH-canoniche restano tutte validate.

## Non implementato (ancora)
- **Root-cause noindex injection**: il quote-sensitivity in `cfHot404BridgePlugin.ts` (regex `name=["']robots["']` che non matcha `name=robots` post-minify) — fix scelto = solo sampler robusto (deciso con l'owner). Follow-up se le copie drift dovessero comparire indicizzate in GSC.
- **`cathedral-flip-simulation.spec.ts` non gira in CI**: l'include vitest è `tests/**/*.test.{ts,tsx}`, quindi i `.spec.ts` non vengono raccolti. L'edit resta per coerenza sibling-class ma non esegue oggi; rinominare l'estensione è fuori scope (potrebbe far emergere fallimenti non correlati).
- **Bug dati hreflang `jobs-im-zurich`** su alcune copie self-canonical (job mis-assegnati canton, es. Baar/Zug sotto zurigo): concern separato (crawler/canton-assignment), non tocca questo gate.