### PR TITLE
fix(email-cascade): anchor soft-throttle regex to exact Cloudflare error code

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -700,7 +700,7 @@ function isRateLimitedError(msg) {
  * daily cap, so the rest of the run had nothing left to fall back to).
  */
 function isSoftThrottleError(msg) {
-  return !!msg && /code=10004|email\.sending\.error\.throttled/i.test(msg);
+  return !!msg && /code=10004\b|email\.sending\.error\.throttled/i.test(msg);
 }
 
 // Short cooldown for soft-throttled providers (mirrors the AI-model


### PR DESCRIPTION
## Implementato

Follow-up robustness fix for a non-blocking gap found in an independent local review of PR #3458 (merged as the soft-throttle-cooldown fix for Cloudflare `code=10004`).

- `isSoftThrottleError()` in `scripts/lib/email-cascade.mjs` matched `code=10004` as an unanchored substring. Since real Cloudflare messages render as `code=${cfCode}:` with an exact integer, this only matches today's known code — but a hypothetical future Cloudflare code sharing the same leading digits (e.g. `code=100041`) would still match the `code=10004` prefix and get misclassified as a soft throttle instead of a hard quota-exhausted error.
- Anchored the match with `\b` (`code=10004\b`) so only the exact code followed by a word boundary (colon, space, end of string) matches.
- Verified against real CF message shape, trailing-colon, end-of-string, and the hypothetical colliding-code case (now correctly does not match).
- `npx vitest run tests/email-cascade-burst.test.ts` → 24/24 pass, no regressions.

## Non implementato (ancora)

- Nessuno — single-line regex hardening, no further scope.
