### PR TITLE
chore(pr-review-loop): full permissions via --dangerously-skip-permissions

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -386,11 +386,17 @@ jobs:
           # è l'App-bot; senza whitelist la review abortirebbe "non-human actor".
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
-          # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e
-          # navigation history (`git log -L`, `git blame`, `git show`). Tier high
-          # paga il bump a claude-sonnet-5 per probing regex/assertion/idempotency.
-          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(rg:*),Bash(git:*),Read,Grep,Glob'"
+          # Owner-approved 2026-07-01: `--dangerously-skip-permissions` sostituisce
+          # l'`--allowedTools` scoped precedente. Il reviewer restava bloccato su
+          # probing esplorativo legittimo (es. testare `${!key_var}` indirect
+          # expansion in un tmp script durante la review di PR #3180, bash -n
+          # syntax-check) fuori dall'allowlist gh/rg/git/Read/Grep/Glob — si
+          # arrangiava sempre (review completa comunque postata), ma su richiesta
+          # esplicita si rimuove il vincolo così Claude ha accesso pieno.
+          # Rischio noto e accettato: reviewer gira su OGNI PR (incluse quelle
+          # aperte da bot/automation) con GITHUB_TOKEN pull-requests:write +
+          # issues:write, senza restrizione su Bash/Write/Edit.
+          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Reviewer automatico PR #${{ steps.resolve.outputs.pr_number }} ("${{ steps.resolve.outputs.title }}"). Tier: ${{ steps.tier.outputs.tier }}.
 


### PR DESCRIPTION
## Implementato
- `pr-review-loop.yml`: replaced the scoped `--allowedTools 'Bash(gh:*),Bash(rg:*),Bash(git:*),Read,Grep,Glob'` with `--dangerously-skip-permissions` on the Claude review step, per explicit owner request.

## Perché
Reviewing PR #3180, the agent hit repeated permission denials trying to write/run a scratch bash script (`/tmp/t.sh`) to empirically test `${!key_var}` indirect-expansion behavior — outside the prior allowlist. The review still completed successfully (34/40 turns, posted `## LGTM`) by falling back to manual code reading, but the owner asked to remove the restriction entirely so future reviews aren't blocked on this class of tool call.

## Rischio noto e accettato (esplicitamente confermato dall'owner)
This job now has unrestricted Bash/Write/Edit on **every** PR review, including PRs opened by bots/automation, running with a `GITHUB_TOKEN` that has `pull-requests: write` + `issues: write`. The prior scoping was a deliberate guardrail (see removed comment) against a credentialed CI process acting on diff content it didn't author. Flagged to the owner before this change; they chose to proceed anyway.

## Non implementato (ancora)
- Other Claude-driven CI jobs (`issue-fix.yml`, `pr-redflag-fixer.yml`, `lessons-harvester.yml`, `post-merge-followup.yml`) still use scoped `--allowedTools` — not touched, out of scope for this request.