### PR TITLE
fix(seo): redirect legacy cluster orphans to the live page, not an archived bridge

### DIFF
--- a/build-plugins/cfHot404BridgePlugin.ts
+++ b/build-plugins/cfHot404BridgePlugin.ts
@@ -40,6 +40,13 @@ import searchClusterMapFile from '../data/search-cluster-301-map.json';
 const SEARCH_CLUSTER_LEGACY_PATHS: string[] = Object.keys(
   (searchClusterMapFile as { map?: Record<string, string> }).map ?? {},
 );
+// Trailing-slash-normalized lookup: these legacy cluster orphans have a
+// VERIFIED-LIVE target (a specific live cluster or the canton board), so they
+// must REDIRECT the user to the real page rather than dead-end on a "Pagina
+// archiviata" compat bridge — see the meta-refresh branch in the emit loop.
+const SEARCH_CLUSTER_LEGACY_SET = new Set(
+  SEARCH_CLUSTER_LEGACY_PATHS.map((p) => p.replace(/\/+$/, '')),
+);
 
 // Anti-runaway rail (NOT a recovery limit): the 40k hard cap used to bite the
 // real CF-confirmed 404 universe — a time-sliced sweep (build-cf-hot-404s.mjs,
@@ -206,6 +213,9 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
 
         const to = withSlash(resolution.canonicalPath);
         const kind = resolution.kind;
+        // A legacy cluster orphan whose target is verified-live: redirect the
+        // user straight there instead of serving the archived compat bridge.
+        const isClusterRedirect = SEARCH_CLUSTER_LEGACY_SET.has(fromNorm);
 
         // Canton-drift recovery as a REAL 200 page WITH the job's full content.
         // For an IT canton-moved orphan (the apex is NOT behind the locale Worker,
@@ -254,16 +264,38 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
         // straight at it. Other kinds land on a listing/landing.
         const body = kind === 'canton-moved'
           ? `Questo annuncio e stato spostato. Lo trovi aggiornato alla pagina collegata qui sotto.`
+          : isClusterRedirect
+          ? `Questa ricerca ha una versione aggiornata. Ti stiamo portando alla pagina corretta; se non vieni reindirizzato, aprila qui sotto.`
           : `Questa pagina ${kind === 'company' ? 'azienda' : kind === 'search' ? 'di ricerca' : "dell annuncio"} non e piu disponibile. Abbiamo mantenuto una pagina compatibile per evitare un errore e mostrarti le offerte aggiornate per questa zona.`;
