### PR TITLE
chore(ci): cut autonomous-loop Claude burn (anti-churn + parked-retry throttle)

### DIFF
--- a/scripts/ci/check-issue-already-resolved.mjs
+++ b/scripts/ci/check-issue-already-resolved.mjs
@@ -164,11 +164,22 @@ function main() {
     return;
   }
 
-  const raw = gh(['issue', 'view', ISSUE, ...repoArgs, '--json', 'number,title,body,labels'], { allowFail: true });
+  const raw = gh(['issue', 'view', ISSUE, ...repoArgs, '--json', 'number,title,body,labels,state'], { allowFail: true });
   if (!raw) { console.log('Issue fetch failed — proceeding.'); setOutput(false); return; }
 
   let iss;
   try { iss = JSON.parse(raw); } catch { console.log('Issue parse failed — proceeding.'); setOutput(false); return; }
+
+  // CLOSED short-circuit (#3116-class): if the issue was already closed (resolved organically,
+  // or by close-recovered-failure-issues) before the `agent:fix` labeled-event reached the
+  // fixer, a Claude run reproduces a closed issue's fix for nothing. Skip with NO side-effects
+  // (no label churn on a closed issue). issue-fix routing already skips non-OPEN; this closes
+  // the race where the close lands between label and run. Proceed-safe: unknown state → fall through.
+  if (String(iss.state || '').toUpperCase() === 'CLOSED') {
+    console.log(`Issue #${ISSUE} is CLOSED — short-circuit, skip Claude fixer (no work on a closed issue).`);
+    setOutput(true);
+    return;
+  }
 
   const labels = (iss.labels || []).map((l) => l.name);
   // Only follow-up issues carry the cited-file / suggested-action structure this matcher
@@ -258,6 +269,33 @@ ${OUTCOME}`;
     shortCircuit(
       `⏭️ **Pre-flight (auto, zero-Claude)**: la PR **#${closer}** (già mergiata) dichiara esplicitamente di chiudere/superare questa issue (\`Closes\`/\`Supersedes #${ISSUE}\`) ma GitHub non l'ha auto-chiusa — probabile **done-but-open** (es. \`Closes #a #b\` multi-issue: chiude solo la prima). Salto il fixer autonomo per non sprecare quota Max OAuth.`,
       `- dichiarata risolta da #${closer} (merged)`,
+    );
+    return;
+  }
+
+  // SIGNAL 1b (own-branch merge): the autonomous fixer names its branch `fix/issue-<N>`
+  // (issue-fix.yml § "Branch isolato"). A MERGED PR on EXACTLY that head means the fixer
+  // already landed this (non-aggregate) follow-up's fix — even when the PR carried no
+  // `Closes #N` keyword (SIGNAL 1 requires one). This is the #3116-class waste: the drainer
+  // re-applies `agent:fix` AFTER the fix merged → a full Claude run reproduces an
+  // already-merged fix and burns shared Max quota (often ending in error_max_turns + a RED
+  // job). Aggregates already returned above (one item merged ≠ all), so this only fires for
+  // single-item follow-ups whose own fix-branch landed. Proceed-safe: unreadable/empty list
+  // → skip this signal, fall through to the token matcher.
+  let mergedOwnBranch = null;
+  try {
+    const ownBranchPrs = JSON.parse(
+      gh(['pr', 'list', '--state', 'merged', '--head', `fix/issue-${ISSUE}`, ...repoArgs,
+          '--json', 'number,mergedAt', '--limit', '5'], { allowFail: true }) || '[]',
+    );
+    const m = ownBranchPrs.find((pr) => pr.mergedAt);
+    mergedOwnBranch = m ? m.number : null;
+  } catch { mergedOwnBranch = null; }
+  if (mergedOwnBranch) {
+    console.log(`Issue #${ISSUE}: the fixer's own branch fix/issue-${ISSUE} already merged in PR #${mergedOwnBranch} → short-circuit, skip Claude fixer.`);
+    shortCircuit(
+      `⏭️ **Pre-flight (auto, zero-Claude)**: il branch del fixer autonomo \`fix/issue-${ISSUE}\` risulta **già mergiato** nella PR **#${mergedOwnBranch}** — il fix per questa follow-up single-item è già landato (anche senza \`Closes #${ISSUE}\`). La re-label \`agent:fix\` (drainer) farebbe ripartire una run Claude che riproduce un fix già fatto (classe #3116). Salto il fixer per non sprecare quota Max OAuth.`,
+      `- fix già mergiato in #${mergedOwnBranch} (branch \`fix/issue-${ISSUE}\`)`,
     );
     return;
   }

