### PR TITLE
fix(job-board): risolvi annuncio 'non disponibile' su URL bridge cross-canton

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2541,8 +2541,20 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (!initialJobSlug) return null;
  // When navigating via a previousSlug (bridge), use the current slug for job lookup
  const lookupSlug = bridgeTargetSlug || initialJobSlug;
- return jobs.find((j) => matchesRouteSlug(j, lookupSlug)) || null;
- }, [jobs, initialJobSlug, bridgeTargetSlug, companySlugFilter, locationSlugFilter, searchSlugFilter, editorialLandingDescriptor]);
+ // Primary lookup: the canton-scoped `jobs` array.
+ const scoped = jobs.find((j) => matchesRouteSlug(j, lookupSlug));
+ if (scoped) return scoped;
+ // Cross-canton fallback: a legacy-TI bridge URL (`/cerca-lavoro-ticino/<slug>/`)
+ // for a job that lives in another canton (e.g. BE) parses to jobBoardCanton='TI',
+ // so `jobs` is scoped to TI and never contains the bridged job → it would fall
+ // through to JobOrphanView ("Questo annuncio non è più disponibile") even though
+ // the job is alive and its full content is pre-rendered. The locale-wide
+ // `unscopedJobs` pool (loaded for cross-canton search) DOES contain it, so resolve
+ // from there. This is deterministic (no dependency on the async bridge-rescue
+ // fetch landing before the wholesale `setJobs` of the full load clobbers a merged
+ // record), closing the timing race that intermittently showed the orphan banner.
+ return unscopedJobs.find((j) => matchesRouteSlug(j, lookupSlug)) || null;
+ }, [jobs, unscopedJobs, initialJobSlug, bridgeTargetSlug, companySlugFilter, locationSlugFilter, searchSlugFilter, editorialLandingDescriptor]);
 
  // Cross-canton bridge resolution: when a bridge URL (e.g.
  // /cerca-lavoro-ticino/<old-slug>/) points to a job that now lives in a
@@ -2592,6 +2604,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const targetId = meta.id;
  const match = all.find((j: { id?: string }) => j?.id === targetId);
  if (match) extra = [match];
