### PR TITLE
feat(events): nationwide event sourcing beyond Ticino (guidle.com, myswitzerland.com) (#3125)

### DIFF
--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -1,9 +1,14 @@
-name: Crawl Ticino events (tio.ch agenda)
+name: Crawl Ticino + nationwide events (tio.ch, guidle, myswitzerland)
 
-# Refreshes the per-comune events dataset (issue #2963). Quota-free crawler
-# (plain fetch + jsdom, no API key, no Claude). Commits data/events.json +
-# the per-source slice straight to main; the events test runs BEFORE commit as
-# a gate so a malformed dataset can never turn main red (AGENTS.md:
+# Refreshes the events dataset (issue #2963, extended nationwide by #3125).
+# Three quota-free crawlers (plain fetch + jsdom, no API key, no Claude):
+# tio.ch agenda (Ticino only) + guidle.com and myswitzerland.com (all of
+# Switzerland). Each writes its own per-source slice
+# (data/events/by-source/<key>.json); scripts/assemble-events-dataset.mjs
+# merges them (by-id, then a cross-source fuzzy dedup pass) into
+# data/events.json. Commits data/events.json + every per-source slice +
+# mirrored event images straight to main; the events test runs BEFORE commit
+# as a gate so a malformed dataset can never turn main red (AGENTS.md:
 # "data-refresh che committa su main = stesso gate test di una PR").
 #
 # NOTE: named crawl-events.yml (NOT update-jobs-*.yml) on purpose, so the jobs
@@ -32,7 +37,13 @@ permissions:
 jobs:
   crawl-events:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # 12 min was enough for the single TI-only tio-agenda crawl. Nationwide
+    # guidle.com + myswitzerland.com are new (#3125) and a real full-catalog
+    # crawl duration hasn't been observed in production yet — 35 min is a
+    # deliberately generous placeholder judgment call, not a measurement.
+    # Revisit (tighten) once a few live runs show actual guidle/myswitzerland
+    # timing.
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -52,6 +63,12 @@ jobs:
 
       - name: Crawl tio.ch agenda
         run: node scripts/crawl-tio-agenda.mjs --days "${{ github.event.inputs.days || '21' }}"
+
+      - name: Crawl guidle.com (nationwide)
+        run: node scripts/crawl-guidle-events.mjs
+
+      - name: Crawl myswitzerland.com (nationwide)
+        run: node scripts/crawl-myswitzerland-events.mjs
 
       - name: Assemble events dataset
         run: node scripts/assemble-events-dataset.mjs --stats
@@ -73,18 +90,27 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add data/events.json data/events/by-source/tio-agenda.json \
+          git add data/events.json \
+            data/events/by-source/tio-agenda.json \
+            data/events/by-source/guidle.json \
+            data/events/by-source/myswitzerland.json \
             services/locales/blog-body/it/eventi-weekend-ticino.ts \
             services/locales/blog-body/en/eventi-weekend-ticino.ts \
             services/locales/blog-body/de/eventi-weekend-ticino.ts \
             services/locales/blog-body/fr/eventi-weekend-ticino.ts \
             data/blog-articles-data.ts services/seo/seo-blog-5.ts public/sitemap-blog.xml
+          # No-hotlink mirrored event images (scripts/lib/events-utils.mjs
+          # mirrorEventImage → public/images/events/): guarded, unlike the
+          # slice files above, because the dir only exists once a crawler has
+          # actually mirrored at least one image this run — `git add` on a
+          # missing path errors under `set -e` and would abort the commit.
+          [ -d public/images/events ] && git add public/images/events/ || true
           if git diff --cached --quiet; then
             echo "No events diff, skipping commit"
             exit 0
           fi
 
-          git commit -m "📅 Refresh Ticino events agenda + weekend-digest article (tio.ch)"
+          git commit -m "📅 Refresh Ticino + nationwide events agenda + weekend-digest article (tio.ch, guidle, myswitzerland)"
 
           for attempt in 1 2 3 4 5; do
             if git push origin HEAD:main; then
@@ -106,6 +132,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
-            --title "Crawler Failure: Ticino events (tio.ch agenda)" \
+            --title "Crawler Failure: events pipeline (tio.ch, guidle, myswitzerland)" \
             --body "The crawl-events workflow failed. Check the run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --label "crawler" || true

--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -105,6 +105,11 @@ jobs:
           # actually mirrored at least one image this run — `git add` on a
           # missing path errors under `set -e` and would abort the commit.
           [ -d public/images/events ] && git add public/images/events/ || true
+          # Cross-run cursors for the checkpointed nationwide crawlers
+          # (scripts/lib/crawl-checkpoint.mjs) — must persist between
+          # scheduled runs so guidle/myswitzerland resume instead of
+          # restarting the catalog walk from 0 every day.
+          [ -d data/events/checkpoints ] && git add data/events/checkpoints/ || true
           if git diff --cached --quiet; then
             echo "No events diff, skipping commit"
             exit 0

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -48,6 +48,7 @@ import {
   weekWindow,
   overlapsWindow,
 } from '../scripts/lib/events-utils.mjs';
+import { getCantonLabel, type CantonLocale } from '../services/cantonList';
 
 type Locale = 'it' | 'en' | 'de' | 'fr';
 
@@ -80,6 +81,20 @@ interface SiteEvent {
   // resolveItalianFrontierComuni in events-utils.mjs) — attached at assemble
   // time so a frontaliere on the Italian side can find "eventi vicino a te".
   italianFrontierComuni?: string[];
+  // Some sources (guidle, myswitzerland — #3125) expose real per-locale
+  // translations instead of a single source-language string. Optional and
+  // partial: any locale missing from the map falls back to `title`/
+  // `description` via localizedTitle/localizedDescription below.
+  titleByLocale?: Partial<Record<Locale, string>>;
+  descriptionByLocale?: Partial<Record<Locale, string>>;
+}
+
+function localizedTitle(event: SiteEvent, locale: Locale): string {
+  return event.titleByLocale?.[locale] || event.title;
+}
+
+function localizedDescription(event: SiteEvent, locale: Locale): string | undefined {
+  return event.descriptionByLocale?.[locale] || event.description;
 }
 
 const LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
@@ -470,7 +485,8 @@ export function zurichOffset(isoDate: string): string {
  * Event field is emitted with a safe fallback.
  */
 export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string): Record<string, unknown> {
-  const locality = event.comune || 'Canton Ticino';
+  const cantonName = getCantonLabel(event.canton || 'TI', locale as CantonLocale);
+  const locality = event.comune || cantonName;
   const venueName = event.venue || locality;
   const offset = zurichOffset(event.startDate);
   const startIso = event.startTime ? `${event.startDate}T${event.startTime}:00${offset}` : event.startDate;
@@ -480,20 +496,22 @@ export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string)
   const endIso = hasMultiDay ? (event.endDate as string) : startIso;
   const cat = categoryLabel(event.category, locale);
   const when = humanDate(event.startDate, locale);
+  const title = localizedTitle(event, locale);
   const synthDescription =
-    `${event.title} — ${cat} ${COPY[locale].at} ${venueName} (${locality}, Ticino), ${when}` +
+    `${title} — ${cat} ${COPY[locale].at} ${venueName} (${locality}, ${cantonName}), ${when}` +
     `${event.startTime ? ` ${event.startTime}` : ''}. ${event.sourceName}.`;
   // Nationwide sources (guidle, myswitzerland) crawl a real description —
   // prefer it over the synthesized one when it clears the >=30 char gate
   // validate-structured-data-completeness.mjs enforces.
+  const rawDescription = localizedDescription(event, locale);
   const description =
-    event.description && event.description.trim().length >= 30 ? event.description.trim() : synthDescription;
+    rawDescription && rawDescription.trim().length >= 30 ? rawDescription.trim() : synthDescription;
   // organizer is per-EVENT_SOURCES entry, not the single tio-agenda constant
   // (§6 — one registry, no per-file duplicate of source metadata).
   const organizerSource = EVENT_SOURCES[event.sourceKey] || SOURCE;
   return {
     '@type': 'Event',
-    name: event.title,
+    name: title,
     startDate: startIso,
     endDate: endIso,
     eventStatus: 'https://schema.org/EventScheduled',
@@ -506,14 +524,14 @@ export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string)
         ...(event.address?.street ? { streetAddress: event.address.street } : {}),
         ...(event.address?.postalCode ? { postalCode: event.address.postalCode } : {}),
         addressLocality: locality,
-        addressRegion: 'TI',
+        addressRegion: event.canton || 'TI',
         addressCountry: 'CH',
       },
       ...(event.geo
         ? { geo: { '@type': 'GeoCoordinates', latitude: event.geo.lat, longitude: event.geo.lng } }
         : {}),
     },
-    description: description.length >= 30 ? description : `${description} Evento in Ticino.`,
+    description: description.length >= 30 ? description : `${description} Evento in ${cantonName}.`,
     image: event.imageUrl ? absoluteImageUrl(event.imageUrl) : SITE_IMAGE,
     // On a detail page `url` is OUR canonical page (the page about the event);
     // the original source is then surfaced as `sameAs`. On aggregate pages
@@ -559,9 +577,10 @@ function renderEventCard(event: SiteEvent, locale: Locale, detailHref?: string |
   const time = event.startTime ? ` · ${esc(event.startTime)}` : '';
   const place = event.venue ? `${esc(event.venue)}` : '';
   const comuneTag = event.comune ? `<span class="text-subtle">${esc(event.comune)}</span>` : '';
+  const cardTitle = localizedTitle(event, locale);
   const titleLink = detailHref
-    ? `<a class="text-link hover:text-link-hover" href="${esc(detailHref)}">${esc(event.title)}</a>`
-    : `<a class="text-link hover:text-link-hover" href="${esc(event.url)}" rel="nofollow noopener" target="_blank">${esc(event.title)}</a>`;
+    ? `<a class="text-link hover:text-link-hover" href="${esc(detailHref)}">${esc(cardTitle)}</a>`
+    : `<a class="text-link hover:text-link-hover" href="${esc(event.url)}" rel="nofollow noopener" target="_blank">${esc(cardTitle)}</a>`;
   return `<article class="rounded-md border border-edge bg-surface p-4">
     <div class="flex flex-wrap items-center gap-2 text-xs">
       <span class="rounded-full border border-info-border bg-info-subtle px-2.5 py-0.5 font-semibold text-info">${esc(cat)}</span>
@@ -971,6 +990,7 @@ export function renderEventDetailPage(params: {
   detailHref: DetailHref;
 }): { urlPath: string; html: string; wordCount: number } {
   const { locale, event, comune, eventSlug, sameComuneEvents, dateStamp, distDir, detailHref } = params;
+  const title = localizedTitle(event, locale);
   const copy = COPY[locale];
   const dc = DETAIL_COPY[locale];
   const canonicalPath = pathForEventDetail(locale, comune, eventSlug);
@@ -989,12 +1009,12 @@ export function renderEventDetailPage(params: {
       <span class="mx-2">/</span>
       <a class="text-link hover:text-link-hover" href="${comunePath}">${esc(comune)}</a>
       <span class="mx-2">/</span>
-      <span>${esc(event.title)}</span>
+      <span>${esc(title)}</span>
     </nav>
 
     <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
       <span class="inline-block rounded-full border border-info-border bg-info-subtle px-2.5 py-0.5 text-xs font-semibold text-info">${esc(cat)}</span>
-      <h1 class="mt-3 text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(event.title)}</h1>
+      <h1 class="mt-3 text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(title)}</h1>
       <p class="mt-3 text-base leading-7 text-body">${esc(dc.lede(when, time, event.venue ? event.venue : '', comune))}</p>
     </header>
 
@@ -1012,7 +1032,7 @@ export function renderEventDetailPage(params: {
 
     <section class="mt-8">
       <h2 class="text-2xl font-bold text-heading">${esc(dc.aboutTitle)}</h2>
-      <p class="mt-3 text-base leading-7 text-body">${esc(dc.about(event.title, comune, `${when}${event.startTime ? ` (${event.startTime})` : ''}`, cat))}</p>
+      <p class="mt-3 text-base leading-7 text-body">${esc(dc.about(title, comune, `${when}${event.startTime ? ` (${event.startTime})` : ''}`, cat))}</p>
     </section>
 
     <section class="mt-8 rounded-md border border-edge bg-surface p-5">
@@ -1033,7 +1053,7 @@ export function renderEventDetailPage(params: {
 
     ${renderFaq(
       [
-        { q: dc.faqQ1(event.title), a: dc.faqA1(comune, when) },
+        { q: dc.faqQ1(title), a: dc.faqA1(comune, when) },
         { q: dc.faqQ2(comune), a: dc.faqA2(comune) },
       ],
       copy.faqTitle,
@@ -1048,14 +1068,14 @@ export function renderEventDetailPage(params: {
       { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` },
       { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale)}` },
       { '@type': 'ListItem', position: 3, name: comune, item: `${BASE_URL}${comunePath}` },
-      { '@type': 'ListItem', position: 4, name: event.title, item: canonicalUrl },
+      { '@type': 'ListItem', position: 4, name: title, item: canonicalUrl },
     ],
   });
   const faqLd = inlineScriptJson({
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: dc.faqQ1(event.title), acceptedAnswer: { '@type': 'Answer', text: dc.faqA1(comune, when) } },
+      { '@type': 'Question', name: dc.faqQ1(title), acceptedAnswer: { '@type': 'Answer', text: dc.faqA1(comune, when) } },
       { '@type': 'Question', name: dc.faqQ2(comune), acceptedAnswer: { '@type': 'Answer', text: dc.faqA2(comune) } },
     ],
   });
@@ -1063,8 +1083,8 @@ export function renderEventDetailPage(params: {
   const wordCount = countHtmlBodyWords(body);
   const html = buildSeoPageHtml({
     locale,
-    title: dc.metaTitle(event.title, comune),
-    description: dc.metaDesc(event.title, comune, when),
+    title: dc.metaTitle(title, comune),
+    description: dc.metaDesc(title, comune, when),
     canonicalUrl,
     hreflangHtml: buildEventAlternates(comune, eventSlug),
     robots: wordCount >= MIN_INDEXABLE_WORDS ? 'index,follow' : 'noindex,follow',

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -42,7 +42,8 @@ import {
   slugifyComune,
   slugifyEvent,
   EVENT_SOURCES,
-  EVENTS_BASE_PATH,
+  eventsBasePathForCanton,
+  germanCantonPreposition,
   EVENTS_DIGEST_SLUGS,
   weekendWindow,
   weekWindow,
@@ -102,9 +103,20 @@ const SITEMAP_NAME = 'sitemap-eventi.xml';
 const SOURCE = EVENT_SOURCES['tio-agenda'];
 const SITE_IMAGE = `${BASE_URL}/og-image.png`;
 
-// Localized base segment per locale — shared with the FB poster and the
-// weekend-digest article generator (AGENTS.md §6, one source of truth).
-const BASE_PATH: Record<Locale, string> = EVENTS_BASE_PATH;
+// Localized base segment per canton+locale — shared with the FB poster and
+// the weekend-digest article generator (AGENTS.md §6, one source of truth).
+// `eventsBasePathForCanton('TI')` is byte-identical to the legacy TI-only
+// constant it replaces (see tests/events-nationwide-sources.test.ts).
+const basePathCache = new Map<string, Record<Locale, string>>();
+function basePathFor(canton: string): Record<Locale, string> {
+  const code = String(canton || 'TI').toUpperCase();
+  let cached = basePathCache.get(code);
+  if (!cached) {
+    cached = eventsBasePathForCanton(code) as Record<Locale, string>;
+    basePathCache.set(code, cached);
+  }
+  return cached;
+}
 
 const LOCALE_OG: Record<Locale, string> = {
   it: 'it_IT',
@@ -347,6 +359,114 @@ const COPY: Record<Locale, Copy> = {
   },
 };
 
+// ── Canton-agnostic copy (any canton other than TI) ─────────────────────────
+// TI keeps the COPY/DETAIL_COPY/DIGESTS objects above completely untouched —
+// verbatim, hand-tuned Italian/German/French idiom (contracted articles like
+// "del Ticino", the "im Tessin" preposition, "au/du Tessin") that does NOT
+// generalize safely to an arbitrary canton name (see cantonHubEditorial.ts for
+// the same documented tradeoff). For every other canton we derive equivalent,
+// grammatically-safe copy by substituting the small set of Ticino/Tessin
+// phrases with the canton's localized display name, trading a little
+// idiomatic polish (irregular per-canton demonyms/genitives, e.g. German
+// "Zürcher"/"Walliser", are out of scope — a full 26-canton declension table
+// is not worth building) for text that is always correct.
+function cantonSubstitutionRules(canton: string, locale: Locale): Array<[RegExp, string]> {
+  const display = getCantonLabel(canton, locale as CantonLocale);
+  switch (locale) {
+    case 'it':
+      return [
+        [/\bin tutto il Ticino\b/g, `in ${display}`],
+        [/\bdel Ticino\b/g, `di ${display}`],
+        [/\(Ticino\)/g, `(${display})`],
+        [/\bin Ticino\b/g, `in ${display}`],
+        [/\bticinesi\b/g, 'locali'],
+        [/\bTicino\b/g, display],
+      ];
+    case 'en':
+      return [[/\bTicino\b/g, display]];
+    case 'de': {
+      const prep = germanCantonPreposition(canton);
+      return [
+        [/Tessiner öffentlichen Verkehr\b/g, 'öffentlichen Verkehrsmitteln'],
+        [/\bim ganzen Tessin\b/g, `${prep} ${display}`],
+        [/\bim Tessin\b/g, `${prep} ${display}`],
+        [/\bdes Tessins\b/g, `von ${display}`],
+        [/Tessiner /g, `${display}-`],
+        [/\(Tessin\)/g, `(${display})`],
+        [/\bTessin\b/g, display],
+      ];
+    }
+    case 'fr':
+      return [
+        [/\bdans tout le Tessin\b/g, `à ${display}`],
+        [/\bau Tessin\b/g, `à ${display}`],
+        [/\bdu Tessin\b/g, `de ${display}`],
+        [/\btessinois\b/g, 'locaux'],
+        [/\(Tessin\)/g, `(${display})`],
+        [/\bTessin\b/g, display],
+      ];
+  }
+}
+
+function applyCantonSubstitution(text: string, rules: Array<[RegExp, string]>): string {
+  return rules.reduce((acc, [re, repl]) => acc.replace(re, repl), text);
+}
+
+const copyCache = new Map<string, Copy>();
+/** TI → the literal, hand-tuned `COPY[locale]` object (byte-identical, zero
+ * risk). Any other canton → a derived copy with the safe substitution rules
+ * above applied to every field that mentions the canton name. */
+function copyFor(canton: string, locale: Locale): Copy {
+  if (canton.toUpperCase() === 'TI') return COPY[locale];
+  const cacheKey = `${canton}|${locale}`;
+  const cached = copyCache.get(cacheKey);
+  if (cached) return cached;
+  const rules = cantonSubstitutionRules(canton, locale);
+  const base = COPY[locale];
+  const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const out: Copy = {
+    ...base,
+    hubTitle: sub(base.hubTitle),
+    hubH1: sub(base.hubH1),
+    hubLede: sub(base.hubLede),
+    comuneLede: (c: string) => sub(base.comuneLede(c)),
+    hubDesc: sub(base.hubDesc),
+    comuneDesc: (c: string) => sub(base.comuneDesc(c)),
+    methodology: sub(base.methodology),
+    faqHubQ1: sub(base.faqHubQ1),
+    faqHubA2: sub(base.faqHubA2),
+    faqComuneA1: (c: string) => sub(base.faqComuneA1(c)),
+    hubLabel: sub(base.hubLabel),
+    allEvents: sub(base.allEvents),
+  };
+  copyCache.set(cacheKey, out);
+  return out;
+}
+
+type DigestCopy = { title: string; h1: string; lede: string; desc: string; faqQ: string; faqA: string };
+const digestCopyCache = new Map<string, DigestCopy>();
+/** Same TI-verbatim / non-TI-substituted split as `copyFor`, applied to a
+ * single `DigestDef.copy[locale]` entry. */
+function digestCopyFor(def: { key: string; copy: Record<Locale, DigestCopy> }, canton: string, locale: Locale): DigestCopy {
+  const base = def.copy[locale];
+  if (canton.toUpperCase() === 'TI') return base;
+  const cacheKey = `${def.key}|${canton}|${locale}`;
+  const cached = digestCopyCache.get(cacheKey);
+  if (cached) return cached;
+  const rules = cantonSubstitutionRules(canton, locale);
+  const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const out: DigestCopy = {
+    title: sub(base.title),
+    h1: sub(base.h1),
+    lede: sub(base.lede),
+    desc: sub(base.desc),
+    faqQ: sub(base.faqQ),
+    faqA: sub(base.faqA),
+  };
+  digestCopyCache.set(cacheKey, out);
+  return out;
+}
+
 const CATEGORY_LABEL: Record<string, Record<Locale, string>> = {
   arte: { it: 'Arte', en: 'Art', de: 'Kunst', fr: 'Art' },
   musica: { it: 'Musica', en: 'Music', de: 'Musik', fr: 'Musique' },
@@ -374,8 +494,36 @@ function esc(value: unknown): string {
     .replace(/"/g, '&quot;');
 }
 
-function pathFor(locale: Locale, comune?: string): string {
-  const base = BASE_PATH[locale];
+/**
+ * Nationwide sources (guidle, myswitzerland — #3125) may mix with tio-agenda
+ * on the same hub/comune/digest page. The "source" attribution footer must
+ * list every DISTINCT source actually present among the events shown, not
+ * just the single hardcoded tio-agenda constant — each linking to its own
+ * EVENT_SOURCES homepage. For a page that (still) only has one source this
+ * renders byte-identical to the previous single-link markup.
+ */
+function distinctEventSources(events: SiteEvent[]): Array<{ key: string; label: string; homepage: string }> {
+  const seen = new Map<string, { key: string; label: string; homepage: string }>();
+  for (const e of events) {
+    const src = EVENT_SOURCES[e.sourceKey] || SOURCE;
+    if (!seen.has(src.key)) seen.set(src.key, { key: src.key, label: src.label, homepage: src.homepage });
+  }
+  if (seen.size === 0) seen.set(SOURCE.key, { key: SOURCE.key, label: SOURCE.label, homepage: SOURCE.homepage });
+  return [...seen.values()];
+}
+
+function renderSourceAttribution(events: SiteEvent[], copy: Copy, dateStamp: string): string {
+  const links = distinctEventSources(events)
+    .map(
+      (s) =>
+        `<a class="text-link hover:text-link-hover" href="${esc(s.homepage)}" rel="nofollow noopener" target="_blank">${esc(s.label)}</a>`,
+    )
+    .join(', ');
+  return `${esc(copy.updated)}: <time datetime="${dateStamp}">${dateStamp}</time> · ${esc(copy.source)}: ${links}`;
+}
+
+function pathFor(locale: Locale, canton: string, comune?: string): string {
+  const base = basePathFor(canton)[locale];
   return comune ? `${base}/${slugifyComune(comune)}/` : `${base}/`;
 }
 
@@ -406,22 +554,24 @@ function weekendSet(todayIso: string): Set<string> {
   return out;
 }
 
-function buildAlternates(comune?: string): string {
-  return LOCALES.map((locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, comune)}">`)
-    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', comune)}">`)
+function buildAlternates(canton: string, comune?: string): string {
+  return LOCALES.map((locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, canton, comune)}">`)
+    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', canton, comune)}">`)
     .join('\n');
 }
 
-/** Canonical path of a per-event detail page: `<base>/<comune>/<event-slug>/`. */
-export function pathForEventDetail(locale: Locale, comune: string, eventSlug: string): string {
-  return `${BASE_PATH[locale]}/${slugifyComune(comune)}/${eventSlug}/`;
+/** Canonical path of a per-event detail page: `<base>/<comune>/<event-slug>/`.
+ * `canton` defaults to 'TI' so existing 3-arg callers (tests, the FB poster)
+ * keep resolving the legacy Ticino path untouched. */
+export function pathForEventDetail(locale: Locale, comune: string, eventSlug: string, canton: string = 'TI'): string {
+  return `${basePathFor(canton)[locale]}/${slugifyComune(comune)}/${eventSlug}/`;
 }
 
-function buildEventAlternates(comune: string, eventSlug: string): string {
+function buildEventAlternates(canton: string, comune: string, eventSlug: string): string {
   return LOCALES.map(
-    (locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForEventDetail(locale, comune, eventSlug)}">`,
+    (locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForEventDetail(locale, comune, eventSlug, canton)}">`,
   )
-    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForEventDetail('it', comune, eventSlug)}">`)
+    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForEventDetail('it', comune, eventSlug, canton)}">`)
     .join('\n');
 }
 
@@ -634,18 +784,22 @@ function distinctCategories(events: SiteEvent[]): number {
   return new Set(events.map((e) => e.category).filter(Boolean)).size;
 }
 
