### PR TITLE
feat(ads): instrument GPT rail slots + extend AdSense fill timeout to 12s

### DIFF
--- a/components/shared/AdSenseBanner.tsx
+++ b/components/shared/AdSenseBanner.tsx
@@ -374,13 +374,16 @@ export default function AdSenseBanner({
  // AdSense before it can report unfilled, leaving a 400px reservation
  // on every blocked slot for 90s. Multiple slots × 400px = 800-1200px
  // of visible dead-space below the fold on every page load (S7).
- // 8s is plenty for genuine fills (real fills land <2s in practice).
+ // Most genuine fills land <2s, but Privacy Sandbox / Attestation auctions
+ // can legitimately settle slower; an 8s cutoff false-collapsed late fills
+ // and logged them as ad_collapsed, depressing the measured fill-rate. 12s
+ // keeps the dead-space short while giving slow auctions room to fill.
  fillTimeoutRef.current = setTimeout(() => {
  const status = el.getAttribute('data-ad-status');
  if (status === 'filled') return;
  cleanupAsyncWatchers();
  collapseWhenLayoutSafe(`fill timeout (status=${status})`);
- }, 8_000);
+ }, 12_000);
 
  return true;
  };

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { trackAdEvent } from '@/services/adAnalytics';
 import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
 import { isLikelyBot } from '@/services/adAnalytics';
 
@@ -117,6 +118,7 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   // (remove the global pubads listener and destroy the slot).
   const slotRef = useRef<any>(null);
   const slotHandlerRef = useRef<((event: any) => void) | null>(null);
+  const viewableHandlerRef = useRef<((event: any) => void) | null>(null);
   // Stable, unique DOM id for this slot instance (GPT needs a real element id).
   const divIdRef = useRef<string>(`gpt-slot-${++slotSeq}`);
   const [rendered, setRendered] = useState(false);
@@ -166,10 +168,31 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
           // Held in a ref so unmount can remove it — otherwise every slot leaks
           // a global pubads listener that re-fires for every other slot.
           const handler = (event: any) => {
-            if (event?.slot === slot) setEmpty(!!event.isEmpty);
+            if (event?.slot !== slot) return;
+            const isEmpty = !!event.isEmpty;
+            setEmpty(isEmpty);
+            // Telemetry so the blended PostHog fill-rate is interpretable: GAM
+            // side-rail no-fills were previously invisible (CSS-hidden, no event),
+            // which dragged the blended ad_filled/ad_collapsed ratio down and made
+            // a stable real fill-rate look like a crash. Tagged network:'gpt'.
+            trackAdEvent(isEmpty ? 'ad_collapsed' : 'ad_filled', {
+              slot: adUnitPath,
+              format: 'gpt',
+              network: 'gpt',
+              ...(isEmpty ? { reason: 'gpt_no_fill' } : {}),
+            });
           };
           slotHandlerRef.current = handler;
           gt.pubads().addEventListener('slotRenderEnded', handler);
