### PR TITLE
ci(worker): auto-deploy + auto-configure the Cloudflare email worker

### DIFF
--- a/.github/workflows/deploy-email-worker.yml
+++ b/.github/workflows/deploy-email-worker.yml
@@ -1,0 +1,94 @@
+# Deploy the Cloudflare Email Routing Worker (infra/cloudflare-email-worker).
+#
+# Same gap deploy-worker.yml closed for the locale-router: nothing re-deployed
+# the email worker, so the STOP-reply + reply-tracking handler sat in the repo
+# without ever going live (it did NOT exist on the account). This deploys it on
+# every push to main that touches its directory, then configures it via the CF
+# API (scripts/cf-email-worker-setup.mjs): sets the worker secrets STOP_SECRET
+# (= NEWSLETTER_SECRET) and FORWARD_TO (resolved from the zone catch-all target,
+# so no email is committed), and binds the outreach reply address to the worker.
+#
+# Credentials come from Firebase Remote Config (repo convention — same as
+# deploy-worker.yml), hydrated by scripts/load-rc-env.mjs:
+#   CF_API_TOKEN      — needs Workers Scripts:Edit (deploy + secrets) and, for the
+#                       inbound binding, Zone→Email Routing:Edit. Missing the
+#                       Email Routing scope only skips the rule (warns), not the deploy.
+#   CF_ACCOUNT_ID     — Cloudflare account id.
+#   NEWSLETTER_SECRET — becomes the worker's STOP_SECRET (matches the Cloud Function side).
+# FIREBASE_SERVICE_ACCOUNT_JSON (repo secret) authenticates the RC read.
+name: Deploy Email Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/cloudflare-email-worker/**'
+      - 'scripts/cf-email-worker-setup.mjs'
+  workflow_dispatch: {}
+
+# Never cancel an in-flight deploy: a half-applied worker/routing change is worse
+# than waiting. Serialize so concurrent merges deploy in order.
+concurrency:
+  group: deploy-email-worker
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # load-rc-env.mjs only needs firebase-admin — install it standalone
+      # instead of a full `npm ci` (the repo's install is heavy and unneeded).
+      - name: Install firebase-admin (for RC read)
+        run: npm install --no-save firebase-admin
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON not set — cannot read CF creds from Remote Config."
+            exit 1
+          fi
+
+      - name: Load Cloudflare creds + NEWSLETTER_SECRET from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Verify creds present
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "::error::CF_API_TOKEN / CF_ACCOUNT_ID not hydrated from Remote Config."
+            exit 1
+          fi
+          if [ -z "$NEWSLETTER_SECRET" ]; then
+            echo "::error::NEWSLETTER_SECRET not hydrated from Remote Config — cannot set STOP_SECRET."
+            exit 1
+          fi
+
+      - name: Deploy Email Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ env.CF_API_TOKEN }}
+          accountId: ${{ env.CF_ACCOUNT_ID }}
+          workingDirectory: infra/cloudflare-email-worker
+          command: deploy
+
+      # Sets STOP_SECRET + FORWARD_TO worker secrets via the CF API and binds the
+      # outreach reply address to the worker. Runs AFTER deploy so the worker
+      # script exists. Secrets are essential (fail on error); the routing rule is
+      # best-effort (warns if the token lacks Email Routing:Edit).
+      - name: Configure secrets + Email Routing binding
+        run: node scripts/cf-email-worker-setup.mjs

--- a/infra/cloudflare-email-worker/stop-reply-handler.js
+++ b/infra/cloudflare-email-worker/stop-reply-handler.js
@@ -19,15 +19,14 @@
  * Detection MIRRORS scripts/lib/stop-reply-detect.mjs (single source) — kept in
  * lockstep (AGENTS.md Non-Negotiable #6); both are unit-tested.
  *
- * Bindings (wrangler.email.toml / dashboard):
- *   vars:    STOP_REPLY_FN_URL  (https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply)
- *            REPLY_TRACK_FN_URL (https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachReplyTrack)
- *            FORWARD_TO         (the human inbox to forward every reply to)
- *   secret:  STOP_SECRET        (== NEWSLETTER_SECRET; `wrangler secret put STOP_SECRET`)
+ * Deploy + config are AUTOMATED by .github/workflows/deploy-email-worker.yml
+ * (wrangler deploy + scripts/cf-email-worker-setup.mjs). Bindings:
+ *   vars (wrangler.toml):  STOP_REPLY_FN_URL, REPLY_TRACK_FN_URL
+ *   secrets (CF API, set by the setup script): STOP_SECRET (== NEWSLETTER_SECRET),
+ *            FORWARD_TO (the human inbox; resolved from the zone catch-all target)
  *
- * NOTE: binding the Worker to the inbound address in Cloudflare Email Routing is a
- * manual dashboard/API step (declared in the PR's ## Non implementato) — the code
- * here is the handler that step points at.
+ * The inbound binding (outreach reply address → "send to worker") is also set
+ * by the setup script via the Email Routing API — no manual dashboard step.
  */
 
 // MIRROR of scripts/lib/stop-reply-detect.mjs STOP_INTENT_PATTERNS. Keep in sync.

