### PR TITLE
perf(cdn): dedup job descriptions + split expired-jobs for runtime

### DIFF
--- a/build-plugins/expiredJobsSplitPlugin.ts
+++ b/build-plugins/expiredJobsSplitPlugin.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import {
+  buildSlimExpiredEntry,
+  makeExpiredKeyAssigner,
+} from './shared/slimExpiredIndex';
+
+/**
+ * Splits the aggregated `data/expired-jobs.json` archive into:
+ *   - `dist/data/expired-jobs-index.json` — slim index (no descriptionByLocale)
+ *   - `dist/data/expired-detail/<key>.json` — full per-entry detail
+ *
+ * Replaces the single ~56MB / ~11MB-gz file the SPA used to fetch whole on
+ * every navigation to an expired job (hooks/useExpiredJob.ts). Build-time
+ * consumers (jobsSeoPagesPlugin seeding window.__EXPIRED_JOB_DATA__) keep
+ * reading `data/expired-jobs.json` directly and are unaffected.
+ *
+ * Mirrors localeJobsSplitPlugin's emit contract (apply:'build', closeBundle for
+ * dist + configureServer for the dev server).
+ */
+export function expiredJobsSplitPlugin(rootDir: string): Plugin {
+  const expiredJobsPath = path.resolve(rootDir, 'data', 'expired-jobs.json');
+
+  function generateFiles(outDir: string): number {
+    if (!fs.existsSync(expiredJobsPath)) return 0;
+    let entries: Record<string, unknown>[];
+    try {
+      entries = JSON.parse(fs.readFileSync(expiredJobsPath, 'utf-8'));
+    } catch {
+      return 0;
+    }
+    if (!Array.isArray(entries)) return 0;
+
+    const dataDir = path.resolve(outDir, 'data');
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    const detailDir = path.resolve(dataDir, 'expired-detail');
+    if (!fs.existsSync(detailDir)) fs.mkdirSync(detailDir, { recursive: true });
+
+    const assignKey = makeExpiredKeyAssigner();
+    const slimIndex: Record<string, unknown>[] = [];
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const key = assignKey(entry.slug as string | undefined);
+      fs.writeFileSync(
+        path.resolve(detailDir, `${key}.json`),
+        JSON.stringify(entry),
+        'utf-8',
+      );
+      slimIndex.push(buildSlimExpiredEntry(entry, key));
+    }
+
+    fs.writeFileSync(
+      path.resolve(dataDir, 'expired-jobs-index.json'),
+      JSON.stringify(slimIndex),
+      'utf-8',
+    );
+    return slimIndex.length;
+  }
+
+  return {
+    name: 'expired-jobs-split',
+    apply: 'build',
+    closeBundle() {
+      const distDir = path.resolve(rootDir, 'dist');
+      const count = generateFiles(distDir);
+      if (count > 0) {
+        console.log(`[expired-jobs-split] Generated slim index + ${count} detail files`);
+      }
+    },
+    configureServer() {
+      // In dev, emit to public/data/ so the dev server can serve them.
+      const publicDir = path.resolve(rootDir, 'public');
+      const count = generateFiles(publicDir);
+      if (count > 0) {
+        console.log(`[expired-jobs-split] Dev: generated slim index + ${count} detail files in public/data/`);
+      }
+    },
+  };
+}

--- a/build-plugins/jobsJsonDistCleanupPlugin.ts
+++ b/build-plugins/jobsJsonDistCleanupPlugin.ts
@@ -1,25 +1,34 @@
 /**
- * jobsJsonDistCleanupPlugin — strip the 88 MB master `dist/data/jobs.json`
- * from the deploy artifact after all build plugins have consumed it.
+ * jobsJsonDistCleanupPlugin — strip redundant job-dataset monoliths from the
+ * deploy artifact after all build plugins have consumed them.
  *
- * Why: `public/data/jobs.json` is the master crawler dataset with every job
- * and every locale variant (`titleByLocale`, `descriptionByLocale`, etc.).
- * Vite copies `public/` to `dist/` verbatim, so the master would ship to
- * GitHub Pages even though the runtime SPA only ever fetches the locale-
- * flattened shards (`/data/jobs-{locale}.json`, ~24 MB each) and the
- * `/data/jobs-slug-map.json` (5 MB). Dropping the master from `dist/`
- * frees ~88 MB on the deploy artifact (we are bumping against the 10 GB
- * GitHub Pages cap).
+ * Targets:
+ *   - `dist/data/jobs.json` (~88 MB) — the master crawler dataset with every
+ *     job and every locale variant (`titleByLocale`, `descriptionByLocale`).
+ *   - `dist/data/expired-jobs.json` (~56 MB) — the expired archive with
+ *     `descriptionByLocale` ×4. Replaced at runtime by the slim
+ *     `expired-jobs-index.json` + `expired-detail/<key>.json` files emitted by
+ *     `expiredJobsSplitPlugin` (the SPA used to fetch this whole file, ~11 MB
+ *     gz, on every navigation to an expired job). Still committed in
+ *     `public/data/` (Vite copies it to `dist/`), so it must be stripped here.
+ *   - `dist/data/jobs-{locale}.json` — the full per-locale shards. No longer
+ *     emitted by `localeJobsSplitPlugin` (their descriptions duplicated
+ *     `job-detail/<id>.json` and were never needed for listing); listed here
+ *     defensively in case a stale committed copy ever sneaks into `public/`.
  *
- * Build-plugins that need the full dataset (jobsSeoPagesPlugin,
- * jobOgImagesPlugin, localeJobsSplitPlugin, etc.) read from `data/jobs.json`
- * or `public/data/jobs.json` — both upstream of `dist/`, so this cleanup
- * is invisible to them.
+ * Vite copies `public/` to `dist/` verbatim, so any committed copy would ship
+ * to GitHub Pages / the CDN. The runtime SPA only fetches the slim indices
+ * (`/data/jobs-{locale}-index.json`), per-job detail (`/data/job-detail/<id>.json`),
+ * the slug map, and the expired slim index + detail — never these monoliths.
  *
- * Position: registered with `enforce: 'post'` so its `closeBundle` runs
- * after every other build-plugin that might still need `dist/data/jobs.json`
- * (none today, but future plugins reading from the dist copy would be
- * caught here in CI before the artifact is uploaded).
+ * Build-plugins that need the full datasets (jobsSeoPagesPlugin,
+ * jobOgImagesPlugin, localeJobsSplitPlugin, expiredJobsSplitPlugin) read from
+ * `data/*.json` or `public/data/*.json` — both upstream of `dist/`, so this
+ * cleanup is invisible to them.
+ *
+ * Position: registered with `enforce: 'post'` so its `closeBundle` runs after
+ * every other build-plugin (including expiredJobsSplitPlugin, whose slim index
+ * + detail files must survive) before the artifact is uploaded.
  */
 
 import fs from 'node:fs';
