### PR TITLE
fix(journalist): aggregate link check into single result, not per-locale

### DIFF
--- a/components/pages/JournalistDashboardPage.tsx
+++ b/components/pages/JournalistDashboardPage.tsx
@@ -759,28 +759,18 @@ export default function JournalistDashboardPage(): React.ReactElement {
               <Link2 className="w-3.5 h-3.5" />
               {t('journalistDashboard.detail.linkCheckHeading')}
             </p>
-            <ul className="space-y-2 text-sm">
-              {ARTICLE_LOCALES.map((loc) => {
-                const check = openArticle.linkCheck?.[loc];
-                return (
-                  <li key={loc} className="flex items-start justify-between gap-2">
-                    <span className="text-muted shrink-0">{LOCALE_LABELS[loc]}</span>
-                    {check ? (
-                      <span className={`text-right ${check.brokenLinks ? 'text-danger' : 'text-success'}`}>
-                        {check.brokenLinks
-                          ? t('journalistDashboard.detail.linkCheck.broken', {
-                              broken: check.brokenLinks,
-                              total: check.totalLinks ?? 0,
-                            })
-                          : t('journalistDashboard.detail.linkCheck.ok', { total: check.totalLinks ?? 0 })}
-                      </span>
-                    ) : (
-                      <span className="text-muted">{t('journalistDashboard.detail.linkCheckUnavailable')}</span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
+            {openArticle.linkCheck ? (
+              <p className={`text-sm ${openArticle.linkCheck.brokenLinks ? 'text-danger' : 'text-success'}`}>
+                {openArticle.linkCheck.brokenLinks
+                  ? t('journalistDashboard.detail.linkCheck.broken', {
+                      broken: openArticle.linkCheck.brokenLinks,
+                      total: openArticle.linkCheck.totalLinks ?? 0,
+                    })
+                  : t('journalistDashboard.detail.linkCheck.ok', { total: openArticle.linkCheck.totalLinks ?? 0 })}
+              </p>
+            ) : (
+              <p className="text-sm text-muted">{t('journalistDashboard.detail.linkCheckUnavailable')}</p>
+            )}
           </div>
         </div>
       )}

--- a/scripts/check-journalist-article-links.mjs
+++ b/scripts/check-journalist-article-links.mjs
@@ -12,6 +12,12 @@
  * and writes the result back onto the doc so the dashboard can surface
  * "3 broken links" without a human re-checking manually.
  *
+ * Result is a SINGLE aggregate across all locale pages, not one per locale
+ * (was: `linkCheck.<locale>`). Each locale page carries the same site chrome
+ * (nav/footer/breadcrumb), so a per-locale breakdown mostly repeated the same
+ * count 4x with no editorial signal — the redazione just needs one
+ * "N link, M broken" figure for the article.
+ *
  * Best-effort at every level: a network hiccup on one locale must not abort
  * the run, crash other docs, or block other locales of the same doc.
  *
@@ -120,17 +126,34 @@ async function processDoc(db, docSnap) {
   }
 
   console.log(`\n🔗 Checking links for journalist_articles/${docId} (${locales.length} locale(s))...`);
+  let totalLinks = 0;
+  let brokenLinks = 0;
+  const brokenUrls = [];
+  let localesChecked = 0;
   for (const locale of locales) {
     const url = publishedUrls[locale];
     try {
       const result = await checkPageLinks(url);
-      await docSnap.ref.update({ [`linkCheck.${locale}`]: result });
-      console.log(`  ${result.brokenLinks > 0 ? '⚠️ ' : '✅'} ${locale}: ${result.totalLinks} link(s), ${result.brokenLinks} broken`);
+      totalLinks += result.totalLinks;
+      brokenLinks += result.brokenLinks;
+      for (const brokenUrl of result.brokenUrls) {
+        if (brokenUrls.length < MAX_BROKEN_URLS_STORED) brokenUrls.push(brokenUrl);
+      }
+      localesChecked += 1;
     } catch (err) {
       // Best-effort per locale: log and move on, never abort the doc or the run.
       console.warn(`  ⚠️  ${docId}/${locale}: link check failed (non-fatal): ${err.message}`);
     }
   }
+
+  if (!localesChecked) {
+    console.warn(`  ⚠️  ${docId}: all locale link checks failed — leaving previous linkCheck untouched.`);
+    return;
+  }
+
+  const aggregate = { checkedAt: new Date().toISOString(), totalLinks, brokenLinks, brokenUrls, localesChecked };
+  await docSnap.ref.update({ linkCheck: aggregate });
+  console.log(`  ${brokenLinks > 0 ? '⚠️ ' : '✅'} ${totalLinks} link(s) across ${localesChecked} locale(s), ${brokenLinks} broken`);
 }
 
 async function main() {

--- a/services/journalistTypes.ts
+++ b/services/journalistTypes.ts
@@ -49,6 +49,8 @@ export interface JournalistArticleLinkCheckResult {
   totalLinks?: number;
   brokenLinks?: number;
   brokenUrls?: string[];
+  /** Number of locale pages that contributed to the aggregate above. */
+  localesChecked?: number;
 }
 
 export interface JournalistArticle {
@@ -83,7 +85,10 @@ export interface JournalistArticle {
   /** Set when status === 'failed'; cleared on successful resubmission. */
   errorMessage?: string;
   analytics?: JournalistArticleAnalytics;
-  linkCheck?: Partial<Record<ArticleLocale, JournalistArticleLinkCheckResult>>;
+  /** Aggregated across all published locale pages — not per-locale, since the
+   *  same-origin link set is dominated by shared site chrome (nav/footer)
+   *  that repeats per locale prefix, not editorial differences. */
+  linkCheck?: JournalistArticleLinkCheckResult;
 }
 
 export const JOURNALIST_STATUS_PILL: Record<JournalistArticleStatus, { label: string; color: string }> = {

--- a/tests/check-journalist-article-links-ordering.test.ts
+++ b/tests/check-journalist-article-links-ordering.test.ts
@@ -60,7 +60,7 @@ describe('processDoc — live gate (issue #3209 item 2 follow-up)', () => {
     expect(fetchSpy).toHaveBeenCalled();
     expect(docSnap.ref.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        'linkCheck.it': expect.objectContaining({ totalLinks: 0, brokenLinks: 0 }),
+        linkCheck: expect.objectContaining({ totalLinks: 0, brokenLinks: 0, localesChecked: 1 }),
       }),
     );
   });


### PR DESCRIPTION
## Implementato
- `scripts/check-journalist-article-links.mjs`: `processDoc()` now aggregates the per-locale link checks (total/broken/urls, capped at `MAX_BROKEN_URLS_STORED`) into ONE `linkCheck` write per doc instead of `linkCheck.<locale>` x4.
- `services/journalistTypes.ts`: `JournalistArticle.linkCheck` type changed from `Partial<Record<ArticleLocale, JournalistArticleLinkCheckResult>>` to a single `JournalistArticleLinkCheckResult`; added `localesChecked` to the result shape.
- `components/pages/JournalistDashboardPage.tsx`: dashboard "Controllo link" panel now renders one line ("N link, M rotti") instead of 4 identical per-locale rows.
- `tests/check-journalist-article-links-ordering.test.ts`: updated assertion to the new aggregate write shape.

Rationale: the per-locale breakdown was checking the whole live page (nav/footer/breadcrumb included, not just article body), so the count was dominated by shared site chrome that repeats identically across every locale — 4 rows showing "12 link, tutti funzionanti" carried no editorial signal for the redazione. One aggregate number is what's actually actionable.

Cron interval is 15min (`publish-journalist-articles.yml`), so any doc still holding the old per-locale shape self-heals on the next run — no backfill needed.

## Non implementato (ancora)
Nessuno.