### PR TITLE
chore(ai-models): surface cacheHits in run summary

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1880,7 +1880,7 @@ export function printRunSummary() {
   const s = getStats();
   const lines = [
     `\n📊 AI Model Run Summary`,
-    `   Calls: ${s.calls} | Successes: ${s.successes} | Retries: ${s.retries} | Fallbacks: ${s.fallbacks}`,
+    `   Calls: ${s.calls} | Successes: ${s.successes} | Retries: ${s.retries} | Fallbacks: ${s.fallbacks} | Cache hits: ${s.cacheHits}`,
     `   Exhausted: ${s.exhausted} models [${s.exhaustedModels.join(', ') || 'none'}]`,
     `   Provider cooldowns: ${s.providerCooldowns}`,
   ];


### PR DESCRIPTION
## Implementato

- **`printRunSummary` ora stampa `Cache hits: N`** (`scripts/lib/ai-models.mjs`): la response-cache opt-in di #3074 traccia `_stats.cacheHits` ma non veniva mai stampata → effetto della cache invisibile nei log CI, non misurabile. Aggiunta alla riga summary esistente. Nessun cambio di comportamento, solo osservabilità.

Razionale: prima di decidere le leve di consumo più grosse su `generate-article` (frequenza cron / cap retry — il burner #1), serve poter **misurare** l'effetto reale della cache su un run vero. Questo lo abilita.

## Non implementato (ancora)

- **Leve di consumo su `generate-article` (cron 48/giorno + cap amplificazione fact-check×min-words)** — sono il taglio dominante ma un tradeoff qualità/volume da decidere dall'owner con i dati di `Cache hits` alla mano (deciso esplicitamente: prima misurare, poi agire). **Next step:** rivalutare dopo aver osservato i `Cache hits` su una run reale di generate-article.
- **3 nit adversarial su #3079** (gh `--paginate` >30 review, proceed-safe su crash step, over-exclusion marker reviewer) — minori, non funnel-critical. **Next step:** follow-up opzionale se emergono in pratica.