### PR TITLE
fix(crawlers): remove single-canton fetch facets from national employers (SRG/SMN/Skyguide/Mikron/PEMSA)

### DIFF
--- a/scripts/lib/avaloq-job-parser.mjs
+++ b/scripts/lib/avaloq-job-parser.mjs
@@ -213,7 +213,9 @@ export function isAvaloqTargetLocation(raw = '') {
 }
 
 export function inferAvaloqCanton(raw = '') {
-  return inferAnyCanton(raw) || 'TI';
+  // No Ticino default — Avaloq is Zürich-based and hires nationally; leave blank
+  // when unresolved so the downstream hardening derives the canton.
+  return inferAnyCanton(raw) || '';
 }
 
 export function buildAvaloqLocalizedContent(detail = {}, companyName = 'Avaloq') {

--- a/scripts/lib/bosch-job-parser.mjs
+++ b/scripts/lib/bosch-job-parser.mjs
@@ -1,8 +1,5 @@
 import { JSDOM } from 'jsdom';
 import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
-import { getCompanyDefaults } from './crawler-location-config.mjs';
-
-const HQ = getCompanyDefaults('bosch');
 
 function normalize(value = '') {
   return String(value || '').trim();
@@ -138,7 +135,9 @@ export function parseBoschJobDetail(html = '') {
     // Location-first: the location field is authoritative; resolve it before the
     // job title so a canton/city name in the title can't override the real
     // location via inferAnyCanton's TARGET_CANTONS array-order sensitivity.
-    canton: inferAnyCanton(location) || inferAnyCanton(title) || HQ.canton,
+    // No Ticino default — Bosch's CH crawl is national (?country=ch); leave
+    // blank when unresolved so the PLZ/locality hardening derives the canton.
+    canton: inferAnyCanton(location) || inferAnyCanton(title) || '',
   };
 }
 
@@ -152,7 +151,7 @@ export function inferBoschCategory(detail = {}) {
 
 export function buildBoschLocalizedContent(detail = {}) {
   const title = normalize(detail.title);
-  const locationLabel = normalize(detail.location || 'Ticino');
+  const locationLabel = normalize(detail.location || 'Svizzera');
   const lowerTitle = title.toLowerCase();
   const baseDescription = detail.description || '';
   const titleByLocale = {

--- a/scripts/lib/kone-job-parser.mjs
+++ b/scripts/lib/kone-job-parser.mjs
@@ -253,7 +253,9 @@ export async function fetchAllKoneJobs() {
     const city = normalizeSpace(loc.city || '');
     const region = normalizeSpace(loc.region || '');
     const location = city || region || 'Switzerland';
-    const canton = inferAnyCanton(location) || 'VS';
+    // No Valais default — KONE (Schweiz) AG is Zürich/Adliswil and the API is
+    // national; leave blank when unresolved so the PLZ/locality hardening fills it.
+    const canton = inferAnyCanton(location) || '';
 
     // Description
     const descriptionText = buildDescription(sections);

--- a/scripts/lib/mikron-job-parser.mjs
+++ b/scripts/lib/mikron-job-parser.mjs
@@ -1,20 +1,19 @@
 /**
  * Mikron Group — Drupal-based job listing parser
  *
- * Mikron Group is a Swiss industrial/precision manufacturing company
- * with operations in Agno, Canton Ticino (Mikron Machining division).
+ * Mikron Group is a Swiss industrial/precision manufacturing company with
+ * two Swiss sites: Mikron Machining in Agno (Ticino) and Mikron Automation
+ * in Boudry (Neuchâtel). Both publish on the same national career page; the
+ * canton is derived per-job from each teaser's location value.
  *
  * Career page: https://www.mikron.com/en/group/our-people/join-us/jobs
- * The page uses a Drupal Views module with AJAX filtering.
- * Jobs are rendered as HTML cards with division, function, and location metadata.
- *
- * Location filter for Agno: ?location=Switzerland%2C+Agno
+ * The page uses a Drupal Views module; the first page of job teasers is
+ * rendered server-side with division, function, and location metadata.
  */
 
 import { isTargetSwissLocation } from './target-swiss-locations.mjs';
 
 export const MIKRON_CAREERS_URL = 'https://www.mikron.com/en/group/our-people/join-us/jobs';
-export const MIKRON_AGNO_URL = `${MIKRON_CAREERS_URL}?location=Switzerland%2C+Agno`;
 export const MIKRON_HOST = 'www.mikron.com';
 
 export const AGNO_LOCATION_KEYWORDS = ['agno', 'ticino', 'lugano'];
@@ -86,15 +85,52 @@ export function isAgnoLocation(locationText = '') {
  *
  * @param {string} html - Raw HTML of the jobs page
  * @param {object} options - Options
- * @param {boolean} options.filterAgno - If true, only return Agno jobs (default: true)
+ * @param {boolean} options.filterAgno - If true, keep only Agno/TI jobs (default: false → all Swiss sites)
  * @returns {Array<{title: string, url: string, division: string, jobFunction: string, location: string, idx: number}>}
  */
 export function parseMikronJobs(html = '', options = {}) {
-  const { filterAgno = true } = options;
+  const { filterAgno = false } = options;
   if (!html || typeof html !== 'string') return [];
 
   const jobs = [];
   let idx = 0;
+
+  // Strategy 0 (primary): the Drupal "open_jobs" view renders one
+  // <article class="mi-job-teaser"> per job, server-side, with a
+  // job-attributes block that includes the real "Location" value
+  // (e.g. "Switzerland, Boudry" for the Automation division in NE,
+  // "Switzerland, Agno" for Machining in TI). Parse the full article so
+  // the location is never fabricated and non-Agno (NE/…) jobs survive.
+  const teaserRe = /<article[^>]*class="[^"]*mi-job-teaser[^"]*"[^>]*>([\s\S]*?)<\/article>/gi;
+  let teaserMatch;
+  while ((teaserMatch = teaserRe.exec(html)) !== null) {
+    const block = teaserMatch[1];
+    const linkMatch = block.match(/<a[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/i);
+    if (!linkMatch) continue;
+    const url = linkMatch[1];
+    const title = normalizeSpace(htmlToText(linkMatch[2]));
+    if (!title || title.length < 3) continue;
+
+    const text = normalizeSpace(htmlToText(block));
+    const locMatch = block.match(/(Switzerland|Germany|France|China|USA|Singapore|Lithuania)\s*,\s*([A-Za-zÀ-ÿ.\-\s]+?)\s*</i)
+      || text.match(/(Switzerland|Germany|France|China|USA|Singapore|Lithuania)\s*,\s*([A-Za-zÀ-ÿ.\-]+)/i);
+    const location = locMatch ? normalizeSpace(`${locMatch[1]}, ${locMatch[2]}`) : '';
+    const divisionMatch = text.match(/Division\s+([A-Za-z&\s]+?)(?=\s+(?:Function|Location|Workload|$))/i);
+
+    idx++;
+    jobs.push({
+      title,
+      url: url.startsWith('http') ? url : `https://${MIKRON_HOST}${url}`,
+      division: divisionMatch ? normalizeSpace(divisionMatch[1]) : '',
+      jobFunction: '',
+      location,
+      idx,
+    });
+  }
+  if (jobs.length > 0) {
+    const filtered = filterAgno ? jobs.filter((j) => !j.location || isAgnoLocation(j.location)) : jobs;
+    return dedupeByUrl(filtered);
+  }
 
   // Strategy 1: Look for views-row or article elements containing job links
   const rowRe = /<(?:article|div|tr)[^>]*class="[^"]*(?:views-row|job|node)[^"]*"[^>]*>([\s\S]*?)<\/(?:article|div|tr)>/gi;
@@ -127,7 +163,7 @@ export function parseMikronJobs(html = '', options = {}) {
       url: url.startsWith('http') ? url : `https://${MIKRON_HOST}${url}`,
       division,
       jobFunction,
-      location: location || 'Switzerland, Agno',
+      location,
       idx,
     });
   }
@@ -149,17 +185,21 @@ export function parseMikronJobs(html = '', options = {}) {
         url: `https://${MIKRON_HOST}${url}`,
         division: '',
         jobFunction: '',
-        location: 'Switzerland, Agno',
+        location: '',
         idx,
       });
     }
   }
 
-  // Deduplicate by URL
+  return dedupeByUrl(jobs);
+}
+
+/** Deduplicate parsed job rows by their (lowercased) URL. */
+function dedupeByUrl(jobs = []) {
   const seen = new Set();
   return jobs.filter((j) => {
-    const key = j.url.toLowerCase();
-    if (seen.has(key)) return false;
+    const key = String(j.url || '').toLowerCase();
+    if (!key || seen.has(key)) return false;
     seen.add(key);
     return true;
   });

--- a/scripts/lib/pemsa-job-parser.mjs
+++ b/scripts/lib/pemsa-job-parser.mjs
@@ -1,9 +1,9 @@
 /**
  * PEMSA — WordPress career page parser
  *
- * Listing: https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/?_canton=125
- *   WordPress with WP Grid Builder. Pre-filtered for canton=Ticino (125).
- *   Job links in format: https://www.pemsa.ch/it/job/{slug}-{id}/
+ * Listing: https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/
+ *   WordPress with WP Grid Builder. National listing (all cantons, no canton
+ *   facet). Job links in format: https://www.pemsa.ch/it/job/{slug}-{id}/
  *
  * Detail: https://www.pemsa.ch/it/job/{slug}-{id}/
  *   JSON-LD JobPosting with title, description, datePosted, validThrough,
@@ -13,9 +13,9 @@
  * electrical, HVAC, and industrial trades. HQ in Geneva, branch in Ticino.
  */
 
-import { isTargetSwissLocation } from './target-swiss-locations.mjs';
+import { isTargetSwissLocation, inferAnyCanton } from './target-swiss-locations.mjs';
 
-const LISTING_URL = 'https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/?_canton=125';
+const LISTING_URL = 'https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/';
 
 function normalizeSpace(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -223,14 +223,15 @@ export async function parsePemsaDetailPage(url, timeoutMs = 15000) {
 }
 
 /**
- * Check if a PEMSA job is Ticino-relevant.
+ * Check if a PEMSA job is in a Swiss target canton (all 26).
+ * (Name kept for API stability; scope is now CH-wide, not Ticino-only.)
  */
 export function isPemsaTicinoRelevant(job = {}) {
-  const region = normalizeSpace(job.region || '').toUpperCase();
-  if (region === 'TI') return true;
-
-  const city = normalizeSpace(job.city || '').toLowerCase();
-  if (!city) return true; // Pre-filtered by canton=125
+  const region = normalizeSpace(job.region || '');
+  const city = normalizeSpace(job.city || '');
+  // inferAnyCanton resolves both canton codes ("GE") and city names ("Genève").
+  if (inferAnyCanton(region) || inferAnyCanton(city)) return true;
+  if (!city && !region) return true; // PEMSA is a Swiss-only agency — keep location-less rows
   return isTargetSwissLocation(city);
 }
 
@@ -240,7 +241,7 @@ export function isPemsaTicinoRelevant(job = {}) {
  */
 export function buildPemsaLocalizedContent(job = {}) {
   const title = normalizeSpace(job.title);
-  const city = normalizeSpace(job.city) || 'Ticino';
+  const city = normalizeSpace(job.city) || 'Svizzera';
   const desc = job.description || '';
   const sectionCount = job.descriptionSectionCount || 0;
   const sourceLength = job.descriptionSourceLength || 0;

--- a/scripts/lib/ruag-job-parser.mjs
+++ b/scripts/lib/ruag-job-parser.mjs
@@ -169,12 +169,14 @@ export function isRuagTargetLocation(raw = '') {
 }
 
 export function inferRuagCanton(raw = '') {
-  return inferAnyCanton(raw) || 'TI';
+  // No Ticino default — RUAG is Bern-based and national (defence); leave blank
+  // when unresolved so the downstream hardening derives the canton.
+  return inferAnyCanton(raw) || '';
 }
 
 export function buildRuagLocalizedContent(detail = {}, companyName = 'RUAG AG', locale = 'it') {
   const title = String(detail.title || '').trim();
-  const location = String(detail.location || '').trim() || 'Ticino';
+  const location = String(detail.location || '').trim() || 'Svizzera';
   const description = String(detail.description || '').trim();
   return {
     titleByLocale: {

--- a/scripts/lib/skyguide-job-parser.mjs
+++ b/scripts/lib/skyguide-job-parser.mjs
@@ -78,7 +78,10 @@ export function isSkyguideTargetLocation(raw = '') {
 }
 
 export function inferSkyguideCanton(raw = '') {
-  return inferAnyCanton(raw) || 'TI';
+  // No Ticino default — Skyguide's two area control centres are in Geneva (GE)
+  // and Dübendorf (ZH), plus towers nationwide. Leave blank when unresolved;
+  // the downstream hardening derives the canton from the city.
+  return inferAnyCanton(raw) || '';
 }
 
 export function parseSkyguideJobDetail(html = '') {
@@ -121,7 +124,7 @@ export function parseSkyguideJobDetail(html = '') {
 
 export function buildSkyguideLocalizedContent(detail = {}, companyName = 'Skyguide') {
   const title = String(detail.title || '').trim();
-  const location = String(detail.location || '').trim() || 'Ticino';
+  const location = String(detail.location || '').trim() || 'Svizzera';
   const description = String(detail.description || '').trim();
   return {
     titleByLocale: {

--- a/scripts/lib/srg-ssr-job-parser.mjs
+++ b/scripts/lib/srg-ssr-job-parser.mjs
@@ -5,8 +5,8 @@
  * Source: https://jobs.srgssr.ch/
  *
  * The SRG SSR career portal is a server-side rendered page with no public
- * JSON API.  The crawler fetches the HTML listing page (filtered by
- * canton Wallis, id 1137442) and parses job card links.  For each job it
+ * JSON API.  The crawler fetches the national HTML listing page (no canton
+ * facet) and parses job card links.  For each job it
  * fetches the detail page and extracts the embedded JSON-LD JobPosting
  * schema, which contains title, description, qualifications, location,
  * employment type, posting date, etc.
@@ -31,11 +31,13 @@ export const SRG_SSR_COMPANY_DOMAIN = 'srgssr.ch';
 const CAREER_BASE = 'https://jobs.srgssr.ch';
 
 /**
- * Canton filter IDs used by the career portal's server-side form.
- * filter_40 = Kanton select.  1137442 = Wallis.
+ * National listing — NO canton facet. SRG SSR is the national public
+ * broadcaster (SRF Zürich/Basel, RTS Genève/Lausanne, RSI Lugano/Comano,
+ * RTR Chur, SWI + HQ Bern, Biel/Bienne); the previous `filter_40=1137442`
+ * (Wallis) facet returned ~0 jobs. Each job's real canton is inferred
+ * per-record from its JSON-LD `jobLocation.address`.
  */
-const WALLIS_FILTER_ID = '1137442';
-const LISTING_URL = `${CAREER_BASE}/?lang=de&filter_40=${WALLIS_FILTER_ID}`;
+const LISTING_URL = `${CAREER_BASE}/?lang=de`;
 
 /** Organisation code → human-readable sub-entity label. */
 const ORG_LABELS = {
@@ -314,22 +316,22 @@ function extractRequirements(jsonLd) {
 /* ── Main fetch function ───────────────────────────────────── */
 
 /**
- * Fetch all SRG SSR Valais jobs from the career portal.
+ * Fetch all SRG SSR jobs (national, all cantons) from the career portal.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
  * by the AI localization step and translate-pending pipeline.
  */
 export async function fetchAllSrgSsrJobs() {
-  console.log(`🔍 Fetching SRG SSR jobs (Wallis filter)`);
+  console.log(`🔍 Fetching SRG SSR jobs (national, all cantons)`);
   console.log(`   Source: ${LISTING_URL}\n`);
 
-  // Step 1: Fetch the Wallis-filtered listing page
+  // Step 1: Fetch the national listing page (all cantons)
   const listingHtml = await fetchPage(LISTING_URL);
   const listings = parseListingHtml(listingHtml);
 
   if (listings.length === 0) {
-    console.warn('⚠️  No Wallis job listings found on the career page.');
+    console.warn('⚠️  No job listings found on the career page.');
     return [];
   }
 
@@ -354,8 +356,8 @@ export async function fetchAllSrgSsrJobs() {
       const addressLocality = normalizeSpace(jlAddress.addressLocality || '');
       const infoLineParts = (listing.infoLine || '').split(',').map(s => s.trim());
       const locationFromInfo = infoLineParts.length > 1 ? infoLineParts.slice(1).join(', ') : '';
-      const location = addressLocality || locationFromInfo || 'Valais';
-      const canton = inferAnyCanton(location) || 'VS';
+      const location = addressLocality || locationFromInfo || '';
+      const canton = inferAnyCanton(location) || '';
       const postalCode = String(jlAddress.postalCode || '').trim() || '';
       const streetAddress = normalizeSpace(jlAddress.streetAddress || '');
 

--- a/scripts/lib/swiss-medical-network-job-parser.mjs
+++ b/scripts/lib/swiss-medical-network-job-parser.mjs
@@ -36,6 +36,12 @@ export function smnPostingDetailApiUrl(id = '') {
   return `${SMN_POSTINGS_API}/${encodeURIComponent(id)}`;
 }
 
+/** Extract the numeric SmartRecruiters posting id from a SwissMedicalNetwork1 URL. */
+export function extractSmnPostingId(url = '') {
+  const m = String(url || '').match(/smartrecruiters\.com\/SwissMedicalNetwork1\/(\d+)/i);
+  return m ? m[1] : '';
+}
+
 /**
  * Normalize a SmartRecruiters postings-list entry to {id, title, city, region,
  * canton, postalCode, country}. The canton is inferred from the API region
@@ -48,6 +54,8 @@ export function normalizeSmnApiPosting(posting = {}) {
   // region is often a 2-letter canton code ("BE"); normalizeAnyCantonCode
   // resolves both codes and names, then fall back to city-name inference.
   const canton = normalizeAnyCantonCode(region) || inferAnyCanton(region) || inferAnyCanton(city) || '';
+  const empLabel = `${posting.typeOfEmployment?.id || ''} ${posting.typeOfEmployment?.label || ''}`.toLowerCase();
+  const employmentType = /part[\s-]?time|teilzeit|temps\s*partiel|tempo\s*parziale/.test(empLabel) ? 'PART_TIME' : 'FULL_TIME';
   return {
     id: String(posting.id || ''),
     title: normalizeSpace(posting.name || ''),
@@ -56,6 +64,7 @@ export function normalizeSmnApiPosting(posting = {}) {
     canton,
     postalCode: normalizeSpace(loc.postalCode || ''),
     country: String(loc.country || '').toLowerCase(),
+    employmentType,
   };
 }
 

--- a/scripts/lib/swiss-medical-network-job-parser.mjs
+++ b/scripts/lib/swiss-medical-network-job-parser.mjs
@@ -12,9 +12,64 @@
  * Job application links go to jobs.smartrecruiters.com/SwissMedicalNetwork1/...
  */
 
-import { isTargetSwissLocation } from './target-swiss-locations.mjs';
+import { isTargetSwissLocation, inferAnyCanton } from './target-swiss-locations.mjs';
+import { normalizeAnyCantonCode } from './crawler-location-config.mjs';
 
 export const TICINO_REGION_UUID = '7845726f-4952-4b7c-88da-8ff4f85e6afb';
+
+// ─── SmartRecruiters public API (CH-wide source of truth) ──────────────────
+// The swissmedical.net careers page is React-rendered and region-filtered; the
+// SmartRecruiters posting API exposes ALL Swiss Medical Network jobs across the
+// 26 cantons with per-job location (city/region/postalCode) — no clinic registry
+// or Ticino default needed. Company id is taken from the apply-URL path
+// (jobs.smartrecruiters.com/SwissMedicalNetwork1/...).
+export const SMN_SR_COMPANY_ID = 'SwissMedicalNetwork1';
+export const SMN_POSTINGS_API = `https://api.smartrecruiters.com/v1/companies/${SMN_SR_COMPANY_ID}/postings`;
+
+/** Build the postings list API URL for a given pagination window. */
+export function smnPostingsApiUrl(offset = 0, limit = 100) {
+  return `${SMN_POSTINGS_API}?limit=${limit}&offset=${offset}`;
+}
+
+/** Build the posting-detail API URL for a posting id. */
+export function smnPostingDetailApiUrl(id = '') {
+  return `${SMN_POSTINGS_API}/${encodeURIComponent(id)}`;
+}
+
+/**
+ * Normalize a SmartRecruiters postings-list entry to {id, title, city, region,
+ * canton, postalCode, country}. The canton is inferred from the API region
+ * (often a 2-letter code) or the city — no Ticino fallback.
+ */
+export function normalizeSmnApiPosting(posting = {}) {
+  const loc = posting.location || {};
+  const city = normalizeSpace(loc.city || '');
+  const region = normalizeSpace(loc.region || '');
+  // region is often a 2-letter canton code ("BE"); normalizeAnyCantonCode
+  // resolves both codes and names, then fall back to city-name inference.
+  const canton = normalizeAnyCantonCode(region) || inferAnyCanton(region) || inferAnyCanton(city) || '';
+  return {
+    id: String(posting.id || ''),
+    title: normalizeSpace(posting.name || ''),
+    city,
+    region,
+    canton,
+    postalCode: normalizeSpace(loc.postalCode || ''),
+    country: String(loc.country || '').toLowerCase(),
+  };
+}
+
+/** Extract a rich description from a SmartRecruiters posting-detail jobAd. */
+export function extractSmnApiDescription(detail = {}) {
+  const secs = detail?.jobAd?.sections || {};
+  const order = ['jobDescription', 'qualifications', 'additionalInformation', 'companyDescription'];
+  const parts = [];
+  for (const key of order) {
+    const text = htmlToText(secs[key]?.text || '');
+    if (text) parts.push(text);
+  }
+  return parts.join('\n\n').trim();
+}
 
 export const TICINO_CLINICS = [
   { code: 'CSA', name: 'Clinica Sant\'Anna', city: 'Sorengo' },

--- a/scripts/lib/tally-weijl-job-parser.mjs
+++ b/scripts/lib/tally-weijl-job-parser.mjs
@@ -312,8 +312,10 @@ export async function fetchAllTallyWeijlJobs() {
     const title = normalizeSpace(listing.title);
     if (!title || title.length < 3) continue;
 
-    const city = normalizeSpace(listing.city) || 'Sion';
-    const canton = inferAnyCanton(city) || inferAnyCanton(listing.state || '') || 'VS';
+    // No Sion/Valais default — Tally Weijl is Basel-based with stores nationwide;
+    // leave blank when unresolved so the hardening derives the location/canton.
+    const city = normalizeSpace(listing.city) || '';
+    const canton = inferAnyCanton(city) || inferAnyCanton(listing.state || '') || '';
     const publicUrl = listing.url;
 
     // Fetch detail page for description

--- a/scripts/update-bosch-jobs.mjs
+++ b/scripts/update-bosch-jobs.mjs
@@ -33,7 +33,6 @@ import {
   buildBoschLocalizedContent,
   inferBoschCategory,
 } from './lib/bosch-job-parser.mjs';
-import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
@@ -45,7 +44,6 @@ const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'bosch-thermotechnik-ag.json');
 
 const COMPANY_KEY = 'bosch-thermotechnik-ag';
-const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Bosch Thermotechnik AG';
 const COMPANY_HOST = 'jobs.bosch.com';
 const COMPANY_DOMAIN = 'bosch.ch';
@@ -153,11 +151,11 @@ async function buildBoschJob(listing) {
     company: COMPANY_NAME,
     companyKey: COMPANY_KEY,
     companyDomain: COMPANY_DOMAIN,
-    location: detail.location || listing.location || 'Rivera',
-    addressLocality: detail.location || listing.location || 'Rivera',
-    addressRegion: detail.canton || DEFAULT_CANTON,
+    location: detail.location || listing.location || 'Svizzera',
+    addressLocality: detail.location || listing.location || 'Svizzera',
+    addressRegion: detail.canton || '',
     addressCountry: 'CH',
-    canton: detail.canton || DEFAULT_CANTON,
+    canton: detail.canton || '',
     country: 'CH',
     employmentType: normalize(detail.employmentType).includes('part') ? 'part-time' : 'full-time',
     contractType: normalize(detail.employmentType).includes('part') ? 'part-time' : 'full-time',

--- a/scripts/update-mikron-jobs.mjs
+++ b/scripts/update-mikron-jobs.mjs
@@ -18,8 +18,9 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 } from './assemble-jobs-dataset.mjs';
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, mergeLocaleTextMap, detectLang,
 } from './lib/dedicated-crawler-common.mjs';
-import { parseMikronJobs, parseMikronJobDetail, slugify, normalizeSpace, htmlToText, MIKRON_AGNO_URL, MIKRON_HOST } from './lib/mikron-job-parser.mjs';
+import { parseMikronJobs, parseMikronJobDetail, slugify, normalizeSpace, htmlToText, MIKRON_CAREERS_URL, MIKRON_HOST } from './lib/mikron-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 
@@ -104,15 +105,39 @@ function buildFallbackDescription(title, division, locale = 'en') {
   return `Open position: ${title} at Mikron Group in Agno, Canton Ticino, Switzerland.${division ? ` Division: ${division}.` : ''}\n\nMikron Group is a global leader in precision manufacturing and automation, headquartered in Biel/Bienne (Switzerland) with operations worldwide. The Mikron Machining division, based in Agno (Ticino), specializes in the design and production of high-precision machining systems for the automotive, medical, electronics, and watchmaking industries. The company offers a dynamic working environment, career growth opportunities, a positive corporate culture with strong team spirit, and competitive compensation with excellent social benefits.`;
 }
 
-async function fetchMikronJobs() {
-  console.log(`🔍 Fetching Mikron Group Agno jobs`);
-  console.log(`   URL: ${MIKRON_AGNO_URL}`);
+// Known Swiss site addresses, keyed by city. Other cities fall back to the
+// PLZ/city enrichment downstream (street/postalCode left empty).
+const MIKRON_SITE_ADDRESS = {
+  agno:   { postalCode: '6982', streetAddress: 'Via Ginnasio 17, 6982 Agno' },
+  boudry: { postalCode: '2017', streetAddress: 'Route du Vignoble 17, 2017 Boudry' },
+};
 
-  const html = await fetchPage(MIKRON_AGNO_URL);
+/** Resolve {city, canton, postalCode, streetAddress} from a "Country, City" location.
+ * A blank canton means non-Swiss/unresolved — the caller drops the job. When the
+ * location string is empty, fall back to the Swiss division → site mapping
+ * (Machining → Agno TI, Automation → Boudry NE; Tool is Rottweil DE → unresolved). */
+function resolveMikronLocation(rawLocation = '', division = '') {
+  const parts = String(rawLocation || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const city = parts.length > 1 ? parts[parts.length - 1] : (parts[0] || '');
+  const canton = city ? inferAnyCanton(city) : '';
+  if (canton) return { city, canton, ...(MIKRON_SITE_ADDRESS[city.toLowerCase()] || {}) };
+  if (!city) {
+    const d = String(division || '').toLowerCase();
+    if (d.includes('machining')) return { city: 'Agno', canton: 'TI', ...MIKRON_SITE_ADDRESS.agno };
+    if (d.includes('automation')) return { city: 'Boudry', canton: 'NE', ...MIKRON_SITE_ADDRESS.boudry };
+  }
+  return { city, canton: '' };
+}
+
+async function fetchMikronJobs() {
+  console.log(`🔍 Fetching Mikron Group jobs (all Swiss sites)`);
+  console.log(`   URL: ${MIKRON_CAREERS_URL}`);
+
+  const html = await fetchPage(MIKRON_CAREERS_URL);
   if (!html) return [];
 
-  const parsed = parseMikronJobs(html, { filterAgno: true });
-  console.log(`  📋 Agno jobs parsed from page: ${parsed.length}`);
+  const parsed = parseMikronJobs(html, { filterAgno: false });
+  console.log(`  📋 jobs parsed from page: ${parsed.length}`);
 
   const jobs = [];
   for (const p of parsed) {
@@ -122,11 +147,13 @@ async function fetchMikronJobs() {
     // Fetch detail page for rich description
     let descEn = '';
     let descIt = '';
+    let rawLocation = p.location || '';
     if (p.url) {
       console.log(`    🔗 Fetching detail page: ${p.url}`);
       const detailHtml = await fetchPage(p.url);
       if (detailHtml) {
         const detail = parseMikronJobDetail(detailHtml);
+        if (detail.location) rawLocation = detail.location;
         if (detail.description && detail.description.split(/\s+/).length >= 30) {
           descEn = detail.description;
           console.log(`    ✅ Detail description: ${descEn.split(/\s+/).length} words`);
@@ -140,6 +167,16 @@ async function fetchMikronJobs() {
       await new Promise((r) => setTimeout(r, 500));
     }
 
+    // Derive the real site/canton per-job (Agno TI vs Boudry NE vs …).
+    // A blank canton = non-Swiss (USA/Germany) or unresolved → drop the job
+    // instead of mislabeling it as the Agno HQ.
+    const { city, canton, postalCode, streetAddress } = resolveMikronLocation(rawLocation, p.division);
+    if (!canton) {
+      console.log(`    ⏭️ Skipped non-Swiss/unresolved location: ${title} (${rawLocation || 'n/a'})`);
+      continue;
+    }
+    const city0 = city;
+
     // Fallback: build a rich description (>50 words) if detail page failed
     if (!descEn || descEn.split(/\s+/).length < 50) {
       descEn = buildFallbackDescription(title, p.division, 'en');
@@ -152,15 +189,16 @@ async function fetchMikronJobs() {
 
     jobs.push({
       url: p.url, applyUrl: p.url, title, company: COMPANY_NAME, companyKey: COMPANY_KEY,
-      location: 'Agno', canton: DEFAULT_CANTON, country: 'CH',
-      postalCode: '6982', streetAddress: 'Via Ginnasio 17, 6982 Agno',
+      location: city0, canton, country: 'CH',
+      ...(postalCode && { postalCode }),
+      ...(streetAddress && { streetAddress }),
       description: descEn, descriptionByLocale: { en: descEn, it: descIt },
       titleByLocale: { en: title }, slug, slugByLocale: { en: slug, it: slugify(title, 'mikron') },
       sourceLang: detectLang(descEn || title, 'en'),
       category: detectCategory(title), datePosted: new Date().toISOString().split('T')[0],
       source: 'mikron-html-crawler', employmentType,
       experienceLevel: detectExperienceLevel(title), sector: 'Manifattura / Precision Manufacturing',
-      _targetScope: { canton: DEFAULT_CANTON, location: 'Agno' },
+      _targetScope: { canton, location: city0 },
     });
   }
   return jobs;
@@ -216,7 +254,7 @@ async function main() {
   // Adapter
   const adapterPath = path.join(ADAPTERS_DIR, `${COMPANY_KEY}.json`);
   const adapter = fs.existsSync(adapterPath) ? JSON.parse(fs.readFileSync(adapterPath, 'utf-8')) : {};
-  Object.assign(adapter, { companyKey: COMPANY_KEY, companyName: COMPANY_NAME, companyHost: MIKRON_HOST, enabled: true, priority: Math.max(adapter.priority || 0, 10), crawlerModes: ['html'], seedUrls: [MIKRON_AGNO_URL], notes: 'Drupal Views page — filter Agno TI.', updatedAt: new Date().toISOString() });
+  Object.assign(adapter, { companyKey: COMPANY_KEY, companyName: COMPANY_NAME, companyHost: MIKRON_HOST, enabled: true, priority: Math.max(adapter.priority || 0, 10), crawlerModes: ['html'], seedUrls: [MIKRON_CAREERS_URL], notes: 'Drupal Views page — national listing (all Swiss sites); canton derived per-job (Agno TI / Boudry NE).', updatedAt: new Date().toISOString() });
   fs.mkdirSync(path.dirname(adapterPath), { recursive: true });
   fs.writeFileSync(adapterPath, JSON.stringify(adapter, null, 2) + '\n');
 

--- a/scripts/update-otis-jobs.mjs
+++ b/scripts/update-otis-jobs.mjs
@@ -43,7 +43,6 @@ import {
   inferEmploymentType,
   buildPublicUrl,
 } from './lib/otis-job-parser.mjs';
-import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
@@ -54,7 +53,6 @@ const ROOT = path.resolve(__dirname, '..');
 const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'otis';
-const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Otis SA';
 
 function isCompanyJob(job) {
@@ -112,12 +110,14 @@ async function main() {
     const description = detail.description;
     const publicUrl = buildPublicUrl(raw.externalPath);
     const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
-    // Prefer detail city (from full location text) over listing city
-    const city = detail.city || raw.city || 'Ticino';
+    // Prefer detail city (from full location text) over listing city. No Ticino
+    // default — Otis runs a national service network; leave blank when unresolved
+    // so the PLZ/locality hardening derives it instead of mislabeling on TI.
+    const city = detail.city || raw.city || '';
     // City-first: resolve the (detail-preferred) city alone before the raw
     // listing location, so the more authoritative city wins over the array-order
     // sensitivity of a combined string.
-    const canton = inferAnyCanton(city) || inferAnyCanton(raw.location) || detail.canton || DEFAULT_CANTON;
+    const canton = inferAnyCanton(city) || inferAnyCanton(raw.location) || detail.canton || '';
     const jobSlug = slugify(`${raw.title}-otis-${safeLocationToken(city, 'Ticino')}`);
     parsedJobs.push({
       id: `otis-${urlHash}`,

--- a/scripts/update-pemsa-jobs.mjs
+++ b/scripts/update-pemsa-jobs.mjs
@@ -2,8 +2,8 @@
 /**
  * PEMSA — Dedicated Crawler
  *
- * Crawls https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/?_canton=125
- * 1. Fetches listing page (pre-filtered for Ticino) → extracts job URLs
+ * Crawls https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/
+ * 1. Fetches national listing page (all cantons) → extracts job URLs
  * 2. Fetches each detail page → extracts JSON-LD JobPosting
  * 3. Merges into data/jobs.json
  * 4. Updates adapter config
@@ -42,6 +42,7 @@ import {
   buildPemsaLocalizedContent,
 } from './lib/pemsa-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
@@ -57,7 +58,7 @@ const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'PEMSA';
 const COMPANY_HOST = 'www.pemsa.ch';
 const COMPANY_DOMAIN = 'pemsa.ch';
-const CAREERS_URL = 'https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/?_canton=125';
+const CAREERS_URL = 'https://www.pemsa.ch/it/le-nostre-offerte-di-lavoro/';
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 const TIMEOUT_MS = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
@@ -134,7 +135,11 @@ function parseDate(dateStr = '') {
 }
 
 function buildPemsaJob(detail, url) {
-  const city = detail.city || 'Ticino';
+  const city = detail.city || '';
+  // PEMSA is a national agency (HQ Geneva + Ticino branch); the JSON-LD region
+  // field is usually empty, so derive the canton per-job from the city. Only
+  // fall back to the HQ default when nothing resolves.
+  const canton = inferAnyCanton(city) || inferAnyCanton(detail.region || '') || DEFAULT_CANTON;
   const localized = buildPemsaLocalizedContent(detail);
 
   return {
@@ -147,9 +152,9 @@ function buildPemsaJob(detail, url) {
     companyDomain: COMPANY_DOMAIN,
     location: city,
     addressLocality: city,
-    addressRegion: detail.region || 'TI',
+    addressRegion: detail.region || canton,
     addressCountry: detail.country || 'CH',
-    canton: DEFAULT_CANTON,
+    canton,
     country: 'CH',
     category: inferCategory(detail.title),
     sector: 'Edilizia e tecnica',
@@ -213,7 +218,7 @@ function updateAdapterConfig(jobs) {
   for (const job of jobs) {
     seedMetaByUrl[job.url] = {
       location: job.location,
-      canton: DEFAULT_CANTON,
+      canton: job.canton || DEFAULT_CANTON,
       company: COMPANY_NAME,
       postedDate: job.postedDate,
     };
@@ -226,7 +231,7 @@ function updateAdapterConfig(jobs) {
     priority: 18,
     crawlerModes: ['html'],
     seedUrls: [CAREERS_URL],
-    notes: 'Dedicated PEMSA crawler. Listing page pre-filtered for Ticino (canton=125). Detail pages have JSON-LD JobPosting with full location data. Construction/trades staffing agency.',
+    notes: 'Dedicated PEMSA crawler. National listing (all cantons). Detail pages have JSON-LD JobPosting with full location data; canton inferred per-job from the city. Construction/trades staffing agency.',
     updatedAt: new Date().toISOString(),
     seedMetaByUrl,
   });
@@ -255,7 +260,7 @@ async function main() {
   console.log('═══════════════════════════════════════════════');
   console.log(`  Careers page: ${CAREERS_URL}\n`);
 
-  console.log('🔍 Fetching PEMSA Ticino job listings...');
+  console.log('🔍 Fetching PEMSA job listings (all cantons)...');
   const jobUrls = await parsePemsaListingPage(TIMEOUT_MS);
   console.log(`📋 Found ${jobUrls.length} job URLs on listing page`);
 
@@ -283,10 +288,10 @@ async function main() {
     if (jobs.length + skipped < jobUrls.length) await sleep(DETAIL_DELAY_MS);
   }
 
-  console.log(`\n📍 Ticino-relevant: ${jobs.length} / ${jobUrls.length}`);
+  console.log(`\n📍 Swiss-relevant: ${jobs.length} / ${jobUrls.length}`);
 
   if (jobs.length === 0) {
-    console.log('⚠️ No Ticino-relevant jobs found — skipping.');
+    console.log('⚠️ No Swiss-relevant jobs found — skipping.');
     return;
   }
 

--- a/scripts/update-pemsa-jobs.mjs
+++ b/scripts/update-pemsa-jobs.mjs
@@ -137,9 +137,10 @@ function parseDate(dateStr = '') {
 function buildPemsaJob(detail, url) {
   const city = detail.city || '';
   // PEMSA is a national agency (HQ Geneva + Ticino branch); the JSON-LD region
-  // field is usually empty, so derive the canton per-job from the city. Only
-  // fall back to the HQ default when nothing resolves.
-  const canton = inferAnyCanton(city) || inferAnyCanton(detail.region || '') || DEFAULT_CANTON;
+  // field is usually empty, so derive the canton per-job from the city. No HQ
+  // default — leave blank when unresolved so the downstream hardening fills it
+  // instead of mislabeling on Ticino.
+  const canton = inferAnyCanton(city) || inferAnyCanton(detail.region || '') || '';
   const localized = buildPemsaLocalizedContent(detail);
 
   return {

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -143,7 +143,6 @@ async function fetchListings() {
     const rows = parseSkyguideListings(html);
     console.log(`📋 Page ${page + 1} (startrow ${startRow}): ${rows.length} rows`);
     if (rows.length === 0) break;
-    let added = 0;
     for (const row of rows) {
       // Keep only Swiss locations (all 26 cantons); Skyguide is CH-only but the
       // guard stays as a safety net.
@@ -152,12 +151,12 @@ async function fetchListings() {
       if (seen.has(key)) continue;
       seen.add(key);
       discovered.push(row);
-      added += 1;
       console.log(`  📄 ${row.title} (${row.location})`);
     }
     // Last page reached when the page wasn't full (no further rows to fetch).
+    // (Bounded by LISTING_MAX_PAGES; we don't early-break on all-duplicate pages
+    // because SuccessFactors paginates sequentially by startrow.)
     if (rows.length < LISTING_PAGE_SIZE) break;
-    if (added === 0 && page > 0) break;
   }
 
   if (discovered.length < 1) {

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -49,10 +49,13 @@ const COMPANY_NAME = 'Skyguide';
 const COMPANY_HOST = 'jobs.skyguide.ch';
 const COMPANY_DOMAIN = 'skyguide.ch';
 const DETAIL_BASE = 'https://jobs.skyguide.ch';
-const LISTING_URLS = [
-  'https://jobs.skyguide.ch/search/?createNewAlert=false&q=&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_location=Locarno%2C+CH',
-  'https://jobs.skyguide.ch/search/?createNewAlert=false&q=&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_location=Lugano+Agno%2C+CH',
-];
+// National listing — NO location facet. Skyguide's largest sites are the two
+// area control centres in Geneva (GE) and Dübendorf (ZH), plus tower units
+// nationwide; the previous Locarno + Lugano-Agno facets omitted them. The
+// SuccessFactors search paginates via `startrow` (25 rows/page).
+const LISTING_BASE = 'https://jobs.skyguide.ch/search/?createNewAlert=false&q=&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_location=';
+const LISTING_PAGE_SIZE = 25;
+const LISTING_MAX_PAGES = 20;
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 function readJson(filePath, fallback) {
@@ -128,26 +131,37 @@ function isTrustedDomain(rawUrl = '') {
 }
 
 async function fetchListings() {
-  console.log('🔍 Fetching Skyguide jobs from filtered listings...');
+  console.log('🔍 Fetching Skyguide jobs (national, all cantons)...');
   const discovered = [];
   const seen = new Set();
 
-  for (const listingUrl of LISTING_URLS) {
+  for (let page = 0; page < LISTING_MAX_PAGES; page += 1) {
+    const startRow = page * LISTING_PAGE_SIZE;
+    const listingUrl = `${LISTING_BASE}&startrow=${startRow}`;
+    // eslint-disable-next-line no-await-in-loop
     const html = await fetchHtml(listingUrl, SKYGUIDE_FETCH_OPTS);
     const rows = parseSkyguideListings(html);
-    console.log(`📋 Rows from filter ${listingUrl}: ${rows.length}`);
+    console.log(`📋 Page ${page + 1} (startrow ${startRow}): ${rows.length} rows`);
+    if (rows.length === 0) break;
+    let added = 0;
     for (const row of rows) {
-      if (!isSkyguideTargetLocation(row.location)) continue;
+      // Keep only Swiss locations (all 26 cantons); Skyguide is CH-only but the
+      // guard stays as a safety net.
+      if (row.location && !isSkyguideTargetLocation(row.location)) continue;
       const key = absoluteUrl(row.href);
       if (seen.has(key)) continue;
       seen.add(key);
       discovered.push(row);
+      added += 1;
       console.log(`  📄 ${row.title} (${row.location})`);
     }
+    // Last page reached when the page wasn't full (no further rows to fetch).
+    if (rows.length < LISTING_PAGE_SIZE) break;
+    if (added === 0 && page > 0) break;
   }
 
   if (discovered.length < 1) {
-    throw new Error(`Expected at least 1 Skyguide job in Ticino/Grigioni, found ${discovered.length}`);
+    throw new Error(`Expected at least 1 Skyguide job, found ${discovered.length}`);
   }
   return discovered;
 }
@@ -252,15 +266,15 @@ function refreshLocalizedSlugs() {
       const localizedTitle = String(next.titleByLocale?.[locale] || '').trim();
       if (!localizedTitle) continue;
       // Slug-only guard: `addressLocality`/`location` can be the literal
-      // "undefined"/"null" string (truthy → slips past `|| 'Ticino'`) → `-undefined`
+      // "undefined"/"null" string (truthy → slips past `|| 'Svizzera'`) → `-undefined`
       // in an active slug (#952, class #900/#901). Stored addressLocality untouched.
       // Guard each operand BEFORE the `||`: a literal "undefined" addressLocality is
       // truthy, so `addressLocality || location` would short-circuit on it and mask a
-      // valid `location`, yielding the 'Ticino' fallback instead of the real city
+      // valid `location`, yielding the 'Svizzera' fallback instead of the real city
       // (#1151). `safeLocationToken(x, null)` returns null for missing/"undefined"/
       // "null", letting the `||` fall through to `location`.
       const localizedLocation =
-        safeLocationToken(next.addressLocality, null) || safeLocationToken(next.location, 'Ticino');
+        safeLocationToken(next.addressLocality, null) || safeLocationToken(next.location, 'Svizzera');
       const slug = slugify(`${localizedTitle} ${COMPANY_NAME} ${localizedLocation}`);
       if (slug && next.slugByLocale[locale] !== slug) {
         next.slugByLocale[locale] = slug;
@@ -292,8 +306,8 @@ function updateAdapterConfig(jobs) {
     enabled: true,
     priority: 15,
     crawlerModes: ['html'],
-    seedUrls: LISTING_URLS,
-    notes: 'Dedicated Skyguide crawler parses the SuccessFactors filtered listings for Locarno and Lugano Agno and extracts full detail pages.',
+    seedUrls: [`${LISTING_BASE}&startrow=0`],
+    notes: 'Dedicated Skyguide crawler parses the national SuccessFactors listing (all cantons, paginated) and extracts full detail pages; canton derived per-job.',
     updatedAt: new Date().toISOString(),
     seedMetaByUrl,
   });
@@ -320,7 +334,7 @@ async function main() {
   console.log('═══════════════════════════════════════════════');
   console.log('  Skyguide — Dedicated Crawler');
   console.log('═══════════════════════════════════════════════');
-  console.log(`  Listing filters: ${LISTING_URLS.length}\n`);
+  console.log(`  Listing: national (all cantons)\n`);
 
   const listings = await fetchListings();
   const jobs = [];

--- a/scripts/update-swiss-medical-network-jobs.mjs
+++ b/scripts/update-swiss-medical-network-jobs.mjs
@@ -21,7 +21,7 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 } from './assemble-jobs-dataset.mjs';
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, mergeLocaleTextMap, detectLang,
 } from './lib/dedicated-crawler-common.mjs';
-import { smnPostingsApiUrl, smnPostingDetailApiUrl, normalizeSmnApiPosting, extractSmnApiDescription, SMN_POSTINGS_API, slugify, normalizeSpace } from './lib/swiss-medical-network-job-parser.mjs';
+import { smnPostingsApiUrl, smnPostingDetailApiUrl, normalizeSmnApiPosting, extractSmnApiDescription, extractSmnPostingId, SMN_POSTINGS_API, slugify, normalizeSpace } from './lib/swiss-medical-network-job-parser.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 
@@ -87,6 +87,33 @@ async function fetchJson(url) {
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
 }
 
+/**
+ * Posting ids already owned by a DEDICATED SMN clinic crawler (genolier,
+ * montchoisi, valère, beaulieu, ste-anne, bethanien, obach, siloah, moutier, …).
+ * They read the same SmartRecruiters tenant with a clinic filter, so the CH-wide
+ * umbrella must skip those postings to avoid duplicate / canonical-churn pages
+ * (the dedicated crawler keeps its stable per-clinic slug). Future dedicated SMN
+ * crawlers are covered automatically — any non-umbrella slice with a
+ * SwissMedicalNetwork1 URL claims its posting ids.
+ */
+function loadDedicatedClinicPostingIds() {
+  const ids = new Set();
+  const dir = path.resolve(ROOT, 'data', 'jobs', 'by-crawler');
+  let files = [];
+  try { files = fs.readdirSync(dir).filter((f) => f.endsWith('.json')); } catch { return ids; }
+  for (const f of files) {
+    if (f === `${COMPANY_KEY}.json`) continue; // skip the umbrella's own slice
+    let data;
+    try { data = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')); } catch { continue; }
+    const jobs = data?.jobs || (Array.isArray(data) ? data : []);
+    for (const j of jobs) {
+      const id = extractSmnPostingId(j?.url);
+      if (id) ids.add(id);
+    }
+  }
+  return ids;
+}
+
 /** Fetch every SmartRecruiters posting (paginated), CH-wide. */
 async function fetchAllApiPostings() {
   const LIMIT = 100;
@@ -150,7 +177,7 @@ function buildJobFromApi(posting, detailDescription = '', applyUrl = '', posting
     category: detectCategory(posting.title),
     datePosted: new Date().toISOString().split('T')[0],
     source: 'swiss-medical-smartrecruiters-crawler',
-    employmentType: 'FULL_TIME',
+    employmentType: posting.employmentType || 'FULL_TIME',
     experienceLevel: detectExperienceLevel(posting.title),
     sector: 'Sanità / Healthcare',
     _targetScope: { canton, location: city },
@@ -212,11 +239,19 @@ async function main() {
   const rawPostings = await fetchAllApiPostings();
   if (!rawPostings.length) { console.log('\n⚠️ Could not fetch Swiss Medical Network postings from the SmartRecruiters API.'); return; }
 
-  // Keep only Swiss postings (the tenant is CH-only, but guard anyway).
-  const postings = rawPostings
+  // Keep only Swiss postings (the tenant is CH-only, but guard anyway —
+  // accept both the ISO code 'ch' and a spelled-out country name).
+  const isSwissCountry = (c = '') => !c || /^(ch|switzerland|suisse|schweiz|svizzera)/.test(c);
+  const swissPostings = rawPostings
     .map(normalizeSmnApiPosting)
-    .filter((p) => p.id && p.title && (!p.country || p.country === 'ch'));
-  console.log(`  📋 Swiss postings: ${postings.length} / ${rawPostings.length}`);
+    .filter((p) => p.id && p.title && isSwissCountry(p.country));
+
+  // Drop postings already owned by a dedicated SMN clinic crawler (same
+  // SmartRecruiters tenant) to prevent duplicate / canonical-churn job pages.
+  const dedicatedIds = loadDedicatedClinicPostingIds();
+  const postings = swissPostings.filter((p) => !dedicatedIds.has(p.id));
+  const skippedDedicated = swissPostings.length - postings.length;
+  console.log(`  📋 Swiss postings: ${postings.length} / ${rawPostings.length} (skipped ${skippedDedicated} owned by dedicated clinic crawlers)`);
 
   // Fetch each posting's detail (description + canonical public URL).
   const discoveredJobs = [];

--- a/scripts/update-swiss-medical-network-jobs.mjs
+++ b/scripts/update-swiss-medical-network-jobs.mjs
@@ -2,12 +2,14 @@
 /**
  * Dedicated Swiss Medical Network crawler runner.
  *
- * Swiss Medical Network operates multiple healthcare facilities across Switzerland,
- * including Clinica Sant'Anna and Clinica Moncucco in Ticino.
- * Uses SmartRecruiters as ATS.
+ * Swiss Medical Network operates 25+ healthcare facilities across Switzerland
+ * (Genolier VD, Montchoisi/Lausanne VD, Valère VS, Fribourg, Bern, Zürich,
+ * Neuchâtel, Sant'Anna/Moncucco TI, …). Uses SmartRecruiters as its ATS.
  *
- * Career page: https://www.swissmedical.net/en/career/job-offers
- * Ticino filter: ?region=7845726f-4952-4b7c-88da-8ff4f85e6afb
+ * Source: SmartRecruiters public postings API (CH-wide, all cantons) —
+ *   https://api.smartrecruiters.com/v1/companies/SwissMedicalNetwork1/postings
+ * The swissmedical.net careers page is React-rendered and region-filtered, so
+ * we read the API directly and infer the canton per-job from the API location.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -19,8 +21,8 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 } from './assemble-jobs-dataset.mjs';
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, mergeLocaleTextMap, detectLang,
 } from './lib/dedicated-crawler-common.mjs';
-import { parseSwissMedicalJobs, parseSmartRecruiterDetail, getClinicAddress, slugify, normalizeSpace, TICINO_REGION_UUID } from './lib/swiss-medical-network-job-parser.mjs';
-import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { smnPostingsApiUrl, smnPostingDetailApiUrl, normalizeSmnApiPosting, extractSmnApiDescription, SMN_POSTINGS_API, slugify, normalizeSpace } from './lib/swiss-medical-network-job-parser.mjs';
+import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -30,10 +32,9 @@ const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'swiss-medical-network';
-const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Swiss Medical Network';
 const COMPANY_HOST = 'www.swissmedical.net';
-const CAREERS_URL = `https://www.swissmedical.net/en/career/job-offers?region=${TICINO_REGION_UUID}`;
+const CAREERS_URL = 'https://www.swissmedical.net/en/career/job-offers';
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 function normalize(value = '') { return String(value || '').trim().toLowerCase(); }
@@ -74,68 +75,86 @@ function detectExperienceLevel(title = '') {
   return 'MID';
 }
 
-async function fetchPage(url) {
+async function fetchJson(url) {
   const timeoutMs = parseInt(process.env.JOBS_CRAWLER_TIMEOUT_MS || '20000', 10);
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(url, { signal: controller.signal, headers: { 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)', Accept: 'text/html', 'Accept-Language': 'en,it-CH;q=0.9' } });
+    const res = await fetch(url, { signal: controller.signal, headers: { 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)', Accept: 'application/json' } });
     clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
-    return await res.text();
+    return await res.json();
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
 }
 
-async function fetchCareersPage() {
-  return fetchPage(CAREERS_URL);
+/** Fetch every SmartRecruiters posting (paginated), CH-wide. */
+async function fetchAllApiPostings() {
+  const LIMIT = 100;
+  const all = [];
+  let offset = 0;
+  for (let page = 0; page < 50; page += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const data = await fetchJson(smnPostingsApiUrl(offset, LIMIT));
+    const content = Array.isArray(data?.content) ? data.content : [];
+    if (content.length === 0) break;
+    all.push(...content);
+    const total = Number(data?.totalFound || 0);
+    console.log(`  📄 postings ${offset}-${offset + content.length} of ${total || '?'}`);
+    offset += content.length;
+    if (total && all.length >= total) break;
+    if (content.length < LIMIT) break;
+  }
+  return all;
 }
 
 /**
  * Build a rich fallback description (>50 words) for Swiss Medical Network.
  */
-function buildFallbackDescription(title, clinic, city, locale = 'en') {
+function buildFallbackDescription(title, city, locale = 'en') {
   if (locale === 'it') {
-    return `Posizione aperta: ${title} presso ${clinic} a ${city}, Cantone Ticino, Svizzera.\n\nSwiss Medical Network è il principale gruppo sanitario privato in Svizzera, fondato nel 2002. Il gruppo gestisce oltre 20 strutture sanitarie tra cui cliniche, centri medici e istituti di riabilitazione in tutta la Svizzera. ${clinic} offre un ambiente di lavoro stimolante e dinamico, con condizioni di impiego allineate ai contratti collettivi di lavoro. Il gruppo è in costante crescita e offre opportunità di sviluppo professionale, formazione continua e un pacchetto retributivo competitivo con ottime prestazioni sociali. Candidarsi per entrare a far parte di un team appassionato e dedicato alla cura dei pazienti.`;
+    return `Posizione aperta: ${title} presso Swiss Medical Network${city ? ` a ${city}` : ''}, Svizzera.\n\nSwiss Medical Network è il principale gruppo sanitario privato in Svizzera, fondato nel 2002. Il gruppo gestisce oltre 20 strutture sanitarie tra cui cliniche, centri medici e istituti di riabilitazione in tutta la Svizzera. Offre un ambiente di lavoro stimolante e dinamico, con condizioni di impiego allineate ai contratti collettivi di lavoro. Il gruppo è in costante crescita e offre opportunità di sviluppo professionale, formazione continua e un pacchetto retributivo competitivo con ottime prestazioni sociali. Candidarsi per entrare a far parte di un team appassionato e dedicato alla cura dei pazienti.`;
   }
-  return `Open position: ${title} at ${clinic} in ${city}, Canton Ticino, Switzerland.\n\nSwiss Medical Network is Switzerland's leading private healthcare group, established in 2002. The group operates over 20 healthcare facilities including clinics, medical centers, and rehabilitation institutes across Switzerland. ${clinic} offers a stimulating and dynamic working environment, with employment terms aligned with collective bargaining agreements. The group is constantly growing and offers professional development opportunities, continuous training, and a competitive compensation package with excellent social benefits. Apply to become part of a passionate team dedicated to patient care.`;
+  return `Open position: ${title} at Swiss Medical Network${city ? ` in ${city}` : ''}, Switzerland.\n\nSwiss Medical Network is Switzerland's leading private healthcare group, established in 2002. The group operates over 20 healthcare facilities including clinics, medical centers, and rehabilitation institutes across Switzerland. It offers a stimulating and dynamic working environment, with employment terms aligned with collective bargaining agreements. The group is constantly growing and offers professional development opportunities, continuous training, and a competitive compensation package with excellent social benefits. Apply to become part of a passionate team dedicated to patient care.`;
 }
 
-function buildJobFromParsed(parsed, detailDescription = '') {
-  const slug = slugify(parsed.title, 'swiss-medical-network');
-  const clinic = parsed.clinic || 'Swiss Medical Network';
-  const city = parsed.city || 'Lugano';
-  const address = getClinicAddress(clinic, city);
+function buildJobFromApi(posting, detailDescription = '', applyUrl = '', postingUrl = '') {
+  const slug = slugify(posting.title, 'swiss-medical-network');
+  const city = posting.city || '';
+  // Real canton from the API location. No Ticino default: leave blank when
+  // unresolved (the downstream PLZ/locality hardening fills it) rather than
+  // mislabeling a non-TI clinic as Ticino.
+  const canton = posting.canton || inferAnyCanton(city) || '';
 
-  // Use detail description if rich enough, otherwise use fallback
   let descEn = detailDescription;
   if (!descEn || descEn.split(/\s+/).length < 50) {
-    descEn = buildFallbackDescription(parsed.title, clinic, city, 'en');
+    descEn = buildFallbackDescription(posting.title, city, 'en');
   }
-  const descIt = buildFallbackDescription(parsed.title, clinic, city, 'it');
+  const descIt = buildFallbackDescription(posting.title, city, 'it');
 
   return {
-    url: parsed.applyUrl || `https://www.swissmedical.net/en/career/job-offers`,
-    applyUrl: parsed.applyUrl || '',
-    title: parsed.title,
+    url: postingUrl || applyUrl || `https://www.swissmedical.net/en/career/job-offers`,
+    applyUrl: applyUrl || postingUrl || '',
+    title: posting.title,
     company: COMPANY_NAME,
     companyKey: COMPANY_KEY,
     location: city,
-    canton: DEFAULT_CANTON,
+    addressLocality: city,
+    addressRegion: canton,
+    canton,
     country: 'CH',
-    postalCode: address.postalCode,
-    streetAddress: address.streetAddress,
+    ...(posting.postalCode && { postalCode: posting.postalCode }),
     description: descEn,
     descriptionByLocale: { en: descEn, it: descIt },
-    titleByLocale: { en: parsed.title },
-    slug, slugByLocale: { en: slug, it: slugify(parsed.title, 'swiss-medical-network') },
-    category: detectCategory(parsed.title),
+    titleByLocale: { en: posting.title },
+    slug, slugByLocale: { en: slug, it: slugify(posting.title, 'swiss-medical-network') },
+    category: detectCategory(posting.title),
     datePosted: new Date().toISOString().split('T')[0],
     source: 'swiss-medical-smartrecruiters-crawler',
-    employmentType: parsed.employmentRate?.includes('100') ? 'FULL_TIME' : 'PART_TIME',
-    experienceLevel: detectExperienceLevel(parsed.title),
+    employmentType: 'FULL_TIME',
+    experienceLevel: detectExperienceLevel(posting.title),
     sector: 'Sanità / Healthcare',
-    _targetScope: { canton: DEFAULT_CANTON, location: city },
-    sourceLang: detectLang(descEn || parsed.title, 'en'),
+    _targetScope: { canton, location: city },
+    sourceLang: detectLang(descEn || posting.title, 'en'),
   };
 }
 
@@ -172,7 +191,7 @@ async function mergeJobs(discoveredJobs) {
 function updateAdapterConfig() {
   const adapterPath = path.join(ADAPTERS_DIR, `${COMPANY_KEY}.json`);
   const adapter = fs.existsSync(adapterPath) ? JSON.parse(fs.readFileSync(adapterPath, 'utf-8')) : {};
-  Object.assign(adapter, { companyKey: COMPANY_KEY, companyName: COMPANY_NAME, companyHost: COMPANY_HOST, enabled: true, priority: Math.max(adapter.priority || 0, 10), crawlerModes: ['html'], seedUrls: [CAREERS_URL], notes: 'SwissMedical.net career page — SmartRecruiters ATS — Ticino region filter.', updatedAt: new Date().toISOString() });
+  Object.assign(adapter, { companyKey: COMPANY_KEY, companyName: COMPANY_NAME, companyHost: COMPANY_HOST, enabled: true, priority: Math.max(adapter.priority || 0, 10), crawlerModes: ['html'], seedUrls: [SMN_POSTINGS_API, CAREERS_URL], notes: 'Swiss Medical Network — SmartRecruiters public postings API (CH-wide, all cantons); canton inferred per-job from the API location.', updatedAt: new Date().toISOString() });
   fs.mkdirSync(path.dirname(adapterPath), { recursive: true });
   fs.writeFileSync(adapterPath, JSON.stringify(adapter, null, 2) + '\n');
 }
@@ -190,37 +209,37 @@ async function main() {
 
     const beforeSnapshot = snapshotJobSlugs(readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS).filter(isSwissMedicalJob))
 
-  const html = await fetchCareersPage();
-  if (!html) { console.log('\n⚠️ Could not fetch Swiss Medical Network careers page.'); return; }
+  const rawPostings = await fetchAllApiPostings();
+  if (!rawPostings.length) { console.log('\n⚠️ Could not fetch Swiss Medical Network postings from the SmartRecruiters API.'); return; }
 
-  const parsed = parseSwissMedicalJobs(html);
-  console.log(`  📋 Ticino jobs parsed: ${parsed.length}`);
+  // Keep only Swiss postings (the tenant is CH-only, but guard anyway).
+  const postings = rawPostings
+    .map(normalizeSmnApiPosting)
+    .filter((p) => p.id && p.title && (!p.country || p.country === 'ch'));
+  console.log(`  📋 Swiss postings: ${postings.length} / ${rawPostings.length}`);
 
-  // Fetch detail pages from SmartRecruiters for rich descriptions
+  // Fetch each posting's detail (description + canonical public URL).
   const discoveredJobs = [];
-  for (const p of parsed) {
+  for (const p of postings) {
     let detailDescription = '';
-    if (p.applyUrl) {
-      console.log(`    🔗 Fetching detail page: ${p.applyUrl}`);
-      const detailHtml = await fetchPage(p.applyUrl);
-      if (detailHtml) {
-        const detail = parseSmartRecruiterDetail(detailHtml);
-        if (detail.description && detail.description.split(/\s+/).length >= 30) {
-          detailDescription = detail.description;
-          console.log(`    ✅ Detail description: ${detailDescription.split(/\s+/).length} words`);
-        } else {
-          console.log(`    ⚠️ Detail page description too short (${(detail.description || '').split(/\s+/).length} words), using fallback`);
-        }
-      } else {
-        console.log(`    ⚠️ Could not fetch detail page, using fallback`);
+    let applyUrl = '';
+    let postingUrl = '';
+    const detail = await fetchJson(smnPostingDetailApiUrl(p.id));
+    if (detail) {
+      applyUrl = String(detail.applyUrl || '');
+      postingUrl = String(detail.postingUrl || '');
+      const desc = extractSmnApiDescription(detail);
+      if (desc && desc.split(/\s+/).length >= 30) {
+        detailDescription = desc;
       }
-      // Small delay to be respectful to SmartRecruiters
-      await new Promise((r) => setTimeout(r, 500));
     }
-    discoveredJobs.push(buildJobFromParsed(p, detailDescription));
+    console.log(`    ✅ ${p.title} → ${p.city || '?'} (${p.canton || '?'})`);
+    discoveredJobs.push(buildJobFromApi(p, detailDescription, applyUrl, postingUrl));
+    // Small delay to be respectful to the SmartRecruiters API.
+    await new Promise((r) => setTimeout(r, 150));
   }
 
-  if (discoveredJobs.length === 0) { console.log('\n⚠️ No Ticino Swiss Medical Network jobs found.'); return; }
+  if (discoveredJobs.length === 0) { console.log('\n⚠️ No Swiss Medical Network jobs found.'); return; }
 
   updateAdapterConfig();
   await mergeJobs(discoveredJobs);
@@ -231,19 +250,19 @@ async function main() {
   if (fs.existsSync(DATA_JOBS)) {
     const jobs = JSON.parse(fs.readFileSync(DATA_JOBS, 'utf-8'));
     let fixed = 0;
-    for (const j of (Array.isArray(jobs) ? jobs : [])) { if (!isSwissMedicalJob(j)) continue; if (j.company !== COMPANY_NAME) { j.company = COMPANY_NAME; fixed++; } j.companyKey = COMPANY_KEY; j.country = 'CH'; if (!j.canton) { j.canton = DEFAULT_CANTON; fixed++; } }
+    for (const j of (Array.isArray(jobs) ? jobs : [])) { if (!isSwissMedicalJob(j)) continue; if (j.company !== COMPANY_NAME) { j.company = COMPANY_NAME; fixed++; } j.companyKey = COMPANY_KEY; j.country = 'CH'; if (!j.canton) { const c = inferAnyCanton(j.location || j.addressLocality || ''); if (c) { j.canton = c; fixed++; } } }
     if (fixed > 0) { writeJsonAtomic(DATA_JOBS, jobs); writeJsonAtomic(PUBLIC_JOBS, jobs); }
   }
 
   const finalJobs = readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS);
   const companyJobs = (Array.isArray(finalJobs) ? finalJobs : []).filter(isSwissMedicalJob);
-  console.log(`\n📊 Swiss Medical Network Ticino jobs: ${companyJobs.length}`);
+  console.log(`\n📊 Swiss Medical Network jobs: ${companyJobs.length}`);
   const afterSnapshot = snapshotJobSlugs(companyJobs);
   const diff = computeCrawlDiff(beforeSnapshot, afterSnapshot);
   printCrawlChangeSummary(diff, 'Swiss Medical Network');
   writeCrawlChangeSummaryToGH(diff, 'Swiss Medical Network');
 
-  validateDedicatedLocaleCoverage({ strictEnvVar: 'JOBS_SWISS_MEDICAL_STRICT', label: 'Swiss Medical Network', dataJobsPath: DATA_JOBS, isTargetJob: isSwissMedicalJob, locales: LOCALES, isTrustedDomain, untrustedDomainReason: 'url_not_swiss_medical_domain', failWhenNoJobs: false, noJobsMessage: 'No Swiss Medical Network Ticino jobs found.' });
+  validateDedicatedLocaleCoverage({ strictEnvVar: 'JOBS_SWISS_MEDICAL_STRICT', label: 'Swiss Medical Network', dataJobsPath: DATA_JOBS, isTargetJob: isSwissMedicalJob, locales: LOCALES, isTrustedDomain, untrustedDomainReason: 'url_not_swiss_medical_domain', failWhenNoJobs: false, noJobsMessage: 'No Swiss Medical Network jobs found.' });
   console.log('\n✅ Swiss Medical Network crawler complete.');
 
   const _durationMs = getCrawlerElapsedMs();

--- a/tests/crawler-fetch-facet-scope.test.ts
+++ b/tests/crawler-fetch-facet-scope.test.ts
@@ -15,6 +15,7 @@ import { parseMikronJobs } from '@/scripts/lib/mikron-job-parser.mjs';
 import {
   normalizeSmnApiPosting,
   extractSmnApiDescription,
+  extractSmnPostingId,
   smnPostingsApiUrl,
 } from '@/scripts/lib/swiss-medical-network-job-parser.mjs';
 
@@ -92,6 +93,19 @@ describe('Swiss Medical Network — SmartRecruiters API normalization', () => {
   it('leaves canton blank (never Ticino) when unresolved', () => {
     const p = normalizeSmnApiPosting({ id: '3', name: 'X', location: { city: 'Bellelay', country: 'ch' } });
     expect(p.canton).toBe('');
+  });
+
+  it('derives PART_TIME / FULL_TIME from the API employment type', () => {
+    const pt = normalizeSmnApiPosting({ id: '4', name: 'X', location: { city: 'Bern', region: 'BE', country: 'ch' }, typeOfEmployment: { id: 'part-time', label: 'Part-time' } });
+    const ft = normalizeSmnApiPosting({ id: '5', name: 'Y', location: { city: 'Bern', region: 'BE', country: 'ch' }, typeOfEmployment: { id: 'permanent', label: 'Full-time' } });
+    expect(pt.employmentType).toBe('PART_TIME');
+    expect(ft.employmentType).toBe('FULL_TIME');
+  });
+
+  it('extracts the posting id used to de-dup against dedicated clinic crawlers', () => {
+    expect(extractSmnPostingId('https://jobs.smartrecruiters.com/SwissMedicalNetwork1/744000134713627-some-slug')).toBe('744000134713627');
+    expect(extractSmnPostingId('https://jobs.smartrecruiters.com/SwissMedicalNetwork1/744000134713627')).toBe('744000134713627');
+    expect(extractSmnPostingId('https://example.com/x')).toBe('');
   });
 
   it('joins jobAd sections into a description', () => {

--- a/tests/crawler-fetch-facet-scope.test.ts
+++ b/tests/crawler-fetch-facet-scope.test.ts
@@ -1,0 +1,106 @@
+/**
+ * National-employer fetch-facet scope guards.
+ *
+ * These crawlers previously narrowed their fetch to a single canton/city
+ * (SRG → Wallis facet, Swiss Medical Network → Ticino region UUID, Skyguide →
+ * Locarno/Lugano-Agno facet, Mikron → Agno filter, PEMSA → canton=125) and/or
+ * defaulted unresolved jobs to Ticino. This locks in the CH-wide behaviour:
+ * canton derived per-job, no Ticino fallback, foreign rows excluded.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { inferSkyguideCanton } from '@/scripts/lib/skyguide-job-parser.mjs';
+import { isPemsaTicinoRelevant } from '@/scripts/lib/pemsa-job-parser.mjs';
+import { parseMikronJobs } from '@/scripts/lib/mikron-job-parser.mjs';
+import {
+  normalizeSmnApiPosting,
+  extractSmnApiDescription,
+  smnPostingsApiUrl,
+} from '@/scripts/lib/swiss-medical-network-job-parser.mjs';
+
+describe('Skyguide canton inference — no Ticino default', () => {
+  it('derives the real canton for the big control centres', () => {
+    expect(inferSkyguideCanton('Genève, CH')).toBe('GE');
+    expect(inferSkyguideCanton('Dübendorf, CH')).toBe('ZH');
+    expect(inferSkyguideCanton('Sion, CH')).toBe('VS');
+  });
+
+  it('returns blank (not TI) when the location is unknown', () => {
+    expect(inferSkyguideCanton('')).toBe('');
+    expect(inferSkyguideCanton('Atlantis')).toBe('');
+  });
+});
+
+describe('PEMSA relevance — all 26 cantons, not Ticino-only', () => {
+  it('keeps non-Ticino Swiss cities', () => {
+    expect(isPemsaTicinoRelevant({ city: 'Genève' })).toBe(true);
+    expect(isPemsaTicinoRelevant({ city: 'Bulle' })).toBe(true);
+    expect(isPemsaTicinoRelevant({ city: 'Lugano' })).toBe(true);
+  });
+
+  it('rejects foreign locations', () => {
+    expect(isPemsaTicinoRelevant({ city: 'Paris' })).toBe(false);
+    expect(isPemsaTicinoRelevant({ city: 'Milano' })).toBe(false);
+  });
+});
+
+describe('Mikron teaser parsing — keeps non-Agno Swiss sites, no fabricated location', () => {
+  const FIXTURE = `
+    <div class="open-jobs">
+      <article class="mi-job-teaser">
+        <h3><a href="/en/controls-engineer-1" class="stretched-link">Controls Engineer</a></h3>
+        <div class="job-attributes"><div><div>Division</div><div>Automation</div></div>
+        <div><div>Location</div><div>Switzerland, Boudry</div></div></div>
+      </article>
+      <article class="mi-job-teaser">
+        <h3><a href="/en/cnc-operator-2" class="stretched-link">CNC Operator</a></h3>
+        <div class="job-attributes"><div><div>Division</div><div>Machining</div></div>
+        <div><div>Location</div><div>Switzerland, Agno</div></div></div>
+      </article>
+      <article class="mi-job-teaser">
+        <h3><a href="/en/sales-rep-3" class="stretched-link">Sales Rep</a></h3>
+        <div class="job-attributes"><div><div>Division</div><div>Tool</div></div>
+        <div><div>Location</div><div>Germany, Rottweil</div></div></div>
+      </article>
+    </div>`;
+
+  it('extracts the real per-teaser location (Boudry survives, never forced to Agno)', () => {
+    const jobs = parseMikronJobs(FIXTURE, { filterAgno: false });
+    const byTitle = Object.fromEntries(jobs.map((j) => [j.title, j.location]));
+    expect(byTitle['Controls Engineer']).toBe('Switzerland, Boudry');
+    expect(byTitle['CNC Operator']).toBe('Switzerland, Agno');
+    expect(byTitle['Sales Rep']).toBe('Germany, Rottweil');
+  });
+});
+
+describe('Swiss Medical Network — SmartRecruiters API normalization', () => {
+  it('builds the postings API URL with pagination', () => {
+    expect(smnPostingsApiUrl(0, 100)).toContain('/companies/SwissMedicalNetwork1/postings');
+    expect(smnPostingsApiUrl(100, 100)).toContain('offset=100');
+  });
+
+  it('resolves canton from a 2-letter region code', () => {
+    const p = normalizeSmnApiPosting({ id: '1', name: 'Médecin', location: { city: 'Biel', region: 'BE', country: 'ch' } });
+    expect(p).toMatchObject({ city: 'Biel', canton: 'BE', country: 'ch' });
+  });
+
+  it('resolves canton from the city when region is absent', () => {
+    const p = normalizeSmnApiPosting({ id: '2', name: 'Infirmier', location: { city: 'Genève', country: 'ch' } });
+    expect(p.canton).toBe('GE');
+  });
+
+  it('leaves canton blank (never Ticino) when unresolved', () => {
+    const p = normalizeSmnApiPosting({ id: '3', name: 'X', location: { city: 'Bellelay', country: 'ch' } });
+    expect(p.canton).toBe('');
+  });
+
+  it('joins jobAd sections into a description', () => {
+    const detail = { jobAd: { sections: {
+      jobDescription: { text: '<p>Main mission here.</p>' },
+      qualifications: { text: '<ul><li>Skill A</li></ul>' },
+    } } };
+    const desc = extractSmnApiDescription(detail);
+    expect(desc).toContain('Main mission here.');
+    expect(desc).toContain('Skill A');
+  });
+});


### PR DESCRIPTION
## Implementato

Rimuove i facet cantone/città al **fetch layer** da 5 datori nazionali/multi-sito i cui job svizzeri non arrivavano in ricerca (classe diversa dai default-città di #2958: qui è un parametro nell'URL/endpoint di fetch). Canton derivato per-job. Conteggi misurati dal vivo:

- **SRG SSR** (`srg-ssr-job-parser.mjs`): rimosso `filter_40=Wallis` (HQ è Bern!) → listing nazionale; canton per-job dal JSON-LD; via i default `'Valais'`/`'VS'`. **0 → 22 job**.
- **Swiss Medical Network** (`swiss-medical-network-job-parser.mjs` + runner): dalla pagina React filtrata `?region=<Ticino UUID>` all'**API pubblica SmartRecruiters** (`/companies/SwissMedicalNetwork1/postings`, CH-wide, paginata); canton per-job via `normalizeAnyCantonCode`/`inferAnyCanton`, niente default Ticino; descrizione dalle sezioni `jobAd`; `employmentType` dall'API; filtro paese CH robusto. Funzioni HTML legacy mantenute (test invariati).
  - **De-dup vs crawler clinica dedicati (🔴 reviewer)**: l'umbrella **salta i posting già posseduti** da altre slice che puntano al tenant `SwissMedicalNetwork1` (`extractSmnPostingId` + `loadDedicatedClinicPostingIds`) → le cliniche dedicate tengono il loro slug stabile, l'umbrella aggiunge solo le cliniche senza crawler dedicato. **Live: 96 posting → 35 esclusi → 61 nuovi CH-wide, zero overlap/churn.**
- **Skyguide** (`skyguide-job-parser.mjs` + runner): rimosso il facet `optionsFacetsDD_location=Locarno/Lugano-Agno` → nazionale **paginato** (`startrow`); via i default `'TI'`/`'Ticino'`. **1 → 8 job**, inclusi i centri di controllo Genève (GE) e Dübendorf (ZH).
- **Mikron** (`mikron-job-parser.mjs` + runner): rimosso il no-op `?location=Switzerland,Agno`; riscritta l'estrazione teaser che **fabbricava** "Switzerland, Agno" → location reale; tenuti tutti i siti svizzeri (Agno TI + Boudry NE), scartati gli esteri. Recupera i job **Boudry/NE**.
- **PEMSA** (`pemsa-job-parser.mjs` + runner): rimosso `?_canton=125`; canton per-job dalla città; via il default `'Ticino'` **e** il residuo `|| DEFAULT_CANTON` (🟡 reviewer). **67 → 226 URL**.

**Sweep wrong-canton-default (post-review)** — stessa classe `inferAnyCanton(x) || '<canton>'` rimossa dai datori **nazionali** dove defaultava sul cantone sbagliato:
- **KONE** `|| 'VS'`→`''` (Zürich/Adliswil) — 🔴 reviewer; **Otis** `'Ticino'`/`DEFAULT_CANTON`→`''`; **Bosch** HQ/`'Ticino'`/`'Rivera'`/`DEFAULT_CANTON`→`''`/`'Svizzera'` (crawl `?country=ch`); **Avaloq** `'TI'`→`''` (Zürich); **RUAG** `'TI'`+`'Ticino'`→`''`/`'Svizzera'` (Bern); **Tally Weijl** `'Sion'`/`'VS'`→`''` (Basel). Rimossi i binding `DEFAULT_CANTON`/`getCompanyDefaults`/`HQ` ora inutilizzati.

- **Test**: `tests/crawler-fetch-facet-scope.test.ts` (12 casi) — canton reale + niente default TI; Mikron Boudry/Agno; SMN region-code/città, employmentType, posting-id de-dup. Tutti i test dei crawler toccati (kone/avaloq/ruag/bosch/tally-weijl/otis/skyguide/pemsa) verdi.

## Non implementato (ancora)

- **Default canton/città su datori single-site / regionali**: il pattern `inferAnyCanton(x) || '<canton>'` resta (volutamente) in ~20 crawler **mono-sede o regionali** — banche/ospedali/università cantonali e aziende a sede unica: GR (`gkb`, `kanton-gr`, `fhgr`, `flury-stiftung`, `hochgebirgsklinik-davos`, `kulm-hotel`, `spital-thusis`…), VS (`bcvs`, `canton-valais`, `fondation-domus`, `berner-montage`), VD (`debiopharm`), GL (`laderach`), TI single-site. Il fallback HQ-canton è **legittimo** (stessa categoria accettata per Bracco/FNZ in #2958: il fetch è già della sede, le righe risolte usano la città reale).
- **Candidati nazionali incerti** (`axpo`, `board`, `richemont`, `marriott`, `siemens-healthineers`): richiedono verifica per-azienda single-vs-multi-site → audit follow-up dedicato (classe già coperta sui casi certi in questa PR).
- **Mikron divisione "Tool"** (Rottweil DE): righe vuote+Tool → scartate (corretto, sito tedesco).
- **Mikron paginazione AJAX**: solo la prima pagina è server-side (Mikron pubblica poche decine di ruoli) → follow-up se supera una pagina.
- **Sibling default-città** (UBS/Workday/Galenica/Tschuggen/Swiss Life/Fielmann): coperti in #2958 (mergiata), non qui.
