### PR TITLE
fix(ci): bump seed-title-baselines.yml timeout 60→150min

### DIFF
--- a/.github/workflows/seed-title-baselines.yml
+++ b/.github/workflows/seed-title-baselines.yml
@@ -59,12 +59,14 @@ permissions:
 jobs:
   seed:
     runs-on: ubuntu-latest
-    # Was 15 — the locale/Ticino shard rehydrate below can fall back to
-    # sequential git clones (~14min/locale, ~12min combined for the 4 Ticino
-    # legs per post-deploy-validate-dist.yml's own measured worst case) when
-    # the same-run tar artifacts are missing, so give it the same headroom
-    # (mirrors seed-text-html-ratio-baseline.yml's fix for issue #3104).
-    timeout-minutes: 60
+    # Was 60 — measured too low once this workflow grew to scan 3 baselines
+    # sequentially (run 28751237762 cancelled by this exact timeout at
+    # 60m13s, mid title-no-disambig-hash scan). Real measured cost at
+    # current corpus size (~2.8M pages): ~14min setup+rehydrate (or up to
+    # ~26min on the sequential git-clone fallback path) + ~28min per audit
+    # scan × 3 audits ≈ 98min. 150 gives headroom for the slow-path
+    # rehydrate plus scan-time growth before the next bump is needed.
+    timeout-minutes: 150
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Implementato

- `.github/workflows/seed-title-baselines.yml`: `timeout-minutes: 60` → `150`. Root cause of run `28751237762` being cancelled at exactly 60m13s mid-`Generate title-no-disambig-hash baseline` step — not a manual cancel, the job's own timeout fired. The workflow scans 3 full-corpus baselines sequentially (title-length, title-no-disambig-hash, h1-title-duplicates) since PR #3595's sibling-audit migration; real measured cost at current ~2.8M-page corpus size is ~14min setup/rehydrate + ~28min per audit scan × 3 ≈ 98min, well past the 60min budget the job had before that migration added the third scan.
- Checked sibling `seed-*.yml` workflows (`seed-text-html-ratio-baseline.yml`, `seed-bfs-depth-baseline.yml`, `seed-orphan-pages-baseline.yml`) for the same construct (AGENTS.md sibling-pattern-fix discipline) — each generates only ONE baseline (single scan, ~42min total), so their existing 60min timeout is correctly sized for their actual workload. Confirmed false positive, not touched.

## Non implementato (ancora)

Nessuno — this PR's scope is exactly the timeout bump; the actual baseline reseed (task tracked separately) resumes once this merges and the workflow is re-triggered with the new budget.

## Test plan

- [x] YAML change is a single scalar edit (`timeout-minutes: 60` → `150`), diff reviewed line-by-line, no other lines touched.
- [x] `git diff origin/main` confirms only `.github/workflows/seed-title-baselines.yml` changed.
- Live verify: re-triggering `workflow_dispatch` on `main` post-merge and confirming the run completes within the new budget (in progress as follow-up).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
