### PR TITLE
docs: SEO-RULES trailing-slash reword + jobPostingSchema docblock accuracy (review-nit bundle)

### DIFF
--- a/build-plugins/shared/jobPostingSchema.ts
+++ b/build-plugins/shared/jobPostingSchema.ts
@@ -191,7 +191,8 @@ export type EmploymentType =
 /**
  * Canonical prod origin — fallback base for absolutizing a same-origin
  * (root-relative) `hiringOrganization.logo` path when the caller omits
- * `opts.baseUrl` (every current caller passes it).
+ * `opts.baseUrl` (publisherAdPagesPlugin relies on this fallback; all
+ * other callers pass it explicitly).
  */
 const CANONICAL_ORIGIN = 'https://frontaliereticino.ch';
 

--- a/docs/SEO-RULES.md
+++ b/docs/SEO-RULES.md
@@ -4,7 +4,7 @@
 
 ## Canonical URL
 
-**Always use `https://frontaliereticino.ch/`** — no `www`, no trailing slash (except root). All sitemaps, hreflang, JSON-LD, and workflow scripts must use this form.
+**Always use `https://frontaliereticino.ch`** — no `www`. Every page URL is slash-terminated (site-wide trailing-slash convention: `buildPath()` forces it; no-slash variants 301 to the slash form at the edge) — only the bare origin string carries no trailing path slash. All sitemaps, hreflang, JSON-LD, and workflow scripts must use this form.
 
 ## Static Page Generation
 


### PR DESCRIPTION
## Implementato

- `docs/SEO-RULES.md`: la riga canonical-URL diceva «no trailing slash (except root)» — contraddiceva la convenzione site-wide slash-terminated (buildPath, sitemap, hreflang, e da #3488 anche 301 edge). Riformulata: ogni URL di pagina è slash-terminated, solo l'origin nudo è senza slash di path. (🟡 dal local review di #3488)
- `build-plugins/shared/jobPostingSchema.ts`: docblock di CANONICAL_ORIGIN affermava «every current caller passes it» ma `publisherAdPagesPlugin.ts:388` chiama `buildJobPostingSchema` senza `baseUrl` e vive sul fallback. Corretto. (🟡 dal local review di #3489)

Diff doc/comment-only, zero cambi di comportamento.

## Non implementato (ancora)

Nessuno.