--- a/infra/cloudflare-email-worker/wrangler.toml
+++ b/infra/cloudflare-email-worker/wrangler.toml
@@ -1,16 +1,16 @@
-# Cloudflare Email Routing Worker for inbound cold-email STOP replies.
+# Cloudflare Email Routing Worker for inbound cold-email STOP replies + reply
+# tracking.
 #
-# Deploy: `npx wrangler deploy` from this dir.
-# Then (MANUAL, one-time, dashboard or API):
-#   Cloudflare → Email → Email Routing → Routing rules → the outreach reply
-#   address (the cold-email From, e.g. valerie@frontaliereticino.ch) → action
-#   "Send to a Worker" → frontaliere-stop-reply-handler.
-# Binding the Worker to the address is the manual infra step (see PR #2620 body
-# ## Non implementato); the handler code lives in stop-reply-handler.js.
+# Deploy + config are AUTOMATED by .github/workflows/deploy-email-worker.yml on
+# every push to main touching this dir: it runs `wrangler deploy` then
+# scripts/cf-email-worker-setup.mjs, which (via the CF API) sets the worker
+# secrets STOP_SECRET (= NEWSLETTER_SECRET) and FORWARD_TO (resolved from the
+# zone catch-all target, so no address is committed), and binds the outreach
+# reply address (valerie@frontaliereticino.ch) → this worker. No manual step.
 #
-# Secrets / vars (set after deploy):
-#   npx wrangler secret put STOP_SECRET     # == NEWSLETTER_SECRET (Cloud Function side)
-#   STOP_REPLY_FN_URL / REPLY_TRACK_FN_URL / FORWARD_TO are plain vars below.
+# The two CF-URL vars below are plain (non-secret) and applied on each deploy.
+# STOP_SECRET / FORWARD_TO are worker SECRETS set out-of-band by the setup script
+# — never committed here.
 
 name = "frontaliere-stop-reply-handler"
 main = "stop-reply-handler.js"
@@ -22,10 +22,9 @@ STOP_REPLY_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/
 # Cloud Function that records EVERY inbound reply (reply telemetry for the admin
 # dashboard). Additive to STOP suppression; same x-stop-secret gate.
 REPLY_TRACK_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachReplyTrack"
-# Human inbox that every inbound reply is forwarded to (must be a verified
-# Email Routing destination). Fill in with the real monitored address before
-# deploy — left as a placeholder so no personal address is committed.
-FORWARD_TO = "REPLACE_WITH_VERIFIED_DESTINATION@example.com"
+# NOTE: FORWARD_TO (the human inbox replies are forwarded to) is a worker SECRET
+# set by scripts/cf-email-worker-setup.mjs from the zone catch-all target — not a
+# committed var, so no personal address lands in the repo.
 
 [observability]
 enabled = true