--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -54,8 +54,8 @@ const LBL_PARKED = 'fu-parked';
 // agent:fix-queued) non verrà mai drenato: chiudilo (riapribile se ricorre). I
 // `fu-parked` (tentativi esauriti) sono i candidati principali. Drain, non
 // perdita: commento esplicito + reversibile. 0 disabilita.
-const AGEOUT_DAYS = Number(process.env.FOLLOWUP_AGEOUT_DAYS || 21);
-const AGEOUT_INACTIVE_DAYS = Number(process.env.FOLLOWUP_AGEOUT_INACTIVE_DAYS || 14);
+const AGEOUT_DAYS = Number(process.env.FOLLOWUP_AGEOUT_DAYS || 10);
+const AGEOUT_INACTIVE_DAYS = Number(process.env.FOLLOWUP_AGEOUT_INACTIVE_DAYS || 7);
 const AGEOUT_MAX_PER_RUN = Number(process.env.FOLLOWUP_AGEOUT_MAX_PER_RUN || 20);
 
 // Esiti FIX_OUTCOME (contratto ISSUES.md: il fixer chiude ogni run con
@@ -272,16 +272,21 @@ const prioRank = (iss) => (has(iss, 'fu-prio:high') ? 0 : 1); // high prima
 // --- PARKED-RETRY: ri-accoda i parked ritentabili (convergenza backlog) -------
 // Un follow-up va `fu-parked` dopo MAX_ATTEMPTS fix falliti. Molti fallirono per
 // cause ORA risolte (cap turni #1919/#1952, aggregate-sweep #1979, drift #2007):
-// restano un pool stagnante che NON drena fino all'age-out 21gg. Questo ri-prova
+// restano un pool stagnante che NON drena fino all'age-out 10gg. Questo ri-prova
 // i parked con il fixer migliorato, BOUNDED (no loop infinito):
 //   - skip WF-scope (capability-guard: il fixer CI non può toccare workflows →
 //     re-fail garantito; restano umani/age-out);
 //   - cooldown: solo parked fermi da ≥ RETRY_COOLDOWN_DAYS (non i freschi);
 //   - generation-cap: `fu-reparked:N` ≤ MAX_REPARK_GEN (poi resta parked stabile);
 //   - cap/run anti-burst.
