### PR TITLE
fix(border-data): remove dead 01.2S.gif webcam feed

### DIFF
--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -77,15 +77,6 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'high',
  peak: '7:00-8:30, 17:00-18:30',
  tips: 'border.tips.chiassoCentro',
- webcams: [
- {
- label: 'A2 – Chiasso via Como (direzione sud)',
- imageUrl: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/01.2S.gif',
- sourceName: TI_POLCA_SOURCE_NAME,
- sourceUrl: TI_POLCA_SOURCE_URL,
- refreshIntervalMs: 60000,
- },
- ],
  },
  {
  name: 'Chiasso-Brogeda',
@@ -137,15 +128,6 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'medium',
  peak: '7:00-8:30, 17:00-18:30',
  tips: 'border.tips.chiassoStrada',
- webcams: [
- {
- label: 'A2 – Chiasso via Como (direzione sud)',
- imageUrl: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/01.2S.gif',
- sourceName: TI_POLCA_SOURCE_NAME,
- sourceUrl: TI_POLCA_SOURCE_URL,
- refreshIntervalMs: 60000,
- },
- ],
  },
  {
  name: 'Maslianico-Pizzamiglio',


### PR DESCRIPTION
## Implementato

- Removed the `webcams` entry pointing at `https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/01.2S.gif` from both `Chiasso Centro (Ponte Chiasso)` and `Chiasso-Strada` in `data/borderCrossings.ts` — the URL returns a consistent, genuine 404 (real HTML 404 body, verified 3x via curl from a residential-class IP, not a `401/403/429/451` cloud-IP-block artifact per the existing `evaluateWebcamResult` indeterminate-handling logic). Still listed in ti.ch's own catalog page, so this is external content drift on their end (or a dead physical camera), not a stale reference on our side — no working replacement filename was found to substitute.
- Wait-time data for both affected crossings is untouched; only the broken image widget is removed. `webcams` is a documented-optional field (`webcams?: WebcamRef[]`) and 9 of 11 crossings still have live webcams (well above the `>=3` floor asserted by `tests/border-wait-webcam.test.ts`).
- This mirrors the exact precedent already established for issue #3274 (removal of 3 dead `00.3{N,S,O}.gif` feeds from the same file).
- Verified locally: `npx vitest run tests/border-wait-webcam.test.ts tests/check-border-data-health.test.ts` → 40/40 passing.

Closes #3338

## Non implementato (ancora)

Nessuno.