### PR TITLE
fix(article-gen): defer on quality reject instead of hard-failing the run

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -7149,6 +7149,33 @@ function wallBudgetExceeded() {
   return (Date.now() - RUN_START_MS) > RUN_WALL_BUDGET_MS;
 }
 
+/**
+ * True when the error is a CONTENT/QUALITY rejection (fact-check block,
+ * topic-gate REGOLA #0 abort, fabrication, or a non-conformant headline that
+ * survived its retry budget) rather than an infrastructure bug.
+ *
+ * Such rejections mean "no acceptable article this run" — exactly the same
+ * disposition as a duplicate or an exhausted free-model pool. The retry loops
+ * rotate to the next headline/keyword on these; if every candidate is
+ * exhausted the run defers cleanly (exit 0) instead of hard-failing and raising
+ * a false-positive "Workflow Failure: Generate Blog Article" Bug issue
+ * (run 28000585473: a too-long headline after retry crashed the run with
+ * exit 1 → spurious issue #2750).
+ *
+ * Per CLAUDE.md non-negotiable #1 the quality gate itself is NEVER lowered —
+ * the slop is still refused; we only reclassify the disposition from
+ * "infrastructure failure" to "clean deferral". Single source of truth so the
+ * proven-pool catch, the evergreen catch, and the top-level main().catch can
+ * never drift apart (non-negotiable #6).
+ */
+function isQualityRejectError(e) {
+  if (!e) return false;
+  if (e.qualityReject === true || e.topicGateAbort === true) return true;
+  return /fact-check|rigettato|veridicità|fabricat|topic-gate abort|headline validation failed/i.test(
+    String(e.message || ''),
+  );
+}
+
 async function main() {
   // Positional <url> = first non-flag argv (so `--section=` can precede it).
   let url = process.argv.slice(2).find((a) => !a.startsWith('--'));
@@ -7571,8 +7598,7 @@ async function main() {
             // 2026-05-11). Same quality outcome (slop not published)
             // but workflow stays green and retry budget is honored.
             const isTopicGateAbort = e.topicGateAbort === true || /topic-gate abort/i.test(e.message);
-            const isQualityReject = isTopicGateAbort
-              || /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
+            const isQualityReject = isQualityRejectError(e);
             if (isQualityReject && attempt < MAX_DUPLICATE_RETRIES) {
               const tag = isTopicGateAbort ? 'topic-gate (REGOLA #0)' : 'qualità';
               console.error(`\n⚠️  Articolo rigettato per ${tag} — provo un altro headline... (${attempt}/${MAX_DUPLICATE_RETRIES})\n`);
@@ -7727,8 +7753,7 @@ async function main() {
           // Includes REGOLA #0 topic-gate aborts — same rationale as the proven-pool
           // branch above (~line 5946).
           const isTopicGateAbort = e.topicGateAbort === true || /topic-gate abort/i.test(e.message);
-          const isQualityReject = isTopicGateAbort
-            || /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
+          const isQualityReject = isQualityRejectError(e);
           if (!isDuplicate && !isQualityReject) throw e; // Infrastructure error → propagate
 
           if (isTopicGateAbort) {
@@ -7961,13 +7986,20 @@ async function generateAndValidateArticle(url, sourceContext = null) {
           continue;
         }
 
-        // Budget exhausted — hard-fail the run rather than publish a
-        // non-conformant article. Per CLAUDE.md rule #1: never lower
-        // validation thresholds as a workaround.
-        throw new Error(
+        // Budget exhausted — refuse to publish a non-conformant article. Per
+        // CLAUDE.md rule #1 we NEVER lower the validation threshold; the slop is
+        // dropped. But this is a content/quality rejection (the free model kept
+        // emitting an over-length title), NOT an infrastructure bug — tag it so
+        // the retry loops rotate to the next headline/keyword and, if every
+        // candidate is exhausted, the run defers cleanly (exit 0) instead of
+        // hard-failing and raising a spurious "Workflow Failure" Bug issue
+        // (run 28000585473 → issue #2750).
+        const headlineErr = new Error(
           `Headline validation failed after retry. ` +
           `Title: "${itTitle}" — Errors: ${summary}`,
         );
+        headlineErr.qualityReject = true;
+        throw headlineErr;
       }
 
       // Step 3a.0-titlesync: ensure <title> ↔ <h1> sync.
@@ -8427,6 +8459,17 @@ main().catch((e) => {
   if (isQuotaExhaustedError(e)) {
     finalizeRunReport('deferred', { notes: [...RUN_REPORT.notes, `Deferred (all free models exhausted): ${e.message}`] });
     console.error(`\n⚠️  Differito: tutti i modelli AI gratuiti sono temporaneamente esauriti (quota giornaliera). Riprovo al prossimo run. ${e.message}`);
+    process.exit(0);
+  }
+  // Content/quality rejection that bubbled all the way up (e.g. manual-URL mode,
+  // or every headline/keyword in a loop exhausted on quality grounds). The slop
+  // was correctly NOT published — but "no acceptable article this run" is a clean
+  // deferral, not an infrastructure failure: exit 0 so the self-trigger back-off
+  // retries later instead of marking the run red and raising a false-positive
+  // "Workflow Failure: Generate Blog Article" Bug issue (run 28000585473 → #2750).
+  if (isQualityRejectError(e)) {
+    finalizeRunReport('deferred', { notes: [...RUN_REPORT.notes, `Deferred (content quality rejected, slop not published): ${e.message}`] });
+    console.error(`\n⚠️  Differito: nessun articolo conforme prodotto in questa run (rigetto qualità — slop non pubblicato). Riprovo al prossimo run. ${e.message}`);
     process.exit(0);
   }
   finalizeRunReport('error', { notes: [...RUN_REPORT.notes, `Error: ${e.message}`] });

--- a/tests/topic-gate-abort-retry.test.ts
+++ b/tests/topic-gate-abort-retry.test.ts
@@ -38,7 +38,10 @@ describe('topic-gate-abort recovery in headline retry loops', () => {
     expect(provenBlock, 'proven-pool quality-reject block not found').toBeTruthy();
     expect(provenBlock![0]).toMatch(/e\.topicGateAbort\s*===\s*true/);
     expect(provenBlock![0]).toMatch(/\/topic-gate abort\/i/);
-    expect(provenBlock![0]).toMatch(/isQualityReject\s*=\s*isTopicGateAbort/);
+    // The quality decision is now delegated to the shared isQualityRejectError
+    // helper so the proven-pool catch, evergreen catch, and main().catch can
+    // never drift apart (CLAUDE.md non-negotiable #6).
+    expect(provenBlock![0]).toMatch(/isQualityReject\s*=\s*isQualityRejectError\(e\)/);
   });
 
   it('recognises err.topicGateAbort and the message pattern at the evergreen catch site', () => {
@@ -66,5 +69,63 @@ describe('topic-gate-abort recovery in headline retry loops', () => {
     );
     expect(provenBlock).toBeTruthy();
     expect(provenBlock!.length).toBeGreaterThanOrEqual(2); // both call sites
+  });
+});
+
+/**
+ * Regression test for the headline-validation hard-fail incident
+ * (run 28000585473 → spurious Bug issue #2750, 2026-06-23).
+ *
+ * A free-tier model kept emitting an over-length IT title (>110 char); after
+ * the headline retry budget was spent, create-article.mjs threw
+ * `Headline validation failed after retry`. That message did NOT match the
+ * quality-reject regex, so it propagated as an infrastructure error: the run
+ * exited 1, the workflow went red, and the `if: failure()` step opened a
+ * false-positive "Workflow Failure" Bug issue — even though "no conformant
+ * headline this run" is the SAME benign disposition as a fact-check reject.
+ *
+ * Fix: the throw is tagged `err.qualityReject = true`, and a single shared
+ * `isQualityRejectError(e)` helper recognises every content-rejection shape
+ * (topic-gate abort, fact-check, fabrication, non-conformant headline). The
+ * retry loops rotate; if exhausted, main().catch defers cleanly (exit 0). Per
+ * CLAUDE.md non-negotiable #1 the headline gate itself is untouched — slop is
+ * still refused, only the disposition changes from failure to deferral.
+ */
+describe('headline-validation reject defers instead of hard-failing', () => {
+  it('the headline-validation throw site tags the error as a quality reject', () => {
+    const block = SRC.match(
+      /Headline validation failed after retry[\s\S]*?throw headlineErr;/,
+    );
+    expect(block, 'headline-validation throw block not found').toBeTruthy();
+    expect(block![0]).toMatch(/\.qualityReject\s*=\s*true/);
+  });
+
+  it('a single isQualityRejectError helper recognises every content-rejection shape', () => {
+    const helper = SRC.match(
+      /function isQualityRejectError\(e\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(helper, 'isQualityRejectError helper not found').toBeTruthy();
+    const body = helper![0];
+    // Flag shapes (fast path).
+    expect(body).toMatch(/e\.qualityReject\s*===\s*true/);
+    expect(body).toMatch(/e\.topicGateAbort\s*===\s*true/);
+    // Message-pattern fallback covers fact-check, fabrication, topic-gate, and
+    // the headline-validation failure that triggered #2750.
+    expect(body).toMatch(/fact-check/);
+    expect(body).toMatch(/fabricat/);
+    expect(body).toMatch(/topic-gate abort/);
+    expect(body).toMatch(/headline validation failed/);
+  });
+
+  it('main().catch defers (exit 0) on a quality reject, not exit 1', () => {
+    // The top-level catch must treat a bubbled-up quality reject the same as an
+    // exhausted free-model pool: finalize as deferred and exit 0 so the
+    // self-trigger back-off retries — never raise a spurious failure issue.
+    const tail = SRC.slice(SRC.indexOf('main().catch'));
+    expect(tail).toMatch(/if\s*\(isQualityRejectError\(e\)\)\s*\{/);
+    const guard = tail.match(/if\s*\(isQualityRejectError\(e\)\)\s*\{[\s\S]*?process\.exit\(0\);/);
+    expect(guard, 'quality-reject guard in main().catch not found').toBeTruthy();
+    expect(guard![0]).toMatch(/finalizeRunReport\('deferred'/);
+    expect(guard![0]).toMatch(/process\.exit\(0\)/);
   });
 });


### PR DESCRIPTION
## Contesto

Run [28000585473](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28000585473) (Generate Blog Article) è fallita con exit 1 → step rosso → `if: failure()` ha aperto l'issue spuria **#2750** "Workflow Failure".

Causa root: un modello free-tier ha continuato a emettere un titolo IT >110 char; esaurito il retry budget, `create-article.mjs` lanciava `Headline validation failed after retry`. Quel messaggio **non** matchava nessun pattern di quality-reject (`/fact-check|rigettato|veridicità|fabricat/`) → propagava come errore infrastrutturale (exit 1). Ma "nessun headline conforme in questa run" è la **stessa disposizione benigna** di un fact-check reject o di un pool free esaurito: lo slop va rifiutato, ma la run deve **differire**, non fallire.

## Implementato

- **Tag del throw headline**: l'errore di `validateHeadline` esaurito-budget ora porta `err.qualityReject = true` (rispecchia il pattern esistente `err.topicGateAbort`). Il gate >110 char resta invariato — nessuna soglia abbassata (non-negotiable #1).
- **Helper condiviso `isQualityRejectError(e)`**: unico source-of-truth che riconosce ogni forma di content-rejection (flag `qualityReject`/`topicGateAbort`, + regex su `fact-check|rigettato|veridicità|fabricat|topic-gate abort|headline validation failed`). Sostituisce la regex duplicata **letteralmente** nei due catch block (non-negotiable #6).
- **Uso dell'helper ai tre siti**: catch proven-pool, catch evergreen, e `main().catch` — così non possono driftare.
- **Deferral in `main().catch`**: su quality-reject bubbled-up ora `finalizeRunReport('deferred')` + `process.exit(0)` (identico al ramo quota-exhausted già esistente), invece di exit 1 + issue spuria. Il self-trigger back-off riprova al prossimo run.
- I retry loop già ruotavano su fact-check/topic-gate; ora ruotano anche su headline non-conforme → gli articoli continuano a essere prodotti, la run differisce solo quando **ogni** candidato fallisce.
- **Test**: esteso `tests/topic-gate-abort-retry.test.ts` (62→nuovi casi) con il contratto dell'helper, il tag `qualityReject` sul throw, e il deferral exit-0 in `main().catch`. `npm run test:articles` verde (62 test), suite topic-gate verde (7 test).

## Non implementato (ancora)

- **Troncamento deterministico del titolo a ≤110 char come last-resort** (invece di rifiutare): out of scope e più rischioso — un titolo LLM tagliato a parola può risultare goffo e degradare il `<title>` SEO. Il deferral + rotazione produce comunque un articolo conforme dal candidato successivo. Eventuale follow-up se i deferral per-headline diventano frequenti.
- **Verifica live end-to-end del nuovo path di deferral**: il prossimo run notturno con pool free esaurito è il banco di prova naturale; non riproducibile in CI pre-merge senza esaurire i modelli reali. Se un futuro run di sole-quality-reject dovesse ancora finire rosso → riaprire.

Closes #2750

🤖 Generated with [Claude Code](https://claude.com/claude-code)