### PR TITLE
feat(outreach): fill Insights Aziende contacts — bridge discovered emails into Firestore

### DIFF
--- a/.github/workflows/employer-contacts-refresh.yml
+++ b/.github/workflows/employer-contacts-refresh.yml
@@ -1,0 +1,69 @@
+name: Refresh Employer Outreach Contacts
+
+# Weekly: discover an HR/contact email per company in the admin "Insights
+# Aziende" dashboard and upsert it to Firestore `employer_contacts/{companyKey}`,
+# so the contact column fills in (and the cold-email sender has a recipient).
+# Best-effort, open-data only (jobs.json own-domain + registry + web search →
+# scrape contact/impressum/careers pages). Idempotent: only fills the still-empty
+# ones, never clobbers an admin-edited address. Zero-Claude (deterministic).
+
+on:
+  schedule:
+    - cron: '30 4 * * 1'  # weekly, Monday 04:30 UTC (after the daily traffic refresh)
+  workflow_dispatch:
+    inputs:
+      min_views:
+        description: 'Only enrich companies with at least this many dashboard views'
+        required: false
+        default: '5'
+      limit:
+        description: 'Cap the number of companies processed (0 = no cap)'
+        required: false
+        default: '0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: employer-contacts-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ FIREBASE_SERVICE_ACCOUNT_JSON not set — aborting"; exit 1
+          fi
+
+      - name: Assemble jobs dataset (own-domain source)
+        run: node scripts/assemble-jobs-dataset.mjs --stats || true
+
+      - name: Discover + upsert employer contacts (Firestore)
+        run: |
+          node scripts/sync-employer-contacts-to-firestore.mjs \
+            --apply \
+            --min-views "${{ github.event.inputs.min_views || '5' }}" \
+            --limit "${{ github.event.inputs.limit || '0' }}"

