### PR TITLE
feat(ci): PR-opener data-refresh via the GitHub App token (B2b tail 2/3)

### DIFF
--- a/.github/workflows/refine-url-first-seen.yml
+++ b/.github/workflows/refine-url-first-seen.yml
@@ -103,6 +103,19 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
         run: node scripts/load-rc-env.mjs
 
+      # App installation token = primary push/PR identity (re-triggers review/CI;
+      # GITHUB_TOKEN would not, anti-recursion). Uses Actions secrets APP_ID/
+      # APP_PRIVATE_KEY (not Firebase), so it works even after Cleanup SA. Falls
+      # back to env.GITHUB_PAT. B2b tail migration.
+      - name: Mint App token (primary identity, PAT fallback)
+        if: inputs.dry_run == 'false'
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
       - name: Cleanup SA
         if: always()
         run: rm -f /tmp/sa.json /tmp/firebase-sa.json
@@ -114,14 +127,14 @@ jobs:
           # RC, NOT an Actions secret — `secrets.GH_PAT` does not exist). Used
           # for BOTH the branch push and `gh pr create`: a PR created with
           # secrets.GITHUB_TOKEN is blocked by anti-recursion (issue #1114).
-          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GH_TOKEN: ${{ env.APP_TOKEN || env.GITHUB_PAT }}
         run: |
           if git diff --quiet data/url-first-seen.json; then
             echo "No diff in data/url-first-seen.json — nothing to PR."
             exit 0
           fi
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GITHUB_PAT not loaded from Remote Config — cannot create PR (a secrets.GITHUB_TOKEN PR is blocked by anti-recursion). Check Firebase SA / RC availability."
+            echo "::error::No App/PAT token (Firebase RC / App creds) — cannot create PR (a secrets.GITHUB_TOKEN PR is blocked by anti-recursion). Check APP_ID/APP_PRIVATE_KEY or Firebase SA / RC availability."
             exit 1
           fi
           BRANCH="chore/url-first-seen-refresh-${GITHUB_RUN_ID}"

--- a/.github/workflows/refresh-shard-weights.yml
+++ b/.github/workflows/refresh-shard-weights.yml
@@ -98,6 +98,18 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
         run: node scripts/load-rc-env.mjs
 
+      # App installation token = primary PR identity (re-triggers tests gate;
+      # GITHUB_TOKEN would not, anti-recursion). Uses Actions secrets (not
+      # Firebase) so it survives Cleanup SA. Falls back to env.GITHUB_PAT.
+      - name: Mint App token (primary identity, PAT fallback)
+        if: inputs.dry_run != 'true'
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
       - name: Cleanup SA
         if: always()
         run: rm -f /tmp/firebase-sa.json
@@ -108,7 +120,7 @@ jobs:
           # GITHUB_PAT loaded into $GITHUB_ENV above (Firebase RC, not an Actions
           # secret). A PR opened with secrets.GITHUB_TOKEN is blocked by
           # anti-recursion AND would not trigger the tests gate.
-          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GH_TOKEN: ${{ env.APP_TOKEN || env.GITHUB_PAT }}
         run: |
           set -euo pipefail
           if git diff --quiet tests/shard-weights.json; then
@@ -116,7 +128,7 @@ jobs:
             exit 0
           fi
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GITHUB_PAT not loaded from Remote Config — cannot open PR."
+            echo "::error::No App/PAT token — cannot open PR (GITHUB_TOKEN blocked by anti-recursion). Check APP_ID/APP_PRIVATE_KEY or Firebase RC."
             exit 1
           fi
           BRANCH="chore/shard-weights-refresh-${GITHUB_RUN_ID}"


### PR DESCRIPTION
## Implementato

**Workstream B — coda PAT, batch 2/3**. Migra all'App (`frontaliere-automation[bot]`) i 2 data-refresh che **aprono una PR** (così la PR auto-aperta ri-triggera review/CI senza dipendere dal PAT):
- **`refine-url-first-seen`**, **`refresh-shard-weights`**: token PR/push = `env.APP_TOKEN || env.GITHUB_PAT`.

Ognuno aggiunge lo step **Mint App token** (secrets `APP_ID`/`APP_PRIVATE_KEY` — non Firebase — quindi sopravvive al `Cleanup SA`), e il guard fail-loud ora accetta App **o** PAT (controlla il `GH_TOKEN` risolto). PAT fallback; lint verde.

## Non implementato (ancora)

- **Batch 3/3**: `traffic-data-freshness` (usa `scripts/lib/trigger-self.sh` — va ispezionato quale var legge), + azioni-PR `auto-merge-sweep`/`pr-redflag-fixer`/`recycle-stale-prs`, + `pr-collision-detector` (GITHUB_TOKEN basta).
- **App-auth-health monitor** + **rimozione PAT** (dopo smoke-test completo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)