### PR TITLE
fix(job-alerts): backfill stale auto-derived sector fields (#2993)

### DIFF
--- a/scripts/backfill-personalization-sector.mjs
+++ b/scripts/backfill-personalization-sector.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Backfill: correct STALE auto-derived sector fields on subscriber profiles
+ * (issue #2993, follow-up to #3146).
+ *
+ * The daily personalization enrichment (send-job-alerts.mjs) is no-clobber: it
+ * only fills a BLANK field. Before #3146 the sector derivation summed
+ * viewed-job categories WITHOUT de-duping, so a subscriber whose ATS mis-tags N
+ * roles (e.g. EOC labels nurse jobs "admin") got `sector_interest` set to the
+ * repeated mis-tag (N×2 weight) instead of their EXPLICIT on-site category
+ * filter (×3). #3146 fixed the derivation for all FUTURE enrichments, but the
+ * already-written wrong value sticks forever (no-clobber never re-touches it).
+ *
+ * This one-shot re-derives sector with the fixed logic and overwrites ONLY when
+ * it is safe and demonstrably a correction:
+ *   • the profile was auto-enriched by us (`personalization_enriched_at` set);
+ *   • the freshly-derived sector is non-blank and DIFFERS from the stored one;
+ *   • the STORED sector is NOT one the user explicitly filtered by on-site
+ *     (`filterUsage.category`) — so an intentional sector is never overwritten.
+ * It touches only `sector_interest` / `job_category`; location/company/search
+ * fields (which may come from signup geo, not personalization) are left intact.
+ *
+ * Reuses the SAME pure `derivePersonalizationPatch` as the live pipeline (no
+ * logic fork): the enrichable fields are blanked so the no-clobber derivation
+ * re-emits the ideal sector.
+ *
+ * Default is DRY RUN. Pass --apply to write. --limit N caps scanned profiles;
+ * --email <addr> targets a single subscriber (useful for verification).
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=<sa.json> node scripts/backfill-personalization-sector.mjs
+ *   GOOGLE_APPLICATION_CREDENTIALS=<sa.json> node scripts/backfill-personalization-sector.mjs --apply
+ */
+
+import { pathToFileURL } from 'node:url';
+import {
+  derivePersonalizationPatch,
+  PERSONALIZATION_FIELDS,
+} from './lib/subscriber-personalization.mjs';
+
+const SECTOR_FIELDS = ['sector_interest', 'job_category'];
+
+function parseArgs(argv) {
+  const args = { apply: false, limit: Infinity, email: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--apply') args.apply = true;
+    else if (a === '--limit') args.limit = Number(argv[++i]) || Infinity;
+    else if (a === '--email') args.email = String(argv[++i] || '').toLowerCase().trim();
+  }
+  return args;
+}
+
+async function getFirestoreAdmin() {
+  const admin = await import('firebase-admin');
+  if (!admin.default.apps?.length) {
+    admin.default.initializeApp({
+      credential: admin.default.credential.applicationDefault(),
+      projectId: process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || 'frontaliere-ticino',
+    });
+  }
+  return { db: admin.default.firestore(), FieldValue: admin.default.firestore.FieldValue };
+}
+
+const norm = (v) => String(v || '').trim().toLowerCase();
+
+/**
+ * Compute the safe sector correction for one subscriber, or null when nothing
+ * should change.
+ * @returns {Record<string,string>|null}
+ */
+export function computeSectorCorrection(subscriber, personalization, alerts) {
+  // Blank the enrichable fields so the no-clobber derivation re-emits the ideal.
+  const blanked = { ...subscriber };
+  for (const f of PERSONALIZATION_FIELDS) blanked[f] = '';
+  const ideal = derivePersonalizationPatch({ subscriber: blanked, personalization, alerts, clicked: null }) || {};
+
+  // The categories the user EXPLICITLY filtered by on-site. This backfill ONLY
+  // repairs the precise #3146 bug — an explicit category filter that was
+  // overridden by repeated mis-tagged viewed-job categories. So we correct a
+  // field ONLY when the freshly-derived value IS an explicitly-filtered category
+  // AND the stored value is NOT. That avoids re-deriving on drifted browsing
+  // data (which could flip a still-valid sector, e.g. health → tech, without
+  // any explicit signal behind it) — those are left untouched.
+  const explicitCategories = new Set(
+    Object.keys(personalization?.filterUsage?.category || {}).map(norm),
+  );
+
+  const correction = {};
+  for (const field of SECTOR_FIELDS) {
+    const stored = subscriber[field];
+    const next = ideal[field];
+    if (!next || !String(next).trim()) continue;          // nothing better to write
+    if (norm(stored) === norm(next)) continue;            // already correct
+    if (!explicitCategories.has(norm(next))) continue;    // new value isn't an explicit filter → not the bug
+    if (stored && explicitCategories.has(norm(stored))) continue; // stored is also explicit → user's choice
+    correction[field] = next;
+  }
+  return Object.keys(correction).length > 0 ? correction : null;
+}
+
+async function loadAlerts(db, email) {
+  const snap = await db.collection('job_alert_subscribers').doc(email).collection('alerts').get();
+  return snap.docs.map((d) => d.data());
+}
+
+async function loadPersonalization(db, email) {
+  const doc = await db.collection('newsletter_subscribers').doc(email)
+    .collection('private').doc('personalization').get();
+  return doc.exists ? doc.data() : null;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(args.apply ? '⚙️  APPLY mode — will write sector corrections' : '🔵 DRY RUN — no writes (pass --apply to commit)');
+  const { db, FieldValue } = await getFirestoreAdmin();
+
+  // Only profiles we previously auto-enriched carry the field; orderBy returns
+  // exactly those (Firestore skips docs missing the ordered field).
+  let query = db.collection('newsletter_subscribers').orderBy('personalization_enriched_at');
+  let docs;
+  if (args.email) {
+    const d = await db.collection('newsletter_subscribers').doc(args.email).get();
+    docs = d.exists ? [d] : [];
+  } else {
+    docs = (await query.get()).docs;
+  }
+  console.log(`   Candidate enriched profiles: ${docs.length}`);
+
+  let scanned = 0;
+  const corrections = [];
+  for (const doc of docs) {
+    if (scanned >= args.limit) break;
+    scanned++;
+    const email = doc.id;
+    const subscriber = doc.data() || {};
+    const [personalization, alerts] = await Promise.all([
+      loadPersonalization(db, email),
+      loadAlerts(db, email),
+    ]);
+    const correction = computeSectorCorrection(subscriber, personalization, alerts);
+    if (correction) {
+      corrections.push({ email, before: { sector_interest: subscriber.sector_interest, job_category: subscriber.job_category }, after: correction });
+    }
+  }
+
+  console.log(`   Scanned: ${scanned}   Corrections: ${corrections.length}`);
+  for (const c of corrections.slice(0, 50)) {
+    console.log(`   • ${c.email}: ${c.before.sector_interest ?? '∅'}/${c.before.job_category ?? '∅'} → ${c.after.sector_interest ?? '(keep)'}/${c.after.job_category ?? '(keep)'}`);
+  }
+  if (corrections.length > 50) console.log(`   … and ${corrections.length - 50} more`);
+
+  if (!args.apply) {
+    console.log('\n🔵 DRY RUN complete — re-run with --apply to write the above corrections.');
+    return;
+  }
+  if (corrections.length === 0) {
+    console.log('\n✅ Nothing to correct.');
+    return;
+  }
+
+  let written = 0;
+  // Small batches; this is a one-shot, no need for the chunked helper.
+  const CHUNK = 400;
+  for (let i = 0; i < corrections.length; i += CHUNK) {
+    const batch = db.batch();
+    for (const c of corrections.slice(i, i + CHUNK)) {
+      batch.set(db.collection('newsletter_subscribers').doc(c.email), {
+        ...c.after,
+        sector_backfilled_at: FieldValue.serverTimestamp(),
+        updated_at: FieldValue.serverTimestamp(),
+      }, { merge: true });
+      written++;
+    }
+    await batch.commit();
+  }
+  console.log(`\n✅ Applied ${written} sector correction(s).`);
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); });
+}

