### PR TITLE
fix(job-canon): CDN-offload canton-drift map + restore dead IT 404 recovery

### DIFF
--- a/build-plugins/jobCanonRedirectMapPlugin.ts
+++ b/build-plugins/jobCanonRedirectMapPlugin.ts
@@ -21,9 +21,11 @@
  * flat `{slug: prefix}` value collapsed to whichever locale wrote first (it), so
  * the en/de/fr Worker 301'd every orphan to the ITALIAN page — a permanent
  * cross-locale redirect that de-indexed the localized canonical. Keying by locale
- * keeps each locale's real section (no transform of the IT one). Emitted at the
- * dist ROOT (not /data/, which is CDN-offloaded → same-origin 404) so the
- * 404.html fetch is same-origin.
+ * keeps each locale's real section (no transform of the IT one). Emitted into
+ * dist here, then pushed to cdn.frontaliereticino.ch and deleted from dist by
+ * the deploy CDN-offload step (deploy-it-pages-prep.sh step_push_cdn +
+ * offload-generated-images-cdn.mjs), same as /data and /og — 404.html and the
+ * Worker both fetch shards via a CDN-absolute URL, not same-origin.
  *
  * Streaming + bounded: one small JSON per shard (a few hundred slugs each), keyed
  * by the localized last segment (identical across all 4 locales), built once from

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -203,13 +203,14 @@ const NOT_FOUND_CACHE_CONTROL = 'public, max-age=300, s-maxage=7200';
 // redirect a path we can't confirm. IT traffic is not routed through this Worker
 // and keeps the soft path — see wrangler.toml.)
 //
-// The slug→{locale: section-prefix} map is emitted at the IT dist root
-// (jobCanonRedirectMapPlugin → /job-canon/<shard>.json) and fetched here from the
-// public apex; that path is outside the Worker's locale routes, so the subrequest
-// flows straight to the IT Pages origin (no Worker re-entry) and is edge-cached
-// (cacheEverything + cacheTtl) so repeat 404s for the same shard don't re-hit the
-// origin. Best-effort throughout: any miss/timeout/parse error returns null and
-// the normal 404 path runs.
+// The slug→{locale: section-prefix} map is emitted by jobCanonRedirectMapPlugin
+// and pushed to cdn.frontaliereticino.ch/job-canon/<shard>.json (CDN-offloaded,
+// same as /data and /og — see deploy-it-pages-prep.sh step_push_cdn). Fetched
+// here as a plain cross-origin subrequest (Workers fetch() is not CORS-bound,
+// unlike public/404.html's browser-context fetch) and edge-cached (cacheEverything
+// + cacheTtl) so repeat 404s for the same shard don't re-hit the CDN. Best-effort
+// throughout: any miss/timeout/parse error returns null and the normal 404 path
+// runs.
 //
 // LOCALE-AWARE (do NOT collapse): the slug segment is IDENTICAL across all 4
 // locales — only the section prefix is localized. The map value is therefore a
@@ -275,6 +276,10 @@ const LEGACY_PAGINATION_RE =
 
 const MAP_FETCH_TIMEOUT_MS = 2000;
 const JOB_CANON_CACHE_TTL = 21600; // 6 h — map changes only on deploy
+// CDN-offloaded (see comment above recoverCantonDriftOrphan). MIRRORS the
+// literal in public/404.html — duplicated, not imported, same reason as
+// JOB_DETAIL_RE above (standalone Worker runtime, not part of the Vite bundle).
+const JOB_CANON_CDN_BASE = 'https://cdn.frontaliereticino.ch';
 
 // Shard key for /job-canon/<sk>.json. MIRRORS public/404.html + the plugin's
 // shardKey(): first 2 chars of the lowercased slug, non-alphanumerics → '_',
