### PR TITLE
fix(e2e): mask live FX rate on currency-comparator visual baseline

### DIFF
--- a/components/comparators/CurrencyExchange.tsx
+++ b/components/comparators/CurrencyExchange.tsx
@@ -524,7 +524,16 @@ const CurrencyExchange: React.FC = () => {
  </div>
  </div>
 
- <div className="space-y-2">
+ {/* `exchange-rate-panel`: live CHF/EUR mid-market rate + last-update
+     timestamp, sourced from useExchangeRate() (TwelveData → Firestore
+     cache). Both move independently of any code change (real-world FX
+     ticks + refresh cadence), so this is a visual-regression
+     false-positive source on every deploy — same class of problem as
+     DYNAMIC_REGION_SELECTORS in tests/e2e/seo-visual-regression.spec.ts,
+     masked here via the currency-comparator case's `extraMaskSelectors`
+     (this testid isn't in the global list because it only exists on this
+     one comparator page). */}
+ <div className="space-y-2" data-testid="exchange-rate-panel">
  <label htmlFor="exchange-rate" className="text-xs font-bold text-muted uppercase tracking-wide flex items-center gap-2">
  {t('currency.real_market_rate')}
  <div className="group relative inline-flex items-center cursor-help">

--- a/tests/e2e/seo-visual-regression.spec.ts
+++ b/tests/e2e/seo-visual-regression.spec.ts
@@ -34,13 +34,14 @@ interface VisualCase {
   // last element to mount; waiting for `domcontentloaded` + fonts is not
   // enough on the live env (CDN + analytics scripts slow first paint).
   readySelector?: string;
-  // Optional per-case override for `maxDiffPixelRatio` (default 0.02, applied
-  // in the loop below for cases that don't set this). `home` and
-  // `salary-calculator` are deliberately kept at the tight default — they
-  // were curated to be sensitive to regressions. Only raise this for a case
-  // with a known source of legitimate, unmaskable pixel drift (see
-  // currency-comparator below).
-  maxDiffPixelRatio?: number;
+  // Optional extra mask selectors, ON TOP of DYNAMIC_REGION_SELECTORS, for
+  // dynamic widgets that only exist on THIS case's page (so adding them to
+  // the global list would be dead weight everywhere else — mask() silently
+  // ignores selectors matching nothing, but a per-page testid still doesn't
+  // belong in a page-agnostic list). E.g. currency-comparator's live
+  // CHF/EUR rate + last-update timestamp: real-world FX values that move
+  // independently of code, same false-positive class as the global list.
+  extraMaskSelectors?: string[];
 }
 
 const CASES: VisualCase[] = [
@@ -70,16 +71,24 @@ const CASES: VisualCase[] = [
   // by the guard in tests/noindex-builders.test.ts), so gating on it forces a
   // deterministic full-comparator capture on both sides.
   //
-  // `maxDiffPixelRatio: 0.04` (vs the 0.02 default): the live FX rate feeding
-  // this comparator drifts continuously, which reflows/redraws the rendered
-  // rate figures above the fold on every run — pixel diff unrelated to any
-  // code regression. `home` and `salary-calculator` have no such live-data
-  // source and stay at the tight default.
+  // `exchange-rate-panel` (extraMaskSelectors) covers the live CHF/EUR
+  // mid-market rate + "Aggiornato: HH:MM:SS" timestamp (useExchangeRate(),
+  // TwelveData → Firestore cache) — a real-world value that ticks
+  // independently of any code change. Unmasked, it produced a real (not
+  // flaky — reproduced identically on both the initial attempt and the
+  // Playwright retry) pixel diff on every deploy where the rate moved
+  // between baseline capture and validate-live (run 28506482095: 26182px /
+  // ratio 0.03, just over the 0.02 threshold). Not in the global
+  // DYNAMIC_REGION_SELECTORS list because that testid only exists on this
+  // one comparator page. A prior fix attempt (#3197, since superseded)
+  // instead raised maxDiffPixelRatio to 0.04 for this case — masking the
+  // actual dynamic region is the correct fix and keeps every case, including
+  // this one, at the tight 0.02 default.
   {
     name: 'currency-comparator',
     url: '/comparatori/cambio-valuta/',
     readySelector: '#exchange-amount',
-    maxDiffPixelRatio: 0.04,
+    extraMaskSelectors: ['[data-testid="exchange-rate-panel"]'],
   },
 ];
 
@@ -185,9 +194,9 @@ for (const c of CASES) {
     // first-paint UX, which is the value visual baselines provide.
     await expect(page).toHaveScreenshot(`${c.name}.png`, {
       fullPage: false,
-      maxDiffPixelRatio: c.maxDiffPixelRatio ?? 0.02,
+      maxDiffPixelRatio: 0.02,
       animations: 'disabled',
-      mask: DYNAMIC_REGION_SELECTORS.map((sel) => page.locator(sel)),
+      mask: [...DYNAMIC_REGION_SELECTORS, ...(c.extraMaskSelectors ?? [])].map((sel) => page.locator(sel)),
     });
   });
 }


