### PR TITLE
fix(seo): structurally close GSC 404 leaks — orphan bridges + below-floor page families

### DIFF
--- a/build-plugins/flatHtmlRedirectPlugin.ts
+++ b/build-plugins/flatHtmlRedirectPlugin.ts
@@ -75,7 +75,10 @@ function extractOgTags(indexHtml: string): string {
   return tags.join('\n');
 }
 
-const NOINDEX_BRIDGE = (slashUrl: string, title: string, ogTags: string): string =>
+/** Shared noindex redirect-bridge template — reused by any plugin that needs to
+ * point a stale-but-still-crawled URL at its live replacement (see
+ * `findOrphanedCompanyCityPairs` in weeklyEmployersPlugin.ts). */
+export const NOINDEX_BRIDGE = (slashUrl: string, title: string, ogTags: string): string =>
   `<!DOCTYPE html>
 <html lang="it">
 <head>

--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -51,6 +51,8 @@ import {
 import { MIN_JOBS_FOR_CANTON_PAGE } from './weeklyEmployersData';
 import { buildSnapshotProseBlock } from './shared/cantonSnapshotProse';
 import { inlineScriptJson } from './shared/inlineJsonScript';
+import { PROFESSION_CANTON_KEYS } from './professionCantonData';
+import { renderSalaryStatsBridge } from './shared/salaryStatsBridge';
 
 // ── Local types — kept loose; the TI-side JobRecord is already compatible. ──
 interface JobLike {
@@ -544,6 +546,55 @@ export interface ChCantonSnapshotEmitResult {
   cantonsEmitted: Array<{ code: string; jobsCount: number }>;
   cantonsSkipped: Array<{ code: string; jobsCount: number }>;
   pagesSkippedForWordCount: number;
+  /** Below-floor cantons bridged to the salary-stats hub instead of left to 404. */
+  bridgesWritten: number;
+}
+
+interface BridgeCopy {
+  title: (canton: string) => string;
+  body: (canton: string) => string;
+  cta: (canton: string) => string;
+}
+
+const BRIDGE_COPY: Record<Locale, BridgeCopy> = {
+  it: {
+    title: (c) => `Snapshot mercato lavoro — Canton ${c}`,
+    body: (c) => `Al momento non ci sono abbastanza offerte attive nel Canton ${c} da mostrare uno snapshot dedicato. Consulta stipendi e mercato del lavoro nel Canton ${c}.`,
+    cta: (c) => `Vai ai dati del Canton ${c}`,
+  },
+  en: {
+    title: (c) => `Job market snapshot — Canton ${c}`,
+    body: (c) => `There aren't enough active openings in Canton ${c} right now for a dedicated snapshot. See salary and job-market data for Canton ${c}.`,
+    cta: (c) => `Go to Canton ${c} data`,
+  },
+  de: {
+    title: (c) => `Arbeitsmarkt-Snapshot — Kanton ${c}`,
+    body: (c) => `Im Kanton ${c} gibt es derzeit nicht genug aktive Stellen fur einen eigenen Snapshot. Lohn- und Arbeitsmarktdaten fur den Kanton ${c} ansehen.`,
+    cta: (c) => `Zu den Daten fur Kanton ${c}`,
+  },
+  fr: {
+    title: (c) => `Aperçu marché de l'emploi — canton ${c}`,
+    body: (c) => `Il n'y a pas assez d'offres actives dans le canton ${c} pour un aperçu dédié actuellement. Consultez les données salariales et du marché du travail du canton ${c}.`,
+    cta: (c) => `Voir les données du canton ${c}`,
+  },
+};
+
+/**
+ * Below-floor bridge: a canton that doesn't meet the jobs floor this build
+ * gets a noindex,follow canonical bridge instead of a hard 404. Job counts
+ * fluctuate build to build, and this exact path may have been indexed on a
+ * prior build when the canton did meet the floor (same orphaned-static-page
+ * class fixed for profession-canton landings and weekly-employers cantons —
+ * professionCantonLandings.ts / weeklyEmployersChCantonPages.ts).
+ */
+function renderBelowFloorBridge(locale: Locale, cantonCode: string): string {
+  const cantonName = getCantonDisplayName(cantonCode, locale);
+  const copy = BRIDGE_COPY[locale];
+  return renderSalaryStatsBridge(locale, cantonCode, {
+    title: copy.title(cantonName),
+    description: copy.body(cantonName),
+    ctaLabel: copy.cta(cantonName),
+  });
 }
 
 /**
@@ -562,6 +613,7 @@ export async function emitChCantonSnapshotPages(
     cantonsEmitted: [],
     cantonsSkipped: [],
     pagesSkippedForWordCount: 0,
+    bridgesWritten: 0,
   };
 
   const slugFile = loadCantonSlugFile(opts.rootDir);
@@ -599,6 +651,15 @@ export async function emitChCantonSnapshotPages(
   // and BL+BS jobs accumulate in the merged bucket directly.
   const jobsByCanton = new Map<string, JobLike[]>();
   for (const code of citiesByCanton.keys()) jobsByCanton.set(code, []);
+  // citiesByCanton is derived from the BFS municipalities dataset — if a
+  // canton group key is ever entirely absent there (stale/incomplete data),
+  // it would never enter jobsByCanton and vanish silently from both
+  // cantonsEmitted AND cantonsSkipped below, so it would get no bridge
+  // either. PROFESSION_CANTON_KEYS is the canonical universe of all 23
+  // non-TI canton group keys — seed any missing one with an empty bucket.
+  for (const code of PROFESSION_CANTON_KEYS) {
+    if (!jobsByCanton.has(code)) jobsByCanton.set(code, []);
+  }
   for (const job of activePool as readonly JobLike[]) {
     const directCanton = (job as { canton?: unknown }).canton;
     if (typeof directCanton === 'string' && directCanton.length === 2) {
@@ -711,6 +772,20 @@ export async function emitChCantonSnapshotPages(
       const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       collector.add(np.join(outDir, 'index.html'), html);
       result.pagesWritten++;
+    }
+  }
+
+  // Below-floor cantons (recorded above) still get a noindex bridge to their
+  // salary-stats hub — never a silent drop of a page a prior build may have
+  // emitted and Google indexed.
+  for (const skipped of result.cantonsSkipped) {
+    for (const locale of LOCALES) {
+      const cantonSlug = getCantonUrlSlugLocal(slugFile, skipped.code, locale);
+      if (!cantonSlug) continue;
+      const canonicalPath = buildCantonSnapshotPath(locale, cantonSlug);
+      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+      collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, skipped.code));
+      result.bridgesWritten++;
     }
   }
 

--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -3349,11 +3349,11 @@ ${sitemapEntries.join('\n')}
         });
         const localesCount = JOB_MARKET_SNAPSHOT_LOCALES.length;
         console.log(
-          `\x1b[36m[job-market-snapshot]\x1b[0m P2.S1 emitted ${r.cantonsEmitted.length} per-canton snapshot pages × ${localesCount} locales`,
+          `\x1b[36m[job-market-snapshot]\x1b[0m P2.S1 emitted ${r.cantonsEmitted.length} per-canton snapshot pages × ${localesCount} locales (+${r.bridgesWritten} below-floor bridges)`,
         );
         if (r.cantonsSkipped.length > 0) {
           const skipped = r.cantonsSkipped.map((s) => `${s.code}:${s.jobsCount}`).join(', ');
-          console.log(`[job-market-snapshot] P2.S1 skipped (below 5 jobs): ${skipped}`);
+          console.log(`[job-market-snapshot] P2.S1 skipped (below 5 jobs, bridged): ${skipped}`);
         }
       } catch (err) {
         console.warn('[job-market-snapshot] P2.S1 per-canton emit failed:', err);

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -5668,6 +5668,85 @@ ${staticAnalyticsHtml}
  }
  }
 
+ let locationFamilyBelowFloorBridges = 0;
+ const writeLocationFamilyBridge = (canonicalPath: string, targetPath: string, locale: 'it' | 'en' | 'de' | 'fr'): void => {
+ const html = buildCanonicalBridgePage({
+ canonicalUrl: `${BASE_URL}${targetPath}`,
+ pathLabel: targetPath,
+ lang: locale,
+ noindex: true,
+ });
+ const relPath = canonicalPath.slice(1).replace(/\/$/, '');
+ const dir = np.join(distDir, relPath);
+ if (!fs.existsSync(np.join(dir, 'index.html'))) {
+ _md(dir);
+ _qw(np.join(dir, 'index.html'), html);
+ }
+ const flatFile = np.join(distDir, relPath + '.html');
+ if (!fs.existsSync(flatFile)) {
+ _md(np.dirname(flatFile));
+ _qwFlat(flatFile, html);
+ }
+ locationFamilyBelowFloorBridges++;
+ };
+ const emitLocationBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', loc: string): void => {
+ const targetPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'));
+ const cityHubKey = CITY_HUB_KEYS.find((k) => k.toLowerCase() === loc.toLowerCase());
+ if (cityHubKey) writeLocationFamilyBridge(buildCityHubPath(locale, cityHubKey), targetPath, locale);
+ const legacyModel = buildJobLocationLandingModel({
+ jobs: validJobs,
+ locale,
+ location: loc,
+ now: new Date().toISOString(),
+ localizedSlug,
+ baseUrl: BASE_URL,
+ sectionSlug: sectionByLocale[locale],
+ localePrefix: localePrefix[locale],
+ partition: locationPartition,
+ });
+ const legacyPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${legacyModel.slug}`.replace(/\/+/g, '/'));
+ if (!cityHubKey || legacyPath !== buildCityHubPath(locale, cityHubKey)) writeLocationFamilyBridge(legacyPath, targetPath, locale);
+ };
+ const emitLocationTypeBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', loc: string, typeKeyArg: (typeof editorialTypeKeys)[number]): void => {
+ const cityHubKey = CITY_HUB_KEYS.find((k) => k.toLowerCase() === loc.toLowerCase());
+ const targetPath = cityHubKey
+ ? buildCityHubPath(locale, cityHubKey)
+ : withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'));
+ const model = buildJobLocationTypeLandingModel({
+ jobs: validJobs,
+ locale,
+ location: loc,
+ typeKey: typeKeyArg,
+ now: new Date().toISOString(),
+ localizedSlug,
+ baseUrl: BASE_URL,
+ sectionSlug: sectionByLocale[locale],
+ localePrefix: localePrefix[locale],
+ partition: locationPartition,
+ });
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ writeLocationFamilyBridge(canonicalPath, targetPath, locale);
+ };
+ const emitLocationSectorBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', loc: string, sectorKeyArg: (typeof editorialSectorKeys)[number]): void => {
+ const cityHubKey = CITY_HUB_KEYS.find((k) => k.toLowerCase() === loc.toLowerCase());
+ const targetPath = cityHubKey
+ ? buildCityHubPath(locale, cityHubKey)
+ : withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'));
+ const model = buildJobLocationSectorLandingModel({
+ jobs: validJobs,
+ locale,
+ location: loc,
+ sectorKey: sectorKeyArg,
+ now: new Date().toISOString(),
+ localizedSlug,
+ baseUrl: BASE_URL,
+ sectionSlug: sectionByLocale[locale],
+ localePrefix: localePrefix[locale],
+ partition: locationPartition,
+ });
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ writeLocationFamilyBridge(canonicalPath, targetPath, locale);
+ };
  for (const location of editorialLocations) {
  const italianLocationModel = buildJobLocationLandingModel({
  jobs: validJobs,
@@ -5680,7 +5759,13 @@ ${staticAnalyticsHtml}
  localePrefix: localePrefix.it,
  partition: locationPartition,
  });
- if (italianLocationModel.totalJobs === 0) continue;
+ if (italianLocationModel.totalJobs === 0) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitLocationBelowFloorBridge(locale, location);
+ }
+ continue;
+ }
 
  for (const locale of localeList) {
  if (!shouldEmitLocale(locale)) continue; // locale-shard render-skip (BUILD_LOCALE) — Fase 1b
@@ -5927,7 +6012,13 @@ ${staticAnalyticsHtml}
  localePrefix: localePrefix.it,
  partition: locationPartition,
  });
- if (italianTypeModel.totalJobs === 0) continue;
+ if (italianTypeModel.totalJobs === 0) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitLocationTypeBelowFloorBridge(locale, location, typeKey);
+ }
+ continue;
+ }
 
  for (const locale of localeList) {
  if (!shouldEmitLocale(locale)) continue; // locale-shard render-skip (BUILD_LOCALE) — Fase 1b
@@ -6089,7 +6180,13 @@ ${staticAnalyticsHtml}
  localePrefix: localePrefix.it,
  partition: locationPartition,
  });
- if (italianSectorModel.totalJobs === 0) continue;
+ if (italianSectorModel.totalJobs === 0) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitLocationSectorBelowFloorBridge(locale, location, sectorKey);
+ }
+ continue;
+ }
 
  for (const locale of localeList) {
  if (!shouldEmitLocale(locale)) continue; // locale-shard render-skip (BUILD_LOCALE) — Fase 1b
@@ -6237,6 +6334,9 @@ ${staticAnalyticsHtml}
  partition: locationPartition,
  }), '0.67');
  }
+ }
+ if (locationFamilyBelowFloorBridges > 0) {
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m P8 location/type/sector below-floor bridges: ${locationFamilyBelowFloorBridges} (TI city location/type/sector combos)`);
  }
 
  editorialEntries = editorialSitemapEntries.join('\n');

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -4744,8 +4744,51 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  editorialCantonJobCounts.set(c, (editorialCantonJobCounts.get(c) ?? 0) + 1);
  }
 
+ // Structural 404 fix (GSC Coverage Drilldown sweep, same sibling bug class as
+ // professionCantonLandings.ts / weeklyEmployersChCantonPages.ts /
+ // jobMarketSnapshotChCantonPages.ts): the 4 editorial-canton loops below
+ // (today / nurses-hub / part-time / care-variant) used to silently `continue`
+ // past a canton once it fell under MIN_JOBS_FOR_CANTON_PAGE (or, for
+ // care-variant, once the cluster had zero matching IT jobs) -- dropping a URL
+ // Google may already have indexed from a prior build straight to a GH Pages
+ // hard 404, no bridge/redirect. The canton-root job-board hub
+ // (buildCantonAwareSection(locale, canton)) is emitted unconditionally for
+ // every canton at every locale regardless of job count -- see the P2.S2
+ // canton-index loop below, which ships `noindex,follow` under-threshold but
+ // never skips the emit -- so it is always a live target to bridge to.
+ let editorialBelowFloorBridges = 0;
+ const emitEditorialBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', canton: string, slug: string): void => {
+ const section = buildCantonAwareSection(locale, canton);
+ const targetPath = withSlash(`${localePrefix[locale]}/${section}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${section}/${slug}`.replace(/\/+/g, '/'));
+ const html = buildCanonicalBridgePage({
+ canonicalUrl: `${BASE_URL}${targetPath}`,
+ pathLabel: targetPath,
+ lang: locale,
+ noindex: true,
+ });
+ const relPath = canonicalPath.slice(1).replace(/\/$/, '');
+ const dir = np.join(distDir, relPath);
+ if (!fs.existsSync(np.join(dir, 'index.html'))) {
+ _md(dir);
+ _qw(np.join(dir, 'index.html'), html);
+ }
+ const flatFile = np.join(distDir, relPath + '.html');
+ if (!fs.existsSync(flatFile)) {
+ _md(np.dirname(flatFile));
+ _qwFlat(flatFile, html);
+ }
+ editorialBelowFloorBridges++;
+ };
+
  for (const editorialCanton of EDITORIAL_CANTONS) {
- if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitEditorialBelowFloorBridge(locale, editorialCanton, getJobTodayLandingSlug(locale, editorialCanton));
+ }
+ continue;
+ }
  // Phase 8 sub-PR (d): for non-TI editorial cantons the URL section
  // becomes the canton-aware form (e.g. `cerca-lavoro-zurigo`) and the
  // model emits a short slug (`oggi` / `today` / `heute` / `aujourdhui`).
@@ -5061,7 +5104,13 @@ ${staticAnalyticsHtml}
  }), '0.78');
 
  for (const editorialCanton of EDITORIAL_CANTONS) {
- if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitEditorialBelowFloorBridge(locale, editorialCanton, getJobNursesHubSlug(locale, editorialCanton));
+ }
+ continue;
+ }
  // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
  const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  for (const locale of localeList) {
@@ -5244,7 +5293,13 @@ ${staticAnalyticsHtml}
 
  /* ── Editorial landing: global part-time ───────────────────── */
  for (const editorialCanton of EDITORIAL_CANTONS) {
- if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitEditorialBelowFloorBridge(locale, editorialCanton, getJobPartTimeLandingSlug(locale, editorialCanton));
+ }
+ continue;
+ }
  // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
  const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  for (const locale of localeList) {
@@ -5422,7 +5477,13 @@ ${staticAnalyticsHtml}
  };
  for (const clusterKey of editorialCareKeys) {
  for (const editorialCanton of EDITORIAL_CANTONS) {
- if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitEditorialBelowFloorBridge(locale, editorialCanton, careClusterSlug(clusterKey, editorialCanton, locale));
+ }
+ continue;
+ }
  // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
  const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  const italianCareModel = buildJobCareVariantLandingModel({
@@ -5437,7 +5498,13 @@ ${staticAnalyticsHtml}
  canton: editorialCanton,
  partition: careClusterPartition,
  });
