### PR TITLE
feat(newsletter): personalize the greeting with the subscriber's first name

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1281,6 +1281,7 @@ function subscriberFromFirestoreRow(row) {
   const fresh = calculateEngagementScore(row);
   return {
     email,
+    name: row.name || null,
     locale: (row.preferred_locale || row.locale || 'it').split(/[-_]/)[0] || 'it',
     sourceChannel: row.source_channel || row.source || 'newsletter_page',
     locationInterest: row.location_interest || null,
@@ -2151,6 +2152,7 @@ async function main() {
       weeklyFact: getWeeklyFact(locale),
       metrics,
       locale,
+      recipientName: subscriber.name,
       issueNumber,
       unsubscribeUrl: makeUnsubscribeUrl(subscriber.email),
       resubscribeUrl: makeResubscribeUrl(subscriber.email),

--- a/services/newsletter-template.mjs
+++ b/services/newsletter-template.mjs
@@ -23,6 +23,7 @@ const RED = '#ef4444';
 const NL_I18N = {
   it: {
     greeting: 'Buongiorno, frontaliere.',
+    greetingNamed: 'Buongiorno, {name}.',
     greetingSub: 'Ecco cosa succede ai tuoi soldi questa settimana.',
     rateCta: 'Confronta i tassi di cambio \u2192',
     editorialTitle: 'Parliamoci chiaro.',
@@ -71,6 +72,7 @@ const NL_I18N = {
   },
   en: {
     greeting: 'Good morning, frontaliere.',
+    greetingNamed: 'Good morning, {name}.',
     greetingSub: 'Here\u2019s what\u2019s happening to your money this week.',
     rateCta: 'Compare exchange rates \u2192',
     editorialTitle: 'Let\u2019s be honest.',
@@ -119,6 +121,7 @@ const NL_I18N = {
   },
   de: {
     greeting: 'Guten Morgen, Grenzg\u00e4nger.',
+    greetingNamed: 'Guten Morgen, {name}.',
     greetingSub: 'Das passiert diese Woche mit deinem Geld.',
     rateCta: 'Wechselkurse vergleichen \u2192',
     editorialTitle: 'Mal ehrlich.',
@@ -167,6 +170,7 @@ const NL_I18N = {
   },
   fr: {
     greeting: 'Bonjour, frontalier.',
+    greetingNamed: 'Bonjour, {name}.',
     greetingSub: 'Voici ce qui arrive \u00e0 ton argent cette semaine.',
     rateCta: 'Comparer les taux de change \u2192',
     editorialTitle: 'Soyons honn\u00eates.',
@@ -248,6 +252,39 @@ function escapeHtml(str) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+/**
+ * Extract a safe, display-ready FIRST name from a stored subscriber name, or null
+ * when it isn't a usable human first name (so the greeting falls back to generic).
+ * Defensive because `name` is free-text user input rendered into HTML email:
+ * first whitespace token only, letters + hyphen/apostrophe (Unicode), length 2-30,
+ * rejects emails / digits / symbols. Title-cases each segment (anna-maria→Anna-Maria).
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+export function sanitizeFirstName(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const first = raw.trim().split(/\s+/)[0] || '';
+  if (first.length < 2 || first.length > 30) return null;
+  if (!/^[\p{L}][\p{L}'’-]*$/u.test(first)) return null; // letters + ' ’ - only
+  return first.toLowerCase().replace(/(^|[-'’])(\p{L})/gu, (_, sep, ch) => sep + ch.toUpperCase());
+}
+
+/**
+ * Greeting line: "Buongiorno, {Name}." when we have a usable name, else the
+ * generic per-locale greeting. The name is sanitized then HTML-escaped (belt &
+ * suspenders — the sanitizer already excludes HTML metacharacters).
+ * @param {string} locale
+ * @param {unknown} rawName
+ * @returns {string}
+ */
+export function personalizeGreeting(locale, rawName) {
+  const loc = nlNormLocale(locale);
+  const name = sanitizeFirstName(rawName);
+  if (!name) return nlT(loc, 'greeting');
+  const tpl = nlT(loc, 'greetingNamed') || nlT(loc, 'greeting');
+  return tpl.replace('{name}', escapeHtml(name));
 }
 
 export function directUrl(path) {
@@ -369,7 +406,7 @@ function renderTopBar(locale, issueNumberOverride) {
     </td></tr>`;
 }
 
-function renderHeroExchangeRate({ rate, previousRate, locale }) {
+function renderHeroExchangeRate({ rate, previousRate, locale, recipientName }) {
   const diff = rate - previousRate;
   const pct = previousRate > 0 ? Math.abs((diff / previousRate) * 100).toFixed(1) : '0.0';
   const isDown = diff < -0.0005;
@@ -398,7 +435,7 @@ function renderHeroExchangeRate({ rate, previousRate, locale }) {
   return `
     <tr><td class="section-pad" style="background:${BRAND_DARK};color:#fff;padding:32px 28px 28px;text-align:center;">
       <div style="font-size:13px;text-transform:uppercase;letter-spacing:2px;color:${BRAND_ORANGE};font-weight:700;margin-bottom:6px;">${nlT(locale, 'realtimeUpdate')}</div>
-      <div style="font-size:28px;font-weight:800;margin:0 0 4px;line-height:1.2;color:#fff;">${nlT(locale, 'greeting')}</div>
+      <div style="font-size:28px;font-weight:800;margin:0 0 4px;line-height:1.2;color:#fff;">${personalizeGreeting(locale, recipientName)}</div>
       <div style="font-size:14px;color:#94a3b8;margin:0 0 20px;">${nlT(locale, 'greetingSub')}</div>
 
       <!--[if mso]><table cellpadding="0" cellspacing="0" align="center"><tr><td style="background:#1e293b;border-radius:16px;padding:20px 36px;"><![endif]-->
@@ -702,7 +739,7 @@ export function buildNewsletter(data) {
   html += renderTopBar(locale, data.issueNumber);
 
   // 2. Hero exchange rate
-  if (data.exchangeRate) html += renderHeroExchangeRate({ ...data.exchangeRate, locale });
+  if (data.exchangeRate) html += renderHeroExchangeRate({ ...data.exchangeRate, locale, recipientName: data.recipientName });
 
   // 3. Editorial (AI briefing or fallback)
   html += renderEditorial(locale, data.aiBriefing, totalJobs);

--- a/tests/newsletter-greeting.test.ts
+++ b/tests/newsletter-greeting.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFirstName, personalizeGreeting } from '../services/newsletter-template.mjs';
+
+describe('sanitizeFirstName', () => {
+  it('takes the first name token and title-cases it', () => {
+    expect(sanitizeFirstName('mario rossi')).toBe('Mario');
+    expect(sanitizeFirstName('  MARIO  ')).toBe('Mario');
+    expect(sanitizeFirstName('anna-maria de luca')).toBe('Anna-Maria');
+    expect(sanitizeFirstName("o'brien")).toBe("O'Brien"); // segment after apostrophe is capitalized
+  });
+
+  it('preserves accented letters', () => {
+    expect(sanitizeFirstName('chloé')).toBe('Chloé');
+    expect(sanitizeFirstName('józef')).toBe('Józef');
+  });
+
+  it('rejects non-name junk → null (greeting falls back to generic)', () => {
+    for (const bad of [null, undefined, '', '  ', 'a', 'x'.repeat(31), 'user@example.com', 'mario123', 'jean_paul', '<script>', '€uro', '42']) {
+      expect(sanitizeFirstName(bad as string)).toBeNull();
+    }
+  });
+});
+
+describe('personalizeGreeting', () => {
+  it('uses the name across all four locales', () => {
+    expect(personalizeGreeting('it', 'Mario')).toBe('Buongiorno, Mario.');
+    expect(personalizeGreeting('en', 'Mario')).toBe('Good morning, Mario.');
+    expect(personalizeGreeting('de', 'Mario')).toBe('Guten Morgen, Mario.');
+    expect(personalizeGreeting('fr', 'Mario')).toBe('Bonjour, Mario.');
+  });
+
+  it('falls back to the generic greeting when no usable name', () => {
+    expect(personalizeGreeting('it', null)).toBe('Buongiorno, frontaliere.');
+    expect(personalizeGreeting('it', 'newsletter@x.ch')).toBe('Buongiorno, frontaliere.');
+    expect(personalizeGreeting('en', '')).toBe('Good morning, frontaliere.');
+  });
+
+  it('never injects HTML (malicious name is rejected → generic)', () => {
+    const out = personalizeGreeting('it', '<img src=x onerror=alert(1)>');
+    expect(out).toBe('Buongiorno, frontaliere.');
+    expect(out).not.toContain('<img');
+  });
+
+  it('defaults unknown locale to Italian', () => {
+    expect(personalizeGreeting('xx', 'Mario')).toBe('Buongiorno, Mario.');
+  });
+});


### PR DESCRIPTION
## Implementato

Il saluto hero era statico ("Buongiorno, frontaliere." × locale). Ora, quando abbiamo un nome usabile sull'iscritto, lo salutiamo per nome: **"Buongiorno, Mario."** — altrimenti **fallback identico** al saluto generico di oggi.

- **`services/newsletter-template.mjs`**: `personalizeGreeting(locale, name)` + `sanitizeFirstName` (primo token, lettere Unicode + trattino/apostrofo, title-case, lunghezza 2-30, scarta email/cifre/simboli → fallback generico). Il nome è **sanitizzato E HTML-escaped** prima del render (è input free-text in una email HTML → anti-injection). Nuovo template per-locale `greetingNamed`; render via `renderHeroExchangeRate`.
- **`scripts/send-newsletter.mjs`**: passa il `name` dell'iscritto a `buildNewsletter` (`recipientName`) + aggiunge `name` alla proiezione subscriber.

Tutti e 4 i locali (it/en/de/fr). Testato (sanitize + greeting, 7 casi incl. rifiuto injection). Render end-to-end verificato: con nome → `Buongiorno, Mario.`, senza → `Buongiorno, frontaliere.`.

## Non implementato (ancora)

- **Backfill nomi**: molti iscritti non hanno un `name` salvato → vedono il fallback generico (nessuna regressione). Raccogliere/derivare il nome (es. da Google/LinkedIn login o form) è fuori scope.
- **WhatsNewModal**: è un cambiamento alla email, non una feature dell'app UI → nessuna entry.
- **Greeting senza exchange-rate**: il saluto vive nella hero exchange-rate (render condizionale, comportamento invariato); una newsletter senza tasso non ha saluto né prima né ora.

> Nota: questa PR fa anche da **canarino** per la validazione C2 (Workstream B) — se finisce behind main, `pr-autorebase` la rebaserà via l'App token e potremo osservare se il run risultante evita il gate `action_required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)