### PR TITLE
fix(crawlers): skip futile Playwright hop for cross-origin PastaHR anti-bot fence (#3255)

### DIFF
--- a/scripts/lib/pastahr-widget-client.mjs
+++ b/scripts/lib/pastahr-widget-client.mjs
@@ -28,8 +28,27 @@
  *      unavailable or the request fails; the caller then re-throws the original
  *      error (prior data preserved).
  *
+ *      CROSS-ORIGIN CAVEAT (#3255): this fallback can only work when the widget
+ *      endpoint is SAME-ORIGIN with the employer's career page (the Phenom/
+ *      Straumann case: both on careers.straumann.com). For PastaHR (IGS Bern /
+ *      GZO Wetzikon) the referer is the employer's own domain (igsbern.ch /
+ *      gzo.ch) but the endpoint is www.publicjobs.ch — a genuinely cross-origin
+ *      fetch from inside the page. When Cloudflare blocks that request it does
+ *      not attach CORS headers to the block response, so the browser can never
+ *      surface a status code to `page.evaluate` — it always throws a generic
+ *      `TypeError: Failed to fetch`, indistinguishable from a real network
+ *      failure. Incident logs (#3255) show this fallback has a 0% observed
+ *      success rate whenever it fires for the cross-origin case — it cannot
+ *      clear a block it cannot even see. So for cross-origin pairs we skip the
+ *      browser hop entirely (no point paying for a Chromium install/launch that
+ *      is structurally unable to help) and let the block flow into the shared
+ *      retry/backoff loop below instead, since the underlying WAF fence has
+ *      proven to be transient (later scheduled runs on the same source
+ *      routinely succeed with a plain Node fetch).
+ *
  * Why not Jina? Jina Reader only supports GET; a POST payload cannot be replayed
- * through it, so the Playwright browser path is the correct last-resort here.
+ * through it, so the Playwright browser path is the correct last-resort here
+ * for the same-origin (Phenom) case.
  *
  * Exported surface:
  *   PASTAHR_BROWSER_USER_AGENTS               — UA pool
@@ -133,6 +152,22 @@ function isAntiBotStatus(status) {
 }
 
 /**
+ * Whether two URLs share an origin (scheme + host + port). Used to detect the
+ * PastaHR cross-origin case (#3255) where the Playwright fallback's in-page
+ * `fetch` is subject to the endpoint's CORS policy and can never observe a
+ * WAF block response (see module doc "CROSS-ORIGIN CAVEAT" above).
+ */
+function isCrossOrigin(urlA, urlB) {
+  try {
+    return new URL(urlA).origin !== new URL(urlB).origin;
+  } catch {
+    // Malformed URL — be conservative and assume cross-origin (skip the
+    // browser hop rather than risk a pointless launch).
+    return true;
+  }
+}
+
+/**
  * Last-resort replay of a widget POST through a real headless Chromium.
  * The browser presents an authentic TLS fingerprint + JS execution environment
  * that the Cloudflare WAF accepts when a plain Node fetch (even with realistic
@@ -156,6 +191,21 @@ function isAntiBotStatus(status) {
  * navigation fails / the response is not valid JSON.
  */
 async function fetchWidgetViaPlaywright(bodyString, contentType, endpoint, { referer, origin, ua, timeoutMs }) {
+  // Cross-origin pair (PastaHR): the in-page fetch below is subject to the
+  // endpoint's CORS policy, and a Cloudflare block response never carries
+  // CORS headers — so a blocked request always surfaces as an unreadable
+  // `TypeError: Failed to fetch`, never a real result (#3255). Skip the
+  // Chromium install/launch entirely rather than pay for an attempt that is
+  // structurally unable to succeed; the caller's retry/backoff loop is the
+  // only thing that can actually clear a transient WAF fence here.
+  if (isCrossOrigin(referer, endpoint)) {
+    console.warn(
+      `[widget-pw] Skipping Playwright fallback — ${endpoint} is cross-origin to ${referer} `
+      + '(CORS blocks a WAF-blocked response from ever being readable in-page, #3255)',
+    );
+    return null;
+  }
+
   let browser;
   try {
     browser = await launchChromium({ headless: true });
@@ -179,19 +229,15 @@ async function fetchWidgetViaPlaywright(bodyString, contentType, endpoint, { ref
     // Replay the widget POST from within the page's JS context.
     //
     // CORS NOTE: this fetch runs in the browser, so it IS subject to the page's
-    // CORS policy (unlike the Node-side fetch path, which is not). When the
-    // endpoint is cross-origin to the navigated page — the PastaHR case, where
-    // the page is the employer site (e.g. igsbern.ch / gzo.ch) but the endpoint
-    // is www.publicjobs.ch — only headers on the CORS-safelist
-    // (Accept, Accept-Language, Content-Language, and Content-Type with a
-    // form/text value) keep this a "simple request" that needs no preflight.
-    // `X-Requested-With` is NOT safelisted: adding it forces a preflight OPTIONS
-    // that publicjobs.ch does not answer, so the whole fetch dies with
-    // `TypeError: Failed to fetch` (#2992) — defeating the anti-bot fallback.
-    // The header is only needed on the Node path (WAF fingerprint, no CORS), so
-    // it is deliberately omitted here. The urlencoded body keeps Content-Type
-    // safelisted; the same-origin Phenom case (careers.straumann.com) is exempt
-    // from CORS entirely, so dropping the header is harmless there too.
+    // CORS policy (unlike the Node-side fetch path, which is not). The
+    // cross-origin PastaHR case never reaches here — it's skipped earlier in
+    // this function (see the guard above, #3255). What DOES reach here is the
+    // same-origin Phenom/Straumann case, which is exempt from CORS entirely, so
+    // this header set is a courtesy match of the real in-page widget XHR rather
+    // than a CORS requirement. `X-Requested-With` is still deliberately omitted
+    // — it is not on the CORS-safelist and forces a preflight OPTIONS that would
+    // matter again if this function is ever reused for another cross-origin
+    // pair, so keep the safelisted-only header set as the default (#2992).
     const result = await page.evaluate(
       async ({ ep, body, ct }) => {
         const res = await fetch(ep, {
@@ -238,11 +284,14 @@ function fetchPastaHrPageViaPlaywright(params, opts) {
  * Steps (the whole sequence runs inside the shared transient-retry loop, so a
  * transient 429/5xx or network blip self-heals with exponential backoff):
  *   1. Attempt a plain Node fetch with realistic Chrome 131 headers.
- *   2. On 403 / 401 / 406 anti-bot fence: replay via a real headless Chromium
- *      (the browser's TLS fingerprint + JS context clears IP-reputation blocks).
- *   3. On null from Playwright (unavailable / timed out): re-throw the original
- *      error so the caller's safe-fail / prior-data-preserved path runs.
- *   4. On a transient 429/5xx (not an anti-bot status): backoff + retry; a
+ *   2. On 403 / 401 / 406 anti-bot fence: PastaHR's endpoint (publicjobs.ch) is
+ *      cross-origin to the referer, so the Playwright fallback is skipped (see
+ *      module doc "CROSS-ORIGIN CAVEAT", #3255) and the failure is instead
+ *      marked retryable — the WAF fence has proven transient (subsequent
+ *      scheduled runs routinely succeed), so a few backoff-spaced retries
+ *      within THIS run give it a chance to self-heal instead of failing the
+ *      whole crawl on a single blocked attempt.
+ *   3. On a transient 429/5xx (not an anti-bot status): backoff + retry; a
  *      persistent failure throws after retries are exhausted.
  *
  * @param {URLSearchParams} params   — POST body (caller builds the full payload)
@@ -258,9 +307,7 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
 
   // Wrap the attempt in the shared transient-retry loop so a transient 429/5xx
   // or network blip self-heals with exponential backoff (the behaviour the old
-  // `fetchJson` path provided before this client was extracted, #1846). The
-  // anti-bot fence (403/401/406) is NOT retryable — it routes to Playwright once
-  // per attempt and re-throws (IP-reputation will not change on a bare retry).
+  // `fetchJson` path provided before this client was extracted, #1846).
   return fetchWithRetry(async () => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -281,14 +328,20 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
       throw err;
     } catch (err) {
       clearTimeout(timer);
-      // Anti-bot fence (403/401/406): retry once via headless browser, which
-      // the WAF treats as a genuine visitor.
+      // Anti-bot fence (403/401/406): try the headless-browser replay, which
+      // the WAF treats as a genuine visitor — but see the cross-origin caveat
+      // above, PastaHR always skips it and falls straight through to marking
+      // the error retryable.
       const status = firstStatus ?? err?.status;
       if (isAntiBotStatus(status)) {
         console.warn(`[pastahr] HTTP ${status} from ${PASTAHR_ENDPOINT} — trying Playwright anti-bot fallback`);
         const result = await fetchPastaHrPageViaPlaywright(params, { referer, origin, ua, timeoutMs: 45000 });
         if (result !== null) return result;
-        // Playwright unavailable or also blocked — re-throw original HTTP error.
+        // Playwright unavailable, cross-origin-skipped, or also blocked. The
+        // WAF fence at this endpoint has proven transient (#3255) — mark the
+        // error retryable so the shared backoff loop gives it a few more
+        // spaced attempts within this run instead of failing on the first hit.
+        err.retryable = true;
       }
       throw err;
     }
@@ -310,8 +363,15 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
  * Steps (wrapped in the shared transient-retry loop — 429/5xx/network blips
  * self-heal with exponential backoff before any error surfaces):
  *   1. Plain Node fetch with Chrome 131 UA + full client-hint headers.
- *   2. On 403 / 401 / 406: Playwright browser POST fallback.
- *   3. Playwright null → re-throw original error.
+ *   2. On 403 / 401 / 406: Playwright browser POST fallback (skipped when
+ *      `endpoint` is cross-origin to `referer` — see module doc "CROSS-ORIGIN
+ *      CAVEAT", #3255 — since the in-page fetch can never observe a blocked
+ *      response's status through the browser's CORS enforcement in that case).
+ *   3. Playwright null: for a cross-origin pair, mark the error retryable so
+ *      the shared backoff loop below gives the (empirically transient) WAF
+ *      fence a few more spaced attempts within this run; for a same-origin
+ *      pair (e.g. Phenom/Straumann, where Playwright genuinely could have
+ *      cleared the block) re-throw the original error unchanged.
  *   4. Transient 429/5xx (non-anti-bot) → backoff + retry; throw on exhaustion.
  *
  * @param {string|object} body       — request body; objects are JSON-serialised automatically
@@ -377,6 +437,12 @@ export async function fetchPostWidgetWithAntiBotHardening(body, endpoint, { refe
           timeoutMs: 45000,
         });
         if (result !== null) return result;
+        // Playwright unavailable/skipped/blocked. Only a cross-origin pair
+        // (Playwright structurally could never observe the block, #3255) gets
+        // marked retryable so the shared backoff loop below can self-heal a
+        // transient WAF fence; a same-origin pair (Playwright genuinely had a
+        // shot at clearing it) keeps the original fail-fast behaviour.
+        if (isCrossOrigin(referer, endpoint)) err.retryable = true;
       }
       throw err;
     }

--- a/tests/crawler-shared-fetch-retry.test.ts
+++ b/tests/crawler-shared-fetch-retry.test.ts
@@ -9,14 +9,32 @@
  *   - playwright-runtime.fetchWithRateLimit   (every Playwright ATS crawler)
  *
  * Invariant under test (same as the merged helper): retry bounded on TRANSIENT
- * signals (network/timeout/429/5xx), fail fast on persistent 4xx (404/403),
- * never retry anti-bot blocks.
+ * signals (network/timeout/429/5xx), fail fast on persistent 4xx (404). Plain
+ * anti-bot blocks (403/401/406) route to the Playwright fallback; a
+ * SAME-ORIGIN anti-bot block that survives Playwright still fails fast, but a
+ * CROSS-ORIGIN one (PastaHR/publicjobs.ch — #3255) is retried with backoff
+ * because Playwright can never observe that block (browser-enforced CORS) and
+ * the fence has proven transient across scheduled runs.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { fetchHtml as hospitalFetchHtml } from '../scripts/lib/hospital-custom-html-helpers.mjs';
 import { fetchGreenhouseJobs, GreenhouseApiError } from '../scripts/lib/ats-clients/greenhouse-client.mjs';
 import { fetchLeverJobs } from '../scripts/lib/ats-clients/lever-client.mjs';
+
+// The PastaHR/GZO-Wetzikon/IGS-Bern case (#3255) is cross-origin between the
+// employer's career page (referer) and the widget endpoint (publicjobs.ch), so
+// the Playwright fallback is structurally unable to observe a WAF-blocked
+// response (browser-enforced CORS strips it to an unreadable `Failed to
+// fetch`) and must be SKIPPED rather than launched. Mock `launchChromium` so
+// any regression that still tries to launch a browser for that case fails the
+// test loudly instead of silently spending 30-45s on a real Chromium
+// install/launch in CI.
+const { launchChromiumMock } = vi.hoisted(() => ({ launchChromiumMock: vi.fn() }));
+vi.mock('../scripts/lib/ensure-chromium.mjs', () => ({
+  launchChromium: launchChromiumMock,
+}));
+
 import {
   fetchPostWidgetWithAntiBotHardening,
   fetchPastaHrWidgetPage,
@@ -47,6 +65,7 @@ const FAST = { JOBS_CRAWLER_RETRY_BASE_MS: '0' };
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  launchChromiumMock.mockReset();
   delete process.env.JOBS_CRAWLER_RETRY_BASE_MS;
 });
 
@@ -211,6 +230,90 @@ describe('pastahr-widget-client.fetchPastaHrWidgetPage (PastaHR URL-encoded POST
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(fetchPastaHrWidgetPage(new URLSearchParams({ page: '0' }), OPTS)).rejects.toThrow(/HTTP 404/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #3255: GZO Wetzikon + IGS Bern both failed with
+// `[widget-pw] Playwright fallback failed: page.evaluate: TypeError: Failed
+// to fetch` after the primary Node fetch got HTTP 403. The referer
+// (igsbern.ch / gzo.ch) is cross-origin to the widget endpoint
+// (www.publicjobs.ch), so the in-page `fetch` inside Playwright is subject to
+// browser-enforced CORS: a Cloudflare block response carries no CORS headers,
+// so the browser can NEVER read a status — it always throws a generic
+// "Failed to fetch", 0% observed success across every incident log checked.
+// Fix: skip the (structurally futile) Playwright hop for cross-origin pairs
+// and mark the anti-bot failure retryable instead, so the shared backoff loop
+// gives the (empirically transient — later scheduled runs routinely succeed)
+// WAF fence a few more spaced attempts within the SAME run.
+describe('pastahr-widget-client — cross-origin anti-bot fence retry (#3255)', () => {
+  const CROSS_ORIGIN_OPTS = { referer: 'https://www.gzo.ch/karriere/offene-stellen', origin: 'https://www.gzo.ch' };
+
+  it('fetchPastaHrWidgetPage: skips Playwright and retries a transient cross-origin 403 until it clears', async () => {
+    withFastRetry();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(403, {}))
+      .mockResolvedValueOnce(jsonResponse(403, {}))
+      .mockResolvedValueOnce(jsonResponse(200, { jobs: [{ id: 1 }] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const data = await fetchPastaHrWidgetPage(new URLSearchParams({ page: '0' }), CROSS_ORIGIN_OPTS);
+    expect(data.jobs).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // Playwright must never be launched for a cross-origin pair — it cannot
+    // observe a blocked response through CORS, so it would only waste time.
+    expect(launchChromiumMock).not.toHaveBeenCalled();
+  });
+
+  it('fetchPastaHrWidgetPage: exhausts backoff and throws if the cross-origin 403 never clears', async () => {
+    withFastRetry();
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPastaHrWidgetPage(new URLSearchParams({ page: '0' }), CROSS_ORIGIN_OPTS),
+    ).rejects.toThrow(/HTTP 403/);
+    // 1 initial attempt + the shared default of 3 retries = 4 total.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(launchChromiumMock).not.toHaveBeenCalled();
+  });
+
+  it('fetchPostWidgetWithAntiBotHardening: skips Playwright and retries a transient cross-origin 403 until it clears', async () => {
+    withFastRetry();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(403, {}))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const data = await fetchPostWidgetWithAntiBotHardening(
+      { from: 0 },
+      'https://www.publicjobs.ch/widget',
+      CROSS_ORIGIN_OPTS,
+    );
+    expect(data).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(launchChromiumMock).not.toHaveBeenCalled();
+  });
+
+  it('fetchPostWidgetWithAntiBotHardening: a SAME-ORIGIN 403 still attempts Playwright (unlike the cross-origin case)', async () => {
+    withFastRetry();
+    // Same-origin pair (Straumann/Phenom-style): Playwright IS a genuine
+    // candidate to clear the block, so launchChromium must be reached. Make
+    // it reject (no real browser in this unit test) so we can assert the
+    // final failure is NOT silently retried away — same-origin keeps the
+    // original fail-fast contract, only the cross-origin case gets the new
+    // retry behaviour.
+    launchChromiumMock.mockRejectedValue(new Error('no browser in unit test'));
+    const SAME_ORIGIN_OPTS = { referer: 'https://careers.straumann.com/', origin: 'https://careers.straumann.com' };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPostWidgetWithAntiBotHardening({ from: 0 }, 'https://careers.straumann.com/widgets', SAME_ORIGIN_OPTS),
+    ).rejects.toThrow(/HTTP 403/);
+    expect(launchChromiumMock).toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Implementato

- Root cause: the dedicated GZO Spital Wetzikon crawler workflow was failing with `HTTP 403 from https://www.publicjobs.ch/widget`, and the Playwright anti-bot fallback that's supposed to recover from that also failed with `page.evaluate: TypeError: Failed to fetch`. That second failure isn't a bug in the fallback logic — it's a structural CORS limitation. GZO Wetzikon and IGS Bern both use PastaHR, whose widget endpoint (`www.publicjobs.ch`) is **cross-origin** to the employer's career page (`gzo.ch` / `igsbern.ch`). When Cloudflare blocks the request, the block response carries no CORS headers, so the in-page `fetch()` inside the Playwright fallback can never read a status code — it always throws a generic, unreadable `TypeError: Failed to fetch`, 0% observed success across the incident logs checked. Meanwhile the WAF fence itself is transient: later scheduled runs of the same crawler routinely succeed with a plain Node fetch.
- Fixed in the **shared module** `scripts/lib/pastahr-widget-client.mjs` (used by both GZO Wetzikon and IGS Bern, and — for the generic POST path — Straumann), per the sibling-pattern rule, so the fix covers the whole class of the bug instead of just the reported crawler:
  - Added `isCrossOrigin(urlA, urlB)` helper.
  - `fetchWidgetViaPlaywright` now skips the Chromium install/launch entirely when the endpoint is cross-origin to the referer (structurally unable to observe a block there), logging why, instead of paying ~30-45s per failed attempt for nothing.
  - `fetchPastaHrWidgetPage` (PastaHR/GZO/IGS Bern — always cross-origin): on an anti-bot 403/401/406 with Playwright skipped, marks the error `retryable = true` so it flows into the existing shared `fetchWithRetry` backoff loop instead of failing the whole crawl on the very first blocked attempt.
  - `fetchPostWidgetWithAntiBotHardening` (generic POST widget client — Straumann/Phenom is same-origin): only marks the error retryable when the specific `referer`/`endpoint` pair passed in is cross-origin, so the currently-working same-origin Straumann path keeps its original Playwright-then-fail-fast behaviour unchanged.
  - No bot-detection evasion: no fake identity, no IP rotation. The existing descriptive UA / standard headers / rate-limit courtesy are untouched — this only changes retry cadence and skips a fallback hop that can never work for this endpoint pair.
- Test coverage added in `tests/crawler-shared-fetch-retry.test.ts` (mocking `launchChromium` via `vi.mock`/`vi.hoisted`):
  - Cross-origin PastaHR 403→403→200 retries and recovers, asserting `launchChromium` is never called.
  - Cross-origin PastaHR 403 persisting through all retries throws, `launchChromium` still never called.
  - Cross-origin generic-POST 403→200 retries and recovers via the same guard.
  - Same-origin generic-POST 403 still attempts Playwright (regression guard proving the Straumann path is untouched).
  - `npx vitest run tests/crawler-shared-fetch-retry.test.ts` → 16/16 passing.
- `docs/CRAWLERS.md` checked (`grep -i "publicjobs|pastahr|widget-pw|GZO|IGS Bern"`) — no existing integration notes reference this module, so no doc update was needed.
- `.github/workflows/update-jobs-gzo-wetzikon.yml` intentionally left untouched (its "Load secrets from Remote Config" step was already fixed separately in #3265); confirmed via `git diff origin/main --stat` that this PR touches only the two files listed above.

## Non implementato (ancora)

Nessuno. `publicjobs.ch/widget` itself is not being replaced or migrated — the crawler still targets it (it's PastaHR's actual API surface, not an alternate/legitimate access path issue), and the fix addresses the retry/backoff gap that was turning a transient WAF fence into a hard crawl failure. If a future run shows the WAF fence is no longer transient (i.e. retries stop clearing it within a run and every scheduled run fails), that would indicate a permanent IP-reputation block requiring a different access path — not observed in the incident history checked for #3255.