### PR TITLE
feat(stability): auto-open backlog issues from GA4/PostHog/CF real-user errors

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -78,6 +78,17 @@ jobs:
           node scripts/analytics-report.mjs $FLAGS
         continue-on-error: true
 
+      - name: Sync app_error issues to backlog
+        # Turns the errorHealth.appErrors block just computed above into
+        # deduplicated GitHub issues (top offenders, threshold-gated) — see
+        # scripts/app-error-issue-sync.mjs. Report-only: never fails the job.
+        if: always()
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/app-error-issue-sync.mjs
+        continue-on-error: true
+
       - name: Generate Report Summary
         if: always()
         run: |

--- a/.github/workflows/cf-5xx-monitor.yml
+++ b/.github/workflows/cf-5xx-monitor.yml
@@ -1,0 +1,80 @@
+name: Cloudflare 5xx Monitor
+
+# Daily zone-wide 5xx watchdog. production-canary.yml already probes a FIXED
+# list of known URLs every 15min — this catches 5xx on ANY path across the
+# whole zone (unknown/new routes, CDN asset paths, locale-router shards),
+# reusing the same GraphQL dataset as scripts/cf-status-report.mjs via its
+# --json flag (no new integration, no duplicated CF-analytics construct —
+# AGENTS.md #6).
+#
+# Zero-Claude by design (pure node + the existing gh issue-creator) per the
+# frugality rules in AGENTS.md — no claude-code-action, no Max-quota burn.
+#
+# Auth: CF_API_TOKEN lives in Firebase Remote Config, loaded via
+# scripts/load-rc-env.mjs (same mechanism as dmarc-monitor.yml /
+# discover-404s-via-cloudflare.yml).
+#
+# Free-plan retention is ~3 days and queries are capped at ~1 day per call
+# (see scripts/lib/cf-analytics.mjs), hence the daily cadence.
+
+on:
+  schedule:
+    # Daily 03:50 UTC — 10min after discover-404s-via-cloudflare (03:40),
+    # which already reads the same zone's GraphQL analytics; keeping the two
+    # CF-analytics reads close together avoids spreading the CF token budget
+    # window across the day.
+    - cron: '50 3 * * *'
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: 'Look-back window in hours (max ~23.9, free plan)'
+        required: false
+        type: string
+        default: '23'
+
+concurrency:
+  group: cf-5xx-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Load RC secrets
+        run: node scripts/load-rc-env.mjs
+
+      - name: Sync Cloudflare 5xx issues to backlog
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CF_5XX_HOURS: ${{ inputs.hours || '23' }}
+        run: node scripts/cf-5xx-issue-sync.mjs

--- a/.github/workflows/posthog-error-monitor.yml
+++ b/.github/workflows/posthog-error-monitor.yml
@@ -1,0 +1,80 @@
+name: PostHog Error Monitor
+
+# Weekly watchdog for real-user JS errors captured via PostHog `$exception`
+# autocapture. Companion to the GA4 app_error sync inside analytics.yml
+# (scripts/app-error-issue-sync.mjs) — same "top-N over threshold → backlog
+# issue" pattern (scripts/lib/error-issue-sync.mjs), different source, so an
+# error only PostHog captures (or vice versa, e.g. GA4 blocked by a
+# consent/ad-blocker edge case PostHog isn't) doesn't go unnoticed.
+#
+# Zero-Claude by design (pure node + the existing gh issue-creator) per the
+# frugality rules in AGENTS.md — no claude-code-action, no Max-quota burn.
+#
+# Auth: POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID / POSTHOG_HOST live in
+# Firebase Remote Config, loaded via scripts/load-rc-env.mjs (same mechanism
+# as monitor-cls-posthog.mjs / triage-app-errors.mjs).
+
+on:
+  schedule:
+    # Weekly, Tuesday 07:25 UTC — offset from the GA4 sync (Monday 07:00,
+    # inside analytics.yml) so the two error-tracking passes don't land on
+    # the same weekly slot, and clear of every other 07:xx Monday cron
+    # (dmarc-monitor, app-auth-health-monitor, funnel-metrics-snapshot,
+    # gsc-frontaliere-monitor all run Monday).
+    - cron: '25 7 * * 2'
+  workflow_dispatch:
+    inputs:
+      windowDays:
+        description: 'Look-back window in days'
+        required: false
+        type: string
+        default: '7'
+
+concurrency:
+  group: posthog-error-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        # load-rc-env.mjs needs firebase-admin from node_modules to read
+        # Remote Config; the monitor itself only uses node built-ins + gh CLI.
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Load RC secrets
+        run: node scripts/load-rc-env.mjs
+
+      - name: Sync PostHog exception issues to backlog
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WINDOW_DAYS: ${{ inputs.windowDays || '7' }}
+        run: node scripts/posthog-error-issue-sync.mjs

