### PR TITLE
fix(journalist-dashboard): fix 404 image suggestions, add selected highlight, auto alt text

### DIFF
--- a/components/pages/JournalistDashboardPage.tsx
+++ b/components/pages/JournalistDashboardPage.tsx
@@ -70,6 +70,7 @@ import type {
   ArticleLocale,
 } from '@/services/journalistTypes';
 import { searchImageCatalog, type CatalogImageCandidate } from '@/services/journalistImageCatalog';
+import { cdnBlogImage } from '@/services/seo/blogImageCdn';
 
 type ViewMode = 'list' | 'article';
 
@@ -308,13 +309,19 @@ export default function JournalistDashboardPage(): React.ReactElement {
     }
   };
 
+  /** Keeps a manually-entered alt untouched; only fills it in when blank (title-derived template). */
+  const withAutoImageAlt = (currentAlt: string): string =>
+    currentAlt.trim() || (title.trim() ? t('journalistDashboard.editor.imageAltAuto', { title: title.trim() }) : currentAlt);
+
   const handleImageUpload = async (file: File) => {
     if (!user || !draftId) return;
     setUploadingImage(true);
     try {
       const url = await uploadArticleImage(user.uid, draftId, file);
+      const autoAlt = withAutoImageAlt(imageAlt);
       setImage(url);
-      await saveDraft(draftId, { image: url });
+      if (autoAlt !== imageAlt) setImageAlt(autoAlt);
+      await saveDraft(draftId, { image: url, imageAlt: autoAlt });
       setSaveMsg({ ok: true, text: t('journalistDashboard.editor.imageSaved') });
     } catch (err) {
       reportCaughtError(err, 'journalistDashboard.imageUpload');
@@ -356,11 +363,13 @@ export default function JournalistDashboardPage(): React.ReactElement {
   };
 
   const handlePickCatalogImage = async (path: string) => {
+    const autoAlt = withAutoImageAlt(imageAlt);
     setImage(path);
+    if (autoAlt !== imageAlt) setImageAlt(autoAlt);
     setImageCandidates(null);
     if (draftId) {
       try {
-        await saveDraft(draftId, { image: path });
+        await saveDraft(draftId, { image: path, imageAlt: autoAlt });
         setSaveMsg({ ok: true, text: t('journalistDashboard.editor.imageSaved') });
       } catch (err) {
         reportCaughtError(err, 'journalistDashboard.imageUpload');
@@ -773,7 +782,7 @@ export default function JournalistDashboardPage(): React.ReactElement {
               {t('journalistDashboard.editor.imageLabel')}
             </label>
             {image && (
-              <img src={image} alt={imageAlt} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
+              <img src={cdnBlogImage(image)} alt={imageAlt} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
             )}
             {draftId ? (
               <>
@@ -808,16 +817,28 @@ export default function JournalistDashboardPage(): React.ReactElement {
                         {t('journalistDashboard.editor.suggestImagesEmpty')}
                       </p>
                     ) : (
-                      imageCandidates.map((candidate) => (
-                        <button
-                          key={candidate.path}
-                          type="button"
-                          onClick={() => { void handlePickCatalogImage(candidate.path); }}
-                          className="relative rounded-xl overflow-hidden border border-edge hover:ring-2 hover:ring-accent transition-shadow"
-                        >
-                          <img src={candidate.path} alt="" className="w-full h-20 object-cover" />
-                        </button>
-                      ))
+                      imageCandidates.map((candidate) => {
+                        const isSelected = candidate.path === image;
+                        return (
+                          <button
+                            key={candidate.path}
+                            type="button"
+                            onClick={() => { void handlePickCatalogImage(candidate.path); }}
+                            aria-label={t('journalistDashboard.editor.selectImage')}
+                            aria-pressed={isSelected}
+                            className={`relative rounded-xl overflow-hidden border transition-shadow ${
+                              isSelected ? 'border-accent ring-2 ring-accent' : 'border-edge hover:ring-2 hover:ring-accent'
+                            }`}
+                          >
+                            <img src={cdnBlogImage(candidate.path)} alt="" className="w-full h-20 object-cover" />
+                            {isSelected && (
+                              <span className="absolute top-1 right-1 rounded-full bg-accent text-on-accent p-0.5">
+                                <CheckCircle2 className="w-4 h-4" />
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })
                     )}
                   </div>
                 )}

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -3503,6 +3503,8 @@ Regeln:
   'journalistDashboard.editor.imageLabel': 'Titelbild',
   'journalistDashboard.editor.imageNeedsDraft': 'Speichere zuerst den Entwurf, um ein Bild hochladen zu können.',
   'journalistDashboard.editor.imageAltPlaceholder': 'Alternativtext des Bildes',
+  'journalistDashboard.editor.imageAltAuto': 'Redaktionelles Bild zu: {title}',
+  'journalistDashboard.editor.selectImage': 'Bild auswählen',
   'journalistDashboard.editor.uploadingImage': 'Bild wird hochgeladen...',
   'journalistDashboard.editor.imageSaved': 'Bild hochgeladen und gespeichert.',
   'journalistDashboard.editor.imageError': 'Bild-Upload fehlgeschlagen. Bitte versuche es erneut.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -3500,6 +3500,8 @@ Rules:
   'journalistDashboard.editor.imageLabel': 'Cover image',
   'journalistDashboard.editor.imageNeedsDraft': 'Save the draft first to be able to upload an image.',
   'journalistDashboard.editor.imageAltPlaceholder': 'Image alt text',
+  'journalistDashboard.editor.imageAltAuto': 'Editorial image related to: {title}',
+  'journalistDashboard.editor.selectImage': 'Select image',
   'journalistDashboard.editor.uploadingImage': 'Uploading image...',
   'journalistDashboard.editor.imageSaved': 'Image uploaded and saved.',
   'journalistDashboard.editor.imageError': 'Image upload failed. Please try again.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -3503,6 +3503,8 @@ Règles :
   'journalistDashboard.editor.imageLabel': 'Image de couverture',
   'journalistDashboard.editor.imageNeedsDraft': 'Enregistrez d’abord le brouillon pour pouvoir télécharger une image.',
   'journalistDashboard.editor.imageAltPlaceholder': 'Texte alternatif de l’image',
+  'journalistDashboard.editor.imageAltAuto': 'Image éditoriale relative à : {title}',
+  'journalistDashboard.editor.selectImage': 'Sélectionner l’image',
   'journalistDashboard.editor.uploadingImage': 'Téléchargement de l’image en cours...',
   'journalistDashboard.editor.imageSaved': 'Image téléchargée et enregistrée.',
   'journalistDashboard.editor.imageError': 'Échec du téléchargement de l’image. Veuillez réessayer.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -3590,6 +3590,8 @@ Regole:
   'journalistDashboard.editor.imageLabel': 'Immagine di copertina',
   'journalistDashboard.editor.imageNeedsDraft': 'Salva prima la bozza per poter caricare un\'immagine.',
   'journalistDashboard.editor.imageAltPlaceholder': 'Testo alternativo dell\'immagine',
+  'journalistDashboard.editor.imageAltAuto': 'Immagine editoriale relativa a: {title}',
+  'journalistDashboard.editor.selectImage': 'Seleziona immagine',
   'journalistDashboard.editor.uploadingImage': 'Caricamento immagine in corso...',
   'journalistDashboard.editor.imageSaved': 'Immagine caricata e salvata.',
   'journalistDashboard.editor.imageError': 'Caricamento immagine non riuscito. Riprova.',


### PR DESCRIPTION
## Implementato
- Fix 404 on suggested/selected cover images in the "suggerisci immagini" (image suggester) panel of the journalist article-creation dashboard: both the candidate thumbnails (`imageCandidates.map`) and the selected cover preview now render through `cdnBlogImage()` (`services/seo/blogImageCdn.ts`) instead of the bare `/images/blog/*.webp` path. Root cause: the local catalog manifest (`journalistImageCatalog.ts` / `scripts/generate-journalist-image-catalog.mjs`) stores site-relative paths, but production build offloads full blog hero images to `cdn.frontaliereticino.ch` and deletes them from `dist/images/blog` — any component rendering the bare path 404s.
- Added a persistent selected-state indicator on the picked candidate: accent border/ring + `CheckCircle2` badge (previously only a hover-only ring, so after picking an image there was no visual confirmation of which one was selected). Also added `aria-label`/`aria-pressed` to the candidate buttons (previously no accessible name).
- Alt text auto-generation: when a cover image is picked (catalog suggestion or manual upload) and the alt field is still blank, it's now auto-filled from the article title (`journalistDashboard.editor.imageAltAuto`, e.g. "Immagine editoriale relativa a: {title}"), mirroring the existing server-side fallback template in `scripts/publish-journalist-article.mjs`. Manually-entered alt text is never overwritten.
- New i18n keys added in all 4 locales (`it/en/de/fr-core.ts`): `journalistDashboard.editor.imageAltAuto`, `journalistDashboard.editor.selectImage`.

## Non implementato (ancora)
Nessuno.