### PR TITLE
fix(seo): junk-term "owner" — stop thin /search-owner-{city}/ pages

### DIFF
--- a/services/relatedSearchJunkTerms.mjs
+++ b/services/relatedSearchJunkTerms.mjs
@@ -70,6 +70,12 @@ export const RELATED_SEARCH_JUNK_TERMS = new Set([
   'ensure', 'ensuring', 'providing', 'including',
   'environment', 'development', 'management', 'quality',
   'projects', 'tasks', 'employees', 'staff', 'requirements',
+  // 'owner' — generic possessive noun harvested from job body text
+  // ("business owner", "process owner"), never itself a searchable role.
+  // Combined with a leaked cross-canton location it produced
+  // /search-owner-zurich/ (0 live matches once source job rotated out —
+  // thin/empty page, 100% bounce all 4 locales, GA4-flagged 2026-07-03).
+  'owner', 'owners',
   // ── Scraped web/UI noise ──
   'cookie', 'cookies', 'javascript', 'browser', 'newsletter', 'website',
 ]);


### PR DESCRIPTION
## Implementato
- Added "owner"/"owners" to `RELATED_SEARCH_JUNK_TERMS` in `services/relatedSearchJunkTerms.mjs` (single shared source, imported by `services/relatedSearchClusters.ts`, `build-plugins/relatedSearchClustersPlugin.ts`, `scripts/audit-related-search-candidates.mjs`).
- Root cause: `buildRelatedSearches()` harvests generic body-text tokens from job description text as "related search" chip candidates. A job mentioning "business owner"/"process owner" combined with the job's location (e.g. Zurich) produced a `/search-owner-zurich/` chip, indexed by Google across all 4 locale prefixes. Once the source job rotated out of the dataset, the free-text query matched 0 live jobs — thin/empty result page, GA4-confirmed 100% bounce rate.
- Same remediation pattern already established for "cookie"/"sowie" (see file header comment) — this is generation-time filtering at the single shared source, so it closes the class for the client-rendered widget AND the static cluster-emission plugin (which re-filters against this same list at emit time even for already-committed candidate data, per its own header comment) without needing a data-file migration.
- Verified `data/related-search-candidates.json`/`data/related-search-enriched.json` are audit/raw-candidate artifacts (not directly emitted to dist without passing through the plugin's junk-term re-filter) — no stale-data prune needed in this PR.
- Tests: `npx vitest run tests/related-search-clusters.test.ts tests/related-search-clusters-or-fill-floor.test.ts tests/related-search-clusters-shell.test.ts` → 100/100 passed.

## Non implementato (ancora)
Nessuno.