### PR TITLE
fix(seo): recover cross-locale company-hub prefix 404s with within-locale 301

### DIFF
--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -177,6 +177,20 @@ const NOT_FOUND_CACHE_CONTROL = 'public, max-age=300, s-maxage=7200';
 // build-plugin modules. Keep the three copies in lockstep when touching any one.
 const JOB_DETAIL_RE =
   /^(?:\/(?:en|de|fr))?\/(?:cerca-lavoro|find-jobs|jobs-im|jobs-in|trouver-emploi|job-search|jobsuche|recherche-emploi)-[a-z-]+\/([^/]+)\/?$/;
+
+// Cross-locale company-hub prefix recovery (see recoverCrossLocaleCompanyPrefix).
+// Company-hub URLs carry a LOCALIZED prefix on the last path segment:
+//   IT azienda-   EN company-   DE unternehmen-   FR entreprise-
+// The build emits each locale's hub ONLY under that locale's prefix, so a hub
+// requested with a foreign prefix (e.g. the IT `azienda-` kept on an /fr route)
+// is a hard origin 404. COMPANY_HUB_RE captures the locale-route prefix and the
+// last segment generically; the prefix alternation lives ONLY in
+// COMPANY_PREFIX_RE (single source of truth, no literal re-duplication).
+const COMPANY_PREFIX_BY_LOCALE = { en: 'company', de: 'unternehmen', fr: 'entreprise' };
+const COMPANY_PREFIX_RE = /^(?:azienda|company|unternehmen|entreprise)-(.+)$/;
+const COMPANY_HUB_RE =
+  /^(\/(?:en|de|fr)\/(?:cerca-lavoro|find-jobs|jobs-im|jobs-in|trouver-emploi|job-search|jobsuche|recherche-emploi)-[a-z-]+)\/([^/]+)\/?$/;
+
 const MAP_FETCH_TIMEOUT_MS = 2000;
 const JOB_CANON_CACHE_TTL = 21600; // 6 h — map changes only on deploy
 
