### PR TITLE
chore: reseed title/disambig/h1-dup baselines to mode:rate

### DIFF
--- a/data/h1-title-duplicates-baseline.json
+++ b/data/h1-title-duplicates-baseline.json
@@ -1,7 +1,77 @@
 {
-  "generated": "2026-04-27T16:04:52Z",
-  "_note": "Tightened from 2107 → 0 after the universal 'never truncate <title>' fix landed in commit a7eab849d (run 25003146824 confirmed 0 offenders across 118025 scanned pages). The ratchet now blocks the very first regression — any future plugin that emits title === h1 will fail the deploy gate immediately.",
-  "total": 0,
-  "byFeature": {},
-  "byLocale": {}
+  "generated": "2026-07-05T22:04:14.422Z",
+  "mode": "rate",
+  "tolerance": {
+    "relPct": 20,
+    "absPp": 1,
+    "minAbsDelta": 5,
+    "maxDeltaPp": 3
+  },
+  "scanned": 2068992,
+  "totalOffenders": 0,
+  "totalRatePct": 0,
+  "byFeature": {
+    "spa-other": {
+      "scanned": 1612,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "fuel-daily": {
+      "scanned": 6326,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "health-premiums": {
+      "scanned": 366,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "job-market-snapshot": {
+      "scanned": 93,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "spa-locale": {
+      "scanned": 4347,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "job-board": {
+      "scanned": 2033096,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "weekly-employers-hub": {
+      "scanned": 100,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "career-landings": {
+      "scanned": 6074,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "eventi": {
+      "scanned": 4396,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "weekly-employers": {
+      "scanned": 339,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "blog": {
+      "scanned": 12198,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "border-wait": {
+      "scanned": 45,
+      "offenders": 0,
+      "ratePct": 0
+    }
+  },
+  "byLocale": {},
+  "_comment": "Rate-based baseline for audit-h1-title-duplicates (title === h1). Tracks the offender RATE (offenders/scanned) per feature so organic page growth does not regress the build. A feature fails only when its rate exceeds baseRate*(1+relPct/100)+absPp AND its absolute offender count grows by more than minAbsDelta. Rates must only DECREASE going forward (modulo tolerance)."
 }

--- a/data/title-length-baseline.json
+++ b/data/title-length-baseline.json
@@ -1,23 +1,83 @@
 {
-  "generated": "2026-06-24T08:00:00.000Z",
+  "generated": "2026-07-05T21:15:52.118Z",
+  "mode": "rate",
   "threshold": 66,
-  "total": 56371,
+  "tolerance": {
+    "relPct": 20,
+    "absPp": 1,
+    "minAbsDelta": 5,
+    "maxDeltaPp": 3
+  },
+  "scanned": 2068992,
+  "totalOffenders": 3893,
+  "totalRatePct": 0.1882,
   "byFeature": {
-    "spa-locale": 30,
-    "spa-other": 171,
-    "job-board": 53462,
-    "weekly-employers": 15,
-    "weekly-employers-hub": 10,
-    "career-landings": 1650,
-    "fuel-daily": 35,
-    "blog": 2700,
-    "eventi": 340
+    "spa-other": {
+      "scanned": 1612,
+      "offenders": 10,
+      "ratePct": 0.6203
+    },
+    "fuel-daily": {
+      "scanned": 6326,
+      "offenders": 28,
+      "ratePct": 0.4426
+    },
+    "health-premiums": {
+      "scanned": 366,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "job-market-snapshot": {
+      "scanned": 93,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "spa-locale": {
+      "scanned": 4347,
+      "offenders": 31,
+      "ratePct": 0.7131
+    },
+    "job-board": {
+      "scanned": 2033096,
+      "offenders": 294,
+      "ratePct": 0.0145
+    },
+    "weekly-employers-hub": {
+      "scanned": 100,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "career-landings": {
+      "scanned": 6074,
+      "offenders": 1362,
+      "ratePct": 22.4234
+    },
+    "eventi": {
+      "scanned": 4396,
+      "offenders": 204,
+      "ratePct": 4.6406
+    },
+    "weekly-employers": {
+      "scanned": 339,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "blog": {
+      "scanned": 12198,
+      "offenders": 1964,
+      "ratePct": 16.101
+    },
+    "border-wait": {
+      "scanned": 45,
+      "offenders": 0,
+      "ratePct": 0
+    }
   },
   "byLocale": {
-    "en": 13802,
-    "it": 12446,
-    "fr": 13957,
-    "de": 13466
+    "it": 472,
+    "de": 709,
+    "fr": 2176,
+    "en": 536
   },
-  "note": "2026-05-26 rebaseline (post-deploy run 26433750487, validate-dist job 77816972748): spa-locale 25→41 (+16, organic). Run 6aec41ca restored the title-brand budget logic (clampSiteSuffix now drops the suffix only when base+suffix>66) and the remaining 41 spa-locale offenders are titles whose base alone already exceeds 66 (translation expansion in DE/EN/FR cathedral landings) or use hardcoded `${name} | Frontaliere Ticino` paths outside clampSiteSuffix. Per explicit user override: raise the feature ratchet rather than truncate distinct keyword-rich bases. Per-page 66-char threshold unchanged. Numbers must only DECREASE going forward from this new floor. blog bucket added 2026-05-18: ogPagesPlugin stopped truncating long article headlines with mid-word '…' (CTR collapsed 4.8 % → 1.68 % on /calcola-stipendio/ era). Articles now emit verbatim per universal titleSuffix policy. Source count of article headlines >66 chars: ~2336 across 4 locales; baseline set to 2700 to absorb collision-disambiguator variance. Drive DOWN by shortening titleBase in scripts/create-article.mjs prompts and back-editing seo-blog*.ts headlines, then rebaseline. 2026-06-03 update (post-deploy run 26862980338, validate-dist job 79226069863): spa-locale 41→48 (+7, organic) — the new Switzerland-wide article section (PR #1173, `articoli-svizzera`) shipped localized section/archive landing pages whose keyword-rich bases exceed 66 chars. Same explicit-override rationale as the 05-26 bump: raise the feature ratchet rather than truncate distinct keyword-rich bases. Every other bucket dropped sharply vs the 05-18 floor (job-board 53462→42, blog 2700→1680) and keeps its generous cap as organic-growth headroom; only spa-locale was at its ceiling. Per-page 66-char threshold unchanged. 2026-06-03 update #2 (post-deploy run 26880918111, validate-dist job 79289530860 — surfaced once gate:seo-source went green via #1274/#1275; this audit step had been masked behind the earlier source-validator failure): spa-locale 48→65 and fuel-daily 1→16. spa-locale (+17, organic) — more localized keyword-rich section/archive landing pages from the Switzerland-wide article section (#1173) plus DE/EN/FR translation expansion whose bases alone exceed 66; set to the exact observed count (65) since these are manually-authored, stable landings. fuel-daily (1→13 observed, baselined to 16 with +3 headroom) — the per-zone/per-city daily fuel pages (#1042/#1241) emit a `${H1} (${date})` title; the long DE/FR zone-name variants (e.g. `Schweizer Benzin-Tankstellen Tessin — vollständiger Index (2026-06-03)` ≈ 72 chars) exceed 66 after the functional date-stamp, and the new Italian-stations index pages are classified into this bucket too. Headroom added because the bucket is data-volatile (border zones/cities grow as MIMIT/crawler data lands daily), mirroring the blog-bucket collision-variance headroom rationale. Same explicit-override principle: raise the feature ratchet rather than truncate distinct keyword-rich bases or drop the freshness-signalling date-stamp. Per-page 66-char threshold unchanged; numbers must only DECREASE going forward from this floor. 2026-06-03 update #3 (post-deploy run 26893907998, validate-dist job 79341638442): spa-locale 65→90. The #1284 bump set spa-locale to the exact observed 65, but the Switzerland-wide article section (#1173) is actively shipping more localized section/archive landings — the next dist already showed 74 (+9 in hours), re-failing the post-deploy gate on a tight floor. Per the same explicit-user-override principle, raised to 90 with deliberate headroom (~22% over the 74 observed) so the steadily-growing keyword-rich landing set doesn't re-trip this post-deploy gate (and churn deploys) on every new article batch. fuel-daily 16 held (no longer regressed). Per-page 66-char threshold unchanged; drive DOWN by shortening localized landing title bases, then re-tighten. 2026-06-23 update (post-deploy run 28021666012, validate-dist job 82939221600 — reopened issue #2751): fuel-daily 16→24. The data-volatile per-zone/per-city daily fuel pages grew to 19 observed offenders (border zones/cities keep landing as MIMIT/TCS crawler data accrues daily — the long DE/FR zone-name + `(date)` titles exceed 66). Verified NOT a template inflation: #2793 (FR fuel grammar `du essence`→`d'essence`/`de gasoil`) shortens or holds FR fuel titles, so the +3 is pure organic data growth. Every other bucket dropped sharply vs the floor (job-board 53462→286, blog 2700→1703, spa-locale 90→72) and keeps its generous cap as headroom. Per the same explicit-user-override principle established 2026-05-26/06-03: raise the data-volatile feature ratchet rather than truncate distinct keyword-rich bases or drop the freshness-signalling date-stamp. Set to 24 (~26% over 19 observed) — same deliberate-headroom rationale as the spa-locale 74→90 bump — so the daily-growing fuel set doesn't re-trip this post-deploy gate (and churn deploys) on every new MIMIT/TCS batch. Per-page 66-char threshold unchanged; numbers must only DECREASE going forward from this floor. 2026-06-24 update (post-deploy run 28079730896, validate-dist FAIL — spa-locale 91>90): fuel-daily 24→35, with the ROOT cause being a classifier drift, not organic spa-locale growth. The title-length classifyFeature fuel regex had drifted BEHIND its sibling classifiers (audit-text-html-ratio, audit-page-weight, audit-dist-multi) — it still used the older BARE alternation (`gasoline-price`, `diesel-price`, `dieselpreis`, `prix-gasoil`) and so failed to match the en/de/fr COUNTRY-SUFFIXED fuel section slugs the corpus actually emits (`gasoline-price-switzerland`, `diesel-price-switzerland`, `dieselpreis-schweiz`, `prix-gasoil-suisse` — see build-plugins/fuelDailyData.ts FUEL_SECTION_SLUG). Those daily-volatile fuel town pages (e.g. `/fr/prix-gasoil-suisse/italie/bardello-con-malgesso-e-bregano/aujourd-hui/`, long Italian comune names) therefore fell through to the generic spa-locale (en/de/fr) bucket and drifted its ratchet over cap on a normal daily MIMIT/TCS crawl — exactly the false-positive class the jobBoardSections.mjs extraction fixed for job pages. Fixed by extracting the canonical matcher into scripts/lib/fuelSections.mjs (FUEL_SECTION_RX) and wiring all the audit classifiers to it, so the drift cannot recur by construction. Net effect on observed counts: the 9 leaked fuel offenders move spa-locale→fuel-daily (fuel-daily 19→28 observed; spa-locale 91→82 observed — i.e. the prior spa-locale floor was partly fuel contamination, not pure article-landing growth, so 82 sits comfortably under the existing 90 cap with restored headroom). fuel-daily baselined to 35 (~26% over the 28 observed) — same deliberate-headroom rationale as the prior fuel-daily bumps (data-volatile: border comuni keep crossing 66 as crawler data accrues). Per-page 66-char threshold unchanged; numbers must only DECREASE going forward from this floor. 2026-07-01 update (post-deploy run 28502574935, validate-dist FAIL — spa-locale 126>90): root cause was classifier drift, not organic spa-locale growth. The Ticino events refresh (commit 012aca04e2d) added per-event detail pages whose metaTitle template (build-plugins/eventsSeoPagesPlugin.ts DETAIL_COPY, all 4 locales) has no length clamp by design (verbose event names + city/canton disambiguator are legitimate distinct content). audit-text-html-ratio.mjs already carved these paths (/eventi/ticino, /events/ticino, /veranstaltungen/tessin, /evenements/tessin) into a dedicated eventi bucket (comment: same classifier-drift class as #2853/#2910 fuel/svizzera leaks) but that fix was never ported to this script, so the it-locale event pages fell into spa-other and the en/de/fr event pages fell into spa-locale, inflating it from its genuine ~28 to 126. Fixed by porting the identical eventi classifier branch here. Computed exactly (not estimated) from data/events.json against the DETAIL_COPY.metaTitle template for all 4 locales: 121 event-detail-page offenders (it 23, en 23, de 42, fr 33) move into the new eventi bucket, leaving spa-locale at a genuine 28 (comfortably under the existing 90 cap, unchanged) and spa-other at a genuine 10 (comfortably under the existing 171 cap, unchanged). eventi baselined to 150 (~24% headroom over the 121 observed) — same deliberate-headroom rationale as the fuel-daily/blog data-volatile buckets, since the crawler-fed tio.ch agenda dataset changes daily. Per-page 66-char threshold unchanged; do not clamp event titles (legitimate keyword-rich content, same policy as the other data-volatile buckets). 2026-07-02 update (follow-up #2911 of PR #2910): re-tightened spa-locale 90->30 (genuine observed count 28 from post-deploy run 28502574935, computed exactly per the note above, + 2 headroom) — restores gate sensitivity now that the #2910 svizzera-article reclassification (~91+28 pages moved spa-locale/spa-other -> blog) and the eventi-bucket fix above have both landed; a slack 90 cap on a genuine-28 bucket would let a future regression of up to +62 pages slip through unnoticed. If the next post-deploy validate-dist trips this bucket on organic growth (not a classifier regression), read the new observed count from the run and re-baseline again rather than reverting the tightening. 2026-07-04 update (issue #3232, validate-dist run 28697987396 / deploy run 28695687535): eventi 150→340. NOT a classifier-drift regression this time — the eventi classifier (scripts/lib/eventsSections.mjs, already canton-aware since the #3232-precursor fix in PR #3410) correctly buckets these pages; the count grew because the events feature itself was legitimately expanded nationwide (issue #3125, merged) — eventi scanned pages went 56→1304 (audit-reports/text-html-ratio.json, same run) and title-length offenders 121→283. Verified this is NOT a fixable title-generation bug: inspected the actual offenders (topOffenders in audit-reports/title-length.json) and every one is a real, distinct event name (proper noun, e.g. 'Settimana di corso intensivo estivo di scrittura creativa: fra memoria e immaginazione, con Patrizia Barbuiani e Markus Zohner — Lugano (Tessin) | Veranstaltungen') composed via cantonSubstitutionRules — same category as the blog bucket's uncontrollable-length article headlines, not boilerplate that can be trimmed. Baselined to 340 (~20% headroom over the 283 observed) — same deliberate-headroom rationale as the other data-volatile buckets, since the crawler-fed events dataset changes daily and now spans all cantons. weekly-employers (12, unchanged) was ALSO regressed in the same run (514>12), but root-caused to a real code bug rather than legitimate growth: the legacy TI company-hub emitter in build-plugins/jobsSeoPagesPlugin.ts built its company set from ALL cantons (no TI filter) despite emitting exclusively under the Ticino-branded URL/title, so every Swiss company — not just TI ones — got a 'Ticino'-branded hub page once validJobs went nationwide. Fixed at the source (canton filter added, matching the sibling per-canton block's existing pattern) in the same PR instead of widening this cap; see PR body for details. Per-page 66-char threshold unchanged. 2026-07-05 update (audit:all failure, weekly-employers 1360>12): NOT a data regression — root-caused to the SAME classifier-drift class as the 2026-06-24 fuel and 2026-07-01 eventi incidents above. This classifier's employer-landing branch had never been split into career-landings/weekly-employers/weekly-employers-hub the way audit-text-html-ratio's already was: it lumped the evergreen per-company `cerca-lavoro-ticino/azienda-{slug}` career-landing pages (build-plugins/companyHubBridgePlugin.ts, uncontrolled-length third-party company names, same class as blog/eventi headline overflow) into 'weekly-employers' instead of a separate 'career-landings' bucket, so the ~12-calibrated cap (itself only ever measuring career-landings under the wrong name) blew past it once the career-landing company set grew with nationwide job sourcing. Separately, the weekly-employers-hub alternation carried a typo'd German slug (`unternehmen-die-einstellen`, matching nothing real — the actual weekly slug is `unternehmen-einstellen`, see build-plugins/weeklyEmployersData.ts) and was missing the French weekly slug `entreprises-recrutent` entirely (had only the different all-companies-hub slug `entreprises-qui-recrutent`), so real DE/FR weekly-employer pages fell through to spa-locale instead — plausibly the source of the same-run spa-locale 31>30 drift. Fixed by extracting the shared matcher into scripts/lib/employerLandingSections.mjs (mirroring the fuelSections.mjs precedent) and wiring both audit-title-length.mjs and audit-text-html-ratio.mjs (eliminating what was a literal duplicate) to it; audit-dist-multi.mjs's three independently-drifted hand-copied mirror classifiers were deleted and replaced with direct imports of the two real classifyFeature functions. Baseline split: weekly-employers 12→15 (true per-city×company weekly leaf, previously never actually measured under this name — old code routed it to weekly-employers-hub instead; text-html-ratio's parallel bucket shows 0 offenders on 334 scanned, small headroom for the newly-corrected DE/FR routing), weekly-employers-hub 0(unset)→10 (new key — previously uncounted; same low-risk expectation), career-landings 0(unset)→1650 (~21% headroom over the 1360 observed, same real pages simply moved from the mislabeled bucket — deliberate headroom for the data-volatile company-name-length population, same rationale as the other third-party-text buckets above). Per-page 66-char threshold unchanged; verify the exact post-fix counts against the next live validate-dist run and re-baseline (tighten) if the observed numbers differ from this provisional split."
+  "_comment": "Rate-based baseline for audit-title-length (title length > 66 chars). The per-page threshold is the hard quality gate; this ratchet tracks the offender RATE (offenders/scanned) per feature so organic page growth does not regress the build. A feature fails only when its rate exceeds baseRate*(1+relPct/100)+absPp AND its absolute offender count grows by more than minAbsDelta. Rates must only DECREASE going forward (modulo tolerance)."
 }

--- a/data/title-no-disambig-hash-baseline.json
+++ b/data/title-no-disambig-hash-baseline.json
@@ -1,17 +1,82 @@
 {
-  "generated": "2026-05-06T01:19:31.096Z",
-  "_note": "Per-feature ratchet for the (#abcdef12) disambiguator visible in <title>. Counts can only go DOWN. Fix at source by renaming colliding articles (year, city, source qualifier) so the base title is unique without the hash.",
-  "total": 62631,
+  "generated": "2026-07-05T21:40:22.349Z",
+  "mode": "rate",
+  "tolerance": {
+    "relPct": 20,
+    "absPp": 1,
+    "minAbsDelta": 5,
+    "maxDeltaPp": 3
+  },
+  "scanned": 2068992,
+  "totalOffenders": 539,
+  "totalRatePct": 0.0261,
   "byFeature": {
-    "blog": 539,
-    "job-board": 62021,
-    "spa-other": 54,
-    "weekly-employers": 17
+    "spa-other": {
+      "scanned": 1612,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "fuel-daily": {
+      "scanned": 6326,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "health-premiums": {
+      "scanned": 366,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "job-market-snapshot": {
+      "scanned": 93,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "spa-locale": {
+      "scanned": 4347,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "job-board": {
+      "scanned": 2033096,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "weekly-employers-hub": {
+      "scanned": 100,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "career-landings": {
+      "scanned": 6074,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "eventi": {
+      "scanned": 4396,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "weekly-employers": {
+      "scanned": 339,
+      "offenders": 0,
+      "ratePct": 0
+    },
+    "blog": {
+      "scanned": 12198,
+      "offenders": 539,
+      "ratePct": 4.4188
+    },
+    "border-wait": {
+      "scanned": 45,
+      "offenders": 0,
+      "ratePct": 0
+    }
   },
   "byLocale": {
-    "it": 16678,
-    "de": 15719,
-    "en": 15053,
-    "fr": 15181
-  }
+    "it": 277,
+    "de": 59,
+    "en": 149,
+    "fr": 54
+  },
+  "_note": "Rate-based ratchet for the (#abcdef12) disambiguator visible in <title>. Tracks the offender RATE (offenders/scanned) per feature so organic page growth does not regress the build. A feature fails only when its rate exceeds baseRate*(1+relPct/100)+absPp AND its absolute offender count grows by more than minAbsDelta. Rates must only DECREASE going forward (modulo tolerance)."
 }


### PR DESCRIPTION
## Implementato
- Regenerated `data/title-length-baseline.json`, `data/title-no-disambig-hash-baseline.json`, `data/h1-title-duplicates-baseline.json` from a live production `dist/` scan via `seed-title-baselines.yml` run [28754022266](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28754022266), which completed cleanly after PR #3599 bumped the job's `timeout-minutes` 60→150 (the prior run 28751237762 was cancelled mid-scan by the old ceiling).
- All 3 files now carry `"mode": "rate"` (scanned 2,068,992 pages) instead of the legacy flat-count shape, activating the mix-adjusted rate ratchet (`scripts/lib/mixAdjustedRateGate.mjs`) migrated in PR #3595/#3594 for `audit-title-length.mjs`, `audit-title-no-disambig-hash.mjs`, and `audit-h1-title-duplicates.mjs`.
- This is the final piece of the standing "fix validate-dist structurally" effort: with these baselines live, `post-deploy-validate-dist` stops comparing today's per-feature offender rate against a stale flat count, ending the recurring class of false-fails from pure organic page-count growth (e.g. the spa-locale 31-vs-cap-30 title-length false-fail, #1077/#3232-class).
- Ran the 5 rate-gate vitest suites locally against these exact files as a sanity check (30/30 passing): `mix-adjusted-rate-gate`, `audit-title-length-rate-gate`, `audit-text-html-ratio-rate-gate`, `audit-h1-title-duplicates-rate-gate`, `audit-title-no-disambig-hash-rate-gate`.

## Non implementato (ancora)
Nessuno.

## Test plan
- [x] `npx vitest run tests/seo/mix-adjusted-rate-gate.test.ts tests/seo/audit-title-length-rate-gate.test.ts tests/seo/audit-text-html-ratio-rate-gate.test.ts tests/seo/audit-h1-title-duplicates-rate-gate.test.ts tests/seo/audit-title-no-disambig-hash-rate-gate.test.ts` — 30/30 passing locally.
- [x] Verified all 3 downloaded baseline JSONs have `"mode": "rate"` at top level.
- [ ] Live-verify next `post-deploy-validate-dist` run passes clean with no title-length/disambig-hash/h1-dup false-fails — will confirm post-merge.