### PR TITLE
fix(ci): followup-drainer settling guard misreads a concluded fix run

### DIFF
--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -388,6 +388,23 @@ function minutesSince(iso) {
   return (Date.now() - then) / 60000;
 }
 
+/**
+ * Vero se un `agent:fix` senza PR va contato come "settling" (promozione
+ * fresca, run non ancora registrata in `gh run list`) e deve quindi rinviare
+ * il drain di un tick invece di procedere al rescue/orphan. Un commento
+ * FIX_OUTCOME bumpa `updatedAt` esattamente come l'edit di promozione, quindi
+ * l'età da sola non distingue "appena promosso" da "appena CONCLUSO (fallito)
+ * con verdetto già postato" — serve `outcome === null` nel guard, altrimenti
+ * un fix appena fallito viene scambiato per settling e il drain dell'intera
+ * coda si ferma per un tick a vuoto (bug osservato 2026-07-05: #3578 max-turns
+ * commentato a 16:35:59 → il tick di drain successivo lo conta come settling).
+ * Pura → testabile.
+ * @param {{outcome: string|null, ageMin: number, settleMin: number}} args
+ */
+export function isSettlingPromotion({ outcome, ageMin, settleMin }) {
+  return outcome === null && ageMin < settleMin;
+}
+
 /** Ultimo verdetto FIX_OUTCOME sulla issue, o null. Best-effort: null su errore
  * gh/parse → fail-open al rescue normale (mai park per un glitch API). */
 function latestFixOutcome(num) {
@@ -524,7 +541,16 @@ function main() {
     // assestamento, blocca il drain di 1 tick), o è un fix già COMPLETATO senza
     // PR (fallito/skip). Quest'ultimo NON deve bloccare il drain (era il bug del
     // settling a 30min): lo lasciamo all'orphan-rescue quando supera i 30min.
-    if (ageMin < SETTLE_MIN) { settlingPromotions++; continue; } // registrazione run
+    // `outcome` va calcolato PRIMA del check settling: un commento FIX_OUTCOME
+    // bumpa `updatedAt` esattamente come una promozione fresca, quindi age da
+    // solo non distingue "appena promosso, run non ancora visibile" da "appena
+    // CONCLUSO (fallito) con verdetto già postato". Senza `outcome === null` nel
+    // guard, un fix appena fallito veniva riclassificato come settling e
+    // rinviava l'intero drain di un tick a vuoto (bug osservato 2026-07-05:
+    // #3578 max-turns con commento a 16:35:59 → il drain di 16:36 lo conta come
+    // settling e rinvia la promozione del prossimo candidato in coda).
+    const outcome = latestFixOutcome(iss.number);
+    if (isSettlingPromotion({ outcome, ageMin, settleMin: SETTLE_MIN })) { settlingPromotions++; continue; } // registrazione run
     if (ageMin < ORPHAN_MIN_AGE_MIN) continue; // fix finito senza PR ma non ancora orfano → non bloccare il drain
     // vecchio + nessuna PR → orfano. Ma «nessuna PR» ha due cause diverse:
     // (a) run morta/crashata (nessun verdetto) → ri-tentabile; (b) ABORT pulita
@@ -533,7 +559,6 @@ function main() {
     // quota (root cause #1478). Distingui via l'ultimo marker FIX_OUTCOME: se è
     // NON_RETRYABLE → park SUBITO senza consumare i tentativi residui (nessuna
     // perdita: resta aperto, ri-triabile a mano se il contesto cambia).
-    const outcome = latestFixOutcome(iss.number);
     if (outcome && NON_RETRYABLE.has(outcome)) {
       console.log(`PARK #${iss.number} (esito non-ri-tentabile: ${outcome}) → no re-queue, evito run identica`);
       edit(iss.number, { add: [LBL_PARKED], remove: [LBL_FIX, LBL_QUEUED] });

--- a/tests/followup-drainer-outcome.test.ts
+++ b/tests/followup-drainer-outcome.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { latestFixOutcomeFromComments, NON_RETRYABLE, isAgeOutEligible } from '../scripts/ci/followup-drainer.mjs';
+import { latestFixOutcomeFromComments, NON_RETRYABLE, isAgeOutEligible, isSettlingPromotion } from '../scripts/ci/followup-drainer.mjs';
 
 type Comment = { body?: string; createdAt?: string };
 const at = (n: number) => new Date(2026, 0, n).toISOString();
@@ -62,6 +62,23 @@ describe('NON_RETRYABLE (quali esiti → park immediato)', () => {
     for (const code of ['overlap-skip', 'pr-already-open', 'pr-created']) {
       expect(NON_RETRYABLE.has(code)).toBe(false);
     }
+  });
+});
+
+describe('isSettlingPromotion (regressione 2026-07-05: esito ≠ promozione fresca)', () => {
+  it('vero SOLO su promozione fresca senza verdetto ancora entro la finestra settle', () => {
+    expect(isSettlingPromotion({ outcome: null, ageMin: 1, settleMin: 3 })).toBe(true);
+  });
+
+  it('falso se un FIX_OUTCOME esiste già, anche se age è sotto settleMin (run CONCLUSA, non fresca)', () => {
+    // #3578: max-turns commentato a 16:35:59 bumpa updatedAt → age~0min, ma la
+    // run è già finita — non deve contare come settling (bloccava il drain).
+    expect(isSettlingPromotion({ outcome: 'max-turns', ageMin: 0.5, settleMin: 3 })).toBe(false);
+    expect(isSettlingPromotion({ outcome: 'no-root-cause', ageMin: 0, settleMin: 3 })).toBe(false);
+  });
+
+  it('falso oltre la finestra settle anche senza verdetto (passa al ramo orphan)', () => {
+    expect(isSettlingPromotion({ outcome: null, ageMin: 5, settleMin: 3 })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Implementato

- `followup-drainer.mjs`: la classificazione "settling" (promozione fresca, run non ancora visibile in `gh run list`) usava solo l'età di `iss.updatedAt`. Un commento `FIX_OUTCOME` postato a fine run bumpa `updatedAt` esattamente come l'edit di promozione, quindi un fix appena FALLITO (senza PR) veniva scambiato per "appena promosso" e faceva rinviare l'intero drain della coda di un tick — confermato live 2026-07-05 (issue #3578, `max-turns` commentato alle 16:35:59 → il tick di drain a 16:36 lo conta come settling invece di procedere a promuovere il prossimo candidato in coda `agent:fix-queued`).
- Estratta la predicate pura `isSettlingPromotion({outcome, ageMin, settleMin})`: vera SOLO se non esiste ancora un verdetto `FIX_OUTCOME` (`outcome === null`) ed è entro la finestra di assestamento. Se il verdetto esiste già, la classificazione cade nel ramo orphan/rescue esistente (età valutata su `ORPHAN_MIN_AGE_MIN`), non blocca più il drain.
- Riuso lo stesso `outcome` già calcolato per il guard settling nel ramo NON_RETRYABLE/max-turns sottostante (rimossa la doppia chiamata `latestFixOutcome`).
- Aggiunti test di regressione in `tests/followup-drainer-outcome.test.ts` (`isSettlingPromotion`), che replicano esattamente il caso #3578.

## Non implementato (ancora)

Nessuno.