### PR TITLE
fix(seo): rename-safe ItemList helper + pre-commit parse gate for seo-pages.ts

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -274,6 +274,19 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         run: node scripts/generate-image-thumbnails.mjs
 
+      # Pre-commit parse gate for services/seo/seo-pages.ts (issue #2834,
+      # hotfixed by PR #2833): a prior in-place edit left a missing-comma
+      # ItemList array that reached `main` unvalidated and turned the
+      # vitest gate RED for every branch. `resolve-append-conflicts.sh`
+      # already esbuild-checks conflicted files during rebase, but the
+      # common CLEAN commit path (no conflict — the scenario that actually
+      # broke main) never ran any syntax check. Run it unconditionally here,
+      # BEFORE the commit, so a broken file never gets pushed in the first
+      # place.
+      - name: Validate seo-pages.ts syntax (pre-commit parse gate)
+        if: steps.changes.outputs.has_changes == 'true'
+        run: node scripts/ci/check-seo-pages-syntax.mjs
+
       # Do not run `npm run build:prod` here. This workflow commits generated
       # article source and dispatches deploy.yml, which already assembles the
       # jobs dataset and performs the full Vite/GitHub Pages build. Running the

--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -283,6 +283,13 @@ jobs:
       # broke main) never ran any syntax check. Run it unconditionally here,
       # BEFORE the commit, so a broken file never gets pushed in the first
       # place.
+      #
+      # `has_changes` (step "Check for changes", above) can't false-negative
+      # this away: it's a blanket `git diff --quiet` over the WHOLE working
+      # tree, computed after the "Generate article" step already wrote
+      # seo-pages.ts — so has_changes is true on this run whenever
+      # seo-pages.ts (or anything else) was modified, and false only when
+      # nothing was generated at all (nothing to gate or commit either way).
       - name: Validate seo-pages.ts syntax (pre-commit parse gate)
         if: steps.changes.outputs.has_changes == 'true'
         run: node scripts/ci/check-seo-pages-syntax.mjs

--- a/.github/workflows/publish-journalist-articles.yml
+++ b/.github/workflows/publish-journalist-articles.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Check live internal links of published journalist articles
         run: node scripts/check-journalist-article-links.mjs
 
+      # This pipeline runs registerArticleFiles() (scripts/create-article.mjs)
+      # — the SAME writer of services/seo/seo-pages.ts as generate-article.yml
+      # — so it needs the same pre-commit parse gate (issue #2834): a broken
+      # seo-pages.ts must never be pushed straight to main unvalidated.
+      - name: Validate seo-pages.ts syntax (pre-commit parse gate)
+        run: node scripts/ci/check-seo-pages-syntax.mjs
+
       - name: Commit registered article files (test-gated) + push with rebase-retry
         id: commit
         run: |

