### PR TITLE
fix(job-alerts): close 3 geo-preference adversarial nits from PR #3146

### DIFF
--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -495,6 +495,17 @@ async function getFirestoreAdmin() {
 
 // ── Load jobs from data/jobs.json ────────────────────────────
 
+// Static floor for the 4 cities the subscriber-preference flags hardcode
+// (jobAlertMatching.mjs preferenceCities). Without it, a subscriber whose
+// home city has zero live jobs in today's crawl snapshot would fail to
+// resolve to "ti" via the dataset-derived cityToCanton index below and fall
+// through to CH-wide, even though same-canton jobs from nearby TI cities
+// exist (review nit on PR #3146, issue #3155). Exported for direct unit
+// testing — see tests/job-alert-geo-preference-pipeline.test.ts.
+export const STATIC_CITY_CANTON_FLOOR = {
+  lugano: 'ti', bellinzona: 'ti', mendrisio: 'ti', chiasso: 'ti',
+};
+
 // Returns the recent-job match pool AND a lightweight slug/id → geography index
 // over the FULL dataset. The index lets us recover the location of the job a
 // one-tap subscriber engaged with (`sourceJobSlug`) even when that job is older
@@ -511,7 +522,9 @@ function loadJobs() {
   // City → canton index over the FULL dataset, so the graduated geo preference
   // (#2993) can resolve a subscriber's preferred city (e.g. "bellinzona") to its
   // canton ("ti") and treat every TI job as in-area — not just exact-city hits.
-  const cityToCanton = new Map();
+  // Seeded with STATIC_CITY_CANTON_FLOOR; dataset entries below never override
+  // these (`!has` guard) since all four are unambiguously Ticino.
+  const cityToCanton = new Map(Object.entries(STATIC_CITY_CANTON_FLOOR));
   for (const j of jobs) {
     const geo = [j.location || j.addressLocality || '', j.canton || ''].filter(Boolean);
     const company = j.company || '';

--- a/services/jobAlertMatching.mjs
+++ b/services/jobAlertMatching.mjs
@@ -264,9 +264,21 @@ export function buildAlertProfile(alert, subscriber = null, extras = {}) {
     ...municipalityToCantons(sub.municipality).map((c) => c.toLowerCase()),
   ]);
 
+  // A raw 2-letter canton code (from a clicked/source job's geography) is
+  // already fully captured by preferredCantons above via lookupCanton.
+  // Leaving it in preferredLocations too would make partitionByGeoPreference's
+  // locTokenHit() treat the bare code as a city name — a redundant surface
+  // that could theoretically collide with an unrelated 2-letter token in a
+  // job's location text. Canton-level matching already covers this signal,
+  // so drop bare codes here instead of reasoning about token collisions
+  // downstream (review nit on PR #3146, issue #3155).
+  const preferredLocationNames = preferredLocations.filter(
+    (l) => !(l.length === 2 && SWISS_CANTONS.has(l)),
+  );
+
   return {
     hardKeywords, softTokens, company, locations, alertLocations, cantons, sectors, contractTypes,
-    specificJobIds, specificCompanyKey, preferredLocations, preferredCantons,
+    specificJobIds, specificCompanyKey, preferredLocations: preferredLocationNames, preferredCantons,
   };
 }
 

--- a/tests/job-alert-geo-preference-pipeline.test.ts
+++ b/tests/job-alert-geo-preference-pipeline.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Closes two adversarial nits raised on the PR #3146 review (graduated geo
+ * preference, issue #2993) that were left "unverified" rather than fixed —
+ * see issue #3155.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { buildAlertProfile, partitionByGeoPreference } from '../services/jobAlertMatching.mjs';
+import { filterUnsentJobs, normalizeSentMap } from '../scripts/lib/alert-sent-jobs.mjs';
+import { filterLiveJobs, STATIC_CITY_CANTON_FLOOR } from '../scripts/send-job-alerts.mjs';
+
+function job(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-id',
+    slug: 'job-slug',
+    slugByLocale: {},
+    title: 'Software Engineer',
+    description: 'We are hiring a backend software engineer in Ticino.',
+    company: 'Board International',
+    companyKey: 'board-international',
+    location: 'Lugano',
+    addressLocality: 'Lugano',
+    addressRegion: 'TI',
+    canton: 'TI',
+    contract: 'full-time',
+    sector: 'IT',
+    category: 'Software',
+    firstSeenAt: '2026-06-10T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('STATIC_CITY_CANTON_FLOOR (nit: cityToCanton coverage gap, PR #3146)', () => {
+  it('guarantees the 4 hardcoded city-preference flags resolve to Ticino regardless of today\'s crawl snapshot', () => {
+    // These are the same 4 cities jobAlertMatching.mjs's preferenceCities()
+    // treats as explicit TI signals — the dataset-derived cityToCanton index
+    // in loadJobs() must never be the ONLY way to resolve them, or a
+    // subscriber whose home city has zero live jobs today falls through to
+    // CH-wide instead of same-canton jobs from a nearby TI city.
+    expect(STATIC_CITY_CANTON_FLOOR).toEqual({
+      lugano: 'ti', bellinzona: 'ti', mendrisio: 'ti', chiasso: 'ti',
+    });
+  });
+
+  it('resolves a subscriber\'s home city to TI via buildAlertProfile even with an empty dataset-derived index', () => {
+    const profile = buildAlertProfile(
+      { keywords: ['infermiere'] },
+      { location_interest: 'Bellinzona' },
+      { cityToCanton: STATIC_CITY_CANTON_FLOOR }, // simulates today's snapshot having zero Bellinzona jobs
+    );
+    expect(profile.preferredCantons).toEqual(['ti']);
+  });
+});
+
+describe('geo-preference floor survives the full send pipeline (nit: minLocal vs per-email cap, PR #3146)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps in-area jobs ordered before out-of-area padding through dedup + live-check + final slice', async () => {
+    // Below GEO_PREFERENCE_MIN_LOCAL (5): 3 TI (in-area) + 3 BS (padding),
+    // so partitionByGeoPreference returns TI-first then BS (never starved).
+    const tiJobs = [0, 1, 2].map((i) => job({ id: `ti-${i}`, slug: `ti-${i}`, canton: 'TI', location: 'Lugano', addressLocality: 'Lugano', addressRegion: 'TI' }));
+    const bsJobs = [0, 1, 2].map((i) => job({ id: `bs-${i}`, slug: `bs-${i}`, canton: 'BS', location: 'Basel', addressLocality: 'Basel', addressRegion: 'BS' }));
+
+    const profile = buildAlertProfile(
+      { keywords: ['infermiere'] },
+      { location_interest: 'Lugano' },
+      { cityToCanton: { lugano: 'ti' } },
+    );
+    const ranked = partitionByGeoPreference([...tiJobs, ...bsJobs], profile);
+    expect(ranked.map((j) => j.canton)).toEqual(['TI', 'TI', 'TI', 'BS', 'BS', 'BS']);
+
+    // Dedup drops one already-sent TI job (filterUnsentJobs preserves order).
+    const sentMap = normalizeSentMap({ 'ti-1': Date.now() });
+    const deduped = filterUnsentJobs(ranked, sentMap, Date.now());
+    expect(deduped.map((j) => j.id)).toEqual(['ti-0', 'ti-2', 'bs-0', 'bs-1', 'bs-2']);
+
+    // Live-link check drops one BS job (filterLiveJobs preserves order too).
+    const fetchSpy = vi.fn(async (url: string) => ({ status: String(url).includes('bs-1') ? 404 : 200, ok: !String(url).includes('bs-1') }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const liveMatched = await filterLiveJobs(deduped, 'it', new Map());
+
+    // Final per-email cap (buildAlertEmail renders/slices the first 10).
+    const sentJobs = liveMatched.slice(0, 10);
+
+    expect(sentJobs.map((j) => j.id)).toEqual(['ti-0', 'ti-2', 'bs-0', 'bs-2']);
+    // The invariant the review nit left unverified: no out-of-area job ever
+    // precedes a surviving in-area job in what actually gets sent.
+    const firstBsIdx = sentJobs.findIndex((j) => j.canton === 'BS');
+    const lastTiIdx = sentJobs.map((j) => j.canton).lastIndexOf('TI');
+    expect(firstBsIdx).toBeGreaterThan(lastTiIdx);
+  });
+});

--- a/tests/job-alert-matching.test.ts
+++ b/tests/job-alert-matching.test.ts
@@ -312,6 +312,24 @@ describe('jobAlertMatching — profile geo preference (issue #2993)', () => {
     expect(profile.preferredCantons).toEqual(['ti']);
   });
 
+  it('drops the bare canton code from a clicked/source job\'s geography out of preferredLocations (review nit, PR #3146)', () => {
+    // loadJobs()'s locationIndex stores geo as [location, canton] (e.g.
+    // ['Lugano', 'TI']), so a raw 2-letter canton code legitimately reaches
+    // strongLocations. It must not survive into preferredLocations — the
+    // canton signal is already captured via preferredCantons, and keeping the
+    // bare code as a "location" would let partitionByGeoPreference's
+    // locTokenHit() match it against an unrelated 2-letter token in some
+    // other job's address text.
+    const profile = buildAlertProfile(
+      { keywords: ['infermiere'] },
+      {},
+      { strongLocations: ['lugano', 'ti'], cityToCanton },
+    );
+    expect(profile.preferredLocations).toEqual(['lugano']);
+    expect(profile.preferredLocations).not.toContain('ti');
+    expect(profile.preferredCantons).toEqual(['ti']);
+  });
+
   it('excludes passive viewed-job cities from the preference (only strong signals)', () => {
     // The send loop passes filter/clicked/source locations as strongLocations and
     // keeps passive viewed cities in behaviorLocations — only the former drive the split.


### PR DESCRIPTION
## Implementato

Closes the 3 low-risk adversarial nits the reviewer raised on PR #3146 (graduated geo preference, #2993) that follow-up issue #3155 never actually tracked (its body was a literal empty `PLACEHOLDER_BODY`):

1. **Canton-code / location-token collision surface** — a raw 2-letter canton code (from a clicked/source job's `[location, canton]` geography) could reach `preferredLocations` and get passed to `locTokenHit()` in `partitionByGeoPreference`, a redundant surface since canton-level matching is already fully covered by `preferredCantons` via `lookupCanton`. `services/jobAlertMatching.mjs` now strips bare 2-letter canton-code entries out of `preferredLocations` before returning the profile.
2. **`cityToCanton` dataset-snapshot coverage gap** — the city→canton index was built solely from today's crawl snapshot, so a subscriber whose home city had zero live jobs that day would fail to resolve to its canton entirely (falling through to CH-wide instead of same-canton jobs from a nearby city). `scripts/send-job-alerts.mjs` now seeds the index with a static floor (`STATIC_CITY_CANTON_FLOOR`) for the 4 cities the subscriber-preference flags already hardcode (lugano/bellinzona/mendrisio/chiasso → ti).
3. **`minLocal` floor vs. per-email cap interaction, untraced** — added a regression test (`tests/job-alert-geo-preference-pipeline.test.ts`) that runs a synthetic below-floor batch through `partitionByGeoPreference` → `filterUnsentJobs` → `filterLiveJobs` → the final per-email slice, and asserts in-area jobs never end up ordered after out-of-area padding in what actually gets sent. Confirms the existing code was already correct — this closes the "not verified" gap with a concrete trace rather than a code change.

Addresses #3155 — a multi-item follow-up aggregate, so not auto-closed by keyword (per `docs/AGENTS-HISTORY.md#multi-issue-close`); its 2 tracked items (backfill script + these 3 review nits) are now both done, so #3155 will be closed manually once this PR merges.

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] `npx vitest run tests/job-alert-matching.test.ts tests/job-alert-geo-preference-pipeline.test.ts tests/alert-sent-jobs.test.ts tests/job-alert-live-link-check.test.ts` → 71/71 passed
- [x] `node scripts/ci/check-sibling-patterns.mjs` → 18 flagged files reviewed; all are name-token-only overlaps (SWISS_CANTONS/cityToCanton/locTokenHit reused across unrelated crawler-parser/migration/newsletter-ranking code), none share the actual antipattern fixed here — confirmed false positives, no further changes needed
