### PR TITLE
fix(ci): force rebase.backend=merge on dist-history pull to guard merge driver

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -658,8 +658,15 @@ jobs:
           # below stays as a belt-and-braces recovery for any unexpected
           # mid-rebase state; it is a safe no-op when no rebase is in progress
           # (e.g. a plain push-rejected race).
+          # `rebase.backend=merge` is forced explicitly (git >=2.26 default,
+          # but not guaranteed on every runner image): the `apply` backend
+          # replays patches instead of doing a real merge and SILENTLY
+          # SKIPS merge drivers, so the json-first-seen driver above would
+          # never fire and the CONFLICT wedge (see above) could reappear
+          # with no signal (#2921, follow-up of #2920).
           for i in 1 2 3 4 5; do
-            if git -c rebase.autoStash=true pull --rebase origin main \
+            if git -c rebase.autoStash=true -c rebase.backend=merge \
+                pull --rebase origin main \
                 && git push origin HEAD:main; then
               echo "[dist-history] pushed on attempt $i"
               exit 0


### PR DESCRIPTION
## Implementato
- `.github/workflows/deploy.yml`, `dist-history` step: added `-c rebase.backend=merge` to the `git ... pull --rebase origin main` invocation (alongside the existing `-c rebase.autoStash=true`), scoped to that single command only.
- Added an inline comment explaining why: the `apply` rebase backend replays patches instead of doing a real merge and silently skips custom merge drivers (`.gitattributes` → `merge=json-first-seen`), so without this pin the `url-first-seen.json` wedge fixed in #2920 could reappear with no signal if a runner ever defaulted to (or was configured with) the apply backend.
- Verified `git config rebase.backend merge` is valid git syntax in a scratch repo (`git config --get rebase.backend` reads back `merge`), and confirmed the `-c key=value` inline form (matching the existing `-c rebase.autoStash=true` pattern already on that line) is accepted by git locally.
- Confirmed the edited `deploy.yml` still parses as valid YAML (python `yaml.safe_load`).

## Non implementato (ancora)
- Live confirmation of which rebase backend the actual GitHub Actions runner used *before* this fix (i.e., proof the bug was real, not just theoretical) — not observable from the diff or locally. `blocked: external — requires reading runner git version / behavior on an actual `dist-history` push, only observable on the next real deploy run on `main` post-merge.` This is a hardening/defensive fix either way (pinning the backend is safe and correct regardless of what the runner's default turns out to be), so it does not block closing this issue, but I have not fabricated a "verified GREEN on live runner" claim.

Closes #2921