### PR TITLE
fix(redazione): sentence-case shouting title + reassign article author

### DIFF
--- a/data/blog-articles-data.ts
+++ b/data/blog-articles-data.ts
@@ -24746,8 +24746,8 @@ const RAW_ARTICLES = [
  date: '2026-07-03T07:41:06.369Z',
  image: '/images/blog/acqua-non-potabile-lavizzara.webp',
  hasCalculator: false,
- authorSlug: 'marco-ferrari',
- authorName: 'Marco Ferrari',
+ authorSlug: 'samuele-valente',
+ authorName: 'Samuele Valente',
  },
 ] satisfies Article[];
 

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -5313,6 +5313,15 @@ function validate(data, opts = {}) {
       fr: `Image éditoriale relative à: ${itTitle}`,
     };
   }
+  // Guard against a shouting imageAlt slipping through when the LLM returns
+  // it directly (imageAlt is a required schema field, so the fallback above
+  // doesn't always run) — same casing failure mode as the title, so reuse
+  // the same locale-agnostic collapse guard instead of trusting raw output.
+  for (const locale of ['it', 'en', 'de', 'fr']) {
+    if (typeof data.imageAlt[locale] === 'string') {
+      data.imageAlt[locale] = collapseShoutingTitle(data.imageAlt[locale]);
+    }
+  }
   // Sanitize id
   data.id = data.id.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
 

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2034,6 +2034,19 @@ const TITLE_CASING_PROPER_NOUNS = new Set([
   'austria', 'liechtenstein',
 ]);
 
