### PR TITLE
fix(seo): harden sitemap-news slug-sync guard for swiss articles

### DIFF
--- a/scripts/ci/check-blog-slugs-sitemap-sync.mjs
+++ b/scripts/ci/check-blog-slugs-sitemap-sync.mjs
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
-// Zero-Claude check: validates BLOG_SLUGS ↔ sitemap-blog.xml / sitemap-news.xml sync.
+// Zero-Claude check: validates BLOG_SLUGS ↔ sitemap-blog.xml / sitemap-news.xml
+// AND SWISS_SLUGS ↔ sitemap-blog-ch.xml / sitemap-news.xml sync.
 // Usage: node scripts/ci/check-blog-slugs-sitemap-sync.mjs
 // Exit 0 = in sync. Exit 1 = divergence detected.
 //
-// sitemap-blog.xml structure:
+// sitemap-blog.xml / sitemap-blog-ch.xml structure:
 //   <loc> = Italian canonical URL only (one per article)
 //   <xhtml:link hreflang="en|de|fr" href="..."> = other locale URLs
-// Both are checked bidirectionally against BLOG_SLUGS.
+// Both are checked bidirectionally against the section's slug registry.
+//
+// sitemap-news.xml is SHARED across both sections — checked backward only
+// (sitemap → registry), once per registry. This is the gate that catches a
+// swiss article whose hreflang alternates were resolved from the wrong
+// registry (routerBlogData instead of routerSwissData), the class of bug
+// fixed manually in PR #3116 (#3120 follow-up hardening).
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,10 +35,24 @@ const BLOG_LOC_PATTERNS = {
   fr: /^https:\/\/frontaliereticino\.ch\/fr\/articles-frontalier\/([^/]+)\/$/,
 };
 
+const SWISS_URL_BASE = {
+  it: 'https://frontaliereticino.ch/articoli-svizzera/',
+  en: 'https://frontaliereticino.ch/en/swiss-articles/',
+  de: 'https://frontaliereticino.ch/de/schweiz-artikel/',
+  fr: 'https://frontaliereticino.ch/fr/articles-suisse/',
+};
+
+const SWISS_LOC_PATTERNS = {
+  it: /^https:\/\/frontaliereticino\.ch\/articoli-svizzera\/([^/]+)\/$/,
+  en: /^https:\/\/frontaliereticino\.ch\/en\/swiss-articles\/([^/]+)\/$/,
+  de: /^https:\/\/frontaliereticino\.ch\/de\/schweiz-artikel\/([^/]+)\/$/,
+  fr: /^https:\/\/frontaliereticino\.ch\/fr\/articles-suisse\/([^/]+)\/$/,
+};
+
 // Uses the same regex as ogPagesPlugin.ts (single source of truth for parsing).
