### PR TITLE
fix(profession-landings): "see all offers" CTA → sector hub, not generic job board

### DIFF
--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -250,7 +250,12 @@ function renderFeaturedJobs(
     locale,
     emptyStateHtml: emptyHtml,
   });
-  const ctaHref = buildJobBoardUrl(locale);
+  // "See all N offers" CTA → the landing's sector hub (e.g. nurses →
+  // /cerca-lavoro-ticino/infermieri/) so the visitor lands on a filtered
+  // search, not the generic root. Reuses CTA_SECTOR; null (healthcare-ticino,
+  // whose copy says "all openings") falls back to the unfiltered hub.
+  const ctaSector = CTA_SECTOR[id];
+  const ctaHref = ctaSector ? buildSectorHubPath(locale, ctaSector) : buildJobBoardUrl(locale);
   const ctaLabel = snapshot.featured.length > 0 && snapshot.liveCount > 0
     ? pickCtaAllJobs(id, locale, snapshot.liveCount)
     : (copy.featuredJobsCtaAllLabel ?? 'Vedi tutti gli annunci →');

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -86,8 +86,45 @@ import {
   renderEmployerCardListHtml,
   type EmployerCardEmployer,
 } from './shared/employerCardHtml';
+import {
+  buildSectorHubPath,
+  type SectorHubKey,
+} from './jobSectorLanding';
 
 // ── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Maps each profession landing to the job-board sector hub that lists its
+ * openings (e.g. /lavoro-ticino-autista/ → /cerca-lavoro-ticino/autisti/).
+ * The "see all N offers" CTA deep-links here instead of the generic job-board
+ * root, so the visitor lands on a search already filtered to the profession.
+ *
+ * Every target is a crawlable, indexed sector-hub PATH (emitted unconditionally
+ * by jobSectorPagesPlugin) — NOT a robots-disallowed `?q=` query URL — so it
+ * stays internal-link/crawl safe (no rel="nofollow"; see no-internal-nofollow
+ * test). A profession without a sound sector match falls back to the root.
+ */
+const PROFESSION_SECTOR_HUB: Partial<Record<ProfessionId, SectorHubKey>> = {
+  infermiere: 'infermieri',
+  operaio: 'industria',
+  impiegato: 'commercio',
+  ingegnere: 'ingegneri',
+  educatore: 'educatori',
+  autista: 'autisti',
+  muratore: 'edilizia',
+  cuoco: 'cuochi',
+  cameriere: 'camerieri',
+  elettricista: 'elettricisti',
+};
+
+/**
+ * CTA target for the "see all offers" link on a profession landing: the
+ * profession's sector hub when mapped, else the generic job-board root.
+ */
+function buildProfessionAllJobsUrl(id: ProfessionId, locale: ProfessionLocale): string {
+  const sector = PROFESSION_SECTOR_HUB[id];
+  return sector ? buildSectorHubPath(locale, sector) : buildJobBoardUrl(locale);
+}
 
 function esc(s: unknown): string {
   return String(s ?? '')
@@ -193,11 +230,15 @@ function renderFeaturedJobs(
     locale,
     emptyStateHtml: emptyHtml,
   });
