### PR TITLE
fix(test): green main — update auth-gate region name after #2944 gate.title change

### DIFF
--- a/tests/job-status-gated-behind-auth.test.tsx
+++ b/tests/job-status-gated-behind-auth.test.tsx
@@ -55,7 +55,7 @@ describe('Offer status gated behind auth (logged-out)', () => {
   expect(screen.queryByText(/Scaduta il/i)).not.toBeInTheDocument();
 
   // The auth gate is still presented to drive sign-up.
-  expect(screen.getByRole('region', { name: /Continua per vedere/i })).toBeInTheDocument();
+  expect(screen.getByRole('region', { name: /come candidarti/i })).toBeInTheDocument();
 
   // The job title still renders (information scent), just not the dead-status.
   expect(
@@ -70,6 +70,6 @@ describe('Offer status gated behind auth (logged-out)', () => {
   expect(screen.queryByText(/non è più disponibile/i)).not.toBeInTheDocument();
 
   // The auth gate is still presented.
-  expect(screen.getByRole('region', { name: /Continua per vedere/i })).toBeInTheDocument();
+  expect(screen.getByRole('region', { name: /come candidarti/i })).toBeInTheDocument();
  });
 });


### PR DESCRIPTION
## Implementato

`main` è rosso su `tests/job-status-gated-behind-auth.test.tsx` (2 casi logged-out). Root cause: **#2944** ha promosso la headline `apply_now` spostandone la copy dentro la i18n key `jobBoard.gate.title`. `JobExpiredView`/`JobOrphanView` rendono la region auth-gate con `aria-label={t('jobBoard.gate.title')}`, quindi il nome accessibile è passato da *"Continua per vedere…"* a *"Scopri come candidarti a questo lavoro"*; il test cercava ancora la vecchia stringa → fail.

- Aggiornato il matcher `getByRole('region', { name: ... })` da `/Continua per vedere/i` a `/come candidarti/i` (le due occorrenze).
- **Behavior invariato**: gli assert di status-hiding (`/non è più attiva/i`, `/Scaduta il/i`, `/non è più disponibile/i` assenti finché non si fa login) passavano già — sono falliti SOLO i due assert sul nome della region. Nessun gate abbassato.
- Test-only, zero modifiche production. Verde locale: 2/2.
- Verificato che `tests/authGateExperiment.test.ts` (che ha la vecchia stringa come `CONTROL_HEADLINE`) NON è stale: la usa come fixture-control locale passata all'hook, self-contained, già verde.

## Non implementato (ancora)

- Nessun altro file referenzia la vecchia copy in modo stale (grep `tests/`+`components/`+`services/` → solo l'experiment fixture, intenzionale).
- Non tocco la copy né l'esperimento (#2944 è una owner product call già mergeata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)