### PR TITLE
fix(create-article): prompt-level guard against unescaped quotes breaking JSON output

### DIFF
--- a/scripts/batch-add-faq-to-articles.mjs
+++ b/scripts/batch-add-faq-to-articles.mjs
@@ -28,7 +28,7 @@ const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, '..');
 import { callLLM, callSingleModel, AI_MODELS, initScoreStore, getStats, flushScores, resetExhaustedModel } from './lib/ai-models.mjs';
 import { freeTranslateWithRetry, logCascadeSummary } from './lib/free-translate.mjs';
-import { stripCodeFences, findMatchingClose, fixJsonStringBody } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, findMatchingClose, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT } from './lib/llm-json-repair.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 
 // ── CLI argument parsing ─────────────────────────────────────
@@ -471,6 +471,8 @@ REGOLE:
 ARTICOLO:
 ${bodyText.slice(0, 6000)}
 
+${JSON_QUOTE_SAFETY_RULE_IT}
+
 Rispondi SOLO con un JSON array (no markdown, no code fences):
 [{"q":"Domanda 1?","a":"Risposta 1."},{"q":"Domanda 2?","a":"Risposta 2."}]`;
 
@@ -522,6 +524,8 @@ REGOLE:
 
 ARTICOLO:
 ${bodyText.slice(0, 6000)}
+
+${JSON_QUOTE_SAFETY_RULE_IT}
 
 Rispondi SOLO con un JSON array (no markdown, no code fences):
 [{"q":"Domanda 1?","a":"Risposta 1."},{"q":"Domanda 2?","a":"Risposta 2."}]`;

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2118,7 +2118,8 @@ async function splitBodyIntoSections(fullBody, title) {
         'Sei un redattore italiano. Dividi il testo fornito in ESATTAMENTE 3 sezioni bilanciate ' +
         '(body1, body2, body3) senza aggiungere, riassumere o rimuovere contenuto — solo suddividere ' +
         'nei punti più naturali. Preserva ESATTAMENTE la formattazione markdown esistente (grassetto ' +
-        '**testo**, elenchi, e link interni nel formato [testo](nav:azione)). Rispondi SOLO in JSON.',
+        '**testo**, elenchi, e link interni nel formato [testo](nav:azione)). Rispondi SOLO in JSON.\n\n' +
+        JSON_QUOTE_SAFETY_RULE_IT,
     },
     { role: 'user', content: `Titolo: ${title}\n\nTesto da dividere:\n${text}` },
   ];

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -76,7 +76,7 @@ import { translateFieldFreeMt } from './lib/article-free-mt.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
-import { stripCodeFences, fixJsonStringBody } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT } from './lib/llm-json-repair.mjs';
 import {
   factCheckFingerprint,
   totalMajorWeight,
@@ -4307,6 +4307,8 @@ REGOLA FONDAMENTALE: Ogni fatto, dato, legge, data, cifra e istituzione nel tuo 
 
 QUANDO LA FONTE NON CONTIENE UN DATO: scrivi "non ancora specificato", "in fase di definizione", o ometti il dettaglio. NON inventare numeri, date o riferimenti normativi per riempire il testo.
 
+${JSON_QUOTE_SAFETY_RULE_IT}
+
 Rispondi SOLO con JSON valido, senza markdown.` },
     // Phase 3 prior: inject winner-fingerprint as additive system context.
     // Skipped when data/article-performance.json is missing or empty so the
@@ -4387,7 +4389,7 @@ Rispondi SOLO con JSON valido, senza markdown.` },
       try {
         const retryRaw = await callLLM(
           [
-            { role: 'system', content: 'Sei un giornalista finanziario esperto. Rispondi SOLO con JSON valido senza markdown.' },
+            { role: 'system', content: `Sei un giornalista finanziario esperto. Rispondi SOLO con JSON valido senza markdown.\n\n${JSON_QUOTE_SAFETY_RULE_IT}` },
             {
               role: 'user',
               content: `Riformula il seguente titolo in italiano per il sito Frontaliere Ticino.\n\nTITOLO ATTUALE (${firstCap.originalLength} caratteri, troppo lungo):\n${itContent.title}\n\nVINCOLI OBBLIGATORI:\n- MASSIMO 60 caratteri totali (target 50-55).\n- NON includere il suffisso " | Frontaliere Ticino" (verrà aggiunto automaticamente).\n- Mantieni la keyword principale e il significato.\n- Stile giornalistico, niente clickbait.\n\nRispondi con JSON: {"title": "..."}`,
@@ -4617,8 +4619,9 @@ async function translateContentFreeMt(sourceLang, targetLang, targetLabel, sourc
 
 async function translateArticle(data) {
   async function callWithRetry(prompt, maxTokens, label) {
+    const safePrompt = `${prompt}\n\n${JSON_QUOTE_SAFETY_RULE_IT}`;
     const raw = await callLLM(
-      [{ role: 'user', content: prompt }],
+      [{ role: 'user', content: safePrompt }],
       { temperature: 0.5, maxTokens, jsonMode: true },
     );
     try {
@@ -4631,7 +4634,7 @@ async function translateArticle(data) {
       const retry1Tokens = isTruncation ? Math.max(maxTokens * 3, 12000) : maxTokens + 4000;
       console.error(`  🔄 Retry ${label} con maxTokens=${retry1Tokens}${isTruncation ? ' (troncamento rilevato)' : ''}...`);
       const raw2 = await callLLM(
-        [{ role: 'user', content: prompt }],
+        [{ role: 'user', content: safePrompt }],
         { temperature: 0.5, maxTokens: retry1Tokens, jsonMode: true },
       );
       try {
@@ -4643,7 +4646,7 @@ async function translateArticle(data) {
         // Third attempt with maximum tokens
         const retry2Tokens = 16000;
         const raw3 = await callLLM(
-          [{ role: 'user', content: prompt }],
+          [{ role: 'user', content: safePrompt }],
           { temperature: 0.3, maxTokens: retry2Tokens, jsonMode: true },
         );
         try {

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -1479,6 +1479,8 @@ CRITERI DI SELEZIONE (in ordine di priorità):
 6. NO SPORT: Evita risultati sportivi, partite, campionati
 7. SPECIFICITÀ TICINO: La notizia deve riguardare il Canton Ticino o la regione di confine
 
+${JSON_QUOTE_SAFETY_RULE_IT}
+
 Rispondi con un JSON object (no markdown, no code fences):
 {
   "selectedIndex": <numero dell'headline scelta>,
@@ -1507,6 +1509,8 @@ CRITERI DI SELEZIONE (in ordine di priorità):
 6. NO INTRATTENIMENTO: Evita gossip, spettacolo, celebrità senza rilevanza politico-economica
 7. RESPIRO NAZIONALE: La notizia può riguardare qualsiasi cantone o le istituzioni federali; non limitarti al Ticino.
 8. ⚠️ NO TEMI FRONTALIERI (CRITICO): SCARTA le headline il cui ARGOMENTO PRINCIPALE è esclusivamente frontaliero (permesso G/B/C, ristorni Ticino-Italia, imposta alla fonte frontalieri, dogane/valichi e pendolarismo IT-CH, telelavoro frontalieri, accordo frontalieri IT-CH, soglia 20 km). Appartengono alla sezione frontalieri separata; qui sarebbero duplicati fuori scopo. ATTENZIONE: una riforma o statistica NAZIONALE (es. AVS/LPP, LAMal, mercato del lavoro, Consiglio federale) che menziona i frontalieri come categoria tra quelle impattate è RILEVANTE — il tema principale è nazionale, non frontaliero. Scegli temi a interesse nazionale generale.
+
+${JSON_QUOTE_SAFETY_RULE_IT}
 
 Rispondi con un JSON object (no markdown, no code fences):
 {
@@ -2728,6 +2732,8 @@ CRITERI DI GIUDIZIO:
 - PASS = nessun fatto verificabilmente falso, al massimo minor e fino a 2 major
 
 ATTENZIONE: se hai dubbi su un fatto, è MEGLIO segnalarlo come "major" che ignorarlo. Un falso positivo (segnalare un fatto vero come sospetto) è preferibile a un falso negativo (non segnalare un fatto falso).
+
+${JSON_QUOTE_SAFETY_RULE_IT}
 
 Rispondi SOLO in JSON valido:
 {

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2729,6 +2729,8 @@ CRITERI DI GIUDIZIO:
 
 ATTENZIONE: se hai dubbi su un fatto, è MEGLIO segnalarlo come "major" che ignorarlo. Un falso positivo (segnalare un fatto vero come sospetto) è preferibile a un falso negativo (non segnalare un fatto falso).
 
+${JSON_QUOTE_SAFETY_RULE_IT}
+
 Rispondi SOLO in JSON valido:
 {
   "verdict": "PASS" | "FAIL",

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -12,6 +12,20 @@ export function stripCodeFences(raw) {
   return String(raw).replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
 }
 
+/**
+ * Prompt-side guard against the recurring "quoted term echoed from the
+ * source" JSON corruption (e.g. a headline quoting «tassa sulla salute» —
+ * see issue #3282, run 28600753915: 6/6 attempts across 6 different models
+ * — gpt-4.1, gemini-2.5-flash, gpt-4.1-nano, groq/gpt-oss-120b, gpt-4o-mini,
+ * plus every free fallback — hit the identical corruption, proving this is
+ * a prompt gap, not a model-quality issue the fallback chain can route
+ * around). Append/inline this into every prompt whose response is
+ * JSON.parse()'d, so models are told up front how to emit an internal
+ * double quote instead of leaving it to the fixJsonStringBody() heuristic
+ * below to guess after the fact.
+ */
+export const JSON_QUOTE_SAFETY_RULE_IT = '⚠️ VIRGOLETTE NEI VALORI JSON: se riporti un termine o una frase citata tra virgolette (es. la cosiddetta "tassa sulla salute"), NON usare mai il carattere " dentro un valore stringa JSON — usa virgolette singole (\'tassa sulla salute\') o guillemet («tassa sulla salute»). Se devi proprio usare virgolette doppie interne, escapale sempre con \\" (es. "la cosiddetta \\"tassa sulla salute\\""). Una virgoletta doppia non escapata dentro una stringa rende l\'intero JSON non valido e scarta l\'intero articolo.';
+
 /** Index of the bracket/brace matching the opener at openIdx, quote/escape aware. */
 export function findMatchingClose(src, openIdx) {
   const open = src[openIdx];


### PR DESCRIPTION
## Implementato

Root cause of #3282: the "Generate Blog Article" workflow failed with `Expected ',' or '}' after property value in JSON` on a headline quoting «tassa sulla salute». Full CI log analysis (run 28600753915) showed the IDENTICAL parse error across all 6 attempted models (gpt-4.1, gemini-2.5-flash, gpt-4.1-nano, groq/gpt-oss-120b, gpt-4o-mini, plus every free fallback within each) — proving this is a prompt-engineering gap, not a model-quality issue the existing fallback chain can route around. No prompt ever told models how to escape a double quote embedded in a JSON string value when echoing a quoted source phrase, so `fixJsonStringBody()`'s post-hoc repair heuristic (already hardened for exactly this pattern) was chasing a moving target instead of preventing the malformed output at the source.

- Added `JSON_QUOTE_SAFETY_RULE_IT` to `scripts/lib/llm-json-repair.mjs` — an explicit instruction telling the model to use single quotes/guillemets or `\"`-escape when echoing a quoted phrase inside a JSON string value.
- Injected it into every `create-article.mjs` prompt whose response is `JSON.parse()`'d:
  - main IT-generation system prompt
  - IT title-cap retry system prompt
  - the shared `callWithRetry()` choke point (covers EN/DE/FR translation, missing-field retry, translation-check retry, and title-length retry — all 3 internal attempts)
  - `splitBodyIntoSections()` — flagged by round-1 review: same `JSON.parse(repairLlmJson(...))` pattern, reached from the separate journalist-publish pipeline (`publish-journalist-article.mjs:deriveJournalistContent` → `.github/workflows/publish-journalist-articles.yml`), not covered by the first pass despite already having `jsonMode`+`jsonSchema` (which didn't protect the original #3282 call site either).
  - `llmFactCheck()` — flagged by round-2 review: prompt echoes the full article body and explicitly instructs the model to quote phrases from it into `issues[].claim`/`reason` (the prompt's own example issue-phrase is the literal `"Tassa sulla salute"` headline that caused #3282), and its `JSON.parse()` at the call site has no `repairLlmJson()` guard at all — same crash-the-whole-generation failure class (parse failure isn't absorbed; retries exhaust across models then throws per Non-Negotiable #1 "never publish unverified").
- Sibling-pattern fix (same construct, same file class): `scripts/batch-add-faq-to-articles.mjs`'s `generateFaqIT` and `generateTopUpFaqIT` build JSON arrays from article body text the same way — added the same guard to both prompts.
- Confirmed no other `JSON.parse(repairLlmJson(...))`/`fixJsonStringBody`/`repairJsonArray` call sites exist outside `scripts/create-article.mjs` and `scripts/batch-add-faq-to-articles.mjs` (`rg -l "repairLlmJson|fixJsonStringBody|repairJsonArray" scripts build-plugins services functions server`), so the guard now covers every JSON-parsed LLM prompt in this class.
- `node --check` on all touched files, plus `npx vitest run tests/scripts/llm-json-repair.test.ts tests/create-article-template.test.ts tests/create-article-gates.test.ts tests/scripts/create-article-integration.test.ts` — 91 tests green.
- GitNexus impact: `callWithRetry` (private closure, 0 upstream callers), `splitBodyIntoSections` (private closure, journalist-publish path only), `llmFactCheck` (prompt-string-only change, no signature/contract change), and `generateFaqIT` (6 upstream, LOW risk, only prompt string content changed) all LOW risk.

## Non implementato (ancora)

Nessuno.

Deferred nit (non funnel-critical, round-2 review): `HEADLINE_SELECTION_PROMPT`'s `reason` field can echo a quoted phrase and lacks the guard too, but both its `JSON.parse()` call sites already have regex-based recovery (`idxMatch`/`reasonMatch`) that degrades gracefully to a skipped/clamped batch instead of throwing — no funnel impact, dropped per REVIEW.md nit-disposition rule.

Closes #3282