+// Real institutional/legal acronyms from VERIFIED_DOMAIN_FACTS (istituzioni,
+// aliquote) that must stay uppercase when a fully-uppercase ("shouting")
+// title is sentence-cased below. Deliberately excludes short tokens that
+// double as common Italian words (e.g. "ai", "usi") to avoid leaving those
+// wrongly capitalized. Non-exhaustive — extend as new ones are hit.
+const TITLE_CASING_KNOWN_ACRONYMS = new Set([
+  'avs', 'ipg', 'ac', 'lainf', 'laa', 'igm', 'ijm', 'lpp', 'irpef', 'inps',
+  'mef', 'inail', 'seco', 'sem', 'suva', 'ustat', 'ufsp', 'bag', 'supsi',
+  'eoc', 'dfe', 'dss', 'are', 'bfs', 'bps', 'ufas', 'ufg', 'udsc', 'fedpol',
+  'lamal', 'iva', 'chf', 'cu', 'ral', 'ssn', 'sepa', 'ccnl', 'cmu', 'naspi',
+  'covid', 'cdi', 'ats',
+]);
+
 /**
  * Normalize a journalist-typed title from Title Case to sentence case: only
  * the first letter of the title is capitalized, every other word is
@@ -2042,21 +2055,76 @@ const TITLE_CASING_PROPER_NOUNS = new Set([
  * canton/city/country proper noun (TITLE_CASING_PROPER_NOUNS), either of
  * which is preserved as-is. No-op if the title doesn't look Title-Cased to
  * begin with (issue #3174 follow-up — "redazione" title casing).
+ *
+ * When EVERY word is uppercase ("shouting", e.g. a full LLM title dropped in
+ * all caps rather than journalist Title-Case — live incident: "LA SOSPENSIONE
+ * DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA..."), the plain
+ * per-word acronym check below is a no-op (every word trivially equals its
+ * own uppercase form), so that mode uses TITLE_CASING_KNOWN_ACRONYMS instead
+ * of the generic check, and splits on hyphens so compound proper nouns like
+ * "ITALIA-SVIZZERA" are still recognised per-side.
  */
 function normalizeTitleCasing(rawTitle) {
   const s = String(rawTitle || '').replace(/\s+/g, ' ').trim();
   if (!s) return s;
   const words = s.split(' ');
+  const letterWords = words.filter((w) => /[A-Za-zÀ-ÿ]/.test(w));
+  const isShouting = letterWords.length > 0 && letterWords.every((w) => w === w.toUpperCase());
   const looksTitleCase = words.filter((w) => /^[A-ZÀ-Ý]/.test(w)).length >= Math.ceil(words.length * 0.6);
-  if (!looksTitleCase) return s;
+  if (!looksTitleCase && !isShouting) return s;
+
+  let isFirstWord = true;
+  const normalizeToken = (token) => {
+    const bareLetters = token.replace(/[^A-Za-zÀ-ÿ]/g, '');
+    if (!bareLetters) return token;
+    const bareLower = bareLetters.toLowerCase();
+    const isAcronym = isShouting
+      ? TITLE_CASING_KNOWN_ACRONYMS.has(bareLower)
+      : token.length > 1 && token === token.toUpperCase() && token !== token.toLowerCase();
+    let result;
+    if (isAcronym) {
+      result = token;
+    } else if (TITLE_CASING_PROPER_NOUNS.has(bareLower)) {
+      result = token.replace(bareLetters, bareLetters.charAt(0).toUpperCase() + bareLetters.slice(1).toLowerCase());
+    } else {
+      const lower = token.toLowerCase();
+      result = isFirstWord ? lower.charAt(0).toUpperCase() + lower.slice(1) : lower;
+    }
+    isFirstWord = false;
+    return result;
+  };
+
   return words
-    .map((w, idx) => {
-      const isAcronym = w.length > 1 && w === w.toUpperCase() && w !== w.toLowerCase();
-      if (isAcronym) return w;
-      const bareLower = w.replace(/^[^A-Za-zÀ-ÿ]+|[^A-Za-zÀ-ÿ]+$/g, '').toLowerCase();
-      if (TITLE_CASING_PROPER_NOUNS.has(bareLower)) return w;
+    .map((w) => (isShouting && w.includes('-') ? w.split('-').map(normalizeToken).join('-') : normalizeToken(w)))
+    .join(' ');
+}
+
+/**
+ * Locale-agnostic guard against a translated title coming back fully
+ * uppercase. Deliberately NOT the full normalizeTitleCasing algorithm above —
+ * that enforces Italian sentence-case grammar (lowering "Il"/"Della" etc.),
+ * which is wrong for EN (Title Case), DE (every noun capitalized), and FR
+ * conventions. This only fires on the pathological ALL-CAPS case and applies
+ * a minimal, safe fallback (capitalize first letter, lowercase the rest,
+ * preserve known acronyms) — not a per-locale-correct title case.
+ */
+function collapseShoutingTitle(rawTitle) {
+  const s = String(rawTitle || '').replace(/\s+/g, ' ').trim();
+  if (!s) return s;
+  const words = s.split(' ');
+  const letterWords = words.filter((w) => /[A-Za-zÀ-ÿ]/.test(w));
+  const isShouting = letterWords.length > 0 && letterWords.every((w) => w === w.toUpperCase());
+  if (!isShouting) return s;
+  let isFirstWord = true;
+  return words
+    .map((w) => {
+      const bareLetters = w.replace(/[^A-Za-zÀ-ÿ]/g, '');
+      if (!bareLetters) return w;
+      if (TITLE_CASING_KNOWN_ACRONYMS.has(bareLetters.toLowerCase())) return w;
       const lower = w.toLowerCase();
-      return idx === 0 ? lower.charAt(0).toUpperCase() + lower.slice(1) : lower;
+      const result = isFirstWord ? lower.charAt(0).toUpperCase() + lower.slice(1) : lower;
+      isFirstWord = false;
+      return result;
     })
     .join(' ');
 }
@@ -4429,6 +4497,16 @@ Rispondi SOLO con JSON valido, senza markdown.` },
       console.warn(`  ✂️ [title-cap] IT title truncato: ${finalCap.originalLength} → ${finalCap.value.length} chars`);
     }
     itContent.title = finalCap.value;
+    // capBlogTitle only trims length/brand-suffix — it doesn't fix casing, so
+    // an LLM that emits a fully-uppercase title (live incident, issue-driven
+    // fix) slips through untouched. normalizeTitleCasing already existed for
+    // the journalist-publish pipeline (publish-journalist-article.mjs) but was
+    // never wired into this AI-generation path — closing that gap here.
+    const casedTitle = normalizeTitleCasing(itContent.title);
+    if (casedTitle !== itContent.title) {
+      console.warn(`  🔡 [title-case] IT title normalizzato: "${itContent.title}" → "${casedTitle}"`);
+      itContent.title = casedTitle;
+    }
   }
 
   // Preserve FAQ from AI response (not in REQUIRED_IT_BODY_FIELDS, extracted separately)
@@ -4975,6 +5053,11 @@ ${terminologyByLang[targetLang] || ''}`;
       console.warn(`  ✂️ [title-cap] ${locale.toUpperCase()} title truncato: ${finalCap.originalLength} → ${finalCap.value.length} chars`);
     }
     localeContent.title = finalCap.value;
+    const uncappedTitle = collapseShoutingTitle(localeContent.title);
+    if (uncappedTitle !== localeContent.title) {
+      console.warn(`  🔡 [title-case] ${locale.toUpperCase()} title normalizzato: "${localeContent.title}" → "${uncappedTitle}"`);
+      localeContent.title = uncappedTitle;
+    }
   }
 
   console.error(`  ✅ Articolo assemblato — ${Object.keys(data.content).length} lingue`);
