### PR TITLE
fix(test): allow empty canton in events dataset integrity gate

### DIFF
--- a/tests/events-pipeline.test.ts
+++ b/tests/events-pipeline.test.ts
@@ -456,7 +456,10 @@ describe('assembled dataset integrity (data/events.json)', () => {
       // Nationwide sources (guidle, myswitzerland — #3125) resolve events to
       // any of the 26 cantons, not just TI; assert membership in the same
       // canton list the job board uses instead of the pre-#3125 TI-only check.
-      expect(CANTON_CODES).toContain(e.canton);
+      // '' is also valid: myswitzerland.com leaves canton blank when
+      // resolveComuneNationwide finds no confident comune match (event shown
+      // on the canton hub only — crawl-myswitzerland-events.mjs:370/413/505).
+      expect(e.canton === '' || CANTON_CODES.includes(e.canton)).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Implementato
- `tests/events-pipeline.test.ts`: the "assembled dataset integrity" gate now accepts `canton === ''` in addition to `CANTON_CODES` membership. myswitzerland.com's crawler deliberately leaves `canton: ''` when `resolveComuneNationwide` can't confidently match a comune (event still committed, shown on the canton hub only — see `crawl-myswitzerland-events.mjs:370,413,505`). PR #3339's fix asserted strict `CANTON_CODES` membership, which broke on this legitimate case on the first live run after merge (workflow_dispatch run [28653378040](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28653378040) — `AssertionError: expected [...] to include ''`).
- Verified locally: `npx vitest run tests/events-pipeline.test.ts tests/events-nationwide-sources.test.ts tests/blog-body-typescript-syntax.test.ts` → 60/60 passed.

## Non implementato (ancora)
Nessuno.