### PR TITLE
fix(email-cascade): Cloudflare code=10004 throttle gets a cooldown, not permanent retirement

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -607,8 +607,11 @@ async function sendViaCloudflare(email) {
   );
 
   if (!res.ok) {
-    // 429 (code 10004 throttled) and quota-exceeded bodies are caught by
-    // isRateLimitedError → provider retired for the rest of the run.
+    // code=10004 (email.sending.error.throttled) is a short burst-window
+    // rate limit, distinct from quota-exceeded — caught by
+    // isSoftThrottleError → provider cools down briefly instead of being
+    // retired for the rest of the run. Other 429/403 bodies still go
+    // through isRateLimitedError → hard exhaustion.
     const err = await res.text().catch(() => '');
     // Surface the CF error code/message as discrete fields. The raw JSON body
     // gets truncated in CI logs right after `"code":` (GitHub secret masking),
@@ -677,12 +680,42 @@ const SEND_FNS = {
  */
 function isRateLimitedError(msg) {
   if (!msg) return false;
+  if (isSoftThrottleError(msg)) return false;
   if (msg.includes('429')) return true;
   if (msg.includes('403') &&
       /reached[^"]{0,40}(limit|quota|cap|messages)|rate.?limit|too many|quota|limit of/i.test(msg)) {
     return true;
   }
   return false;
+}
+
+/**
+ * Detect a transient burst-window throttle (Cloudflare code 10004,
+ * "email.sending.error.throttled") as opposed to real quota exhaustion.
+ * Cloudflare can return this well before its documented daily/monthly cap
+ * is reached, and it clears after a short cooldown — treating it like
+ * isRateLimitedError permanently benches a provider that still has quota
+ * to spare (root cause of the 2026-07-04 mass-failure: cloudflare hit
+ * this at send #100/1000 and every other provider was already at its
+ * daily cap, so the rest of the run had nothing left to fall back to).
+ */
+function isSoftThrottleError(msg) {
+  return !!msg && /code=10004|email\.sending\.error\.throttled/i.test(msg);
+}
+
+// Short cooldown for soft-throttled providers (mirrors the AI-model
+// provider cooldown in ai-models.mjs) — provider skipped for a bit,
+// quota counter left untouched so it resumes once the burst window clears.
+const PROVIDER_COOLDOWN_MS = 30_000;
+const _providerCooldownUntil = {};
+
+function cooldownProvider(providerId) {
+  _providerCooldownUntil[providerId] = Date.now() + PROVIDER_COOLDOWN_MS;
+  console.warn(`🧊 ${providerId} cooled down for ${PROVIDER_COOLDOWN_MS / 1000}s (throttled, quota untouched)`);
+}
+
+function isProviderCoolingDown(providerId) {
+  return (_providerCooldownUntil[providerId] || 0) > Date.now();
 }
 
 async function sendSingle(email, forceProvider, finalizeForProvider) {
@@ -694,6 +727,7 @@ async function sendSingle(email, forceProvider, finalizeForProvider) {
   for (const provider of providers) {
     if (!isProviderConfigured(provider.id)) continue;
     if (remainingQuota(provider.id) <= 0) continue;
+    if (isProviderCoolingDown(provider.id)) continue;
 
     try {
       // Optional hook: let the caller finalize the payload for the provider that
@@ -707,7 +741,9 @@ async function sendSingle(email, forceProvider, finalizeForProvider) {
       return result;
     } catch (err) {
       errors.push(`[${provider.id}] ${err.message}`);
-      if (isRateLimitedError(err.message)) {
+      if (isSoftThrottleError(err.message)) {
+        cooldownProvider(provider.id);
+      } else if (isRateLimitedError(err.message)) {
         incrementCounter(provider.id, remainingQuota(provider.id));
         console.warn(`⚠️  ${provider.id} rate-limited/exhausted — skipping for rest of run`);
       }
@@ -727,7 +763,8 @@ async function sendSingleThrottled(email, forceProvider, lastSendMap, delayMs, f
   const providers = forceProvider
     ? PROVIDERS.filter(p => p.id === forceProvider)
     : PROVIDERS;
-  const nextProvider = providers.find(p => isProviderConfigured(p.id) && remainingQuota(p.id) > 0);
+  const nextProvider = providers.find(p =>
+    isProviderConfigured(p.id) && remainingQuota(p.id) > 0 && !isProviderCoolingDown(p.id));
 
   if (nextProvider) {
     // Reserve a delay-spaced slot SYNCHRONOUSLY (read + write lastSendMap with no

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -7,6 +7,7 @@ import {
   fetchCloudflareDeliveryStats,
   campaignIdTag,
   PROVIDERS,
+  remainingQuota,
 } from '../scripts/lib/email-cascade.mjs';
 
 /* ------------------------------------------------------------------ */
@@ -35,6 +36,10 @@ describe('isRateLimitedError', () => {
   it('does NOT match a 403 with bare "reached" lacking limit/quota context', () => {
     // e.g. a network-style 403 body — must not retire a healthy provider.
     expect(isRateLimitedError('Mailgun 403: {"errors":["upstream host could not be reached"]}')).toBe(false);
+  });
+
+  it('does NOT match Cloudflare code=10004 (soft burst throttle, handled by cooldown instead)', () => {
+    expect(isRateLimitedError('Cloudflare 429 code=10004: email.sending.error.throttled')).toBe(false);
   });
 
   it('does NOT match unrelated errors', () => {
@@ -257,7 +262,7 @@ describe('sendEmailCascade — cloudflare provider', () => {
     delete process.env.CF_API_TOKEN;
   });
 
-  it('retires cloudflare after a 429 throttle (no burst across a batch)', async () => {
+  it('cools down cloudflare after a code=10004 soft throttle without burning quota (no burst across a batch)', async () => {
     const calls: string[] = [];
     globalThis.fetch = (async (url: string) => {
       calls.push(String(url));
@@ -279,12 +284,16 @@ describe('sendEmailCascade — cloudflare provider', () => {
       meta: {},
     }));
 
+    const quotaBefore = remainingQuota('cloudflare');
     const { sent, failed } = await sendEmailCascade(emails, { forceProvider: 'cloudflare', delayMs: 0 });
 
     const sendCalls = calls.filter(u => u.includes(CF_SEND)).length;
-    expect(sendCalls).toBe(1); // 429 → provider exhausted → rest skipped locally
+    expect(sendCalls).toBe(1); // 429 → provider cools down → rest skipped locally within the cooldown window
     expect(sent.length).toBe(0);
     expect(failed.length).toBe(10);
+    // code=10004 is a burst throttle, not the daily cap being reached —
+    // quota must stay exactly where it was before the batch.
+    expect(remainingQuota('cloudflare')).toBe(quotaBefore);
   });
 });
 


### PR DESCRIPTION
## Implementato

- `isSoftThrottleError()` in `scripts/lib/email-cascade.mjs` detects Cloudflare's `code=10004` (`email.sending.error.throttled`) burst-window throttle as distinct from a hard quota-exhausted 429/403.
- On soft throttle, the provider gets a 30s cooldown (`cooldownProvider`/`isProviderCoolingDown`, mirrors the existing AI-model provider cooldown in `ai-models.mjs`) instead of `incrementCounter(id, remainingQuota(id))` permanently maxing its quota out for the rest of the run.
- `isRateLimitedError()` now excludes soft-throttle messages so the two paths are mutually exclusive.
- Both provider-selection call sites (`sendSingle`, `sendSingleThrottled`) skip a provider while it's cooling down.
- Updated `tests/email-cascade-burst.test.ts`: the old test asserted the previous (now-wrong) permanent-retirement behavior for code=10004; replaced with an assertion that quota is untouched after the throttle, plus a new `isRateLimitedError` case confirming it no longer matches the CF soft-throttle signature.

Root cause of https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28700101785/job/85116573277: cloudflare hit code=10004 at send #100 of a 1000/day quota, got permanently retired for the run, and every other provider (mailgun/resend/mailjet/mailtrap/maileroo) was already at its own daily cap — so ~550 of 1198 newsletter recipients received nothing.

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] `npx vitest run tests/email-cascade-burst.test.ts` — 24/24 green, including the new/updated cooldown assertions.