### PR TITLE
fix(audit): stop scan-prev-slug-losses.mjs colliding on id-less jobs

### DIFF
--- a/scripts/backfill-prev-slugs-from-loss-events.mjs
+++ b/scripts/backfill-prev-slugs-from-loss-events.mjs
@@ -31,6 +31,7 @@ import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { stableSlugHash } from './lib/dedicated-crawler-common.mjs';
+import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -141,9 +142,10 @@ function buildFileLocaleIndex(file, maxCommits = 400) {
     try { parsed = JSON.parse(content); } catch { continue; }
     if (!Array.isArray(parsed?.jobs)) continue;
     for (const job of parsed.jobs) {
-      if (!job?.id) continue;
-      let m = byJob.get(job.id);
-      if (!m) { m = new Map(); byJob.set(job.id, m); }
+      const jobKey = resolveJobDiffKey(job);
+      if (!jobKey) continue;
+      let m = byJob.get(jobKey);
+      if (!m) { m = new Map(); byJob.set(jobKey, m); }
       if (job.previousSlugsByLocale && typeof job.previousSlugsByLocale === 'object') {
         for (const [loc, arr] of Object.entries(job.previousSlugsByLocale)) {
           for (const s of (arr || [])) {
@@ -201,7 +203,7 @@ function main() {
     }
     process.stderr.write(`  [${fileCount}/${filesByName.size}] ${file} (${entries.length} jobs)\n`);
     const slice = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    const byId = new Map(slice.jobs.map(j => [j.id, j]));
+    const byId = new Map(slice.jobs.map(j => [resolveJobDiffKey(j), j]).filter(([k]) => k));
 
     // Build the per-file locale index ONCE; per-job lookup is O(1) below.
     const fileIndex = buildFileLocaleIndex(filePath);
@@ -225,7 +227,7 @@ function main() {
         const { targetJob, redirected } = resolveRecoveryTarget(job, slug, bySuffixHash);
         if (redirected) {
           stats.slugsRedirected = (stats.slugsRedirected || 0) + 1;
-          console.warn(`  ↪️  Redirect "${slug}" from ${jobId} to ${targetJob.id} (disambiguator tail matches that job instead)`);
+          console.warn(`  ↪️  Redirect "${slug}" from ${jobId} to ${resolveJobDiffKey(targetJob)} (disambiguator tail matches that job instead)`);
         }
         let locale = slugLocaleIndex.get(slug);
         if (locale) {
@@ -246,7 +248,7 @@ function main() {
           if (targetJob.previousSlugsByLocale[locale].length > CAP) {
             targetJob.previousSlugsByLocale[locale] = targetJob.previousSlugsByLocale[locale].slice(-CAP);
           }
-          changedJobIds.add(targetJob.id);
+          changedJobIds.add(resolveJobDiffKey(targetJob));
           stats.slugsRestoredByLocale++;
         }
         // Also sync flat previousSlugs for legacy consumers

--- a/scripts/cleanup-jobs.mjs
+++ b/scripts/cleanup-jobs.mjs
@@ -22,6 +22,7 @@ import {
 } from './lib/validate-job-url.mjs';
 import { hardenJobLocaleFields, stableSlugHash } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -388,24 +389,29 @@ async function main() {
         console.log(`⏭️  Slice URL validation skipped (JOBS_SKIP_URL_VALIDATION=1) — keeping ${kept.length} jobs`);
       } else {
         console.log(`🧹 Slice housekeeping: checking ${kept.length} jobs (concurrency=${MAX_CONCURRENCY}, timeout=${TIMEOUT_MS}ms)`);
-        const checks = await validateJobUrls(kept.map((j) => ({ id: j.id, url: j.url })), { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS });
+        // Keyed by resolveJobDiffKey() not bare job.id: id-less per-crawler
+        // slices (JOBS_HOUSEKEEPING_SCOPE+SLICE_FILE mode — see #3411) stamp
+        // `.id` only at data/jobs.json assembly time, so every job.id here is
+        // `undefined` and a bare-id Map collapses all of them onto one key,
+        // making lookups return an arbitrary sibling job's validation result.
+        const checks = await validateJobUrls(kept.map((j) => ({ id: resolveJobDiffKey(j), url: j.url })), { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS });
         const checkById = new Map(checks.map((c) => [c.id, c]));
         const fallbackCandidates = kept
           .filter((job) => {
-            const c = checkById.get(job.id);
+            const c = checkById.get(resolveJobDiffKey(job));
             return c?.valid === false && job.applyUrl && job.applyUrl !== job.url;
           })
-          .map((job) => ({ id: job.id, url: job.applyUrl }));
+          .map((job) => ({ id: resolveJobDiffKey(job), url: job.applyUrl }));
         const fallbackById = fallbackCandidates.length > 0
           ? new Map((await validateJobUrls(fallbackCandidates, { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS })).map((c) => [c.id, c]))
           : new Map();
         kept = kept.filter((job) => {
-          const c = checkById.get(job.id);
+          const c = checkById.get(resolveJobDiffKey(job));
           if (c && c.valid === false) {
-            const fallback = fallbackById.get(job.id);
+            const fallback = fallbackById.get(resolveJobDiffKey(job));
             if (fallback && fallback.valid !== false) return true;
             if (isFreshProtected(job) && !c.definitive) return true;
-            urlRemoved.push({ id: job.id, reason: c.reason });
+            urlRemoved.push({ id: resolveJobDiffKey(job), reason: c.reason });
             return false;
           }
           return true;
@@ -464,12 +470,14 @@ async function main() {
       // map under their disambiguated slug, so they're tracked separately.
       const keptSlugs = new Set(kept.map((j) => j.slug).filter(Boolean));
       const sliceRemoved = hardenedJobs.filter((j) => j.slug && !keptSlugs.has(j.slug));
-      const archiveJobsById = new Map(hardenedJobs.map((j) => [j.id, j]));
-      const archiveRefs = sliceRemoved.map((j) => ({ id: j.id }));
+      // Keyed by resolveJobDiffKey() not bare j.id — see comment above on the
+      // checkById Map for why bare id-less-slice ids collide (#3411).
+      const archiveJobsById = new Map(hardenedJobs.map((j) => [resolveJobDiffKey(j), j]));
+      const archiveRefs = sliceRemoved.map((j) => ({ id: resolveJobDiffKey(j) }));
       for (const loser of dedupLosers) {
-        // Use a synthetic id key to avoid colliding with the original job id
+        // Use a synthetic key to avoid colliding with the original job's key
         // (the original may already be in the map under its pre-dedup slug).
-        const loserKey = `__dedup__${loser.id}__${loser.slug}`;
+        const loserKey = `__dedup__${resolveJobDiffKey(loser)}__${loser.slug}`;
         archiveJobsById.set(loserKey, loser);
         archiveRefs.push({ id: loserKey });
       }

--- a/scripts/lib/job-match-key.mjs
+++ b/scripts/lib/job-match-key.mjs
@@ -31,3 +31,35 @@ export function extractStableJobId(url) {
   // pinned byte-for-byte by tests/job-url-key.test.ts.
   return mergeUrlKey(url);
 }
+
+/**
+ * Resolve a diff-stable key for a job record, for building `Map`s keyed by
+ * job identity in audit tooling that reads raw per-crawler slice files
+ * (scripts/scan-prev-slug-losses.mjs, scripts/backfill-prev-slugs-from-loss-events.mjs).
+ *
+ * `.id` is only stamped at data/jobs.json assembly time
+ * (assemble-jobs-dataset.mjs → buildStableId) and is never written back onto
+ * the committed per-crawler slice on disk. Several dedicated crawlers
+ * (ferrovia-retica, julius-baer, mikron, relewant, swiss-medical-network,
+ * casale — see #3411) therefore commit slices where every job's `.id` is
+ * `undefined`. A `Map` keyed on bare `job.id` collapses ALL such jobs in a
+ * slice onto the single `undefined` key, so lookups silently return an
+ * arbitrary sibling job instead of missing — corrupting the diff instead of
+ * just skipping it.
+ *
+ * Falls back, in order: real `.id` > `extractStableJobId(url)` > `slug`.
+ * Returns null only when a job has none of id/url/slug (should not happen
+ * for a real crawled record) so callers can skip it instead of colliding.
+ *
+ * @param {{id?: string, url?: string, slug?: string}} [job]
+ * @returns {string|null}
+ */
+export function resolveJobDiffKey(job = {}) {
+  if (job?.id) return job.id;
+  // extractStableJobId already namespaces its own return value
+  // (uuid:/num:/hex:/url:), so it's used as-is — no double prefix.
+  const urlKey = extractStableJobId(job?.url);
+  if (urlKey) return urlKey;
+  const slug = String(job?.slug || '').trim().toLowerCase();
+  return slug ? `slug:${slug}` : null;
+}

--- a/scripts/scan-prev-slug-losses.mjs
+++ b/scripts/scan-prev-slug-losses.mjs
@@ -19,6 +19,11 @@
  *   Cross-reference with the current working-tree slice to compute
  *   "still recoverable" (i.e. losses not yet healed by later runs).
  *
+ * Jobs are diffed by resolveJobDiffKey() (scripts/lib/job-match-key.mjs),
+ * not bare `.id` — several dedicated crawlers commit slices where `.id` is
+ * never stamped (see #3411), and a Map keyed on bare `.id` would collapse
+ * every such job onto the same `undefined` key.
+ *
  * Usage:
  *   node scripts/scan-prev-slug-losses.mjs [--since "60 days ago"] [--out /tmp/recoverable-slugs.json]
  */
@@ -26,120 +31,171 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const DIR = 'data/jobs/by-crawler';
 const ABS_DIR = path.join(ROOT, DIR);
 
-const args = process.argv.slice(2);
-const sinceIdx = args.indexOf('--since');
-const SINCE = sinceIdx !== -1 ? args[sinceIdx + 1] : '60 days ago';
-const outIdx = args.indexOf('--out');
-const OUT = outIdx !== -1 ? args[outIdx + 1] : '/tmp/recoverable-slugs.json';
-const eventsIdx = args.indexOf('--events-out');
-const EVENTS_OUT = eventsIdx !== -1 ? args[eventsIdx + 1] : '/tmp/prev-slug-loss-events.jsonl';
+/**
+ * Diff two versions of a slice file's `jobs` array and return, for every job
+ * present in both, the slugs that were in `prevJobs`' before-state but are
+ * absent from `curJobs`' after-state. Jobs are matched via
+ * resolveJobDiffKey() so id-less jobs fall back to a stable URL/slug key
+ * instead of colliding under `undefined`.
+ *
+ * Pure function — no I/O — so it's directly unit-testable.
+ *
+ * @param {Array<object>} prevJobs
+ * @param {Array<object>} curJobs
+ * @returns {Array<{ jobKey: string, lost: string[] }>}
+ */
+export function diffJobSlices(prevJobs, curJobs) {
+  const results = [];
+  if (!Array.isArray(prevJobs) || !Array.isArray(curJobs)) return results;
 
-const slices = execSync(`ls ${ABS_DIR}/*.json`, { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
-process.stderr.write(`Scanning ${slices.length} slice files since "${SINCE}"…\n`);
-
-const lossesByJob = new Map();
-const lossesByFile = new Map();
-const lossEvents = [];
-
-let fileIdx = 0;
-for (const file of slices) {
-  fileIdx++;
-  if (fileIdx % 25 === 0) process.stderr.write(`  ${fileIdx}/${slices.length}…\n`);
-  const rel = path.relative(ROOT, file);
-  let commits;
-  try {
-    commits = execSync(
-      `git log --since="${SINCE}" --reverse --pretty=format:%H -- ${rel}`,
-      { encoding: 'utf8', cwd: ROOT }
-    ).trim().split('\n').filter(Boolean);
-  } catch { continue; }
-  if (commits.length === 0) continue;
-
-  let prev = null;
-  for (const commit of commits) {
-    const res = spawnSync('git', ['show', `${commit}:${rel}`],
-      { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, cwd: ROOT });
-    if (res.status !== 0) continue;
-    let cur;
-    try { cur = JSON.parse(res.stdout); } catch { continue; }
-    if (!cur?.jobs) continue;
-    if (prev && Array.isArray(prev.jobs)) {
-      const byId = new Map(prev.jobs.map(j => [j.id, j]));
-      for (const aj of cur.jobs) {
-        const bj = byId.get(aj.id);
-        if (!bj) continue;
-        const beforeAll = new Set();
-        if (Array.isArray(bj.previousSlugs)) for (const s of bj.previousSlugs) if (s) beforeAll.add(s);
-        if (bj.previousSlugsByLocale) for (const a of Object.values(bj.previousSlugsByLocale))
-          for (const s of (a || [])) if (s) beforeAll.add(s);
-        if (bj.slug) beforeAll.add(bj.slug);
-        if (bj.slugByLocale) for (const s of Object.values(bj.slugByLocale)) if (s) beforeAll.add(s);
-        const afterActive = new Set();
-        if (aj.slug) afterActive.add(aj.slug);
-        if (aj.slugByLocale) for (const s of Object.values(aj.slugByLocale)) if (s) afterActive.add(s);
-        const afterPrev = new Set();
-        if (Array.isArray(aj.previousSlugs)) for (const s of aj.previousSlugs) if (s) afterPrev.add(s);
-        if (aj.previousSlugsByLocale) for (const a of Object.values(aj.previousSlugsByLocale))
-          for (const s of (a || [])) if (s) afterPrev.add(s);
-        const lost = [...beforeAll].filter(s => !afterActive.has(s) && !afterPrev.has(s));
-        if (lost.length === 0) continue;
-        lossEvents.push({ commit: commit.slice(0, 10), file: file.replace(`${ABS_DIR}/`, ''), jobId: aj.id, lost });
-        lossesByFile.set(file, (lossesByFile.get(file) || 0) + lost.length);
-        if (!lossesByJob.has(aj.id)) lossesByJob.set(aj.id, { slugs: new Set(), file });
-        for (const s of lost) lossesByJob.get(aj.id).slugs.add(s);
-      }
-    }
-    prev = cur;
+  const byKey = new Map();
+  for (const j of prevJobs) {
+    const key = resolveJobDiffKey(j);
+    if (key) byKey.set(key, j);
   }
+
+  for (const aj of curJobs) {
+    const key = resolveJobDiffKey(aj);
+    if (!key) continue;
+    const bj = byKey.get(key);
+    if (!bj) continue;
+
+    const beforeAll = new Set();
+    if (Array.isArray(bj.previousSlugs)) for (const s of bj.previousSlugs) if (s) beforeAll.add(s);
+    if (bj.previousSlugsByLocale) for (const a of Object.values(bj.previousSlugsByLocale))
+      for (const s of (a || [])) if (s) beforeAll.add(s);
+    if (bj.slug) beforeAll.add(bj.slug);
+    if (bj.slugByLocale) for (const s of Object.values(bj.slugByLocale)) if (s) beforeAll.add(s);
+
+    const afterActive = new Set();
+    if (aj.slug) afterActive.add(aj.slug);
+    if (aj.slugByLocale) for (const s of Object.values(aj.slugByLocale)) if (s) afterActive.add(s);
+
+    const afterPrev = new Set();
+    if (Array.isArray(aj.previousSlugs)) for (const s of aj.previousSlugs) if (s) afterPrev.add(s);
+    if (aj.previousSlugsByLocale) for (const a of Object.values(aj.previousSlugsByLocale))
+      for (const s of (a || [])) if (s) afterPrev.add(s);
+
+    const lost = [...beforeAll].filter(s => !afterActive.has(s) && !afterPrev.has(s));
+    if (lost.length === 0) continue;
+    results.push({ jobKey: key, lost });
+  }
+
+  return results;
 }
 
-const totalLost = [...lossesByJob.values()].reduce((n, x) => n + x.slugs.size, 0);
-console.log(JSON.stringify({
-  since: SINCE,
-  totalLost,
-  filesAffected: lossesByFile.size,
-  jobsAffected: lossesByJob.size,
-  eventsCount: lossEvents.length,
-}, null, 2));
+function main() {
+  const args = process.argv.slice(2);
+  const sinceIdx = args.indexOf('--since');
+  const SINCE = sinceIdx !== -1 ? args[sinceIdx + 1] : '60 days ago';
+  const outIdx = args.indexOf('--out');
+  const OUT = outIdx !== -1 ? args[outIdx + 1] : '/tmp/recoverable-slugs.json';
+  const eventsIdx = args.indexOf('--events-out');
+  const EVENTS_OUT = eventsIdx !== -1 ? args[eventsIdx + 1] : '/tmp/prev-slug-loss-events.jsonl';
 
-console.log('\nTOP 30 FILES BY LOST SLUGS:');
-for (const [f, n] of [...lossesByFile.entries()].sort((a, b) => b[1] - a[1]).slice(0, 30)) {
-  console.log(`  ${n.toString().padStart(5)}  ${f.replace(`${ABS_DIR}/`, '')}`);
+  const slices = execSync(`ls ${ABS_DIR}/*.json`, { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+  process.stderr.write(`Scanning ${slices.length} slice files since "${SINCE}"…\n`);
+
+  const lossesByJob = new Map();
+  const lossesByFile = new Map();
+  const lossEvents = [];
+
+  let fileIdx = 0;
+  for (const file of slices) {
+    fileIdx++;
+    if (fileIdx % 25 === 0) process.stderr.write(`  ${fileIdx}/${slices.length}…\n`);
+    const rel = path.relative(ROOT, file);
+    let commits;
+    try {
+      commits = execSync(
+        `git log --since="${SINCE}" --reverse --pretty=format:%H -- ${rel}`,
+        { encoding: 'utf8', cwd: ROOT }
+      ).trim().split('\n').filter(Boolean);
+    } catch { continue; }
+    if (commits.length === 0) continue;
+
+    let prev = null;
+    for (const commit of commits) {
+      const res = spawnSync('git', ['show', `${commit}:${rel}`],
+        { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, cwd: ROOT });
+      if (res.status !== 0) continue;
+      let cur;
+      try { cur = JSON.parse(res.stdout); } catch { continue; }
+      if (!cur?.jobs) continue;
+      if (prev && Array.isArray(prev.jobs)) {
+        for (const { jobKey, lost } of diffJobSlices(prev.jobs, cur.jobs)) {
+          lossEvents.push({ commit: commit.slice(0, 10), file: file.replace(`${ABS_DIR}/`, ''), jobId: jobKey, lost });
+          lossesByFile.set(file, (lossesByFile.get(file) || 0) + lost.length);
+          if (!lossesByJob.has(jobKey)) lossesByJob.set(jobKey, { slugs: new Set(), file });
+          for (const s of lost) lossesByJob.get(jobKey).slugs.add(s);
+        }
+      }
+      prev = cur;
+    }
+  }
+
+  const totalLost = [...lossesByJob.values()].reduce((n, x) => n + x.slugs.size, 0);
+  console.log(JSON.stringify({
+    since: SINCE,
+    totalLost,
+    filesAffected: lossesByFile.size,
+    jobsAffected: lossesByJob.size,
+    eventsCount: lossEvents.length,
+  }, null, 2));
+
+  console.log('\nTOP 30 FILES BY LOST SLUGS:');
+  for (const [f, n] of [...lossesByFile.entries()].sort((a, b) => b[1] - a[1]).slice(0, 30)) {
+    console.log(`  ${n.toString().padStart(5)}  ${f.replace(`${ABS_DIR}/`, '')}`);
+  }
+
+  // Cross-reference with current state: emit "recoverable" list (entries still missing today).
+  const recoverable = [];
+  let alreadyPresent = 0, deletedJobs = 0;
+  for (const [jobKey, { file, slugs }] of lossesByJob.entries()) {
+    if (!fs.existsSync(file)) { deletedJobs++; continue; }
+    const d = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const j = d.jobs?.find(x => resolveJobDiffKey(x) === jobKey);
+    if (!j) { deletedJobs++; continue; }
+    const known = new Set([
+      ...(Array.isArray(j.previousSlugs) ? j.previousSlugs : []),
+      ...Object.values(j.previousSlugsByLocale || {}).flatMap(a => Array.isArray(a) ? a : []),
+      j.slug,
+      ...Object.values(j.slugByLocale || {}),
+    ].filter(Boolean));
+    const toRestore = [...slugs].filter(s => !known.has(s));
+    if (toRestore.length === 0) { alreadyPresent++; continue; }
+    recoverable.push({ jobId: jobKey, file: file.replace(`${ABS_DIR}/`, ''), slugs: toRestore });
+  }
+
+  fs.writeFileSync(EVENTS_OUT, lossEvents.map(e => JSON.stringify(e)).join('\n') + '\n');
+  fs.writeFileSync(OUT, JSON.stringify(recoverable, null, 2));
+
+  console.log('\nRECOVERABILITY:');
+  console.log(`  already healed:       ${alreadyPresent}`);
+  console.log(`  jobs no longer exist: ${deletedJobs}`);
+  console.log(`  recoverable jobs:     ${recoverable.length}`);
+  console.log(`  recoverable slugs:    ${recoverable.reduce((n, r) => n + r.slugs.length, 0)}`);
+  console.log(`\nWrote:`);
+  console.log(`  ${EVENTS_OUT}  (${lossEvents.length} loss events)`);
+  console.log(`  ${OUT}  (input for scripts/backfill-prev-slugs-from-loss-events.mjs)`);
 }
 
-// Cross-reference with current state: emit "recoverable" list (entries still missing today).
-const recoverable = [];
-let alreadyPresent = 0, deletedJobs = 0;
-for (const [jobId, { file, slugs }] of lossesByJob.entries()) {
-  if (!fs.existsSync(file)) { deletedJobs++; continue; }
-  const d = JSON.parse(fs.readFileSync(file, 'utf8'));
-  const j = d.jobs?.find(x => x.id === jobId);
-  if (!j) { deletedJobs++; continue; }
-  const known = new Set([
-    ...(Array.isArray(j.previousSlugs) ? j.previousSlugs : []),
-    ...Object.values(j.previousSlugsByLocale || {}).flatMap(a => Array.isArray(a) ? a : []),
-    j.slug,
-    ...Object.values(j.slugByLocale || {}),
-  ].filter(Boolean));
-  const toRestore = [...slugs].filter(s => !known.has(s));
-  if (toRestore.length === 0) { alreadyPresent++; continue; }
-  recoverable.push({ jobId, file: file.replace(`${ABS_DIR}/`, ''), slugs: toRestore });
+const isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`
+      || import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  main();
 }
-
-fs.writeFileSync(EVENTS_OUT, lossEvents.map(e => JSON.stringify(e)).join('\n') + '\n');
-fs.writeFileSync(OUT, JSON.stringify(recoverable, null, 2));
-
-console.log('\nRECOVERABILITY:');
-console.log(`  already healed:       ${alreadyPresent}`);
-console.log(`  jobs no longer exist: ${deletedJobs}`);
-console.log(`  recoverable jobs:     ${recoverable.length}`);
-console.log(`  recoverable slugs:    ${recoverable.reduce((n, r) => n + r.slugs.length, 0)}`);
-console.log(`\nWrote:`);
-console.log(`  ${EVENTS_OUT}  (${lossEvents.length} loss events)`);
-console.log(`  ${OUT}  (input for scripts/backfill-prev-slugs-from-loss-events.mjs)`);

--- a/tests/cleanup-jobs-archive-dedup-losers.test.ts
+++ b/tests/cleanup-jobs-archive-dedup-losers.test.ts
@@ -378,6 +378,142 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
     expect(archived?.previousSlugs).toContain('legacy-lead-engineer-2025');
     expect(archived?.previousSlugs).toContain('lead-engineer');
   }, 30000);
+
+  // #3411: dedicated crawlers (ferrovia-retica, julius-baer, mikron,
+  // relewant, swiss-medical-network, casale) commit slices where `.id` is
+  // never stamped (it's only added at data/jobs.json assembly time). Two
+  // id-less jobs that both age out (> JOBS_STALE_DAYS) land in
+  // `sliceRemoved`, each referenced by `{ id: j.id }` — before the fix that
+  // was `{ id: undefined }` for both, so `archiveJobsById.get(undefined)`
+  // resolved to whichever job the Map's bare-id keying happened to keep
+  // last, archiving one job's content twice under two different slugs
+  // instead of each job's own content. These jobs carry no `id` field at
+  // all — that's what real per-crawler slices look like.
+  it('does not collide id-less slice jobs when archiving age-pruned removals', async () => {
+    const dir = makeTempDir();
+    const slicePath = path.join(dir, 'id-less-age-prune-test.json');
+    const expiredDir = path.join(dir, 'expired');
+    const crawlerKey = `id-less-age-prune-${Date.now()}`;
+
+    const stripId = (job: CleanupSliceJob): Omit<CleanupSliceJob, 'id'> => {
+      const { id: _id, ...rest } = job;
+      return rest;
+    };
+
+    const jobs = [
+      stripId(buildJob({
+        id: 'job-stale-A',
+        slug: 'engineer-lugano-stale',
+        title: 'Engineer Lugano (stale A)',
+        crawledAt: daysAgo(90),
+      })),
+      stripId(buildJob({
+        id: 'job-stale-B',
+        slug: 'designer-bellinzona-stale',
+        title: 'Designer Bellinzona (stale B)',
+        location: 'Bellinzona',
+        addressLocality: 'Bellinzona',
+        crawledAt: daysAgo(95),
+      })),
+      stripId(buildJob({
+        id: 'job-fresh-C',
+        slug: 'nurse-mendrisio-fresh',
+        title: 'Nurse Mendrisio (fresh)',
+        location: 'Mendrisio',
+        addressLocality: 'Mendrisio',
+        crawledAt: daysAgo(1),
+      })),
+    ];
+
+    fs.writeFileSync(slicePath, JSON.stringify({ crawlerKey, jobs }, null, 2), 'utf-8');
+
+    const result = await runCleanupSlice(slicePath, expiredDir);
+    const output = result.stdout + result.stderr;
+    expect(result.code, output).toBe(0);
+
+    const sliceParsed = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+    const keptJobs: CleanupSliceJob[] = Array.isArray(sliceParsed?.jobs) ? sliceParsed.jobs : sliceParsed;
+    expect(keptJobs.length).toBe(1);
+    expect(keptJobs[0].slug).toBe('nurse-mendrisio-fresh');
+
+    const expiredSlicePath = path.join(expiredDir, `${crawlerKey}.json`);
+    expect(fs.existsSync(expiredSlicePath)).toBe(true);
+    const expiredEntries: ExpiredEntry[] = JSON.parse(fs.readFileSync(expiredSlicePath, 'utf-8'));
+
+    // Before the fix, both stale removals resolved to the same (last-keyed)
+    // job under the collapsed `undefined` key — asserting each archived
+    // slug carries ITS OWN title (not a copy of the other's) catches that
+    // regression; a count-only assertion would pass even with swapped/
+    // duplicated content.
+    expect(expiredEntries).toHaveLength(2);
+    const bySlug = new Map(expiredEntries.map((e) => [e.slug, e]));
+    expect(bySlug.get('engineer-lugano-stale')?.title).toBe('Engineer Lugano (stale A)');
+    expect(bySlug.get('designer-bellinzona-stale')?.title).toBe('Designer Bellinzona (stale B)');
+  }, 30000);
+
+  it('does not collide id-less slice jobs when validating URLs (checkById/fallbackById)', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/apply') {
+        res.writeHead(200, { 'content-type': 'text/html' });
+        res.end('<html><body>Application form</body></html>');
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'text/html' });
+      res.end('<html><body>Not found</body></html>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('test server did not bind to a port');
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      const dir = makeTempDir();
+      const slicePath = path.join(dir, 'id-less-url-validation-test.json');
+      const expiredDir = path.join(dir, 'expired');
+      const crawlerKey = `id-less-url-validation-${Date.now()}`;
+
+      const stripId = (job: CleanupSliceJob): Omit<CleanupSliceJob, 'id'> => {
+        const { id: _id, ...rest } = job;
+        return rest;
+      };
+
+      // Both jobs are id-less. One has a dead canonical URL but a live
+      // applyUrl fallback (must survive); the other has a fully dead URL
+      // with no fallback (must be removed). Before the fix, checkById /
+      // fallbackById collapsed both onto the `undefined` key, so either
+      // job could inherit the other's validation verdict.
+      const jobs = [
+        stripId(buildJob({
+          id: 'job-fallback-kept',
+          slug: 'nurse-live-apply',
+          title: 'Nurse With Live Apply URL',
+          crawledAt: new Date().toISOString(),
+          url: `${baseUrl}/dead-detail-A`,
+          applyUrl: `${baseUrl}/apply`,
+        })),
+        stripId(buildJob({
+          id: 'job-dead-removed',
+          slug: 'nurse-dead-url',
+          title: 'Nurse With Dead URL',
+          crawledAt: new Date().toISOString(),
+          url: `${baseUrl}/dead-detail-B`,
+        })),
+      ];
+
+      fs.writeFileSync(slicePath, JSON.stringify({ crawlerKey, jobs }, null, 2), 'utf-8');
+
+      const result = await runCleanupSliceWithUrlValidation(slicePath, expiredDir);
+      const output = result.stdout + result.stderr;
+      expect(result.code, output).toBe(0);
+
+      const sliceParsed = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+      const keptJobs: CleanupSliceJob[] = Array.isArray(sliceParsed?.jobs) ? sliceParsed.jobs : sliceParsed;
+      expect(keptJobs).toHaveLength(1);
+      expect(keptJobs[0].slug).toBe('nurse-live-apply');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });
 
 describe('cleanup-jobs standard mode — archives within-slice slug-dedup losers', () => {

--- a/tests/job-match-key-stable-id.test.ts
+++ b/tests/job-match-key-stable-id.test.ts
@@ -9,7 +9,7 @@
  * stable token preserves the merge.
  */
 import { describe, it, expect } from 'vitest';
-import { extractStableJobId } from '../scripts/lib/job-match-key.mjs';
+import { extractStableJobId, resolveJobDiffKey } from '../scripts/lib/job-match-key.mjs';
 
 describe('extractStableJobId', () => {
   it('extracts the UUID from PwC-style URLs', () => {
@@ -69,5 +69,53 @@ describe('extractStableJobId', () => {
 
   it('normalises trailing slashes and case', () => {
     expect(extractStableJobId('https://Example.com/Path/')).toBe(extractStableJobId('https://example.com/path'));
+  });
+});
+
+// Regression coverage for #3411: scan-prev-slug-losses.mjs and
+// backfill-prev-slugs-from-loss-events.mjs build Map<key, job> diff/lookup
+// structures from raw per-crawler slice files, where several dedicated
+// crawlers (ferrovia-retica, julius-baer, mikron, relewant,
+// swiss-medical-network, casale) commit records with `.id` unset — it's
+// only stamped at data/jobs.json assembly time. Keying those Maps on bare
+// `job.id` collapsed every id-less job in a slice onto the shared
+// `undefined` key, corrupting lookups instead of just missing them.
+describe('resolveJobDiffKey', () => {
+  it('prefers the real .id when present', () => {
+    const job = { id: 'company-abc123', url: 'https://example.com/jobs/1' };
+    expect(resolveJobDiffKey(job)).toBe('company-abc123');
+  });
+
+  it('falls back to the stable URL-derived key when .id is absent', () => {
+    const job = { url: 'https://www.rhb.ch/it/job/some-title_2026-2227/' };
+    expect(resolveJobDiffKey(job)).toBe(extractStableJobId(job.url));
+    expect(resolveJobDiffKey(job)).not.toContain('undefined');
+  });
+
+  it('produces distinct keys for distinct id-less jobs sharing no id (no collision)', () => {
+    const jobA = { url: 'https://www.rhb.ch/it/job/job-a/' };
+    const jobB = { url: 'https://www.rhb.ch/it/job/job-b/' };
+    const keyA = resolveJobDiffKey(jobA);
+    const keyB = resolveJobDiffKey(jobB);
+    expect(keyA).not.toBe(keyB);
+    expect(keyA).not.toBeNull();
+    expect(keyB).not.toBeNull();
+  });
+
+  it('falls back to slug when both .id and .url are absent', () => {
+    const job = { slug: 'Some-Job-Slug' };
+    expect(resolveJobDiffKey(job)).toBe('slug:some-job-slug');
+  });
+
+  it('returns null when a job has no id, url, or slug', () => {
+    expect(resolveJobDiffKey({})).toBeNull();
+    expect(resolveJobDiffKey(undefined as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it('does not double-prefix the already-namespaced extractStableJobId output', () => {
+    const job = { url: 'https://example.com/jobs/only-a-slug' };
+    const key = resolveJobDiffKey(job);
+    expect(key).toBe('url:https://example.com/jobs/only-a-slug');
+    expect(key).not.toContain('url:url:');
   });
 });

--- a/tests/scan-prev-slug-losses.test.ts
+++ b/tests/scan-prev-slug-losses.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for #3411: scan-prev-slug-losses.mjs's per-commit diff
+ * used to build `Map(prev.jobs.map(j => [j.id, j]))`. Several dedicated
+ * crawlers (ferrovia-retica, julius-baer, mikron, relewant,
+ * swiss-medical-network, casale) commit per-crawler slice files where
+ * `.id` is never stamped — it's only added at data/jobs.json assembly
+ * time, not written back onto the committed slice. When every job in a
+ * slice has `.id === undefined`, the diff Map collapsed them all onto a
+ * single `undefined` key, so lookups returned an arbitrary sibling job
+ * instead of missing — corrupting the "lost slug" diff into garbage
+ * inflated counts instead of a clean skip.
+ *
+ * diffJobSlices() now resolves jobs via resolveJobDiffKey() (real `.id` >
+ * stable URL-derived key > slug), so id-less slices diff correctly instead
+ * of colliding.
+ */
+import { describe, it, expect } from 'vitest';
+import { diffJobSlices } from '../scripts/scan-prev-slug-losses.mjs';
+
+describe('diffJobSlices', () => {
+  it('detects a lost slug for a normal job with .id present', () => {
+    const prev = [
+      { id: 'company-aaa', slug: 'job-a', previousSlugs: ['job-a-old'] },
+    ];
+    const cur = [
+      { id: 'company-aaa', slug: 'job-a' }, // 'job-a-old' silently dropped
+    ];
+    const result = diffJobSlices(prev, cur);
+    expect(result).toHaveLength(1);
+    expect(result[0].jobKey).toBe('company-aaa');
+    expect(result[0].lost).toEqual(['job-a-old']);
+  });
+
+  it('reports no loss when previousSlugs survive the diff', () => {
+    const prev = [
+      { id: 'company-aaa', slug: 'job-a', previousSlugs: ['job-a-old'] },
+    ];
+    const cur = [
+      { id: 'company-aaa', slug: 'job-a', previousSlugs: ['job-a-old'] },
+    ];
+    expect(diffJobSlices(prev, cur)).toHaveLength(0);
+  });
+
+  it('does not collide id-less jobs onto a shared undefined key (the #3411 bug)', () => {
+    // Mirrors ferrovia-retica.json: every job in the slice has no `.id`,
+    // only a `url` and `slug`. Two distinct jobs, each losing its own
+    // distinct previousSlugs entry between commits.
+    const prev = [
+      { url: 'https://www.rhb.ch/it/job/job-a/', slug: 'job-a', previousSlugs: ['job-a-old'] },
+      { url: 'https://www.rhb.ch/it/job/job-b/', slug: 'job-b', previousSlugs: ['job-b-old'] },
+    ];
+    const cur = [
+      { url: 'https://www.rhb.ch/it/job/job-a/', slug: 'job-a' },
+      { url: 'https://www.rhb.ch/it/job/job-b/', slug: 'job-b' },
+    ];
+
+    const result = diffJobSlices(prev, cur);
+
+    // Before the fix: both jobs collided under Map key `undefined`, so
+    // byId.get(undefined) always resolved to job-b (the last one inserted)
+    // — job-a would incorrectly diff against job-b's before-state, and the
+    // real per-job attribution was lost/garbled.
+    expect(result).toHaveLength(2);
+    const byKey = new Map(result.map(r => [r.jobKey, r.lost]));
+    expect(byKey.get('url:https://www.rhb.ch/it/job/job-a')).toEqual(['job-a-old']);
+    expect(byKey.get('url:https://www.rhb.ch/it/job/job-b')).toEqual(['job-b-old']);
+    // Distinct keys, not the collided `undefined`.
+    expect(new Set(result.map(r => r.jobKey)).size).toBe(2);
+  });
+
+  it('does not fabricate a loss for an id-less job with no prior counterpart', () => {
+    const prev = [
+      { url: 'https://www.rhb.ch/it/job/job-a/', slug: 'job-a', previousSlugs: ['job-a-old'] },
+    ];
+    const cur = [
+      { url: 'https://www.rhb.ch/it/job/job-a/', slug: 'job-a' },
+      { url: 'https://www.rhb.ch/it/job/job-c/', slug: 'job-c' }, // brand-new job, no prior version
+    ];
+    const result = diffJobSlices(prev, cur);
+    expect(result).toHaveLength(1);
+    expect(result[0].jobKey).toBe('url:https://www.rhb.ch/it/job/job-a');
+  });
+
+  it('falls back to slug matching when neither id nor url is present', () => {
+    const prev = [
+      { slug: 'job-a', previousSlugs: ['job-a-old'] },
+    ];
+    const cur = [
+      { slug: 'job-a' },
+    ];
+    const result = diffJobSlices(prev, cur);
+    expect(result).toHaveLength(1);
+    expect(result[0].jobKey).toBe('slug:job-a');
+  });
+
+  it('skips jobs with no id, url, or slug on either side instead of crashing', () => {
+    const prev = [{ previousSlugs: ['orphan-old'] }];
+    const cur = [{}];
+    expect(diffJobSlices(prev, cur)).toHaveLength(0);
+  });
+
+  it('accounts for previousSlugsByLocale and slugByLocale in before/after sets', () => {
+    const prev = [
+      {
+        id: 'company-bbb',
+        slugByLocale: { it: 'lavoro-it', en: 'job-en' },
+        previousSlugsByLocale: { it: ['lavoro-it-old'] },
+      },
+    ];
+    const cur = [
+      {
+        id: 'company-bbb',
+        slugByLocale: { it: 'lavoro-it', en: 'job-en' },
+        // 'lavoro-it-old' dropped from both previousSlugsByLocale and previousSlugs
+      },
+    ];
+    const result = diffJobSlices(prev, cur);
+    expect(result).toHaveLength(1);
+    expect(result[0].lost).toEqual(['lavoro-it-old']);
+  });
+
+  it('returns no results for empty or malformed input arrays', () => {
+    expect(diffJobSlices([], [])).toHaveLength(0);
+    expect(diffJobSlices(null as unknown as unknown[], [])).toHaveLength(0);
+    expect(diffJobSlices([], null as unknown as unknown[])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Implementato

- Root cause: `scan-prev-slug-losses.mjs` and its consumer `backfill-prev-slugs-from-loss-events.mjs` diffed/looked up per-crawler slice jobs via `Map(jobs.map(j => [j.id, j]))`. `.id` is only stamped at `data/jobs.json` assembly time (`buildStableId` in `assemble-jobs-dataset.mjs`) and never written back onto the committed per-crawler slice files. Confirmed 6 dedicated-crawler slices commit every job with `.id` unset: `ferrovia-retica.json` (10/10), `julius-baer.json` (82/82), `swiss-medical-network.json` (60/60), `relewant.json` (19/19), `mikron.json` (4/4), `casale.json` (1/4).
- Every id-less job in a slice collapsed onto the shared `undefined` Map key, so lookups silently returned an arbitrary sibling job instead of `undefined` — corrupting the loss diff (garbage/inflated counts) instead of just skipping the job.
- Fix approach: option 1 from the issue (defensive fallback key in the audit tooling), applied as a **shared** helper rather than duplicated inline logic, per the sibling-pattern rule.
  - Added `resolveJobDiffKey(job)` to `scripts/lib/job-match-key.mjs`: prefers real `.id`, falls back to `extractStableJobId(url)` (already namespaced `uuid:`/`num:`/`hex:`/`url:`, used as-is — no double prefix), then `slug:<slug>`. Returns `null` only if a job has none of id/url/slug, so callers can skip instead of colliding.
  - `scripts/scan-prev-slug-losses.mjs`: extracted the per-commit diff into a pure, exported, directly-testable `diffJobSlices(prevJobs, curJobs)` using `resolveJobDiffKey` for both the before/after Map and the current-state recoverability cross-reference. Wrapped the previously-unconditional top-level script body in `main()` behind an `isMain` guard so the module can be imported by tests without executing the real git-history scan as a side effect.
  - **Sibling fix (AGENTS.md #6):** `backfill-prev-slugs-from-loss-events.mjs` — the direct downstream consumer of this script's output — had the *exact same* collision pattern in three places: `buildFileLocaleIndex`'s per-job history index (`if (!job?.id) continue`), the current-slice `byId` Map, and the `changedJobIds` dedup `Set`. Left unfixed, it would have both kept corrupting id-less-job recovery on its own AND been incompatible with the new namespaced `jobId` keys emitted by the fixed scan script. Switched all three to `resolveJobDiffKey` for consistency across the whole scan→backfill pipeline.
  - **Reviewer-flagged sibling, fixed in `f5f6df42c22`:** the original claim in this section that `scripts/cleanup-jobs.mjs` was safe was wrong — true only for its non-slice (`data/jobs.json` post-assembly) path. Reviewer correctly caught that `cleanup-jobs.mjs`'s **slice-only mode** (`SLICE_FILE` set — used by every dedicated-crawler workflow that also sets `JOBS_HOUSEKEEPING_SCOPE`) operates on the *raw, unassembled* per-crawler slice, i.e. the same `.id`-unset invariant this PR fixes elsewhere. `checkById`/`fallbackById` (URL-validation results, `cleanup-jobs.mjs:L398,L406`) and `archiveJobsById` (expired-job archival feeding soft-landing redirects, `L475`) all keyed on bare `job.id`, so id-less jobs collided and could receive an arbitrary sibling's validation verdict or archived content — worse than the previousSlugs loss this PR targets (silent job-page removal / mis-attributed archived content, not just lost slug history). Switched all three Maps and every id reference derived from them to `resolveJobDiffKey()`. Added regression coverage in `tests/cleanup-jobs-archive-dedup-losers.test.ts` for both collision points (age-pruned removals landing in `archiveJobsById`, and `checkById`/`fallbackById` during URL validation) — both fail pre-fix, pass post-fix. `scripts/fetch-article-trending.mjs`'s `Map(entries.map(e => [e.id, ...]))` remains an unrelated false positive (Firestore analytics doc IDs, always present, not job records).
- Verified end-to-end locally: `node scripts/scan-prev-slug-losses.mjs --since "6 hours ago"` now reports `ferrovia-retica.json` with a bounded, sane per-job loss (was garbage/collided before); feeding that output into `node scripts/backfill-prev-slugs-from-loss-events.mjs --dry-run` resolves every id-less job correctly (`jobs missing in current: 0`).
- Tests: `tests/scan-prev-slug-losses.test.ts` (new) covers normal id-present diffing, the id-less-collision regression (2 distinct id-less jobs no longer merge into 1), no-fabricated-loss for brand-new id-less jobs, slug-only fallback, and `previousSlugsByLocale`/`slugByLocale` accounting. `tests/job-match-key-stable-id.test.ts` extended with `resolveJobDiffKey` coverage (id preference, URL fallback, slug fallback, null on no identity, no double-`url:` prefix). `tests/cleanup-jobs-archive-dedup-losers.test.ts` (new) covers the `cleanup-jobs.mjs` sibling fix. All green: `npx vitest run tests/scan-prev-slug-losses.test.ts tests/job-match-key-stable-id.test.ts tests/cleanup-jobs-archive-dedup-losers.test.ts` → 28 passed; previously also verified `tests/backfill-prev-slugs-hash-guard.test.ts`, `tests/job-url-key.test.ts` + `tests/decontaminate-prev-slugs-flat-array.test.ts` (unaffected) to confirm no regression on the shared `extractStableJobId` dependency.

## Non implementato (ancora)

Nessuno

Closes #3411
