### PR TITLE
fix(jobboard): place job-detail top banner beside the back link (not below)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7109,7 +7109,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
      to its right (the empty band beside the link). Banner is lg+ only; on
      mobile the row collapses to just the link. Auto Ads stay untouched —
      additional manual display unit. */}
- <div className="flex items-start gap-4">
+ <div className="flex items-center gap-4">
  <button
  onClick={backToList}
  className="inline-flex items-center gap-2 min-h-[44px] text-sm font-semibold text-accent hover:underline shrink-0"

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7104,29 +7104,31 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  return (
  <div className="space-y-6">
+ {/* Back link + top leaderboard share one row: the "back" link keeps its
+     natural width on the left, the desktop banner fills the rest of the row
+     to its right (the empty band beside the link). Banner is lg+ only; on
+     mobile the row collapses to just the link. Auto Ads stay untouched —
+     additional manual display unit. */}
+ <div className="flex items-start gap-4">
  <button
  onClick={backToList}
- className="inline-flex items-center gap-2 min-h-[44px] text-sm font-semibold text-accent hover:underline"
+ className="inline-flex items-center gap-2 min-h-[44px] text-sm font-semibold text-accent hover:underline shrink-0"
  >
  <ArrowLeft size={14} />
  {t('jobBoard.backToList')}
  </button>
-
- {authPendingNoticeJsx}
-
- {/* Top leaderboard banner — full content-width, pinned at the very top of
-     the job-detail view (above the rail grid, just under the "back" link), so
-     it occupies the top ad slot instead of sitting one row down beside the
-     side rails. Desktop (lg+) only; Auto Ads stay untouched — additional
-     manual display unit. */}
  {isDesktopLg && (
  <AdSenseBanner
  adSlot={AD_SLOTS.JOBDETAIL_TOP_BANNER.slot}
  adFormat={AD_SLOTS.JOBDETAIL_TOP_BANNER.format}
  fullWidthResponsive={AD_SLOTS.JOBDETAIL_TOP_BANNER.fullWidthResponsive}
  minHeight={AD_SLOTS.JOBDETAIL_TOP_BANNER.placeholderMinHeight}
+ className="flex-1 min-w-0"
  />
  )}
+ </div>
+
+ {authPendingNoticeJsx}
 
  {/* 3-column rail grid: left rail | content | right rail. 180px rails at xl
      (1280–1399), widening to 300px at xlw (≥1400) to host the ArticleRailAd


### PR DESCRIPTION
## Implementato

- Follow-up di #2844. Il top leaderboard del job-detail (desktop, slot `JOBDETAIL_TOP_BANNER`) era su una **riga full-width sotto** "Torna a tutti gli annunci". Ora back-link e banner condividono **una sola riga flex** (`flex items-center gap-4`):
  - il back-link tiene la sua larghezza naturale a sinistra (`shrink-0`);
  - il banner riempie il resto della riga a destra (`flex-1 min-w-0`) → occupa la banda **al lato** del link (non sotto);
  - `items-center` allinea verticalmente i due → si leggono come **due colonne della stessa riga** (il back-link non resta più incollato in alto col banner che pende sotto).
- Gate `isDesktopLg` (≥1024px) invariato: su mobile la riga collassa al solo back-link (banner nascosto).
- Invariati: stesso slot/format, `fullWidthResponsive`, riserva CLS 100px. Auto Ads non toccati.

Solo `components/community/JobBoard.tsx`. Diff vs `origin/main` verificato; esbuild OK; `vitest` job-board verde; layout validato con repro strutturale (back-link sx + banner dx, centrati, rail/contenuto sotto).

## Non implementato (ancora)

- **Verifica live del fill reale**: non riproducibile pre-merge — #2844/#2828 non ancora deployati su prod e AdSense non serve creatività a browser headless/bot. Posizionamento/allineamento validati via repro; rendering live da verificare post-deploy.
- **Posizione label "PUBBLICITÀ"**: resta centrato sopra l'`<ins>` (comportamento standard `AdSenseBanner`); nessun override (non funnel-critical).