### PR TITLE
fix(ci): keep head ref of a reopened PR (close+reopen retrigger was orphaning branches)

### DIFF
--- a/.github/workflows/worktree-branch-janitor.yml
+++ b/.github/workflows/worktree-branch-janitor.yml
@@ -171,12 +171,26 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           set -uo pipefail
           if [ "$HEAD_REPO" != "$REPO" ]; then echo "skip fork head ($HEAD_REPO)"; exit 0; fi
           case "$HEAD_REF" in
             "$DEFAULT_BRANCH"|gh-pages|HEAD) echo "skip protected $HEAD_REF"; exit 0 ;;
           esac
+          # Guard against the close+reopen CI-retrigger hack (scripts/ci/pr-autorebase.mjs
+          # reopenToRetrigger): a momentary `closed` event fires this job, but the PR is
+          # reopened ~2s later. Deleting its head ref orphans an OPEN PR — mergeable=UNKNOWN,
+          # it needs a re-push, and the re-push re-gates CI as `action_required` (the whole
+          # branch-disappears cascade). Re-query the CURRENT state and delete ONLY if the PR
+          # is STILL closed. The short sleep closes the tiny close→reopen race window.
+          # (Forensics 2026-06-23: #2787/#2793 lost their branches exactly this way.)
+          sleep 8
+          STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "")
+          if [ "$STATE" = "OPEN" ]; then
+            echo "skip: PR #$PR_NUM is OPEN again (close+reopen retrigger) — head ref $HEAD_REF kept"
+            exit 0
+          fi
           if gh api -X DELETE "repos/$REPO/git/refs/heads/$HEAD_REF" 2>/dev/null; then
             echo "deleted origin/$HEAD_REF (PR closed unmerged)"
           else


### PR DESCRIPTION
## Implementato

**Root cause (forensics 2026-06-23 sui blocchi di #2787/#2793).** Timeline identico su entrambe:
```
closed by valerielinc-ops
reopened by valerielinc-ops      (~2s dopo)
head_ref_deleted by github-actions[bot]   (~30-140s dopo)
```
`scripts/ci/pr-autorebase.mjs` → `reopenToRetrigger()` fa `gh pr close` + `gh pr reopen` per ri-triggerare review+tests dopo un rebase. L'evento `closed` momentaneo scatena il job `delete-closed-unmerged` di `worktree-branch-janitor.yml`, che **cancellava la head ref fidandosi del solo payload evento** (`github.event.pull_request.merged == false`), senza ri-controllare che la PR fosse stata riaperta. Risultato: PR OPEN **senza head branch** → `mergeable=UNKNOWN`, serve re-push manuale, e il re-push **ri-gating della CI come `action_required`** (l'intero cascade che ha stallato #2787/#2793 oggi).

**Fix** (`.github/workflows/worktree-branch-janitor.yml`, job `delete-closed-unmerged`): prima del `DELETE` ri-interroga lo **stato CORRENTE** della PR (`gh pr view --json state`) e cancella la head ref **solo se ANCORA closed**. Un breve `sleep 8` chiude la finestra di race close→reopen (il runner parte comunque >10s dopo, ma il sleep è cintura+bretelle). Il path legittimo (PR davvero chiusa-non-mergiata) resta invariato.

## Non implementato (ancora)

- **Sibling `check-sibling-patterns` (5 file con `HEAD_REF`/`PR_NUM`)** — ispezionati: NESSUNO ha lo stesso antipattern (cancellazione head-ref su evento `closed` fidandosi del payload). `pr-redflag-fixer.yml` triggera su `pull_request_review`, non cancella branch (li *consuma* e gestisce già il branch-sparito); `pr-review-loop.yml`/`post-merge-followup.yml`/`is-followup-fix-pr.mjs` usano `PR_NUM` come variabile comune, nessuna delete. Il job cron del janitor (riga ~150) ri-interroga già lo stato fresco via `gh pr list` → mai stato affetto. Quindi la classe è chiusa qui.
- **Rimuovere il close+reopen in `pr-autorebase.mjs`** come meccanismo di retrigger — fuori scope: è il loro retrigger deliberato e, con questo fix, è innocuo (riapre la CI come voluto senza orfanare il branch). Un retrigger alternativo (empty commit / `gh workflow run`) è un follow-up separato.
- Workflow-change non validabile in esecuzione pre-merge (gira solo on-event) → se un futuro `closed`-reale smettesse di potare i branch closed-unmerged, controllare il guard di stato. Path legittimo coperto: STATE!=OPEN → delete come prima.