### PR TITLE
fix(ai-models): close Groq TPM + NVIDIA context gaps, self-learning token-cap discovery

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1540,6 +1540,7 @@ export async function initScoreStore() {
     let loaded = 0;
     let decayed = 0;
     let exhaustedRestored = 0;
+    let learnedLimitsRestored = 0;
     let source = 'aggregate';
 
     const aggregateRef = _firestoreDb
@@ -1608,9 +1609,18 @@ export async function initScoreStore() {
           console.warn(`🚫 [ScoreStore] ${modelId} still exhausted until ${resetTime.toISOString().slice(0, 16)}`);
         }
       }
+
+      // Runtime-learned request-token ceiling (see _learnRequestTokenLimit) —
+      // unlike exhaustedUntil this isn't a daily quota, it's a static size
+      // limit, so it restores unconditionally for every provider including
+      // local/fallback.
+      if (typeof data.maxRequestTokens === 'number' && data.maxRequestTokens > 0) {
+        _learnedRequestTokenLimits.set(modelId, data.maxRequestTokens);
+        learnedLimitsRestored++;
+      }
     }
 
-    console.log(`☁️  [ScoreStore] Loaded ${loaded} model scores from Firestore [${source}] (${decayed} decayed, ${exhaustedRestored} still exhausted)`);
+    console.log(`☁️  [ScoreStore] Loaded ${loaded} model scores from Firestore [${source}] (${decayed} decayed, ${exhaustedRestored} still exhausted, ${learnedLimitsRestored} learned token limits)`);
 
     // Register exit hooks for final flush
     _registerExitHooks();
@@ -1671,6 +1681,12 @@ async function _persistScoresToFirestore() {
       entry.exhaustedUntil = tomorrow.toISOString();
     } else {
       entry.exhaustedUntil = null;
+    }
+
+    // Runtime-learned request-token ceiling (see _learnRequestTokenLimit).
+    // Not a daily quota — no local/fallback exemption needed.
+    if (_learnedRequestTokenLimits.has(modelId)) {
+      entry.maxRequestTokens = _learnedRequestTokenLimits.get(modelId);
     }
 
     modelsDelta[_encodeModelId(modelId)] = entry;
@@ -2235,6 +2251,14 @@ const MODEL_MAX_REQUEST_TOKENS = {
   'Llama-3.2-90B-Vision-Instruct':      8000,
   // cerebras/* models — apiModelId is stripped of the provider prefix
   'llama3.1-8b':                        8000,
+  // NVIDIA small-context models overrun by this codebase's ~8000-token
+  // completion budget (run 28732970228, 2026-07-05): both threw HTTP 400
+  // "maximum context length is N tokens" against a ~9000-token generation
+  // prompt. llama-3.1-nemotron-nano-vl-8b-v1 (context 16384) still has room
+  // for a smaller prompt; nemotron-mini-4b-instruct (context 4096) cannot
+  // fit any of this codebase's generation prompts regardless of trimming.
+  'nvidia/llama-3.1-nemotron-nano-vl-8b-v1': 8000,
+  'nvidia/nemotron-mini-4b-instruct':        3000,
 };
 
 /**
@@ -2261,7 +2285,86 @@ const MODEL_MAX_REQUEST_TOKENS = {
  */
 const DEFAULT_REQUEST_TOKENS_BY_PROVIDER = {
   [PROVIDER.GITHUB]: 8000,
+  // Groq free tier enforces a tokens-per-minute (TPM) cap, not a per-model
+  // context limit: run 28732970228 (2026-07-05) shows 4 unrelated Groq
+  // models — openai/gpt-oss-120b, qwen/qwen3.6-27b, llama-3.1-8b-instant,
+  // openai/gpt-oss-20b — all fail identically with HTTP 413 "Request too
+  // large ... on tokens per minute (TPM)" at the same ~8300-token estimate.
+  // Same account-wide-cap shape as GitHub Models above.
+  [PROVIDER.GROQ]: 8000,
 };
