### PR TITLE
fix(crawler): drop X-Requested-With from in-page widget POST replay (#2992)

### DIFF
--- a/scripts/lib/pastahr-widget-client.mjs
+++ b/scripts/lib/pastahr-widget-client.mjs
@@ -177,6 +177,21 @@ async function fetchWidgetViaPlaywright(bodyString, contentType, endpoint, { ref
     await page.goto(referer, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
 
     // Replay the widget POST from within the page's JS context.
+    //
+    // CORS NOTE: this fetch runs in the browser, so it IS subject to the page's
+    // CORS policy (unlike the Node-side fetch path, which is not). When the
+    // endpoint is cross-origin to the navigated page — the PastaHR case, where
+    // the page is the employer site (e.g. igsbern.ch / gzo.ch) but the endpoint
+    // is www.publicjobs.ch — only headers on the CORS-safelist
+    // (Accept, Accept-Language, Content-Language, and Content-Type with a
+    // form/text value) keep this a "simple request" that needs no preflight.
+    // `X-Requested-With` is NOT safelisted: adding it forces a preflight OPTIONS
+    // that publicjobs.ch does not answer, so the whole fetch dies with
+    // `TypeError: Failed to fetch` (#2992) — defeating the anti-bot fallback.
+    // The header is only needed on the Node path (WAF fingerprint, no CORS), so
+    // it is deliberately omitted here. The urlencoded body keeps Content-Type
+    // safelisted; the same-origin Phenom case (careers.straumann.com) is exempt
+    // from CORS entirely, so dropping the header is harmless there too.
     const result = await page.evaluate(
       async ({ ep, body, ct }) => {
         const res = await fetch(ep, {
@@ -185,7 +200,6 @@ async function fetchWidgetViaPlaywright(bodyString, contentType, endpoint, { ref
             Accept: 'application/json, text/javascript, */*; q=0.01',
             'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
             'Content-Type': ct,
-            'X-Requested-With': 'XMLHttpRequest',
           },
           body,
         });


### PR DESCRIPTION
## Implementato

Fix root-cause della failure ricorrente del crawler **IGS Bern (Soteria)** (#2992).

- **Diagnosi**: `www.publicjobs.ch/widget` risponde **403** agli IP datacenter di GitHub Actions (anti-bot Cloudflare). Il fallback Playwright (#1783) — che dovrebbe sbloccare il 403 replaiando il POST da dentro un Chromium reale — falliva con `page.evaluate: TypeError: Failed to fetch`.
- **Causa**: il fetch in-page punta a `publicjobs.ch` **cross-origin** rispetto alla pagina navigata (sito datore: `igsbern.ch` / `gzo.ch`). L'header `X-Requested-With: XMLHttpRequest` **non è CORS-safelisted** → forza un preflight `OPTIONS` che publicjobs.ch non gestisce → la fetch muore prima di leggere la risposta. Il fallback non poteva quindi MAI superare il 403.
- **Fix chirurgico**: rimosso `X-Requested-With` **solo** dal fetch in-page (`page.evaluate`) di `fetchWidgetViaPlaywright` in `scripts/lib/pastahr-widget-client.mjs`. Senza quell'header il POST urlencoded resta una "simple request" CORS che passa cross-origin. L'header resta sul path Node (`makePastaHrBrowserHeaders`), dove serve al fingerprint WAF e non è soggetto a CORS.
- **Verifica empirica**: replay Playwright locale (no 403 locale → isola CORS dal WAF): con `X-Requested-With` → `Failed to fetch`; senza → 200 + `rows: 2`. `npx vitest run tests/crawler-shared-fetch-retry.test.ts` → 12/12 verde.
- **Class-fix (modulo condiviso)**: la patch copre tutti i client del fallback: **IGS Bern** + **GZO Wetzikon** (cross-origin urlencoded → publicjobs.ch) risolti; **Straumann/Phenom** è same-origin (`careers.straumann.com` == endpoint) → CORS non si applica, rimozione innocua. `check-sibling-patterns.mjs`: unico file con `page.evaluate` + `X-Requested-With` è questo.

## Non implementato (ancora)

- **`update-ibsa-jobs.mjs` / `update-lidl-jobs.mjs` / `update-zambon-jobs.mjs`** (segnalati dal sibling-checker per `XMLHttpRequest`): non toccati — usano `X-Requested-With` su una `fetch` **Node-side** (non in `page.evaluate`), che NON è soggetta a CORS. È l'uso legittimo identico al path Node che ho deliberatamente conservato; non è lo stesso antipattern.
- **Path Phenom/JSON con endpoint cross-origin**: motivo: out of scope — non esiste oggi un client Phenom cross-origin (Straumann è same-origin). Se in futuro se ne aggiunge uno, `application/json` forza comunque un preflight a prescindere da `X-Requested-With` → andrà gestito con navigazione same-origin all'origin dell'endpoint.
- **Verifica live su IP datacenter realmente bloccato**: motivo: non riproducibile pre-merge (il 403 dipende dalla reputazione IP del runner). Trigger di conferma post-merge: ri-eseguire `update-jobs-igs-bern.yml` su `main` e verificare che il fallback Playwright restituisca i job invece di `Failed to fetch`.
