### PR TITLE
fix(ci): merge driver for url-first-seen.json — stop dist-history push wedge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,15 @@ data/dist-size-history.jsonl       merge=union
 data/quality-alerts-history.jsonl  merge=union
 data/quota-history.jsonl           merge=union
 data/thin-page-promotions.jsonl    merge=union
+
+# data/url-first-seen.json is a pretty-printed JSON OBJECT ("url": "ISO-date",
+# one sorted line each), not a JSONL log — so `merge=union` cannot be used (it
+# would concatenate both sides' lines into duplicate keys / invalid JSON). The
+# same multi-producer race that the union driver fixes for the logs above
+# wedged the dist-history push loop on this file instead (run 28142157430: 5
+# rebase attempts, all CONFLICT → aborted → never landed). The custom
+# `json-first-seen` driver unions the two maps keeping the EARLIEST first-seen
+# date per URL (monotonic), so the conflict cannot occur by construction. The
+# driver is defined with `git config merge.json-first-seen.driver` in the
+# workflow step that rebases this file (see .github/workflows/deploy.yml).
+data/url-first-seen.json           merge=json-first-seen

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -551,6 +551,14 @@ jobs:
           fi
           git config user.name "dist-history-bot"
           git config user.email "dist-history-bot@frontaliereticino.ch"
+          # Wire up the custom merge driver declared in .gitattributes for
+          # data/url-first-seen.json (`merge=json-first-seen`). Without this
+          # config the attribute is inert and git falls back to a 3-way text
+          # merge → the very CONFLICT that wedged this loop. The driver unions
+          # the two URL→date maps keeping the earliest first-seen, so the
+          # rebase below auto-resolves instead of aborting.
+          git config merge.json-first-seen.driver \
+            'node scripts/ci/merge-json-first-seen.mjs %O %A %B'
           git add data/dist-size-history.jsonl data/url-first-seen.json
           git commit -m "chore(dist-history): append run ${GITHUB_RUN_ID} (${GITHUB_SHA::8})"
           # The build job leaves dist/ and other generated files dirty
@@ -570,15 +578,18 @@ jobs:
           # regularly out-race a 3×5 s window. The extended budget hits
           # a ~95 s total wait before giving up, which empirically
           # covers every observed conflict cluster on the main branch.
-          # A `pull --rebase` that hits a conflict (concurrent producer added
-          # rows to data/dist-size-history.jsonl / url-first-seen.json) leaves
-          # the tree mid-rebase. Without aborting, every later attempt dies on
+          # Both committed files now auto-resolve during the rebase via
+          # .gitattributes merge drivers: `merge=union` for the JSONL append
+          # log, and `merge=json-first-seen` (configured above) for the
+          # url-first-seen.json map. Historically url-first-seen.json had NO
+          # driver, so a concurrent producer touching nearby lines left the
+          # tree mid-rebase; without aborting, every later attempt died on
           # "Pulling is not possible because you have unmerged files" and the
-          # loop wedges until the job is canceled (run 27976954013). The
-          # merge=union .gitattributes resolves the JSONL append cleanly, and
-          # the abort below recovers from any residual conflict so each retry
-          # starts from a clean tree. `--abort` is a safe no-op when no rebase
-          # is in progress (e.g. a push-rejected race).
+          # loop wedged until the job was canceled (run 27976954013, and again
+          # run 28142157430 where all 5 attempts CONFLICTed). The `--abort`
+          # below stays as a belt-and-braces recovery for any unexpected
+          # mid-rebase state; it is a safe no-op when no rebase is in progress
+          # (e.g. a plain push-rejected race).
           for i in 1 2 3 4 5; do
             if git -c rebase.autoStash=true pull --rebase origin main \
                 && git push origin HEAD:main; then

