### PR TITLE
feat(article): AI_MODELS_FORCE_CHAIN to validate/measure the local fallback on demand

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: ''
+      force_chain:
+        description: 'Diagnostic: comma-separated model chain to force (e.g. local/fallback) — bypasses the auto cascade. Use to validate/measure the local fallback on demand without waiting for natural remote exhaustion. Leave empty in normal runs.'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   # Shared group: only 1 run active at a time, next run queues (not skipped).
@@ -170,6 +175,10 @@ jobs:
         env:
           CREATE_ARTICLE_REPORT_FILE: .tmp/create-article-run-report.json
           TARGET_SECTION: ${{ steps.section.outputs.section }}
+          # Diagnostic chain override (empty in normal runs). Lets ops force the
+          # local fallback (or any subset) on demand to validate/measure it
+          # without waiting for the remote pool to exhaust naturally.
+          AI_MODELS_FORCE_CHAIN: ${{ github.event.inputs.force_chain }}
           # Section-aware wall-clock budget. The `frontaliere` pipeline is
           # gate-heavier than `svizzera`: it carries the frontaliere-density
           # relevance gate (>=8 keyword hits) on top of the shared fact-check /
@@ -185,12 +194,13 @@ jobs:
           #
           # When the local-LLM fallback is enabled (ARTICLE_LOCAL_FALLBACK=1),
           # generation can fall to a slow CPU model whose single calls take
-          # minutes; the 55-min cap then cuts the run off mid-generation before
-          # it can land a fact-check-passing article (measured Jun-29: 3b did 12
-          # attempts/55min, 7b only ~2/55min — both deferred on the wall, not on
-          # quality-exhaustion). Raise the budget to 300 min in that mode so the
-          # local path can RUN TO COMPLETION and we can measure its real
-          # end-to-end time. Still under the 360-min job `timeout-minutes`
+          # minutes. NB (corrected Jun-29, run 28390219943): earlier "3b 12/55min,
+          # 7b ~2/55min, deferred on the wall" was WRONG — every local call was
+          # dying at undici's 300s headersTimeout as `fetch failed`, so no local
+          # generation ever completed (fixed in #3102 via a per-call dispatcher).
+          # The 300-min budget still gives a genuinely-slow CPU model room to RUN
+          # TO COMPLETION so we can measure its real end-to-end time. Still under
+          # the 360-min job `timeout-minutes`
           # (300min create-article + ollama setup + commit/deploy < 360). Defers
           # stay rare/acceptable; this just stops the premature cut-off so the
           # measurement is real. Reverts to 55/30 min when the var is unset.

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -2939,8 +2939,23 @@ export async function callLLM(messages, opts = {}) {
 
   let chain = o.chain || [...DEFAULT_CHAIN];
 
-  // If a specific model is requested, start the chain from that model
-  if (o.model) {
+  // Diagnostic override: AI_MODELS_FORCE_CHAIN=local/fallback,gemini-flash-latest
+  // pins the chain to exactly these models (in order), bypassing DEFAULT_CHAIN,
+  // the o.model start-point, and score sorting. Lets ops validate/measure a
+  // specific provider (e.g. the local fallback) on demand without waiting for the
+  // remote pool to exhaust. Unknown ids are dropped; empty result → ignore override.
+  const _forceChainRaw = (process.env.AI_MODELS_FORCE_CHAIN || '').trim();
+  const _forcedChain = _forceChainRaw
+    ? _forceChainRaw.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+  if (_forcedChain.length) {
+    console.warn(`🔧 [ai-models] AI_MODELS_FORCE_CHAIN active — chain pinned to: ${_forcedChain.join(' → ')}`);
+    chain = _forcedChain;
+  }
+
+  // If a specific model is requested, start the chain from that model.
+  // Skipped under a forced chain — the override owns the order verbatim.
+  if (o.model && !_forcedChain.length) {
     const idx = chain.indexOf(o.model);
     if (idx > 0) {
       chain = chain.slice(idx);
@@ -2953,7 +2968,10 @@ export async function callLLM(messages, opts = {}) {
   // Sort by accumulated score — models that are working well come first,
   // models that have been failing are pushed down.
   // The initial call uses DEFAULT_CHAIN order (all scores 0, tiebreak by index).
-  chain = sortChainByScore(chain);
+  // A forced chain keeps its explicit order (no score reshuffle).
+  if (!_forcedChain.length) {
+    chain = sortChainByScore(chain);
+  }
 
   const errors = [];
 

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { AI_MODELS, DEFAULT_CHAIN, isModelAvailable, callSingleModel } from '../scripts/lib/ai-models.mjs';
+import { AI_MODELS, DEFAULT_CHAIN, isModelAvailable, callSingleModel, callLLM } from '../scripts/lib/ai-models.mjs';
 
 // Local open-source fallback provider: opt-in last-resort used when every remote
 // free-tier provider is daily-exhausted. These invariants guard the two things
@@ -98,6 +98,41 @@ describe('local LLM fallback provider', () => {
       if (prevUrl === undefined) delete process.env.LOCAL_LLM_URL; else process.env.LOCAL_LLM_URL = prevUrl;
       if (prevModel === undefined) delete process.env.LOCAL_LLM_MODEL; else process.env.LOCAL_LLM_MODEL = prevModel;
       if (prevTimeout === undefined) delete process.env.LOCAL_LLM_TIMEOUT_MS; else process.env.LOCAL_LLM_TIMEOUT_MS = prevTimeout;
+    }
+  });
+
+  // AI_MODELS_FORCE_CHAIN pins the cascade to an explicit list so ops can
+  // validate/measure a specific provider (e.g. the local fallback) on demand
+  // without waiting for the remote pool to exhaust naturally.
+  it('AI_MODELS_FORCE_CHAIN pins callLLM to exactly the listed models', async () => {
+    const prevFetch = globalThis.fetch;
+    const prevForce = process.env.AI_MODELS_FORCE_CHAIN;
+    const prevUrl = process.env.LOCAL_LLM_URL;
+    const prevModel = process.env.LOCAL_LLM_MODEL;
+    process.env.LOCAL_LLM_ENABLED = '1';
+    process.env.LOCAL_LLM_URL = 'http://127.0.0.1:11434/v1/chat/completions';
+    process.env.LOCAL_LLM_MODEL = 'qwen2.5:7b';
+    process.env.AI_MODELS_FORCE_CHAIN = 'local/fallback';
+    const urls: string[] = [];
+    try {
+      globalThis.fetch = (async (url: string) => {
+        urls.push(url);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ choices: [{ message: { content: 'forced' } }] }),
+        };
+      }) as unknown as typeof fetch;
+      const out = await callLLM([{ role: 'user', content: 'hi' }], { maxRetriesPerModel: 1 });
+      expect(out).toBe('forced');
+      // Exactly one call, to the local endpoint only — no remote provider touched.
+      expect(urls).toHaveLength(1);
+      expect(urls[0]).toBe('http://127.0.0.1:11434/v1/chat/completions');
+    } finally {
+      globalThis.fetch = prevFetch;
+      if (prevForce === undefined) delete process.env.AI_MODELS_FORCE_CHAIN; else process.env.AI_MODELS_FORCE_CHAIN = prevForce;
+      if (prevUrl === undefined) delete process.env.LOCAL_LLM_URL; else process.env.LOCAL_LLM_URL = prevUrl;
+      if (prevModel === undefined) delete process.env.LOCAL_LLM_MODEL; else process.env.LOCAL_LLM_MODEL = prevModel;
     }
   });
 });


