### PR TITLE
fix(crawler): unresolved-canton skip guard sibling-class fix + registry/retranslation gaps

### DIFF
--- a/scripts/lib/beekeeper-job-parser.mjs
+++ b/scripts/lib/beekeeper-job-parser.mjs
@@ -196,6 +196,7 @@ export async function fetchAllBeekeeperJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
       location,
       canton,
       url: publicUrl,

--- a/scripts/lib/cern-job-parser.mjs
+++ b/scripts/lib/cern-job-parser.mjs
@@ -253,6 +253,7 @@ export async function fetchAllCernJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
       location,
       canton,
       url: publicUrl,

--- a/scripts/lib/clariant-job-parser.mjs
+++ b/scripts/lib/clariant-job-parser.mjs
@@ -130,6 +130,28 @@ export function resolveAddress(raw = {}) {
   };
 }
 
+/**
+ * Resolve the canton for a job, or signal that it should be skipped.
+ *
+ * Mirrors the unresolved-canton skip guard in scripts/lib/planzer-job-parser.mjs:
+ * when real location text was present but doesn't resolve to any known Swiss
+ * canton, never fabricate the Muttenz HQ canton for a job that isn't
+ * positively there (AGENTS.md Non-Negotiable #3) — return null so the caller
+ * skips the job instead of defaulting to HQ.canton.
+ *
+ * @param {string} realLocationText - location text as scraped, BEFORE the HQ.city fallback
+ * @param {string} rawLocation - realLocationText, or HQ.city when absent
+ * @param {string} city - resolved city (from resolveAddress)
+ * @returns {string|null} canton code, or null meaning "skip this job"
+ */
+export function resolveClariantCanton(realLocationText, rawLocation, city) {
+  const inferredCanton = inferSwissTargetCanton(rawLocation) || inferSwissTargetCanton(city);
+  if (normalizeSpace(realLocationText) && !inferredCanton) {
+    return null;
+  }
+  return inferredCanton || HQ.canton;
+}
+
 /* ── Company Matchers ──────────────────────────────────────── */
 
 /**
@@ -240,7 +262,7 @@ export function extractClariantDetailContent(html = '') {
   const start = html.indexOf(startMarker);
   if (start === -1) return '';
   const rest = html.slice(start + startMarker.length);
-  const end = rest.search(/<div\s+class="jobColumnTwo"/i);
+  const end = rest.search(/<div\s+class="[^"]*\bjobColumnTwo\b[^"]*"/i);
   const raw = end === -1 ? rest : rest.slice(0, end);
   return normalizeSpace(decodeHtmlEntities(stripHtml(raw)));
 }
@@ -356,12 +378,17 @@ export async function fetchAllClariantJobs() {
     const jobReqId = parseClariantJobId(detailDescription);
 
     const title = tile.title;
-    const rawLocation = tile.location || microdata.locationLabel || HQ.city;
+    const realLocationText = tile.location || microdata.locationLabel || '';
+    const rawLocation = realLocationText || HQ.city;
     // Strip a trailing ", CH"/", Switzerland" country suffix before resolving.
     const cityOnly = rawLocation.replace(/,\s*(CH|Switzerland|Schweiz|Suisse|Svizzera)\s*$/i, '').trim();
     const { city, postalCode, streetAddress } = resolveAddress({ city: cityOnly });
     const location = normalizeSpace(cityOnly || city);
-    const canton = inferSwissTargetCanton(rawLocation) || inferSwissTargetCanton(city) || HQ.canton;
+    const canton = resolveClariantCanton(realLocationText, rawLocation, city);
+    if (canton === null) {
+      console.warn(` ⚠️ Clariant: skipping unresolvable location "${realLocationText}" (${title})`);
+      continue;
+    }
 
     const descParts = [];
     if (detailDescription) descParts.push(detailDescription);

--- a/scripts/lib/crawler-location-config.mjs
+++ b/scripts/lib/crawler-location-config.mjs
@@ -201,6 +201,7 @@ export const COMPANY_HQ = {
   // Cathedral CH-wide expansion (2026-05-10): UBS HQ is Zürich. Per-job
   // canton is set by the canton-quorum-gate on the parser output.
   'ubs':                          { city: 'Zürich',             canton: 'ZH', postalCode: '8001', addressRegion: 'ZH' },
+  'smg-swiss-marketplace-group':  { city: 'Zürich',             canton: 'ZH', postalCode: '8005', addressRegion: 'ZH' },
   'interdiscount':                { city: 'Naters',             canton: 'VS', postalCode: '3904', addressRegion: 'VS' },
   'matterhorn-gotthard-bahn':     { city: 'Brig',               canton: 'VS', postalCode: '3900', addressRegion: 'VS' },
   'swiss-life':                   { city: 'Sion',               canton: 'VS', postalCode: '1950', addressRegion: 'VS' },

--- a/scripts/lib/debiopharm-job-parser.mjs
+++ b/scripts/lib/debiopharm-job-parser.mjs
@@ -171,6 +171,10 @@ export function parseDebiopharmJobDetailPayload(detail = {}) {
     employmentType: normalizeDebiopharmEmploymentType(detail.type || ''),
     sourceLanguage: String(detail.language || 'en').trim() || 'en',
     publishedDate: String(detail.published || '').trim(),
-    inferredCanton: inferAnyCanton(city) || inferAnyCanton(region) || 'VD',
+    // null means "real location text present but unresolvable to any Swiss
+    // canton" — the caller must skip the job rather than fabricate the
+    // Lausanne HQ canton (AGENTS.md Non-Negotiable #3). Only default to 'VD'
+    // when there was no real city/region text at all.
+    inferredCanton: inferAnyCanton(city) || inferAnyCanton(region) || ((city || region) ? null : 'VD'),
   };
 }

--- a/scripts/lib/komax-group-job-parser.mjs
+++ b/scripts/lib/komax-group-job-parser.mjs
@@ -43,6 +43,7 @@ import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, fetchHtml, normalizeSpace } from './crawler-template.mjs';
 import { decodeHtmlEntities } from './decode-html-entities.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 export const KOMAX_KEY = 'komax';
 export const KOMAX_COMPANY_NAME = 'Komax';
@@ -155,6 +156,28 @@ export function resolveAddress(city = '', postalCodeFromFeed = '') {
   };
 }
 
+/**
+ * Resolve the canton for a job, or signal (via null) that it should be
+ * skipped.
+ *
+ * isSwissLocation() filters on the feed's ", CH," country-code segment
+ * only — it is NOT restricted to Dierikon/Thun, so a real, non-empty city
+ * text that is neither Dierikon nor Thun (nor otherwise inferable) must
+ * never fabricate the Dierikon HQ canton (LU) for a job that isn't
+ * positively there (AGENTS.md Non-Negotiable #3, mirrors
+ * clariant-job-parser.mjs / swisslog-job-parser.mjs / debiopharm). Only
+ * default to HQ.canton when there's no real city text at all.
+ */
+export function resolveKomaxCanton(rawCity = '') {
+  const cityText = String(rawCity || '').trim();
+  if (/dierikon/i.test(cityText)) return 'LU';
+  if (/thun/i.test(cityText)) return 'BE';
+  const inferredCanton = inferAnyCanton(cityText);
+  if (inferredCanton) return inferredCanton;
+  if (cityText) return null;
+  return HQ.canton;
+}
+
 function detectCategory(title = '') {
   const t = normalize(title);
   if (/procurement|einkauf|supply chain|logistik|logistic/.test(t)) return 'Logistica';
@@ -205,7 +228,11 @@ export async function fetchAllKomaxGroupJobs() {
     if (!title || title.length < 3) continue;
     const { city: rawCity, postalCode: feedPostalCode } = parseLocation(listing.location);
     const address = resolveAddress(rawCity, feedPostalCode);
-    const canton = /dierikon/i.test(rawCity) ? 'LU' : /thun/i.test(rawCity) ? 'BE' : HQ.canton;
+    const canton = resolveKomaxCanton(rawCity);
+    if (canton === null) {
+      console.warn(` ⚠️ Komax: skipping unresolvable location "${rawCity}" (${title})`);
+      continue;
+    }
     const descriptionHtml = listing.descriptionHtml || '';
     const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;

--- a/scripts/lib/lindt-spruengli-job-parser.mjs
+++ b/scripts/lib/lindt-spruengli-job-parser.mjs
@@ -221,6 +221,25 @@ export function extractCityFromLocationText(raw = '') {
 }
 
 /**
+ * Resolve the canton for a job's already-extracted city, or signal (via
+ * null) that it should be skipped.
+ *
+ * extractCityFromLocationText()'s comma-split branch returns the raw text
+ * before the first comma UNCONDITIONALLY (only its dash-split fallback
+ * branch checks inferAnyCanton()) — so `city` here can be a real, present
+ * location string that still fails to resolve to any known Swiss canton.
+ * Given the board spans ZH/SZ/SO/LU/BE and more (see file header), never
+ * fabricate the Kilchberg HQ canton (ZH) for a job that isn't positively
+ * there (AGENTS.md Non-Negotiable #3, mirrors clariant-job-parser.mjs /
+ * swisslog-job-parser.mjs). Callers only reach this after already
+ * confirming `city` is non-empty, so there is no separate "no real text"
+ * branch here.
+ */
+export function resolveLindtSpruengliCanton(city = '') {
+  return inferAnyCanton(city) || null;
+}
+
+/**
  * Pick city / postal code / street address for a job, falling back to the
  * documented HQ address (Kilchberg ZH) ONLY when the job's own resolved
  * city text actually matches Kilchberg — never by canton alone (Lindt &
@@ -308,7 +327,11 @@ export async function fetchAllLindtSpruengliJobs() {
       continue;
     }
 
-    const canton = inferAnyCanton(city) || HQ.canton;
+    const canton = resolveLindtSpruengliCanton(city);
+    if (canton === null) {
+      console.warn(`   ⚠️ Skipping unresolvable location "${city}" (${title})`);
+      continue;
+    }
     const { postalCode, streetAddress } = resolveAddress(city);
 
     const publicUrl = listing.url || CAREER_URL;

--- a/scripts/lib/smg-swiss-marketplace-group-job-parser.mjs
+++ b/scripts/lib/smg-swiss-marketplace-group-job-parser.mjs
@@ -278,6 +278,7 @@ export async function fetchAllSmgSwissMarketplaceGroupJobs() {
         titleByLocale: { [sourceLang]: title },
         description: descriptionText || `${title} — SMG Swiss Marketplace Group`,
         descriptionByLocale: { [sourceLang]: descriptionText || `${title} — SMG Swiss Marketplace Group` },
+        needsRetranslation: true,
         location,
         canton,
         url: publicUrl,

--- a/scripts/lib/staubli-job-parser.mjs
+++ b/scripts/lib/staubli-job-parser.mjs
@@ -256,6 +256,7 @@ export async function fetchAllStaubliJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
       location,
       canton,
       url: publicUrl,

--- a/scripts/lib/swisslog-job-parser.mjs
+++ b/scripts/lib/swisslog-job-parser.mjs
@@ -199,13 +199,21 @@ const HQ_CITY_RX = /\bbuchs\b/i;
 // correct 'AG' without guessing a street/postal HQ fallback for it.
 const SECONDARY_AG_CITY_RX = /\bm[äa]genwil\b/i;
 
-function resolveCanton(cityText = '', region = '') {
+/**
+ * Resolve the canton for a job, or signal (via null) that it should be
+ * skipped. The crawl is Switzerland-wide (not restricted to Buchs/Mägenwil),
+ * so a real city text that doesn't resolve to any known Swiss canton must
+ * never fabricate the Buchs HQ canton (AG) for a job that isn't positively
+ * there (AGENTS.md Non-Negotiable #3, mirrors clariant-job-parser.mjs).
+ *
+ * @param {string} realCityText - city text as scraped, BEFORE resolveAddress's HQ.city fallback
+ */
+export function resolveCanton(cityText = '', region = '', realCityText = cityText) {
   if (HQ_CITY_RX.test(cityText) || SECONDARY_AG_CITY_RX.test(cityText)) return 'AG';
-  return (
-    inferSwissTargetCanton(cityText) ||
-    inferSwissTargetCanton(`${cityText} ${region}`) ||
-    HQ.canton
-  );
+  const inferredCanton = inferSwissTargetCanton(cityText) || inferSwissTargetCanton(`${cityText} ${region}`);
+  if (inferredCanton) return inferredCanton;
+  if (normalizeSpace(realCityText)) return null;
+  return HQ.canton;
 }
 
 function resolveAddress(rawLoc = {}) {
@@ -366,7 +374,12 @@ export async function fetchAllSwisslogJobs() {
       address: listing.rawAddress?.streetAddress || '',
     });
     const location = normalizeSpace(listing.locationLabel || city || HQ.city);
-    const canton = resolveCanton(city, region);
+    const realCityText = normalizeSpace(listing.cityRaw || listing.locationLabel || '');
+    const canton = resolveCanton(city, region, realCityText);
+    if (canton === null) {
+      console.warn(` ⚠️ Swisslog: skipping unresolvable location "${realCityText}" (${title})`);
+      continue;
+    }
 
     const descriptionCore = stripHtml(listing.descriptionHtml || '');
     const descriptionParts = [descriptionCore, listing.boilerplate].filter(Boolean);

--- a/scripts/lib/talan-job-parser.mjs
+++ b/scripts/lib/talan-job-parser.mjs
@@ -249,6 +249,7 @@ export async function fetchAllTalanJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
       location,
       canton,
       url: publicUrl,

--- a/scripts/update-debiopharm-jobs.mjs
+++ b/scripts/update-debiopharm-jobs.mjs
@@ -205,7 +205,7 @@ async function fetchDebiopharmDetail(shortcode) {
   return fetchJson(`${DEBIOPHARM_WORKABLE_DETAIL_API_BASE}/${encodeURIComponent(shortcode)}`, Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000);
 }
 
-function buildDebiopharmJob(listing, detail) {
+export function buildDebiopharmJob(listing, detail) {
   const parsed = parseDebiopharmJobDetailPayload(detail);
   const title = parsed.title || String(listing?.title || '').trim();
   const city = parsed.city || 'Lausanne';
@@ -217,7 +217,14 @@ function buildDebiopharmJob(listing, detail) {
   const detailUrl = buildDebiopharmDetailUrl(listing.shortcode);
   const applyUrl = buildDebiopharmApplyUrl(listing.shortcode);
   const publishedDate = toIsoDate(parsed.publishedDate);
-  const canton = inferAnyCanton(city) || parsed.inferredCanton;
+  // Trust parsed.inferredCanton as-is: it was already derived from the RAW
+  // (pre-HQ-default) city/region inside parseDebiopharmJobDetailPayload().
+  // Re-deriving from `city` here is wrong — `city` is `parsed.city`, which is
+  // ITSELF already HQ-defaulted to 'Lausanne' when the raw city was empty, so
+  // inferAnyCanton(city) would trivially resolve to 'VD' and short-circuit
+  // before ever consulting the real null-skip signal (e.g. empty city + a
+  // genuinely unresolvable region would wrongly publish as Lausanne/VD).
+  const canton = parsed.inferredCanton;
   if (canton === null) {
     console.warn(`     ⚠️  Skipping unresolvable location "${city}" (${title})`);
     return null;
@@ -505,4 +512,9 @@ async function main() {
   await assembleJobsDataset();
 }
 
-main().catch((err) => exitCrawlerOnError(err, 'Debiopharm'));
+// Guard top-level execution so the module can be imported by tests (e.g.
+// buildDebiopharmJob's skip-guard wiring test) without triggering a live
+// crawl. Run only when invoked directly via `node scripts/update-debiopharm-jobs.mjs`.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => exitCrawlerOnError(err, 'Debiopharm'));
+}

--- a/scripts/update-debiopharm-jobs.mjs
+++ b/scripts/update-debiopharm-jobs.mjs
@@ -217,7 +217,11 @@ function buildDebiopharmJob(listing, detail) {
   const detailUrl = buildDebiopharmDetailUrl(listing.shortcode);
   const applyUrl = buildDebiopharmApplyUrl(listing.shortcode);
   const publishedDate = toIsoDate(parsed.publishedDate);
-  const canton = inferAnyCanton(city) || parsed.inferredCanton || DEFAULT_CANTON;
+  const canton = inferAnyCanton(city) || parsed.inferredCanton;
+  if (canton === null) {
+    console.warn(`     ⚠️  Skipping unresolvable location "${city}" (${title})`);
+    return null;
+  }
 
   return {
     title,
@@ -449,7 +453,9 @@ async function main() {
       console.log(`     ⏭️  Skipping (not Switzerland): ${detail?.location?.countryCode || '?'}`);
       continue;
     }
-    discoveredJobs.push(buildDebiopharmJob(listing, detail));
+    const job = buildDebiopharmJob(listing, detail);
+    if (!job) continue;
+    discoveredJobs.push(job);
   }
 
   if (discoveredJobs.length === 0) {

--- a/tests/clariant-crawler.test.ts
+++ b/tests/clariant-crawler.test.ts
@@ -10,6 +10,7 @@ import {
   parseClariantMicrodata,
   parseClariantJobId,
   extractClariantDetailContent,
+  resolveClariantCanton,
 } from '../scripts/lib/clariant-job-parser.mjs';
 
 describe('Clariant crawler parser', () => {
@@ -123,6 +124,27 @@ describe('Clariant crawler parser', () => {
     });
   });
 
+  // ── resolveClariantCanton (unresolved-canton skip guard — task-critical) ──
+  describe('resolveClariantCanton', () => {
+    it('resolves a known Swiss city to its canton', () => {
+      expect(resolveClariantCanton('Muttenz', 'Muttenz', 'Muttenz')).toBe('BL');
+      expect(resolveClariantCanton('Bern', 'Bern', 'Bern')).toBe('BE');
+    });
+
+    it('falls back to the Muttenz HQ canton when no real location text was scraped at all', () => {
+      expect(resolveClariantCanton('', 'Muttenz', 'Muttenz')).toBe('BL');
+    });
+
+    it('returns null (skip) when real location text is present but unresolvable — never fabricates HQ canton', () => {
+      expect(resolveClariantCanton('Nonexistentburg', 'Nonexistentburg', 'Nonexistentburg')).toBeNull();
+    });
+
+    it('does NOT return null for the negative-control case that would have failed under the old logic (Bern, not BL)', () => {
+      expect(resolveClariantCanton('Bern', 'Bern', 'Bern')).toBe('BE');
+      expect(resolveClariantCanton('Bern', 'Bern', 'Bern')).not.toBe('BL');
+    });
+  });
+
   // ── Listing parse (real jobs2web search-results table fixture) ──
   describe('parseClariantListing', () => {
     // Verbatim structure observed live at
@@ -233,6 +255,20 @@ describe('Clariant crawler parser', () => {
       expect(description).toContain('41492');
       expect(description).toContain('Global Headquarters in Pratteln, Switzerland');
       expect(description).toContain('Responsibilities include strategic analysis and reporting');
+      expect(description).not.toContain('Sidebar content that must NOT be included');
+    });
+
+    it('stops at a compound-class jobColumnTwo marker (e.g. class="col jobColumnTwo"), not just an exact match', () => {
+      const html = `
+        <span class="jobdescription">
+        <p>Join Clariant at its Global Headquarters in Pratteln, Switzerland.</p>
+        </span>
+        <div class="col jobColumnTwo" style="width:25%;">
+        <p>Sidebar content that must NOT be included.</p>
+        </div>
+      `;
+      const description = extractClariantDetailContent(html);
+      expect(description).toContain('Global Headquarters in Pratteln, Switzerland');
       expect(description).not.toContain('Sidebar content that must NOT be included');
     });
 

--- a/tests/debiopharm-job-parser.test.ts
+++ b/tests/debiopharm-job-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseDebiopharmJobDetailPayload } from '../scripts/lib/debiopharm-job-parser.mjs';
+import { buildDebiopharmJob } from '../scripts/update-debiopharm-jobs.mjs';
 
 describe('debiopharm-job-parser', () => {
   // ── parseDebiopharmJobDetailPayload.inferredCanton (unresolved-canton skip guard — task-critical) ──
@@ -35,6 +36,42 @@ describe('debiopharm-job-parser', () => {
       });
       expect(parsed.inferredCanton).toBe('BE');
       expect(parsed.inferredCanton).not.toBe('VD');
+    });
+  });
+
+  // ── buildDebiopharmJob wiring (update-debiopharm-jobs.mjs — regression) ──
+  // parsed.city is ALREADY HQ-defaulted (Lausanne) by
+  // parseDebiopharmJobDetailPayload() itself, independently of whether
+  // inferredCanton resolved. A caller that re-derives canton from
+  // `parsed.city` (rather than trusting `parsed.inferredCanton` directly)
+  // would see `inferAnyCanton('Lausanne')` resolve truthy and short-circuit
+  // before ever consulting the real null-skip signal — silently publishing a
+  // fabricated Lausanne/VD job for an empty-city + unresolvable-region input.
+  describe('buildDebiopharmJob (skip-guard wiring, not just the parser in isolation)', () => {
+    it('returns null (skips) for an empty city + a genuinely unresolvable region', () => {
+      const job = buildDebiopharmJob(
+        { shortcode: 'abc123', title: 'Scientist' },
+        { title: 'Scientist', location: { city: '', region: 'Nonexistentregion', countryCode: 'CH' } },
+      );
+      expect(job).toBeNull();
+    });
+
+    it('still builds a real job for a resolvable city', () => {
+      const job = buildDebiopharmJob(
+        { shortcode: 'def456', title: 'Scientist' },
+        { title: 'Scientist', location: { city: 'Lausanne', region: 'Vaud', countryCode: 'CH' } },
+      );
+      expect(job).not.toBeNull();
+      expect(job.addressRegion).toBe('VD');
+    });
+
+    it('still falls back to the Lausanne HQ canton when there is no real city/region text at all', () => {
+      const job = buildDebiopharmJob(
+        { shortcode: 'ghi789', title: 'Scientist' },
+        { title: 'Scientist', location: { city: '', region: '', countryCode: 'CH' } },
+      );
+      expect(job).not.toBeNull();
+      expect(job.addressRegion).toBe('VD');
     });
   });
 });

--- a/tests/debiopharm-job-parser.test.ts
+++ b/tests/debiopharm-job-parser.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { parseDebiopharmJobDetailPayload } from '../scripts/lib/debiopharm-job-parser.mjs';
+
+describe('debiopharm-job-parser', () => {
+  // ── parseDebiopharmJobDetailPayload.inferredCanton (unresolved-canton skip guard — task-critical) ──
+  describe('inferredCanton', () => {
+    it('resolves a known Swiss city/region to its canton', () => {
+      const parsed = parseDebiopharmJobDetailPayload({
+        title: 'Scientist',
+        location: { city: 'Lausanne', region: 'Vaud', countryCode: 'CH' },
+      });
+      expect(parsed.inferredCanton).toBe('VD');
+    });
+
+    it('falls back to the Lausanne HQ canton (VD) when no real city/region text was scraped at all', () => {
+      const parsed = parseDebiopharmJobDetailPayload({
+        title: 'Scientist',
+        location: { city: '', region: '', countryCode: 'CH' },
+      });
+      expect(parsed.inferredCanton).toBe('VD');
+    });
+
+    it('returns null (skip) when real city/region text is present but unresolvable — never fabricates the HQ canton', () => {
+      const parsed = parseDebiopharmJobDetailPayload({
+        title: 'Scientist',
+        location: { city: 'Nonexistentburg', region: 'Nonexistentregion', countryCode: 'CH' },
+      });
+      expect(parsed.inferredCanton).toBeNull();
+    });
+
+    it('does NOT fabricate VD for the negative-control case (Bern, not VD)', () => {
+      const parsed = parseDebiopharmJobDetailPayload({
+        title: 'Scientist',
+        location: { city: 'Bern', region: '', countryCode: 'CH' },
+      });
+      expect(parsed.inferredCanton).toBe('BE');
+      expect(parsed.inferredCanton).not.toBe('VD');
+    });
+  });
+});

--- a/tests/komax-group-crawler.test.ts
+++ b/tests/komax-group-crawler.test.ts
@@ -6,6 +6,7 @@ import {
   isKomaxJob,
   isTrustedDomain,
   resolveAddress,
+  resolveKomaxCanton,
 } from '../scripts/lib/komax-group-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -230,6 +231,33 @@ describe('Komax crawler parser', () => {
       expect(result.city).toBe('Dierikon');
       expect(result.postalCode).toBe('6036');
       expect(result.streetAddress).toBe('Industriestrasse 6');
+    });
+  });
+
+  // ── resolveKomaxCanton (unresolved-canton skip guard — isSwissLocation()
+  // filters on the ", CH," country segment, NOT on Dierikon/Thun, so a real
+  // but unrecognized city must never fabricate the Dierikon HQ canton,
+  // task-critical) ──
+  describe('resolveKomaxCanton', () => {
+    it('resolves the HQ cities directly, bypassing generic inference', () => {
+      expect(resolveKomaxCanton('Dierikon')).toBe('LU');
+      expect(resolveKomaxCanton('Thun')).toBe('BE');
+    });
+
+    it('resolves a known Swiss city outside the two hardcoded cities via generic inference', () => {
+      expect(resolveKomaxCanton('Bern')).toBe('BE');
+    });
+
+    it('falls back to the Dierikon HQ canton when no city text was scraped at all', () => {
+      expect(resolveKomaxCanton('')).toBe('LU');
+    });
+
+    it('returns null (skip) when city text is present but unresolvable — never fabricates the HQ canton', () => {
+      expect(resolveKomaxCanton('Nonexistentburg')).toBeNull();
+    });
+
+    it('does NOT fabricate LU for the negative-control case (Bern, not LU)', () => {
+      expect(resolveKomaxCanton('Bern')).not.toBe('LU');
     });
   });
 });

