### PR TITLE
fix(ci): whitelist github-actions[bot] in post-merge-followup triage

### DIFF
--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -86,6 +86,11 @@ jobs:
           REPO: ${{ github.repository }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Schedule/manual-dispatch → actor umano (owner) oggi, ma stesso
+          # class-fix dei sibling: se un'automation interna dispatchasse questo
+          # workflow via GITHUB_TOKEN (actor `github-actions[bot]`) senza
+          # whitelist, claude-code-action aborterebbe "non-human actor". Mai `*`.
+          allowed_bots: "github-actions[bot], claude[bot]"
           show_full_output: true
           claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
           prompt: |

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -87,6 +87,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Questo workflow viene dispatchato anche da automation interna
+          # (self-retry step "Retry once" + cascade post-LGTM via GITHUB_TOKEN
+          # → actor `github-actions[bot]`): senza whitelist claude-code-action
+          # aborta con "Workflow initiated by non-human actor" (run 28111857700
+          # exit 1). Whitelist esplicita (mai `*`), allineata ai sibling
+          # pr-review-loop / pr-redflag-fixer / issue-fix.
+          allowed_bots: "github-actions[bot], claude[bot]"
           show_full_output: true
           # max-turns 20 (era 15): il triage completo (parse PR body + reviews,
           # filtro churn/funnel, dedup, in-flight overlap, gh issue create)

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -87,13 +87,20 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Questo workflow viene dispatchato anche da automation interna
-          # (self-retry step "Retry once" + cascade post-LGTM via GITHUB_TOKEN
-          # → actor `github-actions[bot]`): senza whitelist claude-code-action
-          # aborta con "Workflow initiated by non-human actor" (run 28111857700
-          # exit 1). Whitelist esplicita (mai `*`), allineata ai sibling
-          # pr-review-loop / pr-redflag-fixer / issue-fix.
-          allowed_bots: "github-actions[bot], claude[bot]"
+          # Questo workflow viene ri-triggerato (on: pull_request: closed) da
+          # automation interna, con DUE actor bot distinti — entrambi vanno in
+          # whitelist o claude-code-action aborta "Workflow initiated by
+          # non-human actor":
+          #  - `frontaliere-automation[bot]`: actor del path PRIMARIO di cascade
+          #    post-LGTM. `auto-merge-on-lgtm.yml` mergia con
+          #    `MERGE_PRIMARY_TOKEN = APP_TOKEN || GITHUB_PAT || GITHUB_TOKEN`;
+          #    col token della GitHub App il merge-push porta actor App → è il
+          #    caso comune. Stesso motivo per cui issue-fix.yml lo include.
+          #  - `github-actions[bot]`: self-retry step "Retry once" (L154
+          #    `gh workflow run` via GITHUB_TOKEN, run 28111857700 exit 1) +
+          #    fallback merge su GITHUB_TOKEN.
+          # `claude[bot]` per simmetria coi sibling. Mai `*`.
+          allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
           # max-turns 20 (era 15): il triage completo (parse PR body + reviews,
           # filtro churn/funnel, dedup, in-flight overlap, gh issue create)


### PR DESCRIPTION
## Implementato

Risolve il fallimento del job **Post-merge follow-up triage** ([run 28111857700](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28111857700/job/83241079956), exit 1):

> `Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

Causa: `post-merge-followup.yml` (`on: pull_request: closed` + self-retry) viene ri-triggerato da automation interna con actor bot, ma lo step `Run Claude follow-up triage` (`claude-code-action@v1`) non aveva `allowed_bots` → l'action rifiuta gli actor bot e abortisce.

- **`.github/workflows/post-merge-followup.yml`**: aggiunto `allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"`. Due actor distinti vanno coperti:
  - **`frontaliere-automation[bot]`** — actor del path **primario** di cascade post-LGTM: `auto-merge-on-lgtm.yml` mergia con `MERGE_PRIMARY_TOKEN = APP_TOKEN` (GitHub App), e quel merge-push ri-triggera il `pull_request: closed`. Stesso motivo per cui `issue-fix.yml:L192` lo include già.
  - **`github-actions[bot]`** — self-retry step `Retry once` (`gh workflow run` via `GITHUB_TOKEN`, l'actor del run 28111857700) + fallback merge su `GITHUB_TOKEN`.
  - `claude[bot]` per simmetria coi sibling. Mai `*`.
- **`.github/workflows/lessons-harvester.yml`**: aggiunto `allowed_bots: "github-actions[bot], claude[bot]"` — era l'ultimo workflow `claude-code-action` privo dell'input (class-fix AGENTS.md #6). Gira solo su schedule/dispatch con actor umano oggi.

Audit post-fix: tutti e 5 i workflow `anthropics/claude-code-action` impostano `allowed_bots`. YAML validato con `yaml.safe_load`.

## Non implementato (ancora)

- **`frontaliere-automation[bot]` NON aggiunto a `lessons-harvester.yml`**: quel workflow è triggerato solo da `schedule`/`workflow_dispatch`, mai dal merge-cascade via token App → l'actor App non è un suo trigger. Coperto da `github-actions[bot]` (eventuale dispatch via GITHUB_TOKEN). Aggiungerlo sarebbe rumore non giustificato dal trigger model.
- Nessuna validazione live: verificabile solo al prossimo merge-cascade / self-retry del workflow — osservabile post-merge su `main`. Solo gating dell'actor, nessun cambiamento di logica di triage.