### PR TITLE
fix(seo): relative hrefs in hub pagination flat ladder (page-weight budget)

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1311,9 +1311,18 @@ function renderPagination(locale: HubLocale, basePath: string, current: number, 
   // /cerca-lavoro-ticino/tutti/page-387/). Class names are short (.hp, .hc);
   // their rules now live in public/assets/seo-static.css (already linked on
   // these pages) instead of a per-page inline <style> block.
+  //
+  // Hrefs are root-relative (paginatedPath returns `/…/page-N/`), matching
+  // the compact nav above and the `class="thp"` ladder in buildHubHtml.
+  // The absolute `${BASE_URL}` prefix (28 B × every page anchor) was pure
+  // dead weight here — crawlers resolve root-relative links identically and
+  // every anchor is preserved — and with cantons now at ~1500 archive pages
+  // it alone pushed /fr/trouver-emploi-tessin/tous/ past the 215 KB budget
+  // (run 28090796553, ~42 KB of prefix). rel=prev/next <link> head hints
+  // stay absolute (canonical convention).
   const flatAnchors: string[] = [];
   for (let p = 1; p <= total; p++) {
-    const href = `${BASE_URL}${paginatedPath(basePath, p)}`;
+    const href = paginatedPath(basePath, p);
     if (p === current) {
       flatAnchors.push(`<strong class="hc" aria-current="page">${pageWord}&nbsp;${p}</strong>`);
     } else {


### PR DESCRIPTION
## Implementato

- `build-plugins/seoHubsPlugin.ts` (`renderPagination`): the "browse all archive pages" flat ladder now builds anchor hrefs with root-relative `paginatedPath(basePath, p)` instead of the absolute `${BASE_URL}${paginatedPath(...)}` form. At ~1500 archive pages per canton the `https://frontaliereticino.ch` prefix was 28 B × 1515 anchors ≈ **42 KB of pure dead weight**, which pushed `/fr/trouver-emploi-tessin/tous/` over the 215 KB `audit:page-weight` budget and failed `validate-dist` (run 28090796553).
- This is a **root-cause byte fix, not a threshold bump**: `MAX_HTML_BYTES` is untouched. Crawlers resolve root-relative links identically and **every page anchor is preserved** — zero SEO/crawl loss. The change aligns the flat ladder with the compact nav directly above it and the `class="thp"` ladder in `buildHubHtml`, which already emit relative hrefs.
- Estimated effect on the offending page: ~216 KB → ~174 KB (measured against the live HTML). Fixes the **entire canton × locale flat-ladder class**, not just the one offending page.
- Comment updated to record why the ladder is relative (rename/comment discipline).

Closes #2843

## Non implementato (ancora)

- `rel=prev/next` `<link>` head hints (lines 1056-1057), hreflang `<link>`/`xhtml:link`, and `canonical` keep the absolute `${BASE_URL}` prefix — that is the correct convention for head metadata and structured-data URLs (2 per page, negligible weight). Deliberately out of scope.
- Sibling sweep (`node scripts/ci/check-sibling-patterns.mjs`): the 8 flagged files share only generic `basePath`/`paginatedPath` tokens. Verified by hand that none carries the same antipattern — `seoHubsData.ts` defines the relative helper; `staticPagesPlugin.ts` (3882/3951) and `shared/cantonHubEditorial.ts` (135) already use relative `paginatedPath`; the rest (`jobMarketSnapshotPlugin.ts`, `router.ts`, `urlStateService.ts`, `validate-page-seo-quality.mjs`, `git-commit-data.sh`) only touch `basePath` unrelated to pagination href encoding. Line 1316 was the sole absolute-prefix flat-ladder anchor. Nothing to sweep.
- Full SSG page-weight re-measure is post-merge only (local SEO build OOMs); the estimate is derived from the live page bytes. If the next deploy's `validate-dist` page-weight still flags the page, revisit (revert-trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)