### PR TITLE
ci(pr): collapse PR test+body-contract fan-out (minimise concurrency footprint)

### DIFF
--- a/.github/workflows/pr-body-contract.yml
+++ b/.github/workflows/pr-body-contract.yml
@@ -13,9 +13,15 @@
 # unit-tested helper scripts/lib/pr-body-closes-check.mjs (tests/pr-body-closes-check.test.ts);
 # keep the two in sync if the rule changes.
 #
-# It does NOT block auto-merge (auto-merge-on-lgtm only gates on the `## LGTM`
-# string, never on other checks) — the failing status is an early nudge, not a
-# hard gate. Pure github-script (no Claude, no PAT) → zero shared-quota cost.
+# Footprint: this used to fan out 4 jobs (body-contract + sibling-check +
+# cls-ad-slot-check + client-lookbehind-check) per PR push. They are now steps
+# of a SINGLE `contract` job, sharing one checkout, to minimise the per-PR
+# Actions-concurrency footprint (Free plan ~20 shared slots — fanning out
+# PR-side jobs starved the pipeline behind queued crawler runs). All checks are
+# behaviour-preserving: the same scripts run, the same sticky comments post, and
+# a blocking violation (body contract / cls / lookbehind) still turns the check
+# RED. Body-contract itself does NOT block auto-merge (auto-merge-on-lgtm gates
+# only on the `## LGTM` string); the red status is an early nudge.
 name: pr-body-contract
 
 on:
@@ -31,10 +37,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  # Single job, sequential steps. The body-contract step runs on every event
+  # (incl. `edited`); the source-guard steps (checkout + sibling/cls/lookbehind)
+  # are gated on `!cancelled() && action != 'edited'` so they (a) still run when
+  # the body-contract step has already setFailed — each is an independent gate —
+  # and (b) skip on a pure body `edited` (the diff is unchanged), exactly as the
+  # old per-job `if: github.event.action != 'edited'` did.
+  contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - name: PR-body completeness + multi-issue Closes (no checkout, all events)
+        uses: actions/github-script@v8
         with:
           script: |
             const STICKY = '<!-- pr-body-contract -->';
@@ -129,34 +142,28 @@ jobs:
             await upsert(parts.join('\n\n'));
             core.setFailed(`PR body contract: ${fails.join('; ')}`);
 
-  # Sibling-class surfacer (zero-Claude, advisory). Il finding reviewer più
-  # ricorrente dopo il body-contract è il 🔴 "stesso antipattern nel file
-  # gemello" (sibling-class-fix: 4/5 dei 🔴 campionati 2026-06-12, ~98 re-review
-  # + 37 round fixer extra in 7gg). check-sibling-patterns.mjs calcola la lista
-  # candidati in modo deterministico; questo job la posta come sticky comment a
-  # PR-open, così (a) l'autore (agent locale o fixer) la vede PRIMA della
-  # review, (b) il reviewer la consuma senza ricostruire la grep a mano (turni
-  # risparmiati). Heuristico → advisory: MAI setFailed (falsi positivi attesi),
-  # non blocca nulla. Skip su action=edited (il body non cambia il diff).
-  sibling-check:
-    if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+      # --- Source-guard steps: one shared checkout, skip on `edited` ------------
+      # `fetch-depth: 0 filter: blob:none` serves all three guards: the sibling
+      # three-dot diff needs the commit-graph + merge-base (blobs lazy-fetched on
+      # demand, ~100s faster than a full blob clone); the cls/lookbehind scans
+      # read the HEAD working tree (materialised by checkout). `!cancelled()` so
+      # they still run after the body-contract step setFailed (independent gates).
+      - name: Checkout (for source guards)
+        if: ${{ !cancelled() && github.event.action != 'edited' }}
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # Storia completa (commit-graph + merge-base con la base branch) serve
-          # per il three-dot diff dello script. `fetch-depth: 0` full però
-          # scaricava ~11GB di blob storici → 143s misurati (il commento "~40s"
-          # era ottimistico). `filter: blob:none`: commit-graph + blob HEAD, i
-          # blob storici lazy-fetch — il diff name-status usa solo i tree
-          # (presenti) e legge il contenuto dei soli file cambiati (pochi blob
-          # on-demand). La sticky `<!-- sibling-check -->` che il reviewer
-          # consuma arriva ~100s prima.
           fetch-depth: 0
           filter: blob:none
