### PR TITLE
fix(seo): shadowed svizzera article dateModified fallback + hreflang absence coverage

### DIFF
--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -20,7 +20,7 @@ import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
-import { loadSwissArticleCanonicalOverrides, resolveSwissArticleCanonicalUrl } from './shared/swissArticleCanonicalOverrides';
+import { loadSwissArticleCanonicalOverrides, resolveSwissArticleCanonicalUrl, resolveShadowedArticleWinnerSlug } from './shared/swissArticleCanonicalOverrides';
 
 export function ogPagesPlugin(rootDir: string): Plugin {
  return {
@@ -303,8 +303,14 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  // reference that the regex can't capture, so we need these external sources.
  const seoDateMod = b.match(/"dateModified":\s*"([^"]+)"/)?.[1] ?? '';
  const articleSlug = cp.replace(SECTION.canonicalPrefix, '').replace(/\/$/, '');
+ // Issue #3368 item 1: a shadowed svizzera article's own slug was dropped
+ // from sitemap-blog-ch.xml (PR #3360), so sitemapLastmodBySlug misses it —
+ // fall back to the authoritative winner's still-present <lastmod> (same
+ // near-duplicate content) before the static SEO literal.
+ const winnerSlug = resolveShadowedArticleWinnerSlug(articleSlug, swissArticleCanonicalOverrides);
  const dateMod = articleUpdatedAtById[articleId]
  || sitemapLastmodBySlug[articleSlug]
+ || (winnerSlug ? sitemapLastmodBySlug[winnerSlug] : '')
  || seoDateMod;
 
  // Extract source structuredData @type and author format

--- a/build-plugins/shared/swissArticleCanonicalOverrides.ts
+++ b/build-plugins/shared/swissArticleCanonicalOverrides.ts
@@ -74,3 +74,25 @@ export function resolveSwissArticleCanonicalUrl(
 ): string {
   return overrides[slug] || defaultUrl;
 }
+
+/**
+ * Issue #3368 item 1: a shadowed article's own slug is deliberately absent
+ * from `sitemap-blog-ch.xml` (see the CORRECTION note above), so a
+ * `<lastmod>`-derived JSON-LD `dateModified` fallback keyed on the page's
+ * own slug always misses for shadowed pages. Since the shadowed and
+ * authoritative pages are a near-duplicate pair about the same content,
+ * the authoritative winner's still-present sitemap `<lastmod>` is a valid
+ * freshness proxy — this resolves the winner's own slug (last URL path
+ * segment) from the same override map already loaded for canonical/og:url,
+ * so callers can look it up in `sitemapLastmodBySlug` instead of falling
+ * straight through to a static SEO-literal date. Returns `undefined` for a
+ * non-shadowed slug (no override entry).
+ */
+export function resolveShadowedArticleWinnerSlug(
+  slug: string,
+  overrides: Readonly<Record<string, string>>,
+): string | undefined {
+  const winnerUrl = overrides[slug];
+  if (!winnerUrl) return undefined;
+  return winnerUrl.replace(/\/$/, '').split('/').pop() || undefined;
+}

--- a/tests/blog-slugs-sitemap-sync.test.ts
+++ b/tests/blog-slugs-sitemap-sync.test.ts
@@ -196,19 +196,24 @@ describe('SWISS_SLUGS ↔ sitemap-blog-ch.xml / sitemap-news.xml sync (gate: pre
     ).toHaveLength(0);
   });
 
