### PR TITLE
fix(border-webcam): resolve 3 false/dead webcam alerts (#3438)

### DIFF
--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -17,6 +17,13 @@ export interface WebcamRef {
  refreshIntervalMs?: number;
  /** Optional explicit license note shown in <figcaption>. */
  license?: string;
+ /**
+  * Per-webcam override for the watchdog's MIN_WEBCAM_BYTES floor
+  * (scripts/check-border-data-health.mjs). Some vendors legitimately serve a
+  * much smaller real JPEG than the ~10KB Ticino-GIF default; without an
+  * override the watchdog mis-flags them as broken (issue #3438).
+  */
+ minBytes?: number;
 }
 
 export interface BorderCrossing {
@@ -267,11 +274,18 @@ export const borderCrossings: BorderCrossing[] = [
  tips: 'border.tips.lanzoArogno',
  webcams: [
  {
- label: "Lago di Lugano – vista da Lanzo d'Intelvi (SkylineWebcams)",
- imageUrl: 'https://cdn.skylinewebcams.com/live5540.jpg',
- sourceName: 'SkylineWebcams',
- sourceUrl: 'https://www.skylinewebcams.com/en/webcam/italia/lombardia/como/lago-di-lugano.html',
+ // SkylineWebcams retired the hotlinkable snapshot endpoint (live5540.jpg
+ // now returns a 200 with a static "404 Not Found" HTML stub cached since
+ // 2021 — genuinely dead, not a monitor false-positive; verified 2026-07-05,
+ // issue #3438). Replaced with the same underlying camera (id 5540) served
+ // directly by its originating vendor, visioray — already trusted elsewhere
+ // in this file for Zenna-Dirinella (same low-res JPEG class, see minBytes).
+ label: "Lago di Lugano – vista da Lanzo d'Intelvi",
+ imageUrl: 'https://weather-cams.visioray.com/snap/5540.jpg',
+ sourceName: "Webcam Lago di Lugano – Lanzo d'Intelvi",
+ sourceUrl: 'https://www.ilmeteo.it/webcam/Lanzo+d%27Intelvi',
  refreshIntervalMs: 300000,
+ minBytes: 4000,
  },
  ],
  },
@@ -476,6 +490,9 @@ export const borderCrossings: BorderCrossing[] = [
  sourceName: '4Insiders Weather Webcam',
  sourceUrl: 'https://www.4insiders.webcam/webcam/arzo/10557',
  refreshIntervalMs: 300000,
+ // Vendor serves a real ~2.6-3.7KB JPEG thumbnail (verified 2026-07-05,
+ // issue #3438) — below the ~10KB Ticino-GIF default floor.
+ minBytes: 1500,
  },
  ],
  },
@@ -579,6 +596,9 @@ export const borderCrossings: BorderCrossing[] = [
  sourceName: 'Webcam Maccagno – Lago Maggiore',
  sourceUrl: 'https://www.ilmeteo.it/webcam/Maccagno',
  refreshIntervalMs: 300000,
+ // Vendor serves a real ~6.6-8.9KB JPEG (verified 2026-07-05, issue #3438)
+ // — below the ~10KB Ticino-GIF default floor.
+ minBytes: 4000,
  },
  ],
  },

