### PR TITLE
fix(seo): keep native canton for expired canton-drifted soft-landings

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9845,6 +9845,22 @@ ${staticAnalyticsHtml}
  // hreflang/canonical audits or OOMs, restore the `if (known) break`.
  const knownNorm = known ? known.replace(/\/+$/, '') : known;
  if (knownNorm === compatPath) break; // already the canonical path — no-op
+ // Native-canton-wins for EXPIRED slugs. COMPAT_JOB_PATTERNS above only match
+ // Ticino sections, so a canton-drifted job indexed under BOTH its native
+ // non-TI canton (e.g. Zurich — the canonical per `location` and the committed
+ // ledger) AND a legacy TI section would have its rich soft-landing HIJACKED
+ // onto the TI path, abandoning the native (indexed) URL to the thin cfHot404
+ // "Pagina archiviata" stub (observed: EFG "Internship – Business Management,
+ // Global Markets & Treasury" Zurich — /…-zurich/… served the stub while
+ // /…-ticino/… served the real content). Unlike the #2600 case below, an
+ // EXPIRED slug has NO active page covering its native canton, so the native
+ // ledger path is the ONLY rich page it will ever get: keep it. The drifted TI
+ // URL still recovers via the cfHot404 bridge, which resolves the slug's ledger
+ // canonical and emits a `canton-moved` bridge pointing at the native page.
+ // ACTIVE slugs (currentSlugs) keep the existing override: their native canton
+ // is already served by the live job page, so moving the soft-landing onto the
+ // drifted indexed URL is correct.
+ if (known && !currentSlugs.has(slug)) break;
  if (known) cantonDriftCompatSlugs.add(slug);
  (tracking[slug] as Record<string, string>)[locale] = compatPath;
  compatAdded++;

--- a/tests/soft-landing-seo.test.ts
+++ b/tests/soft-landing-seo.test.ts
@@ -54,6 +54,20 @@ describe('Soft-landing SEO pages for expired jobs', () => {
   it('includes expired jobs in sitemap at low priority', () => {
     expect(pluginSource).toContain('sitemap-jobs-expired.xml');
   });
+
+  it('keeps the native canton for EXPIRED canton-drifted slugs (no Ticino hijack)', () => {
+    // COMPAT_JOB_PATTERNS only match Ticino sections, so a canton-drifted job
+    // indexed under its native non-TI canton (e.g. Zurich) AND a legacy TI
+    // section used to have its rich soft-landing moved onto the TI path,
+    // abandoning the native indexed URL to the thin cfHot404 "Pagina archiviata"
+    // stub. The guard keeps the native ledger path for EXPIRED (non-current)
+    // slugs while preserving the #2600 override for ACTIVE slugs (whose native
+    // canton is already served by the live job page).
+    const driftStart = pluginSource.indexOf('Canton-drift recovery');
+    const guardIdx = pluginSource.indexOf('if (known && !currentSlugs.has(slug)) break;');
+    expect(driftStart).toBeGreaterThan(-1);
+    expect(guardIdx).toBeGreaterThan(driftStart);
+  });
 });
 
 describe('SPA does not override static HTML metadata for expired job pages', () => {


### PR DESCRIPTION
## Implementato

Fix del motivo per cui `https://frontaliereticino.ch/en/find-jobs-zurich/internship-business-management-global-markets-treasury-efg-zurich/` non serviva contenuto reale ma lo stub thin "Pagina archiviata".

**Root cause:** il merge dei GSC-404 compat-path nella pipeline expired-job soft-landing (`build-plugins/jobsSeoPagesPlugin.ts`) usa `COMPAT_JOB_PATTERNS` che riconoscono **solo le sezioni Ticino**. Per un job *canton-drifted* indicizzato sotto SIA il suo cantone nativo non-TI (Zurigo — canonico per `location` e per il ledger `all-known-job-slugs.json`) SIA una sezione TI legacy, il compat-path TI **sovrascriveva** il path nativo nel tracking → la soft-landing ricca veniva emessa sotto `/…-ticino/…`, abbandonando l'URL nativo (Zurigo, quello indicizzato) al solo bridge stub cfHot404.

**Change (chirurgico, 1 guard):** nel canton-drift override, salta la sovrascrittura per gli slug **EXPIRED** (non in `currentSlugs`): il loro path nativo nel ledger è l'unica pagina ricca che otterranno, quindi va preservato. L'URL TI driftato recupera comunque via il bridge cfHot404, che risolve il canonical dal ledger ed emette un bridge `canton-moved` puntando alla pagina nativa (logica già esistente in `resolveSearchConsoleCompatTarget` + `cfHot404BridgePlugin`, `slugIndex` da `all-known-job-slugs.json`). Gli slug **ACTIVE** mantengono l'override #2600 esistente (il loro cantone nativo è già servito dalla live job page).

- `build-plugins/jobsSeoPagesPlugin.ts`: aggiunto `if (known && !currentSlugs.has(slug)) break;` prima della sovrascrittura del canton-drift, con commento esplicativo.
- `tests/soft-landing-seo.test.ts`: test di regressione source-string che verifica la presenza del guard dentro la sezione "Canton-drift recovery".

**Effetto live atteso (post-deploy):** `/en/find-jobs-zurich/…-efg-zurich/` e i sibling-locale ZH serviranno la soft-landing ricca (descrizione reale del job scaduto); gli URL TI driftati diventeranno bridge `canton-moved` con canonical → pagina ZH nativa (consolidamento equity verso il cantone reale). Verificato pre-fix: `/cerca-lavoro-ticino/…-efg-zurich/` già serve contenuto reale (24KB), `/en/find-jobs-zurich/…` serviva lo stub 2.8KB.

## Non implementato (ancora)

- **Generalizzazione di `COMPAT_JOB_PATTERNS` a tutti i cantoni:** fuori scope. Il guard risolve la classe canton-drift-con-ledger-nativo (la più comune); i compat-path puramente non-TI senza ledger nativo restano non registrati come soft-landing diretta. Follow-up separato se emergono orfani non-TI senza ledger.
- **Sibling-class check (`scripts/ci/check-sibling-patterns.mjs`):** ha flaggato 7 file per token coincidenti (`cfHot404`, `currentSlugs`) — nessuno condivide l'antipattern reale (pattern compat solo-TI):
  - `build-plugins/cfHot404BridgePlugin.ts` è il *consumer* corretto (risolve già `canton-moved` via `slugIndex`), non l'antipattern.
  - `searchConsoleCompat.ts` (resolver) gestisce già tutti i cantoni genericamente (`JOB_BOARD_SECTION_COMPAT_PATTERN`).
  - `scripts/{backfill-expired-from-history,backfill-slug-aliases,update-eoc-jobs}.mjs` condividono solo il nome-variabile `currentSlugs`; logica scollegata.
  - `scripts/{build-cf-hot-404s,ingest-gsc-coverage-404s}` + workflow `discover-404s` costruiscono l'accumulator cf-hot-404, non emettono soft-landing. Nessun antipattern.
- **Validazione SSG emit:** l'emit soft-landing valida solo post-merge su `main` (full SEO build locale OOMa). **Revert-trigger:** se il prossimo deploy dist-affecting mostra `/en/find-jobs-zurich/…-efg-zurich/` ancora a stub, o un audit hreflang/canonical regredisce, → revert del guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