--- a/scripts/cf-email-worker-setup.mjs
+++ b/scripts/cf-email-worker-setup.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * cf-email-worker-setup.mjs — post-deploy config for the Cloudflare Email
+ * Routing Worker (infra/cloudflare-email-worker), run by deploy-email-worker.yml
+ * AFTER `wrangler deploy` has created/updated the worker script.
+ *
+ * Does, idempotently, via the Cloudflare API (so no secret/email ever lands in
+ * the repo or the CI logs):
+ *   1. Sets the worker secrets STOP_SECRET (= NEWSLETTER_SECRET) and FORWARD_TO.
+ *      FORWARD_TO is resolved from the zone's catch-all forward target, so the
+ *      worker forwards replies to the SAME inbox the catch-all already used —
+ *      adding the worker rule never silently drops a reply.
+ *   2. Ensures an Email Routing rule: the outreach address
+ *      (valerie@frontaliereticino.ch) → "send to worker"
+ *      frontaliere-stop-reply-handler. Idempotent (updates an existing rule by
+ *      matcher, else creates one).
+ *
+ * Env (hydrated by scripts/load-rc-env.mjs in CI):
+ *   CF_API_TOKEN      — needs Workers Scripts:Edit (secrets) + Email Routing:Edit (rule)
+ *   CF_ACCOUNT_ID
+ *   NEWSLETTER_SECRET — becomes the worker's STOP_SECRET
+ *
+ * Failure policy: secrets are essential → fail the job if they can't be set.
+ * The Email Routing rule is best-effort → on error (e.g. token missing the
+ * Email Routing:Edit scope) it warns and exits 0, so the worker still deploys
+ * and the rule can be bound once.
+ */
+
+const ZONE_NAME = 'frontaliereticino.ch';
+const WORKER_NAME = 'frontaliere-stop-reply-handler';
+// The cold-email From / reply address. Inbound replies to it must hit the worker.
+const OUTREACH_ADDRESS = 'valerie@frontaliereticino.ch';
+const RULE_NAME = 'cold-email reply → stop-reply-handler';
+
+const API = 'https://api.cloudflare.com/client/v4';
+const TOKEN = process.env.CF_API_TOKEN;
+const ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
+const NEWSLETTER_SECRET = process.env.NEWSLETTER_SECRET;
+
+function mask(value) {
+  // GitHub Actions: scrub the value from any subsequent log line.
+  if (value && process.env.GITHUB_ENV) process.stdout.write(`::add-mask::${value}\n`);
+}
+
+async function cf(path, { method = 'GET', body } = {}) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = {};
+  try { json = await res.json(); } catch { /* non-JSON error body */ }
+  return { ok: res.ok && json.success !== false, status: res.status, json };
+}
+
+function fail(msg) {
+  console.error(`::error::${msg}`);
+  process.exit(1);
+}
+
+async function resolveZoneId() {
+  const r = await cf(`/zones?name=${encodeURIComponent(ZONE_NAME)}`);
+  const id = r.ok ? (r.json.result?.[0]?.id || '') : '';
+  if (!id) fail(`zone ${ZONE_NAME} not found (token Zone:Read scope?)`);
+  return id;
+}
+
+async function resolveForwardTarget(zoneId) {
+  const r = await cf(`/zones/${zoneId}/email/routing/rules/catch_all`);
+  if (!r.ok) return '';
+  const forward = (r.json.result?.actions || []).find((a) => a.type === 'forward');
+  return forward?.value?.[0] || '';
+}
+
+async function putSecret(name, text) {
+  const r = await cf(`/accounts/${ACCOUNT_ID}/workers/scripts/${WORKER_NAME}/secrets`, {
+    method: 'PUT',
+    body: { name, text, type: 'secret_text' },
+  });
+  if (!r.ok) {
+    fail(`could not set worker secret ${name} (status ${r.status}: ${JSON.stringify(r.json.errors || r.json).slice(0, 200)})`);
+  }
+  console.log(`✓ secret ${name} set on ${WORKER_NAME}`);
+}
+
+async function ensureRoutingRule(zoneId) {
+  const desired = {
+    name: RULE_NAME,
+    enabled: true,
+    matchers: [{ type: 'literal', field: 'to', value: OUTREACH_ADDRESS }],
+    actions: [{ type: 'worker', value: [WORKER_NAME] }],
+  };
+  const list = await cf(`/zones/${zoneId}/email/routing/rules`);
+  if (!list.ok) {
+    console.log(`::warning::could not list Email Routing rules (status ${list.status}) — bind ${OUTREACH_ADDRESS} → ${WORKER_NAME} manually.`);
+    return;
+  }
+  const existing = (list.json.result || []).find((rule) =>
+    (rule.matchers || []).some((m) => m.type === 'literal' && (m.value || '').toLowerCase() === OUTREACH_ADDRESS));
+  const target = existing
+    ? { method: 'PUT', path: `/zones/${zoneId}/email/routing/rules/${existing.tag}` }
+    : { method: 'POST', path: `/zones/${zoneId}/email/routing/rules` };
+  const r = await cf(target.path, { method: target.method, body: desired });
+  if (!r.ok) {
+    console.log(`::warning::could not ${existing ? 'update' : 'create'} the Email Routing rule (status ${r.status}: ${JSON.stringify(r.json.errors || r.json).slice(0, 200)}). Bind ${OUTREACH_ADDRESS} → ${WORKER_NAME} manually (token Email Routing:Edit scope?).`);
+    return;
+  }
+  console.log(`✓ Email Routing rule ${existing ? 'updated' : 'created'}: ${OUTREACH_ADDRESS} → worker ${WORKER_NAME}`);
+}
+
+async function main() {
+  if (!TOKEN || !ACCOUNT_ID) fail('CF_API_TOKEN / CF_ACCOUNT_ID not set (Remote Config not hydrated).');
+  if (!NEWSLETTER_SECRET) fail('NEWSLETTER_SECRET not set — cannot configure STOP_SECRET.');
+  mask(NEWSLETTER_SECRET);
+
+  const zoneId = await resolveZoneId();
+
+  const forwardTo = await resolveForwardTarget(zoneId);
+  mask(forwardTo);
+  if (forwardTo) {
+    console.log('✓ FORWARD_TO resolved from the zone catch-all target.');
+  } else {
+    console.log('::warning::no catch-all forward target found — FORWARD_TO left unset (replies are still tracked; just not forwarded to a human inbox).');
+  }
+
+  // Essential: the secrets the worker gates on.
+  await putSecret('STOP_SECRET', NEWSLETTER_SECRET);
+  if (forwardTo) await putSecret('FORWARD_TO', forwardTo);
+
+  // Best-effort: the inbound binding.
+  await ensureRoutingRule(zoneId);
+
+  console.log('Email worker setup complete.');
+}
+
+main().catch((err) => fail(err?.message || String(err)));