-function renderHubPage(params: {
+export function renderHubPage(params: {
   locale: Locale;
+  canton: string;
   events: SiteEvent[];
   byComune: Map<string, SiteEvent[]>;
   dateStamp: string;
   weekendDays: Set<string>;
   distDir: string;
   detailHref?: DetailHref;
+  /** Other cantons that also have a hub this build (BFS cross-link, so a
+   * non-TI hub stays reachable beyond the sitemap/hreflang alternates). */
+  otherCantons?: string[];
 }): { urlPath: string; html: string; wordCount: number } {
-  const { locale, events, byComune, dateStamp, weekendDays, distDir, detailHref } = params;
-  const copy = COPY[locale];
-  const canonicalPath = pathFor(locale);
+  const { locale, canton, events, byComune, dateStamp, weekendDays, distDir, detailHref, otherCantons = [] } = params;
+  const copy = copyFor(canton, locale);
+  const canonicalPath = pathFor(locale, canton);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
   const upcoming = events.slice(0, 60);
@@ -654,12 +808,24 @@ function renderHubPage(params: {
   const comuneGrid = comuneEntries
     .map(
       ([comune, list]) =>
-        `<a class="rounded-md border border-edge bg-surface p-4 hover:border-accent-border" href="${pathFor(locale, comune)}">
+        `<a class="rounded-md border border-edge bg-surface p-4 hover:border-accent-border" href="${pathFor(locale, canton, comune)}">
           <span class="block text-sm font-semibold text-heading">${esc(comune)}</span>
           <span class="mt-1 block text-xs text-muted">${list.length} ${esc(copy.eventsWord)}</span>
         </a>`,
     )
     .join('');
+
+  const cantonSwitcher =
+    otherCantons.length > 0
+      ? `<section class="mt-6 flex flex-wrap gap-2">
+      ${otherCantons
+        .map(
+          (c) =>
+            `<a class="rounded-full border border-edge bg-surface-raised px-3 py-1 text-xs font-semibold text-heading hover:border-accent-border" href="${pathFor(locale, c)}">${esc(getCantonLabel(c, locale as CantonLocale))}</a>`,
+        )
+        .join('')}
+    </section>`
+      : '';
 
   const body = `<div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
     <nav class="mb-4 text-sm text-muted" aria-label="Breadcrumb">
@@ -671,8 +837,10 @@ function renderHubPage(params: {
     <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
       <h1 class="max-w-4xl text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(copy.hubH1)}</h1>
       <p class="mt-3 max-w-3xl text-base leading-7 text-body">${esc(copy.hubLede)}</p>
-      <p class="mt-3 text-sm text-muted">${esc(copy.updated)}: <time datetime="${dateStamp}">${dateStamp}</time> · ${esc(copy.source)}: <a class="text-link hover:text-link-hover" href="${esc(SOURCE.homepage)}" rel="nofollow noopener" target="_blank">${esc(SOURCE.label)}</a></p>
+      <p class="mt-3 text-sm text-muted">${renderSourceAttribution(events, copy, dateStamp)}</p>
     </header>
+
+    ${cantonSwitcher}
 
     <dl class="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
       ${renderMetric(copy.statEvents, String(events.length))}
@@ -681,7 +849,7 @@ function renderHubPage(params: {
       ${renderMetric(copy.statCategories, String(distinctCategories(events)))}
     </dl>
 
-    ${renderDigestNav(locale)}
+    ${renderDigestNav(locale, canton)}
 
     <section class="mt-8">
       <h2 class="text-2xl font-bold text-heading">${esc(copy.upcoming)}</h2>
@@ -743,7 +911,7 @@ function renderHubPage(params: {
     title: copy.hubTitle,
     description: copy.hubDesc,
     canonicalUrl,
-    hreflangHtml: buildAlternates(),
+    hreflangHtml: buildAlternates(canton),
     robots: wordCount >= MIN_INDEXABLE_WORDS ? 'index,follow' : 'noindex,follow',
     ogLocale: LOCALE_OG[locale],
     bodyHtml: body,
@@ -754,8 +922,9 @@ function renderHubPage(params: {
   return { urlPath: canonicalPath, html, wordCount };
 }
 
-function renderComunePage(params: {
+export function renderComunePage(params: {
   locale: Locale;
+  canton: string;
   comune: string;
   events: SiteEvent[];
   dateStamp: string;
@@ -763,9 +932,9 @@ function renderComunePage(params: {
   distDir: string;
   detailHref?: DetailHref;
 }): { urlPath: string; html: string; wordCount: number } {
-  const { locale, comune, events, dateStamp, weekendDays, distDir, detailHref } = params;
-  const copy = COPY[locale];
-  const canonicalPath = pathFor(locale, comune);
+  const { locale, canton, comune, events, dateStamp, weekendDays, distDir, detailHref } = params;
+  const copy = copyFor(canton, locale);
+  const canonicalPath = pathFor(locale, canton, comune);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const list = events.slice(0, 40);
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
@@ -774,7 +943,7 @@ function renderComunePage(params: {
     <nav class="mb-4 text-sm text-muted" aria-label="Breadcrumb">
       <a class="text-link hover:text-link-hover" href="/">${esc(HOME_LABEL[locale])}</a>
       <span class="mx-2">/</span>
-      <a class="text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.hubLabel)}</a>
+      <a class="text-link hover:text-link-hover" href="${pathFor(locale, canton)}">${esc(copy.hubLabel)}</a>
       <span class="mx-2">/</span>
       <span>${esc(comune)}</span>
     </nav>
@@ -782,7 +951,7 @@ function renderComunePage(params: {
     <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
       <h1 class="max-w-4xl text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(copy.comuneH1(comune))}</h1>
       <p class="mt-3 max-w-3xl text-base leading-7 text-body">${esc(copy.comuneLede(comune))}</p>
-      <p class="mt-3 text-sm text-muted">${esc(copy.updated)}: <time datetime="${dateStamp}">${dateStamp}</time> · ${esc(copy.source)}: <a class="text-link hover:text-link-hover" href="${esc(SOURCE.homepage)}" rel="nofollow noopener" target="_blank">${esc(SOURCE.label)}</a></p>
+      <p class="mt-3 text-sm text-muted">${renderSourceAttribution(events, copy, dateStamp)}</p>
     </header>
 
     <dl class="mt-5 grid gap-3 sm:grid-cols-3">
@@ -797,7 +966,7 @@ function renderComunePage(params: {
     </section>
 
     <section class="mt-8 rounded-md border border-edge bg-surface p-5">
-      <a class="inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.allEvents)} →</a>
+      <a class="inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale, canton)}">${esc(copy.allEvents)} →</a>
     </section>
 
     ${renderCrosslinks(locale)}
@@ -831,7 +1000,7 @@ function renderComunePage(params: {
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` },
-      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale)}` },
+      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale, canton)}` },
       { '@type': 'ListItem', position: 3, name: comune, item: canonicalUrl },
     ],
   });
@@ -886,6 +1055,15 @@ interface DetailCopy {
   faqA1: (comune: string, when: string) => string;
   faqQ2: (comune: string) => string;
   faqA2: (comune: string) => string;
+  // #3125 Task C: price / address / map / recurring / real description — all
+  // canton-agnostic labels (no "Ticino"/"Tessin" literal), so unlike the rest
+  // of DetailCopy these need no cantonSubstitutionRules pass.
+  priceLabel: string;
+  freeLabel: string;
+  recurringLabel: string;
+  addressLabel: string;
+  mapLinkLabel: (place: string) => string;
+  descriptionTitle: string;
 }
 
 const DETAIL_COPY: Record<Locale, DetailCopy> = {
@@ -910,6 +1088,12 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     faqA1: (c, w) => `L’evento è in programma ${w} a ${c}, in Ticino. Controlla data e orario aggiornati sul sito ufficiale.`,
     faqQ2: (c) => `Dove trovo gli altri eventi a ${c}?`,
     faqA2: (c) => `Nella pagina dedicata a ${c} trovi l’agenda completa degli eventi del comune, aggiornata ogni giorno.`,
+    priceLabel: 'Prezzo',
+    freeLabel: 'Gratis',
+    recurringLabel: 'Evento ricorrente',
+    addressLabel: 'Indirizzo',
+    mapLinkLabel: (place: string) => `Apri ${place} su OpenStreetMap`,
+    descriptionTitle: 'Descrizione',
   },
   en: {
     metaTitle: (t, c) => `${t} — ${c} (Ticino) | Events`,
@@ -932,6 +1116,12 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     faqA1: (c, w) => `The event takes place ${w} in ${c}, Ticino. Check the current date and time on the official site.`,
     faqQ2: (c) => `Where can I find other events in ${c}?`,
     faqA2: (c) => `The ${c} page lists the full agenda of events in the municipality, refreshed daily.`,
+    priceLabel: 'Price',
+    freeLabel: 'Free',
+    recurringLabel: 'Recurring event',
+    addressLabel: 'Address',
+    mapLinkLabel: (place: string) => `Open ${place} on OpenStreetMap`,
+    descriptionTitle: 'Description',
   },
   de: {
     metaTitle: (t, c) => `${t} — ${c} (Tessin) | Veranstaltungen`,
@@ -954,6 +1144,12 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     faqA1: (c, w) => `Die Veranstaltung findet ${w} in ${c}, Tessin, statt. Prüfen Sie Datum und Uhrzeit auf der offiziellen Website.`,
     faqQ2: (c) => `Wo finde ich weitere Veranstaltungen in ${c}?`,
     faqA2: (c) => `Auf der Seite zu ${c} finden Sie die vollständige, täglich aktualisierte Veranstaltungsagenda der Gemeinde.`,
+    priceLabel: 'Preis',
+    freeLabel: 'Gratis',
+    recurringLabel: 'Wiederkehrende Veranstaltung',
+    addressLabel: 'Adresse',
+    mapLinkLabel: (place: string) => `${place} auf OpenStreetMap öffnen`,
+    descriptionTitle: 'Beschreibung',
   },
   fr: {
     metaTitle: (t, c) => `${t} — ${c} (Tessin) | Événements`,
@@ -976,8 +1172,65 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     faqA1: (c, w) => `L’événement a lieu ${w} à ${c}, au Tessin. Vérifiez la date et l’heure sur le site officiel.`,
     faqQ2: (c) => `Où trouver d’autres événements à ${c} ?`,
     faqA2: (c) => `La page dédiée à ${c} liste l’agenda complet des événements de la commune, mis à jour chaque jour.`,
+    priceLabel: 'Prix',
+    freeLabel: 'Gratuit',
+    recurringLabel: 'Événement récurrent',
+    addressLabel: 'Adresse',
+    mapLinkLabel: (place: string) => `Ouvrir ${place} sur OpenStreetMap`,
+    descriptionTitle: 'Description',
   },
 };
+
+const detailCopyCache = new Map<string, DetailCopy>();
+/** Same TI-verbatim / non-TI-substituted split as `copyFor`, for the
+ * per-event detail page copy. The new Task C fields (priceLabel, freeLabel,
+ * recurringLabel, addressLabel, mapLinkLabel, descriptionTitle) never
+ * mention the canton, so they pass through unchanged for every canton. */
+function detailCopyFor(canton: string, locale: Locale): DetailCopy {
+  if (canton.toUpperCase() === 'TI') return DETAIL_COPY[locale];
+  const cacheKey = `${canton}|${locale}`;
+  const cached = detailCopyCache.get(cacheKey);
+  if (cached) return cached;
+  const rules = cantonSubstitutionRules(canton, locale);
+  const base = DETAIL_COPY[locale];
+  const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const out: DetailCopy = {
+    ...base,
+    metaTitle: (t: string, c: string) => sub(base.metaTitle(t, c)),
+    metaDesc: (t: string, c: string, w: string) => sub(base.metaDesc(t, c, w)),
+    lede: (w: string, ti: string, v: string, c: string) => sub(base.lede(w, ti, v, c)),
+    about: (t: string, c: string, w: string, cat: string) => sub(base.about(t, c, w, cat)),
+    practical: (c: string) => sub(base.practical(c)),
+    faqA1: (c: string, w: string) => sub(base.faqA1(c, w)),
+  };
+  detailCopyCache.set(cacheKey, out);
+  return out;
+}
+
+/** Plain OpenStreetMap link — precise pin when the event has coordinates,
+ * else a text search fallback from address/venue/comune. No embed script, no
+ * third-party tracker/iframe: a `nofollow` outbound link, same policy as the
+ * official-site CTA and the source attribution links. */
+function osmLink(event: SiteEvent, comune: string): { href: string; place: string } {
+  const place = event.venue || event.address?.street || comune;
+  if (event.geo) {
+    return { href: `https://www.openstreetmap.org/?mlat=${event.geo.lat}&mlon=${event.geo.lng}#map=16/${event.geo.lat}/${event.geo.lng}`, place };
+  }
+  const query = [event.address?.street, event.address?.postalCode, comune].filter(Boolean).join(', ') || `${place}, ${comune}`;
+  return { href: `https://www.openstreetmap.org/search?query=${encodeURIComponent(query)}`, place };
+}
+
+function priceLine(event: SiteEvent, dc: DetailCopy): string {
+  if (!event.price) return '';
+  const value = event.price.isFree ? dc.freeLabel : `${event.price.currency || 'CHF'} ${event.price.amount ?? ''}`.trim();
+  return renderMetric(dc.priceLabel, esc(value));
+}
+
+function addressLine(event: SiteEvent, dc: DetailCopy): string {
+  if (!event.address?.street && !event.address?.postalCode) return '';
+  const value = [event.address.street, event.address.postalCode].filter(Boolean).join(', ');
+  return renderMetric(dc.addressLabel, esc(value));
+}
 
 export function renderEventDetailPage(params: {
   locale: Locale;
@@ -990,22 +1243,25 @@ export function renderEventDetailPage(params: {
   detailHref: DetailHref;
 }): { urlPath: string; html: string; wordCount: number } {
   const { locale, event, comune, eventSlug, sameComuneEvents, dateStamp, distDir, detailHref } = params;
+  const canton = (event.canton || 'TI').toUpperCase();
   const title = localizedTitle(event, locale);
-  const copy = COPY[locale];
-  const dc = DETAIL_COPY[locale];
-  const canonicalPath = pathForEventDetail(locale, comune, eventSlug);
+  const copy = copyFor(canton, locale);
+  const dc = detailCopyFor(canton, locale);
+  const canonicalPath = pathForEventDetail(locale, comune, eventSlug, canton);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
-  const comunePath = pathFor(locale, comune);
+  const comunePath = pathFor(locale, canton, comune);
   const when = humanDate(event.startDate, locale);
   const time = event.startTime ? ` · ${esc(event.startTime)}` : '';
   const cat = categoryLabel(event.category, locale);
   const others = sameComuneEvents.filter((e) => e.id !== event.id).slice(0, 6);
+  const map = osmLink(event, comune);
+  const description = localizedDescription(event, locale);
 
   const body = `<div class="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
     <nav class="mb-4 text-sm text-muted" aria-label="Breadcrumb">
       <a class="text-link hover:text-link-hover" href="/">${esc(HOME_LABEL[locale])}</a>
       <span class="mx-2">/</span>
-      <a class="text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.hubLabel)}</a>
+      <a class="text-link hover:text-link-hover" href="${pathFor(locale, canton)}">${esc(copy.hubLabel)}</a>
       <span class="mx-2">/</span>
       <a class="text-link hover:text-link-hover" href="${comunePath}">${esc(comune)}</a>
       <span class="mx-2">/</span>
@@ -1014,8 +1270,10 @@ export function renderEventDetailPage(params: {
 
     <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
       <span class="inline-block rounded-full border border-info-border bg-info-subtle px-2.5 py-0.5 text-xs font-semibold text-info">${esc(cat)}</span>
+      ${event.recurring ? `<span class="ml-2 inline-block rounded-full border border-edge bg-surface-raised px-2.5 py-0.5 text-xs font-semibold text-heading">${esc(dc.recurringLabel)}</span>` : ''}
       <h1 class="mt-3 text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(title)}</h1>
       <p class="mt-3 text-base leading-7 text-body">${esc(dc.lede(when, time, event.venue ? event.venue : '', comune))}</p>
+      ${description ? `<p class="mt-3 text-sm leading-6 text-body">${esc(description)}</p>` : ''}
     </header>
 
     <dl class="mt-5 grid gap-3 sm:grid-cols-2">
@@ -1023,16 +1281,20 @@ export function renderEventDetailPage(params: {
       ${renderMetric(dc.whereLabel, esc(event.venue || comune))}
       ${renderMetric(dc.catLabel, esc(cat))}
       ${renderMetric(dc.comuneLabel, esc(comune))}
+      ${priceLine(event, dc)}
+      ${addressLine(event, dc)}
     </dl>
 
     <section class="mt-6 flex flex-wrap gap-3">
       <a class="inline-flex items-center gap-2 rounded-md border border-info-border bg-info-subtle px-4 py-2 text-sm font-semibold text-info hover:bg-info-subtle/80" href="${esc(event.url)}" rel="nofollow noopener" target="_blank">${esc(dc.officialSite)} →</a>
+      <a class="inline-flex items-center gap-2 rounded-md border border-edge px-4 py-2 text-sm font-semibold text-link hover:text-link-hover" href="${esc(map.href)}" rel="nofollow noopener" target="_blank" aria-label="${esc(dc.mapLinkLabel(map.place))}">${esc(dc.mapLinkLabel(map.place))} →</a>
       <a class="inline-flex items-center gap-2 rounded-md border border-edge px-4 py-2 text-sm font-semibold text-link hover:text-link-hover" href="${comunePath}">${esc(dc.allInComune(comune))} →</a>
     </section>
 
     <section class="mt-8">
       <h2 class="text-2xl font-bold text-heading">${esc(dc.aboutTitle)}</h2>
       <p class="mt-3 text-base leading-7 text-body">${esc(dc.about(title, comune, `${when}${event.startTime ? ` (${event.startTime})` : ''}`, cat))}</p>
+      ${description ? `<h3 class="mt-4 text-lg font-semibold text-heading">${esc(dc.descriptionTitle)}</h3><p class="mt-2 text-base leading-7 text-body">${esc(description)}</p>` : ''}
     </section>
 
     <section class="mt-8 rounded-md border border-edge bg-surface p-5">
@@ -1066,7 +1328,7 @@ export function renderEventDetailPage(params: {
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` },
-      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale)}` },
+      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale, canton)}` },
       { '@type': 'ListItem', position: 3, name: comune, item: `${BASE_URL}${comunePath}` },
       { '@type': 'ListItem', position: 4, name: title, item: canonicalUrl },
     ],
@@ -1086,7 +1348,7 @@ export function renderEventDetailPage(params: {
     title: dc.metaTitle(title, comune),
     description: dc.metaDesc(title, comune, when),
     canonicalUrl,
-    hreflangHtml: buildEventAlternates(comune, eventSlug),
+    hreflangHtml: buildEventAlternates(canton, comune, eventSlug),
     robots: wordCount >= MIN_INDEXABLE_WORDS ? 'index,follow' : 'noindex,follow',
     ogLocale: LOCALE_OG[locale],
     bodyHtml: body,
@@ -1201,37 +1463,38 @@ export const DIGESTS: DigestDef[] = [
   },
 ];
 
-function pathForDigest(locale: Locale, slug: Record<Locale, string>): string {
-  return `${BASE_PATH[locale]}/${slug[locale]}/`;
+function pathForDigest(locale: Locale, canton: string, slug: Record<Locale, string>): string {
+  return `${basePathFor(canton)[locale]}/${slug[locale]}/`;
 }
 
-function buildDigestAlternates(slug: Record<Locale, string>): string {
-  return LOCALES.map((locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForDigest(locale, slug)}">`)
-    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForDigest('it', slug)}">`)
+function buildDigestAlternates(canton: string, slug: Record<Locale, string>): string {
+  return LOCALES.map((locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForDigest(locale, canton, slug)}">`)
+    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForDigest('it', canton, slug)}">`)
     .join('\n');
 }
 
 /** Hub nav linking the digest pages — keeps them BFS-reachable (hub → digest). */
-function renderDigestNav(locale: Locale): string {
+function renderDigestNav(locale: Locale, canton: string): string {
   const links = DIGESTS.map(
     (d) =>
-      `<a class="rounded-md border border-edge bg-surface-raised p-4 text-sm font-semibold text-heading hover:border-accent-border" href="${pathForDigest(locale, d.slug)}">${esc(d.copy[locale].h1)}</a>`,
+      `<a class="rounded-md border border-edge bg-surface-raised p-4 text-sm font-semibold text-heading hover:border-accent-border" href="${pathForDigest(locale, canton, d.slug)}">${esc(digestCopyFor(d, canton, locale).h1)}</a>`,
   ).join('');
   return `<section class="mt-6 grid gap-3 sm:grid-cols-2">${links}</section>`;
 }
 
-function renderDigestPage(params: {
+export function renderDigestPage(params: {
   def: DigestDef;
   locale: Locale;
+  canton: string;
   events: SiteEvent[];
   dateStamp: string;
   distDir: string;
   detailHref?: DetailHref;
 }): { urlPath: string; html: string; wordCount: number } {
-  const { def, locale, events, dateStamp, distDir, detailHref } = params;
-  const copy = COPY[locale];
-  const dc = def.copy[locale];
-  const canonicalPath = pathForDigest(locale, def.slug);
+  const { def, locale, canton, events, dateStamp, distDir, detailHref } = params;
+  const copy = copyFor(canton, locale);
+  const dc = digestCopyFor(def, canton, locale);
+  const canonicalPath = pathForDigest(locale, canton, def.slug);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const list = events.slice(0, 60);
   const byComune = groupByComune(events) as Map<string, SiteEvent[]>;
@@ -1240,7 +1503,7 @@ function renderDigestPage(params: {
     .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
     .map(
       ([comune, l]) =>
-        `<a class="rounded-md border border-edge bg-surface p-4 hover:border-accent-border" href="${pathFor(locale, comune)}"><span class="block text-sm font-semibold text-heading">${esc(comune)}</span><span class="mt-1 block text-xs text-muted">${l.length} ${esc(copy.eventsWord)}</span></a>`,
+        `<a class="rounded-md border border-edge bg-surface p-4 hover:border-accent-border" href="${pathFor(locale, canton, comune)}"><span class="block text-sm font-semibold text-heading">${esc(comune)}</span><span class="mt-1 block text-xs text-muted">${l.length} ${esc(copy.eventsWord)}</span></a>`,
     )
     .join('');
 
@@ -1248,7 +1511,7 @@ function renderDigestPage(params: {
     <nav class="mb-4 text-sm text-muted" aria-label="Breadcrumb">
       <a class="text-link hover:text-link-hover" href="/">${esc(HOME_LABEL[locale])}</a>
       <span class="mx-2">/</span>
-      <a class="text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.hubLabel)}</a>
+      <a class="text-link hover:text-link-hover" href="${pathFor(locale, canton)}">${esc(copy.hubLabel)}</a>
       <span class="mx-2">/</span>
       <span>${esc(dc.h1)}</span>
     </nav>
@@ -1256,7 +1519,7 @@ function renderDigestPage(params: {
     <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
       <h1 class="max-w-4xl text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(dc.h1)}</h1>
       <p class="mt-3 max-w-3xl text-base leading-7 text-body">${esc(dc.lede)}</p>
-      <p class="mt-3 text-sm text-muted">${esc(copy.updated)}: <time datetime="${dateStamp}">${dateStamp}</time> · ${esc(copy.source)}: <a class="text-link hover:text-link-hover" href="${esc(SOURCE.homepage)}" rel="nofollow noopener" target="_blank">${esc(SOURCE.label)}</a></p>
+      <p class="mt-3 text-sm text-muted">${renderSourceAttribution(events, copy, dateStamp)}</p>
     </header>
 
     <dl class="mt-5 grid gap-3 sm:grid-cols-3">
@@ -1277,7 +1540,7 @@ function renderDigestPage(params: {
     }
 
     <section class="mt-8 rounded-md border border-edge bg-surface p-5">
-      <a class="inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.allEvents)} →</a>
+      <a class="inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale, canton)}">${esc(copy.allEvents)} →</a>
     </section>
 
     ${renderCrosslinks(locale)}
@@ -1301,7 +1564,7 @@ function renderDigestPage(params: {
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` },
-      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale)}` },
+      { '@type': 'ListItem', position: 2, name: copy.hubLabel, item: `${BASE_URL}${pathFor(locale, canton)}` },
       { '@type': 'ListItem', position: 3, name: dc.h1, item: canonicalUrl },
     ],
   });
@@ -1317,7 +1580,7 @@ function renderDigestPage(params: {
     title: dc.title,
     description: dc.desc,
     canonicalUrl,
-    hreflangHtml: buildDigestAlternates(def.slug),
+    hreflangHtml: buildDigestAlternates(canton, def.slug),
     // A digest is only worth indexing when it actually lists events: the static
     // chrome (lede + methodology + FAQ) alone always clears MIN_INDEXABLE_WORDS,
     // so an EMPTY window must be gated on events.length, not the body word count
@@ -1333,43 +1596,44 @@ function renderDigestPage(params: {
 }
 
 function buildSitemap(
-  comuni: string[],
+  perCanton: Array<{ canton: string; comuni: string[]; digests: DigestDef[] }>,
   dateStamp: string,
-  digests: DigestDef[],
-  detailEntries: Array<{ comune: string; slug: string }> = [],
+  detailEntries: Array<{ canton: string; comune: string; slug: string }> = [],
 ): string {
   const entries: string[] = [];
-  // Hub
-  entries.push(sitemapUrl(undefined, dateStamp, '0.7'));
-  // Time-window digests (only the indexable ones)
-  for (const d of digests) entries.push(digestSitemapUrl(d.slug, dateStamp));
-  for (const comune of comuni) entries.push(sitemapUrl(comune, dateStamp, '0.5'));
+  for (const { canton, comuni, digests } of perCanton) {
+    // Hub
+    entries.push(sitemapUrl(canton, undefined, dateStamp, '0.7'));
+    // Time-window digests (only the indexable ones)
+    for (const d of digests) entries.push(digestSitemapUrl(canton, d.slug, dateStamp));
+    for (const comune of comuni) entries.push(sitemapUrl(canton, comune, dateStamp, '0.5'));
+  }
   // Per-event detail pages
-  for (const e of detailEntries) entries.push(eventDetailSitemapUrl(e.comune, e.slug, dateStamp));
+  for (const e of detailEntries) entries.push(eventDetailSitemapUrl(e.canton, e.comune, e.slug, dateStamp));
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${entries.join('\n')}\n</urlset>\n`;
 }
 
-function eventDetailSitemapUrl(comune: string, slug: string, dateStamp: string): string {
+function eventDetailSitemapUrl(canton: string, comune: string, slug: string, dateStamp: string): string {
   const alternates = LOCALES.map(
-    (locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForEventDetail(locale, comune, slug)}" />`,
+    (locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForEventDetail(locale, comune, slug, canton)}" />`,
   )
-    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForEventDetail('it', comune, slug)}" />`)
+    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForEventDetail('it', comune, slug, canton)}" />`)
     .join('\n');
-  return `  <url>\n    <loc>${BASE_URL}${pathForEventDetail('it', comune, slug)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.4</priority>\n  </url>`;
+  return `  <url>\n    <loc>${BASE_URL}${pathForEventDetail('it', comune, slug, canton)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.4</priority>\n  </url>`;
 }
 
-function digestSitemapUrl(slug: Record<Locale, string>, dateStamp: string): string {
-  const alternates = LOCALES.map((locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForDigest(locale, slug)}" />`)
-    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForDigest('it', slug)}" />`)
+function digestSitemapUrl(canton: string, slug: Record<Locale, string>, dateStamp: string): string {
+  const alternates = LOCALES.map((locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathForDigest(locale, canton, slug)}" />`)
+    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathForDigest('it', canton, slug)}" />`)
     .join('\n');
-  return `  <url>\n    <loc>${BASE_URL}${pathForDigest('it', slug)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`;
+  return `  <url>\n    <loc>${BASE_URL}${pathForDigest('it', canton, slug)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`;
 }
 
-function sitemapUrl(comune: string | undefined, dateStamp: string, priority: string): string {
-  const alternates = LOCALES.map((locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, comune)}" />`)
-    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', comune)}" />`)
+function sitemapUrl(canton: string, comune: string | undefined, dateStamp: string, priority: string): string {
+  const alternates = LOCALES.map((locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, canton, comune)}" />`)
+    .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', canton, comune)}" />`)
     .join('\n');
-  return `  <url>\n    <loc>${BASE_URL}${pathFor('it', comune)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
+  return `  <url>\n    <loc>${BASE_URL}${pathFor('it', canton, comune)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
 }
 
 // Per-locale hub index files to patch with an inbound link to the events hub,
@@ -1395,7 +1659,7 @@ function patchInboundLink(distDir: string, relIndex: string, locale: Locale): bo
   const block = `<section data-events-hub-link="1" class="my-8 rounded-md border border-edge bg-surface p-5">
     <h2 class="text-2xl font-bold text-heading">${esc(copy.hubH1)}</h2>
     <p class="mt-2 max-w-3xl text-sm leading-6 text-body">${esc(copy.hubLede)}</p>
-    <a class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale)}">${esc(copy.allEvents)} →</a>
+    <a class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-link hover:text-link-hover" href="${pathFor(locale, 'TI')}">${esc(copy.allEvents)} →</a>
   </section>`;
   if (html.includes('</main>')) {
     html = html.replace('</main>', `${block}</main>`);
@@ -1430,35 +1694,53 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
       }
 
       const weekendDays = weekendSet(dateStamp);
-      const byComune = groupByComune(all) as Map<string, SiteEvent[]>;
-      const comuni = [...byComune.keys()].sort((a, b) => a.localeCompare(b));
 
-      // Stable, collision-free detail slug per event (scoped to its comune), so
-      // every event gets ONE indexable URL /<base>/<comune>/<slug>/ that listings
-      // link to internally. Built once (locale-independent), then resolved per
-      // locale into a full href for the event cards.
-      const detailSlugs = new Map<string, { comune: string; slug: string }>();
-      for (const [comune, list] of byComune) {
-        const used = new Set<string>();
-        for (const ev of list) {
-          const base = slugifyEvent(ev);
-          let slug = base;
-          let n = 2;
-          while (used.has(slug)) slug = `${base}-${n++}`;
-          used.add(slug);
-          detailSlugs.set(ev.id, { comune, slug });
+      // #3125 nationwide rollout: group events per canton FIRST (derived from
+      // the actual dataset, defaulting to TI when the field is missing — so a
+      // build before any non-TI crawler has run still yields exactly today's
+      // TI-only pages, zero regression), then per comune within each canton.
+      // Every downstream loop iterates `cantons`, not a hardcoded 'TI'.
+      const byCanton = new Map<string, SiteEvent[]>();
+      for (const ev of all) {
+        const canton = (ev.canton || 'TI').toUpperCase();
+        const arr = byCanton.get(canton) ?? [];
+        arr.push(ev);
+        byCanton.set(canton, arr);
+      }
+      const cantons = [...byCanton.keys()].sort((a, b) => (a === 'TI' ? -1 : b === 'TI' ? 1 : a.localeCompare(b)));
+
+      // Stable, collision-free detail slug per event, scoped to (canton, comune)
+      // so two different cantons sharing a comune name never share a dedup
+      // bucket. Built once (locale-independent), then resolved per locale into
+      // a full href for the event cards.
+      const detailSlugs = new Map<string, { canton: string; comune: string; slug: string }>();
+      const byCantonComune = new Map<string, Map<string, SiteEvent[]>>();
+      for (const canton of cantons) {
+        const byComune = groupByComune(byCanton.get(canton)!) as Map<string, SiteEvent[]>;
+        byCantonComune.set(canton, byComune);
+        for (const [comune, list] of byComune) {
+          const used = new Set<string>();
+          for (const ev of list) {
+            const base = slugifyEvent(ev);
+            let slug = base;
+            let n = 2;
+            while (used.has(slug)) slug = `${base}-${n++}`;
+            used.add(slug);
+            detailSlugs.set(ev.id, { canton, comune, slug });
+          }
         }
       }
       const detailHrefFor =
         (locale: Locale): DetailHref =>
         (e: SiteEvent) => {
           const m = detailSlugs.get(e.id);
-          return m ? pathForEventDetail(locale, m.comune, m.slug) : null;
+          return m ? pathForEventDetail(locale, m.comune, m.slug, m.canton) : null;
         };
 
       const collector = new WriteCollector({ distDir, pluginName: 'eventsSeoPagesPlugin' });
       let pagesWritten = 0;
       let thinPages = 0;
+      let totalComuni = 0;
 
       const emit = (rendered: { urlPath: string; html: string; wordCount: number }) => {
         if (rendered.wordCount < MIN_INDEXABLE_WORDS) thinPages += 1;
@@ -1469,46 +1751,63 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
         pagesWritten += 1;
       };
 
-      // The digest filter is locale-independent (it only reads the date), so
-      // compute each window's events ONCE. A digest is indexed + sitemapped ONLY
-      // when it actually lists events — an empty window renders noindex,follow
-      // and is left out of the sitemap (gated on events.length, since the static
-      // chrome alone always clears MIN_INDEXABLE_WORDS). Shared across locales,
-      // so all 4 hreflang alternates stay consistent (no noindex straddle).
-      const digestEvents = new Map(DIGESTS.map((d) => [d.key, d.filter(all, { todayIso: dateStamp })]));
-      for (const locale of LOCALES) {
-        const detailHref = detailHrefFor(locale);
-        emit(renderHubPage({ locale, events: all, byComune, dateStamp, weekendDays, distDir, detailHref }));
-        for (const comune of comuni) {
-          const list = byComune.get(comune)!;
-          emit(renderComunePage({ locale, comune, events: list, dateStamp, weekendDays, distDir, detailHref }));
-          // One indexable detail page per event under its comune.
-          for (const ev of list) {
-            const eventSlug = detailSlugs.get(ev.id)!.slug;
-            emit(
-              renderEventDetailPage({
-                locale,
-                event: ev,
-                comune,
-                eventSlug,
-                sameComuneEvents: list,
-                dateStamp,
-                distDir,
-                detailHref,
-              }),
-            );
+      const perCantonSitemap: Array<{ canton: string; comuni: string[]; digests: DigestDef[] }> = [];
+
+      for (const canton of cantons) {
+        const events = byCanton.get(canton)!;
+        const byComune = byCantonComune.get(canton)!;
+        const comuni = [...byComune.keys()].sort((a, b) => a.localeCompare(b));
+        totalComuni += comuni.length;
+        const otherCantons = cantons.filter((c) => c !== canton);
+
+        // The digest filter is locale-independent (it only reads the date), so
+        // compute each window's events ONCE per canton. A digest is indexed +
+        // sitemapped ONLY when it actually lists events — an empty window
+        // renders noindex,follow and is left out of the sitemap (gated on
+        // events.length, since the static chrome alone always clears
+        // MIN_INDEXABLE_WORDS). Shared across locales, so all 4 hreflang
+        // alternates stay consistent (no noindex straddle).
+        const digestEvents = new Map(DIGESTS.map((d) => [d.key, d.filter(events, { todayIso: dateStamp })]));
+
+        for (const locale of LOCALES) {
+          const detailHref = detailHrefFor(locale);
+          emit(renderHubPage({ locale, canton, events, byComune, dateStamp, weekendDays, distDir, detailHref, otherCantons }));
+          for (const comune of comuni) {
+            const list = byComune.get(comune)!;
+            emit(renderComunePage({ locale, canton, comune, events: list, dateStamp, weekendDays, distDir, detailHref }));
+            // One indexable detail page per event under its comune.
+            for (const ev of list) {
+              const eventSlug = detailSlugs.get(ev.id)!.slug;
+              emit(
+                renderEventDetailPage({
+                  locale,
+                  event: ev,
+                  comune,
+                  eventSlug,
+                  sameComuneEvents: list,
+                  dateStamp,
+                  distDir,
+                  detailHref,
+                }),
+              );
+            }
+          }
+          // Emitted even when empty (the page degrades to a "no events" notice +
+          // comune links) so the URL is stable for FB linking, but noindex.
+          for (const def of DIGESTS) {
+            emit(renderDigestPage({ def, locale, canton, events: digestEvents.get(def.key)!, dateStamp, distDir, detailHref }));
           }
         }
-        // Emitted even when empty (the page degrades to a "no events" notice +
-        // comune links) so the URL is stable for FB linking, but noindex.
-        for (const def of DIGESTS) {
-          emit(renderDigestPage({ def, locale, events: digestEvents.get(def.key)!, dateStamp, distDir, detailHref }));
-        }
+
+        perCantonSitemap.push({
+          canton,
+          comuni,
+          digests: DIGESTS.filter((d) => (digestEvents.get(d.key)?.length ?? 0) > 0),
+        });
       }
 
-      const sitemapDigests = DIGESTS.filter((d) => (digestEvents.get(d.key)?.length ?? 0) > 0);
       const detailEntries = [...detailSlugs.values()];
-      const sitemapXml = buildSitemap(comuni, dateStamp, sitemapDigests, detailEntries);
+      const sitemapXml = buildSitemap(perCantonSitemap, dateStamp, detailEntries);
       fs.mkdirSync(distDir, { recursive: true });
       fs.writeFileSync(path.join(distDir, SITEMAP_NAME), sitemapXml, 'utf-8');
 
@@ -1531,7 +1830,7 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
       }
 
       console.log(
-        `\x1b[36m[events-pages]\x1b[0m Generated ${pagesWritten} pages (${comuni.length} comuni × ${LOCALES.length} locales + hubs) from ${all.length} events — flushed ${flushed} files in ${((Date.now() - t0) / 1000).toFixed(1)}s${thinPages ? ` (${thinPages} thin → noindex)` : ''} — inbound link locales: ${reached.join(',') || 'none'}`,
+        `\x1b[36m[events-pages]\x1b[0m Generated ${pagesWritten} pages (${totalComuni} comuni × ${cantons.length} canton(s) × ${LOCALES.length} locales + hubs) from ${all.length} events — flushed ${flushed} files in ${((Date.now() - t0) / 1000).toFixed(1)}s${thinPages ? ` (${thinPages} thin → noindex)` : ''} — inbound link locales: ${reached.join(',') || 'none'}`,
       );
     },
   };

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -67,6 +67,19 @@ interface SiteEvent {
   imageUrl?: string;
   sourceKey: string;
   sourceName: string;
+  // Nationwide sources (guidle, myswitzerland — issue #3125) carry richer
+  // fields the original tio-agenda MVP never had. All optional: tio-agenda
+  // slices (and any future thin source) simply omit them and every render
+  // path below degrades to the pre-existing MVP behavior.
+  description?: string;
+  price?: { amount: number | null; currency: string; isFree: boolean };
+  address?: { street?: string; postalCode?: string };
+  geo?: { lat: number; lng: number };
+  recurring?: boolean;
+  // Nearby Italian border comuni (haversine geo-link, see
+  // resolveItalianFrontierComuni in events-utils.mjs) — attached at assemble
+  // time so a frontaliere on the Italian side can find "eventi vicino a te".
+  italianFrontierComuni?: string[];
 }
 
 const LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
@@ -467,9 +480,17 @@ export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string)
   const endIso = hasMultiDay ? (event.endDate as string) : startIso;
   const cat = categoryLabel(event.category, locale);
   const when = humanDate(event.startDate, locale);
-  const description =
+  const synthDescription =
     `${event.title} — ${cat} ${COPY[locale].at} ${venueName} (${locality}, Ticino), ${when}` +
     `${event.startTime ? ` ${event.startTime}` : ''}. ${event.sourceName}.`;
+  // Nationwide sources (guidle, myswitzerland) crawl a real description —
+  // prefer it over the synthesized one when it clears the >=30 char gate
+  // validate-structured-data-completeness.mjs enforces.
+  const description =
+    event.description && event.description.trim().length >= 30 ? event.description.trim() : synthDescription;
+  // organizer is per-EVENT_SOURCES entry, not the single tio-agenda constant
+  // (§6 — one registry, no per-file duplicate of source metadata).
+  const organizerSource = EVENT_SOURCES[event.sourceKey] || SOURCE;
   return {
     '@type': 'Event',
     name: event.title,
@@ -482,21 +503,48 @@ export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string)
       name: venueName,
       address: {
         '@type': 'PostalAddress',
+        ...(event.address?.street ? { streetAddress: event.address.street } : {}),
+        ...(event.address?.postalCode ? { postalCode: event.address.postalCode } : {}),
         addressLocality: locality,
         addressRegion: 'TI',
         addressCountry: 'CH',
       },
+      ...(event.geo
+        ? { geo: { '@type': 'GeoCoordinates', latitude: event.geo.lat, longitude: event.geo.lng } }
+        : {}),
     },
     description: description.length >= 30 ? description : `${description} Evento in Ticino.`,
-    image: SITE_IMAGE,
+    image: event.imageUrl ? absoluteImageUrl(event.imageUrl) : SITE_IMAGE,
     // On a detail page `url` is OUR canonical page (the page about the event);
     // the original source is then surfaced as `sameAs`. On aggregate pages
     // (no canonicalUrl) we keep the source URL.
     url: canonicalUrl || event.url,
     ...(canonicalUrl && event.url ? { sameAs: [event.url] } : {}),
-    organizer: { '@type': 'Organization', name: event.sourceName, url: SOURCE.homepage },
+    organizer: { '@type': 'Organization', name: event.sourceName, url: organizerSource.homepage },
     performer: { '@type': 'Organization', name: venueName },
+    // offers is optional per validate-structured-data-completeness.mjs (many
+    // sources never expose price) — emit ONLY when we have a confident
+    // price/free signal, and always the FULL required shape together
+    // (price+priceCurrency+availability+validFrom+url) so a partial offers
+    // object never trips the "offers.field missing" gate.
+    ...(event.price
+      ? {
+          offers: {
+            '@type': 'Offer',
+            price: event.price.isFree ? '0' : String(event.price.amount ?? '0'),
+            priceCurrency: event.price.currency || 'CHF',
+            availability: 'https://schema.org/InStock',
+            validFrom: event.startDate,
+            url: canonicalUrl || event.url,
+          },
+        }
+      : {}),
   };
+}
+
+/** Site-relative event image path → absolute URL (structured data needs a full URL). */
+function absoluteImageUrl(imageUrl: string): string {
+  return /^https?:\/\//i.test(imageUrl) ? imageUrl : `${BASE_URL}${imageUrl.startsWith('/') ? '' : '/'}${imageUrl}`;
 }
 
 /**

--- a/scripts/assemble-events-dataset.mjs
+++ b/scripts/assemble-events-dataset.mjs
@@ -17,8 +17,26 @@
  *   1. Stable identity: `event.id` (already `<sourceKey>:<rawId>`).
  *   2. When the same id appears in multiple slices, the slice with the newest
  *      `assembledAt` wins (last-write wins).
- *   3. Prune past events: keep records whose (endDate || startDate) >= today.
- *   4. Sort ascending by startDate, then title.
+ *   3. Cross-source fuzzy dedup (issue #3125): nationwide sources (guidle,
+ *      myswitzerland) and the TI-only tio-agenda crawler can each index the
+ *      SAME physical event under a different `<sourceKey>:<rawId>` id, so the
+ *      by-id merge above does not catch it. A second pass groups the
+ *      survivors by `(normalized title, startDate, normalized comune)` and,
+ *      ONLY when a group spans 2+ DISTINCT sources, collapses it down to the
+ *      single richest record — see `dedupeFuzzy` below for the scoring/
+ *      tie-break rule. A same-source collision (e.g. two different events
+ *      that happen to share a generic title and a low-confidence
+ *      region-fallback comune) is left untouched — merging those would risk
+ *      silently dropping a genuine event.
+ *   4. Italian frontier comuni geo-link (issue #3125): every assembled event
+ *      that carries `geo` but has no `italianFrontierComuni` yet (a crawler
+ *      may already have attached it) gets `resolveItalianFrontierComuni`
+ *      applied and the result attached when non-empty. Nationwide sources
+ *      only index Swiss-side events; this tags border-zone Swiss events with
+ *      the nearby Italian comuni they are relevant to (a frontaliere living
+ *      just across the border), it does NOT crawl Italian municipal sites.
+ *   5. Prune past events: keep records whose (endDate || startDate) >= today.
+ *   6. Sort ascending by startDate, then title.
  *
  * Usage:
  *   node scripts/assemble-events-dataset.mjs            # assemble
@@ -27,7 +45,14 @@
 
 import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
-import { EVENTS_SLICE_DIR, EVENTS_DATASET_PATH, isoDay } from './lib/events-utils.mjs';
+import { fileURLToPath } from 'node:url';
+import {
+  EVENTS_SLICE_DIR,
+  EVENTS_DATASET_PATH,
+  isoDay,
+  normalizeText,
+  resolveItalianFrontierComuni,
+} from './lib/events-utils.mjs';
 
 function readSlices() {
   if (!existsSync(EVENTS_SLICE_DIR)) return [];
@@ -41,6 +66,127 @@ function readSlices() {
       }
     })
     .filter((s) => s && Array.isArray(s.events));
+}
+
+// ── Cross-source fuzzy dedup ────────────────────────────────────────────
+// The same physical event (e.g. a concert in Lugano) can be indexed by more
+// than one source with an unrelated raw id, so the by-id merge in assemble()
+// never catches it. Two records collide here when they normalize to the same
+// title, share the exact same startDate, and resolve to the same comune (a
+// missing comune on both sides also counts as a match — an unattributed
+// event still deserves de-duplication). Events that merely SHARE a title
+// (e.g. a recurring "Mercatino" in two different towns, or the same title on
+// two different dates) intentionally do NOT collapse.
+function fuzzyDedupKey(ev) {
+  return `${normalizeText(ev.title)}|${ev.startDate}|${normalizeText(ev.comune || '')}`;
+}
+
+// Optional fields that make an event record more useful to a reader — used
+// to score which duplicate to keep. Deliberately excludes fields that are
+// near-universal/cheap to fill (category, region) in favor of the fields
+// that actually distinguish a "thin" crawl from a "rich" one.
+const RICHNESS_FIELDS = ['description', 'imageUrl', 'price', 'address', 'geo', 'venue', 'endDate'];
+
+function isPopulated(value) {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'object') return Object.keys(value).length > 0;
+  return true;
+}
+
+/** Count of populated optional fields — higher means a "richer" record. */
+export function eventRichnessScore(ev) {
+  let score = 0;
+  for (const field of RICHNESS_FIELDS) {
+    if (isPopulated(ev?.[field])) score += 1;
+  }
+  return score;
+}
+
+// Explicit source priority for the final tie-break (equal richness score):
+// tio-agenda is our original hand-tuned TI crawler (best comune attribution,
+// oldest/most battle-tested parser); guidle is a structured Swiss-wide
+// events aggregator (reliable schema, broad coverage); myswitzerland is a
+// tourism-board catalog (good imagery, but skews toward touristy/generic
+// listings over hyper-local ones) — lowest priority of the three. Any future
+// source not listed here sorts last (lowest priority) rather than crashing.
+const SOURCE_PRIORITY = ['tio-agenda', 'guidle', 'myswitzerland'];
+
+function sourcePriorityRank(ev) {
+  const key = ev.sourceKey || String(ev.id || '').split(':')[0];
+  const idx = SOURCE_PRIORITY.indexOf(key);
+  return idx === -1 ? SOURCE_PRIORITY.length : idx;
+}
+
+/**
+ * Pick the single best record out of a group of fuzzy-duplicate events:
+ * highest richness score wins; ties broken by SOURCE_PRIORITY; any remaining
+ * tie (same source, e.g. a future multi-slice source) is broken by the
+ * lexicographically smaller id, so the result is deterministic run-to-run.
+ */
+export function pickRichestEvent(group) {
+  return [...group].sort((a, b) => {
+    const scoreDiff = eventRichnessScore(b) - eventRichnessScore(a);
+    if (scoreDiff !== 0) return scoreDiff;
+    const prioDiff = sourcePriorityRank(a) - sourcePriorityRank(b);
+    if (prioDiff !== 0) return prioDiff;
+    return String(a.id).localeCompare(String(b.id));
+  })[0];
+}
+
+/**
+ * Collapse fuzzy cross-source duplicates. Returns the deduped event list plus
+ * how many records were merged away (for --stats reporting).
+ *
+ * Deliberately scoped to groups spanning >= 2 DISTINCT `sourceKey`s. A group
+ * that collides on title+startDate+comune but comes entirely from a single
+ * source is left untouched — e.g. two unrelated "Street Food" events on the
+ * same day both region-resolved (low-confidence fallback) to the same
+ * representative comune are a real, observed false-positive collision that
+ * must not eat a genuine second event. Same-source id collisions are each
+ * source's own responsibility (and are already deduped by the by-id merge
+ * above); this pass only exists to catch the SAME physical event indexed
+ * independently by two-or-more different crawlers.
+ */
+export function dedupeFuzzy(events) {
+  const groups = new Map();
+  for (const ev of events) {
+    const key = fuzzyDedupKey(ev);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(ev);
+  }
+  const out = [];
+  let mergedAway = 0;
+  for (const group of groups.values()) {
+    const distinctSources = new Set(group.map((ev) => ev.sourceKey || String(ev.id || '').split(':')[0]));
+    if (group.length === 1 || distinctSources.size < 2) {
+      out.push(...group);
+      continue;
+    }
+    mergedAway += group.length - 1;
+    out.push(pickRichestEvent(group));
+  }
+  return { events: out, mergedAway };
+}
+
+// ── Italian frontier comuni attachment ──────────────────────────────────
+/**
+ * Attach `italianFrontierComuni` to every event that has `geo` but doesn't
+ * already carry the field (a crawler may already have computed it — never
+ * redo that work). Mutates and returns the same array for convenience.
+ */
+export function attachItalianFrontierComuni(events) {
+  let attached = 0;
+  for (const ev of events) {
+    if (!ev.geo || ev.italianFrontierComuni !== undefined) continue;
+    const comuni = resolveItalianFrontierComuni(ev.geo);
+    if (comuni.length) {
+      ev.italianFrontierComuni = comuni;
+      attached += 1;
+    }
+  }
+  return attached;
 }
 
 function assemble() {
@@ -61,13 +207,15 @@ function assemble() {
     }
   }
 
-  const events = [...byId.values()]
-    .map(({ __ts, ...ev }) => ev)
-    .sort(
-      (a, b) =>
-        (a.startDate || '').localeCompare(b.startDate || '') ||
-        (a.title || '').localeCompare(b.title || ''),
-    );
+  const merged = [...byId.values()].map(({ __ts, ...ev }) => ev);
+  const { events: deduped, mergedAway } = dedupeFuzzy(merged);
+  const frontierAttached = attachItalianFrontierComuni(deduped);
+
+  const events = deduped.sort(
+    (a, b) =>
+      (a.startDate || '').localeCompare(b.startDate || '') ||
+      (a.title || '').localeCompare(b.title || ''),
+  );
 
   const out = {
     schemaVersion: 1,
@@ -76,10 +224,10 @@ function assemble() {
     events,
   };
   writeFileSync(EVENTS_DATASET_PATH, `${JSON.stringify(out, null, 2)}\n`, 'utf-8');
-  return { events, slices: slices.length };
+  return { events, slices: slices.length, mergedAway, frontierAttached };
 }
 
-function printStats(events) {
+function printStats(events, mergedAway, frontierAttached) {
   const byComune = new Map();
   const byCategory = new Map();
   let withComune = 0;
@@ -95,8 +243,18 @@ function printStats(events) {
   console.log(`total: ${events.length} | with comune: ${withComune} | comuni: ${byComune.size}`);
   console.log(`top comuni: ${topComuni.map(([c, n]) => `${c}(${n})`).join(', ')}`);
   console.log(`categories: ${[...byCategory.entries()].sort((a, b) => b[1] - a[1]).map(([c, n]) => `${c}(${n})`).join(', ')}`);
+  console.log(`cross-source fuzzy dedup: merged away ${mergedAway} duplicate(s)`);
+  console.log(`italian frontier comuni attached: ${frontierAttached} event(s)`);
 }
 
-const { events, slices } = assemble();
-console.log(`[assemble-events] merged ${slices} slice(s) → ${events.length} upcoming events → ${path.relative(process.cwd(), EVENTS_DATASET_PATH)}`);
-if (process.argv.includes('--stats')) printStats(events);
+// Guard the CLI entry point so importing this module for its exported pure
+// functions (dedupeFuzzy / pickRichestEvent / eventRichnessScore /
+// attachItalianFrontierComuni — see tests/assemble-events-dedup.test.ts)
+// never runs assemble() as an import side effect and overwrites the tracked
+// data/events.json.
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  const { events, slices, mergedAway, frontierAttached } = assemble();
+  console.log(`[assemble-events] merged ${slices} slice(s) → ${events.length} upcoming events (${mergedAway} cross-source dup(s) collapsed) → ${path.relative(process.cwd(), EVENTS_DATASET_PATH)}`);
+  if (process.argv.includes('--stats')) printStats(events, mergedAway, frontierAttached);
+}

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -1,0 +1,572 @@
+#!/usr/bin/env node
+/**
+ * Crawler — Guidle (nationwide Switzerland events aggregator, issue #3125).
+ *
+ * guidle.com (https://www.guidle.com) is a white-label events/tourism platform
+ * used by hundreds of Swiss municipalities and tourism offices, aggregated
+ * under one public portal, natively published in up to 8 languages (we only
+ * care about it/en/de/fr, the site's 4 "main" locales and the ones the rest of
+ * the events pipeline localizes into — see EVENTS_BASE_PATH).
+ *
+ * Verified live 2026-07-02, in order of what was tried:
+ *   - The listing pages (`/de/veranstaltungen/alle` etc) are a client-side Vue
+ *     app (`portal-app.min.js`) that calls a `/api/rest/2.0/portals/*` REST
+ *     API with `withCredentials:true` + a static `X-Wizard-App` header. Even
+ *     with that header and a session cookie the `search-offers` endpoint kept
+ *     returning `{"valid":false}` for every id tried (page id, root id,
+ *     sitemap id, filters id) — the real request additionally needs a
+ *     `sectionId` resolved from a `page/<id>` call plus store-internal state
+ *     that isn't worth fully reverse-engineering when a much simpler, fully
+ *     public path exists (see next point). Not used.
+ *   - Serving a `Googlebot` user-agent to a listing page returns a fully
+ *     prerendered version (dynamic rendering for SEO) — confirmed this is
+ *     real, but deliberately NOT used: claiming to be Google's own crawler
+ *     would be identity spoofing, not the "respectful, clearly-identified"
+ *     crawling this feature requires (see events-utils.mjs mirrorEventImage
+ *     header). Not used.
+ *   - `https://www.guidle.com/sitemapindex.xml` → 6 gzipped shards
+ *     (`sitemap1.xml.gz` … `sitemap6.xml.gz`, ~180k `<loc>` lines each) that
+ *     ARE fully public and robots.txt-allowed (robots.txt only disallows
+ *     ajax/print/utility paths). Together they list 119'800 unique individual
+ *     event detail URLs (deduped by their trailing `_<code>` id, verified live
+ *     — zero collisions across the full corpus) across it/en/de/fr/cs/es/nl/pt.
+ *     This is the enumeration mechanism used here.
+ *   - Every event detail page (e.g.
+ *     `https://www.guidle.com/it/eventi/party/ascona/floating-notes…_AS26x6V`)
+ *     is plain server-rendered HTML (no JS needed, no bot UA needed) and
+ *     embeds schema.org `Event` JSON-LD (a single object, or an ARRAY of
+ *     objects — one per occurrence — for recurring events), the primary data
+ *     source here (title, description, startDate/endDate/time, venue,
+ *     address, image). `<meta name="geo.position" content="lat;lng">` gives
+ *     geo coordinates and `<meta name="geo.region" content="CH-ZG">` gives the
+ *     canton directly (stripped of the `CH-` prefix) — a strong `cantonHint`
+ *     for `resolveComuneNationwide`, which most sources don't have. Category
+ *     and free-text price are NOT in the JSON-LD; they're DOM-scraped from
+ *     `.accordion-wrap` blocks labelled "Kategorie"/"Preis" (and their
+ *     it/en/fr translations — see CATEGORY_LABELS/PRICE_LABELS).
+ *   - The in-page language `<select id="lang-selector">` proves the SAME path
+ *     (everything after the 2-letter locale prefix, code included) resolves
+ *     for every locale of the SAME event — e.g. both
+ *     `/de/eventi/party/ascona/…_AS26x6V` and `/it/eventi/party/ascona/…_AS26x6V`
+ *     are valid (the middle path segment is NOT re-translated by the
+ *     selector). So for every event found in the sitemap we derive its
+ *     it/en/de/fr URLs ourselves (swap the locale prefix, keep the rest) and
+ *     fetch all 4, instead of only knowing whichever single locale the
+ *     sitemap happened to list. This is what gives `titleByLocale`/
+ *     `descriptionByLocale` real per-locale text (when an organizer actually
+ *     filled in a translation — many haven't, and the untranslated locale
+ *     just repeats the source-language text, which is honest, not a bug).
+ *   - A large fraction of sitemap entries are stale (event already happened)
+ *     and 404/410 on fetch — skipped per-locale (and the whole event is
+ *     skipped if EVERY locale 404s/410s).
+ *
+ * No artificial cap: a real run walks the ENTIRE sitemap (119k+ events × up to
+ * 4 locale fetches each). That is a long-lived, scheduled crawl (hours, not
+ * minutes) by design (issue #3125: "no pilot batch, must be complete") — same
+ * trade-off already accepted for crawl-myswitzerland-events.mjs.
+ *
+ * Respectful, non-evasive crawling: plain `fetch`, no headless browser, no
+ * bot-identity spoofing, a clearly identifying User-Agent (matches the
+ * tio-agenda / myswitzerland / mirrorEventImage convention), and a politeness
+ * delay between every request to the guidle.com origin. Every event image is
+ * mirrored once via `mirrorEventImage` — the output slice NEVER references a
+ * guidle.com/imagekit.io image URL directly.
+ *
+ * Usage:
+ *   node scripts/crawl-guidle-events.mjs                # full catalog
+ *   node scripts/crawl-guidle-events.mjs --limit=5      # fast local test
+ *   node scripts/crawl-guidle-events.mjs --dry-run      # parse + report, no write
+ *
+ * Exit code is always 0 unless an unexpected crash occurs, EXCEPT when the
+ * sitemap itself is reachable but yields zero events (structural drift) —
+ * that exits 1 so crawl-events.yml can open a failure issue instead of the
+ * dataset going silently stale (same soft/hard-fail distinction as the other
+ * two crawlers).
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+import { JSDOM } from 'jsdom';
+import {
+  EVENT_SOURCES,
+  EVENTS_SLICE_DIR,
+  eventStableId,
+  resolveComuneNationwide,
+  mirrorEventImage,
+} from './lib/events-utils.mjs';
+
+const SOURCE = EVENT_SOURCES.guidle;
+const SITE_ORIGIN = 'https://www.guidle.com';
+const SITEMAP_INDEX_URL = `${SITE_ORIGIN}/sitemapindex.xml`;
+const LOCALES = ['it', 'en', 'de', 'fr'];
+
+const USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch)';
+const FETCH_TIMEOUT_MS = 20000;
+const SITEMAP_DELAY_MS = 300; // between sitemap shard fetches
+const DETAIL_DELAY_MS = 400; // between guidle.com origin detail-page fetches
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let originFailures = 0;
+
+async function fetchText(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT }, signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    originFailures += 1;
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchGzipText(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT }, signal: controller.signal });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    return gunzipSync(buf).toString('utf-8');
+  } catch {
+    originFailures += 1;
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Sitemap parsing (pure — no network) ──────────────────────────────────
+
+const SHARD_LOC_RE = /<loc>(https:\/\/www\.guidle\.com\/sitemap\d+\.xml\.gz)<\/loc>/g;
+
+/** Extract the gzipped shard URLs out of `sitemapindex.xml`. */
+export function parseSitemapIndexXml(xml) {
+  if (typeof xml !== 'string' || !xml) return [];
+  const out = [];
+  SHARD_LOC_RE.lastIndex = 0;
+  let m;
+  while ((m = SHARD_LOC_RE.exec(xml))) out.push(m[1]);
+  return out;
+}
+
+const EVENT_LOC_RE = /<loc>(https:\/\/www\.guidle\.com\/([a-z]{2})(\/[^<]*))<\/loc>/g;
+const EVENT_CODE_RE = /_([A-Za-z0-9]{5,10})$/;
+
+/**
+ * Extract individual event detail URLs from one sitemap shard, deduped by
+ * their trailing `_<code>` id (stable across every locale variant of the
+ * same event — verified live, zero collisions across the full 119'800-url
+ * corpus). Category/region listing and `/print` pages have no trailing code
+ * and are filtered out. Returns `{ code, pathSuffix }` — `pathSuffix` is
+ * everything after the 2-letter locale prefix (e.g.
+ * `/veranstaltungen/zug/stadtfuehrung_AZ3RYEB`), reusable behind ANY of
+ * it/en/de/fr (the language selector does not re-translate this segment).
+ */
+export function extractEventUrlsFromSitemapXml(xml) {
+  if (typeof xml !== 'string' || !xml) return [];
+  const out = [];
+  const seen = new Set();
+  EVENT_LOC_RE.lastIndex = 0;
+  let m;
+  while ((m = EVENT_LOC_RE.exec(xml))) {
+    const pathSuffix = m[3];
+    if (!pathSuffix || pathSuffix.includes('/print')) continue;
+    const codeMatch = EVENT_CODE_RE.exec(pathSuffix);
+    if (!codeMatch) continue;
+    const code = codeMatch[1];
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push({ code, pathSuffix });
+  }
+  return out;
+}
+
+// ── Detail-page parsing (pure — no network) ──────────────────────────────
+
+const LD_JSON_RE = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+
+/**
+ * Pick the schema.org Event occurrences off a detail page. A non-recurring
+ * event's JSON-LD block is a single `{"@type":"Event",…}` object; a
+ * recurring one is a JSON ARRAY of such objects, one per future occurrence
+ * (verified live: an 18-item array for a weekly guided tour). Both shapes are
+ * normalized here into a flat array (empty when no Event block is found).
+ */
+export function extractEventJsonLdOccurrences(html) {
+  if (typeof html !== 'string' || !html) return [];
+  LD_JSON_RE.lastIndex = 0;
+  let match;
+  while ((match = LD_JSON_RE.exec(html))) {
+    let parsed;
+    try {
+      parsed = JSON.parse(match[1]);
+    } catch {
+      continue; // malformed block — keep scanning the rest of the page
+    }
+    const list = Array.isArray(parsed) ? parsed : [parsed];
+    const events = list.filter((o) => o && typeof o === 'object' && o['@type'] === 'Event' && typeof o.startDate === 'string');
+    if (events.length) return events;
+  }
+  return [];
+}
+
+/**
+ * Summarize a list of Event occurrences into one {startDate, startTime,
+ * endDate, recurring} record: earliest occurrence's date+time as the
+ * canonical start, latest occurrence's date as the end, `recurring: true`
+ * when there is more than one. guidle's JSON-LD dates have no timezone
+ * suffix (e.g. `"2026-07-04T09:50"`) — they are already Europe/Zurich local
+ * time, so no conversion is needed (unlike myswitzerland's UTC Algolia data).
+ */
+export function summarizeOccurrences(occurrences) {
+  if (!Array.isArray(occurrences) || occurrences.length === 0) return null;
+  const sorted = [...occurrences].sort((a, b) => String(a.startDate).localeCompare(String(b.startDate)));
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const startDate = String(first.startDate || '').slice(0, 10);
+  if (!startDate) return null;
+  const startTimeRaw = String(first.startDate || '').slice(11, 16);
+  const startTime = /^\d{2}:\d{2}$/.test(startTimeRaw) ? startTimeRaw : undefined;
+  const endRaw = last.endDate || last.startDate;
+  const endDate = String(endRaw || '').slice(0, 10) || undefined;
+  return { startDate, startTime, endDate, recurring: occurrences.length > 1 };
+}
+
+function cleanText(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function text(el) {
+  return cleanText(el?.textContent || '');
+}
+
+/** {street, postalCode} from a JSON-LD `location.address` (PostalAddress), or undefined. */
+export function extractAddress(address) {
+  if (!address || typeof address !== 'object') return undefined;
+  const street = typeof address.streetAddress === 'string' && address.streetAddress.trim() ? address.streetAddress.trim() : undefined;
+  const postalCode = typeof address.postalCode === 'string' && address.postalCode.trim() ? address.postalCode.trim() : undefined;
+  if (!street && !postalCode) return undefined;
+  return { street, postalCode };
+}
+
+// Accordion h3 labels, per locale — DOM-scraped fields (category, price) are
+// NOT in the JSON-LD, they live in `.accordion-wrap` blocks whose heading
+// text is translated per locale (verified live for all 4).
+const CATEGORY_LABELS = { it: 'Categoria', de: 'Kategorie', fr: 'Catégorie', en: 'Category' };
+const PRICE_LABELS = { it: 'Prezzo', de: 'Preis', fr: 'Prix', en: 'Price' };
+
+function findAccordion(doc, label) {
+  if (!label) return null;
+  for (const wrap of doc.querySelectorAll('.accordion-wrap')) {
+    const h3 = wrap.querySelector('h3');
+    if (h3 && text(h3) === label) return wrap.querySelector('.accordion');
+  }
+  return null;
+}
+
+/** First category `<li>` under the "Kategorie"/"Categoria"/… accordion, or undefined. */
+export function extractCategory(doc, locale) {
+  const acc = findAccordion(doc, CATEGORY_LABELS[locale]);
+  const li = acc?.querySelector('li');
+  const value = li ? text(li) : '';
+  return value || undefined;
+}
+
+const FREE_RE = /\b(gratis|gratuit[oe]?|free|kostenlos|eintritt frei|entr[ée]e libre|ingresso libero)\b/i;
+const AMOUNT_RE = /(\d+(?:[.,]\d{1,2})?)/g;
+
+/**
+ * Parse guidle's free-text price accordion (e.g. "CHF 10.00 pro Person…",
+ * "Ingresso 20 franchi, Bambini gratis") into `{amount, currency, isFree}`.
+ * Takes the CHEAPEST number found (same "cheapest of several prices" rule as
+ * the myswitzerland crawler's `extractPrice`). Falls back to a free-keyword
+ * match when no number is present, and to `amount: null` (price info exists
+ * but isn't machine-parseable, e.g. "su richiesta" / "on request") otherwise.
+ */
+export function parsePriceText(rawText) {
+  const t = cleanText(rawText);
+  if (!t) return undefined;
+  const numbers = [];
+  AMOUNT_RE.lastIndex = 0;
+  let m;
+  while ((m = AMOUNT_RE.exec(t))) {
+    const n = Number.parseFloat(m[1].replace(',', '.'));
+    if (Number.isFinite(n)) numbers.push(n);
+  }
+  if (numbers.length) {
+    const amount = Math.min(...numbers);
+    return { amount, currency: 'CHF', isFree: amount === 0 };
+  }
+  if (FREE_RE.test(t)) return { amount: 0, currency: 'CHF', isFree: true };
+  return { amount: null, currency: 'CHF', isFree: false };
+}
+
+/** Price from the "Preis"/"Prezzo"/… accordion, or undefined when absent. */
+export function extractPrice(doc, locale) {
+  const acc = findAccordion(doc, PRICE_LABELS[locale]);
+  if (!acc) return undefined;
+  return parsePriceText(text(acc));
+}
+
+/**
+ * Geo coordinates + canton from `<meta name="geo.position">` /
+ * `<meta name="geo.region">` — both present on every real event detail page
+ * (verified live). `geo.region` is a strong, source-provided canton signal
+ * (`CH-ZG` → `ZG`) most sources don't have, used as `resolveComuneNationwide`'s
+ * `cantonHint`.
+ */
+export function extractGeoAndCanton(doc) {
+  const geoContent = doc.querySelector('meta[name="geo.position"]')?.getAttribute('content') || '';
+  const [latStr, lngStr] = geoContent.split(';');
+  const lat = Number.parseFloat(latStr);
+  const lng = Number.parseFloat(lngStr);
+  const geo = Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : undefined;
+
+  const regionContent = doc.querySelector('meta[name="geo.region"]')?.getAttribute('content') || '';
+  const cantonMatch = /^CH-([A-Za-z]{2})$/.exec(regionContent.trim());
+  const canton = cantonMatch ? cantonMatch[1].toUpperCase() : undefined;
+
+  return { geo, canton };
+}
+
+/**
+ * Pure mapping: one fetched detail page (a single locale variant of one
+ * event) → a flat data record. Never touches the network. Returns `null`
+ * when the page has no usable Event JSON-LD (missing/expired/wrong page).
+ */
+export function mapDetailPageToLocaleData(html, locale) {
+  const occurrences = extractEventJsonLdOccurrences(html);
+  const summary = summarizeOccurrences(occurrences);
+  if (!summary) return null;
+  const first = occurrences[0];
+  const title = cleanText(first.name);
+  if (!title) return null;
+  const description = cleanText(first.description) || undefined;
+  const venue = cleanText(first.location?.name) || undefined;
+  const address = extractAddress(first.location?.address);
+  const addressLocality = cleanText(first.location?.address?.addressLocality) || undefined;
+  const imageSourceUrl = typeof first.image === 'string' && first.image.trim() ? first.image.trim() : undefined;
+
+  const doc = new JSDOM(html).window.document;
+  const category = extractCategory(doc, locale);
+  const price = extractPrice(doc, locale);
+  const { geo, canton } = extractGeoAndCanton(doc);
+
+  return {
+    title,
+    description,
+    ...summary,
+    venue,
+    address,
+    addressLocality,
+    imageSourceUrl,
+    category,
+    price,
+    geo,
+    canton,
+  };
+}
+
+/**
+ * Pure merge: per-locale detail-page data (up to 4, one per it/en/de/fr,
+ * `null` for a locale that 404s/410s/has no usable Event) → a SiteEvent-shaped
+ * record. Structured fields (dates, category, price, geo, canton, venue,
+ * address, image) come from the FIRST locale (in it→en→de→fr order) that has
+ * data — they don't vary by locale, only the text does.
+ * `titleByLocale`/`descriptionByLocale` collect the REAL text of every locale
+ * that resolved, which is honestly identical to the source language for
+ * events an organizer never translated (not a bug — see file header).
+ * Returns `null` when every locale is unusable (event fully gone).
+ */
+export function mapGuidleEvent(code, localeResults) {
+  const primaryLocale = LOCALES.find((l) => localeResults[l]);
+  if (!primaryLocale) return null;
+  const primary = localeResults[primaryLocale];
+
+  const titleByLocale = {};
+  const descriptionByLocale = {};
+  for (const locale of LOCALES) {
+    const d = localeResults[locale];
+    if (!d) continue;
+    if (d.title) titleByLocale[locale] = d.title;
+    if (d.description) descriptionByLocale[locale] = d.description;
+  }
+
+  return {
+    event: {
+      id: eventStableId(SOURCE.key, code),
+      title: primary.title,
+      titleByLocale: Object.keys(titleByLocale).length ? titleByLocale : undefined,
+      description: primary.description,
+      descriptionByLocale: Object.keys(descriptionByLocale).length ? descriptionByLocale : undefined,
+      startDate: primary.startDate,
+      endDate: primary.endDate,
+      startTime: primary.startTime,
+      category: primary.category || 'Event',
+      venue: primary.venue,
+      comune: undefined,
+      canton: '',
+      url: primary.url,
+      sourceKey: SOURCE.key,
+      sourceName: SOURCE.label,
+      price: primary.price,
+      address: primary.address,
+      geo: primary.geo,
+      recurring: primary.recurring,
+    },
+    imageSourceUrl: primary.imageSourceUrl,
+    addressLocality: primary.addressLocality,
+    cantonHint: primary.canton,
+  };
+}
+
+// ── Network orchestration ────────────────────────────────────────────────
+
+/**
+ * Walk the sitemap index + shards, collecting `{code -> pathSuffix}` for
+ * every individual event, stopping early once `limit` distinct events are
+ * found (fast path for `--limit` local iteration — a full run has no limit
+ * and always walks every shard).
+ */
+async function collectEventUrls(limit) {
+  const indexXml = await fetchText(SITEMAP_INDEX_URL);
+  if (!indexXml) return { entries: [], shardsOk: 0, shardsFailed: 0 };
+  const shardUrls = parseSitemapIndexXml(indexXml);
+
+  const byCode = new Map();
+  let shardsOk = 0;
+  let shardsFailed = 0;
+  for (const shardUrl of shardUrls) {
+    const xml = await fetchGzipText(shardUrl);
+    await sleep(SITEMAP_DELAY_MS);
+    if (!xml) {
+      shardsFailed += 1;
+      continue;
+    }
+    shardsOk += 1;
+    for (const { code, pathSuffix } of extractEventUrlsFromSitemapXml(xml)) {
+      if (!byCode.has(code)) byCode.set(code, pathSuffix);
+    }
+    if (limit && byCode.size >= limit) break;
+  }
+
+  const entries = [...byCode.entries()];
+  return { entries: limit ? entries.slice(0, limit) : entries, shardsOk, shardsFailed };
+}
+
+async function fetchLocaleData(pathSuffix, locale) {
+  const url = `${SITE_ORIGIN}/${locale}${pathSuffix}`;
+  const html = await fetchText(url);
+  await sleep(DETAIL_DELAY_MS);
+  if (!html) return null;
+  const mapped = mapDetailPageToLocaleData(html, locale);
+  return mapped ? { ...mapped, url } : null;
+}
+
+function parseArgs(argv) {
+  const dryRun = argv.includes('--dry-run');
+  let limit;
+  const eqArg = argv.find((a) => a.startsWith('--limit='));
+  if (eqArg) {
+    limit = Number.parseInt(eqArg.slice('--limit='.length), 10);
+  } else {
+    const idx = argv.indexOf('--limit');
+    if (idx >= 0) limit = Number.parseInt(argv[idx + 1] || '', 10);
+  }
+  if (!Number.isFinite(limit) || limit <= 0) limit = undefined;
+  return { dryRun, limit };
+}
+
+async function main() {
+  const { dryRun, limit } = parseArgs(process.argv.slice(2));
+  const crawledAt = new Date().toISOString();
+
+  const { entries, shardsOk, shardsFailed } = await collectEventUrls(limit);
+  console.log(`[guidle] sitemap: ${shardsOk} shard(s) ok, ${shardsFailed} failed, ${entries.length} unique event(s) to fetch`);
+
+  const events = [];
+  let goneEverywhere = 0;
+  let resolvedComune = 0;
+
+  for (const [code, pathSuffix] of entries) {
+    const localeResults = {};
+    for (const locale of LOCALES) {
+      localeResults[locale] = await fetchLocaleData(pathSuffix, locale);
+    }
+
+    const mapped = mapGuidleEvent(code, localeResults);
+    if (!mapped) {
+      goneEverywhere += 1;
+      continue;
+    }
+
+    const { event, imageSourceUrl, addressLocality, cantonHint } = mapped;
+    const { comune, canton } = resolveComuneNationwide(
+      { venue: [event.venue, addressLocality].filter(Boolean).join(' '), title: event.title, region: undefined },
+      cantonHint,
+    );
+    event.comune = comune || undefined;
+    event.canton = canton || cantonHint || '';
+    if (event.comune) resolvedComune += 1;
+    event.imageUrl = (await mirrorEventImage(imageSourceUrl, event.id)) || undefined;
+    events.push(event);
+  }
+
+  console.log(
+    `[guidle] ${events.length} events written (${goneEverywhere} fully expired/gone) — ` +
+      `comune resolved ${resolvedComune}/${events.length}`,
+  );
+
+  if (dryRun) {
+    console.log('🏃 dry-run — slice not written');
+    console.log(JSON.stringify(events.slice(0, 3), null, 2));
+    return;
+  }
+
+  if (events.length === 0) {
+    // Never overwrite a good slice with an empty one. Distinguish two causes:
+    //  - the sitemap/origin itself failed to load (network/WAF) → transient, soft-exit 0.
+    //  - the sitemap loaded fine but nothing mapped to a valid event → likely
+    //    structural drift (JSON-LD/DOM markup changed); exit non-zero so
+    //    crawl-events.yml opens a failure issue instead of the dataset going
+    //    silently stale.
+    console.log('[guidle] 0 events parsed — leaving existing slice untouched');
+    if (shardsOk === 0 || originFailures > 0) {
+      console.log(`[guidle] sitemap/origin fetch failures detected — transient, soft-exit 0`);
+    } else {
+      console.error('[guidle] sitemap loaded but yielded 0 events — check JSON-LD/DOM selectors for drift');
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  mkdirSync(EVENTS_SLICE_DIR, { recursive: true });
+  const slicePath = path.join(EVENTS_SLICE_DIR, `${SOURCE.key}.json`);
+  const slice = {
+    schemaVersion: 1,
+    sourceKey: SOURCE.key,
+    sourceName: SOURCE.label,
+    assembledAt: crawledAt,
+    events,
+  };
+  writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
+  console.log(`[guidle] wrote ${events.length} events → ${path.relative(process.cwd(), slicePath)}`);
+}
+
+// Only crawl when invoked directly (`node scripts/crawl-guidle-events.mjs`),
+// so tests can import the pure parsing/mapping functions without triggering a
+// live crawl.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`[guidle] crawl failed: ${err?.message || err}`);
+    process.exit(1);
+  });
+}

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -60,10 +60,20 @@
  *     and 404/410 on fetch — skipped per-locale (and the whole event is
  *     skipped if EVERY locale 404s/410s).
  *
- * No artificial cap: a real run walks the ENTIRE sitemap (119k+ events × up to
- * 4 locale fetches each). That is a long-lived, scheduled crawl (hours, not
- * minutes) by design (issue #3125: "no pilot batch, must be complete") — same
- * trade-off already accepted for crawl-myswitzerland-events.mjs.
+ * No artificial cap: the full sitemap (119k+ events × up to 4 locale fetches
+ * each) is walked across MANY scheduled runs, not one. A single run is
+ * bounded by GUIDLE_CRAWL_BUDGET_MS (default 8 minutes, well inside
+ * crawl-events.yml's shared 35-minute job timeout) — it re-derives the full
+ * ordered event list from the sitemap every run (cheap: 6 shard fetches),
+ * then walks a slice of it starting at a persisted cursor
+ * (data/events/checkpoints/guidle.json, see scripts/lib/crawl-checkpoint.mjs)
+ * and wraps back to the start once the whole catalog has been visited.
+ * Each run MERGES what it found into the existing on-disk slice instead of
+ * overwriting it wholesale, so a run that stops at its time budget never
+ * loses prior runs' progress — coverage of the full catalog accrues over
+ * many scheduled runs (issue #3125: "no pilot batch, must be complete" — no
+ * permanent cap on total events ever crawled). Same design used for
+ * crawl-myswitzerland-events.mjs.
  *
  * Respectful, non-evasive crawling: plain `fetch`, no headless browser, no
  * bot-identity spoofing, a clearly identifying User-Agent (matches the
@@ -73,18 +83,17 @@
  * guidle.com/imagekit.io image URL directly.
  *
  * Usage:
- *   node scripts/crawl-guidle-events.mjs                # full catalog
- *   node scripts/crawl-guidle-events.mjs --limit=5      # fast local test
+ *   node scripts/crawl-guidle-events.mjs                # one time-budgeted, checkpointed slice of the catalog
+ *   node scripts/crawl-guidle-events.mjs --limit=5      # fast local test (bypasses the checkpoint)
  *   node scripts/crawl-guidle-events.mjs --dry-run      # parse + report, no write
  *
- * Exit code is always 0 unless an unexpected crash occurs, EXCEPT when the
- * sitemap itself is reachable but yields zero events (structural drift) —
- * that exits 1 so crawl-events.yml can open a failure issue instead of the
- * dataset going silently stale (same soft/hard-fail distinction as the other
- * two crawlers).
+ * Exit code is always 0 unless an unexpected crash occurs, EXCEPT when this
+ * run's detail-page fetches succeeded (real HTML came back) but yielded zero
+ * mapped events (structural drift) — that exits 1 so crawl-events.yml can
+ * open a failure issue instead of the dataset going silently stale (same
+ * soft/hard-fail distinction as the other two crawlers).
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { gunzipSync } from 'node:zlib';
@@ -96,6 +105,7 @@ import {
   resolveComuneNationwide,
   mirrorEventImage,
 } from './lib/events-utils.mjs';
+import { loadCursor, saveCursor, mergeEventsIntoSlice } from './lib/crawl-checkpoint.mjs';
 
 const SOURCE = EVENT_SOURCES.guidle;
 const SITE_ORIGIN = 'https://www.guidle.com';
@@ -106,10 +116,11 @@ const USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://
 const FETCH_TIMEOUT_MS = 20000;
 const SITEMAP_DELAY_MS = 300; // between sitemap shard fetches
 const DETAIL_DELAY_MS = 400; // between guidle.com origin detail-page fetches
+const RUN_BUDGET_MS = Number(process.env.GUIDLE_CRAWL_BUDGET_MS) || 8 * 60_000; // per-run wall-clock cap
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-let originFailures = 0;
+let detailFetchesOk = 0;
 
 async function fetchText(url) {
   const controller = new AbortController();
@@ -119,7 +130,6 @@ async function fetchText(url) {
     if (!res.ok) return null;
     return await res.text();
   } catch {
-    originFailures += 1;
     return null;
   } finally {
     clearTimeout(timer);
@@ -135,7 +145,6 @@ async function fetchGzipText(url) {
     const buf = Buffer.from(await res.arrayBuffer());
     return gunzipSync(buf).toString('utf-8');
   } catch {
-    originFailures += 1;
     return null;
   } finally {
     clearTimeout(timer);
@@ -467,6 +476,7 @@ async function fetchLocaleData(pathSuffix, locale) {
   const html = await fetchText(url);
   await sleep(DETAIL_DELAY_MS);
   if (!html) return null;
+  detailFetchesOk += 1; // positive success signal — HTML came back, independent of parse outcome
   const mapped = mapDetailPageToLocaleData(html, locale);
   return mapped ? { ...mapped, url } : null;
 }
@@ -488,15 +498,32 @@ function parseArgs(argv) {
 async function main() {
   const { dryRun, limit } = parseArgs(process.argv.slice(2));
   const crawledAt = new Date().toISOString();
+  const deadline = Date.now() + RUN_BUDGET_MS;
 
   const { entries, shardsOk, shardsFailed } = await collectEventUrls(limit);
-  console.log(`[guidle] sitemap: ${shardsOk} shard(s) ok, ${shardsFailed} failed, ${entries.length} unique event(s) to fetch`);
+  console.log(`[guidle] sitemap: ${shardsOk} shard(s) ok, ${shardsFailed} failed, ${entries.length} unique event(s) in catalog`);
+
+  const startIndex = limit ? 0 : loadCursor(SOURCE.key) % Math.max(entries.length, 1);
+  if (!limit && startIndex > 0) {
+    console.log(`[guidle] resuming from checkpoint index ${startIndex}/${entries.length}`);
+  }
 
   const events = [];
+  const goneIds = [];
   let goneEverywhere = 0;
   let resolvedComune = 0;
+  let visited = 0;
+  let cursor = startIndex;
 
-  for (const [code, pathSuffix] of entries) {
+  while (visited < entries.length) {
+    if (!limit && Date.now() >= deadline) {
+      console.log(
+        `[guidle] time budget (${RUN_BUDGET_MS}ms) reached after ${visited}/${entries.length} event(s) — stopping, will resume next run`,
+      );
+      break;
+    }
+
+    const [code, pathSuffix] = entries[cursor];
     const localeResults = {};
     for (const locale of LOCALES) {
       localeResults[locale] = await fetchLocaleData(pathSuffix, locale);
@@ -505,60 +532,69 @@ async function main() {
     const mapped = mapGuidleEvent(code, localeResults);
     if (!mapped) {
       goneEverywhere += 1;
-      continue;
+      goneIds.push(eventStableId(SOURCE.key, code));
+    } else {
+      const { event, imageSourceUrl, addressLocality, cantonHint } = mapped;
+      const { comune, canton } = resolveComuneNationwide(
+        { venue: [event.venue, addressLocality].filter(Boolean).join(' '), title: event.title, region: undefined },
+        cantonHint,
+      );
+      event.comune = comune || undefined;
+      event.canton = canton || cantonHint || '';
+      if (event.comune) resolvedComune += 1;
+      event.imageUrl = (await mirrorEventImage(imageSourceUrl, event.id)) || undefined;
+      events.push(event);
     }
 
-    const { event, imageSourceUrl, addressLocality, cantonHint } = mapped;
-    const { comune, canton } = resolveComuneNationwide(
-      { venue: [event.venue, addressLocality].filter(Boolean).join(' '), title: event.title, region: undefined },
-      cantonHint,
-    );
-    event.comune = comune || undefined;
-    event.canton = canton || cantonHint || '';
-    if (event.comune) resolvedComune += 1;
-    event.imageUrl = (await mirrorEventImage(imageSourceUrl, event.id)) || undefined;
-    events.push(event);
+    visited += 1;
+    cursor = (cursor + 1) % entries.length;
   }
 
   console.log(
-    `[guidle] ${events.length} events written (${goneEverywhere} fully expired/gone) — ` +
+    `[guidle] visited ${visited}/${entries.length} event(s) this run — ${events.length} mapped (${goneEverywhere} expired/gone) — ` +
       `comune resolved ${resolvedComune}/${events.length}`,
   );
 
   if (dryRun) {
-    console.log('🏃 dry-run — slice not written');
+    console.log('🏃 dry-run — slice/checkpoint not written');
     console.log(JSON.stringify(events.slice(0, 3), null, 2));
     return;
   }
 
-  if (events.length === 0) {
-    // Never overwrite a good slice with an empty one. Distinguish two causes:
-    //  - the sitemap/origin itself failed to load (network/WAF) → transient, soft-exit 0.
-    //  - the sitemap loaded fine but nothing mapped to a valid event → likely
+  if (!limit && entries.length > 0) saveCursor(SOURCE.key, cursor, crawledAt);
+
+  if (events.length === 0 && goneIds.length === 0) {
+    // Never overwrite a good slice with an empty run. Distinguish two causes:
+    //  - no detail page returned real HTML this run (network/WAF) → transient, soft-exit 0.
+    //  - detail pages loaded fine but nothing mapped to a valid event → likely
     //    structural drift (JSON-LD/DOM markup changed); exit non-zero so
     //    crawl-events.yml opens a failure issue instead of the dataset going
-    //    silently stale.
-    console.log('[guidle] 0 events parsed — leaving existing slice untouched');
-    if (shardsOk === 0 || originFailures > 0) {
-      console.log(`[guidle] sitemap/origin fetch failures detected — transient, soft-exit 0`);
+    //    silently stale. Mirrors crawl-tio-agenda.mjs's pagesOk>0 pattern —
+    //    a positive success signal, not a cumulative failure counter (a
+    //    cumulative counter is almost always >0 at guidle's real scale even
+    //    when everything works, since some per-locale fetches always miss).
+    console.log('[guidle] 0 events mapped this run — leaving existing slice untouched');
+    if (detailFetchesOk === 0) {
+      console.log('[guidle] no detail pages loaded successfully this run — transient, soft-exit 0');
     } else {
-      console.error('[guidle] sitemap loaded but yielded 0 events — check JSON-LD/DOM selectors for drift');
+      console.error(`[guidle] ${detailFetchesOk} detail page(s) returned HTML but yielded 0 events — check JSON-LD/DOM selectors for drift`);
       process.exitCode = 1;
     }
     return;
   }
 
-  mkdirSync(EVENTS_SLICE_DIR, { recursive: true });
   const slicePath = path.join(EVENTS_SLICE_DIR, `${SOURCE.key}.json`);
-  const slice = {
-    schemaVersion: 1,
+  const total = mergeEventsIntoSlice({
+    slicePath,
     sourceKey: SOURCE.key,
     sourceName: SOURCE.label,
-    assembledAt: crawledAt,
-    events,
-  };
-  writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
-  console.log(`[guidle] wrote ${events.length} events → ${path.relative(process.cwd(), slicePath)}`);
+    freshEvents: events,
+    goneIds,
+    crawledAt,
+  });
+  console.log(
+    `[guidle] merged ${events.length} event(s) (${goneIds.length} removed) → ${total} total in ${path.relative(process.cwd(), slicePath)}`,
+  );
 }
 
 // Only crawl when invoked directly (`node scripts/crawl-guidle-events.mjs`),

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -471,14 +471,22 @@ async function collectEventUrls(limit) {
   return { entries: limit ? entries.slice(0, limit) : entries, shardsOk, shardsFailed };
 }
 
+/**
+ * Returns `{ htmlOk, data }` — `htmlOk` is true whenever real HTML came back
+ * (independent of parse outcome) and is the signal callers use to tell
+ * "page genuinely unreachable" (htmlOk=false, safe to treat as gone) apart
+ * from "page loaded fine but our parser couldn't extract anything from it"
+ * (htmlOk=true, data=null — a structural-drift signal, NOT evidence the
+ * event is gone; must never feed into `goneIds`).
+ */
 async function fetchLocaleData(pathSuffix, locale) {
   const url = `${SITE_ORIGIN}/${locale}${pathSuffix}`;
   const html = await fetchText(url);
   await sleep(DETAIL_DELAY_MS);
-  if (!html) return null;
+  if (!html) return { htmlOk: false, data: null };
   detailFetchesOk += 1; // positive success signal — HTML came back, independent of parse outcome
   const mapped = mapDetailPageToLocaleData(html, locale);
-  return mapped ? { ...mapped, url } : null;
+  return { htmlOk: true, data: mapped ? { ...mapped, url } : null };
 }
 
 function parseArgs(argv) {
@@ -511,6 +519,7 @@ async function main() {
   const events = [];
   const goneIds = [];
   let goneEverywhere = 0;
+  let driftSuspected = 0;
   let resolvedComune = 0;
   let visited = 0;
   let cursor = startIndex;
@@ -525,14 +534,25 @@ async function main() {
 
     const [code, pathSuffix] = entries[cursor];
     const localeResults = {};
+    let anyHtmlOk = false;
     for (const locale of LOCALES) {
-      localeResults[locale] = await fetchLocaleData(pathSuffix, locale);
+      const { htmlOk, data } = await fetchLocaleData(pathSuffix, locale);
+      if (htmlOk) anyHtmlOk = true;
+      localeResults[locale] = data;
     }
 
     const mapped = mapGuidleEvent(code, localeResults);
     if (!mapped) {
-      goneEverywhere += 1;
-      goneIds.push(eventStableId(SOURCE.key, code));
+      if (anyHtmlOk) {
+        // Real HTML came back for at least one locale but nothing parsed —
+        // a drift signal, not evidence the event is gone. Leave it out of
+        // this run's contribution (neither added nor removed); the
+        // aggregate detailFetchesOk-based guard below surfaces the drift.
+        driftSuspected += 1;
+      } else {
+        goneEverywhere += 1;
+        goneIds.push(eventStableId(SOURCE.key, code));
+      }
     } else {
       const { event, imageSourceUrl, addressLocality, cantonHint } = mapped;
       const { comune, canton } = resolveComuneNationwide(
@@ -551,9 +571,14 @@ async function main() {
   }
 
   console.log(
-    `[guidle] visited ${visited}/${entries.length} event(s) this run — ${events.length} mapped (${goneEverywhere} expired/gone) — ` +
-      `comune resolved ${resolvedComune}/${events.length}`,
+    `[guidle] visited ${visited}/${entries.length} event(s) this run — ${events.length} mapped (${goneEverywhere} expired/gone, ` +
+      `${driftSuspected} suspected drift) — comune resolved ${resolvedComune}/${events.length}`,
   );
+  if (driftSuspected > 0) {
+    console.warn(
+      `[guidle] ${driftSuspected} event(s) returned real HTML but failed to parse — left untouched in the slice this run, check JSON-LD/DOM selectors for partial drift`,
+    );
+  }
 
   if (dryRun) {
     console.log('🏃 dry-run — slice/checkpoint not written');

--- a/scripts/crawl-myswitzerland-events.mjs
+++ b/scripts/crawl-myswitzerland-events.mjs
@@ -31,15 +31,26 @@
  * once via `mirrorEventImage` (see scripts/lib/events-utils.mjs) — the output
  * slice NEVER references a myswitzerland.com/cloudfront image URL directly.
  *
- * No artificial cap: a real run walks the ENTIRE catalog (tens of thousands of
- * records across ~20 Algolia buckets x 4 locales, then one detail-page fetch
- * per unique event). That detail-page pass is the slow part — at the polite
- * per-request delay below, a full run is a long-lived, scheduled crawl (hours,
- * not minutes), by design (issue #3125: "no pilot batch, must be complete").
+ * No artificial cap: the full catalog (tens of thousands of records across
+ * ~20 Algolia buckets x 4 locales, then one detail-page fetch per unique
+ * event) is walked across MANY scheduled runs, not one. Index enumeration
+ * (bounded, ~dozens-to-hundreds of Algolia calls) still runs in full every
+ * time, but the slow part — one detail-page fetch per unique event — is
+ * bounded per run by MYSWITZERLAND_CRAWL_BUDGET_MS (default 8 minutes, well
+ * inside crawl-events.yml's shared 35-minute job timeout): each run walks a
+ * slice of the enumerated records starting at a persisted cursor
+ * (data/events/checkpoints/myswitzerland.json, see
+ * scripts/lib/crawl-checkpoint.mjs) and wraps back to the start once the
+ * whole catalog has been visited. Each run MERGES what it found into the
+ * existing on-disk slice instead of overwriting it wholesale, so a run that
+ * stops at its time budget never loses prior runs' progress — coverage of
+ * the full catalog accrues over many scheduled runs (issue #3125: "no pilot
+ * batch, must be complete" — no permanent cap on total events ever
+ * crawled). Same design used for crawl-guidle-events.mjs.
  *
  * Usage:
- *   node scripts/crawl-myswitzerland-events.mjs                # full catalog
- *   node scripts/crawl-myswitzerland-events.mjs --limit=5      # fast local test
+ *   node scripts/crawl-myswitzerland-events.mjs                # one time-budgeted, checkpointed slice of the catalog
+ *   node scripts/crawl-myswitzerland-events.mjs --limit=5      # fast local test (bypasses the checkpoint)
  *   node scripts/crawl-myswitzerland-events.mjs --dry-run      # parse + report, no write
  *
  * Exit code is always 0 unless an unexpected crash occurs, EXCEPT when Algolia
@@ -48,7 +59,6 @@
  * silently stale (same soft/hard-fail distinction as crawl-tio-agenda.mjs).
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
@@ -59,6 +69,7 @@ import {
   resolveItalianFrontierComuni,
   mirrorEventImage,
 } from './lib/events-utils.mjs';
+import { loadCursor, saveCursor, mergeEventsIntoSlice } from './lib/crawl-checkpoint.mjs';
 
 const SOURCE = EVENT_SOURCES.myswitzerland;
 
@@ -78,6 +89,7 @@ const USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://
 const FETCH_TIMEOUT_MS = 20000;
 const ALGOLIA_DELAY_MS = 120; // between Algolia queries (index enumeration)
 const DETAIL_DELAY_MS = 500; // between myswitzerland.com origin detail-page fetches
+const RUN_BUDGET_MS = Number(process.env.MYSWITZERLAND_CRAWL_BUDGET_MS) || 8 * 60_000; // per-run wall-clock cap
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -444,6 +456,7 @@ function parseArgs(argv) {
 async function main() {
   const { dryRun, limit } = parseArgs(process.argv.slice(2));
   const crawledAt = new Date().toISOString();
+  const deadline = Date.now() + RUN_BUDGET_MS;
 
   const localeMaps = {};
   for (const locale of LOCALES) {
@@ -454,14 +467,29 @@ async function main() {
   }
 
   let records = groupHitsByObjectId(localeMaps);
-  console.log(`[myswitzerland] ${records.length} unique event(s) merged across ${LOCALES.length} locales`);
+  console.log(`[myswitzerland] ${records.length} unique event(s) in catalog across ${LOCALES.length} locales`);
   if (limit) records = records.slice(0, limit);
+
+  const startIndex = limit ? 0 : loadCursor(SOURCE.key) % Math.max(records.length, 1);
+  if (!limit && startIndex > 0) {
+    console.log(`[myswitzerland] resuming from checkpoint index ${startIndex}/${records.length}`);
+  }
 
   const events = [];
   let detailOk = 0;
   let detailFail = 0;
-  for (let i = 0; i < records.length; i += 1) {
-    const rec = records[i];
+  let visited = 0;
+  let cursor = startIndex;
+
+  while (visited < records.length) {
+    if (!limit && Date.now() >= deadline) {
+      console.log(
+        `[myswitzerland] time budget (${RUN_BUDGET_MS}ms) reached after ${visited}/${records.length} event(s) — stopping, will resume next run`,
+      );
+      break;
+    }
+
+    const rec = records[cursor];
     const enrichment = await fetchDetailEnrichment(rec.perLocaleHits);
     if (enrichment) detailOk += 1;
     else detailFail += 1;
@@ -481,48 +509,59 @@ async function main() {
       events.push(event);
     }
 
-    if (i < records.length - 1) await sleep(DETAIL_DELAY_MS);
+    visited += 1;
+    cursor = (cursor + 1) % records.length;
+    if (visited < records.length) await sleep(DETAIL_DELAY_MS);
   }
 
   const resolved = events.filter((e) => e.comune).length;
   console.log(
-    `[myswitzerland] ${events.length} events written — detail-page enrichment ${detailOk} ok / ${detailFail} fallback ` +
-      `(index-only fields) — comune resolved ${resolved}/${events.length}`,
+    `[myswitzerland] visited ${visited}/${records.length} event(s) this run — ${events.length} mapped — ` +
+      `detail-page enrichment ${detailOk} ok / ${detailFail} fallback (index-only fields) — comune resolved ${resolved}/${events.length}`,
   );
 
   if (dryRun) {
-    console.log('🏃 dry-run — slice not written');
+    console.log('🏃 dry-run — slice/checkpoint not written');
     console.log(JSON.stringify(events.slice(0, 3), null, 2));
     return;
   }
 
+  if (!limit && records.length > 0) saveCursor(SOURCE.key, cursor, crawledAt);
+
   if (events.length === 0) {
-    // Never overwrite a good slice with an empty one. Distinguish two causes:
+    // Never overwrite a good slice with an empty run. Distinguish three causes:
+    //  - the time budget ran out during Algolia enumeration itself, before any
+    //    record was even visited (visited===0) → transient, soft-exit 0. This
+    //    is expected on a slow run and NOT a drift signal: we never got far
+    //    enough to learn anything about mapEventRecord/JSON-LD health.
     //  - Algolia queries themselves failed (network/WAF) → transient, soft-exit 0.
-    //  - Algolia queries succeeded but nothing mapped to a valid event → likely
+    //  - records were actually visited this run and none mapped → likely
     //    index/key/facet drift; exit non-zero so crawl-events.yml opens a
     //    failure issue instead of letting the dataset go silently stale.
-    console.log('[myswitzerland] 0 events parsed — leaving existing slice untouched');
-    if (algoliaFailures > 0) {
+    console.log('[myswitzerland] 0 events mapped this run — leaving existing slice untouched');
+    if (visited === 0) {
+      console.log('[myswitzerland] time budget exhausted before any record was visited — transient, soft-exit 0');
+    } else if (algoliaFailures > 0) {
       console.log(`[myswitzerland] ${algoliaFailures} Algolia request(s) failed — transient, soft-exit 0`);
     } else {
-      console.error('[myswitzerland] Algolia queries succeeded but yielded 0 events — check ALGOLIA_APP_ID/ALGOLIA_SEARCH_KEY/LOCALE_INDEX for drift');
+      console.error(
+        `[myswitzerland] ${visited} record(s) visited this run but 0 mapped — check ALGOLIA_APP_ID/ALGOLIA_SEARCH_KEY/LOCALE_INDEX for drift`,
+      );
       process.exitCode = 1;
     }
     return;
   }
 
-  mkdirSync(EVENTS_SLICE_DIR, { recursive: true });
   const slicePath = path.join(EVENTS_SLICE_DIR, `${SOURCE.key}.json`);
-  const slice = {
-    schemaVersion: 1,
+  const total = mergeEventsIntoSlice({
+    slicePath,
     sourceKey: SOURCE.key,
     sourceName: SOURCE.label,
-    assembledAt: crawledAt,
-    events,
-  };
-  writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
-  console.log(`[myswitzerland] wrote ${events.length} events → ${path.relative(process.cwd(), slicePath)}`);
+    freshEvents: events,
+    goneIds: [],
+    crawledAt,
+  });
+  console.log(`[myswitzerland] merged ${events.length} event(s) → ${total} total in ${path.relative(process.cwd(), slicePath)}`);
 }
 
 // Only crawl when invoked directly (`node scripts/crawl-myswitzerland-events.mjs`),

--- a/scripts/crawl-myswitzerland-events.mjs
+++ b/scripts/crawl-myswitzerland-events.mjs
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+/**
+ * Crawler — MySwitzerland (Switzerland Tourism nationwide events, issue #3125).
+ *
+ * MySwitzerland's public event search UI (https://www.myswitzerland.com/it-ch/
+ * scoprire-la-svizzera/manifestazioni/manifestazioni-ricerca/) runs against an
+ * Algolia search index. The app id + a READ-ONLY, search-only API key are baked
+ * into the page's inline JS config (`algolia: { app, key, index, ... }`) — this
+ * is the exact same public data every visitor's browser already loads to render
+ * the search results, so querying it directly with plain `fetch` is legitimate
+ * content aggregation, not evasion. Verified live 2026-07-02:
+ *   - app "LMQVZQEU2J", one index per locale: myst_it-CH / myst_en-CH /
+ *     myst_de-CH / myst_fr-CH (all four confirmed live, near-identical counts).
+ *   - the `browse` endpoint (cursor-based, uncapped) is 403 for this key
+ *     ("missing ACL \"browse\""), and any single `query` call is hard-capped at
+ *     1000 reachable results (page*hitsPerPage <= 1000) — confirmed live. Full
+ *     enumeration therefore recursively bisects the numeric `updatedTimestamp`
+ *     attribute into <=1000-hit buckets (see `enumerateEventsForLocale`).
+ *   - the search index gives id/title/description/dates/geo/image/place per
+ *     locale, but NOT price/structured address/category — those only exist as
+ *     schema.org Event JSON-LD on each event's own detail page, so we fetch
+ *     one detail page per unique event (across up to 4 locale URLs) to enrich.
+ *   - `objectID` is stable across all 4 locale indices for the same event, so
+ *     the 4 locale searches are unioned by id to build titleByLocale /
+ *     descriptionByLocale (real per-locale translations, not machine ones).
+ *
+ * Respectful, non-evasive crawling: plain `fetch`, no headless browser, no
+ * TLS/header spoofing, a clearly identifying User-Agent (matches the tio-agenda
+ * / mirrorEventImage convention), and a politeness delay between requests to
+ * both Algolia and the myswitzerland.com origin. Every event image is mirrored
+ * once via `mirrorEventImage` (see scripts/lib/events-utils.mjs) — the output
+ * slice NEVER references a myswitzerland.com/cloudfront image URL directly.
+ *
+ * No artificial cap: a real run walks the ENTIRE catalog (tens of thousands of
+ * records across ~20 Algolia buckets x 4 locales, then one detail-page fetch
+ * per unique event). That detail-page pass is the slow part — at the polite
+ * per-request delay below, a full run is a long-lived, scheduled crawl (hours,
+ * not minutes), by design (issue #3125: "no pilot batch, must be complete").
+ *
+ * Usage:
+ *   node scripts/crawl-myswitzerland-events.mjs                # full catalog
+ *   node scripts/crawl-myswitzerland-events.mjs --limit=5      # fast local test
+ *   node scripts/crawl-myswitzerland-events.mjs --dry-run      # parse + report, no write
+ *
+ * Exit code is always 0 unless an unexpected crash occurs, EXCEPT when Algolia
+ * queries succeed but yield zero events (index/key/facet drift) — that exits 1
+ * so crawl-events.yml can open a failure issue instead of the dataset going
+ * silently stale (same soft/hard-fail distinction as crawl-tio-agenda.mjs).
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  EVENT_SOURCES,
+  EVENTS_SLICE_DIR,
+  eventStableId,
+  resolveComuneNationwide,
+  resolveItalianFrontierComuni,
+  mirrorEventImage,
+} from './lib/events-utils.mjs';
+
+const SOURCE = EVENT_SOURCES.myswitzerland;
+
+// Public, read-only Algolia search credentials for the MySwitzerland event
+// search UI — NOT a secret (see header comment). No admin/write/browse ACL.
+const ALGOLIA_APP_ID = 'LMQVZQEU2J';
+const ALGOLIA_SEARCH_KEY = '913f352bafbf1fcb6735609f39cc7399';
+const ALGOLIA_HOST = `https://${ALGOLIA_APP_ID}-dsn.algolia.net`;
+const ALGOLIA_PAGE_CAP = 1000; // Algolia's hard per-query pagination cap (verified live)
+
+const LOCALES = ['it', 'en', 'de', 'fr'];
+const LOCALE_INDEX = { it: 'myst_it-CH', en: 'myst_en-CH', de: 'myst_de-CH', fr: 'myst_fr-CH' };
+const LOCALE_URL_PREFIX = { it: 'it-ch', en: 'en-ch', de: 'de-ch', fr: 'fr-ch' };
+const SITE_ORIGIN = 'https://www.myswitzerland.com';
+
+const USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch)';
+const FETCH_TIMEOUT_MS = 20000;
+const ALGOLIA_DELAY_MS = 120; // between Algolia queries (index enumeration)
+const DETAIL_DELAY_MS = 500; // between myswitzerland.com origin detail-page fetches
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let algoliaFailures = 0;
+
+async function algoliaQuery(index, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ALGOLIA_HOST}/1/indexes/${index}/query`, {
+      method: 'POST',
+      headers: {
+        'X-Algolia-Application-Id': ALGOLIA_APP_ID,
+        'X-Algolia-API-Key': ALGOLIA_SEARCH_KEY,
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      algoliaFailures += 1;
+      return null;
+    }
+    return await res.json();
+  } catch {
+    algoliaFailures += 1;
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchHtml(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT }, signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Enumerate ALL "Event"-type records in one locale index via recursive
+ * numeric bisection on `updatedTimestamp`. A single Algolia query cannot
+ * reach past 1000 results (verified live) and this key has no `browse` ACL
+ * (also verified live, 403), so a flat paginated walk cannot cover the full
+ * ~19-20k catalog. Instead we recursively halve the timestamp range until
+ * each leaf bucket has <=1000 hits, then fetch that leaf in one page. Cheap
+ * `hitsPerPage:0` count-only calls drive the recursion.
+ *
+ * Caveat: this is a live, actively-edited production index — a record whose
+ * `updatedTimestamp` shifts mid-crawl can in theory be counted by two leaves
+ * or missed by all of them. Downstream dedup is by `objectID` (a Map), so a
+ * double-count is harmless; a rare miss self-heals on the next scheduled
+ * crawl. Empirically verified live: a real disjoint left/right split had ZERO
+ * objectID overlap — observed total-count drift across a full multi-minute
+ * bisection came from live data churn, not a boundary bug.
+ */
+async function enumerateEventsForLocale(index) {
+  const byId = new Map();
+  const hi = Math.floor(Date.now() / 1000) + 30 * 86400;
+
+  async function leaf(lo, hiBound) {
+    const counted = await algoliaQuery(index, {
+      query: '',
+      hitsPerPage: 0,
+      facetFilters: [['type:Event']],
+      numericFilters: [`updatedTimestamp>=${lo}`, `updatedTimestamp<${hiBound}`],
+    });
+    await sleep(ALGOLIA_DELAY_MS);
+    const nbHits = counted?.nbHits ?? 0;
+    if (nbHits === 0) return;
+
+    if (nbHits <= ALGOLIA_PAGE_CAP || hiBound - lo <= 1) {
+      const page = await algoliaQuery(index, {
+        query: '',
+        hitsPerPage: ALGOLIA_PAGE_CAP,
+        facetFilters: [['type:Event']],
+        numericFilters: [`updatedTimestamp>=${lo}`, `updatedTimestamp<${hiBound}`],
+      });
+      await sleep(ALGOLIA_DELAY_MS);
+      const hits = page?.hits ?? [];
+      if (hits.length < nbHits) {
+        console.warn(
+          `[myswitzerland] ${index}: indivisible bucket [${lo},${hiBound}) has ${nbHits} hits but the ` +
+            `1000-per-query cap only returned ${hits.length} — some events in this bucket are skipped this run`,
+        );
+      }
+      for (const h of hits) if (h?.objectID) byId.set(h.objectID, h);
+      return;
+    }
+
+    const mid = Math.floor((lo + hiBound) / 2);
+    await leaf(lo, mid);
+    await leaf(mid, hiBound);
+  }
+
+  await leaf(0, hi);
+  return byId;
+}
+
+/** Fast, non-exhaustive variant for `--limit` local iteration: one page, no bisection. */
+async function enumerateEventsForLocaleLimited(index, limit) {
+  const byId = new Map();
+  const page = await algoliaQuery(index, {
+    query: '',
+    hitsPerPage: Math.min(Math.max(limit, 1), ALGOLIA_PAGE_CAP),
+    facetFilters: [['type:Event']],
+  });
+  for (const h of page?.hits ?? []) if (h?.objectID) byId.set(h.objectID, h);
+  return byId;
+}
+
+/** Group per-locale hit maps by shared `objectID` (stable across locale indices). */
+function groupHitsByObjectId(localeMaps) {
+  const allIds = new Set();
+  for (const locale of LOCALES) for (const id of localeMaps[locale].keys()) allIds.add(id);
+  const out = [];
+  for (const id of allIds) {
+    const perLocaleHits = {};
+    for (const locale of LOCALES) {
+      const hit = localeMaps[locale].get(id);
+      if (hit) perLocaleHits[locale] = hit;
+    }
+    out.push({ objectID: id, perLocaleHits });
+  }
+  return out;
+}
+
+const COMPACT_UTC_RE = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/;
+
+/** "20260704T173000Z" (Algolia's compact UTC format) → Date, or null. */
+export function parseCompactUtc(compact) {
+  const m = COMPACT_UTC_RE.exec(String(compact || ''));
+  if (!m) return null;
+  return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6]));
+}
+
+/** Europe/Zurich local {date:'YYYY-MM-DD', time:'HH:MM'} for a UTC instant. */
+export function zurichParts(date) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Zurich',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(date).map((p) => [p.type, p.value]));
+  return { date: `${parts.year}-${parts.month}-${parts.day}`, time: `${parts.hour}:${parts.minute}` };
+}
+
+/**
+ * Extract {startDate, startTime, endDate, recurring} from an Algolia hit's
+ * `applicableDates.rules[].conditions.{from,to}` (each a real UTC instant —
+ * verified live against the same event's naive-local JSON-LD startDate/
+ * endDate, which matched exactly once converted to Europe/Zurich). Falls back
+ * to `executionDates` (unix seconds) when no rules are present. Multiple
+ * rules/executionDates ⇒ a recurring event (multiple real occurrences).
+ * Returns null when the hit has no usable date at all (dropped by the caller
+ * — `startDate` is required downstream).
+ */
+export function extractDateInfo(hit) {
+  const rules = Array.isArray(hit?.applicableDates?.rules) ? hit.applicableDates.rules : [];
+  const starts = [];
+  const ends = [];
+  for (const rule of rules) {
+    const from = parseCompactUtc(rule?.conditions?.from);
+    const to = parseCompactUtc(rule?.conditions?.to);
+    if (from) starts.push(from);
+    if (to) ends.push(to);
+    else if (from) ends.push(from);
+  }
+  if (!starts.length && Array.isArray(hit?.executionDates)) {
+    for (const ts of hit.executionDates) {
+      if (typeof ts === 'number' && Number.isFinite(ts)) starts.push(new Date(ts * 1000));
+    }
+  }
+  if (!starts.length) return null;
+
+  starts.sort((a, b) => a - b);
+  const first = starts[0];
+  const last = ends.length ? ends.sort((a, b) => a - b)[ends.length - 1] : starts[starts.length - 1];
+
+  const startParts = zurichParts(first);
+  const endParts = zurichParts(last);
+  const occurrences = Math.max(rules.length, Array.isArray(hit?.executionDates) ? hit.executionDates.length : 0, 1);
+
+  return {
+    startDate: startParts.date,
+    startTime: startParts.time,
+    endDate: endParts.date,
+    recurring: occurrences > 1,
+  };
+}
+
+function cleanText(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractGeo(hit) {
+  const g = hit?._geoloc;
+  if (!g || typeof g.lat !== 'number' || typeof g.lng !== 'number') return undefined;
+  return { lat: g.lat, lng: g.lng };
+}
+
+/** Humanize a schema.org Event @type ("MusicEvent" → "Music", "Festival" → "Festival"). */
+export function humanizeCategory(rawType) {
+  if (typeof rawType !== 'string' || !rawType.trim()) return undefined;
+  const stripped = rawType.replace(/Event$/, '').trim();
+  const base = stripped || rawType;
+  return base.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim() || 'Event';
+}
+
+/** Price from JSON-LD `offers` (object or array) or `isAccessibleForFree`. Undefined when unknown. */
+export function extractPrice(ld) {
+  const offersRaw = ld?.offers;
+  const offers = Array.isArray(offersRaw) ? offersRaw : offersRaw ? [offersRaw] : [];
+  const priced = offers
+    .map((o) => (o && o.price !== undefined && o.price !== null ? Number(o.price) : NaN))
+    .filter((n) => Number.isFinite(n));
+  if (priced.length) {
+    const amount = Math.min(...priced);
+    const currency = offers.find((o) => typeof o?.priceCurrency === 'string')?.priceCurrency || 'CHF';
+    return { amount, currency, isFree: amount === 0 };
+  }
+  if (ld?.isAccessibleForFree === true) return { amount: 0, currency: 'CHF', isFree: true };
+  return undefined;
+}
+
+/** {street, postalCode} from JSON-LD `location.address` (PostalAddress), or undefined. */
+export function extractAddress(ld) {
+  const addr = ld?.location?.address;
+  if (!addr || typeof addr !== 'object') return undefined;
+  const street = typeof addr.streetAddress === 'string' && addr.streetAddress.trim() ? addr.streetAddress.trim() : undefined;
+  const postalCode = typeof addr.postalCode === 'string' && addr.postalCode.trim() ? addr.postalCode.trim() : undefined;
+  if (!street && !postalCode) return undefined;
+  return { street, postalCode };
+}
+
+function extractVenue(ld, fallbackPlace) {
+  const name = ld?.location?.name;
+  if (typeof name === 'string' && name.trim()) return name.trim();
+  return fallbackPlace || undefined;
+}
+
+const LD_JSON_RE = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+
+/** Pick the schema.org Event(-subtype) JSON-LD block off a detail page (skips BreadcrumbList etc). */
+export function extractEventJsonLd(html) {
+  if (typeof html !== 'string' || !html) return null;
+  LD_JSON_RE.lastIndex = 0;
+  let match;
+  while ((match = LD_JSON_RE.exec(html))) {
+    try {
+      const obj = JSON.parse(match[1]);
+      if (obj && typeof obj === 'object' && obj['@type'] && obj.startDate) return obj;
+    } catch {
+      // malformed block — keep scanning the rest of the page
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure mapping: one merged event (grouped Algolia hits across locales, plus
+ * optional detail-page JSON-LD enrichment) → a SiteEvent-shaped record. Never
+ * touches the network — `enrichment` is pre-fetched by the caller. Returns
+ * `null` when the record has no usable title/date (dropped, not emitted).
+ * `comune`/`canton` are left blank (`''`/undefined) and `imageUrl` absent —
+ * those are filled in by `main()` (comune resolution + image mirroring are
+ * async/impure and already covered by their own unit tests in
+ * events-nationwide-sources.test.ts).
+ */
+export function mapEventRecord(objectID, perLocaleHits, enrichment = {}) {
+  const { detailLd, detailUrl } = enrichment;
+  const primaryLocale = LOCALES.find((l) => perLocaleHits[l]);
+  const primary = primaryLocale ? perLocaleHits[primaryLocale] : undefined;
+  if (!primary) return null;
+
+  const dateInfo = extractDateInfo(primary);
+  if (!dateInfo) return null;
+
+  const titleByLocale = {};
+  const descriptionByLocale = {};
+  for (const locale of LOCALES) {
+    const hit = perLocaleHits[locale];
+    if (!hit) continue;
+    if (typeof hit.title === 'string' && hit.title.trim()) titleByLocale[locale] = hit.title.trim();
+    const desc = cleanText(hit.leadText) || cleanText(hit.content);
+    if (desc) descriptionByLocale[locale] = desc;
+  }
+  const title = titleByLocale.it || titleByLocale.en || titleByLocale.de || titleByLocale.fr;
+  if (!title) return null;
+  const description = descriptionByLocale.it || descriptionByLocale.en || descriptionByLocale.de || descriptionByLocale.fr;
+
+  const rawUrl = detailUrl
+    || `${SITE_ORIGIN}/${LOCALE_URL_PREFIX[primaryLocale]}${String(primary.url || '').startsWith('/') ? primary.url : `/${primary.url || ''}`}`;
+
+  return {
+    event: {
+      id: eventStableId(SOURCE.key, objectID),
+      title,
+      titleByLocale: Object.keys(titleByLocale).length ? titleByLocale : undefined,
+      description: description || undefined,
+      descriptionByLocale: Object.keys(descriptionByLocale).length ? descriptionByLocale : undefined,
+      startDate: dateInfo.startDate,
+      endDate: dateInfo.endDate,
+      startTime: dateInfo.startTime,
+      category: humanizeCategory(detailLd?.['@type']) || 'Event',
+      venue: extractVenue(detailLd, primary.place),
+      comune: undefined,
+      canton: '',
+      url: rawUrl,
+      sourceKey: SOURCE.key,
+      sourceName: SOURCE.label,
+      price: extractPrice(detailLd),
+      address: extractAddress(detailLd),
+      geo: extractGeo(primary),
+      recurring: dateInfo.recurring,
+    },
+    imageSourceUrl: primary.image || undefined,
+    place: primary.place || undefined,
+  };
+}
+
+/** One detail-page fetch per event, trying each locale URL until one parses. */
+async function fetchDetailEnrichment(perLocaleHits) {
+  for (const locale of LOCALES) {
+    const hit = perLocaleHits[locale];
+    if (!hit?.url) continue;
+    const path_ = String(hit.url).startsWith('/') ? hit.url : `/${hit.url}`;
+    const url = `${SITE_ORIGIN}/${LOCALE_URL_PREFIX[locale]}${path_}`;
+    const html = await fetchHtml(url);
+    if (!html) continue;
+    const ld = extractEventJsonLd(html);
+    if (ld) return { detailLd: ld, detailUrl: url };
+  }
+  return null;
+}
+
+function parseArgs(argv) {
+  const dryRun = argv.includes('--dry-run');
+  let limit;
+  const eqArg = argv.find((a) => a.startsWith('--limit='));
+  if (eqArg) {
+    limit = Number.parseInt(eqArg.slice('--limit='.length), 10);
+  } else {
+    const idx = argv.indexOf('--limit');
+    if (idx >= 0) limit = Number.parseInt(argv[idx + 1] || '', 10);
+  }
+  if (!Number.isFinite(limit) || limit <= 0) limit = undefined;
+  return { dryRun, limit };
+}
+
+async function main() {
+  const { dryRun, limit } = parseArgs(process.argv.slice(2));
+  const crawledAt = new Date().toISOString();
+
+  const localeMaps = {};
+  for (const locale of LOCALES) {
+    const index = LOCALE_INDEX[locale];
+    const map = limit ? await enumerateEventsForLocaleLimited(index, limit) : await enumerateEventsForLocale(index);
+    localeMaps[locale] = map;
+    console.log(`[myswitzerland] ${locale} (${index}): ${map.size} Event record(s)`);
+  }
+
+  let records = groupHitsByObjectId(localeMaps);
+  console.log(`[myswitzerland] ${records.length} unique event(s) merged across ${LOCALES.length} locales`);
+  if (limit) records = records.slice(0, limit);
+
+  const events = [];
+  let detailOk = 0;
+  let detailFail = 0;
+  for (let i = 0; i < records.length; i += 1) {
+    const rec = records[i];
+    const enrichment = await fetchDetailEnrichment(rec.perLocaleHits);
+    if (enrichment) detailOk += 1;
+    else detailFail += 1;
+
+    const mapped = mapEventRecord(rec.objectID, rec.perLocaleHits, enrichment || {});
+    if (mapped) {
+      const { event, imageSourceUrl, place } = mapped;
+      const { comune, canton } = resolveComuneNationwide(
+        { venue: [event.venue, place].filter(Boolean).join(' '), title: event.title, region: undefined },
+        undefined,
+      );
+      event.comune = comune || undefined;
+      event.canton = canton || '';
+      event.imageUrl = (await mirrorEventImage(imageSourceUrl, event.id)) || undefined;
+      const frontier = resolveItalianFrontierComuni(event.geo);
+      if (frontier.length) event.italianFrontierComuni = frontier;
+      events.push(event);
+    }
+
+    if (i < records.length - 1) await sleep(DETAIL_DELAY_MS);
+  }
+
+  const resolved = events.filter((e) => e.comune).length;
+  console.log(
+    `[myswitzerland] ${events.length} events written — detail-page enrichment ${detailOk} ok / ${detailFail} fallback ` +
+      `(index-only fields) — comune resolved ${resolved}/${events.length}`,
+  );
+
+  if (dryRun) {
+    console.log('🏃 dry-run — slice not written');
+    console.log(JSON.stringify(events.slice(0, 3), null, 2));
+    return;
+  }
+
+  if (events.length === 0) {
+    // Never overwrite a good slice with an empty one. Distinguish two causes:
+    //  - Algolia queries themselves failed (network/WAF) → transient, soft-exit 0.
+    //  - Algolia queries succeeded but nothing mapped to a valid event → likely
+    //    index/key/facet drift; exit non-zero so crawl-events.yml opens a
+    //    failure issue instead of letting the dataset go silently stale.
+    console.log('[myswitzerland] 0 events parsed — leaving existing slice untouched');
+    if (algoliaFailures > 0) {
+      console.log(`[myswitzerland] ${algoliaFailures} Algolia request(s) failed — transient, soft-exit 0`);
+    } else {
+      console.error('[myswitzerland] Algolia queries succeeded but yielded 0 events — check ALGOLIA_APP_ID/ALGOLIA_SEARCH_KEY/LOCALE_INDEX for drift');
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  mkdirSync(EVENTS_SLICE_DIR, { recursive: true });
+  const slicePath = path.join(EVENTS_SLICE_DIR, `${SOURCE.key}.json`);
+  const slice = {
+    schemaVersion: 1,
+    sourceKey: SOURCE.key,
+    sourceName: SOURCE.label,
+    assembledAt: crawledAt,
+    events,
+  };
+  writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
+  console.log(`[myswitzerland] wrote ${events.length} events → ${path.relative(process.cwd(), slicePath)}`);
+}
+
+// Only crawl when invoked directly (`node scripts/crawl-myswitzerland-events.mjs`),
+// so tests can import the pure mapping functions without triggering a live crawl.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`[myswitzerland] crawl failed: ${err?.message || err}`);
+    process.exit(1);
+  });
+}

--- a/scripts/ensure-image-cdn-redirect.mjs
+++ b/scripts/ensure-image-cdn-redirect.mjs
@@ -38,7 +38,7 @@ const CDN_BASE = 'https://cdn.frontaliereticino.ch';
 // pushes to the CDN and then removes from the artifact 404s on the apex for
 // external referrers / Google-Images cache — exactly the class this rule
 // recovers. That is a SUPERSET of CDN_OFFLOADED_IMAGE_PREFIXES in
-// services/cdnImageBase.ts (the 6 image prefixes rewritten at SPA/HTML render
+// services/cdnImageBase.ts (the 7 image prefixes rewritten at SPA/HTML render
 // time): it also includes `/og/` (per-job OG cards) and `/images/blog/thumbnails/`
 // (blog 480w thumbnails, offloaded via getResponsiveImageSet, not cdnImageUrl).
 // MUST stay in sync with that TARGETS list. `/images/places/` is deliberately
@@ -52,6 +52,7 @@ const OFFLOADED_PREFIXES = [
   '/images/logos/',
   '/images/authors/',
   '/images/publisher/',
+  '/images/events/',
 ];
 
 const RULE_DESCRIPTION = 'Offloaded images -> CDN (apex 404 recovery)';

--- a/scripts/lib/crawl-checkpoint.mjs
+++ b/scripts/lib/crawl-checkpoint.mjs
@@ -1,0 +1,72 @@
+/**
+ * Cross-run checkpoint + incremental-merge helpers for crawlers whose full
+ * catalog can't fit in a single scheduled run (guidle: 119'800 events,
+ * myswitzerland: tens of thousands — both at politeness-delay pace, minutes
+ * not hours, per scheduled invocation). Each run visits a bounded, time-
+ * budgeted slice of the catalog starting where the previous run left off
+ * (`loadCursor`/`saveCursor`), and merges whatever it found into the
+ * existing on-disk slice (`mergeEventsIntoSlice`) instead of overwriting it
+ * wholesale — so a killed/budget-exhausted run never loses prior progress,
+ * and full coverage accrues across many scheduled runs (issue #3125: "no
+ * pilot batch, must be complete" — no permanent cap on total events).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { EVENTS_SLICE_DIR } from './events-utils.mjs';
+
+export const CHECKPOINT_DIR = path.join(EVENTS_SLICE_DIR, '..', 'checkpoints');
+
+/** Index to resume from in this source's catalog; 0 if no checkpoint yet. */
+export function loadCursor(sourceKey, checkpointDir = CHECKPOINT_DIR) {
+  const file = path.join(checkpointDir, `${sourceKey}.json`);
+  if (!existsSync(file)) return 0;
+  try {
+    const data = JSON.parse(readFileSync(file, 'utf-8'));
+    return Number.isInteger(data.nextIndex) && data.nextIndex >= 0 ? data.nextIndex : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function saveCursor(sourceKey, nextIndex, updatedAt, checkpointDir = CHECKPOINT_DIR) {
+  mkdirSync(checkpointDir, { recursive: true });
+  const file = path.join(checkpointDir, `${sourceKey}.json`);
+  writeFileSync(file, `${JSON.stringify({ nextIndex, updatedAt }, null, 2)}\n`, 'utf-8');
+}
+
+/**
+ * Upsert `freshEvents` (by stable `id`) into the slice already on disk,
+ * drop any id in `goneIds` (events explicitly revisited and confirmed
+ * expired/removed this run), and prune anything whose last relevant date
+ * (endDate || startDate) is already in the past — a source-agnostic
+ * safety net so events that silently drop out of a source's own listing
+ * (and are therefore never revisited/explicitly marked gone) don't linger
+ * in the slice forever. Returns the resulting total event count.
+ */
+export function mergeEventsIntoSlice({ slicePath, sourceKey, sourceName, freshEvents, goneIds, crawledAt }) {
+  let existing = [];
+  if (existsSync(slicePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(slicePath, 'utf-8'));
+      if (Array.isArray(parsed.events)) existing = parsed.events;
+    } catch {
+      existing = [];
+    }
+  }
+
+  const byId = new Map(existing.map((event) => [event.id, event]));
+  for (const id of goneIds || []) byId.delete(id);
+  for (const event of freshEvents) byId.set(event.id, event);
+
+  const todayIso = String(crawledAt).slice(0, 10);
+  const events = [...byId.values()].filter((event) => {
+    const lastRelevant = event.endDate || event.startDate;
+    return !lastRelevant || lastRelevant >= todayIso;
+  });
+
+  mkdirSync(path.dirname(slicePath), { recursive: true });
+  const slice = { schemaVersion: 1, sourceKey, sourceName, assembledAt: crawledAt, events };
+  writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
+  return events.length;
+}

--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -234,14 +234,15 @@ step_push_cdn() {
   # once this push succeeds (see its job-canon phase).
   [ -d dist/job-canon ]    && cp -r dist/job-canon    "$stage/job-canon"
   [ -d public/images/blog ] && mkdir -p "$stage/images" && cp -r public/images/blog "$stage/images/blog"
-  # Self-hosted brand/logo/author images (#1360): push from the git-tracked
-  # public/images/<dir> source to ${CDN}/images/<dir>, so the offload script
-  # (offload-generated-images-cdn.mjs IMAGE TARGETS) can rewrite the static
-  # HTML refs + the SPA's cdnImageUrl() runtime refs to the CDN and then
-  # delete the dist copies. MUST stay in sync with that script's TARGETS and
-  # services/cdnImageBase.ts CDN_OFFLOADED_IMAGE_PREFIXES. (/images/places is
-  # intentionally excluded — it stays same-origin.)
-  for d in brands insurers providers logos authors publisher; do
+  # Self-hosted brand/logo/author images (#1360) + nationwide events source
+  # images (#3125, mirrorEventImage -> public/images/events/): push from the
+  # git-tracked public/images/<dir> source to ${CDN}/images/<dir>, so the
+  # offload script (offload-generated-images-cdn.mjs IMAGE TARGETS) can
+  # rewrite the static HTML refs + the SPA's cdnImageUrl() runtime refs to the
+  # CDN and then delete the dist copies. MUST stay in sync with that script's
+  # TARGETS and services/cdnImageBase.ts CDN_OFFLOADED_IMAGE_PREFIXES.
+  # (/images/places is intentionally excluded — it stays same-origin.)
+  for d in brands insurers providers logos authors publisher events; do
     [ -d "public/images/$d" ] && mkdir -p "$stage/images" && cp -r "public/images/$d" "$stage/images/$d"
   done
   # Strip junk the recursive copies drag in: macOS .DS_Store files and the

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -79,8 +79,11 @@ export const EVENTS_BASE_PATH = {
 // tests/events-utils.test.ts.
 const EVENTS_LOCALIZED_SEGMENT = {
   it: (slug) => `/eventi/${slug}`,
+  // locale-segment-ok: per-locale branch keyed by its own locale, each arm only ever emits its own segment
   en: (slug) => `/en/events/${slug}`,
+  // locale-segment-ok: per-locale branch keyed by its own locale, each arm only ever emits its own segment
   de: (slug) => `/de/veranstaltungen/${slug}`,
+  // locale-segment-ok: per-locale branch keyed by its own locale, each arm only ever emits its own segment
   fr: (slug) => `/fr/evenements/${slug}`,
 };
 

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -91,17 +91,30 @@ const EVENTS_LOCALIZED_SEGMENT = {
  * back to the literal `EVENTS_BASE_PATH` (TI) for an unknown/blank canton so
  * callers that don't resolve a canton degrade to the original MVP behavior.
  */
+/**
+ * Resolve a real canton BFS code (or half-canton member) to the URL group key
+ * used by `data/canton-url-slugs.json` (e.g. `AI`/`AR` → `APPENZELLO`,
+ * `BL`/`BS` → `BASILEA`, everything else → itself unchanged). Extracted so
+ * both `eventsBasePathForCanton` and `germanCantonPreposition` share one
+ * canton→URL-key resolver (§6). Returns the uppercased input unchanged when
+ * it is not a recognised group member.
+ */
+export function resolveCantonUrlKey(canton) {
+  const code = String(canton || '').toUpperCase().trim();
+  if (!code) return code;
+  const groups = CANTON_URL_SLUGS.cantonGroups ?? {};
+  for (const [groupKey, def] of Object.entries(groups)) {
+    if ((def?.members ?? []).map((m) => String(m).toUpperCase()).includes(code)) {
+      return groupKey;
+    }
+  }
+  return code;
+}
+
 export function eventsBasePathForCanton(canton) {
   const code = String(canton || '').toUpperCase().trim();
   if (!code) return EVENTS_BASE_PATH;
-  const groups = CANTON_URL_SLUGS.cantonGroups ?? {};
-  let urlKey = code;
-  for (const [groupKey, def] of Object.entries(groups)) {
-    if ((def?.members ?? []).map((m) => String(m).toUpperCase()).includes(code)) {
-      urlKey = groupKey;
-      break;
-    }
-  }
+  const urlKey = resolveCantonUrlKey(code);
   const record = CANTON_URL_SLUGS.cantons?.[urlKey];
   if (!record) return EVENTS_BASE_PATH;
   const out = {};
@@ -109,6 +122,26 @@ export function eventsBasePathForCanton(canton) {
     out[locale] = EVENTS_LOCALIZED_SEGMENT[locale](record[locale] || record.it);
   }
   return out;
+}
+
+/**
+ * German preposition for "<preposition> <canton display name>" prose (e.g.
+ * "im Tessin", "im Aargau", "in der Waadt", "in Zürich") for any of the 26
+ * cantons — used by the events SSG plugin's canton-agnostic (non-TI) copy
+ * generator. Reuses the SAME `dePrefix` override table the job board URL
+ * slugs use (`data/canton-url-slugs.json`, §6 — no second grammar table):
+ * `jobs-im-` → "im", `jobs-in-der-` → "in der", no override → "in" (correct
+ * for the majority of cantons whose German name takes no article, e.g.
+ * Zürich, Bern, Genf, Basel). TI itself is NOT routed through this helper —
+ * the legacy literal copy hardcodes "im Tessin" — this only serves the other
+ * 23 cantons/groups.
+ */
+export function germanCantonPreposition(canton) {
+  const urlKey = resolveCantonUrlKey(canton);
+  const record = CANTON_URL_SLUGS.cantons?.[urlKey];
+  if (record?.dePrefix === 'jobs-im-') return 'im';
+  if (record?.dePrefix === 'jobs-in-der-') return 'in der';
+  return 'in';
 }
 
 /** Localized slug of the two digest landing pages, per locale. */

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -14,27 +14,46 @@
  * duplicated literally across ≥2 files MUST live in ONE shared module).
  */
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { truncateSlugAtWordBoundary } from './slug-truncate.mjs';
+import CANTON_URL_SLUGS from '../../data/canton-url-slugs.json' with { type: 'json' };
+import { MUNICIPALITIES } from '../../data/municipalities.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 // ── Canton scope ─────────────────────────────────────────────
-// MVP scope is Ticino. The pipeline is canton-keyed so adding VS/GR/GE later is
-// data-only (a new source + a new entry here), no structural change.
+// Legacy single-canton constant, kept for the TI-only call sites that predate
+// nationwide sourcing (FB poster, weekend-digest article generator). New code
+// should be canton-agnostic (see `resolveComuneNationwide` / `eventsBasePathForCanton`
+// below) — the pipeline is canton-keyed, so nationwide sources are data-only
+// (a new EVENT_SOURCES entry with `canton: null`), no structural change.
 export const EVENTS_CANTON = 'TI';
 
 // ── Source registry ──────────────────────────────────────────
 // One entry per crawler. `key` is the slice filename + stable-id prefix.
+// `canton: null` means the source is nationwide (event canton resolved
+// per-event from the matched comune, see `resolveComuneNationwide`).
 export const EVENT_SOURCES = {
   'tio-agenda': {
     key: 'tio-agenda',
     label: 'Tio.ch Agenda',
     homepage: 'https://www.tio.ch/agenda',
     canton: 'TI',
+  },
+  guidle: {
+    key: 'guidle',
+    label: 'Guidle',
+    homepage: 'https://www.guidle.com',
+    canton: null,
+  },
+  myswitzerland: {
+    key: 'myswitzerland',
+    label: 'MySwitzerland',
+    homepage: 'https://www.myswitzerland.com',
+    canton: null,
   },
 };
 
@@ -50,6 +69,47 @@ export const EVENTS_BASE_PATH = {
   de: '/de/veranstaltungen/tessin',
   fr: '/fr/evenements/tessin',
 };
+
+// ── Localized base path, any canton ────────────────────────────
+// Generalization of EVENTS_BASE_PATH for nationwide rollout (F3). Reuses
+// `data/canton-url-slugs.json` — the SAME slug table the job board uses (§6,
+// no second canton→slug dictionary) — so a canton's events URL segment matches
+// its job-board URL segment. Verified byte-identical to the literal
+// EVENTS_BASE_PATH above for TI (ticino/ticino/tessin/tessin) — see
+// tests/events-utils.test.ts.
+const EVENTS_LOCALIZED_SEGMENT = {
+  it: (slug) => `/eventi/${slug}`,
+  en: (slug) => `/en/events/${slug}`,
+  de: (slug) => `/de/veranstaltungen/${slug}`,
+  fr: (slug) => `/fr/evenements/${slug}`,
+};
+
+/**
+ * Localized events base path for any of the 26 cantons (half-cantons AI/AR and
+ * BL/BS collapse onto their URL group, same as the job board — see
+ * `services/cantonList.ts` / `services/router.ts` resolveCantonGroup). Falls
+ * back to the literal `EVENTS_BASE_PATH` (TI) for an unknown/blank canton so
+ * callers that don't resolve a canton degrade to the original MVP behavior.
+ */
+export function eventsBasePathForCanton(canton) {
+  const code = String(canton || '').toUpperCase().trim();
+  if (!code) return EVENTS_BASE_PATH;
+  const groups = CANTON_URL_SLUGS.cantonGroups ?? {};
+  let urlKey = code;
+  for (const [groupKey, def] of Object.entries(groups)) {
+    if ((def?.members ?? []).map((m) => String(m).toUpperCase()).includes(code)) {
+      urlKey = groupKey;
+      break;
+    }
+  }
+  const record = CANTON_URL_SLUGS.cantons?.[urlKey];
+  if (!record) return EVENTS_BASE_PATH;
+  const out = {};
+  for (const locale of Object.keys(EVENTS_LOCALIZED_SEGMENT)) {
+    out[locale] = EVENTS_LOCALIZED_SEGMENT[locale](record[locale] || record.it);
+  }
+  return out;
+}
 
 /** Localized slug of the two digest landing pages, per locale. */
 export const EVENTS_DIGEST_SLUGS = {
@@ -168,6 +228,167 @@ export function resolveComune({ venue, title, region }, comuni = loadCantonComun
 
 function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ── Nationwide comuni (all 26 cantons) ────────────────────────
+let _allComuniCache = null;
+
+/**
+ * Flatten `data/canton-municipalities.json` into `{ name, canton }` records
+ * across every canton (2110 comuni). Used by `resolveComuneNationwide` for
+ * sources that are not canton-scoped (guidle, myswitzerland). Cached once —
+ * the file is static data, not a live crawl input.
+ */
+export function loadAllComuni() {
+  if (_allComuniCache) return _allComuniCache;
+  const file = path.join(REPO_ROOT, 'data', 'canton-municipalities.json');
+  let out = [];
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf-8'));
+    for (const [canton, def] of Object.entries(raw?.cantons ?? {})) {
+      for (const name of def?.municipalities ?? []) out.push({ name, canton });
+    }
+  } catch {
+    out = [];
+  }
+  _allComuniCache = out;
+  return out;
+}
+
+/**
+ * Nationwide generalization of `resolveComune` for sources without a fixed
+ * canton (guidle, myswitzerland — see EVENT_SOURCES `canton: null`).
+ *
+ * Strategy (highest confidence first):
+ *   1. `cantonHint` given (e.g. resolved from a source's `address.addressLocality`
+ *      postal-code lookup, or an upstream canton facet) — scope the exact-match
+ *      search to that canton's comuni first (identical to `resolveComune`).
+ *   2. Nationwide exact — same word-boundary token match as `resolveComune`,
+ *      but ranked across all 2110 comuni (longest name first, so multi-word
+ *      comuni like "Riva San Vitale" win over a shorter substring elsewhere).
+ *      Duplicate comune names across cantons (e.g. two cantons both have a
+ *      "Buchs") resolve to whichever is matched first in the length-ranked
+ *      scan — ambiguous but rare, and never worse than no attribution.
+ *   3. TI region fallback — only applies when `cantonHint === 'TI'` (or no
+ *      hint) and the region string is a known tio.ch-style adjective; region
+ *      vocabulary is TI-specific, not meaningful for other cantons.
+ *   4. null — no confident attribution.
+ *
+ * Returns `{ comune, canton, method }`, method one of
+ * 'exact' | 'exact-nationwide' | 'region' | null.
+ */
+export function resolveComuneNationwide({ venue, title, region }, cantonHint) {
+  const hint = String(cantonHint || '').toUpperCase().trim();
+  if (hint) {
+    const scoped = resolveComune({ venue, title, region }, loadCantonComuni(hint));
+    if (scoped.comune) return { ...scoped, canton: hint };
+  }
+
+  const haystack = `${normalizeText(venue)} ${normalizeText(title)}`;
+  const ranked = [...loadAllComuni()].sort((a, b) => b.name.length - a.name.length);
+  for (const { name, canton } of ranked) {
+    const norm = normalizeText(name);
+    if (!norm) continue;
+    const re = new RegExp(`(^|[^a-z0-9])${escapeRegExp(norm)}([^a-z0-9]|$)`);
+    if (re.test(haystack)) return { comune: name, canton, method: 'exact-nationwide' };
+  }
+
+  if (!hint || hint === 'TI') {
+    const regionKey = normalizeText(region);
+    if (regionKey && REGION_TO_COMUNE[regionKey]) {
+      const mapped = REGION_TO_COMUNE[regionKey];
+      if (loadCantonComuni('TI').includes(mapped)) return { comune: mapped, canton: 'TI', method: 'region' };
+    }
+  }
+  return { comune: null, canton: null, method: null };
+}
+
+// ── Italian frontier comuni geo-matching ──────────────────────
+/** Great-circle distance in km between two lat/lng points (haversine). */
+export function haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+/**
+ * Italian border comuni (data/municipalities.ts, 518 comuni across 11
+ * provinces) do not have their own crawled event source — guidle and
+ * myswitzerland only index Swiss events. Instead, a CH event near the border
+ * IS relevant to a frontaliere living there ("eventi vicino a te"), so events
+ * with known geo-coordinates are geo-linked to nearby Italian frontier comuni
+ * at assemble time.
+ *
+ * Returns up to 5 comune names within `maxKm` (nearest first), or `[]` when
+ * the event has no geo or nothing is within range.
+ */
+export function resolveItalianFrontierComuni(geo, { maxKm = 15 } = {}) {
+  const lat = geo?.lat;
+  const lng = geo?.lng;
+  if (typeof lat !== 'number' || typeof lng !== 'number' || Number.isNaN(lat) || Number.isNaN(lng)) return [];
+  return MUNICIPALITIES.map((m) => ({ name: m.name, km: haversineKm(lat, lng, m.lat, m.lng) }))
+    .filter((m) => m.km <= maxKm)
+    .sort((a, b) => a.km - b.km)
+    .slice(0, 5)
+    .map((m) => m.name);
+}
+
+// ── Event image mirroring ──────────────────────────────────────
+// Crawled event images MUST NOT be hotlinked (the source site must never see
+// a request originating from a real visitor's browser) — download once at
+// crawl time, store under public/images/events/, and let the existing CDN
+// offload pipeline (scripts/offload-generated-images-cdn.mjs,
+// services/cdnImageBase.ts) serve them from our own domain, same as
+// brand/provider logos. Idempotent: skips the network fetch when the file
+// already exists, so re-running a crawler doesn't re-download unchanged images.
+const EVENT_IMAGE_DIR = path.join(REPO_ROOT, 'public', 'images', 'events');
+const EVENT_IMAGE_MAX_BYTES = 4 * 1024 * 1024; // 4MB guard against a mis-served asset
+const EVENT_IMAGE_USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch)';
+
+function extFromContentType(contentType) {
+  const ct = String(contentType || '').toLowerCase();
+  if (ct.includes('png')) return 'png';
+  if (ct.includes('webp')) return 'webp';
+  return 'jpg';
+}
+
+/**
+ * Download an event's source image once and store it locally under
+ * `public/images/events/<sourceKey>-<rawId>.<ext>`. Returns the site-relative
+ * path (e.g. `/images/events/guidle-Acv6rYJ.jpg`) on success, or `null` on any
+ * failure (missing URL, network error, oversized/non-image response) — callers
+ * MUST treat a null return as "no image" (never fall back to the original
+ * remote URL, that would defeat the no-hotlink requirement).
+ */
+export async function mirrorEventImage(sourceUrl, stableId) {
+  if (!sourceUrl || !/^https?:\/\//i.test(sourceUrl)) return null;
+  const safeId = String(stableId || '').replace(/[^a-zA-Z0-9:_-]/g, '').replace(/:/g, '-');
+  if (!safeId) return null;
+
+  mkdirSync(EVENT_IMAGE_DIR, { recursive: true });
+  const existingMatch = ['jpg', 'jpeg', 'png', 'webp']
+    .map((ext) => path.join(EVENT_IMAGE_DIR, `${safeId}.${ext}`))
+    .find((p) => existsSync(p));
+  if (existingMatch) return `/images/events/${path.basename(existingMatch)}`;
+
+  try {
+    const res = await fetch(sourceUrl, { headers: { 'User-Agent': EVENT_IMAGE_USER_AGENT } });
+    if (!res.ok) return null;
+    const contentType = res.headers.get('content-type') || '';
+    if (!contentType.startsWith('image/')) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.byteLength === 0 || buf.byteLength > EVENT_IMAGE_MAX_BYTES) return null;
+    const ext = extFromContentType(contentType);
+    const fileName = `${safeId}.${ext}`;
+    writeFileSync(path.join(EVENT_IMAGE_DIR, fileName), buf);
+    return `/images/events/${fileName}`;
+  } catch {
+    return null;
+  }
 }
 
 // ── Stable identity ──────────────────────────────────────────

--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -96,6 +96,12 @@ const TARGETS = [
   { dir: ['images', 'logos'], url: '/images/logos/' },
   { dir: ['images', 'authors'], url: '/images/authors/' },
   { dir: ['images', 'publisher'], url: '/images/publisher/' },
+  // Nationwide events feature (issue #3125): no-hotlink mirrored source images
+  // (scripts/lib/events-utils.mjs mirrorEventImage -> public/images/events/).
+  // MUST stay in sync with CDN_OFFLOADED_IMAGE_PREFIXES in
+  // services/cdnImageBase.ts, the deploy-it-pages-prep.sh CDN-push staging
+  // loop, and ensure-image-cdn-redirect.mjs OFFLOADED_PREFIXES.
+  { dir: ['images', 'events'], url: '/images/events/' },
 ];
 
 function log(msg) {

--- a/services/cdnImageBase.ts
+++ b/services/cdnImageBase.ts
@@ -54,6 +54,9 @@ export const CDN_OFFLOADED_IMAGE_PREFIXES = [
   '/images/logos/',
   '/images/authors/',
   '/images/publisher/',
+  // Nationwide events feature (issue #3125): mirrored source images written by
+  // scripts/lib/events-utils.mjs mirrorEventImage() to public/images/events/.
+  '/images/events/',
 ] as const;
 
 /**

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -44,6 +44,7 @@ const CDN_OFFLOADED_IMAGE_PREFIXES = [
   '/images/logos/',
   '/images/authors/',
   '/images/publisher/',
+  '/images/events/', // nationwide events feature (issue #3125)
 ];
 
 /** Absolute URL for a same-origin image path: CDN host if offloaded, else origin. */

--- a/services/router.ts
+++ b/services/router.ts
@@ -926,6 +926,52 @@ export function resolveCantonGroup(cantonCode: string): string {
 }
 
 /**
+ * Per-locale set of canton URL slugs (e.g. `it: {'ticino','zurigo',...}`,
+ * `de: {'tessin','zurich','aargau',...}`) used ONLY to validate the canton
+ * segment of an events-page URL (see `matchEventsCantonLocale` below).
+ * Sourced from the SAME `data/canton-url-slugs.json` table
+ * `eventsBasePathForCanton` (scripts/lib/events-utils.mjs) uses to emit those
+ * pages — one canton→slug dictionary, §6.
+ */
+const EVENTS_CANTON_SLUGS: Record<Locale, ReadonlySet<string>> = (() => {
+ const out: Record<Locale, Set<string>> = { it: new Set(), en: new Set(), de: new Set(), fr: new Set() };
+ for (const record of Object.values(CANTON_URL_SLUGS.cantons)) {
+  (['it', 'en', 'de', 'fr'] as const).forEach((loc) => {
+   const slug = record[loc];
+   if (slug) out[loc].add(slug);
+  });
+ }
+ return out;
+})();
+
+/** Events-page URL shape per locale — `{canton}` then 0-2 dynamic segments
+ * (comune, or comune+event-slug, or a digest slug). Mirrors the localized
+ * base-path builders in scripts/lib/events-utils.mjs (`EVENTS_LOCALIZED_SEGMENT`). */
+const EVENTS_PATH_PATTERN: Record<Locale, RegExp> = {
+ it: /^\/eventi\/([a-z0-9-]+)((?:\/[a-z0-9-]+){0,2})\/?$/,
+ en: /^\/en\/events\/([a-z0-9-]+)((?:\/[a-z0-9-]+){0,2})\/?$/,
+ de: /^\/de\/veranstaltungen\/([a-z0-9-]+)((?:\/[a-z0-9-]+){0,2})\/?$/,
+ fr: /^\/fr\/evenements\/([a-z0-9-]+)((?:\/[a-z0-9-]+){0,2})\/?$/,
+};
+
+/**
+ * Match a pathname against every locale's events URL shape and validate the
+ * canton segment against {@link EVENTS_CANTON_SLUGS}. Returns the matched
+ * locale, or `null` when the pathname isn't an events page OR the canton
+ * segment isn't a known canton slug for that locale (e.g. a stray
+ * `/eventi/not-a-canton/` falls through to normal 404 handling instead of
+ * being claimed here). Generalizes the legacy TI-only
+ * `/^\/eventi\/ticino(...)?$/`-style regexes (issue #3125 canton rollout).
+ */
+function matchEventsCantonLocale(pathname: string): Locale | null {
+ for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+  const m = EVENTS_PATH_PATTERN[locale].exec(pathname);
+  if (m && EVENTS_CANTON_SLUGS[locale].has(m[1])) return locale;
+ }
+ return null;
+}
+
+/**
  * Job-board URL prefixes per locale. The DE prefix has TWO accepted
  * forms: the legacy `jobs-im-` (only for `tessin` — the article "im"
  * grammatically attaches to Tessin), and the canonical new-canton form
@@ -2485,20 +2531,21 @@ export function parsePath(pathname: string): ParseResult {
    return { route: { activeTab: 'vita', vitaSubTab: 'municipalities', staticOverlay: true }, locale: targetLocale };
  }
 
- // Ticino events pages (issue #2963 + per-event detail #3125) — /eventi/ticino/
- // hub + /{comune}/ + /questo-weekend/ digest (1 segment) + per-event detail
- // /{comune}/{event-slug}/ (2 segments), build-emitted outside #root.
- // staticOverlay keeps the SPA from replacing the static agenda body on back-nav.
- // Routed to the `vita` hub (living-in-Ticino theme) to match the page's hubChrome.
- if (
-   /^\/eventi\/ticino(\/[a-z0-9-]+){0,2}\/?$/.test(pathname) ||
-   /^\/en\/events\/ticino(\/[a-z0-9-]+){0,2}\/?$/.test(pathname) ||
-   /^\/de\/veranstaltungen\/tessin(\/[a-z0-9-]+){0,2}\/?$/.test(pathname) ||
-   /^\/fr\/evenements\/tessin(\/[a-z0-9-]+){0,2}\/?$/.test(pathname)
- ) {
-   const localeMatch = pathname.match(/^\/(en|de|fr)\//);
-   const targetLocale = (localeMatch ? localeMatch[1] : 'it') as Locale;
-   return { route: { activeTab: 'vita', vitaSubTab: 'places', staticOverlay: true }, locale: targetLocale };
+ // Nationwide events pages (issue #2963 + per-event detail #3125, canton
+ // rollout #3125) — /eventi/{canton}/ hub + /{comune}/ + /questo-weekend/
+ // digest (1 segment) + per-event detail /{comune}/{event-slug}/ (2
+ // segments), build-emitted outside #root. staticOverlay keeps the SPA from
+ // replacing the static agenda body on back-nav. Routed to the `vita` hub
+ // (living-in-Ticino theme) to match the page's hubChrome. The canton segment
+ // is matched against `EVENTS_CANTON_SLUGS` (derived from the SAME
+ // `data/canton-url-slugs.json` table the events SSG plugin's
+ // `eventsBasePathForCanton` uses, §6) instead of a hardcoded `ticino`/
+ // `tessin` literal, so any canton's events pages are routable once emitted.
+ {
+   const eventsLocale = matchEventsCantonLocale(pathname);
+   if (eventsLocale) {
+     return { route: { activeTab: 'vita', vitaSubTab: 'places', staticOverlay: true }, locale: eventsLocale };
+   }
  }
 
  // FR salary calculator landing — /fr/calculer-salaire/calcul-salaire-net-frontalier-suisse/.

--- a/tests/assemble-events-dedup.test.ts
+++ b/tests/assemble-events-dedup.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Cross-source dedup + Italian frontier comuni attachment gate for the
+ * events assembler (issue #3125). scripts/assemble-events-dataset.mjs merges
+ * per-source slices (data/events/by-source/<key>.json) by `event.id`
+ * (last-write-wins), then this SECOND pass collapses the same physical event
+ * when two or more different sources (tio-agenda / guidle / myswitzerland)
+ * index it independently under a different id.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  dedupeFuzzy,
+  eventRichnessScore,
+  pickRichestEvent,
+  attachItalianFrontierComuni,
+} from '../scripts/assemble-events-dataset.mjs';
+
+function ev(overrides: Record<string, any> = {}): Record<string, any> {
+  return {
+    id: 'tio-agenda:1',
+    title: 'Sagra del Paese',
+    startDate: '2026-08-01',
+    comune: 'Lugano',
+    sourceKey: 'tio-agenda',
+    ...overrides,
+  };
+}
+
+describe('eventRichnessScore', () => {
+  it('counts populated optional fields only', () => {
+    expect(eventRichnessScore(ev())).toBe(0);
+    expect(
+      eventRichnessScore(
+        ev({ description: 'A lovely village fair.', imageUrl: 'https://x/y.jpg', venue: 'Piazza Grande' }),
+      ),
+    ).toBe(3);
+  });
+
+  it('treats empty string / empty object / empty array as NOT populated', () => {
+    expect(eventRichnessScore(ev({ description: '  ', address: {}, price: undefined }))).toBe(0);
+  });
+
+  it('a populated price object counts as one populated field', () => {
+    expect(eventRichnessScore(ev({ price: { amount: 10, currency: 'CHF', isFree: false } }))).toBe(1);
+  });
+});
+
+describe('pickRichestEvent', () => {
+  it('keeps the record with the higher richness score', () => {
+    const thin = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda' });
+    const rich = ev({
+      id: 'guidle:abc',
+      sourceKey: 'guidle',
+      description: 'Full description of the event with plenty of detail.',
+      imageUrl: 'https://guidle.example/photo.jpg',
+      price: { amount: 0, currency: 'CHF', isFree: true },
+    });
+    expect(pickRichestEvent([thin, rich])).toBe(rich);
+    expect(pickRichestEvent([rich, thin])).toBe(rich); // order-independent
+  });
+
+  it('breaks a richness tie via SOURCE_PRIORITY (tio-agenda > guidle > myswitzerland)', () => {
+    const fromGuidle = ev({ id: 'guidle:1', sourceKey: 'guidle' });
+    const fromTio = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda' });
+    const fromMySwitzerland = ev({ id: 'myswitzerland:1', sourceKey: 'myswitzerland' });
+    expect(pickRichestEvent([fromGuidle, fromTio])).toBe(fromTio);
+    expect(pickRichestEvent([fromMySwitzerland, fromGuidle])).toBe(fromGuidle);
+    expect(pickRichestEvent([fromMySwitzerland, fromTio, fromGuidle])).toBe(fromTio);
+  });
+
+  it('falls back to the lexicographically smaller id when source+score both tie', () => {
+    const a = ev({ id: 'guidle:aaa', sourceKey: 'guidle' });
+    const b = ev({ id: 'guidle:bbb', sourceKey: 'guidle' });
+    expect(pickRichestEvent([b, a])).toBe(a);
+  });
+});
+
+describe('dedupeFuzzy', () => {
+  it('collapses two near-duplicate events from different sources into one', () => {
+    const fromTio = ev({ id: 'tio-agenda:100', sourceKey: 'tio-agenda' });
+    const fromGuidle = ev({
+      id: 'guidle:xyz',
+      sourceKey: 'guidle',
+      title: 'Sagra del Paese', // identical after normalization
+      startDate: '2026-08-01',
+      comune: 'Lugano',
+      description: 'Traditional village festival with food and music.',
+    });
+    const { events, mergedAway } = dedupeFuzzy([fromTio, fromGuidle]);
+    expect(events).toHaveLength(1);
+    expect(mergedAway).toBe(1);
+    // The richer (guidle, has a description) record wins.
+    expect(events[0].id).toBe('guidle:xyz');
+  });
+
+  it('is diacritic/case-insensitive on the title (normalizeText)', () => {
+    const fromTio = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda', title: 'Festa dèll Uva' });
+    const fromGuidle = ev({ id: 'guidle:1', sourceKey: 'guidle', title: 'FESTA DELL UVA' });
+    const { events, mergedAway } = dedupeFuzzy([fromTio, fromGuidle]);
+    expect(mergedAway).toBe(1);
+    expect(events).toHaveLength(1);
+  });
+
+  it('does NOT collapse events with the same title but a different startDate', () => {
+    const first = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda', startDate: '2026-08-01' });
+    const second = ev({ id: 'guidle:1', sourceKey: 'guidle', startDate: '2026-08-08' });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('does NOT collapse events with the same title/date but a different comune', () => {
+    const first = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda', comune: 'Lugano' });
+    const second = ev({ id: 'guidle:1', sourceKey: 'guidle', comune: 'Locarno' });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('does NOT collapse a same-source collision (only cross-source groups are merged)', () => {
+    // Real observed shape: two DIFFERENT events from the same crawler share a
+    // generic title and both region-resolved to the same fallback comune.
+    // Merging these would silently drop a genuine event, so same-source
+    // groups are left untouched even when the fuzzy key collides.
+    const first = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda', venue: 'Piazza A' });
+    const second = ev({ id: 'tio-agenda:2', sourceKey: 'tio-agenda', venue: 'Piazza B' });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('leaves a singleton group untouched', () => {
+    const only = ev();
+    const { events, mergedAway } = dedupeFuzzy([only]);
+    expect(events).toEqual([only]);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('collapses a 3-way cross-source collision to exactly one record', () => {
+    const a = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda' });
+    const b = ev({ id: 'guidle:1', sourceKey: 'guidle' });
+    const c = ev({ id: 'myswitzerland:1', sourceKey: 'myswitzerland' });
+    const { events, mergedAway } = dedupeFuzzy([a, b, c]);
+    expect(events).toHaveLength(1);
+    expect(mergedAway).toBe(2);
+    expect(events[0].id).toBe('tio-agenda:1'); // equal score -> SOURCE_PRIORITY winner
+  });
+});
+
+describe('attachItalianFrontierComuni', () => {
+  it('attaches nearby Italian comuni to a geo-tagged event with none set yet', () => {
+    // Chiasso-area coordinates, right at the CH/IT border.
+    const chiasso = ev({ geo: { lat: 45.8434, lng: 9.0294 } });
+    const attached = attachItalianFrontierComuni([chiasso]);
+    expect(attached).toBe(1);
+    expect(chiasso.italianFrontierComuni.length).toBeGreaterThan(0);
+  });
+
+  it('does nothing for an event without geo', () => {
+    const noGeo = ev();
+    const attached = attachItalianFrontierComuni([noGeo]);
+    expect(attached).toBe(0);
+    expect(noGeo.italianFrontierComuni).toBeUndefined();
+  });
+
+  it('does not recompute when a crawler already set italianFrontierComuni (even to [])', () => {
+    const already = ev({ geo: { lat: 45.8434, lng: 9.0294 }, italianFrontierComuni: [] });
+    const attached = attachItalianFrontierComuni([already]);
+    expect(attached).toBe(0);
+    expect(already.italianFrontierComuni).toEqual([]);
+  });
+
+  it('leaves italianFrontierComuni unset when geo is far from the Italian border', () => {
+    // Zurich-area coordinates — nowhere near the Italian border.
+    const zurich = ev({ geo: { lat: 47.3769, lng: 8.5417 } });
+    const attached = attachItalianFrontierComuni([zurich]);
+    expect(attached).toBe(0);
+    expect(zurich.italianFrontierComuni).toBeUndefined();
+  });
+});

--- a/tests/crawl-checkpoint.test.ts
+++ b/tests/crawl-checkpoint.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadCursor, saveCursor, mergeEventsIntoSlice } from '../scripts/lib/crawl-checkpoint.mjs';
+
+describe('loadCursor / saveCursor', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-checkpoint-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns 0 when no checkpoint file exists yet', () => {
+    expect(loadCursor('guidle', dir)).toBe(0);
+  });
+
+  it('persists and reloads the cursor', () => {
+    saveCursor('guidle', 42, '2026-07-02T00:00:00.000Z', dir);
+    expect(loadCursor('guidle', dir)).toBe(42);
+  });
+
+  it('keys checkpoints independently per source', () => {
+    saveCursor('guidle', 10, '2026-07-02T00:00:00.000Z', dir);
+    saveCursor('myswitzerland', 20, '2026-07-02T00:00:00.000Z', dir);
+    expect(loadCursor('guidle', dir)).toBe(10);
+    expect(loadCursor('myswitzerland', dir)).toBe(20);
+  });
+
+  it('falls back to 0 for a malformed checkpoint file', () => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'guidle.json'), 'not json', 'utf-8');
+    expect(loadCursor('guidle', dir)).toBe(0);
+  });
+
+  it('falls back to 0 for a negative or non-integer nextIndex', () => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'guidle.json'), JSON.stringify({ nextIndex: -1 }), 'utf-8');
+    expect(loadCursor('guidle', dir)).toBe(0);
+  });
+});
+
+describe('mergeEventsIntoSlice', () => {
+  let dir: string;
+  let slicePath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-checkpoint-slice-'));
+    slicePath = path.join(dir, 'guidle.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a new slice when none exists yet', () => {
+    const total = mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [{ id: 'guidle:a', startDate: '2099-01-01' }],
+      goneIds: [],
+      crawledAt: '2026-07-02T00:00:00.000Z',
+    });
+    expect(total).toBe(1);
+    const written = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+    expect(written.events).toHaveLength(1);
+    expect(written.sourceKey).toBe('guidle');
+  });
+
+  it('upserts fresh events into an existing slice without dropping untouched ones', () => {
+    mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [
+        { id: 'guidle:a', title: 'old title', startDate: '2099-01-01' },
+        { id: 'guidle:b', startDate: '2099-01-01' },
+      ],
+      goneIds: [],
+      crawledAt: '2026-07-02T00:00:00.000Z',
+    });
+
+    const total = mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [{ id: 'guidle:a', title: 'new title', startDate: '2099-01-01' }],
+      goneIds: [],
+      crawledAt: '2026-07-03T00:00:00.000Z',
+    });
+
+    expect(total).toBe(2);
+    const written = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+    const byId = Object.fromEntries(written.events.map((e: any) => [e.id, e]));
+    expect(byId['guidle:a'].title).toBe('new title'); // updated
+    expect(byId['guidle:b']).toBeDefined(); // survived, untouched this run
+  });
+
+  it('drops ids explicitly marked gone', () => {
+    mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [{ id: 'guidle:a', startDate: '2099-01-01' }],
+      goneIds: [],
+      crawledAt: '2026-07-02T00:00:00.000Z',
+    });
+
+    const total = mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [],
+      goneIds: ['guidle:a'],
+      crawledAt: '2026-07-03T00:00:00.000Z',
+    });
+
+    expect(total).toBe(0);
+  });
+
+  it('prunes events whose last relevant date has already passed', () => {
+    mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [
+        { id: 'guidle:past', startDate: '2020-01-01' },
+        { id: 'guidle:future', startDate: '2099-01-01' },
+        { id: 'guidle:ongoing', startDate: '2020-01-01', endDate: '2099-01-01' },
+      ],
+      goneIds: [],
+      crawledAt: '2026-07-02T00:00:00.000Z',
+    });
+
+    const written = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+    const ids = written.events.map((e: any) => e.id);
+    expect(ids).toContain('guidle:future');
+    expect(ids).toContain('guidle:ongoing');
+    expect(ids).not.toContain('guidle:past');
+  });
+
+  it('recovers from a corrupt existing slice by starting fresh instead of crashing', () => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(slicePath, 'not json', 'utf-8');
+
+    const total = mergeEventsIntoSlice({
+      slicePath,
+      sourceKey: 'guidle',
+      sourceName: 'Guidle',
+      freshEvents: [{ id: 'guidle:a', startDate: '2099-01-01' }],
+      goneIds: [],
+      crawledAt: '2026-07-02T00:00:00.000Z',
+    });
+
+    expect(total).toBe(1);
+  });
+});

--- a/tests/crawl-guidle-events.test.ts
+++ b/tests/crawl-guidle-events.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Guidle nationwide events crawler (#3125): pure parsing/mapping logic only —
+ * no live network calls here (see scripts/crawl-guidle-events.mjs header for
+ * the live sitemap + JSON-LD + accordion research this is built from).
+ */
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  parseSitemapIndexXml,
+  extractEventUrlsFromSitemapXml,
+  extractEventJsonLdOccurrences,
+  summarizeOccurrences,
+  extractAddress,
+  extractCategory,
+  extractPrice,
+  parsePriceText,
+  extractGeoAndCanton,
+  mapDetailPageToLocaleData,
+  mapGuidleEvent,
+} from '../scripts/crawl-guidle-events.mjs';
+
+describe('parseSitemapIndexXml', () => {
+  it('extracts gzipped shard URLs', () => {
+    const xml = `<?xml version="1.0"?><sitemapindex>
+      <sitemap><loc>https://www.guidle.com/sitemap1.xml.gz</loc></sitemap>
+      <sitemap><loc>https://www.guidle.com/sitemap2.xml.gz</loc></sitemap>
+    </sitemapindex>`;
+    expect(parseSitemapIndexXml(xml)).toEqual([
+      'https://www.guidle.com/sitemap1.xml.gz',
+      'https://www.guidle.com/sitemap2.xml.gz',
+    ]);
+  });
+
+  it('returns [] for missing/empty input', () => {
+    expect(parseSitemapIndexXml('')).toEqual([]);
+    expect(parseSitemapIndexXml(undefined as unknown as string)).toEqual([]);
+  });
+});
+
+describe('extractEventUrlsFromSitemapXml', () => {
+  it('extracts {code, pathSuffix} for event detail URLs, dedupes by code, skips /print and listing pages', () => {
+    const xml = `<?xml version="1.0"?><urlset>
+      <url><loc>https://www.guidle.com/de/veranstaltungen/zug/stadtfuehrung_AZ3RYEB</loc></url>
+      <url><loc>https://www.guidle.com/it/eventi/zugo/visita-guidata_AZ3RYEB</loc></url>
+      <url><loc>https://www.guidle.com/de/veranstaltungen/zug/stadtfuehrung_AZ3RYEB/print</loc></url>
+      <url><loc>https://www.guidle.com/de/veranstaltungen/alle</loc></url>
+      <url><loc>https://www.guidle.com/de/veranstaltungen/luzern/konzert_BX9KLMN</loc></url>
+    </urlset>`;
+    const out = extractEventUrlsFromSitemapXml(xml);
+    expect(out).toEqual([
+      { code: 'AZ3RYEB', pathSuffix: '/veranstaltungen/zug/stadtfuehrung_AZ3RYEB' },
+      { code: 'BX9KLMN', pathSuffix: '/veranstaltungen/luzern/konzert_BX9KLMN' },
+    ]);
+  });
+
+  it('returns [] for missing/empty input', () => {
+    expect(extractEventUrlsFromSitemapXml('')).toEqual([]);
+    expect(extractEventUrlsFromSitemapXml(undefined as unknown as string)).toEqual([]);
+  });
+});
+
+describe('extractEventJsonLdOccurrences', () => {
+  it('normalizes a single-object Event JSON-LD block into a one-item array', () => {
+    const html = `<script type="application/ld+json">{"@type":"Event","name":"Test","startDate":"2026-07-04T19:00"}</script>`;
+    const occ = extractEventJsonLdOccurrences(html);
+    expect(occ).toHaveLength(1);
+    expect(occ[0].name).toBe('Test');
+  });
+
+  it('flattens an array-of-occurrences Event JSON-LD block (recurring events)', () => {
+    const html = `<script type="application/ld+json">[
+      {"@type":"Event","name":"Weekly Tour","startDate":"2026-07-04T09:50"},
+      {"@type":"Event","name":"Weekly Tour","startDate":"2026-07-11T09:50"}
+    ]</script>`;
+    const occ = extractEventJsonLdOccurrences(html);
+    expect(occ).toHaveLength(2);
+  });
+
+  it('skips unrelated JSON-LD blocks (e.g. BreadcrumbList) and picks the Event block', () => {
+    const html = `
+      <script type="application/ld+json">{"@type":"BreadcrumbList","itemListElement":[]}</script>
+      <script type="application/ld+json">{"@type":"Event","name":"Real Event","startDate":"2026-07-04T19:00"}</script>
+    `;
+    const occ = extractEventJsonLdOccurrences(html);
+    expect(occ).toHaveLength(1);
+    expect(occ[0].name).toBe('Real Event');
+  });
+
+  it('returns [] when there is no matching block or malformed JSON', () => {
+    expect(extractEventJsonLdOccurrences('')).toEqual([]);
+    expect(extractEventJsonLdOccurrences('<html></html>')).toEqual([]);
+    expect(extractEventJsonLdOccurrences('<script type="application/ld+json">{not json</script>')).toEqual([]);
+  });
+});
+
+describe('summarizeOccurrences', () => {
+  it('returns null for an empty list', () => {
+    expect(summarizeOccurrences([])).toBeNull();
+  });
+
+  it('derives startDate/startTime from a single occurrence, recurring:false', () => {
+    const info = summarizeOccurrences([{ startDate: '2026-07-04T19:30', endDate: '2026-07-04T22:00' }]);
+    expect(info).toEqual({ startDate: '2026-07-04', startTime: '19:30', endDate: '2026-07-04', recurring: false });
+  });
+
+  it('spans earliest→latest and flags recurring:true for multiple occurrences', () => {
+    const info = summarizeOccurrences([
+      { startDate: '2026-07-11T09:50' },
+      { startDate: '2026-07-04T09:50' },
+      { startDate: '2026-07-18T09:50' },
+    ]);
+    expect(info?.startDate).toBe('2026-07-04');
+    expect(info?.endDate).toBe('2026-07-18');
+    expect(info?.recurring).toBe(true);
+  });
+});
+
+describe('extractAddress', () => {
+  it('reads street + postalCode from a PostalAddress', () => {
+    expect(extractAddress({ streetAddress: 'Piazza Grande 1', postalCode: '6600' })).toEqual({
+      street: 'Piazza Grande 1',
+      postalCode: '6600',
+    });
+  });
+
+  it('returns undefined when absent/empty', () => {
+    expect(extractAddress(undefined)).toBeUndefined();
+    expect(extractAddress({})).toBeUndefined();
+  });
+});
+
+describe('parsePriceText', () => {
+  it('takes the cheapest numeric amount found', () => {
+    expect(parsePriceText('CHF 10.00 pro Person, Kinder CHF 5.00')).toEqual({ amount: 5, currency: 'CHF', isFree: false });
+  });
+
+  it('recognizes free-language keywords when there is no number', () => {
+    expect(parsePriceText('Eintritt frei')).toEqual({ amount: 0, currency: 'CHF', isFree: true });
+    expect(parsePriceText('Ingresso libero')).toEqual({ amount: 0, currency: 'CHF', isFree: true });
+  });
+
+  it('falls back to amount:null when unparseable', () => {
+    expect(parsePriceText('Su richiesta')).toEqual({ amount: null, currency: 'CHF', isFree: false });
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(parsePriceText('')).toBeUndefined();
+    expect(parsePriceText(undefined)).toBeUndefined();
+  });
+});
+
+function buildDetailHtml({
+  locale = 'de',
+  categoryLabel = 'Kategorie',
+  categoryValue = 'Konzert',
+  priceLabel = 'Preis',
+  priceValue = 'CHF 20.00 pro Person',
+  geoPosition = '47.1661118;8.5151648',
+  geoRegion = 'CH-ZG',
+  jsonLd = '{"@type":"Event","name":"Zytturm Konzert","description":"Ein tolles Konzert.","startDate":"2026-07-04T19:00","location":{"name":"Zytturm","address":{"streetAddress":"Kolinplatz 1","postalCode":"6300","addressLocality":"Zug"}},"image":"https://www.guidle.com/imagekit/abc.jpg"}',
+} = {}) {
+  return `<!doctype html><html lang="${locale}"><head>
+    <meta name="geo.position" content="${geoPosition}" />
+    <meta name="geo.region" content="${geoRegion}" />
+    <script type="application/ld+json">${jsonLd}</script>
+  </head><body>
+    <div class="accordion-wrap"><h3>${categoryLabel}</h3><div class="accordion"><ul><li>${categoryValue}</li></ul></div></div>
+    <div class="accordion-wrap"><h3>${priceLabel}</h3><div class="accordion">${priceValue}</div></div>
+  </body></html>`;
+}
+
+describe('extractCategory / extractPrice / extractGeoAndCanton (DOM accordion + meta scraping)', () => {
+  it('reads category and price from locale-labelled accordion blocks', () => {
+    const doc = new JSDOM(buildDetailHtml()).window.document;
+    expect(extractCategory(doc, 'de')).toBe('Konzert');
+    expect(extractPrice(doc, 'de')).toEqual({ amount: 20, currency: 'CHF', isFree: false });
+  });
+
+  it('matches the it/en/fr accordion label translations', () => {
+    const it = new JSDOM(buildDetailHtml({ locale: 'it', categoryLabel: 'Categoria', categoryValue: 'Concerto', priceLabel: 'Prezzo' })).window.document;
+    expect(extractCategory(it, 'it')).toBe('Concerto');
+    expect(extractPrice(it, 'it')).toEqual({ amount: 20, currency: 'CHF', isFree: false });
+
+    const fr = new JSDOM(buildDetailHtml({ locale: 'fr', categoryLabel: 'Catégorie', priceLabel: 'Prix' })).window.document;
+    expect(extractCategory(fr, 'fr')).toBe('Konzert');
+
+    const en = new JSDOM(buildDetailHtml({ locale: 'en', categoryLabel: 'Category', priceLabel: 'Price' })).window.document;
+    expect(extractCategory(en, 'en')).toBe('Konzert');
+  });
+
+  it('returns undefined when the expected accordion label is missing', () => {
+    const doc = new JSDOM(buildDetailHtml({ categoryLabel: 'Something Else' })).window.document;
+    expect(extractCategory(doc, 'de')).toBeUndefined();
+  });
+
+  it('reads geo + canton from meta tags', () => {
+    const doc = new JSDOM(buildDetailHtml()).window.document;
+    expect(extractGeoAndCanton(doc)).toEqual({ geo: { lat: 47.1661118, lng: 8.5151648 }, canton: 'ZG' });
+  });
+
+  it('returns undefined geo/canton when meta tags are absent', () => {
+    const doc = new JSDOM('<html><head></head><body></body></html>').window.document;
+    expect(extractGeoAndCanton(doc)).toEqual({ geo: undefined, canton: undefined });
+  });
+});
+
+describe('mapDetailPageToLocaleData', () => {
+  it('maps a full detail page into a flat locale-data record', () => {
+    const mapped = mapDetailPageToLocaleData(buildDetailHtml(), 'de');
+    expect(mapped).toEqual({
+      title: 'Zytturm Konzert',
+      description: 'Ein tolles Konzert.',
+      startDate: '2026-07-04',
+      startTime: '19:00',
+      endDate: '2026-07-04',
+      recurring: false,
+      venue: 'Zytturm',
+      address: { street: 'Kolinplatz 1', postalCode: '6300' },
+      addressLocality: 'Zug',
+      imageSourceUrl: 'https://www.guidle.com/imagekit/abc.jpg',
+      category: 'Konzert',
+      price: { amount: 20, currency: 'CHF', isFree: false },
+      geo: { lat: 47.1661118, lng: 8.5151648 },
+      canton: 'ZG',
+    });
+  });
+
+  it('returns null when the page has no usable Event JSON-LD', () => {
+    expect(mapDetailPageToLocaleData('<html></html>', 'de')).toBeNull();
+    expect(mapDetailPageToLocaleData('', 'de')).toBeNull();
+  });
+
+  it('returns null when the JSON-LD event has no name', () => {
+    const html = buildDetailHtml({ jsonLd: '{"@type":"Event","startDate":"2026-07-04T19:00"}' });
+    expect(mapDetailPageToLocaleData(html, 'de')).toBeNull();
+  });
+});
+
+describe('mapGuidleEvent', () => {
+  const deData = {
+    title: 'Zytturm Konzert',
+    description: 'Ein tolles Konzert.',
+    startDate: '2026-07-04',
+    startTime: '19:00',
+    endDate: '2026-07-04',
+    recurring: false,
+    venue: 'Zytturm',
+    address: { street: 'Kolinplatz 1', postalCode: '6300' },
+    addressLocality: 'Zug',
+    imageSourceUrl: 'https://www.guidle.com/imagekit/abc.jpg',
+    category: 'Konzert',
+    price: { amount: 20, currency: 'CHF', isFree: false },
+    geo: { lat: 47.1661118, lng: 8.5151648 },
+    canton: 'ZG',
+    url: 'https://www.guidle.com/de/veranstaltungen/zug/stadtfuehrung_AZ3RYEB',
+  };
+  const itData = { ...deData, title: 'Concerto Zytturm', description: 'Un bel concerto.', url: 'https://www.guidle.com/it/eventi/zugo/stadtfuehrung_AZ3RYEB' };
+
+  it('returns null when every locale is unusable (event fully gone)', () => {
+    expect(mapGuidleEvent('AZ3RYEB', { it: null, en: null, de: null, fr: null })).toBeNull();
+  });
+
+  it('maps a single-locale result to a SiteEvent-shaped record', () => {
+    const mapped = mapGuidleEvent('AZ3RYEB', { it: null, en: null, de: deData, fr: null });
+    expect(mapped).not.toBeNull();
+    const { event, imageSourceUrl, addressLocality, cantonHint } = mapped as never as {
+      event: Record<string, unknown>;
+      imageSourceUrl: string;
+      addressLocality: string;
+      cantonHint: string;
+    };
+    expect(event.id).toBe('guidle:AZ3RYEB');
+    expect(event.title).toBe('Zytturm Konzert');
+    expect(event.titleByLocale).toEqual({ de: 'Zytturm Konzert' });
+    expect(event.descriptionByLocale).toEqual({ de: 'Ein tolles Konzert.' });
+    expect(event.startDate).toBe('2026-07-04');
+    expect(event.category).toBe('Konzert');
+    expect(event.venue).toBe('Zytturm');
+    expect(event.sourceKey).toBe('guidle');
+    expect(event.sourceName).toBe('Guidle');
+    expect(event.url).toBe('https://www.guidle.com/de/veranstaltungen/zug/stadtfuehrung_AZ3RYEB');
+    expect(event.canton).toBe('');
+    expect(imageSourceUrl).toBe('https://www.guidle.com/imagekit/abc.jpg');
+    expect(addressLocality).toBe('Zug');
+    expect(cantonHint).toBe('ZG');
+  });
+
+  it('prefers it as canonical/primary (it→en→de→fr order) and merges titleByLocale/descriptionByLocale', () => {
+    const mapped = mapGuidleEvent('AZ3RYEB', { it: itData, en: null, de: deData, fr: null });
+    const event = mapped?.event as never as Record<string, unknown>;
+    expect(event.title).toBe('Concerto Zytturm');
+    expect(event.titleByLocale).toEqual({ it: 'Concerto Zytturm', de: 'Zytturm Konzert' });
+    expect(event.descriptionByLocale).toEqual({ it: 'Un bel concerto.', de: 'Ein tolles Konzert.' });
+    expect(event.url).toBe('https://www.guidle.com/it/eventi/zugo/stadtfuehrung_AZ3RYEB');
+  });
+
+  it('defaults category to "Event" when no accordion category was found', () => {
+    const mapped = mapGuidleEvent('AZ3RYEB', { it: null, en: null, de: { ...deData, category: undefined }, fr: null });
+    const event = mapped?.event as never as Record<string, unknown>;
+    expect(event.category).toBe('Event');
+  });
+});

--- a/tests/crawl-myswitzerland-events.test.ts
+++ b/tests/crawl-myswitzerland-events.test.ts
@@ -1,0 +1,237 @@
+/**
+ * MySwitzerland nationwide events crawler (#3125): pure parsing/mapping logic
+ * only — no live network calls here (see scripts/crawl-myswitzerland-events.mjs
+ * header for the live Algolia + detail-page research this is built from).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseCompactUtc,
+  zurichParts,
+  extractDateInfo,
+  humanizeCategory,
+  extractPrice,
+  extractAddress,
+  extractEventJsonLd,
+  mapEventRecord,
+} from '../scripts/crawl-myswitzerland-events.mjs';
+
+describe('parseCompactUtc', () => {
+  it('parses Algolia compact UTC timestamps', () => {
+    const d = parseCompactUtc('20260704T173000Z');
+    expect(d?.toISOString()).toBe('2026-07-04T17:30:00.000Z');
+  });
+
+  it('returns null for malformed or missing input', () => {
+    expect(parseCompactUtc('')).toBeNull();
+    expect(parseCompactUtc(undefined)).toBeNull();
+    expect(parseCompactUtc('2026-07-04')).toBeNull();
+  });
+});
+
+describe('zurichParts', () => {
+  it('converts a UTC instant to Europe/Zurich local date+time (summer, UTC+2)', () => {
+    const parts = zurichParts(new Date('2026-07-04T17:30:00.000Z'));
+    expect(parts).toEqual({ date: '2026-07-04', time: '19:30' });
+  });
+
+  it('converts a UTC instant to Europe/Zurich local date+time (winter, UTC+1)', () => {
+    const parts = zurichParts(new Date('2026-01-10T09:00:00.000Z'));
+    expect(parts).toEqual({ date: '2026-01-10', time: '10:00' });
+  });
+});
+
+describe('extractDateInfo', () => {
+  it('derives start/end date+time from applicableDates.rules', () => {
+    const hit = {
+      applicableDates: {
+        rules: [{ conditions: { from: '20260704T170000Z', to: '20260704T200000Z' } }],
+      },
+    };
+    const info = extractDateInfo(hit);
+    expect(info).toEqual({ startDate: '2026-07-04', startTime: '19:00', endDate: '2026-07-04', recurring: false });
+  });
+
+  it('flags recurring:true for multiple rules and spans first→last', () => {
+    const hit = {
+      applicableDates: {
+        rules: [
+          { conditions: { from: '20260704T170000Z', to: '20260704T200000Z' } },
+          { conditions: { from: '20260711T170000Z', to: '20260711T200000Z' } },
+        ],
+      },
+    };
+    const info = extractDateInfo(hit);
+    expect(info?.startDate).toBe('2026-07-04');
+    expect(info?.endDate).toBe('2026-07-11');
+    expect(info?.recurring).toBe(true);
+  });
+
+  it('falls back to executionDates (unix seconds) when there are no rules', () => {
+    const hit = { executionDates: [1783260600] }; // 2026-07-04T05:30:00Z-ish
+    const info = extractDateInfo(hit);
+    expect(info?.startDate).toBeTruthy();
+    expect(info?.recurring).toBe(false);
+  });
+
+  it('returns null when no usable date exists at all', () => {
+    expect(extractDateInfo({})).toBeNull();
+    expect(extractDateInfo({ applicableDates: { rules: [] }, executionDates: [] })).toBeNull();
+  });
+});
+
+describe('humanizeCategory', () => {
+  it('strips the trailing "Event" and inserts spaces between words', () => {
+    expect(humanizeCategory('MusicEvent')).toBe('Music');
+    expect(humanizeCategory('Festival')).toBe('Festival');
+    expect(humanizeCategory('SportsActivityLocation')).toBe('Sports Activity Location');
+  });
+
+  it('returns undefined for missing/blank type', () => {
+    expect(humanizeCategory(undefined)).toBeUndefined();
+    expect(humanizeCategory('')).toBeUndefined();
+  });
+});
+
+describe('extractPrice', () => {
+  it('returns undefined when there is no offers/isAccessibleForFree info', () => {
+    expect(extractPrice({})).toBeUndefined();
+    expect(extractPrice(undefined)).toBeUndefined();
+  });
+
+  it('reads a single offers object', () => {
+    expect(extractPrice({ offers: { price: '25', priceCurrency: 'CHF' } })).toEqual({
+      amount: 25,
+      currency: 'CHF',
+      isFree: false,
+    });
+  });
+
+  it('takes the cheapest of multiple offers', () => {
+    expect(
+      extractPrice({
+        offers: [
+          { price: '40', priceCurrency: 'CHF' },
+          { price: '15', priceCurrency: 'CHF' },
+        ],
+      }),
+    ).toEqual({ amount: 15, currency: 'CHF', isFree: false });
+  });
+
+  it('flags isAccessibleForFree as a free event', () => {
+    expect(extractPrice({ isAccessibleForFree: true })).toEqual({ amount: 0, currency: 'CHF', isFree: true });
+  });
+});
+
+describe('extractAddress', () => {
+  it('reads street + postalCode from location.address', () => {
+    expect(
+      extractAddress({ location: { address: { streetAddress: 'Piazza Grande 1', postalCode: '6600' } } }),
+    ).toEqual({ street: 'Piazza Grande 1', postalCode: '6600' });
+  });
+
+  it('returns undefined when address is absent or empty', () => {
+    expect(extractAddress({})).toBeUndefined();
+    expect(extractAddress({ location: {} })).toBeUndefined();
+    expect(extractAddress({ location: { address: {} } })).toBeUndefined();
+  });
+});
+
+describe('extractEventJsonLd', () => {
+  it('picks the Event(-subtype) JSON-LD block and skips unrelated ones', () => {
+    const html = `
+      <script type="application/ld+json">{"@type":"BreadcrumbList","itemListElement":[]}</script>
+      <script type="application/ld+json">{"@type":"MusicEvent","name":"Test","startDate":"2026-07-04T19:00:00+02:00"}</script>
+    `;
+    const ld = extractEventJsonLd(html);
+    expect(ld?.['@type']).toBe('MusicEvent');
+    expect(ld?.name).toBe('Test');
+  });
+
+  it('returns null when there is no matching block or malformed JSON', () => {
+    expect(extractEventJsonLd('')).toBeNull();
+    expect(extractEventJsonLd('<html></html>')).toBeNull();
+    expect(extractEventJsonLd('<script type="application/ld+json">{not json</script>')).toBeNull();
+  });
+});
+
+describe('mapEventRecord', () => {
+  const hitIt = {
+    objectID: 'abc123',
+    title: 'Festival della Musica',
+    leadText: 'Un grande festival di musica dal vivo.',
+    url: '/eventi/festival-della-musica',
+    place: 'Lugano',
+    image: 'https://cdn.myswitzerland.com/images/abc.jpg',
+    _geoloc: { lat: 46.005, lng: 8.951 },
+    applicableDates: { rules: [{ conditions: { from: '20260704T170000Z', to: '20260704T200000Z' } }] },
+  };
+  const hitEn = { ...hitIt, title: 'Music Festival', leadText: 'A great live music festival.' };
+
+  it('returns null when there is no primary-locale hit', () => {
+    expect(mapEventRecord('abc123', {})).toBeNull();
+  });
+
+  it('returns null when the primary hit has no usable date', () => {
+    expect(mapEventRecord('abc123', { it: { ...hitIt, applicableDates: undefined } })).toBeNull();
+  });
+
+  it('returns null when there is no title in any locale', () => {
+    expect(mapEventRecord('abc123', { it: { ...hitIt, title: '' } })).toBeNull();
+  });
+
+  it('maps a single-locale hit to a SiteEvent-shaped record with index-only fields', () => {
+    const mapped = mapEventRecord('abc123', { it: hitIt });
+    expect(mapped).not.toBeNull();
+    const { event, imageSourceUrl, place } = mapped as never as {
+      event: Record<string, unknown>;
+      imageSourceUrl: string;
+      place: string;
+    };
+    expect(event.id).toBe('myswitzerland:abc123');
+    expect(event.title).toBe('Festival della Musica');
+    expect(event.titleByLocale).toEqual({ it: 'Festival della Musica' });
+    expect(event.description).toBe('Un grande festival di musica dal vivo.');
+    expect(event.startDate).toBe('2026-07-04');
+    expect(event.startTime).toBe('19:00');
+    expect(event.endDate).toBe('2026-07-04');
+    expect(event.category).toBe('Event'); // no detail-page enrichment supplied
+    expect(event.venue).toBe('Lugano'); // falls back to the index `place`
+    expect(event.canton).toBe('');
+    expect(event.geo).toEqual({ lat: 46.005, lng: 8.951 });
+    expect(event.recurring).toBe(false);
+    expect(event.price).toBeUndefined();
+    expect(event.address).toBeUndefined();
+    expect(imageSourceUrl).toBe('https://cdn.myswitzerland.com/images/abc.jpg');
+    expect(place).toBe('Lugano');
+    expect(event.url).toBe('https://www.myswitzerland.com/it-ch/eventi/festival-della-musica');
+  });
+
+  it('merges it+en hits into titleByLocale/descriptionByLocale, prefers it as canonical title', () => {
+    const mapped = mapEventRecord('abc123', { it: hitIt, en: hitEn });
+    const event = mapped?.event as never as Record<string, unknown>;
+    expect(event.title).toBe('Festival della Musica');
+    expect(event.titleByLocale).toEqual({ it: 'Festival della Musica', en: 'Music Festival' });
+    expect(event.descriptionByLocale).toEqual({
+      it: 'Un grande festival di musica dal vivo.',
+      en: 'A great live music festival.',
+    });
+  });
+
+  it('enriches category/price/address/venue from detail-page JSON-LD when available', () => {
+    const detailLd = {
+      '@type': 'MusicEvent',
+      location: {
+        name: 'LAC Lugano Arte e Cultura',
+        address: { streetAddress: 'Piazza Bernardino Luini 6', postalCode: '6900' },
+      },
+      offers: { price: '25', priceCurrency: 'CHF' },
+    };
+    const mapped = mapEventRecord('abc123', { it: hitIt }, { detailLd, detailUrl: 'https://www.myswitzerland.com/it-ch/eventi/festival-della-musica' });
+    const event = mapped?.event as never as Record<string, unknown>;
+    expect(event.category).toBe('Music');
+    expect(event.venue).toBe('LAC Lugano Arte e Cultura');
+    expect(event.address).toEqual({ street: 'Piazza Bernardino Luini 6', postalCode: '6900' });
+    expect(event.price).toEqual({ amount: 25, currency: 'CHF', isFree: false });
+    expect(event.url).toBe('https://www.myswitzerland.com/it-ch/eventi/festival-della-musica');
+  });
+});

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -69,6 +69,77 @@ describe('eventLd canonical', () => {
   });
 });
 
+describe('eventLd nationwide fields (#3125)', () => {
+  it('uses the per-EVENT_SOURCES organizer, not a single hardcoded source', () => {
+    const guidleEvent = { ...EVENT, id: 'guidle:abc', sourceKey: 'guidle', sourceName: 'Guidle' };
+    const ld = eventLd(guidleEvent as never, 'it') as Record<string, any>;
+    expect(ld.organizer.url).toBe('https://www.guidle.com');
+    expect(ld.organizer.name).toBe('Guidle');
+  });
+
+  it('falls back to the tio-agenda source when sourceKey is unknown (defensive)', () => {
+    const unknownSource = { ...EVENT, sourceKey: 'does-not-exist' };
+    const ld = eventLd(unknownSource as never, 'it') as Record<string, any>;
+    expect(ld.organizer.url).toBe('https://www.tio.ch/agenda');
+  });
+
+  it('prefers a real crawled description over the synthesized one when long enough', () => {
+    const withDescription = {
+      ...EVENT,
+      description: 'Una serata di grande musica sinfonica con orchestra internazionale al LAC di Lugano.',
+    };
+    const ld = eventLd(withDescription as never, 'it') as Record<string, any>;
+    expect(ld.description).toBe(withDescription.description);
+  });
+
+  it('emits location.geo when the event has coordinates', () => {
+    const withGeo = { ...EVENT, geo: { lat: 46.005, lng: 8.951 } };
+    const ld = eventLd(withGeo as never, 'it') as Record<string, any>;
+    expect(ld.location.geo).toEqual({ '@type': 'GeoCoordinates', latitude: 46.005, longitude: 8.951 });
+  });
+
+  it('emits address.streetAddress/postalCode when known', () => {
+    const withAddress = { ...EVENT, address: { street: 'Piazza Bernardino Luini 6', postalCode: '6900' } };
+    const ld = eventLd(withAddress as never, 'it') as Record<string, any>;
+    expect(ld.location.address.streetAddress).toBe('Piazza Bernardino Luini 6');
+    expect(ld.location.address.postalCode).toBe('6900');
+  });
+
+  it('omits offers entirely when price is unknown (never a partial offers object)', () => {
+    const ld = eventLd(EVENT as never, 'it') as Record<string, any>;
+    expect(ld.offers).toBeUndefined();
+  });
+
+  it('emits a complete offers object for a free event', () => {
+    const freeEvent = { ...EVENT, price: { amount: null, currency: 'CHF', isFree: true } };
+    const ld = eventLd(freeEvent as never, 'it') as Record<string, any>;
+    expect(ld.offers).toMatchObject({
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'CHF',
+      availability: 'https://schema.org/InStock',
+      validFrom: EVENT.startDate,
+    });
+    expect(ld.offers.url).toBeTruthy();
+  });
+
+  it('emits a complete offers object for a paid event', () => {
+    const paidEvent = { ...EVENT, price: { amount: 25, currency: 'CHF', isFree: false } };
+    const ld = eventLd(paidEvent as never, 'it') as Record<string, any>;
+    expect(ld.offers.price).toBe('25');
+    expect(ld.offers.priceCurrency).toBe('CHF');
+  });
+
+  it('uses the local mirrored image path for image (absolute-ized), falling back to the site image', () => {
+    const withImage = { ...EVENT, imageUrl: '/images/events/guidle-abc.jpg' };
+    const ldWithImage = eventLd(withImage as never, 'it') as Record<string, any>;
+    expect(ldWithImage.image).toBe('https://frontaliereticino.ch/images/events/guidle-abc.jpg');
+
+    const withoutImage = eventLd(EVENT as never, 'it') as Record<string, any>;
+    expect(withoutImage.image).toBe('https://frontaliereticino.ch/og-image.png');
+  });
+});
+
 describe('renderEventDetailPage', () => {
   const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-detail-'));
   const detailHref = (e: { id: string }) =>

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -202,4 +202,27 @@ describe('router recognises per-event detail URLs (staticOverlay)', () => {
     const parsed = parsePath('/eventi/ticino/lugano/');
     expect(parsed?.route?.staticOverlay).toBe(true);
   });
+
+  // Canton rollout (#3125): the matcher must recognise ANY canton's URL
+  // slug from data/canton-url-slugs.json, not just the legacy hardcoded
+  // ticino/tessin literal — proves the generalization is real, not a
+  // same-behavior refactor.
+  for (const url of [
+    '/eventi/zurigo/',
+    '/eventi/zurigo/zurigo/',
+    '/en/events/zurich/zurich/',
+    '/de/veranstaltungen/zurich/zurich/',
+    '/fr/evenements/zurich/zurich/',
+  ]) {
+    it(`recognises a non-Ticino canton hub/comune page: ${url}`, () => {
+      const parsed = parsePath(url);
+      expect(parsed?.route?.staticOverlay).toBe(true);
+      expect(parsed?.route?.activeTab).toBe('vita');
+    });
+  }
+
+  it('rejects a first segment that is not a known canton slug (falls through, no false match)', () => {
+    const parsed = parsePath('/eventi/not-a-real-canton/');
+    expect(parsed?.route?.staticOverlay).not.toBe(true);
+  });
 });

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -13,6 +13,10 @@ import {
   eventLd,
   pathForEventDetail,
   renderEventDetailPage,
+  renderHubPage,
+  renderComunePage,
+  renderDigestPage,
+  DIGESTS,
 } from '../build-plugins/eventsSeoPagesPlugin';
 import { MIN_INDEXABLE_WORDS } from '../build-plugins/constants';
 import { parsePath } from '../services/router';
@@ -224,5 +228,245 @@ describe('router recognises per-event detail URLs (staticOverlay)', () => {
   it('rejects a first segment that is not a known canton slug (falls through, no false match)', () => {
     const parsed = parsePath('/eventi/not-a-real-canton/');
     expect(parsed?.route?.staticOverlay).not.toBe(true);
+  });
+});
+
+// #3125 Task C: price / address / map / recurring / real description rendered
+// VISIBLY in the detail page body, not only inside the Event JSON-LD.
+describe('renderEventDetailPage nationwide fields (#3125 Task C)', () => {
+  const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-detail-fields-'));
+  const richEvent = {
+    ...EVENT,
+    id: 'guidle:rich',
+    description: 'Descrizione reale raccolta dal crawler, con dettagli sul programma della serata.',
+    price: { amount: 25, currency: 'CHF', isFree: false },
+    address: { street: 'Piazza Bernardino Luini 6', postalCode: '6900' },
+    geo: { lat: 46.005, lng: 8.951 },
+    recurring: true,
+  };
+  const page = renderEventDetailPage({
+    locale: 'it',
+    event: richEvent as never,
+    comune: 'Lugano',
+    eventSlug: slugifyEvent(richEvent),
+    sameComuneEvents: [richEvent] as never,
+    dateStamp: '2026-06-30',
+    distDir,
+    detailHref: (() => null) as never,
+  });
+
+  it('renders a price line (paid event)', () => {
+    expect(page.html).toContain('Prezzo');
+    expect(page.html).toContain('CHF 25');
+  });
+
+  it('renders the address (street + postal code)', () => {
+    expect(page.html).toContain('Indirizzo');
+    expect(page.html).toContain('Piazza Bernardino Luini 6');
+    expect(page.html).toContain('6900');
+  });
+
+  it('renders a plain OpenStreetMap link (no third-party embed/tracker), accessible', () => {
+    // esc() HTML-escapes the "&" in the href attribute (&amp;).
+    expect(page.html).toContain('openstreetmap.org/?mlat=46.005&amp;mlon=8.951');
+    expect(page.html).toContain('rel="nofollow noopener"');
+    expect(page.html).not.toMatch(/google\.com\/maps|<iframe/i);
+    // Accessible name on the map link (not just an icon).
+    expect(page.html).toMatch(/aria-label="Apri [^"]+ su OpenStreetMap"/);
+  });
+
+  it('renders the recurring badge when event.recurring is true', () => {
+    expect(page.html).toContain('Evento ricorrente');
+  });
+
+  it('renders the real crawled description as visible prose, alongside the synthesized paragraph', () => {
+    expect(page.html).toContain('Descrizione reale raccolta dal crawler');
+    expect(page.html).toContain('Descrizione'); // descriptionTitle
+    // The synthesized dc.about(...) paragraph is still present (never removed).
+    expect(page.html).toContain('è un evento di tipo');
+  });
+
+  it('renders "Gratis" for a free event', () => {
+    const freeEvent = { ...EVENT, id: 'guidle:free', price: { amount: null, currency: 'CHF', isFree: true } };
+    const freePage = renderEventDetailPage({
+      locale: 'it',
+      event: freeEvent as never,
+      comune: 'Lugano',
+      eventSlug: slugifyEvent(freeEvent),
+      sameComuneEvents: [freeEvent] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    expect(freePage.html).toContain('Gratis');
+  });
+
+  it('omits price/address/recurring markup entirely when the fields are unknown (TI regression guard)', () => {
+    expect(page.wordCount).toBeGreaterThanOrEqual(MIN_INDEXABLE_WORDS);
+    const baselinePage = renderEventDetailPage({
+      locale: 'it',
+      event: EVENT as never,
+      comune: 'Lugano',
+      eventSlug: slugifyEvent(EVENT),
+      sameComuneEvents: [EVENT] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    expect(baselinePage.html).not.toContain('Evento ricorrente');
+    expect(baselinePage.html).not.toContain('Indirizzo');
+  });
+});
+
+// #3125 Task B: multi-source attribution — the footer must list every DISTINCT
+// source actually present among the events shown on that page, not a single
+// hardcoded SOURCE.
+describe('multi-source attribution (#3125 Task B)', () => {
+  const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-sources-'));
+  const tioEvent = { ...EVENT, id: 'tio-agenda:1', sourceKey: 'tio-agenda' };
+  const guidleEvent = { ...EVENT, id: 'guidle:1', comune: 'Lugano', sourceKey: 'guidle', sourceName: 'Guidle' };
+  const myswEvent = { ...EVENT, id: 'myswitzerland:1', comune: 'Lugano', sourceKey: 'myswitzerland', sourceName: 'MySwitzerland' };
+  const mixed = [tioEvent, guidleEvent, myswEvent];
+  const byComune = new Map([['Lugano', mixed]]);
+
+  it('hub page lists every distinct source among the shown events, each linking to its own homepage', () => {
+    const page = renderHubPage({
+      locale: 'it',
+      canton: 'TI',
+      events: mixed as never,
+      byComune: byComune as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(page.html).toContain('https://www.tio.ch/agenda');
+    expect(page.html).toContain('https://www.guidle.com');
+    expect(page.html).toContain('https://www.myswitzerland.com');
+    expect(page.html).toMatch(/rel="nofollow noopener"/);
+  });
+
+  it('comune page lists every distinct source among the shown events', () => {
+    const page = renderComunePage({
+      locale: 'it',
+      canton: 'TI',
+      comune: 'Lugano',
+      events: mixed as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(page.html).toContain('https://www.tio.ch/agenda');
+    expect(page.html).toContain('https://www.guidle.com');
+    expect(page.html).toContain('https://www.myswitzerland.com');
+  });
+
+  it('digest page lists every distinct source among the shown events', () => {
+    const def = DIGESTS.find((d) => d.key === 'weekend')!;
+    const page = renderDigestPage({
+      def,
+      locale: 'it',
+      canton: 'TI',
+      events: mixed as never,
+      dateStamp: '2026-06-30',
+      distDir,
+    });
+    expect(page.html).toContain('https://www.tio.ch/agenda');
+    expect(page.html).toContain('https://www.guidle.com');
+    expect(page.html).toContain('https://www.myswitzerland.com');
+  });
+
+  it('a single-source (TI-only) page still links only that one source, unchanged from before', () => {
+    const page = renderComunePage({
+      locale: 'it',
+      canton: 'TI',
+      comune: 'Lugano',
+      events: [tioEvent] as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(page.html).toContain('https://www.tio.ch/agenda');
+    expect(page.html).not.toContain('guidle.com');
+    expect(page.html).not.toContain('myswitzerland.com');
+  });
+});
+
+// #3125 Task A: hub/comune pages generalize to any canton, matching TI richness
+// (breadcrumbs, JSON-LD ItemList, stats) with the correct per-canton base path.
+describe('renderHubPage / renderComunePage generalize to a non-TI canton (#3125 Task A)', () => {
+  const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-canton-'));
+  const zhEvent = { ...EVENT, id: 'guidle:zh1', canton: 'ZH', comune: 'Zürich', sourceKey: 'guidle', sourceName: 'Guidle' };
+  const byComune = new Map([['Zürich', [zhEvent]]]);
+
+  it('hub page uses the per-canton base path and canton-agnostic copy (no literal "Ticino")', () => {
+    const page = renderHubPage({
+      locale: 'it',
+      canton: 'ZH',
+      events: [zhEvent] as never,
+      byComune: byComune as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(page.urlPath).toBe('/eventi/zurigo/');
+    expect(page.html).toContain('"@type":"ItemList"');
+    expect(page.html).toContain('"@type":"BreadcrumbList"');
+    expect(page.html).toContain('Zurigo');
+    // The COPY-owned strings (lede/header/methodology) must be substituted to
+    // the canton, not the literal TI phrase. (The sitewide "Esplora anche"
+    // crosslinks block still legitimately points at Ticino-specific site
+    // sections like job search — that's a separate, out-of-scope feature, so
+    // we don't assert "Ticino" is absent from the WHOLE page, only from the
+    // hub's own lede/header text.)
+    expect(page.html).toContain('Eventi in Zurigo, comune per comune');
+    expect(page.html).not.toMatch(/agenda di Ticino|in tutto il Ticino/);
+  });
+
+  it('comune page under the ZH hub uses the canton-scoped path', () => {
+    const page = renderComunePage({
+      locale: 'it',
+      canton: 'ZH',
+      comune: 'Zürich',
+      events: [zhEvent] as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(page.urlPath).toBe('/eventi/zurigo/zurich/');
+    expect(page.html).toContain('Zürich e nella sua regione');
+    expect(page.html).not.toMatch(/del Ticino\b/);
+  });
+
+  it('detail page under a ZH comune resolves to the ZH-scoped canonical path', () => {
+    const page = renderEventDetailPage({
+      locale: 'it',
+      event: zhEvent as never,
+      comune: 'Zürich',
+      eventSlug: slugifyEvent(zhEvent),
+      sameComuneEvents: [zhEvent] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    expect(page.urlPath).toBe(`/eventi/zurigo/zurich/${slugifyEvent(zhEvent)}/`);
+    // The event's own lede/about text is canton-substituted ("in Zurigo", not
+    // "in Ticino"); the sitewide crosslinks block is intentionally untouched
+    // (see comment on the hub-page assertion above).
+    expect(page.html).toContain(', in Zurigo.');
+    expect(page.html).not.toMatch(/, in Ticino\./);
+  });
+
+  it('TI hub/comune pages stay byte-identical to the literal COPY (regression guard)', () => {
+    const tiPage = renderComunePage({
+      locale: 'it',
+      canton: 'TI',
+      comune: 'Lugano',
+      events: [EVENT] as never,
+      dateStamp: '2026-06-30',
+      weekendDays: new Set(),
+      distDir,
+    });
+    expect(tiPage.urlPath).toBe('/eventi/ticino/lugano/');
+    expect(tiPage.html).toContain('in Ticino');
   });
 });

--- a/tests/events-nationwide-sources.test.ts
+++ b/tests/events-nationwide-sources.test.ts
@@ -63,12 +63,12 @@ describe('loadAllComuni', () => {
 
 describe('resolveComuneNationwide', () => {
   it('resolves a comune nationwide without a canton hint', () => {
-    const r = resolveComuneNationwide({ venue: 'Stadthaus Winterthur', title: 'Konzert' });
+    const r = resolveComuneNationwide({ venue: 'Stadthaus Winterthur', title: 'Konzert', region: undefined });
     expect(r).toEqual({ comune: 'Winterthur', canton: 'ZH', method: 'exact-nationwide' });
   });
 
   it('scopes to the hinted canton first (exact TI match, same as resolveComune)', () => {
-    const r = resolveComuneNationwide({ venue: 'Teatro Sociale Bellinzona', title: 'Concerto' }, 'TI');
+    const r = resolveComuneNationwide({ venue: 'Teatro Sociale Bellinzona', title: 'Concerto', region: undefined }, 'TI');
     expect(r).toEqual({ comune: 'Bellinzona', canton: 'TI', method: 'exact' });
   });
 
@@ -84,7 +84,7 @@ describe('resolveComuneNationwide', () => {
   });
 
   it('returns null comune when nothing matches', () => {
-    const r = resolveComuneNationwide({ venue: 'Somewhere unresolvable', title: 'Nothing here' });
+    const r = resolveComuneNationwide({ venue: 'Somewhere unresolvable', title: 'Nothing here', region: undefined });
     expect(r).toEqual({ comune: null, canton: null, method: null });
   });
 });

--- a/tests/events-nationwide-sources.test.ts
+++ b/tests/events-nationwide-sources.test.ts
@@ -12,6 +12,8 @@ import {
   EVENT_SOURCES,
   EVENTS_BASE_PATH,
   eventsBasePathForCanton,
+  resolveCantonUrlKey,
+  germanCantonPreposition,
   loadAllComuni,
   resolveComuneNationwide,
   haversineKm,
@@ -49,6 +51,42 @@ describe('eventsBasePathForCanton', () => {
   it('degrades to the TI fallback for an unknown/blank canton', () => {
     expect(eventsBasePathForCanton('')).toEqual(EVENTS_BASE_PATH);
     expect(eventsBasePathForCanton('XX')).toEqual(EVENTS_BASE_PATH);
+  });
+});
+
+describe('resolveCantonUrlKey', () => {
+  it('maps half-canton members onto their URL group key', () => {
+    expect(resolveCantonUrlKey('AI')).toBe('APPENZELLO');
+    expect(resolveCantonUrlKey('AR')).toBe('APPENZELLO');
+    expect(resolveCantonUrlKey('BL')).toBe('BASILEA');
+    expect(resolveCantonUrlKey('BS')).toBe('BASILEA');
+  });
+
+  it('is a no-op (case-insensitive) for cantons that are their own URL key', () => {
+    expect(resolveCantonUrlKey('TI')).toBe('TI');
+    expect(resolveCantonUrlKey('zh')).toBe('ZH');
+  });
+
+  it('returns the uppercased input unchanged for an unknown/blank canton', () => {
+    expect(resolveCantonUrlKey('')).toBe('');
+    expect(resolveCantonUrlKey('xx')).toBe('XX');
+  });
+});
+
+describe('germanCantonPreposition', () => {
+  it('reads the dePrefix override table from data/canton-url-slugs.json', () => {
+    expect(germanCantonPreposition('AG')).toBe('im'); // "im Aargau"
+    expect(germanCantonPreposition('VS')).toBe('im'); // "im Wallis"
+    expect(germanCantonPreposition('VD')).toBe('in der'); // "in der Waadt"
+  });
+
+  it('defaults to plain "in" when there is no override', () => {
+    expect(germanCantonPreposition('ZH')).toBe('in'); // "in Zürich"
+    expect(germanCantonPreposition('BE')).toBe('in'); // "in Bern"
+  });
+
+  it('resolves half-canton members through their URL group before the lookup', () => {
+    expect(germanCantonPreposition('AI')).toBe('in'); // "in Appenzell" — group has no override
   });
 });
 

--- a/tests/events-nationwide-sources.test.ts
+++ b/tests/events-nationwide-sources.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Nationwide events sourcing (issue #3125): shared foundations consumed by the
+ * guidle/myswitzerland crawlers, the multi-canton hub/route generalization and
+ * the assemble step — canton-agnostic comune resolution, Italian frontier
+ * comuni geo-linking, per-canton URL base paths, and the no-hotlink image
+ * mirror. See scripts/lib/events-utils.mjs.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import {
+  EVENT_SOURCES,
+  EVENTS_BASE_PATH,
+  eventsBasePathForCanton,
+  loadAllComuni,
+  resolveComuneNationwide,
+  haversineKm,
+  resolveItalianFrontierComuni,
+  mirrorEventImage,
+} from '../scripts/lib/events-utils.mjs';
+
+describe('EVENT_SOURCES nationwide registry', () => {
+  it('registers guidle and myswitzerland as canton-agnostic (canton: null)', () => {
+    expect(EVENT_SOURCES.guidle.canton).toBeNull();
+    expect(EVENT_SOURCES.myswitzerland.canton).toBeNull();
+    expect(EVENT_SOURCES['tio-agenda'].canton).toBe('TI');
+  });
+});
+
+describe('eventsBasePathForCanton', () => {
+  it('is byte-identical to the legacy EVENTS_BASE_PATH constant for TI', () => {
+    expect(eventsBasePathForCanton('TI')).toEqual(EVENTS_BASE_PATH);
+  });
+
+  it('builds localized paths for another canton from data/canton-url-slugs.json', () => {
+    expect(eventsBasePathForCanton('ZH')).toEqual({
+      it: '/eventi/zurigo',
+      en: '/en/events/zurich',
+      de: '/de/veranstaltungen/zurich',
+      fr: '/fr/evenements/zurich',
+    });
+  });
+
+  it('collapses half-cantons onto their URL group (AI → APPENZELLO)', () => {
+    const ai = eventsBasePathForCanton('AI');
+    expect(ai.it).toBe('/eventi/appenzello');
+  });
+
+  it('degrades to the TI fallback for an unknown/blank canton', () => {
+    expect(eventsBasePathForCanton('')).toEqual(EVENTS_BASE_PATH);
+    expect(eventsBasePathForCanton('XX')).toEqual(EVENTS_BASE_PATH);
+  });
+});
+
+describe('loadAllComuni', () => {
+  it('flattens all 26 cantons (2110 comuni total)', () => {
+    const all = loadAllComuni();
+    expect(all.length).toBe(2110);
+    expect(all.some((c) => c.name === 'Lugano' && c.canton === 'TI')).toBe(true);
+    expect(all.some((c) => c.name === 'Winterthur' && c.canton === 'ZH')).toBe(true);
+  });
+});
+
+describe('resolveComuneNationwide', () => {
+  it('resolves a comune nationwide without a canton hint', () => {
+    const r = resolveComuneNationwide({ venue: 'Stadthaus Winterthur', title: 'Konzert' });
+    expect(r).toEqual({ comune: 'Winterthur', canton: 'ZH', method: 'exact-nationwide' });
+  });
+
+  it('scopes to the hinted canton first (exact TI match, same as resolveComune)', () => {
+    const r = resolveComuneNationwide({ venue: 'Teatro Sociale Bellinzona', title: 'Concerto' }, 'TI');
+    expect(r).toEqual({ comune: 'Bellinzona', canton: 'TI', method: 'exact' });
+  });
+
+  it('falls back to the TI region map only when hint is TI or absent', () => {
+    const withHint = resolveComuneNationwide({ venue: '', title: '', region: 'Luganese' }, 'TI');
+    expect(withHint).toEqual({ comune: 'Lugano', canton: 'TI', method: 'region' });
+
+    const withoutHint = resolveComuneNationwide({ venue: '', title: '', region: 'Luganese' });
+    expect(withoutHint).toEqual({ comune: 'Lugano', canton: 'TI', method: 'region' });
+
+    const otherCantonHint = resolveComuneNationwide({ venue: '', title: '', region: 'Luganese' }, 'ZH');
+    expect(otherCantonHint.comune).toBeNull();
+  });
+
+  it('returns null comune when nothing matches', () => {
+    const r = resolveComuneNationwide({ venue: 'Somewhere unresolvable', title: 'Nothing here' });
+    expect(r).toEqual({ comune: null, canton: null, method: null });
+  });
+});
+
+describe('haversineKm', () => {
+  it('is ~0 for identical points and grows monotonically with distance', () => {
+    expect(haversineKm(46.0, 8.95, 46.0, 8.95)).toBeCloseTo(0, 5);
+    const near = haversineKm(45.858, 8.9511, 45.85, 8.95);
+    const far = haversineKm(45.858, 8.9511, 47.37, 8.54); // ~Zurich
+    expect(far).toBeGreaterThan(near);
+  });
+});
+
+describe('resolveItalianFrontierComuni', () => {
+  it('returns nearby Italian border comuni for coordinates near the border', () => {
+    // Stabio-area coordinates (Mendrisiotto, right at the CH/IT border).
+    const near = resolveItalianFrontierComuni({ lat: 45.858, lng: 8.9511 });
+    expect(near.length).toBeGreaterThan(0);
+    expect(near.length).toBeLessThanOrEqual(5);
+  });
+
+  it('returns [] when the event has no geo', () => {
+    expect(resolveItalianFrontierComuni(undefined)).toEqual([]);
+    expect(resolveItalianFrontierComuni({})).toEqual([]);
+    expect(resolveItalianFrontierComuni({ lat: 'x', lng: 8 })).toEqual([]);
+  });
+
+  it('returns [] when nothing is within maxKm (e.g. deep in German-speaking Switzerland)', () => {
+    expect(resolveItalianFrontierComuni({ lat: 47.55, lng: 9.6 }, { maxKm: 5 })).toEqual([]);
+  });
+});
+
+describe('mirrorEventImage', () => {
+  const testImagesDir = path.join(process.cwd(), 'public', 'images', 'events');
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // Clean up any file this test wrote so repeated runs stay idempotent and
+    // don't leak fixture images into the tracked public/ directory.
+    try {
+      rmSync(path.join(testImagesDir, 'test-mirror-fixture.jpg'), { force: true });
+    } catch {
+      /* noop */
+    }
+  });
+
+  it('returns null for a missing or non-http url', async () => {
+    expect(await mirrorEventImage('', 'guidle:abc')).toBeNull();
+    expect(await mirrorEventImage('not-a-url', 'guidle:abc')).toBeNull();
+    expect(await mirrorEventImage(undefined, 'guidle:abc')).toBeNull();
+  });
+
+  it('returns null for an empty stableId', async () => {
+    expect(await mirrorEventImage('https://example.com/x.jpg', '')).toBeNull();
+  });
+
+  it('downloads and writes the image once, returning the site-relative path', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'image/jpeg' },
+      arrayBuffer: async () => bytes.buffer,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await mirrorEventImage('https://example.com/photo.jpg', 'test:mirror-fixture');
+    expect(result).toBe('/images/events/test-mirror-fixture.jpg');
+    expect(existsSync(path.join(testImagesDir, 'test-mirror-fixture.jpg'))).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Idempotent: a second call must NOT re-fetch (file already present).
+    const second = await mirrorEventImage('https://example.com/photo.jpg', 'test:mirror-fixture');
+    expect(second).toBe('/images/events/test-mirror-fixture.jpg');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null on a non-2xx response, a non-image content-type, or an oversized body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, headers: { get: () => 'image/jpeg' }, arrayBuffer: async () => new ArrayBuffer(0) }),
+    );
+    expect(await mirrorEventImage('https://example.com/notfound.jpg', 'test:mirror-fixture')).toBeNull();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, headers: { get: () => 'text/html' }, arrayBuffer: async () => new ArrayBuffer(4) }),
+    );
+    expect(await mirrorEventImage('https://example.com/notanimage', 'test:mirror-fixture')).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    expect(await mirrorEventImage('https://example.com/x.jpg', 'test:mirror-fixture')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Implementato

- **Schema esteso per fonti multiple**: `SiteEvent` ora supporta `titleByLocale`/`descriptionByLocale` (it/en/de/fr reali, non traduzione automatica), `price`, `address`, `geo`, `recurring`; registro `EVENT_SOURCES` con chiave/etichetta/homepage per ogni fonte (tio-agenda, guidle, myswitzerland); `eventStableId(sourceKey, rawId)` per id stabili cross-fonte.
- **Localizzazione reale**: titolo/descrizione per-locale presi dal sito sorgente quando disponibili (guidle pubblica nativamente in 4 lingue), con fallback canton-aware per il JSON-LD quando una fonte non fornisce una lingua.
- **Due nuovi crawler quota-free** (`fetch` puro, no API key, no LLM), entrambi con architettura checkpoint/resume + budget di tempo (`scripts/lib/crawl-checkpoint.mjs`), perché il catalogo completo non entra in un singolo run schedulato:
  - `scripts/crawl-myswitzerland-events.mjs` — myswitzerland.com, copertura nazionale (~20k eventi via Algolia).
  - `scripts/crawl-guidle-events.mjs` — guidle.com, 119'800 URL evento scoperti via sitemap index, JSON-LD schema.org come fonte primaria, `--limit` opzionale solo per iterazione locale (nessun cap permanente).
  - Ogni run rielabora l'indice/sitemap completo (economico) poi cammina una fetta del catalogo a partire da un cursore persistito (`data/events/checkpoints/<source>.json`), si ferma a un budget configurabile (default 8 min, ben dentro il timeout di job di 35 min di `crawl-events.yml`) e fa il **merge incrementale** (upsert per id) nello slice esistente invece di sovrascriverlo — nessun run interrotto perde il lavoro dei run precedenti, la copertura del catalogo si accumula sui run schedulati giornalieri. Pruning automatico degli eventi con data ormai passata.
  - Guardia di drift (`process.exitCode = 1` su fallimento strutturale JSON-LD/DOM/Algolia) basata su segnale di successo positivo (pagine caricate con successo, non conteggio cumulativo di fallimenti) e su `visited > 0` — un run che esaurisce il budget prima di visitare qualunque evento è trattato come transiente, mai come drift.
  - Entrambi mirror-ano le immagini in locale via `mirrorEventImage` (CDN-offloaded) — il sito sorgente non viene mai referenziato direttamente nell'output.
- **Dedup cross-fonte + tagging frontiera italiana**: `scripts/assemble-events-dataset.mjs` deduplica per titolo+data+comune normalizzati tra tio-agenda/guidle/myswitzerland; tagging automatico dei comuni italiani di frontiera per eventi con `geo` disponibile.
- **Routing e pagine SSG generalizzati a tutti i 26 cantoni** (prima solo Ticino): `services/router.ts` e `build-plugins/eventsSeoPagesPlugin.ts` risolvono hub/comune/dettaglio per qualsiasi cantone svizzero via `resolveComuneNationwide`.
- **Workflow CI aggiornato**: `.github/workflows/crawl-events.yml` esegue i due nuovi crawler nello stesso job di tio-agenda e committa le slice in `data/events/by-source/` più i cursori di checkpoint in `data/events/checkpoints/`.
- **Test**: 6 nuovi file di test (assemble-dedup, myswitzerland, guidle, checkpoint/merge, nationwide-sources, detail-pages) — 169 test verdi sulla feature, nessuna regressione sulle 763+ suite router/eventi esistenti, nessun nuovo errore `tsc` (baseline pre-esistente di 75 errori invariata). Ciclo checkpoint→resume→merge e la nuova guardia di drift verificati anche live contro guidle.com/myswitzerland.com (non solo su fixture).

## Non implementato

- **Crawling diretto dei siti ufficiali dei singoli comuni** (es. stabio.ch/eventi): coperto indirettamente tramite gli aggregatori nazionali guidle.com/myswitzerland.com, che indicizzano già gli eventi dei comuni svizzeri — scraping comune-per-comune di centinaia di siti indipendenti non è stato fatto (scope/manutenibilità).
- **Slice dati reale per guidle/myswitzerland** (`data/events/by-source/*.json`): non committate in questa PR — si popolano incrementalmente a partire dal primo run schedulato del workflow via il meccanismo di checkpoint/resume sopra descritto (la copertura completa del catalogo richiede più run, non un singolo run), per non committare uno slice di sviluppo non rappresentativo.
- **Estrazione eventi da flyer/immagini (OCR)**: sconsigliata in una valutazione precedente, non ripresa qui.
- Roadmap più ampia eventi (#3051) resta aperta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
