### PR TITLE
fix(authgate): attribute clipboard copy of the job title too

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6354,7 +6354,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  try {
  const sel = typeof window !== 'undefined' ? window.getSelection() : null;
  const selectionText = sel?.toString() ?? '';
- if (!shouldAttributeCopy(selectionText)) return;
+ if (!shouldAttributeCopy(selectionText, localizedTitle)) return;
  let selectionHtml = '';
  if (sel && sel.rangeCount > 0) {
  const holder = document.createElement('div');

--- a/services/jobCopyAttribution.ts
+++ b/services/jobCopyAttribution.ts
@@ -51,11 +51,26 @@ const escapeHtml = (s: string): string =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 
+/** Collapse whitespace + lowercase so a copied selection can be matched
+ * against the rendered job title regardless of incidental spacing/case. */
+const normalizeForTitleMatch = (s: string): string =>
+  s.trim().replace(/\s+/g, ' ').toLowerCase();
+
 /**
- * True when a selection is long enough to be worth attributing.
+ * True when a selection is worth attributing. A selection at or above the
+ * tiny-copy floor always qualifies. In addition, a selection that IS the job
+ * title (case/whitespace-insensitive) qualifies even when it falls under the
+ * floor — short titles like "Cuoco" are exactly the snippet users paste into a
+ * search box, and must still carry our brand + canonical URL instead of handing
+ * the searcher straight to a competitor.
  */
-export function shouldAttributeCopy(selectionText: string): boolean {
-  return selectionText.trim().length >= COPY_ATTRIBUTION_MIN_CHARS;
+export function shouldAttributeCopy(selectionText: string, jobTitle?: string): boolean {
+  if (selectionText.trim().length >= COPY_ATTRIBUTION_MIN_CHARS) return true;
+  if (jobTitle) {
+    const title = normalizeForTitleMatch(jobTitle);
+    if (title && normalizeForTitleMatch(selectionText) === title) return true;
+  }
+  return false;
 }
 
 /**

--- a/tests/job-copy-attribution.test.ts
+++ b/tests/job-copy-attribution.test.ts
@@ -25,6 +25,20 @@ describe('shouldAttributeCopy', () => {
   it('trims before measuring', () => {
     expect(shouldAttributeCopy(`   ${'x'.repeat(COPY_ATTRIBUTION_MIN_CHARS)}   `)).toBe(true);
   });
+
+  it('attributes a short selection that IS the job title', () => {
+    // "Cuoco" is below the floor but is exactly what users paste into search.
+    expect(shouldAttributeCopy('Cuoco')).toBe(false);
+    expect(shouldAttributeCopy('Cuoco', 'Cuoco')).toBe(true);
+  });
+
+  it('matches the title case- and whitespace-insensitively', () => {
+    expect(shouldAttributeCopy('  cUoCo   80-100%  ', 'Cuoco 80-100%')).toBe(true);
+  });
+
+  it('does not attribute a short non-title selection even with a title given', () => {
+    expect(shouldAttributeCopy('CHF 90k', 'Radiologo/a')).toBe(false);
+  });
 });
 
 describe('buildJobCopyAttribution', () => {


### PR DESCRIPTION
## Implementato

Estende la copy-attribution dell'auth gate (oggi attiva sulla *description* del job) anche al **titolo**.

- `services/jobCopyAttribution.ts`: `shouldAttributeCopy(selectionText, jobTitle?)` ora qualifica una selezione che **coincide col titolo** del job (match case/whitespace-insensitive via `normalizeForTitleMatch`) **anche sotto** la soglia `COPY_ATTRIBUTION_MIN_CHARS = 25`. Prima un titolo corto (es. "Cuoco") veniva saltato dal floor tiny-selection → l'utente che lo incollava in un motore di ricerca veniva consegnato a un competitor senza il nostro brand + URL canonico (lo snippet esatto che i replay PostHog mostrano incollato in ricerca).
- `components/community/JobBoard.tsx`: `handleGateCopy` passa `localizedTitle` a `shouldAttributeCopy`.
- `tests/job-copy-attribution.test.ts`: +3 test (titolo corto attribuito; match case/whitespace-insensitive; snippet corto non-titolo resta non attribuito). Suite verde (12/12).

Le selezioni corte casuali (singola parola/numero/data) che NON sono il titolo restano intoccate — il floor anti-rumore vale ancora.

Nessun side-effect su SEO/monetizzazione/Auto Ads: riscrive solo ciò che l'utente ha già scelto di copiare. Nessun sibling funnel-critical condivide il costrutto (`check-sibling-patterns` verde; unico caller di `shouldAttributeCopy` è `handleGateCopy`).

## Non implementato (ancora)

- Copy-attribution sulla view job-detail autenticata (non-gate): out of scope — il task riguarda l'auth gate, e lì il titolo è già attribuito via `onCopy` div-level + floor.
- Match fuzzy/parziale titolo (es. titolo + company insieme): non necessario — l'`<h1>` del gate renderizza solo `localizedTitle`, quindi il match esatto normalizzato copre il caso reale senza rischio di falsi positivi.