### PR TITLE
fix(jobboard): narrow job-detail container to 1440px for lateral breathing room

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2518,10 +2518,15 @@ const App: React.FC = () => {
  // Widen past max-w-7xl (1280) at ≥1400px so the job-detail view's 3-column
  // rail grid (300px | content | 300px) gets room for BOTH rails AND a readable
  // centre — otherwise the 600px of rails collapse the content column to ~630px
- // inside the 1280 cap (measured live). Mutually-exclusive ranges (`max-xlw:` <
- // 1400, `xlw:` ≥ 1400) so the v4 cascade can't pin it to 7xl. Inner list view
- // self-caps (max-w-6xl), so only the rail'd detail/gate views use the width.
- <div className="max-xlw:max-w-7xl xlw:max-w-[1900px] mx-auto">
+ // inside the 1280 cap (measured live). Capped at 1440px (matching the blog
+ // article view above), not 1900: the wider cap let the centre run ~1180px at
+ // 1920 so the article ran edge-to-edge against the rails with no lateral
+ // breathing room. 1440 keeps the 300px half-page rails AND a comfortable
+ // ~530px article column with white margins either side. Mutually-exclusive
+ // ranges (`max-xlw:` < 1400, `xlw:` ≥ 1400) so the v4 cascade can't pin it to
+ // 7xl. Inner list view self-caps (max-w-6xl), so only the rail'd detail/gate
+ // views use the width.
+ <div className="max-xlw:max-w-7xl xlw:max-w-[1440px] mx-auto">
  <JobBoard
  initialJobSlug={jobSlug || undefined}
  initialFilterParams={jobBoardFilterParams}


### PR DESCRIPTION
## Implementato

- Il container del job-detail era `xlw:max-w-[1900px]` → a 1920px la colonna centrale correva ~1180px e l'articolo arrivava bordo-a-bordo contro i rail laterali (300px), senza spazio bianco laterale (cramped, vedi screenshot live).
- Portato a **`xlw:max-w-[1440px]`**, **identico alla blog article view** (stesso `ft-rail-grid-x` 300px) → l'intero blocco rail+contenuto si centra con **margini bianchi laterali**, la colonna articolo scende a ~530px (lettura comoda) e il contenuto centrale "respira", come nelle altre view del sito.
- **Rail 300px half-page preservati** (nessuna perdita di inventory/revenue). Commento sopra il wrapper aggiornato con la nuova motivazione.
- One-liner in `App.tsx` (wrapper `activeTab === 'job-board'`); la list view si auto-cappa (`max-w-6xl` < 1440) quindi non è toccata; gate + detail beneficiano uguale.

`App.tsx` (9 insertions, 4 deletions). esbuild OK. Larghezze validate via repro: 1900 → article col 829px (no respiro); 1440 → 531px + margini 240px/lato.

## Non implementato (ancora)

- **Match strutturale 1:1 con la home** (rail a filo viewport + gap interni): la home usa rail SPA da 160px a tutta larghezza; replicarlo qui significherebbe ridurre i rail del job-detail a <300px e perdere le creatività half-page (revenue). Scelto invece il pattern già adottato dalla article view (cap 1440 + rail 300px), che dà lo stesso effetto di respiro senza toccare l'inventory.
- **Verifica live**: layout validato via repro strutturale; rendering reale da confermare post-deploy.