--- a/scripts/app-error-issue-sync.mjs
+++ b/scripts/app-error-issue-sync.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * app-error-issue-sync.mjs — turns the GA4 `errorHealth.appErrors` block
+ * from reports/analytics-latest.json (produced by
+ * `analytics-report.mjs --save`, which analytics.yml already runs weekly)
+ * into deduplicated GitHub backlog issues.
+ *
+ * Threshold-gated: only errors with >= MIN_COUNT hits in the report window
+ * open/recur an issue, so a single one-off exception doesn't spam the
+ * backlog. Capped at MAX_ISSUES per run.
+ *
+ * Labeled `stability` + `app-error` — NOT `agent:fix`. AGENTS.md's
+ * auto-route allowlist is `crawler`/`follow-up` only; a real user-facing
+ * error needs human triage before an autonomous fixer touches it.
+ *
+ * Report-only source: any failure here (missing report, bad JSON) logs and
+ * exits 0 so it never paints the parent workflow red over a reporting gap.
+ */
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { sanitizeTrackedDiagnosticValue } from './lib/sanitizeTrackedDiagnostics.mjs';
+import { syncErrorIssues } from './lib/error-issue-sync.mjs';
+
+const REPORT_PATH = process.env.ANALYTICS_REPORT_PATH || 'reports/analytics-latest.json';
+const MIN_COUNT = Number(process.env.APP_ERROR_MIN_COUNT || 5);
+const MAX_ISSUES = Number(process.env.APP_ERROR_MAX_ISSUES || 5);
+
+export function truncate(value, n) {
+  const str = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}
+
+export function main() {
+  let report;
+  try {
+    report = JSON.parse(readFileSync(REPORT_PATH, 'utf8'));
+  } catch (e) {
+    console.log(`[app-error-issue-sync] no report at ${REPORT_PATH} (${e.message}) — skip`);
+    return;
+  }
+
+  const eh = report?.ga4?.errorHealth;
+  if (!eh || !eh.totalErrors) {
+    console.log('[app-error-issue-sync] no errorHealth / zero errors in report — nothing to sync');
+    return;
+  }
+
+  const entries = (eh.appErrors || [])
+    .filter((e) => (e.count || 0) >= MIN_COUNT)
+    .sort((a, b) => b.count - a.count);
+
+  if (!entries.length) {
+    console.log(`[app-error-issue-sync] no app_error above MIN_COUNT=${MIN_COUNT} — nothing to sync`);
+    return;
+  }
+
+  const stackByMessage = new Map((eh.topStacks || []).map((s) => [s.message, s.stack]));
+
+  return syncErrorIssues({
+    entries,
+    maxIssues: MAX_ISSUES,
+    labels: ['stability', 'app-error'],
+    source: 'Weekly Analytics Report — GA4 app_error',
+    priorityFor: (e) => ((eh.errorRate >= 1.0 || e.count >= MIN_COUNT * 10) ? 2 : 3),
+    titleFor: (e) => {
+      const type = truncate(sanitizeTrackedDiagnosticValue(e.errorType) || 'error', 20);
+      const msg = truncate(sanitizeTrackedDiagnosticValue(e.errorMessage), 60);
+      return `App Error: ${type} — ${msg}`;
+    },
+    bodyFor: (e) => {
+      const stack = stackByMessage.get(e.errorMessage);
+      const lines = [
+        `**Type:** ${sanitizeTrackedDiagnosticValue(e.errorType)}`,
+        `**Message:** ${sanitizeTrackedDiagnosticValue(e.errorMessage)}`,
+        `**Page:** ${sanitizeTrackedDiagnosticValue(e.pagePath)}`,
+        `**Hits (report window):** ${e.count} | **Affected users:** ${e.users}`,
+        `**Site-wide error rate:** ${eh.errorRate}% (${eh.healthStatus})`,
+      ];
+      if (stack) {
+        lines.push('', '**Stack:**', '```', truncate(sanitizeTrackedDiagnosticValue(stack), 1500), '```');
+      }
+      lines.push('', '_Source: GA4 `app_error` events — full errorHealth table in the Weekly Analytics Report run summary._');
+      return lines.join('\n');
+    },
+  });
+}
+
+// Run only when invoked directly (not when imported by the test suite), so
+// importing main()/truncate() never triggers a live gh call — same guard as
+// scripts/dmarc-monitor.mjs.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const results = await main();
+  if (results) {
+    console.log(`[app-error-issue-sync] synced ${results.filter(Boolean).length}/${results.length} issue(s)`);
+  }
+}