+
+      # Sibling-class surfacer (zero-Claude, ADVISORY — never fails). Il finding
+      # reviewer più ricorrente dopo il body-contract è il 🔴 "stesso antipattern
+      # nel file gemello" (sibling-class-fix). check-sibling-patterns.mjs calcola
+      # i candidati in modo deterministico; lo step posta una sticky comment così
+      # (a) l'autore la vede PRIMA della review, (b) il reviewer non rifà la grep.
       - name: Surface sibling candidates
         id: sib
+        if: ${{ !cancelled() && github.event.action != 'edited' }}
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -167,7 +174,9 @@ jobs:
             const r = JSON.parse(require('fs').readFileSync('sibling-report.json','utf8'));
             console.log('candidates=' + r.candidates.length);
           " >> "$GITHUB_OUTPUT"
-      - uses: actions/github-script@v8
+      - name: Post sibling-check comment (advisory)
+        if: ${{ !cancelled() && github.event.action != 'edited' }}
+        uses: actions/github-script@v8
         with:
           script: |
             const STICKY = '<!-- sibling-check -->';
@@ -215,33 +224,21 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
 
-  # Blocking gate (escalation #1954, bucket reviewer-finding/cls-layout 6×/14d):
-  # forbid hard-coded AdSense <ins> in build-plugins. Only adSlotHtml() may emit
-  # the raw ad markup; its min-height/format come from the registry
-  # services/adsenseSlots.ts so the reserved space matches the real ad unit →
-  # zero CLS (the #1910 280-vs-400px regression). Zero-Claude, exits 1 on
-  # violation. Also covered by tests/check-cls-ad-slots.test.ts in the vitest gate.
-  cls-ad-slot-check:
-    if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      # Blocking gate (escalation #1954, bucket reviewer-finding/cls-layout 6×/14d):
+      # forbid hard-coded AdSense <ins> in build-plugins. Only adSlotHtml() may emit
+      # the raw ad markup; its min-height/format come from the registry
+      # services/adsenseSlots.ts so the reserved space matches the real ad unit →
+      # zero CLS (the #1910 280-vs-400px regression). Zero-Claude, exits 1 on
+      # violation. Also covered by tests/check-cls-ad-slots.test.ts in the vitest gate.
       - name: Forbid hard-coded AdSense <ins> in build-plugins
+        if: ${{ !cancelled() && github.event.action != 'edited' }}
         run: node scripts/ci/check-cls-ad-slots.mjs
 
-  # Blocking gate (#1996 → #1999): forbid regex lookbehind ((?<=/(?<!) in
-  # client-bundled source. Older Safari/WebKit throws "invalid group specifier
-  # name" at parse time → crashed job-detail render for Google Jobs traffic (lost
-  # ad impressions). build-plugins/ + scripts/ are build-time (Node) → exempt.
-  # Comment-aware; zero-Claude. Also covered by tests/check-client-lookbehind.test.ts.
-  client-lookbehind-check:
-    if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      # Blocking gate (#1996 → #1999): forbid regex lookbehind ((?<=/(?<!) in
+      # client-bundled source. Older Safari/WebKit throws "invalid group specifier
+      # name" at parse time → crashed job-detail render for Google Jobs traffic (lost
+      # ad impressions). build-plugins/ + scripts/ are build-time (Node) → exempt.
+      # Comment-aware; zero-Claude. Also covered by tests/check-client-lookbehind.test.ts.
       - name: Forbid regex lookbehind in client-bundled source
