### PR TITLE
feat(ads): box ad in the calculator input column (fills trailing whitespace)

### DIFF
--- a/components/calculator/InputCard.tsx
+++ b/components/calculator/InputCard.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '../../services/i18n';
 import { useNavigationOptional } from '@/services/NavigationContext';
 import { resilientImport } from '@/services/resilientImport';
 import { SegmentControl as SharedSegmentControl } from '@/components/shared/SegmentControl';
+import CalculatorFormBoxAd from '@/components/shared/CalculatorFormBoxAd';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { reportCaughtError } from '@/services/errorReporter';
 // exchangeRateService is lazy-loaded to reduce main bundle size
@@ -1094,6 +1095,11 @@ const InputCardBase: React.FC<Props> = ({ inputs, setInputs, onCalculate, focusF
  <Shield size={12} className="text-success flex-shrink-0 mt-0.5" />
  <p className="text-xs text-success leading-relaxed">{t('input.dataDisclaimer')}</p>
  </div>
+
+ {/* Box ad filling the trailing white space of the input column. Last child
+ of the scrollable column → a fill grows the column's own scroll area and
+ shifts no page content (CLS-safe); collapses when unsold. */}
+ <CalculatorFormBoxAd />
 
  </div>
  )}

--- a/components/shared/CalculatorFormBoxAd.tsx
+++ b/components/shared/CalculatorFormBoxAd.tsx
@@ -1,0 +1,39 @@
+/**
+ * CalculatorFormBoxAd — dedicated GPT/GAM box at the bottom of the calculator
+ * input column.
+ *
+ * Fills the white space below the form when the input column is shorter than
+ * the results column. Serves `/23355151813/calculator-form-box` (300x250 /
+ * 336x280 + fluid) via GptAdSlot.
+ *
+ * CLS-safe by POSITION: it is the LAST element in the scrollable input column,
+ * so filling it only extends the column's own scroll area — it pushes nothing
+ * below it on the page (minHeight 0 = no reserved band). Collapses to
+ * display:none when unsold (default GptAdSlot behaviour) so it never leaves
+ * white space when there is no demand.
+ *
+ * GPT (pubads) is independent of adsbygoogle.js → Auto Ads keep serving
+ * untouched (AGENTS §7). Runtime kill-switch: Firebase Remote Config
+ * `KILL_CALCULATOR_FORM_BOX` (~1 min, no redeploy; default-safe = shown).
+ */
+import GptAdSlot, { type GptSize } from '@/components/shared/GptAdSlot';
+import { useKillSwitches } from '@/hooks/useKillSwitches';
+
+const FORM_BOX_UNIT_PATH = '/23355151813/calculator-form-box';
+const FORM_BOX_SIZES: GptSize[] = [[300, 250], [336, 280], 'fluid'];
+
+export default function CalculatorFormBoxAd() {
+  const { calculatorFormBox: killed } = useKillSwitches();
+  return (
+    <GptAdSlot
+      adUnitPath={FORM_BOX_UNIT_PATH}
+      sizes={FORM_BOX_SIZES}
+      killed={killed}
+      // No reserved band: the slot is the last child of a scrollable column, so
+      // a fill grows the column's scroll area without shifting page content
+      // (CLS-safe by position). Collapses when unsold → no white space.
+      minHeight={0}
+      className="mx-5 mb-5 mt-2 w-full flex justify-center"
+    />
+  );
+}

--- a/hooks/useKillSwitches.ts
+++ b/hooks/useKillSwitches.ts
@@ -32,6 +32,7 @@ export type KillSwitchKey =
   | 'gptPocSlot'
   | 'articleRailAds'
   | 'desktopTopBanner'
+  | 'calculatorFormBox'
   | 'headerBidding';
 
 export type KillSwitchState = Readonly<Record<KillSwitchKey, boolean>>;
@@ -50,6 +51,7 @@ export const KILL_SWITCH_RC_KEYS: Readonly<Record<KillSwitchKey, string>> = {
   gptPocSlot: 'KILL_GPT_POC_SLOT',
   articleRailAds: 'KILL_ARTICLE_RAIL_ADS',
   desktopTopBanner: 'KILL_DESKTOP_TOP_BANNER',
+  calculatorFormBox: 'KILL_CALCULATOR_FORM_BOX',
   headerBidding: 'KILL_HEADER_BIDDING',
 } as const;
 
@@ -62,6 +64,7 @@ const DEFAULT_STATE: KillSwitchState = {
   gptPocSlot: false,
   articleRailAds: false,
   desktopTopBanner: false,
+  calculatorFormBox: false,
   headerBidding: false,
 } as const;
 

