### PR TITLE
fix(ci): redflag detector no longer matches negation prose

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -3,6 +3,11 @@ name: Auto-merge on Claude LGTM
 # Auto-merge scatta SOLO quando coesistono DUE condizioni, qualunque arrivi prima:
 #   A) review claude-bot sulla HEAD corrente con `## LGTM` e NO `🔴 Important`;
 #   B) check-run `vitest (unit + integration)` sulla HEAD == `success`.
+# Il check "NO 🔴 Important" per (A) NON vive nel job `if:` sotto — un `contains()`
+# YAML è una substring-match naive, e "🔴 Important" appare anche nella prosa di
+# NEGAZIONE del reviewer ("zero 🔴 Important findings...", PR #3330): il job veniva
+# skippato per una PR con `## LGTM` e zero findings reali. La decisione vive SOLO
+# in auto-merge-eval.mjs (REDFLAG_IMPORTANT_RE, negation-aware) — vedi sotto.
 # In passato il gate vitest bloccava SOLO su conclusion==failure: se vitest era
 # pending/mancante il merge PROCEDEVA → una PR poteva mergiare prima della fine
 # dei test e, se poi andavano rossi, main andava rosso (osservato #1454: LGTM
@@ -31,11 +36,13 @@ permissions:
 
 jobs:
   auto-merge:
-    # Pre-filtro a livello di evento (il resto dei gate è in auto-merge-eval.mjs,
-    # uguale per entrambi i trigger):
+    # Pre-filtro a livello di evento (il resto dei gate, incluso il check
+    # `🔴 Important` negation-aware, è in auto-merge-eval.mjs — single source of
+    # truth per entrambi i trigger):
     #   - pull_request_review: review autore = claude-bot (user.type=='Bot' +
-    #     startsWith 'claude'), state 'commented', body con `## LGTM` e senza
-    #     `🔴 Important`, PR non draft.
+    #     startsWith 'claude'), state 'commented', body con `## LGTM`, PR non
+    #     draft. NON filtra su `🔴 Important` qui (vedi commento header) — se il
+    #     body ha un 🔴 reale, auto-merge-eval.mjs lo blocca comunque a valle.
     #   - workflow_run: solo se la run di `tests` è conclusa con success (vitest
     #     verde) — altrimenti inutile valutare.
     if: |
@@ -44,7 +51,6 @@ jobs:
         startsWith(github.event.review.user.login, 'claude') &&
         github.event.review.state == 'commented' &&
         contains(github.event.review.body, '## LGTM') &&
