### PR TITLE
perf(validate-dist): tar-pack locale shard artifacts to fix dead rehydrate fast-path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -620,6 +620,35 @@ jobs:
       # git clone when this artifact is missing (e.g. a failed shard push/upload),
       # so a locale is NEVER silently un-validated. IT/main shard untouched
       # (`matrix.locale != 'it'`) → matrix-equivalence sha256 intact.
+      #
+      # PACK INTO ONE TAR FIRST. The previous version uploaded the raw
+      # `dist/<loc>` tree (~410k loose files) directly. actions/upload-artifact@v7
+      # enumerates every file before upload and STACK-OVERFLOWED on that count —
+      # "##[error]Maximum call stack size exceeded" — so the upload silently
+      # failed (continue-on-error → step shows green, no artifact produced). The
+      # fast path was therefore DEAD on every deploy: validate-dist's rehydrate
+      # always fell through to the ~675s git-clone fallback. Packing the subtree
+      # into a single artifact.tar (exactly how the github-pages artifact is
+      # shipped) makes upload enumerate ONE file → no stack overflow, and the
+      # validate-dist side untars it straight into dist/ (no extra cp copy).
+      - name: Pack locale shard dist (tar) for post-deploy validation
+        if: matrix.locale != 'it'
+        # continue-on-error for the same reason as the upload+push steps: a pack
+        # failure must degrade to validate-dist's git-clone fallback, never flip
+        # build-locale.result→failure (which would block the Pages publish).
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          members=( "${{ matrix.locale }}" )
+          # dist/<loc>.html (= the /{loc} homepage) is normally present; guard so
+          # a future strip that drops it can't make tar exit non-zero. NB: use a
+          # full `if` — `[ -f ] && members+=()` would itself exit non-zero (and
+          # abort the step under set -e) when the homepage is absent.
+          if [ -f "dist/${{ matrix.locale }}.html" ]; then
+            members+=( "${{ matrix.locale }}.html" )
+          fi
+          tar -C dist -cf "$RUNNER_TEMP/locale-dist-${{ matrix.locale }}.tar" "${members[@]}"
+          ls -lh "$RUNNER_TEMP/locale-dist-${{ matrix.locale }}.tar"
       - name: Upload locale shard dist for post-deploy validation
         if: matrix.locale != 'it'
         # MUST stay continue-on-error: this is a non-essential speedup artifact.
@@ -635,9 +664,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: locale-dist-${{ matrix.locale }}-${{ github.run_id }}
-          path: |
-            dist/${{ matrix.locale }}
-            dist/${{ matrix.locale }}.html
+          # Single tar (see "Pack locale shard dist" above) — NOT the ~410k-file
+          # tree, which overflows the action's file enumerator.
+          path: ${{ runner.temp }}/locale-dist-${{ matrix.locale }}.tar
+          # compression-level 1: the tar is mostly HTML (very compressible) and
+          # this step gates the Pages publish, so favour a fast upload over a few
+          # extra MB. validate-dist downloads it over GitHub's internal network.
+          compression-level: 1
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -250,18 +250,32 @@ jobs:
             # the `if` condition is exempt from `set -e`, so a missing/failed
             # download simply falls through to the git-clone FALLBACK below — a
             # locale is NEVER silently un-validated.
+            #
+            # The artifact is a SINGLE tar (`locale-dist-<loc>.tar`, packed
+            # `-C dist`, members `<loc>/` + `<loc>.html`) — see deploy.yml "Pack
+            # locale shard dist (tar)". It used to be the raw ~410k-file tree, but
+            # upload-artifact@v7 stack-overflowed enumerating that many files so
+            # the artifact was never produced and this fast path was dead (every
+            # deploy paid the git-clone fallback). We untar straight into dist/ —
+            # no intermediate `cp -r` (the git-clone path's extra full-tree copy).
             dl="$RUNNER_TEMP/locale-dist-$loc"
             rm -rf "$dl"; mkdir -p "$dl"
