### PR TITLE
chore(seo): downgrade SEO-landing moratorium from deploy gate to non-blocking tracker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,7 @@ jobs:
   # Removes the ×4 duplicated data-prep from the locale shards and guarantees
   # every shard builds from the IDENTICAL job snapshot (no crawler-commit-window
   # divergence). Mirrors deploy-matrix-experiment.yml's prep VERBATIM, plus the
-  # monolith's Active-jobs regression check + SEO moratorium check.
+  # monolith's Active-jobs regression check + SEO position tracking.
   prep:
     needs: matrix-setup
     runs-on: ubuntu-latest
@@ -198,14 +198,16 @@ jobs:
         # data/active-jobs-baseline.json auto-ratchets UP only — manual
         # commit required to lower (see CLAUDE.md rule #1).
         run: npm run audit:active-jobs-regression
-      - name: SEO moratorium check (CLAUDE.md #19)
-        # Block new build-plugin-emitted SEO landings while the 7-day GSC
-        # avg position is > 7.5. Long-tail dilution from 50+ SEO PRs in
-        # 10 days drove avg position 5.7 → 8.62. Re-enable when ≤ 7.5.
-        # Only runs on pull_request events — main pushes have already passed
-        # the gate, and workflow_dispatch is exempt so we can manually deploy
-        # fixes/refactors that happen to add a file matching the pattern.
+      - name: SEO position tracking (non-blocking)
+        # Refresh the 7-day GSC avg-position snapshot for status visibility and
+        # PRINT where it stands. NON-BLOCKING by design (owner decision
+        # 2026-06-24): the former SEO-landing moratorium was downgraded from a
+        # deploy gate to a tracker. Losing real SEO traffic / serving users 404s
+        # (e.g. ~14k/day indexed ricerca-stipendio-* pages going 404) outweighs
+        # the avg-position vanity metric, so position is monitored but never
+        # blocks a deploy. check-seo-moratorium.mjs reports only (always exit 0).
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           # OAuth2 path (currently not set; SA fallback in
           # refresh-gsc-position-rolling.mjs uses GOOGLE_APPLICATION_CREDENTIALS

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ data/pending-releases.json
 data/batch-faq-progress.json
 scratchpad.md
 
-# SEO moratorium gate artifact (refresh-gsc-position-rolling.mjs in CI)
+# SEO position tracking artifact (refresh-gsc-position-rolling.mjs in CI)
 data/gsc-position-rolling.json
 
 # Aggregated data files — assembled at build/deploy time from per-crawler slices

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Iniettato in ogni sessione agent. Detail durevole nei docs, carica on-demand.
 
 ## Non-Negotiables
 
-1. Mai abbassare quality threshold/test tolerance/validation/SEO gate/moratorium per passare build. Fix root cause.
+1. Mai abbassare quality threshold/test tolerance/validation/SEO gate per passare build. Fix root cause. (NB: il moratorium SEO-landing è stato rimosso/declassato a tracking il 2026-06-24 — non è più un gate; vedi `## Static SEO Pages`.)
 2. Mai downgrade error → warning per sbloccare deploy.
 3. Job page structured data DEVE includere in ogni locale: `baseSalary`, `postalCode`, `streetAddress`, `title`, `description`, `datePosted`, `hiringOrganization.name`, `jobLocation`, `employmentType`. Source mancante → safe default, non rimozione check.
 4. Mai accettare thin content indicizzato <50 parole.
@@ -120,7 +120,7 @@ CI test gate: `npm ci`, `node scripts/assemble-jobs-dataset.mjs --stats`, `node 
 - SEO landing order: breadcrumb, header con one-line lede ≤120 chars, 3-5 stat tile, advice banner se utile, primary CTA, data area, prose lunga.
 - Solo semantic color token esistenti; no inline hex.
 - Crawler dedicati: merge job by stable id `extractStableJobId(job.url)`, preserva previous slug, truncate via `truncateSlugAtWordBoundary`.
-- SEO automation moratorium: no nuove build-plugin SEO landing finché `data/gsc-position-rolling.json` 7-day avg position >7.5. Eccezioni: bug fix, net-reducing consolidation, redirect/bridge emitter.
+- SEO landing moratorium **RIMOSSO** (owner 2026-06-24): nuove build-plugin SEO landing sono consentite. La posizione media 7-day GSC (`data/gsc-position-rolling.json`) resta **tracciata** per valutare lo status, ma è solo informativa — `scripts/check-seo-moratorium.mjs` è report-only (always exit 0) e lo step CI in `deploy.yml` è `continue-on-error`, mai bloccante. Razionale: perdere traffico SEO reale / servire 404 agli utenti (es. ~14k/giorno di pagine `ricerca-stipendio-*` indicizzate andate 404) vale più della metrica-vanity di posizione media. NON re-introdurre un gate bloccante sulla posizione senza richiesta esplicita owner.
 
 ## Accessibility And UX
 

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -952,7 +952,7 @@ export function buildClusterContext(
   // already-committed candidates file. This guard runs at emit time, so it
   // cleans the LIVE /…/ricerca/ hub + stops emitting the thin doorway landings
   // (e.g. /…/ricerca-cookie-bern/) without waiting for the weekly audit regen.
-  // Net-reducing consolidation — a moratorium exception. See relatedSearchJunkTerms.mjs.
+  // Net-reducing consolidation (drops thin junk doorways). See relatedSearchJunkTerms.mjs.
   if (isJunkSearchKeyword(keyword)) {
     profileRecord('bc:tokenize', __tTokenize);
     return null;

--- a/build-plugins/shared/sectorHubClusters.ts
+++ b/build-plugins/shared/sectorHubClusters.ts
@@ -26,8 +26,8 @@
  * Both structures are keyed on {@link SectorHubKey}, so every entry is a real
  * hub that {@link buildSectorHubPath} can resolve to a trailing-slash URL in
  * any of the 4 locales — labels come from SECTOR_HUB_DISPLAY. No new pages are
- * created (moratorium-safe): this only adds internal links to pages that
- * already exist in `sitemap-sector.xml`.
+ * created: this only adds internal links to pages that already exist in
+ * `sitemap-sector.xml`.
  */
 
 import type { SectorHubKey } from '../jobSectorLanding';

--- a/scripts/check-seo-moratorium.mjs
+++ b/scripts/check-seo-moratorium.mjs
@@ -1,108 +1,81 @@
 #!/usr/bin/env node
 /**
- * SEO moratorium gate — enforces CLAUDE.md non-negotiable rule #19.
+ * SEO position tracker — REPORT-ONLY (non-blocking).
  *
- * Reads `data/gsc-position-rolling.json` (produced by
- * `scripts/refresh-gsc-position-rolling.mjs`). If the 7-day avg position
- * is > THRESHOLD, BLOCKS any PR that adds a new build-plugin-emitted
- * SEO landing emitter (file matching `build-plugins/*Landing*.ts`,
- * `*Pages.ts`, `*Hub.ts`).
+ * History: this was a deploy GATE that blocked any PR adding a new
+ * build-plugin-emitted SEO landing while the 7-day GSC avg position was
+ * > THRESHOLD. Owner decision (2026-06-24) DOWNGRADED it from a blocker to a
+ * tracker: losing real SEO traffic and serving users 404s (e.g. ~14k/day of
+ * indexed `ricerca-stipendio-*` pages going 404) outweighs the avg-position
+ * vanity metric. New SEO landings are no longer blocked.
  *
- * Exempt — even during moratorium:
- *   - Modifications to existing files (only ADDITIONS are blocked)
- *   - Files containing "JobOrphanBridge" (redirect/bridge emitters)
- *   - Files containing "Bridge" (URL-bridge emitters)
- *   - Files containing "Redirect"
+ * What it still does: reads `data/gsc-position-rolling.json` (produced by
+ * `scripts/refresh-gsc-position-rolling.mjs`), prints the current 7-day avg
+ * position, and — for visibility only — lists any new SEO-landing emitter
+ * files added in the PR diff. It NEVER fails the build.
  *
- * The rule body itself also exempts:
- *   - bug fixes to existing landings (these don't add new files → not caught)
- *   - consolidation refactors that NET-REDUCE page count (manual judgement)
- *
- * Exit codes:
- *   0 — moratorium not active, OR active but no forbidden additions
- *   1 — moratorium active AND PR adds a new SEO landing emitter
- *   2 — internal error (missing data file, missing git context)
+ * Exit code: ALWAYS 0. (Kept as a script, not deleted, so the CI step keeps
+ * surfacing the position signal in deploy logs.)
  */
 import { readFileSync, existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
+// Informational reference line only — no longer enforced.
 const THRESHOLD = 7.5;
 const ROLLING = process.env.GSC_ROLLING_FILE || 'data/gsc-position-rolling.json';
 
-function isExemptPath(path) {
-  // Bridge/redirect emitters: never new landings — they collapse URLs
-  if (/Bridge/i.test(path)) return true;
-  if (/Redirect/i.test(path)) return true;
-  return false;
-}
-
-function matchesLandingPattern(path) {
+function isLandingEmitter(path) {
+  // Bridge/redirect emitters collapse URLs — never a new landing surface.
+  if (/Bridge/i.test(path) || /Redirect/i.test(path)) return false;
   return /^build-plugins\/.+(Landing[^/]*|Pages|Hub)\.ts$/.test(path);
 }
 
 function main() {
   if (!existsSync(ROLLING)) {
-    console.error(`Missing ${ROLLING}. Run scripts/refresh-gsc-position-rolling.mjs first.`);
-    process.exit(2);
+    console.log(`ℹ️  SEO position tracking: ${ROLLING} not present — skipping (non-blocking).`);
+    return; // exit 0
   }
 
-  const rolling = JSON.parse(readFileSync(ROLLING, 'utf8'));
-  const avg = Number(rolling.avg_position);
+  let avg;
+  try {
+    avg = Number(JSON.parse(readFileSync(ROLLING, 'utf8')).avg_position);
+  } catch (e) {
+    console.log(`ℹ️  SEO position tracking: could not read ${ROLLING} (${e.message}) — skipping.`);
+    return; // exit 0
+  }
+
   if (!Number.isFinite(avg)) {
-    console.error(`Malformed ${ROLLING}: avg_position is not a number.`);
-    process.exit(2);
+    console.log(`ℹ️  SEO position tracking: avg_position missing/non-numeric — skipping.`);
+    return; // exit 0
   }
 
-  if (avg <= THRESHOLD) {
-    console.log(`Moratorium not active: avg_position ${avg.toFixed(2)} ≤ ${THRESHOLD}`);
-    process.exit(0);
-  }
+  const trend = avg <= THRESHOLD ? `at/below ${THRESHOLD} (healthy)` : `above ${THRESHOLD} reference`;
+  console.log(`📊 SEO position tracking: 7-day GSC avg position ${avg.toFixed(2)} — ${trend}.`);
 
-  // Moratorium active — inspect the diff
+  // List any new landing emitters purely for visibility (NOT blocking).
   const base = process.env.GITHUB_BASE_REF || 'main';
-  let diff;
+  let diff = '';
   try {
     diff = execSync(`git diff --name-status origin/${base}...HEAD`, { encoding: 'utf8' });
-  } catch (e) {
-    // Fallback: try without origin/ prefix (local runs without remote)
+  } catch {
     try {
       diff = execSync(`git diff --name-status ${base}...HEAD`, { encoding: 'utf8' });
-    } catch (e2) {
-      console.error(`Unable to compute git diff against ${base}: ${e2.message}`);
-      process.exit(2);
+    } catch {
+      /* no git context — skip the diff note */
     }
   }
 
-  const forbidden = diff.split('\n').filter((line) => {
-    if (!line.startsWith('A\t')) return false; // ADDITIONS only
-    const path = line.split('\t')[1];
-    if (!path) return false;
-    if (!matchesLandingPattern(path)) return false;
-    if (isExemptPath(path)) return false;
-    return true;
-  });
+  const newLandings = diff
+    .split('\n')
+    .filter((l) => l.startsWith('A\t'))
+    .map((l) => l.split('\t')[1])
+    .filter((p) => p && isLandingEmitter(p));
 
-  if (forbidden.length === 0) {
-    console.log(
-      `Moratorium active (avg position ${avg.toFixed(2)} > ${THRESHOLD}) ` +
-      `but no new SEO landing emitters added — OK.`,
-    );
-    process.exit(0);
+  if (newLandings.length) {
+    console.log(`📝 New SEO-landing emitter(s) in this PR (allowed — tracking only):`);
+    for (const p of newLandings) console.log(`   + ${p}`);
   }
-
-  console.error(
-    `Moratorium active (avg position ${avg.toFixed(2)} > ${THRESHOLD}). ` +
-    `The following new SEO-landing files are blocked:`,
-  );
-  for (const line of forbidden) {
-    console.error(`  ${line}`);
-  }
-  console.error('');
-  console.error('Per CLAUDE.md rule #19, NO new build-plugin-emitted SEO landings may');
-  console.error('be merged while the 7-day GSC avg position > 7.5. Exceptions: bug');
-  console.error('fixes to existing landings, consolidation refactors that NET-REDUCE');
-  console.error('page count, redirect/bridge emitters, JobOrphanBridge variants.');
-  process.exit(1);
+  // Always succeed — tracking, not gating.
 }
 
 main();

--- a/tests/scripts/check-seo-moratorium.test.ts
+++ b/tests/scripts/check-seo-moratorium.test.ts
@@ -2,14 +2,14 @@
 /**
  * Unit tests for scripts/check-seo-moratorium.mjs.
  *
- * Covers the two structural branches:
- *   1. avg_position ≤ THRESHOLD  → exit 0 regardless of diff (moratorium off)
- *   2. avg_position > THRESHOLD + diff adds a new `build-plugins/*Landing*.ts`
- *      → exit 1 (moratorium active and PR violates it)
+ * The script is REPORT-ONLY (the SEO-landing moratorium was downgraded from a
+ * deploy gate to a tracker — owner decision 2026-06-24). It must therefore
+ * ALWAYS exit 0, regardless of the 7-day avg position or whether the PR adds a
+ * new SEO-landing emitter; it only PRINTS the position and, for visibility,
+ * lists any new landing emitters.
  *
- * Both tests spawn the script in a temp git repo so we can fully control the
- * diff that `git diff --name-status origin/main...HEAD` returns — no mocks
- * needed, just real git plumbing.
+ * Tests spawn the script in a temp git repo so we can fully control the diff
+ * that `git diff --name-status origin/main...HEAD` returns — no mocks needed.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
@@ -57,7 +57,22 @@ function setupRepo(): string {
   return repo;
 }
 
-describe('check-seo-moratorium', () => {
+function writeRolling(repo: string, avg: number) {
+  writeFileSync(
+    join(repo, 'data', 'gsc-position-rolling.json'),
+    JSON.stringify({ avg_position: avg, window: { start: '2026-05-10', end: '2026-05-17' }, daily: [] }),
+  );
+}
+
+function runTracker(repo: string) {
+  return spawnSync('node', ['scripts/check-seo-moratorium.mjs'], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_BASE_REF: 'main' },
+  });
+}
+
+describe('check-seo-moratorium (report-only tracker)', () => {
   let repo: string;
 
   beforeEach(() => {
@@ -72,70 +87,44 @@ describe('check-seo-moratorium', () => {
     }
   });
 
-  it('exits 0 when avg_position ≤ 7.5 (moratorium not active)', () => {
-    writeFileSync(
-      join(repo, 'data', 'gsc-position-rolling.json'),
-      JSON.stringify({
-        avg_position: 6.5,
-        window: { start: '2026-05-10', end: '2026-05-17' },
-        daily: [],
-      }),
-    );
-    // Even add a forbidden file — it must not trigger when moratorium is off
-    writeFileSync(join(repo, 'build-plugins', 'newLandingPlugin.ts'), '// new\n');
-
-    const r = spawnSync('node', ['scripts/check-seo-moratorium.mjs'], {
-      cwd: repo,
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_BASE_REF: 'main' },
-    });
+  it('exits 0 and reports a healthy position when avg ≤ 7.5', () => {
+    writeRolling(repo, 6.5);
+    const r = runTracker(repo);
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/Moratorium not active/);
+    expect(r.stdout).toMatch(/avg position 6\.50/);
+    expect(r.stdout).toMatch(/healthy/);
   });
 
-  it('exits 1 when avg_position > 7.5 AND diff adds a new build-plugins/*Landing*.ts', () => {
-    writeFileSync(
-      join(repo, 'data', 'gsc-position-rolling.json'),
-      JSON.stringify({
-        avg_position: 8.62,
-        window: { start: '2026-05-10', end: '2026-05-17' },
-        daily: [],
-      }),
-    );
+  it('NEVER blocks: exits 0 even when avg > 7.5 AND the PR adds a new landing emitter', () => {
+    writeRolling(repo, 8.62);
     // Stage a new landing emitter and commit so it shows up in git diff
     writeFileSync(join(repo, 'build-plugins', 'fooLandingPlugin.ts'), '// new landing\n');
     git(repo, 'add', 'build-plugins/fooLandingPlugin.ts');
     git(repo, 'commit', '-m', 'feat: add foo landing');
 
-    const r = spawnSync('node', ['scripts/check-seo-moratorium.mjs'], {
-      cwd: repo,
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_BASE_REF: 'main' },
-    });
-    expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/Moratorium active \(avg position 8\.62 > 7\.5\)/);
-    expect(r.stderr).toMatch(/fooLandingPlugin\.ts/);
+    const r = runTracker(repo);
+    expect(r.status).toBe(0); // tracking only — must not fail the build
+    expect(r.stdout).toMatch(/avg position 8\.62/);
+    // The new landing is surfaced for visibility, explicitly marked as allowed.
+    expect(r.stdout).toMatch(/fooLandingPlugin\.ts/);
+    expect(r.stdout).toMatch(/tracking only/);
   });
 
-  it('exits 0 when moratorium active but diff only adds an exempt Bridge emitter', () => {
-    writeFileSync(
-      join(repo, 'data', 'gsc-position-rolling.json'),
-      JSON.stringify({
-        avg_position: 8.62,
-        window: { start: '2026-05-10', end: '2026-05-17' },
-        daily: [],
-      }),
-    );
+  it('does not flag exempt Bridge/Redirect emitters as new landings', () => {
+    writeRolling(repo, 8.62);
     writeFileSync(join(repo, 'build-plugins', 'jobOrphanBridgePlugin.ts'), '// bridge\n');
     git(repo, 'add', 'build-plugins/jobOrphanBridgePlugin.ts');
     git(repo, 'commit', '-m', 'feat: add bridge');
 
-    const r = spawnSync('node', ['scripts/check-seo-moratorium.mjs'], {
-      cwd: repo,
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_BASE_REF: 'main' },
-    });
+    const r = runTracker(repo);
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/no new SEO landing emitters/);
+    expect(r.stdout).not.toMatch(/jobOrphanBridgePlugin\.ts/);
+  });
+
+  it('exits 0 (non-blocking) when the rolling data file is missing', () => {
+    // No gsc-position-rolling.json written → must skip gracefully, never fail.
+    const r = runTracker(repo);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/not present|skipping/);
   });
 });


### PR DESCRIPTION
## Implementato

Decisione owner (2026-06-24): il **moratorium SEO-landing** (blocco di nuove build-plugin landing finché la posizione media GSC 7-day è >7.5) stava **costando traffico SEO reale e servendo 404 agli utenti** — es. ~14k/giorno di pagine `ricerca-stipendio-*` indicizzate da Google che ora fanno 404. La posizione media è una metrica-vanity; recuperare le pagine perse fa crescere i click reali anche se alza la media.

Si **mantiene il segnale** di posizione (utile per valutare lo status), si **rimuove il blocco**:

- `scripts/check-seo-moratorium.mjs`: ora **report-only** — stampa la media 7-day e lista eventuali nuovi landing emitter per visibilità, ma **esce SEMPRE 0**.
- `.github/workflows/deploy.yml`: lo step continua a fare il refresh dello snapshot (tracking), rinominato **"SEO position tracking (non-blocking)"** e marcato `continue-on-error: true`.
- `AGENTS.md`: moratorium documentato come rimosso/declassato a tracking; rimosso "moratorium" dalla lista dei gate non-abbassabili (non è più un gate). Aggiunta nota "non re-introdurre un blocker sulla posizione senza richiesta owner".
- `tests/scripts/check-seo-moratorium.test.ts`: riscritto per il contratto report-only (always exit 0, anche con avg >7.5 + nuovo landing emitter aggiunto; Bridge/Redirect non flaggati). 4/4 verdi in locale.
- Rimossi commenti stale "moratorium exception"/"moratorium-safe" in `relatedSearchClustersPlugin.ts` e `sectorHubClusters.ts`; label `.gitignore` aggiornata.

`refresh-gsc-position-rolling.mjs` e `data/gsc-position-rolling.json` sono **mantenuti** — il tracking della posizione continua, semplicemente non blocca più i deploy.

## Non implementato (ancora)

- **Generazione delle pagine perse `ricerca-stipendio-*`**: è il problema a valle che questo sblocca, ma è una PR separata. Richiede prima di capire *perché* sono passate indexed→404 (job sorgente scaduto vs cap traffic-evidence vs prune thin-content) per non re-emettere thin content <50 parole (resta valido il non-negoziabile AGENTS.md #4). Segue.
- **Verifica live del tracking non-bloccante**: lo step gira solo su `pull_request`; il comportamento report-only è coperto da unit test, ma la prima esecuzione CI reale si osserva sul prossimo deploy PR.