### PR TITLE
feat(ci): data-refresh pushers via the GitHub App token (B2b tail 1/3)

### DIFF
--- a/.github/workflows/batch-faq-articles.yml
+++ b/.github/workflows/batch-faq-articles.yml
@@ -62,6 +62,17 @@ jobs:
       - name: Load RC secrets
         run: node scripts/load-rc-env.mjs
 
+      # App installation token = primary push identity so the data commit on main
+      # re-triggers deploy (GITHUB_TOKEN would not, anti-recursion). Falls back to
+      # env.GITHUB_PAT. B2b tail migration.
+      - name: Mint App token (primary identity, PAT fallback)
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
       - name: Verify GH_MODELS_PAT is set
         run: |
           if [ -z "$GH_MODELS_PAT" ]; then
@@ -114,7 +125,7 @@ jobs:
           git commit -m "❓ Auto-generated FAQ for ${MODIFIED} blog articles"
 
           # Push with retry (handles concurrent pushes from other workflows)
-          REMOTE_URL="https://x-access-token:${GITHUB_PAT}@github.com/${{ github.repository }}.git"
+          REMOTE_URL="https://x-access-token:${APP_TOKEN:-$GITHUB_PAT}@github.com/${{ github.repository }}.git"
           for attempt in 1 2 3; do
             if git push "$REMOTE_URL" HEAD:main; then
               echo "✅ Changes committed and pushed to main"

--- a/.github/workflows/refresh-bfs-stats.yml
+++ b/.github/workflows/refresh-bfs-stats.yml
@@ -57,6 +57,17 @@ jobs:
         # Loads GITHUB_PAT (used to dispatch generate-article.yml) from RC.
         run: node scripts/load-rc-env.mjs
 
+      # App installation token = primary dispatch identity (App tokens re-trigger
+      # workflows like generate-article; GITHUB_TOKEN would not, anti-recursion).
+      # Falls back to env.GITHUB_PAT then GITHUB_TOKEN. B2b tail migration.
+      - name: Mint App token (primary identity, PAT fallback)
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
       - name: Refresh BFS stats
         id: refresh
         run: node scripts/refresh-bfs-stats.mjs
@@ -94,7 +105,7 @@ jobs:
       - name: Dispatch generate-article (new quarter only)
         if: steps.refresh.outputs.new_quarter != ''
         env:
-          GH_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.APP_TOKEN || env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           NEW_QUARTER: ${{ steps.refresh.outputs.new_quarter }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then


### PR DESCRIPTION
## Implementato

**Workstream B — coda PAT, batch 1/3**. Migra i primi 2 workflow data-refresh che usano il PAT all'App GitHub (`frontaliere-automation[bot]`), così dispatch/push-dati ri-triggerano il downstream senza dipendere dal PAT mantenuto a mano:
- **`refresh-bfs-stats`**: token dispatch = `env.APP_TOKEN || env.GITHUB_PAT || secrets.GITHUB_TOKEN`.
- **`batch-faq-articles`**: token del push `REMOTE_URL` = `${APP_TOKEN:-$GITHUB_PAT}`.

Ognuno aggiunge lo step **Mint App token** (`scripts/ci/mint-app-token.mjs`). PAT tenuto come fallback. Lint `gha-node-runtime` verde (nessuna action nuova).

## Non implementato (ancora)

- **Batch 2/3** — i 3 data-refresh con error-check espliciti sul PAT (`refine-url-first-seen`, `refresh-shard-weights`, `traffic-data-freshness`): vanno migrati sistemando i guard `[ -z GITHUB_PAT ]` perché accettino App‖PAT (altrimenti fallirebbero loud con App presente ma PAT assente).
- **Batch 3/3** — azioni-PR (`auto-merge-sweep`, `pr-redflag-fixer`, `recycle-stale-prs`) + `pr-collision-detector` (GITHUB_TOKEN basta).
- **App-auth-health monitor** (sostituto di `gh-pat-expiry-monitor`).
- **Rimozione PAT** → solo dopo che tutta la coda è su App + smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)