### PR TITLE
fix(llm-json-repair): stop corrupting bare array strings and markdown-adjacent quotes

### DIFF
--- a/scripts/lib/llm-json-repair.mjs
+++ b/scripts/lib/llm-json-repair.mjs
@@ -148,13 +148,26 @@ function precededByFreshOpen(str, idx, fixAsterisks) {
  * reads `..."tassa": "un tributo" imposto...`, where "tassa" is mid-prose,
  * not a key). A genuine key must itself have been freshly opened right
  * after a real `,`/`{`, not reached while another string was already open.
+ *
+ * A `*` run right after the quote isn't trusted unconditionally either —
+ * bold markdown routinely sits INSIDE a still-open string right after an
+ * earlier stray quote (`"testo "citato" **grassetto** fine."`), so what
+ * follows the run must itself look like a fresh continuation, same as the
+ * comma/colon branches below. Blind trust here closed the string early and
+ * corrupted everything after it, including unrelated sibling JSON keys
+ * (issue #3618 item 2).
  */
 function decideQuoteCloses(str, quoteIdx, fixAsterisks) {
   let j = quoteIdx + 1;
   while (j < str.length && /\s/.test(str[j])) j++;
   const next = str[j];
-  if (next === undefined || next === '}' || next === ']' || (fixAsterisks && next === '*')) {
+  if (next === undefined || next === '}' || next === ']') {
     return true;
+  }
+  if (fixAsterisks && next === '*') {
+    let k = j;
+    while (k < str.length && str[k] === '*') k++;
+    return afterSeparatorLooksValid(str, k, false, fixAsterisks);
   }
   if (next === ':') {
     const keyOpen = findPrecedingUnescapedQuote(str, quoteIdx);
@@ -237,11 +250,22 @@ function scanKeyEnd(str, i) {
  * looks like a valid JSON continuation, given `afterSepPos` already points
  * just past that separator. A colon expects a value (lenient: values
  * legitimately contain embedded quotes, e.g. prose). A comma/asterisk-run
- * expects a fresh key: unlike a value, a key can't legitimately contain its
- * own embedded quote, so it's scanned strictly and must be followed by a
- * real colon — this is what rejects `"tassa", "un tributo", e discusso.`
+ * first tries a fresh key: unlike a value, a key can't legitimately contain
+ * its own embedded quote, so it's scanned strictly and must be followed by
+ * a real colon — this is what rejects `"tassa", "un tributo", e discusso.`
  * (no colon after the strictly-scanned "un tributo") while still accepting
  * `"a":"...","b":"..."` (each key strictly closes, colon follows).
+ *
+ * If the key interpretation fails, a comma can still be a genuine
+ * separator between bare VALUES, not just object entries (`["a","b"]`) —
+ * rejecting outright here corrupted every bare string-array element
+ * (issue #3602). But the fallback must reuse the SAME strict, no-retry
+ * close (scanKeyEnd) rather than the permissive scanValueEnd/scanStringEnd
+ * used for real values below: that permissive scanner is designed to skip
+ * past an ambiguous embedded quote and keep looking for a later real
+ * closer, which is exactly wrong for this candidate — it let a deliberate
+ * prose aside (`"tassa", "un tributo", e discusso.`) telescope all the way
+ * to the string's true end and get mistaken for a valid fresh value.
  */
 function afterSeparatorLooksValid(str, afterSepPos, isColon, fixAsterisks) {
   let i = afterSepPos;
@@ -255,8 +279,8 @@ function afterSeparatorLooksValid(str, afterSepPos, isColon, fixAsterisks) {
     if (keyEnd === -1) return false;
     let m = keyEnd;
     while (m < str.length && /\s/.test(str[m])) m++;
-    if (str[m] !== ':') return false;
-    return afterSeparatorLooksValid(str, m + 1, true, fixAsterisks);
+    if (str[m] === ':') return afterSeparatorLooksValid(str, m + 1, true, fixAsterisks);
+    return looksLikeJsonContinuation(str, keyEnd, fixAsterisks);
   }
   const valueEnd = scanValueEnd(str, i, fixAsterisks);
   return valueEnd !== -1 && looksLikeJsonContinuation(str, valueEnd, fixAsterisks);

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -148,6 +148,49 @@ describe('fixJsonStringBody', () => {
     expect(parsed.b).toBe('Anche "questo" qui.');
   });
 
+  // Regression (issue #3602): afterSeparatorLooksValid's comma-branch only ever
+  // tried interpreting a quoted candidate following a comma as a fresh object
+  // KEY (must be followed by ':'), returning false outright otherwise. A comma
+  // inside an array separates bare VALUES, not key:value pairs, so this
+  // corrupted every plain string-array field (e.g. tags) by merging elements.
+  it('does not merge bare string-array elements at a plain comma separator', () => {
+    const broken = '{"tags":["a","b"],"body":"ok"}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.tags).toEqual(['a', 'b']);
+    expect(parsed.body).toBe('ok');
+  });
+
+  it('still rejects a comma-then-quoted-aside as an array separator when the fallback value never resolves (no regression from the #3602 fix)', () => {
+    const broken = '{"a":"il termine "tassa", "un tributo", e discusso."}';
+    const repaired = fixJsonStringBody(broken);
+    const parsed = JSON.parse(repaired);
+    expect(parsed.a).toBe('il termine "tassa", "un tributo", e discusso.');
+  });
+
+  // Regression: decideQuoteCloses() unconditionally trusted any quote
+  // immediately followed by a '*' run (fixAsterisks) as a genuine closer,
+  // without checking that what follows the run looks like a real
+  // continuation — unlike the comma/colon branches, which do. Bold markdown
+  // routinely sits INSIDE a still-open string right after an earlier stray
+  // quote, so this closed the string early and corrupted everything after
+  // it, including unrelated sibling JSON keys (issue #3618 item 2).
+  it('does not close a string early at a stray quote merely because markdown bold follows, when the bold is literal content still inside the string', () => {
+    const broken = '{"a":"testo "citato" **grassetto** fine.","b":"next"}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.a).toBe('testo "citato" **grassetto** fine.');
+    expect(parsed.b).toBe('next');
+  });
+
+  it('still converts a genuine markdown-bold separator between two bare array string elements', () => {
+    const broken = '{"tags":["value1"**"value2"],"c":1}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.tags).toEqual(['value1', 'value2']);
+    expect(parsed.c).toBe(1);
+  });
+
   // Regression: scanValueEnd() treated '{'/'[' as ending the value immediately
   // after the opening bracket instead of finding the matching close. That made
   // the lookahead wrongly reject a preceding string field's real closing quote


### PR DESCRIPTION
## Implementato

- Fixed `afterSeparatorLooksValid`'s comma-branch (`scripts/lib/llm-json-repair.mjs`): previously only tried interpreting a quoted candidate following a comma as a fresh object *key* (must be followed by `:`), rejecting outright otherwise. A comma inside an array separates *values*, not key:value pairs, so this merged every bare string-array element (`["a","b"]` → one corrupted string). Fixed by reusing the same strict, no-retry close (`scanKeyEnd`) for the value-fallback path — verified this doesn't regress the module's own existing prose-aside false-positive guard (a permissive value-scan fallback would have telescoped past the string's real terminator; caught this via a real regression run before finalizing, see Test plan).
- Fixed `decideQuoteCloses`'s markdown-bold branch: it unconditionally trusted any quote immediately followed by a `**`/`***` run (when `fixAsterisks` is set) as a genuine closer, without checking that what follows the run looks like a real continuation — unlike the comma/colon branches, which do verify. Bold markdown routinely sits *inside* a still-open string right after an earlier stray quote (e.g. `"testo "citato" **grassetto** fine."`), so this closed the string early and corrupted everything after it, including unrelated sibling JSON keys.
- Added 4 new regression tests (`tests/scripts/llm-json-repair.test.ts`): bare string-array elements, the prose-aside false-positive guard (re-verified post-fix), markdown-bold-as-literal-content-inside-an-open-string, and markdown-bold-as-genuine-array-separator (the case the branch was originally meant to handle, confirmed still works).

Both bugs live in the single shared `scripts/lib/llm-json-repair.mjs` module used by `repairLlmJson()` in `scripts/create-article.mjs` (the repair path every article-generation JSON payload goes through) and by `batch-add-faq-to-articles.mjs`'s `repairJsonArray`.

Closes #3602

Addresses issue #3618 item 2 (markdown-bold + stray-quote interaction) — confirmed via direct testing to be a real, more severe bug than the reviewer's own suggested example indicated (that example alone didn't reproduce a failure; additional edge-case variants did, with total parse corruption including the JSON key).

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] `node --check scripts/lib/llm-json-repair.mjs`
- [x] `npx vitest run tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/scripts/create-article-integration.test.ts tests/scripts/llm-json-repair.test.ts` — 114/114 green (110 pre-existing + 4 new)
- [x] Direct `node -e` empirical repro of issue #3602's exact example, both new edge cases, and the reviewer's own #3618 suggested example — all now parse correctly
- [x] `node scripts/ci/check-sibling-patterns.mjs` — flagged `scripts/create-article.mjs` (shares `fixAsterisks` token). Confirmed false positive: it's the call site into this same shared, now-fixed function, not a separate duplicate implementation — grepped repo-wide for `decideQuoteCloses`/`afterSeparatorLooksValid`/`scanKeyEnd`, single definition location confirmed.
