### PR TITLE
chore(ci): switch high-tier Claude model from Opus to Sonnet 5

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -79,11 +79,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        # Tier high (opus, max-turns alti): issue funnel-critical — crawler/parser/
+        # Tier high (claude-sonnet-5, max-turns alti): issue funnel-critical — crawler/parser/
         # build-plugin/workflow CI/test gate, o uno script che MUTA/emette dati
         # indicizzati (backfill/migrate/assemble/sitemap/canonical/slug/
         # structured-data/seo). Bug lì = rischio propagato su ogni merge → probing
-        # opus paga. Tier normal (sonnet) per il resto. Mirror ESATTO di
+        # rigoroso paga. Tier normal (claude-sonnet-4-6) per il resto. Mirror ESATTO di
         # pr-review-loop: il bare `scripts/` NON escala più (mandava ogni menzione
         # di script — inclusi helper `scripts/{ci,dev,evals}/` e audit/report
         # read-only — a opus@40; osservato 2026-06-04 come tier-breadth waste). Gli
@@ -94,7 +94,7 @@ jobs:
           if echo "$body" | grep -qiE 'crawler|parser|build-plugin|\.github/workflows/|test gate|validator|migrator' \
              || echo "$body" | grep -qiE 'scripts/[a-z0-9_./-]*(backfill|migrate|assemble|sitemap|canonical|slug|structured-data|seo|index)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
-            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
             # 40->50 (misurato 06-12): 44 run/7gg morti error_max_turns a
             # num_turns=41 (es. run 27386343034) = run opus intera bruciata,
             # 0 PR, issue ri-accodata -> retry = doppio burn. Il cap esiste
@@ -249,7 +249,8 @@ jobs:
         # lascia un marker FIX_OUTCOME del fixer → il backstop sotto posta un
         # generico `no-pr-unspecified` che il drainer IGNORA (BACKSTOP_MARKER) →
         # l'item viene trattato come orfano ri-tentabile e ri-accodato fino a
-        # MAX_ATTEMPTS, bruciando ~3 run opus su un item che esaurisce il budget
+        # MAX_ATTEMPTS, bruciando ~3 run del tier high (claude-sonnet-5) su un item
+        # che esaurisce il budget
         # in modo DETERMINISTICO (ri-tentarlo lo riproduce). Questo step rileva
         # SPECIFICAMENTE il subtype `error_max_turns` dall'execution file e posta
         # un marker granulare `max-turns` (senza BACKSTOP_MARKER → il drainer lo

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -203,13 +203,13 @@ jobs:
             exit 0
           fi
 
-          # Tier (mirror di pr-review-loop / issue-fix): high (opus) se la PR
+          # Tier (mirror di pr-review-loop / issue-fix): high (claude-sonnet-5) se la PR
           # tocca CODE funnel-critical (tests/, build-plugins/, scripts/lib/,
           # services/seo*), normal (sonnet) altrimenti.
           crit=$(echo "$files" | grep -E '^(tests/|build-plugins/|scripts/lib/|services/seo)' || true)
           if [ -n "$crit" ]; then
             echo "tier=high"   >> "$GITHUB_OUTPUT"
-            echo "model=claude-opus-4-8"   >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-5"   >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -63,8 +63,8 @@ jobs:
       # Claude / tier minimal. Sorgente unica (AGENTS.md #6: niente regex letterale
       # duplicata tra step). Include lockfile (package-lock/pnpm-lock/yarn.lock),
       # `*.snap`, baseline binarie (png/jpg/webp/gif/svg/ico/woff) — es. una PR di
-      # soli baseline PNG visivi sotto tests/ non deve escalare a opus per "diff
-      # binario".
+      # soli baseline PNG visivi sotto tests/ non deve escalare al tier high per
+      # "diff binario".
       NONCODE_RE: '^(data/|public/|reports/|_newsletter_variants/|docs/)|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$|\.(snap|png|jpe?g|webp|gif|svg|ico|woff2?)$'
     # Gate evento: SOLO `tests` concluso success (vitest verde) E triggerato da
     # un `pull_request` (i `workflow_dispatch` dell'autorebase e i `push` su main
