### PR TITLE
fix(seo-404): case-insensitive hostname strip + www. variant support

### DIFF
--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -212,8 +212,10 @@ export interface JobSlugCanonicalIndex {
 
 const ensureTrailingSlash = (p: string): string => (p.endsWith('/') ? p : `${p}/`);
 
+// URL#hostname is already lowercased per the URL spec, so these stay lowercase.
 const SITE_HOSTNAME = new URL(BASE_URL).hostname;
 const DUPLICATE_HOSTNAME_PREFIX = `/${SITE_HOSTNAME}/`;
+const DUPLICATE_HOSTNAME_WWW_PREFIX = `/www.${SITE_HOSTNAME}/`;
 
 function normalizePath(input: string): string {
  let clean = `/${String(input || '').trim().replace(/^\/+/, '')}`.replace(/\/+/g, '/');
@@ -222,7 +224,15 @@ function normalizePath(input: string): string {
  // an absolute-URL-built-as-relative artifact from a stray external backlink)
  // — without this the whole path never matches any branch below and is left
  // unresolved even though the real path after the duplicate IS recoverable.
- if (clean.startsWith(DUPLICATE_HOSTNAME_PREFIX)) clean = clean.slice(SITE_HOSTNAME.length + 1);
+ // Match case-insensitively (GSC may index `/Frontaliereticino.ch/...`) and
+ // also strip an optional `www.` variant. Slice the ORIGINAL (not lowercased)
+ // string so the remaining path keeps its real casing.
+ const lowerClean = clean.toLowerCase();
+ if (lowerClean.startsWith(DUPLICATE_HOSTNAME_WWW_PREFIX)) {
+  clean = clean.slice(DUPLICATE_HOSTNAME_WWW_PREFIX.length - 1);
+ } else if (lowerClean.startsWith(DUPLICATE_HOSTNAME_PREFIX)) {
+  clean = clean.slice(DUPLICATE_HOSTNAME_PREFIX.length - 1);
+ }
  if (clean === '/') return clean;
  return clean.replace(/\/$/, '');
 }

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -460,6 +460,42 @@ describe('Search Console 404 compatibility resolver', () => {
     });
   });
 
+  it('strips a differently-cased leading duplicate hostname (GSC-indexed casing drift)', () => {
+    expect(
+      resolveSearchConsoleCompatTarget(
+        '/Frontaliereticino.ch/en/find-jobs-ticino/some-expired-job-slug',
+      ),
+    ).toEqual({
+      canonicalPath: '/en/find-jobs-ticino/',
+      kind: 'expired-job',
+      locale: 'en',
+    });
+  });
+
+  it('strips a www.-prefixed leading duplicate hostname', () => {
+    expect(
+      resolveSearchConsoleCompatTarget(
+        '/www.frontaliereticino.ch/en/find-jobs-ticino/some-expired-job-slug',
+      ),
+    ).toEqual({
+      canonicalPath: '/en/find-jobs-ticino/',
+      kind: 'expired-job',
+      locale: 'en',
+    });
+  });
+
+  it('strips a differently-cased www.-prefixed leading duplicate hostname', () => {
+    expect(
+      resolveSearchConsoleCompatTarget(
+        '/WWW.FrontaliereTicino.CH/en/find-jobs-ticino/some-expired-job-slug',
+      ),
+    ).toEqual({
+      canonicalPath: '/en/find-jobs-ticino/',
+      kind: 'expired-job',
+      locale: 'en',
+    });
+  });
+
   it('recovers the wrong-locale-word DE TI section guess to the real jobs-im-tessin section', () => {
     expect(resolveSearchConsoleCompatTarget('/de/jobs-in-ticino')).toEqual({
       canonicalPath: '/de/jobs-im-tessin/',


### PR DESCRIPTION
## Implementato

- `build-plugins/searchConsoleCompat.ts` — `normalizePath()`'s `DUPLICATE_HOSTNAME_PREFIX` strip now matches case-insensitively (GSC may index e.g. `/Frontaliereticino.ch/...`), so differently-cased duplicate-hostname artifacts no longer silently stay unresolved.
- Added a `DUPLICATE_HOSTNAME_WWW_PREFIX` variant so a leading `/www.frontaliereticino.ch/...` segment is also stripped (any casing), in addition to the bare-hostname variant.
- The matched prefix is sliced off the *original* (not lowercased) string, so the remaining path keeps its real casing.
- Sibling-pattern check (AGENTS.md #6): grepped `build-plugins/searchConsoleCompat.ts`, `scripts/prune-404-compat-paths.ts`, and `scripts/ingest-gsc-coverage-404s.ts` (the resolver's direct/indirect callers per GitNexus impact) for the same case-sensitive hostname-prefix-strip construct — no other occurrence found. `inferLocale()`'s `startsWith('/en/')`/`'/de/'`/`'/fr/'` checks in the same file are lexically similar (path-prefix `startsWith`) but semantically different (locale detection, not hostname-duplicate stripping) and are not a duplicate of this bug class — treated as a false positive, not touched, to keep the fix surgical.
- Regression tests added to `tests/search-console-compat.test.ts`: differently-cased hostname prefix, `www.`-prefixed hostname, and differently-cased `www.`-prefixed hostname. All 25 tests in the file pass (`npx vitest run tests/search-console-compat.test.ts`).
- GitNexus impact analysis on `resolveSearchConsoleCompatTarget` (the only caller of `normalizePath`, both in `build-plugins/searchConsoleCompat.ts`): risk LOW, 4 direct callers (`scripts/prune-404-compat-paths.ts:main`, `scripts/ingest-gsc-coverage-404s.ts:main`, `legacyRedirectsPlugin.ts closeBundle`, `cfHot404BridgePlugin.ts closeBundle`) — all within the intended SEO-404 resolution pipeline, no unexpected blast radius.

## Non implementato (ancora)

Nessuno

Closes #3401