-        const html = buildCanonicalBridgePage({
+        let html = buildCanonicalBridgePage({
           canonicalUrl: `${BASE_URL}${to}`,
           pathLabel: to,
-          title: kind === 'canton-moved' ? 'Annuncio spostato | Frontaliere Ticino' : 'Pagina archiviata | Frontaliere Ticino',
+          title: kind === 'canton-moved'
+            ? 'Annuncio spostato | Frontaliere Ticino'
+            : isClusterRedirect
+            ? 'Ricerca aggiornata | Frontaliere Ticino'
+            : 'Pagina archiviata | Frontaliere Ticino',
           description: kind === 'canton-moved' ? `Annuncio spostato: vedi ${to}.` : `Annuncio non piu disponibile collegato a ${to}.`,
           body,
-          ctaLabel: kind === 'canton-moved' ? 'Vai all annuncio' : 'Vedi le offerte aggiornate',
+          ctaLabel: kind === 'canton-moved'
+            ? 'Vai all annuncio'
+            : isClusterRedirect
+            ? 'Apri la ricerca aggiornata'
+            : 'Vedi le offerte aggiornate',
           noindex: true,
         });
+
+        if (isClusterRedirect) {
+          // Land the user on the real (verified-live) page immediately. With the
+          // canonical link + noindex already set on the page, a meta-refresh is
+          // 301-equivalent for crawlers and an instant redirect for users — the
+          // same pattern cantonOrphanRedirectsPlugin uses. Replaces the dead-end
+          // "Pagina archiviata" compat bridge for these orphans.
+          html = html.replace(
+            '</head>',
+            `  <meta http-equiv="refresh" content="0; url=${to}">\n  </head>`,
+          );
+        }
 
         fs.mkdirSync(outDir, { recursive: true });
         fs.writeFileSync(path.join(outDir, 'index.html'), html, 'utf-8');

--- a/tests/cf-hot-404-bridge.test.ts
+++ b/tests/cf-hot-404-bridge.test.ts
@@ -62,6 +62,26 @@ describe('cfHot404BridgePlugin', () => {
     const file = path.join(tmp, 'dist', rel('/cerca-lavoro-zurigo/preexisting-richer-role'));
     expect(fs.readFileSync(file, 'utf-8')).toBe('<html>RICHER</html>');
   });
+
+  it('emits a legacy cluster orphan as a meta-refresh REDIRECT to its live target, not an archived bridge', () => {
+    // Data-driven: pick a real entry from the committed cluster recovery map so
+    // the test survives map regeneration.
+    const map = (
+      JSON.parse(fs.readFileSync(path.resolve('data/search-cluster-301-map.json'), 'utf-8')) as {
+        map: Record<string, string>;
+      }
+    ).map;
+    const [legacyPath, target] = Object.entries(map)[0];
+    const file = path.join(tmp, 'dist', rel(legacyPath.replace(/\/$/, '')));
+    expect(fs.existsSync(file)).toBe(true);
+    const html = fs.readFileSync(file, 'utf-8');
+    // Redirects the user straight to the live page…
+    expect(html).toContain(`<meta http-equiv="refresh" content="0; url=${target}"`);
+    expect(html).toContain(`rel="canonical" href="https://frontaliereticino.ch${target}"`);
+    expect(html).toContain('noindex');
+    // …instead of dead-ending on the archived compat copy.
+    expect(html).not.toContain('Pagina archiviata');
+  });
 });
 
 /**


### PR DESCRIPTION
## Implementato

Il recupero cluster-404 (#2917) emetteva una **"Pagina archiviata"** (compat-bridge 200, canonical→target) su ogni URL cluster legacy. Ma **ogni target è verificato-vivo** (cluster specifico o canton-board, da `data/search-cluster-301-map.json`), quindi far atterrare l'utente su una pagina archiviata è sbagliato. Caso: `/cerca-lavoro-ticino/ricerca-mansioni-tecnico-biomedico-50/` → canonical vivo `/cerca-lavoro-svizzera/ricerca-tecnico-biomedico-50/` ma mostrava "Pagina archiviata".

Fix: per i cluster-orphan (target verificato-vivo) inietto un **meta-refresh** al target (301-equivalente con canonical + noindex già presenti, pattern di `cantonOrphanRedirectsPlugin`) → l'utente atterra sulla **pagina reale**. I bridge non-cluster mantengono la compat-page.

- `cfHot404BridgePlugin.ts`: `SEARCH_CLUSTER_LEGACY_SET` → wording "Ricerca aggiornata" + `<meta http-equiv="refresh">`.
- `tests/cf-hot-404-bridge.test.ts`: assert meta-refresh al target + niente "Pagina archiviata". 7/7 verdi.

### Perché NON ho toccato il junk-filter
È corretto: i match alti su `mansioni`/`compiti`/`progetti` sono **spuri** (filler in ogni descrizione); i test esistenti li asseriscono junk apposta. Le query junk-led con coda-ruolo reale (`tecnico-biomedico`) hanno già un cluster vivo de-junked → soluzione = redirect all'esistente, non rilassare il filtro (riammetterebbe doorway). Dei 64 termini junk-led residui: 22 de-junkano a cluster vivo, 42 a bare-city low-value.

## Non implementato (ancora)
- Verifica live post-deploy (meta-refresh coperto da unit test; redirect reale osservabile al deploy).
- Coda 18% non-candidato (gap generazione candidati) — follow-up separato.
- Hard 301 nativo: IT-route bypassa il Worker → richiederebbe CF Bulk Redirects; meta-refresh+canonical è l'equivalente statico già in uso.