### PR TITLE
fix(harvester): don't count max-turns burn when the run delivered a PR (#2653)

### DIFF
--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -276,9 +276,19 @@ export function isAvoidableAlreadyFixed(title, labels) {
 // the genuine signal — a fixable loop the budget should have covered → countable.
 // Same feedback-loop class as isAvoidableAlreadyFixed. Pure → unit-tested.
 // `labels` is an array of label-name strings.
-export function isAvoidableMaxTurns(title, labels) {
+//   3. The run ALREADY SHIPPED A PR (`hasDeliveredPr`, i.e. the issue carries a
+//      `<!-- FIX_OUTCOME: pr-created -->` marker): the cap was hit on harmless
+//      POST-delivery churn (telemetry comment, sibling-sweep verify, a second
+//      item). The workflow's own `Classify outcome` step already treats this as
+//      job-SUCCESS ("false-failure: lavoro consegnato"). Counting it as burn was
+//      the false positive driving escalation #2653 (3/5 examples — #2590/#2560/
+//      #2476 — opened a MERGED PR then overran). By-construction: a run that
+//      delivered a PR can never inflate the bucket, mirroring the workflow.
+export function isAvoidableMaxTurns(title, labels, hasDeliveredPr = false) {
   const names = Array.isArray(labels) ? labels : [];
   const t = String(title || '');
+  // (3) a PR was delivered → cap hit on post-delivery overrun, not a fixable loop.
+  if (hasDeliveredPr) return false;
   // (2) drainer already parked it as structurally non-fixable → expected death.
   if (names.includes('needs-human')) return false;
   // (1) aggregate multi-item → over-budget by construction (circuit-breaker target),
@@ -399,6 +409,12 @@ async function main() {
     // Lo stesso principio dedup-per-sorgente vale per i reviewer-finding sopra,
     // dove la chiave è la PR (vedi tallyFindings).
     const seenThisIssue = new Set();
+    // A `pr-created` marker anywhere on the issue means a fixer run delivered a PR
+    // (open or merged) — so a `max-turns` death is post-delivery overrun, not a
+    // fixable loop (escalation #2653). Pre-scan once; per-issue dedup already
+    // collapses re-queued runs, and a delivered PR means the work landed.
+    const hasDeliveredPr = comments.some((c) =>
+      /<!--\s*FIX_OUTCOME:\s*pr-created\s*-->/i.test(String(c.body || '')));
     for (const c of comments) {
       const m = String(c.body || '').match(/<!--\s*FIX_OUTCOME:\s*([a-z0-9-]+)\s*-->/i);
       if (!m) continue;
@@ -440,7 +456,7 @@ async function main() {
       // actionable structural fix beyond what shipped (#2291 + circuit-breaker), so
       // don't escalate it (root cause of #2439: bucket re-fired at 14/14d, examples
       // dominated by aggregate / parked runs). Single-item still-routable deaths count.
-      if (code === 'max-turns' && !isAvoidableMaxTurns(issue.title, labelNames)) continue;
+      if (code === 'max-turns' && !isAvoidableMaxTurns(issue.title, labelNames, hasDeliveredPr)) continue;
       const k = `fix-outcome:${code}`;
       if (seenThisIssue.has(k)) continue;
       seenThisIssue.add(k);

--- a/tests/harvest-escalation-avoidable.test.ts
+++ b/tests/harvest-escalation-avoidable.test.ts
@@ -57,6 +57,25 @@ describe('isAvoidableMaxTurns — non escalare la morte al cap che è determinis
     expect(isAvoidableMaxTurns('follow-up(#9): 1 item deferred — fix(x)', ['follow-up'])).toBe(true);
   });
 
+  it('PR consegnato (hasDeliveredPr) → NON contabile, anche single-item routable (#2653: overrun post-delivery)', () => {
+    // 3/5 esempi dell'escalation #2653 (#2590/#2560/#2476) hanno aperto un PR poi
+    // mergiato, poi sforato il cap su churn post-delivery. Un run che ha consegnato
+    // un PR è SUCCESS (come lo classifica già issue-fix.yml) → mai burn evitabile.
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2590): 1 item deferred — fix(x)',
+      ['follow-up', 'agent:triaged'],
+      true,
+    )).toBe(false);
+    // senza PR consegnato la stessa issue single-item resta il segnale genuino
+    expect(isAvoidableMaxTurns(
+      'follow-up(#2590): 1 item deferred — fix(x)',
+      ['follow-up', 'agent:triaged'],
+      false,
+    )).toBe(true);
+    // hasDeliveredPr domina anche su aggregate/parked (irrilevante, ma esplicito)
+    expect(isAvoidableMaxTurns('follow-up(#x): 3 items deferred', ['follow-up'], true)).toBe(false);
+  });
+
   it('input degeneri → contabile-safe non gonfia (proceed: solo le esclusioni esplicite scartano)', () => {
     // nessuna label needs-human, nessun marcatore aggregate → resta contabile,
     // ma in pratica un titolo vuoto non fa scattare nulla a valle (count basso).


### PR DESCRIPTION
## Implementato
- `isAvoidableMaxTurns(title, labels, hasDeliveredPr=false)` in `scripts/ci/harvest-agent-lessons.mjs`: terzo argomento — se il run ha consegnato un PR, la morte `max-turns` è overrun post-delivery, **non** burn evitabile → ritorna `false` (non contabile).
- Pre-scan dei commenti dell'issue per il marker `<!-- FIX_OUTCOME: pr-created -->` (in-memory, zero API extra) → `hasDeliveredPr`, passato al call-site del bucket `max-turns`.
- 3 nuove asserzioni in `tests/harvest-escalation-avoidable.test.ts` (14/14 verdi): PR consegnato → non contabile (anche single-item routable e anche aggregate); senza PR → resta il segnale genuino.

### Perché
L'escalation #2653 ha rifirato `fix-outcome:max-turns` 6×/14gg, ma 3/5 esempi (#2590/#2560/#2476) avevano **aperto un PR poi mergiato** e sforato il cap solo su churn post-delivery (commento telemetria, sibling-sweep, secondo item). `issue-fix.yml` `Classify outcome` già li tratta come job-SUCCESS ("false-failure: lavoro consegnato"); il harvester non aveva il check PR-delivery → falsi positivi senza loop fixabile dietro. Fix by-construction: un run che ha consegnato un PR non può più gonfiare il bucket. Con questo, il bucket avrebbe contato solo le 2 morti genuine no-PR (#2533/#2467), sotto soglia → nessuna escalation.

Nessuna modifica a max-turns caps/prompt (vincolo AGENTS.md).

## Non implementato (ancora)
- **Riduzione overrun alla sorgente** (prompt issue-fix: STOP immediato dopo `gh pr create` + marker `pr-created`): è una leva prose/prompt — il harvester stesso dichiara che le regole prose non prevengono la ricorrenza, quindi è il counting-fix qui sopra quello strutturale. Eventuale follow-up separato.

Closes #2653