### PR TITLE
fix(deploy): stop dist-history commit step wedging on rebase conflict (union JSONL + abort retry)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Append-only JSONL history logs. Concurrent producers on `main` (deploy
+# shards + crons) only ever append rows, so a line-union merge is always the
+# correct resolution. Without this, a rebase against a remote that gained new
+# rows hand-conflicts, the deploy retry loop is left mid-rebase, and every
+# retry then dies on "Pulling is not possible because you have unmerged files"
+# until the job is canceled (run 27976954013: dist-size-history.jsonl conflict
+# wedged the IT deploy shard). `merge=union` keeps both sides' new lines so the
+# conflict cannot occur by construction.
+data/dist-size-history.jsonl       merge=union
+data/quality-alerts-history.jsonl  merge=union
+data/quota-history.jsonl           merge=union
+data/thin-page-promotions.jsonl    merge=union

--- a/.github/workflows/batch-faq-articles.yml
+++ b/.github/workflows/batch-faq-articles.yml
@@ -121,7 +121,9 @@ jobs:
               exit 0
             fi
             echo "⚠️  Push attempt $attempt failed — rebasing..."
-            git pull --rebase origin main || true
+            # Abort a conflicting rebase so the next attempt starts clean
+            # instead of wedging on "unmerged files".
+            git pull --rebase origin main || { git rebase --abort 2>/dev/null || true; }
             sleep 3
           done
           echo "❌ Push failed after 3 attempts"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -563,12 +563,22 @@ jobs:
           # regularly out-race a 3×5 s window. The extended budget hits
           # a ~95 s total wait before giving up, which empirically
           # covers every observed conflict cluster on the main branch.
+          # A `pull --rebase` that hits a conflict (concurrent producer added
+          # rows to data/dist-size-history.jsonl / url-first-seen.json) leaves
+          # the tree mid-rebase. Without aborting, every later attempt dies on
+          # "Pulling is not possible because you have unmerged files" and the
+          # loop wedges until the job is canceled (run 27976954013). The
+          # merge=union .gitattributes resolves the JSONL append cleanly, and
+          # the abort below recovers from any residual conflict so each retry
+          # starts from a clean tree. `--abort` is a safe no-op when no rebase
+          # is in progress (e.g. a push-rejected race).
           for i in 1 2 3 4 5; do
             if git -c rebase.autoStash=true pull --rebase origin main \
                 && git push origin HEAD:main; then
               echo "[dist-history] pushed on attempt $i"
               exit 0
             fi
+            git rebase --abort 2>/dev/null || true
             case "$i" in
               1) sleep 5 ;;
               2) sleep 10 ;;

--- a/.github/workflows/funnel-metrics-snapshot.yml
+++ b/.github/workflows/funnel-metrics-snapshot.yml
@@ -97,8 +97,11 @@ jobs:
             git config user.email "valerielinc@gmail.com"
             git add data/funnel-metrics-history.json
             git commit -m "📊 Funnel metrics snapshot $(date -u +%Y-%m-%d)"
+            # Abort any conflicting rebase before retrying, otherwise the loop
+            # wedges on "unmerged files" until the job is canceled.
             for i in 1 2 3; do
               git pull --rebase origin main && git push && { echo "pushed=true" >> "$GITHUB_OUTPUT"; exit 0; }
+              git rebase --abort 2>/dev/null || true
               sleep $((i * 5))
             done
             echo "::warning::Failed to push funnel-metrics history after 3 attempts"

--- a/.github/workflows/revenue-monitor.yml
+++ b/.github/workflows/revenue-monitor.yml
@@ -70,8 +70,12 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add reports/revenue-*.md reports/revenue-*.json 2>/dev/null || true
             git commit -m "📊 Weekly revenue monitor report" || exit 0
+            # Abort any conflicting rebase before retrying, otherwise the loop
+            # wedges on "unmerged files" until the job is canceled.
             for i in 1 2 3; do
-              git pull --rebase origin main && git push && exit 0 || sleep $((i * 5))
+              git pull --rebase origin main && git push && exit 0
+              git rebase --abort 2>/dev/null || true
+              sleep $((i * 5))
             done
             echo "::warning::Failed to push revenue report after 3 attempts"
           else


### PR DESCRIPTION
## Implementato

Root-causes the canceled IT deploy shard in run [27976954013](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/27976954013/job/82799395156).

**Failure chain:** the `Commit dist-size-history row + url-first-seen updates` step committed the dist-history row, then `git -c rebase.autoStash=true pull --rebase origin main` hit a **merge conflict in `data/dist-size-history.jsonl`** (a concurrent producer had appended rows to `main`). The rebase stopped mid-way; the retry loop **never aborted** it, so attempts 2-5 all died instantly on `Pulling is not possible because you have unmerged files`. The step hung until the job was **canceled** → red shard. (`continue-on-error: true` does not catch a *canceled* step, only a *failed* one.)

Two-layer fix:

- **`.gitattributes` (new): `merge=union` for the 4 append-only JSONL history logs** — `data/dist-size-history.jsonl`, `data/quality-alerts-history.jsonl`, `data/quota-history.jsonl`, `data/thin-page-promotions.jsonl`. All verified pure-append (`appendFileSync`, one row/run; the `HISTORY_CAP` in `tune-discovery-quota.mjs` caps a *separate* state object, not the jsonl). Union merge keeps both sides' appended lines → concurrent-append conflicts cannot occur by construction. Proven locally: a rebase of `+r4` (local) onto `+r3` (remote) over a shared base now resolves clean (`r1,r2,r3,r4`) instead of conflicting.
- **`git rebase --abort` recovery in the 4 retry loops that lacked it** — `deploy.yml`, `revenue-monitor.yml`, `funnel-metrics-snapshot.yml`, `batch-faq-articles.yml`. So a conflict on a non-JSONL file (e.g. `data/url-first-seen.json`, a JSON object that can't union-merge) aborts and retries from a clean tree instead of wedging the loop until the job is canceled. `--abort` is a safe no-op when no rebase is in progress (push-rejected race).

Behavior preserved: same files committed, same retry counts/backoff, same warnings. No deploy output bytes change (`.gitattributes` only affects git's merge resolution; the deploy build doesn't read it).

## Non implementato (ancora)

- **`build-evidence-and-tune.yml` / `quality-alerts.yml` retry loops** — sibling data-commit loops, but they **already** call `git rebase --abort || true` on conflict, so they are not part of the wedge class; left untouched.
- **`scripts/lib/git-commit-data.sh`** — already a robust 3-way-merge + abort helper; the deploy step deliberately does not route through it (it would pull in crawler-file commit logic + trigger unrelated deploy paths). Out of scope.
- **`scripts/batch-add-faq-to-articles.mjs` / `scripts/backfill-ai-search-optimization.mjs`** — single `execSync('git pull --rebase ...')` calls, not retry loops; lower wedge risk and a different (Node, not workflow-bash) surface. Deferred — not implicated in this failure.
- Live confirmation that the next IT deploy commits the dist-history row cleanly happens **post-merge on `main`** (the conflict only reproduces under concurrent producers on `main`, not on a PR). Revert trigger: if a future deploy still wedges this step → revisit.