### PR TITLE
fix(seo): absolutize JobPosting hiringOrganization.logo in JSON-LD (#3473)

### DIFF
--- a/build-plugins/shared/jobPostingSchema.ts
+++ b/build-plugins/shared/jobPostingSchema.ts
@@ -107,8 +107,8 @@ export interface BuildJobPostingOptions {
   /** Absolute canonical URL for the job page (`url` on the schema). */
   readonly url: string;
   /**
-   * Optional site base URL — reserved for future use (e.g. emitting
-   * `sameAs` for hiring org). Never affects mandatory-field output.
+   * Optional site base URL — used to absolutize a same-origin (root-relative)
+   * `hiringOrganization.logo` path. Never affects mandatory-field output.
    */
   readonly baseUrl?: string;
 }
@@ -187,6 +187,13 @@ export type EmploymentType =
   | 'OTHER';
 
 // ── Internal helpers ────────────────────────────────────────────────────────
+
+/**
+ * Canonical prod origin — fallback base for absolutizing a same-origin
+ * (root-relative) `hiringOrganization.logo` path when the caller omits
+ * `opts.baseUrl` (every current caller passes it).
+ */
+const CANONICAL_ORIGIN = 'https://frontaliereticino.ch';
 
 const EMPLOYMENT_TYPE_MAP: Record<string, EmploymentType> = {
   permanent: 'FULL_TIME',
@@ -534,9 +541,19 @@ export function buildJobPostingSchema(
   );
   const baseSalary = resolveBaseSalary(job);
 
-  const logo = job.companyLogoUrl && String(job.companyLogoUrl).trim().length > 0
+  const rawLogo = job.companyLogoUrl && String(job.companyLogoUrl).trim().length > 0
     ? String(job.companyLogoUrl).trim()
     : undefined;
+  // Schema.org `logo` is URL-typed: Google's job rich-result pipeline expects a
+  // fully-qualified absolute URL and can ignore a root-relative path like the
+  // curated `/images/brands/<key>.png` assets (issue #3473). Absolutize
+  // same-origin root-relative paths against the caller's canonical base (in
+  // prod those paths 301 to the image CDN, so the URL is always fetchable);
+  // already-absolute URLs pass through verbatim. `//`-prefixed values are
+  // protocol-relative, not root-relative — never prefix those.
+  const logo = rawLogo && rawLogo.startsWith('/') && !rawLogo.startsWith('//')
+    ? `${(opts.baseUrl || CANONICAL_ORIGIN).replace(/\/+$/, '')}${rawLogo}`
+    : rawLogo;
   const sameAs = job.companyDomain && String(job.companyDomain).trim().length > 0
     ? `https://${String(job.companyDomain).replace(/^https?:\/\//, '').trim()}`
     : undefined;

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4121,9 +4121,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // JSON-LD hiringOrganization.logo needs a fetchable URL — companyLogoUrl can
  // now return an inlined initials data: URI (fine for <img>, not for schema),
  // so fall back to the site icon for those rather than emitting a data URI.
+ // Root-relative same-origin paths (CDN base not injected, e.g. dev) are
+ // absolutized: schema.org `logo` is URL-typed and Google can ignore a
+ // relative value (#3473). `//` = protocol-relative, never prefixed.
  const rawLogo = companyLogoUrl(job);
  const logo = rawLogo && !rawLogo.startsWith('data:')
- ? rawLogo
+ ? (rawLogo.startsWith('/') && !rawLogo.startsWith('//')
+ ? `${window.location.origin}${rawLogo}`
+ : rawLogo)
  : 'https://frontaliereticino.ch/icons/icon-512x512.png';
  const salaryMin = Number.isFinite(Number(job.salaryMin))
  ? Number(job.salaryMin)

--- a/tests/seo/jobposting-schema.test.ts
+++ b/tests/seo/jobposting-schema.test.ts
@@ -261,3 +261,59 @@ describe('buildJobPostingSchema — required opts', () => {
     ).toThrow();
   });
 });
