### PR TITLE
fix(employer-traffic): exclude sponsored from free-listing candidate pitch

### DIFF
--- a/.github/workflows/employer-traffic-refresh.yml
+++ b/.github/workflows/employer-traffic-refresh.yml
@@ -1,8 +1,15 @@
 name: Refresh Employer Traffic Metrics
 
-# Daily: compute per-company crawled-apply counts (PostHog) and write them to
-# Firestore `employer_crawled_traffic/{companyKey}` so the publisher dashboard
-# can show each employer "we sent you N candidates from your free listings".
+# Daily: compute per-company crawled-apply counts (GA4, sponsored excluded)
+# and write them to Firestore `employer_crawled_traffic/{companyKey}` so the
+# publisher dashboard can show each employer "we sent you N candidates from
+# your free listings". GA4 replaced PostHog as the production source
+# (#employer-traffic-ga4-sponsored-split): PostHog can't distinguish
+# sponsored/free ads from the item_id label alone (counts them together,
+# inflating the "free" pitch), and repeated PostHog quota exhaustion made it
+# unreliable as a daily cron dependency. GA4 custom dimensions
+# (employer_key, is_sponsored) are already emitted by trackJobApply on every
+# apply click, so the split is exact, not estimated.
 # Zero-Claude (deterministic data refresh).
 
 on:
@@ -47,11 +54,11 @@ jobs:
             echo "⚠️ FIREBASE_SERVICE_ACCOUNT_JSON not set — aborting"; exit 1
           fi
 
-      - name: Load secrets from Remote Config (PostHog keys, GA4 property)
+      - name: Load secrets from Remote Config (GA4 property)
         run: node scripts/load-rc-env.mjs
 
-      - name: Compute per-company crawled traffic (PostHog)
-        run: node scripts/employer-traffic-report.mjs --source posthog --days 90 --min 1 --json /tmp/employer-traffic.json
+      - name: Compute per-company crawled traffic (GA4)
+        run: node scripts/employer-traffic-report.mjs --source ga4 --days 90 --min 1 --json /tmp/employer-traffic.json
 
       - name: Write to Firestore (employer_crawled_traffic)
         run: node scripts/write-employer-traffic.mjs /tmp/employer-traffic.json

--- a/scripts/employer-traffic-report.mjs
+++ b/scripts/employer-traffic-report.mjs
@@ -3,23 +3,29 @@
  * Employer traffic report — "candidati inviati per azienda".
  *
  * Conta i candidati che mandiamo (gratis) verso il sito di ogni azienda, cioè
- * i click "Candidati" sugli annunci, distinguendo sponsorizzati da crawlati.
+ * i click "Candidati" sugli annunci SOLO gratuiti — lo sponsorizzato arriva
+ * già diretto al datore (copy box dashboard), va escluso dalla pitch.
  * È il dato che alimenta sia la prova in-prodotto sia l'outreach commerciale
  * ("vi abbiamo mandato N candidati il mese scorso, gratis").
  *
  * DUE SORGENTI (i touchpoint emettono entrambi gli eventi via analytics.ts):
  *
- *   --source posthog  (DEFAULT) — interroga lo STORICO via HogQL su PostHog.
- *       Aggrega `select_content` con content_type IN (job_board_apply,
- *       job_board_apply_header_logo, job_board_apply_header_title) — tutti i
- *       punti da cui un candidato esce verso l'azienda (titolo, logo, bottone).
- *       Azienda estratta dalla label `item_id = "<company>_<title>"`.
- *       Vantaggio: HogQL legge le proprietà raw → dati RETROATTIVI, niente
- *       custom dimension richieste. Usalo per partire subito.
+ *   --source ga4  (PRODUZIONE, cron employer-traffic-refresh.yml) — interroga
+ *       l'evento pulito `job_apply` (employer_key + is_sponsored, custom
+ *       dimension registrate). Unica sorgente che sa DAVVERO distinguere
+ *       sponsorizzato da gratuito (aggregateGa4Rows esclude sponsored dal
+ *       conteggio) — niente stima, split esatto. Solo dati POST-deploy (le
+ *       custom dimension GA4 non sono retroattive).
  *
