### PR TITLE
fix(canton): reconcile ALL stale ledger sections to current canton (recovery → live page, not dead canton)

### DIFF
--- a/scripts/migrate-all-known-job-slugs-canton-aware.mjs
+++ b/scripts/migrate-all-known-job-slugs-canton-aware.mjs
@@ -29,7 +29,7 @@
 // path verbatim — resolveCantonSection short-circuits on 'TI'.
 import fs from 'node:fs';
 import path from 'node:path';
-import { createCantonResolvers, SECTION_LEGACY_TI } from '../build-plugins/shared/cantonResolvers.mjs';
+import { createCantonResolvers } from '../build-plugins/shared/cantonResolvers.mjs';
 
 const TRACKING_PATH = path.resolve('data/all-known-job-slugs.json');
 const JOBS_PATH = path.resolve('data/jobs.json');
@@ -73,12 +73,6 @@ for (const job of jobs) {
   }
 }
 
-// 2. Pre-compute TI legacy path prefixes for cheap matching.
-const TI_PATH_PREFIX = {};
-for (const locale of LOCALES) {
-  TI_PATH_PREFIX[locale] = `${LOCALE_PREFIX[locale]}/${SECTION_LEGACY_TI[locale]}/`;
-}
-
 let rewritten = 0;
 let kept = 0;
 let orphanKept = 0;
@@ -98,22 +92,38 @@ for (const [trackingSlug, entry] of Object.entries(tracking)) {
   }
   const canton = resolveJobCanton({ canton: job.canton, location: job.location });
   cantonStats.set(canton, (cantonStats.get(canton) || 0) + 1);
-  if (canton === 'TI') {
-    kept++;
-    out[trackingSlug] = entry;
-    continue;
-  }
+  // Reconcile EVERY locale path to the job's CURRENT canton section — not only
+  // TI→canton. The old `if (!oldPath.startsWith(tiPrefix)) continue` skipped any
+  // path already on a non-TI section, so a job that later migrated BETWEEN non-TI
+  // cantons (e.g. ZH→BE) kept its first non-TI section forever → the canon map /
+  // 404 bridge then 301'd the orphan to a canton where the live page no longer
+  // exists (a redirect to a dead page, never recovered). Replacing only the
+  // SECTION segment and keeping the rest (slug + trailing slash) verbatim keeps
+  // the slug-body invariant (tests/migrate-all-known-job-slugs-canton-aware.test.ts)
+  // and makes a TI job a natural no-op (resolveCantonSection('TI') returns the
+  // legacy TI section), so TI invariance still holds without a special-case.
   const newEntry = { ...entry };
   let touched = false;
   for (const locale of LOCALES) {
     const oldPath = entry[locale];
-    if (typeof oldPath !== 'string') continue;
-    const tiPrefix = TI_PATH_PREFIX[locale];
-    if (!oldPath.startsWith(tiPrefix)) continue; // already canton-aware or hand-edited
-    const remainder = oldPath.slice(tiPrefix.length);
+    if (typeof oldPath !== 'string' || !oldPath.startsWith('/')) continue;
+    const lp = LOCALE_PREFIX[locale]; // '', '/en', '/de', '/fr'
+    let afterLp;
+    if (lp) {
+      if (!oldPath.startsWith(`${lp}/`)) continue; // locale-prefix mismatch — leave it
+      afterLp = oldPath.slice(lp.length);
+    } else {
+      afterLp = oldPath;
+    }
+    const m = afterLp.match(/^\/([^/]+)\/(.*)$/); // [, section, rest]
+    if (!m) continue; // not a /<section>/<slug> path — leave it
+    const rest = m[2]; // slug body + any trailing slash, preserved verbatim
     const newSection = resolveCantonSection(locale, canton);
-    newEntry[locale] = `${LOCALE_PREFIX[locale]}/${newSection}/${remainder}`.replace(/\/+/g, '/');
-    touched = true;
+    const newPath = `${lp}/${newSection}/${rest}`;
+    if (newPath !== oldPath) {
+      newEntry[locale] = newPath;
+      touched = true;
+    }
   }
   if (touched) rewritten++;
   else kept++;

--- a/tests/migrate-all-known-job-slugs-canton-aware.test.ts
+++ b/tests/migrate-all-known-job-slugs-canton-aware.test.ts
@@ -75,6 +75,47 @@ describe('migrate-all-known-job-slugs-canton-aware', () => {
     expect(entry.source).toBe('gsc-404-import');
   });
 
