### PR TITLE
fix(generate-article): cap local/fallback timeout to remaining wall-clock budget

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3137,7 +3137,17 @@ function repairLlmJson(raw) {
 // ── LLM call with body2 validation (model fallback via centralized ai-models.mjs) ──
 async function callLLM(messages, opts = {}) {
   const maxBody2Retries = 5;
-  const isBody2Check = opts.jsonMode && messages.some(m => m.content?.includes('body2'));
+  // Require ALL body/title/excerpt field names present (not just 'body2') so this
+  // only fires for the actual full-article generation prompt (which lists every
+  // REQUIRED_IT_BODY_FIELDS name together, see the "content.${primaryLocale}
+  // (title, excerpt, body1, body2, body3, faq)" instruction). A bare 'body2'
+  // substring also matches translateBodyField's single-field translation calls
+  // (prompt/schema `{"body2": "..."}`), where `missing` is guaranteed non-empty
+  // (title/excerpt/body1/body3 are never in that payload) regardless of
+  // translation quality — the retry-exhaustion path now throws instead of
+  // falling through, which used to ship the (valid) translated JSON anyway but
+  // would now discard it and ship IT-language content under /en /de /fr.
+  const isBody2Check = opts.jsonMode && REQUIRED_IT_BODY_FIELDS.every(f => messages.some(m => m.content?.includes(f)));
   for (let attempt = 1; attempt <= maxBody2Retries; attempt++) {
     const modelUsedRef = { model: null };
     // Default per-call ceiling 90s (was 120s, 2026-06-15). 90s still comfortably

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3156,16 +3156,26 @@ async function callLLM(messages, opts = {}) {
     const result = await _aiCallLLM(messages, { temperature: 0.7, maxTokens: 4000, timeout: 90_000, deadlineMs: RUN_START_MS + RUN_WALL_BUDGET_MS, ...opts, modelUsedRef });
     if (isBody2Check) {
       let itContent = null;
+      let parseErr = null;
       try {
         const parsed = JSON.parse(repairLlmJson(result));
         itContent = normalizeItalianContentFromPayload(parsed);
-      } catch {
+      } catch (e) {
+        parseErr = e;
         itContent = null;
       }
 
       const missing = [];
       if (!itContent) {
         missing.push('content.it non normalizzabile');
+        // Previously swallowed silently — every "non normalizzabile" failure
+        // was unreproducible (no evidence of what the model actually sent).
+        // Log the parse error + a raw snippet so a recurring malformed-JSON
+        // pattern from a specific model can actually be root-caused.
+        if (parseErr) {
+          const snippet = String(result).slice(0, 300).replace(/\n/g, '\\n');
+          console.error(`  🔎 JSON parse fallito (${modelUsedRef.model || 'unknown'}): ${parseErr.message} — raw[0:300]: ${snippet}`);
+        }
       } else {
         for (const field of REQUIRED_IT_BODY_FIELDS) {
           if (!itContent?.[field] || itContent[field].length < 1) {
@@ -3193,7 +3203,15 @@ async function callLLM(messages, opts = {}) {
         // rest of this run after MAX_CONSECUTIVE_CONTENT_FAILURES; local/fallback
         // never is — it's the last resort when the whole remote chain is dead).
         recordModelContentFailure(modelUsedRef.model);
-        if (attempt < maxBody2Retries) continue;
+        // Bail out of this retry budget the moment the run-wide wall-clock
+        // deadline is gone, instead of blindly looping to maxBody2Retries.
+        // When every remote model is already exhausted, each retry here
+        // re-invokes local/fallback's ~6-10min CPU inference — 5 blind
+        // retries can burn the entire run budget on one unreliable model,
+        // leaving the outer model-rotation loop (callGemini's
+        // CREATE_ARTICLE_MIN_WORDS_RETRIES) zero real chance to try anything.
+        // Failing fast here instead preserves whatever budget is left for it.
+        if (attempt < maxBody2Retries && !wallBudgetExceeded()) continue;
       } else {
         recordModelContentSuccess(modelUsedRef.model);
       }

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3212,6 +3212,14 @@ async function callLLM(messages, opts = {}) {
         // CREATE_ARTICLE_MIN_WORDS_RETRIES) zero real chance to try anything.
         // Failing fast here instead preserves whatever budget is left for it.
         if (attempt < maxBody2Retries && !wallBudgetExceeded()) continue;
+        // Do NOT fall through to `return result` below — that would ship the
+        // still-invalid payload (e.g. CJK/Cyrillic-drifted content.it, see
+        // isNonItalianScript above) straight to the indexed blog on the very
+        // first attempt whenever the budget is already gone, instead of only
+        // after maxBody2Retries genuinely-exhausted tries. Throw so the caller
+        // falls back to the next model in the chain (or the outer safety net)
+        // instead of publishing malformed/wrong-language content.
+        throw new Error(`Output JSON incompleto (tentativo ${attempt}/${maxBody2Retries}${wallBudgetExceeded() ? ', budget esaurito' : ''}): ${missing.join(', ')}`);
       } else {
         recordModelContentSuccess(modelUsedRef.model);
       }

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -2934,7 +2934,22 @@ async function _getLocalDispatcher(timeoutMs) {
 async function _callLocal(model, messages, opts) {
   const apiModel = getApiModelId(model); // = getLocalLlmModelId()
   // Raise the timeout floor for slow CPU inference (caller's timeout may be ~60s).
-  const timeout = Math.max(opts.timeout || 0, getLocalLlmTimeoutMs());
+  let timeout = Math.max(opts.timeout || 0, getLocalLlmTimeoutMs());
+  // Cap to the caller's remaining wall-clock budget (opts.deadlineMs, e.g.
+  // create-article.mjs's RUN_WALL_BUDGET_MS). Without this, a single
+  // local/fallback call can outlive the overall run deadline by its whole
+  // ~10min CPU-inference floor — the per-chain-walk deadline check (see
+  // ai-models.mjs's "wall-clock deadline exceeded" branch) only gates
+  // whether a NEW cascade walk starts, not how long an already-dispatched
+  // local call is allowed to run. Observed run 28744325535: 5 body2-repair
+  // retries each re-invoked local/fallback (~6-10min each) past the 30min
+  // svizzera budget, leaving zero time for any later fallback attempt.
+  // Floor at 15s so a near-expired deadline still gets one honest last try
+  // instead of silently degrading to a 0ms request.
+  if (opts.deadlineMs) {
+    const remaining = opts.deadlineMs - Date.now();
+    timeout = Math.max(15_000, Math.min(timeout, remaining));
+  }
   const dispatcher = await _getLocalDispatcher(timeout);
   return _callOpenAICompatible(apiModel, messages, { ...opts, timeout }, {
     endpoint: getLocalLlmUrl(),

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -221,6 +221,55 @@ describe('local LLM fallback provider', () => {
     }
   }, 8000);
 
+  // Regression guard (run 28744325535, 2026-07-05): create-article.mjs's body2
+  // JSON-repair loop re-invokes local/fallback up to 5 times, each carrying
+  // opts.deadlineMs = the run's overall wall-clock budget. Before this fix,
+  // _callLocal only used LOCAL_LLM_TIMEOUT_MS (a flat ~10min CPU-inference
+  // floor) and ignored how much of that budget was already spent, so a single
+  // in-flight local call could run 6-10min past the deadline undetected — 5
+  // such retries burned an entire 30min run budget on one unreliable model,
+  // leaving zero time for any other fallback attempt. _callLocal must cap its
+  // effective timeout to the remaining time until opts.deadlineMs.
+  it('caps the local call timeout to the remaining opts.deadlineMs budget, not the flat LOCAL_LLM_TIMEOUT_MS floor', async () => {
+    const prevUrl = process.env.LOCAL_LLM_URL;
+    const prevModel = process.env.LOCAL_LLM_MODEL;
+    const prevTimeout = process.env.LOCAL_LLM_TIMEOUT_MS;
+    process.env.LOCAL_LLM_ENABLED = '1';
+    process.env.LOCAL_LLM_MODEL = 'qwen2.5:7b';
+    // Deliberately huge — if the deadline cap did not apply, the call would
+    // hang for anywhere near this long instead of aborting quickly below.
+    process.env.LOCAL_LLM_TIMEOUT_MS = '900000';
+
+    const server = http.createServer((_req, _res) => {
+      // Never write a response — simulates a still-running CPU inference.
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    process.env.LOCAL_LLM_URL = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const start = Date.now();
+    try {
+      await expect(
+        callSingleModel([{ role: 'user', content: 'hi' }], {
+          model: AI_MODELS.LOCAL_FALLBACK,
+          maxRetriesPerModel: 1,
+          // Budget effectively already exhausted — the call must abort near
+          // immediately (floored at 15s in the implementation), never ride
+          // the 900_000ms LOCAL_LLM_TIMEOUT_MS floor above.
+          deadlineMs: Date.now() + 300,
+        }),
+      ).rejects.toThrow();
+      const elapsedMs = Date.now() - start;
+      expect(elapsedMs).toBeLessThan(20_000);
+    } finally {
+      server.close();
+      if (prevUrl === undefined) delete process.env.LOCAL_LLM_URL; else process.env.LOCAL_LLM_URL = prevUrl;
+      if (prevModel === undefined) delete process.env.LOCAL_LLM_MODEL; else process.env.LOCAL_LLM_MODEL = prevModel;
+      if (prevTimeout === undefined) delete process.env.LOCAL_LLM_TIMEOUT_MS; else process.env.LOCAL_LLM_TIMEOUT_MS = prevTimeout;
+    }
+  }, 25_000);
+
   // AI_MODELS_FORCE_CHAIN pins the cascade to an explicit list so ops can
   // validate/measure a specific provider (e.g. the local fallback) on demand
   // without waiting for the remote pool to exhaust naturally.


### PR DESCRIPTION
## Implementato

- `_callLocal` (scripts/lib/ai-models.mjs) now caps its effective timeout to the remaining time until `opts.deadlineMs` (when the caller passes one), floored at 15s. Previously it only used `Math.max(opts.timeout, LOCAL_LLM_TIMEOUT_MS)`, ignoring how much of the overall run's wall-clock budget was already spent — a single in-flight local/fallback call (CPU inference, ~6-10min) could run well past the run's deadline undetected.
- `callLLM`'s body2 JSON-repair retry loop (scripts/create-article.mjs) now stops early once `wallBudgetExceeded()` is true, instead of always looping to `maxBody2Retries` (5). This mirrors the same guard already used by the outer headline-retry loop (`wallBudgetExceeded()` at lines 7963/8257/8318) — it was simply missing here.
- On `content.it non normalizzabile` (JSON.parse failure), the raw parse error + a 300-char raw-payload snippet is now logged instead of silently discarded, so a recurring malformed-JSON shape from a specific model is diagnosable next time.
- Added a regression test (`tests/local-llm-fallback.test.ts`) proving `_callLocal`'s timeout is bounded by `opts.deadlineMs` even when `LOCAL_LLM_TIMEOUT_MS` is huge (900s) — the call must abort near-immediately when the deadline is already effectively expired, not ride the flat local-timeout floor.

### Root cause (live, post-merge finding from run 28744325535)

This is a follow-up to #3576 (which fixed local/fallback being wrongly *banned*). After that merge, the very next post-merge svizzera run still produced **no article**, for a distinct reason: all remote models were already exhausted for the run, so `local/fallback` was invoked 5 times inside the body2 JSON-repair loop — each attempt took 6-10min of real CPU inference and produced malformed JSON (`content.it non normalizzabile`). Those 5 attempts alone burned the entire 30min svizzera wall-clock budget. The separate "6 named-model" outer retry loop (`CREATE_ARTICLE_MIN_WORDS_RETRIES`) then ran its 6 attempts, but every single one failed **instantly** with `Ministral-3B: skipped — wall-clock deadline exceeded ... aborted remaining chain (N models left)` — the deadline was already gone, so none of the 6 attempts ever tried a single model, including local/fallback itself.

The chain-walk's per-model deadline check (ai-models.mjs) only gates whether a *new* cascade walk starts in time — it does not bound how long an already-dispatched local call is allowed to run, and the inner body2 retry loop had no budget check of its own before looping again. This fix closes both gaps.

### GitNexus impact check

`gitnexus_impact({target:"_callLocal", direction:"upstream"})` reports HIGH risk (18 impacted symbols across `shared-jobs-crawler.mjs`, `re-enrich-jobs.mjs`, `enrich-related-search-clusters.mjs`, etc. — anything that can reach `local/fallback` transitively). In practice the new cap is gated behind `if (opts.deadlineMs)`, and `deadlineMs` is set by exactly one caller in the whole codebase (`create-article.mjs`'s `callLLM`, confirmed via `grep -rn deadlineMs scripts/`). Every other caller never passes `deadlineMs`, so `_callLocal`'s new capping branch is a no-op for them — behavior is unchanged outside create-article.mjs.

## Non implementato (ancora)

Nessuno. The known gap (deadline check not bounding local/fallback's in-flight duration, and the inner retry loop not respecting the run-wide budget) is fixed and covered by a regression test in this PR. Empirical live verification (a post-merge run of this fix actually producing an article, for both frontaliere and svizzera) is tracked as ongoing observation of the next scheduled `generate-article.yml` runs — not a reason to hold this PR, since the fix itself is complete, tested, and scoped; if a live run surfaces a further distinct failure mode it will be filed/fixed as its own follow-up per the standing goal.