### PR TITLE
feat(ads): dedicated desktop top-banner GAM unit above the H1 (no more gap)

### DIFF
--- a/components/shared/ArticleRailAd.tsx
+++ b/components/shared/ArticleRailAd.tsx
@@ -6,7 +6,7 @@
  * dedicated GAM ad unit (/23355151813/article-rail-{left,right}, sizes
  * 300x600 / 160x600 / 300x250 + fluid, AdSense backfill on) via GPT, so AdSense
  * Auto Ads keep serving untouched. Created programmatically by
- * scripts/gam-create-rail-units.mjs.
+ * scripts/gam-create-ad-units.mjs.
  *
  * Lives inside the rail's existing `sticky top-6` stack, so the half-page ad
  * rides down the gutter as the reader scrolls. Runtime kill-switch: Firebase
@@ -24,7 +24,7 @@ const RAIL_AD_UNIT_PATHS = {
 } as const;
 
 // Premium vertical display sizes first, box + fluid as fallback — must match
-// what the GAM ad unit allows (see scripts/gam-create-rail-units.mjs). Used on
+// what the GAM ad unit allows (see scripts/gam-create-ad-units.mjs). Used on
 // the wide (300px) reading-page rails (blog / job / static SEO).
 const RAIL_SIZES: GptSize[] = [[300, 600], [160, 600], [300, 250], 'fluid'];
 // Narrow rail (160px SPA tool-page gutter): only 160-wide creatives + fluid, so

--- a/components/shared/DesktopTopBanner.tsx
+++ b/components/shared/DesktopTopBanner.tsx
@@ -1,0 +1,47 @@
+/**
+ * DesktopTopBanner — dedicated desktop top-of-page GPT/GAM leaderboard.
+ *
+ * Replaces our reliance on Google's variable-height in-page Auto Ad at the top
+ * of the tool pages. That Auto Ad (`.google-auto-placed`) rendered inside an
+ * aspect-ratio box much taller than the real creative, leaving a ~120px blank
+ * band above the fold (the reported "gap in alto"). A deliberate unit lets us
+ * pin the exact height instead.
+ *
+ * Serves `/23355151813/desktop-top-banner` (970x90 / 728x90 — a single 90px
+ * creative height, NO fluid) via GptAdSlot with a 90px reserve, so the slot
+ * reserves exactly the creative height: zero blank band AND zero CLS. Unfilled
+ * impressions collapse to `display:none` (GptAdSlot), so the slot never leaves
+ * white space when there is no demand.
+ *
+ * GPT (pubads) is independent of `adsbygoogle.js`, so AdSense Auto Ads keep
+ * serving untouched (AGENTS §7) — this is additive, not a suppression. Runtime
+ * kill-switch: Firebase Remote Config `KILL_DESKTOP_TOP_BANNER` (~1 min, no
+ * redeploy; default-safe = shown).
+ *
+ * CSS-gated to >=lg (1024px): the unit only allows desktop leaderboards
+ * (728-970 wide), so below that the container can't fit a creative and the slot
+ * stays hidden (mobile/​tablet keep their own Auto Ads).
+ */
+import GptAdSlot, { type GptSize } from '@/components/shared/GptAdSlot';
+import { useKillSwitches } from '@/hooks/useKillSwitches';
+
+const TOP_BANNER_UNIT_PATH = '/23355151813/desktop-top-banner';
+// Uniform 90px-tall leaderboards only — a single creative height means the
+// 90px reserve below matches the fill exactly (no over-reserve gap, no shift).
+const TOP_BANNER_SIZES: GptSize[] = [[970, 90], [728, 90]];
+
+export default function DesktopTopBanner() {
+  const { desktopTopBanner: killed } = useKillSwitches();
+  return (
+    <GptAdSlot
+      adUnitPath={TOP_BANNER_UNIT_PATH}
+      sizes={TOP_BANNER_SIZES}
+      killed={killed}
+      minHeight={90}
+      // Desktop-only leaderboard, centred, full content width. `hidden` below
+      // lg so mobile/tablet render nothing (no reserve). GptAdSlot collapses to
+      // display:none on no-fill, so an empty slot leaves no band.
+      className="hidden lg:block w-full text-center mb-4"
+    />
+  );
+}

