### PR TITLE
🌐 og:locale: Swiss-market variants (it_CH/de_CH/fr_CH) on all emitters

### DIFF
--- a/build-plugins/annualReportPlugin.ts
+++ b/build-plugins/annualReportPlugin.ts
@@ -84,10 +84,10 @@ const REPORT_SLUG: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Shape of a single row in data/jobs.json (subset — only the fields we read). */

--- a/build-plugins/borderMunicipalityPagesPlugin.ts
+++ b/build-plugins/borderMunicipalityPagesPlugin.ts
@@ -46,10 +46,10 @@ const MUNICIPALITY_BASE_PATH: Record<Locale, string> = {
 };
 
 const LOCALE_OG: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const HUB_PATH = '/vivere-in-ticino/comuni-di-frontiera/';

--- a/build-plugins/borderWaitMapPlugin.ts
+++ b/build-plugins/borderWaitMapPlugin.ts
@@ -62,10 +62,10 @@ const MAP_PATH: Record<BorderWaitLocale, string> = {
 };
 
 const OG_LOCALE: Record<BorderWaitLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 function esc(s: unknown): string {

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -762,10 +762,10 @@ const COPY: Record<BorderWaitLocale, Copy> = {
 };
 
 const LOCALE_OG: Record<BorderWaitLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 // ── Inline JS cache-buster for webcam refresh ──────────────────

--- a/build-plugins/calculatorLegacyAliasPlugin.ts
+++ b/build-plugins/calculatorLegacyAliasPlugin.ts
@@ -101,7 +101,7 @@ const ENTRIES: ReadonlyArray<LegacyAliasEntry> = [
       { q: 'Ist der 13. Monatslohn enthalten?', a: 'Ja — der verwendete Bruttolohn enthält bereits den 13. Monatslohn, soweit vertraglich vorgesehen, und AHV/ALV/UV/KTG/BVG werden auf derselben Basis abgezogen. Ein 14. Monat ist in der Schweiz selten und gilt als diskretionärer Bonus.' },
       { q: 'Kann ich das vorausgefüllte Szenario teilen?', a: 'Ja — kopieren Sie nach Eingabe der Werte die URL aus der Adressleiste. Der Query-String kodiert alle Parameter, sodass die empfangende Person dasselbe Szenario direkt vorgeführt bekommt.' },
     ],
-    ogLocale: 'de_DE',
+    ogLocale: 'de_CH',
   },
   {
     locale: 'fr',
@@ -116,7 +116,7 @@ const ENTRIES: ReadonlyArray<LegacyAliasEntry> = [
       { q: 'Le 13ème mois est-il inclus ?', a: 'Oui — le brut utilisé inclut le 13ème mois lorsque prévu au contrat, et AVS/AC/LAA/IJM/LPP sont déduits sur la même base. Un 14ème mois est rare en Suisse et traité comme bonus discrétionnaire, pas intégré au scénario par défaut.' },
       { q: 'Puis-je partager le scénario pré-rempli ?', a: 'Oui — copiez l\'URL depuis la barre d\'adresse après avoir ajusté les entrées. La query string encode tous les paramètres, le destinataire ouvre exactement le même scénario sans le re-saisir.' },
     ],
-    ogLocale: 'fr_FR',
+    ogLocale: 'fr_CH',
   },
 ];
 

