### PR TITLE
fix(seo): guard company-hub namespace collision in cathedral migration redirects

### DIFF
--- a/build-plugins/legacyRedirectsPlugin.ts
+++ b/build-plugins/legacyRedirectsPlugin.ts
@@ -9,7 +9,13 @@ import type { Plugin } from 'vite';
 import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, GTAG_SNIPPET } from './constants';
 import { resolveSearchConsoleCompatTarget } from './searchConsoleCompat';
 import { readCompatPaths } from '../scripts/lib/compat-paths-store.mjs';
-import { resolveCantonSection, resolveJobCanton, type CantonLocale } from './shared/cantonSection';
+import {
+ resolveCantonSection,
+ resolveJobCanton,
+ isCompanyHubNamespaceSlug,
+ AGGREGATE_KEY,
+ type CantonLocale,
+} from './shared/cantonSection';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { loadJobsJson } from './shared/loadJobsJson';
 import cantonSlugFile from '../data/canton-url-slugs.json';
@@ -317,6 +323,14 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  let count = 0;
  let compatCount = 0;
  let cathedralCount = 0;
+ // `/cerca-lavoro-ticino/azienda-{slug}/` (and per-locale equivalents) is the
+ // RESERVED company-hub namespace (see isCompanyHubNamespaceSlug). A job whose
+ // OWN slug happens to start with that prefix must not get a cathedral bridge
+ // page canonicalizing to its foreign-canton URL there — same invariant as the
+ // other 6 call sites fixed for issue #2976 (PR validate-dist-company-hub-namespace-6th-site).
+ // Fall back to the Switzerland aggregator canonical; the redirect target/CTA
+ // still points at the real page, so UX is unaffected.
+ const redirectCanonicalOverride = new Map<string, string>();
 
  // Build hreflang lookup from sitemaps so legacy pages can point to locale variants
  const hreflangMap = buildHreflangMap(rootDir);
@@ -350,6 +364,11 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  if (!redirects[from]) {
  redirects[from] = to;
  cathedralCount++;
+ if (isCompanyHubNamespaceSlug(slug, locale)) {
+ const aggregatorSection = resolveCantonSection(locale, AGGREGATE_KEY);
+ const aggregatorPath = `${localePrefix[locale]}/${aggregatorSection}/`.replace(/\/+/g, '/');
+ redirectCanonicalOverride.set(from, `${BASE_URL}${aggregatorPath}`);
+ }
  }
  }
  }
@@ -403,7 +422,7 @@ export function legacyRedirectsPlugin(rootDir: string): Plugin {
  inLanguage: 'it',
  });
  const html = buildCanonicalBridgePage({
- canonicalUrl: `${BASE_URL}${to}`,
+ canonicalUrl: redirectCanonicalOverride.get(fromRaw) ?? `${BASE_URL}${to}`,
  pathLabel: to,
  title: 'Pagina spostata',
  description: 'Questa URL legacy ha una pagina canonica aggiornata su Frontaliere Ticino.',


### PR DESCRIPTION
## Implementato

- `build-plugins/legacyRedirectsPlugin.ts`: the "Phase 8.4 cathedral migration map" block (writes legacy TI-section bridge pages for every non-TI job) had **no** company-hub-namespace-collision guard at all — the only one of 7 emit sites for this invariant left unaudited after #3264. When a non-TI job's own generated slug happened to start with the reserved `azienda-`/`company-`/`unternehmen-`/`entreprise-` prefix, this wrote a bridge page physically at `dist/cerca-lavoro-ticino/azienda-{slug}/index.html` (and locale equivalents) with `<link rel=canonical>` pointing at the job's real foreign-canton URL — reproducing the exact issue #2976 bug class via an unrelated code path.
- Confirmed live: two post-#3264 jobs (a Vaud job canonicalizing to VD, a Zurich job canonicalizing to ZH) both served this violating bridge page under the TI legacy path, which is why `tests/seo/cathedral-sector-hubs.test.ts` was still failing post-merge on a fresh `validate-dist` run despite #3264.
- Fix follows the exact established pattern from the other 6 sites: on collision (`isCompanyHubNamespaceSlug`), the bridge page's `<link rel=canonical>` falls back to the Switzerland aggregator URL (`resolveCantonSection(locale, AGGREGATE_KEY)`) instead of the job's real canton URL. The redirect target / visible CTA (`pathLabel`) is untouched — it still points at the real live job page, so there's no UX regression, only the canonical tag changes.
- Checked `build-plugins/cantonOrphanRedirectsPlugin.ts` as a possible sibling (same "legacy TI bridge" shape): false positive — it enumerates fixed sector/city hub slot combinations (`slugForSlot`), never job-derived slugs, so it can't produce a company-hub-prefixed collision. No hardcoded `cerca-lavoro-ticino` literal or `canonicalUrl` misuse found there either.
- Verified locally: `tsc --noEmit` clean for this file (pre-existing unrelated errors elsewhere untouched), `tests/seo/cathedral-sector-hubs.test.ts` + `tests/seo/cathedral-no-ti-hardcodes.test.ts` (line-shift-sensitive allowlist, still passes — uses content-based inline marker) + `tests/search-console-compat.test.ts` all green (29/29).

## Non implementato (ancora)

Nessuno.

Note (out of scope, separately flagged): the latest `validate-dist` run also showed `tests/seo/cathedral-canton-landing-order.test.ts` failing for a Zurich canton-landing page (element-ordering invariant) — this is a different bug class, absent from the original failing run (28583894494) that motivated this fix, and unrelated to company-hub-namespace routing. Not fixed here; will track separately if it persists on the next live run.