+ // Seed the locale-wide pool so the `selectedJob` unscoped fallback can
+ // resolve this (and any other) cross-canton bridge job deterministically,
+ // independent of whether the canton-scoped `jobs` array retains the merge.
+ if (!cancelled && all.length > 0) {
+ setUnscopedJobs((prev) => prev.length > 0
+ ? prev
+ : dedupeJobsForListing(all.map((job: unknown) => normalizeIncomingJob(job))));
+ }
  }
  }
  } catch {

--- a/tests/bridge-canton-aware.test.ts
+++ b/tests/bridge-canton-aware.test.ts
@@ -122,6 +122,28 @@ describe('Bridge page canton-aware UX', () => {
       // Filter must be id-based to avoid loading a 5MB monolith into state.
       expect(jobBoardSrc).toMatch(/all\.find\(\(j: \{ id\?: string \}\) => j\?\.id === targetId\)/);
     });
+
+    it('selectedJob resolves cross-canton bridge jobs from the unscoped pool (no orphan for live content)', () => {
+      // Root-cause guard for "Questo annuncio non è più disponibile" on a
+      // legacy-TI bridge URL (e.g. /cerca-lavoro-ticino/<BE-job-slug>/): the URL
+      // parses to jobBoardCanton='TI', so the canton-scoped `jobs` array never
+      // contains the BE job. The async bridge-rescue fetch can race against the
+      // wholesale `setJobs` of the full load (which would clobber a merged
+      // record) → intermittent JobOrphanView for a live, pre-rendered job.
+      //
+      // The deterministic fix: `selectedJob` must ALSO look up the locale-wide
+      // `unscopedJobs` pool (already loaded for cross-canton search) before
+      // falling through to the orphan view. This resolves synchronously off
+      // in-memory data, independent of the rescue fetch timing.
+      const selectedJobStart = jobBoardSrc.indexOf('const selectedJob = useMemo(');
+      expect(selectedJobStart).toBeGreaterThan(-1);
+      const selectedJobBlock = jobBoardSrc.slice(selectedJobStart, selectedJobStart + 2500);
+      // The unscoped pool is consulted as a fallback inside the selectedJob memo.
+      expect(selectedJobBlock).toMatch(/unscopedJobs\.find\(\(j\) => matchesRouteSlug\(j, lookupSlug\)\)/);
+      // And `unscopedJobs` is a reactive dependency so the memo recomputes once
+      // the pool lands.
+      expect(selectedJobBlock).toMatch(/\}, \[jobs, unscopedJobs,/);
+    });
   });
 
   describe('F1: backfilled previousSlugs for the canonical Denner case', () => {


### PR DESCRIPTION
## Contesto

Un annuncio live (es. `redattore-legge-trattato-confederazione-svizzera-bern`, canton **BE**) appariva ad alcuni utenti come **«Questo annuncio non è più disponibile o non è stato trovato»** pur caricando il contenuto reale (HTML pre-renderizzato, JSON-LD `JobPosting`, salario, descrizione).

### Root cause
Un job non-TI è emesso a **due** URL:
- `/cerca-lavoro-berna/<slug>/` — pagina canton-aware (canonical)
- `/cerca-lavoro-ticino/<slug>/` — **bridge legacy-TI** (contenuto pieno, `<link rel=canonical>`→berna), per preservare gli URL storici indicizzati (`jobsSeoPagesPlugin.ts`).

Sul bridge URL il router forza `jobBoardCanton='TI'` → la SPA scarica l'index locale-wide ma lo **filtra a soli TI** (`scopeJobsToCanton`) → il job BE non è mai in `jobs` → `selectedJob=null` → `JobOrphanView`.

Esisteva già un rescue cross-canton (slim-index fetch per `id`), ma la sua `setJobs` poteva essere **clobberata** dalla `setJobs` wholesale del full-load, e `bridgeFetchAttempted` bloccava il retry → orphan **intermittente** (timing/cache-dependent, da qui «per alcuni utenti»). Riprodotto: da sloggato e via nav SPA il rescue risolveva; lo screenshot loggato ha colpito la race.

## Implementato

- **`components/community/JobBoard.tsx` — `selectedJob` memo**: aggiunto fallback al pool locale-wide `unscopedJobs` (già caricato per la ricerca cross-canton e contenente TUTTI i cantoni) quando il `jobs` canton-scoped non contiene lo slug. Risoluzione **sincrona** su dati in-memory, indipendente dal timing del rescue → chiude la race deterministicamente. `unscopedJobs` aggiunto alle dependency del memo. Stesso matcher `matchesRouteSlug` (anche via `previousSlugs`, preservati da `normalizeIncomingJob` che fa `{ ...raw }`) → nessun rischio di risolvere il job sbagliato.
- **`JobBoard.tsx` — bridge rescue effect**: quando fetcha `/data/jobs-${locale}-index.json` per `id` (ramo shard-empty, **realtà prod attuale** — shard disabilitati), ora **semina anche `unscopedJobs`** (se vuoto) → il fallback sincrono si innesca anche nei casi in cui `finalize` non avesse ancora popolato il pool. Nota: questa semina vive nel ramo shard-empty; il pool è comunque popolato dal full-load legacy (`legacyArr`) che è il path di produzione.
- **`tests/bridge-canton-aware.test.ts`**: regressione (suite vitest CI) che asserisce il fallback `unscopedJobs` nel memo `selectedJob` e la dependency reattiva.

Nessuna modifica all'emit SSG (il bridge resta, canonical→berna corretto): il fix è puramente lato risoluzione SPA. Nessuna firma esportata cambiata; cambiamento additivo (short-circuit: `unscopedJobs.find` gira solo quando `jobs.find` fallisce, ~caso cross-canton).

## Non implementato (ancora)

- **Verifica live post-deploy**: la correzione è logica deterministica (coperta da unit test + ragionamento), ma il comportamento sull'URL bridge si osserva solo dopo il deploy del bundle SPA su `main`. Next step: post-merge, ricaricare `/cerca-lavoro-ticino/redattore-legge-trattato-confederazione-svizzera-bern/` (full-load + nav SPA interna) e confermare che renda il job reale, mai l'orphan banner. Nessun revert-trigger atteso (nessun impatto memoria/build SSG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)