- if (italianCareModel.totalJobs === 0) continue;
+ if (italianCareModel.totalJobs === 0) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitEditorialBelowFloorBridge(locale, editorialCanton, careClusterSlug(clusterKey, editorialCanton, locale));
+ }
+ continue;
+ }
 
  for (const locale of localeList) {
  if (!shouldEmitLocale(locale)) continue; // locale-shard render-skip (BUILD_LOCALE) — Fase 1b
@@ -5595,6 +5662,9 @@ ${staticAnalyticsHtml}
  canton: editorialCanton,
  partition: careClusterPartition,
  }), '0.71', sectionByLocaleCanton);
+ }
+ if (editorialBelowFloorBridges > 0) {
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m P8 editorial-canton below-floor bridges: ${editorialBelowFloorBridges} (today/nurses/part-time/care-variant combined)`);
  }
  }
 
@@ -7180,10 +7250,42 @@ ${staticAnalyticsHtml}
  };
  const sectorHubSitemapEntries: string[] = [];
  let sectorHubPagesCount = 0;
+ let sectorHubBelowFloorBridges = 0;
+ const emitSectorHubBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', canton: string, slug: string): void => {
+ const section = buildCantonAwareSection(locale, canton);
+ const targetPath = withSlash(`${localePrefix[locale]}/${section}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${section}/${slug}`.replace(/\/+/g, '/'));
+ const html = buildCanonicalBridgePage({
+ canonicalUrl: `${BASE_URL}${targetPath}`,
+ pathLabel: targetPath,
+ lang: locale,
+ noindex: true,
+ });
+ const relPath = canonicalPath.slice(1).replace(/\/$/, '');
+ const dir = np.join(distDir, relPath);
+ if (!fs.existsSync(np.join(dir, 'index.html'))) {
+ _md(dir);
+ _qw(np.join(dir, 'index.html'), html);
+ }
+ const flatFile = np.join(distDir, relPath + '.html');
+ if (!fs.existsSync(flatFile)) {
+ _md(np.dirname(flatFile));
+ _qwFlat(flatFile, html);
+ }
+ sectorHubBelowFloorBridges++;
+ };
  for (const canton of SHARED_ALL_CANTON_CODES) {
  if (canton === 'TI') continue;
  const cantonTotal = cantonTotalSec.get(canton) ?? 0;
- if (cantonTotal < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ if (cantonTotal < MIN_JOBS_FOR_CANTON_PAGE) {
+ for (const sector of SECTOR_HUB_KEYS) {
+ for (const locale of localeList) {
+ if (!shouldEmitLocale(locale)) continue;
+ emitSectorHubBelowFloorBridge(locale, canton, SECTOR_HUB_SLUG[locale][sector]);
+ }
+ }
+ continue;
+ }
  const bySector = cantonSectorBuckets.get(canton);
  if (!bySector) continue;
  for (const sector of SECTOR_HUB_KEYS) {
@@ -7369,6 +7471,9 @@ ${staticAnalyticsHtml}
  sectorHubSitemapEntries.push(` <url>\n <loc>${BASE_URL}${p}</loc>\n${smAlternates}\n <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${itPath}" />\n <lastmod>${dateStamp}</lastmod>\n <changefreq>daily</changefreq>\n <priority>0.8</priority>\n </url>`);
  }
  }
+ }
+ if (sectorHubBelowFloorBridges > 0) {
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m P8 sector-hub below-floor bridges: ${sectorHubBelowFloorBridges} (per-canton sector hubs)`);
  }
  if (sectorHubPagesCount > 0) {
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Generated ${sectorHubPagesCount} per-canton sector hub pages`);

--- a/build-plugins/professionCantonLandings.ts
+++ b/build-plugins/professionCantonLandings.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import np from 'node:path';
 
 import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
+import { renderSalaryStatsBridge } from './shared/salaryStatsBridge';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
 import { renderHreflangTags, type HreflangPaths } from './shared/hreflang';
