### PR TITLE
fix(crawler): aldi-suisse via TYPO3 REST API (homepage SSR links gone)

### DIFF
--- a/scripts/lib/aldi-suisse-job-parser.mjs
+++ b/scripts/lib/aldi-suisse-job-parser.mjs
@@ -2,18 +2,23 @@
  * ALDI Suisse -- jobs.aldi.ch job parser
  *
  * ALDI Suisse uses SAP SuccessFactors as their ATS
- * (career5.successfactors.eu, company=HoferSELive). The careers page
- * at jobs.aldi.ch renders job cards via JavaScript but also includes
- * direct job detail URLs in the SSR HTML as /job/{id} paths.
+ * (career5.successfactors.eu, company=HoferSELive). The careers portal at
+ * jobs.aldi.ch is a TYPO3 site: it no longer server-renders `/job/{id}`
+ * links — the job list is loaded client-side from the JSON REST endpoint
+ * `${ALDI_SEARCH_API}` (each row carries city/zip/address/workload), and
+ * each detail page (`/job/{id}`) is server-rendered HTML whose job-specific
+ * body lives in `<div class="description">`.
  *
  * ALDI has stores across Ticino including locations in Lugano area,
  * Bellinzona, and other TI municipalities.
  *
  * Exports:
- *   parseAldiListingPage(html)     -- extract job links from listing page
+ *   parseAldiSearchResults(json)   -- extract job rows from the REST API
+ *   parseAldiListingPage(html)     -- (legacy) extract job links from SSR HTML
  *   parseAldiDetailPage(html)      -- extract job data from detail page
  *   isAldiTicinoJob(job)           -- filter for Ticino positions
  *   isAldiJob(job)                 -- match ALDI jobs in dataset
+ *   ALDI_SEARCH_API                -- TYPO3 REST job-search endpoint
  *   ALDI_SUCCESSFACTORS_BASE       -- SuccessFactors base URL
  */
 
@@ -24,6 +29,15 @@ export const ALDI_SUCCESSFACTORS_BASE = 'https://career5.successfactors.eu/caree
 
 /** ALDI Suisse job detail URL prefix */
 export const ALDI_JOB_BASE = 'https://www.jobs.aldi.ch';