@@ -224,12 +224,12 @@ jobs:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
-        # Tier high (opus, max-turns 40, adversarial pass): toccato CODE
+        # Tier high (claude-sonnet-5, max-turns 40, adversarial pass): toccato CODE
         # funnel-critical — test gate, workflow CI, build-plugin SEO, o script
         # che mutano/emettono dati indicizzati (crawler/parser/adapter, backfill,
         # migrate, assemble dataset, sitemap/canonical/slug/structured-data).
         # Bug in questi path = falso senso di sicurezza che si propaga su ogni
-        # merge, quindi probing opus paga. Tier normal 15->25 (misurato: 13
+        # merge, quindi probing rigoroso paga. Tier normal 15->25 (misurato: 13
         # run/7gg morti `error_max_turns` a num_turns=16 senza postare review,
         # es. run 27345572135/27340191180 - review intera bruciata + PR ferma
         # fino al rescuer). Tier normal (sonnet, max-turns 25) per
@@ -242,7 +242,7 @@ jobs:
         # rigenerati (NONCODE_RE) NON sono reviewabili come code → non escalano il
         # tier e una PR data/docs-only resta normal (sonnet posta comunque
         # `## LGTM` → auto-merge). Questo evita che 50 `data/jobs/*.json`
-        # rigenerati da un crawler trascinino su opus o gonfino il diff.
+        # rigenerati da un crawler trascinino sul tier high o gonfino il diff.
         #
         # Budget 25→40: con l'espansione del contratto (REVIEW.md no-short-circuit
         # su tier high + step 7 perf-claim + escalation ❓ funnel-critical, sopra
@@ -298,11 +298,12 @@ jobs:
           # crawler_parser_only <file-list> → exit 0 se TUTTI i file funnel-critical
           # sono crawler/parser/adapter di UNA singola fonte datore (fetch+parse di un
           # employer). Owner-approved 2026-06-30 (Tier-3 token-lever): questi vanno
-          # reviewati da sonnet (non opus) — bug-class = meno job da una sola fonte, NON
-          # regressione SEO/monetizzazione. RESTANO su opus (NON match qui): SEO-emitter
+          # reviewati dal tier normal/claude-sonnet-4-6 (non tier high) — bug-class =
+          # meno job da una sola fonte, NON regressione SEO/monetizzazione. RESTANO sul
+          # tier high/claude-sonnet-5 (NON match qui): SEO-emitter
           # (sitemap/canonical/slug/structured-data/assemble/backfill/migrate),
           # tests/, .github/workflows/, build-plugins/. Conservativo: anche UN solo file