--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -16,6 +16,7 @@ import {
 import AiExtractableTable from '@/components/shared/AiExtractableTable';
 import FaqAccordion from '@/components/shared/FaqAccordion';
 import { SilentErrorBoundary } from '@/components/shared/ErrorBoundary';
+import DesktopTopBanner from '@/components/shared/DesktopTopBanner';
 
 // Eagerly load InputCard in THIS chunk so it parses only when CalcolatoreTabContent loads.
 // This removes InputCard and MobileCalcLayout from the main App bundle.
@@ -51,6 +52,12 @@ export default function CalcolatoreTabContent() {
 
  if (calcolatoreSubTab === 'calculator') {
  return (
+ <>
+ {/* Dedicated desktop top-banner (GPT/GAM leaderboard) above the H1 —
+ replaces reliance on the variable-height Auto Ad whose box left a blank
+ band above the fold. Outside space-y-8 so the hidden (mobile) slot adds
+ no phantom top gap. */}
+ <DesktopTopBanner />
  <div className="space-y-8">
  {seoLanding === 'new-frontier-over20km' ? (
  <Suspense fallback={<div className="h-64 rounded-3xl bg-surface-raised animate-pulse mb-6" />}>
@@ -334,6 +341,7 @@ export default function CalcolatoreTabContent() {
  </>
  )}
  </div>
+ </>
  );
  }
 

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -31,6 +31,7 @@ export type KillSwitchKey =
   | 'orphanLandings'
   | 'gptPocSlot'
   | 'articleRailAds'
+  | 'desktopTopBanner'
   | 'headerBidding';
 
 export type KillSwitchState = Readonly<Record<KillSwitchKey, boolean>>;
@@ -48,6 +49,7 @@ export const KILL_SWITCH_RC_KEYS: Readonly<Record<KillSwitchKey, string>> = {
   orphanLandings: 'KILL_ORPHAN_LANDINGS_LINKS',
   gptPocSlot: 'KILL_GPT_POC_SLOT',
   articleRailAds: 'KILL_ARTICLE_RAIL_ADS',
+  desktopTopBanner: 'KILL_DESKTOP_TOP_BANNER',
   headerBidding: 'KILL_HEADER_BIDDING',
 } as const;
 
@@ -59,6 +61,7 @@ const DEFAULT_STATE: KillSwitchState = {
   orphanLandings: false,
   gptPocSlot: false,
   articleRailAds: false,
+  desktopTopBanner: false,
   headerBidding: false,
 } as const;
 

--- a/scripts/gam-create-ad-units.mjs
+++ b/scripts/gam-create-ad-units.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 /**
- * Create (or reuse) the desktop article side-rail ad units in Google Ad Manager,
- * then print the GPT ad-unit paths to wire into the front-end.
+ * Create (or reuse) the site's own GPT/GAM display ad units in Google Ad
+ * Manager, then print the GPT ad-unit paths to wire into the front-end.
  *
- * WHY GAM (not AdSense): the original AdSense rail units were archived in the
+ * Covers the desktop article side-rails AND the desktop top banner.
+ *
+ * WHY GAM (not AdSense): the original AdSense units were archived in the
  * 2026-04-26 prune, and the AdSense Management API v2 cannot create ad units
  * for this account (POST adunits → 403 PERMISSION_DENIED) nor reactivate an
  * archived one (state is read-only). The site already serves a GPT slot
@@ -14,18 +16,22 @@
  * impressions, so fill stays comparable to a plain AdSense unit while Auto Ads
  * keep serving untouched.
  *
- * Each rail unit allows the premium vertical display sizes (300x600 half-page,
- * 160x600 wide skyscraper) plus 300x250 + fluid as a fallback, mirroring the
- * PoC unit's BROWSER/fluid/AdSense-enabled config. AdSense settings are
- * inherited from the network root (already AdSense-enabled).
+ * Sizes are per-unit (see TARGETS). AdSense settings are inherited from the
+ * network root (already AdSense-enabled).
+ *  - Rails: premium verticals (300x600 half-page, 160x600 skyscraper) + 300x250
+ *    box + fluid fallback.
+ *  - Top banner: uniform-height leaderboards only (970x90, 728x90), isFluid
+ *    false — a single creative height (90px) lets the front-end slot reserve
+ *    exactly that height, so it never leaves a blank band above the fold (the
+ *    gap a variable-height Auto Ad / aspect-ratio box caused).
  *
  * Auth: service-account JSON with GAM (dfp) access on the network.
  *   GOOGLE_APPLICATION_CREDENTIALS=./mcp-gsc-main/service_account_credentials.json
  *
  * Usage:
  *   GOOGLE_APPLICATION_CREDENTIALS=./mcp-gsc-main/service_account_credentials.json \
- *     node scripts/gam-create-rail-units.mjs            # create/reuse
- *   ... node scripts/gam-create-rail-units.mjs --dry-run  # list only, no writes
+ *     node scripts/gam-create-ad-units.mjs            # create/reuse
+ *   ... node scripts/gam-create-ad-units.mjs --dry-run  # list only, no writes
  */
 import { readFileSync } from 'node:fs';
 import { createSign } from 'node:crypto';
@@ -35,12 +41,12 @@ const NETWORK_CODE = '23355151813';
 const APP_NAME = 'frontaliere-rail';
 const DRY_RUN = process.argv.includes('--dry-run');
 
+// Each target carries its own sizes + isFluid.
 const TARGETS = [
-  { adUnitCode: 'article-rail-left', name: 'Article rail — left (desktop)' },
-  { adUnitCode: 'article-rail-right', name: 'Article rail — right (desktop)' },
+  { adUnitCode: 'article-rail-left', name: 'Article rail — left (desktop)', sizes: [[300, 600], [160, 600], [300, 250]], isFluid: true },
+  { adUnitCode: 'article-rail-right', name: 'Article rail — right (desktop)', sizes: [[300, 600], [160, 600], [300, 250]], isFluid: true },
+  { adUnitCode: 'desktop-top-banner', name: 'Desktop top banner', sizes: [[970, 90], [728, 90]], isFluid: false },
 ];
-// Premium vertical display sizes first, box + fluid as fallback.
-const SIZES = [[300, 600], [160, 600], [300, 250]];
 
 const saPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
 if (!saPath) { console.error('✗ set GOOGLE_APPLICATION_CREDENTIALS to the GAM service-account JSON'); process.exit(1); }
@@ -96,7 +102,7 @@ async function findByCode(token, adUnitCode) {
 }
 
 function adUnitXml(parentId, t) {
-  const sizesXml = SIZES.map(([w, h]) =>
+  const sizesXml = t.sizes.map(([w, h]) =>
     `<adUnitSizes><size><width>${w}</width><height>${h}</height><isAspectRatio>false</isAspectRatio></size>` +
     `<environmentType>BROWSER</environmentType></adUnitSizes>`).join('');
   // Element order must follow the AdUnit XSD: parentId, name, targetWindow,
@@ -107,7 +113,7 @@ function adUnitXml(parentId, t) {
     `<targetWindow>TOP</targetWindow>` +
     `<adUnitCode>${escapeXml(t.adUnitCode)}</adUnitCode>` +
     sizesXml +
-    `<isFluid>true</isFluid>` +
+    `<isFluid>${t.isFluid ? 'true' : 'false'}</isFluid>` +
     `</adUnits>`;
 }
 

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -82,6 +82,10 @@ const REMOTE_CONFIG_DEFAULTS: Record<string, string> = {
  // 'false' = rails SHOWN. Flip to 'true' in the Remote Config console to kill
  // both rail ads within ~1 min (no redeploy) if they regress Auto Ads / RPM / CWV.
  KILL_ARTICLE_RAIL_ADS: 'false',
+ // Desktop top banner (dedicated GPT/GAM leaderboard above the H1). Default
+ // 'false' = shown. Flip to 'true' to kill it within ~1 min (no redeploy);
+ // Auto Ads keep serving untouched.
+ KILL_DESKTOP_TOP_BANNER: 'false',
  // Header-bidding (Prebid) pre-auction on the explicit GPT slots. Default
  // 'false' = auction allowed (still gated by PREBID_ENABLED in
  // services/headerBidding.ts). Flip to 'true' to disable Prebid within ~1 min

--- a/tests/use-kill-switches.test.ts
+++ b/tests/use-kill-switches.test.ts
@@ -25,6 +25,7 @@ describe('useKillSwitches', () => {
       orphanLandings: false,
       gptPocSlot: false,
       articleRailAds: false,
+      desktopTopBanner: false,
       headerBidding: false,
     });
   });
@@ -73,6 +74,7 @@ describe('useKillSwitches', () => {
       orphanLandings: true,
       gptPocSlot: true,
       articleRailAds: false,
+      desktopTopBanner: false,
       headerBidding: false,
     });
   });
@@ -83,7 +85,7 @@ describe('useKillSwitches', () => {
     renderHook(() => useKillSwitches());
 
     await waitFor(() => {
-      expect(rcMock).toHaveBeenCalledTimes(8);
+      expect(rcMock).toHaveBeenCalledTimes(9);
     });
 
     const callArgs = rcMock.mock.calls.map(([arg]) => arg);
@@ -94,6 +96,7 @@ describe('useKillSwitches', () => {
     expect(callArgs).toContain('KILL_ORPHAN_LANDINGS_LINKS');
     expect(callArgs).toContain('KILL_GPT_POC_SLOT');
     expect(callArgs).toContain('KILL_ARTICLE_RAIL_ADS');
+    expect(callArgs).toContain('KILL_DESKTOP_TOP_BANNER');
     expect(callArgs).toContain('KILL_HEADER_BIDDING');
   });
 });


### PR DESCRIPTION
## Implementato

Su tua richiesta: invece di dipendere dall'Auto Ad `.google-auto-placed` in cima (box ad altezza variabile che lasciava una banda bianca sopra la piega), un **GAM unit dedicato che controlliamo noi**, posizionato **sopra l'H1** del calcolatore.

- **GAM**: nuovo unit `/23355151813/desktop-top-banner` (sizes **970×90 + 728×90**, `isFluid:false` → altezza uniforme 90px). Generalizzato lo script di creazione rail a sizes/isFluid per-target e rinominato `scripts/gam-create-rail-units.mjs` → **`scripts/gam-create-ad-units.mjs`** (ref in `ArticleRailAd.tsx` aggiornati). **Unit creato in GAM** (id 23358321494, verificato via re-query).
- **Front-end**: `DesktopTopBanner` lo serve via `GptAdSlot` con **reserve 90px** e `hidden lg:block` (solo desktop). Montato in cima al contenuto calcolatore, **sopra l'H1**, **fuori da `space-y-8`** così lo slot nascosto su mobile non aggiunge un gap fantasma in alto. Collassa a `display:none` se invenduto (GptAdSlot) → nessuno spazio bianco senza domanda.
- **Zero gap + zero CLS by-construction**: altezza creative unica (90px) = reserve == fill, quindi nessun box sovradimensionato (era questo il problema dell'Auto Ad / aspect-ratio).
- **Kill-switch**: `KILL_DESKTOP_TOP_BANNER` (`useKillSwitches` + RC default), default-safe = mostrato. GPT non tocca `adsbygoogle.js` → **Auto Ads intatti** (AGENTS §7): è additivo, non sopprime nulla.
- Il fix CSS #2864 resta come rete di sicurezza per ogni Auto Ad residuo.

### Verifica
- 11/11 test verdi (`use-kill-switches` aggiornato per il nuovo switch — 8→9 — e `check-cls-ad-slots`).
- `tsc` pulito sui file toccati (errori residui solo in file pre-esistenti non toccati: `services/seo/seo-pages.ts`, `PublisherDashboardPage.tsx`, alcuni test).
- Unit GAM creato e confermato via `gam-create-ad-units.mjs --dry-run` (`= reuse desktop-top-banner id=23358321494`).
- Push via REST API (`gh api git/*`) perché `git push` HTTP falliva con `curl 28 operation too slow` sul repo grande (fallback noto).

## Non implementato (ancora)

- **Possibile compresenza con un Auto Ad in cima**: gli Auto Ads potrebbero ancora iniettare un `.google-auto-placed` vicino al nostro unit (non controllabile). Di norma Google evita di impilarsi accanto a uno slot manuale; se accade è additivo (più revenue) e il #2864 garantisce comunque niente gap. Da osservare in RUM/AdSense post-deploy.
- **Altre tool-tab** (payslip/bonus/ecc.): il banner è montato sulla sub-tab `calculator` (la pagina segnalata). Estendibile alle altre in follow-up se desiderato.
- **Fill non forzabile**: dipende dalla domanda GAM/AdSense; un top-leaderboard above-the-fold ha però fill atteso buono, e se vuoto collassa (niente gap).
- **Sizes**: solo leaderboard 90px per garantire zero-gap/zero-CLS. Un 970×250 billboard (più revenue) reintrodurrebbe il trade-off altezza/gap → valutabile a parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)