--- a/tests/lindt-spruengli-crawler.test.ts
+++ b/tests/lindt-spruengli-crawler.test.ts
@@ -5,6 +5,7 @@ import {
   isLindtSpruengliJob,
   isTrustedDomain,
   extractCityFromLocationText,
+  resolveLindtSpruengliCanton,
 } from '../scripts/lib/lindt-spruengli-job-parser.mjs';
 import {
   SPRUENGLI_KEY,
@@ -119,6 +120,30 @@ describe('Lindt & Sprüngli crawler parser', () => {
     it('returns empty for blank input', () => {
       expect(extractCityFromLocationText('')).toBe('');
       expect(extractCityFromLocationText(undefined as unknown as string)).toBe('');
+    });
+  });
+
+  // ── resolveLindtSpruengliCanton (unresolved-canton skip guard — the board
+  // spans ZH/SZ/SO/LU/BE+, so a real-but-unrecognized city must never
+  // fabricate the Kilchberg HQ canton, task-critical) ──
+  describe('resolveLindtSpruengliCanton', () => {
+    it('resolves a known Swiss city to its canton', () => {
+      expect(resolveLindtSpruengliCanton('Kilchberg')).toBe('ZH');
+      expect(resolveLindtSpruengliCanton('Altendorf')).toBe('SZ');
+    });
+
+    it('returns null (skip) when the city text is present but unresolvable — never fabricates the HQ canton', () => {
+      expect(resolveLindtSpruengliCanton('Nonexistentburg')).toBeNull();
+    });
+
+    it('does NOT fabricate ZH for the negative-control case (Altendorf, not ZH)', () => {
+      expect(resolveLindtSpruengliCanton('Altendorf')).not.toBe('ZH');
+    });
+
+    it('surfaces the comma-split extractCityFromLocationText gap: an unresolvable city is still extracted, and must be caught downstream by this guard, not silently defaulted', () => {
+      const city = extractCityFromLocationText('Nonexistentburg, Switzerland');
+      expect(city).toBe('Nonexistentburg');
+      expect(resolveLindtSpruengliCanton(city)).toBeNull();
     });
   });
 

--- a/tests/swisslog-crawler.test.ts
+++ b/tests/swisslog-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   SWISSLOG_COMPANY_NAME,
   isSwisslogJob,
   isTrustedDomain,
+  resolveCanton,
 } from '../scripts/lib/swisslog-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -12,6 +13,30 @@ describe('Swisslog crawler parser', () => {
   it('exports valid company key and name', () => {
     expect(SWISSLOG_KEY).toBe('swisslog');
     expect(SWISSLOG_COMPANY_NAME).toBe('Swisslog');
+  });
+
+  // ── resolveCanton (unresolved-canton skip guard — Switzerland-wide crawl, task-critical) ──
+  describe('resolveCanton', () => {
+    it('resolves the Buchs/Mägenwil HQ cities directly, bypassing generic inference', () => {
+      expect(resolveCanton('Buchs', '')).toBe('AG');
+      expect(resolveCanton('Mägenwil', '')).toBe('AG');
+    });
+
+    it('resolves a known Swiss city outside the HQ cantons via generic inference', () => {
+      expect(resolveCanton('Bern', '', 'Bern')).toBe('BE');
+    });
+
+    it('falls back to the Buchs HQ canton when no real city text was scraped at all', () => {
+      expect(resolveCanton('Buchs', '', '')).toBe('AG');
+    });
+
+    it('returns null (skip) when real city text is present but unresolvable — never fabricates the HQ canton', () => {
+      expect(resolveCanton('Nonexistentburg', '', 'Nonexistentburg')).toBeNull();
+    });
+
+    it('does NOT fabricate AG for the negative-control case (Bern, not AG)', () => {
+      expect(resolveCanton('Bern', '', 'Bern')).not.toBe('AG');
+    });
   });
 
   // ── isCompanyJob ──


