### PR TITLE
feat(monetize): above-fold driveby ads on under-monetized SEO landing pages

### DIFF
--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -45,6 +45,7 @@ import {
   BASE_URL,
   MIN_INDEXABLE_WORDS,
   countHtmlBodyWords,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags } from './shared/hreflang';
@@ -1742,6 +1743,7 @@ function renderSnapshotPage(inp: SnapshotPageInputs): string {
     </header>
     ${degradedNote}
     ${statTiles}
+    ${DRIVEBY_AD_SNIPPET}
     ${topRolesList}
     ${topEmployersList}
     ${cityBreakdown}
@@ -2018,6 +2020,7 @@ function renderHubPage(inp: HubPageInputs): string {
     ${degradedNote}
     ${heroStatsHtml}
     ${ctaHtml}
+    ${DRIVEBY_AD_SNIPPET}
     ${latestWeeksHtml}
     ${archiveHtml}
     ${sectorsHtml}
@@ -2983,6 +2986,7 @@ function renderSectorPage(inp: SectorPageInputs): string {
     </header>
     ${statTiles}
     ${ctaHtml}
+    ${DRIVEBY_AD_SNIPPET}
     ${topEmployersList}
     ${trendSection}
     ${frontalierContextHtml}

--- a/build-plugins/marketReportPlugin.ts
+++ b/build-plugins/marketReportPlugin.ts
@@ -38,6 +38,7 @@ import {
   BASE_URL,
   countHtmlBodyWords,
   MIN_INDEXABLE_WORDS,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
@@ -626,6 +627,7 @@ function renderReport(opts: {
       <p style="${LEDE_STYLE}">${esc(copy.ledeIntro)}</p>
     </header>
     ${statCards}
+    ${DRIVEBY_AD_SNIPPET}
     <section class="s-KZc0LQ">
       <h2 style="${H2_STYLE}">${esc(copy.topEmployersH2)}</h2>
       <p style="${BODY_STYLE}">${esc(copy.topEmployersP)}</p>

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -37,6 +37,7 @@ import {
   BASE_URL,
   MIN_INDEXABLE_WORDS,
   countHtmlBodyWords,
+  DRIVEBY_AD_SNIPPET,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { firstParsableMs } from './shared/firstParsableDate';
@@ -2428,6 +2429,7 @@ export function renderTopHubPage(inp: TopHubPageInputs): string {
   </header>
   ${topStatsHtml}
   ${topJobBoardCtaHtml}
+  ${DRIVEBY_AD_SNIPPET}
   ${renderCityHubsListBlock(locale)}
   <section class="s-KZc0LQ" aria-labelledby="weTopMethodology">
     <h2 id="weTopMethodology" style="${H2_STYLE}">${esc(LINKING_COPY[locale].cityHubsTitle)} — ${esc(copy.kickerCurrent)}</h2>
@@ -2443,6 +2445,9 @@ export function renderTopHubPage(inp: TopHubPageInputs): string {
 ${faqHtml}
   </section>
   ${renderLocaleSwitcherBlock(locale, (alt) => topHubPath(alt))}
+  <section class="s-sC82IX" aria-label="advertisement">
+    ${adSlotHtml('JOBLIST_END_MULTIPLEX')}
+  </section>
   ${wrapHubSeoContextWeekly(locale, 'Ticino', true)}
 </article>`;
 
@@ -2976,6 +2981,7 @@ export function renderWeeklyEmployersPage(inp: WeeklyEmployersPageInputs): strin
   ${cityAdviceBannerHtml}
   ${cityCtaHtml}
   ${archiveNote}
+  ${DRIVEBY_AD_SNIPPET}
   <section class="s-KZc0LQ" aria-labelledby="topCompanies">
     <h2 id="topCompanies" style="${H2_STYLE}"><span aria-hidden="true">🏆</span> ${esc(copy.topCompaniesTitle)}</h2>
     ${topCompaniesHtml}
@@ -3537,6 +3543,7 @@ export function renderCompanyCityPage(inp: CompanyCityPageInputs): string {
   ${ccAdviceBannerHtml}
   ${ccCtaHtml}
   ${archiveNote}
+  ${DRIVEBY_AD_SNIPPET}
   <section class="s-KZc0LQ" aria-labelledby="companyCityJobs">
     <h2 id="companyCityJobs" style="${H2_STYLE}">${esc(copy.companyCityJobsHeading(employer, cityDisplay))}</h2>
     ${jobsListHtml}

--- a/tests/regression/seo-static-ad-slots.test.ts
+++ b/tests/regression/seo-static-ad-slots.test.ts
@@ -31,7 +31,8 @@ interface Spec {
 }
 
 const SPECS: Spec[] = [
-  // F5 weekly-employers — 2 render funcs, JOBLIST slot
+  // F5 weekly-employers — 3 render funcs, JOBLIST slot
+  { file: 'build-plugins/weeklyEmployersPlugin.ts', fn: 'renderTopHubPage', expectedSlot: 'JOBLIST_END_MULTIPLEX' },
   { file: 'build-plugins/weeklyEmployersPlugin.ts', fn: 'renderWeeklyEmployersPage', expectedSlot: 'JOBLIST_END_MULTIPLEX' },
   { file: 'build-plugins/weeklyEmployersPlugin.ts', fn: 'renderCompanyCityPage', expectedSlot: 'JOBLIST_END_MULTIPLEX' },
   // F2 health-premiums — 3 render funcs, ARTICLE slot


### PR DESCRIPTION
## Implementato

Round 2 della monetizzazione data-driven (segue #2732). Diagnosi AdSense (ultimi 30g): **`/aziende-che-assumono` rende CHF 3.30 su 2.905 pageview = PV-RPM 1.14**, molto sotto la media sito (~3.6), perché le sue pagine avevano **solo** un `JOBLIST_END_MULTIPLEX` in fondo (bassa viewability) + Auto Ads — nessun inventory display above-fold. `job-market-snapshot` e `market-report` avevano la stessa forma single-slot-in-fondo.

Aggiunto il `DRIVEBY_AD_SNIPPET` condiviso (`FT_DRIVEBY_ATF_DISPLAY`, display autorelaxed, CLS-reserved via min-height inline) **above-fold** — dopo le stat-tiles/risposta, prima del contenuto lungo — portando queste pagine alla **norma 2-slot** già usata da `/oggi` e health-premium:

- **weeklyEmployersPlugin** (il win, 2.905 pv RPM 1.14): driveby in `renderTopHubPage`, `renderWeeklyEmployersPage`, `renderCompanyCityPage`. `renderTopHubPage` aveva **ZERO** slot manuali → aggiunto anche il `JOBLIST_END_MULTIPLEX` (con SPEC entry nel regression guard).
- **jobMarketSnapshotPlugin**: driveby in `renderSnapshotPage`, `renderHubPage`, `renderSectorPage`.
- **marketReportPlugin**: driveby dopo le stat-card.

Tutte le pagine sono content-rich (word-gate plugin 300/350/800 + skip-guard `MIN_INDEXABLE_WORDS` che non emette pagine thin). Mobile-first (driveby sotto H1/risposta, sopra il contenuto lungo), non adiacente all'end-multiplex. Auto Ads intoccati; riusa unità AdSense esistenti (nessuna unità nuova).

**Regression-safety**: `DRIVEBY_AD_SNIPPET` è costante interpolata, non una call `adSlotHtml('SLOT')` letterale → i conteggi del guard `seo-static-ad-slots` restano invariati (jobMarketSnapshot 3, marketReport 1, weekly per-funzione 1). L'unica eccezione è il nuovo end-multiplex letterale in `renderTopHubPage`, che ha la sua SPEC entry → **17 test (era 16), tutti verdi**.

**Sibling-class (AGENTS.md rule 6)**: `orphanQueryLandingPlugin` ha la stessa forma single-slot ma è **deliberatamente NON toccato** — sono leaf anti-doorway, la superficie più thin del sito; aggiungere densità ad lì rischia l'ad-to-content ratio AdSense. Lasciato a 1 slot.

**Validazione locale**: regression `seo-static-ad-slots` 17/17; weekly-employers 40 + company-city 52 + job-market-snapshot 37 + job-market-sector 34; text-ratio 6 + plugin-output-size 6 (il driveby non rompe ratio/budget); no-hex 18; nofollow-guard verde; tsc 0 nuovi errori sui file toccati.

## Non implementato (ancora)

- **Slot fluid in-content extra** su /oggi (border-wait/fuel-daily) e weekly-employers: richiede restructure del guard `seo-static-ad-slots.test.ts` (FILE_SPECS/SPECS assumono "tutte le call = stesso slot"); aggiungere un secondo tipo di slot letterale rompe l'asserzione → batch dedicato.
- **orphanQueryLandingPlugin driveby**: NO-GO per ad-density su pagine doorway thin (vedi sopra). Se in futuro queste pagine acquisiscono contenuto sostanziale, rivalutare.
- **Ad su festività-ticino + aliquote-imposta-alla-fonte** (5.6k + 6.2k impr GSC/mese): batch editoriale separato (staticPagesPlugin IT + editorialContent EN/DE/FR + SPA).
- **Widget CTR vacanze-scolastiche**: leva traffico più grande (27.724 impr, 0.3% CTR) ma serve widget interattivo + critical-CSS reserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)