- *   --source ga4 — interroga l'evento pulito `job_apply` (employer_key +
- *       is_sponsored, custom dimension registrate). Solo dati POST-deploy
- *       (le custom dimension GA4 non sono retroattive).
+ *   --source posthog  (DEFAULT CLI, solo backfill manuale/storico) —
+ *       interroga lo STORICO via HogQL su PostHog. Aggrega `select_content`
+ *       con content_type IN (job_board_apply, job_board_apply_header_logo,
+ *       job_board_apply_header_title). Azienda estratta dalla label
+ *       `item_id = "<company>_<title>"`, che NON porta il flag sponsored →
+ *       impossibile escluderlo, il numero include sponsorizzato+gratuito
+ *       insieme (mai usarlo per il cron di produzione: gonfia la pitch "free"
+ *       e la quota API PostHog non è affidabile per un cron giornaliero).
+ *       Vantaggio: dati RETROATTIVI, niente custom dimension richieste.
  *
  * Metrica per la pitch (`candidates`) = MIN(persone distinte, sessioni distinte),
  * non i click grezzi: un candidato che clicca logo+titolo+bottone è UNA persona,
@@ -150,16 +156,30 @@ async function fromGa4(days) {
   });
   const j = await r.json();
   if (j.error) throw new Error(`GA4: ${JSON.stringify(j.error).slice(0, 200)}`);
+  return aggregateGa4Rows(j.rows || []);
+}
+
+/**
+ * Pure aggregator GA4 rows → per-employer conteggi (unit-testable, no fetch).
+ * La pitch "candidati inviati dagli annunci gratuiti" DEVE escludere lo
+ * sponsorizzato (con sponsorizzato le candidature arrivano già diretto al
+ * datore, copy box dashboard) — persons/sessions/clicks qui sono free-only,
+ * lo sponsored va solo nel campo `sponsored` (non sommato al resto).
+ */
+export function aggregateGa4Rows(rows) {
   const byKey = new Map();
-  for (const row of (j.rows || [])) {
+  for (const row of (rows || [])) {
     const key = row.dimensionValues[0].value;
     const sponsored = row.dimensionValues[1].value === 'sponsored';
     const users = Number(row.metricValues[0].value) || 0;
     const sessions = Number(row.metricValues[1].value) || 0;
     const clicks = Number(row.metricValues[2].value) || 0;
     const e = byKey.get(key) || { key, persons: 0, sessions: 0, clicks: 0, sponsored: 0 };
-    e.persons += users; e.sessions += sessions; e.clicks += clicks;
-    if (sponsored) e.sponsored += users;
+    if (sponsored) {
+      e.sponsored += users;
+    } else {
+      e.persons += users; e.sessions += sessions; e.clicks += clicks;
+    }
     byKey.set(key, e);
   }
   // Stesso numero conservativo del path PostHog (#2384): pitch = min(persone, sessioni).
@@ -219,4 +239,7 @@ async function run() {
   }
 }
 
-run().catch(e => { console.error(e.message || e); process.exit(1); });
+// Esegui solo se invocato direttamente (aggregateGa4Rows resta importabile per i test).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  run().catch(e => { console.error(e.message || e); process.exit(1); });
+}

--- a/scripts/write-employer-traffic.mjs
+++ b/scripts/write-employer-traffic.mjs
@@ -9,12 +9,20 @@
  * dashboard's slugify(companyName) lookup). Read-only public collection
  * (firestore.rules); writes happen here via the Admin SDK only.
  *
+ * Stale-doc pruning: buildTrafficDocs() only emits rows with candidates > 0
+ * (no "0 candidati" noise), so a company that drops OUT of this run's set —
+ * e.g. its previous count came from a source that couldn't exclude sponsored
+ * traffic and the corrected free-only count is now 0 — must not keep its old
+ * (now-wrong) doc forever. Any existing `employer_crawled_traffic/{key}` doc
+ * whose key is NOT in the current run's key set is deleted every run.
+ *
  * Usage (CI, after the report):
  *   node scripts/employer-traffic-report.mjs --json /tmp/report.json
  *   node scripts/write-employer-traffic.mjs /tmp/report.json
  *
  * Auth: GOOGLE_APPLICATION_CREDENTIALS (service-account file) or
- * FIREBASE_SERVICE_ACCOUNT_JSON. No-op-safe: empty/invalid report → exit 0.
+ * FIREBASE_SERVICE_ACCOUNT_JSON. No-op-safe: empty/invalid report → exit 0
+ * (skips pruning too — a broken/empty report must never wipe the collection).
  */
 
 import fs from 'node:fs';
