### PR TITLE
fix(seo-gate): events get own text-html-ratio bucket + reseed workflow

### DIFF
--- a/.github/workflows/seed-text-html-ratio-baseline.yml
+++ b/.github/workflows/seed-text-html-ratio-baseline.yml
@@ -1,0 +1,118 @@
+name: Seed text-html-ratio baseline
+
+# One-shot helper workflow: regenerates data/text-html-ratio-baseline.json
+# against the latest deployed dist/ (downloaded from the most recent
+# `github-pages` artifact) and uploads the JSON as an artifact.
+#
+# Why this exists
+# ---------------
+# `audit-text-html-ratio` is a per-feature ratchet. When a new markup-heavy
+# feature ships (Ticino events hub + per-comune pages, statistics/author
+# pages), its low text-to-HTML-ratio pages land in the `spa-locale`/`spa-other`
+# catch-all buckets and trip the ratchet even though the pages are legitimate.
+# The companion classifier fix (this PR) routes events into their own `eventi`
+# bucket; this workflow then recomputes the baseline against a real prod dist
+# so every bucket (the new `eventi` one included) gets accurate counts.
+#
+# Mirrors `seed-title-baselines.yml` / `seed-bfs-depth-baseline.yml` exactly.
+#
+# Usage
+# -----
+# 1. Trigger via "Run workflow" (workflow_dispatch) ON THIS BRANCH so the run
+#    uses the updated classifier (the `eventi` bucket only exists here).
+# 2. Download the `text-html-ratio-baseline-${{ github.run_id }}` artifact.
+# 3. Replace, commit, push:
+#       cp /tmp/text-html-ratio-baseline.json data/
+#       git add data/text-html-ratio-baseline.json
+#       git commit -m "chore(seo-gate): reseed text-html-ratio baseline (eventi bucket)"
+#       git push
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_run_id:
+        description: 'deploy.yml run id whose github-pages dist to audit. Leave empty to use the latest successful deploy.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund --prefer-offline
+
+      - name: Resolve deploy run id
+        id: latest
+        run: |
+          run_id="${{ inputs.deploy_run_id }}"
+          if [ -z "$run_id" ]; then
+            run_id=$(gh run list \
+              --workflow=deploy.yml \
+              --status=success \
+              --limit=1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+          fi
+          echo "Using deploy run: $run_id"
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download github-pages artifact from latest deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/gh-pages-artifact dist
+          gh run download ${{ steps.latest.outputs.run_id }} \
+            --name "github-pages" \
+            --dir /tmp/gh-pages-artifact/
+          ls -lh /tmp/gh-pages-artifact/
+
+      - name: Extract dist/
+        run: |
+          tar -xf /tmp/gh-pages-artifact/artifact.tar -C dist
+          echo "Total HTML files:"
+          find dist -name '*.html' | wc -l
+
+      - name: Generate text-html-ratio baseline
+        run: |
+          node scripts/audit-text-html-ratio.mjs \
+            --write-baseline=data/text-html-ratio-baseline.json
+          echo ""
+          echo "==== text-html-ratio baseline preview (byFeature) ===="
+          node -e "const b=require('./data/text-html-ratio-baseline.json');console.log(JSON.stringify({mode:b.mode,threshold:b.threshold,scanned:b.scanned,totalOffenders:b.totalOffenders,byFeature:b.byFeature},null,2))"
+
+      - name: Upload baseline
+        uses: actions/upload-artifact@v7
+        with:
+          name: text-html-ratio-baseline-${{ github.run_id }}
+          path: data/text-html-ratio-baseline.json
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Echo download instructions
+        run: |
+          echo "════════════════════════════════════════════════════════════════"
+          echo "Baseline generated. Next steps:"
+          echo "  gh run download ${{ github.run_id }} \\"
+          echo "    --name text-html-ratio-baseline-${{ github.run_id }} --dir /tmp/"
+          echo "  cp /tmp/text-html-ratio-baseline.json data/"
+          echo "  git add data/text-html-ratio-baseline.json"
+          echo "  git commit -m 'chore(seo-gate): reseed text-html-ratio baseline (eventi bucket)'"
+          echo "  git push"
+          echo "════════════════════════════════════════════════════════════════"

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -82,6 +82,12 @@ function classifyFeature(relPath) {
   if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane|tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/(?:^|\/)(?:meteo-frontalieri|commute-weather|pendler-wetter|meteo-frontaliers|allerte-meteo|weather-alerts|wetter-warnungen|alertes-meteo)\//.test(p)) return 'weather';
+  // Ticino events hub + per-comune pages (all 4 locale section slugs). These are
+  // inherently markup-heavy (event cards + Event JSON-LD + maps) with a low
+  // text-to-HTML ratio, exactly like border-wait/fuel-daily/weather. Give them
+  // their own ratchet bucket so they don't pollute the spa-locale/spa-other
+  // catch-all (same classifier-drift class as #2853/#2910 fuel/svizzera leaks).
+  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }


### PR DESCRIPTION
Third and final post-deploy gate failure from deploy run 28382578734 (after #3052 noindex/cathedral and #3084 validate-live/sitemap-news).

## Implementato

**validate-dist → `audit:all`/`text-html-ratio` ratchet** (`spa-locale 0→59`, `spa-other 2→23`):
- Root cause **confirmed** via an `audit-dist-from-run` replay (run 28389181103) on the failed deploy's dist: the offenders are the Ticino **events** pages — hub `/eventi/ticino/` + per-comune `/eventi/ticino/{comune}/` and their `/en|/de|/fr` variants (e.g. `/en/events/ticino/lugano/`, `/de/veranstaltungen/tessin/airolo/`). They are inherently markup-heavy (event cards + Event JSON-LD + maps), ~6–9% text/HTML ratio, and were falling into the **catch-all** `spa-locale`/`spa-other` buckets — the exact classifier-drift class as #2853/#2910 (fuel/svizzera leaks into the spa-locale ratchet).
- `scripts/audit-text-html-ratio.mjs`: classify the events section (all four locale slugs — `eventi/ticino`, `events/ticino`, `veranstaltungen/tessin`, `evenements/tessin`) into a dedicated **`eventi`** bucket, exactly like `border-wait`/`fuel-daily`/`weather` already are. Events stop polluting the catch-all, so `spa-locale`/`spa-other` fall back toward their real (non-events) counts. Verified the rule matches every locale path and leaves `/en/cross-border-articles/…` (spa-locale) and `/statistiche/…` (spa-other) untouched; `audit-text-html-ratio-rate-gate.test.ts` (5/5) green.
- `.github/workflows/seed-text-html-ratio-baseline.yml`: one-shot reseed helper (mirrors `seed-title-baselines.yml`) — downloads a prod dist (`deploy_run_id` input) and runs the audit with `--write-baseline` so every bucket, the new `eventi` one included, gets accurate counts. Reusable infra (none existed for this gate before).

## Non implementato (ancora)

- **Regenerated `data/text-html-ratio-baseline.json`** (with the `eventi` bucket + corrected `spa-locale`/`spa-other` counts): the seed workflow can only be dispatched **once it is on the default branch** (GitHub `workflow_dispatch` limitation), and a correct linux/prod baseline can only be computed in CI against a real dist (local full-dist audit is OOM-prone). **Next step (concatenated):** on merge, dispatch `seed-text-html-ratio-baseline.yml` with `deploy_run_id=<latest deploy>` → download the artifact → open a follow-up PR committing the regenerated baseline. Until that lands, the `eventi` bucket has no baseline entry and the gate stays red on it — harmless, since validate-dist is post-deploy and **rollback is disabled** (`if: false` since 2026-06-12), so no deploy is reverted. This PR does NOT close the task; the baseline PR does.