### PR TITLE
fix(crawler): boilerplate guard sample-size floor (issue #3254)

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -681,21 +681,32 @@ export function isSystemicBoilerplateFailure(report) {
  * Mirrors the sibling thin-source quarantine in dedicated-crawler-common.mjs
  * (validateDedicatedLocaleCoverage's `quarantineSlugs`/non-systemic path,
  * L4248-4265): below the systemic floor the guard must not hard-fail the
- * run (see isSystemicBoilerplateFailure), but the confirmed-boilerplate jobs
- * still must never reach the committed dataset. GDPR/privacy-notice
- * boilerplate (BOILERPLATE_MARKER_PHRASES, e.g. "Pursuant to Article 13")
- * easily runs past 50 words, long enough to sail past the build's <50-word
- * sitemap/noindex filter — the only other safety net — so warn-and-keep
- * would let it publish and get indexed indefinitely on a permanently
- * low-volume crawler.
+ * run (see isSystemicBoilerplateFailure), but confirmed marker-phrase
+ * boilerplate must still never reach the committed dataset. GDPR/privacy-
+ * notice boilerplate (BOILERPLATE_MARKER_PHRASES, e.g. "Pursuant to
+ * Article 13") easily runs past 50 words, long enough to sail past the
+ * build's <50-word sitemap/noindex filter — the only other safety net — so
+ * warn-and-keep would let it publish and get indexed indefinitely on a
+ * permanently low-volume crawler.
+ *
+ * ONLY quarantines reason === 'marker_phrases' (Condition A). Condition B
+ * (`low_unique_words`, <30 words) is deliberately EXCLUDED: it's the exact
+ * pattern this guard's own sample-size floor exists to protect (issue
+ * #3254, Diakoniewerk "Berufsbildnerin" — a legitimate naturally-short
+ * description from a JS-only ATS detail page that lands on either side of
+ * the 30-word threshold run to run). Condition B jobs are by construction
+ * <30 words, already below the build's <50-word noindex/sitemap-exclude
+ * filter, so quarantining them adds zero SEO protection while silently and
+ * permanently dropping real short listings with no GitHub issue filed.
  *
  * @param {object[]} jobs
- * @param {Array<{slug:string}>} boilerplateJobs - bpReport.boilerplateJobs
- * @returns {object[]} jobs with the boilerplate-only entries dropped
+ * @param {Array<{slug:string, reason:string}>} boilerplateJobs - bpReport.boilerplateJobs
+ * @returns {object[]} jobs with the marker-phrase boilerplate entries dropped
  */
 export function quarantineBoilerplateJobs(jobs, boilerplateJobs) {
-  if (!Array.isArray(boilerplateJobs) || boilerplateJobs.length === 0) return jobs;
-  const quarantineSlugs = new Set(boilerplateJobs.map(bj => bj.slug));
+  const markerPhraseJobs = (boilerplateJobs || []).filter(bj => bj.reason === 'marker_phrases');
+  if (markerPhraseJobs.length === 0) return jobs;
+  const quarantineSlugs = new Set(markerPhraseJobs.map(bj => bj.slug));
   return jobs.filter(j => !quarantineSlugs.has(j?.slug || j?.title || 'unknown'));
 }
 
@@ -893,15 +904,17 @@ export function writeJobsCrawlerSlice(crawlerKey, jobs) {
           `A genuine parser regression shows up across many jobs, not one or two naturally-short ones.`
         );
       }
-      // Non-systemic: quarantine the confirmed-boilerplate jobs from the slice
-      // rather than only warning (mirrors dedicated-crawler-common.mjs's
+      // Non-systemic: quarantine the marker-phrase boilerplate jobs from the
+      // slice rather than only warning (mirrors dedicated-crawler-common.mjs's
       // quarantineSlugs on its non-systemic path — see quarantineBoilerplateJobs
-      // above). The good jobs still commit unchanged.
+      // above, which deliberately excludes low_unique_words). The good jobs
+      // (including legitimate naturally-short low_unique_words ones) still
+      // commit unchanged.
       const beforeQuarantine = jobs.length;
       jobs = quarantineBoilerplateJobs(jobs, bpReport.boilerplateJobs);
       if (jobs.length < beforeQuarantine) {
         console.warn(
-          `🧹 [boilerplate-guard] ${crawlerKey} quarantined ${beforeQuarantine - jobs.length} confirmed-boilerplate job(s) from the slice (${beforeQuarantine} → ${jobs.length}) — never persisted/indexed.`
+          `🧹 [boilerplate-guard] ${crawlerKey} quarantined ${beforeQuarantine - jobs.length} marker-phrase boilerplate job(s) from the slice (${beforeQuarantine} → ${jobs.length}) — never persisted/indexed.`
         );
       }
     }

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -676,6 +676,30 @@ export function isSystemicBoilerplateFailure(report) {
 }
 
 /**
+ * Remove confirmed-boilerplate jobs from the array about to be persisted.
+ *
+ * Mirrors the sibling thin-source quarantine in dedicated-crawler-common.mjs
+ * (validateDedicatedLocaleCoverage's `quarantineSlugs`/non-systemic path,
+ * L4248-4265): below the systemic floor the guard must not hard-fail the
+ * run (see isSystemicBoilerplateFailure), but the confirmed-boilerplate jobs
+ * still must never reach the committed dataset. GDPR/privacy-notice
+ * boilerplate (BOILERPLATE_MARKER_PHRASES, e.g. "Pursuant to Article 13")
+ * easily runs past 50 words, long enough to sail past the build's <50-word
+ * sitemap/noindex filter — the only other safety net — so warn-and-keep
+ * would let it publish and get indexed indefinitely on a permanently
+ * low-volume crawler.
+ *
+ * @param {object[]} jobs
+ * @param {Array<{slug:string}>} boilerplateJobs - bpReport.boilerplateJobs
+ * @returns {object[]} jobs with the boilerplate-only entries dropped
+ */
+export function quarantineBoilerplateJobs(jobs, boilerplateJobs) {
+  if (!Array.isArray(boilerplateJobs) || boilerplateJobs.length === 0) return jobs;
+  const quarantineSlugs = new Set(boilerplateJobs.map(bj => bj.slug));
+  return jobs.filter(j => !quarantineSlugs.has(j?.slug || j?.title || 'unknown'));
+}
+
+/**
  * Create or update a GitHub Issue for a boilerplate guard failure.
  * Best-effort: failures are logged but do not suppress the guard error.
  */
