### PR TITLE
fix(firestore): allow journalist_articles read on non-existent docs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -324,7 +324,13 @@ service cloud.firestore {
             : false));
     }
     match /journalist_articles/{articleId} {
-      allow read: if isSignedIn() && request.auth.uid == resource.data.authorUid;
+      // `resource == null` (doc doesn't exist yet) must be allowed to read-through
+      // to a clean "not found" — otherwise dereferencing `.data` on a null resource
+      // throws a rules-evaluation error, which Firestore surfaces to the client as
+      // PERMISSION_DENIED. That broke both the new-draft id-collision check in
+      // createDraft() and the dashboard's slug-availability check, since both
+      // call getDoc() on an article id that doesn't exist yet for a brand-new draft.
+      allow read: if isSignedIn() && (resource == null || request.auth.uid == resource.data.authorUid);
       allow create: if isSignedIn()
         && isActiveJournalist()
         && request.resource.data.authorUid == request.auth.uid


### PR DESCRIPTION
## Implementato
- `firestore.rules`: la regola `allow read` su `journalist_articles/{articleId}` dereferenziava `resource.data.authorUid` anche quando il documento non esiste ancora — Firestore valuta `resource == null` per un doc inesistente, e dereferenziare `.data` lancia un errore di valutazione della regola che il client vede come `PERMISSION_DENIED` invece di un normale "non trovato".
- Root cause verificata a livello di codice: sia `createDraft()` (controllo id-collision via `getDoc` prima del `setDoc`) sia il controllo di disponibilità slug nel form (`handleTitleBlur` → `getArticle(computedSlug)`) fanno esattamente questo `getDoc` su un id che per una bozza nuova non esiste ancora — spiega entrambi gli errori riportati (`journalistDashboard.save` e `journalistDashboard.slugCheck`).
- Fix: `allow read: if isSignedIn() && (resource == null || request.auth.uid == resource.data.authorUid);` — leggere un doc inesistente ora restituisce correttamente "non trovato" invece di un errore di permessi. Nessun dato esposto in più (un doc inesistente non ha `data`).

## Non implementato
- Il 404 reale su navigazione diretta a `/redazione/` (e, verificato live, anche `/dashboard/` e `/i-miei-annunci/`) — non è la stessa causa di questo bug, è la dashboard non pre-renderizzata che serve `public/404.html` con self-heal via `sessionStorage.redirect`; da verificare separatamente se il self-heal funziona correttamente per queste route.
- Le richieste di redesign del form redazione (titolo sentence-case, riassunto auto-generato, campo paragrafi unico con split via AI, rimozione FAQ manuale, selezione immagine di copertina da libreria) — scope più ampio, pianificato separatamente.

## Test plan
- [ ] Deploy automatico su merge (`.github/workflows/deploy-firestore-rules.yml` triggera su push a `firestore.rules`)
- [ ] Verifica live: creare una bozza nuova in `/redazione/` e confermare che salvataggio e controllo slug non lancino più `Missing or insufficient permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)