### PR TITLE
fix(seo): correct stale swiss-article hreflang in sitemap-news (3 dead URLs)

### DIFF
--- a/public/sitemap-news.xml
+++ b/public/sitemap-news.xml
@@ -13870,9 +13870,9 @@
     <loc>https://frontaliereticino.ch/articoli-svizzera/ristorni-fiscali-frontaliere/</loc>
     <lastmod>2026-06-27</lastmod>
     <xhtml:link rel="alternate" hreflang="it" href="https://frontaliereticino.ch/articoli-svizzera/ristorni-fiscali-frontaliere/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/swiss-articles/tax-rebates-border-workers/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/schweiz-artikel/steuer-rueckzahlungen-grenzgaenger/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-suisse/ristournes-fiscales-frontaliers/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/swiss-articles/fiscal-reimbursements-for-frontier-workers-how-they-work/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://frontaliereticino.ch/de/schweiz-artikel/steuer-ruckerstattungen-fur-grenzpendler-wie-sie-funktionieren/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://frontaliereticino.ch/fr/articles-suisse/remboursements-fiscaux-pour-travailleurs-frontaliers-comment-ils-fonctionnent/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://frontaliereticino.ch/articoli-svizzera/ristorni-fiscali-frontaliere/" />
     <news:news>
       <news:publication>


### PR DESCRIPTION
## Implementato
- `public/sitemap-news.xml`: the `<url>` block for the swiss article `/articoli-svizzera/ristorni-fiscali-frontaliere/` carried en/de/fr hreflang alternates pointing at the **blog** article's localized slugs (`/{loc}/swiss-articles/tax-rebates-border-workers/` … those slugs belong to `routerBlogData` `ristorni-fiscali-ticino`, served under `/cross-border-articles/`), so no page exists under the swiss section → the 3 dead links flagged by `validate:sitemap-links` (`sitemap-news.xml: 3 missing`).
- `dist/sitemap-news.xml` is the committed `public/sitemap-news.xml` verbatim (`cleanup-news-sitemap` runs dry-run), so the fix points the 3 hreflang at the swiss article's REAL slugs from `routerSwissData` (id `ristorni-fiscali-frontaliere`, line 213) — all four locale URLs verified **live-200**. XML re-validated well-formed. No live URL changes; only the news-sitemap alternates corrected.

## Non implementato (ancora)
- **Hardening of the generator that produced the cross-registry slug** (so a swiss article never again inherits a blog article's localized slug in the news sitemap) — a follow-up; not required to clear this gate. The 3 reported URLs are now fixed.