### PR TITLE
fix: round 8 backlog batch (2 fixes, 2 issues)

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -253,6 +253,16 @@ const EMPTY_OK_CRAWLERS = new Set([
   // roles) — the architecture/design firm has 0 open positions right now.
   // The parser is healthy and re-arms when a vacancy is published (#3198).
   'a-group',
+  // Medics Labor AG (Bern, Refline tenant 1474): the listing page
+  // (https://app.reflinejobs.io/1474/positions.html?lang=de) returns HTTP 200
+  // with the unchanged anchor-list structure and explicitly states "Zurzeit
+  // haben wir keine Vakanzen. Schauen Sie gerne später wieder bei uns vorbei."
+  // (currently no vacancies). The small private lab (2 open roles as of
+  // 2026-06-29) legitimately went to 0 openings; the shared Refline parser
+  // (`refline-common.mjs`) is healthy and re-arms when a new posting appears.
+  // Same legitimately-empty small-employer case as linnea and
+  // wuerth-international (#3344).
+  'medics-labor',
 ]);
 
 /** Read JSON file, return null on any error. */

--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -189,6 +189,51 @@ export function isGenuinePrBodyContractViolation(text) {
   return true;
 }
 
+// ---- `sibling-class-fix` false-positive guard (DETERMINISTIC) ---------------
+// Same false-positive class as `isGenuinePrBodyContractViolation` above, applied
+// to the OTHER process-failure-mode bucket the reviewer regex matches loosely on
+// sweep vocabulary (`sibling`, `file gemello`, `stesso anti-pattern`, `non
+// toccat[o]`, …). Unlike pr-body-contract (structural gate already blocks missing
+// sections), `check-sibling-patterns.mjs` is a candidate-SURFACER with no
+// enforcement — but the reviewer regex still can't tell these senses apart:
+//   (a) GENUINE violation — a sibling file left un-swept still carries the SAME
+//       antipattern the PR just fixed elsewhere (e.g. #3317: `.slice(0, 20)`
+//       cap-trim fixed in one crawler, "resta intatto" in 7 siblings). This is
+//       the escalation target. A divergent-but-deferred nit ("diverges from the
+//       sibling's pattern — deferred, non funnel-critical", #3312) is STILL a
+//       real finding here — AGENTS.md #8 abolished deferral-as-closure, so only
+//       (b)/(c) below are excluded, never a plain "deferred".
+//   (b) AFFIRMATION — the reviewer confirms the sibling sweep is COMPLETE / no
+//       residual finding ("nessun sibling residuo", "no inconsistency", "coerente
+//       col sibling", "correctly mirrors the sibling"). NOT a defect. Includes the
+//       same emoji-as-word trap that inflated pr-body-contract (#2397/#2396): a
+//       line like "nessun 🔴/🟡 da propagare" (#3319) contains the literal glyphs
+//       `detectSeverity` substring-matches on, even though the sentence explicitly
+//       says there is NOTHING to report.
+//   (c) DECLARED FALSE POSITIVE — the reviewer explicitly invokes AGENTS.md #6's
+//       own escape hatch: the construct is "solo lessicalmente simile ma
+//       semanticamente diverso" / an explicit "falso positivo" — not the same bug
+//       class, just a shared token.
+// Issue #3325 (escalation ×6 in 14gg: #3319/#3317/#3312/#3267/#3265) — the bucket
+// had no filter at all, unlike its pr-body-contract sibling shipped in #3332.
+// Pure → unit-tested, mirrors isGenuinePrBodyContractViolation's structure.
+const SIBLING_CLASS_AFFIRM_RE =
+  /nessun\w*\s*(?:[\u{1F534}\u{1F7E1}]\s*\/?\s*)*(?:da propagare|altro finding|bug replicat\w*|antipattern replicat\w*)|nessun\s+sibling\s+resid\w*|no inconsistenc\w*|not a candidate for|correctly mirrors? the sibling|coerente\s+(?:col|con il)\s+sibling|match(?:es)?\s+the sibling'?s?\s+(?:proven\s+)?(?:pattern|guard)/iu;
+const SIBLING_CLASS_FALSE_POSITIVE_RE =
+  /falso positivo|solo lessicalmente simil\w*|lessicalmente simil\w*(?:[^.]{0,40})semanticamente divers\w*|semanticamente divers\w*|non è (?:lo stesso|la stessa) (?:anti-?pattern|costrutto|classe)|not the same (?:anti-?pattern|construct|bug class)|false positive/i;
+export function isGenuineSiblingClassViolation(text) {
+  const s = String(text || '');
+  // (c) explicit false-positive declaration wins first — a reviewer can declare
+  //     lexical-vs-semantic mismatch even inside an otherwise alarming sentence.
+  if (SIBLING_CLASS_FALSE_POSITIVE_RE.test(s)) return false;
+  // (b) the line AFFIRMS the sweep is complete / nothing to propagate → not a
+  //     defect, even if it contains 🔴/🟡 glyphs as prose rather than a marker.
+  if (SIBLING_CLASS_AFFIRM_RE.test(s)) return false;
+  // Default: no affirmation, no declared false positive → conservative: keep as
+  // a genuine (possibly deferred-but-real) sibling-class finding.
+  return true;
+}
+
 export function bucketFinding(text) {
   for (const t of TAXONOMY) {
     if (!t.re.test(text)) continue;
@@ -198,6 +243,10 @@ export function bucketFinding(text) {
     // next matching taxonomy entry / fingerprint net so a co-mentioned real defect
     // (sibling-class-fix, stale-comment) still clusters in its own bucket.
     if (t.key === 'pr-body-contract' && !isGenuinePrBodyContractViolation(text)) continue;
+    // sibling-class-fix: same treatment (issue #3325) — drop affirmations /
+    // declared false positives so the bucket counts only genuine unswept-sibling
+    // findings, mirroring pr-body-contract's filter above.
+    if (t.key === 'sibling-class-fix' && !isGenuineSiblingClassViolation(text)) continue;
     return t.key;
   }
   return fingerprintFinding(text); // unbucketed → fingerprint safety net (or null)

--- a/tests/harvest-escalation-avoidable.test.ts
+++ b/tests/harvest-escalation-avoidable.test.ts
@@ -12,11 +12,20 @@
  *     è già bloccata dal gate deterministico pr-body-contract.yml. Il bucket ricorre
  *     per affermazioni ("sezioni presenti e sensate") ed etichette-di-posizione
  *     ("PR body ## Implementato L2" su un finding di altro tipo). Conta solo (a).
+ *   - #3325 `reviewer-finding/sibling-class-fix`: stessa classe di #2440 ma per il
+ *     bucket sibling-sweep (regex su `sibling`/`file gemello`/`stesso anti-pattern`/
+ *     `non toccat[o]`). Il bucket non aveva NESSUN filtro (a differenza del suo
+ *     gemello pr-body-contract, #3332) → ricorso ×6 in 14gg (#3319/#3317/#3312/
+ *     #3267/#3265) contando affermazioni ("nessun sibling residuo", "no
+ *     inconsistency") e persino un caso di emoji-come-parola ("nessun 🔴/🟡 da
+ *     propagare", #3319) che ingannava `detectSeverity`. Conta solo la violazione
+ *     genuina; scarta affermazioni e falsi-positivi dichiarati esplicitamente.
  */
 import { describe, it, expect } from 'vitest';
 import {
   isAvoidableMaxTurns,
   isGenuinePrBodyContractViolation,
+  isGenuineSiblingClassViolation,
   bucketFinding,
 } from '../scripts/ci/harvest-agent-lessons.mjs';
 
@@ -157,5 +166,56 @@ describe('bucketFinding — pr-body-contract scarta i falsi positivi e lascia ri
 
   it('violazione genuina di sezione mancante resta pr-body-contract', () => {
     expect(bucketFinding('🔴 process: manca la sezione `## Implementato`')).toBe('pr-body-contract');
+  });
+});
+
+describe('isGenuineSiblingClassViolation — conta solo il sibling non-sweepato, non affermazioni/falsi-positivi (#3325)', () => {
+  it('sibling non toccato con lo stesso anti-pattern → violazione (contabile, es. #3317)', () => {
+    expect(isGenuineSiblingClassViolation(
+      '🔴 Important: stesso anti-pattern `.slice(0, 20)` keep-oldest cap-trim non-journalizzato che questa PR ha appena fixato resta intatto in 7 crawler company-specific attivi, non toccato da questa PR né dichiarato in `## Non implementato`.',
+    )).toBe(true);
+  });
+
+  it('nit di divergenza dal sibling anche se "deferred" resta violazione genuina (AGENTS.md #8 abolisce deferral-as-closure, es. #3312)', () => {
+    expect(isGenuineSiblingClassViolation(
+      '🟡 Nit: pre-flight is awaited inline per-payload, unlike the sibling events poster which batches all checks upfront via Promise.allSettled — deferred, non funnel-critical.',
+    )).toBe(true);
+  });
+
+  it('affermazione "nessun 🔴/🟡 da propagare" → NON violazione, anche coi glifi emoji letterali (#3319)', () => {
+    expect(isGenuineSiblingClassViolation(
+      'Cross-file (sticky sibling-check): condividono token ma non replicano il pattern cap-check-con-auto-esclusione fixato qui — nessun 🔴/🟡 da propagare.',
+    )).toBe(false);
+  });
+
+  it('affermazione "correctly mirrors the sibling ... no inconsistency" → NON violazione (es. #3267)', () => {
+    expect(isGenuineSiblingClassViolation(
+      'isSystemicBoilerplateFailure correctly mirrors the sibling floor — ratio AND count AND total-eligible, not ratio alone. No inconsistency, not a candidate for the same split.',
+    )).toBe(false);
+  });
+
+  it('falso positivo dichiarato esplicitamente (AGENTS.md #6: lessicalmente simile, semanticamente diverso) → NON violazione', () => {
+    expect(isGenuineSiblingClassViolation(
+      '🟡 Nit: il costrutto è solo lessicalmente simile ma semanticamente diverso — falso positivo, non è lo stesso anti-pattern del sibling.',
+    )).toBe(false);
+  });
+
+  it('vocabolario sibling senza affermazione né falso-positivo dichiarato → conservativo: violazione', () => {
+    expect(isGenuineSiblingClassViolation('🟡 sibling non toccato, verificare a mano')).toBe(true);
+  });
+});
+
+describe('bucketFinding — sibling-class-fix scarta i falsi positivi (#3325)', () => {
+  it('violazione genuina di sibling non-sweepato resta sibling-class-fix', () => {
+    expect(bucketFinding(
+      '🔴 Important: stesso anti-pattern non toccato, resta intatto nei 7 crawler sibling',
+    )).toBe('sibling-class-fix');
+  });
+
+  it('affermazione con emoji-come-parola non finisce in sibling-class-fix', () => {
+    const b = bucketFinding(
+      'Cross-file (sticky sibling-check): non replicano il pattern fixato qui — nessun 🔴/🟡 da propagare.',
+    );
+    expect(b).not.toBe('sibling-class-fix');
   });
 });


### PR DESCRIPTION
## Implementato

- **#3344**: `medics-labor` crawler health-check false-positive fixed. Live-verified the source (`app.reflinejobs.io/1474/positions.html?lang=de`, HTTP 200, unchanged structure) explicitly states no current vacancies — a genuinely-empty small employer, not a broken parser. Added `medics-labor` to the existing `EMPTY_OK_CRAWLERS` allowlist in `scripts/check-crawler-health.mjs`, same class as `linnea`/`dxt-commodities`/`wuerth-international`. Test: `npx vitest run tests/scripts/check-crawler-health.test.ts` → 15/15 passed.
- **#3325**: added `isGenuineSiblingClassViolation()` false-positive filter to the `reviewer-finding/sibling-class-fix` bucket in `scripts/ci/harvest-agent-lessons.mjs`, mirroring the existing `isGenuinePrBodyContractViolation` pattern (shipped in #3332) for the analogous pr-body-contract bucket. This bucket had escalated 6 times in 14 days (#3319/#3317/#3312/#3267/#3265) from affirmations ("nessun sibling residuo") and an emoji-as-word trap ("nessun 🔴/🟡 da propagare") being counted as genuine violations. New unit tests added to `tests/harvest-escalation-avoidable.test.ts` covering genuine violations, affirmations, and declared false positives. Test: `npx vitest run tests/harvest-escalation-avoidable.test.ts` → 24/24 passed.

Note: a third issue in this round, #3338 (two broken Ticino border webcams), was independently fixed and merged by the automated pipeline (PR #3352) while this batch was in progress — no action needed here, dropped from this bundle to avoid duplication.

## Non implementato (ancora)

Nessuno.