### PR TITLE
fix(ci): structural fix for validate-dist TI canton-drift + Ticino rehydrate speedup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -699,7 +699,7 @@ jobs:
       # the full rationale (git-clone fallback was ~12min wall across the 4
       # legs combined, run 28564001685).
       - name: Pack Ticino shard dist (tar) for post-deploy validation
-        if: vars.TICINO_SHARD_LIVE == 'true'
+        if: matrix.locale != 'it' && vars.TICINO_SHARD_LIVE == 'true'
         continue-on-error: true
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -718,7 +718,7 @@ jobs:
           ls -lh "$RUNNER_TEMP/ticino-dist-${{ matrix.locale }}.tar"
           rm -rf "$src"
       - name: Upload Ticino shard dist for post-deploy validation
-        if: vars.TICINO_SHARD_LIVE == 'true'
+        if: matrix.locale != 'it' && vars.TICINO_SHARD_LIVE == 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -439,6 +439,43 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: bash scripts/lib/push-ticino-shard.sh it dist
+
+      # Same-run tar artifact for post-deploy-validate-dist's Ticino rehydrate
+      # fast path — mirrors "Pack locale shard dist (tar)" below. Previously
+      # validate-dist rehydrated each Ticino subtree by `git clone --depth 1`
+      # of the ~4 GB shard repo, one locale at a time (~12min wall on run
+      # 28564001685). push-ticino-shard.sh already builds an offloaded staged
+      # copy at $RUNNER_TEMP/ticino-src-it/dist/$sub (byte-identical to what it
+      # just force-pushed) and now leaves it in place instead of deleting it —
+      # pack that into one tar (same stack-overflow-avoidance reason as the
+      # locale tar: upload-artifact enumerates every file, so a raw ~220k-file
+      # tree would fail the same way). validate-dist still falls back to the
+      # git clone when this artifact is missing/corrupt.
+      - name: Pack Ticino shard dist (tar) for post-deploy validation
+        if: matrix.locale == 'it' && vars.TICINO_SHARD_LIVE == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          sub="cerca-lavoro-ticino"
+          src="$RUNNER_TEMP/ticino-src-it/dist"
+          if [ ! -d "$src/$sub" ]; then
+            echo "no staged ticino-it subtree (push skipped/failed) — validate-dist will fall back to git clone"
+            exit 0
+          fi
+          tar -C "$src" -cf "$RUNNER_TEMP/ticino-dist-it.tar" "$sub"
+          ls -lh "$RUNNER_TEMP/ticino-dist-it.tar"
+          rm -rf "$src"
+      - name: Upload Ticino shard dist for post-deploy validation
+        if: matrix.locale == 'it' && vars.TICINO_SHARD_LIVE == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ticino-dist-it-${{ github.run_id }}
+          path: ${{ runner.temp }}/ticino-dist-it.tar
+          compression-level: 1
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Strip Ticino subtree (IT)
         if: matrix.locale == 'it'
         env:
