### PR TITLE
feat(jobboard): side rails + top banner on cerca-lavoro listing/editorial views

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1813,6 +1813,42 @@ const JobCard = React.memo(({ job, jobHref, salary, logo, isNew, postedLabel, lo
 ));
 JobCard.displayName = 'JobCard';
 
+/**
+ * JobBoardRailShell — wraps a cerca-lavoro listing/editorial page view in the
+ * same monetisation chrome the job-detail view already carries (#2948): a
+ * desktop top leaderboard + the 3-column full-height side-rail grid (180px rails
+ * @xl widening to 300px @xlw, half-page creatives only at xlw). Below xl it
+ * collapses to a single column, so mobile/tablet layout is byte-identical to
+ * before. Module-level (never defined inside render) so the persistent GPT rail
+ * slots are not remounted as the visitor navigates between board views.
+ *
+ * The center column keeps its own `space-y-6` rhythm (the wrapped branch root),
+ * so existing listing/editorial spacing is unchanged; the shell only adds the
+ * banner above and the rail gutters beside it.
+ */
+const JobBoardRailShell: React.FC<{ isDesktopLg: boolean; children: React.ReactNode }> = ({ isDesktopLg, children }) => (
+ <div className="space-y-6">
+ {isDesktopLg && (
+ <AdSenseBanner
+ adSlot={AD_SLOTS.JOBDETAIL_TOP_BANNER.slot}
+ adFormat={AD_SLOTS.JOBDETAIL_TOP_BANNER.format}
+ fullWidthResponsive={AD_SLOTS.JOBDETAIL_TOP_BANNER.fullWidthResponsive}
+ minHeight={AD_SLOTS.JOBDETAIL_TOP_BANNER.placeholderMinHeight}
+ />
+ )}
+ <div className="ft-rail-grid-x xl:grid xl:max-xlw:grid-cols-[180px_1fr_180px] xl:gap-4 xlw:grid-cols-[300px_minmax(0,1fr)_300px]">
+ <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="left" /></Suspense>
+ </aside>
+ <div className="min-w-0">{children}</div>
+ <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col">
+ <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense>
+ </aside>
+ </div>
+ </div>
+);
+JobBoardRailShell.displayName = 'JobBoardRailShell';
+
 const JobBoard: React.FC<JobBoardProps> = ({
  onPostJob,
  initialJobSlug,
@@ -5497,6 +5533,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  if (editorialJobTodayLanding) {
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -5591,11 +5628,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialOfficialGazetteLanding) {
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -5710,11 +5749,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialNursesHubLanding) {
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -5818,12 +5859,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialCareVariantLanding) {
  const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialCareVariantLanding.parentHubHref);
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -5916,11 +5959,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialLocationLanding) {
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -6029,12 +6074,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialLocationTypeLanding) {
  const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialLocationTypeLanding.parentLocationHref);
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -6126,12 +6173,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialLocationSectorLanding) {
  const { canton: parentCanton, slug: parentSlug } = hubLinkRoute(editorialLocationSectorLanding.parentLocationHref);
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -6223,11 +6272,13 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
  if (editorialSectorRegionLanding) {
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  <section className="rounded-3xl border border-info-border bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-6 sm:p-8">
  <p className="text-xs font-bold uppercase tracking-[0.18em] text-info">
@@ -6320,6 +6371,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
  {authGateModalJsx}
  </div>
+ </JobBoardRailShell>
  );
  }
 
@@ -7647,6 +7699,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
 
  return (
+ <JobBoardRailShell isDesktopLg={isDesktopLg}>
  <div className="space-y-6">
  {searchSlugFilter && (
  <div className="rounded-xl border border-accent-border bg-accent-subtle p-3 text-sm text-accent flex items-center justify-between gap-3">
@@ -8344,6 +8397,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </div>
  </div>
  </div>
+ </JobBoardRailShell>
  );
 };
 


### PR DESCRIPTION
## Implementato

Risolve #2948 — porta la stessa monetizzazione di job-detail/home sulle pagine `cerca-lavoro-*/` (listing + landing editoriali), per tutte e 4 le locale.

- Nuovo componente module-level `JobBoardRailShell` (in `components/community/JobBoard.tsx`): top leaderboard desktop (`AD_SLOTS.JOBDETAIL_TOP_BANNER`, gate `isDesktopLg`) + griglia 3 colonne con rail laterali full-height (180px @xl → 300px @xlw, creatives half-page solo @xlw; singola colonna sotto xl → layout mobile/tablet invariato). Riusa `ArticleRailAdStack` (stesso GAM unit + kill-switch Remote Config delle rail articolo/job-detail) → "barre laterali multiple e continue" come nella pagina articoli.
- Wrappate le **9** page-view del board che prima erano single-column senza rail né banner:
  - listing/ricerca principale (fall-through)
  - 8 landing editoriali: `editorialJobTodayLanding`, `editorialOfficialGazetteLanding`, `editorialNursesHubLanding`, `editorialCareVariantLanding`, `editorialLocationLanding`, `editorialLocationTypeLanding`, `editorialLocationSectorLanding`, `editorialSectorRegionLanding`
- Module-level (non definito in render) → gli slot GPT persistenti non vengono rimontati navigando tra le view del board.

### Enumerazione altre pagine (parte "enumera dove mancano le barre")

- **Home + tutti gli altri tab SPA** (calculator/stats/confronti/fisco/vita/guida): già coperti dalle rail narrow (160px) di `App.tsx` (`sideRailEligible`).
- **Articoli (blog)**: già rail proprie via `BlogArticles`.
- **Job-detail + auth-gate**: già rail + top banner (invariati).
- **Expired/orphan job**: già rail dentro `JobExpiredView`/`JobOrphanView`.
- **Landing SEO statiche** (staticOverlay): già rail portalate in `#rail-left-root`/`#rail-right-root`.
- **Admin**: niente ads (corretto).

Verifica: `tsc --noEmit` zero errori nei file app toccati (50 errori residui sono pre-esistenti in `tests/**` + `PublisherDashboardPage.tsx`, non toccati); `vitest` jobboard suite verde; balance JSX 9 open / 9 close.

## Non implementato (ancora)

- **Sweep sibling `check-sibling-patterns.mjs`**: i candidati emersi (`minHeight`, `ArticleRailAdStack`, `isDesktopLg`) sono token-overlap euristici su API esistenti, non lo stesso antipattern — nessun sibling da modificare.
- **Top banner anche sotto `isDesktopLg`/mobile**: deliberatamente desktop-only (come job-detail) per non spingere il contenuto sotto la fold su mobile; Auto Ads coprono il mobile.
- **Verifica live RPM/fill delle rail**: non misurabile pre-merge (richiede GAM live post-deploy) — osservazione post-merge; se le rail su listing rendono ~€0 si valuterà collapse come per le rail App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)