### PR TITLE
feat(newsletter): confident first-name resolution + persist firstName on send

### DIFF
--- a/scripts/lib/deriveNameFromEmail.mjs
+++ b/scripts/lib/deriveNameFromEmail.mjs
@@ -37,16 +37,31 @@ function deaccent(s) {
 }
 
 /**
+ * recognizeFirstName — high-confidence first name from a free-text candidate
+ * (an email local-part OR a display name like "Mario Rossi"). Takes the first
+ * token (split on space / . _ + -), rejects role/relay words, and requires it
+ * to be a recognized first name in the open-source dataset. Returns the
+ * title-cased name, or null when the token isn't a confident human first name
+ * (caller then falls back to the generic greeting). Precision over recall.
+ *
+ * @param {unknown} candidate
+ * @returns {string|null}
+ */
+export function recognizeFirstName(candidate) {
+  if (!candidate || typeof candidate !== 'string') return null;
+  const norm = candidate.toLowerCase().trim();
+  if (!norm || ROLE_LOCALPARTS.has(norm)) return null;
+  const first = norm.split(/[\s._+\-]+/).filter(Boolean)[0] || '';
+  if (!first || ROLE_LOCALPARTS.has(first)) return null;
+  if (!FIRST_NAMES.has(deaccent(first))) return null; // must be a real first name
+  return sanitizeFirstName(first); // validity + title-case display form
+}
+
+/**
  * @param {unknown} email
  * @returns {string|null} a title-cased first name, or null when not derivable
  */
 export function deriveNameFromEmail(email) {
   if (!email || typeof email !== 'string' || !email.includes('@')) return null;
-  const local = email.split('@')[0].toLowerCase().trim();
-  if (ROLE_LOCALPARTS.has(local)) return null;
-  // firstname<sep>lastname or a bare firstname — take the first token.
-  const first = local.split(/[._+\-]+/).filter(Boolean)[0] || '';
-  if (!first || ROLE_LOCALPARTS.has(first)) return null;
-  if (!FIRST_NAMES.has(deaccent(first))) return null; // must be a real first name
-  return sanitizeFirstName(first); // validity + title-case display form
+  return recognizeFirstName(email.split('@')[0]);
 }

--- a/scripts/lib/subscriberFromFirestoreRow.mjs
+++ b/scripts/lib/subscriberFromFirestoreRow.mjs
@@ -1,5 +1,36 @@
 import { parseEmailField } from './parseEmailField.mjs';
+import { deriveNameFromEmail, recognizeFirstName } from './deriveNameFromEmail.mjs';
+import { sanitizeFirstName } from '../../services/newsletter-template.mjs';
 import { calculateEngagementScore } from '../../functions/src/lib/engagementScore.js';