+        if: ${{ !cancelled() && github.event.action != 'edited' }}
         run: node scripts/ci/check-client-lookbehind.mjs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,34 +6,18 @@ name: tests
 # (added in PR #294) landed already-failing without anyone noticing, and the
 # `#root{min-height:100vh}` bug hit production for 24h until manual report.
 #
-# Wall time: the vitest portion alone was ~408s on a single runner (the full
-# job ~8-13 min) and was the dominant slice of the auto-merge wait — every PR
-# blocks on the `vitest (unit + integration)` check before auto-merge-on-lgtm
-# proceeds. The suite (~847 files, `isolate:true` → +30% but deterministic) is
-# SHARDED across parallel runners via `vitest run --shard=i/N`, splitting the
-# vitest portion deterministically (LPT-balanced, see vitest.config.ts) across
-# shards. Measured on a green 4-shard run (#27614921918): per shard ~164s
-# vitest + ~113s fixed overhead (checkout 38s + npm ci 20s + assemble jobs.json
-# 52s + lints/migrate ~3s) = ~281s, slowest shard.
+# Footprint: this used to fan out a 4-shard matrix + aggregator (5 runners per
+# PR). It now runs the suite in a SINGLE job. On the Free plan the whole
+# account shares a ~20 concurrent-job pool, and a per-PR fan-out of test shards
+# starved the PR pipeline (auto-merge, Claude review, pr-body-contract) behind
+# queued crawler runs — PRs sat un-dequeued. Collapsing to one runner frees 4
+# slots per PR at zero observable wall-time cost: the vitest check is NEVER the
+# gating slice — every PR ALSO blocks on the Claude review (`pr-review-loop`),
+# which averages ~10 min — so a single full run (~8-9 min: ~408s vitest + ~113s
+# overhead) lands inside the review window and review stays the bottleneck.
 #
-# Why N=4 and not 8: the vitest check is NEVER the gating slice of a PR — every
-# PR ALSO blocks on the Claude review (`pr-review-loop`) before
-# auto-merge-on-lgtm proceeds, and that review averages ~11 min (median ~10 min,
-# fastest ever ~8 min / 475s observed over the last 40 runs). So as long as the
-# slowest vitest shard finishes well inside the review window it costs the PR
-# zero extra wall time. At 4 shards the slowest shard is ~281s (~4.7 min) — it
-# lands in under half the review median and comfortably under the fastest review
-# ever seen, so review stays the bottleneck either way. Going to 8 shards would
-# only trim the slowest shard to ~195s (a wall-time win the PR cannot observe,
-# since it still waits on the ~10 min review) while DOUBLING the runners spawned
-# per PR and the pressure on the shared Actions concurrency pool (deploy,
-# crawlers, lighthouse all compete for it). 4 is the documented-measured-green
-# config (#27614921918): ~212 files/shard keeps CPU/memory contention low enough
-# that the heavy source-scan guards (no-inlanguage, cathedral-no-ti-hardcodes,
-# …) don't spike past their per-test timeout — a documented flake source on slow
-# runners — so the safety margin of the 8-shard split is retained. Sharding is
-# behaviour-preserving: every file still runs, split deterministically; no test
-# is skipped and no threshold is relaxed.
+# Behaviour-preserving: every test still runs, no test is skipped and no
+# threshold is relaxed — only the parallelism (wall-time, not coverage) changed.
 #
 # Tests that read data/jobs.json (gitignored): the assemble step regenerates
 # it from the per-slice files committed under data/jobs-by-slice/.