@@ -67,14 +75,25 @@ async function run() {
   catch (e) { console.error(`report illeggibile: ${e.message}`); process.exit(1); }
 
   const docs = buildTrafficDocs(report);
-  if (!docs.length) { console.log('Nessuna azienda con candidati > 0 — niente da scrivere.'); return; }
+  if (!docs.length) { console.log('Nessuna azienda con candidati > 0 — niente da scrivere (pruning skippato, report vuoto).'); return; }
 
   const { db, FieldValue } = await getDb();
   const { commitInChunks } = await import('./lib/firestore-batch.mjs');
   const written = await commitInChunks(db, docs, (batch, { key, data }) => {
     batch.set(db.collection(COLLECTION).doc(key), { ...data, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
   });
-  console.log(`✅ ${COLLECTION}: scritte ${written} aziende (window ${report.days}gg, source ${report.source}).`);
+
+  // Prune stale docs (see header comment): delete every existing doc whose key
+  // is NOT in this run's set, so a company that dropped to 0 candidates loses
+  // its old (possibly inflated) doc instead of keeping it forever.
+  const currentKeys = new Set(docs.map((d) => d.key));
+  const existingSnap = await db.collection(COLLECTION).select().get();
+  const staleRefs = existingSnap.docs.filter((d) => !currentKeys.has(d.id)).map((d) => d.ref);
+  const deleted = staleRefs.length
+    ? await commitInChunks(db, staleRefs, (batch, ref) => batch.delete(ref))
+    : 0;
+
+  console.log(`✅ ${COLLECTION}: scritte ${written} aziende (window ${report.days}gg, source ${report.source})${deleted ? `, ${deleted} stale rimosse` : ''}.`);
 }
 
 // Esegui solo se invocato direttamente (buildTrafficDocs resta importabile per i test).

--- a/scripts/write-employer-traffic.mjs
+++ b/scripts/write-employer-traffic.mjs
@@ -105,7 +105,7 @@ async function run() {
 
   let deleted = 0;
   let pruneSkipped = false;
-  if (staleRefs.length && staleRatio > PRUNE_FLOOR_PCT && !process.env.EMPLOYER_TRAFFIC_PRUNE_FORCE) {
+  if (staleRefs.length && staleRatio > PRUNE_FLOOR_PCT && process.env.EMPLOYER_TRAFFIC_PRUNE_FORCE !== '1') {
     pruneSkipped = true;
     console.warn(`⚠️ prune skippato: rimuoverebbe ${staleRefs.length}/${existingSnap.size} doc (${staleRatio.toFixed(0)}%), oltre il floor ${PRUNE_FLOOR_PCT}% — probabile report parziale, non churn reale. Per il cutover one-time PostHog→GA4 forza con EMPLOYER_TRAFFIC_PRUNE_FORCE=1.`);
   } else if (staleRefs.length) {

--- a/scripts/write-employer-traffic.mjs
+++ b/scripts/write-employer-traffic.mjs
@@ -14,7 +14,16 @@
  * e.g. its previous count came from a source that couldn't exclude sponsored
  * traffic and the corrected free-only count is now 0 — must not keep its old
  * (now-wrong) doc forever. Any existing `employer_crawled_traffic/{key}` doc
- * whose key is NOT in the current run's key set is deleted every run.
+ * whose key is NOT in the current run's key set is deleted, UNLESS that would
+ * remove more than PRUNE_FLOOR_PCT (default 50%) of existing docs in one run
+ * — a GA4 report that "succeeds" (no fetch error) but is missing rows for a
+ * subset of employer/is_sponsored combos (transient API glitch) looks
+ * identical to "these companies really have 0 candidates now", so a mass
+ * drop is treated as suspect and skipped (logged, not silently dropped)
+ * rather than wiping the collection. The one known LEGITIMATE mass-drop is
+ * the one-time PostHog→GA4 cutover correction (sponsored-inflated employers
+ * flipping to their true free-only count, possibly 0) — force it once with
+ * EMPLOYER_TRAFFIC_PRUNE_FORCE=1.
  *
  * Usage (CI, after the report):
  *   node scripts/employer-traffic-report.mjs --json /tmp/report.json
@@ -28,6 +37,7 @@
 import fs from 'node:fs';
 
 const COLLECTION = 'employer_crawled_traffic';
+const PRUNE_FLOOR_PCT = Number(process.env.EMPLOYER_TRAFFIC_PRUNE_FLOOR_PCT) || 50;
 
 /** Shape the Firestore docs from a report JSON. Pure → unit-testable. */
 export function buildTrafficDocs(report) {
@@ -85,15 +95,24 @@ async function run() {
 
   // Prune stale docs (see header comment): delete every existing doc whose key
   // is NOT in this run's set, so a company that dropped to 0 candidates loses
-  // its old (possibly inflated) doc instead of keeping it forever.
+  // its old (possibly inflated) doc instead of keeping it forever — unless
+  // that would remove more than PRUNE_FLOOR_PCT of existing docs at once,
+  // which looks more like a partial/glitched report than real churn.
   const currentKeys = new Set(docs.map((d) => d.key));
   const existingSnap = await db.collection(COLLECTION).select().get();
   const staleRefs = existingSnap.docs.filter((d) => !currentKeys.has(d.id)).map((d) => d.ref);
-  const deleted = staleRefs.length
-    ? await commitInChunks(db, staleRefs, (batch, ref) => batch.delete(ref))
-    : 0;
+  const staleRatio = existingSnap.size > 0 ? (staleRefs.length / existingSnap.size) * 100 : 0;
 
-  console.log(`✅ ${COLLECTION}: scritte ${written} aziende (window ${report.days}gg, source ${report.source})${deleted ? `, ${deleted} stale rimosse` : ''}.`);
+  let deleted = 0;
+  let pruneSkipped = false;
+  if (staleRefs.length && staleRatio > PRUNE_FLOOR_PCT && !process.env.EMPLOYER_TRAFFIC_PRUNE_FORCE) {
+    pruneSkipped = true;
+    console.warn(`⚠️ prune skippato: rimuoverebbe ${staleRefs.length}/${existingSnap.size} doc (${staleRatio.toFixed(0)}%), oltre il floor ${PRUNE_FLOOR_PCT}% — probabile report parziale, non churn reale. Per il cutover one-time PostHog→GA4 forza con EMPLOYER_TRAFFIC_PRUNE_FORCE=1.`);
+  } else if (staleRefs.length) {
+    deleted = await commitInChunks(db, staleRefs, (batch, ref) => batch.delete(ref));
+  }
+
+  console.log(`✅ ${COLLECTION}: scritte ${written} aziende (window ${report.days}gg, source ${report.source})${deleted ? `, ${deleted} stale rimosse` : ''}${pruneSkipped ? ' [prune skippato: floor]' : ''}.`);
 }
 
 // Esegui solo se invocato direttamente (buildTrafficDocs resta importabile per i test).

--- a/tests/employer-traffic-report.test.ts
+++ b/tests/employer-traffic-report.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateGa4Rows } from '../scripts/employer-traffic-report.mjs';
+
+function ga4Row(key: string, sponsored: boolean, users: number, sessions: number, clicks: number) {
+  return {
+    dimensionValues: [{ value: key }, { value: sponsored ? 'sponsored' : 'free' }],
+    metricValues: [{ value: String(users) }, { value: String(sessions) }, { value: String(clicks) }],
+  };
+}
+
+describe('aggregateGa4Rows', () => {
+  it('excludes sponsored traffic from the free-ads pitch count', () => {
+    const rows = aggregateGa4Rows([
+      ga4Row('casale-sa', false, 9, 9, 12),
+      ga4Row('casale-sa', true, 40, 40, 50),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].candidates).toBe(9);
+    expect(rows[0].persons).toBe(9);
+    expect(rows[0].sessions).toBe(9);
+    expect(rows[0].clicks).toBe(12);
+    expect(rows[0].sponsored).toBe(40);
+  });
+
+  it('candidates = min(persons, sessions), free-only', () => {
+    const rows = aggregateGa4Rows([ga4Row('acme', false, 15, 10, 20)]);
+    expect(rows[0].candidates).toBe(10);
+  });
+
+  it('employer with only sponsored ads gets 0 free candidates', () => {
+    const rows = aggregateGa4Rows([ga4Row('sponsored-only', true, 25, 25, 30)]);
+    expect(rows[0].candidates).toBe(0);
+    expect(rows[0].sponsored).toBe(25);
+  });
+
+  it('returns [] for empty rows', () => {
+    expect(aggregateGa4Rows([])).toEqual([]);
+    expect(aggregateGa4Rows(undefined as unknown as [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Implementato
- `scripts/employer-traffic-report.mjs`: `fromGa4()` refactored into pure exported `aggregateGa4Rows()` — sponsored traffic now excluded from `persons`/`sessions`/`clicks` (and therefore from `candidates`), only tallied in the separate `sponsored` field. Previously both tiers were summed together, so the "N candidati inviati dai vostri annunci gratuiti" pitch silently included sponsored-ad traffic.
- Added anti-autorun guard (`if (process.argv[1] && fileURLToPath(...) === path.resolve(...))`) mirroring the sibling `write-employer-traffic.mjs` pattern, so `aggregateGa4Rows` is importable/unit-testable without a live network call or `process.exit`.
- `.github/workflows/employer-traffic-refresh.yml`: production cron switched from `--source posthog` to `--source ga4`. Two reasons: (1) PostHog's `item_id` label has no sponsored/free flag at all — it structurally can't do the split (root cause of the bug is *only* fixable via GA4); (2) PostHog API quota exhaustion makes it an unreliable daily-cron dependency (per owner report). `GA4_PROPERTY_ID` is already wired via Remote Config and used in production by 6+ other scripts; `trackJobApply` (services/analytics.ts:1415) already emits `employer_key`/`is_sponsored` on every apply-click touchpoint (4/4 call sites in `JobBoard.tsx`), so no new instrumentation is needed — this was pre-built infra just never flipped on as the default source.
- New test `tests/employer-traffic-report.test.ts` (4 cases): sponsored excluded from candidates count, `candidates = min(persons, sessions)` free-only, employer with only-sponsored ads → 0 free candidates, empty input.
- Docstring header updated to state GA4 is now the production source and document exactly why PostHog can't be used for the daily cron (kept as CLI default for manual/historical backfill only — unaffected, still documented).
- **Review fix 1 (🔴, commit `78035b96c6d`):** `scripts/write-employer-traffic.mjs` now prunes stale Firestore docs. `buildTrafficDocs()` only ever emits `candidates > 0` rows, so a company whose free-candidate count dropped to 0 under the corrected GA4 split (previously inflated by sponsored traffic under PostHog) kept its old `employer_crawled_traffic/{key}` doc forever — the dashboard box never actually self-hid as originally claimed here. `write-employer-traffic.mjs` now deletes every existing doc whose key is NOT in the current run's key set after writing, so a company that drops out of the pitch loses its stale doc instead of keeping the old inflated count. Empty/invalid report → no-op, pruning is skipped too (never wipes the collection on a broken run).
- **Review fix 2 (🔴, this commit):** unguarded pruning could delete valid docs on a GA4 report that "succeeds" (no fetch error) but is missing rows for a subset of `employer_key`/`is_sponsored` combos (transient API glitch) — indistinguishable from "these companies really have 0 candidates now" but with the same destructive effect. Added `PRUNE_FLOOR_PCT` (default 50%, env-overridable): pruning is skipped (logged, not silent) if it would remove more than that share of existing docs in one run. The one known legitimate mass-drop — the one-time PostHog→GA4 cutover correction — can be forced past the floor with `EMPLOYER_TRAFFIC_PRUNE_FORCE=1` for that single manual run.

## Non implementato (ancora)
Nessuno.

Sibling-pattern check (Non-Negotiable #6): grepped `item_id.*sponsor` and all consumers of `employer-traffic-report.mjs`. Two adjacent scripts found:
- `scripts/build-employer-insights.mjs` — separate PostHog pipeline for the cold-outreach "proof page" (`employer_insights/{key}`), explicitly a *total* candidates metric (views − candidates = "lost", loss-aversion hook) — semantically different from the dashboard's free-only pitch. False positive, not touched.
- `scripts/generate-cold-emails.mjs` — only consumes the generic JSON shape (`e.candidates`/`e.clicks`/`e.name`), still works with either source; docstring intentionally still shows `--source posthog` as its manual usage example (ad-hoc backfill tool, not the daily cron). Not affected.

Root cause fixed at both the data layer (GA4 aggregation excludes sponsored) and the write layer (`PublisherDashboardPage.tsx` reads `employer_crawled_traffic/{key}.candidates` directly with no TTL/recompute, so a stale doc had to be actively pruned, not just left unwritten, and the pruning itself needed a floor against partial-report false positives) — a sponsored-only publisher now correctly loses its stale doc and the box self-hides once GA4 data propagates (next daily cron run, ≤24h), without risking mass-deletion on a glitched report.
