### PR TITLE
feat(article): raise wall budget to 300min when local LLM fallback is on (measure)

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -172,7 +172,19 @@ jobs:
           # ~35min uncancelled (concurrency `cancel-in-progress: false`), so a
           # 55-min frontaliere budget is safe and well under the hard cap.
           # svizzera keeps the original 30-min cap (it never approaches it).
-          CREATE_ARTICLE_MAX_WALL_MS: ${{ steps.section.outputs.section == 'svizzera' && '1800000' || '3300000' }}
+          #
+          # When the local-LLM fallback is enabled (ARTICLE_LOCAL_FALLBACK=1),
+          # generation can fall to a slow CPU model whose single calls take
+          # minutes; the 55-min cap then cuts the run off mid-generation before
+          # it can land a fact-check-passing article (measured Jun-29: 3b did 12
+          # attempts/55min, 7b only ~2/55min — both deferred on the wall, not on
+          # quality-exhaustion). Raise the budget to 300 min in that mode so the
+          # local path can RUN TO COMPLETION and we can measure its real
+          # end-to-end time. Still under the 360-min job `timeout-minutes`
+          # (300min create-article + ollama setup + commit/deploy < 360). Defers
+          # stay rare/acceptable; this just stops the premature cut-off so the
+          # measurement is real. Reverts to 55/30 min when the var is unset.
+          CREATE_ARTICLE_MAX_WALL_MS: ${{ vars.ARTICLE_LOCAL_FALLBACK == '1' && '18000000' || (steps.section.outputs.section == 'svizzera' && '1800000' || '3300000') }}
         run: |
           echo "📰 Generating blog article (section=$TARGET_SECTION)..."
           if [ -n "${{ inputs.url }}" ]; then


### PR DESCRIPTION
## Implementato

Per decisione owner (29/06: "accetta i defer rari e aumenta la finestra così misuriamo quanto impiega"). Alza il wall budget di `create-article.mjs` a **300 min** quando il fallback LLM locale è attivo (`vars.ARTICLE_LOCAL_FALLBACK == '1'`), così il path locale lento su CPU **completa** invece di essere tagliato a 55 min a metà generazione — per misurarne il tempo reale end-to-end.

**Contesto (misurato):** con il fallback locale ON, 2 run di validazione hanno mostrato che entrambi i modelli deferivano sul **wall**, non per esaurimento qualità: `qwen2.5:3b` faceva 12 tentativi/55min (contenuti troppo deboli → fact-check FAIL), `qwen2.5:7b` solo ~2/55min (CPU troppo lenta). Il cap a 55 min mascherava quanto impiega davvero una generazione locale completa.

**Modifica** (`.github/workflows/generate-article.yml`, env `CREATE_ARTICLE_MAX_WALL_MS`):
- `ARTICLE_LOCAL_FALLBACK == '1'` → `18000000` (300 min), sotto il `timeout-minutes: 360` del job (300 + setup ollama + commit/deploy < 360).
- var non settata → invariato: 55 min (frontaliere) / 30 min (svizzera). **Default behaviour unchanged.**

- `python yaml` + `actionlint` puliti.

## Non implementato (ancora)

Nessuno. La modifica è completa: cambia solo il valore del budget wall in modalità fallback-locale, gated sulla repo var.

Note di verifica (non scope residuo):
- **Tempo reale del path locale**: l'obiettivo della modifica è proprio misurarlo. Dopo il merge riattivo `ARTICLE_LOCAL_FALLBACK=1` e lancio un run, leggendo il tempo end-to-end e se il 7B arriva mai a un consensus-PASS con budget pieno. Esito → MEMORY.
- **Cadenza**: un run in modalità locale può durare fino a 300 min e il concurrency-group serializza → cadenza ridotta SOLO quando il var è ON (l'owner ha accettato i defer rari). Con var OFF nessun impatto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
