### PR TITLE
fix(deploy): cross-shard CDN-push ordering guard for matrix deploy (#2569)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -641,9 +641,38 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      # ── Cross-shard CDN-push ordering guard (#2569 atomicity) ────────────
+      # The non-IT shard HTML was rewritten to reference cdn.frontaliereticino.ch
+      # for /data + /assets (the "Offload shard refs to CDN" step above). The IT
+      # shard pushes THIS build's CDN payload (data/assets) from a SEPARATE
+      # parallel matrix runner with no ordering vs this leg. Publishing this
+      # shard BEFORE the IT CDN push lands this build's payload would put the
+      # live locale ahead of the CDN (refs 404 / serve a prior build's data).
+      # deploy-it-pages-prep.sh stamps DEPLOY_BUILD_ID into the CDN's
+      # cdn-build-id.txt in the SAME force-push as the payload, so this gate —
+      # polling that marker until it equals THIS build's id — only unblocks once
+      # the IT CDN push has atomically published this build. continue-on-error so
+      # a timeout never flips build-locale.result→failure (that would block the
+      # whole Pages publish); instead the gate's outcome gates the publish step
+      # below, so a stuck/failed IT CDN push leaves this shard UNPUBLISHED
+      # (stale, surfaced by the #2658 path) rather than published-ahead.
+      - name: Wait for IT CDN push (cross-shard ordering guard)
+        id: cdn-gate
+        if: matrix.locale != 'it'
+        continue-on-error: true
+        env:
+          DEPLOY_BUILD_ID: ${{ needs.matrix-setup.outputs.build_id }}
+        run: bash scripts/lib/wait-cdn-build-id.sh "${DEPLOY_BUILD_ID}"
+
       - name: Push locale shard
         id: push-shard
-        if: matrix.locale != 'it'
+        # Only publish once the ordering guard confirmed the IT CDN push landed
+        # THIS build (steps.cdn-gate.outcome == 'success'). On a gate timeout the
+        # shard is skipped (NOT pushed ahead of the CDN); the stale-shard
+        # surfacing step below fires on skip|failure so the unpublished locale is
+        # never shipped silently. (cdn-gate is itself a no-op exit-0 when
+        # DEPLOY_BUILD_ID is unset, so non-matrix/local paths are unaffected.)
+        if: matrix.locale != 'it' && steps.cdn-gate.outcome == 'success'
         # Stays continue-on-error (transient shard-repo/network errors must NOT
         # block the whole Pages publish — build-locale has fail-fast:false, a
         # hard failure here would flip build-locale.result→failure→no publish).
@@ -663,12 +692,16 @@ jobs:
         # continue-on-error resilience is deliberate) — but make it LOUD: warning
         # annotation + a deduped tracking issue so the stale locale is never
         # shipped silently. Self-resolves on the next green push (reopen-within).
-        if: matrix.locale != 'it' && steps.push-shard.outcome == 'failure'
+        # Also fires when the #2569 CDN ordering guard timed out (cdn-gate
+        # failure → push-shard SKIPPED): the shard is intentionally NOT published
+        # ahead of the IT CDN push, so the live locale stays stale and must be
+        # surfaced the same way.
+        if: matrix.locale != 'it' && (steps.push-shard.outcome == 'failure' || steps.cdn-gate.outcome == 'failure')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::warning title=Stale locale shard::Push of the ${{ matrix.locale }} shard failed — the live ${{ matrix.locale }} pages serve STALE content until the next successful deploy. Deploy stays green by design (transient-tolerant); investigate the shard repo / deploy key."
+          echo "::warning title=Stale locale shard::Push of the ${{ matrix.locale }} shard did not publish (push failure, or the #2569 CDN ordering guard timed out waiting for the IT CDN push) — the live ${{ matrix.locale }} pages serve STALE content until the next successful deploy. Deploy stays green by design (transient-tolerant); investigate the shard repo / deploy key / IT CDN push."
           node scripts/lib/github-issue-creator.mjs \
             --title "Deploy: ${{ matrix.locale }} locale shard push failed (stale live locale)" \
             --description "## Push locale shard fallito — locale live STALE

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -191,6 +191,14 @@ step_push_cdn() {
   if [ "$payload_bytes" -gt 950000000 ]; then
     echo "::warning::CDN payload ${payload_bytes} bytes (>950 MB) — approaching GitHub Pages ~1 GB soft limit; run the CDN assets/ janitor or split (e.g. keep blog heroes on jsDelivr)"
   fi
+  # Cross-shard atomicity marker (#2569): stamp THIS build's DEPLOY_BUILD_ID
+  # into the CDN payload so it is published in the SAME force-push as the
+  # assets/data. The non-IT shards (en/de/fr) poll cdn.frontaliereticino.ch/
+  # cdn-build-id.txt for this exact id BEFORE publishing → they never go live
+  # referencing a CDN that does not yet hold this build's /data + /assets.
+  # When DEPLOY_BUILD_ID is unset (local run / monolith path) the marker is
+  # written empty — harmless, the shard gate only enforces on a non-empty id.
+  printf '%s' "${DEPLOY_BUILD_ID:-}" > "$stage/cdn-build-id.txt"
   cd "$stage"
   git init -q
   git checkout -q -b main

--- a/scripts/lib/wait-cdn-build-id.sh
+++ b/scripts/lib/wait-cdn-build-id.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# scripts/lib/wait-cdn-build-id.sh — cross-shard CDN-push ordering guard (#2569)
+#
+# In the matrix deploy (.github/workflows/deploy.yml, build-locale) the IT shard
+# pushes the CDN repo (og + data + assets) via deploy-it-pages-prep.sh while the
+# en/de/fr shards push their locale subtrees via push-locale-shard.sh — all on
+# SEPARATE parallel matrix runners with NO ordering between them. The non-IT
+# shard HTML has its /data + /assets refs rewritten to cdn.frontaliereticino.ch
+# (the "Offload shard refs to CDN" step). So if a non-IT shard publishes BEFORE
+# the IT CDN push lands THIS build's payload, the live locale references a CDN
+# that does not yet hold this build's data/assets → inconsistent (shard ahead of
+# CDN) state until the IT leg catches up (or, if IT CDN push fails entirely, the
+# IT leg + Pages deploy fail but en/de/fr may have ALREADY gone live).
+#
+# This guard makes the non-IT shard publish WAIT until the IT CDN push has
+# published THIS build's marker. deploy-it-pages-prep.sh stamps DEPLOY_BUILD_ID
+# into cdn-build-id.txt inside the SAME force-push as the assets/data, so the
+# marker turning equal to the expected id PROVES this build's CDN payload is live
+# (atomic: one force-push publishes the whole tree + the marker together).
+#
+# Usage:
+#   wait-cdn-build-id.sh <expected_build_id>
+#
+# Env (optional, with safe defaults):
+#   CDN_BUILD_ID_URL    marker URL (default https://cdn.frontaliereticino.ch/cdn-build-id.txt)
+#   CDN_WAIT_TIMEOUT_S  total budget in seconds before giving up (default 600)
+#   CDN_WAIT_INTERVAL_S poll interval in seconds (default 15)
+#
+# Exit codes:
+#   0  — the CDN marker matched <expected_build_id> within the timeout, OR the
+#        guard is intentionally a NO-OP (empty expected id → e.g. a local run /
+#        non-matrix path that never sets DEPLOY_BUILD_ID). Safe to publish.
+#   1  — timed out without the CDN reaching this build's id → DO NOT publish the
+#        shard (the caller fails the leg so a stale/ahead shard is never shipped).
+#
+# Deliberately NOT `set -e`: every curl is allowed to fail (CDN not yet updated
+# is the EXPECTED transient case during the poll) and is guarded explicitly.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+expected="${1:-}"
+
+# NO-OP guard: no expected id (local run / non-matrix monolith path that does not
+# set DEPLOY_BUILD_ID) → nothing to gate on, allow the publish exactly as before.
+if [ -z "$expected" ]; then
+  echo "[wait-cdn-build-id] no expected build id (DEPLOY_BUILD_ID unset) — skipping gate (no-op)"
+  exit 0
+fi
+
+url="${CDN_BUILD_ID_URL:-https://cdn.frontaliereticino.ch/cdn-build-id.txt}"
+timeout_s="${CDN_WAIT_TIMEOUT_S:-600}"
+interval_s="${CDN_WAIT_INTERVAL_S:-15}"
+[[ "$timeout_s"  =~ ^[0-9]+$ ]] || timeout_s=600
+[[ "$interval_s" =~ ^[0-9]+$ ]] || interval_s=15
+[ "$interval_s" -ge 1 ] || interval_s=15
+
+echo "[wait-cdn-build-id] gating shard publish on CDN build id=${expected} (url=${url}, timeout=${timeout_s}s, interval=${interval_s}s)"
+
+elapsed=0
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+  # `|| true` (and a literal fallback): under a caller's `set -e`/pipefail a
+  # curl miss (404 / not-yet-published) must NOT abort — it is the expected
+  # transient state we are polling through.
+  got="$(curl -fsS "$url" 2>/dev/null || true)"
+  got="$(printf '%s' "$got" | tr -d '[:space:]')"
+  if [ "$got" = "$expected" ]; then
+    echo "[wait-cdn-build-id] ✅ CDN published build id=${expected} after ${elapsed}s (${attempt} polls) — shard publish unblocked"
+    exit 0
+  fi
+  if [ "$elapsed" -ge "$timeout_s" ]; then
+    echo "::error::[wait-cdn-build-id] timed out after ${elapsed}s waiting for CDN build id=${expected} (last seen='${got}') — NOT publishing this shard ahead of the IT CDN push (#2569 atomicity guard)"
+    exit 1
+  fi
+  echo "[wait-cdn-build-id] CDN id='${got}' != '${expected}' (elapsed ${elapsed}s/${timeout_s}s) — retrying in ${interval_s}s"
+  sleep "$interval_s"
+  elapsed=$((elapsed + interval_s))
+done

--- a/tests/lib/wait-cdn-build-id.test.ts
+++ b/tests/lib/wait-cdn-build-id.test.ts
@@ -1,0 +1,98 @@
+// Tests for scripts/lib/wait-cdn-build-id.sh — the #2569 cross-shard CDN-push
+// ordering guard. The non-IT matrix shards run this before publishing so they
+// never go live ahead of the IT CDN push.
+//
+// We never hit the real CDN: a tiny local file: URL stands in for the marker
+// endpoint (curl supports file://), so the match / no-op / timeout branches are
+// all covered deterministically and fast.
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve, join } from 'node:path';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const SCRIPT = resolve('scripts/lib/wait-cdn-build-id.sh');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(args: string[], env: Record<string, string> = {}): RunResult {
+  try {
+    const stdout = execFileSync('bash', [SCRIPT, ...args], {
+      env: { PATH: process.env.PATH ?? '', ...env },
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+}
+
+function markerUrl(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cdn-build-id-'));
+  const file = join(dir, 'cdn-build-id.txt');
+  writeFileSync(file, contents);
+  return `file://${file}`;
+}
+
+describe('scripts/lib/wait-cdn-build-id.sh', () => {
+  it('is a no-op (exit 0) when no expected build id is given (non-matrix / local path)', () => {
+    const { code, stdout } = run([''], { CDN_WAIT_TIMEOUT_S: '0' });
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/no expected build id/i);
+  });
+
+  it('unblocks (exit 0) when the CDN marker already equals the expected id', () => {
+    const url = markerUrl('1718000000123');
+    const { code, stdout } = run(['1718000000123'], {
+      CDN_BUILD_ID_URL: url,
+      CDN_WAIT_TIMEOUT_S: '5',
+      CDN_WAIT_INTERVAL_S: '1',
+    });
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/CDN published build id=1718000000123/);
+  });
+
+  it('tolerates trailing whitespace/newline in the marker', () => {
+    const url = markerUrl('1718000000123\n');
+    const { code } = run(['1718000000123'], {
+      CDN_BUILD_ID_URL: url,
+      CDN_WAIT_TIMEOUT_S: '5',
+      CDN_WAIT_INTERVAL_S: '1',
+    });
+    expect(code).toBe(0);
+  });
+
+  it('fails (exit 1) when the CDN never reaches the expected id within the timeout', () => {
+    const url = markerUrl('an-older-build-id');
+    const { code, stdout } = run(['the-new-build-id'], {
+      CDN_BUILD_ID_URL: url,
+      CDN_WAIT_TIMEOUT_S: '0', // immediate single-shot poll then give up
+      CDN_WAIT_INTERVAL_S: '1',
+    });
+    expect(code).toBe(1);
+    expect(stdout).toMatch(/timed out/i);
+    expect(stdout).toMatch(/#2569/);
+  });
+
+  it('fails (exit 1) when the marker endpoint is missing (404) and the timeout elapses', () => {
+    const url = `file://${join(tmpdir(), 'does-not-exist-cdn-build-id.txt')}`;
+    const { code, stdout } = run(['some-build-id'], {
+      CDN_BUILD_ID_URL: url,
+      CDN_WAIT_TIMEOUT_S: '0',
+      CDN_WAIT_INTERVAL_S: '1',
+    });
+    expect(code).toBe(1);
+    expect(stdout).toMatch(/timed out/i);
+  });
+});


### PR DESCRIPTION
Closes #2569

## Implementato

Risolve l'atomicità CDN-push cross-shard del deploy matrix (item 2 di #2569) con un **guard di ordinamento**: gli shard non-IT (en/de/fr) non pubblicano finché la CDN push del leg IT non ha pubblicato il payload di QUESTA build.

- **`scripts/lib/deploy-it-pages-prep.sh`** — `step_push_cdn` ora scrive `DEPLOY_BUILD_ID` in `cdn-build-id.txt` dentro lo stage CDN, così il marker viene pubblicato nella STESSA `git push -f` di og/data/assets (atomico: una sola force-push pubblica payload + marker insieme). Marker vuoto quando `DEPLOY_BUILD_ID` è unset (run locale / path monolite) → innocuo.
- **`scripts/lib/wait-cdn-build-id.sh`** (nuovo) — poll di `https://cdn.frontaliereticino.ch/cdn-build-id.txt` finché == build id atteso, con budget timeout bounded (default 600s, interval 15s, override via env). Exit 0 al match o quando il build id atteso è vuoto (no-op per path non-matrix/locale); exit 1 al timeout. Non usa `set -e`: ogni curl-miss durante il poll è lo stato transiente atteso, guardato esplicitamente (AGENTS.md GHA bash `set -e`).
- **`.github/workflows/deploy.yml`** — nuovo step `Wait for IT CDN push (cross-shard ordering guard)` (id `cdn-gate`, `matrix.locale != 'it'`, `continue-on-error`) prima di `Push locale shard`; il push shard ora è gated su `steps.cdn-gate.outcome == 'success'`. Al timeout del guard lo shard viene **skippato** (non pubblicato ahead della CDN) e lo step di surfacing #2658 (esteso a `cdn-gate.outcome == 'failure'`) segnala lo shard stale invece di shipparlo silenziosamente.
- **`tests/lib/wait-cdn-build-id.test.ts`** (nuovo) — 5 test: no-op (id vuoto), match (marker == id via `file://`), trim whitespace, timeout (id mai raggiunto), 404 marker. Tutti verdi.

Item 1 di #2569 (flip `LOCALE_MATRIX_BUILD` → default ON) è **già soddisfatto**: la repo variable `LOCALE_MATRIX_BUILD=true` è già settata (verificato: `gh variable list` → `LOCALE_MATRIX_BUILD  true  2026-06-22T06:34:10Z`). Nessuna azione richiesta su item 1.

Byte-equivalence (`deploy-matrix-experiment.yml` job `compare`): preservata — `cdn-build-id.txt` va nello stage del repo CDN, NON in `dist/`, quindi non tocca i manifest dist confrontati da `compare-dist-manifests.mjs`.

## Non implementato (ancora)

- **Validazione end-to-end pre-merge del guard**: il path matrix di `deploy.yml` (`build:ci`/CDN push/shard push) gira SOLO post-merge su `main` — non è verificabile sul `pull_request`. **Revert-trigger esplicito**: se il prossimo deploy matrix regredisce (es. il guard si incastra su un leg e blocca la pubblicazione shard nonostante una CDN push IT riuscita, o il timeout 600s si rivela troppo stretto per la propagazione raw.githubusercontent del marker) → revert di questa PR. Mitigazione già inclusa: il guard è `continue-on-error` (un timeout NON flippa `build-locale.result→failure`, quindi non blocca la Pages publish del leg IT) e al timeout lo shard resta stale + segnalato via #2658, non bloccato per sempre.
- **Tuning del timeout/interval** (600s/15s): scelti conservativi; un eventuale aggiustamento è follow-up dopo osservazione dei tempi reali di propagazione del marker CDN sul primo deploy matrix.
- **Sibling `build-plugins/constants.ts`** (flaggato da `check-sibling-patterns.mjs` per il token condiviso `DEPLOY_BUILD_ID`): NON toccato e non in scope — `constants.ts` è il *produttore* del build-id (`process.env.DEPLOY_BUILD_ID` → `BUILD_ID`/`dist/build-id.txt`), mentre questa PR aggiunge un *consumatore* distinto della stessa env var per un marker CDN. Nessun antipattern condiviso (nessuna regex/guard/floor duplicata da estrarre); solo riuso della stessa variabile d'ambiente canonica.