### PR TITLE
feat(ads): Prebid.js header bidding on explicit GPT slots (default-off)

### DIFF
--- a/components/shared/ArticleRailAd.tsx
+++ b/components/shared/ArticleRailAd.tsx
@@ -55,12 +55,13 @@ export interface ArticleRailAdProps {
 }
 
 const ArticleRailAd: React.FC<ArticleRailAdProps> = ({ side, enabled = true, reserve = true, narrow = false, onEmptyChange }) => {
-  const { articleRailAds: killed } = useKillSwitches();
+  const { articleRailAds: killed, headerBidding: hbKilled } = useKillSwitches();
   return (
     <GptAdSlot
       adUnitPath={RAIL_AD_UNIT_PATHS[side]}
       sizes={narrow ? RAIL_SIZES_NARROW : RAIL_SIZES}
       killed={killed}
+      headerBiddingKilled={hbKilled}
       enabled={enabled}
       onEmptyChange={onEmptyChange}
       minHeight={reserve ? 600 : 0}

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { trackAdEvent } from '@/services/adAnalytics';
 import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
 import { isLikelyBot } from '@/services/adAnalytics';
+import { prebidActiveFor, requestHeaderBids } from '@/services/headerBidding';
 
 // Master flag for the GPT stack (PoC activated in #2289). Flip to `false`
 // (one-line, then deploy) to disable every GPT slot if GPT serving regresses
@@ -94,6 +95,12 @@ export interface GptAdSlotProps {
   sizes: GptSize[];
   /** Runtime kill-switch (caller wires it to Firebase Remote Config). */
   killed?: boolean;
+  /**
+   * Runtime kill-switch for the header-bidding auction ONLY (caller wires it to
+   * Firebase Remote Config `KILL_HEADER_BIDDING`). When `true`, the slot still
+   * serves via GPT/AdSense — only the Prebid pre-auction is skipped. Default `false`.
+   */
+  headerBiddingKilled?: boolean;
   /** Extra eligibility gate (e.g. article long enough). Default `true`. */
   enabled?: boolean;
   /** Reserved min-height (px) to prevent CLS before the creative fills. */
@@ -115,6 +122,7 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   adUnitPath,
   sizes,
   killed = false,
+  headerBiddingKilled = false,
   enabled = true,
   minHeight = 250,
   className = 'mx-auto my-6 w-full max-w-[336px] text-center',
@@ -206,7 +214,25 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
           };
           viewableHandlerRef.current = viewableHandler;
           gt.pubads().addEventListener('impressionViewable', viewableHandler);
-          gt.display(divId);
+          // Header bidding: run a Prebid auction for this slot and apply the
+          // winning hb_* targeting BEFORE display(), so SSP demand competes with
+          // AdSense dynamic-allocation inside the same GAM auction. AdSense Auto
+          // Ads are unaffected. requestHeaderBids() is a no-op when disabled /
+          // unconfigured and always resolves (fail-soft + hard timeout), so GPT
+          // display is never blocked by the auction.
+          if (!headerBiddingKilled && prebidActiveFor(adUnitPath)) {
+            void requestHeaderBids({ code: divId, adUnitPath, sizes }).finally(() => {
+              gt.cmd.push(() => {
+                try {
+                  gt.display(divId);
+                } catch {
+                  /* fail-soft */
+                }
+              });
+            });
+          } else {
+            gt.display(divId);
+          }
           setRendered(true);
         } catch {
           /* fail-soft: never let an ad break the page */

--- a/components/shared/GptPocSlot.tsx
+++ b/components/shared/GptPocSlot.tsx
@@ -23,12 +23,13 @@ const GPT_POC_AD_UNIT_PATH = '/23355151813/gpt-poc-articoli';
 const GPT_POC_SIZES: GptSize[] = [[300, 250], 'fluid'];
 
 const GptPocSlot: React.FC = () => {
-  const { gptPocSlot: killed } = useKillSwitches();
+  const { gptPocSlot: killed, headerBidding: hbKilled } = useKillSwitches();
   return (
     <GptAdSlot
       adUnitPath={GPT_POC_AD_UNIT_PATH}
       sizes={GPT_POC_SIZES}
       killed={killed}
+      headerBiddingKilled={hbKilled}
       minHeight={250}
       className="mx-auto my-6 w-full max-w-[336px] text-center"
     />

--- a/docs/HEADER-BIDDING.md
+++ b/docs/HEADER-BIDDING.md
@@ -1,0 +1,62 @@
+# Header Bidding (Prebid.js)
+
+Client-side header bidding layered on the **explicit GAM/GPT slots** only
+(`GptAdSlot`: article rails + PoC). It runs a Prebid auction before
+`googletag.display()` and passes the winning `hb_*` targeting to GPT, so SSP
+demand competes with AdSense dynamic-allocation inside the same GAM auction.
+
+> **AdSense Auto Ads are NOT header-bid.** Auto Ads (anchor/in-page/vignette,
+> ~95% of revenue) are placed by AdSense itself, not as GPT slots, so Prebid
+> cannot touch them. Header bidding is purely additive on the explicit slots.
+
+## Status: built, default-OFF (inert)
+
+The integration is merged but does **nothing** until all three of the following
+exist. Until then `requestHeaderBids()` is a no-op and GPT serves AdSense-only,
+exactly as before.
+
+| Gate | Where | Default |
+|------|-------|---------|
+| `PREBID_ENABLED` master flag | `services/headerBidding.ts` | `false` |
+| `VITE_PREBID_CONFIG` env (bidder IDs) | build env | unset → empty |
+| `/assets/prebid.js` self-hosted bundle | `public/assets/` | absent |
+| `KILL_HEADER_BIDDING` Remote Config | Firebase RC | `'false'` (runtime off-switch) |
+
+## Go-live checklist
+
+1. **Sign up SSPs** and obtain per-ad-unit placement IDs. Recommended for
+   CH/IT/EU traffic at current volume: Criteo, Sovrn, Media.net, Yieldlab
+   (DACH), Equativ/Smart (FR). Amazon APS via the Prebid adapter once approved.
+2. **Build a custom Prebid bundle** at <https://docs.prebid.org/download.html>
+   selecting the chosen bidder adapters **plus** `consentManagementTcf` (EU/CH
+   GDPR — reads the TCF string from the existing Funding Choices CMP) and
+   `gptPreAuction`. Drop the output at `public/assets/prebid.js`. Do **not** use
+   the generic CDN bundle — it lacks our adapters and bloats the critical path.
+3. **Create the GAM line items.** Header bidding only monetizes if GAM has the
+   price-bucket line items + universal creative keyed on `hb_pb` / `hb_adid` /
+   `hb_size` targeting. Use Prebid's GAM setup tooling
+   (<https://docs.prebid.org/adops/before-you-start.html>). Without these, bids
+   can never win the GAM auction. **This is the step that actually turns on
+   revenue — code alone does nothing.**
+4. **Set `VITE_PREBID_CONFIG`** (build secret) to the JSON map of ad unit path →
+   bids, e.g.:
+   ```json
+   {
+     "/23355151813/article-rail-left":  [{"bidder":"criteo","params":{"networkId":12345}}, {"bidder":"sovrn","params":{"tagid":"998877"}}],
+     "/23355151813/article-rail-right": [{"bidder":"criteo","params":{"networkId":12345}}, {"bidder":"sovrn","params":{"tagid":"998877"}}],
+     "/23355151813/gpt-poc-articoli":   [{"bidder":"medianet","params":{"cid":"8CU...","crid":"45678"}}]
+   }
+   ```
+5. **Flip `PREBID_ENABLED = true`** and deploy.
+6. **Monitor** RPM/viewability/`hb_*` line-item fill in GAM, and CWV (INP/CLS/LCP
+   via CF Web Analytics) — the auction adds JS + latency. Roll back instantly via
+   `KILL_HEADER_BIDDING = 'true'` in Remote Config (no deploy) if CWV regresses
+   or revenue drops.
+
+## CWV / safety notes
+
+- Per-slot lazy load (IntersectionObserver, inherited from `GptAdSlot`), hard
+  1000 ms auction timeout + 500 ms wall-clock guard → display is never blocked.
+- Bot- and production-host-gated (shared with AdSense/GPT loaders).
+- All failure paths fail-soft: a broken auction silently falls back to plain
+  GPT display.

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -30,7 +30,8 @@ export type KillSwitchKey =
   | 'weeklyEmployers'
   | 'orphanLandings'
   | 'gptPocSlot'
-  | 'articleRailAds';
+  | 'articleRailAds'
+  | 'headerBidding';
 
 export type KillSwitchState = Readonly<Record<KillSwitchKey, boolean>>;
 
@@ -47,6 +48,7 @@ export const KILL_SWITCH_RC_KEYS: Readonly<Record<KillSwitchKey, string>> = {
   orphanLandings: 'KILL_ORPHAN_LANDINGS_LINKS',
   gptPocSlot: 'KILL_GPT_POC_SLOT',
   articleRailAds: 'KILL_ARTICLE_RAIL_ADS',
+  headerBidding: 'KILL_HEADER_BIDDING',
 } as const;
 
 const DEFAULT_STATE: KillSwitchState = {
@@ -57,6 +59,7 @@ const DEFAULT_STATE: KillSwitchState = {
   orphanLandings: false,
   gptPocSlot: false,
   articleRailAds: false,
+  headerBidding: false,
 } as const;
 
 function parseBooleanFlag(value: string | undefined | null): boolean {

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -467,3 +467,8 @@ video.unrulymedia.com, 2564526802, RESELLER
 video.unrulymedia.com, 5672421953199218469, RESELLER
 yahoo.com, 57289, RESELLER, e1a5b5b6e3255540
 zetaglobal.net, 891, RESELLER
+
+# Sovrn — publisher 607103 (new account, pending). DIRECT seller lines required
+# for approval; reseller chain already declared above (shared with prior Sovrn id).
+lijit.com, 607103, DIRECT, fafdf38b16bf6b2b
+lijit.com, 607103-eb, DIRECT, fafdf38b16bf6b2b

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -82,6 +82,11 @@ const REMOTE_CONFIG_DEFAULTS: Record<string, string> = {
  // 'false' = rails SHOWN. Flip to 'true' in the Remote Config console to kill
  // both rail ads within ~1 min (no redeploy) if they regress Auto Ads / RPM / CWV.
  KILL_ARTICLE_RAIL_ADS: 'false',
+ // Header-bidding (Prebid) pre-auction on the explicit GPT slots. Default
+ // 'false' = auction allowed (still gated by PREBID_ENABLED in
+ // services/headerBidding.ts). Flip to 'true' to disable Prebid within ~1 min
+ // (no redeploy); slots keep serving via GPT/AdSense.
+ KILL_HEADER_BIDDING: 'false',
  // E3: Inline consulting CTA on calculator results view.
  // Default 'true' so the CTA is visible until explicitly disabled via Firebase
  // Remote Config console. Flip to 'false' to hide the CTA without a redeploy.

--- a/services/headerBidding.ts
+++ b/services/headerBidding.ts
@@ -1,0 +1,168 @@
+/**
+ * headerBidding — Prebid.js wrapper for the explicit GAM/GPT slots.
+ *
+ * Runs a client-side header-bidding auction BEFORE GptAdSlot calls
+ * `gt.display()`, then hands the winning bid's targeting (hb_pb / hb_adid /
+ * hb_size) to GPT via `pbjs.setTargetingForGPTAsync`. SSP demand thus competes
+ * with AdSense dynamic-allocation inside the same GAM auction. AdSense Auto Ads
+ * are untouched — header bidding only augments the explicit pubads slots that
+ * GptAdSlot already serves (article rails, PoC).
+ *
+ * SAFETY (default-inert, fail-soft):
+ *  - `PREBID_ENABLED` master flag (default `false`): the whole stack does
+ *    nothing until a self-hosted `/assets/prebid.js` bundle, SSP placement IDs
+ *    (`VITE_PREBID_CONFIG`) and the GAM `hb_*` line items all exist. Flip to
+ *    `true` only at go-live. See docs/HEADER-BIDDING.md.
+ *  - Per-slot Remote Config kill-switch (`KILL_HEADER_BIDDING`) wired by the
+ *    caller via useKillSwitches — turns the auction off within ~1 min, no deploy.
+ *  - `requestHeaderBids()` ALWAYS resolves (no config / load error / bot /
+ *    timeout) and never rejects: a broken auction must never block GPT display
+ *    or stop an ad from serving. A hard wall-clock guard resolves even if
+ *    prebid.js never loads or `bidsBackHandler` never fires.
+ *  - Bot- and production-host-gated like the AdSense / GPT loaders, so bot
+ *    traffic never inflates bid requests.
+ */
+
+import type { GptSize } from '@/components/shared/GptAdSlot';
+import { isLikelyBot } from '@/services/adAnalytics';
+import { isAdSenseProductionHost } from '@/components/shared/AdSenseBanner';
+import { bidsForAdUnit, hasConfiguredBidders } from '@/services/prebidConfig';
+
+/**
+ * Master flag for the entire header-bidding stack. Flip to `true` ONLY once the
+ * `/assets/prebid.js` bundle, `VITE_PREBID_CONFIG` and the GAM `hb_*` line items
+ * are all live (docs/HEADER-BIDDING.md). `false` = no auction; GPT serves
+ * AdSense-only exactly as before this module landed.
+ */
+export const PREBID_ENABLED = false;
+
+// Self-hosted custom Prebid build (display adapters: criteo, sovrn, medianet,
+// yieldlab, smartadserver + consentManagementTcf for EU/CH GDPR + gptPreAuction).
+// Built from prebid.org/download and dropped in /public/assets — never the
+// generic CDN bundle (it lacks our adapters and bloats the critical path).
+const PREBID_SCRIPT_SRC = '/assets/prebid.js';
+const DEFAULT_TIMEOUT_MS = 1000;
+
+interface PbjsSlotDef {
+  /** GPT div element id — Prebid matches the auction back to this GPT slot. */
+  code: string;
+  /** GAM ad unit path, keys the configured bids in prebidConfig. */
+  adUnitPath: string;
+  /** Requested sizes (mirrors the GPT slot); 'fluid' is dropped for the banner auction. */
+  sizes: readonly GptSize[];
+}
+
+let scriptRequested = false;
+let configured = false;
+
+function pbjs(): Record<string, unknown> & { que: Array<() => void> } {
+  const w = window as unknown as { pbjs?: Record<string, unknown> & { que?: Array<() => void> } };
+  const p = (w.pbjs = w.pbjs || {});
+  p.que = p.que || [];
+  return p as Record<string, unknown> & { que: Array<() => void> };
+}
+
+function ensurePrebidScript(): void {
+  if (scriptRequested || typeof document === 'undefined') return;
+  scriptRequested = true;
+  pbjs(); // ensure window.pbjs.que exists before the bundle evaluates
+  if (document.querySelector(`script[src="${PREBID_SCRIPT_SRC}"]`)) return;
+  const s = document.createElement('script');
+  s.src = PREBID_SCRIPT_SRC;
+  s.async = true;
+  document.head.appendChild(s);
+}
+
+function configurePrebid(): void {
+  if (configured) return;
+  configured = true;
+  const p = pbjs();
+  p.que.push(() => {
+    try {
+      (p as unknown as { setConfig: (c: unknown) => void }).setConfig({
+        priceGranularity: 'dense',
+        bidderTimeout: DEFAULT_TIMEOUT_MS,
+        useBidCache: true,
+        // EU/CH traffic: pass the IAB TCF v2 consent string to bidders. Funding
+        // Choices (Google's CMP, already loaded) provides it; Prebid reads it
+        // from the standard __tcfapi CMP interface.
+        consentManagement: {
+          gdpr: { cmpApi: 'iab', timeout: 3000, defaultGdprScope: true },
+        },
+        // Forward the GAM slot name to bidders for reporting / targeting.
+        gptPreAuction: { enabled: true },
+      });
+    } catch {
+      /* fail-soft */
+    }
+  });
+}
+
+/** Whether a header-bidding auction should run for this ad unit right now. */
+export function prebidActiveFor(adUnitPath: string): boolean {
+  return (
+    PREBID_ENABLED &&
+    typeof window !== 'undefined' &&
+    hasConfiguredBidders() &&
+    bidsForAdUnit(adUnitPath).length > 0 &&
+    isAdSenseProductionHost(window.location.hostname) &&
+    !isLikelyBot()
+  );
+}
+
+/**
+ * Run a header-bidding auction for a single GPT slot and apply the winning
+ * targeting to it. ALWAYS resolves (fail-soft); never rejects; never blocks GPT
+ * display longer than ~`timeoutMs`. Caller must call `gt.display()` only after
+ * the returned promise settles.
+ */
+export function requestHeaderBids(slot: PbjsSlotDef, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+  if (!prebidActiveFor(slot.adUnitPath)) return Promise.resolve();
+  ensurePrebidScript();
+  configurePrebid();
+
+  const bids = bidsForAdUnit(slot.adUnitPath).map((b) => ({ ...b }));
+  const sizes = slot.sizes.filter((s): s is [number, number] => Array.isArray(s));
+  if (!bids.length || !sizes.length) return Promise.resolve();
+
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    // Hard wall-clock guard: if prebid.js never loads or bidsBackHandler never
+    // fires, resolve anyway so GPT still serves. A touch above the auction
+    // timeout so a normal auction always wins the race.
+    const guard = window.setTimeout(done, timeoutMs + 500);
+
+    pbjs().que.push(() => {
+      try {
+        const p = pbjs() as unknown as {
+          addAdUnits: (u: unknown) => void;
+          requestBids: (o: unknown) => void;
+          setTargetingForGPTAsync: (codes: string[]) => void;
+        };
+        p.addAdUnits([{ code: slot.code, mediaTypes: { banner: { sizes } }, bids }]);
+        p.requestBids({
+          timeout: timeoutMs,
+          adUnitCodes: [slot.code],
+          bidsBackHandler: () => {
+            try {
+              p.setTargetingForGPTAsync([slot.code]);
+            } catch {
+              /* fail-soft */
+            } finally {
+              window.clearTimeout(guard);
+              done();
+            }
+          },
+        });
+      } catch {
+        window.clearTimeout(guard);
+        done();
+      }
+    });
+  });
+}

--- a/services/prebidConfig.ts
+++ b/services/prebidConfig.ts
@@ -1,0 +1,70 @@
+/**
+ * prebidConfig — declarative Prebid.js demand config for the explicit GAM/GPT
+ * slots (article rails, PoC). Header bidding only augments these GPT pubads
+ * slots; it NEVER touches AdSense Auto Ads (~95% revenue), the same boundary
+ * GptAdSlot already keeps. See docs/HEADER-BIDDING.md.
+ *
+ * Bidder placement IDs are intentionally NOT hardcoded: they are per-SSP account
+ * identifiers, differ per ad unit, and must never live in the repo. They are
+ * injected at build time via the `VITE_PREBID_CONFIG` env var — a JSON object
+ * mapping each GAM ad unit path to its Prebid bids, e.g.:
+ *
+ *   VITE_PREBID_CONFIG='{"/23355151813/article-rail-left":[
+ *     {"bidder":"criteo","params":{"networkId":12345}},
+ *     {"bidder":"sovrn","params":{"tagid":"998877"}},
+ *     {"bidder":"medianet","params":{"cid":"8CU...","crid":"45678"}}
+ *   ]}'
+ *
+ * Unset / empty / malformed → empty map → `requestHeaderBids()` is a no-op that
+ * resolves instantly, so GPT serves AdSense-only exactly as today. This keeps
+ * the whole header-bidding stack inert until real SSP accounts and the matching
+ * GAM line items exist — safe to merge with no behaviour change.
+ */
+
+export interface PrebidBid {
+  /** Prebid bidder code, e.g. 'criteo', 'sovrn', 'medianet', 'yieldlab'. */
+  bidder: string;
+  /** Bidder-specific placement params (shape varies per SSP). */
+  params: Record<string, unknown>;
+}
+
+export type PrebidConfigMap = Readonly<Record<string, readonly PrebidBid[]>>;
+
+function parsePrebidConfig(raw: string | undefined): PrebidConfigMap {
+  if (!raw || !raw.trim()) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, PrebidBid[]> = {};
+    for (const [adUnitPath, bids] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(bids)) continue;
+      const valid = bids.filter(
+        (b): b is PrebidBid =>
+          !!b &&
+          typeof b === 'object' &&
+          typeof (b as { bidder?: unknown }).bidder === 'string' &&
+          !!(b as { params?: unknown }).params &&
+          typeof (b as { params?: unknown }).params === 'object',
+      );
+      if (valid.length) out[adUnitPath] = valid;
+    }
+    return out;
+  } catch {
+    // Build-time trusted input, but never let a malformed string break the SPA.
+    return {};
+  }
+}
+
+const PREBID_CONFIG: PrebidConfigMap = parsePrebidConfig(
+  (import.meta as unknown as { env?: Record<string, string | undefined> }).env?.VITE_PREBID_CONFIG,
+);
+
+/** Bids configured for a given GAM ad unit path (empty array if none). */
+export function bidsForAdUnit(adUnitPath: string): readonly PrebidBid[] {
+  return PREBID_CONFIG[adUnitPath] ?? [];
+}
+
+/** True when at least one ad unit has bidders configured via env. */
+export function hasConfiguredBidders(): boolean {
+  return Object.keys(PREBID_CONFIG).length > 0;
+}

--- a/tests/use-kill-switches.test.ts
+++ b/tests/use-kill-switches.test.ts
@@ -25,6 +25,7 @@ describe('useKillSwitches', () => {
       orphanLandings: false,
       gptPocSlot: false,
       articleRailAds: false,
+      headerBidding: false,
     });
   });
 
@@ -72,6 +73,7 @@ describe('useKillSwitches', () => {
       orphanLandings: true,
       gptPocSlot: true,
       articleRailAds: false,
+      headerBidding: false,
     });
   });
 
