### PR TITLE
fix(resilience): recover lazy service-chunk imports from stale-deploy version skew

### DIFF
--- a/components/calculator/ConsultingCTA.tsx
+++ b/components/calculator/ConsultingCTA.tsx
@@ -19,6 +19,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Headphones, ArrowRight } from 'lucide-react';
 import { useTranslation } from '@/services/i18n';
+import { resilientImport } from '@/services/resilientImport';
 import { Analytics } from '@/services/analytics';
 import { useNavigationOptional } from '@/services/NavigationContext';
 
@@ -55,7 +56,7 @@ export const ConsultingCTA: React.FC<Props> = ({ enabledOverride }) => {
  let cancelled = false;
  (async () => {
  try {
- const { getConfigValue } = await import('@/services/firebase');
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  const raw = await getConfigValue(FLAG_KEY);
  if (cancelled) return;
  setEnabled(parseBooleanFlag(raw));

--- a/components/calculator/ResultsView.tsx
+++ b/components/calculator/ResultsView.tsx
@@ -3,6 +3,7 @@ import { ScrollText, Trophy, Armchair, Info, PartyPopper, Calculator, ChevronRig
 // jsPDF and autoTable are lazy-imported inside exportPDF() — only needed on user click (~134KB gzip saved from critical path)
 import { SimulationResult, TaxResult, TaxBreakdownItem, SimulationInputs } from '../../types';
 import { lazyRetry } from '@/services/lazyRetry';
+import { resilientImport } from '@/services/resilientImport';
 import DataFreshness from '@/components/shared/DataFreshness';
 import { AD_SLOTS } from '@/services/adsenseSlots';
 // ComparisonChart is lazy-loaded to avoid pulling vendor-charts (~114KB gzip) into the critical path
@@ -243,7 +244,7 @@ const ResultsViewBase: React.FC<Props> = ({ result, inputs, focusArea = null, on
  let cancelled = false;
  (async () => {
  try {
- const { getConfigValue } = await import('@/services/firebase');
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  const val = await getConfigValue('ENABLE_CALCULATOR_PAYWALL');
  if (!cancelled) setPaywallEnabled(val === 'true');
  } catch { /* RC unavailable — feature stays off */ }

--- a/components/community/JobAlertSection.tsx
+++ b/components/community/JobAlertSection.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useEffect, useState } from 'react';
 import { lazyRetry } from '@/services/lazyRetry';
+import { resilientImport } from '@/services/resilientImport';
 import { useAuth } from '@/services/authService';
 
 const JobAlertForm = lazyRetry(() => import('@/components/community/JobAlertForm'));
@@ -14,7 +15,7 @@ export default function JobAlertSection({ initialKeyword = '', onRequireAuth }: 
  const [enabled, setEnabled] = useState<boolean | null>(null);
 
  useEffect(() => {
- import('@/services/firebase')
+ resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function')
  .then(({ getConfigValue }) => getConfigValue('ENABLE_JOB_ALERTS'))
  .then((v) => setEnabled(v === 'true'))
  .catch(() => setEnabled(false));

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, Suspense } from 'react';
 import { lazyRetry } from '@/services/lazyRetry';
+import { resilientImport } from '@/services/resilientImport';
 import { cdnDataUrl } from '@/services/cdnDataBase';
 import { cdnImageUrl } from '@/services/cdnImageBase';
 import { requestJobAlertOpen } from '@/services/jobAlertOpenSignal';
@@ -1892,7 +1893,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // FRO-353: Feature flag for Job Alerts (controlled via Firebase Remote Config)
  const [enableJobAlerts, setEnableJobAlerts] = useState(false);
  useEffect(() => {
- import('@/services/firebase').then(({ getConfigValue }) =>
+ resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function').then(({ getConfigValue }) =>
  getConfigValue('ENABLE_JOB_ALERTS').then((v) => setEnableJobAlerts(v === 'true'))
  ).catch(() => {});
  }, []);

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -21,6 +21,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { resilientImport } from '@/services/resilientImport';
 
 export type KillSwitchKey =
   | 'fuelDaily'
@@ -78,7 +79,7 @@ export function useKillSwitches(): KillSwitchState {
 
     (async () => {
       try {
-        const { getConfigValue } = await import('@/services/firebase');
+        const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
         const entries = await Promise.all(
           (Object.keys(KILL_SWITCH_RC_KEYS) as KillSwitchKey[]).map(async (key) => {
             try {

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -13,46 +13,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { hasActiveSlot } from '@/services/popupQueue';
 import { reportCaughtError } from '@/services/errorReporter';
 import { isNewsletterAutologinInFlight, parseNewsletterAutologin } from '@/services/newsletterAutologinSignal';
-
-// ─── Resilient Dynamic Import ────────────────────────────────
-// After a deploy, old chunk hashes no longer exist on the CDN.
-// When the user clicks a button that triggers a dynamic import (e.g.
-// LinkedIn sign-in → import firebase), the import fails with
-// "TypeError: Importing a module script failed".
-// This helper clears caches and retries once before giving up.
-
-function isChunkLoadError(err: unknown): boolean {
- const msg = (err as Error)?.message || '';
- return msg.includes('Importing a module script failed') ||
- msg.includes('Failed to fetch dynamically imported module') ||
- msg.includes('error loading dynamically imported module') ||
- (err as Error)?.name === 'ChunkLoadError';
-}
-
-async function resilientImport<T>(factory: () => Promise<T>): Promise<T> {
- try {
- return await factory();
- } catch (err) {
- if (!isChunkLoadError(err)) throw err;
- // Clear all caches so the browser fetches fresh chunks
- if ('caches' in window) {
- const names = await caches.keys();
- await Promise.all(names.map(n => caches.delete(n)));
- }
- // Retry once after cache clear
- try {
- return await factory();
- } catch {
- // Chunk truly gone — reload page to get fresh HTML with new hashes
- const reloadKey = '_authChunkReload';
- if (!sessionStorage.getItem(reloadKey)) {
- sessionStorage.setItem(reloadKey, '1');
- window.location.reload();
- }
- throw err;
- }
- }
-}
+import { resilientImport } from '@/services/resilientImport';
 
 // ─── Lazy Firebase Auth Loading ────────────────────────────────
 
@@ -115,8 +76,8 @@ async function ensureFirebaseAuth(): Promise<void> {
  try {
  logAuthDebug('ensureFirebaseAuth:start');
  const [firebaseModule, authModule] = await Promise.all([
- import('@/services/firebase'),
- import('firebase/auth'),
+ resilientImport(() => import('@/services/firebase'), (m) => typeof m.getApp === 'function'),
+ resilientImport(() => import('firebase/auth'), (m) => typeof m.getAuth === 'function'),
  ]);
  _authModule = authModule;
  const appInstance = await firebaseModule.getApp();
@@ -171,8 +132,8 @@ export async function saveUserProfileToFirestore(user: any, provider: 'google' |
  if (!email) return;
 
  const [{ getApp }, fsModule] = await Promise.all([
- import('@/services/firebase'),
- import('firebase/firestore'),
+ resilientImport(() => import('@/services/firebase'), (m) => typeof m.getApp === 'function'),
+ resilientImport(() => import('firebase/firestore'), (m) => typeof m.getFirestore === 'function'),
  ]);
 
  const db = fsModule.getFirestore(await getApp());
@@ -869,7 +830,7 @@ const LINKEDIN_CF_BASE = 'https://europe-west6-frontaliere-ticino.cloudfunctions
  */
 export async function isLinkedInSignInAvailable(): Promise<boolean> {
  try {
- const { getConfigValue } = await import('@/services/firebase');
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  const clientId = await getConfigValue('LINKEDIN_SIGNIN_CLIENT_ID');
  return Boolean(clientId && clientId.trim().length > 0);
  } catch {
@@ -914,7 +875,7 @@ export function consumeAuthJobContext(): AuthJobContext | null {
  */
 export async function signInWithLinkedIn(redirectPath?: string): Promise<void> {
  try {
- const { getConfigValue } = await resilientImport(() => import('@/services/firebase'));
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  const { Analytics } = await resilientImport(() => import('@/services/analytics'));
 
  const clientId = await getConfigValue('LINKEDIN_SIGNIN_CLIENT_ID');
@@ -1309,7 +1270,7 @@ export async function initOneTap(): Promise<boolean> {
  try {
  // Get client ID from Remote Config
  if (!clientId) {
- const { getConfigValue } = await import('@/services/firebase');
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  clientId = await getConfigValue('GOOGLE_OAUTH_CLIENT_ID');
  if (!clientId) {
  console.warn('⚠️ GOOGLE_OAUTH_CLIENT_ID not found in Remote Config');
@@ -1373,9 +1334,9 @@ async function persistOneTapSubscriber(user: { email?: string | null; displayNam
  if (typeof window !== 'undefined' && window.localStorage?.getItem('newsletter_subscribed') === 'true') return;
  try {
  const [{ getFirestore }, { getApp }, newsletterModule] = await Promise.all([
- import('firebase/firestore'),
- import('@/services/firebase'),
- import('@/services/newsletterSubscribers'),
+ resilientImport(() => import('firebase/firestore'), (m) => typeof m.getFirestore === 'function'),
+ resilientImport(() => import('@/services/firebase'), (m) => typeof m.getApp === 'function'),
+ resilientImport(() => import('@/services/newsletterSubscribers'), (m) => typeof m.normalizeNewsletterEmail === 'function'),
  ]);
  const db = getFirestore(await getApp());
  const normalizedEmail = newsletterModule.normalizeNewsletterEmail(rawEmail);

--- a/services/clarity.ts
+++ b/services/clarity.ts
@@ -13,6 +13,7 @@
 
 import { isAnalyticsGranted } from '@/services/consentService';
 import { reportCaughtError } from '@/services/errorReporter';
+import { resilientImport } from '@/services/resilientImport';
 
 let _initialized = false;
 
@@ -36,7 +37,7 @@ export async function initClarity(): Promise<void> {
  }
 
  try {
- const { getConfigValue } = await import('@/services/firebase');
+ const { getConfigValue } = await resilientImport(() => import('@/services/firebase'), (m) => typeof m.getConfigValue === 'function');
  const projectId = await getConfigValue('CLARITY_PROJECT_ID');
 
  if (!projectId) {
@@ -56,7 +57,8 @@ export async function initClarity(): Promise<void> {
  t.crossOrigin = 'anonymous';
  t.src = 'https://www.clarity.ms/tag/' + i;
  const s = l.getElementsByTagName(r)[0];
- s.parentNode?.insertBefore(t, s);
+ if (s && s.parentNode) s.parentNode.insertBefore(t, s);
+ else (l.head || l.documentElement).appendChild(t);
  })(window, document, 'clarity', 'script', projectId);
 
  if (import.meta.env.DEV) {

--- a/services/resilientImport.ts
+++ b/services/resilientImport.ts
@@ -1,0 +1,96 @@
+/**
+ * Resilient dynamic import for lazily-loaded service chunks.
+ *
+ * Chunk filenames are STABLE (non-hashed) on this site (see vite.config rollup
+ * output). After a deploy, two distinct stale-deploy failure modes can hit a
+ * client still running the previous build:
+ *
+ *  1. import() REJECTS with "Failed to fetch dynamically imported module" —
+ *     the chunk URL 404s because the CDN replaced/purged the old file.
+ *
+ *  2. import() RESOLVES but the returned module's named exports are undefined —
+ *     the CDN/Cloudflare SPA fallback served index.html (HTTP 200) for the
+ *     missing .js, so import() parses an HTML document as an (empty) module.
+ *     Downstream code then throws on a MINIFIED name, e.g.
+ *     "n.getApp is not a function", "n is not a function",
+ *     "Ze is not a constructor", "[clarity.init] e is not a function".
+ *
+ * Both are the same root cause (stale build vs. current CDN assets). This helper
+ * clears caches, retries once, and finally reloads the page to fetch fresh HTML
+ * that references the current chunk URLs. A single sessionStorage key guards
+ * against reload loops across every caller.
+ */
+
+export function isChunkLoadError(err: unknown): boolean {
+  const msg = (err as Error)?.message || '';
+  return (
+    msg.includes('Importing a module script failed') ||
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('error loading dynamically imported module') ||
+    (err as Error)?.name === 'ChunkLoadError'
+  );
+}
+
+// Shared across all callers so a stale deploy triggers at most one reload per
+// session, no matter which service chunk was the first to fail.
+const RELOAD_KEY = '_serviceChunkReload';
+
+/**
+ * Load a dynamically-imported module, recovering from stale-deploy failures.
+ *
+ * @param factory  the `() => import(...)` thunk.
+ * @param validate optional guard run against the resolved module. Return
+ *                 `false` when an expected export is missing (mode 2 above):
+ *                 the module is then treated as a stale chunk and retried with
+ *                 the same cache-clear → reload path as an outright fetch error.
+ */
+export async function resilientImport<T>(
+  factory: () => Promise<T>,
+  validate?: (mod: T) => boolean,
+): Promise<T> {
+  const attempt = async (): Promise<T> => {
+    const mod = await factory();
+    if (validate && !validate(mod)) {
+      // Resolved, but missing expected exports — SPA-fallback HTML served for a
+      // purged chunk. Surface it as a chunk-load error so the recovery path runs.
+      const stale = new Error(
+        'Failed to fetch dynamically imported module (stale chunk: expected exports missing)',
+      );
+      stale.name = 'ChunkLoadError';
+      throw stale;
+    }
+    return mod;
+  };
+
+  try {
+    return await attempt();
+  } catch (err) {
+    if (!isChunkLoadError(err)) throw err;
+    // Clear all caches so the browser refetches fresh chunks.
+    if (typeof window !== 'undefined' && 'caches' in window) {
+      try {
+        const names = await caches.keys();
+        await Promise.all(names.map((n) => caches.delete(n)));
+      } catch {
+        /* cache eviction is best-effort */
+      }
+    }
+    // Retry once after cache clear.
+    try {
+      return await attempt();
+    } catch (err2) {
+      // Chunk truly gone — reload to get fresh HTML with current chunk URLs.
+      if (typeof window !== 'undefined') {
+        try {
+          if (!sessionStorage.getItem(RELOAD_KEY)) {
+            sessionStorage.setItem(RELOAD_KEY, '1');
+            window.location.reload();
+          }
+        } catch {
+          /* sessionStorage unavailable (private mode) — skip reload guard */
+        }
+      }
+      throw err2;
+    }
+  }
+}

--- a/tests/resilient-import.test.ts
+++ b/tests/resilient-import.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resilientImport, isChunkLoadError } from '@/services/resilientImport';
+
+/**
+ * resilientImport recovers from two stale-deploy failure modes:
+ *  1. import() rejects with a chunk-load error (purged chunk → 404).
+ *  2. import() resolves but the module is missing expected exports (version
+ *     skew: stable-named chunks where a cached entry pulls a fresh chunk whose
+ *     export shape differs → "n.getApp is not a function" on a minified name).
+ * Both clear caches, retry once, then reload (guarded to once per session).
+ */
+describe('resilientImport', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    // Fresh caches mock per test.
+    (globalThis as any).caches = {
+      keys: vi.fn().mockResolvedValue(['c1', 'c2']),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+  });
+
+  it('returns the module on first success', async () => {
+    const mod = { getApp: () => 'app' };
+    const factory = vi.fn().mockResolvedValue(mod);
+    const result = await resilientImport(factory);
+    expect(result).toBe(mod);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a valid module through when validate() is satisfied', async () => {
+    const mod = { getConfigValue: () => 'v' };
+    const result = await resilientImport(
+      () => Promise.resolve(mod),
+      (m) => typeof m.getConfigValue === 'function',
+    );
+    expect(result).toBe(mod);
+  });
+
+  it('retries once after clearing caches when validate() fails, then recovers', async () => {
+    const good = { getApp: () => 'app' };
+    // First call resolves a stale (export-less) module; retry resolves a good one.
+    const factory = vi
+      .fn()
+      .mockResolvedValueOnce({} as { getApp?: () => string })
+      .mockResolvedValueOnce(good);
+
+    const result = await resilientImport(factory, (m) => typeof m.getApp === 'function');
+
+    expect(result).toBe(good);
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect((globalThis as any).caches.delete).toHaveBeenCalledTimes(2); // c1 + c2
+  });
+
+  it('reloads at most once per session when the chunk is truly gone', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reload },
+    });
+
+    const chunkErr = Object.assign(new Error('Failed to fetch dynamically imported module'), {
+      name: 'ChunkLoadError',
+    });
+    const factory = vi.fn().mockRejectedValue(chunkErr);
+
+    await expect(resilientImport(factory)).rejects.toThrow();
+    expect(factory).toHaveBeenCalledTimes(2); // initial + one retry
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem('_serviceChunkReload')).toBe('1');
+
+    // A subsequent failure must NOT reload again (guard holds across callers).
+    reload.mockClear();
+    await expect(resilientImport(factory)).rejects.toThrow();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not swallow non-chunk errors', async () => {
+    const factory = vi.fn().mockRejectedValue(new TypeError('genuine bug'));
+    await expect(resilientImport(factory)).rejects.toThrow('genuine bug');
+    expect(factory).toHaveBeenCalledTimes(1); // no retry for unrelated errors
+  });
+
+  it('isChunkLoadError recognises the stale-deploy signatures', () => {
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module'))).toBe(true);
+    expect(isChunkLoadError(new Error('Importing a module script failed'))).toBe(true);
+    expect(isChunkLoadError(Object.assign(new Error('x'), { name: 'ChunkLoadError' }))).toBe(true);
+    expect(isChunkLoadError(new Error('something else'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Fix per la classe di errori JS #2 + parte di #4 emersa dall'analisi PostHog (14gg): `import()` di chunk servizio che, dopo un deploy, risolve ma con export `undefined` per **version-skew** (filename chunk STABILI non-hashed + cache HTTP → client mischia entry cached + chunk firebase fresco), causando crash su nomi minificati:
- `[auth.loadFirebaseAuth] n.getApp is not a function` (198 utenti)
- `[auth.initOneTap] n is not a function` (135)
- `[auth.loadFirebaseAuth] Ze is not a constructor` (100)
- `[clarity.init] e is not a function` (115)

Modifiche:
- **Nuovo modulo condiviso `services/resilientImport.ts`**: estrae l'helper `resilientImport`/`isChunkLoadError` finora locale ad authService (de-duplica per evitare drift, AGENTS.md #6) e aggiunge un parametro `validate(mod)`: se il modulo risolve ma manca l'export atteso (caso version-skew), lo tratta come chunk stale → svuota le caches, ritenta una volta, ricarica la pagina **max una volta per sessione** (chiave `sessionStorage` condivisa fra tutti i caller → niente reload-loop).
- **`services/authService.ts`**: rimossa la copia locale, ora importa dal modulo condiviso. Wrappati con `validate` tutti i dynamic import firebase/auth/firestore che chiamano un export: `ensureFirebaseAuth` (getApp/getAuth), `saveUserProfileToFirestore`, `initOneTap` (getConfigValue), `persistOneTapSubscriber`.
- **`services/clarity.ts`**: wrappato l'import firebase (`getConfigValue`) + hardening dell'injection dello script (fallback a `document.head` se non esiste alcun `<script>`).
- **Sibling-class fix nella stessa PR** (i `getConfigValue` dinamici funnel-critical, dal `check-sibling-patterns.mjs`): `components/calculator/ResultsView.tsx`, `components/calculator/ConsultingCTA.tsx`, `hooks/useKillSwitches.ts`, `components/community/JobBoard.tsx`, `components/community/JobAlertSection.tsx` (questi ultimi due leggono `ENABLE_JOB_ALERTS` → un fallimento faceva apparire i job-alert disabilitati).
- **`tests/resilient-import.test.ts`**: 6 test (success, validate-pass, retry-after-validate-fail, reload-once-per-sessione, no-swallow di errori non-chunk, firme `isChunkLoadError`). Verdi in locale.

Verificato: `tsc --noEmit` senza nuovi errori nei file toccati; vitest del nuovo file 6/6 verde.

## Non implementato (ancora)

- **Restanti `import('@/services/firebase')` non wrappati** (`check-sibling-patterns` ne segnala altri): `components/pages/ApiStatus.tsx` usa import **statico** (non soggetto al fallimento del chunk dinamico) ed è una pagina admin a basso traffico → fuori dalla classe a rischio; `exchangeRateService`/`statsService`/`fuelPricesService`/`behaviorTracker`/`jobViewsService`/`firestoreService`/`SubscriptionPreferencesController`/`SalarySurvey` ecc. condividono il pattern ma **non compaiono nei top-error PostHog** (gated da azione-utente specifica, frequenza bassa) → deferiti per non fare un sweep drive-by di ~30 file in una sola PR; follow-up consigliato per migrarli progressivamente o introdurre una lint-rule.
- I match `TypeError`/`parentNode`/`insertBefore`/`ChunkLoadError` del sibling-check su `build-plugins/*`, `scripts/*`, `ErrorBoundary`/`ChunkLoadErrorBoundary`/`posthog-error-filter` sono **falsi positivi** (costrutti generici, non lo stesso antipattern di stale-import).
- **Fix sistemico version-skew (filename chunk content-hashed)**: la causa radice è l'uso di filename stabili in vite.config; passare a hash farebbe 404-pulito → reject già gestito, ma è un cambio build rischioso e fuori scope qui (deciso a monte per evitare cache-churn).
- `[firebase.initRemoteConfig] Failed to fetch` (66 utenti): già gestito (try/catch + default locali) → rumore di rete, non un bug.