### PR TITLE
fix(ci): redundant settings-JSON bypassPermissions fallback for crawler-data-quality-audit

### DIFF
--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -110,6 +110,16 @@ jobs:
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
+          # Redundant with --dangerously-skip-permissions below: 2 live runs
+          # (28593412005, 28594828826, 2026-07-02) resolved permissionMode to
+          # "default" despite that flag being present in claude_args, blocking
+          # every Bash/gh call with "This command requires approval" (issue
+          # #3269) — a byte-identical pr-review-loop.yml run the same day got
+          # bypassPermissions fine, so it's a claude_args string-parsing flake,
+          # not a config error here. `settings` sets defaultMode via structured
+          # JSON, a different code path in the action — kept alongside the CLI
+          # flag as a fallback in case the flag drops again.
+          settings: '{"permissions":{"defaultMode":"bypassPermissions"}}'
           claude_args: "--max-turns 40 --model claude-sonnet-5 --dangerously-skip-permissions"
           prompt: |
             Audit qualità dati crawler, settimanale. Finestra lookback: ${{ env.WINDOW_DAYS }} giorni.


### PR DESCRIPTION
## Implementato
- Aggiunto input `settings: '{"permissions":{"defaultMode":"bypassPermissions"}}'` a `crawler-data-quality-audit.yml`, accanto (non in sostituzione) al `--dangerously-skip-permissions` esistente in `claude_args`.
- **Motivazione**: 2 run live dello stesso giorno ([28593412005](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28593412005), [28594828826](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28594828826)) hanno risolto `permissionMode` a `"default"` nonostante il flag fosse presente in `claude_args` — ogni comando Bash/gh bloccato con "This command requires approval" (issue #3269). Un run byte-identico di `pr-review-loop.yml` lo stesso giorno ha ottenuto `bypassPermissions` correttamente, escludendo config locale (`.claude/settings.json` verificato: nessun blocco permissions, solo hooks+env).
- Verificato via `action.yml`/`docs/configuration.md` upstream (`anthropics/claude-code-action`): `settings` è un input JSON separato, un path di parsing diverso da `claude_args` — se il parsing della stringa CLI droppa di nuovo il flag (comportamento non deterministico osservato), il JSON strutturato dovrebbe comunque impostare `permissions.defaultMode`. `claude_args` resta la fonte primaria (ha precedenza secondo la doc), `settings` è solo un fallback ridondante sullo stesso intento.
- YAML validato (`python3 -c "import yaml; yaml.safe_load(...)"` → `YAML_OK`).

## Non implementato (ancora)
- **Verifica live del fix**: in questa PR — verrà lanciato un run manuale post-merge di `crawler-data-quality-audit.yml` per confermare che il flake non si ripresenta. Se il run mostra ancora `permissionMode: "default"`/comandi bloccati, il fix non è sufficiente e serve escalation upstream (issue #3269 già apre questa strada).
- **Propagazione ai 5 workflow sibling** (`issue-fix.yml`, `pr-review-loop.yml`, `pr-redflag-fixer.yml`, `post-merge-followup.yml`, `lessons-harvester.yml`, tutti con lo stesso costrutto `--dangerously-skip-permissions` in `claude_args` adottato oggi 2026-07-02): **posposta a PR concatenata**, condizionata all'esito della verifica live qui sopra — non ha senso applicare il fallback a 5 workflow in produzione prima di aver confermato che risolve davvero il problema su uno solo. Se il run manuale post-merge conferma il fix, apro la PR sibling immediatamente dopo (stessa PR-chain, non "out of scope": è la stessa classe di bug, AGENTS.md non-negotiable #6).