### PR TITLE
fix(generate-article): cut LOCAL_LLM_TIMEOUT_MS 30min→15min, root cause of empty runs

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -170,15 +170,22 @@ jobs:
           ollama run "$LOCAL_MODEL" "ok" >/dev/null 2>&1 || true
           # Export so the generate step's ai-models cascade can reach the local
           # model as last resort. ollama exposes an OpenAI-compatible endpoint.
-          # LOCAL_LLM_TIMEOUT_MS gives a full CPU generation room (30 min, well
-          # under the 300-min wall) and also sizes undici's headers/body timeout
-          # via the local dispatcher — non-streaming CPU inference otherwise dies
-          # at undici's 300s default as `fetch failed` before any output.
+          # LOCAL_LLM_TIMEOUT_MS also sizes undici's headers/body timeout via the
+          # local dispatcher — non-streaming CPU inference otherwise dies at
+          # undici's 300s default as `fetch failed` before any output.
+          # 900000 (15min), not 30min: run 28755532056 showed both real
+          # successful completions finish in 9.3min/11.9min (qwen2.5:7b, full
+          # production prompt), while the one call that never finishes still
+          # burns the ENTIRE ceiling before giving up. At 30min that single
+          # stuck attempt consumed more than half of the 55min frontaliere wall
+          # budget for zero output — starving every later retry/expand attempt
+          # of the time they needed. 15min keeps ~25% headroom over the slowest
+          # observed success while halving the worst-case wasted-attempt cost.
           {
             echo "LOCAL_LLM_ENABLED=1"
             echo "LOCAL_LLM_URL=http://127.0.0.1:11434/v1/chat/completions"
             echo "LOCAL_LLM_MODEL=$LOCAL_MODEL"
-            echo "LOCAL_LLM_TIMEOUT_MS=1800000"
+            echo "LOCAL_LLM_TIMEOUT_MS=900000"
           } >> "$GITHUB_ENV"
           echo "🧠 Local LLM fallback ready: $LOCAL_MODEL (last-resort in the cascade)"
 


### PR DESCRIPTION
## Implementato

- `LOCAL_LLM_TIMEOUT_MS` reduced from `1800000` (30min) to `900000` (15min) in `.github/workflows/generate-article.yml`'s Ollama setup step.
- Root cause traced with precise timestamp arithmetic against real production log (run 28755532056, frontaliere section, 55min wall budget via `CREATE_ARTICLE_MAX_WALL_MS`): both real successful local-fallback completions finished in 9.3min and 11.9min (qwen2.5:7b, full production prompt). One call that never completes still burned the **entire 30-minute ceiling** before giving up — over half of the total 55-minute run budget wasted on a single doomed attempt, starving every later retry (and the cheap last-resort `expandShortItalianContent` step, never even reached) of remaining time.
- Confirmed the deadline-clamp logic in `scripts/lib/ai-models.mjs` (`_callLocal`) is correct — it clamps to `min(LOCAL_LLM_TIMEOUT_MS, remaining run budget)`. The ceiling constant itself was miscalibrated: 2.5-3x larger than what successful completions empirically need. Halving it keeps ~25% headroom over the slowest observed success while halving the worst-case cost of a stuck attempt, freeing budget for more retry/expand attempts.
- Two prior wrong hypotheses ruled out before landing on this fix (documented in the commit message): Ollama context-window truncation (tested locally — runtime `n_ctx=4096`, not 2048, plenty of headroom for the production prompt) and missing `deadlineMs` threading in `expandShortItalianContent` (already correctly injected by `create-article.mjs`'s local `callLLM` wrapper for every in-file caller).
- Sibling check: `LOCAL_LLM_TIMEOUT_MS` referenced in exactly two places repo-wide (`ai-models.mjs` reads it, this workflow sets it) — no duplicate to fix elsewhere. `tests/local-llm-fallback.test.ts` already uses `900000` as its own test-local value; nothing to update there.

## Non implementato (ancora)

- **Non verificabile pre-merge**: se il ceiling più basso libera davvero budget sufficiente perché un run produca un articolo reale (invece di fermarsi thin/vuoto) è verificabile solo osservando i prossimi run live di `generate-article.yml` (entrambe le sezioni). Recompute della timeline osservata con 900000 al posto di 1800000 suggerisce che il run 28755532056 avrebbe probabilmente raggiunto almeno un tentativo aggiuntivo e/o il passo `expandShortItalianContent` entro il budget — ma è una proiezione, non una misura. Trigger di revert/follow-up: se dopo il merge i prossimi 2-3 run su entrambe le sezioni continuano a non produrre un articolo reale per lo stesso motivo (attesa esaurita sul local/fallback), il prossimo passo è riordinare il retry loop per provare `expandShortItalianContent` prima di esaurire tutti i tentativi di rigenerazione completa — cambio di flusso più invasivo, deliberatamente non incluso in questa PR chirurgica.