### PR TITLE
fix(newsletter): close Auth/Firestore subscription gap, bulletproof bounce classification

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -39,6 +39,7 @@ import {
 import { sendRenewalReminders } from './src/publisherRenewalCore.js';
 import { handleVerifyPublisherDomain } from './src/publisherDomainVerifyCore.js';
 import { enforceFreeTierCap } from './src/publisherFreeCapCore.js';
+import { syncAuthAccountForSubscriber } from './src/newsletterSubscriberAuthSync.js';
 
 ensureAdminApp();
 
@@ -1019,6 +1020,23 @@ export const forwardPublisherApplication = onDocumentCreated(
  if (!result.ok) console.error('[forwardPublisherApplication]', result.error);
  } catch (error) {
  console.error('[forwardPublisherApplication]', error instanceof Error ? error.message : String(error));
+ }
+ },
+);
+
+// Closes the 522-orphan gap (lead-capture gates write Firestore directly, no
+// Auth account): silently create a shadow Auth user, single site-wide
+// mechanism instead of patching all ~16 capture call sites.
+export const syncNewsletterSubscriberAuth = onDocumentCreated(
+ { region: 'europe-west6', memory: '256MiB', document: 'newsletter_subscribers/{email}' },
+ async (event) => {
+ const emailId = event.params.email;
+ if (emailId === '_meta_') return;
+ try {
+ const result = await syncAuthAccountForSubscriber(emailId);
+ if (result.created) console.log(`[syncNewsletterSubscriberAuth] created Auth user for ${emailId}`);
+ } catch (error) {
+ console.error('[syncNewsletterSubscriberAuth]', error instanceof Error ? error.message : String(error));
  }
  },
 );

