### PR TITLE
perf(tests): speed up 7 slow vitest suites (~80s → ~7s)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@types/pdfkit": "^0.17.5",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.24",
+        "esbuild": "^0.25.12",
         "firebase-admin": "^13.6.1",
         "html-minifier-terser": "^6.1.0",
         "jsdom": "^28.0.0",

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "@types/pdfkit": "^0.17.5",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.24",
+    "esbuild": "^0.25.12",
     "firebase-admin": "^13.6.1",
     "html-minifier-terser": "^6.1.0",
     "jsdom": "^28.0.0",

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -927,6 +927,11 @@ function chunkText(text, maxChars = 1800) {
 }
 
 function delay(ms) {
+  // Under Vitest every fetch call in this cascade is mocked, so the real
+  // network never benefits from spacing out retries/chunks — skip the wait
+  // to keep failure-cascade tests (empty-translation retries, chunk pacing)
+  // from burning multiple real seconds per assertion.
+  if (process.env.VITEST) return Promise.resolve();
   return new Promise((r) => setTimeout(r, ms));
 }
 

--- a/scripts/lib/geberit-job-parser.mjs
+++ b/scripts/lib/geberit-job-parser.mjs
@@ -191,7 +191,11 @@ async function postSearch(body, { retries = 3 } = {}) {
     } catch (err) {
       lastErr = err;
       if (attempt < retries) {
-        await new Promise((r) => setTimeout(r, 1000 * 2 ** attempt));
+        // Configurable base delay (matches JOBS_CRAWLER_RETRY_BASE_MS used by
+        // transient-fetch.mjs) so tests that deliberately trigger this retry
+        // path via a 5xx response don't have to eat the real 1s/2s/4s backoff.
+        const baseMs = Number(process.env.JOBS_CRAWLER_RETRY_BASE_MS ?? 1000);
+        await new Promise((r) => setTimeout(r, baseMs * 2 ** attempt));
       }
     }
   }

