### PR TITLE
fix(self-heal): raise version-skew reload guard from 1 to 2 per session

### DIFF
--- a/index.html
+++ b/index.html
@@ -841,6 +841,15 @@
          Placed before <script type="module"> which is deferred by spec, so these
          handlers are registered before any module JS executes. -->
     <script>
+      // Session-wide reload ceiling shared by every recovery handler below AND
+      // services/resilientImport.ts (mirrored there as MAX_RELOADS — that module
+      // can't be imported here since this bootstrap script runs pre-module).
+      // Raised from 1 to 2: a client can carry more than one independently stale
+      // chunk (e.g. vendor-icons.js AND i18n.js both skewed), and the first
+      // recovery only busts the HTTP cache for chunks already loaded on that
+      // page, so a second, not-yet-loaded stale chunk can still surface after
+      // the first reload and needs its own retry.
+      var FR_MAX_RELOADS = 2;
       // Unregister any leftover service workers from previous deploys.
       // Stale SWs can serve outdated cached assets that reference non-existent chunk hashes.
       if ('serviceWorker' in navigator) {
@@ -939,9 +948,9 @@
           if (!isAsset) return;
           // Skip reload for ad-blocked analytics/tracking chunks
           if (isAdBlocked) return;
-          // Session-level reload counter: allow at most 1 reload per browser session
+          // Session-level reload counter: allow at most FR_MAX_RELOADS reloads per browser session
           var reloadCount = parseInt(sessionStorage.getItem('_swReloadCount') || '0', 10);
-          if (reloadCount >= 1) {
+          if (reloadCount >= FR_MAX_RELOADS) {
             try {
               var blocked = JSON.parse(sessionStorage.getItem('_resourceErrors') || '[]');
               if (blocked.length > 0) blocked[blocked.length - 1].triggeredReload = 'blocked';
@@ -992,8 +1001,8 @@
       //      ("does not provide an export named 'House'", Firefox "import not
       //      found", WebKit "Importing binding name ... is not found").
       // Both chunks loaded fine (HTTP 200), so the resource/import handlers above
-      // never fire. Self-heal: clear caches + reload ONCE (shared _swReloadCount
-      // ceiling). Post-propagation the refetched chunk set is consistent.
+      // never fire. Self-heal: clear caches + reload (shared _swReloadCount /
+      // FR_MAX_RELOADS ceiling). Post-propagation the refetched chunk set is consistent.
       // Keep the message regexes in sync with isVersionSkewError /
       // isModuleLinkSkewMessage in services/resilientImport.ts (this inline
       // bootstrap script cannot import that module).
@@ -1014,7 +1023,7 @@
         var skewLink = /does not provide an export named|import not found|indirect export|Importing binding name/.test(m);
         if (!skewCall && !skewLink) return;
         var reloadCount = parseInt(sessionStorage.getItem('_swReloadCount') || '0', 10);
-        if (reloadCount >= 1) return;
+        if (reloadCount >= FR_MAX_RELOADS) return;
         sessionStorage.setItem('_swReloadCount', String(reloadCount + 1));
         try {
           sessionStorage.setItem('_forceReloadInfo', JSON.stringify({
@@ -1059,7 +1068,7 @@
 
         if (isAdBlocked) return;
         var reloadCount = parseInt(sessionStorage.getItem('_swReloadCount') || '0', 10);
-        if (reloadCount >= 1) {
+        if (reloadCount >= FR_MAX_RELOADS) {
           try {
             var blocked = JSON.parse(sessionStorage.getItem('_resourceErrors') || '[]');
             if (blocked.length > 0) blocked[blocked.length - 1].triggeredReload = 'blocked';

--- a/services/resilientImport.ts
+++ b/services/resilientImport.ts
@@ -84,9 +84,10 @@ export function isModuleLinkSkewMessage(msg: string): boolean {
  * route here → recoverFromStaleChunk().
  *
  * The predicate is signature-based. A genuine app bug producing the same message
- * costs at most ONE extra reload before the per-session guard blocks further
- * reloads and the error UI is shown — identical to the existing chunk-recovery
- * tradeoff, and far better than a permanent white screen on a real skew.
+ * costs at most MAX_RELOADS extra reloads before the per-session guard blocks
+ * further reloads and the error UI is shown — identical to the existing
+ * chunk-recovery tradeoff, and far better than a permanent white screen on a
+ * real skew.
  */
 export function isVersionSkewError(err: unknown): boolean {
   const e = err as { name?: string; message?: string } | null | undefined;
@@ -108,8 +109,12 @@ export function isVersionSkewError(err: unknown): boolean {
 // Session-wide reload ceiling shared across ALL three recovery surfaces:
 // resilientImport's chunk-load path (below), recoverFromStaleChunk (called by
 // ErrorBoundary + global window-error handler), and index.html bootstrap handlers.
-// At most one reload per session total; the value `>= 1` blocks further reloads.
+// Raised from 1 to 2 (issue: single sessions observed hitting TWO independently
+// stale chunks, e.g. vendor-icons.js then i18n.js — bustAssetHttpCache() only
+// refetches chunks already loaded on the current page, so a second, not-yet-loaded
+// stale chunk can still surface after the first reload and needs its own retry).
 const BOOTSTRAP_RELOAD_KEY = '_swReloadCount';
+const MAX_RELOADS = 2;
 
 // Upper bound on how long the HTTP-cache bust may run before we reload anyway.
 // Asset chunks are small and refetched in parallel; this is only a backstop so a
@@ -189,9 +194,9 @@ export async function bustAssetHttpCache(): Promise<void> {
  * browser refetches a CONSISTENT set of stable-named chunks (post-propagation,
  * the skew is gone). Called by the ErrorBoundary version-skew recovery; shares
  * the `_swReloadCount` ceiling with the index.html bootstrap recovery so the two
- * skew surfaces (React-caught + global window error) reload at most once total.
- * No-op outside the browser. Returns true if a reload was scheduled, false if
- * the per-session guard blocked it.
+ * skew surfaces (React-caught + global window error) reload at most MAX_RELOADS
+ * times total. No-op outside the browser. Returns true if a reload was
+ * scheduled, false if the per-session guard blocked it.
  */
 export async function recoverFromStaleChunk(reason: string): Promise<boolean> {
   if (typeof window === 'undefined') return false;
@@ -205,11 +210,11 @@ export async function recoverFromStaleChunk(reason: string): Promise<boolean> {
   } catch {
     /* private mode — proceed without the guard */
   }
-  if (reloadCount >= 1) return false;
+  if (reloadCount >= MAX_RELOADS) return false;
   try {
     sessionStorage.setItem(BOOTSTRAP_RELOAD_KEY, String(reloadCount + 1));
   } catch {
-    /* private mode — guard unavailable, still attempt one reload below */
+    /* private mode — guard unavailable, still attempt the reload below */
   }
   // Best-effort breadcrumb for Analytics.initGlobalErrorTracking() post-reload.
   try {
@@ -289,7 +294,7 @@ export async function resilientImport<T>(
         let shouldReload = false;
         try {
           const rc = parseInt(sessionStorage.getItem(BOOTSTRAP_RELOAD_KEY) || '0', 10) || 0;
-          if (rc < 1) {
+          if (rc < MAX_RELOADS) {
             sessionStorage.setItem(BOOTSTRAP_RELOAD_KEY, String(rc + 1));
             shouldReload = true;
           }
@@ -299,7 +304,7 @@ export async function resilientImport<T>(
         if (shouldReload) {
           // Bust the HTTP cache before reloading: a stale-but-200 chunk (HTML
           // served for a purged name, or a skewed dependency) would otherwise be
-          // re-served from the disk cache and the one reload wasted.
+          // re-served from the disk cache and the reload wasted.
           await bustAssetHttpCache();
           window.location.reload();
         }

--- a/services/resilientImport.ts
+++ b/services/resilientImport.ts
@@ -114,7 +114,7 @@ export function isVersionSkewError(err: unknown): boolean {
 // refetches chunks already loaded on the current page, so a second, not-yet-loaded
 // stale chunk can still surface after the first reload and needs its own retry).
 const BOOTSTRAP_RELOAD_KEY = '_swReloadCount';
-const MAX_RELOADS = 2;
+export const MAX_RELOADS = 2;
 
 // Upper bound on how long the HTTP-cache bust may run before we reload anyway.
 // Asset chunks are small and refetched in parallel; this is only a backstop so a

--- a/tests/resilient-import.test.ts
+++ b/tests/resilient-import.test.ts
@@ -6,6 +6,7 @@ import {
   isModuleLinkSkewMessage,
   recoverFromStaleChunk,
   bustAssetHttpCache,
+  MAX_RELOADS,
 } from '@/services/resilientImport';
 
 /**
@@ -14,7 +15,7 @@ import {
  *  2. import() resolves but the module is missing expected exports (version
  *     skew: stable-named chunks where a cached entry pulls a fresh chunk whose
  *     export shape differs → "n.getApp is not a function" on a minified name).
- * Both clear caches, retry once, then reload (guarded to once per session).
+ * Both clear caches, retry once, then reload (guarded to MAX_RELOADS per session).
  */
 describe('resilientImport', () => {
   beforeEach(() => {
@@ -58,7 +59,7 @@ describe('resilientImport', () => {
     expect((globalThis as any).caches.delete).toHaveBeenCalledTimes(2); // c1 + c2
   });
 
-  it('reloads at most once per session when the chunk is truly gone', async () => {
+  it('reloads up to MAX_RELOADS times per session when the chunk is truly gone', async () => {
     const reload = vi.fn();
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -76,7 +77,15 @@ describe('resilientImport', () => {
     // Uses the shared _swReloadCount key — same ceiling as recoverFromStaleChunk + index.html.
     expect(sessionStorage.getItem('_swReloadCount')).toBe('1');
 
-    // A subsequent failure must NOT reload again (guard holds across callers).
+    // A second, independently-stale chunk in the same session still has budget left.
+    for (let n = 2; n <= MAX_RELOADS; n++) {
+      reload.mockClear();
+      await expect(resilientImport(factory)).rejects.toThrow();
+      expect(reload).toHaveBeenCalledTimes(1);
+      expect(sessionStorage.getItem('_swReloadCount')).toBe(String(n));
+    }
+
+    // Once the ceiling is reached, a further failure must NOT reload again.
     reload.mockClear();
     await expect(resilientImport(factory)).rejects.toThrow();
     expect(reload).not.toHaveBeenCalled();
@@ -195,20 +204,28 @@ describe('recoverFromStaleChunk', () => {
     expect(sessionStorage.getItem('_swReloadCount')).toBe('1');
   });
 
-  it('honours a reload already triggered by the index.html bootstrap recovery', async () => {
+  it('honours the reload ceiling already reached by the index.html bootstrap recovery', async () => {
     const reload = setHostname('frontaliereticino.ch');
     // index.html's resource/import/skew handlers set this same counter.
-    sessionStorage.setItem('_swReloadCount', '1');
+    sessionStorage.setItem('_swReloadCount', String(MAX_RELOADS));
     const scheduled = await recoverFromStaleChunk('after-bootstrap-reload');
     expect(scheduled).toBe(false);
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('is guarded to a single reload per session', async () => {
+  it('is guarded to at most MAX_RELOADS reloads per session', async () => {
     const reload = setHostname('frontaliereticino.ch');
-    await recoverFromStaleChunk('first');
+
+    for (let n = 1; n <= MAX_RELOADS; n++) {
+      reload.mockClear();
+      const scheduled = await recoverFromStaleChunk(`attempt-${n}`);
+      expect(scheduled).toBe(true);
+      expect(reload).toHaveBeenCalledTimes(1);
+    }
+
+    // Ceiling reached — a further failure must NOT reload again.
     reload.mockClear();
-    const scheduled = await recoverFromStaleChunk('second');
+    const scheduled = await recoverFromStaleChunk('over-the-limit');
     expect(scheduled).toBe(false);
     expect(reload).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Root cause investigation for a live production error (`SyntaxError: The requested module './vendor-icons.js' does not provide an export named 'by'`) reported on frontaliereticino.ch.
- Confirmed via GA4 (`analytics-report.mjs --ga4`, last 3 days): 357 `app_error` events / 145 affected users / 58 who saw the visible error screen, concentrated around the Jun 29-30 deploy window and declining since.
- Found the specific gap: a single session hit **two independently stale chunks in sequence** (`vendor-icons.js` then `i18n.js`, both "does not provide an export named" link-time skew errors). `bustAssetHttpCache()` only refetches chunks already loaded on the current page, so a second, not-yet-loaded stale chunk can surface *after* the first self-heal reload — but the existing `_swReloadCount` guard allowed only **1** reload per browser session total, shared across all recovery surfaces. The second skew error had no budget left to self-heal, leaving the user stuck on the error screen (exactly the reported symptom).
- Verified separately that the live deployed bundle is currently internally self-consistent (no active server-side export/import mismatch across the 129 live chunks that import from `vendor-icons.js`) — this is purely a client-side stale-cache recovery gap, not a deploy defect.

## Change
Raise the shared reload ceiling from 1 to 2 per session, consistently across all 5 gating call sites:
- `services/resilientImport.ts`: `recoverFromStaleChunk()` and `resilientImport()`'s own retry path (new `MAX_RELOADS` constant).
- `index.html`: 3 inline bootstrap handlers (resource-error, unhandled-rejection/window-error, and generic resource-load) that mirror the same logic pre-module (new `FR_MAX_RELOADS` constant, kept in sync per existing code comments).

No behavior change for the success path or for genuine (non-skew) errors — the predicate is signature-based (matches only recognized version-skew error shapes), so the worst case for an unrelated bug is one extra reload cycle before the existing error UI shows, same as today.

## Implementato
- Diagnosi root-cause via dati GA4 live (errorHealth: 357 eventi/145 utenti/3gg) + verifica consistenza live-bundle (129 chunk che importano da vendor-icons.js, zero mismatch → nessun difetto server-side attivo).
- Alzato il tetto condiviso di reload self-heal da 1 a 2 per sessione, sincronizzato su tutti e 5 i call site: `recoverFromStaleChunk()` + retry path di `resilientImport()` in `services/resilientImport.ts`, e i 3 handler inline mirror in `index.html`.
- Commenti aggiornati ovunque per riflettere il nuovo comportamento (nessun commento stantio lasciato con "at most one reload").

## Non implementato (ancora)
- Bust "manifest-based" di TUTTI i chunk stabili noti (non solo quelli già caricati in pagina) — eliminerebbe anche un ipotetico 3°/4° chunk stale nella stessa sessione, ma richiede un nuovo artefatto di build (manifest) + step di deploy; fuori scope per questo fix mirato.
- Gap UX di `ErrorBoundary` (la schermata di errore lampeggia fino a ~4s anche quando l'auto-recovery è in corso) — non toccato in questa PR.
- Verifica live post-merge (monitor GA4 `errorHealth`/`reloadHealth` nei giorni successivi per confermare che il pattern doppio-chunk-stale non si ripresenti) — pendente al merge+deploy.

## Test plan
- [x] `tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in other files untouched).
- [x] `gitnexus_detect_changes` confirms only the intended `resilientImport` symbol touched, in exactly the 2 intended files.
- [ ] Post-merge: watch GA4 `errorHealth`/`reloadHealth` over the following days for the double-stale-chunk pattern (single user, 2+ distinct "does not provide an export named" errors) to confirm it stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
