### PR TITLE
fix(deploy): per-locale Ticino shard deploy keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -432,7 +432,10 @@ jobs:
         # never UNSERVED). The shard otherwise keeps serving its previous build.
         continue-on-error: true
         env:
-          SHARD_TICINO_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_DEPLOY_KEY }}
+          SHARD_TICINO_IT_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_IT_DEPLOY_KEY }}
+          SHARD_TICINO_EN_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_EN_DEPLOY_KEY }}
+          SHARD_TICINO_DE_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_DE_DEPLOY_KEY }}
+          SHARD_TICINO_FR_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_FR_DEPLOY_KEY }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: bash scripts/lib/push-ticino-shard.sh it dist
@@ -646,7 +649,10 @@ jobs:
         if: matrix.locale != 'it'
         continue-on-error: true
         env:
-          SHARD_TICINO_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_DEPLOY_KEY }}
+          SHARD_TICINO_IT_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_IT_DEPLOY_KEY }}
+          SHARD_TICINO_EN_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_EN_DEPLOY_KEY }}
+          SHARD_TICINO_DE_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_DE_DEPLOY_KEY }}
+          SHARD_TICINO_FR_DEPLOY_KEY: ${{ secrets.SHARD_TICINO_FR_DEPLOY_KEY }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: bash scripts/lib/push-ticino-shard.sh "${{ matrix.locale }}" dist

--- a/docs/TICINO-SHARD-RUNBOOK.md
+++ b/docs/TICINO-SHARD-RUNBOOK.md
@@ -34,10 +34,10 @@ Tutto **dormiente**. Due gate indipendenti (populate-then-strip):
 
 | Gate | Tipo | Abilita |
 |------|------|---------|
-| `SHARD_TICINO_DEPLOY_KEY` | secret | il **push** per-leg (popola gli shard) |
+| `SHARD_TICINO_<LOC>_DEPLOY_KEY` (×4) | secret | il **push** per-leg (popola lo shard `<loc>`) |
 | `TICINO_SHARD_LIVE=true`  | variabile repo | lo **strip** da dist (apex < 10 GB), solo se il push del run ha lasciato l'ok-marker |
 
-Senza il secret ogni step Ticino è un no-op → build identico a oggi.
+Senza i secret ogni step Ticino è un no-op → build identico a oggi.
 
 ---
 
@@ -50,16 +50,16 @@ for loc in it en de fr; do
     --description "Ticino-$loc Pages shard for frontaliereticino.ch (origin-ticino-$loc, Worker-only)"
 done
 
-# 2. UNA coppia di chiavi, autorizzata come deploy key (write) su TUTTI E 4 i repo,
-#    + la chiave privata come UN secret nel repo principale.
-ssh-keygen -t ed25519 -N "" -C "frontaliere-ticino deploy key" -f /tmp/ticino_shard_key
+# 2. UNA coppia di chiavi PER REPO (GitHub rifiuta la stessa deploy key su >1 repo)
+#    + la privata come secret per-locale SHARD_TICINO_<LOC>_DEPLOY_KEY.
 for loc in it en de fr; do
-  gh repo deploy-key add /tmp/ticino_shard_key.pub \
-    --repo valerielinc-ops/frontaliere-ticino-$loc --title "ci-deploy" --allow-write
+  K="$(mktemp -u)"
+  ssh-keygen -t ed25519 -N "" -C "frontaliere-ticino-$loc deploy key" -f "$K"
+  gh repo deploy-key add "$K.pub" --repo valerielinc-ops/frontaliere-ticino-$loc --title "ci-deploy" --allow-write
+  gh secret set "SHARD_TICINO_$(echo $loc|tr a-z A-Z)_DEPLOY_KEY" \
+    --repo valerielinc-ops/frontaliere-si-o-no < "$K"
+  rm -f "$K" "$K.pub"
 done
-gh secret set SHARD_TICINO_DEPLOY_KEY \
-  --repo valerielinc-ops/frontaliere-si-o-no < /tmp/ticino_shard_key
-rm -f /tmp/ticino_shard_key /tmp/ticino_shard_key.pub
 ```
 
 Abilita GitHub Pages su ogni repo (branch `main`) e imposta il custom domain

--- a/scripts/lib/push-ticino-shard.sh
+++ b/scripts/lib/push-ticino-shard.sh
@@ -24,10 +24,11 @@
 #     <locale>    ∈ {it, en, de, fr}
 #     <dist_dir>  build output dir (e.g. "dist")
 #
-# Required env:
-#   SHARD_TICINO_DEPLOY_KEY  — SSH deploy key (write) authorised on ALL FOUR
-#                              frontaliere-ticino-<loc> repos (one key, four deploy
-#                              keys). Missing → skip (exit 0), never an error.
+# Required env (per-locale — GitHub rejects the same deploy key on >1 repo, so
+# each frontaliere-ticino-<loc> has its OWN key, exactly like the locale shards):
+#   SHARD_TICINO_<LOCALE>_DEPLOY_KEY  — e.g. SHARD_TICINO_IT_DEPLOY_KEY. The write
+#                              deploy key for frontaliere-ticino-<loc>. Read via
+#                              indirect expansion. Missing → skip (exit 0).
 # Optional env:
 #   RUNNER_TEMP / SHARD_HISTORY_CAP / GITHUB_SHA / GITHUB_RUN_ID — as the locale shard.
 #
@@ -66,10 +67,12 @@ if [ -z "${RUNNER_TEMP:-}" ]; then
 fi
 
 push_ticino_shard() {
-  local key_val stage stage_src keyfile src_n prev_n rc
-  key_val="${SHARD_TICINO_DEPLOY_KEY:-}"
+  local key_var key_val stage stage_src keyfile src_n prev_n rc
+  # Per-locale deploy key via indirect expansion (mirrors push-locale-shard.sh).
+  key_var="SHARD_TICINO_$(echo "$loc" | tr a-z A-Z)_DEPLOY_KEY"
+  key_val="${!key_var:-}"
   if [ -z "$key_val" ]; then
-    echo "no SHARD_TICINO_DEPLOY_KEY secret — skipping $loc Ticino shard push (split disabled)"; return 0
+    echo "no $key_var secret — skipping $loc Ticino shard push (split disabled)"; return 0
   fi
   if [ ! -d "$dist_dir/$sub" ]; then
     echo "$dist_dir/$sub absent — skipping $loc Ticino shard push"; return 0


### PR DESCRIPTION
## Implementato

GitHub rifiuta la stessa deploy key su >1 repo ("Key is already in use"), quindi il piano "1 key sui 4 repo" non funziona. Passo a **una key per repo** (come i locale shard):

- `scripts/lib/push-ticino-shard.sh`: legge `SHARD_TICINO_<LOCALE>_DEPLOY_KEY` via indirect expansion (`key_var="SHARD_TICINO_$(echo $loc|tr a-z A-Z)_DEPLOY_KEY"`), come `push-locale-shard.sh`.
- `.github/workflows/deploy.yml`: entrambi gli step "Push Ticino shard" passano i 4 secret per-locale.
- `docs/TICINO-SHARD-RUNBOOK.md`: FASE 1 genera una keypair per repo.

I 4 repo + 4 deploy key + 4 secret `SHARD_TICINO_{IT,EN,DE,FR}_DEPLOY_KEY` sono già provisionati (gh CLI). Deploy-side only, gated (key per-locale + `TICINO_SHARD_LIVE`) → no-op finché non si flippa. Nessuna modifica al Worker.

Validazione: YAML OK · actionlint 0 nuovi finding · shellcheck+bash -n clean.

## Non implementato (ancora)

- **Seed + DNS + routing Worker + flip** — prossimi step del provisioning (runbook FASE 3–5), in corso nella stessa sessione. Questa PR sblocca il seed (il push per-leg ora trova le key per-locale). Il task resta aperto fino al deploy IT verde live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)