### PR TITLE
feat(eventi): pubblicazione Facebook degli eventi del Ticino (#2963)

### DIFF
--- a/.github/workflows/fb-events-daily-schedule.yml
+++ b/.github/workflows/fb-events-daily-schedule.yml
@@ -1,0 +1,81 @@
+name: FB Events Schedule
+
+# Posts the soonest upcoming Ticino events to the Facebook Page, geo-anchored
+# per comune (chained feature on #2963). Posts immediately (low volume), linking
+# to our /eventi/ticino/<comune>/ landing pages to drive the SEO funnel.
+
+on:
+  schedule:
+    # Twice daily at :50 — a free minute clear of the job FB slots
+    # (:05/:15/:25/:35/:45/:55), the article cron (:22) and article-gen
+    # (:07/:37). Runs after the 05:40 events crawl has refreshed data/events.json.
+    - cron: '50 8,16 * * *'
+  workflow_dispatch:
+    inputs:
+      volume:
+        description: 'Max events to post this run'
+        required: false
+        default: '3'
+        type: string
+      dry_run:
+        description: 'Skip Graph API call (preview only)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['true', 'false']
+
+# Serialize so two runs never post-and-commit the ledger concurrently (the only
+# writer of data/fb-posted-events.json).
+concurrency:
+  group: fb-events-schedule
+  cancel-in-progress: false
+
+permissions:
+  contents: write  # to commit fb-posted-events.json
+  issues: write
+
+jobs:
+  schedule:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with: { node-version: 22, cache: npm }
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from RC
+        run: node scripts/load-rc-env.mjs
+
+      - name: Post FB events
+        env:
+          FB_EVENT_VOLUME: ${{ github.event.inputs.volume || '3' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: node scripts/schedule-fb-events-daily.mjs
+
+      - name: Commit posted-events tracking
+        if: success() && github.event.inputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          if git diff --quiet data/fb-posted-events.json 2>/dev/null; then
+            echo "no changes"; exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/fb-posted-events.json
+          git commit -m "📅 Track posted FB events"
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then echo "push ok"; exit 0; fi
+            git fetch origin main || true
+            git rebase origin/main || { git rebase --abort; sleep 2; continue; }
+            sleep $((attempt * 2))
+          done
+          echo "::warning::push failed after 5 attempts"

--- a/scripts/schedule-fb-events-daily.mjs
+++ b/scripts/schedule-fb-events-daily.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Daily Facebook poster for Ticino events (chained feature on issue #2963).
+ *
+ * Picks the few SOONEST upcoming events from data/events.json that haven't been
+ * posted yet, and posts each to the Facebook Page linking to OUR per-comune
+ * events landing page (`/eventi/ticino/<comune>/`) so the post drives traffic
+ * into the SEO funnel. Each post is geo-anchored with the event comune's FB
+ * Place ID (data/fb-place-ids.json) for local-discovery reach — the same
+ * mechanism the jobs poster uses, reusing its `loadPlaceIds`/`lookupPlaceId`.
+ *
+ * Channel-agnostic primitives (ledger, sanitization) come from
+ * scripts/lib/social-post-utils.mjs — no logic is duplicated (AGENTS.md §6).
+ *
+ * Posts immediately (like the articles poster), low-volume, time-relevant.
+ * Exit code is always 0 (CI-soft) unless an unexpected crash occurs.
+ *
+ * Usage:
+ *   FB_PAGE_ID=… FB_PAGE_ACCESS_TOKEN=… node scripts/schedule-fb-events-daily.mjs
+ *   DRY_RUN=1 node scripts/schedule-fb-events-daily.mjs       # no POST, prints plan
+ *
+ * Env:
+ *   FB_PAGE_ID, FB_PAGE_ACCESS_TOKEN — Graph API credentials (required for POST)
+ *   FB_EVENT_VOLUME                  — events per run (default 3, max 10)
+ *   DRY_RUN=1                        — plan only
+ */
+
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { loadEventsDataset, upcomingEvents, slugifyComune } from './lib/events-utils.mjs';
+import { loadLedger, appendLedger, stripDiacritics, truncateBody, SITE_URL } from './lib/social-post-utils.mjs';
+import { loadPlaceIds, lookupPlaceId } from './schedule-fb-jobs-daily.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const GRAPH_BASE = 'https://graph.facebook.com/v21.0';
+const LEDGER_PATH = path.join(REPO_ROOT, 'data', 'fb-posted-events.json');
+const DEFAULT_VOLUME = 3;
+const MAX_VOLUME = 10;
+const FB_MESSAGE_HARD_LIMIT = 600;
+
+const CATEGORY_EMOJI = {
+  arte: '🎨', musica: '🎵', teatro: '🎭', cinema: '🎬', feste: '🎉',
+  musei: '🏛️', conferenze: '🎤', sport: '⚽', appuntamenti: '📌', sociale: '🤝',
+};
+
+const MONTHS_IT = ['gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre'];
+
+/** "sab 4 luglio" style Italian date from an ISO YYYY-MM-DD (no Date tz drift). */
+function humanDateIt(iso) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso || '');
+  if (!m) return iso || '';
+  const day = Number(m[3]);
+  const month = MONTHS_IT[Number(m[2]) - 1] || '';
+  return `${day} ${month}`;
+}
+
+/** Hashtag-safe token: diacritic-free, alnum only. */
+function tagWord(s) {
+  return stripDiacritics(String(s || '')).replace(/[^A-Za-z0-9]/g, '');
+}
+
+/** Canonical IT events URL for an event: comune page when known, else hub. */
+export function buildEventUrl(event) {
+  if (event?.comune) return `${SITE_URL}/eventi/ticino/${slugifyComune(event.comune)}/`;
+  return `${SITE_URL}/eventi/ticino/`;
+}
+
+/**
+ * Build the FB caption for one event:
+ *
+ *   {emoji} {title}
+ *   📍 {comune}  📅 {date}{ · time}
+ *
+ *   👉 Scopri gli eventi a {comune}:
+ *
+ *   {hashtags}
+ */
+export function buildEventCaption(event) {
+  const emoji = CATEGORY_EMOJI[event?.category] || '📅';
+  const title = String(event?.title || '').trim();
+  const comune = String(event?.comune || 'Ticino').trim();
+  const when = humanDateIt(event?.startDate);
+  const time = event?.startTime ? ` · ${event.startTime}` : '';
+
+  const metaChunks = [`📍 ${comune}`];
+  if (when) metaChunks.push(`📅 ${when}${time}`);
+
+  const tags = ['#eventiticino'];
+  const comuneTag = tagWord(comune);
+  if (comuneTag && comuneTag.toLowerCase() !== 'ticino') tags.push(`#${comuneTag}`);
+  const catTag = event?.category ? tagWord(event.category) : '';
+  if (catTag) tags.push(`#${catTag}`);
+  tags.push('#ticino', '#frontalieri');
+  const hashtags = [...new Set(tags.map((t) => t.toLowerCase()))].slice(0, 5).join(' ');
+
+  const cta = event?.comune ? `👉 Scopri gli eventi a ${comune}:` : '👉 Scopri gli eventi in Ticino:';
+  const parts = [`${emoji} ${truncateBody(title, 150)}`, metaChunks.join('  '), '', cta, '', hashtags];
+  let out = parts.join('\n').trim();
+  if (out.length > FB_MESSAGE_HARD_LIMIT) out = out.slice(0, FB_MESSAGE_HARD_LIMIT);
+  return out;
+}
+
+/** Select the soonest-starting upcoming events not yet in `postedSet`. */
+export function selectUnpostedEvents(events, postedSet, limit) {
+  if (!Array.isArray(events)) return [];
+  // upcomingEvents already sorts ascending by startDate then title.
+  return events.filter((e) => e && e.id && !postedSet.has(e.id)).slice(0, Math.max(0, limit | 0));
+}
+
+/**
+ * @param {object} [opts]
+ * @param {NodeJS.ProcessEnv} [opts.env]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {string} [opts.repoRoot]
+ * @param {(...a: unknown[]) => void} [opts.log]
+ * @param {(...a: unknown[]) => void} [opts.warn]
+ * @param {string} [opts.todayIso]
+ */
+export async function run(opts = {}) {
+  const env = opts.env || process.env;
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const repoRoot = opts.repoRoot || REPO_ROOT;
+  const log = opts.log || console.log;
+  const warn = opts.warn || console.warn;
+
+  const dryRun = env.DRY_RUN === '1' || env.DRY_RUN === 'true';
+  const volume = Math.min(MAX_VOLUME, Math.max(1, Number(env.FB_EVENT_VOLUME) || DEFAULT_VOLUME));
+  const pageId = env.FB_PAGE_ID;
+  const token = env.FB_PAGE_ACCESS_TOKEN;
+  const ledgerPath = path.join(repoRoot, 'data', 'fb-posted-events.json');
+
+  log('🗓️', `FB events daily poster — volume=${volume}, dry=${dryRun}`);
+
+  const dataset = loadEventsDataset(path.join(repoRoot, 'data', 'events.json'));
+  const upcoming = upcomingEvents(dataset.events, opts.todayIso);
+  if (upcoming.length === 0) {
+    log('ℹ️', 'no upcoming events, exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+
+  const ledger = loadLedger(ledgerPath);
+  const postedSet = new Set(ledger.posted.map((e) => e?.id).filter(Boolean));
+  const candidates = selectUnpostedEvents(upcoming, postedSet, volume);
+  if (candidates.length === 0) {
+    log('ℹ️', 'no unposted upcoming events, exiting');
+    return { ok: true, posted: 0, dryRun, payloads: [] };
+  }
+
+  const placeIds = loadPlaceIds(repoRoot);
+  const payloads = candidates.map((event) => ({
+    id: event.id,
+    url: buildEventUrl(event),
+    message: buildEventCaption(event),
+    placeId: lookupPlaceId(event.comune, placeIds),
+  }));
+  const placed = payloads.filter((p) => p.placeId).length;
+  log('📍', `place tag resolved for ${placed}/${payloads.length} payloads`);
+
+  if (dryRun) {
+    log('🏃', `DRY_RUN — would post ${payloads.length} event(s)`);
+    for (const p of payloads) log('  •', `${p.url}${p.placeId ? ` [place=${p.placeId}]` : ''}\n${p.message}\n`);
+    return { ok: true, posted: 0, dryRun: true, payloads };
+  }
+
+  if (!pageId || !token) {
+    warn('⚠️', 'FB_PAGE_ID or FB_PAGE_ACCESS_TOKEN missing — skipping');
+    return { ok: false, posted: 0, dryRun, payloads };
+  }
+  if (typeof fetchImpl !== 'function') {
+    warn('⚠️', 'no fetch impl available — skipping');
+    return { ok: false, posted: 0, dryRun, payloads };
+  }
+
+  const TRANSIENT = new Set([1, 2, 4, 17]);
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  let posted = 0;
+  for (const p of payloads) {
+    // Best-effort OG rescrape so the FB card uses the page's fresh og:* tags.
+    try {
+      await fetchImpl(`${GRAPH_BASE}/?id=${encodeURIComponent(p.url)}&scrape=true&access_token=${encodeURIComponent(token)}`, { method: 'POST' });
+    } catch { /* best-effort */ }
+
+    const apiUrl = `${GRAPH_BASE}/${pageId}/feed`;
+    const body = () => {
+      const b = new URLSearchParams({ message: p.message, link: p.url, access_token: token });
+      if (p.placeId) b.append('place', p.placeId);
+      return b;
+    };
+
+    let data = null;
+    let res = null;
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      try {
+        res = await fetchImpl(apiUrl, { method: 'POST', body: body() });
+        data = await res.json();
+      } catch (err) {
+        warn('⚠️', `POST failed for ${p.id} (attempt ${attempt}): ${err.message}`);
+        data = null;
+      }
+      if (res?.ok && data?.id) break;
+      if (attempt < 2 && TRANSIENT.has(data?.error?.code)) {
+        warn('⏳', `FB transient error ${data?.error?.code} for ${p.id}, retrying in 2s`);
+        await sleep(2000);
+        continue;
+      }
+      break;
+    }
+
+    if (res?.ok && data?.id) {
+      posted += 1;
+      appendLedger(ledgerPath, [{ id: p.id, url: p.url, postId: data.id, postedAt: new Date().toISOString() }]);
+      log('✅', `posted ${p.id} → ${data.id}`);
+    } else {
+      warn('⚠️', `FB API error for ${p.id}: ${JSON.stringify(data).slice(0, 200)}`);
+    }
+  }
+
+  log('🏁', `posted ${posted}/${payloads.length} events`);
+  return { ok: true, posted, dryRun, payloads };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  run()
+    .then((r) => process.exit(r.ok ? 0 : 0))
+    .catch((err) => {
+      console.error(`[fb-events] failed: ${err?.message || err}`);
+      process.exit(0);
+    });
+}

--- a/tests/fb-events-scheduler.test.ts
+++ b/tests/fb-events-scheduler.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Guard for the Facebook events poster (chained feature on #2963):
+ * caption/URL building, unposted selection, and a dry-run of `run()` that must
+ * never POST. Mirrors the contract of the jobs/articles FB schedulers.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildEventCaption,
+  buildEventUrl,
+  selectUnpostedEvents,
+  run,
+} from '../scripts/schedule-fb-events-daily.mjs';
+
+const EVENT = {
+  id: 'tio-agenda:1',
+  title: 'Concerto sinfonico al LAC',
+  startDate: '2099-07-04',
+  startTime: '20:00',
+  category: 'musica',
+  comune: 'Lugano',
+  canton: 'TI',
+  url: 'https://www.tio.ch/agenda/day/20990704/1',
+  sourceKey: 'tio-agenda',
+  sourceName: 'Tio.ch Agenda',
+};
+
+describe('buildEventUrl', () => {
+  it('links to the comune page when comune is known', () => {
+    expect(buildEventUrl(EVENT)).toBe('https://frontaliereticino.ch/eventi/ticino/lugano/');
+  });
+  it('falls back to the canton hub when no comune', () => {
+    expect(buildEventUrl({ ...EVENT, comune: undefined })).toBe('https://frontaliereticino.ch/eventi/ticino/');
+  });
+});
+
+describe('buildEventCaption', () => {
+  const caption = buildEventCaption(EVENT);
+  it('includes title, comune, date and a category emoji', () => {
+    expect(caption).toContain('Concerto sinfonico al LAC');
+    expect(caption).toContain('📍 Lugano');
+    expect(caption).toContain('4 luglio');
+    expect(caption).toContain('🎵');
+  });
+  it('emits deduped, comune + category hashtags', () => {
+    expect(caption).toContain('#eventiticino');
+    expect(caption).toContain('#lugano');
+    expect(caption).toContain('#musica');
+    expect(caption).toContain('#frontalieri');
+  });
+  it('does not emit a #ticino comune tag for canton-level events', () => {
+    const c = buildEventCaption({ ...EVENT, comune: undefined });
+    // comune tag is skipped, but the always-on #ticino tag is still present
+    expect(c).toContain('#eventiticino');
+    expect(c).not.toMatch(/#Ticino\b/);
+  });
+});
+
+describe('selectUnpostedEvents', () => {
+  const events = [
+    { id: 'a', startDate: '2099-01-01' },
+    { id: 'b', startDate: '2099-01-02' },
+    { id: 'c', startDate: '2099-01-03' },
+  ];
+  it('skips already-posted and respects the limit', () => {
+    const out = selectUnpostedEvents(events, new Set(['a']), 1);
+    expect(out.map((e) => e.id)).toEqual(['b']);
+  });
+  it('returns [] when everything is posted', () => {
+    expect(selectUnpostedEvents(events, new Set(['a', 'b', 'c']), 5)).toEqual([]);
+  });
+});
+
+describe('run() dry-run', () => {
+  function fixtureRepo() {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'fb-events-'));
+    mkdirSync(path.join(root, 'data'), { recursive: true });
+    writeFileSync(
+      path.join(root, 'data', 'events.json'),
+      JSON.stringify({ schemaVersion: 1, events: [EVENT, { ...EVENT, id: 'tio-agenda:2', comune: 'Bellinzona' }] }),
+    );
+    writeFileSync(
+      path.join(root, 'data', 'fb-place-ids.json'),
+      JSON.stringify({ schemaVersion: 1, places: { Lugano: { id: '106534719384213', name: 'Lugano' } } }),
+    );
+    return root;
+  }
+
+  it('builds payloads, resolves place ids, and never POSTs in dry-run', async () => {
+    const root = fixtureRepo();
+    let fetchCalls = 0;
+    const res = await run({
+      env: { DRY_RUN: '1', FB_EVENT_VOLUME: '5' },
+      repoRoot: root,
+      todayIso: '2099-01-01',
+      fetchImpl: (() => {
+        fetchCalls += 1;
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'x' }) });
+      }),
+      log: () => {},
+      warn: () => {},
+    });
+    expect(res.dryRun).toBe(true);
+    expect(res.posted).toBe(0);
+    expect(fetchCalls).toBe(0); // dry-run must not call the Graph API
+    expect(res.payloads).toHaveLength(2);
+    expect(res.payloads[0].url).toContain('/eventi/ticino/');
+    expect(res.payloads.find((p) => p.url.includes('/lugano/')).placeId).toBe('106534719384213');
+    // ledger must not be written in dry-run
+    expect(existsSync(path.join(root, 'data', 'fb-posted-events.json'))).toBe(false);
+  });
+
+  it('skips posting when credentials are missing (non-dry)', async () => {
+    const root = fixtureRepo();
+    const res = await run({
+      env: { FB_EVENT_VOLUME: '2' },
+      repoRoot: root,
+      todayIso: '2099-01-01',
+      fetchImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'x' }) }),
+      log: () => {},
+      warn: () => {},
+    });
+    expect(res.ok).toBe(false);
+    expect(res.posted).toBe(0);
+  });
+});


