### PR TITLE
fix(ai-models): local fallback no longer inherits remote daily-quota bans; GitHub Models default request-token cap

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1590,7 +1590,12 @@ export async function initScoreStore() {
         });
       }
 
-      if (data.exhaustedUntil) {
+      // Local CPU fallback has no daily-quota concept (unlike a remote API
+      // account) — a stale content/timeout failure from hours ago says
+      // nothing about whether the local server will fail again right now.
+      // Skip restoring any persisted ban for it so it's always eligible as
+      // last resort every run. See markModelExhausted / _persistScoresToFirestore.
+      if (data.exhaustedUntil && getProvider(modelId) !== PROVIDER.LOCAL) {
         const resetTime = data.exhaustedUntil.toDate
           ? data.exhaustedUntil.toDate()   // Firestore Timestamp
           : new Date(data.exhaustedUntil); // ISO string fallback
@@ -1655,8 +1660,11 @@ async function _persistScoresToFirestore() {
       updatedAt: now,
     };
 
-    // If model is exhausted, persist the reset time (next midnight UTC)
-    if (_exhaustedModels.has(modelId)) {
+    // If model is exhausted, persist the reset time (next midnight UTC).
+    // Local CPU fallback is exempt: it has no daily-quota concept, so a
+    // content/timeout failure must never survive past this process — see
+    // the matching restore-path guard above (initScoreStore).
+    if (_exhaustedModels.has(modelId) && getProvider(modelId) !== PROVIDER.LOCAL) {
       const tomorrow = new Date();
       tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
       tomorrow.setUTCHours(0, 0, 0, 0);
@@ -2227,6 +2235,32 @@ const MODEL_MAX_REQUEST_TOKENS = {
   'Llama-3.2-90B-Vision-Instruct':      8000,
   // cerebras/* models — apiModelId is stripped of the provider prefix
   'llama3.1-8b':                        8000,
+};
+
+/**
+ * Per-PROVIDER default request-token cap, consulted only when a model has no
+ * entry in MODEL_MAX_REQUEST_TOKENS above. MODEL_MAX_REQUEST_TOKENS is a
+ * whack-a-mole list grown one incident at a time (each entry added only
+ * after that specific model 413'd in production); dozens of models on the
+ * same account-wide tier never get added and burn a full 413 round-trip
+ * every time the prompt grows past the tier's real ceiling.
+ *
+ * GitHub Models specifically is verified account-wide, not per-model: runs
+ * 28730759322 / 28729689806 (2026-07-05) show Phi-4-mini-reasoning,
+ * Meta-Llama-3.1-405B-Instruct, Meta-Llama-3.1-8B-Instruct, Ministral-3B, and
+ * Llama-4-Maverick-17B-128E-Instruct-FP8 — five otherwise-unrelated model
+ * families — all fail with the byte-identical "Request body too large ...
+ * Max size: 8000 tokens" at the same ~9600-token estimate. That is the free
+ * tier's request cap, independent of any single model's advertised context
+ * window. Applying it as a provider default (instead of waiting to hardcode
+ * each new model one incident at a time) lets the pre-flight skip-guard
+ * catch the whole family immediately and fall through to a provider that can
+ * actually take the payload — most importantly the local fallback, which
+ * would otherwise only be reached after burning the entire GitHub Models
+ * roster on guaranteed 413s.
+ */
+const DEFAULT_REQUEST_TOKENS_BY_PROVIDER = {
+  [PROVIDER.GITHUB]: 8000,
 };
 
 /**
@@ -3118,8 +3152,11 @@ export async function callLLM(messages, opts = {}) {
     // Skip models whose REQUEST (input) token cap is below the estimated prompt
     // size. Without this, models like o1 / gpt-5-mini / Phi-4 get tried with a
     // payload they cannot fit and return HTTP 413, burning a retry slot for
-    // every fallback. See MODEL_MAX_REQUEST_TOKENS for the per-model caps.
-    const reqLimit = MODEL_MAX_REQUEST_TOKENS[apiModelId];
+    // every fallback. Per-model overrides in MODEL_MAX_REQUEST_TOKENS win;
+    // otherwise fall back to the provider-wide default (see
+    // DEFAULT_REQUEST_TOKENS_BY_PROVIDER) so untracked models on the same
+    // account-wide tier are caught too, not just the handful hardcoded so far.
+    const reqLimit = MODEL_MAX_REQUEST_TOKENS[apiModelId] ?? DEFAULT_REQUEST_TOKENS_BY_PROVIDER[provider];
     if (reqLimit) {
       const estTokens = estimateRequestTokens(messages, o);
       if (estTokens > reqLimit) {

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import http from 'node:http';
 import type { Socket } from 'node:net';
 import { once } from 'node:events';
@@ -296,6 +296,111 @@ describe('local LLM fallback provider', () => {
       if (prevForce === undefined) delete process.env.AI_MODELS_FORCE_CHAIN; else process.env.AI_MODELS_FORCE_CHAIN = prevForce;
       if (prevGem === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = prevGem;
       if (prevUrl === undefined) delete process.env.LOCAL_LLM_URL; else process.env.LOCAL_LLM_URL = prevUrl;
+    }
+  });
+});
+
+// Regression guard for the outage where `local/fallback` sat wrongly banned
+// for up to 24h, across every workflow run, after just 2 bad structured-JSON
+// outputs from the small quantized model. The daily-quota "exhausted until
+// next midnight UTC" persistence in ai-models.mjs was written for remote
+// rate-limited providers and was applying identically to the local CPU
+// fallback, which has no such quota — permanently disabling the one
+// guaranteed last-resort model meant to keep article generation from failing
+// end-to-end. Exercised against an in-memory firebase-admin stub (same
+// pattern as tests/publisher-pending-reap.test.ts) since the real behaviour
+// only shows up across the read/write round-trip with Firestore.
+describe('local LLM fallback exhaustion never persists past the run (Firestore)', () => {
+  const prevCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  const prevFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = '/dev/null';
+    // Discovery hits real provider APIs when a key is configured in the
+    // environment; force every discovery fetch to fail fast so this test
+    // never depends on network access or ambient API keys.
+    globalThis.fetch = (async () => { throw new Error('network disabled in test'); }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = prevFetch;
+    if (prevCreds === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS; else process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCreds;
+    vi.doUnmock('firebase-admin');
+  });
+
+  // In-memory Firestore stub matching the single-aggregate-doc layout
+  // initScoreStore/_persistScoresToFirestore use:
+  //   collection('ai_model_scores').doc('_all').get() / .set({models}, {merge:true})
+  function mockFirestore(store: Record<string, { models?: Record<string, unknown> }>) {
+    vi.doMock('firebase-admin', () => {
+      const admin: Record<string, unknown> = {
+        apps: [] as unknown[],
+        credential: { applicationDefault: () => ({}) },
+        initializeApp: () => { (admin.apps as unknown[]).push({}); },
+        firestore: () => ({
+          collection: () => ({
+            doc: (id: string) => ({
+              get: async () => ({
+                exists: store[id] != null,
+                data: () => store[id],
+              }),
+              set: async (data: { models?: Record<string, unknown> }, opts?: { merge?: boolean }) => {
+                if (opts?.merge && store[id]) {
+                  store[id] = { ...store[id], ...data, models: { ...(store[id].models || {}), ...(data.models || {}) } };
+                } else {
+                  store[id] = data;
+                }
+              },
+            }),
+            // Legacy per-model collection scan (one-time migration path in
+            // initScoreStore, used only when the aggregate doc has no models yet).
+            get: async () => ({ docs: [] }),
+          }),
+        }),
+      };
+      return { default: admin };
+    });
+  }
+
+  it('write path: exhausting local/fallback never sets exhaustedUntil; exhausting a remote model still does', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    mod.markModelExhausted(mod.AI_MODELS.LOCAL_FALLBACK, 'content');
+    mod.markModelExhausted(mod.AI_MODELS.GPT4O, 'quota');
+    await mod.flushScores();
+
+    const persisted = store._all.models as Record<string, { exhaustedUntil: string | null }>;
+    expect(persisted['local__fallback'].exhaustedUntil).toBeNull();
+    expect(persisted['gpt-4o'].exhaustedUntil).not.toBeNull();
+    expect(new Date(persisted['gpt-4o'].exhaustedUntil as string).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('restore path: a pre-existing persisted ban on local/fallback is never restored on process restart; the same ban on a remote model is', async () => {
+    const tomorrow = new Date();
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    tomorrow.setUTCHours(0, 0, 0, 0);
+    const store: Record<string, { models?: Record<string, unknown> }> = {
+      _all: {
+        models: {
+          local__fallback: { modelId: 'local/fallback', score: 0, exhaustedUntil: tomorrow.toISOString() },
+          'gpt-4o': { modelId: 'gpt-4o', score: 0, exhaustedUntil: tomorrow.toISOString() },
+        },
+      },
+    };
+    mockFirestore(store);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const mod = await import('../scripts/lib/ai-models.mjs');
+      await mod.initScoreStore();
+      const loadLine = logSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('[ScoreStore] Loaded'));
+      expect(loadLine).toBeDefined();
+      // Only gpt-4o's ban should survive the restore — local/fallback's must not.
+      expect(loadLine).toMatch(/\(0 decayed, 1 still exhausted\)/);
+    } finally {
+      logSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Implementato

- **Root cause 1 (the actual outage):** `local/fallback` (the zero-cost Ollama last-resort model) was being subjected to the same "exhausted until next midnight UTC" Firestore persistence designed for remote rate-limited providers. After just 2 bad structured-JSON outputs (`MAX_CONSECUTIVE_CONTENT_FAILURES=2`) or a timeout, it got banned for the rest of the calendar day — confirmed continuously active across three separate runs spanning 2026-07-04 23:30 UTC through 2026-07-05 05:35 UTC, and across multiple consecutive days via Firestore-persisted state. `scripts/lib/ai-models.mjs`: exempted `PROVIDER.LOCAL` from both the write-side persist (`_persistScoresToFirestore`) and the read-side restore (`initScoreStore`) of the midnight ban. The legitimate in-process, single-run circuit breaker (`markModelExhausted`/`_shouldSkipExhausted`) is untouched — local still gets skipped for the rest of *that* run on failure, it just never carries the ban into the next run/day.
- **Root cause 2 (wasted cascade time):** the generate-article prompt has grown to ~9600 estimated tokens, exceeding GitHub Models' account-wide free-tier request cap of 8000 tokens. Confirmed via runs 28730759322 / 28729689806 (2026-07-05): 5 unrelated model families (Phi-4-mini-reasoning, Meta-Llama-3.1-405B/8B, Ministral-3B, Llama-4-Maverick) all failing with the byte-identical `HTTP 413 ... Max size: 8000 tokens`. The existing `MODEL_MAX_REQUEST_TOKENS` skip-guard was a hand-curated whack-a-mole list covering ~16 of the ~80 GitHub Models entries, so most of the roster was live-tried and 413'd every single call. Added `DEFAULT_REQUEST_TOKENS_BY_PROVIDER[PROVIDER.GITHUB] = 8000`, consulted by the existing pre-flight guard whenever a model has no specific override — the whole family is now pre-filtered generically, reaching a viable model (local or otherwise) much faster.
- **Interaction:** because #1 kept local permanently disabled and #2 meant burning through most of the GitHub roster before failing, every run for both `frontaliere` and `svizzera` sections failed end-to-end with zero articles produced — matching the reported symptom exactly.
- **Tests:** added two regression tests to `tests/local-llm-fallback.test.ts` exercising the write path (`markModelExhausted` + `flushScores` against an in-memory Firestore stub → `local/fallback` persists `exhaustedUntil: null`, a control remote model still persists a real ban) and the restore path (a pre-existing persisted ban on `local/fallback` is never restored on process init; the same ban on a remote model is). Confirmed sibling-pattern-free: exhaustion persistence and the per-model token-cap map both live solely in `ai-models.mjs` — no duplicated copy elsewhere to fix (AGENTS.md #6 grep performed, no siblings found).
- Verified via `gitnexus_detect_changes({scope:"all"})`: diff touches exactly the 4 intended functions (`initScoreStore`, `_persistScoresToFirestore`, `callLLM`, plus the new constant), `risk_level: "low"`, `affected_processes: []`. The isolated `gitnexus_impact` CRITICAL rating on `_persistScoresToFirestore` reflects raw caller-count of the shared persistence function (40 dependents across the whole AI-calling surface) — confirmed benign: the changed logic only branches on `getProvider(modelId) === PROVIDER.LOCAL`, and `local/` is the model-id prefix for exactly one model system-wide (`local/fallback`), so the other 39 dependents' behavior is byte-identical.
- Ran the full `ai-models.mjs`-touching test suite (`tests/local-llm-fallback.test.ts`, `tests/scripts/ai-models-get-preferred-model.test.ts`, `tests/scripts/ai-models-response-cache.test.ts`): 23/23 passing.

## Non implementato (ancora)

Nessuno.