### PR TITLE
fix(border-data): remove dead 07.2N.gif webcam feed (#3372)

### DIFF
--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -341,13 +341,13 @@ export const borderCrossings: BorderCrossing[] = [
  sourceUrl: TI_POLCA_SOURCE_URL,
  refreshIntervalMs: 60000,
  },
- {
- label: 'A2 – Mendrisio (uscita Stabio) direzione nord',
- imageUrl: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/07.2N.gif',
- sourceName: TI_POLCA_SOURCE_NAME,
- sourceUrl: TI_POLCA_SOURCE_URL,
- refreshIntervalMs: 60000,
- },
+ // NOTE: 'A2 – Mendrisio (uscita Stabio) direzione nord' (07.2N.gif) was
+ // removed 2026-07-03 (issue #3372) — upstream www4.ti.ch feed returns a
+ // confirmed HTTP 404 (checked from multiple vantage points, with and
+ // without cookies/Referer; not a transient cloud-IP block — still listed
+ // on the ti.ch webcam gallery page but the underlying image is gone). No
+ // replacement feed exists at this exact vantage point; 02.0N.gif and
+ // 06.8S.gif above still cover this crossing.
  ],
  },
  {

--- a/scripts/analyze-webcam-frame.mjs
+++ b/scripts/analyze-webcam-frame.mjs
@@ -158,17 +158,10 @@ export const WEBCAM_FEEDS = {
     // New A2-corridor feed (PR #2286). Warmup-gated until calibration is validated.
     introducedAt: '2026-06-16',
   },
-  // A2 Mendrisio interchange (km 7.2) — the 4-lane motorway funnelling the
-  // Stabio/Gaggiolo crossings. Busy-but-flowing midday traffic reads ~13 vehicles,
-  // so capacity is high: only a genuine bumper-to-bumper jam (~36) flags a queue.
-  '07.2N': {
-    url: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/07.2N.gif',
-    crossings: ['gaggiolo'],
-    box: [0, 30, 400, 195],
-    capacity: 36,
-    // New A2-corridor feed (PR #2286). Warmup-gated until calibration is validated.
-    introducedAt: '2026-06-16',
-  },
+  // '07.2N' (A2 Mendrisio interchange, km 7.2) REMOVED 2026-07-03 (issue #3372):
+  // the upstream www4.ti.ch feed now returns a confirmed HTTP 404 (checked from
+  // multiple vantage points, not a transient cloud-IP block). No replacement feed
+  // exists at this exact vantage point; 'gaggiolo' still votes on 02.0N + 06.8S.
   // A2 Melide–Bissone causeway (km 17.84) — the multi-lane road carrying the
   // Campione d'Italia–Bissone crossing. Live moderate flow ~7–8 vehicles; a busy
   // (but moving) causeway view, so capacity is generous to keep flow under the gate.

--- a/tests/analyze-webcam-aggregate.test.ts
+++ b/tests/analyze-webcam-aggregate.test.ts
@@ -186,9 +186,12 @@ describe('CROSSING_TO_FEEDS registry', () => {
     expect(CROSSING_TO_FEEDS['chiasso-brogeda']).toEqual(
       expect.arrayContaining(['00.3S', '03.3S']),
     );
+    // '07.2N' was removed (issue #3372): the upstream www4.ti.ch feed 404s and
+    // has no replacement; 'gaggiolo' now votes on the two remaining feeds.
     expect(CROSSING_TO_FEEDS['gaggiolo']).toEqual(
-      expect.arrayContaining(['02.0N', '06.8S', '07.2N']),
+      expect.arrayContaining(['02.0N', '06.8S']),
     );
+    expect(CROSSING_TO_FEEDS['gaggiolo']).not.toContain('07.2N');
     expect(CROSSING_TO_FEEDS['san-pietro']).toEqual(
       expect.arrayContaining(['02.0N', '06.8S']),
     );
@@ -216,7 +219,8 @@ describe('CROSSING_TO_FEEDS registry', () => {
   });
 
   it('new A2-corridor feeds (PR #2286) carry introducedAt for warmup gating', () => {
-    for (const k of ['03.3S', '07.2N', '17.84S', '04.4N']) {
+    // '07.2N' removed (issue #3372) — dead upstream feed, no replacement.
+    for (const k of ['03.3S', '17.84S', '04.4N']) {
       expect(WEBCAM_FEEDS[k].introducedAt, `feed ${k}`).toBeDefined();
     }
   });


### PR DESCRIPTION
## Implementato

- Removed the dead `07.2N.gif` webcam entry from `data/borderCrossings.ts` (Gaggiolo crossing display list). Verified live: `https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/07.2N.gif` returns a confirmed HTTP 404 from multiple vantage points (with/without Referer/cookies) — not a transient cloud-IP block. The upstream ti.ch gallery page still lists it (dead link on their end), and no replacement feed exists at that exact vantage point. `02.0N.gif` and `06.8S.gif` still cover the Gaggiolo crossing.
- Sibling fix (AGENTS.md #6): the same dead `07.2N.gif` URL was also registered in `scripts/analyze-webcam-frame.mjs`'s `WEBCAM_FEEDS` congestion-detection registry, feeding the wait-time queue-vote pipeline. It was silently failing every fetch (caught + returned `null`, filtered out of `aggregateWebcamResults`) — not user-visible breakage, but dead weight retried every cron run and contributing nothing to the vote. Removed the `'07.2N'` entry there too.
- Updated `tests/analyze-webcam-aggregate.test.ts` fixtures/assertions to match the reduced feed set (`CROSSING_TO_FEEDS['gaggiolo']` no longer includes `07.2N`; the `introducedAt` warmup-gating assertion drops it from its list).
- Investigated the "stale wait-times" half of the issue title: `scripts/check-border-data-health.mjs`'s freshness (83min old, 6h threshold) and all-mock-source (0/25 mock) checks were both `✅ OK` in the watchdog run linked from the issue — only the webcam check tripped. Re-ran the health script locally post-fix: `✅ ALL HEALTHY (13 webcam URLs checked)`, confirming the watchdog trigger is resolved and there is no separate stale-wait-time/mock-fallback root cause currently active.
- Ran a full URL health sweep across every `imageUrl` in `data/borderCrossings.ts` (14 unique URLs) — confirmed `07.2N.gif` was the only broken one; no other sibling dead feeds in the registry.

## Non implementato (ancora)

Nessuno

## Test plan

- [x] `npx vitest run tests/analyze-webcam-aggregate.test.ts tests/check-border-data-health.test.ts` — 55/55 passed
- [x] `npx vitest run` across all border/webcam/traffic-related suites (14 files, 257 tests) — all passed
- [x] `npx tsc --noEmit` — no errors in touched files
- [x] `node scripts/check-border-data-health.mjs` run live post-fix — `✅ ALL HEALTHY`

Closes #3372