### PR DESCRIPTION
Riferito a #2963 — PR concatenata #2 (rule #8: il task resta aperto fino a completamento). Costruisce sopra la feature eventi già live (#3013).

## Implementato

- **`scripts/schedule-fb-events-daily.mjs`** — posta i pochi eventi più imminenti non ancora pubblicati da `data/events.json`:
  - **geo-anchor per-comune** via `loadPlaceIds`/`lookupPlaceId` (riusati da `schedule-fb-jobs-daily.mjs`) + `data/fb-place-ids.json` (FB Place ID per 2242 comuni) — verificato in dry-run: place-id risolto per Lugano/Mendrisio/…
  - **ledger dedup** `data/fb-posted-events.json` via i primitivi condivisi `loadLedger`/`appendLedger` (`social-post-utils.mjs`) — nessuna logica duplicata (AGENTS.md §6).
  - ogni post **linka a `/eventi/ticino/<comune>/`** (le nostre landing) per alimentare il funnel SEO; caption = emoji-categoria + titolo + comune·data·ora + CTA + hashtag.
  - post immediato low-volume (default 3/run), retry sui transient FB (codici 1/2/4/17), rescrape OG pre-post, guardia `import.meta.url` per i test.
- **`.github/workflows/fb-events-daily-schedule.yml`** — cron 2×/giorno (08:50 e 16:50 UTC, slot `:50` libero clear di job `:05–:55`/articoli `:22`/article-gen `:07/:37`/weather `:23`/crawl-events `:40`), Firebase SA + `load-rc-env.mjs` per i secret FB (stesso meccanismo del poster articoli, secret già configurati), commit ledger rebase-retry. `concurrency` serializzata.
- **`tests/fb-events-scheduler.test.ts`** (9): caption (titolo/comune/data/emoji/hashtag), `buildEventUrl` (comune-page vs hub), `selectUnpostedEvents` (dedup+limit), `run()` dry-run che **non chiama mai la Graph API** e non scrive il ledger + skip senza credenziali.