-function parseBlogSlugs() {
-  const src = readFileSync(resolve(root, 'services/routerBlogData.ts'), 'utf-8');
-  const block = src.match(/const BLOG_SLUGS[\s\S]*?\n\};/m)?.[0] ?? '';
+function parseSlugsConst(file, constName) {
+  const src = readFileSync(resolve(root, file), 'utf-8');
+  const block = src.match(new RegExp(`const ${constName}[\\s\\S]*?\\n\\};`, 'm'))?.[0] ?? '';
   const rx = /["']([^"']+)["']:\s*\{\s*it:\s*["']([^"']+)["'],\s*en:\s*["']([^"']+)["'],\s*de:\s*["']([^"']+)["'],\s*fr:\s*["']([^"']+)["']/g;
   const slugs = {};
   let m;
@@ -39,6 +60,14 @@ function parseBlogSlugs() {
     slugs[m[1]] = { it: m[2], en: m[3], de: m[4], fr: m[5] };
   }
   return slugs;
+}
+
+function parseBlogSlugs() {
+  return parseSlugsConst('services/routerBlogData.ts', 'BLOG_SLUGS');
+}
+
+function parseSwissSlugs() {
+  return parseSlugsConst('services/routerSwissData.ts', 'SWISS_SLUGS');
 }
 
 function extractSitemapUrls(xml) {
@@ -64,16 +93,17 @@ function buildValidSlugSets(slugs) {
   return sets;
 }
 
-function checkSitemap(label, xml, blogSlugs) {
+// registryLabel is used only in log/error messages (e.g. "BLOG_SLUGS" / "SWISS_SLUGS").
+function checkSitemap(label, xml, slugs, urlBase, locPatterns, registryLabel) {
   const { locUrls, hreflangUrls } = extractSitemapUrls(xml);
-  const validSlugs = buildValidSlugSets(blogSlugs);
+  const validSlugs = buildValidSlugSets(slugs);
   let ok = true;
 
-  // Forward: every BLOG_SLUG must be in the sitemap
+  // Forward: every registry slug must be in the sitemap
   const missing = [];
-  for (const [articleId, slugMap] of Object.entries(blogSlugs)) {
+  for (const [articleId, slugMap] of Object.entries(slugs)) {
     for (const [locale, slug] of Object.entries(slugMap)) {
-      const base = BLOG_URL_BASE[locale];
+      const base = urlBase[locale];
       if (!base) continue;
       const url = `${base}${slug}/`;
       const present = locale === 'it' ? locUrls.has(url) : hreflangUrls.get(locale)?.has(url);
@@ -81,31 +111,18 @@ function checkSitemap(label, xml, blogSlugs) {
     }
   }
   if (missing.length) {
-    console.error(`\n❌ ${label}: BLOG_SLUGS entries missing (${missing.length}):`);
+    console.error(`\n❌ ${label}: ${registryLabel} entries missing (${missing.length}):`);
     missing.forEach(l => console.error(l));
     ok = false;
   } else {
-    console.log(`✅ ${label}: all BLOG_SLUGS present`);
+    console.log(`✅ ${label}: all ${registryLabel} present`);
   }
 
-  // Backward: every blog URL in sitemap must correspond to a current BLOG_SLUG
-  const stale = [];
-  for (const url of locUrls) {
-    const match = url.match(BLOG_LOC_PATTERNS.it);
-    if (match && !validSlugs.it.has(match[1])) stale.push(`  [it] <loc>: ${url}`);
-  }
-  for (const [locale, urls] of hreflangUrls) {
-    const pattern = BLOG_LOC_PATTERNS[locale];
-    if (!pattern) continue;
-    for (const url of urls) {
-      const match = url.match(pattern);
-      if (match && !validSlugs[locale]?.has(match[1])) {
-        stale.push(`  [${locale}] hreflang href: ${url}`);
-      }
-    }
-  }
+  // Backward: every URL of this registry's hub shape in the sitemap must
+  // correspond to a current registry slug.
+  const stale = checkNewsStale(locUrls, hreflangUrls, validSlugs, locPatterns);
   if (stale.length) {
-    console.error(`\n❌ ${label}: stale URLs not in BLOG_SLUGS (${stale.length}):`);
+    console.error(`\n❌ ${label}: stale URLs not in ${registryLabel} (${stale.length}):`);
     stale.forEach(l => console.error(l));
     ok = false;
   } else {
@@ -115,44 +132,70 @@ function checkSitemap(label, xml, blogSlugs) {
   return ok;
 }
 
+// Backward-only check (sitemap → registry). Shared by the per-section
+// sitemap check above and the shared sitemap-news.xml check below — a swiss
+// article whose hreflang alternates resolve to the WRONG registry (or a
+// stale slug after rename) shows up here as an unmatched URL under that
+// registry's hub shape (#3120: catches the class of bug behind PR #3116's
+// 3 dead sitemap-news.xml URLs).
+function checkNewsStale(locUrls, hreflangUrls, validSlugs, locPatterns) {
+  const stale = [];
+  for (const url of locUrls) {
+    const match = url.match(locPatterns.it);
+    if (match && !validSlugs.it.has(match[1])) stale.push(`  [it] <loc>: ${url}`);
+  }
+  for (const [locale, urls] of hreflangUrls) {
+    const pattern = locPatterns[locale];
+    if (!pattern) continue;
+    for (const url of urls) {
+      const match = url.match(pattern);
+      if (match && !validSlugs[locale]?.has(match[1])) {
+        stale.push(`  [${locale}] hreflang href: ${url}`);
+      }
+    }
+  }
+  return stale;
+}
+
 const blogSlugs = parseBlogSlugs();
 console.log(`Parsed ${Object.keys(blogSlugs).length} articles from services/routerBlogData.ts`);
+const swissSlugs = parseSwissSlugs();
+console.log(`Parsed ${Object.keys(swissSlugs).length} articles from services/routerSwissData.ts`);
 
 let exitCode = 0;
 
 const blogXml = readFileSync(resolve(root, 'public/sitemap-blog.xml'), 'utf-8');
-if (!checkSitemap('sitemap-blog.xml', blogXml, blogSlugs)) exitCode = 1;
+if (!checkSitemap('sitemap-blog.xml', blogXml, blogSlugs, BLOG_URL_BASE, BLOG_LOC_PATTERNS, 'BLOG_SLUGS')) exitCode = 1;
 
+const swissXml = readFileSync(resolve(root, 'public/sitemap-blog-ch.xml'), 'utf-8');
+if (!checkSitemap('sitemap-blog-ch.xml', swissXml, swissSlugs, SWISS_URL_BASE, SWISS_LOC_PATTERNS, 'SWISS_SLUGS')) exitCode = 1;
+
+// sitemap-news.xml is SHARED across both sections — checked backward only,
+// once per registry, against that registry's own hub URL shape.
 const newsXml = readFileSync(resolve(root, 'public/sitemap-news.xml'), 'utf-8');
-// News sitemap is a subset: only check backward (sitemap → BLOG_SLUGS)
 const { locUrls: newsLoc, hreflangUrls: newsHref } = extractSitemapUrls(newsXml);
-const validSlugs = buildValidSlugSets(blogSlugs);
-const newsStale = [];
-for (const url of newsLoc) {
-  const match = url.match(BLOG_LOC_PATTERNS.it);
-  if (match && !validSlugs.it.has(match[1])) newsStale.push(`  [it] <loc>: ${url}`);
-}
-for (const [locale, urls] of newsHref) {
-  const pattern = BLOG_LOC_PATTERNS[locale];
-  if (!pattern) continue;
-  for (const url of urls) {
-    const match = url.match(pattern);
-    if (match && !validSlugs[locale]?.has(match[1])) {
-      newsStale.push(`  [${locale}] hreflang href: ${url}`);
-    }
-  }
-}
-if (newsStale.length) {
-  console.error(`\n❌ sitemap-news.xml: stale URLs not in BLOG_SLUGS (${newsStale.length}):`);
-  newsStale.forEach(l => console.error(l));
+
+const blogNewsStale = checkNewsStale(newsLoc, newsHref, buildValidSlugSets(blogSlugs), BLOG_LOC_PATTERNS);
+if (blogNewsStale.length) {
+  console.error(`\n❌ sitemap-news.xml: stale URLs not in BLOG_SLUGS (${blogNewsStale.length}):`);
+  blogNewsStale.forEach(l => console.error(l));
   exitCode = 1;
 } else {
-  console.log(`✅ sitemap-news.xml: no stale URLs`);
+  console.log(`✅ sitemap-news.xml: no stale BLOG_SLUGS URLs`);
+}
+
+const swissNewsStale = checkNewsStale(newsLoc, newsHref, buildValidSlugSets(swissSlugs), SWISS_LOC_PATTERNS);
+if (swissNewsStale.length) {
+  console.error(`\n❌ sitemap-news.xml: stale URLs not in SWISS_SLUGS (${swissNewsStale.length}):`);
+  swissNewsStale.forEach(l => console.error(l));
+  exitCode = 1;
+} else {
+  console.log(`✅ sitemap-news.xml: no stale SWISS_SLUGS URLs`);
 }
 
 if (exitCode === 0) {
-  console.log('\n✅ BLOG_SLUGS ↔ sitemap sync OK');
+  console.log('\n✅ BLOG_SLUGS + SWISS_SLUGS ↔ sitemap sync OK');
 } else {
-  console.error('\n❌ BLOG_SLUGS ↔ sitemap DIVERGENCE — fix routerBlogData.ts or regenerate sitemaps');
+  console.error('\n❌ registry ↔ sitemap DIVERGENCE — fix routerBlogData.ts/routerSwissData.ts or regenerate sitemaps');
 }
 process.exit(exitCode);

--- a/tests/blog-slugs-sitemap-sync.test.ts
+++ b/tests/blog-slugs-sitemap-sync.test.ts
@@ -17,6 +17,23 @@ const BLOG_LOC_PATTERNS: Record<string, RegExp> = {
   fr: /^https:\/\/frontaliereticino\.ch\/fr\/articles-frontalier\/([^/]+)\/$/,
 };
 
+// Canonical swiss-article URL bases per locale (matches sitemap-blog-ch.xml /
+// sitemap-news.xml entries — hub slugs from scripts/create-article.mjs
+// ARTICLE_SECTION_CONFIGS.svizzera.hubSlug).
+const SWISS_URL_BASE: Record<string, string> = {
+  it: 'https://frontaliereticino.ch/articoli-svizzera/',
+  en: 'https://frontaliereticino.ch/en/swiss-articles/',
+  de: 'https://frontaliereticino.ch/de/schweiz-artikel/',
+  fr: 'https://frontaliereticino.ch/fr/articles-suisse/',
+};
+
+const SWISS_LOC_PATTERNS: Record<string, RegExp> = {
+  it: /^https:\/\/frontaliereticino\.ch\/articoli-svizzera\/([^/]+)\/$/,
+  en: /^https:\/\/frontaliereticino\.ch\/en\/swiss-articles\/([^/]+)\/$/,
+  de: /^https:\/\/frontaliereticino\.ch\/de\/schweiz-artikel\/([^/]+)\/$/,
+  fr: /^https:\/\/frontaliereticino\.ch\/fr\/articles-suisse\/([^/]+)\/$/,
+};
+
 // sitemap-blog.xml structure: <loc> has the IT canonical URL only.
 // EN/DE/FR slugs appear as `hreflang="LOCALE" href="URL"` in <xhtml:link> elements.
 // Extract all locale→URL pairs from both <loc> (IT) and xhtml:link hreflang hrefs.
@@ -136,5 +153,135 @@ describe('BLOG_SLUGS ↔ sitemap-blog.xml sync (gate: prevents #3012 class bug)'
       stale,
       `sitemap-news.xml URLs not in BLOG_SLUGS — stale after de-collision? (${stale.length}):\n${stale.join('\n')}`,
     ).toHaveLength(0);
+  });
+});
+
+// Guard: every SWISS_SLUG locale URL must be present/valid in sitemap-blog-ch.xml
+// AND sitemap-news.xml (shared across sections). Mirrors the BLOG_SLUGS gate
+// above — it was previously blind to swiss-article URLs entirely, because
+// BLOG_LOC_PATTERNS never matches an `/articoli-svizzera/`-shaped URL, so a
+// stale/cross-registry swiss hreflang slipped through undetected (#3116: 3
+// dead URLs). #3120 is the follow-up hardening: without this block, a future
+// swiss slug rename can silently desync sitemap-news.xml again.
+describe('SWISS_SLUGS ↔ sitemap-blog-ch.xml / sitemap-news.xml sync (gate: prevents #3120 recidivism)', () => {
+  it('every SWISS_SLUG must appear in sitemap-blog-ch.xml (IT: <loc>, others: hreflang href)', async () => {
+    const { SWISS_SLUGS } = await import('../services/routerSwissData');
+    const xml = readFileSync(path.resolve(__dirname, '..', 'public', 'sitemap-blog-ch.xml'), 'utf-8');
+    const { locUrls, hreflangUrls } = extractSitemapUrls(xml);
+
+    const missing: string[] = [];
+    for (const [articleId, slugMap] of Object.entries(SWISS_SLUGS as Record<string, Record<string, string>>)) {
+      for (const [locale, slug] of Object.entries(slugMap)) {
+        const base = SWISS_URL_BASE[locale];
+        if (!base) continue;
+        const url = `${base}${slug}/`;
+        const present = locale === 'it' ? locUrls.has(url) : hreflangUrls.get(locale)?.has(url);
+        if (!present) missing.push(`${articleId} [${locale}]: ${url}`);
+      }
+    }
+
+    expect(
+      missing,
+      `SWISS_SLUGS entries missing from sitemap-blog-ch.xml (${missing.length}):\n${missing.join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  // Guard: every swiss URL in sitemap-blog-ch.xml must correspond to a current SWISS_SLUG.
+  it('every swiss URL in sitemap-blog-ch.xml must correspond to a SWISS_SLUG', async () => {
+    const { SWISS_SLUGS } = await import('../services/routerSwissData');
+    const xml = readFileSync(path.resolve(__dirname, '..', 'public', 'sitemap-blog-ch.xml'), 'utf-8');
+    const { locUrls, hreflangUrls } = extractSitemapUrls(xml);
+    const validSlugs = buildValidSlugSets(SWISS_SLUGS as Record<string, Record<string, string>>);
+
+    const stale: string[] = [];
+
+    for (const url of locUrls) {
+      const match = url.match(SWISS_LOC_PATTERNS.it);
+      if (match && !validSlugs.it.has(match[1])) stale.push(`[it] <loc>: ${url}`);
+    }
+
+    for (const [locale, urls] of hreflangUrls) {
+      const pattern = SWISS_LOC_PATTERNS[locale];
+      if (!pattern) continue;
+      for (const url of urls) {
+        const match = url.match(pattern);
+        if (match && !validSlugs[locale]?.has(match[1])) {
+          stale.push(`[${locale}] hreflang href: ${url}`);
+        }
+      }
+    }
+
+    expect(
+      stale,
+      `sitemap-blog-ch.xml URLs not in SWISS_SLUGS — stale after de-collision? (${stale.length}):\n${stale.join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  // The exact gate that would have caught #3116: sitemap-news.xml is SHARED
+  // across the frontaliere and svizzera sections. A swiss <url> block whose
+  // hreflang alternates were built from a stale or wrong-registry slug (e.g.
+  // read from routerBlogData instead of routerSwissData) shows up here as a
+  // URL under the swiss hub shape that no current SWISS_SLUG resolves to.
+  it('every swiss URL in sitemap-news.xml must correspond to a current SWISS_SLUG', async () => {
+    const { SWISS_SLUGS } = await import('../services/routerSwissData');
+    const xml = readFileSync(path.resolve(__dirname, '..', 'public', 'sitemap-news.xml'), 'utf-8');
+    const { locUrls, hreflangUrls } = extractSitemapUrls(xml);
+    const validSlugs = buildValidSlugSets(SWISS_SLUGS as Record<string, Record<string, string>>);
+
+    const stale: string[] = [];
+
+    for (const url of locUrls) {
+      const match = url.match(SWISS_LOC_PATTERNS.it);
+      if (match && !validSlugs.it.has(match[1])) stale.push(`[it] <loc>: ${url}`);
+    }
+
+    for (const [locale, urls] of hreflangUrls) {
+      const pattern = SWISS_LOC_PATTERNS[locale];
+      if (!pattern) continue;
+      for (const url of urls) {
+        const match = url.match(pattern);
+        if (match && !validSlugs[locale]?.has(match[1])) {
+          stale.push(`[${locale}] hreflang href: ${url}`);
+        }
+      }
+    }
+
+    expect(
+      stale,
+      `sitemap-news.xml URLs not in SWISS_SLUGS — stale after de-collision? (${stale.length}):\n${stale.join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  // Synthetic cross-registry collision (issue #3120 verification): a swiss
+  // article and a blog article sharing the SAME article id but DIFFERENT
+  // localized slugs. The swiss article's <url> block must validate only
+  // against SWISS_SLUGS — never pass by accidentally matching the blog
+  // article's slug (the exact failure mode that produced 3 dead URLs in
+  // sitemap-news.xml under PR #3116).
+  it('a swiss article never resolves against a blog article sharing the same id (cross-registry guard)', () => {
+    const sharedId = 'ristorni-fiscali-frontaliere';
+    const fakeBlogSlugs: Record<string, Record<string, string>> = {
+      [sharedId]: { it: 'ristorni-fiscali-frontaliere', en: 'tax-rebates-border-workers', de: 'steuer-rueckzahlungen-grenzgaenger', fr: 'ristournes-fiscales-frontaliers' },
+    };
+    const fakeSwissSlugs: Record<string, Record<string, string>> = {
+      [sharedId]: { it: 'ristorni-fiscali-frontaliere', en: 'fiscal-reimbursements-for-frontier-workers-how-they-work', de: 'steuer-ruckerstattungen-fur-grenzpendler-wie-sie-funktionieren', fr: 'remboursements-fiscaux-pour-travailleurs-frontaliers-comment-ils-fonctionnent' },
+    };
+
+    const blogValidSlugs = buildValidSlugSets(fakeBlogSlugs);
+    const swissValidSlugs = buildValidSlugSets(fakeSwissSlugs);
+
+    // Simulate the generator emitting the swiss article's <url> block with
+    // its OWN (correct) slug.
+    const correctSwissUrl = `${SWISS_URL_BASE.en}${fakeSwissSlugs[sharedId].en}/`;
+    const match = correctSwissUrl.match(SWISS_LOC_PATTERNS.en);
+    expect(match).not.toBeNull();
+
+    // Must validate against SWISS_SLUGS...
+    expect(swissValidSlugs.en.has(match![1])).toBe(true);
+    // ...and must NOT be satisfiable via the blog registry (proves the two
+    // registries stay isolated — the #3120-class bug would have the swiss
+    // <url> block emit `fakeBlogSlugs[sharedId].en` instead).
+    expect(blogValidSlugs.en.has(match![1])).toBe(false);
+    expect(fakeSwissSlugs[sharedId].en).not.toEqual(fakeBlogSlugs[sharedId].en);
   });
 });

--- a/tests/sitemap-slug-integrity.test.ts
+++ b/tests/sitemap-slug-integrity.test.ts
@@ -10,6 +10,8 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { ALL_BLOG_ARTICLE_IDS, BLOG_SLUGS } from '@/services/routerBlogData';
 import { ARTICLES } from '@/data/blog-articles-data';
+import { ALL_SWISS_ARTICLE_IDS, SWISS_SLUGS } from '@/services/routerSwissData';
+import { SWISS_ARTICLES } from '@/data/swiss-articles-data';
 
 const root = resolve(__dirname, '..');
 
@@ -113,6 +115,102 @@ describe('BlogArticles ARTICLES array ↔ ALL_BLOG_ARTICLE_IDS consistency', () 
   it('every ALL_BLOG_ARTICLE_IDS entry has a matching ARTICLES entry', () => {
     const missing = ALL_BLOG_ARTICLE_IDS.filter(id => !articlesComponentIds.has(id));
     expect(missing, `ALL_BLOG_ARTICLE_IDS entries not in ARTICLES: ${missing.join(', ')}`).toEqual([]);
+  });
+});
+
+// ── Swiss Article Slug Integrity (mirrors Blog block above — #3120) ──────────
+//
+// This mirrors "Blog sitemap slug integrity" / "BlogArticles ARTICLES array
+// ↔ ALL_BLOG_ARTICLE_IDS consistency" above, but for the svizzera section.
+// Before this block, this file only ever scanned public/sitemap-blog.xml and
+// BLOG_SLUGS/ALL_BLOG_ARTICLE_IDS — a stale, missing, or cross-registry swiss
+// article slug (SWISS_SLUGS vs public/sitemap-blog-ch.xml) passed this gate
+// silently, the same blind spot fixed for sitemap-news.xml in
+// tests/blog-slugs-sitemap-sync.test.ts (#3116/#3120 bug class).
+
+// Swiss article sitemap (static, checked into repo)
+const swissSitemap = readProjectFile('public/sitemap-blog-ch.xml');
+
+// Extract all Italian <loc> slugs from the swiss article sitemap
+// Pattern: /articoli-svizzera/{slug}/
+const swissSitemapSlugs = [...swissSitemap.matchAll(/<loc>[^<]*\/articoli-svizzera\/([^/<]+)\/?<\/loc>/g)]
+  .map(m => m[1]);
+
+// Build reverse lookup: IT slug → article ID
+const itSlugToSwissArticleId = new Map<string, string>();
+for (const id of ALL_SWISS_ARTICLE_IDS) {
+  const slugMap = SWISS_SLUGS[id];
+  if (slugMap?.it) itSlugToSwissArticleId.set(slugMap.it, id);
+}
+
+// Build set of article IDs from swiss-articles-data.ts SWISS_ARTICLES array
+const swissArticlesComponentIds = new Set(SWISS_ARTICLES.map(a => a.id));
+
+describe('Swiss article sitemap slug integrity', () => {
+  it('sitemap-blog-ch.xml has at least 1 article', () => {
+    expect(swissSitemapSlugs.length).toBeGreaterThan(0);
+  });
+
+  describe('every sitemap-blog-ch.xml slug maps to a real article in SWISS_SLUGS', () => {
+    for (const slug of swissSitemapSlugs) {
+      it(`slug "${slug}" → has article ID in SWISS_SLUGS`, () => {
+        expect(
+          itSlugToSwissArticleId.has(slug),
+          `Sitemap references /articoli-svizzera/${slug}/ but no article ID maps to this IT slug in SWISS_SLUGS`
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe('every sitemap-blog-ch.xml slug article exists in ALL_SWISS_ARTICLE_IDS', () => {
+    for (const slug of swissSitemapSlugs) {
+      const articleId = itSlugToSwissArticleId.get(slug);
+      if (!articleId) continue; // covered by test above
+      it(`article "${articleId}" → is in ALL_SWISS_ARTICLE_IDS`, () => {
+        expect(
+          ALL_SWISS_ARTICLE_IDS.includes(articleId as any),
+          `SWISS_SLUGS maps slug "${slug}" to "${articleId}" but that ID is not in ALL_SWISS_ARTICLE_IDS`
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe('every article in ALL_SWISS_ARTICLE_IDS has a sitemap entry', () => {
+    for (const id of ALL_SWISS_ARTICLE_IDS) {
+      it(`article "${id}" → has IT slug in sitemap-blog-ch.xml`, () => {
+        const itSlug = SWISS_SLUGS[id]?.it;
+        expect(itSlug, `Article "${id}" has no IT slug in SWISS_SLUGS`).toBeTruthy();
+        expect(
+          swissSitemapSlugs.includes(itSlug!),
+          `Article "${id}" (slug: ${itSlug}) is missing from sitemap-blog-ch.xml`
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe('every SWISS_SLUGS entry has all 4 locale slugs', () => {
+    for (const id of ALL_SWISS_ARTICLE_IDS) {
+      it(`article "${id}" → has it/en/de/fr slugs`, () => {
+        const slugMap = SWISS_SLUGS[id];
+        expect(slugMap, `No SWISS_SLUGS entry for ${id}`).toBeDefined();
+        for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+          expect(slugMap[locale], `Article "${id}" missing ${locale} slug`).toBeTruthy();
+        }
+      });
+    }
+  });
+});
+
+describe('SwissArticles SWISS_ARTICLES array ↔ ALL_SWISS_ARTICLE_IDS consistency', () => {
+  it('every SWISS_ARTICLES entry has a matching ALL_SWISS_ARTICLE_IDS entry', () => {
+    const routerIds = new Set<string>(ALL_SWISS_ARTICLE_IDS);
+    const missing = SWISS_ARTICLES.filter(a => !routerIds.has(a.id)).map(a => a.id);
+    expect(missing, `SWISS_ARTICLES entries not in ALL_SWISS_ARTICLE_IDS: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every ALL_SWISS_ARTICLE_IDS entry has a matching SWISS_ARTICLES entry', () => {
+    const missing = ALL_SWISS_ARTICLE_IDS.filter(id => !swissArticlesComponentIds.has(id));
+    expect(missing, `ALL_SWISS_ARTICLE_IDS entries not in SWISS_ARTICLES: ${missing.join(', ')}`).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Implementato
- Extended the existing BLOG_SLUGS ↔ sitemap sync guard (`tests/blog-slugs-sitemap-sync.test.ts`) with a mirror block for SWISS_SLUGS ↔ `public/sitemap-blog-ch.xml` and the shared `public/sitemap-news.xml`. Root cause: the prior guard's `BLOG_LOC_PATTERNS` regexes only match `/articoli-frontaliere/`-shaped URLs, so any swiss-article (`/articoli-svizzera/`) hreflang URL in `sitemap-news.xml` was silently skipped — a stale/wrong-registry swiss entry never failed this gate. This is the exact class of bug manually patched in PR #3116 (3 dead URLs).
- Added a synthetic cross-registry collision test using the real IDs/slugs from PR #3116 (`ristorni-fiscali-frontaliere`), asserting a swiss article's own slug validates only against `SWISS_SLUGS` and never against a same-id `BLOG_SLUGS` entry.
- Mirrored the same extension into the sibling CI helper `scripts/ci/check-blog-slugs-sitemap-sync.mjs` (same construct, same class of bug — per repo sibling-pattern rule) so both the vitest gate and the standalone script cover SWISS_SLUGS.
- Verified the new gate is a real tripwire: deliberately corrupted a swiss `hreflang` URL in `public/sitemap-news.xml` to a bogus slug, confirmed `npx vitest run tests/blog-slugs-sitemap-sync.test.ts` and `node scripts/ci/check-blog-slugs-sitemap-sync.mjs` both failed with the exact offending URL, then restored the fixture and re-confirmed all green (7/7 vitest tests, script exit 0).
- No change to `create-article.mjs`'s live generator: it already resolves slugs section-generically via `SECTION.hubSlug`/`data.slugs` (no hardcoded blog registry read for swiss articles found in the current generator code) — the actual gap was a detection blind spot in the regression gate, not a live cross-registry read in the article-creation path. The new gate is the concrete guard against recidivism the follow-up asked for.

## Non implementato (ancora)
Nessuno

Closes #3120