### PR TITLE
fix(generate-article): stop 300min local-fallback override from defeating deadlineMs abort

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -204,19 +204,22 @@ jobs:
           # 55-min frontaliere budget is safe and well under the hard cap.
           # svizzera keeps the original 30-min cap (it never approaches it).
           #
-          # When the local-LLM fallback is enabled (ARTICLE_LOCAL_FALLBACK=1),
-          # generation can fall to a slow CPU model whose single calls take
-          # minutes. NB (corrected Jun-29, run 28390219943): earlier "3b 12/55min,
-          # 7b ~2/55min, deferred on the wall" was WRONG — every local call was
-          # dying at undici's 300s headersTimeout as `fetch failed`, so no local
-          # generation ever completed (fixed in #3102 via a per-call dispatcher).
-          # The 300-min budget still gives a genuinely-slow CPU model room to RUN
-          # TO COMPLETION so we can measure its real end-to-end time. Still under
-          # the 360-min job `timeout-minutes`
-          # (300min create-article + ollama setup + commit/deploy < 360). Defers
-          # stay rare/acceptable; this just stops the premature cut-off so the
-          # measurement is real. Reverts to 55/30 min when the var is unset.
-          CREATE_ARTICLE_MAX_WALL_MS: ${{ vars.ARTICLE_LOCAL_FALLBACK == '1' && '18000000' || (steps.section.outputs.section == 'svizzera' && '1800000' || '3300000') }}
+          # Local-LLM fallback (ARTICLE_LOCAL_FALLBACK=1) previously blew this
+          # budget to 300min (18000000) so a slow CPU call could run to
+          # completion for measurement (fixed in #3102 via a per-call
+          # dispatcher after an earlier false "deferred on wall" reading).
+          # That measurement is done: across 60 runs 2026-06-30..07-03, local
+          # fallback engaged in only 2/60 runs, ~6-11min per call, both
+          # succeeded — well inside the normal 55/30min budget. Meanwhile the
+          # 300min override was silently defeating the deadlineMs cascade-
+          # abort safety added in #3307 (RUN_START_MS + RUN_WALL_BUDGET_MS
+          # never elapsed within a run), letting single generate/translate/
+          # fact-check calls walk the entire free-tier chain uninterrupted —
+          # the real driver behind 60-140min runs, not the local fallback.
+          # Reverting unconditionally to the section-based budget restores
+          # the deadlineMs abort and keeps local fallback available (it still
+          # fires when reached) without the runaway ceiling.
+          CREATE_ARTICLE_MAX_WALL_MS: ${{ steps.section.outputs.section == 'svizzera' && '1800000' || '3300000' }}
         run: |
           echo "📰 Generating blog article (section=$TARGET_SECTION)..."
           if [ -n "${{ inputs.url }}" ]; then


### PR DESCRIPTION
## Implementato

`CREATE_ARTICLE_MAX_WALL_MS` in `.github/workflows/generate-article.yml` no longer gets inflated to 300min (18000000ms) when `ARTICLE_LOCAL_FALLBACK==1`. It now always uses the plain section-based budget (55min frontaliere / 30min svizzera).

**Why:** the 300min override was added 2026-06-29 as a one-time measurement window (let the CPU-only Ollama qwen2.5:7b fallback run to completion, since an earlier undici-timeout bug had made it look permanently non-functional — fixed in #3102). That measurement is now done: sampled the last 60 runs (2026-06-30 → 2026-07-03) — local fallback actually engaged in only 2/60 runs, taking ~6-11min per call, both succeeded. It's a rare, cheap, working last-resort — it never needed 300min.

Meanwhile that same 300min ceiling was silently defeating an unrelated, already-merged safety mechanism: `opts.deadlineMs` in `scripts/lib/ai-models.mjs` (added in #3307) aborts a single cascade walk once `RUN_START_MS + RUN_WALL_BUDGET_MS` elapses, instead of letting one `callLLM()` call try every model in the free-tier chain. With the budget stretched to 300min, that deadline almost never fires within a run, so a single generate/translate/fact-check call could walk the whole chain uninterrupted — confirmed in logs: the two longest sampled runs (137.8min, 75.8min) show 135-220 "Falling back to X" events with repeating ~90s timeout gaps, accounting for 58-77% of their wall-clock, with Ollama never even invoked in most of them. That's the real driver of the 60-140min run-time spread (median 21.7min, p90 59.9min, max 137.8min across the 60-run sample), not the local fallback.

Reverting to the section-based budget unconditionally restores the `deadlineMs` abort (so a stuck cascade walk gets cut at ~55/30min instead of running unbounded) while keeping local fallback available and used within that window.

## Non implementato (ancora)

Nessuno.

Confirmed scope-adjacent items are *not* in scope here (correctly not listed as deferred, since they're separate concerns, not part of this fix):
- Cron (`7,37 * * * *`) vs self-trigger-chain overlap: 8/60 sampled runs were cancelled, but all-but-one were `schedule`-triggered runs superseded by the concurrency group before any job started (`jobs:[]`, ~0 wasted runner-minutes) — cosmetic Actions-history noise, not a real time cost, and expected to shrink further as run durations shorten. No change needed.
- The remote free-tier cascade's own retry/backoff tuning (~90s per-model timeout, multi-PAT rotation) is unchanged — out of scope for this fix, which only restores an existing safety mechanism that was accidentally disabled.

## Test plan

- [x] `npx vitest run tests/workflow-permissions-parity.test.ts tests/deploy-workflow.test.ts tests/followup-drainer-workflow-scope.test.ts` — 34/34 passed
- [x] YAML re-parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/generate-article.yml'))"`)
- [x] `gitnexus_detect_changes` — risk_level none (workflow YAML, no indexed code symbols touched)
- [ ] Live: next few `generate-article` runs should complete within ~55/30min instead of occasionally running 1-2+ hours — verify via `gh run list --workflow "Generate Blog Article"` durations post-merge.