### PR DESCRIPTION
## Implementato

Rende **automatico il deploy + config del Cloudflare email worker** (`infra/cloudflare-email-worker`), che gestisce STOP-suppression + reply-tracking (#2847). Diagnosi: il worker **non esisteva sull'account CF** — nessun workflow lo deployava (stesso gap che `deploy-worker.yml` ha chiuso per il locale-router). Email Routing è già enabled+ready sulla zona.

- **`.github/workflows/deploy-email-worker.yml`** (nuovo): trigger `push main` su `infra/cloudflare-email-worker/**` + lo script di setup, e `workflow_dispatch`. Carica CF creds + `NEWSLETTER_SECRET` da Remote Config (stessa convenzione di `deploy-worker.yml`), fa `wrangler deploy` (cloudflare/wrangler-action@v3), poi esegue lo script di setup. Concurrency serializzata, timeout 15m.
- **`scripts/cf-email-worker-setup.mjs`** (nuovo, CF API, idempotente):
  - setta i **secret** worker `STOP_SECRET` (= `NEWSLETTER_SECRET`) e `FORWARD_TO` (risolto dal **target del catch-all** della zona → inoltro risposte preservato, nessun indirizzo committato). Secret essenziali → fail su errore.
  - **binda** l'indirizzo reply (`valerie@frontaliereticino.ch`) → "send to worker" via Email Routing API. Best-effort: se il token non ha `Email Routing:Edit` avvisa ma il deploy passa.
- **`wrangler.toml`**: rimosso il placeholder var `FORWARD_TO` (ora secret); header aggiornato. **`stop-reply-handler.js`**: header aggiornato (deploy/bind ora automatico, niente più step manuale dashboard).

Risultato: entrambi i worker Cloudflare (locale-router + email) sono ora CI-deployed. Niente PII nel repo (secret/email solo via CF API a runtime, mascherati).

## Non implementato (ancora)

- **Validazione live solo post-merge** (claim non testabile sul PR — i job CF girano solo su `main`/dispatch): se la versione di `wrangler` pinnata da `wrangler-action@v3` non supportasse `compatibility_date = "2026-01-01"`/`[observability]`, o se il token CF mancasse di `Workers Scripts:Edit`/`Email Routing:Edit`, il primo run fallirebbe → **revert-trigger**: se `deploy-email-worker` fallisce al primo `workflow_dispatch`, rollback del workflow e fix scope-token. Verifica live post-merge via `gh workflow run deploy-email-worker.yml`.
- **Generalizzazione N-worker**: i due worker hanno deploy diversi (l'email worker non ha route/cache/regression-check del locale-router) → due workflow dedicati invece di uno generico matrix. Nessun terzo worker da coprire (`infra/cloudflare/` non è un worker script).
- **Sibling**: nessuna classe-pattern replicata (workflow+script nuovi, isolati).

🤖 Generated with [Claude Code](https://claude.com/claude-code)