### PR TITLE
fix(seo): thread escape-aware measureLength through composeSerpJobTitle disambiguator branch

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -253,6 +253,15 @@ export function safeIsoDate(raw: unknown): string | null {
  *
  * The optional `disambiguator` is appended as ` · {token}` INSIDE the
  * 66-char cap (audit:title-length) for collision-prone titles.
+ *
+ * `measureLength` mirrors {@link composeSerpJobTitle}'s option: the result
+ * of this wrapper is emitted as `<title>${esc(title)}</title>` further down
+ * this file, so callers MUST pass `(s) => esc(s).length` (the local `esc`
+ * defined inside {@link jobsSeoPagesPlugin}) so the brand-append decision is
+ * budgeted on the escaped string that actually ships, not the pre-escape
+ * one — a raw `&`/`<`/`>`/`"` in the role/company/city expands on escape and
+ * can otherwise let a title exceed the cap post-escape (same class fixed in
+ * seoPageShell.ts's `normalizeShellTitle`, PR #3365 / #3402).
  */
 export function composeJobPageTitle(
  jobTitle: string,
@@ -261,8 +270,9 @@ export function composeJobPageTitle(
  locale: string,
  disambiguator?: string,
  cityOptional?: boolean,
+ measureLength?: (s: string) => number,
 ): string {
- return composeSerpJobTitle(jobTitle, company, city, locale, { disambiguator, cityOptional });
+ return composeSerpJobTitle(jobTitle, company, city, locale, { disambiguator, cityOptional, measureLength });
 }
 
 /**
@@ -2271,10 +2281,10 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  for (const locale of localeList) {
  const lt = String(job?.titleByLocale?.[locale] || job.title || '');
  const loc = String(job.location || '').trim();
- const baseTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale);
+ const baseTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale, undefined, undefined, (s) => esc(s).length);
  const bucket = titleCollisionByLocale[locale];
  bucket.set(baseTitle, (bucket.get(baseTitle) || 0) + 1);
- const noCityTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale, undefined, true);
+ const noCityTitle = composeJobPageTitle(lt, String(job.company || ''), loc, locale, undefined, true, (s) => esc(s).length);
  const noCityBucket = noCityTitleCollisionByLocale[locale];
  noCityBucket.set(noCityTitle, (noCityBucket.get(noCityTitle) || 0) + 1);
  }
@@ -2579,7 +2589,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // locale. The non-disambiguated probe doubles as `ogTitle` (social
  // cards omit the disambiguator by design — see comment below). Saves
  // 1 call per page always, 2 when no collision (the common case).
- const baseTitleProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale);
+ const baseTitleProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, undefined, undefined, (s) => esc(s).length);
  const collidesInLocale = (titleCollisionByLocale[locale].get(baseTitleProbe) || 0) > 1;
  // City-drop decision (#1932): drop the city ONLY when this page does not
  // collide on the full (with-city) title AND its city-less "role — company"
@@ -2587,7 +2597,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // collapse two multi-sede pages into a duplicate <title> (audit:title-
  // uniqueness). On the residual mid-`…` pages (role+city > 66 char) this lets
  // the bare role fill the budget verbatim instead of truncating mid-word.
- const noCityProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, undefined, true);
+ const noCityProbe = composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, undefined, true, (s) => esc(s).length);
  const cityIsDroppable = !collidesInLocale
   && (noCityTitleCollisionByLocale[locale].get(noCityProbe) || 0) <= 1;
  // Build a HUMAN-READABLE disambiguator from the job's metadata (cascade:
@@ -2602,7 +2612,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // `cityIsDroppable` only ever holds when the page does NOT collide, so
  // `disambiguatorToken` is empty here and the droppable branch is `noCityProbe`.
  let title = disambiguatorToken
- ? composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, disambiguatorToken)
+ ? composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, disambiguatorToken, undefined, (s) => esc(s).length)
  : (cityIsDroppable ? noCityProbe : baseTitleProbe);
  // <title> must differ from the <h1> (audit:h1-title-duplicates). With the
  // role>city>company cascade the title normally carries the city or brand
@@ -2616,6 +2626,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
   localizedTitle, String(job.company || ''), jobLocation, locale,
   h1AvoidToken || `${REF_LABEL[locale] || REF_LABEL.it} ${fnv8(String(job.slug || job.id || localizedTitle))}`,
   cityIsDroppable,
+  (s) => esc(s).length,
  );
  }
  // Cross-corpus uniqueness net (see claimUniqueTitle above): guarantees no
@@ -2623,7 +2634,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // The recompose preserves the city-drop decision so a clash falls back to a
  // disambiguator on the SAME (city-less or city-bearing) headline shape.
  title = claimUniqueTitle(locale, title, `${String(job.slug || job.id || '')}::${locale}`,
- (d) => composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, d, cityIsDroppable));
+ (d) => composeJobPageTitle(localizedTitle, String(job.company || ''), jobLocation, locale, d, cityIsDroppable, (s) => esc(s).length));
  // Clean variant for og:title — the city-bearing probe minus any trailing
  // " · {disambiguator}". The disambig is needed in the HTML <title> for SEO
  // uniqueness, but social cards look better without the trailing metadata.
@@ -10991,9 +11002,16 @@ ${staticAnalyticsHtml}
  // word-truncated the headline to make room for it. Uniqueness is now
  // guaranteed by claimUniqueTitle (cross-corpus registry, see above)
  // which only suffixes a `rif.` token on an ACTUAL collision.
- // Note: we work on the RAW headline (no HTML-escape) so `&` / `<` are not
- // expanded into multi-char entities that fool the length-based budget;
- // esc() is applied ONCE at the <title> call site downstream.
+ // Note: candidate/headline SELECTION works on the RAW strings (no
+ // HTML-escape) so `&` / `<` are not expanded into multi-char entities that
+ // fool the cascade's length-based budget; the concatenated headline itself
+ // stays unescaped here. The FINAL brand-append decision, though, is
+ // budgeted on the escaped length (`measureLength: (s) => esc(s).length`,
+ // #3402) because esc() is applied ONCE at the <title> call site downstream
+ // and a raw `&`/`<`/`>`/`"` expands on that escape — checking pre-escape
+ // length there could let a title exceed the cap post-escape. Must match
+ // the measureLength used to populate `noCityTitleCollisionByLocale`
+ // (composeJobPageTitle call sites above) so the probe keys line up.
  // City-drop on expired soft-landings (#1932): the city is droppable when the
  // city-less "role — company" headline is unique among ACTIVE pages in this
  // locale (noCityTitleCollisionByLocale). The shared claimUniqueTitle registry
@@ -11003,14 +11021,14 @@ ${staticAnalyticsHtml}
  // on the non-colliding majority (22.8 % of expired titles overflowed at
  // role+city > 66 char).
  const __expiredNoCityProbe = hasRealTitle
-  ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { cityOptional: true })
-  : composeSerpJobTitle(copy.title, '', jobLocation, locale, { cityOptional: true });
+  ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { cityOptional: true, measureLength: (s) => esc(s).length })
+  : composeSerpJobTitle(copy.title, '', jobLocation, locale, { cityOptional: true, measureLength: (s) => esc(s).length });
  const __expiredCityDroppable = hasRealTitle
   && (noCityTitleCollisionByLocale[locale].get(__expiredNoCityProbe) || 0) <= 1;
  const __expiredCompose = (disambiguator?: string): string =>
   hasRealTitle
-   ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { disambiguator, cityOptional: __expiredCityDroppable })
-   : composeSerpJobTitle(copy.title, '', jobLocation, locale, { disambiguator });
+   ? composeSerpJobTitle(jobTitle, jobCompany, jobLocation, locale, { disambiguator, cityOptional: __expiredCityDroppable, measureLength: (s) => esc(s).length })
+   : composeSerpJobTitle(copy.title, '', jobLocation, locale, { disambiguator, measureLength: (s) => esc(s).length });
  let pageTitleRaw = __expiredCompose();
  // <h1> equality guard (audit:h1-title-duplicates): the static H1 below is
  // "role — company"; when the cascade lands on that exact string and the

--- a/build-plugins/shared/titleSuffix.ts
+++ b/build-plugins/shared/titleSuffix.ts
@@ -189,6 +189,18 @@ export interface SerpJobTitleOptions {
    * (17.8 % active / 22.8 % expired) on non-colliding role+company pages.
    */
   cityOptional?: boolean;
+  /**
+   * Length function used for the FINAL brand-decision (mirrors
+   * {@link buildTitleWithBrand}'s `measureLength` param). Default raw
+   * `.length`. Callers whose composed title is emitted through a render
+   * layer that HTML-escapes it exactly once (e.g. `<title>${esc(title)}</title>`
+   * in `jobsSeoPagesPlugin.ts`) must pass `(s) => esc(s).length` so the
+   * brand-append decision is budgeted on the string that actually ships —
+   * see {@link buildTitleWithBrand} for the "C&A Schweiz" rationale. Only
+   * applied to the internal {@link buildTitleWithBrand} call; the candidate
+   * cascade above still selects on raw length (unaffected by this option).
+   */
+  measureLength?: (s: string) => number;
 }
 
 /**
@@ -283,7 +295,7 @@ export function composeSerpJobTitle(
       ? truncateHeadline(role, roleBudget) + cityTail
       : truncateHeadline(role, budget);
   }
-  return buildTitleWithBrand(headline + disamb, brand, maxChars);
+  return buildTitleWithBrand(headline + disamb, brand, maxChars, options.measureLength);
 }
 
 /**

--- a/tests/jobs-seo-title-h1-datemodified.test.ts
+++ b/tests/jobs-seo-title-h1-datemodified.test.ts
@@ -7,7 +7,7 @@ import {
  fnv8,
  titleCompareKey,
 } from '../build-plugins/jobsSeoPagesPlugin';
-import { composeSerpJobTitle, truncateHeadline, TITLE_MAX_CHARS } from '../build-plugins/shared/titleSuffix';
+import { composeSerpJobTitle, truncateHeadline, TITLE_MAX_CHARS, TITLE_BRAND_SUFFIX } from '../build-plugins/shared/titleSuffix';
 import { stripLeadingSectionLabel } from '../build-plugins/shared/jobDescription/parser';
 
 describe('safeIsoDate', () => {
@@ -114,6 +114,51 @@ describe('composeSerpJobTitle (role > city > company > brand cascade)', () => {
  const malformedCity = ': Ticino, Switzerland.Availability to work on-site is required. What we offer youAt ALTEN you benefit from a permanent contract.';
  const out = composeSerpJobTitle('Java Software Ingegnere', 'ALTEN Switzerland', malformedCity, 'it');
  expect(out.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ });
+});
+
+describe('composeSerpJobTitle measureLength (#3402: disambiguator-branch escape-budget gap)', () => {
+ // Follow-up from PR #3365's adversarial check: the internal recursive
+ // buildTitleWithBrand call at titleSuffix.ts:286 (the disambiguator branch)
+ // did not forward measureLength, so the brand-append decision was always
+ // budgeted on the RAW (pre-escape) length even for callers whose composed
+ // title is later HTML-escaped exactly once (jobsSeoPagesPlugin.ts's
+ // `<title>${esc(title)}</title>`). A company/role/city containing `&`
+ // expands by 4 chars on escape ("&" -> "&amp;"), which can silently push
+ // an already-budgeted title past the 66-char cap post-escape.
+ const esc = (s: string): string => s
+ .replace(/&/g, '&amp;')
+ .replace(/</g, '&lt;')
+ .replace(/>/g, '&gt;')
+ .replace(/"/g, '&quot;');
+ const role = 'Addetto vendite senior';
+ const company = 'C&A';
+ const city = 'Lugano';
+ const disambiguator = '80%';
+
+ it('without measureLength (raw default): brand is appended but the escaped title overflows the cap', () => {
+ const out = composeSerpJobTitle(role, company, city, 'it', { disambiguator });
+ expect(out.endsWith(TITLE_BRAND_SUFFIX)).toBe(true);
+ expect(out.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ // The string that actually ships in <title>${esc(title)}</title> blows
+ // the cap — this is the exact gap #3402 flagged for the reachable path.
+ expect(esc(out).length).toBeGreaterThan(TITLE_MAX_CHARS);
+ });
+
+ it('with escape-aware measureLength: brand is dropped so the escaped title respects the cap', () => {
+ const out = composeSerpJobTitle(role, company, city, 'it', {
+ disambiguator,
+ measureLength: (s) => esc(s).length,
+ });
+ expect(out.endsWith(TITLE_BRAND_SUFFIX)).toBe(false);
+ expect(esc(out).length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+ });
+
+ it('composeJobPageTitle wrapper forwards measureLength to the disambiguator branch (live call-site shape)', () => {
+ const withoutFix = composeJobPageTitle(role, company, city, 'it', disambiguator);
+ const withFix = composeJobPageTitle(role, company, city, 'it', disambiguator, undefined, (s) => esc(s).length);
+ expect(esc(withoutFix).length).toBeGreaterThan(TITLE_MAX_CHARS);
+ expect(esc(withFix).length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
  });
 });
 


### PR DESCRIPTION
## Implementato

Follow-up from PR #3365's adversarial check (issue #3402): `build-plugins/shared/titleSuffix.ts:286`'s recursive `buildTitleWithBrand` call (the disambiguator branch inside `composeSerpJobTitle`) never forwarded `measureLength`, so the brand-append decision was always budgeted on the raw (pre-escape) length.

**Reachability confirmed**: this path IS live. `build-plugins/jobsSeoPagesPlugin.ts` composes job-page `<title>` via `composeJobPageTitle`/`composeSerpJobTitle` (both active-job cascade around `jobsSeoPagesPlugin.ts:2592-2636` and expired-job cascade at `jobsSeoPagesPlugin.ts:11017-11024`) then emits `` `<title>${esc(title)}</title>` `` directly — unlike `build-plugins/shared/seoPageShell.ts:65`'s `normalizeShellTitle` (already fixed in #3365), which strips and re-decides the brand suffix AFTER escaping. A company/role/city containing `&`/`<`/`>`/`"` (e.g. "C&A") can therefore push a title past the 66-char cap post-escape in the SERP — same class of bug as #3365.

Changes:
- `build-plugins/shared/titleSuffix.ts`: added optional `measureLength` to `SerpJobTitleOptions`, threaded to the `buildTitleWithBrand` call at line ~295 (was line 286 pre-diff).
- `build-plugins/jobsSeoPagesPlugin.ts`: added matching `measureLength` param to the `composeJobPageTitle` wrapper; updated all 7 live call sites (active-job title composition + collision-map population) and both expired-job `composeSerpJobTitle` calls to pass `(s) => esc(s).length` (the file's local `esc`). Applied consistently to BOTH the map-population pass and the query/probe calls so `titleCollisionByLocale`/`noCityTitleCollisionByLocale` keys stay in sync (population and lookup must use the same measure or collisions get silently missed).
- `tests/jobs-seo-title-h1-datemodified.test.ts`: new `describe('composeSerpJobTitle measureLength (#3402...)')` block — regression case with `company: 'C&A'` proving (a) without `measureLength` the brand is appended but the escaped title exceeds `TITLE_MAX_CHARS`, (b) with `measureLength: (s) => esc(s).length` the brand is correctly dropped so the escaped title respects the cap, and (c) the `composeJobPageTitle` wrapper forwards the option correctly.

Sibling check (AGENTS.md #6): grepped all `buildTitleWithBrand(`/`composeSerpJobTitle(` call sites repo-wide. `build-plugins/publisherAdPagesPlugin.ts:405` calls `composeSerpJobTitle` without `measureLength`, but its result flows into `buildSeoPageHtml` → `seoPageShell.ts`'s `normalizeShellTitle`, which strips any existing brand suffix and re-decides it with the escape-aware measure regardless of what `composeSerpJobTitle` chose — so that call site is self-healing and not part of this bug class; left unchanged. All other `buildTitleWithBrand(` call sites (annualReportPlugin.ts, weeklyEmployersPlugin.ts, costOfLivingLandingsCopy.ts, etc.) call it directly, not through `composeSerpJobTitle`'s recursive branch, so they don't have this specific gap.

Ran `npx tsc --noEmit` on the two touched source files (clean) and targeted vitest: `tests/jobs-seo-title-h1-datemodified.test.ts`, `tests/job-title-location.test.ts`, `tests/title-length.test.ts`, `tests/format-seo-title.test.ts`, `tests/seo/gsc-keyword-title-fallback.test.ts`, `tests/jobs-seo-pages-plugin.test.ts`, `tests/seo/job-detail-html-snapshot.test.ts`, `tests/job-board-titles.test.ts`, `tests/seo/static-job-page-body.test.ts`, `tests/seo/static-job-page-spa-alignment.test.ts`, `tests/clamp-meta-description.test.ts` — all green.

## Non implementato (ancora)

Nessuno.

Closes #3402