### PR TITLE
fix(sitemap): sync frontaliere hreflang URLs with de-duped slugs (main-red)

### DIFF
--- a/public/sitemap-blog.xml
+++ b/public/sitemap-blog.xml
@@ -784,9 +784,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendio-iva/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendio-iva/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/13th-avs-pension-mixed-financing-salary-vat/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/13-ahv-rente-mischfinanzierung-gehalt-mwst/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/13eme-rente-avs-financement-mixte-salaire-tva/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/13th-avs-pension-mixed-financing-salary-vat-proposal/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/13-ahv-rente-mischfinanzierung-gehalt-mwst-vorschlag/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/13eme-rente-avs-financement-mixte-salaire-tva-proposition/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendio-iva/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/tredicesima-avs-stipendio-iva.webp</image:loc>
@@ -3462,7 +3462,7 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/comuni-frontiera-nuove-regole-fiscali/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/comuni-frontiera-nuove-regole-fiscali/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/border-municipalities-new-tax-rules/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzgemeinden-neue-steuerregeln/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzgemeinden-steuerliche-auswirkungen/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/communes-frontalieres-nouvelles-regles-fiscales/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/comuni-frontiera-nuove-regole-fiscali/" />
     <image:image>
@@ -4637,9 +4637,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/disoccupazione-stabile-svizzera-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/disoccupazione-stabile-svizzera-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/unemployment-switzerland-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/arbeitslosigkeit-schweiz-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/chomage-suisse-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/stable-unemployment-switzerland-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/stabile-arbeitslosigkeit-schweiz-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/chomage-stable-suisse-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/disoccupazione-stabile-svizzera-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/disoccupazione-stabile-svizzera-2026.webp</image:loc>
@@ -4994,9 +4994,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/iniziativa-contro-dumping-ticino/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/iniziativa-contro-dumping-ticino/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/anti-dumping-initiative-ticino/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/anti-dumping-cross-border-initiative-ticino/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/anti-dumping-initiative-ticino/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/initiative-anti-dumping-ticino/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/initiative-contre-dumping-frontaliers-ticino/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/iniziativa-contro-dumping-ticino/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/iniziativa-contro-dumping-ticino.webp</image:loc>
@@ -7529,7 +7529,7 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/san-gottardo-wind-farm-expansion/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/san-gottardo-wind-farm-expansion-project/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/san-gottardo-windestreckung-expansion/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/expansion-san-gottardo-parc-eolien/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo/" />
@@ -9144,9 +9144,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/lavena-ponte-tresa-annaffiatoi/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/lavena-ponte-tresa-annaffiatoi/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/lavena-ponte-tresa-green/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/lavena-ponte-tresa-sprinklers/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/lavena-ponte-tresa-grun/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/lavena-ponte-tresa-verdure/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/lavena-ponte-tresa-arrosoirs/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/lavena-ponte-tresa-annaffiatoi/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/lavena-ponte-tresa-annaffiatoi.webp</image:loc>
@@ -10413,9 +10413,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/la-quinta-svizzera-che-ha-un-debole-per-milano/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/la-quinta-svizzera-che-ha-un-debole-per-milano/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/slug-en/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/slug-de/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/slug-fr/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/fifth-switzerland-weakness-for-milan/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/die-fuenfte-schweiz-schwaeche-fuer-mailand/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/cinquieme-suisse-faible-pour-milan/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/la-quinta-svizzera-che-ha-un-debole-per-milano/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/la-quinta-svizzera-che-ha-un-debole-per-milano.webp</image:loc>
@@ -12712,9 +12712,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/health-subsidies-mendrisio-delays/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/health-subsidies-mendrisio-delays-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/gesundheitssubventionen-mendrisio-verzogerungen/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/subventions-assurance-maladie-mendrisio-retards/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/subventions-assurance-maladie-mendrisio-retards-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/sussidi-cassa-malati-mendrisio-ritardi.webp</image:loc>
@@ -13443,7 +13443,7 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/costi-cure-domocilio-ticino-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/costi-cure-domocilio-ticino-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/home-care-costs-ticino-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/home-care-expenses-ticino-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/kosten-fur-pflege-zuhause-tessin-2026/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/couts-des-soins-a-domicile-tessin-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/costi-cure-domocilio-ticino-2026/" />
@@ -27655,9 +27655,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-abandoned-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/ticino-polizei-projekt-aufgegeben-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/projet-police-tessin-abandonne-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-abandoned-project-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/tessin-polizei-aufgegebenes-projekt-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/police-tessin-projet-abandonne-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/polizia-ticino-abbandono-progetto-2026.webp</image:loc>
@@ -27791,9 +27791,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-abandoned-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/ticino-polizei-projekt-aufgegeben-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/projet-police-tessin-abandonne-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-cancellation-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/tessin-polizei-projektaufgabe-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/annulation-projet-police-tessin-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/polizia-ticino-progetto-abbandono-2026.webp</image:loc>
@@ -28898,7 +28898,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/penuria-carburante-svizzera-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/fuel-shortage-switzerland-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/treibstoffmangel-schweiz-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/penurie-de-carburant-suisse-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/penurie-carburant-suisse-2026-crise/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/penuria-carburante-svizzera-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/penuria-carburante-svizzera-2026.webp</image:loc>
@@ -29068,7 +29068,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/movieri-traffico-ss340-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/traffic-observers-lake-como-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/verkehrsbeobachter-comer-see-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/observateurs-trafic-lac-como-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/agents-trafic-route-ss340-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/movieri-traffico-ss340-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/movieri-traffico-ss340-2026.webp</image:loc>
@@ -30615,7 +30615,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/incidente-a9-turate-feriti-frontalieri/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/a9-turate-accident-injured-cross-border-workers/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/unfall-a9-turate-verletzte-grenzgaenger/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/accident-a9-turate-blesses-travailleurs-frontaliers/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/collision-a9-turate-blesses-frontaliers/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/incidente-a9-turate-feriti-frontalieri/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/incidente-a9-turate-feriti-frontalieri.webp</image:loc>
@@ -31004,9 +31004,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/lugano-pensilina-disturbances-quick-intervention/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/lugano-pensilina-disturbances-quick-intervention-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/lugano-pensilina-aufruhr-schnelle-intervention/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/lugano-pensilina-troubles-intervention-rapide/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/lugano-pensilina-troubles-intervention-rapide-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/disordini-pensilina-lugano-intervento-veloce-2026.webp</image:loc>
@@ -34081,9 +34081,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/carburante-svizzera-scorte-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/carburante-svizzera-scorte-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/swiss-fuel-reserves-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/schweizer-treibstoffvorrate-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/reserves-de-carburant-suisse-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/switzerland-fuel-reserves-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/schweizer-kraftstoffvorrate-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/reserves-carburant-suisse-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/carburante-svizzera-scorte-2026/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/carburante-svizzera-scorte-2026.webp</image:loc>
@@ -37074,7 +37074,7 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/case-lusso-svizzera-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/case-lusso-svizzera-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/luxury-homes-switzerland-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/luxusimmobilien-schweiz-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/luxushaeuser-schweiz-2026/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/maisons-de-luxe-suisse-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/case-lusso-svizzera-2026/" />
     <image:image>