@@ -59,17 +43,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Each shard runs ~1/4 of the test files in parallel. fail-fast:false so a
-  # red shard does NOT cancel its siblings — one run surfaces the full failure
-  # set instead of forcing re-runs to discover the next failing file.
-  vitest-shard:
-    name: vitest shard ${{ matrix.shard }}/4
+  # Single job, full suite. The job name `vitest (unit + integration)` is
+  # LOAD-BEARING: auto-merge-on-lgtm's "Block merge if vitest gate is RED" step
+  # keys on it (`select(.name == "vitest (unit + integration)")`), as do
+  # auto-merge-eval gate 3 and pr-autorebase's workflow_dispatch expectation.
+  # Do NOT rename.
+  vitest:
+    name: vitest (unit + integration)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
+    # 20 min (was 15 at 4 shards): the single runner now executes all ~847 test
+    # files, so the margin against the heavy source-scan guards (no-inlanguage,
+    # cathedral-no-ti-hardcodes, …) spiking on a slow runner is widened to keep
+    # a transient slow run from going RED on a timeout instead of a real failure.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
@@ -114,11 +100,10 @@ jobs:
         # content-addressable cache under .cache/assemble-jobs (keyed on a
         # sha256 of every slice file + an internal output-version) that restores
         # the assembled outputs in ~0.3s instead of re-running the ~52s
-        # assembly. That cache is useless on a fresh CI runner unless persisted
-        # — without this step every one of the N shards paid the full ~52s.
-        # The script's internal version+fingerprint guarantees correctness, so
-        # the restore-keys cascade cannot replay a stale jobs.json across slice
-        # or assembler changes (cache-miss → full assembly → fresh snapshot).
+        # assembly. The script's internal version+fingerprint guarantees
+        # correctness, so the restore-keys cascade cannot replay a stale
+        # jobs.json across slice or assembler changes (cache-miss → full
+        # assembly → fresh snapshot).
         uses: actions/cache@v5
         with:
           path: .cache/assemble-jobs
@@ -139,44 +124,23 @@ jobs:
         # canton-aware section paths. The migration is idempotent.
         run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
 
-      - name: vitest run (shard ${{ matrix.shard }}/4)
+      - name: vitest run (full suite)
         # Emit a per-file timing JSON alongside the default reporter. It feeds
-        # scripts/ci/generate-shard-weights.mjs, which refreshes
-        # tests/shard-weights.json (the LPT BalancedSequencer's input) from real
-        # CI durations — local timings over-weight CPU-bound scan guards because
-        # the dev box runs ~3-10× slower under contention. The json reporter is
-        # additive (default reporter still prints), so failures stay visible.
-        run: npm test -- --shard=${{ matrix.shard }}/4 --reporter=default --reporter=json --outputFile=shard-timing-${{ matrix.shard }}.json
+        # scripts/ci/generate-shard-weights.mjs / refresh-shard-weights.yml,
+        # which keep tests/shard-weights.json fresh (still consumed by the LPT
+        # BalancedSequencer in vitest.config.ts). A single full run is complete
+        # per-file timing data — a superset of the old per-shard files. The json
+        # reporter is additive (default reporter still prints), failures stay
+        # visible.
+        run: npm test -- --reporter=default --reporter=json --outputFile=shard-timing-1.json
 
-      - name: Upload shard timing
-        # always() so we still collect timings when a shard is red (a slow test
+      - name: Upload test timing
+        # always() so we still collect timings when the run is red (a slow test
         # that times out is exactly the data point we want for re-balancing).
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: shard-timing-${{ matrix.shard }}
-          path: shard-timing-${{ matrix.shard }}.json
+          name: shard-timing-1
+          path: shard-timing-1.json
           retention-days: 7
           if-no-files-found: ignore
