### PR TITLE
fix(crawler-health): dxt-commodities legittimamente vuoto, non broken

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -206,6 +206,17 @@ const EMPTY_OK_CRAWLERS = new Set([
   // open competitions right now; the selector is healthy and re-arms when a
   // listing reappears.
   'moncucco',
+  // DXT Commodities S.A. (Lugano, TI): the WordPress + WPSM accordion careers
+  // page (https://dxt.com/careers/) returns HTTP 200 with the full ~370 KB
+  // rendered page (166 panels) for the crawler's default desktop UA, but every
+  // location group (London, Lugano, Singapore, Stamford) currently holds a
+  // single placeholder panel reading "There are no open positions at the
+  // moment. Please check back." The energy/commodity trader (Duferco Group)
+  // legitimately has no Lugano openings right now; the WPSM parser correctly
+  // skips the no-positions placeholders and re-arms when a vacancy is
+  // published. Same legitimately-empty small-employer case as linnea and
+  // banca-raiffeisen-vedeggio-cassarate.
+  'dxt-commodities',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Contesto
Il monitor crawler-health ha flaggato `dxt-commodities` come **broken** (#2965) dopo 3+ run consecutivi a 0 job (ora 6).

## Diagnosi (curl reale su https://dxt.com/careers/)
- Con lo UA desktop di default del crawler (`Safari/17`): **HTTP 200**, pagina reale completa (~370 KB, **166 pannelli WPSM**, `<title>Opportunities - DXT Commodities</title>`). Il fetch funziona (anche `noUA`/`Googlebot`/`FrontaliereTicinoBot` → 200; solo un UA `Chrome/120` casuale prende 403 — il default usato dal crawler NON è bloccato).
- Eseguito il parser reale (`findLuganoAccordionIds` + `parseWpsmAccordionPanels`) contro l'HTML scaricato: trova il gruppo Lugano `24059` correttamente, ma **tutti e 4 i gruppi-località** (London `21045`, Lugano `24059`, Singapore `20961`, Stamford `24129`) contengono **un solo pannello placeholder**: _"There are no open positions at the moment. Please check back."_
- Storico health: `lastNonZeroJobs: 1`, ultimo successo 2026-06-21 → l'unica posizione Lugano residua è stata chiusa, da lì 0 job.

**Conclusione:** fetch e parser sono sani. DXT (trader energia/commodity, Gruppo Duferco) non ha aperture a Lugano in questo momento. È un **falso positivo** del monitor, non un crawler rotto.

## Implementato
- `scripts/check-crawler-health.mjs`: aggiunto `'dxt-commodities'` a `EMPTY_OK_CRAWLERS` con commento che documenta l'evidenza curl. È la **stessa classe** dei ~25 crawler già in allowlist (es. `linnea`, `banca-raiffeisen-vedeggio-cassarate`, `moncucco`): sorgente piccola che legittimamente ritorna 0 → empty fresco = `healthy`, `consecutiveEmptyRuns` resettato a 0, si ri-arma da solo quando ricompare una vacancy.

## Non implementato (ancora)
Nessuno. Lo scope dell'issue è chiuso: nessuna modifica a crawler/parser necessaria (entrambi sani), nessun sibling da sweepare (`scripts/ci/check-sibling-patterns.mjs` verde: l'aggiunta di una stringa a un Set non condivide costrutti con file gemelli). Lo stato runtime in `data/crawler-health.json` (generato) si auto-corregge al prossimo run giornaliero di `check-crawler-health.mjs` (emptyOk → healthy) — non va editato a mano.

## Test
- `npx vitest run tests/scripts/check-crawler-health.test.ts` → 13/13 ✓
- `npx vitest run tests/dxt-crawler.test.ts` → 34/34 ✓ (parser sano)

Closes #2965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP4M9Y453n15kfojVtfnAA