--- a/scripts/cf-5xx-issue-sync.mjs
+++ b/scripts/cf-5xx-issue-sync.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * cf-5xx-issue-sync.mjs — zone-wide Cloudflare 5xx watchdog.
+ *
+ * Shells out to the existing scripts/cf-status-report.mjs (--json --class=5)
+ * instead of re-implementing the GraphQL query (AGENTS.md #6 — no duplicated
+ * CF-analytics construct; the query already lives in scripts/lib/cf-analytics.mjs
+ * and cf-status-report.mjs), then opens/dedupes GitHub issues for paths with
+ * sustained 5xx volume.
+ *
+ * Complements production-canary.yml, which probes a FIXED list of known URLs
+ * every 15min — this catches 5xx on ANY path across the whole zone (unknown
+ * routes, CDN asset paths, locale-router shards) that the fixed probe list
+ * doesn't cover.
+ *
+ * Report-only source: a CF API failure logs and exits 0 rather than failing
+ * the workflow — this is a backlog feeder, not a gate.
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { sanitizeUrlLikeText } from './lib/sanitizeTrackedDiagnostics.mjs';
+import { syncErrorIssues } from './lib/error-issue-sync.mjs';
+
+const HOURS = process.env.CF_5XX_HOURS || '23';
+const MIN_COUNT = Number(process.env.CF_5XX_MIN_COUNT || 20);
+const MAX_ISSUES = Number(process.env.CF_5XX_MAX_ISSUES || 5);
+
+export async function main() {
+  if (!process.env.CF_API_TOKEN) {
+    console.log('[cf-5xx-issue-sync] CF_API_TOKEN missing — skip');
+    return;
+  }
+
+  let data;
+  try {
+    const out = execFileSync(
+      'node',
+      ['scripts/cf-status-report.mjs', '--json', '--class=5', `--hours=${HOURS}`, '--limit=50'],
+      { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 },
+    );
+    data = JSON.parse(out);
+  } catch (e) {
+    console.error(`[cf-5xx-issue-sync] cf-status-report.mjs failed: ${e.message}`);
+    return;
+  }
+
+  const entries = (data.detail || [])
+    .filter((r) => r.count >= MIN_COUNT)
+    .sort((a, b) => b.count - a.count);
+
+  if (!entries.length) {
+    console.log(`[cf-5xx-issue-sync] no path with >= ${MIN_COUNT} 5xx in last ${HOURS}h — nothing to sync`);
+    return;
+  }
+
+  return syncErrorIssues({
+    entries,
+    maxIssues: MAX_ISSUES,
+    labels: ['stability', 'cloudflare-5xx'],
+    source: `Cloudflare 5xx Monitor — last ${HOURS}h (zone-wide)`,
+    priorityFor: (e) => (e.count >= MIN_COUNT * 5 ? 2 : 3),
+    titleFor: (e) => `CF 5xx: ${sanitizeUrlLikeText(e.url).slice(0, 80)}`,
+    bodyFor: (e) => [
+      `**Status:** ${e.status}`,
+      `**URL:** ${sanitizeUrlLikeText(e.url)}`,
+      `**Requests (last ${HOURS}h):** ${e.count}`,
+      '',
+      '_Source: Cloudflare GraphQL Analytics (`httpRequestsAdaptiveGroups`), zone-wide eyeball 5xx — see scripts/cf-status-report.mjs._',
+    ].join('\n'),
+  });
+}
+
+// Run only when invoked directly (not when imported by the test suite), so
+// importing main() never triggers a live CF/gh call — same guard as
+// scripts/dmarc-monitor.mjs.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const results = await main();
+  if (results) {
+    console.log(`[cf-5xx-issue-sync] synced ${results.filter(Boolean).length}/${results.length} issue(s)`);
+  }
+}