-
-  # Aggregator gate. Preserves the EXACT check-run name every downstream
-  # consumer keys on — auto-merge-on-lgtm's "Block merge if vitest gate is RED"
-  # step (`select(.name == "vitest (unit + integration)")`), auto-merge-eval
-  # gate 3, and pr-autorebase's workflow_dispatch expectation. Green ONLY when
-  # all 4 shards are green; any shard failure/cancellation makes this RED, so
-  # the merge gate behaves identically to the old single-job version.
-  vitest:
-    name: vitest (unit + integration)
-    runs-on: ubuntu-latest
-    needs: vitest-shard
-    if: ${{ always() }}
-    steps:
-      - name: Fail unless every shard is green
-        run: |
-          result='${{ needs.vitest-shard.result }}'
-          echo "aggregated shard result: '$result'"
-          if [ "$result" != "success" ]; then
-            echo "::error::one or more vitest shards did not succeed (result='$result') — gate is RED"
-            exit 1
-          fi
-          echo "all 4 vitest shards green — gate is GREEN"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,17 @@ name: tests
 # account shares a ~20 concurrent-job pool, and a per-PR fan-out of test shards
 # starved the PR pipeline (auto-merge, Claude review, pr-body-contract) behind
 # queued crawler runs — PRs sat un-dequeued. Collapsing to one runner frees 4
-# slots per PR at zero observable wall-time cost: the vitest check is NEVER the
-# gating slice — every PR ALSO blocks on the Claude review (`pr-review-loop`),
-# which averages ~10 min — so a single full run (~8-9 min: ~408s vitest + ~113s
-# overhead) lands inside the review window and review stays the bottleneck.
+# slots per PR.
+#
+# MEASURED, not estimated (CI run 28099661052, full ~847-file suite on one
+# 4-vCPU runner): vitest 366s + setup/assemble/lint overhead → 536s total job
+# wall (~8.9 min). The `pool: 'threads'` worker pool (below) parallelises files
+# across the runner's 4 vCPUs, so wall ≈ work/4 — NOT the 4×164s≈656s an
+# additive per-shard model predicts (536s is ~1.9× a single shard's ~281s, not
+# 4×). 536s lands inside the ~10 min Claude review window (`pr-review-loop`), so
+# the review stays the gating slice and the vitest check costs the PR ~zero
+# extra wall time. The same measured run completed every heavy source-scan guard
+# (no-inlanguage, cathedral-no-ti-hardcodes, …) with no per-test timeout.
 #
 # Behaviour-preserving: every test still runs, no test is skipped and no
 # threshold is relaxed — only the parallelism (wall-time, not coverage) changed.
@@ -52,9 +59,11 @@ jobs:
     name: vitest (unit + integration)
     runs-on: ubuntu-latest
     # 20 min (was 15 at 4 shards): the single runner now executes all ~847 test
-    # files, so the margin against the heavy source-scan guards (no-inlanguage,
-    # cathedral-no-ti-hardcodes, …) spiking on a slow runner is widened to keep
-    # a transient slow run from going RED on a timeout instead of a real failure.
+    # files. The measured job wall is 536s (run 28099661052), so 1200s is a ~2.2×
+    # headroom against a slow-runner spike — wide enough to keep a transient slow
+    # run from going RED on a JOB timeout instead of a real failure. (Per-test
+    # timeouts are unchanged from vitest.config.ts and were not hit in the
+    # measured run.)
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5

--- a/tests/ci-vitest-check-name.test.ts
+++ b/tests/ci-vitest-check-name.test.ts
@@ -78,29 +78,28 @@ describe('VITEST_CHECK_NAME (#1602 drift guard)', () => {
 });
 
 /**
- * Guard analogo per VITEST_SHARD_NAME_RE (#2438): il regex deve matchare il
- * `name:` del job SHARD in tests.yml (`vitest shard ${{ matrix.shard }}/4`).
- * `vitestFailureIsTransientCancellation` lo usa per riaprire gli shard sotto
- * l'aggregatore; un rename del job senza aggiornare il regex farebbe leggere 0
- * shard → l'heal transient non scatterebbe mai (silenzioso, come #1602).
+ * Contratto single-job post de-sharding (#2882): tests.yml esegue UN solo job
+ * `vitest (unit + integration)` — non esiste più un job `vitest-shard:` con
+ * matrice. `VITEST_SHARD_NAME_RE` e `vitestFailureIsTransientCancellation`
+ * RESTANO in scripts/ci/lib (dormienti): senza check-run shard l'heal ritorna
+ * `false`, che è il comportamento CORRETTO nel nuovo mondo — un vitest=failure
+ * sull'HEAD è sempre un fail reale, mai un mascheramento da shard `cancelled`
+ * collassato dall'aggregatore. Questo guard fissa il contratto single-job: una
+ * futura re-introduzione dello sharding DEVE aggiornare consapevolmente sia
+ * tests.yml sia l'heal (la unit `vitest-check-selection.test.ts` copre la funzione).
  */