--- a/scripts/check-border-data-health.mjs
+++ b/scripts/check-border-data-health.mjs
@@ -199,8 +199,8 @@ export function evaluateWebcamResult(result, minBytes = MIN_WEBCAM_BYTES) {
 /**
  * Collect the unique webcam image URLs (with the crossings each serves) from the
  * borderCrossings registry. Pure: takes the array, returns a dedup map.
- * @param {Array<{name?: string, webcams?: Array<{imageUrl?: string, label?: string}>}>} crossings
- * @returns {Map<string, {url: string, crossings: string[], label: string|null}>}
+ * @param {Array<{name?: string, webcams?: Array<{imageUrl?: string, label?: string, minBytes?: number}>}>} crossings
+ * @returns {Map<string, {url: string, crossings: string[], label: string|null, minBytes: number|undefined}>}
  */
 export function collectWebcamUrls(crossings) {
   const map = new Map();
@@ -208,7 +208,7 @@ export function collectWebcamUrls(crossings) {
     for (const w of c?.webcams || []) {
       const url = w?.imageUrl;
       if (!url) continue;
-      if (!map.has(url)) map.set(url, { url, crossings: [], label: w?.label ?? null });
+      if (!map.has(url)) map.set(url, { url, crossings: [], label: w?.label ?? null, minBytes: w?.minBytes });
       map.get(url).crossings.push(c?.name ?? '(unnamed)');
     }
   }
@@ -331,9 +331,9 @@ async function main() {
   }
   const brokenWebcams = [];
   let indeterminateWebcams = 0;
-  for (const { url, crossings: served, label } of webcamUrls.values()) {
+  for (const { url, crossings: served, label, minBytes } of webcamUrls.values()) {
     const result = await fetchWebcam(url);
-    const verdict = evaluateWebcamResult(result);
+    const verdict = evaluateWebcamResult(result, minBytes ?? MIN_WEBCAM_BYTES);
     if (verdict.broken) {
       brokenWebcams.push({ url, served, label, reason: verdict.reason });
       lines.push(`❌ WEBCAM BROKEN: ${url} (${verdict.reason}) — serves: ${served.join(', ')}`);

--- a/tests/check-border-data-health.test.ts
+++ b/tests/check-border-data-health.test.ts
@@ -179,6 +179,16 @@ describe('collectWebcamUrls', () => {
     expect(collectWebcamUrls([]).size).toBe(0);
     expect(collectWebcamUrls(undefined as unknown as []).size).toBe(0);
   });
+
+  it('carries a per-webcam minBytes override through to the map entry (issue #3438)', () => {
+    const crossings = [
+      { name: 'Zenna-Dirinella', webcams: [{ imageUrl: 'https://x/small.jpg', label: 'Small', minBytes: 4000 }] },
+      { name: 'Chiasso Centro', webcams: [{ imageUrl: 'https://x/a.gif', label: 'A' }] },
+    ];
+    const map = collectWebcamUrls(crossings);
+    expect(map.get('https://x/small.jpg')!.minBytes).toBe(4000);
+    expect(map.get('https://x/a.gif')!.minBytes).toBeUndefined();
+  });
 });
 
 describe('isStalenessCheckActive (active-window gate)', () => {


### PR DESCRIPTION
## Implementato

- `WebcamRef.minBytes?: number` — per-webcam override for the watchdog's fixed `MIN_WEBCAM_BYTES` (10KB) floor, wired through `collectWebcamUrls` → `evaluateWebcamResult(result, minBytes ?? MIN_WEBCAM_BYTES)` in `scripts/check-border-data-health.mjs`. Fixes 2 confirmed false-positive vendors that legitimately serve smaller-than-10KB real JPEGs:
  - Saltrio-Arzo (webcam-4insiders, `10557.jpg`) → `minBytes: 1500` (verified ~2.6-3.7KB real JPEG, 2026-07-05)
  - Zenna-Dirinella (`weather-cams.visioray.com/snap/3590.jpg`) → `minBytes: 4000` (verified ~6.6-8.9KB real JPEG, 2026-07-05)
- Replaced the genuinely dead Lanzo d'Intelvi-Arogno webcam: `cdn.skylinewebcams.com/live5540.jpg` now serves a cached 404 HTML stub since 2021 (confirmed via content inspection, not a monitor false-positive). Replaced with the same physical camera (id 5540) served live by `weather-cams.visioray.com`, the same vendor already trusted for Zenna-Dirinella in this file. Verified live via curl (200, `image/jpeg`, `Last-Modified` matching request time).
- New test in `tests/check-border-data-health.test.ts` covering `minBytes` propagation through `collectWebcamUrls`.
- Full border test suite green (92/92 across `check-border-data-health.test.ts`, `border-wait-webcam.test.ts`, `border-wait-pages.test.ts`, `border-wait-og-webcam.test.ts`).

## Non implementato (ancora)

Nessuno.