### PR TITLE
feat(outreach): auto-suppress STOP replies + env-configurable sending identity (#2620)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ data/employer-outreach/contacts.json
 data/employer-outreach/report.json
 data/employer-outreach/drafts/
 data/employer-outreach/send-log.json
+data/employer-outreach/inbound-replies.jsonl

--- a/functions/index.js
+++ b/functions/index.js
@@ -16,6 +16,7 @@ import { handleChatbotInference } from './src/chatbotInference.js';
 import { handleLinkedInCallback } from './src/linkedinAuthCallback.js';
 import { handleJobAlertUnsubscribe } from './src/jobAlertUnsubscribe.js';
 import { handleOutreachUnsubscribe } from './src/outreachUnsubscribe.js';
+import { handleOutreachStopReply } from './src/outreachStopReply.js';
 import { handleEmployerInsights } from './src/employerInsights.js';
 import { handleRecaptchaVerification } from './src/recaptchaVerification.js';
 import { getPublicConfigValues } from './src/publicConfig.js';
@@ -703,6 +704,44 @@ export const outreachUnsubscribe = onRequest(
  } catch (error) {
  console.error('[outreachUnsubscribe] Error:', error);
  res.status(500).type('html').send('<h1>Errore interno</h1><p>Riprova più tardi.</p>');
+ }
+ },
+);
+
+/**
+ * outreachStopReply — server-side auto-suppress from a STOP / UNSUBSCRIBE reply
+ * (follow-up #2620, item 2). The Cloudflare Email Worker
+ * (infra/cloudflare-email-worker/stop-reply-handler.js) POSTs the parsed inbound
+ * reply { from, subject, body } with a shared secret (NEWSLETTER_SECRET) in the
+ * `x-stop-secret` header; this writes employer_outreach_suppression/{companyKey}
+ * the same way the one-click path does. POST-only, secret-gated.
+ */
+export const outreachStopReply = onRequest(
+ {
+ region: 'europe-west6',
+ memory: '256MiB',
+ timeoutSeconds: 30,
+ cors: false,
+ },
+ async (req, res) => {
+ if (req.method !== 'POST') {
+ res.status(405).send('Method not allowed');
+ return;
+ }
+ try {
+ const { newsletterSecret } = await getNewsletterSecrets();
+ const body = req.body || {};
+ const result = await handleOutreachStopReply({
+ from: body.from,
+ subject: body.subject,
+ body: body.body,
+ secret: newsletterSecret,
+ providedSecret: String(req.get('x-stop-secret') || ''),
+ });
+ res.status(result.status).type('text').send(result.body);
+ } catch (error) {
+ console.error('[outreachStopReply] Error:', error);
+ res.status(500).type('text').send('error');
  }
  },
 );

--- a/functions/src/outreachStopReply.js
+++ b/functions/src/outreachStopReply.js
@@ -1,0 +1,117 @@
+/**
+ * outreachStopReply.js — server-side auto-suppress from a STOP / UNSUBSCRIBE
+ * reply to a cold-email (employer outreach) campaign (follow-up #2620, item 2).
+ *
+ * The Cloudflare Email Worker (infra/cloudflare-email-worker/stop-reply-handler.js)
+ * receives the inbound reply (all @frontaliereticino.ch mail is routed through
+ * Cloudflare Email Routing) and POSTs the parsed { from, subject, body } here.
+ * This handler:
+ *   1. Confirms the body/subject expresses a STOP intent.
+ *   2. Reverse-maps the sender address to a companyKey via the Firestore
+ *      `employer_contacts` collection (the admin-editable contacts registry —
+ *      same source send-cold-emails.mjs overlays).
+ *   3. Writes `employer_outreach_suppression/{companyKey}` with source
+ *      'stop-reply', BYTE-IDENTICAL in shape to the one-click path
+ *      (outreachUnsubscribe.js) so send-cold-emails.mjs honours it next touch.
+ *
+ * Auth: the Worker sends a shared secret (NEWSLETTER_SECRET, already provisioned)
+ * in the `x-stop-secret` header. Without it the request is rejected — this
+ * endpoint must never be a public write to the suppression list.
+ *
+ * Detection lives in scripts/lib/stop-reply-detect.mjs (the single source shared
+ * with scripts/process-stop-replies.mjs); the heuristic is re-implemented here as
+ * a tiny self-contained copy because Cloud Functions deploy from functions/ and
+ * cannot import the scripts/ tree at runtime. Keep the two in lockstep
+ * (AGENTS.md Non-Negotiable #6) — both are covered by unit tests.
+ */
+
+import admin from 'firebase-admin';
+import { getAdminDb } from './newsletterResendWebhookCore.js';
+
+const SUPPRESSION_COLLECTION = 'employer_outreach_suppression';
+const CONTACTS_COLLECTION = 'employer_contacts';
+
+// MIRROR of scripts/lib/stop-reply-detect.mjs STOP_INTENT_PATTERNS. Keep in sync.
+const STOP_INTENT_PATTERNS = [
+  /\bstop\b/i,
+  /\bunsubscribe\b/i,
+  /\bunsub\b/i,
+  /\bdisiscriv\w*/i,
+  /\brimuovet?em?i\b/i,
+  /\bcancellat?em?i\b/i,
+  /\bcancellate(?:mi|ci)?\b/i,
+  /\bremove\s+me\b/i,
+  /\bopt[\s-]?out\b/i,
+  /non\s+(?:mi\s+)?(?:scriv|contatt|invi|mandat?)\w*\s+pi[uù]/i,
+  /annull\w*\s+l\W?iscrizione/i,
+];
+
+export function isStopReply({ subject = '', body = '', text = '' } = {}) {
+  const haystack = `${subject || ''}\n${body || text || ''}`;
+  if (!haystack.trim()) return false;
+  return STOP_INTENT_PATTERNS.some((re) => re.test(haystack));
+}
+
+// MIRROR of scripts/lib/stop-reply-detect.mjs extractSenderEmail. Keep in sync.
+export function extractSenderEmail(fromHeader) {
+  const raw = String(fromHeader || '').trim();
+  if (!raw) return '';
+  const angle = raw.match(/<([^>]+)>/);
+  const candidate = (angle ? angle[1] : raw).trim();
+  const m = candidate.match(/[^\s<>"']+@[^\s<>"']+\.[^\s<>"']+/);
+  return m ? m[0].toLowerCase().replace(/[).,;]+$/, '') : '';
+}
+
+/**
+ * Resolve a sender address to a companyKey by scanning employer_contacts.
+ * Returns '' if no contact has that email (verified or inferred).
+ */
+async function resolveCompanyKey(db, senderEmail) {
+  const addr = String(senderEmail || '').trim().toLowerCase();
+  if (!addr) return '';
+  const snap = await db.collection(CONTACTS_COLLECTION).get();
+  let found = '';
+  snap.forEach((doc) => {
+    if (found) return;
+    const d = doc.data() || {};
+    const verified = String(d.email || '').trim().toLowerCase();
+    const inferred = String(d.emailInferred || '').trim().toLowerCase();
+    if (verified === addr || inferred === addr) found = (d.companyKey || doc.id || '').trim();
+  });
+  return found;
+}
+
+/**
+ * Core handler. `db` is injectable for unit tests.
+ * Returns { status, body, companyKey? }.
+ */
+export async function handleOutreachStopReply({ from, subject, body, secret, providedSecret, db: injectedDb }) {
+  if (!secret || providedSecret !== secret) {
+    return { status: 403, body: 'forbidden' };
+  }
+  if (!isStopReply({ subject, body })) {
+    // Not an opt-out — nothing to do, but a 200 so the Worker doesn't retry.
+    return { status: 200, body: 'no-stop-intent' };
+  }
+  const fromEmail = extractSenderEmail(from);
+  if (!fromEmail) {
+    return { status: 200, body: 'no-sender' };
+  }
+
+  const db = injectedDb || getAdminDb();
+  const companyKey = await resolveCompanyKey(db, fromEmail);
+  if (!companyKey) {
+    // Unknown sender: we can't safely map to a company. Record nothing in the
+    // suppression list (keyed by companyKey), but signal so the Worker logs it.
+    return { status: 200, body: 'unknown-sender' };
+  }
+
+  await db.collection(SUPPRESSION_COLLECTION).doc(companyKey).set({
+    companyKey,
+    suppressedAt: admin.firestore.FieldValue.serverTimestamp(),
+    source: 'stop-reply',
+    suppressedFrom: fromEmail,
+  }, { merge: true });
+
+  return { status: 200, body: 'suppressed', companyKey };
+}

