### PR TITLE
fix(newsletter): stop truncating AI subject line mid-sentence

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -536,13 +536,13 @@ async function generateAISubject(ctx) {
     // and trips the inlineQaCheck `length < 10` gate, aborting the entire send.
     // Require at least 10 chars AND a 3+ letter run to ensure real text.
     if (raw.length < 10 || !/[\p{L}]{3,}/u.test(raw)) return null;
-    // Ensure subject is a complete sentence — never truncate with ellipsis
-    if (raw.length > 55) {
-      // Too long — ask AI failed to respect limit, use as-is up to 55
-      // Find last natural break point (space, comma, colon) before 55
-      const cutoff = raw.lastIndexOf(' ', 55);
-      return cutoff > 30 ? raw.slice(0, cutoff) : raw.slice(0, 55);
-    }
+    // Ensure subject is a complete sentence — never truncate. A word-boundary
+    // cut still risks lopping off the sentence's final word (e.g. "...il ruolo
+    // più" with "cliccato" chopped off) since it only checks for *a* space,
+    // not whether the cut lands after a complete clause. Safer to discard an
+    // over-limit AI subject and let the caller fall back to FALLBACK_SUBJECT
+    // than to ship a grammatically broken one.
+    if (raw.length > 55) return null;
     return raw;
   } catch (e) {
     console.warn('\u26a0\ufe0f AI subject failed:', e.message?.slice(0, 200));


### PR DESCRIPTION
## Implementato

- `scripts/send-newsletter.mjs:generateAISubject` non tronca più a 55 char con `lastIndexOf(' ', 55)`: quel taglio poteva cadere dopo una parola-funzione (es. "più") lasciando la frase monca senza marcatore di troncamento (nessun `…`), passando indisturbata il QA gate (`inlineQaCheck` controlla solo ellipsis-truncation).
- Root cause reale (non ipotetico): newsletter `weekly_2026-06-29` inviata con subject "🩺 Nuove opportunità a Lugano: scopri il ruolo più" invece di "...più cliccato" — verificato decodificando l'header RFC2047 dell'email ricevuta.
- Fix: subject AI oltre 55 char viene scartato (`return null`) e il chiamante (riga 2089, `subject || getVariantFallback(variant, loc)`) usa già il fallback curato — nessun altro punto da toccare.
- Sibling-pattern check (`lastIndexOf(' ', ...)` truncation) grep'd contro `build-plugins/**`, `services/newsletter-template.mjs`, `services/publisherBlastEmail.mjs`, `scripts/send-job-alerts.mjs`, `scripts/lib/social-post-utils.mjs`: tutti appendono `…` esplicito dopo il taglio (troncamento dichiarato, contratto diverso) — **falso positivo**, non stessa classe di bug del subject-line "complete sentence, no ellipsis".
- Test: `newsletter-email-quality.test.ts` (31), `newsletter-qa-gate.test.ts` (11), `newsletter-locale-urls.test.ts`, `newsletter-dynamic-metrics.test.ts`, `parse-email-field.test.ts`, `job-alert-email.test.ts` — tutti verdi (151 test).
- GitNexus impact: LOW risk, unico caller `main` (riga 2082), già gestisce `null` via fallback esistente.

## Non implementato (ancora)

Nessuno. (Il cert error TLS separato su `email.frontaliereticino.ch` — causa del "certificate error" segnalato insieme al subject troncato — è un problema di config Mailgun/DNS esterno al codice, non un task PR: CNAME riverificato via API Mailgun, provisioning cert Let's Encrypt automatico in corso lato Mailgun, nessun codice repo coinvolto.)