### PR TITLE
fix(ads): desktop top-banner CLS-safe (no collapse-shift above the fold)

### DIFF
--- a/components/shared/DesktopTopBanner.tsx
+++ b/components/shared/DesktopTopBanner.tsx
@@ -38,9 +38,14 @@ export default function DesktopTopBanner() {
       sizes={TOP_BANNER_SIZES}
       killed={killed}
       minHeight={90}
-      // Desktop-only leaderboard, centred, full content width. `hidden` below
-      // lg so mobile/tablet render nothing (no reserve). GptAdSlot collapses to
-      // display:none on no-fill, so an empty slot leaves no band.
+      // CLS-safe: keep the 90px reserve even when unfilled. This slot sits ABOVE
+      // THE FOLD (above the H1); collapsing it on no-fill would yank the H1 and
+      // all content below upward and register a Cumulative Layout Shift (the
+      // "header jumps up after load" report). A stable 90px footprint is worth
+      // more than recovering a thin band when there's no demand.
+      collapseOnEmpty={false}
+      // Desktop-only leaderboard, centred, full content width. `hidden` below lg
+      // so mobile/tablet render nothing (no reserve, no band).
       className="hidden lg:block w-full text-center mb-4"
     />
   );

--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -116,6 +116,16 @@ export interface GptAdSlotProps {
    * blank column. Fires once per `slotRenderEnded`; default-noop when omitted.
    */
   onEmptyChange?: (empty: boolean) => void;
+  /**
+   * Whether to collapse the wrapper to `display:none` when GPT reports the slot
+   * empty. Default `true` (rails / below-content slots: an unfilled slot should
+   * vanish so it leaves no blank box). Set `false` for an ABOVE-THE-FOLD slot
+   * (e.g. the desktop top banner) where collapsing would yank the content below
+   * upward and register a Cumulative Layout Shift: there we keep the reserved
+   * `minHeight` so the slot's footprint never changes (CLS-safe), at the cost of
+   * a thin reserved band when no creative fills.
+   */
+  collapseOnEmpty?: boolean;
 }
 
 const GptAdSlot: React.FC<GptAdSlotProps> = ({
@@ -128,6 +138,7 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
   className = 'mx-auto my-6 w-full max-w-[336px] text-center',
   style,
   onEmptyChange,
+  collapseOnEmpty = true,
 }) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   // GPT slot + its slotRenderEnded handler, kept so unmount can tear both down
@@ -284,11 +295,15 @@ const GptAdSlot: React.FC<GptAdSlotProps> = ({
       ref={wrapperRef}
       aria-hidden={!rendered || empty}
       // Reserve space to avoid CLS when the creative fills (mirrors
-      // placeholderMinHeight in services/adsenseSlots.ts). Once GPT reports the
-      // slot empty we drop it from layout entirely (`display:none`) so it adds
-      // neither reserved height nor a flex-gap slot — keeping the side-rail
-      // stack gapless.
-      style={empty ? { display: 'none' } : { minHeight, contain: 'layout', ...style }}
+      // placeholderMinHeight in services/adsenseSlots.ts). When GPT reports the
+      // slot empty we normally drop it from layout entirely (`display:none`) so
+      // it adds neither reserved height nor a flex-gap slot — keeping the
+      // side-rail stack gapless. EXCEPTION: `collapseOnEmpty={false}` (the
+      // above-the-fold top banner) keeps the reserved `minHeight` even when
+      // empty, because collapsing it would pull the content below upward and
+      // register a CLS; a stable footprint is worth more than recovering a thin
+      // band there.
+      style={empty && collapseOnEmpty ? { display: 'none' } : { minHeight, contain: 'layout', ...style }}
       className={className}
     >
       <div id={divIdRef.current} />


### PR DESCRIPTION
## Implementato

Fix di un Cumulative Layout Shift introdotto dal top-banner (#2868): il banner riservava 90px sopra l'H1, ma `GptAdSlot` collassava il wrapper a `display:none` quando GPT segnalava lo slot vuoto (no-fill, ~7s) → l'H1 e tutto il contenuto sotto venivano tirati su = **shift above-the-fold** ("l'header sembra più in basso, poi si allinea/salta").

- Aggiunto opt-out `collapseOnEmpty` a `GptAdSlot` (default `true`, preserva il comportamento rail/below-content dove uno slot vuoto deve sparire senza lasciare banda).
- `DesktopTopBanner` passa `collapseOnEmpty={false}`: lo slot mantiene i 90px riservati anche se invenduto → **footprint stabile, zero CLS** sopra la piega. Trade-off: una banda riservata di 90px quando non c'è domanda (accettabile per un leaderboard premium above-the-fold che di norma riempie).

### Verifica
- `check-cls-ad-slots` verde (7/7), `tsc` pulito sui file toccati.
- Misurato live (PerformanceObserver layout-shift) su `/`: il banner riserva 90px stabili; rimosso il caso di collasso 90→0 che generava ~0.06 di CLS quando scattava.

## Non implementato (ancora) — CLS residuo PRE-ESISTENTE, da confermare

Misurando la home `/` ho trovato CLS totale ~0.10 (poor) con più sorgenti **non legate a questa PR**, che NON tocco alla cieca (rischio regressione su un gate CLS — vietato da AGENTS senza misura/conferma):
- **`#main-content` cresce in altezza ~6s dopo il load** (≈0.06): una sezione di contenuto sotto la piega che si espande (`BUTTON.w-full…` 50→169px, `UL.space-y-3…`). Probabile sezione lazy/FAQ che idrata tardi → spinge giù il footer.
- **Reposition precoce ~1s** (≈0.02): un elemento header/ticker che si sposta.
- **`autoad-top-reserve` (250px)**: riserva per l'Auto Ad Google in cima; se l'ad reale rende un'altezza diversa (es. 90 vs 250) il collasso/riallineamento genera lo shift "header basso → si allinea sotto l'ad". È il meccanismo anti-CLS documentato (#2190) e nelle mie sessioni headless l'Auto Ad non si inietta, quindi non l'ho potuto riprodurre/validare. Da indagare con una misura sul tuo browser (dove l'Auto Ad serve).

Proposta: un pass CLS dedicato su questi tre, con misura prima/dopo. Dimmi se procedo (in particolare conferma quale elemento vedi "saltare" sul tuo browser, così miro al colpevole giusto invece di toccare il reserve documentato a naso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)