### PR TITLE
fix(seo-404): case-insensitive locale-prefix detection in inferLocale()

### DIFF
--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -238,9 +238,15 @@ function normalizePath(input: string): string {
 }
 
 function inferLocale(path: string): SupportedLocale {
- if (path.startsWith('/en/')) return 'en';
- if (path.startsWith('/de/')) return 'de';
- if (path.startsWith('/fr/')) return 'fr';
+ // Match case-insensitively (GSC may index a locale segment with drifted
+ // casing, e.g. `/EN/find-jobs-ticino/...`) — mirrors normalizePath()'s
+ // duplicate-hostname-prefix check above (PR #3419). Unlike that check there
+ // is nothing to slice/preserve here: the return value is always one of the
+ // four fixed locale codes, never a substring of `path`.
+ const lowerPath = path.toLowerCase();
+ if (lowerPath.startsWith('/en/')) return 'en';
+ if (lowerPath.startsWith('/de/')) return 'de';
+ if (lowerPath.startsWith('/fr/')) return 'fr';
  return 'it';
 }
 

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -496,6 +496,37 @@ describe('Search Console 404 compatibility resolver', () => {
     });
   });
 
+  // Issue #3429 — follow-up to PR #3419. GSC may index a locale-prefix
+  // segment with drifted casing (e.g. `/EN/...` instead of `/en/`). The
+  // case-sensitive section-match regexes below still fail to recover the
+  // SPECIFIC slug for a case-drifted path (that's a separate, harder
+  // problem not in scope here), but inferLocale() must still detect the
+  // correct locale so the generic search-fallback branch lands on the
+  // right-locale listing instead of silently defaulting to 'it'.
+  it('detects the correct locale from a case-drifted locale prefix (search fallback)', () => {
+    expect(
+      resolveSearchConsoleCompatTarget('/EN/find-jobs-ticino/ricerca-qualcosa'),
+    ).toEqual({
+      canonicalPath: '/en/find-jobs-ticino/',
+      kind: 'search',
+      locale: 'en',
+    });
+    expect(
+      resolveSearchConsoleCompatTarget('/De/jobs-im-tessin/suche-qualcosa'),
+    ).toEqual({
+      canonicalPath: '/de/jobs-im-tessin/',
+      kind: 'search',
+      locale: 'de',
+    });
+    expect(
+      resolveSearchConsoleCompatTarget('/FR/trouver-emploi-tessin/recherche-quelque-chose'),
+    ).toEqual({
+      canonicalPath: '/fr/trouver-emploi-tessin/',
+      kind: 'search',
+      locale: 'fr',
+    });
+  });
+
   it('recovers the wrong-locale-word DE TI section guess to the real jobs-im-tessin section', () => {
     expect(resolveSearchConsoleCompatTarget('/de/jobs-in-ticino')).toEqual({
       canonicalPath: '/de/jobs-im-tessin/',


### PR DESCRIPTION
## Implementato
- `inferLocale()` (`build-plugins/searchConsoleCompat.ts:240-249`) now matches the `/en/`, `/de/`, `/fr/` prefixes case-insensitively, so a case-drifted GSC-indexed path (e.g. `/EN/find-jobs-ticino/expired-slug`) resolves to the correct locale instead of silently falling through to the `it` default.
- Mirrors the case-insensitive-match pattern from PR #3419's `normalizePath()` fix; unlike that fix there's nothing to slice/preserve since `inferLocale()` only returns one of 4 fixed locale codes.
- Regression tests added in `tests/search-console-compat.test.ts` covering `/EN/`, `/De/`, `/FR/` case-drifted prefixes resolving through the search-fallback branch to the right-locale canonical target.
- Grepped the file for other case-sensitive `startsWith('/xx/')` constructs — none remain.

## Non implementato (ancora)
Nessuno. (Issue mentioned optionally checking live GSC data for actually-observed case-drifted locale segments — this is a preventive fix per the issue's own framing of "low-confidence/low-likelihood edge case", not blocking.)

Closes #3429