### PR TITLE
fix(ai-models): GitHub models stay eligible for PAT rotation despite persisted exhaustion

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1700,9 +1700,25 @@ export function markModelExhausted(modelId) {
   console.warn(`🚫 Model ${modelId} marked as exhausted — will be skipped for rest of run`);
 }
 
+// Whether the chain runner should SKIP a model because it's exhausted.
+// For GitHub models this is NOT just `_exhaustedModels.has(model)`: a persisted
+// daily-limit was recorded against ONE GitHub account, but with multiple PATs a
+// different account's fresh quota can still serve the model. So while any PAT is
+// un-exhausted this run, GitHub models stay eligible — `_callGitHub` rotates to
+// the fresh account. Without this, a model marked exhausted by account #1
+// earlier today would be skipped on every later run, never reaching rotation.
+function _shouldSkipExhausted(model) {
+  if (!_exhaustedModels.has(model)) return false;
+  if (getProvider(model) === PROVIDER.GITHUB) {
+    const pats = getGhModelsPats();
+    if (pats.length > 1 && pats.some((_, i) => !_ghExhaustedPats.has(i))) return false;
+  }
+  return true;
+}
+
 /** Check whether a model is still usable this run */
 export function isModelAvailable(modelId) {
-  if (_exhaustedModels.has(modelId)) return false;
+  if (_shouldSkipExhausted(modelId)) return false;
   // Check that we have the API key for the model's provider
   return !!getApiKeyForProvider(getProvider(modelId));
 }
