### PR TITLE
feat(article): widen frontaliere topic pool — INPS/Agenzia Entrate feeds, new seeds, evergreen sub-topics

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -1116,6 +1116,20 @@ const PRIORITY_EVERGREEN_TOPICS = [
   { keyword: 'quellensteuer schweiz tarife 2026', angle: 'Quellensteuer-Tarife alle Kantone: Tessin, Graubünden, Wallis, Bern. Berechnung, Abzüge, NOV-Schwelle 120k CHF', locale: 'de', searchVolume: 880 },
   { keyword: 'grenzgänger schweiz steuern 2026', angle: 'Steuerliche Pflichten für Grenzgänger nach neuem Abkommen: alte vs neue Grenzgänger, Italien-Steuer, Beispielrechnungen', locale: 'de', searchVolume: 260 },
   { keyword: 'g bewilligung antrag 2026', angle: 'G-Bewilligung Antrag Schritt für Schritt: Dokumente, Migrationsamt, Kosten 65 CHF, 5-Jahres-Gültigkeit, Verlängerung', locale: 'de', searchVolume: 110 },
+  // 2026-07-01 (issue #3138 Leva #2): sub-angles absent from the pool above —
+  // border-municipality life, extra professions, cross-border life-events,
+  // INPS/Agenzia Entrate procedure. Widens the pool so fewer candidates
+  // collapse into near-duplicates of the fiscal/pension/health core above.
+  { keyword: 'vivere a Como e lavorare in Ticino da frontaliere', angle: 'Pendolarismo Como-Chiasso: tempi di percorrenza, costo della vita a confronto, quartieri consigliati, treno vs auto' },
+  { keyword: 'vivere a Varese e lavorare in Ticino da frontaliere', angle: 'Pendolarismo Varese-Lugano: collegamenti, costo della vita, scuole per i figli, comunità di frontalieri' },
+  { keyword: 'totalizzazione contributi AVS INPS domanda come funziona', angle: 'Procedura di totalizzazione dei contributi tra AVS svizzera e INPS italiana: modulistica, tempistiche, calcolo della pensione risultante' },
+  { keyword: 'quadro RW dichiarazione conto corrente svizzero Agenzia Entrate', angle: 'Obblighi di monitoraggio fiscale (quadro RW) per il conto bancario svizzero del frontaliere: IVAFE, sanzioni per omessa dichiarazione, casi pratici' },
+  { keyword: 'matrimonio frontaliere italiano cittadino svizzero regime fiscale', angle: 'Cosa cambia fiscalmente e a livello di permesso quando un frontaliere sposa un cittadino svizzero o residente in Svizzera' },
+  { keyword: 'successione eredità frontaliere conto svizzero Italia', angle: 'Successione transfrontaliera: come si tassa un conto o un immobile svizzero ereditato da un frontaliere residente in Italia, doppia imposizione e convenzioni' },
+  { keyword: 'divorzio frontaliere assegno mantenimento Svizzera Italia', angle: 'Separazione e divorzio quando un coniuge è frontaliere: giurisdizione competente, calcolo dell\'assegno di mantenimento su stipendio svizzero, riconoscimento della sentenza' },
+  { keyword: 'frontaliere infermiere Ticino stipendio requisiti', angle: 'Lavorare come infermiere in Ticino da frontaliere: stipendio, riconoscimento titolo di studio italiano, permesso G, differenze con l\'Italia' },
+  { keyword: 'frontaliere operaio edile Ticino contratto CCL', angle: 'Lavoro edile in Ticino per frontalieri: contratto collettivo (CCL), salario minimo, sicurezza sul lavoro, differenze con i cantieri italiani' },
+  { keyword: 'frontaliere autista camionista Ticino permesso', angle: 'Diventare autista/camionista frontaliere in Ticino: patenti riconosciute, tempi di guida, stipendio, permesso G per il settore trasporti' },
 ];
 
 // ── News sources to auto-scan ───────────────────────────────
@@ -1208,6 +1222,13 @@ const NEWS_SOURCES = [
   'https://www.varesenoi.it/?s=frontalieri',               // varesenoi WP search for frontalieri (HTML, dead sub-category replacement)
   // swissinfo.ch RSS removed — 410 Gone (FRO-415, re-confirmed 2026-05-13 — HTML home page added above as replacement)
   // admin.ch RSS removed — WAF challenge blocks scraping (FRO-415)
+  // 2026-07-01 (issue #3138 Leva #1): Italian institutional feeds, national
+  // scope but heavily pension/fiscal — filtered downstream by the same
+  // FRONTALIERI_DOMAIN_RE relevance gate as every other source. Both
+  // curl-verified live before adding (INPS/Agenzia Entrate have no
+  // frontaliere-scoped feed, only site-wide news).
+  'https://www.inps.it/it/it.rss.news.xml',                // INPS — pensioni/AVS-INPS/NASpI national news
+  'https://www.agenziaentrate.gov.it/portale/c/portal/rss/entrate?idrss=0753fcb1-1a42-4f8c-f40d-02793c6aefb4', // Agenzia Entrate — comunicati (730, quadro CE, dichiarazioni)
 ];
 
 // Fallback: when an RSS feed yields 0 recent items, scrape the base HTML site instead