@@ -32,15 +41,26 @@ export function jobsJsonDistCleanupPlugin(rootDir: string): Plugin {
   apply: 'build',
   enforce: 'post',
   closeBundle() {
-   const target = path.resolve(rootDir, 'dist', 'data', 'jobs.json');
-   if (!fs.existsSync(target)) return;
-   try {
-    const stat = fs.statSync(target);
-    fs.unlinkSync(target);
-    const mb = (stat.size / 1_048_576).toFixed(1);
-    console.log(`[jobs-json-dist-cleanup] Removed dist/data/jobs.json (${mb} MB) — runtime fetches the per-locale shards instead.`);
-   } catch (err) {
-    console.warn('[jobs-json-dist-cleanup] Failed to remove dist/data/jobs.json:', err);
+   const distData = path.resolve(rootDir, 'dist', 'data');
+   const targets = [
+    'jobs.json',
+    'expired-jobs.json',
+    'jobs-it.json',
+    'jobs-en.json',
+    'jobs-de.json',
+    'jobs-fr.json',
+   ];
+   for (const name of targets) {
+    const target = path.resolve(distData, name);
+    if (!fs.existsSync(target)) continue;
+    try {
+     const stat = fs.statSync(target);
+     fs.unlinkSync(target);
+     const mb = (stat.size / 1_048_576).toFixed(1);
+     console.log(`[jobs-json-dist-cleanup] Removed dist/data/${name} (${mb} MB) — runtime fetches the slim index / per-entry detail instead.`);
+    } catch (err) {
+     console.warn(`[jobs-json-dist-cleanup] Failed to remove dist/data/${name}:`, err);
+    }
    }
   },
  };

--- a/build-plugins/localeJobsSplitPlugin.ts
+++ b/build-plugins/localeJobsSplitPlugin.ts
@@ -65,9 +65,12 @@ const DETAIL_FIELDS = new Set([
 /**
  * Generates locale-specific job JSON files at build time.
  *
- * Reads `data/jobs.json` and emits `dist/data/jobs-{locale}.json` for each locale.
- * Each file flattens the *ByLocale fields into the base fields for that locale,
- * reducing per-request payload by ~35%.
+ * Reads `data/jobs.json` and emits, for each locale, the slim listing index
+ * `dist/data/jobs-{locale}-index.json` (+ first-page slim slice), plus a shared
+ * `jobs-slug-map.json` and per-job `job-detail/{id}.json` files. Records are
+ * flattened from *ByLocale to base fields for the locale. The full
+ * `jobs-{locale}.json` monolith is intentionally NOT emitted — its descriptions
+ * duplicated job-detail and were never needed for listing (see inline note).
  *
  * Also generates files in `public/data/` for the Vite dev server.
  */
@@ -92,12 +95,13 @@ export function localeJobsSplitPlugin(rootDir: string): Plugin {
  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
 
  for (const locale of LOCALES) {
+ // Locale-flattened records (full *ByLocale → base fields). Kept in memory
+ // to derive the slim index + first-page slim below, but no longer written
+ // to disk: the full `jobs-{locale}.json` monolith (~48MB each, descriptions
+ // ×4 locales) duplicated prose already canonical in job-detail/{id}.json and
+ // was only ever a listing fallback (listing never reads descriptions). All
+ // consumers repointed to jobs-{locale}-index.json + job-detail.
  const localeJobs = jobs.map((j) => buildLocaleJob(j, locale));
- fs.writeFileSync(
- path.resolve(dataDir, `jobs-${locale}.json`),
- JSON.stringify(localeJobs),
- 'utf-8',
- );
  // Slim index: listing-only fields for fast initial LCP (FRO-386)
  const slimJobs = localeJobs.map(buildLocaleJobSlim);
  fs.writeFileSync(
@@ -171,7 +175,7 @@ export function localeJobsSplitPlugin(rootDir: string): Plugin {
  const distDir = path.resolve(rootDir, 'dist');
  const count = generateFiles(distDir);
  if (count > 0) {
- console.log(`[locale-jobs-split] Generated 4 locale files + 4 slim index files + 4 first-page slim files + slug map + ${count} detail files (${count} jobs)`);
+ console.log(`[locale-jobs-split] Generated 4 slim index files + 4 first-page slim files + slug map + ${count} detail files (${count} jobs)`);
  }
  },
  configureServer(server) {
@@ -179,7 +183,7 @@ export function localeJobsSplitPlugin(rootDir: string): Plugin {
  const publicDir = path.resolve(rootDir, 'public');
  const count = generateFiles(publicDir);
  if (count > 0) {
- console.log(`[locale-jobs-split] Dev: generated 4 locale files in public/data/`);
+ console.log(`[locale-jobs-split] Dev: generated 4 slim index files + slug map + detail files in public/data/`);
  }
  },
  };

--- a/build-plugins/shared/slimExpiredIndex.ts
+++ b/build-plugins/shared/slimExpiredIndex.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared shape helpers for the expired-jobs split (expiredJobsSplitPlugin) and
+ * its runtime consumer (hooks/useExpiredJob.ts). Single source of truth so the
+ * emitter and the client can't drift on which fields live in the slim index vs
+ * the per-entry detail file.
+ *
+ * The full `expired-jobs.json` (5000 entries × descriptionByLocale ×4 locales,
+ * ~56MB / ~11MB gz) used to be fetched whole on every SPA navigation to an
+ * expired job. We split it into:
+ *   - `expired-jobs-index.json` — slim: every field EXCEPT descriptionByLocale,
+ *     plus a `key` pointing at the detail file. Carries all slug variants
+ *     (slug, slugByLocale, previousSlugs, previousSlugsByLocale) so the client
+ *     can resolve any landing slug to its entry. ~1MB gz.
+ *   - `expired-detail/<key>.json` — the full entry incl descriptionByLocale.
+ */
+
+/** Fields dropped from the slim index (heavy prose, fetched lazily per entry). */
+const DETAIL_ONLY_EXPIRED_FIELDS = new Set(['descriptionByLocale']);
+
+/** Stable, filesystem-safe detail-file key for an expired entry. URL-safe slugs
+ * map to themselves; anything else is sanitised and length-capped (filesystem
+ * 255-byte limit) so the emit never fails on a pathological slug. Uniqueness
+ * across the corpus is enforced by the caller (see makeKeyAssigner). */
+export function sanitizeExpiredKey(slug: string | undefined | null): string {
+  const base = String(slug || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 180);
+  return base || 'unknown';
+}
+
+/** Returns a key assigner that guarantees uniqueness: on collision it appends
+ * an incrementing suffix. Use one assigner per emit pass. */
+export function makeExpiredKeyAssigner(): (slug: string | undefined | null) => string {
+  const seen = new Set<string>();
+  return (slug) => {
+    const base = sanitizeExpiredKey(slug);
+    let key = base;
+    let n = 1;
+    while (seen.has(key)) {
+      key = `${base}-${n}`;
+      n += 1;
+    }
+    seen.add(key);
+    return key;
+  };
+}
+
+/** Build the slim index entry (everything except descriptionByLocale) + key. */
+export function buildSlimExpiredEntry(
+  entry: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const slim: Record<string, unknown> = { key };
+  for (const [field, value] of Object.entries(entry)) {
+    if (DETAIL_ONLY_EXPIRED_FIELDS.has(field)) continue;
+    if (value !== undefined) slim[field] = value;
+  }
+  return slim;
+}

--- a/build-plugins/shared/slimJobIndex.ts
+++ b/build-plugins/shared/slimJobIndex.ts
@@ -22,7 +22,10 @@ export const SLIM_INDEX_FIELDS: ReadonlySet<string> = new Set([
   'title',
   'company', 'companyKey', 'companyDomain', 'url',
   'location', 'canton',
-  'addressLocality', 'sector',
+  // addressRegion: read by newsletter location matching (matchJobsForSubscriber
+  // in services/newsletter-content.mjs) which consumes the slim index — without
+  // it region-specific subscriber matching silently degrades.
+  'addressLocality', 'addressRegion', 'sector',
   'category', 'contract', 'department',
   'salaryMin', 'salaryMax', 'currency',
   'postedDate', 'crawledAt', 'firstSeenAt',

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -1158,7 +1158,11 @@ function BlogArticles({
  useEffect(() => {
  if (!selectedArticle) return;
  let cancelled = false;
- fetch(cdnDataUrl(`/data/jobs-${locale}.json`))
+ // Slim listing index — the cross-link sidebar's relevance ranking
+ // (getRelatedJobsForArticle) only reads title/company/category/slug, never
+ // descriptions, so the index suffices and avoids pulling the ~10MB-gz full
+ // locale file on every article view (the monolith is no longer shipped).
+ fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`))
  .then(res => {
  if (!res.ok) throw new Error(`${res.status}`);
  return res.json();
@@ -1167,9 +1171,7 @@ function BlogArticles({
  if (!cancelled && Array.isArray(data)) setCrossLinkJobs(data);
  })
  .catch(() => {
- // Locale shard unreachable — the master /data/jobs.json (88 MB) is
- // no longer shipped to the artifact, so we just skip the cross-link
- // sidebar instead of falling back to the master. The article still
+ // Index unreachable — skip the cross-link sidebar; the article still
  // renders fully.
  });
  return () => { cancelled = true; };

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2205,26 +2205,23 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
  };
 
- /** Legacy slim-index → locale → monolithic fallback (FRO-386). */
+ /** Legacy slim-index fallback (FRO-386). The full `jobs-{locale}.json`
+  * monolith tier was removed (its descriptions duplicated job-detail and are
+  * never needed for listing); the slim index is now the sole listing source. */
  const loadLegacyLocaleJobs = async (): Promise<JobListing[]> => {
  const slimIndexUrl = `/data/jobs-${locale}-index.json`;
- const localeUrl = `/data/jobs-${locale}.json`;
  try {
  const res = await fetch(cdnDataUrl(slimIndexUrl));
  if (res.ok) return (await res.json()) as JobListing[];
  throw new Error(`slim index ${res.status}`);
  } catch {
+ // One discrete retry of the slim index (fetchAllJobs hits the same file)
+ // so a transient 5xx doesn't cascade into a hard empty-listing failure.
  try {
- const res = await fetch(cdnDataUrl(localeUrl));
- if (res.ok) return (await res.json()) as JobListing[];
- throw new Error(`locale jobs ${res.status}`);
- } catch {
- // Final fallback — locale-flattened JSON (same URL as the tier above,
- // but kept as a discrete attempt so a transient slim-index 5xx doesn't
- // cascade into a hard failure when the full-locale file is reachable
- // through a different CDN cache key).
  const all = (await fetchAllJobs(locale)) as unknown as JobListing[];
  return Array.isArray(all) ? all : [];
+ } catch {
+ return [];
  }
  }
  };
@@ -3227,19 +3224,17 @@ const JobBoard: React.FC<JobBoardProps> = ({
  unscopedJobs, sortedJobs,
  ]);
 
- // Shared locale-wide pool loader (slim index → locale monolith fallback).
- // Used by BOTH the company-hub broaden and the search-broaden triggers so the
- // fetch/normalize/dedupe path lives in exactly one place (no copy-paste drift).
- // Returns the normalized pool, or null when nothing usable came back; the
- // caller owns the cancelled-guard + setState.
+ // Shared locale-wide pool loader (slim index). Used by BOTH the company-hub
+ // broaden and the search-broaden triggers so the fetch/normalize/dedupe path
+ // lives in exactly one place (no copy-paste drift). The full jobs-{locale}.json
+ // monolith fallback was removed (no longer shipped; listing needs no
+ // descriptions). Returns the normalized pool, or null when nothing usable came
+ // back; the caller owns the cancelled-guard + setState.
  const loadUnscopedPool = useCallback(async (): Promise<JobListing[] | null> => {
  let pool: unknown[] = [];
  const slimRes = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`));
  if (slimRes.ok) {
  pool = await slimRes.json();
- } else {
- const localeRes = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
- if (localeRes.ok) pool = await localeRes.json();
  }
  const arr = Array.isArray(pool) ? pool : [];
  if (arr.length === 0) return null;

--- a/components/vita/TicinoCompanies.tsx
+++ b/components/vita/TicinoCompanies.tsx
@@ -572,12 +572,14 @@ const TicinoCompanies: React.FC = () => {
 
  useEffect(() => {
  let cancelled = false;
- fetch(cdnDataUrl(`/data/jobs-${locale}.json?fresh=${Date.now()}`), { cache: 'no-store' })
+ // Slim listing index (company/location/companyKey only — all this view needs
+ // to count jobs per company). The full jobs-{locale}.json monolith and the
+ // master jobs.json are no longer shipped to the CDN.
+ fetch(cdnDataUrl(`/data/jobs-${locale}-index.json?fresh=${Date.now()}`), { cache: 'no-store' })
  .then((res) => {
  if (!res.ok) throw new Error(`${res.status}`);
  return res.json();
  })
- .catch(() => fetch(cdnDataUrl(`/data/jobs.json?fresh=${Date.now()}`), { cache: 'no-store' }).then((r) => r.json()))
  .then((data: JobListingLite[]) => {
  if (cancelled || !Array.isArray(data)) return;
  const counts: Record<string, number> = {};

--- a/hooks/useExpiredJob.ts
+++ b/hooks/useExpiredJob.ts
@@ -1,9 +1,11 @@
 /**
  * useExpiredJob — lazy-fetch hook for expired job metadata.
  *
- * Fetches /data/expired-jobs.json once (module-level cache) and returns the
- * first job matching the given slug (any locale slug). Only initiates the
- * fetch when called with a non-nullish slug.
+ * Fetches the slim /data/expired-jobs-index.json once (module-level cache),
+ * matches the given slug (any locale slug or previous slug), then lazy-fetches
+ * the matched entry's /data/expired-detail/<key>.json for the description. This
+ * replaces fetching the whole ~11MB-gz expired-jobs.json monolith on every SPA
+ * navigation to an expired job. Only initiates the fetch for a non-nullish slug.
  */
 
 import { useEffect, useState } from 'react';
@@ -19,35 +21,58 @@ export interface ExpiredJob {
  addressLocality?: string;
  descriptionByLocale?: Record<string, string>;
  slugByLocale?: Record<string, string>;
+ previousSlugs?: string[];
+ previousSlugsByLocale?: Record<string, string[]>;
  sector?: string;
  expiredAt?: string;
+ /** Detail-file key — present on slim index entries; points at expired-detail/<key>.json. */
+ key?: string;
 }
 
-// Module-level cache — shared across all hook instances
-let cachedExpiredJobs: ExpiredJob[] | null = null;
-let fetchPromise: Promise<ExpiredJob[]> | null = null;
+// Module-level caches — shared across all hook instances.
+let cachedExpiredIndex: ExpiredJob[] | null = null;
+let indexFetchPromise: Promise<ExpiredJob[]> | null = null;
+const detailCache = new Map<string, ExpiredJob | null>();
 
-function fetchExpiredJobs(): Promise<ExpiredJob[]> {
- if (cachedExpiredJobs) return Promise.resolve(cachedExpiredJobs);
- if (!fetchPromise) {
- fetchPromise = fetch(cdnDataUrl('/data/expired-jobs.json'))
+function fetchExpiredIndex(): Promise<ExpiredJob[]> {
+ if (cachedExpiredIndex) return Promise.resolve(cachedExpiredIndex);
+ if (!indexFetchPromise) {
+ indexFetchPromise = fetch(cdnDataUrl('/data/expired-jobs-index.json'))
  .then((r) => r.json() as Promise<ExpiredJob[]>)
  .then((data) => {
- cachedExpiredJobs = data;
+ cachedExpiredIndex = data;
  return data;
  })
  .catch(() => {
- fetchPromise = null; // allow retry on next call
+ indexFetchPromise = null; // allow retry on next call
  return [] as ExpiredJob[];
  });
  }
- return fetchPromise;
+ return indexFetchPromise;
+}
+
+function fetchExpiredDetail(key: string): Promise<ExpiredJob | null> {
+ if (detailCache.has(key)) return Promise.resolve(detailCache.get(key) ?? null);
+ return fetch(cdnDataUrl(`/data/expired-detail/${key}.json`))
+ .then((r) => (r.ok ? (r.json() as Promise<ExpiredJob>) : null))
+ .then((d) => {
+ detailCache.set(key, d);
+ return d;
+ })
+ .catch(() => {
+ detailCache.set(key, null);
+ return null;
+ });
 }
 
 function matchExpiredSlug(job: ExpiredJob, slug: string): boolean {
  if (job.slug === slug) return true;
- if (job.slugByLocale) {
- return Object.values(job.slugByLocale).some((s) => s === slug);
+ if (job.slugByLocale && Object.values(job.slugByLocale).some((s) => s === slug)) return true;
+ if (job.previousSlugs && job.previousSlugs.includes(slug)) return true;
+ if (job.previousSlugsByLocale) {
+ for (const arr of Object.values(job.previousSlugsByLocale)) {
+ if (Array.isArray(arr) && arr.includes(slug)) return true;
+ }
  }
  return false;
 }
@@ -83,9 +108,20 @@ export function seededJobMatchesSlug(slug: string): boolean {
   try {
     const raw = (window as unknown as Record<string, unknown>).__EXPIRED_JOB_DATA__;
     if (!raw || typeof raw !== 'object') return false;
-    const job = raw as { slug?: string; slugByLocale?: Record<string, string> };
+    const job = raw as {
+      slug?: string;
+      slugByLocale?: Record<string, string>;
+      previousSlugs?: string[];
+      previousSlugsByLocale?: Record<string, string[]>;
+    };
     if (job.slug === slug) return true;
-    if (job.slugByLocale) return Object.values(job.slugByLocale).some((s) => s === slug);
+    if (job.slugByLocale && Object.values(job.slugByLocale).some((s) => s === slug)) return true;
+    if (job.previousSlugs && job.previousSlugs.includes(slug)) return true;
+    if (job.previousSlugsByLocale) {
+      for (const arr of Object.values(job.previousSlugsByLocale)) {
+        if (Array.isArray(arr) && arr.includes(slug)) return true;
+      }
+    }
     return false;
   } catch { return false; }
 }
@@ -127,13 +163,23 @@ export function useExpiredJob(slug: string | undefined): {
  return;
  }
 
- // 2. Fall back to runtime JSON fetch (for SPA navigation to expired jobs)
+ // 2. Fall back to runtime fetch (for SPA navigation to expired jobs):
+ //    slim index → match → lazy-fetch the matched entry's detail file for
+ //    its descriptionByLocale.
  let cancelled = false;
  setLoading(true);
- fetchExpiredJobs().then((jobs) => {
+ fetchExpiredIndex().then(async (jobs) => {
  if (cancelled) return;
  const found = jobs.find((j) => matchExpiredSlug(j, slug)) ?? null;
- setExpiredJob(found);
+ if (!found) {
+ setExpiredJob(null);
+ setLoading(false);
+ return;
+ }
+ const detail = found.key ? await fetchExpiredDetail(found.key) : null;
+ if (cancelled) return;
+ // Detail carries descriptionByLocale; merge over the slim index entry.
+ setExpiredJob(detail ? { ...found, ...detail } : found);
  setLoading(false);
  });
  return () => { cancelled = true; };

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -146,6 +146,11 @@ step_push_cdn() {
   for d in brands insurers providers logos authors publisher; do
     [ -d "public/images/$d" ] && mkdir -p "$stage/images" && cp -r "public/images/$d" "$stage/images/$d"
   done
+  # Strip junk the recursive copies drag in: macOS .DS_Store files and the
+  # internal build-telemetry assets/.hash-age.json (chunk first-seen/last-access
+  # timestamps — not a runtime asset, must not be published).
+  find "$stage" -name '.DS_Store' -delete 2>/dev/null || true
+  rm -f "$stage/assets/.hash-age.json" 2>/dev/null || true
   if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ]; then
     echo "no offloadable assets present — skipping CDN push"; return 0
   fi

--- a/services/chatbotTools.ts
+++ b/services/chatbotTools.ts
@@ -250,10 +250,14 @@ export function buildJobUrl(job: JobRecord, locale: Locale): string {
 
 // ─── Main entrypoint ──────────────────────────────────────────────────────
 
-/** Safe dataset loader — returns [] on any error so the tool never throws. */
+/** Safe dataset loader — returns [] on any error so the tool never throws.
+ * Uses the slim listing index (the full jobs-{locale}.json monolith is no
+ * longer shipped). Ranking still matches title/company/location/category; the
+ * description/requirements body signal is dropped (not in the index) — an
+ * acceptable degradation for the chat search vs. pulling ~10MB-gz on open. */
 async function loadJobs(locale: Locale): Promise<JobRecord[]> {
  try {
- const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`), { cache: 'force-cache' });
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`), { cache: 'force-cache' });
  if (!res.ok) return [];
  const data = await res.json();
  return Array.isArray(data) ? (data as JobRecord[]) : [];

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -408,15 +408,18 @@ export function getDefaultCantonForVisit(): string {
  * @deprecated  D9: per-canton shards are the new source of truth. Migrate to
  *              {@link fetchJobsForCanton} or {@link fetchAggregatedJobs}.
  *
- * Fetches `/data/jobs-{locale}.json` (~24 MB, all cantons mixed, locale-
- * flattened). Used by JobBoard as a final fallback when both the slim-index
- * and the canton shards are unavailable. The master `/data/jobs.json` (88 MB
- * with all *ByLocale fields) is no longer shipped to the deploy artifact —
- * it lives in `public/data/` for build-plugin consumers and is stripped from
+ * Fetches `/data/jobs-{locale}-index.json` (slim listing index, ~1MB gz, all
+ * cantons mixed, locale-flattened — listing fields only, no descriptions).
+ * Used by JobBoard as a final fallback when both the first-page slim asset and
+ * the canton shards are unavailable. Detail (descriptions) is never needed here
+ * — the detail view lazy-fetches `job-detail/{id}.json`. The full
+ * `jobs-{locale}.json` monolith is no longer emitted (its prose duplicated
+ * job-detail); the master `/data/jobs.json` (88 MB with all *ByLocale fields)
+ * lives in `public/data/` for build-plugin consumers and is stripped from
  * `dist/` by `jobsJsonDistCleanupPlugin`. Bypasses the IDB cache entirely.
  */
 export async function fetchAllJobs(locale: Locale): Promise<Job[]> {
- const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`));
  if (!res.ok) {
   throw new Error(`[jobsService] fetchAllJobs(${locale}): HTTP ${res.status}`);
  }

--- a/services/newsletterPreview.ts
+++ b/services/newsletterPreview.ts
@@ -181,11 +181,31 @@ export async function buildNewsletterPreviewHtml(
 
  let jobs: any[] = [];
  try {
- // Newsletter preview is IT-only (sample render for the editor); the
- // per-locale split (data/jobs-it.json) has identical jobs flattened to
- // IT strings — same content as the old monolithic jobs.json for IT.
- const res = await fetch(cdnDataUrl('/data/jobs-it.json'));
- jobs = res.ok ? await res.json() : [];
+ // Newsletter preview is IT-only (sample render for the editor). The full
+ // per-locale `jobs-it.json` monolith is no longer shipped (its descriptions
+ // duplicated job-detail). matchJobsForSubscriber's quality gate needs each
+ // candidate's description (>=120 chars), but the slim index carries none, so
+ // we: (1) fetch the slim index, (2) take a recency-ranked shortlist, (3)
+ // enrich just those with descriptions from job-detail/{id}.json. In the
+ // preview's serverless context job-popularity.json is absent, so the matcher
+ // already ranks by freshness only — the recency shortlist matches its pick.
+ const res = await fetch(cdnDataUrl('/data/jobs-it-index.json'));
+ const index: any[] = res.ok ? await res.json() : [];
+ const recencyVal = (j: any) => Date.parse(j?.postedDate || j?.crawledAt || j?.firstSeenAt || '') || 0;
+ const shortlist = [...index].sort((a, b) => recencyVal(b) - recencyVal(a)).slice(0, 40);
+ jobs = await Promise.all(
+ shortlist.map(async (j) => {
+ if (!j?.id) return j;
+ try {
+ const dRes = await fetch(cdnDataUrl(`/data/job-detail/${j.id}.json`));
+ if (!dRes.ok) return j;
+ const detail = await dRes.json();
+ return { ...j, descriptionByLocale: detail?.descriptionByLocale, description: detail?.description };
+ } catch {
+ return j;
+ }
+ }),
+ );
  } catch (e) {
  reportCaughtError(e, 'newsletterPreview.fetchJobsData');
  }

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -272,15 +272,16 @@ async function loadJobsBySlug(locale: Locale): Promise<Map<string, any>> {
  if (cached) return cached;
  const pending = jobsBySlugPromiseByLocale[locale];
  if (pending) return pending;
- // Per-locale fetch: `jobs-{locale}.json` is the master `jobs.json` flattened
- // to one locale. The cross-locale `slugByLocale` is no longer in this file
- // — that lookup table lives in `jobs-slug-map.json` and is consumed by the
- // router. For the SEO meta path we only need the active-locale slug, so
- // the per-locale shard is sufficient.
+ // Per-locale fetch: the slim listing index `jobs-{locale}-index.json` (the
+ // full `jobs-{locale}.json` monolith is no longer emitted). The index has
+ // the slug→id mapping + listing fields; the SEO meta path (resolveJobSeoBySlug)
+ // lazy-fetches `job-detail/{id}.json` for the description + structured-data
+ // fields (postalCode/streetAddress/...) it needs per job. The count path
+ // (getActiveJobCountLabel) only needs map.size, which the index provides.
  const promise = (async () => {
  const out = new Map<string, any>();
  try {
- const res = await fetch(cdnDataUrl(`/data/jobs-${locale}.json`));
+ const res = await fetch(cdnDataUrl(`/data/jobs-${locale}-index.json`));
  if (!res.ok) return out;
  const list = await res.json();
  if (!Array.isArray(list)) return out;
@@ -296,6 +297,28 @@ async function loadJobsBySlug(locale: Locale): Promise<Map<string, any>> {
  })();
  jobsBySlugPromiseByLocale[locale] = promise;
  return promise;
+}
+
+/** Per-job detail cache (description + structured-data fields), keyed by job id.
+ * Replaces the description fields the slim index drops; CDN-cached + memoised
+ * here so repeat SPA navigations to the same job don't refetch. */
+const jobDetailCache = new Map<string, any>();
+async function loadJobDetail(jobId: string | undefined | null): Promise<any | null> {
+ if (!jobId) return null;
+ if (jobDetailCache.has(jobId)) return jobDetailCache.get(jobId);
+ try {
+ const res = await fetch(cdnDataUrl(`/data/job-detail/${jobId}.json`));
+ if (!res.ok) {
+ jobDetailCache.set(jobId, null);
+ return null;
+ }
+ const detail = await res.json();
+ jobDetailCache.set(jobId, detail);
+ return detail;
+ } catch {
+ jobDetailCache.set(jobId, null);
+ return null;
+ }
 }
 
 /**
@@ -337,8 +360,13 @@ async function resolveJobSeoBySlug(
  const cleanSlug = normalizeSeoText(slug);
  if (!cleanSlug) return null;
  const map = await loadJobsBySlug(locale);
- const job = map.get(cleanSlug);
- if (!job) return null;
+ const slim = map.get(cleanSlug);
+ if (!slim) return null;
+ // The slim index lacks description + structured-data fields (postalCode,
+ // streetAddress, baseSalary). Lazy-fetch the per-job detail and merge so the
+ // JobPosting builder still gets all 9 mandatory fields (CLAUDE.md rule #3).
+ const detail = await loadJobDetail(slim?.id);
+ const job = detail ? { ...slim, ...detail } : slim;
  const localizedTitle = normalizeSeoText(String(job?.titleByLocale?.[locale] || job?.title || ''));
  const localizedDescription = compactSeoDescription(String(job?.descriptionByLocale?.[locale] || job?.description || ''), 360);
  if (!localizedTitle || !localizedDescription) return null;

--- a/tests/expired-jobs-split.test.ts
+++ b/tests/expired-jobs-split.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeExpiredKey,
+  makeExpiredKeyAssigner,
+  buildSlimExpiredEntry,
+} from '../build-plugins/shared/slimExpiredIndex';
+
+describe('slimExpiredIndex — sanitizeExpiredKey', () => {
+  it('keeps URL-safe slugs intact', () => {
+    expect(sanitizeExpiredKey('sales-assistant-cambiavalute-ch-ticino')).toBe(
+      'sales-assistant-cambiavalute-ch-ticino',
+    );
+  });
+
+  it('lowercases and replaces unsafe characters', () => {
+    expect(sanitizeExpiredKey('Foo Bar/Baz?x=1')).toBe('foo-bar-baz-x-1');
+  });
+
+  it('trims leading/trailing separators', () => {
+    expect(sanitizeExpiredKey('--edge--')).toBe('edge');
+  });
+
+  it('caps length to a filesystem-safe bound', () => {
+    const key = sanitizeExpiredKey('a'.repeat(500));
+    expect(key.length).toBeLessThanOrEqual(180);
+  });
+
+  it('falls back to "unknown" for empty/nullish slugs', () => {
+    expect(sanitizeExpiredKey('')).toBe('unknown');
+    expect(sanitizeExpiredKey(undefined)).toBe('unknown');
+    expect(sanitizeExpiredKey('???')).toBe('unknown');
+  });
+});
+
+describe('slimExpiredIndex — makeExpiredKeyAssigner', () => {
+  it('returns the base key on first use', () => {
+    const assign = makeExpiredKeyAssigner();
+    expect(assign('alpha')).toBe('alpha');
+  });
+
+  it('suffixes colliding keys so detail filenames stay unique', () => {
+    const assign = makeExpiredKeyAssigner();
+    expect(assign('dup')).toBe('dup');
+    expect(assign('dup')).toBe('dup-1');
+    expect(assign('dup')).toBe('dup-2');
+  });
+
+  it('treats slugs that sanitise to the same value as collisions', () => {
+    const assign = makeExpiredKeyAssigner();
+    expect(assign('Foo Bar')).toBe('foo-bar');
+    expect(assign('foo/bar')).toBe('foo-bar-1');
+  });
+});
+
+describe('slimExpiredIndex — buildSlimExpiredEntry', () => {
+  const entry = {
+    slug: 'job-x',
+    title: 'Job X',
+    titleByLocale: { it: 'Lavoro X' },
+    company: 'Acme',
+    descriptionByLocale: { it: 'long prose...', en: 'more prose...' },
+    slugByLocale: { it: 'job-x', en: 'job-x-en' },
+    previousSlugs: ['old-job-x'],
+    previousSlugsByLocale: { it: ['vecchio-job-x'] },
+    sector: 'finance',
+    expiredAt: '2026-01-01',
+  };
+
+  it('drops descriptionByLocale (the heavy field) from the slim index', () => {
+    const slim = buildSlimExpiredEntry(entry, 'job-x');
+    expect(slim).not.toHaveProperty('descriptionByLocale');
+  });
+
+  it('attaches the detail-file key', () => {
+    const slim = buildSlimExpiredEntry(entry, 'job-x');
+    expect(slim.key).toBe('job-x');
+  });
+
+  it('preserves every slug-variant field needed for runtime matching', () => {
+    const slim = buildSlimExpiredEntry(entry, 'job-x');
+    expect(slim.slug).toBe('job-x');
+    expect(slim.slugByLocale).toEqual({ it: 'job-x', en: 'job-x-en' });
+    expect(slim.previousSlugs).toEqual(['old-job-x']);
+    expect(slim.previousSlugsByLocale).toEqual({ it: ['vecchio-job-x'] });
+  });
+
+  it('preserves display fields (title, company, sector, expiredAt)', () => {
+    const slim = buildSlimExpiredEntry(entry, 'job-x');
+    expect(slim.title).toBe('Job X');
+    expect(slim.titleByLocale).toEqual({ it: 'Lavoro X' });
+    expect(slim.company).toBe('Acme');
+    expect(slim.sector).toBe('finance');
+    expect(slim.expiredAt).toBe('2026-01-01');
+  });
+});

--- a/tests/seo-localization.test.ts
+++ b/tests/seo-localization.test.ts
@@ -42,12 +42,13 @@ describe('SEO localization', () => {
     const section = getSeoSection(route);
     const path = buildPath(route, 'it');
 
-    // After the jobs.json → jobs-{locale}.json migration the SEO loader
-    // fetches the per-locale shard. The fixture here mimics the shape that
-    // localeJobsSplitPlugin emits: `slug` is already flattened to the
-    // active locale's variant, and `*ByLocale` fields are dropped.
+    // After the jobs-{locale}.json → slim-index + job-detail migration the SEO
+    // loader fetches the slim listing index for the slug→id mapping, then the
+    // per-job `job-detail/<id>.json` for the description + structured-data
+    // fields. The index carries listing fields only (no description); the
+    // detail file carries the prose. `slug` is flattened to the active locale.
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      if (String(input) === '/data/jobs-it.json') {
+      if (String(input) === '/data/jobs-it-index.json') {
         return {
           ok: true,
           json: async () => ([
@@ -55,13 +56,25 @@ describe('SEO localization', () => {
               id: 'efg-5967',
               slug: 'responsabile-fondi-pensione-efg-international-ag-lugano',
               title: 'Responsabile Fondazione',
-              description: 'Gestione e amministrazione del fondo pensione aziendale a Lugano.',
               company: 'EFG International AG',
               location: 'Lugano',
               contract: 'permanent',
               postedDate: '2026-03-06',
             },
           ]),
+        } as Response;
+      }
+      if (String(input) === '/data/job-detail/efg-5967.json') {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 'efg-5967',
+            title: 'Responsabile Fondazione',
+            description: 'Gestione e amministrazione del fondo pensione aziendale a Lugano.',
+            company: 'EFG International AG',
+            location: 'Lugano',
+            employmentType: 'FULL_TIME',
+          }),
         } as Response;
       }
       throw new Error(`Unexpected fetch: ${String(input)}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ import { llmsTxtPlugin } from './build-plugins/llmsTxtPlugin';
 import { adminDataPlugin } from './build-plugins/adminDataPlugin';
 import { crawlerRegistryPlugin } from './build-plugins/crawlerRegistryPlugin';
 import { localeJobsSplitPlugin } from './build-plugins/localeJobsSplitPlugin';
+import { expiredJobsSplitPlugin } from './build-plugins/expiredJobsSplitPlugin';
 import { jobsJsonDistCleanupPlugin } from './build-plugins/jobsJsonDistCleanupPlugin';
 import { webpPlugin } from './build-plugins/webpPlugin';
 import { pdfWhitepapersPlugin } from './build-plugins/pdfWhitepapersPlugin';
@@ -136,6 +137,7 @@ export default defineConfig(({ mode }) => {
  adminDataPlugin(__dirname),
  crawlerRegistryPlugin(__dirname),
  localeJobsSplitPlugin(__dirname), // SPA reads per-locale job JSONs at runtime
+ expiredJobsSplitPlugin(__dirname), // slim expired index + per-entry detail (vs 11MB-gz monolith)
  // Strip the 88 MB master `dist/data/jobs.json` after every build plugin
  // has consumed `public/data/jobs.json`. Frees ~88 MB on the deploy
  // artifact (10 GB GH Pages cap). `enforce: 'post'` runs after every


### PR DESCRIPTION
## Implementato

Due ottimizzazioni di storage/egress sulla CDN, entrambe eliminano copie ridondanti della prosa pesante delle descrizioni job. Premessa verificata: la **meta crawler-facing resta SSG** (`jobsSeoPagesPlugin` emette `og:description` a build) → la non-negotiable SEO è intatta a prescindere.

### Fix 1 — rimozione del monolite `jobs-{locale}.json` full (~195MB raw / ~40MB gz)
Le sue descrizioni duplicavano `job-detail/<id>.json` e non servono mai al listing. `localeJobsSplitPlugin` non lo emette più. Repoint di **tutti e 7** i consumer runtime (sweep completo, non solo i 3 del piano iniziale):
- pool di listing → slim index: `JobBoard.loadLegacyLocaleJobs` + `loadUnscopedPool`, `jobsService.fetchAllJobs`, `TicinoCompanies`, `BlogArticles` (cross-link, prima scaricava ~10MB gz a ogni apertura articolo);
- `seoService.resolveJobSeoBySlug` → slim index per slug→id + fetch lazy di `job-detail/<id>.json` per description + i campi structured-data JobPosting (`postalCode`/`streetAddress`/`baseSalary`, mandatori CLAUDE.md #3);
- `newsletterPreview` → slim index + enrichment via `job-detail` della shortlist matchata (il quality-gate `passesQualityGate` richiede description ≥120 char);
- `chatbot.searchJobs` → slim index (mantiene ranking su title/company/location/category).
- `addressRegion` aggiunto a `SLIM_INDEX_FIELDS` così il match location della newsletter non degrada in silenzio.

### Fix 2 — split di `expired-jobs.json` (~56MB / ~11MB gz)
Era fetchato **intero** a ogni navigazione SPA verso un annuncio scaduto. Nuovo `expiredJobsSplitPlugin` emette uno slim `expired-jobs-index.json` + per-entry `expired-detail/<key>.json`. `useExpiredJob` fetcha l'index piccolo, matcha lo slug (ora anche su `previousSlugs`/`previousSlugsByLocale`), poi fetcha un solo file detail. Helper condiviso `slimExpiredIndex.ts` (no drift). L'atterraggio diretto (seed `window.__EXPIRED_JOB_DATA__`) e il seed build-time (legge `data/expired-jobs.json`) sono invariati.

### Pulizia publish CDN
I monoliti full vengono strippati da `dist` prima del push CDN (`jobsJsonDistCleanupPlugin` esteso a `expired-jobs.json` + `jobs-{locale}.json`), così un eventuale copia committata in `public/data` non finisce live. Aggiunto strip di `.DS_Store` + `assets/.hash-age.json` (telemetria build) dallo stage CDN in `deploy-it-pages-prep.sh`.

## Non implementato (ancora)

- **Riduzione storage non validabile pre-merge** (il `build:ci` + push CDN girano solo post-merge su `main`). **Revert-trigger**: se il prossimo deploy mostra il repo CDN non ridotto, o la nav SPA su annuncio scaduto hang/404, o il match newsletter regredisce visibilmente → revert.
- **Degrado ricerca chatbot**: `searchJobs` perde il match sul corpo `description` (non più nell'index); resta su title/company/location/category. Accettabile (feature non-funnel) vs scaricare ~10MB gz all'apertura; un two-pass index→enrich è possibile follow-up se la qualità ricerca regredisce.
- **`data/`+`public/data/expired-jobs.json` full restano scritti** dalla pipeline (cleanup/assemble, due writer + cache-restore) — non rimossi per non rischiare la pipeline; lo strip avviene a valle su `dist`. Out of scope il prune del committed `public/data/expired-jobs.json` (5.4MB repo bloat pre-esistente).
- **Verifica live post-merge** (test plan): `curl cdn.frontaliereticino.ch/data/expired-jobs-index.json` + un `expired-detail/<key>.json`; assenza di `jobs-{locale}.json` full e `expired-jobs.json` su CDN; nav SPA su un annuncio scaduto.

## Test
- Nuovo `tests/expired-jobs-split.test.ts` (12 test): shape index/detail + dedup key + sanitize.
- `tests/seo-localization.test.ts` aggiornato al nuovo layout (slim index + job-detail); verde.
- Sweep regressione verde: router (498), soft-landing-seo, locale-emit-filter, job-slug-consistency, featured-job-projection, jobsService.scopeJobsToCanton, cleanup-jobs-archive-dedup-losers.
- `tsc --noEmit`: zero errori introdotti (46 baseline pre-esistenti in file non toccati).
- GitNexus impact `fetchAllJobs`: risk LOW, unico caller diretto già aggiornato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)