### PR TITLE
fix(seo): re-baseline DOWN BFS-depth ratchet for sitemap-jobs-ticino

### DIFF
--- a/data/bfs-depth-baseline.json
+++ b/data/bfs-depth-baseline.json
@@ -270,11 +270,11 @@
       "deepest": 7
     },
     "sitemap-jobs-ticino.xml": {
-      "total": 2902,
-      "reached": 2902,
-      "atDepthGtMax": 1516,
-      "ratePct": 52.2398,
-      "deepest": 7
+      "total": 1378,
+      "reached": 1378,
+      "atDepthGtMax": 546,
+      "ratePct": 39.6226,
+      "deepest": 6
     },
     "sitemap-jobs-turgovia.xml": {
       "total": 239,


### PR DESCRIPTION
## Implementato

Re-baselined the `audit:max-bfs-depth` ratchet for `sitemap-jobs-ticino.xml` down in `data/bfs-depth-baseline.json`, locking in the improvement from PR #3164 (location-inference override fix for colliding canton pins).

- Source of the observed number: the **last authoritative gate-executed** `audit:max-bfs-depth` PASS, from the `validate-dist` job of `deploy-publish.yml` run [28561412892](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28561412892) (2026-07-02T04:11Z, dist built from post-#3164 `main`). This is the most recent run where the real gate script actually executed end-to-end and printed the rebaseline-candidate JSON (most later deploy-publish runs were cancelled/skipped due to high-frequency parallel merges today, so they never produced an authoritative gate-verified number).
- Old: `total: 2902, atDepthGtMax: 1516, ratePct: 52.2398, deepest: 7` (set by #3156, pre-#3164).
- New: `total: 1378, atDepthGtMax: 546, ratePct: 39.6226, deepest: 6` — consistent with the ~37% improvement predicted in #3164's PR body.
- Verified: JSON stays valid, all 10 tests in `tests/seo/audit-bfs-depth-rate-gate.test.ts` pass, GitNexus `detect_changes` reports 0 affected code symbols (pure data-only ratchet floor, no logic change).

Note for visibility (not actioned in this PR — separate concern): a much later, non-gate-verified `dist` build (from the `seed-bfs-depth-baseline.yml` one-shot workflow, using the latest successful *build-only* `deploy.yml` run at 2026-07-02T13:44Z) showed `sitemap-jobs-ticino.xml` at ~90.9% and `sitemap-border-wait.xml` regressing similarly (27%→~82%) — i.e. a broad, site-wide reachability signal, not specific to jobs-ticino/#3164. That dist was never validated by the real gate (the corresponding `deploy-publish` run was skipped from concurrency), so it isn't used as the re-baseline source here per AGENTS.md's rule against fabricating/using unverified numbers. Flagging it in case it indicates a real regression worth a separate follow-up investigation.

## Non implementato (ancora)

Nessuno.

Closes #3186