### PR TITLE
fix(mobile-plans): best-options badge non più tagliato su mobile

### DIFF
--- a/components/comparators/MobileOperators.tsx
+++ b/components/comparators/MobileOperators.tsx
@@ -465,14 +465,14 @@ const MobileOperators: React.FC = () => {
  const currency = op.country === 'IT' ? '€' : 'CHF';
  const roamingLabel = limit === 'illimitati' ? t('mobile.roamingUnlimited') : `${limit} GB`;
  return (
- <li key={op.name} className="flex items-baseline justify-between gap-3">
+ <li key={op.name} className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
  <span className="flex items-baseline gap-2 min-w-0">
  <span className="text-success font-bold tabular-nums">{rank}.</span>
  <strong className="text-strong truncate">{op.name}</strong>
  </span>
- <span className="flex items-baseline gap-2 flex-shrink-0">
+ <span className="flex items-baseline gap-2 min-w-0 pl-6 sm:pl-0 sm:flex-shrink-0">
  <span className="text-body font-bold tabular-nums whitespace-nowrap">{op.monthlyCost} {currency}</span>
- <span className="px-2 py-0.5 rounded-full bg-success-strong text-on-accent text-xs font-medium whitespace-nowrap">{roamingLabel}</span>
+ <span className="px-2 py-0.5 rounded-full bg-success-strong text-on-accent text-xs font-medium truncate">{roamingLabel}</span>
  </span>
  </li>
  );


### PR DESCRIPTION
## Implementato

- `components/comparators/MobileOperators.tsx` — `renderBestRow` (riepilogo "Migliori opzioni"): la riga passava da single-line flex con gruppo destro `flex-shrink-0` che conteneva prezzo + badge roaming `whitespace-nowrap` ("unlimited roaming"). Su mobile stretto il badge non entrava e **sforava il bordo destro della card**, tagliando il valore GB roaming.
- Riga ora **stack verticale su mobile** (`flex flex-col`): nome su riga 1, prezzo + badge indentati (`pl-6`) su riga 2. Da `sm:` in su torna il layout single-line originale (`sm:flex-row sm:justify-between sm:flex-shrink-0 sm:pl-0`).
- Badge da `whitespace-nowrap` → `truncate` (+ `min-w-0` sul gruppo) come rete di sicurezza anti-overflow.
- **Effetto sull'ordinamento percepito**: il ranking è "top 3 by roaming GB / price ratio" (intenzionale, `mobile.bestOptionsHint`). Su mobile il badge GB era tagliato → l'utente vedeva solo i prezzi (es. Swiss: 29.9 → 39.9 → 29.95) e lo leggeva come ordinamento rotto. Reso il badge sempre visibile, l'ordine per valore (unlimited / 32 GB sopra 11.4 GB) si auto-spiega.

## Non implementato (ancora)

- Nessun cambio alla logica di ranking né alla semantica dati (es. `Salt Travel` resta `20 GB`, non "illimitati"): scelta chirurgica per non regredire un ranking deliberato che evita di promuovere micro-roaming 1 GB e piani costosi. Se l'utente vuole un ordinamento per prezzo puro o una rimodulazione del peso "unlimited vs GB", è un follow-up di prodotto.
- Verifica visuale mobile live: post-deploy (build/serve locale SEO OOM-prone, validazione via CI `tests` + curl live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)