### PR TITLE
fix(ci): revert schedule/workflow_dispatch workflows to scoped --allowedTools

### DIFF
--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -110,17 +110,19 @@ jobs:
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          # Redundant with --dangerously-skip-permissions below: 2 live runs
-          # (28593412005, 28594828826, 2026-07-02) resolved permissionMode to
-          # "default" despite that flag being present in claude_args, blocking
-          # every Bash/gh call with "This command requires approval" (issue
-          # #3269) — a byte-identical pr-review-loop.yml run the same day got
-          # bypassPermissions fine, so it's a claude_args string-parsing flake,
-          # not a config error here. `settings` sets defaultMode via structured
-          # JSON, a different code path in the action — kept alongside the CLI
-          # flag as a fallback in case the flag drops again.
-          settings: '{"permissions":{"defaultMode":"bypassPermissions"}}'
-          claude_args: "--max-turns 40 --model claude-sonnet-5 --dangerously-skip-permissions"
+          # 2026-07-02: `--dangerously-skip-permissions` (+ `settings` JSON fallback,
+          # PR #3277) tried and failed across 3 live runs (28593412005, 28594828826,
+          # 28599900446) — permissionMode resolves to "default" every time on this
+          # workflow's schedule/workflow_dispatch trigger, blocking ~75% of Bash calls
+          # incl. the actual audit script ("requires approval", issue #3269). Confirmed
+          # NOT specific to this workflow: post-merge-followup.yml's own `schedule` run
+          # the same day (28594653701) hit the identical wall. workflow_run/issues-
+          # triggered siblings (pr-review-loop, issue-fix) get real bypassPermissions
+          # with the same config — the differentiator is event_name, not settings, not
+          # actor (confirmed with both a human and a bot actor on the broken side).
+          # Falling back to scoped --allowedTools (read-only audit: no Edit/Write
+          # needed) until the upstream root cause is understood.
+          claude_args: "--max-turns 40 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob'"
           prompt: |
             Audit qualità dati crawler, settimanale. Finestra lookback: ${{ env.WINDOW_DAYS }} giorni.
 

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -93,10 +93,12 @@ jobs:
           # aborterebbe "non-human actor". Mai `*`.
           allowed_bots: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped
-          # (rationale completo: post-merge-followup.yml claude_args comment, stesso
-          # fix, evita drift tra copie duplicate).
-          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --dangerously-skip-permissions"
+          # 2026-07-02: ROLLBACK di --dangerously-skip-permissions (rationale completo:
+          # post-merge-followup.yml claude_args comment) — issue #3269: sui trigger
+          # schedule/workflow_dispatch il flag non produce mai bypassPermissions
+          # (permissionMode resta "default", quasi ogni Bash bloccato); i workflow con
+          # trigger workflow_run/issues invece funzionano con la stessa config identica.
+          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.
 

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -142,17 +142,19 @@ jobs:
           # Se una sessione satura il cap (batch grande) → error_max_turns → run NON
           # success → watermark non avanza → la prossima run schedulata ri-copre la
           # finestra; l'idempotenza salta le PR già commentate, riprende le restanti.
