### PR TITLE
fix(deploy): retry rclone binary download on transient network failure

### DIFF
--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -152,7 +152,11 @@ _publish_cdn_r2() {
   local rtmp="${RUNNER_TEMP:-/tmp}"
   if ! command -v rclone >/dev/null 2>&1; then
     echo "[r2] rclone not found — installing static binary…"
-    if curl -fsSL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o "$rtmp/rclone.zip" \
+    # --retry: a bare Recv-failure/Connection-reset on this single-shot download
+    # (transient network blip, e.g. #run-28599750786) previously failed the
+    # WHOLE deploy prep step (no fallback) even though nothing else was wrong.
+    if curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+         https://downloads.rclone.org/rclone-current-linux-amd64.zip -o "$rtmp/rclone.zip" \
        && unzip -q -o -j "$rtmp/rclone.zip" '*/rclone' -d "$rtmp/rclone-bin"; then
       chmod +x "$rtmp/rclone-bin/rclone" 2>/dev/null || true
       export PATH="$rtmp/rclone-bin:$PATH"


### PR DESCRIPTION
## Implementato

- `scripts/lib/deploy-it-pages-prep.sh`: added `curl --retry 3 --retry-delay 2 --retry-all-errors` to the rclone static-binary download in `_publish_cdn_r2()`. Root cause of https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28599750786/job/84806407228 — a bare `curl: (35) Recv failure: Connection reset by peer` on the single-shot, no-retry `curl -fsSL` download failed the whole "Drop dist/assets after CDN push" FATAL guard, aborting IT deploy prep for that run (fail-safe design kept last-good live; no user-facing outage, but nothing new published that run). A transient network blip should not take down the entire step.
- Sibling-pattern grep (`curl -fsSL`/`-fsS` across `scripts/`, `build-plugins/`, `.github/workflows/`) run per AGENTS.md #6: other matches (`wait-cdn-build-id.sh`, `push-ticino-shard.sh`, `push-locale-shard.sh`) are false positives — they already sit inside a retry/poll loop or have a tolerant `|| true`/`|| echo 0` fallback. `setup-selfhosted-runner.sh` and `generate-article.yml`'s ollama install are one-off/manual bootstrap paths, not part of the autonomous deploy-critical path — not the same failure class.

## Non implementato (ancora)

Nessuno.