+
+/**
+ * ALDI Suisse TYPO3 REST job-search endpoint.
+ * Returns `{ jobs: [{ url:'job/{id}', title, city, zip, address, shift_type,
+ * area_of_activity_title, career_level_title, sys_language_uid, ... }] }`.
+ * Replaces the dead SSR `/job/{id}` link scraping (the homepage no longer
+ * server-renders those anchors).
+ */
+export const ALDI_SEARCH_API = 'https://www.jobs.aldi.ch/rest/jobs/search';
 
 /** Ticino locations where ALDI operates */
 const TICINO_LOCATIONS = [
@@ -52,11 +66,65 @@ function stripHtml(html = '') {
 }
 
 /**
- * Extract job links from the ALDI Suisse listing page.
+ * Parse the ALDI Suisse TYPO3 REST job-search response (the live discovery
+ * path). The careers site no longer server-renders `/job/{id}` anchors; the
+ * job list is fetched client-side from {@link ALDI_SEARCH_API} as JSON.
  *
- * The homepage (jobs.aldi.ch) and the Italian version (/it) contain
- * carousel cards linking directly to job detail pages via /job/{numericId}.
- * It also has links to SuccessFactors for some positions.
+ * Each row already carries the canonical structured fields (city, zip,
+ * address, workload) so the detail page only needs to supply the prose body.
+ *
+ * @param {string|object} payload Raw JSON string or parsed `{ jobs: [...] }`.
+ * @returns {{ url: string, jobId: string, title: string, city: string,
+ *   zip: string, address: string, workload: string, areaTitle: string,
+ *   careerLevel: string, latitude: string, longitude: string, langUid: number }[]}
+ */
+export function parseAldiSearchResults(payload) {
+  let data = payload;
+  if (typeof payload === 'string') {
+    try {
+      data = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+  }
+  const rows = Array.isArray(data?.jobs) ? data.jobs : [];
+  const seen = new Set();
+  const results = [];
+  for (const j of rows) {
+    const rel = String(j?.url || '').trim();
+    if (!rel) continue;
+    const url = /^https?:\/\//i.test(rel)
+      ? rel
+      : `${ALDI_JOB_BASE}/${rel.replace(/^\/+/, '')}`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    // `shift_type`/`shift` hold the human percentage ("50 - 70%"); the numeric
+    // `workload` field is an internal relevance score, NOT a percentage.
+    results.push({
+      url,
+      jobId: String(j?.job_id ?? j?.rmk_id ?? '').trim(),
+      title: normalizeSpace(String(j?.title || '')),
+      city: normalizeSpace(String(j?.city || '')),
+      zip: String(j?.zip || '').trim(),
+      address: normalizeSpace(String(j?.address || '')),
+      workload: normalizeSpace(String(j?.shift_type || j?.shift || '')),
+      areaTitle: normalizeSpace(String(j?.area_of_activity_title || '')),
+      careerLevel: normalizeSpace(String(j?.career_level_title || '')),
+      latitude: String(j?.latitude || '').trim(),
+      longitude: String(j?.longitude || '').trim(),
+      langUid: Number.isFinite(j?.sys_language_uid) ? j.sys_language_uid : 0,
+    });
+  }
+  return results;
+}
+
+/**
+ * (Legacy) Extract job links from an ALDI Suisse SSR listing page.
+ *
+ * Kept for the historical carousel/SuccessFactors anchor shape and unit
+ * tests. The live careers site no longer ships these anchors — discovery now
+ * goes through {@link parseAldiSearchResults}. This remains a harmless
+ * fallback should ALDI ever re-introduce server-rendered job links.
  *
  * @param {string} html - Raw HTML of the listing page
  * @returns {{ url: string, title: string, location: string, percentage: string }[]}
@@ -137,19 +205,33 @@ export function parseAldiDetailPage(html = '') {
     percentage = normalizeSpace(pctMatch[1]);
   }
 
-  // Body
+  // Body — the live TYPO3 detail page wraps the job-specific sections
+  // (Aufgaben / Profil / Unser Angebot) in `<div class="description">` (a
+  // flat block, no nested <div>). Older fixtures used <main>/<article>/.content,
+  // kept here as fallbacks.
   let body = '';
-  const contentMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
+  const contentMatch = html.match(/<div[^>]*class="[^"]*\bdescription\b[^"]*"[^>]*>([\s\S]*?)<\/div>/i)
+    || html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
     || html.match(/<article[^>]*>([\s\S]*?)<\/article>/i)
     || html.match(/<div[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
 
-  if (contentMatch) {
-    body = stripHtml(contentMatch[1]);
+  const contentHtml = contentMatch ? contentMatch[1] : '';
+  if (contentHtml) {
+    body = stripHtml(contentHtml);
+  }
+
+  // Requirements — bullet items within the job content block.
+  const requirements = [];
+  const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let liMatch;
+  while ((liMatch = liRe.exec(contentHtml || html)) !== null) {
+    const text = normalizeSpace(stripHtml(liMatch[1]));
+    if (text.length > 5 && text.length < 300) requirements.push(text);
   }
 
   if (!title && !body) return null;
 
-  return { title, body, location, percentage };
+  return { title, body, location, percentage, requirements };
 }
 
 /**

--- a/scripts/update-aldi-suisse-jobs.mjs
+++ b/scripts/update-aldi-suisse-jobs.mjs
@@ -2,13 +2,15 @@
 /**
  * Dedicated ALDI Suisse crawler runner.
  *
- * ALDI uses SAP SuccessFactors as their ATS. Their careers portal is at
- * jobs.aldi.ch. The homepage contains direct job links at /job/{numericId}.
- * Each detail page is SSR HTML with full job descriptions.
+ * ALDI uses SAP SuccessFactors as their ATS, surfaced through a TYPO3 careers
+ * portal at jobs.aldi.ch. The portal no longer server-renders `/job/{id}`
+ * links — the job list is loaded client-side from the JSON REST endpoint
+ * (`/rest/jobs/search`), and each detail page keeps the job-specific body in
+ * `<div class="description">`.
  *
  * This crawler:
- *   1. Fetches the ALDI homepage and /it page for job detail URLs
- *   2. Fetches each detail page and parses title/description/location
+ *   1. Fetches the ALDI REST job-search API for job rows (url/city/zip/...)
+ *   2. Fetches each detail page and parses the description/requirements body
  *   3. Merges parsed jobs into data/jobs.json
  *   4. Runs localization + validation
  */
@@ -42,7 +44,12 @@ import {
   normalizeKey,
   mergePreserveLocaleData,
 } from './lib/dedicated-crawler-common.mjs';
-import { inferEmploymentType } from './lib/aldi-suisse-job-parser.mjs';
+import {
+  inferEmploymentType,
+  parseAldiSearchResults,
+  parseAldiDetailPage,
+  ALDI_SEARCH_API,
+} from './lib/aldi-suisse-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
@@ -58,11 +65,6 @@ const ALDI_KEY = 'aldi-suisse';
 const ALDI_COMPANY_NAME = 'ALDI SUISSE';
 const HQ = getCompanyDefaults(ALDI_KEY);
 const ALDI_HOST = 'www.jobs.aldi.ch';
-const ALDI_BASE = 'https://www.jobs.aldi.ch';
-const ALDI_LISTING_URLS = [
-  'https://www.jobs.aldi.ch/',
-  'https://www.jobs.aldi.ch/it',
-];
 
 /** Ticino city → postal code map for ALDI store locations */
 const TICINO_PLZ = {
@@ -86,21 +88,6 @@ function slugify(value = '') {
     .replace(/^-+|-+$/g, '')
     .replace(/-{2,}/g, '-')
     .slice(0, 180);
-}
-
-function stripHtml(html = '') {
-  return String(html || '')
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/\s+/g, ' ')
-    .trim();
 }
 
 /* -- Matchers ---------------------------------------------------------- */
@@ -144,61 +131,50 @@ function mergeCompanyJobs(parsedJobs) {
   return clean;
 }
 
-/* -- Discovery --------------------------------------------------------- */
-async function fetchAldiJobUrls() {
-  const allUrls = new Set();
+/* -- Discovery (REST API) --------------------------------------------- */
+async function fetchAldiListings() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
+  console.log(`\ud83d\udd0d Fetching ALDI Suisse jobs: ${ALDI_SEARCH_API}`);
 
-  for (const listUrl of ALDI_LISTING_URLS) {
-    console.log(`\ud83d\udd0d Fetching ALDI Suisse page: ${listUrl}`);
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(ALDI_SEARCH_API, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json', 'User-Agent': UA },
+      redirect: 'follow',
+    });
+    clearTimeout(timer);
 
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-      const res = await fetch(listUrl, {
-        signal: controller.signal,
-        headers: { Accept: 'text/html', 'User-Agent': UA },
-      });
-      clearTimeout(timer);
-
-      if (!res.ok) { console.warn(`\u26a0\ufe0f ALDI page returned ${res.status} for ${listUrl}`); continue; }
-
-      const html = await res.text();
-
-      const jobIdPattern = /href="(\/job\/\d+)"/gi;
-      let match;
-      while ((match = jobIdPattern.exec(html)) !== null) {
-        allUrls.add(`${ALDI_BASE}${match[1]}`);
-      }
-
-      const fullJobPattern = /href="(https?:\/\/[^"]*jobs\.aldi\.ch\/job\/\d+)"/gi;
-      while ((match = fullJobPattern.exec(html)) !== null) {
-        allUrls.add(match[1]);
-      }
-    } catch (err) {
-      console.warn(`\u26a0\ufe0f Failed to fetch ALDI page ${listUrl}: ${err.message}`);
+    if (!res.ok) {
+      console.warn(`\u26a0\ufe0f ALDI search API returned ${res.status}`);
+      return [];
     }
-  }
 
