### PR TITLE
fix(jobboard): hold skeleton until terminal cross-locale fallback (kill residual "0" flash)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -3484,7 +3484,16 @@ const JobBoard: React.FC<JobBoardProps> = ({
  (Boolean(deferredSearchQuery.trim()) || Boolean(companySlugFilter))
  && (
  fullLoadPending
- || (filteredJobs.length === 0 && (pendingFallbacks > 0 || !anyFallbackAttempted))
+ || (filteredJobs.length === 0 && (
+ pendingFallbacks > 0
+ || !anyFallbackAttempted
+ // Terminal cross-locale fallback (Tier 4) hasn't run yet. For a 0-result
+ // search the in-canton tiers are all empty, so this fetch WILL fire and may
+ // still bring results — hold the skeleton instead of flashing "0" in the gap
+ // between an earlier fallback settling and Tier 4 firing. Once it's attempted
+ // (ref set), a still-empty set falls through to the genuine empty-state.
+ || (Boolean(deferredSearchQuery.trim()) && !crossLocaleFetchAttempted.current)
+ ))
  );
 
  // True when the result set is the in-canton OR-fallback (Tier 2). Keeps


### PR DESCRIPTION
Follow-up a #2934. Su `/cerca-lavoro-svizzera/ricerca-responsabile-del-negozio/` il flash provvisorio "1 + alert" è eliminato (verificato live), ma restava un **"0 offerte trovate" di ~1 frame** tra il settle del full-shard e l'arrivo dei risultati cross-locale.

## Implementato

- **Root cause**: nel gap tra full-load e risultati Tier-4, `filteredJobs` è 0, un fallback precedente ha già settato il ref (`anyFallbackAttempted` true) e `pendingFallbacks` è tornato 0 → `resultsResolving` diventava brevemente false → render del conteggio "0".
- **Fix** (`components/community/JobBoard.tsx`): per una ricerca attiva con `filteredJobs===0`, mantengo `resultsResolving` (skeleton) anche finché `crossLocaleFetchAttempted.current` è false. Per una ricerca a 0 risultati i tier in-cantone sono tutti vuoti → il fallback cross-locale (Tier 4) **partirà** e può ancora portare risultati → niente "0" nel gap. Una volta tentato (ref settato), un set ancora vuoto cade nel genuine empty-state → ricerca davvero vuota **non resta bloccata** in loading.
- **Verificato in dev (cache-disabled)**: TI salary-search → "30 offerte trovate" pulito; query inesistente → loading → no-results (niente "0" intermedio nudo); default board 12092 risultati + card; nessuno bloccato. Test `jobboard-*` verdi (32).

## Non implementato (ancora)

- **Gap "0" su viste company-only** (senza search query): non toccato — il fallback terminale lì è `companyBroaden`, non cross-locale, e il caso non è stato segnalato. La clausola è scoped a `deferredSearchQuery.trim()` per non bloccare le viste company.
- **Nessun sibling**: `resultsResolving`/`crossLocaleFetchAttempted` vivono solo in `components/community/JobBoard.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)