### PR TITLE
fix(seo-audit): fix eventi classifier drift into spa-locale/spa-other (#3232)

### DIFF
--- a/scripts/audit-dist-multi.mjs
+++ b/scripts/audit-dist-multi.mjs
@@ -38,6 +38,7 @@ import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { TYPES_ACCEPT_IN_LANGUAGE_LIST } from '../services/seo/inlanguage-whitelist.data.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
+import { EVENTS_SECTION_RX } from './lib/eventsSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
 import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
@@ -324,7 +325,10 @@ function classifyFeatureRatio(relPath) {
   if (/(?:^|\/)(?:mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|tessin-arbeitsmarkt|marche-travail-tessin|tessin-marche-emploi|mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
   if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane|tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|temps-attente-frontiere)\//.test(p)) return 'border-wait';
-  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
+  // Canton-aware events sections → shared matcher (scripts/lib/eventsSections.mjs).
+  // Was TI-only; leaked non-TI canton events pages into spa-locale/spa-other
+  // once nationwide event sourcing shipped (#3125/#3243), causing #3232.
+  if (EVENTS_SECTION_RX.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }
@@ -340,7 +344,10 @@ function classifyFeatureTitle(relPath) {
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
   if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
-  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
+  // Canton-aware events sections → shared matcher (scripts/lib/eventsSections.mjs).
+  // Was TI-only; leaked non-TI canton events pages into spa-locale/spa-other
+  // once nationwide event sourcing shipped (#3125/#3243), causing #3232.
+  if (EVENTS_SECTION_RX.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }
@@ -356,7 +363,10 @@ function classifyFeatureH1(relPath) {
   if (/(?:^|\/)(?:mercato-lavoro|job-market|arbeitsmarkt|marche-emploi)\//.test(p)) return 'job-market-snapshot';
   if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
-  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
+  // Canton-aware events sections → shared matcher (scripts/lib/eventsSections.mjs).
+  // Was TI-only; leaked non-TI canton events pages into spa-locale/spa-other
+  // once nationwide event sourcing shipped (#3125/#3243), causing #3232.
+  if (EVENTS_SECTION_RX.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -22,6 +22,7 @@ import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { EJP_STRIPPED_MARKER } from '../build-plugins/shared/ejpMarker.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
+import { EVENTS_SECTION_RX } from './lib/eventsSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
 import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
@@ -82,12 +83,16 @@ function classifyFeature(relPath) {
   if (BLOG_SECTION_RX.test(p) || /(?:^|\/)(?:blog|articles)\//.test(p)) return 'blog';
   if (/(?:^|\/)(?:traffico-dogane|border-wait|wartezeit-grenze|temps-attente-douane|tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|temps-attente-frontiere)\//.test(p)) return 'border-wait';
   if (/(?:^|\/)(?:meteo-frontalieri|commute-weather|pendler-wetter|meteo-frontaliers|allerte-meteo|weather-alerts|wetter-warnungen|alertes-meteo)\//.test(p)) return 'weather';
-  // Ticino events hub + per-comune pages (all 4 locale section slugs). These are
-  // inherently markup-heavy (event cards + Event JSON-LD + maps) with a low
-  // text-to-HTML ratio, exactly like border-wait/fuel-daily/weather. Give them
-  // their own ratchet bucket so they don't pollute the spa-locale/spa-other
-  // catch-all (same classifier-drift class as #2853/#2910 fuel/svizzera leaks).
-  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
+  // Canton-aware events hub + per-comune pages (all 4 locale section slugs,
+  // every canton — shared matcher, scripts/lib/eventsSections.mjs). These
+  // are inherently markup-heavy (event cards + Event JSON-LD + maps) with a
+  // low text-to-HTML ratio, exactly like border-wait/fuel-daily/weather.
+  // Give them their own ratchet bucket so they don't pollute the
+  // spa-locale/spa-other catch-all. Was TI-only, which leaked non-TI canton
+  // events pages into spa-locale/spa-other once nationwide event sourcing
+  // shipped (#3125/#3243), causing the #3232 regression (same
+  // classifier-drift class as #2853/#2910 fuel/svizzera leaks).
+  if (EVENTS_SECTION_RX.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -34,6 +34,7 @@ import { fileURLToPath } from 'node:url';
 import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { JOB_BOARD_SECTION_RX } from './lib/jobBoardSections.mjs';
+import { EVENTS_SECTION_RX } from './lib/eventsSections.mjs';
 import { FUEL_SECTION_RX } from './lib/fuelSections.mjs';
 import { BLOG_SECTION_RX } from './lib/articleSections.mjs';
 
@@ -75,12 +76,16 @@ export function classifyFeature(relPath) {
   if (/(?:^|\/)(?:mercato-lavoro|mercato-lavoro-ticino|job-market|ticino-job-market|arbeitsmarkt|arbeitsmarkt-tessin|marche-emploi|marche-travail|marche-emploi-tessin|marche-travail-tessin)\//.test(p)) return 'job-market-snapshot';
   if (BLOG_SECTION_RX.test(p)) return 'blog';
   if (/(?:^|\/)(?:tempi-attesa-frontiera|border-wait-times|grenzwartezeiten|wartezeit-grenze|temps-attente-frontiere)\//.test(p)) return 'border-wait';
-  // Ticino events hub + per-comune pages (all 4 locale section slugs). Split
-  // out so they don't pollute the spa-locale/spa-other catch-all — same
-  // classifier-drift class as #2853/#2910 fuel/svizzera leaks. Mirrors
-  // audit-text-html-ratio.mjs's classifyFeature (kept in sync manually since
-  // the two classifiers intentionally diverge on other buckets).
-  if (/(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/.test(p)) return 'eventi';
+  // Canton-aware events sections (TI legacy + every canton + digest
+  // landings) → shared matcher. Split out so they don't pollute the
+  // spa-locale/spa-other catch-all — same classifier-drift class as
+  // #2853/#2910 fuel/svizzera leaks and the job-board TI-only leak fixed
+  // above. Was TI-only, which leaked non-TI canton events pages into
+  // spa-locale/spa-other once nationwide event sourcing shipped (#3125/
+  // #3243), causing the #3232 regression. Mirrors audit-text-html-ratio.mjs's
+  // classifyFeature (kept in sync manually since the two classifiers
+  // intentionally diverge on other buckets).
+  if (EVENTS_SECTION_RX.test(p)) return 'eventi';
   if (/^\/(en|de|fr)\//.test(p)) return 'spa-locale';
   return 'spa-other';
 }

--- a/scripts/lib/eventsSections.mjs
+++ b/scripts/lib/eventsSections.mjs
@@ -1,0 +1,49 @@
+/**
+ * Shared canton-aware events section matcher.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Shared "is this dist path under an events section?" matcher, extracted
+ * per AGENTS.md non-negotiable #6 (a regex duplicated literally in ≥2 files →
+ * one shared module) so the TI-vs-canton-aware drift class that already hit
+ * job-board (2026-06-11 post-deploy title-length failure, fixed via
+ * `./jobBoardSections.mjs`) doesn't keep recurring feature-by-feature.
+ *
+ * Consumers: the audit feature-classifiers audit-title-length,
+ * audit-text-html-ratio, and audit-dist-multi's copies of both.
+ *
+ * Why this is broad (all cantons, not just TI).
+ *   The old literal was TI-only:
+ *     /(?:^|\/)(?:eventi\/ticino|events\/ticino|veranstaltungen\/tessin|evenements\/tessin)(?:\/|$)/
+ *   Commit c1e56b62679 (#3125/#3243) shipped nationwide event sourcing
+ *   (guidle.com, myswitzerland.com) — every canton now gets its own events
+ *   section via `eventsBasePathForCanton()` (scripts/lib/events-utils.mjs),
+ *   e.g. `/eventi/zurigo/`, `/en/events/aargau/`, `/de/veranstaltungen/bern/`
+ *   — but the classifier kept matching ONLY the TI segment. Every non-TI
+ *   events page fell through to the generic `spa-locale` (en/de/fr) /
+ *   `spa-other` (it) buckets, whose baseline caps are small (30 / event
+ *   pages are markup-heavy by design — event cards + Event JSON-LD + a map —
+ *   so this drifted BOTH the title-length and text-html-ratio ratchets on a
+ *   normal crawl, with no real content-quality regression (issue #3232).
+ *   Matching the locale segment generically (any canton/comune/digest slug)
+ *   removes the false positive and auto-covers any future canton.
+ */
+
+/**
+ * Matches the leading events section segment of a normalised dist path
+ * (a path beginning with `/`, optionally locale-prefixed `/en|/de|/fr`).
+ * Examples that match: `/eventi/ticino/…`, `/eventi/zurigo/…`,
+ * `/en/events/aargau/…`, `/de/veranstaltungen/graubunden/…`,
+ * `/fr/evenements/vaud/…`, `/eventi/questo-weekend/…` (digest landing).
+ */
+export const EVENTS_SECTION_RX =
+  /(?:^|\/)(?:eventi|events|veranstaltungen|evenements)\/[a-z][a-z-]*(?:\/|$)/;
+
+/**
+ * @param {string} normalisedPath path that already starts with `/` and has had
+ *   the `dist/` prefix and trailing `index.html` stripped (the form the audit
+ *   classifiers build before bucketing).
+ * @returns {boolean} true when the path is under any canton-aware events
+ *   section (TI legacy, any canton, or a digest landing).
+ */
+export function isEventsSectionPath(normalisedPath) {
+  return EVENTS_SECTION_RX.test(normalisedPath);
+}

--- a/tests/seo/events-section-classifier.test.ts
+++ b/tests/seo/events-section-classifier.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Guard for the canton-aware events section matcher
+ * (scripts/lib/eventsSections.mjs) and the audit feature classifiers that
+ * consume it (scripts/audit-title-length.mjs, scripts/audit-text-html-ratio.mjs,
+ * scripts/audit-dist-multi.mjs).
+ *
+ * Regression context (issue #3232 — 2026-07-03 post-deploy validate-dist
+ * failure, 28th recurrence): the classifier matched ONLY the TI/Tessin
+ * events segment (`eventi/ticino`, `events/ticino`, `veranstaltungen/tessin`,
+ * `evenements/tessin`), so every NON-TI canton events page fell into the
+ * volatile `spa-locale` / `spa-other` buckets once nationwide event sourcing
+ * shipped (#3125/#3243). Events pages are inherently markup-heavy (event
+ * cards + Event JSON-LD + maps), so this drifted BOTH the title-length and
+ * text-html-ratio ratchets over their small spa-locale/spa-other caps with
+ * no real content-quality regression. These must classify as `eventi` (its
+ * own ratchet bucket) and auto-cover every present and future canton — same
+ * fix shape as the job-board TI-only leak (2026-06-11,
+ * scripts/lib/jobBoardSections.mjs).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyFeature as classifyFeatureTitle } from '../../scripts/audit-title-length.mjs';
+import { isEventsSectionPath, EVENTS_SECTION_RX } from '../../scripts/lib/eventsSections.mjs';
+
+// classifyFeature takes a dist-relative path (with `dist/` prefix + index.html).
+const rel = (p: string) => `dist${p}index.html`;
+
+describe('events section matcher', () => {
+  const eventsPaths = [
+    // TI legacy (regression guard — must keep matching)
+    '/eventi/ticino/',
+    '/en/events/ticino/',
+    '/de/veranstaltungen/tessin/',
+    '/fr/evenements/tessin/',
+    // Non-TI cantons, every locale prefix (the exact #3232 leak case)
+    '/eventi/zurigo/',
+    '/en/events/zurich/',
+    '/en/events/aargau/',
+    '/de/veranstaltungen/aargau/',
+    '/de/veranstaltungen/graubunden/',
+    '/fr/evenements/argovie/',
+    '/fr/evenements/zurich/',
+    '/en/events/graubunden/',
+    '/en/events/schwyz/',
+    '/en/events/thurgau/',
+    // Digest sub-pages (this-week / this-weekend) under a canton section
+    '/eventi/ticino/questa-settimana/',
+    '/en/events/aargau/this-week/',
+    '/de/veranstaltungen/aargau/diese-woche/',
+    '/eventi/argovia/questa-settimana/',
+    // Per-comune leaf page
+    '/de/veranstaltungen/zurich/chur/open-training-acroyoga/',
+    '/en/events/graubunden/flims/flims-unesco-world-heritage-site/',
+  ];
+
+  it.each(eventsPaths)('classifies %s as eventi', (p) => {
+    expect(isEventsSectionPath(p)).toBe(true);
+    expect(classifyFeatureTitle(rel(p))).toBe('eventi');
+  });
+
+  const nonEventsPaths = [
+    // Locale landing / guides must NOT be swallowed by the broadened matcher
+    '/en/guide-cross-border-taxation-2026/',
+    '/de/steuern-und-rente/quellensteuersaetze-tessin-2026/',
+    '/blog/qualche-articolo/',
+    '/glossario-frontaliere/',
+    // Job-board must stay distinct
+    '/cerca-lavoro-ticino/',
+    '/en/find-jobs-geneva/',
+  ];
+
+  it.each(nonEventsPaths)('does NOT classify %s as eventi', (p) => {
+    expect(isEventsSectionPath(p)).toBe(false);
+    expect(classifyFeatureTitle(rel(p))).not.toBe('eventi');
+  });
+
+  it('regex is anchored on a path boundary (no mid-segment false match)', () => {
+    // A path whose segment merely contains "events" mid-word must not match.
+    expect(EVENTS_SECTION_RX.test('/blog/best-events-in-switzerland/')).toBe(false);
+  });
+
+  it('does not match a bare events root with no canton/comune segment', () => {
+    expect(EVENTS_SECTION_RX.test('/eventi/')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Root-caused and fixed the `eventi` classifier-drift bug behind the recurring (28th occurrence) `validate-dist` failure in #3232, for both gates:

- **text-html-ratio**: `classifyFeature()`'s eventi-bucket regex in `scripts/audit-text-html-ratio.mjs` (and the manually-synced copies in `scripts/audit-title-length.mjs` and `scripts/audit-dist-multi.mjs`'s 3 classifiers) was TI-only, matching only `ticino`/`tessin` path segments. Once nationwide event sourcing shipped (#3125/#3243), non-TI canton event pages (Zürich, Aargau, Graubünden, etc.) fell through into the generic `spa-locale`/`spa-other` catch-all buckets, which have small baseline caps — the false-positive regression.
- **title-length**: same root cause, same buckets, same fix (shared `classifyFeature`, confirmed via grep that `audit-h1-title-duplicates.mjs` / `audit-title-no-disambig-hash.mjs` import it directly rather than duplicating it, so they inherit the fix with no code change).
- Same classifier-drift bug class previously fixed for job-board sections (2026-06-11, `JOB_BOARD_SECTION_RX`). Applied the identical pattern here: extracted a shared canton-aware `EVENTS_SECTION_RX` into a new `scripts/lib/eventsSections.mjs`, used it in all 4 real occurrences (Non-Negotiable #6 — fixed the whole class in one PR, not just the CI-blocking file).
- Added `tests/seo/events-section-classifier.test.ts` (28 cases: TI legacy, every non-TI canton × all 4 locales, digest sub-pages, per-comune leaf pages, path-boundary/anchoring guards) mirroring the existing `job-board-section-classifier.test.ts` precedent.
- **Verified against real production data**, not just synthetic tests: sampled actual offender paths from the failing CI run's downloaded artifact (deploy_run_id 28560349880 / validate run 28564001685) — confirmed non-TI canton event pages (`de/veranstaltungen/graubunden/...`, `en/events/graubunden/...`, `fr/evenements/grisons/...`, `eventi/grigioni/...`) were misclassified as `spa-locale`/`spa-other` under the old regex, and now correctly classify as `eventi` under the fix.
- **Measured the fix against the real failing dist** via `audit-dist-from-run.yml` replay (this branch's code against deploy_run_id 28670120203's `github-pages` artifact — run [28680464541](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28680464541)):
  - `audit:title-length` → PASS, baseline ratchet OK, no regressions.
  - `audit:text-html-ratio` → PASS, 64 offenders ≤ baseline 111 (−47 offenders moved out of the mis-bucketed catch-alls into `eventi`).
- GitNexus pre-commit check: `detect_changes({scope:"all"})` reports 0 (expected — diff was already committed by the time of the check). `detect_changes({scope:"compare", base_ref:"origin/main"})` errors with `ENOBUFS` (this worktree's branch point has diverged far from current `origin/main`, overflowing the tool's diff buffer — a tool limitation, not a code issue). Substituted a manual grep audit: confirmed `classifyFeature` (the only touched exported symbol) has exactly 2 direct importers (`audit-h1-title-duplicates.mjs`, `audit-title-no-disambig-hash.mjs`), both safe re-exporters unaffected by the bucket-label change; the other touched files (`audit-dist-multi.mjs`'s 3 inline classifier copies) are manually-synced duplicates by design, all 3 updated identically in this PR.
- The separately-tracked `weekly-employers` title-length regression (491 vs baseline 12) was already fixed on `origin/main` by #3365 (merged before this branch was cut) via a different root cause (brand-suffix concatenation bypassing `buildTitleWithBrand`) — no action needed here.

## Non implementato (ancora)

Nessuno.

Closes #3232
