### PR TITLE
fix(job-alerts): close resolveSignalTier's field-enumeration gap in tier-3 patch gate

### DIFF
--- a/functions/src/jobAlertBackfillCore.js
+++ b/functions/src/jobAlertBackfillCore.js
@@ -146,8 +146,18 @@ export function resolveSignalTier(data, personalization) {
   const tier = getSignalTier(data);
   if (tier !== 'none') return { tier, patch: null };
 
+  // `derivePersonalizationPatch` already guarantees a non-null return has at
+  // least one non-blank field (see its own `Object.keys(patch).length > 0`
+  // check) — so `if (patch)` alone is correct and complete. A prior version
+  // of this check instead named 4 of the 6 `PERSONALIZATION_FIELDS`
+  // (`job_category`/`location_interest`/`geo_city`/`job_search_query`),
+  // silently dropping any patch whose ONLY derived field was `job_company` or
+  // `sector_interest` — e.g. a subscriber who clicked a specific employer's
+  // job (the strongest signal this module derives, `CLICK_WEIGHT`) but has no
+  // location/category signal at all would fall through to a weaker tier or
+  // 'none', losing real derived data instead of using it.
   const patch = derivePersonalizationPatch({ subscriber: data, personalization, alerts: [] });
-  if (patch && (patch.job_category || patch.location_interest || patch.geo_city || patch.job_search_query)) {
+  if (patch) {
     return { tier: 'personalization-fallback', patch };
   }
 

--- a/tests/job-alert-backfill-trigger.test.ts
+++ b/tests/job-alert-backfill-trigger.test.ts
@@ -198,6 +198,20 @@ describe('resolveSignalTier — tier-3 personalization fallback', () => {
   it('stays none when personalization has nothing usable (empty viewedJobs/filterUsage)', () => {
     expect(resolveSignalTier({}, { viewedJobs: [], filterUsage: {} })).toEqual({ tier: 'none', patch: null });
   });
+
+  it('derives personalization-fallback from a company-only signal, not just job_category/location_interest/geo_city/job_search_query (#3378)', () => {
+    // Regression: a subscriber who only has a viewed-job COMPANY (no
+    // location/category derivable, no search history) produces a patch whose
+    // ONLY field is `job_company` — a real, non-blank field `derivePersonalizationPatch`
+    // guarantees is present (its own `Object.keys(patch).length > 0` contract).
+    // A prior version of this gate named only 4 of the 6 `PERSONALIZATION_FIELDS`
+    // (missing `job_company`/`sector_interest`), so this exact patch was silently
+    // discarded and the subscriber wrongly fell through toward 'none'/tier-4
+    // instead of using the real derived signal.
+    const result = resolveSignalTier({}, { viewedJobs: [{ company: 'Acme SA' }] });
+    expect(result.tier).toBe('personalization-fallback');
+    expect(result.patch).toEqual({ job_company: 'Acme SA' });
+  });
 });
 
 describe('handleNewsletterSubscriberCreated — tier-3 personalization fallback', () => {


### PR DESCRIPTION
## Implementato

- Fixed the tier-3 `personalization-fallback` classification gate in `resolveSignalTier` (`functions/src/jobAlertBackfillCore.js`): the truthiness check `patch.job_category || patch.location_interest || patch.geo_city || patch.job_search_query` only enumerated 4 of the 6 `PERSONALIZATION_FIELDS`. `derivePersonalizationPatch` already guarantees any non-null return has at least one non-blank field (its own `Object.keys(patch).length > 0` contract), so a patch whose ONLY derived field was `job_company` (e.g. a subscriber with a viewed-job company but no location/category/search signal) or `sector_interest` was silently dropped by the gate — the subscriber wrongly fell through toward a weaker tier / `'none'` instead of using the real derived signal. Replaced the 4-field enumeration with `if (patch)`, matching the already-correct pattern used at the other `derivePersonalizationPatch` call site (`scripts/send-job-alerts.mjs:1499`).
- Traced `derivePersonalizationPatch` (`functions/src/lib/subscriberPersonalization.js`) end-to-end against the stale/zero-weight `filterUsage` fixture the issue asked for: **already correct** — PR #3391 (merged ahead of this branch) fixed `fromUsageMap`/`topWeighted` so an explicit zero count stays zero-weight and can never win `topWeighted`, and `derivePersonalizationPatch`'s `isBlank` gate already rejects any resulting blank field before it reaches the patch. Confirmed via the existing zero-weight regression tests (`tests/subscriber-personalization.test.ts`, `tests/backfill-jobalerts-from-newsletter.test.ts`) — no further change needed on that half.
- Added a regression test (`tests/job-alert-backfill-trigger.test.ts`) covering a company-only personalization patch (no location/category/search signal) to lock in the gate fix and prevent recidivism.
- Sibling-pattern check (AGENTS.md #6): grepped for other truthiness checks against named `patch.<field>` properties from `derivePersonalizationPatch` — the only other call site (`scripts/send-job-alerts.mjs`) already uses the correct `if (patch)` pattern, so this was the sole buggy instance, now aligned.

## Non implementato (ancora)

Nessuno

Closes #3378