### PR TITLE
fix(jobboard): lift job-detail top leaderboard into the empty top band (above rails)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7114,6 +7114,20 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  {authPendingNoticeJsx}
 
+ {/* Top leaderboard banner — full content-width, pinned at the very top of
+     the job-detail view (above the rail grid, just under the "back" link), so
+     it occupies the top ad slot instead of sitting one row down beside the
+     side rails. Desktop (lg+) only; Auto Ads stay untouched — additional
+     manual display unit. */}
+ {isDesktopLg && (
+ <AdSenseBanner
+ adSlot={AD_SLOTS.JOBDETAIL_TOP_BANNER.slot}
+ adFormat={AD_SLOTS.JOBDETAIL_TOP_BANNER.format}
+ fullWidthResponsive={AD_SLOTS.JOBDETAIL_TOP_BANNER.fullWidthResponsive}
+ minHeight={AD_SLOTS.JOBDETAIL_TOP_BANNER.placeholderMinHeight}
+ />
+ )}
+
  {/* 3-column rail grid: left rail | content | right rail. 180px rails at xl
      (1280–1399), widening to 300px at xlw (≥1400) to host the ArticleRailAd
      half-page creatives — same full-height side-rail layout as the article
@@ -7128,19 +7142,6 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  {/* ── Center content (existing 12-col job-detail grid) ── */}
  <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6">
- {/* Top leaderboard banner — full content-width above the header on
- desktop (lg+), spanning both the article and sidebar columns. Auto
- Ads stay untouched; this is an additional manual display unit. */}
- {isDesktopLg && (
- <div className="lg:col-span-12">
- <AdSenseBanner
- adSlot={AD_SLOTS.JOBDETAIL_TOP_BANNER.slot}
- adFormat={AD_SLOTS.JOBDETAIL_TOP_BANNER.format}
- fullWidthResponsive={AD_SLOTS.JOBDETAIL_TOP_BANNER.fullWidthResponsive}
- minHeight={AD_SLOTS.JOBDETAIL_TOP_BANNER.placeholderMinHeight}
- />
- </div>
- )}
  <article className="lg:col-span-8 lg:self-start space-y-4 sm:space-y-5">
  <header className="rounded-3xl border border-edge bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-4 sm:p-6">
  <div className="flex items-start gap-3 sm:gap-4">


### PR DESCRIPTION
## Implementato

- Spostato il **top leaderboard** del job-detail (desktop, slot `JOBDETAIL_TOP_BANNER`, introdotto in #2828) dalla prima cella del grid interno a 12 colonne (`lg:col-span-12`) a uno slot **full content-width sopra il `ft-rail-grid-x`**, subito sotto il link "Torna a tutti gli annunci".
  - Prima il banner era il primo figlio della colonna centrale → renderizzava una riga più in basso, allineato ai side rail, lasciando una **banda vuota in cima** alla pagina (lo "spazio verde" segnalato).
  - Ora occupa quella banda in alto; i rail e l'articolo scorrono sotto il banner.
- Rimosso il wrapper `<div className="lg:col-span-12">` non più necessario (il banner non è più figlio del grid): l'`AdSenseBanner` rende il proprio wrapper full-width.
- Invariati: stesso slot/format, `fullWidthResponsive`, riserva CLS 100px (`placeholderMinHeight`), gate `isDesktopLg` (≥1024px). Auto Ads non toccati.

Solo `components/community/JobBoard.tsx` (14 insertions, 13 deletions). Diff verificato vs `origin/main`. Sintassi validata con esbuild; `vitest` job-board (jobboard-detail-apply-links, job-board-titles) verde.

## Non implementato (ancora)

- **Verifica live del fill reale dell'ad**: non riproducibile pre-merge — #2828 (rail-grid + top banner nel full-detail) **non è ancora deployato** su prod (il live mostra la versione precedente senza rail-grid), e AdSense non serve creatività a browser headless/bot. Layout di posizionamento validato con repro strutturale (banner full-width in cima, rail sotto). Verifica del rendering live post-deploy.
- **Gated/expired/orphan view**: fuori scope — `JOBDETAIL_TOP_BANNER` è usato solo nel full-detail di `JobBoard.tsx`; le altre view hanno la propria strategia ad (nessun pattern gemello "banner dentro center grid" da sweepare).