--- a/functions/src/lib/bounceClassification.js
+++ b/functions/src/lib/bounceClassification.js
@@ -1,0 +1,110 @@
+import admin from 'firebase-admin';
+
+/**
+ * Hard-vs-soft bounce classification — shared by every newsletter*WebhookCore.js.
+ * All 5 providers used to collapse reputation/soft rejects (Mailjet `blocked`,
+ * Maileroo `rejected`, Mailtrap `soft_bounce`/`reject`, Mailgun `severity:
+ * temporary`) into the same permanent `status: 'bounced'` as a genuine hard
+ * bounce — which is excluded from every future send (see
+ * services/emailSuppression.mjs) — so one provider hiccup could permanently
+ * kill a real, engaged subscriber. Soft signals now only increment
+ * `soft_bounce_count`; only SOFT_ESCALATION_THRESHOLD consecutive soft rejects
+ * with no delivery/open in between escalate to a real `bounced`. Any
+ * delivered/open/click event resets the counter (recovery signal).
+ */
+
+export const SOFT_ESCALATION_THRESHOLD = 3;
+
+/**
+ * @param {{ provider: 'mailjet'|'maileroo'|'mailtrap'|'mailgun'|'resend', rawEvent: string, eventData: object }} args
+ * @returns {'hard'|'soft'}
+ */
+export function classifyBounceSeverity({ provider, rawEvent, eventData }) {
+  const raw = String(rawEvent || '').toLowerCase();
+  switch (provider) {
+    case 'mailjet':
+      // Mailjet already tells us: `blocked` is always reputation/soft; a real
+      // `bounce` event is hard only when Mailjet itself flags hard_bounce.
+      if (raw === 'blocked') return 'soft';
+      return eventData?.hard_bounce ? 'hard' : 'soft';
+    case 'maileroo':
+      // `rejected` = provider-side reputation reject; `failed` = real delivery failure.
+      return raw === 'rejected' ? 'soft' : 'hard';
+    case 'mailtrap':
+      return (raw === 'soft_bounce' || raw === 'reject') ? 'soft' : 'hard';
+    case 'mailgun': {
+      const severity = String(eventData?.severity || '').toLowerCase();
+      if (severity === 'temporary') return 'soft';
+      if (severity === 'permanent') return 'hard';
+      // No severity captured (e.g. a pre-send `rejected`) — treat as soft, conservative.
+      return raw === 'rejected' ? 'soft' : 'hard';
+    }
+    case 'resend': {
+      const bounceType = String(eventData?.bounce?.type || eventData?.bounce_type || '').toLowerCase();
+      return (bounceType === 'transient' || bounceType === 'undetermined') ? 'soft' : 'hard';
+    }
+    default:
+      return 'hard';
+  }
+}
+
+/**
+ * Fields to merge into the caller's subscriberUpdate object for a bounce event.
+ * Hard: identical to the prior behavior (permanent bounced status). Soft:
+ * never touches `status` directly — only tracks the counter; escalation is a
+ * separate follow-up step, see maybeEscalateSoftBounce.
+ *
+ * @param {{ severity: 'hard'|'soft', reason: string }} args
+ */
+export function bounceUpdateFields({ severity, reason }) {
+  const FieldValue = admin.firestore.FieldValue;
+  if (severity === 'hard') {
+    return {
+      status: 'bounced',
+      bounced_at: FieldValue.serverTimestamp(),
+      bounce_reason: reason,
+      bounce_severity: 'hard',
+      soft_bounce_count: 0,
+    };
+  }
+  return {
+    last_soft_bounce_at: FieldValue.serverTimestamp(),
+    bounce_reason: reason,
+    bounce_severity: 'soft',
+    soft_bounce_count: FieldValue.increment(1),
+  };
+}
+
+/**
+ * Fields that reset the soft-bounce counter on any successful delivery/open/
+ * click — the recovery signal proving the address is actually alive.
+ */
+export function softBounceRecoveryFields() {
+  return { soft_bounce_count: 0 };
+}
+
+/**
+ * Call AFTER the main subscriberUpdate write, only when the just-applied bounce
+ * was soft. Reads the post-write soft_bounce_count and, once it reaches the
+ * threshold with no intervening recovery, escalates to a real, permanent
+ * `bounced` status.
+ *
+ * @param {FirebaseFirestore.DocumentReference} subscriberRef
+ * @param {string} reason latest bounce reason, folded into the escalation audit trail
+ * @returns {Promise<boolean>} true if this call escalated the subscriber
+ */
+export async function maybeEscalateSoftBounce(subscriberRef, reason) {
+  const snap = await subscriberRef.get();
+  const data = snap.data() || {};
+  const count = Number(data.soft_bounce_count) || 0;
+  if (count < SOFT_ESCALATION_THRESHOLD || data.status === 'bounced') return false;
+
+  const FieldValue = admin.firestore.FieldValue;
+  await subscriberRef.set({
+    status: 'bounced',
+    bounced_at: FieldValue.serverTimestamp(),
+    bounce_reason: `${reason} (escalated after ${count} consecutive soft rejects)`,
+    bounce_severity: 'hard',
+  }, { merge: true });
+  return true;
+}

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -2,6 +2,7 @@ import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
+import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 
 /**
  * Maileroo webhook handler — receives delivery events and stores them in Firestore.
@@ -146,25 +147,33 @@ export async function persistMailerooEvent(db, event) {
     updated_at: FieldValue.serverTimestamp(),
   };
 
+  let bounceSeverity = null;
+
   if (type === 'delivered') {
     subscriberUpdate.last_delivered_at = FieldValue.serverTimestamp();
+    Object.assign(subscriberUpdate, softBounceRecoveryFields());
   } else if (type === 'open') {
     subscriberUpdate.last_open_at = FieldValue.serverTimestamp();
     subscriberUpdate.open_count = FieldValue.increment(1);
+    Object.assign(subscriberUpdate, softBounceRecoveryFields());
   } else if (type === 'click') {
     subscriberUpdate.last_click_at = FieldValue.serverTimestamp();
     subscriberUpdate.click_count = FieldValue.increment(1);
     subscriberUpdate.last_clicked_url = clickedUrl;
+    Object.assign(subscriberUpdate, softBounceRecoveryFields());
   } else if (type === 'bounce') {
-    subscriberUpdate.status = 'bounced';
-    subscriberUpdate.bounced_at = FieldValue.serverTimestamp();
-    subscriberUpdate.bounce_reason = bounceReason;
+    bounceSeverity = classifyBounceSeverity({ provider: 'maileroo', rawEvent: event.event_type, eventData: data });
+    Object.assign(subscriberUpdate, bounceUpdateFields({ severity: bounceSeverity, reason: bounceReason }));
   } else if (type === 'complaint') {
     subscriberUpdate.status = 'complained';
     subscriberUpdate.complained_at = FieldValue.serverTimestamp();
   }
 
   await subscriberRef.set(subscriberUpdate, { merge: true });
+
+  if (bounceSeverity === 'soft') {
+    await maybeEscalateSoftBounce(subscriberRef, bounceReason);
+  }
 
   // Refresh engagement score after counter changes (FRO-17)
   if (type === 'open' || type === 'click' || type === 'send') {

--- a/functions/src/newsletterMailgunWebhookCore.js
+++ b/functions/src/newsletterMailgunWebhookCore.js
@@ -2,6 +2,7 @@ import admin from 'firebase-admin';
 import crypto from 'crypto';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
+import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 
 /**
  * Mailgun webhook handler — receives delivery events and stores them in Firestore.
@@ -97,19 +98,25 @@ async function persistMailgunEvent(db, eventData) {
  updated_at: FieldValue.serverTimestamp(),
  };
 
+ let bounceSeverity = null;
+ let bounceReasonText = '';
+
  if (type === 'delivered') {
  subscriberUpdate.last_delivered_at = FieldValue.serverTimestamp();
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'open') {
  subscriberUpdate.last_open_at = FieldValue.serverTimestamp();
  subscriberUpdate.open_count = FieldValue.increment(1);
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'click') {
  subscriberUpdate.last_click_at = FieldValue.serverTimestamp();
  subscriberUpdate.click_count = FieldValue.increment(1);
  subscriberUpdate.last_clicked_url = eventData.url || '';
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'bounce') {
- subscriberUpdate.status = 'bounced';
- subscriberUpdate.bounced_at = FieldValue.serverTimestamp();
- subscriberUpdate.bounce_reason = eventData['delivery-status']?.description || eventData.reason || '';
+ bounceSeverity = classifyBounceSeverity({ provider: 'mailgun', rawEvent: mgEvent, eventData });
+ bounceReasonText = eventData['delivery-status']?.description || eventData.reason || '';
+ Object.assign(subscriberUpdate, bounceUpdateFields({ severity: bounceSeverity, reason: bounceReasonText }));
  } else if (type === 'unsubscribed') {
  subscriberUpdate.status = 'unsubscribed';
  subscriberUpdate.unsubscribed_at = FieldValue.serverTimestamp();
@@ -119,6 +126,10 @@ async function persistMailgunEvent(db, eventData) {
  }
 
  await subscriberRef.set(subscriberUpdate, { merge: true });
+
+ if (bounceSeverity === 'soft') {
+ await maybeEscalateSoftBounce(subscriberRef, bounceReasonText);
+ }
 
  // Refresh engagement score after counter changes (FRO-17)
  if (type === 'open' || type === 'click' || type === 'send') {

--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
+import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 
 /**
  * Mailjet webhook handler — receives delivery events and stores them in Firestore.
@@ -91,21 +92,26 @@ export async function persistMailjetEvent(db, eventData) {
  updated_at: FieldValue.serverTimestamp(),
  };
 
+ let bounceSeverity = null;
+ let bounceReasonText = '';
+
  if (type === 'send') {
  subscriberUpdate.last_sent_at = FieldValue.serverTimestamp();
  subscriberUpdate.send_count = FieldValue.increment(1);
  } else if (type === 'open') {
  subscriberUpdate.last_open_at = FieldValue.serverTimestamp();
  subscriberUpdate.open_count = FieldValue.increment(1);
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'click') {
  subscriberUpdate.last_click_at = FieldValue.serverTimestamp();
  subscriberUpdate.click_count = FieldValue.increment(1);
  subscriberUpdate.last_clicked_url = eventData.url || '';
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'bounce') {
- subscriberUpdate.status = 'bounced';
- subscriberUpdate.bounced_at = FieldValue.serverTimestamp();
- subscriberUpdate.bounce_reason = eventData.error || '';
+ bounceSeverity = classifyBounceSeverity({ provider: 'mailjet', rawEvent: mjEvent, eventData });
+ bounceReasonText = eventData.error || '';
  subscriberUpdate.bounce_hard = !!eventData.hard_bounce;
+ Object.assign(subscriberUpdate, bounceUpdateFields({ severity: bounceSeverity, reason: bounceReasonText }));
  } else if (type === 'unsubscribed') {
  subscriberUpdate.status = 'unsubscribed';
  subscriberUpdate.unsubscribed_at = FieldValue.serverTimestamp();
@@ -116,6 +122,10 @@ export async function persistMailjetEvent(db, eventData) {
 
  if (Object.keys(subscriberUpdate).length > 1) {
  await subscriberRef.set(subscriberUpdate, { merge: true });
+ }
+
+ if (bounceSeverity === 'soft') {
+ await maybeEscalateSoftBounce(subscriberRef, bounceReasonText);
  }
 
  // Refresh engagement score after counter changes (FRO-17)

--- a/functions/src/newsletterMailtrapWebhookCore.js
+++ b/functions/src/newsletterMailtrapWebhookCore.js
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 
 /**
  * Mailtrap webhook handler — receives delivery events and stores them in Firestore.
@@ -79,19 +80,25 @@ async function persistMailtrapEvent(db, eventData) {
  updated_at: FieldValue.serverTimestamp(),
  };
 
+ let bounceSeverity = null;
+ let bounceReasonText = '';
+
  if (type === 'delivered') {
  subscriberUpdate.last_delivered_at = FieldValue.serverTimestamp();
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'open') {
  subscriberUpdate.last_open_at = FieldValue.serverTimestamp();
  subscriberUpdate.open_count = FieldValue.increment(1);
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'click') {
  subscriberUpdate.last_click_at = FieldValue.serverTimestamp();
  subscriberUpdate.click_count = FieldValue.increment(1);
  subscriberUpdate.last_clicked_url = eventData.url || '';
+ Object.assign(subscriberUpdate, softBounceRecoveryFields());
  } else if (type === 'bounce') {
- subscriberUpdate.status = 'bounced';
- subscriberUpdate.bounced_at = FieldValue.serverTimestamp();
- subscriberUpdate.bounce_reason = eventData.bounce_category || eventData.event || '';
+ bounceSeverity = classifyBounceSeverity({ provider: 'mailtrap', rawEvent: eventData.event, eventData });
+ bounceReasonText = eventData.bounce_category || eventData.event || '';
+ Object.assign(subscriberUpdate, bounceUpdateFields({ severity: bounceSeverity, reason: bounceReasonText }));
  } else if (type === 'unsubscribed') {
  subscriberUpdate.status = 'unsubscribed';
  subscriberUpdate.unsubscribed_at = FieldValue.serverTimestamp();
@@ -105,6 +112,10 @@ async function persistMailtrapEvent(db, eventData) {
  }
 
  await subscriberRef.set(subscriberUpdate, { merge: true });
+
+ if (bounceSeverity === 'soft') {
+ await maybeEscalateSoftBounce(subscriberRef, bounceReasonText);
+ }
 
  // Refresh engagement score after counter changes (FRO-17)
  if (type === 'open' || type === 'click' || type === 'send') {

--- a/functions/src/newsletterResendWebhookCore.js
+++ b/functions/src/newsletterResendWebhookCore.js
@@ -3,6 +3,7 @@ import { Resend } from 'resend';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 import { buildDeliveryDocId as buildCanonicalDeliveryDocId } from './lib/deliveryDocId.js';
+import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 
 function normalizeEmail(value) {
  return String(value || '').trim().toLowerCase();
@@ -121,12 +122,14 @@ function buildSubscriberUpdate(eventType, data, currentStatus) {
  }
  if (eventType === 'delivered') {
  update.last_delivered_at = admin.firestore.FieldValue.serverTimestamp();
+ Object.assign(update, softBounceRecoveryFields());
  }
  if (eventType === 'open') {
  update.last_open_at = admin.firestore.FieldValue.serverTimestamp();
  update.lastOpenAt = admin.firestore.FieldValue.serverTimestamp();
  update.open_count = FieldValue.increment(1);
  update.openCount = FieldValue.increment(1);
+ Object.assign(update, softBounceRecoveryFields());
  }
  if (eventType === 'click') {
  update.last_click_at = admin.firestore.FieldValue.serverTimestamp();
@@ -135,13 +138,11 @@ function buildSubscriberUpdate(eventType, data, currentStatus) {
  update.clickCount = FieldValue.increment(1);
  update.last_clicked_url = sanitizeString(data.link_url || data.target_url);
  update.last_clicked_section = sanitizeString(data.section_id);
+ Object.assign(update, softBounceRecoveryFields());
  }
- if (eventType === 'bounce') {
- update.last_bounced_at = admin.firestore.FieldValue.serverTimestamp();
- update.status = 'bounced';
- update.isActive = false;
- update.active = false;
- }
+ // Bounce classification/severity is handled by the caller (needs the raw
+ // provider bounce payload, which this constructed `data` object doesn't
+ // carry) — see the `type === 'bounce'` block right after this call.
  if (eventType === 'complaint') {
  update.last_complained_at = admin.firestore.FieldValue.serverTimestamp();
  update.status = 'complained';
@@ -235,7 +236,25 @@ export async function applyResendWebhookEvent(rawEvent, options = {}) {
  }, currentStatus);
 
  subscriberUpdate.provider = 'resend';
- await db.collection('newsletter_subscribers').doc(email).set(subscriberUpdate, { merge: true });
+
+ let bounceSeverity = null;
+ let bounceReasonText = '';
+ if (type === 'bounce') {
+ bounceSeverity = classifyBounceSeverity({ provider: 'resend', rawEvent: rawEvent?.type, eventData: data });
+ bounceReasonText = sanitizeString(data.bounce?.message) || sanitizeString(data.reason) || '';
+ Object.assign(subscriberUpdate, bounceUpdateFields({ severity: bounceSeverity, reason: bounceReasonText }));
+ if (bounceSeverity === 'hard') {
+ subscriberUpdate.isActive = false;
+ subscriberUpdate.active = false;
+ }
+ }
+
+ const subscriberRef = db.collection('newsletter_subscribers').doc(email);
+ await subscriberRef.set(subscriberUpdate, { merge: true });
+
+ if (bounceSeverity === 'soft') {
+ await maybeEscalateSoftBounce(subscriberRef, bounceReasonText);
+ }
 
  // Update engagement score after metrics change (FRO-17)
  if (type === 'open' || type === 'click' || type === 'send') {

--- a/functions/src/newsletterSubscriberAuthSync.js
+++ b/functions/src/newsletterSubscriberAuthSync.js
@@ -1,0 +1,53 @@
+/**
+ * Newsletter subscriber → Auth account sync (gap-review, orphan-subscriber fix).
+ *
+ * ~522 of 5241 `newsletter_subscribers` docs have no Firebase Auth user behind
+ * them, because lead-capture gates (job_gate, popup, lead_magnet, analysis_gate,
+ * calculator_paywall, offerwall, chatbot, ...) write straight to Firestore via
+ * `upsertNewsletterSubscriber` and never touch `firebase/auth`. Rather than
+ * patch each of the ~16 call sites, this module is invoked by a single
+ * `onDocumentCreated` trigger (see functions/index.js) on every new
+ * `newsletter_subscribers/{email}` doc, and silently creates a matching Auth
+ * account (no password, `emailVerified:false`, no email sent) when one doesn't
+ * already exist. Subscribers coming from auth_google/auth_facebook/auth_linkedin
+ * already have an Auth account created before the Firestore doc, so this is a
+ * no-op for the common case.
+ */
+
+import admin from 'firebase-admin';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * @param {string} rawEmail  the newsletter_subscribers/{email} doc id (or an email field)
+ * @returns {Promise<{created: boolean, uid?: string, reason?: string, error?: string}>}
+ */
+export async function syncAuthAccountForSubscriber(rawEmail) {
+  const email = typeof rawEmail === 'string' ? rawEmail.trim().toLowerCase() : '';
+
+  if (!email || email === '_meta_' || !EMAIL_RE.test(email)) {
+    return { created: false, reason: 'invalid_email' };
+  }
+
+  try {
+    await admin.auth().getUserByEmail(email);
+    return { created: false, reason: 'already_exists' };
+  } catch (error) {
+    if (error?.code !== 'auth/user-not-found') {
+      console.error('[syncAuthAccountForSubscriber]', error instanceof Error ? error.message : String(error));
+      return { created: false, reason: 'error', error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  try {
+    const userRecord = await admin.auth().createUser({ email, emailVerified: false, disabled: false });
+    return { created: true, uid: userRecord.uid };
+  } catch (error) {
+    if (error?.code === 'auth/email-already-exists') {
+      // Race with a concurrent write (e.g. the client's own signup flow) — not an error.
+      return { created: false, reason: 'already_exists' };
+    }
+    console.error('[syncAuthAccountForSubscriber]', error instanceof Error ? error.message : String(error));
+    return { created: false, reason: 'error', error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/scripts/dev/backfill-newsletter-subscriber-auth.mjs
+++ b/scripts/dev/backfill-newsletter-subscriber-auth.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Backfill Firebase Auth accounts for the existing `newsletter_subscribers`
+ * docs that have none (~522 of 5241 — lead-capture gates like job_gate, popup,
+ * lead_magnet, analysis_gate, calculator_paywall, offerwall, chatbot write
+ * straight to Firestore via upsertNewsletterSubscriber and never touch Auth).
+ *
+ * Going forward the `syncNewsletterSubscriberAuth` onDocumentCreated trigger
+ * (functions/index.js, functions/src/newsletterSubscriberAuthSync.js) closes
+ * this gap for every NEW subscriber doc. This script is a one-time catch-up
+ * for the docs that already existed before that trigger was deployed.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/backfill-newsletter-subscriber-auth.mjs
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/backfill-newsletter-subscriber-auth.mjs --apply
+ *
+ * Default is dry-run — prints the planned Auth-user creations and a summary.
+ * Pass `--apply` to actually call admin.auth().createUser(...).
+ *
+ * Note: this intentionally duplicates the small amount of Admin SDK logic from
+ * functions/src/newsletterSubscriberAuthSync.js rather than importing it —
+ * this script runs standalone (node scripts/dev/*.mjs) outside the
+ * `functions/` Firebase deploy bundle, and per repo precedent
+ * (backfill-onetap-orphan-subscribers.mjs) the two deploy boundaries are kept
+ * fully decoupled.
+ */
+import admin from 'firebase-admin';
+
+const APPLY = process.argv.includes('--apply');
+
+if (!admin.apps?.length) {
+  admin.initializeApp({ credential: admin.credential.applicationDefault() });
+}
+const db = admin.firestore();
+const auth = admin.auth();
+
+console.log(APPLY ? '🟢 APPLY mode — will create Auth users' : '🟡 DRY RUN — no writes (pass --apply to commit)');
+
+// ─── Pull both sides ───────────────────────────────────────
+const authUsers = [];
+let pageToken;
+do {
+  const page = await auth.listUsers(1000, pageToken);
+  authUsers.push(...page.users);
+  pageToken = page.pageToken;
+} while (pageToken);
+
+const existingAuthEmails = new Set(
+  authUsers.filter((u) => u.email).map((u) => u.email.toLowerCase()),
+);
+
+const subSnap = await db.collection('newsletter_subscribers').get();
+const subscriberEmails = subSnap.docs
+  .filter((d) => d.id !== '_meta_')
+  .map((d) => (d.data().email || d.id || '').toLowerCase().trim())
+  .filter(Boolean);
+
+// De-dupe (a handful of docs may share an email via legacy doc ids).
+const uniqueSubscriberEmails = [...new Set(subscriberEmails)];
+
+// ─── Identify orphans (subscriber doc, no Auth user) ───
+const orphans = uniqueSubscriberEmails.filter((email) => !existingAuthEmails.has(email));
+
+console.log(`\n${uniqueSubscriberEmails.length} newsletter_subscribers docs, ${orphans.length} with no matching Auth user\n`);
+
+if (orphans.length === 0) {
+  console.log('Nothing to backfill.');
+  process.exit(0);
+}
+
+console.log('Preview (first 5):');
+for (const email of orphans.slice(0, 5)) {
+  console.log(`  would create → ${email}`);
+}
+
+// ─── Create (or preview) ────────────────────────────────────
+let created = 0;
+let skipped = 0;
+let errors = 0;
+
+if (APPLY) {
+  for (const email of orphans) {
+    try {
+      await auth.createUser({ email, emailVerified: false, disabled: false });
+      created++;
+    } catch (error) {
+      if (error?.code === 'auth/email-already-exists') {
+        // Raced with a concurrent write (e.g. the new trigger, or the user
+        // signing up between the listUsers() snapshot and now) — not an error.
+        skipped++;
+      } else {
+        errors++;
+        console.error(`  error → ${email}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+}
+
+console.log(`\nSummary: ${orphans.length} orphans found`);
+if (APPLY) {
+  console.log(`  created: ${created}`);
+  console.log(`  skipped (raced/already-exists): ${skipped}`);
+  console.log(`  errors: ${errors}`);
+} else {
+  console.log(`  Would create: ${orphans.length}`);
+  console.log('\nRe-run with --apply to commit.');
+}
+process.exit(0);

--- a/scripts/dev/reactivate-false-positive-bounces.mjs
+++ b/scripts/dev/reactivate-false-positive-bounces.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * One-time remediation for the 2223 `newsletter_subscribers` docs that were
+ * marked `bounced` before the hard/soft bounce classifier existed (see
+ * functions/src/lib/bounceClassification.js) — back then every provider
+ * signal (including reputation-based soft rejects) wrote the same permanent
+ * `status: 'bounced'`, which is excluded from every future send.
+ *
+ * This reactivates ONLY the subset showing strong evidence of being a false
+ * positive: the subscriber has previously and successfully received mail
+ * (last_delivered_at set) or engaged with it (open_count > 0) — proving the
+ * mailbox is alive — AND the recorded bounce_reason is not an unambiguous
+ * hard-bounce signal (mailbox genuinely doesn't exist / is disabled). Never-
+ * delivered subscribers and unambiguous hard bounces are left untouched, to
+ * avoid burning sender reputation on the 5 free-tier ESPs on a real dead list.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/reactivate-false-positive-bounces.mjs
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/reactivate-false-positive-bounces.mjs --apply
+ *
+ * Default is dry-run — prints the reactivation candidates and a summary.
+ * Pass `--apply` to actually write to Firestore.
+ */
+import admin from 'firebase-admin';
+
+const APPLY = process.argv.includes('--apply');
+
+if (!admin.apps?.length) {
+  admin.initializeApp({ credential: admin.credential.applicationDefault() });
+}
+const db = admin.firestore();
+const FieldValue = admin.firestore.FieldValue;
+
+// Unambiguous hard-bounce signals — the mailbox itself is gone/rejecting
+// permanently. Never reactivate on these, regardless of prior engagement.
+const HARD_BOUNCE_PATTERN = /does not exist|no such user|no such mailbox|user unknown|unknown user|invalid recipient|invalid mailbox|mailbox not found|mailbox unavailable|recipient rejected|address rejected|nonexistent|non-?existent|account.*disabled|disabled account|550[ -]?5\.1\.1|550[ -]?5\.1\.10|user doesn'?t exist/i;
+
+console.log(APPLY ? '🟢 APPLY mode — will write to Firestore' : '🟡 DRY RUN — no writes (pass --apply to commit)');
+
+const subSnap = await db.collection('newsletter_subscribers').where('status', '==', 'bounced').get();
+const bounced = subSnap.docs.filter((d) => d.id !== '_meta_');
+
+console.log(`\n${bounced.length} bounced newsletter_subscribers docs found\n`);
+
+const candidates = [];
+let neverDelivered = 0;
+let hardReason = 0;
+
+for (const doc of bounced) {
+  const data = doc.data();
+  const everDelivered = !!data.last_delivered_at;
+  const everOpened = Number(data.open_count) > 0;
+  const reason = String(data.bounce_reason || '');
+
+  if (!everDelivered && !everOpened) {
+    neverDelivered++;
+    continue;
+  }
+  if (HARD_BOUNCE_PATTERN.test(reason)) {
+    hardReason++;
+    continue;
+  }
+  candidates.push({ id: doc.id, ref: doc.ref, reason, everDelivered, everOpened });
+}
+
+console.log(`Reactivation candidates (probable false positives): ${candidates.length}`);
+console.log(`  excluded — never delivered nor opened: ${neverDelivered}`);
+console.log(`  excluded — unambiguous hard-bounce reason: ${hardReason}`);
+
+console.log('\nPreview (first 10):');
+for (const c of candidates.slice(0, 10)) {
+  console.log(`  ${c.id} — reason="${c.reason}" delivered=${c.everDelivered} opened=${c.everOpened}`);
+}
+
+if (candidates.length === 0) {
+  console.log('\nNothing to reactivate.');
+  process.exit(0);
+}
+
+let reactivated = 0;
+let failed = 0;
+// Two writes per candidate (subscriber doc + events entry) — keep well under
+// Firestore's 500-writes-per-batch limit.
+const batchSize = 200;
+
+if (APPLY) {
+  for (let i = 0; i < candidates.length; i += batchSize) {
+    const slice = candidates.slice(i, i + batchSize);
+    const batch = db.batch();
+    for (const c of slice) {
+      batch.set(c.ref, {
+        status: 'confirmed',
+        isActive: true,
+        active: true,
+        soft_bounce_count: 0,
+        previous_bounce_reason: c.reason,
+        bounce_reactivated_at: FieldValue.serverTimestamp(),
+      }, { merge: true });
+      batch.set(c.ref.collection('events').doc(), {
+        event_type: 'bounce_reactivated',
+        reason: `probable false positive (delivered=${c.everDelivered}, opened=${c.everOpened}): ${c.reason}`,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+      reactivated++;
+    }
+    try {
+      await batch.commit();
+      process.stdout.write(`  batch ${Math.floor(i / batchSize) + 1}: ${slice.length} reactivated\n`);
+    } catch (err) {
+      failed += slice.length;
+      reactivated -= slice.length;
+      console.error(`  batch ${Math.floor(i / batchSize) + 1} failed:`, err.message);
+    }
+  }
+}
+
+console.log(`\n${APPLY ? 'Reactivated' : 'Would reactivate'} ${candidates.length - failed}/${candidates.length}${failed ? ` (${failed} failed)` : ''}`);
+if (!APPLY) console.log('\nRe-run with --apply to commit.');
+process.exit(0);

--- a/tests/bounce-classification.test.ts
+++ b/tests/bounce-classification.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyBounceSeverity,
+  bounceUpdateFields,
+  softBounceRecoveryFields,
+  maybeEscalateSoftBounce,
+  SOFT_ESCALATION_THRESHOLD,
+} from '../functions/src/lib/bounceClassification.js';
+
+function fakeSubscriberRef(initial: Record<string, unknown> = {}) {
+  let data = { ...initial };
+  const writes: Array<Record<string, unknown>> = [];
+  return {
+    get: async () => ({ exists: true, data: () => data }),
+    set: async (update: Record<string, unknown>) => {
+      data = { ...data, ...update };
+      writes.push(update);
+    },
+    __writes: writes,
+    __data: () => data,
+  };
+}
+
+describe('bounceClassification', () => {
+  describe('classifyBounceSeverity', () => {
+    it('mailjet: blocked is always soft', () => {
+      expect(classifyBounceSeverity({ provider: 'mailjet', rawEvent: 'blocked', eventData: {} })).toBe('soft');
+    });
+
+    it('mailjet: bounce with hard_bounce flag is hard', () => {
+      expect(classifyBounceSeverity({ provider: 'mailjet', rawEvent: 'bounce', eventData: { hard_bounce: true } })).toBe('hard');
+    });
+
+    it('mailjet: bounce without hard_bounce flag is soft', () => {
+      expect(classifyBounceSeverity({ provider: 'mailjet', rawEvent: 'bounce', eventData: {} })).toBe('soft');
+    });
+
+    it('maileroo: rejected is soft, failed is hard', () => {
+      expect(classifyBounceSeverity({ provider: 'maileroo', rawEvent: 'rejected', eventData: {} })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'maileroo', rawEvent: 'failed', eventData: {} })).toBe('hard');
+    });
+
+    it('mailtrap: soft_bounce and reject are soft, bounce is hard', () => {
+      expect(classifyBounceSeverity({ provider: 'mailtrap', rawEvent: 'soft_bounce', eventData: {} })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'mailtrap', rawEvent: 'reject', eventData: {} })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'mailtrap', rawEvent: 'bounce', eventData: {} })).toBe('hard');
+    });
+
+    it('mailgun: severity=temporary is soft, permanent is hard', () => {
+      expect(classifyBounceSeverity({ provider: 'mailgun', rawEvent: 'failed', eventData: { severity: 'temporary' } })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'mailgun', rawEvent: 'failed', eventData: { severity: 'permanent' } })).toBe('hard');
+      expect(classifyBounceSeverity({ provider: 'mailgun', rawEvent: 'rejected', eventData: {} })).toBe('soft');
+    });
+
+    it('resend: transient/undetermined bounce.type is soft, otherwise hard', () => {
+      expect(classifyBounceSeverity({ provider: 'resend', rawEvent: 'email.bounced', eventData: { bounce: { type: 'Transient' } } })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'resend', rawEvent: 'email.bounced', eventData: { bounce: { type: 'Undetermined' } } })).toBe('soft');
+      expect(classifyBounceSeverity({ provider: 'resend', rawEvent: 'email.bounced', eventData: {} })).toBe('hard');
+    });
+  });
+
+  describe('bounceUpdateFields', () => {
+    it('hard: sets permanent bounced status and resets the soft counter', () => {
+      const fields = bounceUpdateFields({ severity: 'hard', reason: 'user unknown' });
+      expect(fields.status).toBe('bounced');
+      expect(fields.bounce_severity).toBe('hard');
+      expect(fields.bounce_reason).toBe('user unknown');
+      expect(fields.soft_bounce_count).toBe(0);
+    });
+
+    it('soft: never sets status, only tracks the counter', () => {
+      const fields = bounceUpdateFields({ severity: 'soft', reason: 'greylisted' });
+      expect(fields.status).toBeUndefined();
+      expect(fields.bounce_severity).toBe('soft');
+      expect(fields.bounce_reason).toBe('greylisted');
+      expect(fields.soft_bounce_count).toBeDefined();
+    });
+  });
+
+  it('softBounceRecoveryFields resets the counter to zero', () => {
+    expect(softBounceRecoveryFields()).toEqual({ soft_bounce_count: 0 });
+  });
+
+  describe('maybeEscalateSoftBounce', () => {
+    it('does not escalate below the threshold', async () => {
+      const ref = fakeSubscriberRef({ soft_bounce_count: SOFT_ESCALATION_THRESHOLD - 1, status: 'confirmed' });
+      const escalated = await maybeEscalateSoftBounce(ref as any, 'greylisted');
+      expect(escalated).toBe(false);
+      expect(ref.__data().status).toBe('confirmed');
+    });
+
+    it('escalates to a permanent bounced status once the threshold is reached', async () => {
+      const ref = fakeSubscriberRef({ soft_bounce_count: SOFT_ESCALATION_THRESHOLD, status: 'confirmed' });
+      const escalated = await maybeEscalateSoftBounce(ref as any, 'greylisted');
+      expect(escalated).toBe(true);
+      expect(ref.__data().status).toBe('bounced');
+      expect(ref.__data().bounce_severity).toBe('hard');
+      expect(String(ref.__data().bounce_reason)).toContain('escalated after');
+    });
+
+    it('is a no-op if already bounced', async () => {
+      const ref = fakeSubscriberRef({ soft_bounce_count: SOFT_ESCALATION_THRESHOLD + 5, status: 'bounced' });
+      const escalated = await maybeEscalateSoftBounce(ref as any, 'greylisted');
+      expect(escalated).toBe(false);
+    });
+  });
+});

--- a/tests/newsletter-mailjet-webhook-core.test.ts
+++ b/tests/newsletter-mailjet-webhook-core.test.ts
@@ -4,7 +4,7 @@ import { persistMailjetEvent, handleMailjetWebhookRequest } from '../functions/s
 /**
  * Fake Firestore db that captures all set/add calls for assertion.
  */
-function createFakeDb() {
+function createFakeDb(existingDocs: Record<string, Record<string, Record<string, unknown>>> = {}) {
   const sets: Array<{ collection: string; docId: string; data: Record<string, unknown> }> = [];
   const adds: Array<{ collection: string; data: Record<string, unknown> }> = [];
 
@@ -12,6 +12,13 @@ function createFakeDb() {
     doc: (docId: string) => ({
       set: async (data: Record<string, unknown>, _opts?: unknown) => {
         sets.push({ collection: name, docId, data });
+      },
+      get: async () => {
+        const docData = existingDocs[name]?.[docId];
+        return {
+          exists: !!docData,
+          data: () => docData || {},
+        };
       },
       collection: (subName: string) => {
         const subPath = `${name}/${docId}/${subName}`;


### PR DESCRIPTION
## Implementato

**A — Close the 522-orphan leak (Auth account missing for Firestore subscriber doc)**
- New `syncNewsletterSubscriberAuth` trigger (`onDocumentCreated` on `newsletter_subscribers/{email}`) silently creates a Firebase Auth account (no password, no UX change) for every future subscriber — one mechanism instead of patching ~16 individual capture call sites.
- `scripts/dev/backfill-newsletter-subscriber-auth.mjs` (dry-run by default, `--apply` to write) backfills the 522 existing orphans.

**B — Bulletproof bounce classification (root cause, not just data cleanup)**
- New `functions/src/lib/bounceClassification.js` shared by all 5 ESP webhook cores (Mailjet, Maileroo, Mailtrap, Mailgun, Resend).
- Reputation/greylisting-based soft signals (Mailjet `blocked`, Maileroo `rejected`, Mailtrap `soft_bounce`/`reject`, Mailgun `severity:temporary`, Resend `bounce.type:transient|undetermined`) no longer collapse into a permanent `status: 'bounced'` on the first event.
- Soft signals accumulate via `soft_bounce_count`; a delivery/open/click resets the counter. After 3 consecutive soft rejects with no recovery signal, it escalates to a real, permanent `bounced`. Mirrors the existing reversible-status design in `scripts/lib/subscriberSunset.mjs`.
- `services/emailSuppression.mjs`'s exclusion sets are untouched — soft-bounced-but-not-escalated subscribers remain sendable by design.
- New `tests/bounce-classification.test.ts` (13 tests) covers classification across all 5 providers plus the escalation threshold/idempotency logic.

**C — Remediate the 2223 currently-bounced subscribers**
- `scripts/dev/reactivate-false-positive-bounces.mjs` (dry-run by default, `--apply` to write) reactivates ONLY subscribers with strong false-positive evidence: prior successful delivery or open (mailbox proven alive) AND a non-hard-bounce reason.
- Live dry-run against production: of 2223 bounced, **1867 qualify as probable false positives** (355 excluded as never delivered/opened, 1 excluded as an unambiguous hard-bounce reason).

## Non implementato (ancora)
- `--apply` has not been run for either script yet (both executed live in dry-run only, against production data, to get the real numbers above) — pending explicit go-ahead given the scale of the write (1867 subscriber docs).
- No dedicated end-to-end webhook test suite exists for Mailtrap/Mailgun (pre-existing gap, not introduced here); the new bounce-classification logic for those two providers is covered directly by `tests/bounce-classification.test.ts` instead.

## Test plan
- [x] `tests/bounce-classification.test.ts` — 13/13 passing
- [x] `tests/newsletter-mailjet-webhook-core.test.ts`, `newsletter-maileroo-webhook-core.test.ts`, `newsletter-resend-webhook-core.test.ts` — 40/40 passing
- [x] `node --check` on every modified/new file
- [x] GitNexus impact analysis on all modified functions — LOW risk, no HIGH/CRITICAL
- [x] Live dry-run of both new scripts against production Firestore (read-only, no writes)
- [ ] `--apply` run for both backfill/reactivation scripts (pending go-ahead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)