### PR TITLE
feat(newsletter): greet by name harvested from "Name <addr>" email field

### DIFF
--- a/scripts/lib/parseEmailField.mjs
+++ b/scripts/lib/parseEmailField.mjs
@@ -1,0 +1,45 @@
+/**
+ * parseEmailField — robustly split a stored email field that may be a bare
+ * address ("mario.rossi@example.com") OR an RFC822 display form ("Mario Rossi
+ * <mario.rossi@example.com>" / "\"Mario Rossi\" <mario.rossi@example.com>").
+ *
+ * Some subscriber records were written with the full display string in the
+ * `email` field instead of a separate `name`. Left raw, that string leaks into
+ * the To: header and unsubscribe links (verified live 2026-06-25: a subscriber
+ * whose `email` held "Name <addr>" received To: that exact string and a
+ * polluted List-Unsubscribe param), and the human name sitting inside it never
+ * reaches the greeting.
+ *
+ * Returns the bare lowercased address (what To:/unsubscribe/doc-lookups want)
+ * plus the ORIGINAL-case display name (null when absent) so the newsletter can
+ * fall back to it as a greeting-name source.
+ *
+ * @param {unknown} raw
+ * @returns {{ email: string, displayName: string | null }}
+ */
+export function parseEmailField(raw) {
+  const str = String(raw || '').trim();
+  if (!str) return { email: '', displayName: null };
+
+  // "Display Name <addr@host>" (optionally quoted display name).
+  const angle = str.match(/^(.*?)<\s*([^<>\s]+)\s*>\s*$/);
+  if (angle) {
+    const name = angle[1].trim().replace(/^"(.*)"$/, '$1').trim();
+    const email = angle[2].trim().toLowerCase();
+    // A "name" that is itself an address (or empty) is not a human name.
+    return { email, displayName: name && !name.includes('@') ? name : null };
+  }
+
+  return { email: str.toLowerCase(), displayName: null };
+}
+
+/**
+ * Bare lowercased address from an email field, stripping any display name.
+ * Drop-in replacement for the old `trim().toLowerCase()` normalizer that also
+ * handles the "Name <addr>" form.
+ * @param {unknown} raw
+ * @returns {string}
+ */
+export function normalizeEmailAddress(raw) {
+  return parseEmailField(raw).email;
+}

--- a/scripts/lib/subscriberFromFirestoreRow.mjs
+++ b/scripts/lib/subscriberFromFirestoreRow.mjs
@@ -1,0 +1,50 @@
+import { parseEmailField } from './parseEmailField.mjs';
+import { calculateEngagementScore } from '../../functions/src/lib/engagementScore.js';
+
+/**
+ * Project a raw `newsletter_subscribers` Firestore row into the subscriber
+ * shape the send pipeline consumes. Extracted into its own module (away from
+ * the CLI `send-newsletter.mjs`, which can't be imported by vitest — its
+ * shebang + `import.meta.glob` break the vite/rollup parser) so the
+ * name-harvest behaviour is unit-testable.
+ *
+ * IMPORTANT: callers must pass the RAW `row` (do NOT pre-normalize
+ * `row.email`). The "Name <addr>" display name is harvested HERE via
+ * parseEmailField; pre-stripping the wrapper upstream would silently disable
+ * the greeting-name harvest while leaving `row.name` empty.
+ *
+ * @param {Record<string, any>} row
+ * @returns {object | null} null when the row has no usable email address
+ */
+export function subscriberFromFirestoreRow(row) {
+  const parsed = parseEmailField(row.email);
+  const email = parsed.email;
+  if (!email) return null;
+  const fresh = calculateEngagementScore(row);
+  return {
+    email,
+    // Greeting-name resolution: stored social name → display name harvested
+    // from a "Name <addr>" email field → (later) dataset-validated email guess.
+    name: row.name || parsed.displayName || null,
+    locale: (row.preferred_locale || row.locale || 'it').split(/[-_]/)[0] || 'it',
+    sourceChannel: row.source_channel || row.source || 'newsletter_page',
+    locationInterest: row.location_interest || null,
+    sectorInterest: row.sector_interest || null,
+    job_slug: row.job_slug || null,
+    job_company: row.job_company || null,
+    job_location: row.job_location || null,
+    job_category: row.job_category || null,
+    job_search_query: row.job_search_query || null,
+    job_context_backfill_slug: row.job_context_backfill_slug || null,
+    source: row.source || null,
+    preferences: row.preferences || {},
+    type: row.type || null,
+    // Default true: only skip autologin if user explicitly opted out
+    autologinEnabled: row.autologin_enabled !== false,
+    createdAt: row.createdAt?.toDate?.() || (row.created_at ? new Date(row.created_at) : null),
+    // Engagement metadata used for prioritized send order
+    sendCount: Number(row.send_count || row.sendCount) || 0,
+    engagementScore: fresh.score,
+    engagementLevel: fresh.level,
+  };
+}

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -48,6 +48,7 @@ import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { getCascadeDailyCapacity } from './lib/email-cascade.mjs';
 import { deriveNameFromEmail } from './lib/deriveNameFromEmail.mjs';
