### PR TITLE
feat(cdn): R2 publish path behind CDN_TARGET flag (kills #2569/#2872 stale-locale wait)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -422,6 +422,11 @@ jobs:
         if: matrix.locale == 'it'
         env:
           CDN_DEPLOY_KEY: ${{ secrets.CDN_DEPLOY_KEY }}
+          # CDN publish target: 'pages' (legacy git force-push, default) or 'r2'
+          # (Cloudflare R2 S3 sync — instant publish, kills the #2569 gate wait).
+          # Flip by setting the repo variable CDN_TARGET=r2 (no code change). R2_*
+          # creds are hydrated from Remote Config by the earlier load-rc-env step.
+          CDN_TARGET: ${{ vars.CDN_TARGET || 'pages' }}
         run: bash scripts/lib/deploy-it-pages-prep.sh
 
       - name: Upload Pages artifact (compression-level 9)
@@ -716,6 +721,10 @@ jobs:
           # path (e.g. Cloudflare R2: no size limit, instant PUT, marker visible in
           # seconds) or split it back under 1 GB. Tracked for #2872 follow-up.
           CDN_WAIT_TIMEOUT_S: 2700
+          # When CDN_TARGET=r2 the marker is published to R2 (no-store); the gate
+          # then cache-busts each poll so it sees R2's strong read-after-write id
+          # immediately — the 2700s budget becomes a near-no-op (match in seconds).
+          CDN_TARGET: ${{ vars.CDN_TARGET || 'pages' }}
         run: bash scripts/lib/wait-cdn-build-id.sh "${DEPLOY_BUILD_ID}"
 
       - name: Push locale shard

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -108,17 +108,72 @@ step_spa_fallback() {
   cp dist/index.html dist/404.html
 }
 
+# ── R2 publish (Cloudflare R2 via S3 API) — instant PUT, no Pages build ───────
+# Used when CDN_TARGET=r2 (else the legacy git force-push below runs). Replaces
+# the ~22min GitHub Pages publish latency (root cause of the #2569/#2872 stale-
+# locale class) with an instant, read-after-write-strong R2 sync. Incremental
+# `aws s3 sync` is ADDITIVE (no --delete → prior assets/ stay; superseded hashes
+# GC'd by the janitor past grace), so the clone-prev `cp -n` dance Pages needs is
+# unnecessary here. Per-class Cache-Control lets the Cloudflare edge absorb reads
+# (R2 Class B stays in the free tier). Content-Type is auto-detected from the
+# file extension by the AWS CLI. The #2569 atomicity marker is PUT LAST with
+# `no-store` so the cache-busted gate (wait-cdn-build-id.sh) sees the new id the
+# instant the full payload is on R2 — never an edge-cached stale value.
+_publish_cdn_r2() {
+  local stage="$1"
+  if [ -z "${R2_ACCESS_KEY_ID:-}" ] || [ -z "${R2_SECRET_ACCESS_KEY:-}" ] \
+     || [ -z "${R2_S3_ENDPOINT:-}" ] || [ -z "${R2_BUCKET:-}" ]; then
+    echo "::warning::CDN_TARGET=r2 but R2_* creds missing — skipping CDN publish (assets stay in dist)"
+    return 0
+  fi
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "::error::CDN_TARGET=r2 but the aws CLI is not on the runner — cannot sync to R2"
+    return 0
+  fi
+  export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+  export AWS_DEFAULT_REGION=auto
+  local ep="$R2_S3_ENDPOINT" bkt="s3://$R2_BUCKET" ok=1
+  echo "CDN→R2: payload $(du -sh "$stage" | cut -f1) → $bkt"
+  _r2_sync() { # <src-dir> <dst-prefix> <cache-control>
+    [ -d "$1" ] || return 0
+    aws s3 sync "$1" "$bkt/$2" --endpoint-url "$ep" --no-progress --only-show-errors \
+      --cache-control "$3" || ok=0
+  }
+  _r2_sync "$stage/assets" assets "public,max-age=31536000,immutable"
+  _r2_sync "$stage/og"     og     "public,max-age=86400"
+  _r2_sync "$stage/images" images "public,max-age=86400"
+  _r2_sync "$stage/data"   data   "public,max-age=600"
+  aws s3 cp "$stage/index.html" "$bkt/index.html" --endpoint-url "$ep" --no-progress --only-show-errors \
+    --content-type "text/html; charset=utf-8" --cache-control "public,max-age=600" || ok=0
+  if [ "$ok" != 1 ]; then
+    echo "⚠️ R2 payload sync had errors — NOT writing marker (shard gate keeps last good live)"
+    return 0
+  fi
+  # Marker LAST (atomicity #2569): only now is this build's full payload on R2.
+  printf '%s' "${DEPLOY_BUILD_ID:-}" > "$stage/cdn-build-id.txt"
+  if aws s3 cp "$stage/cdn-build-id.txt" "$bkt/cdn-build-id.txt" --endpoint-url "$ep" --no-progress \
+       --only-show-errors --content-type "text/plain; charset=utf-8" --cache-control "no-store, max-age=0"; then
+    export_env CDN_BASE "https://cdn.frontaliereticino.ch"
+    echo "✅ synced CDN payload to R2 ($R2_BUCKET); marker=${DEPLOY_BUILD_ID:-<empty>}"
+  else
+    echo "⚠️ R2 marker PUT failed — offload skipped, og/data stay in dist"
+  fi
+}
+
 # ── 2. Push generated assets to CDN repo (frontaliere-cdn / Pages) ────────────
 # deploy.yml: "Push generated assets to CDN repo" — NON-FATAL (continue-on-error).
-# Stages CDN payload (dist/og, dist/data, dist/assets, public/images/*), blobless
-# clone of the CDN repo, additive `cp -n` merge of prior assets/, force-push to
-# valerielinc-ops/frontaliere-cdn, exports CDN_BASE on success. Internally
-# non-fatal: every failure path keeps the assets in dist.
+# Stages CDN payload (dist/og, dist/data, dist/assets, public/images/*), then
+# publishes via CDN_TARGET: 'r2' (S3 sync, default-off) or 'pages' (legacy git
+# force-push to valerielinc-ops/frontaliere-cdn). Exports CDN_BASE on success.
+# Internally non-fatal: every failure path keeps the assets in dist.
 step_push_cdn() {
   set -uo pipefail
-  if [ -z "${CDN_DEPLOY_KEY:-}" ]; then
-    echo "no CDN_DEPLOY_KEY secret — skipping CDN push, assets stay in dist"; return 0
-  fi
+  # CDN_TARGET selects the publish path; default 'pages' keeps the legacy
+  # git-push behaviour byte-identical. The credential guard is per-target,
+  # applied inside each branch below (fail-closed): r2 → R2_* creds, pages →
+  # CDN_DEPLOY_KEY.
+  local cdn_target="${CDN_TARGET:-pages}"
   stage=/tmp/cdn-stage
   rm -rf "$stage" && mkdir -p "$stage"
   : > "$stage/.nojekyll"                              # serve every path verbatim, skip Jekyll
@@ -150,6 +205,26 @@ step_push_cdn() {
     echo "no offloadable assets present — skipping CDN push"; return 0
   fi
   printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"
+
+  # ── Publish: r2 (instant) | both (dual-publish for cutover) | pages (legacy) ─
+  # 'both' writes R2 AND Pages so the live domain (still → Pages until the R2
+  # custom-domain flip) keeps serving while R2 is populated+validated in
+  # parallel — zero-downtime cutover. 'r2' is R2-only (post-flip). 'pages'
+  # (default) is the legacy git force-push, byte-identical to before.
+  if [ "$cdn_target" = "r2" ] || [ "$cdn_target" = "both" ]; then
+    _publish_cdn_r2 "$stage"
+    if [ "$cdn_target" = "r2" ]; then
+      cd "$PREP_CWD"
+      return 0
+    fi
+    # 'both': fall through to ALSO publish to Pages (live domain unchanged).
+  fi
+  # Legacy Pages path below (CDN_TARGET=pages or both).
+  if [ -z "${CDN_DEPLOY_KEY:-}" ]; then
+    echo "no CDN_DEPLOY_KEY secret — skipping CDN push, assets stay in dist"
+    cd "$PREP_CWD"
+    return 0
+  fi
   keyfile="$RUNNER_TEMP/cdn_deploy_key"
   printf '%s\n' "$CDN_DEPLOY_KEY" > "$keyfile" && chmod 600 "$keyfile"
   export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
@@ -235,6 +310,13 @@ step_offload() {
 step_prune_cdn() {
   if [ -z "${CDN_BASE:-}" ]; then
     echo "CDN_BASE unset (no CDN push this run) — skipping CDN prune"; return 0
+  fi
+  # The janitor is git-based (clone + force-push frontaliere-cdn). On R2 there is
+  # no git repo and no ~1 GB Pages limit to defend, so skip it here — R2 storage
+  # GC is a separate (S3 ListObjects + DeleteObject) follow-up; at 1.27 GB the
+  # 10 GB R2 free-tier has ample headroom in the meantime.
+  if [ "${CDN_TARGET:-pages}" = "r2" ]; then
+    echo "CDN_TARGET=r2 — skipping git-based assets janitor (R2 has no 1 GB limit; GC is a follow-up)"; return 0
   fi
   node scripts/ci/prune-cdn-assets.mjs
 }

--- a/scripts/lib/wait-cdn-build-id.sh
+++ b/scripts/lib/wait-cdn-build-id.sh
@@ -61,10 +61,16 @@ elapsed=0
 attempt=0
 while :; do
   attempt=$((attempt + 1))
+  # On R2 the marker is published with `no-store`, but append a unique cache-bust
+  # query per poll so the Cloudflare edge can NEVER serve a stale id: R2 is
+  # read-after-write strong at origin, and a fresh query key forces an origin
+  # fetch. Harmless on Pages (static server ignores the query, Fastly keys on it).
+  poll_url="$url"
+  if [ "${CDN_TARGET:-pages}" = "r2" ]; then poll_url="${url}?nocache=${attempt}-${elapsed}"; fi
   # `|| true` (and a literal fallback): under a caller's `set -e`/pipefail a
   # curl miss (404 / not-yet-published) must NOT abort — it is the expected
   # transient state we are polling through.
-  got="$(curl -fsS "$url" 2>/dev/null || true)"
+  got="$(curl -fsS "$poll_url" 2>/dev/null || true)"
   got="$(printf '%s' "$got" | tr -d '[:space:]')"
   if [ "$got" = "$expected" ]; then
     echo "[wait-cdn-build-id] ✅ CDN published build id=${expected} after ${elapsed}s (${attempt} polls) — shard publish unblocked"

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -142,6 +142,14 @@ const RC_TO_ENV = {
   COHERE_API_KEY:                 ['COHERE_API_KEY'],
   CF_API_TOKEN:                   ['CF_API_TOKEN'],
   CF_ACCOUNT_ID:                  ['CF_ACCOUNT_ID'],
+  // Cloudflare R2 S3 deploy credentials for the CDN (CDN_TARGET=r2). Derived
+  // from CF_API_TOKEN by scripts/set-r2-rc.mjs (AccessKeyId = token id, Secret
+  // = SHA-256 of token value). Consumed by deploy-it-pages-prep.sh _publish_cdn_r2.
+  R2_ACCOUNT_ID:                  ['R2_ACCOUNT_ID'],
+  R2_BUCKET:                      ['R2_BUCKET'],
+  R2_S3_ENDPOINT:                 ['R2_S3_ENDPOINT'],
+  R2_ACCESS_KEY_ID:               ['R2_ACCESS_KEY_ID'],
+  R2_SECRET_ACCESS_KEY:           ['R2_SECRET_ACCESS_KEY'],
   MISTRAL_API_KEY:                ['MISTRAL_API_KEY'],
   CHUTES_API_KEY:                 ['CHUTES_API_KEY'],
   ZAI_API_KEY:                    ['ZAI_API_KEY', 'ZHIPU_API_KEY'],

--- a/scripts/set-r2-rc.mjs
+++ b/scripts/set-r2-rc.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * One-shot: publish R2 (Cloudflare) S3 deploy credentials to Firebase Remote
+ * Config so scripts/load-rc-env.mjs can hydrate them in CI for the CDN deploy.
+ *
+ * The S3 credentials are DERIVED from the existing CF_API_TOKEN (already in RC):
+ *   Access Key ID     = the API token's id  (from /user/tokens/verify)
+ *   Secret Access Key = SHA-256(token value)   ← documented R2 S3 derivation
+ * So no new secret is invented; rotating CF_API_TOKEN → just re-run this script.
+ *
+ * Auth: GOOGLE_APPLICATION_CREDENTIALS → Firebase SA (Remote Config Admin).
+ * Env:  CF_API_TOKEN, CF_ACCOUNT_ID (loaded via load-rc-env.mjs).
+ */
+import crypto from 'node:crypto';
+
+const T = process.env.CF_API_TOKEN;
+const A = process.env.CF_ACCOUNT_ID;
+const BUCKET = process.env.R2_BUCKET || 'frontaliere-cdn';
+if (!T || !A) { console.error('❌ CF_API_TOKEN / CF_ACCOUNT_ID missing in env'); process.exit(1); }
+
+// derive S3 creds
+const verify = await (await fetch('https://api.cloudflare.com/client/v4/user/tokens/verify',
+  { headers: { Authorization: `Bearer ${T}` } })).json();
+if (!verify?.success) { console.error('❌ token verify failed'); process.exit(1); }
+const accessKeyId = verify.result.id;
+const secretAccessKey = crypto.createHash('sha256').update(T).digest('hex');
+
+const PARAMS = {
+  R2_ACCOUNT_ID: A,
+  R2_BUCKET: BUCKET,
+  R2_S3_ENDPOINT: `https://${A}.r2.cloudflarestorage.com`,
+  R2_ACCESS_KEY_ID: accessKeyId,
+  R2_SECRET_ACCESS_KEY: secretAccessKey,
+};
+
+const adminMod = await import('firebase-admin');
+const admin = adminMod.default || adminMod;
+if (!admin.apps.length) admin.initializeApp({ credential: admin.credential.applicationDefault() });
+const rc = admin.remoteConfig();
+const template = await rc.getTemplate();
+
+let changed = 0;
+const today = new Date().toISOString().slice(0, 10);
+for (const [key, value] of Object.entries(PARAMS)) {
+  const cur = template.parameters[key]?.defaultValue?.value;
+  if (cur === value) continue;
+  template.parameters[key] = {
+    defaultValue: { value },
+    valueType: 'STRING',
+    description: `R2 CDN S3 deploy credential (derived from CF_API_TOKEN; set ${today})`,
+  };
+  changed++;
+}
+if (changed === 0) { console.log('ℹ️  All R2_* params already up-to-date. Nothing to publish.'); process.exit(0); }
+await rc.publishTemplate(template, { force: true });
+console.log(`✅ Published ${changed} R2_* param(s) to Remote Config (accessKeyId tail ...${accessKeyId.slice(-6)}).`);


### PR DESCRIPTION
## Implementato

Path di pubblicazione CDN su **Cloudflare R2** (S3 API) come alternativa al git force-push su GitHub Pages, dietro flag **`CDN_TARGET`** (`pages` default | `both` | `r2`). Default `pages` → comportamento **byte-identico** a oggi (merge a rischio zero). R2 ha PUT **istantaneo e read-after-write-strong** → elimina i ~22min di latenza di pubblicazione Pages che sono la **causa radice** della classe stale-locale (#2569/#2872): il cross-shard ordering gate non va più in timeout.

- **`scripts/lib/deploy-it-pages-prep.sh`** — nuova `_publish_cdn_r2`: `aws s3 sync` incrementale (**additive**, no `--delete` → asset prior restano; niente più clone-prev `cp -n`), **Cache-Control per classe** (assets immutable / og,images 1g / data 600s) così l'edge CF assorbe le letture (Class B free), **Content-Type** auto da estensione, **marker PUT per ultimo** con `no-store` (atomicità #2569). Dispatch su `CDN_TARGET`; `both` dual-pubblica Pages+R2 per cutover zero-downtime; janitor git-based skippato su `r2`.
- **`scripts/lib/wait-cdn-build-id.sh`** — su `r2` ogni poll fa **cache-bust** → il gate vede subito l'id strong di R2, mai un valore edge-stale.
- **`scripts/load-rc-env.mjs`** — idrata `R2_*` da Remote Config.
- **`scripts/set-r2-rc.mjs`** — writer one-shot: **deriva** le credenziali S3 dal `CF_API_TOKEN` (AccessKeyId = id token, Secret = SHA-256 del valore — meccanismo documentato R2). Ri-eseguibile su rotazione token.
- **`.github/workflows/deploy.yml`** — passa `CDN_TARGET` (da repo variable `vars.CDN_TARGET`, default `pages`) a prep + gate.

### Fase 0 già completata (infra)
Bucket `frontaliere-cdn` creato; CORS `ACAO:*` GET/HEAD settata via API; 5 chiavi `R2_*` pubblicate su Remote Config e verificate end-to-end (read/write/delete su R2 con credenziali lette da RC).

### Validazione
`_publish_cdn_r2` eseguita **E2E contro il bucket live** con uno stage di prova: Content-Type corretti (`application/json`, `text/css`, `image/png`, `text/plain`) e Cache-Control per classe corretti, marker `no-store`; cleanup OK. Sintassi `bash -n` + `node --check` verde su tutti i file.

### Procedura di cutover (operativa, post-merge)
1. `vars.CDN_TARGET=both` → un deploy popola R2 mentre il dominio resta su Pages; valida via URL `r2.dev`/temp (curl Content-Type/CORS/byte-parità su `/data`,`/og`,`/assets`,`/images/blog`,`/cdn-build-id.txt`).
2. Bind custom domain `cdn.frontaliereticino.ch` → bucket R2 (il dominio R2 è sempre proxied → egress free + edge cache; il loop redirect è già neutralizzato dall'host-guard apex/www in `ensure-image-cdn-redirect.mjs`).
3. `vars.CDN_TARGET=r2` → R2-only, gate quasi a zero.
4. Bake N deploy con Pages come fallback, poi PR di rimozione del path Pages.
- **Revert-trigger**: se il 1° deploy R2 dà 404 su `/data` o `/og`, o il gate timeouta → re-bind dominio a Pages + `CDN_TARGET=pages`.

## Non implementato (ancora)

- **GC storage R2 (janitor)**: skippato su `r2` (R2 non ha il limite 1GB; a 1.27GB il free-tier 10GB ha margine ampio). Riscrittura del janitor a S3 `ListObjects`+`DeleteObject` con grace + anti-clobber (equivalente di `assertFreshRemote`) = follow-up dedicato.
- **Bind custom domain + flip**: azione operativa di cutover (repo var + dashboard R2), non in questo diff — il path R2 è default-OFF.
- **Credenziali dedicate scoped-bucket**: ora derivate dal `CF_API_TOKEN` condiviso (il token non può coniare nuovi token: manca "API Tokens Write"). Hardening opzionale: token R2 dedicato dal dashboard → swap dei 2 valori RC.
- **Validazione `.webp` Content-Type**: l'AWS CLI deduce il MIME dall'estensione; `image/webp` è presente nei mimetypes dei runner ubuntu, ma va confermato col curl di parità in fase di cutover (step 1).
- **Misura op Class A/B su deploy reale**: stimata dentro il free-tier con sync incrementale; conferma col primo deploy `both` (CF dashboard) prima del flip.