@@ -656,6 +693,41 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: bash scripts/lib/push-ticino-shard.sh "${{ matrix.locale }}" dist
+
+      # Same-run tar artifact for post-deploy-validate-dist's Ticino rehydrate
+      # fast path — see the IT leg's "Pack Ticino shard dist" step above for
+      # the full rationale (git-clone fallback was ~12min wall across the 4
+      # legs combined, run 28564001685).
+      - name: Pack Ticino shard dist (tar) for post-deploy validation
+        if: vars.TICINO_SHARD_LIVE == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          case "${{ matrix.locale }}" in
+            en) sub="en/find-jobs-ticino" ;;
+            de) sub="de/jobs-im-tessin" ;;
+            fr) sub="fr/trouver-emploi-tessin" ;;
+            *) echo "::error::unsupported locale '${{ matrix.locale }}'"; exit 1 ;;
+          esac
+          src="$RUNNER_TEMP/ticino-src-${{ matrix.locale }}/dist"
+          if [ ! -d "$src/$sub" ]; then
+            echo "no staged ticino-${{ matrix.locale }} subtree (push skipped/failed) — validate-dist will fall back to git clone"
+            exit 0
+          fi
+          tar -C "$src" -cf "$RUNNER_TEMP/ticino-dist-${{ matrix.locale }}.tar" "$sub"
+          ls -lh "$RUNNER_TEMP/ticino-dist-${{ matrix.locale }}.tar"
+          rm -rf "$src"
+      - name: Upload Ticino shard dist for post-deploy validation
+        if: vars.TICINO_SHARD_LIVE == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ticino-dist-${{ matrix.locale }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/ticino-dist-${{ matrix.locale }}.tar
+          compression-level: 1
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Strip Ticino subtree (non-IT)
         if: matrix.locale != 'it'
         env:

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -303,10 +303,22 @@ jobs:
         # deploy.yml strips dist/<ticino-subtree> from the apex/locale artifacts
         # (strip-ticino-subtree.sh) and publishes ONE Pages repo PER LOCALE
         # (frontaliere-ticino-<loc>, push-ticino-shard.sh). Restore each subtree
-        # by cloning its shard repo so validators that walk dist for the Ticino
-        # URLs don't false-flag them missing. (No tar artifact: the push is
-        # per-leg direct, so the published shard repo is the source of truth.)
+        # so validators that walk dist for the Ticino URLs don't false-flag
+        # them missing.
+        #
+        # PRIMARY: same-run per-locale tar artifact (`ticino-dist-<loc>-<run>`,
+        # "Pack Ticino shard dist" step in deploy.yml) built from
+        # push-ticino-shard.sh's already-offloaded staged copy — byte-identical
+        # to what was force-pushed. Fetched via `gh run download` (same-run, no
+        # API lag), same pattern as the locale rehydrate above. FALLBACK: full
+        # `git clone` of the shard repo when the artifact is missing/corrupt —
+        # a locale is NEVER silently un-validated. Before the tar artifact
+        # existed, all 4 legs paid the git-clone path unconditionally: ~12min
+        # combined wall on run 28564001685 (~250k files/clone × 4, sequential).
         if: ${{ vars.TICINO_SHARD_LIVE == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
         run: |
           set -uo pipefail
           declare -A TICINO_SUB=( [it]=cerca-lavoro-ticino [en]=en/find-jobs-ticino [de]=de/jobs-im-tessin [fr]=fr/trouver-emploi-tessin )
@@ -316,6 +328,26 @@ jobs:
               echo "Ticino $loc ($sub) present in artifact — skip rehydrate"
               continue
             fi
+
+            dl="$RUNNER_TEMP/ticino-dist-$loc"
+            rm -rf "$dl"; mkdir -p "$dl"
+            if gh run download "$DEPLOY_RUN_ID" --name "ticino-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/ticino-dist-$loc.tar" ]; then
+              mkdir -p "dist/$(dirname "$sub")"
+              rm -rf "dist/$sub"
+              # `|| true`: a corrupt/truncated tar must fall through to the
+              # git-clone fallback below, not abort under `set -e`.
+              tar -C dist -xf "$dl/ticino-dist-$loc.tar" || true
+              rm -rf "$dl"
+              if [ -d "dist/$sub" ]; then
+                echo "rehydrated Ticino $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
+                continue
+              fi
+              echo "[rehydrate] ticino-$loc tar present but no $sub subtree after extract — falling back to git clone"
+            else
+              rm -rf "$dl"
+              echo "[rehydrate] ticino-$loc artifact absent — falling back to git clone"
+            fi
+
             tmp="$RUNNER_TEMP/rehydrate-ticino-$loc"
             rm -rf "$tmp"
             if ! git clone --depth 1 --single-branch --branch main \

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -11603,7 +11603,10 @@ ${staticAnalyticsHtml}
  if (!slugByLocale || typeof slugByLocale !== 'object') continue;
  // Sibling guard, same rationale as the active-jobs cross-locale bridge
  // below (PR #3052, isCompanyHubNamespaceSlug / issue #2976 recurrence).
- const ejCantonForCrossLocale = String((ej as { canton?: string })?.canton || DEFAULT_CANTON);
+ // expired-jobs records carry no `canton` field (only location/addressLocality),
+ // so resolve via the shared location→canton lookup like the other 3 call sites
+ // — a raw `ej.canton` read always falls back to DEFAULT_CANTON and never fires.
+ const ejCantonForCrossLocale = sharedResolveJobCanton(ej as { canton?: string; location?: string });
  for (const baseLocale of localeList) {
  const baseSlug = slugByLocale[baseLocale];
  if (!baseSlug) continue;

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -11601,6 +11601,9 @@ ${staticAnalyticsHtml}
  for (const ej of expiredJobsData) {
  const slugByLocale = (ej && ej.slugByLocale) as Record<string, string> | undefined;
  if (!slugByLocale || typeof slugByLocale !== 'object') continue;
+ // Sibling guard, same rationale as the active-jobs cross-locale bridge
+ // below (PR #3052, isCompanyHubNamespaceSlug / issue #2976 recurrence).
+ const ejCantonForCrossLocale = String((ej as { canton?: string })?.canton || DEFAULT_CANTON);
  for (const baseLocale of localeList) {
  const baseSlug = slugByLocale[baseLocale];
  if (!baseSlug) continue;
@@ -11625,6 +11628,7 @@ ${staticAnalyticsHtml}
  // rationale as the active-jobs block (jobSectorPagesPlugin owns
  // these paths).
  if (RESERVED_HUB_SLUGS.has(foreignSlug)) continue;
+ if (ejCantonForCrossLocale !== 'TI' && isCompanyHubNamespaceSlug(foreignSlug, baseLocale)) continue;
  const relPath = `${localePrefix[baseLocale]}/${sectionByLocale[baseLocale]}/${foreignSlug}`.replace(/\/+/g, '/');
  const relPathKey = relPath.replace(/^\//, '').replace(/\/+$/, '');
  // Active job wins if a live page already occupies this path.
@@ -12034,6 +12038,13 @@ ${staticAnalyticsHtml}
  let crossLocaleCount = 0;
  for (const job of validJobs) {
   await collector.awaitDrainSlot(6); // bound flush backlog (#1290)
+ // Sibling guard to the active-job/previousSlug legacy-TI bridges above
+ // (PR #3052, isCompanyHubNamespaceSlug): a non-TI job whose foreign slug
+ // merely starts with azienda-/company-/unternehmen-/entreprise- must not
+ // be mirrored into the reserved TI company-hub namespace below, or its
+ // canonical (the job's real, non-TI canton) drifts the
+ // cathedral-sector-hubs invariant (issue #2976 recurrence).
+ const jobCantonForCrossLocale = sharedResolveJobCanton(job as { canton?: string; location?: string });
  const slugPerLocale: Record<string, string> = {};
  for (const locale of localeList) {
  const s = localizedSlug(job, locale);
@@ -12079,6 +12090,7 @@ ${staticAnalyticsHtml}
  // reserved sector/city hub (same rationale as the previousSlugs
  // guard above — protects jobSectorPagesPlugin's curated hubs).
  if (RESERVED_HUB_SLUGS.has(foreignSlug)) continue;
+ if (jobCantonForCrossLocale !== 'TI' && isCompanyHubNamespaceSlug(foreignSlug, baseLocale)) continue;
  const relPath = `${localePrefix[baseLocale]}/${sectionByLocale[baseLocale]}/${foreignSlug}`.replace(/\/+/g, '/');
  const relPathKey = relPath.replace(/^\//, '').replace(/\/+$/, '');
  // Skip if an active job page already occupies this path (another

--- a/scripts/lib/push-ticino-shard.sh
+++ b/scripts/lib/push-ticino-shard.sh
@@ -166,7 +166,13 @@ push_ticino_shard() {
   )
   rc=$?
   rm -f "$keyfile"
-  rm -rf "$stage_src"
+  # NOTE: stage_src is intentionally NOT removed here. It holds the already
+  # CDN-offloaded copy of this locale's Ticino subtree — byte-identical to
+  # what was just force-pushed to the shard repo. The caller (deploy.yml,
+  # "Pack Ticino shard dist" step) packs it into a same-run tar artifact for
+  # post-deploy-validate-dist's rehydrate fast path (mirrors the locale-shard
+  # tar artifact), then removes it. Runners are ephemeral — leaving it behind
+  # when the caller doesn't consume it is a no-op cleanup-wise.
   if [ "$rc" -eq 0 ]; then
     touch "$RUNNER_TEMP/shard-ok-ticino-$loc"   # consumed by the strip step
     echo "✅ pushed ticino-$loc shard"


### PR DESCRIPTION
## Implementato

- Root-cause fix for the current validate-dist failure (run [28564001685](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28564001685/job/84690228053), issue #3232): `isCompanyHubNamespaceSlug` guard (introduced in PR #3052 for issue #2976) was only applied to 2 of 4 identical call sites in `build-plugins/jobsSeoPagesPlugin.ts`. The 2 missed siblings — `cross-locale-active-bridge` (~line 12093) and `cross-locale-expired-bridge` (~line 11631) — let a non-TI job whose foreign slug merely starts with `azienda-`/`company-`/`unternehmen-`/`entreprise-` get mirrored into the reserved TI company-hub URL namespace with a non-TI canonical, exactly reproducing the `cathedral-sector-hubs.test.ts` drift (Helvetia Versicherungen/VD, Implenia Zurich/ZH). Both sites now carry the same guard as their already-fixed siblings.
- Structural speed fix for the ~12min "Rehydrate Ticino shards" step (the dominant non-test cost in the job, per the per-step timing pull from the failing run): it only ever `git clone`'d 4 separate large shard repos sequentially with no fast path, unlike the sibling locale-shard rehydrate step which already had one. Mirrors that already-working pattern:
  - `scripts/lib/push-ticino-shard.sh`: preserves its staged, CDN-offloaded output (`stage_src`) instead of deleting it, so it can be packed for the fast path.
  - `.github/workflows/deploy.yml`: packs that staged output into a same-run tar artifact per locale (IT + non-IT legs) and uploads it.
  - `.github/workflows/post-deploy-validate-dist.yml`: downloads that artifact via `gh run download` and rehydrates from the tar; falls back to the original `git clone` only if the artifact is missing/corrupt (a locale/canton is never silently un-validated).
- Investigated `gate:seo-source` (~953s, the other dominant cost) as a sharding candidate: its 4 source validators already run concurrently on the runner's 4 vCPUs (existing `run_validator`/background-pids pattern, not new), and vitest's `threads` pool already saturates that same CPU budget internally within the single `gate:seo-source` process. Adding external `--shard=i/N` processes would only add redundant Node/vite-transform startup cost without adding real parallelism — verified this is a dead end before touching anything, not implemented.
- History review: `gh issue list --search "Validation Failure (dist)"` shows 34 issues since 2026-05-28, failing on many distinct validators/tests across runs (not one repeatable cause) — e.g. a separate historical run (28270979909, issue #2976) failed on `validate:sitemap-pages`, not this canton-drift bug. The fragility is a pattern of many distinct data-driven SEO bugs surfacing over time, not one systemic flakiness cause.

## Non implementato (ancora)

- `gate:seo-source`'s ~953s wall (vs. a ~110s figure cited in an old code comment) reflects organic growth of the site's `dist/` tree since that comment was written, not a discovered discrete bug. Root-causing which specific test(s) among the 78 in `tests/seo/` are now the long pole requires per-test timing profiled against a real built `dist/` — not safely doable in this environment right now: local disk headroom here is ~3.2GB (a real `dist/` artifact is 700MB+ compressed, several GB unpacked), and a full local SEO build is disallowed by project policy (OOM risk). `blocked: insufficient local disk/build headroom to profile safely` — next step for whoever picks this up: either run with more disk headroom, or add temporary per-test timing (`--reporter=verbose`) to the CI step for one live run and read the breakdown from the job log.
- The bug-class fix here is scoped to the TI legacy-section reconstruction mechanism (only TI has this "pre-cathedral URL" bridge); confirmed via grep there is no equivalent construct for other cantons needing the same fix.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both modified workflow files — valid YAML.
- [x] `npx tsc --noEmit -p .` — zero new errors in `jobsSeoPagesPlugin.ts`.
- [x] `npx vitest run tests/cross-canton-active-drift-bridge.test.ts tests/jobs-seo-pages-plugin.test.ts tests/previous-slugs-bridge.test.ts tests/bridge-canton-aware.test.ts` — 21/21 passing (source-regression guards for this exact bridge mechanism).
- [ ] `tests/seo/cathedral-sector-hubs.test.ts` is `dist/`-gated (no-op without a built site) — can only be verified against the next real deploy's `validate-dist` run. Revert trigger: if the next post-deploy `validate-dist` still shows any TI-namespace hub with a non-self/non-aggregator canonical, this fix is incomplete and needs re-investigation.
- [ ] Ticino-rehydrate wall-time improvement can only be measured on the next real deploy run (post-deploy-validate-dist only runs after a deploy). Revert trigger: if the tar-artifact fast path errors or the fallback silently swallows a Ticino locale, revert and re-investigate — the fallback path is unchanged git-clone logic so worst case is no regression vs. today.