--- a/scripts/lib/error-issue-sync.mjs
+++ b/scripts/lib/error-issue-sync.mjs
@@ -1,0 +1,54 @@
+/**
+ * error-issue-sync.mjs — shared "top-N recurring error → GitHub backlog
+ * issue" sync, used by every user-facing error source (GA4 app_error,
+ * PostHog $exception, Cloudflare zone-wide 5xx).
+ *
+ * Extracted per AGENTS.md #6 (no literal duplication of the same construct
+ * across sibling scripts) so scripts/app-error-issue-sync.mjs,
+ * scripts/posthog-error-issue-sync.mjs and scripts/cf-5xx-issue-sync.mjs
+ * share one create/dedupe loop instead of three copy-pasted ones.
+ *
+ * Relies on scripts/lib/github-issue-creator.mjs for the actual dedup
+ * (stable title prefix match against OPEN issues → comment instead of
+ * duplicate).
+ */
+
+import { createGithubIssue } from './github-issue-creator.mjs';
+
+/**
+ * @param {object} opts
+ * @param {Array<object>} opts.entries    Already-sorted (desc by relevance) list of error entries.
+ * @param {number} [opts.maxIssues]       Cap on how many issues to open/touch per run (avoids backlog flooding).
+ * @param {(entry:object)=>string} opts.titleFor   Stable issue title (first ~60 chars must be a unique discriminator).
+ * @param {(entry:object)=>string} opts.bodyFor    Issue body markdown.
+ * @param {(entry:object)=>number} [opts.priorityFor]  1-4 (Linear-style, 3=medium default).
+ * @param {string[]} [opts.labels]        Extra labels beyond the priority label.
+ * @param {string} [opts.source]          Human label for the "Workflow:" line in the issue body.
+ * @returns {Promise<Array<object|null>>}
+ */
+export async function syncErrorIssues({
+  entries,
+  maxIssues = 5,
+  titleFor,
+  bodyFor,
+  priorityFor,
+  labels = [],
+  source,
+}) {
+  const results = [];
+  for (const entry of entries.slice(0, maxIssues)) {
+    const title = titleFor(entry);
+    if (!title) continue;
+    const priority = priorityFor ? priorityFor(entry) : 3;
+    // eslint-disable-next-line no-await-in-loop -- sequential to stay under gh API rate limits
+    const res = await createGithubIssue({
+      title,
+      description: bodyFor(entry),
+      priority,
+      labels,
+      workflow: source,
+    });
+    results.push(res);
+  }
+  return results;
+}

