### PR TITLE
fix(seo): explicit width/height on the 3 img tags missing dimension attributes

### DIFF
--- a/components/community/TrendingSection.tsx
+++ b/components/community/TrendingSection.tsx
@@ -86,6 +86,8 @@ function TrendingSection({ trendingJobs, popularity, onJobClick, heading, ariaLa
  <img
  src={job.logoUrl}
  alt=""
+ width={24}
+ height={24}
  className="w-6 h-6 object-contain"
  loading="lazy"
  onError={(e) => {

--- a/components/pages/JournalistDashboardPage.tsx
+++ b/components/pages/JournalistDashboardPage.tsx
@@ -428,7 +428,7 @@ export default function JournalistDashboardPage(): React.ReactElement {
           isSelected ? 'border-accent ring-2 ring-accent' : 'border-edge hover:ring-2 hover:ring-accent'
         }`}
       >
-        <img src={cdnBlogImage(candidate.path)} alt="" loading="lazy" className="w-full h-20 object-cover" />
+        <img src={cdnBlogImage(candidate.path)} alt="" width={1200} height={600} loading="lazy" className="w-full h-20 object-cover" />
         {isSelected && (
           <span className="absolute top-1 right-1 rounded-full bg-accent text-on-accent p-0.5">
             <CheckCircle2 className="w-4 h-4" />
@@ -858,7 +858,7 @@ export default function JournalistDashboardPage(): React.ReactElement {
               {t('journalistDashboard.editor.imageLabel')}
             </label>
             {image && (
-              <img src={cdnBlogImage(image)} alt={imageAlt} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
+              <img src={cdnBlogImage(image)} alt={imageAlt} width={1200} height={600} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
             )}
             {draftId ? (
               <>

--- a/components/pages/JournalistDashboardPage.tsx
+++ b/components/pages/JournalistDashboardPage.tsx
@@ -428,7 +428,7 @@ export default function JournalistDashboardPage(): React.ReactElement {
           isSelected ? 'border-accent ring-2 ring-accent' : 'border-edge hover:ring-2 hover:ring-accent'
         }`}
       >
-        <img src={cdnBlogImage(candidate.path)} alt="" width={1200} height={600} loading="lazy" className="w-full h-20 object-cover" />
+        <img src={cdnBlogImage(candidate.path)} alt="" width={1200} height={675} loading="lazy" className="w-full h-20 object-cover" />
         {isSelected && (
           <span className="absolute top-1 right-1 rounded-full bg-accent text-on-accent p-0.5">
             <CheckCircle2 className="w-4 h-4" />
@@ -858,7 +858,7 @@ export default function JournalistDashboardPage(): React.ReactElement {
               {t('journalistDashboard.editor.imageLabel')}
             </label>
             {image && (
-              <img src={cdnBlogImage(image)} alt={imageAlt} width={1200} height={600} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
+              <img src={cdnBlogImage(image)} alt={imageAlt} width={1200} height={675} className="w-full max-w-sm rounded-xl border border-edge mb-2" />
             )}
             {draftId ? (
               <>


### PR DESCRIPTION
## Implementato

- `components/community/TrendingSection.tsx`: aggiunto `width={24}` / `height={24}` all'`<img>` del logo aziendale (riga 86 del finding). Il box era già fissato via CSS (`w-6 h-6`, nessun CLS effettivo), gli attributi espliciti sono belt-and-braces come richiesto dal nit #1 dell'audit alt-text/CLS. L'`alt=""` resta vuoto di proposito: il logo è decorativo, il nome azienda è testo adiacente.
- Sibling sweep (Non-Negotiable #6, stessa classe di costrutto "`<img>` senza attributi width/height"): grep dell'intero albero `components/` — le UNICHE altre due istanze nel repo erano in `components/pages/JournalistDashboardPage.tsx` (righe 431 e 861, immagini blog via `cdnBlogImage`). Aggiunto `width={1200}` / `height={675}` (intrinseco 16:9 reale della pipeline blog: 2517/2997 file in `public/images/blog/` sono 1200×675, `backfill-small-images.mjs` normalizza a `resize({width:1200, height:675})`, il JSON-LD di `create-article.mjs` dichiara 1200×675). NB: la prima versione di questa PR usava `height={600}` assumendo il 2:1 dal render di `BlogArticles.tsx` — premessa errata: lì il box è forzato da container `aspect-[2/1]` + `object-cover`, mentre alla riga 861 (`w-full max-w-sm`, nessuna height CSS) governa il ratio intrinseco; il 2:1 avrebbe ri-causato ~11% di shift. Corretto a 675 dal local review (commit `5ba24c648ce`).
- Nit #2 dell'audit (immagine Google One Tap `lh3.googleusercontent.com` senza width/height/loading): **nessuna azione possibile né necessaria** — iniettata a runtime da script third-party in overlay, assente dal source del repo (grep 0 hit), non contenuto indicizzato. Lo dichiara il finding stesso; non è scope deferito.
- Osservazione flagcdn (2 PNG bandiera ~1KB, già con alt + 32x21 + lazy): il finding la classifica esplicitamente cosmetica e già CLS-safe; self-hosting di asset esterni funzionanti sarebbe refactor non chirurgico fuori dalla classe del bug (attributi dimensione mancanti). Non actionable in questo scope.

Closes #3478

## Non implementato (ancora)

Nessuno.

## Test

- `npx vitest run tests/community/TrendingSection.href.test.tsx` → 5/5 verdi.
- `JournalistDashboardPage` non ha test dedicati; modifiche attribute-only su `<img>` (nessun cambio di comportamento/segnatura). GitNexus impact upstream su entrambi i componenti: risk LOW, 0 dependents.