+
+/**
+ * Runtime-learned per-model request-token ceilings, parsed directly out of a
+ * 413/400 error body the first time a model hits one (see
+ * _learnRequestTokenLimit below), instead of waiting for a human to notice
+ * the pattern in logs and hardcode it into MODEL_MAX_REQUEST_TOKENS /
+ * DEFAULT_REQUEST_TOKENS_BY_PROVIDER above. Both of those maps are
+ * whack-a-mole: they only cover providers someone already got burned by.
+ * This map makes the skip-guard self-correcting for every OTHER provider —
+ * Cerebras, Mistral, HuggingFace, Cloudflare, Together, Fireworks,
+ * OpenRouter, Gemini, whatever comes next — after its very first failure,
+ * in-run immediately and cross-run via the same Firestore aggregate doc
+ * already used for scores/exhaustion (see initScoreStore /
+ * _persistScoresToFirestore). Keyed by the full chain model id (e.g.
+ * 'groq/openai/gpt-oss-120b'), matching _modelScores' keyspace — not by the
+ * bare apiModelId, so two providers serving the same bare model id under
+ * different tiers don't clobber each other's learned limit.
+ */
+const _learnedRequestTokenLimits = new Map();
+
+/**
+ * Pull a concrete numeric token ceiling out of a 413/400 error body, when the
+ * provider states one explicitly. Two known shapes so far:
+ *   - Context-length caps (NVIDIA, OpenAI-style):
+ *       "maximum context length is 16384 tokens. However, you requested
+ *        17397 tokens (9397 in the messages, 8000 in the completion)."
+ *     Converted to an input-only ceiling (context − completion) because
+ *     estimateRequestTokens() below only estimates input, never completion.
+ *   - Request-size / TPM caps (Groq, GitHub Models):
+ *       "... Limit 6000, Used 0, Requested 8264 ..." (Groq TPM)
+ *       "... Max size: 8000 tokens ..." (GitHub Models)
+ *
+ * Returns null when the body doesn't match a known shape — the model simply
+ * isn't auto-learned this time; static maps / provider defaults still apply.
+ */
+function _parseRequestTokenLimit(bodyText = '') {
+  const b = String(bodyText);
+
+  const ctxMatch = b.match(/maximum context length is (\d+) tokens/i);
+  if (ctxMatch) {
+    const maxContext = Number(ctxMatch[1]);
+    const completionMatch = b.match(/(\d+)\s*in the completion/i);
+    const completionTokens = completionMatch ? Number(completionMatch[1]) : 0;
+    const inputCeiling = maxContext - completionTokens;
+    if (inputCeiling > 0) return inputCeiling;
+  }
+
+  const limitMatch = b.match(/\bLimit\s+(\d+)\b/i);
+  if (limitMatch) return Number(limitMatch[1]);
+
+  const maxSizeMatch = b.match(/Max size:\s*(\d+)\s*tokens?/i);
+  if (maxSizeMatch) return Number(maxSizeMatch[1]);
+
+  return null;
+}
+
+/**
+ * Cache a freshly-parsed request-token ceiling for `modelForTracking` and
+ * mark it dirty for the next Firestore flush (same debounce path as
+ * recordModelSuccess/recordModelFailure/markModelExhausted), so future
+ * processes start with the limit already known instead of re-discovering it
+ * via a wasted 413/400. No-op when the body doesn't match a known shape or
+ * the parsed value doesn't change anything already known.
+ */
+function _learnRequestTokenLimit(modelForTracking, bodyText) {
+  const limit = _parseRequestTokenLimit(bodyText);
+  if (!limit || limit <= 0) return;
+  if (_learnedRequestTokenLimits.get(modelForTracking) === limit) return;
+  _learnedRequestTokenLimits.set(modelForTracking, limit);
+  _dirtyModels.add(modelForTracking);
+  _schedulePersist();
+}
 
 /**
  * Estimate token count for a list of OpenAI-format messages. Uses the standard
@@ -2404,6 +2507,11 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
         // Non-retryable client errors (unknown model, context too small)
         const nrc = classifyNonRetryableError(res.status, raw);
         if (nrc.nonRetryable) {
+          // Learn the real size cap from `raw` while it's still untruncated —
+          // the Error message below slices it to 300 chars (and callers slice
+          // further to 200 for logging), which is why this can't be recovered
+          // after the fact from logs.
+          _learnRequestTokenLimit(modelForTracking, raw);
           if (nrc.markExhausted) {
             markModelExhausted(modelForTracking, 'nonretryable');
             _stats.exhausted++;
@@ -2865,6 +2973,9 @@ async function _callGeminiRaw(model, messages, opts) {
         // Non-retryable client errors (unknown model, context too small)
         const nrc = classifyNonRetryableError(res.status, raw);
         if (nrc.nonRetryable) {
+          // Learn the real size cap from `raw` while it's still untruncated —
+          // see the matching call in _callOpenAICompatible for why.
+          _learnRequestTokenLimit(model, raw);
           if (nrc.markExhausted) {
             markModelExhausted(model);
             _stats.exhausted++;
@@ -3152,11 +3263,18 @@ export async function callLLM(messages, opts = {}) {
     // Skip models whose REQUEST (input) token cap is below the estimated prompt
     // size. Without this, models like o1 / gpt-5-mini / Phi-4 get tried with a
     // payload they cannot fit and return HTTP 413, burning a retry slot for
-    // every fallback. Per-model overrides in MODEL_MAX_REQUEST_TOKENS win;
-    // otherwise fall back to the provider-wide default (see
-    // DEFAULT_REQUEST_TOKENS_BY_PROVIDER) so untracked models on the same
-    // account-wide tier are caught too, not just the handful hardcoded so far.
-    const reqLimit = MODEL_MAX_REQUEST_TOKENS[apiModelId] ?? DEFAULT_REQUEST_TOKENS_BY_PROVIDER[provider];
+    // every fallback. Three sources, tightest known bound wins: hand-curated
+    // MODEL_MAX_REQUEST_TOKENS, runtime-learned _learnedRequestTokenLimits
+    // (parsed straight out of a prior 413/400 body — see
+    // _learnRequestTokenLimit — and persisted across runs via Firestore, so
+    // providers nobody has hardcoded yet still get caught after their first
+    // failure), and the provider-wide DEFAULT_REQUEST_TOKENS_BY_PROVIDER.
+    const knownLimits = [
+      MODEL_MAX_REQUEST_TOKENS[apiModelId],
+      _learnedRequestTokenLimits.get(model),
+      DEFAULT_REQUEST_TOKENS_BY_PROVIDER[provider],
+    ].filter((v) => typeof v === 'number' && v > 0);
+    const reqLimit = knownLimits.length ? Math.min(...knownLimits) : undefined;
     if (reqLimit) {
       const estTokens = estimateRequestTokens(messages, o);
       if (estTokens > reqLimit) {

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1979,6 +1979,7 @@ export function resetState() {
   _dirtyModels.clear();
   _consecutive429.clear();
   _consecutiveContentFailures.clear();
+  _learnedRequestTokenLimits.clear();
   _mutationCount = 0;
   if (_persistTimer) { clearTimeout(_persistTimer); _persistTimer = null; }
   _stats.calls = 0;
@@ -2356,10 +2357,20 @@ function _parseRequestTokenLimit(bodyText = '') {
  * processes start with the limit already known instead of re-discovering it
  * via a wasted 413/400. No-op when the body doesn't match a known shape or
  * the parsed value doesn't change anything already known.
+ *
+ * This is called for every nonRetryable classification, not just size-related
+ * ones (401/402/404 bodies pass through the same call site) — the regexes
+ * above are narrow enough that an unrelated error is unlikely to match, but a
+ * false-positive match would otherwise persist forever and permanently
+ * skip-guard the model out of every future run (the pre-flight guard means it
+ * never gets a chance to hit a different, correct error and self-correct).
+ * The floor below caps that blast radius: no real provider cap is low enough
+ * to reject every prompt this codebase generates (~8-9k tokens), so a parsed
+ * value this small is almost certainly a misparse, not a real limit.
  */
 function _learnRequestTokenLimit(modelForTracking, bodyText) {
   const limit = _parseRequestTokenLimit(bodyText);
-  if (!limit || limit <= 0) return;
+  if (!limit || limit < 500) return;
   if (_learnedRequestTokenLimits.get(modelForTracking) === limit) return;
   _learnedRequestTokenLimits.set(modelForTracking, limit);
   _dirtyModels.add(modelForTracking);

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -300,6 +300,42 @@ describe('local LLM fallback provider', () => {
   });
 });
 
