### PR TITLE
feat(job-alerts): tier-4 URL-derived canton signal, applied live at signup

### DIFF
--- a/functions/src/jobAlertBackfillCore.js
+++ b/functions/src/jobAlertBackfillCore.js
@@ -50,11 +50,29 @@
  *     `job_category`/`job_location` at signup time. The derived patch is
  *     merged onto the subscriber doc (see `jobAlertBackfillTrigger.js`) so
  *     `buildAlertProfile` benefits from it immediately, not just on the next
- *     manual enrichment pass.
+ *     manual enrichment pass. A patch carrying ONLY `job_search_query` (no
+ *     category/location resolved from it) still counts — `buildAlertProfile`
+ *     (services/jobAlertMatching.mjs) actively folds it into soft keyword
+ *     tokens, it's not write-only data.
+ *  4. `url-fallback` — weakest tier, tried only when tier 3 also finds
+ *     nothing: derive a canton from `consent_source_url`/`source_page` when
+ *     it points at a single-canton job-board page (`/cerca-lavoro-ticino/…`,
+ *     `/fr/trouver-emploi-valais/…`). Live (2026-07-03): 151 of the 523
+ *     remaining no-signal subscribers landed on exactly such a page — signup
+ *     happened via a generic channel (auth popup, newsletter box) on top of
+ *     a job listing, so the canton is right there in the URL and never made
+ *     it into a flat field. Written as a bare lowercase 2-letter code
+ *     (`location_interest: 'ti'`), the shape `buildAlertProfile` already
+ *     recognizes as a canton via its own `SWISS_CANTONS` check — a soft
+ *     ranking signal like tier 2, never a hard `cantonFilter`. Half-canton
+ *     URL groups (`jobs-im-tessin`'s siblings `APPENZELLO`/`BASILEA`) and the
+ *     Switzerland-wide aggregator are deliberately skipped as too ambiguous
+ *     or too broad — see `lib/jobBoardUrlCanton.js`.
  */
 
 import { isNewsletterExcluded } from './lib/emailSuppression.js';
 import { derivePersonalizationPatch } from './lib/subscriberPersonalization.js';
+import { deriveCantonFromJobBoardUrl } from './lib/jobBoardUrlCanton.js';
 
 export const MAX_ALERTS_PER_USER = 3; // services/jobAlertService.ts:68
 export const ALERT_ID = 'backfill-newsletter';
@@ -92,26 +110,52 @@ export function getSignalTier(data) {
  * @returns {boolean}
  */
 export function signalTierChanged(beforeData, afterData) {
-  const beforeTier = beforeData ? getSignalTier(beforeData) : 'none';
-  return getSignalTier(afterData) !== beforeTier;
+  const beforeTier = beforeData ? getCheapSignalTier(beforeData) : 'none';
+  return getCheapSignalTier(afterData) !== beforeTier;
 }
 
 /**
- * Tier resolution with the 3rd, weaker fallback layered on top of
- * `getSignalTier`: when the flat fields carry nothing, derive one from the
- * `private/personalization` subdoc. Returns the patch too so callers can
- * merge it onto the subscriber doc — see tier-3 rationale in the file header.
+ * Tiers 1/2/4 — everything resolvable WITHOUT a `private/personalization`
+ * read (tier 3 needs that subdoc, fetched separately, see
+ * `backfillJobAlertOnPersonalizationSync`). Used only to gate the flat-doc
+ * write trigger cheaply; never for tier SELECTION — `resolveSignalTier`
+ * below keeps tier 3 (personalization, richer signal) checked ahead of
+ * tier 4 (URL, weaker) regardless of what this function returns.
+ * @param {Record<string, unknown>|null|undefined} data
+ * @returns {'signal'|'location-fallback'|'url-fallback'|'none'}
+ */
+function getCheapSignalTier(data) {
+  const tier = getSignalTier(data);
+  if (tier !== 'none') return tier;
+  return deriveCantonFromJobBoardUrl(data?.consent_source_url) || deriveCantonFromJobBoardUrl(data?.source_page)
+    ? 'url-fallback'
+    : 'none';
+}
+
+/**
+ * Tier resolution with the weaker fallbacks layered on top of
+ * `getSignalTier`: when the flat fields carry nothing, try the
+ * `private/personalization` subdoc (tier 3), then the job-board URL the
+ * subscriber landed on (tier 4). Returns the patch too so callers can merge
+ * it onto the subscriber doc — see tier rationale in the file header.
  * @param {Record<string, unknown>|null|undefined} data
  * @param {Record<string, unknown>|null|undefined} [personalization]
- * @returns {{tier: 'signal'|'location-fallback'|'personalization-fallback'|'none', patch: Record<string, string>|null}}
+ * @returns {{tier: 'signal'|'location-fallback'|'personalization-fallback'|'url-fallback'|'none', patch: Record<string, string>|null}}
  */
 export function resolveSignalTier(data, personalization) {
   const tier = getSignalTier(data);
   if (tier !== 'none') return { tier, patch: null };
+
   const patch = derivePersonalizationPatch({ subscriber: data, personalization, alerts: [] });
-  if (patch && (patch.job_category || patch.location_interest || patch.geo_city)) {
+  if (patch && (patch.job_category || patch.location_interest || patch.geo_city || patch.job_search_query)) {
     return { tier: 'personalization-fallback', patch };
   }
+
+  const urlCanton = deriveCantonFromJobBoardUrl(data?.consent_source_url) || deriveCantonFromJobBoardUrl(data?.source_page);
+  if (urlCanton) {
+    return { tier: 'url-fallback', patch: { location_interest: urlCanton } };
+  }
+
   return { tier: 'none', patch: null };
 }
 
@@ -145,7 +189,10 @@ export function shouldSkipSubscriber(email, data, personalization = null) {
 export function buildAlertPayload(email, data, existingBackfill, personalization = null) {
   const { tier } = resolveSignalTier(data, personalization);
   const channel = data?.source_channel || 'unknown';
-  const tierSuffix = tier === 'location-fallback' || tier === 'personalization-fallback' ? `:${tier}` : '';
+  const tierSuffix =
+    tier === 'location-fallback' || tier === 'personalization-fallback' || tier === 'url-fallback'
+      ? `:${tier}`
+      : '';
   return {
     email,
     userId: data?.user_id || null,

--- a/functions/src/lib/cantonUrlSlugs.json
+++ b/functions/src/lib/cantonUrlSlugs.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Source of truth: canton code -> URL-safe slug per locale. ASCII anglicized for non-IT locales; Italian-native for IT. Slugs are lowercase, hyphen-separated, ASCII-only (no umlauts/diacritics). NOTE (2026-05-10): half-cantons AI+AR merged into URL group APPENZELLO; BL+BS merged into URL group BASILEA. The `cantons` table contains the 22 single cantons + the 2 virtual groups (24 entries total). The `cantonGroups` table records group membership so internal BFS/quorum logic can keep using AI/AR/BL/BS while URL emission and per-canton shards collapse onto the group code. Use resolveCantonGroup() to map a real canton code to its URL key. NOTE (2026-05-10): German preposition override via `dePrefix` for cantons whose name takes a definite article in German (im Aargau, im Thurgau, im Jura, im Wallis, in der Waadt). TI keeps frozen `jobs-im-tessin` via legacy router branch.",
+  "_lastUpdated": "2026-05-10",
+  "_syncNote": "Verbatim copy of ../../../data/canton-url-slugs.json — functions/ has no bundler and cannot import outside its own dir at deploy time (firebase.json source:\"functions\"), so this JSON is duplicated here. Parity enforced by tests/canton-url-slugs-parity.test.ts — keep both files identical.",
+  "cantons": {
+    "AG": {"it": "argovia",             "en": "aargau",              "de": "aargau",              "fr": "argovie",             "dePrefix": "jobs-im-"},
+    "APPENZELLO": {"it": "appenzello",  "en": "appenzell",           "de": "appenzell",           "fr": "appenzell"},
+    "BE": {"it": "berna",               "en": "bern",                "de": "bern",                "fr": "berne"},
+    "BASILEA": {"it": "basilea",        "en": "basel",               "de": "basel",               "fr": "bale"},
+    "FR": {"it": "friburgo",            "en": "fribourg",            "de": "freiburg",            "fr": "fribourg"},
+    "GE": {"it": "ginevra",             "en": "geneva",              "de": "genf",                "fr": "geneve"},
+    "GL": {"it": "glarona",             "en": "glarus",              "de": "glarus",              "fr": "glaris"},
+    "GR": {"it": "grigioni",            "en": "graubunden",          "de": "graubunden",          "fr": "grisons"},
+    "JU": {"it": "giura",               "en": "jura",                "de": "jura",                "fr": "jura",                "dePrefix": "jobs-im-"},
+    "LU": {"it": "lucerna",             "en": "lucerne",             "de": "luzern",              "fr": "lucerne"},
+    "NE": {"it": "neuchatel",           "en": "neuchatel",           "de": "neuenburg",           "fr": "neuchatel"},
+    "NW": {"it": "nidvaldo",            "en": "nidwalden",           "de": "nidwalden",           "fr": "nidwald"},
+    "OW": {"it": "obvaldo",             "en": "obwalden",            "de": "obwalden",            "fr": "obwald"},
+    "SG": {"it": "san-gallo",           "en": "st-gallen",           "de": "st-gallen",           "fr": "saint-gall"},
+    "SH": {"it": "sciaffusa",           "en": "schaffhausen",        "de": "schaffhausen",        "fr": "schaffhouse"},
+    "SO": {"it": "soletta",             "en": "solothurn",           "de": "solothurn",           "fr": "soleure"},
+    "SZ": {"it": "svitto",              "en": "schwyz",              "de": "schwyz",              "fr": "schwytz"},
+    "TG": {"it": "turgovia",            "en": "thurgau",             "de": "thurgau",             "fr": "thurgovie",           "dePrefix": "jobs-im-"},
+    "TI": {"it": "ticino",              "en": "ticino",              "de": "tessin",              "fr": "tessin"},
+    "UR": {"it": "uri",                 "en": "uri",                 "de": "uri",                 "fr": "uri"},
+    "VD": {"it": "vaud",                "en": "vaud",                "de": "waadt",               "fr": "vaud",                "dePrefix": "jobs-in-der-"},
+    "VS": {"it": "vallese",             "en": "valais",              "de": "wallis",              "fr": "valais",              "dePrefix": "jobs-im-"},
+    "ZG": {"it": "zugo",                "en": "zug",                 "de": "zug",                 "fr": "zoug"},
+    "ZH": {"it": "zurigo",              "en": "zurich",              "de": "zurich",              "fr": "zurich"}
+  },
+  "cantonGroups": {
+    "APPENZELLO": {"members": ["AI", "AR"]},
+    "BASILEA":    {"members": ["BL", "BS"]}
+  },
+  "aggregate": {"it": "svizzera", "en": "switzerland", "de": "schweiz", "fr": "suisse"}
+}

--- a/functions/src/lib/jobBoardUrlCanton.js
+++ b/functions/src/lib/jobBoardUrlCanton.js
@@ -1,0 +1,89 @@
+/**
+ * Derive a canton code from a job-board URL a subscriber landed on
+ * (`consent_source_url`/`source_page` on `newsletter_subscribers/{email}`).
+ * Ported from `services/router.ts` (`parseJobBoardSlug`, `JOB_BOARD_PREFIX`)
+ * since Cloud Functions have no bundler and cannot import that TS module —
+ * see `cantonUrlSlugs.json` for the shared-data duplication note.
+ *
+ * Deliberately conservative: only resolves single-canton job-board URLs.
+ * The Switzerland-wide aggregator (`cerca-lavoro-svizzera` etc.) and the
+ * half-canton URL groups (`APPENZELLO`, `BASILEA` — real member canton
+ * AI/AR or BL/BS can't be told apart from the URL alone) return `null`
+ * rather than a signal too broad or ambiguous to act on.
+ */
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+/** @type {{cantons: Record<string, {it: string, en: string, de: string, fr: string, dePrefix?: string}>}} */
+const CANTON_URL_SLUGS = require('./cantonUrlSlugs.json');
+
+const JOB_BOARD_PREFIX = {
+  it: 'cerca-lavoro-',
+  en: 'find-jobs-',
+  de: 'jobs-in-',
+  fr: 'trouver-emploi-',
+};
+const JOB_BOARD_PREFIX_LEGACY_DE = 'jobs-im-'; // legacy TI-only, e.g. jobs-im-tessin
+
+const AMBIGUOUS_GROUP_CODES = new Set(['APPENZELLO', 'BASILEA']);
+
+/**
+ * @param {string} pathSegment  first non-locale path segment, e.g. `cerca-lavoro-ticino`
+ * @param {'it'|'en'|'de'|'fr'} locale
+ * @returns {string|null}  2-letter canton code, or null if unresolved/ambiguous
+ */
+function parseJobBoardSegment(pathSegment, locale) {
+  if (!pathSegment) return null;
+
+  if (locale === 'de' && pathSegment === `${JOB_BOARD_PREFIX_LEGACY_DE}tessin`) {
+    return 'TI';
+  }
+
+  if (locale === 'de') {
+    for (const [code, record] of Object.entries(CANTON_URL_SLUGS.cantons)) {
+      if (record.dePrefix && pathSegment === `${record.dePrefix}${record.de}`) {
+        return AMBIGUOUS_GROUP_CODES.has(code) ? null : code;
+      }
+    }
+  }
+
+  const prefix = JOB_BOARD_PREFIX[locale];
+  if (!pathSegment.startsWith(prefix)) return null;
+  const tail = pathSegment.slice(prefix.length);
+  if (!tail) return null;
+
+  for (const [code, record] of Object.entries(CANTON_URL_SLUGS.cantons)) {
+    if (record[locale] === tail) {
+      return AMBIGUOUS_GROUP_CODES.has(code) ? null : code;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {string|null|undefined} url  absolute URL or path, e.g.
+ *   `https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/` or
+ *   `/fr/trouver-emploi-valais/some-job/`
+ * @returns {string|null}  lowercase 2-letter canton code (e.g. `'ti'`), or null
+ */
+export function deriveCantonFromJobBoardUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+
+  let pathname;
+  try {
+    pathname = new URL(url, 'https://frontaliereticino.ch').pathname;
+  } catch {
+    return null;
+  }
+
+  const segments = pathname.split('/').filter(Boolean);
+  if (!segments.length) return null;
+
+  const locale = ['en', 'de', 'fr'].includes(segments[0]) ? segments[0] : 'it';
+  const boardSegment = locale === 'it' ? segments[0] : segments[1];
+
+  const cantonCode = parseJobBoardSegment(boardSegment, locale);
+  return cantonCode ? cantonCode.toLowerCase() : null;
+}

--- a/tests/canton-url-slugs-parity.test.ts
+++ b/tests/canton-url-slugs-parity.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Drift guard for the canton URL slug table.
+ *
+ * data/canton-url-slugs.json is canonical (services/router.ts reads it).
+ * functions/src/lib/cantonUrlSlugs.json is a verbatim duplicate — Cloud
+ * Functions have no bundler and cannot import outside functions/ at deploy
+ * time (firebase.json source:"functions") — see the _syncNote in that file
+ * and functions/src/lib/jobBoardUrlCanton.js. This test locks the two
+ * copies together so they can never drift silently.
+ */
+import { describe, it, expect } from 'vitest';
+
+import canonical from '../data/canton-url-slugs.json';
+import duplicate from '../functions/src/lib/cantonUrlSlugs.json';
+
+describe('canton-url-slugs.json parity (functions/ duplicate === canonical)', () => {
+  it('cantons table matches', () => {
+    expect(duplicate.cantons).toEqual(canonical.cantons);
+  });
+
+  it('cantonGroups table matches', () => {
+    expect(duplicate.cantonGroups).toEqual(canonical.cantonGroups);
+  });
+
+  it('aggregate slugs match', () => {
+    expect(duplicate.aggregate).toEqual(canonical.aggregate);
+  });
+});

--- a/tests/job-alert-backfill-trigger.test.ts
+++ b/tests/job-alert-backfill-trigger.test.ts
@@ -238,4 +238,104 @@ describe('handleNewsletterSubscriberCreated — tier-3 personalization fallback'
     expect(result.created).toBe(false);
     expect(result.reason).toBe('no-signal');
   });
+
+  it('derives personalization-fallback from a bare search query with no viewed jobs', () => {
+    const result = resolveSignalTier({}, { searches: [{ query: 'infermiera', ts: 1 }] });
+    expect(result.tier).toBe('personalization-fallback');
+    expect(result.patch).toEqual({ job_search_query: 'infermiera' });
+  });
+});
+
+describe('resolveSignalTier — tier-4 URL fallback', () => {
+  it('derives a canton from an Italian job-board consent URL', () => {
+    const result = resolveSignalTier({ consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' }, null);
+    expect(result).toEqual({ tier: 'url-fallback', patch: { location_interest: 'ti' } });
+  });
+
+  it('derives a canton from a French locale-prefixed source_page path', () => {
+    const result = resolveSignalTier({ source_page: '/fr/trouver-emploi-valais/some-job/' }, null);
+    expect(result).toEqual({ tier: 'url-fallback', patch: { location_interest: 'vs' } });
+  });
+
+  it('falls back to source_page when consent_source_url resolves nothing', () => {
+    const result = resolveSignalTier(
+      { consent_source_url: 'https://frontaliereticino.ch/', source_page: '/cerca-lavoro-ticino/some-job/' },
+      null,
+    );
+    expect(result).toEqual({ tier: 'url-fallback', patch: { location_interest: 'ti' } });
+  });
+
+  it('prefers tier-3 personalization over tier-4 URL when both are available', () => {
+    const result = resolveSignalTier(
+      { consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' },
+      { viewedJobs: [{ location: 'Mendrisio', category: 'IT / Tecnologia' }] },
+    );
+    expect(result.tier).toBe('personalization-fallback');
+  });
+
+  it('stays none for the Switzerland-wide aggregator URL', () => {
+    const result = resolveSignalTier({ consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-svizzera/' }, null);
+    expect(result).toEqual({ tier: 'none', patch: null });
+  });
+
+  it('stays none for an ambiguous half-canton group URL', () => {
+    const result = resolveSignalTier({ consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-basilea/' }, null);
+    expect(result).toEqual({ tier: 'none', patch: null });
+  });
+
+  it('stays none when the URL is not a job-board page', () => {
+    const result = resolveSignalTier({ consent_source_url: 'https://frontaliereticino.ch/blog/some-article/' }, null);
+    expect(result).toEqual({ tier: 'none', patch: null });
+  });
+});
+
+describe('signalTierChanged — tier-4 URL awareness', () => {
+  it('is true on doc creation when the doc only carries a job-board consent URL', () => {
+    const after = { consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' };
+    expect(signalTierChanged(null, after)).toBe(true);
+  });
+
+  it('is false when a non-job-board URL is added (no eligibility flip)', () => {
+    const before = {};
+    const after = { consent_source_url: 'https://frontaliereticino.ch/blog/some-article/' };
+    expect(signalTierChanged(before, after)).toBe(false);
+  });
+
+  it('is false for an unrelated field update once the URL tier is already settled', () => {
+    const before = { consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/', opens: 3 };
+    const after = { consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/', opens: 4 };
+    expect(signalTierChanged(before, after)).toBe(false);
+  });
+
+  it('is true when tier upgrades from url-fallback to signal', () => {
+    const before = { consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' };
+    const after = { ...before, job_category: 'tech' };
+    expect(signalTierChanged(before, after)).toBe(true);
+  });
+});
+
+describe('handleNewsletterSubscriberCreated — tier-4 URL fallback', () => {
+  it('creates a url-fallback alert from a job-board consent URL with no other signal', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated(
+      'a@b.ch',
+      { source_channel: 'popup', consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' },
+      { db: db as any },
+    );
+    expect(result.created).toBe(true);
+    expect(result.tier).toBe('newsletter_subscribers:popup:url-fallback');
+    const parentWrite = db.writes.find((w) => w.path === 'job_alert_subscribers/a@b.ch');
+    expect(parentWrite?.payload).toMatchObject({ location_interest: 'ti' });
+  });
+
+  it('does not derive url-fallback from a non-job-board URL', async () => {
+    const db = fakeDb();
+    const result = await handleNewsletterSubscriberCreated(
+      'a@b.ch',
+      { source_channel: 'popup', consent_source_url: 'https://frontaliereticino.ch/blog/some-article/' },
+      { db: db as any },
+    );
+    expect(result.created).toBe(false);
+    expect(result.reason).toBe('no-signal');
+  });
 });

--- a/tests/job-board-url-canton.test.ts
+++ b/tests/job-board-url-canton.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCantonFromJobBoardUrl } from '../functions/src/lib/jobBoardUrlCanton.js';
+
+describe('deriveCantonFromJobBoardUrl', () => {
+  it('resolves an Italian (default locale, no prefix segment) job-board URL', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/')).toBe('ti');
+  });
+
+  it('resolves an English locale-prefixed job-board URL', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/en/find-jobs-geneva/some-job/')).toBe('ge');
+  });
+
+  it('resolves a French locale-prefixed job-board URL', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/fr/trouver-emploi-vaud/some-job/')).toBe('vd');
+  });
+
+  it('resolves the legacy German jobs-im-tessin URL (TI frozen exception)', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/de/jobs-im-tessin/some-job/')).toBe('ti');
+  });
+
+  it('resolves a German dePrefix canton (Aargau: im Aargau)', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/de/jobs-im-aargau/some-job/')).toBe('ag');
+  });
+
+  it('resolves a German dePrefix canton with a different preposition (Waadt: in der Waadt)', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/de/jobs-in-der-waadt/some-job/')).toBe('vd');
+  });
+
+  it('resolves a plain German job-board URL without dePrefix (Zurich)', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/de/jobs-in-zurich/some-job/')).toBe('zh');
+  });
+
+  it('accepts a relative path with no origin', () => {
+    expect(deriveCantonFromJobBoardUrl('/cerca-lavoro-ticino/some-job/')).toBe('ti');
+  });
+
+  it('returns null for the Switzerland-wide aggregator', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/cerca-lavoro-svizzera/')).toBeNull();
+  });
+
+  it('returns null for the ambiguous APPENZELLO group URL', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/cerca-lavoro-appenzello/')).toBeNull();
+  });
+
+  it('returns null for the ambiguous BASILEA group URL', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/cerca-lavoro-basilea/')).toBeNull();
+  });
+
+  it('returns null for a non-job-board page', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/blog/some-article/')).toBeNull();
+  });
+
+  it('returns null for the bare job-board prefix with no canton tail', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/cerca-lavoro-/')).toBeNull();
+  });
+
+  it('returns null for a malformed URL', () => {
+    expect(deriveCantonFromJobBoardUrl('not a url at all: ///')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(deriveCantonFromJobBoardUrl(null)).toBeNull();
+    expect(deriveCantonFromJobBoardUrl(undefined)).toBeNull();
+    expect(deriveCantonFromJobBoardUrl('')).toBeNull();
+  });
+
+  it('returns null for a root path with no segments', () => {
+    expect(deriveCantonFromJobBoardUrl('https://frontaliereticino.ch/')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Implementato

- New tier-4 signal fallback: `functions/src/lib/jobBoardUrlCanton.js` exports `deriveCantonFromJobBoardUrl(url)`, which derives a canton code from `consent_source_url`/`source_page` when it points at a single-canton job-board URL (`/cerca-lavoro-ticino/…`, `/fr/trouver-emploi-valais/…`, legacy `/de/jobs-im-tessin/…`, dePrefix cantons like `/de/jobs-im-aargau/`). Ported from `services/router.ts`'s `parseJobBoardSlug`/`JOB_BOARD_PREFIX` since `functions/` has no bundler and cannot import outside its own directory.
- `functions/src/lib/cantonUrlSlugs.json` — verbatim duplicate of `data/canton-url-slugs.json` (same no-bundler constraint), with a parity test (`tests/canton-url-slugs-parity.test.ts`) locking the two together so they can't drift.
- `functions/src/jobAlertBackfillCore.js`: `resolveSignalTier` now tries tier-4 (URL) after tiers 1/2/3, writing a soft `location_interest` (never a hard `cantonFilter`, same precedent as tier 2). Half-canton ambiguous groups (APPENZELLO/BASILEA) and the Switzerland-wide aggregator are deliberately skipped as unresolvable/too broad.
- Widened tier-3 (`personalization-fallback`) to also accept a patch containing ONLY `job_search_query` — previously required `job_category`/`location_interest`/`geo_city` too, silently dropping subscribers whose only derivable signal was a search query, even though `buildAlertProfile` (`services/jobAlertMatching.mjs`) already actively consumes `job_search_query` into soft keyword tokens.
- **Applied live at subscription time**, not just in the batch backfill: added `getCheapSignalTier` (tiers 1/2/4, zero-read) and rewired `signalTierChanged` — the cheap pre-filter gate on the real-time `onDocumentWritten` trigger — to use it, so a brand-new subscriber whose only signal is the job-board URL they landed on now actually reaches `resolveSignalTier` at signup, instead of being filtered out before the trigger's real logic ever runs. Kept as a separate function from `getSignalTier` (which stays tiers-1/2-only) specifically to avoid a priority-inversion bug where the weaker URL tier could preempt the richer personalization tier inside `resolveSignalTier`'s own branching, which is untouched by the gate.
- `scripts/backfill-jobalerts-from-newsletter.mjs` and its shim (`scripts/lib/jobalert-backfill-core.mjs`) need zero changes — they call the same shared `resolveSignalTier`/`shouldSkipSubscriber`/`buildAlertPayload` functions, so the batch path inherits tier-4 + the widened tier-3 automatically.
- Tests: `tests/job-board-url-canton.test.ts` (16 cases: all 4 locales, legacy DE, dePrefix cantons, ambiguous-group skip, aggregator skip, malformed/relative/root URLs), new `describe` blocks in `tests/job-alert-backfill-trigger.test.ts` covering `resolveSignalTier`'s tier-4 + widened tier-3, `signalTierChanged`'s URL-awareness, and an end-to-end `handleNewsletterSubscriberCreated` case. All affected suites green locally (`job-alert-backfill-trigger`, `job-board-url-canton`, `canton-url-slugs-parity`, `backfill-jobalerts-from-newsletter` — 121 tests, 0 failures).

## Non implementato (ancora)

Nessuno.