### PR TITLE
fix(analytics): guard lazy-proxy deref — kill the #1 runtime exception (undefined Analytics export)

### DIFF
--- a/services/analyticsProxy.ts
+++ b/services/analyticsProxy.ts
@@ -15,7 +15,21 @@ export const Analytics: Record<string, (...a: unknown[]) => void> = new Proxy(
  {
  get: (_t, method: string) =>
  (...args: unknown[]) => {
- import('@/services/analytics').then(m => (m.Analytics as any)[method](...args));
+ // Guard + catch like the sibling lazy helpers below (lines 28, 37): a
+ // stale-deploy chunk can resolve the dynamic import to a module whose
+ // `Analytics` export is undefined, so `m.Analytics[method]` throws and —
+ // with no `.catch()` — surfaces as an unhandledrejection captured by the
+ // handler in analytics.ts. That is the site's #1 runtime exception:
+ // Safari phrases it `undefined is not an object (evaluating 't.Analytics[i]')`,
+ // V8 `Cannot read properties of undefined (reading 'trackFunnelStep')` —
+ // same null-deref, different engine wording. Analytics is fire-and-forget,
+ // so swallow both the missing-export case and any throw inside the call.
+ import('@/services/analytics')
+ .then((m) => {
+ const fn = (m.Analytics as any)?.[method];
+ if (typeof fn === 'function') fn(...args);
+ })
+ .catch(() => {});
  },
  },
 );


### PR DESCRIPTION
## Implementato

Fix dell'eccezione runtime **#1 del sito** (~58 in 7gg su `/cerca-lavoro-ticino/` + ~25 altrove, correlata all'~83% di abbandono sul job board).

**Root cause** (un solo bug, da indagine PostHog $exception): `services/analyticsProxy.ts:18` faceva `import('@/services/analytics').then(m => (m.Analytics as any)[method](...args))` **senza guard né `.catch()`**, a differenza dei sibling lazy (righe 28, 37) e di `lazyRetry.ts` che fanno tutti `.catch(() => {})`. Su un chunk di deploy stale l'import risolve un modulo con export `Analytics` undefined → `m.Analytics[method]` throwa nel `.then` → unhandledrejection → catturata dall'handler in `analytics.ts:1046` → PostHog.

I due "errori" osservati sono **lo stesso null-deref**, phrasing diverso per engine:
- Safari/WebKit: `undefined is not an object (evaluating 't.Analytics[i]')` (58×, `t`=`m`, `i`=method minificato) — 100% iOS Safari/Firefox iOS.
- V8: `Cannot read properties of undefined (reading 'trackFunnelStep')` (~25×).

(La memo `n.getApp` è obsoleta: quell'errore non compare più.)

**Fix**: optional-chaining guard + `.catch()`, coerente col pattern già usato:
```ts
import('@/services/analytics')
  .then((m) => { const fn = (m.Analytics as any)?.[method]; if (typeof fn === 'function') fn(...args); })
  .catch(() => {});
```
Analytics è fire-and-forget → droppare l'evento su un chunk rotto è corretto. Nessun impatto SEO/ad/monetizzazione.

**Sweep classe (AGENTS.md §6)**: gli altri deref dinamici `m.Analytics.X` (`lazyRetry.ts:35/53/74`) hanno **già** `.catch()` → non sfuggono; questo era l'unico non protetto. `check-sibling-patterns` verde.

## Non implementato (ancora)

- **Perché `m.Analytics` è undefined** (version-skew/chunk stale): è il sintomo che il guard neutralizza; la causa a monte (gestione stale-deploy) è già coperta altrove (#9f4b43fdb31) ed è fuori scope.
- **Test**: il proxy è fire-and-forget e l'errore è asincrono (unhandledrejection) — non testabile in modo sincrono non-flaky; i sibling identici (`lazyRetry`, righe 28/37) sono parimenti non testati. Verifica = calo del conteggio `$exception` PostHog post-deploy (`t.Analytics[i]` + `trackFunnelStep`-undefined → ~0).