### PR TITLE
feat(ci): weekly Claude-driven crawler data quality audit

### DIFF
--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -1,0 +1,156 @@
+name: Crawler Data Quality Audit (weekly, Claude)
+
+# Weekly LLM-driven audit mirroring the manual review that produced PR #3245
+# (15-day git-history audit of `data/jobs/by-crawler/*.json` — slug stability,
+# translation system, crawling/merge system, slug regeneration, needsTranslation
+# staleness, housekeeping). That manual pass found 7-8 real defects (incl. the
+# `previousSlugs` cross-job contamination bug and a flat-array redirect bug) that
+# no existing automated check caught: `crawler-health-monitor.yml` only checks
+# UP/DOWN freshness (empty/stale runs), not semantic correctness of the JSON
+# content itself. This workflow fills that gap.
+#
+# Deliberately Claude, not a deterministic script: the defects found were subtle
+# (cross-job slug contamination, silent-drop-instead-of-redirect) and needed code
+# reading + git-history reasoning, not a fixed regex/threshold check.
+#
+# Deliberately NOT auto-routed to agent:fix (ISSUES.md category `other` — no
+# label/title pattern here matches issue-triage's `crawler`/`parser-broken`/
+# `priority:high`+crawler regex, see scripts/lib/classify-issue.mjs): an LLM
+# audit's findings are judgment calls like `validation-failure` ("transiente-vs-
+# persistente non decidibile deterministicamente" — ISSUES.md), so a human
+# triages before any fix lands, same caution already applied there. Read-only
+# except `gh issue create/list/comment` — no self-fix.
+#
+# Zero-issue runs are silent (mirrors evergreen-refresh-audit.yml /
+# dmarc-monitor.yml): the agent creates an issue ONLY when it has real evidence.
+
+on:
+  schedule:
+    - cron: '20 8 * * 1' # weekly, Monday 08:20 UTC (clear of dmarc-monitor 07:10, crawler-health-monitor 06:30)
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: 'Git-history lookback window in days (default 15, matches the manual audit that found PR #3245).'
+        required: false
+        default: '15'
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+concurrency:
+  group: crawler-data-quality-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      # Plain fetch-depth:0 would pull the full ~11GB .git history (see
+      # pr-review-loop.yml's checkout comment for the cost). shallow-since with a
+      # margin past the lookback window gets exactly the commits the audit needs
+      # without that cost; falls back to a full unshallow if shallow-since ever
+      # fails (network hiccup, git version quirk) rather than running the audit
+      # with an incomplete window silently.
+      - name: Deepen history for lookback window
+        env:
+          WINDOW_DAYS: ${{ inputs.window_days || '15' }}
+        run: |
+          set -euo pipefail
+          SINCE=$(date -u -d "$((WINDOW_DAYS + 5)) days ago" +%Y-%m-%d)
+          git fetch --shallow-since="$SINCE" origin main || git fetch --unshallow origin main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # Ensure the label exists BEFORE the Claude step — `gh issue create --label`
+      # on a non-existent label fails the call, which would otherwise burn a Claude
+      # turn on a retry loop for something a 1-line deterministic step prevents.
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "crawler-data-quality" --color "5319E7" \
+            --description "Weekly Claude audit: semantic data-quality finding in data/jobs/by-crawler" \
+            --force 2>/dev/null || true
+
+      - name: Setup Headroom compression proxy
+        uses: ./.github/actions/setup-headroom
+
+      - name: Run Claude data quality audit
+        id: audit
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WINDOW_DAYS: ${{ inputs.window_days || '15' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Schedule → triggering_actor is frontaliere-automation[bot] (same
+          # correction as post-merge-followup.yml, PR #3157). Whitelist mirrors
+          # every other scheduled Claude workflow. Never `*`.
+          allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
+          allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
+          show_full_output: true
+          claude_args: "--max-turns 40 --model claude-sonnet-5 --dangerously-skip-permissions"
+          prompt: |
+            Audit qualità dati crawler, settimanale. Finestra lookback: ${{ env.WINDOW_DAYS }} giorni.
+
+            **Contesto:** questo audit replica manualmente eseguito che ha prodotto la PR #3245 (7-8 difetti reali: contaminazione cross-job di `previousSlugs`, un bug che droppava invece di redirectare gli slug in un array flat, staleness di `needsTranslation`, regressioni di slug regeneration). Nessun check automatico esistente copre la correttezza SEMANTICA del contenuto JSON — `crawler-health-monitor.yml` verifica solo se un crawler produce output fresco/non-vuoto, non se il contenuto è corretto. Il tuo scopo è lo stesso identico audit, ripetuto.
+
+            **Bootstrap:**
+            1. Leggi `docs/CRAWLERS.md` (architettura crawler/translation/slug) e `AGENTS.md → ## Static SEO Pages` (contratto previousSlugs/bridge pages) SOLO per il contesto necessario — non serve tutto AGENTS.md.
+            2. `git log --since="${{ env.WINDOW_DAYS }} days ago" --oneline -- data/jobs/by-crawler/` per la finestra di commit da esaminare. Se il volume è enorme (centinaia di commit — normale coi crawler dedicati automatici), NON leggere ogni diff: campiona i commit più grandi (`git log --since="${{ env.WINDOW_DAYS }} days ago" --stat -- data/jobs/by-crawler/ | ...`) e usa gli script deterministici sotto come segnale primario invece di leggere diff a mano uno per uno.
+
+            **Verifiche (stesse 5 categorie dell'audit manuale):**
+
+            1. **Slug stability / previousSlugs correctness**: esegui `node scripts/decontaminate-prev-slugs.mjs` (SENZA `--apply`, dry-run) contro `data/jobs/by-crawler/*.json` corrente. Se riporta contaminazioni (`moved > 0`) → REGRESSIONE del bug fixato in #3245: è evidenza concreta, la decontaminazione post-merge dovrebbe aver riportato tutto a 0. Ispeziona anche a campione se `previousSlugs` flat e `previousSlugsByLocale` per-locale restano coerenti tra loro (stesso schema del bug flat-array fixato dopo #3245).
+            2. **Translation system**: campiona job con `needsTranslation: true` — quanti sono più vecchi di 72h (`crawledAt`/`updatedAt`) senza traduzione risolta? Un accumulo crescente indica una pipeline di traduzione bloccata (non copiato da nessun health-check esistente).
+            3. **Crawling / merge system**: verifica a campione la correttezza del merge by-stable-id (`extractStableJobId(job.url)`) — job duplicati con lo stesso id-stabile ma slug diversi non collassati, o entries orfane dopo un merge.
+            4. **Slug regeneration correctness**: campiona slug troncati — verifica che `truncateSlugAtWordBoundary` non abbia prodotto tronconi a metà parola o slug regenerati senza motivo (title wording minore che NON dovrebbe produrre nuovo slug, vedi `docs/CRAWLERS.md` riga 32).
+            5. **Housekeeping**: `previousSlugs`/`previousSlugsByLocale` che puntano a target inesistenti nel dataset corrente, oggetti locale vuoti, `crawledAt` molto vecchio su un job ancora marcato attivo.
+
+            **Filtro evidenza (CRITICO — no rumore):** apri un finding SOLO con evidenza concreta e citabile (comando eseguito + output, o file:riga specifici) — mai un sospetto vago. Se una categoria non produce nulla di anomalo, salta silenziosamente: NON forzare un finding per "coprire" ogni categoria.
+
+            **Dedup (prima di creare qualsiasi issue):** `gh issue list --state open --label crawler-data-quality --json number,title,body --limit 50`. Se un'issue aperta copre già lo stesso pattern (stesso script/categoria, non necessariamente stesso job) → posta un commento `🔁 Ricorrenza rilevata nel run <link run>` su quella issue con la nuova evidenza invece di aprirne una nuova.
+
+            **Se trovi evidenza NUOVA (nessun match dedup):**
+            - `gh issue create --title "[data-quality] <categoria>: <sintesi breve>" --label crawler-data-quality --body "<evidenza + comando/output + file interessati + prossimo passo suggerito + link a questo run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>"`.
+            - **NON** usare i label `crawler`, `parser-broken`, o `priority:high` insieme a un titolo che contiene "crawler"/"parser" — instraderebbero l'issue nell'auto-fix pipeline (`issue-triage.yml` → `agent:fix` immediato), che qui è deliberatamente escluso: è un giudizio LLM, va triagiato da un umano prima di un fix automatico (stessa cautela di `validation-failure` in ISSUES.md).
+            - Massimo 5 issue per run (se trovi più pattern, aggrega i correlati in una singola issue invece di aprirne 5+).
+
+            **Se non trovi nulla:** non fare nulla, log pulito, nessuna issue. Non e' un errore.
+
+            **Constraint:**
+            - Read-only sul codice/dati: NIENTE `git commit`/`push`/edit di file. L'unica scrittura ammessa è `gh issue create`/`gh issue comment` (e la lettura via `gh issue list`).
+            - Non tentare fix — questo audit trova, non ripara.
+            - Incerto se qualcosa è un vero difetto → non aprire issue; se borderline ma degno di attenzione umana, apri comunque MA marca chiaramente "da verificare" nel body.
+
+      - name: Claude usage metrics
+        if: always()
+        run: node scripts/ci/claude-usage-summary.mjs "${{ steps.audit.outputs.execution_file }}" "crawler-data-quality-audit"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -64,6 +64,10 @@ jobs:
           WINDOW_DAYS: ${{ inputs.window_days || '15' }}
         run: |
           set -euo pipefail
+          if ! [[ "$WINDOW_DAYS" =~ ^[0-9]+$ ]]; then
+            echo "window_days must be a positive integer, got: $WINDOW_DAYS" >&2
+            exit 1
+          fi
           SINCE=$(date -u -d "$((WINDOW_DAYS + 5)) days ago" +%Y-%m-%d)
           git fetch --shallow-since="$SINCE" origin main || git fetch --unshallow origin main
 
@@ -95,6 +99,11 @@ jobs:
           WINDOW_DAYS: ${{ inputs.window_days || '15' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # github_token required alongside claude_code_oauth_token: without it
+          # allowed_non_write_users is a silent no-op (post-merge-followup.yml,
+          # PR #3182 — every scheduled run failed "User does not have write
+          # access", zero turns, zero cost, until this line was added there).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Schedule → triggering_actor is frontaliere-automation[bot] (same
           # correction as post-merge-followup.yml, PR #3157). Whitelist mirrors
           # every other scheduled Claude workflow. Never `*`.


### PR DESCRIPTION
## Implementato
- Nuovo workflow `.github/workflows/crawler-data-quality-audit.yml`: cron settimanale (lunedì 08:20 UTC, orario libero da `dmarc-monitor` 07:10 e `crawler-health-monitor` 06:30) + `workflow_dispatch` con input `window_days` (default 15, stessa finestra dell'audit manuale che ha prodotto la PR #3245).
- Un agente Claude (`claude-sonnet-5`, max-turns 40, read-only tranne `gh issue create/list/comment`) ripete le stesse 5 verifiche fatte manualmente in questa sessione contro `data/jobs/by-crawler/*.json`: slug stability/`previousSlugs` (via `node scripts/decontaminate-prev-slugs.mjs` dry-run — se `moved > 0` è una regressione del bug fixato in #3245), staleness `needsTranslation`, correttezza merge-by-stable-id, correttezza slug regeneration, housekeeping (target orfani, locale vuoti).
- Deepen-history mirato (`git fetch --shallow-since=...` con margine sulla finestra, fallback `--unshallow`) invece di `fetch-depth: 0` pieno — evita il costo di scaricare l'intera history ~11GB su un repo a heavy churn (stesso razionale documentato in `pr-review-loop.yml`).
- Se trova evidenza concreta e NON già coperta da un'issue aperta (dedup via `gh issue list --label crawler-data-quality`) → `gh issue create` con label `crawler-data-quality` (creato deterministicamente pre-Claude via `gh label create --force`). Deliberatamente **NON** instradato ad auto-fix: nessun titolo/label match la regex `crawler`/`parser-broken`/`priority:high`+crawler di `scripts/lib/classify-issue.mjs` (verificato con un run diretto dello script → `category:"other", route:"none"`), quindi l'issue finisce nel backlog per triage umano, stessa cautela già applicata a `validation-failure` in ISSUES.md ("transiente-vs-persistente non decidibile deterministicamente" — qui vale lo stesso per un giudizio LLM).
- Se non trova nulla → run silenziosa, nessuna issue (stesso pattern di `evergreen-refresh-audit.yml`/`dmarc-monitor.yml`).
- `Report failure to GitHub Issues` step standard via `scripts/lib/github-issue-creator.mjs` su `failure()`.

## Non implementato (ancora)
- Nessuno. Verifica: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/crawler-data-quality-audit.yml'))"` → YAML valido. `node scripts/lib/classify-issue.mjs` confermato route=`none`/category=`other` per titolo+label scelti. `gitnexus_detect_changes(scope:"staged")` → nessun symbol/processo toccato (solo nuovo file YAML). Zero file JS/TS/vitest toccati → nessun impatto sulla test suite. Verifica live (post-merge, obbligatoria per nuovo workflow per AGENTS.md): `gh workflow run crawler-data-quality-audit.yml --ref main` per il primo trigger reale, poi osservare se produce un'issue plausibile o run pulita.