### PR TITLE
feat(email): re-enable maileroo provider in the cascade (DMARC-aligned)

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -43,13 +43,14 @@ const PROVIDERS = [
   { id: 'resend',   dailyLimit: 100, monthlyLimit: 3000  },
   { id: 'mailjet',  dailyLimit: 200, monthlyLimit: 6000  },
   { id: 'mailtrap', dailyLimit: 150, monthlyLimit: 4000  },
-  // maileroo: DISABLED by choice (not by a missing record). The DKIM selector
-  // mta._domainkey.frontaliereticino.ch IS now published (added 2026-06-30) and
-  // the domain is at DMARC p=reject, so Maileroo can sign DMARC-aligned mail.
-  // It is kept out of the cascade pending an owner decision + confirmation, over
-  // the next DMARC report window, that Maileroo's mail actually passes alignment.
-  // Re-enable by uncommenting the entry below once that is confirmed.
-  // { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
+  // maileroo: free tier (100/day). DKIM selector mta._domainkey.frontaliereticino.ch
+  // is published and Maileroo signs DMARC-aligned. Verified 2026-06-30 with a live
+  // test send to Gmail (X-Maileroo-Ref-Id 411800c3...): dkim=pass
+  // header.i=@frontaliereticino.ch s=mta, spf=pass smtp.mailfrom=@frontaliereticino.ch
+  // (return-path on our domain, 85.204.106.x authorized via include:_spf.maileroo.com),
+  // dmarc=pass at p=reject (dis=NONE), delivered to inbox. Placed before cloudflare so
+  // the purely-free providers are preferred over the paid Workers quota.
+  { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
   // Cloudflare Email Service: limit is MONTHLY (3000/mo included on Workers Paid),
   // there is no documented per-day cap. dailyLimit is the 3000/30 ≈ 100/day spread
   // so the in-memory guard keeps a single day from burning a disproportionate


### PR DESCRIPTION
Riattivazione di **Maileroo** nella catena di invio email. Il blocco era il record DKIM mancante (causa reale di #3066); ora `mta._domainkey.frontaliereticino.ch` è pubblicato e Maileroo firma allineato.

## Implementato
- `scripts/lib/email-cascade.mjs`: ri-aggiunto `{ id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000 }` in `PROVIDERS`, posizionato **prima di cloudflare** (i provider puramente free precedono la quota paid Workers). Commento aggiornato con l'evidenza di verifica.
- Nessun altro wiring necessario: counter, usage-log, `isConfigured('maileroo')` e la provider-fn map (`maileroo: sendViaMaileroo`) erano già presenti e si basano su `PROVIDERS` / il branch maileroo.

**Evidenza (test reale, 2026-06-30, X-Maileroo-Ref-Id `411800c3...`, send via Maileroo API → Gmail):**
```
dkim=pass  header.i=@frontaliereticino.ch s=mta
spf=pass   smtp.mailfrom=abuse@frontaliereticino.ch  (85.204.106.10 via include:_spf.maileroo.com)
dmarc=pass (p=REJECT sp=REJECT dis=NONE)  — consegnata in inbox
```
Sia SPF (return-path sul nostro dominio) sia DKIM (selector `mta`, `d=frontaliereticino.ch`) sono allineati → DMARC passa a `p=reject`. Il "0% pass" storico era solo per DKIM assente, ora risolto. DNS verificato live: DKIM TXT + click CNAME (`click.frontaliereticino.ch → click.maileroo.net`) pubblicati su Cloudflare.

Test impattati verdi localmente: `email-cascade-burst` + `public-config-allowlist` (25/25).

## Non implementato (ancora)
- Nessuno. Lo scope (riattivazione Maileroo dopo verifica deliverability) è completo. Il monitor DMARC (#3066, già chiuso) confermerà il pass anche sulla finestra di report aggregati nelle prossime ~24h; nessuna azione ulteriore dovuta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)