### PR TITLE
fix(ci): allow frontaliere-automation[bot] in pr-review-loop allowed_bots

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -209,7 +209,11 @@ jobs:
           # (hardening #898): mai `*`. `claude[bot]` copre le PR fix-issue;
           # `github-actions[bot]` copre eventuali PR aperte da automation interna
           # (run 26621967484 era exit 1 col precedente vincolo non-human-actor).
-          allowed_bots: "github-actions[bot], claude[bot]"
+          # `frontaliere-automation[bot]` (App): le PR aggiornate/aperte via App
+          # token (autorebase App-push, issue-fix) triggerano `pull_request` con
+          # actor = l'App → senza whitelist la review aborta "non-human actor:
+          # frontaliere-automation" (exit 1) → niente `## LGTM` → pipeline ferma.
+          allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
           # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
           # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e


### PR DESCRIPTION
## Contesto

Errore live ricorrente nelle review: **`Workflow initiated by non-human actor: frontaliere-automation (type: Bot). Add bot to allowed_bots list`** → exit 1. Quando una PR è aggiornata/aperta via App token (autorebase App-push, issue-fix), i workflow `pull_request` triggerano con actor = `frontaliere-automation[bot]`, ma `pr-review-loop.yml` non aveva l'App in `allowed_bots` → `claude-code-action` abortiva → niente review → niente `## LGTM` → niente auto-merge → **pipeline autonoma ferma** (merge manuale dell'owner).

## Implementato

- `.github/workflows/pr-review-loop.yml`: aggiunto `frontaliere-automation[bot]` alla whitelist `allowed_bots` (oltre a `github-actions[bot]`, `claude[bot]`). Mai `*` (hardening #898).

## Non implementato (ancora)

- Nessuno scope residuo. Le altre whitelist `allowed_bots` sono coperte: `lessons-harvester.yml` e `pr-redflag-fixer.yml` aggiornati nella PR gemella #3048 (push-auth + allowed_bots non-drift); `post-merge-followup.yml` e `issue-fix.yml` già includevano l'App.

## Note merge

PR dedicata al solo `pr-review-loop.yml` (unico `REVIEW_WORKFLOW_DRIFT_FILES`): il reviewer Claude **salta** la workflow-validation su un branch che modifica questo file → nessuna review possibile by-design. Merge atteso via il **drift-fallback deterministico** in `scripts/ci/auto-merge-eval.mjs` (autore fidato + `pr-body-contract` verde + vitest success), nessun 🔴 pregresso. Isolata da #3048 proprio per non far driftare quella PR (che così può ri-girare la review e chiudere il suo 🔴).

## Test plan

- [x] YAML valido.
- [ ] Post-merge: una PR aggiornata via App token (es. prossimo autorebase) NON deve più far abortire `pr-review-loop` con "non-human actor".