### PR TITLE
fix(ci): remove scoped --allowedTools static-validation aborts in 4 claude-code-action workflows

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -190,14 +190,9 @@ jobs:
           # `github-actions[bot]` (re-label interno). Il PAT user `valerielinc-ops`
           # è un account umano → bypassa `allowed_bots`, già coperto dal gate `if`.
           allowed_bots: 'github-actions[bot], claude[bot], frontaliere-automation[bot]'
-          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
-          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
-          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
-          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
-          # syntax that cannot be statically analyzed", "Newline followed by # inside a
-          # quoted argument can hide arguments from path validation"). Preventivo qui
-          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
-          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped
+          # (rationale completo: post-merge-followup.yml claude_args comment, stesso
+          # fix, evita drift tra copie duplicate).
           claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di fix autonomo per la issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}"). Tier: ${{ steps.tier.outputs.tier }}.

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -190,7 +190,15 @@ jobs:
           # `github-actions[bot]` (re-label interno). Il PAT user `valerielinc-ops`
           # è un account umano → bypassa `allowed_bots`, già coperto dal gate `if`.
           allowed_bots: 'github-actions[bot], claude[bot], frontaliere-automation[bot]'
-          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
+          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
+          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
+          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
+          # syntax that cannot be statically analyzed", "Newline followed by # inside a
+          # quoted argument can hide arguments from path validation"). Preventivo qui
+          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
+          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di fix autonomo per la issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}"). Tier: ${{ steps.tier.outputs.tier }}.
 

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -93,14 +93,9 @@ jobs:
           # aborterebbe "non-human actor". Mai `*`.
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
-          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
-          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
-          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
-          # syntax that cannot be statically analyzed", "Newline followed by # inside a
-          # quoted argument can hide arguments from path validation"). Preventivo qui
-          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
-          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped
+          # (rationale completo: post-merge-followup.yml claude_args comment, stesso
+          # fix, evita drift tra copie duplicate).
           claude_args: "--max-turns 20 --model claude-sonnet-4-6 --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -93,7 +93,15 @@ jobs:
           # aborterebbe "non-human actor". Mai `*`.
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
+          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
+          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
+          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
+          # syntax that cannot be statically analyzed", "Newline followed by # inside a
+          # quoted argument can hide arguments from path validation"). Preventivo qui
+          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
+          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.
 

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -132,8 +132,7 @@ jobs:
           # cause della run schedulata che falliva 100% dal merge di PR #3157 con "User
           # does not have write access on this repository" (turns=0, $0 — falliva PRIMA
           # di invocare Claude, zero triage creato da allora). Stessi 3 nomi di
-          # allowed_bots: il job è già scoped Bash(gh:*)-only + `gh issue create`/`gh pr
-          # comment` (niente Write/Edit), quindi il bypass resta a basso rischio.
+          # allowed_bots.
           allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
           # max-turns DINAMICO = min(20 + 6*batch_count, 60), floor 20 (era 20 fisso per
@@ -143,7 +142,17 @@ jobs:
           # Se una sessione satura il cap (batch grande) → error_max_turns → run NON
           # success → watermark non avanza → la prossima run schedulata ri-copre la
           # finestra; l'idempotenza salta le PR già commentate, riprende le restanti.
-          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          # 2026-07-02: `--dangerously-skip-permissions` sostituisce l'`--allowedTools`
+          # scoped precedente, stesso fix di pr-review-loop.yml (owner-approved
+          # 2026-07-01). Lo scoped `Bash(gh:*)` fa validazione statica del comando e
+          # abortiva su sintassi shell legittima ("Contains shell syntax that cannot
+          # be statically analyzed", "Newline followed by # inside a quoted argument
+          # can hide arguments from path validation") durante il triage batch, run
+          # perse senza summary comment postato (watermark non avanza, prossima run
+          # schedulata ri-tenta). Rischio noto e accettato, stesso di pr-review-loop:
+          # il prompt resta constraint a `gh issue create`/`gh pr comment` read-only,
+          # ma il processo Claude ora ha accesso Bash/Write/Edit pieno.
+          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-4-6 --dangerously-skip-permissions"
           prompt: |
             Triage automatico follow-up in BATCH (${{ github.event_name }}).
             PR da processare (CSV): ${{ steps.collect.outputs.batch_prs }}

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -290,14 +290,9 @@ jobs:
           # error_max_turns al cap 30 (run 27390252111/27375482475/27373263097)
           # = peggior failure-rate del loop; ogni fail brucia ~8-14min di run
           # opus senza commit e lascia il rosso alla escalation needs-human.