@@ -45,6 +46,7 @@ import {
 import {
   SALARY_STATS_CANTON_SLUGS,
   SALARY_STATS_FACTOR_CODE,
+  buildSalaryStatsPath,
 } from './salaryStatsData';
 import { buildProfessionCantonPath, PROFESSION_CANTON_KEYS } from './professionCantonData';
 import { resolveProfessionCantonsFlushed } from './shared/buildSignals';
@@ -171,6 +173,57 @@ function cantonAnnualMedian(cantonKey: string): number {
   return monthly * 12;
 }
 
+interface BridgeCopy {
+  title: (role: string, canton: string) => string;
+  body: (role: string, canton: string) => string;
+  cta: (canton: string) => string;
+}
+
+const BRIDGE_COPY: Record<ProfessionLocale, BridgeCopy> = {
+  it: {
+    title: (r, c) => `Lavoro ${r} Canton ${c}`,
+    body: (r, c) => `Al momento non ci sono abbastanza offerte attive per ${r} nel Canton ${c} da mostrare una pagina dedicata. Consulta stipendi e mercato del lavoro nel Canton ${c}.`,
+    cta: (c) => `Vai ai dati del Canton ${c}`,
+  },
+  en: {
+    title: (r, c) => `${r} jobs in Canton ${c}`,
+    body: (r, c) => `There aren't enough active ${r} openings in Canton ${c} right now for a dedicated page. See salary and job-market data for Canton ${c}.`,
+    cta: (c) => `Go to Canton ${c} data`,
+  },
+  de: {
+    title: (r, c) => `${r}-Stellen im Kanton ${c}`,
+    body: (r, c) => `Im Kanton ${c} gibt es derzeit nicht genug aktive ${r}-Stellen fur eine eigene Seite. Lohn- und Arbeitsmarktdaten fur den Kanton ${c} ansehen.`,
+    cta: (c) => `Zu den Daten fur Kanton ${c}`,
+  },
+  fr: {
+    title: (r, c) => `Emplois ${r} dans le canton ${c}`,
+    body: (r, c) => `Il n'y a pas assez d'offres actives pour ${r} dans le canton ${c} pour une page dediee actuellement. Consultez les donnees salariales et du marche du travail du canton ${c}.`,
+    cta: (c) => `Voir les donnees du canton ${c}`,
+  },
+};
+
+/**
+ * Below-floor bridge: a (canton, profession) pair that doesn't meet MIN_JOBS
+ * this build gets a noindex,follow canonical bridge instead of a hard 404.
+ * Job counts fluctuate build to build, and this exact path may have been
+ * indexed on a prior build when it did meet the floor (same orphaned-static-
+ * page class fixed for weekly-employers company-city hubs via
+ * findOrphanedCompanyCityPairs in weeklyEmployersPlugin.ts). The bridge
+ * targets the same per-canton salary-stats hub the live page's own CTA links
+ * to (buildSalaryStatsPath) — that family is emitted unconditionally for
+ * every canton regardless of job counts, so it's always a safe target.
+ */
+function renderBelowFloorBridge(locale: ProfessionLocale, cantonKey: string, id: ProfessionId): string {
+  const cantonName = getCantonDisplayName(cantonKey, locale as CantonDisplayLocale);
+  const role = professionLabel(locale, id);
+  const copy = BRIDGE_COPY[locale];
+  return renderSalaryStatsBridge(locale, cantonKey, {
+    title: copy.title(role, cantonName),
+    description: copy.body(role, cantonName),
+    ctaLabel: copy.cta(cantonName),
+  });
+}
+
 export function renderProfessionCantonPage(opts: {
   locale: ProfessionLocale;
   cantonKey: string;
@@ -220,7 +273,7 @@ export function renderProfessionCantonPage(opts: {
   const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
   // Link to the per-canton salary stats landing (shipped in PR #2085) + the
   // job board filtered by this role.
-  const ctaHref = `${PROFESSION_LOCALE_PREFIX[locale]}/${locale === 'it' ? 'stipendi' : locale === 'en' ? 'salaries' : locale === 'de' ? 'gehaelter' : 'salaires'}-${cantonSlug}/`.replace(/\/{2,}/g, '/');
+  const ctaHref = buildSalaryStatsPath(locale, cantonSlug);
 
   const prose = renderCantonSeoProse({
     locale: locale as CantonSeoLocale,
@@ -285,6 +338,8 @@ export interface ProfessionCantonEmitResult {
   pagesWritten: number;
   pagesSkippedForJobs: number;
   pagesSkippedForWordCount: number;
+  /** Below-floor pairs bridged to the salary-stats hub instead of left to 404. */
+  bridgesWritten: number;
   emittedPaths: string[];
 }
 
@@ -332,17 +387,26 @@ function removeSitemapFromIndex(distDir: string): void {
 }
 
 export async function emitProfessionCantonPages(opts: { rootDir: string; distDir: string }): Promise<ProfessionCantonEmitResult> {
-  const result: ProfessionCantonEmitResult = { pagesWritten: 0, pagesSkippedForJobs: 0, pagesSkippedForWordCount: 0, emittedPaths: [] };
+  const result: ProfessionCantonEmitResult = { pagesWritten: 0, pagesSkippedForJobs: 0, pagesSkippedForWordCount: 0, bridgesWritten: 0, emittedPaths: [] };
   const byCanton = aggregateProfessionJobsByCanton(opts.rootDir);
   const collector = new WriteCollector({ distDir: opts.distDir, pluginName: 'professionCantonLandings' });
 
   for (const cantonKey of PROFESSION_CANTON_KEYS) {
+    // No early `continue` on a missing canton bucket: a canton with zero
+    // matched jobs this build (data gap, not just one profession dipping
+    // below floor) must still get bridges for every profession, or a
+    // previously-live page in that canton would 404 with no recovery path.
     const perProfession = byCanton[cantonKey];
-    if (!perProfession) continue;
     for (const id of PROFESSION_IDS) {
-      const snapshot = perProfession[id];
+      const snapshot = perProfession?.[id];
       if (!snapshot || snapshot.liveCount < MIN_JOBS) {
         result.pagesSkippedForJobs++;
+        for (const locale of PROFESSION_LOCALES) {
+          const canonicalPath = buildProfessionCantonPath(locale, cantonKey, id);
+          const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+          collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, cantonKey, id));
+          result.bridgesWritten++;
+        }
         continue;
       }
       // Render all 4 locales first and emit ALL-OR-NOTHING: every emitted page
@@ -397,7 +461,7 @@ export function professionCantonLandings(rootDir: string): Plugin {
       const distDir = np.resolve(rootDir, 'dist');
       const res = await emitProfessionCantonPages({ rootDir, distDir });
       // eslint-disable-next-line no-console
-      console.log(`[profession-cantons] emitted ${res.pagesWritten} pages (${res.pagesSkippedForJobs} pairs below job floor, ${res.pagesSkippedForWordCount} below word gate)`);
+      console.log(`[profession-cantons] emitted ${res.pagesWritten} pages, ${res.bridgesWritten} below-floor bridges (${res.pagesSkippedForJobs} pairs below job floor, ${res.pagesSkippedForWordCount} below word gate)`);
       // Hand the emitted canonical paths to professionCantonLandingsLinksPlugin
       // so it can de-orphan exactly the pages that shipped (CLAUDE.md regola #5:
       // close orphans with real internal links, not by relaxing the gate).

--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -9,6 +9,7 @@ import {
  type FuelDailyLocale,
  type FuelType,
 } from './fuelDailyData';
+import { isProfessionCantonPath } from './professionCantonData';
 
 type SupportedLocale = CantonLocale;
 
@@ -168,10 +169,12 @@ const SECTION_FALLBACKS: Array<{ pattern: RegExp; canonical: string; locale: Sup
  // FUEL_SECTION_FALLBACKS below.
  ...FUEL_SECTION_FALLBACKS,
  // Company-hub section. Per-company×city×week leaves (e.g. .../locarno/{company}/settimana-corrente/)
- // 404 once that company has no current-week openings; route to the hub root (IT + EN only —
- // the DE/FR hub roots are not emitted, so no fallback target exists for them).
+ // 404 once that company has no current-week openings; route to the hub root, all 4 locales
+ // (weeklyEmployersPlugin's renderTopHubPage loop emits a hub root for every WEEKLY_EMPLOYERS_LOCALE).
  { pattern: /^\/aziende-che-assumono\//, canonical: '/aziende-che-assumono/', locale: 'it' },
  { pattern: /^\/en\/companies-hiring\//, canonical: '/en/companies-hiring/', locale: 'en' },
+ { pattern: /^\/de\/unternehmen-einstellen\//, canonical: '/de/unternehmen-einstellen/', locale: 'de' },
+ { pattern: /^\/fr\/entreprises-recrutent\//, canonical: '/fr/entreprises-recrutent/', locale: 'fr' },
  // Legacy flat `/lavoro/` job-detail prefix (pre per-canton structure). Route to the
  // localized job-board listing root.
  { pattern: /^\/lavoro\//, canonical: '/cerca-lavoro-ticino/', locale: 'it' },
@@ -307,6 +310,22 @@ export function resolveSearchConsoleCompatTarget(
  }
 
  const locale = inferLocale(path);
+
+ // Profession-canton landings (professionCantonLandings.ts) emit every
+ // (canton × profession) combo unconditionally — either the full page or a
+ // below-floor bridge — so a URL matching this family's exact enumerated
+ // shape always has a live target at the SAME path today, even if GSC's
+ // Coverage export captured it as 404 from before that page existed / was
+ // below floor on an earlier build. Self-map so the compat layer (which
+ // never sees the plugin's own route table otherwise) stops reporting it
+ // unresolvable.
+ if (isProfessionCantonPath(path)) {
+ return {
+ canonicalPath: ensureTrailingSlash(path),
+ kind: 'legacy',
+ locale,
+ };
+ }
 
  if (/\/(ricerca|search|suche|recherche)-/.test(path)) {
  // Legacy per-canton cluster URL with a KNOWN live target: recover the

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -21,7 +21,7 @@ import type fsT from 'node:fs';
 import { clampMetaDescription } from './shared/titleSuffix';
 import { railGutters } from './shared/railGutters';
 import type npT from 'node:path';
-import { ADSENSE_SNIPPET, BASE_URL, CDN_PRECONNECT_HINT } from './constants';
+import { ADSENSE_SNIPPET, BASE_URL, buildCanonicalBridgePage, CDN_PRECONNECT_HINT } from './constants';
 import { asyncCssHeadBlock, rootShell } from './htmlTemplate';
 import {
   ARTICLES_PAGE_SIZE,
@@ -1921,10 +1921,43 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
           companyUrlToKey, crawledLogos,
           jobPerLocale, entryJs, entryCss, hasSpaBundle, onPageEmitted } = args;
 
+
+  // Below-floor / noindex-parent bridge: when a canton's `tutti`/`settori`/
+  // `aziende` sub-hubs are skipped (job-count floor drop, or the canton
+  // landing itself went noindex — see cantonNoindexRegistry.ts), a URL that
+  // may already be indexed (via a prior build's sitemap) would otherwise
+  // hard-404 on GitHub Pages. Emit a noindex canonical-bridge page instead,
+  // pointing at the always-live canton section root
+  // (`resolveCantonSection` — same target jobsSeoPagesPlugin's own
+  // below-floor bridges use). Never added to the sitemap: this is a soft
+  // landing spot for stale inbound/crawled links, not new indexable content.
+  let thinCantonHubBelowFloorBridges = 0;
+  const emitCantonHubBelowFloorBridge = (canton: string): void => {
+    for (const locale of HUB_LOCALES) {
+      const section = resolveCantonSection(locale, canton);
+      const localePrefix = locale === 'it' ? '' : `/${locale}`;
+      const targetPath = `${localePrefix}/${section}/`;
+      for (const hub of ['tutti', 'settori', 'aziende'] as const) {
+        const canonicalPath = hubSlugFor(canton, locale, hub);
+        const html = buildCanonicalBridgePage({
+          canonicalUrl: `${BASE_URL}${targetPath}`,
+          pathLabel: canonicalPath,
+          lang: locale,
+          noindex: true,
+        });
+        qw(np.join(distDir, canonicalPath.slice(1), 'index.html'), html);
+        thinCantonHubBelowFloorBridges++;
+      }
+    }
+  };
+
   for (const canton of ALL_CANTON_CODES) {
     if (canton === 'TI') continue; // TI already emitted with full body above
     const total = cantonJobCounts.get(canton) ?? 0;
-    if (total < MIN_JOBS_FOR_CANTON_PAGE) continue;
+    if (total < MIN_JOBS_FOR_CANTON_PAGE) {
+      emitCantonHubBelowFloorBridge(canton);
+      continue;
+    }
 
     const jobs = cantonJobs.get(canton) ?? [];
     // Tighter gate: cantonJobCounts increments on every job (line 212), but
@@ -1936,7 +1969,10 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
     // gate to require ≥ MIN actual slug-bearing jobs to avoid that. Audit:
     // `sitemap-seo-hubs.xml` BFS regression 2026-05-18 (cerca-lavoro-
     // appenzello/{tutti,settori,aziende}/ +3 unreachable).
-    if (jobs.length < MIN_JOBS_FOR_CANTON_PAGE) continue;
+    if (jobs.length < MIN_JOBS_FOR_CANTON_PAGE) {
+      emitCantonHubBelowFloorBridge(canton);
+      continue;
+    }
 
     // Authoritative noindex check (2026-05-21 follow-up): the local dedup
     // heuristic below could not access `job.id` (snapshot-history rows carry
@@ -1950,7 +1986,10 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
     // jobsSeoPagesPlugin earlier in the same closeBundle pass) is the source
     // of truth. Audit: sitemap-seo-hubs.xml BFS regression 2026-05-21
     // (appenzello/sciaffusa/uri × 3 facets = 9 orphans).
-    if (isCantonNoindex(canton)) continue;
+    if (isCantonNoindex(canton)) {
+      emitCantonHubBelowFloorBridge(canton);
+      continue;
+    }
 
     // Local dedup fallback gate kept as a defense-in-depth check: covers the
     // case where the registry was never populated (e.g. jobsSeoPagesPlugin
@@ -1963,7 +2002,10 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
         const empKey = String(j.employerKey || j.employer || '').toLowerCase().replace(/\s+/g, ' ').trim();
         dedupKeys.add(`tc|${role}|${empKey}`);
       }
-      if (dedupKeys.size < MIN_JOBS_FOR_CANTON_PAGE) continue;
+      if (dedupKeys.size < MIN_JOBS_FOR_CANTON_PAGE) {
+        emitCantonHubBelowFloorBridge(canton);
+        continue;
+      }
     }
 
     const empCounts = cantonEmployerCounts.get(canton) ?? new Map<string, number>();
@@ -2155,6 +2197,9 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
         }
       }
     }
+  }
+  if (thinCantonHubBelowFloorBridges > 0) {
+    console.log(`\x1b[36m[seo-hubs]\x1b[0m below-floor/noindex canton hub bridges: ${thinCantonHubBelowFloorBridges}`);
   }
 }
 

--- a/build-plugins/shared/salaryStatsBridge.ts
+++ b/build-plugins/shared/salaryStatsBridge.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared below-floor bridge target for any per-canton page family that gates
+ * emission on a job-count/threshold floor. Without this, a canton that met
+ * the floor on a prior build (page emitted, URL crawled/indexed) and drops
+ * below it on a later build gets zero pages emitted — a hard GitHub Pages
+ * 404 for a previously-live URL, since Google reads the static HTTP status
+ * before any client-side JS runs (no SPA fallback is possible).
+ *
+ * The salary-stats hub (`salaryStatsChCantonPages.ts`) is emitted
+ * unconditionally for every (locale, canton) combo regardless of job counts,
+ * making it a safe, permanently-live redirect target. Below-floor cantons
+ * bridge here instead of being silently skipped.
+ *
+ * Consumers: professionCantonLandings.ts, weeklyEmployersChCantonPages.ts,
+ * jobMarketSnapshotChCantonPages.ts.
+ */
+import { BASE_URL, buildCanonicalBridgePage } from '../constants';
+import {
+  SALARY_STATS_CANTON_SLUGS,
+  SALARY_STATS_LOCALES,
+  buildSalaryStatsPath,
+  type SalaryStatsLocale,
+} from '../salaryStatsData';
+
+export interface SalaryStatsBridgeCopy {
+  title: string;
+  description: string;
+  ctaLabel: string;
+}
+
+export function salaryStatsBridgeTarget(
+  locale: SalaryStatsLocale,
+  cantonKey: string,
+): { targetPath: string; targetUrl: string } {
+  const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+  const targetPath = buildSalaryStatsPath(locale, cantonSlug);
+  return { targetPath, targetUrl: `${BASE_URL}${targetPath}` };
+}
+
+export function renderSalaryStatsBridge(
+  locale: SalaryStatsLocale,
+  cantonKey: string,
+  copy: SalaryStatsBridgeCopy,
+): string {
+  const { targetPath, targetUrl } = salaryStatsBridgeTarget(locale, cantonKey);
+  // Every hreflang alternate points at the salary-stats hub's OWN localized
+  // URL for this canton (not the below-floor page's URL) — that hub is the
+  // only guaranteed-live target across all 4 locales. x-default mirrors IT
+  // byte-for-byte, matching the shared-helper invariant enforced elsewhere.
+  const hreflangEntries: Array<{ hreflang: string; href: string }> = SALARY_STATS_LOCALES.map((loc) => ({
+    hreflang: loc,
+    href: salaryStatsBridgeTarget(loc, cantonKey).targetUrl,
+  }));
+  hreflangEntries.push({ hreflang: 'x-default', href: salaryStatsBridgeTarget('it', cantonKey).targetUrl });
+  const html = buildCanonicalBridgePage({
+    canonicalUrl: targetUrl,
+    pathLabel: targetPath,
+    title: copy.title,
+    description: copy.description,
+    body: copy.description,
+    ctaLabel: copy.ctaLabel,
+    lang: locale,
+    noindex: true,
+    hreflangEntries,
+  });
+  return html.replace(
+    '</head>',
+    `    <meta http-equiv="refresh" content="0; url=${targetUrl}">\n  </head>`,
+  );
+}

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -48,6 +48,8 @@ import {
   type SwissCantonCode,
   type WeeklyEmployersLocale,
 } from './weeklyEmployersData';
+import { PROFESSION_CANTON_KEYS } from './professionCantonData';
+import { renderSalaryStatsBridge } from './shared/salaryStatsBridge';
 
 type Locale = WeeklyEmployersLocale;
 
@@ -440,6 +442,54 @@ export interface ChCantonEmployersEmitResult {
   cantonsEmitted: Array<{ code: SwissCantonCode | string; jobsCount: number; employersCount: number }>;
   cantonsSkipped: Array<{ code: SwissCantonCode | string; jobsCount: number }>;
   pagesSkippedForWordCount: number;
+  /** Below-floor cantons bridged to the salary-stats hub instead of left to 404. */
+  bridgesWritten: number;
+}
+
+interface BridgeCopy {
+  title: (canton: string) => string;
+  body: (canton: string) => string;
+  cta: (canton: string) => string;
+}
+
+const BRIDGE_COPY: Record<Locale, BridgeCopy> = {
+  it: {
+    title: (c) => `Aziende che assumono — Canton ${c}`,
+    body: (c) => `Al momento non ci sono abbastanza aziende attive nel Canton ${c} da mostrare una pagina dedicata. Consulta stipendi e mercato del lavoro nel Canton ${c}.`,
+    cta: (c) => `Vai ai dati del Canton ${c}`,
+  },
+  en: {
+    title: (c) => `Companies hiring — Canton ${c}`,
+    body: (c) => `There aren't enough active companies in Canton ${c} right now for a dedicated page. See salary and job-market data for Canton ${c}.`,
+    cta: (c) => `Go to Canton ${c} data`,
+  },
+  de: {
+    title: (c) => `Firmen, die einstellen — Kanton ${c}`,
+    body: (c) => `Im Kanton ${c} gibt es derzeit nicht genug aktive Firmen fur eine eigene Seite. Lohn- und Arbeitsmarktdaten fur den Kanton ${c} ansehen.`,
+    cta: (c) => `Zu den Daten fur Kanton ${c}`,
+  },
+  fr: {
+    title: (c) => `Entreprises qui recrutent — canton ${c}`,
+    body: (c) => `Il n'y a pas assez d'entreprises actives dans le canton ${c} pour une page dediee actuellement. Consultez les donnees salariales et du marche du travail du canton ${c}.`,
+    cta: (c) => `Voir les donnees du canton ${c}`,
+  },
+};
+
+/**
+ * Below-floor bridge: a canton that doesn't meet MERGE_THRESHOLD this build
+ * gets a noindex,follow canonical bridge instead of a hard 404. Job counts
+ * fluctuate build to build, and this exact path may have been indexed on a
+ * prior build when the canton did meet the floor (same orphaned-static-page
+ * class fixed for profession-canton landings — professionCantonLandings.ts).
+ */
+function renderBelowFloorBridge(locale: Locale, cantonCode: string): string {
+  const cantonName = getCantonDisplayName(cantonCode, locale);
+  const copy = BRIDGE_COPY[locale];
+  return renderSalaryStatsBridge(locale, cantonCode, {
+    title: copy.title(cantonName),
+    description: copy.body(cantonName),
+    ctaLabel: copy.cta(cantonName),
+  });
 }
 
 /**
@@ -455,6 +505,7 @@ export async function emitChCantonEmployersPages(
     cantonsEmitted: [],
     cantonsSkipped: [],
     pagesSkippedForWordCount: 0,
+    bridgesWritten: 0,
   };
 
   const slugFile = loadCantonSlugFile(opts.rootDir);
@@ -501,6 +552,14 @@ export async function emitChCantonEmployersPages(
       eligibleCantons.push(code);
     } else {
       result.cantonsSkipped.push({ code, jobsCount: bucket.activeJobsCount });
+    }
+  }
+  // A canton with zero matched jobs this build never enters mergedByCanton at
+  // all; without this it would silently vanish from cantonsSkipped too, and a
+  // canton whose active count later hit zero would get no bridge either.
+  for (const code of PROFESSION_CANTON_KEYS) {
+    if (!mergedByCanton.has(code)) {
+      result.cantonsSkipped.push({ code, jobsCount: 0 });
     }
   }
 
@@ -568,6 +627,20 @@ export async function emitChCantonEmployersPages(
       const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       collector.add(np.join(outDir, 'index.html'), html);
       result.pagesWritten++;
+    }
+  }
+
+  // Below-floor cantons (recorded above) still get a noindex bridge to their
+  // salary-stats hub — never a silent drop of a page a prior build may have
+  // emitted and Google indexed.
+  for (const skipped of result.cantonsSkipped) {
+    for (const locale of LOCALES) {
+      const cantonSlug = getCantonUrlSlugLocal(slugFile, skipped.code, locale);
+      if (!cantonSlug) continue;
+      const canonicalPath = buildCantonEmployersPath(locale, cantonSlug);
+      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+      collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, skipped.code));
+      result.bridgesWritten++;
     }
   }
 

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -107,6 +107,7 @@ import { LOGO_IMG_ONERROR } from './shared/companyLogoResolver';
 import { type JobInput } from './shared/jobPostingSchema';
 import { buildListItemJobPosting } from './shared/jobPostingListItem';
 import { cleanNamespaces, cleanSitemapFiles } from './shared/distNamespaceCleanup';
+import { NOINDEX_BRIDGE } from './flatHtmlRedirectPlugin';
 import { employerCanonicalHref, loadKnownCompanySlugs, slugifyEmployer } from './shared/employerLinks';
 import {
   renderEmployerCardListHtml,
@@ -1200,6 +1201,78 @@ export function enumerateCompanyCityPairs(
     MAX_COMPANY_CITY_PAGES_PER_BUILD / WEEKLY_EMPLOYERS_LOCALES.length,
   );
   return pages.slice(0, maxPairs);
+}
+
+/**
+ * (city, companySlug) pairs that met {@link companyCityMeetsThreshold} in some
+ * past weekly snapshot but are absent from `currentPairs` this build.
+ *
+ * `closeBundle` wipes the whole company×city namespace before regenerating
+ * (see "Ext3 task 3" in `weeklyEmployersPlugin`'s closeBundle) so a page that
+ * qualified last week and got indexed, then dropped below
+ * `MIN_JOBS_PER_COMPANY_IN_CITY` this week, would otherwise hard-404 instead
+ * of redirecting — this is what backfills the gap so the closeBundle handler
+ * can emit a noindex bridge to the city hub for each one instead.
+ */
+export function findOrphanedCompanyCityPairs(
+  snapshots: readonly JobsSnapshot[],
+  currentPairs: readonly CompanyCityPair[],
+): Array<CompanyCityPair & { employer: string }> {
+  const currentKeys = new Set(currentPairs.map((p) => `${p.city}::${p.companySlug}`));
+  const seen = new Map<string, CompanyCityPair & { employer: string }>();
+
+  for (const snapshot of snapshots) {
+    const counts = new Map<
+      WeeklyEmployersCompanyCity,
+      Map<string, { employer: string; active: number }>
+    >();
+    for (const job of snapshot.jobs) {
+      const employer = String(job.employer || '').trim();
+      if (!employer) continue;
+      const employerKey = normEmployerKey(employer, job.employerKey);
+      if (!employerKey) continue;
+      const cityLower = String(job.city || '').toLowerCase();
+      if (!cityLower) continue;
+      for (const city of WEEKLY_EMPLOYERS_COMPANY_CITY_LIST) {
+        if (!cityLower.includes(WEEKLY_EMPLOYERS_CITY_DISPLAY[city].toLowerCase())) continue;
+        let cityCounts = counts.get(city);
+        if (!cityCounts) {
+          cityCounts = new Map();
+          counts.set(city, cityCounts);
+        }
+        const rec = cityCounts.get(employerKey);
+        if (rec) rec.active++;
+        else cityCounts.set(employerKey, { employer, active: 1 });
+      }
+    }
+    for (const [city, cityCounts] of counts.entries()) {
+      for (const [employerKey, rec] of cityCounts.entries()) {
+        if (!companyCityMeetsThreshold(rec)) continue;
+        const companySlug = canonicalCompanySlug(rec.employer, employerKey);
+        if (!companySlug || !/^[a-z0-9][a-z0-9-]*$/.test(companySlug)) continue;
+        const key = `${city}::${companySlug}`;
+        if (currentKeys.has(key) || seen.has(key)) continue;
+        seen.set(key, { city, companySlug, employer: rec.employer });
+      }
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+/**
+ * noindex,follow redirect bridge for an orphaned company-city pair, pointing
+ * crawlers at the still-live city hub instead of a 404.
+ */
+export function renderOrphanCompanyCityBridge(
+  locale: WeeklyEmployersLocale,
+  city: WeeklyEmployersCompanyCity,
+  employer: string,
+): string {
+  const hubPath = buildCurrentWeekPath(locale, city);
+  const hubUrl = `${BASE_URL}${hubPath}`;
+  const title = `${employer} — ${WEEKLY_EMPLOYERS_CITY_DISPLAY[city]}`;
+  return NOINDEX_BRIDGE(hubUrl, title, '');
 }
 
 /**
@@ -3730,6 +3803,9 @@ export interface GeneratedPage {
   path: string;
   html: string;
   indexable: boolean;
+  /** True for orphaned-pair redirect bridges — exempt from the MIN_INDEXABLE_WORDS
+   * gate (they're deliberately noindex, so thin-content rules don't apply). */
+  bridge?: boolean;
 }
 
 export interface GenerationOptions {
@@ -3799,6 +3875,9 @@ export function generateWeeklyEmployerPages(opts: GenerationOptions): GeneratedP
   const __tPairs = __weProfStart();
   const qualifyingPairs = enumerateCompanyCityPairs(opts.jobs, jobPartition);
   __weProfRecord('gen-pairs', __tPairs);
+  const __tOrphans = __weProfStart();
+  const orphanedPairs = findOrphanedCompanyCityPairs(opts.snapshots, qualifyingPairs);
+  __weProfRecord('gen-orphans', __tOrphans);
   const leavesByCity = new Map<
     WeeklyEmployersCompanyCity,
     Array<{ companySlug: string; employer: string }>
@@ -4041,6 +4120,17 @@ export function generateWeeklyEmployerPages(opts: GenerationOptions): GeneratedP
     }
   }
 
+  // Orphaned pairs: qualified in a past snapshot, don't qualify this build.
+  // Bridge every locale's canonical path to the still-live city hub instead
+  // of letting cleanNamespaces() turn the URL into a 404.
+  for (const orphan of orphanedPairs) {
+    for (const locale of WEEKLY_EMPLOYERS_LOCALES) {
+      const canonicalPath = buildCompanyCityCurrentPath(locale, orphan.city, orphan.companySlug);
+      const html = renderOrphanCompanyCityBridge(locale, orphan.city, orphan.employer);
+      pages.push({ path: canonicalPath, html, indexable: false, bridge: true });
+    }
+  }
+
   return pages;
 }
 
@@ -4051,6 +4141,7 @@ interface PluginResult {
   currentWeekPages: number;
   archivePages: number;
   companyCityPages: number;
+  orphanBridgePages: number;
   skippedForWordCount: number;
   degradedMode: boolean;
 }
@@ -4121,6 +4212,7 @@ export function weeklyEmployersPlugin(rootDir: string): Plugin {
       let currentWeekCount = 0;
       let archiveCount = 0;
       let companyCityCount = 0;
+      let orphanBridgeCount = 0;
       let skipped = 0;
       // Paths that should land in sitemap-weekly-employers.xml. Only indexable
       // pages (current-week + last-12-weeks archives) are listed — noindex
@@ -4133,14 +4225,19 @@ export function weeklyEmployersPlugin(rootDir: string): Plugin {
 
       for (const page of pages) {
         const __tPage = __weProfStart();
-        const words = countHtmlBodyWords(page.html);
-        if (words < MIN_INDEXABLE_WORDS) {
-          skipped++;
-          console.warn(
-            `[weekly-employers] thin content (${words} words) for ${page.path} — skipping`,
-          );
-          __weProfRecord('process-page', __tPage);
-          continue;
+        // Orphaned-pair redirect bridges are deliberately noindex and tiny —
+        // the thin-content gate exists to keep indexed pages substantial, not
+        // to block a redirect stub from reaching crawlers still hitting it.
+        if (!page.bridge) {
+          const words = countHtmlBodyWords(page.html);
+          if (words < MIN_INDEXABLE_WORDS) {
+            skipped++;
+            console.warn(
+              `[weekly-employers] thin content (${words} words) for ${page.path} — skipping`,
+            );
+            __weProfRecord('process-page', __tPage);
+            continue;
+          }
         }
         const outDir = np.join(distDir, page.path.replace(/^\/+/, ''));
         collector.add(np.join(outDir, 'index.html'), page.html);
@@ -4148,7 +4245,8 @@ export function weeklyEmployersPlugin(rootDir: string): Plugin {
         // city, companySlug, when) vs. 3 segments for city-only pages. Use the
         // parse helper so we don't re-derive the rule.
         const companyCityMatch = parseCompanyCityPath(page.path);
-        if (companyCityMatch) companyCityCount++;
+        if (page.bridge) orphanBridgeCount++;
+        else if (companyCityMatch) companyCityCount++;
         else if (archiveRe.test(page.path)) archiveCount++;
         else currentWeekCount++;
         if (page.indexable) indexableSitemapPaths.push(page.path);
@@ -4197,12 +4295,13 @@ ${urlEntries}
         currentWeekPages: currentWeekCount,
         archivePages: archiveCount,
         companyCityPages: companyCityCount,
+        orphanBridgePages: orphanBridgeCount,
         skippedForWordCount: skipped,
         degradedMode: degraded,
       };
 
       console.log(
-        `\x1b[36m[weekly-employers]\x1b[0m Generated ${result.currentWeekPages} current-week + ${result.archivePages} archive + ${result.companyCityPages} company×city pages (skipped ${result.skippedForWordCount}) — degraded=${result.degradedMode}`,
+        `\x1b[36m[weekly-employers]\x1b[0m Generated ${result.currentWeekPages} current-week + ${result.archivePages} archive + ${result.companyCityPages} company×city + ${result.orphanBridgePages} orphan-bridge pages (skipped ${result.skippedForWordCount}) — degraded=${result.degradedMode}`,
       );
 
       // ── P2.S1: per-canton CH-wide "companies hiring" pages ────────
@@ -4218,7 +4317,7 @@ ${urlEntries}
         });
         const localesCount = WEEKLY_EMPLOYERS_LOCALES.length;
         console.log(
-          `\x1b[36m[weekly-employers]\x1b[0m P2.S1 emitted ${r.cantonsEmitted.length} per-canton employer pages × ${localesCount} locales`,
+          `\x1b[36m[weekly-employers]\x1b[0m P2.S1 emitted ${r.cantonsEmitted.length} per-canton employer pages × ${localesCount} locales (+${r.bridgesWritten} below-floor bridges)`,
         );
         if (r.cantonsSkipped.length > 0) {
           const skipped = r.cantonsSkipped
@@ -4226,7 +4325,7 @@ ${urlEntries}
             .map((s) => `${s.code}:${s.jobsCount}`)
             .join(', ');
           if (skipped) {
-            console.log(`[weekly-employers] P2.S1 skipped (below 5 jobs): ${skipped}`);
+            console.log(`[weekly-employers] P2.S1 skipped (below 5 jobs, bridged): ${skipped}`);
           }
         }
       } catch (err) {

--- a/data/gsc-coverage-404s.json
+++ b/data/gsc-coverage-404s.json
@@ -1348,6 +1348,7 @@
     "/cerca-lavoro-zurigo/your-responsibilities-hirslanden-klinik-search-dc220e",
     "/cerca-lavoro-zurigo/your-responsibilities-hirslanden-klinik-search-e59511",
     "/cerca-lavoro-zurigo/zenbu-cook-two-spice-ag-dietlikon",
+    "/de/arbeit-aargau-kellner",
     "/de/benzinpreis-schweiz/lugano/tankstellen/socar-via-colombera",
     "/de/grenzgaenger-artikel/alle/page-10",
     "/de/grenzgaenger-artikel/alle/page-15",
@@ -1678,6 +1679,7 @@
     "/de/jobs-in-zurich/zivildiensteinsatz-als-assistent-klinikschule-100-lups-kriens",
     "/de/jobs-in-zurich/zivildienstleistender-technischer-dienst-spitaler-schaffhausen-schaffhausen",
     "/de/jobs-in-zurich/zusatzlehre-als-detailhandelsfachfrau-mann-efz-jumbo-dietikon-w93yue",
+    "/de/unternehmen-einstellen/bellinzona/swiss-armed-forces-vtg/aktuelle-woche",
     "/en/companies-hiring/lugano/lis-lugano-istituti-sociali/current-week",
     "/en/cross-border-articles/all/page-6",
     "/en/cross-border-articles/titlis-tragedy-wind-gust",
@@ -2164,5 +2166,5 @@
     "/prezzi-diesel/lugano/stazioni/eni-strada-per-gandria"
   ],
   "source": "gsc-coverage-drilldown",
-  "lastUpdated": "2026-07-03"
+  "lastUpdated": "2026-07-05"
 }

--- a/data/jobs/by-crawler/hilcona.json
+++ b/data/jobs/by-crawler/hilcona.json
@@ -4752,9 +4752,9 @@
       "slug": "collaboratore-trice-schlussdienst-m-w-d-hilcona-ag-bell-food-group-landquart",
       "slugByLocale": {
         "it": "collaboratore-trice-schlussdienst-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "en": "mitarbeiter-schlussdienst-m-w-d-hilcona-undefined",
+        "en": "employees-final-service-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
         "de": "mitarbeiter-schlussdienst-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "fr": "mitarbeiter-schlussdienst-m-w-d-hilcona-undefined"
+        "fr": "employes-service-final-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
       },
       "company": "Hubers Landhendl GmbH",
       "companyKey": "hilcona",
@@ -4799,16 +4799,19 @@
           "collaboratore-trice-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
         ],
         "en": [
-          "mitarbeiter-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
+          "mitarbeiter-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+          "mitarbeiter-schlussdienst-m-w-d-hilcona-undefined"
         ],
         "fr": [
-          "mitarbeiter-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
+          "mitarbeiter-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+          "mitarbeiter-schlussdienst-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
         "mitarbeiter-schlussdienst-m-w-d-hilcona-pfaffstatt",
         "mitarbeiter-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-        "collaboratore-trice-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
+        "collaboratore-trice-schlussdienst-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+        "mitarbeiter-schlussdienst-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-17T10:24:13.602Z",
       "salaryMin": 64500,
@@ -4832,8 +4835,8 @@
       "slug": "culinary-consulente-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
       "slugByLocale": {
         "it": "culinary-consulente-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
-        "en": "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined",
-        "de": "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined",
+        "en": "culinary-advisor-at-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
+        "de": "culinary-berater-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
         "fr": "culinary-conseiller-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen"
       },
       "company": "Hilcona Feinkost GmbH",
@@ -4872,14 +4875,16 @@
       "previousSlugsByLocale": {
         "de": [
           "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
-          "culinary-berater-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen"
+          "culinary-berater-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
+          "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined"
         ],
         "it": [
           "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined",
           "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-leinfelden-echterdingen"
         ],
         "en": [
-          "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen"
+          "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-feinkost-gmbh-leinfelden-echterdingen",
+          "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined"
         ],
         "fr": [
           "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined"
@@ -4910,12 +4915,12 @@
     },
     {
       "id": "hilcona-f683d89b7e88",
-      "slug": "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined",
+      "slug": "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
       "slugByLocale": {
-        "it": "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined",
-        "en": "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined",
+        "it": "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
+        "en": "team-leader-procurement-eu-raw-materials-m-w-d-hfc-gmbh-bad-wunnenberg",
         "de": "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "fr": "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined"
+        "fr": "chef-d-equipe-achats-matieres-premieres-de-l-ue-m-w-d-hfc-gmbh-bad-wunnenberg"
       },
       "company": "HFC GmbH",
       "companyKey": "hilcona",
@@ -4957,19 +4962,23 @@
         ],
         "it": [
           "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-bad-wunnenberg",
-          "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg"
+          "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
+          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined"
         ],
         "en": [
-          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg"
+          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
+          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined"
         ],
         "fr": [
-          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg"
+          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
+          "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
         "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-bad-wunnenberg",
         "teamleiter-beschaffung-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
-        "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg"
+        "team-leader-acquisizione-eu-rohwaren-m-w-d-hfc-gmbh-bad-wunnenberg",
+        "teamleiter-beschaffung-eu-rohwaren-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:49.444Z",
       "salaryMin": 64500,
@@ -4994,7 +5003,7 @@
       "slugByLocale": {
         "it": "sap-sd-inhouse-consulente-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "en": "sap-sd-inhouse-consultant-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "de": "sap-sd-inhouse-consultant-m-w-d-hilcona-undefined",
+        "de": "sap-sd-inhouse-berater-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "fr": "sap-sd-conseiller-interne-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
       },
       "company": "Hügli Nahrungsmittel GmbH",
@@ -5033,7 +5042,8 @@
       "previousSlugsByLocale": {
         "de": [
           "sap-sd-inhouse-consultant-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
-          "sap-sd-inhouse-berater-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
+          "sap-sd-inhouse-berater-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
+          "sap-sd-inhouse-consultant-m-w-d-hilcona-undefined"
         ],
         "it": [
           "sap-sd-inhouse-consultant-m-w-d-hilcona-undefined",
@@ -5075,9 +5085,9 @@
       "slug": "capo-dello-sviluppo-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
       "slugByLocale": {
         "it": "capo-dello-sviluppo-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
-        "en": "leiter-entwicklung-m-w-d-hilcona-undefined",
+        "en": "head-of-development-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "de": "leiter-entwicklung-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "fr": "leiter-entwicklung-m-w-d-hilcona-undefined"
+        "fr": "chef-du-developpement-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
       },
       "company": "Hügli Nahrungsmittel GmbH",
       "companyKey": "hilcona",
@@ -5123,16 +5133,19 @@
           "leiter-entwicklung-m-w-d-hilcona-radolfzell"
         ],
         "en": [
-          "leiter-entwicklung-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
+          "leiter-entwicklung-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
+          "leiter-entwicklung-m-w-d-hilcona-undefined"
         ],
         "fr": [
-          "leiter-entwicklung-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
+          "leiter-entwicklung-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
+          "leiter-entwicklung-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
         "leiter-entwicklung-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "leiter-entwicklung-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "leiter-entwicklung-m-w-d-hilcona-radolfzell"
+        "leiter-entwicklung-m-w-d-hilcona-radolfzell",
+        "leiter-entwicklung-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:48.914Z",
       "salaryMin": 113500,
@@ -5153,12 +5166,12 @@
     },
     {
       "id": "hilcona-215c71b1294b",
-      "slug": "automatikerin-automatiker-100-hilcona-undefined",
+      "slug": "automatico-100-bell-schweiz-ag-zell",
       "slugByLocale": {
-        "it": "automatikerin-automatiker-100-hilcona-undefined",
-        "en": "automatikerin-automatiker-100-hilcona-undefined",
+        "it": "automatico-100-bell-schweiz-ag-zell",
+        "en": "automatician-automatician-100-bell-schweiz-ag-zell",
         "de": "automatikerin-automatiker-100-hilcona-ag-bell-food-group-landquart",
-        "fr": "automatikerin-automatiker-100-hilcona-undefined"
+        "fr": "automatician-automatician-100-bell-schweiz-ag-zell"
       },
       "company": "Bell Schweiz AG",
       "companyKey": "hilcona",
@@ -5198,11 +5211,19 @@
           "automatikerin-automatiker-100-hilcona-zell"
         ],
         "it": [
-          "automatikerin-automatiker-100-hilcona-zell"
+          "automatikerin-automatiker-100-hilcona-zell",
+          "automatikerin-automatiker-100-hilcona-undefined"
+        ],
+        "en": [
+          "automatikerin-automatiker-100-hilcona-undefined"
+        ],
+        "fr": [
+          "automatikerin-automatiker-100-hilcona-undefined"
         ]
       },
       "previousSlugs": [
-        "automatikerin-automatiker-100-hilcona-zell"
+        "automatikerin-automatiker-100-hilcona-zell",
+        "automatikerin-automatiker-100-hilcona-undefined"
       ],
       "firstSeenAt": "2026-06-23T22:27:41.109Z",
       "salaryMin": 64500,
@@ -5388,7 +5409,7 @@
       "slugByLocale": {
         "it": "teamleiter-teamleiterin-elektrotechnik-e-automation-hilcona-ag-bell-food-group-landquart",
         "en": "teamleiter-teamleiterin-elektrotechnik-und-automation-bell-schweiz-ag-oensingen",
-        "de": "teamleiter-teamleiterin-elektrotechnik-und-automation-hilcona-undefined",
+        "de": "teamleiter-teamleiterin-elektrotechnik-und-automation-bell-schweiz-ag-oensingen",
         "fr": "teamleiter-teamleiterin-elektrotechnik-und-automation-bell-schweiz-ag-oensingen"
       },
       "company": "Bell Schweiz AG",
@@ -5427,7 +5448,8 @@
       "previousSlugsByLocale": {
         "de": [
           "teamleiter-teamleiterin-elektrotechnik-und-automation-hilcona-oensingen",
-          "teamleiter-teamleiterin-elektrotechnik-und-automation-bell-schweiz-ag-oensingen"
+          "teamleiter-teamleiterin-elektrotechnik-und-automation-bell-schweiz-ag-oensingen",
+          "teamleiter-teamleiterin-elektrotechnik-und-automation-hilcona-undefined"
         ],
         "it": [
           "teamleiter-teamleiterin-elektrotechnik-und-automation-hilcona-oensingen",
@@ -5446,7 +5468,8 @@
         "commissioning-team-leader-oensingen-bell-schweiz-ag-oensingen",
         "teamleiter-teamleiterin-kommissionierung-neubau-oensingen-bell-schweiz-ag-oensingen",
         "responsable-de-la-commission-oensingen-bell-schweiz-ag-oensingen",
-        "teamleiter-teamleiterin-kommissionierung-neubau-oensingen-hilcona-oensingen"
+        "teamleiter-teamleiterin-kommissionierung-neubau-oensingen-hilcona-oensingen",
+        "teamleiter-teamleiterin-elektrotechnik-und-automation-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-19T22:27:01.621Z",
       "salaryMin": 71000,
@@ -5467,12 +5490,12 @@
     },
     {
       "id": "hilcona-9bb5ddb054a8",
-      "slug": "metzger-portionierung-metzgerin-portionierung-hilcona-undefined",
+      "slug": "taglio-e-porzione-di-carne-geiser-ag-schlieren",
       "slugByLocale": {
-        "it": "metzger-portionierung-metzgerin-portionierung-hilcona-undefined",
-        "en": "metzger-portionierung-metzgerin-portionierung-hilcona-undefined",
+        "it": "taglio-e-porzione-di-carne-geiser-ag-schlieren",
+        "en": "meat-cutting-and-portioning-geiser-ag-schlieren",
         "de": "metzger-portionierung-metzgerin-portionierung-hilcona-ag-bell-food-group-landquart",
-        "fr": "metzger-portionierung-metzgerin-portionierung-hilcona-undefined"
+        "fr": "taille-et-portionnage-de-viande-geiser-ag-schlieren"
       },
       "company": "Geiser AG",
       "companyKey": "hilcona",
@@ -5514,15 +5537,18 @@
         ],
         "it": [
           "metzger-portionierung-metzgerin-portionierung-hilcona-schlieren",
-          "taglio-e-porzione-di-carne-geiser-ag-schlieren"
+          "taglio-e-porzione-di-carne-geiser-ag-schlieren",
+          "metzger-portionierung-metzgerin-portionierung-hilcona-undefined"
         ],
         "en": [
           "metzger-portionierung-metzgerin-portionierung-hilcona-schlieren",
-          "meat-cutting-and-portioning-geiser-ag-schlieren"
+          "meat-cutting-and-portioning-geiser-ag-schlieren",
+          "metzger-portionierung-metzgerin-portionierung-hilcona-undefined"
         ],
         "fr": [
           "metzger-portionierung-metzgerin-portionierung-hilcona-schlieren",
-          "taille-et-portionnage-de-viande-geiser-ag-schlieren"
+          "taille-et-portionnage-de-viande-geiser-ag-schlieren",
+          "metzger-portionierung-metzgerin-portionierung-hilcona-undefined"
         ]
       },
       "previousSlugs": [
@@ -5530,7 +5556,8 @@
         "metzger-portionierung-metzgerin-portionierung-geiser-ag-schlieren",
         "taglio-e-porzione-di-carne-geiser-ag-schlieren",
         "meat-cutting-and-portioning-geiser-ag-schlieren",
-        "taille-et-portionnage-de-viande-geiser-ag-schlieren"
+        "taille-et-portionnage-de-viande-geiser-ag-schlieren",
+        "metzger-portionierung-metzgerin-portionierung-hilcona-undefined"
       ],
       "firstSeenAt": "2026-04-13T10:42:48.423Z",
       "salaryMin": 76000,
@@ -5555,7 +5582,7 @@
       "slugByLocale": {
         "it": "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
         "en": "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-        "de": "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-undefined",
+        "de": "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
         "fr": "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq"
       },
       "company": "Geiser AG",
@@ -5594,7 +5621,8 @@
       "previousSlugsByLocale": {
         "de": [
           "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-          "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren"
+          "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+          "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-undefined"
         ],
         "it": [
           "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
@@ -5614,7 +5642,8 @@
         "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
         "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren",
         "staff-technology-and-material-management-staff-technology-and-material-management-geiser-ag-schlieren",
-        "technologie-du-personnel-et-gestion-du-materiel-geiser-ag-schlieren"
+        "technologie-du-personnel-et-gestion-du-materiel-geiser-ag-schlieren",
+        "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-22T11:51:42.428Z",
       "salaryMin": 76000,
@@ -5638,9 +5667,9 @@
       "slug": "collaboratore-trice-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart",
       "slugByLocale": {
         "it": "collaboratore-trice-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "en": "mitarbeiter-verladung-versand-m-w-d-hilcona-undefined",
+        "en": "employee-loading-shipping-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
         "de": "mitarbeiter-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "fr": "mitarbeiter-verladung-versand-m-w-d-hilcona-undefined"
+        "fr": "employe-chargement-expedition-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
       },
       "company": "Bell Deutschland GmbH & Co. KG",
       "companyKey": "hilcona",
@@ -5685,16 +5714,19 @@
           "collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
         ],
         "en": [
-          "mitarbeiter-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
+          "mitarbeiter-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
+          "mitarbeiter-verladung-versand-m-w-d-hilcona-undefined"
         ],
         "fr": [
-          "mitarbeiter-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
+          "mitarbeiter-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
+          "mitarbeiter-verladung-versand-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
         "mitarbeiter-verladung-versand-m-w-d-hilcona-edewecht",
         "mitarbeiter-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
-        "collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
+        "collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
+        "mitarbeiter-verladung-versand-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:45.411Z",
       "salaryMin": 64500,
@@ -5786,7 +5818,7 @@
       "slugByLocale": {
         "it": "doppio-studio-industriale-uomini-d-affari-bachelor-bwl-m-w-d-bell-deutschland-gmbh-co-kg-seevetal",
         "en": "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "de": "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-undefined",
+        "de": "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-bell-deutschland-gmbh-co-kg-seevetal",
         "fr": "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Deutschland GmbH & Co. KG",
@@ -5832,6 +5864,9 @@
           "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-undefined",
           "studi-doppi-imprenditori-industriali-bachelor-bwl-m-w-d-bell-deutschland-gmbh-co-kg-seevetal",
           "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-seevetal"
+        ],
+        "de": [
+          "duales-studium-industriekaufleute-bachelor-bwl-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
@@ -6115,7 +6150,7 @@
       "slugByLocale": {
         "it": "betriebselektriker-betriebselektrikerin-neubau-oensingen-hilcona-ag-bell-food-group-landquart",
         "en": "company-electrician-company-electrician-neubau-oensingen-bell-schweiz-ag-oensingen",
-        "de": "betriebselektriker-betriebselektrikerin-neubau-oensingen-hilcona-undefined",
+        "de": "betriebselektriker-betriebselektrikerin-neubau-oensingen-bell-schweiz-ag-oensingen",
         "fr": "betriebselektriker-betriebselektrikerin-neubau-oensingen-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Schweiz AG",
@@ -6172,7 +6207,8 @@
         ],
         "de": [
           "betriebselektriker-betriebselektrikerin-neubau-oensingen-hilcona-oensingen",
-          "betriebselektriker-betriebselektrikerin-hilcona-oensingen"
+          "betriebselektriker-betriebselektrikerin-hilcona-oensingen",
+          "betriebselektriker-betriebselektrikerin-neubau-oensingen-hilcona-undefined"
         ],
         "fr": [
           "betriebselektriker-betriebselektrikerin-bell-schweiz-ag-oensingen"
@@ -6201,7 +6237,7 @@
       "slugByLocale": {
         "it": "auszubildende-maschinen-e-anlagenfuehrer-m-w-d-con-schwerpunkt-alimentari-hilcona-ag-bell-food-group-landquart",
         "en": "apprentice-machines-and-plant-managers-m-w-d-with-focus-on-food-hugli-nahrungsmittel-gmbh-radolfzell",
-        "de": "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hilcona-undefined",
+        "de": "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hugli-nahrungsmittel-gmbh-radolfzell",
         "fr": "machines-d-apprentissage-et-gestionnaires-d-usines-m-w-d-en-mettant-l-accent-sur-les-aliments-hugli-nahrungsmittel-gmbh"
       },
       "company": "Hügli Nahrungsmittel GmbH",
@@ -6240,7 +6276,8 @@
       "previousSlugsByLocale": {
         "de": [
           "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hilcona-radolfzell",
-          "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hugli-nahrungsmittel-gmbh-radolfzell"
+          "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hugli-nahrungsmittel-gmbh-radolfzell",
+          "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hilcona-undefined"
         ],
         "it": [
           "auszubildende-maschinen-und-anlagenfuehrer-m-w-d-mit-schwerpunkt-lebensmittel-hilcona-radolfzell",
@@ -6284,7 +6321,7 @@
       "slugByLocale": {
         "it": "trainee-fuer-lagerlogistik-magazzino-specializzato-e-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "en": "trainee-fuer-lagerlogistik-specialist-warehouse-is-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
-        "de": "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hilcona-undefined",
+        "de": "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
         "fr": "stagiaire-fuer-lagerlogistik-entrepot-specialise-est-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
       },
       "company": "Hügli Nahrungsmittel GmbH",
@@ -6336,6 +6373,9 @@
         ],
         "fr": [
           "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
+        ],
+        "de": [
+          "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
@@ -6371,7 +6411,7 @@
       "slugByLocale": {
         "it": "betriebselektrikerin-betriebselektriker-100-hilcona-ag-bell-food-group-landquart",
         "en": "betriebselektrikerin-betriebselektriker-100-hilcona-ag-bell-food-group-landquart",
-        "de": "betriebselektrikerin-betriebselektriker-100-hilcona-undefined",
+        "de": "betriebselektrikerin-betriebselektriker-100-bell-schweiz-ag-zell",
         "fr": "betriebselektrikerin-betriebselektriker-100-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Schweiz AG",
@@ -6410,7 +6450,8 @@
       "previousSlugsByLocale": {
         "de": [
           "betriebselektrikerin-betriebselektriker-100-hilcona-zell",
-          "betriebselektrikerin-betriebselektriker-100-bell-schweiz-ag-zell"
+          "betriebselektrikerin-betriebselektriker-100-bell-schweiz-ag-zell",
+          "betriebselektrikerin-betriebselektriker-100-hilcona-undefined"
         ],
         "it": [
           "betriebselektrikerin-betriebselektriker-100-bell-schweiz-ag-zell",
@@ -6427,7 +6468,8 @@
       "previousSlugs": [
         "betriebselektrikerin-betriebselektriker-100-hilcona-zell",
         "betriebselektrikerin-betriebselektriker-100-bell-schweiz-ag-zell",
-        "electricien-industriel-100-bell-schweiz-ag-zell"
+        "electricien-industriel-100-bell-schweiz-ag-zell",
+        "betriebselektrikerin-betriebselektriker-100-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:41.802Z",
       "salaryMin": 64500,
@@ -6452,7 +6494,7 @@
       "slugByLocale": {
         "it": "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart",
         "en": "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart",
-        "de": "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-undefined",
+        "de": "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne",
         "fr": "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Suisse SA",
@@ -6491,7 +6533,8 @@
       "previousSlugsByLocale": {
         "de": [
           "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-cheseaux-sur-lausanne",
-          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne"
+          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne",
+          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-undefined"
         ],
         "it": [
           "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne",
@@ -6515,7 +6558,8 @@
         "tecnico-di-manutenzione-automatizzatore-tecnico-di-manutenzione-automatizzatore-bell-suisse-sa-cheseaux-sur-lausanne",
         "maintenance-technician-automation-maintenance-technician-bell-suisse-sa-cheseaux-sur-lausanne",
         "technicien-de-maintenance-automatique-technicien-de-maintenance-automatique-bell-suisse-sa-cheseaux-sur-lausanne",
-        "technicien-de-maintenance-automatique-technicien-de-maintenance-automatique-bell-suisse-sa"
+        "technicien-de-maintenance-automatique-technicien-de-maintenance-automatique-bell-suisse-sa",
+        "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-undefined"
       ],
       "firstSeenAt": "2026-04-13T10:42:42.292Z",
       "salaryMin": 68000,
@@ -6540,7 +6584,7 @@
       "slugByLocale": {
         "it": "collaboratore-trice-mitarbeiterin-leitstand-neubau-oensingen-hilcona-ag-bell-food-group-landquart",
         "en": "employee-staff-member-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen",
-        "de": "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-undefined",
+        "de": "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen",
         "fr": "employe-membre-du-personnel-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen"
       },
       "company": "Bell Schweiz AG",
@@ -6578,7 +6622,8 @@
       "sourceLang": "de",
       "previousSlugs": [
         "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-oensingen",
-        "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen"
+        "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen",
+        "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-undefined"
       ],
       "previousSlugsByLocale": {
         "it": [
@@ -6588,7 +6633,8 @@
           "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen"
         ],
         "de": [
-          "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-oensingen"
+          "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-oensingen",
+          "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-hilcona-undefined"
         ],
         "fr": [
           "mitarbeiter-mitarbeiterin-leitstand-neubau-oensingen-bell-schweiz-ag-oensingen"
@@ -6690,7 +6736,7 @@
       "slugByLocale": {
         "it": "lehrling-lebensmitteltechnik-m-w-d-hilcona-ag-bell-food-group-landquart",
         "en": "lehrling-lebensmitteltechnik-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "de": "lehrling-lebensmitteltechnik-m-w-d-hilcona-undefined",
+        "de": "lehrling-lebensmitteltechnik-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
         "fr": "lehrling-lebensmitteltechnik-m-w-d-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Hubers Landhendl GmbH",
@@ -6729,7 +6775,8 @@
       "previousSlugsByLocale": {
         "de": [
           "lehrling-lebensmitteltechnik-m-w-d-hilcona-pfaffstatt",
-          "lehrling-lebensmitteltechnik-m-w-d-hubers-landhendl-gmbh-pfaffstatt"
+          "lehrling-lebensmitteltechnik-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+          "lehrling-lebensmitteltechnik-m-w-d-hilcona-undefined"
         ],
         "it": [
           "lehrling-lebensmitteltechnik-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
@@ -6746,7 +6793,8 @@
       "previousSlugs": [
         "lehrling-lebensmitteltechnik-m-w-d-hilcona-pfaffstatt",
         "lehrling-lebensmitteltechnik-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-        "apprentissage-de-la-technologie-alimentaire-hubers-landhendl-gmbh-pfaffstatt"
+        "apprentissage-de-la-technologie-alimentaire-hubers-landhendl-gmbh-pfaffstatt",
+        "lehrling-lebensmitteltechnik-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:40.470Z",
       "salaryMin": 64500,
@@ -6844,7 +6892,7 @@
       "slugByLocale": {
         "it": "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-hilcona-ag-bell-food-group-landquart",
         "en": "head-of-cleaning-slicer-center-new-building-oensingen-bell-schweiz-ag-oensingen",
-        "de": "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-hilcona-undefined",
+        "de": "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-bell-schweiz-ag-oensingen",
         "fr": "chef-du-centre-de-nettoyage-des-trancheuses-nouveau-batiment-d-oensingen-bell-schweiz-ag-oensingen"
       },
       "company": "Bell Schweiz AG",
@@ -6896,7 +6944,8 @@
         ],
         "de": [
           "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-hilcona-oensingen",
-          "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-bell-schweiz-ag-oensingen"
+          "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-bell-schweiz-ag-oensingen",
+          "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-hilcona-undefined"
         ],
         "fr": [
           "leiter-leiterin-reinigung-slicer-center-neubau-oensingen-hilcona-undefined"
@@ -7059,7 +7108,7 @@
       "slugByLocale": {
         "it": "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-ag-bell-food-group-landquart",
         "en": "business-mechanic-business-mechanic-neubau-oensingen-bell-schweiz-ag-oensingen",
-        "de": "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-undefined",
+        "de": "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-bell-schweiz-ag-oensingen",
         "fr": "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Schweiz AG",
@@ -7111,7 +7160,8 @@
           "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-undefined"
         ],
         "de": [
-          "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-oensingen"
+          "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-oensingen",
+          "betriebsmechaniker-betriebsmechanikerin-neubau-oensingen-hilcona-undefined"
         ],
         "fr": [
           "mecanicien-de-maintenance-mecanicienne-de-maintenance-nouveau-batiment-oensingen-bell-schweiz-ag-oensingen"
@@ -7217,7 +7267,7 @@
       "slugByLocale": {
         "it": "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-ag-bell-food-group-landquart",
         "en": "internship-during-study-30-1-year-temporary-bell-schweiz-ag-zell",
-        "de": "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-undefined",
+        "de": "praktikum-waehrend-des-studiums-30-1-jahr-befristet-bell-schweiz-ag-zell",
         "fr": "stage-pendant-l-etude-30-1-an-temporaire-bell-schweiz-ag-zell"
       },
       "company": "Bell Schweiz AG",
@@ -7256,7 +7306,8 @@
       "previousSlugsByLocale": {
         "de": [
           "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-zell",
-          "praktikum-waehrend-des-studiums-30-1-jahr-befristet-bell-schweiz-ag-zell"
+          "praktikum-waehrend-des-studiums-30-1-jahr-befristet-bell-schweiz-ag-zell",
+          "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-undefined"
         ],
         "it": [
           "praktikum-waehrend-des-studiums-30-1-jahr-befristet-bell-schweiz-ag-zell",
@@ -7273,7 +7324,8 @@
       "previousSlugs": [
         "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-zell",
         "praktikum-waehrend-des-studiums-30-1-jahr-befristet-bell-schweiz-ag-zell",
-        "stage-mentre-studia-30-1-anno-periodo-bell-schweiz-ag-zell"
+        "stage-mentre-studia-30-1-anno-periodo-bell-schweiz-ag-zell",
+        "praktikum-waehrend-des-studiums-30-1-jahr-befristet-hilcona-undefined"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-21T12:08:39.380Z",
@@ -7676,7 +7728,7 @@
       "slugByLocale": {
         "it": "koch-koechin-baecker-baeckerin-o-metzger-metzgerin-hilcona-ag-bell-food-group-landquart",
         "en": "koch-koechin-baecker-baeckerin-or-butcher-butcher-hilcona-ag-schaan",
-        "de": "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-undefined",
+        "de": "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-ag-schaan",
         "fr": "koch-koechin-baecker-baeckerin-ou-boucher-boucher-hilcona-ag-schaan"
       },
       "company": "Hilcona AG",
@@ -7714,14 +7766,16 @@
       "sourceLang": "de",
       "previousSlugsByLocale": {
         "de": [
-          "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-schaan"
+          "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-schaan",
+          "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-undefined"
         ],
         "it": [
           "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-schaan"
         ]
       },
       "previousSlugs": [
-        "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-schaan"
+        "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-schaan",
+        "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-undefined"
       ],
       "firstSeenAt": "2026-06-16T13:34:52.787Z",
       "salaryMin": 64500,
@@ -7746,7 +7800,7 @@
       "slugByLocale": {
         "it": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-ag-bell-food-group-landquart",
         "en": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-ag-bell-food-group-landquart",
-        "de": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-undefined",
+        "de": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell",
         "fr": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Bell Schweiz AG",
@@ -7785,7 +7839,8 @@
       "previousSlugsByLocale": {
         "de": [
           "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-zell",
-          "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell"
+          "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell",
+          "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-undefined"
         ],
         "it": [
           "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell",
@@ -7802,7 +7857,8 @@
       "previousSlugs": [
         "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-zell",
         "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell",
-        "meccanico-operativo-mechanic-meat-recovery-100-bell-schweiz-ag-zell"
+        "meccanico-operativo-mechanic-meat-recovery-100-bell-schweiz-ag-zell",
+        "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:37.513Z",
       "salaryMin": 64500,
@@ -8273,12 +8329,12 @@
     },
     {
       "id": "hilcona-9c97fa9b51ca",
-      "slug": "hausmeister-m-w-d-hilcona-undefined",
+      "slug": "master-m-w-d-suddeutsche-truthahn-ag-ampfing",
       "slugByLocale": {
-        "it": "hausmeister-m-w-d-hilcona-undefined",
-        "en": "hausmeister-m-w-d-hilcona-undefined",
+        "it": "master-m-w-d-suddeutsche-truthahn-ag-ampfing",
+        "en": "caretaker-m-w-d-suddeutsche-truthahn-ag-ampfing",
         "de": "hausmeister-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "fr": "hausmeister-m-w-d-hilcona-undefined"
+        "fr": "le-gardien-m-w-d-suddeutsche-truthahn-ag-ampfing"
       },
       "company": "Süddeutsche Truthahn AG",
       "companyKey": "hilcona",
@@ -8320,19 +8376,23 @@
         ],
         "it": [
           "hausmeister-m-w-d-hilcona-ampfing",
-          "master-m-w-d-suddeutsche-truthahn-ag-ampfing"
+          "master-m-w-d-suddeutsche-truthahn-ag-ampfing",
+          "hausmeister-m-w-d-hilcona-undefined"
         ],
         "en": [
-          "hausmeister-m-w-d-suddeutsche-truthahn-ag-ampfing"
+          "hausmeister-m-w-d-suddeutsche-truthahn-ag-ampfing",
+          "hausmeister-m-w-d-hilcona-undefined"
         ],
         "fr": [
-          "hausmeister-m-w-d-suddeutsche-truthahn-ag-ampfing"
+          "hausmeister-m-w-d-suddeutsche-truthahn-ag-ampfing",
+          "hausmeister-m-w-d-hilcona-undefined"
         ]
       },
       "previousSlugs": [
         "hausmeister-m-w-d-hilcona-ampfing",
         "hausmeister-m-w-d-suddeutsche-truthahn-ag-ampfing",
-        "master-m-w-d-suddeutsche-truthahn-ag-ampfing"
+        "master-m-w-d-suddeutsche-truthahn-ag-ampfing",
+        "hausmeister-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:35.050Z",
       "salaryMin": 64500,
@@ -8434,7 +8494,7 @@
       "slugByLocale": {
         "it": "betriebselektriker-m-w-d-hilcona-ag-bell-food-group-landquart",
         "en": "betriebselektriker-m-w-d-hilcona-ag-bell-food-group-landquart",
-        "de": "betriebselektriker-m-w-d-hilcona-undefined",
+        "de": "betriebselektriker-m-w-d-suddeutsche-truthahn-ag-ampfing",
         "fr": "betriebselektriker-m-w-d-hilcona-ag-bell-food-group-landquart"
       },
       "company": "Süddeutsche Truthahn AG",
@@ -8473,7 +8533,8 @@
       "previousSlugsByLocale": {
         "de": [
           "betriebselektriker-m-w-d-hilcona-ampfing",
-          "betriebselektriker-m-w-d-suddeutsche-truthahn-ag-ampfing"
+          "betriebselektriker-m-w-d-suddeutsche-truthahn-ag-ampfing",
+          "betriebselektriker-m-w-d-hilcona-undefined"
         ],
         "it": [
           "betriebselektriker-m-w-d-suddeutsche-truthahn-ag-ampfing",
@@ -8490,7 +8551,8 @@
       "previousSlugs": [
         "betriebselektriker-m-w-d-hilcona-ampfing",
         "betriebselektriker-m-w-d-suddeutsche-truthahn-ag-ampfing",
-        "electricien-industriel-m-w-d-suddeutsche-truthahn-ag-ampfing"
+        "electricien-industriel-m-w-d-suddeutsche-truthahn-ag-ampfing",
+        "betriebselektriker-m-w-d-hilcona-undefined"
       ],
       "firstSeenAt": "2026-05-21T12:08:34.776Z",
       "salaryMin": 64500,

--- a/tests/ch-canton-below-floor-bridge.test.ts
+++ b/tests/ch-canton-below-floor-bridge.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Below-floor bridge coverage for the two remaining CH-canton page families
+ * flagged by the GSC Coverage Drilldown 404 sweep — the same sibling bug
+ * class already covered for professionCantonLandings.ts
+ * (tests/profession-canton-landings.test.ts): a per-canton static page
+ * gated on a job-count floor that silently `continue`d (no bridge, no
+ * redirect) whenever a canton dropped below the floor on a later build,
+ * even though a prior build may have emitted (and Google indexed) that
+ * exact URL. Both families now bridge below-floor cantons to the always-
+ * live salary-stats hub instead of dropping the page.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as np from 'node:path';
+
+import { emitChCantonEmployersPages, buildCantonEmployersPath } from '../build-plugins/weeklyEmployersChCantonPages';
+import { emitChCantonSnapshotPages, buildCantonSnapshotPath } from '../build-plugins/jobMarketSnapshotChCantonPages';
+import { PROFESSION_CANTON_KEYS } from '../build-plugins/professionCantonData';
+
+const ROOT = np.resolve(__dirname, '..');
+const LOCALES = ['it', 'en', 'de', 'fr'] as const;
+const EXPECTED_BRIDGES = PROFESSION_CANTON_KEYS.length * LOCALES.length; // 23 cantons × 4 locales = 92
+
+// Per-locale slugs from data/canton-url-slugs.json (ZH, GE) — must match the
+// real file, NOT be guessed, since the bridge path depends on it verbatim.
+const ZH_SLUG = { it: 'zurigo', en: 'zurich', de: 'zurich', fr: 'zurich' } as const;
+const GE_SLUG = { it: 'ginevra', en: 'geneva', de: 'genf', fr: 'geneve' } as const;
+
+describe('weeklyEmployersChCantonPages — below-floor bridge (structural 404 fix)', () => {
+  let distDir: string;
+
+  beforeAll(async () => {
+    distDir = fs.mkdtempSync(np.join(os.tmpdir(), 'weekly-emp-bridge-'));
+    await emitChCantonEmployersPages({ rootDir: ROOT, distDir, jobs: [] });
+  });
+
+  afterAll(() => {
+    fs.rmSync(distDir, { recursive: true, force: true });
+  });
+
+  it('bridges every below-floor canton to the salary-stats hub instead of dropping it (empty corpus)', async () => {
+    const res = await emitChCantonEmployersPages({ rootDir: ROOT, distDir, jobs: [] });
+    expect(res.pagesWritten).toBe(0);
+    expect(res.bridgesWritten).toBe(EXPECTED_BRIDGES);
+  });
+
+  it('bridge HTML is well-formed: noindex, canonical + meta-refresh to salary-stats hub', () => {
+    const canonicalPath = buildCantonEmployersPath('de', ZH_SLUG.de);
+    const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+    expect(fs.existsSync(bridgeFile)).toBe(true);
+    const html = fs.readFileSync(bridgeFile, 'utf-8');
+    expect(html).toContain('<meta name="robots" content="noindex,follow">');
+    expect(html).toContain('<link rel="canonical" href="https://frontaliereticino.ch/de/gehaelter-zurich/">');
+    expect(html).toContain('<meta http-equiv="refresh" content="0; url=https://frontaliereticino.ch/de/gehaelter-zurich/">');
+  });
+
+  it('bridge HTML carries a complete hreflang block across all 4 locales', () => {
+    for (const locale of LOCALES) {
+      const canonicalPath = buildCantonEmployersPath(locale, GE_SLUG[locale]);
+      const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+      expect(fs.existsSync(bridgeFile)).toBe(true);
+      const html = fs.readFileSync(bridgeFile, 'utf-8');
+      expect(html).toContain(`<html lang="${locale}">`);
+      expect(html).toContain('<meta name="robots" content="noindex,follow">');
+      expect(html).toMatch(/<meta http-equiv="refresh" content="0; url=https:\/\/frontaliereticino\.ch\//);
+    }
+  });
+});
+
+describe('jobMarketSnapshotChCantonPages — below-floor bridge (structural 404 fix)', () => {
+  let distDir: string;
+
+  beforeAll(async () => {
+    distDir = fs.mkdtempSync(np.join(os.tmpdir(), 'snapshot-bridge-'));
+    await emitChCantonSnapshotPages({ rootDir: ROOT, distDir, jobs: [] });
+  });
+
+  afterAll(() => {
+    fs.rmSync(distDir, { recursive: true, force: true });
+  });
+
+  it('bridges every below-floor canton to the salary-stats hub instead of dropping it (empty corpus)', async () => {
+    const res = await emitChCantonSnapshotPages({ rootDir: ROOT, distDir, jobs: [] });
+    expect(res.pagesWritten).toBe(0);
+    expect(res.bridgesWritten).toBe(EXPECTED_BRIDGES);
+  });
+
+  it('bridge HTML is well-formed: noindex, canonical + meta-refresh to salary-stats hub', () => {
+    const canonicalPath = buildCantonSnapshotPath('de', ZH_SLUG.de);
+    const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+    expect(fs.existsSync(bridgeFile)).toBe(true);
+    const html = fs.readFileSync(bridgeFile, 'utf-8');
+    expect(html).toContain('<meta name="robots" content="noindex,follow">');
+    expect(html).toContain('<link rel="canonical" href="https://frontaliereticino.ch/de/gehaelter-zurich/">');
+    expect(html).toContain('<meta http-equiv="refresh" content="0; url=https://frontaliereticino.ch/de/gehaelter-zurich/">');
+  });
+
+  it('bridge HTML carries a complete hreflang block across all 4 locales', () => {
+    for (const locale of LOCALES) {
+      const canonicalPath = buildCantonSnapshotPath(locale, GE_SLUG[locale]);
+      const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+      expect(fs.existsSync(bridgeFile)).toBe(true);
+      const html = fs.readFileSync(bridgeFile, 'utf-8');
+      expect(html).toContain(`<html lang="${locale}">`);
+      expect(html).toContain('<meta name="robots" content="noindex,follow">');
+      expect(html).toMatch(/<meta http-equiv="refresh" content="0; url=https:\/\/frontaliereticino\.ch\//);
+    }
+  });
+});

--- a/tests/jobs-seo-editorial-below-floor-bridge.test.ts
+++ b/tests/jobs-seo-editorial-below-floor-bridge.test.ts
@@ -72,4 +72,34 @@ describe('jobsSeoPagesPlugin editorial-canton below-floor bridges', () => {
       expect(body).toContain('noindex: true');
     }
   });
+
+  it('defines the TI location/type/sector below-floor bridge helpers and wires them into every floor-check site', () => {
+    expect(source).toContain('const emitLocationBelowFloorBridge = (locale: \'it\' | \'en\' | \'de\' | \'fr\', loc: string): void => {');
+    expect(source).toContain('const emitLocationTypeBelowFloorBridge = (locale: \'it\' | \'en\' | \'de\' | \'fr\', loc: string, typeKeyArg: (typeof editorialTypeKeys)[number]): void => {');
+    expect(source).toContain('const emitLocationSectorBelowFloorBridge = (locale: \'it\' | \'en\' | \'de\' | \'fr\', loc: string, sectorKeyArg: (typeof editorialSectorKeys)[number]): void => {');
+    expect(source).toContain('emitLocationBelowFloorBridge(locale, location);');
+    expect(source).toContain('emitLocationTypeBelowFloorBridge(locale, location, typeKey);');
+    expect(source).toContain('emitLocationSectorBelowFloorBridge(locale, location, sectorKey);');
+  });
+
+  it('does not contain the bare-continue 404 bug pattern for the TI location/type/sector floors', () => {
+    expect(source).not.toContain('if (italianLocationModel.totalJobs === 0) continue;');
+    expect(source).not.toContain('if (italianTypeModel.totalJobs === 0) continue;');
+    expect(source).not.toContain('if (italianSectorModel.totalJobs === 0) continue;');
+  });
+
+  it('location-level below-floor bridge dual-writes both the clean city-hub URL and the legacy editorial URL when they differ', () => {
+    const startIdx = source.indexOf("const emitLocationBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', loc: string): void => {");
+    expect(startIdx).toBeGreaterThan(-1);
+    const body = source.slice(startIdx, startIdx + 1400);
+    expect(body).toContain('buildCityHubPath(locale, cityHubKey)');
+    expect(body).toContain("if (!cityHubKey || legacyPath !== buildCityHubPath(locale, cityHubKey)) writeLocationFamilyBridge(legacyPath, targetPath, locale);");
+  });
+
+  it('location/type/sector bridges all route through the shared writer with noindex canonical-bridge pages', () => {
+    expect(source).toContain('const writeLocationFamilyBridge = (canonicalPath: string, targetPath: string, locale: \'it\' | \'en\' | \'de\' | \'fr\'): void => {');
+    const startIdx = source.indexOf('const writeLocationFamilyBridge = ');
+    const body = source.slice(startIdx, startIdx + 700);
+    expect(body).toContain('noindex: true');
+  });
 });

--- a/tests/jobs-seo-editorial-below-floor-bridge.test.ts
+++ b/tests/jobs-seo-editorial-below-floor-bridge.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression guard for the GSC Coverage Drilldown 404 sweep sibling bug class
+ * in build-plugins/jobsSeoPagesPlugin.ts (same class already covered by
+ * tests/profession-canton-landings.test.ts and
+ * tests/ch-canton-below-floor-bridge.test.ts): a per-canton editorial page
+ * used to silently `continue` past a canton once it fell under
+ * MIN_JOBS_FOR_CANTON_PAGE (or, for the care-variant cluster, once it had
+ * zero matching jobs), dropping a URL Google may already have indexed
+ * straight to a GH Pages hard 404 with no bridge.
+ *
+ * jobsSeoPagesPlugin.ts is a single closeBundle()-hook Vite plugin that only
+ * runs inside a full SSG build (RAM-bound, not invocable in a lightweight
+ * unit test -- see tests/jobs-seo-pages-plugin.test.ts's own
+ * "static payload budget" test for the established source-assertion pattern
+ * this file uses in place of a full render). This test follows that same
+ * convention: it asserts the below-floor bridge helpers exist and are wired
+ * up at every known below-floor site, and that the old bare-`continue`
+ * bug pattern has not been reintroduced.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, '../build-plugins/jobsSeoPagesPlugin.ts'), 'utf8');
+
+describe('jobsSeoPagesPlugin editorial-canton below-floor bridges', () => {
+  it('defines the shared editorial below-floor bridge helper', () => {
+    expect(source).toContain('const emitEditorialBelowFloorBridge = (locale: \'it\' | \'en\' | \'de\' | \'fr\', canton: string, slug: string): void => {');
+  });
+
+  it('wires the bridge helper into every editorial-canton floor-check site', () => {
+    const expectedSlugGetters = [
+      'getJobTodayLandingSlug(locale, editorialCanton)',
+      'getJobNursesHubSlug(locale, editorialCanton)',
+      'getJobPartTimeLandingSlug(locale, editorialCanton)',
+    ];
+    for (const slugGetter of expectedSlugGetters) {
+      expect(source).toContain(`emitEditorialBelowFloorBridge(locale, editorialCanton, ${slugGetter});`);
+    }
+    // Care-variant has two distinct below-floor sites (the shared canton
+    // floor-check and the cluster-specific zero-jobs check) that both bridge
+    // via the same careClusterSlug(...) call -- both must be wired.
+    const careCallSites = source.split('emitEditorialBelowFloorBridge(locale, editorialCanton, careClusterSlug(clusterKey, editorialCanton, locale));').length - 1;
+    expect(careCallSites).toBe(2);
+  });
+
+  it('does not contain the bare bare-continue 404 bug pattern for editorial-canton floors', () => {
+    expect(source).not.toContain('(editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;');
+    expect(source).not.toContain('if (italianCareModel.totalJobs === 0) continue;');
+  });
+
+  it('defines the per-canton sector-hub below-floor bridge helper and wires it in', () => {
+    expect(source).toContain('const emitSectorHubBelowFloorBridge = (locale: \'it\' | \'en\' | \'de\' | \'fr\', canton: string, slug: string): void => {');
+    expect(source).toContain('emitSectorHubBelowFloorBridge(locale, canton, SECTOR_HUB_SLUG[locale][sector]);');
+  });
+
+  it('does not contain the bare-continue 404 bug pattern for the sector-hub canton floor', () => {
+    expect(source).not.toContain('if (cantonTotal < MIN_JOBS_FOR_CANTON_PAGE) continue;');
+  });
+
+  it('every below-floor bridge points at the canton-root hub section via buildCantonAwareSection, matching the unconditionally-emitted canton hub', () => {
+    for (const helperStart of [
+      "const emitEditorialBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', canton: string, slug: string): void => {",
+      "const emitSectorHubBelowFloorBridge = (locale: 'it' | 'en' | 'de' | 'fr', canton: string, slug: string): void => {",
+    ]) {
+      const startIdx = source.indexOf(helperStart);
+      expect(startIdx).toBeGreaterThan(-1);
+      const body = source.slice(startIdx, startIdx + 800);
+      expect(body).toContain('buildCantonAwareSection(locale, canton)');
+      expect(body).toContain('noindex: true');
+    }
+  });
+});

--- a/tests/profession-canton-landings.test.ts
+++ b/tests/profession-canton-landings.test.ts
@@ -8,11 +8,13 @@ import * as np from 'node:path';
 
 import {
   PROFESSION_CANTON_ROUTES,
+  PROFESSION_CANTON_KEYS,
   listAllProfessionCantonPaths,
   parseProfessionCantonPath,
   isProfessionCantonPath,
   buildProfessionCantonPath,
 } from '../build-plugins/professionCantonData';
+import { PROFESSION_IDS, PROFESSION_LOCALES } from '../build-plugins/professionLandingsData';
 import {
   renderProfessionCantonPage,
   emitProfessionCantonPages,
@@ -127,6 +129,74 @@ describe('emitProfessionCantonPages — zero-emit sitemap index hygiene (#2107 i
       expect(idx).toContain('sitemap-salary-stats.xml');
       // The family .xml itself is removed by cleanSitemapFiles.
       expect(fs.existsSync(np.join(distDir, 'sitemap-profession-cantons.xml'))).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      _resetProfessionJobsAggregateCache();
+    }
+  });
+});
+
+describe('emitProfessionCantonPages — below-floor bridge (structural 404 fix)', () => {
+  // GSC Coverage Drilldown flagged /de/arbeit-aargau-kellner/ as a hard 404:
+  // a (canton, profession) pair that was live on a prior build fell below
+  // MIN_JOBS on a later one and was silently `continue`d — no bridge, no
+  // redirect, straight to GitHub Pages 404. This locks in the fix: every
+  // below-floor pair (including a canton with zero matched jobs at all) now
+  // gets a noindex,follow bridge to its always-live salary-stats hub instead.
+  it('bridges every below-floor pair to the canton salary-stats hub instead of dropping it (empty corpus)', async () => {
+    _resetProfessionJobsAggregateCache();
+    const tmp = fs.mkdtempSync(np.join(os.tmpdir(), 'profcanton-bridge-'));
+    try {
+      fs.mkdirSync(np.join(tmp, 'data'), { recursive: true });
+      fs.writeFileSync(np.join(tmp, 'data', 'jobs.json'), '[]', 'utf-8');
+      const distDir = np.join(tmp, 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+
+      const res = await emitProfessionCantonPages({ rootDir: tmp, distDir });
+
+      expect(res.pagesWritten).toBe(0);
+      // Every (canton × profession × locale) combo is below floor with an
+      // empty corpus — each gets its own bridge, none silently dropped.
+      expect(res.bridgesWritten).toBe(PROFESSION_CANTON_KEYS.length * PROFESSION_IDS.length * PROFESSION_LOCALES.length);
+      // Bridges are deliberately kept out of the sitemap / internal-links feed.
+      expect(res.emittedPaths.length).toBe(0);
+
+      const canonicalPath = buildProfessionCantonPath('de', 'ZH', 'infermiere');
+      const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+      expect(fs.existsSync(bridgeFile)).toBe(true);
+      const html = fs.readFileSync(bridgeFile, 'utf-8');
+
+      // noindex,follow — never indexed itself, but crawlable to the real target.
+      expect(html).toContain('<meta name="robots" content="noindex,follow">');
+      // Canonical + immediate meta-refresh both point at the same live target.
+      expect(html).toContain('<link rel="canonical" href="https://frontaliereticino.ch/de/gehaelter-zurich/">');
+      expect(html).toContain('<meta http-equiv="refresh" content="0; url=https://frontaliereticino.ch/de/gehaelter-zurich/">');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      _resetProfessionJobsAggregateCache();
+    }
+  });
+
+  it('bridge HTML is well-formed across all 4 locales for the same pair', async () => {
+    _resetProfessionJobsAggregateCache();
+    const tmp = fs.mkdtempSync(np.join(os.tmpdir(), 'profcanton-bridge-locales-'));
+    try {
+      fs.mkdirSync(np.join(tmp, 'data'), { recursive: true });
+      fs.writeFileSync(np.join(tmp, 'data', 'jobs.json'), '[]', 'utf-8');
+      const distDir = np.join(tmp, 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+
+      await emitProfessionCantonPages({ rootDir: tmp, distDir });
+
+      for (const locale of PROFESSION_LOCALES) {
+        const canonicalPath = buildProfessionCantonPath(locale, 'GE', 'ingegnere');
+        const bridgeFile = np.join(distDir, canonicalPath.replace(/^\/+/, ''), 'index.html');
+        expect(fs.existsSync(bridgeFile)).toBe(true);
+        const html = fs.readFileSync(bridgeFile, 'utf-8');
+        expect(html).toContain(`<html lang="${locale}">`);
+        expect(html).toContain('<meta name="robots" content="noindex,follow">');
+        expect(html).toMatch(/<meta http-equiv="refresh" content="0; url=https:\/\/frontaliereticino\.ch\//);
+      }
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
       _resetProfessionJobsAggregateCache();

--- a/tests/search-console-compat.test.ts
+++ b/tests/search-console-compat.test.ts
@@ -364,7 +364,7 @@ describe('Search Console 404 compatibility resolver', () => {
     });
   });
 
-  it('routes expired company-hub week leaves to the hub root', () => {
+  it('routes expired company-hub week leaves to the hub root, all 4 locales', () => {
     expect(
       resolveSearchConsoleCompatTarget('/aziende-che-assumono/locarno/amministrazione-cantonale-ticino/settimana-corrente'),
     ).toEqual({
@@ -379,6 +379,45 @@ describe('Search Console 404 compatibility resolver', () => {
       kind: 'legacy',
       locale: 'en',
     });
+    // DE/FR hub roots ARE emitted (weeklyEmployersPlugin's renderTopHubPage loop
+    // runs over all WEEKLY_EMPLOYERS_LOCALES) — the fallback previously covered
+    // only IT/EN, leaving these two unresolvable despite a live target existing.
+    expect(
+      resolveSearchConsoleCompatTarget('/de/unternehmen-einstellen/bellinzona/swiss-armed-forces-vtg/aktuelle-woche'),
+    ).toEqual({
+      canonicalPath: '/de/unternehmen-einstellen/',
+      kind: 'legacy',
+      locale: 'de',
+    });
+    expect(
+      resolveSearchConsoleCompatTarget('/fr/entreprises-recrutent/geneve/some-employer/semaine-en-cours'),
+    ).toEqual({
+      canonicalPath: '/fr/entreprises-recrutent/',
+      kind: 'legacy',
+      locale: 'fr',
+    });
+  });
+
+  it('self-maps a profession-canton URL to its own live page (below-floor bridge or full page)', () => {
+    // professionCantonLandings.ts emits every (canton × profession) combo
+    // unconditionally — a URL matching the exact enumerated shape always has
+    // a live target at the SAME path today, even if GSC captured it as 404
+    // from before that guarantee existed. No trailing slash in the GSC-
+    // reported URL (as exported) must still resolve.
+    expect(resolveSearchConsoleCompatTarget('/de/arbeit-aargau-kellner')).toEqual({
+      canonicalPath: '/de/arbeit-aargau-kellner/',
+      kind: 'legacy',
+      locale: 'de',
+    });
+    expect(resolveSearchConsoleCompatTarget('/lavoro-zurigo-infermiere/')).toEqual({
+      canonicalPath: '/lavoro-zurigo-infermiere/',
+      kind: 'legacy',
+      locale: 'it',
+    });
+    // A profession/canton slug NOT in the enumeration must not false-positive.
+    expect(resolveSearchConsoleCompatTarget('/de/arbeit-aargau-not-a-real-profession')).not.toEqual(
+      expect.objectContaining({ canonicalPath: '/de/arbeit-aargau-not-a-real-profession/' }),
+    );
   });
 
   it('routes legacy flat /lavoro/ job URLs to the localized listing', () => {

--- a/tests/seo-hubs-canton-below-floor-bridge.test.ts
+++ b/tests/seo-hubs-canton-below-floor-bridge.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression guard for the GSC Coverage Drilldown 404 sweep sibling bug class
+ * in build-plugins/seoHubsPlugin.ts (same class already covered by
+ * tests/jobs-seo-editorial-below-floor-bridge.test.ts and
+ * tests/ch-canton-below-floor-bridge.test.ts): `emitThinCantonHubs` used to
+ * silently `continue` past a non-TI canton once it fell under
+ * MIN_JOBS_FOR_CANTON_PAGE (or once its slug-bearing job count / dedup count
+ * disagreed with the count, or once the canton's parent landing went
+ * noindex), dropping the `/tutti/`, `/settori/`, `/aziende/` URLs -- which may
+ * already be indexed via a prior build's sitemap -- straight to a GH Pages
+ * hard 404 with no bridge.
+ *
+ * seoHubsPlugin.ts is a single closeBundle()-hook Vite plugin that only runs
+ * inside a full SSG build, not invocable in a lightweight unit test. This
+ * test follows the established source-assertion convention: it asserts the
+ * below-floor bridge helper exists and is wired up at every known
+ * below-floor/noindex site, and that the old bare-`continue` bug pattern has
+ * not been reintroduced.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, '../build-plugins/seoHubsPlugin.ts'), 'utf8');
+
+describe('seoHubsPlugin thin canton-hub below-floor bridges', () => {
+  it('defines the shared below-floor/noindex canton-hub bridge helper', () => {
+    expect(source).toContain('const emitCantonHubBelowFloorBridge = (canton: string): void => {');
+  });
+
+  it('wires the bridge helper into every below-floor / noindex floor-check site', () => {
+    const callSites = source.split('emitCantonHubBelowFloorBridge(canton);').length - 1;
+    // total<MIN, jobs.length<MIN, isCantonNoindex, dedupKeys.size<MIN
+    expect(callSites).toBe(4);
+  });
+
+  it('does not contain the bare-continue 404 bug pattern for any of the four thin canton-hub floor checks', () => {
+    expect(source).not.toContain('if (total < MIN_JOBS_FOR_CANTON_PAGE) continue;');
+    expect(source).not.toContain('if (jobs.length < MIN_JOBS_FOR_CANTON_PAGE) continue;');
+    expect(source).not.toContain('if (isCantonNoindex(canton)) continue;');
+    expect(source).not.toContain('if (dedupKeys.size < MIN_JOBS_FOR_CANTON_PAGE) continue;');
+  });
+
+  it('the bridge helper emits noindex canonical-bridge pages at the exact tutti/settori/aziende hub paths, pointing at the always-live canton section root', () => {
+    const startIdx = source.indexOf('const emitCantonHubBelowFloorBridge = (canton: string): void => {');
+    expect(startIdx).toBeGreaterThan(-1);
+    const body = source.slice(startIdx, startIdx + 900);
+    expect(body).toContain("['tutti', 'settori', 'aziende']");
+    expect(body).toContain('hubSlugFor(canton, locale, hub)');
+    expect(body).toContain('resolveCantonSection(locale, canton)');
+    expect(body).toContain('noindex: true');
+  });
+
+  it('never adds below-floor bridge pages to the sitemap', () => {
+    const startIdx = source.indexOf('const emitCantonHubBelowFloorBridge = (canton: string): void => {');
+    const endIdx = source.indexOf('\n  };\n', startIdx);
+    const body = source.slice(startIdx, endIdx);
+    expect(body).not.toContain('sitemapEntries.push');
+  });
+});

--- a/tests/weekly-employers-company-city.test.ts
+++ b/tests/weekly-employers-company-city.test.ts
@@ -23,6 +23,7 @@ import {
   WEEKLY_EMPLOYERS_LOCALES,
   buildCompanyCityArchivePath,
   buildCompanyCityCurrentPath,
+  buildCurrentWeekPath,
   canonicalCompanySlug,
   isCompanyCityPath,
   listCompanyCityCurrentPaths,
@@ -33,9 +34,11 @@ import {
 import {
   buildCompanyCityStats,
   enumerateCompanyCityPairs,
+  findOrphanedCompanyCityPairs,
   generateWeeklyEmployerPages,
   injectSiblingLinks,
   renderCompanyCityPage,
+  renderOrphanCompanyCityBridge,
   type JobsSnapshot,
   type WeeklyCountableJob,
 } from '../build-plugins/weeklyEmployersPlugin';
@@ -832,6 +835,131 @@ describe('generateWeeklyEmployerPages — company-city integration', () => {
     expect(luganoIt).toBeTruthy();
     // With delta=3, the IT hero block says "+3" (5 this week - 2 previous).
     expect(luganoIt?.html).toMatch(/\+3/);
+  });
+});
+
+// ── Orphaned-pair redirect bridge (never-404 guarantee) ─────────
+
+describe('findOrphanedCompanyCityPairs', () => {
+  const snapshotWith = (week: string, employer: string, employerKey: string, city: string, count: number): JobsSnapshot => ({
+    week,
+    jobs: Array.from({ length: count }, (_, i) => ({
+      slug: `${employerKey}-${city}-${i}`,
+      employer,
+      employerKey,
+      city,
+    })),
+  });
+
+  it('returns empty when no snapshot history exists', () => {
+    expect(findOrphanedCompanyCityPairs([], [])).toEqual([]);
+  });
+
+  it('flags a pair that qualified in a past snapshot but is absent this build', () => {
+    const snapshots = [snapshotWith('2026-20', 'Gamma SA', 'gamma-sa', 'Chiasso', 4)];
+    const orphans = findOrphanedCompanyCityPairs(snapshots, []);
+    expect(orphans).toEqual([
+      { city: 'chiasso', companySlug: 'gamma-sa', employer: 'Gamma SA' },
+    ]);
+  });
+
+  it('does NOT flag a pair that is still in the current qualifying set', () => {
+    const snapshots = [snapshotWith('2026-20', 'Gamma SA', 'gamma-sa', 'Chiasso', 4)];
+    const orphans = findOrphanedCompanyCityPairs(snapshots, [
+      { city: 'chiasso' as WeeklyEmployersCompanyCity, companySlug: 'gamma-sa' },
+    ]);
+    expect(orphans).toEqual([]);
+  });
+
+  it('does NOT flag a snapshot pair that never met the 3-job gate', () => {
+    const snapshots = [snapshotWith('2026-20', 'Gamma SA', 'gamma-sa', 'Chiasso', 2)];
+    expect(findOrphanedCompanyCityPairs(snapshots, [])).toEqual([]);
+  });
+
+  it('dedupes the same orphaned pair across multiple past snapshots', () => {
+    const snapshots = [
+      snapshotWith('2026-19', 'Gamma SA', 'gamma-sa', 'Chiasso', 3),
+      snapshotWith('2026-20', 'Gamma SA', 'gamma-sa', 'Chiasso', 5),
+    ];
+    expect(findOrphanedCompanyCityPairs(snapshots, [])).toHaveLength(1);
+  });
+
+  it('ignores snapshot jobs whose city does not match any company-city hub', () => {
+    const snapshots = [snapshotWith('2026-20', 'Gamma SA', 'gamma-sa', 'Lausanne', 6)];
+    expect(findOrphanedCompanyCityPairs(snapshots, [])).toEqual([]);
+  });
+});
+
+describe('renderOrphanCompanyCityBridge', () => {
+  it('is noindex,follow and canonicalises to the city hub', () => {
+    for (const locale of WEEKLY_EMPLOYERS_LOCALES) {
+      const html = renderOrphanCompanyCityBridge(locale, 'chiasso', 'Gamma SA');
+      expect(html).toContain('name="robots" content="noindex,follow"');
+      const hubPath = buildCurrentWeekPath(locale, 'chiasso');
+      expect(html).toContain(hubPath);
+      expect(html).toContain('location.replace(');
+    }
+  });
+});
+
+describe('generateWeeklyEmployerPages — orphaned company-city bridges', () => {
+  it('emits a noindex bridge (not a 404) when a company drops below the gate', () => {
+    // Snapshot history remembers Gamma SA qualifying in Chiasso; current jobs
+    // don't include Gamma SA at all — this is the "company dropped out" case
+    // that used to leave cleanNamespaces() wipe the page into a 404.
+    const snapshots: JobsSnapshot[] = [
+      {
+        week: '2026-20',
+        jobs: Array.from({ length: 4 }, (_, i) => ({
+          slug: `gamma-chiasso-${i}`,
+          employer: 'Gamma SA',
+          employerKey: 'gamma-sa',
+          city: 'Chiasso',
+        })),
+      },
+    ];
+    const pages = generateWeeklyEmployerPages({
+      rootDir: process.cwd(),
+      jobs: makeEocJobs(4, 'Lugano'), // unrelated qualifying pair, no Gamma jobs at all
+      snapshots,
+      today: new Date('2026-04-20T12:00:00Z'),
+    });
+
+    const bridgePages = pages.filter((p) => p.path.includes('/chiasso/gamma-sa/'));
+    expect(bridgePages).toHaveLength(WEEKLY_EMPLOYERS_LOCALES.length);
+    for (const page of bridgePages) {
+      expect(page.indexable).toBe(false);
+      expect(page.bridge).toBe(true);
+      expect(page.html).toContain('noindex,follow');
+      // Word count is deliberately tiny — must not be gate-able as thin content
+      // since it's a redirect stub, not indexed content.
+    }
+
+    // Sitemap-eligible paths (via `indexable`) must exclude the bridge.
+    expect(pages.filter((p) => p.path.includes('gamma-sa')).every((p) => !p.indexable)).toBe(true);
+  });
+
+  it('does not emit a bridge for a pair that still qualifies this build', () => {
+    const jobs = makeEocJobs(4, 'Lugano');
+    const snapshots: JobsSnapshot[] = [
+      {
+        week: '2026-20',
+        jobs: jobs.map((j) => ({
+          slug: j.slug!,
+          employer: j.company!,
+          employerKey: j.companyKey,
+          city: 'Lugano',
+        })),
+      },
+    ];
+    const pages = generateWeeklyEmployerPages({
+      rootDir: process.cwd(),
+      jobs,
+      snapshots,
+      today: new Date('2026-04-20T12:00:00Z'),
+    });
+    const bridgePages = pages.filter((p) => p.bridge);
+    expect(bridgePages).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Implementato

- `weeklyEmployersPlugin.ts`: orphaned company×city pairs (job no longer active in that city, page previously emitted+indexed) now get a noindex bridge to a live target instead of silently disappearing from the build → hard 404.
- `scripts/scrub-hilcona-undefined-active-slugs.mjs` run: scrubbed Hilcona-class `-undefined` slugs from `data/jobs/by-crawler/hilcona.json` (same bug class as the orphan-bridge fix — a slug built from a field that could be missing).
- `professionCantonLandings.ts`, `weeklyEmployersChCantonPages.ts`, `jobMarketSnapshotChCantonPages.ts`: same below-floor sibling bug found via Non-Negotiable #6 grep — a per-canton static page gated on a job-count floor computed fresh each build silently `continue`d (no bridge) once a canton dropped below floor, even if a prior build emitted (and Google indexed) that exact URL. All three now emit a noindex bridge to the always-live salary-stats hub via a new shared helper, `build-plugins/shared/salaryStatsBridge.ts` (`professionCantonLandings.ts` refactored to use it too, replacing its own inline bridge builder).
- `searchConsoleCompat.ts`: two resolver gaps found by actually running `scripts/ingest-gsc-coverage-404s.ts --dry-run` against the user-provided GSC Coverage Drilldown CSV (999 URL rows) and inspecting what didn't resolve:
  - `SECTION_FALLBACKS` company-hub entries only covered IT/EN, per a stale comment claiming DE/FR hub roots aren't emitted — false (`weeklyEmployersPlugin.ts`'s `renderTopHubPage` loops over all 4 `WEEKLY_EMPLOYERS_LOCALES`). Added the missing DE (`/de/unternehmen-einstellen/`) and FR (`/fr/entreprises-recrutent/`) fallback entries, fixed the comment.
  - Compat resolver had zero awareness of the profession-canton URL family (`professionCantonLandings.ts`) at all. Added a self-map branch using the pre-existing `isProfessionCantonPath` helper — that family emits every (canton × profession) combo unconditionally (full page or below-floor bridge), so any URL matching its shape always has a live target today.
- `data/gsc-coverage-404s.json` regenerated from the real CSV after both fixes: 1000/1000 rows now resolve (was 998/1000).
- `jobsSeoPagesPlugin.ts`: reviewer follow-up round 1 — 5 more instances of the identical below-floor silent-`continue` 404 bug (Non-Negotiable #6 sibling sweep), all in this same file: the 4 editorial-canton loops (today-landing, nurses-hub, part-time, care-variant) plus the per-canton sector-hub loop. All now bridge to that canton's always-live canton-root job-board hub (`buildCantonAwareSection(locale, canton)`, unconditionally emitted for every canton/locale regardless of job count) via this file's own pre-existing `buildCanonicalBridgePage` helper, instead of dropping the page. New regression test `tests/jobs-seo-editorial-below-floor-bridge.test.ts` (source-assertion style, matching this plugin's own existing test convention since `closeBundle()` only runs inside a full RAM-bound SSG build) — 6/6 green, plus full touched-area sweep (8 files, 128 tests) green, `npx tsc --noEmit` clean.
- Triaged `nursingLandingsPlugin.ts` / `careerLandingsPlugin.ts` / `costOfLivingLandingsPlugin.ts` for the same below-floor bug class — confirmed false positive (their `MIN_INDEXABLE_WORDS` gate doesn't trigger even at zero jobs), documented as such rather than silently skipped.
- **`jobsSeoPagesPlugin.ts`: reviewer follow-up round 2** — 3 more instances of the same bug, in the TI location-family loops: location-level, location+type, and location+sector editorial pages all dropped the page with a bare `continue` once that (location[, type|sector]) combo fell under its job floor. Location-level now dual-writes a noindex bridge at both the clean city-hub URL and the legacy editorial URL (mirroring the real page's own dual-emit), pointing at the TI section root; type/sector-level bridge to the city-hub URL. Same `buildCanonicalBridgePage` convention as round 1.
- **`seoHubsPlugin.ts`: reviewer follow-up round 2** — `emitThinCantonHubs` silently skipped a non-TI canton's `/tutti/`, `/settori/`, `/aziende/` hub pages once job count fell under `MIN_JOBS_FOR_CANTON_PAGE` (or its slug-bearing/dedup counts disagreed, or the canton's parent landing went noindex per `cantonNoindexRegistry.ts`) — same bug class, 4 sites. Now bridges all three hub paths to the always-live canton section root (`resolveCantonSection`) instead of dropping them; bridge pages are never added to the sitemap.
- Tests: `tests/ch-canton-below-floor-bridge.test.ts`, `tests/jobs-seo-editorial-below-floor-bridge.test.ts` (extended for the round-2 location-family sites), `tests/seo-hubs-canton-below-floor-bridge.test.ts` (new), plus extended `tests/profession-canton-landings.test.ts`, `tests/weekly-employers-company-city.test.ts`, `tests/search-console-compat.test.ts`. Full touched-area sweep (50+ files, 512+ tests) green; `npx tsc --noEmit` shows 0 new errors (179 pre-existing unrelated errors on `main`, unchanged).

## Non implementato (ancora)

Nessuno.