+// In-memory Firestore stub matching the single-aggregate-doc layout
+// initScoreStore/_persistScoresToFirestore use:
+//   collection('ai_model_scores').doc('_all').get() / .set({models}, {merge:true})
+// Hoisted to module scope so both the local-fallback-exhaustion suite and the
+// learned-request-token-limit suite below share one implementation.
+function mockFirestore(store: Record<string, { models?: Record<string, unknown> }>) {
+  vi.doMock('firebase-admin', () => {
+    const admin: Record<string, unknown> = {
+      apps: [] as unknown[],
+      credential: { applicationDefault: () => ({}) },
+      initializeApp: () => { (admin.apps as unknown[]).push({}); },
+      firestore: () => ({
+        collection: () => ({
+          doc: (id: string) => ({
+            get: async () => ({
+              exists: store[id] != null,
+              data: () => store[id],
+            }),
+            set: async (data: { models?: Record<string, unknown> }, opts?: { merge?: boolean }) => {
+              if (opts?.merge && store[id]) {
+                store[id] = { ...store[id], ...data, models: { ...(store[id].models || {}), ...(data.models || {}) } };
+              } else {
+                store[id] = data;
+              }
+            },
+          }),
+          // Legacy per-model collection scan (one-time migration path in
+          // initScoreStore, used only when the aggregate doc has no models yet).
+          get: async () => ({ docs: [] }),
+        }),
+      }),
+    };
+    return { default: admin };
+  });
+}
+
 // Regression guard for the outage where `local/fallback` sat wrongly banned
 // for up to 24h, across every workflow run, after just 2 bad structured-JSON
 // outputs from the small quantized model. The daily-quota "exhausted until
