### PR TITLE
fix(ai-visibility): persist trend via committed history file, not gitignored reports/

### DIFF
--- a/.github/workflows/ai-visibility-check.yml
+++ b/.github/workflows/ai-visibility-check.yml
@@ -65,27 +65,31 @@ jobs:
         with:
           name: ai-visibility-${{ github.run_number }}
           path: reports/ai-visibility-*
-          retention-days: 365
+          # 90 = repository maximum; higher values are silently clamped (and the
+          # committed data/ai-visibility-history.jsonl is the long-term record).
+          retention-days: 90
 
-      - name: Commit reports
+      - name: Commit visibility history
         if: inputs.dry_run != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add reports/ai-visibility-*.json reports/ai-visibility-latest.md
+          # Full reports live under reports/ which is gitignored (preserved as
+          # build artifacts only). Only the compact append-only history file is
+          # committed so the next monthly run can compute the trend.
+          git add data/ai-visibility-history.jsonl
           if git diff --cached --quiet; then
-            echo "No report changes to commit."
+            echo "No history changes to commit."
             exit 0
           fi
           DATE=$(date -u +%Y-%m-%d)
           git commit -m "📊 AI visibility report — ${DATE}"
-          # Centralized rebase-retry helper survives concurrent pushes.
-          # AI visibility reports are timestamped append-only files plus a
-          # single latest.md; on rebase conflict re-stage the artifacts we
-          # already produced on top of the new base.
+          # Centralized rebase-retry helper survives concurrent pushes from other
+          # workflows. The history file is append-only, so on a rebase conflict
+          # keep the local commit and union both sides instead of regenerating.
           bash scripts/lib/git-push-with-retry.sh \
             --branch "$GITHUB_REF_NAME" \
-            --regenerate-cmd "git add reports/ai-visibility-*.json reports/ai-visibility-latest.md"
+            --in-place-resolver-cmd "source scripts/lib/resolve-append-conflicts.sh && resolve_append_conflicts && git add -A"
 
       - name: Create GitHub issue if citations dropped
         if: inputs.dry_run != 'true'

--- a/scripts/check-ai-visibility.mjs
+++ b/scripts/check-ai-visibility.mjs
@@ -20,7 +20,7 @@
  *   reports/ai-visibility-latest.md           — Human-readable markdown summary
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, appendFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,6 +28,11 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..');
 const REPORTS_DIR = join(PROJECT_ROOT, 'reports');
+// Full reports live in the gitignored reports/ dir (artifacts only). The
+// trend needs a previous score that survives a fresh CI checkout, so a compact
+// append-only summary is committed here instead (mirrors
+// data/quality-alerts-history.jsonl).
+const HISTORY_FILE = join(PROJECT_ROOT, 'data', 'ai-visibility-history.jsonl');
 
 const SITE_DOMAIN = 'frontaliereticino.ch';
 const SITE_URL = `https://${SITE_DOMAIN}`;