-  it('every shadowed (canonical-overridden) SWISS_SLUG is ABSENT from sitemap-blog-ch.xml', async () => {
+  it('every shadowed (canonical-overridden) SWISS_SLUG is ABSENT from sitemap-blog-ch.xml (IT: <loc>, others: hreflang href)', async () => {
     const { SWISS_SLUGS } = await import('../services/routerSwissData');
     const { loadSwissArticleCanonicalOverrides } = await import('../build-plugins/shared/swissArticleCanonicalOverrides');
     const xml = readFileSync(path.resolve(__dirname, '..', 'public', 'sitemap-blog-ch.xml'), 'utf-8');
-    const { locUrls } = extractSitemapUrls(xml);
+    const { locUrls, hreflangUrls } = extractSitemapUrls(xml);
     const overrides = loadSwissArticleCanonicalOverrides({ readFileSync }, path.resolve(__dirname, '..', 'data', 'swiss-article-canonical-overrides.json'));
 
     const stillPresent: string[] = [];
     for (const [articleId, slugMap] of Object.entries(SWISS_SLUGS as Record<string, Record<string, string>>)) {
       const itSlug = (slugMap as Record<string, string>).it;
       if (!itSlug || !Object.prototype.hasOwnProperty.call(overrides, itSlug)) continue;
-      const url = `${SWISS_URL_BASE.it}${itSlug}/`;
-      if (locUrls.has(url)) stillPresent.push(`${articleId} [it]: ${url}`);
+      for (const [locale, slug] of Object.entries(slugMap)) {
+        const base = SWISS_URL_BASE[locale];
+        if (!base) continue;
+        const url = `${base}${slug}/`;
+        const present = locale === 'it' ? locUrls.has(url) : hreflangUrls.get(locale)?.has(url);
+        if (present) stillPresent.push(`${articleId} [${locale}]: ${url}`);
+      }
     }
 
     expect(

--- a/tests/sitemap-slug-integrity.test.ts
+++ b/tests/sitemap-slug-integrity.test.ts
@@ -304,7 +304,13 @@ describe('Swiss article sitemap slug integrity', () => {
   // the sitemap-drop fix so a future re-add (e.g. a careless create-article
   // sync) regresses the hard self-canonical CI gate instead of failing
   // silently.
-  describe('every shadowed (canonical-overridden) article is ABSENT from sitemap-blog-ch.xml', () => {
+  //
+  // Issue #3368 item 2: the IT-<loc>-only check below was blind to a
+  // partial-removal regression (IT loc dropped, EN/DE/FR hreflang alternates
+  // left stray) — it would pass even if a shadowed article's hreflang hrefs
+  // stayed in the sitemap. Mirrors the locale-specific branch already used by
+  // `registerHreflangIntegrityChecks` to check EN/DE/FR too.
+  describe('every shadowed (canonical-overridden) article is ABSENT from sitemap-blog-ch.xml (IT loc + EN/DE/FR hreflang)', () => {
     for (const id of shadowedSwissArticleIds) {
       it(`article "${id}" → IT slug is NOT in sitemap-blog-ch.xml`, () => {
         const itSlug = SWISS_SLUGS[id]?.it;
@@ -314,6 +320,18 @@ describe('Swiss article sitemap slug integrity', () => {
           `Article "${id}" (slug: ${itSlug}) is canonical-overridden but still listed in sitemap-blog-ch.xml — violates "Sitemap <loc> URLs MUST self-canonicalize"`
         ).toBe(false);
       });
+
+      for (const locale of ALT_LOCALES) {
+        it(`article "${id}" → ${locale} slug has NO hreflang alternate in sitemap-blog-ch.xml`, () => {
+          const slug = SWISS_SLUGS[id]?.[locale];
+          expect(slug, `Article "${id}" has no ${locale} slug in SWISS_SLUGS`).toBeTruthy();
+          const hreflangSlugs = extractHreflangSlugs(swissSitemap, 'svizzera', locale);
+          expect(
+            hreflangSlugs.includes(slug!),
+            `Article "${id}" (${locale} slug: ${slug}) is canonical-overridden but still has a hreflang alternate in sitemap-blog-ch.xml — violates self-canonical gate`
+          ).toBe(false);
+        });
+      }
     }
   });
 

--- a/tests/swiss-article-canonical-overrides.test.ts
+++ b/tests/swiss-article-canonical-overrides.test.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import {
   loadSwissArticleCanonicalOverrides,
   resolveSwissArticleCanonicalUrl,
+  resolveShadowedArticleWinnerSlug,
 } from '@/build-plugins/shared/swissArticleCanonicalOverrides';
 
 // Issue #3010 item 1 (follow-up to PR #3000 "de-collide duplicate svizzera
@@ -146,5 +147,23 @@ describe('resolveSwissArticleCanonicalUrl', () => {
   it('falls back to defaultUrl (self-canonical) for any slug with no override entry', () => {
     expect(resolveSwissArticleCanonicalUrl('winner-slug', overrides, 'https://frontaliereticino.ch/articoli-svizzera/winner-slug/'))
       .toBe('https://frontaliereticino.ch/articoli-svizzera/winner-slug/');
+  });
+});
+
+// Issue #3368 item 1: sitemapLastmodBySlug (build-plugins/ogPagesPlugin.ts
+// JSON-LD dateModified fallback 2) is keyed by a page's own slug, which is
+// deliberately absent from the sitemap for shadowed articles (see the
+// CORRECTION note above) — so it always misses for them. This resolver lets
+// the plugin fall back to the authoritative winner's own slug instead, whose
+// sitemap <lastmod> is still present.
+describe('resolveShadowedArticleWinnerSlug', () => {
+  const overrides = { 'shadowed-slug': 'https://frontaliereticino.ch/articoli-svizzera/winner-slug/' };
+
+  it('returns the winner slug (last URL path segment) for a shadowed slug', () => {
+    expect(resolveShadowedArticleWinnerSlug('shadowed-slug', overrides)).toBe('winner-slug');
+  });
+
+  it('returns undefined for any slug with no override entry (not shadowed)', () => {
+    expect(resolveShadowedArticleWinnerSlug('winner-slug', overrides)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Implementato

- **Item 1 (JSON-LD dateModified fallback)**: `build-plugins/ogPagesPlugin.ts` — since PR #3360 drops a shadowed svizzera article's own `<url>` block from `sitemap-blog-ch.xml`, the `sitemapLastmodBySlug[articleSlug]` fallback (fallback 2) always misses for those 3 pages, and `articleUpdatedAtById` (fallback 1) is always empty for svizzera articles (never set `updatedAt`) — so `dateModified` was silently falling through to the static `seoDateMod` literal. Added a new fallback that resolves the canonical-override winner's own slug (via a new `resolveShadowedArticleWinnerSlug()` helper in `build-plugins/shared/swissArticleCanonicalOverrides.ts`, reusing the override map already loaded in this section) and looks up *its* still-present sitemap `<lastmod>` before falling to the literal. Unit-tested in `tests/swiss-article-canonical-overrides.test.ts`.
- **Item 2 (test hreflang coverage)**: the shadowed-article "must be ABSENT from sitemap" assertions in `tests/blog-slugs-sitemap-sync.test.ts:199` and `tests/sitemap-slug-integrity.test.ts:307` only checked the IT `<loc>`, never the EN/DE/FR hreflang alternates in the same `<url>` block — a partial-removal regression (IT dropped, hreflang left stray) would have passed both tests silently. Both now mirror the locale-specific branch already used elsewhere in each file to check hreflang too.

Verified: `npx vitest run tests/swiss-article-canonical-overrides.test.ts tests/blog-slugs-sitemap-sync.test.ts tests/sitemap-slug-integrity.test.ts tests/seo-completeness.test.ts` → all green (74805 tests). GitNexus impact on `ogPagesPlugin` (upstream): LOW risk, single caller (`vite.config.ts`).

## Non implementato (ancora)

Nessuno.

Addresses item 1 and item 2 of `#3368` (both completed above, in full — not a partial fix). No closing keyword used here on purpose: `#3368` is a 2-item follow-up aggregate, and the PR-body contract gate blocks auto-close on aggregate issues to prevent a partial fix from prematurely closing multi-item scope (incident #3050 → #3036). Since both items are done in this PR, `#3368` will be marked done by hand once this merges, citing this PR.
