### PR TITLE
feat(ci): auto-merge merges via the GitHub App token (B2b-1, PAT fallback)

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -91,13 +91,28 @@ jobs:
         continue-on-error: true
         run: node scripts/load-rc-env.mjs
 
-      # PAT-down = degrado silenzioso a catena del loop autonomo (merge senza
+      # Primary merge identity = GitHub App installation token (`frontaliere-
+      # automation[bot]`): auto-mints, no expiry, and its merge-push to main
+      # re-triggers the deploy + post-merge-followup cascade (no GITHUB_TOKEN
+      # anti-recursion). Sets env.APP_TOKEN; missing App creds → falls back to
+      # env.GITHUB_PAT, then GITHUB_TOKEN. The identity gates already allowlist
+      # the App slug (#2881). B2b-1 of the App migration.
+      - name: Mint App token (primary identity, PAT fallback)
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
+      # Token-down = degrado silenzioso a catena del loop autonomo (merge senza
       # cascade, coda congelata, routing/re-queue inerti). Alert inline
       # deterministico, dedup sul titolo canonico del monitor daily
       # (gh-pat-expiry-monitor.yml) che resta l'owner dell'auto-close.
-      # GH_TOKEN = GITHUB_TOKEN, NON il PAT (e' la cosa rotta).
-      - name: Alert PAT-down (dedup, zero-Claude)
-        if: env.GITHUB_PAT == ''
+      # GH_TOKEN = GITHUB_TOKEN, NON l'App/PAT. Scatta solo se NESSUN token
+      # cascade-capable (né App né PAT).
+      - name: Alert token-down (dedup, zero-Claude)
+        if: env.APP_TOKEN == '' && env.GITHUB_PAT == ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,9 +172,9 @@ jobs:
           #   1. RC non carica → env.GITHUB_PAT vuoto → fallback diretto.
           #   2. Merge col PAT fallisce (es. PAT senza scope PR-write) → retry
           #      con GITHUB_TOKEN, così l'auto-merge non si rompe mai.
-          MERGE_PRIMARY_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          MERGE_PRIMARY_TOKEN: ${{ env.APP_TOKEN || env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           MERGE_FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HAS_PAT: ${{ env.GITHUB_PAT != '' }}
+          HAS_PAT: ${{ env.APP_TOKEN != '' || env.GITHUB_PAT != '' }}
         run: node scripts/ci/auto-merge-eval.mjs "${{ steps.resolve.outputs.pr_number }}"
 
       - name: Cleanup Firebase credentials


### PR DESCRIPTION
## Implementato

**Workstream B step 2b-1**: migra l'identità di **merge** in `auto-merge-on-lgtm` all'App GitHub (`frontaliere-automation[bot]`).

- `MERGE_PRIMARY_TOKEN = env.APP_TOKEN || env.GITHUB_PAT || secrets.GITHUB_TOKEN` (App primario, PAT fallback, GITHUB_TOKEN ultima spiaggia).
- Aggiunto lo step **Mint App token** (riusa `scripts/ci/mint-app-token.mjs` da #2859) + alert "token-down" allargato (scatta solo se né App né PAT).
- L'App auto-minta (niente scadenza da babysittare) e il suo squash-merge push su `main` **ri-triggera il cascade deploy + post-merge-followup** come il PAT (no anti-ricorsione GITHUB_TOKEN).
- I gate d'identità **già allowlistano** lo slug App (#2881); `post-merge-followup` chiave sull'**autore** della PR (invariato), non sul merger → l'App-as-merger non lo rompe.

PAT tenuto come fallback. Lint `gha-node-runtime` resta verde (nessuna action nuova).

## Non implementato (ancora)

- **`issue-triage` (routing label) + `followup-drainer`** → App||PAT: prossimo increment B2b-2.
- **`issue-fix` (identità PR-creation)** + aggiornamento capability-guard prompt (l'App ha `workflows:write`) → B2b-3.
- **App-auth-health monitor** (sostituto di `gh-pat-expiry-monitor`) → follow-up.
- **Rimozione PAT** → solo dopo smoke-test di un ciclo completo issue→fix→review→merge→deploy→followup sull'App.
- **Verifica live C1** (merge App → cascade deploy/followup): osservabile al primo merge via App post-merge di questa PR (questa stessa PR è mergiata dall'auto-merge → buon primo test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)