--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -108,10 +108,10 @@ function esc(s: unknown): string {
 }
 
 const OG_LOCALE: Record<CareerLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /**

--- a/build-plugins/companyHubBridgePlugin.ts
+++ b/build-plugins/companyHubBridgePlugin.ts
@@ -56,7 +56,7 @@ const COMP_PREFIX: Record<Locale, string> = COMPANY_ROUTE_PREFIX;
 const COMPANY_SEGMENT_PREFIXES = new Set(['azienda', 'company', 'unternehmen', 'firma', 'entreprise', 'societe']);
 
 const LOCALE_PREFIX: Record<Locale, string> = { it: '', en: '/en', de: '/de', fr: '/fr' };
-const OG_LOCALE: Record<Locale, string> = { it: 'it_IT', en: 'en_US', de: 'de_DE', fr: 'fr_FR' };
+const OG_LOCALE: Record<Locale, string> = { it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
 
 // Switzerland-wide aggregator hub used as canonical target for unmatched
 // (`Azienda non più attiva`) bridges. The aggregator covers every canton,

--- a/build-plugins/comparisonsHubPlugin.ts
+++ b/build-plugins/comparisonsHubPlugin.ts
@@ -77,10 +77,10 @@ function mdLinks(s: string): string {
 }
 
 const OG_LOCALE: Record<ComparisonsLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const RELATED_LINKS: Record<ComparisonsLocale, Array<{ href: string; label: string }>> = {

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -114,10 +114,10 @@ function esc(s: unknown): string {
 }
 
 const OG_LOCALE: Record<ColLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 // City ↔ paired commuter province (mirrors costOfLivingLandingsCopy)

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -125,10 +125,10 @@ function basePathFor(canton: string): Record<Locale, string> {
 }
 
 const LOCALE_OG: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const INTL_LANG: Record<Locale, string> = {

--- a/build-plugins/faqHubPlugin.ts
+++ b/build-plugins/faqHubPlugin.ts
@@ -182,10 +182,10 @@ const COPY: Record<FaqHubLocale, FaqHubCopy> = {
 };
 
 const OG_LOCALE: Record<FaqHubLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 // Parent hub link (Guida sub-tab) for breadcrumb.

--- a/build-plugins/frSalaireNetLandingPlugin.ts
+++ b/build-plugins/frSalaireNetLandingPlugin.ts
@@ -81,7 +81,7 @@ import {
 const URL_PATH = '/fr/calculer-salaire/calcul-salaire-net-frontalier-suisse/';
 const CALCULATOR_PATH = '/fr/calculer-salaire/';
 const LOCALE = 'fr' as const;
-const OG_LOCALE = 'fr_FR';
+const OG_LOCALE = 'fr_CH';
 const TITLE = 'Calcul salaire net frontalier Suisse 2026 | Frontaliere Ticino';
 const META_DESCRIPTION =
   'Calcul salaire net frontalier Suisse 2026: barème détaillé des cotisations AVS/AI/AC, LPP, impôt à la source. Salaire moyen 6 500 CHF brut, ~5 200 CHF net.';

--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -731,10 +731,10 @@ interface PageInputs {
 }
 
 const LOCALE_OG: Record<FuelDailyLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const FUEL_PRODUCT_IMAGE_URL = `${BASE_URL}/og-image.png`;

--- a/build-plugins/healthPremiumsLandingPlugin.ts
+++ b/build-plugins/healthPremiumsLandingPlugin.ts
@@ -282,10 +282,10 @@ function renderSparkline(
 }
 
 const LOCALE_OG: Record<HealthPremiumLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 // ── Data extraction ────────────────────────────────────────────

--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -178,9 +178,9 @@ export function withSlash(p: string): string {
  return p.endsWith('/') ? p : p + '/';
 }
 
-/** OG locale mapping (e.g., 'it' → 'it_IT'). */
+/** OG locale mapping (e.g., 'it' → 'it_CH'). */
 export const LOCALE_OG: Record<string, string> = {
- it: 'it_IT',
+ it: 'it_CH',
  en: 'en_GB',
  de: 'de_CH',
  fr: 'fr_CH',
@@ -309,7 +309,7 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  seoMainClass = 'seo-static-content',
  } = opts;
 
- const ogLocale = ogLocaleOverride || LOCALE_OG[locale] || 'it_IT';
+ const ogLocale = ogLocaleOverride || LOCALE_OG[locale] || 'it_CH';
  // Clamp the <meta name="description"> / og:description to the SERP snippet
  // budget (word-aware, ≤160 char). JSON-LD `description` in jsonLdScripts is
  // untouched. Mirrors the runtime clamp in services/seoService.ts so the

--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -76,10 +76,10 @@ const LOCALE_PREFIX: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Locale-aware "find-jobs-{canton}" URL segment prefix. */