--- a/scripts/build-employer-insights.mjs
+++ b/scripts/build-employer-insights.mjs
@@ -26,6 +26,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getFirestoreDb } from './lib/firestore-admin.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const argv = process.argv.slice(2);
@@ -199,12 +200,8 @@ async function main() {
 
   if (!APPLY) { console.log('\n(dry-run — pass --apply to write Firestore employer_insights/*)'); return; }
 
-  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  if (!credPath || !fs.existsSync(credPath)) throw new Error('GOOGLE_APPLICATION_CREDENTIALS required for --apply');
-  const { initializeApp, cert, getApps } = await import('firebase-admin/app');
-  const { getFirestore, FieldValue } = await import('firebase-admin/firestore');
-  if (getApps().length === 0) initializeApp({ credential: cert(JSON.parse(fs.readFileSync(credPath, 'utf8'))) });
-  const db = getFirestore();
+  const { FieldValue } = await import('firebase-admin/firestore');
+  const db = await getFirestoreDb();
   let written = 0;
   for (let i = 0; i < docs.length; i += 400) {
     const batch = db.batch();

--- a/scripts/enrich-employer-contacts.mjs
+++ b/scripts/enrich-employer-contacts.mjs
@@ -22,11 +22,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import dns from 'node:dns/promises';
 import { fileURLToPath } from 'node:url';
 import { classifySector, slugify } from './lib/employer-sectors.mjs';
-import { apexDomain, extractCompanyEmails, pickBestEmail, inferPatternEmail } from './lib/email-finder.mjs';
-import { extractDdgDomains, guessDomains, rankDomains } from './lib/domain-finder.mjs';
+import { apexDomain, pickBestEmail, inferPatternEmail } from './lib/email-finder.mjs';
+import { ATS_DOMAINS, mxOk, findDomain, scrapeCompanyEmails } from './lib/email-enrichment.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
@@ -36,76 +35,6 @@ function arg(name, def) {
   if (i < 0) return def;
   const n = process.argv[i + 1];
   return n && !n.startsWith('--') ? n : true;
-}
-
-// Third-party ATS / job-board domains: a careers/website URL pointing here is
-// NOT the employer's own domain, so its apex would be wrong (e.g. emailing
-// ncoreplat.com). Skip email-scraping when the resolved apex is one of these.
-const ATS_DOMAINS = new Set([
-  'lever.co', 'greenhouse.io', 'myworkdayjobs.com', 'workday.com', 'smartrecruiters.com',
-  'personio.de', 'personio.com', 'recruitee.com', 'ncoreplat.com', 'ostendis.com',
-  'refline.ch', 'prospective.ch', 'jobs.ch', 'jobscout24.ch', 'indeed.com',
-  'jobcloud.ch', 'softgarden.io', 'teamtailor.com', 'workable.com', 'bamboohr.com',
-  'orior.ch', 'oraclecloud.com', 'taleo.net', 'successfactors.com', 'eu.greenhouse.io',
-]);
-
-async function fetchText(url, timeoutMs = 8000) {
-  try {
-    const ctrl = new AbortController();
-    const t = setTimeout(() => ctrl.abort(), timeoutMs);
-    const r = await fetch(url, { signal: ctrl.signal, redirect: 'follow', headers: { 'User-Agent': 'Mozilla/5.0 (compatible; frontaliereticino-enrichment/1.0)' } });
-    clearTimeout(t);
-    if (!r.ok) return '';
-    return (await r.text()).slice(0, 500_000);
-  } catch { return ''; }
-}
-
-async function mxOk(domain) {
-  try { const mx = await dns.resolveMx(domain); return Array.isArray(mx) && mx.length > 0; } catch { return false; }
-}
-
-// Find the employer's own domain when the registry lacks it: web search +
-// heuristic guesses, validated by MX + a name-token match (rejects directories).
-let _lastDdg = 0;
-async function findDomain(name) {
-  const wait = 2500 - (Date.now() - _lastDdg); // space DDG calls (avoid throttling)
-  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
-  _lastDdg = Date.now();
-  let candidates = [];
-  try {
-    const ctrl = new AbortController();
-    const t = setTimeout(() => ctrl.abort(), 9000);
-    const r = await fetch('https://html.duckduckgo.com/html/?q=' + encodeURIComponent(name + ' sito ufficiale'),
-      { signal: ctrl.signal, headers: { 'User-Agent': 'Mozilla/5.0', 'Accept-Language': 'it' } });
-    clearTimeout(t);
-    if (r.ok) candidates = extractDdgDomains(await r.text());
-  } catch { /* search unavailable → fall back to guesses */ }
-  candidates.push(...guessDomains(name));
-  const valid = [];
-  for (const d of [...new Set(candidates)]) { if (!ATS_DOMAINS.has(d) && await mxOk(d)) valid.push(d); if (valid.length >= 6) break; }
-  return rankDomains(valid, name)[0] || '';
-}
-
-/**
- * Deep-scrape the employer's OWN domain (contact/impressum/careers pages) and
- * return the on-domain emails found (third-party noise dropped by the domain
- * filter in email-finder). Returns [] for unknown/ATS domains.
- */
-async function scrapeCompanyEmails(domain) {
-  if (!domain || ATS_DOMAINS.has(domain)) return [];
-  const paths = ['', '/contatti', '/contatti/', '/it/contatti', '/contact', '/contact/', '/kontakt', '/impressum', '/chi-siamo', '/lavora-con-noi', '/lavora-con-noi/', '/jobs', '/careers', '/azienda/contatti'];
-  const origins = [`https://www.${domain}`, `https://${domain}`];
-  const found = new Set();
-  for (const origin of origins) {
-    for (const p of paths) {
-      const html = await fetchText(origin + p);
-      if (!html) continue;
-      for (const e of extractCompanyEmails(html, domain)) found.add(e);
-      if (found.size >= 8) return [...found];
-    }
-    if (found.size) break;
-  }
-  return [...found];
 }
 
 /** Registry: company key → own website domain (apex), excluding ATS hosts. */

--- a/scripts/lib/email-enrichment.mjs
+++ b/scripts/lib/email-enrichment.mjs
@@ -1,0 +1,91 @@
+// Shared employer-contact enrichment network helpers.
+//
+// The pure parsing/scoring logic lives in `email-finder.mjs` / `domain-finder.mjs`
+// (unit-tested). This module holds the network + DNS side-effecting helpers that
+// were previously duplicated between `enrich-employer-contacts.mjs` and
+// `sync-employer-contacts-to-firestore.mjs`: a single copy keeps the ATS
+// blocklist, scrape paths and DDG rate-limit from drifting apart.
+
+import dns from 'node:dns/promises';
+import { extractCompanyEmails } from './email-finder.mjs';
+import { extractDdgDomains, guessDomains, rankDomains } from './domain-finder.mjs';
+
+// Third-party ATS / job-board domains: a careers/website URL pointing here is
+// NOT the employer's own domain, so its apex would be wrong (e.g. emailing
+// ncoreplat.com). Skip email-scraping when the resolved apex is one of these.
+export const ATS_DOMAINS = new Set([
+  'lever.co', 'greenhouse.io', 'myworkdayjobs.com', 'workday.com', 'smartrecruiters.com',
+  'personio.de', 'personio.com', 'recruitee.com', 'ncoreplat.com', 'ostendis.com',
+  'refline.ch', 'prospective.ch', 'jobs.ch', 'jobscout24.ch', 'indeed.com',
+  'jobcloud.ch', 'softgarden.io', 'teamtailor.com', 'workable.com', 'bamboohr.com',
+  'orior.ch', 'oraclecloud.com', 'taleo.net', 'successfactors.com', 'eu.greenhouse.io',
+  'intervieweb.it', 'inrecruiting.intervieweb.it', 'abacuscity.ch', 'umantis.com',
+  'dualoo.com', 'guidecom.de', 'rexx-systems.com', 'join.com', 'factorial.co',
+]);
+
+/** Fetch a URL's text (best-effort, capped, timed out). Empty string on any failure. */
+export async function fetchText(url, timeoutMs = 8000) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    const r = await fetch(url, { signal: ctrl.signal, redirect: 'follow', headers: { 'User-Agent': 'Mozilla/5.0 (compatible; frontaliereticino-enrichment/1.0)' } });
+    clearTimeout(t);
+    if (!r.ok) return '';
+    return (await r.text()).slice(0, 500_000);
+  } catch { return ''; }
+}
+
+/** True when the apex domain publishes at least one MX record (mailbox exists). */
+export async function mxOk(domain) {
+  try { const mx = await dns.resolveMx(domain); return Array.isArray(mx) && mx.length > 0; } catch { return false; }
+}
+
+// Find the employer's own domain when the registry lacks it: web search +
+// heuristic guesses, validated by MX + a name-token match (rejects directories).
+let _lastDdg = 0;
+export async function findDomain(name) {
+  const wait = 2500 - (Date.now() - _lastDdg); // space DDG calls (avoid throttling)
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  _lastDdg = Date.now();
+  let candidates = [];
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 9000);
+    const r = await fetch('https://html.duckduckgo.com/html/?q=' + encodeURIComponent(name + ' sito ufficiale'),
+      { signal: ctrl.signal, headers: { 'User-Agent': 'Mozilla/5.0', 'Accept-Language': 'it' } });
+    clearTimeout(t);
+    if (r.ok) candidates = extractDdgDomains(await r.text());
+  } catch { /* search unavailable → fall back to guesses */ }
+  candidates.push(...guessDomains(name));
+  const valid = [];
+  for (const d of [...new Set(candidates)]) { if (!ATS_DOMAINS.has(d) && await mxOk(d)) valid.push(d); if (valid.length >= 6) break; }
+  return rankDomains(valid, name)[0] || '';
+}
+
+/** Contact/impressum/careers paths probed on an employer's own domain. */
+export const CONTACT_PATHS = [
+  '', '/contatti', '/contatti/', '/it/contatti', '/contact', '/contact/', '/kontakt',
+  '/impressum', '/chi-siamo', '/lavora-con-noi', '/lavora-con-noi/', '/jobs', '/careers',
+  '/azienda/contatti',
+];
+
+/**
+ * Deep-scrape the employer's OWN domain (contact/impressum/careers pages) and
+ * return the on-domain emails found (third-party noise dropped by the domain
+ * filter in email-finder). Returns [] for unknown/ATS domains.
+ */
+export async function scrapeCompanyEmails(domain) {
+  if (!domain || ATS_DOMAINS.has(domain)) return [];
+  const origins = [`https://www.${domain}`, `https://${domain}`];
+  const found = new Set();
+  for (const origin of origins) {
+    for (const p of CONTACT_PATHS) {
+      const html = await fetchText(origin + p);
+      if (!html) continue;
+      for (const e of extractCompanyEmails(html, domain)) found.add(e);
+      if (found.size >= 8) return [...found];
+    }
+    if (found.size) break;
+  }
+  return [...found];
+}