-  console.log(`\u2705 Discovered ${allUrls.size} ALDI Suisse job URLs`);
-  return [...allUrls];
+    const json = await res.json();
+    const listings = parseAldiSearchResults(json);
+    console.log(`\u2705 Discovered ${listings.length} ALDI Suisse jobs`);
+    return listings;
+  } catch (err) {
+    console.warn(`\u26a0\ufe0f Failed to fetch ALDI search API: ${err.message}`);
+    return [];
+  }
 }
 
 /* -- Detail page fetching & parsing ------------------------------------ */
-async function fetchAndParseDetailPages(urls) {
+async function fetchAndParseDetailPages(listings) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 15000;
   const concurrency = Number(process.env.JOBS_CRAWLER_CONCURRENCY) || 3;
   const jobs = [];
 
-  for (let i = 0; i < urls.length; i += concurrency) {
-    const batch = urls.slice(i, i + concurrency);
+  for (let i = 0; i < listings.length; i += concurrency) {
+    const batch = listings.slice(i, i + concurrency);
     const results = await Promise.allSettled(
-      batch.map(async (url) => {
+      batch.map(async (listing) => {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), timeoutMs);
         try {
-          const res = await fetch(url, {
+          const res = await fetch(listing.url, {
             signal: controller.signal,
             headers: { Accept: 'text/html', 'User-Agent': UA },
             redirect: 'follow',
@@ -206,7 +182,7 @@ async function fetchAndParseDetailPages(urls) {
           clearTimeout(timer);
           if (!res.ok) return null;
           const html = await res.text();
-          return { url, html };
+          return { listing, html };
         } catch {
           clearTimeout(timer);
           return null;
@@ -216,40 +192,24 @@ async function fetchAndParseDetailPages(urls) {
 
     for (const r of results) {
       if (r.status !== 'fulfilled' || !r.value) continue;
-      const { url, html } = r.value;
+      const { listing, html } = r.value;
 
-      const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
-      const rawTitle = h1Match ? stripHtml(h1Match[1]) : '';
-      if (!rawTitle || rawTitle.length < 5) continue;
+      const parsed = parseAldiDetailPage(html) || {};
+      const rawTitle = listing.title || parsed.title || '';
+      if (!rawTitle || rawTitle.length < 3) continue;
 
-      let location = '';
-      const locMatch = html.match(/(?:Standort|Sede|Location)\s*:?\s*([^<\n,]+)/i)
-        || html.match(/addressLocality['"]\s*:\s*['"]([^'"]+)/i);
-      if (locMatch) location = locMatch[1].trim();
+      // REST row holds the canonical structured fields; the detail page only
+      // supplies the prose body + bullet requirements.
+      let description = parsed.body || '';
+      if (description.length > 8000) description = description.slice(0, 8000);
+      const requirements = Array.isArray(parsed.requirements) ? parsed.requirements : [];
+      const location = listing.city || parsed.location || '';
+      const workPct = String(listing.workload || parsed.percentage || '').replace(/\s+/g, '');
 
-      let workPct = '';
-      const pctMatch = rawTitle.match(/(\d+\s*(?:-\s*\d+)?\s*%)/);
-      if (pctMatch) workPct = pctMatch[1].replace(/\s+/g, '');
-
-      let description = '';
-      const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
-        || html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
-      if (mainMatch) {
-        description = stripHtml(mainMatch[1]);
-        if (description.length > 8000) description = description.slice(0, 8000);
-      }
-
-      const requirements = [];
-      const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
-      let liMatch;
-      const mainHtml = mainMatch ? mainMatch[1] : html;
-      while ((liMatch = liRe.exec(mainHtml)) !== null) {
-        const text = stripHtml(liMatch[1]);
-        if (text.length > 10 && text.length < 300) requirements.push(text);
-      }
-
-      const urlHash = createHash('sha1').update(url).digest('hex').slice(0, 12);
+      const urlHash = createHash('sha1').update(listing.url).digest('hex').slice(0, 12);
       const jobSlug = slugify(`${rawTitle}-aldi-suisse`);
+      const canton = inferAnyCanton(location) || HQ.canton;
+      const postalCode = listing.zip || TICINO_PLZ[location.toLowerCase()] || HQ.postalCode || '';
 
       jobs.push({
         id: `aldi-suisse-${urlHash}`,
@@ -265,12 +225,12 @@ async function fetchAndParseDetailPages(urls) {
         requirements: requirements.slice(0, 20),
         requirementsByLocale: { it: requirements.slice(0, 20) },
         location,
-        postalCode: TICINO_PLZ[location.toLowerCase()] || '6928',
-        canton: inferAnyCanton(location) || HQ.canton,
-        addressLocality: location || 'Manno',
-        addressRegion: inferAnyCanton(location) || HQ.addressRegion,
+        postalCode,
+        canton,
+        addressLocality: location || HQ.city,
+        addressRegion: canton,
         addressCountry: 'CH',
-        streetAddress: 'Centro Monda 8',
+        streetAddress: listing.address || 'Centro Monda 8',
         employmentType: inferEmploymentType(rawTitle, description, workPct || ''),
         category: 'retail',
         contract: 'full-time',
@@ -278,9 +238,9 @@ async function fetchAndParseDetailPages(urls) {
         currency: 'CHF',
         featured: false,
         postedDate: new Date().toISOString().slice(0, 10),
-        url,
+        url: listing.url,
         source: 'ALDI Suisse Dedicated Parser',
-        sourceLang: detectLang(description || rawTitle, 'it'),
+        sourceLang: detectLang(description || rawTitle, 'de'),
         crawledAt: new Date().toISOString(),
       });
     }
@@ -299,14 +259,14 @@ async function main() {
 
     const _beforeSnapshot = snapshotJobSlugs(readExistingCrawlerJobs(ALDI_KEY, DATA_JOBS).filter(isAldiJob))
 
-  const detailUrls = await fetchAldiJobUrls();
-  if (detailUrls.length === 0) {
-    console.log('\u2139\ufe0f No ALDI Suisse job URLs discovered. Exiting OK.');
+  const listings = await fetchAldiListings();
+  if (listings.length === 0) {
+    console.log('\u2139\ufe0f No ALDI Suisse jobs discovered. Exiting OK.');
     return;
   }
 
-  console.log(`\ud83d\udd0d Fetching ${detailUrls.length} detail pages...`);
-  const parsedJobs = await fetchAndParseDetailPages(detailUrls);
+  console.log(`\ud83d\udd0d Fetching ${listings.length} detail pages...`);
+  const parsedJobs = await fetchAndParseDetailPages(listings);
   console.log(`\ud83e\udde9 Parsed ${parsedJobs.length} ALDI Suisse jobs from detail pages.`);
 
   if (parsedJobs.length === 0) {

--- a/tests/aldi-suisse-crawler.test.ts
+++ b/tests/aldi-suisse-crawler.test.ts
@@ -1,18 +1,84 @@
 /**
  * ALDI Suisse crawler parser tests
  *
- * Tests parseAldiListingPage(), parseAldiDetailPage(),
- * isAldiTicinoJob(), isAldiJob(), and constants.
+ * Tests parseAldiSearchResults(), parseAldiListingPage(),
+ * parseAldiDetailPage(), isAldiTicinoJob(), isAldiJob(), and constants.
  */
 import { describe, it, expect } from 'vitest';
 
 import {
+  parseAldiSearchResults,
   parseAldiListingPage,
   parseAldiDetailPage,
   isAldiTicinoJob,
   isAldiJob,
+  ALDI_SEARCH_API,
   ALDI_SUCCESSFACTORS_BASE,
 } from '@/scripts/lib/aldi-suisse-job-parser.mjs';
+
+// --- Fixture: live TYPO3 REST job-search response ---
+const SEARCH_JSON = {
+  jobs: [
+    {
+      rmk_id: '74455',
+      title: 'Mitarbeiter Verkauf (m/w/d)',
+      shift_type: '50 - 70%',
+      shift: '50 - 70%',
+      url: 'job/1271973201',
+      area_of_activity_title: 'Filialteam',
+      workload: 59,
+      career_level_title: 'Berufseinsteiger',
+      sys_language_uid: 0,
+      latitude: '47.10',
+      longitude: '9.06',
+      city: 'Näfels',
+      address: 'Oberdorf 54',
+      zip: '8752',
+      job_id: '1271973201',
+    },
+    {
+      rmk_id: '77113',
+      title: 'Filialleiter/in (m/w/d)',
+      shift_type: '100%',
+      url: 'job/1409127233',
+      area_of_activity_title: 'Filialteam',
+      sys_language_uid: 2,
+      city: 'Bellinzona',
+      address: 'Via Stazione 1',
+      zip: '6500',
+      job_id: '1409127233',
+    },
+    // duplicate URL — must be deduped
+    {
+      title: 'Mitarbeiter Verkauf (m/w/d) dup',
+      url: 'job/1271973201',
+      city: 'Näfels',
+      zip: '8752',
+      job_id: '1271973201',
+    },
+  ],
+};
+
+// --- Fixture: live TYPO3 detail page (description div) ---
+const DETAIL_TYPO3_HTML = `
+<html><body>
+  <h1 class="title">Mitarbeiter Verkauf (m/w/d)</h1>
+  <div class="profilecolumn"><b>ARBEITSORT</b> 8752 Näfels, Oberdorf 54</div>
+  <div class="shifttype">50 - 70%</div>
+  <div class="description">
+    <p><b>Aufgaben</b></p>
+    <ul>
+      <li>Warenbereitstellung</li>
+      <li>Kassieren und Kundenberatung</li>
+      <li>Reinigung der Filiale</li>
+    </ul>
+    <p><b>Profil</b></p>
+    <ul>
+      <li>Berufserfahrung im Verkauf</li>
+      <li>Gute Deutschkenntnisse</li>
+    </ul>
+  </div>
+</body></html>`;
 
 // --- Fixture: Homepage with /job/{id} links ---
 const LISTING_HTML = `
@@ -68,6 +134,54 @@ const DETAIL_HTML = `
 </main>
 </body>
 </html>`;
+
+// ===================================================================
+// parseAldiSearchResults (live REST discovery path)
+// ===================================================================
+
+describe('parseAldiSearchResults', () => {
+  it('extracts job rows from the REST payload', () => {
+    const rows = parseAldiSearchResults(SEARCH_JSON);
+    // 3 input rows, 1 duplicate URL → 2 unique
+    expect(rows.length).toBe(2);
+  });
+
+  it('builds absolute detail URLs from relative job/{id}', () => {
+    const rows = parseAldiSearchResults(SEARCH_JSON);
+    expect(rows[0].url).toBe('https://www.jobs.aldi.ch/job/1271973201');
+  });
+
+  it('carries the structured location fields (city/zip/address)', () => {
+    const rows = parseAldiSearchResults(SEARCH_JSON);
+    expect(rows[0].city).toBe('Näfels');
+    expect(rows[0].zip).toBe('8752');
+    expect(rows[0].address).toBe('Oberdorf 54');
+  });
+
+  it('uses shift_type as the human workload, not the numeric workload score', () => {
+    const rows = parseAldiSearchResults(SEARCH_JSON);
+    expect(rows[0].workload).toBe('50 - 70%');
+  });
+
+  it('deduplicates rows that share a URL', () => {
+    const rows = parseAldiSearchResults(SEARCH_JSON);
+    const naefels = rows.filter((r) => r.url.includes('1271973201'));
+    expect(naefels.length).toBe(1);
+  });
+
+  it('accepts a raw JSON string payload', () => {
+    const rows = parseAldiSearchResults(JSON.stringify(SEARCH_JSON));
+    expect(rows.length).toBe(2);
+  });
+
+  it('returns empty array for malformed / empty input', () => {
+    expect(parseAldiSearchResults('')).toEqual([]);
+    expect(parseAldiSearchResults('not json')).toEqual([]);
+    expect(parseAldiSearchResults(null)).toEqual([]);
+    expect(parseAldiSearchResults({})).toEqual([]);
+    expect(parseAldiSearchResults({ jobs: [] })).toEqual([]);
+  });
+});
 
 // ===================================================================
 // parseAldiListingPage
@@ -142,6 +256,22 @@ describe('parseAldiDetailPage', () => {
     expect(parseAldiDetailPage('')).toBeNull();
     expect(parseAldiDetailPage(null)).toBeNull();
   });
+
+  it('extracts the body from the live TYPO3 <div class="description">', () => {
+    const result = parseAldiDetailPage(DETAIL_TYPO3_HTML);
+    expect(result).not.toBeNull();
+    expect(result.title).toBe('Mitarbeiter Verkauf (m/w/d)');
+    expect(result.body).toContain('Aufgaben');
+    expect(result.body).toContain('Kassieren');
+    expect(result.body).toContain('Profil');
+  });
+
+  it('extracts bullet requirements from the description block', () => {
+    const result = parseAldiDetailPage(DETAIL_TYPO3_HTML);
+    expect(result.requirements.length).toBe(5);
+    expect(result.requirements).toContain('Warenbereitstellung');
+    expect(result.requirements).toContain('Gute Deutschkenntnisse');
+  });
 });
 
 // ===================================================================
@@ -208,5 +338,11 @@ describe('ALDI_SUCCESSFACTORS_BASE', () => {
   it('points to SuccessFactors with ALDI company', () => {
     expect(ALDI_SUCCESSFACTORS_BASE).toContain('successfactors');
     expect(ALDI_SUCCESSFACTORS_BASE).toContain('aldisuis');
+  });
+});
+
+describe('ALDI_SEARCH_API', () => {
+  it('points to the jobs.aldi.ch REST job-search endpoint', () => {
+    expect(ALDI_SEARCH_API).toBe('https://www.jobs.aldi.ch/rest/jobs/search');
   });
 });


### PR DESCRIPTION
## Causa

Il crawler `aldi-suisse` è `broken` (6 run consecutivi a 0 job). Scopriva i job scrapando `href="/job/{id}"` dalla homepage SSR di `jobs.aldi.ch`. ALDI ha migrato il portale carriere a **TYPO3**: la homepage **non server-renderizza più** quei link → `fetchAldiJobUrls()` ritorna 0 URL → 0 job → broken.

Verificato con `curl`:
- `https://www.jobs.aldi.ch/` → HTTP 200 ma **0** `href="/job/…"` (prima erano la sorgente).
- I job ora si caricano client-side dall'endpoint REST JSON `https://www.jobs.aldi.ch/rest/jobs/search` → **29 job** live con campi strutturati (`url`, `title`, `city`, `zip`, `address`, `shift_type`, lat/long, `sys_language_uid`).
- Il body job-specifico (Aufgaben/Profil/Unser Angebot) sul detail page vive in `<div class="description">` (TYPO3), **non** in `<main>`/`<article>` che il parser cercava → anche le descrizioni erano vuote.

## Implementato

- `scripts/lib/aldi-suisse-job-parser.mjs`:
  - Nuova `parseAldiSearchResults(json)` + costante `ALDI_SEARCH_API` (`/rest/jobs/search`): normalizza le row REST (url assoluto da `job/{id}`, dedup per URL, `shift_type` come workload umano — il campo numerico `workload` è uno score interno, non una %).
  - `parseAldiDetailPage`: estrae il body dal selettore reale `<div class="description">` (con fallback `<main>`/`<article>`/`.content`) e ritorna anche `requirements` (bullet `<li>`).
- `scripts/update-aldi-suisse-jobs.mjs`:
  - Discovery via REST (`fetchAldiListings`) al posto dello scraping homepage; rimossi `ALDI_LISTING_URLS`, `ALDI_BASE` e lo `stripHtml` locale ora morti.
  - `fetchAndParseDetailPages(listings)` usa i metadati strutturati REST per `location/postalCode/streetAddress/workPercentage` (niente più fallback errato a Manno/`6928` per i job fuori TI) e il detail page solo per descrizione/requisiti; `sourceLang` default `'de'` (i job sono DE).
- `tests/aldi-suisse-crawler.test.ts`: +8 test (`parseAldiSearchResults`: estrazione/URL-assoluti/city-zip-address/workload/dedup/JSON-string/input-malformato; detail TYPO3 `description` div + requirements; costante `ALDI_SEARCH_API`). Suite **33 passed**.

Dry-run live end-to-end: **29 job** scoperti, detail page con titolo reale + descrizione ~125 parole + 13-16 requisiti (nessun thin content <50 parole).

## Non implementato (ancora)

- Nessuno. Lo scope dell'issue (discovery rotta → 0 job) è interamente risolto e validato live.

## Note reviewer

- **Sibling sweep** (`node scripts/ci/check-sibling-patterns.mjs`): i candidati segnalati condividono solo token generici (`contentHtml`, `mainHtml`, `numericId` = nomi di variabili locali in parser di datori diversi; `aldi-suisse-job-parser` = solo una menzione nel docblock di `successfactors-client.mjs`). **Falsi positivi**: la classe di bug è specifica del portale TYPO3 di ALDI (homepage senza link SSR), nessun altro crawler scrapa `jobs.aldi.ch`.
- GitNexus impact `parseAldiDetailPage` (upstream): **LOW**, modifica additiva (`requirements`), unico consumer è il runner ALDI.

Closes #2964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP4M9Y453n15kfojVtfnAA