### PR TITLE
fix(events): nationwide-canton test + issue-reporter body drop (#3333)

### DIFF
--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -62,27 +62,34 @@ jobs:
         run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Crawl tio.ch agenda
+        id: crawl-tio
         run: node scripts/crawl-tio-agenda.mjs --days "${{ github.event.inputs.days || '21' }}"
 
       - name: Crawl guidle.com (nationwide)
+        id: crawl-guidle
         run: node scripts/crawl-guidle-events.mjs
 
       - name: Crawl myswitzerland.com (nationwide)
+        id: crawl-myswitzerland
         run: node scripts/crawl-myswitzerland-events.mjs
 
       - name: Assemble events dataset
+        id: assemble
         run: node scripts/assemble-events-dataset.mjs --stats
 
       - name: Refresh weekend-digest article body (evergreen, body-only)
+        id: digest
         # Rewrites the 4 blog-body files of the stable `eventi-weekend-ticino`
         # article with the current weekend's events (no re-registration, no RSS
         # churn). Soft-fail: a refresh hiccup must never block the events commit.
         run: node scripts/generate-events-digest-article.mjs || echo "::warning::digest article refresh skipped"
 
       - name: Gate — events dataset + refreshed body must keep the suite green
+        id: gate
         run: npx vitest run tests/events-pipeline.test.ts tests/blog-body-typescript-syntax.test.ts
 
       - name: Commit dataset (rebase-retry pattern)
+        id: commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -138,5 +145,18 @@ jobs:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: events pipeline (tio.ch, guidle, myswitzerland)" \
-            --body "The crawl-events workflow failed. Check the run logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --label "crawler" || true
+            --description "## Crawler fallito
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}
+
+          **Step outcomes:**
+          - Crawl tio.ch agenda: ${{ steps.crawl-tio.outcome }}
+          - Crawl guidle.com (nationwide): ${{ steps.crawl-guidle.outcome }}
+          - Crawl myswitzerland.com (nationwide): ${{ steps.crawl-myswitzerland.outcome }}
+          - Assemble events dataset: ${{ steps.assemble.outcome }}
+          - Refresh weekend-digest article: ${{ steps.digest.outcome }}
+          - Gate (vitest): ${{ steps.gate.outcome }}
+          - Commit dataset: ${{ steps.commit.outcome }}" \
+            --label "crawler" \
+            --workflow "${{ github.workflow }}" || true

--- a/tests/events-pipeline.test.ts
+++ b/tests/events-pipeline.test.ts
@@ -27,6 +27,7 @@ import {
   loadCantonComuni,
 } from '../scripts/lib/events-utils.mjs';
 import { eventLd, zurichOffset } from '../build-plugins/eventsSeoPagesPlugin';
+import { CANTON_CODES } from '../services/cantonList';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -452,7 +453,10 @@ describe('assembled dataset integrity (data/events.json)', () => {
       expect(e.title.length).toBeGreaterThan(0);
       expect(e.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       if (e.endDate) expect(e.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      expect(e.canton).toBe('TI');
+      // Nationwide sources (guidle, myswitzerland — #3125) resolve events to
+      // any of the 26 cantons, not just TI; assert membership in the same
+      // canton list the job board uses instead of the pre-#3125 TI-only check.
+      expect(CANTON_CODES).toContain(e.canton);
     }
   });
 });


### PR DESCRIPTION
## Implementato
- `tests/events-pipeline.test.ts`: the "assembled dataset integrity" test hardcoded `expect(e.canton).toBe('TI')`, predating the nationwide event sourcing rollout (#3125/#3243, guidle.com + myswitzerland.com) which deliberately resolves events to any of the 26 cantons via `resolveComuneNationwide` (confirmed live: `eventsSeoPagesPlugin.ts` already has full per-canton hub-page + copy-substitution support for "any canton other than TI"). A legitimately-resolved `SZ` event was failing this stale assertion and blocking `crawl-events` from committing the dataset (run 28648916288, job 84961979747). Now asserts membership in `CANTON_CODES` (`services/cantonList.ts`), the same 26-canton list the job board already uses.
- `.github/workflows/crawl-events.yml`: the "Report failure to GitHub Issues" step called `github-issue-creator.mjs --body "..."`, but the script's CLI arg parser only reads `--description` — `--body` is silently dropped, so every auto-filed issue (e.g. #3333) landed with an empty body instead of the run link. Fixed to `--description`, matching the pattern already used by every other crawler workflow (checked all workflow call sites of this script — `crawl-events.yml` was the only one using the wrong flag). Also added `id:` to each pipeline step and a step-outcomes list in the description, plus `--workflow`, so a filed issue now shows which stage failed instead of just "check the logs".

## Non implementato (ancora)
Nessuno.