-            if gh run download "$DEPLOY_RUN_ID" --name "locale-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -d "$dl/$loc" ]; then
-              rm -rf "dist/$loc"
-              cp -r "$dl/$loc" "dist/$loc"
-              if [ -f "$dl/$loc.html" ]; then cp "$dl/$loc.html" "dist/$loc.html"; fi
-              echo "rehydrated $loc from artifact: $(find "dist/$loc" -type f | wc -l) files"
+            if gh run download "$DEPLOY_RUN_ID" --name "locale-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/locale-dist-$loc.tar" ]; then
+              rm -rf "dist/$loc" "dist/$loc.html"
+              # `|| true`: a corrupt/truncated tar must fall through to the
+              # git-clone fallback (the `[ -d dist/$loc ]` check below), not abort
+              # the whole rehydrate step under `set -e` and skip the fallback.
+              tar -C dist -xf "$dl/locale-dist-$loc.tar" || true
               rm -rf "$dl"
-              continue
+              if [ -d "dist/$loc" ]; then
+                echo "rehydrated $loc from tar artifact: $(find "dist/$loc" -type f | wc -l) files"
+                continue
+              fi
+              echo "[rehydrate] $loc tar present but no $loc/ subtree after extract — falling back to git clone"
+            else
+              rm -rf "$dl"
+              echo "[rehydrate] $loc artifact absent — falling back to git clone"
             fi
-            rm -rf "$dl"
-            echo "[rehydrate] $loc artifact absent — falling back to git clone"
 
             tmp="$RUNNER_TEMP/rehydrate-$loc"
             rm -rf "$tmp"
@@ -279,7 +293,10 @@ jobs:
             echo "rehydrated $loc: $(find "dist/$loc" -type f | wc -l) files"
             rm -rf "$tmp"
           done
-          echo "dist after rehydrate: $(du -sh dist | cut -f1)"
+          # Cheap disk-pressure readout instead of `du -sh dist` (a ~70s full
+          # stat-walk of ~1.27M files just for a log line). df is instant and is
+          # the metric that actually matters after rehydrating ~27G into dist/.
+          df -h / | tail -1
 
       - name: Migrate all-known-job-slugs to canton-aware paths
         # Phase 8c: the committed `data/all-known-job-slugs.json` accumulates
@@ -661,13 +678,21 @@ jobs:
       - name: Build size summary
         run: |
           echo "=== Recovered dist size summary ==="
-          du -sh dist/
+          # Was `du -sh dist/` — a full stat-walk of ~1.27M files (~76s) for a
+          # number that is ~27G every build (low signal) and is ALSO printed by
+          # the rehydrate step. Dropped; `df -h` shows the disk headroom that
+          # actually matters here (OOM/disk-full risk) for free.
+          df -h / | tail -1
           # The per-HTML `find … -exec du -sh {} +` over ~132k+ files (top-10 by
           # size) was ~2min of pure stat-walk for observability that nothing
           # consumes — dropped. Per-plugin byte attribution already lives in the
           # build job's "Audit dist bytes" step. Keep the cheap sitemap listing.
+          #
+          # `find dist -name sitemap*.xml` ALSO walked the full ~1.27M-file tree.
+          # The sitemap index + shards live at the dist root (and one level down
+          # for any per-locale set), so glob those paths directly — no full walk.
           echo "Sitemaps:"
