### PR TITLE
fix(eventi): pre-flight HEAD landing check before FB article post to avoid 404 (#3047)

### DIFF
--- a/scripts/lib/social-post-utils.mjs
+++ b/scripts/lib/social-post-utils.mjs
@@ -292,3 +292,48 @@ export function buildArticleCaption({ ogTitle, ogDescription, category }) {
     hashtags,
   ].join('\n').trim();
 }
+
+// ── Landing-page pre-flight (immediate posters) ─────────────
+
+const PREFLIGHT_TIMEOUT_MS = 5000;
+
+/**
+ * HEAD-check that a just-built landing page is actually live before an
+ * immediate (non-scheduled) poster links to it. Immediate posters link to
+ * per-comune / per-article pages emitted at build time; if the deploy is
+ * slow or retrying, the page can still 404 at click-time — posting anyway
+ * would burn the click on a dead link with zero ad impression.
+ *
+ * HEAD-only (cheap, no body), bounded by a timeout via AbortController (same
+ * pattern as `scripts/probe-5xx.mjs`) so one slow/hanging comune can't stall
+ * the whole batch — callers should run these concurrently (Promise.allSettled).
+ *
+ * Fails safe: a clean 4xx OR a network error/timeout both count as "not
+ * live" and the caller should skip the post. A missing/ambiguous status
+ * (e.g. a minimal test mock, or a 5xx which may just be a transient CDN
+ * blip) is treated as live so it never blocks posting on something that
+ * isn't actually a dead link.
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<boolean>}
+ */
+export async function isLandingPageLive(url, opts = {}) {
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const timeoutMs = opts.timeoutMs || PREFLIGHT_TIMEOUT_MS;
+  if (typeof fetchImpl !== 'function') return true;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, { method: 'HEAD', signal: controller.signal });
+    if (res && typeof res.status === 'number' && res.status >= 400 && res.status < 500) return false;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/schedule-fb-articles-daily.mjs
+++ b/scripts/schedule-fb-articles-daily.mjs
@@ -49,6 +49,7 @@ import {
   loadLedger,
   appendLedger,
   ARTICLE_PLACE_ID,
+  isLandingPageLive,
 } from './lib/social-post-utils.mjs';
 
 export { buildArticleUrl, buildArticleCaption } from './lib/social-post-utils.mjs';
@@ -331,7 +332,16 @@ export async function run(opts = {}) {
   }
 
   let posted = 0;
+  let skipped = 0;
   for (const p of payloads) {
+    // Pre-flight: this immediate poster links to a freshly-built article page;
+    // a slow build/deploy can leave it not-yet-live, so skip on a confirmed
+    // 4xx rather than post a link that 404s (see isLandingPageLive doc).
+    if (!(await isLandingPageLive(p.url, { fetchImpl }))) {
+      warn('🚧', `landing page not live yet for "${p.articleId}" (${p.url}) — skipping post`);
+      skipped += 1;
+      continue;
+    }
     await rescrapeOg(p.url);
     const apiUrl = `${GRAPH_BASE}/${pageId}/feed`;
     const buildBody = () => new URLSearchParams({
@@ -377,8 +387,8 @@ export async function run(opts = {}) {
     }
   }
 
-  log('🏁', `posted ${posted}/${payloads.length} article(s)`);
-  return { ok: posted > 0, posted, dryRun, payloads };
+  log('🏁', `posted ${posted}/${payloads.length} article(s)${skipped ? ` (${skipped} skipped — landing not live yet)` : ''}`);
+  return { ok: posted > 0, posted, skipped, dryRun, payloads };
 }
 
 // ── CLI ─────────────────────────────────────────────────────

--- a/scripts/schedule-fb-events-daily.mjs
+++ b/scripts/schedule-fb-events-daily.mjs
@@ -28,7 +28,7 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadEventsDataset, upcomingEvents, slugifyComune, isoDay, weekendWindow, weekendEvents } from './lib/events-utils.mjs';
-import { loadLedger, appendLedger, stripDiacritics, truncateBody, SITE_URL } from './lib/social-post-utils.mjs';
+import { loadLedger, appendLedger, stripDiacritics, truncateBody, SITE_URL, isLandingPageLive } from './lib/social-post-utils.mjs';
 import { loadPlaceIds, lookupPlaceId } from './schedule-fb-jobs-daily.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -38,7 +38,6 @@ const LEDGER_PATH = path.join(REPO_ROOT, 'data', 'fb-posted-events.json');
 const DEFAULT_VOLUME = 3;
 const MAX_VOLUME = 10;
 const FB_MESSAGE_HARD_LIMIT = 600;