-          # 2026-07-02: `--dangerously-skip-permissions` sostituisce l'`--allowedTools`
-          # scoped precedente, stesso fix di pr-review-loop.yml (owner-approved
-          # 2026-07-01). Lo scoped `Bash(gh:*)` fa validazione statica del comando e
-          # abortiva su sintassi shell legittima ("Contains shell syntax that cannot
-          # be statically analyzed", "Newline followed by # inside a quoted argument
-          # can hide arguments from path validation") durante il triage batch, run
-          # perse senza summary comment postato (watermark non avanza, prossima run
-          # schedulata ri-tenta). Rischio noto e accettato, stesso di pr-review-loop:
-          # il prompt resta constraint a `gh issue create`/`gh pr comment` read-only,
-          # ma il processo Claude ora ha accesso Bash/Write/Edit pieno.
-          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-4-6 --dangerously-skip-permissions"
+          # 2026-07-02: ROLLBACK di `--dangerously-skip-permissions` (adottato la
+          # mattina stessa) — issue #3269: run schedulati/workflow_dispatch (questo
+          # workflow gira su `schedule`) risolvono `permissionMode` a "default"
+          # nonostante il flag, bloccando quasi ogni Bash con "requires approval"
+          # (confermato sul run 28594653701 di oggi, 13:43Z: 36 blocchi, zero
+          # comment postato). pr-review-loop.yml (trigger `workflow_run`) e
+          # issue-fix.yml (trigger `issues`) invece OTTENGONO bypassPermissions
+          # regolarmente con la stessa config — il pattern correla con
+          # l'event_name del trigger (schedule/workflow_dispatch → sempre bloccato,
+          # anche con actor umano), non con settings/claude_args. Torniamo allo
+          # scoped `--allowedTools` precedente (problema noto ma minore: rifiuta
+          # a volte sintassi shell non staticamente analizzabile, non blocca TUTTO).
+          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Triage automatico follow-up in BATCH (${{ github.event_name }}).
             PR da processare (CSV): ${{ steps.collect.outputs.batch_prs }}


### PR DESCRIPTION
## Implementato
- `crawler-data-quality-audit.yml`, `post-merge-followup.yml`, `lessons-harvester.yml` (i 3 workflow con trigger `schedule`/`workflow_dispatch`) tornano da `--dangerously-skip-permissions` allo scoped `--allowedTools` precedente.

## Perché
`--dangerously-skip-permissions` (+ fallback `settings` JSON, PR #3277) è stato testato su 3 run live di `crawler-data-quality-audit.yml` e su un run schedulato di `post-merge-followup.yml` (già in produzione, nessun fix applicato) — in tutti e 4 i casi `permissionMode` risolve a `"default"`, bloccando ~75% delle chiamate Bash con "This command requires approval" (incl. lo script di audit vero e proprio). Vedi issue #3269 per i dettagli completi.

**Pattern confermato — correla col trigger, non con la config:**
| Workflow | Trigger | permissionMode |
|---|---|---|
| `crawler-data-quality-audit.yml` | `workflow_dispatch` | `default` ❌ (3/3 run) |
| `post-merge-followup.yml` | `schedule` | `default` ❌ |
| `pr-review-loop.yml` | `workflow_run` | `bypassPermissions` ✅ |
| `issue-fix.yml` | `issues` | `bypassPermissions` ✅ |

Confermato anche che non è una questione di actor (bot vs umano): il run rotto di `crawler-data-quality-audit.yml` è stato triggerato da un attore umano (`valerielinc-ops` via workflow_dispatch), quello rotto di `post-merge-followup.yml` da un bot (`frontaliere-automation[bot]` via schedule) — entrambi rotti allo stesso modo. I 2 workflow rimasti su `--dangerously-skip-permissions` (`issue-fix.yml`, `pr-redflag-fixer.yml`) hanno trigger event-driven (`issues`, `pull_request_review`) e restano quindi non toccati da questa PR.

Il rollback riporta questi 3 workflow al comportamento noto da prima di oggi (rischio già documentato: lo scoped `Bash(gh:*)`/`Bash(node:*)`/ecc. a volte rifiuta sintassi shell non staticamente analizzabile — ma questo bloccava una minoranza di run, non quasi tutto il lavoro come il bypass rotto).

## Non implementato (ancora)
- Root cause upstream non identificata: perché `claude-code-action` differenzia `permissionMode` in base a `event_name` (schedule/workflow_dispatch → sempre `default`, altri eventi → `bypassPermissions` regolare) resta sconosciuto — nessuna documentazione pubblica trovata (`docs/security.md`, `docs/configuration.md`) che lo descriva. Investigazione ulteriore o escalation upstream restano aperte, tracciate su issue #3269.
- `lessons-harvester.yml` non ha un run recente con lo step Claude eseguito (skip per assenza di cluster novel oggi) — impossibile confermare/escludere direttamente lo stesso sintomo su questo workflow specifico, ma applica lo stesso fix preventivamente per coerenza con gli altri 2 `schedule`-triggered.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>