### PR TITLE
fix(seo): frontalierePillarPlugin og:locale Swiss variants — unbreak main vitest

### DIFF
--- a/build-plugins/frontalierePillarPlugin.ts
+++ b/build-plugins/frontalierePillarPlugin.ts
@@ -54,10 +54,10 @@ function esc(s: unknown): string {
 }
 
 const OG_LOCALE: Record<FrontalierePillarLocale, string> = {
-  it: 'it_IT',
+  it: 'it_CH',
   en: 'en_US',
-  de: 'de_DE',
-  fr: 'fr_FR',
+  de: 'de_CH',
+  fr: 'fr_CH',
 };
 
 const TILE_STYLES = [STAT_TILE_ACCENT, STAT_TILE_SUCCESS, STAT_TILE_BASE] as const;


### PR DESCRIPTION
## Implementato

- `build-plugins/frontalierePillarPlugin.ts`: mappa `OG_LOCALE` da varianti generiche (`it_IT`/`de_DE`/`fr_FR`) a varianti Swiss-market (`it_CH`/`de_CH`/`fr_CH`), `en_US` invariato — coerente con i 35 emitter di #3487.

**Root cause del main-red:** il plugin pillar è entrato con #3469 da un branch tagliato PRIMA del merge di #3487, portando la vecchia mappa; lo structural guard `tests/og-locale-swiss-variants.test.ts` (aggiunto proprio da #3487 per catturare questo drift) ha fatto il suo lavoro e ha messo main rosso al primo run full-suite post-merge. Questo è il fix root-cause, non un ritocco del test (Non-Negotiable #1/#5).

Verifica: `npx vitest run tests/og-locale-swiss-variants.test.ts` → 4/4 verdi in worktree; sibling grep su build-plugins/services/index.html → zero residui generici.

## Non implementato (ancora)

Nessuno.