### PR TITLE
fix(seo): strip one-sided sitemap hreflang annotation groups (reciprocity, #3474)

### DIFF
--- a/build-plugins/sitemapAliasPlugin.ts
+++ b/build-plugins/sitemapAliasPlugin.ts
@@ -135,7 +135,9 @@ const XHTML_LINK_LINE_RX = /[ \t]*<xhtml:link\b[^>]*?\/>[ \t]*\r?\n?/g;
  * listed nowhere, so those annotations never had effect at the sitemap level.
  *
  * This pass removes the `xhtml:link` elements from every `<url>` block whose
- * annotation group is incomplete, and keeps complete groups byte-identical
+ * annotation group is incomplete — including degenerate self-only groups
+ * (every href equal to the block's own `<loc>`) — and keeps complete groups
+ * byte-identical
  * (e.g. sitemap-salary-hub.xml, the reciprocal subsets of
  * sitemap-pages.xml). `<loc>` entries are NEVER added or removed. The
  * on-page HTML hreflang mesh — complete and reciprocal for every stripped
@@ -192,9 +194,16 @@ export function sanitizeSitemapHreflangReciprocity(
     let changed = false;
     for (const b of annotated) {
       if (!b.alive) continue;
-      const ok = b.hrefs.every(
-        (a) => locSet.has(a.href) && backRefs.get(a.href)?.has(b.loc),
-      );
+      // A group whose every href is the block's own <loc> (seo-hubs page-N
+      // emits a single self-referential hreflang="it" link) self-satisfies
+      // the reciprocity check while carrying zero hreflang information — and
+      // an it-only survivor makes validate-locale-shard-build's all-locales
+      // check depend on readdir order. Degenerate ⇒ strip.
+      const ok =
+        b.hrefs.some((a) => a.href !== b.loc) &&
+        b.hrefs.every(
+          (a) => locSet.has(a.href) && backRefs.get(a.href)?.has(b.loc),
+        );
       if (!ok) {
         b.alive = false;
         changed = true;

--- a/build-plugins/sitemapAliasPlugin.ts
+++ b/build-plugins/sitemapAliasPlugin.ts
@@ -1,5 +1,8 @@
 /**
  * Post-build sitemap tasks:
+ * 0. Sanitize hreflang reciprocity: strip `xhtml:link` annotation groups
+ *    that violate Google's sitemap-hreflang method (issue #3474). See
+ *    `sanitizeSitemapHreflangReciprocity` below.
  * 1. Keep backward compatibility with the legacy sitemap_news.xml filename
  * 2. Regenerate `dist/sitemap.xml` as a sitemap index containing EVERY
  *    `dist/sitemap-*.xml` file present after the build. This turns the
@@ -99,6 +102,133 @@ ${entries}
 `;
 }
 
+/** One sitemap file's name + raw XML content, as read from dist/. */
+export interface SitemapXmlFile {
+  file: string;
+  xml: string;
+}
+
+/** A `<url>` block that carries xhtml:link hreflang annotations. */
+interface AnnotatedBlock {
+  file: string;
+  loc: string;
+  hrefs: { lang: string; href: string }[];
+  alive: boolean;
+}
+
+const URL_BLOCK_RX = /<url>[\s\S]*?<\/url>/g;
+const LOC_RX = /<loc>\s*([^<]+?)\s*<\/loc>/;
+const XHTML_LINK_ELEMENT_RX = /<xhtml:link\b[^>]*?\/>/g;
+/** Matches a whole xhtml:link line incl. leading indent + trailing newline. */
+const XHTML_LINK_LINE_RX = /[ \t]*<xhtml:link\b[^>]*?\/>[ \t]*\r?\n?/g;
+
+/**
+ * Strip hreflang annotation groups that violate sitemap-hreflang reciprocity
+ * (issue #3474).
+ *
+ * Google's sitemap-hreflang method requires every alternate URL referenced by
+ * an `xhtml:link` annotation to (a) appear as its own `<url><loc>` entry in
+ * one of the site's sitemaps and (b) annotate the referring URL back (return
+ * tag). Incomplete groups are ignored by Google and surface as "no return
+ * tag" noise in Search Console. The committed blog/blog-ch/glossario/news
+ * sitemaps annotate IT-only `<loc>` entries whose EN/DE/FR alternates are
+ * listed nowhere, so those annotations never had effect at the sitemap level.
+ *
+ * This pass removes the `xhtml:link` elements from every `<url>` block whose
+ * annotation group is incomplete, and keeps complete groups byte-identical
+ * (e.g. sitemap-salary-hub.xml, the reciprocal subsets of
+ * sitemap-pages.xml). `<loc>` entries are NEVER added or removed. The
+ * on-page HTML hreflang mesh — complete and reciprocal for every stripped
+ * URL — remains the authoritative hreflang signal (same valid pattern as the
+ * sitemap-jobs-* / sitemap-search-clusters-* shards).
+ *
+ * NOTE: only the emitted dist/ copies are sanitized. The `public/` sitemap
+ * sources keep their annotations on purpose: they are load-bearing build
+ * metadata (staticPagesPlugin locale-variant emission, legacyRedirectsPlugin
+ * hreflang map, llms.txt, IndexNow locale-URL submission).
+ *
+ * Pure function (no I/O) so unit tests can exercise it with fixtures.
+ * Returns a Map of file name → sanitized XML for the files that changed.
+ */
+export function sanitizeSitemapHreflangReciprocity(
+  files: readonly SitemapXmlFile[],
+): Map<string, string> {
+  // ── Pass 1: global <loc> set + annotated blocks ──
+  const locSet = new Set<string>();
+  const annotated: AnnotatedBlock[] = [];
+  for (const { file, xml } of files) {
+    for (const blockMatch of xml.matchAll(URL_BLOCK_RX)) {
+      const block = blockMatch[0];
+      const loc = block.match(LOC_RX)?.[1];
+      if (!loc) continue;
+      locSet.add(loc);
+      const hrefs: { lang: string; href: string }[] = [];
+      for (const el of block.matchAll(XHTML_LINK_ELEMENT_RX)) {
+        const lang = el[0].match(/hreflang="([^"]+)"/)?.[1];
+        const href = el[0].match(/href="([^"]+)"/)?.[1];
+        if (lang && href) hrefs.push({ lang, href });
+      }
+      if (hrefs.length > 0) annotated.push({ file, loc, hrefs, alive: true });
+    }
+  }
+
+  // ── Pass 2: reciprocity fixpoint ──
+  // A group survives iff every annotated href is a listed <loc> AND that
+  // loc's own (still-alive) annotations point back. Stripping a one-sided
+  // group can orphan a neighbour that relied on its return tag, so iterate
+  // until stable (symmetric groups converge in one round; the loop only
+  // ever strips more, so it terminates).
+  for (;;) {
+    const backRefs = new Map<string, Set<string>>();
+    for (const b of annotated) {
+      if (!b.alive) continue;
+      let refs = backRefs.get(b.loc);
+      if (!refs) {
+        refs = new Set<string>();
+        backRefs.set(b.loc, refs);
+      }
+      for (const a of b.hrefs) refs.add(a.href);
+    }
+    let changed = false;
+    for (const b of annotated) {
+      if (!b.alive) continue;
+      const ok = b.hrefs.every(
+        (a) => locSet.has(a.href) && backRefs.get(a.href)?.has(b.loc),
+      );
+      if (!ok) {
+        b.alive = false;
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  const deadByFile = new Map<string, Set<string>>();
+  for (const b of annotated) {
+    if (b.alive) continue;
+    let dead = deadByFile.get(b.file);
+    if (!dead) {
+      dead = new Set<string>();
+      deadByFile.set(b.file, dead);
+    }
+    dead.add(b.loc);
+  }
+
+  // ── Pass 3: rewrite only the files with dead groups ──
+  const out = new Map<string, string>();
+  for (const { file, xml } of files) {
+    const dead = deadByFile.get(file);
+    if (!dead || dead.size === 0) continue;
+    const nextXml = xml.replace(URL_BLOCK_RX, (block) => {
+      const loc = block.match(LOC_RX)?.[1];
+      if (!loc || !dead.has(loc)) return block;
+      return block.replace(XHTML_LINK_LINE_RX, '');
+    });
+    if (nextXml !== xml) out.set(file, nextXml);
+  }
+  return out;
+}
+
 export function sitemapAliasPlugin(rootDir: string): Plugin {
   return {
     name: 'sitemap-alias',
@@ -115,6 +245,28 @@ export function sitemapAliasPlugin(rootDir: string): Plugin {
         const fs = await import('node:fs');
         const distDir = path.resolve(rootDir, 'dist');
         if (!fs.existsSync(distDir)) return;
+
+        // 0. Hreflang-reciprocity sanitizer (issue #3474). Runs BEFORE the
+        //    legacy alias copy so sitemap_news.xml inherits sanitized
+        //    content, and before index regeneration.
+        const sitemapFiles: SitemapXmlFile[] = fs
+          .readdirSync(distDir)
+          .filter(
+            (f) => SITEMAP_FILE_PATTERN.test(f) && !EXCLUDED_SITEMAP_FILES.has(f),
+          )
+          .map((file) => ({
+            file,
+            xml: fs.readFileSync(path.join(distDir, file), 'utf-8'),
+          }));
+        const sanitized = sanitizeSitemapHreflangReciprocity(sitemapFiles);
+        for (const [file, xml] of sanitized) {
+          fs.writeFileSync(path.join(distDir, file), xml, 'utf-8');
+        }
+        if (sanitized.size > 0) {
+          console.log(
+            `\x1b[36m[sitemap-alias]\x1b[0m Stripped one-sided hreflang groups from ${sanitized.size} sitemap(s): ${[...sanitized.keys()].join(', ')}`,
+          );
+        }
 
         // 1. Legacy alias: sitemap-news.xml → sitemap_news.xml
         //    Must run BEFORE discovery so the alias file exists when the

--- a/scripts/submit-indexnow-batch.mjs
+++ b/scripts/submit-indexnow-batch.mjs
@@ -128,6 +128,24 @@ export function extractUrls(xml, urls) {
   return count;
 }
 
+// ── Extract only hreflang alternate URLs into the accumulator ──
+// Used by the public/-registry compensation pass below: the DEPLOYED
+// sitemaps no longer carry xhtml:link annotations for one-sided hreflang
+// groups (the build strips them per Google's sitemap-hreflang reciprocity
+// rule — see build-plugins/sitemapAliasPlugin.ts, issue #3474), but the
+// EN/DE/FR alternate pages are live and must keep receiving IndexNow
+// submissions. The committed public/ sitemap sources keep the annotations
+// as build metadata, so the locale URLs are read from there. <loc> truth
+// stays with the live/dist sitemaps — only alternate hrefs are unioned.
+export function extractAlternateUrls(xml, urls) {
+  let count = 0;
+  for (const m of xml.matchAll(/hreflang="[^"]*"\s+href="([^"]+)"/g)) {
+    urls.add(m[1].trim());
+    count++;
+  }
+  return count;
+}
+
 // ── Fetch one sub-sitemap live over HTTP (with retry) ─────────
 async function fetchSitemapXml(file) {
   const url = `${SITEMAP_BASE}/${file}`;
@@ -218,6 +236,22 @@ export async function getUrlsFromSitemaps() {
     if (empty.length > 0) {
       console.warn(`  ⚠️  ${empty.length} sitemap(s) returned 200 but 0 URLs: ${empty.join(', ')} — verify this is expected.`);
     }
+  }
+
+  // Locale-alternate compensation from the public/ registry (see
+  // extractAlternateUrls docs). No-op when the checkout is unavailable or
+  // when the sitemap still carries its annotations (pure union).
+  const publicDir = resolve(getProjectRoot(), 'public');
+  let alternatesAdded = 0;
+  for (const file of filteredSitemaps) {
+    const publicPath = resolve(publicDir, file);
+    if (!existsSync(publicPath)) continue;
+    try {
+      alternatesAdded += extractAlternateUrls(readFileSync(publicPath, 'utf-8'), urls);
+    } catch { /* unreadable public sitemap — live/dist collection stands */ }
+  }
+  if (alternatesAdded > 0) {
+    console.log(`  public/ registry: ${alternatesAdded} hreflang alternates unioned (${urls.size} unique total)`);
   }
 
   // Add extra key URLs not typically in sitemaps

--- a/scripts/submit-indexnow.js
+++ b/scripts/submit-indexnow.js
@@ -136,10 +136,44 @@ function getRecentNewsUrls(newsXml, count) {
   return locs.slice(-count);
 }
 
+// Read a sitemap from public/ ONLY (no dist/ preference). The URL-block
+// lookups below resolve a URL's hreflang alternates, and since the build
+// strips one-sided xhtml:link groups from dist/ sitemaps (issue #3474 —
+// see build-plugins/sitemapAliasPlugin.ts), the annotated public/ sources
+// are the registry for locale alternates. <loc> sets are identical in both.
+function readPublicXml(file) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const rootDir = resolve(__dirname, '..');
+  return readFileSync(resolve(rootDir, 'public', file), 'utf-8');
+}
+
+// Expand a list of newly deployed URLs with their hreflang alternates from
+// the public/ sitemap registry (issue #3474): a new article surfaces in the
+// sitemap diff only via its IT <loc> once dist/ annotations are stripped,
+// but its EN/DE/FR alternate pages are just as new and live, and must keep
+// receiving IndexNow submissions. No-op for URLs without an annotated
+// public/ <url> block. Never removes URLs.
+function expandWithPublicAlternates(urls) {
+  if (urls.length === 0) return urls;
+  const publicXml = ['sitemap-pages.xml', 'sitemap-blog.xml', 'sitemap-glossario.xml', 'sitemap-jobs.xml', 'sitemap-news.xml']
+    .map(f => { try { return readPublicXml(f); } catch { return ''; } }).join('\n');
+  const expanded = new Set(urls);
+  const targets = new Set(urls);
+  for (const match of publicXml.matchAll(/<url>[\s\S]*?<\/url>/g)) {
+    const block = match[0];
+    const blockUrls = extractUrlsFromUrlBlock(block);
+    if (blockUrls.some(u => targets.has(u))) {
+      for (const u of blockUrls) expanded.add(u);
+    }
+  }
+  return [...expanded].sort();
+}
+
 function getBingUrlsSubset() {
-  // Read all sub-sitemaps for URL block lookup
+  // Read all sub-sitemaps for URL block lookup — public/ only, since the
+  // lookup exists to resolve hreflang alternates (see readPublicXml docs).
   const sitemapXml = ['sitemap-pages.xml', 'sitemap-blog.xml', 'sitemap-glossario.xml']
-    .map(f => { try { return readXml(['public', f]); } catch { return ''; } }).join('\n');
+    .map(f => { try { return readPublicXml(f); } catch { return ''; } }).join('\n');
 
   // Preferred: the newly generated article URL (from CI workflow output)
   if (ARTICLE_URL) {
@@ -159,7 +193,7 @@ function getBingUrlsSubset() {
   }
   let newsXml = '';
   try {
-    newsXml = readXml(['public', 'sitemap-news.xml']);
+    newsXml = readPublicXml('sitemap-news.xml');
   } catch {
     return { urls: [], reason: 'no-news-sitemap' };
   }
@@ -474,9 +508,12 @@ async function submitToIndexNow() {
   const urlList = getUrlsFromSitemaps();
   console.log(`📊 ${urlList.length} URLs trovati nelle sitemap (tutte le lingue)`);
 
-  // Sitemap diff: fetch deployed sitemaps and find new URLs
+  // Sitemap diff: fetch deployed sitemaps and find new URLs.
+  // The diff is expanded with each new URL's hreflang alternates from the
+  // public/ registry (see expandWithPublicAlternates) — dist/live sitemaps
+  // no longer annotate one-sided groups (issue #3474).
   const deployedUrls = await getDeployedUrls();
-  const newUrls = getNewUrls(urlList, deployedUrls);
+  const newUrls = expandWithPublicAlternates(getNewUrls(urlList, deployedUrls));
 
   if (deployedUrls.size === 0) {
     console.log('ℹ️  Nessuna sitemap deployata trovata — invio tutti gli URLs');

--- a/tests/sitemap-hreflang-reciprocity.test.ts
+++ b/tests/sitemap-hreflang-reciprocity.test.ts
@@ -105,6 +105,24 @@ describe('sanitizeSitemapHreflangReciprocity — fixtures', () => {
     expect(countLocs(sanitized)).toBe(2);
   });
 
+  it('strips a degenerate self-only group (seo-hubs page-N pattern: sole annotation is the own <loc>)', () => {
+    const pageNLoc = `${BASE}/lavoro-svizzera/2/`;
+    const xml = urlset(
+      urlBlock(pageNLoc, [ann('it', pageNLoc)]),
+      urlBlock(itLoc, fullGroup()),
+      urlBlock(enLoc, fullGroup()),
+    );
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-seo-hubs.xml', xml }]);
+    const sanitized = out.get('sitemap-seo-hubs.xml')!;
+    // The self-referential annotation goes; loc entries and the complete
+    // reciprocal group survive untouched.
+    expect(sanitized).not.toContain(`href="${pageNLoc}"`);
+    expect(countAnnotations(sanitized)).toBe(6);
+    expect(countLocs(sanitized)).toBe(3);
+    expect(sanitized).toContain(`<loc>${pageNLoc}</loc>`);
+    expect(sanitized).not.toMatch(/\n[ \t]*\n/);
+  });
+
   it('cascades to a fixpoint: stripping an invalid group also strips neighbours that relied on its return tag', () => {
     const cLoc = `${BASE}/de/grenzgaenger-artikel/beispiel/`; // never a <loc>
     const xml = urlset(

--- a/tests/sitemap-hreflang-reciprocity.test.ts
+++ b/tests/sitemap-hreflang-reciprocity.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression tests for the dist-side sitemap hreflang-reciprocity sanitizer
+ * (issue #3474).
+ *
+ * Google's sitemap-hreflang method requires every alternate referenced by an
+ * `xhtml:link` annotation to appear as its own `<url><loc>` entry (in any of
+ * the site's sitemaps) carrying a return annotation. The committed
+ * blog/blog-ch/glossario/news sitemaps annotate IT-only `<loc>` entries whose
+ * EN/DE/FR alternates are listed nowhere, so those annotation groups are
+ * ignored by Google and surface as "no return tag" noise in Search Console.
+ *
+ * `sanitizeSitemapHreflangReciprocity` (build-plugins/sitemapAliasPlugin.ts)
+ * strips one-sided groups from the emitted dist/ copies and keeps complete
+ * groups (sitemap-salary-hub.xml pattern) byte-identical. These tests pin:
+ *
+ * 1. Fixture-level behaviour: strip one-sided, keep reciprocal, cross-file
+ *    resolution, return-tag requirement, fixpoint cascade, loc preservation.
+ * 2. Real-file invariants on the committed public/ sitemaps: every
+ *    annotation surviving the sanitizer satisfies reciprocity, `<loc>`
+ *    entries are NEVER added or removed, and the known one-sided files
+ *    (blog, blog-ch, glossario, news) come out with zero annotations.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  sanitizeSitemapHreflangReciprocity,
+  type SitemapXmlFile,
+} from '../build-plugins/sitemapAliasPlugin';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASE = 'https://frontaliereticino.ch';
+
+const ann = (lang: string, href: string) =>
+  `    <xhtml:link rel="alternate" hreflang="${lang}" href="${href}" />`;
+
+/** Pretty-printed <url> block in the committed public/ sitemap shape. */
+const urlBlock = (loc: string, annotations: readonly string[]) =>
+  ['  <url>', `    <loc>${loc}</loc>`, ...annotations, '    <lastmod>2026-04-03</lastmod>', '  </url>'].join('\n');
+
+const urlset = (...blocks: readonly string[]) =>
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n        xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${blocks.join('\n')}\n</urlset>\n`;
+
+const countLocs = (xml: string) => [...xml.matchAll(/<loc>/g)].length;
+const countAnnotations = (xml: string) => [...xml.matchAll(/<xhtml:link\b/g)].length;
+
+describe('sanitizeSitemapHreflangReciprocity — fixtures', () => {
+  const itLoc = `${BASE}/articoli-frontaliere/esempio/`;
+  const enLoc = `${BASE}/en/cross-border-articles/example/`;
+  const fullGroup = () => [
+    ann('it', itLoc),
+    ann('en', enLoc),
+    ann('x-default', itLoc),
+  ];
+
+  it('strips a one-sided group (alternates listed nowhere) but preserves the <url>/<loc> entries', () => {
+    const xml = urlset(
+      urlBlock(itLoc, [ann('it', itLoc), ann('en', enLoc), ann('x-default', itLoc)]),
+    );
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-blog.xml', xml }]);
+
+    expect(out.has('sitemap-blog.xml')).toBe(true);
+    const sanitized = out.get('sitemap-blog.xml')!;
+    expect(countAnnotations(sanitized)).toBe(0);
+    expect(countLocs(sanitized)).toBe(1);
+    expect(sanitized).toContain(`<loc>${itLoc}</loc>`);
+    expect(sanitized).toContain('<lastmod>2026-04-03</lastmod>');
+    // No dangling blank lines where the annotations used to be.
+    expect(sanitized).not.toMatch(/\n[ \t]*\n/);
+  });
+
+  it('keeps a complete reciprocal group byte-identical (salary-hub pattern)', () => {
+    const xml = urlset(
+      urlBlock(itLoc, fullGroup()),
+      urlBlock(enLoc, fullGroup()),
+    );
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-salary-hub.xml', xml }]);
+    // Nothing changed → file not in the output map at all.
+    expect(out.size).toBe(0);
+  });
+
+  it('resolves reciprocity across files (alternate listed in a sibling sitemap)', () => {
+    const fileA: SitemapXmlFile = {
+      file: 'sitemap-a.xml',
+      xml: urlset(urlBlock(itLoc, fullGroup())),
+    };
+    const fileB: SitemapXmlFile = {
+      file: 'sitemap-b.xml',
+      xml: urlset(urlBlock(enLoc, fullGroup())),
+    };
+    const out = sanitizeSitemapHreflangReciprocity([fileA, fileB]);
+    expect(out.size).toBe(0);
+  });
+
+  it('strips when the alternate is a listed <loc> WITHOUT a return annotation (bare-loc jobs pattern)', () => {
+    const xml = urlset(
+      urlBlock(itLoc, [ann('it', itLoc), ann('en', enLoc)]),
+      urlBlock(enLoc, []), // listed, but does not annotate back
+    );
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-mixed.xml', xml }]);
+    const sanitized = out.get('sitemap-mixed.xml')!;
+    expect(countAnnotations(sanitized)).toBe(0);
+    expect(countLocs(sanitized)).toBe(2);
+  });
+
+  it('cascades to a fixpoint: stripping an invalid group also strips neighbours that relied on its return tag', () => {
+    const cLoc = `${BASE}/de/grenzgaenger-artikel/beispiel/`; // never a <loc>
+    const xml = urlset(
+      // A ↔ B reciprocal…
+      urlBlock(itLoc, [ann('it', itLoc), ann('en', enLoc)]),
+      // …but B's group also references C, which is listed nowhere → B is
+      // stripped → A loses its return tag → A must be stripped too.
+      urlBlock(enLoc, [ann('it', itLoc), ann('en', enLoc), ann('de', cLoc)]),
+    );
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-cascade.xml', xml }]);
+    const sanitized = out.get('sitemap-cascade.xml')!;
+    expect(countAnnotations(sanitized)).toBe(0);
+    expect(countLocs(sanitized)).toBe(2);
+  });
+
+  it('leaves annotation-free sitemaps untouched', () => {
+    const xml = urlset(urlBlock(itLoc, []), urlBlock(enLoc, []));
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-jobs-ticino.xml', xml }]);
+    expect(out.size).toBe(0);
+  });
+
+  it('parses the compact single-line emit shape used by plugin-emitted sitemaps', () => {
+    // salaryHubPlugin emits `<xhtml:link rel="alternate" hreflang=".." href=".."/>`
+    // (no space before `/>`), blocks joined without pretty-print guarantees.
+    const compact =
+      `<?xml version="1.0" encoding="UTF-8"?>\n<urlset>\n` +
+      `  <url>\n    <loc>${itLoc}</loc>\n    <xhtml:link rel="alternate" hreflang="it" href="${itLoc}"/>\n    <xhtml:link rel="alternate" hreflang="en" href="${enLoc}"/>\n  </url>\n` +
+      `</urlset>\n`;
+    const out = sanitizeSitemapHreflangReciprocity([{ file: 'sitemap-compact.xml', xml: compact }]);
+    const sanitized = out.get('sitemap-compact.xml')!;
+    expect(countAnnotations(sanitized)).toBe(0);
+    expect(countLocs(sanitized)).toBe(1);
+  });
+});
+
+describe('sanitizeSitemapHreflangReciprocity — committed public/ sitemaps', () => {
+  const publicDir = path.join(ROOT, 'public');
+  const files: SitemapXmlFile[] = fs
+    .readdirSync(publicDir)
+    .filter((f) => /^sitemap-[a-z0-9][a-z0-9-]*\.xml$/i.test(f))
+    .map((file) => ({
+      file,
+      xml: fs.readFileSync(path.join(publicDir, file), 'utf-8'),
+    }));
+  const sanitizedXml = new Map(files.map((f) => [f.file, f.xml] as const));
+  for (const [file, xml] of sanitizeSitemapHreflangReciprocity(files)) {
+    sanitizedXml.set(file, xml);
+  }
+
+  it('never adds or removes a <loc> entry in any sitemap', () => {
+    for (const { file, xml } of files) {
+      const before = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+      const after = [...sanitizedXml.get(file)!.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+      expect(after, file).toEqual(before);
+    }
+  });
+
+  it('fully strips the known one-sided files (blog, blog-ch, glossario, news) — issue #3474', () => {
+    for (const file of ['sitemap-blog.xml', 'sitemap-blog-ch.xml', 'sitemap-glossario.xml', 'sitemap-news.xml']) {
+      const xml = sanitizedXml.get(file);
+      expect(xml, `${file} missing from public/`).toBeDefined();
+      expect(countAnnotations(xml!), file).toBe(0);
+    }
+  });
+
+  it('every surviving annotation satisfies reciprocity (alternate is a listed <loc> with a return tag)', () => {
+    const locSet = new Set<string>();
+    const annotationsByLoc = new Map<string, Set<string>>();
+    for (const xml of sanitizedXml.values()) {
+      for (const blockMatch of xml.matchAll(/<url>[\s\S]*?<\/url>/g)) {
+        const block = blockMatch[0];
+        const loc = block.match(/<loc>\s*([^<]+?)\s*<\/loc>/)?.[1];
+        if (!loc) continue;
+        locSet.add(loc);
+        for (const el of block.matchAll(/<xhtml:link\b[^>]*?\/>/g)) {
+          const href = el[0].match(/href="([^"]+)"/)?.[1];
+          if (!href) continue;
+          let set = annotationsByLoc.get(loc);
+          if (!set) {
+            set = new Set<string>();
+            annotationsByLoc.set(loc, set);
+          }
+          set.add(href);
+        }
+      }
+    }
+    const violations: string[] = [];
+    for (const [loc, hrefs] of annotationsByLoc) {
+      for (const href of hrefs) {
+        if (!locSet.has(href)) violations.push(`${loc} → ${href} (alternate not a listed <loc>)`);
+        else if (!annotationsByLoc.get(href)?.has(loc)) violations.push(`${loc} → ${href} (no return tag)`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the reciprocal-complete groups of sitemap-pages.xml (never strips a correct signal)', () => {
+    const xml = sanitizedXml.get('sitemap-pages.xml')!;
+    // The 7 top-level tab pages are listed in all 4 locales with symmetric
+    // annotation groups (28 <url> blocks × 5 annotations) — they must survive.
+    expect(countAnnotations(xml)).toBeGreaterThanOrEqual(28 * 5);
+    expect(xml).toContain(`hreflang="en" href="${BASE}/en/tax/"`);
+  });
+});

--- a/tests/submit-indexnow-batch.test.ts
+++ b/tests/submit-indexnow-batch.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { extractUrls, getUrlsFromSitemaps } from '../scripts/submit-indexnow-batch.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { extractAlternateUrls, extractUrls, getUrlsFromSitemaps } from '../scripts/submit-indexnow-batch.mjs';
 
 // A fresh Response per call: a Response body is single-use, so reusing one
 // object across the 6 sub-sitemap fetches would throw on the 2nd read and
@@ -102,5 +105,40 @@ describe('getUrlsFromSitemaps (live mode branches)', () => {
     expect(urls).toContain('https://frontaliereticino.ch/lavoro');
     expect(urls).toContain('https://frontaliereticino.ch/');
     expect([...urls]).toEqual([...urls].sort());
+  });
+
+  it('unions the EN/DE/FR alternates from the public/ registry even when the live sitemaps carry none (issue #3474)', async () => {
+    // The deployed sitemaps no longer annotate one-sided hreflang groups
+    // (build-plugins/sitemapAliasPlugin.ts strips them), so the locale
+    // article URLs MUST come from the committed public/ sources — a live
+    // response with zero annotations must not shrink the submission set.
+    vi.stubGlobal('fetch', xmlResponder('<urlset></urlset>'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    const blogXml = fs.readFileSync(path.join(root, 'public', 'sitemap-blog.xml'), 'utf-8');
+    const enAlternate = blogXml.match(/hreflang="en"\s+href="([^"]+)"/)?.[1];
+    expect(enAlternate).toBeTruthy();
+
+    const urls = await getUrlsFromSitemaps();
+    expect(urls).toContain(enAlternate);
+  });
+});
+
+describe('extractAlternateUrls (public/-registry compensation)', () => {
+  it('extracts only hreflang alternate hrefs, never <loc> entries', () => {
+    const urls = new Set<string>();
+    const xml = `<urlset>
+      <url>
+        <loc>https://frontaliereticino.ch/articoli-frontaliere/esempio/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/cross-border-articles/example/" />
+      </url>
+    </urlset>`;
+
+    const count = extractAlternateUrls(xml, urls);
+
+    expect(count).toBe(1);
+    expect([...urls]).toEqual(['https://frontaliereticino.ch/en/cross-border-articles/example/']);
   });
 });


### PR DESCRIPTION
## Implementato

Fix del finding #3474 (annotazioni hreflang one-sided nelle sitemap blog) usando la **seconda opzione sanzionata dall'issue stessa**: «drop the one-sided annotations and rely on the already-correct HTML method».

- **`build-plugins/sitemapAliasPlugin.ts`** — nuovo task 0 "hreflang-reciprocity sanitizer": funzione pura esportata `sanitizeSitemapHreflangReciprocity()` che, a `closeBundle` (prima dell'alias `sitemap_news.xml` e della rigenerazione dell'index), rimuove gli elementi `xhtml:link` da ogni `<url>` block il cui annotation-group viola la reciprocità richiesta dal metodo sitemap-hreflang di Google (ogni alternate deve essere un `<loc>` listato in una sitemap del sito E annotare di ritorno). Regola valutata sul set globale di tutte le `dist/sitemap-*.xml` (cross-file OK), con iterazione a fixpoint. I gruppi completi restano **byte-identici** (sitemap-salary-hub.xml; i 7 gruppi × 4 locali di sitemap-pages.xml). Nessun `<loc>` viene mai aggiunto o rimosso (regola ferma anti-cut). Sanitizzazione **solo su dist/**: i sorgenti `public/` mantengono le annotazioni perché sono build-metadata load-bearing (staticPagesPlugin emissione varianti locale, legacyRedirectsPlugin hreflang map, llms.txt, IndexNow).
- **Fix dell'intera classe sibling (AGENTS.md #6)**, non solo dei 2 file del finding: la stessa one-sidedness era presente in sitemap-blog.xml (13725 annotazioni), sitemap-blog-ch.xml (1430), sitemap-glossario.xml (210), sitemap-news.xml (3475, alias `sitemap_news.xml` incluso by-ordering), sitemap-jobs.xml (5) e in 154/182 gruppi di sitemap-pages.xml. Il sanitizer è data-driven sul set globale → la classe è chiusa by-construction anche per sitemap future.
- **`scripts/submit-indexnow-batch.mjs`** — compensazione discovery Bing/IndexNow: nuova `extractAlternateUrls()` esportata + union degli alternate hreflang dal registry `public/` (il workflow ha il checkout). Le sitemap live sanitizzate non veicolano più gli URL locale → senza compensazione ~20k URL EN/DE/FR sarebbero usciti dal set di submission (regola: mai perdere discovery).
- **`scripts/submit-indexnow.js`** (post-deploy) — stessa compensazione senza spam del diff: `expandWithPublicAlternates()` espande SOLO i `newUrls` post-diff con gli alternate del registry public/ (una union pre-diff avrebbe flaggato ~20k alternate come "nuovi" a ogni deploy una volta live la sanitizzazione); il lookup del block per il path Bing new-article ora usa `readPublicXml()` (public-only; prima preferiva dist → post-strip avrebbe perso gli alternate del nuovo articolo).
- **Test** — nuovo `tests/sitemap-hreflang-reciprocity.test.ts` (11 test: fixture strip/keep/cross-file/return-tag/fixpoint-cascade/compact-shape + invarianti sui file `public/` reali: nessun `<loc>` aggiunto/rimosso, blog/blog-ch/glossario/news → 0 annotazioni, ogni annotazione sopravvissuta soddisfa la reciprocità, i 28×5 gruppi completi di pages.xml sopravvivono); esteso `tests/submit-indexnow-batch.test.ts` (+2: compensazione con live vuoto → l'alternate EN reale resta nel set; `extractAlternateUrls` non estrae `<loc>`).
- **Verifica end-to-end locale** (FAST_BUILD `npm run build`, sitemapAliasPlugin è plugin core sempre attivo): dist/sitemap-blog.xml 2745 locs / 0 xhtml:link (era 13725), blog-ch 286/0, glossario 42/0, news 695/0 + alias sanitizzato, pages 182 locs / 140 annotazioni = esattamente i 28 blocchi reciproci × 5, jobs 1/0. Mutazioni tracked da build ripristinate post-verifica.
- **Blast radius (GitNexus impact, upstream)**: `sitemapAliasPlugin` ← solo `vite.config.ts` (LOW); `getUrlsFromSitemaps` ← solo `submitToIndexNow` nello stesso file (LOW). Nessun processo/modulo HIGH/CRITICAL.
- **Zero impatto sui gate ratchet**: nessun `<loc>` cambia → `audit:max-bfs-depth`, `audit:orphan-sitemap-pages`, `audit:sitemap-canonicals`, `validate-sitemap-pages` invariati; `validate-sitemap-links` ha strettamente meno URL hreflang da verificare; `diff-sitemaps` è loc-based e informational. `check-blog-slugs-sitemap-sync`, `seo-completeness`, `sitemap-xdefault-matches-it`, google-news-compliance leggono `public/` (invariato).
- **Perché non l'opzione 1 dell'issue** (emettere le `<url>` EN/DE/FR con annotation set completi): non è un fix chirurgico ma una feature con prerequisiti strutturali. Le pagine archivio non-IT `page-N>1` sono stub SPA "Pagina archiviata" per il cap deliberato anti-bloat dist (2026-05-13) e gli indici sezione locale non hanno il navigatore page-N (verificato live: `/en/cross-border-articles/all/page-2/` = stub, indice EN senza navigatore) → ~8.2k URL locale starebbero a BFS depth ≥5/∞ → hard-fail VERO (non falso positivo) dei gate ratchet `audit:max-bfs-depth` (baseline sitemap-blog: 0 offenders, deepest 3) e orphan-pages, più gate content-quality su 8.235 pagine non validabili pre-merge (full build solo in CI, OOM-prone). Richiederebbe di invertire una decisione architetturale deliberata → eventualmente task separato con owner sign-off; l'issue definisce esplicitamente il drop come fix valido alternativo, quindi questo finding è chiuso qui.

- **[post-review] Strip anche dei gruppi degeneri self-only** (commit `ab9b7a307a6`, 🔴 dal local review): un gruppo il cui ogni href coincide col proprio `<loc>` (seo-hubs page-N emette un singolo `xhtml:link hreflang="it"` auto-referenziale) auto-soddisfaceva il fixpoint di reciprocità e sopravviveva → `dist/sitemap-seo-hubs.xml` restava con annotation solo-it e `validate-locale-shard-build` check (4) (gate bloccante deploy, ispeziona il PRIMO sitemap annotato in ordine readdir e pretende tutte e 4 le locale) diventava una lotteria di ordinamento. Il bullet «Zero impatto sui gate ratchet» sopra era quindi incompleto: vale ORA, con questo strip (seo-hubs esce senza annotation → mai candidato del check). Fixture test aggiunto con la shape esatta page-N; suite reciprocity 12/12 verde in locale.
- **[post-review] Perdita IndexNow dichiarata e tracciata (#3499)**: `extractUrls` estrae anche gli href hreflang dai sitemap live, quindi pre-PR gli URL root-archivio hub EN/DE/FR (~12-16 pagine, mai `<loc>` da nessuna parte) entravano nel batch IndexNow via le annotation page-1 di seo-hubs; post-strip escono e la compensazione public/-registry non copre i sitemap plugin-emitted. Perdita accettata (pagine live, hreflang on-page completo, link interni → discovery via crawl intatta; perso solo il canale push Bing) — il fix pulito (fonte-verità hub consumabile da plain node) è il piano di completamento in #3499. La verifica post-merge «set di submission invariato» va letta al netto di questi ~12-16 URL.

Verifica post-merge prevista: `curl -s https://frontaliereticino.ch/sitemap-blog.xml | grep -c "xhtml:link"` → 0 dopo il primo deploy; sitemap-pages.xml → 140; run `submit-indexnow-batch` (dry-run) → set di submission invariato (~n URL con alternates dal registry public/).

## Non implementato (ancora)

Nessuno.

Closes #3474

