### PR TITLE
fix(seo): stop en/de/fr svizzera article sections leaking into spa-locale title-length ratchet

### DIFF
--- a/scripts/audit-dist-multi.mjs
+++ b/scripts/audit-dist-multi.mjs
@@ -39,6 +39,7 @@ import { createHash } from 'node:crypto';
 import { TYPES_ACCEPT_IN_LANGUAGE_LIST } from '../services/seo/inlanguage-whitelist.data.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
+import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -319,7 +320,7 @@ function classifyFeatureRatio(relPath) {
   if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board'; // canton-aware (shared matcher)
   if (/(?:^|\/)(?:premi-cassa-malati|health-insurance-premiums|health-premiums|krankenkassenpraemien|krankenkassen-praemien|primes-assurance-maladie|primes-assurance-maladie-communes|primi-cassa-malati-comuni)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|tessin-arbeitsmarkt|marche-travail-tessin|tessin-marche-emploi|mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane|tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
@@ -334,7 +335,7 @@ function classifyFeatureTitle(relPath) {
   if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board'; // canton-aware (shared matcher)
   if (/(?:^|\/)(?:premi-cassa-malati|cassa-malati|health-premiums|health-insurance|krankenkassen-praemien|krankenkasse|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
@@ -349,7 +350,7 @@ function classifyFeatureH1(relPath) {
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|firmen-die-einstellen|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers-hub';
   if (/(?:^|\/)(?:premi-cassa-malati|health-premiums|krankenkassen-praemien|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';

--- a/scripts/audit-page-weight.mjs
+++ b/scripts/audit-page-weight.mjs
@@ -18,6 +18,7 @@ import { writeAuditReport } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
+import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
 // 215 KB cap (was 200 KB). The TI job-board landing
 // /cerca-lavoro-ticino/index.html crossed the original 200 KB cap on run
@@ -61,7 +62,7 @@ function featureForPath(relPath) {
   if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\//.test(p)) return 'weekly-employers';
   if (FUEL_SECTION_RX.test(p)) return 'fuel-daily';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane)\//.test(p)) return 'border-wait';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -23,6 +23,7 @@ import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { EJP_STRIPPED_MARKER } from '../build-plugins/shared/ejpMarker.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
+import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
@@ -78,7 +79,7 @@ function classifyFeature(relPath) {
   if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:premi-cassa-malati|health-insurance-premiums|health-premiums|krankenkassenpraemien|krankenkassen-praemien|primes-assurance-maladie|primes-assurance-maladie-communes|primi-cassa-malati-comuni)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|tessin-arbeitsmarkt|marche-travail-tessin|tessin-marche-emploi|mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|blog|articles)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane|tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/(?:^|\/)(?:meteo-frontalieri|commute-weather|pendler-wetter|meteo-frontaliers|allerte-meteo|weather-alerts|wetter-warnungen|alertes-meteo)\//.test(p)) return 'weather';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -35,6 +35,7 @@ import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
+import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
@@ -72,7 +73,7 @@ export function classifyFeature(relPath) {
   if (JOB_BOARD_SECTION_RX.test(p)) return 'job-board';
   if (/(?:^|\/)(?:premi-cassa-malati|cassa-malati|health-premiums|health-insurance|krankenkassen-praemien|krankenkasse|primes-assurance-maladie)\//.test(p)) return 'health-premiums';
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
-  if (/(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier)\//.test(p)) return 'blog';
+  if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';

--- a/scripts/lib/articleSections.mjs
+++ b/scripts/lib/articleSections.mjs
@@ -1,0 +1,62 @@
+/**
+ * Shared blog/article section matcher.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Shared "is this dist path under an editorial article section?" matcher,
+ * extracted per CLAUDE.md non-negotiable #6 (a regex duplicated literally in
+ * ≥2 files → one shared module) so the locale-section drift that caused the
+ * 2026-06-24 post-deploy `title-length` failure (`spa-locale 91>90`) stops
+ * recurring. Same drift class the `fuelSections.mjs` extraction (#2853) fixed
+ * for fuel pages and `jobBoardSections.mjs` (#1300+) fixed for job pages.
+ *
+ * Why this exists.
+ *   The site emits two parallel article sections, each with one localized hub
+ *   slug per locale (services/articleSections.ts → `ARTICLE_SECTIONS[*].indexSlug`):
+ *
+ *               it                     en                  de                 fr
+ *     fronta.:  articoli-frontaliere   cross-border-articles  grenzgaenger-artikel  articles-frontalier
+ *     svizzera: articoli-svizzera      swiss-articles         schweiz-artikel       articles-suisse
+ *
+ *   The audit feature-classifiers each inlined this alternation, but only ever
+ *   listed the `frontaliere` slugs — the `svizzera` mirror section (PR #1173)
+ *   shipped its localized hub/archive landings (`/en/swiss-articles/…`,
+ *   `/de/schweiz-artikel/…`, `/fr/articles-suisse/…`) afterwards and was never
+ *   added. Those en/de/fr svizzera article pages therefore fell through to the
+ *   generic `spa-locale` (en/de/fr) bucket instead of `blog`. As the svizzera
+ *   section grew, their long keyword-rich titles drifted the volatile
+ *   `spa-locale` title-length ratchet over its cap on a normal article batch,
+ *   with no real SEO change — the same false-positive class as the fuel leak.
+ *   (`blog`, the correct bucket, carries deliberate headroom for exactly this
+ *   data-volatile article growth, so reclassifying them there is behaviour-
+ *   correct, not a gate relaxation.)
+ *
+ * Keeping the bucket correct.
+ *   `BLOG_SECTION_RX` lists every CURRENT canonical hub slug for BOTH sections.
+ *   It MUST stay in sync with `ARTICLE_SECTIONS[*].indexSlug` in
+ *   services/articleSections.ts — a new section or locale hub slug shipped
+ *   there must be added here in the same change.
+ *
+ * Consumers: the audit feature-classifiers `audit-title-length` (re-exported to
+ * `audit-h1-title-duplicates` + `audit-title-no-disambig-hash`),
+ * `audit-text-html-ratio`, `audit-page-weight`, and `audit-dist-multi`.
+ */
+
+/**
+ * Matches the leading editorial-article section segment of a normalised dist
+ * path (a path beginning with `/`, optionally locale-prefixed `/en|/de|/fr`).
+ * Anchors on a path boundary and stops at the next `/`, so it only ever
+ * classifies the SECTION segment — deeper, more specific buckets are checked
+ * before this in every classifier and still win.
+ */
+export const BLOG_SECTION_RX =
+  /(?:^|\/)(?:articoli-frontaliere|cross-border-articles|grenzgaenger-artikel|articles-frontalier|articoli-svizzera|swiss-articles|schweiz-artikel|articles-suisse)\//;
+
+/**
+ * @param {string} normalisedPath path that already starts with `/` and has had
+ *   the `dist/` prefix and trailing `index.html` stripped (the form the audit
+ *   classifiers build before bucketing).
+ * @returns {boolean} true when the path is under any editorial article section
+ *   (frontaliere or svizzera, any locale).
+ */
+export function isBlogSectionPath(normalisedPath) {
+  return BLOG_SECTION_RX.test(normalisedPath);
+}

--- a/tests/seo/article-section-classifier.test.ts
+++ b/tests/seo/article-section-classifier.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Guard for the editorial-article section matcher (scripts/lib/articleSections.mjs)
+ * and the audit feature classifier that consumes it (scripts/audit-title-length.mjs
+ * → also imported by audit-h1-title-duplicates + audit-title-no-disambig-hash;
+ * mirrored in audit-text-html-ratio, audit-page-weight, audit-dist-multi).
+ *
+ * Regression context (2026-06-24 post-deploy validate-dist failure `spa-locale 91>90`):
+ * the title-length classifier's `blog` regex only ever listed the `frontaliere`
+ * article-section slugs. The parallel `svizzera` mirror section (PR #1173) ships
+ * its own localized hub/archive landings (`/en/swiss-articles/…`,
+ * `/de/schweiz-artikel/…`, `/fr/articles-suisse/…` — see services/articleSections.ts
+ * ARTICLE_SECTIONS.svizzera.indexSlug) but was never added, so those en/de/fr
+ * svizzera article pages fell into the volatile `spa-locale` bucket instead of
+ * `blog` and drifted its ratchet over cap on a normal article batch, with no real
+ * SEO change. They must classify as `blog` (the article bucket, with deliberate
+ * data-volatile headroom) for EVERY locale, and the matcher must stay in sync
+ * with ARTICLE_SECTIONS so the drift cannot recur. Same class as the fuel-section
+ * leak (#2853) and the job-board section leak (#1300+).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyFeature } from '../../scripts/audit-title-length.mjs';
+import { isBlogSectionPath, BLOG_SECTION_RX } from '../../scripts/lib/articleSections.mjs';
+
+// classifyFeature takes a dist-relative path (with `dist/` prefix + index.html).
+const rel = (p: string) => `dist${p}index.html`;
+
+describe('editorial-article section matcher', () => {
+  const articlePaths = [
+    // frontaliere section (already matched before the fix — must keep matching)
+    '/articoli-frontaliere/come-funziona-il-conguaglio/',
+    '/en/cross-border-articles/some-long-keyword-rich-headline/',
+    '/de/grenzgaenger-artikel/lange-ueberschrift/',
+    '/fr/articles-frontalier/titre-long/',
+    // svizzera section (the leak — en/de/fr were drifting into spa-locale)
+    '/articoli-svizzera/panoramica-cantoni/',
+    '/en/swiss-articles/a-very-long-switzerland-wide-section-headline/',
+    '/de/schweiz-artikel/eine-lange-schweizweite-ueberschrift/',
+    '/fr/articles-suisse/un-titre-suisse-tres-long/',
+  ];
+
+  it.each(articlePaths)('classifies %s as blog', (p) => {
+    expect(isBlogSectionPath(p)).toBe(true);
+    expect(classifyFeature(rel(p))).toBe('blog');
+  });
+
+  // Every CURRENT canonical hub slug from ARTICLE_SECTIONS[*].indexSlug must
+  // match — the sync invariant that prevents the svizzera (and any future
+  // section/locale) drift from recurring.
+  const canonicalHubSlugs = [
+    'articoli-frontaliere', 'cross-border-articles', 'grenzgaenger-artikel', 'articles-frontalier',
+    'articoli-svizzera', 'swiss-articles', 'schweiz-artikel', 'articles-suisse',
+  ];
+  it.each(canonicalHubSlugs)('matches canonical hub slug %s', (slug) => {
+    expect(isBlogSectionPath(`/${slug}/`)).toBe(true);
+    expect(isBlogSectionPath(`/en/${slug}/x/`)).toBe(true);
+  });
+
+  const nonArticlePaths = [
+    // Non-article en/de/fr landings that legitimately STAY in spa-locale.
+    '/fr/salaires-schaffhouse/',
+    '/en/tax/',
+    '/de/grenzgaenger-ratgeber/versteckte-kosten-chf-eur-wechselkurs/',
+    // Fuel pages keep their own bucket, not blog.
+    '/fr/prix-gasoil-suisse/italie/bardello-con-malgesso-e-bregano/aujourd-hui/',
+    // Profession-canton job landings keep their own bucket.
+    '/en/jobs-zurich-cook/',
+  ];
+  it.each(nonArticlePaths)('does NOT classify %s as blog', (p) => {
+    expect(isBlogSectionPath(p)).toBe(false);
+    expect(classifyFeature(rel(p))).not.toBe('blog');
+  });
+
+  it('regex is anchored on a path boundary (no mid-segment false match)', () => {
+    // A deeper segment merely containing "articles" mid-word must not match.
+    expect(BLOG_SECTION_RX.test('/en/swiss-articles-archive-old/')).toBe(false);
+    // The hub slug needs a trailing `/` (a bare slug with no child is the hub
+    // index itself, classified elsewhere — must not partial-match).
+    expect(BLOG_SECTION_RX.test('/en/swiss-articles')).toBe(false);
+  });
+
+  it('validator form: "/" + dist-relative path matches the article section', () => {
+    expect(isBlogSectionPath('/' + 'en/swiss-articles/x/index.html')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Contesto

Post-deploy **validate-dist** rosso sul gate `title-length`:
`❌ FAIL title-length — 2148 offender(s) over threshold 66 — regressed features: spa-locale(91>90)`
(run [28117604304](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28117604304); il run successivo [28120871542](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28120871542) è crashato su ENOSPC — runner difettoso, vedi sotto — prima di rieseguire gli audit).

**Root cause = stessa classe di drift del fuel-leak #2853.** I classifier feature degli audit-ratchet listavano nel bucket `blog` solo gli slug della sezione articoli `frontaliere`. La sezione mirror `svizzera` (PR #1173) emette i propri hub/archive localizzati (`/en/swiss-articles/…`, `/de/schweiz-artikel/…`, `/fr/articles-suisse/…` — vedi `services/articleSections.ts` `ARTICLE_SECTIONS.svizzera.indexSlug`) mai aggiunti ai classifier → le pagine articolo en/de/fr svizzera cadevano nel bucket volatile catch-all `spa-locale` invece di `blog`, facendo driftare il suo ratchet oltre cap (91>90) su un normale batch di articoli, senza alcun cambiamento SEO reale.

## Implementato

- Estratto il matcher degli hub-slug di sezione articolo in un modulo condiviso `scripts/lib/articleSections.mjs` (`BLOG_SECTION_RX` + `isBlogSectionPath`), che mirrora `fuelSections.mjs` e copre **entrambe** le sezioni (`frontaliere` + `svizzera`) × tutti i locali (it/en/de/fr). Da tenere in sync con `ARTICLE_SECTIONS[*].indexSlug` (documentato nel docblock).
- Wired i **4** classifier ratchet alla costante condivisa: `audit-title-length.mjs`, `audit-text-html-ratio.mjs`, `audit-page-weight.mjs`, `audit-dist-multi.mjs` (3 occorrenze interne). Il drift slug-di-sezione non può più ricorrere by-construction (non-negotiable #6: regex duplicata in ≥2 file → un modulo condiviso).
- Preservati i token generici legacy `blog|articles` nei 3 classifier che li avevano (OR esplicito) → unica differenza di comportamento = l'aggiunta intenzionale degli slug svizzera.
- Aggiunto `tests/seo/article-section-classifier.test.ts` (23 test, mirror di `fuel-section-classifier.test.ts`): verifica che le pagine svizzera en/de/fr classifichino `blog`, che le non-article restino `spa-locale`, l'anchoring su path-boundary, e l'invariante di sync su ogni hub slug canonico.

**Nessun cambiamento di baseline/gate.** Le pagine svizzera (offender ≤91 in spa-locale + ≤28 in spa-other) si spostano nel bucket `blog` (cap 2700, 1705 osservato → headroom ampio anche nel caso peggiore ~1824), riportando `spa-locale` sotto il suo cap esistente di 90. La soglia per-pagina di 66 char è **invariata**. Verificato: `data/title-length-baseline.json` non è nel diff.

## Non implementato (ancora)

- **ENOSPC del run 28120871542 (il run linkato):** è un flake infra, non un difetto del workflow. Il runner ha disco da 145G e il run che passa la rehydrate (17:36) ne usa al picco solo ~79G (67G liberi); l'ENOSPC è avvenuto mentre il runner scriveva il **proprio** `_diag/Worker.log` in fase di dispose → istanza runner difettosa/sotto-provisioned. Nessun fix di codice giustificato (sarebbe speculativo, non-negotiable #6); il prossimo deploy dist-affecting su runner sano riesegue lo step senza problemi.
- **Altre inline-list di slug articolo NON migrate al modulo condiviso:** `scripts/create-article.mjs` (mappa slug per *generazione* articoli, non un classifier ratchet), `scripts/lib/social-post-utils.mjs`, `scripts/schedule-fb-articles-daily.mjs`, più i build-plugin/componenti `.ts`/`.tsx` (che già importano il canonico `services/articleSections.ts`). Code path diversi, non parte della classe-bug del ratchet title-length — stesso deferral che il fuel-fix #2853 ha fatto (follow-up #2857). Drift-proofing puro, behaviour-neutral oggi.
- **Re-tightening del cap `spa-locale` post-fix:** deferito. Il conteggio esatto post-reclassificazione è misurabile solo sul prossimo post-deploy (gli SEO build full OOMano in locale); abbassare il cap ora su numeri non misurati rischierebbe un re-trip. Da ratchettare giù dopo aver osservato il count reale.

## Test

- [x] `npx vitest run tests/seo/article-section-classifier.test.ts` → 23 passed
- [x] `npx vitest run tests/seo/fuel-section-classifier.test.ts` → 27 passed (nessuna regressione)
- [x] `npx vitest run tests/seo/` → 943 passed, 0 failed
- [x] `classifyFeature` test diretto: pagine svizzera it/en/de/fr → `blog`; fuel → `fuel-daily`; landing generiche en/de/fr → `spa-locale`
- [ ] Verifica live sul prossimo post-deploy validate-dist: `title-length` verde, `spa-locale ≤ 90`, `blog < 2700` (non verificabile pre-merge — SEO build full OOMa in locale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)