--- a/tests/backfill-personalization-sector.test.ts
+++ b/tests/backfill-personalization-sector.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { computeSectorCorrection } from '../scripts/backfill-personalization-sector.mjs';
+
+/**
+ * The backfill repairs ONLY the #3146 bug signature: an EXPLICIT on-site
+ * category filter that an old, non-de-duped derivation overrode with a repeated
+ * mis-tagged viewed-job category. It must never re-derive on drifted browsing
+ * data nor touch an intentionally-set sector.
+ */
+describe('backfill-personalization-sector — computeSectorCorrection', () => {
+  it('corrects a stale sector when an explicit filter was overridden by repeated mis-tagged views (#2993)', () => {
+    const correction = computeSectorCorrection(
+      { sector_interest: 'admin', job_category: 'admin' },
+      {
+        filterUsage: { category: { health: 1 } }, // explicit on-site filter
+        viewedJobs: Array.from({ length: 10 }, () => ({ category: 'admin' })), // ATS mis-tag noise
+      },
+      [],
+    );
+    expect(correction).toEqual({ sector_interest: 'health', job_category: 'health' });
+  });
+
+  it('is a no-op when the stored sector already matches the explicit filter', () => {
+    const correction = computeSectorCorrection(
+      { sector_interest: 'health', job_category: 'health' },
+      { filterUsage: { category: { health: 2 } }, viewedJobs: [{ category: 'health' }] },
+      [],
+    );
+    expect(correction).toBeNull();
+  });
+
+  it('does NOT re-derive on drifted views — only moves TO an explicitly-filtered category', () => {
+    // Stored health, no explicit filter, views now lean tech. The old value is
+    // not a bug footprint (no explicit filter behind tech) → leave it.
+    const correction = computeSectorCorrection(
+      { sector_interest: 'Sanita / Ospedali', job_category: 'Sanita / Ospedali' },
+      { filterUsage: {}, viewedJobs: Array.from({ length: 5 }, () => ({ category: 'tech' })) },
+      [],
+    );
+    expect(correction).toBeNull();
+  });
+
+  it('does NOT overwrite a sector that the user also explicitly filtered by', () => {
+    // Both health and admin explicitly filtered; stored admin is a real choice.
+    const correction = computeSectorCorrection(
+      { sector_interest: 'admin', job_category: 'admin' },
+      { filterUsage: { category: { admin: 1, health: 5 } }, viewedJobs: [] },
+      [],
+    );
+    expect(correction).toBeNull();
+  });
+
+  it('is a no-op when there is no personalization data', () => {
+    expect(computeSectorCorrection({ sector_interest: 'admin' }, null, [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Implementato

Follow-up concatenato a #3146. L'enrichment giornaliero è **no-clobber**: un `sector_interest` scritto **sbagliato** dalla derivazione pre-#3146 (una categoria di job vista e mal-etichettata, ripetuta, che schiacciava un filtro categoria **esplicito**) resta bloccato per sempre — non viene mai ri-toccato. #3146 ha corretto la *logica* per gli enrichment futuri; questo one-shot ripara i **valori già scritti**.

`scripts/backfill-personalization-sector.mjs` (dry-run di default, `--apply` per scrivere; `--email`/`--limit` per scope):
- Scansiona **solo** i profili che abbiamo auto-enriched (`personalization_enriched_at` presente).
- Riusa la **stessa** `derivePersonalizationPatch` pura (nessun fork di logica): blanca i campi enrichabili così la derivazione no-clobber corretta ri-emette il sector ideale.
- Corregge **solo la firma esatta del bug**: scrive un campo sector **iff** il valore ri-derivato È una categoria che l'utente ha **filtrato esplicitamente** on-site **E** il valore stale **non** lo è. Così non ri-deriva mai su dati di browsing andati alla deriva (che potrebbero ribaltare un sector ancora valido senza alcun segnale esplicito dietro) e non sovrascrive mai un sector filtrato di proposito. Tocca solo `sector_interest`/`job_category`; location/company/search restano intatti.

**Dry-run completo sui dati live:** 29 profili enriched → **2 correzioni**, entrambe con la firma del bug (un filtro `health` esplicito sovrascritto dal rumore delle view): il profilo dell'owner stesso (`sales`→`health`) e l'utente segnalato in #2993 (`admin`→`health`). Un guard più largo iniziale ne flaggava 8, inclusa una regressione `health`→`tech`: **il dry-run l'ha intercettata** e il guard è stato stretto alla regola del filtro-esplicito.

**Test:** 5 (corregge sulla firma; no-op su già-corretto / drift di view / filtro esplicito / nessun dato).

Closes #2993

## Non implementato (ancora)

- **Esecuzione di `--apply` sui 2 profili live** — step manuale **gated sull'OK owner** (è una scrittura su dati utente live, anche se minima/validata/reversibile via marker `sector_backfilled_at`). Next step: dopo il merge di questa PR, eseguo `node scripts/backfill-personalization-sector.mjs --apply` (impatto esatto: i 2 profili del dry-run) previa conferma. La precisione geografica (richiesta principale di #2993) è già **live** via #3146; questo apply chiude l'ultimo residuo di correttezza profilo.