@@ -9104,7 +9187,7 @@ export { translateArticle, enforceStrongInternalLinks, findBestFallbackImage, pi
 // Redazione redesign (issue #3174 follow-up): the journalist now authors only
 // {title, body}; these derive the title-casing/excerpt/body1-3/cover-image
 // candidates the shared pipeline above still expects.
-export { normalizeTitleCasing, generateExcerpt, splitBodyIntoSections, findStockImageCandidates };
+export { normalizeTitleCasing, collapseShoutingTitle, generateExcerpt, splitBodyIntoSections, findStockImageCandidates };
 
 // Only run the AI generation pipeline when invoked directly as a CLI — importing
 // this module (to reuse registerArticleFiles/buildBodyFile) must NOT execute it.

--- a/scripts/publish-journalist-article.mjs
+++ b/scripts/publish-journalist-article.mjs
@@ -46,6 +46,7 @@ import {
   validateAndEnforceCTA,
   optimizeSeoMetadata,
   normalizeTitleCasing,
+  collapseShoutingTitle,
   splitBodyIntoSections,
   generateExcerpt,
   checkTranslatedSlugCollisions,
@@ -119,7 +120,7 @@ function buildPipelineData(docId, doc) {
     // auto-generation uses (it never translates alt text either — see its
     // `data.imageAlt = { it/en/de/fr: ... itTitle ... }` fallback block).
     imageAlt: {
-      it: doc.imageAlt || `Immagine editoriale relativa a: ${title}`,
+      it: doc.imageAlt ? collapseShoutingTitle(doc.imageAlt) : `Immagine editoriale relativa a: ${title}`,
       en: `Editorial image related to: ${title}`,
       de: `Redaktionelles Bild zu: ${title}`,
       fr: `Image éditoriale relative à: ${title}`,

--- a/services/locales/blog-meta-de.ts
+++ b/services/locales/blog-meta-de.ts
@@ -8234,7 +8234,7 @@ const blogMetaDe: Record<string, string> = {
     'blog.article.deduzione-figli-frontalieri-2026.imageAlt': 'Luftaufnahme der Lugano Seeuferpromenade mit Steuerdokumenten auf einem Tisch im Vordergrund',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.title': 'Rückerstopp: Konvention Italien-Schweiz & \'Gesundheitssteuer\'',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.excerpt': 'Wir analysieren die Aussetzung der Rückvergütungen Italien-Schweiz im Lichte des Steuerabkommens und der "Gesundheitssteuer" und bewerten die rechtlichen Auswirkungen und',
-    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Redaktionelles Bild zu: LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA “TASSA SULLA SALUTE”',
+    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Redaktionelles Bild zu: La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della “tassa sulla salute”',
 };
 
 export default blogMetaDe;

--- a/services/locales/blog-meta-en.ts
+++ b/services/locales/blog-meta-en.ts
@@ -8235,7 +8235,7 @@ const blogMetaEn: Record<string, string> = {
     'blog.article.deduzione-figli-frontalieri-2026.imageAlt': 'Aerial view of Lugano lakefront with tax documents on a desk in the foreground',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.title': 'Italy-Switzerland Rebates: The \'Health Tax\' Case',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.excerpt': 'Let\'s analyze the suspension of the Italy-Switzerland rebates in the light of the Tax Convention and the "health tax", evaluating legal and',
-    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Editorial image related to: LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA “TASSA SULLA SALUTE”',
+    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Editorial image related to: La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della “tassa sulla salute”',
 };
 
 export default blogMetaEn;

--- a/services/locales/blog-meta-fr.ts
+++ b/services/locales/blog-meta-fr.ts
@@ -8236,7 +8236,7 @@ const blogMetaFr: Record<string, string> = {
     'blog.article.deduzione-figli-frontalieri-2026.imageAlt': 'Vue aérienne du front de lac de Lugano avec des documents fiscaux sur un bureau au premier plan',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.title': 'Ristournes suspendues: la convention et la «taxe santé»',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.excerpt': 'Analysons la suspension des restaurants Italie-Suisse à la lumière de la Convention fiscale et de la « taxe sur la santé », en évaluant les implications juridiques et',
-    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Image éditoriale relative à: LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA “TASSA SULLA SALUTE”',
+    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Image éditoriale relative à: La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della “tassa sulla salute”',
 };
 
 export default blogMetaFr;

--- a/services/locales/blog-meta-it.ts
+++ b/services/locales/blog-meta-it.ts
@@ -8234,9 +8234,9 @@ const blogMetaIt: Record<string, string> = {
     'blog.article.deduzione-figli-frontalieri-2026.title': 'Frontalieri: possibile rimozione deduzione fiscale per figli',
     'blog.article.deduzione-figli-frontalieri-2026.excerpt': 'Un\'iniziativa propone di eliminare la deduzione fiscale per i figli dei lavoratori frontalieri con figli all\'estero.',
     'blog.article.deduzione-figli-frontalieri-2026.imageAlt': 'Vista aerea del lungolago di Lugano con documenti fiscali in primo piano',
-    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.title': 'LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA “TASSA SULLA SALUTE”',
+    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.title': 'La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della “tassa sulla salute”',
     'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.excerpt': 'Analizziamo la sospensione dei ristorni Italia-Svizzera alla luce della Convenzione fiscale e della "tassa sulla salute", valutando implicazioni giuridiche e',
-    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Immagine editoriale relativa a: LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA “TASSA SULLA SALUTE”',
+    'blog.article.la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso.imageAlt': 'Immagine editoriale relativa a: La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della “tassa sulla salute”',
 };
 
 export default blogMetaIt;

--- a/tests/blog-title-casing.test.ts
+++ b/tests/blog-title-casing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTitleCasing, collapseShoutingTitle } from '../scripts/create-article.mjs';
+
+// Live incident: an article was published with a fully-uppercase IT title
+// ("LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA:
+// IL CASO DELLA \"TASSA SULLA SALUTE\"") because normalizeTitleCasing was only
+// wired into the journalist-publish pipeline, never into create-article.mjs's
+// own AI-generation path — and even wired in, its old per-word acronym check
+// was a no-op on fully-uppercase input (every word trivially equals its own
+// uppercase form). Both gaps are fixed; this locks in the fix.
+describe('normalizeTitleCasing — shouting (fully-uppercase) titles', () => {
+  it('sentence-cases the reported live-incident title, preserving the compound proper noun', () => {
+    const shouting = 'LA SOSPENSIONE DEI RISTORNI ALLA PROVA DELLA CONVENZIONE ITALIA-SVIZZERA: IL CASO DELLA "TASSA SULLA SALUTE"';
+    expect(normalizeTitleCasing(shouting)).toBe(
+      'La sospensione dei ristorni alla prova della convenzione Italia-Svizzera: il caso della "tassa sulla salute"',
+    );
+  });
+
+  it('preserves known institutional acronyms and CHF in a shouting title', () => {
+    expect(normalizeTitleCasing('NUOVO ACCORDO CON LA SVIZZERA E CHF 500')).toBe(
+      'Nuovo accordo con la Svizzera e CHF 500',
+    );
+  });
+
+  it('does not mistake short Italian function words for acronyms', () => {
+    expect(normalizeTitleCasing('LA SOSPENSIONE DEI RISTORNI')).toBe('La sospensione dei ristorni');
+  });
+
+  it('leaves an already sentence-cased title untouched (no-op)', () => {
+    expect(normalizeTitleCasing('AVS e LPP: cosa cambia nel 2026')).toBe('AVS e LPP: cosa cambia nel 2026');
+  });
+
+  it('still sentence-cases journalist Title Case input while preserving an inline acronym', () => {
+    expect(normalizeTitleCasing('Nuove Regole AVS Per Il Ticino')).toBe('Nuove regole AVS per il Ticino');
+  });
+
+  it('still preserves canton/city/country proper nouns in Title Case input (issue #3174)', () => {
+    expect(normalizeTitleCasing('Nuove Regole Per Il Ticino')).toBe('Nuove regole per il Ticino');
+  });
+});
+
+describe('collapseShoutingTitle — locale-agnostic ALL-CAPS guard (EN/DE/FR)', () => {
+  it('fixes a shouting translated title without imposing Italian sentence-case grammar', () => {
+    expect(collapseShoutingTitle('THE SUSPENSION OF TAX REFUNDS UNDER THE ITALY-SWITZERLAND TREATY')).toBe(
+      'The suspension of tax refunds under the italy-switzerland treaty',
+    );
+  });
+
+  it('preserves known acronyms in a shouting translated title', () => {
+    expect(collapseShoutingTitle('NEW AVS AND CHF 500 RULES')).toBe('New AVS and CHF 500 rules');
+  });
+
+  it('is a no-op on normally-cased titles', () => {
+    expect(collapseShoutingTitle('The New Cross-Border Rules')).toBe('The New Cross-Border Rules');
+  });
+});

--- a/tests/blog-title-casing.test.ts
+++ b/tests/blog-title-casing.test.ts
@@ -54,3 +54,23 @@ describe('collapseShoutingTitle — locale-agnostic ALL-CAPS guard (EN/DE/FR)', 
     expect(collapseShoutingTitle('The New Cross-Border Rules')).toBe('The New Cross-Border Rules');
   });
 });