--- a/scripts/gam-create-ad-units.mjs
+++ b/scripts/gam-create-ad-units.mjs
@@ -46,6 +46,7 @@ const TARGETS = [
   { adUnitCode: 'article-rail-left', name: 'Article rail — left (desktop)', sizes: [[300, 600], [160, 600], [300, 250]], isFluid: true },
   { adUnitCode: 'article-rail-right', name: 'Article rail — right (desktop)', sizes: [[300, 600], [160, 600], [300, 250]], isFluid: true },
   { adUnitCode: 'desktop-top-banner', name: 'Desktop top banner', sizes: [[970, 90], [728, 90]], isFluid: false },
+  { adUnitCode: 'calculator-form-box', name: 'Calculator form box', sizes: [[300, 250], [336, 280]], isFluid: true },
 ];
 
 const saPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -86,6 +86,9 @@ const REMOTE_CONFIG_DEFAULTS: Record<string, string> = {
  // 'false' = shown. Flip to 'true' to kill it within ~1 min (no redeploy);
  // Auto Ads keep serving untouched.
  KILL_DESKTOP_TOP_BANNER: 'false',
+ // Calculator form box (dedicated GPT/GAM 300x250 at the bottom of the
+ // calculator input column). Default 'false' = shown; collapses when unsold.
+ KILL_CALCULATOR_FORM_BOX: 'false',
  // Header-bidding (Prebid) pre-auction on the explicit GPT slots. Default
  // 'false' = auction allowed (still gated by PREBID_ENABLED in
  // services/headerBidding.ts). Flip to 'true' to disable Prebid within ~1 min

--- a/tests/use-kill-switches.test.ts
+++ b/tests/use-kill-switches.test.ts
@@ -26,6 +26,7 @@ describe('useKillSwitches', () => {
       gptPocSlot: false,
       articleRailAds: false,
       desktopTopBanner: false,
+      calculatorFormBox: false,
       headerBidding: false,
     });
   });
@@ -75,6 +76,7 @@ describe('useKillSwitches', () => {
       gptPocSlot: true,
       articleRailAds: false,
       desktopTopBanner: false,
+      calculatorFormBox: false,
       headerBidding: false,
     });
   });
@@ -85,7 +87,7 @@ describe('useKillSwitches', () => {
     renderHook(() => useKillSwitches());
 
     await waitFor(() => {
-      expect(rcMock).toHaveBeenCalledTimes(9);
+      expect(rcMock).toHaveBeenCalledTimes(10);
     });
 
     const callArgs = rcMock.mock.calls.map(([arg]) => arg);
@@ -97,6 +99,7 @@ describe('useKillSwitches', () => {
     expect(callArgs).toContain('KILL_GPT_POC_SLOT');
     expect(callArgs).toContain('KILL_ARTICLE_RAIL_ADS');
     expect(callArgs).toContain('KILL_DESKTOP_TOP_BANNER');
+    expect(callArgs).toContain('KILL_CALCULATOR_FORM_BOX');
     expect(callArgs).toContain('KILL_HEADER_BIDDING');
   });
 });


### PR DESCRIPTION
## Implementato

Problema 1 (tuo): lo spazio bianco in fondo alla colonna del form calcolatore (su desktop la colonna input è spesso più corta della colonna risultati). Riempito con un box ad dedicato, **subito dopo la nota privacy** (come richiesto).

- **GAM**: nuovo unit `/23355151813/calculator-form-box` (300×250 + 336×280 + fluid), creato via `gam-create-ad-units.mjs` (id 23357347233, verificato con `--dry-run`).
- **`CalculatorFormBoxAd`** lo serve via `GptAdSlot`, montato come **ultimo figlio della colonna input scrollabile** (`components/calculator/InputCard.tsx`), subito dopo il disclaimer `input.dataDisclaimer`.
- **CLS-safe by position**: `minHeight 0` + ultimo elemento in un contenitore `overflow-y-auto` → un fill estende solo lo scroll della colonna, **non sposta nessun contenuto di pagina** (zero CLS). **Collassa** (`display:none`) quando invenduto → nessuno spazio bianco senza domanda (come volevi).
- **Kill-switch** `KILL_CALCULATOR_FORM_BOX` (`useKillSwitches` + RC default). GPT indipendente da `adsbygoogle.js` → **Auto Ads intatti** (AGENTS §7), additivo.

### Verifica
- 16/16 test verdi (`use-kill-switches` aggiornato 9→10 switch, `check-cls-ad-slots`, `kill-switches-conditional-render`).
- `tsc` pulito sui file toccati.
- Unit GAM creato e confermato (`= reuse calculator-form-box id=23357347233`).

## Non implementato (ancora)

- **CLS top (problema 2)**: il fix del mio banner (CLS-safe, no collasso-shift) è già mergiato in #2894. Il resto del salto in cima che hai visto negli screenshot è **Google Auto Ads** che impilano slot in alto (riserva 250px × più ad) e poi collassano — meccanismo anti-CLS documentato (#2190), rischioso da toccare alla cieca e non riproducibile in headless. Da rimisurare **dopo che #2894 è live** prima di intervenire sul reserve.
- **Box solo sul layout desktop del form** (quello con `mx-5 mb-5`/`space-y-4`, che hai segnalato). Se lo vuoi anche sull'altro layout (`mx-2`) lo aggiungo in follow-up.
- **Fill non forzabile**: dipende dalla domanda; se vuoto, collassa (niente banda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)