-          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
-          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
-          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
-          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
-          # syntax that cannot be statically analyzed", "Newline followed by # inside a
-          # quoted argument can hide arguments from path validation"). Preventivo qui
-          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
-          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped
+          # (rationale completo: post-merge-followup.yml claude_args comment, stesso
+          # fix, evita drift tra copie duplicate).
           claude_args: "--max-turns 45 --model ${{ steps.guard.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di chiusura 🔴 per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.guard.outputs.tier }}. Round: ${{ steps.guard.outputs.round }}/2.

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -290,7 +290,15 @@ jobs:
           # error_max_turns al cap 30 (run 27390252111/27375482475/27373263097)
           # = peggior failure-rate del loop; ogni fail brucia ~8-14min di run
           # opus senza commit e lascia il rosso alla escalation needs-human.
-          claude_args: "--max-turns 45 --model ${{ steps.guard.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
+          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped,
+          # stesso fix di pr-review-loop.yml (owner-approved 2026-07-01) e
+          # post-merge-followup.yml (stesso giorno). Lo scoped Bash(...) fa validazione
+          # statica del comando e abortiva su sintassi shell legittima ("Contains shell
+          # syntax that cannot be statically analyzed", "Newline followed by # inside a
+          # quoted argument can hide arguments from path validation"). Preventivo qui
+          # (nessun fallimento osservato nelle run recenti), ma stesso costrutto
+          # sibling — owner ha approvato l'estensione preventiva a tutta la classe.
+          claude_args: "--max-turns 45 --model ${{ steps.guard.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di chiusura 🔴 per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.guard.outputs.tier }}. Round: ${{ steps.guard.outputs.round }}/2.
 


### PR DESCRIPTION
## Implementato
- `post-merge-followup.yml` claude_args switched from scoped `--allowedTools 'Bash(gh:*),Read,Grep,Glob'` to `--dangerously-skip-permissions`, matching the fix already applied to `pr-review-loop.yml` on 2026-07-01 (owner-approved).
- Root cause confirmed via last-50-run log audit: the scoped Bash allowlist does static command validation and rejects legitimate shell syntax, producing `"Contains shell syntax (string) that cannot be statically analyzed"` and `"Newline followed by # inside a quoted argument can hide arguments from path validation"` tool_result errors. These appeared in 7 of the last 15 completed runs (some concluded `success` anyway — Claude worked around the error, wasting turns; others concluded `failure`).
- Removed a now-stale comment justifying the old scoped-Bash restriction as the write-access-bypass risk mitigation (no longer accurate once the flag changed), added a new comment mirroring `pr-review-loop.yml`'s rationale and accepted-risk note.
- Verified: `permissions:` block on `post-merge-followup.yml` (`contents:read, pull-requests:write, issues:write, id-token:write`) already matches `pr-review-loop.yml`'s job permissions, plus an extra `actions:read` genuinely needed by `collect-followup-batch.mjs` for watermark reads — no change needed there.
- Sibling-pattern grep (AGENTS.md non-negotiable #6) found the same scoped-`--allowedTools` construct in `issue-fix.yml`, `pr-redflag-fixer.yml`, `lessons-harvester.yml`. No failures observed in their last 8 runs each, but owner approved extending the fix preventively to close the whole class rather than wait for each to fail independently — all three switched to `--dangerously-skip-permissions` in the same PR.

## Non implementato (ancora)
Nessuno.