### PR TITLE
fix(jobboard): skip first-page fast-paint on filtered views (kills provisional-count flash)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2282,8 +2282,16 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // over normally. Skipped for canton-scoped pages other than TI because the
  // first-page asset is recency-ordered/TI-dominant — painting it for, say,
  // /cerca-lavoro-zurigo/ would flash mostly-TI cards before the scoped set.
+ //
+ // Also skipped for any FILTERED view (active search / company / location): the
+ // slim first-page is a recency-ordered generic payload, so filtering it yields
+ // a misleading provisional count + fallback banner (e.g. "1 offerta", then "0",
+ // then the real "34") before the authoritative shard lands. Holding the
+ // jobsLoading skeleton (hero + skeleton cards, same LCP element) until the full
+ // load is cleaner and avoids that flash; the unfiltered listing keeps the paint.
  const firstPaintEligible =
  !seededJob &&
+ !searchQuery.trim() && !companySlugFilter && !locationSlugFilter &&
  (targetCanton === AGGREGATE_CANTON_CODE || targetCanton === 'TI');
  if (firstPaintEligible) {
  const firstPage = await loadFirstPageSlim();


### PR DESCRIPTION
Follow-up a #2925 (che soppresse il flash "0" durante i fallback pool). Stesso sintomo, causa diversa, segnalata dall'owner sull'URL aggregate `/cerca-lavoro-svizzera/ricerca-responsabile-del-negozio/`: la pagina mostrava **"1 annuncio + alert" → "0" → "34 offerte"** prima di stabilizzarsi.

## Implementato

- **Root cause (case B)**: su route aggregate (`/cerca-lavoro-svizzera/`) e TI, un payload "first-page slim" recency-ordered viene dipinto presto per un LCP veloce (`firstPaintEligible`, #2580). Per una **vista filtrata** (ricerca/azienda/località) quel payload provvisorio viene filtrato → conteggio fuorviante + banner fallback (es. "1 offerta") che poi salta quando il full shard autoritativo atterra.
- **Fix** (`components/community/JobBoard.tsx`): `firstPaintEligible` ora salta il first-page paint quando è attivo un filtro `searchQuery` / `companySlugFilter` / `locationSlugFilter`. Così lo **skeleton `jobsLoading` esistente** (che renderizza già l'hero reale — l'elemento LCP — + skeleton cards) regge fino al full load; nessun numero provvisorio viene mai mostrato.
- **CWV preservato**: la listing default (non filtrata) mantiene il fast first-page paint → LCP invariato. Per le landing filtrate l'LCP è comunque l'hero, renderizzato dallo skeleton path immediatamente.
- **Verificato live in dev** vs dati CDN reali: aggregate search ora fa `skeleton → "Caricamento offerte…" → conteggio finale` senza flash "1"/"0"; la pagina salary-search TI (#2925) resta pulita a "30 offerte trovate".

## Risposta al ❓ del reviewer su #2925 (query successive)

Il reviewer chiedeva di un possibile flash empty-state per una query **modificata dopo** il load iniziale (refs `*FetchAttempted` one-shot già a true, `pendingFallbacks=0`). In pratica non si verifica: i pool broaden/cross-locale sono **già in memoria** dopo la prima ricerca thin e i memo (`crossCantonFallbackJobs`/`crossLocaleFallbackJobs`/…) ricalcolano **sincroni** sul nuovo `deferredSearchQuery` nello stesso commit → nessun frame a 0. Se una query successiva richiede un pool **non ancora** fetchato, il relativo ref è ancora `false` → l'effect parte e `pendingFallbacks` lo copre. Quando tutti i pool sono esauriti e la nuova query ha davvero 0 match → `noResults` immediato è lo stato terminale **corretto** (nessun fetch in volo), non un flash.

## Non implementato (ancora)

- **Nessun sibling da sweepare**: `firstPaintEligible` / `loadFirstPageSlim` esistono solo in `components/community/JobBoard.tsx` (verificato grep). `check-sibling-patterns` su #2925 aveva flaggato solo collisioni di nome (`SalarySurvey.tsx` token `loadingResults`, già corretto; `audit-jobs-source-match.mjs` token `filteredJobs`, script di audit) — non pertinenti a questo cambio.
- **Partial-count thin>0 su viste NON-aggregate/non-TI**: fuori scope — quei cantoni non eseguono affatto il first-page paint, quindi non hanno il flash provvisorio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)