### PR TITLE
Externalize critical CSS to /assets/critical.css (blocking link)

### DIFF
--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -10,7 +10,7 @@
 import { FAVICON_LINKS, GTAG_SNIPPET, ADSENSE_SNIPPET, BASE_URL, SPA_ACTION_REDIRECT_SCRIPT, SEO_STATIC_CSS_FILENAME, CDN_PRECONNECT_HINT } from './constants';
 import { escapeInlineScript } from './shared/inlineJsonScript';
 import { clampMetaDescription } from './shared/titleSuffix';
-import { CRITICAL_CSS } from './shared/criticalCss';
+import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { railGutters } from './shared/railGutters';
 
 /**
@@ -25,9 +25,10 @@ import { railGutters } from './shared/railGutters';
  *  - `data-clarity-unmask="true"` so Microsoft Clarity keeps the href in
  *    session recordings.
  *
- * First paint is rendered from the inline {@link CRITICAL_CSS} block, so the
- * static SEO content (rendered immediately, not behind a skeleton) does not
- * FOUC while the full sheet streams in. This is the SAME pattern the sibling
+ * First paint is rendered from the render-blocking {@link CRITICAL_CSS_LINK}
+ * (`/assets/critical.css`), so the static SEO content (rendered immediately,
+ * not behind a skeleton) does not FOUC while the full sheet streams in. This
+ * is the SAME pattern the sibling
  * static emitters already use (`staticPagesPlugin.ts`, `ogPagesPlugin.ts`,
  * `asyncCssPlugin.ts`, and the hand-rolled job-detail head in
  * `jobsSeoPagesPlugin.ts`) — kept in one helper here so the buildSimplePage
@@ -65,8 +66,9 @@ export const ASYNC_CSS_FALLBACK_SCRIPT =
   `<script>setTimeout(function(){var ls=document.querySelectorAll('link[media="print"][href*="/assets/"]');for(var i=0;i<ls.length;i++){ls[i].media='all'}if(ls[0]){try{sessionStorage.setItem('_cssFallbackInfo',JSON.stringify({href:ls[0].href,delayMs:3000,pagePath:location.pathname+location.search,ts:new Date().toISOString()}))}catch(e){}}},3000)</script>`;
 
 /**
- * Full non-render-blocking CSS `<head>` block for static SEO landing pages:
- *   1. inline `<style>` with the first-paint {@link CRITICAL_CSS},
+ * Full CSS `<head>` block for static SEO landing pages:
+ *   1. render-BLOCKING `<link>` to the first-paint {@link CRITICAL_CSS_LINK}
+ *      (`/assets/critical.css`),
  *   2. async-swapped Vite entry stylesheet (optional — only when a SPA bundle
  *      is present for the page),
  *   3. async-swapped `seo-static.css` (the s-* utility sheet),
@@ -82,7 +84,7 @@ export function asyncCssHeadBlock(entryCss?: string): string {
   const entryCssHref = entryCss ? (/^https?:\/\//.test(entryCss) ? entryCss : `/assets/${entryCss}`) : '';
   const entryLink = entryCssHref ? `\n    ${asyncCssLink(entryCssHref)}` : '';
   return (
-    `<style>${CRITICAL_CSS}</style>` +
+    CRITICAL_CSS_LINK +
     `${entryLink}\n    ${asyncCssLink(`/assets/${SEO_STATIC_CSS_FILENAME}`)}` +
     `\n    ${ASYNC_CSS_FALLBACK_SCRIPT}`
   );
@@ -137,7 +139,7 @@ export const HEAD_SUFFIX_GTAG = ` ${GTAG_SNIPPET}
  * header, `h-14 md:h-20` = 56/80px) INTO `#root`, which — starting empty — would
  * shove that sibling content down by the header height on mount (live: ~0.08
  * desktop CLS on `/cerca-lavoro-*`). The `.ft-hdr-reserve` spacer (height pinned
- * in {@link CRITICAL_CSS} via `ROOT_HEADER_RESERVE_CSS`) holds the header height
+ * in `shared/criticalCss.ts`'s `ROOT_HEADER_RESERVE_CSS`) holds the header height
  * from first paint so nothing jumps. `createRoot().render()` REPLACES #root's
  * children (client render, not hydration), so the spacer leaves no residue and
  * the real same-height header takes its place shift-free.
@@ -320,10 +322,10 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  // every plugin that renders via this shell / seoPageShell.
  const ldTags = jsonLdScripts.map(ld => ` <script type="application/ld+json">${escapeInlineScript(ld)}</script>`).join('\n');
  // Both the Vite entry sheet AND seo-static.css are loaded NON-render-blocking
- // via the `media="print"` swap, with first paint rendered from the inline
- // CRITICAL_CSS block (see {@link asyncCssHeadBlock}). Static SEO content is
- // shown immediately (not behind a skeleton), so the inline critical CSS keeps
- // first paint stable while the full sheets stream in — no FOUC. Issue #1991 /
+ // via the `media="print"` swap, with first paint rendered from the render-
+ // blocking /assets/critical.css link (see {@link asyncCssHeadBlock}). Static
+ // SEO content is shown immediately (not behind a skeleton), so critical.css
+ // keeps first paint stable while the full sheets stream in — no FOUC. Issue #1991 /
  // follow-up of PR #1984: removes the last render-blocking CSS on the
  // buildSimplePage static-landing path (LCP/CWV → organic ranking).
  //
@@ -373,7 +375,7 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  // (`h-14 md:h-20` = 56/80px) fills `#root` and shoves the sibling content (rail
  // grid / `main.seo-static-content`) down by the header height — live: rail-grid
  // +75px @944ms ≈ 0.08 CLS on city-hub, same residual on landings. The
- // `.ft-hdr-reserve` spacer (height pinned in CRITICAL_CSS) holds that height
+ // `.ft-hdr-reserve` spacer (height pinned in shared/criticalCss.ts) holds that height
  // from first paint so nothing jumps, AND makes index.tsx's `hasStaticContent()`
  // true so its mount-time `#root` min-height floor engages, covering the
  // createRoot()-empties-#root collapse too. `createRoot()` REPLACES #root's

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -18,7 +18,7 @@ import { truncateCodeUnits } from './shared/safeTruncate';
 import { findChunkFile, findChunkFiles } from './shared/chunkFiles';
 import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { inlineScriptJson } from './shared/inlineJsonScript';
-import { CRITICAL_CSS } from './shared/criticalCss';
+import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 
 export function ogPagesPlugin(rootDir: string): Plugin {
@@ -650,13 +650,6 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  ].filter(Boolean).join('');
  const preloadTag = corePreloads ? '\n ' + corePreloads : '';
 
- // Critical CSS (first-paint, non-render-blocking) — single source of truth in
- // shared/criticalCss.ts, shared with staticPagesPlugin. This used to be a
- // hand-copied literal that had drifted (missing the font-metric overrides
- // staticPages/index.html carry → no font CLS stabilization on OG pages); the
- // shared constant makes that drift impossible (#1586).
- const criticalCSS = CRITICAL_CSS;
-
  // ── Build related articles helper for cross-linking (SEO: inter-article links) ──
  const relatedArticlesLabel: Record<string, string> = {
  it: 'Articoli correlati', en: 'Related articles', de: 'Verwandte Artikel', fr: 'Articles connexes',
@@ -1099,7 +1092,7 @@ ${href}
 ${headTags}
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${blogPreloads}
  <script>if(localStorage.theme==='dark')document.documentElement.classList.add('dark');window.__ARTICLE_TITLE__=${inlineScriptJson(localizedTitle)}</script>
- <style>${criticalCSS}</style>
+ ${CRITICAL_CSS_LINK}
  <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
  <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin>
  <link rel="preload" as="style" crossorigin href="/assets/${entryCss}" data-clarity-unmask="true">

--- a/build-plugins/shared/criticalCss.ts
+++ b/build-plugins/shared/criticalCss.ts
@@ -1,17 +1,33 @@
 /**
- * Single source of truth for the first-paint CRITICAL CSS inlined as a
- * `<style>` block by the SEO static-page emitters (`staticPagesPlugin` and
- * `ogPagesPlugin`).
+ * Single source of truth for the first-paint CRITICAL CSS served to every
+ * static SEO page as `/assets/critical.css` (written by
+ * `staticScriptsPlugin.ts` from {@link CRITICAL_CSS} at build time) and
+ * linked via the render-BLOCKING {@link CRITICAL_CSS_LINK} — NOT the
+ * `media="print"` async-swap trick used for `seo-static.css`/the entry sheet.
  *
- * Why this lives here (and is NOT externalized into `seo-static.css`):
- * this block is render-blocking-by-design — it carries the `@font-face`
- * declaration (with font-metric overrides for CLS prevention), the global
- * `*,::after,::before` border-box reset and the `body{}` rules that must paint
- * BEFORE the async Tailwind stylesheet (`media="print"` swap) arrives. Moving
- * it into the shared sheet would make it render-blocking and globalize the
- * resets onto every page that links the sheet — a site-wide FCP/LCP/CWV
- * regression. PR #1587 deliberately left it inline for exactly this reason; see
- * that PR body. So it stays an inline block, but the STRING is defined once.
+ * Why it must stay render-blocking (unchanged from when it was an inline
+ * `<style>` block, PR #1587): it carries the `@font-face` declaration (with
+ * font-metric overrides for CLS prevention), the global `*,::after,::before`
+ * border-box reset, the `body{}` rules and every CLS-reservation block below
+ * — all of it must be in effect BEFORE the async Tailwind stylesheet
+ * (`media="print"` swap) arrives, or the swap itself causes the reflow this
+ * file exists to prevent.
+ *
+ * Why externalizing it (issue: move inline styles/scripts to CDN-served
+ * files, 2026-07) does not reintroduce the #1587 regression: #1587 was about
+ * making the block ASYNC (media=print-swapped, i.e. arriving AFTER first
+ * paint) — that's a correctness bug, not a bytes-on-the-wire one. A
+ * synchronous same-origin `<link rel="stylesheet">`, discovered by the HTML
+ * parser near the top of `<head>`, still blocks first paint exactly like the
+ * inline block did; the only change is one extra same-origin request
+ * (HTTP/2, no new connection) instead of the bytes already sitting in the
+ * document. That's the part with no offline proof — full local SEO builds
+ * OOM (AGENTS.md), so this trade is shipped as an explicitly UNVALIDATED
+ * perf claim with a stated revert trigger (see the PR). `/assets/critical.css`
+ * is root-relative/same-origin like every other file `staticScriptsPlugin.ts`
+ * emits (`early-boot.js`, `gtag-init.js`, …) — not pushed onto the separate
+ * `cdn.frontaliereticino.ch` host, which would add a cross-origin
+ * connection for no benefit on a render-blocking resource.
  *
  * Heading font (`Space Grotesk`, issue #2659): article/OG cold-loads showed a
  * dominant ~0.32 layout shift (live PerformanceObserver, 2026-06-23) because
@@ -322,3 +338,20 @@ export const CRITICAL_CSS =
   SEO_STATIC_HERO_RESERVE_CSS +
   SEO_SEARCH_HUB_RESERVE_CSS +
   ROOT_HEADER_RESERVE_CSS;
+
+/**
+ * Filename `staticScriptsPlugin.ts` writes {@link CRITICAL_CSS} to under
+ * `dist/assets/` — STABLE (no content hash), like every other file that
+ * plugin emits, so it revalidates via the `/assets/*` `max-age=600` header
+ * instead of a rename on every content change.
+ */
+export const CRITICAL_CSS_FILENAME = 'critical.css';
+
+/**
+ * Render-blocking `<link>` for {@link CRITICAL_CSS_FILENAME} — deliberately
+ * NOT the `media="print"` async-swap `asyncCssLink()` (`htmlTemplate.ts`)
+ * uses for `seo-static.css`/the entry sheet, because this stylesheet must
+ * still be in effect at first paint (see the file header comment).
+ */
+export const CRITICAL_CSS_LINK =
+  `<link rel="stylesheet" href="/assets/${CRITICAL_CSS_FILENAME}" data-clarity-unmask="true">`;

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -14,7 +14,7 @@ import { WriteCollector } from './batchWrite';
 import { resolveSpaBundle } from './spaBundleResolver';
 import { resolveStaticPagesFlushed } from './shared/buildSignals';
 import { findChunkFile, findChunkFiles } from './shared/chunkFiles';
