### PR TITLE
fix(crawlers): Holmes Place canton fallback skips city inference

### DIFF
--- a/scripts/lib/holmes-place-job-parser.mjs
+++ b/scripts/lib/holmes-place-job-parser.mjs
@@ -118,6 +118,7 @@ import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, normalizeSpace } from './crawler-template.mjs';
 import { stripContactPII } from './strip-contact-pii.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 import {
   createBrowser,
   createPoliteContext,
@@ -274,6 +275,26 @@ export function resolveAddress(raw = {}) {
     postalCode: explicitPostal || (branch ? branch.postalCode : ''),
     streetAddress: explicitStreet || (branch ? branch.streetAddress : ''),
   };
+}
+
+/**
+ * Resolve canton/addressRegion for a job, matched by postalCode (unique per
+ * branch — city alone is ambiguous for the 2 Zürich branches). Falls through
+ * to city-text canton inference (never straight to the HQ canton) so a job
+ * posted from a city outside the 5 known branches — a scrape drift or a
+ * genuinely new location — doesn't get silently mislabeled as Oberrieden/ZH.
+ *
+ * @param {string} postalCode
+ * @param {string} city
+ * @param {string} [location]
+ * @returns {string} canton/addressRegion code
+ */
+export function resolveCantonFallback(postalCode, city, location = '') {
+  return (
+    BRANCHES.find((b) => b.postalCode === postalCode)?.canton ||
+    inferAnyCanton(city || location) ||
+    CONFIG_HQ.canton
+  );
 }
 
 /* ── Company Matchers ──────────────────────────────────────── */
@@ -553,7 +574,7 @@ export async function fetchAllHolmesPlaceJobs() {
       location,
       // Matched by postalCode (unique per branch — city alone is ambiguous
       // for the 2 Zürich branches) rather than re-deriving from resolveAddress.
-      canton: BRANCHES.find((b) => b.postalCode === postalCode)?.canton || CONFIG_HQ.canton,
+      canton: resolveCantonFallback(postalCode, city, location),
       url: CAREER_URL,
       source: 'Holmes Place Dedicated Parser',
       sourceLang,
@@ -561,7 +582,7 @@ export async function fetchAllHolmesPlaceJobs() {
 
       // ── Recommended fields ──
       addressLocality: city || location,
-      addressRegion: BRANCHES.find((b) => b.postalCode === postalCode)?.addressRegion || CONFIG_HQ.addressRegion,
+      addressRegion: resolveCantonFallback(postalCode, city, location),
       streetAddress,
       postalCode,
       addressCountry: 'CH',

--- a/tests/holmes-place-crawler.test.ts
+++ b/tests/holmes-place-crawler.test.ts
@@ -6,6 +6,7 @@ import {
   isHolmesPlaceJob,
   isTrustedDomain,
   resolveAddress,
+  resolveCantonFallback,
   normalizeHolmesPlaceListing,
   buildDescription,
   detectCategory,
@@ -154,6 +155,26 @@ describe('Holmes Place crawler parser', () => {
     it('matches Oberrieden case-insensitively and ignores surrounding whitespace', () => {
       const resolved = resolveAddress({ city: '  OBERRIEDEN  ' });
       expect(resolved.streetAddress).toBe('Seestrasse 97');
+    });
+  });
+
+  // ── resolveCantonFallback (never falls straight to the HQ canton for an
+  // unrecognized city — must try city-text canton inference first) ──
+  describe('resolveCantonFallback', () => {
+    it('matches a known branch by postalCode first', () => {
+      expect(resolveCantonFallback('1204', 'Genève')).toBe('GE');
+    });
+
+    it('infers canton from city text when no branch postalCode matches, instead of defaulting to the Oberrieden HQ canton (ZH)', () => {
+      // Bern is not one of the 5 known Holmes Place branches, and its
+      // postalCode (3011) matches no branch — a canton-only/HQ-only fallback
+      // would mislabel this BE job as ZH. This is the exact bug class this
+      // test guards against.
+      expect(resolveCantonFallback('3011', 'Bern')).toBe('BE');
+    });
+
+    it('falls back to the Oberrieden HQ canton only when the city itself cannot be resolved to any canton', () => {
+      expect(resolveCantonFallback('', '')).toBe('ZH');
     });
   });
 


### PR DESCRIPTION
## Implementato

Follow-up fix for a bug found in an independent local review of PR #3455 (Wave D batch 7), which merged before the fix landed (the real reviewer posted `## LGTM` and auto-merge fired on the original commit while a local review pass was still in progress — this PR lands the fix that review surfaced).

- **Holmes Place canton fallback** (`scripts/lib/holmes-place-job-parser.mjs`): `canton`/`addressRegion` fell straight through to the Oberrieden HQ canton (`ZH`) for any job outside the 5 known branches, unlike all 6 sibling parsers in the same batch (Hornbach, New Yorker, Kiabi, Josef Müller, Kuhn Rikon, migrolino), each of which chains a real city-text canton inference (`inferSwissTargetCanton`/`inferAnyCanton`) before the HQ fallback. A scrape drift surfacing an unlisted city (e.g. a new/renamed club, or a partial-match failure against `BRANCHES`) would have silently mislabeled that job's canton as ZH instead of its real canton.
- Extracted the fallback logic into an exported `resolveCantonFallback(postalCode, city, location)` (postalCode branch match → `inferAnyCanton(city)` → HQ canton), used for both `canton` and `addressRegion` (confirmed identical for every branch + HQ entry, so one helper serves both).
- Added 3 new unit tests directly against `resolveCantonFallback`, including the negative-control case (`resolveCantonFallback('3011', 'Bern')` → `'BE'`, not `'ZH'`) that would have failed under the old logic.

`npx vitest run tests/holmes-place-crawler.test.ts` → 44/44 pass (41 pre-existing + 3 new).

## Non implementato (ancora)

- Nessuno — self-contained fix, single file + its test, no further scope.