+
+// Reviewer nit (PR #3350): imageAlt is a required LLM schema field, so the
+// title-casing fix only reached it via the fallback template branch
+// (`!data.imageAlt`, built from the already-corrected title). When the LLM
+// returns imageAlt directly it bypassed normalization entirely — if the
+// model echoes the same shouting style across the whole field (the observed
+// failure mode for this bug class), the fix now runs collapseShoutingTitle
+// unconditionally on every data.imageAlt[locale] string before it's saved.
+describe('collapseShoutingTitle — applied unconditionally to imageAlt (create-article.mjs validate())', () => {
+  it('fixes a fully-shouting imageAlt returned directly by the LLM', () => {
+    expect(collapseShoutingTitle('IMMAGINE EDITORIALE RELATIVA ALLA SOSPENSIONE DEI RISTORNI')).toBe(
+      'Immagine editoriale relativa alla sospensione dei ristorni',
+    );
+  });
+
+  it('is a no-op on the mixed-case fallback template (already-normalized title embedded)', () => {
+    const fallback = 'Immagine editoriale relativa a: La sospensione dei ristorni alla prova della convenzione Italia-Svizzera';
+    expect(collapseShoutingTitle(fallback)).toBe(fallback);
+  });
+});


### PR DESCRIPTION
## Implementato