--- a/scripts/lib/mymemory-translate.mjs
+++ b/scripts/lib/mymemory-translate.mjs
@@ -59,7 +59,9 @@ export async function translateWithMyMemory(text, sourceLang, targetLang) {
   const slot = Math.max(now, nextSlotMs);
   nextSlotMs = slot + 1000;
   const wait = slot - now;
-  if (wait > 0) {
+  // Under Vitest fetch is always mocked, so there's no real API to rate-limit
+  // against — skip the spacing wait to avoid burning real seconds per call.
+  if (wait > 0 && !process.env.VITEST) {
     await new Promise((r) => setTimeout(r, wait));
   }
 

--- a/tests/blog-body-typescript-syntax.test.ts
+++ b/tests/blog-body-typescript-syntax.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import ts from 'typescript';
+import esbuild from 'esbuild';
 import { describe, expect, it } from 'vitest';
 
 const BLOG_BODY_ROOT = path.resolve(__dirname, '..', 'services', 'locales', 'blog-body');
@@ -24,37 +24,30 @@ function collectTypeScriptFiles(dir: string): string[] {
 }
 
 describe('blog body locale files', () => {
-  // 1700+ files transpiled via ts.transpileModule; under full-suite parallel load
-  // this regularly exceeds the default 5 s — raised to 30 s to prevent flakiness.
+  // 10,000+ files. esbuild's async transform runs on its background service,
+  // which parses concurrently across cores — ~2.3x faster here than the
+  // single-threaded ts.transpileModule loop this replaced, for the same
+  // syntax-only (no type-check) validation.
   it('parse as valid TypeScript modules', async () => {
     const files = collectTypeScriptFiles(BLOG_BODY_ROOT);
-    const failures: string[] = [];
 
-    for (const filePath of files) {
+    const results = await Promise.all(files.map(async (filePath) => {
       const source = fs.readFileSync(filePath, 'utf8');
-      const result = ts.transpileModule(source, {
-        compilerOptions: {
-          module: ts.ModuleKind.ESNext,
-          target: ts.ScriptTarget.ES2022,
-        },
-        fileName: filePath,
-        reportDiagnostics: true,
-      });
-
-      const diagnostics = (result.diagnostics || [])
-        .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
-
-      if (diagnostics.length > 0) {
-        const message = diagnostics
-          .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
-          .join('\n');
-        failures.push(`${path.relative(process.cwd(), filePath)}\n${message}`);
+      try {
+        await esbuild.transform(source, { loader: 'ts', format: 'esm', target: 'es2022' });
+        return null;
+      } catch (err) {
+        const messages = (err as { errors?: Array<{ text: string }> }).errors
+          ?.map((e) => e.text)
+          .join('\n') || String(err);
+        return `${path.relative(process.cwd(), filePath)}\n${messages}`;
       }
-    }
+    }));
+    const failures = results.filter((f): f is string => f !== null);
 
     expect(
       failures,
       `Invalid blog body TypeScript files:\n\n${failures.slice(0, 10).join('\n\n')}`,
     ).toHaveLength(0);
-  }, 120_000);
+  }, 60_000);
 });

--- a/tests/geberit-crawler.test.ts
+++ b/tests/geberit-crawler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import {
   GEBERIT_KEY,
   GEBERIT_COMPANY_NAME,
@@ -130,7 +130,13 @@ describe('Geberit crawler parser', () => {
 });
 
 describe('fetchAllGeberitJobs (SuccessFactors RMK search API)', () => {
-  afterEach(() => vi.restoreAllMocks());
+  // Skip the real exponential backoff (1s/2s/4s) fetchWithRetry does on
+  // retryable statuses — the 503 test below deliberately triggers it.
+  beforeEach(() => { process.env.JOBS_CRAWLER_RETRY_BASE_MS = '0'; });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.JOBS_CRAWLER_RETRY_BASE_MS;
+  });
 
   function apiRecord(over = {}) {
     return {

--- a/tests/luks-crawler.test.ts
+++ b/tests/luks-crawler.test.ts
@@ -137,6 +137,10 @@ describe('Luzerner Kantonsspital (LUKS) crawler parser', () => {
     const realFetch = globalThis.fetch;
 
     beforeEach(() => {
+      // Skip the real exponential backoff (1s/2s/4s) fetchWithRetry does on
+      // retryable statuses — several tests below deliberately return 500/503
+      // to exercise graceful degradation, and don't need the real delay.
+      process.env.JOBS_CRAWLER_RETRY_BASE_MS = '0';
       // Default: every fetch fails (network down). Override per-test below.
       globalThis.fetch = vi.fn(async () => {
         return new Response('', { status: 500 });
@@ -145,6 +149,7 @@ describe('Luzerner Kantonsspital (LUKS) crawler parser', () => {
 
     afterEach(() => {
       globalThis.fetch = realFetch;
+      delete process.env.JOBS_CRAWLER_RETRY_BASE_MS;
     });
 
     it('returns [] when JobAbo not yet reinstated (advertCollection empty)', async () => {

--- a/tests/paraplegie-crawler.test.ts
+++ b/tests/paraplegie-crawler.test.ts
@@ -60,10 +60,15 @@ describe('Schweizer Paraplegiker-Gruppe (paraplegie) crawler parser', () => {
     const realFetch = globalThis.fetch;
 
     beforeEach(() => {
+      // Skip the real exponential backoff (1s/2s/4s) fetchWithRetry does on
+      // retryable statuses — several tests below deliberately return 500/503
+      // to exercise graceful degradation, and don't need the real delay.
+      process.env.JOBS_CRAWLER_RETRY_BASE_MS = '0';
       globalThis.fetch = vi.fn(async () => new Response('', { status: 500 })) as any;
     });
     afterEach(() => {
       globalThis.fetch = realFetch;
+      delete process.env.JOBS_CRAWLER_RETRY_BASE_MS;
     });
 
     it('hits the correct Prospective medium endpoint and parses a rich job', async () => {

--- a/tests/scripts/mine-topic-candidates.test.ts
+++ b/tests/scripts/mine-topic-candidates.test.ts
@@ -738,9 +738,13 @@ describe('orchestrator: aggregation + scoring', () => {
 describe('mineTopicCandidates orchestrator', () => {
   it('writes a valid JSON with all sources missing → empty candidates', async () => {
     const out = tempPath('all-missing.json');
-    cleanupPaths.push(out);
+    const vocabOut = tempPath('all-missing-vocab.json');
+    const expOut = tempPath('all-missing-exp.json');
+    cleanupPaths.push(out, vocabOut, expOut);
     const result = await mineTopicCandidates({
       outputPath: out,
+      vocabOutputPath: vocabOut,
+      experimentalOutputPath: expOut,
       blogMetaPath: '/nonexistent/blog-meta.ts',
       articlePerformancePath: '/nonexistent/perf.json',
       gscOrphansImpl: async () => ({
@@ -772,6 +776,8 @@ describe('mineTopicCandidates orchestrator', () => {
         candidates: [],
         reason: 'no FB token',
       }),
+      suggestImpl: async () => ({ ok: false, candidates: [] }),
+      newsRssImpl: async () => ({ ok: false, candidates: [] }),
       now: () => '2026-05-06T22:00:00.000Z',
     });
     expect(result.candidates).toEqual([]);
@@ -838,11 +844,16 @@ describe('mineTopicCandidates orchestrator', () => {
       }),
       redditImpl: async () => ({ ok: false, candidates: [] }),
       facebookImpl: async () => ({ ok: false, candidates: [] }),
+      suggestImpl: async () => ({ ok: false, candidates: [] }),
+      newsRssImpl: async () => ({ ok: false, candidates: [] }),
       now: () => '2026-05-06T22:00:00.000Z',
     });
 
-    await mineTopicCandidates({ outputPath: out1, ...mocks() });
-    await mineTopicCandidates({ outputPath: out2, ...mocks() });
+    const vocabOut = tempPath('deterministic-vocab.json');
+    const expOut = tempPath('deterministic-exp.json');
+    cleanupPaths.push(vocabOut, expOut);
+    await mineTopicCandidates({ outputPath: out1, vocabOutputPath: vocabOut, experimentalOutputPath: expOut, ...mocks() });
+    await mineTopicCandidates({ outputPath: out2, vocabOutputPath: vocabOut, experimentalOutputPath: expOut, ...mocks() });
 
     expect(readFileSync(out1, 'utf-8')).toBe(readFileSync(out2, 'utf-8'));
     const parsed = JSON.parse(readFileSync(out1, 'utf-8'));
@@ -855,7 +866,9 @@ describe('mineTopicCandidates orchestrator', () => {
 
   it('drops candidates with novelty < 0.3', async () => {
     const out = tempPath('novelty-drop.json');
-    cleanupPaths.push(out);
+    const vocabOut = tempPath('novelty-drop-vocab.json');
+    const expOut = tempPath('novelty-drop-exp.json');
+    cleanupPaths.push(out, vocabOut, expOut);
     // Set up a temp blog-meta file with a single title.
     const metaPath = tempPath('blog-meta.ts');
     cleanupPaths.push(metaPath);
@@ -865,6 +878,8 @@ describe('mineTopicCandidates orchestrator', () => {
     );
     const result = await mineTopicCandidates({
       outputPath: out,
+      vocabOutputPath: vocabOut,
+      experimentalOutputPath: expOut,
       blogMetaPath: metaPath,
       articlePerformancePath: '/nope.json',
       gscOrphansImpl: async () => ({
@@ -889,6 +904,8 @@ describe('mineTopicCandidates orchestrator', () => {
       googleTrendsImpl: async () => ({ ok: false, perGeo: {}, candidates: [] }),
       redditImpl: async () => ({ ok: false, candidates: [] }),
       facebookImpl: async () => ({ ok: false, candidates: [] }),
+      suggestImpl: async () => ({ ok: false, candidates: [] }),
+      newsRssImpl: async () => ({ ok: false, candidates: [] }),
       now: () => '2026-05-06T22:00:00.000Z',
     });
     expect(

--- a/tests/trafficScheduler.webcam-only.test.ts
+++ b/tests/trafficScheduler.webcam-only.test.ts
@@ -138,6 +138,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -411,12 +412,20 @@ describe('runTrafficCollection — routes to webcam-only fallback', () => {
     )) as CoreModule;
 
     // hereApiKey present (would normally win) but budget exhausted → must fall back
-    // to TomTom, NOT to webcam-only or a skip.
-    const result = await runTrafficCollection({
+    // to TomTom, NOT to webcam-only or a skip. TomTom routing rate-limits itself
+    // with a real 1s inter-batch setTimeout (25 crossings / batch size 2 = 12
+    // delays = ~12s) to stay under the free-tier QPS cap — fake timers let this
+    // real production delay resolve instantly against the fully-mocked fetch
+    // below, without touching Date (the budget-month check above depends on it).
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] });
+    const resultPromise = runTrafficCollection({
       hereApiKey: 'here-key',
       tomtomApiKey: 'tt-key',
       enableWebcam: false,
     });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+    vi.useRealTimers();
 
     expect(result.skipped).toBeUndefined(); // did NOT skip the run
     expect(result.source).not.toBe('webcam-only'); // did NOT degrade to webcam-only


### PR DESCRIPTION
## Implementato

- **tests/geberit-crawler.test.ts** (7042ms → 30ms): `postSearch`'s independent retry backoff in `scripts/lib/geberit-job-parser.mjs` now honors `JOBS_CRAWLER_RETRY_BASE_MS` (already used by `transient-fetch.mjs`), instead of a hardcoded 1s/2s/4s real delay.
- **tests/dedicated-crawler-localization-pipeline.test.ts** (25569ms → 223ms): `scripts/lib/free-translate.mjs` and `scripts/lib/mymemory-translate.mjs` now skip their real rate-limit spacing `setTimeout` under `process.env.VITEST` (matches the existing `dedicated-crawler-common.mjs` cache-disable pattern) — production behavior against the real APIs is unchanged since `VITEST` is never set outside tests (verified via `gitnexus_impact` on `translateWithMyMemory`: all real callers are 2-3 hops downstream, LOW risk).
- **tests/luks-crawler.test.ts**, **tests/paraplegie-crawler.test.ts**: same `JOBS_CRAWLER_RETRY_BASE_MS`-driven fix.
- **tests/blog-body-typescript-syntax.test.ts** (18716ms → 4827ms): swapped single-threaded `ts.transpileModule` for `esbuild.transform` run concurrently via `Promise.all` (esbuild's background service parses across cores); same syntax-only validation, verified via an injected-syntax-error check. Added `esbuild` as an explicit `package.json` devDependency (was only transitive via `vite`).
- **tests/scripts/mine-topic-candidates.test.ts** (16530ms → 1338ms): 3 tests were missing `suggestImpl`/`newsRssImpl` mocks, causing real live calls to Google Suggest/News RSS — added the missing stubs (matches an existing precedent already used elsewhere in the same file).
- **Bug fix (found while investigating the above)**: 3 tests in the same file never overrode `vocabOutputPath`/`experimentalOutputPath`, so every test run was silently overwriting the real `data/demand-vocabulary.json` and `data/experimental-candidates.json` with test fixture data. Fixed by pointing all `mineTopicCandidates()` calls at temp-dir paths.
- **tests/trafficScheduler.webcam-only.test.ts** (12118ms → 89ms): the "TomTom fallback" test hit a real, unmocked 1s inter-batch rate-limit `setTimeout` in `functions/src/trafficSchedulerCore.js` (12 batches × 1s ≈ 12s) — scoped `vi.useFakeTimers()` + `vi.runAllTimersAsync()` to just this one test (timers only, `Date` left real since the budget-month check depends on it). No assertions changed.

Combined, these 7 files drop from ~80s to ~7s real time, with zero changes to test assertions, retry counts, or coverage.

## Non implementato

- **tests/search-console-compat.test.ts** (~13.6s) — intentional, documented full-coverage scan over the real committed 404-path corpus (150k-300k+ entries); the regex compilation is already hoisted to module scope per an existing code comment. Reducing this further means either sampling/truncating coverage or restructuring the scan itself — needs explicit approval, not attempted.
- **tests/seo-completeness.test.ts** (43,927 generated `it()` cases from route × check × locale cross-products) — slowness is intrinsic to test-case volume, not a timer/network issue. A fix would mean collapsing many `it()` into fewer tests with internal loops (structural test-design change) — needs explicit approval, not attempted.

## Test plan

- [x] Each of the 7 fixed files run individually and verified before/after timings above
- [x] All 7 files run together: 111 tests pass, no regressions
- [x] Confirmed `data/demand-vocabulary.json` / `data/experimental-candidates.json` are untouched after running the full mine-topic-candidates suite
- [x] `gitnexus_impact` run on `postSearch` and `translateWithMyMemory` — both LOW risk, no HIGH/CRITICAL callers affected