### PR TITLE
feat(outreach): web-UI cold-email send + send/reply tracking

### DIFF
--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -8,7 +8,7 @@ import { getSerpExperimentDiagnostics } from '@/services/seoService';
 import { useAuth } from '@/services/authService';
 import { buildNewsletterPreviewHtml } from '@/services/newsletterPreview';
 import { cdnDataUrl } from '@/services/cdnDataBase';
-import { fetchAdminEmployerInsights, updateEmployerContact, type EmployerInsightsRow } from '@/services/adminInsights';
+import { fetchAdminEmployerInsights, updateEmployerContact, sendColdEmail, type EmployerInsightsRow, type EmployerOutreachStatus } from '@/services/adminInsights';
 // Cold-email sequence: single shared source so the admin preview is byte-identical
 // to what send-cold-emails.mjs actually sends (AGENTS.md Non-Negotiable #6).
 import { buildSequence } from '../../scripts/lib/cold-email-sequence.mjs';
@@ -107,6 +107,42 @@ interface CrawlerSummaryRow {
 
 type CrawlerSortColumn = 'title' | 'schedule' | 'lastRun' | 'total' | 'newCount' | 'updatedCount' | 'removedCount' | 'unchangedCount' | 'duration' | 'status' | 'quality';
 type InsightsSortColumn = 'companyName' | 'views' | 'candidates' | 'lost' | 'adsCount' | 'conversionRate' | 'generatedAt';
+
+/**
+ * Compact cold-email outreach status for the Insights Aziende dashboard: which
+ * touch was sent, whether the company replied, and whether it opted out.
+ * Mirrors the employer_outreach_* telemetry collections (read-only).
+ */
+function OutreachStatusBadge({ outreach }: { outreach?: EmployerOutreachStatus }) {
+  if (!outreach || (outreach.lastTouch === 0 && !outreach.replied && !outreach.suppressed)) {
+    return <span className="text-muted">—</span>;
+  }
+  const sentLabel = outreach.lastTouch > 0
+    ? `Inviata T${outreach.lastTouch}${outreach.touchesSent.length > 1 ? ` (${outreach.touchesSent.length})` : ''}`
+    : null;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {sentLabel && (
+        <span className="inline-flex items-center rounded-full bg-surface-muted px-2 py-0.5 text-[10px] font-medium text-body">
+          {sentLabel}
+        </span>
+      )}
+      {outreach.suppressed ? (
+        <span className="inline-flex items-center rounded-full bg-danger-subtle px-2 py-0.5 text-[10px] font-medium text-danger">
+          Opt-out
+        </span>
+      ) : outreach.replied ? (
+        <span className="inline-flex items-center rounded-full bg-success-subtle px-2 py-0.5 text-[10px] font-medium text-success">
+          ✓ Ha risposto{outreach.replyCount > 1 ? ` (${outreach.replyCount})` : ''}
+        </span>
+      ) : sentLabel ? (
+        <span className="inline-flex items-center rounded-full bg-surface-muted px-2 py-0.5 text-[10px] font-medium text-muted">
+          In attesa
+        </span>
+      ) : null}
+    </span>
+  );
+}
 type CrawlerSortDirection = 'asc' | 'desc';
 
 type WorkflowContext = 'jobs' | 'content' | 'seo' | 'analytics';
@@ -350,6 +386,8 @@ export default function AdminPanel() {
  const [contactSaving, setContactSaving] = useState(false);
  const [contactSaveMsg, setContactSaveMsg] = useState<string | null>(null);
  const [previewTouch, setPreviewTouch] = useState(1);
+ const [sendingTouch, setSendingTouch] = useState(false);
+ const [sendMsg, setSendMsg] = useState<{ ok: boolean; text: string } | null>(null);
  // Crawler table filters & expansion
  const [crawlerNameFilter, setCrawlerNameFilter] = useState('');
  const [crawlerChangeFilter, setCrawlerChangeFilter] = useState<'all' | 'new' | 'updated' | 'removed' | 'none'>('all');
@@ -551,6 +589,7 @@ export default function AdminPanel() {
  setContactRoleDraft(row.topRole || '');
  setContactSaveMsg(null);
  setPreviewTouch(1);
+ setSendMsg(null);
  };
 
  const closeContactModal = () => {
@@ -592,6 +631,56 @@ export default function AdminPanel() {
  setContactSaveMsg(`✗ ${err instanceof Error ? err.message : 'Errore salvataggio.'}`);
  } finally {
  setContactSaving(false);
+ }
+ };
+
+ // Send the currently-previewed touch to the company (admin-only, irreversible
+ // outward action → explicit confirm). The Cloud Function re-checks gate, email,
+ // suppression and dedup; on success we optimistically update the row's outreach
+ // status so the badge reflects the send without a refetch.
+ const handleSendTouch = async (force: boolean) => {
+ if (!contactModalRow) return;
+ const row = contactModalRow;
+ const touch = previewTouch;
+ if (!row.contactEmail) {
+ setSendMsg({ ok: false, text: 'Imposta prima un’email verificata per questa azienda.' });
+ return;
+ }
+ const confirmText = force
+ ? `Re-inviare la touch ${touch} a ${row.contactEmail}? È già stata inviata.`
+ : `Inviare la touch ${touch} a ${row.contactEmail}?`;
+ if (typeof window !== 'undefined' && !window.confirm(confirmText)) return;
+ setSendingTouch(true);
+ setSendMsg(null);
+ try {
+ const res = await sendColdEmail(user, row.companyKey, touch, force);
+ const sentAt = new Date().toISOString();
+ setInsightsRows(prev => prev.map(r => {
+ if (r.companyKey !== row.companyKey) return r;
+ const prevOutreach = r.outreach;
+ const touchesSent = [...new Set([...(prevOutreach?.touchesSent || []), touch])].sort((a, b) => a - b);
+ return {
+ ...r,
+ outreach: {
+ lastTouch: Math.max(touch, prevOutreach?.lastTouch || 0),
+ lastSentAt: sentAt,
+ touchesSent,
+ sendCount: (prevOutreach?.sendCount || 0) + 1,
+ replied: prevOutreach?.replied || false,
+ lastRepliedAt: prevOutreach?.lastRepliedAt || null,
+ replyCount: prevOutreach?.replyCount || 0,
+ suppressed: prevOutreach?.suppressed || false,
+ suppressedAt: prevOutreach?.suppressedAt || null,
+ },
+ };
+ }));
+ setSendMsg({ ok: true, text: res.tracked
+ ? `✓ Touch ${touch} inviata a ${res.to}.`
+ : `✓ Inviata a ${res.to}, ma il tracking non è stato scritto (ricontrolla più tardi).` });
+ } catch (err) {
+ setSendMsg({ ok: false, text: `✗ ${err instanceof Error ? err.message : 'Invio non riuscito.'}` });
+ } finally {
+ setSendingTouch(false);
  }
  };
 
@@ -3215,6 +3304,7 @@ export default function AdminPanel() {
  </button>
  </th>
  ))}
+ <th scope="col" className="px-3 py-2 text-left font-semibold">Outreach</th>
  <th scope="col" className="px-3 py-2 text-right font-semibold">Azione</th>
  </tr>
  </thead>