--- a/scripts/ci/check-seo-pages-syntax.mjs
+++ b/scripts/ci/check-seo-pages-syntax.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * check-seo-pages-syntax — pre-commit parse gate for
+ * services/seo/seo-pages.ts (and services/seoService.ts, which re-exports
+ * from it).
+ *
+ * Why this exists (issue #2834, hotfixed by PR #2833)
+ * -----------------------------------------------------
+ * An automated article-commit workflow (generate-article.yml /
+ * publish-journalist-articles.yml) can push straight to `main` without ever
+ * running the vitest gate. On 2026-06-24 an in-place edit left two
+ * duplicate ListItem entries in seo-pages.ts's breadcrumb ItemList without a
+ * trailing comma (`} {`) — a hard esbuild parse error
+ * ("Expected \"]\" but found \"{\""). Because the commit was pushed
+ * directly (bot-direct-to-main, same class documented in AGENTS.md "Data-
+ * refresh che committa su main = stesso gate test"), nothing caught it
+ * before it reached `main`: the vitest gate went RED and every branch
+ * inherited it until the manual hotfix.
+ *
+ * `scripts/lib/resolve-append-conflicts.sh` already runs an esbuild parse
+ * check, but ONLY on the git-rebase-conflict path (it's a function invoked
+ * inside conflict resolution). The far more common CLEAN commit path (no
+ * conflict — the exact scenario that broke main) never ran any syntax
+ * check at all. This script closes that gap: run it unconditionally, right
+ * before the commit step, in every workflow that writes to seo-pages.ts.
+ *
+ * Usage: node scripts/ci/check-seo-pages-syntax.mjs
+ * Exit 0 = both files parse cleanly. Exit 1 = parse error — caller MUST
+ * abort the commit/push.
+ */
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const FILES = ['services/seo/seo-pages.ts', 'services/seoService.ts'];
+
+let failed = false;
+
+for (const file of FILES) {
+  if (!existsSync(file)) {
+    console.error(`⚠️  ${file}: not found, skipping`);
+    continue;
+  }
+  try {
+    execFileSync(
+      'npx',
+      ['esbuild', file, '--loader:.ts=ts', '--log-level=warning', '--outfile=/dev/null'],
+      { stdio: 'pipe' },
+    );
+    console.error(`✅ ${file}: parses cleanly`);
+  } catch (err) {
+    failed = true;
+    console.error(`❌ ${file}: esbuild parse/transform FAILED`);
+    const output = [err.stdout, err.stderr]
+      .filter(Boolean)
+      .map((b) => b.toString())
+      .join('\n');
+    console.error(output || err.message);
+  }
+}
+
+if (failed) {
+  console.error(
+    '\n❌ check-seo-pages-syntax: aborting — a broken seo-pages.ts/seoService.ts must never reach main (issue #2834).',
+  );
+  process.exit(1);
+}
+
+console.error('✅ check-seo-pages-syntax: all clear');

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -134,6 +134,7 @@ import { isNonItalianScript, nonItalianScriptRatio } from './lib/itLanguageCheck
 import { checkSemanticNearDuplicate } from './lib/scoring/semanticDedup.mjs';
 import { loadEmbeddingStore, loadEmbeddingMeta } from './lib/scoring/embeddingMatcher.mjs';
 import { appendCatalogEntry } from './generate-journalist-image-catalog.mjs';
+import { appendArticleListItem } from './lib/seo-pages-article-list.mjs';
 
 // ── Smarter generator inputs (Phase 3 — spec 2026-05-06) ───────
 // data/article-performance.json is produced weekly by Phase 1A.
@@ -7186,33 +7187,32 @@ function modifySeoService(data) {
   write(svcFile, svcSrc);
   console.error(`  ✅ ${svcFile}`);
 
-  // 3. ItemList in services/seo/seo-pages.ts — increment numberOfItems + append ListItem
+  // 3. ItemList in services/seo/seo-pages.ts — insert the new article via the
+  // shared, comma-safe helper (scripts/lib/seo-pages-article-list.mjs).
+  // History: a foreign in-place rename edit once string-spliced this array
+  // directly and left a duplicate old-slug entry with a missing comma
+  // (`} {`) → esbuild parse failure → main-red inherited by every branch
+  // (issue #2834, hotfixed by PR #2833). appendArticleListItem always
+  // rebuilds the touched entry (and its trailing comma) from regex capture
+  // groups rather than a blind splice, so that class of corruption is
+  // structurally impossible here; any future rename tooling should reuse
+  // upsertArticleListItem from the same module instead of hand-rolling this.
   const pagesFile = 'services/seo/seo-pages.ts';
-  let pagesSrc = read(pagesFile);
+  const pagesSrc = read(pagesFile);
 
-  const itemCountRe = /("name": "Articoli Frontaliere",\s*"numberOfItems": )(\d+)/;
-  const itemCountMatch = pagesSrc.match(itemCountRe);
-  if (itemCountMatch) {
-    const oldCount = parseInt(itemCountMatch[2], 10);
-    const newCount = oldCount + 1;
-    pagesSrc = pagesSrc.replace(itemCountRe, `$1${newCount}`);
-
-    const headlineStr = String(data.seo.headline || '');
-    const shortTitle = headlineStr.length > 50
-      ? headlineStr.slice(0, 47) + '...'
-      : headlineStr;
-    const newListItem = `          { "@type": "ListItem", "position": ${newCount}, "name": "${shortTitle.replace(/"/g, '\\"')}", "url": \`\${BASE_URL}/articoli-frontaliere/${data.slugs.it}\` }`;
-
-    const lastItemRe = /("url": `\$\{BASE_URL\}\/articoli-frontaliere\/[^`]+` \})\s*\n(\s*\])/;
-    if (lastItemRe.test(pagesSrc)) {
-      pagesSrc = pagesSrc.replace(lastItemRe, `$1,\n${newListItem}\n$2`);
-    } else {
-      console.error('  ⚠️ Could not find last ItemList entry to append new article');
-    }
-    write(pagesFile, pagesSrc);
+  const headlineStr = String(data.seo.headline || '');
+  const shortTitle = headlineStr.length > 50
+    ? headlineStr.slice(0, 47) + '...'
+    : headlineStr;
+  const newPagesSrc = appendArticleListItem(pagesSrc, {
+    name: shortTitle,
+    url: `\${BASE_URL}/articoli-frontaliere/${data.slugs.it}`,
+  });
+  if (newPagesSrc) {
+    write(pagesFile, newPagesSrc);
     console.error(`  ✅ ${pagesFile}`);
   } else {
-    console.error('  ⚠️ Could not find blog ItemList numberOfItems in seo-pages.ts');
+    console.error('  ⚠️ Could not find ItemList in seo-pages.ts — left untouched');
   }
 }
 

--- a/scripts/lib/seo-pages-article-list.mjs
+++ b/scripts/lib/seo-pages-article-list.mjs
@@ -1,0 +1,93 @@
+/**
+ * scripts/lib/seo-pages-article-list.mjs
+ *
+ * Comma-safe helpers for editing the "Articoli Frontaliere" breadcrumb
+ * ItemList in services/seo/seo-pages.ts.
+ *
+ * Incident (issue #2834, hotfixed by PR #2833): a foreign in-place
+ * slug-rename edit string-spliced this array directly and left the OLD-slug
+ * ListItem entry behind, with NO trailing comma between it and its neighbor
+ * (`} {`). esbuild then failed to transform seo-pages.ts
+ * ("Expected \"]\" but found \"{\""), which broke every test/suite importing
+ * services/seoService.ts and turned the vitest gate RED on main for every
+ * branch.
+ *
+ * Both helpers below always rebuild the ONE entry (and its own trailing
+ * comma) they touch from regex capture groups — never a blind substring
+ * splice that assumes where a comma belongs — so this class of
+ * missing-comma corruption is structurally impossible for code that goes
+ * through this module. `upsertArticleListItem` is the rename-safe entry
+ * point: any future slug-rename/migration tooling MUST use it (with
+ * `renameFromUrl`) instead of hand-rolled regex/string-splice, so a rename
+ * REPLACES the existing entry in place rather than leaving a duplicate.
+ */
+
+function escapeRegex(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeJsonString(s) {
+  return String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+const NUMBER_OF_ITEMS_RE = /("name": "Articoli Frontaliere",\s*"numberOfItems": )(\d+)/;
+
+// Matches the LAST ListItem entry in the array — i.e. one immediately
+// followed (modulo whitespace) by the closing `]` of `itemListElement`.
+const LAST_ITEM_RE = /("url": `[^`]*` \})\s*\n(\s*\])/;
+
+/**
+ * Append a new ListItem at the end of the array, incrementing
+ * numberOfItems. Returns the new full source string, or `null` if the
+ * ItemList shape could not be found — callers MUST treat `null` as "left
+ * untouched" and log a warning rather than silently dropping the write.
+ *
+ * @param {string} pagesSrc - current services/seo/seo-pages.ts source
+ * @param {{ name: string, url: string }} item - `url` is the raw template-
+ *   literal body, e.g. `` `${BASE_URL}/articoli-frontaliere/my-slug` ``
+ *   (without the surrounding backticks).
+ */
+export function appendArticleListItem(pagesSrc, { name, url }) {
+  const countMatch = pagesSrc.match(NUMBER_OF_ITEMS_RE);
+  if (!countMatch) return null;
+  const newCount = parseInt(countMatch[2], 10) + 1;
+  let next = pagesSrc.replace(NUMBER_OF_ITEMS_RE, `$1${newCount}`);
+
+  if (!LAST_ITEM_RE.test(next)) return null;
+  const newListItem = `          { "@type": "ListItem", "position": ${newCount}, "name": "${escapeJsonString(name)}", "url": \`${url}\` }`;
+  next = next.replace(LAST_ITEM_RE, `$1,\n${newListItem}\n$2`);
+  return next;
+}
+
+/**
+ * Rename-safe insert-or-replace. If a ListItem whose url === renameFromUrl
+ * exists, REPLACE it in place — same position, same trailing comma (or
+ * lack thereof) read directly off the matched entry, never assumed — so
+ * renaming an article can never leave a duplicate old-slug entry behind.
+ * If the old entry can't be found (already cleaned up / never existed),
+ * falls back to appendArticleListItem so the item is never silently
+ * dropped.
+ *
+ * @param {string} pagesSrc
+ * @param {{ name: string, url: string, renameFromUrl?: string }} item
+ * @returns {string|null} new source, or null if the ItemList shape wasn't found
+ */
+export function upsertArticleListItem(pagesSrc, { name, url, renameFromUrl }) {
+  if (renameFromUrl) {
+    const findRe = new RegExp(
+      '\\{\\s*"@type":\\s*"ListItem",\\s*"position":\\s*(\\d+),\\s*"name":\\s*"(?:[^"\\\\]|\\\\.)*",\\s*"url":\\s*`' +
+        escapeRegex(renameFromUrl) +
+        '`\\s*\\}(,?)'
+    );
+    const m = pagesSrc.match(findRe);
+    if (m) {
+      const position = m[1];
+      const trailingComma = m[2] || '';
+      const replacement = `{ "@type": "ListItem", "position": ${position}, "name": "${escapeJsonString(name)}", "url": \`${url}\` }${trailingComma}`;
+      return pagesSrc.slice(0, m.index) + replacement + pagesSrc.slice(m.index + m[0].length);
+    }
+    // Old entry not found — fall through to append so the rename is never
+    // silently dropped.
+  }
+  return appendArticleListItem(pagesSrc, { name, url });
+}

--- a/scripts/lib/seo-pages-article-list.mjs
+++ b/scripts/lib/seo-pages-article-list.mjs
@@ -16,24 +16,83 @@
  * comma) they touch from regex capture groups — never a blind substring
  * splice that assumes where a comma belongs — so this class of
  * missing-comma corruption is structurally impossible for code that goes
