### PR TITLE
fix(ci): extend article-append integrity gate to BLOG_SLUGS + per-block sitemap loc check

### DIFF
--- a/scripts/ci/validate-article-append-integrity.mjs
+++ b/scripts/ci/validate-article-append-integrity.mjs
@@ -29,14 +29,22 @@
  * resolver can abort the push before a corrupted tree reaches main.
  *
  * Scope notes (deliberately narrow to stay false-positive-free on a clean main):
- *  - Only SWISS_SLUGS (routerSwissData.ts) is slug-uniqueness-checked. The
- *    FRONTALIERE map (routerBlogData.ts) already carries many tolerated
- *    duplicate localized slugs on main and has no equivalent round-trip test,
- *    so checking it would block valid appends.
+ *  - Both SWISS_SLUGS (routerSwissData.ts) and BLOG_SLUGS/FRONTALIERE
+ *    (routerBlogData.ts) are slug-uniqueness-checked (see follow-up #2837).
+ *    BLOG_SLUGS used to carry ~36 tolerated pre-existing duplicate localized
+ *    slugs (last-write-wins on REVERSE_BLOG, same round-trip break as SWISS);
+ *    those were deduplicated in #3012, so this check is now false-positive-free
+ *    on a clean main and can guard the FRONTALIERE map going forward too.
  *  - The merged-entry / duplicate-id .ts shape is already covered by the
  *    per-file esbuild guard in resolve-append-conflicts.sh; not duplicated here.
  *  - The sitemap index (sitemap.xml — <sitemap> blocks, zero <url>) is skipped;
  *    only url-sitemaps (those that actually contain <url>) are balance-checked.
+ *    Verified 1:1 <loc>-per-<url> (both aggregate AND per-block) on all 6
+ *    non-news url-sitemaps in public/ (sitemap-blog-ch, sitemap-blog,
+ *    sitemap-glossario, sitemap-guides, sitemap-jobs, sitemap-pages) in
+ *    addition to sitemap-news.xml — see #2837. The per-block check below
+ *    (not just the aggregate count) is what actually enforces the invariant,
+ *    so a corrupted block can't hide behind a compensating miss elsewhere.
  *
  * Exit 0 = all invariants hold. Exit 1 = at least one violation (caller MUST
  * abort the push). Pure Node built-ins; no dependencies, no network.
@@ -53,12 +61,13 @@ function read(rel) {
   return existsSync(p) ? readFileSync(p, 'utf8') : null;
 }
 
-// ── 1. Duplicate localized slug in SWISS_SLUGS ───────────────────────────────
-// Shape: `'id': { it: '…', en: '…', de: '…', fr: '…' }`. The file holds only the
-// literal map (+ a derived REVERSE_SWISS with no `<loc>: '…'` literals), so
-// locale-keyed string literals belong solely to the map.
-function checkSwissSlugUniqueness() {
-  const rel = 'services/routerSwissData.ts';
+// ── 1. Duplicate localized slug in SWISS_SLUGS / BLOG_SLUGS ─────────────────
+// Shape (both files): `'id': { it: '…', en: '…', de: '…', fr: '…' }`. Each file
+// holds only the literal map (+ a derived REVERSE_* with no `<loc>: '…'`-style
+// literals), so locale-keyed string literals belong solely to the map — a
+// plain regex scan of the whole file is safe without needing to fence the
+// map's start/end.
+function checkSlugUniqueness(rel, reverseMapName) {
   const src = read(rel);
   if (src === null) return;
   const entryRx = /(^|\n)\s*'([^']+)'\s*:\s*\{([^}]*)\}/g;
@@ -74,7 +83,7 @@ function checkSwissSlugUniqueness() {
       if (seen && seen !== id) {
         fail(
           `${rel}: duplicate ${loc.toUpperCase()} slug "${slug}" maps to both ` +
-            `"${seen}" and "${id}" — REVERSE_SWISS collides (round-trip breaks). ` +
+            `"${seen}" and "${id}" — ${reverseMapName} collides (round-trip breaks). ` +
             `Almost always a duplicate article: drop one of the two.`,
         );
       } else {
@@ -84,9 +93,28 @@ function checkSwissSlugUniqueness() {
   }
 }
 
+function checkSwissSlugUniqueness() {
+  checkSlugUniqueness('services/routerSwissData.ts', 'REVERSE_SWISS');
+}
+
+function checkBlogSlugUniqueness() {
+  checkSlugUniqueness('services/routerBlogData.ts', 'REVERSE_BLOG');
+}
+
 // ── 2. url-sitemap <url>/<loc>/<image:image> balance ─────────────────────────
 // A merged <url> block carries two <loc> (and an unbalanced <image:image>) —
 // well-formed XML, but these counts catch it. Skip index sitemaps (no <url>).
+//
+// Two layers, deliberately both kept:
+//  - Aggregate counts (cheap, catches most shapes, gives a single clear count).
+//  - Per-block <loc> count (below): the aggregate alone has a blind spot — if
+//    one merge fuses two <loc> into a single <url> block while another block
+//    elsewhere is missing its <loc> entirely, the totals can still coincide
+//    and the aggregate check passes despite real corruption. The per-block
+//    scan asserts the invariant directly (exactly one <loc> per <url> block)
+//    so that blind spot can't hide a violation. Verified 1:1 on every <url>
+//    block, aggregate AND per-block, across all 7 sitemap-*.xml url-sitemaps
+//    on a clean main (sitemap-news.xml + the 6 others) — see #2837.
 function checkSitemapBalance(rel) {
   const xml = read(rel);
   if (xml === null) return;
@@ -109,10 +137,23 @@ function checkSitemapBalance(rel) {
   if (imgOpen !== imgClose) {
     fail(`${rel}: <image:image> open/close imbalance (${imgOpen} vs ${imgClose}) — malformed merge.`);
   }
+
+  // Per-block check: guards against the aggregate blind spot described above.
+  const blocks = xml.match(/<url>[\s\S]*?<\/url>/g) || [];
+  for (let i = 0; i < blocks.length; i++) {
+    const blockLoc = (blocks[i].match(/<loc>/g) || []).length;
+    if (blockLoc !== 1) {
+      fail(
+        `${rel}: <url> block #${i + 1} has ${blockLoc} <loc> entries (expected exactly 1) — ` +
+          `concurrent-append merge fused entries into one block.`,
+      );
+    }
+  }
 }
 
 // ── Run ──────────────────────────────────────────────────────────────────────
 checkSwissSlugUniqueness();
+checkBlogSlugUniqueness();
 
 const publicDir = join(ROOT, 'public');
 if (existsSync(publicDir)) {
@@ -130,4 +171,6 @@ if (violations.length) {
   );
   process.exit(1);
 }
-console.log('✅ article-append integrity: SWISS slug-uniqueness + url-sitemap balance OK');
+console.log(
+  '✅ article-append integrity: SWISS + BLOG slug-uniqueness + url-sitemap balance OK',
+);

--- a/scripts/lib/resolve-append-conflicts.sh
+++ b/scripts/lib/resolve-append-conflicts.sh
@@ -19,8 +19,9 @@
 #      comma — which previously slipped through and broke the deploy build).
 #   6. Final cross-file integrity gate (scripts/ci/validate-article-append-integrity.mjs):
 #      catches the two corruption shapes that stay syntactically valid and so
-#      slip past step 5 — a duplicate SVIZZERA localized slug (REVERSE_SWISS
-#      collision) and a fused sitemap <url> block (hreflang != <url> count).
+#      slip past step 5 — a duplicate localized slug in SWISS_SLUGS (REVERSE_SWISS
+#      collision) OR BLOG_SLUGS/FRONTALIERE (REVERSE_BLOG collision), and a fused
+#      sitemap <url> block (<loc> count != <url> count, checked per-block too).
 #
 # Usage (sourced — preferred so the function is in scope of the caller):
 #   source scripts/lib/resolve-append-conflicts.sh
@@ -214,12 +215,14 @@ resolve_append_conflicts() {
   done <<< "$CONFLICTED"
 
   # Final cross-file integrity gate. Even when every individual file parses, a
-  # keep-both merge can still (a) duplicate a SVIZZERA localized slug
+  # keep-both merge can still (a) duplicate a localized slug in SWISS_SLUGS
   # (REVERSE_SWISS collides → tests/blog/svizzera-section-routing red) or
-  # (b) fuse two sitemap <url> blocks (hreflang != <url> → tests/seo-completeness
-  # red). Both stay syntactically valid, so the per-file esbuild guard above
-  # can't see them. Validate the whole resolved tree once before declaring
-  # success (skip when an earlier file already failed — we're aborting anyway).
+  # BLOG_SLUGS/FRONTALIERE (REVERSE_BLOG collides, same round-trip-break shape),
+  # or (b) fuse two sitemap <url> blocks (<loc> count != <url> count, checked
+  # per-block → tests/seo-completeness red). All stay syntactically valid, so
+  # the per-file esbuild guard above can't see them. Validate the whole
+  # resolved tree once before declaring success (skip when an earlier file
+  # already failed — we're aborting anyway).
   if [ "$ALL_RESOLVED" = true ] && [ -f scripts/ci/validate-article-append-integrity.mjs ]; then
     if ! node scripts/ci/validate-article-append-integrity.mjs; then
       echo "  ❌ article-append integrity gate failed — refusing to keep this merge"

--- a/tests/validate-article-append-integrity.test.ts
+++ b/tests/validate-article-append-integrity.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression lock for `scripts/ci/validate-article-append-integrity.mjs`
+ * (follow-up #2837 of PR #2835).
+ *
+ * Covers:
+ *  1. The CLI still passes on the real, clean repo tree (both SWISS_SLUGS and
+ *     BLOG_SLUGS uniqueness, and url-sitemap <loc>/<url> balance).
+ *  2. A duplicate localized slug in BLOG_SLUGS (routerBlogData.ts / FRONTALIERE
+ *     section) is now caught — this is the corruption class that redded
+ *     tests/blog/svizzera-section-routing for SWISS_SLUGS and, until #2837,
+ *     had no equivalent gate for BLOG_SLUGS (36 such collisions were
+ *     deduplicated on main in #3012; this test locks the gate that prevents
+ *     recurrence).
+ *  3. A duplicate localized slug in SWISS_SLUGS is still caught (no
+ *     regression from the refactor into a shared `checkSlugUniqueness` helper).
+ *  4. url-sitemap <loc>-per-<url> is checked PER BLOCK, not just in aggregate:
+ *     a fixture where one <url> block has two <loc> and a sibling block has
+ *     zero (aggregate counts coincidentally still balance) is caught.
+ *
+ * Fixtures run the CLI against an isolated temp directory (not the real repo
+ * files) so the test never touches tracked sources.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'ci', 'validate-article-append-integrity.mjs');
+
+const cleanSwissData = [
+  "export const SWISS_SLUGS = {",
+  " 'swiss-a': { it: 'swiss-a-it', en: 'swiss-a-en', de: 'swiss-a-de', fr: 'swiss-a-fr' },",
+  " 'swiss-b': { it: 'swiss-b-it', en: 'swiss-b-en', de: 'swiss-b-de', fr: 'swiss-b-fr' },",
+  "};",
+  "",
+].join('\n');
+
+const cleanBlogData = [
+  "export const BLOG_SLUGS = {",
+  " 'blog-a': { it: 'blog-a-it', en: 'blog-a-en', de: 'blog-a-de', fr: 'blog-a-fr' },",
+  " 'blog-b': { it: 'blog-b-it', en: 'blog-b-en', de: 'blog-b-de', fr: 'blog-b-fr' },",
+  "};",
+  "",
+].join('\n');
+
+const cleanSitemap = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<urlset>',
+  '<url><loc>https://frontaliereticino.ch/a/</loc></url>',
+  '<url><loc>https://frontaliereticino.ch/b/</loc></url>',
+  '</urlset>',
+  '',
+].join('\n');
+
+let tmpDir: string | null = null;
+
+/** Builds a minimal fixture tree the script can run against via `cwd`. */
+function makeFixture(overrides: { swiss?: string; blog?: string; sitemap?: string } = {}): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'article-integrity-fixture-'));
+  mkdirSync(path.join(dir, 'services'), { recursive: true });
+  mkdirSync(path.join(dir, 'public'), { recursive: true });
+  writeFileSync(path.join(dir, 'services', 'routerSwissData.ts'), overrides.swiss ?? cleanSwissData);
+  writeFileSync(path.join(dir, 'services', 'routerBlogData.ts'), overrides.blog ?? cleanBlogData);
+  writeFileSync(path.join(dir, 'public', 'sitemap-test.xml'), overrides.sitemap ?? cleanSitemap);
+  return dir;
+}
+
+function runCli(cwd: string): { status: number; output: string } {
+  try {
+    const output = execFileSync('node', [SCRIPT], { cwd, encoding: 'utf-8' });
+    return { status: 0, output };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { status: err.status ?? -1, output: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+describe('validate-article-append-integrity — real repo tree', () => {
+  it('exits 0 on the current clean tree and checks BOTH SWISS_SLUGS and BLOG_SLUGS', () => {
+    const { status, output } = runCli(ROOT);
+    expect(status).toBe(0);
+    expect(output).toMatch(/SWISS \+ BLOG slug-uniqueness/);
+  });
+});
+
+describe('validate-article-append-integrity — BLOG_SLUGS duplicate slug (fixture)', () => {
+  it('exits 0 on a clean fixture', () => {
+    tmpDir = makeFixture();
+    const { status } = runCli(tmpDir);
+    expect(status).toBe(0);
+  });
+
+  it('catches a duplicate localized BLOG_SLUGS slug (routerBlogData.ts / FRONTALIERE)', () => {
+    const dupBlog = [
+      "export const BLOG_SLUGS = {",
+      " 'blog-a': { it: 'blog-a-it', en: 'blog-a-en', de: 'blog-a-de', fr: 'blog-a-fr' },",
+      // Same IT slug as 'blog-a' but a different article id — REVERSE_BLOG
+      // last-write-wins collision (the #3012 corruption shape).
+      " 'blog-b': { it: 'blog-a-it', en: 'blog-b-en', de: 'blog-b-de', fr: 'blog-b-fr' },",
+      "};",
+      "",
+    ].join('\n');
+    tmpDir = makeFixture({ blog: dupBlog });
+    const { status, output } = runCli(tmpDir);
+    expect(status).toBe(1);
+    expect(output).toMatch(/routerBlogData\.ts/);
+    expect(output).toMatch(/duplicate IT slug "blog-a-it"/);
+    expect(output).toMatch(/REVERSE_BLOG collides/);
+  });
+});
+
+describe('validate-article-append-integrity — SWISS_SLUGS duplicate slug (fixture, no regression)', () => {
+  it('still catches a duplicate localized SWISS_SLUGS slug after the shared-helper refactor', () => {
+    const dupSwiss = [
+      "export const SWISS_SLUGS = {",
+      " 'swiss-a': { it: 'swiss-a-it', en: 'swiss-a-en', de: 'swiss-a-de', fr: 'swiss-a-fr' },",
+      " 'swiss-b': { it: 'swiss-a-it', en: 'swiss-b-en', de: 'swiss-b-de', fr: 'swiss-b-fr' },",
+      "};",
+      "",
+    ].join('\n');
+    tmpDir = makeFixture({ swiss: dupSwiss });
+    const { status, output } = runCli(tmpDir);
+    expect(status).toBe(1);
+    expect(output).toMatch(/routerSwissData\.ts/);
+    expect(output).toMatch(/REVERSE_SWISS collides/);
+  });
+});
+
+describe('validate-article-append-integrity — per-block <loc> check (aggregate blind spot)', () => {
+  it('catches a fused <url> block (two <loc>) even when a sibling block is missing its <loc> and the aggregate totals coincidentally balance', () => {
+    // urlOpen=2, urlClose=2, loc=2 -> aggregate (loc !== urlOpen) check alone
+    // would NOT fire here, since totals coincide. Only the per-block scan
+    // catches the fused first block.
+    const blindSpotSitemap = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<urlset>',
+      '<url><loc>https://frontaliereticino.ch/fused-a/</loc><loc>https://frontaliereticino.ch/fused-b/</loc></url>',
+      '<url></url>',
+      '</urlset>',
+      '',
+    ].join('\n');
+    tmpDir = makeFixture({ sitemap: blindSpotSitemap });
+    const { status, output } = runCli(tmpDir);
+    expect(status).toBe(1);
+    expect(output).toMatch(/sitemap-test\.xml/);
+    expect(output).toMatch(/<url> block #1 has 2 <loc> entries/);
+  });
+
+  it('exits 0 when every <url> block has exactly one <loc>', () => {
+    tmpDir = makeFixture();
+    const { status } = runCli(tmpDir);
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Implementato

Follow-up of #2835 (issue #2837), both items:

**Item 1 — BLOG_SLUGS coverage:**
- Inventoried FRONTALIERE (`BLOG_SLUGS` in `services/routerBlogData.ts`) for duplicate localized slugs by parsing all 2743 entries per locale (it/en/de/fr). Result: **0 duplicates** — the 36 collisions the original PR #2835 body referenced were already deduplicated upstream in PR #3012 (`fix(routing): de-duplicate 36 colliding localized slugs in frontaliere registry`), so no dedup edit to `routerBlogData.ts` was needed here.
- Extended `scripts/ci/validate-article-append-integrity.mjs`: refactored `checkSwissSlugUniqueness` into a shared `checkSlugUniqueness(rel, reverseMapName)` helper, now called for both `services/routerSwissData.ts` (SWISS_SLUGS/REVERSE_SWISS) and `services/routerBlogData.ts` (BLOG_SLUGS/REVERSE_BLOG). This is now false-positive-free on a clean main (verified: 0 findings) and will catch the same REVERSE_*-collision corruption class going forward on the FRONTALIERE map.
- Updated the stale scope-comments in `scripts/lib/resolve-append-conflicts.sh` (steps 6 + final gate) that described SWISS-only coverage.

**Item 2 — sitemap `<loc>`-per-`<url>` verification:**
- Read and counted `<loc>` per `<url>` block in all 6 non-news sitemap files in `public/` (excluding the `sitemap.xml` index and the already-verified `sitemap-news.xml`):
  - `sitemap-blog-ch.xml`: 289 `<url>` / 289 `<loc>` (289 blocks, all 1:1)
  - `sitemap-blog.xml`: 2743 `<url>` / 2743 `<loc>` (2743 blocks, all 1:1)
  - `sitemap-glossario.xml`: 42 `<url>` / 42 `<loc>` (42 blocks, all 1:1)
  - `sitemap-guides.xml`: 8 `<url>` / 8 `<loc>` (8 blocks, all 1:1)
  - `sitemap-jobs.xml`: 1 `<url>` / 1 `<loc>` (1 block, 1:1)
  - `sitemap-pages.xml`: 182 `<url>` / 182 `<loc>` (182 blocks, all 1:1)
  - All confirmed 1:1 **per-block** (not just aggregate) — no relaxation of the assertion needed.
- Hardened the check itself rather than just documenting the invariant: added an explicit **per-`<url>`-block** `<loc>` count assertion in `checkSitemapBalance`, in addition to the existing aggregate count. Rationale: the aggregate check alone has a blind spot — a fused block (2 `<loc>`) plus a starved sibling block (0 `<loc>`) elsewhere can coincidentally balance the totals and slip through. The per-block scan closes that gap with a clear per-block error message.

**Tests added** (`tests/validate-article-append-integrity.test.ts`, isolated tmp-dir fixtures, never touches real repo files):
1. Real repo tree still exits 0 and reports both SWISS + BLOG slug-uniqueness.
2. A duplicate localized BLOG_SLUGS slug (FRONTALIERE) is caught — locks the new gate.
3. A duplicate localized SWISS_SLUGS slug is still caught after the shared-helper refactor (no regression).
4. A fused `<url>` block (2 `<loc>`) + a starved sibling block (0 `<loc>`), where aggregate counts coincidentally balance, is caught only by the new per-block check.

## Test plan

- [x] `node scripts/ci/validate-article-append-integrity.mjs` on clean tree → exit 0, "SWISS + BLOG slug-uniqueness + url-sitemap balance OK"
- [x] `npx vitest run tests/validate-article-append-integrity.test.ts` → 6/6 passed
- [x] `npx vitest run tests/blog/svizzera-section-routing.test.ts tests/blog-slugs-sitemap-sync.test.ts` → 12/12 passed (no regression)
- [x] `git merge origin/main` done pre-PR (workflow-validation-drift profilassi)

## Non implementato (ancora)

Nessuno.

Addresses item 1 di #2837 (in questa PR — dedup pre-esistente già assorbito da #3012, gate esteso a BLOG_SLUGS qui)
Addresses item 2 di #2837 (in questa PR — 6 sitemap verificati, per-block assert aggiunto)

Nota per il reviewer/gate `pr-body-contract`: #2837 è una follow-up aggregata multi-item ("2 item deferred") — niente `Closes` GitHub-native qui per non bypassare il veto multi-item-auto-close. Entrambi gli item sono però COMPLETI in questa PR: chiuderò #2837 manualmente (`gh issue close`) con citazione a questa PR dopo il merge, come da `## Implementato`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
