### PR TITLE
fix(crawler): transgourmet CH-wide fetch, rimuovi filtro canton=Wallis (#3065)

### DIFF
--- a/scripts/lib/interdiscount-job-parser.mjs
+++ b/scripts/lib/interdiscount-job-parser.mjs
@@ -10,13 +10,16 @@
  * API: https://ohws.prospective.ch/public/v1/medium/1000103/jobs
  *   - Medium ID 1000103 = Coop Group career center (shared with Coop, Fust, etc.)
  *   - Company filter: f=70:1114048  (attribute 70 = "Interdiscount")
- *   - Canton filter:  f=30:1024526  (attribute 30 = "Wallis" / Valais)
+ *   - CH-wide fetch: no canton facet (`f=30:{cantonId}`). The per-job canton is
+ *     inferred from attribute 30 downstream, mirroring the canonical coop-ticino
+ *     crawler. A hard Wallis filter previously starved this crawler to ~1 job
+ *     whenever Valais had no openings (sibling of issue #3065); CH-wide ~29.
  *
  * No detail page fetching needed — the API returns full descriptions in szas.*.
  * Detail page URL pattern: https://jobs.coopjobs.ch/offene-stellen/{slug}/{viewkey}
  *
  * Exports the 4 required functions for the crawler template:
- *   - fetchAllInterdiscountJobs()  — Fetch and parse all Valais jobs
+ *   - fetchAllInterdiscountJobs()  — Fetch and parse all CH-wide jobs
  *   - isInterdiscountJob()         — Match jobs belonging to this company
  *   - isTrustedDomain()            — Validate URLs belong to this company
  *   - slugify() / stripHtml()      — Re-exported from crawler-template.mjs
@@ -39,10 +42,10 @@ const API_BASE = 'https://ohws.prospective.ch/public/v1/medium/1000103';
 /**
  * Filter IDs for the Prospective.ch API:
  *   Attribute 70 (Unternehmen/Company): 1114048 = Interdiscount
- *   Attribute 30 (Kanton/Canton): 1024526 = Wallis/Valais
+ * No canton facet (attribute 30): jobs are fetched CH-wide and the per-job
+ * canton is inferred from the API canton label downstream.
  */
 const COMPANY_FILTER_ID = '1114048';
-const CANTON_WALLIS_ID = '1024526';
 const API_LIMIT = 100;
 
 /* ── Helpers ───────────────────────────────────────────────── */
@@ -201,7 +204,11 @@ async function callApi(url) {
 }
 
 /**
- * Fetch Interdiscount job listings from Prospective.ch API, filtered to Wallis/Valais.
+ * Fetch Interdiscount job listings from Prospective.ch API, CH-wide.
+ *
+ * Company filter only (`f=70:`): no canton facet so all CH cantons are
+ * returned; the per-job canton is inferred from attribute 30 downstream.
+ * A hard Wallis filter previously returned ~1 job (sibling of issue #3065).
  * Returns the raw API job objects.
  */
 async function fetchJobListings() {
@@ -216,11 +223,9 @@ async function fetchJobListings() {
     });
     // Company filter: Interdiscount
     params.append('f', `70:${COMPANY_FILTER_ID}`);
-    // Canton filter: Wallis/Valais
-    params.append('f', `30:${CANTON_WALLIS_ID}`);
 
     const apiUrl = `${API_BASE}/jobs?${params}`;
-    console.log(`  📄 Fetching Interdiscount Wallis jobs (offset=${offset})...`);
+    console.log(`  📄 Fetching Interdiscount CH-wide jobs (offset=${offset})...`);
 
     const data = await callApi(apiUrl);
     const items = assertJsonListShape(data, { key: 'jobs', source: INTERDISCOUNT_KEY });
@@ -271,7 +276,7 @@ function buildDescription(szas = {}, title = '', city = '') {
   }
 
   if (sections.length === 0) {
-    return `${title} - Interdiscount, ${city || 'Wallis'}, Schweiz`;
+    return `${title} - Interdiscount, ${city || 'Schweiz'}, Schweiz`;
   }
 
   return sections.join('\n\n');
@@ -305,7 +310,7 @@ function parsePensum(szas = {}, attrs = {}) {
 }
 
 /**
- * Fetch all Interdiscount jobs in Valais/Wallis.
+ * Fetch all Interdiscount jobs CH-wide.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
@@ -315,7 +320,7 @@ export async function fetchAllInterdiscountJobs() {
   console.log(`🔍 Fetching Interdiscount jobs`);
   console.log(`   Platform: Prospective.ch JobBooster (Coop Group Career Center)`);
   console.log(`   API: ${API_BASE}/jobs`);
-  console.log(`   Filters: Company=Interdiscount (70:${COMPANY_FILTER_ID}), Canton=Wallis (30:${CANTON_WALLIS_ID})\n`);
+  console.log(`   Filter: Company=Interdiscount (70:${COMPANY_FILTER_ID}), CH-wide (no canton filter)\n`);
 
   const listings = await fetchJobListings();
   if (!listings || listings.length === 0) {
@@ -343,8 +348,11 @@ export async function fetchAllInterdiscountJobs() {
     );
     const postalCode = normalizeSpace(szas['sza_workplace.zip'] || '');
     const street = normalizeSpace(szas['sza_workplace.street'] || '');
-    const location = city || region || 'Wallis';
-    const canton = normalizeCantonCode(region) || 'VS';
+    const location = city || region || 'Schweiz';
+    const canton = normalizeCantonCode(region);
+    // CH-only gate: drop foreign postings (e.g. Liechtenstein) whose region
+    // doesn't resolve to a Swiss canton — mirrors the coop-ticino crawler.
+    if (!canton) continue;
 
     // Description
     const descriptionText = buildDescription(szas, title, city);
@@ -370,7 +378,7 @@ export async function fetchAllInterdiscountJobs() {
       ? `interdiscount-${viewkey.slice(0, 12)}`
       : `interdiscount-${createHash('sha1').update(publicUrl).digest('hex').slice(0, 12)}`;
 
-    const jobSlug = slugify(`${title} interdiscount ${city || 'wallis'}`);
+    const jobSlug = slugify(`${title} interdiscount ${city || canton}`);
 
     // Posted date from API start_date
     const postedDate = listing.start_date
@@ -424,6 +432,6 @@ export async function fetchAllInterdiscountJobs() {
     jobs.push(job);
   }
 
-  console.log(`\n📋 Total Interdiscount Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total Interdiscount CH-wide jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/jumbo-job-parser.mjs
+++ b/scripts/lib/jumbo-job-parser.mjs
@@ -10,13 +10,16 @@
  * API: https://ohws.prospective.ch/public/v1/medium/1000103/jobs
  *   - Medium ID 1000103 = Coop Group career center (shared with Coop, Interdiscount, etc.)
  *   - Company filter: f=70:1343965  (attribute 70 = "Jumbo")
- *   - Canton filter:  f=30:1024526  (attribute 30 = "Wallis" / Valais)
+ *   - CH-wide fetch: no canton facet (`f=30:{cantonId}`). The per-job canton is
+ *     inferred from attribute 30 downstream, mirroring the canonical coop-ticino
+ *     crawler. A hard Wallis filter previously starved this crawler to ~3 jobs
+ *     whenever Valais had no openings (sibling of issue #3065); CH-wide ~103.
  *
  * No detail page fetching needed — the API returns full descriptions in szas.*.
  * Detail page URL pattern: https://jobs.coopjobs.ch/offene-stellen/{slug}/{viewkey}
  *
  * Exports the 4 required functions for the crawler template:
- *   - fetchAllJumboJobs()     — Fetch and parse all Valais jobs
+ *   - fetchAllJumboJobs()     — Fetch and parse all CH-wide jobs
  *   - isJumboJob()            — Match jobs belonging to this company
  *   - isTrustedDomain()       — Validate URLs belong to this company
  *   - slugify() / stripHtml() — Re-exported from crawler-template.mjs
@@ -39,10 +42,10 @@ const API_BASE = 'https://ohws.prospective.ch/public/v1/medium/1000103';
 /**
  * Filter IDs for the Prospective.ch API:
  *   Attribute 70 (Unternehmen/Company): 1343965 = Jumbo
- *   Attribute 30 (Kanton/Canton): 1024526 = Wallis/Valais
+ * No canton facet (attribute 30): jobs are fetched CH-wide and the per-job
+ * canton is inferred from the API canton label downstream.
  */
 const COMPANY_FILTER_ID = '1343965';
-const CANTON_WALLIS_ID = '1024526';
 const API_LIMIT = 100;
 
 /* ── Helpers ───────────────────────────────────────────────── */
@@ -200,7 +203,11 @@ async function callApi(url) {
 }
 
 /**
- * Fetch JUMBO job listings from Prospective.ch API, filtered to Wallis/Valais.
+ * Fetch JUMBO job listings from Prospective.ch API, CH-wide.
+ *
+ * Company filter only (`f=70:`): no canton facet so all CH cantons are
+ * returned; the per-job canton is inferred from attribute 30 downstream.
+ * A hard Wallis filter previously returned ~3 jobs (sibling of issue #3065).
  * Returns the raw API job objects.
  */
 async function fetchJobListings() {
@@ -215,11 +222,9 @@ async function fetchJobListings() {
     });
     // Company filter: Jumbo
     params.append('f', `70:${COMPANY_FILTER_ID}`);
-    // Canton filter: Wallis/Valais
-    params.append('f', `30:${CANTON_WALLIS_ID}`);
 
     const apiUrl = `${API_BASE}/jobs?${params}`;
-    console.log(`  📄 Fetching JUMBO Wallis jobs (offset=${offset})...`);
+    console.log(`  📄 Fetching JUMBO CH-wide jobs (offset=${offset})...`);
 
     const data = await callApi(apiUrl);
     const items = assertJsonListShape(data, { key: 'jobs', source: JUMBO_KEY });
@@ -263,7 +268,7 @@ function buildDescription(szas = {}, title = '', city = '') {
   }
 
   if (sections.length === 0) {
-    return `${title} - JUMBO, ${city || 'Wallis'}, Schweiz`;
+    return `${title} - JUMBO, ${city || 'Schweiz'}, Schweiz`;
   }
 
   return sections.join('\n\n');
@@ -297,7 +302,7 @@ function parsePensum(szas = {}, attrs = {}) {
 }
 
 /**
- * Fetch all JUMBO jobs in Valais/Wallis.
+ * Fetch all JUMBO jobs CH-wide.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
@@ -307,7 +312,7 @@ export async function fetchAllJumboJobs() {
   console.log(`🔍 Fetching JUMBO jobs`);
   console.log(`   Platform: Prospective.ch JobBooster (Coop Group Career Center)`);
   console.log(`   API: ${API_BASE}/jobs`);
-  console.log(`   Filters: Company=Jumbo (70:${COMPANY_FILTER_ID}), Canton=Wallis (30:${CANTON_WALLIS_ID})\n`);
+  console.log(`   Filter: Company=Jumbo (70:${COMPANY_FILTER_ID}), CH-wide (no canton filter)\n`);
 
   const listings = await fetchJobListings();
   if (!listings || listings.length === 0) {
@@ -335,8 +340,11 @@ export async function fetchAllJumboJobs() {
     );
     const postalCode = normalizeSpace(szas['sza_workplace.zip'] || '');
     const street = normalizeSpace(szas['sza_workplace.street'] || '');
-    const location = city || region || 'Wallis';
-    const canton = normalizeCantonCode(region) || 'VS';
+    const location = city || region || 'Schweiz';
+    const canton = normalizeCantonCode(region);
+    // CH-only gate: drop foreign postings (e.g. Liechtenstein) whose region
+    // doesn't resolve to a Swiss canton — mirrors the coop-ticino crawler.
+    if (!canton) continue;
 
     // Description
     const descriptionText = buildDescription(szas, title, city);
@@ -362,7 +370,7 @@ export async function fetchAllJumboJobs() {
       ? `jumbo-${viewkey.slice(0, 12)}`
       : `jumbo-${createHash('sha1').update(publicUrl).digest('hex').slice(0, 12)}`;
 
-    const jobSlug = slugify(`${title} jumbo ${city || 'wallis'}`);
+    const jobSlug = slugify(`${title} jumbo ${city || canton}`);
 
     // Posted date from API start_date
     const postedDate = listing.start_date
@@ -414,9 +422,9 @@ export async function fetchAllJumboJobs() {
     };
 
     jobs.push(job);
-    console.log(`  ✅ ${title} — ${city || 'Wallis'}`);
+    console.log(`  ✅ ${title} — ${city || canton}`);
   }
 
-  console.log(`\n📋 Total JUMBO Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total JUMBO CH-wide jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/scripts/lib/transgourmet-job-parser.mjs
+++ b/scripts/lib/transgourmet-job-parser.mjs
@@ -113,7 +113,12 @@ function detectEmploymentType(text = '') {
  *
  * API: https://ohws.prospective.ch/public/v1/medium/1003623/jobs
  *   - Medium ID 1003623 = Transgourmet/Prodega career center
- *   - Canton filter:  f=30:1253103  (attribute 30 = "Wallis" / Valais)
+ *   - CH-wide fetch: no canton facet (`f=30:{cantonId}`). The per-job canton
+ *     is inferred from attribute 30 (a localized canton label such as "Bern",
+ *     "Graubünden", "Vallese") via the shared inferAnyCanton helper, mirroring
+ *     the canonical coop-ticino crawler (same Prospective.ch platform). A hard
+ *     Wallis filter previously starved this crawler to 0 jobs whenever Valais
+ *     had no openings (issue #3065); CH-wide it returns ~23 jobs.
  *
  * No detail page fetching needed — the API returns full descriptions
  * in szas.* fields.
@@ -122,7 +127,6 @@ function detectEmploymentType(text = '') {
  */
 
 const API_BASE = 'https://ohws.prospective.ch/public/v1/medium/1003623';
-const CANTON_WALLIS_ID = '1253103';
 const API_LIMIT = 100;
 
 /**
@@ -177,7 +181,11 @@ async function callApi(url) {
 }
 
 /**
- * Fetch Transgourmet job listings from Prospective.ch API, filtered to Wallis/Valais.
+ * Fetch Transgourmet job listings from Prospective.ch API, CH-wide.
+ *
+ * No canton facet (`f=30:{cantonId}`): the per-job canton is inferred from
+ * attribute 30 downstream. A hard Wallis filter previously returned 0 jobs
+ * whenever Valais had no openings (issue #3065).
  */
 async function fetchJobListings() {
   const allListings = [];
@@ -189,11 +197,9 @@ async function fetchJobListings() {
       offset: String(offset),
       limit: String(API_LIMIT),
     });
-    // Canton filter: Wallis/Valais
-    params.append('f', `30:${CANTON_WALLIS_ID}`);
 
     const apiUrl = `${API_BASE}/jobs?${params}`;
-    console.log(`  📄 Fetching Transgourmet Wallis jobs (offset=${offset})...`);
+    console.log(`  📄 Fetching Transgourmet CH-wide jobs (offset=${offset})...`);
 
     const data = await callApi(apiUrl);
     const items = assertJsonListShape(data, { key: 'jobs', source: TRANSGOURMET_KEY });
@@ -232,7 +238,7 @@ function buildDescription(szas = {}, title = '', city = '') {
   if (benefits) sections.push('## Wir bieten\n' + htmlToMarkdown(benefits));
 
   if (sections.length === 0) {
-    return `${title} - Transgourmet/Prodega, ${city || 'Wallis'}, Schweiz`;
+    return `${title} - Transgourmet/Prodega, ${city || 'Schweiz'}, Schweiz`;
   }
 
   return sections.join('\n\n');
@@ -277,7 +283,7 @@ function normalizeCantonCode(regionName = '') {
 }
 
 /**
- * Fetch all Transgourmet jobs in Valais/Wallis.
+ * Fetch all Transgourmet jobs CH-wide.
  * Returns an array of ParsedJob objects (source-locale only).
  *
  * IMPORTANT: Only set source-locale fields. Other locales are filled
@@ -287,7 +293,7 @@ export async function fetchAllTransgourmetJobs() {
   console.log(`🔍 Fetching Transgourmet jobs`);
   console.log(`   Platform: Prospective.ch JobBooster`);
   console.log(`   API: ${API_BASE}/jobs`);
-  console.log(`   Filter: Canton=Wallis (30:${CANTON_WALLIS_ID})\n`);
+  console.log(`   Scope: CH-wide (no canton filter)\n`);
 
   const listings = await fetchJobListings();
   if (!listings || listings.length === 0) {
@@ -315,8 +321,11 @@ export async function fetchAllTransgourmetJobs() {
     );
     const postalCode = normalizeSpace(szas['sza_workplace.zip'] || '');
     const street = normalizeSpace(szas['sza_workplace.street'] || '');
-    const location = city || region || 'Wallis';
-    const canton = normalizeCantonCode(region) || 'VS';
+    const location = city || region || 'Schweiz';
+    const canton = normalizeCantonCode(region);
+    // CH-only gate: drop foreign postings (e.g. Liechtenstein) whose region
+    // doesn't resolve to a Swiss canton — mirrors the coop-ticino crawler.
+    if (!canton) continue;
 
     // Description
     const descriptionText = buildDescription(szas, title, city);
@@ -341,7 +350,7 @@ export async function fetchAllTransgourmetJobs() {
       ? `transgourmet-${viewkey.slice(0, 12)}`
       : `transgourmet-${createHash('sha1').update(publicUrl).digest('hex').slice(0, 12)}`;
 
-    const jobSlug = slugify(`${title} transgourmet ${city || 'wallis'}`);
+    const jobSlug = slugify(`${title} transgourmet ${city || canton}`);
 
     // Posted date from API start_date
     const postedDate = listing.start_date
@@ -393,9 +402,9 @@ export async function fetchAllTransgourmetJobs() {
     };
 
     jobs.push(job);
-    console.log(`  ✅ ${title} — ${city || 'Wallis'}`);
+    console.log(`  ✅ ${title} — ${city || canton}`);
   }
 
-  console.log(`\n📋 Total Transgourmet Valais jobs discovered: ${jobs.length}`);
+  console.log(`\n📋 Total Transgourmet CH-wide jobs discovered: ${jobs.length}`);
   return jobs;
 }

--- a/tests/crawler-fetch-facet-scope.test.ts
+++ b/tests/crawler-fetch-facet-scope.test.ts
@@ -3,11 +3,12 @@
  *
  * These crawlers previously narrowed their fetch to a single canton/city
  * (SRG → Wallis facet, Swiss Medical Network → Ticino region UUID, Skyguide →
- * Locarno/Lugano-Agno facet, Mikron → Agno filter, PEMSA → canton=125) and/or
- * defaulted unresolved jobs to Ticino. This locks in the CH-wide behaviour:
- * canton derived per-job, no Ticino fallback, foreign rows excluded.
+ * Locarno/Lugano-Agno facet, Mikron → Agno filter, PEMSA → canton=125,
+ * Transgourmet/Interdiscount/Jumbo → Wallis facet `f=30:`) and/or defaulted
+ * unresolved jobs to a fixed canton. This locks in the CH-wide behaviour:
+ * canton derived per-job, no fixed fallback, foreign rows excluded.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { inferSkyguideCanton } from '@/scripts/lib/skyguide-job-parser.mjs';
 import { isPemsaTicinoRelevant } from '@/scripts/lib/pemsa-job-parser.mjs';
@@ -18,6 +19,9 @@ import {
   extractSmnPostingId,
   smnPostingsApiUrl,
 } from '@/scripts/lib/swiss-medical-network-job-parser.mjs';
+import { fetchAllTransgourmetJobs } from '@/scripts/lib/transgourmet-job-parser.mjs';
+import { fetchAllInterdiscountJobs } from '@/scripts/lib/interdiscount-job-parser.mjs';
+import { fetchAllJumboJobs } from '@/scripts/lib/jumbo-job-parser.mjs';
 
 describe('Skyguide canton inference — no Ticino default', () => {
   it('derives the real canton for the big control centres', () => {
@@ -117,4 +121,97 @@ describe('Swiss Medical Network — SmartRecruiters API normalization', () => {
     expect(desc).toContain('Main mission here.');
     expect(desc).toContain('Skill A');
   });
+});
+
+describe('Coop-Group Prospective.ch crawlers — CH-wide fetch, no Wallis facet (issue #3065)', () => {
+  // Multi-canton fixture: Bern (BE) + Graubünden (GR) are kept; the
+  // Liechtenstein row has no resolvable Swiss canton and must be dropped.
+  const FIXTURE_JOBS = [
+    {
+      viewkey: '11111111-1111-1111-1111-111111111111',
+      title: 'Lagermitarbeiter',
+      start_date: '2026-06-01',
+      attributes: { '30': ['Bern'], '40': ['unbefristet'] },
+      szas: { sza_title: 'Lagermitarbeiter', 'sza_workplace.city': 'Bern', 'sza_workplace.region': 'Bern' },
+      links: { directlink: 'https://example.ch/job/1' },
+    },
+    {
+      viewkey: '22222222-2222-2222-2222-222222222222',
+      title: 'Verkaufsberater',
+      start_date: '2026-06-02',
+      attributes: { '30': ['Graubünden'], '40': ['unbefristet'] },
+      szas: { sza_title: 'Verkaufsberater', 'sza_workplace.city': 'Chur', 'sza_workplace.region': 'Graubünden' },
+      links: { directlink: 'https://example.ch/job/2' },
+    },
+    {
+      viewkey: '33333333-3333-3333-3333-333333333333',
+      title: 'Filialleiter',
+      start_date: '2026-06-03',
+      attributes: { '30': ['Principato del Liechtenstein'] },
+      szas: { sza_title: 'Filialleiter', 'sza_workplace.city': 'Vaduz', 'sza_workplace.region': 'Principato del Liechtenstein' },
+      links: { directlink: 'https://example.li/job/3' },
+    },
+  ];
+
+  let capturedUrls: string[] = [];
+
+  beforeEach(() => {
+    capturedUrls = [];
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      capturedUrls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ total: FIXTURE_JOBS.length, jobs: FIXTURE_JOBS }),
+      } as unknown as Response;
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const cases = [
+    { name: 'transgourmet', fetchAll: fetchAllTransgourmetJobs, companyFacet: null },
+    { name: 'interdiscount', fetchAll: fetchAllInterdiscountJobs, companyFacet: '70%3A' },
+    { name: 'jumbo', fetchAll: fetchAllJumboJobs, companyFacet: '70%3A' },
+  ];
+
+  for (const { name, fetchAll, companyFacet } of cases) {
+    describe(name, () => {
+      it('never sends a canton facet (f=30:) so the fetch stays CH-wide', async () => {
+        await fetchAll();
+        expect(capturedUrls.length).toBeGreaterThan(0);
+        for (const url of capturedUrls) {
+          expect(url).not.toMatch(/f=30(%3A|:)/i);
+        }
+      });
+
+      if (companyFacet) {
+        it('still scopes by company facet (f=70:)', async () => {
+          await fetchAll();
+          expect(capturedUrls.some((u) => u.includes(companyFacet))).toBe(true);
+        });
+      }
+
+      it('keeps jobs from multiple cantons (BE + GR), never Wallis-only', async () => {
+        const jobs = await fetchAll();
+        const cantons = jobs.map((j) => j.canton);
+        expect(cantons).toContain('BE');
+        expect(cantons).toContain('GR');
+      });
+
+      it('drops foreign rows with no resolvable Swiss canton (Liechtenstein)', async () => {
+        const jobs = await fetchAll();
+        expect(jobs).toHaveLength(2);
+        for (const job of jobs) {
+          expect(job.canton).toBeTruthy();
+          expect(job.country).toBe('CH');
+        }
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Verdetto

**Rottura reale, NON falso positivo.** Il crawler `transgourmet` interroga la
API Prospective.ch (medium `1003623`) con un filtro canton hard-coded su
Wallis/Valais (`f=30:1253103`). Quando il Vallese non ha posizioni aperte la
fetch ritorna 0 job → il monitor crawler-health lo segna `broken` (3 run vuoti
consecutivi). L'endpoint è **sano**: la query CH-wide ritorna ~23 job.

Evidenza curl:
- `GET .../medium/1003623/jobs?lang=de&limit=5` → `total: 23` (job in BE, ZH, VD, GR, NE, BS, SO)
- `GET .../medium/1003623/jobs?...&f=30:1253103` (Wallis) → `total: 0`

Stesso antipattern nei sibling del gruppo Coop sullo stesso medium condiviso
`1000103` (filtro `f=30:1024526` = Wallis): `interdiscount` (Wallis 1 → CH-wide
~28) e `jumbo` (Wallis 3 → CH-wide ~103), entrambi "healthy" per fortuna ma a un
giorno dal medesimo destino. Il crawler canonico `coop-ticino`/`fust` (stesso
medium/piattaforma) è già CH-wide unfiltered → questa PR allinea la classe.

Smoke live post-fix (parser reali contro API live): transgourmet 23 job (GR=1),
interdiscount 28 (1 riga Liechtenstein droppata), jumbo 103 — tutti con job
Grigioni (GR), cantone di confine rilevante per i frontalieri.

## Implementato

- `scripts/lib/transgourmet-job-parser.mjs`: rimosso `CANTON_WALLIS_ID` e il
  `params.append('f', '30:...')`; fetch CH-wide; canton inferito per-job da
  `normalizeCantonCode(region)` con **CH-only gate** (`if (!canton) continue`,
  droppa righe estere); rimossi i default hardcoded `'VS'`/`'Wallis'` da
  location/slug/log; aggiornati jsdoc/commenti/log da "Wallis/Valais" a "CH-wide".
- `scripts/lib/interdiscount-job-parser.mjs`: stessa classe — rimosso solo il
  facet canton (mantenuto il facet company `f=70:1114048`, essenziale sul medium
  condiviso); CH-only gate; default ripuliti; commenti aggiornati.
- `scripts/lib/jumbo-job-parser.mjs`: idem (facet company `f=70:1343965`
  mantenuto); CH-only gate; default ripuliti; commenti aggiornati.
- `tests/crawler-fetch-facet-scope.test.ts`: regression test (fetch mockata) per
  i 3 crawler — verifica assenza di `f=30:`, presenza di `f=70:` (interdiscount/
  jumbo), sopravvivenza multi-canton (BE+GR) e drop delle righe estere
  (Liechtenstein). 23 test verdi nel file; 115 verdi nel subset crawler.

## Non implementato (ancora)

- Nessuno. La classe del bug (`f=30:CANTON_WALLIS_ID` hard-filter) è stata
  sweepata su tutti i parser: gli unici tre file che la condividevano
  (transgourmet/interdiscount/jumbo) sono fixati in questa PR; `coop-ticino` e
  `fust` erano già CH-wide. `data/crawler-health.json` NON viene editato a mano:
  il prossimo run CI del crawler ritorna ~23 job e il monitor auto-resetta
  `consecutiveEmptyRuns`/`status` a healthy (recovery via root-cause, non reset
  manuale dello snapshot bot-owned).

Closes #3065