### PR TITLE
fix(jobboard): extend firstPaintEligible guard to editorial landings on TI

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -2347,15 +2347,18 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // first-page asset is recency-ordered/TI-dominant — painting it for, say,
  // /cerca-lavoro-zurigo/ would flash mostly-TI cards before the scoped set.
  //
- // Also skipped for any FILTERED view (active search / company / location): the
- // slim first-page is a recency-ordered generic payload, so filtering it yields
- // a misleading provisional count + fallback banner (e.g. "1 offerta", then "0",
- // then the real "34") before the authoritative shard lands. Holding the
+ // Also skipped for any FILTERED view (active search / company / location) or
+ // EDITORIAL LANDING (e.g. /cerca-lavoro-ticino/ultimi-3-giorni/, today landing): the
+ // slim first-page is a recency-ordered generic payload, so filtering it (or rendering
+ // it under an editorial subset) yields a misleading provisional count + fallback
+ // banner (e.g. "1 offerta", then "0", then the real "34") before the authoritative
+ // shard lands. (editorialLandingDescriptor is declared below via useMemo; this effect
+ // closure reads it after render, so it is bound.) Holding the
  // jobsLoading skeleton (hero + skeleton cards, same LCP element) until the full
  // load is cleaner and avoids that flash; the unfiltered listing keeps the paint.
  const firstPaintEligible =
  !seededJob &&
- !searchQuery.trim() && !companySlugFilter && !locationSlugFilter &&
+ !searchQuery.trim() && !companySlugFilter && !locationSlugFilter && !editorialLandingDescriptor &&
  (targetCanton === AGGREGATE_CANTON_CODE || targetCanton === 'TI');
  if (firstPaintEligible) {
  const firstPage = await loadFirstPageSlim();


### PR DESCRIPTION
## Implementato
- Aggiunto `!editorialLandingDescriptor` alla congiunzione `firstPaintEligible` in `components/community/JobBoard.tsx` (load effect, ~L2358): lo slim first-page fast paint (#2580) ora è skippato anche sulle editorial landing TI (es. `/cerca-lavoro-ticino/ultimi-3-giorni/`, today landing), non solo su search/company/location come dopo #2927.
- Motivazione: lo slim payload è una lista recency-ordered *unfiltered*; renderla sotto una editorial subset mostrava un count provvisorio sbagliato (es. "1 offerta" → "0" → "34") prima che lo shard autoritativo atterrasse → CLS + impatto RPM. Ora la editorial view tiene lo skeleton `jobsLoading` fino al full load, identico agli altri filtered view.
- Aggiornato il commento esplicativo sopra la guard per includere le editorial landing e annotare che `editorialLandingDescriptor` (useMemo dichiarato più sotto) è letto dalla closure dell'effect dopo il render, quindi è già bound a runtime (nessun TDZ).

## Non implementato (ancora)
Nessuno. `firstPaintEligible` è l'unico costrutto first-paint-guard nel codebase (grep: solo `JobBoard.tsx`); i 10 file segnalati da `check-sibling-patterns.mjs` condividono solo il token generico `searchQuery`, non l'antipattern → falsi positivi. Le aggregate recency landings citate nell'issue non esistono ancora (`weeklyEmployersPlugin.ts`), quindi non c'è guard gemella da estendere.

Closes #2928