### PR TITLE
fix(article): sync pre-flight duplicate threshold + wall-budget guard in evergreen loop (#3220 review follow-up)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -5505,7 +5505,13 @@ function preFlightEvergreenTopicCheck(candidate, existingArticles) {
   const candidateText = `${keyword} ${angle}`;
   const candidateFamily = evergreenTopicFamily(candidateText);
   const candidateTokens = evergreenAngleTokens(candidateText);
-  const PRE_FLIGHT_THRESHOLD = 0.58;
+  // Raised 0.58→0.72 (2026-07-01, PR #3220 review follow-up): this pre-flight
+  // gate runs BEFORE generation and used the exact title-Jaccard-on-shared-
+  // fiscal-vocabulary check that #3220 identified as too aggressive in the
+  // post-generation `checkForDuplicates` TITLE_THRESHOLD — but left this
+  // earlier gate untouched, so candidates could still be rejected here before
+  // ever reaching the loosened post-gen check. Kept in sync with TITLE_THRESHOLD.
+  const PRE_FLIGHT_THRESHOLD = 0.72;
   const FAMILY_TOKEN_OVERLAP_THRESHOLD = 0.50;
   const SATURATED_FAMILIES = new Set(['permesso-g-b', 'lamal-cmi', 'avs-inps', 'telelavoro', 'credito-imposta']);
 
@@ -7860,6 +7866,16 @@ async function main() {
       // "Push prosegue senza nuovo articolo" — the cap, not the pool, was the bottleneck.
       const triedOffsets = new Set([selectedOffset]);
       for (let attempt = 1; attempt <= Math.min(25, totalTopics); attempt++) {
+        // Wall-clock budget guard (2026-07-01, PR #3220 review follow-up): the
+        // sibling news-pool retry loop above (~L7531) checks this every
+        // iteration; this loop didn't, so raising the cap 10→25 risked a
+        // single cron run blowing well past its intended wall-clock budget
+        // (each attempt is ~60-90s plus up to 3×30s fact-check backoff)
+        // instead of falling through gracefully to "prosegue senza nuovo articolo".
+        if (wallBudgetExceeded()) {
+          console.error(`⏱️  Budget wall-clock (${Math.round(RUN_WALL_BUDGET_MS / 60000)}min) superato — interrompo i tentativi evergreen; l'articolo è deferito al prossimo run.`);
+          break;
+        }
         try {
           const topic = selectedTopic;
           const isStaticTopic = PRIORITY_EVERGREEN_TOPICS.includes(topic);


### PR DESCRIPTION
## Implementato

Fix dei 2 finding 🔴 Important segnalati dal review automatico su #3220 (arrivato dopo il merge — vedi nota sotto):

- `preFlightEvergreenTopicCheck`: `PRE_FLIGHT_THRESHOLD` 0.58→0.72, allineato al `TITLE_THRESHOLD` post-generazione già alzato in #3220. Questo gate gira PRIMA della generazione (selezione keyword) — con la soglia vecchia poteva scartare esattamente le keyword che #3220 voleva sbloccare, prima ancora che arrivassero al controllo post-generazione corretto.
- Loop di retry evergreen (cap 10→25 in #3220): aggiunto `if (wallBudgetExceeded()) break;` ad ogni iterazione, stesso pattern del loop gemello news-pool (~L7531). Senza questo, un cap 2.5x più alto senza controllo del budget di tempo nel loop rischiava di far sforare il wall-clock budget di un intero run invece di fermarsi con garbo su "prosegue senza nuovo articolo".

## Non implementato

- I 2 finding 🟡 Nit del review (tracciare `unverified` in RUN_REPORT/metadata articolo; disallineamento commento in `tests/article-duplicate-detection.test.ts`) — marcati come minori/opzionali dal reviewer stesso, lasciati per non ritardare ulteriormente lo sblocco della generazione articoli.

## Nota di processo

Il merge di #3220 è avvenuto ~15s prima che il workflow "PR Review (Claude single-pass)" completasse — un errore di sequenza (controllati solo i check CI, non il gate di review). Il review è arrivato post-merge e ha trovato questi 2 problemi reali. Questa PR li corregge; per questa PR attendo sia i check CI SIA il completamento della review prima del merge.

## Test plan
- `npx vitest run tests/article-duplicate-detection.test.ts tests/pre-spend-topic-gate.test.ts` — 54/54 passati
- `npx vitest run` (suite completa) — 69466 passati, stessi 6 fallimenti pre-esistenti (data/jobs.json assente nel worktree, non relativi al codice)