### PR TITLE
fix(analytics): trailing slash on 7 trackPageView paths to match canonical

### DIFF
--- a/components/calculator/RalComparator.tsx
+++ b/components/calculator/RalComparator.tsx
@@ -165,7 +165,7 @@ const RalComparator: React.FC<{ userProfile?: UserProfileData | null }> = ({ use
 
  // Prefill salary from user profile
  useEffect(() => {
- Analytics.trackPageView('/simulatori/ral-comparator', 'RAL Comparator');
+ Analytics.trackPageView('/simulatori/ral-comparator/', 'RAL Comparator');
  Analytics.trackUIInteraction('ral_comparator', 'screen', 'view', 'open', undefined, 'calculator.ral_comparator.open');
  }, []);
 

--- a/components/pages/ContactPage.tsx
+++ b/components/pages/ContactPage.tsx
@@ -59,7 +59,7 @@ const ContactPage: React.FC<ContactPageProps> = ({ prefill, onPrefillConsumed })
 
  // Apply prefill when navigating from another page
  useEffect(() => {
- Analytics.trackPageView('/contatti', 'Contact Page');
+ Analytics.trackPageView('/contatti/', 'Contact Page');
  Analytics.trackUIInteraction('contact', 'page', 'contact_page', 'view');
  }, []);
 

--- a/components/pages/FaqSection.tsx
+++ b/components/pages/FaqSection.tsx
@@ -37,7 +37,7 @@ const FaqSection: React.FC = () => {
 
  // Inject FAQPage JSON-LD structured data for SEO
  useEffect(() => {
- Analytics.trackPageView('/faq', 'FAQ');
+ Analytics.trackPageView('/faq/', 'FAQ');
  Analytics.trackUIInteraction('faq', 'page', 'faq_section', 'view');
  }, []);
 

--- a/components/pages/FuelPriceStats.tsx
+++ b/components/pages/FuelPriceStats.tsx
@@ -430,7 +430,7 @@ export default function FuelPriceStats() {
  .then((result) => {
  if (cancelled) return;
  setData(result);
- Analytics.trackPageView('/statistiche/prezzi-benzina-confine', 'Prezzi carburanti confine');
+ Analytics.trackPageView('/statistiche/prezzi-benzina-confine/', 'Prezzi carburanti confine');
  Analytics.trackUIInteraction('statistiche', 'carburanti', 'view_dataset', 'view');
  })
  .catch((err) => {

--- a/components/pages/StatsView.tsx
+++ b/components/pages/StatsView.tsx
@@ -35,7 +35,7 @@ const StatsViewInner: React.FC = () => {
  const chart = useChartColors(isDark);
 
  useEffect(() => {
- Analytics.trackPageView('/statistiche', 'Statistiche frontalieri');
+ Analytics.trackPageView('/statistiche/', 'Statistiche frontalieri');
  Analytics.trackUIInteraction('stats', 'dashboard', 'stats_view', 'view');
  let cancelled = false;
  (async () => {

--- a/components/pages/UnemploymentStats.tsx
+++ b/components/pages/UnemploymentStats.tsx
@@ -16,7 +16,7 @@ const UnemploymentStats: React.FC = () => {
  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'));
 
  useEffect(() => {
- Analytics.trackPageView('/statistiche/disoccupazione-svizzera', 'Disoccupazione Svizzera');
+ Analytics.trackPageView('/statistiche/disoccupazione-svizzera/', 'Disoccupazione Svizzera');
  Analytics.trackUIInteraction('stats', 'unemployment', 'unemployment_view', 'view');
  (async () => {
  setLoading(true);

--- a/components/vita/TicineseDialect.tsx
+++ b/components/vita/TicineseDialect.tsx
@@ -215,7 +215,7 @@ const TicineseDialect: React.FC = () => {
  };
 
  useEffect(() => {
- Analytics.trackPageView('/dialetto-ticinese', 'Dialetto Ticinese');
+ Analytics.trackPageView('/dialetto-ticinese/', 'Dialetto Ticinese');
  Analytics.trackUIInteraction('dialect', 'page', 'dialect_page', 'view');
  }, []);
 


### PR DESCRIPTION
## Implementato

Allineati 7 literal `trackPageView('/path')` alla convenzione trailing-slash del sito (AGENTS.md / `feedback_new_links_trailing_slash` → "anche trackPageView").

`services/analytics.ts` `trackPageView()` scrive `page_path` e `page_location` **verbatim** (linee 788-790), zero normalizzazione slash. 7 call-site passavano path senza slash finale mentre la **URL canonica di quelle pagine è slash-terminata** — verificato live: `<link rel="canonical">` finisce in `/` per `/statistiche/`, `/contatti/`, `/dialetto-ticinese/`. Il mismatch splittava le righe GA4 `page_path` (`/statistiche` vs `/statistiche/`) corrompendo la granularità analytics per-pagina (osservato: `highBouncePaths` GA4 con sia `/path` che `/path/`).

File toccati (1 literal ciascuno):
- `components/vita/TicineseDialect.tsx` `/dialetto-ticinese` → `/dialetto-ticinese/`
- `components/calculator/RalComparator.tsx` `/simulatori/ral-comparator` → `…/`
- `components/pages/FaqSection.tsx` `/faq` → `/faq/`
- `components/pages/StatsView.tsx` `/statistiche` → `/statistiche/`
- `components/pages/UnemploymentStats.tsx` `/statistiche/disoccupazione-svizzera` → `…/`
- `components/pages/ContactPage.tsx` `/contatti` → `/contatti/`
- `components/pages/FuelPriceStats.tsx` `/statistiche/prezzi-benzina-confine` → `…/`

Bug-class **delimitata**: `grep trackPageView('...')` non-slash ritorna esattamente questi 7 (gli altri 3 — `/per-le-aziende/`, `/pubblica-offerta/`, `/i-miei-annunci/` — erano già corretti). Pattern by-construction già esistente in `JobsSalaryObservatory.tsx:236` (`trackPageView(buildPath(...))`).

Test: `vitest run analytics-instrumentation analytics-page-context analytics-seo` → 73 passed. Nessun test pinnava i path vecchi.

## Non implementato (ancora)

- **Normalizzazione slash by-construction dentro `trackPageView`** (un solo punto invece di 7 call-site): valutata ma posposta — cambierebbe il runtime per tutti i caller (edge-case query/hash) e non è coperta da test esistenti; i 7 edit espliciti sono la classe completa e verificata. Follow-up se la classe si riapre.
- **Origin-strip hardening** per le righe-errore `/https://…` (86 eventi in `ga4.errorHealth`): code-path diverso (error events, non page_view) — fuori scope di questo fix, follow-up separato.
- **Win SEO di traffico** dall'audit data-driven (cross-link sector-hub +400, anchor leaf→hub +250, navigator city-hub orfani +240, ecc.): toccano build-plugin SSG **non validabili localmente** (SEO build OOM) → posposti a una PR dedicata con validazione CI post-merge. Questo PR è il quick-win sicuro/igienico (est. +0 click SEO, data-quality).