### PR TITLE
fix(json-repair): scanValueEnd must skip to matching close bracket for nested object/array values

### DIFF
--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -162,7 +162,10 @@ function decideQuoteCloses(str, quoteIdx, fixAsterisks) {
 function scanValueEnd(str, i, fixAsterisks) {
   if (i >= str.length) return -1;
   const ch = str[i];
-  if (ch === '{' || ch === '[') return i + 1;
+  if (ch === '{' || ch === '[') {
+    const closeIdx = findMatchingClose(str, i);
+    return closeIdx === -1 ? -1 : closeIdx + 1;
+  }
   if (ch === '"') {
     let j = i + 1;
     while (j < str.length) {

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -147,6 +147,27 @@ describe('fixJsonStringBody', () => {
     expect(parsed.a).toBe('Il termine "extra" qui.');
     expect(parsed.b).toBe('Anche "questo" qui.');
   });
+
+  // Regression: scanValueEnd() treated '{'/'[' as ending the value immediately
+  // after the opening bracket instead of finding the matching close. That made
+  // the lookahead wrongly reject a preceding string field's real closing quote
+  // whenever it was followed by a nested-object field — e.g. the article
+  // schema's imagePrompt (string) always followed by imageAlt ({it,en,de,fr}) —
+  // corrupting already-valid JSON (run 28751915972).
+  it('does not corrupt a valid string field immediately followed by a nested locale object', () => {
+    const valid = '{"title":"Test","imagePrompt":"Panoramic view of Lugano.","imageAlt":{"it":"Vista panoramica.","en":"Panoramic view","de":"Panoramablick","fr":"Vue panoramique"}}';
+    expect(JSON.parse(valid)).toBeTruthy(); // sanity: input is already valid JSON
+    const repaired = fixJsonStringBody(valid, { fixAsterisks: true });
+    expect(repaired).toBe(valid);
+    expect(JSON.parse(repaired)).toEqual(JSON.parse(valid));
+  });
+
+  it('does not corrupt a valid string field immediately followed by a nested array of objects (body3 -> faq shape)', () => {
+    const valid = '{"body3":"Step-by-step guide.","faq":[{"q":"Domanda 1?","a":"Risposta 1."},{"q":"Domanda 2?","a":"Risposta 2."}]}';
+    const repaired = fixJsonStringBody(valid, { fixAsterisks: true });
+    expect(repaired).toBe(valid);
+    expect(JSON.parse(repaired)).toEqual(JSON.parse(valid));
+  });
 });
 
 describe('stripCodeFences', () => {


### PR DESCRIPTION
## Implementato

- Root-caused a distinct, previously-undiagnosed bug uncovered while live-verifying PR #3597 (run 28751915972, frontaliere): after PR #3597's fix correctly skips the schema-incompatible GitHub Models, the run falls back to local/fallback (ollama), which returned a **valid** JSON completion — but `repairLlmJson`/`fixJsonStringBody` (`scripts/lib/llm-json-repair.mjs`) then **corrupted it** before `JSON.parse()`, burning all 5 regeneration retries and producing zero article for the run.
- Bug: `scanValueEnd()` treated any `{`/`[` value as ending immediately after the opening bracket (`return i + 1`) instead of scanning to its matching close. This is used by `decideQuoteCloses()`'s lookahead to decide whether a quote genuinely closes the *previous* string field. Whenever a string field was immediately followed by a nested-object/array field (e.g. the article schema's `imagePrompt` string followed by `imageAlt: {it,en,de,fr}`, or `body3` followed by `faq: [...]`), the lookahead incorrectly concluded the real closing quote of the string field was *not* a closer, escaped it, and merged the two fields into one runaway string — turning already-valid JSON into invalid JSON.
- Fix: reuse the existing `findMatchingClose()` helper (already quote/escape-aware, exported in the same file) to skip past the entire nested value instead of a bespoke 1-char scan.
- Reproduced locally against a minimal valid `{"imagePrompt":"...","imageAlt":{"it":"...",...}}` fixture: `fixJsonStringBody()` corrupted it into the exact `Expected ',' or '}' after property value` shape logged in run 28751915972, confirming this (not a raw-LLM-output defect, not an unenforced ollama schema-mode) is the actual cause of that run's failure.
- Added 2 regression tests (`tests/scripts/llm-json-repair.test.ts`) covering the nested-object and nested-array-of-objects shapes; full suite (28/28) green.
- Ran `node scripts/ci/check-sibling-patterns.mjs`: 4 candidate siblings flagged (`build-plugins/blogContextualLinksPlugin.ts`, `scripts/audit-no-literal-markdown.mjs`, `scripts/lib/klinik-seeschau-job-parser.mjs`, `scripts/batch-add-faq-to-articles.mjs`). Manually inspected all 4: **false positives** — the first three share only the token name `closeIdx` for unrelated HTML tag/content scanning, not the quote-closing value-lookahead construct; the fourth (`batch-add-faq-to-articles.mjs`) already imports `findMatchingClose`/`fixJsonStringBody` from this same shared module (no independent copy of the bug — it inherits the fix automatically).

## Non implementato (ancora)

Nessuno.