### PR TITLE
Warn on capped crawler listings to prevent silent job truncation (#3436)

### DIFF
--- a/scripts/lib/bachtelen-job-parser.mjs
+++ b/scripts/lib/bachtelen-job-parser.mjs
@@ -21,7 +21,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify } from './crawler-template.mjs';
+import { slugify, warnIfListingAtCap } from './crawler-template.mjs';
 import {
   decodeEntities,
   normalizeSpace,
@@ -37,7 +37,8 @@ export const BACHTELEN_KEY = 'bachtelen';
 export const BACHTELEN_COMPANY_NAME = 'Stiftung Bachtelen';
 export const BACHTELEN_COMPANY_DOMAIN = 'bachtelen.ch';
 
-const API_URL = 'https://www.bachtelen.ch/wp-json/wp/v2/job-listings?per_page=50';
+const LISTING_PAGE_CAP = 50;
+const API_URL = `https://www.bachtelen.ch/wp-json/wp/v2/job-listings?per_page=${LISTING_PAGE_CAP}`;
 const PUBLIC_CAREER_URL = 'https://www.bachtelen.ch/arbeiten-bei-uns/offene-stellen/';
 
 const DEFAULT_CITY = 'Grenchen';
@@ -112,6 +113,7 @@ export async function fetchAllBachtelenJobs() {
   }
 
   console.log(`  📋 ${records.length} job listings from WP REST\n`);
+  warnIfListingAtCap({ label: 'Bachtelen WP REST listing', count: records.length, cap: LISTING_PAGE_CAP });
   const todayIso = new Date().toISOString().slice(0, 10);
   const jobs = [];
 

--- a/scripts/lib/benteler-job-parser.mjs
+++ b/scripts/lib/benteler-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { JSDOM } from 'jsdom';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace as _normalizeSpace, fetchHtml, fetchJson } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace as _normalizeSpace, fetchHtml, fetchJson, warnIfListingAtCap } from './crawler-template.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
 import { inferAnyCanton, isTargetSwissLocation } from './target-swiss-locations.mjs';
 import { assertJsonListShapeMultiKey } from './assert-json-list-shape.mjs';
@@ -33,9 +33,10 @@ const HQ = getCompanyDefaults('benteler');
  * We try to discover the SuccessFactors API endpoint and fall back to
  * HTML scraping.
  */
+const SF_API_LIMIT = 50;
 const SF_API_URLS = [
-  'https://career.benteler.com/api/jobs?country=CH&limit=50',
-  'https://career.benteler.com/api/v1/jobs?location=Switzerland&limit=50',
+  `https://career.benteler.com/api/jobs?country=CH&limit=${SF_API_LIMIT}`,
+  `https://career.benteler.com/api/v1/jobs?location=Switzerland&limit=${SF_API_LIMIT}`,
 ];
 
 /* ── Helpers ───────────────────────────────────────────────── */
