### PR TITLE
fix(seo): close GSC-orphan producer + redirect bare page-N (follow-ups from #3185)

### DIFF
--- a/build-plugins/cfHot404BridgePlugin.ts
+++ b/build-plugins/cfHot404BridgePlugin.ts
@@ -207,7 +207,16 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
         // soft-landing / jobOrphan or hub bridge) must win.
         if (fs.existsSync(path.join(outDir, 'index.html'))) { skippedExisting++; continue; }
 
-        const to = withSlash(resolution.canonicalPath);
+        let to = withSlash(resolution.canonicalPath);
+        // A specific pagination-ladder page (bare `page-N` recovery) can shrink
+        // out of existence between the original GSC crawl and this build — the
+        // SPA has no out-of-range fallback for a missing page (blank shell, not
+        // a 404), so verify the static file is actually on disk before pointing
+        // there; otherwise land on the always-live section listing root.
+        if (resolution.fallbackPath) {
+          const pageFile = path.join(distDir, to.slice(1), 'index.html');
+          if (!fs.existsSync(pageFile)) to = withSlash(resolution.fallbackPath);
+        }
         const kind = resolution.kind;
         // A legacy cluster orphan whose target is verified-live: redirect the
         // user straight there instead of serving the archived compat bridge.

--- a/build-plugins/cfHot404BridgePlugin.ts
+++ b/build-plugins/cfHot404BridgePlugin.ts
@@ -199,7 +199,22 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
 
         const from = withSlash(rawPath);
         const fromNorm = from.replace(/\/+$/, '');
-        const toNorm = resolution.canonicalPath.replace(/\/+$/, '');
+
+        let to = withSlash(resolution.canonicalPath);
+        // A specific pagination-ladder page (bare `page-N` recovery) can shrink
+        // out of existence between the original GSC crawl and this build — the
+        // SPA has no out-of-range fallback for a missing page (blank shell, not
+        // a 404), so verify the static file is actually on disk before pointing
+        // there; otherwise land on the always-live section listing root. Must
+        // resolve BEFORE the self-reference check below: for en/fr (whose
+        // pagination word is the legacy "page" itself) an unresolved target
+        // is textually identical to `from`, so checking self-reference against
+        // the raw canonicalPath would wrongly skip the whole bridge.
+        if (resolution.fallbackPath) {
+          const pageFile = path.join(distDir, to.slice(1), 'index.html');
+          if (!fs.existsSync(pageFile)) to = withSlash(resolution.fallbackPath);
+        }
+        const toNorm = to.replace(/\/+$/, '');
         if (from === '/' || fromNorm === toNorm) continue; // never self-reference
 
         const outDir = path.join(distDir, from.slice(1));
@@ -207,16 +222,6 @@ export function cfHot404BridgePlugin(rootDir: string): Plugin {
         // soft-landing / jobOrphan or hub bridge) must win.
         if (fs.existsSync(path.join(outDir, 'index.html'))) { skippedExisting++; continue; }
 
-        let to = withSlash(resolution.canonicalPath);
-        // A specific pagination-ladder page (bare `page-N` recovery) can shrink
-        // out of existence between the original GSC crawl and this build — the
-        // SPA has no out-of-range fallback for a missing page (blank shell, not
-        // a 404), so verify the static file is actually on disk before pointing
-        // there; otherwise land on the always-live section listing root.
-        if (resolution.fallbackPath) {
-          const pageFile = path.join(distDir, to.slice(1), 'index.html');
-          if (!fs.existsSync(pageFile)) to = withSlash(resolution.fallbackPath);
-        }
         const kind = resolution.kind;
         // A legacy cluster orphan whose target is verified-live: redirect the
         // user straight there instead of serving the archived compat bridge.

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9755,6 +9755,12 @@ ${staticAnalyticsHtml}
  // Matches hub-pagination compound keys `<hub-slug>/page-N` (requires a leading
  // path segment; bare `page-N` is NOT matched). Used by the strip block below.
  const HUB_PAGINATION_COMPOUND_KEY_RE = /\/page-\d+$/;
+ // Matches bare `page-N` keys (legacy English pagination-word crawls, e.g.
+ // `page-2`, `page-5`). Now that searchConsoleCompat redirects these to their
+ // localized `pagina-N`/`seite-N` twin (real page, real GSC traffic), they
+ // must NOT also get a static expired-job soft-landing page here — that
+ // would serve a thin 200 at the exact path the redirect is meant to own.
+ const BARE_PAGE_NUMBER_KEY_RE = /^page-\d+$/;
 
  // Strip pre-existing reserved-hub keys from tracking BEFORE the file write.
  // Earlier GSC imports leaked "infermieri" into all-known-job-slugs.json and
@@ -9798,17 +9804,24 @@ ${staticAnalyticsHtml}
  // filtering the derived expiredSlugs list) is what stops BOTH the expired loop
  // AND the self-healing safety-net from re-emitting them. The correct per-locale
  // hubs are emitted by seoHubsPlugin; retired `<hub>/page-N` crawls resolve via
- // searchConsoleCompat → listing root, so no bridge is needed. Bare `page-N`
- // (page-2/page-5, GSC-traffic) has no leading segment → NOT matched → kept.
+ // searchConsoleCompat → listing root, so no bridge is needed.
+ //
+ // Also strips bare `page-N` keys (page-2/page-5 — legacy English pagination
+ // word, real GSC traffic). These used to be deliberately kept (no leading
+ // segment → not matched by the regex above) so their soft-landing page stayed
+ // live rather than 404ing; searchConsoleCompat now 301s them to their real
+ // `pagina-N`/`seite-N` twin, so the static soft-landing page must be removed
+ // too — otherwise it would keep serving a thin 200 at the path the redirect
+ // is meant to own.
  let hubPaginationKeysRemoved = 0;
  for (const key of Object.keys(tracking)) {
- if (HUB_PAGINATION_COMPOUND_KEY_RE.test(key)) {
+ if (HUB_PAGINATION_COMPOUND_KEY_RE.test(key) || BARE_PAGE_NUMBER_KEY_RE.test(key)) {
  delete tracking[key];
  hubPaginationKeysRemoved++;
  }
  }
  if (hubPaginationKeysRemoved > 0) {
- console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Removed ${hubPaginationKeysRemoved} hub-pagination compound key(s) from tracking (cross-locale all-slug soft-landing leak)`);
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Removed ${hubPaginationKeysRemoved} hub-pagination/page-number key(s) from tracking (cross-locale all-slug soft-landing leak + bare page-N redirect handoff)`);
  }
  fs.writeFileSync(trackingPath, JSON.stringify(tracking, null, 2) + '\n', 'utf-8');
 

--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -30,6 +30,19 @@ const JOB_BOARD_PREFIX_BY_LOCALE: Record<SupportedLocale, string> = {
  fr: '/fr',
 };
 
+// Native pagination-ladder word per locale (matches jobsSeoPagesPlugin's
+// `paginationSlugs` / staticPagesPlugin's ladder). Bare `page-N` under a job
+// board section is a legacy English-word crawl (from before canton listings
+// switched to a localized ladder) — recover it to its live `pagina-N`/`seite-N`
+// twin instead of dropping it as an expired-job slug (real GSC traffic).
+const PAGINATION_WORD_BY_LOCALE: Record<SupportedLocale, string> = {
+ it: 'pagina',
+ en: 'page',
+ de: 'seite',
+ fr: 'page',
+};
+const BARE_PAGE_NUMBER_PATTERN = /^page-(\d+)$/;
+
 const COMPANY_ROUTE_PREFIX_BY_LOCALE: Record<SupportedLocale, string> = {
  it: 'azienda',
  en: 'company',
@@ -303,6 +316,19 @@ export function resolveSearchConsoleCompatTarget(
  const urlSection = jobSectionMatch[2];
  const slug = jobSectionMatch[3];
  const prefix = JOB_BOARD_PREFIX_BY_LOCALE[locale];
+ // Bare `page-N` (legacy English pagination word, pre-dating the localized
+ // ladder) → redirect to the section's real `pagina-N`/`seite-N` twin. The
+ // canton is already encoded in urlSection, so no slug index lookup needed.
+ const barePageMatch = slug.match(BARE_PAGE_NUMBER_PATTERN);
+ if (barePageMatch) {
+ const pageNum = barePageMatch[1];
+ const word = PAGINATION_WORD_BY_LOCALE[locale];
+ return {
+ canonicalPath: `${prefix}/${urlSection}/${word}-${pageNum}/`.replace(/\/+/g, '/'),
+ kind: 'legacy',
+ locale,
+ };
+ }
  // Canton-drift recovery (the dominant residual-404 cohort): the slug is
  // globally unique, so if it is a KNOWN job whose current canonical path sits
  // under a DIFFERENT section than the one requested, the request is an ORPHANED

--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -180,6 +180,15 @@ export interface SearchConsoleCompatResolution {
  canonicalPath: string;
  kind: SearchConsoleCompatKind;
  locale: SupportedLocale;
+ // Present only when canonicalPath targets a SPECIFIC pagination-ladder page
+ // number recovered from a legacy bare `page-N` URL. The ladder's length is
+ // recomputed from live job counts on every build and isn't visible to this
+ // pure resolver, so a canton's page N can shrink out of existence between
+ // the original GSC crawl and a later build. The SPA has no out-of-range
+ // handling for a missing page (falls through to a blank shell, not a 404),
+ // so callers with dist/ access should verify canonicalPath's static file
+ // still exists and fall back to this section-listing root if not.
+ fallbackPath?: string;
 }
 
 /**
@@ -327,6 +336,7 @@ export function resolveSearchConsoleCompatTarget(
  canonicalPath: `${prefix}/${urlSection}/${word}-${pageNum}/`.replace(/\/+/g, '/'),
  kind: 'legacy',
  locale,
+ fallbackPath: `${prefix}/${urlSection}/`.replace(/\/+/g, '/'),
  };
  }
  // Canton-drift recovery (the dominant residual-404 cohort): the slug is

--- a/scripts/mine-all-job-slugs.mjs
+++ b/scripts/mine-all-job-slugs.mjs
@@ -55,6 +55,10 @@ function readJson(filePath) {
 
 function isValidJobSlug(slug) {
   if (!slug || typeof slug !== 'string' || slug.length < 3) return false;
+  // A real job slug is a single path segment — anything containing a slash
+  // is a multi-segment URL tail (e.g. hub-pagination `<hub>/page-N`), not a
+  // job slug. Rejecting here closes every mining source in one place.
+  if (slug.includes('/')) return false;
   if (NON_JOB_SLUG_PREFIXES.some((p) => slug.startsWith(p))) return false;
   // Filter out clearly corrupted slugs
   if (slug.includes('undefined') || slug.includes('null')) return false;
@@ -71,7 +75,9 @@ function extractSlugFromPath(urlPath) {
   ];
   for (const prefix of allPrefixes) {
     if (urlPath.startsWith(prefix)) {
-      return urlPath.slice(prefix.length).replace(/\/$/, '') || null;
+      const slug = urlPath.slice(prefix.length).replace(/\/$/, '');
+      if (slug && !slug.includes('/')) return slug;
+      return null;
     }
   }
   return null;

--- a/tests/cf-hot-404-bridge.test.ts
+++ b/tests/cf-hot-404-bridge.test.ts
@@ -22,6 +22,10 @@ describe('cfHot404BridgePlugin', () => {
       { path: '/cerca-lavoro-argovia/recovered-non-ti-role-acme-aarau', hits: 9 },
       { path: '/en/find-jobs-zurich/recovered-non-ti-role-acme-zurich', hits: 7 },
       { path: '/cerca-lavoro-zurigo/preexisting-richer-role', hits: 5 },
+      // Legacy bare page-N whose specific pagination-ladder page was never
+      // built for this run (simulates the canton's page count having shrunk
+      // below 97 since the original GSC crawl).
+      { path: '/cerca-lavoro-argovia/page-97', hits: 4 },
     ],
   };
 
@@ -81,6 +85,20 @@ describe('cfHot404BridgePlugin', () => {
     expect(html).toContain('noindex');
     // …instead of dead-ending on the archived compat copy.
     expect(html).not.toContain('Pagina archiviata');
+  });
+
+  it('falls back to the section listing root when the specific pagination page was never built', () => {
+    // The resolver would canonicalize to /cerca-lavoro-argovia/pagina-97/, but
+    // that page was never built in this dist (canton page count < 97) — the
+    // bridge must point at the always-live section root instead, never at a
+    // page that doesn't exist on disk.
+    const missingPage = path.join(tmp, 'dist', rel('/cerca-lavoro-argovia/pagina-97'));
+    expect(fs.existsSync(missingPage)).toBe(false);
+    const file = path.join(tmp, 'dist', rel('/cerca-lavoro-argovia/page-97'));
+    expect(fs.existsSync(file)).toBe(true);
+    const html = fs.readFileSync(file, 'utf-8');
+    expect(html).toContain('rel="canonical" href="https://frontaliereticino.ch/cerca-lavoro-argovia/"');
+    expect(html).not.toContain('/cerca-lavoro-argovia/pagina-97/');
   });
 });
 

--- a/tests/cf-hot-404-bridge.test.ts
+++ b/tests/cf-hot-404-bridge.test.ts
@@ -26,6 +26,10 @@ describe('cfHot404BridgePlugin', () => {
       // built for this run (simulates the canton's page count having shrunk
       // below 97 since the original GSC crawl).
       { path: '/cerca-lavoro-argovia/page-97', hits: 4 },
+      // Same case, but en's pagination word is the legacy "page" itself, so
+      // an unresolved target is textually identical to the source path —
+      // must not be dropped as a false self-reference.
+      { path: '/en/find-jobs-zurich/page-88', hits: 3 },
     ],
   };
 
@@ -99,6 +103,18 @@ describe('cfHot404BridgePlugin', () => {
     const html = fs.readFileSync(file, 'utf-8');
     expect(html).toContain('rel="canonical" href="https://frontaliereticino.ch/cerca-lavoro-argovia/"');
     expect(html).not.toContain('/cerca-lavoro-argovia/pagina-97/');
+  });
+
+  it('does not drop the bridge as a false self-reference when en/fr share the "page" word', () => {
+    // Before the fallback resolution moved ahead of the self-reference guard,
+    // canonicalPath ('/en/find-jobs-zurich/page-88/') was textually identical
+    // to the source path, so the loop skipped it entirely — no bridge, no
+    // fallback, orphan stayed a blank shell.
+    const file = path.join(tmp, 'dist', rel('/en/find-jobs-zurich/page-88'));
+    expect(fs.existsSync(file)).toBe(true);
+    const html = fs.readFileSync(file, 'utf-8');
+    expect(html).toContain('rel="canonical" href="https://frontaliereticino.ch/en/find-jobs-zurich/"');
+    expect(html).not.toContain('/en/find-jobs-zurich/page-88/');
   });
 });
 

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -259,26 +259,30 @@ describe('Search Console 404 compatibility resolver', () => {
   // the canton already encoded in the URL. IT/DE use a different word
   // ("pagina"/"seite"); EN/FR already use "page" natively, so the canonical
   // target is the same word with a normalized trailing slash.
-  it('redirects bare page-N leaves to their localized pagination-ladder twin', () => {
+  it('redirects bare page-N leaves to their localized pagination-ladder twin, with a section-root fallback', () => {
     expect(resolveSearchConsoleCompatTarget('/cerca-lavoro-friburgo/page-12')).toEqual({
       canonicalPath: '/cerca-lavoro-friburgo/pagina-12/',
       kind: 'legacy',
       locale: 'it',
+      fallbackPath: '/cerca-lavoro-friburgo/',
     });
     expect(resolveSearchConsoleCompatTarget('/de/jobs-in-freiburg/page-9')).toEqual({
       canonicalPath: '/de/jobs-in-freiburg/seite-9/',
       kind: 'legacy',
       locale: 'de',
+      fallbackPath: '/de/jobs-in-freiburg/',
     });
     expect(resolveSearchConsoleCompatTarget('/en/find-jobs-vaud/page-21')).toEqual({
       canonicalPath: '/en/find-jobs-vaud/page-21/',
       kind: 'legacy',
       locale: 'en',
+      fallbackPath: '/en/find-jobs-vaud/',
     });
     expect(resolveSearchConsoleCompatTarget('/fr/trouver-emploi-fribourg/page-9')).toEqual({
       canonicalPath: '/fr/trouver-emploi-fribourg/page-9/',
       kind: 'legacy',
       locale: 'fr',
+      fallbackPath: '/fr/trouver-emploi-fribourg/',
     });
   });
 

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -254,6 +254,34 @@ describe('Search Console 404 compatibility resolver', () => {
     });
   });
 
+  // Bare `page-N` (legacy English pagination word crawls, real GSC traffic) →
+  // 301 to the section's real localized pagination-ladder twin, derived from
+  // the canton already encoded in the URL. IT/DE use a different word
+  // ("pagina"/"seite"); EN/FR already use "page" natively, so the canonical
+  // target is the same word with a normalized trailing slash.
+  it('redirects bare page-N leaves to their localized pagination-ladder twin', () => {
+    expect(resolveSearchConsoleCompatTarget('/cerca-lavoro-friburgo/page-12')).toEqual({
+      canonicalPath: '/cerca-lavoro-friburgo/pagina-12/',
+      kind: 'legacy',
+      locale: 'it',
+    });
+    expect(resolveSearchConsoleCompatTarget('/de/jobs-in-freiburg/page-9')).toEqual({
+      canonicalPath: '/de/jobs-in-freiburg/seite-9/',
+      kind: 'legacy',
+      locale: 'de',
+    });
+    expect(resolveSearchConsoleCompatTarget('/en/find-jobs-vaud/page-21')).toEqual({
+      canonicalPath: '/en/find-jobs-vaud/page-21/',
+      kind: 'legacy',
+      locale: 'en',
+    });
+    expect(resolveSearchConsoleCompatTarget('/fr/trouver-emploi-fribourg/page-9')).toEqual({
+      canonicalPath: '/fr/trouver-emploi-fribourg/page-9/',
+      kind: 'legacy',
+      locale: 'fr',
+    });
+  });
+
   it('routes expired job-detail leaves with a trailing numeric id to the listing', () => {
     expect(
       resolveSearchConsoleCompatTarget(


### PR DESCRIPTION
## Contesto

Continuazione dei due follow-up dichiarati esplicitamente in #3185 ("Non implementato"):
1. Redirect bare `page-N` → gemello `pagina-N`.
2. Trace + fix del producer GSC-orphan che fabbrica le chiavi `<hub-slug>/page-N`.

## Trace del producer

Confermato il colpevole: `scripts/mine-all-job-slugs.mjs`. A differenza di `sync-gsc-orphans.mjs` (che già rifiuta slug con `/`), `isValidJobSlug()`/`extractSlugFromPath()` qui non avevano alcun guard sullo slash. `mineCompatPaths()` estrae slug dall'accumulator `seo-404-compat`: quando questo contiene un URL di hub-pagination (es. `/cerca-lavoro-ticino/alle/page-1021/`), `extractSlugFromPath` restituiva `alle/page-1021` **con lo slash intatto**, `isValidJobSlug` non lo respingeva, e la entry veniva scritta in `data/all-known-job-slugs.json` — esattamente il bug diagnosticato in #3185. Altri script della pipeline (`sync-gsc-orphans.mjs`, `enrich-compat-orphan-slugs.mjs`, `backfill-orphan-slugs-from-registry.mjs`, `migrate-all-known-job-slugs-canton-aware.mjs`, `discover-404s-via-inspection.mjs`, `ingest-gsc-coverage-404s.ts`) sono stati esclusi: o hanno già un guard single-segment, o non scrivono affatto in `all-known-job-slugs.json`.

Verificato anche 11 chiavi bare `page-N` (page-2, page-9, page-12, ...) tuttora presenti nel tracking file — ciascuna con un solo campo locale realmente osservato da GSC (`it`) e i restanti 3 (`en`/`de`/`fr`) **sintetizzati** da `mine-all-job-slugs.mjs` con un template TI-only sbagliato (es. `jobs-im-freiburg` invece del vero `jobs-in-freiburg`) — ulteriore prova che questo script è il producer, non solo per le chiavi composte ma anche per i dati canton-non-aware.

## Implementato

- **`scripts/mine-all-job-slugs.mjs`**: `isValidJobSlug()` ora rifiuta qualunque slug contenente `/` (un vero job slug è sempre un singolo segmento) — chiude il producer in UN solo punto, dato che tutte le 6 mining source + `fuzzyReconcileOrphans` passano da questa funzione. `extractSlugFromPath()` riceve lo stesso guard per parità con `sync-gsc-orphans.mjs`.
- **`build-plugins/searchConsoleCompat.ts`**: bare `page-N` (page-2/page-5, con traffico GSC reale, lasciato deliberatamente senza redirect in #3185) ora risolve con un 301 al gemello nella ladder di paginazione localizzata (`pagina-N` IT, `seite-N` DE, `page-N` invariato per EN/FR che già usano quella parola) — il canton è derivato dalla sezione già presente nell'URL (`urlSection`), non dal tracking file corrotto.
- **`build-plugins/jobsSeoPagesPlugin.ts`**: le chiavi bare `page-N` vengono ora rimosse da `tracking` insieme alle `<hub>/page-N` composte, così il redirect possiede quel path invece che una soft-landing page thin duplicata.
- **`build-plugins/cfHot404BridgePlugin.ts`**: il resolver non sa quante pagine ha oggi un canton (la ladder si ricalcola ad ogni build dai job live), quindi il redirect a una pagina SPECIFICA rischiava di puntare a una pagina non più esistente — la SPA non ha alcun fallback per un numero di pagina fuori range (nessun 404, solo shell bianca 200). Fix in due passi (entrambi emersi dal pr-review-loop):
  - verifica su disco (`dist/.../pagina-N/index.html`) prima di usare il target specifico; se assente, fallback alla section root (sempre viva) via un nuovo campo `fallbackPath` sul resolver;
  - la verifica/fallback deve girare PRIMA del guard anti-self-reference: per EN/FR (parola "page" invariata) un target non risolto è testualmente identico al path sorgente, quindi il guard lo scartava silenziosamente prima ancora di arrivare al fallback (nessun bridge, nessun redirect, l'orfano restava una shell bianca).
- Test aggiunti in `tests/search-console-compat.test.ts` (tutte e 4 le combinazioni locale) e `tests/cf-hot-404-bridge.test.ts` (fallback quando la pagina specifica non esiste su disco + non-regressione del self-reference EN/FR).

## Non implementato

- Pulizia delle 851 chiavi composte + 11 bare esistenti in `data/all-known-job-slugs.json`: il filtro build-time (già presente da #3185, ora esteso) le neutralizza ad ogni build senza bisogno di un prune committato, coerente con la regola "mai prune del tracking file nel repo" (resta archivio fat investigabile).

## Validazione

- 28+104 test verdi su tutte le suite toccate/collegate (search-console-compat, cf-hot-404-bridge, jobs-seo-pages-plugin, expired-slug-variants, soft-landing-seo, job-canon-redirect-map, locale-router-legacy-pagination-301, orphan-canton-paths, orphan-query-landings, migrate-all-known-job-slugs-canton-aware).
- Confermato con dati live (`data/cf-hot-404s.json`): 14 hit reali EN/FR su path `page-N` bare (es. `/en/find-jobs-vaud/page-21`, `/fr/trouver-emploi-vaud/page-13`) — il bug del self-reference non era teorico.
- `tsc --noEmit` pulito sui file toccati.
- GitNexus impact: `resolveSearchConsoleCompatTarget` LOW risk (4 direct caller, tutti generici sul kind restituito — nessun branching su `expired-job` vs `legacy` che cambierebbe copy/comportamento); `isValidJobSlug` MEDIUM risk (7 direct caller, tutti interni allo stesso script — irrigidimento del guard è l'intento).
- Due round di pr-review-loop (🔴 Important su commit e38cf3a e su bd697da) entrambi indirizzati con fix + test dedicato prima del merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
