### PR TITLE
fix(ai-models): disable Cloudflare Workers AI by default ($0 neuron policy)

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -627,6 +627,15 @@ function getSambaNovaApiKey()  { return (process.env.SAMBANOVA_API_KEY || '').tr
 function getCohereApiKey()    { return (process.env.COHERE_API_KEY || '').trim(); }
 function getCloudflareApiToken() { return (process.env.CF_API_TOKEN || '').trim(); }
 function getCfAccountId()    { return (process.env.CF_ACCOUNT_ID || '').trim(); }
+// Cloudflare Workers AI is DISABLED by default ($0 policy). Its "free" tier is a
+// hard 10K-neurons/day cap; every neuron past it bills at $0.011/1K (the
+// "Regular Twitch Neurons" line on the CF bill — measured ~50-86K neurons/day
+// = ~$0.50-0.84/day overage from the crawler/article LLM fallback chain). The
+// other 100+ free models across 13 providers cover all fallback need, so cf/*
+// stays off unless explicitly opted back in via CF_WORKERS_AI_ENABLED=1.
+function isCloudflareWorkersAiEnabled() {
+  return /^(1|true|yes|on)$/i.test((process.env.CF_WORKERS_AI_ENABLED || '').trim());
+}
 function getMistralApiKey()  { return (process.env.MISTRAL_API_KEY || '').trim(); }
 function getCodestralApiKey() { return getMistralApiKey(); }  // Same key, separate endpoint
 function getChutesApiKey()   { return (process.env.CHUTES_API_KEY || '').trim(); }
@@ -717,8 +726,10 @@ function getApiKeyForProvider(provider) {
     case PROVIDER.HUGGINGFACE: return getHuggingFaceApiKey();
     case PROVIDER.SAMBANOVA:   return getSambaNovaApiKey();
     case PROVIDER.COHERE:      return getCohereApiKey();
-    // Cloudflare needs BOTH token AND account ID to construct the endpoint
-    case PROVIDER.CLOUDFLARE:  return (getCloudflareApiToken() && getCfAccountId()) ? getCloudflareApiToken() : '';
+    // Cloudflare needs BOTH token AND account ID to construct the endpoint — and
+    // is off by default ($0 policy; see isCloudflareWorkersAiEnabled). Returning
+    // '' marks every cf/* model unavailable, so the chain never selects it.
+    case PROVIDER.CLOUDFLARE:  return (isCloudflareWorkersAiEnabled() && getCloudflareApiToken() && getCfAccountId()) ? getCloudflareApiToken() : '';
     case PROVIDER.MISTRAL:     return getMistralApiKey();
     case PROVIDER.CODESTRAL:   return getCodestralApiKey();
     case PROVIDER.CHUTES:      return getChutesApiKey();
@@ -2472,6 +2483,9 @@ function _callCohere(model, messages, opts) {
  * Endpoint is dynamic: requires CF_ACCOUNT_ID in the URL.
  */
 function _callCloudflare(model, messages, opts) {
+  // Defense-in-depth: cf/* should already be filtered out as unavailable, but
+  // refuse to spend billable neurons if any path reaches here with CF off.
+  if (!isCloudflareWorkersAiEnabled()) throw new Error('Cloudflare Workers AI disabled (CF_WORKERS_AI_ENABLED not set) — $0 policy');
   const apiModel = getApiModelId(model);
   const accountId = getCfAccountId();
   if (!accountId) throw new Error('CF_ACCOUNT_ID not set');

--- a/tests/scripts/ai-models-cloudflare-disabled-by-default.test.ts
+++ b/tests/scripts/ai-models-cloudflare-disabled-by-default.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Cost guardrail: Cloudflare Workers AI must stay OFF by default ($0 policy).
+//
+// Its "free" tier is a hard 10K-neurons/day cap; every neuron past it bills at
+// $0.011/1K — surfaced on the CF bill as "Regular Twitch Neurons". Measured
+// ~50-86K neurons/day (~$0.50-0.84/day overage) coming entirely from the
+// crawler/article LLM fallback chain selecting @cf/* models. The other 100+
+// free models across 13 providers cover all fallback need, so cf/* may only be
+// re-enabled by an explicit CF_WORKERS_AI_ENABLED opt-in.
+const aiModels = await import('../../scripts/lib/ai-models.mjs');
+
+// Internal id carries the `cf/` provider prefix (getProvider keys on it).
+const CF_MODEL = aiModels.AI_MODELS.CF_LLAMA_3_3_70B;
+
+describe('ai-models Cloudflare Workers AI $0 policy', () => {
+  let prevToken: string | undefined;
+  let prevAccount: string | undefined;
+  let prevFlag: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.CF_API_TOKEN;
+    prevAccount = process.env.CF_ACCOUNT_ID;
+    prevFlag = process.env.CF_WORKERS_AI_ENABLED;
+    // Credentials present (they exist in CI for CDN/embeddings), flag absent.
+    process.env.CF_API_TOKEN = 'dummy-token';
+    process.env.CF_ACCOUNT_ID = 'dummy-account';
+    delete process.env.CF_WORKERS_AI_ENABLED;
+    aiModels.resetState();
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.CF_API_TOKEN;
+    else process.env.CF_API_TOKEN = prevToken;
+    if (prevAccount === undefined) delete process.env.CF_ACCOUNT_ID;
+    else process.env.CF_ACCOUNT_ID = prevAccount;
+    if (prevFlag === undefined) delete process.env.CF_WORKERS_AI_ENABLED;
+    else process.env.CF_WORKERS_AI_ENABLED = prevFlag;
+  });
+
+  it('marks cf/* models unavailable even when CF credentials are set', () => {
+    expect(aiModels.isModelAvailable(CF_MODEL)).toBe(false);
+  });
+
+  it('re-enables cf/* only when CF_WORKERS_AI_ENABLED is truthy', () => {
+    process.env.CF_WORKERS_AI_ENABLED = '1';
+    expect(aiModels.isModelAvailable(CF_MODEL)).toBe(true);
+  });
+
+  it('skips a cf-only chain with a no-neuron reason rather than calling Cloudflare', async () => {
+    let caught: Error | undefined;
+    try {
+      await aiModels.callLLM([{ role: 'user', content: "Reply with 'ok'." }], {
+        chain: [CF_MODEL],
+        retries: 0,
+        maxTokens: 8,
+      } as Parameters<typeof aiModels.callLLM>[1]);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    // Never reaches the billable inference endpoint; fails at the availability gate.
+    expect(String(caught?.message || '')).not.toMatch(/Errors:\s*$/);
+  });
+});


### PR DESCRIPTION
## Diagnosi spesa

La voce **"Regular Twitch Neurons"** sulla billing Cloudflare = **Workers AI** (fatturato in Neuron). Nessun binding `[ai]` nei Worker: ogni Neuron viene da chiamate HTTP a `api.cloudflare.com/.../ai/v1/chat/completions` fatte dal provider **Cloudflare** nella catena di fallback LLM di `scripts/lib/ai-models.mjs` (crawler job, generatore articoli, enrichment).

Misura live via GraphQL (`aiInferenceAdaptiveGroups`), ultimi 7 giorni:

| Giorno | Neuron | Note |
|---|---|---|
| 06-18 | 10.6K | appena sopra free cap |
| 06-22 | 86.4K | |
| 06-24 | 59.7K | overage ≈ 49.7K → ~$0.55 (≈ $0.48 fatturato) |
| 06-25 | 82.7K (parziale) | |

Free tier = **10K Neuron/giorno**; l'overage costa **$0.011/1K**. Totale 7gg ≈ 370K Neuron, **100% modelli `@cf/*`** (Mistral Small 3.1, Llama 4 Scout, Llama 3.2 3B, Qwen3 30B, Nemotron 120B, …). Costo attuale ~$0.50–0.84/giorno (~$13/mese) e in crescita.

## Implementato

- Gate del provider Cloudflare Workers AI dietro opt-in esplicito `CF_WORKERS_AI_ENABLED` (default **OFF**) in `scripts/lib/ai-models.mjs`:
  - `getApiKeyForProvider(CLOUDFLARE)` ritorna `''` quando il flag è off → ogni modello `cf/*` risulta **unavailable** → la catena non lo seleziona mai (punto singolo che governa TUTTI i `cf/*`).
  - Guardia difensiva in `_callCloudflare`: throw immediato se il flag è off, così nessun path diretto può spendere Neuron.
- Nuovo helper `isCloudflareWorkersAiEnabled()` (accetta `1|true|yes|on`).
- Test guardrail `tests/scripts/ai-models-cloudflare-disabled-by-default.test.ts` (3 test): cf/* indisponibile di default anche con credenziali CF presenti; riabilitabile solo col flag; chain cf-only fallisce al gate senza chiamare l'endpoint billable.
- Il secret `CF_API_TOKEN` resta intatto (serve a CDN/embeddings/Remote Config): disabilitiamo solo l'inferenza Workers AI, non il token.

Effetto: spesa Workers AI → **$0**. Le altre 13 provider (100+ modelli free: GitHub Models, Gemini, Groq, OpenRouter, Cerebras, Mistral, …) coprono tutto il fabbisogno di fallback → nessuna perdita di capacità.

## Non implementato (ancora)

- Backfill/replay dei job già crawlati con `@cf/*`: non necessario (l'output è identico ad altri modelli; nessun byte SEO perso).
- Riabilitazione condizionata (es. usare Workers AI solo entro un budget < 10K Neuron/giorno): out of scope — la policy richiesta è $0 netto, non un cap.
- Validazione live post-merge: la riduzione a 0 Neuron è osservabile solo dopo che i prossimi run dei crawler girano da `main` senza selezionare `cf/*`; verificabile sul GraphQL `aiInferenceAdaptiveGroups` nei giorni successivi (atteso: byDate → 0 nuovi Neuron). Se per qualche motivo i Neuron NON scendessero, indica un caller CF AI fuori da `ai-models.mjs` (non trovato in audit) → follow-up.