@@ -154,6 +155,7 @@ async function trySuccessFactorsApi() {
       });
       if (items.length > 0) {
         console.log(`   API returned ${items.length} jobs`);
+        warnIfListingAtCap({ label: 'Benteler SuccessFactors listing', count: items.length, cap: SF_API_LIMIT });
         return items;
       }
     } catch (err) {

--- a/scripts/lib/bkw-job-parser.mjs
+++ b/scripts/lib/bkw-job-parser.mjs
@@ -25,7 +25,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, fetchHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, fetchHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -39,6 +39,7 @@ const CAREER_URL = 'https://job.bkw.com/?lang=en';
 // returns all open positions in a single response.
 const LISTING_URL = 'https://job.bkw.com/?lang=en';
 const LISTING_HOST = 'job.bkw.com';
+const LISTING_PAGE_CAP = 2000;
 const SECTOR = 'Energy / Buildings / Infrastructure (utilities & engineering services)';
 
 // Realistic browser UA — the front (www.bkw.ch) is Akamai-protected and 403s
@@ -179,7 +180,7 @@ async function fetchListingHtml() {
         Accept: 'text/html,application/xhtml+xml',
         'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
       },
-      body: 'offset=0&limit=2000&lang=en&query=&place=&radius=50000',
+      body: `offset=0&limit=${LISTING_PAGE_CAP}&lang=en&query=&place=&radius=50000`,
       signal: controller.signal,
     });
     if (!res.ok) {
@@ -285,10 +286,11 @@ async function enrichListing(row) {
  * Returns an array of raw listing objects ready for the assembly loop.
  */
 async function fetchJobListings() {
-  console.log(`   Fetching listing: POST ${LISTING_URL} (limit=2000)`);
+  console.log(`   Fetching listing: POST ${LISTING_URL} (limit=${LISTING_PAGE_CAP})`);
   const html = await fetchListingHtml();
   const rows = parseListingRows(html);
   console.log(`  📋 Listing rows: ${rows.length}`);
+  warnIfListingAtCap({ label: 'BKW Career Center listing', count: rows.length, cap: LISTING_PAGE_CAP });
 
   // Cheap pre-filter: drop the obvious German/Austrian cities before we pay
   // for a detail-page fetch. inferSwissTargetCanton returns null for them.

--- a/scripts/lib/bucher-suter-job-parser.mjs
+++ b/scripts/lib/bucher-suter-job-parser.mjs
@@ -54,7 +54,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, normalizeSpace, normalizeDescriptionSpace, warnIfListingAtCap } from './crawler-template.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
 import { inferSwissTargetCanton, canonicalSwissCityName, findSwissCityInText } from './target-swiss-locations.mjs';
 import {
@@ -77,7 +77,8 @@ const HQ = getCompanyDefaults(BUCHER_SUTER_KEY) || {
 };
 
 const BASE_URL = 'https://www.bucher-suter.com';
-const API_URL = `${BASE_URL}/wp-json/wp/v2/job-listings?per_page=50`;
+const LISTING_PAGE_CAP = 50;
+const API_URL = `${BASE_URL}/wp-json/wp/v2/job-listings?per_page=${LISTING_PAGE_CAP}`;
 
 /* ── Discovery: WordPress REST API listing metadata ─────────────────── */
 
@@ -199,6 +200,7 @@ export async function fetchAllBucherSuterJobs() {
   }
 
   console.log(`   📋 WordPress job listings found: ${listings.length}`);
+  warnIfListingAtCap({ label: 'Bucher + Suter WP REST listing', count: listings.length, cap: LISTING_PAGE_CAP });
 
   const jobs = [];
   let skippedNonSwiss = 0;

--- a/scripts/lib/canton-valais-job-parser.mjs
+++ b/scripts/lib/canton-valais-job-parser.mjs
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { JSDOM } from 'jsdom';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace as _normalizeSpace, fetchHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace as _normalizeSpace, fetchHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 import { assertJsonListShapeMultiKey } from './assert-json-list-shape.mjs';
@@ -153,6 +153,10 @@ async function tryServiceNowApi() {
         });
         if (items.length > 0) {
           console.log(`   ServiceNow API returned ${items.length} items`);
+          const limitParam = new URL(apiUrl).searchParams.get('sysparm_limit');
+          if (limitParam) {
+            warnIfListingAtCap({ label: 'Canton du Valais listing', count: items.length, cap: Number(limitParam) });
+          }
           return items;
         }
       } else {

--- a/scripts/lib/clienia-ag-job-parser.mjs
+++ b/scripts/lib/clienia-ag-job-parser.mjs
@@ -18,7 +18,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify } from './crawler-template.mjs';
+import { slugify, warnIfListingAtCap } from './crawler-template.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -32,7 +32,8 @@ export const CLIENIA_AG_KEY = 'clienia-ag';
 export const CLIENIA_AG_COMPANY_NAME = 'Clienia AG';
 export const CLIENIA_AG_COMPANY_DOMAIN = 'clienia.ch';
 
-const API_URL = 'https://www.clienia.ch/wp-json/wp/v2/jobs?per_page=100&_fields=id,slug,link,title,date,location';
+const LISTING_PAGE_CAP = 100;
+const API_URL = `https://www.clienia.ch/wp-json/wp/v2/jobs?per_page=${LISTING_PAGE_CAP}&_fields=id,slug,link,title,date,location`;
 const POLITE_DELAY_MS = 250;
 
 export function isCleniaAgJob(job) {
@@ -101,6 +102,7 @@ export async function fetchAllCleniaAgJobs() {
     return [];
   }
   console.log(`  ✓ ${listings.length} jobs from WP REST`);
+  warnIfListingAtCap({ label: 'Clienia AG WP REST listing', count: listings.length, cap: LISTING_PAGE_CAP });
   console.log(`  📄 Fetching detail pages for rich descriptions...`);
 
   const todayIso = new Date().toISOString().slice(0, 10);

--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -646,6 +646,32 @@ export async function fetchHtmlWithCookies(url, options = {}) {
  *
  * Usage: `main().catch((err) => exitCrawlerOnError(err, 'Company Label'));`
  */
+/**
+ * Warn when a single-shot listing fetch (fixed page-size/limit query param,
+ * no offset pagination) comes back with exactly `cap` results — the
+ * canonical signal that the real listing count may have exceeded the
+ * hardcoded cap and been silently truncated (issue #3436). If the API
+ * response carries its own `total`/`count` metadata, pass it as `total` for
+ * a precise check instead of the `count === cap` heuristic.
+ *
+ * Pure logging — never throws, never changes control flow.
+ */
+export function warnIfListingAtCap({ label, count, cap, total }) {
+  if (typeof total === 'number' && total > count) {
+    console.warn(
+      `⚠️  ${label}: API reports ${total} total listings but only ${count} were fetched (cap=${cap}). Listing is truncated — add pagination.`,
+    );
+    return true;
+  }
+  if (typeof total !== 'number' && count === cap) {
+    console.warn(
+      `⚠️  ${label}: fetched exactly the cap (${cap}) with no total/count field to verify completeness. If the real listing count ever exceeds ${cap}, jobs will be silently dropped — verify live count or add pagination.`,
+    );
+    return true;
+  }
+  return false;
+}
+
 export function exitCrawlerOnError(err, label = 'crawler') {
   if (isConnectionLevelFetchError(err)) {
     console.log(

--- a/scripts/lib/giardino-job-parser.mjs
+++ b/scripts/lib/giardino-job-parser.mjs
@@ -32,7 +32,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace, warnIfListingAtCap } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -41,7 +41,8 @@ export const GIARDINO_KEY = 'giardino';
 export const GIARDINO_COMPANY_NAME = 'Giardino Group';
 export const GIARDINO_COMPANY_DOMAIN = 'giardinohotels.ch';
 
-const API_URL = 'https://giardinohotels.ch/wp-json/wp/v2/jobs?per_page=50';
+const LISTING_PAGE_CAP = 50;
+const API_URL = `https://giardinohotels.ch/wp-json/wp/v2/jobs?per_page=${LISTING_PAGE_CAP}`;
 const SITE_BASE = 'https://giardinohotels.ch';
 const UA =
   process.env.JOBS_CRAWLER_USER_AGENT ||
@@ -352,6 +353,7 @@ export async function fetchAllGiardinoJobs() {
   }
 
   console.log(`  📋 WordPress jobs found: ${listings.length}`);
+  warnIfListingAtCap({ label: 'Giardino Group WP REST listing', count: listings.length, cap: LISTING_PAGE_CAP });
 
   const jobs = [];
   for (const listing of listings) {

--- a/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
+++ b/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
@@ -24,7 +24,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { assertJsonListShape } from './assert-json-list-shape.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -36,6 +36,7 @@ export const HOCHGEBIRGSKLINIK_DAVOS_COMPANY_DOMAIN = 'hochgebirgsklinik.ch';
 const CAREER_URL = 'https://karriere.hochgebirgsklinik.ch/';
 const TYPESENSE_PROXY_URL = 'https://api.my-job-shop.com/api/typesense/multi_search';
 const JOB_SHOP_ID = '9c3b04cb-7265-5acb-a208-199c8a9d547a';
+const TYPESENSE_PAGE_CAP = 250;
 
 const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
   || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
@@ -288,7 +289,7 @@ async function fetchJobListings(apiKey) {
           collection: 'offers',
           q: '*',
           query_by: 'title',
-          per_page: 250,
+          per_page: TYPESENSE_PAGE_CAP,
         }],
       }),
     });
@@ -302,6 +303,7 @@ async function fetchJobListings(apiKey) {
 
     const hits = assertJsonListShape(results, { key: 'hits', source: HOCHGEBIRGSKLINIK_DAVOS_KEY });
     console.log(`  📊 Typesense found: ${results.found} jobs, returned: ${hits.length}`);
+    warnIfListingAtCap({ label: 'Hochgebirgsklinik Davos listing', count: hits.length, cap: TYPESENSE_PAGE_CAP, total: results.found });
     return hits.map((h) => h.document);
   } catch (err) {
     clearTimeout(timer);

--- a/scripts/lib/ksgl-job-parser.mjs
+++ b/scripts/lib/ksgl-job-parser.mjs
@@ -33,7 +33,7 @@
  *     step fills in fr/it/en.
  */
 import { createHash } from 'node:crypto';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -46,6 +46,7 @@ export const KSGL_COMPANY_DOMAIN = 'ksgl.ch';
 const CAREER_URL = 'https://www.ksgl.ch/karriere';
 const PROSPECTIVE_TENANT = '1000665';
 const LISTING_URL = `https://ohws.prospective.ch/public/v1/careercenter/${PROSPECTIVE_TENANT}/`;
+const LISTING_PAGE_CAP = 200;
 const JOBS_HOST = 'jobs.ksgl.ch';
 
 const DEFAULT_CANTON = 'GL';
@@ -249,7 +250,7 @@ export async function fetchAllKsglJobs() {
   // Step 1: POST listing with limit=200 to grab every advert in one page.
   const html = await safeFetch(LISTING_URL, {
     method: 'POST',
-    body: 'offset=0&limit=200&lang=de',
+    body: `offset=0&limit=${LISTING_PAGE_CAP}&lang=de`,
     accept: 'text',
   });
   if (!html) {
@@ -258,6 +259,7 @@ export async function fetchAllKsglJobs() {
   }
   const listings = parseListingHtml(html);
   console.log(`   ✓ Discovered ${listings.length} advert links in listing`);
+  warnIfListingAtCap({ label: 'KSGL Career Center listing', count: listings.length, cap: LISTING_PAGE_CAP });
   if (listings.length === 0) return [];
 
   // Step 2: fetch each detail page and extract JSON-LD JobPosting.

--- a/scripts/lib/lups-job-parser.mjs
+++ b/scripts/lib/lups-job-parser.mjs
@@ -31,7 +31,7 @@
  *     step fills in fr/it/en.
  */
 import { createHash } from 'node:crypto';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -44,6 +44,7 @@ export const LUPS_COMPANY_DOMAIN = 'lups.ch';
 const CAREER_URL = 'https://www.lups.ch/karriere';
 const PROSPECTIVE_TENANT = '1001516';
 const LISTING_URL = `https://ohws.prospective.ch/public/v1/careercenter/${PROSPECTIVE_TENANT}/`;
+const LISTING_PAGE_CAP = 200;
 
 const DEFAULT_CANTON = 'LU';
 const DEFAULT_CITY = 'Luzern';
@@ -244,7 +245,7 @@ export async function fetchAllLupsJobs() {
 
   const html = await safeFetch(LISTING_URL, {
     method: 'POST',
-    body: 'offset=0&limit=200&lang=de',
+    body: `offset=0&limit=${LISTING_PAGE_CAP}&lang=de`,
     accept: 'text',
   });
   if (!html) {
@@ -253,6 +254,7 @@ export async function fetchAllLupsJobs() {
   }
   const listings = parseListingHtml(html);
   console.log(`   ✓ Discovered ${listings.length} advert links in listing`);
+  warnIfListingAtCap({ label: 'LUPS Career Center listing', count: listings.length, cap: LISTING_PAGE_CAP });
   if (listings.length === 0) return [];
 
   const jobs = [];

--- a/scripts/lib/rheinmetall-air-defence-job-parser.mjs
+++ b/scripts/lib/rheinmetall-air-defence-job-parser.mjs
@@ -37,6 +37,7 @@ import {
   stripHtml,
   normalizeSpace,
   fetchJson,
+  warnIfListingAtCap,
 } from './crawler-template.mjs';
 
 export const RHEINMETALL_AIR_DEFENCE_KEY = 'rheinmetall-air-defence';
@@ -44,10 +45,11 @@ export const RHEINMETALL_AIR_DEFENCE_COMPANY_NAME = 'Rheinmetall Air Defence AG'
 export const RHEINMETALL_AIR_DEFENCE_COMPANY_DOMAIN = 'rheinmetall.com';
 
 const API_BASE = 'https://www.rheinmetall.com/api';
+const LISTING_SIZE_CAP = 200;
 const LISTING_URL =
   `${API_BASE}/en/career/vacancies?filter=${encodeURIComponent(
     JSON.stringify({ companyName: [RHEINMETALL_AIR_DEFENCE_COMPANY_NAME] })
-  )}&size=200`;
+  )}&size=${LISTING_SIZE_CAP}`;
 
 const TRUSTED_HOSTS = new Set(['www.rheinmetall.com', 'rheinmetall.com']);
 
@@ -185,6 +187,11 @@ function buildJob(listing, detail) {
 export async function fetchAllRheinmetallAirDefenceJobs() {
   const results = await fetchListingResults();
   console.log(`📋 Rheinmetall Air Defence AG: ${results.length} listings found`);
+  warnIfListingAtCap({
+    label: 'Rheinmetall Air Defence AG listing',
+    count: results.length,
+    cap: LISTING_SIZE_CAP,
+  });
 
   const seen = new Set();
   const jobs = [];

--- a/scripts/lib/spital-lachen-job-parser.mjs
+++ b/scripts/lib/spital-lachen-job-parser.mjs
@@ -18,7 +18,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify } from './crawler-template.mjs';
+import { slugify, warnIfListingAtCap } from './crawler-template.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -32,7 +32,8 @@ export const SPITAL_LACHEN_KEY = 'spital-lachen';
 export const SPITAL_LACHEN_COMPANY_NAME = 'Spital Lachen';
 export const SPITAL_LACHEN_COMPANY_DOMAIN = 'spital-lachen.ch';
 
-const REST_LISTING_URL = 'https://spital-lachen.ch/wp-json/wp/v2/dcwi_jobs?per_page=100&_fields=id,slug,link,title,date,modified,unternehmensbereich';
+const LISTING_PAGE_CAP = 100;
+const REST_LISTING_URL = `https://spital-lachen.ch/wp-json/wp/v2/dcwi_jobs?per_page=${LISTING_PAGE_CAP}&_fields=id,slug,link,title,date,modified,unternehmensbereich`;
 const PUBLIC_CAREER_URL = 'https://spital-lachen.ch/jobs-karriere/offene-stellen/';
 
 const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
@@ -136,6 +137,7 @@ export async function fetchAllSpitalLachenJobs() {
     return [];
   }
   console.log(`  ✓ ${data.length} jobs from REST listing`);
+  warnIfListingAtCap({ label: 'Spital Lachen WP REST listing', count: data.length, cap: LISTING_PAGE_CAP });
   if (!data.length) return [];
 
   const todayIso = new Date().toISOString().slice(0, 10);

--- a/scripts/lib/spz-job-parser.mjs
+++ b/scripts/lib/spz-job-parser.mjs
@@ -21,7 +21,7 @@
  * entries → fetch each detail page → extract JSON-LD JobPosting.
  */
 import { createHash } from 'node:crypto';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -34,6 +34,7 @@ export const SPZ_COMPANY_DOMAIN = 'paraplegie.ch';
 const CAREER_URL = 'https://www.paraplegie.ch/de/karriere';
 const PROSPECTIVE_TENANT = '1001777';
 const LISTING_URL = `https://ohws.prospective.ch/public/v1/careercenter/${PROSPECTIVE_TENANT}/`;
+const LISTING_PAGE_CAP = 200;
 
 const DEFAULT_CANTON = 'LU';
 const DEFAULT_CITY = 'Nottwil';
@@ -234,7 +235,7 @@ export async function fetchAllSpzJobs() {
 
   const html = await safeFetch(LISTING_URL, {
     method: 'POST',
-    body: 'offset=0&limit=200&lang=de',
+    body: `offset=0&limit=${LISTING_PAGE_CAP}&lang=de`,
     accept: 'text',
   });
   if (!html) {
@@ -243,6 +244,7 @@ export async function fetchAllSpzJobs() {
   }
   const listings = parseListingHtml(html);
   console.log(`   ✓ Discovered ${listings.length} advert links in listing`);
+  warnIfListingAtCap({ label: 'SPZ Career Center listing', count: listings.length, cap: LISTING_PAGE_CAP });
   if (listings.length === 0) return [];
 
   const jobs = [];

--- a/scripts/lib/valiant-bank-job-parser.mjs
+++ b/scripts/lib/valiant-bank-job-parser.mjs
@@ -52,7 +52,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, fetchHtml } from './crawler-template.mjs';
+import { slugify, fetchHtml, warnIfListingAtCap } from './crawler-template.mjs';
 import { extractJobPostingLd, jobPostingAddress, jobPostingDescriptionText } from './jsonld-jobposting.mjs';
 import { normalizeCantonCode, inferAnyCanton } from './target-swiss-locations.mjs';
 
@@ -63,7 +63,8 @@ export const VALIANT_BANK_COMPANY_NAME = 'Valiant Bank AG';
 export const VALIANT_BANK_COMPANY_DOMAIN = 'valiant.ch';
 
 const CAREERCENTER_TENANT = '1000394';
-const LISTING_URL = `https://jobs.valiant.ch/public/v1/careercenter/${CAREERCENTER_TENANT}/?lang=de&limit=100`;
+const LISTING_PAGE_CAP = 100;
+const LISTING_URL = `https://jobs.valiant.ch/public/v1/careercenter/${CAREERCENTER_TENANT}/?lang=de&limit=${LISTING_PAGE_CAP}`;
 const CAREER_URL = 'https://www.valiant.ch/en/ueber-valiant/arbeiten-bei-valiant-offene-stellen';
 const SECTOR = 'Banche / Servizi Finanziari';
 
@@ -218,6 +219,7 @@ export async function fetchAllValiantBankJobs() {
   }
 
   console.log(`  📋 Listings found: ${listings.length}`);
+  warnIfListingAtCap({ label: 'Valiant Bank Career Center listing', count: listings.length, cap: LISTING_PAGE_CAP });
 
   const jobs = [];
   const seenSlugs = new Set();

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -35,7 +35,7 @@ import {
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
-import { exitCrawlerOnError } from './lib/crawler-template.mjs';
+import { exitCrawlerOnError, warnIfListingAtCap } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -49,7 +49,8 @@ const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'ALTEN Switzerland';
 const COMPANY_DOMAIN = 'alten.ch';
 const COMPANY_HOST = 'www.alten.ch';
-const CAREERS_URL = 'https://www.alten.ch/career/jobs/?pagenum=1&per_page=100';
+const LISTING_PAGE_CAP = 100;
+const CAREERS_URL = `https://www.alten.ch/career/jobs/?pagenum=1&per_page=${LISTING_PAGE_CAP}`;
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 function readJson(filePath, fallback) {
@@ -158,6 +159,7 @@ async function discoverListings() {
       const html = await page.content();
       const listings = parseAltenListingHtml(html);
       console.log(`📋 Total Swiss ALTEN jobs discovered (CH-wide): ${listings.length}`);
+      warnIfListingAtCap({ label: 'ALTEN listing', count: listings.length, cap: LISTING_PAGE_CAP });
       for (const listing of listings) console.log(`  📄 ${listing.title} (${listing.location})`);
       if (listings.length < 1) throw new Error(`Expected at least 1 ALTEN Swiss job, found ${listings.length}`);
       return listings;

--- a/scripts/update-banca-sempione-jobs.mjs
+++ b/scripts/update-banca-sempione-jobs.mjs
@@ -48,7 +48,7 @@ import {
   normalizeKey,
   mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
-import { exitCrawlerOnError } from './lib/crawler-template.mjs';
+import { exitCrawlerOnError, warnIfListingAtCap } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
 
 
@@ -63,7 +63,8 @@ const BANCA_SEMPIONE_KEY = 'banca-sempione';
 const HQ = getCompanyDefaults(BANCA_SEMPIONE_KEY);
 const BANCA_SEMPIONE_COMPANY_NAME = 'Banca del Sempione';
 const BANCA_SEMPIONE_HOST = 'www.bancasempione.ch';
-const BANCA_SEMPIONE_API_URL = 'https://www.bancasempione.ch/wp-json/wp/v2/job?per_page=100';
+const LISTING_PAGE_CAP = 100;
+const BANCA_SEMPIONE_API_URL = `https://www.bancasempione.ch/wp-json/wp/v2/job?per_page=${LISTING_PAGE_CAP}`;
 const BANCA_SEMPIONE_CAREERS_URL = 'https://www.bancasempione.ch/lavora-con-noi/';
 const BANCA_SEMPIONE_LOCALES = ['it', 'en', 'de', 'fr'];
 
@@ -249,6 +250,7 @@ async function fetchBancaSempioneJobs() {
   }
 
   console.log(`📋 WP REST API returned ${wpJobs.length} job listing(s).`);
+  warnIfListingAtCap({ label: 'Banca del Sempione listing', count: wpJobs.length, cap: LISTING_PAGE_CAP });
 
   const jobs = [];
 

--- a/scripts/update-pwc-jobs.mjs
+++ b/scripts/update-pwc-jobs.mjs
@@ -13,7 +13,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { exitCrawlerOnError } from './lib/crawler-template.mjs';
+import { exitCrawlerOnError, warnIfListingAtCap } from './lib/crawler-template.mjs';
 import { fileURLToPath } from 'node:url';
 import {
   printPublishedJobUrls,
@@ -61,7 +61,8 @@ const COMPANY_NAME = 'PwC Switzerland';
 const COMPANY_HOST = 'www.pwc.ch';
 const COMPANY_DOMAIN = 'pwc.ch';
 const CAREERS_URL = 'https://www.pwc.ch/en/careers-with-pwc/open-positions.html';
-const API_URL = 'https://ohws.prospective.ch/public/v1/medium/1000311/jobs?lang=en&offset=0&limit=500';
+const LISTING_LIMIT = 500;
+const API_URL = `https://ohws.prospective.ch/public/v1/medium/1000311/jobs?lang=en&offset=0&limit=${LISTING_LIMIT}`;
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 const TIMEOUT_MS = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 25000;
@@ -138,6 +139,7 @@ async function fetchAllListings() {
 
   console.log(`API returned ${total} PwC jobs total`);
   console.log(`Parsed ${items.length} job items`);
+  warnIfListingAtCap({ label: 'PwC listing', count: items.length, cap: LISTING_LIMIT, total });
 
   return items;
 }


### PR DESCRIPTION
## Implementato

Issue #3436 flagged `scripts/lib/rheinmetall-air-defence-job-parser.mjs`: hardcoded `size=200` listing fetch, no pagination, no warning if the real count exceeds 200 → silent job truncation risk (funnel/SEO traffic). Rheinmetall's own doc comment explicitly forbids reintroducing page pagination for this API (documented instability: only 64/79 unique jobs recovered across 8 pages, overlapping/duplicate IDs) — so the fix is a warning guard, per the issue's own suggested alternative, not pagination.

Per AGENTS.md sibling-pattern-fix rule, audited the full crawler fleet for the same class of bug: single-shot fetch + fixed size/limit cap + no offset loop + no truncation check. Found 17 true positives total (Rheinmetall + 16 siblings, including 4 caught by the review bot on this PR's first pass) and confirmed the rest already paginate properly (e.g. Concordia's offset loop) or are otherwise safe.

- Added shared `warnIfListingAtCap({label, count, cap, total})` helper to `scripts/lib/crawler-template.mjs` — logs a warning when a fetch returns exactly the cap with no total/count to verify against, or precisely when an API-provided `total` exceeds the fetched count. Pure logging, never throws, no control-flow change.
- Wired the guard into all 17 affected crawlers: `rheinmetall-air-defence`, `pwc` and `hochgebirgsklinik-davos` (both have a real API `total` field — exercise the precise-comparison branch), `bachtelen`, `bucher-suter`, `clienia-ag`, `giardino`, `spital-lachen`, `valiant-bank`, `ksgl`, `lups`, `spz`, `bkw`, `benteler`, `banca-sempione`, `alten`, `canton-valais`.
- Verified non-regression: `node --check` on all 18 changed files, `npx vitest run` green on the 11 crawlers with existing test coverage (295/295), dynamic-import smoke test on the remaining 7 without dedicated coverage.

Closes #3436

## Non implementato (ancora)

Nessuno.