+  it('reconciles a stale NON-TI section to the job current canton (ZH→BE drift)', () => {
+    // The old migration only rewrote TI-prefixed paths, so a job that migrated
+    // between non-TI cantons kept its first non-TI section forever → recovery
+    // 301'd the orphan to a dead canton. The fix reconciles every section.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-canton-drift-'));
+    tmpDirs.push(tmp);
+    const dataDir = path.join(tmp, 'data');
+    fs.mkdirSync(dataDir);
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-url-slugs.json'), path.join(dataDir, 'canton-url-slugs.json'));
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-municipalities.json'), path.join(dataDir, 'canton-municipalities.json'));
+
+    const cantonSlugs = JSON.parse(fs.readFileSync(path.join(dataDir, 'canton-url-slugs.json'), 'utf-8'));
+    const zhItSlug = cantonSlugs.cantons.ZH.it;
+    const beItSlug = cantonSlugs.cantons.BE.it;
+    const SLUG = 'projektleiter-acme-bern';
+
+    // Job is now in BE, but its ledger entry is stale on the ZH section.
+    fs.writeFileSync(path.join(dataDir, 'jobs.json'), JSON.stringify([
+      { id: 'j3', slug: SLUG, canton: 'BE', location: 'Bern', slugByLocale: { it: SLUG, en: SLUG, de: SLUG, fr: SLUG } },
+    ]));
+    fs.writeFileSync(path.join(dataDir, 'all-known-job-slugs.json'), JSON.stringify({
+      [SLUG]: {
+        it: `/cerca-lavoro-${zhItSlug}/${SLUG}/`,
+        en: `/en/find-jobs-zurich/${SLUG}/`,
+        de: `/de/jobs-in-zurich/${SLUG}/`,
+        fr: `/fr/trouver-emploi-zurich/${SLUG}/`,
+      },
+    }));
+
+    execFileSync('node', [SCRIPT], { cwd: tmp, stdio: 'pipe' });
+
+    const out = JSON.parse(fs.readFileSync(path.join(dataDir, 'all-known-job-slugs.json'), 'utf-8'));
+    const entry = out[SLUG];
+    expect(entry.it).toBe(`/cerca-lavoro-${beItSlug}/${SLUG}/`);
+    expect(entry.it).not.toContain(`cerca-lavoro-${zhItSlug}`);
+    // Slug body preserved verbatim across all locales.
+    for (const loc of ['it', 'en', 'de', 'fr'] as const) {
+      expect(entry[loc].endsWith(`/${SLUG}/`)).toBe(true);
+    }
+  });
+
   it('leaves TI jobs untouched (invariance)', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-canton-ti-'));
     tmpDirs.push(tmp);


### PR DESCRIPTION
## Contesto — item #1 della «coda» residua

Il ledger `data/all-known-job-slugs.json` alimenta il **canon-map** (worker 301 en/de/fr) e il **cfHot404 bridge** (IT): il recovery di un orphan ricostruisce `<sezione-ledger>/<slug>/`. `migrate-all-known-job-slugs-canton-aware.mjs` riscriveva SOLO le entry ancora sulla sezione TI (`if (!oldPath.startsWith(tiPrefix)) continue`), assumendo che ogni path non-TI fosse già corretto.

**Bug:** un job migrato TRA cantoni non-TI (es. ZH→BE, o un job di St-Moritz mis-sezionato TI→GR) manteneva per sempre la prima sezione non-TI → il recovery 301-ava l'orphan verso un cantone dove la pagina live NON esiste più (redirect verso una 404, mai recuperato). È la classe «67 stale» segnalata nel residuo — misurata ora a **2.046 entry**.

## Implementato

- `scripts/migrate-all-known-job-slugs-canton-aware.mjs`: riconcilia OGNI path locale alla sezione del **cantone corrente** del job (non solo TI→canton). Sostituisce solo il segmento **sezione**, mantiene il resto (slug + slash finale) verbatim → l'invariante slug-body resta (test) e un job TI è un no-op naturale (`resolveCantonSection('TI')` → sezione legacy TI), quindi l'invarianza TI regge senza short-circuit. Rimosso il `TI_PATH_PREFIX` + import `SECTION_LEGACY_TI` ora morti.
- `tests/migrate-all-known-job-slugs-canton-aware.test.ts`: nuovo caso non-TI→non-TI (ZH→BE) che il vecchio codice mancava; i casi esistenti (TI→ZH + invarianza TI) restano verdi. **3/3 verde.**

**Verifica live:** misurato sul ledger reale → **2.046 entry stale riconciliate** al cantone corretto (1.4% di 145k). Campioni verificati live: la pagina spostata risolve **200 al cantone riconciliato** (es. `…st-moritz` ora `/cerca-lavoro-grigioni/…` 200; St. Moritz è in GR, non TI). Il ledger committato viene rigenerato+riconciliato dal prossimo run CI (deploy / sync-gsc-orphans) → **questa PR è script+test only** (niente dump da 40MB nel diff).

## Non implementato (ancora)

- **Recupero IT istantaneo** (no worker sull'apex, solo bridge deploy-time lag ~24h; costo worker cap già sfondato) e **long-tail sotto min-hits=2** (rischio OOM SSG, serve build misurato): item residui della coda, trade-off infra/OOM — non in scope qui.
- **Slug bad-translation pre-ledger** (es. `search-team-leader-…`): non in nessun ledger → non riconciliabili da questo fix.
- **Spike errori JS client-side** ~2.8%: concern separato non-404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)