### PR TITLE
fix(jobboard): kill latent '0' flash on company-hub broadening (Tier 3.5)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1949,6 +1949,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // still stale. A 0-result search holds the skeleton until this is true instead
  // of flashing "0 / no results" during the cross-locale processing window.
  const [crossLocaleSettled, setCrossLocaleSettled] = useState(false);
+ // Flips true once the company-hub broadening (Tier 3.5) fallback has fully
+ // settled — i.e. AFTER the locale-wide pool fetch + parse/dedup AND
+ // `setUnscopedJobs`. Same batching guarantee as `crossLocaleSettled`: set in
+ // the same batch as the results so there is never a frame where it reads
+ // "settled" while the 0-result count is still stale. A company-only view (no
+ // search) holds the skeleton until this is true instead of flashing "0 / no
+ // results" during the pool-processing window.
+ const [companyBroadenSettled, setCompanyBroadenSettled] = useState(false);
  const [enrichmentLoading, setEnrichmentLoading] = useState(false);
  // FRO-353: Feature flag for Job Alerts (controlled via Firebase Remote Config)
  const [enableJobAlerts, setEnableJobAlerts] = useState(false);
@@ -3346,6 +3354,10 @@ const JobBoard: React.FC<JobBoardProps> = ({
  reportCaughtError(err, 'jobBoard.loadJobs.companyBroaden');
  } finally {
  setPendingFallbacks((n) => n - 1);
+ // Mark the terminal company-broaden fallback settled (batched with
+ // setUnscopedJobs on the success path, so results + settled flip together —
+ // no stale-0 frame). Mirrors the crossLocaleSettled pattern for Tier 4.
+ if (!cancelled) setCompanyBroadenSettled(true);
  }
  })();
  return () => { cancelled = true; };
@@ -3539,6 +3551,15 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // flips true batched with the results, after which a still-empty set falls
  // through to the genuine empty-state (so a truly empty query isn't stuck).
  || (Boolean(deferredSearchQuery.trim()) && !crossLocaleSettled)
+ // Terminal company-broaden fallback (Tier 3.5) hasn't fully SETTLED yet.
+ // For a company-only view (no search) the in-canton tiers are empty, so
+ // this fetch fires and may still bring results — hold the skeleton across
+ // its entire lifecycle (fetch + parse/dedup of the locale-wide pool), not
+ // just until it's attempted, so the count never flashes "0" mid-processing.
+ // `settled` flips true batched with the results; a still-empty set then
+ // falls through to the genuine empty-state (not stuck). Mirrors the
+ // crossLocaleSettled guard for the search path (Tier 4).
+ || (Boolean(companySlugFilter) && !deferredSearchQuery.trim() && !companyBroadenSettled)
  // The query-match search index (`searchIndex`) is built incrementally over
  // the loaded jobs via rAF chunks and only committed when complete. Until it
  // covers every loaded job, `indexedQueryMatch` returns no hits, so a search


### PR DESCRIPTION
## Implementato

- Aggiunge lo state flag **`companyBroadenSettled`** (mirror di `crossLocaleSettled` da #2952) per il fallback Tier 3.5 company-hub broadening in `components/community/JobBoard.tsx`. Settato a `true` nel blocco `finally` dell'effect `companyBroaden`, batchato con `setUnscopedJobs` sul success path (garanzia React 18: results + settled flip insieme, nessun frame intermedio con settled=true e count ancora stale).
- Estende **`resultsResolving`** con la guard `|| (Boolean(companySlugFilter) && !deferredSearchQuery.trim() && !companyBroadenSettled)`: le viste company-only (filtro azienda, nessuna ricerca, tier in-canton vuoti) tengono lo skeleton per l'intera finestra fetch + parse/dedup del pool locale-wide, prevenendo il flash "0" latente nel path `companyBroaden`. Mirror della guard `crossLocaleSettled` per il path search (Tier 4).
- Nessun sibling da sweepare: il costrutto vive solo in `JobBoard.tsx`. `tsc --noEmit` su `JobBoard.tsx` pulito.

**Supersedes #2957** (stesso fix): #2957 era 3059 commit dietro `origin/main` e, dopo il force-push di riallineamento, il suo job `review` restava bloccato su `action_required` (ref-recreation → workflow non-approvabile via API). Questo branch è fresco da `origin/main`, quindi il review gira normale.

Closes #2955

## Non implementato (ancora)

- Verifica live sul prod-timing specifico: la race è latente (non segnalata in prod), replicabile solo con cache disabilitata + fetch lento su una company page senza in-canton openings. Il pattern è identico a quello corretto in #2952 → difensivo ma corretto per costruzione.