### PR TITLE
feat(survey): multilingual feature-request micro-survey (PostHog capture)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ const unlockAchievement = (id: string) => {
 
 const GamificationWidget = lazyRetry(() => import('@/components/community/GamificationWidget'));
 const NewsletterPopup = lazyRetry(() => import('@/components/community/NewsletterPopup'));
+const FeatureSurvey = lazyRetry(() => import('@/components/community/FeatureSurvey'));
 const OfferwallNewsletterGate = lazyRetry(() => import('@/components/community/OfferwallNewsletterGate'));
 const NewsletterInline = lazyRetry(() => import('@/components/community/Newsletter'));
 const NewsletterMount = lazyRetry(() => import('@/components/community/NewsletterMount'));
@@ -3427,6 +3428,7 @@ const App: React.FC = () => {
 
  <Suspense fallback={null}>
  <NewsletterPopup />
+ <FeatureSurvey />
  <OfferwallNewsletterGate />
  <NewsletterMount />
  {showWhatsNew && (

--- a/components/community/FeatureSurvey.tsx
+++ b/components/community/FeatureSurvey.tsx
@@ -1,0 +1,228 @@
+/**
+ * FeatureSurvey — "Which feature would you like next?" micro-survey.
+ *
+ * A compact, dismissible bottom-corner card (NOT a full-screen modal) so it
+ * never blocks page content or fights AdSense Auto Ads vignettes for z-index.
+ * Single-select feature chips + an optional free-text "other" field. Responses
+ * are captured to PostHog (`feature_survey_response`) and mirrored to GA4 via
+ * Analytics, reusing the analytics pipeline already wired in the app — no extra
+ * SDK, no PostHog dashboard config, no consent banner (PostHog runs under
+ * legitimate interest, see services/posthog.ts).
+ *
+ * Fully localised (IT/EN/DE/FR) through the existing i18n core chunk.
+ *
+ * Timing: shows after real engagement (≥2 page views + 25s on site), respects
+ * the shared popup queue so it never overlaps the newsletter popup, and is
+ * remembered for 90 days once dismissed or answered.
+ */
+
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Lightbulb, Send, CheckCircle2 } from 'lucide-react';
+import { useTranslation } from '@/services/i18n';
+import { Analytics } from '@/services/analytics';
+import { captureEvent } from '@/services/posthog';
+import { isLikelyBot } from '@/services/botPatterns';
+import { requestSlot, releaseSlot, isActive, subscribe, POPUP_PRIORITY } from '@/services/popupQueue';
+
+const SLOT_ID = 'feature-survey';
+const DISMISSED_KEY = 'feature_survey_dismissed'; // timestamp once dismissed/answered
+const PAGE_VIEW_KEY = 'feature_survey_pageviews';
+const DISMISS_DAYS = 90; // long cooldown — survey, not a recurring nag
+const MIN_TIME_MS = 25_000; // 25s on site before it may appear
+const PAGE_VIEW_THRESHOLD = 2; // only engaged visitors
+
+// Stable option ids (locale-independent) so PostHog aggregates across languages.
+const OPTIONS = [
+  { id: 'salary_tools', icon: '💰' },
+  { id: 'traffic_alerts', icon: '🚦' },
+  { id: 'job_match', icon: '💼' },
+  { id: 'tax_guide', icon: '📋' },
+  { id: 'insurance', icon: '🏥' },
+  { id: 'mobile_app', icon: '📱' },
+  { id: 'other', icon: '✏️' },
+] as const;
+
+type OptionId = (typeof OPTIONS)[number]['id'];
+
+const FeatureSurvey: React.FC = () => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [queueActive, setQueueActive] = useState(false);
+  const [selected, setSelected] = useState<OptionId | null>(null);
+  const [otherText, setOtherText] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const timeReady = useRef(false);
+  const requested = useRef(false);
+
+  // Never show for bots/crawlers — they must see full page content, and we don't
+  // want survey events polluting analytics. Mirrors the PostHog bot gate.
+  const isBot = useMemo(() => isLikelyBot(), []);
+
+  useEffect(() => {
+    if (isBot) return;
+
+    // Respect the 90-day cooldown after a dismiss or an answer.
+    const dismissed = localStorage.getItem(DISMISSED_KEY);
+    if (dismissed) {
+      const daysSince = (Date.now() - parseInt(dismissed, 10)) / (1000 * 60 * 60 * 24);
+      if (daysSince < DISMISS_DAYS) return;
+    }
+
+    // Engagement gate: count page views this session.
+    const pageViews = parseInt(sessionStorage.getItem(PAGE_VIEW_KEY) || '0', 10) + 1;
+    sessionStorage.setItem(PAGE_VIEW_KEY, String(pageViews));
+
+    const tryRequest = () => {
+      if (requested.current) return;
+      if (!timeReady.current) return;
+      if (pageViews < PAGE_VIEW_THRESHOLD) return;
+      requested.current = true;
+      requestSlot(SLOT_ID, POPUP_PRIORITY.NEWSLETTER); // same low urgency as newsletter
+      setVisible(true);
+    };
+
+    const timer = setTimeout(() => {
+      timeReady.current = true;
+      tryRequest();
+    }, MIN_TIME_MS);
+
+    const unsub = subscribe(() => setQueueActive(isActive(SLOT_ID)));
+
+    return () => {
+      clearTimeout(timer);
+      unsub();
+    };
+  }, [isBot]);
+
+  const persistCooldown = () => {
+    localStorage.setItem(DISMISSED_KEY, String(Date.now()));
+  };
+
+  const handleDismiss = () => {
+    persistCooldown();
+    setVisible(false);
+    releaseSlot(SLOT_ID);
+    Analytics.trackUIInteraction('feature_survey', 'card', 'survey', 'dismiss');
+  };
+
+  const handleSubmit = () => {
+    if (!selected) return;
+    const trimmed = otherText.trim().slice(0, 280);
+    const payload: Record<string, string> = {
+      feature: selected,
+      page: window.location.pathname,
+    };
+    if (selected === 'other' && trimmed) payload.detail = trimmed;
+
+    captureEvent('feature_survey_response', payload);
+    Analytics.trackEvent('feature_survey_response', payload);
+
+    persistCooldown();
+    setSubmitted(true);
+    // Auto-close shortly after the thank-you state.
+    setTimeout(() => {
+      setVisible(false);
+      releaseSlot(SLOT_ID);
+    }, 2200);
+  };
+
+  if (isBot || !visible || !queueActive) return null;
+
+  const portalTarget = document.getElementById('modal-root') || document.body;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label={t('survey.feature.aria')}
+      className="fixed z-[60] bottom-3 right-3 left-3 sm:left-auto sm:bottom-5 sm:right-5 w-auto sm:w-[22rem] max-w-[calc(100vw-1.5rem)] bg-surface rounded-2xl shadow-2xl border border-edge overflow-hidden animate-fade-in"
+    >
+      <div className="bg-gradient-to-r from-info-strong to-success-strong p-3 sm:p-4 text-on-accent">
+        <button
+          onClick={handleDismiss}
+          className="absolute top-2 right-2 p-1.5 min-w-[44px] min-h-[44px] flex items-center justify-center text-on-accent/70 hover:text-on-accent hover:bg-on-accent/20 rounded-lg transition-colors"
+          aria-label={t('survey.feature.close')}
+        >
+          <X className="w-5 h-5" />
+        </button>
+        <div className="flex items-center gap-2 pr-10">
+          <div className="p-1.5 bg-on-accent/20 rounded-lg shrink-0">
+            <Lightbulb className="w-5 h-5" />
+          </div>
+          <div>
+            <h2 className="text-base font-bold font-display leading-tight">{t('survey.feature.title')}</h2>
+            <p className="text-on-accent/80 text-xs mt-0.5">{t('survey.feature.subtitle')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-3 sm:p-4">
+        {submitted ? (
+          <div className="text-center py-4">
+            <CheckCircle2 className="w-10 h-10 text-success mx-auto mb-2" />
+            <p className="font-bold text-strong mb-0.5">{t('survey.feature.thanks.title')}</p>
+            <p className="text-sm text-subtle">{t('survey.feature.thanks.body')}</p>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              {OPTIONS.map((opt) => {
+                const isSel = selected === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    onClick={() => setSelected(opt.id)}
+                    aria-pressed={isSel}
+                    className={
+                      'inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium border transition-colors min-h-[44px] ' +
+                      (isSel
+                        ? 'bg-info-subtle border-info text-strong'
+                        : 'bg-surface-alt border-edge text-body hover:bg-surface-raised')
+                    }
+                  >
+                    <span aria-hidden="true">{opt.icon}</span>
+                    {t(`survey.feature.option.${opt.id}`)}
+                  </button>
+                );
+              })}
+            </div>
+
+            {selected === 'other' && (
+              <textarea
+                value={otherText}
+                onChange={(e) => setOtherText(e.target.value)}
+                maxLength={280}
+                rows={2}
+                placeholder={t('survey.feature.otherPlaceholder')}
+                className="mt-3 w-full px-3 py-2 bg-surface-alt border border-edge rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-info text-strong text-sm resize-none"
+              />
+            )}
+
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <button
+                type="button"
+                onClick={handleDismiss}
+                className="px-3 py-2 text-sm font-medium text-muted hover:text-body transition-colors"
+              >
+                {t('survey.feature.dismiss')}
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!selected}
+                className="inline-flex items-center gap-2 px-4 py-2.5 bg-gradient-to-r from-info-strong to-success-strong text-on-accent text-sm font-bold rounded-xl hover:from-info-strong-hover hover:to-success-strong-hover transition-[color,background-color,border-color,opacity] disabled:opacity-50 disabled:cursor-not-allowed shadow-lg"
+              >
+                <Send className="w-4 h-4" />
+                {t('survey.feature.submit')}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    portalTarget,
+  );
+};
+
+export default FeatureSurvey;

--- a/components/community/WhatsNewModal.tsx
+++ b/components/community/WhatsNewModal.tsx
@@ -33,6 +33,18 @@ interface Release {
 
 export const RELEASES: Release[] = [
  {
+ version: '3.54.0',
+ date: '2026-06-22',
+ titleKey: 'whatsNew.v3540.title',
+ items: [
+ {
+ type: 'feature',
+ titleKey: 'whatsNew.v3540.featureSurvey.title',
+ descKey: 'whatsNew.v3540.featureSurvey.desc',
+ },
+ ],
+ },
+ {
  version: '3.53.0',
  date: '2026-06-17',
  titleKey: 'whatsNew.v3530.title',

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -3417,6 +3417,28 @@ Regeln:
  'whatsNew.v3500.title': 'Überarbeitetes Arbeitgeberportal',
  'whatsNew.v3500.publisherRedesign.title': 'Inserate aufgeben: neuer Look und Dashboard',
  'whatsNew.v3500.publisherRedesign.desc': 'Die Arbeitgeberseiten wirken wärmer und klarer: Gratis- und Gesponsert-Plan im Vergleich sowie ein „Meine Inserate“-Dashboard mit animierten Statistiken und Konversionstrichter pro Inserat.',
+
+  // ─── Feature request survey ──────────────────────────────
+  'survey.feature.title': 'Welche Funktion wünschst du dir?',
+  'survey.feature.subtitle': 'Hilf uns zu entscheiden, was wir bauen (10 Sek.)',
+  'survey.feature.option.salary_tools': 'Lohn-Tools',
+  'survey.feature.option.traffic_alerts': 'Verkehrsmeldungen',
+  'survey.feature.option.job_match': 'Passende Jobs',
+  'survey.feature.option.tax_guide': 'Steuer-Guide',
+  'survey.feature.option.insurance': 'Versicherungsvergleich',
+  'survey.feature.option.mobile_app': 'Mobile App',
+  'survey.feature.option.other': 'Andere',
+  'survey.feature.otherPlaceholder': 'Sag uns, was du brauchst…',
+  'survey.feature.submit': 'Senden',
+  'survey.feature.dismiss': 'Nicht jetzt',
+  'survey.feature.close': 'Schliessen',
+  'survey.feature.aria': 'Funktions-Umfrage',
+  'survey.feature.thanks.title': 'Danke!',
+  'survey.feature.thanks.body': 'Dein Feedback hilft uns, besser zu werden.',
+
+  'whatsNew.v3540.title': 'Sag uns, welche Funktion du willst',
+  'whatsNew.v3540.featureSurvey.title': 'Funktions-Umfrage',
+  'whatsNew.v3540.featureSurvey.desc': 'Eine kurze Umfrage fragt, welche Funktion du als Nächstes möchtest: Lohn-Tools, Verkehrsmeldungen, passende Stellenangebote und mehr. Es dauert zehn Sekunden und hilft uns zu entscheiden, was wir als Nächstes bauen.',
 };
 
 export default deCore;

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -3414,6 +3414,28 @@ Rules:
  'whatsNew.v3500.title': 'Refreshed employer portal',
  'whatsNew.v3500.publisherRedesign.title': 'Post jobs: new look and dashboard',
  'whatsNew.v3500.publisherRedesign.desc': 'The employer pages got a warmer, clearer look: Free vs Sponsored plans side by side, and a “My ads” dashboard with animated stats and a conversion funnel for every listing.',
+
+  // ─── Feature request survey ──────────────────────────────
+  'survey.feature.title': 'Which feature would you like?',
+  'survey.feature.subtitle': 'Help us decide what to build (10 sec)',
+  'survey.feature.option.salary_tools': 'Salary tools',
+  'survey.feature.option.traffic_alerts': 'Traffic alerts',
+  'survey.feature.option.job_match': 'Tailored jobs',
+  'survey.feature.option.tax_guide': 'Tax guide',
+  'survey.feature.option.insurance': 'Insurance compare',
+  'survey.feature.option.mobile_app': 'Mobile app',
+  'survey.feature.option.other': 'Other',
+  'survey.feature.otherPlaceholder': 'Tell us what you need…',
+  'survey.feature.submit': 'Send',
+  'survey.feature.dismiss': 'Not now',
+  'survey.feature.close': 'Close',
+  'survey.feature.aria': 'Feature survey',
+  'survey.feature.thanks.title': 'Thank you!',
+  'survey.feature.thanks.body': 'Your feedback helps us improve.',
+
+  'whatsNew.v3540.title': 'Tell us which feature you want',
+  'whatsNew.v3540.featureSurvey.title': 'Feature survey',
+  'whatsNew.v3540.featureSurvey.desc': 'A short survey asks which feature you would like next: salary tools, traffic alerts, tailored job offers and more. It takes ten seconds and helps us decide what to build next.',
 };
 
 export default enCore;

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -3417,6 +3417,28 @@ Règles :
  'whatsNew.v3500.title': 'Portail employeurs renouvelé',
  'whatsNew.v3500.publisherRedesign.title': 'Publier des offres : nouveau look et tableau de bord',
  'whatsNew.v3500.publisherRedesign.desc': 'Les pages employeurs ont un aspect plus chaleureux et clair : forfaits Gratuit et Sponsorisé comparés, et un tableau de bord « Mes annonces » avec statistiques animées et entonnoir de conversion par annonce.',
+
+  // ─── Feature request survey ──────────────────────────────
+  'survey.feature.title': 'Quelle fonctionnalité aimeriez-vous ?',
+  'survey.feature.subtitle': 'Aidez-nous à décider quoi créer (10 s)',
+  'survey.feature.option.salary_tools': 'Outils salaire',
+  'survey.feature.option.traffic_alerts': 'Alertes trafic',
+  'survey.feature.option.job_match': 'Offres sur mesure',
+  'survey.feature.option.tax_guide': 'Guide fiscal',
+  'survey.feature.option.insurance': 'Comparateur assurances',
+  'survey.feature.option.mobile_app': 'Appli mobile',
+  'survey.feature.option.other': 'Autre',
+  'survey.feature.otherPlaceholder': 'Dites-nous ce qu’il vous faut…',
+  'survey.feature.submit': 'Envoyer',
+  'survey.feature.dismiss': 'Plus tard',
+  'survey.feature.close': 'Fermer',
+  'survey.feature.aria': 'Sondage fonctionnalités',
+  'survey.feature.thanks.title': 'Merci !',
+  'survey.feature.thanks.body': 'Votre avis nous aide à nous améliorer.',
+
+  'whatsNew.v3540.title': 'Dites-nous quelle fonctionnalité vous voulez',
+  'whatsNew.v3540.featureSurvey.title': 'Sondage fonctionnalités',
+  'whatsNew.v3540.featureSurvey.desc': 'Un court sondage vous demande quelle fonctionnalité vous aimeriez ensuite : outils de salaire, alertes trafic, offres d’emploi sur mesure et plus. Cela prend dix secondes et nous aide à décider quoi créer ensuite.',
 };
 
 export default frCore;

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -3504,5 +3504,27 @@ Regole:
  'whatsNew.v3500.title': 'Portale aziende rinnovato',
  'whatsNew.v3500.publisherRedesign.title': 'Pubblica offerte: nuova veste e dashboard',
  'whatsNew.v3500.publisherRedesign.desc': 'Le pagine per le aziende hanno un look più caldo e chiaro: piani Gratis e Sponsorizzato a confronto e una dashboard “I miei annunci” con statistiche animate e imbuto di conversione per ogni annuncio.',
+
+  // ─── Feature request survey ──────────────────────────────
+  'survey.feature.title': 'Quale funzione vorresti?',
+  'survey.feature.subtitle': 'Aiutaci a decidere cosa costruire (10 sec)',
+  'survey.feature.option.salary_tools': 'Strumenti stipendio',
+  'survey.feature.option.traffic_alerts': 'Avvisi traffico',
+  'survey.feature.option.job_match': 'Offerte su misura',
+  'survey.feature.option.tax_guide': 'Guida fiscale',
+  'survey.feature.option.insurance': 'Confronto assicurazioni',
+  'survey.feature.option.mobile_app': 'App mobile',
+  'survey.feature.option.other': 'Altro',
+  'survey.feature.otherPlaceholder': 'Dicci cosa ti servirebbe…',
+  'survey.feature.submit': 'Invia',
+  'survey.feature.dismiss': 'Non ora',
+  'survey.feature.close': 'Chiudi',
+  'survey.feature.aria': 'Sondaggio funzionalità',
+  'survey.feature.thanks.title': 'Grazie!',
+  'survey.feature.thanks.body': 'Il tuo parere ci aiuta a migliorare.',
+
+  'whatsNew.v3540.title': 'Dicci che funzione vuoi',
+  'whatsNew.v3540.featureSurvey.title': 'Sondaggio funzionalità',
+  'whatsNew.v3540.featureSurvey.desc': 'Un breve sondaggio ti chiede quale funzione vorresti vedere prossimamente: strumenti per lo stipendio, avvisi traffico, offerte su misura e altro. Bastano dieci secondi e ci aiuti a decidere cosa costruire dopo.',
 };
 export default translations;

--- a/tests/feature-survey.test.tsx
+++ b/tests/feature-survey.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * FeatureSurvey micro-survey coverage.
+ *
+ * Verifies the engagement gate (time + page views), the 90-day dismiss
+ * cooldown, and that a submit captures `feature_survey_response` to PostHog
+ * (and GA via Analytics) with the stable, locale-independent option id.
+ */
+
+import React from 'react';
+import { render, screen, cleanup, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+import FeatureSurvey from '@/components/community/FeatureSurvey';
+import { captureEvent } from '@/services/posthog';
+import { Analytics } from '@/services/analytics';
+import { isLikelyBot } from '@/services/botPatterns';
+
+vi.mock('@/services/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    locale: 'it' as const,
+  }),
+}));
+
+vi.mock('@/services/posthog', () => ({
+  captureEvent: vi.fn(),
+}));
+
+vi.mock('@/services/analytics', () => ({
+  Analytics: {
+    trackEvent: vi.fn(),
+    trackUIInteraction: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/botPatterns', () => ({
+  isLikelyBot: vi.fn(() => false),
+}));
+
+// Popup queue: grant the slot immediately so visibility depends only on the
+// component's own engagement gate, which is what we're testing.
+vi.mock('@/services/popupQueue', () => ({
+  requestSlot: vi.fn(() => true),
+  releaseSlot: vi.fn(),
+  isActive: vi.fn(() => true),
+  subscribe: (listener: () => void) => {
+    listener();
+    return () => {};
+  },
+  POPUP_PRIORITY: { NEWSLETTER: 20 },
+}));
+
+const captureMock = vi.mocked(captureEvent);
+const trackEventMock = vi.mocked(Analytics.trackEvent);
+const isBotMock = vi.mocked(isLikelyBot);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+  sessionStorage.clear();
+  captureMock.mockClear();
+  trackEventMock.mockClear();
+  isBotMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('FeatureSurvey engagement gate', () => {
+  it('stays hidden before the time threshold elapses', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1'); // → 2 page views on mount
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('appears after time + page-view thresholds are met', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+    expect(screen.queryByRole('dialog')).not.toBeNull();
+  });
+
+  it('never shows for bots', async () => {
+    isBotMock.mockReturnValue(true);
+    sessionStorage.setItem('feature_survey_pageviews', '5');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('respects the 90-day dismiss cooldown', async () => {
+    localStorage.setItem('feature_survey_dismissed', String(Date.now()));
+    sessionStorage.setItem('feature_survey_pageviews', '5');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('FeatureSurvey submission', () => {
+  it('captures the stable option id to PostHog and GA, then sets the cooldown', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+
+    // Pick a feature chip (label key === stable id mapping via t()).
+    fireEvent.click(screen.getByText('survey.feature.option.traffic_alerts'));
+    fireEvent.click(screen.getByText('survey.feature.submit'));
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = captureMock.mock.calls[0];
+    expect(eventName).toBe('feature_survey_response');
+    expect(payload).toMatchObject({ feature: 'traffic_alerts' });
+    expect(trackEventMock).toHaveBeenCalledWith('feature_survey_response', expect.objectContaining({ feature: 'traffic_alerts' }));
+    expect(localStorage.getItem('feature_survey_dismissed')).not.toBeNull();
+  });
+
+  it('includes free-text detail when "other" is chosen', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+
+    fireEvent.click(screen.getByText('survey.feature.option.other'));
+    fireEvent.change(screen.getByPlaceholderText('survey.feature.otherPlaceholder'), {
+      target: { value: 'PDF export of payslips' },
+    });
+    fireEvent.click(screen.getByText('survey.feature.submit'));
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    const [, payload] = captureMock.mock.calls[0];
+    expect(payload).toMatchObject({ feature: 'other', detail: 'PDF export of payslips' });
+  });
+
+  it('does not submit when no feature is selected', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+
+    fireEvent.click(screen.getByText('survey.feature.submit'));
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Implementato

- **Nuovo componente `components/community/FeatureSurvey.tsx`**: micro-survey "quale funzione vorresti?" come card bottom-corner dismissible (NON modale full-screen) → non blocca contenuto né combatte z-index con AdSense Auto Ads.
- **Single-select chips** di feature candidate (strumenti stipendio, avvisi traffico, offerte su misura, guida fiscale, confronto assicurazioni, app mobile) + free-text opzionale "altro" (max 280 char).
- **Cattura risposte via PostHog** `captureEvent('feature_survey_response', { feature, page, detail? })` con id opzione **stabili locale-independent** (es. `traffic_alerts`) → aggregazione cross-lingua nella dashboard PostHog; mirror su GA4 via `Analytics.trackEvent`. Riusa la pipeline analytics già montata, zero nuova SDK, zero config dashboard, zero consent banner.
- **Localizzazione completa IT/EN/DE/FR**: 16 chiavi `survey.feature.*` aggiunte al chunk `core` di ogni locale (sempre caricato).
- **Wiring in `App.tsx`**: `<FeatureSurvey />` lazy accanto a `NewsletterPopup`, dentro il Suspense esistente.
- **Integrazione popup queue**: `requestSlot`/`releaseSlot` con priorità `NEWSLETTER` → non si sovrappone mai al newsletter popup.
- **Gate non intrusivo**: appare solo dopo engagement reale (≥2 page view + 25s sul sito), **skippa i bot** (`isLikelyBot`), cooldown 90 giorni dopo dismiss o risposta (localStorage).
- **Entry WhatsNew v3.54.0** + relative chiavi (feature user-facing → richiesto da AGENTS.md).
- **Test `tests/feature-survey.test.tsx`** (7 casi): engagement gate, skip bot, cooldown 90gg, submit cattura id stabile su PostHog+GA, free-text "altro", no-submit senza selezione.

### PostHog vs Firebase — verifica fattibilità
PostHog è la via **facile**: `captureEvent` è già wired (`services/posthog.ts`), le risposte sono interrogabili nella dashboard PostHog senza alcun backend, e il bot-gate / persistence sono già gestiti. Firebase avrebbe richiesto una nuova collection Firestore + security rules + tooling di lettura per lo stesso risultato. Scelto PostHog.

## Non implementato (ancora)

- **Survey nativo PostHog (dashboard-managed)**: scartato — non supporta multilingua pulito (richiederebbe 4 survey separate + targeting per proprietà) e aggiunge bundle survey extra. Il componente custom riusa l'i18n esistente.
- **Persistenza risposte su Firestore**: out of scope — PostHog copre l'analisi; valutabile come follow-up solo se servisse join con dati utente autenticati.
- **A/B test sul set di opzioni / sul timing**: follow-up — l'infrastruttura feature-flag PostHog (`getFeatureFlag`) è già disponibile se in futuro si vuole variare le opzioni.
- **Verifica live post-deploy** (card visibile dopo engagement, evento in PostHog): da fare su `main` post-merge — non verificabile sul `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)