### PR DESCRIPTION
## Contesto

Dopo #3102 (fix del 300s undici headersTimeout) il fallback locale 7b può finalmente completare una generazione, ma viene **raggiunto solo a esaurimento TOTALE del pool remoto**. Negli orari con quota remota disponibile i run producono via remoto in ~6min (es. run 28401186784 / 28403174900, entrambi committano un articolo) e il local non si attiva mai → misurarne il tempo reale dipendeva dal cogliere una finestra di full-exhaustion casuale.

## Implementato

- `scripts/lib/ai-models.mjs` — `callLLM` legge `AI_MODELS_FORCE_CHAIN` (lista CSV di model id): se valorizzato, fissa la cascata **esattamente** a quei modelli nell'ordine dato, bypassando `DEFAULT_CHAIN`, lo start-point `o.model` e `sortChainByScore`. Inerte quando l'env è vuoto → **zero impatto sui run normali**. Log `🔧 AI_MODELS_FORCE_CHAIN active`.
- `.github/workflows/generate-article.yml` — nuovo input `workflow_dispatch.force_chain`, esportato come `AI_MODELS_FORCE_CHAIN` nell'env dello step Generate. Misura/validazione on-demand: `gh workflow run generate-article.yml -f force_chain=local/fallback`. Corretto anche il commento stale del wall-budget ("7b ~2/55min, deferred on the wall") → era il bug undici-300s di #3102 (nessuna generazione locale completava), non lentezza CPU.
- `tests/local-llm-fallback.test.ts` — nuovo test: con `AI_MODELS_FORCE_CHAIN=local/fallback`, `callLLM` fa **una sola** chiamata, al solo endpoint locale (nessun provider remoto toccato). 6/6 verde; `email-cascade-burst` non impattato.

## Non implementato (ancora)

- **Misura empirica del 7b (durata Generate + esito fact-check)**: `in arrivo` — a merge avvenuto lancio `gh workflow run generate-article.yml -f force_chain=local/fallback -f section=frontaliere` e leggo durata reale + se il 7b supera il consensus fact-check, poi salvo i numeri in MEMORY. È il primo modo deterministico di ottenerli (prima dipendeva dall'esaurimento naturale del remoto).
- **Claim wall-time/memoria non validabile sul `pull_request`**: il path locale gira solo post-merge su `main`. Revert-trigger: se un run forzato OOMa o non completa entro `LOCAL_LLM_TIMEOUT_MS` (30min) → il 7b è troppo lento per CPU, si conferma che serve un modello/VM più grande; nessun impatto sui run normali (override opt-in, off di default).

## Sibling-pattern (AGENTS.md #6)

`check-sibling-patterns` flagga `scripts/set-chutes-rc.mjs` e `scripts/smoke-test-ai-models.mjs` per il token condiviso `DEFAULT_CHAIN` → **falsi positivi**: il primo lo cita solo in una stringa di log, il secondo lo importa per pingare ogni modello in un smoke-test. Nessuno dei due implementa la logica di costruzione chain di `callLLM`, dove l'override è correttamente collocato in **un solo** punto (single source).