### PR TITLE
fix(ci): stop redundant Claude reviews on autorebase main-merges

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -99,8 +99,23 @@ jobs:
           if [ -z "$code" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Delta dall'ultima LGTM = SOLO data/docs (nessun code) → skip Claude; LGTM carry-forward (fingerprint code-only), vitest gira comunque."
+            exit 0
+          fi
+          # Il compare 2-dot last...HEAD vede ANCHE il code che main ha portato in
+          # un rebase di solo main-merge — ma quel code NON è il contributo della
+          # PR, che resta invariato. Confronta allora il FINGERPRINT del contributo
+          # (3-dot vs merge-base con main, code-only) a HEAD vs all'ultima LGTM: se
+          # uguale, la PR non ha cambiato il proprio code (es. autorebase ha solo
+          # mergiato main) → skip Claude. Stessa funzione che auto-merge-eval usa
+          # per il carry-forward dell'LGTM → niente drift. NULL/incerto → review
+          # piena (conservativo). vitest gira comunque sull'head (safety net).
+          fpHead=$(node scripts/ci/pr-contribution-fingerprint.mjs "$HEAD_SHA" 2>/dev/null || echo NULL)
+          fpLast=$(node scripts/ci/pr-contribution-fingerprint.mjs "$last" 2>/dev/null || echo NULL)
+          if [ -n "$fpHead" ] && [ "$fpHead" != "NULL" ] && [ "$fpHead" = "$fpLast" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Contributo CODE invariato dall'ultima LGTM (fingerprint $fpHead) — solo main-merge nel delta → skip Claude; LGTM carry-forward, vitest gira comunque."
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Code cambiato dall'ultima LGTM → review piena."
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "Code del contributo cambiato dall'ultima LGTM (fpHead=$fpHead fpLast=$fpLast) → review piena."
           fi
 
       - name: Determine review tier

--- a/scripts/ci/auto-merge-eval.mjs
+++ b/scripts/ci/auto-merge-eval.mjs
@@ -92,7 +92,7 @@ function notifyAwaitingVitest(pr) {
  * Conservativo: qualunque incertezza (compare troncato, patch mancanti su file
  * grossi, errore API) → ritorna null → niente carry-forward (stale come prima).
  */
-function prContributionFingerprint(sha) {
+export function prContributionFingerprint(sha) {
   let mb;
   try {
     mb = gh(['api', `repos/${REPO}/compare/main...${sha}`, '--jq', '.merge_base_commit.sha'],

--- a/scripts/ci/pr-autorebase.mjs
+++ b/scripts/ci/pr-autorebase.mjs
@@ -8,11 +8,17 @@
  * porti avanti l'`## LGTM` esistente (il contributo proprio della PR è invariato
  * su un rebase di solo main-merge). Tocchiamo solo le PR "near-merge".
  *
- * NB sul trigger: un push PAT su un branch PR NON ri-triggera in modo
- * affidabile i workflow `pull_request` (osservato: head rebasati di #1587/#1526
- * con zero check-run) — per questo dispatchiamo tests.yml esplicitamente invece
- * di affidarci al push. Questo evita anche di bruciare quota Claude: nessuna
- * review Opus/Sonnet riparte sul rebase.
+ * NB sul trigger: il push del rebase si autentica via App/PAT (x-access-token) e
+ * RI-TRIGGERA i workflow `pull_request` — incluso `pr-review-loop`, che con
+ * `cancel-in-progress` cancella la review in corso. Per NON bruciare quota Claude
+ * né innescare un livelock, (a) dispatchiamo comunque tests.yml esplicitamente
+ * (più affidabile di affidarsi al push per il solo vitest) e (b) **defer del
+ * rebase finché una review è in volo** (vedi reviewInProgress): rebasare mentre la
+ * review gira la cancella, e con main caldo non concluderebbe mai (la PR
+ * collision-risk va behind a ogni tick) → niente `## LGTM`, niente merge.
+ * (Storico: il claim "push PAT non ri-triggera pull_request" su #1587/#1526 era
+ * uno zero-check-run da rebase pre-#1597 che non dispatchava, non l'assenza di
+ * trigger; il push autenticato App/PAT ri-triggera, osservato su #3038.)
  *
  * Per ogni PR OPEN non-draft:
  *   GATE (frugalità): procedi solo se "near-merge" =
@@ -218,6 +224,25 @@ function vitestFailureIsTransient(head) {
     ['api', `repos/${REPO}/commits/${head}/check-runs?per_page=100`],
     { json: true, allowFail: true });
   return vitestFailureIsTransientCancellation(out && out.check_runs);
+}
+
+/** C'è una review Claude (`pr-review-loop`, check-run `review`) ANCORA in volo
+ * sull'head (status `queued`/`in_progress`)? Il push del rebase si autentica via
+ * App/PAT (x-access-token) e quindi RI-TRIGGERA `pull_request` → `pr-review-loop`
+ * ha `cancel-in-progress: true` → il nostro push CANCELLA la review in corso e ne
+ * avvia un'altra. Con main caldo (commit ogni pochi minuti) e una review da
+ * ~8-11min, una PR collision-risk va `behind>0` a metà review, l'autorebase la
+ * rebasa, il push cancella la review, che riparte → LIVELOCK: la review non
+ * conclude mai, l'`## LGTM` non viene mai postato, niente merge (e quota Claude
+ * bruciata a ogni restart). Difesa: se una review è in volo, DEFER il rebase di un
+ * tick (come ACTIVITY_GUARD). Il rebase non è urgente (main è sempre fresco); la
+ * review conclude, posta il verdetto, e auto-merge-eval porta avanti l'LGTM. */
+function reviewInProgress(head) {
+  const out = gh(
+    ['api', `repos/${REPO}/commits/${head}/check-runs?per_page=100`,
+      '--jq', '[.check_runs[] | select(.name == "review" and (.status == "in_progress" or .status == "queued"))] | length'],
+    { json: false, allowFail: true });
+  return (parseInt((out || '0').trim(), 10) || 0) > 0;
 }
 
 /**
@@ -498,6 +523,18 @@ async function processPR(pr) {
     return;
   }
   console.log(`PR #${num} (${branch}) è ${behind} dietro main, near-merge → valuto rebase.`);
+
+  // Review-in-flight guard: NON rebasare mentre una review Claude è in volo
+  // sull'head. Il push del rebase (App/PAT) ri-triggera pr-review-loop, che con
+  // cancel-in-progress CANCELLA la review in corso e la riavvia → con main caldo
+  // la review non conclude mai (livelock; quota bruciata). Defer di un tick: la
+  // review conclude, posta il verdetto, auto-merge-eval porta avanti l'LGTM. Il
+  // rebase non è urgente (main è sempre fresco). NB: l'orphan-heal sopra dispatcha
+  // solo tests (no push), quindi non è soggetto a questa race.
+  if (reviewInProgress(head)) {
+    console.log(`PR #${num}: review Claude in volo sull'head ${head.slice(0, 8)} — skip rebase questo tick (un push ora la cancellerebbe; defer finché conclude).`);
+    return;
+  }
 
   // Activity-guard: se l'head è stato pushato pochi minuti fa, un contributor/
   // agent è probabilmente mid-flight (sta ancora pushando fix su una PR LGTM'd).

--- a/scripts/ci/pr-contribution-fingerprint.mjs
+++ b/scripts/ci/pr-contribution-fingerprint.mjs
@@ -1,0 +1,36 @@
+/**
+ * pr-contribution-fingerprint.mjs — stampa un hash STABILE del contributo CODE
+ * di una PR a un dato SHA (zero-Claude, sola compare API).
+ *
+ * Riusa ESATTAMENTE `prContributionFingerprint` di auto-merge-eval.mjs (3-dot vs
+ * merge-base con main, code-only, invariante alla churn di main) così che il
+ * re-review guard di `pr-review-loop.yml` e il carry-forward dell'LGTM di
+ * auto-merge-eval decidano "contributo invariato" con LA STESSA semantica — niente
+ * drift by-construction (AGENTS.md #6).
+ *
+ * Uso:  node scripts/ci/pr-contribution-fingerprint.mjs <sha>
+ *   stdout: sha256 esadecimale del fingerprint, oppure `NULL` se non calcolabile
+ *           (compare troncato/errore/file grandi → bail conservativo: il guard NON
+ *           deve skippare la review su un NULL).
+ * Env:  GH_TOKEN (read-only), GITHUB_REPOSITORY.
+ *
+ * Confronto nel guard: fingerprint(HEAD) === fingerprint(last-LGTM-commit) ⇒ il
+ * contributo della PR è identico (es. rebase di solo main-merge) ⇒ skip Claude.
+ */
+import { createHash } from 'node:crypto';
+import { prContributionFingerprint } from './auto-merge-eval.mjs';
+
+const sha = process.argv[2];
+if (!sha) {
+  console.error('uso: node scripts/ci/pr-contribution-fingerprint.mjs <sha>');
+  process.exit(2);
+}
+
+const fp = prContributionFingerprint(sha);
+if (fp == null) {
+  // null = incertezza (compare troncato/errore): emetti NULL così il guard cade
+  // sul ramo conservativo (review piena), mai uno skip su fingerprint inaffidabile.
+  process.stdout.write('NULL\n');
+} else {
+  process.stdout.write(createHash('sha256').update(fp).digest('hex') + '\n');
+}

--- a/tests/auto-merge-eval-fingerprint.test.ts
+++ b/tests/auto-merge-eval-fingerprint.test.ts
@@ -6,7 +6,7 @@
  * (token-lever #1). Un file dati grosso senza `.patch` NON deve forzare il bail.
  */
 import { describe, it, expect } from 'vitest';
-import { codeContributionFingerprint, NON_REVIEWABLE_FINGERPRINT_RE } from '../scripts/ci/auto-merge-eval.mjs';
+import { codeContributionFingerprint, NON_REVIEWABLE_FINGERPRINT_RE, prContributionFingerprint } from '../scripts/ci/auto-merge-eval.mjs';
 
 type F = { filename: string; status: string; patch?: string };
 
@@ -51,5 +51,13 @@ describe('codeContributionFingerprint (code-only carry-forward)', () => {
     for (const p of ['scripts/x.mjs', 'build-plugins/y.ts', 'components/z.tsx']) {
       expect(NON_REVIEWABLE_FINGERPRINT_RE.test(p)).toBe(false);
     }
+  });
+
+  // Il re-review guard di pr-review-loop.yml (via scripts/ci/pr-contribution-
+  // fingerprint.mjs) RIUSA questa funzione per decidere "contributo invariato →
+  // skip Claude" con la STESSA semantica del carry-forward (no drift, AGENTS.md
+  // #6). Se l'export sparisse, il CLI fallirebbe a runtime nel guard.
+  it('prContributionFingerprint resta esportata (riuso dal re-review guard CLI)', () => {
+    expect(typeof prContributionFingerprint).toBe('function');
   });
 });


### PR DESCRIPTION
## Implementato

Riduce le review Claude ridondanti che un rebase di autorebase fa ripartire su una PR il cui **contributo è invariato** (solo `git merge origin/main`). Due guard complementari.

**Causa radice:** `pr-autorebase` pusha il rebase via App token (`x-access-token`), che — a differenza del `GITHUB_TOKEN` di default (soppresso dall'anti-ricorsione) — **ri-triggera** i workflow `pull_request`. Quindi ogni rebase fa ripartire `pr-review-loop`. Con `cancel-in-progress` + main caldo, una PR `collision-risk` (che per mergiare deve essere 0-behind) viene rebasata a ogni avanzamento di main, la review è cancellata a metà e riavviata → può livelockare senza mai postare un verdetto (osservato su #3038), bruciando quota a ogni ciclo.

- **Part A — `pr-autorebase.mjs`**: defer del rebase finché un check `review` Claude è `in_progress` sull'head (nuovo `reviewInProgress()`, stessa forma di `ACTIVITY_GUARD`). Il push cancellerebbe la review in corso; deferire di un tick la lascia concludere e postare `## LGTM`/🔴 (poi `auto-merge-eval` porta avanti l'LGTM). Sblocca il livelock **pre-LGTM**.
- **Part B — `pr-review-loop.yml`**: il re-review guard ora skippa Claude anche quando il **fingerprint del contributo CODE** (3-dot vs merge-base con main, code-only) è invariato dall'ultima LGTM, non solo quando il delta 2-dot è data-only. Un rebase di solo main-merge cambia il delta 2-dot (code di main) ma non il contributo → la review ripartiva a vuoto; ora fa carry-forward. Riusa il fingerprint ESATTO di `auto-merge-eval` via un CLI sottile (`scripts/ci/pr-contribution-fingerprint.mjs`) → stessa semantica del carry-forward LGTM, niente drift (AGENTS.md #6). vitest gira comunque su ogni head (safety net di correttezza).
- **Fix commento stale** in `pr-autorebase.mjs` che affermava il contrario (push App/PAT non ri-triggera `pull_request`) — lo fa, è il meccanismo stesso.
- **Test**: guardia di regressione sull'export `prContributionFingerprint` (riuso dal CLI del guard). Suite fingerprint + autorebase-action verdi (14 test).

**Trigger graph (invariato, su cui si appoggia):** `tests.yml` ha `workflow_dispatch`; `auto-merge-on-lgtm` fira su `workflow_run`(tests completed) + `pull_request_review` → vitest + carry-forward LGTM continuano a portare al merge dopo una review skippata.

## Non implementato (ancora)

- Nessuno. La classe "review ridondante su rebase" è chiusa sia pre-LGTM (Part A) sia post-LGTM (Part B). I candidati `check-sibling-patterns` sono falsi positivi su token generici (`auto-merge-eval` come nome-script referenziato, `allowFail`/`HEAD_SHA`): la logica fingerprint è già centralizzata in `auto-merge-eval` e riusata, non duplicata.
- Nota su `pr-review-loop.yml`: la PR tocca un `REVIEW_WORKFLOW_DRIFT_FILE` → la sua review Claude può fallire la validation (401, App esige byte-identico a main) e l'auto-merge passa dal drift-fallback deterministico di `auto-merge-eval` (vitest + collision). Atteso, non un blocker.
