### PR TITLE
fix(spa): unify version-skew reload guard on _swReloadCount (follow-up #3071)

### DIFF
--- a/services/resilientImport.ts
+++ b/services/resilientImport.ts
@@ -72,18 +72,25 @@ export function isVersionSkewError(err: unknown): boolean {
   );
 }
 
-// Shared across all callers so a stale deploy triggers at most one reload per
-// session, no matter which service chunk was the first to fail. The
-// `index.html` bootstrap recovery uses its own `_swReloadCount` for the same
-// purpose; both ceilings are honoured so a session reloads at most once total.
+// Per-session reload guard for resilientImport's own import() recovery path.
 const RELOAD_KEY = '_serviceChunkReload';
+
+// Session-wide reload ceiling SHARED with the `index.html` bootstrap recovery
+// (resource-error, dynamic-import, and version-skew handlers all gate on this
+// counter). recoverFromStaleChunk reads+increments the SAME key so the
+// ErrorBoundary skew path and the global window-error skew path can never each
+// fire their own reload — the session reloads at most once across BOTH skew
+// surfaces (the value `>= 1` blocks further reloads, matching index.html).
+const BOOTSTRAP_RELOAD_KEY = '_swReloadCount';
 
 /**
  * Clear all CacheStorage entries and reload the page ONCE per session so the
  * browser refetches a CONSISTENT set of stable-named chunks (post-propagation,
- * the skew is gone). Shared by resilientImport's import() recovery and the
- * ErrorBoundary version-skew recovery. No-op outside the browser. Returns true
- * if a reload was scheduled, false if the per-session guard blocked it.
+ * the skew is gone). Called by the ErrorBoundary version-skew recovery; shares
+ * the `_swReloadCount` ceiling with the index.html bootstrap recovery so the two
+ * skew surfaces (React-caught + global window error) reload at most once total.
+ * No-op outside the browser. Returns true if a reload was scheduled, false if
+ * the per-session guard blocked it.
  */
 export async function recoverFromStaleChunk(reason: string): Promise<boolean> {
   if (typeof window === 'undefined') return false;
@@ -91,15 +98,15 @@ export async function recoverFromStaleChunk(reason: string): Promise<boolean> {
   if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
     return false;
   }
-  let guarded = false;
+  let reloadCount = 0;
   try {
-    guarded = !!sessionStorage.getItem(RELOAD_KEY);
+    reloadCount = parseInt(sessionStorage.getItem(BOOTSTRAP_RELOAD_KEY) || '0', 10) || 0;
   } catch {
     /* private mode — proceed without the guard */
   }
-  if (guarded) return false;
+  if (reloadCount >= 1) return false;
   try {
-    sessionStorage.setItem(RELOAD_KEY, '1');
+    sessionStorage.setItem(BOOTSTRAP_RELOAD_KEY, String(reloadCount + 1));
   } catch {
     /* private mode — guard unavailable, still attempt one reload below */
   }

--- a/tests/resilient-import.test.ts
+++ b/tests/resilient-import.test.ts
@@ -148,7 +148,17 @@ describe('recoverFromStaleChunk', () => {
     expect(scheduled).toBe(true);
     expect((globalThis as any).caches.delete).toHaveBeenCalledTimes(2);
     expect(reload).toHaveBeenCalledTimes(1);
-    expect(sessionStorage.getItem('_serviceChunkReload')).toBe('1');
+    // Shares the `_swReloadCount` ceiling with the index.html bootstrap recovery.
+    expect(sessionStorage.getItem('_swReloadCount')).toBe('1');
+  });
+
+  it('honours a reload already triggered by the index.html bootstrap recovery', async () => {
+    const reload = setHostname('frontaliereticino.ch');
+    // index.html's resource/import/skew handlers set this same counter.
+    sessionStorage.setItem('_swReloadCount', '1');
+    const scheduled = await recoverFromStaleChunk('after-bootstrap-reload');
+    expect(scheduled).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
   });
 
   it('is guarded to a single reload per session', async () => {


### PR DESCRIPTION
Follow-up del 🟡 nit della review su #3071 (cross-chunk version-skew self-heal).

## Contesto

In #3071 i due path di recovery dello skew usavano guard di sessione **separati**:
- `recoverFromStaleChunk` (ErrorBoundary, skew preso da React) → `_serviceChunkReload`
- handler `window 'error'` in `index.html` (skew fuori da React) → `_swReloadCount`

→ una singola sessione poteva far partire **due** reload con cache-clear, contraddicendo la garanzia documentata "≤1 reload per sessione". Nit corretto.

## Implementato

- **`services/resilientImport.ts`** — `recoverFromStaleChunk` ora legge+incrementa lo **stesso** contatore `_swReloadCount` che la bootstrap recovery di `index.html` già usa (resource-error, dynamic-import, skew). I due surface di skew (React-caught + global window error) condividono un solo ceiling → la sessione fa **al massimo un reload totale** tra entrambi. Il path import() di `resilientImport` mantiene il suo `_serviceChunkReload` separato (pre-esistente, load-time, non flaggato).
- **`tests/resilient-import.test.ts`** — +1 test: `recoverFromStaleChunk` rispetta un reload già scattato dalla bootstrap recovery (`_swReloadCount=1` → no-op). 13/13 verde locale.

## Non implementato (ancora)

Nessuno. Il path import() di `resilientImport` (`_serviceChunkReload`) resta volutamente separato: è recovery di load-time, non co-occorre con uno skew a call-time sulla stessa navigazione, e non era oggetto del nit.