### PR TITLE
fix(job-alerts): batch backfill re-checks tier-3 before tier-4 URL fallback

### DIFF
--- a/scripts/backfill-jobalerts-from-newsletter.mjs
+++ b/scripts/backfill-jobalerts-from-newsletter.mjs
@@ -31,7 +31,13 @@
  * data either, but it's a correct zero-cost catch-all. A 3rd tier derives
  * signal from the `private/personalization` subcollection (`viewedJobs[]`,
  * `filterUsage`) for subscribers still unresolved after tiers 1/2 — read
- * lazily, only for the `no-signal` remainder, via `resolveSignalTier`.
+ * lazily, gated on `getSignalTier` (tiers 1/2 only, NOT the 4th URL
+ * fallback below — a job-board URL alone must never skip this read, since
+ * `resolveSignalTier` prefers the richer tier-3 signal over tier 4 when
+ * both are available). A 4th tier derives a canton from the job-board URL
+ * the subscriber landed on (`consent_source_url`/`source_page`) when tiers
+ * 1/2/3 all found nothing — see `jobAlertBackfillCore.js` for the full
+ * tier rationale.
  *
  * The backfilled alert is deliberately near-empty (`keywords: []`,
  * `locations: []`, `cantonFilter: null`): `buildAlertProfile`
@@ -61,6 +67,7 @@ import {
   MAX_ALERTS_PER_USER,
   ALERT_ID,
   normalizeEmail,
+  getSignalTier,
   shouldSkipSubscriber,
   buildAlertPayload,
   resolveSignalTier,
@@ -68,7 +75,15 @@ import {
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
-export { MAX_ALERTS_PER_USER, ALERT_ID, normalizeEmail, shouldSkipSubscriber, buildAlertPayload, resolveSignalTier };
+export {
+  MAX_ALERTS_PER_USER,
+  ALERT_ID,
+  normalizeEmail,
+  getSignalTier,
+  shouldSkipSubscriber,
+  buildAlertPayload,
+  resolveSignalTier,
+};
 
 let _db = null;
 async function getFirestoreAdmin() {
@@ -104,13 +119,18 @@ async function main() {
     const channel = data.source_channel || 'unknown';
     byChannel[channel] = byChannel[channel] || { created: 0, skipped: 0 };
 
-    let skipReason = shouldSkipSubscriber(email, data);
     // Lazy tier-3 lookup: only pay for the extra `private/personalization`
-    // read when the flat fields alone resolve nothing — cheap for the
-    // majority who already carry job_category/location_interest, an extra
-    // read only for the "no-signal" remainder (see resolveSignalTier).
+    // read when tiers 1/2 (flat job_category/location_interest/geo_city)
+    // alone resolve nothing — cheap for the majority who already carry
+    // those fields. Gated on `getSignalTier` (tiers 1/2 ONLY), not on
+    // `shouldSkipSubscriber`/`resolveSignalTier` — those also resolve tier
+    // 4 (URL) from the same flat data, and tier 4 alone finding a canton
+    // must never skip this read: resolveSignalTier checks tier 3 before
+    // tier 4, so a subscriber with both a job-board URL AND real browsing
+    // data (job_category/sector, not just canton) deserves the richer
+    // signal, not just whatever tier 4 found first.
     let personalization = null;
-    if (skipReason === 'no-signal') {
+    if (getSignalTier(data) === 'none') {
       const personalizationSnap = await db
         .collection('newsletter_subscribers')
         .doc(email)
@@ -119,9 +139,9 @@ async function main() {
         .get();
       if (personalizationSnap.exists) {
         personalization = personalizationSnap.data();
-        skipReason = shouldSkipSubscriber(email, data, personalization);
       }
     }
+    const skipReason = shouldSkipSubscriber(email, data, personalization);
     if (skipReason) {
       counts[skipReason]++;
       byChannel[channel].skipped++;

--- a/tests/backfill-jobalerts-from-newsletter.test.ts
+++ b/tests/backfill-jobalerts-from-newsletter.test.ts
@@ -2,11 +2,28 @@ import { describe, expect, it } from 'vitest';
 import {
   ALERT_ID,
   buildAlertPayload,
+  getSignalTier,
   MAX_ALERTS_PER_USER,
   normalizeEmail,
   resolveSignalTier,
   shouldSkipSubscriber,
 } from '../scripts/backfill-jobalerts-from-newsletter.mjs';
+
+describe('backfill-jobalerts-from-newsletter — getSignalTier stays URL-blind', () => {
+  // main()'s lazy `private/personalization` fetch is gated on
+  // `getSignalTier(data) === 'none'`, NOT on `shouldSkipSubscriber`/
+  // `resolveSignalTier` — those also resolve the URL-derived tier 4 from
+  // the same flat data, and tier 4 finding a canton must never skip the
+  // read: a subscriber landing on a job-board page may ALSO have richer
+  // tier-3 browsing data (job_category/sector, not just canton), which
+  // resolveSignalTier is supposed to prefer over tier 4 — but only gets
+  // the chance to if the caller actually fetches personalization first.
+  it('is "none" for a subscriber whose only signal is a job-board consent URL', () => {
+    expect(getSignalTier({ consent_source_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/some-job/' })).toBe(
+      'none',
+    );
+  });
+});
 
 describe('backfill-jobalerts-from-newsletter — shouldSkipSubscriber', () => {
   it('is eligible when job_category is present', () => {


### PR DESCRIPTION
## Implementato
- Bug fix in `scripts/backfill-jobalerts-from-newsletter.mjs`: the lazy `private/personalization` read was gated on `shouldSkipSubscriber(...)`/`resolveSignalTier(...)`'s result, but that result already resolves tier 4 (URL-derived canton, from flat fields only). Any subscriber with a job-board consent URL (`consent_source_url`/`source_page`) immediately resolved as `'url-fallback'`, so the `if` gate for reading personalization never fired for them — silently skipping a read that would often have found richer tier-3 signal (`job_category`/sector from `viewedJobs`/`filterUsage`).
- Fix: gate the lazy read on `getSignalTier(data) === 'none'` instead — tiers 1/2 only, URL-blind by construction — guaranteeing personalization is always consulted before tier 4 is allowed to "win," matching `resolveSignalTier`'s existing internal tier-3-over-tier-4 priority (`functions/src/jobAlertBackfillCore.js`, unchanged by this PR).
- Confirmed the live `onDocumentWritten` trigger paths in `functions/index.js` do NOT share this bug: `backfillJobAlertOnNewsletterSignup` never uses personalization by original design (out of scope for that trigger), and `backfillJobAlertOnPersonalizationSync` already gates on the unaffected `getSignalTier` (tiers 1/2 only) before proceeding. This fix is batch-script-only.
- New regression test in `tests/backfill-jobalerts-from-newsletter.test.ts`: `getSignalTier` stays `'none'` (URL-blind) for a subscriber whose only signal is a job-board consent URL.
- Re-ran the dry-run against live data with the fix: `personalization-fallback` rose 599 → 1769, `url-fallback` fell 1313 → 143 (subscribers correctly reclassified to the richer tier). Total eligible (4134) and no-signal (345) counts are unchanged — the bug affected *which* tier a subscriber lands in, not overall eligibility.

## Non implementato (ancora)
- Nothing outstanding — this is a scoped correctness fix for the batch script's lazy-read gating, verified against live data and covered by a regression test.