--- a/infra/cloudflare-email-worker/stop-reply-handler.js
+++ b/infra/cloudflare-email-worker/stop-reply-handler.js
@@ -1,0 +1,111 @@
+/**
+ * stop-reply-handler.js — Cloudflare Email Routing Worker for inbound cold-email
+ * replies (follow-up #2620, item 2).
+ *
+ * Cloudflare Email Routing forwards every @frontaliereticino.ch message; this
+ * Worker is bound (Email Routing → custom address → "Send to a Worker") to the
+ * outreach reply address (the cold-email `From`, e.g. valerie@frontaliereticino.ch
+ * via OUTREACH_FROM_ADDRESS). On each inbound message it:
+ *   1. Parses the From header + subject + a bounded prefix of the text body.
+ *   2. If it expresses a STOP / UNSUBSCRIBE intent, POSTs { from, subject, body }
+ *      to the outreachStopReply Cloud Function (secret-gated via STOP_SECRET),
+ *      which reverse-maps the sender → companyKey and writes
+ *      employer_outreach_suppression/{companyKey} — the SAME suppression
+ *      send-cold-emails.mjs honours.
+ *   3. ALWAYS forwards the original message to the human inbox (FORWARD_TO) so no
+ *      reply is ever swallowed — STOP handling is additive, not a replacement for
+ *      reading replies.
+ *
+ * Detection MIRRORS scripts/lib/stop-reply-detect.mjs (single source) — kept in
+ * lockstep (AGENTS.md Non-Negotiable #6); both are unit-tested.
+ *
+ * Bindings (wrangler.email.toml / dashboard):
+ *   vars:    STOP_REPLY_FN_URL  (https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply)
+ *            FORWARD_TO         (the human inbox to forward every reply to)
+ *   secret:  STOP_SECRET        (== NEWSLETTER_SECRET; `wrangler secret put STOP_SECRET`)
+ *
+ * NOTE: binding the Worker to the inbound address in Cloudflare Email Routing is a
+ * manual dashboard/API step (declared in the PR's ## Non implementato) — the code
+ * here is the handler that step points at.
+ */
+
+// MIRROR of scripts/lib/stop-reply-detect.mjs STOP_INTENT_PATTERNS. Keep in sync.
+const STOP_INTENT_PATTERNS = [
+  /\bstop\b/i,
+  /\bunsubscribe\b/i,
+  /\bunsub\b/i,
+  /\bdisiscriv\w*/i,
+  /\brimuovet?em?i\b/i,
+  /\bcancellat?em?i\b/i,
+  /\bcancellate(?:mi|ci)?\b/i,
+  /\bremove\s+me\b/i,
+  /\bopt[\s-]?out\b/i,
+  /non\s+(?:mi\s+)?(?:scriv|contatt|invi|mandat?)\w*\s+pi[uù]/i,
+  /annull\w*\s+l\W?iscrizione/i,
+];
+
+function isStopReply(subject, body) {
+  const haystack = `${subject || ''}\n${body || ''}`;
+  if (!haystack.trim()) return false;
+  return STOP_INTENT_PATTERNS.some((re) => re.test(haystack));
+}
+
+// Read a bounded prefix of the raw email stream as text. We only need the first
+// few KB — a STOP intent in a reply lives at the top, and reading the whole MIME
+// body (attachments etc.) would waste Worker CPU/memory.
+async function readBodyPrefix(stream, maxBytes = 8192) {
+  if (!stream) return '';
+  const reader = stream.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (total < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.length;
+    }
+  } catch {
+    // best-effort: partial read is enough for STOP detection
+  } finally {
+    try { reader.releaseLock(); } catch { /* noop */ }
+  }
+  const merged = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) { merged.set(c.subarray(0, Math.min(c.length, maxBytes - off)), off); off += c.length; if (off >= maxBytes) break; }
+  return new TextDecoder('utf-8', { fatal: false }).decode(merged.subarray(0, maxBytes));
+}
+
+export default {
+  /**
+   * Cloudflare Email Routing entrypoint.
+   * @param {EmailMessage} message
+   * @param {Record<string, string>} env
+   * @param {ExecutionContext} ctx
+   */
+  async email(message, env, ctx) {
+    const from = message.from || '';
+    const subject = (message.headers && message.headers.get && message.headers.get('subject')) || '';
+
+    // Detect on subject first (cheap); read the body only if needed.
+    let body = '';
+    if (!isStopReply(subject, '')) {
+      body = await readBodyPrefix(message.raw);
+    }
+
+    if (isStopReply(subject, body) && env.STOP_REPLY_FN_URL && env.STOP_SECRET) {
+      // Fire-and-forget the suppression POST; never block forwarding on it.
+      const suppress = fetch(env.STOP_REPLY_FN_URL, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
+        body: JSON.stringify({ from, subject, body: body.slice(0, 2000) }),
+      }).catch(() => { /* best-effort; the cron processor is the safety net */ });
+      ctx.waitUntil(suppress);
+    }
+
+    // ALWAYS forward to the human inbox so no reply is lost.
+    if (env.FORWARD_TO) {
+      try { await message.forward(env.FORWARD_TO); } catch { /* recipient may be unverified; ignore */ }
+    }
+  },
+};