### PR DESCRIPTION
## Summary
- `validate-live`'s visual-regression gate failed on a real production deploy (run 28506482095, job 84500624321): `currency-comparator` diffed 26182px (ratio 0.03) against its baseline, over the 0.02 threshold, on the initial attempt AND the Playwright retry.
- Downloaded the diff artifacts (`gh run download 28506482095 --name visual-diffs-live`) and confirmed via pixel-level crop comparison: the "TASSO DI MERCATO REALE" (`1 CHF = 1.0835 EUR` → `1.0836 EUR`) rate value and the "Aggiornato: HH:MM:SS" last-update timestamp both changed between baseline capture (2026-06-29) and this validate-live run (2026-07-01). Both come from `useExchangeRate()` (TwelveData → Firestore cache), a live-computed value that moves with real-world FX rates independently of any code change — exactly the false-positive class `DYNAMIC_REGION_SELECTORS` already exists to solve for other rotating widgets in this file.
- (Noted but out of scope: the same diff artifacts also showed a transient header-nav icon rendering glitch, reproduced identically across both attempts within that run. Traced this to the concurrent CDN-purge/propagation window this job runs in (`validate-live` purges the Cloudflare edge cache immediately before running Playwright, in parallel with a background CDN-bundle-serves-live check) rather than a code regression — confirmed the header renders correctly with the unchanged code locally. This matches the already-tracked chunk/version-skew propagation-window class of issue and isn't something a test-file change can fix, so left untouched per the "keep the diff minimal, don't scope-creep" instruction.)
- **Reconciled with #3197**: while this PR was in flight, a separate PR (#3197, "raise currency-comparator visual-regression threshold to 4%") merged into `main` for the same underlying CI failure, by widening `maxDiffPixelRatio` for this case instead of masking the dynamic region. That's the workaround this task explicitly ruled out. Rebasing this branch onto the new `main` hit a real conflict on the same lines; resolved it by keeping the mask-based fix and reverting the threshold override entirely — `currency-comparator` (and every other case) stays at the tight, shared 0.02 default. No case-specific threshold exists anymore.

## Change
- `components/comparators/CurrencyExchange.tsx`: tag the rate-display container (label + live rate input + last-updated timestamp) with `data-testid="exchange-rate-panel"`.
- `tests/e2e/seo-visual-regression.spec.ts`: add an optional per-case `extraMaskSelectors?: string[]` field to `VisualCase` (selectors that only exist on that one case's page, so they don't belong in the page-agnostic `DYNAMIC_REGION_SELECTORS` list), set it for `currency-comparator` to `['[data-testid="exchange-rate-panel"]']`, and merge it into the mask list at capture time.

## Implementato
- Diagnosi root-cause confermata sugli artifact reali del run fallito (screenshot expected/actual/diff scaricati e ispezionati a livello di pixel), non dedotta.
- Aggiunto `data-testid="exchange-rate-panel"` al pannello tasso di cambio live in `CurrencyExchange.tsx`.
- Esteso il modello dati `VisualCase` con `extraMaskSelectors` opzionale e collegato alla mask list della case `currency-comparator`, riusando l'idioma già esistente (`mask()` di Playwright, ignora selettori assenti).
- Verifica locale: build `dist` interrotta per spazio disco insufficiente nell'ambiente sandbox; usato invece `vite` dev server + script Playwright standalone per navigare `/comparatori/cambio-valuta/`, confermare che `[data-testid="exchange-rate-panel"]` risolve a un elemento reale e visibile (bounding box coerente con l'area del tasso di cambio) e che uno screenshot con lo stesso identico `mask` della spec dipinge la regione corretta in rosa, senza toccare la colonna "Importo da Convertire" né altri widget già mascherati (`whats-new-badge`, `gamification-toast`).
- `tsc --noEmit` pulito sui file toccati.
- `gitnexus impact` su `CurrencyExchange` (upstream): 0 impattati, rischio LOW — coerente con una modifica di solo attributo JSX senza cambio di comportamento.

## Non implementato (ancora)
- Rigenerazione del baseline PNG `currency-comparator-chromium-linux.png` — necessaria dopo il merge perché il mask ora dipinge in rosa un'area che nel baseline committato mostra ancora il testo reale non mascherato. Verrà lanciata via `gh workflow run regenerate-visual-baselines.yml` subito dopo il merge, come da istruzioni.
- Il glitch transitorio delle icone header osservato nello stesso run (probabile finestra di propagazione CDN concorrente al purge) — non è un difetto di codice riproducibile localmente, resta una nota per eventuale follow-up separato se dovesse ripresentarsi in run futuri.
- Il salto `STALE_BASELINES` per `salary-calculator` — già tracciato separatamente, non toccato.

## Test plan
- [x] `tsc --noEmit` sui file modificati — nessun nuovo errore.
- [x] `mcp__gitnexus__impact` (via CLI `gitnexus impact CurrencyExchange --direction upstream`) — 0 impattati, rischio LOW.
- [x] Sanity check locale (vite dev server + script Playwright standalone): il selettore si risolve a un elemento visibile e il mask copre esattamente l'area del tasso/timestamp.
- [ ] CI `tests` (vitest) + `pr-review-loop` — in attesa.
- [ ] Post-merge: `regenerate-visual-baselines.yml` per aggiornare `currency-comparator-chromium-linux.png`.
- [ ] Osservazione naturale (senza forzare/cancellare run) del prossimo ciclo `deploy-publish` reale per confermare che `validate-live` passi con questo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
