### PR TITLE
fix(company-hub-bridge): brand-alias-aware canonical closes validate-dist race

### DIFF
--- a/build-plugins/companyHubBridgePlugin.ts
+++ b/build-plugins/companyHubBridgePlugin.ts
@@ -37,6 +37,9 @@ import { renderCantonSeoProse, buildCantonSeoProseFaqItems, type CantonSeoLocale
 import type { Locale } from '../services/i18n';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { COMPANY_ROUTE_PREFIX } from './shared/cantonSection';
+import { buildCanonicalBridgePage } from './constants';
+import { isBrandAlias, resolveBrandCanonical } from './shared/brandCanonicalMap';
+import { buildTitleWithBrand } from './shared/titleSuffix';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 
@@ -495,6 +498,34 @@ function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
   });
 }
 
+// autoDiscoverCompanyHubs() seeds candidates straight from the crawler
+// universe (data/jobs/by-crawler/*.json), independent of BRAND_CANONICAL_MAP,
+// so a declared alias slug (e.g. `migros-ticino`) can be discovered here too.
+// jobsSeoPagesPlugin owns the correct noindex→primary bridge for that slug,
+// but its emission is data-dependent (BRAND_UMBRELLAS aggregation must find
+// a qualifying entry); when it doesn't fire for a given build, this plugin's
+// `fs.existsSync` skip-guard sees no file and falls through to
+// `renderUnmatchedPage`, wrongly canonicalizing the alias to the
+// Switzerland-wide aggregator instead of the brand primary (issue #3232
+// recurrence, tests/seo/brand-dedup.test.ts). Bridging to the SAME primary
+// here — via the same `buildCanonicalBridgePage` helper jobsSeoPagesPlugin
+// uses for its own alias pages — makes the two emitters agree regardless of
+// write order, closing the race structurally instead of one build at a time.
+function renderBrandAliasBridge(entry: HubEntry, canonicalSlug: string): string {
+  const primaryHubPath = buildHubPath(entry.locale, canonicalSlug);
+  const companyName = entry.displayName;
+  return buildCanonicalBridgePage({
+    canonicalUrl: `${BASE_URL}${primaryHubPath}`,
+    pathLabel: primaryHubPath,
+    title: buildTitleWithBrand(esc(companyName)),
+    description: `Pagina alternativa per ${companyName}. Apri la pagina canonica per gli annunci aggiornati.`,
+    body: `Questa URL azienda non e la variante canonica. Apri la pagina principale dell'azienda per gli annunci aggiornati.`,
+    ctaLabel: String(companyName || 'Apri azienda'),
+    lang: entry.locale,
+    noindex: true,
+  });
+}
+
 export function companyHubBridgePlugin(rootDir: string): Plugin {
   return {
     name: 'company-hub-bridge',
@@ -539,9 +570,12 @@ export function companyHubBridgePlugin(rootDir: string): Plugin {
         const flatTarget = path.join(distDir, hubPath.replace(/\/+$/, '') + '.html');
         if (fs.existsSync(indexTarget)) { skipped++; continue; }
 
-        const html = entry.kind === 'matched'
-          ? renderMatchedPage(entry, distDir)
-          : renderUnmatchedPage(entry, distDir);
+        const brandCanonicalSlug = resolveBrandCanonical(entry.companySlug);
+        const html = (brandCanonicalSlug && isBrandAlias(entry.companySlug))
+          ? renderBrandAliasBridge(entry, brandCanonicalSlug)
+          : entry.kind === 'matched'
+            ? renderMatchedPage(entry, distDir)
+            : renderUnmatchedPage(entry, distDir);
 
         try {
           fs.mkdirSync(path.dirname(indexTarget), { recursive: true });


### PR DESCRIPTION
## Implementato

- Root cause of the recurring `gate:seo-source` failure in `post-deploy-validate-dist.yml` (run [28730460931](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28730460931), `tests/seo/brand-dedup.test.ts`): `build-plugins/companyHubBridgePlugin.ts`'s `autoDiscoverCompanyHubs()` seeds company-hub candidates straight from `data/jobs/by-crawler/*.json`, entirely independent of `BRAND_CANONICAL_MAP`. When a declared brand alias (e.g. `migros-ticino`) is discovered this way and `jobsSeoPagesPlugin`'s own alias-bridge emission doesn't fire first for that build (its `BRAND_UMBRELLAS` aggregation is data-dependent), `companyHubBridgePlugin`'s `fs.existsSync` write-guard sees no file on disk and falls through to `renderUnmatchedPage`, wrongly canonicalizing the alias to the generic Switzerland-wide aggregator (`/cerca-lavoro-svizzera/`) instead of the brand primary (`/cerca-lavoro-ticino/azienda-migros/`).
- Structural fix (not a re-baseline / not brand-specific): `companyHubBridgePlugin.ts` now checks `isBrandAlias(entry.companySlug)`/`resolveBrandCanonical()` before deciding matched/unmatched, and routes any brand-alias slug through the same `buildCanonicalBridgePage` helper `jobsSeoPagesPlugin.ts` already uses for its own alias bridges. Both emitters now agree on the same canonical for every alias in `BRAND_CANONICAL_MAP` (`migros-ticino`, `gruppo-migros`, `guess`, `guess-europe`, `guess-sagl`, `guess-europe-switzerland`, `guess-ticino`, `medacta`, `medacta-international`, `medacta-sa`, `medacta-italia`, `medacta-rancate`, `casale`, `casale-lugano`, `casale-chemical`, `casale-group`), regardless of which plugin's `closeBundle` writes the file first — closing the cross-plugin write-order race by construction instead of depending on plugin registration order.
- Sibling-pattern audit (AGENTS.md #6): grepped every `build-plugins/*.ts` writer touching the `azienda-*`/`company-*` reserved namespace. `jobOrphanBridgePlugin.ts` and `legacyRedirectsPlugin.ts` already guard via `isCompanyHubNamespaceSlug` and defer entirely to the dedicated company-hub emitters rather than deciding their own canonical — not siblings of this defect. `jobsSeoPagesPlugin.ts` was already `BRAND_CANONICAL_MAP`-aware. `companyHubBridgePlugin.ts` was the only writer of hub-kind pages with this blind spot.
- Verified locally: `npx tsc --noEmit` clean on touched files; `npx vitest run tests/seo/` green (module-level `brand-dedup.test.ts` assertions pass; build-output-layer assertions are opt-in/skipped without a local `dist/`, consistent with existing test design).

## Non implementato (ancora)

- Il layer build-output di `tests/seo/brand-dedup.test.ts` (quello che effettivamente riproduce il bug) non è verificabile pre-merge: richiede un `dist/` reale, e la build SEO completa locale va in OOM su questa macchina (vedi memoria progetto). La verifica reale avviene sul prossimo `post-deploy-validate-dist.yml` post-merge. Trigger di revert: se quel run mostra ANCORA un mismatch di canonical per un qualsiasi alias in `BRAND_CANONICAL_MAP` (non solo migros-ticino) → rivedere il fix, non re-baseline.
- Issue #3232 è un bucket generico di ricorrenza per "Post-deploy Validate Dist fallita" che accumula root cause diverse e scorrelate nel tempo (53 commenti storici, molteplici cause). Questa PR fixa la causa dietro l'ultima ricorrenza (run 1109 / validation run 28730460931), ma NON chiude l'issue con `Closes` — il bucket resta aperto per future ricorrenze scorrelate. Referenziata qui senza keyword di chiusura: #3232.