### PR TITLE
fix(i18n): add missing jobAlert.error.generic key in all 4 locales (main red)

### DIFF
--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -823,6 +823,7 @@ const deCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Ihre Alerts',
  'jobAlert.loading': 'Alerts werden geladen...',
  'jobAlert.error.emptyFields': 'Geben Sie mindestens ein Stichwort oder ein Gebiet ein.',
+ 'jobAlert.error.generic': 'Alert konnte nicht erstellt werden. Bitte erneut versuchen.',
  'jobAlert.sector': 'Branche',
  'jobAlert.edit': 'Bearbeiten',
  'jobAlert.updated': 'Alert aktualisiert.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -820,6 +820,7 @@ const enCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Your alerts',
  'jobAlert.loading': 'Loading alerts...',
  'jobAlert.error.emptyFields': 'Enter at least one keyword or area.',
+ 'jobAlert.error.generic': 'Could not create the alert. Please try again.',
  'jobAlert.sector': 'Sector',
  'jobAlert.edit': 'Edit',
  'jobAlert.updated': 'Alert updated.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -823,6 +823,7 @@ const frCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Vos alertes',
  'jobAlert.loading': 'Chargement des alertes...',
  'jobAlert.error.emptyFields': 'Saisissez au moins un mot-clé ou une zone.',
+ 'jobAlert.error.generic': 'Impossible de créer l\'alerte. Réessayez.',
  'jobAlert.sector': 'Secteur',
  'jobAlert.edit': 'Modifier',
  'jobAlert.updated': 'Alerte mise à jour.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -860,6 +860,7 @@ const translations: Record<string, string> = {
  'jobAlert.yourAlerts': 'Le tue alert',
  'jobAlert.loading': 'Caricamento alert...',
  'jobAlert.error.emptyFields': 'Inserisci almeno una keyword o una zona.',
+ 'jobAlert.error.generic': 'Errore durante la creazione dell\'alert. Riprova.',
  'jobAlert.sector': 'Settore',
  'jobAlert.edit': 'Modifica',
  'jobAlert.updated': 'Alert aggiornata.',


### PR DESCRIPTION
## Implementato

**Fix main-red.** `components/community/JobAlertForm.tsx:229` chiama `t("jobAlert.error.generic")` ma la chiave non era mai stata aggiunta ai file locale → `tests/i18n-completeness.test.ts` falliva con 4 errori (`Missing keys in 'it'/'en'/'de'/'fr': jobAlert.error.generic`), rosso ereditato da ogni branch via merge (vitest shard 1/4 rosso su PR #2760 e successive).

Aggiunta la chiave accanto a `jobAlert.error.emptyFields` in tutti e 4 i core:
- `it`: "Errore durante la creazione dell'alert. Riprova."
- `en`: "Could not create the alert. Please try again."
- `de`: "Alert konnte nicht erstellt werden. Bitte erneut versuchen."
- `fr`: "Impossible de créer l'alerte. Réessayez."

Bonus: ora il toast d'errore del job-alert mostra il messaggio localizzato invece del fallback IT hardcoded.

Verificato locale: `tests/i18n-completeness.test.ts` 16/16 (era 4 failed).

## Non implementato (ancora)

Nessuno scope aggiuntivo: fix chirurgico a una sola classe (chiave locale mancante). Il guard `i18n-completeness` resta la rete che ha catturato il problema — nessun nuovo test necessario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)