### PR TITLE
fix(post-merge-followup): auth bug — scheduled runs failing 100% since batching merge

### DIFF
--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -107,12 +107,25 @@ jobs:
           # actor bot distinti — entrambi vanno in whitelist o claude-code-action aborta
           # "Workflow initiated by non-human actor":
           #  - `frontaliere-automation[bot]`: actor del path PRIMARIO di cascade
-          #    post-LGTM (`auto-merge-on-lgtm.yml` mergia con APP_TOKEN). Lo schedule
-          #    gira come `github-actions[bot]`, ma manteniamo la whitelist per il path
+          #    post-LGTM (`auto-merge-on-lgtm.yml` mergia con APP_TOKEN). CORREZIONE
+          #    2026-07-01: l'assunzione "lo schedule gira come github-actions[bot]" era
+          #    sbagliata — `triggering_actor` osservato sui run schedulati è
+          #    `frontaliere-automation[bot]` (ultimo autore del commit che ha introdotto
+          #    il cron, PR #3157). Manteniamo comunque la whitelist anche per il path
           #    workflow_dispatch self-invocato e per simmetria coi sibling (issue-fix).
-          #  - `github-actions[bot]`: actor degli eventi `schedule` / dispatch.
+          #  - `github-actions[bot]`: fallback per eventuali dispatch manuali via UI.
           # `claude[bot]` per simmetria coi sibling. Mai `*`.
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
+          # `allowed_bots` bypassa solo il gate "non-human actor" — claude-code-action fa
+          # un secondo check SEPARATO ("does the actor have write access") via l'API
+          # collaborator-permission, che una GitHub App bot NON supera (non è un
+          # collaborator classico anche se ha accesso reale via installation). Root
+          # cause della run schedulata che falliva 100% dal merge di PR #3157 con "User
+          # does not have write access on this repository" (turns=0, $0 — falliva PRIMA
+          # di invocare Claude, zero triage creato da allora). Stessi 3 nomi di
+          # allowed_bots: il job è già scoped Bash(gh:*)-only + `gh issue create`/`gh pr
+          # comment` (niente Write/Edit), quindi il bypass resta a basso rischio.
+          allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
           # max-turns DINAMICO = min(20 + 6*batch_count, 60), floor 20 (era 20 fisso per
           # UNA PR). AGENTS.md vieta di ABBASSARE i turni di post-merge-followup (15→20

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -103,6 +103,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # `allowed_non_write_users` (sotto) funziona SOLO con `github_token` esplicito,
+          # non con la sola GitHub App auth di `claude_code_oauth_token` (docs/security.md
+          # anthropics/claude-code-action: "Only works when github_token is provided as
+          # input"). Senza questo il bypass del gate write-access è un no-op silenzioso e
+          # la run continua a fallire con lo stesso errore che questo file dichiara di
+          # risolvere (trovato in review PR #3182). Token auto-generato, scope limitato ai
+          # `permissions:` del job (pull-requests/issues write), scade a fine job — NON un
+          # PAT statico.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Il merge che alimenta questo workflow è fatto da automation interna con DUE
           # actor bot distinti — entrambi vanno in whitelist o claude-code-action aborta
           # "Workflow initiated by non-human actor":


### PR DESCRIPTION
## Problema

Ogni run schedulata di `post-merge-followup` (cron `0 */3`, introdotto da #3157) fallisce PRIMA di invocare Claude, con:

```
##[error]Action failed with error: User does not have write access on this repository
```

`turns=0`, `total_tokens=0`, costo $0 — ma zero triage follow-up viene creato da quando #3157 è stato mergiato.

## Root cause

`allowed_bots` (già settato con `frontaliere-automation[bot]`) bypassa SOLO il gate "workflow initiated by non-human actor". `claude-code-action` fa un secondo check separato — verifica write-access via l'API collaborator-permission — che una GitHub App bot non supera anche se ha accesso reale via installation. L'input dedicato a questo bypass (`allowed_non_write_users`) non era mai stato settato in nessun workflow del repo.

Correzione minore anche nel commento: l'assunzione "lo schedule gira come `github-actions[bot]`" era sbagliata — il `triggering_actor` osservato sui run falliti è `frontaliere-automation[bot]`.

## Fix

- Aggiunge `allowed_non_write_users` con la stessa whitelist di `allowed_bots` (nessuna estensione di permessi: il job resta scoped a `Bash(gh:*),Read,Grep,Glob` — nessun Write/Edit).
- Fix in review (PR #3182, pr-review-loop 🔴): `allowed_non_write_users` funziona SOLO con `github_token` esplicito, non con la sola GitHub App auth di `claude_code_oauth_token` (docs/security.md, anthropics/claude-code-action). Aggiunto `github_token: ${{ secrets.GITHUB_TOKEN }}` — token auto-generato, scope limitato ai `permissions:` del job, scade a fine job.

## Implementato
- `allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"` + `github_token` nello step `claude-code-action` di `post-merge-followup.yml`
- Commento aggiornato con la root cause (due gate separati) e la correzione sul `triggering_actor`

## Non implementato
- Nessuna verifica live end-to-end ancora eseguita (nessun run schedulato/dispatch dopo il push) — verificare sul prossimo run cron o via `workflow_dispatch` che il job superi il gate write-access e arrivi a invocare Claude
- Non toccati gli altri 4 workflow Claude-driven. Correzione: `lessons-harvester.yml` usa anch'esso `schedule` (cron giornaliero) — non verificato se soffra dello stesso bug (il suo commento interno assume ancora "actor umano oggi"); fuori scope per questa PR, va controllato separatamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)