### PR TITLE
fix(job-alerts): replay logged-out alert intent after sign-in (recover #3 funnel)

### DIFF
--- a/components/community/JobAlertForm.tsx
+++ b/components/community/JobAlertForm.tsx
@@ -12,6 +12,7 @@ import type { JobAlert, JobAlertConfig } from '@/services/jobAlertService';
 import { listCantonOptions, getCantonLabel, type CantonLocale } from '@/services/cantonList';
 import { ABOVE_MOBILE_NAV_BOTTOM } from '@/components/shared/mobileNavClearance';
 import { consumeJobAlertOpen } from '@/services/jobAlertOpenSignal';
+import { savePendingJobAlert, consumePendingJobAlert } from '@/services/pendingJobAlert';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -163,10 +164,65 @@ export default function JobAlertForm({ authUser, onRequireAuth, initialKeyword =
  setToast(msg);
  setTimeout(() => setToast(null), 3000);
  }, []);
+  const buildConfig = useCallback((): JobAlertConfig => ({
+    keywords: keyword.trim() ? keyword.trim().split(/[,;]+/).map((k) => k.trim()).filter(Boolean) : [],
+    locations: selectedLocations,
+    contractTypes: selectedContracts,
+    sectors: selectedSectors,
+    // Cathedral CH-wide geo scoping: empty selection = "all cantons", explicit codes scope it.
+    cantonFilter: selectedCantons.length > 0 ? selectedCantons : null,
+    frequency,
+    locale: locale as "it" | "en" | "de" | "fr",
+  }), [keyword, selectedLocations, selectedContracts, selectedSectors, selectedCantons, frequency, locale]);
+
+  const configIsEmpty = (c: JobAlertConfig): boolean => c.keywords.length === 0 && c.locations.length === 0;
+
+  const persistAlert = useCallback(
+    async (uid: string, email: string, config: JobAlertConfig, surface: 'inline_card' | 'post_auth_auto'): Promise<void> => {
+      const { createAlert } = await import("@/services/jobAlertService");
+      const alert = await createAlert(uid, email, config);
+      setAlerts((prev) => [alert, ...prev]);
+      import("@/services/analytics")
+        .then(({ Analytics }) =>
+          Analytics.trackJobAlertCreated({
+            keywords: config.keywords.join(", "),
+            location: config.locations.join(", "),
+            frequency: config.frequency,
+            surface,
+          }),
+        )
+        .catch(() => {});
+    },
+    [],
+  );
+
+  // After the auth round-trip, replay a stashed alert intent so a logged-out
+  // "create" completes itself instead of forcing a re-entry + re-submit
+  // (the 536 click -> 39 create / 93% drop at exactly this step).
+  const pendingConsumedRef = useRef(false);
+  useEffect(() => {
+    if (!authUser || pendingConsumedRef.current) return;
+    const pending = consumePendingJobAlert();
+    if (!pending) return;
+    pendingConsumedRef.current = true;
+    (async () => {
+      try {
+        await persistAlert(authUser.uid, authUser.email || "", pending, "post_auth_auto");
+        showToast(t("jobAlert.created") || "Alert creata! Riceverai una email con le nuove offerte.");
+      } catch {
+        // Re-stash so a transient failure can retry on a later auth-ready render.
+        savePendingJobAlert(pending);
+        pendingConsumedRef.current = false;
+      }
+    })();
+  }, [authUser, persistAlert, showToast, t]);
+
 
  const handleCreate = async () => {
  if (!authUser) {
- onRequireAuth?.();
+ const pendingConfig = buildConfig();
+          if (!configIsEmpty(pendingConfig)) savePendingJobAlert(pendingConfig);
+          onRequireAuth?.();
  return;
  }
 
@@ -177,29 +233,8 @@ export default function JobAlertForm({ authUser, onRequireAuth, initialKeyword =
 
  setSaving(true);
  try {
- const { createAlert } = await import('@/services/jobAlertService');
- const config: JobAlertConfig = {
- keywords: keyword.trim() ? keyword.trim().split(/[,;]+/).map((k) => k.trim()).filter(Boolean) : [],
- locations: selectedLocations,
- contractTypes: selectedContracts,
- sectors: selectedSectors,
- // Cathedral CH-wide geo scoping (CATHEDRAL-STATUS #12): empty selection
- // = "all cantons" (legacy behaviour), explicit codes scope the alert.
- cantonFilter: selectedCantons.length > 0 ? selectedCantons : null,
- frequency,
- locale: locale as 'it' | 'en' | 'de' | 'fr',
- };
- const alert = await createAlert(authUser.uid, authUser.email || '', config);
- setAlerts((prev) => [alert, ...prev]);
- // FRO-334: Track alert creation
- import('@/services/analytics').then(({ Analytics }) => {
- Analytics.trackJobAlertCreated({
- keywords: config.keywords.join(', '),
- location: config.locations.join(', '),
- frequency: config.frequency,
- surface: 'inline_card',
- });
- }).catch(() => {});
+ const config = buildConfig();
+      await persistAlert(authUser.uid, authUser.email || '', config, 'inline_card');
  showToast(t('jobAlert.created') || 'Alert creata! Riceverai una email con le nuove offerte.');
  // Reset form
  setKeyword('');

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1819,7 +1819,7 @@ export const Analytics = {
  keywords?: string;
  location?: string;
  frequency?: string;
- surface?: 'inline_card' | 'job_detail_prompt' | 'job_detail_button' | 'sticky_banner' | 'end_card' | 'preferences';
+ surface?: 'inline_card' | 'job_detail_prompt' | 'job_detail_button' | 'sticky_banner' | 'end_card' | 'preferences' | 'post_auth_auto';
  } = {}) => {
  // Defensive: collapse undefined/empty to clear sentinels rather than null
  // so PostHog HogQL queries never see mixed null/empty values for the same

--- a/services/pendingJobAlert.ts
+++ b/services/pendingJobAlert.ts
@@ -1,0 +1,69 @@
+/**
+ * Pending job-alert intent — survives the auth round-trip.
+ *
+ * A logged-out user who fills the job-alert form and clicks "create" is sent
+ * through the sign-in flow (Google popup or newsletter-autologin redirect) and,
+ * on the old behaviour, landed back with an empty form and had to re-enter +
+ * re-submit. Almost nobody did (PostHog: 536 CTA clicks → 39 alerts created,
+ * a 93% drop at exactly this step).
+ *
+ * We stash the intended alert config here BEFORE triggering auth and replay it
+ * once the user is authenticated, auto-creating the alert they asked for.
+ * sessionStorage (not in-memory) so it survives a redirect-based sign-in; a
+ * short TTL so a config abandoned mid-auth never fires a surprise alert later.
+ */
+
+import type { JobAlertConfig } from '@/services/jobAlertService';
+
+const KEY = 'pending_job_alert';
+// Long enough for a Google popup or newsletter-autologin token exchange, short
+// enough that an abandoned attempt never resurfaces in a later session/visit.
+const TTL_MS = 15 * 60 * 1000;
+
+interface StoredPendingAlert {
+  config: JobAlertConfig;
+  savedAt: number;
+}
+
+export function savePendingJobAlert(config: JobAlertConfig): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload: StoredPendingAlert = { config, savedAt: Date.now() };
+    window.sessionStorage.setItem(KEY, JSON.stringify(payload));
+  } catch {
+    /* sessionStorage unavailable (private mode) — degrade to no replay */
+  }
+}
+
+/**
+ * Return the pending alert config and clear it, but only if it was saved within
+ * the TTL. Returns null when absent, expired, or malformed.
+ */
+export function consumePendingJobAlert(): JobAlertConfig | null {
+  if (typeof window === 'undefined') return null;
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(KEY);
+    if (raw) window.sessionStorage.removeItem(KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredPendingAlert;
+    if (!parsed || typeof parsed.savedAt !== 'number' || !parsed.config) return null;
+    if (Date.now() - parsed.savedAt > TTL_MS) return null;
+    return parsed.config;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingJobAlert(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/tests/pending-job-alert.test.ts
+++ b/tests/pending-job-alert.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  savePendingJobAlert,
+  consumePendingJobAlert,
+  clearPendingJobAlert,
+} from '@/services/pendingJobAlert';
+import type { JobAlertConfig } from '@/services/jobAlertService';
+
+const config: JobAlertConfig = {
+  keywords: ['infermiere'],
+  locations: ['Lugano'],
+  contractTypes: [],
+  sectors: [],
+  cantonFilter: null,
+  frequency: 'daily',
+  locale: 'it',
+};
+
+describe('pendingJobAlert', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('round-trips a saved config', () => {
+    savePendingJobAlert(config);
+    expect(consumePendingJobAlert()).toEqual(config);
+  });
+
+  it('consumes once — a second consume returns null', () => {
+    savePendingJobAlert(config);
+    expect(consumePendingJobAlert()).toEqual(config);
+    expect(consumePendingJobAlert()).toBeNull();
+  });
+
+  it('returns null when nothing is pending', () => {
+    expect(consumePendingJobAlert()).toBeNull();
+  });
+
+  it('expires entries older than the TTL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-22T10:00:00Z'));
+    savePendingJobAlert(config);
+    // 16 minutes later — past the 15-minute TTL.
+    vi.setSystemTime(new Date('2026-06-22T10:16:00Z'));
+    expect(consumePendingJobAlert()).toBeNull();
+  });
+
+  it('honours a config saved just within the TTL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-22T10:00:00Z'));
+    savePendingJobAlert(config);
+    vi.setSystemTime(new Date('2026-06-22T10:14:00Z'));
+    expect(consumePendingJobAlert()).toEqual(config);
+  });
+
+  it('clear removes a pending entry', () => {
+    savePendingJobAlert(config);
+    clearPendingJobAlert();
+    expect(consumePendingJobAlert()).toBeNull();
+  });
+
+  it('returns null on malformed storage', () => {
+    sessionStorage.setItem('pending_job_alert', '{not json');
+    expect(consumePendingJobAlert()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Implementato

Fix del rilevatore **#3 job-alert** (funnel reale: `ENABLE_JOB_ALERTS='true'` live). PostHog: 536 click CTA → **39 alert creati** (drop del 93%), tutto al confine auth. Un utente sloggato che compila il form e clicca "Crea alert" viene mandato al login via `onRequireAuth()` e torna su un **form vuoto con la config persa** → deve re-inserire e re-submittare. Quasi nessuno lo fa.

`JobAlertForm` è l'**unico chokepoint di creazione** (sia `JobBoard` che `JobAlertSection` lo renderizzano passando `onRequireAuth`; sticky banner / end card dispatchano solo `openJobAlert` per espanderlo; il prompt one-tap su job-detail è authed-only e già auto-offerto allo sblocco dell'auth-gate). Fixare il form copre ogni superficie.

- **Nuovo `services/pendingJobAlert.ts`**: salva la `JobAlertConfig` desiderata in `sessionStorage` PRIMA di triggerare l'auth (sopravvive a redirect / newsletter-autologin reload, non solo al popup Google), con TTL 15 min così un tentativo abbandonato non crea un alert a sorpresa in una sessione successiva.
- **`components/community/JobAlertForm.tsx`**: sul "crea" da sloggato salva la config come pending prima di `onRequireAuth()`; un nuovo effect auth-ready consuma il pending e **auto-crea l'alert** (surface `post_auth_auto`), con ref-guard contro doppia creazione e re-stash su fallimento transiente. Estratti `buildConfig()` + `persistAlert()` così il path manuale e quello automatico condividono un'unica routine create/track (no duplicazione).
- **`services/analytics.ts`**: aggiunto `'post_auth_auto'` allo union `surface` di `trackJobAlertCreated`.
- **`tests/pending-job-alert.test.ts`**: TTL, consume-once, storage malformato (7 test, verdi).

Verificato: `tsc --noEmit` nessun errore nei file toccati; vitest nuovo file 7/7 verde.

## Non implementato (ancora)

- **Sibling `JobBoard.tsx` / `JobAlertSection.tsx`** (flaggati da `check-sibling-patterns` per `createAlert`/`onRequireAuth`/`trackJobAlertCreated`): NON hanno l'antipattern del drop logged-out — JobAlertSection e JobBoard **renderizzano JobAlertForm** (ereditano il fix) e il loro path one-tap (`subscribeJobAlertOneTap`) è **authed-only** (il prompt è gated su `userEmail && userId`, gli sloggati non lo vedono mai) con l'auto-prompt post-auth-gate già esistente (`justAuthedJobIdRef`). I match sono API/wiring condivisi, non duplicazione di logica.
- **Cattura via job_detail_prompt per sloggati**: non aggiunta — by design il prompt è solo per autenticati e la regola `silent_consent` sconsiglia email-capture senza login esplicito; il path form (con login esplicito) è quello corretto.
- **Verifica live**: l'auto-create post-auth è osservabile solo live post-merge (richiede il flusso auth reale Google/autologin). Da validare su PostHog: salita di `job_alert_created` con `surface='post_auth_auto'`. Nessun revert-trigger necessario (fail-safe: su errore ri-stasha; nessun cambio per utenti già loggati).