@@ -449,6 +454,21 @@ async function runCheck() {
   await writeFile(mdPath, generateMarkdown(report));
   console.log(`📝 Markdown report: ${mdPath}`);
 
+  // Append a compact summary to the committed history file so the next monthly
+  // run can compute trend (reports/ is gitignored → never survives a fresh
+  // checkout, so the JSON reports there cannot back the trend in CI).
+  const historyEntry = {
+    date: dateStr,
+    score: citedCount,
+    scoreMax: QUERIES.length,
+    scorePercent: report.meta.scorePercent,
+    platformsChecked: availablePlatforms,
+    results: Object.fromEntries(results.map(r => [r.query, r.citedByAny])),
+  };
+  await mkdir(dirname(HISTORY_FILE), { recursive: true });
+  await appendFile(HISTORY_FILE, JSON.stringify(historyEntry) + '\n');
+  console.log(`🗂  History: ${HISTORY_FILE}`);
+
   // ── Summary ─────────────────────────────────────────────────────────────
 
   console.log(`\n${'═'.repeat(60)}`);
@@ -481,6 +501,33 @@ function buildCompetitorSummary(results) {
 // ─── Load previous report for trend ─────────────────────────────────────────
 
 async function loadPreviousReport(currentDate) {
+  // Primary source: committed append-only history file. reports/ is gitignored,
+  // so in CI it starts empty every run — only this file survives across the
+  // monthly schedule and can back the trend.
+  try {
+    if (existsSync(HISTORY_FILE)) {
+      const lines = (await readFile(HISTORY_FILE, 'utf8'))
+        .split('\n')
+        .map(l => l.trim())
+        .filter(Boolean);
+      for (let i = lines.length - 1; i >= 0; i--) {
+        let entry;
+        try { entry = JSON.parse(lines[i]); } catch { continue; }
+        if (!entry?.date || entry.date === currentDate) continue;
+        return {
+          previousDate: entry.date,
+          previousScore: entry.score ?? 0,
+          previousFile: 'data/ai-visibility-history.jsonl',
+          previousResults: entry.results || {},
+        };
+      }
+    }
+  } catch {
+    // fall through to the legacy reports/ scan below
+  }
+
+  // Legacy fallback: scan the gitignored reports/ dir. Only useful in local dev
+  // where prior full reports may still be present.
   try {
     const files = (await import('node:fs')).readdirSync(REPORTS_DIR)
       .filter(f => f.startsWith('ai-visibility-') && f.endsWith('.json') && !f.includes(currentDate))
@@ -498,11 +545,6 @@ async function loadPreviousReport(currentDate) {
     for (const r of (prevData.results || [])) {
       prevByQuery[r.query] = r.citedByAny;
     }
-
-    const gained = [];
-    const lost = [];
-    // We'll compare after current results are computed externally
-    // For now, just return basic trend data
 
     return {
       previousDate: prevDate,


### PR DESCRIPTION
## Implementato

Il workflow mensile **AI Visibility Check** (`ai-visibility-check.yml`) falliva a OGNI run (es. [run 26758037479](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26758037479)) nello step **Commit reports**:

- `git add reports/ai-visibility-*.json reports/ai-visibility-latest.md` punta a `reports/`, che è **gitignored** (`.gitignore:40`). `git add` di path ignorati espliciti stampa `paths are ignored` ed esce **non-zero** → sotto `bash -e` (default GitHub Actions) lo step abortiva con exit 1. Il run del 1° giugno è arrivato fino a lì (Gemini quota-exceeded NON crashava lo script, era gestito per-call) e poi è morto sul commit.
- Effetto collaterale: la **feature trend** era morta in CI. `loadPreviousReport()` leggeva i JSON precedenti da `reports/`, che però non sopravvive mai a un checkout fresco → nessuno score precedente, trend sempre assente.

Fix (root-cause, allineato al pattern canonico `data/quality-alerts-history.jsonl`):

- **`scripts/check-ai-visibility.mjs`**: persiste un riassunto compatto append-only in `data/ai-visibility-history.jsonl` (file **tracciato**, non ignorato) — `{date, score, scoreMax, scorePercent, platformsChecked, results}` per run. `loadPreviousReport()` ora legge il trend da questo file (con fallback al vecchio scan di `reports/` per il dev locale). I report completi restano in `reports/` come **artifact** (già caricati).
- **`.github/workflows/ai-visibility-check.yml`**: lo step (rinominato **Commit visibility history**) ora committa solo `data/ai-visibility-history.jsonl`. Il push usa `git-push-with-retry.sh` con `--in-place-resolver-cmd` (`resolve_append_conflicts`), il resolver corretto per file append-only (il vecchio `--regenerate-cmd` faceva hard-reset → avrebbe perso la riga appesa).
- Retention artifact `365 → 90` (massimo del repo; 365 veniva clampato silenziosamente con warning a ogni run). Lo storico di lungo periodo è ora il file committato.

Allineamento issue-tracking: lo step **Report failure to GitHub Issues** (`github-issue-creator.mjs`, `--priority 2 --label Bug --workflow`) è già byte-identico al pattern canonico (es. `revenue-monitor.yml`); lo step mensile **Create GitHub issue** continua a usare `gh issue create` (uno per mese, titolo datato — dedup non necessario). Nessuna modifica necessaria lì.

Validato in locale: syntax check OK; run reale con history seedato → trend letto correttamente (`📉 -3 vs 2026-05-01`), JSONL valido; dry-run invariato. GitNexus impact: risk LOW, 0 processi affetti (funzioni interne al CLI script).

## Non implementato (ancora)

- **`revenue-monitor.yml` (sibling stessa classe «commit di `reports/` gitignored»)**: NON toccato. A differenza di ai-visibility, NON fallisce (il suo `git add reports/...` ha `2>/dev/null || true` e la condizione di guardia su `reports/` è sempre falsa → no-op silenzioso, non crash). Un fix proprio richiederebbe il refactor del suo script separato (`revenue-monitor.mjs`) su un workflow non rotto → fuori scope di questo fix. Follow-up se si vuole il commit dei report revenue funzionante.
- **Gemini quota-exceeded**: lo script tollera già i fallimenti per-call (platform marcata `checked:false`); con tutte le call Gemini KO lo score può risultare 0 e generare un falso «citations dropped». Non affrontato qui (concern di data-quality separato dal fix del crash); l'aggiunta di Perplexity/altri provider come fonte primaria sarebbe il rimedio.