--- a/scripts/lib/firestore-admin.mjs
+++ b/scripts/lib/firestore-admin.mjs
@@ -1,0 +1,32 @@
+// Shared firebase-admin Firestore bootstrap for the outreach/insights scripts.
+//
+// Every script that writes employer data (build-employer-insights,
+// sync-employer-contacts-to-firestore, send-cold-emails, write-employer-traffic…)
+// repeated the same cert-from-GOOGLE_APPLICATION_CREDENTIALS init. One copy here
+// stops the project id / credential-shape handling from drifting between them.
+
+import fs from 'node:fs';
+
+/**
+ * Initialise (once) and return the Admin Firestore handle.
+ * Credentials come from the GOOGLE_APPLICATION_CREDENTIALS service-account JSON;
+ * an explicit `project_id` uses a cert credential, otherwise we fall back to
+ * application-default with the canonical project id.
+ *
+ * @param {string} [projectId='frontaliere-ticino'] fallback project id
+ * @returns {Promise<import('firebase-admin/firestore').Firestore>}
+ */
+export async function getFirestoreDb(projectId = 'frontaliere-ticino') {
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath || !fs.existsSync(credPath)) {
+    throw new Error('GOOGLE_APPLICATION_CREDENTIALS required (Firebase service account JSON).');
+  }
+  const { initializeApp, cert, getApps, applicationDefault } = await import('firebase-admin/app');
+  const { getFirestore } = await import('firebase-admin/firestore');
+  if (getApps().length === 0) {
+    const cred = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+    if (cred.project_id) initializeApp({ credential: cert(cred) });
+    else initializeApp({ credential: applicationDefault(), projectId });
+  }
+  return getFirestore();
+}