--- a/scripts/ci/merge-json-first-seen.mjs
+++ b/scripts/ci/merge-json-first-seen.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// merge-json-first-seen.mjs — custom git merge driver for monotonic
+// "URL → first-seen ISO date" JSON maps (currently data/url-first-seen.json).
+//
+// WHY THIS EXISTS
+// ---------------
+// data/url-first-seen.json is a pretty-printed JSON object (one
+// "url": "YYYY-MM-DD" per sorted line). Many producers on `main` (every
+// deploy shard + post-merge auto-commits) append freshly-emitted URLs to it
+// concurrently. A plain 3-way text merge (git's default) raises a content
+// CONFLICT whenever two sides touch nearby lines — which wedged the
+// dist-history push loop in deploy.yml (run 28142157430: 5 rebase attempts
+// all aborted, url-first-seen.json never landed). `merge=union` is WRONG for a
+// JSON object (it concatenates both sides' lines → duplicate keys / invalid
+// JSON), so the JSONL union trick can't be reused here.
+//
+// This driver applies the file's real merge semantics instead: union the two
+// maps and keep the EARLIEST first-seen date per URL (monotonic — never
+// regress a first-seen). ISO dates sort lexically, so min = earliest. Output
+// matches the generator (scripts/refresh-url-first-seen.mjs): keys sorted,
+// 2-space pretty print, trailing newline. Ancestor (%O) is irrelevant for a
+// union-min merge, so it is ignored.
+//
+// Registered in .gitattributes as `merge=json-first-seen`; the driver itself
+// is wired up with `git config merge.json-first-seen.driver` in the workflow
+// step before the rebase (see deploy.yml). Invoked by git as:
+//   node scripts/ci/merge-json-first-seen.mjs %O %A %B
+// git reads the merged result back from %A (ours); exit 0 = resolved.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const [, , , oursPath, theirsPath] = process.argv;
+
+function load(p) {
+  try {
+    const obj = JSON.parse(readFileSync(p, 'utf8') || '{}');
+    return obj && typeof obj === 'object' ? obj : {};
+  } catch {
+    return {};
+  }
+}
+
+const merged = {};
+for (const src of [load(oursPath), load(theirsPath)]) {
+  for (const [url, date] of Object.entries(src)) {
+    const cur = merged[url];
+    // Keep the earliest first-seen (lexical min over ISO YYYY-MM-DD).
+    if (cur === undefined || String(date) < String(cur)) merged[url] = date;
+  }
+}
+
+const sorted = {};
+for (const url of Object.keys(merged).sort()) sorted[url] = merged[url];
+writeFileSync(oursPath, JSON.stringify(sorted, null, 2) + '\n');
+process.exit(0);


### PR DESCRIPTION
## Implementato

Fix per il wedge ricorrente del push loop `dist-history` in `deploy.yml` (osservato run 28142157430: 5 tentativi di rebase tutti `CONFLICT` su `data/url-first-seen.json` → `url-first-seen.json` mai atterrato su `main`).

**Root cause:** `data/url-first-seen.json` è un **oggetto JSON** pretty-printed (`"url": "YYYY-MM-DD"`, una riga ordinata per URL), committato a ogni deploy IT mentre altri produttori su `main` lo toccano in concorrenza. Non aveva merge driver → git fa un 3-way text-merge → `CONFLICT` su righe vicine. La retry loop poteva solo `--abort`, mai risolvere. `merge=union` (usato per i `.jsonl`) qui è **sbagliato**: concatenerebbe le righe dei due lati → chiavi duplicate / JSON invalido.

- **Nuovo merge driver** `scripts/ci/merge-json-first-seen.mjs`: unisce le due mappe `URL → data` tenendo la **prima data (min lessicale ISO = più antica)** per URL — semantica monotona identica al generatore `scripts/refresh-url-first-seen.mjs`. Output: chiavi ordinate, pretty 2-spazi, newline finale. Ignora l'ancestor (irrilevante per union-min).
- **`.gitattributes`**: `data/url-first-seen.json merge=json-first-seen` + commento sul perché `merge=union` non è applicabile.
- **`deploy.yml`** (step dist-history): `git config merge.json-first-seen.driver '...'` prima del commit/rebase così l'attributo è attivo; commenti stale del push loop aggiornati (non affermano più che solo il JSONL si risolve da solo).
- Verificato: self-test del driver (union + earliest) + **integration test reale** (`git rebase` con conflitto su `url-first-seen.json` → auto-risolto, exit 0, mappa corretta); `node --check` OK; `check-sibling-patterns.mjs` verde; nessun test snapshotta `.gitattributes`/url-first-seen.

## Non implementato (ancora)

- **Altri file JSON-object in push-rebase loop su `main`** (`data/funnel-metrics-history.json`, `data/quota-state.json`, `data/alert-snoozes.json`, `data/batch-faq-progress.json`): **non toccati** — classe diversa. Sono **single-producer** (un singolo workflow schedulato ciascuno, nessuna gara multi-produttore come il deploy shard) e hanno semantica di merge diversa (latest-wins / replace, non union-min-date). Il driver `json-first-seen` non vi si applica; nessuno di essi compare nel cluster di fallimenti. Follow-up se in futuro mostrano conflitti reali.
- **`refine-url-first-seen.yml`**: usa il path PR (branch + auto-merge), non il `pull --rebase` locale → i conflitti lì sono gestiti da `auto-merge-eval` (skip DIRTY), non da questo driver. Out of scope.
