### PR TITLE
fix(ads): migrate GPT collapseEmptyDivs to setConfig collapseDiv

### DIFF
--- a/components/shared/GptAdSlot.tsx
+++ b/components/shared/GptAdSlot.tsx
@@ -77,9 +77,8 @@ function initGptFramework(): void {
     try {
       if (!gptServicesEnabled) {
         gptServicesEnabled = true;
-        // Modern GPT config API (pubads().enableSingleRequest() is deprecated).
-        gt.setConfig({ singleRequest: true });
-        gt.pubads().collapseEmptyDivs(true);
+        // Modern GPT config API (pubads().enableSingleRequest()/collapseEmptyDivs() are deprecated).
+        gt.setConfig({ singleRequest: true, collapseDiv: 'BEFORE_FETCH' });
         gt.enableServices();
       }
     } catch {


### PR DESCRIPTION
## Implementato

`components/shared/GptAdSlot.tsx`: `gt.pubads().collapseEmptyDivs(true)` was logging a GPT deprecation warning in every ad-bearing page's console (`[GPT] PubAdsService.collapseEmptyDivs is deprecated, use googletag.setConfig({collapseDiv: ...}) instead.`, https://goo.gle/gpt-message#170 — found live by the user). Replaced with the documented Config API equivalent, folded into the existing `setConfig` call: `gt.setConfig({ singleRequest: true, collapseDiv: 'BEFORE_FETCH' })`. `'BEFORE_FETCH'` is Google's documented 1:1 behavioral equivalent of the legacy `collapseEmptyDivs(true)` call — same collapsing behavior, no ad slots disabled, no config change beyond the deprecated-API migration.

Verified: single call-site in the codebase (grepped, no siblings). GitNexus impact on `initGptFramework` = LOW risk, 1 direct caller (`defineAndDisplay`), 0 processes affected. `tsc --noEmit` clean. `npx vitest run tests/article-ad-slots.test.ts tests/check-cls-ad-slots.test.ts tests/regression/seo-static-ad-slots.test.ts` — 31/31 passed.

## Non implementato (ancora)

Nessuno per lo scope di questa PR (fix GPT deprecation).

Due findings separati, distinti per dominio, NON in questa PR:
- Un 404 reale e riproducibile su `cdn.frontaliereticino.ch/fonts/{inter,space-grotesk}-latin.woff2` (segnalato dall'utente, confermato via curl diretto). Indagine estesa nel codice attuale (vite.config.ts renderBuiltUrl esclude già `/fonts/` dal CDN rebase per l'incidente #1293; offload-generated-images-cdn.mjs scopa solo `/assets/`, non `/fonts/`; l'HTML live della homepage oggi emette correttamente riferimenti same-origin) non ha trovato un path di codice attuale che generi quell'URL — nessuna root cause identificata, nessun fix possibile senza sapere quale pagina/tab l'ha generato. Tracciato in issue di follow-up separata, non bloccante per questa PR (dominio diverso, nessun fix code-level disponibile allo stato attuale delle informazioni).
- `dsp.360yield.com/dsp_match/... 400` — richiesta cookie-sync di un partner ad-tech RTB di terze parti, nessun riferimento nel nostro codebase, comportamento server-side del partner. Non fixabile/non da toccare (out of scope, third-party).

## Test plan

- [x] `tsc --noEmit`: clean
- [x] `npx vitest run` sui test ad-slot correlati: 31/31 passed
- [x] GitNexus impact: LOW risk