### PR TITLE
fix(article): feed verified-facts sheet into evergreen generation prompt (frontaliere cadence)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2888,12 +2888,28 @@ async function fetchPageContent(url) {
     console.error(`📊 Articolo statistica BFS: trimestre ${quarter}`);
     return await buildStatsBfsPromptContent(quarter);
   }
-  // Handle evergreen topics — no URL to fetch, use keyword angle as content
+  // Handle evergreen topics — no URL to fetch, use keyword angle as content.
+  //
+  // Evergreen articles have NO real news source, so the synthetic prompt below
+  // IS the article's only "SOURCE CONTENT". Historically it told the model to
+  // "use only verified, stable facts" WITHOUT supplying any — so free-tier
+  // models filled the gap from training data and routinely hallucinated the
+  // stable cross-border facts (imposta alla fonte location, accordo dates,
+  // franchigia, 20km threshold, transitional period). The fact-checker, which
+  // DOES carry VERIFIED_DOMAIN_FACTS as ground truth, then blocked every such
+  // article on consensus criticals → the frontaliere evergreen path produced
+  // ~0 articles/run for days (issue #2947: frontaliere cadence collapsed while
+  // svizzera — mostly real-news, already source-grounded — kept producing).
+  //
+  // Fix: feed the SAME VERIFIED_DOMAIN_FACTS sheet into the generation prompt.
+  // REGOLA #1 ("ogni fatto DEVE essere presente nel SOURCE CONTENT") then works
+  // FOR convergence instead of against it: the model rewrites from the exact
+  // values the fact-checker validates against. No gate is lowered.
   if (url.startsWith('evergreen://')) {
     const keyword = process.env._EVERGREEN_KEYWORD || decodeURIComponent(url.replace('evergreen://', ''));
     const angle = process.env._EVERGREEN_ANGLE || '';
     console.error(`📚 Articolo evergreen: "${keyword}"`);
-    return `[ARTICOLO EVERGREEN SEO]\nKeyword target: ${keyword}\nAngolo editoriale: ${angle}\n\nGenera un articolo approfondito e pratico ottimizzato per questa keyword long-tail. Usa solo fatti verificati e stabili sul dominio frontalieri Ticino-Italia. Se servono esempi, presentali come scenari ipotetici, senza nomi, aziende, città o importi specifici inventati.`;
+    return `[ARTICOLO EVERGREEN SEO]\nKeyword target: ${keyword}\nAngolo editoriale: ${angle}\n\nGenera un articolo approfondito e pratico ottimizzato per questa keyword long-tail. Usa solo fatti verificati e stabili sul dominio frontalieri Ticino-Italia. Se servono esempi, presentali come scenari ipotetici, senza nomi, aziende, città o importi specifici inventati.\n\n${VERIFIED_DOMAIN_FACTS}\n\n⚠️ I FATTI VERIFICATI qui sopra sono la TUA SOURCE CONTENT autorevole: date, aliquote, franchigie, istituzioni e numeri DEVONO corrispondere ESATTAMENTE a quei valori (lo stesso foglio è usato dal fact-checker, che blocca l'articolo se divergi). Per dettagli NON coperti dal foglio, attieniti a nozioni stabili e generali del dominio; se un dato specifico non è certo, ometti o usa formulazioni qualitative invece di inventare cifre/date precise.`;
   }
   console.error(`📰 Fetching: ${url}`);
   try {


### PR DESCRIPTION
## Implementato

Fix root-cause del crollo di cadenza degli articoli **frontaliere** (issue #2947).

**Diagnosi** (dai log di `generate-article.yml`): ogni run frontaliere generava bozze evergreen con buona density (15–28 keyword hits) ma veniva **bloccato al 100% dal fact-check consensus gate** (`🚨 Consensus criticals (≥2 modelli) — BLOCCATO`). Gli articoli evergreen non hanno una fonte-notizia reale: il contenuto sintetico in `fetchPageContent` diceva al modello «usa solo fatti verificati e stabili» **senza fornirli**, così i modelli free-tier allucinavano i fatti stabili CH-IT (luogo dell'imposta alla fonte, date dell'accordo, franchigia €10k, soglia 20 km, periodo transitorio 2024-2033). Il fact-checker porta `VERIFIED_DOMAIN_FACTS` come ground truth, il generatore no → nessuna convergenza: tutti i ~10 tentativi keyword rigettati, budget esaurito, nessun articolo. La sezione `svizzera` (per lo più news reali, già source-grounded) continuava a produrre, mascherando il collasso (frontaliere ~1-3/giorno vs svizzera 10-33/giorno).

**Fix** (`scripts/create-article.mjs`, ramo `evergreen://` di `fetchPageContent`): inietto lo **stesso** foglio `VERIFIED_DOMAIN_FACTS` nel SOURCE CONTENT del prompt di generazione evergreen. Così REGOLA #1 («ogni fatto DEVE essere presente nel SOURCE CONTENT») lavora **a favore** della convergenza invece che contro: il generatore riscrive dagli stessi valori che il fact-checker valida. **Nessun gate abbassato** (rispetta Non-Negotiable #1): la barra anti-allucinazione resta intatta, il generatore ora è semplicemente allineato sulla stessa verità.

- Verificato `node --check` + `npm run test:articles` → 64/64 verdi, incluso `article-tax-content-guard` (rigetto esempi fiscali stale): il fix è allineato al guard esistente, non lo indebolisce.

## Non implementato (ancora)

- **Alternanza sezioni frontaliere⇄svizzera 50/50 invariata** — owner ha confermato (29-06) di mantenere lo split 50/50. Il fix di generazione da solo riporta frontaliere a ~metà dei run (era ~0). Nessuna modifica a `generate-article.yml`.
- **Sibling-class sweep**: `check-sibling-patterns.mjs` segnala solo `scripts/lib/topic-sources/gscOrphans.mjs` per token condiviso `nKeyword` — falso positivo euristico (incidentale dalla parola "keyword" nei commenti aggiunti). Non esiste un sibling con lo stesso antipattern «source sintetica senza fatti»: il ramo `stats-bfs://` costruisce da numeri Firestore reali e il ramo news da pagine reali — entrambi già source-grounded. Niente da sweepare.
- **Garanzia 1-articolo-per-run al 100%**: il fix alza drasticamente il pass-rate evergreen sui topic fiscali/permessi che fallivano sempre, ma non è un hard-guarantee per ogni singola keyword (topic non coperti dal foglio fatti restano dipendenti dalla conoscenza stabile del modello). Da osservare sul cadence post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