+
+/**
+ * Resolve the greeting first name for a subscriber row, highest confidence
+ * first. Anything not confidently a real human first name resolves to null,
+ * and the caller falls back to the generic "frontaliere" greeting.
+ *
+ *   1. row.firstName — clean stored first name (no re-derivation needed)
+ *   2. row.name      — social display name (Google/LinkedIn/Facebook auth)
+ *   3. display name harvested from a "Name <addr>" email field — dataset-validated
+ *   4. dataset-validated guess from the email local-part
+ *
+ * (1)/(2) are trusted auth-provided names → only sanitized. (3)/(4) are
+ * lower-trust → must clear recognizeFirstName/deriveNameFromEmail (role-word
+ * + open-source names dataset), so "Frontaliere Ticino <addr>" or "info@…"
+ * never produce a bogus greeting.
+ *
+ * @param {Record<string, any>} row
+ * @param {{ email: string, displayName: string|null }} parsed
+ * @returns {string|null}
+ */
+function resolveFirstName(row, parsed) {
+  return (
+    sanitizeFirstName(row.firstName) ||
+    sanitizeFirstName(row.name) ||
+    recognizeFirstName(parsed.displayName) ||
+    deriveNameFromEmail(parsed.email) ||
+    null
+  );
+}
 
 /**
  * Project a raw `newsletter_subscribers` Firestore row into the subscriber
@@ -21,11 +52,15 @@ export function subscriberFromFirestoreRow(row) {
   const email = parsed.email;
   if (!email) return null;
   const fresh = calculateEngagementScore(row);
+  const firstName = resolveFirstName(row, parsed);
   return {
     email,
-    // Greeting-name resolution: stored social name → display name harvested
-    // from a "Name <addr>" email field → (later) dataset-validated email guess.
     name: row.name || parsed.displayName || null,
+    // Greeting first name (high-confidence or null → generic greeting).
+    firstName,
+    // When the doc has no stored firstName yet but we resolved one, persist it
+    // on the next send so future runs skip re-derivation (see persistDelivery).
+    firstNameToPersist: !row.firstName && firstName ? firstName : null,
     locale: (row.preferred_locale || row.locale || 'it').split(/[-_]/)[0] || 'it',
     sourceChannel: row.source_channel || row.source || 'newsletter_page',
     locationInterest: row.location_interest || null,

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -47,7 +47,6 @@ import { makeUnsubscribeUrl, makeResubscribeUrl, generateAutologinCode } from '.
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { getCascadeDailyCapacity } from './lib/email-cascade.mjs';
-import { deriveNameFromEmail } from './lib/deriveNameFromEmail.mjs';
 import { normalizeEmailAddress } from './lib/parseEmailField.mjs';
 import { subscriberFromFirestoreRow } from './lib/subscriberFromFirestoreRow.mjs';
 
@@ -1477,11 +1476,17 @@ async function persistDelivery(recipient, messageId, meta) {
       }, { merge: true });
     }
     // Update subscriber-level counters
-    await subRef.set({
+    const subUpdate = {
       last_sent_at: new Date(),
       send_count: FieldValue ? FieldValue.increment(1) : 1,
       updated_at: new Date(),
-    }, { merge: true });
+    };
+    // Persist a freshly-resolved first name (display-name harvest / dataset
+    // email guess) so future sends read it from firstName instead of
+    // re-deriving. Only set when the doc had none (subscriberFromFirestoreRow
+    // leaves firstNameToPersist null otherwise) → never clobbers a stored name.
+    if (recipient.firstNameToPersist) subUpdate.firstName = recipient.firstNameToPersist;
+    await subRef.set(subUpdate, { merge: true });
     // Refresh engagement score after counter changes (FRO-17). Belt-and-suspenders
     // alongside the ESP webhook recompute, so the persisted score stays fresh
     // even if a webhook delivery is lost.
@@ -2133,10 +2138,10 @@ async function main() {
       weeklyFact: getWeeklyFact(locale),
       metrics,
       locale,
-      // Stored name (from social sign-in) first; else a dataset-validated guess
-      // from the email local-part; else null → generic greeting. The template's
-      // personalizeGreeting title-cases it (handles ALL-CAPS stored names).
-      recipientName: subscriber.name || deriveNameFromEmail(subscriber.email),
+      // High-confidence first name resolved in subscriberFromFirestoreRow
+      // (stored firstName/name → harvested display name → dataset email guess),
+      // or null → generic greeting. personalizeGreeting title-cases it.
+      recipientName: subscriber.firstName,
       issueNumber,
       unsubscribeUrl: makeUnsubscribeUrl(subscriber.email),
       resubscribeUrl: makeResubscribeUrl(subscriber.email),

--- a/tests/derive-name-from-email.test.ts
+++ b/tests/derive-name-from-email.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { deriveNameFromEmail } from '../scripts/lib/deriveNameFromEmail.mjs';
+import { deriveNameFromEmail, recognizeFirstName } from '../scripts/lib/deriveNameFromEmail.mjs';
 import { sanitizeFirstName, personalizeGreeting } from '../services/newsletter-template.mjs';
+
+describe('recognizeFirstName (shared validator)', () => {
+  it('recognizes a real first name from a display name or token, title-cased', () => {
+    expect(recognizeFirstName('Mario Rossi')).toBe('Mario');
+    expect(recognizeFirstName('giuseppe')).toBe('Giuseppe');
+    expect(recognizeFirstName('FRANCESCA galli')).toBe('Francesca');
+  });
+
+  it('rejects role/brand words and non-names → null', () => {
+    for (const v of ['Frontaliere Ticino', 'Newsletter', 'info', 'no-reply', 'cooldude', '', null, undefined]) {
+      expect(recognizeFirstName(v as string)).toBeNull();
+    }
+  });
+});
 
 describe('deriveNameFromEmail (dataset-validated)', () => {
   it('derives recognized first names from the local-part', () => {

--- a/tests/parse-email-field.test.ts
+++ b/tests/parse-email-field.test.ts
@@ -104,3 +104,49 @@ describe('subscriberFromFirestoreRow harvests name from a polluted email field',
     expect(s?.name).toBeNull();
   });
 });
+
+// Confident first-name resolution + persistence flag (greet by name when sure,
+// else generic "frontaliere"; persist the resolved name so it isn't re-derived).
+describe('subscriberFromFirestoreRow first-name resolution', () => {
+  it('validates + flags a harvested name for persistence', () => {
+    const s = subscriberFromFirestoreRow({ email: 'Mario Rossi <mario.rossi@example.com>', name: null });
+    expect(s?.firstName).toBe('Mario');
+    expect(s?.firstNameToPersist).toBe('Mario'); // no stored firstName → persist
+    expect(personalizeGreeting('it', s?.firstName)).toBe('Buongiorno, Mario.');
+  });
+
+  it('stored firstName wins and is NOT re-flagged for persistence', () => {
+    const s = subscriberFromFirestoreRow({
+      email: 'Mario Rossi <mario.rossi@example.com>', name: null, firstName: 'Gianni',
+    });
+    expect(s?.firstName).toBe('Gianni');
+    expect(s?.firstNameToPersist).toBeNull();
+  });
+
+  it('stored social name wins over the email field', () => {
+    const s = subscriberFromFirestoreRow({ email: 'Mario Rossi <mario.rossi@example.com>', name: 'Luca Bianchi' });
+    expect(s?.firstName).toBe('Luca');
+  });
+
+  it('dataset-validated guess from the bare email local-part', () => {
+    const s = subscriberFromFirestoreRow({ email: 'giuseppe.verdi@example.com', name: null });
+    expect(s?.firstName).toBe('Giuseppe');
+    expect(s?.firstNameToPersist).toBe('Giuseppe');
+  });
+
+  // A role/brand display name in the email field must NOT produce a bogus
+  // greeting — it falls back to the generic "frontaliere", nothing persisted.
+  it('rejects a role/brand display name → generic greeting, nothing persisted', () => {
+    for (const email of [
+      'Frontaliere Ticino <weekly@example.com>',
+      'Newsletter <news@example.com>',
+      'Info <info@example.com>',
+      'cooldude2000@example.com',
+    ]) {
+      const s = subscriberFromFirestoreRow({ email, name: null });
+      expect(s?.firstName).toBeNull();
+      expect(s?.firstNameToPersist).toBeNull();
+      expect(personalizeGreeting('it', s?.firstName)).toBe('Buongiorno, frontaliere.');
+    }
+  });
+});


### PR DESCRIPTION
Follow-up di #2936 (issue #2938). #2939 ha già indurito `parseEmailField` contro i campi non-indirizzo (#2938 item 3), quindi questa PR è solo la **confidenza sul nome del saluto + persistenza**.

Due gap residui: il display-name harvested dal campo email finiva nel saluto **senza validazione** (un campo sporco con nome-ruolo/brand → "Buongiorno, Frontaliere."/"Info."), e il nome veniva **ri-dedotto a ogni invio**.

## Implementato

- **`scripts/lib/deriveNameFromEmail.mjs`**: estratto `recognizeFirstName(candidate)` (role-word stop-list + dataset open-source nomi + `sanitizeFirstName`); `deriveNameFromEmail` ora vi delega → unico validatore, niente drift.
- **`scripts/lib/subscriberFromFirestoreRow.mjs`**: `resolveFirstName()` risolve il nome saluto per **confidenza decrescente**: `row.firstName` (stored, niente re-derive) → `row.name` (nome social) → display-name harvested dal campo email (**validato a dataset**) → guess dal local-part email (**validato a dataset**) → `null` (saluto generico "frontaliere"). I nomi auth-provided (firstName/name) sono solo sanitizzati; le fonti a bassa fiducia (campo email/local-part) **devono** superare il dataset → mai saluto bogus. Espone `subscriber.firstName` + `firstNameToPersist` (valorizzato solo se il doc non ha già `firstName` → **non sovrascrive mai** un nome stored).
- **`scripts/send-newsletter.mjs`**: il saluto legge `subscriber.firstName`; `persistDelivery` scrive `firstName` sul doc subscriber all'invio → i run futuri leggono il nome invece di ri-dedurlo (backfill **lazy**, #2938 item 1).
- **Test**: `recognizeFirstName` (riconosce/rifiuta role/brand), `subscriberFromFirestoreRow` catena confidenza + `firstNameToPersist` + rifiuto role/brand → saluto generico. 43 test verdi nel subset newsletter. Dati fittizi (`example.com`), nessuna PII.

Risolve la confidenza richiesta dall'owner: nome certo → lo uso; incerto → "frontaliere"; e lo salvo in `firstName` su Firestore per non dedurlo ogni volta.

## Non implementato (ancora)

- **#2938 item 1 (completo) — backfill/split del campo `email = "Name <addr>"`**: questa PR fa solo il backfill **lazy di `firstName`** all'invio; lo split del campo `email` per i consumer non-newsletter (reporting/admin/export) resta uno script di migrazione separato (mutazione bulk di produzione, più rischiosa) — #2938 resta aperto.
- **#2938 item 2 — guard all'intake**: la sorgente che produce `email = "Name <addr>"` non è identificata; il fix read-side copre il funnel newsletter, ma il punto di scrittura va tracciato a parte — #2938 resta aperto.
- **#2938 item 3**: già risolto da #2939 (parseEmailField rifiuta i non-indirizzi). Nessuna modifica a `parseEmailField.mjs` in questa PR.
- **Sibling `normalizeEmail`/field-name (`check-sibling-patterns.mjs`)**: candidati euristici per nomi-campo condivisi e `normalizeEmail`; non lo stesso antipattern (webhook/provider = email nude; `services/newsletterSubscribers.ts` = proiezione client SPA, non send/greeting). Giustificati come in #2936.

## Test plan

- [x] `npx vitest run tests/parse-email-field.test.ts tests/derive-name-from-email.test.ts tests/newsletter-greeting.test.ts tests/newsletter-subscriber-priority.test.ts tests/newsletter-subscriber-status.test.ts` → 43 passed.
- [x] Smoke `import` di `send-newsletter.mjs` + risoluzione: "Mario Rossi <…>"→Mario(persist), "giuseppe.verdi@"→Giuseppe(persist), "Frontaliere Ticino <…>"→null(generico), stored firstName→non sovrascritto.
- [ ] Verifica live prossimo invio: subscriber con nome certo riceve "Buongiorno, <Nome>." e il doc ottiene `firstName`; record con nome-ruolo nel campo email → "Buongiorno, frontaliere.".

Refs #2938