-          find dist -name "sitemap*.xml" -exec du -sh {} + | sort -rh || true
+          du -sh dist/sitemap*.xml dist/*/sitemap*.xml 2>/dev/null | sort -rh || true
 
       # On failure, upload structured audit reports + sitemaps so a debug
       # agent can diagnose without rebuilding dist/. Each audit script writes


### PR DESCRIPTION
## Implementato

Speedup del job `validate-dist` (post-deploy-validate-dist.yml), misurato a **2598s (~43min)** sull'ultima run success (27971887599). I tre colli reali (dalle tabelle per-gate del log): `audit:all` 1137s, **rehydrate locale shards 675s**, `gate:seo-source` 510s.

Questa PR aggredisce il rehydrate (regressione pura) + due full-walk informazionali:

- **Fix root-cause del fast-path rehydrate (deploy.yml + post-deploy-validate-dist.yml).** Il rehydrate dei subtree en/de/fr ha un fast-path (download artifact same-run) e un fallback git-clone (~675s). Il fast-path era **morto a ogni deploy**: `deploy.yml` caricava l'albero grezzo `dist/<loc>` (~410k file sciolti) e `actions/upload-artifact@v7` andava in **`##[error]Maximum call stack size exceeded`** enumerando quel numero di file. `continue-on-error: true` mascherava il fallimento (step verde, artifact mai prodotto) → validate-dist cadeva **sempre** nel git-clone (en 412k + de 434k + fr 414k file, dist finale 27G, ~675s).
  - deploy.yml: nuovo step **"Pack locale shard dist (tar)"** che impacchetta `dist/<loc>` + `dist/<loc>.html` in **un solo tar** (stesso schema dell'artifact `github-pages`) prima dell'upload → upload enumera 1 file, niente overflow. Inserito dopo "Offload shard refs to CDN" → tar byte-identico a ciò che `push-locale-shard.sh` pusha (e quindi al contenuto del git-clone fallback).
  - post-deploy-validate-dist.yml: il rehydrate scarica il tar e fa **untar diretto in `dist/`** (niente `cp -r` intermedio del path git-clone). Fallback git-clone **preservato**; un tar corrotto/troncato (`tar … || true` + check `[ -d dist/$loc ]`) **degrada al git-clone**, mai gate saltato.
  - Atteso: rehydrate **~675s → ~200s**.

- **Drop di tre full-tree stat-walk usati solo per righe di log** (~1.27M file ciascuno):
  - rehydrate: `du -sh dist` (~70s) → `df -h /` (istantaneo, mostra la disk-pressure che conta davvero).
  - Build size summary: `du -sh dist/` (~76s, ridondante col du del rehydrate) → `df -h /`; `find dist -name "sitemap*.xml"` (full-walk) → glob `dist/sitemap*.xml dist/*/sitemap*.xml` (i sitemap stanno in root).

**Invarianti preservate:** nessuna gate-logic toccata; contenuto dist rehydratato byte-identico (tar dopo offload-CDN); IT/main shard intatto (`matrix.locale != 'it'`) → matrix-equivalence sha256 invariata; fallback git-clone resta la rete di sicurezza (worst case = comportamento attuale).

**Validato localmente:** round-trip tar (pack→untar in dist) **byte-identico** su fixture (subtree + homepage, `it` non toccato); tar corrotto → `[ -d dist/en ]=no` → cade nel git-clone; `actionlint` pulito sui file modificati (l'unico warning SC2015:356 è pre-esistente, fuori dal diff).

## Non implementato (ancora)

- **Claim perf non verificabile pre-merge → revert-trigger.** I tempi (rehydrate ~200s, e i 2598s totali) si misurano solo sul prossimo deploy post-merge su `main` (il `build:ci`-scale gira solo lì). **Se il prossimo `validate-dist` post-merge non scarica il tar (log "artifact absent — falling back to git clone" ancora presente per en/de/fr) o se l'upload-artifact ri-fallisce → revert.** Verifica: nei log della build-locale lo step "Upload locale shard dist" deve essere realmente success (artifact `locale-dist-<loc>-<runid>` presente in `gh api .../artifacts`), e nel rehydrate deve comparire "rehydrated <loc> from tar artifact".
- **Leva `gate:seo-source` (510s) — overlap col post-build NON fatto (rischio).** `tests/seo` **legge `dist/`** (cathedral-hreflang-x-default, related-search-clusters, …), quindi non può sovrapporsi al rehydrate, solo al pool post-build (audit:all single-thread lascia core liberi). Win realistico ~287s ma con contention CPU + rischio timeout vitest → flakiness su `main` (main-red catastrofico, cascata). Deferito come concern separato (scheduling test), non bundlato per non rischiare il blocco di questa PR.
- **Leva `audit:all` (1137s) — worker_threads NON fatto (refactor separato).** Il runner è ubuntu-latest **4 vCPU / 16 GB** (repo public; i commenti "7 GB OOM" sono stale → la giustificazione serial è obsoleta), quindi la parallelizzazione (TODO già citato in `audit-runner.mjs:29-35`, `AUDIT_WORKERS=N`) è ora sicura. Ma è un refactor di ~14 file (12 auditor + runner + worker entry + parità byte-identica via test), e il guadagno reale del post-build è limitato dal floor del light-pool (~850s su 4 core saturi). Design completo disponibile; va in PR dedicata con parity-test e revert-trigger proprio.

Non chiude issue (#2751 è il tracker auto-gestito delle validation-failure, non perf-correlato).