@@ -3238,6 +3328,7 @@ export default function AdminPanel() {
  <td className="px-3 py-2 text-right text-body">{row.totals.adsCount.toLocaleString('it-IT')}</td>
  <td className="px-3 py-2 text-right text-body">{(row.totals.conversionRate * 100).toFixed(1)}%</td>
  <td className="px-3 py-2 text-right text-muted whitespace-nowrap">{formatInsightsDate(row.generatedAt)}</td>
+ <td className="px-3 py-2 text-left whitespace-nowrap"><OutreachStatusBadge outreach={row.outreach} /></td>
  <td className="px-3 py-2 text-right whitespace-nowrap">
  <div className="inline-flex items-center gap-1.5">
  <button
@@ -3263,7 +3354,7 @@ export default function AdminPanel() {
  ))}
  {!insightsLoading && insightsFiltered.length === 0 && (
  <tr>
- <td colSpan={8} className="px-3 py-6 text-center text-muted">
+ <td colSpan={9} className="px-3 py-6 text-center text-muted">
  Nessuna azienda trovata.
  </td>
  </tr>
@@ -3292,6 +3383,10 @@ export default function AdminPanel() {
  <div><span className="block text-muted">#Annunci</span><span className="text-body">{row.totals.adsCount.toLocaleString('it-IT')}</span></div>
  <div><span className="block text-muted">Conv.</span><span className="text-body">{(row.totals.conversionRate * 100).toFixed(1)}%</span></div>
  <div><span className="block text-muted">Data</span><span className="text-body">{formatInsightsDate(row.generatedAt)}</span></div>
+ </div>
+ <div className="flex items-center gap-1.5 text-xs">
+ <span className="text-muted">Outreach:</span>
+ <OutreachStatusBadge outreach={row.outreach} />
  </div>
  <div className="grid grid-cols-2 gap-2">
  <button
@@ -3340,6 +3435,13 @@ export default function AdminPanel() {
  {contactModalRow.companyName}
  </h3>
  <p className="text-xs text-muted">{contactModalRow.totals.candidates.toLocaleString('it-IT')} candidati · {contactModalRow.totals.views.toLocaleString('it-IT')} visite</p>
+ <div className="mt-1.5 flex items-center gap-1.5 text-xs">
+ <span className="text-muted">Outreach:</span>
+ <OutreachStatusBadge outreach={contactModalRow.outreach} />
+ {contactModalRow.outreach?.lastSentAt && (
+ <span className="text-muted">· ultima {formatInsightsDate(contactModalRow.outreach.lastSentAt)}</span>
+ )}
+ </div>
  </div>
  <button
  type="button"
@@ -3432,7 +3534,7 @@ export default function AdminPanel() {
  type="button"
  role="tab"
  aria-selected={previewTouch === t.touch}
- onClick={() => setPreviewTouch(t.touch)}
+ onClick={() => { setPreviewTouch(t.touch); setSendMsg(null); }}
  className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors border ${
  previewTouch === t.touch
  ? 'border-accent bg-accent-subtle text-accent'
@@ -3452,6 +3554,41 @@ export default function AdminPanel() {
  <pre className="px-3 py-3 text-sm text-body whitespace-pre-wrap font-sans leading-relaxed">{t.body}</pre>
  </div>
  ))}
+ {/* Web-UI send: dispatch the previewed touch. Gate, verified-email,
+ suppression and dedup are re-checked server-side; this is just the trigger. */}
+ <div className="space-y-2 rounded-lg border border-edge bg-surface-raised px-3 py-3">
+ {contactModalRow.outreach?.suppressed ? (
+ <p className="text-xs text-danger">Azienda in opt-out (STOP/disiscrizione) — invio bloccato.</p>
+ ) : !contactModalRow.contactEmail ? (
+ <p className="text-xs text-subtle">Imposta un’email verificata qui sopra per abilitare l’invio.</p>
+ ) : contactModalRow.outreach?.touchesSent?.includes(previewTouch) ? (
+ <div className="flex flex-wrap items-center gap-2">
+ <span className="text-xs text-muted">Touch {previewTouch} già inviata{contactModalRow.outreach?.lastSentAt ? ` (${formatInsightsDate(contactModalRow.outreach.lastSentAt)})` : ''}.</span>
+ <button
+ type="button"
+ disabled={sendingTouch}
+ onClick={() => handleSendTouch(true)}
+ className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-surface-muted hover:bg-surface-alt disabled:opacity-60 text-body text-xs font-semibold transition-colors"
+ >
+ {sendingTouch ? <Loader2 size={14} className="animate-spin" aria-hidden="true" /> : null}
+ Forza re-invio
+ </button>
+ </div>
+ ) : (
+ <button
+ type="button"
+ disabled={sendingTouch}
+ onClick={() => handleSendTouch(false)}
+ className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-success-strong hover:bg-success-strong-hover disabled:opacity-60 text-on-accent text-sm font-semibold transition-colors"
+ >
+ {sendingTouch ? <Loader2 size={14} className="animate-spin" aria-hidden="true" /> : null}
+ {sendingTouch ? 'Invio…' : `Invia touch ${previewTouch} a ${contactModalRow.contactEmail}`}
+ </button>
+ )}
+ {sendMsg && (
+ <p className={`text-xs ${sendMsg.ok ? 'text-success' : 'text-danger'}`}>{sendMsg.text}</p>
+ )}
+ </div>
  <a
  href={contactModalRow.insightsUrl}
  target="_blank"

--- a/components/pages/EmployerInsightsPage.tsx
+++ b/components/pages/EmployerInsightsPage.tsx
@@ -295,6 +295,19 @@ export function EmployerInsightsReport({ data }: { data: EmployerInsights }): Re
         </a>
       </RevealSection>
 
+      {/* Save-as-PDF: lets the company keep its own copy without us emailing an
+          attachment (attachments hurt cold-email deliverability). Browser
+          print-to-PDF; hidden in the printed output itself. */}
+      <div className="text-center print:hidden">
+        <button
+          type="button"
+          onClick={() => { if (typeof window !== 'undefined') window.print(); }}
+          className="inline-flex items-center justify-center gap-2 px-5 py-2.5 text-sm font-semibold text-body bg-surface-alt hover:bg-surface-muted border border-edge rounded-xl transition-colors"
+        >
+          Salva questi dati in PDF
+        </button>
+      </div>
+
       <p className="text-center text-xs text-muted">
         Dati relativi a {data.companyName} generati il{' '}
         {new Date(data.generatedAt).toLocaleDateString('it-IT')} · pagina privata, non indicizzata.

--- a/functions/index.js
+++ b/functions/index.js
@@ -17,13 +17,17 @@ import { handleLinkedInCallback } from './src/linkedinAuthCallback.js';
 import { handleJobAlertUnsubscribe } from './src/jobAlertUnsubscribe.js';
 import { handleOutreachUnsubscribe } from './src/outreachUnsubscribe.js';
 import { handleOutreachStopReply } from './src/outreachStopReply.js';
+import { handleOutreachReplyTrack } from './src/outreachReplyTrack.js';
 import { handleEmployerInsights } from './src/employerInsights.js';
 import { handleRecaptchaVerification } from './src/recaptchaVerification.js';
 import { getPublicConfigValues } from './src/publicConfig.js';
 import { handleGeminiGenerate } from './src/geminiGenerate.js';
 import { handleGetExchangeRate } from './src/exchangeRate.js';
 import { handleCreateFeedbackIssue, handleGetAdminGithubToken } from './src/githubProxy.js';
-import { handleAdminEmployerInsights } from './src/adminEmployerInsights.js';
+import { handleAdminEmployerInsights, assertAdmin } from './src/adminEmployerInsights.js';
+import { handleAdminSendColdEmail } from './src/adminSendColdEmail.js';
+import { getAdminDb } from './src/newsletterResendWebhookCore.js';
+import { Resend } from 'resend';
 import { handleCreatePublisherCheckout, handleStripeWebhook, handleCreateBillingPortal, handleArchivePublisherAd, handleRestorePublisherAd } from './src/stripePublisherCore.js';
 import { reapStalePendingPayments } from './src/publisherPendingReapCore.js';
 import { onDocumentCreated } from 'firebase-functions/v2/firestore';
@@ -138,6 +142,66 @@ export const adminEmployerInsights = onRequest(
       res.status(status).json(body);
     } catch (error) {
       console.error('[adminEmployerInsights]', error instanceof Error ? error.message : String(error));
+      res.status(500).json({ ok: false, error: 'internal_error' });
+    }
+  },
+);
+
+// adminSendColdEmail — admin-gated web-UI cold-email sender. POST { companyKey,
+// touch, force? } with the admin's Firebase ID token. Enforces verified-email,
+// suppression and dedup server-side, sends via Resend (one-click List-Unsubscribe
+// header), and logs the send to employer_outreach_sends so the dashboard tracks
+// it. The send body is the shared buildSequence (byte-identical to the preview).
+export const adminSendColdEmail = onRequest(
+  {
+    region: 'europe-west6',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true,
+  },
+  async (req, res) => {
+    try {
+      if (req.method !== 'POST') {
+        res.status(405).json({ ok: false, error: 'method_not_allowed' });
+        return;
+      }
+      const auth = await assertAdmin(req);
+      if (!auth.ok) {
+        res.status(auth.status).json({ ok: false, error: auth.error });
+        return;
+      }
+      const { resendApiKey, newsletterSecret } = await getNewsletterSecrets();
+      if (!resendApiKey) {
+        res.status(503).json({ ok: false, error: 'resend_key_missing' });
+        return;
+      }
+      const resend = new Resend(resendApiKey);
+      const sendEmail = async ({ from, to, subject, text, unsubUrl }) => {
+        const { data, error } = await resend.emails.send({
+          from,
+          to,
+          subject,
+          text,
+          headers: {
+            'List-Unsubscribe': `<${unsubUrl}>`,
+            'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+          },
+        });
+        if (error) throw new Error(error.message || 'resend_error');
+        return { messageId: (data && data.id) || '' };
+      };
+      const body = req.body || {};
+      const { status, body: out } = await handleAdminSendColdEmail({
+        companyKey: body.companyKey,
+        touch: body.touch,
+        force: Boolean(body.force),
+        secret: newsletterSecret,
+        db: getAdminDb(),
+        sendEmail,
+      });
+      res.status(status).json(out);
+    } catch (error) {
+      console.error('[adminSendColdEmail]', error instanceof Error ? error.message : String(error));
       res.status(500).json({ ok: false, error: 'internal_error' });
     }
   },
@@ -741,6 +805,43 @@ export const outreachStopReply = onRequest(
  res.status(result.status).type('text').send(result.body);
  } catch (error) {
  console.error('[outreachStopReply] Error:', error);
+ res.status(500).type('text').send('error');
+ }
+ },
+);
+
+/**
+ * outreachReplyTrack — records ANY inbound cold-email reply (not just STOP) so
+ * the admin dashboard can show whether a company replied. The Cloudflare Email
+ * Worker POSTs { from, subject } for every inbound reply with the shared secret
+ * in `x-stop-secret`; this upserts employer_outreach_replies/{companyKey}.
+ * Additive to outreachStopReply (which still handles STOP suppression).
+ * POST-only, secret-gated.
+ */
+export const outreachReplyTrack = onRequest(
+ {
+ region: 'europe-west6',
+ memory: '256MiB',
+ timeoutSeconds: 30,
+ cors: false,
+ },
+ async (req, res) => {
+ if (req.method !== 'POST') {
+ res.status(405).send('Method not allowed');
+ return;
+ }
+ try {
+ const { newsletterSecret } = await getNewsletterSecrets();
+ const body = req.body || {};
+ const result = await handleOutreachReplyTrack({
+ from: body.from,
+ subject: body.subject,
+ secret: newsletterSecret,
+ providedSecret: String(req.get('x-stop-secret') || ''),
+ });
+ res.status(result.status).type('text').send(result.body);
+ } catch (error) {
+ console.error('[outreachReplyTrack] Error:', error);
  res.status(500).type('text').send('error');
  }
  },

--- a/functions/src/adminEmployerInsights.js
+++ b/functions/src/adminEmployerInsights.js
@@ -36,6 +36,11 @@ const ADMIN_EMAIL_ALLOWLIST = new Set(['valerielinc@gmail.com']);
 const BASE_URL = 'https://frontaliereticino.ch';
 const INSIGHTS_COLLECTION = 'employer_insights';
 const CONTACTS_COLLECTION = 'employer_contacts';
+// Outreach telemetry collections (written by send-cold-emails.mjs + the inbound
+// reply Cloud Functions). Read-only here, merged into each row as `outreach`.
+const SENDS_COLLECTION = 'employer_outreach_sends';
+const REPLIES_COLLECTION = 'employer_outreach_replies';
+const SUPPRESSION_COLLECTION = 'employer_outreach_suppression';
 
 // Pragmatic email shape check (server-side; the SPA also validates). Empty string
 // is allowed by the caller (clears the field) and never reaches this regex.
@@ -48,7 +53,9 @@ function buildInsightsUrl(companyKey, secret) {
 }
 
 // ── Admin gate (mirrors githubProxy.js assertAdmin) ─────────────────────────
-async function assertAdmin(req) {
+// Exported so adminSendColdEmail reuses the exact same gate (allowlist + verified
+// email) instead of a third copy.
+export async function assertAdmin(req) {
   const header = req.get ? req.get('Authorization') : req.headers?.authorization;
   const idToken = typeof header === 'string' && header.startsWith('Bearer ')
     ? header.slice(7).trim()
@@ -84,11 +91,62 @@ async function loadContactsMap(db) {
   return map;
 }
 
+/**
+ * Read the three outreach-telemetry collections once → Map(companyKey → status).
+ * Lets the dashboard show, per company: which touch was sent + when, whether the
+ * company replied, and whether it opted out (STOP). All three are best-effort —
+ * a missing collection just yields empty status, never an error.
+ */
+async function loadOutreachMap(db) {
+  const map = new Map();
+  const ensure = (key) => {
+    if (!map.has(key)) {
+      map.set(key, {
+        lastTouch: 0, lastSentAt: null, touchesSent: [], sendCount: 0,
+        replied: false, lastRepliedAt: null, replyCount: 0,
+        suppressed: false, suppressedAt: null,
+      });
+    }
+    return map.get(key);
+  };
+
+  const [sends, replies, suppression] = await Promise.all([
+    db.collection(SENDS_COLLECTION).get().catch(() => ({ forEach() {} })),
+    db.collection(REPLIES_COLLECTION).get().catch(() => ({ forEach() {} })),
+    db.collection(SUPPRESSION_COLLECTION).get().catch(() => ({ forEach() {} })),
+  ]);
+
+  sends.forEach((doc) => {
+    const d = doc.data() || {};
+    const o = ensure(String(d.companyKey || doc.id));
+    const touches = Array.isArray(d.touches) ? d.touches : [];
+    o.touchesSent = [...new Set(touches.map((x) => Number(x?.touch || 0)).filter(Boolean))].sort((a, b) => a - b);
+    o.sendCount = touches.length;
+    o.lastTouch = Number(d.lastTouch || (o.touchesSent.length ? o.touchesSent[o.touchesSent.length - 1] : 0));
+    o.lastSentAt = d.lastSentAt ? String(d.lastSentAt) : null;
+  });
+  replies.forEach((doc) => {
+    const d = doc.data() || {};
+    const o = ensure(String(d.companyKey || doc.id));
+    o.replied = d.replied !== false;
+    o.lastRepliedAt = d.lastRepliedAt ? String(d.lastRepliedAt) : null;
+    o.replyCount = Number(d.replyCount || 0);
+  });
+  suppression.forEach((doc) => {
+    const d = doc.data() || {};
+    const o = ensure(String(d.companyKey || doc.id));
+    o.suppressed = true;
+    o.suppressedAt = d.suppressedAt ? String(d.suppressedAt) : null;
+  });
+  return map;
+}
+
 /** GET → lean per-company insights list merged with the editable contact. */
 async function handleList(db, newsletterSecret) {
-  const [snap, contacts] = await Promise.all([
+  const [snap, contacts, outreach] = await Promise.all([
     db.collection(INSIGHTS_COLLECTION).get(),
     loadContactsMap(db),
+    loadOutreachMap(db),
   ]);
 
   const insights = snap.docs.map((doc) => {
@@ -114,6 +172,11 @@ async function handleList(db, newsletterSecret) {
       contactName: c.contactName || '',
       contactRole: c.contactRole || '',
       topRole: c.topRole || '',
+      outreach: outreach.get(companyKey) || {
+        lastTouch: 0, lastSentAt: null, touchesSent: [], sendCount: 0,
+        replied: false, lastRepliedAt: null, replyCount: 0,
+        suppressed: false, suppressedAt: null,
+      },
     };
   });
 

--- a/functions/src/adminSendColdEmail.js
+++ b/functions/src/adminSendColdEmail.js
@@ -1,0 +1,132 @@
+/**
+ * adminSendColdEmail.js — admin-gated, web-UI cold-email sender.
+ *
+ * Lets the owner send one cold-outreach touch to a company straight from the
+ * admin dashboard (AdminPanel → Insights Aziende) instead of the CLI, so every
+ * send is centrally tracked in employer_outreach_sends (same collection the CLI
+ * writes) and visible in the dashboard.
+ *
+ * Safeguards (all enforced server-side, never trusting the client):
+ *   1. Admin gate — Firebase ID token + ADMIN_EMAIL_ALLOWLIST (reuses assertAdmin).
+ *   2. Verified email only — never sends to an inferred/guessed address.
+ *   3. Suppression — refuses if the company opted out (employer_outreach_suppression).
+ *   4. Dedup — refuses to re-send a touch already logged, unless `force: true`.
+ *   5. Single source — body built from the shared buildSequence (byte-identical
+ *      to the CLI send and the dashboard preview).
+ *
+ * The actual transport is injected (`sendEmail`) so the core is unit-testable
+ * without hitting Resend; functions/index.js supplies the Resend-backed sender.
+ */
+
+import { FieldValue } from 'firebase-admin/firestore';
+import { buildSequence } from './coldEmailSequence.js';
+import { buildInsightsUrl } from './employerInsights.js';
+import { buildUnsubUrl } from './outreachUnsubscribe.js';
+
+const INSIGHTS_COLLECTION = 'employer_insights';
+const CONTACTS_COLLECTION = 'employer_contacts';
+const SENDS_COLLECTION = 'employer_outreach_sends';
+const SUPPRESSION_COLLECTION = 'employer_outreach_suppression';
+// Matches the CLI default (send-cold-emails.mjs --days-label) so the preview,
+// the CLI send and the web-UI send phrase the period identically.
+const PERIOD_LABEL = 'negli ultimi 3 mesi';
+const VALID_TOUCHES = new Set([1, 2, 3, 4]);
+
+async function getDoc(db, collection, id) {
+  try {
+    const snap = await db.collection(collection).doc(id).get();
+    return snap && snap.exists ? (snap.data() || {}) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Core handler — `db` and `sendEmail` are injectable for unit tests.
+ * Returns { status, body }. `sendEmail({ from, to, subject, text, unsubUrl })`
+ * must resolve to { messageId } or throw.
+ *
+ * @param {{ companyKey?: string, touch?: number, force?: boolean,
+ *           secret?: string, db: any,
+ *           sendEmail: (msg: { from: string, to: string, subject: string,
+ *                              text: string, unsubUrl: string }) => Promise<{ messageId?: string }> }} args
+ */
+export async function handleAdminSendColdEmail({ companyKey, touch, force, secret, db, sendEmail }) {
+  const key = String(companyKey || '').trim();
+  const touchNum = Number(touch);
+  if (!key) return { status: 400, body: { ok: false, error: 'missing_company_key' } };
+  if (!VALID_TOUCHES.has(touchNum)) return { status: 400, body: { ok: false, error: 'invalid_touch' } };
+  if (!secret) return { status: 503, body: { ok: false, error: 'secret_not_configured' } };
+
+  const insights = await getDoc(db, INSIGHTS_COLLECTION, key);
+  if (!insights) return { status: 404, body: { ok: false, error: 'no_insights' } };
+
+  // Verified address only — an inferred guess must never be auto-sent.
+  const contact = (await getDoc(db, CONTACTS_COLLECTION, key)) || {};
+  const toEmail = String(contact.email || '').trim();
+  if (!toEmail) return { status: 422, body: { ok: false, error: 'no_verified_email' } };
+
+  // Opt-out wins over everything.
+  const suppressed = await getDoc(db, SUPPRESSION_COLLECTION, key);
+  if (suppressed) return { status: 409, body: { ok: false, error: 'suppressed' } };
+
+  // Dedup: don't re-send a touch already logged unless explicitly forced.
+  const sends = (await getDoc(db, SENDS_COLLECTION, key)) || {};
+  const sentTouches = Array.isArray(sends.touches)
+    ? sends.touches.map((x) => Number(x && x.touch)).filter(Boolean)
+    : [];
+  if (!force && sentTouches.includes(touchNum)) {
+    return { status: 409, body: { ok: false, error: 'already_sent', touch: touchNum } };
+  }
+
+  const totals = insights.totals || {};
+  const sequence = buildSequence({
+    company: insights.companyName || contact.companyName || key,
+    candidates: Number(totals.candidates || 0),
+    periodLabel: PERIOD_LABEL,
+    contactName: contact.contactName || '',
+    topRole: contact.topRole || '',
+  });
+  const message = sequence.find((m) => m.touch === touchNum);
+  if (!message) return { status: 500, body: { ok: false, error: 'touch_not_built' } };
+
+  const insightsUrl = buildInsightsUrl(key, secret);
+  const unsubUrl = buildUnsubUrl(key, secret);
+  const text = message.body
+    .split('{{INSIGHTS_URL}}').join(insightsUrl)
+    .split('{{UNSUB_URL}}').join(unsubUrl);
+
+  let result;
+  try {
+    result = await sendEmail({
+      from: 'Valerie <valerie@frontaliereticino.ch>',
+      to: toEmail,
+      subject: message.subject,
+      text,
+      unsubUrl,
+    });
+  } catch (err) {
+    return { status: 502, body: { ok: false, error: 'send_failed', detail: err && err.message ? err.message : String(err) } };
+  }
+
+  const messageId = (result && result.messageId) || '';
+  const sentAt = new Date().toISOString();
+  try {
+    await db.collection(SENDS_COLLECTION).doc(key).set({
+      companyKey: key,
+      lastTouch: touchNum,
+      lastSentAt: sentAt,
+      touches: FieldValue.arrayUnion({
+        touch: touchNum, sentAt, provider: 'resend', messageId,
+        subject: message.subject, via: 'web-ui',
+      }),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+  } catch {
+    // The email already went out — a telemetry write failure must not be
+    // reported as a send failure. Surface a soft flag instead.
+    return { status: 200, body: { ok: true, touch: touchNum, to: toEmail, messageId, tracked: false } };
+  }
+
+  return { status: 200, body: { ok: true, touch: touchNum, to: toEmail, messageId, tracked: true } };
+}

--- a/functions/src/coldEmailSequence.js
+++ b/functions/src/coldEmailSequence.js
@@ -1,0 +1,88 @@
+/**
+ * coldEmailSequence.js — SINGLE SOURCE of the cold-outreach email sequence.
+ *
+ * Lives inside functions/ so it is bundled into the deployed Cloud Functions
+ * (the `adminSendColdEmail` web-UI sender imports it). It is ALSO re-exported by
+ * scripts/lib/cold-email-sequence.mjs, which is what the Node scripts
+ * (generate-/send-cold-emails) and the browser admin panel
+ * (components/pages/AdminPanel.tsx → email preview) import. One copy → the admin
+ * preview, the CLI send, and the web-UI send are byte-identical (AGENTS.md
+ * Non-Negotiable #6). Pure ESM, no node imports, so every runtime can load it.
+ *
+ * `{{UNSUB_URL}}` / `{{INSIGHTS_URL}}` are placeholders substituted at send time
+ * by the sender (send-cold-emails.mjs or adminSendColdEmail): the real tokenized
+ * one-click unsubscribe link and the per-company stats-page link.
+ */
+
+export const PRICE = 'CHF 49 al mese per annuncio';
+// Indirizzo opt-out: chi risponde qui (o "STOP") va messo `suppressed` nel send-log.
+export const OPTOUT_EMAIL = 'valerie@frontaliereticino.ch';
+
+/**
+ * Le 4 email della sequenza. Personalizzazione Livello 4 (skill cold-email):
+ * numero REALE di candidati + RUOLO più cliccato, connessi al problema (i click
+ * si perdono). Tono da pari, una sola call-to-action a basso attrito per touch.
+ */
+export function buildSequence({ company, candidates, periodLabel, contactName, topRole }) {
+  // Solo il nome di battesimo nel saluto ("Ciao Denise,"), non nome+cognome.
+  const firstName = (contactName || '').trim().split(/\s+/)[0];
+  const hi = firstName ? `Ciao ${firstName},` : 'Buongiorno,';
+  // Ruolo accorciato per leggibilità; fallback neutro se assente o generico
+  // (titoli-pagina tipo "Lavora con noi", "Concorsi", "Careers" non sono ruoli).
+  const role = (topRole || '').replace(/\s+/g, ' ').trim();
+  const GENERIC_ROLE = /lavora con noi|lavorare con noi|concors|careers?|^jobs?$|offerte di lavoro|posizioni aperte|unsolicited|spontane/i;
+  const pagina = role && !GENERIC_ROLE.test(role) ? `pagina di "${role.slice(0, 48)}"` : 'pagina lavoro';
+  // Opt-out obbligatorio su ogni touch (norma cold-email B2B + deliverability).
+  // Footer leggibile dall'umano; l'header List-Unsubscribe lo aggiunge il sender.
+  // One-click opt-out link ({{UNSUB_URL}}) is substituted at send time by the
+  // sender (buildUnsubUrl(companyKey)). The STOP/email reply path is kept as a
+  // fallback for clients that don't render the link. Drafts keep the literal
+  // placeholder (no companyKey context).
+  const footer = `\n\n—\nPer non ricevere più queste email: {{UNSUB_URL}}\nIn alternativa rispondete con "STOP" (o scrivete a ${OPTOUT_EMAIL}) e vi rimuoviamo subito.`;
+  const seq = [
+    {
+      touch: 1, gapDays: 0, subject: 'candidati inviati',
+      body: `${hi}
+
+${periodLabel} vi abbiamo mandato ${candidates} persone alla vostra ${pagina} da frontaliereticino.ch — gratis, dagli annunci che pubblichiamo per voi.
+
+Il punto è che quei click arrivano sul vostro sito e spesso si perdono. Possiamo farveli arrivare come candidature dirette, CV incluso, nella vostra casella.
+
+Ho preparato i vostri dati reali (annunci, visite, candidati) qui: {{INSIGHTS_URL}}
+
+Valerie`,
+    },
+    {
+      touch: 2, gapDays: 4, subject: 'di quei click',
+      body: `${hi}
+
+Di quei ${candidates} candidati che vi abbiamo mandato ${periodLabel}, quanti si sono poi candidati davvero da voi?
+
+Con l'annuncio sponsorizzato la candidatura arriva diretta nella vostra casella — niente form esterni, niente dispersione. Vi mando un esempio reale?
+
+Valerie`,
+    },
+    {
+      touch: 3, gapDays: 5, subject: 'quanto costa',
+      body: `${hi}
+
+Diverse aziende ticinesi hanno già reso sponsorizzati i loro ruoli da noi. Costa ${PRICE} — contro la fee di un recruiter (migliaia di CHF a ruolo) o un singolo posting su jobs.ch.
+
+Se vi aiuta a coprire anche un solo ruolo, si ripaga da solo. Provo a mostrarvelo sul vostro annuncio più visto?
+
+Valerie`,
+    },
+    {
+      touch: 4, gapDays: 7, subject: 'chiudo',
+      body: `${hi}
+
+Non vi disturbo oltre. In ogni caso vi lascio il riepilogo dei candidati che vi abbiamo mandato finora — usatelo come volete.
+
+Se più avanti volete amplificarlo, sapete dove trovarmi.
+
+Valerie`,
+    },
+  ];
+  // Append the opt-out footer to every touch so drafts and real sends match.
+  return seq.map((m) => ({ ...m, body: m.body + footer }));
+}

--- a/functions/src/employerInsights.js
+++ b/functions/src/employerInsights.js
@@ -17,11 +17,29 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 import { getAdminDb } from './newsletterResendWebhookCore.js';
 
 const INSIGHTS_COLLECTION = 'employer_insights';
+// Canonical prod domain (AGENTS.md). Kept in lockstep with the scripts-side
+// builder scripts/lib/employer-insights-token.mjs (BASE_URL + INSIGHTS_PATH).
+const BASE_URL = 'https://frontaliereticino.ch';
+const INSIGHTS_PATH = '/azienda/';
 
 export function generateInsightsToken(companyKey, secret) {
   return createHmac('sha256', secret)
     .update(`employer_insights:${String(companyKey).trim()}`)
     .digest('hex');
+}
+
+/**
+ * Per-company stats-page URL — MUST stay byte-identical to
+ * scripts/lib/employer-insights-token.mjs `buildInsightsUrl` so a link minted by
+ * the web-UI sender (adminSendColdEmail) verifies the same as one from the CLI.
+ * Falls back to the site home when the secret is missing (never emit an unsigned
+ * link). A cross-boundary parity test guards the two builders against drift.
+ */
+export function buildInsightsUrl(companyKey, secret) {
+  if (!secret) return `${BASE_URL}/`;
+  const key = String(companyKey).trim();
+  const token = generateInsightsToken(key, secret);
+  return `${BASE_URL}${INSIGHTS_PATH}${encodeURIComponent(key)}/?t=${token}`;
 }
 
 export function verifyInsightsToken(companyKey, token, secret) {

--- a/functions/src/outreachReplyTrack.js
+++ b/functions/src/outreachReplyTrack.js
@@ -1,0 +1,56 @@
+/**
+ * outreachReplyTrack.js — server-side recording of ANY inbound cold-email reply
+ * so the admin dashboard can show "ha risposto sì/no" per company.
+ *
+ * The Cloudflare Email Worker (infra/cloudflare-email-worker/stop-reply-handler.js)
+ * POSTs every inbound reply { from, subject } here, gated by the shared secret
+ * (NEWSLETTER_SECRET) in the `x-stop-secret` header — same gate as
+ * outreachStopReply. STOP-intent replies still go to outreachStopReply for
+ * suppression; this endpoint is purely additive reply telemetry.
+ *
+ * It reverse-maps the sender → companyKey (shared with outreachStopReply, no
+ * drift) and upserts `employer_outreach_replies/{companyKey}` with the last
+ * reply + a running count. Sender that maps to no company → no write.
+ *
+ * POST-only, secret-gated, never writes for an unidentifiable/unknown sender.
+ */
+
+import { FieldValue } from 'firebase-admin/firestore';
+import { getAdminDb } from './newsletterResendWebhookCore.js';
+// Single source for sender parsing + company reverse-map (AGENTS.md #6 — no drift).
+import { extractSenderEmail, resolveCompanyKey } from './outreachStopReply.js';
+
+const REPLIES_COLLECTION = 'employer_outreach_replies';
+
+/**
+ * Core handler — `db` injectable for unit tests. Returns { status, body }.
+ * @param {{ from?: string, subject?: string, secret?: string,
+ *           providedSecret?: string, db?: any }} args
+ */
+export async function handleOutreachReplyTrack({ from, subject, secret, providedSecret, db: injectedDb }) {
+  // Secret gate (mirrors outreachStopReply): never let an unauthenticated caller
+  // write reply telemetry.
+  if (!secret || String(providedSecret || '') !== String(secret)) {
+    return { status: 403, body: 'forbidden' };
+  }
+
+  const senderEmail = extractSenderEmail(from);
+  if (!senderEmail) return { status: 200, body: 'no-sender' };
+
+  const db = injectedDb || getAdminDb();
+  const companyKey = await resolveCompanyKey(db, senderEmail);
+  if (!companyKey) return { status: 200, body: 'unknown-sender' };
+
+  const now = new Date().toISOString();
+  await db.collection(REPLIES_COLLECTION).doc(companyKey).set({
+    companyKey,
+    replied: true,
+    lastRepliedAt: now,
+    lastReplyFrom: senderEmail,
+    lastReplySubject: String(subject || '').slice(0, 200),
+    replyCount: FieldValue.increment(1),
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true });
+
+  return { status: 200, body: 'recorded' };
+}

--- a/functions/src/outreachStopReply.js
+++ b/functions/src/outreachStopReply.js
@@ -66,7 +66,7 @@ export function extractSenderEmail(fromHeader) {
  * Resolve a sender address to a companyKey by scanning employer_contacts.
  * Returns '' if no contact has that email (verified or inferred).
  */
-async function resolveCompanyKey(db, senderEmail) {
+export async function resolveCompanyKey(db, senderEmail) {
   const addr = String(senderEmail || '').trim().toLowerCase();
   if (!addr) return '';
   const snap = await db.collection(CONTACTS_COLLECTION).get();

--- a/functions/src/outreachUnsubscribe.js
+++ b/functions/src/outreachUnsubscribe.js
@@ -44,6 +44,24 @@ export function generateOutreachUnsubToken(companyKey, secret) {
     .digest('hex');
 }
 
+// One-click unsubscribe path — kept in lockstep with the scripts-side builder
+// scripts/lib/outreach-unsubscribe-token.mjs (OUTREACH_UNSUB_PATH).
+const OUTREACH_UNSUB_PATH = '/disiscrivi-outreach/';
+
+/**
+ * One-click unsubscribe URL — MUST stay byte-identical to
+ * scripts/lib/outreach-unsubscribe-token.mjs `buildUnsubUrl`, so a link minted by
+ * the web-UI sender (adminSendColdEmail) is honoured by this same Cloud Function.
+ * Falls back to the site home when the secret is missing (never emit an unsigned
+ * link). A cross-boundary parity test guards the two builders against drift.
+ */
+export function buildUnsubUrl(companyKey, secret) {
+  if (!secret) return `${BASE_URL}/`;
+  const key = String(companyKey).trim();
+  const token = generateOutreachUnsubToken(key, secret);
+  return `${BASE_URL}${OUTREACH_UNSUB_PATH}?c=${encodeURIComponent(key)}&t=${token}`;
+}
+
 export function verifyOutreachToken(companyKey, token, secret) {
   if (!secret || !companyKey || !token) return false;
   const expected = generateOutreachUnsubToken(companyKey, secret);

--- a/infra/cloudflare-email-worker/stop-reply-handler.js
+++ b/infra/cloudflare-email-worker/stop-reply-handler.js
@@ -21,6 +21,7 @@
  *
  * Bindings (wrangler.email.toml / dashboard):
  *   vars:    STOP_REPLY_FN_URL  (https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply)
+ *            REPLY_TRACK_FN_URL (https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachReplyTrack)
  *            FORWARD_TO         (the human inbox to forward every reply to)
  *   secret:  STOP_SECRET        (== NEWSLETTER_SECRET; `wrangler secret put STOP_SECRET`)
  *
@@ -86,6 +87,18 @@ export default {
   async email(message, env, ctx) {
     const from = message.from || '';
     const subject = (message.headers && message.headers.get && message.headers.get('subject')) || '';
+
+    // Track EVERY inbound reply (best-effort) so the admin dashboard can show
+    // whether a company replied. Only from+subject are needed (no body read),
+    // so this runs cheaply on every message. Additive to STOP suppression below.
+    if (env.REPLY_TRACK_FN_URL && env.STOP_SECRET) {
+      const track = fetch(env.REPLY_TRACK_FN_URL, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
+        body: JSON.stringify({ from, subject }),
+      }).catch(() => { /* best-effort telemetry; never block forwarding */ });
+      ctx.waitUntil(track);
+    }
 
     // Detect on subject first (cheap); read the body only if needed.
     let body = '';

--- a/infra/cloudflare-email-worker/wrangler.toml
+++ b/infra/cloudflare-email-worker/wrangler.toml
@@ -10,7 +10,7 @@
 #
 # Secrets / vars (set after deploy):
 #   npx wrangler secret put STOP_SECRET     # == NEWSLETTER_SECRET (Cloud Function side)
-#   STOP_REPLY_FN_URL / FORWARD_TO are plain vars below.
+#   STOP_REPLY_FN_URL / REPLY_TRACK_FN_URL / FORWARD_TO are plain vars below.
 
 name = "frontaliere-stop-reply-handler"
 main = "stop-reply-handler.js"
@@ -19,6 +19,9 @@ compatibility_date = "2026-01-01"
 [vars]
 # Cloud Function that resolves sender→companyKey and writes the suppression doc.
 STOP_REPLY_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply"
+# Cloud Function that records EVERY inbound reply (reply telemetry for the admin
+# dashboard). Additive to STOP suppression; same x-stop-secret gate.
+REPLY_TRACK_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachReplyTrack"
 # Human inbox that every inbound reply is forwarded to (must be a verified
 # Email Routing destination). Fill in with the real monitored address before
 # deploy — left as a placeholder so no personal address is committed.

--- a/scripts/lib/cold-email-sequence.mjs
+++ b/scripts/lib/cold-email-sequence.mjs
@@ -1,85 +1,12 @@
 /**
- * cold-email-sequence.mjs — SINGLE SOURCE of the cold-outreach email sequence.
+ * cold-email-sequence.mjs — re-export of the SINGLE SOURCE cold-email sequence.
  *
- * Pure ESM (no node imports) so BOTH the Node scripts (generate-/send-cold-emails)
- * AND the browser admin panel (components/pages/AdminPanel.tsx → email preview)
- * import the SAME `buildSequence`. Keeping one copy means the admin preview is
- * byte-identical to what we actually send — no drift (AGENTS.md Non-Negotiable #6).
- *
- * `{{UNSUB_URL}}` / `{{INSIGHTS_URL}}` are placeholders substituted at send time
- * by send-cold-emails.mjs (and by the admin preview, which fills INSIGHTS_URL with
- * the real tokenized link and leaves a human-readable note for UNSUB_URL).
+ * The canonical builder lives in functions/src/coldEmailSequence.js so it can be
+ * bundled into the deployed Cloud Functions (the web-UI sender adminSendColdEmail
+ * imports it there). This thin shim keeps the historical import path working for
+ * the Node scripts (generate-/send-cold-emails) and the browser admin panel
+ * (components/pages/AdminPanel.tsx → email preview) — all of them resolve to the
+ * SAME module instance, so the preview, the CLI send, and the web-UI send stay
+ * byte-identical (AGENTS.md Non-Negotiable #6, no drift).
  */
-
-export const PRICE = 'CHF 49 al mese per annuncio';
-// Indirizzo opt-out: chi risponde qui (o "STOP") va messo `suppressed` nel send-log.
-export const OPTOUT_EMAIL = 'valerie@frontaliereticino.ch';
-
-/**
- * Le 4 email della sequenza. Personalizzazione Livello 4 (skill cold-email):
- * numero REALE di candidati + RUOLO più cliccato, connessi al problema (i click
- * si perdono). Tono da pari, una sola call-to-action a basso attrito per touch.
- */
-export function buildSequence({ company, candidates, periodLabel, contactName, topRole }) {
-  // Solo il nome di battesimo nel saluto ("Ciao Denise,"), non nome+cognome.
-  const firstName = (contactName || '').trim().split(/\s+/)[0];
-  const hi = firstName ? `Ciao ${firstName},` : 'Buongiorno,';
-  // Ruolo accorciato per leggibilità; fallback neutro se assente o generico
-  // (titoli-pagina tipo "Lavora con noi", "Concorsi", "Careers" non sono ruoli).
-  const role = (topRole || '').replace(/\s+/g, ' ').trim();
-  const GENERIC_ROLE = /lavora con noi|lavorare con noi|concors|careers?|^jobs?$|offerte di lavoro|posizioni aperte|unsolicited|spontane/i;
-  const pagina = role && !GENERIC_ROLE.test(role) ? `pagina di "${role.slice(0, 48)}"` : 'pagina lavoro';
-  // Opt-out obbligatorio su ogni touch (norma cold-email B2B + deliverability).
-  // Footer leggibile dall'umano; l'header List-Unsubscribe lo aggiunge il sender.
-  // One-click opt-out link ({{UNSUB_URL}}) is substituted at send time by
-  // send-cold-emails.mjs (buildUnsubUrl(companyKey)). The STOP/email reply path
-  // is kept as a fallback for clients that don't render the link. Drafts keep
-  // the literal placeholder (no companyKey context).
-  const footer = `\n\n—\nPer non ricevere più queste email: {{UNSUB_URL}}\nIn alternativa rispondete con "STOP" (o scrivete a ${OPTOUT_EMAIL}) e vi rimuoviamo subito.`;
-  const seq = [
-    {
-      touch: 1, gapDays: 0, subject: 'candidati inviati',
-      body: `${hi}
-
-${periodLabel} vi abbiamo mandato ${candidates} persone alla vostra ${pagina} da frontaliereticino.ch — gratis, dagli annunci che pubblichiamo per voi.
-
-Il punto è che quei click arrivano sul vostro sito e spesso si perdono. Possiamo farveli arrivare come candidature dirette, CV incluso, nella vostra casella.
-
-Ho preparato i vostri dati reali (annunci, visite, candidati) qui: {{INSIGHTS_URL}}
-
-Valerie`,
-    },
-    {
-      touch: 2, gapDays: 4, subject: 'di quei click',
-      body: `${hi}
-
-Di quei ${candidates} candidati che vi abbiamo mandato ${periodLabel}, quanti si sono poi candidati davvero da voi?
-
-Con l'annuncio sponsorizzato la candidatura arriva diretta nella vostra casella — niente form esterni, niente dispersione. Vi mando un esempio reale?
-
-Valerie`,
-    },
-    {
-      touch: 3, gapDays: 5, subject: '49 vs migliaia',
-      body: `${hi}
-
-Diverse aziende ticinesi hanno già reso sponsorizzati i loro ruoli da noi. Costa ${PRICE} — contro la fee di un recruiter (migliaia di CHF a ruolo) o un singolo posting su jobs.ch.
-
-Se vi aiuta a coprire anche un solo ruolo, si ripaga da solo. Provo a mostrarvelo sul vostro annuncio più visto?
-
-Valerie`,
-    },
-    {
-      touch: 4, gapDays: 7, subject: 'chiudo',
-      body: `${hi}
-
-Non vi disturbo oltre. In ogni caso vi lascio il riepilogo dei candidati che vi abbiamo mandato finora — usatelo come volete.
-
-Se più avanti volete amplificarlo, sapete dove trovarmi.
-
-Valerie`,
-    },
-  ];
-  // Append the opt-out footer to every touch so drafts and real sends match.
-  return seq.map((m) => ({ ...m, body: m.body + footer }));
-}
+export { PRICE, OPTOUT_EMAIL, buildSequence } from '../../functions/src/coldEmailSequence.js';

--- a/scripts/send-cold-emails.mjs
+++ b/scripts/send-cold-emails.mjs
@@ -234,6 +234,45 @@ function mergeFirestoreContacts(contacts, fsContacts) {
   return contacts;
 }
 
+/**
+ * Best-effort mirror of a REAL send to Firestore so the admin dashboard
+ * (adminEmployerInsights → AdminPanel "Insights Aziende") can show which touch
+ * went out and when — the local send-log.json is gitignored and only lives on
+ * this machine. Collection `employer_outreach_sends`, doc id = companyKey.
+ *
+ * Never throws: the send must never depend on this write succeeding. The
+ * firebase-admin app is already initialized by loadFirestoreContacts/
+ * loadFirestoreSuppression (both run before any real send), so we only grab the
+ * existing app here; if it isn't up we silently skip.
+ */
+async function recordSendToFirestore(key, touchNum, subject, result) {
+  if (!key) return;
+  try {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credPath || !fs.existsSync(credPath)) return;
+    const { getApps } = await import('firebase-admin/app');
+    if (getApps().length === 0) return; // app not initialized → nothing to mirror to
+    const { getFirestore, FieldValue } = await import('firebase-admin/firestore');
+    const db = getFirestore();
+    const sentAt = new Date().toISOString();
+    await db.collection('employer_outreach_sends').doc(key).set({
+      companyKey: key,
+      lastTouch: touchNum,
+      lastSentAt: sentAt,
+      touches: FieldValue.arrayUnion({
+        touch: touchNum,
+        sentAt,
+        provider: result?.provider || '',
+        messageId: result?.messageId || '',
+        subject: String(subject || '').slice(0, 200),
+      }),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+  } catch (err) {
+    console.warn(`↷ Firestore send-track non scritto per ${key} (${err.message}).`);
+  }
+}
+
 // ─────────────────────────────────────────────────────────────
 
 async function run() {
@@ -389,6 +428,9 @@ async function run() {
       messageId: result.messageId,
     });
     saveSendLog(logPath, sendLog);
+    // Mirror to Firestore (best-effort, non-blocking) so the admin dashboard
+    // sees which touch went out and when. Failures stay local-only, never abort.
+    void recordSendToFirestore(key, item._touch, item.subject, result);
   } : undefined;
 
   import('./lib/email-cascade.mjs').then(async ({ sendEmailCascade, logProviderSummary }) => {

--- a/services/adminInsights.ts
+++ b/services/adminInsights.ts
@@ -9,6 +9,8 @@
 
 const ADMIN_INSIGHTS_ENDPOINT =
   'https://europe-west6-frontaliere-ticino.cloudfunctions.net/adminEmployerInsights';
+const ADMIN_SEND_COLD_EMAIL_ENDPOINT =
+  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/adminSendColdEmail';
 
 export interface EmployerInsightsTotals {
   views: number;
@@ -34,6 +36,34 @@ export interface EmployerInsightsRow {
   contactRole: string;
   /** Most-clicked role — drives the email preview personalization. */
   topRole: string;
+  /**
+   * Outreach telemetry (read-only): which cold-email touch was sent + when,
+   * whether the company replied, and whether it opted out (STOP). Sourced from
+   * the employer_outreach_sends / _replies / _suppression collections.
+   */
+  outreach?: EmployerOutreachStatus;
+}
+
+/** Per-company cold-email send/reply/opt-out status shown in the dashboard. */
+export interface EmployerOutreachStatus {
+  /** Highest touch number sent so far (0 = nothing sent). */
+  lastTouch: number;
+  /** ISO timestamp of the last send, or null. */
+  lastSentAt: string | null;
+  /** Distinct touch numbers sent, ascending. */
+  touchesSent: number[];
+  /** Total send events logged (counts re-sends). */
+  sendCount: number;
+  /** True once any inbound reply was recorded. */
+  replied: boolean;
+  /** ISO timestamp of the last reply, or null. */
+  lastRepliedAt: string | null;
+  /** Number of inbound replies recorded. */
+  replyCount: number;
+  /** True if the company opted out (STOP reply / one-click unsubscribe). */
+  suppressed: boolean;
+  /** ISO timestamp of opt-out, or null. */
+  suppressedAt: string | null;
 }
 
 /** Editable fields the admin can push back for one company's outreach contact. */
@@ -109,4 +139,58 @@ export async function updateEmployerContact(
     }
     throw new Error(`Salvataggio non riuscito (${data.error || res.status}).`);
   }
+}
+
+/** Result of a web-UI cold-email send. `tracked: false` means the email went out
+ *  but the send-log write failed (rare) — the dashboard may not reflect it yet. */
+export interface SendColdEmailResult {
+  touch: number;
+  to: string;
+  messageId: string;
+  tracked: boolean;
+}
+
+/**
+ * Send one cold-email touch to a company from the dashboard (admin only). The
+ * Cloud Function re-checks the admin gate, verified email, suppression and dedup
+ * server-side, sends via Resend, and logs to employer_outreach_sends. `force`
+ * re-sends a touch already logged. Throws a human-readable message on refusal.
+ */
+export async function sendColdEmail(
+  user: AuthLike | null | undefined,
+  companyKey: string,
+  touch: number,
+  force = false,
+): Promise<SendColdEmailResult> {
+  if (!user) {
+    throw new Error('Devi essere autenticato come admin per inviare email.');
+  }
+  if (!companyKey) {
+    throw new Error('Company key mancante.');
+  }
+  const idToken = await user.getIdToken();
+  const res = await fetch(ADMIN_SEND_COLD_EMAIL_ENDPOINT, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ companyKey, touch, force }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) {
+    const reasons: Record<string, string> = {
+      not_admin: 'Accesso negato: questo account non è autorizzato.',
+      no_verified_email: 'Nessuna email verificata per questa azienda: impostala prima di inviare.',
+      suppressed: 'Azienda disiscritta (opt-out): invio bloccato.',
+      already_sent: `Touch ${touch} già inviata a questa azienda. Usa "forza re-invio" se vuoi rispedirla.`,
+      no_insights: 'Nessun dato insights per questa azienda.',
+      resend_key_missing: 'Provider email non configurato (RESEND_API_KEY).',
+      send_failed: 'Invio email fallito dal provider. Riprova.',
+    };
+    throw new Error(reasons[data.error] || `Invio non riuscito (${data.error || res.status}).`);
+  }
+  return {
+    touch: Number(data.touch ?? touch),
+    to: String(data.to || ''),
+    messageId: String(data.messageId || ''),
+    tracked: data.tracked !== false,
+  };
 }

--- a/tests/admin-send-cold-email-handler.test.ts
+++ b/tests/admin-send-cold-email-handler.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { handleAdminSendColdEmail } from '../functions/src/adminSendColdEmail.js';
+
+// Web-UI cold-email sender core. Admin gate is enforced by the onRequest wrapper
+// (functions/index.js); this core enforces the rest server-side: verified email,
+// suppression, dedup, single-source body. Transport is injected so no real email
+// is sent.
+
+const SECRET = 'test-secret';
+const KEY = 'casale-sa';
+
+function fakeDb({ insights, contact, suppression, sends } = {} as any) {
+  const writes: Array<{ coll: string; id: string; data: any }> = [];
+  const data: Record<string, any> = {
+    employer_insights: insights,
+    employer_contacts: contact,
+    employer_outreach_suppression: suppression,
+    employer_outreach_sends: sends,
+  };
+  return {
+    writes,
+    collection(coll: string) {
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              const d = data[coll];
+              return d ? { exists: true, data: () => d } : { exists: false, data: () => null };
+            },
+            async set(payload: any) { writes.push({ coll, id, data: payload }); },
+          };
+        },
+      };
+    },
+  };
+}
+
+function fakeSender() {
+  const sent: any[] = [];
+  const sendEmail = async (msg: any) => { sent.push(msg); return { messageId: 'msg_123' }; };
+  return { sent, sendEmail };
+}
+
+const baseInsights = { companyName: 'Casale SA', totals: { candidates: 49 } };
+const baseContact = { email: 'denise@casale.ch', contactName: 'Denise Rossi', topRole: 'Infermiere/a' };
+
+describe('handleAdminSendColdEmail', () => {
+  it('sends a fresh touch, substitutes the tokenized links, and logs the send', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: baseContact });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.to).toBe('denise@casale.ch');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toBe('candidati inviati');
+    // Placeholders replaced with real signed URLs (no leftover template tokens).
+    expect(sent[0].text).toContain('https://frontaliereticino.ch/azienda/casale-sa/?t=');
+    expect(sent[0].text).not.toContain('{{INSIGHTS_URL}}');
+    expect(sent[0].text).not.toContain('{{UNSUB_URL}}');
+    expect(sent[0].unsubUrl).toContain('/disiscrivi-outreach/?c=casale-sa&t=');
+    // Logged to employer_outreach_sends for the dashboard.
+    expect(db.writes.some((w) => w.coll === 'employer_outreach_sends')).toBe(true);
+  });
+
+  it('refuses a touch already sent (dedup) unless forced', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: baseContact, sends: { touches: [{ touch: 1 }] } });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('already_sent');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('re-sends a logged touch when force=true', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: baseContact, sends: { touches: [{ touch: 1 }] } });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, force: true, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('refuses if the company opted out (suppression)', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: baseContact, suppression: { companyKey: KEY } });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('suppressed');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('refuses when there is no verified email (never sends to an inferred guess)', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: { contactName: 'Denise', emailInferred: 'guess@casale.ch' } });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('no_verified_email');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('rejects an invalid touch number', async () => {
+    const db = fakeDb({ insights: baseInsights, contact: baseContact });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 9, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_touch');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('404s when the company has no insights doc', async () => {
+    const db = fakeDb({ contact: baseContact });
+    const { sent, sendEmail } = fakeSender();
+    const res = await handleAdminSendColdEmail({ companyKey: KEY, touch: 1, secret: SECRET, db, sendEmail });
+    expect(res.status).toBe(404);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/tests/cold-email-url-parity.test.ts
+++ b/tests/cold-email-url-parity.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+// Cross-boundary parity: the Cloud Function builders (functions/, deployed) MUST
+// produce byte-identical URLs to the scripts/lib builders (CLI). A link minted by
+// the web-UI sender (adminSendColdEmail) has to verify the same as one from the
+// CLI send — any drift in domain, path, token scheme or encoding breaks the gate.
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { buildInsightsUrl as fnInsightsUrl } from '../functions/src/employerInsights.js';
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { buildUnsubUrl as fnUnsubUrl } from '../functions/src/outreachUnsubscribe.js';
+// @ts-expect-error — plain .mjs helper, no types
+import { buildInsightsUrl as scInsightsUrl } from '../scripts/lib/employer-insights-token.mjs';
+// @ts-expect-error — plain .mjs helper, no types
+import { buildUnsubUrl as scUnsubUrl } from '../scripts/lib/outreach-unsubscribe-token.mjs';
+
+const SECRET = 'parity-secret-deterministic';
+
+describe('cold-email URL builders: functions ↔ scripts parity (no drift)', () => {
+  for (const key of ['casale-sa', 'eoc-ente-ospedaliero', 'a&b/co. (ti)']) {
+    it(`insights URL identical for "${key}"`, () => {
+      expect(fnInsightsUrl(key, SECRET)).toBe(scInsightsUrl(key, SECRET));
+    });
+    it(`unsubscribe URL identical for "${key}"`, () => {
+      expect(fnUnsubUrl(key, SECRET)).toBe(scUnsubUrl(key, SECRET));
+    });
+  }
+
+  it('both fall back to the site home when the secret is missing', () => {
+    expect(fnInsightsUrl('casale-sa', '')).toBe(scInsightsUrl('casale-sa', ''));
+    expect(fnUnsubUrl('casale-sa', '')).toBe(scUnsubUrl('casale-sa', ''));
+  });
+});

--- a/tests/outreach-reply-track-handler.test.ts
+++ b/tests/outreach-reply-track-handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .js Cloud Function module, no types
+import { handleOutreachReplyTrack } from '../functions/src/outreachReplyTrack.js';
+
+// Server-side reply telemetry (records EVERY inbound cold-email reply so the
+// admin dashboard can show "ha risposto sì/no"). Mirrors the secret-gated,
+// sender→companyKey path of outreachStopReply but writes to a separate
+// employer_outreach_replies collection. Never writes for an unknown sender.
+
+const SECRET = 'shared-test-secret';
+
+/** Minimal fake Firestore: one contact + capturing reply set(). */
+function fakeDb({ contactEmail = 'denise@casale.ch', companyKey = 'casale-sa' } = {}) {
+  const writes: Array<{ id: string; data: any }> = [];
+  return {
+    writes,
+    collection(name: string) {
+      if (name === 'employer_contacts') {
+        return {
+          async get() {
+            return {
+              forEach(cb: (d: any) => void) {
+                cb({ id: companyKey, data: () => ({ companyKey, email: contactEmail }) });
+              },
+            };
+          },
+        };
+      }
+      if (name === 'employer_outreach_replies') {
+        return {
+          doc(id: string) {
+            return { async set(data: any) { writes.push({ id, data }); } };
+          },
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+  };
+}
+
+describe('handleOutreachReplyTrack', () => {
+  it('rejects a request without the shared secret (403, no write)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachReplyTrack({
+      from: 'denise@casale.ch', subject: 'Re: candidati inviati',
+      secret: SECRET, providedSecret: 'wrong', db,
+    });
+    expect(res.status).toBe(403);
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('records a reply from a known sender (200 recorded, replied=true)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachReplyTrack({
+      from: 'Denise <denise@casale.ch>', subject: 'Re: candidati inviati',
+      secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('recorded');
+    expect(db.writes).toHaveLength(1);
+    expect(db.writes[0].id).toBe('casale-sa');
+    expect(db.writes[0].data.replied).toBe(true);
+    expect(db.writes[0].data.lastReplySubject).toBe('Re: candidati inviati');
+  });
+
+  it('does not record a reply from an unknown sender (200 unknown-sender, no write)', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachReplyTrack({
+      from: 'stranger@elsewhere.com', subject: 'hello',
+      secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('unknown-sender');
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('returns no-sender when the From header has no address', async () => {
+    const db = fakeDb();
+    const res = await handleOutreachReplyTrack({
+      from: '', subject: 'x', secret: SECRET, providedSecret: SECRET, db,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('no-sender');
+    expect(db.writes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Implementato

Upgrade dell'outreach cold-email applicando la skill `cold-email` (copy plain peer-to-peer, niente branding/allegati sull'email; il branded resta sulla landing `/azienda/<key>/`).

**Invio dalla web UI (richiesto)**
- Nuova Cloud Function `adminSendColdEmail` (`functions/src/adminSendColdEmail.js` + wrapper in `functions/index.js`): l'owner invia una touch a un'azienda dal pannello admin. Gate server-side: `assertAdmin` (allowlist + Firebase ID token), **solo email verificata** (mai inferita), **suppression** (opt-out → blocco), **dedup** (touch già inviata → blocco salvo `force`). Invio via Resend con header `List-Unsubscribe` one-click (RFC 8058).
- UI: bottone "Invia touch N a <email>" nel modal contatto (`AdminPanel.tsx`), con `window.confirm`, stato/feedback, "Forza re-invio" se già inviata, e blocco se opt-out/no-email. Service `sendColdEmail()` in `services/adminInsights.ts`.

**Tracking (richiesto)**
- Invii: ogni invio (CLI Phase A + web-UI) scrive `employer_outreach_sends/{companyKey}` (touch, quando, provider, subject, via).
- Risposte: il worker CF (`stop-reply-handler.js`) ora POSTa ogni reply a `outreachReplyTrack` (nuova CF) che registra `employer_outreach_replies/{companyKey}`; STOP/suppression restano separati.
- Dashboard: `adminEmployerInsights` fa merge di sends+replies+suppression in ogni riga; `AdminPanel` mostra badge "Inviata T2 · ✓ Ha risposto · Opt-out · In attesa" (tabella + mobile + modal).

**Single source (no drift)**
- Il builder sequenza si sposta in `functions/src/coldEmailSequence.js` (così la CF deployata può importarlo — functions non ha bundler); `scripts/lib/cold-email-sequence.mjs` lo ri-esporta. CLI send, preview dashboard e web-UI send restano byte-identici.
- `buildInsightsUrl`/`buildUnsubUrl` aggiunti lato functions come mirror dei builder `scripts/lib`, con **test di parità cross-boundary** che ne garantisce l'identità byte-per-byte.

**Altro**
- Landing `EmployerInsightsPage`: bottone "Salva in PDF" (browser print-to-PDF, `print:hidden`) — risposta alla domanda PDF: né allegato né dump inline, ma copia scaricabile dalla pagina.
- Copy: subject touch-3 `49 vs migliaia` → `quanto costa` (skill: subject internal/boring, no pitch).

**Test** (tutti verdi): `admin-send-cold-email-handler` (gate/dedup/suppression/no-email/link sostituiti), `outreach-reply-track-handler`, `cold-email-url-parity` (drift guard), + suite cold-email/insights esistenti.

## Non implementato (ancora)

- **Deploy + binding infra** (manuale, gated, fuori da questa PR): `firebase deploy --only functions` per `adminSendColdEmail`+`outreachReplyTrack`; settare `REPLY_TRACK_FN_URL` sul worker CF Email Routing e `wrangler deploy`. Senza, il tracking risposte non gira ancora (claim non validabile pre-merge → verifica live post-deploy).
- **HTML email**: invio solo `text/plain` (scelta deliverability skill). Nessuna versione HTML brandizzata — deliberato.
- **PDF lato server / allegato**: non implementato deliberatamente (allegati peggiorano deliverability); solo print-to-PDF client sulla landing.
- **Sibling sweep**: il candidate-surfacer ha listato solo token generici condivisi (`firstName`, `getIdToken`, `contactEmail`, `sentLabel`, `lastSentAt`, `sendCount`) con file non correlati — non lo stesso antipattern, nessuna classe-fix da propagare (feature coesa, non un pattern regex/guard replicato).
- **Rate-limit / batch send**: l'invio web-UI è one-shot per-touch (con dedup); nessun invio massivo schedulato da UI (out of scope, resta il CLI per i batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)