--- a/scripts/posthog-error-issue-sync.mjs
+++ b/scripts/posthog-error-issue-sync.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * posthog-error-issue-sync.mjs — queries PostHog `$exception` events (same
+ * HogQL shape as scripts/triage-app-errors.mjs' top-messages query) for the
+ * top recurring client errors and opens/dedupes GitHub backlog issues for
+ * the ones above threshold.
+ *
+ * Companion to app-error-issue-sync.mjs (GA4 source): kept as a separate
+ * script because PostHog's `$exception` payload and GA4's `app_error`
+ * custom-dimension payload aren't a 1:1 join, and either source can capture
+ * an error the other misses (ad blockers / consent state / SDK differences).
+ *
+ * Report-only source: a PostHog API failure logs and exits 0 rather than
+ * failing the workflow — this is a backlog feeder, not a gate.
+ */
+import { pathToFileURL } from 'node:url';
+import { sanitizeTrackedDiagnosticValue } from './lib/sanitizeTrackedDiagnostics.mjs';
+import { syncErrorIssues } from './lib/error-issue-sync.mjs';
+
+export function truncate(value, n) {
+  const str = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}
+
+async function hogql(host, pid, key, query) {
+  const r = await fetch(`${host}/api/projects/${pid}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!r.ok) throw new Error(`PH ${r.status}: ${(await r.text()).slice(0, 300)}`);
+  return r.json();
+}
+
+export async function main() {
+  // Read env lazily (not at module load) so importing this module for tests
+  // doesn't freeze stale/missing credentials — each run's env is fixed by
+  // the time main() is invoked, whether that's the CLI entrypoint below or
+  // a test calling main() directly.
+  const HOST = process.env.POSTHOG_HOST || 'https://eu.posthog.com';
+  const PID = process.env.POSTHOG_PROJECT_ID;
+  const KEY = process.env.POSTHOG_PERSONAL_API_KEY;
+  const WINDOW_DAYS = process.env.WINDOW_DAYS || '7';
+  const MIN_COUNT = Number(process.env.POSTHOG_ERROR_MIN_COUNT || 5);
+  const MAX_ISSUES = Number(process.env.POSTHOG_ERROR_MAX_ISSUES || 5);
+
+  if (!KEY || !PID) {
+    console.log('[posthog-error-issue-sync] POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID missing — skip');
+    return;
+  }
+
+  const query = `
+    SELECT
+      properties.$exception_values.1 AS msg,
+      properties.$exception_types.1 AS type,
+      count() AS n,
+      count(DISTINCT $session_id) AS sessions,
+      any(properties.$current_url) AS sample_url
+    FROM events
+    WHERE event = '$exception'
+      AND timestamp > now() - INTERVAL ${WINDOW_DAYS} DAY
+    GROUP BY msg, type
+    ORDER BY n DESC
+    LIMIT 25
+  `.trim();
+
+  let rows;
+  try {
+    const result = await hogql(HOST, PID, KEY, query);
+    rows = result.results || [];
+  } catch (e) {
+    console.error(`[posthog-error-issue-sync] HogQL query failed: ${e.message}`);
+    return;
+  }
+
+  const entries = rows
+    .map(([msg, type, n, sessions, sampleUrl]) => ({
+      message: msg, type: type || 'exception', count: n, sessions, sampleUrl,
+    }))
+    .filter((e) => e.count >= MIN_COUNT);
+
+  if (!entries.length) {
+    console.log(`[posthog-error-issue-sync] no $exception above MIN_COUNT=${MIN_COUNT} in last ${WINDOW_DAYS}d — nothing to sync`);
+    return;
+  }
+
+  return syncErrorIssues({
+    entries,
+    maxIssues: MAX_ISSUES,
+    labels: ['stability', 'app-error'],
+    source: `PostHog Error Monitor — last ${WINDOW_DAYS}d`,
+    priorityFor: (e) => (e.count >= MIN_COUNT * 10 ? 2 : 3),
+    titleFor: (e) => `PostHog Exception: ${truncate(sanitizeTrackedDiagnosticValue(e.type), 20)} — ${truncate(sanitizeTrackedDiagnosticValue(e.message), 60)}`,
+    bodyFor: (e) => [
+      `**Type:** ${sanitizeTrackedDiagnosticValue(e.type)}`,
+      `**Message:** ${sanitizeTrackedDiagnosticValue(e.message)}`,
+      `**Occurrences (last ${WINDOW_DAYS}d):** ${e.count} | **Distinct sessions:** ${e.sessions}`,
+      `**Sample URL:** ${sanitizeTrackedDiagnosticValue(e.sampleUrl)}`,
+      '',
+      '_Source: PostHog `$exception` autocapture events._',
+    ].join('\n'),
+  });
+}
+
+// Run only when invoked directly (not when imported by the test suite), so
+// importing main()/truncate() never triggers a live PostHog/gh call — same
+// guard as scripts/dmarc-monitor.mjs.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const results = await main();
+  if (results) {
+    console.log(`[posthog-error-issue-sync] synced ${results.filter(Boolean).length}/${results.length} issue(s)`);
+  }
+}

--- a/tests/error-issue-sync.test.ts
+++ b/tests/error-issue-sync.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Coverage for the GA4 / PostHog / Cloudflare "top-N recurring error →
+ * GitHub backlog issue" sync (scripts/lib/error-issue-sync.mjs +
+ * scripts/{app-error,posthog-error,cf-5xx}-issue-sync.mjs).
+ *
+ * All three entry scripts guard their live-call `main()` behind an
+ * `import.meta.url === pathToFileURL(process.argv[1]).href` check (same
+ * pattern as scripts/dmarc-monitor.mjs), so importing them here never fires
+ * a real gh/PostHog/Cloudflare call — every external boundary (gh CLI via
+ * node:child_process, PostHog via fetch, the cf-status-report.mjs subprocess,
+ * and reports/analytics-latest.json via node:fs) is mocked.
+ */
+
+const execFileSync = vi.fn();
+vi.mock('node:child_process', () => {
+  const mock = { execFileSync: (...args: unknown[]) => execFileSync(...args) };
+  return { ...mock, default: mock };
+});
+
+const readFileSync = vi.fn();
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: (...args: unknown[]) => readFileSync(...args) };
+});
+
+const { syncErrorIssues } = await import('../scripts/lib/error-issue-sync.mjs');
+const appErrorSync = await import('../scripts/app-error-issue-sync.mjs');
+const posthogSync = await import('../scripts/posthog-error-issue-sync.mjs');
+const cfSync = await import('../scripts/cf-5xx-issue-sync.mjs');
+
+function ghCalls(): string[][] {
+  return execFileSync.mock.calls
+    .filter((c) => c[0] === 'gh')
+    .map((c) => c[1] as string[]);
+}
+
+function createCalls(): string[][] {
+  return ghCalls().filter((a) => a[0] === 'issue' && a[1] === 'create');
+}
+
+function issueListEmptyThenCreate(nextNumber: number) {
+  execFileSync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'list') return '[]';
+    if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'create') {
+      return `https://github.com/o/r/issues/${nextNumber}`;
+    }
+    return '';
+  });
+}
+
+beforeEach(() => {
+  execFileSync.mockReset();
+  readFileSync.mockReset();
+  delete process.env.GH_REPO;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('syncErrorIssues (shared loop)', () => {
+  it('creates one issue per entry, capped at maxIssues, in entry order', async () => {
+    issueListEmptyThenCreate(1);
+    const entries = [{ n: 1 }, { n: 2 }, { n: 3 }];
+    await syncErrorIssues({
+      entries,
+      maxIssues: 2,
+      labels: ['stability'],
+      source: 'test',
+      titleFor: (e: { n: number }) => `Error ${e.n}`,
+      bodyFor: () => 'body',
+    });
+    expect(createCalls()).toHaveLength(2);
+  });
+
+  it('skips an entry whose titleFor returns falsy', async () => {
+    issueListEmptyThenCreate(1);
+    const entries = [{ n: 1 }, { n: 2 }];
+    await syncErrorIssues({
+      entries,
+      labels: [],
+      source: 'test',
+      titleFor: (e: { n: number }) => (e.n === 1 ? '' : `Error ${e.n}`),
+      bodyFor: () => 'body',
+    });
+    expect(createCalls()).toHaveLength(1);
+  });
+
+  it('defaults to priority 3 (medium) when priorityFor is omitted', async () => {
+    issueListEmptyThenCreate(1);
+    await syncErrorIssues({
+      entries: [{ n: 1 }],
+      labels: [],
+      source: 'test',
+      titleFor: () => 'Error',
+      bodyFor: () => 'body',
+    });
+    const labels: string[] = [];
+    const call = createCalls()[0];
+    for (let i = 0; i < call.length; i++) if (call[i] === '--label') labels.push(call[i + 1]);
+    expect(labels).toContain('priority:medium');
+  });
+
+  it('applies priorityFor per-entry to escalate above the default', async () => {
+    issueListEmptyThenCreate(1);
+    await syncErrorIssues({
+      entries: [{ n: 1 }],
+      labels: [],
+      source: 'test',
+      priorityFor: () => 2,
+      titleFor: () => 'Error',
+      bodyFor: () => 'body',
+    });
+    const labels: string[] = [];
+    const call = createCalls()[0];
+    for (let i = 0; i < call.length; i++) if (call[i] === '--label') labels.push(call[i + 1]);
+    expect(labels).toContain('priority:high');
+  });
+});
+
+describe('app-error-issue-sync.mjs', () => {
+  it('exits silently (no gh call) when the report file is missing', async () => {
+    readFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await appErrorSync.main();
+    expect(ghCalls()).toHaveLength(0);
+  });
+
+  it('exits silently when errorHealth has zero errors', async () => {
+    readFileSync.mockReturnValue(JSON.stringify({ ga4: { errorHealth: { totalErrors: 0 } } }));
+    await appErrorSync.main();
+    expect(ghCalls()).toHaveLength(0);
+  });
+
+  it('filters out app_error entries below MIN_COUNT and syncs the rest, attaching the matching stack', async () => {
+    issueListEmptyThenCreate(101);
+    readFileSync.mockReturnValue(JSON.stringify({
+      ga4: {
+        errorHealth: {
+          totalErrors: 50,
+          errorRate: 0.2,
+          healthStatus: '🟢 HEALTHY',
+          appErrors: [
+            { errorType: 'TypeError', errorMessage: 'x is not a function', pagePath: '/it/lavoro', count: 12, users: 9 },
+            { errorType: 'TypeError', errorMessage: 'one-off, below threshold', pagePath: '/it/x', count: 1, users: 1 },
+          ],
+          topStacks: [{ message: 'x is not a function', stack: 'at foo (bar.js:1:1)' }],
+        },
+      },
+    }));
+
+    await appErrorSync.main();
+
+    const calls = createCalls();
+    expect(calls).toHaveLength(1); // only the >=5-count entry syncs
+    const body = calls[0][calls[0].indexOf('--body') + 1];
+    expect(body).toContain('x is not a function');
+    expect(body).toContain('at foo (bar.js:1:1)');
+  });
+
+  it('escalates priority to high when the site-wide error rate is critical', async () => {
+    issueListEmptyThenCreate(102);
+    readFileSync.mockReturnValue(JSON.stringify({
+      ga4: {
+        errorHealth: {
+          totalErrors: 500,
+          errorRate: 2.5, // >= 1.0 threshold
+          healthStatus: '🔴 CRITICAL',
+          appErrors: [
+            { errorType: 'TypeError', errorMessage: 'boom', pagePath: '/it/x', count: 6, users: 6 },
+          ],
+          topStacks: [],
+        },
+      },
+    }));
+
+    await appErrorSync.main();
+
+    const call = createCalls()[0];
+    const labels: string[] = [];
+    for (let i = 0; i < call.length; i++) if (call[i] === '--label') labels.push(call[i + 1]);
+    expect(labels).toContain('priority:high');
+  });
+
+  it('truncate() collapses whitespace and ellipsizes past the limit', () => {
+    expect(appErrorSync.truncate('a   b\nc', 100)).toBe('a b c');
+    expect(appErrorSync.truncate('x'.repeat(10), 5)).toBe('xxxx…');
+  });
+});
+
+describe('posthog-error-issue-sync.mjs', () => {
+  it('exits silently (no fetch, no gh call) when credentials are missing', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    delete process.env.POSTHOG_PERSONAL_API_KEY;
+    delete process.env.POSTHOG_PROJECT_ID;
+
+    await posthogSync.main();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ghCalls()).toHaveLength(0);
+  });
+
+  it('exits silently when the HogQL query throws', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'k';
+    process.env.POSTHOG_PROJECT_ID = 'p';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'boom' }));
+
+    await posthogSync.main();
+
+    expect(ghCalls()).toHaveLength(0);
+    delete process.env.POSTHOG_PERSONAL_API_KEY;
+    delete process.env.POSTHOG_PROJECT_ID;
+  });
+
+  it('filters rows below MIN_COUNT and syncs the rest', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'k';
+    process.env.POSTHOG_PROJECT_ID = 'p';
+    issueListEmptyThenCreate(201);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          ['Cannot read properties of null', 'TypeError', 9, 7, 'https://frontaliereticino.ch/it/lavoro/'],
+          ['rare one-off', 'Error', 1, 1, 'https://frontaliereticino.ch/it/x/'],
+        ],
+      }),
+    }));
+
+    await posthogSync.main();
+
+    expect(createCalls()).toHaveLength(1);
+    delete process.env.POSTHOG_PERSONAL_API_KEY;
+    delete process.env.POSTHOG_PROJECT_ID;
+  });
+});
+
+describe('cf-5xx-issue-sync.mjs', () => {
+  it('exits silently (no subprocess, no gh call) when CF_API_TOKEN is missing', async () => {
+    delete process.env.CF_API_TOKEN;
+    await cfSync.main();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('exits silently when the cf-status-report subprocess fails', async () => {
+    process.env.CF_API_TOKEN = 't';
+    execFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'node' && args[0] === 'scripts/cf-status-report.mjs') throw new Error('boom');
+      return '';
+    });
+
+    await cfSync.main();
+
+    expect(ghCalls()).toHaveLength(0);
+    delete process.env.CF_API_TOKEN;
+  });
+
+  it('filters paths below MIN_COUNT (default 20) and syncs only the sustained one', async () => {
+    // cf-status-report.mjs builds `url` as clientRequestHTTPHost +
+    // clientRequestPath — host+path only, Cloudflare's GraphQL dimension
+    // never carries a query string here — so a realistic fixture has none.
+    process.env.CF_API_TOKEN = 't';
+    execFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'node' && args[0] === 'scripts/cf-status-report.mjs') {
+        return JSON.stringify({
+          detail: [
+            { status: 502, url: 'frontaliereticino.ch/it/lavoro/', count: 45 },
+            { status: 500, url: 'frontaliereticino.ch/it/rare/', count: 3 },
+          ],
+        });
+      }
+      if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'list') return '[]';
+      if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'create') return 'https://github.com/o/r/issues/301';
+      return '';
+    });
+
+    await cfSync.main();
+
+    const calls = createCalls();
+    expect(calls).toHaveLength(1);
+    const title = calls[0][calls[0].indexOf('--title') + 1];
+    expect(title).toContain('frontaliereticino.ch/it/lavoro/');
+    delete process.env.CF_API_TOKEN;
+  });
+});


