### PR TITLE
fix(crawler): drop off-domain social cards in Klinik Gut listing parser (#2680)

### DIFF
--- a/scripts/lib/klinik-gut-job-parser.mjs
+++ b/scripts/lib/klinik-gut-job-parser.mjs
@@ -176,6 +176,13 @@ export function parseKlinikGutListing(html = '') {
 
     const detailUrl = new URL(rawHref, ORIGIN).toString();
     if (RESTRICTED_PATHS.has(new URL(detailUrl).pathname)) continue;
+    // Skip cards linking off the klinik-gut.ch domain — e.g. the "Social Media"
+    // / "Folgen Sie uns" card whose `infobox__more` href is the Instagram profile
+    // (https://www.instagram.com/klinikgut/). Those are not job openings; left in,
+    // they'd be crawled as a job with an off-domain URL and fail strict
+    // localization validation (url_not_klinik-gut_domain + untranslated teaser,
+    // since the social detail fetch 429s), failing the whole crawl. #2680
+    if (!isTrustedDomain(detailUrl)) continue;
 
     const id = pathSlug(detailUrl);
     if (!id || seen.has(id)) continue;

--- a/tests/klinik-gut-crawler.test.ts
+++ b/tests/klinik-gut-crawler.test.ts
@@ -113,6 +113,25 @@ describe('Klinik Gut crawler parser', () => {
       );
     });
 
+    it('drops a card linking off-domain to a social profile (#2680 Instagram)', () => {
+      const html = `<ul>
+    <li class="rz-infobox__item">
+      <h3>Social Media</h3>
+      <div class="infobox__text">Folgen Sie uns auf Instagram</div>
+      <a href="https://www.instagram.com/klinikgut/" class="infobox__more btn btn-primary">Mehr Informationen</a>
+    </li>
+    <li class="rz-infobox__item">
+      <h3>Dipl. Pflegefachperson HF</h3>
+      <div class="infobox__text">Pflege in St. Moritz</div>
+      <a href="https://www.klinik-gut.ch/de/dipl-pflegefachperson-hf" class="infobox__more btn btn-primary">Mehr Informationen</a>
+    </li>
+  </ul>`;
+      const rows = parseKlinikGutListing(html);
+      // The Instagram "Social Media" card is filtered; only the real opening remains.
+      expect(rows.map((r) => r.id)).toEqual(['dipl-pflegefachperson-hf']);
+      expect(rows.every((r) => r.detailUrl.includes('klinik-gut.ch'))).toBe(true);
+    });
+
     it('uses the stable path slug as canonical id', () => {
       const rows = parseKlinikGutListing(LISTING_HTML);
       expect(rows[0].id).toBe('wahlstudienjahr-praktisches-jahr');


### PR DESCRIPTION
## Implementato
- In `parseKlinikGutListing` (`scripts/lib/klinik-gut-job-parser.mjs`): dopo aver risolto il `detailUrl`, skippa i card il cui URL non è su `klinik-gut.ch` usando l'helper esistente `isTrustedDomain(detailUrl)`.
- Test `tests/klinik-gut-crawler.test.ts` (17/17 verdi): nuovo caso che verifica che un card "Social Media → instagram.com/klinikgut" sia filtrato e resti solo l'opening reale.

### Perché
Il crawler falliva 3 run consecutivi su `Klinik Gut AG localization validation failed (4 issues)`, tutti sullo pseudo-job `social-media-klinik-gut-st-moritz`: `url_not_klinik-gut_domain [all]` + `untranslated_description [it/en/fr]`. La pagina careers ha un card "Social Media / Folgen Sie uns" il cui link `infobox__more` è il profilo Instagram; il parser lo estraeva come job, e l'URL off-domain + il teaser non-fetchabile (Instagram 429) facevano fallire la validazione localization e l'intero crawl.

## Non implementato (ancora)
- **Sibling-class**: il gate condiviso `url_not_<company>_domain` in `dedicated-crawler-common.mjs` resta la rete di sicurezza per tutti gli altri crawler (fallirebbe rumorosamente sullo stesso sintomo). Il card Instagram è specifico del layout della pagina Klinik Gut, non un costrutto condiviso → nessun twin da sweepare (confermato da `check-sibling-patterns`).
- Il crawler gira contro sito WAF-protected (Chromium); validato via unit-test del parser, non end-to-end live (verifica live al prossimo run schedulato post-merge).

Closes #2680