### PR TITLE
fix(seo): re-baseline BFS-depth ratchet for sitemap-jobs-ticino (unblock validate-dist)

### DIFF
--- a/data/bfs-depth-baseline.json
+++ b/data/bfs-depth-baseline.json
@@ -270,11 +270,11 @@
       "deepest": 7
     },
     "sitemap-jobs-ticino.xml": {
-      "total": 2033,
-      "reached": 2033,
-      "atDepthGtMax": 756,
-      "ratePct": 37.1864,
-      "deepest": 8
+      "total": 2902,
+      "reached": 2902,
+      "atDepthGtMax": 1516,
+      "ratePct": 52.2398,
+      "deepest": 7
     },
     "sitemap-jobs-turgovia.xml": {
       "total": 239,


### PR DESCRIPTION
## Contesto

Il gate post-deploy `validate-dist` → `audit:max-bfs-depth` fallisce su `main` (run [28418018516](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28418018516)) e **blocca il job `publish`** (IndexNow / Google Indexing API / GSC ping → indicizzazione fresh-content sospesa). Unico gate rosso:

```
sitemap-jobs-ticino.xml: rate 52.24% below crawl depth (allowed ≤ 47.76%, baseline 37.19%)
  — 1516 URLs vs baseline 756, deepest now 7
```

## Causa (deliberata, non un bug)

Tutti i 20+ sitemap per-cantone (`berna`, `basilea`, `zurigo`, …) sono **già** baselinati a ~75% buried: i job non-TI stanno in fondo per design (il sito è funnel TI-centrico). L'espansione crawler CH-wide (#2958/#3046) + il dual-emit del relocation-bridge non-TI (#3069/#3144) ha portato ~760 job non-TI in più sul route `/find-jobs-ticino/`. Gli hub TI linkano prima i job TI → questi bridge stanno a depth 6-7, raggiungibili solo via deep pagination. `jobs-ticino` è in transizione verso lo stesso equilibrio ~75% dei sibling; a 52% è ancora **sotto** il rate già accettato per ogni altro cantone.

Diff: tutti i sibling sono cresciuti in conteggio (berna +2207, zurigo +2968…) ma a **rate piatto** → passano (il rate-ratchet ignora la crescita organica). Solo `jobs-ticino` ha mosso il **rate** → unico fail.

## Implementato

- Re-floor del ratchet BFS-depth per `sitemap-jobs-ticino.xml` in `data/bfs-depth-baseline.json` ai conteggi reali del dist deployato (dall'output `--json` autorevole del run 28418018516): `total 2033→2902`, `reached 2033→2902`, `atDepthGtMax 756→1516`, `ratePct 37.1864→52.2398`, `deepest 8→7`. **Nessuna pagina tagliata o noindexata** — è l'operazione-ratchet documentata (`audit:max-bfs-depth:rebaseline` / `seed-bfs-depth-baseline.yml`).
- Verifica con la funzione-core del gate stesso (`evaluateBfsGate`) contro i conteggi candidate reali: **0 regressions, 0 hard-fails → gate PASS**. Resta solo il warning non-gating `sitemap-salary-stats.xml` (16.67%, ≪ soglia hard-fail 90%), identico al run fallito.
- `tests/seo/audit-bfs-depth-rate-gate.test.ts`: 10/10 verdi.

## Non implementato (ancora)

- **Fix strutturale permanente (de-index dei bridge non-TI da `sitemap-jobs-ticino.xml`, mantenendoli solo nel loro sitemap cantonale → `jobs-ticino` torna a ~37% e resta piatto):** NON fatto. De-indicizza ~760 URL bridge → richiede OK esplicito owner per le regole never-noindex/never-cut. **[blocked: decisione owner — area coperta dalla follow-up #3150 relocation-bridge].** È la via per rendere il gate *definitivamente* stabile invece del re-floor periodico.
- **Re-floor futuro durante la transizione 52%→~75%:** il nuovo cap è ~65% (`52.24·1.15+5`). Man mano che il dual-emit non-TI continua, `jobs-ticino` può richiedere 1-2 re-baseline di routine prima di plateauare a ~75% come i sibling. Trigger di re-baseline = stesso comando. **[tracked: manutenzione ratchet di routine].**
- **7 nuovi shard sitemap non baselinati** (`salary-stats` 16.67%; `blog-ch`/`eventi`/`profession-cantons`/`publisher-ads`/`search-clusters-006/7/8` a 0%): restano warning **non-gating** (<90%). **[deferred: prossimo full-rebaseline di routine, non-gating].**

## Verifica post-merge

- [ ] Prossimo deploy `main` → `validate-dist` / `audit:max-bfs-depth` verde → `publish` gira (IndexNow/GIA/GSC).