@@ -328,40 +364,6 @@ describe('local LLM fallback exhaustion never persists past the run (Firestore)'
     if (prevCreds === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS; else process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCreds;
     vi.doUnmock('firebase-admin');
   });
-
-  // In-memory Firestore stub matching the single-aggregate-doc layout
-  // initScoreStore/_persistScoresToFirestore use:
-  //   collection('ai_model_scores').doc('_all').get() / .set({models}, {merge:true})
-  function mockFirestore(store: Record<string, { models?: Record<string, unknown> }>) {
-    vi.doMock('firebase-admin', () => {
-      const admin: Record<string, unknown> = {
-        apps: [] as unknown[],
-        credential: { applicationDefault: () => ({}) },
-        initializeApp: () => { (admin.apps as unknown[]).push({}); },
-        firestore: () => ({
-          collection: () => ({
-            doc: (id: string) => ({
-              get: async () => ({
-                exists: store[id] != null,
-                data: () => store[id],
-              }),
-              set: async (data: { models?: Record<string, unknown> }, opts?: { merge?: boolean }) => {
-                if (opts?.merge && store[id]) {
-                  store[id] = { ...store[id], ...data, models: { ...(store[id].models || {}), ...(data.models || {}) } };
-                } else {
-                  store[id] = data;
-                }
-              },
-            }),
-            // Legacy per-model collection scan (one-time migration path in
-            // initScoreStore, used only when the aggregate doc has no models yet).
-            get: async () => ({ docs: [] }),
-          }),
-        }),
-      };
-      return { default: admin };
-    });
-  }
 
   it('write path: exhausting local/fallback never sets exhaustedUntil; exhausting a remote model still does', async () => {
     const store: Record<string, { models?: Record<string, unknown> }> = {};
@@ -398,9 +400,119 @@ describe('local LLM fallback exhaustion never persists past the run (Firestore)'
       const loadLine = logSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('[ScoreStore] Loaded'));
       expect(loadLine).toBeDefined();
       // Only gpt-4o's ban should survive the restore — local/fallback's must not.
-      expect(loadLine).toMatch(/\(0 decayed, 1 still exhausted\)/);
+      expect(loadLine).toMatch(/\(0 decayed, 1 still exhausted, \d+ learned token limits\)/);
     } finally {
       logSpy.mockRestore();
     }
+  });
+});
+
+// Regression guard for the structural fix (run 28732970228, 2026-07-05): Groq's
+// TPM cap and two NVIDIA models' context-length caps were hit live in
+// production with no hardcoded entry to catch them, wasting a retry slot on
+// every fallback attempt. Instead of only hardcoding those two, the skip-guard
+// now learns any provider's numeric limit straight out of its first 413/400
+// body and remembers it — in-run immediately, cross-run via the same
+// Firestore aggregate doc already used for scores/exhaustion.
+describe('self-learning request-token-limit discovery (generalizes beyond hardcoded providers)', () => {
+  const prevCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  const prevGroqKey = process.env.GROQ_API_KEY;
+  const prevNvidiaKey = process.env.NVIDIA_API_KEY;
+  const prevForceChain = process.env.AI_MODELS_FORCE_CHAIN;
+  const prevFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = '/dev/null';
+    process.env.GROQ_API_KEY = 'test-key';
+    process.env.NVIDIA_API_KEY = 'test-key';
+    globalThis.fetch = (async () => { throw new Error('network disabled in test'); }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = prevFetch;
+    if (prevCreds === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS; else process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCreds;
+    if (prevGroqKey === undefined) delete process.env.GROQ_API_KEY; else process.env.GROQ_API_KEY = prevGroqKey;
+    if (prevNvidiaKey === undefined) delete process.env.NVIDIA_API_KEY; else process.env.NVIDIA_API_KEY = prevNvidiaKey;
+    if (prevForceChain === undefined) delete process.env.AI_MODELS_FORCE_CHAIN; else process.env.AI_MODELS_FORCE_CHAIN = prevForceChain;
+    vi.doUnmock('firebase-admin');
+  });
+
+  it('write path: a Groq TPM 413 (production shape) persists the parsed Limit as maxRequestTokens for that model only', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    process.env.AI_MODELS_FORCE_CHAIN = 'groq/openai/gpt-oss-120b';
+    globalThis.fetch = (async () => ({
+      ok: false,
+      status: 413,
+      text: async () => JSON.stringify({
+        error: {
+          message: 'Request too large for model `openai/gpt-oss-120b` in organization `org_01kjsfybv9epwv9jvhb9jz5yk5` service tier `on_demand` on tokens per minute (TPM): Limit 8000, Used 0, Requested 8277, Please try again in 2.077s.',
+          type: 'tokens',
+          code: 'rate_limit_exceeded',
+        },
+      }),
+    })) as unknown as typeof fetch;
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    await expect(mod.callLLM([{ role: 'user', content: 'hi' }], { maxRetriesPerModel: 1 })).rejects.toThrow('All AI models failed');
+
+    const persisted = store._all.models as Record<string, { maxRequestTokens?: number }>;
+    expect(persisted['groq__openai__gpt-oss-120b'].maxRequestTokens).toBe(8000);
+  });
+
+  it('write path: an NVIDIA context-length 400 persists (context − completion) as maxRequestTokens', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    process.env.AI_MODELS_FORCE_CHAIN = 'nvidia/nvidia/some-other-model';
+    globalThis.fetch = (async () => ({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({
+        error: {
+          message: "This model's maximum context length is 16384 tokens. However, you requested 17397 tokens (9397 in the messages, 8000 in the completion). Please reduce the length of the messages or completion.",
+        },
+      }),
+    })) as unknown as typeof fetch;
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    await expect(mod.callLLM([{ role: 'user', content: 'hi' }], { maxRetriesPerModel: 1 })).rejects.toThrow('All AI models failed');
+
+    const persisted = store._all.models as Record<string, { maxRequestTokens?: number }>;
+    expect(persisted['nvidia__nvidia__some-other-model'].maxRequestTokens).toBe(16384 - 8000);
+  });
+
+  it('restore path: a pre-existing learned limit is loaded on init and pre-flight-skips the model without ever calling fetch', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {
+      _all: {
+        models: {
+          'groq__openai__gpt-oss-120b': { modelId: 'groq/openai/gpt-oss-120b', score: 0, maxRequestTokens: 500 },
+        },
+      },
+    };
+    mockFirestore(store);
+    process.env.AI_MODELS_FORCE_CHAIN = 'groq/openai/gpt-oss-120b';
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    // initScoreStore() itself opportunistically probes free-model discovery
+    // endpoints (unrelated to the skip-guard under test here) — let that
+    // settle against the network-disabled default fetch from beforeEach
+    // before swapping in the call-tracking fetch below, so a discovery probe
+    // can't be mistaken for the model-invocation call this test forbids.
+    await mod.initScoreStore();
+
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('fetch should never be called — pre-flight skip-guard should have short-circuited');
+    }) as unknown as typeof fetch;
+
+    // ~2500 estimated tokens (chars/4 + safety margin) — comfortably over the
+    // learned 500-token cap restored from the store above.
+    const bigPrompt = 'x'.repeat(10_000);
+    await expect(mod.callLLM([{ role: 'user', content: bigPrompt }], { maxRetriesPerModel: 1 })).rejects.toThrow('All AI models failed');
+    expect(fetchCalled).toBe(false);
   });
 });


