### PR TITLE
fix(jobs): relocation bridge (not orphan tombstone) for live cross-canton legacy-TI URLs

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9843,6 +9843,16 @@ ${staticAnalyticsHtml}
  // be non-reciprocal and could trip audit-hreflang #4. Declared in the merge
  // scope so the emit loop (same closure, reads `tracking` directly) can read it.
  const cantonDriftCompatSlugs = new Set<string>();
+ // Active-job canton-drift recovery: when the compat-merge below overwrites an
+ // ACTIVE job's locale path with its legacy-TI drift URL, remember the job's
+ // REAL (live) canonical path, keyed by the drift compat path. The self-healing
+ // pass (search activeDriftRealPathByCompat) reads this to emit a relocation
+ // bridge pointing at the live page instead of a "job removed" tombstone — the
+ // job is ALIVE (served at its current canton URL), so the orphan stub was a
+ // soft-404 regression on the indexed legacy-TI URL (e.g. a VS Swiss-Life job
+ // 404-orphaned at /fr/trouver-emploi-tessin/<slug>/ while live at
+ // /fr/trouver-emploi-valais/<slug>/).
+ const activeDriftRealPathByCompat = new Map<string, string>();
  try {
  const compatPaths: string[] = readCompatPaths(rootDir).paths;
  let compatAdded = 0;
@@ -9921,6 +9931,13 @@ ${staticAnalyticsHtml}
  // drifted indexed URL is correct.
  if (known && !currentSlugs.has(slug)) break;
  if (known) cantonDriftCompatSlugs.add(slug);
+ // ACTIVE job whose live canonical path we're about to overwrite with the
+ // drift URL: stash the real path so the self-healing pass emits a relocation
+ // bridge to the live page instead of a "job removed" tombstone (see
+ // activeDriftRealPathByCompat declaration). `known` is the pre-overwrite
+ // ledger path (the job's current canton URL); `compatPath` is the legacy-TI
+ // drift URL that becomes the new tracking value.
+ if (known && currentSlugs.has(slug)) activeDriftRealPathByCompat.set(compatPath, known);
  (tracking[slug] as Record<string, string>)[locale] = compatPath;
  compatAdded++;
  break;
@@ -12037,6 +12054,7 @@ ${staticAnalyticsHtml}
  // This handles edge cases like locale-variant tracking keys that match a
  // currentSlug value but whose locale paths differ from the active job paths.
  let healedCount = 0;
+ let relocatedActiveCount = 0;
  for (const [, paths] of Object.entries(tracking) as [string, Record<string, string>][]) {
  for (const locale of localeList) {
  const relPath = paths?.[locale];
@@ -12049,6 +12067,37 @@ ${staticAnalyticsHtml}
  const absFile = np.join(distDir, relPath.replace(/^\//, ''), 'index.html');
  if (_writtenPaths.has(absFile)) continue;
  const __tSelfHealing = startTimer();
+
+ // Active cross-canton job: this tracking path is the job's legacy-TI drift
+ // URL, overwritten by the compat-merge above (search activeDriftRealPathByCompat).
+ // The job is ALIVE at `driftRealPath` (its current canton page), so emit a
+ // RELOCATION bridge pointing users + Google there, NOT a "job removed"
+ // tombstone. The bridge's canonical/CTA both target the live page, so equity
+ // consolidates to the real canton URL and visitors reach the open offer.
+ const driftRealPath = activeDriftRealPathByCompat.get(relPath);
+ if (driftRealPath) {
+ const realUrl = `${BASE_URL}${withSlash(driftRealPath)}`;
+ const movedCopy = ({
+ it: { title: 'Annuncio spostato', body: 'Questo annuncio è ora pubblicato in un\'altra sezione. Aprilo alla pagina aggiornata qui sotto.', cta: 'Apri l\'annuncio aggiornato' },
+ en: { title: 'Listing moved', body: 'This listing is now published in another section. Open it on the updated page below.', cta: 'Open the updated listing' },
+ de: { title: 'Anzeige verschoben', body: 'Diese Anzeige ist jetzt in einem anderen Bereich veröffentlicht. Öffnen Sie sie auf der aktualisierten Seite unten.', cta: 'Aktualisierte Anzeige öffnen' },
+ fr: { title: 'Offre déplacée', body: 'Cette offre est désormais publiée dans une autre section. Ouvrez-la sur la page à jour ci-dessous.', cta: 'Ouvrir l\'offre à jour' },
+ } as const)[locale] ?? { title: 'Annuncio spostato', body: 'Questo annuncio è ora pubblicato in un\'altra sezione.', cta: 'Apri l\'annuncio aggiornato' };
+ const movedHtml = buildCanonicalBridgePage({
+ canonicalUrl: realUrl,
+ pathLabel: withSlash(driftRealPath),
+ title: `${movedCopy.title} | Frontaliere Ticino`,
+ description: movedCopy.body,
+ body: movedCopy.body,
+ ctaLabel: movedCopy.cta,
+ lang: locale,
+ noindex: true,
+ });
+ writeSoftLandingPage(relPath.replace(/^\//, ''), movedHtml);
+ relocatedActiveCount++;
+ recordEmit('self-healing', __tSelfHealing);
+ continue;
+ }
 
  const listingPath = `${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/');
  const listingUrl = `${BASE_URL}${withSlash(listingPath)}`;
@@ -12073,6 +12122,9 @@ ${staticAnalyticsHtml}
  healedCount++;
  recordEmit('self-healing', __tSelfHealing);
  }
+ }
+ if (relocatedActiveCount > 0) {
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Relocated ${relocatedActiveCount} active cross-canton drift URLs to their live canonical page (no orphan tombstone)`);
  }
  if (healedCount > 0) {
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Self-healed ${healedCount} tracking paths with no prior coverage`);

--- a/tests/cross-canton-active-drift-bridge.test.ts
+++ b/tests/cross-canton-active-drift-bridge.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+const jobsSeoSrc = fs.readFileSync(
+  path.resolve(root, 'build-plugins/jobsSeoPagesPlugin.ts'),
+  'utf-8',
+);
+
+// Regression guard for the cross-canton ACTIVE-job orphan bug.
+//
+// A non-TI job that is ALIVE (e.g. a Valais Swiss-Life listing) keeps a legacy
+// indexed URL under the Ticino section (/fr/trouver-emploi-tessin/<slug>/). The
+// compat-merge OVERWRITES that active job's locale tracking path with this drift
+// URL (so the live job is the one served at its real canton page). Before this
+// fix the drift URL then fell through to the self-healing pass, which emitted a
+// `noindex` "offer removed" tombstone — a soft-404 for a LIVE job, served as a
+// bundle-less stub so the SPA-side cross-canton fallback could never recover it.
+//
+// The fix: stash the job's real (live) canonical path at overwrite time, and in
+// the self-healing pass emit a RELOCATION bridge whose canonical + CTA point at
+// the live canton page instead of the tombstone.
+describe('Cross-canton active-job drift URL → relocation bridge (not orphan)', () => {
+  it('stashes the live canonical path only for ACTIVE jobs at compat-merge overwrite', () => {
+    // The capture must be gated on currentSlugs (active) — expired jobs already
+    // `break` earlier and must NOT be relocated (their native page is gone).
+    expect(jobsSeoSrc).toContain('const activeDriftRealPathByCompat = new Map<string, string>();');
+    expect(jobsSeoSrc).toMatch(
+      /if \(known && currentSlugs\.has\(slug\)\) activeDriftRealPathByCompat\.set\(compatPath, known\);/,
+    );
+    // Capture must happen BEFORE the tracking value is overwritten with the drift path,
+    // so `known` still holds the live canonical path.
+    const captureIdx = jobsSeoSrc.indexOf('activeDriftRealPathByCompat.set(compatPath, known)');
+    const overwriteIdx = jobsSeoSrc.indexOf('(tracking[slug] as Record<string, string>)[locale] = compatPath;');
+    expect(captureIdx).toBeGreaterThan(-1);
+    expect(overwriteIdx).toBeGreaterThan(-1);
+    expect(captureIdx).toBeLessThan(overwriteIdx);
+  });
+
+  it('self-healing emits a relocation bridge to the LIVE page for active drift URLs', () => {
+    // The self-healing pass must consult the stash by the tracking path...
+    expect(jobsSeoSrc).toMatch(/const driftRealPath = activeDriftRealPathByCompat\.get\(relPath\);/);
+    // ...and build a canonical bridge whose canonicalUrl is the live page (BASE_URL +
+    // the real canton path), NOT the section listing root.
+    expect(jobsSeoSrc).toMatch(/const realUrl = `\$\{BASE_URL\}\$\{withSlash\(driftRealPath\)\}`;/);
+    const branchIdx = jobsSeoSrc.indexOf('const driftRealPath = activeDriftRealPathByCompat.get(relPath);');
+    const branch = jobsSeoSrc.slice(branchIdx, branchIdx + 1600);
+    expect(branch).toContain('canonicalUrl: realUrl');
+    expect(branch).toContain('pathLabel: withSlash(driftRealPath)');
+    // Must short-circuit before the orphan tombstone below.
+    expect(branch).toContain('continue;');
+  });
+
+  it('relocation bridge carries a "moved" message in all four locales (not "removed")', () => {
+    const branchIdx = jobsSeoSrc.indexOf('const driftRealPath = activeDriftRealPathByCompat.get(relPath);');
+    const branch = jobsSeoSrc.slice(branchIdx, branchIdx + 1600);
+    // One entry per locale, framed as a relocation rather than a removal.
+    expect(branch).toMatch(/it:\s*\{[^}]*Annuncio spostato/);
+    expect(branch).toMatch(/en:\s*\{[^}]*Listing moved/);
+    expect(branch).toMatch(/de:\s*\{[^}]*Anzeige verschoben/);
+    expect(branch).toMatch(/fr:\s*\{[^}]*Offre déplacée/);
+  });
+});


### PR DESCRIPTION
## Problema

`https://frontaliereticino.ch/fr/trouver-emploi-tessin/conseiller-en-immobilier-f-h-d-agence-generale-sion-valais-romand-swiss-life-ch/` serviva una pagina **"Cette offre a été mise à jour ou supprimée"** (orphan tombstone, `noindex`, **senza bundle React**) per un job **VIVO**.

Diagnosi live:
- Job `swiss-life-e12b28060b4c`, canton **VS**, ALIVE (crawled 2026-06-28).
- Pagina canonica `/fr/trouver-emploi-valais/<slug>/` = full content (24 KB) ✓.
- Bridge legacy-TI `/fr/trouver-emploi-tessin/<slug>/` = stub orphan 2.6 KB ✗.
- Lo stub è bundle-less → il fallback SPA cross-canton (#3069) **non può** recuperarlo (non monta nessun JobBoard; zero fetch `/data/`).

Causa (in `jobsSeoPagesPlugin.ts`): il compat-merge dei 404 GSC, per un job **ATTIVO** con path-ledger noto, **sovrascrive** `tracking[slug][locale]` con l'URL drift legacy-TI (riga ~9924), aspettandosi un soft-landing ricco lì. Ma nessun soft-landing viene emesso per un job attivo → il path drift cade nel **self-healing** che emette un **tombstone "offerta rimossa"** (un soft-404 per un job vivo). Pattern su ~10k URL FR (e molti EN/DE) di job vivi non-TI.

## Implementato

- `jobsSeoPagesPlugin.ts`: nuova mappa `activeDriftRealPathByCompat` che, al momento dell'overwrite del compat-merge per un job **attivo** (`known && currentSlugs.has(slug)`), salva il **path canonico reale (vivo)** del job, keyed sull'URL drift.
- Self-healing pass: prima di emettere il tombstone, consulta `activeDriftRealPathByCompat.get(relPath)`; se presente (= job vivo, drift cross-canton) emette un **relocation bridge** con `canonicalUrl` **e** CTA che puntano alla **pagina viva** (`/fr/trouver-emploi-valais/<slug>/`), copy "annuncio spostato / listing moved / Anzeige verschoben / offre déplacée" in tutti e 4 i locali, `noindex,follow`. L'equity consolida sull'URL canton reale e l'utente raggiunge l'offerta aperta.
- Solo le pagine che **prima** ricevevano il tombstone per un job attivo cambiano; i job realmente scaduti (compat path net-new senza ledger) mantengono il tombstone via `healedCount`. Nessun path attualmente funzionante è toccato.
- Nuovo log `Relocated N active cross-canton drift URLs…`.
- Test regressione source-based `tests/cross-canton-active-drift-bridge.test.ts` (3 test): cattura gated su `currentSlugs` + ordine prima dell'overwrite; branch self-healing usa `canonicalUrl: realUrl` (pagina viva, non listing) e `continue` prima del tombstone; copy "moved" nei 4 locali.

Verifica: `vitest` verde su `bridge-canton-aware`, `search-console-compat`, `orphan-canton-paths`, `cf-hot-404-bridge`, `previous-slugs-bridge`, `noindex-builders`, `bridge-orphan-flicker-guard`, `audit-orphan-pages`, `canton-orphan-redirects` + nuovo test (70+ test). `tsc --noEmit` pulito sui file toccati. Sibling-pattern check: solo token generici condivisi (falsi positivi) — l'antipattern overwrite→tombstone vive solo qui.

## Non implementato (ancora)

- **Validazione SSG-emit solo post-merge (revert-trigger):** il comportamento di emit (relocation bridge invece di tombstone, conteggio `Relocated N`) gira solo nella build SEO completa (`build:ci`), che OOMa in locale e gira solo su `main` post-merge. Non è verificabile sul `pull_request`. **Se il prossimo deploy mostra un crollo del conteggio relocation atteso, errori di emit, o regressione mem/wall-time sul path SSG → revert.** Verifica live post-deploy: `curl` di `/fr/trouver-emploi-tessin/conseiller-en-immobilier-f-h-d-agence-generale-sion-valais-romand-swiss-life-ch/` deve servire un relocation bridge con `<link rel=canonical>` → `/fr/trouver-emploi-valais/<slug>/` (non il tombstone "mise à jour ou supprimée").
- **Full-content al bridge (non in scope):** servire il contenuto completo del job direttamente all'URL legacy-TI (anziché un relocation bridge sottile) raddoppierebbe ~30k pagine full-content su un path SSG memory-bound/OOM-prone → scartato per rischio memoria; il relocation bridge (canonical+CTA→pagina viva, equity consolidata) è la scelta SEO-corretta e memory-neutral.

Adiacente al tema orphan-recovery di #2923/#3015 ma meccanismo distinto (job-detail attivo canton-drift nel self-healing, non cluster/pagination) → niente `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)