### PR TITLE
fix(analytics): SilentErrorBoundary reports full URL instead of page path

### DIFF
--- a/components/shared/ErrorBoundary.tsx
+++ b/components/shared/ErrorBoundary.tsx
@@ -301,7 +301,7 @@ export class SilentErrorBoundary extends Component<SilentBoundaryProps, SilentBo
  message: `[SilentBoundary:${props.boundary}] ${error.name}: ${decoded.slice(0, 160)}`,
  stack: error.stack?.slice(0, 500) || '',
  componentStack: stack,
- pagePath: typeof window !== 'undefined' ? window.location.href : '',
+ pagePath: typeof window !== 'undefined' ? window.location.pathname + window.location.search : '',
  pageTitle: typeof document !== 'undefined' ? document.title : '',
  fatal: false,
  });


### PR DESCRIPTION
## Implementato
- `components/shared/ErrorBoundary.tsx:304` — `SilentErrorBoundary.componentDidCatch` now sends `window.location.pathname + window.location.search` as `pagePath`, matching the pattern already used at line 241 (the main `ErrorBoundary`) and every other call site in the file.
- Root cause: this one call site sent the full `window.location.href` (protocol+origin+path), polluting GA4 `topErrorPages` / `app_error.page_path` attribution with malformed entries like `/https://frontaliereticino.ch/...` instead of the actual route.
- Verified via sibling-pattern sweep (`node scripts/ci/check-sibling-patterns.mjs` + manual grep for `pagePath.*window.location.href` / `page_path.*window.location.href`) — no other instance of this construct exists in the codebase; this was the only offender.
- Ran full relevant local test suite (`shared-components-smoke`, `ChunkLoadErrorBoundary`, `resilient-import`, `dom-reconciliation-guard`) — 61/61 passed, no regression.

## Non implementato (ancora)
Nessuno.