### PR DESCRIPTION
## Implementato

- `DEFAULT_REQUEST_TOKENS_BY_PROVIDER[PROVIDER.GROQ] = 8000` — closes the observed Groq tokens-per-minute HTTP 413 (4 models failing identically at ~8277-8310 estimated tokens in run 28732970228).
- `MODEL_MAX_REQUEST_TOKENS` entries for `nvidia/llama-3.1-nemotron-nano-vl-8b-v1` (8000) and `nvidia/nemotron-mini-4b-instruct` (3000) — closes the observed NVIDIA HTTP 400 "maximum context length" errors from the same run.
- **Structural fix (per session goal, not just a point patch):** self-learning request-token-limit discovery —
  - `_parseRequestTokenLimit(bodyText)` regex-parses the real numeric limit out of untruncated 413/400 error bodies (covers the context-length shape, the Groq TPM "Limit N" shape, and the GitHub Models "Max size: N tokens" shape).
  - `_learnRequestTokenLimit(modelForTracking, bodyText)` caches the parsed limit in a new `_learnedRequestTokenLimits` map and persists it through the existing Firestore aggregate-doc mechanism (`initScoreStore`/`_persistScoresToFirestore`), the same store already used for model scores/exhaustion.
  - Hooked into `_callOpenAICompatible` and `_callGeminiRaw` at the point where the untruncated error body is still available, before truncation/throw.
  - `callLLM`'s pre-flight skip-guard now takes `Math.min()` across the static `MODEL_MAX_REQUEST_TOKENS` map, the per-provider default, and any learned limit.
  - This means any provider/model (Cerebras, Mistral, HuggingFace, Cloudflare, Together, Fireworks, OpenRouter, or future Groq/NVIDIA models) that returns a parseable size-cap error is now caught after its first failure — in the same run and in future runs — without requiring a human to notice the pattern in logs and hardcode a new entry.
