### PR TITLE
fix(events): resolve real price for Event offers, stop fabricating on ambiguous price

### DIFF
--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -48,6 +48,7 @@ import {
   weekendWindow,
   weekWindow,
   overlapsWindow,
+  hasConfidentPrice,
 } from '../scripts/lib/events-utils.mjs';
 import { getCantonLabel, type CantonLocale } from '../services/cantonList';
 import { imageObjectLd, type ImageObjectLd } from '../services/seo/imageObjectLd';
@@ -628,12 +629,16 @@ export function zurichOffset(isoDate: string): string {
 /**
  * schema.org/Event object for one agenda entry.
  *
- * `offers` is deliberately OMITTED: the agenda never exposes a price, and
- * asserting `price:"0"` (free) on paid concerts/theatre would misrepresent an
- * indexed page (structured-data policy risk). Google treats `offers` as
- * recommended-not-required, and validate-structured-data-completeness.mjs now
- * validates it only when present. Every other Google-required/recommended
- * Event field is emitted with a safe fallback.
+ * `offers` is emitted ONLY when `event.price` carries a confident price/free
+ * signal (`hasConfidentPrice` — real parsed amount or a matched free
+ * keyword); asserting `price:"0"` on a paid concert/theatre event would
+ * misrepresent an indexed page (structured-data policy risk), so an event
+ * with no price data on file (or an ambiguous "su richiesta"-style price
+ * that couldn't be parsed to a number) still gets no `offers` block at all.
+ * Google treats `offers` as recommended-not-required, and
+ * validate-structured-data-completeness.mjs validates it only when present.
+ * Every other Google-required/recommended Event field is emitted with a
+ * safe fallback.
  */
 export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string): Record<string, unknown> {
   const cantonName = getCantonLabel(event.canton || 'TI', locale as CantonLocale);
@@ -696,12 +701,12 @@ export function eventLd(event: SiteEvent, locale: Locale, canonicalUrl?: string)
     // price/free signal, and always the FULL required shape together
     // (price+priceCurrency+availability+validFrom+url) so a partial offers
     // object never trips the "offers.field missing" gate.
-    ...(event.price
+    ...(hasConfidentPrice(event.price)
       ? {
           offers: {
             '@type': 'Offer',
-            price: event.price.isFree ? '0' : String(event.price.amount ?? '0'),
-            priceCurrency: event.price.currency || 'CHF',
+            price: event.price!.isFree ? '0' : String(event.price!.amount),
+            priceCurrency: event.price!.currency || 'CHF',
             availability: 'https://schema.org/InStock',
             validFrom: event.startDate,
             url: canonicalUrl || event.url,
@@ -1261,8 +1266,11 @@ function osmLink(event: SiteEvent, comune: string): { href: string; place: strin
 }
 
 function priceLine(event: SiteEvent, dc: DetailCopy): string {
-  if (!event.price) return '';
-  const value = event.price.isFree ? dc.freeLabel : `${event.price.currency || 'CHF'} ${event.price.amount ?? ''}`.trim();
+  // Same confidence gate as eventLd()'s `offers`: an ambiguous price (present
+  // but not machine-parseable, e.g. "su richiesta") renders nothing rather
+  // than a bare "CHF" with no amount.
+  if (!hasConfidentPrice(event.price)) return '';
+  const value = event.price!.isFree ? dc.freeLabel : `${event.price!.currency || 'CHF'} ${event.price!.amount}`.trim();
   return renderMetric(dc.priceLabel, esc(value));
 }
 

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -104,8 +104,14 @@ import {
   eventStableId,
   resolveComuneNationwide,
   mirrorEventImage,
+  parsePriceText,
 } from './lib/events-utils.mjs';
 import { loadCursor, saveCursor, mergeEventsIntoSlice } from './lib/crawl-checkpoint.mjs';
+
+// Re-exported so existing importers (tests/crawl-guidle-events.test.ts) keep
+// working — the parser itself now lives in events-utils.mjs, shared with
+// crawl-tio-agenda.mjs's own free-text "Prezzo:" field (AGENTS.md §6).
+export { parsePriceText } from './lib/events-utils.mjs';
 
 const SOURCE = EVENT_SOURCES.guidle;
 const SITE_ORIGIN = 'https://www.guidle.com';
@@ -287,35 +293,6 @@ export function extractCategory(doc, locale) {
   const li = acc?.querySelector('li');
   const value = li ? text(li) : '';
   return value || undefined;
-}
-
-const FREE_RE = /\b(gratis|gratuit[oe]?|free|kostenlos|eintritt frei|entr[ée]e libre|ingresso libero)\b/i;
-const AMOUNT_RE = /(\d+(?:[.,]\d{1,2})?)/g;
-
-/**
- * Parse guidle's free-text price accordion (e.g. "CHF 10.00 pro Person…",
- * "Ingresso 20 franchi, Bambini gratis") into `{amount, currency, isFree}`.
- * Takes the CHEAPEST number found (same "cheapest of several prices" rule as
- * the myswitzerland crawler's `extractPrice`). Falls back to a free-keyword
- * match when no number is present, and to `amount: null` (price info exists
- * but isn't machine-parseable, e.g. "su richiesta" / "on request") otherwise.
- */
-export function parsePriceText(rawText) {
-  const t = cleanText(rawText);
-  if (!t) return undefined;
-  const numbers = [];
-  AMOUNT_RE.lastIndex = 0;
-  let m;
-  while ((m = AMOUNT_RE.exec(t))) {
-    const n = Number.parseFloat(m[1].replace(',', '.'));
-    if (Number.isFinite(n)) numbers.push(n);
-  }
-  if (numbers.length) {
-    const amount = Math.min(...numbers);
-    return { amount, currency: 'CHF', isFree: amount === 0 };
-  }
-  if (FREE_RE.test(t)) return { amount: 0, currency: 'CHF', isFree: true };
-  return { amount: null, currency: 'CHF', isFree: false };
 }
 
 /** Price from the "Preis"/"Prezzo"/… accordion, or undefined when absent. */

--- a/scripts/crawl-tio-agenda.mjs
+++ b/scripts/crawl-tio-agenda.mjs
@@ -19,6 +19,14 @@
  * the same convention `crawl-guidle-events.mjs` / `crawl-myswitzerland-events.mjs`
  * already use.
  *
+ * Price ("offers" JSON-LD gap): the day-page card never carries a price, only
+ * the per-event detail page does (a "Prezzo:" label, empty/hidden when tio.ch
+ * has no price on file). `enrichEventsWithPrice` below fetches each event's
+ * own detail page once and parses it with the same `parsePriceText` guidle
+ * uses, so `eventLd()` (build-plugins/eventsSeoPagesPlugin.ts) can emit a
+ * real `offers` block instead of omitting it — never fabricated: an event
+ * with no price signal at all still gets no `offers`, by design.
+ *
  * Usage:
  *   node scripts/crawl-tio-agenda.mjs                 # next 21 days
  *   node scripts/crawl-tio-agenda.mjs --days 30       # custom horizon
@@ -41,6 +49,7 @@ import {
   resolveComune,
   loadCantonComuni,
   mirrorEventImage,
+  parsePriceText,
 } from './lib/events-utils.mjs';
 
 const SOURCE = EVENT_SOURCES['tio-agenda'];
@@ -54,6 +63,12 @@ const POLITE_DELAY_MS = 600;
 // already on disk from a previous run), so a steady-state re-crawl only pays
 // this for genuinely new events.
 const IMAGE_MIRROR_DELAY_MS = 150;
+// Politeness delay between per-event detail-page fetches (price extraction —
+// same tio.ch host as the day pages, so same order of magnitude delay). Not
+// idempotent/cached like the image mirror: price can change run to run, so
+// every event is re-fetched every crawl. At ~136 events/run this adds ~80s,
+// well inside the 35min crawl-events.yml budget.
+const PRICE_FETCH_DELAY_MS = 600;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -177,8 +192,9 @@ export function warnIfLowConfidenceComuneShare(byMethod, resolved) {
  * tio.ch/biglietteria.ch flyer URL `parseDayHtml` extracts from the DOM.
  * Mirrors the guidle/myswitzerland crawlers' convention (map → mirror →
  * store), just applied as a post-pass here since tio-agenda parses every
- * event straight off the already-fetched day pages (no per-event detail
- * fetch to hang the mirror call off of).
+ * event straight off the already-fetched day pages — the card itself never
+ * carries a price either, that's a separate per-event fetch, see
+ * `enrichEventsWithPrice` below.
  *
  * Returns a NEW array (does not mutate `events`). `mirrorFn` is injectable so
  * tests can verify the replace-or-drop contract without a live network call.
@@ -191,6 +207,47 @@ export async function mirrorEventImages(events, mirrorFn = mirrorEventImage) {
     // Only pace real network attempts (skipped for events with no source
     // image at all, and skipped entirely under an injected test mirrorFn).
     if (mirrorFn === mirrorEventImage && ev.imageUrl) await sleep(IMAGE_MIRROR_DELAY_MS);
+  }
+  return out;
+}
+
+/**
+ * Parse an event detail page's "Prezzo:" label into `{amount, currency,
+ * isFree}` via the shared `parsePriceText` (same parser guidle's price
+ * accordion uses). tio.ch renders the label unconditionally but leaves it
+ * empty when no price is on file — `parsePriceText('')` correctly returns
+ * `undefined` for that case, so no price signal never becomes a fabricated
+ * one. Returns `undefined` when the label itself is missing (page shape
+ * changed, or fetch returned something unexpected).
+ */
+export function extractTioPrice(html) {
+  const m = /<strong>\s*Prezzo:\s*<\/strong>\s*([^<]*)/i.exec(html || '');
+  if (!m) return undefined;
+  return parsePriceText(m[1]);
+}
+
+/**
+ * Fetch each event's own detail page once and attach a `price` (the day-page
+ * card this crawler otherwise parses never carries one — see file header).
+ * Populating `price` here is what lets `eventLd()`
+ * (build-plugins/eventsSeoPagesPlugin.ts) emit a real schema.org `offers`
+ * block for tio-agenda events instead of always omitting it.
+ *
+ * Not idempotent/cached like `mirrorEventImages` — every event is re-fetched
+ * every run since price can change. A fetch failure (network/timeout) just
+ * leaves `price` unset, same soft-fail convention as `fetchHtml` callers
+ * elsewhere in this file.
+ *
+ * Returns a NEW array (does not mutate `events`). `fetchFn` is injectable so
+ * tests can verify parsing without a live network call.
+ */
+export async function enrichEventsWithPrice(events, fetchFn = fetchHtml) {
+  const out = [];
+  for (const ev of events) {
+    const html = ev.url ? await fetchFn(ev.url) : null;
+    const price = html ? extractTioPrice(html) : undefined;
+    out.push(price ? { ...ev, price } : { ...ev });
+    if (fetchFn === fetchHtml) await sleep(PRICE_FETCH_DELAY_MS);
   }
   return out;
 }
@@ -259,10 +316,17 @@ async function main() {
     return;
   }
 
+  // Per-event detail fetch (offers/JSON-LD gap): attach `price` where tio.ch
+  // has one on file, BEFORE mirroring images or writing the slice — see
+  // `enrichEventsWithPrice` above.
+  const pricedEvents = await enrichEventsWithPrice(events);
+  const withPrice = pricedEvents.filter((e) => e.price).length;
+  console.log(`[tio-agenda] price resolved ${withPrice}/${pricedEvents.length}`);
+
   // No-hotlink policy (events-utils.mjs mirrorEventImage): replace every raw
   // tio.ch/biglietteria.ch flyer URL with our own mirrored copy (or drop it)
   // BEFORE it reaches the dry-run preview or the written slice.
-  const mirroredEvents = await mirrorEventImages(events);
+  const mirroredEvents = await mirrorEventImages(pricedEvents);
 
   if (dryRun) {
     console.log('🏃 dry-run — slice not written');

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -512,6 +512,52 @@ export function eventStableId(sourceKey, rawId) {
   return `${sourceKey}:${String(rawId).trim()}`;
 }
 
+// ── Price parsing ────────────────────────────────────────────
+// Shared by every crawler that scrapes a free-text price field (guidle's
+// price accordion, tio-agenda's "Prezzo:" label) — one regex pair, not a
+// copy per crawler (AGENTS.md §6: literal duplicate regex across ≥2 files
+// must live in one shared module).
+const PRICE_FREE_RE = /\b(gratis|gratuit[oe]?|free|kostenlos|eintritt frei|entr[ée]e libre|ingresso libero)\b/i;
+const PRICE_AMOUNT_RE = /(\d+(?:[.,]\d{1,2})?)/g;
+
+/**
+ * Parse a free-text price snippet (e.g. "CHF 10.00 pro Person", "Ingresso 20
+ * franchi, Bambini gratis", "Eintritt frei") into `{amount, currency, isFree}`.
+ * Takes the CHEAPEST number found when several are present. Falls back to a
+ * free-keyword match when no number is present, and to `amount: null` (price
+ * info exists but isn't machine-parseable, e.g. "su richiesta" / "on
+ * request") otherwise. Returns `undefined` for empty/missing input — callers
+ * treat that as "no price signal at all", never as "free".
+ */
+export function parsePriceText(rawText) {
+  const t = typeof rawText === 'string' ? rawText.replace(/\s+/g, ' ').trim() : '';
+  if (!t) return undefined;
+  const numbers = [];
+  PRICE_AMOUNT_RE.lastIndex = 0;
+  let m;
+  while ((m = PRICE_AMOUNT_RE.exec(t))) {
+    const n = Number.parseFloat(m[1].replace(',', '.'));
+    if (Number.isFinite(n)) numbers.push(n);
+  }
+  if (numbers.length) {
+    const amount = Math.min(...numbers);
+    return { amount, currency: 'CHF', isFree: amount === 0 };
+  }
+  if (PRICE_FREE_RE.test(t)) return { amount: 0, currency: 'CHF', isFree: true };
+  return { amount: null, currency: 'CHF', isFree: false };
+}
+
+/**
+ * Whether a parsed `{amount, currency, isFree}` price carries a confident
+ * enough signal to publish as schema.org `offers` — `isFree: true` or a real
+ * parsed `amount`. Excludes the `amount: null` ambiguous bucket (price
+ * mentioned but not machine-parseable, e.g. "su richiesta"): asserting
+ * `price:"0"` there would fabricate "free" for a plausibly-paid event.
+ */
+export function hasConfidentPrice(price) {
+  return Boolean(price) && (price.isFree === true || typeof price.amount === 'number');
+}
+
 // ── Date helpers ─────────────────────────────────────────────
 /** Convert "YYYYMMDD" → "YYYY-MM-DD". Returns '' on malformed input. */
 export function isoFromCompactDate(compact) {

--- a/tests/events-pipeline.test.ts
+++ b/tests/events-pipeline.test.ts
@@ -10,7 +10,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { parseDayHtml, warnIfLowConfidenceComuneShare, mirrorEventImages } from '../scripts/crawl-tio-agenda.mjs';
+import {
+  parseDayHtml,
+  warnIfLowConfidenceComuneShare,
+  mirrorEventImages,
+  extractTioPrice,
+  enrichEventsWithPrice,
+} from '../scripts/crawl-tio-agenda.mjs';
 import {
   resolveComune,
   slugifyComune,
@@ -355,6 +361,81 @@ describe('eventLd — schema.org/Event completeness gate', () => {
         'en',
       ),
     );
+  });
+
+  const baseEvent = {
+    id: 'tio-agenda:6',
+    title: 'Yoga e Pilates',
+    startDate: '2026-07-04',
+    canton: 'TI',
+    url: 'https://www.tio.ch/agenda/day/20260704/63071',
+    sourceKey: 'tio-agenda',
+    sourceName: 'Tio.ch Agenda',
+  };
+
+  it('emits offers with a real price when event.price has a confident amount', () => {
+    const ld = eventLd(
+      { ...baseEvent, price: { amount: 19, currency: 'CHF', isFree: false } },
+      'it',
+      'https://frontaliereticino.ch/eventi/ticino/melide/',
+    ) as Record<string, any>;
+    expect(ld.offers).toEqual({
+      '@type': 'Offer',
+      price: '19',
+      priceCurrency: 'CHF',
+      availability: 'https://schema.org/InStock',
+      validFrom: '2026-07-04',
+      url: 'https://frontaliereticino.ch/eventi/ticino/melide/',
+    });
+  });
+
+  it('emits offers with price "0" when event.price is confidently free', () => {
+    const ld = eventLd({ ...baseEvent, price: { amount: 0, currency: 'CHF', isFree: true } }, 'it') as Record<string, any>;
+    expect(ld.offers?.price).toBe('0');
+  });
+
+  it('omits offers (never fabricates "0") when price is present but not machine-parseable', () => {
+    // e.g. tio.ch "Prezzo:" label says "su richiesta" / "CHF" with no digits —
+    // parsePriceText returns amount: null, isFree: false for this bucket.
+    const ld = eventLd({ ...baseEvent, price: { amount: null, currency: 'CHF', isFree: false } }, 'it') as Record<string, any>;
+    expect(ld.offers).toBeUndefined();
+  });
+});
+
+describe('extractTioPrice + enrichEventsWithPrice (offers/JSON-LD gap, tio.ch "Prezzo:" label)', () => {
+  it('parses a real "N CHF" price off a detail page', () => {
+    const html = '<div><span><strong>Prezzo:</strong> 19 CHF </span></div>';
+    expect(extractTioPrice(html)).toEqual({ amount: 19, currency: 'CHF', isFree: false });
+  });
+
+  it('returns undefined when the label is present but empty (tio.ch has no price on file)', () => {
+    const html = '<span class="d-none"> <strong>Prezzo:</strong></span>';
+    expect(extractTioPrice(html)).toBeUndefined();
+  });
+
+  it('returns undefined when the label is missing entirely (unexpected page shape)', () => {
+    expect(extractTioPrice('<div>no price label here</div>')).toBeUndefined();
+    expect(extractTioPrice('')).toBeUndefined();
+  });
+
+  it('enrichEventsWithPrice attaches price from the injected fetch, never mutates the source array', async () => {
+    const events = [
+      { id: 'tio-agenda:63071', url: 'https://www.tio.ch/agenda/day/20260704/63071' },
+      { id: 'tio-agenda:63038', url: 'https://www.tio.ch/agenda/day/20260703/63038' },
+    ];
+    const fakeFetch = async (url: string) =>
+      url.endsWith('63071') ? '<strong>Prezzo:</strong> 19 CHF' : '<span class="d-none"><strong>Prezzo:</strong></span>';
+    const out = await enrichEventsWithPrice(events, fakeFetch);
+    expect(out[0].price).toEqual({ amount: 19, currency: 'CHF', isFree: false });
+    expect(out[1].price).toBeUndefined();
+    expect(events[0].price).toBeUndefined(); // non-mutating
+  });
+
+  it('enrichEventsWithPrice leaves price unset on fetch failure (soft-fail, never fabricates)', async () => {
+    const events = [{ id: 'tio-agenda:1', url: 'https://www.tio.ch/agenda/day/20260704/1' }];
+    const failingFetch = async () => null;
+    const out = await enrichEventsWithPrice(events, failingFetch);
+    expect(out[0].price).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Implementato

- `scripts/crawl-tio-agenda.mjs`: `enrichEventsWithPrice` fetches each event's tio.ch detail page and parses the "Prezzo:" label (`extractTioPrice`) via the shared parser, attaching `event.price` before the dataset is written — the tio-agenda crawler previously had zero price extraction, so GSC's missing-`offers` warning fired on every tio-sourced event page regardless of whether the source actually had a price (confirmed live: the reported Melide "Yoga e Pilates" event has a real `Prezzo: 19 CHF` on its detail page).
- `scripts/lib/events-utils.mjs`: extracted `parsePriceText`/`hasConfidentPrice` out of `crawl-guidle-events.mjs` (previously a local, undeduplicated copy) into one shared module per AGENTS.md §6 sibling-pattern rule, now used by both `crawl-tio-agenda.mjs` and `crawl-guidle-events.mjs`. `crawl-guidle-events.mjs` re-exports `parsePriceText` so its existing test import keeps working.
- `build-plugins/eventsSeoPagesPlugin.ts`: fixed a latent fabrication bug — `eventLd()`'s `offers` and the sibling `priceLine()` used `String(event.price.amount ?? '0')` gated only on `event.price` being truthy, so an ambiguous price (present but unparseable, `amount: null`) fell through to a fabricated "free" (`price: "0"`) offer, contradicting the code's own "never fabricate" comment. Both now gate on `hasConfidentPrice()`.
- `tests/events-pipeline.test.ts`: added coverage for `extractTioPrice`/`enrichEventsWithPrice` (real price parse, empty/missing label, non-mutating, soft-fail on fetch error) and a regression test locking in the fabrication fix (`omits offers when price is present but not machine-parseable`).

Verified live: the reported Morcote "Summer in Morcote" event genuinely has no price/booking signal on its source page — it correctly continues to omit `offers` (no signal, no claim), consistent with the codebase's existing anti-fabrication policy.

Tests: `npx vitest run tests/crawl-guidle-events.test.ts tests/events-pipeline.test.ts tests/events-digest-article.test.ts tests/events-detail-pages.test.ts tests/events-nationwide-sources.test.ts` → 145/145 passed. `npx tsc --noEmit` → no new errors (pre-existing unrelated failures only).

## Non implementato (ancora)

Nessuno.