@@ -305,7 +310,7 @@ async function recoverCantonDriftOrphan(url, locale) {
   const timer = setTimeout(() => controller.abort(), MAP_FETCH_TIMEOUT_MS);
   let map;
   try {
-    const mapUrl = new URL(`/job-canon/${sk}.json`, url.origin);
+    const mapUrl = new URL(`/job-canon/${sk}.json`, JOB_CANON_CDN_BASE);
     const resp = await fetch(mapUrl.toString(), {
       signal: controller.signal,
       cf: { cacheEverything: true, cacheTtl: JOB_CANON_CACHE_TTL },

--- a/public/404.html
+++ b/public/404.html
@@ -43,11 +43,13 @@
     <!-- Canton-drift recovery + SPA redirect. A job slug is globally unique, so an
          orphaned canton-variant 404 (the canton drifted between crawls, leaving the
          already-indexed URL behind) is redirected to the slug's CURRENT canonical
-         page via the sharded map at /job-canon/ (jobCanonRedirectMapPlugin). These
+         page via the sharded map at cdn.frontaliereticino.ch/job-canon/
+         (jobCanonRedirectMapPlugin, CDN-offloaded same as /data and /og). These
          orphans cannot be recovered statically (a 404 URL has no GSC impressions),
          so request-time lookup is the only way. Non-job 404s fall through to the SPA. -->
     <script>
       (function() {
+        var JOB_CANON_CDN = 'https://cdn.frontaliereticino.ch';
         // Paths that are real static files — do NOT redirect (let 404 show)
         var staticExts = /\.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|json|xml|txt|map|webmanifest)$/i;
         var pathname = location.pathname;
@@ -132,7 +134,7 @@
         // last-resort sectionRoot fallback only; both run in .then/.catch below,
         // after the fetch has confirmed the slug is not in the canonical map.
         var timer = setTimeout(function() { go(sectionRoot); }, 1500);
-        fetch('/job-canon/' + sk + '.json', { cache: 'force-cache' })
+        fetch(JOB_CANON_CDN + '/job-canon/' + sk + '.json', { cache: 'force-cache' })
           .then(function(r) { return r.ok ? r.json() : null; })
           .then(function(map) {
             var entry = map && map[slug];

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -176,10 +176,11 @@ _publish_cdn_r2() {
     [ -d "$1" ] || return 0
     "${RC[@]}" copy "$1" "$bkt/$2" --header-upload "Cache-Control: $3" --stats=0 || ok=0
   }
-  _r2_sync "$stage/assets" assets "public,max-age=31536000,immutable"
-  _r2_sync "$stage/og"     og     "public,max-age=86400"
-  _r2_sync "$stage/images" images "public,max-age=86400"
-  _r2_sync "$stage/data"   data   "public,max-age=600"
+  _r2_sync "$stage/assets"    assets    "public,max-age=31536000,immutable"
+  _r2_sync "$stage/og"        og        "public,max-age=86400"
+  _r2_sync "$stage/images"    images    "public,max-age=86400"
+  _r2_sync "$stage/data"      data      "public,max-age=600"
+  _r2_sync "$stage/job-canon" job-canon "public,max-age=600"
   "${RC[@]}" copyto "$stage/index.html" "$bkt/index.html" \
     --header-upload "Content-Type: text/html; charset=utf-8" --header-upload "Cache-Control: public,max-age=600" || ok=0
   if [ "$ok" != 1 ]; then

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -104,8 +104,14 @@ run_nonfatal() {
 
 # ── 1. SPA fallback (GitHub Pages serves 404.html for unknown paths) ──────────
 # deploy.yml: "SPA fallback" — FATAL (plain `run:`).
+# public/404.html (canton-drift recovery + generic SPA redirect-restore — see
+# its own header comment) is already copied to dist/404.html by Vite's default
+# publicDir behavior, so only fall back to the plain index.html copy when it is
+# somehow absent (defensive: public/404.html is git-tracked and should always
+# exist). Previously this unconditionally overwrote dist/404.html, silently
+# discarding the canton-drift recovery script for every IT-locale deploy.
 step_spa_fallback() {
-  cp dist/index.html dist/404.html
+  [ -f dist/404.html ] || cp dist/index.html dist/404.html
 }
 
 # ── R2 publish (Cloudflare R2 via S3 API) — instant PUT, no Pages build ───────
@@ -193,7 +199,8 @@ _publish_cdn_r2() {
 
 # ── 2. Push generated assets to CDN repo (frontaliere-cdn / Pages) ────────────
 # deploy.yml: "Push generated assets to CDN repo" — NON-FATAL (continue-on-error).
-# Stages CDN payload (dist/og, dist/data, dist/assets, public/images/*), then
+# Stages CDN payload (dist/og, dist/data, dist/assets, dist/job-canon,
+# public/images/*), then
 # publishes via CDN_TARGET: 'r2' (S3 sync, default-off) or 'pages' (legacy git
 # force-push to valerielinc-ops/frontaliere-cdn). Exports CDN_BASE on success.
 # Internally non-fatal: every failure path keeps the assets in dist.
@@ -220,6 +227,11 @@ step_push_cdn() {
   [ -d dist/og ]           && cp -r dist/og           "$stage/og"
   [ -d dist/data ]         && cp -r dist/data         "$stage/data"
   [ -d dist/assets ]       && cp -r dist/assets       "$stage/assets"
+  # Canton-drift 404-recovery shard map (jobCanonRedirectMapPlugin, ~29 MB /
+  # 400 shards): runtime-fetch only (public/404.html + the Worker), no static
+  # HTML ref to rewrite, so the offload script just deletes dist/job-canon
+  # once this push succeeds (see its job-canon phase).
+  [ -d dist/job-canon ]    && cp -r dist/job-canon    "$stage/job-canon"
   [ -d public/images/blog ] && mkdir -p "$stage/images" && cp -r public/images/blog "$stage/images/blog"
   # Self-hosted brand/logo/author images (#1360): push from the git-tracked
   # public/images/<dir> source to ${CDN}/images/<dir>, so the offload script
@@ -236,7 +248,7 @@ step_push_cdn() {
   # timestamps — not a runtime asset, must not be published).
   find "$stage" -name '.DS_Store' -delete 2>/dev/null || true
   rm -f "$stage/assets/.hash-age.json" 2>/dev/null || true
-  if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ]; then
+  if [ ! -d "$stage/og" ] && [ ! -d "$stage/data" ] && [ ! -d "$stage/assets" ] && [ ! -d "$stage/images" ] && [ ! -d "$stage/job-canon" ]; then
     echo "no offloadable assets present — skipping CDN push"; return 0
   fi
   printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch CDN</title>frontaliereticino.ch asset CDN' > "$stage/index.html"

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -2,7 +2,7 @@
 // offload-generated-images-cdn.mjs
 //
 // Offload BUILD-GENERATED assets out of the GitHub Pages artifact, rewriting
-// their references to the dedicated CDN repo's Pages site (CDN_BASE). Two phases:
+// their references to the dedicated CDN repo's Pages site (CDN_BASE). Three phases:
 //   1. per-job OG cards (dist/og)  — rewrite static og:image refs in HTML
 //   2. all data JSON/CSV (dist/data) — inject runtime CDN base AND rewrite static
 //      same-origin /data/ refs (JSON-LD contentUrl, download hrefs) → CDN in HTML,
@@ -11,6 +11,10 @@
 //      pins its file; robots.txt Allow/Disallow are crawl directives, not content
 //      links, so they no longer pin (they kept 62 MB — incl. 55 MB expired-jobs.json
 //      — in the artifact even though the bytes were already live on the CDN).
+//   3. job-canon canton-drift 404-recovery shard map (dist/job-canon) — no static
+//      HTML ref exists at all (public/404.html and the Worker both fetch it via a
+//      CDN-absolute URL hardcoded at the consumer, not a runtime-injected base), so
+//      this phase is a plain guarded delete once the CDN push has staged it.
 // (The JS/CSS bundle is offloaded separately: ASSET_CDN/renderBuiltUrl rebases it
 //  at build time; the deploy verify step deletes dist/assets fail-safe.)
 //
@@ -196,6 +200,14 @@ function offloadAll(distDir, cdnBase) {
   // data inject + ref-collect + same-origin→CDN rewrite setup.
   const dataDir = path.join(distDir, 'data');
   const hasData = fs.existsSync(dataDir);
+
+  // job-canon (canton-drift 404-recovery shard map): runtime-fetch only, via a
+  // CDN-absolute URL hardcoded in public/404.html and the Worker — unlike
+  // og/data/images there is NO static HTML ref to rewrite or guard (confirmed:
+  // no `/job-canon/` literal exists in any dist HTML), so once the push to the
+  // CDN repo succeeds, the dist copy is simply redundant and can be deleted.
+  const jobCanonDir = path.join(distDir, 'job-canon');
+  const hasJobCanon = fs.existsSync(jobCanonDir);
   // Escape `<` so the inline <script> can't be broken out of — same class as
   // build-plugins/shared/inlineJsonScript.ts (inlined here: this .mjs runs under
   // plain Node and can't import the TS helper). cdnBase is a controlled config
@@ -405,6 +417,17 @@ function offloadAll(distDir, cdnBase) {
       removed++;
     });
     log(`data → ${cdnBase} ; injected base into ${injected}/${htmlSeen} HTML ; rewrote /data/ refs in ${dataRefRewritten} HTML ; removed ${removed} files (kept ${kept} still-same-origin) ; freed ${(freed / 1048576).toFixed(0)} MB`);
+  }
+
+  // job-canon: no refs to check — the CDN push (deploy-it-pages-prep.sh
+  // step_push_cdn) already staged it under the SAME payload as og/data before
+  // this script runs, so its presence on the CDN is as certain as theirs.
+  if (!hasJobCanon) {
+    log('no dist/job-canon — skipping job-canon delete');
+  } else {
+    const freed = dirSize(jobCanonDir);
+    fs.rmSync(jobCanonDir, { recursive: true, force: true });
+    log(`job-canon → ${cdnBase} ; freed ${(freed / 1048576).toFixed(0)} MB`);
   }
 
   log(`single-pass offload over ${scanned} HTML/XML/TXT files ; assets: rewrote /assets/ refs in ${assetRewritten} (dist/assets dropped by the deploy verify step)`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -278,10 +278,12 @@ export default defineConfig(({ mode }) => {
  // only fills paths with no richer page. Hard MAX_EMIT cap in the plugin.
  cfHot404BridgePlugin(__dirname),
  // Sharded slug→canonical-section map (dist/job-canon/*.json) read by
- // public/404.html to redirect canton-drift orphans to their real page at
- // request time — the only way to recover the EXISTING orphans (not enumerable
- // statically: a 404 URL has no GSC impressions). Pin kills NEW drift; this
- // recovers the indexed ones. Root-level emit (not /data/, which is CDN-offloaded).
+ // public/404.html + the Worker to redirect canton-drift orphans to their real
+ // page at request time — the only way to recover the EXISTING orphans (not
+ // enumerable statically: a 404 URL has no GSC impressions). Pin kills NEW
+ // drift; this recovers the indexed ones. Emitted here into dist, then pushed
+ // to the CDN and deleted from dist by the deploy CDN-offload step (same as
+ // /data and /og — see deploy-it-pages-prep.sh + offload-generated-images-cdn.mjs).
  jobCanonRedirectMapPlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links


### PR DESCRIPTION
## Implementato

**A. CDN-offload `dist/job-canon/*.json`** (canton-drift 404-recovery shard map, ~29 MB / 400 shards), same pattern already used for `/data` and `/og`:
- `scripts/lib/deploy-it-pages-prep.sh` (`step_push_cdn`): stage `dist/job-canon` into the CDN push payload; updated the "no offloadable assets" guard to include it.
- `scripts/offload-generated-images-cdn.mjs`: new delete-only phase (no static HTML ref exists to rewrite — confirmed via full-repo grep) that removes `dist/job-canon` once the CDN push has staged it.
- `infra/cloudflare-worker/locale-router.js`: `recoverCantonDriftOrphan` now fetches shards from `https://cdn.frontaliereticino.ch/job-canon/<sk>.json` instead of same-origin (`JOB_CANON_CDN_BASE` const, mirrors the existing duplication pattern of `JOB_DETAIL_RE`).
- `public/404.html`: same fetch now prefixed with a CDN-absolute base (`JOB_CANON_CDN`).
- `build-plugins/jobCanonRedirectMapPlugin.ts` + `vite.config.ts`: updated stale header comments that described job-canon as deliberately kept same-origin/root-emitted (that rationale is now obsolete/inverted).

**B. Fixed separately-discovered production bug**: `step_spa_fallback` in `deploy-it-pages-prep.sh` unconditionally did `cp dist/index.html dist/404.html` on every IT-locale deploy, silently overwriting the richer `public/404.html` (canton-drift recovery + generic SPA-redirect-restore) with a plain SPA-fallback copy — verified live that `frontaliereticino.ch/404.html` served the homepage instead of the recovery script. Fixed with an existence guard: `[ -f dist/404.html ] || cp dist/index.html dist/404.html`. Confirmed via `.github/workflows/deploy.yml` step ordering that `push-ticino-shard.sh` (which stages the Ticino/`it` shard's own `404.html`) runs *before* this step, so only the main IT apex was ever affected; en/de/fr shards don't ship a static `404.html` at all (they rely on the Worker's real 301) and are unaffected.

**Testing**: ran the 5 directly-affected suites (`job-canon-redirect-map`, all 4 `locale-router-*-301` tests) plus the 2 suites that directly invoke `offload-generated-images-cdn.mjs` (`cdn-data-preconnect-inject`, `job-detail-seed`) — 62/62 green. Syntax-checked `deploy-it-pages-prep.sh` (`bash -n`), `offload-generated-images-cdn.mjs` + `locale-router.js` (`node --check`), and the 3 inline `<script>` blocks in `public/404.html` (`new Function`).

**GitNexus**: `impact` on `recoverCantonDriftOrphan` → LOW risk, 0 tracked callers. `step_spa_fallback`/`step_push_cdn` (bash functions) are outside GitNexus's JS/TS index — blast radius for those instead verified manually via the `deploy.yml` step-ordering trace above. `detect_changes` returns 0 changed/affected against the indexed main tree (worktree-local diff, expected — not a gap in this PR's coverage).

## Non implementato (ancora)

Nessuno. Both original asks (CDN-feasibility investigation → implement, and the discovered dead-404-recovery bug) are fully implemented and tested in this PR.