### PR TITLE
fix(crawlers): canton-level address gate leaks HQ street/postal cross-city

### DIFF
--- a/scripts/lib/audemars-piguet-job-parser.mjs
+++ b/scripts/lib/audemars-piguet-job-parser.mjs
@@ -255,7 +255,7 @@ export async function fetchAllAudemarsPiguetJobs() {
       // ── Recommended fields ──
       addressLocality: city || location,
       addressRegion: region || canton,
-      postalCode: postalCode || (canton === HQ.canton ? HQ.postalCode : ''),
+      postalCode,
       addressCountry: 'CH',
       country: 'CH',
       category: detectCategory(title),

--- a/scripts/lib/beekeeper-job-parser.mjs
+++ b/scripts/lib/beekeeper-job-parser.mjs
@@ -139,10 +139,11 @@ function pickSwissAddress(jobPosting = {}) {
   const locations = Array.isArray(jobPosting.jobLocation) ? jobPosting.jobLocation : [];
   const chLoc = locations.find((loc) => loc?.address?.addressCountry === 'CH');
   const address = chLoc?.address || {};
+  const isHqCity = !address.addressLocality || /z[üu]rich/i.test(address.addressLocality);
   return {
     city: address.addressLocality || HQ.city,
-    postalCode: address.postalCode || HQ.postalCode,
-    streetAddress: address.streetAddress || HQ.streetAddress,
+    postalCode: address.postalCode || (isHqCity ? HQ.postalCode : ''),
+    streetAddress: address.streetAddress || (isHqCity ? HQ.streetAddress : ''),
   };
 }
 

--- a/scripts/lib/pallas-kliniken-job-parser.mjs
+++ b/scripts/lib/pallas-kliniken-job-parser.mjs
@@ -204,9 +204,13 @@ export async function fetchAllPallasKlinikenJobs() {
     const sourceLang = detectLang(description, 'de');
 
     const addr = ld.jobLocation?.address || {};
-    const city = normalizeSpace(decodeEntities(addr.addressLocality || '')) || HQ.city;
-    const postalCode = String(addr.postalCode || HQ.postalCode);
-    const streetAddress = normalizeSpace(decodeEntities(addr.streetAddress || HQ.streetAddress));
+    const rawCity = normalizeSpace(decodeEntities(addr.addressLocality || ''));
+    const city = rawCity || HQ.city;
+    const isHqCity = !rawCity || /olten/i.test(rawCity);
+    const postalCode = addr.postalCode ? String(addr.postalCode) : (isHqCity ? HQ.postalCode : '');
+    const streetAddress = addr.streetAddress
+      ? normalizeSpace(decodeEntities(addr.streetAddress))
+      : (isHqCity ? HQ.streetAddress : '');
     const canton = pickCanton(city);
 
     const datePosted = (ld.datePosted && /^\d{4}-\d{2}-\d{2}$/.test(ld.datePosted))

--- a/scripts/lib/straumann-job-parser.mjs
+++ b/scripts/lib/straumann-job-parser.mjs
@@ -325,7 +325,7 @@ export async function fetchAllStraumannJobs() {
       // ── Recommended fields ──
       addressLocality: location,
       addressRegion: canton,
-      postalCode: canton === HQ.canton ? HQ.postalCode : undefined,
+      postalCode: /basel/i.test(location) ? HQ.postalCode : undefined,
       addressCountry: 'CH',
       country: 'CH',
       category: listing.category || detectCategory(title),

--- a/scripts/lib/talan-job-parser.mjs
+++ b/scripts/lib/talan-job-parser.mjs
@@ -254,7 +254,7 @@ export async function fetchAllTalanJobs() {
       // ── Recommended fields ──
       addressLocality: city || location,
       addressRegion: region || canton,
-      postalCode: postalCode || (canton === HQ.canton ? HQ.postalCode : ''),
+      postalCode: postalCode || (/gen[eè]ve|geneva/i.test(location) ? HQ.postalCode : ''),
       addressCountry: 'CH',
       country: 'CH',
       category: detectCategory(title),

--- a/scripts/lib/thermo-fisher-scientific-job-parser.mjs
+++ b/scripts/lib/thermo-fisher-scientific-job-parser.mjs
@@ -323,7 +323,7 @@ export async function fetchAllThermoFisherScientificJobs() {
 
       // ── Recommended fields ──
       addressLocality,
-      postalCode: canton === HQ.canton ? (listing.postalCode || HQ.postalCode) : (listing.postalCode || ''),
+      postalCode: listing.postalCode || (/reinach/i.test(addressLocality) ? HQ.postalCode : ''),
       addressRegion: canton,
       addressCountry: 'CH',
       country: 'CH',

--- a/scripts/lib/yapeal-job-parser.mjs
+++ b/scripts/lib/yapeal-job-parser.mjs
@@ -154,11 +154,12 @@ function resolveAddress(officeRaw = '') {
   const canton = office ? inferSwissTargetCanton(office) : null;
 
   if (office && canton) {
+    const isHqCity = /z[üu]rich/i.test(office);
     return {
       city: office,
       canton,
-      postalCode: canton === HQ.canton ? HQ.postalCode : '',
-      streetAddress: canton === HQ.canton ? HQ.streetAddress : '',
+      postalCode: isHqCity ? HQ.postalCode : '',
+      streetAddress: isHqCity ? HQ.streetAddress : '',
       region: canton,
     };
   }


### PR DESCRIPTION
## Implementato
- `yapeal-job-parser.mjs`: `resolveAddress()` now gates postalCode/streetAddress fallback on HQ city match (Zürich), not canton match.
- `talan-job-parser.mjs`: final-assembly postalCode fallback gated on HQ city (Genève) instead of canton.
- `audemars-piguet-job-parser.mjs`: removed redundant canton-gated re-fallback at final assembly — `resolveAddress()` already correctly city-gates on Le Brassus; the outer canton check was silently re-injecting HQ postalCode for any other VD city.
- `straumann-job-parser.mjs`: postalCode fallback gated on HQ city (Basel) instead of canton.
- `thermo-fisher-scientific-job-parser.mjs`: postalCode fallback gated on HQ city (Reinach) instead of canton.
- `beekeeper-job-parser.mjs`: `pickSwissAddress()` — was an *unconditional* HQ fallback (worse variant, no gate at all); now only backfills postalCode/streetAddress when the job has no addressLocality or it matches HQ city (Zürich).
- `pallas-kliniken-job-parser.mjs`: same unconditional-fallback bug fixed the same way, gated on HQ city (Olten).
- Verified `implenia-job-parser.mjs` (matched initial broad grep) — false positive, its postalCode fallback is already city-gated (`location === HQ.city`); the only canton-level check there is `addressRegion` formatting, which is correct behavior (addressRegion is expected to reflect canton).

Root cause: every one of these files was built (in some cases by different agent sessions across weeks) treating "fallback to HQ address when job's canton equals HQ's canton" as the correct anti-bug pattern — including `yapeal-job-parser.mjs` itself, which had been cited as the canonical reference implementation for newer crawlers. A job located in a different city of the same canton as HQ (e.g. any Vaud city other than Le Brassus for Audemars Piguet, any Basel-Landschaft city other than Reinach for Thermo Fisher) incorrectly inherited HQ's exact street address and postal code in JobPosting structured data — a live SEO/schema correctness defect (AGENTS.md Non-Negotiable #3), not indexing-affecting but factually wrong per-job data.

Verification: `node --check` on all 7 files, `npx vitest run` on the 6 files with dedicated test suites (116 tests, all green — `pallas-kliniken-job-parser.mjs` has no pre-existing dedicated test file; fix logic manually smoke-tested with 4 cases: known-different-city/no-own-address, HQ-city/no-own-address, known-different-city/own-address-present, fully-empty). GitNexus `detect_changes` returned zero changes for this worktree (known limitation — index appears scoped to the primary worktree path, not new worktrees; not treated as a blocker given independent verification).

## Non implementato (ancora)
Nessuno — questa PR è scope-completa (7 file, stesso pattern, stessa PR per disciplina sibling-fix di AGENTS.md #6). Corollario aperto separato: la stessa contaminazione è stata trovata in un'ondata parallela di crawler nuovi (batch-3, ~12 aziende: sophia-genetics, victorinox, edmond-de-rothschild, sygnum, postauto, bucherer, cordenpharma, bcv, vz-vermoegenszentrum, deloitte + 2 da verificare) — tracciato e in corso in un task separato (audit+fix pre-bundling in `wave-ab-batch3`, non ancora una PR aperta), non incluso qui perché quei file non sono ancora su `main`.