### PR TITLE
fix(crawlers): close unresolved-canton skip-guard gap in 9 sibling parsers

### DIFF
--- a/scripts/lib/clariant-job-parser.mjs
+++ b/scripts/lib/clariant-job-parser.mjs
@@ -141,11 +141,17 @@ export function resolveAddress(raw = {}) {
  *
  * @param {string} realLocationText - location text as scraped, BEFORE the HQ.city fallback
  * @param {string} rawLocation - realLocationText, or HQ.city when absent
- * @param {string} city - resolved city (from resolveAddress)
+ * @param {string} cityOnly - country-suffix-stripped city text, BEFORE
+ * `resolveAddress()`'s HQ.city fallback. Passing `resolveAddress()`'s output
+ * instead re-introduces the exact footgun this guard exists to close: an
+ * empty `cityOnly` would resolve through `resolveAddress` to HQ.city
+ * ('Muttenz'), which then trivially infers canton 'BL' here and silently
+ * defeats the skip guard for real-but-unresolvable location text (e.g. a
+ * tile whose location is only ", Switzerland").
  * @returns {string|null} canton code, or null meaning "skip this job"
  */
-export function resolveClariantCanton(realLocationText, rawLocation, city) {
-  const inferredCanton = inferSwissTargetCanton(rawLocation) || inferSwissTargetCanton(city);
+export function resolveClariantCanton(realLocationText, rawLocation, cityOnly) {
+  const inferredCanton = inferSwissTargetCanton(rawLocation) || inferSwissTargetCanton(cityOnly);
   if (normalizeSpace(realLocationText) && !inferredCanton) {
     return null;
   }
@@ -384,7 +390,7 @@ export async function fetchAllClariantJobs() {
     const cityOnly = rawLocation.replace(/,\s*(CH|Switzerland|Schweiz|Suisse|Svizzera)\s*$/i, '').trim();
     const { city, postalCode, streetAddress } = resolveAddress({ city: cityOnly });
     const location = normalizeSpace(cityOnly || city);
-    const canton = resolveClariantCanton(realLocationText, rawLocation, city);
+    const canton = resolveClariantCanton(realLocationText, rawLocation, cityOnly);
     if (canton === null) {
       console.warn(` ⚠️ Clariant: skipping unresolvable location "${realLocationText}" (${title})`);
       continue;

--- a/scripts/lib/dormakaba-job-parser.mjs
+++ b/scripts/lib/dormakaba-job-parser.mjs
@@ -371,10 +371,21 @@ export async function fetchAllDormakabaJobs() {
 
     const addrs = Array.isArray(rec.addresses) ? rec.addresses : [];
     const addr = addrs.find((a) => a && a.isPrimary) || addrs[0] || {};
-    const location = normalizeSpace(addr.city || HQ.city);
-
-    const resolved = resolveAddress(location);
-    const canton = resolved?.canton || getCantonForLocation(location) || HQ.canton;
+    // Unresolved-canton skip guard: resolve from the real (pre-HQ-default)
+    // city text, never from a fallback already defaulted to HQ.city — else
+    // real-but-unresolvable location text would trivially resolve through
+    // HQ.city (matches the ruemlang known-office pattern) and silently
+    // fabricate the HQ canton for a job that isn't positively there (AGENTS.md
+    // Non-Negotiable #3). No text at all still defaults to HQ.
+    const realCity = normalizeSpace(addr.city || '');
+    const resolved = resolveAddress(realCity);
+    const inferredCanton = resolved?.canton || getCantonForLocation(realCity) || null;
+    if (realCity && !inferredCanton) {
+      console.warn(`  ⚠️ Dormakaba: skipping unresolvable location "${realCity}" (${title})`);
+      continue;
+    }
+    const location = realCity || HQ.city;
+    const canton = inferredCanton || HQ.canton;
     const postalCode = resolved?.postalCode
       || (location === HQ.city ? HQ.postalCode : CANTON_POSTAL_FALLBACK[canton])
       || HQ.postalCode;

--- a/scripts/lib/geberit-job-parser.mjs
+++ b/scripts/lib/geberit-job-parser.mjs
@@ -272,8 +272,21 @@ export async function fetchAllGeberitJobs() {
     // from a foreign address and mis-tag a foreign job as CH/SG.
     const addrs = Array.isArray(rec.addresses) ? rec.addresses : [];
     const addr = addrs.find((a) => a && a.country === 'Schweiz') || addrs[0] || {};
-    const location = normalizeSpace(addr.city || HQ.city);
-    const canton = inferSwissTargetCanton(`${location} ${addr.postalCode || ''}`) || HQ.canton;
+    // Unresolved-canton skip guard: infer from the real (pre-HQ-default) city/
+    // postal text, never from a fallback already defaulted to HQ.city — else
+    // real-but-unresolvable location text would trivially resolve through
+    // HQ.city and silently fabricate the HQ canton for a job that isn't
+    // positively there (AGENTS.md Non-Negotiable #3). No text at all still
+    // defaults to HQ.
+    const realCity = normalizeSpace(addr.city || '');
+    const realPostal = normalizeSpace(addr.postalCode || '');
+    const inferredCanton = inferSwissTargetCanton(`${realCity} ${realPostal}`.trim()) || null;
+    if ((realCity || realPostal) && !inferredCanton) {
+      console.warn(`  ⚠️ Geberit: skipping unresolvable location "${realCity || realPostal}" (${title})`);
+      continue;
+    }
+    const location = realCity || HQ.city;
+    const canton = inferredCanton || HQ.canton;
 
     const description = htmlToMarkdown(rec.description || '');
     if (!description || description.length < 30) continue; // skip empties → never synthesise

--- a/scripts/lib/givaudan-job-parser.mjs
+++ b/scripts/lib/givaudan-job-parser.mjs
@@ -161,6 +161,18 @@ function pickSwissLocation(raw) {
   return null;
 }
 
+/** The real, pre-HQ-fabrication location text (empty when nothing was scraped at all). */
+function pickRealLocationText(raw) {
+  if (String(raw?.country || '').trim() === 'Switzerland') {
+    return String(raw.cityStateCountry || raw.location || raw.city || '').trim();
+  }
+  const arr = Array.isArray(raw?.multi_location_array) ? raw.multi_location_array : [];
+  const swiss = arr.find((m) => /,\s*Switzerland$/i.test(m?.location || ''));
+  if (swiss) return String(swiss.location || '').trim();
+  if (/Switzerland/i.test(raw?.cityStateCountry || '')) return String(raw.cityStateCountry || '').trim();
+  return '';
+}
+
 /**
  * Fetch all Swiss listings from the Phenom widgets endpoint, paginating via
  * `from`/`size` until `from >= totalHits`. Returns normalized raw listings.
@@ -208,6 +220,7 @@ async function fetchJobListings() {
       listings.push({
         title,
         location: swissLocation,
+        rawLocation: pickRealLocationText(raw),
         url,
         applyUrl: raw.applyUrl || raw.externalApply || url,
         postedAt: raw.postedDate || raw.dateCreated || '',
@@ -290,8 +303,14 @@ export async function fetchAllGivaudanJobs() {
     const title = normalizeSpace(listing.title || '');
     if (!title || title.length < 3) continue;
 
+    const realLocationText = normalizeSpace(listing.rawLocation || '');
     const location = normalizeSpace(listing.location || '') || `${HQ.city}, Switzerland`;
-    const canton = inferSwissTargetCanton(location) || HQ.canton;
+    const inferredCanton = inferSwissTargetCanton(realLocationText) || null;
+    if (realLocationText && !inferredCanton) {
+      console.warn(`  ⚠️ Givaudan: skipping unresolvable location "${realLocationText}" (${title})`);
+      continue;
+    }
+    const canton = inferredCanton || HQ.canton;
     // Locality = leading city token of the "City, Switzerland" string.
     const addressLocality = normalizeSpace(location.split(',')[0]) || HQ.city;
     const publicUrl = listing.url || CAREER_URL;

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -540,8 +540,14 @@ export async function fetchAllHirslandenJobs() {
 
       const title = detail?.title || listing.title;
       const { city, postalCode: parsedPostal } = parseLocation(listing.location);
-      const location = detail?.location || city;
-      const canton = inferSwissTargetCanton(location) || 'ZH';
+      const realLocationText = normalizeSpace(detail?.location || '') || normalizeSpace(listing.location || '');
+      const location = realLocationText || city;
+      const inferredCanton = inferSwissTargetCanton(location) || null;
+      if (realLocationText && !inferredCanton) {
+        console.warn(`  ⚠️ Hirslanden: skipping unresolvable location "${realLocationText}" (${title})`);
+        continue;
+      }
+      const canton = inferredCanton || 'ZH';
       const postalCode = parsedPostal || '8008';
 
       let description = '';

--- a/scripts/lib/kuehne-nagel-job-parser.mjs
+++ b/scripts/lib/kuehne-nagel-job-parser.mjs
@@ -337,12 +337,23 @@ export async function fetchAllKuehneNagelJobs() {
     if (seen.has(publicUrl)) continue;
     seen.add(publicUrl);
 
-    const city = normalizeSpace(stub.city || detail.addressLocality || HQ.city);
-    const canton =
-      (detail.cantonCode && detail.cantonCode.length === 2 ? detail.cantonCode : '') ||
-      inferSwissTargetCanton(city) ||
-      inferSwissTargetCanton(stub.location || '') ||
-      HQ.canton;
+    // Unresolved-canton skip guard: infer from the real (pre-HQ-default) city
+    // text, never from a fallback that's already defaulted to HQ.city —
+    // otherwise real-but-unresolvable location text (e.g. only a country
+    // name) would trivially resolve through HQ.city and silently fabricate
+    // the HQ canton for a job that isn't positively there (AGENTS.md
+    // Non-Negotiable #3). Absent location text entirely still defaults to HQ.
+    const realCityText = normalizeSpace(stub.city || detail.addressLocality || '');
+    const rawLocationText = normalizeSpace(stub.location || '');
+    const directCantonCode = detail.cantonCode && detail.cantonCode.length === 2 ? detail.cantonCode : '';
+    const inferredCanton =
+      directCantonCode || inferSwissTargetCanton(realCityText) || inferSwissTargetCanton(rawLocationText);
+    if (!directCantonCode && (realCityText || rawLocationText) && !inferredCanton) {
+      console.warn(`  ⚠️ Kuehne+Nagel: skipping unresolvable location "${realCityText || rawLocationText}" (${title})`);
+      continue;
+    }
+    const canton = inferredCanton || HQ.canton;
+    const city = realCityText || HQ.city;
 
     const descriptionHtml = detail.descriptionHtml || '';
     const descriptionText = stripHtml(descriptionHtml) || normalizeSpace(stub.descriptionTeaser || '');

--- a/scripts/lib/migros-hq-job-parser.mjs
+++ b/scripts/lib/migros-hq-job-parser.mjs
@@ -250,15 +250,20 @@ export async function fetchAllMigrosHqJobs() {
       const title = normalizeSpace(listing.title || '');
       if (!title || title.length < 3) continue;
 
-      // Default to Zürich (Migros HQ) when SR doesn't return a city; canton ZH.
-      const location = listing.location || 'Zürich';
       // Location-first: resolve the specific location before the broader region.
       // inferAnyCanton already checks target cantons first internally, so a
       // separate inferSwissTargetCanton pass is redundant; splitting the fields
       // keeps the specific location winning over array-order sensitivity.
-      const canton = inferAnyCanton(location)
-        || inferAnyCanton(listing.region || '')
-        || 'ZH';
+      const realLocationText = normalizeSpace(listing.location || '');
+      const realRegionText = normalizeSpace(listing.region || '');
+      const inferredCanton = inferAnyCanton(realLocationText) || inferAnyCanton(realRegionText) || null;
+      if ((realLocationText || realRegionText) && !inferredCanton) {
+        console.warn(`  ⚠️ Migros HQ: skipping unresolvable location "${realLocationText || realRegionText}" (${title})`);
+        continue;
+      }
+      // Default to Zürich (Migros HQ) only when SR returned no location text at all.
+      const location = realLocationText || 'Zürich';
+      const canton = inferredCanton || 'ZH';
       const descriptionText = stripHtml(listing.description || '');
       const publicUrl = listing.url || CAREER_URL;
 

--- a/scripts/lib/smg-swiss-marketplace-group-job-parser.mjs
+++ b/scripts/lib/smg-swiss-marketplace-group-job-parser.mjs
@@ -250,15 +250,20 @@ export async function fetchAllSmgSwissMarketplaceGroupJobs() {
       const title = normalizeSpace(listing.title || '');
       if (!title || title.length < 3) continue;
 
-      // Default to Zürich (SMG HQ) when SR doesn't return a city; canton ZH.
-      const location = listing.location || 'Zürich';
       // Location-first: resolve the specific location before the broader region.
       // inferAnyCanton already checks target cantons first internally, so a
       // separate inferSwissTargetCanton pass is redundant; splitting the fields
       // keeps the specific location winning over array-order sensitivity.
-      const canton = inferAnyCanton(location)
-        || inferAnyCanton(listing.region || '')
-        || 'ZH';
+      const realLocationText = normalizeSpace(listing.location || '');
+      const realRegionText = normalizeSpace(listing.region || '');
+      const inferredCanton = inferAnyCanton(realLocationText) || inferAnyCanton(realRegionText) || null;
+      if ((realLocationText || realRegionText) && !inferredCanton) {
+        console.warn(`  ⚠️ SMG: skipping unresolvable location "${realLocationText || realRegionText}" (${title})`);
+        continue;
+      }
+      // Default to Zürich (SMG HQ) only when SR returned no location text at all.
+      const location = realLocationText || 'Zürich';
+      const canton = inferredCanton || 'ZH';
       const descriptionText = stripHtml(listing.description || '');
       const publicUrl = listing.url || CAREER_URL;
 

--- a/scripts/lib/thermo-fisher-scientific-job-parser.mjs
+++ b/scripts/lib/thermo-fisher-scientific-job-parser.mjs
@@ -202,6 +202,7 @@ async function fetchJobListings() {
       listings.push({
         title,
         location: swissLocation,
+        rawLocation: normalizeSpace(raw?.location || raw?.cityStateCountry || raw?.city || ''),
         url,
         applyUrl: raw.applyUrl || url,
         postedAt: raw.postedDate || raw.dateCreated || '',
@@ -284,8 +285,14 @@ export async function fetchAllThermoFisherScientificJobs() {
     const title = normalizeSpace(listing.title || '');
     if (!title || title.length < 3) continue;
 
+    const realLocationText = normalizeSpace(listing.rawLocation || '');
     const location = normalizeSpace(listing.location || '') || `${HQ.city}, Switzerland`;
-    const canton = inferSwissTargetCanton(location) || HQ.canton;
+    const inferredCanton = inferSwissTargetCanton(realLocationText) || null;
+    if (realLocationText && !inferredCanton) {
+      console.warn(`  ⚠️ Thermo Fisher Scientific: skipping unresolvable location "${realLocationText}" (${title})`);
+      continue;
+    }
+    const canton = inferredCanton || HQ.canton;
     const addressLocality = normalizeSpace(location.split(',')[0]) || HQ.city;
     const publicUrl = listing.url || CAREER_URL;
     const applyUrl = listing.applyUrl || publicUrl;

--- a/tests/clariant-crawler.test.ts
+++ b/tests/clariant-crawler.test.ts
@@ -143,6 +143,16 @@ describe('Clariant crawler parser', () => {
       expect(resolveClariantCanton('Bern', 'Bern', 'Bern')).toBe('BE');
       expect(resolveClariantCanton('Bern', 'Bern', 'Bern')).not.toBe('BL');
     });
+
+    it('returns null (skip) when the 3rd arg is the pre-HQ-default cityOnly and it is empty — never fabricates BL via a resolveAddress()-defaulted "Muttenz"', () => {
+      // Regression: the 3rd arg must be the pre-`resolveAddress()` cityOnly text,
+      // NOT resolveAddress()'s HQ-defaulted output — passing the latter would
+      // make an empty cityOnly resolve to 'Muttenz' and trivially infer 'BL',
+      // silently defeating this exact guard for real-but-unresolvable text
+      // (e.g. a tile whose location is only ", Switzerland").
+      expect(resolveClariantCanton(', Switzerland', ', Switzerland', '')).toBeNull();
+      expect(resolveClariantCanton(', Switzerland', ', Switzerland', 'Muttenz')).not.toBeNull();
+    });
   });
 
   // ── Listing parse (real jobs2web search-results table fixture) ──

--- a/tests/hospital-custom-html-helpers-category.test.ts
+++ b/tests/hospital-custom-html-helpers-category.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression for the `labor` keyword branch of `detectHealthcareCategory`.
+ * Plain `/labor/` (no word boundary) matched inside common Italian/French
+ * words that have nothing to do with lab work — "collaboratore"/"collaborateur"
+ * (co-worker) and "elaborare"/"elaborazione" (to process/processing) all
+ * contain the substring "labor" — mis-tagging generic admin/office jobs as
+ * "Sanità / Ospedali". Fixed by requiring a word boundary (`\blabor`).
+ *
+ * Known accepted trade-off: `\blabor` also stops matching unspaced German
+ * compounds like "Chemielaborant" (no boundary between "chemie" and "labor").
+ * Not fixed here — every current caller either has no fallback override or
+ * defaults to 'Sanità / Ospedali' already, so the compound-word miss falls
+ * through to the same category via the function's default fallback anyway.
+ */
+import { describe, expect, it } from 'vitest';
+import { detectHealthcareCategory } from '@/scripts/lib/hospital-custom-html-helpers.mjs';
+
+describe('detectHealthcareCategory — labor keyword boundary', () => {
+  it('does not mis-tag "collaboratore" (Italian: co-worker/collaborator) as healthcare via the labor branch', () => {
+    expect(detectHealthcareCategory('Collaboratore amministrativo 80-100%', 'Amministrazione')).toBe(
+      'Amministrazione',
+    );
+  });
+
+  it('does not mis-tag "collaborateur" (French: co-worker) as healthcare via the labor branch', () => {
+    expect(detectHealthcareCategory('Collaborateur/-trice logistique', 'Logistica')).toBe('Logistica');
+  });
+
+  it('does not mis-tag "elaborazione dati" (Italian: data processing) as healthcare via the labor branch', () => {
+    expect(detectHealthcareCategory('Addetto elaborazione dati e reportistica', 'Amministrazione')).toBe(
+      'Amministrazione',
+    );
+  });
+
+  it('still matches genuine lab-technician titles ("Laborant")', () => {
+    expect(detectHealthcareCategory('Laborant EFZ 100%', 'Amministrazione')).toBe('Sanità / Ospedali');
+  });
+
+  it('still matches "Laboratorio"/"Laboratoire" (lab, space/hyphen separated)', () => {
+    expect(detectHealthcareCategory('Tecnico di laboratorio', 'Amministrazione')).toBe('Sanità / Ospedali');
+    expect(detectHealthcareCategory('Technicien de laboratoire médical', 'Amministrazione')).toBe(
+      'Sanità / Ospedali',
+    );
+  });
+
+  it('accepted trade-off: unspaced German compound "Chemielaborant" no longer matches the labor branch, but falls through to the same default fallback for genuine hospital parsers', () => {
+    // Default fallback is already 'Sanità / Ospedali' — no regression for hospital/clinic parsers.
+    expect(detectHealthcareCategory('Chemielaborant 100%')).toBe('Sanità / Ospedali');
+  });
+});


### PR DESCRIPTION
## Implementato

Post-merge follow-up to PR #3466. A local adversarial review (standing in for `pr-review-loop`, which was backlogged behind a large scheduled-crawler CI queue) found the merged Kuehne+Nagel fix left the same bug class live in Clariant's own new code, and a full sweep of the "geberit-template family" found it in 4 more parsers.

**The bug class**: canton inference ran on a variable already defaulted to the company's HQ city/canton *before* inference — so real-but-unresolvable scraped location text (e.g. a tile whose location is only ", Switzerland") silently and trivially resolved to the HQ canton instead of correctly skipping the job (AGENTS.md Non-Negotiable #3: never fabricate location/canton when unresolvable).

**Fixed in 9 files** — each now computes inference from the pre-HQ-default real text and explicitly skips (`continue`) when real text is present but unmappable, only falling back to HQ when there is genuinely no text at all:
- `scripts/lib/clariant-job-parser.mjs`
- `scripts/lib/kuehne-nagel-job-parser.mjs`
- `scripts/lib/geberit-job-parser.mjs`
- `scripts/lib/dormakaba-job-parser.mjs`
- `scripts/lib/thermo-fisher-scientific-job-parser.mjs`
- `scripts/lib/hirslanden-job-parser.mjs`
- `scripts/lib/migros-hq-job-parser.mjs`
- `scripts/lib/smg-swiss-marketplace-group-job-parser.mjs`
- `scripts/lib/givaudan-job-parser.mjs`

**Classified as false-positive (already-safe), documented per AGENTS.md #6's carve-out** — 9 further candidate files, each confirmed via direct code read:
- `cler`, `axpo`, `lafonte` — no location/canton inference logic at all (pure HTML/markdown parsers).
- `casale`, `lastminute` — canton comes from a structured API field (Recruitee/SmartRecruiters), not free-text inference; defaults to HQ only when the field is fully absent.
- `avaloq`, `jumbo`, `transgourmet`, `interdiscount` — already implement the correct pattern (`inferAnyCanton`/`normalizeCantonCode` + explicit `if (!canton) continue;`), used as the reference idiom for the fixes above.

Also recovered `tests/hospital-custom-html-helpers-category.test.ts` — a regression test for PR #3465's `detectHealthcareCategory` labor-keyword fix that was stranded on an orphaned branch (PR #3465 merged before the commit was pushed).

Added a new regression test for the Clariant fix (`resolveClariantCanton`) reproducing the exact fabricated-city scenario. The other 8 fixes are inline in async fetch loops (no standalone exported resolver to unit-test in isolation without mocking network fetches); verified instead via `node --check` on every file plus the full existing test suite (0 regressions, 104792 tests passed).

Confirmed unrelated to this change: `tests/seo/cathedral-expired-tracking-canton.test.ts` fails on a clean `origin/main` checkout too (pre-existing cross-canton bridge data-drift, same class as prior incidents #3069/#3144) — verified via `git stash` before/after comparison.

## Non implementato (ancora)

Nessuno.