### PR TITLE
fix(crawler): keep count-leading concorso titles on concorsi.ti.ch

### DIFF
--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -3781,9 +3781,17 @@ function extractRexxJobTitle(html) {
   // Concorsi.ti.ch layout is not fixed across announcements:
   // often h2[2] is just "33/26" and h2[3] is the real title.
   // Select the best semantic candidate instead of hard index.
-  const sectionRe = /^(compiti|requisiti|condizioni|scadenza|aufgaben|anforderungen)\s*:/i;
+  // Every content section heading on this portal ends with a colon
+  // (Requisiti:, Compiti:, Condizioni:, Scadenza:, Osservazioni particolari:,
+  // Documenti e condizioni di presentazione della candidatura:, Stipendio …:).
+  // Real job titles never end with a colon, so a trailing-colon check rejects the
+  // whole heading class — not just the few enumerated keywords (which previously
+  // let a long heading like "Documenti …:" win when the title lacked a preferred
+  // keyword). Kept in sync with SECTION_HEADING_RE in scripts/lib/tich-job-parser.mjs.
+  const sectionRe = /^(compiti|requisiti|condizioni|scadenza|osservazioni|documenti|stipendio|mansioni|profilo|aufgaben|anforderungen)\b/i;
   const candidates = h2s.filter((h) => (
     h.length > 20 &&
+    !/:\s*$/.test(h) &&
     !sectionRe.test(h) &&
     !/^\d+\/\d+$/.test(h.trim()) &&
     !/^dipartimento\b/i.test(h) &&

--- a/scripts/lib/tich-job-parser.mjs
+++ b/scripts/lib/tich-job-parser.mjs
@@ -61,6 +61,25 @@ const INSTITUTIONAL_RE =
   /^(Repubblica(\s+e\s+Cantone)?|Cantone\s+Ticino|Offerte?\s+d['']impieghi|Offerta\s+di\s+lavoro|Amministrazione\s+cantonale|Portal\s*7|Jobportal|Rexx|Sezione\s+delle\s+risorse|Foglio\s+Ufficiale|\d{1,3}\s*\/\s*\d{2,4}\s*$|Concorsi\s+per\s+(la\s+)?nomina|Dipartimento\b)/i;
 
 /**
+ * A concorso reference number such as "5/25" or "87 / 2026". These appear as a
+ * standalone heading before the position title and must be skipped. NOTE: this
+ * must NOT match real titles that merely *start* with a count, e.g.
+ * "1 Apprendista operatore/trice informatico/a AFC …" — the position count is a
+ * legitimate part of the concorso title.
+ */
+const CONCORSO_NUMBER_RE = /^\d{1,3}\s*\/\s*\d{2,4}\s*$/;
+
+/**
+ * Section headings of the job notice (Compiti, Requisiti, Condizioni, …). On the
+ * Rexx Systems Portal 7 page these render as their own headings and, when the
+ * real title is skipped, the first one ("Requisiti:") gets mis-picked as the
+ * title (FRO-70 follow-up). Every section heading on this portal ends with a
+ * colon and/or is one of these well-known labels, so reject the whole class.
+ */
+const SECTION_HEADING_RE =
+  /:\s*$|^(compiti|requisiti|condizioni|scadenza|osservazioni|documenti|stipendio|mansioni|profilo|aufgaben|anforderungen)\b/i;
+
+/**
  * Heading elements to try, in priority order, when extracting the title.
  * We skip any text that matches INSTITUTIONAL_RE or is too short/numeric.
  */
@@ -156,7 +175,8 @@ export function parseTichDetailPage(html = '') {
         if (
           text.length >= 10 &&
           !INSTITUTIONAL_RE.test(text) &&
-          !/^\d/.test(text) // skip pure numeric codes like "5/25"
+          !CONCORSO_NUMBER_RE.test(text) && // skip concorso numbers like "5/25" (but keep "1 Apprendista …")
+          !SECTION_HEADING_RE.test(text) // skip section headings like "Requisiti:"
         ) {
           title = text;
           break;

--- a/tests/tich-job-parser.test.ts
+++ b/tests/tich-job-parser.test.ts
@@ -357,3 +357,46 @@ describe('parseTichDetailPage / edge cases', () => {
     expect(shortDesc.length).toBeLessThan(0.25 * result.sourceBodyLength);
   });
 });
+
+// ─── parseTichDetailPage — count-leading title vs section heading (FRO-70 follow-up) ──
+// Real concorsi.ti.ch (Rexx Portal 7) detail pages render every heading as an
+// <h2 class="emp_nr_subtitle">. The actual title routinely starts with a position
+// count ("1 Apprendista …", "2 Collaboratori …"). The old `/^\d/` guard skipped
+// any heading starting with a digit, so the count-leading title was dropped and
+// the next heading "Requisiti:" was mis-picked as the job title.
+// Regression: https://www.concorsi.ti.ch/offerte-d'impieghi.html?yid=4203
+describe('parseTichDetailPage / count-leading title (emp_nr_subtitle)', () => {
+  const REAL_TITLE =
+    '1 Apprendista operatore/trice informatico/a AFC, per il periodo dal 31 agosto 2026 al 30 agosto 2029, presso il Centro dei sistemi informativi, Bellinzona';
+  const html = `<!DOCTYPE html>
+<html lang="it"><head>
+  <title>Offerta di lavoro ${REAL_TITLE} presso Amministrazione Cantonale Ticino Jobportal</title>
+</head><body>
+  <h1>Repubblica e Cantone Ticino</h1>
+  <div class="emp_nr_outerframe"><div class="emp_nr_innerframe">
+    <h2 class="emp_nr_subtitle">Dipartimento delle finanze e dell'economia</h2>
+    <h2 class="emp_nr_subtitle">87/26</h2>
+    <h2 class="emp_nr_subtitle">${REAL_TITLE}</h2>
+    <h2 class="emp_nr_subtitle">Requisiti:</h2>
+    <p>buona riuscita scolastica in matematica e scienze</p>
+    <h2 class="emp_nr_subtitle">Osservazioni particolari:</h2>
+    <p>sede scolastica: Centro Professionale Tecnico di Locarno</p>
+    <h2 class="emp_nr_subtitle">Documenti e condizioni di presentazione della candidatura:</h2>
+    <p>le candidature vanno inoltrate on-line sul sito www.ti.ch/concorsi</p>
+    <h2 class="emp_nr_subtitle">Scadenza:</h2>
+    <p>24 giugno 2026</p>
+  </div></div>
+</body></html>`;
+
+  const result = parseTichDetailPage(html);
+
+  it('extracts the count-leading concorso title, not the "Requisiti:" section heading', () => {
+    expect(result.title).toContain('Apprendista operatore/trice informatico');
+    expect(result.title).not.toBe('Requisiti:');
+    expect(result.title).not.toMatch(/:\s*$/); // never a section heading
+  });
+
+  it('does not pick any other section heading as the title', () => {
+    expect(result.title).not.toMatch(/^(Requisiti|Osservazioni|Documenti|Scadenza)/i);
+  });
+});


### PR DESCRIPTION
## Contesto

L'annuncio live [yid=4203](https://frontaliereticino.ch/cerca-lavoro-ticino/1-apprendista-operatore-trice-informatico-a-afc-per-il-periodo-dal-31-agosto-2026-al-30-agosto-2029-presso-il-centro-dei-sistemi-informativi-213hqz/) mostrava titolo **"Requisiti:"** invece di "1 Apprendista operatore/trice informatico/a AFC …".

Root cause: i titoli concorsi.ti.ch (Rexx Portal 7) iniziano spesso con un conteggio posti ("**1** Apprendista …", "2 Collaboratori …"). Il parser dedicato `parseTichDetailPage` saltava ogni heading che inizia con una cifra (`/^\d/`, pensato per i numeri concorso tipo "5/25") → il titolo veniva scartato e veniva preso l'heading successivo "Requisiti:". Verificato riproducendo l'HTML live: prima → `"Requisiti:"`, dopo → titolo reale.

## Implementato

- `scripts/lib/tich-job-parser.mjs`: sostituito il guard `/^\d/` con `CONCORSO_NUMBER_RE` preciso (`^\d{1,3}\s*/\s*\d{2,4}$`) che scarta SOLO i numeri concorso, non i titoli count-leading; aggiunto `SECTION_HEADING_RE` (colon finale + label note: Requisiti/Compiti/Condizioni/Scadenza/Osservazioni/Documenti/Stipendio/Mansioni/Profilo/Aufgaben/Anforderungen) per rifiutare l'intera classe di heading di sezione nello step di estrazione titolo.
- `scripts/lib/shared-jobs-crawler.mjs` (`extractRexxJobTitle`, sibling stessa classe — AGENTS.md #6): stesso guard trailing-colon + lista keyword estesa, così un titolo senza keyword "preferred" non può più perdere contro un heading lungo come "Documenti e condizioni di presentazione della candidatura:".
- `tests/tich-job-parser.test.ts`: 2 test di regressione che riproducono la struttura reale `emp_nr_subtitle` (titolo con conteggio iniziale + heading "Requisiti:" successivo) — asseriscono titolo reale e mai un heading di sezione. Suite 25/25 verde.

## Non implementato (ancora)

- **Estrazione della regex section-heading in un modulo condiviso**: i due parser operano in paradigmi diversi (regex su stringa vs JSDOM su DOM); l'estrazione aggiungerebbe coupling cross-modulo (tich-job-parser dipende solo da jsdom). Tenuti in parità con commento di cross-reference esplicito in entrambi. Follow-up se i due divergono di nuovo.
- **Auto-heal del dato già indicizzato per yid=4203**: `data/jobs.json` è generato in CI (non committato) e l'entry ha `crawledAt: 2026-06-09` (pre-fix) e non è stato ri-crawlato; il merge usa `...next` sul `title` quindi si auto-corregge al prossimo crawl che lo ri-scopre. La scadenza del concorso è 24 giugno 2026 (oggi) → probabile expire prima del ri-crawl. Nessuna modifica al dato possibile via repo (file gitignored).
- **Stima salario apprendistato** (`salaryMin 41600` su paga reale fr 550–950/mese): proviene dallo stimatore per-cantone/categoria, fuori scope di questo parser — eventuale follow-up dedicato.