### PR TITLE
fix(spa): bust the HTTP cache on chunk version-skew recovery (#3097)

### DIFF
--- a/components/ChunkLoadErrorBoundary.tsx
+++ b/components/ChunkLoadErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, type ReactNode } from 'react';
-import { isModuleLinkSkewMessage } from '@/services/resilientImport';
+import { isModuleLinkSkewMessage, bustAssetHttpCache } from '@/services/resilientImport';
 
 /**
  * Last-resort boundary for Vite chunk-load failures during render.
@@ -63,7 +63,11 @@ export class ChunkLoadErrorBoundary extends Component<Props, State> {
       const last = Number(sessionStorage.getItem(RELOAD_FLAG) ?? '0');
       if (Date.now() - last > RELOAD_COOLDOWN_MS) {
         sessionStorage.setItem(RELOAD_FLAG, String(Date.now()));
-        window.location.reload();
+        // Bust the HTTP cache (not just CacheStorage) before reloading: a
+        // link-time version-skew (#3097) re-serves the same stale cross-origin
+        // chunk on a plain reload, so this boundary's one reload would be wasted.
+        // Show the "Aggiornamento…" fallback while the async bust + reload run.
+        void bustAssetHttpCache().finally(() => window.location.reload());
         return { hasError: true };
       }
     } catch {

--- a/components/shared/ErrorBoundary.tsx
+++ b/components/shared/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Analytics, decodeReactError } from '../../services/analytics';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { t } from '../../services/i18n';
-import { isVersionSkewError, recoverFromStaleChunk } from '../../services/resilientImport';
+import { isVersionSkewError, recoverFromStaleChunk, bustAssetHttpCache } from '../../services/resilientImport';
 
 interface Props {
  children: ReactNode;
@@ -235,7 +235,10 @@ export class ErrorBoundary extends Component<Props, State> {
  pagePath: this.state.snapshotUrl || window.location.pathname + window.location.search,
  blocked: false,
  });
- window.location.reload();
+ // Bust the HTTP cache (not just CacheStorage) before reloading. If the user
+ // landed here via a version-skew (#3097), a plain reload re-serves the same
+ // stale chunk and leaves them stuck; cache:'reload' refetches a fresh set.
+ void bustAssetHttpCache().finally(() => window.location.reload());
  }}
  className="flex items-center gap-2 px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent rounded-xl font-bold transition-colors"
  >

--- a/index.html
+++ b/index.html
@@ -848,6 +848,56 @@
           registrations.forEach(function(r) { r.unregister(); });
         });
       }
+      // Self-heal recovery shared by the version-skew handlers below. CacheStorage
+      // (caches.*) is EMPTY on this site — no service worker caches /assets — so a
+      // version-skewed chunk lives ONLY in the HTTP disk cache (cross-origin
+      // cdn.frontaliereticino.ch/assets/* modules, Cache-Control max-age=600). A
+      // plain location.reload() re-serves the SAME stale bytes within that window,
+      // wasting the one allowed reload and stranding the user on the error page
+      // (#3097; works in incognito only because there is no persistent HTTP cache).
+      // Refetch every loaded /assets/ JS+CSS with cache:'reload' to OVERWRITE the
+      // stale HTTP cache entries, THEN reload onto a consistent, current set.
+      // Time-boxed so a hung refetch never blocks the reload. Mirrors
+      // bustAssetHttpCache() in services/resilientImport.ts — kept inline because
+      // this bootstrap script runs before any module JS loads.
+      function frBustAssetCacheThenReload() {
+        function reload() { try { location.reload(); } catch (e) {} }
+        function clearCacheStorage() {
+          if (!('caches' in window)) return Promise.resolve();
+          return caches.keys().then(function(names) {
+            return Promise.all(names.map(function(n) { return caches.delete(n); }));
+          }).catch(function() {});
+        }
+        var urls = [];
+        try {
+          var entries = (window.performance && performance.getEntriesByType)
+            ? performance.getEntriesByType('resource') : [];
+          for (var i = 0; i < entries.length; i++) {
+            var n = entries[i].name || '';
+            if (/\/assets\/.+\.(js|css)(\?|$)/.test(n)) urls.push(n);
+          }
+        } catch (e) {}
+        if (!urls.length) {
+          try {
+            var els = document.querySelectorAll('script[src*="/assets/"], link[href*="/assets/"]');
+            for (var j = 0; j < els.length; j++) {
+              var u = els[j].src || els[j].href;
+              if (u) urls.push(u);
+            }
+          } catch (e) {}
+        }
+        var uniq = [];
+        for (var k = 0; k < urls.length; k++) if (uniq.indexOf(urls[k]) === -1) uniq.push(urls[k]);
+        if (!uniq.length || typeof fetch !== 'function') { clearCacheStorage().then(reload, reload); return; }
+        var done = false;
+        function finish() { if (done) return; done = true; reload(); }
+        setTimeout(finish, 4000);
+        clearCacheStorage().then(function() {
+          return Promise.all(uniq.map(function(u) {
+            return fetch(u, { cache: 'reload', mode: 'cors', credentials: 'omit' }).catch(function() {});
+          }));
+        }).then(finish, finish);
+      }
       // Suppress Firebase SDK internal IndexedDB DOMExceptions (race condition
       // when IDB connection closes during page suspend/resume on iOS Safari).
       // Must be registered here (before module JS) to catch errors that fire
@@ -922,13 +972,9 @@
               timestamp: new Date().toISOString()
             }));
           } catch(ex) {}
-          if ('caches' in window) {
-            caches.keys().then(function(names) {
-              return Promise.all(names.map(function(n) { return caches.delete(n); }));
-            }).then(function() { location.reload(); });
-          } else {
-            location.reload();
-          }
+          // A purged /assets/ script/link 404'd: bust the HTTP cache (in case a
+          // stale-but-200 sibling lingers) then reload onto a current set.
+          frBustAssetCacheThenReload();
         }
       }, true);
       // Catch CROSS-CHUNK VERSION-SKEW errors thrown OUTSIDE React (event
@@ -980,13 +1026,8 @@
             timestamp: new Date().toISOString()
           }));
         } catch(ex) {}
-        if ('caches' in window) {
-          caches.keys().then(function(names) {
-            return Promise.all(names.map(function(n) { return caches.delete(n); }));
-          }).then(function() { location.reload(); });
-        } else {
-          location.reload();
-        }
+        // HTTP-cache bust (not just CacheStorage) — see frBustAssetCacheThenReload.
+        frBustAssetCacheThenReload();
       });
       // Catch dynamic import() rejections (React.lazy chunk 404s from stale SW
       // cache) AND link-time version-skew SyntaxErrors (#3097) from an import()
@@ -1050,13 +1091,8 @@
             type: 'dynamic_import'
           }));
         } catch(ex) {}
-        if ('caches' in window) {
-          caches.keys().then(function(names) {
-            return Promise.all(names.map(function(n) { return caches.delete(n); }));
-          }).then(function() { location.reload(); });
-        } else {
-          location.reload();
-        }
+        // HTTP-cache bust (not just CacheStorage) — see frBustAssetCacheThenReload.
+        frBustAssetCacheThenReload();
       });
     </script>
     <script type="module" src="/index.tsx"></script>

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { installDomReconciliationGuard } from './services/domReconciliationGuard';
 import { maybeHandleCvDownload } from './services/cvDownloadIntercept';
+import { bustAssetHttpCache } from './services/resilientImport';
 
 // Harden the DOM against third-party mutation (Google Translate, extensions)
 // crashing React's reconciler with NotFoundError on insertBefore/removeChild.
@@ -17,7 +18,9 @@ window.addEventListener('vite:preloadError', (_event) => {
  // Allow one reload per 5-minute window to prevent infinite loops
  if (!last || Date.now() - Number(last) > 5 * 60 * 1000) {
  sessionStorage.setItem(key, String(Date.now()));
- window.location.reload();
+ // Bust the HTTP cache (not just CacheStorage) before reloading — a stale-but-200
+ // preloaded chunk would otherwise be re-served from the disk cache (#3097).
+ void bustAssetHttpCache().finally(() => window.location.reload());
  }
 });
 

--- a/services/lazyRetry.ts
+++ b/services/lazyRetry.ts
@@ -1,4 +1,5 @@
 import React, { lazy } from 'react';
+import { bustAssetHttpCache } from '@/services/resilientImport';
 
 /**
  * Retry wrapper for React.lazy dynamic imports.
@@ -84,7 +85,11 @@ export function lazyRetry<T extends React.ComponentType<any>>(
  pagePath: window.location.pathname + window.location.search,
  blocked: false,
  })).catch(() => {});
- window.location.reload();
+ // Bust the HTTP cache (not just CacheStorage) before reloading: a stale-but-200
+ // chunk (SPA-fallback HTML for a .js, or a cached module the retries kept
+ // re-linking) would otherwise be re-served from the disk cache and this one
+ // reload wasted (#3097).
+ void bustAssetHttpCache().finally(() => window.location.reload());
  // Reject to satisfy the type, though reload will prevent this from running
  reject(err);
  });

--- a/services/resilientImport.ts
+++ b/services/resilientImport.ts
@@ -111,6 +111,79 @@ export function isVersionSkewError(err: unknown): boolean {
 // At most one reload per session total; the value `>= 1` blocks further reloads.
 const BOOTSTRAP_RELOAD_KEY = '_swReloadCount';
 
+// Upper bound on how long the HTTP-cache bust may run before we reload anyway.
+// Asset chunks are small and refetched in parallel; this is only a backstop so a
+// hung/blocked refetch can never strand the user on the error page.
+const BUST_TIMEOUT_MS = 4000;
+
+/**
+ * Overwrite the STALE entries the skewed chunks occupy in the browser's HTTP
+ * disk cache, so the subsequent reload loads a consistent, current chunk set.
+ *
+ * Why this is necessary on top of `caches.delete()` (issue #3097, recurrence of
+ * the #3071/#3131 self-heal): the version-skewed chunks are cross-origin module
+ * scripts served from `cdn.frontaliereticino.ch/assets/*` with
+ * `Cache-Control: max-age=600, must-revalidate`. CacheStorage (`caches.*`) is
+ * EMPTY on this site — no service worker caches `/assets` — so `caches.delete()`
+ * is a no-op, and a plain `location.reload()` re-serves the SAME stale bytes from
+ * the HTTP cache within the 600 s window. The one allowed reload is then wasted
+ * and the error page persists (works in incognito only because there is no
+ * persistent HTTP cache). `fetch(url, { cache: 'reload' })` bypasses the HTTP
+ * cache AND replaces the stored entry with current bytes, breaking the skew.
+ *
+ * Best-effort and time-boxed: every refetch swallows its own error and the whole
+ * batch races a {@link BUST_TIMEOUT_MS} timer, so recovery never hangs. Resolves
+ * once the cache has been refreshed (or the timer fires); the caller then reloads.
+ */
+export async function bustAssetHttpCache(): Promise<void> {
+  if (typeof window === 'undefined' || typeof fetch !== 'function') return;
+
+  let urls: string[] = [];
+  try {
+    const entries =
+      typeof performance !== 'undefined' && typeof performance.getEntriesByType === 'function'
+        ? performance.getEntriesByType('resource')
+        : [];
+    urls = entries
+      .map((e) => (e as PerformanceResourceTiming).name)
+      .filter((u) => /\/assets\/.+\.(?:js|css)(?:\?|$)/.test(u));
+  } catch {
+    /* Resource Timing unavailable — fall back to a DOM scan below. */
+  }
+  if (urls.length === 0 && typeof document !== 'undefined') {
+    try {
+      document
+        .querySelectorAll<HTMLScriptElement | HTMLLinkElement>(
+          'script[src*="/assets/"], link[href*="/assets/"]',
+        )
+        .forEach((el) => {
+          const u = (el as HTMLScriptElement).src || (el as HTMLLinkElement).href;
+          if (u) urls.push(u);
+        });
+    } catch {
+      /* DOM unavailable */
+    }
+  }
+
+  const unique = Array.from(new Set(urls));
+  if (unique.length === 0) return;
+
+  // `cache: 'reload'` forces a network refetch that overwrites the cache entry.
+  // `mode: 'cors'` + `credentials: 'omit'` match how the <script crossorigin>
+  // module fetches partition the cache, so the reload reuses these fresh bytes.
+  const refetch = Promise.all(
+    unique.map((u) =>
+      fetch(u, { cache: 'reload', mode: 'cors', credentials: 'omit' }).catch(() => {
+        /* one failed refetch must not block the others or the reload */
+      }),
+    ),
+  );
+  await Promise.race([
+    refetch,
+    new Promise<void>((resolve) => setTimeout(resolve, BUST_TIMEOUT_MS)),
+  ]);
+}
+
 /**
  * Clear all CacheStorage entries and reload the page ONCE per session so the
  * browser refetches a CONSISTENT set of stable-named chunks (post-propagation,
@@ -160,6 +233,9 @@ export async function recoverFromStaleChunk(reason: string): Promise<boolean> {
       /* cache eviction is best-effort */
     }
   }