@@ -2672,7 +2688,7 @@ export async function callSingleModel(messages, opts = {}) {
   const o = { ...DEFAULT_OPTS, ...opts };
   const model = o.model || AI_MODELS.GPT4O;
 
-  if (_exhaustedModels.has(model)) {
+  if (_shouldSkipExhausted(model)) {
     throw new Error(`[${model}] Model is exhausted for this run`);
   }
 
@@ -2747,7 +2763,7 @@ export async function callLLM(messages, opts = {}) {
     // to avoid log floods like "[mistral/nemo] Skipped — exhausted" repeated
     // 300+ times in a single run (one per fallback attempt × per fact-check
     // retry × per generation retry).
-    if (_exhaustedModels.has(model)) {
+    if (_shouldSkipExhausted(model)) {
       if (!_exhaustedLogged.has(model)) {
         console.warn(`⏭️  [${model}] Skipped — exhausted (daily limit, future hits silenced)`);
         _exhaustedLogged.add(model);

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -853,6 +853,9 @@ const _exhaustedModels = new Set();
 // subsequent GitHub calls skip them and go straight to a fresh account's PAT.
 // Reset per run (resetState) — daily limits reset on the provider side anyway.
 const _ghExhaustedPats = new Set();
+// modelId → reason it was exhausted ('quota' | 'timeout' | 'content' | 'stale' |
+// 'nonretryable'). Gates the GitHub multi-PAT skip-exemption (quota only).
+const _exhaustReason = new Map();
 // Tracks which exhausted models have already been logged this run, so a model
 // that's been exhausted since startup doesn't produce a "Skipped — exhausted"
 // line every time the fallback chain ticks past it.
@@ -1340,7 +1343,7 @@ export async function _discoverProvider(cfg) {
     for (const model of DEFAULT_CHAIN) {
       if (!model.startsWith(cfg.prefix)) continue;
       if (!offeredIds.has(model.slice(prefixLen))) {
-        markModelExhausted(model);
+        markModelExhausted(model, 'stale');
         stale++;
       }
     }
@@ -1476,6 +1479,9 @@ export async function initScoreStore() {
           : new Date(data.exhaustedUntil); // ISO string fallback
         if (resetTime > now) {
           _exhaustedModels.add(modelId);
+          // Persisted exhaustedUntil is the daily-limit (quota) path → eligible
+          // for the GitHub multi-PAT skip-exemption.
+          _exhaustReason.set(modelId, 'quota');
           exhaustedRestored++;
           console.warn(`🚫 [ScoreStore] ${modelId} still exhausted until ${resetTime.toISOString().slice(0, 16)}`);
         }
@@ -1638,7 +1644,7 @@ export function recordModelContentFailure(modelId) {
   const count = (_consecutiveContentFailures.get(modelId) || 0) + 1;
   _consecutiveContentFailures.set(modelId, count);
   if (count >= MAX_CONSECUTIVE_CONTENT_FAILURES) {
-    markModelExhausted(modelId);
+    markModelExhausted(modelId, 'content');
     _stats.exhausted++;
     console.warn(`🚫 [${modelId}] Exhausted after ${count} consecutive content-quality failures`);
   }
@@ -1693,11 +1699,18 @@ function sortChainByScore(chain) {
  * It will be skipped for the remainder of this process
  * and persisted to Firestore so other workflows also skip it.
  */
-export function markModelExhausted(modelId) {
+// `reason` records WHY a model was exhausted so the GitHub multi-PAT exemption
+// only resurrects quota/daily-limit exhaustion (account-specific → rotation to a
+// fresh PAT can fix it), NOT timeout / content-failure / stale / non-retryable
+// exhaustion (account-independent → rotation cannot help, and re-trying would
+// neutralise those circuit-breakers). Default 'quota' covers the daily-limit and
+// rate-limit paths; the non-quota breakers pass an explicit reason.
+export function markModelExhausted(modelId, reason = 'quota') {
   _exhaustedModels.add(modelId);
+  _exhaustReason.set(modelId, reason);
   _dirtyModels.add(modelId);
   _schedulePersist();
-  console.warn(`🚫 Model ${modelId} marked as exhausted — will be skipped for rest of run`);
+  console.warn(`🚫 Model ${modelId} marked as exhausted (${reason}) — will be skipped for rest of run`);
 }
 
 // Whether the chain runner should SKIP a model because it's exhausted.
@@ -1709,7 +1722,11 @@ export function markModelExhausted(modelId) {
 // earlier today would be skipped on every later run, never reaching rotation.
 function _shouldSkipExhausted(model) {
   if (!_exhaustedModels.has(model)) return false;
-  if (getProvider(model) === PROVIDER.GITHUB) {
+  // Only QUOTA/daily-limit exhaustion is account-specific and thus fixable by
+  // rotating to a fresh PAT. Timeout / content-failure / stale / non-retryable
+  // exhaustion would recur on every account, so those keep skipping (otherwise
+  // the circuit-breaker is neutralised and full timeouts re-incur per attempt).
+  if (getProvider(model) === PROVIDER.GITHUB && _exhaustReason.get(model) === 'quota') {
     const pats = getGhModelsPats();
     if (pats.length > 1 && pats.some((_, i) => !_ghExhaustedPats.has(i))) return false;
   }
@@ -1772,6 +1789,7 @@ export function printRunSummary() {
 export function resetState() {
   _exhaustedModels.clear();
   _ghExhaustedPats.clear();
+  _exhaustReason.clear();
   _exhaustedLogged.clear();
   _providerCooldown.clear();
   _modelScores.clear();
@@ -2180,7 +2198,7 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
         const nrc = classifyNonRetryableError(res.status, raw);
         if (nrc.nonRetryable) {
           if (nrc.markExhausted) {
-            markModelExhausted(modelForTracking);
+            markModelExhausted(modelForTracking, 'nonretryable');
             _stats.exhausted++;
           }
           const err = new Error(`[${displayModel}] HTTP ${res.status}: ${raw.slice(0, 300)}`);
@@ -2867,7 +2885,7 @@ export async function callLLM(messages, opts = {}) {
       // exhausted so subsequent callLLM invocations skip it entirely.
       const isTimeoutFailure = e.name === 'AbortError' || e.name === 'TimeoutError' || /timeout|aborted/i.test(msg);
       if (isTimeoutFailure) {
-        markModelExhausted(model);
+        markModelExhausted(model, 'timeout');
         _stats.exhausted++;
       }
       recordModelFailure(model, {

--- a/tests/scripts/ai-models-github-multi-pat.test.ts
+++ b/tests/scripts/ai-models-github-multi-pat.test.ts
@@ -11,7 +11,7 @@ const aiModels = (await import('../../scripts/lib/ai-models.mjs')) as unknown as
   callLLM: (messages: unknown, opts?: Record<string, unknown>) => Promise<string>;
   getGhModelsPats: () => string[];
   resetState: () => void;
-  markModelExhausted: (m: string) => void;
+  markModelExhausted: (m: string, reason?: string) => void;
   isModelAvailable: (m: string) => boolean;
   AI_MODELS: Record<string, string>;
 };
@@ -118,8 +118,22 @@ describe('GitHub Models PAT rotation', () => {
     // remain available so rotation to the fresh account can happen.
     process.env.GH_MODELS_PAT = 'pat1';
     process.env.GH_MODELS_PAT_2 = 'pat2';
-    markModelExhausted(AI_MODELS.GPT4O);
+    markModelExhausted(AI_MODELS.GPT4O, 'quota');
     expect(isModelAvailable(AI_MODELS.GPT4O)).toBe(true); // exempt: pat2 still fresh
+  });
+
+  it('does NOT resurrect a GitHub model exhausted for timeout/content (rotation cannot fix)', () => {
+    process.env.GH_MODELS_PAT = 'pat1';
+    process.env.GH_MODELS_PAT_2 = 'pat2';
+    // Timeout/content-failure are account-independent → must keep skipping even
+    // with fresh PATs, or the circuit-breaker is neutralised.
+    markModelExhausted(AI_MODELS.GPT4O, 'timeout');
+    expect(isModelAvailable(AI_MODELS.GPT4O)).toBe(false);
+    resetState();
+    process.env.GH_MODELS_PAT = 'pat1';
+    process.env.GH_MODELS_PAT_2 = 'pat2';
+    markModelExhausted(AI_MODELS.GPT4O, 'content');
+    expect(isModelAvailable(AI_MODELS.GPT4O)).toBe(false);
   });
 
   it('single PAT: an exhausted GitHub model is NOT resurrected', () => {

--- a/tests/scripts/ai-models-github-multi-pat.test.ts
+++ b/tests/scripts/ai-models-github-multi-pat.test.ts
@@ -11,9 +11,11 @@ const aiModels = (await import('../../scripts/lib/ai-models.mjs')) as unknown as
   callLLM: (messages: unknown, opts?: Record<string, unknown>) => Promise<string>;
   getGhModelsPats: () => string[];
   resetState: () => void;
+  markModelExhausted: (m: string) => void;
+  isModelAvailable: (m: string) => boolean;
   AI_MODELS: Record<string, string>;
 };
-const { callLLM, getGhModelsPats, resetState, AI_MODELS } = aiModels;
+const { callLLM, getGhModelsPats, resetState, markModelExhausted, isModelAvailable, AI_MODELS } = aiModels;
 
 const PAT_ENV = ['GH_MODELS_PAT', 'GH_MODELS_PAT_2', 'GH_MODELS_PAT_3'] as const;
 let saved: Record<string, string | undefined>;
@@ -107,6 +109,23 @@ describe('GitHub Models PAT rotation', () => {
     });
     expect(pat2Body).not.toBeNull();
     expect((pat2Body as Record<string, { type?: string }>)?.response_format?.type).toBe('json_schema');
+  });
+
+  it('a GitHub model marked exhausted stays eligible while another PAT is fresh', () => {
+    // The real-world gap (run 27974308840): gpt-4o was marked exhausted (persisted
+    // from account #1's daily limit) and SKIPPED on every later run, so _callGitHub
+    // — and thus PAT rotation — was never reached. With ≥2 PATs the model must
+    // remain available so rotation to the fresh account can happen.
+    process.env.GH_MODELS_PAT = 'pat1';
+    process.env.GH_MODELS_PAT_2 = 'pat2';
+    markModelExhausted(AI_MODELS.GPT4O);
+    expect(isModelAvailable(AI_MODELS.GPT4O)).toBe(true); // exempt: pat2 still fresh
+  });
+
+  it('single PAT: an exhausted GitHub model is NOT resurrected', () => {
+    process.env.GH_MODELS_PAT = 'solo';
+    markModelExhausted(AI_MODELS.GPT4O);
+    expect(isModelAvailable(AI_MODELS.GPT4O)).toBe(false);
   });
 
   it('single PAT: a daily limit is NOT swallowed (no phantom rotation)', async () => {


### PR DESCRIPTION
## Implementato

Follow-up a #2697 (multi-PAT GitHub) — fix di un gap scoperto **live** che impediva alla rotazione di attivarsi.

- **Causa**: la rotazione multi-PAT vive dentro `_callGitHub`, ma il chain runner **salta** un modello PRIMA di chiamarlo quando `_exhaustedModels.has(model)`. Quel set è idratato da Firestore (`exhaustedUntil` = prossima mezzanotte). Quindi un modello GitHub marcato esausto dall'account #1 a inizio giornata veniva saltato su OGNI run successivo → `_callGitHub` mai raggiunto → rotazione mai attivata.
- **Osservato** (run `27974308840`, dopo aver caricato `GH_MODELS_PAT_2/3` in RC): i PAT extra caricati correttamente, ma `gpt-4o`/`gpt-4.1` loggavano `⏭️ Skipped — exhausted` → la quota fresca dei nuovi account non veniva mai usata.
- **Fix**: `_shouldSkipExhausted(model)` — per i modelli GitHub ritorna `false` finché **almeno un PAT è ancora non-esausto** in questo run, così il modello resta eleggibile e `_callGitHub` ruota all'account fresco. Applicato ai 3 punti di skip (`isModelAvailable`, `callSingleModel`, chain runner). Modelli non-GitHub e setup mono-PAT invariati.
- 2 nuovi test (esenzione con 2 PAT / nessuna resurrezione con 1 PAT); suite ai-models verde.

## Non implementato (ancora)

- **Esaurimento per-(modello,PAT)**: il tracking resta per-modello globale + `_ghExhaustedPats` per-PAT-per-run. Sufficiente per il caso reale (quota account separata); un tracking persistito per-account sarebbe più preciso ma molto più invasivo → follow-up se necessario.
- **Validazione live**: osservabile al prossimo run che carica RC (con i 3 PAT). Revert: rimuovi i `GH_MODELS_PAT_2/3` da RC → torna mono-PAT.

## Test plan

- [x] `npx vitest run tests/scripts/ai-models-github-multi-pat.test.ts …` → 12 passati (locale): esenzione skip multi-PAT, no-resurrezione mono-PAT, rotazione, schema-mode, parsing.
- [ ] Post-merge: un run `generate-article.yml` con account #1 esausto deve mostrare `🔁 [GitHub] PAT #1 esaurito — ruoto al PAT #2` e generare con la quota fresca, invece di `Skipped — exhausted`.