### PR TITLE
feat(jobalert): backfill alerts from job_gate newsletter subscribers

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -41,6 +41,7 @@ import { sendRenewalReminders } from './src/publisherRenewalCore.js';
 import { handleVerifyPublisherDomain } from './src/publisherDomainVerifyCore.js';
 import { enforceFreeTierCap } from './src/publisherFreeCapCore.js';
 import { syncAuthAccountForSubscriber } from './src/newsletterSubscriberAuthSync.js';
+import { handleNewsletterSubscriberCreated } from './src/jobAlertBackfillTrigger.js';
 
 ensureAdminApp();
 
@@ -1057,6 +1058,32 @@ export const syncNewsletterSubscriberAuth = onDocumentCreated(
  if (result.created) console.log(`[syncNewsletterSubscriberAuth] created Auth user for ${emailId}`);
  } catch (error) {
  console.error('[syncNewsletterSubscriberAuth]', error instanceof Error ? error.message : String(error));
+ }
+ },
+);
+
+// Real-time counterpart of scripts/backfill-jobalerts-from-newsletter.mjs:
+// every new newsletter_subscribers doc that carries job-search signal (or,
+// failing that, a location signal) gets a near-empty job_alert_subscribers
+// entry the day after signup, instead of waiting for the next manual batch
+// run. Shares its decision logic with the batch script via
+// jobAlertBackfillCore.js.
+export const backfillJobAlertOnNewsletterSignup = onDocumentCreated(
+ { region: 'europe-west6', memory: '256MiB', document: 'newsletter_subscribers/{email}' },
+ async (event) => {
+ const emailId = event.params.email;
+ const snap = event.data;
+ if (!snap || emailId === '_meta_') return;
+ try {
+ const result = await handleNewsletterSubscriberCreated(emailId, snap.data());
+ if (result.created) {
+ console.log(`[backfillJobAlertOnNewsletterSignup] created alert for ${emailId} (${result.tier})`);
+ }
+ } catch (error) {
+ console.error(
+ '[backfillJobAlertOnNewsletterSignup]',
+ error instanceof Error ? error.message : String(error),
+ );
  }
  },
 );

--- a/functions/index.js
+++ b/functions/index.js
@@ -30,7 +30,7 @@ import { getAdminDb } from './src/newsletterResendWebhookCore.js';
 import { Resend } from 'resend';
 import { handleCreatePublisherCheckout, handleStripeWebhook, handleCreateBillingPortal, handleArchivePublisherAd, handleRestorePublisherAd } from './src/stripePublisherCore.js';
 import { reapStalePendingPayments } from './src/publisherPendingReapCore.js';