- Fix del titolo IT pubblicato in full-caps per l'articolo `la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso` (era `LA SOSPENSIONE DEI RISTORNI...` → ora `La sospensione dei ristorni...`), più i campi `imageAlt` derivati in tutti e 4 i locale (it/en/de/fr) che embeddavano il titolo IT sorgente in maiuscolo.
- Root-cause fix in `scripts/create-article.mjs`: `normalizeTitleCasing()` esisteva già (issue #3174) ma era wired solo nella pipeline giornalista (`publish-journalist-article.mjs`), mai nella pipeline di generazione AI propria di `create-article.mjs` — ora chiamata dopo `capBlogTitle` sul titolo IT finale.
- Bug aggiuntivo nello stesso `normalizeTitleCasing()`: il check acronimo per-parola era un no-op su input interamente maiuscolo (ogni parola combacia trivialmente con la propria versione uppercase) — aggiunta modalità "shouting" con allowlist di acronimi istituzionali reali (da `VERIFIED_DOMAIN_FACTS`) e split su trattino per riconoscere nomi propri composti (es. `ITALIA-SVIZZERA` → `Italia-Svizzera`).
- Sibling fix per EN/DE/FR: nuovo `collapseShoutingTitle()` locale-agnostico (guard minimale contro titoli ALL-CAPS nella traduzione, senza imporre la grammatica sentence-case italiana che sarebbe sbagliata per EN Title Case / DE noun-capitalization) wired nel blocco di finalizzazione titolo multi-locale.
- Fix review nit: `data.imageAlt[locale]` (campo `required` nello schema LLM, quindi non sempre passa dal ramo fallback che deriva dal titolo già corretto) ora passa incondizionatamente per `collapseShoutingTitle()` su tutti e 4 i locale in `validate()` — copre anche il caso in cui l'LLM restituisce direttamente un `imageAlt` interamente in maiuscolo, senza toccare il testo AI-authored normale (guard no-op su stringhe non interamente shouting). Due nuovi test in `tests/blog-title-casing.test.ts`.
- Riassegnato l'autore dell'articolo da `marco-ferrari` a `samuele-valente` in `data/blog-articles-data.ts` (richiesta esplicita).
- Nuovo test `tests/blog-title-casing.test.ts` (11 test) copre: il titolo esatto dell'incidente live, preservazione acronimi/nomi propri composti, no-op su titoli già corretti, il guard EN/DE/FR, e il guard `imageAlt` incondizionato.

Nota autorship (risposta alla ❓ review): l'articolo riassegnato è lo STESSO articolo del fix titolo sopra — `la-sospensione-dei-ristorni-alla-prova-della-convenzione-italia-svizzera-il-caso`, confermato via `git show <sha> -U15 -- data/blog-articles-data.ts` (stesso `id`, stessa `date`/`image`). Non esiste un secondo articolo `acqua-non-potabile-lavizzara` distinto: quel filename è solo il valore (invariato) del campo `image` di questo stesso articolo, coincidenza di naming, non un id separato. La riassegnazione `marco-ferrari` → `samuele-valente` è intenzionale e mirata a questo articolo, per richiesta esplicita dell'utente.

## Non implementato (ancora)

Nessuno. Profilo autore self-editabile (`/redazione/`) + dashboard superadmin (vedi tutti gli articoli della redazione + riassegna autore) consegnati in PR concatenata #3356 (branch `feat/redazione-admin-panel`).