--- a/infra/cloudflare-email-worker/wrangler.toml
+++ b/infra/cloudflare-email-worker/wrangler.toml
@@ -1,0 +1,29 @@
+# Cloudflare Email Routing Worker for inbound cold-email STOP replies.
+#
+# Deploy: `npx wrangler deploy` from this dir.
+# Then (MANUAL, one-time, dashboard or API):
+#   Cloudflare → Email → Email Routing → Routing rules → the outreach reply
+#   address (the cold-email From, e.g. valerie@frontaliereticino.ch) → action
+#   "Send to a Worker" → frontaliere-stop-reply-handler.
+# Binding the Worker to the address is the manual infra step (see PR #2620 body
+# ## Non implementato); the handler code lives in stop-reply-handler.js.
+#
+# Secrets / vars (set after deploy):
+#   npx wrangler secret put STOP_SECRET     # == NEWSLETTER_SECRET (Cloud Function side)
+#   STOP_REPLY_FN_URL / FORWARD_TO are plain vars below.
+
+name = "frontaliere-stop-reply-handler"
+main = "stop-reply-handler.js"
+compatibility_date = "2026-01-01"
+
+[vars]
+# Cloud Function that resolves sender→companyKey and writes the suppression doc.
+STOP_REPLY_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply"
+# Human inbox that every inbound reply is forwarded to (must be a verified
+# Email Routing destination). Fill in with the real monitored address before
+# deploy — left as a placeholder so no personal address is committed.
+FORWARD_TO = "REPLACE_WITH_VERIFIED_DESTINATION@example.com"
+
+[observability]
+enabled = true
+head_sampling_rate = 1

--- a/scripts/lib/outreach-suppression.mjs
+++ b/scripts/lib/outreach-suppression.mjs
@@ -1,0 +1,65 @@
+/**
+ * outreach-suppression.mjs — SINGLE SOURCE of the suppression write shape used by
+ * the STOP-reply auto-suppress path.
+ *
+ * The Firestore collection `employer_outreach_suppression` (doc id = companyKey)
+ * is READ by scripts/send-cold-emails.mjs (loadFirestoreSuppression) and already
+ * WRITTEN by functions/src/outreachUnsubscribe.js for the one-click path. This
+ * helper mirrors that exact write shape so a STOP reply suppresses a company the
+ * same way a one-click unsubscribe does — no parallel/divergent schema
+ * (AGENTS.md Non-Negotiable #6).
+ *
+ * Doc fields (must stay in sync with outreachUnsubscribe.js):
+ *   companyKey  — string, also the doc id
+ *   suppressedAt — server/ISO timestamp
+ *   source      — provenance tag ('stop-reply' here vs 'one-click' there)
+ */
+
+export const SUPPRESSION_COLLECTION = 'employer_outreach_suppression';
+
+/**
+ * Resolve an inbound sender email to a companyKey using the contacts registry
+ * (the same { [companyKey]: { email } } map send-cold-emails.mjs sends to).
+ * Returns the FIRST matching companyKey or '' if the address is unknown.
+ *
+ * @param {string} senderEmail lower-cased bare address
+ * @param {Record<string, {email?: string, emailInferred?: string}>} contacts
+ * @returns {string}
+ */
+export function resolveCompanyKeyByEmail(senderEmail, contacts) {
+  const addr = String(senderEmail || '').trim().toLowerCase();
+  if (!addr || !contacts) return '';
+  for (const [key, c] of Object.entries(contacts)) {
+    const verified = String(c?.email || '').trim().toLowerCase();
+    const inferred = String(c?.emailInferred || '').trim().toLowerCase();
+    if (verified === addr || inferred === addr) return key;
+  }
+  return '';
+}
+
+/**
+ * Write a suppression doc to Firestore for `companyKey`, mirroring the one-click
+ * path's shape. `db` is the firebase-admin Firestore handle; `serverTimestamp`
+ * is passed in so this stays free of a hard firebase-admin import (the CF Email
+ * Worker uses its own binding). Idempotent (merge:true) — a repeat STOP just
+ * refreshes the timestamp.
+ *
+ * @param {object} args
+ * @param {import('firebase-admin/firestore').Firestore} args.db
+ * @param {string} args.companyKey
+ * @param {*} args.serverTimestamp value to store in suppressedAt (FieldValue or ISO string)
+ * @param {string} [args.source='stop-reply']
+ * @param {string} [args.fromEmail] optional sender address, stored for audit
+ * @returns {Promise<void>}
+ */
+export async function writeSuppression({ db, companyKey, serverTimestamp, source = 'stop-reply', fromEmail }) {
+  const key = String(companyKey || '').trim();
+  if (!key) throw new Error('writeSuppression: companyKey required');
+  const doc = {
+    companyKey: key,
+    suppressedAt: serverTimestamp,
+    source,
+  };
+  if (fromEmail) doc.suppressedFrom = String(fromEmail).trim().toLowerCase();
+  await db.collection(SUPPRESSION_COLLECTION).doc(key).set(doc, { merge: true });
+}