- Regression tests: 3 new tests in `tests/local-llm-fallback.test.ts` covering the learn-write path (Groq 413, NVIDIA 400 on a model NOT in the static map) and the learn-restore path (pre-flight skip without ever calling fetch). Fixed one pre-existing test whose log-format assertion broke due to the new learned-limits count in the `ScoreStore` log line. All 14 tests in the file pass.
- Sibling-pattern check (`check-sibling-patterns.mjs`) flagged 13 files sharing tokens with the diff (`HuggingFace`, `ScoreStore`, `initScoreStore`, `estimateRequestTokens`, `OpenRouter`, `gpt-oss-120b`). Manually inspected all 13 — confirmed false positives: `create-article.mjs`, `shared-jobs-crawler.mjs`, `batch-add-faq-to-articles.mjs`, `send-newsletter.mjs` only import the shared functions from `ai-models.mjs` (no independent copy of the token-cap construct); `backfill-small-images.mjs`, `evidence/constants.mjs`, `evidence/embeddingClient.mjs`, `free-translate.mjs`, `local-opus-mt.mjs`, `local-mt-translate.py` reference "HuggingFace" only in the context of local embedding/translation/image model downloads, unrelated to the LLM chat-completion cascade; `alerts/detectors/cost.mjs` and `smoke-test-ai-models.mjs` reference "OpenRouter" only in comments/alert strings; `llm-json-repair.mjs` references "gpt-oss-120b" only as an example model name in a comment. None contain their own 413/context-length handling or token-cap map.

## Non implementato (ancora)

Nessuno.