### PR TITLE
fix(generate-blog): prune dead models, tighten token/output caps, fix nested-object JSON repair

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -82,18 +82,18 @@ export const AI_MODELS = Object.freeze({
   LLAMA_4_MAVERICK: 'Llama-4-Maverick-17B-128E-Instruct-FP8',
   LLAMA_4_SCOUT:    'Llama-4-Scout-17B-16E-Instruct',
   LLAMA_3_3_70B:    'Llama-3.3-70B-Instruct',
-  LLAMA_3_1_405B:   'Meta-Llama-3.1-405B-Instruct',
-  LLAMA_3_1_8B:     'Meta-Llama-3.1-8B-Instruct',
+  // LLAMA_3_1_405B removed — GitHub Models HTTP 400 "unknown_model: Meta-Llama-3.1-405B-Instruct" (2026-07-05, confirmed retired live against the real inference endpoint, 20x in 30-run sample)
+  // LLAMA_3_1_8B removed — GitHub Models HTTP 400 "unknown_model: Meta-Llama-3.1-8B-Instruct" (2026-07-05, confirmed retired live against the real inference endpoint, 20x in 30-run sample). NB: GROQ_LLAMA_3_1_8B/CB_LLAMA_3_1_8B/FW_LLAMA_3_1_8B/NV_LLAMA_3_1_8B are separate, still-alive constants on other providers.
   PHI_4:            'Phi-4',
   DEEPSEEK_R1:      'DeepSeek-R1',
-  COHERE_CMD_R_PLUS:'Cohere-command-r-plus-08-2024',
+  // COHERE_CMD_R_PLUS removed — GitHub Models HTTP 400 "unknown_model: Cohere-command-r-plus-08-2024" (2026-07-05, confirmed retired live against the real inference endpoint, 14x in 30-run sample)
   CODESTRAL:        'Codestral-2501',
   GPT_4_1:          'gpt-4.1',
   GPT_4_1_MINI:     'gpt-4.1-mini',
   GPT_4_1_NANO:     'gpt-4.1-nano',
   // COHERE_CMD_R removed — GitHub Models HTTP 400 "unknown_model: Cohere-command-r-08-2024" (2026-07-05, confirmed retired live against the real inference endpoint)
   COHERE_CMD_A:     'Cohere-command-a',
-  LLAMA_3_2_90B:    'Llama-3.2-90B-Vision-Instruct',
+  // LLAMA_3_2_90B removed — GitHub Models HTTP 400 "unknown_model: Llama-3.2-90B-Vision-Instruct" (2026-07-05, confirmed retired live against the real inference endpoint, 12x in 30-run sample)
   DEEPSEEK_V3:      'DeepSeek-V3-0324',
   // GPT_5_NANO removed — GitHub Models HTTP 400 "unavailable_model" (2026-05-18)
   // GPT_5_MINI removed — GitHub Models HTTP 400 "unavailable_model" (2026-05-18)
@@ -384,12 +384,12 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.COHERE_CMD_A,       // 15. Cohere latest          (GitHub Models)
   AI_MODELS.MISTRAL_SMALL,      // 16. Mistral Small latest   (Mistral AI direct)
   AI_MODELS.GROQ_LLAMA_3_3,     // 17. Llama 3.3 70B          (Groq)
-  AI_MODELS.COHERE_CMD_R_PLUS,  // 18. Cohere multilingual    (GitHub Models)
+  // AI_MODELS.COHERE_CMD_R_PLUS removed chain — GitHub Models HTTP 400 "unknown_model: Cohere-command-r-plus-08-2024" (2026-07-05, confirmed retired live, 14x in 30-run sample)
   AI_MODELS.COH_CMD_A,          // 18b. Cohere Command A      (Cohere direct - 1000/month)
   AI_MODELS.GEMINI_31_PRO,      // 18d. Gemini 3.1 Pro preview (Gemini API free)
   AI_MODELS.COH_CMD_R_PLUS,     // 18c. Cohere Command R+     (Cohere direct - 1000/month)
   AI_MODELS.CF_LLAMA_3_3_70B,   // 19. Llama 3.3 70B FP8     (Cloudflare Workers AI)
-  AI_MODELS.LLAMA_3_1_405B,     // 20. Meta 405B flagship     (GitHub Models)
+  // AI_MODELS.LLAMA_3_1_405B removed chain — GitHub Models HTTP 400 "unknown_model: Meta-Llama-3.1-405B-Instruct" (2026-07-05, confirmed retired live, 20x in 30-run sample)
   // MISTRAL_MEDIUM_3 removed — GitHub Models HTTP 404 "unknown_model" (2026-04)
   AI_MODELS.GROQ_QWEN3_32B,      // 22. Qwen3 32B              (Groq - ultra fast)
   AI_MODELS.CB_QWEN3_235B,       // 22a. Qwen3 235B frontier   (Cerebras preview — ultra fast)
@@ -398,7 +398,7 @@ export const DEFAULT_CHAIN = [
   // JAMBA_1_5_LARGE removed — GitHub Models HTTP 400 "unknown_model" (2026-04)
   // SN_LLAMA_3_3_70B removed — SambaNova HTTP 402 PAYMENT_METHOD_REQUIRED (2026-04)
   // AI_MODELS.O1 removed — GitHub Models HTTP 400 "unavailable_model" (2026-05-18)
-  AI_MODELS.LLAMA_3_2_90B,      // 24. Llama 3.2 90B           (GitHub Models)
+  // AI_MODELS.LLAMA_3_2_90B removed chain — GitHub Models HTTP 400 "unknown_model: Llama-3.2-90B-Vision-Instruct" (2026-07-05, confirmed retired live, 12x in 30-run sample)
   AI_MODELS.GEMINI_2_FLASH,     // 25. Google 2.0 flash       (Gemini API free)
   // AI_MODELS.GEMINI_31_FLASH_LITE removed — Gemini API HTTP 404 "models/gemini-3.1-flash-lite-preview is no longer available" (2026-05-27, run 26534353239).
   //                                 The deprecated preview kept winning the fallback selector because 404 didn't mark it exhausted, causing the
@@ -451,7 +451,7 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.OR_GEMMA_4_26B,     // 55. Gemma 4 26B MoE         (OpenRouter free — replaces DeepSeek R1 Zero)
   // OR_DEEPSEEK_R1Z removed from OpenRouter free list (2026-04)
   // GROQ_COMPOUND_MINI removed — Groq HTTP 404 "model compound-mini does not exist" (2026-04)
-  AI_MODELS.LLAMA_3_1_8B,       // 56. Meta 8B fast           (GitHub Models)
+  // AI_MODELS.LLAMA_3_1_8B removed chain — GitHub Models HTTP 400 "unknown_model: Meta-Llama-3.1-8B-Instruct" (2026-07-05, confirmed retired live, 20x in 30-run sample)
   AI_MODELS.MINISTRAL_3B,       // 57. Mistral 3B fast        (GitHub Models)
   AI_MODELS.CF_GPT_OSS_20B,     // 58. GPT-OSS 20B            (Cloudflare Workers AI)
   // AI_MODELS.O3_MINI removed — GitHub Models HTTP 400 "unavailable_model" (2026-05-18)
@@ -2282,7 +2282,7 @@ const MAX_COMPLETION_TOKENS_MODELS = new Set([
  *   - Phi-4 / Cohere-command-a / Cohere-command-r-plus-08-2024 /
  *     Llama-3.2-90B-Vision-Instruct / cerebras/llama3.1-8b cap at 8000
  *
- * Heuristic: estimated_tokens = chars / 4 + safety_margin (500).
+ * Heuristic: estimated_tokens = chars / 3.5 + safety_margin (500).
  * If the estimate exceeds MODEL_MAX_REQUEST_TOKENS[apiModelId], skip the model.
  *
  * Conservative caps: a few of these limits are higher in practice but the
@@ -2460,10 +2460,16 @@ function _learnSchemaIncompatible(modelForTracking) {
 }
 
 /**
- * Estimate token count for a list of OpenAI-format messages. Uses the standard
- * chars/4 ≈ tokens heuristic — accurate enough for "is this prompt going to
- * blow past 4000?" decisions. Adds a 500-token safety margin to account for
- * the response prefix, role markers, and tokenizer variance.
+ * Estimate token count for a list of OpenAI-format messages. Uses a chars/3.5
+ * ≈ tokens heuristic — accurate enough for "is this prompt going to blow past
+ * 4000?" decisions. Adds a 500-token safety margin to account for the
+ * response prefix, role markers, and tokenizer variance.
+ *
+ * Divisor verified 2026-07-05 against run 28732970228: NVIDIA's own tokenizer
+ * reported 8771 tokens for a prompt whose chars/4 + 500 estimate came out to
+ * only 7785 — a ~13% undercount that let the 8000-token skip-guard under-fire
+ * and let a doomed HTTP call through. chars/3.5 + 500 on the same prompt
+ * yields ~8826, within 1% of the real count and back over the cap.
  *
  * Exported for tests / smoke probes.
  */
@@ -2484,7 +2490,7 @@ export function estimateRequestTokens(messages, opts = {}) {
   if (opts.jsonSchema?.schema) {
     try { chars += JSON.stringify(opts.jsonSchema.schema).length; } catch { /* noop */ }
   }
-  return Math.ceil(chars / 4) + SAFETY_MARGIN;
+  return Math.ceil(chars / 3.5) + SAFETY_MARGIN;
 }
 
 /** Models with lower max output token limits.
@@ -2504,6 +2510,11 @@ const MODEL_MAX_OUTPUT_TOKENS = {
   'command-r7b-12-2024': 4096,
   // Groq Llama 4 family enforces max_tokens <= 8192.
   'meta-llama/llama-4-scout-17b-16e-instruct': 8192,
+  // GitHub Models HTTP 400 (run 28732970228, 2026-07-05, 19x in 30-run sample):
+  // "max_completion_tokens=8000 cannot be greater than max_model_len=
+  // max_total_tokens=4096" — this codebase's default article-generation
+  // maxTokens (8000) always overran Phi-4-mini-reasoning's real 4096 limit.
+  'Phi-4-mini-reasoning': 4000,
 };
 
 // ── Low-level provider calls ─────────────────────────────────

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -158,7 +158,18 @@ function decideQuoteCloses(str, quoteIdx, fixAsterisks) {
  * `fixAsterisks` must match the caller's setting — this lookahead has to
  * agree with the real main-loop pass on whether a bare `*` run is a
  * structural comma-stand-in or literal content, or it can mis-scan across
- * an asterisk boundary the main loop would have converted. */
+ * an asterisk boundary the main loop would have converted.
+ *
+ * A `{`/`[` value must scan all the way to its real matching close (via
+ * findMatchingClose), not just past the opening bracket — an early `i + 1`
+ * return left `looksLikeJsonContinuation` checking the character right
+ * after the bracket (the nested value's own first key/element, never a
+ * valid top-level continuation), so it always rejected. That falsely
+ * rejected any string value immediately followed by a nested-object/array
+ * sibling — exactly `"imagePrompt": "...", "imageAlt": {"it": ...}`, used
+ * in every article-generation prompt — cascading into "Expected ',' or
+ * '}'" on the article's *own* well-formed imagePrompt string (run
+ * 28751915972, confirmed post-#3597, 2026-07-05). */
 function scanValueEnd(str, i, fixAsterisks) {
   if (i >= str.length) return -1;
   const ch = str[i];

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -26,7 +26,17 @@ export function stripCodeFences(raw) {
  */
 export const JSON_QUOTE_SAFETY_RULE_IT = '⚠️ VIRGOLETTE NEI VALORI JSON: se riporti un termine o una frase citata tra virgolette (es. la cosiddetta "tassa sulla salute"), NON usare mai il carattere " dentro un valore stringa JSON — usa virgolette singole (\'tassa sulla salute\') o guillemet («tassa sulla salute»). Se devi proprio usare virgolette doppie interne, escapale sempre con \\" (es. "la cosiddetta \\"tassa sulla salute\\""). Una virgoletta doppia non escapata dentro una stringa rende l\'intero JSON non valido e scarta l\'intero articolo.';
 
-/** Index of the bracket/brace matching the opener at openIdx, quote/escape aware. */
+/**
+ * Index of the bracket/brace matching the opener at openIdx, quote/escape aware.
+ *
+ * Known gap (issue #3604): the quote toggle below is a raw "" flip with no
+ * decideQuoteCloses-style disambiguation. If the nested value itself contains
+ * an unescaped embedded quote (the same corruption class this module exists
+ * to fix, one level deeper — e.g. a quoted term inside imageAlt.it), the
+ * toggle desyncs and this can return the wrong close index, which then makes
+ * scanValueEnd() wrongly reject the *preceding* field's real closing quote.
+ * Pre-existing, not introduced by the scanValueEnd fix that calls this.
+ */
 export function findMatchingClose(src, openIdx) {
   const open = src[openIdx];
   const close = open === '[' ? ']' : open === '{' ? '}' : null;

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -26,20 +26,32 @@ export function stripCodeFences(raw) {
  */
 export const JSON_QUOTE_SAFETY_RULE_IT = '⚠️ VIRGOLETTE NEI VALORI JSON: se riporti un termine o una frase citata tra virgolette (es. la cosiddetta "tassa sulla salute"), NON usare mai il carattere " dentro un valore stringa JSON — usa virgolette singole (\'tassa sulla salute\') o guillemet («tassa sulla salute»). Se devi proprio usare virgolette doppie interne, escapale sempre con \\" (es. "la cosiddetta \\"tassa sulla salute\\""). Una virgoletta doppia non escapata dentro una stringa rende l\'intero JSON non valido e scarta l\'intero articolo.';
 
-/** Index of the bracket/brace matching the opener at openIdx, quote/escape aware. */
-export function findMatchingClose(src, openIdx) {
+/** Index of the bracket/brace matching the opener at openIdx.
+ *
+ * Skips over string content using scanStringEnd's quote-disambiguation
+ * (`fixAsterisks` must match the caller's setting) rather than a naive
+ * unescaped-quote toggle: a nested string value can itself legitimately
+ * contain a lone stray unescaped quote (an odd count before the real
+ * closer — e.g. a quoted term missing its closing mark), which flips a
+ * naive toggle's parity and makes depth-counting skip past or never reach
+ * the true matching bracket, returning -1 or a wrong earlier close and
+ * corrupting the *preceding* sibling field's own valid closing quote
+ * (confirmed regression: `{"imagePrompt":"...","imageAlt":{"it":"...
+ * torre "di Lugano...","en":"..."}}`, odd embedded quote count in `it` →
+ * old toggle desyncs → `imagePrompt` itself gets corrupted). */
+export function findMatchingClose(src, openIdx, fixAsterisks = false) {
   const open = src[openIdx];
   const close = open === '[' ? ']' : open === '{' ? '}' : null;
   if (!close) return -1;
   let depth = 0;
-  let inStr = false;
-  let esc = false;
   for (let i = openIdx; i < src.length; i++) {
     const ch = src[i];
-    if (esc) { esc = false; continue; }
-    if (ch === '\\') { esc = true; continue; }
-    if (ch === '"') { inStr = !inStr; continue; }
-    if (inStr) continue;
+    if (ch === '"') {
+      const strEnd = scanStringEnd(src, i, fixAsterisks);
+      if (strEnd === -1) return -1;
+      i = strEnd - 1;
+      continue;
+    }
     if (ch === open) depth++;
     else if (ch === close) { depth--; if (depth === 0) return i; }
   }
@@ -174,26 +186,33 @@ function scanValueEnd(str, i, fixAsterisks) {
   if (i >= str.length) return -1;
   const ch = str[i];
   if (ch === '{' || ch === '[') {
-    const closeIdx = findMatchingClose(str, i);
+    const closeIdx = findMatchingClose(str, i, fixAsterisks);
     return closeIdx === -1 ? -1 : closeIdx + 1;
   }
-  if (ch === '"') {
-    let j = i + 1;
-    while (j < str.length) {
-      if (str[j] === '\\') { j += 2; continue; }
-      if (str[j] === '"') {
-        if (decideQuoteCloses(str, j, fixAsterisks)) return j + 1;
-        j++;
-        continue;
-      }
-      j++;
-    }
-    return -1;
-  }
+  if (ch === '"') return scanStringEnd(str, i, fixAsterisks);
   const numMatch = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(str.slice(i));
   if (numMatch && numMatch[0]) return i + numMatch[0].length;
   const kwMatch = /^(?:true|false|null)\b/.exec(str.slice(i));
   if (kwMatch) return i + kwMatch[0].length;
+  return -1;
+}
+
+/** Index just past a string's real closing quote (str[i] must be '"'), using
+ * decideQuoteCloses to skip stray embedded unescaped quotes rather than
+ * stopping at the first one. -1 if unterminated. Shared by scanValueEnd and
+ * findMatchingClose so both treat "does this quote really close the
+ * string?" identically. */
+function scanStringEnd(str, i, fixAsterisks) {
+  let j = i + 1;
+  while (j < str.length) {
+    if (str[j] === '\\') { j += 2; continue; }
+    if (str[j] === '"') {
+      if (decideQuoteCloses(str, j, fixAsterisks)) return j + 1;
+      j++;
+      continue;
+    }
+    j++;
+  }
   return -1;
 }
 

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -176,6 +176,29 @@ describe('fixJsonStringBody', () => {
     expect(parsed.imagePrompt).toBe('Scena con la "tassa sulla salute" citata.');
     expect(parsed.imageAlt).toEqual({ it: 'Vista panoramica', en: 'Panoramic view' });
   });
+
+  // Regression: findMatchingClose() walked strings with a naive unescaped-
+  // quote toggle. A nested value with an ODD count of stray embedded quotes
+  // before its real closer (e.g. a quoted term missing its closing mark)
+  // flips the toggle's parity, so the brace-depth counter never reaches (or
+  // reaches too early) the true matching '}' — returning -1 and making the
+  // '{'/'[' branch of scanValueEnd wrongly reject the *preceding* sibling
+  // field's real closing quote, corrupting it (PR #3601 round-1 review).
+  it('does not corrupt the preceding sibling field when a nested object value has an odd stray-quote count', () => {
+    const broken = '{"imagePrompt":"Scena con la torre.","imageAlt":{"it":"La chiamano torre "di Lugano, simbolo della citta.","en":"Panoramic view"}}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.imagePrompt).toBe('Scena con la torre.');
+    expect(parsed.imageAlt.en).toBe('Panoramic view');
+  });
+
+  it('does not corrupt the preceding sibling field when a faq array item has an odd stray-quote count', () => {
+    const broken = '{"body3":"Testo introduttivo.","faq":[{"q":"Cosa significa "frontaliere nel senso ampio?","a":"Risposta."}]}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.body3).toBe('Testo introduttivo.');
+    expect(parsed.faq).toHaveLength(1);
+  });
 });
 
 describe('stripCodeFences', () => {

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -168,6 +168,14 @@ describe('fixJsonStringBody', () => {
     expect(repaired).toBe(valid);
     expect(JSON.parse(repaired)).toEqual(JSON.parse(valid));
   });
+
+  it('still escapes a genuine embedded quote in a string value immediately followed by a nested-object sibling key', () => {
+    const broken = '{"imagePrompt":"Scena con la "tassa sulla salute" citata.","imageAlt":{"it":"Vista panoramica","en":"Panoramic view"}}';
+    const repaired = fixJsonStringBody(broken);
+    const parsed = JSON.parse(repaired);
+    expect(parsed.imagePrompt).toBe('Scena con la "tassa sulla salute" citata.');
+    expect(parsed.imageAlt).toEqual({ it: 'Vista panoramica', en: 'Panoramic view' });
+  });
 });
 
 describe('stripCodeFences', () => {


### PR DESCRIPTION
## Implementato

- Pruned 4 dead GitHub Models catalog IDs (`LLAMA_3_1_405B`, `LLAMA_3_1_8B`, `COHERE_CMD_R_PLUS`, `LLAMA_3_2_90B`) — confirmed HTTP 400 `unknown_model` live, 12-20x each across a 30-run log sample.
- Tightened `estimateRequestTokens`'s chars-per-token divisor from 4 to 3.5, closing a ~13% undercount confirmed against NVIDIA's own tokenizer (run 28732970228) that let the pre-flight skip-guard under-fire.
- Added `MODEL_MAX_OUTPUT_TOKENS['Phi-4-mini-reasoning'] = 4000` (was uncapped, defaulting to 8000 against a real 4096 `max_model_len` — run 28732970228, 19x in 30-run sample).
- Root-caused and fixed the recurring `Expected ',' or '}'` JSON.parse corruption in `scripts/lib/llm-json-repair.mjs`: `scanValueEnd`'s `{`/`[` branch returned right past the opening bracket instead of scanning to its real matching close (via the existing `findMatchingClose` helper), so the lookahead validator wrongly rejected the true closing quote of any string value immediately followed by a nested-object/array-valued sibling key — exactly the `imagePrompt` → `imageAlt` shape every article-generation prompt uses, and the `body3` → `faq` (array-of-objects) shape. Confirmed recurring post-#3597 via run 28751915972 (identical failure point, 6/6 occurrences), reproduced and fixed in isolation, then verified against the live schema shape. Added 3 regression tests (clean nested-object, embedded-quote nested-object, clean nested-array-of-objects).
- Round-1 review flagged a deeper pre-existing gap: `findMatchingClose`'s raw quote-toggle desynced when the nested value it walks has its own odd count of stray embedded unescaped quotes (e.g. a quoted term missing its closing mark inside `imageAlt.it`), corrupting the *preceding* sibling field the same way the original bug did, one level deeper. Filed as issue #3604 and fixed: `findMatchingClose` now skips string content via a shared `scanStringEnd` helper using the same `decideQuoteCloses` disambiguation `scanValueEnd` already applied at the top level, instead of a naive toggle. 2 more regression tests added (odd-embedded-quote nested object/array) — full `llm-json-repair.test.ts` suite green (31/31).

## Non implementato (ancora)

Nessuno

Closes #3604
