### PR TITLE
perf(translate): cap cascade deadline under Argos-first (cut wall-clock 269→~120min)

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -226,6 +226,17 @@ jobs:
         if: inputs.skip_translate != true
         env:
           JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          # Cap the slow cascade's run-wide deadline so it does a SHORT top-up pass
+          # instead of expanding to fill 250min (measured: Phase 2b grew to 229min /
+          # ~269min total on run 28074729486 even though Phase 2a had already drained
+          # the bulk in 23min — the cascade always runs to its budget). Under Argos-first
+          # the fast engine (Phase 2a + the Phase 2c mop-up) covers the backlog, so 90min
+          # is plenty for the premium-upgrade + contamination-fix the cascade uniquely
+          # does; the rest defers to the next of ~7 runs/day. Self-throttling: the
+          # deadline is measured from RUN_START, so a long Phase 2a shrinks the window.
+          # Revert path (TRANSLATE_ARGOS_FIRST_DISABLE=1, cascade is primary) keeps the
+          # full 250min. (== '1' avoids the '' vs '0' numeric-coercion footgun.)
+          JOBS_CASCADE_DEADLINE_MS: ${{ vars.TRANSLATE_ARGOS_FIRST_DISABLE == '1' && '15000000' || '5400000' }}
           # Local Opus-MT tier (Helsinki-NLP via @huggingface/transformers, on-runner).
           # Free, deterministic, offline; reuses the ONNX runtime proven for embeddings.
           # Kept ON as the cascade's local fallback for the remainder (and for the

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -97,7 +97,16 @@ const TIME_BUDGET_MS = 320 * 60 * 1000;
 // inside the 350min timeout. Falls back to now() when no marker exists
 // (cascade-first / standalone), identical to the prior behaviour.
 const RUN_START_MS = readRunStartMs() ?? Date.now();
-const CASCADE_LOCALIZATION_DEADLINE_MS = 250 * 60 * 1000;
+// Run-wide deadline for the slow HTTP/ONNX cascade. Default 250min (cascade-first
+// era: the cascade IS the primary translator). Under Argos-first the fast
+// CTranslate2 bulk (Phase 2a) + the Argos mop-up (Phase 2c) already cover the
+// backlog, so the cascade only needs a SHORT premium-upgrade / contamination-fix
+// pass — translate-pending.yml caps it via JOBS_CASCADE_DEADLINE_MS so the cascade
+// stops expanding to fill 250min and the whole job's wall-clock drops. Measured
+// from RUN_START_MS, so a long Phase 2a self-throttles the cascade (it steps aside
+// when the bulk pass ran long, takes its window when the bulk was quick).
+const CASCADE_LOCALIZATION_DEADLINE_MS =
+  Number(process.env.JOBS_CASCADE_DEADLINE_MS) || 250 * 60 * 1000;
 
 function readJson(filePath) {
   try {


### PR DESCRIPTION
## Implementato

Dopo il reorder Argos-first (#2757), la verifica live ha mostrato che **il wall-clock non scendeva** nonostante Phase 2a fosse veloce:

| Step (run 28074729486) | Durata |
|---|---|
| Phase 2a (Argos bulk) | **23min** (backlog drenato) |
| Phase 2b (cascade ONNX) | **229min** ⚠️ |
| Phase 2c (mop-up) | 4min |
| **Totale** | **269min** |

**Causa radice:** la cascade lenta (Phase 2b) ha un budget run-wide di 250min (`CASCADE_LOCALIZATION_DEADLINE_MS`) e **lo riempie sempre** — 229min per ~100 job su 45 aziende, diverse "no flags cleared" = grinding a basso rendimento. Il reorder da solo non bastava: la cascade si espande fino al budget.

**Fix:**
- `CASCADE_LOCALIZATION_DEADLINE_MS` ora **env-configurabile** (`JOBS_CASCADE_DEADLINE_MS`, default 250min invariato).
- Sotto Argos-first il workflow la cappa a **90min**: il motore veloce (Phase 2a + mop-up Phase 2c) copre già il backlog, quindi la cascade fa solo un breve pass di premium-upgrade + fix-contaminazione; il resto slitta al prossimo dei ~7 run/giorno.
- **Self-throttling**: il deadline è misurato da RUN_START, quindi una Phase 2a lunga restringe automaticamente la finestra della cascade (si fa da parte quando il bulk è stato lungo, prende il suo slot quando è stato corto).
- Path revert (`TRANSLATE_ARGOS_FIRST_DISABLE=1`) mantiene i 250min pieni, selezionato con `vars.X == '1'` (evita il footgun di coercion `''`/`'0'` fixato in #2783).

**Atteso:** totale ~110-130min vs 269min, sotto anche il baseline pre-change (~138min), mantenendo consistency + qualità di Argos-first.

Validato: YAML + actionlint puliti; `node --check`; override env verificato (90min/250min); 11 test relocalize verdi.

## Non implementato (ancora)

- **REVERT-TRIGGER perf (non misurabile pre-merge):** la riduzione wall-clock è verificabile solo sul prossimo run live. Se il prossimo translate-pending NON scende verso ~120min o il backlog flagged inizia a crescere (cascade troppo corta per la contaminazione in arrivo) → alzare `JOBS_CASCADE_DEADLINE_MS` (env, zero code-change) o settare `TRANSLATE_ARGOS_FIRST_DISABLE=1`.
- **Sibling sweep `RUN_START`:** il sibling-check segnala `create-article.mjs`/`translate-run-clock.mjs`/`local-mt-mopup.mjs` per token `RUN_START` condiviso — falsi positivi: il deadline cascade è unico in `relocalize`; il mop-up ha già il suo `MOPUP_DEADLINE_MS` env-configurabile. Nessun antipattern condiviso da fixare.
- **Tuning fine del valore 90min:** scelto come primo cap bilanciato (latency vs throughput cascade); env-tunabile senza code-change dopo misura live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)