@@ -232,6 +246,34 @@ async function recoverCantonDriftOrphan(url, locale) {
   // Never 301 to the path we are already on (avoids a redirect loop).
   if (canonical === url.pathname.replace(/\/+$/, '') + '/') return null;
 
+  const location = canonical + url.search + url.hash;
+  return new Response(null, {
+    status: 301,
+    headers: { Location: location, 'Cache-Control': NOT_FOUND_CACHE_CONTROL },
+  });
+}
+
+// Returns a within-locale 301 Response when the requested path is a company-hub
+// orphaned only by a wrong-locale company prefix (e.g. the IT `azienda-` prefix
+// kept on an /fr `trouver-emploi-*` route), otherwise null. The fix swaps ONLY
+// the company prefix to the request locale's canonical one
+// (COMPANY_PREFIX_BY_LOCALE) and leaves the rest of the path byte-identical, so
+// the 301 stays strictly within-locale (never crosses to IT) and lands on the
+// real 200 hub. Purely synchronous (no map/subrequest): the prefix↔locale
+// mapping is deterministic. The caller runs this ONLY after the canton-drift map
+// miss, so a real job-detail slug (which lives in /job-canon) is never hijacked.
+function recoverCrossLocaleCompanyPrefix(url, locale) {
+  const correct = COMPANY_PREFIX_BY_LOCALE[locale];
+  if (!correct) return null;
+  const m = url.pathname.match(COMPANY_HUB_RE);
+  if (!m) return null;
+  const [, routePrefix, lastSeg] = m;
+  const pm = lastSeg.match(COMPANY_PREFIX_RE);
+  if (!pm) return null; // last segment is not a company-prefixed hub → leave alone
+  const rest = pm[1];
+  // Already canonical for this locale → nothing to fix (loop guard).
+  if (lastSeg === `${correct}-${rest}`) return null;
+  const canonical = `${routePrefix}/${correct}-${rest}/`;
   const location = canonical + url.search + url.hash;
   return new Response(null, {
     status: 301,
@@ -452,6 +494,12 @@ export default {
       // match[1] is the request's locale (en|de|fr) — keep the 301 within-locale.
       const redirect = await recoverCantonDriftOrphan(url, match[1]);
       if (redirect) return redirect;
+      // Cross-locale company-hub prefix mismatch (e.g. IT `azienda-` prefix on an
+      // /fr route) → within-locale 301 to the canonical prefix. Synchronous, and
+      // runs only AFTER the canton-drift map miss so a real job slug that happens
+      // to start with a prefix word is never hijacked.
+      const companyRedirect = recoverCrossLocaleCompanyPrefix(url, match[1]);
+      if (companyRedirect) return companyRedirect;
     }
 
     // Stamp Cache-Control on 404s too: see NOT_FOUND_CACHE_CONTROL. GitHub

--- a/public/404.html
+++ b/public/404.html
@@ -73,12 +73,27 @@
         // canonical page; unknown/expired slug (slug-form drift, never tracked) →
         // the canton listing. Never a dead 404 for a job path.
         var sectionRoot = pathname.replace(/\/+$/, '').split('/').slice(0, -1).join('/') + '/';
+        // Company-hub orphaned only by a wrong-locale prefix (azienda-/company-/
+        // unternehmen-/entreprise- mismatched to the route locale) → the exact hub
+        // under THIS locale's canonical prefix. Mirrors the Worker's
+        // recoverCrossLocaleCompanyPrefix; here it ALSO covers the IT route (which
+        // bypasses the Worker). Used only as the fallback when the canton-drift map
+        // has no entry for the slug (company slugs never are), so a real job slug
+        // that happens to start with a prefix word is recovered by the map first.
+        var companyPrefixes = { it: 'azienda', en: 'company', de: 'unternehmen', fr: 'entreprise' };
+        function companyHubTarget() {
+          var cpm = slug.match(/^(?:azienda|company|unternehmen|entreprise)-(.+)$/);
+          if (!cpm) return null;
+          var correctCp = companyPrefixes[locale];
+          if (!correctCp || slug === correctCp + '-' + cpm[1]) return null; // already canonical
+          return sectionRoot.replace(/\/$/, '') + '/' + correctCp + '-' + cpm[1] + '/';
+        }
         var done = false;
         function go(target) {
           if (done) return; done = true; clearTimeout(timer);
           location.replace(target + location.search + location.hash);
         }
-        var timer = setTimeout(function() { go(sectionRoot); }, 1500);
+        var timer = setTimeout(function() { go(companyHubTarget() || sectionRoot); }, 1500);
         fetch('/job-canon/' + sk + '.json', { cache: 'force-cache' })
           .then(function(r) { return r.ok ? r.json() : null; })
           .then(function(map) {
@@ -90,11 +105,12 @@
               : (typeof entry === 'string' && locale === 'it' ? entry : null);
             var canon = prefix ? (prefix + '/' + slug + '/') : null;
             // Exact canonical page when the slug is known AND it differs from the
-            // requested (orphaned) path; otherwise the canton listing.
+            // requested (orphaned) path; else the cross-locale company hub when the
+            // slug is a wrong-prefix hub; otherwise the canton listing.
             if (canon && canon !== pathname.replace(/\/+$/, '') + '/') go(canon);
-            else go(sectionRoot);
+            else go(companyHubTarget() || sectionRoot);
           })
-          .catch(function() { go(sectionRoot); });
+          .catch(function() { go(companyHubTarget() || sectionRoot); });
       })();
     </script>
     <!-- Firebase/GA4 error tracking for 404 page (only fires if redirect didn't happen) -->

--- a/tests/locale-router-xlocale-company-prefix-301.test.ts
+++ b/tests/locale-router-xlocale-company-prefix-301.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Cross-locale company-hub prefix recovery in the Cloudflare locale-router Worker.
+ *
+ * Company-hub URLs carry a LOCALIZED prefix on the last path segment
+ * (IT azienda- / EN company- / DE unternehmen- / FR entreprise-). The build
+ * emits each locale's hub ONLY under that locale's prefix, so a hub requested
+ * with a foreign prefix — e.g. the IT `azienda-` prefix kept on an /fr
+ * `trouver-emploi-*` route — is a hard origin 404. The Worker upgrades these to
+ * a within-locale 301 that swaps ONLY the company prefix to the request
+ * locale's canonical one, leaving the rest of the path byte-identical.
+ *
+ * The recovery runs only AFTER the canton-drift map miss, so a real job-detail
+ * slug (tracked in /job-canon) is never hijacked. The mock therefore returns a
+ * 404 origin and a missing map (the /job-canon/ shard 404s) for the
+ * company-prefix cases, and a populated map for the no-hijack case.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error — plain JS Worker module, no type declarations.
+import worker from '../infra/cloudflare-worker/locale-router.js';
+
+const APEX = 'https://frontaliereticino.ch';
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+
+beforeEach(() => {
+  const cache = { match: vi.fn(async () => undefined), put: vi.fn(async () => {}) };
+  (globalThis as unknown as { caches: { default: typeof cache } }).caches = { default: cache };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as unknown as { caches?: unknown }).caches;
+});
+
+/**
+ * Mock fetch: the shard origin returns `originStatus`; the /job-canon/<sk>.json
+ * request returns `map` (200) or a 404 when `map` is null (canton-drift miss).
+ */
+function mockFetch(originStatus: number, map: Record<string, Record<string, string>> | null): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+    const u = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (u.includes('/job-canon/')) {
+      return map
+        ? new Response(JSON.stringify(map), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        : new Response('not found', { status: 404 });
+    }
+    return new Response(originStatus === 404 ? 'gh-pages-404' : 'ok', { status: originStatus });
+  });
+}
+
+const SLUG = 'azienda-amministrazione-cantonale-ticino';
+const REST = 'amministrazione-cantonale-ticino';
+
+describe('locale-router cross-locale company-prefix 301', () => {
+  it('301s an /fr route carrying the IT azienda- prefix to entreprise-', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(new Request(`${APEX}/fr/trouver-emploi-tessin/${SLUG}/`), {}, ctx);
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe(`/fr/trouver-emploi-tessin/entreprise-${REST}/`);
+  });
+
+  it('301s an /de route carrying the IT azienda- prefix to unternehmen-', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(new Request(`${APEX}/de/jobs-im-tessin/${SLUG}/`), {}, ctx);
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe(`/de/jobs-im-tessin/unternehmen-${REST}/`);
+  });
+
+  it('301s an /en route carrying the IT azienda- prefix to company-', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(new Request(`${APEX}/en/find-jobs-ticino/${SLUG}/`), {}, ctx);
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe(`/en/find-jobs-ticino/company-${REST}/`);
+  });
+
+  it('normalises any foreign prefix, not just the IT one (EN company- on /fr → entreprise-)', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(
+      new Request(`${APEX}/fr/trouver-emploi-tessin/company-${REST}/`),
+      {},
+      ctx,
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe(`/fr/trouver-emploi-tessin/entreprise-${REST}/`);
+  });
+
+  it('does NOT 301 when the prefix already matches the locale (loop guard → soft 404)', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(
+      new Request(`${APEX}/fr/trouver-emploi-tessin/entreprise-${REST}/`),
+      {},
+      ctx,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('preserves the query string and hash on the 301', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(
+      new Request(`${APEX}/fr/trouver-emploi-tessin/${SLUG}/?utm_source=x`),
+      {},
+      ctx,
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe(`/fr/trouver-emploi-tessin/entreprise-${REST}/?utm_source=x`);
+  });
+
+  it('never hijacks a real job slug that happens to start with a prefix word (canton-drift wins)', async () => {
+    // A job-detail slug present in /job-canon must be canton-drift-recovered to
+    // its mapped canonical, NOT prefix-swapped — recovery order guarantees this.
+    mockFetch(404, { 'azienda-energetica-role-lugano': { fr: '/fr/trouver-emploi-tessin' } });
+
+    const res = await worker.fetch(
+      new Request(`${APEX}/fr/trouver-emploi-zurich/azienda-energetica-role-lugano/`),
+      {},
+      ctx,
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe('/fr/trouver-emploi-tessin/azienda-energetica-role-lugano/');
+  });
+
+  it('leaves a non-company orphan slug on the soft-404 path (no spurious 301)', async () => {
+    mockFetch(404, null);
+
+    const res = await worker.fetch(
+      new Request(`${APEX}/fr/trouver-emploi-tessin/developpeur-acme-lugano/`),
+      {},
+      ctx,
+    );
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Implementato

Le **company-hub page** portano un prefisso localizzato sull'ultimo segmento del path:
`IT azienda-` · `EN company-` · `DE unternehmen-` · `FR entreprise-`. Il build emette ogni hub **solo** sotto il prefisso del suo locale, quindi una hub richiesta con prefisso di un altro locale — es. il prefisso IT `azienda-` mantenuto su una route `/fr/trouver-emploi-*/` — è un **404 secco** dall'origine. Caso osservato nei log CF `origin-fr` (es. `/fr/trouver-emploi-tessin/azienda-amministrazione-cantonale-ticino/` → 404, mentre `/fr/trouver-emploi-tessin/entreprise-amministrazione-cantonale-ticino/` → 200).

Recupero **within-locale** che scambia **solo** il company-prefix con quello canonico del locale della richiesta, lasciando il resto del path byte-identico → il 301 atterra sulla hub 200 reale, mai cross-locale verso IT:

- `infra/cloudflare-worker/locale-router.js`: `recoverCrossLocaleCompanyPrefix(url, locale)`, eseguito **dopo** il miss della mappa canton-drift (locali en/de/fr gestiti dal Worker) così uno slug job reale che inizia per una parola-prefisso non viene mai dirottato. La lista dei 4 prefissi vive in un solo posto (`COMPANY_PREFIX_RE`); `COMPANY_HUB_RE` cattura il segmento generico (no ri-duplicazione letterale).
- `public/404.html`: stesso swap come fallback soft-404, che copre **anche la route IT** (bypassa il Worker); applicato solo quando la mappa canton-drift non ha l'entry (le company-slug non ci sono mai), rispecchiando l'ordine del Worker.
- `tests/locale-router-xlocale-company-prefix-301.test.ts`: 8 test (FR/DE/EN azienda→prefisso corretto, qualsiasi prefisso estero, loop-guard su prefisso già canonico, preserva query/hash, **no-hijack** di job slug reale che inizia per parola-prefisso → canton-drift vince, no-301 spurio su slug non-company).

### Verifica
- `npx vitest run` sui file worker/404/job-canon: **27/27 verdi** (8 nuovi + 19 esistenti, canton-drift invariato).
- Classificati live tutti i 10 top-404 `origin-fr`: 9/10 erano job-detail canton-drift **già 301→200 sull'apex** (loggavano 404 solo su origin raw, senza Worker); l'unica classe scoperta era il company-prefix cross-locale — questa PR.

## Non implementato (ancora)

- **Job-detail canton-drift (9/10 dei 404 origin-fr)**: già coperti dal redirect canton-drift esistente sull'apex (target verificati 200). Nessuna azione — non è una regressione, è raw-origin senza Worker.
- **Verifica live post-deploy del 301**: il Worker si deploya via wrangler post-merge; `azienda-` su route en/de/fr → 301 verso il prefisso corretto è verificabile solo sull'apex dopo il deploy del Worker. Se il prossimo deploy Worker non emette il 301 atteso → indagare wrangler deploy, non la logica (coperta da unit test).
- **Esistenza-aware (no 301→404 per company inesistente)**: lo swap è deterministico, non verifica che la hub target esista. Una company senza hub → 301→404 (stesso esito del soft-404 attuale, su traffico non-eyeball/worker-probe). Out of scope: richiederebbe una company-slug map emessa (peso build); il caso reale deriva sempre da hub esistenti con prefisso manglato.