@@ -42632,8 +42632,8 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/frontalieri-immondizia-cantello-multa/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/frontalieri-immondizia-cantello-multa/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/cross-border-waste-cantello-fine/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzueberschreitender-muell-cantello-busse/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/cross-border-workers-waste-cantello-fine/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzgaenger-muell-cantello-busse/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/dechets-transfrontaliers-cantello-amende/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/frontalieri-immondizia-cantello-multa/" />
     <image:image>
@@ -42751,9 +42751,9 @@
   <url>
     <loc>https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/slug-en/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/slug-de/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/slug-fr/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/permit-g-vs-b-cross-border-workers-2026-beyond-20km/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/genehmigung-g-vs-b-grenzgaenger-2026-jenseits-20km/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/permis-g-vs-b-frontaliers-2026-au-dela-20km/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/permesso-g-vs-b-frontalieri-2026-oltre-20-km.webp</image:loc>
@@ -43926,7 +43926,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/kindergarten-teacher-ticino-salary-requirements/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/kindergartenlehrer-tessin-gehalt-voraussetzungen/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/educateur-de-la-petite-enfance-tessin-salaire-exigences/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/educateur-petite-enfance-tessin-salaires-exigences/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti/" />
     <image:image>
       <image:loc>https://frontaliereticino.ch/images/blog/educatore-infanzia-ticino-stipendi-requisiti.webp</image:loc>
@@ -44044,7 +44044,7 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/frontaliere-asilo-nido-guida-2026/</loc>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/frontaliere-asilo-nido-guida-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/cross-border-workers-nursery-switzerland/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzgaenger-kindergarten-schweiz/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/grenzgaenger-kindergarten-guide-2026/" />
     <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/frontalier-creche-suisse/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/frontaliere-asilo-nido-guida-2026/" />
     <image:image>

--- a/public/sitemap-news.xml
+++ b/public/sitemap-news.xml
@@ -3836,9 +3836,9 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/</loc>
     <lastmod>2026-05-01</lastmod>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-abandoned-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/ticino-polizei-projekt-aufgegeben-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/projet-police-tessin-abandonne-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-abandoned-project-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/tessin-polizei-aufgegebenes-projekt-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/police-tessin-projet-abandonne-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/" />
     <news:news>
       <news:publication>
