### PR TITLE
fix(cdn-offload): og/image CDN rewrite no-ops on shard dists — drop existsSync gate from rewrite list (#3475)

### DIFF
--- a/scripts/offload-generated-images-cdn.mjs
+++ b/scripts/offload-generated-images-cdn.mjs
@@ -183,9 +183,19 @@ const DATA_FILE = "([^\"'\\s)?<>]+?\\.(?:json|csv))";
 function offloadAll(distDir, cdnBase) {
   const escOrigin = ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  // og rewrite/guard regexes per present target dir.
+  // og/image rewrite/guard regexes: compiled for EVERY target, NOT gated on
+  // the target dir being present in THIS dist (#3475). Shard dists (the en/de/
+  // fr shard runners and the Ticino staged copies) are pruned to one locale
+  // subtree and carry no dist/og or dist/images/* — yet their HTML still
+  // references those paths, and the bytes are already on the CDN (the IT leg
+  // pushes them). Gating the rewrite on fs.existsSync silently no-op'd it
+  // there: og:image + brand/logo <img> refs stayed on the main domain and paid
+  // a CF 301 hop to the CDN on every fetch (users, social scrapers,
+  // Googlebot-Image) while /assets/ + /data/ rewrites on the SAME pages did
+  // apply. Dir presence only matters for the guarded DELETE below (can't
+  // delete what isn't there) — that's what ogTargets gates.
   const ogTargets = TARGETS.filter((t) => fs.existsSync(path.join(distDir, ...t.dir)));
-  const ogCompiled = ogTargets.map((t) => {
+  const ogCompiled = TARGETS.map((t) => {
     const escUrl = t.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return {
       t,
@@ -403,7 +413,9 @@ function offloadAll(distDir, cdnBase) {
       log(`GUARD: unrewritten same-origin ref(s) survive — keeping in dist (non-fatal): ${kept.join(' | ')}`);
     }
   } else {
-    log('no OG offload target dirs present — skipping og delete');
+    // Shard-dist path (#3475): no local dirs to delete, but the rewrites above
+    // DID run — log the count so CI shows the offload applied on shard legs.
+    log(`no OG offload target dirs present — skipping og delete (og/image refs rewritten in ${ogRewritten} files)`);
   }
 
   // data: delete cdn-only files, keep any /data/ path referenced same-origin in HTML.

--- a/tests/offload-image-refs-shard-dist.test.ts
+++ b/tests/offload-image-refs-shard-dist.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression guard for #3475 — og/image CDN rewrites on SHARD dists.
+ *
+ * scripts/offload-generated-images-cdn.mjs used to compile its og/image
+ * rewrite regexes only for TARGETS whose dir exists under dist/
+ * (fs.existsSync gate). On the en/de/fr shard runners and the Ticino staged
+ * copies the dist is pruned to a single locale subtree with NO dist/og or
+ * dist/images/* — so the rewrite list compiled empty and og:image +
+ * brand-logo refs silently stayed on the main domain, paying a Cloudflare
+ * 301 hop to cdn.frontaliereticino.ch on every fetch, while the ungated
+ * /assets/ + /data/ rewrites on the SAME pages did apply.
+ *
+ * Contract locked here (runs the real script end-to-end on a throwaway dist):
+ *   1. Shard-like dist (no og/images dirs): og:image + /images/brands/ refs
+ *      (quoted AND unquoted attr forms) are rewritten to CDN_BASE; refs
+ *      already on another host stay untouched.
+ *   2. Full-dist behavior unchanged: present target dirs are still rewritten
+ *      AND guard-deleted exactly as before.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT = fileURLToPath(
+  new URL('../scripts/offload-generated-images-cdn.mjs', import.meta.url),
+);
+const CDN_BASE = 'https://valerielinc-ops.github.io/frontaliere-cdn';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* gone */ }
+  }
+});
+
+function makeDist(): { tmp: string; distDir: string } {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'offload-shard-'));
+  tmpDirs.push(tmp);
+  const distDir = path.join(tmp, 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  return { tmp, distDir };
+}
+
+function runOffload(tmp: string): void {
+  // Real script, cwd=tmp so it resolves cwd()/dist to the throwaway tree.
+  execFileSync('node', [SCRIPT], {
+    cwd: tmp,
+    env: { ...process.env, CDN_BASE },
+    stdio: 'pipe',
+  });
+}
+
+// Mirrors a live job page in a pruned shard subtree: unquoted brand-logo
+// <img src=…> (as emitted), quoted variant, main-domain og:image, plus a ref
+// already on a different CDN host that must survive untouched.
+const JOB_PAGE_HTML =
+  '<!doctype html><html><head><meta charset="utf-8"><title>t</title>' +
+  '<meta property="og:image" content="https://frontaliereticino.ch/og/jobs/mansioni-hirslanden-2f7ac8.webp">' +
+  '</head><body>' +
+  '<img src=/images/brands/hirslanden.png alt=a width=32 height=32>' +
+  '<img src="/images/brands/other-logo.png" alt="b">' +
+  '<img src="https://cdn.frontaliereticino.ch/images/brands/already.png" alt="c">' +
+  '</body></html>';
+
+describe('og/image CDN rewrite on shard dists (#3475)', () => {
+  it('rewrites og:image + brand refs even when dist/og and dist/images are ABSENT', () => {
+    const { tmp, distDir } = makeDist();
+    // Shard reality: HTML nested under the locale subtree, no og/images dirs.
+    const pageDir = path.join(distDir, 'cerca-lavoro-ticino', 'lavoro-hirslanden');
+    fs.mkdirSync(pageDir, { recursive: true });
+    const htmlPath = path.join(pageDir, 'index.html');
+    fs.writeFileSync(htmlPath, JOB_PAGE_HTML, 'utf8');
+
+    runOffload(tmp);
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    // og:image → CDN.
+    expect(html).toContain(`content="${CDN_BASE}/og/jobs/mansioni-hirslanden-2f7ac8.webp"`);
+    expect(html).not.toContain('https://frontaliereticino.ch/og/');
+    // Brand logos → CDN, both unquoted and quoted attr forms.
+    expect(html).toContain(`src=${CDN_BASE}/images/brands/hirslanden.png`);
+    expect(html).toContain(`src="${CDN_BASE}/images/brands/other-logo.png"`);
+    expect(html).not.toContain('src=/images/brands/');
+    expect(html).not.toContain('"/images/brands/');
+    // Already-offloaded ref on another host untouched (no double-rewrite).
+    expect(html).toContain('src="https://cdn.frontaliereticino.ch/images/brands/already.png"');
+  });
+
+  it('still rewrites AND guard-deletes target dirs that ARE present (full-dist parity)', () => {
+    const { tmp, distDir } = makeDist();
+    const ogDir = path.join(distDir, 'og', 'jobs');
+    fs.mkdirSync(ogDir, { recursive: true });
+    fs.writeFileSync(path.join(ogDir, 'a.webp'), 'x', 'utf8');
+    const htmlPath = path.join(distDir, 'index.html');
+    fs.writeFileSync(
+      htmlPath,
+      '<!doctype html><html><head><title>t</title>' +
+        '<meta property="og:image" content="https://frontaliereticino.ch/og/jobs/a.webp">' +
+        '</head><body></body></html>',
+      'utf8',
+    );
+
+    runOffload(tmp);
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain(`content="${CDN_BASE}/og/jobs/a.webp"`);
+    // No surviving same-origin ref → offloaded dir deleted from the artifact.
+    expect(fs.existsSync(path.join(distDir, 'og'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

- `scripts/offload-generated-images-cdn.mjs`: le regex di rewrite og/image (`ogCompiled`) sono ora compilate per **TUTTI** i `TARGETS`, non più gated su `fs.existsSync(dist/<target dir>)`. Sui dist shard (runner en/de/fr e staged copy Ticino, potati a un solo subtree locale senza `dist/og` né `dist/images/*`) la lista compilava vuota e il rewrite og/image no-oppava in silenzio: og:image e loghi brand restavano sul main domain e pagavano un 301 Cloudflare verso `cdn.frontaliereticino.ch` a ogni fetch (utenti, social scraper, Googlebot-Image) — mentre i rewrite `/assets/` e `/data/` non gated sulle STESSE pagine si applicavano. Il gate `existsSync` resta SOLO dove serve: sul guarded delete (`ogTargets`) — non si può cancellare una dir che non c'è. La safety net del redirect CF resta intatta (non toccata).
- Log del path shard: il ramo "no OG offload target dirs present" ora riporta il conteggio dei file riscritti, così i log CI delle leg shard mostrano che l'offload si è applicato.
- `tests/offload-image-refs-shard-dist.test.ts` (nuovo): esegue lo script reale end-to-end su un dist throwaway — (1) dist shard-like SENZA `dist/og`/`dist/images`: og:image + `/images/brands/` (forma attributo quoted E unquoted) riscritti a CDN_BASE, ref già su altro host intatti; (2) parità full-dist: dir presente → rewrite + guarded delete invariati.
- Sibling-check (classe del bug, AGENTS.md #6): grep di `existsSync` gating su rewrite in `build-plugins/**` e `scripts/` — unico altro match è `blogImageCdnFinalizePlugin.ts:104`, **falso positivo**: gira in `closeBundle()` durante la build completa dove `dist/images/blog` esiste sempre (mai su dist shard potati), quindi lì il gate è un genuino guard "niente da fare", non la stessa classe.

Test: `npx vitest run tests/offload-image-refs-shard-dist.test.ts tests/cdn-data-preconnect-inject.test.ts tests/blogImageCdn.test.ts tests/cdn-image-base.test.ts tests/prune-cdn-assets.test.ts` → 27 test verdi.

GitNexus impact su `offloadAll` (upstream): risk LOW — 1 caller diretto (`main` nello stesso file), 0 processi impattati; i consumer esterni invocano lo script intero (deploy.yml step shard, `deploy-it-pages-prep.sh`, `push-ticino-shard.sh`) e il contratto delete/non-fatal è invariato.

Verifica post-merge (non validabile pre-merge, lo script gira solo nelle leg deploy): dopo il prossimo deploy, curl di una job page live deve mostrare `src=https://cdn.frontaliereticino.ch/images/brands/*.png` e og:image su `cdn.frontaliereticino.ch/og/jobs/...` (niente 301). Se una leg shard mostrasse regressioni → revert di questa PR (il fallback 301 CF resta comunque attivo, nessun 404 possibile).

Closes #3475

## Non implementato (ancora)

Nessuno