-          # non-crawler nel set → opus.
+          # non-crawler nel set → tier high.
           crawler_parser_only() {
             local fs="$1" nonmatch
             nonmatch=$(echo "$fs" | grep -vE '^scripts/update-[a-z0-9-]+-jobs\.mjs$|^scripts/lib/[a-z0-9-]+-job-parser\.mjs$|^scripts/lib/ats-clients/|^scripts/crawl-[a-z0-9-]+\.mjs$|^scripts/(scaffold-crawler|generate-company-parser|generate-company-adapter-stubs|generate-crawler-companies|manage-company-adapter|regen-parser-fix-slices|list-job-crawler-company-keys|check-crawler-health)\.mjs$' || true)
@@ -314,8 +315,9 @@ jobs:
           # commit reviewato, non l'intera PR. Il grosso del contributo era già stato
           # reviewato; ri-leggerlo per intero a ogni fix-push brucia token (osservato
           # su #3038: review Opus full ripetute sullo stesso codice). Modello per
-          # criticità del DELTA: funnel-critical → opus (rigore, scope ridotto);
-          # altrimenti sonnet. Prima review / nessun commit precedente / delta vuoto
+          # criticità del DELTA: funnel-critical → tier high/claude-sonnet-5 (rigore,
+          # scope ridotto); altrimenti tier normal/claude-sonnet-4-6. Prima review /
+          # nessun commit precedente / delta vuoto
           # → review piena (sotto). Il fingerprint-skip a monte (guard step) copre già
           # il caso "contributo invariato"; qui il contributo È cambiato, ma in modo
           # incrementale. Il prompt resta autorizzato a Read/grep i file pieni per il
@@ -329,7 +331,7 @@ jobs:
               echo "incremental_base=$lastRev" >> "$GITHUB_OUTPUT"
               echo "Incremental re-review: solo il delta dei file PR da $lastRev:"; echo "$delta_code"
               if funnel_crit "$delta_code" && ! crawler_parser_only "$delta_code"; then
-                set_tier incremental-high claude-opus-4-8 25
+                set_tier incremental-high claude-sonnet-5 25
               elif funnel_crit "$delta_code"; then
                 # crawler/parser-only funnel-critical delta → sonnet (owner-approved)
                 set_tier incremental-high claude-sonnet-4-6 25
@@ -341,11 +343,12 @@ jobs:
             echo "Nessun delta-code nei file PR dall'ultima review → review piena."
           fi
 
-          # CODE funnel-critical → high (full scope, 40 turni). Modello: opus, salvo
-          # i diff crawler/parser-only → sonnet (owner-approved 2026-06-30, stesso
-          # scope+turni, solo modello più economico). Altrimenti normal (sonnet/25).
+          # CODE funnel-critical → high (full scope, 40 turni). Modello: claude-sonnet-5,
+          # salvo i diff crawler/parser-only → claude-sonnet-4-6 (owner-approved
+          # 2026-06-30, stesso scope+turni, solo modello del tier normal). Altrimenti
+          # normal (claude-sonnet-4-6/25).
           if funnel_crit "$code_files" && ! crawler_parser_only "$code_files"; then
-            set_tier high claude-opus-4-8 40
+            set_tier high claude-sonnet-5 40
           elif funnel_crit "$code_files"; then
             set_tier high claude-sonnet-4-6 40
           else
@@ -386,7 +389,7 @@ jobs:
           # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
           # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e
           # navigation history (`git log -L`, `git blame`, `git show`). Tier high
-          # paga il bump opus per probing regex/assertion/idempotency.
+          # paga il bump a claude-sonnet-5 per probing regex/assertion/idempotency.
           claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(rg:*),Bash(git:*),Read,Grep,Glob'"
           prompt: |
             Reviewer automatico PR #${{ steps.resolve.outputs.pr_number }} ("${{ steps.resolve.outputs.title }}"). Tier: ${{ steps.tier.outputs.tier }}.


### PR DESCRIPTION
## Summary
- `issue-fix.yml`, `pr-redflag-fixer.yml`, `pr-review-loop.yml` selected `claude-opus-4-8` for the tier `high`/`incremental-high` path. Switched all 4 model assignments to `claude-sonnet-5`.
- Updated the adjacent rationale comments that named "opus" as the current model, disambiguating high-tier (`claude-sonnet-5`) from the existing normal-tier `claude-sonnet-4-6` — both are now "sonnet", so the old "sonnet (non opus)" phrasing would've been ambiguous.
- Left untouched: comments narrating specific past incidents/run IDs that happened under Opus (those remain accurate historical records, e.g. `osservato`/`misurato` stats referencing real run numbers).

## Implementato
- Sostituiti i 4 punti `model=claude-opus-4-8` / `claude-opus-4-8` → `claude-sonnet-5` nei tre workflow.
- Allineati i commenti di rationale "current-state" (header tier, regole crawler/parser-only, incremental re-review) al nuovo modello.

## Non implementato (ancora)
- Non toccato `claude-sonnet-4-6` (tier normal) — fuori scope, l'ask era solo "da opus a sonnet 5".
- Non toccati i commenti storici con run ID specifici (rimangono fatti accaduti sotto Opus).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` su tutti e 3 i file → YAML valido
- [x] grep di verifica: zero `claude-opus-4-8` residui nei 3 file, 4 nuove occorrenze `claude-sonnet-5` nei punti di assegnazione modello
- [ ] verifica live: prossima PR/issue che triggera tier `high` deve usare effettivamente `claude-sonnet-5` (osservabile da `claude_args` nel log del run)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>