### PR TITLE
fix(deploy): raise CDN ordering-guard timeout 600s→1800s (stale en/de/fr shards)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -695,6 +695,19 @@ jobs:
         continue-on-error: true
         env:
           DEPLOY_BUILD_ID: ${{ needs.matrix-setup.outputs.build_id }}
+          # The IT shard's CDN push (deploy-it-pages-prep.sh) only stamps THIS
+          # build's marker at the END of the IT leg, which runs ~15-22min LONGER
+          # than the en/de/fr legs: IT's SSG build alone can reach ~43min vs ~23min
+          # for the others, then IT spends another ~9-10min on the Pages+CDN deploy
+          # prep. The non-IT gate starts polling the moment ITS (shorter) build
+          # finishes, so it must out-wait that whole gap. The previous default of
+          # 600s (10min) left ~zero headroom — observed runs matched the marker at
+          # 540s (60s to spare) and tipped into a stale-shard on normal variance
+          # (#2786/#2806/#2807: gate gave up ~13s before the marker landed),
+          # silently shipping a stale en/de/fr locale. 1800s (30min) covers even
+          # the worst-case 43min IT SSG build with margin; the gate still exits the
+          # instant the marker matches, so the budget is a ceiling, not a fixed wait.
+          CDN_WAIT_TIMEOUT_S: 1800
         run: bash scripts/lib/wait-cdn-build-id.sh "${DEPLOY_BUILD_ID}"
 
       - name: Push locale shard


### PR DESCRIPTION
## Implementato

Root cause dei recurring **#2786 (en) / #2806 (de) / #2807 (fr)** "locale shard push failed (stale live locale)": **non** errore transiente né deploy-key scaduta — è il **CDN ordering guard** (`scripts/lib/wait-cdn-build-id.sh`, step `cdn-gate` in `deploy.yml`) che **timeout**.

Meccanica verificata sui run (`28021509306`, `28009694807` falliti; `28015967567` verde):
- Il gate ha `continue-on-error: true` → in timeout il `conclusion` mostra `success` (mascherato) ma l'`outcome` reale è `failure`. Le condizioni a valle usano `.outcome`: `push-shard` → **skipped** (gate≠success), `Surface stale-locale` → **fires** (gate==failure) → apre l'issue. Solo en/de/fr (it non gata).
- Il marker `cdn-build-id.txt` viene stampato dall'IT shard solo **alla fine** del suo leg, che gira ~15-22min più a lungo dei leg non-IT (build SSG IT fino a ~43min vs ~23min, poi ~9-10min di deploy-prep Pages+CDN). Il gate non-IT parte appena finisce la SUA build (più corta) → deve out-attendere tutto quel gap.
- Budget `600s` (10min) = margine ~zero: run verde ha matchato il marker a **540s** (60s di margine); i run falliti hanno mollato **~13s prima** che il marker atterrasse → stale shard spedito silenziosamente (deploy verde by design).

Fix: set `CDN_WAIT_TIMEOUT_S: 1800` (30min) nell'env dello step `cdn-gate`. Copre anche il worst-case 43min IT SSG build con margine. Il gate esce **nell'istante** in cui il marker matcha → il budget è un soffitto, non un'attesa fissa: nel caso normale esce ancora a ~9-16min.

`Closes #2786`
`Closes #2806`
`Closes #2807`

## Non implementato (ancora)

- **`scripts/lib/wait-cdn-build-id.sh` non toccato** (flaggato dal sibling-checker per il token condiviso `CDN_WAIT_TIMEOUT_S`): è il *consumer* della env var, non un antipattern duplicato. Già defaulta a 600 e onora l'override — il fix è proprio passare l'override al call-site. Nessun costrutto da sweepare.
- **Riduzione strutturale del gap IT-vs-non-IT** (es. anticipare il CDN push, accorciare la build SSG IT): out of scope — fix chirurgico sul budget del guard. Il collo SSG build ~43min è documentato off-limits.
- **Claim wall-time non validabile pre-merge**: il deploy matrix gira solo post-merge su `main`. Revert-trigger: se un prossimo deploy mostra ancora il gate in timeout (marker oltre 1800s) → indagare un genuino fallimento del push IT CDN (non più budget) o alzare ulteriormente.