-describe('VITEST_SHARD_NAME_RE (#2438 shard-name drift guard)', () => {
-  it('matcha il name: del job shard reso da tests.yml per ogni indice della matrice', () => {
-    const m = TESTS_YML.match(/^\s*vitest-shard:\s*\n(?:.*\n)*?\s*name:\s*(.+?)\s*$/m);
-    expect(m, 'job `vitest-shard:` con `name:` non trovato in tests.yml').toBeTruthy();
-    const tpl = (m![1] || '').replace(/^['"]|['"]$/g, '');
-    // Estrae il count statico dal template `vitest shard ${{ matrix.shard }}/N`.
-    const countMatch = tpl.match(/\}\}\/(\d+)\s*$/);
-    expect(countMatch, `count statico /N non trovato in name: "${tpl}"`).toBeTruthy();
-    const count = Number(countMatch![1]);
-    // Espande il template per ogni shard della matrice e verifica il match.
-    for (let i = 1; i <= count; i++) {
-      const rendered = tpl.replace(/\$\{\{\s*matrix\.shard\s*\}\}/g, String(i));
-      expect(VITEST_SHARD_NAME_RE.test(rendered), `regex non matcha shard "${rendered}"`).toBe(true);
-    }
+describe('vitest single-job contract (#2882 de-sharding)', () => {
+  it('tests.yml ha il job `vitest:` e NESSUN job `vitest-shard:`', () => {
+    expect(/^[ \t]*vitest:[ \t]*$/m.test(TESTS_YML), 'job `vitest:` mancante in tests.yml').toBe(true);
+    expect(
+      /^[ \t]*vitest-shard:[ \t]*$/m.test(TESTS_YML),
+      'job `vitest-shard:` ancora presente — de-sharding incompleto (aggiorna anche l’heal in vitestCheck.mjs)',
+    ).toBe(false);
   });
 
-  it('NON matcha il nome dell’aggregatore (i due check-name restano distinti)', () => {
+  it('VITEST_SHARD_NAME_RE resta sano: matcha un nome shard ma NON l’aggregatore', () => {
+    // Dormiente ma non rotto: se lo sharding torna deve ancora distinguere i due.
+    expect(VITEST_SHARD_NAME_RE.test('vitest shard 1/4')).toBe(true);
     expect(VITEST_SHARD_NAME_RE.test(VITEST_CHECK_NAME)).toBe(false);
   });
 });


### PR DESCRIPTION
## Implementato

Riduce al minimo i job che una singola PR fa partire in parallelo, per non saturare il pool ~20 job concorrenti del piano Free (i crawler in coda affamavano la pipeline PR: auto-merge, review, body-contract restavano un-dequeued).

- **`tests.yml`**: collassato il matrix a 4 shard + aggregatore (5 runner/PR) in **un solo job** che gira la suite intera. Nome del check `vitest (unit + integration)` preservato byte-identico (load-bearing: auto-merge-on-lgtm, auto-merge-eval gate 3, pr-autorebase ci keyano). `timeout-minutes` 15→20. Comportamento invariato: ogni test gira, nessuna soglia/tolleranza abbassata — cambia solo il wall-time (no coverage). Continua a emettere `shard-timing-1` (superset completo) → `refresh-shard-weights` resta alimentato.
- **`pr-body-contract.yml`**: collassati i 4 job (`check` + `sibling-check` + `cls-ad-slot-check` + `client-lookbehind-check`) in **un solo job** con checkout condiviso (`blob:none`) e step sequenziali, gated `!cancelled() && action != 'edited'` (girano anche se body-contract fa `setFailed`; saltano su `edited`). Script `github-script` **byte-identici** all'originale; sticky comment e gate bloccanti (body/cls/lookbehind → RED) preservati.
- **`tests/ci-vitest-check-name.test.ts`**: il guard `#2438` asseriva il job `vitest-shard:` rimosso → aggiornato al contratto single-job `#2882`.

Footprint per push di PR: da ~10 a ~4 job (tests 1 + contract 1 + collision 1 + review 1).

### Wall-time: MISURATO, non stimato (chiude il 🔴 del reviewer)

Run CI reale **28099661052** (success, suite intera ~847 file su un runner 4-vCPU): **vitest 366s + overhead → 536s di wall totale del job (~8.9 min)**. Il pool `pool: 'threads'` parallelizza i file sui 4 vCPU del runner → wall ≈ work/4, **non** i 4×164s≈656s di un modello additivo per-shard (536s è ~1.9× il wall di una singola shard ~281s, non 4×). 536s **dentro** la finestra review ~10 min → la review resta la slice gating, il check vitest costa ~zero wall alla PR. Lo stesso run ha completato **tutti** i source-scan guard pesanti (no-inlanguage, cathedral-no-ti-hardcodes, …) **senza alcun per-test timeout**. `timeout-minutes:20` (1200s) = ~2.2× headroom sul wall misurato.

## Non implementato (ancora)

- **Matrix-collapse dei ~450 crawler `update-jobs-*.yml`** (causa primaria della starvation, ~84 crawler in coda davanti alle PR): fix strutturale fuori scope, escluso su decisione owner per questa iterazione.
- **Macchina shard-heal lasciata dormiente (deferito, non rimosso):** `VITEST_SHARD_NAME_RE` + `vitestFailureIsTransientCancellation` (scripts/ci/lib) + il ramo heal di `pr-autorebase.mjs` restano. Senza check-run shard la funzione ritorna `false` = comportamento **corretto** nel nuovo mondo. NON rimossi qui per non toccare CI merge-critical nello stesso diff; `vitest-check-selection.test.ts` resta verde sui suoi input sintetici. Cleanup dead-code → follow-up.
- **Sibling-check candidates** (`adSlotHtml`, `setFailed`): falsi positivi — il diff tocca solo struttura YAML CI + un guard test; quei token sono in commenti/script riportati verbatim, nessuna logica condivisa modificata.

### Risposte agli adversarial check del reviewer

1. **`cancelled` del job vitest singolo non auto-recuperato?** No, non stranda. `cancel-in-progress` cancella un run SOLO quando ne parte uno PIÙ NUOVO sullo stesso `ref`: quel run più nuovo è il superseding e va a completamento, fornendo la conclusion autoritativa. L'ultimo run di ogni catena di cancel non è mai `cancelled` (niente lo supera) → `latestCompletedVitestConclusion` prende il più recente completato; auto-merge-eval è event-driven su `workflow_run: completed` → ri-valuta. Nessun path stranded → nessuna modifica CI merge-critical necessaria.
2. **Branch-protection sui context collassati?** Moot: `main` **NON è branch-protected** (verificato: GitHub API `branches/main/protection` → 404 "Branch not protected"). Nessun required-status-context esiste → il rename/collasso dei job non lascia nulla non-reporting. L'enforcement CLS/lookbehind resta comunque dual-covered nel gate vitest.
3. **Overhead `isolate:true` non misurato?** Refutato dal wall misurato 536s << 1200s timeout (run 28099661052), margine ~2.2×.
