### PR TITLE
fix(i18n): add missing jobAlert.error.generic key (main-red unblock)

### DIFF
--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -823,6 +823,7 @@ const deCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Ihre Alerts',
  'jobAlert.loading': 'Alerts werden geladen...',
  'jobAlert.error.emptyFields': 'Geben Sie mindestens ein Stichwort oder ein Gebiet ein.',
+ 'jobAlert.error.generic': 'Beim Erstellen des Alerts ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.',
  'jobAlert.sector': 'Branche',
  'jobAlert.edit': 'Bearbeiten',
  'jobAlert.updated': 'Alert aktualisiert.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -820,6 +820,7 @@ const enCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Your alerts',
  'jobAlert.loading': 'Loading alerts...',
  'jobAlert.error.emptyFields': 'Enter at least one keyword or area.',
+ 'jobAlert.error.generic': 'Something went wrong creating your alert. Please try again.',
  'jobAlert.sector': 'Sector',
  'jobAlert.edit': 'Edit',
  'jobAlert.updated': 'Alert updated.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -823,6 +823,7 @@ const frCore: Record<string, string> = {
  'jobAlert.yourAlerts': 'Vos alertes',
  'jobAlert.loading': 'Chargement des alertes...',
  'jobAlert.error.emptyFields': 'Saisissez au moins un mot-clé ou une zone.',
+ 'jobAlert.error.generic': "Une erreur s'est produite lors de la création de l'alerte. Veuillez réessayer.",
  'jobAlert.sector': 'Secteur',
  'jobAlert.edit': 'Modifier',
  'jobAlert.updated': 'Alerte mise à jour.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -860,6 +860,7 @@ const translations: Record<string, string> = {
  'jobAlert.yourAlerts': 'Le tue alert',
  'jobAlert.loading': 'Caricamento alert...',
  'jobAlert.error.emptyFields': 'Inserisci almeno una keyword o una zona.',
+ 'jobAlert.error.generic': "Errore durante la creazione dell'alert. Riprova.",
  'jobAlert.sector': 'Settore',
  'jobAlert.edit': 'Modifica',
  'jobAlert.updated': 'Alert aggiornata.',


### PR DESCRIPTION
## Implementato

- Aggiunta la chiave i18n mancante `jobAlert.error.generic` in tutti e 4 i locale core (`it/en/de/fr-core.ts`), accanto a `jobAlert.error.emptyFields`.
- `components/community/JobAlertForm.tsx:229` chiama `t('jobAlert.error.generic')` (toast di errore creazione alert) ma la chiave non era mai stata definita → `tests/i18n-completeness.test.ts` falliva su **ogni branch** (`Missing keys in 'it'/'en'/'de'/'fr': jobAlert.error.generic`).
- **main è rosso** su questo test (run `tests` su `main` = failure); con il gate auto-merge che attende `tests` verde, blocca il merge di tutte le PR aperte. Questo fix sblocca la cascata.
- Test `i18n-completeness` verde in locale (16/16) dopo il fix.

## Non implementato (ancora)

- Nessun altro scope: fix chirurgico a singola chiave. Il messaggio IT combacia col fallback già hardcoded nel componente (`"Errore durante la creazione dell'alert."`); en/de/fr tradotti coerentemente con il tono dei messaggi vicini.
- Non toccato il branch foreign `fix/jobalert-error-generic-i18n` (worktree parallelo non committato, con un duplicato di chiave in `de-core.ts` e nessuna PR) — lasciato intatto come lavoro altrui; questo PR è la versione pulita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)