+
+describe('buildJobPostingSchema — hiringOrganization.logo absolutization (#3473)', () => {
+  const jobWithLogo = (companyLogoUrl: string): JobInput => ({
+    id: 'hirslanden-1',
+    title: 'Infermiere/a diplomato/a',
+    company: 'Hirslanden Klinik',
+    city: 'Lugano',
+    companyLogoUrl,
+  });
+
+  it('absolutizes a root-relative logo path against opts.baseUrl', () => {
+    const schema = buildJobPostingSchema(jobWithLogo('/images/brands/hirslanden.png'), {
+      ...OPTS,
+      baseUrl: 'https://frontaliereticino.ch',
+    });
+    expect(schema.hiringOrganization.logo).toBe(
+      'https://frontaliereticino.ch/images/brands/hirslanden.png',
+    );
+  });
+
+  it('falls back to the canonical origin when opts.baseUrl is omitted', () => {
+    const schema = buildJobPostingSchema(jobWithLogo('/images/brands/hirslanden.png'), OPTS);
+    expect(schema.hiringOrganization.logo).toBe(
+      'https://frontaliereticino.ch/images/brands/hirslanden.png',
+    );
+  });
+
+  it('never emits a double slash when baseUrl has a trailing slash', () => {
+    const schema = buildJobPostingSchema(jobWithLogo('/images/brands/hirslanden.png'), {
+      ...OPTS,
+      baseUrl: 'https://frontaliereticino.ch/',
+    });
+    expect(schema.hiringOrganization.logo).toBe(
+      'https://frontaliereticino.ch/images/brands/hirslanden.png',
+    );
+  });
+
+  it('passes an already-absolute logo URL through verbatim', () => {
+    const abs = 'https://cdn.frontaliereticino.ch/images/brands/hirslanden.png';
+    const schema = buildJobPostingSchema(jobWithLogo(abs), {
+      ...OPTS,
+      baseUrl: 'https://frontaliereticino.ch',
+    });
+    expect(schema.hiringOrganization.logo).toBe(abs);
+  });
+
+  it('never prefixes a protocol-relative URL', () => {
+    const schema = buildJobPostingSchema(jobWithLogo('//example.com/logo.png'), OPTS);
+    expect(schema.hiringOrganization.logo).toBe('//example.com/logo.png');
+  });
+
+  it('omits logo entirely when companyLogoUrl is blank', () => {
+    const schema = buildJobPostingSchema(jobWithLogo('   '), OPTS);
+    expect(schema.hiringOrganization.logo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Implementato

- **`hiringOrganization.logo` sempre URL assoluto nel JSON-LD JobPosting** (`build-plugins/shared/jobPostingSchema.ts`): i path root-relative (es. `/images/brands/hirslanden.png`, curati in `CRAWLED_COMPANY_LOGOS`) sono ora assolutizzati contro `opts.baseUrl` (fallback: origin canonico `https://frontaliereticino.ch`). Schema.org tipizza `logo` come URL e le linee guida structured-data di Google si aspettano URL fully-qualified: un valore relativo rischiava che il logo venisse ignorato nel job rich result. Il fix copre TUTTI gli emitter che delegano al builder canonico: pagine job statiche attive + expired (`jobsSeoPagesPlugin`), embed ItemList (`jobPostingListItem` → `jobsSeoPagesPlugin` + `weeklyEmployersPlugin`) e JSON-LD runtime SPA (`seoService`). URL già assoluti passano invariati; `//` protocol-relative mai prefissati; il campo non viene mai rimosso. I path same-origin `/images/brands/*` 301-ano al CDN immagini in prod (verificato live), quindi l'URL emesso è sempre fetchabile.
- **Sibling della stessa classe (AGENTS.md #6)**: l'emitter JSON-LD inline della SPA in `components/community/JobBoard.tsx` ora assolutizza contro `window.location.origin` il path root-relative che leakava quando `window.__CDN_DATA_BASE__` non è iniettato (dev/degradazione offload).
- **Test**: 6 nuovi casi in `tests/seo/jobposting-schema.test.ts` — assolutizzazione con `baseUrl`, fallback origin canonico, `baseUrl` con trailing slash (no doppio slash), pass-through URL assoluto, protocol-relative mai prefissato, logo omesso su input blank.
- Doc di `BuildJobPostingOptions.baseUrl` aggiornata (era «reserved for future use» — ora è usato per l'assolutizzazione del logo; mai impatta i 9 campi obbligatori, invariante rule #3 intatta: `assertMandatoryFieldsComplete` e i test esistenti restano verdi).

Verifica sibling (`node scripts/ci/check-sibling-patterns.mjs`, 6 candidati — tutti **falsi positivi** confermati a mano):
- `jobsSeoPagesPlugin.ts` / `seoService.ts`: call-site che *passano* `companyLogoUrl` al builder fixato → coperti da questo fix, nessun emit proprio.
- `companyLogoResolver.ts` / `JobOrphanView.tsx`: il logo alimenta `<img src>` HTML, non una property URL-typed JSON-LD — il relative è corretto lì.
- `useNavigationState.ts` / `urlStateService.ts`: collisione lessicale sul nome `CANONICAL_ORIGIN` (routing, non schema). Il literal origin per-modulo è convenzione pre-esistente del repo (32+ occorrenze in .ts); riuso di `BASE_URL` da `build-plugins/constants.ts` impossibile senza rompere il bundle SPA (modulo Node-only: `child_process`/`fs`/`path`, e `jobPostingSchema` è importato da `services/seoService.ts`).

Test locali: `npx vitest run tests/seo/jobposting-schema.test.ts tests/jobposting-jsonld.test.ts tests/build-plugins/job-posting-list-item.test.ts tests/weekly-employers-company-city.test.ts` → 83 test verdi. `tsc --noEmit`: zero errori nei file toccati (i soli errori sono pre-esistenti su main in file non correlati).

Closes #3473

## Non implementato (ancora)

Nessuno.
