### PR TITLE
fix(jobs): scale part-time salary estimate to the stated workload

### DIFF
--- a/scripts/lib/structured-salary.mjs
+++ b/scripts/lib/structured-salary.mjs
@@ -19,6 +19,56 @@ function inferSalaryRange(job) {
   };
 }
 
+// Part-time roles state an employment percentage in the contract/title
+// (e.g. "Part-time (20%)", "Teilzeit 60%", "Temps partiel (20 %)"). The salary
+// estimate is a full-time-equivalent annual figure, so it must be reduced to
+// the stated workload. Same percentage-extraction shape as isPartTime() in
+// build-plugins/jobEditorialLanding.ts.
+function partTimeEmploymentFraction(job) {
+  const raw = [
+    job?.contract,
+    job?.employmentType,
+    job?.title,
+    job?.titleByLocale?.it,
+    job?.titleByLocale?.en,
+    job?.titleByLocale?.de,
+    job?.titleByLocale?.fr,
+  ]
+    .map((value) => String(value || ''))
+    .join(' ');
+  const pcts = (raw.match(/(\d{1,3})\s*%/g) || [])
+    .map((match) => Number(match.replace(/[^0-9]/g, '')))
+    .filter((n) => Number.isFinite(n) && n > 0 && n <= 100);
+  if (!pcts.length) return null;
+  // Use the upper bound of a stated range ("60-80%" → 80). A workload of 100%
+  // (or a "80-100%" span) is effectively full-time — never reduce the salary.
+  const workload = Math.max(...pcts);
+  if (workload >= 100) return null;
+  return workload / 100;
+}
+
+/**
+ * Reduce a full-time-equivalent salary estimate to the stated part-time
+ * workload. Returns null for full-time roles (or part-time roles with no
+ * stated percentage), so callers keep the unscaled estimate. Shared by
+ * ensureStructuredSalary() here and the re-enrich pipeline so both produce
+ * the identical part-time band (no estimator drift between the two writers).
+ *
+ * @param {number} estimatedMin - Full-time estimate lower bound
+ * @param {number} estimatedMax - Full-time estimate upper bound
+ * @param {object} job - Job whose contract/title carries the employment %
+ * @returns {{ min: number, max: number, fraction: number } | null}
+ */
+export function reduceSalaryToPartTime(estimatedMin, estimatedMax, job) {
+  const fraction = partTimeEmploymentFraction(job);
+  if (fraction === null) return null;
+  return {
+    min: roundToHundreds(estimatedMin * fraction),
+    max: roundToHundreds(estimatedMax * fraction),
+    fraction,
+  };
+}
+
 function normalizeCurrency(job) {
   const raw = String(
     job?.currency ||
@@ -35,11 +85,24 @@ export function ensureStructuredSalary(job) {
   const existingMin = toFiniteNumber(job.salaryMin) ?? toFiniteNumber(job?.baseSalary?.value?.minValue);
   const existingMax = toFiniteNumber(job.salaryMax) ?? toFiniteNumber(job?.baseSalary?.value?.maxValue);
   const estimated = inferSalaryRange(job);
-  const minValue = existingMin && existingMin > 0 ? existingMin : estimated.min;
+  let minValue = existingMin && existingMin > 0 ? existingMin : estimated.min;
   let maxValue = existingMax && existingMax >= minValue ? existingMax : null;
 
   if (!maxValue) {
     maxValue = roundToHundreds(Math.max(estimated.max, minValue * 1.2));
+  }
+
+  // Reduce a full-time-equivalent estimate to the stated part-time workload.
+  // Only applied when the current bounds ARE the full-time estimate, never a
+  // salary reported in the posting (which already reflects the real pay). This
+  // also keeps the pass idempotent: once scaled, the bounds no longer equal the
+  // full-time estimate, so a re-run leaves them untouched.
+  if (minValue === estimated.min) {
+    const reduced = reduceSalaryToPartTime(estimated.min, estimated.max, job);
+    if (reduced) {
+      minValue = reduced.min;
+      maxValue = reduced.max;
+    }
   }
 
   const currency = normalizeCurrency(job);

--- a/scripts/re-enrich-jobs.mjs
+++ b/scripts/re-enrich-jobs.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { callLLM, isAnyModelAvailable } from './lib/ai-models.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { reduceSalaryToPartTime } from './lib/structured-salary.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -954,9 +955,20 @@ async function enrichJob(job, aiState) {
   const reportedSalary = extractReportedAnnualSalary(jobWithNormalizedCategory);
   const existingSalary = FORCE_REESTIMATE ? null : extractExistingAnnualSalary(jobWithNormalizedCategory);
   const estimated = estimateSalaryFromSectors(jobWithNormalizedCategory);
+  // Part-time roles state an employment percentage (e.g. "Part-time (20%)").
+  // The sector estimate is a full-time-equivalent band, so reduce it to the
+  // stated workload. Shared helper keeps this identical to the harden pass in
+  // structured-salary.mjs (same chokepoint, no estimator drift).
+  const reducedEstimate = reduceSalaryToPartTime(
+    estimated.minValue,
+    estimated.maxValue,
+    jobWithNormalizedCategory,
+  );
+  const estMin = reducedEstimate ? reducedEstimate.min : estimated.minValue;
+  const estMax = reducedEstimate ? reducedEstimate.max : estimated.maxValue;
   const salary = reportedSalary || existingSalary || {
-    salaryMin: estimated.minValue,
-    salaryMax: estimated.maxValue,
+    salaryMin: estMin,
+    salaryMax: estMax,
     currency: String(job.currency || 'CHF').toUpperCase() || 'CHF',
     source: 'sectors_estimation',
   };
@@ -976,9 +988,11 @@ async function enrichJob(job, aiState) {
   if (reportedSalary) {
     salarySource = 'reported';
   } else if (existingSalary) {
+    // Fingerprint against the part-time-aware estimate (estMin/estMax), so a
+    // persisted scaled band is still recognised as 'estimated', not 'existing'.
     salarySource =
-      existingSalary.salaryMin === estimated.minValue
-        && existingSalary.salaryMax === estimated.maxValue
+      existingSalary.salaryMin === estMin
+        && existingSalary.salaryMax === estMax
         ? 'estimated'
         : 'existing';
   }

--- a/tests/structured-salary.test.ts
+++ b/tests/structured-salary.test.ts
@@ -37,6 +37,59 @@ describe('structured salary hardening', () => {
     expect(result.job.baseSalary?.value?.maxValue).toBe(118000);
   });
 
+  it('reduces an estimated salary to the stated part-time workload', () => {
+    const fullTime = ensureStructuredSalary({
+      title: 'Sales Associate',
+      category: 'Commerciale',
+      canton: 'ZH',
+      employmentType: 'FULL_TIME',
+    });
+    const partTime = ensureStructuredSalary({
+      title: 'Sales Associate - Part-time (20%)',
+      category: 'Commerciale',
+      canton: 'ZH',
+      contract: 'part-time',
+      employmentType: 'PART_TIME',
+    });
+
+    // 20% workload → roughly one fifth of the full-time estimate.
+    expect(partTime.job.salaryMin).toBe(Math.round((fullTime.job.salaryMin * 0.2) / 100) * 100);
+    expect(partTime.job.salaryMax).toBe(Math.round((fullTime.job.salaryMax * 0.2) / 100) * 100);
+    expect(partTime.job.salaryMax).toBeGreaterThan(partTime.job.salaryMin);
+    expect(partTime.job.baseSalary?.value?.minValue).toBe(partTime.job.salaryMin);
+  });
+
+  it('is idempotent: a scaled part-time salary is not reduced again', () => {
+    const first = ensureStructuredSalary({
+      title: 'Verkaufsmitarbeiter – Teilzeit (20 %)',
+      category: 'Commerciale',
+      canton: 'ZH',
+      contract: 'part-time',
+      employmentType: 'PART_TIME',
+    });
+    const second = ensureStructuredSalary(first.job);
+
+    expect(second.job.salaryMin).toBe(first.job.salaryMin);
+    expect(second.job.salaryMax).toBe(first.job.salaryMax);
+    expect(second.changed).toBe(false);
+  });
+
+  it('keeps a salary reported in the posting even for a part-time role', () => {
+    const result = ensureStructuredSalary({
+      title: 'Pflegefachperson Teilzeit (60%)',
+      category: 'health',
+      canton: 'TI',
+      contract: 'part-time',
+      employmentType: 'PART_TIME',
+      salaryMin: 33000,
+      salaryMax: 41000,
+      currency: 'CHF',
+    });
+
+    expect(result.job.salaryMin).toBe(33000);
+    expect(result.job.salaryMax).toBe(41000);
+  });
+
   it('reports how many jobs were hardened in a collection', () => {
     const hardened = hardenJobsWithStructuredSalary([
       {


### PR DESCRIPTION
## Implementato

Riduce la salary band stimata alla percentuale di impiego dichiarata per le offerte part-time. Esempio della issue (Cartier 20%): **CHF 73'500-111'500 → CHF 14'700-22'300**.

- **`scripts/lib/structured-salary.mjs`**: nuovo helper condiviso `reduceSalaryToPartTime()` che estrae la percentuale di impiego da `contract`/`employmentType`/`title*` (stessa forma `/(\d{1,3})\s*%/` del detector `isPartTime` esistente) e scala la stima full-time. Applicato in `ensureStructuredSalary()` — il chokepoint di hardening attraversato da ogni crawler e dallo step `assemble-jobs-dataset.mjs` del deploy → la pagina live si corregge al prossimo deploy senza toccare file dati committati.
- **`scripts/re-enrich-jobs.mjs`**: unico sibling che materializza la salary in modo indipendente (scrive `data/jobs.json` + `public/data/jobs.json`). Usa lo **stesso** helper condiviso (niente drift dell'estimator) + fingerprint di provenienza `salarySource` aggiornato per riconoscere una band part-time già scalata come `estimated`.
- **`tests/structured-salary.test.ts`**: 3 nuovi test (scaling, idempotenza, reported-wins).

Guardrail:
1. **Reported wins**: lo scaling parte solo quando la band è *uguale* alla stima full-time fresca, mai una salary dal testo dell'annuncio.
2. **Idempotente**: una band scalata non eguaglia più la stima full-time → re-run la lascia invariata (verificato run1 73500→14700, run2/run3 stabili).
3. **Default safe**: nessuna percentuale, oppure `100%`/`80-100%` → nessuna riduzione.

Impatto misurato sulle slice by-crawler: ~1.433 offerte part-time con % esplicita, di cui ~1.215 attualmente su stima full-time che si correggono al prossimo deploy. Job full-time invariati (byte-identici, control test).

Test: 6/6 `structured-salary` + suite `swiss-salary-estimation`/`jobCardHtml`/`profession-median-estimated` verdi (54 test).

## Non implementato (ancora)

- **Part-time senza percentuale numerica** (solo la parola "Part-time"/"Teilzeit" senza `NN%`): nessuno scaling — il fattore di workload non è quantificabile dal testo, riduco solo quando la percentuale è dichiarata (scelta conservativa, no guess).
- **Regex di estrazione % duplicata cross-language**: `isPartTime()` in `build-plugins/jobEditorialLanding.ts`/`jobsSeoPagesPlugin.ts` (TS, runtime build) condivide la forma `/(\d{1,3})\s*%/` ma è un detector booleano di classificazione, concern diverso dallo scaling salary (Node script `.mjs`). Non estratto in un modulo unico per il confine TS-build ↔ MJS-script; il commento in `partTimeEmploymentFraction` documenta il mirror. Il fix di classe salary-estimation è completo: gli unici due estimator (`ensureStructuredSalary`, `estimateSalaryFromSectors`) usano entrambi `reduceSalaryToPartTime`.
- **Backfill esplicito dei file `data/jobs/by-crawler/*.json` committati**: non necessario — `data/jobs.json` è rigenerato in CI via `assemble`→harden a ogni deploy, quindi i valori si correggono senza commit di dati.