+import { parseEmailField, normalizeEmailAddress } from './lib/parseEmailField.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -119,7 +120,9 @@ function readArgValue(name) {
 }
 
 function normalizeEmail(raw) {
-  return String(raw || '').trim().toLowerCase();
+  // Strip any "Name <addr>" display wrapper so To:/unsubscribe/doc-lookups
+  // always get the bare lowercased address (see parseEmailField).
+  return normalizeEmailAddress(raw);
 }
 
 function hashEmail(email) {
@@ -1277,12 +1280,15 @@ function enrichSubscriberJobContext(subscriber, jobIndex) {
 const EXCLUDED_STATUSES = NEWSLETTER_EXCLUDED_STATUSES;
 
 function subscriberFromFirestoreRow(row) {
-  const email = normalizeEmail(row.email);
+  const parsed = parseEmailField(row.email);
+  const email = parsed.email;
   if (!email) return null;
   const fresh = calculateEngagementScore(row);
   return {
     email,
-    name: row.name || null,
+    // Greeting-name resolution: stored social name → display name harvested
+    // from a "Name <addr>" email field → (later) dataset-validated email guess.
+    name: row.name || parsed.displayName || null,
     locale: (row.preferred_locale || row.locale || 'it').split(/[-_]/)[0] || 'it',
     sourceChannel: row.source_channel || row.source || 'newsletter_page',
     locationInterest: row.location_interest || null,

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -40,7 +40,7 @@ import { pickWinner, resolveWinnersByProvider } from '../services/newsletter-ab-
 import { loadCampaignVariantTotals, previousCampaignIds } from './lib/newsletter-ab-data.mjs';
 import { buildDeliveryDocId } from '../functions/src/lib/deliveryDocId.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib/emailExperimentPostHog.js';
-import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
+import { refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { NEWSLETTER_EXCLUDED_STATUSES } from '../services/emailSuppression.mjs';
 import { makeUnsubscribeUrl, makeResubscribeUrl, generateAutologinCode } from '../services/newsletterUrls.mjs';
@@ -48,7 +48,8 @@ import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { getCascadeDailyCapacity } from './lib/email-cascade.mjs';
 import { deriveNameFromEmail } from './lib/deriveNameFromEmail.mjs';
-import { parseEmailField, normalizeEmailAddress } from './lib/parseEmailField.mjs';
+import { normalizeEmailAddress } from './lib/parseEmailField.mjs';
+import { subscriberFromFirestoreRow } from './lib/subscriberFromFirestoreRow.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -1279,39 +1280,6 @@ function enrichSubscriberJobContext(subscriber, jobIndex) {
 // Shared source of truth (services/emailSuppression.mjs) so all senders agree.
 const EXCLUDED_STATUSES = NEWSLETTER_EXCLUDED_STATUSES;
 
-function subscriberFromFirestoreRow(row) {
-  const parsed = parseEmailField(row.email);
-  const email = parsed.email;
-  if (!email) return null;
-  const fresh = calculateEngagementScore(row);
-  return {
-    email,
-    // Greeting-name resolution: stored social name → display name harvested
-    // from a "Name <addr>" email field → (later) dataset-validated email guess.
-    name: row.name || parsed.displayName || null,
-    locale: (row.preferred_locale || row.locale || 'it').split(/[-_]/)[0] || 'it',
-    sourceChannel: row.source_channel || row.source || 'newsletter_page',
-    locationInterest: row.location_interest || null,
-    sectorInterest: row.sector_interest || null,
-    job_slug: row.job_slug || null,
-    job_company: row.job_company || null,
-    job_location: row.job_location || null,
-    job_category: row.job_category || null,
-    job_search_query: row.job_search_query || null,
-    job_context_backfill_slug: row.job_context_backfill_slug || null,
-    source: row.source || null,
-    preferences: row.preferences || {},
-    type: row.type || null,
-    // Default true: only skip autologin if user explicitly opted out
-    autologinEnabled: row.autologin_enabled !== false,
-    createdAt: row.createdAt?.toDate?.() || (row.created_at ? new Date(row.created_at) : null),
-    // Engagement metadata used for prioritized send order
-    sendCount: Number(row.send_count || row.sendCount) || 0,
-    engagementScore: fresh.score,
-    engagementLevel: fresh.level,
-  };
-}
-
 async function fetchTargetSubscriber(email) {
   const normalized = normalizeEmail(email);
   if (!normalized) return null;
@@ -1334,14 +1302,16 @@ async function fetchSubscribers() {
     snap.docs.forEach((d) => {
       if (d.id === '_meta_') return;
       const row = d.data();
-      const email = normalizeEmail(row.email);
-      if (!email) return;
+      if (!row.email) return;
       const status = (row.status || '').toLowerCase();
       if (EXCLUDED_STATUSES.has(status)) return;
       // Belt-and-suspenders: also exclude if unsubscribedAt is set (frontend handler bug backfill)
       if (row.unsubscribedAt || row.unsubscribed_at) return;
-      const subscriber = subscriberFromFirestoreRow({ ...row, email });
-      if (subscriber) subscribers.set(email, subscriber);
+      // Pass the RAW row.email so subscriberFromFirestoreRow can harvest a
+      // "Name <addr>" display name; it strips the wrapper internally and
+      // returns the bare address on subscriber.email.
+      const subscriber = subscriberFromFirestoreRow(row);
+      if (subscriber) subscribers.set(subscriber.email, subscriber);
     });
   } catch (e) {
     console.warn('\u26a0\ufe0f Subscriber fetch failed:', e.message);

--- a/tests/parse-email-field.test.ts
+++ b/tests/parse-email-field.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parseEmailField, normalizeEmailAddress } from '../scripts/lib/parseEmailField.mjs';
 import { personalizeGreeting } from '../services/newsletter-template.mjs';
+import { subscriberFromFirestoreRow } from '../scripts/lib/subscriberFromFirestoreRow.mjs';
 
 describe('parseEmailField', () => {
   it('passes through a bare address (lowercased)', () => {
@@ -58,5 +59,30 @@ describe('greeting harvested from a polluted email field', () => {
     const row = { email: 'Mario Rossi <mario.rossi@example.com>', name: 'Gianni' };
     const recipientName = row.name || parseEmailField(row.email).displayName;
     expect(personalizeGreeting('it', recipientName)).toBe('Buongiorno, Gianni.');
+  });
+});
+
+// Regression guard for the real send path: subscriberFromFirestoreRow must
+// receive the RAW row.email and harvest the display name itself, returning the
+// bare address on .email. (A caller that pre-strips the wrapper before passing
+// the row would silently disable the harvest — the bug caught in review.)
+describe('subscriberFromFirestoreRow harvests name from a polluted email field', () => {
+  it('returns bare email + harvested name when only the email field carries it', () => {
+    const s = subscriberFromFirestoreRow({ email: 'Mario Rossi <mario.rossi@example.com>', name: null });
+    expect(s?.email).toBe('mario.rossi@example.com');
+    expect(s?.name).toBe('Mario Rossi');
+    expect(personalizeGreeting('it', s?.name)).toBe('Buongiorno, Mario.');
+  });
+
+  it('stored name wins; bare email still normalized', () => {
+    const s = subscriberFromFirestoreRow({ email: 'Mario Rossi <mario.rossi@example.com>', name: 'Gianni' });
+    expect(s?.email).toBe('mario.rossi@example.com');
+    expect(s?.name).toBe('Gianni');
+  });
+
+  it('plain bare email yields no harvested name', () => {
+    const s = subscriberFromFirestoreRow({ email: 'bare@example.com', name: null });
+    expect(s?.email).toBe('bare@example.com');
+    expect(s?.name).toBeNull();
   });
 });

--- a/tests/parse-email-field.test.ts
+++ b/tests/parse-email-field.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { parseEmailField, normalizeEmailAddress } from '../scripts/lib/parseEmailField.mjs';
+import { personalizeGreeting } from '../services/newsletter-template.mjs';
+
+describe('parseEmailField', () => {
+  it('passes through a bare address (lowercased)', () => {
+    expect(parseEmailField('Mario@Example.com')).toEqual({ email: 'mario@example.com', displayName: null });
+    expect(parseEmailField('  spaced@example.com ')).toEqual({ email: 'spaced@example.com', displayName: null });
+  });
+
+  it('extracts bare address + original-case display name from "Name <addr>"', () => {
+    expect(parseEmailField('Mario Rossi <mario.rossi@example.com>')).toEqual({
+      email: 'mario.rossi@example.com',
+      displayName: 'Mario Rossi',
+    });
+    // lowercased-in-storage variant (normalizeEmail used to lowercase the whole field)
+    expect(parseEmailField('mario rossi <mario.rossi@example.com>')).toEqual({
+      email: 'mario.rossi@example.com',
+      displayName: 'mario rossi',
+    });
+  });
+
+  it('handles a quoted display name', () => {
+    expect(parseEmailField('"Anna Maria" <anna@example.com>')).toEqual({
+      email: 'anna@example.com',
+      displayName: 'Anna Maria',
+    });
+  });
+
+  it('treats an address-only angle form as no display name', () => {
+    expect(parseEmailField('<bob@example.com>')).toEqual({ email: 'bob@example.com', displayName: null });
+  });
+
+  it('empty / nullish → empty address', () => {
+    for (const v of [null, undefined, '', '   ']) {
+      expect(parseEmailField(v as string)).toEqual({ email: '', displayName: null });
+    }
+  });
+
+  it('normalizeEmailAddress strips the display wrapper', () => {
+    expect(normalizeEmailAddress('Mario Rossi <mario.rossi@example.com>')).toBe('mario.rossi@example.com');
+    expect(normalizeEmailAddress('bare@example.com')).toBe('bare@example.com');
+  });
+});
+
+// The reported case: subscriber whose `email` field holds the full display
+// string and has no separate `name` → greeting must become "Buongiorno, Mario."
+// instead of the generic "Buongiorno, frontaliere." (mirrors send-newsletter's
+// resolution: row.name || parseEmailField(row.email).displayName).
+describe('greeting harvested from a polluted email field', () => {
+  it('greets by first name when name lives inside the email field', () => {
+    const row = { email: 'Mario Rossi <mario.rossi@example.com>', name: null as string | null };
+    const recipientName = row.name || parseEmailField(row.email).displayName;
+    expect(personalizeGreeting('it', recipientName)).toBe('Buongiorno, Mario.');
+  });
+
+  it('stored name still wins over the email field', () => {
+    const row = { email: 'Mario Rossi <mario.rossi@example.com>', name: 'Gianni' };
+    const recipientName = row.name || parseEmailField(row.email).displayName;
+    expect(personalizeGreeting('it', recipientName)).toBe('Buongiorno, Gianni.');
+  });
+});


### PR DESCRIPTION
## Implementato

Alcuni record subscriber hanno il display string completo (es. `Mario Rossi <mario.rossi@example.com>`) dentro il campo `email` invece di un campo `name` separato. Due effetti, entrambi visti su un invio reale (2026-06-25): la stringa raw finisce nell'header `To:` e nel param `List-Unsubscribe`, e il nome umano dentro l'email non arriva mai al saluto → il subscriber riceve il generico "Buongiorno, frontaliere." pur avendo il nome nel dato.

Fix al confine di lettura nel send-newsletter (la `class` del bug, non il singolo campo):

- **`scripts/lib/parseEmailField.mjs`** (nuovo modulo condiviso, anti-drift): `parseEmailField(raw)` → `{ email: bare-lowercased, displayName: original-case|null }`, gestisce sia indirizzo nudo sia forma `Name <addr>` / `"Name" <addr>`. `normalizeEmailAddress()` è drop-in del vecchio `trim().toLowerCase()` che ora **estrae anche l'indirizzo nudo** dal wrapper.
- **`scripts/send-newsletter.mjs`**: `normalizeEmail()` delega a `normalizeEmailAddress()` → `To:` / unsubscribe / doc-lookup ricevono sempre l'indirizzo nudo (risolve la pollution di header e List-Unsubscribe).
- **`subscriberFromFirestoreRow`**: risoluzione nome diventa `row.name || display-name-dal-campo-email || (poi) guess email validato a dataset`. `sanitizeFirstName` già riduce "Mario Rossi" → "Mario", quindi il saluto diventa "Buongiorno, Mario.".
- **`tests/parse-email-field.test.ts`**: 8 test su parsing (bare/`Name <addr>`/quoted/address-only/nullish), strip del wrapper, e il caso end-to-end del saluto (nome dal campo email; stored name che vince sul campo email). Dati fittizi (`example.com`), nessuna PII.

Si innesta sulla risoluzione già esistente (#2863 first-name greeting, #2874 email-dataset guess): il display-name harvested si inserisce come fonte **tra** lo stored social name e il guess da dataset. Byte-identico per i subscriber già con `name` o con email nuda.

## Non implementato (ancora)

- **Backfill Firestore dei record `email = "Name <addr>"`** (split → `name` + `email` nudo nel doc): non fatto — il parse al confine di lettura copre già il sintomo per l'invio (To:/unsubscribe/saluto) senza mutare dati di produzione (più rischioso). Follow-up di igiene dati.
- **Guard all'intake** (handler iscrizione / import che ha prodotto i record sporchi): non toccato — la sorgente esatta della pollution non è identificata; il fix read-side è completo per il funnel newsletter. Follow-up.
- **Sibling `normalizeEmail` (12 file, flaggati da `check-sibling-patterns.mjs`)**: NON modificati perché normalizzano email da sorgenti diverse, non lo stesso antipattern:
  - `functions/src/newsletter*WebhookCore.js` (Maileroo/Mailgun/Mailjet/Mailtrap/Resend/Unosend) + `newsletterSubscriptionManagement.js` + `lib/deliveryDocId.js`: normalizzano email **in arrivo dai provider/webhook** (sempre indirizzo nudo) o per doc-keying; non costruiscono `To:` né salutano.
  - `services/jobAlertService.ts` (impact GitNexus: LOW, solo create/delete/updateAlert client SPA): doc-key dall'email dell'utente autenticato lato client; l'harvest del nome appartiene al send path.
  - `services/newsletter-subject-assign.mjs` / `newsletter-subject-variants.mjs`: hashing deterministico per A/B; la pollution non rompe `To:`/nome (e ora ricevono comunque email nuda dal send path).
  - `scripts/migrate-job-alerts-to-subscribers.mjs`: migrazione one-time, non funnel live.
- **Personalizzazione saluto job-alert** (`scripts/send-job-alerts.mjs`): fuori scope (funnel diverso, l'utente ha chiesto la newsletter); costruisce `To:` da `alert.email`/`data.email` senza `normalizeEmail` → eventuale pollution è issue separata, non flaggata dal sibling-checker.

## Test plan

- [x] `npx vitest run tests/parse-email-field.test.ts tests/derive-name-from-email.test.ts tests/newsletter-greeting.test.ts tests/newsletter-subscriber-priority.test.ts tests/newsletter-subscriber-status.test.ts` → 31 passed.
- [ ] Verifica live sul prossimo invio newsletter: subscriber con nome nel campo email riceve "Buongiorno, <Nome>." e `To:` con indirizzo nudo.