### PR TITLE
fix(deploy-publish): re-upload Pages artifact at level 9, not store (6.5 GB→816 MB)

### DIFF
--- a/.github/workflows/deploy-publish.yml
+++ b/.github/workflows/deploy-publish.yml
@@ -92,8 +92,9 @@ jobs:
           fi
 
       # Cross-run handoff of the Pages artifact. The `github-pages` artifact (a
-      # single ~720 MB gzip tarball, `artifact.tar`) was uploaded by the BUILD
-      # run. actions/deploy-pages can only publish an artifact that lives in the
+      # single ~816 MB zip envelope over an uncompressed `artifact.tar`) was
+      # uploaded by the BUILD run.
+      # actions/deploy-pages can only publish an artifact that lives in the
       # CURRENT run (Pages binds the deployment to the run via OIDC), so download
       # the build's artifact and re-upload it here under the same name. This is a
       # download+upload of one tarball, not a rebuild.
@@ -112,10 +113,16 @@ jobs:
           path: pages-artifact/artifact.tar
           retention-days: 1
           if-no-files-found: error
-          # Already a gzip tarball — storing (level 0) avoids a pointless
-          # re-deflate of incompressible data. deploy-pages extracts the zip
-          # envelope and hands artifact.tar to the Pages backend regardless.
-          compression-level: 0
+          # artifact.tar is an UNCOMPRESSED tar (deploy-it-pages-prep.sh packs it
+          # with `tar -cf`, no -z) — all the size reduction comes from the zip
+          # envelope upload-artifact wraps it in. The build run uploads at
+          # compression-level 9 (816 MB envelope over a ~6.5 GB tar). Re-upload at
+          # the SAME level here: a previous `compression-level: 0` stored the tar
+          # raw → the github-pages artifact ballooned 816 MB → 6.5 GB, an 8× blob
+          # for deploy-pages to push to the Pages backend (slower, hits the 10-min
+          # cap, wastes storage). Served content is identical either way — Pages
+          # extracts the tar — so the only effect of level 0 was the bloat.
+          compression-level: 9
 
       # Reset a stuck Pages `errored` state BEFORE publishing. After bursts of
       # failed/cancelled deployments GitHub Pages can latch into status=errored


### PR DESCRIPTION
## Implementato

Il github-pages artifact è esploso da **816 MB a 6.5 GB** quando il deploy è passato da build+deploy aggregati a build→publish separati (#2692).

**Root cause.** Lo split ri-materializza l'artifact `github-pages` del build run dentro il publish run prima di `actions/deploy-pages` (che può pubblicare solo un artifact che vive nel run corrente). Quel re-upload usava `compression-level: 0` sull'assunzione **sbagliata** che `artifact.tar` fosse "already a gzip tarball".

Non lo è: `scripts/lib/deploy-it-pages-prep.sh` lo impacchetta con `tar -cf` (**no `-z`**) → tar **non compresso** (~6.5 GB). Tutta la riduzione di dimensione viene dalla zip envelope che `upload-artifact` ci avvolge attorno. Il build run uploada a **level 9** → envelope 816 MB; il publish run a **level 0 (store)** lo ri-espandeva ai 6.5 GB pieni.

**Evidenza (i run del goal):**
- build run `27969171901` → `github-pages` = **816 MB**
- publish run `27971887599` → `github-pages` ri-uploadato = **6527 MB** (8×)

Il contenuto servito è identico (Pages estrae il tar comunque): l'unico effetto del level 0 era il bloat — upload 8× più lento verso il backend Pages, più probabile sfondare il cap di polling 10-min, e spreco di storage Actions.

**Fix:** `compression-level: 0` → `9` nel re-upload, per pareggiare il build. Corretti anche i due commenti che descrivevano `artifact.tar` come gzip tarball.

## Non implementato (ancora)

- Estrazione della costante `compression-level: 9` in un punto condiviso tra `deploy.yml` (build upload) e `deploy-publish.yml` (re-upload): i due valori devono restare allineati ma sono in workflow diversi; un drift futuro è possibile. Posposto (out of scope: nessun meccanismo YAML per condividere un literal tra workflow senza un layer di templating che il repo non usa). I due punti sono ora ancorati a vicenda dai commenti.
- Non verificabile pre-merge: la dimensione effettiva dell'artifact del prossimo publish run è osservabile solo post-merge sul prossimo deploy `main`. Revert-trigger: se il prossimo publish run mostra ancora `github-pages` ≫ ~1 GB → rivedere il packing del tar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)