### PR TITLE
fix(article-gen): unblock frontaliere evergreen generation on saturated corpus (#3138)

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -353,7 +353,17 @@ jobs:
               git commit -m "$COMMIT_SUBJECT"
             fi
           else
-            git commit -m "📰 Auto-generated blog article"
+            # No article published this run (evergreen pool exhausted /
+            # wall-budget hit) but tracker state still changed — e.g. the
+            # evergreen-rejected cross-run memory (#3138). The old generic
+            # "Auto-generated blog article" message would misleadingly label
+            # a state-only commit as an article publish.
+            CHANGED_PATHS="$(git diff --cached --name-only)"
+            if ! echo "$CHANGED_PATHS" | grep -qE '^data/(blog|swiss)-articles-data\.ts$'; then
+              git commit -m "chore(article-gen): update run-state tracker (nessun articolo questo run)"
+            else
+              git commit -m "📰 Auto-generated blog article"
+            fi
           fi
 
           # Push with centralized rebase-retry helper. The append-only files

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -107,6 +107,10 @@ import {
   loadEvergreenCounter as _loadEvergreenCounter,
   persistEvergreenCounter as _persistEvergreenCounter,
   rankAndSelectHeadlines as _rankAndSelectHeadlines,
+  loadEvergreenRejectedTracker as _loadEvergreenRejectedTracker,
+  isEvergreenRejected as _isEvergreenRejected,
+  appendEvergreenRejected as _appendEvergreenRejected,
+  persistEvergreenRejectedTracker as _persistEvergreenRejectedTracker,
 } from './lib/article-topic-selector.mjs';
 
 // ── Phase 3 — Discovery pool + quota controller ──────────────────
@@ -1791,6 +1795,15 @@ function buildDynamicEvergreenTopics() {
     { k: `frontaliere documenti primo giorno lavoro ticino ${y}`, a: `Checklist operativa per il primo giorno di lavoro in Ticino: documenti, contratto, permesso, dati bancari e assicurazione sanitaria.` },
     { k: `frontaliere scelta comune residenza italia svizzera ${y}`, a: `Come valutare residenza in Italia o Svizzera nel ${y}: costi, tempi di viaggio, sanità e fiscalità con criteri decisionali.` },
     { k: `frontaliere trasporti chiasso lugano abbonamenti ${y}`, a: `Guida pratica ai trasporti Chiasso-Lugano per frontalieri: treno, auto, parcheggi e abbonamenti con checklist dei costi da verificare.` },
+    // 6 pillars added 2026-07-02 (#3138): frontaliere evergreen pool was
+    // saturated against the 2728-article corpus, blocking generation on
+    // every run. New base themes, not variations of an existing pillar.
+    { k: `frontaliere cambio datore lavoro procedura permesso ${y}`, a: `Guida ${y} al cambio datore di lavoro per frontalieri: preavviso, rinnovo permesso G, continuità contributiva e documenti da aggiornare.` },
+    { k: `frontaliere infortunio lavoro assicurazione lainf ${y}`, a: `Assicurazione infortuni LAINF per frontalieri nel ${y}: copertura, procedura di denuncia e differenze con la malattia professionale.` },
+    { k: `frontaliere pensionamento anticipato pianificazione ${y}`, a: `Pensionamento anticipato per frontalieri ${y}: impatto su AVS/secondo pilastro, riduzione rendita e scenari di pianificazione ipotetici.` },
+    { k: `frontaliere nascita figlio anagrafe pratiche ${y}`, a: `Nascita di un figlio per famiglie frontaliere nel ${y}: iscrizione anagrafica, assegni familiari e pratiche consolari con checklist operativa.` },
+    { k: `frontaliere licenziamento diritti preavviso indennita ${y}`, a: `Licenziamento del lavoratore frontaliere nel ${y}: termini di preavviso, indennità e diritti con scenari ipotetici, non casi reali.` },
+    { k: `frontaliere formazione professionale riqualifica corsi ${y}`, a: `Formazione professionale e riqualifica per frontalieri nel ${y}: corsi riconosciuti, finanziamenti e come valutarne il ritorno pratico.` },
   ];
   const addOns = [
     'entro 20 km',
@@ -5706,6 +5719,12 @@ function evergreenTopicFamily(text) {
   if (hasAny(['disoccup'])) return 'disoccupazione';
   if (hasAny(['second']) && hasAny(['pilastr', 'lpp'])) return 'secondo-pilastro';
   if (hasAny(['auto']) && hasAny(['pendolar', 'frontali'])) return 'auto-pendolare';
+  // #3138 2026-07-02: pillar 8's 6 addon variants (entro/oltre 20km,
+  // famiglia/single, simulazione, errori comuni) are all near-duplicates
+  // of the base topic once it's published — this family classifies them
+  // together so pre-flight rejects the whole neighborhood in one shot
+  // instead of burning a generation attempt per addon.
+  if (hasAny(['resid']) && hasAny(['comun', 'scelt'])) return 'residenza-comune';
   return null;
 }
 
@@ -5734,7 +5753,9 @@ function preFlightEvergreenTopicCheck(candidate, existingArticles) {
   // ever reaching the loosened post-gen check. Kept in sync with TITLE_THRESHOLD.
   const PRE_FLIGHT_THRESHOLD = 0.72;
   const FAMILY_TOKEN_OVERLAP_THRESHOLD = 0.50;
-  const SATURATED_FAMILIES = new Set(['permesso-g-b', 'lamal-cmi', 'avs-inps', 'telelavoro', 'credito-imposta']);
+  // 'residenza-comune' added 2026-07-02 (#3138): pillar 8's base topic was
+  // just published, making its 6 addon variants immediate near-duplicates.
+  const SATURATED_FAMILIES = new Set(['permesso-g-b', 'lamal-cmi', 'avs-inps', 'telelavoro', 'credito-imposta', 'residenza-comune']);
 
   for (const existing of existingArticles) {
     const existingText = `${existing.title || ''} ${existing.excerpt || ''} ${existing.id || ''}`;
@@ -8058,6 +8079,13 @@ async function main() {
       const baseIndex = weekNum % topicPool.length;
       const totalTopics = topicPool.length;
 
+      // Cross-run duplicate memory (#3138, 2026-07-02): keywords already
+      // confirmed duplicate post-generation in a PREVIOUS cron run. Without
+      // this, a saturated pool (frontaliere: 2728 articles) gets the same
+      // doomed neighborhood re-attempted every 30-min run forever, since
+      // each run otherwise starts with zero memory of prior failures.
+      let evergreenRejectedTracker = _loadEvergreenRejectedTracker();
+
       // Pre-flight check — find first keyword that doesn't conflict with existing articles
       let selectedTopic = null;
       let selectedOffset = -1;
@@ -8066,6 +8094,10 @@ async function main() {
       for (let offset = 0; offset < totalTopics; offset++) {
         const idx = (baseIndex + offset) % totalTopics;
         const candidate = topicPool[idx];
+        if (_isEvergreenRejected(evergreenRejectedTracker, candidate.keyword)) {
+          console.error(`   ⏭️  [${idx}] "${candidate.keyword}" → già rigettato come duplicato in run precedente — skip`);
+          continue;
+        }
         const check = preFlightEvergreenCheck(candidate);
         if (check.duplicate) {
           console.error(`   ⏭️  [${idx}] "${candidate.keyword}" → simile a "${check.existingTitle}" [${check.existingId}] (${(check.sim * 100).toFixed(0)}%) — skip`);
@@ -8127,6 +8159,13 @@ async function main() {
         } catch (e) {
           const isDuplicate = e.message.includes('DUPLICATO');
           if (isDuplicate) captureDuplicateReasons(e.message);
+          if (isDuplicate && selectedTopic) {
+            // Cross-run memory (#3138): persist immediately (not batched at
+            // run end) so a mid-loop wallBudgetExceeded() break can't lose
+            // already-confirmed rejections from this run.
+            evergreenRejectedTracker = _appendEvergreenRejected(evergreenRejectedTracker, selectedTopic.keyword);
+            try { _persistEvergreenRejectedTracker(evergreenRejectedTracker); } catch { /* ignore */ }
+          }
           // Fact-check / quality failures → try next keyword instead of crashing.
           // Includes REGOLA #0 topic-gate aborts — same rationale as the proven-pool
           // branch above (~line 5946).
@@ -8149,6 +8188,10 @@ async function main() {
             if (triedOffsets.has(realOffset)) continue;
             const idx = (baseIndex + realOffset) % totalTopics;
             const candidate = topicPool[idx];
+            if (_isEvergreenRejected(evergreenRejectedTracker, candidate.keyword)) {
+              triedOffsets.add(realOffset);
+              continue;
+            }
             const check = preFlightEvergreenCheck(candidate);
             if (!check.duplicate) {
               selectedTopic = candidate;

--- a/scripts/lib/article-topic-selector.mjs
+++ b/scripts/lib/article-topic-selector.mjs
@@ -106,6 +106,15 @@ export const EXPERIMENTAL_RATIO_DEFAULT = 0.10;
 export const EVERGREEN_QUOTA_DEFAULT = 0.30;
 export const EVERGREEN_COUNTER_PATH = 'data/topic-candidates-evergreen-counter.json';
 
+// Cross-run memory of evergreen keywords confirmed duplicate post-generation
+// (#3138 follow-up, 2026-07-02). Without this, a saturated corpus (e.g.
+// frontaliere, 2728 articles) makes the SAME evergreen pool neighborhood
+// get re-attempted on every 30-min cron run — each run "forgets" what the
+// previous run already proved is a duplicate. Persisted here so the next
+// run can skip known-rejected keywords for free (no wasted generation).
+export const EVERGREEN_REJECTED_PATH = 'data/topic-candidates-evergreen-rejected.json';
+export const EVERGREEN_REJECTED_MAX_IDS = 500;
+
 // Scoring weights — per design doc.
 export const SCORE_WEIGHT_DEMAND = 0.6;
 export const SCORE_WEIGHT_DIVERSITY = 0.2;
@@ -919,6 +928,56 @@ export function shouldForceEvergreen(count, ratio = EVERGREEN_QUOTA_DEFAULT) {
   return ((Math.max(0, Math.floor(count)) % bucket) < threshold);
 }
 
+/**
+ * Load the evergreen-rejected tracker from disk. Returns `{keywords: []}`
+ * on any read/parse failure or missing file — byte-identical to today's
+ * behavior when the file has never been written.
+ */
+export function loadEvergreenRejectedTracker(opts = {}) {
+  const path = (opts && opts.path) || EVERGREEN_REJECTED_PATH;
+  const raw = loadJsonSafe(path);
+  if (!raw || typeof raw !== 'object' || !Array.isArray(raw.keywords)) {
+    return { keywords: [] };
+  }
+  return { keywords: raw.keywords.filter((x) => typeof x === 'string') };
+}
+
+/** Whether `keyword` was already confirmed a duplicate in a previous run. */
+export function isEvergreenRejected(tracker, keyword) {
+  if (!tracker || !Array.isArray(tracker.keywords) || !keyword) return false;
+  return tracker.keywords.includes(keyword);
+}
+
+/**
+ * Append a confirmed-duplicate keyword to the tracker (dedup, FIFO-capped
+ * at `EVERGREEN_REJECTED_MAX_IDS`, oldest evicted first). Pure — caller
+ * persists the returned tracker.
+ */
+export function appendEvergreenRejected(tracker, keyword, opts = {}) {
+  const maxIds = (opts && opts.maxIds) || EVERGREEN_REJECTED_MAX_IDS;
+  const keywords = Array.isArray(tracker?.keywords) ? tracker.keywords.slice() : [];
+  if (keyword && !keywords.includes(keyword)) keywords.push(keyword);
+  while (keywords.length > maxIds) keywords.shift();
+  return { keywords };
+}
+
+/** Persist the evergreen-rejected tracker to disk. */
+export function persistEvergreenRejectedTracker(tracker, opts = {}) {
+  const path = (opts && opts.path) || EVERGREEN_REJECTED_PATH;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({ keywords: Array.isArray(tracker?.keywords) ? tracker.keywords : [] }, null, 2) + '\n',
+      'utf-8',
+    );
+    return true;
+  } catch (e) {
+    console.warn(`[generator] could not write evergreen-rejected tracker to ${path}: ${e.message}`);
+    return false;
+  }
+}
+
 // ── Top-level orchestrator ────────────────────────────────────────
 
 /**
@@ -1188,4 +1247,10 @@ export default {
   persistExperimentalCounter,
   shouldUseExperimentalTier,
   rankAndSelectHeadlines,
+  EVERGREEN_REJECTED_PATH,
+  EVERGREEN_REJECTED_MAX_IDS,
+  loadEvergreenRejectedTracker,
+  isEvergreenRejected,
+  appendEvergreenRejected,
+  persistEvergreenRejectedTracker,
 };

--- a/tests/scripts/article-topic-selector.test.ts
+++ b/tests/scripts/article-topic-selector.test.ts
@@ -24,6 +24,10 @@ const {
   loadExperimentalCounter,
   persistExperimentalCounter,
   shouldUseExperimentalTier,
+  loadEvergreenRejectedTracker,
+  isEvergreenRejected,
+  appendEvergreenRejected,
+  persistEvergreenRejectedTracker,
   RANKER_MIN_SCORE,
   EXPERIMENTAL_RATIO_DEFAULT,
 } = selectorMod as any;
@@ -356,5 +360,47 @@ describe('experimental counter', () => {
     const p = join(workDir, 'counter.json');
     persistExperimentalCounter({ count: 7 }, { path: p });
     expect(loadExperimentalCounter({ path: p })).toEqual({ count: 7 });
+  });
+});
+
+describe('evergreen-rejected tracker (#3138)', () => {
+  it('returns {keywords:[]} when missing', () => {
+    expect(loadEvergreenRejectedTracker({ path: join(workDir, 'missing.json') })).toEqual({ keywords: [] });
+  });
+
+  it('isEvergreenRejected is false for an unseen keyword', () => {
+    expect(isEvergreenRejected({ keywords: ['frontaliere a'] }, 'frontaliere b')).toBe(false);
+  });
+
+  it('isEvergreenRejected is true once appended', () => {
+    const tracker = appendEvergreenRejected({ keywords: [] }, 'frontaliere scelta comune residenza italia svizzera 2026 entro 20 km');
+    expect(isEvergreenRejected(tracker, 'frontaliere scelta comune residenza italia svizzera 2026 entro 20 km')).toBe(true);
+  });
+
+  it('append dedupes the same keyword', () => {
+    let tracker = { keywords: [] };
+    tracker = appendEvergreenRejected(tracker, 'kw-a');
+    tracker = appendEvergreenRejected(tracker, 'kw-a');
+    expect(tracker.keywords).toEqual(['kw-a']);
+  });
+
+  it('append FIFO-caps at maxIds, evicting oldest first', () => {
+    let tracker = { keywords: [] };
+    for (let i = 0; i < 5; i++) tracker = appendEvergreenRejected(tracker, `kw-${i}`, { maxIds: 3 });
+    expect(tracker.keywords).toEqual(['kw-2', 'kw-3', 'kw-4']);
+  });
+
+  it('persists + reloads', () => {
+    const p = join(workDir, 'rejected.json');
+    const tracker = appendEvergreenRejected({ keywords: [] }, 'kw-x');
+    persistEvergreenRejectedTracker(tracker, { path: p });
+    expect(loadEvergreenRejectedTracker({ path: p })).toEqual({ keywords: ['kw-x'] });
+  });
+
+  it('does not mutate the input tracker (pure)', () => {
+    const original = { keywords: ['kw-a'] };
+    const next = appendEvergreenRejected(original, 'kw-b');
+    expect(original.keywords).toEqual(['kw-a']);
+    expect(next.keywords).toEqual(['kw-a', 'kw-b']);
   });
 });


### PR DESCRIPTION
## Implementato

Root cause (#3138): frontaliere (2728 articoli) esaurisce i 25 tentativi evergreen a OGNI run 30-min cron. Pillar 8 ("scelta comune residenza") appena pubblicato (commit `5f01782834b`) rende i suoi 6 addon-variant near-duplicati; zero memoria cross-run fa ri-tentare lo stesso vicinato condannato a ogni run.

Implementate 3 leve dalla diagnosi dell'owner sull'issue (2 delle 3 esplicitamente proposte, "Leva #1" + "Leva #3"):

- **Memoria cross-run duplicati** (`scripts/lib/article-topic-selector.mjs`): nuovo tracker `data/topic-candidates-evergreen-rejected.json` (FIFO cap 500 keyword). `loadEvergreenRejectedTracker`/`isEvergreenRejected`/`appendEvergreenRejected`/`persistEvergreenRejectedTracker`. Persistito immediatamente su ogni duplicato confermato post-generazione (non a fine run, per non perdere stato su `wallBudgetExceeded()` mid-loop). Consultato in entrambi i loop evergreen (`scripts/create-article.mjs`) per skippare keyword già note come duplicate, zero costo di generazione.
- **Family classifier `residenza-comune`**: `evergreenTopicFamily()` + `SATURATED_FAMILIES` (stesso pattern delle 5 famiglie esistenti: `permesso-g-b`, `lamal-cmi`, `avs-inps`, `telelavoro`, `credito-imposta`) → pre-flight rigetta l'intero vicinato pillar-8 in un colpo solo, senza generazione.
- **Pool evergreen ampliato**: 6 nuovi pillar dinamici (`buildDynamicEvergreenTopics()`) — temi base nuovi, NON variazioni di un pillar esistente: cambio datore lavoro, infortunio LAINF, pensionamento anticipato, nascita figlio, licenziamento, formazione professionale. Pool dinamico 9→15 pillar (63→105 entry), pool totale 116→158.
- **Workflow commit-message accuracy** (`.github/workflows/generate-article.yml`): un run che aggiorna solo il tracker (nessun articolo pubblicato) non usa più il messaggio fuorviante "📰 Auto-generated blog article" — nuovo `chore(article-gen): update run-state tracker (nessun articolo questo run)` quando `data/{blog,swiss}-articles-data.ts` non è tra i file staged.

Test: 6 nuovi test unit su `tests/scripts/article-topic-selector.test.ts` (tracker load/append/dedupe/FIFO-cap/persist-reload/purezza) — 40/40 verdi. Regressione: `tests/article-duplicate-detection.test.ts` (31/31) + `tests/scripts/create-article-integration.test.ts` (35/35) verdi, nessuna funzione toccata da questi due file diretta ma verificato per sicurezza. GitNexus impact pre-edit: LOW risk su tutte e 3 le funzioni target.

Sibling-pattern check (`node scripts/ci/check-sibling-patterns.mjs`): 2 file gemelli flaggati (`scripts/lib/demand-vocabulary.mjs`, `scripts/mine-topic-candidates.mjs`) — entrambi condividono solo `loadJsonSafe`, l'helper condiviso che ho CHIAMATO (non duplicato/reimplementato). **Falso positivo**: stesso helper riusato, non stesso antipattern — nessuna azione richiesta.

## Non implementato (ancora)

- **Leva #2 (priorità RSS/news fresche vs evergreen fallback)**: non necessaria per l'obiettivo dichiarato ("nessun run bloccato") — Leva #1+#3 già rimuovono il collo di bottiglia attuale (pool 158 topic + memoria permanente dei duplicati = settimane/mesi di margine). È un lavoro di ottimizzazione dell'ordine di priorità Phase1→Phase3→Phase2 genuinamente separato, non blocca il fix di questo bug. Se dopo osservazione live (prossimi run cron) il pool torna a saturarsi, riaprire come task distinto.
- Nessun'altra voce residua. Task considerato completo per lo scope dichiarato dall'owner: dopo il merge, verifica live sui prossimi run `generate-article.yml` per la sezione frontaliere (Task #5 di follow-up, non bloccante sul merge).