### PR TITLE
fix(article): AI_MODELS_FORCE_CHAIN must not hijack the fact-check (safety)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2708,7 +2708,11 @@ async function _runSingleFactCheck(model, prompt, opts = {}) {
     // cache:true — verdict is deterministic (temperature 0); re-checking an
     // unchanged body with the same judge model reuses the result instead of
     // re-running the full fallback cascade.
-    { model, temperature: 0.0, maxTokens: 4000, timeout: 60_000, cache: true }
+    // bypassForceChain:true — the verification models are the real quality gate
+    // and must stay independent of AI_MODELS_FORCE_CHAIN. Without this, forcing
+    // generation onto the local model would also force the checker onto it
+    // (the model grading itself), so a forced run could publish unchecked content.
+    { model, temperature: 0.0, maxTokens: 4000, timeout: 60_000, cache: true, bypassForceChain: true }
   );
 
   const jsonMatch = raw.match(/\{[\s\S]*\}/);

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -2944,8 +2944,14 @@ export async function callLLM(messages, opts = {}) {
   // the o.model start-point, and score sorting. Lets ops validate/measure a
   // specific provider (e.g. the local fallback) on demand without waiting for the
   // remote pool to exhaust. Unknown ids are dropped; empty result → ignore override.
+  //
+  // `opts.bypassForceChain` exempts a call from the override. The fact-check sets
+  // it so that forcing generation onto the local model does NOT also drag the
+  // independent verification models onto it — otherwise the model would grade its
+  // own output (circular self-consensus) and a forced run could publish unchecked
+  // content. With the exemption, generation=local + fact-check=real remote gate.
   const _forceChainRaw = (process.env.AI_MODELS_FORCE_CHAIN || '').trim();
-  const _forcedChain = _forceChainRaw
+  const _forcedChain = (_forceChainRaw && !o.bypassForceChain)
     ? _forceChainRaw.split(',').map((s) => s.trim()).filter(Boolean)
     : [];
   if (_forcedChain.length) {

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -135,4 +135,47 @@ describe('local LLM fallback provider', () => {
       if (prevModel === undefined) delete process.env.LOCAL_LLM_MODEL; else process.env.LOCAL_LLM_MODEL = prevModel;
     }
   });
+
+  // bypassForceChain exempts a call (the fact-check) from AI_MODELS_FORCE_CHAIN, so
+  // forcing generation onto the local model never drags the independent verification
+  // models onto it — the model would otherwise grade its own output and a forced run
+  // could publish unchecked content. Distinguishing setup: force_chain pins to local,
+  // local IS enabled, AND a remote (Gemini) model is available. Without the bypass the
+  // call hits local; WITH the bypass it must start from the remote model instead.
+  it('bypassForceChain routes to the remote model, not the forced local one', async () => {
+    const prevFetch = globalThis.fetch;
+    const prevForce = process.env.AI_MODELS_FORCE_CHAIN;
+    const prevGem = process.env.GEMINI_API_KEY;
+    const prevUrl = process.env.LOCAL_LLM_URL;
+    process.env.LOCAL_LLM_ENABLED = '1';
+    process.env.LOCAL_LLM_URL = 'http://127.0.0.1:11434/v1/chat/completions';
+    process.env.AI_MODELS_FORCE_CHAIN = 'local/fallback';
+    process.env.GEMINI_API_KEY = 'fake-key-for-routing-test';
+    const urls: string[] = [];
+    try {
+      globalThis.fetch = (async (url: string) => {
+        urls.push(String(url));
+        // Gemini uses a different response shape than OpenAI-compatible.
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ candidates: [{ content: { parts: [{ text: 'remote-ok' }] } }] }),
+        };
+      }) as unknown as typeof fetch;
+      await callLLM([{ role: 'user', content: 'hi' }], {
+        model: AI_MODELS.GEMINI_FLASH,
+        bypassForceChain: true,
+        maxRetriesPerModel: 1,
+      }).catch(() => { /* shape/parse differences are fine — we only assert routing */ });
+      // The very first call under bypass must be the remote endpoint, never local.
+      expect(urls.length).toBeGreaterThan(0);
+      expect(urls[0]).not.toContain('11434');
+      expect(urls[0]).toContain('googleapis.com');
+    } finally {
+      globalThis.fetch = prevFetch;
+      if (prevForce === undefined) delete process.env.AI_MODELS_FORCE_CHAIN; else process.env.AI_MODELS_FORCE_CHAIN = prevForce;
+      if (prevGem === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = prevGem;
+      if (prevUrl === undefined) delete process.env.LOCAL_LLM_URL; else process.env.LOCAL_LLM_URL = prevUrl;
+    }
+  });
 });


### PR DESCRIPTION
## Contesto

#3123 ha introdotto `AI_MODELS_FORCE_CHAIN` per forzare la cascata su un modello specifico (es. `local/fallback`) e misurare/validare il fallback locale on-demand. L'override però era **globale**: anche `_runSingleFactCheck` passa per `callLLM`, quindi forzando la generazione sul modello locale si forzavano **anche i modelli di verifica** sullo stesso modello → il modello giudicava il proprio output (self-consensus circolare) e un run forzato poteva **PUBBLICARE contenuto non realmente fact-checkato** (viola Non-Negotiable #1 quality-gate / #4 thin-content).

## Implementato

- `scripts/lib/ai-models.mjs` — `callLLM` rispetta `opts.bypassForceChain`: quando `true`, la call **ignora** `AI_MODELS_FORCE_CHAIN` e usa la cascata normale (DEFAULT_CHAIN + score sort + start-point). L'override resta attivo per tutte le altre call (la generazione).
- `scripts/create-article.mjs` — `_runSingleFactCheck` passa `bypassForceChain: true` alla sua `callLLM`. I modelli di verifica (`GPT-4.1` / `Gemini Flash` / `GPT-4o`) restano il **gate reale indipendente**, qualunque sia il force_chain.
- `tests/local-llm-fallback.test.ts` — nuovo test distinguente: con `AI_MODELS_FORCE_CHAIN=local/fallback`, local abilitato E una chiave Gemini, una call con `bypassForceChain:true` parte dall'endpoint **remoto** (`googleapis.com`), **mai** dal locale (`11434`). 7/7 verde; `email-cascade-burst` 23/23.

## Effetto netto

Con `force_chain=local/fallback`: la **generazione** gira sul 7b locale (misura fedele del tempo CPU) ma il **fact-check** resta sui modelli remoti reali → se il 7b sbaglia i fatti fiscali, il gate fa **defer** (niente commit), nessuna pubblicazione di contenuto non validato. Sblocca in sicurezza la misurazione del 7b che #3123 voleva abilitare.

## Non implementato (ancora)

- **Misura empirica del 7b**: `in arrivo` — a merge avvenuto lancio `gh workflow run generate-article.yml -f force_chain=local/fallback -f section=frontaliere` e leggo durata Generate reale del 7b + verdetto del fact-check remoto (PASS→commit / criticals→defer), poi salvo i numeri in MEMORY. Ora è sicuro perché il gate remoto resta attivo.

## Sibling-pattern (AGENTS.md #6)

`check-sibling-patterns` flagga `.github/workflows/generate-article.yml` per il token `AI_MODELS_FORCE_CHAIN` → **falso positivo**: il workflow si limita a **settare** l'env dall'input `force_chain`; non è un caller di `callLLM` e non ha la logica di bypass (che è puramente code-level in `callLLM` + fact-check).