@@ -4012,9 +4012,9 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/</loc>
     <lastmod>2026-05-01</lastmod>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-abandoned-2026/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/ticino-polizei-projekt-aufgegeben-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/projet-police-tessin-abandonne-2026/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/ticino-police-project-cancellation-2026/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/tessin-polizei-projektaufgabe-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/annulation-projet-police-tessin-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/" />
     <news:news>
       <news:publication>
@@ -5444,7 +5444,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/penuria-carburante-svizzera-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/fuel-shortage-switzerland-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/treibstoffmangel-schweiz-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/penurie-de-carburant-suisse-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/penurie-carburant-suisse-2026-crise/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/penuria-carburante-svizzera-2026/" />
     <news:news>
       <news:publication>
@@ -5664,7 +5664,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/movieri-traffico-ss340-2026/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/traffic-observers-lake-como-2026/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/verkehrsbeobachter-comer-see-2026/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/observateurs-trafic-lac-como-2026/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/agents-trafic-route-ss340-2026/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/movieri-traffico-ss340-2026/" />
     <news:news>
       <news:publication>
@@ -9907,9 +9907,9 @@
     <loc>https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/</loc>
     <lastmod>2026-05-16</lastmod>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/slug-en/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/slug-de/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/slug-fr/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/permit-g-vs-b-cross-border-workers-2026-beyond-20km/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/genehmigung-g-vs-b-grenzgaenger-2026-jenseits-20km/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/permis-g-vs-b-frontaliers-2026-au-dela-20km/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/" />
     <news:news>
       <news:publication>
@@ -10657,7 +10657,7 @@
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/kindergarten-teacher-ticino-salary-requirements/" />
     <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/grenzgaenger-artikel/kindergartenlehrer-tessin-gehalt-voraussetzungen/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/educateur-de-la-petite-enfance-tessin-salaire-exigences/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-frontalier/educateur-petite-enfance-tessin-salaires-exigences/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti/" />
     <news:news>
       <news:publication>


### PR DESCRIPTION
## Contesto

`main` è **rosso** su `tests/seo-completeness.test.ts` ("Sitemap URLs match router buildPath for all locales") con **40 fallimenti** `Sitemap missing [en/de/fr] URL: … for route blog/<id>`.

**Causa radice:** #3012 ha de-duplicato 7 slug localizzati frontaliere in `services/routerBlogData.ts` ma **non ha rigenerato le sitemap committate**. Diversamente da #3000 (che, de-duplicando svizzera, aggiornò anche `sitemap-blog-ch.xml` + `sitemap-news.xml` + RSS), #3012 ha toccato **solo** `routerBlogData.ts` → gli URL `<xhtml:link hreflang>` en/de/fr nelle sitemap non corrispondono più a `buildPath` → test main-red.

## Implementato

- **`public/sitemap-blog.xml`**: ri-sincronizzati gli href hreflang `en`/`de`/`fr` di ogni blocco articolo frontaliere dalla sorgente corrente `BLOG_SLUGS` (ancorando sul `<loc>` IT invariato). **40 href corretti su 21 blocchi** — copre tutto il drift accumulato (non solo i 7 articoli di #3012, ma ogni articolo i cui slug tradotti erano stale).
- **`public/sitemap-news.xml`**: stesso sync, **12 href su 6 blocchi** (è anche dentro lo scope del precedente #3000).
- Rimossi **3 URL placeholder live-rotti** (`slug-en`/`slug-de`/`slug-fr` dell'articolo `la-quinta-svizzera-che-ha-un-debole-per-milano`, mai tradotti).
- Diff = puro swap di URL (52 inserzioni / 52 cancellazioni), nessun cambio strutturale.

## Verifica

- `vitest run tests/seo-completeness.test.ts` → **43370 pass** (era 40 failed).
- `tests/sitemap-slug-integrity.test.ts` → 10908 pass (con `data/jobs.json` generato).
- Sweep `tests/*sitemap*` + `*hreflang*` + `*news*` + `seo-completeness` → verdi (l'unico rosso era ENOENT su `data/jobs.json`, file generato in CI, assente nel worktree — non una regressione).
- Scan `public/*.xml`: **0 placeholder `slug-en/de/fr` residui**.

## Non implementato (ancora)

- Nessuno. Il sync copre tutti i blocchi frontaliere con drift in entrambe le sitemap lette dal gate SEO. Le sitemap svizzera (`sitemap-blog-ch.xml`) erano già allineate da #3000. RSS frontaliere (`rss-{en,de,fr}.xml`) non contenevano gli slug stale (verificato con grep) → niente da sincronizzare.