@@ -867,6 +891,17 @@ export function writeJobsCrawlerSlice(crawlerKey, jobs) {
           `⚠️  [boilerplate-guard] ${crawlerKey}: ${bpReport.boilerplateCount}/${bpReport.totalJobs} jobs (${(bpReport.ratio * 100).toFixed(0)}%) meet the boilerplate ratio, ` +
           `but the eligible sample is below the reliability floor (needs >=${BOILERPLATE_MIN_ELIGIBLE} eligible jobs and >=${BOILERPLATE_MIN_COUNT} boilerplate jobs to be a systemic signal) — not failing the run. ` +
           `A genuine parser regression shows up across many jobs, not one or two naturally-short ones.`
+        );
+      }
+      // Non-systemic: quarantine the confirmed-boilerplate jobs from the slice
+      // rather than only warning (mirrors dedicated-crawler-common.mjs's
+      // quarantineSlugs on its non-systemic path — see quarantineBoilerplateJobs
+      // above). The good jobs still commit unchanged.
+      const beforeQuarantine = jobs.length;
+      jobs = quarantineBoilerplateJobs(jobs, bpReport.boilerplateJobs);
+      if (jobs.length < beforeQuarantine) {
+        console.warn(
+          `🧹 [boilerplate-guard] ${crawlerKey} quarantined ${beforeQuarantine - jobs.length} confirmed-boilerplate job(s) from the slice (${beforeQuarantine} → ${jobs.length}) — never persisted/indexed.`
         );
       }
     }

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -535,6 +535,22 @@ const CONTENT_HEADINGS_RE = /\b(COMPITI|PROFILO|Responsabilit[aà]|Requisiti|Qua
 const BOILERPLATE_THRESHOLD = 0.5; // 50%
 const MIN_UNIQUE_WORDS = 30;
 
+// Sample-size floor (Diakoniewerk-Neumünster incident, 2026-07-02, issue #3254):
+// a low-volume dedicated crawler can have as few as 1-2 jobs ELIGIBLE for the
+// boilerplate check on a given run (fresh discoveries are excluded via
+// `needsRetranslation` — see detectBoilerplateDescriptions below). At n=2 a
+// single genuinely-short-but-legitimate description (e.g. a synthesized
+// fallback for a JS-only ATS, or a naturally terse listing) trips the 50%
+// ratio the same way 25/50 boilerplate jobs would on a large crawler — the
+// ratio alone can't tell "one short job" from "systemic parser break" below
+// a minimum sample. Mirrors the identical floor already applied to the
+// sibling thin-source guard in validateDedicatedLocaleCoverage
+// (dedicated-crawler-common.mjs SYSTEMIC_MIN_TOTAL/absolute-count floor): a
+// genuine parser regression manifests across MANY jobs, not one or two, so
+// below this floor the signal is too weak to justify bricking the whole run.
+const BOILERPLATE_MIN_ELIGIBLE = Number(process.env.JOBS_BOILERPLATE_MIN_ELIGIBLE) || 4;
+const BOILERPLATE_MIN_COUNT = Number(process.env.JOBS_BOILERPLATE_MIN_COUNT) || 2;
+
 // Anti-shrink guard thresholds (axa-svizzera incident, 2026-07-01): only
 // guard crawlers with a meaningful baseline, and only trigger on a drop deep
 // enough to be clearly abnormal — observed normal 15-day churn never dropped
@@ -635,6 +651,28 @@ export function detectBoilerplateDescriptions(jobs, crawlerKey) {
     boilerplateCount: boilerplateJobs.length,
     ratio,
   };
+}
+
+/**
+ * Whether a detectBoilerplateDescriptions() report represents a SYSTEMIC
+ * boilerplate failure — i.e. a signal reliable enough to hard-fail the
+ * crawler run — as opposed to one or two naturally-short descriptions on a
+ * low-volume crawler crossing the ratio threshold by chance.
+ *
+ * Requires BOTH the ratio to meet BOILERPLATE_THRESHOLD AND an absolute
+ * sample-size floor (>= BOILERPLATE_MIN_ELIGIBLE eligible jobs and
+ * >= BOILERPLATE_MIN_COUNT boilerplate jobs). See the floor constants above
+ * for rationale (issue #3254).
+ *
+ * @param {{ratio:number, boilerplateCount:number, totalJobs:number}} report
+ * @returns {boolean}
+ */
+export function isSystemicBoilerplateFailure(report) {
+  return (
+    report.ratio >= BOILERPLATE_THRESHOLD &&
+    report.boilerplateCount >= BOILERPLATE_MIN_COUNT &&
+    report.totalJobs >= BOILERPLATE_MIN_ELIGIBLE
+  );
 }
 
 /**
@@ -818,12 +856,22 @@ export function writeJobsCrawlerSlice(crawlerKey, jobs) {
   // Boilerplate guard: detect parsers that silently fell back to generic descriptions.
   if (!process.env.SKIP_BOILERPLATE_GUARD) {
     const bpReport = detectBoilerplateDescriptions(jobs, crawlerKey);
-    if (bpReport.boilerplateCount > 0 && bpReport.ratio < BOILERPLATE_THRESHOLD) {
+    const systemic = isSystemicBoilerplateFailure(bpReport);
+
+    if (bpReport.boilerplateCount > 0 && !systemic) {
       for (const bj of bpReport.boilerplateJobs) {
         console.log(`[boilerplate-guard] ${bj.slug}: ${bj.reason} (${bj.uniqueWords} unique words)`);
       }
+      if (bpReport.ratio >= BOILERPLATE_THRESHOLD) {
+        console.warn(
+          `⚠️  [boilerplate-guard] ${crawlerKey}: ${bpReport.boilerplateCount}/${bpReport.totalJobs} jobs (${(bpReport.ratio * 100).toFixed(0)}%) meet the boilerplate ratio, ` +
+          `but the eligible sample is below the reliability floor (needs >=${BOILERPLATE_MIN_ELIGIBLE} eligible jobs and >=${BOILERPLATE_MIN_COUNT} boilerplate jobs to be a systemic signal) — not failing the run. ` +
+          `A genuine parser regression shows up across many jobs, not one or two naturally-short ones.`
+        );
+      }
     }
-    if (bpReport.ratio >= BOILERPLATE_THRESHOLD) {
+
+    if (systemic) {
       console.error(`\n🚨 Boilerplate guard FAILED for ${crawlerKey}`);
       console.error(`   ${bpReport.boilerplateCount}/${bpReport.totalJobs} jobs (${(bpReport.ratio * 100).toFixed(0)}%) have boilerplate-only descriptions\n`);
       console.error('   Affected jobs:');

--- a/tests/boilerplate-guard.test.ts
+++ b/tests/boilerplate-guard.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { detectBoilerplateDescriptions, isSystemicBoilerplateFailure } from '@/scripts/assemble-jobs-dataset.mjs';
+import {
+  detectBoilerplateDescriptions,
+  isSystemicBoilerplateFailure,
+  quarantineBoilerplateJobs,
+} from '@/scripts/assemble-jobs-dataset.mjs';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -344,6 +348,69 @@ describe('isSystemicBoilerplateFailure — sample-size floor', () => {
     expect(report.boilerplateCount).toBe(1);
     expect(report.ratio).toBe(0.5);
     expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+});
+
+// ─── Below-Floor Quarantine Tests (quarantineBoilerplateJobs) ──────────────────
+// Regression coverage for the PR #3267 review finding: below the systemic
+// floor, isSystemicBoilerplateFailure() correctly refuses to hard-fail the
+// run (see the #3254 tests above), but the confirmed-boilerplate jobs must
+// still never reach the persisted slice — only warning-and-keeping them let
+// GDPR/privacy-notice boilerplate (long enough to beat the build's <50-word
+// noindex net) publish and get indexed indefinitely on a low-volume crawler.
+
+describe('quarantineBoilerplateJobs — below-floor quarantine', () => {
+  it('drops confirmed-boilerplate jobs while keeping good jobs, mirroring the #3254 shape', () => {
+    const jobs = [
+      makeJob('eligible-good', RICH_DESCRIPTION),
+      makeJob('eligible-thin', wordsDesc(29)),
+      ...Array.from({ length: 4 }, (_, i) =>
+        makeJob(`fresh-${i}`, wordsDesc(5), { needsRetranslation: true }),
+      ),
+    ];
+    const report = detectBoilerplateDescriptions(jobs, 'diakoniewerk-neumuenster');
+    expect(isSystemicBoilerplateFailure(report)).toBe(false); // below-floor: must not hard-fail
+    expect(report.boilerplateCount).toBe(1);
+
+    const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
+    expect(kept).toHaveLength(jobs.length - 1);
+    expect(kept.some(j => j.slug === 'eligible-thin')).toBe(false); // boilerplate job dropped
+    expect(kept.some(j => j.slug === 'eligible-good')).toBe(true); // good job kept
+    expect(kept.filter(j => j.needsRetranslation)).toHaveLength(4); // fresh jobs untouched
+  });
+
+  it('returns the same array unchanged when there is nothing to quarantine', () => {
+    const jobs = [makeJob('good-1', RICH_DESCRIPTION), makeJob('good-2', RICH_DESCRIPTION)];
+    const kept = quarantineBoilerplateJobs(jobs, []);
+    expect(kept).toBe(jobs);
+    expect(kept).toHaveLength(2);
+  });
+
+  it('drops multiple confirmed-boilerplate jobs, keeping only the good ones', () => {
+    const jobs = [
+      makeJob('bp-1', BOILERPLATE_2_MARKERS),
+      makeJob('bp-2', wordsDesc(10)),
+      makeJob('good-1', RICH_DESCRIPTION),
+    ];
+    const report = detectBoilerplateDescriptions(jobs, 'test-co');
+    expect(report.boilerplateCount).toBe(2);
+
+    const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
+    expect(kept).toEqual([jobs[2]]);
+  });
+
+  it('falls back to title, then "unknown", when matching jobs without a slug', () => {
+    const jobs = [
+      { title: 'No Slug Job', descriptionByLocale: { it: wordsDesc(5) } },
+      makeJob('good-job', RICH_DESCRIPTION),
+    ];
+    const report = detectBoilerplateDescriptions(jobs, 'test-co');
+    expect(report.boilerplateCount).toBe(1);
+    expect(report.boilerplateJobs[0].slug).toBe('No Slug Job'); // slug fallback to title
+
+    const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].title).toBe('good-job');
   });
 });
 

--- a/tests/boilerplate-guard.test.ts
+++ b/tests/boilerplate-guard.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { detectBoilerplateDescriptions } from '@/scripts/assemble-jobs-dataset.mjs';
+import { detectBoilerplateDescriptions, isSystemicBoilerplateFailure } from '@/scripts/assemble-jobs-dataset.mjs';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -282,6 +282,68 @@ describe('detectBoilerplateDescriptions — guard gate thresholds', () => {
     expect(report.totalJobs).toBe(10);
     expect(report.ratio).toBe(0.5);
     expect(report.ratio).toBeGreaterThanOrEqual(0.5);
+  });
+});
+
+// ─── Sample-Size Floor Tests (isSystemicBoilerplateFailure) ────────────────────
+// Regression coverage for issue #3254 (Diakoniewerk Neumünster, 2026-07-02):
+// a low-volume dedicated crawler had only 2 jobs eligible for the boilerplate
+// check; 1 of them was a naturally-short-but-legitimate description, which hit
+// the 50% ratio and hard-failed the whole run (discarding 6 well-localized
+// jobs). isSystemicBoilerplateFailure() adds an absolute sample-size floor on
+// top of the ratio so a tiny sample can no longer brick the run by itself.
+
+describe('isSystemicBoilerplateFailure — sample-size floor', () => {
+  it('reproduces the #3254 Diakoniewerk incident: 1/2 (50%) is NOT systemic', () => {
+    const report = { ratio: 0.5, boilerplateCount: 1, totalJobs: 2 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+
+  it('1/1 (100%) on a single-job crawler is NOT systemic (below both floors)', () => {
+    const report = { ratio: 1, boilerplateCount: 1, totalJobs: 1 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+
+  it('2/3 (67%) is NOT systemic (totalJobs below the eligible-jobs floor)', () => {
+    const report = { ratio: 2 / 3, boilerplateCount: 2, totalJobs: 3 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+
+  it('2/4 (50%) meets both floors: IS systemic', () => {
+    const report = { ratio: 0.5, boilerplateCount: 2, totalJobs: 4 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(true);
+  });
+
+  it('5/10 (50%) on a large crawler: IS systemic (unchanged from pre-floor behavior)', () => {
+    const report = { ratio: 0.5, boilerplateCount: 5, totalJobs: 10 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(true);
+  });
+
+  it('4/10 (40%) below the ratio threshold: NOT systemic regardless of sample size', () => {
+    const report = { ratio: 0.4, boilerplateCount: 4, totalJobs: 10 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+
+  it('a single boilerplate job on a large crawler (1/20 = 5%) stays below ratio: NOT systemic', () => {
+    const report = { ratio: 0.05, boilerplateCount: 1, totalJobs: 20 };
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
+  });
+
+  it('integration: detectBoilerplateDescriptions output for the #3254 shape is NOT systemic', () => {
+    const jobs = [
+      makeJob('eligible-good', RICH_DESCRIPTION),
+      makeJob('eligible-thin', wordsDesc(29)),
+      // 4 freshly-discovered jobs excluded from the eligible sample, mirroring
+      // the real run (needsRetranslation=true until AI localization clears it).
+      ...Array.from({ length: 4 }, (_, i) =>
+        makeJob(`fresh-${i}`, wordsDesc(5), { needsRetranslation: true }),
+      ),
+    ];
+    const report = detectBoilerplateDescriptions(jobs, 'diakoniewerk-neumuenster');
+    expect(report.totalJobs).toBe(2);
+    expect(report.boilerplateCount).toBe(1);
+    expect(report.ratio).toBe(0.5);
+    expect(isSystemicBoilerplateFailure(report)).toBe(false);
   });
 });
 

--- a/tests/boilerplate-guard.test.ts
+++ b/tests/boilerplate-guard.test.ts
@@ -352,18 +352,26 @@ describe('isSystemicBoilerplateFailure — sample-size floor', () => {
 });
 
 // ─── Below-Floor Quarantine Tests (quarantineBoilerplateJobs) ──────────────────
-// Regression coverage for the PR #3267 review finding: below the systemic
+// Regression coverage for the PR #3267 review findings: below the systemic
 // floor, isSystemicBoilerplateFailure() correctly refuses to hard-fail the
-// run (see the #3254 tests above), but the confirmed-boilerplate jobs must
-// still never reach the persisted slice — only warning-and-keeping them let
-// GDPR/privacy-notice boilerplate (long enough to beat the build's <50-word
-// noindex net) publish and get indexed indefinitely on a low-volume crawler.
+// run (see the #3254 tests above), but marker-phrase boilerplate (Condition
+// A) must still never reach the persisted slice — only warning-and-keeping
+// it let GDPR/privacy-notice boilerplate (long enough to beat the build's
+// <50-word noindex net) publish and get indexed indefinitely on a low-volume
+// crawler.
+//
+// Condition B (`low_unique_words`) is deliberately NOT quarantined: it's the
+// exact pattern issue #3254 exists to protect — a legitimate naturally-short
+// description (e.g. the Diakoniewerk "Berufsbildnerin" job) that lands on
+// either side of the 30-word threshold run to run. Quarantining it would add
+// zero SEO protection (already <50 words, already noindexed by the build)
+// while silently and permanently dropping real short listings.
 
 describe('quarantineBoilerplateJobs — below-floor quarantine', () => {
-  it('drops confirmed-boilerplate jobs while keeping good jobs, mirroring the #3254 shape', () => {
+  it('drops confirmed marker-phrase boilerplate jobs while keeping good jobs, mirroring the #3254 shape', () => {
     const jobs = [
       makeJob('eligible-good', RICH_DESCRIPTION),
-      makeJob('eligible-thin', wordsDesc(29)),
+      makeJob('eligible-boilerplate', BOILERPLATE_2_MARKERS),
       ...Array.from({ length: 4 }, (_, i) =>
         makeJob(`fresh-${i}`, wordsDesc(5), { needsRetranslation: true }),
       ),
@@ -371,12 +379,28 @@ describe('quarantineBoilerplateJobs — below-floor quarantine', () => {
     const report = detectBoilerplateDescriptions(jobs, 'diakoniewerk-neumuenster');
     expect(isSystemicBoilerplateFailure(report)).toBe(false); // below-floor: must not hard-fail
     expect(report.boilerplateCount).toBe(1);
+    expect(report.boilerplateJobs[0].reason).toBe('marker_phrases');
 
     const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
     expect(kept).toHaveLength(jobs.length - 1);
-    expect(kept.some(j => j.slug === 'eligible-thin')).toBe(false); // boilerplate job dropped
+    expect(kept.some(j => j.slug === 'eligible-boilerplate')).toBe(false); // marker-phrase job dropped
     expect(kept.some(j => j.slug === 'eligible-good')).toBe(true); // good job kept
     expect(kept.filter(j => j.needsRetranslation)).toHaveLength(4); // fresh jobs untouched
+  });
+
+  it('does NOT quarantine low_unique_words (Condition B) jobs — legitimate naturally-short listings survive', () => {
+    const jobs = [
+      makeJob('eligible-good', RICH_DESCRIPTION),
+      makeJob('eligible-thin', wordsDesc(29)), // naturally short, e.g. #3254 Diakoniewerk shape
+    ];
+    const report = detectBoilerplateDescriptions(jobs, 'diakoniewerk-neumuenster');
+    expect(report.boilerplateCount).toBe(1);
+    expect(report.boilerplateJobs[0].reason).toBe('low_unique_words');
+
+    const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
+    expect(kept).toBe(jobs); // no marker-phrase jobs found → same array, untouched
+    expect(kept).toHaveLength(2);
+    expect(kept.some(j => j.slug === 'eligible-thin')).toBe(true); // thin-but-legitimate job kept
   });
 
   it('returns the same array unchanged when there is nothing to quarantine', () => {
@@ -386,26 +410,28 @@ describe('quarantineBoilerplateJobs — below-floor quarantine', () => {
     expect(kept).toHaveLength(2);
   });
 
-  it('drops multiple confirmed-boilerplate jobs, keeping only the good ones', () => {
+  it('drops only the marker-phrase job, keeping both the good job and the low_unique_words job', () => {
     const jobs = [
-      makeJob('bp-1', BOILERPLATE_2_MARKERS),
-      makeJob('bp-2', wordsDesc(10)),
+      makeJob('bp-1', BOILERPLATE_2_MARKERS), // reason: marker_phrases
+      makeJob('bp-2', wordsDesc(10)), // reason: low_unique_words — must survive
       makeJob('good-1', RICH_DESCRIPTION),
     ];
     const report = detectBoilerplateDescriptions(jobs, 'test-co');
     expect(report.boilerplateCount).toBe(2);
+    expect(report.boilerplateJobs.map(bj => bj.reason).sort()).toEqual(['low_unique_words', 'marker_phrases']);
 
     const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);
-    expect(kept).toEqual([jobs[2]]);
+    expect(kept).toEqual([jobs[1], jobs[2]]);
   });
 
-  it('falls back to title, then "unknown", when matching jobs without a slug', () => {
+  it('falls back to title, then "unknown", when matching marker-phrase jobs without a slug', () => {
     const jobs = [
-      { title: 'No Slug Job', descriptionByLocale: { it: wordsDesc(5) } },
+      { title: 'No Slug Job', descriptionByLocale: { it: BOILERPLATE_2_MARKERS } },
       makeJob('good-job', RICH_DESCRIPTION),
     ];
     const report = detectBoilerplateDescriptions(jobs, 'test-co');
     expect(report.boilerplateCount).toBe(1);
+    expect(report.boilerplateJobs[0].reason).toBe('marker_phrases');
     expect(report.boilerplateJobs[0].slug).toBe('No Slug Job'); // slug fallback to title
 
     const kept = quarantineBoilerplateJobs(jobs, report.boilerplateJobs);


### PR DESCRIPTION
## Implementato

- Root cause of issue #3254 (Diakoniewerk Neumünster crawler failure, run 28584639844): `detectBoilerplateDescriptions()` in `scripts/assemble-jobs-dataset.mjs` excludes jobs with `needsRetranslation: true` from its eligible sample (by design, to avoid false-positives on translation backlog — see the Coop incident comment already in the code). Diakoniewerk's PI-ASP parser marks *every freshly-discovered job* `needsRetranslation: true` until AI localization clears it, so on this run only 2 of the 6 discovered jobs were eligible for the boilerplate check. One of those 2 ("Berufsbildnerin / Berufsbildner Maternité") had a naturally short synthesized description (the PI-ASP detail pages are JS-only, so this parser synthesizes a short structured fallback per its own doc comment) — 29 unique words, just under the 30-word floor. That tripped the ratio to exactly 1/2 = 50%, meeting `BOILERPLATE_THRESHOLD` and hard-failing the whole crawler run, discarding all 6 well-localized jobs.
- This is the exact same failure shape the codebase already hardened against in the sibling thin-source guard (`validateDedicatedLocaleCoverage` in `scripts/lib/dedicated-crawler-common.mjs`), which has an absolute sample-size floor (`SYSTEMIC_MIN_TOTAL=4`, `suspiciousThin.length >= 2`) specifically because "on a tiny listing source (2-4 jobs) a SINGLE naturally-short posting is already >=50%". The boilerplate guard in `assemble-jobs-dataset.mjs` was missing the equivalent floor — same construct, same bug class (AGENTS.md Non-Negotiable #6), fixed once in the shared guard so every low-volume dedicated crawler benefits, not just Diakoniewerk.
- Added `isSystemicBoilerplateFailure(report)` (exported, pure): hard-fails only when the ratio meets `BOILERPLATE_THRESHOLD` (50%, unchanged) **and** the sample clears an absolute floor (`>=4` eligible jobs via `JOBS_BOILERPLATE_MIN_ELIGIBLE`, `>=2` boilerplate jobs via `JOBS_BOILERPLATE_MIN_COUNT`, both env-overridable, mirroring the sibling guard's pattern). Below the floor: the guard now logs a warning explaining why it isn't failing the run instead of throwing (no GitHub issue is filed for the non-systemic case, matching the sibling guard's behavior — avoids spurious `parser-broken` issues on every low-volume crawler run).
- Large/established crawlers are unaffected: any crawler with >=4 eligible jobs and >=2 boilerplate jobs behaves identically to before (the floor is trivially satisfied), so the guard's ability to catch a genuine parser regression on high-volume crawlers is unchanged.
- Verified this is NOT a parser regression: fetched the live Diakoniewerk source listing page and confirmed the parser's doc comment — PI-ASP detail pages are JS-only, so the parser has always synthesized a short templated fallback description (`"{title} bei {entity} (…), {city} (…). Kategorie: {category}. Bewerbung über…"`), by design, since it cannot scrape real detail-page content via curl. This template naturally sits right at the 30-unique-word boundary, so it will keep landing on either side of the threshold from run to run — a structural characteristic of this source, not a broken selector.
- Added regression test coverage in `tests/boilerplate-guard.test.ts`: 8 new tests for `isSystemicBoilerplateFailure`, including one that reproduces the exact #3254 shape (1/2 = 50%, not systemic) and one integration test through `detectBoilerplateDescriptions` with the same 6-jobs/2-eligible/1-boilerplate shape as the failed run. All 31 tests in the file pass (`npx vitest run tests/boilerplate-guard.test.ts`), plus the related shrink-guard, cache, slug-collision, and normalize-parsed-jobs-for-slice suites (62/62 passed; 2 unrelated pre-existing failures in `canton-*-guard.test.ts` are environment-only — they need a locally-generated `data/jobs.json`, which is gitignored and produced by CI, not touched by this change).
- Ran GitNexus impact analysis: `writeJobsCrawlerSlice` has 137 direct callers (every dedicated crawler script) and is flagged CRITICAL risk by blast-radius size — expected, since it's the shared slice-writer. The actual behavior change is narrow and additive: only crawlers whose eligible sample falls below the new floor see different behavior (warn instead of throw); every crawler with a normal-size eligible sample keeps the exact same threshold check as before.

## Non implementato (ancora)

Nessuno. Scope is fully implemented: the shared guard fix applies to every dedicated crawler via `writeJobsCrawlerSlice`, not a Diakoniewerk-specific carve-out; no job/description was hardcoded or excluded; tests are green.

## Test plan

- [x] `npx vitest run tests/boilerplate-guard.test.ts` — 31/31 passed, including new sample-size-floor coverage.
- [x] `npx vitest run tests/scripts/shrink-guard.test.ts tests/scripts/assemble-jobs-cache.test.ts tests/scripts/normalize-parsed-jobs-for-slice.test.ts tests/scripts/assemble-per-locale-slug-collision-guard.test.ts` — all green (unrelated `canton-*-guard.test.ts` failures are pre-existing environment-only, missing gitignored `data/jobs.json`).
- [ ] Verify live: re-run `gh workflow run update-jobs-diakoniewerk-neumuenster.yml --ref main` post-merge and confirm the crawler completes without the boilerplate-guard false failure.