### PR DESCRIPTION
## Implementato

- `scripts/lib/error-issue-sync.mjs`: shared "top-N recurring error → dedup'd GitHub issue" loop (AGENTS.md #6 — one create/dedupe loop instead of three copy-pasted ones), built on the existing `scripts/lib/github-issue-creator.mjs`.
- `scripts/app-error-issue-sync.mjs`: reads `reports/analytics-latest.json` (already produced weekly by `analytics-report.mjs --save`), syncs GA4 `errorHealth.appErrors` above a count threshold into backlog issues, attaching the matching stack trace from `errorHealth.topStacks` when available.
- `.github/workflows/analytics.yml`: new report-only step ("Sync app_error issues to backlog") wired right after the existing weekly Analytics Report run, `continue-on-error: true` so a sync hiccup never reddens the parent workflow.
- `scripts/posthog-error-issue-sync.mjs` + `.github/workflows/posthog-error-monitor.yml`: new weekly (Tue 07:25 UTC) monitor querying PostHog `$exception` autocapture events via HogQL (same query shape as the existing ad-hoc `scripts/triage-app-errors.mjs`), syncing top recurring exceptions.
- `scripts/cf-5xx-issue-sync.mjs` + `.github/workflows/cf-5xx-monitor.yml`: new daily (03:50 UTC) zone-wide Cloudflare 5xx watchdog, shelling out to the existing `scripts/cf-status-report.mjs --json` (no duplicated CF GraphQL query construct) — complements `production-canary.yml`'s fixed-URL-list probe by catching 5xx on *any* path.
- All three sources: threshold-gated (won't open an issue for a single one-off), capped issues/run, labeled `stability` + a source-specific label (`app-error` / `cloudflare-5xx`) — deliberately **not** `agent:fix` (AGENTS.md's auto-route allowlist is `crawler`/`follow-up` only; a real user-facing error needs human triage first). All error/URL text sanitized via the existing `sanitizeTrackedDiagnosticValue`/`sanitizeUrlLikeText` helpers before it reaches an issue title/body.
- Each sync script guards its live-call `main()` behind `import.meta.url === pathToFileURL(process.argv[1]).href` (same pattern as `scripts/dmarc-monitor.mjs`) so importing them is side-effect-free.
- `tests/error-issue-sync.test.ts` (15 tests, green): covers `syncErrorIssues` (maxIssues cap, title-skip, default/escalated priority) and all three sync scripts' threshold filtering, credential/report-missing no-op paths, and priority escalation — via mocked `node:child_process`/`node:fs`/`fetch`, never a live `gh`/PostHog/Cloudflare call. Cron slots audited against all existing `.github/workflows/*.yml` schedules — no collisions.

## Non implementato (ancora)

Nessuno.