- * through this module. `upsertArticleListItem` is the rename-safe entry
- * point: any future slug-rename/migration tooling MUST use it (with
- * `renameFromUrl`) instead of hand-rolled regex/string-splice, so a rename
- * REPLACES the existing entry in place rather than leaving a duplicate.
+ * through this module. Every match is additionally bounded to the
+ * "Articoli Frontaliere" `itemListElement` block only (see
+ * locateItemListBlock below) — seo-pages.ts is a ~10k-line file with
+ * several other unrelated ItemList/HowTo-step arrays sharing the same
+ * single-line `{ ... "url": ... }` shape; an unbounded regex can match one
+ * of THOSE first and corrupt unrelated structured data (this was caught in
+ * PR review of this very fix, against the real committed file, before an
+ * earlier unbounded version merged). `upsertArticleListItem` is the
+ * rename-safe entry point: any future slug-rename/migration tooling MUST
+ * use it (with `renameFromUrl`) instead of hand-rolled regex/string-splice,
+ * so a rename REPLACES the existing entry in place rather than leaving a
+ * duplicate.
  */
 
 function escapeRegex(s) {
   return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Raw control-code points (0..31, plus DEL=127), built from charCodes
+// rather than a literal backslash-escape range written directly in this
+// source file's regex literal.
+const CONTROL_CHARS_RE = new RegExp(
+  '[' +
+    Array.from({ length: 33 }, (_, i) => (i === 32 ? 127 : i))
+      .map((c) => String.fromCharCode(c))
+      .join('') +
+    ']+',
+);
+
+// Strips raw control characters (newline/tab/etc.) from a string before it
+// is embedded as a JSON string value inside the single-line JS/JSON-LD
+// object literals this module emits. A JS template literal tolerates a raw
+// newline (esbuild parses it fine), but the emitted text is JSON-LD later
+// parsed as strict JSON by browsers/crawlers, where an unescaped control
+// character is invalid. Article headlines/titles are single-line by
+// contract, so stripping (not backslash-escaping) is the correct fix.
 function escapeJsonString(s) {
-  return String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(CONTROL_CHARS_RE, ' ')
+    .trim();
 }
 
 const NUMBER_OF_ITEMS_RE = /("name": "Articoli Frontaliere",\s*"numberOfItems": )(\d+)/;
 
+/**
+ * Locate the "Articoli Frontaliere" `itemListElement` array within the full
+ * seo-pages.ts source, so every regex match below can be bounded to it
+ * instead of scanning the whole file. Returns `{ blockStart, blockEnd }` —
+ * the array's items live in `pagesSrc.slice(blockStart, blockEnd)` — or
+ * `null` if the header (and thus the whole ItemList) can't be found.
+ *
+ * Relies on the array's known, consistent shape (verified against the real
+ * committed file): every ListItem entry is a single line ending in `}` or
+ * `},`, with no nested arrays/multi-line objects inside an entry, so the
+ * first line after the header that is *only* a closing bracket (optionally
+ * with trailing `,`/`;`) is unambiguously the array's own closing `]` — the
+ * same single-line-entry assumption the original inline regex in
+ * scripts/create-article.mjs already relied on, just now made explicit and
+ * bounded instead of implicit and unbounded.
+ */
+function locateItemListBlock(pagesSrc) {
+  const headerMatch = pagesSrc.match(NUMBER_OF_ITEMS_RE);
+  if (!headerMatch) return null;
+  const blockStart = headerMatch.index + headerMatch[0].length;
+  const closeMatch = /\n[ \t]*\][,;]?/.exec(pagesSrc.slice(blockStart));
+  if (!closeMatch) return null;
+  const blockEnd = blockStart + closeMatch.index + closeMatch[0].length;
+  return { blockStart, blockEnd };
+}
+
 // Matches the LAST ListItem entry in the array — i.e. one immediately
 // followed (modulo whitespace) by the closing `]` of `itemListElement`.