### PR DESCRIPTION
## Implementato

- **Unresolved-canton skip guard** added to 4 parsers where real (non-empty) location text that fails to resolve via `inferSwissTargetCanton`/`inferAnyCanton` was previously silently defaulted to the company's HQ canton — now returns `null` and the job is skipped (`continue`), distinct from "no location text at all" (which still safely defaults to HQ). Each gets a small, exported, unit-tested resolver function:
  - `scripts/lib/clariant-job-parser.mjs` → `resolveClariantCanton()` (#3435 item 1, original target)
  - `scripts/lib/swisslog-job-parser.mjs` → `resolveCanton()` now exported, third `realCityText` param added (real sibling found via mandatory `check-sibling-patterns.mjs` sweep — crawl is Switzerland-wide, not city-restricted)
  - `scripts/lib/debiopharm-job-parser.mjs` → `inferredCanton` in `parseDebiopharmJobDetailPayload()`, consumed by `scripts/update-debiopharm-jobs.mjs`'s `buildDebiopharmJob()` (real sibling; `isDebiopharmSwissJob()` filters on country only, not canton)
  - `scripts/lib/komax-group-job-parser.mjs` → `resolveKomaxCanton()` (real sibling; `isSwissLocation()` filters on the `, CH,` country segment, not restricted to Dierikon/Thun, and the file's own comment already flagged the theoretical risk)
  - `scripts/lib/lindt-spruengli-job-parser.mjs` → `resolveLindtSpruengliCanton()` (real sibling; `extractCityFromLocationText()`'s comma-split branch returns raw text unconditionally without checking `inferAnyCanton`, unlike its dash-split branch — board spans ZH/SZ/SO/LU/BE+ per file's own header doc)
- `scripts/lib/clariant-job-parser.mjs`: widened `extractClariantDetailContent()`'s `jobColumnTwo` sidebar-marker regex to a class-contains match, handling compound-class variants like `class="col jobColumnTwo"` (#3435 item 2)
- `scripts/lib/clariant-job-parser.mjs` pagination Switzerland-only filter verified live across `startrow=0/20/40/60`: filtered query correctly returns 0 rows past the site's real 1-job total, while the *same offsets* unfiltered return 20 non-CH rows each (US/CN/ES/JP/MX/BR/DE/FR/SE) — proves the `locationsearch=switzerland` filter persists server-side deep into pagination, no client-side filter needed (#3435 item 3, verification-only)
- `scripts/lib/crawler-location-config.mjs`: added missing `COMPANY_HQ['smg-swiss-marketplace-group']` entry (#3379 item 4)
- Added `needsRetranslation: true` to 5 parsers that were missing it: `smg-swiss-marketplace-group`, `talan`, `staubli`, `cern`, `beekeeper` (#3379 item 5)
- New test coverage: `tests/debiopharm-job-parser.test.ts` (new file, this parser had zero coverage), plus new `describe` blocks in `tests/clariant-crawler.test.ts`, `tests/swisslog-crawler.test.ts`, `tests/komax-group-crawler.test.ts`, `tests/lindt-spruengli-crawler.test.ts`
- Full mandatory sibling-pattern sweep (`node scripts/ci/check-sibling-patterns.mjs`) run to convergence (2 rounds — 2nd round triggered by this PR's own new `cityText`/`rawCity` parameter names). All remaining candidates manually confirmed as false positives: `bosch-job-parser.mjs` (fallback target is `''`, no fabrication), `kulm-hotel-job-parser.mjs` (`mapLocationToCity()` always resolves to a real GR town — dead code), `rittmeyer-job-parser.mjs` / `blast-publisher-ads.mjs` / `publisherJobProjection.mjs` / `send-job-alerts.mjs` / `services/publisherBlastEmail.mjs` (unrelated use of `locationLabel` for slug/display text, no canton logic), `google-switzerland-job-parser.mjs` (`location` is a hardcoded literal `'Zürich'`, never scraped), `planzer-job-parser.mjs` (the reference-correct source pattern itself), `sunrise-job-parser.mjs` / `scripts/update-sunrise-jobs.mjs` (already implements the correct drop-unresolved design via `inferSunriseCanton`)
- Follow-up commit `ce17263`: while `pr-review-loop`'s automated review was stuck queued behind CI runner-pool starvation, ran a local adversarial `code-reviewer` subagent standing in for it. It caught a real regression in `scripts/update-debiopharm-jobs.mjs`'s `buildDebiopharmJob()`: the caller re-derived canton via `inferAnyCanton(city)` where `city` is `parsed.city`, itself already HQ-defaulted to `'Lausanne'` inside the parser — so an empty city + genuinely unresolvable region would resolve `city → 'Lausanne'` and short-circuit to VD before ever consulting the parser's real `inferredCanton` null-skip signal, silently defeating this exact PR's skip guard. Fixed by trusting `parsed.inferredCanton` directly; `buildDebiopharmJob` exported and 3 new wiring tests added (`tests/debiopharm-job-parser.test.ts`) covering the empty-city/unresolvable-region skip, a resolvable-city pass-through, and the no-text-at-all HQ-default. Also added the missing ESM main-module guard (`if (import.meta.url === ...)`) around the file's `main()` call — discovered because importing the module for the new test triggered a live network crawl on load; scoped only to this file, not the 7 other pre-existing `update-*.mjs` files missing the same guard (different bug class, out of scope for this PR)

## Non implementato (ancora)

- `scripts/update-debiopharm-jobs.mjs`'s `postProcessJobs()` backfill loop (canonicalizes already-published jobs) still has an unguarded `|| DEFAULT_CANTON` fallback — **deliberately not extended here**: that loop touches already-live, possibly-indexed jobs, and dropping/dequalifying them conflicts with the site's "never cut live pages without explicit OK" policy. This is a different risk class from skipping a not-yet-published job during fresh admission (which this PR does fix). Blocked: needs explicit owner approval before applying the skip-guard to already-published jobs — will open as a separate follow-up if approved.
- Issue #3379 items 1–3 (Saint-Gobain crawler ATS discovery, 5 remaining batch-3 companies, Wave C's 37 bespoke companies) are **out of this PR's scope** — they are new-crawler-creation work, not the code-quality/sibling-pattern-fix class this PR addresses. They remain open and tracked on issue #3379/#3337, not closed by this PR.

All 3 items in #3435 resolved by this PR (see `## Implementato` above) — closing manually after merge, not via auto-close keyword (aggregate follow-up issue, per `contract.yml`'s multi-item-aggregate policy).

