### PR TITLE
fix(alerts+newsletter): accent-fold locToken + reject rollover dates (#2727 items 2-3)

### DIFF
--- a/services/locToken.mjs
+++ b/services/locToken.mjs
@@ -5,15 +5,46 @@
 //
 // `needle` must appear in `haystack` bounded by string start/end or a non-letter
 // character on both sides, so the location "bern" no longer matches a job in
-// "bernex"/"berna". Unicode-aware (`\p{L}`) so accented city names delimit
-// correctly; multi-word locations ("san gallo") match as a contiguous phrase;
-// hyphen/comma-delimited cities still match ("lugano" in "Lugano-Paradiso").
+// "bernex"/"berna". Multi-word locations ("san gallo") match as a contiguous
+// phrase; hyphen/comma-delimited cities still match ("lugano" in
+// "Lugano-Paradiso").
 //
+// Both sides are run through `normalizeLocToken` first so the .mjs path folds
+// diacritics + collapses whitespace/hyphens exactly like the .ts path
+// `isLocationMatch` (which goes through `normalizeSearchText`). Without this the
+// two funnels drift: "Zürich" would not match "zurich", and "san-gallo" /
+// "san  gallo" (double space) would not match "san gallo" — the same false-
+// negative class #2630 closed for substrings (#2713 follow-up, #2727 item 2).
+
+/**
+ * Fold a location string to a comparable form: lowercase, strip diacritics
+ * (NFD → drop combining marks), and collapse every run of non-alphanumeric
+ * characters (whitespace, hyphens, commas, …) to a single ASCII space, trimmed.
+ * Mirrors the token shape produced by textUtils.normalizeSearchText so the
+ * `.mjs` geo match and the `.ts` `isLocationMatch` stay aligned.
+ *
+ * @param {string} value
+ * @returns {string} normalized, single-space-delimited ASCII tokens
+ */
+export function normalizeLocToken(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
 // @param {string} haystack lowercased joined job-location text
 // @param {string} needle   lowercased alert/profile/subscriber location token
 // @returns {boolean}
 export function locTokenHit(haystack, needle) {
-  if (!needle) return false;
-  const esc = String(needle).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(^|[^\\p{L}])${esc}([^\\p{L}]|$)`, 'u').test(String(haystack));
+  const n = normalizeLocToken(needle);
+  if (!n) return false;
+  const h = normalizeLocToken(haystack);
+  if (!h) return false;
+  // After normalization both sides are single-space-delimited ASCII tokens, so a
+  // space-padded boundary test is a correct word-boundary match and still finds
+  // multi-word phrases ("san gallo") and hyphen-joined cities ("lugano paradiso").
+  return ` ${h} `.includes(` ${n} `);
 }

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -105,7 +105,16 @@ export function parseDateField(raw) {
     // Reject impossible DD/MM (e.g. month>12) → caller falls through to the
     // next field rather than trusting a misparse.
     if (day < 1 || day > 31 || month < 1 || month > 12) return NaN;
-    return Date.UTC(year, month - 1, day);
+    const ts = Date.UTC(year, month - 1, day);
+    // The range guard above is necessary but NOT sufficient: in-range-but-
+    // impossible calendar dates (31/04, 31/02) pass it, and Date.UTC silently
+    // ROLLS them over to the next month (31/02 → 3 Mar) instead of failing —
+    // a valid-but-WRONG timestamp that bypasses the firstSeenAt fallthrough,
+    // the exact failure class #2630 set out to eliminate (#2727 item 3).
+    // Round-trip check: reject if UTC normalized the day/month away.
+    const back = new Date(ts);
+    if (back.getUTCDate() !== day || back.getUTCMonth() !== month - 1) return NaN;
+    return ts;
   }
   return new Date(raw).getTime();
 }

--- a/tests/loc-token.test.ts
+++ b/tests/loc-token.test.ts
@@ -25,4 +25,24 @@ describe('locTokenHit — whole-token geo match (#2630)', () => {
   it('empty needle never matches', () => {
     expect(locTokenHit('lugano', '')).toBe(false);
   });
+
+  // #2727 item 2: align .mjs accent-folding + whitespace normalization with the
+  // .ts isLocationMatch path so the two funnels stop drifting.
+  it('folds diacritics on both needle and haystack', () => {
+    expect(locTokenHit('zurich zh', 'zürich')).toBe(true);
+    expect(locTokenHit('zürich zh', 'zurich')).toBe(true);
+    expect(locTokenHit('geneve ge', 'genève')).toBe(true);
+    expect(locTokenHit('genève ge', 'geneve')).toBe(true);
+  });
+
+  it('collapses whitespace and hyphens in the needle', () => {
+    expect(locTokenHit('san gallo sg', 'san-gallo')).toBe(true);
+    expect(locTokenHit('san gallo sg', 'san  gallo')).toBe(true);
+    expect(locTokenHit('san gallo sg', ' san gallo ')).toBe(true);
+  });
+
+  it('still rejects substring collisions after normalization', () => {
+    expect(locTokenHit('bernex geneve ge', 'bern')).toBe(false);
+    expect(locTokenHit('zurichsee zh', 'zurich')).toBe(false);
+  });
 });

--- a/tests/newsletter-date-parse.test.ts
+++ b/tests/newsletter-date-parse.test.ts
@@ -37,4 +37,33 @@ describe('parseDateField — European DD/MM slash dates (#2630)', () => {
   it('returns NaN for junk', () => {
     expect(Number.isNaN(parseDateField('not-a-date'))).toBe(true);
   });
+
+  // #2727 item 3: in-range but calendar-impossible dates pass the day<=31 &&
+  // month<=12 guard, and Date.UTC silently rolls them to the next month
+  // (31/04 → 1 May, 31/02 → 3 Mar). The round-trip check must reject them so
+  // the caller falls through to firstSeenAt rather than trusting a shifted ts.
+  it('returns NaN for an in-range but impossible day (31/04)', () => {
+    expect(Number.isNaN(parseDateField('31/04/26'))).toBe(true);
+  });
+
+  it('returns NaN for 31/02 (February rollover)', () => {
+    expect(Number.isNaN(parseDateField('31/02/26'))).toBe(true);
+  });
+
+  it('returns NaN for 29/02 in a non-leap year', () => {
+    expect(Number.isNaN(parseDateField('29/02/26'))).toBe(true);
+  });
+
+  it('accepts 29/02 in a leap year', () => {
+    const d = new Date(parseDateField('29/02/24'));
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(1); // February
+    expect(d.getUTCDate()).toBe(29);
+  });
+
+  it('accepts a valid end-of-month date (30/04)', () => {
+    const d = new Date(parseDateField('30/04/26'));
+    expect(d.getUTCMonth()).toBe(3); // April
+    expect(d.getUTCDate()).toBe(30);
+  });
 });


### PR DESCRIPTION
## Implementato

Risolve gli item 2 e 3 della follow-up #2727 (deferred da #2713/#2630).

- **Item 2 — accent-folding + whitespace robustness in `services/locToken.mjs` `locTokenHit`.** Il path `.mjs` (usato dal funnel job-alert in `jobAlertMatching.mjs` e dal ranking/pre-filter newsletter in `newsletter-content.mjs`) NON folfeatava i diacritici, mentre il path `.ts` `isLocationMatch` passa per `normalizeSearchText` (accent-folding). Falsi negativi: "Zürich" non matchava "zurich", e `san-gallo` / `san  gallo` (doppio spazio) non matchavano `san gallo` — la stessa classe di false-negative che #2630 chiuse per le substring. Estratto un helper `normalizeLocToken` che mirrora `normalizeSearchText` (lowercase, NFD diacritic-strip, collapse di whitespace/hyphen/punteggiatura a singolo spazio) e applicato a **needle + haystack** dentro `locTokenHit`, così la robustezza è by-construction nella funzione: i caller non devono pre-collassare. Il boundary-test resta whole-token (space-padded `includes`) → continua a rifiutare le collisioni substring ("bern" non matcha "bernex", "zurich" non matcha "zurichsee").
- **Item 3 — guard rollover calendario in `services/newsletter-content.mjs` `parseDateField`.** Date in-range ma impossibili nel calendario (`31/04`, `31/02`, `29/02` in anno non bisestile) passavano il guard `day<=31 && month<=12` e `Date.UTC` le faceva traboccare silenziosamente al mese dopo (`31/02`→3 mar) producendo un timestamp valido-ma-sbagliato che bypassa il fallthrough a `firstSeenAt` — stessa failure mode che #2630 voleva eliminare. Aggiunto round-trip check dopo `Date.UTC`: `new Date(ts).getUTCDate() === day && getUTCMonth() === month-1`; se fallisce → `NaN` → il caller (`toDateValue`) prosegue al campo successivo.
- **Test estesi** (file esistenti): `tests/loc-token.test.ts` (folding accenti su entrambi i lati, collapse whitespace/hyphen nel needle, substring-collision ancora rifiutata) e `tests/newsletter-date-parse.test.ts` (`31/04`, `31/02`, `29/02` non-leap → NaN; `29/02` leap e `30/04` ancora validi). Suite locale verde (full vitest: 1 timeout flaky in `mine-topic-candidates.test.ts`, ~17s isolato vs 15s gate — non correlato, passa isolato con `--testTimeout`).

### Sibling-pattern audit (AGENTS.md #6)
`node scripts/ci/check-sibling-patterns.mjs` segnala 5 file che condividono i costrutti `isLocationMatch`/`normalizeSearchText`/`textUtils`: `services/personalizationScoring.ts`, `services/textUtils.ts`, `build-plugins/jobsSeoPagesPlugin.ts`, `components/community/JobBoard.tsx`, `services/searchStem.mjs`. **Nessuno condivide l'antipattern**: sono il path `.ts` che GIÀ folfeata i diacritici via `normalizeSearchText` — è la reference corretta a cui questa PR allinea il path `.mjs`, non un sibling da fixare. Il match dello script è dovuto ai riferimenti incrociati nei commenti che ho aggiunto.

## Non implementato (ancora)

- **Item 1 — `cantonFilter` in `services/jobAlertMatching.mjs` droppa job con `canton:''` ma `location` valida in area TI.** Deferito: allentare il filtro hard senza una mappatura canton↔città affidabile re-introduce falsi positivi. Richiede prima (a) misurare quanti job reali hanno `canton:''` ma `location` in area TI; (b) costruire una tabella di resolving canton↔città; (c) solo allora allentare il filtro usando il mapping. Resta tracciato come scope misurazione-dipendente — la classe di rischio (recall vs falsi positivi) impone dati prima del codice.
- **Backfill storico dei timestamp già parsati col rollover** non eseguito: il fix è read-time (`parseDateField` su `postedDate` grezzo a ogni run newsletter), non c'è cache persistita da migrare → non necessario.

Closes #2727