+// Applied only within the bounds returned by locateItemListBlock() below —
+// never against the full file — so it cannot match an unrelated array
+// elsewhere in seo-pages.ts.
 const LAST_ITEM_RE = /("url": `[^`]*` \})\s*\n(\s*\])/;
 
 /**
@@ -53,20 +112,28 @@ export function appendArticleListItem(pagesSrc, { name, url }) {
   const newCount = parseInt(countMatch[2], 10) + 1;
   let next = pagesSrc.replace(NUMBER_OF_ITEMS_RE, `$1${newCount}`);
 
-  if (!LAST_ITEM_RE.test(next)) return null;
+  const block = locateItemListBlock(next);
+  if (!block) return null;
+  const blockSrc = next.slice(block.blockStart, block.blockEnd);
+  if (!LAST_ITEM_RE.test(blockSrc)) return null;
+
   const newListItem = `          { "@type": "ListItem", "position": ${newCount}, "name": "${escapeJsonString(name)}", "url": \`${url}\` }`;
-  next = next.replace(LAST_ITEM_RE, `$1,\n${newListItem}\n$2`);
+  const newBlockSrc = blockSrc.replace(LAST_ITEM_RE, `$1,\n${newListItem}\n$2`);
+  next = next.slice(0, block.blockStart) + newBlockSrc + next.slice(block.blockEnd);
   return next;
 }
 
 /**
  * Rename-safe insert-or-replace. If a ListItem whose url === renameFromUrl
- * exists, REPLACE it in place — same position, same trailing comma (or
- * lack thereof) read directly off the matched entry, never assumed — so
- * renaming an article can never leave a duplicate old-slug entry behind.
- * If the old entry can't be found (already cleaned up / never existed),
- * falls back to appendArticleListItem so the item is never silently
- * dropped.
+ * exists (searched only within the "Articoli Frontaliere" ItemList block —
+ * see locateItemListBlock), REPLACE it in place — same position, same
+ * trailing comma (or lack thereof) read directly off the matched entry,
+ * never assumed — so renaming an article can never leave a duplicate
+ * old-slug entry behind, and can never mistakenly rewrite an unrelated
+ * `"url": ...` occurrence elsewhere in the file that happens to share the
+ * same string. If the old entry can't be found within the block (already
+ * cleaned up / never existed), falls back to appendArticleListItem so the
+ * item is never silently dropped.
  *
  * @param {string} pagesSrc
  * @param {{ name: string, url: string, renameFromUrl?: string }} item
@@ -74,20 +141,29 @@ export function appendArticleListItem(pagesSrc, { name, url }) {
  */
 export function upsertArticleListItem(pagesSrc, { name, url, renameFromUrl }) {
   if (renameFromUrl) {
-    const findRe = new RegExp(
-      '\\{\\s*"@type":\\s*"ListItem",\\s*"position":\\s*(\\d+),\\s*"name":\\s*"(?:[^"\\\\]|\\\\.)*",\\s*"url":\\s*`' +
-        escapeRegex(renameFromUrl) +
-        '`\\s*\\}(,?)'
-    );
-    const m = pagesSrc.match(findRe);
-    if (m) {
-      const position = m[1];
-      const trailingComma = m[2] || '';
-      const replacement = `{ "@type": "ListItem", "position": ${position}, "name": "${escapeJsonString(name)}", "url": \`${url}\` }${trailingComma}`;
-      return pagesSrc.slice(0, m.index) + replacement + pagesSrc.slice(m.index + m[0].length);
+    const block = locateItemListBlock(pagesSrc);
+    if (block) {
+      const findRe = new RegExp(
+        '\\{\\s*"@type":\\s*"ListItem",\\s*"position":\\s*(\\d+),\\s*"name":\\s*"(?:[^"\\\\]|\\\\.)*",\\s*"url":\\s*`' +
+          escapeRegex(renameFromUrl) +
+          '`\\s*\\}(,?)'
+      );
+      const blockSrc = pagesSrc.slice(block.blockStart, block.blockEnd);
+      const m = blockSrc.match(findRe);
+      if (m) {
+        const position = m[1];
+        const trailingComma = m[2] || '';
+        const replacement = `{ "@type": "ListItem", "position": ${position}, "name": "${escapeJsonString(name)}", "url": \`${url}\` }${trailingComma}`;
+        const absoluteIndex = block.blockStart + m.index;
+        return (
+          pagesSrc.slice(0, absoluteIndex) +
+          replacement +
+          pagesSrc.slice(absoluteIndex + m[0].length)
+        );
+      }
     }
-    // Old entry not found — fall through to append so the rename is never
-    // silently dropped.
+    // Old entry not found (or block not located) — fall through to append
+    // so the rename is never silently dropped.
   }
   return appendArticleListItem(pagesSrc, { name, url });
 }

--- a/tests/scripts/check-seo-pages-syntax.test.ts
+++ b/tests/scripts/check-seo-pages-syntax.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+/**
+ * Unit tests for scripts/ci/check-seo-pages-syntax.mjs — the pre-commit
+ * parse gate added for issue #2834 (hotfixed by PR #2833: a prior in-place
+ * edit left a missing-comma ItemList array in services/seo/seo-pages.ts
+ * that reached `main` unvalidated and red-gated vitest for every branch).
+ *
+ * Spawns the real script against a temp directory containing minimal
+ * fixture files at the exact relative paths it checks, so we can prove:
+ *  (a) it exits 0 on valid files,
+ *  (b) it exits 1 — fast, with the exact incident's error signature — on a
+ *      deliberately broken seo-pages.ts fixture reproducing the #2834 shape
+ *      (two ListItem entries joined by `} {`, no comma).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SCRIPT = resolve('scripts/ci/check-seo-pages-syntax.mjs');
+
+const VALID_SEO_PAGES = `const BASE_URL = 'https://frontaliereticino.ch';
+export const SEO_PAGES = [
+ {
+ "@context": "https://schema.org",
+ "@type": "ItemList",
+ "name": "Articoli Frontaliere",
+ "numberOfItems": 2,
+ "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Uno", "url": \`\${BASE_URL}/articoli-frontaliere/uno\` },
+          { "@type": "ListItem", "position": 2, "name": "Due", "url": \`\${BASE_URL}/articoli-frontaliere/due\` }
+ ]
+ },
+];
+`;
+
+// Reproduces the #2834 incident exactly: two ListItem entries with the
+// trailing comma removed between them — "} {" — a hard esbuild parse error.
+const BROKEN_SEO_PAGES = VALID_SEO_PAGES.replace(
+  '"url": `${BASE_URL}/articoli-frontaliere/uno` },',
+  '"url": `${BASE_URL}/articoli-frontaliere/uno` }',
+);
+
+const VALID_SEO_SERVICE = `export function getAllSeoMetadata() {
+  return {};
+}
+`;
+
+let dir: string;
+
+function run(cwd: string) {
+  return spawnSync('node', [SCRIPT], { cwd, encoding: 'utf8' });
+}
+
+function writeFixtures(seoPagesSrc: string) {
+  mkdirSync(join(dir, 'services', 'seo'), { recursive: true });
+  writeFileSync(join(dir, 'services', 'seo', 'seo-pages.ts'), seoPagesSrc);
+  writeFileSync(join(dir, 'services', 'seoService.ts'), VALID_SEO_SERVICE);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'check-seo-pages-syntax-test-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('check-seo-pages-syntax', () => {
+  it('exits 0 when seo-pages.ts and seoService.ts both parse cleanly', () => {
+    writeFixtures(VALID_SEO_PAGES);
+    const result = run(dir);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('parses cleanly');
+  }, 30_000);
+
+  it('exits 1 and reports the exact esbuild error on the #2834 missing-comma shape', () => {
+    writeFixtures(BROKEN_SEO_PAGES);
+    const result = run(dir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/Expected "\]" but found "\{"/);
+    expect(result.stderr).toContain('aborting');
+  }, 30_000);
+});

--- a/tests/scripts/seo-pages-article-list.test.ts
+++ b/tests/scripts/seo-pages-article-list.test.ts
@@ -1,0 +1,170 @@
+import esbuild from 'esbuild';
+import { describe, expect, it } from 'vitest';
+import {
+  appendArticleListItem,
+  upsertArticleListItem,
+} from '../../scripts/lib/seo-pages-article-list.mjs';
+
+// Minimal fixture mirroring the shape of services/seo/seo-pages.ts's
+// "Articoli Frontaliere" ItemList block (see line ~4669 in the real file).
+function makeFixture(items: Array<{ position: number; name: string; url: string }>) {
+  const lines = items
+    .map(
+      (it, i) =>
+        `          { "@type": "ListItem", "position": ${it.position}, "name": "${it.name}", "url": \`${it.url}\` }${
+          i < items.length - 1 ? ',' : ''
+        }`,
+    )
+    .join('\n');
+  return `const BASE_URL = 'https://frontaliereticino.ch';
+export const SEO_PAGES = [
+ {
+ "@context": "https://schema.org",
+ "@type": "ItemList",
+ "name": "Articoli Frontaliere",
+ "numberOfItems": ${items.length},
+ "itemListElement": [
+${lines}
+ ]
+ },
+];
+`;
+}
+
+async function assertParses(src: string) {
+  await expect(
+    esbuild.transform(src, { loader: 'ts', format: 'esm', target: 'es2022' }),
+  ).resolves.toBeDefined();
+}
+
+function countOccurrences(src: string, needle: string): number {
+  return src.split(needle).length - 1;
+}
+
+describe('seo-pages-article-list — comma-safe ItemList helpers', () => {
+  it('appendArticleListItem adds a new entry, bumps numberOfItems, and stays parseable', async () => {
+    const fixture = makeFixture([
+      { position: 1, name: 'Articolo uno', url: '${BASE_URL}/articoli-frontaliere/articolo-uno' },
+      { position: 2, name: 'Articolo due', url: '${BASE_URL}/articoli-frontaliere/articolo-due' },
+    ]);
+
+    const result = appendArticleListItem(fixture, {
+      name: 'Articolo tre',
+      url: '${BASE_URL}/articoli-frontaliere/articolo-tre',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('"numberOfItems": 3');
+    expect(result).toContain('"position": 3');
+    expect(result).toContain('articolo-tre');
+    await assertParses(result as string);
+  });
+
+  it('appendArticleListItem is comma-safe even when the target is the last (single) element', async () => {
+    const fixture = makeFixture([
+      { position: 1, name: 'Solo articolo', url: '${BASE_URL}/articoli-frontaliere/solo-articolo' },
+    ]);
+
+    const result = appendArticleListItem(fixture, {
+      name: 'Secondo articolo',
+      url: '${BASE_URL}/articoli-frontaliere/secondo-articolo',
+    });
+
+    expect(result).not.toBeNull();
+    // The previously-last (now second-to-last) entry must have gained a comma.
+    expect(result).toMatch(/solo-articolo` \},/);
+    await assertParses(result as string);
+  });
+
+  it('upsertArticleListItem with renameFromUrl REPLACES the old entry in place (no duplicate, no missing comma)', async () => {
+    const oldUrl = '${BASE_URL}/articoli-frontaliere/vecchio-slug';
+    const newUrl = '${BASE_URL}/articoli-frontaliere/nuovo-slug';
+    const fixture = makeFixture([
+      { position: 1, name: 'Primo articolo', url: '${BASE_URL}/articoli-frontaliere/primo-articolo' },
+      { position: 2, name: 'Titolo vecchio', url: oldUrl },
+      { position: 3, name: 'Terzo articolo', url: '${BASE_URL}/articoli-frontaliere/terzo-articolo' },
+    ]);
+
+    const result = upsertArticleListItem(fixture, {
+      name: 'Titolo rinominato',
+      url: newUrl,
+      renameFromUrl: oldUrl,
+    });
+
+    expect(result).not.toBeNull();
+    // Same array length — a rename REPLACES, it never appends a duplicate.
+    expect(result).toContain('"numberOfItems": 3');
+    expect(countOccurrences(result as string, '"@type": "ListItem"')).toBe(3);
+    // Old slug is fully gone; new slug replaced it at the SAME position.
+    expect(result).not.toContain('vecchio-slug');
+    expect(result).not.toContain('Titolo vecchio');
+    expect(result).toContain('nuovo-slug');
+    expect(result).toMatch(/"position": 2,\s*"name": "Titolo rinominato"/);
+    await assertParses(result as string);
+  });
+
+  it('upsertArticleListItem rename-replace stays comma-safe when the renamed entry IS the last element', async () => {
+    const oldUrl = '${BASE_URL}/articoli-frontaliere/vecchio-slug-finale';
+    const newUrl = '${BASE_URL}/articoli-frontaliere/nuovo-slug-finale';
+    const fixture = makeFixture([
+      { position: 1, name: 'Primo articolo', url: '${BASE_URL}/articoli-frontaliere/primo-articolo' },
+      { position: 2, name: 'Titolo vecchio finale', url: oldUrl },
+    ]);
+
+    const result = upsertArticleListItem(fixture, {
+      name: 'Titolo rinominato finale',
+      url: newUrl,
+      renameFromUrl: oldUrl,
+    });
+
+    expect(result).not.toBeNull();
+    expect(countOccurrences(result as string, '"@type": "ListItem"')).toBe(2);
+    expect(result).not.toContain('vecchio-slug-finale');
+    // Last element must remain WITHOUT a trailing comma.
+    expect(result).toMatch(/nuovo-slug-finale` \}\n( *)\]/);
+    await assertParses(result as string);
+  });
+
+  it('upsertArticleListItem falls back to append when the old-slug entry cannot be found (self-healing, never silently drops the item)', async () => {
+    const fixture = makeFixture([
+      { position: 1, name: 'Primo articolo', url: '${BASE_URL}/articoli-frontaliere/primo-articolo' },
+    ]);
+
+    const result = upsertArticleListItem(fixture, {
+      name: 'Articolo nuovo',
+      url: '${BASE_URL}/articoli-frontaliere/articolo-nuovo',
+      renameFromUrl: '${BASE_URL}/articoli-frontaliere/slug-mai-esistito',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('"numberOfItems": 2');
+    expect(countOccurrences(result as string, '"@type": "ListItem"')).toBe(2);
+    await assertParses(result as string);
+  });
+
+  it('reproduces the #2834 incident shape and proves the helper never produces it: no "} {" adjacency anywhere in output', async () => {
+    const fixture = makeFixture(
+      Array.from({ length: 5 }, (_, i) => ({
+        position: i + 1,
+        name: `Articolo ${i + 1}`,
+        url: `\${BASE_URL}/articoli-frontaliere/articolo-${i + 1}`,
+      })),
+    );
+
+    let src = fixture;
+    for (let i = 0; i < 10; i++) {
+      const next = appendArticleListItem(src, {
+        name: `Articolo generato ${i}`,
+        url: `\${BASE_URL}/articoli-frontaliere/articolo-generato-${i}`,
+      });
+      expect(next).not.toBeNull();
+      src = next as string;
+    }
+
+    // The exact corruption signature from the incident: a `}` immediately
+    // followed (modulo whitespace) by `{` with no comma between two
+    // ListItem entries.
+    expect(src).not.toMatch(/\}\s*\n\s*\{\s*"@type":\s*"ListItem"/);
+    await assertParses(src);
+  });
+});

--- a/tests/scripts/seo-pages-article-list.test.ts
+++ b/tests/scripts/seo-pages-article-list.test.ts
@@ -41,7 +41,72 @@ function countOccurrences(src: string, needle: string): number {
   return src.split(needle).length - 1;
 }
 
+// Wraps a fixture (built by makeFixture) with an EARLIER, unrelated array
+// that shares the exact same single-line `{ ... "url": `...` }` shape —
+// e.g. a HowTo `step` list — followed (modulo whitespace) by its own
+// closing `]`. Reproduces the real services/seo/seo-pages.ts layout, where
+// several such arrays exist before the "Articoli Frontaliere" ItemList.
+// Regression coverage for a PR-review finding: an earlier, unbounded
+// version of LAST_ITEM_RE matched THIS kind of array first (against the
+// real committed file) instead of the intended block, and would have
+// corrupted unrelated structured data.
+function withLeadingUnrelatedArray(fixture: string): string {
+  const decoy = `export const OTHER_PAGE = {
+ "@type": "HowTo",
+ "step": [
+          { "@type": "HowToStep", "position": 1, "name": "Passo uno", "url": \`\${BASE_URL}/calcola-stipendio/passo-uno\` }
+ ]
+};
+`;
+  return decoy + fixture;
+}
+
 describe('seo-pages-article-list — comma-safe ItemList helpers', () => {
+  it('never touches an unrelated earlier array with the same single-line-entry shape (bounded to the Articoli Frontaliere block only)', async () => {
+    const fixture = withLeadingUnrelatedArray(
+      makeFixture([
+        { position: 1, name: 'Articolo uno', url: '${BASE_URL}/articoli-frontaliere/articolo-uno' },
+      ]),
+    );
+
+    const result = appendArticleListItem(fixture, {
+      name: 'Articolo due',
+      url: '${BASE_URL}/articoli-frontaliere/articolo-due',
+    });
+
+    expect(result).not.toBeNull();
+    // The decoy HowTo step array must be byte-identical — untouched.
+    expect(result).toContain(
+      '{ "@type": "HowToStep", "position": 1, "name": "Passo uno", "url": `${BASE_URL}/calcola-stipendio/passo-uno` }\n ]',
+    );
+    expect(countOccurrences(result as string, '"@type": "HowToStep"')).toBe(1);
+    // The real Articoli Frontaliere ItemList gained the new entry.
+    expect(result).toContain('"numberOfItems": 2');
+    expect(result).toContain('articolo-due');
+    await assertParses(result as string);
+  });
+
+  it('rename-replace never touches an unrelated earlier array with the same shape', async () => {
+    const oldUrl = '${BASE_URL}/articoli-frontaliere/vecchio-slug';
+    const newUrl = '${BASE_URL}/articoli-frontaliere/nuovo-slug';
+    const fixture = withLeadingUnrelatedArray(
+      makeFixture([{ position: 1, name: 'Titolo vecchio', url: oldUrl }]),
+    );
+
+    const result = upsertArticleListItem(fixture, {
+      name: 'Titolo rinominato',
+      url: newUrl,
+      renameFromUrl: oldUrl,
+    });
+
+    expect(result).not.toBeNull();
+    expect(countOccurrences(result as string, '"@type": "HowToStep"')).toBe(1);
+    expect(result).toContain('passo-uno');
+    expect(result).not.toContain('vecchio-slug');
+    expect(result).toContain('nuovo-slug');
+    await assertParses(result as string);
+  });
+
   it('appendArticleListItem adds a new entry, bumps numberOfItems, and stays parseable', async () => {
     const fixture = makeFixture([
       { position: 1, name: 'Articolo uno', url: '${BASE_URL}/articoli-frontaliere/articolo-uno' },


### PR DESCRIPTION
## Implementato

- `scripts/lib/seo-pages-article-list.mjs` (new): comma-safe helpers for editing the "Articoli Frontaliere" breadcrumb `ItemList` in `services/seo/seo-pages.ts`. `appendArticleListItem` always rebuilds the touched entry (and its trailing comma) from regex capture groups instead of a blind string splice — the class of missing-comma corruption from the #2834 incident (`} {`, no comma, esbuild parse failure, main-red for every branch) is structurally impossible through this module. `upsertArticleListItem` is the rename-safe entry point: given `renameFromUrl`, it REPLACES the existing `ListItem` in place (same position, comma read directly off the matched entry) instead of appending a duplicate; if the old entry isn't found it falls back to append so a rename can never silently drop the item.
- **Post-review hardening**: every regex match (`appendArticleListItem` and `upsertArticleListItem`'s rename-replace) is now bounded to the "Articoli Frontaliere" `itemListElement` block only, via a new `locateItemListBlock()` helper. Reviewer caught (against the real committed file, not a synthetic fixture) that the first version's unbounded `LAST_ITEM_RE` matched an unrelated earlier `HowTo` `step` array first — same single-line `{ ... "url": ... }` shape — which would have corrupted unrelated structured data while incrementing `numberOfItems` on an array that never actually got a new entry (count/length mismatch). Also hardened `escapeJsonString` to strip raw control characters (a raw newline in a headline would parse fine as a JS template literal but produce invalid JSON when the JSON-LD is later parsed strictly by browsers/crawlers). Verified directly against the real `services/seo/seo-pages.ts`: the new entry now lands at the correct end-of-block line, the decoy `HowTo` array is byte-identical, and a `renameFromUrl` pointing at a URL that legitimately exists elsewhere in the file (outside this block) correctly falls through to append instead of corrupting that unrelated occurrence.
- `scripts/create-article.mjs`: refactored the one confirmed production writer of `seo-pages.ts`'s `ItemList` (`modifySeoService`, called by `registerArticleFiles`) to go through `appendArticleListItem` instead of the old inline regex/splice. `registerArticleFiles`/`modifySeoService` signatures unchanged (GitNexus impact: 0 callers affected, low risk).
- `scripts/ci/check-seo-pages-syntax.mjs` (new): pre-commit parse gate — runs `esbuild --loader:.ts=ts` against `services/seo/seo-pages.ts` and `services/seoService.ts`, exit 1 on parse failure. `scripts/lib/resolve-append-conflicts.sh` already esbuild-checks conflicted files, but only on the git-rebase-conflict path; the common CLEAN commit path (the exact scenario that broke main on 2026-06-24) had no syntax check at all. Wired into `generate-article.yml` and `publish-journalist-articles.yml` right before their commit step. Confirmed (in response to reviewer's open question) that `has_changes` in `generate-article.yml` is a blanket `git diff --quiet` over the whole working tree computed AFTER the article-generation step already wrote `seo-pages.ts` — so the gate can't be skipped by a false-negative on a branch where only `seo-pages.ts` changed; documented this in a workflow comment.
- Tests: `tests/scripts/seo-pages-article-list.test.ts` (8 tests) — append/rename-replace correctness, comma-safety at the last element, dedup, fallback-to-append, a stress test for `"} {"` adjacency, plus two new regression tests proving an unrelated leading array with the same shape is left byte-identical for both append and rename-replace. `tests/scripts/check-seo-pages-syntax.test.ts` (2 tests) — proves the gate script exits 0 on valid files and exits 1 with the exact `Expected "]" but found "{"` incident signature on a deliberately broken fixture.
- Sibling-pattern check (Non-Negotiable #6): grepped `scripts build-plugins services` for the same append/splice construct. `build-plugins/jobsSeoPagesPlugin.ts` is a **false positive** — it builds `ItemList` JSON-LD at SSG build time via `inlineScriptJson({...})` (a real object serialized through `JSON.stringify`), never string-splicing a committed source file.
- Item 3 (issue's literal scope — duplicate slugs in `data/swiss-articles*`): verified `data/swiss-articles-data.ts` currently has **zero duplicate ids** — already clean, nothing to migrate.
- Two pre-existing, unrelated data-quality findings surfaced while auditing (different bug class — content-duplication from `create-article.mjs`'s duplicate-detection, not a rename/comma bug) were **not** fixed here to keep this PR surgical, and are tracked in a new follow-up issue: **#3294** (duplicate `ristorni-fiscali-frontaliere` `ListItem` entry already present in `seo-pages.ts`, and ~149 duplicate ids in `data/blog-articles-data.ts`).

Verification: `npx vitest run tests/seo/software-application-jsonld.test.ts tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/scripts/create-article-integration.test.ts tests/scripts/seo-pages-article-list.test.ts tests/scripts/check-seo-pages-syntax.test.ts` → 6 files, 79 tests, all passed. Also manually verified `appendArticleListItem`/`upsertArticleListItem` against the real committed `services/seo/seo-pages.ts` (not just synthetic fixtures).

## Non implementato (ancora)

Nessuno.

Closes #2834