+  // The skew lives in the HTTP cache, which `caches.delete()` does not touch —
+  // bust it so the reload loads current bytes rather than the same stale set.
+  await bustAssetHttpCache();
   window.location.reload();
   return true;
 }
@@ -210,14 +286,22 @@ export async function resilientImport<T>(
     } catch (err2) {
       // Chunk truly gone — reload to get fresh HTML with current chunk URLs.
       if (typeof window !== 'undefined') {
+        let shouldReload = false;
         try {
           const rc = parseInt(sessionStorage.getItem(BOOTSTRAP_RELOAD_KEY) || '0', 10) || 0;
           if (rc < 1) {
             sessionStorage.setItem(BOOTSTRAP_RELOAD_KEY, String(rc + 1));
-            window.location.reload();
+            shouldReload = true;
           }
         } catch {
           /* sessionStorage unavailable (private mode) — skip reload guard */
+        }
+        if (shouldReload) {
+          // Bust the HTTP cache before reloading: a stale-but-200 chunk (HTML
+          // served for a purged name, or a skewed dependency) would otherwise be
+          // re-served from the disk cache and the one reload wasted.
+          await bustAssetHttpCache();
+          window.location.reload();
         }
       }
       throw err2;

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -8,6 +8,7 @@ import { parsePath, buildPath, buildAllLocalePaths, type AppRoute } from './rout
 import { ALL_GLOSSARY_TERM_IDS, ALL_BORDER_CROSSING_IDS } from './router';
 import { resolveCompanyLogoUrl, isMultiLocation } from './jobDataNormalization';
 import { reportCaughtError } from './errorReporter';
+import { bustAssetHttpCache } from './resilientImport';
 import { cdnDataUrl } from './cdnDataBase';
 import { normalizeStructuredData } from './seo/schema-normalizers';
 import { cdnBlogImage } from './seo/blogImageCdn';
@@ -32,11 +33,14 @@ async function retryImport<T>(factory: () => Promise<T>, label: string): Promise
  msg.includes('error loading dynamically imported module');
  if (!isChunkError) throw err;
 
- // Clear SW caches and retry once
+ // Clear SW caches and retry once. CacheStorage alone is not enough: the
+ // chunk also lives in the HTTP disk cache (stable-named, max-age=600), which
+ // a bare retry would re-read — bust it so the retry fetches current bytes (#3097).
  if ('caches' in window) {
  const names = await caches.keys();
  await Promise.all(names.map(n => caches.delete(n)));
  }
+ await bustAssetHttpCache();
  try {
  return await factory();
  } catch (retryErr) {

--- a/tests/components/ChunkLoadErrorBoundary.test.tsx
+++ b/tests/components/ChunkLoadErrorBoundary.test.tsx
@@ -64,6 +64,14 @@ function ChunkThrower({ message }: { message: string }) {
   throw new Error(message);
 }
 
+// The boundary now reloads ASYNCHRONOUSLY (#3097): getDerivedStateFromError kicks
+// off bustAssetHttpCache() — which refetches stale /assets chunks with
+// cache:'reload' so a plain reload doesn't re-serve them — and reloads in the
+// .finally(). With no /assets resources in the test DOM the bust resolves on a
+// microtask, so flush microtasks before asserting reload() ran. Works under fake
+// timers too (the bust early-returns before scheduling any timer).
+const flushReload = () => act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
 describe('ChunkLoadErrorBoundary', () => {
   it('renders children when no error occurs', () => {
     render(
@@ -75,7 +83,7 @@ describe('ChunkLoadErrorBoundary', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 
-  it('reloads on the first chunk-load failure', () => {
+  it('reloads on the first chunk-load failure', async () => {
     render(
       <CatchAll>
         <ChunkLoadErrorBoundary>
@@ -83,10 +91,11 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('reloads on a link-time version-skew SyntaxError (#3097)', () => {
+  it('reloads on a link-time version-skew SyntaxError (#3097)', async () => {
     // The chunk fetched fine but a cached importer links an export the stale
     // dependency no longer provides — handled via isModuleLinkSkewMessage.
     render(
@@ -96,6 +105,7 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -118,7 +128,7 @@ describe('ChunkLoadErrorBoundary', () => {
     expect(screen.getByText(/Aggiornamento del sito in corso/i)).toBeInTheDocument();
   });
 
-  it('does NOT reload twice within the 60s cooldown', () => {
+  it('does NOT reload twice within the 60s cooldown', async () => {
     vi.useFakeTimers();
     const start = 1_700_000_000_000;
     vi.setSystemTime(start);
@@ -130,6 +140,7 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     expect(reloadSpy).toHaveBeenCalledTimes(1);
     first.unmount();
 
@@ -143,13 +154,14 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     // Still 1 — second render inside the cooldown must NOT trigger reload.
     expect(reloadSpy).toHaveBeenCalledTimes(1);
     // CatchAll caught the rethrown error.
     expect(screen.getByTestId('caught')).toBeInTheDocument();
   });
 
-  it('reloads again once the 60s cooldown has elapsed', () => {
+  it('reloads again once the 60s cooldown has elapsed', async () => {
     vi.useFakeTimers();
     const start = 1_700_000_000_000;
     vi.setSystemTime(start);
@@ -161,6 +173,7 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     expect(reloadSpy).toHaveBeenCalledTimes(1);
     first.unmount();
 
@@ -174,6 +187,7 @@ describe('ChunkLoadErrorBoundary', () => {
         </ChunkLoadErrorBoundary>
       </CatchAll>,
     );
+    await flushReload();
     expect(reloadSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/resilient-import.test.ts
+++ b/tests/resilient-import.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   resilientImport,
   isChunkLoadError,
   isVersionSkewError,
   isModuleLinkSkewMessage,
   recoverFromStaleChunk,
+  bustAssetHttpCache,
 } from '@/services/resilientImport';
 
 /**
@@ -217,5 +218,118 @@ describe('recoverFromStaleChunk', () => {
     const scheduled = await recoverFromStaleChunk('dev');
     expect(scheduled).toBe(false);
     expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * bustAssetHttpCache (#3097): the #3071/#3131 self-heal only cleared CacheStorage
+ * (empty here — no asset-caching service worker) and then reloaded, so the HTTP
+ * disk cache re-served the SAME version-skewed cross-origin chunk within the
+ * max-age=600 window → the one allowed reload was wasted and the error page
+ * persisted (works in incognito only — no persistent HTTP cache). bustAssetHttpCache
+ * refetches the loaded /assets/ chunks with `cache: 'reload'`, OVERWRITING the
+ * stale entries so the subsequent reload loads a consistent, current set.
+ */
+describe('bustAssetHttpCache', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let perfSpy: ReturnType<typeof vi.spyOn>;
+  const originalFetch = (globalThis as any).fetch;
+
+  const mockResources = (names: string[]) => {
+    perfSpy = vi
+      .spyOn(performance, 'getEntriesByType')
+      .mockReturnValue(names.map((name) => ({ name })) as unknown as PerformanceEntryList);
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    (globalThis as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    perfSpy?.mockRestore();
+    (globalThis as any).fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it('refetches every loaded /assets/ JS+CSS with cache:reload, skipping non-assets', async () => {
+    mockResources([
+      'https://cdn.frontaliereticino.ch/assets/vendor-icons.js',
+      'https://cdn.frontaliereticino.ch/assets/App.js',
+      'https://cdn.frontaliereticino.ch/assets/index.css',
+      'https://cdn.frontaliereticino.ch/data/jobs.json', // data, not a code chunk
+      'https://www.googletagmanager.com/gtag/js', // third-party
+    ]);
+
+    await bustAssetHttpCache();
+
+    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([
+      'https://cdn.frontaliereticino.ch/assets/vendor-icons.js',
+      'https://cdn.frontaliereticino.ch/assets/App.js',
+      'https://cdn.frontaliereticino.ch/assets/index.css',
+    ]);
+    for (const call of fetchMock.mock.calls) {
+      // cache:'reload' is what overwrites the stale HTTP cache entry; cors+omit
+      // match the <script crossorigin> module fetch so the reload reuses them.
+      expect(call[1]).toMatchObject({ cache: 'reload', mode: 'cors', credentials: 'omit' });
+    }
+  });
+
+  it('deduplicates repeated URLs', async () => {
+    mockResources([
+      'https://cdn.frontaliereticino.ch/assets/App.js',
+      'https://cdn.frontaliereticino.ch/assets/App.js',
+    ]);
+    await bustAssetHttpCache();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves even when a refetch rejects (best-effort)', async () => {
+    mockResources(['https://cdn.frontaliereticino.ch/assets/App.js']);
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(bustAssetHttpCache()).resolves.toBeUndefined();
+  });
+
+  it('no-ops when fetch is unavailable', async () => {
+    mockResources(['https://cdn.frontaliereticino.ch/assets/App.js']);
+    delete (globalThis as any).fetch;
+    await expect(bustAssetHttpCache()).resolves.toBeUndefined();
+  });
+
+  it('does not fetch when no /assets/ chunks are loaded', async () => {
+    mockResources(['https://example.com/x.js']);
+    await bustAssetHttpCache();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads anyway when a refetch hangs past the timeout', async () => {
+    vi.useFakeTimers();
+    mockResources(['https://cdn.frontaliereticino.ch/assets/App.js']);
+    fetchMock.mockReturnValue(new Promise(() => {/* never settles */}));
+    const pending = bustAssetHttpCache();
+    await vi.advanceTimersByTimeAsync(4000);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('recoverFromStaleChunk busts the HTTP cache before reloading', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, hostname: 'frontaliereticino.ch', reload: vi.fn() },
+    });
+    (globalThis as any).caches = {
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+    mockResources(['https://cdn.frontaliereticino.ch/assets/vendor-icons.js']);
+
+    const scheduled = await recoverFromStaleChunk('version_skew:link');
+
+    expect(scheduled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cdn.frontaliereticino.ch/assets/vendor-icons.js',
+      expect.objectContaining({ cache: 'reload' }),
+    );
+    expect((window.location.reload as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Implementato
- `services/resilientImport.ts`: nuovo `bustAssetHttpCache()` — rifetcha ogni `/assets/*.{js,css}` caricato con `fetch(url, { cache: 'reload', mode: 'cors', credentials: 'omit' })`, **sovrascrivendo** le entry stale nella HTTP disk-cache; best-effort + time-boxed (4s). Chiamato da `recoverFromStaleChunk` e dal retry di `resilientImport` **prima** del reload.
- `index.html`: helper inline `frBustAssetCacheThenReload()` che rispecchia il TS (il bootstrap gira prima del module JS), cablato in **tutti e tre** gli handler di reload (resource-404, runtime version-skew, dynamic-import rejection).
- `components/ChunkLoadErrorBoundary.tsx`, `components/shared/ErrorBoundary.tsx` (bottone "Ricarica Pagina"), `services/lazyRetry.ts`, `index.tsx` (`vite:preloadError`), `services/seoService.ts` (`retryImport`): bustano la HTTP cache prima di reload/retry — l'intera **classe** self-heal.
- Test: unit di `bustAssetHttpCache` (filtra a /assets js+css, dedup, best-effort su reject, no-op senza `fetch`, time-box su fetch appeso) + integrazione che `recoverFromStaleChunk` busta prima del reload; test di `ChunkLoadErrorBoundary` aggiornati per il reload ora **async** (mostra il fallback "Aggiornamento…" durante il bust).

## Root cause (#3097, recidiva di #3071/#3131)
Lo skew è rilevato correttamente, ma il self-heal faceva `caches.delete()` (solo **CacheStorage**, vuota qui — nessun SW cacha `/assets`) + `location.reload()`. I chunk skew-ati vivono nella **HTTP disk-cache** (module cross-origin `cdn.frontaliereticino.ch/assets/*`, `Cache-Control: max-age=600, must-revalidate`). Entro i 600s il reload **riserve gli stessi byte stale** → stesso `SyntaxError: ... does not provide an export named 'House'` → guard `_swReloadCount>=1` consumato → pagina errore persiste. ("In anonimo funziona" = nessuna HTTP cache persistente.) `cache: 'reload'` bypassa **e rimpiazza** l'entry → skew rotto by-construction.

## Non implementato (ancora)
- **Nessuno scope residuo**: l'intera classe (reload/retry self-heal che non bustava la HTTP cache) è sweepata in questa PR.
- **Sibling-check — falsi positivi** (verificati a mano: classe diversa, condividono solo il token DOM `HTMLScriptElement`/`HTMLLinkElement`, nessun reload/cache self-heal): `components/community/BlogArticles.tsx`, `components/community/JobBoard.tsx`, `components/shared/AdSenseBanner.tsx`, `services/clarity.ts`, `services/recaptchaLoader.ts` (loader di script terze-parti/contenuto).
- **Revert-trigger** (non build-verificabile pre-merge): la correttezza del refetch `cache:'reload'`+reload è coperta da unit test; l'effetto end-to-end del busting HTTP cross-origin si osserva solo post-deploy. Se un prossimo deploy producesse loop di reload o mancata recovery → revert.

Closes #3097