+          // Viewability is the real RPM driver (AdSense ACTIVE_VIEW_VIEWABILITY
+          // fell ~0.46→0.33 while fill stayed stable). Emit ad_viewable per slot
+          // so the SPA can track per-page viewability of the rail units.
+          const viewableHandler = (event: any) => {
+            if (event?.slot !== slot) return;
+            trackAdEvent('ad_viewable', { slot: adUnitPath, format: 'gpt', network: 'gpt' });
+          };
+          viewableHandlerRef.current = viewableHandler;
+          gt.pubads().addEventListener('impressionViewable', viewableHandler);
           gt.display(divId);
           setRendered(true);
         } catch {
@@ -200,6 +223,10 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
         if (slotHandlerRef.current) {
           gt.pubads().removeEventListener('slotRenderEnded', slotHandlerRef.current);
           slotHandlerRef.current = null;
+        }
+        if (viewableHandlerRef.current) {
+          gt.pubads().removeEventListener('impressionViewable', viewableHandlerRef.current);
+          viewableHandlerRef.current = null;
         }
         if (slotRef.current) {
           gt.destroySlots?.([slotRef.current]);

--- a/services/adAnalytics.ts
+++ b/services/adAnalytics.ts
@@ -27,7 +27,13 @@ import { captureEvent as posthogCapture } from './posthog';
 // historical `@/services/adAnalytics` import path used by <AdSenseBanner> + tests.
 export { isLikelyBot } from './botPatterns';
 
-export type AdEvent = 'ad_request' | 'ad_filled' | 'ad_unfilled' | 'ad_collapsed' | 'ad_bot_skip';
+export type AdEvent =
+  | 'ad_request'
+  | 'ad_filled'
+  | 'ad_unfilled'
+  | 'ad_collapsed'
+  | 'ad_bot_skip'
+  | 'ad_viewable';
 
 export interface AdEventProps {
   slot: string;
@@ -35,6 +41,14 @@ export interface AdEventProps {
   page_path?: string;
   page_template?: string;
   reason?: string;
+  /**
+   * Ad network that produced the event. Defaults to 'adsense' when omitted so
+   * historical AdSense events keep their meaning; GPT/GAM slots pass 'gpt' so
+   * fill-rate and viewability can be segmented per network (the un-tagged GPT
+   * no-fills were what made the blended PostHog fill-rate look like a crash —
+   * GAM side-rail no-fills were invisible in the metric).
+   */
+  network?: 'adsense' | 'gpt';
 }
 
 function getPagePath(): string {
@@ -69,6 +83,7 @@ export function trackAdEvent(event: AdEvent, props: AdEventProps): void {
       ad_format: props.format,
       page_path: path,
       page_template: props.page_template ?? classifyTemplate(path),
+      network: props.network ?? 'adsense',
       ...(props.reason ? { reason: props.reason } : {}),
     };
     posthogCapture(event, payload);


### PR DESCRIPTION
## Implementato

Fix del rilevatore #1 (calo fill-rate ads). **Verifica AdSense Management API** (6 settimane, dim WEEK): il fill-rate REALE (`AD_REQUESTS_COVERAGE`) è rimasto **stabile ~0.51–0.64** — il "crollo 67%→42%" visto in PostHog era in gran parte un **artefatto di misura**: gli slot GAM laterali (rail, aggiunti 16–18 giu) si nascondono in CSS sul no-fill **senza emettere telemetria**, quindi i loro no-fill erano invisibili mentre quelli AdSense contavano → il ratio *blended* `ad_filled/ad_collapsed` scendeva.

La stessa query AdSense ha rivelato il **vero driver del RPM**: `ACTIVE_VIEW_VIEWABILITY` scesa **~0.46→0.33** a fill costante (RPM 4.46→2.82 sulla settimana del 14 giu). È la viewability, non il fill, a muovere il revenue.

Modifiche:
- **`services/adAnalytics.ts`**: nuovo evento `ad_viewable` + prop opzionale `network` (`'adsense'` default | `'gpt'`), inclusa nel payload di ogni evento ad → fill-rate e viewability segmentabili per network.
- **`components/shared/GptAdSlot.tsx`**: emette `ad_filled`/`ad_collapsed` (`network:'gpt'`) su `slotRenderEnded` e `ad_viewable` su `impressionViewable`, con teardown dei listener → la metrica blended diventa interpretabile e la viewability dei rail diventa osservabile.
- **`components/shared/AdSenseBanner.tsx`**: fill timeout 8s→12s, così le aste Privacy-Sandbox lente non vengono false-collassate (e mis-loggate come `ad_collapsed`).

Verificato: `tsc --noEmit` nessun errore nei file toccati; `tests/adsense-lazy-load.test.ts` 15/15 verde. Nessun altro componente GPT da strumentare (GptAdSlot è l'unico sito `slotRenderEnded`/`googletag.display`).

## Non implementato (ancora)

- **Width-timeout (safety layout) lasciato a 8s** di proposito: protegge il CLS (collassa slot la cui larghezza non si materializza), non la latenza di fill → allungarlo ritarderebbe il collasso di slot genuinamente rotti e peggiorerebbe il CLS.
- **Recupero della viewability** (il vero driver RPM): non incluso qui — è un intervento separato su posizionamento/CLS dei rail (già in parte affrontato dai fix CLS recenti #2629/#2649/#2663/#2690). Questa PR rende la viewability *misurabile* per-slot; l'ottimizzazione del placement è follow-up una volta raccolti i dati `ad_viewable`.
- **Claim revenue non validabile pre-merge**: l'effetto del timeout 12s sul ratio collapse/fill e l'effetto viewability si osservano solo live post-deploy su PostHog. Revert-trigger: se il prossimo deploy mostra CLS in regressione o aumento di dead-space ad → revert del timeout a 8s. Nessun cambio al serving né ad Auto Ads.