### PR TITLE
feat(job-alerts): feed email-click engagement into personalization (#3025)

### DIFF
--- a/scripts/lib/subscriber-personalization.mjs
+++ b/scripts/lib/subscriber-personalization.mjs
@@ -79,17 +79,25 @@ function fromUsageMap(map) {
  * @param {DeriveInput} input
  * @returns {Record<string, string>|null} patch, or null when nothing to fill.
  */
-export function derivePersonalizationPatch({ subscriber, personalization, alerts = [] } = {}) {
+export function derivePersonalizationPatch({ subscriber, personalization, alerts = [], clicked = null } = {}) {
   const sub = subscriber || {};
   const p = personalization || {};
   const viewedJobs = Array.isArray(p.viewedJobs) ? p.viewedJobs : [];
   const searches = Array.isArray(p.searches) ? p.searches : [];
   const filterUsage = p.filterUsage && typeof p.filterUsage === 'object' ? p.filterUsage : {};
   const alertList = Array.isArray(alerts) ? alerts : [];
+  // A click on a job in an email is the STRONGEST intent signal we hold — the
+  // user actively chose that job out of the inbox — so it outranks a passive
+  // on-site filter (×3) or view (×2). Resolved from the ESP-recorded
+  // `last_clicked_url` by the caller; see send-job-alerts.mjs clickedJobMeta.
+  const clk = clicked || {};
+  const clickedLocations = Array.isArray(clk.locations) ? clk.locations : [];
+  const CLICK_WEIGHT = 5;
 
-  // ── Location: filter usage (strongest — an explicit filter action) > viewed
-  //    job cities > explicit alert locations / cantons.
+  // ── Location: clicked job (strongest) > filter usage (explicit filter
+  //    action) > viewed job cities > explicit alert locations / cantons.
   const locationEntries = [
+    ...clickedLocations.map((l) => ({ value: l, weight: CLICK_WEIGHT })),
     ...fromUsageMap(filterUsage.location).map((e) => ({ ...e, weight: e.weight * 3 })),
     ...viewedJobs.map((v) => ({ value: v?.location, weight: 2 })),
     ...alertList.flatMap((a) => [
@@ -107,8 +115,11 @@ export function derivePersonalizationPatch({ subscriber, personalization, alerts
   ];
   const sector = topWeighted(sectorEntries);
 
-  // ── Company: most-viewed employer.
-  const company = topWeighted(viewedJobs.map((v) => ({ value: v?.company, weight: 1 })));
+  // ── Company: clicked employer (strongest) > most-viewed employer.
+  const company = topWeighted([
+    { value: clk.company, weight: CLICK_WEIGHT },
+    ...viewedJobs.map((v) => ({ value: v?.company, weight: 1 })),
+  ]);
 
   // ── Search query: most recent search, else newest viewed-job title-ish, else
   //    alert keywords / source title.

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -35,6 +35,7 @@ import {
   DEDUP_WINDOW_MS,
 } from './lib/alert-sent-jobs.mjs';
 import { derivePersonalizationPatch } from './lib/subscriber-personalization.mjs';
+import { extractSlugFromSourcePage } from './backfill-newsletter-job-context.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -443,9 +444,11 @@ function loadJobs() {
   const locationIndex = new Map();
   for (const j of jobs) {
     const geo = [j.location || j.addressLocality || '', j.canton || ''].filter(Boolean);
-    if (geo.length > 0) {
+    const company = j.company || '';
+    if (geo.length > 0 || company) {
+      const meta = { geo, company };
       for (const key of [j.slug, ...Object.values(j.slugByLocale || {}), j.id]) {
-        if (key) locationIndex.set(String(key).toLowerCase(), geo);
+        if (key) locationIndex.set(String(key).toLowerCase(), meta);
       }
     }
     if (firstParsableMs(j.crawledAt, j.postedDate) >= cutoff) recent.push(j);
@@ -465,10 +468,29 @@ function sourceJobLocationsFor(alert, locationIndex) {
   ];
   for (const k of keys) {
     if (!k) continue;
-    const geo = locationIndex.get(String(k).toLowerCase());
-    if (geo) return geo;
+    const meta = locationIndex.get(String(k).toLowerCase());
+    if (meta?.geo?.length) return meta.geo;
   }
   return [];
+}
+
+// Resolve the job a subscriber CLICKED in a previous alert/newsletter email,
+// from the ESP-recorded `last_clicked_url`, into its geography + employer. A
+// click is the strongest intent signal we hold (the user picked that job out of
+// the inbox) — fed at the highest weight into personalization + matching (#3025).
+// The webhooks already persist `last_clicked_url`; we just consume it here,
+// where the jobs index is available (functions have no job data).
+function clickedJobMeta(lastClickedUrl, locationIndex) {
+  if (!lastClickedUrl || !locationIndex || locationIndex.size === 0) {
+    return { locations: [], company: '' };
+  }
+  // Reuse the canonical job-board-URL → slug parser (returns '' for non-job
+  // URLs like preferences/unsubscribe links, so those are ignored).
+  const slug = extractSlugFromSourcePage(lastClickedUrl);
+  if (!slug) return { locations: [], company: '' };
+  const meta = locationIndex.get(slug.toLowerCase());
+  if (!meta) return { locations: [], company: '' };
+  return { locations: meta.geo || [], company: meta.company || '' };
 }
 
 // Extract soft browsing signals from the personalization subdoc
@@ -1117,6 +1139,11 @@ async function main() {
   // back into the flat profile fields (no-clobber).
   const personalizationRaw = new Map();
   const subscriberDocExists = new Set();
+  // Last job-link the subscriber CLICKED in an email (ESP-recorded
+  // `last_clicked_url`), keyed by email. The strongest intent signal we hold —
+  // resolved to job geo/employer and fed at top weight into matching +
+  // personalization (#3025). Prefer the alert-channel click over the newsletter.
+  const lastClickedUrlByEmail = new Map();
   for (const email of alertEmails) {
     try {
       const subDoc = await db.collection('newsletter_subscribers').doc(email).get();
@@ -1124,6 +1151,7 @@ async function main() {
         subscriberDocExists.add(email.toLowerCase());
         const data = subDoc.data() || {};
         subscriberProfiles.set(email.toLowerCase(), data);
+        if (data.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), data.last_clicked_url);
         if (isAddressSuppressed(data.status)) suppressedEmails.add(email.toLowerCase());
         const lastSentAt = data.last_sent_at;
         if (lastSentAt) {
@@ -1139,8 +1167,11 @@ async function main() {
       // A bounce/complaint reported on the alert channel lands on the
       // job_alert_subscribers doc, not newsletter_subscribers — check both.
       const alertSubDoc = await db.collection('job_alert_subscribers').doc(email).get();
-      if (alertSubDoc.exists && isAddressSuppressed(alertSubDoc.data()?.status)) {
-        suppressedEmails.add(email.toLowerCase());
+      if (alertSubDoc.exists) {
+        const alertData = alertSubDoc.data() || {};
+        if (isAddressSuppressed(alertData.status)) suppressedEmails.add(email.toLowerCase());
+        // Alert-channel click is the most relevant — overrides the newsletter one.
+        if (alertData.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), alertData.last_clicked_url);
       }
       // Personalization subdoc (browsing-derived location + intent). Read here
       // so the matcher can fold it into ranking; absent for users who never
@@ -1193,8 +1224,11 @@ async function main() {
     // personalization (filter usage + viewed-job geography) and the geography of
     // the job it was created from, then score every recent job against it.
     const behavior = behaviorProfiles.get(alert.email.toLowerCase()) || {};
+    // The job the subscriber last clicked in an email — fold its geography into
+    // the soft location boost (strongest intent; #3025).
+    const clicked = clickedJobMeta(lastClickedUrlByEmail.get(alert.email.toLowerCase()), locationIndex);
     const extras = {
-      behaviorLocations: behavior.behaviorLocations || [],
+      behaviorLocations: [...(behavior.behaviorLocations || []), ...clicked.locations],
       behaviorTokens: behavior.behaviorTokens || [],
       sourceJobLocations: sourceJobLocationsFor(alert, locationIndex),
     };
@@ -1344,6 +1378,8 @@ async function main() {
         subscriber: subscriberProfiles.get(key) || null,
         personalization: personalizationRaw.get(key) || null,
         alerts: alertsByEmail.get(key),
+        // Strongest signal: the job this subscriber last clicked in an email.
+        clicked: clickedJobMeta(lastClickedUrlByEmail.get(key), locationIndex),
       });
       if (patch) enrichTargets.push({ key, patch });
     }

--- a/tests/subscriber-personalization.test.ts
+++ b/tests/subscriber-personalization.test.ts
@@ -72,6 +72,25 @@ describe('derivePersonalizationPatch', () => {
     expect(patch?.job_search_query).toBe('infermiere notturno');
   });
 
+  it('clicked location wins when browsing is light (strongest signal, #3025)', () => {
+    const patch = derivePersonalizationPatch({
+      subscriber: {},
+      personalization: { viewedJobs: [{ location: 'Lugano' }] }, // weight 2
+      clicked: { locations: ['Bellinzona'], company: 'EOC' }, // weight 5
+    });
+    expect(patch?.location_interest).toBe('Bellinzona');
+    expect(patch?.job_company).toBe('EOC');
+  });
+
+  it('no-clobber still holds with a clicked signal present', () => {
+    const patch = derivePersonalizationPatch({
+      subscriber: { job_company: 'Existing SA' },
+      clicked: { locations: ['Lugano'], company: 'EOC' },
+    });
+    expect(patch?.job_company).toBeUndefined(); // already set → not clobbered
+    expect(patch?.location_interest).toBe('Lugano'); // empty → filled from click
+  });
+
   it('returns null when there is nothing to fill', () => {
     expect(derivePersonalizationPatch({ subscriber: {}, personalization: null, alerts: [] })).toBeNull();
     // All fields already populated → null.


### PR DESCRIPTION
Closes #3025. Continues the #2993 personalization arc (after #3005 matcher + #3024 profile enrichment). A **click on a job in an email is the strongest intent signal we hold** — the user actively chose that job out of the inbox — yet it was never fed back into alert targeting.

## Implementato

- **Consume the click signal the webhooks already record.** All six ESP webhook cores already persist `last_clicked_url` on `newsletter_subscribers/{email}` and `job_alert_subscribers/{email}`. Functions can't turn a slug into job metadata (no jobs dataset is bundled into `functions/`), so the resolution happens where the data already lives — the **daily alert sender**: it now reads `last_clicked_url` from both docs (preferring the alert-channel click), resolves the clicked job via the jobs index, and emits its **location + canton + employer**.
- **Highest-weight signal.** The resolved click is fed into:
  - **matching this run** — folded into the soft location boost (`extras.behaviorLocations`), so same-area-as-last-click jobs rank up immediately;
  - **`derivePersonalizationPatch`** (new `clicked` input, weight 5 > filter-usage ×3 > view ×2 > alert config) — fills the durable `location_interest`/`geo_city`/`job_company` profile fields (still **no-clobber**), which next run's matcher and the newsletter/employer-blast funnels read.
- **Job index now carries employer.** `loadJobs`'s slug/id index value went from `[location,canton]` to `{ geo, company }` so a clicked job resolves to its company too (`sourceJobLocationsFor` updated to read `.geo`).
- **Zero webhook / functions-deploy changes; DRY.** Reuses the shared `extractSlugFromSourcePage` parser (imported from `backfill-newsletter-job-context.mjs`, guarded against side-effects) instead of a second URL→slug regex. Fully fail-soft (non-job URLs like preferences/unsubscribe links resolve to empty).

Tests: `tests/subscriber-personalization.test.ts` (+2) cover the clicked signal outranking light browsing and the no-clobber guard holding with a click present. Full job-alert suite green (132 incl. matching/email/dedup).

## Non implementato (ancora)

Nessuno. Con #3005 (dedup + match-signals), #3024 (profile enrichment da browsing+alert) e questa PR (engagement-click → personalizzazione al peso massimo), ogni segnale che il sito raccoglie — browsing, alert config, source job, e ora i click in email — alimenta sia il matching sia il profilo durevole. La sola direzione adiacente resta **hard geo-scoping da location inferita**, che è una decisione prodotto owner-gated (tenuto SOFT di proposito per non azzerare i match di un'alert sparsa), non un completamento meccanico — quindi è un task separato, non residuo di questo.