### Verifica eseguita
`vitest` 9 test FB + 20 workflow-permissions-parity verdi; `check-sibling-patterns` nessun gemello da sweepare; DRY_RUN su `data/events.json` reale (112 eventi) → 3 payload con place-id per-comune risolti e caption corrette.

### Go-live
I secret `FB_PAGE_ID`/`FB_PAGE_ACCESS_TOKEN` sono già su RC (li usa il poster articoli) → al merge il cron pubblica live. Prima esecuzione verificabile con `gh workflow run fb-events-daily-schedule.yml -f dry_run=true`.

## Non implementato (ancora) — task #2963 APERTO, prosegue

- **PR concatenata #3 — digest weekend/settimana sul blog:** articolo "Eventi nel weekend in Ticino" generato da `data/events.json` via il path articoli (`create-article.mjs` writer sequence / `generate-article.yml`). Mappato, in arrivo.
- **PR concatenata #4 — immagini flyer con `imageObjectLd`:** mirror CDN dei flyer + `<img>` accessibile + ImageObject license-completo nel JSON-LD.
- **Crawler siti comunali singoli + altri cantoni:** richiedono mappa comune→URL ufficiale (assente nei dataset) e fonti non-tio.ch → in valutazione di fattibilità; se task realmente separato apro issue dedicata, altrimenti PR concatenata.