### PR TITLE
fix(llm-json-repair): capture raw pre-repair text for JSON parse diagnostics

### DIFF
--- a/scripts/batch-add-faq-to-articles.mjs
+++ b/scripts/batch-add-faq-to-articles.mjs
@@ -28,7 +28,7 @@ const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, '..');
 import { callLLM, callSingleModel, AI_MODELS, initScoreStore, getStats, flushScores, resetExhaustedModel, printRunSummary } from './lib/ai-models.mjs';
 import { freeTranslateWithRetry, logCascadeSummary } from './lib/free-translate.mjs';
-import { stripCodeFences, findMatchingClose, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, findMatchingClose, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError, describeRawForDiagnostics } from './lib/llm-json-repair.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 
 // ── CLI argument parsing ─────────────────────────────────────
@@ -490,6 +490,7 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
     const regexFaq = extractFaqFromText(raw);
     if (regexFaq && regexFaq.length >= 2) return regexFaq;
     console.error(`  [JSON parse failed] ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
+    console.error(`  ${describeRawForDiagnostics(raw)}`);
     throw new Error(`JSON non valido dalla generazione FAQ: ${parseErr.message}`);
   }
   const faq = extractFaqArray(parsed);
@@ -542,6 +543,8 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
   } catch (parseErr) {
     const regexFaq = extractFaqFromText(raw);
     if (regexFaq && regexFaq.length >= 1) return regexFaq;
+    console.error(`  [JSON parse failed] ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
+    console.error(`  ${describeRawForDiagnostics(raw)}`);
     throw new Error(`JSON non valido dalla generazione top-up FAQ: ${parseErr.message}`);
   }
   const faq = extractFaqArray(parsed);

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -76,7 +76,7 @@ import { translateFieldFreeMt } from './lib/article-free-mt.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
-import { stripCodeFences, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError } from './lib/llm-json-repair.mjs';
+import { stripCodeFences, fixJsonStringBody, JSON_QUOTE_SAFETY_RULE_IT, describeJsonParseError, describeRawForDiagnostics } from './lib/llm-json-repair.mjs';
 import {
   factCheckFingerprint,
   totalMajorWeight,
@@ -3186,6 +3186,7 @@ async function callLLM(messages, opts = {}) {
         // pattern from a specific model can actually be root-caused.
         if (parseErr) {
           console.error(`  🔎 JSON parse fallito (${modelUsedRef.model || 'unknown'}): ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
+          console.error(`  📄 ${describeRawForDiagnostics(result)}`);
         }
       } else {
         for (const field of REQUIRED_IT_BODY_FIELDS) {
@@ -4464,6 +4465,7 @@ Rispondi SOLO con JSON valido, senza markdown.` },
     // we don't pay double for a transient `***`-between-properties glitch.
     console.error(`❌ JSON parse error: ${parseErr.message}`);
     console.error(`   ${describeJsonParseError(itRepaired, parseErr)}`);
+    console.error(`   ${describeRawForDiagnostics(itRaw)}`);
     const isTruncation = /Unterminated|Unexpected end/i.test(parseErr.message);
     const retryTokens = isTruncation ? 16000 : 8000;
     console.error(`  🔄 Retry IT con maxTokens=${retryTokens}${isTruncation ? ' (troncamento rilevato)' : ''}...`);
@@ -4767,6 +4769,7 @@ async function translateArticle(data) {
     } catch (parseErr) {
       console.error(`  ⚠️  JSON parse error (${label}): ${parseErr.message}`);
       console.error(`     ${describeJsonParseError(repaired, parseErr)}`);
+      console.error(`     ${describeRawForDiagnostics(raw)}`);
       // Detect truncation (model hit output cap): use 3× tokens on retry
       const isTruncation = parseErr.message.includes('Unterminated') || parseErr.message.includes('Unexpected end');
       const retry1Tokens = isTruncation ? Math.max(maxTokens * 3, 12000) : maxTokens + 4000;

--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -319,6 +319,22 @@ export function describeJsonParseError(repairedText, parseErr, contextChars = 12
   return `repaired[${start}:${end}] around position ${pos}: ${before}<<HERE>>${after}`;
 }
 
+/**
+ * Bounded raw (pre-repair) text snippet for diagnosing residual repair gaps
+ * that describeJsonParseError() cannot show — its position windows around
+ * the POST-repair string, which is undiagnosable on its own when the repair
+ * itself is what's still wrong (repairLlmJson/repairJsonArray change the
+ * string's length via escaping/fence-stripping, so that offset doesn't map
+ * back into the untouched completion). Log this alongside it so the next
+ * occurrence of a still-unparseable repaired string can actually be
+ * root-caused from the real input instead of guessed at.
+ */
+export function describeRawForDiagnostics(raw, maxChars = 4000) {
+  const str = String(raw ?? '');
+  const truncated = str.length > maxChars;
+  return `raw[0:${Math.min(str.length, maxChars)}]${truncated ? ` (troncato, totale ${str.length})` : ''}: ${str.slice(0, maxChars).replace(/\n/g, '\\n')}`;
+}
+
 export function fixJsonStringBody(input, { fixAsterisks = false } = {}) {
   let out = '';
   let inStr = false;


### PR DESCRIPTION
## Implementato

- Added shared `describeRawForDiagnostics(raw, maxChars=4000)` export in `scripts/lib/llm-json-repair.mjs`, returning a bounded, newline-escaped snippet of the raw pre-repair LLM completion text.
- Rationale: `describeJsonParseError()`'s context window centers on the POST-repair string's `JSON.parse()` error offset. Since `repairLlmJson`/`repairJsonArray` change the string's length (quote-escaping, code-fence stripping, newline collapsing), that offset cannot be mapped back to the original raw completion — some "JSON parse fallito" occurrences were fundamentally undiagnosable from existing logs alone (surfaced during live verification of issue 3604's fix, run 28757866877: a superficially-similar `imageAlt` parse failure whose root cause could not be confirmed from the visible log window).
- Wired `describeRawForDiagnostics()` alongside every existing `describeJsonParseError()` call:
  - `scripts/create-article.mjs`: 3 call sites (callLLM body2-check branch, IT-content retry path, third JSON-parse-error branch).
  - `scripts/batch-add-faq-to-articles.mjs`: 2 call sites (`generateFaqIT`, `generateTopUpFaqIT`) — found via the mandatory `node scripts/ci/check-sibling-patterns.mjs` sweep as a genuine sibling instance of the same diagnostic gap. `generateTopUpFaqIT`'s site had no diagnostic logging at all before this change.
- Verified `node --check` on all 3 touched files (syntax OK) and the full relevant vitest suite: `tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/scripts/create-article-integration.test.ts tests/scripts/llm-json-repair.test.ts` → 105/105 tests passing.
- Re-ran `check-sibling-patterns.mjs` after the fix; remaining flags (`maxChars`, `parseErr`) manually confirmed as false positives — generic parameter/catch-variable names in unrelated files (ATS feed clients, truncation helpers) with no `describeJsonParseError`/`repairLlmJson`/`repairJsonArray` involvement.

## Non implementato (ancora)

Nessuno. This PR's scope is the diagnostic instrumentation itself, fully implemented and tested. The still-open question of what actually caused run 28757866877's specific `imageAlt` parse failure is tracked separately in a follow-up issue (filed after this merges), since answering it requires the raw-capture logs this PR adds — it is not part of this PR's completable scope.