-import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { onDocumentCreated, onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import {
   handleForwardApplication,
@@ -42,6 +42,7 @@ import { handleVerifyPublisherDomain } from './src/publisherDomainVerifyCore.js'
 import { enforceFreeTierCap } from './src/publisherFreeCapCore.js';
 import { syncAuthAccountForSubscriber } from './src/newsletterSubscriberAuthSync.js';
 import { handleNewsletterSubscriberCreated } from './src/jobAlertBackfillTrigger.js';
+import { signalTierChanged } from './src/jobAlertBackfillCore.js';
 
 ensureAdminApp();
 
@@ -1063,19 +1064,32 @@ export const syncNewsletterSubscriberAuth = onDocumentCreated(
 );
 
 // Real-time counterpart of scripts/backfill-jobalerts-from-newsletter.mjs:
-// every new newsletter_subscribers doc that carries job-search signal (or,
+// every newsletter_subscribers doc that carries job-search signal (or,
 // failing that, a location signal) gets a near-empty job_alert_subscribers
-// entry the day after signup, instead of waiting for the next manual batch
-// run. Shares its decision logic with the batch script via
-// jobAlertBackfillCore.js.
-export const backfillJobAlertOnNewsletterSignup = onDocumentCreated(
+// entry, instead of waiting for the next manual batch run. Shares its
+// decision logic with the batch script via jobAlertBackfillCore.js.
+//
+// onDocumentWritten (not onDocumentCreated): social sign-in flows
+// (services/authService.ts) write this doc twice, unsequenced — an
+// un-awaited auth-fields-only write races the full signal-carrying upsert,
+// and the bare write structurally tends to land first. A one-shot create
+// hook would see zero signal and skip the subscriber permanently once the
+// real signal arrives via a later merge. signalTierChanged gates the write
+// hook so it only does real work when eligibility actually flips, which
+// both catches the delayed signal and keeps routine engagement writes
+// (open/click tracking) a cheap no-op.
+export const backfillJobAlertOnNewsletterSignup = onDocumentWritten(
  { region: 'europe-west6', memory: '256MiB', document: 'newsletter_subscribers/{email}' },
  async (event) => {
  const emailId = event.params.email;
- const snap = event.data;
- if (!snap || emailId === '_meta_') return;
+ if (emailId === '_meta_') return;
+ const after = event.data?.after;
+ if (!after?.exists) return; // ignore deletes
+ const afterData = after.data();
+ const beforeData = event.data?.before?.exists ? event.data.before.data() : null;
+ if (!signalTierChanged(beforeData, afterData)) return;
  try {
- const result = await handleNewsletterSubscriberCreated(emailId, snap.data());
+ const result = await handleNewsletterSubscriberCreated(emailId, afterData);
  if (result.created) {
  console.log(`[backfillJobAlertOnNewsletterSignup] created alert for ${emailId} (${result.tier})`);
  }

--- a/functions/src/jobAlertBackfillCore.js
+++ b/functions/src/jobAlertBackfillCore.js
@@ -1,0 +1,99 @@
+/**
+ * Pure decision logic shared by the batch backfill script
+ * (`scripts/backfill-jobalerts-from-newsletter.mjs`, via the
+ * `scripts/lib/jobalert-backfill-core.mjs` shim) and the real-time
+ * `onDocumentCreated` trigger (`jobAlertBackfillTrigger.js`) that fires on
+ * every new `newsletter_subscribers/{email}` doc going forward.
+ *
+ * Canonical here (not in `services/`) because Cloud Functions have no
+ * bundler and cannot import anything outside `functions/`.
+ *
+ * Signal tiers, cheapest-first:
+ *  1. `job_category`/`job_location` — job-specific context (job_gate unlock,
+ *     JobBoard social sign-in with a job in progress). `buildAlertProfile`
+ *     (services/jobAlertMatching.mjs) turns these into soft keyword/sector
+ *     tokens automatically.
+ *  2. `location_interest`/`geo_city` — generic location signal with no job
+ *     context (IP-geolocated city, a location preference picked elsewhere).
+ *     Live count against prod newsletter_subscribers (2026-07-03) found this
+ *     tier adds only ~5 subscribers beyond tier 1 — most no-signal docs have
+ *     no geo data at all — but it's a correct, zero-cost fallback so it's
+ *     kept: `buildAlertProfile` already reads these same fields into
+ *     preferredLocations/preferredCantons as a SOFT ranking signal, so a
+ *     tier-2 alert becomes a broad "jobs near you" digest rather than a
+ *     precise match — never a hard filter (`cantonFilter` stays null).
+ */
+
+import { isNewsletterExcluded } from './lib/emailSuppression.js';
+
+export const MAX_ALERTS_PER_USER = 3; // services/jobAlertService.ts:68
+export const ALERT_ID = 'backfill-newsletter';
+
+export function normalizeEmail(raw) {
+  return String(raw || '').trim().toLowerCase();
+}
+
+/**
+ * @returns {'signal'|'location-fallback'|'none'}
+ */
+function getSignalTier(data) {
+  const category = String(data?.job_category || '').trim();
+  const location = String(data?.job_location || '').trim();
+  if (category || location) return 'signal';
+  const locationInterest = String(data?.location_interest || '').trim();
+  const geoCity = String(data?.geo_city || '').trim();
+  if (locationInterest || geoCity) return 'location-fallback';
+  return 'none';
+}
+
+/**
+ * Pure eligibility check for one `newsletter_subscribers` doc.
+ * @returns {'invalid-email'|'suppressed'|'no-signal'|null} skip reason, null = eligible.
+ */
+export function shouldSkipSubscriber(email, data) {
+  if (!email || !email.includes('@')) return 'invalid-email';
+  if (isNewsletterExcluded(data?.status)) return 'suppressed';
+  if (getSignalTier(data) === 'none') return 'no-signal';
+  return null;
+}
+
+/**
+ * Pure payload builder — no Firestore I/O, no serverTimestamp (callers stamp
+ * `createdAt`/`backfilled_at`/`updated_at` after this returns, so the shape
+ * stays testable without mocking firebase-admin).
+ *
+ * `existingBackfill` is the full prior `backfill-newsletter` doc data (or
+ * null on first creation). Its `active` flag is carried forward as-is so a
+ * re-run/re-trigger never undoes a user's explicit unsubscribe (`deleteAlert`
+ * sets `active: false`) — only a brand-new doc defaults to `active: true`.
+ */
+export function buildAlertPayload(email, data, existingBackfill) {
+  const tier = getSignalTier(data);
+  const channel = data?.source_channel || 'unknown';
+  return {
+    email,
+    userId: data?.user_id || null,
+    keywords: [],
+    locations: [],
+    contractTypes: [],
+    sectors: [],
+    cantonFilter: null,
+    frequency: 'daily',
+    locale: data?.preferred_locale || data?.locale || 'it',
+    sourceJobSlug: data?.job_slug || null,
+    sourceJobUrl: null,
+    sourceJobTitle: null,
+    specificJobId: null,
+    specificCompanyKey: null,
+    active: existingBackfill ? existingBackfill.active !== false : true,
+    matchCount: existingBackfill?.matchCount || 0,
+    lastMatchedAt: existingBackfill?.lastMatchedAt || null,
+    // Provenance — lets a future audit tell inferred alerts apart from
+    // explicit ones, see which signup channel triggered it, and which
+    // signal tier it was built from.
+    backfilled_from:
+      tier === 'location-fallback'
+        ? `newsletter_subscribers:${channel}:location-fallback`
+        : `newsletter_subscribers:${channel}`,
+  };
+}

--- a/functions/src/jobAlertBackfillCore.js
+++ b/functions/src/jobAlertBackfillCore.js
@@ -2,11 +2,25 @@
  * Pure decision logic shared by the batch backfill script
  * (`scripts/backfill-jobalerts-from-newsletter.mjs`, via the
  * `scripts/lib/jobalert-backfill-core.mjs` shim) and the real-time
- * `onDocumentCreated` trigger (`jobAlertBackfillTrigger.js`) that fires on
- * every new `newsletter_subscribers/{email}` doc going forward.
+ * `onDocumentWritten` trigger (`jobAlertBackfillTrigger.js`) that fires on
+ * every `newsletter_subscribers/{email}` write going forward.
  *
  * Canonical here (not in `services/`) because Cloud Functions have no
  * bundler and cannot import anything outside `functions/`.
+ *
+ * Why `onDocumentWritten`, not `onDocumentCreated`: on every social sign-in
+ * (Google/Facebook/LinkedIn/One-Tap), `saveUserProfileToFirestore`
+ * (services/authService.ts) fires an un-awaited `setDoc(..., {merge:true})`
+ * with only auth fields (no job/location signal), racing the full
+ * `upsertNewsletterSubscriber` write that carries the real signal fields —
+ * and the bare write structurally tends to land first (fewer awaits, no
+ * pre-read). A one-shot `onDocumentCreated` would see zero signal at create
+ * time and skip the subscriber permanently, since the later merge is an
+ * UPDATE the create-hook never sees. `signalTierChanged` (below) lets the
+ * write-hook re-evaluate on every write cheaply (pure field diff, no
+ * Firestore read) and only do real work when eligibility actually flips —
+ * which both catches the delayed signal and keeps routine engagement writes
+ * (open/click tracking) a no-op.
  *
  * Signal tiers, cheapest-first:
  *  1. `job_category`/`job_location` — job-specific context (job_gate unlock,
@@ -34,9 +48,10 @@ export function normalizeEmail(raw) {
 }
 
 /**
+ * @param {Record<string, unknown>|null|undefined} data
  * @returns {'signal'|'location-fallback'|'none'}
  */
-function getSignalTier(data) {
+export function getSignalTier(data) {
   const category = String(data?.job_category || '').trim();
   const location = String(data?.job_location || '').trim();
   if (category || location) return 'signal';
@@ -44,6 +59,20 @@ function getSignalTier(data) {
   const geoCity = String(data?.geo_city || '').trim();
   if (locationInterest || geoCity) return 'location-fallback';
   return 'none';
+}
+
+/**
+ * True when the signal tier differs between the doc's prior and new state —
+ * i.e. this write is the one that actually made (or unmade) eligibility,
+ * not an unrelated field update (auth profile fields, engagement tracking).
+ * `beforeData` is null on doc creation (treated as tier 'none').
+ * @param {Record<string, unknown>|null} beforeData
+ * @param {Record<string, unknown>|null|undefined} afterData
+ * @returns {boolean}
+ */
+export function signalTierChanged(beforeData, afterData) {
+  const beforeTier = beforeData ? getSignalTier(beforeData) : 'none';
+  return getSignalTier(afterData) !== beforeTier;
 }
 
 /**

--- a/functions/src/jobAlertBackfillTrigger.js
+++ b/functions/src/jobAlertBackfillTrigger.js
@@ -1,0 +1,79 @@
+/**
+ * Real-time counterpart of `scripts/backfill-jobalerts-from-newsletter.mjs`.
+ * Fires on every new `newsletter_subscribers/{email}` doc going forward
+ * (see functions/index.js → `backfillJobAlertOnNewsletterSignup`), so a
+ * `job_alert_subscribers/{email}/alerts/backfill-newsletter` entry exists the
+ * day after signup without waiting for the next manual batch run.
+ *
+ * Shares the exact decision logic with the batch script via
+ * `jobAlertBackfillCore.js` — no drift between "day-0 backfill of existing
+ * docs" and "day-N auto-creation for new ones".
+ */
+
+import admin from 'firebase-admin';
+import {
+  MAX_ALERTS_PER_USER,
+  ALERT_ID,
+  normalizeEmail,
+  shouldSkipSubscriber,
+  buildAlertPayload,
+} from './jobAlertBackfillCore.js';
+
+export function getAdminDb() {
+  return admin.firestore();
+}
+
+/**
+ * @param {string} emailId  the newsletter_subscribers/{email} doc id
+ * @param {Record<string, unknown>} data  the doc's field data
+ * @param {{db?: FirebaseFirestore.Firestore}} [deps]
+ * @returns {Promise<{created: boolean, reason?: string, tier?: string}>}
+ */
+export async function handleNewsletterSubscriberCreated(emailId, data, { db = getAdminDb() } = {}) {
+  if (!emailId || emailId === '_meta_') {
+    return { created: false, reason: 'meta_sentinel' };
+  }
+
+  const email = normalizeEmail(data?.email || emailId);
+  const skipReason = shouldSkipSubscriber(email, data);
+  if (skipReason) {
+    return { created: false, reason: skipReason };
+  }
+
+  const subscriberRef = db.collection('job_alert_subscribers').doc(email);
+  const alertsRef = subscriberRef.collection('alerts');
+  // Read every alert doc (not just active:true) — mirrors the batch script,
+  // so a pre-existing user-disabled backfill doc is never mistaken for absent.
+  const existingAlerts = await alertsRef.get();
+  const existingBackfillDoc = existingAlerts.docs.find((d) => d.id === ALERT_ID);
+  const activeOtherCount = existingAlerts.docs.filter(
+    (d) => d.id !== ALERT_ID && d.data().active === true,
+  ).length;
+  if (!existingBackfillDoc && activeOtherCount >= MAX_ALERTS_PER_USER) {
+    return { created: false, reason: 'capped' };
+  }
+
+  const alertPayload = buildAlertPayload(email, data, existingBackfillDoc?.data());
+
+  const parentPayload = {
+    email,
+    userId: alertPayload.userId,
+    locale: alertPayload.locale,
+    updated_at: admin.firestore.FieldValue.serverTimestamp(),
+    created_at: admin.firestore.FieldValue.serverTimestamp(),
+  };
+  const existingParent = await subscriberRef.get();
+  if (existingParent.exists) delete parentPayload.created_at;
+  await subscriberRef.set(parentPayload, { merge: true });
+
+  await alertsRef.doc(ALERT_ID).set(
+    {
+      ...alertPayload,
+      backfilled_at: admin.firestore.FieldValue.serverTimestamp(),
+      ...(existingBackfillDoc ? {} : { createdAt: admin.firestore.FieldValue.serverTimestamp() }),
+    },
+    { merge: true },
+  );
+
+  return { created: true, tier: alertPayload.backfilled_from };
+}

--- a/functions/src/jobAlertBackfillTrigger.js
+++ b/functions/src/jobAlertBackfillTrigger.js
@@ -1,9 +1,12 @@
 /**
  * Real-time counterpart of `scripts/backfill-jobalerts-from-newsletter.mjs`.
- * Fires on every new `newsletter_subscribers/{email}` doc going forward
- * (see functions/index.js → `backfillJobAlertOnNewsletterSignup`), so a
- * `job_alert_subscribers/{email}/alerts/backfill-newsletter` entry exists the
- * day after signup without waiting for the next manual batch run.
+ * Invoked from an `onDocumentWritten` trigger on every
+ * `newsletter_subscribers/{email}` write going forward (see
+ * functions/index.js → `backfillJobAlertOnNewsletterSignup`), gated by
+ * `signalTierChanged` so it only does real work when eligibility actually
+ * flips — see the rationale in `jobAlertBackfillCore.js` for why a plain
+ * `onDocumentCreated` misses subscribers whose signal fields arrive via a
+ * later merge write.
  *
  * Shares the exact decision logic with the batch script via
  * `jobAlertBackfillCore.js` — no drift between "day-0 backfill of existing

--- a/functions/src/lib/emailSuppression.js
+++ b/functions/src/lib/emailSuppression.js
@@ -1,0 +1,78 @@
+/**
+ * Shared subscriber-`status` suppression sets — the single source of truth for
+ * "stop emailing this recipient", used by every sender (newsletter, job alerts,
+ * publisher blast). Extracting it here makes the value drift that previously
+ * existed impossible by-construction: `publisherBlastMatch.mjs` checked for the
+ * literal `'complaint'` (an event-type discriminator, NEVER a subscriber status
+ * value) and so never actually suppressed users who filed a spam complaint,
+ * while `send-job-alerts.mjs` checked no status at all.
+ *
+ * The canonical `status` values are written by every `newsletter*WebhookCore.js`
+ * on provider events: `bounced` (hard bounce), `complained` (spam complaint),
+ * `suppressed` (provider suppression list), and the channel-level `unsubscribed`.
+ * Confirmed against all six webhook cores — they uniformly write `complained`
+ * (the `complaint` strings in those files are event-type names, not statuses).
+ */
+
+/**
+ * Address-level hard signals. The mailbox is dead (bounced), the human flagged
+ * us as spam (complained), or the provider blocklisted the address (suppressed).
+ * These apply across BOTH channels — newsletter AND job alerts — because the
+ * signal is about the address, not a per-channel consent choice.
+ */
+export const ADDRESS_SUPPRESSED_STATUSES = new Set(['bounced', 'complained', 'suppressed']);
+
+/**
+ * Newsletter-channel exclusions: the address-level signals PLUS the channel-level
+ * soft states — `unsubscribed` (explicit opt-out) and `inactive` (the sunset of a
+ * never-engager, see scripts/lib/subscriberSunset.mjs). Both are reversible and
+ * newsletter-specific. Job alerts do NOT fold these in — an alert opt-out is the
+ * per-alert `active:false` flag, a separate consent, and a newsletter-only sunset
+ * must never silently cross to the alert channel. `inactive` is NOT in
+ * ADDRESS_SUPPRESSED_STATUSES because it is a soft, channel-level state, not a
+ * hard cross-channel signal (a bounce/complaint).
+ */
+export const NEWSLETTER_EXCLUDED_STATUSES = new Set(['unsubscribed', 'inactive', ...ADDRESS_SUPPRESSED_STATUSES]);
+
+/**
+ * Job-alert-channel exclusions: the address-level signals PLUS that channel's OWN
+ * `inactive` soft state (the sunset of a never-engaging job-alert subscriber, see
+ * scripts/lib/jobAlertSunset.mjs — issue #2852 item 1). This `inactive` lives on
+ * `job_alert_subscribers/{email}.status` — a completely separate document/field
+ * from the newsletter one above, so there is no cross-channel leak in either
+ * direction. Job alerts have no `unsubscribed` channel status: an alert opt-out
+ * is the per-alert `active:false` flag on the `alerts` subcollection, unrelated
+ * to this top-level doc-level set.
+ */
+export const JOB_ALERT_EXCLUDED_STATUSES = new Set(['inactive', ...ADDRESS_SUPPRESSED_STATUSES]);
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
+
+/**
+ * True when an address-level hard signal (bounce/complaint/suppression) means we
+ * must never email this address again on ANY channel.
+ * @param {string|null|undefined} status
+ * @returns {boolean}
+ */
+export function isAddressSuppressed(status) {
+  return ADDRESS_SUPPRESSED_STATUSES.has(norm(status));
+}
+
+/**
+ * True when a newsletter recipient must be excluded (address signals + unsub).
+ * @param {string|null|undefined} status
+ * @returns {boolean}
+ */
+export function isNewsletterExcluded(status) {
+  return NEWSLETTER_EXCLUDED_STATUSES.has(norm(status));
+}
+
+/**
+ * True when a job-alert recipient must be excluded (address signals + that
+ * channel's own inactivity sunset).
+ * @param {string|null|undefined} status
+ * @returns {boolean}
+ */
+export function isJobAlertExcluded(status) {
+  return JOB_ALERT_EXCLUDED_STATUSES.has(norm(status));
+}

--- a/scripts/backfill-jobalerts-from-newsletter.mjs
+++ b/scripts/backfill-jobalerts-from-newsletter.mjs
@@ -4,7 +4,7 @@
  * ALL `newsletter_subscribers` docs, regardless of `source_channel`.
  *
  * One-off batch pass over EXISTING docs. Going forward, new docs are covered
- * automatically by the `onDocumentCreated` trigger in
+ * automatically by the `onDocumentWritten` trigger in
  * `functions/index.js` → `functions/src/jobAlertBackfillTrigger.js`, which
  * shares the exact same decision logic via `functions/src/jobAlertBackfillCore.js`
  * (re-exported here through `scripts/lib/jobalert-backfill-core.mjs` so both

--- a/scripts/backfill-jobalerts-from-newsletter.mjs
+++ b/scripts/backfill-jobalerts-from-newsletter.mjs
@@ -3,13 +3,20 @@
  * Backfill `job_alert_subscribers/{email}/alerts/backfill-newsletter` from
  * ALL `newsletter_subscribers` docs, regardless of `source_channel`.
  *
+ * One-off batch pass over EXISTING docs. Going forward, new docs are covered
+ * automatically by the `onDocumentCreated` trigger in
+ * `functions/index.js` → `functions/src/jobAlertBackfillTrigger.js`, which
+ * shares the exact same decision logic via `functions/src/jobAlertBackfillCore.js`
+ * (re-exported here through `scripts/lib/jobalert-backfill-core.mjs` so both
+ * paths can never drift apart).
+ *
  * Rationale: a subscriber who left a `job_category`/`job_location` signal
  * behind — no matter which CTA captured their email (job-detail unlock,
  * social sign-in on the job board, One Tap, generic footer signup, …) — is
  * signalling job-search intent even though they never explicitly created an
  * alert. Channel does not need to gate this: a live count against
- * `newsletter_subscribers` (2026-07, 5429 docs) showed the field-based signal
- * check below already discriminates correctly per channel without any
+ * `newsletter_subscribers` (2026-07-03, 5429 docs) showed the field-based
+ * signal check already discriminates correctly per channel without any
  * per-channel branching — `job_gate` (753 eligible), `auth_google` (993),
  * `auth_linkedin` (466) carry real signal; generic/unrelated CTAs
  * (`analysis_gate`, `post_calc_cta`, `newsletter_page`, `lead_magnet`,
@@ -19,6 +26,9 @@
  * source_channel values are dead code paths (`normalizeSourceChannel`,
  * services/newsletterSubscribers.ts, collapses them into `auth_google`/
  * `auth_facebook`/`job_gate` before storage) — 0 live docs, nothing to skip.
+ * A location-only fallback tier (`location_interest`/`geo_city`, see
+ * `jobAlertBackfillCore.js`) adds ~5 more — most no-signal docs have no geo
+ * data either, but it's a correct zero-cost catch-all.
  *
  * The backfilled alert is deliberately near-empty (`keywords: []`,
  * `locations: []`, `cantonFilter: null`): `buildAlertProfile`
@@ -44,63 +54,17 @@
 
 import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { isNewsletterExcluded } from '../services/emailSuppression.mjs';
+import {
+  MAX_ALERTS_PER_USER,
+  ALERT_ID,
+  normalizeEmail,
+  shouldSkipSubscriber,
+  buildAlertPayload,
+} from './lib/jobalert-backfill-core.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
-export const MAX_ALERTS_PER_USER = 3; // services/jobAlertService.ts:68
-export const ALERT_ID = 'backfill-newsletter';
 
-export function normalizeEmail(raw) {
-  return String(raw || '').trim().toLowerCase();
-}
-
-/**
- * Pure eligibility check for one `newsletter_subscribers` doc.
- * @returns {'invalid-email'|'suppressed'|'no-signal'|null} skip reason, null = eligible.
- */
-export function shouldSkipSubscriber(email, data) {
-  if (!email || !email.includes('@')) return 'invalid-email';
-  if (isNewsletterExcluded(data?.status)) return 'suppressed';
-  const category = String(data?.job_category || '').trim();
-  const location = String(data?.job_location || '').trim();
-  if (!category && !location) return 'no-signal';
-  return null;
-}
-
-/**
- * Pure payload builder — no Firestore I/O, no serverTimestamp (caller stamps
- * `createdAt`/`backfilled_at`/`updated_at` after this returns, so the shape
- * stays testable without mocking firebase-admin).
- *
- * `existingBackfill` is the full prior `backfill-newsletter` doc data (or
- * null on first creation). Its `active` flag is carried forward as-is so a
- * re-run never undoes a user's explicit unsubscribe (`deleteAlert` sets
- * `active: false`) — only a brand-new doc defaults to `active: true`.
- */
-export function buildAlertPayload(email, data, existingBackfill) {
-  return {
-    email,
-    userId: data?.user_id || null,
-    keywords: [],
-    locations: [],
-    contractTypes: [],
-    sectors: [],
-    cantonFilter: null,
-    frequency: 'daily',
-    locale: data?.preferred_locale || data?.locale || 'it',
-    sourceJobSlug: data?.job_slug || null,
-    sourceJobUrl: null,
-    sourceJobTitle: null,
-    specificJobId: null,
-    specificCompanyKey: null,
-    active: existingBackfill ? existingBackfill.active !== false : true,
-    matchCount: existingBackfill?.matchCount || 0,
-    lastMatchedAt: existingBackfill?.lastMatchedAt || null,
-    // Provenance — lets a future audit tell inferred alerts apart from
-    // explicit ones, and see which signup channel triggered it.
-    backfilled_from: `newsletter_subscribers:${data?.source_channel || 'unknown'}`,
-  };
-}
+export { MAX_ALERTS_PER_USER, ALERT_ID, normalizeEmail, shouldSkipSubscriber, buildAlertPayload };
 
 let _db = null;
 async function getFirestoreAdmin() {
@@ -161,7 +125,7 @@ async function main() {
     byChannel[channel].created++;
 
     if (DRY_RUN) {
-      console.log(` [dry] ${existingBackfillDoc ? 'merge' : 'create'} job_alert_subscribers/${email}/alerts/${ALERT_ID} (category=${data.job_category || '∅'}, location=${data.job_location || '∅'})`);
+      console.log(` [dry] ${existingBackfillDoc ? 'merge' : 'create'} job_alert_subscribers/${email}/alerts/${ALERT_ID} (${alertPayload.backfilled_from})`);
     } else {
       const parentPayload = {
         email,

--- a/scripts/backfill-jobalerts-from-newsletter.mjs
+++ b/scripts/backfill-jobalerts-from-newsletter.mjs
@@ -1,13 +1,24 @@
 #!/usr/bin/env node
 /**
- * Backfill `job_alert_subscribers/{email}/alerts/backfill-jobgate` from
- * `newsletter_subscribers` docs with `source_channel === 'job_gate'`.
+ * Backfill `job_alert_subscribers/{email}/alerts/backfill-newsletter` from
+ * ALL `newsletter_subscribers` docs, regardless of `source_channel`.
  *
- * Rationale: a user who signed up to unlock a job's detail (the "job_gate"
- * newsletter flow) is actively job-hunting even though they never explicitly
- * created an alert. `job_gate` is a `CONFIRMED_NEWSLETTER_SOURCES` entry
- * (services/newsletterSubscribers.ts:187) — single opt-in, no double
- * confirmation needed — so these subscribers are already mailable.
+ * Rationale: a subscriber who left a `job_category`/`job_location` signal
+ * behind — no matter which CTA captured their email (job-detail unlock,
+ * social sign-in on the job board, One Tap, generic footer signup, …) — is
+ * signalling job-search intent even though they never explicitly created an
+ * alert. Channel does not need to gate this: a live count against
+ * `newsletter_subscribers` (2026-07, 5429 docs) showed the field-based signal
+ * check below already discriminates correctly per channel without any
+ * per-channel branching — `job_gate` (753 eligible), `auth_google` (993),
+ * `auth_linkedin` (466) carry real signal; generic/unrelated CTAs
+ * (`analysis_gate`, `post_calc_cta`, `newsletter_page`, `lead_magnet`,
+ * `calculator_paywall`, `offerwall`, `popup`'s pending majority, no-channel
+ * docs) self-filter to ~0 because they never populate `job_category`/
+ * `job_location` at signup. `tax_calendar_*`/`chatbot_*`/`job_board_auth`
+ * source_channel values are dead code paths (`normalizeSourceChannel`,
+ * services/newsletterSubscribers.ts, collapses them into `auth_google`/
+ * `auth_facebook`/`job_gate` before storage) — 0 live docs, nothing to skip.
  *
  * The backfilled alert is deliberately near-empty (`keywords: []`,
  * `locations: []`, `cantonFilter: null`): `buildAlertProfile`
@@ -20,8 +31,11 @@
  * NOT what an inferred, non-explicit alert should do — a subscriber with a
  * sparse job_category could end up matching nothing.
  *
- * Idempotent: fixed alert id `backfill-jobgate` per subscriber, `merge:true`.
- * Safe to re-run.
+ * Idempotent: fixed alert id `backfill-newsletter` per subscriber,
+ * `merge:true`. Re-running never reactivates an alert the user disabled
+ * (`deleteAlert`, services/jobAlertService.ts:269-275, sets `active:false` +
+ * `unsubscribed_at`) — the payload only defaults `active:true` on first
+ * creation and otherwise carries the existing doc's `active` forward as-is.
  *
  * Usage:
  *   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
@@ -34,7 +48,7 @@ import { isNewsletterExcluded } from '../services/emailSuppression.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 export const MAX_ALERTS_PER_USER = 3; // services/jobAlertService.ts:68
-export const ALERT_ID = 'backfill-jobgate';
+export const ALERT_ID = 'backfill-newsletter';
 
 export function normalizeEmail(raw) {
   return String(raw || '').trim().toLowerCase();
@@ -57,6 +71,11 @@ export function shouldSkipSubscriber(email, data) {
  * Pure payload builder — no Firestore I/O, no serverTimestamp (caller stamps
  * `createdAt`/`backfilled_at`/`updated_at` after this returns, so the shape
  * stays testable without mocking firebase-admin).
+ *
+ * `existingBackfill` is the full prior `backfill-newsletter` doc data (or
+ * null on first creation). Its `active` flag is carried forward as-is so a
+ * re-run never undoes a user's explicit unsubscribe (`deleteAlert` sets
+ * `active: false`) — only a brand-new doc defaults to `active: true`.
  */
 export function buildAlertPayload(email, data, existingBackfill) {
   return {
@@ -74,12 +93,12 @@ export function buildAlertPayload(email, data, existingBackfill) {
     sourceJobTitle: null,
     specificJobId: null,
     specificCompanyKey: null,
-    active: true,
+    active: existingBackfill ? existingBackfill.active !== false : true,
     matchCount: existingBackfill?.matchCount || 0,
     lastMatchedAt: existingBackfill?.lastMatchedAt || null,
     // Provenance — lets a future audit tell inferred alerts apart from
-    // explicit ones without needing a separate collection.
-    backfilled_from: 'newsletter_subscribers_job_gate',
+    // explicit ones, and see which signup channel triggered it.
+    backfilled_from: `newsletter_subscribers:${data?.source_channel || 'unknown'}`,
   };
 }
 
@@ -104,32 +123,42 @@ async function main() {
   const db = await getFirestoreAdmin();
   const { FieldValue } = await import('firebase-admin/firestore');
 
-  console.log(`🔎 Querying newsletter_subscribers where source_channel == 'job_gate'${DRY_RUN ? ' (dry-run)' : ''}`);
-  const snap = await db.collection('newsletter_subscribers').where('source_channel', '==', 'job_gate').get();
-  console.log(`   Found ${snap.size} job_gate subscribers`);
+  console.log(`🔎 Querying all newsletter_subscribers${DRY_RUN ? ' (dry-run)' : ''}`);
+  const snap = await db.collection('newsletter_subscribers').get();
+  console.log(`   Found ${snap.size} subscribers`);
 
   const counts = { created: 0, 'invalid-email': 0, suppressed: 0, 'no-signal': 0, capped: 0 };
+  const byChannel = {};
 
   for (const doc of snap.docs) {
     const data = doc.data();
     const email = normalizeEmail(data.email || doc.id);
+    const channel = data.source_channel || 'unknown';
+    byChannel[channel] = byChannel[channel] || { created: 0, skipped: 0 };
 
     const skipReason = shouldSkipSubscriber(email, data);
     if (skipReason) {
       counts[skipReason]++;
+      byChannel[channel].skipped++;
       continue;
     }
 
     const subscriberRef = db.collection('job_alert_subscribers').doc(email);
     const alertsRef = subscriberRef.collection('alerts');
-    const existingActive = await alertsRef.where('email', '==', email).where('active', '==', true).get();
-    const existingBackfillDoc = existingActive.docs.find((d) => d.id === ALERT_ID);
-    if (!existingBackfillDoc && existingActive.size >= MAX_ALERTS_PER_USER) {
+    // Read every alert doc (not just active:true) so a user-disabled
+    // backfill-newsletter doc is still found — otherwise it would look
+    // "missing" and get silently recreated as active on re-run.
+    const existingAlerts = await alertsRef.get();
+    const existingBackfillDoc = existingAlerts.docs.find((d) => d.id === ALERT_ID);
+    const activeOtherCount = existingAlerts.docs.filter((d) => d.id !== ALERT_ID && d.data().active === true).length;
+    if (!existingBackfillDoc && activeOtherCount >= MAX_ALERTS_PER_USER) {
       counts.capped++;
+      byChannel[channel].skipped++;
       continue;
     }
 
     const alertPayload = buildAlertPayload(email, data, existingBackfillDoc?.data());
+    byChannel[channel].created++;
 
     if (DRY_RUN) {
       console.log(` [dry] ${existingBackfillDoc ? 'merge' : 'create'} job_alert_subscribers/${email}/alerts/${ALERT_ID} (category=${data.job_category || '∅'}, location=${data.job_location || '∅'})`);
@@ -163,6 +192,11 @@ async function main() {
   console.log(` ⏭️  Skipped (no signal)    : ${counts['no-signal']}`);
   console.log(` ⏭️  Skipped (at cap)       : ${counts.capped}`);
   console.log(` ⏭️  Skipped (invalid email): ${counts['invalid-email']}`);
+  console.log('');
+  console.log(' By source_channel (created/skipped):');
+  for (const [channel, c] of Object.entries(byChannel).sort((a, b) => b[1].created - a[1].created)) {
+    console.log(`   ${channel.padEnd(20)} ${String(c.created).padStart(5)} / ${c.skipped}`);
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {

--- a/scripts/backfill-jobalerts-from-newsletter.mjs
+++ b/scripts/backfill-jobalerts-from-newsletter.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Backfill `job_alert_subscribers/{email}/alerts/backfill-jobgate` from
+ * `newsletter_subscribers` docs with `source_channel === 'job_gate'`.
+ *
+ * Rationale: a user who signed up to unlock a job's detail (the "job_gate"
+ * newsletter flow) is actively job-hunting even though they never explicitly
+ * created an alert. `job_gate` is a `CONFIRMED_NEWSLETTER_SOURCES` entry
+ * (services/newsletterSubscribers.ts:187) — single opt-in, no double
+ * confirmation needed — so these subscribers are already mailable.
+ *
+ * The backfilled alert is deliberately near-empty (`keywords: []`,
+ * `locations: []`, `cantonFilter: null`): `buildAlertProfile`
+ * (services/jobAlertMatching.mjs:148-208) already pulls `job_category`,
+ * `job_search_query`, `job_slug`, `sector_interest`, `job_location` straight
+ * off the linked `newsletter_subscribers/{email}` doc via soft tokens +
+ * sector + preferred-location signals — duplicating them onto the alert
+ * would be redundant. Setting `keywords`/`cantonFilter` would instead turn
+ * them into HARD filters (scoreJobForAlert lines 342-348, 377-384), which is
+ * NOT what an inferred, non-explicit alert should do — a subscriber with a
+ * sparse job_category could end up matching nothing.
+ *
+ * Idempotent: fixed alert id `backfill-jobgate` per subscriber, `merge:true`.
+ * Safe to re-run.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
+ *   node scripts/backfill-jobalerts-from-newsletter.mjs [--dry-run]
+ */
+
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { isNewsletterExcluded } from '../services/emailSuppression.mjs';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+export const MAX_ALERTS_PER_USER = 3; // services/jobAlertService.ts:68
+export const ALERT_ID = 'backfill-jobgate';
+
+export function normalizeEmail(raw) {
+  return String(raw || '').trim().toLowerCase();
+}
+
+/**
+ * Pure eligibility check for one `newsletter_subscribers` doc.
+ * @returns {'invalid-email'|'suppressed'|'no-signal'|null} skip reason, null = eligible.
+ */
+export function shouldSkipSubscriber(email, data) {
+  if (!email || !email.includes('@')) return 'invalid-email';
+  if (isNewsletterExcluded(data?.status)) return 'suppressed';
+  const category = String(data?.job_category || '').trim();
+  const location = String(data?.job_location || '').trim();
+  if (!category && !location) return 'no-signal';
+  return null;
+}
+
+/**
+ * Pure payload builder — no Firestore I/O, no serverTimestamp (caller stamps
+ * `createdAt`/`backfilled_at`/`updated_at` after this returns, so the shape
+ * stays testable without mocking firebase-admin).
+ */
+export function buildAlertPayload(email, data, existingBackfill) {
+  return {
+    email,
+    userId: data?.user_id || null,
+    keywords: [],
+    locations: [],
+    contractTypes: [],
+    sectors: [],
+    cantonFilter: null,
+    frequency: 'daily',
+    locale: data?.preferred_locale || data?.locale || 'it',
+    sourceJobSlug: data?.job_slug || null,
+    sourceJobUrl: null,
+    sourceJobTitle: null,
+    specificJobId: null,
+    specificCompanyKey: null,
+    active: true,
+    matchCount: existingBackfill?.matchCount || 0,
+    lastMatchedAt: existingBackfill?.lastMatchedAt || null,
+    // Provenance — lets a future audit tell inferred alerts apart from
+    // explicit ones without needing a separate collection.
+    backfilled_from: 'newsletter_subscribers_job_gate',
+  };
+}
+
+let _db = null;
+async function getFirestoreAdmin() {
+  if (_db) return _db;
+  const { initializeApp, cert, getApps } = await import('firebase-admin/app');
+  const { getFirestore } = await import('firebase-admin/firestore');
+  if (getApps().length === 0) {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credPath || !fs.existsSync(credPath)) {
+      throw new Error('GOOGLE_APPLICATION_CREDENTIALS not set or file missing');
+    }
+    const cred = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
+    initializeApp({ credential: cert(cred), projectId: cred.project_id });
+  }
+  _db = getFirestore();
+  return _db;
+}
+
+async function main() {
+  const db = await getFirestoreAdmin();
+  const { FieldValue } = await import('firebase-admin/firestore');
+
+  console.log(`🔎 Querying newsletter_subscribers where source_channel == 'job_gate'${DRY_RUN ? ' (dry-run)' : ''}`);
+  const snap = await db.collection('newsletter_subscribers').where('source_channel', '==', 'job_gate').get();
+  console.log(`   Found ${snap.size} job_gate subscribers`);
+
+  const counts = { created: 0, 'invalid-email': 0, suppressed: 0, 'no-signal': 0, capped: 0 };
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = normalizeEmail(data.email || doc.id);
+
+    const skipReason = shouldSkipSubscriber(email, data);
+    if (skipReason) {
+      counts[skipReason]++;
+      continue;
+    }
+
+    const subscriberRef = db.collection('job_alert_subscribers').doc(email);
+    const alertsRef = subscriberRef.collection('alerts');
+    const existingActive = await alertsRef.where('email', '==', email).where('active', '==', true).get();
+    const existingBackfillDoc = existingActive.docs.find((d) => d.id === ALERT_ID);
+    if (!existingBackfillDoc && existingActive.size >= MAX_ALERTS_PER_USER) {
+      counts.capped++;
+      continue;
+    }
+
+    const alertPayload = buildAlertPayload(email, data, existingBackfillDoc?.data());
+
+    if (DRY_RUN) {
+      console.log(` [dry] ${existingBackfillDoc ? 'merge' : 'create'} job_alert_subscribers/${email}/alerts/${ALERT_ID} (category=${data.job_category || '∅'}, location=${data.job_location || '∅'})`);
+    } else {
+      const parentPayload = {
+        email,
+        userId: alertPayload.userId,
+        locale: alertPayload.locale,
+        updated_at: FieldValue.serverTimestamp(),
+        created_at: FieldValue.serverTimestamp(),
+      };
+      const existingParent = await subscriberRef.get();
+      if (existingParent.exists) delete parentPayload.created_at;
+      await subscriberRef.set(parentPayload, { merge: true });
+
+      await alertsRef.doc(ALERT_ID).set(
+        {
+          ...alertPayload,
+          backfilled_at: FieldValue.serverTimestamp(),
+          ...(existingBackfillDoc ? {} : { createdAt: FieldValue.serverTimestamp() }),
+        },
+        { merge: true },
+      );
+    }
+    counts.created++;
+  }
+
+  console.log('');
+  console.log(` ✅ Alerts created/updated : ${counts.created}${DRY_RUN ? ' (dry)' : ''}`);
+  console.log(` ⏭️  Skipped (suppressed)   : ${counts.suppressed}`);
+  console.log(` ⏭️  Skipped (no signal)    : ${counts['no-signal']}`);
+  console.log(` ⏭️  Skipped (at cap)       : ${counts.capped}`);
+  console.log(` ⏭️  Skipped (invalid email): ${counts['invalid-email']}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error('❌ Backfill failed:', err);
+      process.exit(1);
+    });
+}

--- a/scripts/lib/jobalert-backfill-core.mjs
+++ b/scripts/lib/jobalert-backfill-core.mjs
@@ -1,0 +1,14 @@
+/**
+ * Shim — canonical module lives at `functions/src/jobAlertBackfillCore.js`
+ * because the real-time `onDocumentCreated` trigger needs it inside
+ * `functions/` (no bundler, cannot import outside that dir). Re-exported
+ * here so the batch backfill script resolves to the exact same logic —
+ * no drift between the one-off backfill and the ongoing trigger.
+ */
+export {
+  MAX_ALERTS_PER_USER,
+  ALERT_ID,
+  normalizeEmail,
+  shouldSkipSubscriber,
+  buildAlertPayload,
+} from '../../functions/src/jobAlertBackfillCore.js';

--- a/scripts/lib/jobalert-backfill-core.mjs
+++ b/scripts/lib/jobalert-backfill-core.mjs
@@ -1,6 +1,6 @@
 /**
  * Shim — canonical module lives at `functions/src/jobAlertBackfillCore.js`
- * because the real-time `onDocumentCreated` trigger needs it inside
+ * because the real-time `onDocumentWritten` trigger needs it inside
  * `functions/` (no bundler, cannot import outside that dir). Re-exported
  * here so the batch backfill script resolves to the exact same logic —
  * no drift between the one-off backfill and the ongoing trigger.
@@ -11,4 +11,6 @@ export {
   normalizeEmail,
   shouldSkipSubscriber,
   buildAlertPayload,
+  getSignalTier,
+  signalTierChanged,
 } from '../../functions/src/jobAlertBackfillCore.js';

--- a/services/emailSuppression.mjs
+++ b/services/emailSuppression.mjs
@@ -1,78 +1,15 @@
 /**
- * Shared subscriber-`status` suppression sets — the single source of truth for
- * "stop emailing this recipient", used by every sender (newsletter, job alerts,
- * publisher blast). Extracting it here makes the value drift that previously
- * existed impossible by-construction: `publisherBlastMatch.mjs` checked for the
- * literal `'complaint'` (an event-type discriminator, NEVER a subscriber status
- * value) and so never actually suppressed users who filed a spam complaint,
- * while `send-job-alerts.mjs` checked no status at all.
- *
- * The canonical `status` values are written by every `newsletter*WebhookCore.js`
- * on provider events: `bounced` (hard bounce), `complained` (spam complaint),
- * `suppressed` (provider suppression list), and the channel-level `unsubscribed`.
- * Confirmed against all six webhook cores — they uniformly write `complained`
- * (the `complaint` strings in those files are event-type names, not statuses).
+ * Shim — canonical module now lives at `functions/src/lib/emailSuppression.js`
+ * because Cloud Functions have no bundler and cannot import anything outside
+ * `functions/` (see `jobAlertBackfillTrigger.js`, which needs this at runtime).
+ * Re-exported here so every existing `scripts/`/test importer keeps resolving
+ * to the exact same module — no drift between the two call sites.
  */
-
-/**
- * Address-level hard signals. The mailbox is dead (bounced), the human flagged
- * us as spam (complained), or the provider blocklisted the address (suppressed).
- * These apply across BOTH channels — newsletter AND job alerts — because the
- * signal is about the address, not a per-channel consent choice.
- */
-export const ADDRESS_SUPPRESSED_STATUSES = new Set(['bounced', 'complained', 'suppressed']);
-
-/**
- * Newsletter-channel exclusions: the address-level signals PLUS the channel-level
- * soft states — `unsubscribed` (explicit opt-out) and `inactive` (the sunset of a
- * never-engager, see scripts/lib/subscriberSunset.mjs). Both are reversible and
- * newsletter-specific. Job alerts do NOT fold these in — an alert opt-out is the
- * per-alert `active:false` flag, a separate consent, and a newsletter-only sunset
- * must never silently cross to the alert channel. `inactive` is NOT in
- * ADDRESS_SUPPRESSED_STATUSES because it is a soft, channel-level state, not a
- * hard cross-channel signal (a bounce/complaint).
- */
-export const NEWSLETTER_EXCLUDED_STATUSES = new Set(['unsubscribed', 'inactive', ...ADDRESS_SUPPRESSED_STATUSES]);
-
-/**
- * Job-alert-channel exclusions: the address-level signals PLUS that channel's OWN
- * `inactive` soft state (the sunset of a never-engaging job-alert subscriber, see
- * scripts/lib/jobAlertSunset.mjs — issue #2852 item 1). This `inactive` lives on
- * `job_alert_subscribers/{email}.status` — a completely separate document/field
- * from the newsletter one above, so there is no cross-channel leak in either
- * direction. Job alerts have no `unsubscribed` channel status: an alert opt-out
- * is the per-alert `active:false` flag on the `alerts` subcollection, unrelated
- * to this top-level doc-level set.
- */
-export const JOB_ALERT_EXCLUDED_STATUSES = new Set(['inactive', ...ADDRESS_SUPPRESSED_STATUSES]);
-
-const norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
-
-/**
- * True when an address-level hard signal (bounce/complaint/suppression) means we
- * must never email this address again on ANY channel.
- * @param {string|null|undefined} status
- * @returns {boolean}
- */
-export function isAddressSuppressed(status) {
-  return ADDRESS_SUPPRESSED_STATUSES.has(norm(status));
-}
-
-/**
- * True when a newsletter recipient must be excluded (address signals + unsub).
- * @param {string|null|undefined} status
- * @returns {boolean}
- */
-export function isNewsletterExcluded(status) {
-  return NEWSLETTER_EXCLUDED_STATUSES.has(norm(status));
-}
-
-/**
- * True when a job-alert recipient must be excluded (address signals + that
- * channel's own inactivity sunset).
- * @param {string|null|undefined} status
- * @returns {boolean}
- */
-export function isJobAlertExcluded(status) {
-  return JOB_ALERT_EXCLUDED_STATUSES.has(norm(status));
-}
+export {
+  ADDRESS_SUPPRESSED_STATUSES,
+  NEWSLETTER_EXCLUDED_STATUSES,
+  JOB_ALERT_EXCLUDED_STATUSES,
+  isAddressSuppressed,
+  isNewsletterExcluded,
+  isJobAlertExcluded,
+} from '../functions/src/lib/emailSuppression.js';

--- a/tests/backfill-jobalerts-from-newsletter.test.ts
+++ b/tests/backfill-jobalerts-from-newsletter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALERT_ID,
+  buildAlertPayload,
+  MAX_ALERTS_PER_USER,
+  normalizeEmail,
+  shouldSkipSubscriber,
+} from '../scripts/backfill-jobalerts-from-newsletter.mjs';
+
+describe('backfill-jobalerts-from-newsletter — shouldSkipSubscriber', () => {
+  it('is eligible when job_category is present', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { job_category: 'tech' })).toBeNull();
+  });
+
+  it('is eligible when only job_location is present', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { job_location: 'Lugano' })).toBeNull();
+  });
+
+  it('skips an invalid/missing email', () => {
+    expect(shouldSkipSubscriber('', { job_category: 'tech' })).toBe('invalid-email');
+    expect(shouldSkipSubscriber('not-an-email', { job_category: 'tech' })).toBe('invalid-email');
+  });
+
+  it('skips a bounced/complained/suppressed/unsubscribed subscriber', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { job_category: 'tech', status: 'bounced' })).toBe('suppressed');
+    expect(shouldSkipSubscriber('a@b.ch', { job_category: 'tech', status: 'unsubscribed' })).toBe('suppressed');
+  });
+
+  it('skips a subscriber with neither job_category nor job_location', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { job_slug: 'some-job-abc123' })).toBe('no-signal');
+    expect(shouldSkipSubscriber('a@b.ch', {})).toBe('no-signal');
+  });
+});
+
+describe('backfill-jobalerts-from-newsletter — buildAlertPayload', () => {
+  it('builds a near-empty alert that leans on the linked newsletter_subscribers doc for matching', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech', job_slug: 'dev-abc123', locale: 'it' }, null);
+    expect(payload.keywords).toEqual([]);
+    expect(payload.locations).toEqual([]);
+    expect(payload.cantonFilter).toBeNull();
+    expect(payload.frequency).toBe('daily');
+    expect(payload.sourceJobSlug).toBe('dev-abc123');
+    expect(payload.active).toBe(true);
+    expect(payload.backfilled_from).toBe('newsletter_subscribers_job_gate');
+  });
+
+  it('defaults locale to it when the subscriber has none', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, null);
+    expect(payload.locale).toBe('it');
+  });
+
+  it('prefers preferred_locale over locale', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech', locale: 'it', preferred_locale: 'de' }, null);
+    expect(payload.locale).toBe('de');
+  });
+
+  it('is idempotent — preserves matchCount/lastMatchedAt from an existing backfilled alert instead of resetting them', () => {
+    const payload = buildAlertPayload(
+      'a@b.ch',
+      { job_category: 'tech' },
+      { matchCount: 7, lastMatchedAt: 'sentinel-timestamp' },
+    );
+    expect(payload.matchCount).toBe(7);
+    expect(payload.lastMatchedAt).toBe('sentinel-timestamp');
+  });
+
+  it('starts matchCount/lastMatchedAt fresh when no prior backfill exists', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, null);
+    expect(payload.matchCount).toBe(0);
+    expect(payload.lastMatchedAt).toBeNull();
+  });
+});
+
+describe('backfill-jobalerts-from-newsletter — normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmail('  A@B.CH  ')).toBe('a@b.ch');
+  });
+});
+
+describe('backfill-jobalerts-from-newsletter — constants', () => {
+  it('uses a stable, deterministic alert id for idempotent re-runs', () => {
+    expect(ALERT_ID).toBe('backfill-jobgate');
+  });
+
+  it('matches the client-side active-alerts cap (services/jobAlertService.ts)', () => {
+    expect(MAX_ALERTS_PER_USER).toBe(3);
+  });
+});

--- a/tests/backfill-jobalerts-from-newsletter.test.ts
+++ b/tests/backfill-jobalerts-from-newsletter.test.ts
@@ -34,14 +34,28 @@ describe('backfill-jobalerts-from-newsletter — shouldSkipSubscriber', () => {
 
 describe('backfill-jobalerts-from-newsletter — buildAlertPayload', () => {
   it('builds a near-empty alert that leans on the linked newsletter_subscribers doc for matching', () => {
-    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech', job_slug: 'dev-abc123', locale: 'it' }, null);
+    const payload = buildAlertPayload(
+      'a@b.ch',
+      { job_category: 'tech', job_slug: 'dev-abc123', locale: 'it', source_channel: 'job_gate' },
+      null,
+    );
     expect(payload.keywords).toEqual([]);
     expect(payload.locations).toEqual([]);
     expect(payload.cantonFilter).toBeNull();
     expect(payload.frequency).toBe('daily');
     expect(payload.sourceJobSlug).toBe('dev-abc123');
     expect(payload.active).toBe(true);
-    expect(payload.backfilled_from).toBe('newsletter_subscribers_job_gate');
+    expect(payload.backfilled_from).toBe('newsletter_subscribers:job_gate');
+  });
+
+  it('records the actual source_channel in backfilled_from, not just job_gate', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech', source_channel: 'auth_google' }, null);
+    expect(payload.backfilled_from).toBe('newsletter_subscribers:auth_google');
+  });
+
+  it('falls back to "unknown" in backfilled_from when source_channel is missing', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, null);
+    expect(payload.backfilled_from).toBe('newsletter_subscribers:unknown');
   });
 
   it('defaults locale to it when the subscriber has none', () => {
@@ -69,6 +83,21 @@ describe('backfill-jobalerts-from-newsletter — buildAlertPayload', () => {
     expect(payload.matchCount).toBe(0);
     expect(payload.lastMatchedAt).toBeNull();
   });
+
+  it('defaults active to true on first creation', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, null);
+    expect(payload.active).toBe(true);
+  });
+
+  it('never reactivates an alert the user explicitly disabled (deleteAlert sets active:false)', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, { active: false, matchCount: 3 });
+    expect(payload.active).toBe(false);
+  });
+
+  it('keeps active true when the existing backfill doc never set it to false', () => {
+    const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, { matchCount: 3 });
+    expect(payload.active).toBe(true);
+  });
 });
 
 describe('backfill-jobalerts-from-newsletter — normalizeEmail', () => {
@@ -79,7 +108,7 @@ describe('backfill-jobalerts-from-newsletter — normalizeEmail', () => {
 
 describe('backfill-jobalerts-from-newsletter — constants', () => {
   it('uses a stable, deterministic alert id for idempotent re-runs', () => {
-    expect(ALERT_ID).toBe('backfill-jobgate');
+    expect(ALERT_ID).toBe('backfill-newsletter');
   });
 
   it('matches the client-side active-alerts cap (services/jobAlertService.ts)', () => {

--- a/tests/backfill-jobalerts-from-newsletter.test.ts
+++ b/tests/backfill-jobalerts-from-newsletter.test.ts
@@ -30,6 +30,14 @@ describe('backfill-jobalerts-from-newsletter — shouldSkipSubscriber', () => {
     expect(shouldSkipSubscriber('a@b.ch', { job_slug: 'some-job-abc123' })).toBe('no-signal');
     expect(shouldSkipSubscriber('a@b.ch', {})).toBe('no-signal');
   });
+
+  it('is eligible via the location-fallback tier when only location_interest is present', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { location_interest: 'Lugano' })).toBeNull();
+  });
+
+  it('is eligible via the location-fallback tier when only geo_city is present', () => {
+    expect(shouldSkipSubscriber('a@b.ch', { geo_city: 'Bellinzona' })).toBeNull();
+  });
 });
 
 describe('backfill-jobalerts-from-newsletter — buildAlertPayload', () => {
@@ -56,6 +64,13 @@ describe('backfill-jobalerts-from-newsletter — buildAlertPayload', () => {
   it('falls back to "unknown" in backfilled_from when source_channel is missing', () => {
     const payload = buildAlertPayload('a@b.ch', { job_category: 'tech' }, null);
     expect(payload.backfilled_from).toBe('newsletter_subscribers:unknown');
+  });
+
+  it('tags backfilled_from with :location-fallback when built from the location-only tier', () => {
+    const payload = buildAlertPayload('a@b.ch', { location_interest: 'Lugano', source_channel: 'popup' }, null);
+    expect(payload.backfilled_from).toBe('newsletter_subscribers:popup:location-fallback');
+    expect(payload.cantonFilter).toBeNull();
+    expect(payload.keywords).toEqual([]);
   });
 
   it('defaults locale to it when the subscriber has none', () => {

--- a/tests/job-alert-backfill-trigger.test.ts
+++ b/tests/job-alert-backfill-trigger.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { handleNewsletterSubscriberCreated } from '../functions/src/jobAlertBackfillTrigger.js';
+import { getSignalTier, signalTierChanged } from '../functions/src/jobAlertBackfillCore.js';
 
 interface AlertDoc {
   id: string;
@@ -34,6 +35,44 @@ function fakeDb({
     }),
   };
 }
+
+describe('signalTierChanged — race-condition guard (onDocumentWritten)', () => {
+  it('is true on doc creation when the doc already carries job signal', () => {
+    expect(signalTierChanged(null, { job_category: 'tech' })).toBe(true);
+  });
+
+  it('is false on doc creation when the doc carries no signal at all', () => {
+    expect(signalTierChanged(null, {})).toBe(false);
+  });
+
+  it('is true when a later merge adds the signal that a bare auth write omitted (the reviewer-flagged race)', () => {
+    // saveUserProfileToFirestore creates the doc with only auth fields...
+    const bareAuthWrite = { auth_uid: 'uid-1', name: 'Foo' };
+    // ...then upsertNewsletterSubscriber merges in the real signal moments later.
+    const fullUpsertMerge = { auth_uid: 'uid-1', name: 'Foo', job_category: 'tech' };
+    expect(signalTierChanged(bareAuthWrite, fullUpsertMerge)).toBe(true);
+  });
+
+  it('is false for an unrelated field update once the tier is already settled (engagement tracking)', () => {
+    const before = { job_category: 'tech', opens: 3 };
+    const after = { job_category: 'tech', opens: 4 };
+    expect(signalTierChanged(before, after)).toBe(false);
+  });
+
+  it('is true when tier upgrades from location-fallback to signal', () => {
+    const before = { location_interest: 'Lugano' };
+    const after = { location_interest: 'Lugano', job_category: 'tech' };
+    expect(signalTierChanged(before, after)).toBe(true);
+  });
+});
+
+describe('getSignalTier', () => {
+  it('returns none/location-fallback/signal in priority order', () => {
+    expect(getSignalTier({})).toBe('none');
+    expect(getSignalTier({ geo_city: 'Lugano' })).toBe('location-fallback');
+    expect(getSignalTier({ job_category: 'tech', geo_city: 'Lugano' })).toBe('signal');
+  });
+});
 
 describe('handleNewsletterSubscriberCreated — meta sentinel', () => {
   it('is a no-op for the _meta_ doc', async () => {

--- a/tests/job-alert-backfill-trigger.test.ts
+++ b/tests/job-alert-backfill-trigger.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { handleNewsletterSubscriberCreated } from '../functions/src/jobAlertBackfillTrigger.js';
+
+interface AlertDoc {
+  id: string;
+  active?: boolean;
+}
+
+function fakeDb({
+  existingAlerts = [] as AlertDoc[],
+  parentExists = false,
+}: { existingAlerts?: AlertDoc[]; parentExists?: boolean } = {}) {
+  const writes: Array<{ path: string; payload: Record<string, unknown>; merge: boolean }> = [];
+
+  return {
+    writes,
+    collection: () => ({
+      doc: (email: string) => ({
+        collection: () => ({
+          get: async () => ({
+            docs: existingAlerts.map((a) => ({ id: a.id, data: () => a })),
+          }),
+          doc: (alertId: string) => ({
+            set: async (payload: Record<string, unknown>, opts: { merge: boolean }) => {
+              writes.push({ path: `job_alert_subscribers/${email}/alerts/${alertId}`, payload, merge: opts.merge });
+            },
+          }),
+        }),
+        get: async () => ({ exists: parentExists }),
+        set: async (payload: Record<string, unknown>, opts: { merge: boolean }) => {
+          writes.push({ path: `job_alert_subscribers/${email}`, payload, merge: opts.merge });
+        },
+      }),
+    }),
+  };
+}
+
+describe('handleNewsletterSubscriberCreated — meta sentinel', () => {
+  it('is a no-op for the _meta_ doc', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated('_meta_', {}, { db: db as any });
+    expect(result).toEqual({ created: false, reason: 'meta_sentinel' });
+    expect(db.writes).toHaveLength(0);
+  });
+});
+
+describe('handleNewsletterSubscriberCreated — skip reasons', () => {
+  it('skips a subscriber with no job or location signal', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated('a@b.ch', {}, { db: db as any });
+    expect(result).toEqual({ created: false, reason: 'no-signal' });
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('skips a suppressed/unsubscribed subscriber even with job signal', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated(
+      'a@b.ch',
+      { job_category: 'tech', status: 'unsubscribed' },
+      { db: db as any },
+    );
+    expect(result).toEqual({ created: false, reason: 'suppressed' });
+  });
+});
+
+describe('handleNewsletterSubscriberCreated — cap enforcement', () => {
+  it('skips when the subscriber already has MAX_ALERTS_PER_USER active alerts', async () => {
+    const db = fakeDb({
+      existingAlerts: [
+        { id: 'alert-1', active: true },
+        { id: 'alert-2', active: true },
+        { id: 'alert-3', active: true },
+      ],
+    });
+    const result = await handleNewsletterSubscriberCreated('a@b.ch', { job_category: 'tech' }, { db: db as any });
+    expect(result).toEqual({ created: false, reason: 'capped' });
+    expect(db.writes).toHaveLength(0);
+  });
+
+  it('does not count inactive alerts toward the cap', async () => {
+    const db = fakeDb({
+      existingAlerts: [
+        { id: 'alert-1', active: false },
+        { id: 'alert-2', active: false },
+        { id: 'alert-3', active: false },
+      ],
+    });
+    const result = await handleNewsletterSubscriberCreated('a@b.ch', { job_category: 'tech' }, { db: db as any });
+    expect(result.created).toBe(true);
+  });
+});
+
+describe('handleNewsletterSubscriberCreated — creation', () => {
+  it('creates an alert for a job-signal subscriber', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated(
+      'a@b.ch',
+      { job_category: 'tech', source_channel: 'job_gate' },
+      { db: db as any },
+    );
+    expect(result.created).toBe(true);
+    expect(result.tier).toBe('newsletter_subscribers:job_gate');
+    const alertWrite = db.writes.find((w) => w.path.includes('/alerts/backfill-newsletter'));
+    expect(alertWrite).toBeDefined();
+    expect(alertWrite?.payload.active).toBe(true);
+    expect(alertWrite?.payload.keywords).toEqual([]);
+  });
+
+  it('creates a location-fallback alert when there is no job signal but a location one', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated(
+      'a@b.ch',
+      { location_interest: 'Lugano', source_channel: 'popup' },
+      { db: db as any },
+    );
+    expect(result.created).toBe(true);
+    expect(result.tier).toBe('newsletter_subscribers:popup:location-fallback');
+  });
+
+  it('never reactivates an alert the user already disabled', async () => {
+    const db = fakeDb({ existingAlerts: [{ id: 'backfill-newsletter', active: false }] });
+    const result = await handleNewsletterSubscriberCreated('a@b.ch', { job_category: 'tech' }, { db: db as any });
+    expect(result.created).toBe(true);
+    const alertWrite = db.writes.find((w) => w.path.includes('/alerts/backfill-newsletter'));
+    expect(alertWrite?.payload.active).toBe(false);
+  });
+
+  it('does not overwrite created_at on an already-existing parent doc', async () => {
+    const db = fakeDb({ parentExists: true });
+    await handleNewsletterSubscriberCreated('a@b.ch', { job_category: 'tech' }, { db: db as any });
+    const parentWrite = db.writes.find((w) => w.path === 'job_alert_subscribers/a@b.ch');
+    expect(parentWrite?.payload).not.toHaveProperty('created_at');
+  });
+});


### PR DESCRIPTION
## Implementato

- `scripts/backfill-jobalerts-from-newsletter.mjs`: script idempotente che crea/aggiorna `job_alert_subscribers/{email}/alerts/backfill-newsletter` per **ogni** `newsletter_subscribers` doc (non più filtrato a `source_channel === 'job_gate'`) che porta un segnale di ricerca lavoro (`job_category`/`job_location`).
- Numeri live (query read-only, 5429 doc totali in `newsletter_subscribers`, 2026-07-03): l'euristica esistente basata sul campo (categoria/location presenti + non escluso) discrimina già correttamente per canale, **senza bisogno di branching per source_channel**:

  | source_channel | totale | esclusi | ha segnale | idonei netti |
  |---|---|---|---|---|
  | auth_google | 3606 | 593 | 877/954 | **993** |
  | job_gate | 850 | 84 | 746/760 | 753 |
  | auth_linkedin | 692 | 130 | 462/476 | **466** |
  | popup | 47 | 6 | 15/15 | 15 |
  | chatbot (chatbot_email) | 6 | 2 | 2/2 | 2 |
  | tutti gli altri (analysis_gate, post_calc_cta, newsletter_page, lead_magnet, calculator_paywall, offerwall, unknown, ecc.) | ~230 | — | 0 | 0 |

  Totale idonei stimati se lo script gira live: **~2229** (753 già coperti da job_gate + ~1476 nuovi tra auth_google/auth_linkedin/popup/chatbot). `tax_calendar_*`/`chatbot_google`/`chatbot_facebook`/`job_board_auth` risultano **0 documenti live**: `normalizeSourceChannel` (`services/newsletterSubscribers.ts`) li accorpa in `auth_google`/`auth_facebook`/`job_gate` prima dello storage — non sono canali reali da gestire a parte.
- Fix bug segnalato dal reviewer (🔴): il cap-check leggeva solo alert `active == true`, quindi un alert che l'utente aveva disattivato (`deleteAlert` → `active: false`) risultava "assente" e veniva ricreato `active: true` a ogni re-run, riattivando silenziosamente un'iscrizione disdetta. Ora legge tutti gli alert doc del subscriber e porta avanti il campo `active` esistente com'è; solo la creazione ex-novo default `active: true`.
- `backfilled_from` ora include il canale reale (`newsletter_subscribers:<source_channel>`) invece di un valore fisso `_job_gate`, per audit.
- **Nuovo (real-time, non solo batch one-off)**: `functions/index.js` → `backfillJobAlertOnNewsletterSignup`, trigger su `newsletter_subscribers/{email}` (stesso pattern di `syncNewsletterSubscriberAuth`). Da ora in poi ogni NUOVA iscrizione newsletter genera l'alert (se idonea) il giorno stesso, senza aspettare il prossimo run manuale del batch script.
- **Fix race condition segnalata dal reviewer (🔴 Important)**: il trigger era inizialmente `onDocumentCreated`, che decide l'eligibilità una sola volta, sui campi presenti al momento della creazione del doc. Sui sign-in social, `saveUserProfileToFirestore` (`services/authService.ts`) scrive lo stesso doc `newsletter_subscribers/{email}` con un `setDoc(..., {merge:true})` **non awaited**, contenente solo campi auth (`auth_uid`/`name`/`photoURL`, zero segnale job/location), in parallelo al flusso pieno (`upsertNewsletterSubscriber`) che scrive il segnale reale — le due write non sono sequenziate, e la write "nuda" tende strutturalmente a vincere la race (meno lavoro, nessun pre-read) su ~72% dei nuovi subscriber stimati (auth_google + auth_linkedin + popup). Un agente di verifica dedicato ha confermato il bug reale e strutturalmente biased, non un caso raro. Fix: switch a `onDocumentWritten` gated da una nuova funzione pura `signalTierChanged(beforeData, afterData)` (`functions/src/jobAlertBackfillCore.js`) che fa scattare la logica di creazione alert solo quando il "tier" di eligibilità cambia realmente tra stato precedente e nuovo — cattura quindi il segnale che arriva via merge successivo, indipendentemente da quale write vince la creazione iniziale, restando un no-op economico su write irrilevanti (aggiornamento campi auth, tracking apertura/click). Preferito rispetto a sequenziare/awaitare i sei call site in `authService.ts`/`App.tsx` perché resiliente per costruzione a nuovi call site futuri, non richiede modificare il codice di autenticazione.
- **Nuovo tier di fallback per location**: se il subscriber non ha `job_category`/`job_location` ma ha `location_interest`/`geo_city`, viene comunque creato un alert near-empty (nessun `cantonFilter`, nessun `keywords` — resta un "jobs vicino a te" via soft-ranking di `buildAlertProfile`, mai un filtro rigido). Numero live verificato: **+5 subscriber** aggiuntivi oltre al tier job-signal — marginale ma corretto e a costo zero, quindi incluso.
- Logica di decisione (`shouldSkipSubscriber`/`buildAlertPayload`/tier) estratta in `functions/src/jobAlertBackfillCore.js`, canonico perché il trigger Cloud Function gira senza bundler e non può importare da fuori `functions/`. Sia lo script batch (`scripts/lib/jobalert-backfill-core.mjs`, shim) sia il trigger real-time (`functions/src/jobAlertBackfillTrigger.js`) puntano allo stesso modulo — zero drift tra i due path.
- `services/emailSuppression.mjs` convertito in shim verso il nuovo canonico `functions/src/lib/emailSuppression.js` (stesso motivo: serve al trigger CF, che non può importare da `services/`).
- Test: 21 in `backfill-jobalerts-from-newsletter.test.ts` (da 18, +tier location-fallback) + 15 in `job-alert-backfill-trigger.test.ts` (9 su meta-sentinel guard/skip reasons/cap enforcement/creazione/no-reactivation/location-fallback/parent-doc idempotency + 6 nuovi su `signalTierChanged`/`getSignalTier`, incluso lo scenario esatto segnalato dal reviewer: bare-auth-write poi merge col segnale reale) — 57/57 pass totali sui file toccati.

## Non implementato (ancora)

Nessuno per lo scope codice — logica, trigger, test e provenance sono tutti live in questa PR.

Due item restano `blocked: richiede go-ahead esplicito owner`, entrambi operativi non di codice:

1. **Esecuzione del batch script** contro Firestore prod (crea gli alert per i ~2229+5 subscriber già esistenti) — invia email reali al prossimo cron daily 07:00 UTC, decisione separata dal merge.
2. **Deploy del trigger `backfillJobAlertOnNewsletterSignup`**: le Cloud Functions si deployano automaticamente in CI al merge su `main` (convenzione di progetto). A differenza del batch script (eseguito solo su comando esplicito), questo trigger — una volta live — genera l'alert **automaticamente per ogni nuova iscrizione newsletter da quel momento in poi**, senza ulteriore azione. Comportamento coerente con la decisione già approvata "Daily frequency + rollout silenzioso", ma segnalato esplicitamente qui perché il suo effetto (a differenza del batch) non richiede più nessun trigger manuale dopo il merge.

## Test plan

- [x] `npx vitest run tests/backfill-jobalerts-from-newsletter.test.ts tests/job-alert-backfill-trigger.test.ts tests/email-suppression.test.ts tests/job-alert-unsubscribe.test.ts` — 57/57 pass (dopo il fix race condition)
- [x] Fix race condition (🔴 Important) applicato in commit successivo sullo stesso branch — nuovo ciclo `pr-review-loop` in corso su questo commit
- [x] `node --check` su tutti i file `.mjs`/`.js` nuovi/modificati — sintassi OK
- [x] Query read-only prod per validare i numeri di cui sopra (5429 doc totali, breakdown per canale + tier location-fallback confermati)
- [ ] Run live con `--dry-run` contro Firestore prod per conferma finale conteggi, poi run scrivente — da fare su richiesta esplicita owner, post-merge
- [ ] Verifica live del trigger `backfillJobAlertOnNewsletterSignup` post-deploy (creare un subscriber di test con segnale job e confermare l'alert generato) — da fare post-merge, dopo il deploy automatico CI

