### PR TITLE
fix(blog): pair body heading to body html by stable key, not post-filter index

### DIFF
--- a/build-plugins/articleSeoFallback.ts
+++ b/build-plugins/articleSeoFallback.ts
@@ -371,9 +371,15 @@ export function buildArticleSeoSections(locale: Locale, title: string, desc: str
  ];
 }
 
-export function cleanupArticleBodySections(sections: Array<string | undefined>): string[] {
+export type ArticleBodySectionInput = { key: string; text: string | undefined };
+export type ArticleBodySectionRendered = { key: string; html: string };
+
+// Keeps each rendered body paired with its source key (body1/body2/body3, ...)
+// through both filter passes below, so a caller pairing a heading to `key`
+// never shifts onto the wrong body when an intermediate section is empty.
+export function cleanupArticleBodySections(sections: ArticleBodySectionInput[]): ArticleBodySectionRendered[] {
  return sections
- .filter((section): section is string => !!section)
- .map((section) => renderArticleBodyHtml(section))
- .filter(Boolean);
+ .filter((section): section is { key: string; text: string } => !!section.text)
+ .map((section) => ({ key: section.key, html: renderArticleBodyHtml(section.text) }))
+ .filter((section) => !!section.html);
 }

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -747,7 +747,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  const nb = parseInt(b.replace('body', ''), 10);
  return na - nb;
  }) : [];
- const bodySections = cleanupArticleBodySections(allBodyKeys.map(k => localizedBody?.[k]));
+ const bodySections = cleanupArticleBodySections(allBodyKeys.map(k => ({ key: k, text: localizedBody?.[k] })));
  const canonicalPath = withTrailingSlash(urlPath);
  const full = `${BASE_URL}${canonicalPath}`;
  const imgU = `${BASE_URL}${en.img}`;
@@ -900,7 +900,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  ldObj.dateModified = normalizeDateTime(en.dateMod || en.datePub || todayIso);
 
  // articleBody excerpt + wordCount (Google Discover uses this for topic relevance)
- const fullBodyHtml = bodySections.join('\n');
+ const fullBodyHtml = bodySections.map((s) => s.html).join('\n');
  const excerpt = extractExcerpt(fullBodyHtml, 500);
  if (excerpt) {
  ldObj.articleBody = excerpt;
@@ -1039,13 +1039,18 @@ ${href}
  en.keywords,
  SECTION.name,
  );
- const bodyWordCount = countWords(bodySections.join(' '));
+ const bodyWordCount = countWords(bodySections.map((s) => s.html).join(' '));
  // bodySections are already-rendered HTML (headings/lists/links) from cleanupArticleBodySections;
  // fallbackSections carry plain prose paragraphs that still need escaping + <p> wrapping.