@@ -81,7 +83,7 @@ describe('useKillSwitches', () => {
     renderHook(() => useKillSwitches());
 
     await waitFor(() => {
-      expect(rcMock).toHaveBeenCalledTimes(7);
+      expect(rcMock).toHaveBeenCalledTimes(8);
     });
 
     const callArgs = rcMock.mock.calls.map(([arg]) => arg);
@@ -92,5 +94,6 @@ describe('useKillSwitches', () => {
     expect(callArgs).toContain('KILL_ORPHAN_LANDINGS_LINKS');
     expect(callArgs).toContain('KILL_GPT_POC_SLOT');
     expect(callArgs).toContain('KILL_ARTICLE_RAIL_ADS');
+    expect(callArgs).toContain('KILL_HEADER_BIDDING');
   });
 });


### PR DESCRIPTION
## Implementato

Layer client-side **header bidding** on the explicit GAM/GPT slots only (article rails + PoC), additive over the existing GPT/AdSense stack.

- **`services/headerBidding.ts`** — Prebid wrapper: runs an auction before `googletag.display()`, applies winning `hb_*` targeting via `setTargetingForGPTAsync`, so SSP demand competes with AdSense dynamic-allocation in the same GAM auction. Bot- + prod-host-gated; fail-soft with hard timeout + wall-clock guard (never blocks display); `PREBID_ENABLED` master flag (default **false**).
- **`services/prebidConfig.ts`** — declarative ad-unit→bidder map parsed from the `VITE_PREBID_CONFIG` build env (no hardcoded SSP IDs). Empty/unset → `requestHeaderBids()` is a no-op.
- **`components/shared/GptAdSlot.tsx`** — new `headerBiddingKilled` prop + pre-display auction handoff. When disabled/unconfigured/killed, falls back to plain `gt.display()` (behaviour unchanged).
- **`ArticleRailAd.tsx` / `GptPocSlot.tsx`** — pass `headerBiddingKilled` from `useKillSwitches`. (`ArticleRailAdStack` inherits via `ArticleRailAd`.)
- **`hooks/useKillSwitches.ts` + `services/firebase.ts`** — new `headerBidding` kill-switch → `KILL_HEADER_BIDDING` Remote Config (default `'false'`), a runtime off-switch with no redeploy.
- **`public/ads.txt`** — Sovrn publisher `607103` DIRECT lines (new pending account); reseller chain was already declared.
- **`docs/HEADER-BIDDING.md`** — go-live checklist (SSP signup, custom Prebid bundle, GAM `hb_*` line items, env, monitoring/rollback).
- **`tests/use-kill-switches.test.ts`** — updated RC contract (7→8 params, asserts `KILL_HEADER_BIDDING`). Green.

