### PR TITLE
fix(generate-article): root-cause recurring JSON-parse/schema failures

### DIFF
--- a/scripts/batch-add-faq-to-articles.mjs
+++ b/scripts/batch-add-faq-to-articles.mjs
@@ -28,7 +28,7 @@ const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, '..');
 import { callLLM, callSingleModel, AI_MODELS, initScoreStore, getStats, flushScores, resetExhaustedModel, printRunSummary } from './lib/ai-models.mjs';
 import { freeTranslateWithRetry, logCascadeSummary } from './lib/free-translate.mjs';
-import { stripCodeFences, findMatchingClose, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, findMatchingClose, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError } from './lib/llm-json-repair.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 
 // ── CLI argument parsing ─────────────────────────────────────
@@ -489,7 +489,7 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
     // Try extracting Q&A pairs via regex as last resort
     const regexFaq = extractFaqFromText(raw);
     if (regexFaq && regexFaq.length >= 2) return regexFaq;
-    console.error(`  [JSON parse failed] ${parseErr.message} — raw[0:300]: ${raw.slice(0, 300).replace(/\n/g, '\\n')}`);
+    console.error(`  [JSON parse failed] ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
     throw new Error(`JSON non valido dalla generazione FAQ: ${parseErr.message}`);
   }
   const faq = extractFaqArray(parsed);

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -76,7 +76,7 @@ import { translateFieldFreeMt } from './lib/article-free-mt.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
-import { stripCodeFences, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError } from './lib/llm-json-repair.mjs';
 import {
   factCheckFingerprint,
   totalMajorWeight,
@@ -3167,8 +3167,10 @@ async function callLLM(messages, opts = {}) {
     if (isBody2Check) {
       let itContent = null;
       let parseErr = null;
+      let repaired = null;
       try {
-        const parsed = JSON.parse(repairLlmJson(result));
+        repaired = repairLlmJson(result);
+        const parsed = JSON.parse(repaired);
         itContent = normalizeItalianContentFromPayload(parsed);
       } catch (e) {
         parseErr = e;
@@ -3180,11 +3182,10 @@ async function callLLM(messages, opts = {}) {
         missing.push('content.it non normalizzabile');
         // Previously swallowed silently — every "non normalizzabile" failure
         // was unreproducible (no evidence of what the model actually sent).
-        // Log the parse error + a raw snippet so a recurring malformed-JSON
+        // Log the parse error + a snippet so a recurring malformed-JSON
         // pattern from a specific model can actually be root-caused.
         if (parseErr) {
-          const snippet = String(result).slice(0, 300).replace(/\n/g, '\\n');
-          console.error(`  🔎 JSON parse fallito (${modelUsedRef.model || 'unknown'}): ${parseErr.message} — raw[0:300]: ${snippet}`);
+          console.error(`  🔎 JSON parse fallito (${modelUsedRef.model || 'unknown'}): ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
         }
       } else {
         for (const field of REQUIRED_IT_BODY_FIELDS) {
@@ -4452,14 +4453,15 @@ Rispondi SOLO con JSON valido, senza markdown.` },
     itRaw = await callLLM(llmMessages, { model: forceModel || GH_MODEL_HEAVY, temperature, maxTokens: 8000, jsonMode: true, jsonSchema: articleSchema });
   }
   let itData;
+  const itRepaired = repairLlmJson(itRaw);
   try {
-    itData = JSON.parse(repairLlmJson(itRaw));
+    itData = JSON.parse(itRepaired);
   } catch (parseErr) {
     // One repair-aware regenerate before giving up. Truncation (output cap
     // hit) gets 2× tokens; structural corruption keeps the same budget so
     // we don't pay double for a transient `***`-between-properties glitch.
     console.error(`❌ JSON parse error: ${parseErr.message}`);
-    console.error(`   Raw response (last 200 chars): ...${itRaw.slice(-200)}`);
+    console.error(`   ${describeJsonParseError(itRepaired, parseErr)}`);
     const isTruncation = /Unterminated|Unexpected end/i.test(parseErr.message);
     const retryTokens = isTruncation ? 16000 : 8000;
     console.error(`  🔄 Retry IT con maxTokens=${retryTokens}${isTruncation ? ' (troncamento rilevato)' : ''}...`);
@@ -4757,11 +4759,12 @@ async function translateArticle(data) {
       [{ role: 'user', content: safePrompt }],
       { temperature: 0.5, maxTokens, jsonMode: true },
     );
+    const repaired = repairLlmJson(raw);
     try {
-      return JSON.parse(repairLlmJson(raw));
+      return JSON.parse(repaired);
     } catch (parseErr) {
       console.error(`  ⚠️  JSON parse error (${label}): ${parseErr.message}`);
-      console.error(`     Raw (last 200 chars): ...${raw.slice(-200)}`);
+      console.error(`     ${describeJsonParseError(repaired, parseErr)}`);
       // Detect truncation (model hit output cap): use 3× tokens on retry
       const isTruncation = parseErr.message.includes('Unterminated') || parseErr.message.includes('Unexpected end');
       const retry1Tokens = isTruncation ? Math.max(maxTokens * 3, 12000) : maxTokens + 4000;

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -91,7 +91,7 @@ export const AI_MODELS = Object.freeze({
   GPT_4_1:          'gpt-4.1',
   GPT_4_1_MINI:     'gpt-4.1-mini',
   GPT_4_1_NANO:     'gpt-4.1-nano',
-  COHERE_CMD_R:     'Cohere-command-r-08-2024',
+  // COHERE_CMD_R removed — GitHub Models HTTP 400 "unknown_model: Cohere-command-r-08-2024" (2026-07-05, confirmed retired live against the real inference endpoint)
   COHERE_CMD_A:     'Cohere-command-a',
   LLAMA_3_2_90B:    'Llama-3.2-90B-Vision-Instruct',
   DEEPSEEK_V3:      'DeepSeek-V3-0324',
@@ -424,7 +424,7 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.OR_GEMMA_3_27B,     // 39. Gemma 3 27B instruct   (OpenRouter free)
   // CB_LLAMA_3_1_70B removed — Cerebras 404 (model deprecated 2026-03)
   AI_MODELS.COH_CMD_A_TRANSLATE,// 40. Cohere translate       (Cohere direct)
-  AI_MODELS.COHERE_CMD_R,       // 41. Cohere Command R       (GitHub Models)
+  // AI_MODELS.COHERE_CMD_R removed — GitHub Models HTTP 400 "unknown_model: Cohere-command-r-08-2024" (2026-07-05, confirmed retired live)
   AI_MODELS.COH_CMD_R,          // 41b. Cohere Command R      (Cohere direct - 1000/month)
   // GROQ_LLAMA_3_1_70B removed — decommissioned 2026-03 (HTTP 422 from Groq)
   AI_MODELS.CF_MISTRAL_SM_31,   // 42. Mistral Small 3.1      (Cloudflare Workers AI)
@@ -831,8 +831,18 @@ const DEFAULT_OPTS = {
  *   (Cohere uses `{ type: 'json_object', schema }`, Gemini uses Proto), or
  *   they 400 on `response_format` entirely. Gemini's native schema path is
  *   wired separately in _callGeminiRaw via `generationConfig.responseSchema`.
+ * - Local (ollama, _callLocal → _callOpenAICompatible with providerName:
+ *   'Local'): ollama's OpenAI-compat endpoint honors the same strict
+ *   json_schema contract (verified 2026-07-05 against a local ollama
+ *   v0.31.1 + qwen2.5:0.5b using the exact production article schema from
+ *   buildArticleJsonSchema() — HTTP 200, valid JSON, all required keys
+ *   present). Without this, local/fallback only got generic `json_object`
+ *   mode (valid JSON syntax, no shape guarantee), which is the direct cause
+ *   of the recurring "content.it non normalizzabile" / JSON parse failures
+ *   logged whenever the cascade reached local/fallback (e.g. run
+ *   28744325535's `imageAlt` object left dangling mid-payload).
  */
-const PROVIDERS_WITH_STRICT_JSON_SCHEMA = new Set(['GitHub', 'OpenRouter', 'Mistral']);
+const PROVIDERS_WITH_STRICT_JSON_SCHEMA = new Set(['GitHub', 'OpenRouter', 'Mistral', 'Local']);
 
 /**
  * Global schema-mode toggle for ops control. Driven by AI_MODELS_SCHEMA_MODE env
@@ -856,15 +866,23 @@ function getSchemaMode() {
  *  - mode=force  → always (probe-only; most providers will 400)
  *  - mode=auto   → OpenAI-compat providers in PROVIDERS_WITH_STRICT_JSON_SCHEMA,
  *                  plus Gemini (which uses its own native responseSchema path,
- *                  not the OpenAI response_format shape — handled in _callGeminiRaw)
+ *                  not the OpenAI response_format shape — handled in _callGeminiRaw),
+ *                  minus any model in _learnedSchemaIncompatible (runtime-learned
+ *                  per-model 400 on schema mode — see _learnSchemaIncompatible)
+ *
+ * `modelForTracking`, when given, is checked against _learnedSchemaIncompatible
+ * so a single model within a provider that 400s on schema mode (e.g. a
+ * GitHub-hosted Ministral/Codestral/Phi-4 variant) stops being offered it,
+ * without punishing the rest of that provider's models.
  *
  * Exported for tests / smoke probes.
  */
-export function shouldUseSchemaMode(providerName, hasSchema = true) {
+export function shouldUseSchemaMode(providerName, hasSchema = true, modelForTracking = undefined) {
   if (!hasSchema) return false;
   const mode = getSchemaMode();
   if (mode === 'off') return false;
   if (mode === 'force') return true;
+  if (modelForTracking && _learnedSchemaIncompatible.has(modelForTracking)) return false;
   if (providerName === 'Gemini') return true;
   return PROVIDERS_WITH_STRICT_JSON_SCHEMA.has(providerName);
 }
@@ -1541,6 +1559,7 @@ export async function initScoreStore() {
     let decayed = 0;
     let exhaustedRestored = 0;
     let learnedLimitsRestored = 0;
+    let schemaIncompatibleRestored = 0;
     let source = 'aggregate';
 
     const aggregateRef = _firestoreDb
@@ -1618,9 +1637,16 @@ export async function initScoreStore() {
         _learnedRequestTokenLimits.set(modelId, data.maxRequestTokens);
         learnedLimitsRestored++;
       }
+
+      // Runtime-learned schema-mode incompatibility (see _learnSchemaIncompatible)
+      // — same unconditional-restore reasoning as maxRequestTokens above.
+      if (data.schemaIncompatible === true) {
+        _learnedSchemaIncompatible.add(modelId);
+        schemaIncompatibleRestored++;
+      }
     }
 
-    console.log(`☁️  [ScoreStore] Loaded ${loaded} model scores from Firestore [${source}] (${decayed} decayed, ${exhaustedRestored} still exhausted, ${learnedLimitsRestored} learned token limits)`);
+    console.log(`☁️  [ScoreStore] Loaded ${loaded} model scores from Firestore [${source}] (${decayed} decayed, ${exhaustedRestored} still exhausted, ${learnedLimitsRestored} learned token limits, ${schemaIncompatibleRestored} schema-incompatible)`);
 
     // Register exit hooks for final flush
     _registerExitHooks();
@@ -1687,6 +1713,11 @@ async function _persistScoresToFirestore() {
     // Not a daily quota — no local/fallback exemption needed.
     if (_learnedRequestTokenLimits.has(modelId)) {
       entry.maxRequestTokens = _learnedRequestTokenLimits.get(modelId);
+    }
+
+    // Runtime-learned schema-mode incompatibility (see _learnSchemaIncompatible).
+    if (_learnedSchemaIncompatible.has(modelId)) {
+      entry.schemaIncompatible = true;
     }
 
     modelsDelta[_encodeModelId(modelId)] = entry;
@@ -1996,6 +2027,7 @@ export function resetState() {
   _consecutive429.clear();
   _consecutiveContentFailures.clear();
   _learnedRequestTokenLimits.clear();
+  _learnedSchemaIncompatible.clear();
   _mutationCount = 0;
   if (_persistTimer) { clearTimeout(_persistTimer); _persistTimer = null; }
   _stats.calls = 0;
@@ -2170,14 +2202,23 @@ function classifyNonRetryableError(status, bodyText = '') {
   // refuses *this* request shape — skip without exhausting so it can still be
   // used by other callers without jsonSchema. The schema-mode allowlist in
   // shouldUseSchemaMode() prevents most of these at send-time.
-  if (
-    b.includes('unsupported parameter') ||
+  //
+  // 'unsupported parameter' alone (bare, no response_format/schema mention) is
+  // the unrelated max_tokens-vs-max_completion_tokens rejection (see
+  // MAX_COMPLETION_TOKENS_MODELS) — do NOT tag it schema_unsupported, or
+  // _learnSchemaIncompatible would permanently stop offering schema mode to a
+  // model whose only real problem is the token-param name.
+  const isSchemaFormatRejection =
     b.includes('does not support response format') ||
-    b.includes('response_format') && b.includes('not support') ||
+    (b.includes('response_format') && b.includes('not support')) ||
     b.includes("unknown name 'type' at 'generation_config.response_schema") ||
-    b.includes('response_schema.properties')
-  ) {
-    return { nonRetryable: true, markExhausted: false };
+    b.includes('response_schema.properties');
+  if (b.includes('unsupported parameter') || isSchemaFormatRejection) {
+    return {
+      nonRetryable: true,
+      markExhausted: false,
+      ...(isSchemaFormatRejection ? { reason: 'schema_unsupported' } : {}),
+    };
   }
   return { nonRetryable: false, markExhausted: false };
 }
@@ -2394,6 +2435,31 @@ function _learnRequestTokenLimit(modelForTracking, bodyText) {
 }
 
 /**
+ * Runtime-learned set of models that 400 on strict JSON-schema mode despite
+ * being in PROVIDERS_WITH_STRICT_JSON_SCHEMA / the Gemini native path —
+ * GitHub Models proxies several sub-model families (Ministral-3B,
+ * Codestral-2501, the Phi-4 family) with inconsistent schema support, so a
+ * per-provider allowlist alone forces schema mode onto them on every cascade
+ * pass, forever, wasting a network round-trip each time
+ * (classifyNonRetryableError's 'schema_unsupported' branch). Same
+ * self-correcting pattern as _learnedRequestTokenLimits above, keyed the same
+ * way (full chain model id, matching _modelScores' keyspace).
+ */
+const _learnedSchemaIncompatible = new Set();
+
+/**
+ * Remember that `modelForTracking` rejected strict JSON-schema mode, so
+ * shouldUseSchemaMode() stops requesting it for this model going forward
+ * (in-run immediately, cross-run via Firestore). No-op if already known.
+ */
+function _learnSchemaIncompatible(modelForTracking) {
+  if (_learnedSchemaIncompatible.has(modelForTracking)) return;
+  _learnedSchemaIncompatible.add(modelForTracking);
+  _dirtyModels.add(modelForTracking);
+  _schedulePersist();
+}
+
+/**
  * Estimate token count for a list of OpenAI-format messages. Uses the standard
  * chars/4 ≈ tokens heuristic — accurate enough for "is this prompt going to
  * blow past 4000?" decisions. Adds a 500-token safety margin to account for
@@ -2480,7 +2546,7 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
   // AI_MODELS_SCHEMA_MODE=force opts in every OpenAI-compat provider (probe
   // mode only — most providers 400 on unsupported response_format types).
   let responseFormat;
-  if (shouldUseSchemaMode(providerName, !!opts.jsonSchema)) {
+  if (shouldUseSchemaMode(providerName, !!opts.jsonSchema, modelForTracking)) {
     responseFormat = {
       type: 'json_schema',
       json_schema: {
@@ -2545,6 +2611,13 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
           // further to 200 for logging), which is why this can't be recovered
           // after the fact from logs.
           _learnRequestTokenLimit(modelForTracking, raw);
+          // Same reasoning: a 400 with this exact shape only happens when we
+          // requested schema mode (responseFormat.type === 'json_schema') and
+          // the model rejected it — remember it so future cascade passes stop
+          // paying the round-trip for a request shape this model never accepts.
+          if (nrc.reason === 'schema_unsupported' && responseFormat?.type === 'json_schema') {
+            _learnSchemaIncompatible(modelForTracking);
+          }
           if (nrc.markExhausted && getProvider(modelForTracking) !== PROVIDER.LOCAL) {
             markModelExhausted(modelForTracking, 'nonretryable');
             _stats.exhausted++;
@@ -2983,7 +3056,7 @@ async function _callGeminiRaw(model, messages, opts) {
   // Gemini has its own response_schema syntax (Proto-style), so it uses a
   // dedicated allowlist entry below — but it still honors the AI_MODELS_SCHEMA_MODE
   // ops kill-switch via the same `shouldUseSchemaMode('Gemini', …)` check.
-  const useGeminiSchema = !!opts.jsonSchema && shouldUseSchemaMode('Gemini', true);
+  const useGeminiSchema = !!opts.jsonSchema && shouldUseSchemaMode('Gemini', true, model);
   const geminiSchema = useGeminiSchema ? sanitizeSchemaForGemini(opts.jsonSchema.schema) : null;
 
   const body = {
@@ -3024,6 +3097,9 @@ async function _callGeminiRaw(model, messages, opts) {
           // Learn the real size cap from `raw` while it's still untruncated —
           // see the matching call in _callOpenAICompatible for why.
           _learnRequestTokenLimit(model, raw);
+          if (nrc.reason === 'schema_unsupported' && useGeminiSchema) {
+            _learnSchemaIncompatible(model);
+          }
           if (nrc.markExhausted) {
             markModelExhausted(model);
             _stats.exhausted++;

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -255,6 +255,37 @@ function looksLikeJsonContinuation(str, pos, fixAsterisks) {
   return afterSeparatorLooksValid(str, i + 1, ch === ':', fixAsterisks);
 }
 
+/**
+ * Build a log-ready excerpt of `repairedText` centered on the byte offset a
+ * `JSON.parse()` SyntaxError reports, so the logged snippet actually shows
+ * the character that broke parsing.
+ *
+ * `repairedText` MUST be the exact string passed to `JSON.parse()` (i.e. the
+ * repairLlmJson/repairJsonArray OUTPUT), not the original raw LLM response.
+ * repairLlmJson/repairJsonArray change the string's length (escaping inner
+ * quotes, collapsing `\n`, stripping code fences), so a `raw[0:300]` snippet
+ * of the PRE-repair text logged next to a POST-repair error position points
+ * at an unrelated byte — every "JSON parse fallito" log produced this way is
+ * undiagnosable (confirmed by hand-reconstructing run 28744325535's logged
+ * position against its logged raw snippet: they land on different
+ * characters). Node's `SyntaxError.message` embeds the offset as
+ * `at position N`; when present, this returns a window around N in
+ * `repairedText` instead of an arbitrary prefix.
+ */
+export function describeJsonParseError(repairedText, parseErr, contextChars = 120) {
+  const str = String(repairedText);
+  const m = /position (\d+)/.exec(parseErr?.message || '');
+  if (!m) {
+    return `repaired[0:${contextChars * 2}]: ${str.slice(0, contextChars * 2).replace(/\n/g, '\\n')}`;
+  }
+  const pos = Math.min(Number(m[1]), str.length);
+  const start = Math.max(0, pos - contextChars);
+  const end = Math.min(str.length, pos + contextChars);
+  const before = str.slice(start, pos).replace(/\n/g, '\\n');
+  const after = str.slice(pos, end).replace(/\n/g, '\\n');
+  return `repaired[${start}:${end}] around position ${pos}: ${before}<<HERE>>${after}`;
+}
+
 export function fixJsonStringBody(input, { fixAsterisks = false } = {}) {
   let out = '';
   let inStr = false;

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -449,7 +449,7 @@ describe('local LLM fallback exhaustion never persists past the run (Firestore)'
       const loadLine = logSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('[ScoreStore] Loaded'));
       expect(loadLine).toBeDefined();
       // Only gpt-4o's ban should survive the restore — local/fallback's must not.
-      expect(loadLine).toMatch(/\(0 decayed, 1 still exhausted, \d+ learned token limits\)/);
+      expect(loadLine).toMatch(/\(0 decayed, 1 still exhausted, \d+ learned token limits, \d+ schema-incompatible\)/);
     } finally {
       logSpy.mockRestore();
     }
@@ -563,5 +563,122 @@ describe('self-learning request-token-limit discovery (generalizes beyond hardco
     const bigPrompt = 'x'.repeat(10_000);
     await expect(mod.callLLM([{ role: 'user', content: bigPrompt }], { maxRetriesPerModel: 1 })).rejects.toThrow('All AI models failed');
     expect(fetchCalled).toBe(false);
+  });
+});
+
+// Regression guard for the structural fix (2026-07-05): GitHub Models proxies
+// several sub-model families (Ministral-3B, Codestral-2501, the Phi-4 family)
+// with inconsistent strict-JSON-schema support despite GitHub being in
+// PROVIDERS_WITH_STRICT_JSON_SCHEMA — a model that 400s on response_format=
+// json_schema got the exact same failing request replayed on every cascade
+// pass, forever, wasting a round-trip each time. Mirrors the self-learning
+// request-token-limit mechanism above: learn per-model (not per-provider),
+// persist via the same Firestore aggregate doc, and stop offering schema mode
+// to that model going forward via shouldUseSchemaMode().
+describe('self-learning schema-incompatibility discovery (per-model, not per-provider)', () => {
+  const prevCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  const prevGhPat = process.env.GH_MODELS_PAT;
+  const prevForceChain = process.env.AI_MODELS_FORCE_CHAIN;
+  const prevFetch = globalThis.fetch;
+
+  const testSchema = { name: 'test_schema', schema: { type: 'object', properties: { a: { type: 'string' } } } };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = '/dev/null';
+    process.env.GH_MODELS_PAT = 'test-pat';
+    globalThis.fetch = (async () => { throw new Error('network disabled in test'); }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = prevFetch;
+    if (prevCreds === undefined) delete process.env.GOOGLE_APPLICATION_CREDENTIALS; else process.env.GOOGLE_APPLICATION_CREDENTIALS = prevCreds;
+    if (prevGhPat === undefined) delete process.env.GH_MODELS_PAT; else process.env.GH_MODELS_PAT = prevGhPat;
+    if (prevForceChain === undefined) delete process.env.AI_MODELS_FORCE_CHAIN; else process.env.AI_MODELS_FORCE_CHAIN = prevForceChain;
+    vi.doUnmock('firebase-admin');
+  });
+
+  it('write path: a GitHub 400 "does not support response format" persists schemaIncompatible for that model only', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    process.env.AI_MODELS_FORCE_CHAIN = 'gpt-4o-mini';
+    globalThis.fetch = (async () => ({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({
+        error: {
+          message: 'Invalid schema for response_format: model does not support response format json_schema',
+          code: 'invalid_request',
+        },
+      }),
+    })) as unknown as typeof fetch;
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    await expect(
+      mod.callLLM([{ role: 'user', content: 'hi' }], { maxRetriesPerModel: 1, jsonSchema: testSchema }),
+    ).rejects.toThrow('All AI models failed');
+
+    const persisted = store._all.models as Record<string, { schemaIncompatible?: boolean }>;
+    expect(persisted['gpt-4o-mini'].schemaIncompatible).toBe(true);
+  });
+
+  it('does NOT tag a bare "unsupported parameter" (max_tokens) rejection as schema-incompatible', async () => {
+    // Same nonRetryable classification path as the schema-format case, but a
+    // different real cause (max_tokens vs max_completion_tokens) — tagging it
+    // schema_unsupported would wrongly disable schema mode for a model whose
+    // actual problem has nothing to do with response_format/response_schema.
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    process.env.AI_MODELS_FORCE_CHAIN = 'gpt-4o-mini';
+    globalThis.fetch = (async () => ({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({
+        error: { message: "Unsupported parameter: 'max_tokens' is not supported with this model.", code: 'unsupported_parameter' },
+      }),
+    })) as unknown as typeof fetch;
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    await expect(
+      mod.callLLM([{ role: 'user', content: 'hi' }], { maxRetriesPerModel: 1, jsonSchema: testSchema }),
+    ).rejects.toThrow('All AI models failed');
+
+    const persisted = store._all.models as Record<string, { schemaIncompatible?: boolean }> | undefined;
+    expect(persisted?.['gpt-4o-mini']?.schemaIncompatible).toBeUndefined();
+  });
+
+  it('restore path: a pre-existing learned incompatibility is loaded on init and shouldUseSchemaMode stops offering schema mode', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {
+      _all: { models: { 'gpt-4o-mini': { modelId: 'gpt-4o-mini', score: 0, schemaIncompatible: true } } },
+    };
+    mockFirestore(store);
+
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+
+    // Provider-level allowlist alone would say yes (GitHub is in
+    // PROVIDERS_WITH_STRICT_JSON_SCHEMA) — the per-model learned flag must
+    // override that for this specific model, without punishing a sibling
+    // GitHub model that was never flagged.
+    expect(mod.shouldUseSchemaMode('GitHub', true, 'gpt-4o-mini')).toBe(false);
+    expect(mod.shouldUseSchemaMode('GitHub', true, 'gpt-4o')).toBe(true);
+  });
+
+  it('AI_MODELS_SCHEMA_MODE=force still probes a flagged model (explicit ops override, not silently suppressed)', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {
+      _all: { models: { 'gpt-4o-mini': { modelId: 'gpt-4o-mini', score: 0, schemaIncompatible: true } } },
+    };
+    mockFirestore(store);
+    const prevMode = process.env.AI_MODELS_SCHEMA_MODE;
+    process.env.AI_MODELS_SCHEMA_MODE = 'force';
+    try {
+      const mod = await import('../scripts/lib/ai-models.mjs');
+      await mod.initScoreStore();
+      expect(mod.shouldUseSchemaMode('GitHub', true, 'gpt-4o-mini')).toBe(true);
+    } finally {
+      if (prevMode === undefined) delete process.env.AI_MODELS_SCHEMA_MODE; else process.env.AI_MODELS_SCHEMA_MODE = prevMode;
+    }
   });
 });

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -9,7 +9,7 @@
 // had this bug inlined — fixed once in shared ./lib/llm-json-repair.mjs.
 
 import { describe, expect, it } from 'vitest';
-import { stripCodeFences, findMatchingClose, fixJsonStringBody } from '../../scripts/lib/llm-json-repair.mjs';
+import { stripCodeFences, findMatchingClose, fixJsonStringBody, describeJsonParseError } from '../../scripts/lib/llm-json-repair.mjs';
 
 describe('fixJsonStringBody', () => {
   it('escapes an unescaped inner quote so the string does not terminate early', () => {
@@ -156,6 +156,46 @@ describe('stripCodeFences', () => {
 
   it('leaves unfenced content untouched', () => {
     expect(stripCodeFences('{"a":1}')).toBe('{"a":1}');
+  });
+});
+
+describe('describeJsonParseError', () => {
+  // Regression: several call sites logged a raw[0:300] snippet of the
+  // PRE-repair text next to a JSON.parse() error whose "position N" is
+  // computed against the POST-repair string — repairLlmJson/repairJsonArray
+  // change the string's length (escaping quotes, collapsing \n, stripping
+  // code fences), so the two coordinate systems don't match and the logged
+  // snippet never showed the actual failing byte (run 28744325535).
+  it('centers the excerpt on the position reported by a real JSON.parse SyntaxError', () => {
+    const repaired = '{"a":"ok","b":"bad}'; // missing closing quote before }
+    let err: Error;
+    try {
+      JSON.parse(repaired);
+      throw new Error('expected JSON.parse to throw');
+    } catch (e) {
+      err = e as Error;
+    }
+    const described = describeJsonParseError(repaired, err);
+    expect(described).toMatch(/position \d+/);
+    expect(described).toContain('<<HERE>>');
+    // The reported position must fall inside the ACTUAL repaired string,
+    // not some unrelated pre-repair offset.
+    const m = /position (\d+)/.exec(err.message);
+    expect(m).not.toBeNull();
+  });
+
+  it('falls back to a plain prefix when the error message has no position', () => {
+    const described = describeJsonParseError('{"a":1}', new Error('some non-standard parse error'));
+    expect(described).toMatch(/^repaired\[0:\d+\]:/);
+    expect(described).not.toContain('<<HERE>>');
+  });
+
+  it('clamps the window to the string bounds near the end', () => {
+    const repaired = '{"a":"short"}';
+    const err = new Error(`Unexpected end of JSON input at position ${repaired.length + 50}`);
+    const described = describeJsonParseError(repaired, err);
+    // Must not throw/slice out of bounds — position is clamped to string length.
+    expect(described).toContain(`position ${repaired.length}`);
   });
 });
 


### PR DESCRIPTION
## Implementato

- **Coordinate-mismatch diagnostic fix**: `describeJsonParseError()` (new, `scripts/lib/llm-json-repair.mjs`) builds a log excerpt centered on the actual byte offset a `JSON.parse()` `SyntaxError` reports, read against the *repaired* string. Previously the logged snippet was a raw pre-repair slice next to a post-repair error position — two different coordinate systems, so the excerpt never showed the byte that actually broke parsing. Wired into all 4 parse-catch sites across `scripts/create-article.mjs` (including the exact site from the reported "content.it non normalizzabile" errors) and `scripts/batch-add-faq-to-articles.mjs`.
- **Local/ollama strict JSON-schema support**: added `'Local'` to `PROVIDERS_WITH_STRICT_JSON_SCHEMA` in `scripts/lib/ai-models.mjs` — verified live against a real ollama v0.31.1 + qwen2.5:0.5b install with the production article JSON schema (HTTP 200, valid JSON, all required keys). Previously local/fallback ran in unstructured JSON mode and produced malformed output on this class of run.
- **Self-learning per-model schema incompatibility**: new `_learnedSchemaIncompatible` Set + `_learnSchemaIncompatible()` (mirrors the existing per-model token-limit learning), persisted via the same Firestore `_dirtyModels`/`_schedulePersist` path. `shouldUseSchemaMode()` now takes an optional `modelForTracking` and stops forcing schema mode onto a model that's previously 400'd on it — scoped per-model (not per-provider), since GitHub Models proxies several sub-model families with inconsistent schema support behind one provider name. `classifyNonRetryableError()` tags genuine `response_format`/`response_schema` rejections with `reason: 'schema_unsupported'`, carefully NOT matching the unrelated bare `'unsupported parameter'` (max_tokens) rejection — that's a distinct failure mode already handled by `MAX_COMPLETION_TOKENS_MODELS`.
- **Dead model prune**: removed `Cohere-command-r-08-2024` from `AI_MODELS`/`DEFAULT_CHAIN` (GitHub Models HTTP 400 `unknown_model`, confirmed retired live 2026-07-05), following the existing repo convention of commenting out with a dated note rather than deleting (inert config-table entry left untouched, matching precedent for other dead models).
- Tests: `tests/scripts/llm-json-repair.test.ts` (+3: position-centered excerpt, fallback-to-prefix, bounds clamping) and `tests/local-llm-fallback.test.ts` (+4: learn-on-400 write path, max_tokens-vs-schema precision guard, Firestore restore path, `AI_MODELS_SCHEMA_MODE=force` override). All 161 tests across the touched suites pass.
- Sibling-pattern sweep (`node scripts/ci/check-sibling-patterns.mjs`, AGENTS.md #6): 19 candidates flagged, all manually confirmed false positives (generic shared tokens — `AI_MODELS`, `SyntaxError`, `parseErr`, `providerName`, `OpenRouter` — used in unrelated, non-LLM-JSON-repair contexts; no duplicated schema-mode logic found anywhere else in the codebase).

## Non implementato (ancora)

Nessuno.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>