### PR TITLE
fix(ci): persist revenue-monitor trend via committed data/, not gitignored reports/

### DIFF
--- a/.github/workflows/revenue-monitor.yml
+++ b/.github/workflows/revenue-monitor.yml
@@ -63,24 +63,28 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
-      - name: Commit report to repo
+      - name: Commit revenue monitor history
         run: |
-          if ! git diff --quiet -- reports/ 2>/dev/null || [ -n "$(git status --porcelain reports/ 2>/dev/null)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add reports/revenue-*.md reports/revenue-*.json 2>/dev/null || true
-            git commit -m "📊 Weekly revenue monitor report" || exit 0
-            # Abort any conflicting rebase before retrying, otherwise the loop
-            # wedges on "unmerged files" until the job is canceled.
-            for i in 1 2 3; do
-              git pull --rebase origin main && git push && exit 0
-              git rebase --abort 2>/dev/null || true
-              sleep $((i * 5))
-            done
-            echo "::warning::Failed to push revenue report after 3 attempts"
-          else
-            echo "No report changes to commit"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Full reports live under reports/ which is gitignored (preserved as
+          # build artifacts only, see "Upload report artifact" above). Only the
+          # compact append-only history file is committed so the next weekly
+          # run can compute the trend (mirrors ai-visibility-check.yml, #2741).
+          git add data/revenue-monitor-history.jsonl
+          if git diff --cached --quiet; then
+            echo "No history changes to commit."
+            exit 0
           fi
+          DATE=$(date -u +%Y-%m-%d)
+          git commit -m "📊 Weekly revenue monitor report — ${DATE}"
+          # Centralized rebase-retry helper survives concurrent pushes from
+          # other workflows. The history file is append-only, so on a rebase
+          # conflict keep the local commit and union both sides instead of
+          # regenerating.
+          bash scripts/lib/git-push-with-retry.sh \
+            --branch "$GITHUB_REF_NAME" \
+            --in-place-resolver-cmd "source scripts/lib/resolve-append-conflicts.sh && resolve_append_conflicts && git add -A"
 
       - name: Cleanup credentials
         if: always()

--- a/scripts/revenue-monitor.mjs
+++ b/scripts/revenue-monitor.mjs
@@ -24,19 +24,25 @@
  *   node scripts/revenue-monitor.mjs --json          # JSON payload
  *   node scripts/revenue-monitor.mjs --markdown      # GitHub-flavored markdown
  *   node scripts/revenue-monitor.mjs --save          # write reports/revenue-YYYY-MM-DD.{md,json}
+ *                                                     # and append data/revenue-monitor-history.jsonl
  *
  * Exits 0 always — this is a monitor, not a gate. Regressions are flagged
  * with ⚠️ / 🔴 in the output so the weekly digest draws attention without
  * blocking CI.
  */
 
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SITE_URL = 'https://frontaliereticino.ch';
 const REPORTS_DIR = resolve(__dirname, '..', 'reports');
+// Full reports live in the gitignored reports/ dir (kept as workflow artifacts
+// only — never survive a fresh CI checkout). A compact append-only summary is
+// committed here instead so the trend has somewhere to persist across weekly
+// runs (mirrors data/ai-visibility-history.jsonl — see PR #2736 / issue #2741).
+const HISTORY_FILE = resolve(__dirname, '..', 'data', 'revenue-monitor-history.jsonl');
 
 // ── Baseline captured Apr 6-19 2026 (see docs/revenue-optimization-remaining.md) ──
 // CTR baselines by URL bucket derived from GSC 28-day query bucketed by path prefix
@@ -469,6 +475,40 @@ export function renderMarkdown(rows, current, baseline = BASELINE) {
   return lines.join('\n');
 }
 
+// Compact append-only summary written to the committed HISTORY_FILE. Mirrors
+// the shape of data/ai-visibility-history.jsonl: one JSON object per line,
+// enough to reconstruct a trend without needing the full (gitignored) report.
+export function buildHistoryEntry(current, rows, dateStr) {
+  const regressions = rows
+    .filter((r) => r.verdict.startsWith('🔴') || r.verdict.startsWith('⚠️'))
+    .map((r) => r.metric);
+  return {
+    date: dateStr,
+    adsense: current.adsense
+      ? {
+          revenuePerDayCHF: current.adsense.revenuePerDayCHF ?? null,
+          rpmCHF: current.adsense.rpmCHF ?? null,
+          desktopRpmCHF: current.adsense.desktopRpmCHF ?? null,
+          authGateImpressions7d: current.adsense.authGateImpressions7d ?? null,
+        }
+      : null,
+    gsc: current.gsc
+      ? {
+          clicksPerDay: current.gsc.clicksPerDay ?? null,
+          avgPosition: current.gsc.avgPosition ?? null,
+          ctrByBucket: current.gsc.ctrByBucket ?? null,
+        }
+      : null,
+    posthog: current.posthog
+      ? {
+          clsP75Mobile: current.posthog.clsP75Mobile ?? null,
+          clsP75Desktop: current.posthog.clsP75Desktop ?? null,
+        }
+      : null,
+    regressions,
+  };
+}
+
 // ── Main ────────────────────────────────────────────────────
 async function main() {
   const current = { adsense: null, gsc: null, posthog: null, errors: [], warnings: [] };
@@ -532,6 +572,13 @@ async function main() {
     writeFileSync(resolve(REPORTS_DIR, `revenue-${stamp}.json`), JSON.stringify(payload, null, 2));
     writeFileSync(resolve(REPORTS_DIR, `revenue-${stamp}.md`), renderMarkdown(rows, current));
     log('💾', `reports/revenue-${stamp}.{json,md} written`);
+
+    // Committed, append-only trend record — reports/ is gitignored and never
+    // survives a fresh CI checkout, so this is the only copy that persists
+    // across weekly runs (issue #2741).
+    if (!existsSync(dirname(HISTORY_FILE))) mkdirSync(dirname(HISTORY_FILE), { recursive: true });
+    appendFileSync(HISTORY_FILE, JSON.stringify(buildHistoryEntry(current, rows, stamp)) + '\n');
+    log('🗂 ', `data/revenue-monitor-history.jsonl appended`);
   }
 }
 

--- a/scripts/revenue-monitor.mjs
+++ b/scripts/revenue-monitor.mjs
@@ -478,6 +478,11 @@ export function renderMarkdown(rows, current, baseline = BASELINE) {
 // Compact append-only summary written to the committed HISTORY_FILE. Mirrors
 // the shape of data/ai-visibility-history.jsonl: one JSON object per line,
 // enough to reconstruct a trend without needing the full (gitignored) report.
+//
+// NOTE: on a push race, scripts/lib/resolve-append-conflicts.sh resolves the
+// conflict by keeping both sides' lines rather than deduping by date — same
+// limitation as data/ai-visibility-history.jsonl. Worst case is a harmless
+// duplicate date line in the history; not worth a bespoke dedupe pass here.
 export function buildHistoryEntry(current, rows, dateStr) {
   const regressions = rows
     .filter((r) => r.verdict.startsWith('🔴') || r.verdict.startsWith('⚠️'))

--- a/tests/scripts/revenue-monitor.test.ts
+++ b/tests/scripts/revenue-monitor.test.ts
@@ -11,6 +11,7 @@ const {
   GSC_BUCKETS,
   bucketCtrFromRows,
   buildComparisonRows,
+  buildHistoryEntry,
   compare,
   fetchPostHogCls,
   renderMarkdown,
@@ -19,6 +20,7 @@ const {
   GSC_BUCKETS: readonly string[];
   bucketCtrFromRows: (rows: any[], buckets: string[]) => Record<string, number | null>;
   buildComparisonRows: (current: any, baseline?: any) => Array<{ metric: string; verdict: string; baseline: unknown; current: unknown }>;
+  buildHistoryEntry: (current: any, rows: Array<{ metric: string; verdict: string }>, dateStr: string) => Record<string, unknown>;
   compare: (current: number | null, baseline: number | null, opts?: { higherIsBetter?: boolean }) => { delta: number | null; deltaPct: number | null; verdict: string };
   fetchPostHogCls: (opts: { apiKey: string | null; projectId: string | null; host?: string; fetchImpl?: unknown }) => Promise<{ clsP75Mobile: number | null; clsP75Desktop: number | null } | null>;
   renderMarkdown: (rows: unknown[], current: any, baseline?: any) => string;
@@ -210,5 +212,45 @@ describe('revenue-monitor / renderMarkdown()', () => {
     const md = renderMarkdown(rows, current);
     expect(md).toContain('## Warnings');
     expect(md).toContain('PostHog skipped');
+  });
+});
+
+describe('revenue-monitor / buildHistoryEntry()', () => {
+  it('produces a compact, JSON-serializable summary keyed by date (issue #2741)', () => {
+    const current = {
+      adsense: { revenuePerDayCHF: 0.9, rpmCHF: 1.0, desktopRpmCHF: 1.2, authGateImpressions7d: 600 },
+      gsc: { clicksPerDay: 320, avgPosition: 5.5, ctrByBucket: { '/job-board/': 6.0 } },
+      posthog: { clsP75Mobile: 0.5, clsP75Desktop: 0.17 },
+    };
+    const rows = buildComparisonRows(current);
+    const entry = buildHistoryEntry(current, rows, '2026-07-06');
+
+    expect(entry.date).toBe('2026-07-06');
+    // Round-trips through JSON.stringify without throwing (this is what gets
+    // appended to data/revenue-monitor-history.jsonl).
+    const parsed = JSON.parse(JSON.stringify(entry));
+    expect(parsed.adsense.revenuePerDayCHF).toBe(0.9);
+    expect(parsed.gsc.clicksPerDay).toBe(320);
+    expect(parsed.posthog.clsP75Mobile).toBe(0.5);
+  });
+
+  it('nulls out sections whose source data is missing', () => {
+    const current = { adsense: null, gsc: null, posthog: null };
+    const rows = buildComparisonRows(current);
+    const entry = buildHistoryEntry(current, rows, '2026-07-06');
+    expect(entry.adsense).toBeNull();
+    expect(entry.gsc).toBeNull();
+    expect(entry.posthog).toBeNull();
+  });
+
+  it('lists regressed/warning metrics by name', () => {
+    const current = {
+      adsense: null,
+      gsc: null,
+      posthog: { clsP75Mobile: 0.62, clsP75Desktop: 0.2 },
+    };
+    const rows = buildComparisonRows(current);
+    const entry = buildHistoryEntry(current, rows, '2026-07-06');
+    expect(entry.regressions).toContain('CLS p75 mobile');
   });
 });


### PR DESCRIPTION
## Implementato

- Fixed `.github/workflows/revenue-monitor.yml` commit step. Old guard checked `reports/` which is gitignored, so the condition was always false and `git add reports/revenue-*` never ran. New step commits `data/revenue-monitor-history.jsonl` instead, following the same pattern as `ai-visibility-check.yml` from PR #2736: stage the file, commit if the staged diff is non-empty, push via `scripts/lib/git-push-with-retry.sh` with `--in-place-resolver-cmd` wired to `scripts/lib/resolve-append-conflicts.sh`.
- Added `HISTORY_FILE` constant and exported `buildHistoryEntry(current, rows, dateStr)` in `scripts/revenue-monitor.mjs`. It builds a compact summary object: AdSense revenue/RPM/desktop-RPM/auth-gate impressions, GSC clicks/avg-position/CTR-by-bucket, PostHog CLS p75 mobile/desktop, and the list of regressed metric names.
- The `--save` code path now appends this entry as one JSON line to `data/revenue-monitor-history.jsonl`, in addition to the existing `reports/revenue-*.{json,md}` files (kept as-is, still uploaded as a workflow artifact).
- No new `.gitattributes` entry needed. Confirmed `data/ai-visibility-history.jsonl` has none either; the generic "keep both sides" resolver in `resolve-append-conflicts.sh` already handles JSONL append conflicts.
- Added 3 unit tests to `tests/scripts/revenue-monitor.test.ts` covering `buildHistoryEntry`: JSON round-trip, null sections when source data is missing, and regressed-metric names surfaced. Full suite: 20/20 passing via `npx vitest run tests/scripts/revenue-monitor.test.ts`.
- Confirmed the rewritten workflow YAML parses correctly.
- Simulated the concurrent-append and rebase-conflict flow locally against a scratch bare git repo: two clones append different lines to the history file and race to push; after `git-push-with-retry.sh` resolves the conflict, both lines survive in the final file. This confirms append-only semantics hold under the same resolver used by `ai-visibility-check.yml`.
- Ran GitNexus impact analysis on `scripts/revenue-monitor.mjs`: LOW risk, isolated to the CLI entrypoint, the workflow, and its own test file.

## Non implementato (ancora)

- Live confirmation that `revenue-monitor.yml` actually commits and pushes `data/revenue-monitor-history.jsonl` on a real GitHub Actions run. This is blocked: external — GitHub Actions cannot be executed locally, only simulated. I validated the git/append/resolver logic with a local scratch-repo simulation and unit tests, but the real first commit only happens on the next scheduled run (Monday 06:15 UTC), or sooner via a manual `gh workflow run revenue-monitor.yml --ref main` that I will trigger after this PR merges.

Closes #2741