-import { CRITICAL_CSS } from './shared/criticalCss';
+import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { jsToJson as sharedJsToJson } from './shared/jsToJson';
 import { buildArticleSeoSections, cleanupArticleBodySections } from './articleSeoFallback';
 import { SECTION_EDITORIAL, SECTION_EDITORIAL_KEYS } from './editorialContent';
@@ -1693,11 +1693,6 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  }
  return tags.length ? '\n ' + tags.join('\n ') : '';
  };
-
- // Critical CSS (first-paint, non-render-blocking) — single source of truth in
- // shared/criticalCss.ts, shared with ogPagesPlugin. See that module for why it
- // stays inline (render-blocking-by-design) rather than externalized (#1586).
- const criticalCSS = CRITICAL_CSS;
 
  /* ── 1. Parse sitemap sub-files for all URLs with hreflang ── */
  let sitemapSrc: string;
@@ -4678,7 +4673,7 @@ ${hubChromeSplit.bodyHtml}
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
  ${DARK_MODE_SCRIPT}
- <style>${criticalCSS}</style>
+ ${CRITICAL_CSS_LINK}
  <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
  <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin>
  ${stylesheetMarkup}${preloadTag}${getPagePreloads(urlPath, locale)}

--- a/build-plugins/staticScriptsPlugin.ts
+++ b/build-plugins/staticScriptsPlugin.ts
@@ -1,6 +1,7 @@
 /**
- * Emits the previously-inline analytics / SPA bootstrap scripts as standalone
- * .js files under dist/assets/ at the end of the build. Used by:
+ * Emits the previously-inline analytics / SPA bootstrap scripts (and, since
+ * the critical-CSS externalization, one stylesheet) as standalone files under
+ * dist/assets/ at the end of the build. Used by:
  *
  *   GTAG_SNIPPET                  → /assets/gtag-init.js
  *   ADSENSE_SNIPPET               → /assets/adsense-loader.js
@@ -8,8 +9,16 @@
  *                                   (concat of dark-mode-init + spa-action-redirect)
  *   POSTHOG_SNIPPET               → /assets/posthog-init.js
  *   FUEL_CHART_SCRIPT             → /assets/fuel-chart.js
+ *   CRITICAL_CSS                  → /assets/critical.css (CRITICAL_CSS_LINK)
  *
- * The two externalised stylesheets (SEO_STATIC_CSS_LINK → /assets/seo-static.css,
+ * critical.css used to be a per-page inline `<style>` block (~4.3 KB ×
+ * 55k+ static SEO pages); it is written here from the same
+ * `shared/criticalCss.ts` constant so there is exactly one source, and
+ * referenced via a render-BLOCKING `<link>` (CRITICAL_CSS_LINK) — not the
+ * media=print async-swap the other externalised stylesheets below use —
+ * because it must still be in effect before first paint.
+ *
+ * The two async-swapped stylesheets (SEO_STATIC_CSS_LINK → /assets/seo-static.css,
  * BRIDGE_CSS_LINK → /assets/bridge.css) need no step here: Vite copies them
  * verbatim from public/assets/ to dist/assets/ under the same STABLE name the
  * page tags reference (constants.ts). They used to be renamed to a hashed copy
@@ -48,6 +57,7 @@ import {
   FUEL_CHART_SCRIPT_CONTENT,
   FUEL_CHART_SCRIPT_FILENAME,
 } from './constants';
+import { CRITICAL_CSS, CRITICAL_CSS_FILENAME } from './shared/criticalCss';
 
 export function staticScriptsPlugin(rootDir: string): Plugin {
   return {
@@ -64,6 +74,7 @@ export function staticScriptsPlugin(rootDir: string): Plugin {
         [EARLY_BOOT_FILENAME, EARLY_BOOT_CONTENT],
         [POSTHOG_INIT_FILENAME, POSTHOG_INIT_CONTENT],
         [FUEL_CHART_SCRIPT_FILENAME, FUEL_CHART_SCRIPT_CONTENT],
+        [CRITICAL_CSS_FILENAME, CRITICAL_CSS],
       ];
 
       let totalBytes = 0;

--- a/tests/build-plugins/asyncCssLandings.test.ts
+++ b/tests/build-plugins/asyncCssLandings.test.ts
@@ -1,15 +1,20 @@
 /**
- * Regression gate (issue #1991, follow-up of PR #1984): static SEO landing
- * pages emitted through the shared `buildSeoPageHtml` / `buildSimplePage` shell
- * MUST load their CSS NON-render-blocking — both the Vite entry stylesheet AND
- * the s-* utility sheet `seo-static.css` — while inlining the first-paint
- * `CRITICAL_CSS` block so there is no FOUC.
+ * Regression gate (issue #1991, follow-up of PR #1984; updated 2026-07 for
+ * the critical-CSS externalization): static SEO landing pages emitted
+ * through the shared `buildSeoPageHtml` / `buildSimplePage` shell MUST load
+ * the Vite entry stylesheet AND the s-* utility sheet `seo-static.css`
+ * NON-render-blocking, while the first-paint critical CSS is loaded via a
+ * render-BLOCKING `<link>` to `/assets/critical.css` ({@link CRITICAL_CSS_LINK})
+ * so there is no FOUC. critical.css used to be an inline `<style>` block;
+ * it is now an external, same-origin, browser-cached file (written by
+ * `staticScriptsPlugin.ts`) — the ONLY synchronous stylesheet this path may
+ * emit.
  *
  * Why this matters: render-blocking CSS delays LCP, a Core Web Vital that
  * feeds Google organic ranking — the site's traffic funnel. PR #1984 added the
  * CDN preconnect but left the sheets blocking; this gate locks the async swap
  * in so the buildSimplePage path cannot silently drift back to a synchronous
- * `<link rel="stylesheet">`.
+ * `<link rel="stylesheet">` for the entry/seo-static sheets.
  *
  * The async pattern is the same one the sibling static emitters already use:
  *   - `<link rel="preload" as="style">`  (start download immediately)
@@ -19,7 +24,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildSimplePage, asyncCssHeadBlock, asyncCssLink } from '../../build-plugins/htmlTemplate';
-import { CRITICAL_CSS } from '../../build-plugins/shared/criticalCss';
+import { CRITICAL_CSS_LINK } from '../../build-plugins/shared/criticalCss';
 import { SEO_STATIC_CSS_FILENAME } from '../../build-plugins/constants';
 
 const SEO_STATIC_HREF = `/assets/${SEO_STATIC_CSS_FILENAME}`;
@@ -43,10 +48,10 @@ describe('asyncCssLink', () => {
 });
 
 describe('asyncCssHeadBlock', () => {
-  it('inlines CRITICAL_CSS and async-loads both entry CSS and seo-static.css', () => {
+  it('loads critical.css via a blocking link and async-loads both entry CSS and seo-static.css', () => {
     const out = asyncCssHeadBlock('index-deadbeef.css');
-    // First-paint critical CSS is inlined (stable paint → no FOUC).
-    expect(out).toContain(`<style>${CRITICAL_CSS}</style>`);
+    // First-paint critical CSS is a blocking <link> (stable paint → no FOUC).
+    expect(out).toContain(CRITICAL_CSS_LINK);
     // Entry sheet async.
     expect(out).toContain('href="/assets/index-deadbeef.css" media="print"');
     // seo-static.css async.
@@ -61,7 +66,7 @@ describe('asyncCssHeadBlock', () => {
 
   it('omits the entry sheet when no SPA bundle is present but still async-loads seo-static.css', () => {
     const out = asyncCssHeadBlock(undefined);
-    expect(out).toContain(`<style>${CRITICAL_CSS}</style>`);
+    expect(out).toContain(CRITICAL_CSS_LINK);
     expect(out).toContain(`href="${SEO_STATIC_HREF}" media="print"`);
     expect(out).not.toContain('index-');
   });
@@ -79,16 +84,18 @@ describe('buildSimplePage · non-render-blocking CSS', () => {
     entryJs: 'index-cafef00d.js',
   };
 
-  it('inlines critical CSS and never emits a synchronous stylesheet for the entry or seo-static sheets', () => {
+  it('loads critical.css via a blocking link and never emits another synchronous stylesheet for the entry or seo-static sheets', () => {
     const html = buildSimplePage(baseOpts);
-    expect(html).toContain(`<style>${CRITICAL_CSS}</style>`);
+    expect(html).toContain(CRITICAL_CSS_LINK);
     // Both sheets ride the media=print swap.
     expect(html).toContain('href="/assets/index-cafef00d.css" media="print"');
     expect(html).toContain(`href="${SEO_STATIC_HREF}" media="print"`);
-    // The only synchronous <link rel="stylesheet"> tags are the <noscript>
-    // fallbacks — strip them and assert nothing render-blocking remains.
+    // The only synchronous <link rel="stylesheet"> tags are critical.css and the
+    // <noscript> fallbacks — strip the noscript blocks and critical.css itself,
+    // then assert nothing else render-blocking remains.
     const withoutNoscript = html.replace(/<noscript>.*?<\/noscript>/g, '');
-    const syncStylesheets = withoutNoscript.match(/<link rel="stylesheet"(?![^>]*media="print")[^>]*>/g) || [];
+    const withoutCriticalCss = withoutNoscript.replace(CRITICAL_CSS_LINK, '');
+    const syncStylesheets = withoutCriticalCss.match(/<link rel="stylesheet"(?![^>]*media="print")[^>]*>/g) || [];
     expect(syncStylesheets, `unexpected render-blocking stylesheet(s): ${syncStylesheets.join(', ')}`).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Implementato

- `CRITICAL_CSS` (`build-plugins/shared/criticalCss.ts`) is no longer inlined as a per-page `<style>` block. `staticScriptsPlugin.ts` now writes it once to `dist/assets/critical.css` (STABLE filename, no content hash — same convention as `early-boot.js`/`gtag-init.js`/etc., revalidated via the existing CF Transform Rule `max-age=600` on `/assets/*`).
- New exports `CRITICAL_CSS_FILENAME` / `CRITICAL_CSS_LINK` in `shared/criticalCss.ts`. `CRITICAL_CSS_LINK` is a plain render-**blocking** `<link rel="stylesheet" href="/assets/critical.css">` — deliberately NOT the `media="print"` async-swap `asyncCssLink()` uses for the entry sheet / `seo-static.css`, because this CSS must still be in effect at first paint (unchanged reasoning from #1587 — only the transport changes: one same-origin request instead of inline bytes).
- Centralized fix in `asyncCssHeadBlock()` (`build-plugins/htmlTemplate.ts`), which every SSG emitter's head block routes through — GitNexus impact analysis confirmed this covers `jobsSeoPagesPlugin.ts`, `seoHubsPlugin.ts`, `jobSectorPagesPlugin.ts`, `jobRecencyPagesPlugin.ts` without touching them directly.
- Direct emitters `staticPagesPlugin.ts` and `ogPagesPlugin.ts` (previously each hand-inlined `<style>${criticalCSS}</style>`) switched to `${CRITICAL_CSS_LINK}`.
- Same-origin (`/assets/critical.css`), not pushed to the separate `cdn.frontaliereticino.ch` host — avoids an extra cross-origin DNS/TCP/TLS round-trip on a render-blocking resource, matching every other file `staticScriptsPlugin.ts` already emits.
- Site-wide, not scoped to `cerca-lavoro-svizzera` — applies to every static SEO emitter (~55k+ pages: job pages, soft-landings, hubs, sector/canton/recency pages, OG pages).
- Updated regression tests (`tests/build-plugins/asyncCssLandings.test.ts`) to assert the new blocking-link contract instead of the old inline `<style>` pattern; `tests/build-plugins/criticalCssRootHeight.test.ts` (content-level invariants, unaffected by delivery mechanism) still passes unmodified. `npx tsc --noEmit` clean on all 5 touched files (74 pre-existing unrelated repo errors, zero new).

## Non implementato (ancora)

- **Live LCP/CLS validation — in questa PR chain, subito dopo il merge.** Full local SEO builds OOM (AGENTS.md), quindi questo trade (inline bytes → 1 richiesta same-origin extra) non è validabile pre-merge. **Revert trigger dichiarato:** se il prossimo deploy mostra un peggioramento misurabile di LCP/CLS su un campione di pagine statiche reali (incluse `/cerca-lavoro-svizzera/*`) via Lighthouse/PSI/CF Web Analytics RUM rispetto al baseline pre-merge → revert immediato di questo commit. Eseguirò la misura live subito dopo il merge, prima di dichiarare il task chiuso.

Closes the "ricerche correlate inline style/script → CDN" task scope for the CSS half (scripts were already externalized pre-existing via `staticScriptsPlugin.ts`).