### PR TITLE
fix(crawlers): widen needsRetranslation drift-check to same/shorter-length rewrites

### DIFF
--- a/scripts/update-coop-jobs.mjs
+++ b/scripts/update-coop-jobs.mjs
@@ -591,8 +591,18 @@ async function postProcessCoopJobs() {
       const markdown = coopDescHtmlToMarkdown(ldDesc);
       const validation = validateCoopDescription(markdown, ldDesc.length);
 
-      // Replace if: current is shorter than JSON-LD markdown, or current is too short
-      if (markdown.length > descLen || descLen < 350) {
+      // Replace if: current is shorter than JSON-LD markdown, current is too
+      // short, OR the raw source text drifted from what's already reflected
+      // in the stored description (issue #3442 completeness gap: this
+      // length-only gate previously skipped the whole rebuild — and
+      // therefore the sourceContentChanged check below — whenever a live
+      // posting was rewritten to similar-or-shorter length, freezing
+      // needsRetranslation exactly like the bug this guard exists to fix).
+      // The incoming markdown still appearing verbatim in the prior stored
+      // text means no real drift; anything else means the source changed.
+      const sourceDrifted =
+        markdown.length > 200 && !normalizeSpace(priorDescriptionText).includes(normalizeSpace(markdown));
+      if (markdown.length > descLen || descLen < 350 || sourceDrifted) {
         if (markdown.length > 200) {
           // Build structured description with metadata
           const lines = [`## ${job.title || ldTitle}`, ''];

--- a/scripts/update-lastminute-jobs.mjs
+++ b/scripts/update-lastminute-jobs.mjs
@@ -649,25 +649,25 @@ async function enrichFromSmartRecruitersApi(seedUrls) {
     });
 
     if (existing) {
-      // Only replace if SR API content is richer
-      if (detail.description.length > (existing.description || '').length * 0.8) {
-        // Snapshot BEFORE mergeLocaleTextMap below mutates descriptionByLocale
-        // (issue #3442): this enrichment loop runs after runDedicatedBaseCrawler,
-        // so the merge-time translation stability lock in
-        // dedicated-crawler-common.mjs never sees this job. Without this guard,
-        // an already fully-translated job gets re-flagged (and re-translated,
-        // with MT non-determinism churning slugByLocale) every time the SR API
-        // returns a description within 20% of the current length — which is
-        // most re-crawls, not just genuine content changes.
+      // Snapshot BEFORE mergeLocaleTextMap below mutates descriptionByLocale
+      // (issue #3442): this enrichment loop runs after runDedicatedBaseCrawler,
+      // so the merge-time translation stability lock in
+      // dedicated-crawler-common.mjs never sees this job. Without this guard,
+      // an already fully-translated job gets re-flagged (and re-translated,
+      // with MT non-determinism churning slugByLocale) every time the SR API
+      // returns a description within 20% of the current length — which is
+      // most re-crawls, not just genuine content changes.
+      const priorDescription = existing.description || '';
+      // Compare BEFORE the richer-content gate below (review #3454/completeness
+      // gap): coverage alone freezes the flag forever once a job reaches full
+      // 4-locale coverage, even if the live SR posting is later rewritten to a
+      // similar-or-shorter length — the >80%-length gate alone would silently
+      // skip this whole block (and this comparison) for that case, exactly
+      // reproducing the bug this guard exists to fix.
+      const sourceContentChanged = normalizeSpace(priorDescription) !== normalizeSpace(detail.description);
+      // Only replace if SR API content is richer, or the source text itself drifted
+      if (sourceContentChanged || detail.description.length > priorDescription.length * 0.8) {
         const wasFullyLocalized = hasFullLocaleCoverage(existing);
-        // Snapshot the prior synced source text too (review #3454): coverage
-        // alone freezes the flag forever once a job reaches full 4-locale
-        // coverage, even if the live SR posting is later rewritten.
-        // `existing.description` stays synced with the SR API every crawl
-        // (see below), so comparing it to the fresh `detail.description`
-        // detects genuine content drift — mirrors the sourceTitleStable gate
-        // in mergePreserveLocaleData.
-        const priorDescription = existing.description || '';
         existing.description = detail.description;
         existing.requirements = Array.isArray(detail.requirements) ? detail.requirements : [];
         existing.descriptionByLocale = mergeLocaleTextMap(
@@ -678,7 +678,6 @@ async function enrichFromSmartRecruitersApi(seedUrls) {
         // Mark for re-translation so AI refreshes IT/DE/FR from the richer
         // English — either the job wasn't fully localized yet, or the SR
         // content genuinely changed since the last sync.
-        const sourceContentChanged = normalizeSpace(priorDescription) !== normalizeSpace(detail.description);
         if (!wasFullyLocalized || sourceContentChanged) {
           existing.needsRetranslation = true;
         }


### PR DESCRIPTION
## Implementato

Follow-up fix for a gap found in an independent local review of PR #3460 (merged as `d5678882ef6` before this fix landed — the real reviewer's auto-merge fired while the local review pass was still in progress, same race as #3459/PR #3455).

- PR #3460 fixed `needsRetranslation` freezing forever once a job reached full 4-locale coverage, by snapshotting prior source text and only suppressing the flag when it's unchanged — but that comparison only ran inside the pre-existing "richer content" branches:
  - `scripts/update-coop-jobs.mjs`: gated on `markdown.length > descLen || descLen < 350`
  - `scripts/update-lastminute-jobs.mjs`: gated on `detail.description.length > existing.description.length * 0.8`
  - A live posting rewritten to a similar-or-shorter length never entered either block, so the new drift comparison never ran and `needsRetranslation` stayed frozen — reproducing the exact bug #3460 was meant to close, just for a narrower trigger (same-or-shorter-length rewrites).
- Widened both entry gates with an OR'd content-drift signal computed *before* the length check:
  - Coop: compares whether the incoming markdown still appears verbatim inside the previously-stored formatted description (`!normalizeSpace(priorDescriptionText).includes(normalizeSpace(markdown))`) — needed because `job.description` is a decorated composite (header/footer wrapper), not raw source text.
  - Lastminute: direct `normalizeSpace` comparison of raw prior vs incoming `description` (already unwrapped, no decoration to strip).
- Verified the drift signal manually against unchanged / rewritten-same-length / rewritten-shorter / too-short-to-matter cases — behaves as intended in all four.
- `npx vitest run tests/coop-crawler.test.ts tests/coopers-crawler.test.ts tests/lastminute-crawler.test.ts tests/lastminute-location-normalization.test.ts tests/dedicated-crawler-common.test.ts` → 122/122 pass, no regressions.

## Non implementato (ancora)

- Nessuno — self-contained completeness fix, same two files PR #3460 touched, no further scope.