-  // Link the "see all" CTA to the job-board root (crawlable, indexed). NOT a
-  // `?q=` keyword deep-link: robots.txt disallows `/*?q=*`, so an internal
-  // `?q=` link is a "disallowed outlink" (SearchAtlas/GSC) and rel="nofollow"
-  // is banned on internal links (tests/no-internal-nofollow.test.tsx).
-  const ctaHref = buildJobBoardUrl(locale);
+  // Link the "see all N offers" CTA to the profession's sector hub
+  // (e.g. /cerca-lavoro-ticino/autisti/) so the visitor lands on a job-board
+  // search already filtered to the profession, not the generic root. The hub
+  // is a crawlable, indexed PATH — NOT a `?q=` keyword deep-link: robots.txt
+  // disallows `/*?q=*`, so an internal `?q=` link is a "disallowed outlink"
+  // (SearchAtlas/GSC) and rel="nofollow" is banned on internal links
+  // (tests/no-internal-nofollow.test.tsx). Falls back to root when the
+  // profession has no mapped sector.
+  const ctaHref = buildProfessionAllJobsUrl(id, locale);
   const ctaLabel = snapshot.featured.length > 0 && snapshot.liveCount > 0
     ? pickCtaAllJobs(id, locale, snapshot.liveCount)
     : (copy.featuredJobsCtaAllLabel ?? 'Vedi tutti gli annunci →');

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -440,6 +440,11 @@ function renderPage(opts: {
 
   const homeUrl = locale === 'it' ? `${BASE_URL}/` : `${BASE_URL}/${locale}/`;
   const jobBoardUrl = `${BASE_URL}${buildJobBoardUrl(locale)}`;
+  // Bottom primary CTA deep-links to the profession's sector hub (filtered
+  // job-board search), same as the featured-jobs CTA — never the generic root.
+  // The breadcrumb below intentionally keeps the root job board as parent
+  // (position 2). Falls back to root when the profession has no mapped sector.
+  const ctaJobsUrl = `${BASE_URL}${buildProfessionAllJobsUrl(id, locale)}`;
   const calculatorUrl = `${BASE_URL}${CALCULATOR_URL[locale]}`;
 
   const breadcrumbLd = inlineScriptJson({
@@ -569,7 +574,7 @@ function renderPage(opts: {
     </section>
     ${relatedHtml}
     <section class="s-p1QaOi">
-      <a href="${esc(jobBoardUrl)}" class="s-cta">${esc(copy.ctaJobs)}</a>
+      <a href="${esc(ctaJobsUrl)}" class="s-cta">${esc(copy.ctaJobs)}</a>
       <a class="s-eXgANZ" href="${esc(calculatorUrl)}">${esc(copy.ctaSimulator)}</a>
     </section>
     <section class="s-GCEyQg" aria-label="${esc(copy.h1)}">

--- a/tests/build-plugins/profession-cta-sector-hub.test.ts
+++ b/tests/build-plugins/profession-cta-sector-hub.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { buildSectorHubPath } from '../../build-plugins/jobSectorLanding';
+
+// The "see all N offers" CTA on a profession landing (e.g. /lavoro-ticino-autista/)
+// must deep-link to the profession's job-board sector hub
+// (e.g. /cerca-lavoro-ticino/autisti/) — a crawlable, indexed PATH that lands
+// the visitor on a search already filtered to the profession — NOT the generic
+// job-board root and NOT a robots-disallowed `?q=` query URL.
+
+const FIXTURE_JOB = {
+  id: 'job-1',
+  title: 'Autista C/CE',
+  titleByLocale: { it: 'Autista C/CE' },
+  company: 'Trasporti Ticino',
+  companyKey: 'trasporti-ticino',
+  companyDomain: 'trasporti.ch',
+  city: 'Lugano',
+  addressLocality: 'Lugano',
+  canton: 'TI',
+  contract: 'full-time',
+  salaryMin: 60000,
+  salaryMax: 75000,
+  postedDate: new Date(Date.now() - 86400000 * 2).toISOString(),
+  daysAgo: 2,
+  slug: 'autista-cce-trasporti-ticino-lugano',
+  slugByLocale: {},
+  employmentType: 'full-time',
+  url: 'https://example.com/job-1',
+  isCantonalFallback: false,
+};
+
+const SNAPSHOT_BASE = {
+  liveCount: 3,
+  fresh30Count: 3,
+  medianSalaryChf: 65000,
+  topEmployers: [],
+};
+
+// profession id → sector hub key it must link to (kept in sync with
+// PROFESSION_SECTOR_HUB in professionLandingsPlugin.ts).
+const EXPECTED: Array<[string, string]> = [
+  ['infermiere', 'infermieri'],
+  ['operaio', 'industria'],
+  ['impiegato', 'commercio'],
+  ['ingegnere', 'ingegneri'],
+  ['educatore', 'educatori'],
+  ['autista', 'autisti'],
+  ['muratore', 'edilizia'],
+  ['cuoco', 'cuochi'],
+  ['cameriere', 'camerieri'],
+  ['elettricista', 'elettricisti'],
+];
+
+const ctaHrefOf = (html: string): string | null => {
+  // The CTA is the last anchor in the featured-jobs section.
+  const matches = [...html.matchAll(/<a href="([^"]+)"[^>]*>[^<]*offer/gi)];
+  if (matches.length > 0) return matches[matches.length - 1][1];
+  // Fallback: any anchor carrying the link-accent CTA styling.
+  const styled = [...html.matchAll(/<a href="([^"]+)"[^>]*font-weight:700/gi)];
+  return styled.length > 0 ? styled[styled.length - 1][1] : null;
+};
+
+describe('profession landing "see all offers" CTA links to the sector hub', () => {
+  for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+    for (const [profession, sector] of EXPECTED) {
+      it(`${profession} (${locale}) → ${sector} hub`, async () => {
+        const mod: any = await import('../../build-plugins/professionLandingsPlugin');
+        const html = mod.renderProfessionFeaturedJobsForTest(profession, locale, {
+          ...SNAPSHOT_BASE,
+          featured: [FIXTURE_JOB],
+        });
+        const href = ctaHrefOf(html);
+        expect(href, `no CTA anchor rendered for ${profession}/${locale}`).toBeTruthy();
+        const expectedPath = buildSectorHubPath(locale, sector as any);
+        expect(href).toBe(expectedPath);
+        // Never the bare job-board root, never a robots-disallowed ?q= link.
+        expect(href).not.toMatch(/\?q=/);
+        expect(href!.replace(/\/+$/, '')).not.toMatch(
+          /\/(cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)$/,
+        );
+      });
+    }
+  }
+});

--- a/tests/build-plugins/profession-cta-sector-hub.test.ts
+++ b/tests/build-plugins/profession-cta-sector-hub.test.ts
@@ -52,13 +52,13 @@ const EXPECTED: Array<[string, string]> = [
 ];
 
 const ctaHrefOf = (html: string): string | null => {
-  // The CTA is the last anchor in the featured-jobs section.
-  const matches = [...html.matchAll(/<a href="([^"]+)"[^>]*>[^<]*offer/gi)];
-  if (matches.length > 0) return matches[matches.length - 1][1];
-  // Fallback: any anchor carrying the link-accent CTA styling.
-  const styled = [...html.matchAll(/<a href="([^"]+)"[^>]*font-weight:700/gi)];
-  return styled.length > 0 ? styled[styled.length - 1][1] : null;
+  // The "see all" CTA is the only anchor styled with `margin-top:14px`
+  // (locale-agnostic — the visible label differs per language).
+  const matches = [...html.matchAll(/<a href="([^"]+)"[^>]*margin-top:14px/gi)];
+  return matches.length > 0 ? matches[matches.length - 1][1] : null;
 };
+
+const ROOT_RE = /\/(cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)$/;
 
 describe('profession landing "see all offers" CTA links to the sector hub', () => {
   for (const locale of ['it', 'en', 'de', 'fr'] as const) {
@@ -71,13 +71,43 @@ describe('profession landing "see all offers" CTA links to the sector hub', () =
         });
         const href = ctaHrefOf(html);
         expect(href, `no CTA anchor rendered for ${profession}/${locale}`).toBeTruthy();
-        const expectedPath = buildSectorHubPath(locale, sector as any);
-        expect(href).toBe(expectedPath);
+        expect(href).toBe(buildSectorHubPath(locale, sector as any));
         // Never the bare job-board root, never a robots-disallowed ?q= link.
         expect(href).not.toMatch(/\?q=/);
-        expect(href!.replace(/\/+$/, '')).not.toMatch(
-          /\/(cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)$/,
-        );
+        expect(href!.replace(/\/+$/, '')).not.toMatch(ROOT_RE);
+      });
+    }
+  }
+});
+
+// Nursing landings are profession landings too; same CTA, same fix
+// (reusing the pre-existing CTA_SECTOR map). `healthcare-ticino` is the
+// deliberate null/root case (its copy says "all openings").
+const NURSING_EXPECTED: Array<[string, string | null]> = [
+  ['nurses', 'infermieri'],
+  ['oss', 'case-anziani'],
+  ['healthcare-ticino', null],
+];
+
+describe('nursing landing "see all offers" CTA links to the sector hub', () => {
+  for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+    for (const [id, sector] of NURSING_EXPECTED) {
+      it(`${id} (${locale}) → ${sector ?? 'root'}`, async () => {
+        const mod: any = await import('../../build-plugins/nursingLandingsPlugin');
+        const html = mod.renderNursingFeaturedJobsForTest(id, locale, {
+          ...SNAPSHOT_BASE,
+          featured: [FIXTURE_JOB],
+        });
+        const href = ctaHrefOf(html);
+        expect(href, `no CTA anchor rendered for ${id}/${locale}`).toBeTruthy();
+        expect(href).not.toMatch(/\?q=/);
+        if (sector) {
+          expect(href).toBe(buildSectorHubPath(locale, sector as any));
+          expect(href!.replace(/\/+$/, '')).not.toMatch(ROOT_RE);
+        } else {
+          // null → unfiltered job-board root (deliberate).
+          expect(href!.replace(/\/+$/, '')).toMatch(ROOT_RE);
+        }
       });
     }
   }


### PR DESCRIPTION
## Implementato

- La CTA **"Vedi tutte le N offerte →"** di ogni profession landing (es. `/lavoro-ticino-autista/`) puntava al **job-board root generico** (`/cerca-lavoro-ticino/`), scaricando il visitatore su una ricerca non filtrata. Ora deep-linka all'**hub di settore** della professione (ricerca già filtrata):
  - `infermiere → /cerca-lavoro-ticino/infermieri/`
  - `operaio → /cerca-lavoro-ticino/industria/`
  - `impiegato → /cerca-lavoro-ticino/commercio/`
  - `ingegnere → /cerca-lavoro-ticino/ingegneri/`
  - `educatore → /cerca-lavoro-ticino/educatori/`
  - `autista → /cerca-lavoro-ticino/autisti/`
  - `muratore → /cerca-lavoro-ticino/edilizia/`
  - `cuoco → /cerca-lavoro-ticino/cuochi/`
  - `cameriere → /cerca-lavoro-ticino/camerieri/`
  - `elettricista → /cerca-lavoro-ticino/elettricisti/`
- Mapping `ProfessionId → SectorHubKey` (`PROFESSION_SECTOR_HUB`) + helper `buildProfessionAllJobsUrl()` in `build-plugins/professionLandingsPlugin.ts`; href costruito via `buildSectorHubPath()` esistente (riuso, no stringhe a mano → trailing-slash by-construction).
- **Bottom primary CTA** (`<a class="s-cta">${copy.ctaJobs}</a>`, "Vedi offerte in Ticino" / "See Ticino openings") fixato nello STESSO file (round-2 reviewer 🔴): puntava ancora a `jobBoardUrl` (root generico) mentre solo la CTA featured era stata corretta. Ora calcola `ctaJobsUrl = ${BASE_URL}${buildProfessionAllJobsUrl(id, locale)}` (stesso helper, fallback root incluso) e lo usa nell'anchor. Breadcrumb posizione 2 lasciato a root (parent corretto, come il sibling nursing).
- I target sono **PATH crawlable/indicizzati** (emessi incondizionatamente da `jobSectorPagesPlugin` per ogni `SECTOR_HUB_KEYS`, anche count 0) — **NON** URL `?q=` (robots-disallowed → no disallowed-outlink, no `rel="nofollow"`). Aggiornato il commento stale che giustificava il vecchio link-to-root.
- Professione senza settore mappato → fallback al root (qui nessuna: tutte e 10 mappate).
- Test nuovo `tests/build-plugins/profession-cta-sector-hub.test.ts`: asserisce href = sector hub atteso, mai root, mai `?q=`. Verde. Suite correlate verdi (`no-disallowed-q-sector-outlinks`, `no-internal-nofollow`).

- **Nursing landing CTA** (sibling segnalato dal reviewer): `nursingLandingsPlugin.ts` aveva lo stesso anti-pattern e i suoi hub erano già nella mappa `CTA_SECTOR` esistente → ora la CTA featured usa `buildSectorHubPath` (nurses → infermieri, oss → case-anziani; `healthcare-ticino` resta null/root deliberato). Test esteso ai casi nursing.

## Non implementato (ancora)

- **City landing CTA** (`costOfLivingLandingsPlugin.ts` / `cityJobsAggregate.ts` → `buildJobBoardUrl`): segnalati dal sibling-check perché condividono l'helper `buildJobBoardUrl`, ma sono **classe distinta** — filtro per *città* (`jobBoardCity`), non *professione→settore*. Richiedono una mappa città→hub separata e altro aggregate; **fuori dallo scope** segnalato (link sulle profession landing). Follow-up se desiderato.
- **Employer grid link** sulla stessa pagina (`renderEmployerGrid` → `buildJobBoardUrl`): link per-employer, concern diverso dalla CTA "tutte le offerte" — lasciato al root.
- **professionCantonLandings**: la sua CTA punta già a una landing stipendi (intent diverso), non al job board — non toccata.
- **Hub mappato vuoto a build-time** (reviewer adversarial q): non verificato che ogni hub di settore mappato contenga offerte della professione (es. `commercio` per `impiegato`); una CTA su hub a count 0 atterra su ricerca filtrata vuota (crawl-safe ma peggiore per conversione del root). Verifica post-deploy / follow-up se i counts lo richiedono.
