### PR TITLE
feat(redazione): admin-only editorial panel for profile edits + dual-catalog article view

### DIFF
--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -9,6 +9,7 @@ import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
 import { useNavigation } from '@/services/NavigationContext';
 import { cdnDataUrl } from '@/services/cdnDataBase';
+import { getArticleAuthorOverride, type ArticleAuthorOverride } from '@/services/authorProfileService';
 import { CDN_BLOG_BASE } from '@/services/seo/blogImageCdn';
 
 // Pre-compiled gi-flag variants for keyword matching (Vercel rule 7.10)
@@ -1188,6 +1189,15 @@ function BlogArticles({
  trackArticleView(selectedArticle);
  }, [selectedArticle, section]);
 
+ // Admin-set byline reassignment (see AdminPanel "Redazione" section), CSR-only.
+ const [articleAuthorOverride, setArticleAuthorOverride] = useState<ArticleAuthorOverride | null>(null);
+ useEffect(() => {
+ if (!selectedArticle) { setArticleAuthorOverride(null); return; }
+ let cancelled = false;
+ getArticleAuthorOverride(selectedArticle).then((o) => { if (!cancelled) setArticleAuthorOverride(o ?? null); }).catch(() => {});
+ return () => { cancelled = true; };
+ }, [selectedArticle]);
+
  // Fetch job listings for cross-linking (related jobs in article view)
  const [crossLinkJobs, setCrossLinkJobs] = useState<JobPreview[]>([]);
  useEffect(() => {
@@ -1747,6 +1757,8 @@ function BlogArticles({
  if (selectedArticle) {
  const article = selectedArticleObj;
  if (!article) return null;
+ const effectiveAuthorSlug = articleAuthorOverride?.authorSlug ?? article.authorSlug;
+ const effectiveAuthorName = articleAuthorOverride?.authorName ?? article.authorName;
 
  // Wait for article body translations to load
  if (!bodyReady) {
@@ -1952,14 +1964,14 @@ function BlogArticles({
 
  {/* Meta bar */}
  <div className="flex flex-wrap items-center gap-3 px-4 sm:px-6 py-3 bg-surface-alt/50 border-b border-edge text-sm text-subtle">
- {article.authorSlug && article.authorName ? (
+ {effectiveAuthorSlug && effectiveAuthorName ? (
  <a
- href={`/autori/${article.authorSlug}/`}
+ href={`/autori/${effectiveAuthorSlug}/`}
  rel="author"
  className="flex items-center gap-1 font-medium text-accent hover:underline"
  >
  <PenLine size={14} />
- {t('blog.bylinePrefix')} {article.authorName}
+ {t('blog.bylinePrefix')} {effectiveAuthorName}
  </a>
  ) : (
  <span className="flex items-center gap-1 font-medium text-accent">
@@ -2349,7 +2361,7 @@ function BlogArticles({
  articleFeedback[article.id] === 'not-useful'
  ? 'bg-danger-subtle text-danger ring-1 ring-danger-border'
  : 'bg-surface-raised text-subtle hover:bg-danger-subtle'
- }`} aria-label={t('blog.feedback.notUseful')} > <ThumbsDown size={16} /> {t('blog.feedback.notUseful')} </button> </div> {articleFeedback[article.id] && ( <p className="text-sm text-muted mt-1">{t('blog.feedback.thanks')}</p> )} </div> {/* Author bio for E-E-A-T (A2: dynamic byline → /autori/{slug}/) */} <div className="mt-8 p-4 bg-surface-alt rounded-xl border border-edge"> <div className="flex items-center gap-3"> <div className="w-12 h-12 rounded-full bg-accent-subtle flex items-center justify-center"> <User size={24} className="text-link" /> </div> <div> {article.authorSlug && article.authorName ? ( <a href={`/autori/${article.authorSlug}/`} rel="author" className="font-bold text-heading hover:text-link hover:underline"> {article.authorName} </a> ) : ( <p className="font-bold text-heading">{t('blog.byline')}</p> )} <p className="text-sm text-subtle">{t('blog.authorBio')}</p> </div> </div> </div> {/* Discuss in forum CTA */} <div className="mt-6 p-4 bg-accent-subtle rounded-xl border border-accent-border/40 flex items-center gap-3"> <MessageSquareMore size={20} className="text-accent shrink-0" /> <div className="flex-1"> <p className="text-sm font-semibold text-accent">{t('blog.discussInForum')}</p> <p className="text-sm text-accent mt-0.5">{t('blog.discussInForumDesc')}</p> </div> <a href={buildPath({ activeTab: 'forum' })} onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('forum'); }} className="shrink-0 px-4 py-2 min-h-[44px] inline-flex items-center bg-accent hover:bg-accent-hover text-on-accent text-sm font-medium rounded-lg transition-colors" > {t('blog.goToForum')} → </a> </div> {/* Prev/Next article navigation */} {(() => { const currentIdx = articles.findIndex(a => a.id === article.id); const prevArticle = currentIdx < articles.length - 1 ? articles[currentIdx + 1] : null; const nextArticle = currentIdx > 0 ? articles[currentIdx - 1] : null; if (!prevArticle && !nextArticle) return null; return ( <div className="border-t border-edge pt-6 mt-8 grid grid-cols-1 sm:grid-cols-2 gap-3"> {prevArticle ? ( <a href={buildPath(buildArticleRoute(prevArticle.id))} onClick={(e) => { e.preventDefault(); handleArticleClick(prevArticle.id); }} className="flex items-center gap-3 p-4 bg-surface-alt/50 rounded-xl hover:bg-surface-raised/50 transition-colors group" > <ChevronLeft size={20} className="text-subtle group-hover:text-accent shrink-0 transition-colors" /> <div className="min-w-0"> <p className="text-sm text-muted mb-1">{t('blog.prevArticle')}</p> <p className="text-sm font-semibold text-body line-clamp-2">{t(`blog.article.${prevArticle.id}.title`)}</p>
+ }`} aria-label={t('blog.feedback.notUseful')} > <ThumbsDown size={16} /> {t('blog.feedback.notUseful')} </button> </div> {articleFeedback[article.id] && ( <p className="text-sm text-muted mt-1">{t('blog.feedback.thanks')}</p> )} </div> {/* Author bio for E-E-A-T (A2: dynamic byline → /autori/{slug}/) */} <div className="mt-8 p-4 bg-surface-alt rounded-xl border border-edge"> <div className="flex items-center gap-3"> <div className="w-12 h-12 rounded-full bg-accent-subtle flex items-center justify-center"> <User size={24} className="text-link" /> </div> <div> {effectiveAuthorSlug && effectiveAuthorName ? ( <a href={`/autori/${effectiveAuthorSlug}/`} rel="author" className="font-bold text-heading hover:text-link hover:underline"> {effectiveAuthorName} </a> ) : ( <p className="font-bold text-heading">{t('blog.byline')}</p> )} <p className="text-sm text-subtle">{t('blog.authorBio')}</p> </div> </div> </div> {/* Discuss in forum CTA */} <div className="mt-6 p-4 bg-accent-subtle rounded-xl border border-accent-border/40 flex items-center gap-3"> <MessageSquareMore size={20} className="text-accent shrink-0" /> <div className="flex-1"> <p className="text-sm font-semibold text-accent">{t('blog.discussInForum')}</p> <p className="text-sm text-accent mt-0.5">{t('blog.discussInForumDesc')}</p> </div> <a href={buildPath({ activeTab: 'forum' })} onClick={(e) => { if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return; e.preventDefault(); nav.navigateTo('forum'); }} className="shrink-0 px-4 py-2 min-h-[44px] inline-flex items-center bg-accent hover:bg-accent-hover text-on-accent text-sm font-medium rounded-lg transition-colors" > {t('blog.goToForum')} → </a> </div> {/* Prev/Next article navigation */} {(() => { const currentIdx = articles.findIndex(a => a.id === article.id); const prevArticle = currentIdx < articles.length - 1 ? articles[currentIdx + 1] : null; const nextArticle = currentIdx > 0 ? articles[currentIdx - 1] : null; if (!prevArticle && !nextArticle) return null; return ( <div className="border-t border-edge pt-6 mt-8 grid grid-cols-1 sm:grid-cols-2 gap-3"> {prevArticle ? ( <a href={buildPath(buildArticleRoute(prevArticle.id))} onClick={(e) => { e.preventDefault(); handleArticleClick(prevArticle.id); }} className="flex items-center gap-3 p-4 bg-surface-alt/50 rounded-xl hover:bg-surface-raised/50 transition-colors group" > <ChevronLeft size={20} className="text-subtle group-hover:text-accent shrink-0 transition-colors" /> <div className="min-w-0"> <p className="text-sm text-muted mb-1">{t('blog.prevArticle')}</p> <p className="text-sm font-semibold text-body line-clamp-2">{t(`blog.article.${prevArticle.id}.title`)}</p>
  </div>
  </a>
  ) : <div />}

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -9,7 +9,7 @@ import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
 import { useNavigation } from '@/services/NavigationContext';
 import { cdnDataUrl } from '@/services/cdnDataBase';
-import { getArticleAuthorOverride, type ArticleAuthorOverride } from '@/services/authorProfileService';
+import { getArticleAuthorOverride, mergeArticleByline, type ArticleAuthorOverride } from '@/services/authorProfileService';
 import { CDN_BLOG_BASE } from '@/services/seo/blogImageCdn';
 
 // Pre-compiled gi-flag variants for keyword matching (Vercel rule 7.10)
@@ -1757,8 +1757,7 @@ function BlogArticles({
  if (selectedArticle) {
  const article = selectedArticleObj;
  if (!article) return null;
- const effectiveAuthorSlug = articleAuthorOverride?.authorSlug ?? article.authorSlug;
- const effectiveAuthorName = articleAuthorOverride?.authorName ?? article.authorName;
+ const { authorSlug: effectiveAuthorSlug, authorName: effectiveAuthorName } = mergeArticleByline(articleAuthorOverride, article);
 
  // Wait for article body translations to load
  if (!bodyReady) {

--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -10,6 +10,10 @@ import { buildNewsletterPreviewHtml } from '@/services/newsletterPreview';
 import { cdnDataUrl } from '@/services/cdnDataBase';
 import { fetchAdminEmployerInsights, updateEmployerContact, sendColdEmail, type EmployerInsightsRow, type EmployerOutreachStatus } from '@/services/adminInsights';
 import { fetchJournalistGrants, setJournalistRole, type JournalistGrant } from '@/services/journalistAdminService';
+import { fetchRedazioneAdminData, updateAuthorProfile, reassignArticleAuthor, type RedazioneAdminData } from '@/services/redazioneAdminService';
+import type { AuthorProfilePatch } from '@/services/authorProfileService';
+import { getAllAuthors } from '@/data/authors';
+import { ARTICLES } from '@/data/blog-articles-data';
 // Cold-email sequence: single shared source so the admin preview is byte-identical
 // to what send-cold-emails.mjs actually sends (AGENTS.md Non-Negotiable #6).
 import { buildSequence } from '../../scripts/lib/cold-email-sequence.mjs';
@@ -315,7 +319,7 @@ export default function AdminPanel() {
  const { user } = useAuth();
  const hasPreloadedWorkflowSnapshots = useRef(false);
  const [copiedCmd, setCopiedCmd] = useState(false);
- const [activeSection, setActiveSection] = useState<'newsletter' | 'owner' | 'insights' | 'journalists' | WorkflowContext>('jobs');
+ const [activeSection, setActiveSection] = useState<'newsletter' | 'owner' | 'insights' | 'journalists' | 'redazione' | WorkflowContext>('jobs');
  const [ownerTab] = useState<'overview'>('overview');
  const [workflowStates, setWorkflowStates] = useState<Record<string, WorkflowRunState>>({});
  const [copiedAiPromptFor, setCopiedAiPromptFor] = useState<string | null>(null);
@@ -396,6 +400,15 @@ export default function AdminPanel() {
  const [journalistEmailDraft, setJournalistEmailDraft] = useState('');
  const [journalistActionPending, setJournalistActionPending] = useState(false);
  const [journalistActionMsg, setJournalistActionMsg] = useState<{ ok: boolean; text: string } | null>(null);
+ // Redazione (superadmin article view across both catalogs + persona profile editor)
+ const [redazioneData, setRedazioneData] = useState<RedazioneAdminData | null>(null);
+ const [redazioneLoading, setRedazioneLoading] = useState(false);
+ const [redazioneError, setRedazioneError] = useState<string | null>(null);
+ const [redazioneActionMsg, setRedazioneActionMsg] = useState<{ ok: boolean; text: string } | null>(null);
+ const [redazioneActionPending, setRedazioneActionPending] = useState(false);
+ const [editingProfileSlug, setEditingProfileSlug] = useState<string | null>(null);
+ const [profileDraft, setProfileDraft] = useState<AuthorProfilePatch>({});
+ const [reassignDraftByArticle, setReassignDraftByArticle] = useState<Record<string, string>>({});
  // Crawler table filters & expansion
  const [crawlerNameFilter, setCrawlerNameFilter] = useState('');
  const [crawlerChangeFilter, setCrawlerChangeFilter] = useState<'all' | 'new' | 'updated' | 'removed' | 'none'>('all');
@@ -624,6 +637,67 @@ export default function AdminPanel() {
  setJournalistActionMsg({ ok: false, text: err instanceof Error ? err.message : 'Errore sconosciuto' });
  } finally {
  setJournalistActionPending(false);
+ }
+ };
+
+ // Load the superadmin editorial view (both catalogs) when "Redazione" tab opens.
+ const loadRedazioneData = async () => {
+ setRedazioneLoading(true);
+ setRedazioneError(null);
+ try {
+ const data = await fetchRedazioneAdminData(user);
+ setRedazioneData(data);
+ } catch (err) {
+ setRedazioneError(err instanceof Error ? err.message : 'Errore sconosciuto');
+ } finally {
+ setRedazioneLoading(false);
+ }
+ };
+
+ useEffect(() => {
+ if (activeSection !== 'redazione') return;
+ loadRedazioneData();
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [activeSection]);
+
+ const startEditingProfile = (slug: string, current: AuthorProfilePatch) => {
+ setEditingProfileSlug(slug);
+ setProfileDraft(current);
+ setRedazioneActionMsg(null);
+ };
+
+ const handleSaveProfile = async (slug: string) => {
+ if (redazioneActionPending) return;
+ setRedazioneActionPending(true);
+ setRedazioneActionMsg(null);
+ try {
+ await updateAuthorProfile(user, slug, profileDraft);
+ setRedazioneActionMsg({ ok: true, text: 'Profilo aggiornato.' });
+ setEditingProfileSlug(null);
+ await loadRedazioneData();
+ } catch (err) {
+ setRedazioneActionMsg({ ok: false, text: err instanceof Error ? err.message : 'Errore sconosciuto' });
+ } finally {
+ setRedazioneActionPending(false);
+ }
+ };
+
+ const handleReassignArticle = async (articleId: string) => {
+ const authorSlug = (reassignDraftByArticle[articleId] || '').trim();
+ if (!authorSlug || redazioneActionPending) return;
+ const author = getAllAuthors().find((a) => a.slug === authorSlug);
+ if (!author) return;
+ if (typeof window !== 'undefined' && !window.confirm(`Riassegnare l'articolo a ${author.name}?`)) return;
+ setRedazioneActionPending(true);
+ setRedazioneActionMsg(null);
+ try {
+ await reassignArticleAuthor(user, articleId, author.slug, author.name);
+ setRedazioneActionMsg({ ok: true, text: `Articolo riassegnato a ${author.name}.` });
+ await loadRedazioneData();
+ } catch (err) {
+ setRedazioneActionMsg({ ok: false, text: err instanceof Error ? err.message : 'Errore sconosciuto' });
+ } finally {
+ setRedazioneActionPending(false);
  }
  };
 
@@ -3056,6 +3130,7 @@ export default function AdminPanel() {
  { id: 'analytics' as const, label: 'Dati', icon: Database },
  { id: 'insights' as const, label: 'Insights Aziende', icon: Building2 },
  { id: 'journalists' as const, label: 'Giornalisti', icon: Newspaper },
+ { id: 'redazione' as const, label: 'Redazione', icon: Users },
  { id: 'newsletter' as const, label: 'Newsletter', icon: Mail },
  ].map(tab => {
  const summary = ['jobs', 'content', 'seo', 'analytics'].includes(tab.id)
@@ -3766,6 +3841,230 @@ export default function AdminPanel() {
  ))}
  </tbody>
  </table>
+ </div>
+ </div>
+ )}
+
+ {/* Redazione section — superadmin view across both article catalogs +
+ admin-only persona profile editor. See services/authorProfileService.ts
+ and services/redazioneAdminService.ts. */}
+ {activeSection === 'redazione' && (
+ <div className="space-y-6">
+ <div className="flex items-center justify-between gap-3 flex-wrap">
+ <h2 className="text-lg font-bold font-display text-strong flex items-center gap-2">
+ <Users size={20} className="text-accent" />
+ Redazione
+ </h2>
+ <button
+ onClick={loadRedazioneData}
+ disabled={redazioneLoading}
+ className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-accent hover:bg-accent-hover text-on-accent text-sm font-medium transition-colors disabled:opacity-60"
+ >
+ {redazioneLoading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+ Aggiorna
+ </button>
+ </div>
+
+ {redazioneActionMsg && (
+ <div className={`rounded-xl border px-4 py-2 text-sm ${redazioneActionMsg.ok ? 'bg-success-subtle border-success-border text-success' : 'bg-danger-subtle border-danger-border text-danger'}`}>
+ {redazioneActionMsg.text}
+ </div>
+ )}
+
+ {redazioneError && (
+ <div className="bg-danger-subtle border border-danger-border rounded-xl px-4 py-2 text-sm text-danger">
+ {redazioneError}
+ </div>
+ )}
+
+ {/* Persona profiles */}
+ <div className="space-y-3">
+ <h3 className="text-sm font-bold text-strong">Profili autore (persona AI)</h3>
+ <p className="text-sm text-muted">
+ Nessun login reale: qui modifichi bio, foto e social delle persona (Marco Ferrari,
+ Samuele Valente, ecc.) senza deploy di codice.
+ </p>
+ <div className="space-y-2">
+ {getAllAuthors().map((author) => {
+ const override = redazioneData?.authorProfiles[author.slug];
+ const merged = { ...author, ...override, social: { ...author.social, ...override?.social } };
+ const isEditing = editingProfileSlug === author.slug;
+ return (
+ <div key={author.slug} className="bg-surface rounded-xl border border-edge p-3">
+ <div className="flex items-center justify-between gap-3 flex-wrap">
+ <div>
+ <p className="font-bold text-strong">{merged.name}</p>
+ <p className="text-sm text-subtle">{merged.role}</p>
+ </div>
+ {!isEditing && (
+ <button
+ onClick={() => startEditingProfile(author.slug, {
+ name: merged.name, role: merged.role, bio: merged.bio,
+ photoPath: merged.photoPath, email: merged.email, social: merged.social,
+ })}
+ className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-edge text-sm font-medium text-subtle hover:text-strong hover:border-accent-border transition-colors"
+ >
+ <Pencil size={14} /> Modifica
+ </button>
+ )}
+ </div>
+ {isEditing && (
+ <div className="mt-3 space-y-2">
+ <input
+ type="text"
+ value={profileDraft.name || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, name: e.target.value }))}
+ placeholder="Nome"
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <input
+ type="text"
+ value={profileDraft.role || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, role: e.target.value }))}
+ placeholder="Ruolo"
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <textarea
+ value={profileDraft.bio || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, bio: e.target.value }))}
+ placeholder="Bio"
+ rows={4}
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <input
+ type="text"
+ value={profileDraft.photoPath || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, photoPath: e.target.value }))}
+ placeholder="/images/authors/slug.jpg"
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <input
+ type="email"
+ value={profileDraft.email || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, email: e.target.value }))}
+ placeholder="Email"
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <input
+ type="text"
+ value={profileDraft.social?.linkedin || ''}
+ onChange={(e) => setProfileDraft((d) => ({ ...d, social: { ...d.social, linkedin: e.target.value } }))}
+ placeholder="LinkedIn URL"
+ className="w-full px-3 py-2 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ />
+ <div className="flex items-center gap-2">
+ <button
+ onClick={() => { void handleSaveProfile(author.slug); }}
+ disabled={redazioneActionPending}
+ className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-accent hover:bg-accent-hover text-on-accent text-sm font-medium transition-colors disabled:opacity-60"
+ >
+ {redazioneActionPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+ Salva
+ </button>
+ <button
+ onClick={() => setEditingProfileSlug(null)}
+ className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-edge text-sm font-medium text-subtle hover:text-strong transition-colors"
+ >
+ <X size={14} /> Annulla
+ </button>
+ </div>
+ </div>
+ )}
+ </div>
+ );
+ })}
+ </div>
+ </div>
+
+ {/* AI-catalog articles — author reassignment */}
+ <div className="space-y-3">
+ <h3 className="text-sm font-bold text-strong">Articoli (catalogo AI) — {ARTICLES.length}</h3>
+ <div className="bg-surface rounded-xl border border-edge overflow-auto max-h-96">
+ <table className="w-full text-sm">
+ <thead className="sticky top-0 bg-surface">
+ <tr className="border-b border-edge text-left text-xs uppercase text-muted">
+ <th className="px-4 py-2">Articolo</th>
+ <th className="px-4 py-2">Autore attuale</th>
+ <th className="px-4 py-2">Riassegna a</th>
+ <th className="px-4 py-2" />
+ </tr>
+ </thead>
+ <tbody>
+ {ARTICLES.map((a) => {
+ const override = redazioneData?.articleAuthorOverrides[a.id];
+ const currentName = override?.authorName || a.authorName || '—';
+ return (
+ <tr key={a.id} className="border-b border-edge last:border-0">
+ <td className="px-4 py-2 text-strong">{a.id}</td>
+ <td className="px-4 py-2 text-subtle">{currentName}</td>
+ <td className="px-4 py-2">
+ <select
+ value={reassignDraftByArticle[a.id] || ''}
+ onChange={(e) => setReassignDraftByArticle((d) => ({ ...d, [a.id]: e.target.value }))}
+ className="px-2 py-1 rounded-lg border border-edge bg-surface-alt text-sm text-strong"
+ >
+ <option value="">— seleziona —</option>
+ {getAllAuthors().map((author) => (
+ <option key={author.slug} value={author.slug}>{author.name}</option>
+ ))}
+ </select>
+ </td>
+ <td className="px-4 py-2 text-right">
+ <button
+ onClick={() => { void handleReassignArticle(a.id); }}
+ disabled={redazioneActionPending || !reassignDraftByArticle[a.id]}
+ className="text-xs font-medium text-link hover:underline disabled:opacity-60"
+ >
+ Riassegna
+ </button>
+ </td>
+ </tr>
+ );
+ })}
+ </tbody>
+ </table>
+ </div>
+ </div>
+
+ {/* Real-journalist articles — read-only, both accounts and content lifecycle
+ are separately owned (see functions/src/redazioneAdminCore.js header). */}
+ <div className="space-y-3">
+ <h3 className="text-sm font-bold text-strong">
+ Articoli giornalisti (tutti gli autori) — {redazioneData?.journalistArticles.length ?? 0}
+ </h3>
+ <div className="bg-surface rounded-xl border border-edge overflow-x-auto">
+ <table className="w-full text-sm">
+ <thead>
+ <tr className="border-b border-edge text-left text-xs uppercase text-muted">
+ <th className="px-4 py-2">Titolo</th>
+ <th className="px-4 py-2">Autore</th>
+ <th className="px-4 py-2">Stato</th>
+ <th className="px-4 py-2">Categoria</th>
+ <th className="px-4 py-2">Aggiornato</th>
+ </tr>
+ </thead>
+ <tbody>
+ {(!redazioneData || redazioneData.journalistArticles.length === 0) && !redazioneLoading && (
+ <tr>
+ <td colSpan={5} className="px-4 py-6 text-center text-muted">Nessun articolo giornalista finora.</td>
+ </tr>
+ )}
+ {redazioneData?.journalistArticles.map((ja) => (
+ <tr key={ja.id} className="border-b border-edge last:border-0">
+ <td className="px-4 py-2 text-strong">{ja.title || ja.id}</td>
+ <td className="px-4 py-2 text-subtle">{ja.authorName || ja.authorEmail || '—'}</td>
+ <td className="px-4 py-2">
+ <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-surface-alt text-muted border-edge">
+ {ja.status || '—'}
+ </span>
+ </td>
+ <td className="px-4 py-2 text-subtle">{ja.category || '—'}</td>
+ <td className="px-4 py-2 text-subtle">{ja.updatedAt ? new Date(ja.updatedAt).toLocaleDateString('it-CH') : '—'}</td>
+ </tr>
+ ))}
+ </tbody>
+ </table>
+ </div>
  </div>
  </div>
  )}

--- a/components/pages/AutorePage.tsx
+++ b/components/pages/AutorePage.tsx
@@ -64,7 +64,11 @@ export const AutorePage: React.FC<AutorePageProps> = ({ slug }) => {
     );
   }
 
-  const { jsonLd } = buildAuthorSeo(author.slug, 'it');
+  // Pass the CSR-merged author (admin persona patch applied on top of the
+  // static registry), not the slug — otherwise buildAuthorSeo re-derives
+  // from the static registry and the JSON-LD goes stale vs. the visible
+  // bio/photo/social above (review nit, PR #3356).
+  const { jsonLd } = buildAuthorSeo(author, 'it');
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 animate-fade-in">

--- a/components/pages/AutorePage.tsx
+++ b/components/pages/AutorePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowLeft, Linkedin, Twitter, Mail, Award, Globe } from 'lucide-react';
 import { useNavigation } from '@/services/NavigationContext';
 import { getAuthorBySlug, type Author } from '@/data/authors';
+import { getMergedAuthor } from '@/services/authorProfileService';
 import { cdnImageUrl } from '@/services/cdnImageBase';
 import { buildAuthorSeo } from '@/services/seo/seo-authors';
 
@@ -27,7 +28,21 @@ interface AutorePageProps {
 
 export const AutorePage: React.FC<AutorePageProps> = ({ slug }) => {
   const nav = useNavigation();
-  const author = getAuthorBySlug(slug);
+  const staticAuthor = getAuthorBySlug(slug);
+  // Static registry renders first (matches the SSG snapshot, no CLS/flash);
+  // an admin-set `author_profiles/{slug}` patch (see AdminPanel "Redazione"
+  // section) is applied on top once fetched, client-side only.
+  const [author, setAuthor] = React.useState<Author | undefined>(staticAuthor);
+
+  React.useEffect(() => {
+    setAuthor(staticAuthor);
+    if (!staticAuthor) return;
+    let cancelled = false;
+    getMergedAuthor(slug).then((merged) => {
+      if (!cancelled && merged) setAuthor(merged);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [slug]);
 
   if (!author) {
     return (

--- a/firestore.rules
+++ b/firestore.rules
@@ -345,5 +345,24 @@ service cloud.firestore {
         && request.auth.uid == resource.data.authorUid
         && resource.data.status == 'draft';
     }
+
+    // Admin-editable overrides for the static AI-persona registry
+    // (data/authors.ts) — bio/photo/social patches keyed by author slug.
+    // Same class of data as data/authors.ts itself (fully public, bundled
+    // into every client build already), so public read is not a new
+    // exposure. Only the manageRedazioneAdmin Cloud Function (Admin SDK,
+    // admin-gated) may write.
+    match /author_profiles/{slug} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    // Admin-set author reassignment for a single AI-catalog article
+    // (data/blog-articles-data.ts entry), keyed by article id. Same
+    // write-only-via-Cloud-Function pattern as author_profiles above.
+    match /article_author_overrides/{articleId} {
+      allow read: if true;
+      allow write: if false;
+    }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,6 +26,7 @@ import { handleCreateFeedbackIssue, handleGetAdminGithubToken } from './src/gith
 import { handleAdminEmployerInsights, assertAdmin } from './src/adminEmployerInsights.js';
 import { handleAdminSendColdEmail } from './src/adminSendColdEmail.js';
 import { handleManageJournalistRole } from './src/journalistRoleCore.js';
+import { handleRedazioneAdmin } from './src/redazioneAdminCore.js';
 import { getAdminDb } from './src/newsletterResendWebhookCore.js';
 import { Resend } from 'resend';
 import { handleCreatePublisherCheckout, handleStripeWebhook, handleCreateBillingPortal, handleArchivePublisherAd, handleRestorePublisherAd } from './src/stripePublisherCore.js';
@@ -224,6 +225,22 @@ export const manageJournalistRole = onRequest(
       res.status(status).json(body);
     } catch (error) {
       console.error('[manageJournalistRole]', error instanceof Error ? error.message : String(error));
+      res.status(500).json({ ok: false, error: 'internal_error' });
+    }
+  },
+);
+
+// Superadmin editorial view + persona-profile/reassignment editor. See
+// functions/src/redazioneAdminCore.js for the two override collections and
+// why journalist-article reassignment is intentionally out of scope here.
+export const manageRedazioneAdmin = onRequest(
+  { region: 'europe-west6', memory: '256MiB', timeoutSeconds: 30, cors: true },
+  async (req, res) => {
+    try {
+      const { status, body } = await handleRedazioneAdmin(req);
+      res.status(status).json(body);
+    } catch (error) {
+      console.error('[manageRedazioneAdmin]', error instanceof Error ? error.message : String(error));
       res.status(500).json({ ok: false, error: 'internal_error' });
     }
   },

--- a/functions/src/redazioneAdminCore.js
+++ b/functions/src/redazioneAdminCore.js
@@ -1,0 +1,166 @@
+/**
+ * redazioneAdminCore.js — ADMIN-only superadmin view + editor for the
+ * editorial team ("redazione").
+ *
+ * Two article catalogs exist and never overlapped before this: the
+ * AI-generated catalog (`data/blog-articles-data.ts`, static, bundled
+ * client-side, byline driven by the static `data/authors.ts` persona
+ * registry) and the real-journalist catalog (`journalist_articles`
+ * Firestore collection, gated by `firestore.rules` to each author's own
+ * uid). This function gives the admin (Valerie, see `assertAdmin`) a
+ * single GET that lists real-journalist articles across ALL authors
+ * (Admin SDK bypasses the per-uid rule) plus the current admin overrides
+ * for the AI-persona registry, and a POST that writes those overrides.
+ *
+ * There are deliberately TWO different override collections rather than
+ * one, because they patch two semantically different things:
+ *   - `author_profiles/{slug}`         — persona bio/photo/social patch.
+ *   - `article_author_overrides/{id}`  — per-article author reassignment
+ *     for the AI catalog only. Reassigning a `journalist_articles` entry
+ *     would mean changing which real Firebase Auth uid owns that draft's
+ *     write access — a different, riskier operation not requested here —
+ *     so real-journalist articles are listed but not reassignable via
+ *     this endpoint.
+ *
+ * Both overrides are applied client-side at runtime (see
+ * services/authorProfileService.ts) on top of the static registries —
+ * they do NOT retroactively rewrite already-built static HTML/JSON-LD for
+ * SSG pages; that stays in sync at the next scheduled rebuild, same as
+ * any other `data/*.ts` edit.
+ *
+ * GET  → { ok, journalistArticles, authorProfiles, articleAuthorOverrides }
+ * POST → body { action: 'updateProfile', slug, patch } or
+ *         { action: 'reassignArticle', articleId, authorSlug, authorName }
+ */
+
+import { getAdminDb } from './newsletterResendWebhookCore.js';
+import { assertAdmin } from './adminEmployerInsights.js';
+
+const AUTHOR_PROFILES_COLLECTION = 'author_profiles';
+const ARTICLE_AUTHOR_OVERRIDES_COLLECTION = 'article_author_overrides';
+const JOURNALIST_ARTICLES_COLLECTION = 'journalist_articles';
+
+const ACTIONS = new Set(['updateProfile', 'reassignArticle']);
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const PROFILE_STRING_FIELDS = ['name', 'role', 'bio', 'photoPath', 'email'];
+const SOCIAL_STRING_FIELDS = ['linkedin', 'twitter', 'mastodon', 'wikidataId'];
+
+/** GET → real-journalist articles (all authors) + both override collections, as-is. */
+async function handleList(db) {
+  const [journalistSnap, profilesSnap, overridesSnap] = await Promise.all([
+    db.collection(JOURNALIST_ARTICLES_COLLECTION).get(),
+    db.collection(AUTHOR_PROFILES_COLLECTION).get(),
+    db.collection(ARTICLE_AUTHOR_OVERRIDES_COLLECTION).get(),
+  ]);
+
+  const journalistArticles = journalistSnap.docs.map((doc) => {
+    const d = doc.data() || {};
+    return {
+      id: doc.id,
+      authorUid: String(d.authorUid || ''),
+      authorName: String(d.authorName || ''),
+      authorEmail: String(d.authorEmail || ''),
+      category: String(d.category || ''),
+      title: String(d.content?.it?.title || ''),
+      status: String(d.status || ''),
+      createdAt: d.createdAt ? String(d.createdAt) : null,
+      updatedAt: d.updatedAt ? String(d.updatedAt) : null,
+      publishedAt: d.publishedAt ? String(d.publishedAt) : null,
+      publishedUrls: d.publishedUrls || null,
+    };
+  });
+
+  const authorProfiles = {};
+  for (const doc of profilesSnap.docs) authorProfiles[doc.id] = doc.data() || {};
+
+  const articleAuthorOverrides = {};
+  for (const doc of overridesSnap.docs) articleAuthorOverrides[doc.id] = doc.data() || {};
+
+  return { status: 200, body: { ok: true, journalistArticles, authorProfiles, articleAuthorOverrides } };
+}
+
+function sanitizeProfilePatch(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const patch = {};
+  for (const field of PROFILE_STRING_FIELDS) {
+    if (raw[field] === undefined) continue;
+    if (typeof raw[field] !== 'string') return null;
+    patch[field] = raw[field].trim();
+  }
+  if (raw.social !== undefined) {
+    if (typeof raw.social !== 'object' || raw.social === null) return null;
+    const social = {};
+    for (const field of SOCIAL_STRING_FIELDS) {
+      if (raw.social[field] === undefined) continue;
+      if (typeof raw.social[field] !== 'string') return null;
+      social[field] = raw.social[field].trim();
+    }
+    patch.social = social;
+  }
+  return Object.keys(patch).length ? patch : null;
+}
+
+async function handleUpdateProfile(db, raw, adminEmail) {
+  const slug = String(raw.slug || '').trim().toLowerCase();
+  if (!slug || !SLUG_RE.test(slug)) {
+    return { status: 400, body: { ok: false, error: 'invalid_input' } };
+  }
+  const patch = sanitizeProfilePatch(raw.patch);
+  if (!patch) {
+    return { status: 400, body: { ok: false, error: 'invalid_input' } };
+  }
+  await db.collection(AUTHOR_PROFILES_COLLECTION).doc(slug).set(
+    { ...patch, updatedAt: new Date().toISOString(), updatedBy: adminEmail },
+    { merge: true },
+  );
+  return { status: 200, body: { ok: true } };
+}
+
+async function handleReassignArticle(db, raw, adminEmail) {
+  const articleId = String(raw.articleId || '').trim();
+  const authorSlug = String(raw.authorSlug || '').trim().toLowerCase();
+  const authorName = String(raw.authorName || '').trim();
+  if (!articleId || !authorSlug || !SLUG_RE.test(authorSlug) || !authorName) {
+    return { status: 400, body: { ok: false, error: 'invalid_input' } };
+  }
+  await db.collection(ARTICLE_AUTHOR_OVERRIDES_COLLECTION).doc(articleId).set(
+    { authorSlug, authorName, updatedAt: new Date().toISOString(), updatedBy: adminEmail },
+    { merge: true },
+  );
+  return { status: 200, body: { ok: true } };
+}
+
+async function handleMutate(db, req, adminEmail) {
+  const raw = req.body && typeof req.body === 'object' ? req.body : {};
+  const action = String(raw.action || '').trim();
+  if (!ACTIONS.has(action)) {
+    return { status: 400, body: { ok: false, error: 'invalid_input' } };
+  }
+  if (action === 'updateProfile') return handleUpdateProfile(db, raw, adminEmail);
+  return handleReassignArticle(db, raw, adminEmail);
+}
+
+/**
+ * Entry point. GET lists both catalogs + current overrides; POST mutates
+ * a persona profile override or an AI-catalog article reassignment. Both
+ * modes require the verified admin (assertAdmin).
+ */
+export async function handleRedazioneAdmin(req) {
+  const method = String(req.method || 'GET').toUpperCase();
+  if (method !== 'GET' && method !== 'POST') {
+    return { status: 405, body: { ok: false, error: 'method_not_allowed' } };
+  }
+
+  const auth = await assertAdmin(req);
+  if (!auth.ok) {
+    return { status: auth.status, body: { ok: false, error: auth.error } };
+  }
+
+  const db = getAdminDb();
+
+  if (method === 'POST') {
+    return handleMutate(db, req, auth.adminEmail);
+  }
+
+  return handleList(db);
+}

--- a/services/authorProfileService.ts
+++ b/services/authorProfileService.ts
@@ -1,0 +1,140 @@
+/**
+ * authorProfileService.ts — runtime overrides on top of the static
+ * `data/authors.ts` persona registry and `data/blog-articles-data.ts`
+ * byline, written admin-only via the `manageRedazioneAdmin` Cloud
+ * Function (see services/redazioneAdminService.ts + AdminPanel.tsx's
+ * "Redazione" section).
+ *
+ * Both override collections are small (a handful of personas / rare
+ * reassignments), so each is fetched once per session and cached — same
+ * shape as exchangeRateService.ts's Firestore-then-fallback pattern, but
+ * with no expiry: an override changes only via an explicit admin action,
+ * not on a schedule, so a stale in-memory copy is only ever stale until
+ * the next page load.
+ *
+ * These overrides only affect client-side rendering (CSR). Already-built
+ * static HTML/JSON-LD for SSG pages stays as it was at build time until
+ * the next scheduled rebuild — same limitation as any other `data/*.ts`
+ * edit in this SSG architecture.
+ */
+
+import { AUTHORS, getAuthorBySlug, type Author, type AuthorSocial } from '@/data/authors';
+import { resilientImport } from '@/services/resilientImport';
+
+const IS_TEST_ENV = typeof process !== 'undefined' && (process.env.NODE_ENV === 'test' || !!process.env.VITEST);
+
+export type AuthorProfilePatch = Partial<Pick<Author, 'name' | 'role' | 'bio' | 'photoPath' | 'email'>> & {
+  social?: Partial<AuthorSocial>;
+};
+
+export interface ArticleAuthorOverride {
+  authorSlug: string;
+  authorName: string;
+}
+
+let profilesCache: Map<string, AuthorProfilePatch> | null = null;
+let profilesPromise: Promise<Map<string, AuthorProfilePatch>> | null = null;
+let overridesCache: Map<string, ArticleAuthorOverride> | null = null;
+let overridesPromise: Promise<Map<string, ArticleAuthorOverride>> | null = null;
+
+async function getDb() {
+  const { getFirestore } = await resilientImport(
+    () => import('firebase/firestore'),
+    (m) => typeof m.getFirestore === 'function',
+  );
+  const { getApp } = await resilientImport(
+    () => import('@/services/firebase'),
+    (m) => typeof m.getApp === 'function',
+  );
+  return getFirestore(await getApp());
+}
+
+async function loadProfiles(): Promise<Map<string, AuthorProfilePatch>> {
+  if (profilesCache) return profilesCache;
+  if (!profilesPromise) {
+    profilesPromise = (async () => {
+      const map = new Map<string, AuthorProfilePatch>();
+      if (IS_TEST_ENV) return map;
+      try {
+        const { collection, getDocs } = await resilientImport(
+          () => import('firebase/firestore'),
+          (m) => typeof m.getDocs === 'function',
+        );
+        const db = await getDb();
+        const snap = await getDocs(collection(db, 'author_profiles'));
+        snap.forEach((doc) => map.set(doc.id, doc.data() as AuthorProfilePatch));
+      } catch {
+        // Offline / permission edge cases — fall back to the static registry only.
+      }
+      profilesCache = map;
+      return map;
+    })();
+  }
+  return profilesPromise;
+}
+
+async function loadOverrides(): Promise<Map<string, ArticleAuthorOverride>> {
+  if (overridesCache) return overridesCache;
+  if (!overridesPromise) {
+    overridesPromise = (async () => {
+      const map = new Map<string, ArticleAuthorOverride>();
+      if (IS_TEST_ENV) return map;
+      try {
+        const { collection, getDocs } = await resilientImport(
+          () => import('firebase/firestore'),
+          (m) => typeof m.getDocs === 'function',
+        );
+        const db = await getDb();
+        const snap = await getDocs(collection(db, 'article_author_overrides'));
+        snap.forEach((doc) => {
+          const d = doc.data() as ArticleAuthorOverride;
+          if (d?.authorSlug && d?.authorName) map.set(doc.id, d);
+        });
+      } catch {
+        // Offline / permission edge cases — fall back to the static byline only.
+      }
+      overridesCache = map;
+      return map;
+    })();
+  }
+  return overridesPromise;
+}
+
+/** Static author merged with its admin-set `author_profiles/{slug}` patch, if any. */
+export async function getMergedAuthor(slug: string): Promise<Author | undefined> {
+  const base = getAuthorBySlug(slug);
+  if (!base) return undefined;
+  const profiles = await loadProfiles();
+  const patch = profiles.get(slug);
+  if (!patch) return base;
+  return {
+    ...base,
+    ...patch,
+    social: { ...base.social, ...patch.social },
+  };
+}
+
+/** Every persona, each merged with its override if one exists. */
+export async function getAllMergedAuthors(): Promise<Author[]> {
+  const profiles = await loadProfiles();
+  return AUTHORS.map((base) => {
+    const patch = profiles.get(base.slug);
+    if (!patch) return base;
+    return { ...base, ...patch, social: { ...base.social, ...patch.social } };
+  });
+}
+
+/** Admin-set author reassignment for this AI-catalog article id, if any. */
+export async function getArticleAuthorOverride(articleId: string): Promise<ArticleAuthorOverride | undefined> {
+  const overrides = await loadOverrides();
+  return overrides.get(articleId);
+}
+
+/** Resolves the byline to show for an AI-catalog article, override applied. */
+export async function getEffectiveArticleByline(
+  article: { id: string; authorSlug?: string; authorName?: string },
+): Promise<{ authorSlug?: string; authorName?: string }> {
+  const override = await getArticleAuthorOverride(article.id);
+  if (override) return override;
+  return { authorSlug: article.authorSlug, authorName: article.authorName };
+}

--- a/services/authorProfileService.ts
+++ b/services/authorProfileService.ts
@@ -130,11 +130,26 @@ export async function getArticleAuthorOverride(articleId: string): Promise<Artic
   return overrides.get(articleId);
 }
 
+/**
+ * Pure override-then-fallback merge, per field. Shared by
+ * `getEffectiveArticleByline` (fetch + merge) and `BlogArticles.tsx` (which
+ * already holds a fetched override in state and only needs the merge step) —
+ * kept as one function so the two call sites can't drift (review nit, PR #3356).
+ */
+export function mergeArticleByline(
+  override: ArticleAuthorOverride | null | undefined,
+  article: { authorSlug?: string; authorName?: string },
+): { authorSlug?: string; authorName?: string } {
+  return {
+    authorSlug: override?.authorSlug ?? article.authorSlug,
+    authorName: override?.authorName ?? article.authorName,
+  };
+}
+
 /** Resolves the byline to show for an AI-catalog article, override applied. */
 export async function getEffectiveArticleByline(
   article: { id: string; authorSlug?: string; authorName?: string },
 ): Promise<{ authorSlug?: string; authorName?: string }> {
   const override = await getArticleAuthorOverride(article.id);
-  if (override) return override;
-  return { authorSlug: article.authorSlug, authorName: article.authorName };
+  return mergeArticleByline(override, article);
 }

--- a/services/redazioneAdminService.ts
+++ b/services/redazioneAdminService.ts
@@ -1,0 +1,118 @@
+/**
+ * redazioneAdminService.ts — client for the ADMIN-only `manageRedazioneAdmin`
+ * Cloud Function (functions/src/redazioneAdminCore.js, region europe-west6).
+ *
+ * Mirrors services/journalistAdminService.ts's calling convention exactly:
+ * same base URL host, same `Authorization: Bearer <idToken>` header, same
+ * `{ ok, ... }` / `{ ok: false, error }` response shape. Consumed by
+ * AdminPanel.tsx's "Redazione" section (superadmin article view across
+ * both catalogs + persona profile editor).
+ */
+
+import type { AuthorProfilePatch, ArticleAuthorOverride } from '@/services/authorProfileService';
+
+const MANAGE_REDAZIONE_ADMIN_ENDPOINT =
+  'https://europe-west6-frontaliere-ticino.cloudfunctions.net/manageRedazioneAdmin';
+
+export interface RedazioneJournalistArticle {
+  id: string;
+  authorUid: string;
+  authorName: string;
+  authorEmail: string;
+  category: string;
+  title: string;
+  status: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  publishedAt: string | null;
+  publishedUrls: Partial<Record<string, string>> | null;
+}
+
+export interface RedazioneAdminData {
+  journalistArticles: RedazioneJournalistArticle[];
+  authorProfiles: Record<string, AuthorProfilePatch>;
+  articleAuthorOverrides: Record<string, ArticleAuthorOverride>;
+}
+
+/** Minimal Firebase user shape — only getIdToken is needed. */
+interface AuthLike {
+  getIdToken: () => Promise<string>;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_admin: 'Accesso negato: questo account non è autorizzato a gestire la redazione.',
+  invalid_input: 'Dati non validi.',
+};
+
+function authErrorMessage(data: { error?: string }, res: Response, fallbackVerb: string): string {
+  return ERROR_MESSAGES[data.error || ''] || `${fallbackVerb} (${data.error || res.status}).`;
+}
+
+/**
+ * Loads real-journalist articles across every author plus the current
+ * persona/article-author overrides. Throws a human-readable message on
+ * auth failure or non-OK response.
+ */
+export async function fetchRedazioneAdminData(user: AuthLike | null | undefined): Promise<RedazioneAdminData> {
+  if (!user) {
+    throw new Error('Devi essere autenticato come admin per vedere la redazione.');
+  }
+  const idToken = await user.getIdToken();
+  const res = await fetch(MANAGE_REDAZIONE_ADMIN_ENDPOINT, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) {
+    throw new Error(authErrorMessage(data, res, 'Impossibile caricare la redazione'));
+  }
+  return {
+    journalistArticles: Array.isArray(data.journalistArticles) ? data.journalistArticles : [],
+    authorProfiles: data.authorProfiles && typeof data.authorProfiles === 'object' ? data.authorProfiles : {},
+    articleAuthorOverrides:
+      data.articleAuthorOverrides && typeof data.articleAuthorOverrides === 'object' ? data.articleAuthorOverrides : {},
+  };
+}
+
+/** Patches a persona's admin-editable profile fields (name/role/bio/photoPath/email/social). */
+export async function updateAuthorProfile(
+  user: AuthLike | null | undefined,
+  slug: string,
+  patch: AuthorProfilePatch,
+): Promise<void> {
+  if (!user) {
+    throw new Error('Devi essere autenticato come admin per modificare un profilo.');
+  }
+  const idToken = await user.getIdToken();
+  const res = await fetch(MANAGE_REDAZIONE_ADMIN_ENDPOINT, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'updateProfile', slug, patch }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) {
+    throw new Error(authErrorMessage(data, res, 'Salvataggio profilo non riuscito'));
+  }
+}
+
+/** Reassigns the byline of an AI-catalog article (`data/blog-articles-data.ts` entry). */
+export async function reassignArticleAuthor(
+  user: AuthLike | null | undefined,
+  articleId: string,
+  authorSlug: string,
+  authorName: string,
+): Promise<void> {
+  if (!user) {
+    throw new Error('Devi essere autenticato come admin per riassegnare un articolo.');
+  }
+  const idToken = await user.getIdToken();
+  const res = await fetch(MANAGE_REDAZIONE_ADMIN_ENDPOINT, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'reassignArticle', articleId, authorSlug, authorName }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) {
+    throw new Error(authErrorMessage(data, res, 'Riassegnazione non riuscita'));
+  }
+}

--- a/services/seo/seo-authors.ts
+++ b/services/seo/seo-authors.ts
@@ -99,16 +99,23 @@ function buildPersonJsonLd(author: Author, canonical: string): Record<string, un
 /**
  * Builds the SEO payload for an author profile page.
  *
- * @throws Error when the slug does not match a registered author. Authors are
+ * Accepts either a slug (resolved against the static registry — used by SSG
+ * and tests) or an already-resolved `Author` object. Callers holding a
+ * CSR-merged author (admin `author_profiles/{slug}` patch applied on top of
+ * the static registry — see `AutorePage.tsx`) MUST pass the merged object,
+ * not the slug, so the emitted Person JSON-LD matches the visible bio/photo/
+ * social instead of silently reverting to the stale static registry values.
+ *
+ * @throws Error when a slug does not match a registered author. Authors are
  *   a closed registry; an unknown slug is a programming error, not user input.
  */
-export function buildAuthorSeo(slug: string, locale: AuthorLocale = 'it'): AuthorSeo {
-  const author = getAuthorBySlug(slug);
+export function buildAuthorSeo(authorOrSlug: string | Author, locale: AuthorLocale = 'it'): AuthorSeo {
+  const author = typeof authorOrSlug === 'string' ? getAuthorBySlug(authorOrSlug) : authorOrSlug;
   if (!author) {
-    throw new Error(`buildAuthorSeo: unknown author slug "${slug}"`);
+    throw new Error(`buildAuthorSeo: unknown author slug "${authorOrSlug}"`);
   }
   const labels = LOCALE_LABELS[locale];
-  const canonical = buildCanonical(slug, locale);
+  const canonical = buildCanonical(author.slug, locale);
   const title = `${author.name} — ${author.role} | ${labels.suffix}`;
   const description = buildDescription(author);
   const ogImage = `${BASE_URL}${author.photoPath}`;

--- a/tests/authors.test.ts
+++ b/tests/authors.test.ts
@@ -118,4 +118,17 @@ describe('buildAuthorSeo', () => {
   it('throws on unknown slug', () => {
     expect(() => buildAuthorSeo('does-not-exist', 'it')).toThrow();
   });
+
+  // Review nit (PR #3356): AutorePage.tsx must pass the CSR-merged author
+  // object (admin persona patch applied on top of the static registry), not
+  // the slug — passing the slug re-derives from the static registry and the
+  // Person JSON-LD goes stale vs. the visible bio/photo/social.
+  it('accepts an already-resolved Author object and reflects its patched fields in the JSON-LD', () => {
+    const staticAuthor = getAuthorBySlug('marco-ferrari')!;
+    const merged = { ...staticAuthor, name: 'Marco Ferrari Patched', bio: staticAuthor.bio };
+    const seo = buildAuthorSeo(merged, 'it');
+    expect(seo.jsonLd.name).toBe('Marco Ferrari Patched');
+    expect(seo.title).toContain('Marco Ferrari Patched');
+    expect(seo.canonical).toBe(`https://frontaliereticino.ch/autori/${staticAuthor.slug}/`);
+  });
 });

--- a/tests/redazione-admin-core.test.ts
+++ b/tests/redazione-admin-core.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mirrors admin-send-cold-email-handler.test.ts's approach for the
+// non-DI handler style (handleManageJournalistRole/adminEmployerInsights):
+// mock the two things redazioneAdminCore.js imports — the admin gate and
+// the Admin SDK db — so we exercise the real handler logic without a live
+// Firebase project.
+
+const verifyIdToken = vi.fn();
+vi.mock('firebase-admin/auth', () => ({
+  getAuth: () => ({ verifyIdToken }),
+}));
+
+function fakeCollection(store: Record<string, any>) {
+  const writes: Array<{ id: string; data: any }> = [];
+  return {
+    writes,
+    async get() {
+      const docs = Object.entries(store).map(([id, data]) => ({ id, data: () => data }));
+      return { docs };
+    },
+    doc(id: string) {
+      return {
+        async set(payload: any, opts?: { merge?: boolean }) {
+          writes.push({ id, data: payload });
+          store[id] = opts?.merge ? { ...(store[id] || {}), ...payload } : payload;
+        },
+      };
+    },
+  };
+}
+
+function fakeDb(data: { journalist_articles?: Record<string, any>; author_profiles?: Record<string, any>; article_author_overrides?: Record<string, any> } = {}) {
+  const collections: Record<string, ReturnType<typeof fakeCollection>> = {
+    journalist_articles: fakeCollection(data.journalist_articles || {}),
+    author_profiles: fakeCollection(data.author_profiles || {}),
+    article_author_overrides: fakeCollection(data.article_author_overrides || {}),
+  };
+  return { collection: (name: string) => collections[name], _collections: collections };
+}
+
+let mockDb: ReturnType<typeof fakeDb>;
+vi.mock('../functions/src/newsletterResendWebhookCore.js', () => ({
+  getAdminDb: () => mockDb,
+}));
+
+const ADMIN_EMAIL = 'valerielinc@gmail.com';
+
+function adminReq(overrides: Record<string, any> = {}) {
+  return {
+    method: 'GET',
+    get: (h: string) => (h === 'Authorization' ? 'Bearer valid-token' : undefined),
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line import/first
+const { handleRedazioneAdmin } = await import('../functions/src/redazioneAdminCore.js');
+
+describe('handleRedazioneAdmin', () => {
+  beforeEach(() => {
+    mockDb = fakeDb();
+    verifyIdToken.mockReset();
+    verifyIdToken.mockResolvedValue({ email: ADMIN_EMAIL, email_verified: true });
+  });
+
+  it('rejects a non-admin caller', async () => {
+    verifyIdToken.mockResolvedValue({ email: 'someone-else@example.com', email_verified: true });
+    const res = await handleRedazioneAdmin(adminReq());
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: 'not_admin' });
+  });
+
+  it('rejects a request with no Authorization header', async () => {
+    const res = await handleRedazioneAdmin({ method: 'GET', get: () => undefined });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'missing_id_token' });
+  });
+
+  it('rejects an unsupported method', async () => {
+    const res = await handleRedazioneAdmin(adminReq({ method: 'DELETE' }));
+    expect(res.status).toBe(405);
+  });
+
+  it('GET lists journalist articles across all authors plus both override collections', async () => {
+    mockDb = fakeDb({
+      journalist_articles: {
+        'art-1': {
+          authorUid: 'uid-1',
+          authorName: 'Giulia Bianchi',
+          authorEmail: 'giulia@example.com',
+          category: 'fiscalita',
+          content: { it: { title: 'Titolo articolo' } },
+          status: 'published',
+          createdAt: '2026-06-01T00:00:00.000Z',
+          updatedAt: '2026-06-02T00:00:00.000Z',
+          publishedAt: '2026-06-02T00:00:00.000Z',
+          publishedUrls: { it: '/blog/titolo-articolo/' },
+        },
+      },
+      author_profiles: { 'marco-ferrari': { bio: 'Bio aggiornata' } },
+      article_author_overrides: { 'art-ai-1': { authorSlug: 'samuele-valente', authorName: 'Samuele Valente' } },
+    });
+    const res = await handleRedazioneAdmin(adminReq());
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.journalistArticles).toHaveLength(1);
+    expect(res.body.journalistArticles[0]).toMatchObject({
+      id: 'art-1',
+      authorUid: 'uid-1',
+      title: 'Titolo articolo',
+      status: 'published',
+    });
+    expect(res.body.authorProfiles['marco-ferrari']).toEqual({ bio: 'Bio aggiornata' });
+    expect(res.body.articleAuthorOverrides['art-ai-1']).toEqual({
+      authorSlug: 'samuele-valente',
+      authorName: 'Samuele Valente',
+    });
+  });
+
+  it('POST updateProfile upserts only the allowlisted fields', async () => {
+    const res = await handleRedazioneAdmin(
+      adminReq({
+        method: 'POST',
+        body: {
+          action: 'updateProfile',
+          slug: 'marco-ferrari',
+          patch: { bio: 'Nuova bio', role: 'Redattore capo', social: { linkedin: 'https://linkedin.com/in/x' } },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const written = mockDb._collections.author_profiles.writes.at(-1)!.data;
+    expect(written.bio).toBe('Nuova bio');
+    expect(written.role).toBe('Redattore capo');
+    expect(written.social).toEqual({ linkedin: 'https://linkedin.com/in/x' });
+    expect(written.updatedBy).toBe(ADMIN_EMAIL);
+  });
+
+  it('POST updateProfile rejects a field outside the allowlist', async () => {
+    const res = await handleRedazioneAdmin(
+      adminReq({
+        method: 'POST',
+        body: { action: 'updateProfile', slug: 'marco-ferrari', patch: { isAdmin: true } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_input');
+  });
+
+  it('POST updateProfile rejects an invalid slug', async () => {
+    const res = await handleRedazioneAdmin(
+      adminReq({
+        method: 'POST',
+        body: { action: 'updateProfile', slug: 'Not A Slug!', patch: { bio: 'x' } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_input');
+  });
+
+  it('POST reassignArticle upserts the article override', async () => {
+    const res = await handleRedazioneAdmin(
+      adminReq({
+        method: 'POST',
+        body: {
+          action: 'reassignArticle',
+          articleId: 'la-sospensione-dei-ristorni',
+          authorSlug: 'samuele-valente',
+          authorName: 'Samuele Valente',
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const written = mockDb._collections.article_author_overrides.writes.at(-1)!.data;
+    expect(written).toMatchObject({ authorSlug: 'samuele-valente', authorName: 'Samuele Valente' });
+  });
+
+  it('POST reassignArticle rejects missing fields', async () => {
+    const res = await handleRedazioneAdmin(
+      adminReq({ method: 'POST', body: { action: 'reassignArticle', articleId: 'x' } }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_input');
+  });
+
+  it('POST with an unknown action is rejected', async () => {
+    const res = await handleRedazioneAdmin(adminReq({ method: 'POST', body: { action: 'deleteEverything' } }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_input');
+  });
+});


### PR DESCRIPTION
## Implementato

- **Firestore**: nuove collection `author_profiles/{slug}` (patch persona AI) e `article_author_overrides/{articleId}` (riassegnazione autore catalogo AI) — read pubblico, write solo via Cloud Function.
- **Cloud Function `manageRedazioneAdmin`** (`functions/src/redazioneAdminCore.js`, region `europe-west6`): GET restituisce `journalist_articles` di TUTTI gli autori (bypass regola per-uid via Admin SDK) + entrambe le collection di override; POST gestisce `updateProfile` (patch persona, campi allowlisted) e `reassignArticle` (riassegna un articolo del catalogo AI). Gate `assertAdmin` (allowlist `valerielinc@gmail.com`, riusato da `adminEmployerInsights.js`).
- **`services/authorProfileService.ts`**: reader client-side runtime, merge override Firestore su registro statico `data/authors.ts` — `getMergedAuthor`, `getAllMergedAuthors`, `getArticleAuthorOverride`, `getEffectiveArticleByline`.
- **`services/redazioneAdminService.ts`**: wrapper client verso `manageRedazioneAdmin` (stesso pattern di `journalistAdminService.ts`).
- **`components/pages/AutorePage.tsx`**: pagina autore mostra il profilo merged (patch admin sovrascrive lo statico) via CSR effect.
- **`components/community/BlogArticles.tsx`**: byline articolo (entrambi i punti di render, incluso il blocco bio E-E-A-T) usa l'override riassegnazione se presente.
- **`components/pages/AdminPanel.tsx`**: nuova sezione "Redazione" — superadmin vede/edita i profili persona AI, riassegna articoli del catalogo AI, e vede (read-only) tutti gli articoli journalist reali cross-autore.
- **Test**: `tests/redazione-admin-core.test.ts`, 10 casi — gate non-admin/no-token, shape GET, validazione+upsert `updateProfile` (allowlist campi, slug invalido), validazione+upsert `reassignArticle`, action sconosciuta. Verde in locale.
- **GitNexus**: `impact()` upstream su tutti i simboli esportati nuovi (`handleRedazioneAdmin`, `getMergedAuthor`, `getArticleAuthorOverride`, `updateAuthorProfile`, `reassignArticleAuthor`) → risk LOW su tutti, caller = solo i punti di integrazione previsti (`functions/index.js`, `AutorePage`, `BlogArticles`, `AdminPanel`). Index rifreshato (`npx gitnexus analyze --skip-agents-md`).
- **Fix review 🔴 Important** (`AutorePage.tsx:67`): `buildAuthorSeo` re-derivava il Person JSON-LD dal registro statico via slug, ignorando lo stato CSR-merged — un patch admin su nome/bio/foto/social aggiornava la pagina visibile ma lasciava lo structured data stale. `buildAuthorSeo(authorOrSlug: string | Author, locale)` ora accetta anche l'oggetto già risolto; `AutorePage` passa l'`author` merged. Verificato via grep: zero consumer SSG/build-plugin di `buildAuthorSeo` esistenti, solo `AutorePage.tsx` + `tests/authors.test.ts` — signature change retrocompatibile e sicuro. Nuovo test in `tests/authors.test.ts` (14/14 verde), typecheck pulito.
- **Fix review 🟡 Nit** (`services/authorProfileService.ts:118,134`): `BlogArticles.tsx` reimplementava inline la stessa logica override-poi-fallback già esportata come `getEffectiveArticleByline` — duplicazione letterale, drift possibile. Estratta la merge pura in `mergeArticleByline`, condivisa da entrambi i call site (`getEffectiveArticleByline` e `BlogArticles.tsx:1760`). Test BlogArticles content-gate (5/5) + authors (14/14) verdi.

Nota: i due ask originari più semplici (title-casing bug root-cause + riassegnazione specifica marco-ferrari→samuele-valente) sono già risolti e mergiati separatamente in PR #3350 — questa PR copre solo i due ask restanti (editing self-serve-style del profilo via pannello admin, visibilità superadmin su entrambi i cataloghi).

## Non implementato (ancora)

- Nessuno. Scope di questa PR (profile editing admin + superadmin dual-catalog visibility) è interamente implementato e testato in questa PR, incluso il fix del 🔴 Important sollevato in review.
- Deferred con motivazione esplicita (review 🟡 Nit, `functions/src/redazioneAdminCore.js:631-643`): `handleReassignArticle` valida la shape di `authorSlug` (`SLUG_RE`) ma non verifica server-side che corrisponda a un author reale in `data/authors.ts` — solo la dropdown client (`AdminPanel.tsx:154`) lo vincola. Il reviewer stesso lo classifica "low likelihood (single trusted admin, normal UI path is safe)". Il fix corretto richiederebbe nuova infra cross-modulo (le Cloud Function in `functions/` non hanno bundler e non possono importare direttamente `data/authors.ts` da root — serve un modulo condiviso dentro `functions/` + shim, pattern già usato altrove nel repo) — sproporzionato per un edge-case a rischio basso con un solo admin fidato dietro una UI già vincolata. Nessun costo di codice duplicato nel frattempo (nessuna costante/slug-list copiata).
- Boundary dichiarato e intenzionale (non deferral): gli override Firestore sono applicati solo CSR a runtime — non riscrivono retroattivamente HTML/JSON-LD statico già buildato per le pagine SSG; quello si allinea al prossimo rebuild schedulato, come ogni altra modifica a `data/*.ts`.
- Boundary dichiarato e intenzionale (non deferral): la riassegnazione via questo pannello copre SOLO il catalogo AI (`article_author_overrides`). Riassegnare un `journalist_articles` significherebbe cambiare quale uid Firebase Auth reale possiede i diritti di scrittura su quel draft — operazione diversa, più rischiosa, non richiesta; questi articoli restano visibili in sola lettura.
