### PR TITLE
fix(crawlers): état de vaud job collapse + shell-injection in guard issues

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -35,7 +35,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 import {
@@ -736,9 +736,12 @@ export function quarantineBoilerplateJobs(jobs, boilerplateJobs) {
  */
 function _createBoilerplateGuardIssue(crawlerKey, report) {
   try {
-    // Check for existing open issue
-    const searchResult = execSync(
-      `gh issue list --label parser-broken --state open --search "${crawlerKey}" --json number,title --limit 5`,
+    // Check for existing open issue. execFileSync passes argv directly to gh
+    // (no shell), so job titles/slugs embedded in the body below can't be
+    // interpreted as shell syntax (backticks, $(), etc. — see shrink-guard sibling).
+    const searchResult = execFileSync(
+      'gh',
+      ['issue', 'list', '--label', 'parser-broken', '--state', 'open', '--search', crawlerKey, '--json', 'number,title', '--limit', '5'],
       { encoding: 'utf8', timeout: 15000 },
     ).trim();
 
@@ -750,8 +753,15 @@ function _createBoilerplateGuardIssue(crawlerKey, report) {
 
     if (existingIssue) {
       // Add comment to existing issue
-      execSync(
-        `gh issue comment ${existingIssue.number} --body "Updated: ${dateStr} — still detecting ${report.boilerplateCount}/${report.totalJobs} boilerplate jobs."`,
+      execFileSync(
+        'gh',
+        [
+          'issue',
+          'comment',
+          String(existingIssue.number),
+          '--body',
+          `Updated: ${dateStr} — still detecting ${report.boilerplateCount}/${report.totalJobs} boilerplate jobs.`,
+        ],
         { encoding: 'utf8', timeout: 15000 },
       );
       console.log(`📋 Updated existing issue #${existingIssue.number}`);
@@ -782,8 +792,20 @@ ${jobsTable}
 - [ ] Compare parser selectors with current page structure
 - [ ] Fix the parser and re-run: \`node scripts/update-${crawlerKey}-jobs.mjs\``;
 
-      execSync(
-        `gh issue create --title "[parser-health] ${crawlerKey}: ${report.boilerplateCount}/${report.totalJobs} jobs have boilerplate-only descriptions" --label parser-broken --label automated --body ${JSON.stringify(body)}`,
+      execFileSync(
+        'gh',
+        [
+          'issue',
+          'create',
+          '--title',
+          `[parser-health] ${crawlerKey}: ${report.boilerplateCount}/${report.totalJobs} jobs have boilerplate-only descriptions`,
+          '--label',
+          'parser-broken',
+          '--label',
+          'automated',
+          '--body',
+          body,
+        ],
         { encoding: 'utf8', timeout: 15000 },
       );
       console.log(`📋 Created new GitHub Issue for ${crawlerKey}`);
@@ -795,8 +817,13 @@ ${jobsTable}
 
 function _createShrinkGuardIssue(crawlerKey, report) {
   try {
-    const searchResult = execSync(
-      `gh issue list --label parser-broken --state open --search "${crawlerKey}" --json number,title --limit 5`,
+    // execFileSync passes argv directly to gh (no shell), so a job title or
+    // slug containing backticks/$() can't be executed as a shell command
+    // (this is what previously caused "Permission denied" on a script path
+    // embedded in the markdown body, see issues #3544/#3468).
+    const searchResult = execFileSync(
+      'gh',
+      ['issue', 'list', '--label', 'parser-broken', '--state', 'open', '--search', crawlerKey, '--json', 'number,title', '--limit', '5'],
       { encoding: 'utf8', timeout: 15000 },
     ).trim();
 
@@ -807,8 +834,15 @@ function _createShrinkGuardIssue(crawlerKey, report) {
     const ratioPercent = Math.round(report.ratio * 100);
 
     if (existingIssue) {
-      execSync(
-        `gh issue comment ${existingIssue.number} --body "Updated: ${dateStr} — slice shrunk again: ${report.newCount}/${report.priorCount} jobs (${ratioPercent}% of prior)."`,
+      execFileSync(
+        'gh',
+        [
+          'issue',
+          'comment',
+          String(existingIssue.number),
+          '--body',
+          `Updated: ${dateStr} — slice shrunk again: ${report.newCount}/${report.priorCount} jobs (${ratioPercent}% of prior).`,
+        ],
         { encoding: 'utf8', timeout: 15000 },
       );
       console.log(`📋 Updated existing issue #${existingIssue.number}`);
@@ -829,8 +863,20 @@ The write was refused — the prior slice on disk was kept, no data was lost.
 - [ ] Compare parser selectors with current page structure
 - [ ] If the shrink is legitimate (real listing count drop), re-run with \`SKIP_SHRINK_GUARD=1 node scripts/update-${crawlerKey}-jobs.mjs\``;
 
-      execSync(
-        `gh issue create --title "[parser-health] ${crawlerKey}: slice would shrink to ${ratioPercent}% of prior (${report.newCount}/${report.priorCount})" --label parser-broken --label automated --body ${JSON.stringify(body)}`,
+      execFileSync(
+        'gh',
+        [
+          'issue',
+          'create',
+          '--title',
+          `[parser-health] ${crawlerKey}: slice would shrink to ${ratioPercent}% of prior (${report.newCount}/${report.priorCount})`,
+          '--label',
+          'parser-broken',
+          '--label',
+          'automated',
+          '--body',
+          body,
+        ],
         { encoding: 'utf8', timeout: 15000 },
       );
       console.log(`📋 Created new GitHub Issue for ${crawlerKey}`);

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -4906,6 +4906,14 @@ export function extractJobIdentityFromUrl(rawUrl = '') {
     if (hashRaw.length > 3 && /^[\w-]+$/.test(hashRaw)) {
       return `${registrableDomain(host)}|#${hashRaw.toLowerCase()}`;
     }
+    // SPA hash-router URLs nest the real per-job path INSIDE the fragment
+    // (Oracle Recruiting Cloud: `#fr/sites/CX_1/job/12345`) — the flat-token
+    // rule above requires no slashes, so this shape fell through to '' and
+    // every job on the same career site collapsed onto one identity via the
+    // hash-stripped canonicalizeJobUrl fallback (état de vaud 28→1, #3468).
+    // Mirror the `inPath` trailing-id heuristic above, applied to the hash.
+    const hashJobMatch = hashRaw.match(/\/jobs?\/([^/?#]+)\/?$/i);
+    if (hashJobMatch?.[1]) return `${registrableDomain(host)}|#${hashJobMatch[1].toLowerCase()}`;
   }
   return '';
 }


### PR DESCRIPTION
## Implementato

- `scripts/lib/dedicated-crawler-common.mjs` — `extractJobIdentityFromUrl` didn't handle SPA hash-router URLs whose id lives inside a nested path in the hash (Oracle Recruiting Cloud: `#fr/sites/CX_1/job/{id}`). It only recognized a flat single-token hash or a `key=value` hash, so a slash-containing hash fell through to `''`, and `fingerprintJob` fell back to `canonicalizeJobUrl` (which unconditionally strips the hash) — identical for every job on the career site. Result: all 28 État de Vaud jobs collapsed onto a single map entry during the shared localize-only merge pass (`mergeAndDeduplicate`), tripping the shrink guard at 1/28 and failing the crawler run (#3468). Added a trailing-id fallback rule for slash-containing hash fragments, purely additive (only engages for hashes that previously produced no identity at all — cannot regress any currently-working crawler). Verified with a live repro: distinct job ids now produce distinct identities, same id still dedupes to the same identity.
- `scripts/assemble-jobs-dataset.mjs` — both `_createBoilerplateGuardIssue` and `_createShrinkGuardIssue` built `gh` commands via `execSync` template strings, embedding markdown bodies (containing scraped job titles/slugs) into a double-quoted shell command via `JSON.stringify()`, which escapes quotes/newlines but not backticks. A backtick in a job title/slug is interpreted by `/bin/sh -c` as command substitution. This is exactly what both #3544 and #3468's CI logs show: the shrink guard's own failure-report issue creation itself failed with `/bin/sh: 1: scripts/lib/etat-de-vaud-job-parser.mjs: Permission denied` / `spawnSync /bin/sh ETIMEDOUT`, hiding the real error behind a secondary crash. Converted both functions to `execFileSync('gh', [...args])`, which passes argv directly to the `gh` binary with no shell involved at all — eliminates the injection class entirely rather than patching individual escaping.
- Sibling check (Non-Negotiable #6): grepped all `scripts/lib/*-job-parser.mjs` + `scripts/update-*.mjs` for the same hash-fragment-with-internal-path URL shape and for other `execSync`-with-interpolated-body call sites. État de Vaud is the only crawler constructing a slash-containing hash URL (Oracle-Recruiting-Cloud siblings edmond-de-rothschild/ubp/hermes/efg all use plain path-based URLs; klinik-schuetzen/klinik-gut/oscam-castelrotto use flat hash tokens already handled by the pre-existing rule) — this is a genuine false positive for a broader sibling fix, not deferred scope. `_createBoilerplateGuardIssue`/`_createShrinkGuardIssue` were the only two `execSync` call sites in the file with interpolated markdown bodies; both fixed in this PR.
- Ran the targeted test suites (`etat-de-vaud-crawler`, `boilerplate-guard`, `job-url-key`, `registry-key-and-uniqueness`, `workday-registry-fingerprint`, `workday-rename-previous-slug`, plus the full `dedicated-crawler-*`/`crawler-*`/registry/slug test set touching the shared merge path) — 436 tests green, 0 regressions.

## Non implementato (ancora)

Nessuno. Post-merge: re-run both crawler workflows live (`update-hitachi-energy-jobs.yml`, `update-etat-de-vaud-jobs.yml`) to confirm the actual CI failures are resolved, per standard post-merge workflow verification — will report back in this PR/issue thread.

Closes #3544
Closes #3468