### PR TITLE
feat(border-webcams): expand webcam coverage + fix dead CV-registry siblings

### DIFF
--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -247,6 +247,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'low',
  peak: 'border.peak.lowTraffic',
  tips: 'border.tips.lanzoArogno',
+ webcams: [
+ {
+ label: "Lago di Lugano – vista da Lanzo d'Intelvi (SkylineWebcams)",
+ imageUrl: 'https://cdn.skylinewebcams.com/live5540.jpg',
+ sourceName: 'SkylineWebcams',
+ sourceUrl: 'https://www.skylinewebcams.com/en/webcam/italia/lombardia/como/lago-di-lugano.html',
+ refreshIntervalMs: 300000,
+ },
+ ],
  },
  {
  name: "Campione d'Italia-Bissone",
@@ -416,6 +425,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'closed',
  peak: '---',
  tips: 'border.tips.roderoStabio',
+ webcams: [
+ {
+ label: 'Stabio – ROTOFIL fabrics SA (webcam meteo)',
+ imageUrl: 'https://images-webcams.windy.com/80/1307708880/current/original/1307708880.jpg',
+ sourceName: 'ROTOFIL fabrics SA',
+ sourceUrl: 'https://rotofil.com/index.php/32/Webcam',
+ refreshIntervalMs: 300000,
+ },
+ ],
  },
  {
  name: 'Saltrio-Arzo',
@@ -433,6 +451,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'low',
  peak: '7:30-8:30',
  tips: 'border.tips.saltrioArzo',
+ webcams: [
+ {
+ label: 'Arzo – Cappella San Carlo (webcam meteo)',
+ imageUrl: 'https://www.webcam-4insiders.com/current/thumbnail/10557.jpg',
+ sourceName: '4Insiders Weather Webcam',
+ sourceUrl: 'https://www.4insiders.webcam/webcam/arzo/10557',
+ refreshIntervalMs: 300000,
+ },
+ ],
  },
  {
  name: 'Ponte Tresa',
@@ -527,6 +554,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'low',
  peak: 'border.peak.lowTraffic',
  tips: 'border.tips.zennaDirinella',
+ webcams: [
+ {
+ label: 'Maccagno con Pino e Veddasca – Lago Maggiore (stessa sponda di Zenna)',
+ imageUrl: 'https://weather-cams.visioray.com/snap/3590.jpg',
+ sourceName: 'Webcam Maccagno – Lago Maggiore',
+ sourceUrl: 'https://www.ilmeteo.it/webcam/Maccagno',
+ refreshIntervalMs: 300000,
+ },
+ ],
  },
  {
  name: 'Biegno-Indemini',
@@ -544,6 +580,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'low',
  peak: 'border.peak.lowTraffic',
  tips: 'border.tips.biegnoIndemini',
+ webcams: [
+ {
+ label: 'Indemini – panorama verso Alpe Sciaga / Monte Tamaro',
+ imageUrl: 'https://lunasole.ch/webcam/latest.jpg',
+ sourceName: 'Webcam Indemini (lunasole.ch)',
+ sourceUrl: 'https://lunasole.ch/webcam/',
+ refreshIntervalMs: 60000,
+ },
+ ],
  },
  {
  name: 'Dumenza-Cassinone',
@@ -561,6 +606,15 @@ export const borderCrossings: BorderCrossing[] = [
  trafficLevel: 'low',
  peak: 'border.peak.lowTraffic',
  tips: 'border.tips.dumenzaCassinone',
+ webcams: [
+ {
+ label: 'Dumenza – webcam comunale',
+ imageUrl: 'https://webcam.comune.dumenza.va.it/download.php?file=dumenza.jpg',
+ sourceName: 'Comune di Dumenza',
+ sourceUrl: 'https://webcam.comune.dumenza.va.it/',
+ refreshIntervalMs: 300000,
+ },
+ ],
  },
  // VERBANIA - TICINO / VS
  {

--- a/scripts/analyze-webcam-frame.mjs
+++ b/scripts/analyze-webcam-frame.mjs
@@ -24,7 +24,7 @@
  * scored (informational), but reported as visibility:'warming-up' with
  * queueDetected:false, so aggregateWebcamResults excludes it from the vote.
  *
- * MAJORITY VOTE: with several cameras per crossing (chiasso-brogeda now sees 4),
+ * MAJORITY VOTE: with several cameras per crossing (chiasso-brogeda now sees 2),
  * a queue flagged on a SINGLE camera is no longer enough — aggregateWebcamResults
  * requires a majority of the good feeds to agree before emitting queueDetected,
  * cutting the structural false-positive rate of the previous any-one-frame rule.
@@ -104,34 +104,13 @@ export const WEBCAM_FEEDS = {
     // Short at-booth urban view (Chiasso centro). Live free-flow ~2 cars (0.20).
     capacity: 10,
   },
-  '00.3S': {
-    url: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/00.3S.gif',
-    crossings: ['chiasso-brogeda'],
-    box: [0, 30, 400, 195],
-    // At-booth Brogeda. Live free-flow ~4 cars (0.29).
-    capacity: 14,
-  },
-  // North view over the Brogeda interchange: permanent multi-lane gantries/buildings.
-  // The old variance heuristic read those structures as a permanent "queue"; YOLO
-  // ignores them (no vehicle class), but the lanes here serve commercial/interchange
-  // flow rather than the passenger-car wait, so this view stays DISPLAY-only
-  // (`cvDetect:false`) and is excluded from queue-detection.
-  '00.3N': {
-    url: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/00.3N.gif',
-    crossings: ['chiasso-brogeda'],
-    box: [0, 30, 400, 195],
-    capacity: 14,
-    cvDetect: false,
-  },
-  // Commercial-customs lane (Brogeda merci): parked/queuing trucks are a constant
-  // regardless of passenger-car wait. Display/CLI only; excluded from queue-detection.
-  '00.3O': {
-    url: 'https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/00.3O.gif',
-    crossings: ['chiasso-brogeda'],
-    box: [0, 30, 400, 195],
-    capacity: 14,
-    cvDetect: false,
-  },
+  // '00.3S'/'00.3N'/'00.3O' (Brogeda at-booth + interchange + commercial-customs
+  // views) REMOVED 2026-07-03 (sibling of issue #3372/#3274): the upstream
+  // www4.ti.ch feeds now consistently return HTTP 200 with a 0-byte body
+  // (confirmed 3x, ~10s apart). Already dropped from the display catalog in
+  // data/borderCrossings.ts (#3274); this registry still had them wired into
+  // queue detection, so chiasso-brogeda's vote silently included a dead feed.
+  // No replacement filename found. chiasso-brogeda now votes on 03.3S + 04.4N.
   // Stabio/Gaggiolo near road view. This is the camera whose variance heuristic
   // false-reported a 15-min wait on a free-flowing road; vehicle counting fixes it.
   '02.0N': {
@@ -191,7 +170,7 @@ export const WEBCAM_FEEDS = {
 export const CROSSING_TO_PRIMARY_FEED = {
   'chiasso-centro': '01.2S',
   'chiasso-strada': '01.2S',
-  'chiasso-brogeda': '00.3S',
+  'chiasso-brogeda': '03.3S',
   'gaggiolo': '02.0N',
   'san-pietro': '02.0N',
   'campione-d-italia-bissone': '17.84S',

--- a/tests/analyze-webcam-aggregate.test.ts
+++ b/tests/analyze-webcam-aggregate.test.ts
@@ -183,9 +183,12 @@ describe('isFeedWarmingUp', () => {
 
 describe('CROSSING_TO_FEEDS registry', () => {
   it('derives multiple detection feeds for the high-traffic crossings', () => {
+    // '00.3S' was removed (sibling of issue #3372/#3274): the upstream www4.ti.ch
+    // feed now returns a 0-byte body; chiasso-brogeda votes on the 2 remaining feeds.
     expect(CROSSING_TO_FEEDS['chiasso-brogeda']).toEqual(
-      expect.arrayContaining(['00.3S', '03.3S']),
+      expect.arrayContaining(['03.3S', '04.4N']),
     );
+    expect(CROSSING_TO_FEEDS['chiasso-brogeda']).not.toContain('00.3S');
     // '07.2N' was removed (issue #3372): the upstream www4.ti.ch feed 404s and
     // has no replacement; 'gaggiolo' now votes on the two remaining feeds.
     expect(CROSSING_TO_FEEDS['gaggiolo']).toEqual(
@@ -197,13 +200,18 @@ describe('CROSSING_TO_FEEDS registry', () => {
     );
   });
 
-  it('EXCLUDES cvDetect:false feeds (commercial / high-texture views) from queue detection', () => {
-    // 00.3N (Brogeda interchange gantries) + 00.3O (commercial-customs trucks)
-    // are display-only: they must NOT participate in queue detection.
-    expect(WEBCAM_FEEDS['00.3N'].cvDetect).toBe(false);
-    expect(WEBCAM_FEEDS['00.3O'].cvDetect).toBe(false);
-    expect(CROSSING_TO_FEEDS['chiasso-brogeda']).not.toContain('00.3N');
-    expect(CROSSING_TO_FEEDS['chiasso-brogeda']).not.toContain('00.3O');
+  it('EXCLUDES any cvDetect:false feed (commercial / high-texture views) from queue detection', () => {
+    // Generic over the current WEBCAM_FEEDS contents rather than pinned to specific
+    // keys, so this doesn't rot when a cvDetect:false feed is later removed as dead
+    // (as happened to '00.3N'/'00.3O', display-only Brogeda views, on 2026-07-03).
+    const cvDetectFalseKeys = Object.entries(WEBCAM_FEEDS)
+      .filter(([, feed]) => feed.cvDetect === false)
+      .map(([key]) => key);
+    for (const key of cvDetectFalseKeys) {
+      for (const feeds of Object.values(CROSSING_TO_FEEDS)) {
+        expect(feeds).not.toContain(key);
+      }
+    }
   });
 
   it('gives Campione d\'Italia-Bissone its first queue-detection feed', () => {
@@ -226,7 +234,8 @@ describe('CROSSING_TO_FEEDS registry', () => {
   });
 
   it('pre-existing feeds have no introducedAt (they vote unconditionally)', () => {
-    for (const k of ['01.2S', '00.3S', '00.3N', '00.3O', '02.0N', '06.8S']) {
+    // '00.3S'/'00.3N'/'00.3O' removed (sibling of #3372/#3274) — dead upstream feeds.
+    for (const k of ['01.2S', '02.0N', '06.8S']) {
       expect(WEBCAM_FEEDS[k].introducedAt, `feed ${k}`).toBeUndefined();
     }
   });


### PR DESCRIPTION
## Implementato

- Aggiunte 6 nuove webcam per valichi prima scoperti (ognuna curl-verificata live prima del merge nel commit):
  - Lanzo d'Intelvi–Arogno
  - Rodero–Stabio
  - Saltrio–Arzo
  - Zenna–Dirinella
  - Biegno–Indemini
  - Dumenza–Cassinone
- Fix sibling (Non-Negotiable #6): rimossi da `scripts/analyze-webcam-frame.mjs` i feed morti `00.3S`/`00.3N`/`00.3O`, già tolti dal layer di display in `data/borderCrossings.ts` nella PR #3274 ma rimasti orfani nel registry CV traffic-detection (`WEBCAM_FEEDS` + `CROSSING_TO_PRIMARY_FEED`). `chiasso-brogeda` ripuntato a `03.3S` come primary feed.
- Aggiornati i 3 assert in `tests/analyze-webcam-aggregate.test.ts` che referenziavano le chiavi rimosse (derivazione feed, esclusione `cvDetect:false`, elenco `introducedAt`).
- Confermato che `scripts/check-border-data-health.mjs` (`collectWebcamUrls`) legge genericamente `c.webcams[]` da `borderCrossings.ts` — le 6 nuove URL sono automaticamente monitorate dal watchdog nightly, nessuna registrazione manuale extra necessaria.
- Verificato: nessun CSP `img-src` allowlist nel repo da aggiornare per i nuovi domini hotlink esterni.
- 72 test rilevanti verdi (`analyze-webcam-aggregate`, `check-border-data-health`, `border-wait-webcam`).

## Non implementato (ancora)

- **Chiasso Centro / Chiasso Strada (`01.2S.gif`) — NON toccato in questa PR, decisione owner richiesta.** Curl ripetuti oggi mostrano il feed `https://www4.ti.ch/fileadmin/DT/temi/webcams/wct_immagini/01.2S.gif` vivo (HTTP 200, 324663 byte, `Last-Modified` ~8h) — ma lo stesso giorno il commit `f33b26d7af6` (PR #3352, issue #3338) lo ha rimosso da questi 2 valichi citando "404 genuino, consistente, verificato da IP residenziale". Questo è uno scenario di flapping feed. Non ho ri-aggiunto l'entry per non sovrascrivere silenziosamente una decisione deliberata dello stesso giorno — serve conferma owner se ri-aggiungere (con monitoraggio staleness più stretto) o lasciare rimosso.
- **7 valichi restano scoperti — ricerca esaustiva, nessuna webcam pubblica genuina trovata** (candidati marginali scartati dagli stessi agent di ricerca per distanza eccessiva o freschezza non verificabile — es. cam Windy/Capolago per Porto Ceresio e Cremenaga): Maslianico–Pizzamiglio, Bizzarone–Novazzano, Ronago–Novazzano, Drezzo–Pedrinate, Porto Ceresio–Brusino, Cremenaga–Ponte Cremenaga, Clivio–Ligornetto. Nessun fix noto: blocked, causa esterna reale (assenza di sorgente pubblica).
- 3 valichi restano intenzionalmente senza webcam per policy/test esistenti (non toccati, invariato): Crociale dei Mulini, Maslianico–Roggiana, Ponte Tresa.

## Test plan

- [x] `npx vitest run tests/analyze-webcam-aggregate.test.ts tests/check-border-data-health.test.ts tests/border-wait-webcam.test.ts` → 72/72 verdi
- [x] Ogni nuova URL webcam curl-verificata live (200, body reale) prima del commit