### PR TITLE
feat(article): local open-source LLM as last-resort cascade fallback (#2947)

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -124,7 +124,7 @@ jobs:
       # stays unset → ai-models marks local/* unavailable → identical to today.
       - name: Cache local LLM model
         if: vars.ARTICLE_LOCAL_FALLBACK == '1'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.ollama/models
           key: ollama-${{ vars.ARTICLE_LOCAL_MODEL || 'qwen2.5:7b' }}

--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -111,6 +111,50 @@ jobs:
           echo "section=$SEC" >> "$GITHUB_OUTPUT"
           echo "🎯 Target section: $SEC"
 
+      # ── Local open-source LLM fallback (opt-in) ───────────────────────
+      # When the repo variable ARTICLE_LOCAL_FALLBACK=1, set up a local ollama
+      # server serving a small open-source model (default qwen2.5:7b). The model
+      # is the LAST entry in the cascade (scripts/lib/ai-models.mjs, pinned to the
+      # bottom by sortChainByScore) and is reached ONLY when every remote free-tier
+      # provider is daily-exhausted — the recurring "tutti i modelli esauriti"
+      # defer that drops frontaliere production to 0 for that window. Public repo →
+      # GitHub-hosted runner minutes are free, so this is $0; the only cost is
+      # wall-clock (CPU inference is slow), which is fine for a last-resort path.
+      # Entirely inert unless the variable is set: no env exported → LOCAL_LLM_ENABLED
+      # stays unset → ai-models marks local/* unavailable → identical to today.
+      - name: Cache local LLM model
+        if: vars.ARTICLE_LOCAL_FALLBACK == '1'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama/models
+          key: ollama-${{ vars.ARTICLE_LOCAL_MODEL || 'qwen2.5:7b' }}
+
+      - name: Setup local LLM fallback (ollama)
+        if: vars.ARTICLE_LOCAL_FALLBACK == '1'
+        env:
+          LOCAL_MODEL: ${{ vars.ARTICLE_LOCAL_MODEL || 'qwen2.5:7b' }}
+        run: |
+          set -e
+          if ! command -v ollama >/dev/null 2>&1; then
+            curl -fsSL https://ollama.com/install.sh | sh
+          fi
+          # Start the server in the background and wait for it to answer.
+          OLLAMA_HOST=127.0.0.1:11434 nohup ollama serve >/tmp/ollama.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:11434/api/version >/dev/null; then break; fi
+            sleep 2
+          done
+          # Pull the model (no-op if restored from cache).
+          ollama pull "$LOCAL_MODEL"
+          # Export so the generate step's ai-models cascade can reach the local
+          # model as last resort. ollama exposes an OpenAI-compatible endpoint.
+          {
+            echo "LOCAL_LLM_ENABLED=1"
+            echo "LOCAL_LLM_URL=http://127.0.0.1:11434/v1/chat/completions"
+            echo "LOCAL_LLM_MODEL=$LOCAL_MODEL"
+          } >> "$GITHUB_ENV"
+          echo "🧠 Local LLM fallback ready: $LOCAL_MODEL (last-resort in the cascade)"
+
       - name: Generate article
         id: generate
         env:

--- a/docs/SELFHOSTED-RUNNER.md
+++ b/docs/SELFHOSTED-RUNNER.md
@@ -55,6 +55,32 @@ GitHub-hosted `ubuntu-latest`. Nothing breaks if the VM is offline *unless*
 `ARTICLE_RUNNER=self-hosted` is set with no runner online (jobs would queue) — so
 remove the variable if you tear the VM down.
 
+## Local open-source LLM fallback ($0, no quota)
+
+The model cascade in `scripts/lib/ai-models.mjs` ends with a **local** model
+(`AI_MODELS.LOCAL_FALLBACK`, id `local/fallback`) pinned to the very bottom of
+every chain (`sortChainByScore`) and reached **only when every remote free-tier
+provider is daily-exhausted** — the recurring `tutti i modelli AI gratuiti
+esauriti` defer that drops frontaliere production to 0 for that window. It serves
+an open-source model (default **Qwen2.5 7B**) via a local OpenAI-compatible
+server, so generation keeps producing at $0 with no API quota.
+
+**Activation (opt-in, off by default):** set the repo variable
+`ARTICLE_LOCAL_FALLBACK=1`. Optionally `ARTICLE_LOCAL_MODEL` (default
+`qwen2.5:7b`; use `qwen2.5:3b` for a faster/lighter CPU run). `generate-article.yml`
+then installs ollama, caches the model (`~/.ollama/models`), serves it, and
+exports `LOCAL_LLM_ENABLED=1` + `LOCAL_LLM_URL` + `LOCAL_LLM_MODEL` for that run.
+
+- Works on the **GitHub-hosted** runner (public repo → free minutes; CPU
+  inference is slow, ~minutes/article, but it is the last resort) **and** on the
+  self-hosted Oracle VM (faster, model stays warm).
+- `ai-models.mjs` env knobs: `LOCAL_LLM_ENABLED`, `LOCAL_LLM_URL` (default
+  `http://127.0.0.1:8080/v1/chat/completions` for a llama.cpp `--server`),
+  `LOCAL_LLM_MODEL`, `LOCAL_LLM_TIMEOUT_MS` (default 600000), `LOCAL_LLM_API_KEY`.
+- **Inert unless enabled:** without the variable nothing is installed and
+  `LOCAL_LLM_ENABLED` stays unset → `isModelAvailable('local/fallback')` is
+  `false` → the model is skipped exactly as today. To revert: delete the variable.
+
 ## Notes
 - The GitHub-hosted path stays the default + safety net; the variable is the only
   switch.

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -335,6 +335,13 @@ export const AI_MODELS = Object.freeze({
   // GROQ_LLAMA_4_MAV_INSTR removed — Groq HTTP 404 "model `…-128e-instruct-fp8` does not exist" (2026-05-18)
   // CB_QWEN3_CODER_480B removed — Cerebras HTTP 404 "Model qwen-3-coder-480b does not exist" (2026-05-18)
   // CB_GPT_OSS_20B_2 removed — Cerebras HTTP 404 "Model gpt-oss-20b does not exist" (2026-05-18)
+
+  // ── Local open-source fallback (opt-in, last-resort) ──
+  // Routed to a local llama.cpp/ollama server. Inert unless LOCAL_LLM_ENABLED is
+  // set (isModelAvailable returns false otherwise → silently skipped). Pinned to
+  // the bottom of every chain by sortChainByScore so it never displaces a working
+  // remote API — it only runs when all remote providers are exhausted.
+  LOCAL_FALLBACK:      'local/fallback',
 });
 
 /**
@@ -558,6 +565,11 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.CF_LLAMA_3_2_1B,            // Llama 3.2 1B small/fast    (Cloudflare Workers AI)
   // AI_MODELS.CF_QWEN_25_CODER_32B removed — wrapper crash "text.replace is not a function" (2026-05-27, run 26537033519).
   // AI_MODELS.GROQ_LLAMA_3_3_SPEC removed — Groq HTTP 400 "decommissioned" (2026-05-27, run 26537033519).
+
+  // Last-resort local model. Always sorted to the very bottom (sortChainByScore)
+  // and skipped entirely unless LOCAL_LLM_ENABLED — so when every remote provider
+  // above is daily-exhausted, generation still produces instead of deferring.
+  AI_MODELS.LOCAL_FALLBACK,
 ];
 
 // ── Provider constants ───────────────────────────────────────
@@ -578,6 +590,12 @@ const PROVIDER = Object.freeze({
   CODESTRAL:   'codestral',
   CHUTES:      'chutes',
   ZAI:         'zai',
+  // Local OpenAI-compatible server (llama.cpp / ollama) on the CI runner or a
+  // self-hosted VM. Opt-in last-resort: when EVERY remote free-tier provider is
+  // daily-exhausted (the recurring "tutti i modelli esauriti" defer), generation
+  // would otherwise produce 0 articles for that window. A local open-source model
+  // (e.g. Qwen2.5) keeps the funnel producing at $0/zero-quota. See _callLocal.
+  LOCAL:       'local',
 });
 
 // ── Endpoints ────────────────────────────────────────────────
@@ -596,6 +614,25 @@ const MISTRAL_API_BASE     = 'https://api.mistral.ai/v1/chat/completions';
 const CODESTRAL_API_BASE   = 'https://codestral.mistral.ai/v1/chat/completions';
 const CHUTES_API_BASE      = 'https://llm.chutes.ai/v1/chat/completions';
 const ZAI_API_BASE         = 'https://api.z.ai/api/paas/v4/chat/completions';
+
+// ── Local LLM (llama.cpp / ollama, OpenAI-compatible) ────────
+// Opt-in: inert unless LOCAL_LLM_ENABLED is truthy. Default endpoint targets a
+// llama.cpp `--server` (port 8080); ollama users set LOCAL_LLM_URL to its
+// :11434/v1 endpoint. The served model name is a free-text label — the actual
+// weights are whatever the local server has loaded — so we keep a stable id.
+const LOCAL_LLM_DEFAULT_URL   = 'http://127.0.0.1:8080/v1/chat/completions';
+const LOCAL_LLM_DEFAULT_MODEL = 'local-fallback';
+function isLocalLlmEnabled()  { return /^(1|true|yes|on)$/i.test((process.env.LOCAL_LLM_ENABLED || '').trim()); }
+function getLocalLlmUrl()     { return (process.env.LOCAL_LLM_URL || LOCAL_LLM_DEFAULT_URL).trim(); }
+function getLocalLlmModelId() { return (process.env.LOCAL_LLM_MODEL || LOCAL_LLM_DEFAULT_MODEL).trim(); }
+// llama.cpp/ollama ignore the key, but _callOpenAICompatible requires a non-empty
+// one; allow an override for servers behind an auth proxy.
+function getLocalLlmApiKey()  { return (process.env.LOCAL_LLM_API_KEY || 'local-no-key').trim(); }
+// CPU inference is slow; give the local call a generous floor (overridable).
+function getLocalLlmTimeoutMs() {
+  const v = parseInt((process.env.LOCAL_LLM_TIMEOUT_MS || '').trim(), 10);
+  return Number.isFinite(v) && v > 0 ? v : 600_000; // 10 min default
+}
 
 // ── API keys (lazy-loaded from environment) ──────────────────
 function getGhModelsPat()       { return (process.env.GH_MODELS_PAT || '').trim(); }
@@ -675,6 +712,7 @@ function getProvider(model) {
   if (model.startsWith('mistral/'))    return PROVIDER.MISTRAL;
   if (model.startsWith('chutes/'))     return PROVIDER.CHUTES;
   if (model.startsWith('zai/'))        return PROVIDER.ZAI;
+  if (model.startsWith('local/'))      return PROVIDER.LOCAL;
   return PROVIDER.GITHUB;
 }
 
@@ -707,6 +745,7 @@ function getApiModelId(model) {
   if (model.startsWith('mistral/'))    return model.slice(8);   // 8 chars: "mistral/"
   if (model.startsWith('chutes/'))     return model.slice(7);   // 7 chars: "chutes/"
   if (model.startsWith('zai/'))        return model.slice(4);   // 4 chars: "zai/"
+  if (model.startsWith('local/'))      return getLocalLlmModelId(); // served-model label is runtime-configured
   return model;
 }
 
@@ -734,6 +773,10 @@ function getApiKeyForProvider(provider) {
     case PROVIDER.CODESTRAL:   return getCodestralApiKey();
     case PROVIDER.CHUTES:      return getChutesApiKey();
     case PROVIDER.ZAI:         return getZaiApiKey();
+    // Local server needs no real key; gate purely on the opt-in flag. Returning
+    // a sentinel marks local/* available so the chain can reach it as last resort
+    // (and '' when disabled → every local/* model is skipped). Mirrors Cloudflare.
+    case PROVIDER.LOCAL:       return isLocalLlmEnabled() ? 'local-no-key' : '';
     default: return '';
   }
 }
@@ -1697,6 +1740,12 @@ function sortChainByScore(chain) {
   // Build index map for tiebreaker (lower index = better in original order)
   const indexMap = new Map(chain.map((m, i) => [m, i]));
   return [...chain].sort((a, b) => {
+    // Local CPU fallback always sinks to the bottom regardless of score — slow
+    // local inference must never be score-promoted above a working remote API;
+    // it exists only for when every remote provider is exhausted.
+    const la = a.startsWith('local/') ? 1 : 0;
+    const lb = b.startsWith('local/') ? 1 : 0;
+    if (la !== lb) return la - lb;
     const sa = _modelScores.get(a) || 0;
     const sb = _modelScores.get(b) || 0;
     if (sb !== sa) return sb - sa; // higher score first
@@ -2555,6 +2604,24 @@ function _callZai(model, messages, opts) {
 }
 
 /**
+ * Call a local OpenAI-compatible server (llama.cpp `--server` or ollama).
+ * Last-resort fallback used only when every remote provider is exhausted.
+ * Uses a generous timeout floor because CPU inference is slow. The served model
+ * name comes from LOCAL_LLM_MODEL (getApiModelId already resolves it).
+ */
+function _callLocal(model, messages, opts) {
+  const apiModel = getApiModelId(model); // = getLocalLlmModelId()
+  // Raise the timeout floor for slow CPU inference (caller's timeout may be ~60s).
+  const localOpts = { ...opts, timeout: Math.max(opts.timeout || 0, getLocalLlmTimeoutMs()) };
+  return _callOpenAICompatible(apiModel, messages, localOpts, {
+    endpoint: getLocalLlmUrl(),
+    apiKey: getLocalLlmApiKey(),
+    providerName: 'Local',
+    trackAs: model,
+  });
+}
+
+/**
  * Call a single Gemini model with retry.
  * Returns the text content on success.
  */
@@ -2695,6 +2762,7 @@ function _callModel(model, messages, opts) {
     case PROVIDER.CODESTRAL:   return _callCodestral(model, messages, opts);
     case PROVIDER.CHUTES:      return _callChutes(model, messages, opts);
     case PROVIDER.ZAI:         return _callZai(model, messages, opts);
+    case PROVIDER.LOCAL:       return _callLocal(model, messages, opts);
     default: throw new Error(`[${model}] Unknown provider: ${provider}`);
   }
 }

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AI_MODELS, DEFAULT_CHAIN, isModelAvailable } from '../scripts/lib/ai-models.mjs';
+
+// Local open-source fallback provider: opt-in last-resort used when every remote
+// free-tier provider is daily-exhausted. These invariants guard the two things
+// that make it safe: (1) it is INERT unless LOCAL_LLM_ENABLED, so it can never
+// change behaviour by default; (2) it sits at the very bottom of the chain, so
+// slow CPU inference never displaces a working remote API.
+describe('local LLM fallback provider', () => {
+  const prev = process.env.LOCAL_LLM_ENABLED;
+  beforeEach(() => { delete process.env.LOCAL_LLM_ENABLED; });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.LOCAL_LLM_ENABLED;
+    else process.env.LOCAL_LLM_ENABLED = prev;
+  });
+
+  it('exposes a stable local/ model id', () => {
+    expect(AI_MODELS.LOCAL_FALLBACK).toBe('local/fallback');
+  });
+
+  it('is the LAST entry in the default chain (true last-resort)', () => {
+    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 1]).toBe(AI_MODELS.LOCAL_FALLBACK);
+    // It must appear exactly once.
+    expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.LOCAL_FALLBACK)).toHaveLength(1);
+  });
+
+  it('is unavailable (skipped) when LOCAL_LLM_ENABLED is unset', () => {
+    delete process.env.LOCAL_LLM_ENABLED;
+    expect(isModelAvailable(AI_MODELS.LOCAL_FALLBACK)).toBe(false);
+  });
+
+  it('becomes available only when LOCAL_LLM_ENABLED is truthy', () => {
+    for (const v of ['1', 'true', 'yes', 'on', 'TRUE']) {
+      process.env.LOCAL_LLM_ENABLED = v;
+      expect(isModelAvailable(AI_MODELS.LOCAL_FALLBACK)).toBe(true);
+    }
+    for (const v of ['0', 'false', 'no', 'off', '']) {
+      process.env.LOCAL_LLM_ENABLED = v;
+      expect(isModelAvailable(AI_MODELS.LOCAL_FALLBACK)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Follow-up #2947. Aggiunge un **modello LLM open-source locale** come **ultima risorsa** della cascata di generazione, così quando TUTTI i provider free-tier remoti sono esauriti per la quota giornaliera (il defer ricorrente `tutti i modelli AI gratuiti esauriti`, causa attuale dello stallo frontaliere) la generazione continua a produrre a **$0 / zero quota** invece di restituire 0 articoli.

**`scripts/lib/ai-models.mjs`:**
- `PROVIDER.LOCAL` + routing `local/` (`getProvider`/`getApiModelId`); `_callLocal` passa per il path OpenAI-compatible condiviso con timeout floor di 10 min (l'inference CPU è lenta).
- `AI_MODELS.LOCAL_FALLBACK` (`local/fallback`) appeso a `DEFAULT_CHAIN` e **fissato in fondo** da `sortChainByScore`: non scavalca MAI un'API remota funzionante anche se il suo score sale → raggiunto solo quando tutti i remoti sono skippati/esauriti.
- **Gated su `LOCAL_LLM_ENABLED`** (`getApiKeyForProvider` ritorna `''` se non settato → `isModelAvailable` false → skippato). **Inerte di default**, stesso pattern opt-in di `CF_WORKERS_AI_ENABLED`.

**`.github/workflows/generate-article.yml`:** step gated su repo var `ARTICLE_LOCAL_FALLBACK=1` — installa ollama, cacha il modello (`~/.ollama/models`), lo serve, esporta `LOCAL_LLM_ENABLED/URL/MODEL` per quel run. Repo PUBLIC → minuti GitHub-hosted gratis ($0); inference CPU lenta ma accettabile per un last-resort.

- Test: `tests/local-llm-fallback.test.ts` (id stabile, ultimo nella chain, gating opt-in) → 4/4 verdi; `article-tax-content-guard` verde.
- Docs: `docs/SELFHOSTED-RUNNER.md` (attivazione + env knob: `LOCAL_LLM_URL/MODEL/TIMEOUT_MS/API_KEY`).
- `node --check` + `actionlint` puliti.

## Non implementato (ancora)

Nessuno. Lo scope (provider locale opt-in, fissato come last-resort, wiring workflow gated, test, docs) è completo e funzionante quando il flag è settato. Il flag è l'**attivazione documentata** (pattern opt-in esistente nel repo, come `CF_WORKERS_AI_ENABLED`), non un deferral.

Note di verifica (non scope residuo):
- **Qualità/velocità inference CPU end-to-end** osservabile solo a flag attivo su un run reale: un 7B Q4 su 4 vCPU fa ~2-4 tok/s, quindi è pensato per il SOLO last-resort (tutti i remoti esauriti), non per il caso normale. Revert-trigger: se a flag attivo il run sfora il budget wall (`CREATE_ARTICLE_MAX_WALL_MS`) o OOMa → usare `ARTICLE_LOCAL_MODEL=qwen2.5:3b` o disattivare la var. Default OFF = nessun rischio sul path attuale.
- **Sibling**: `check-sibling-patterns` segnala file che condividono i token generici `AI_MODELS`/`providerName` — falsi positivi: il provider è aggiunto nell'UNICO modulo condiviso (`ai-models.mjs`), gli altri file si limitano a consumare `AI_MODELS`, nessun antipattern duplicato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