--- a/scripts/lib/stop-reply-detect.mjs
+++ b/scripts/lib/stop-reply-detect.mjs
@@ -1,0 +1,67 @@
+/**
+ * stop-reply-detect.mjs — SINGLE SOURCE of the "is this inbound reply an opt-out?"
+ * detection used by BOTH the inbound CF Email Worker
+ * (infra/cloudflare-email-worker/stop-reply-handler.js) AND the cron/poll
+ * processor (scripts/process-stop-replies.mjs).
+ *
+ * Keeping one copy means the webhook and the batch processor classify replies
+ * identically — no drift (AGENTS.md Non-Negotiable #6). Pure ESM, no node
+ * imports, so the Cloudflare Worker runtime can import it too.
+ *
+ * A reply counts as an opt-out when its subject OR body contains a standalone
+ * STOP / UNSUBSCRIBE intent token. We match on word boundaries so a STOP inside
+ * an unrelated word ("nonstop", "stopover", "unsubscribed already, thanks") does
+ * not over-suppress, while the common real-world forms DO match:
+ *   "STOP", "stop", "Stop.", "UNSUBSCRIBE", "annullare l'iscrizione",
+ *   "rimuovetemi", "cancellatemi", "non scrivetemi più", "remove me".
+ */
+
+// Intent tokens, matched case-insensitively on word boundaries. Italian +
+// English (the two languages the cold-email footer and recipients use). Ordered
+// roughly by frequency; the regex is anchored with \b so substrings inside
+// larger words never match.
+export const STOP_INTENT_PATTERNS = [
+  /\bstop\b/i,
+  /\bunsubscribe\b/i,
+  /\bunsub\b/i,
+  /\bdisiscriv\w*/i, // disiscrivere / disiscrivetemi / disiscrizione
+  /\brimuovet?em?i\b/i, // rimuovetemi / rimuovimi / rimuoveteci
+  /\bcancellat?em?i\b/i, // cancellatemi / cancellami
+  /\bcancellate(?:mi|ci)?\b/i,
+  /\bremove\s+me\b/i,
+  /\bopt[\s-]?out\b/i,
+  /non\s+(?:mi\s+)?(?:scriv|contatt|invi|mandat?)\w*\s+pi[uù]/i, // "non scrivetemi più" / "non contattatemi più"
+  /annull\w*\s+l\W?iscrizione/i, // "annullare l'iscrizione"
+];
+
+/**
+ * True if the given subject/body text expresses an opt-out / STOP intent.
+ * Either field may be empty; we concatenate and test once.
+ *
+ * @param {{subject?: string, body?: string, text?: string}} parts
+ * @returns {boolean}
+ */
+export function isStopReply({ subject = '', body = '', text = '' } = {}) {
+  const haystack = `${subject || ''}\n${body || text || ''}`;
+  if (!haystack.trim()) return false;
+  return STOP_INTENT_PATTERNS.some((re) => re.test(haystack));
+}
+
+/**
+ * Extract a bare email address from a raw From/Sender header value, e.g.
+ *   "Denise Rossi <denise@casale.ch>"  → "denise@casale.ch"
+ *   "denise@casale.ch"                 → "denise@casale.ch"
+ * Returns '' if no address is found. Lower-cased for stable matching against the
+ * contacts registry.
+ *
+ * @param {string} fromHeader
+ * @returns {string}
+ */
+export function extractSenderEmail(fromHeader) {
+  const raw = String(fromHeader || '').trim();
+  if (!raw) return '';
+  const angle = raw.match(/<([^>]+)>/);
+  const candidate = (angle ? angle[1] : raw).trim();
+  const m = candidate.match(/[^\s<>"']+@[^\s<>"']+\.[^\s<>"']+/);
+  return m ? m[0].toLowerCase().replace(/[).,;]+$/, '') : '';
+}

