### PR TITLE
fix(crawler): RUAG discovery passes Airlock cookie wall + self-heals seeds

### DIFF
--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -560,6 +560,78 @@ export async function fetchHtml(url, options = {}) {
 }
 
 /**
+ * Fetch HTML while persisting cookies across the redirect chain.
+ *
+ * Native `fetch` follows redirects automatically but DROPS Set-Cookie between
+ * hops (it has no cookie jar), so it cannot clear cookie-challenge WAFs. The
+ * Airlock Gateway "AL_CHK" cookie-check fronting Swiss defense/gov sites such as
+ * www.ruag.ch sets a cookie and 307-redirects to /cookie-check; without the
+ * cookie resent on the follow-up hop the chain dead-ends at HTTP 400 (so the
+ * facet listing yields zero links). This helper follows redirects MANUALLY with
+ * a per-attempt cookie jar, resending accumulated cookies on each hop exactly as
+ * a browser would, so the challenge completes and the real page is returned.
+ *
+ * Use it for listing/index fetches behind such a challenge. fetchHtml() stays
+ * the default for plain pages — it also carries the Jina IP-block fallback this
+ * helper deliberately omits (a cookie wall is not an IP-reputation block).
+ *
+ * @param {string} url
+ * @param {Object} [options] — { timeoutMs, headers, maxRedirects }
+ */
+export async function fetchHtmlWithCookies(url, options = {}) {
+  const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const maxRedirects = options.maxRedirects ?? 8;
+  return fetchWithRetry(async () => {
+    const jar = new Map();
+    let currentUrl = url;
+    for (let hop = 0; hop <= maxRedirects; hop += 1) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let res;
+      try {
+        const cookieHeader = jar.size
+          ? [...jar.entries()].map(([name, value]) => `${name}=${value}`).join('; ')
+          : undefined;
+        res = await fetch(currentUrl, {
+          method: 'GET',
+          redirect: 'manual',
+          headers: {
+            'User-Agent': DEFAULT_UA,
+            Accept: 'text/html,application/xhtml+xml',
+            ...options.headers,
+            ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+          },
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+      // Absorb every Set-Cookie into the jar so the next hop resends them.
+      for (const cookie of res.headers.getSetCookie?.() ?? []) {
+        const nameValue = cookie.split(';')[0];
+        const eqIdx = nameValue.indexOf('=');
+        if (eqIdx > 0) jar.set(nameValue.slice(0, eqIdx).trim(), nameValue.slice(eqIdx + 1).trim());
+      }
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location');
+        await res.arrayBuffer().catch(() => {}); // drain body to free the socket
+        if (!location) break;
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+      if (!res.ok) {
+        const err = new Error(`HTTP ${res.status} from ${currentUrl}`);
+        err.status = res.status;
+        err.retryable = RETRYABLE_STATUS.has(res.status);
+        throw err;
+      }
+      return await res.text();
+    }
+    throw new Error(`Too many redirects (>${maxRedirects}) fetching ${url}`);
+  }, options);
+}
+
+/**
  * Terminal `.catch` handler for crawlers that run a CUSTOM main() instead of
  * runStandardCrawlerPipeline (which has its own connection-level guard).
  *

--- a/scripts/update-ruag-jobs.mjs
+++ b/scripts/update-ruag-jobs.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { extractStableJobId } from './lib/job-match-key.mjs';
-import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
+import { exitCrawlerOnError, fetchHtml, fetchHtmlWithCookies } from './lib/crawler-template.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -49,15 +49,19 @@ const COMPANY_DOMAIN = 'ruag.ch';
 const LISTING_URLS = [
   'https://www.ruag.ch/en/working-us/job-portal?f%5B0%5D=job_facet_workplace%3A310',
   'https://www.ruag.ch/de/arbeiten-bei-uns/job-portal?f%5B0%5D=job_facet_workplace%3A310',
-  'https://www.ruag.ch/it/lavorare-con-noi/portale-lavoro?f%5B0%5D=job_facet_workplace%3A310',
+  'https://www.ruag.ch/it/interested-career-ruag?f%5B0%5D=job_facet_workplace%3A310',
 ];
+// Cold-start fallback seeds only. Primary discovery is the facet listing above
+// (now behind the Airlock cookie wall — see discoverListingSeeds) plus the
+// last-known-good URLs read from the persisted slice in discoverRuagGraph, so
+// these self-heal each run. RUAG rotates detail-page UUIDs (expired postings
+// return 410), so this static list WILL drift; it exists purely to bootstrap a
+// fresh checkout whose slice is empty. Verified live 2026-06-29.
 const SEED_DETAIL_URLS = [
-  'https://jobs.ruag.ch/posizioni-aperte/apprendista-polimeccanico-a-afc-2026/8719425f-0598-427b-94ec-9d6a1189fe64',
-  'https://jobs.ruag.ch/offene-stellen/data-architect-space-c5i/e2fb49c3-9399-4dc9-8db3-172c6255a543',
-  'https://jobs.ruag.ch/offene-stellen/facility-office-manager/49bf3704-581a-43a6-a61b-e6995907530a',
-  'https://jobs.ruag.ch/offene-stellen/disposition-item-manager/9c1ebff5-de02-4068-a479-b64b91086a5f',
-  'https://jobs.ruag.ch/offene-stellen/technician-electrical/c684b90b-83f4-40b9-99b4-8f9afd171572',
-  'https://jobs.ruag.ch/offene-stellen/technician-maintenance/5b277eeb-bafc-4076-bb5e-21a1bcf71bbb',
+  'https://jobs.ruag.ch/offene-stellen/apprendista-operatore-in-automazione-afc-2026/c224bc01-8478-492d-8f40-a396baf066ce',
+  'https://jobs.ruag.ch/offene-stellen/facility-manager-networks-betriebselektrikerin-schwachstrom/8e281827-5c3f-44d8-a754-cf6caf198437',
+  'https://jobs.ruag.ch/offene-stellen/facility-manager-technics-betriebselektrikerin/190b7508-d7e8-403d-b49f-7c2f57a59965',
+  'https://jobs.ruag.ch/offene-stellen/assistentin-construction-management-west/81b4936b-bb5a-4a41-9298-336b3dc084a5',
 ];
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
@@ -128,19 +132,39 @@ async function discoverListingSeeds() {
   const discovered = new Set();
   for (const url of LISTING_URLS) {
     try {
-      const html = await fetchText(url, 12000);
+      // The www.ruag.ch facet listing sits behind an Airlock Gateway cookie
+      // challenge (AL_CHK → /cookie-check → back). Native fetch drops the
+      // challenge cookie across the redirect, dead-ending at HTTP 400, so use
+      // the cookie-jar fetch that completes the handshake like a browser.
+      const html = await fetchHtmlWithCookies(url, { timeoutMs: 12000 });
       for (const link of parseRuagListingLinks(html)) discovered.add(link);
     } catch {
-      // RUAG listing page currently returns 400 frequently; fallback graph discovery remains primary.
+      // A single locale listing can 404/4xx when RUAG renames a portal path;
+      // the other locales + persisted-slice seeds keep discovery alive.
     }
   }
   return [...discovered];
 }
 
+// Last-known-good detail URLs from the persisted slice. Each successful run
+// refreshes the slice, so these self-heal: dead (410) URLs are skipped during
+// the crawl while live ones re-seed the graph even if the listing format drifts.
+function readPersistedSeedUrls() {
+  const existing = readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS);
+  if (!Array.isArray(existing)) return [];
+  const urls = new Set();
+  for (const job of existing) {
+    const url = String(job?.url || job?.canonicalUrl || '').trim();
+    if (url.startsWith('https://jobs.ruag.ch/')) urls.add(url);
+  }
+  return [...urls];
+}
+
 async function discoverRuagGraph() {
   console.log('🔍 Discovering RUAG job detail pages...');
   const discoveredSeeds = await discoverListingSeeds();
-  const queue = [...new Set([...SEED_DETAIL_URLS, ...discoveredSeeds])];
+  const persistedSeeds = readPersistedSeedUrls();
+  const queue = [...new Set([...SEED_DETAIL_URLS, ...persistedSeeds, ...discoveredSeeds])];
   const seen = new Set();
   const details = [];
 

--- a/tests/crawler-fetch-retry.test.ts
+++ b/tests/crawler-fetch-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchJson, fetchHtml } from '../scripts/lib/crawler-template.mjs';
+import { fetchJson, fetchHtml, fetchHtmlWithCookies } from '../scripts/lib/crawler-template.mjs';
 
 function jsonResponse(status: number, body: unknown) {
   return {
@@ -85,6 +85,68 @@ describe('crawler fetch retry/backoff', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(fetchJson('https://example.test/api', { retries: 0, retryBaseMs: 0 })).rejects.toThrow(/HTTP 503/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function redirectResponse(status: number, location: string, setCookies: string[] = []) {
+  return {
+    ok: false,
+    status,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'location' ? location : null),
+      getSetCookie: () => setCookies,
+    },
+    arrayBuffer: async () => new ArrayBuffer(0),
+    text: async () => '',
+  } as unknown as Response;
+}
+
+function htmlResponseWithHeaders(status: number, body: string) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null, getSetCookie: () => [] },
+    text: async () => body,
+  } as unknown as Response;
+}
+
+describe('fetchHtmlWithCookies cookie-challenge handling', () => {
+  it('persists the challenge cookie across a redirect chain and returns the final page', async () => {
+    // Reproduces the Airlock "AL_CHK" cookie-check that fronts www.ruag.ch:
+    //   307 (sets cookie, → /cookie-check) → 307 (→ back) → 200 (real page).
+    const seen: Array<{ url: string; cookie: string | undefined; redirect: string | undefined }> = [];
+    const fetchMock = vi.fn(async (url: string, init: RequestInit & { redirect?: string }) => {
+      const cookie = (init.headers as Record<string, string> | undefined)?.Cookie;
+      seen.push({ url, cookie, redirect: init.redirect });
+      if (seen.length === 1) {
+        return redirectResponse(307, '/cookie-check?l=%2Fjobs', ['AL_CHK-S=token123; Path=/; Secure; HttpOnly']);
+      }
+      if (seen.length === 2) {
+        return redirectResponse(307, '/jobs');
+      }
+      return htmlResponseWithHeaders(200, '<html>jobs</html>');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const html = await fetchHtmlWithCookies('https://www.example.test/jobs', { retryBaseMs: 0 });
+    expect(html).toBe('<html>jobs</html>');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // First hop carries no cookie; later hops resend the absorbed challenge cookie.
+    expect(seen[0].cookie).toBeUndefined();
+    expect(seen[1].cookie).toContain('AL_CHK-S=token123');
+    expect(seen[2].cookie).toContain('AL_CHK-S=token123');
+    // Redirects are followed manually so cookies can be re-attached per hop.
+    expect(seen.every((s) => s.redirect === 'manual')).toBe(true);
+  });
+
+  it('throws on a hard 4xx without looping forever', async () => {
+    const fetchMock = vi.fn(async () => htmlResponseWithHeaders(404, ''));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchHtmlWithCookies('https://www.example.test/jobs', { retries: 0, retryBaseMs: 0 }),
+    ).rejects.toThrow(/HTTP 404/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Implementato

Root cause di #2951 (crawler RUAG rosso ad ogni run, da ~26/06): la discovery restituiva **0 detail pages** per due cause concomitanti, entrambe verificate live il 2026-06-29:

1. **Tutti i 6 seed detail hardcoded → HTTP 410** (annunci scaduti; RUAG ruota gli UUID delle detail page).
2. **Il listing `www.ruag.ch` è dietro la cookie-challenge Airlock Gateway** (`AL_CHK` → 307 `/cookie-check` → 307 back → 200). Il `fetch` nativo segue i redirect ma **scarta i `Set-Cookie` tra gli hop** (niente cookie-jar), quindi la challenge non si completa mai e la catena muore a HTTP 400 → 0 link dal listing.

Fix:
- **`scripts/lib/crawler-template.mjs`**: nuovo export `fetchHtmlWithCookies(url, opts)` che segue i redirect **manualmente** (`redirect: 'manual'`) con un cookie-jar per-tentativo, rimandando i cookie accumulati ad ogni hop come farebbe un browser → completa la challenge Airlock. Avvolto in `fetchWithRetry` (riusa la logica retry esistente).
- **`scripts/update-ruag-jobs.mjs`**:
  - `discoverListingSeeds()` usa `fetchHtmlWithCookies` sul listing facet (prima `fetchText` → bloccato dalla cookie wall).
  - nuova `readPersistedSeedUrls()` + `discoverRuagGraph()` ri-semina dalla **slice persistita** (`data/jobs/by-crawler/ruag-ag.json`, last-known-good URL) → **self-healing**: i 410 vengono saltati, i live ri-seminano il grafo anche se il listing cambia formato.
  - `SEED_DETAIL_URLS` rinfrescati a 4 URL **live** (solo cold-start; la durabilità viene da listing + slice).
  - URL listing IT corretto: era `/it/lavorare-con-noi/portale-lavoro` (404) → ora `/it/interested-career-ruag`.
- **`tests/crawler-fetch-retry.test.ts`**: 2 test nuovi sulla cookie-challenge (cookie ri-mandato cross-redirect e ritorno della pagina finale; hard-4xx che non cicla).

Validazione end-to-end live (no headless): listing EN+DE (cookie-jar) → 1 seed TI (Lodrino) → grafo via `similarLinks` → **5 detail page parse-ate correttamente** (titolo/location/descrizione/postedDate), quindi `all.length > 0` → niente throw. Test: `npx vitest run` sui 4 file fetch del crawler-template → **71+8 verdi**.

Sweep sibling (`node scripts/ci/check-sibling-patterns.mjs`): i candidati (`getSetCookie`/`cookieHeader`/`DEFAULT_UA`/`currentUrl`) sono **falsi positivi** — overlap lessicale, non la stessa classe di bug. marriott (session-cookie API), implenia (JSESSIONID+CSRF), microsoft/ubs/groupe-mutuel gestiscono già il cookie del **proprio** sito; nessun altro crawler colpisce `www.ruag.ch`. Non rifattorizzati (sarebbe refactor speculativo fuori scope).

Closes #2951

## Non implementato (ancora)

Nessuno. Lo scope dell'issue (ripristino discovery RUAG) è completo: cookie-wall risolto + seed self-healing + IT URL corretto + test. Note di tracking (non scope-residuo, non bloccano la chiusura):
- Il listing IT (`/it/interested-career-ruag`) ritorna 200 ma 0 link server-rendered (job caricati via JS); EN+DE coprono la discovery, gestito con `try/catch` graceful.
- I `SEED_DETAIL_URLS` hardcoded driftano di nuovo nel tempo by-design (RUAG ruota gli UUID); è atteso e mitigato dal self-healing via slice + listing, quindi non è un seed-rot che rompe il crawler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP4M9Y453n15kfojVtfnAA