### PR TITLE
fix(rum): version key + token dashboard + /cdn-cgi/ fuori dalla 301 (#3503)

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -457,9 +457,13 @@ export const GTAG_INIT_FILENAME = 'gtag-init.js';
  * (apex HTML flows through the locale-router Worker), so every emitted page
  * ships the beacon directly. Appended to GTAG_SNIPPET so all static emitters
  * get it by construction; index.html carries its own copy for the SPA.
- * The token is public by design (it is meant to appear in served HTML). #3503
+ * The token is public by design (it is meant to appear in served HTML).
+ * The `version` key is REQUIRED: without it beacon.min.js posts to the
+ * decommissioned central ingest (cloudflareinsights.com → HTML 404); with it
+ * the beacon posts same-origin /cdn-cgi/rum (zone ingest — excluded from the
+ * trailing-slash-301 rule, which was silently 301-killing beacon POSTs). #3503
  */
-export const CF_BEACON_SNIPPET = `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "52ad88ab198a42df98d2f363531b6429"}'></script>`;
+export const CF_BEACON_SNIPPET = `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "1268b58e83f74d22a2136ff48e0746b7", "version": "2024.6.1"}'></script>`;
 
 export const GTAG_SNIPPET = `<script async crossorigin="anonymous" src="https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}"></script>
  <script defer src="/assets/${GTAG_INIT_FILENAME}"></script>

--- a/index.html
+++ b/index.html
@@ -543,7 +543,7 @@
          zone-level auto-inject never provisions its ruleset on this zone
          (apex HTML flows through the locale-router Worker), so the beacon is
          shipped in the HTML directly. Token is public by design. #3503 -->
-    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "52ad88ab198a42df98d2f363531b6429"}'></script>
+    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "1268b58e83f74d22a2136ff48e0746b7", "version": "2024.6.1"}'></script>
 </head>
   <body class="bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transition-colors duration-300 overflow-x-hidden">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:text-blue-600 focus:rounded focus:shadow-lg focus:underline" style="position:absolute;top:0;left:0;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">Vai al contenuto principale</a>

--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -52,8 +52,11 @@
  *    dynamic-redirect phase runs BEFORE the cache and BEFORE Workers routes,
  *    so the 301 also short-circuits Worker invocations and stale edge-cached
  *    200s for no-slash variants. Excluded: paths with a "." (real files:
- *    .xml/.txt/.html/…) and /disiscrivi-* (RFC 8058 one-click unsubscribe —
- *    a 301 would not be re-issued as a POST by mail clients).
+ *    .xml/.txt/.html/…), /cdn-cgi/* (Cloudflare-internal endpoints — the Web
+ *    Analytics beacon POSTs to /cdn-cgi/rum; a 301 is not followed by beacon
+ *    senders, which silently killed RUM ingest, #3503) and /disiscrivi-*
+ *    (RFC 8058 one-click unsubscribe — a 301 would not be re-issued as a
+ *    POST by mail clients).
  *
  * Auth: CF_API_TOKEN — needs Zone→Workers Routes:Edit (already required by
  * deploy-worker.yml) + Zone→Zone Settings/Cache Rules:Edit + Zone→Firewall
@@ -214,6 +217,7 @@ const MANAGED_REDIRECT_RULES = [
       '(http.host eq "frontaliereticino.ch" ' +
       'and not ends_with(http.request.uri.path, "/") ' +
       'and not http.request.uri.path contains "." ' +
+      'and not starts_with(http.request.uri.path, "/cdn-cgi/") ' +
       'and not starts_with(http.request.uri.path, "/disiscrivi-"))',
     action_parameters: {
       from_value: {


### PR DESCRIPTION
## Implementato

- `scripts/cf-locale-failover-setup.mjs`: `/cdn-cgi/*` escluso dalla regola trailing-slash-301 — stava 301-ando `POST /cdn-cgi/rum` (path senza estensione né slash) e i beacon POST non seguono i redirect → ingest same-origin ucciso silenziosamente. Regola già applicata live e verificata (POST non più 301).
- `build-plugins/constants.ts` + `index.html`: aggiunta `"version"` alla config `data-cf-beacon` — senza, beacon.min.js spedisce all'ingest centrale legacy dismesso (`cloudflareinsights.com` → 404 HTML per qualunque token, verificato E2E); con `version` spedisce same-origin `/cdn-cgi/rum` (decodificato dal sorgente del beacon: `p.send?.to ?? (void 0===p.version ? central : same-origin)`).
- Token swappato al site creato da dashboard (`1268b58e…`) — i site creati via API vengono rifiutati da entrambi gli ingest.

Verifica E2E (Playwright + Chrome, HTML riscritto al volo con la config nuova): beacon posta same-origin `frontaliereticino.ch/cdn-cgi/rum?` e raggiunge l'edge (non più 301). Il 2xx finale dipende dall'attivazione dell'ingest di zona (modalità "Enable" nel dashboard, azione owner in corso) — verifica finale post-toggle prima del merge.

Closes #3503

## Non implementato (ancora)

- Merge gated sulla verifica E2E 2xx post-toggle owner ("Enable" su Manage site). Se l'ingest di zona resta 404 anche con Enable → il beacon manuale non ha ingest funzionante su questa zona e si valuta il Worker come proxy ingest (task separato).