--- a/scripts/process-stop-replies.mjs
+++ b/scripts/process-stop-replies.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * process-stop-replies.mjs — auto-suppress employer-outreach recipients who reply
+ * "STOP" / "UNSUBSCRIBE" to a cold email (follow-up #2620, item 2).
+ *
+ * The cold-email footer (scripts/lib/cold-email-sequence.mjs) tells recipients
+ * they can reply "STOP" to be removed. Until now the operator had to set
+ * `suppressed:true` in the send-log by hand — fragile: an unprocessed STOP risks
+ * a CAN-SPAM / nDSG violation and burns the sending domain's reputation. This
+ * script processes inbound replies and writes the suppression the SAME way the
+ * one-click unsubscribe Cloud Function does:
+ *   1. Firestore `employer_outreach_suppression/{companyKey}` (read by
+ *      send-cold-emails.mjs → loadFirestoreSuppression) — best-effort, skipped
+ *      with a warning if no service-account creds are present.
+ *   2. The local send-log.json (`suppressed:true` + reason) so a dry-run / local
+ *      send honours it even without Firestore.
+ *
+ * Inbound source (one of):
+ *   --queue <path>   JSONL/JSON queue of inbound replies, each
+ *                    { from, subject, body } — written by the Cloudflare Email
+ *                    Worker (infra/cloudflare-email-worker/stop-reply-handler.js)
+ *                    or any inbound-route webhook. Default:
+ *                    data/employer-outreach/inbound-replies.jsonl
+ *   --from <addr> --subject <s> --body <s>
+ *                    Process a SINGLE reply from the CLI (manual entry).
+ *
+ * The sender address is reverse-mapped to a companyKey via contacts.json (the
+ * same registry send-cold-emails.mjs sends to). An unknown sender is reported and
+ * skipped (we never suppress a key we can't identify).
+ *
+ * Default = DRY-RUN (prints what it WOULD suppress). Pass --apply to write.
+ *
+ * Examples:
+ *   # dry-run the queue the email worker has accumulated
+ *   node scripts/process-stop-replies.mjs
+ *   # apply suppression from the queue, then truncate the processed queue
+ *   node scripts/process-stop-replies.mjs --apply
+ *   # process a single manual STOP
+ *   node scripts/process-stop-replies.mjs --apply \
+ *     --from "denise@casale.ch" --subject "Re: candidati inviati" --body "STOP"
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isStopReply, extractSenderEmail } from './lib/stop-reply-detect.mjs';
+import {
+  resolveCompanyKeyByEmail,
+  writeSuppression,
+} from './lib/outreach-suppression.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return def;
+  const n = process.argv[i + 1];
+  return n && !n.startsWith('--') ? n : true;
+}
+const has = (name) => process.argv.includes(name);
+
+function loadJson(p, def) {
+  try { return JSON.parse(fs.readFileSync(path.resolve(p), 'utf8')); } catch { return def; }
+}
+
+/**
+ * Read the inbound-reply queue. Accepts either a JSON array or JSONL (one object
+ * per line). Each entry: { from, subject, body }. Missing/empty → [].
+ */
+export function loadInboundQueue(queuePath) {
+  let raw;
+  try { raw = fs.readFileSync(path.resolve(queuePath), 'utf8'); } catch { return []; }
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  // JSON array form.
+  if (trimmed.startsWith('[')) {
+    try { const arr = JSON.parse(trimmed); return Array.isArray(arr) ? arr : []; } catch { return []; }
+  }
+  // JSONL form: one object per non-empty line; skip unparseable lines.
+  const out = [];
+  for (const line of trimmed.split(/\r?\n/)) {
+    const l = line.trim();
+    if (!l) continue;
+    try { out.push(JSON.parse(l)); } catch { /* skip malformed line */ }
+  }
+  return out;
+}
+
+// ── Send-log suppression (local, mirrors send-cold-emails.mjs shape) ──────────
+
+function loadSendLog(logPath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.resolve(logPath), 'utf8'));
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed;
+  } catch { return {}; }
+}
+
+function saveSendLog(logPath, log) {
+  const p = path.resolve(logPath);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(log, null, 2), 'utf8');
+}
+
+/** Mark a company suppressed in the local send-log (shape parity with the sender). */
+export function suppressInSendLog(log, companyKey, reason) {
+  if (!log[companyKey]) log[companyKey] = { touches: [], suppressed: false, suppressedReason: '' };
+  log[companyKey].suppressed = true;
+  log[companyKey].suppressedReason = reason;
+  return log;
+}
+
+/**
+ * Classify a queue of inbound replies into the companyKeys to suppress.
+ * Pure (no IO) so it is unit-testable. Returns { toSuppress, skipped } where
+ * toSuppress is [{ companyKey, fromEmail }] and skipped is [{ reason, ... }].
+ */
+export function classifyReplies(replies, contacts) {
+  const toSuppress = [];
+  const skipped = [];
+  const seen = new Set();
+  for (const r of replies || []) {
+    const fromEmail = extractSenderEmail(r?.from);
+    if (!isStopReply({ subject: r?.subject, body: r?.body, text: r?.text })) {
+      skipped.push({ reason: 'not-a-stop', fromEmail, subject: r?.subject || '' });
+      continue;
+    }
+    if (!fromEmail) {
+      skipped.push({ reason: 'no-sender', subject: r?.subject || '' });
+      continue;
+    }
+    const companyKey = resolveCompanyKeyByEmail(fromEmail, contacts);
+    if (!companyKey) {
+      skipped.push({ reason: 'unknown-sender', fromEmail });
+      continue;
+    }
+    if (seen.has(companyKey)) continue;
+    seen.add(companyKey);
+    toSuppress.push({ companyKey, fromEmail });
+  }
+  return { toSuppress, skipped };
+}
+
+async function run() {
+  const contactsPath = arg('--contacts', path.join(ROOT, 'data/employer-outreach/contacts.json'));
+  const logPath = arg('--log', path.join(ROOT, 'data/employer-outreach/send-log.json'));
+  const queuePath = arg('--queue', path.join(ROOT, 'data/employer-outreach/inbound-replies.jsonl'));
+  const apply = has('--apply');
+
+  // Inbound replies: either a single CLI reply or the accumulated queue.
+  const cliFrom = arg('--from', '');
+  let replies;
+  if (cliFrom && cliFrom !== true) {
+    replies = [{ from: cliFrom, subject: arg('--subject', '') || '', body: arg('--body', '') || '' }];
+  } else {
+    replies = loadInboundQueue(queuePath);
+  }
+
+  if (!replies.length) {
+    console.log(`Nessuna reply da processare (queue: ${path.relative(ROOT, path.resolve(queuePath))}).`);
+    return;
+  }
+
+  const contacts = loadJson(contactsPath, {});
+  const { toSuppress, skipped } = classifyReplies(replies, contacts);
+
+  console.log(`${replies.length} reply lette — ${toSuppress.length} STOP da sopprimere, ${skipped.length} saltate.`);
+  for (const s of skipped) {
+    console.log(`  ↷ skip [${s.reason}] ${s.fromEmail || s.subject || ''}`);
+  }
+  for (const t of toSuppress) {
+    console.log(`  ⛔ ${t.companyKey}  ←  ${t.fromEmail}`);
+  }
+
+  if (!apply) {
+    console.log('\nDRY-RUN — nessuna scrittura. Usa --apply per sopprimere.');
+    return;
+  }
+  if (!toSuppress.length) {
+    console.log('\nNiente da applicare.');
+    return;
+  }
+
+  // 1) Local send-log (always — works without Firestore).
+  const sendLog = loadSendLog(logPath);
+  for (const t of toSuppress) {
+    suppressInSendLog(sendLog, t.companyKey, `STOP reply da ${t.fromEmail}`);
+  }
+  saveSendLog(logPath, sendLog);
+  console.log(`\n✅ send-log aggiornato (${toSuppress.length} suppressed): ${path.relative(ROOT, path.resolve(logPath))}`);
+
+  // 2) Firestore (best-effort, mirrors the one-click write).
+  let db = null;
+  let serverTimestamp = new Date().toISOString();
+  try {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credPath || !fs.existsSync(credPath)) {
+      console.warn('↷ Firestore: GOOGLE_APPLICATION_CREDENTIALS non impostato — suppression scritta solo nel send-log locale.');
+    } else {
+      const { getFirestoreDb } = await import('./lib/firestore-admin.mjs');
+      const adminMod = await import('firebase-admin');
+      const admin = adminMod.default || adminMod;
+      db = await getFirestoreDb();
+      serverTimestamp = admin.firestore.FieldValue.serverTimestamp();
+    }
+  } catch (err) {
+    console.warn(`↷ Firestore non disponibile (${err.message}) — suppression scritta solo nel send-log locale.`);
+    db = null;
+  }
+  if (db) {
+    let written = 0;
+    for (const t of toSuppress) {
+      try {
+        await writeSuppression({ db, companyKey: t.companyKey, serverTimestamp, source: 'stop-reply', fromEmail: t.fromEmail });
+        written++;
+      } catch (err) {
+        console.warn(`↷ Firestore write fallita per ${t.companyKey}: ${err.message}`);
+      }
+    }
+    console.log(`✅ Firestore employer_outreach_suppression aggiornato (${written}/${toSuppress.length}).`);
+  }
+
+  // 3) Truncate the processed queue (only when we read it from disk, applied OK).
+  if (!(cliFrom && cliFrom !== true)) {
+    try {
+      fs.writeFileSync(path.resolve(queuePath), '', 'utf8');
+      console.log(`🧹 Coda inbound svuotata: ${path.relative(ROOT, path.resolve(queuePath))}`);
+    } catch { /* queue file may not exist on disk — fine */ }
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  run().catch((err) => { console.error(err); process.exitCode = 1; });
+}

