### PR TITLE
fix(articles): thin-content = quality-reject → auto-heal, niente run rosso

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -7171,7 +7171,14 @@ function wallBudgetExceeded() {
 function isQualityRejectError(e) {
   if (!e) return false;
   if (e.qualityReject === true || e.topicGateAbort === true) return true;
-  return /fact-check|rigettato|veridicità|fabricat|topic-gate abort|headline validation failed/i.test(
+  // `troppo corto` covers the whole thin-content class (too-short IT body
+  // after the retry+expand ladder, too-short char count, too-short locale
+  // field). A source that cannot reach the adaptive word/char floor is a
+  // per-headline QUALITY problem — skip it and try the next headline rather
+  // than crashing the whole run (run 28078614313: 296/700 IT words
+  // propagated to exit 1 instead of self-healing to another topic). Same
+  // class of bug as the 2026-05-11 topic-gate-abort miss.
+  return /fact-check|rigettato|veridicità|fabricat|topic-gate abort|headline validation failed|troppo corto/i.test(
     String(e.message || ''),
   );
 }
@@ -8217,7 +8224,13 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     } catch (expandErr) {
       console.error(`  ⚠️  Espansione fallita: ${expandErr.message}`);
     }
-    throw new Error(`Contenuto IT troppo corto dopo ${CREATE_ARTICLE_MIN_WORDS_RETRIES} tentativi + espansione (${italianBodyWordCount(data)}/${adaptiveMinWords} parole).`);
+    {
+      const shortErr = new Error(`Contenuto IT troppo corto dopo ${CREATE_ARTICLE_MIN_WORDS_RETRIES} tentativi + espansione (${italianBodyWordCount(data)}/${adaptiveMinWords} parole).`);
+      // Per-headline quality failure → headline retry loops skip this source
+      // and try the next one instead of aborting the run (auto-heal).
+      shortErr.qualityReject = true;
+      throw shortErr;
+    }
   }
 
   // Final thin content guard (after retry/expand attempts)
@@ -8226,7 +8239,9 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     const itPlainCharsFinal = itBodyFinal.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim().length;
     const adaptiveMinChars = computeAdaptiveMinChars(pageContent);
     if (itPlainCharsFinal < adaptiveMinChars) {
-      throw new Error(`Articolo troppo corto dopo retry: ${itPlainCharsFinal} chars (min: ${adaptiveMinChars}). Google penalizza thin content.`);
+      const thinErr = new Error(`Articolo troppo corto dopo retry: ${itPlainCharsFinal} chars (min: ${adaptiveMinChars}). Google penalizza thin content.`);
+      thinErr.qualityReject = true;
+      throw thinErr;
     }
     console.error(`  ✅ [thin-content] Body finale: ${itPlainCharsFinal} chars (min: ${adaptiveMinChars})`);
   }

