### PR TITLE
feat(email): raise cloudflare cascade daily quota to 1000

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -52,11 +52,13 @@ const PROVIDERS = [
   // the purely-free providers are preferred over the paid Workers quota.
   { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
   // Cloudflare Email Service: limit is MONTHLY (3000/mo included on Workers Paid),
-  // there is no documented per-day cap. dailyLimit is the 3000/30 ≈ 100/day spread
-  // so the in-memory guard keeps a single day from burning a disproportionate
-  // share of the monthly allowance. Placed last: it draws on the paid-plan quota,
-  // so prefer the purely-free providers first.
-  { id: 'cloudflare', dailyLimit: 100, monthlyLimit: 3000 },
+  // no documented per-day cap. dailyLimit raised to 1000 (owner request 2026-07-03)
+  // to give more overflow headroom on high-volume days — cloudflare sits last in
+  // the cascade so it only fires after the free providers (850/day combined) are
+  // exhausted; monthlyLimit unchanged, so 2-3 heavy days can burn the month's
+  // allowance early, after which real send errors push overflow to the retry
+  // queue. Placed last: it draws on the paid-plan quota, so prefer free providers first.
+  { id: 'cloudflare', dailyLimit: 1000, monthlyLimit: 3000 },
 ];
 
 // In-memory daily counters (reset on new UTC day)
@@ -319,7 +321,7 @@ async function syncQuotasFromAPIs() {
   _counters.cloudflare = cloudflare;
   _quotasSynced = true;
 
-  console.log(`   Usage today: mailgun=${mailgun}/100, mailjet=${mailjet}/200, mailtrap=${mailtrap}/150, resend=${resend}/100, maileroo=${maileroo}/100, cloudflare=${cloudflare}/100`);
+  console.log(`   Usage today: mailgun=${mailgun}/100, mailjet=${mailjet}/200, mailtrap=${mailtrap}/150, resend=${resend}/100, maileroo=${maileroo}/100, cloudflare=${cloudflare}/1000`);
 }
 
 // ── Provider availability check ──────────────────────────────
@@ -892,7 +894,7 @@ function campaignIdTag(email) {
 /**
  * Total theoretical daily send capacity across the whole cascade —
  * the sum of every provider's daily limit (currently mailgun 100 + resend 100
- * + mailjet 200 + mailtrap 150 + maileroo 100 + cloudflare 100 = 750). Single
+ * + mailjet 200 + mailtrap 150 + maileroo 100 + cloudflare 1000 = 1650). Single
  * source of truth so callers (e.g. the newsletter per-run cap) stay in sync when
  * providers change.
  */

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -51,14 +51,13 @@ const PROVIDERS = [
   // dmarc=pass at p=reject (dis=NONE), delivered to inbox. Placed before cloudflare so
   // the purely-free providers are preferred over the paid Workers quota.
   { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
-  // Cloudflare Email Service: limit is MONTHLY (3000/mo included on Workers Paid),
-  // no documented per-day cap. dailyLimit raised to 1000 (owner request 2026-07-03)
-  // to give more overflow headroom on high-volume days — cloudflare sits last in
-  // the cascade so it only fires after the free providers (850/day combined) are
-  // exhausted; monthlyLimit unchanged, so 2-3 heavy days can burn the month's
-  // allowance early, after which real send errors push overflow to the retry
-  // queue. Placed last: it draws on the paid-plan quota, so prefer free providers first.
-  { id: 'cloudflare', dailyLimit: 1000, monthlyLimit: 3000 },
+  // Cloudflare Email Service: 3000/mo is the included allowance on Workers Paid;
+  // no documented per-day cap. dailyLimit=1000, monthlyLimit=30000 (owner request
+  // 2026-07-03) — owner accepted paid overage above the included 3000/mo, up to
+  // ~$9.45/mo worst case ($0.35/1000 past the included allowance, if cloudflare
+  // maxes out every day of the month). Placed last: it draws on the paid-plan
+  // quota, so prefer the purely-free providers first.
+  { id: 'cloudflare', dailyLimit: 1000, monthlyLimit: 30000 },
 ];
 
 // In-memory daily counters (reset on new UTC day)


### PR DESCRIPTION
## Implementato
- `scripts/lib/email-cascade.mjs`: cloudflare provider `dailyLimit` 100 → 1000, `monthlyLimit` 3000 → 30000 (owner request, discussed re: jobalert send-quota parity check).
- Updated dependent hardcoded strings so they stay in sync: the `syncQuotasFromAPIs()` usage-summary log line, and the `getCascadeDailyCapacity()` doc comment (750 → 1650 total daily cascade capacity).

## Non implementato (ancora)
Nessuno.

## Note
Cloudflare sits last in the cascade (overflow only, after ~850/day free-provider capacity is exhausted), so 1000/day is a ceiling, not a guaranteed daily send volume. Cloudflare's real included allowance is 3000/mo on Workers Paid (unchanged) — `monthlyLimit=30000` here is our accepted budget ceiling, not a free quota; usage above 3000/mo draws paid overage at ~$0.35/1000 emails. Owner was shown the math (worst case ~$9.45/mo if cloudflare maxes out every day) and explicitly accepted it before raising both caps.