-        !contains(github.event.review.body, '🔴 Important') &&
         github.event.pull_request.draft == false)
       ||
       (github.event_name == 'workflow_run' &&

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -41,10 +41,12 @@ jobs:
     # esatta `🔴 Important` è FRAGILE al markdown del reviewer. Osservato su PR #2211:
     # round-1 "🔴 Important: ..." (match) → round-2 "🔴 **Important —** ..." (bold →
     # `contains('🔴 Important')` FALSO → redflag-fix SKIPPATO → 🔴 round-2 mai
-    # indirizzato, PR bloccata, niente auto-merge). `stale-pr-rescuer.yml` già usa la
-    # detection robusta `grep -q "🔴"`: qui ci allineiamo. Il match PRECISO (è davvero
-    # un finding Important, non un 🔴 decorativo) lo fa il preflight sotto, con una
-    # regex tollerante al bold/spaziatura — impossibile in un'espressione `if:` YAML.
+    # indirizzato, PR bloccata, niente auto-merge). Questo `if:` resta un pre-filter
+    # ECONOMICO e volutamente ampio (solo "contiene un 🔴 qualsiasi"). Il match
+    # PRECISO (è davvero un finding Important, non un 🔴 decorativo o prosa che lo
+    # nega) lo fa il preflight sotto, con una regex tollerante al bold/spaziatura MA
+    # che richiede un delimitatore dopo "Important" — impossibile in un'espressione
+    # `if:` YAML.
     if: |
       github.event.review.user.type == 'Bot' &&
       startsWith(github.event.review.user.login, 'claude') &&
@@ -68,10 +70,15 @@ jobs:
         run: |
           set -uo pipefail
           # Marker 🔴-Important tollerante al markdown: il reviewer a volte bolda
-          # ("🔴 **Important —**") o varia la spaziatura. `🔴\s*\*{0,2}\s*Important`
-          # copre `🔴 Important`, `🔴 **Important`, `🔴**Important**`. Un 🔴 NON seguito
-          # da "Important" (decorativo, es. "nessun 🔴") → no-op, niente round speso.
-          if ! printf '%s' "$REVIEW_BODY" | grep -qP '🔴\s*\*{0,2}\s*Important'; then
+          # ("🔴 **Important —**") o varia la spaziatura. Richiede un delimitatore
+          # (`:`, `—`, `-`) subito dopo "Important" (+ bold di chiusura opzionale) —
+          # senza, la stessa regex matchava anche la prosa di negazione del
+          # reviewer ("zero 🔴 Important findings", PR #3330): "Important" lì è un
+          # aggettivo che dice che non ce ne sono, non il marker. Un 🔴 NON seguito
+          # da "Important<delimitatore>" (decorativo o prosa, es. "nessun 🔴") →
+          # no-op, niente round speso. Stessa regex in scripts/ci/lib/constants.mjs
+          # (REDFLAG_IMPORTANT_RE) — YAML `if:` non può importarla, tenerle allineate.
+          if ! printf '%s' "$REVIEW_BODY" | grep -qP '🔴\s*\*{0,2}\s*Important\s*\*{0,2}\s*[:—-]'; then
             echo "Review contiene 🔴 ma nessun finding '🔴 Important' (decorativo) → skip 🔴-fix (no-op)."
             echo "actionable=false" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/.github/workflows/stale-pr-rescuer.yml
+++ b/.github/workflows/stale-pr-rescuer.yml
@@ -106,8 +106,11 @@ jobs:
               # non distinguibili via API, stesso fix per entrambe).
               REASON="tests verdi sull'head corrente da >2h ma nessuna review pr-review-loop l'ha coperto"
               RESCUE="\`git fetch origin main && git merge origin/main\` nel branch \`$BRANCH\` poi push (allinea i workflow file, sana un eventuale app-token 401). Se il merge non serve, attendi ancora — può essere coda congestionata. Vedi AGENTS.md → \"Workflow-validation drift\"."
-            elif echo "$LAST_BODY" | grep -q "🔴" && [ "$LAST_CID" = "$HEAD" ]; then
-              # Classe B: 🔴 sull'head corrente, non ripreso.
+            elif echo "$LAST_BODY" | grep -qP '🔴\s*\*{0,2}\s*Important\s*\*{0,2}\s*[:—-]' && [ "$LAST_CID" = "$HEAD" ]; then
+              # Classe B: 🔴 Important sull'head corrente, non ripreso. Regex
+              # allineata a REDFLAG_IMPORTANT_RE (scripts/ci/lib/constants.mjs):
+              # un bare `grep -q "🔴"` avrebbe mis-triggerato su prosa di
+              # negazione del reviewer ("zero 🔴 Important findings", PR #3330).
               REASON="🔴 Important non ripreso (review sull'head corrente $HEAD, auto-merge skipped, nessun commit nuovo)"
               RESCUE="applica il fix del 🔴 in un nuovo commit sullo stesso branch \`$BRANCH\` → re-review automatica. Vedi la review più recente sulla PR."
             else

--- a/scripts/ci/lib/constants.mjs
+++ b/scripts/ci/lib/constants.mjs
@@ -30,17 +30,31 @@ export const VITEST_SHARD_NAME_RE = /^vitest shard \d+\/\d+$/;
 
 /**
  * Detects a `🔴 Important` finding in a reviewer body, TOLERANT to the reviewer's
- * markdown: `🔴 Important`, `🔴 **Important`, `🔴**Important**` all match. The plain
- * literal `'🔴 Important'` (used historically) misses the bold form, which the
- * reviewer emitted on PR #2211 round-2 ("🔴 **Important —**") → the redflag-fixer
- * skipped and the PR stalled with an unaddressed 🔴, and the auto-merge 🔴-guard
- * could likewise miss it. Single source for the JS-side gates (auto-merge-eval.mjs).
+ * markdown: `🔴 Important:`, `🔴 **Important —**`, `🔴**Important**:` all match. The
+ * plain literal `'🔴 Important'` (used historically) misses the bold form, which
+ * the reviewer emitted on PR #2211 round-2 ("🔴 **Important —**") → the
+ * redflag-fixer skipped and the PR stalled with an unaddressed 🔴, and the
+ * auto-merge 🔴-guard could likewise miss it. Single source for the JS-side gates
+ * (auto-merge-eval.mjs).
+ *
+ * Requires a delimiter (`:`, em-dash `—`, or `-`) right after `Important` (+
+ * optional closing bold). Without it, PR #3330 false-positived: the reviewer's
+ * own negation prose "zero 🔴 Important findings (both nits are non-blocking...)"
+ * matched the bare `🔴\s*\*{0,2}\s*Important` regex — "Important" there is an
+ * adjective inside a sentence saying there are NONE, not the marker — so the
+ * auto-merge 🔴-guard skipped a PR that actually had `## LGTM` and zero real
+ * findings, and the same text would also have mis-tripped stale-pr-rescuer.yml's
+ * Class B rescue. Every real marker observed (colon-delimited, or the PR #2211
+ * bold/dash form) has punctuation immediately after "Important"; plain
+ * continuation prose does not.
  *
  * NB: `pr-redflag-fixer.yml`'s preflight greps the SAME shape in bash
- * (`grep -qP '🔴\s*\*{0,2}\s*Important'`) — a YAML `if:` cannot import this regex,
- * so keep the two equivalent. `stale-pr-rescuer.yml` uses an even broader bare `🔴`.
+ * (`grep -qP '🔴\s*\*{0,2}\s*Important\s*\*{0,2}\s*[:—-]'`) — a YAML `if:` cannot
+ * import this regex, so keep the two equivalent. `stale-pr-rescuer.yml`'s Class B
+ * check now mirrors it too (previously an even broader bare `🔴`, with the same
+ * false-positive exposure).
  */
-export const REDFLAG_IMPORTANT_RE = /🔴\s*\*{0,2}\s*Important/;
+export const REDFLAG_IMPORTANT_RE = /🔴\s*\*{0,2}\s*Important\s*\*{0,2}\s*[:—-]/;
 
 /**
  * File la cui modifica impedisce STRUTTURALMENTE al reviewer Claude di girare

--- a/tests/redflag-important-marker.test.ts
+++ b/tests/redflag-important-marker.test.ts
@@ -5,6 +5,11 @@ import { REDFLAG_IMPORTANT_RE } from '../scripts/ci/lib/constants.mjs';
 // The brittle literal `'🔴 Important'` missed the reviewer's bold form
 // `🔴 **Important —` (PR #2211 round-2) → redflag-fixer skipped + PR stalled.
 // pr-redflag-fixer.yml greps the SAME shape in bash; keep the two equivalent.
+//
+// Requires a delimiter (`:`, `—`, or `-`) right after "Important" — added after
+// PR #3330 false-positived on the reviewer's own negation prose "zero 🔴
+// Important findings (both nits are non-blocking)": bare `Important` with no
+// delimiter is prose describing an ABSENCE of findings, not the marker itself.
 describe('REDFLAG_IMPORTANT_RE (markdown-tolerant 🔴 Important detector)', () => {
   it('matches the plain literal form', () => {
     expect(REDFLAG_IMPORTANT_RE.test('🔴 Important: missing canonical')).toBe(true);
@@ -15,7 +20,7 @@ describe('REDFLAG_IMPORTANT_RE (markdown-tolerant 🔴 Important detector)', () 
   });
 
   it('matches with no space and double-bold', () => {
-    expect(REDFLAG_IMPORTANT_RE.test('🔴**Important** regression')).toBe(true);
+    expect(REDFLAG_IMPORTANT_RE.test('🔴**Important**: regression')).toBe(true);
   });
 
   it('matches inside a real multi-finding review body', () => {
@@ -33,5 +38,11 @@ describe('REDFLAG_IMPORTANT_RE (markdown-tolerant 🔴 Important detector)', () 
 
   it('does NOT match a clean LGTM review with no 🔴', () => {
     expect(REDFLAG_IMPORTANT_RE.test('Looks correct, tests cover it.\n\n## LGTM')).toBe(false);
+  });
+
+  it('does NOT match the PR #3330 false-positive: negation prose with no delimiter after Important', () => {
+    const body =
+      'Correction to my prior review: zero 🔴 Important findings (both nits are non-blocking).\n\n## LGTM';
+    expect(REDFLAG_IMPORTANT_RE.test(body)).toBe(false);
   });
 });


### PR DESCRIPTION
## Implementato

- `scripts/ci/lib/constants.mjs`: `REDFLAG_IMPORTANT_RE` now requires a delimiter (`:`, `—`, or `-`) right after "Important" (+ optional closing bold), instead of matching the bare word. Fixes a false positive where the reviewer's own negation prose — "zero 🔴 Important findings (both nits are non-blocking...)" on PR #3330 — matched as if it were a real `🔴 Important` finding, because "Important" there is an adjective describing an *absence*, not the marker.
- Sibling-pattern sweep (AGENTS.md #6) across the other 3 constructs sharing this exact defect:
  - `.github/workflows/auto-merge-on-lgtm.yml`: removed the YAML-level `!contains(github.event.review.body, '🔴 Important')` pre-filter for the `pull_request_review` path. This was the actual root cause of PR #3330's stall — a naive `contains()` substring check evaluated in the job `if:` *before* any script runs, so it would have kept skipping the job regardless of the JS regex fix. The redflag decision is now made exclusively in `auto-merge-eval.mjs` (matching the file's own documented "single source of truth" design), which checks out `main`'s corrected `constants.mjs` on every run.
  - `.github/workflows/pr-redflag-fixer.yml`: tightened the bash preflight regex (`grep -qP`) to the same shape.
  - `.github/workflows/stale-pr-rescuer.yml`: tightened Class B's bare `grep -q "🔴"` to the same shape — it was independently vulnerable to the identical false positive (confirmed it would have misfired on PR #3330 once its stall age-gate elapsed).
- `tests/redflag-important-marker.test.ts`: added a regression case for the exact PR #3330 false-positive text (must be `false`), adjusted one synthetic fixture that had no realistic delimiter to include one, kept all other existing cases (including the PR #2211 bold/em-dash form) passing unchanged.

## Non implementato (ancora)

Nessuno.

---

Local run: `npx vitest run tests/redflag-important-marker.test.ts tests/auto-merge-sweep.test.ts tests/auto-merge-eval-fingerprint.test.ts tests/auto-merge-collision-gate.test.ts tests/auto-merge-drift-fallback.test.ts` → 41/41 passed.

Once this merges to `main`, PR #3330 (blocked by this exact bug) should be re-evaluated — `actions/checkout@v5` in `auto-merge-on-lgtm.yml` has no `ref:`, so it always runs against `main`'s current `scripts/ci/*`, meaning the fix applies to #3330 without touching its branch.