**Inert by default**: with `PREBID_ENABLED=false`, no `VITE_PREBID_CONFIG`, and no `/assets/prebid.js` bundle, GPT serves AdSense-only exactly as before. **AdSense Auto Ads (~95% revenue) are untouched** — they are not GPT slots and cannot be header-bid. No live behaviour change → no deploy-perf risk in this PR; CWV is validated only at go-live (flip flag), with instant rollback via `KILL_HEADER_BIDDING`.

## Non implementato (ancora)

- **Go-live (`PREBID_ENABLED=true`)** — blocked until: SSP placement IDs exist (Sovrn account **pending approval**; Criteo/Media.net/Yieldlab/Equativ not yet signed up), a self-hosted `/assets/prebid.js` custom bundle is built, and GAM `hb_*` line items are created. Out of scope here; steps in `docs/HEADER-BIDDING.md`. Inert so no revert-trigger needed.
- **`VITE_PREBID_CONFIG`** — not set (no real bidder IDs yet).
- **`/assets/prebid.js`** — not committed; built per-deploy from prebid.org with the chosen adapters (out of scope, deliberate).
- **Amazon APS adapter** — account pending; wired later via the same config/bundle, no code change needed.
- **`check-sibling-patterns` flags** (`JobBoard.tsx`, `QuickLinksGrid.tsx`, `SeoDailyBanner.tsx`, `WeeklyEmployersTeaser.tsx`, `StatsTabContent.tsx`) — **not touched**: they consume unrelated kill switches; the `useKillSwitches` change is purely additive and backward-compatible (each consumer destructures only the keys it needs), and none is a header-bidding surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)