--- a/scripts/lib/discovery/frontaliereAnchor.mjs
+++ b/scripts/lib/discovery/frontaliereAnchor.mjs
@@ -53,6 +53,12 @@ export const FRONTALIERE_STRICT_ANCHORS = [
   /\baziende?\s+che\s+assumon[oa]\s+frontalier/i,
   /\bcambio\s+(?:chf|franco|eur)/i,
   /\beur\s*\/\s*chf|chf\s*\/\s*eur/i,
+  /\btotalizzazione\s+(?:dei\s+)?contributi\b/i,   // INPS/AVS pension coordination term-of-art
+  /\bquadro\s+ce\b/i,                              // 730 foreign-income credit section used by frontalieri
+  /\binps\b.{0,60}\b(?:frontalier|svizzer|ticino|avs|ahv)\b/i,
+  /\b(?:frontalier|svizzer|ticino|avs|ahv)\b.{0,60}\binps\b/i,
+  /\bagenzia\s+(?:delle\s+)?entrate\b.{0,60}\bfrontalier/i,
+  /\bfrontalier.{0,60}\bagenzia\s+(?:delle\s+)?entrate\b/i,
 ];
 
 /**
@@ -110,6 +116,10 @@ export const FRONTALIERE_UNAMBIGUOUS_ANCHORS = [
   /\bmercato\s+del\s+lavoro\s+ticines/i,
   /\baziende?\s+che\s+assumon[oa]\s+frontalier/i,
   /\beur\s*\/\s*chf|chf\s*\/\s*eur/i,
+  /\binps\b.{0,60}\b(?:frontalier|svizzer|ticino|avs|ahv)\b/i,
+  /\b(?:frontalier|svizzer|ticino|avs|ahv)\b.{0,60}\binps\b/i,
+  /\bagenzia\s+(?:delle\s+)?entrate\b.{0,60}\bfrontalier/i,
+  /\bfrontalier.{0,60}\bagenzia\s+(?:delle\s+)?entrate\b/i,
 ];
 
 /**

--- a/scripts/lib/topic-sources/googleNewsRss.mjs
+++ b/scripts/lib/topic-sources/googleNewsRss.mjs
@@ -89,6 +89,16 @@ const SEEDS_FALLBACK = [
   'salari frontalieri Ticino',
   'frontalieri Chiasso permesso lavoro',
   'frontaliere Varese Como Ticino',
+  // 2026-07-01 (issue #3138 Leva #1): angles absent from the pool above —
+  // INPS/Agenzia Entrate procedural news and cross-border life-events —
+  // each seed keeps a frontaliere/Svizzera anchor term so results still
+  // pass the FRONTALIERI_DOMAIN_RE positive filter below.
+  'INPS pensione frontalieri Svizzera Italia',
+  'totalizzazione contributi AVS INPS frontalieri',
+  'Agenzia delle Entrate frontalieri dichiarazione redditi',
+  'successione eredità frontalieri Svizzera Italia',
+  'matrimonio frontalieri Svizzera Italia fiscale',
+  'comuni di confine Ticino frontalieri lavoro',
 ];
 
 const REQUEST_TIMEOUT_MS = 15000;


### PR DESCRIPTION
## Implementato

Attua le prime due leve del backlog di #3138 (frontaliere produce 3 commit/24h vs 17 di svizzera, causa principale: pool topic stretto → alto tasso di duplicati).

- **Leva #1 (sorgenti)**: 2 feed RSS istituzionali nuovi in `NEWS_SOURCES` — INPS (`inps.it/it/it.rss.news.xml`) e Agenzia delle Entrate (`agenziaentrate.gov.it/.../rss/entrate`), entrambi verificati live (`curl` → HTTP 200, XML valido) prima di aggiungerli. Nazionali per ambito ma filtrati a valle dallo stesso `FRONTALIERI_DOMAIN_RE` di ogni altra fonte.
- 6 nuovi seed in `SEEDS_FALLBACK` (Google News RSS discovery) per angoli finora assenti: INPS/totalizzazione contributi, Agenzia delle Entrate, successione/eredità, matrimonio, comuni di confine.
- **Leva #2 (sotto-topic evergreen)**: 9 nuovi entry in `PRIORITY_EVERGREEN_TOPICS` — vita nei comuni di confine (Como, Varese), professioni non ancora coperte (infermiere, edile, autista), eventi di vita transfrontalieri (matrimonio, successione, divorzio), procedure INPS/Agenzia Entrate specifiche (totalizzazione contributi, quadro RW).
- Nuovi anchor regex composti in `frontaliereAnchor.mjs` (`INPS`/`Agenzia delle Entrate` + contesto frontaliere/Svizzera/AVS) così le nuove headline superano il pre-spend relevance gate invece di dipendere solo dal giudizio dell'LLM classifier.

Verificato: `tests/pre-spend-topic-gate.test.ts` (23/23, incluse le fixture cronaca-nera negative control — nessun anchor nuovo causa falsi bypass), più `google-news-compliance`, `googleNewsRss`, `googleNewsRssSource`, `article-topic-selector` (102/102 totali). `node --check` pulito su tutti i file toccati.

## Non implementato

- **Leva #3 (dedup a monte nella topic-selection)** — richiede refactor più ampio del pre-spend gate per confrontare i candidati contro gli slug esistenti prima della generazione; fuori scope per questo PR mirato.
- **Leva #4 (resilienza fact-check sui 429)** — il meccanismo di retry/backoff esistente in `create-article.mjs` è già presente (3 tentativi, backoff crescente); non toccato qui.
- Nessuna nuova sorgente comune di confine (Como/Chiasso) verificata via RSS — coperta solo lato evergreen/seed testuale, non come feed dedicato (non ho trovato feed comunali affidabili nel tempo a disposizione).

## Riferimenti

Closes parte del backlog in #3138 (Leva #1 + Leva #2). Leva #3/#4 restano aperte nell'issue.