### PR TITLE
🖼️ SEO: eager-load above-fold job-header company logo (drop loading=lazy, add decoding=async)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6648,7 +6648,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  width={48}
  height={48}
  className="w-12 h-12 rounded-lg object-contain bg-surface-alt flex-shrink-0"
- loading="lazy"
+ decoding="async"
  onError={handleCompanyLogoError}
  />
  )}
@@ -7407,7 +7407,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  className="w-10 h-10 sm:w-14 sm:h-14 object-contain"
  width={56}
  height={56}
- loading="lazy"
+ decoding="async"
  onError={handleCompanyLogoError}
  />
  ) : (

--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -375,7 +375,7 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
  width={48}
  height={48}
  className="w-12 h-12 rounded-lg object-contain bg-surface-alt flex-shrink-0"
- loading="lazy"
+ decoding="async"
  onError={handleCompanyLogoError}
  />
  )}


### PR DESCRIPTION
## Implementato

- Rimosso `loading="lazy"` dal logo aziendale nel job header above-the-fold (finding audit:images, evidence Playwright: img 48x48 `aboveFold=true` con `loading=lazy`), sostituito con `decoding="async"` così il decode non blocca mai il paint:
  - `components/community/JobBoard.tsx` — gate-view job header (48x48, `alt={companyName}` — l'istanza esatta dell'evidence)
  - `components/community/JobBoard.tsx` — full job-detail `<header>` logo (56x56, `job_board_apply_header_logo`) — sibling della stessa classe
  - `components/community/JobExpiredView.tsx` — `jobHeader` expired-job (48x48, costrutto identico al gate header) — sibling della stessa classe
- Sibling-scan della classe «header logo above-fold lazy» completato: tutti gli altri `loading="lazy"` (list card, related-job card, company banner card in JobBoard/JobExpiredView/JobBridgeView/JobOrphanView, SSG `renderLogoImg` in `build-plugins/jobsSeoPagesPlugin.ts`) sono emit below-the-fold → lazy è corretto lì, invariati.
- SSG statico verificato: l'hero del job page statico (`jobsSeoPagesPlugin.ts` ~3075) NON emette alcun `<img>` logo nell'header — i soli emit logo statici sono card below-fold (related-jobs `.rja`, company card `.cb`), correttamente lazy → nessuna modifica necessaria lato build-plugin.
- Dimensioni `width`/`height` esplicite invariate su tutte le img toccate → zero impatto CLS (come richiesto dal finding: nessuna eccezione lazy che riservi meno spazio).
- `fetchpriority="high"` deliberatamente NON aggiunto: l'LCP su entrambe le pagine campionate è testo (finding: «currently moot»), e forzare high su un logo 48px sottrarrebbe priorità a risorse text-critical.

Closes #3476

## Non implementato (ancora)

Nessuno

## Test plan

- [x] `npx vitest run jobboard job-expired-view app-no-blanket related-search-clusters bridge-canton-aware` — 20 file, 166 test verdi (12 skipped pre-esistenti)
- [x] `tsc --noEmit`: zero errori nei 2 file toccati (110 pre-esistenti altrove, invariati)
- [x] GitNexus impact upstream su `JobBoard` e `JobExpiredView`: risk LOW, 0 direct breakers