-const PREFLIGHT_TIMEOUT_MS = 5000;
 
 const CATEGORY_EMOJI = {
   arte: '🎨', musica: '🎵', teatro: '🎭', cinema: '🎬', feste: '🎉',
@@ -102,47 +101,10 @@ export function buildEventCaption(event) {
   return out;
 }
 
-/**
- * Pre-flight check: is a landing page live before we post a link to it?
- *
- * The events crawl (`:40` past the hour) and this posting cron (`:50`) leave
- * only a short window for the per-comune SSG page to be deployed. If a
- * deploy is slow or retrying, the page can still 404 at click-time — posting
- * anyway would burn the click on a dead link with zero ad impression.
- *
- * HEAD-only (cheap, no body), bounded by a timeout via AbortController (same
- * pattern as `scripts/probe-5xx.mjs`) so one slow/hanging comune can't stall
- * the whole batch — callers should run these concurrently (Promise.allSettled).
- *
- * Fails safe: a clean 4xx OR a network error/timeout both count as "not
- * live" and the caller should skip the post. A missing/ambiguous status
- * (e.g. a minimal test mock, or a 5xx which may just be a transient CDN
- * blip) is treated as live so it never blocks posting on something that
- * isn't actually a dead link.
- *
- * @param {string} url
- * @param {object} [opts]
- * @param {typeof fetch} [opts.fetchImpl]
- * @param {number} [opts.timeoutMs]
- * @returns {Promise<boolean>}
- */
-export async function isLandingPageLive(url, opts = {}) {
-  const fetchImpl = opts.fetchImpl || globalThis.fetch;
-  const timeoutMs = opts.timeoutMs || PREFLIGHT_TIMEOUT_MS;
-  if (typeof fetchImpl !== 'function') return true;
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(url, { method: 'HEAD', signal: controller.signal });
-    if (res && typeof res.status === 'number' && res.status >= 400 && res.status < 500) return false;
-    return true;
-  } catch {
-    return false;
-  } finally {
-    clearTimeout(timer);
-  }
-}
+// isLandingPageLive moved to ./lib/social-post-utils.mjs (shared with the
+// articles poster, AGENTS.md §6 — no duplicate pre-flight logic per channel).
+// Re-exported here for backward-compat with existing test imports.
+export { isLandingPageLive };
 
 /** Select the soonest-starting upcoming events not yet in `postedSet`. */
 export function selectUnpostedEvents(events, postedSet, limit) {

--- a/tests/scripts/schedule-fb-articles-daily.test.ts
+++ b/tests/scripts/schedule-fb-articles-daily.test.ts
@@ -348,10 +348,12 @@ describe('run()', () => {
     expect(loadPosted(tmp).posted).toHaveLength(0);
   });
 
-  it('real run: posts each article (rescrape + feed) and updates the ledger', async () => {
+  it('real run: posts each article (preflight + rescrape + feed) and updates the ledger', async () => {
     const tmp = setupRepo({ articles: [{ id: 'a1', date: '2026-06-12' }] });
     const fetchSpy = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
+      // Pre-flight HEAD probe of the landing page → live (2xx).
+      if (init?.method === 'HEAD') return new Response(null, { status: 200 });
       if (u.includes('scrape=true')) return new Response(JSON.stringify({ scraped: true }), { status: 200 });
       expect(init?.method).toBe('POST');
       return new Response(JSON.stringify({ id: 'pid_post_1' }), { status: 200 });
@@ -366,12 +368,33 @@ describe('run()', () => {
     });
     expect(result.posted).toBe(1);
     expect(result.ok).toBe(true);
-    // OG rescrape + /feed POST = 2 calls.
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // pre-flight HEAD + OG rescrape + /feed POST = 3 calls.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
     const ledger = loadPosted(tmp);
     expect(ledger.posted).toHaveLength(1);
     expect(ledger.posted[0].id).toBe('a1');
     expect(ledger.posted[0].fbPostId).toBe('pid_post_1');
+  });
+
+  it('skips the post when the landing page is not live yet (HEAD 4xx)', async () => {
+    const tmp = setupRepo({ articles: [{ id: 'a1', date: '2026-06-12' }] });
+    const fetchSpy = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'HEAD') return new Response(null, { status: 404 });
+      return new Response(JSON.stringify({ id: 'pid_post_1' }), { status: 200 });
+    });
+    const result = await run({
+      env: { FB_ARTICLE_MAX_AGE_DAYS: '2', FB_PAGE_ID: 'pid', FB_PAGE_ACCESS_TOKEN: 'tok' },
+      now: NOW,
+      repoRoot: tmp,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      log: () => {},
+      warn: () => {},
+    });
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    // a 4xx landing short-circuits before any rescrape/feed POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(loadPosted(tmp).posted).toHaveLength(0);
   });
 
   it('does not re-post an article already in the ledger', async () => {


### PR DESCRIPTION
## Implementato
- Moved `isLandingPageLive` from `scripts/schedule-fb-events-daily.mjs` into the shared `scripts/lib/social-post-utils.mjs` (was already added there for the events poster by PR #3301; the articles poster — the other immediate FB feed poster — still lacked it).
- Wired the same pre-flight HEAD check into `schedule-fb-articles-daily.mjs` before the OG rescrape/POST: a confirmed 4xx skips the post (fails open on network error/timeout/5xx per the existing doc contract).
- Re-exported `isLandingPageLive` from `schedule-fb-events-daily.mjs` for backward-compat with the existing test import path — no behavior change there.
- Added a new test (`skips the post when the landing page is not live yet (HEAD 4xx)`) and updated the existing real-run test in `tests/scripts/schedule-fb-articles-daily.test.ts` for the extra pre-flight HEAD call.

## Non implementato (ancora)
- Item 1 of #3047 (crawler siti comunali singoli + altri cantoni — feasibility/tracking) is unrelated to this fix and remains open on that issue; not addressed here.

## Contesto
Addresses item 2 of #3047 (pre-flight HTTP check before FB post). Item 2's own text names `schedule-fb-events-daily.mjs` explicitly, which already got this guard via PR #3301 (batch follow-up round 3); this PR completes the same protection for `schedule-fb-articles-daily.mjs`, the other immediate FB feed poster, and de-duplicates the pre-flight helper into the shared module per AGENTS.md §6 instead of reintroducing a second copy. The original automated `issue-fix` run (commit `519d483730c` on the now-stale branch `fix/issue-3047`) implemented an equivalent fix but hit `error_max_turns` before opening a PR.

Addresses item 2 of #3047