-const RETRY_COOLDOWN_DAYS = Number(process.env.FOLLOWUP_RETRY_COOLDOWN_DAYS || 2);
-const MAX_REPARK_GEN = Number(process.env.FOLLOWUP_MAX_REPARK_GEN || 2);
-const RETRY_MAX_PER_RUN = Number(process.env.FOLLOWUP_RETRY_MAX_PER_RUN || 5);
+// Token-frugality (2026-06-30): default abbassati per strozzare il ri-burn di
+// quota Max sui parked già falliti MAX_ATTEMPTS×. Cooldown 2→5gg (ri-prova meno
+// spesso), repark-gen 2→1 (un solo giro di retry, poi parked stabile fino
+// all'age-out), cap/run 5→1 (no burst di run Claude su pool a basso rendimento).
+// Override via env se serve più aggressività di convergenza.
+const RETRY_COOLDOWN_DAYS = Number(process.env.FOLLOWUP_RETRY_COOLDOWN_DAYS || 5);
+const MAX_REPARK_GEN = Number(process.env.FOLLOWUP_MAX_REPARK_GEN || 1);
+const RETRY_MAX_PER_RUN = Number(process.env.FOLLOWUP_RETRY_MAX_PER_RUN || 1);
 const reparkGenOf = (iss) => {
   const m = names(iss).map((n) => /^fu-reparked:(\d+)$/.exec(n)).find(Boolean);
   return m ? parseInt(m[1], 10) : 0;


### PR DESCRIPTION
## Contesto

Audit consumo token (owner, 2026-06-30): con l'owner quasi-idle il loop autonomo `post-merge-followup → drainer → issue-fix → pr-review-loop` gira a **~170-210 sessioni-agent Claude/giorno** sulla quota Max condivisa. Questa è la **PR-1 (Tier 1)** di una serie di ottimizzazioni rule-safe: riduce il NUMERO di invocazioni per architettura, **senza abbassare alcun max-turns né quality gate** (per AGENTS.md la frugalità si ottiene così).

## Implementato

- **`scripts/ci/check-issue-already-resolved.mjs` — anti-churn pre-flight (zero-Claude, deterministico):**
  - **CLOSED short-circuit:** se la issue è già `CLOSED` quando l'evento `agent:fix` raggiunge il fixer, salta la run Claude (nessuna side-effect su issue chiusa). Difesa-in-profondità sulla race tra close e run.
  - **SIGNAL 1b (own-branch merge):** se il branch del fixer `fix/issue-<N>` risulta **già mergiato** — anche senza keyword `Closes #N` (che SIGNAL 1 richiede) — short-circuit. Elimina la classe di spreco **#3116**: il drainer ri-applica `agent:fix` *dopo* che il fix è mergiato → una run opus/sonnet intera (spesso `error_max_turns` + job RED) riproduce lavoro già fatto. Aggiunto `state` ai campi `gh issue view`.
  - **Proceed-safe:** aggregate (multi-item) escono prima, e stato sconosciuto/illeggibile → fall-through al token matcher (mai un falso short-circuit che perde lavoro reale).

- **`scripts/ci/followup-drainer.mjs` — throttle del parked-retry (default abbassati, override via env):**
  - `RETRY_COOLDOWN_DAYS 2→5`, `MAX_REPARK_GEN 2→1`, `RETRY_MAX_PER_RUN 5→1`: il drainer smette di ri-bruciare quota su item già falliti `MAX_ATTEMPTS×` (pool a basso rendimento, custode-confermato ~14 item).
  - `AGEOUT_DAYS 21→10`, `AGEOUT_INACTIVE_DAYS 14→7`: drena il backlog stagnante per **chiusura** invece che per costosi re-fix. A coda reale vuota → `issue-fix` va idle → cala anche `pr-review-loop` (il #1 burner) di riflesso.
  - Aggiornato il commento stale "age-out 21gg → 10gg".

**Test:** 64 test CI-script verdi (`check-issue-already-resolved-aggregate`, `followup-drainer-outcome`, `followup-drainer-workflow-scope`, `followup-resolution-match`). `node --check` OK su entrambi gli script.

**Sibling-pattern:** `check-sibling-patterns.mjs` segnala solo token **generici** (`allowFail` helper, `MAX_ATTEMPTS` costante NON toccata, `mergedAt` campo gh) → **falsi positivi lessicali** (token condivisi ≠ stesso antipattern, per disclaimer del tool stesso). Nessuna classe-bug duplicata da sweepare: il cambio è di knob/gate comportamentale, non un costrutto regex/guard copiato.

## Non implementato (ancora)

- **Batch di `post-merge-followup`** (~22-27 Claude/giorno, il #2 consumatore, ~60-80% delle run creano ZERO issue): conversione del trigger da per-PR a schedulato (ogni ~3h, una sessione su tutte le PR mergiate dall'ultima run di successo, con collect-script watermark + idempotenza sul commento di triage). → **PR concatenata (in arrivo) sullo stesso task**; è una ri-architettura del trigger e va isolata per non bloccare queste vincite deterministiche.
- **Tier 2 — `pr-review-loop`** (429-backoff + serializzazione review opus + debounce re-review + prefilter esteso): **PR dedicata** (toccare `pr-review-loop.yml` con 🔴 pregressi può fare deadlock auto-merge → isolata e sequenziata).
- **Tier 3 — opus→sonnet** sui path crawler/parser in review (owner-approved, 2026-06-30): **PR concatenata dopo il merge della Tier 2** (entrambe toccano `pr-review-loop.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)