### PR TITLE
fix(firestore): add missing composite index for journalist dashboard

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -121,6 +121,14 @@
         { "fieldPath": "candidateUid", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "journalist_articles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "authorUid", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## Implementato

- Aggiunto composite index in `firestore.indexes.json` per `journalist_articles`: `authorUid ASC` + `updatedAt DESC`, `queryScope: COLLECTION`.
- Root cause: `services/journalistArticleService.ts:128` esegue `where('authorUid', '==', uid).orderBy('updatedAt', 'desc')` su `journalist_articles` — Firestore richiede un composite index per where+orderBy su campi diversi, non presente → `FirebaseError: The query requires an index` visibile in `/redazione/` (JournalistDashboardPage), "Impossibile caricare i tuoi articoli."
- `deploy-firestore-rules.yml` fira su modifica `firestore.indexes.json` e gira `firebase deploy --only firestore:indexes` (additivo, safe) al merge su main — nessun'azione manuale richiesta.

## Non implementato (ancora)

Nessuno.