--- a/tests/thin-content-quality-reject-retry.test.ts
+++ b/tests/thin-content-quality-reject-retry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test for thin-content recovery in scripts/create-article.mjs.
+ *
+ * 2026-06-24 incident (run 28078614313): a news source produced only
+ * 296/700 Italian words. The generator threw
+ *   `Contenuto IT troppo corto dopo 6 tentativi + espansione (296/700 parole).`
+ * but `isQualityRejectError` did NOT recognise the message, so the error
+ * was treated as an infrastructure failure: it propagated past the
+ * headline-retry loops (which skip quality rejects and try the next
+ * source) AND past `main().catch` (which defers quality rejects with
+ * exit 0). Result: the run exited 1, went red, and raised a
+ * false-positive "Workflow Failure: Generate Blog Article" Bug issue —
+ * instead of self-healing to another topic.
+ *
+ * This is the SAME class of bug as the 2026-05-11 topic-gate-abort miss
+ * (see topic-gate-abort-retry.test.ts): a per-headline quality error
+ * whose wording escaped the recognition regex.
+ *
+ * Fix: `troppo corto` is added to the isQualityRejectError regex (covers
+ * the whole thin-content class — too-short IT body after retry+expand,
+ * too-short char count, too-short locale field) AND the two fatal
+ * thin-content throw sites tag `err.qualityReject = true` explicitly.
+ * Both layers then self-heal: the loop skips the thin source and tries
+ * the next headline; if every candidate is exhausted, main().catch
+ * defers cleanly (exit 0) so the self-trigger back-off retries later.
+ *
+ * The test extracts the real recognition regex from the source and runs
+ * it against the actual thrown messages, so it cannot silently drift.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '..', 'scripts/create-article.mjs'),
+  'utf8',
+);
+
+/** Pull the literal regex used inside isQualityRejectError and rebuild it. */
+function extractQualityRejectRegex(): RegExp {
+  const fn = SRC.match(/function isQualityRejectError\(e\)\s*\{[\s\S]*?\n\}/);
+  expect(fn, 'isQualityRejectError not found').toBeTruthy();
+  const lit = fn![0].match(/\/([^\n]+?)\/i\.test\(/);
+  expect(lit, 'recognition regex literal not found').toBeTruthy();
+  return new RegExp(lit![1], 'i');
+}
+
+describe('thin-content quality-reject recovery', () => {
+  const rx = extractQualityRejectRegex();
+
+  it('recognises the fatal "Contenuto IT troppo corto dopo N tentativi" message', () => {
+    expect(
+      rx.test('Contenuto IT troppo corto dopo 6 tentativi + espansione (296/700 parole).'),
+    ).toBe(true);
+  });
+
+  it('recognises the "Articolo troppo corto dopo retry" char-floor message', () => {
+    expect(
+      rx.test('Articolo troppo corto dopo retry: 1200 chars (min: 2500). Google penalizza thin content.'),
+    ).toBe(true);
+  });
+
+  it('recognises the too-short locale field message', () => {
+    expect(rx.test('Campo body2 troppo corto per en')).toBe(true);
+  });
+
+  it('still does NOT match a genuine infrastructure error', () => {
+    expect(rx.test('ENOBUFS: stdout maxBuffer exceeded')).toBe(false);
+    expect(rx.test('HTTP 500: internal server error')).toBe(false);
+  });
+
+  it('both fatal thin-content throw sites tag err.qualityReject = true', () => {
+    // The retry+expand ladder fatal throw.
+    expect(SRC).toMatch(
+      /shortErr\.qualityReject\s*=\s*true;[\s\S]*?throw shortErr;/,
+    );
+    // The final char-floor thin-content guard.
+    expect(SRC).toMatch(
+      /thinErr\.qualityReject\s*=\s*true;[\s\S]*?throw thinErr;/,
+    );
+  });
+});


### PR DESCRIPTION
## Implementato

Fix radice del fallimento [run 28078614313](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28078614313/job/83128171769) (`Generate Blog Article`): una fonte news ha prodotto solo **296/700 parole IT**, `generateAndValidateArticle` ha lanciato `Contenuto IT troppo corto dopo 6 tentativi + espansione`, ma `isQualityRejectError` **non riconosceva** quel messaggio → trattato come errore infrastrutturale → `process.exit(1)`, run rosso + falso-positivo *Workflow Failure* Bug issue, invece di auto-heal su un altro topic. Stessa classe del miss `topic-gate-abort` del 2026-05-11 (vedi `tests/topic-gate-abort-retry.test.ts`).

- `scripts/create-article.mjs` — `isQualityRejectError`: aggiunto `troppo corto` alla regex di riconoscimento. Copre l'**intera classe** thin-content by-construction: body IT corto dopo retry+expand (l.8224), char-floor finale (l.8239), campo locale corto (l.2124).
- `scripts/create-article.mjs` — i due throw site fatali thin-content taggano esplicitamente `err.qualityReject = true` (belt-and-suspenders, come `err.topicGateAbort`).
- `tests/thin-content-quality-reject-retry.test.ts` — regressione: estrae la regex reale dal sorgente e la verifica contro i messaggi veri (296/700, char-floor, campo locale) + assert sui tag `qualityReject` ai throw site + non-match su errori infra.

**Auto-heal a due livelli** (entrambi keyed su `isQualityRejectError`, ora coperti):
1. **In-run**: i loop di retry per-headline (proven-pool + evergreen) skippano la fonte magra e provano la headline/keyword successiva.
2. **Cross-run**: se ogni candidato è esaurito, `main().catch` differisce con `exit 0` (no run rosso, no Bug issue) → il self-trigger back-off riprova al run successivo.

Nessuna soglia di qualità abbassata (AGENTS.md #1/#4 rispettati): lo slop magro continua a NON essere pubblicato; cambia solo che un topic povero viene scartato invece di far cadere l'intera run.

## Non implementato (ancora)

- **Riduzione lavoro sprecato sulla fonte magra**: il loop interno rigenera 6× la stessa fonte prima di scartarla; un early-bail dopo 2 tentativi sotto soglia ridurrebbe il burn di quota/wall-time. Out of scope — ottimizzazione, non causa del fallimento; il wall-budget esistente (`wallBudgetExceeded`) già limita la run.
- **Errori secondari nei log non fatali** (nemotron content-safety HTTP 400 `roles must alternate`, classifier `User Safety: safe` malformed-JSON → regex fallback, Mistral timeout): non hanno causato il fallimento (fallback già attivi). Follow-up separato se diventano funnel-critical.
- Nessun sibling da sweepare: `isQualityRejectError` esiste solo in `scripts/create-article.mjs` (grep confermato); `check-sibling-patterns.mjs` non flagga costrutti correlati al thin-content.