### PR TITLE
fix(charts): suppress recharts ResponsiveContainer size warning

### DIFF
--- a/components/calculator/ComparisonChart.tsx
+++ b/components/calculator/ComparisonChart.tsx
@@ -300,7 +300,7 @@ const ComparisonChartBase: React.FC<Props> = ({ result, inputs, isDarkMode, isFo
  <div className="flex-1 flex flex-col items-center relative">
  <h4 className="text-xs font-bold uppercase text-muted mb-2">{t('chart.resident_ch')}</h4>
  <div className="w-full h-full relative">
- <ResponsiveContainer>
+ <ResponsiveContainer initialDimension={{ width: 1, height: 1 }}>
  <PieChart>
  <Pie data={pieDataCH} cx="50%" cy="50%" innerRadius={50} outerRadius={70} paddingAngle={2} dataKey="value">
  {pieDataCH.map((entry, index) => <Cell key={`cell-${index}`} fill={entry.color} strokeWidth={0} />)}
@@ -317,7 +317,7 @@ const ComparisonChartBase: React.FC<Props> = ({ result, inputs, isDarkMode, isFo
  <div className="flex-1 flex flex-col items-center relative border-t md:border-t-0 md:border-l border-dashed border-edge pt-4 md:pt-0">
  <h4 className="text-xs font-bold uppercase text-muted mb-2">{t('chart.frontier_worker')}</h4>
  <div className="w-full h-full relative">
- <ResponsiveContainer>
+ <ResponsiveContainer initialDimension={{ width: 1, height: 1 }}>
  <PieChart>
  <Pie data={pieDataIT} cx="50%" cy="50%" innerRadius={50} outerRadius={70} paddingAngle={2} dataKey="value">
  {pieDataIT.map((entry, index) => <Cell key={`cell-${index}`} fill={entry.color} strokeWidth={0} />)}

--- a/components/pages/JobBoardStatsOverview.tsx
+++ b/components/pages/JobBoardStatsOverview.tsx
@@ -484,7 +484,7 @@ const JobBoardStatsOverviewInner: React.FC<{ locale: Locale }> = ({ locale }) =>
  </h3>
  <div className="h-[320px] w-full">
  {data.history.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <ComposedChart
  data={data.history}
  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}

--- a/components/pages/StatsView.tsx
+++ b/components/pages/StatsView.tsx
@@ -133,7 +133,7 @@ const StatsViewInner: React.FC = () => {
  </h3>
  <div className="h-[300px] w-full">
  {historicalData.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <AreaChart
  data={historicalData}
  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
@@ -170,7 +170,7 @@ const StatsViewInner: React.FC = () => {
  </h3>
  <div className="h-[250px] w-full">
  {ageData.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <BarChart
  data={ageData}
  layout="vertical"
@@ -204,7 +204,7 @@ const StatsViewInner: React.FC = () => {
  </h3>
  <div className="h-[250px] w-full">
  {genderTrendData.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <LineChart
  data={genderTrendData}
  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}

--- a/components/pages/UnemploymentStats.tsx
+++ b/components/pages/UnemploymentStats.tsx
@@ -273,7 +273,7 @@ const UnemploymentStats: React.FC = () => {
  </h3>
  <div className="h-[320px] w-full">
  {trendData.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <LineChart
  data={trendData}
  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
@@ -323,7 +323,7 @@ const UnemploymentStats: React.FC = () => {
  </h3>
  <div className="h-[260px] w-full">
  {yearlyData.length > 0 ? (
- <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+ <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 1, height: 1 }}>
  <BarChart
  data={yearlyData}
  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}


### PR DESCRIPTION
## Implementato

Full-site Playwright console crawl from home (40 pages) found one class of recurring console warning: recharts `ResponsiveContainer` logs `width(-1) and height(-1)` when it's given a percent-based `height` (e.g. `height="100%"`) without an `initialDimension`, because it starts from recharts' internal `{width: -1, height: -1}` default before `ResizeObserver` reports the real size.

Fixed every call-site using this pattern by adding `initialDimension={{ width: 1, height: 1 }}` (all are already wrapped in fixed-height containers, so `ResizeObserver` corrects to the real size immediately after mount — no visual change):

- `components/pages/StatsView.tsx` (3 call-sites)
- `components/pages/JobBoardStatsOverview.tsx` (1 call-site)
- `components/pages/UnemploymentStats.tsx` (2 call-sites)
- `components/calculator/ComparisonChart.tsx` (2 call-sites, in the salary-comparison calculator's "Dettagli" breakdown tab — not reachable by the automated link-crawler since it's a JS tab toggle, not an `<a href>`; verified separately with a targeted Playwright script that fills the calculator form and clicks into that tab)

Verified: re-crawl of all 40 pages went from 8 console warnings (all on `/statistiche/`) to 0. Targeted breakdown-tab check also shows 0 chart warnings. `npx vitest run tests/salary-stats-landing.test.ts tests/stats-cache-ttl.test.ts tests/job-board-stats.test.ts` green (16/16). `tsc --noEmit` clean on touched files. GitNexus impact on all 4 touched component functions was LOW risk with no callers affected (JSX-prop-only change, no signature change).

## Non implementato (ancora)

Nessuno. Two unrelated findings surfaced during the crawl but are explicitly out of scope for this fix (different root cause, not part of the recharts sibling-pattern class):

- `net::ERR_BLOCKED_BY_ORB` on the blog cover image for `/articoli-frontaliere/ristorni-frontalieri-pellicini-tavolo-lavoro/` — the image exists in the repo (`public/images/blog/...webp`) and is present on `origin/main`, but the CDN (`cdn.frontaliereticino.ch`) currently 404s it. That's a deploy/offload-pipeline timing issue (`scripts/offload-generated-images-cdn.mjs` runs as part of `deploy.yml`), not a code defect — self-resolves on the next successful deploy, no code change addresses it.
- Google One Tap / FedCM console noise (`Provider's accounts list is empty.`, `AbortError: signal is aborted without reason`) appears site-wide. This is already deliberately triaged as benign upstream noise in `services/benignErrorPatterns.ts` (explicit `AbortError`/One-Tap-degrades-gracefully patterns), and `use_fedcm_for_prompt: false` is a tested, intentional config (`tests/auth-onetap-mobile-guard.test.ts`) — not something this PR should touch.

## Test plan

- [x] Playwright 40-page console crawl before/after: 8 warnings → 0
- [x] Targeted Playwright check of calculator "Dettagli" breakdown tab: 0 chart warnings
- [x] `npx vitest run` on stats-related test files: 16/16 passed
- [x] `tsc --noEmit`: no errors in touched files
- [x] GitNexus impact analysis: LOW risk, no callers affected