### PR TITLE
fix(blog): render article body as semantic HTML instead of flat text

### DIFF
--- a/build-plugins/articleSeoFallback.ts
+++ b/build-plugins/articleSeoFallback.ts
@@ -71,7 +71,7 @@ const renderInlineMarkup = (line: string): string =>
 
 const LIST_LINE_RX = /^[-*]\s+/;
 const QUOTE_LINE_RX = /^>\s?/;
-const HEADING_LINE_RX = /^(#{2,6})\s+(.+)$/;
+const HEADING_LINE_RX = /^(#{1,6})\s+(.+)$/;
 
 // Splits article body markdown (headings, bullet lists, blockquotes, bold/italic/links)
 // into an ordered list of self-contained HTML blocks (one per heading/paragraph/list/quote).
@@ -100,7 +100,9 @@ const buildArticleBodyBlocks = (text: string): string[] => {
  const heading = HEADING_LINE_RX.exec(trimmed);
  if (heading) {
  flushParagraph();
- const level = Math.min(heading[1].length + 1, 4);
+ // Single `#` is rare in body markdown and would collide with the section's own <h2> wrapper
+ // (see articleBodyHtml in ogPagesPlugin.ts), so clamp # and ## to the same h3 level.
+ const level = Math.min(Math.max(heading[1].length, 2) + 1, 4);
  out.push(`<h${level}>${renderInlineMarkup(heading[2])}</h${level}>`);
  i++;
  continue;

--- a/build-plugins/articleSeoFallback.ts
+++ b/build-plugins/articleSeoFallback.ts
@@ -1,3 +1,5 @@
+import { esc } from './htmlTemplate';
+
 type Locale = 'it' | 'en' | 'de' | 'fr';
 
 type ArticleSection = 'frontaliere' | 'svizzera';
@@ -56,18 +58,110 @@ const SVIZZERA_IMPACT_LABEL: Record<Locale, string> = {
  fr: 'Impact concret pour les residents en Suisse',
 };
 
-const stripArticleMarkup = (text: string): string =>
- text
+// Renders inline markdown (links, bold, italic, code) to safe HTML. Escapes the raw text
+// first, then layers markup on top — none of the markdown syntax characters (*[]()`) are
+// HTML-special, so this can't reopen an escaped entity.
+const renderInlineMarkup = (line: string): string =>
+ esc(line)
  .replace(/\[([^\]]+)\]\(nav:[^)]+\)/g, '$1')
- .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
- .replace(/`+/g, '')
- .replace(/\*\*(.*?)\*\*/g, '$1')
- .replace(/\*(.*?)\*/g, '$1')
- .replace(/^#+\s*/gm, '')
- .replace(/^\s*>\s*/gm, '')
- .replace(/^\s*[-*]\s+/gm, '• ')
- .replace(/\n{3,}/g, '\n\n')
- .trim();
+ .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+ .replace(/`([^`]+)`/g, '<code>$1</code>')
+ .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+ .replace(/\*(.*?)\*/g, '<em>$1</em>');
+
+const LIST_LINE_RX = /^[-*]\s+/;
+const QUOTE_LINE_RX = /^>\s?/;
+const HEADING_LINE_RX = /^(#{2,6})\s+(.+)$/;
+
+// Splits article body markdown (headings, bullet lists, blockquotes, bold/italic/links)
+// into an ordered list of self-contained HTML blocks (one per heading/paragraph/list/quote).
+const buildArticleBodyBlocks = (text: string): string[] => {
+ const lines = text.replace(/\r\n/g, '\n').split('\n');
+ const out: string[] = [];
+ let paragraphBuf: string[] = [];
+
+ const flushParagraph = () => {
+ if (paragraphBuf.length) {
+ out.push(`<p>${renderInlineMarkup(paragraphBuf.join(' '))}</p>`);
+ paragraphBuf = [];
+ }
+ };
+
+ let i = 0;
+ while (i < lines.length) {
+ const trimmed = lines[i].trim();
+
+ if (!trimmed) {
+ flushParagraph();
+ i++;
+ continue;
+ }
+
+ const heading = HEADING_LINE_RX.exec(trimmed);
+ if (heading) {
+ flushParagraph();
+ const level = Math.min(heading[1].length + 1, 4);
+ out.push(`<h${level}>${renderInlineMarkup(heading[2])}</h${level}>`);
+ i++;
+ continue;
+ }
+
+ if (LIST_LINE_RX.test(trimmed)) {
+ flushParagraph();
+ const items: string[] = [];
+ while (i < lines.length && LIST_LINE_RX.test(lines[i].trim())) {
+ items.push(`<li>${renderInlineMarkup(lines[i].trim().replace(LIST_LINE_RX, ''))}</li>`);
+ i++;
+ }
+ out.push(`<ul>${items.join('')}</ul>`);
+ continue;
+ }
+
+ if (QUOTE_LINE_RX.test(trimmed)) {
+ flushParagraph();
+ const quoteLines: string[] = [];
+ while (i < lines.length && QUOTE_LINE_RX.test(lines[i].trim())) {
+ quoteLines.push(lines[i].trim().replace(QUOTE_LINE_RX, ''));
+ i++;
+ }
+ out.push(`<blockquote><p>${renderInlineMarkup(quoteLines.join(' '))}</p></blockquote>`);
+ continue;
+ }
+
+ paragraphBuf.push(trimmed);
+ i++;
+ }
+ flushParagraph();
+ return out;
+};
+
+const stripTags = (html: string): string => html.replace(/<[^>]+>/g, '');
+const HEADING_BLOCK_RX = /^<h[2-6]>/;
+
+// Renders full markdown to HTML, then truncates at whole-block boundaries (never mid-tag/mid-list-item)
+// once the rendered plain-text length crosses maxChars — keeps the same effective content budget as
+// the old plain-text truncation without cutting HTML mid-element or dropping a heading's own content.
+const renderArticleBodyHtml = (text: string, maxChars = 1800): string => {
+ const blocks = buildArticleBodyBlocks(text);
+ const kept: string[] = [];
+ let total = 0;
+
+ for (const block of blocks) {
+ const blockLength = stripTags(block).length;
+ if (total + blockLength > maxChars) {
+ if (!kept.length) {
+ kept.push(block);
+ } else {
+ if (HEADING_BLOCK_RX.test(kept[kept.length - 1])) kept.pop();
+ if (kept.length) kept.push('<p>…</p>');
+ }
+ return kept.join('');
+ }
+ kept.push(block);
+ total += blockLength;
+ }
+ return kept.join('');
+};
 
 const tokenizeTopic = (value: string): string[] =>
  value
@@ -278,7 +372,6 @@ export function buildArticleSeoSections(locale: Locale, title: string, desc: str
 export function cleanupArticleBodySections(sections: Array<string | undefined>): string[] {
  return sections
  .filter((section): section is string => !!section)
- .map(stripArticleMarkup)
- .map((section) => section.length > 1800 ? `${section.slice(0, 1800).trim()}...` : section)
+ .map((section) => renderArticleBodyHtml(section))
  .filter(Boolean);
 }

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -451,6 +451,16 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  .replace(/\\t/g, ' ')
  .replace(/\\\\/g, '\\');
 
+ // Preserves \n as actual newlines (needed for body markdown structure: headings/lists/FAQ).
+ const unescapeTsStringRaw = (value: string): string =>
+ value
+ .replace(/\\'/g, '\'')
+ .replace(/\\"/g, '"')
+ .replace(/\\n/g, '\n')
+ .replace(/\\r/g, '')
+ .replace(/\\t/g, ' ')
+ .replace(/\\\\/g, '\\');
+
  const parseBlogMetaLocale = (locale: 'en' | 'de' | 'fr') => {
  const out: Record<string, { title?: string; excerpt?: string; imageAlt?: string }> = {};
  const p = np.resolve(rootDir, `services/locales/${SECTION.metaPrefix}-${locale}.ts`);
@@ -482,7 +492,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  while ((m = rx.exec(src)) !== null) {
  const articleId = m[1];
  const field = m[2];
- const value = unescapeTsString(m[3]);
+ const value = unescapeTsStringRaw(m[3]);
  if (!out[articleId]) out[articleId] = {};
  out[articleId][field] = value;
  }
@@ -515,45 +525,6 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  en: parseBlogBodyLocale('en'),
  de: parseBlogBodyLocale('de'),
  fr: parseBlogBodyLocale('fr'),
- } as const;
-
- // Raw body parser preserving \n as actual newlines (for FAQ markdown extraction)
- const unescapeTsStringRaw = (value: string): string =>
- value
- .replace(/\\'/g, '\'')
- .replace(/\\"/g, '"')
- .replace(/\\n/g, '\n')
- .replace(/\\r/g, '')
- .replace(/\\t/g, ' ')
- .replace(/\\\\/g, '\\');
-
- const parseBlogBodyRawLocale = (locale: 'it' | 'en' | 'de' | 'fr') => {
- const out: Record<string, Record<string, string>> = {};
- const dir = np.resolve(rootDir, 'services', 'locales', SECTION.bodyDir, locale);
- let files: string[] = [];
- try { files = fs.readdirSync(dir); } catch { return out; }
- const rx = /'blog\.article\.([^']+)\.(body\d+|faq)'\s*:\s*'((?:[^'\\]|\\.)*)'/g;
- for (const file of files) {
- if (!file.endsWith('.ts')) continue;
- let src = '';
- try { src = fs.readFileSync(np.join(dir, file), 'utf-8'); } catch { continue; }
- let m: RegExpExecArray | null;
- while ((m = rx.exec(src)) !== null) {
- const articleId = m[1];
- const field = m[2];
- const value = unescapeTsStringRaw(m[3]);
- if (!out[articleId]) out[articleId] = {};
- out[articleId][field] = value;
- }
- }
- return out;
- };
-
- const blogBodyRawByLocale = {
- it: parseBlogBodyRawLocale('it'),
- en: parseBlogBodyRawLocale('en'),
- de: parseBlogBodyRawLocale('de'),
- fr: parseBlogBodyRawLocale('fr'),
  } as const;
 
  const normalizeDateTime = (value: string): string => {
@@ -771,7 +742,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  }
  const articleBodyLocale = (locale === 'it' || locale === 'en' || locale === 'de' || locale === 'fr') ? locale : 'it';
  const localizedBody = blogBodyByLocale[articleBodyLocale][en.articleId] ?? blogBodyByLocale.it[en.articleId];
- const allBodyKeys = localizedBody ? Object.keys(localizedBody).sort((a, b) => {
+ const allBodyKeys = localizedBody ? Object.keys(localizedBody).filter(k => /^body\d+$/.test(k)).sort((a, b) => {
  const na = parseInt(a.replace('body', ''), 10);
  const nb = parseInt(b.replace('body', ''), 10);
  return na - nb;
@@ -968,7 +939,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
 
  // Try structured FAQ from body data first (new articles with AI-generated FAQ)
  let faqPairsFromData: Array<{ question: string; answer: string }> | null = null;
- const articleBodyData = blogBodyRawByLocale[articleBodyLocale]?.[en.articleId] ?? blogBodyRawByLocale.it?.[en.articleId];
+ const articleBodyData = blogBodyByLocale[articleBodyLocale]?.[en.articleId] ?? blogBodyByLocale.it?.[en.articleId];
  if (articleBodyData) {
  const faqRaw = articleBodyData['faq'];
  if (faqRaw) {
@@ -987,7 +958,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  // Use structured FAQ if available, otherwise fall back to heuristic for evergreen articles
  const useFaqPairs = faqPairsFromData ?? (() => {
  if (!EVERGREEN_CATEGORIES.has(articleCategory)) return null;
- const rawBody = blogBodyRawByLocale[articleBodyLocale]?.[en.articleId] ?? blogBodyRawByLocale.it?.[en.articleId];
+ const rawBody = blogBodyByLocale[articleBodyLocale]?.[en.articleId] ?? blogBodyByLocale.it?.[en.articleId];
  if (!rawBody) return null;
  const rawBodyKeys = Object.keys(rawBody).sort((a, b) => {
  const na = parseInt(a.replace(/\D/g, ''), 10);
@@ -1068,23 +1039,24 @@ ${href}
  en.keywords,
  SECTION.name,
  );
- const bodyWordCount = bodySections.join(' ').split(/\s+/).filter(Boolean).length;
+ const bodyWordCount = countWords(bodySections.join(' '));
+ // bodySections are already-rendered HTML (headings/lists/links) from cleanupArticleBodySections;
+ // fallbackSections carry plain prose paragraphs that still need escaping + <p> wrapping.
+ const bodyDerivedSections = bodySections.map((bodyHtml, i) => ({
+ heading: i === 0 ? 'Contesto' : i === 1 ? 'Dettagli operativi' : 'Punti chiave',
+ html: bodyHtml,
+ }));
+ const fallbackDerivedSections = fallbackSections.map((section) => ({
+ heading: section.heading,
+ html: section.paragraphs.map((paragraph) => `<p>${esc(paragraph)}</p>`).join(''),
+ }));
  const sectionSource = !bodySections.length
- ? fallbackSections
+ ? fallbackDerivedSections
  : (bodyWordCount < 360
- ? [
- ...bodySections.map((body, i) => ({
- heading: i === 0 ? 'Contesto' : i === 1 ? 'Dettagli operativi' : 'Punti chiave',
- paragraphs: [body],
- })),
- ...fallbackSections,
- ]
- : bodySections.map((body, i) => ({
- heading: i === 0 ? 'Contesto' : i === 1 ? 'Dettagli operativi' : 'Punti chiave',
- paragraphs: [body],
- })));
+ ? [...bodyDerivedSections, ...fallbackDerivedSections]
+ : bodyDerivedSections);
  const articleBodyHtml = sectionSource
- .map((section) => `<section><h2>${esc(section.heading)}</h2>${section.paragraphs.map((paragraph) => `<p>${esc(paragraph)}</p>`).join('')}</section>`)
+ .map((section) => `<section><h2>${esc(section.heading)}</h2>${section.html}</section>`)
  .join('');
  return `<!DOCTYPE html>
 <html lang="${locale}">
@@ -1105,7 +1077,7 @@ ${headTags}
  ${OFFERWALL_FC_SNIPPET}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
- <div id="root"><main id="main-content"><article><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline s-L_lk4l">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article class="ft-blog-article"><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline s-L_lk4l">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
  <script type="module" crossorigin fetchpriority="high" src="/assets/${entryJs}"></script>
  </body>
 </html>`;
@@ -1128,7 +1100,7 @@ ${headTags}
  ${OFFERWALL_FC_SNIPPET}
  </head>
  <body>
- <div id="root"><main id="main-content"><article><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p>${esc(localizedDesc)}</p><nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article class="ft-blog-article"><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p>${esc(localizedDesc)}</p><nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
  </body>
 </html>`;
  };

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -4359,23 +4359,24 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  seoData.desc,
  '',
  );
- const bodyWordCount = blogBodySections.join(' ').split(/\s+/).filter(Boolean).length;
+ // blogBodySections are already-rendered HTML (headings/lists/links) from cleanupArticleBodySections;
+ // blogFallbackSections carry plain prose paragraphs that still need escaping + <p> wrapping.
+ const bodyWordCount = blogBodySections.join(' ').replace(/<[^>]+>/g, ' ').split(/\s+/).filter(Boolean).length;
+ const blogBodyDerivedSections = blogBodySections.map((bodyHtml, index) => ({
+ heading: bodyHeadingByLocale[localeKey][index] ?? bodyHeadingByLocale[localeKey][2],
+ html: bodyHtml,
+ }));
+ const blogFallbackDerivedSections = blogFallbackSections.map((section) => ({
+ heading: section.heading,
+ html: section.paragraphs.map((paragraph) => `<p class="s-F2hp6o">${esc(paragraph)}</p>`).join(''),
+ }));
  const blogSectionData = !blogBodySections.length
- ? blogFallbackSections
+ ? blogFallbackDerivedSections
  : (bodyWordCount < 360
- ? [
- ...blogBodySections.map((body, index) => ({
- heading: bodyHeadingByLocale[localeKey][index] ?? bodyHeadingByLocale[localeKey][2],
- paragraphs: [body],
- })),
- ...blogFallbackSections,
- ]
- : blogBodySections.map((body, index) => ({
- heading: bodyHeadingByLocale[localeKey][index] ?? bodyHeadingByLocale[localeKey][2],
- paragraphs: [body],
- })));
+ ? [...blogBodyDerivedSections, ...blogFallbackDerivedSections]
+ : blogBodyDerivedSections);
  const blogArticleHtml = blogSectionData
- .map((section) => `<section class="s-Zua2Uq"><h2 class="s-pIiivc">${esc(section.heading)}</h2>${section.paragraphs.map((paragraph) => `<p class="s-F2hp6o">${esc(paragraph)}</p>`).join('')}</section>`)
+ .map((section) => `<section class="s-Zua2Uq"><h2 class="s-pIiivc">${esc(section.heading)}</h2>${section.html}</section>`)
  .join('');
 
  // Build skeleton-matching HTML for #root to minimize CLS at hydration
@@ -4420,7 +4421,7 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  // Heights match AdSenseBanner's placeholderMinHeight values.
  const adPlaceholder = `<div class="s-1zvlaE" aria-hidden="true"></div>`;
  rootHtml = isBlogDetailPage
- ? `<div class="s-wWmcGm">${heroImg}<article><h1 class="s-lHdmvf">${esc(h1Text)}</h1><p class="s-zvDmuv">${esc(seoData.desc)}</p><div class="s-6z0aHu">${blogArticleHtml}</div>${adPlaceholder}${relatedHtml}</article>${adPlaceholder}<div class="s-WR7RLD">${`<div style="${sp};height:12rem"></div>`.repeat(3)}</div><nav class="s-eazYqN">${navHtml}</nav></div>`
+ ? `<div class="s-wWmcGm">${heroImg}<article><h1 class="s-lHdmvf">${esc(h1Text)}</h1><p class="s-zvDmuv">${esc(seoData.desc)}</p><div class="s-6z0aHu ft-blog-body">${blogArticleHtml}</div>${adPlaceholder}${relatedHtml}</article>${adPlaceholder}<div class="s-WR7RLD">${`<div style="${sp};height:12rem"></div>`.repeat(3)}</div><nav class="s-eazYqN">${navHtml}</nav></div>`
  : (() => {
  // FRO-330: SSG article cards — render first 20 articles with real titles for crawlers
  const blogListSlug = firstSeg;

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -2031,3 +2031,17 @@ aside.seo-footer-block .seo-fb-section-body a:hover,
 .ft-blog-article code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em;background:var(--color-surface-alt);padding:.15em .4em;border-radius:4px}
 .ft-blog-article a{color:var(--color-link);text-decoration:underline;text-underline-offset:2px;font-weight:500}
 .ft-blog-article a:hover{text-decoration-thickness:2px}
+
+/* Blog article body (staticPagesPlugin.ts <div class="s-6z0aHu ft-blog-body">): this template already
+   has its own classes for h1/h2/section/p (s-lHdmvf/s-pIiivc/s-Zua2Uq/s-F2hp6o), so only style the tags
+   the markdown-to-HTML renderer newly introduces here — h3/h4/ul/li/blockquote/code/a and bare <p>. */
+.ft-blog-body h3{font-size:1.05rem;font-weight:700;color:var(--color-heading);margin:18px 0 8px;padding-left:10px;border-left:3px solid var(--color-accent)}
+.ft-blog-body h4{font-size:.95rem;font-weight:600;color:var(--color-heading);margin:12px 0 6px}
+.ft-blog-body p{margin:0 0 12px}
+.ft-blog-body ul{margin:0 0 12px;padding:0 0 0 22px}
+.ft-blog-body li{margin:0 0 6px;line-height:1.6}
+.ft-blog-body li strong{color:var(--color-heading)}
+.ft-blog-body blockquote{margin:0 0 12px;padding:8px 14px;border-left:3px solid var(--color-accent);background:var(--color-surface-alt);border-radius:0 8px 8px 0;color:var(--color-subtle)}
+.ft-blog-body blockquote p{margin:0}
+.ft-blog-body code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em;background:var(--color-surface-alt);padding:.15em .4em;border-radius:4px}
+.ft-blog-body a{color:var(--color-link);text-decoration:underline;text-underline-offset:2px;font-weight:500}

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -2013,3 +2013,21 @@ aside.seo-footer-block .seo-fb-section-body a:hover,
 .jbx-c{display:inline-block;padding:3px 9px;margin:2px;border-radius:6px;background:#fef3c7;color:#854d0e;text-decoration:none;font-size:12px;line-height:1.3;border:1px solid #fcd34d}
 .jbx-l{display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:var(--color-accent-subtle);color:#312e81;text-decoration:none;font-size:13px;border:1px solid #c7d2fe}
 .jbx-m{display:inline-block;padding:3px 8px;margin:2px;border-radius:6px;background:#f0fdf4;color:#166534;text-decoration:none;font-size:12px;border:1px solid #bbf7d0}
+
+/* Blog article body (ogPagesPlugin.ts <article class="ft-blog-article">): real typography for
+   the markdown-derived headings/lists/blockquotes/links, instead of relying on unstyled tags. */
+.ft-blog-article{max-width:860px;margin:0 auto;padding:8px 0 40px;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.7;color:var(--color-body)}
+.ft-blog-article h1{font-size:clamp(1.8rem,4vw,2.4rem);font-weight:800;color:var(--color-heading);line-height:1.2;margin:0 0 8px}
+.ft-blog-article section{margin:28px 0}
+.ft-blog-article section>h2{font-size:1.4rem;font-weight:700;color:var(--color-heading);margin:0 0 14px;padding-bottom:8px;border-bottom:2px solid var(--color-edge)}
+.ft-blog-article h3{font-size:1.1rem;font-weight:700;color:var(--color-heading);margin:22px 0 10px;padding-left:10px;border-left:3px solid var(--color-accent)}
+.ft-blog-article h4{font-size:1rem;font-weight:600;color:var(--color-heading);margin:14px 0 6px}
+.ft-blog-article p{margin:0 0 14px;color:var(--color-body)}
+.ft-blog-article ul{margin:0 0 14px;padding:0 0 0 22px}
+.ft-blog-article li{margin:0 0 8px;color:var(--color-body);line-height:1.6}
+.ft-blog-article li strong{color:var(--color-heading)}
+.ft-blog-article blockquote{margin:0 0 14px;padding:10px 16px;border-left:3px solid var(--color-accent);background:var(--color-surface-alt);border-radius:0 8px 8px 0;color:var(--color-subtle)}
+.ft-blog-article blockquote p{margin:0}
+.ft-blog-article code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em;background:var(--color-surface-alt);padding:.15em .4em;border-radius:4px}
+.ft-blog-article a{color:var(--color-link);text-decoration:underline;text-underline-offset:2px;font-weight:500}
+.ft-blog-article a:hover{text-decoration-thickness:2px}

--- a/tests/article-seo-fallback.test.ts
+++ b/tests/article-seo-fallback.test.ts
@@ -22,7 +22,7 @@ describe('article SEO fallback builder', () => {
     expect(allText).toContain('imposta');
   });
 
-  it('cleans markdown-like article body sections before rendering', () => {
+  it('renders markdown-like article body sections into semantic HTML', () => {
     const sections = cleanupArticleBodySections([
       '## Titolo\n**Testo** con [link](https://example.com) e `code`',
       undefined,
@@ -30,8 +30,14 @@ describe('article SEO fallback builder', () => {
     ]);
 
     expect(sections).toEqual([
-      'Titolo\nTesto con link e code',
-      '• punto uno\n• punto due',
+      '<h3>Titolo</h3><p><strong>Testo</strong> con <a href="https://example.com">link</a> e <code>code</code></p>',
+      '<ul><li>punto uno</li><li>punto due</li></ul>',
     ]);
+  });
+
+  it('escapes HTML-special characters in body markdown before adding markup', () => {
+    const sections = cleanupArticleBodySections(['Tom & Jerry <script>alert(1)</script>']);
+
+    expect(sections).toEqual(['<p>Tom &amp; Jerry &lt;script&gt;alert(1)&lt;/script&gt;</p>']);
   });
 });

--- a/tests/article-seo-fallback.test.ts
+++ b/tests/article-seo-fallback.test.ts
@@ -40,4 +40,10 @@ describe('article SEO fallback builder', () => {
 
     expect(sections).toEqual(['<p>Tom &amp; Jerry &lt;script&gt;alert(1)&lt;/script&gt;</p>']);
   });
+
+  it('renders single-# headings (used by some articles) as h3, not literal text', () => {
+    const sections = cleanupArticleBodySections(['# Titolo principale\nTesto del paragrafo.']);
+
+    expect(sections).toEqual(['<h3>Titolo principale</h3><p>Testo del paragrafo.</p>']);
+  });
 });


### PR DESCRIPTION
## Implementato
- Fixed a newline-collapse bug in the shared blog article renderer (`ogPagesPlugin.ts`) that leaked literal `###`/`-` markdown syntax into live article HTML (root cause on https://frontaliereticino.ch/articoli-frontaliere/eventi-weekend-ticino/)
- Excluded the `faq` locale key from body sections so raw FAQ JSON no longer renders as a body paragraph, and removed the resulting duplicate "Punti chiave" heading
- Replaced the plain-text markdown stripper (`stripArticleMarkup`) with a real markdown-to-HTML renderer (`build-plugins/articleSeoFallback.ts`): real `<h3>`/`<h4>` headings, `<ul><li>` bullet lists, `<blockquote>`, `<strong>`/`<em>`/`<code>`, and clickable `<a>` links — instead of flattened `•` bullet text
- Truncation now happens at whole rendered-HTML block boundaries (measured on stripped text length, same budget as before) instead of on raw markdown source, so long articles no longer lose trailing content or get cut mid-tag
- Added scoped typography CSS (`.ft-blog-article` in `public/assets/seo-static.css`) for the new semantic tags, since Tailwind preflight strips default styling from bare HTML elements and this template had none
- **(review fix)** `HEADING_LINE_RX` only matched `##`-`######`; fixed to also match single `#` (used by 3 real articles), clamped to the same `<h3>` level as `##` so it doesn't collide with the section's own `<h2>` wrapper
- **(review fix)** `staticPagesPlugin.ts`'s sibling blog-detail renderer (en/de/fr locale pages) also consumes `cleanupArticleBodySections` and was still `esc()`-wrapping the now-HTML body in a single `<p>`, which would have double-escaped the new markup into visible `&lt;h3&gt;` text — split into HTML body sections vs plain-text fallback sections (same pattern as the `ogPagesPlugin.ts` fix) and added scoped `.ft-blog-body` CSS for only the newly-introduced tags, without touching this template's existing h1/h2/section/p styling
- Updated `tests/article-seo-fallback.test.ts` to assert the new HTML output (HTML-escaping test + single-# heading regression test)

## Non implementato (ancora)
- No visual/browser screenshot verification (build+serve+Playwright) was run in this session — recommend a quick live-render check on `eventi-weekend-ticino` post-deploy
- Did not audit every other existing `/articoli-frontaliere/*` article body for edge cases in the new renderer (nested lists, tables) beyond what the line-based parser already handles (headings, bullets, blockquotes, inline bold/italic/code/links)

## Scope note
This touches the SSG generator shared by **all** `/articoli-frontaliere/*` blog articles (all locales), across both renderers that consume it (`ogPagesPlugin.ts` for `it`, `staticPagesPlugin.ts` for `en`/`de`/`fr`). Verified via:
- Updated + passing `tests/article-seo-fallback.test.ts` (HTML-output assertions, HTML-escaping test, single-# heading test)
- Full `tests/seo-completeness.test.ts` suite (43,885 tests) passing unchanged
- `tsc --noEmit` clean on all touched files
- End-to-end simulation of the real `eventi-weekend-ticino` locale data through the fixed parsing + rendering pipeline, confirming all 9 comuni/events render with correct headings/lists/links and no content loss from truncation
- pr-review-loop (Claude) full review pass completed with 2 findings, both fixed forward in this same PR (see review-fix bullets above)

## Test plan
- [x] `npx vitest run tests/article-seo-fallback.test.ts` — 4/4 passing
- [x] `npx vitest run tests/seo-completeness.test.ts` — 43885/43885 passing
- [x] `npx tsc --noEmit` — clean on touched files
- [ ] Post-merge: verify live HTML on https://frontaliereticino.ch/articoli-frontaliere/eventi-weekend-ticino/ (headings/lists/links render, CSS applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)