### PR TITLE
fix(seo): drop junk-keyword thin doorway landings from /ricerca/ hub

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -67,6 +67,7 @@ import {
   getSearchSlugPrefix,
   stripSearchQueryBoilerplate,
 } from '../services/relatedSearchClusters';
+import { isJunkSearchKeyword } from '../services/relatedSearchJunkTerms.mjs';
 import { stemSearchToken, stemHaystack } from '../services/searchStem.mjs';
 import {
   AGGREGATE_KEY,
@@ -942,6 +943,17 @@ export function buildClusterContext(
   // `candidate.slug` (already markdown-free), so canonical URLs are unaffected.
   const keyword = stripLiteralMarkdown(stripCityFromKeyword(sampleTerm, city));
   if (!keyword) {
+    profileRecord('bc:tokenize', __tTokenize);
+    return null;
+  }
+
+  // Drop junk keywords (generic filler / cross-language connectives / scraped
+  // UI noise like "cookie", "sowie", "pazienti") even when they survive in the
+  // already-committed candidates file. This guard runs at emit time, so it
+  // cleans the LIVE /…/ricerca/ hub + stops emitting the thin doorway landings
+  // (e.g. /…/ricerca-cookie-bern/) without waiting for the weekly audit regen.
+  // Net-reducing consolidation — a moratorium exception. See relatedSearchJunkTerms.mjs.
+  if (isJunkSearchKeyword(keyword)) {
     profileRecord('bc:tokenize', __tTokenize);
     return null;
   }

--- a/scripts/audit-related-search-candidates.mjs
+++ b/scripts/audit-related-search-candidates.mjs
@@ -33,6 +33,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { serializeCandidatesFile } from './lib/related-search-serialize.mjs';
+import { RELATED_SEARCH_JUNK_TERMS } from '../services/relatedSearchJunkTerms.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const JOBS_PATH = path.join(ROOT, 'data', 'jobs.json');
@@ -285,8 +286,11 @@ function buildRelatedSearches({ job, locale }) {
     .toLowerCase()
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '');
+  // Mirror of services/relatedSearchClusters.ts: drop the junk filler / DE
+  // connectives / scraped UI noise so future regens never re-seed thin doorway
+  // candidates (e.g. "cookie bern", "sowie basel"). See relatedSearchJunkTerms.mjs.
   const bodyTokens = extractRelatedTopicTokens(`${description} ${requirementsText}`, 6)
-    .filter((token) => token !== locationToken);
+    .filter((token) => token !== locationToken && !RELATED_SEARCH_JUNK_TERMS.has(token));
 
   const generated = locale === 'it'
     ? bodyTokens.map((token) => `${token} ${location || DEFAULT_CANTON_DISPLAY.toLowerCase()}`.trim())

--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -4,6 +4,9 @@
 
 import type { Locale } from '@/services/i18n';
 import type { JobListing } from '@/components/community/JobBoard';
+import { RELATED_SEARCH_JUNK_TERMS, isJunkSearchKeyword } from './relatedSearchJunkTerms.mjs';
+
+export { RELATED_SEARCH_JUNK_TERMS, isJunkSearchKeyword };
 
 export const DEFAULT_CANTON_DISPLAY = 'Ticino';
 
@@ -300,7 +303,10 @@ export function buildRelatedSearches(params: {
  .normalize('NFD')
  .replace(/[̀-ͯ]/g, '');
  const bodyTokens = extractRelatedTopicTokens(`${summary.join(' ')} ${requirements.join(' ')}`, 6)
- .filter((token) => token !== locationToken);
+ // Drop generic filler / cross-language connectives / scraped UI noise so the
+ // `${token} ${location}` candidates never become thin doorway landings
+ // (e.g. "cookie bern", "sowie basel"). See relatedSearchJunkTerms.mjs.
+ .filter((token) => token !== locationToken && !RELATED_SEARCH_JUNK_TERMS.has(token));
 
  const generated = locale === 'it'
  ? bodyTokens.map((token) => `${token} ${location || DEFAULT_CANTON_DISPLAY.toLowerCase()}`.trim())

--- a/services/relatedSearchJunkTerms.mjs
+++ b/services/relatedSearchJunkTerms.mjs
@@ -1,0 +1,103 @@
+/**
+ * Junk-term denylist for related-search cluster keywords.
+ *
+ * Single source of truth (rule #6: no copy-paste of a constant across files).
+ * Imported by:
+ *   - services/relatedSearchClusters.ts        (runtime SPA widget + future candidate gen)
+ *   - build-plugins/relatedSearchClustersPlugin.ts (emit-time guard — cleans the LIVE hub
+ *     + stops emitting thin doorway landings even from the already-committed,
+ *     stale data/related-search-candidates.json that predates this filter)
+ *   - scripts/audit-related-search-candidates.mjs (generation-time mirror)
+ *
+ * Plain .mjs so BOTH the .ts graph and the .mjs audit script can import the
+ * exact same set (mirrors the existing services/searchStem.mjs pattern).
+ *
+ * ── Why this exists ──────────────────────────────────────────────────────
+ * `extractRelatedTopicTokens` harvests the MOST FREQUENT body tokens of a job
+ * description. The most frequent tokens are inherently generic filler that
+ * appears in every posting regardless of role ("gestione", "sviluppo",
+ * "qualità", "professionale"), scraped UI noise ("cookie"), German connective
+ * nouns leaking from cross-language postings ("sowie", "patienten",
+ * "unterstützung"), and care-OBJECTS rather than job ROLES ("pazienti"). These
+ * produced thin, embarrassing doorway pages such as
+ *   /cerca-lavoro-svizzera/ricerca-cookie-bern/   → "<title>Cookie a Bern</title>"
+ * and polluted the /…/ricerca/ hub index with hundreds of meaningless links.
+ *
+ * ── What is NOT junk ─────────────────────────────────────────────────────
+ * Real job-search intents are deliberately KEPT even when generic: role nouns
+ * (ospedale, medico, medici, medicina, clinica, infermiere, assistenza,
+ * assistente, vendita, stage, manager, formazione, sicurezza, studenti) and
+ * multi-word terms (e.g. "data center technician", "senior associate") — a
+ * keyword is junk only when EVERY one of its tokens is junk/numeric.
+ *
+ * Tokens are compared lowercased + diacritic-stripped (NFD).
+ */
+
+export const RELATED_SEARCH_JUNK_TERMS = new Set([
+  // ── IT — abstract filler / connectives / HR boilerplate / meta ──
+  'pazienti', 'paziente',
+  'gestione', 'sviluppo', 'professionale', 'professionali',
+  'modo', 'compiti', 'mansioni', 'attivita', 'ambiente',
+  'ricerca', 'ricerche', // meta: a "ricerca-ricerca-x" page is nonsense
+  'qualita', 'dati', 'capacita', 'squadra', 'gruppo',
+  'sistemi', 'sistema', 'servizio', 'servizi',
+  'oltre', 'nell', 'nello', 'nella', 'lavorare',
+  'descrizione', 'conoscenza', 'conoscenze', 'vita', 'futuro',
+  'supporto', 'responsabilita', 'requisiti', 'requisito',
+  'progetti', 'progetto', 'posizione', 'posizioni',
+  'offriamo', 'dipendenti', 'competenze', 'competenza',
+  'settore', 'settori', 'soluzioni', 'soluzione',
+  'possibile', 'persone', 'persona', 'presente', 'inoltre',
+  'vuoi', 'presso', 'mediante', 'stipendio',
+  // ── DE — connective nouns / boilerplate leaking from cross-language ads ──
+  'sowie', 'patienten', 'patientinnen', 'patient',
+  'unterstutzung', 'aufgaben', 'bieten', 'mitarbeiter', 'mitarbeiterin',
+  'mitarbeitende', 'mitarbeitenden', 'bereich', 'rahmen', 'umfeld',
+  'kenntnisse', 'weiterbildung', 'entwicklung', 'qualitat',
+  'systeme', 'projekte', 'projekt', 'dienstleistungen',
+  'gruppe', 'abteilung',
+  // ── FR — abstract filler ──
+  'patients', 'competences', 'competence', 'connaissances', 'connaissance',
+  'missions', 'mission', 'domaine', 'domaines', 'taches', 'tache',
+  'developpement', 'gestion', 'qualite', 'systemes',
+  'projets', 'projet', 'environnement', 'profil', 'profils', 'equipe',
+  // ── EN — abstract filler (NOTE: 'data'/'center'/'technician'/'system(s)'
+  //         deliberately excluded — they form real multi-word role searches
+  //         like "data center technician" pinned by unit tests) ──
+  'responsibilities', 'responsibility', 'skills', 'ability', 'abilities',
+  'strong', 'working', 'knowledge', 'relevant', 'various',
+  'ensure', 'ensuring', 'providing', 'including',
+  'environment', 'development', 'management', 'quality',
+  'projects', 'tasks', 'employees', 'staff', 'requirements',
+  // ── Scraped web/UI noise ──
+  'cookie', 'cookies', 'javascript', 'browser', 'newsletter', 'website',
+]);
+
+/**
+ * Normalize a keyword to lowercased, diacritic-stripped, alnum-spaced tokens.
+ * @param {string} keyword
+ * @returns {string[]}
+ */
+function tokenizeKeyword(keyword) {
+  return String(keyword || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/**
+ * A keyword is junk when it has no meaningful token — i.e. EVERY token is a
+ * junk-denylist word or a pure number. Multi-word terms survive as long as at
+ * least one token carries real search intent (so "senior associate",
+ * "tecnico data center", "ospedale lugano" are all kept).
+ * @param {string} keyword
+ * @returns {boolean}
+ */
+export function isJunkSearchKeyword(keyword) {
+  const tokens = tokenizeKeyword(keyword);
+  if (tokens.length === 0) return true;
+  return tokens.every((t) => /^\d+$/.test(t) || RELATED_SEARCH_JUNK_TERMS.has(t));
+}

--- a/tests/related-search-clusters.test.ts
+++ b/tests/related-search-clusters.test.ts
@@ -28,6 +28,7 @@ import {
   pickBestRelatedSearchForPrompt,
   DEFAULT_CANTON_DISPLAY,
   stripSearchQueryBoilerplate,
+  isJunkSearchKeyword,
 } from '@/services/relatedSearchClusters';
 import { renderSearchQueryIntro } from '../build-plugins/shared/jobBoardCommuterContext';
 
@@ -238,6 +239,77 @@ describe('extractRelatedTopicTokens — stopword + length gate', () => {
     const tokens = extractRelatedTopicTokens('Café Café CAFÉ');
     expect(tokens).toContain('cafe');
     expect(tokens.length).toBe(1);
+  });
+});
+
+// ── isJunkSearchKeyword — thin-doorway keyword denylist ─────────────────
+
+describe('isJunkSearchKeyword — drops generic filler / noise, keeps real intents', () => {
+  it('flags single generic-filler / connective / scraped-noise keywords as junk', () => {
+    // These produced thin doorway landings like /…/ricerca-cookie-bern/.
+    for (const junk of ['cookie', 'sowie', 'pazienti', 'patienten', 'unterstutzung',
+      'gestione', 'sviluppo', 'professionale', 'qualita', 'oltre', 'nell', 'dati',
+      'requirements', 'responsibilities', 'skills']) {
+      expect(isJunkSearchKeyword(junk)).toBe(true);
+    }
+  });
+
+  it('treats case / diacritics / surrounding punctuation uniformly', () => {
+    expect(isJunkSearchKeyword('Cookie')).toBe(true);
+    expect(isJunkSearchKeyword('Qualità')).toBe(true);
+    expect(isJunkSearchKeyword('  Sowie  ')).toBe(true);
+  });
+
+  it('flags an all-junk multi-word keyword (e.g. boilerplate salary padding)', () => {
+    expect(isJunkSearchKeyword('stipendio')).toBe(true);
+  });
+
+  it('keeps real single-word job-search intents (role nouns)', () => {
+    for (const real of ['ospedale', 'medico', 'infermiere', 'vendita', 'stage',
+      'manager', 'formazione', 'assistenza', 'sicurezza', 'cuoco']) {
+      expect(isJunkSearchKeyword(real)).toBe(false);
+    }
+  });
+
+  it('keeps multi-word keywords when at least one token carries intent', () => {
+    // "data center technician", "senior associate" and role+city stay indexable
+    // even though some tokens are generic — only ALL-junk keywords are dropped.
+    expect(isJunkSearchKeyword('data center technician')).toBe(false);
+    expect(isJunkSearchKeyword('senior associate')).toBe(false);
+    expect(isJunkSearchKeyword('ospedale lugano')).toBe(false);
+  });
+
+  it('flags empty / whitespace-only / numeric-only as junk', () => {
+    expect(isJunkSearchKeyword('')).toBe(true);
+    expect(isJunkSearchKeyword('   ')).toBe(true);
+    expect(isJunkSearchKeyword('1234')).toBe(true);
+  });
+});
+
+describe('buildRelatedSearches — drops junk body tokens', () => {
+  function makeJunkJob(): JobListing {
+    return {
+      id: 'job-junk',
+      title: 'Software Engineer',
+      company: 'TechCo',
+      location: 'Bellinzona',
+    } as unknown as JobListing;
+  }
+
+  it('never emits a junk-token landing (cookie / sowie / pazienti)', () => {
+    const out = buildRelatedSearches({
+      job: makeJunkJob(),
+      locale: 'it',
+      summary: ['Cookie cookie cookie sowie sowie pazienti pazienti gestione gestione.'],
+      requirements: ['Cookie e gestione dei pazienti.'],
+      aiKeywords: [],
+    });
+    for (const term of out) {
+      const lower = term.toLowerCase();
+      expect(lower).not.toContain('cookie');
+      expect(lower).not.toContain('sowie');
+      expect(lower).not.toContain('pazienti');
+    }
   });
 });
 


### PR DESCRIPTION
## Implementato

La pagina hub `/cerca-lavoro-ticino/ricerca/` (e i suoi 80 page-N + i locali en/de/fr) indicizzava centinaia di "ricerche" prive di senso — filler generico (`gestione`, `qualità`, `sviluppo`, `professionale`), connettivi tedeschi che colano da annunci cross-lingua (`sowie`, `patienten`, `unterstützung`, `aufgaben`), rumore UI scrapato (`cookie` → `<title>Cookie a Bern</title>`) e oggetti-di-cura (`pazienti`). Ognuno generava un **thin doorway** indicizzato (`/cerca-lavoro-svizzera/ricerca-cookie-bern/`, ~110 parole, `index,follow`).

Root cause: `extractRelatedTopicTokens` raccoglie i token **più frequenti** del corpo annuncio → sono per costruzione filler generico.

- **Nuovo modulo condiviso `services/relatedSearchJunkTerms.mjs`** (unica fonte, rule #6): `RELATED_SEARCH_JUNK_TERMS` (131 termini IT/DE/FR/EN + web-noise) + `isJunkSearchKeyword()`. Plain `.mjs` così sia il grafo `.ts` sia l'audit `.mjs` importano lo stesso set (pattern `searchStem.mjs`).
- **`build-plugins/relatedSearchClustersPlugin.ts` (`buildClusterContext`)**: guard emit-time `isJunkSearchKeyword(keyword) → return null`. Pulisce l'hub LIVE **e** smette di emettere i doorway landing **anche dal `data/related-search-candidates.json` già committato e stale**, senza aspettare la regen settimanale dell'audit. Droppa landing + voce-hub + sitemap insieme (chokepoint unico).
- **`services/relatedSearchClusters.ts` (`buildRelatedSearches`)**: filtro junk sui `bodyTokens` → i chip related-search della SPA (via `buildRelatedSearches`, JobBoard.tsx:6738) e i candidati futuri non riseminano junk. Re-export di `isJunkSearchKeyword`/`RELATED_SEARCH_JUNK_TERMS`.
- **`scripts/audit-related-search-candidates.mjs`**: stesso filtro sui `bodyTokens` (mirror) → la prossima regen produce candidati puliti.
- **Precisione**: un keyword è junk **solo** se OGNI token è junk/numerico → restano le categorie reali (`ospedale`, `medico`, `infermiere`, `vendita`, `stage`, `manager`, `formazione`, `assistenza`, `sicurezza`) e i multi-word (`data center technician`, `senior associate`, `ospedale lugano`). `extractRelatedTopicTokens` lasciato intatto → i suoi unit test restano pinnati.
- **Test** (`tests/related-search-clusters.test.ts`): nuovi `describe` per `isJunkSearchKeyword` (junk vs intent reali, case/diacritici, multi-word, vuoto/numerico) + `buildRelatedSearches` non emette mai landing junk. Suite **83/83 verde**.

Net-reducing consolidation → **eccezione moratorium** (riduce thin pages indicizzate, non aggiunge surface).

### Verifica
- `npx vitest run tests/related-search-clusters.test.ts` → 83 passed.
- `npx esbuild build-plugins/relatedSearchClustersPlugin.ts --bundle` → import risolti (value-import RELATIVO `./relatedSearchJunkTerms.mjs`, non `@/`, perché il file è nel grafo `vite.config`).
- `node --check` audit OK; modulo junk: 131 termini, `Cookie`→junk, `Ospedale`/`data center technician`→kept.

## Non implementato (ancora)

- **Rigenerazione di `data/related-search-candidates.json`** (47MB, 203k entry): non rigenerato qui (richiede il dataset jobs completo + gira in CI settimanale). Non serve per pulire il LIVE — il guard emit-time del plugin filtra i candidati stale al prossimo build/deploy. Il filtro in `audit` + `services` garantisce che la prossima regen sia pulita by-construction.
- **Template-leak multi-word stale ("stipendio … svizzera", "… reboot monkey")**: già risolti a monte (N4 source-fix per i template; company-suffix) ma persistono nel file candidati stale; sono **multi-word con un token reale** → non catturati dal junk-filter single-token (by-design, per non droppare ruoli legittimi). Si autopuliscono alla prossima regen audit.
- **Sibling `check-sibling-patterns` (8 flag euristici)**: tutti verificati non-class — `profileRecord`/`searchStem`/`locationToken` sono costrutti diversi; `components/community/JobBoard.tsx` usa `RELATED_SEARCH_STOPWORDS` (L2962) solo per il *location-discount* dello scoring OR-fallback (classe diversa, non doorway-gen) e i suoi chip related-search passano già da `buildRelatedSearches` → **coperti** da questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)