- const bodyDerivedSections = bodySections.map((bodyHtml, i) => ({
- heading: i === 0 ? 'Contesto' : i === 1 ? 'Dettagli operativi' : 'Punti chiave',
- html: bodyHtml,
- }));
+ // Pair each rendered body with its heading by stable key (bodyN, not post-filter
+ // array index) — an empty body2 must not shift body3's html onto body2's heading.
+ const bodyDerivedSections = bodySections.map(({ key, html }) => {
+ const n = parseInt(key.replace(/^body/, ''), 10);
+ return {
+ heading: n === 1 ? 'Contesto' : n === 2 ? 'Dettagli operativi' : 'Punti chiave',
+ html,
+ };
+ });
  const fallbackDerivedSections = fallbackSections.map((section) => ({
  heading: section.heading,
  html: section.paragraphs.map((paragraph) => `<p>${esc(paragraph)}</p>`).join(''),

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -4359,7 +4359,11 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  const localizedBody = articleId
  ? blogBodyByLocale[localeKey as 'it' | 'en' | 'de' | 'fr'][articleId] ?? blogBodyByLocale.it[articleId]
  : undefined;
- const blogBodySections = cleanupArticleBodySections([localizedBody?.body1, localizedBody?.body2, localizedBody?.body3]);
+ const blogBodySections = cleanupArticleBodySections([
+ { key: 'body1', text: localizedBody?.body1 },
+ { key: 'body2', text: localizedBody?.body2 },
+ { key: 'body3', text: localizedBody?.body3 },
+ ]);
  const blogFallbackSections = buildArticleSeoSections(
  localeKey as 'it' | 'en' | 'de' | 'fr',
  seoData.ogT,
@@ -4368,10 +4372,13 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  );
  // blogBodySections are already-rendered HTML (headings/lists/links) from cleanupArticleBodySections;
  // blogFallbackSections carry plain prose paragraphs that still need escaping + <p> wrapping.
- const bodyWordCount = blogBodySections.join(' ').replace(/<[^>]+>/g, ' ').split(/\s+/).filter(Boolean).length;
- const blogBodyDerivedSections = blogBodySections.map((bodyHtml, index) => ({
- heading: bodyHeadingByLocale[localeKey][index] ?? bodyHeadingByLocale[localeKey][2],
- html: bodyHtml,
+ const bodyWordCount = blogBodySections.map((s) => s.html).join(' ').replace(/<[^>]+>/g, ' ').split(/\s+/).filter(Boolean).length;
+ // Pair each rendered body with its heading by stable key (not post-filter array
+ // index) — an empty body2 must not shift body3's html onto body2's heading.
+ const bodyKeyHeadingIndex: Record<string, number> = { body1: 0, body2: 1, body3: 2 };
+ const blogBodyDerivedSections = blogBodySections.map(({ key, html }) => ({
+ heading: bodyHeadingByLocale[localeKey][bodyKeyHeadingIndex[key] ?? 2] ?? bodyHeadingByLocale[localeKey][2],
+ html,
  }));
  const blogFallbackDerivedSections = blogFallbackSections.map((section) => ({
  heading: section.heading,

--- a/tests/article-seo-fallback.test.ts
+++ b/tests/article-seo-fallback.test.ts
@@ -4,6 +4,9 @@ import { buildArticleSeoSections, cleanupArticleBodySections } from '@/build-plu
 
 const wordCount = (value: string) => value.split(/\s+/).filter(Boolean).length;
 
+const keyed = (texts: Array<string | undefined>) =>
+  texts.map((text, i) => ({ key: `body${i + 1}`, text }));
+
 describe('article SEO fallback builder', () => {
   it('builds rich Italian fallback sections with enough semantic depth', () => {
     const sections = buildArticleSeoSections(
@@ -23,27 +26,54 @@ describe('article SEO fallback builder', () => {
   });
 
   it('renders markdown-like article body sections into semantic HTML', () => {
-    const sections = cleanupArticleBodySections([
+    const sections = cleanupArticleBodySections(keyed([
       '## Titolo\n**Testo** con [link](https://example.com) e `code`',
       undefined,
       '- punto uno\n- punto due',
-    ]);
+    ]));
 
-    expect(sections).toEqual([
+    expect(sections.map((s) => s.html)).toEqual([
       '<h3>Titolo</h3><p><strong>Testo</strong> con <a href="https://example.com">link</a> e <code>code</code></p>',
       '<ul><li>punto uno</li><li>punto due</li></ul>',
     ]);
   });
 
   it('escapes HTML-special characters in body markdown before adding markup', () => {
-    const sections = cleanupArticleBodySections(['Tom & Jerry <script>alert(1)</script>']);
+    const sections = cleanupArticleBodySections(keyed(['Tom & Jerry <script>alert(1)</script>']));
 
-    expect(sections).toEqual(['<p>Tom &amp; Jerry &lt;script&gt;alert(1)&lt;/script&gt;</p>']);
+    expect(sections.map((s) => s.html)).toEqual(['<p>Tom &amp; Jerry &lt;script&gt;alert(1)&lt;/script&gt;</p>']);
   });
 
   it('renders single-# headings (used by some articles) as h3, not literal text', () => {
-    const sections = cleanupArticleBodySections(['# Titolo principale\nTesto del paragrafo.']);
+    const sections = cleanupArticleBodySections(keyed(['# Titolo principale\nTesto del paragrafo.']));
 
-    expect(sections).toEqual(['<h3>Titolo principale</h3><p>Testo del paragrafo.</p>']);
+    expect(sections.map((s) => s.html)).toEqual(['<h3>Titolo principale</h3><p>Testo del paragrafo.</p>']);
+  });
+
+  it('preserves the source key when an intermediate body section is empty, so heading pairing never shifts (#3205)', () => {
+    const sections = cleanupArticleBodySections(keyed([
+      'Testo del primo blocco.',
+      undefined, // body2 empty/dropped — must not shift body3's html onto body2's slot
+      'Testo del terzo blocco.',
+    ]));
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].key).toBe('body1');
+    expect(sections[0].html).toContain('primo blocco');
+    expect(sections[1].key).toBe('body3');
+    expect(sections[1].html).toContain('terzo blocco');
+
+    // Mirrors the caller-side pairing in staticPagesPlugin.ts / ogPagesPlugin.ts:
+    // heading must be looked up by stable key, not by the post-filter array index
+    // (which would wrongly pair body3's html with body2's heading).
+    const headingByKey: Record<string, string> = {
+      body1: 'Contesto',
+      body2: 'Dettagli operativi',
+      body3: 'Punti chiave',
+    };
+    const paired = sections.map((s) => ({ heading: headingByKey[s.key], html: s.html }));
+
+    expect(paired[0].heading).toBe('Contesto');
+    expect(paired[1].heading).toBe('Punti chiave');
   });
 });


### PR DESCRIPTION
## Implementato

- `cleanupArticleBodySections` (`build-plugins/articleSeoFallback.ts`) now takes `{key, text}` pairs and returns `{key, html}` pairs, carrying the source key (`body1`/`body2`/`body3`, ...) through both filter passes (drop-falsy-input, drop-empty-render).
- `staticPagesPlugin.ts` (`blogBodyDerivedSections`) and `ogPagesPlugin.ts` (`bodyDerivedSections`) — the sibling with the identical construct, same funnel — now look up the heading by the section's stable key instead of its post-filter array index. An empty `body2` no longer shifts `body3`'s rendered html onto `body2`'s heading slot.
- Extended `tests/article-seo-fallback.test.ts`: updated the 3 existing `cleanupArticleBodySections` tests for the new keyed signature, and added a regression test that exercises the exact bug scenario (body2 empty/falsy) and asserts body1/body3 keep their correct heading via key-based pairing.
- `npx vitest run tests/article-seo-fallback.test.ts` → 5/5 passed.

## Non implementato (ancora)

Nessuno

Closes #3205