--- a/scripts/send-cold-emails.mjs
+++ b/scripts/send-cold-emails.mjs
@@ -44,7 +44,17 @@ import { buildInsightsUrl } from './lib/employer-insights-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
-const FROM_DEFAULT = 'Valerie · Frontaliere Ticino <valerie@frontaliereticino.ch>';
+// Sending identity. Configurable via OUTREACH_FROM_ADDRESS so the outreach can be
+// moved to an ISOLATED sending subdomain (e.g. valerie@outreach.frontaliereticino.ch
+// with its own SPF/DKIM/DMARC — follow-up #2620 item 3) WITHOUT a code change:
+// only the env var flips. The value may be a bare address or a full
+// `Display Name <addr>` form; a bare address is wrapped with the brand display
+// name. Default = the canonical reply address valerie@frontaliereticino.ch.
+// CLI `--from` still overrides everything (one-off sends / tests).
+const OUTREACH_FROM_ADDRESS = (process.env.OUTREACH_FROM_ADDRESS || '').trim() || 'valerie@frontaliereticino.ch';
+const FROM_DEFAULT = OUTREACH_FROM_ADDRESS.includes('<')
+  ? OUTREACH_FROM_ADDRESS
+  : `Valerie · Frontaliere Ticino <${OUTREACH_FROM_ADDRESS}>`;
 
 function arg(name, def) {
   const i = process.argv.indexOf(name);

--- a/tests/outreach-stop-reply-handler.test.ts
+++ b/tests/outreach-stop-reply-handler.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { handleOutreachStopReply } from '../functions/src/outreachStopReply.js';
+
+// Server-side STOP auto-suppress (follow-up #2620 item 2). This is the path the
+// Cloudflare Email Worker hits; it must be secret-gated and must write the
+// suppression doc only for an identifiable STOP from a known sender — never a
+// public write.
+
+const SECRET = 'shared-test-secret';
+
+/** Minimal fake Firestore: a single contact + a capturing suppression set(). */
+function fakeDb({ contactEmail = 'denise@casale.ch', companyKey = 'casale-sa' } = {}) {
+  const writes: Array<{ id: string; data: any }> = [];
+  return {
+    writes,
+    collection(name: string) {
+      if (name === 'employer_contacts') {
+        return {
+          async get() {
+            return {
+              forEach(cb: (d: any) => void) {
+                cb({ id: companyKey, data: () => ({ companyKey, email: contactEmail }) });
+              },
+            };
+          },
+        };
+      }
+      if (name === 'employer_outreach_suppression') {
+        return {
+          doc(id: string) {
+            return { async set(data: any) { writes.push({ id, data }); } };
+          },
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+  };
+}
+
+describe('handleOutreachStopReply', () => {
+  it('rejects a request without the shared secret (403, no write)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachStopReply({
+      from: 'denise@casale.ch', subject: 'x', body: 'STOP',
+      secret: SECRET, providedSecret: 'wrong', db,
+    });
+    expect(res.status).toBe(403);
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('suppresses a known sender who replies STOP', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachStopReply({
+      from: 'Denise <denise@casale.ch>', subject: 'Re: candidati', body: 'STOP',
+      secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('suppressed');
+    expect(res.companyKey).toBe('casale-sa');
+    expect(db.writes).toHaveLength(1);
+    expect(db.writes[0].id).toBe('casale-sa');
+    expect(db.writes[0].data.source).toBe('stop-reply');
+    expect(db.writes[0].data.companyKey).toBe('casale-sa');
+  });
+
+  it('does nothing for a non-STOP reply (200, no write)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachStopReply({
+      from: 'denise@casale.ch', subject: 'Interessati', body: 'quanto costa?',
+      secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('no-stop-intent');
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('does not suppress an unknown sender (200 unknown-sender, no write)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachStopReply({
+      from: 'stranger@elsewhere.com', subject: 'STOP', body: '',
+      secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('unknown-sender');
+    expect(db.writes).toHaveLength(0);
+  });
+});

--- a/tests/stop-reply-detect.test.ts
+++ b/tests/stop-reply-detect.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { isStopReply, extractSenderEmail, STOP_INTENT_PATTERNS } from '../scripts/lib/stop-reply-detect.mjs';
+// @ts-expect-error — plain .mjs helper, no types
+import { resolveCompanyKeyByEmail } from '../scripts/lib/outreach-suppression.mjs';
+// @ts-expect-error — plain .mjs helper, no types
+import { classifyReplies } from '../scripts/process-stop-replies.mjs';
+
+// Auto-suppress from STOP replies (follow-up #2620 item 2). The classifier turns
+// "did the recipient ask to be removed" into "suppress this company" — a
+// compliance-critical decision (nDSG/CAN-SPAM + sending-domain reputation), so
+// over- and under-matching are both real risks worth pinning.
+describe('STOP-reply detection', () => {
+  it('matches the common opt-out forms (IT + EN)', () => {
+    const stops = [
+      { subject: 'Re: candidati inviati', body: 'STOP' },
+      { subject: 'Re: candidati', body: 'stop.' },
+      { subject: 'unsubscribe', body: '' },
+      { subject: '', body: 'Per favore rimuovetemi da questa lista.' },
+      { subject: '', body: 'cancellatemi grazie' },
+      { subject: '', body: 'Vi chiedo di annullare l’iscrizione.' },
+      { subject: '', body: 'non scrivetemi più per favore' },
+      { subject: '', body: 'remove me from your list' },
+      { subject: '', body: 'opt-out' },
+      { subject: '', body: 'disiscrivetemi' },
+    ];
+    for (const r of stops) {
+      expect(isStopReply(r), `should be STOP: ${JSON.stringify(r)}`).toBe(true);
+    }
+  });
+
+  it('does NOT match unrelated replies (no over-suppression)', () => {
+    const notStops = [
+      { subject: 'Re: candidati inviati', body: 'Grazie, ci pensiamo e vi ricontattiamo.' },
+      { subject: 'Interessati', body: 'Quanto costa lo sponsorizzato?' },
+      { subject: 'nonstop flights', body: 'parliamo del nostro stopover a Zurigo' },
+      { subject: '', body: 'Mi sono già iscritto, tutto ok.' },
+      { subject: '', body: '' },
+    ];
+    for (const r of notStops) {
+      expect(isStopReply(r), `should NOT be STOP: ${JSON.stringify(r)}`).toBe(false);
+    }
+  });
+
+  it('exposes the shared pattern list (kept in sync with the CF copies)', () => {
+    expect(Array.isArray(STOP_INTENT_PATTERNS)).toBe(true);
+    expect(STOP_INTENT_PATTERNS.length).toBeGreaterThan(5);
+  });
+});
+
+describe('extractSenderEmail', () => {
+  it('pulls the address out of a display-name From header', () => {
+    expect(extractSenderEmail('Denise Rossi <Denise@Casale.CH>')).toBe('denise@casale.ch');
+  });
+  it('accepts a bare address', () => {
+    expect(extractSenderEmail('hr@aldi.ch')).toBe('hr@aldi.ch');
+  });
+  it('returns empty for junk', () => {
+    expect(extractSenderEmail('')).toBe('');
+    expect(extractSenderEmail('not an email')).toBe('');
+  });
+});
+
+describe('resolveCompanyKeyByEmail', () => {
+  const contacts = {
+    'casale-sa': { email: 'denise@casale.ch' },
+    'aldi-suisse': { email: '', emailInferred: 'hr@aldi.ch' },
+  };
+  it('maps a verified address to its companyKey (case-insensitive)', () => {
+    expect(resolveCompanyKeyByEmail('DENISE@casale.ch', contacts)).toBe('casale-sa');
+  });
+  it('maps an inferred address too', () => {
+    expect(resolveCompanyKeyByEmail('hr@aldi.ch', contacts)).toBe('aldi-suisse');
+  });
+  it('returns empty for an unknown sender', () => {
+    expect(resolveCompanyKeyByEmail('stranger@elsewhere.com', contacts)).toBe('');
+  });
+});
+
+describe('classifyReplies (queue → suppression decisions)', () => {
+  const contacts = {
+    'casale-sa': { email: 'denise@casale.ch' },
+    'aldi-suisse': { email: 'hr@aldi.ch' },
+  };
+
+  it('suppresses only STOP replies from known senders, deduped', () => {
+    const replies = [
+      { from: 'Denise <denise@casale.ch>', subject: 'Re: candidati', body: 'STOP' },
+      { from: 'denise@casale.ch', subject: 'Re: candidati', body: 'stop di nuovo' }, // dup company
+      { from: 'hr@aldi.ch', subject: 'Interessati', body: 'Quanto costa?' }, // not a stop
+      { from: 'unknown@x.com', subject: 'unsubscribe', body: '' }, // unknown sender
+      { from: '', subject: 'STOP', body: '' }, // no sender
+    ];
+    const { toSuppress, skipped } = classifyReplies(replies, contacts);
+    expect(toSuppress.map((t: any) => t.companyKey)).toEqual(['casale-sa']);
+    expect(toSuppress[0].fromEmail).toBe('denise@casale.ch');
+    // not-a-stop, unknown-sender, no-sender (the dup is silently merged, not skipped)
+    const reasons = skipped.map((s: any) => s.reason).sort();
+    expect(reasons).toEqual(['no-sender', 'not-a-stop', 'unknown-sender']);
+  });
+
+  it('handles an empty queue', () => {
+    const { toSuppress, skipped } = classifyReplies([], contacts);
+    expect(toSuppress).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+});


### PR DESCRIPTION
Risolve i 3 item di #2620. L'item 1 (List-Unsubscribe One-Click HTTPS POST) era già stato consegnato in #2641 (verificato: `List-Unsubscribe-Post: List-Unsubscribe=One-Click` + URL HTTPS one-click in `scripts/send-cold-emails.mjs`). Qui si implementano item 2 e item 3.

Closes #2620

## Implementato

**Item 1 — List-Unsubscribe One-Click HTTPS POST (già fatto in #2641, nessun rework)**
- `scripts/send-cold-emails.mjs` emette già `List-Unsubscribe: <https one-click>, <mailto>` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click`, con la CF `outreachUnsubscribe` che scrive `employer_outreach_suppression/{companyKey}`. Dichiarato soddisfatto, non toccato.

**Item 2 — auto-suppress da reply "STOP" (inbox webhook)**
- `scripts/lib/stop-reply-detect.mjs` (nuovo): rilevatore condiviso di intent STOP/UNSUBSCRIBE (IT+EN, ancorato a word-boundary per non sovra-sopprimere) + estrattore dell'indirizzo mittente dall'header From.
- `scripts/lib/outreach-suppression.mjs` (nuovo): forma di scrittura della suppression + resolver email→companyKey, identici alla forma che `outreachUnsubscribe.js` già scrive e `send-cold-emails.mjs` legge (`loadFirestoreSuppression`).
- `scripts/process-stop-replies.mjs` (nuovo): legge una coda di reply inbound (JSON/JSONL) o una singola reply da CLI; per ogni STOP da mittente noto scrive `suppressed:true` nel send-log locale (stessa shape del sender) E `employer_outreach_suppression/{companyKey}` su Firestore (best-effort, degrada senza credenziali). Dry-run di default, `--apply` scrive e svuota la coda processata.
- `functions/src/outreachStopReply.js` + export in `functions/index.js` (nuovo): endpoint CF POST-only, gated da secret condiviso (`NEWSLETTER_SECRET` via header `x-stop-secret`), che risolve mittente→companyKey da `employer_contacts` e scrive la suppression con `source:'stop-reply'`.
- `infra/cloudflare-email-worker/stop-reply-handler.js` + `wrangler.toml` (nuovo): Worker Cloudflare Email Routing (`email()` handler) che rileva lo STOP, fa POST best-effort a `outreachStopReply`, e inoltra SEMPRE la reply alla casella umana (nessuna reply persa). Il rilevatore è in lockstep con `stop-reply-detect.mjs`.
- `.gitignore`: aggiunta `data/employer-outreach/inbound-replies.jsonl` (coda runtime con indirizzi mittenti — PII, mai committata).

**Item 3 — identità di invio outreach isolata**
- `scripts/send-cold-emails.mjs`: il `from` ora legge `process.env.OUTREACH_FROM_ADDRESS` (default `valerie@frontaliereticino.ch`), accetta sia indirizzo nudo sia forma `Display Name <addr>`. Puntare l'invio su un sottodominio isolato (`valerie@outreach.frontaliereticino.ch`) richiede solo il flip della env, nessun cambio di codice. Il flag `--from` resta override per i test.

**Test**
- `tests/stop-reply-detect.test.ts`: detection STOP (match/non-match), estrazione mittente, resolver email→companyKey, classifier coda→decisioni di suppression.
- `tests/outreach-stop-reply-handler.test.ts`: handler CF (gate secret 403, suppress mittente noto, no-op su non-STOP, no-write su mittente sconosciuto) con Firestore iniettato.
- `npm test` completo verde in locale (904 file, 77126 test, 0 fail) dopo i prep step CI (`assemble-jobs-dataset --stats`, `migrate-all-known-job-slugs-canton-aware`).

## Non implementato (ancora)

- **Binding live Cloudflare Email Routing → Worker (item 2, infra manuale)**: associare l'indirizzo di reply outreach al Worker `frontaliere-stop-reply-handler` (Email Routing → "Send to a Worker") è uno step dashboard/API una-tantum, fuori dal codice. Il codice del Worker + `wrangler.toml` sono pronti; restano da impostare il segreto `STOP_SECRET` (== `NEWSLETTER_SECRET`) e la var `FORWARD_TO` (lasciata a placeholder per non committare un indirizzo personale). Finché il binding non è attivo, la rete di sicurezza è `scripts/process-stop-replies.mjs` eseguibile a mano/cron sulla coda.
- **Cron CI per `process-stop-replies.mjs` (item 2)**: non aggiunto un workflow schedulato perché la coda inbound è popolata dal Worker il cui binding è ancora manuale; senza sorgente live un cron girerebbe a vuoto. Follow-up una volta attivo il binding Email Routing.
- **DNS sottodominio outreach isolato — SPF/DKIM/DMARC su `outreach.frontaliereticino.ch` (item 3, infra manuale)**: è configurazione DNS Cloudflare, fuori da una PR di codice. Il codice supporta già il puntamento via `OUTREACH_FROM_ADDRESS`; restano da creare il sottodominio + record SPF/DKIM e DMARC `p=none`, e verificare la mailbox prima del primo invio reale.