### PR TITLE
feat(survey): track feature_survey_impression on display

### DIFF
--- a/components/community/FeatureSurvey.tsx
+++ b/components/community/FeatureSurvey.tsx
@@ -54,6 +54,7 @@ const FeatureSurvey: React.FC = () => {
   const [submitted, setSubmitted] = useState(false);
   const timeReady = useRef(false);
   const requested = useRef(false);
+  const impressionFired = useRef(false);
 
   // Never show for bots/crawlers — they must see full page content, and we don't
   // want survey events polluting analytics. Mirrors the PostHog bot gate.
@@ -94,6 +95,18 @@ const FeatureSurvey: React.FC = () => {
       unsub();
     };
   }, [isBot]);
+
+  // Fire a single impression event once the survey is actually on screen (slot
+  // granted by the popup queue), so we can measure display→submit conversion.
+  // Without this, only submits are captured — a survey that never shows and one
+  // shown-but-ignored look identical in PostHog.
+  useEffect(() => {
+    if (isBot || !visible || !queueActive || impressionFired.current) return;
+    impressionFired.current = true;
+    const payload = { page: window.location.pathname };
+    captureEvent('feature_survey_impression', payload);
+    Analytics.trackEvent('feature_survey_impression', payload);
+  }, [isBot, visible, queueActive]);
 
   const persistCooldown = () => {
     localStorage.setItem(DISMISSED_KEY, String(Date.now()));

--- a/tests/feature-survey.test.tsx
+++ b/tests/feature-survey.test.tsx
@@ -2,8 +2,9 @@
  * FeatureSurvey micro-survey coverage.
  *
  * Verifies the engagement gate (time + page views), the 90-day dismiss
- * cooldown, and that a submit captures `feature_survey_response` to PostHog
- * (and GA via Analytics) with the stable, locale-independent option id.
+ * cooldown, that showing the survey captures a single `feature_survey_impression`,
+ * and that a submit captures `feature_survey_response` to PostHog (and GA via
+ * Analytics) with the stable, locale-independent option id.
  */
 
 import React from 'react';
@@ -114,6 +115,32 @@ describe('FeatureSurvey engagement gate', () => {
   });
 });
 
+describe('FeatureSurvey impression', () => {
+  it('captures a single impression once the survey is shown', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(25_000);
+    });
+
+    const impressions = captureMock.mock.calls.filter(([name]) => name === 'feature_survey_impression');
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0][1]).toMatchObject({ page: expect.any(String) });
+    expect(trackEventMock).toHaveBeenCalledWith('feature_survey_impression', expect.any(Object));
+  });
+
+  it('does not fire an impression before the engagement gate is met', async () => {
+    sessionStorage.setItem('feature_survey_pageviews', '1');
+    await act(async () => {
+      render(<FeatureSurvey />);
+    });
+    // No timer advance → survey not shown yet.
+    expect(captureMock).not.toHaveBeenCalledWith('feature_survey_impression', expect.anything());
+  });
+});
+
 describe('FeatureSurvey submission', () => {
   it('captures the stable option id to PostHog and GA, then sets the cooldown', async () => {
     sessionStorage.setItem('feature_survey_pageviews', '1');
@@ -128,10 +155,9 @@ describe('FeatureSurvey submission', () => {
     fireEvent.click(screen.getByText('survey.feature.option.traffic_alerts'));
     fireEvent.click(screen.getByText('survey.feature.submit'));
 
-    expect(captureMock).toHaveBeenCalledTimes(1);
-    const [eventName, payload] = captureMock.mock.calls[0];
-    expect(eventName).toBe('feature_survey_response');
-    expect(payload).toMatchObject({ feature: 'traffic_alerts' });
+    const responseCall = captureMock.mock.calls.find(([name]) => name === 'feature_survey_response');
+    expect(responseCall).toBeDefined();
+    expect(responseCall![1]).toMatchObject({ feature: 'traffic_alerts' });
     expect(trackEventMock).toHaveBeenCalledWith('feature_survey_response', expect.objectContaining({ feature: 'traffic_alerts' }));
     expect(localStorage.getItem('feature_survey_dismissed')).not.toBeNull();
   });
@@ -151,9 +177,9 @@ describe('FeatureSurvey submission', () => {
     });
     fireEvent.click(screen.getByText('survey.feature.submit'));
 
-    expect(captureMock).toHaveBeenCalledTimes(1);
-    const [, payload] = captureMock.mock.calls[0];
-    expect(payload).toMatchObject({ feature: 'other', detail: 'PDF export of payslips' });
+    const responseCall = captureMock.mock.calls.find(([name]) => name === 'feature_survey_response');
+    expect(responseCall).toBeDefined();
+    expect(responseCall![1]).toMatchObject({ feature: 'other', detail: 'PDF export of payslips' });
   });
 
   it('does not submit when no feature is selected', async () => {
@@ -166,6 +192,6 @@ describe('FeatureSurvey submission', () => {
     });
 
     fireEvent.click(screen.getByText('survey.feature.submit'));
-    expect(captureMock).not.toHaveBeenCalled();
+    expect(captureMock).not.toHaveBeenCalledWith('feature_survey_response', expect.anything());
   });
 });


### PR DESCRIPTION
## Implementato
- `components/community/FeatureSurvey.tsx`: nuovo evento `feature_survey_impression` (PostHog `captureEvent` + GA4 `Analytics.trackEvent`) fired **una sola volta** quando la popup-queue mette davvero il survey a schermo (`visible && queueActive`), via `useEffect` guardato da un ref `impressionFired`. Payload `{ page }` come l'evento di response. Skippa i bot (riusa il gate `isBot` esistente).
- `tests/feature-survey.test.tsx`: nuovo describe "FeatureSurvey impression" (1 impression quando mostrato + nessuna impression prima del gate); asserzioni di submission aggiornate a matchare per nome-evento (`feature_survey_response`) dato che ora `captureEvent` riceve anche l'impression; header doc aggiornato.

**Perché:** finora veniva catturato solo `feature_survey_response` (on submit). Un survey che non si mostra mai e uno mostrato-ma-ignorato erano indistinguibili su PostHog (zero eventi in entrambi i casi). L'impression abilita un funnel reale display→submit e fa capire se il problema è la *comparsa* o la *conversione*. Nasce dalla verifica: 0 `feature_survey_response` in 120gg (survey live da PR #2703, 22 giu), nessuna telemetria sul display.

## Non implementato (ancora)
- Nessun evento su **dismiss-via-PostHog**: il dismiss continua a passare solo da GA4 (`Analytics.trackUIInteraction`), come prima. Out of scope: la leva richiesta è misurare la comparsa, non ridisegnare la telemetria del dismiss.
- Nessun cambio alla **logica popup-queue** (priorità 20 condivisa col newsletter popup): se i dati impression mostrassero che il survey non compare mai perché il newsletter gli ruba sempre lo slot, sarà un follow-up separato — prima servono i dati che questo evento produce.
- Claim di volume/conversione non verificabili pre-merge: i numeri reali si osserveranno su PostHog post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)