--- a/build-plugins/jobMarketSnapshotData.ts
+++ b/build-plugins/jobMarketSnapshotData.ts
@@ -51,10 +51,10 @@ export const JOB_MARKET_LOCALE_PREFIX: Record<JobMarketSnapshotLocale, string> =
 
 /** OG locale codes. */
 export const JOB_MARKET_OG_LOCALE: Record<JobMarketSnapshotLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Breadcrumb / hub display name per locale. */

--- a/build-plugins/jobOrphanBridgePlugin.ts
+++ b/build-plugins/jobOrphanBridgePlugin.ts
@@ -105,10 +105,10 @@ const LOCALE_PREFIX: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 interface OrphanEntry {

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -63,10 +63,10 @@ const LOCALE_PREFIX: Record<JobLandingLocale, string> = {
 };
 
 const LOCALE_OG: Record<JobLandingLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const SECTION_NAME: Record<JobLandingLocale, string> = {

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -77,10 +77,10 @@ const MAX_EMBEDDED_JOBS = 30;
 const SECTOR_PAGE_HARD_BUDGET_BYTES = 195 * 1024; // 195 KB (5 KB safety margin under 200 KB).
 
 const LOCALE_OG: Record<JobBoardLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const SECTION_NAME: Record<JobBoardLocale, string> = {

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -996,10 +996,10 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  fr: '/fr',
  };
  const localeOg: Record<'it' | 'en' | 'de' | 'fr', string> = {
- it: 'it_IT',
+ it: 'it_CH',
  en: 'en_US',
- de: 'de_DE',
- fr: 'fr_FR',
+ de: 'de_CH',
+ fr: 'fr_CH',
  };
  const homeLabel: Record<'it' | 'en' | 'de' | 'fr', string> = {
  it: 'Home',

--- a/build-plugins/legacyAliasPlugin.ts
+++ b/build-plugins/legacyAliasPlugin.ts
@@ -55,10 +55,10 @@ import type { Locale } from '../services/i18n';
 const BASE_URL = 'https://frontaliereticino.ch';
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const HOME_LABEL: Record<Locale, string> = {

--- a/build-plugins/locationHubBridgePlugin.ts
+++ b/build-plugins/locationHubBridgePlugin.ts
@@ -73,10 +73,10 @@ const LOCALE_PREFIX: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 interface HubEntry {

--- a/build-plugins/marketReportPlugin.ts
+++ b/build-plugins/marketReportPlugin.ts
@@ -76,10 +76,10 @@ const REPORT_SLUG: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 interface JobsStatsLeader {

--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -123,10 +123,10 @@ function esc(s: unknown): string {
 }
 
 const OG_LOCALE: Record<NursingLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /**

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -602,7 +602,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
  .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
- const LOC_TAG: Record<string, string> = { it: 'it_IT', en: 'en_US', de: 'de_DE', fr: 'fr_FR' };
+ const LOC_TAG: Record<string, string> = { it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
 
  const assetsDir = np.join(distDir, 'assets');
  // Race-free SPA bundle hash extraction. See spaBundleResolver.ts.
@@ -1028,7 +1028,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="675">
  <meta property="og:image:type" content="${en.img?.includes('.webp') ? 'image/webp' : 'image/jpeg'}">
- <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_IT'}">
+ <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_CH'}">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
  <meta property="fb:app_id" content="891036063797338">

--- a/build-plugins/orphanQueryData.ts
+++ b/build-plugins/orphanQueryData.ts
@@ -31,10 +31,10 @@ export const ORPHAN_LANDING_LOCALE_PREFIX: Record<OrphanLandingLocale, string> =
 };
 
 export const ORPHAN_LANDING_OG_LOCALE: Record<OrphanLandingLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Shape of a single cluster as serialized to data/gsc-orphan-queries-clusters.json. */

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -146,10 +146,10 @@ function inlineFormat(s: string): string {
 }
 
 const OG_LOCALE: Record<ProfessionLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const RELATED_LINKS: Record<ProfessionLocale, Array<{ href: string; label: string }>> = {

--- a/build-plugins/publisherAdPagesPlugin.ts
+++ b/build-plugins/publisherAdPagesPlugin.ts
@@ -38,7 +38,7 @@ import { generateInitialsLogo } from '../services/logoService';
 const LOCALES = ['it', 'en', 'de', 'fr'] as const;
 type AdLocale = (typeof LOCALES)[number];
 
-const OG_LOCALE: Record<AdLocale, string> = { it: 'it_IT', en: 'en_US', de: 'de_DE', fr: 'fr_FR' };
+const OG_LOCALE: Record<AdLocale, string> = { it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
 
 // Locale URL prefix (IT is unprefixed — site convention).
 const localePrefix = (locale: AdLocale): string => (locale === 'it' ? '' : `/${locale}`);

--- a/build-plugins/relatedSearchClustersData.ts
+++ b/build-plugins/relatedSearchClustersData.ts
@@ -18,10 +18,10 @@ export const LOCALE_PREFIX: Record<Locale, string> = {
 };
 
 export const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Known Swiss cities used to detect a city suffix in `sampleTerms[0]`. */

--- a/build-plugins/sectionPagesPlugin.ts
+++ b/build-plugins/sectionPagesPlugin.ts
@@ -82,10 +82,10 @@ const SECTION_IDS: readonly SectionId[] = [
 const LOCALES: readonly SectionLocale[] = ['it', 'en', 'de', 'fr'] as const;
 
 const OG_LOCALE: Record<SectionLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 // ── Locale-specific labels and copy ───────────────────────────────

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -58,10 +58,10 @@ import { renderCantonSeoProse, type CantonSeoLocale, type CantonSeoSlot } from '
 import { buildDayStampIso } from './shared/buildDayStamp';
 
 const LOCALE_OG: Record<HubLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const SECTION_LABEL: Record<HubLocale, { jobBoard: string; companies: string; articles: string }> = {

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -2070,7 +2070,7 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
  .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
- const LOC_TAG: Record<string, string> = { it: 'it_IT', en: 'en_US', de: 'de_DE', fr: 'fr_FR' };
+ const LOC_TAG: Record<string, string> = { it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
 
  // ── Locale-aware SEO fallback ─────────────────────────────
  // When no explicit locale SEO entry exists (which is the case for nearly all
@@ -4557,7 +4557,7 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
- <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_IT'}">
+ <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_CH'}">
  <meta property="og:site_name" content="Frontaliere Ticino">
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -4682,7 +4682,7 @@ ${hubChromeSplit.bodyHtml}
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
- <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_IT'}">
+ <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_CH'}">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="fb:app_id" content="891036063797338">
 ${hrefTags}
@@ -4722,7 +4722,7 @@ ${hrefTags}
  <meta property="og:image:width" content="1200">
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
- <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_IT'}">
+ <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_CH'}">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="fb:app_id" content="891036063797338">
 ${hrefTags}

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -61,10 +61,10 @@ const LOCALE_PREFIX: Record<Locale, string> = {
 };
 
 const OG_LOCALE: Record<Locale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Locale-aware "find-jobs" segment prefix (mirror of jobMarketSnapshotChCantonPages). */

--- a/build-plugins/weeklyEmployersData.ts
+++ b/build-plugins/weeklyEmployersData.ts
@@ -107,10 +107,10 @@ export const WEEKLY_EMPLOYERS_ARCHIVE_PREFIX: Record<WeeklyEmployersLocale, stri
 };
 
 export const WEEKLY_EMPLOYERS_OG_LOCALE: Record<WeeklyEmployersLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 /** Maximum number of past weeks that remain `index,follow`. Older archives go noindex. */

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4516,7 +4516,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  // Set all OG tags so they stay consistent with the job detail page,
  // even if seoService.updateMetaTags runs later with generic fallbacks.
- const ogLocaleMap: Record<string, string> = { it: 'it_IT', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
+ const ogLocaleMap: Record<string, string> = { it: 'it_CH', en: 'en_US', de: 'de_CH', fr: 'fr_CH' };
  const setOg = (prop: string, val: string) => {
  let el = document.querySelector(`meta[property="${prop}"]`);
  if (!el) { el = document.createElement('meta'); el.setAttribute('property', prop); document.head.appendChild(el); }
@@ -4526,7 +4526,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  setOg('og:description', descSnippet);
  setOg('og:url', canonicalHref);
  setOg('og:type', 'article');
- setOg('og:locale', ogLocaleMap[locale] || 'it_IT');
+ setOg('og:locale', ogLocaleMap[locale] || 'it_CH');
  setOg('og:site_name', 'Frontaliere Ticino');
 
  // Ensure the html lang attribute matches the active locale

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
     <meta property="og:url" content="https://frontaliereticino.ch/" />
     <meta property="og:title" content="Frontaliere Ticino 2026 — Calcolo Netto Nuovi e Vecchi Frontalieri" />
     <meta property="og:description" content="Calcola il tuo stipendio netto come frontaliere in Svizzera 2026: simulatore per nuovi e vecchi frontalieri, imposta alla fonte Ticino, IRPEF Italia, AVS/LPP." />
-    <meta property="og:locale" content="it_IT" />
+    <meta property="og:locale" content="it_CH" />
     <meta property="og:site_name" content="Frontaliere Ticino" />
     <meta property="og:image" content="https://frontaliereticino.ch/og-image.png" />
     <meta property="og:image:secure_url" content="https://frontaliereticino.ch/og-image.png" />

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -4749,9 +4749,9 @@ export function updateDocumentLanguage(locale: string): void {
 function getOgLocale(): string {
  const lang = document.documentElement.lang || 'it';
  const localeMap: Record<string, string> = {
- 'it': 'it_IT', 'en': 'en_US', 'de': 'de_CH', 'fr': 'fr_CH',
+ 'it': 'it_CH', 'en': 'en_US', 'de': 'de_CH', 'fr': 'fr_CH',
  };
- return localeMap[lang] || 'it_IT';
+ return localeMap[lang] || 'it_CH';
 }
 
 /**

--- a/tests/og-locale-swiss-variants.test.ts
+++ b/tests/og-locale-swiss-variants.test.ts
@@ -1,0 +1,72 @@
+/**
+ * og:locale Swiss-market variant gate (Issue #3471).
+ *
+ * The site targets the Swiss market (frontaliereticino.ch), so every
+ * `og:locale` emitter must use the Swiss variants (`it_CH`, `de_CH`,
+ * `fr_CH`) instead of the generic country variants (`it_IT`, `de_DE`,
+ * `fr_FR`). English keeps `en_US`/`en_GB` — there is no recognized
+ * Swiss OG variant for English.
+ *
+ * The OG locale map is (pre-existing) duplicated across ~35 build
+ * plugins plus the runtime SPA updaters, and it had already drifted
+ * (runtime emitted `de_CH`/`fr_CH` while the SSG plugins emitted
+ * `de_DE`/`fr_FR`). This test is structural: it scans every emitting
+ * source file and fails on any reintroduction of a generic variant,
+ * making silent drift impossible without touching the plugin import
+ * graph (several plugins run inside build worker threads).
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '..');
+
+/** Generic country variants that have a Swiss-market OG equivalent. */
+const FORBIDDEN_OG_VARIANTS = ['it_IT', 'de_DE', 'fr_FR'] as const;
+
+function listFilesRecursive(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true, recursive: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+    .map((entry) => join(entry.parentPath, entry.name));
+}
+
+describe('og:locale uses Swiss-market variants (Issue #3471)', () => {
+  it('no build plugin emits a generic og:locale country variant', () => {
+    const offenders: string[] = [];
+    for (const file of listFilesRecursive(join(ROOT, 'build-plugins'))) {
+      const src = readFileSync(file, 'utf-8');
+      for (const variant of FORBIDDEN_OG_VARIANTS) {
+        if (src.includes(variant)) offenders.push(`${file}: ${variant}`);
+      }
+    }
+    expect(offenders, 'generic og:locale variants found (use it_CH/de_CH/fr_CH)').toEqual([]);
+  });
+
+  it('runtime SPA og:locale updaters use Swiss variants', () => {
+    for (const rel of ['services/seoService.ts', 'components/community/JobBoard.tsx']) {
+      const src = readFileSync(join(ROOT, rel), 'utf-8');
+      for (const variant of FORBIDDEN_OG_VARIANTS) {
+        expect(src.includes(variant), `${rel} contains generic og:locale variant ${variant}`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it('index.html SPA shell declares the Swiss Italian og:locale', () => {
+    const html = readFileSync(join(ROOT, 'index.html'), 'utf-8');
+    expect(html).toContain('<meta property="og:locale" content="it_CH" />');
+    for (const variant of FORBIDDEN_OG_VARIANTS) {
+      expect(html.includes(variant), `index.html contains generic og:locale ${variant}`).toBe(
+        false,
+      );
+    }
+  });
+
+  it('shared htmlTemplate default map covers all Swiss variants', () => {
+    const src = readFileSync(join(ROOT, 'build-plugins', 'htmlTemplate.ts'), 'utf-8');
+    expect(src).toMatch(/it:\s*'it_CH'/);
+    expect(src).toMatch(/de:\s*'de_CH'/);
+    expect(src).toMatch(/fr:\s*'fr_CH'/);
+  });
+});


### PR DESCRIPTION
## Implementato

- `og:locale` passa alle varianti svizzere (`it_CH`, `de_CH`, `fr_CH`) al posto delle varianti-paese generiche (`it_IT`, `de_DE`, `fr_FR`) su **tutti** gli emitter (fix dell'intera classe sibling, stessa PR):
  - 35 build plugin SSG (mappe `OG_LOCALE`/`LOC_TAG` + fallback `?? 'it_IT'` in `staticPagesPlugin.ts`/`ogPagesPlugin.ts`, `OG_LOCALE = 'fr_FR'` in `frSalaireNetLandingPlugin.ts`, entry `ogLocale:` in `calculatorLegacyAliasPlugin.ts`)
  - `build-plugins/htmlTemplate.ts` → `LOCALE_OG` default condiviso (`it` era l'unica voce ancora generica) + docblock aggiornato
  - `index.html` (shell SPA): `content="it_IT"` → `it_CH`
  - runtime SPA: `services/seoService.ts → getOgLocale()` (voce `it` + fallback) e `components/community/JobBoard.tsx → ogLocaleMap` (idem)
- Chiusa la drift già in atto: il runtime emetteva `de_CH`/`fr_CH` mentre l'SSG emetteva `de_DE`/`fr_FR` sulle stesse pagine.
- Nuovo test strutturale anti-drift `tests/og-locale-swiss-variants.test.ts`: scansiona `build-plugins/**`, `seoService.ts`, `JobBoard.tsx`, `index.html` e fallisce su qualunque reintroduzione di variante generica; asserzione positiva sulla mappa `LOCALE_OG`.
- Modifica values-only: zero cambi a firme/import/control-flow (nessun rischio sul build SSG post-merge; l'extraction della mappa in modulo condiviso è stata deliberatamente evitata perché diversi plugin girano in worker thread e il grafo import di `vite.config` è fragile — l'invariante anti-drift è garantito dal test committato, stesso effetto by-construction senza toccare 37 import graph).
- `en` resta `en_US`/`en_GB`: falso positivo semantico per questa classe — non esiste variante OG svizzera per l'inglese (`en_CH` non è un locale OG riconosciuto), quindi non è scope deferito.
- hreflang non toccato (già corretto con codici lingua bare `it/en/de/fr`, path di codice separato).

Test: `npx vitest run` su 42 file di test che importano i plugin modificati (1416 test) + 36 file che importano `seoService`/`JobBoard` (44770 test) + `seo-localization`/`seo-html-lang-sync`/`flat-html-redirect`: tutti verdi. Il pre-esistente `tests/seo-localization.test.ts` asserisce già `de_CH` sul path runtime.

Closes #3471

## Non implementato (ancora)

Nessuno