--- a/scripts/sync-employer-contacts-to-firestore.mjs
+++ b/scripts/sync-employer-contacts-to-firestore.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * sync-employer-contacts-to-firestore.mjs — fill the admin "Insights Aziende"
+ * dashboard contact column.
+ *
+ * The dashboard (CF `adminEmployerInsights`) reads the per-company outreach
+ * email from Firestore `employer_contacts/{companyKey}`. That collection starts
+ * EMPTY, so every row shows "contatto mancante". The local enrichment
+ * (`enrich-employer-contacts.mjs`) only ever wrote `contacts.json` (gitignored,
+ * invisible to the GET) — nothing bridged the discovered emails INTO Firestore.
+ * This script closes that gap: it discovers an HR/contact email per company and
+ * upserts it to `employer_contacts/{companyKey}` so the dashboard fills in.
+ *
+ * Company universe = the `employer_insights` docs (exactly what the dashboard
+ * lists). Domain resolution, in priority order, all open-data / best-effort:
+ *   1. jobs.json `companyDomain` (the employer's own domain, non-ATS) — same
+ *      `companyKey` as insights, so it joins directly;
+ *   2. `data/crawler-companies-auto.json` registry (by key, then by name-slug);
+ *   3. web-search discovery (`findDomain`: DDG + guesses, MX + name-token gated).
+ * Then scrape the own-domain contact/impressum/careers pages for on-domain
+ * emails and pick the best HR target (`email-finder` scoring). MX-validated.
+ *
+ * Never clobbers a contact that already has an email (admin-edited) unless
+ * `--force`. Never deletes. Idempotent: re-runs only fill the still-missing ones.
+ *
+ * Usage:
+ *   eval "$(GOOGLE_APPLICATION_CREDENTIALS=<sa> node scripts/load-rc-env.mjs)"   # optional (no secrets needed)
+ *   GOOGLE_APPLICATION_CREDENTIALS=<sa> node scripts/sync-employer-contacts-to-firestore.mjs            # dry-run
+ *   GOOGLE_APPLICATION_CREDENTIALS=<sa> node scripts/sync-employer-contacts-to-firestore.mjs --apply    # write
+ *   ... --min-views 10        only enrich companies with ≥N dashboard views (default 5)
+ *   ... --limit 50            cap the number of companies processed this run
+ *   ... --company <key>       single company (debug)
+ *   ... --concurrency 6       parallel scrape workers (default 6)
+ *   ... --force               re-enrich companies that already have an email
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { apexDomain, pickBestEmail } from './lib/email-finder.mjs';
+import { slugify } from './lib/employer-sectors.mjs';
+import { ATS_DOMAINS, mxOk, findDomain, scrapeCompanyEmails } from './lib/email-enrichment.mjs';
+import { getFirestoreDb } from './lib/firestore-admin.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+function arg(name, def) {
+  const i = argv.indexOf(name);
+  if (i < 0) return def;
+  const n = argv[i + 1];
+  return n && !n.startsWith('--') ? n : true;
+}
+
+const APPLY = has('--apply');
+const FORCE = has('--force');
+const MIN_VIEWS = Number(arg('--min-views', 5)) || 0;
+const LIMIT = Number(arg('--limit', 0)) || 0;
+const ONLY = typeof arg('--company') === 'string' ? arg('--company') : '';
+const CONCURRENCY = Math.max(1, Number(arg('--concurrency', 6)) || 6);
+
+/** apex domain with ATS hosts filtered out (empty string if it resolves to an ATS). */
+function ownApex(url) {
+  const apex = apexDomain(url || '');
+  return apex && !ATS_DOMAINS.has(apex) ? apex : '';
+}
+
+/** jobs.json: companyKey → most-frequent own (non-ATS) domain. */
+function loadJobsDomains() {
+  const p = ['data/jobs.json', 'public/data/jobs.json'].map((x) => path.join(ROOT, x)).find(fs.existsSync);
+  const byKey = new Map(); // key → Map(domain → count)
+  if (!p) return new Map();
+  const raw = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const jobs = Array.isArray(raw) ? raw : raw.jobs || [];
+  for (const j of jobs) {
+    const key = j.companyKey;
+    const dom = ownApex(j.companyDomain || '');
+    if (!key || !dom) continue;
+    if (!byKey.has(key)) byKey.set(key, new Map());
+    const m = byKey.get(key);
+    m.set(dom, (m.get(dom) || 0) + 1);
+  }
+  // collapse to the single most-frequent domain per key
+  const out = new Map();
+  for (const [key, m] of byKey) {
+    out.set(key, [...m.entries()].sort((a, b) => b[1] - a[1])[0][0]);
+  }
+  return out;
+}
+
+/** crawler-companies-auto.json: key → domain AND name-slug → domain (own, non-ATS). */
+function loadRegistryDomains() {
+  const byKey = new Map();
+  const byName = new Map();
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/crawler-companies-auto.json'), 'utf8'));
+    const list = Array.isArray(raw) ? raw : Array.isArray(raw.companies) ? raw.companies : Object.values(raw);
+    for (const c of list) {
+      if (!c || typeof c !== 'object') continue;
+      const apex = ownApex(c.website || c.careersUrl || '');
+      if (!apex) continue;
+      if (c.key) byKey.set(slugify(c.key), apex);
+      if (c.name) byName.set(slugify(c.name), apex);
+    }
+  } catch { /* registry optional */ }
+  return { byKey, byName };
+}
+
+/** Resolve a company's own domain from the cheap local sources, web-search last. */
+async function resolveDomain(company, jobsDomains, registry) {
+  const key = company.key;
+  const nameSlug = slugify(company.name || '');
+  const local =
+    jobsDomains.get(key) ||
+    registry.byKey.get(key) ||
+    registry.byKey.get(nameSlug) ||
+    registry.byName.get(nameSlug) ||
+    '';
+  if (local) return { domain: local, domainSource: 'registry' };
+  // Last resort: web-search discovery (rate-limited, MX + name-token gated).
+  const found = await findDomain(company.name || key);
+  return found ? { domain: found, domainSource: 'search' } : { domain: '', domainSource: '' };
+}
+
+/** Discover the best contact email for one company. Returns the enriched record. */
+async function enrichOne(company, jobsDomains, registry) {
+  const { domain, domainSource } = await resolveDomain(company, jobsDomains, registry);
+  const rec = { key: company.key, name: company.name, views: company.views, domain, domainSource, email: '', emailSource: '', emailInferred: '' };
+  if (!domain) return rec;
+  if (!(await mxOk(domain))) { rec.note = 'domain has no MX'; return rec; }
+  const found = await scrapeCompanyEmails(domain);
+  const best = pickBestEmail(found);
+  if (best) { rec.email = best; rec.emailSource = 'scraped'; }
+  // No public address scraped, but the domain accepts mail (MX ok): surface a
+  // low-confidence `info@` guess in the dashboard's INFERRED column. It never
+  // becomes the send recipient on its own — the cold-email sender only uses the
+  // confirmed `email`, so the admin must promote it after verifying.
+  else rec.emailInferred = `info@${domain}`;
+  return rec;
+}
+
+/** Run `worker` over `items` with bounded concurrency, preserving order. */
+async function mapPool(items, concurrency, worker) {
+  const out = new Array(items.length);
+  let next = 0;
+  async function run() {
+    while (next < items.length) {
+      const i = next++;
+      out[i] = await worker(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, run));
+  return out;
+}
+
+async function main() {
+  const db = await getFirestoreDb();
+
+  // Universe = dashboard insights docs.
+  const [insSnap, conSnap] = await Promise.all([
+    db.collection('employer_insights').get(),
+    db.collection('employer_contacts').get(),
+  ]);
+  const existing = new Map(); // key → has-email
+  conSnap.forEach((d) => {
+    const data = d.data() || {};
+    existing.set(String(data.companyKey || d.id), Boolean(String(data.email || '').trim()));
+  });
+
+  let companies = insSnap.docs.map((d) => {
+    const x = d.data() || {};
+    return { key: String(x.companyKey || d.id), name: String(x.companyName || x.companyKey || d.id), views: Number(x.totals?.views || 0) };
+  });
+
+  // Filter: meaningful traffic, skip junk slug-only names, skip already-filled.
+  const looksReal = (c) => c.name && !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(c.name) || c.views >= 20;
+  companies = companies
+    .filter((c) => (ONLY ? c.key === ONLY : c.views >= MIN_VIEWS && looksReal(c)))
+    .filter((c) => FORCE || ONLY || !existing.get(c.key))
+    .sort((a, b) => b.views - a.views);
+  if (LIMIT) companies = companies.slice(0, LIMIT);
+
+  console.log(`Universe: ${insSnap.size} insights docs · ${conSnap.size} existing contacts.`);
+  console.log(`Enriching ${companies.length} companies (min-views=${MIN_VIEWS}, concurrency=${CONCURRENCY}, ${APPLY ? 'APPLY' : 'dry-run'}).\n`);
+
+  const jobsDomains = loadJobsDomains();
+  const registry = loadRegistryDomains();
+
+  let done = 0;
+  const records = await mapPool(companies, CONCURRENCY, async (c) => {
+    const rec = await enrichOne(c, jobsDomains, registry);
+    done++;
+    const tag = rec.email ? `✓ ${rec.email}` : rec.domain ? `· no email (${rec.domain})` : '✗ no domain';
+    console.log(`[${done}/${companies.length}] ${rec.name} (${rec.views}v) → ${tag}`);
+    return rec;
+  });
+
+  const toWrite = records.filter((r) => r.email || r.emailInferred);
+  const scraped = records.filter((r) => r.email).length;
+  console.log(`\nResolved domain for ${records.filter((r) => r.domain).length}/${records.length}; scraped email for ${scraped}, inferred for ${toWrite.length - scraped}.`);
+
+  if (!APPLY) {
+    console.log('\n(dry-run — pass --apply to upsert employer_contacts/*)');
+    return;
+  }
+
+  const { FieldValue } = await import('firebase-admin/firestore');
+  let written = 0;
+  for (let i = 0; i < toWrite.length; i += 400) {
+    const batch = db.batch();
+    for (const r of toWrite.slice(i, i + 400)) {
+      // merge:true + only non-empty fields → never wipes an admin-edited address.
+      // A scraped email lands in `email` (confirmed); a guess only in
+      // `emailInferred` so it can't silently become the send recipient.
+      const doc = {
+        companyKey: r.key,
+        domain: r.domain,
+        enrichedAt: FieldValue.serverTimestamp(),
+        updatedBy: 'sync-employer-contacts',
+      };
+      if (r.email) { doc.email = r.email; doc.emailSource = r.emailSource; }
+      if (r.emailInferred) doc.emailInferred = r.emailInferred;
+      batch.set(db.collection('employer_contacts').doc(r.key), doc, { merge: true });
+      written++;
+    }
+    await batch.commit();
+  }
+  console.log(`\n✅ Upserted ${written} contacts into employer_contacts/ (${scraped} scraped, ${written - scraped} inferred).`);
+}
+
+main().catch((e) => { console.error(e.message || e); process.exit(1); });


### PR DESCRIPTION
## Implementato

**Problema:** la pagina admin *Insights Aziende* (`/gestione-contenuti-xk9mp2q`, tab insights) mostrava "contatto mancante" per **ogni** azienda. La dashboard legge il contatto da Firestore `employer_contacts/{companyKey}`, ma quella collection era **vuota** (0 doc) e niente la popolava: l'enrichment locale scriveva solo `contacts.json` (gitignored, invisibile al GET della CF). Mancava il bridge enrichment → Firestore.

- **`scripts/sync-employer-contacts-to-firestore.mjs`** (nuovo): prende l'universo esatto della dashboard (i doc `employer_insights`), risolve il dominio proprio di ogni azienda da fonti open-data in priorità — `jobs.json` `companyDomain` (non-ATS) → registry `crawler-companies-auto.json` (per key e per name-slug) → web-search `findDomain` (DDG + guess, validati MX + name-token) — poi scrapa le pagine contatti/impressum/careers per un'email HR e fa upsert su `employer_contacts`. Un'email **scraped** finisce nel campo confermato `email`; un guess a bassa confidenza `info@<dominio>` (solo su dominio con MX) finisce in `emailInferred`. Idempotente, `merge:true`, mai cancella, mai sovrascrive un indirizzo editato a mano (flag `--apply`/`--min-views`/`--limit`/`--company`/`--force`/`--concurrency`).
- **Eseguito `--apply` in produzione**: `employer_contacts` passata da **0 → 227 contatti** (105 email confermate scraped + 122 inferred `info@`), domini risolti 253/253. La CF `adminEmployerInsights` legge Firestore direttamente → la dashboard è **già popolata live** (nessun deploy necessario per i dati). Il pannello già renderizza `contactEmailInferred` con label "(inferita)" e bottone "usa questa" nel modal: l'inferred è visibile ma il sender cold-email usa solo `email` confermata → nessun invio automatico a un indirizzo non verificato.
- **`scripts/lib/email-enrichment.mjs`** (nuovo): estratti gli helper di rete (`ATS_DOMAINS`, `fetchText`, `mxOk`, `findDomain`, `scrapeCompanyEmails`, `CONTACT_PATHS`) prima duplicati in `enrich-employer-contacts.mjs` → un'unica copia condivisa (Non-Negotiable #6, no drift).
- **`scripts/lib/firestore-admin.mjs`** (nuovo): estratto il bootstrap firebase-admin (`getFirestoreDb`) — risolve il nit deferito di #2702 — e adottato sia dal nuovo script sia da `build-employer-insights.mjs` (sibling stesso dominio).
- **`enrich-employer-contacts.mjs`** / **`build-employer-insights.mjs`**: refactor per usare le lib condivise.
- **`.github/workflows/employer-contacts-refresh.yml`** (nuovo): cron settimanale (lun 04:30 UTC) + `workflow_dispatch` che ri-esegue il sync `--apply` per tenere i contatti riempiti nel tempo. Zero-Claude, deterministico, modellato su `employer-traffic-refresh.yml`.

## Non implementato (ancora)

- **`send-cold-emails.mjs` non migrato a `getFirestoreDb`**: ha due init firebase-admin (`loadFirestoreSuppression` + `loadFirestoreContacts`) con un branch `applicationDefault` aggiuntivo. Lasciato fuori per restare chirurgico sul dominio insights/contacts; consolidamento repo-wide del boilerplate Firestore = follow-up (era il nit deferito #2702, qui parzialmente chiuso su 3 file).
- **26 aziende (253−227) restano senza contatto**: dominio risolto ma **nessun record MX** → nessun guess `info@` (non si inventa una mailbox inesistente). Restano "mancante" finché un dominio valido non emerge.
- **Inferenza del nome contatto / email personale per-persona**: non eseguita in questo bridge (la fa `enrich-employer-contacts.mjs` quando ha un `contactName` da `contacts.json`). Fuori scope per il bridge Firestore.
- **Hit-rate scraping ~41%**: i grandi siti (eoc.ch, lugano.ch, lidl.ch…) nascondono le email dietro form/JS → niente scrape, solo inferred. Migliorare la copertura (render JS, più path) è un follow-up.

## Test plan

- [x] `node --check` su tutti i file toccati — verde.
- [x] `vitest run tests/email-finder.test.ts tests/domain-finder.test.ts` (16 test) — verde (lib pure immutate).
- [x] `--apply` eseguito: 227 doc scritti, verificato via query Firestore (`employer_contacts` 0 → 227).
- [ ] Verifica visiva dashboard admin che mostra i contatti (post-merge, login admin).