### PR TITLE
chore(newsletter): merge malformed-email subscriber duplicates

### DIFF
--- a/scripts/dev/merge-malformed-subscriber-duplicates.mjs
+++ b/scripts/dev/merge-malformed-subscriber-duplicates.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Merge the two `newsletter_subscribers` docs whose email field/doc-id was
+ * stored as an RFC5322 "Display Name <email>" string instead of a bare
+ * address (historical bad data — no live write path produces this today).
+ *
+ * Each malformed doc is a duplicate of an already-legitimate subscriber doc
+ * keyed by the bare, lowercased email (which also already has a matching
+ * Firebase Auth account). Because `send-newsletter.mjs` sends to
+ * `subscriber.email` verbatim and mail providers accept "Name <email>" as a
+ * valid mailbox, both docs were independently receiving the newsletter —
+ * this consolidates them into the one real subscriber doc.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/merge-malformed-subscriber-duplicates.mjs
+ *   GOOGLE_APPLICATION_CREDENTIALS=… node scripts/dev/merge-malformed-subscriber-duplicates.mjs --apply
+ *
+ * Default is dry-run — prints the planned merge. Pass `--apply` to commit.
+ */
+import admin from 'firebase-admin';
+
+const APPLY = process.argv.includes('--apply');
+
+if (!admin.apps?.length) {
+  admin.initializeApp({ credential: admin.credential.applicationDefault() });
+}
+const db = admin.firestore();
+
+console.log(APPLY ? '🟢 APPLY mode — will write to Firestore' : '🟡 DRY RUN — no writes (pass --apply to commit)');
+
+const MALFORMED_PATTERN = /^(.*)<([^>]+)>$/;
+const SUBCOLLECTIONS = ['campaign_deliveries', 'events'];
+
+const snap = await db.collection('newsletter_subscribers').get();
+const malformed = snap.docs.filter((d) => MALFORMED_PATTERN.test(d.id));
+
+console.log(`${snap.size} newsletter_subscribers docs, ${malformed.length} with a malformed "Name <email>" doc id`);
+
+for (const badDoc of malformed) {
+  const match = badDoc.id.match(MALFORMED_PATTERN);
+  const cleanEmail = match[2].trim().toLowerCase();
+  const cleanRef = db.collection('newsletter_subscribers').doc(cleanEmail);
+  const cleanSnap = await cleanRef.get();
+
+  if (!cleanSnap.exists) {
+    console.log(`  ⚠️  ${badDoc.id} → no clean doc at ${cleanEmail}; skipping (needs manual review)`);
+    continue;
+  }
+
+  console.log(`\n${badDoc.id} → merging into ${cleanEmail}`);
+
+  for (const col of SUBCOLLECTIONS) {
+    const badSub = await badDoc.ref.collection(col).get();
+    const cleanSub = await cleanRef.collection(col).get();
+    const cleanIds = new Set(cleanSub.docs.map((d) => d.id));
+    const toCopy = badSub.docs.filter((d) => !cleanIds.has(d.id));
+    console.log(`  ${col}: ${badSub.size} on malformed doc, ${toCopy.length} to copy (${badSub.size - toCopy.length} already present)`);
+
+    if (APPLY) {
+      for (const subDoc of toCopy) {
+        await cleanRef.collection(col).doc(subDoc.id).set(subDoc.data());
+      }
+    }
+  }
+
+  if (APPLY) {
+    await deleteDocWithSubcollections(badDoc.ref);
+    console.log(`  ✅ deleted malformed doc ${badDoc.id}`);
+  }
+}
+
+console.log(APPLY ? '\nDone.' : '\nRe-run with --apply to commit.');
+
+async function deleteDocWithSubcollections(ref) {
+  for (const col of SUBCOLLECTIONS) {
+    const sub = await ref.collection(col).get();
+    const batch = db.batch();
+    sub.docs.forEach((d) => batch.delete(d.ref));
+    if (sub.size > 0) await batch.commit();
+  }
+  await ref.delete();
+}


### PR DESCRIPTION
## Implementato
- `scripts/dev/merge-malformed-subscriber-duplicates.mjs` — dry-run/`--apply` script that finds `newsletter_subscribers` docs whose doc-id/email was stored as `"Name <email>"` instead of a bare address, merges their `campaign_deliveries`/`events` subcollections into the legit clean-keyed doc (which already existed with full profile + a working Auth account), and deletes the malformed duplicate.
- Ran `--apply` against production already: found 2 malformed docs (`luigi saggese <luigisag@gmail.com>`, `sylvia colombo <silviasavina1967@gmail.com>`), each a duplicate of an existing real subscriber. Both were independently receiving the newsletter (mail providers accept `"Name <email>"` as a valid mailbox), so this stops the double-send and consolidates history (2+2 and 2+5 subcollection docs copied, 0 collisions, malformed docs deleted, verified via live re-query).
- Investigated root cause via a dedicated research agent first: no live code path today can produce this format — client-side `validateEmailStrict` rejects any string with a space before `@`, all ESP webhook recipient fields are bare, all Resend `to:` call sites in the codebase are bare. Confirmed historical bad data (predates current validation), not an active bug.

## Non implementato (ancora)
- No broader dedup sweep for other possible near-duplicate subscriber docs (e.g. differing only by casing/whitespace not matching the `<...>` pattern) — out of scope, this PR only targets the two confirmed malformed records the user pointed at.