### PR TITLE
fix(ads): collapse SPA side-rails on real creative paint (not GPT render flag)

### DIFF
--- a/components/shared/ArticleRailAdStack.tsx
+++ b/components/shared/ArticleRailAdStack.tsx
@@ -71,6 +71,10 @@ const MIN_FILL_PX = 600;
 // Bound the number of same-unit requests (ceiling; the real count is the lower
 // of "panels that cover the viewport" and "panels the gutter holds").
 const MAX_PANELS = 6;
+// Grace before collapsing a rail that has painted no creative. Genuine fills
+// land within ~1-2s; this leaves slow auctions room while keeping a blank
+// gutter short. Mirrors AdSenseBanner's fill-timeout intent.
+const FILL_GRACE_MS = 6000;
 
 const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled = true, count, narrow = false, onEmptyResolved }) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -95,15 +99,46 @@ const ArticleRailAdStack: React.FC<ArticleRailAdStackProps> = ({ side, enabled =
       reported++;
       if (v === false) anyFilled = true;
     }
-    let verdict: boolean | null = null;
-    if (anyFilled) verdict = false;
-    else if (panels > 0 && reported >= panels) verdict = true;
-    // Report every resolved verdict; the App owns dedup (it no-ops a same-value
-    // setState). No per-tab re-arm here: the rail stack stays mounted across SPA
-    // navigations and GPT does not re-request the persistent slot, so once a
-    // rail resolves empty it stays empty for the session and the collapse simply
-    // persists — a local dedup ref would instead swallow a legitimate re-report.
-    if (verdict !== null) onEmptyResolved?.(verdict);
+    // Fast-path collapse ONLY on a clean all-empty GPT verdict. We deliberately
+    // do NOT report `false` from the render flag: GPT often resolves these
+    // narrow rails "non-empty" yet paints no creative (zero-height / house /
+    // pending fills), so EXPANSION is decided by actual iframe paint in the
+    // effect below — not by the unreliable render flag. App owns dedup.
+    if (anyFilled === false && panels > 0 && reported >= panels) onEmptyResolved?.(true);
+  }, [panels, onEmptyResolved]);
+
+  // Authoritative fill signal: collapse from what ACTUALLY renders, not GPT's
+  // render flags. Confirmed live that these rails define their slots but paint
+  // no creative and never fire a clean empty verdict — leaving a blank 160px
+  // column. Here we watch the rail for a real painted ad iframe: expand the
+  // moment one appears, and if none has by FILL_GRACE_MS collapse the gutter so
+  // it never stays blank (no-demand / ad-block / pending). A late paint still
+  // re-expands via the observer.
+  useEffect(() => {
+    if (panels <= 0) return;
+    const el = ref.current;
+    if (!el) return;
+    let last: boolean | null = null;
+    const filled = () => {
+      const frames = el.querySelectorAll<HTMLIFrameElement>('iframe');
+      for (let i = 0; i < frames.length; i++) {
+        if (frames[i].getBoundingClientRect().height > 1) return true;
+      }
+      return false;
+    };
+    const apply = (isFilled: boolean) => {
+      const collapse = !isFilled;
+      if (collapse === last) return;
+      last = collapse;
+      onEmptyResolved?.(collapse);
+    };
+    const mo = typeof MutationObserver !== 'undefined' ? new MutationObserver(() => { if (filled()) apply(true); }) : null;
+    mo?.observe(el, { childList: true, subtree: true });
+    const grace = setTimeout(() => apply(filled()), FILL_GRACE_MS);
+    return () => {
+      mo?.disconnect();
+      clearTimeout(grace);
+    };
   }, [panels, onEmptyResolved]);
 
   useEffect(() => {


### PR DESCRIPTION
## Implementato

Follow-up a #2830 dopo **verifica live** su `/en/` (deploy `1782279269733`): i rail laterali **non collassavano** comunque. Diagnosi live (Playwright + `googletag`):
- GPT carica, `apiReady`, definisce i 4 slot rail (`/article-rail-left|right`).
- **Nessuna creative dipinta**: tutti i wrapper `empty=false`, il primo pannello tiene solo il reserve CLS da 600px, iframe interni 0px. GPT **non emette mai un `isEmpty=true` pulito** per questi rail (li risolve "non-empty" senza dipingere, oppure restano pending).
- Quindi il collapse flag-driven di #2830 non scattava → le colonne bianche da 160px restavano.

**Fix**: decidere il collapse da ciò che **realmente renderizza**, non dai flag GPT (inaffidabili per questi rail stretti):
- Un `MutationObserver` osserva il rail per una creative iframe dipinta (`height > 1px`). **Espande** appena ne appare una; se entro `FILL_GRACE_MS` (6s) non ne è apparsa nessuna, **collassa** il gutter → mai blank (no-demand / ad-block / pending / zero-height fill). Un paint tardivo ri-espande via observer.
- Il verdetto GPT pulito `all-empty` resta come **fast-path** di collasso; non ci fidiamo più del segnale "fill" del flag per l'espansione.

Monetizzazione preservata: se una creative reale dipinge, il rail resta a 160px e mostra l'ad; collassa solo quando non c'è nulla da mostrare. Auto Ads e kill-switch intatti.

### Verifica
- 23/23 test verdi: `check-cls-ad-slots`, `article-ad-slots`, `regression/static-seo-rail-ads`, `handrolled-emitters-rail-gutters`.
- `tsc` pulito su `ArticleRailAdStack.tsx`.
- Geometria del collapse già validata live in #2830 (`main` 1152px→1472px, aside 160px→0px). Questo PR cambia solo il **trigger** (paint-based) che la diagnosi live ha dimostrato necessario.

## Non implementato (ancora)

- **Rail reading 300px (blog / job-board / static SEO)**: stessa classe, griglie separate (alcune HTML statico + portal hydration), `main.seo-static-content` con width diverse → meccanismo per-griglia distinto. Inventario premium 300x600 → fill migliore. Follow-up, come dichiarato in #2830. Le pagine segnalate sono solo tool (160px).
- **Late paint dopo collapse**: se (raro) una creative dipinge dopo i 6s su un aside già a larghezza 0, l'observer ri-espande ma lo slot potrebbe essere stato richiesto a 0px. Edge benigno: questi rail di fatto non si riempiono mai; il caso comune (no-fill → collapse) è coperto. Revert-trigger: se la RUM CF mostra regressione CLS orizzontale su `/`, rivalutare la durata di grace o gating offscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)