### PR TITLE
fix(create-article): stop echoing full body in splitBodyIntoSections

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2159,63 +2159,127 @@ async function generateExcerpt(title, body1, body2, body3) {
   return capBlogDescription(bodyText).value;
 }
 
+/** Char-based thirds over an ordered list of chunks (paragraphs or sentences),
+ * guaranteeing each of the 3 groups gets >=1 chunk whenever items.length >= 3. */
+function chunksByCharThirds(items, joiner) {
+  const total = items.reduce((sum, s) => sum + s.length, 0);
+  let cut1 = -1;
+  let cut2 = -1;
+  let acc = 0;
+  for (let i = 0; i < items.length; i++) {
+    acc += items[i].length;
+    if (cut1 === -1 && acc >= total / 3) cut1 = i + 1;
+    else if (cut2 === -1 && acc >= (total * 2) / 3) cut2 = i + 1;
+  }
+  cut1 = Math.min(Math.max(cut1, 1), items.length - 2);
+  cut2 = Math.min(Math.max(cut2, cut1 + 1), items.length - 1);
+  return {
+    body1: items.slice(0, cut1).join(joiner).trim(),
+    body2: items.slice(cut1, cut2).join(joiner).trim(),
+    body3: items.slice(cut2).join(joiner).trim(),
+  };
+}
+
+/** Zero-LLM last resort: split at paragraph boundaries (falling back to
+ * sentence boundaries, then a raw char cut) so splitBodyIntoSections never
+ * throws — an unavailable/exhausted model degrades to a slightly-less-natural
+ * cut instead of failing the whole article. */
+function deterministicBodySplit(text) {
+  const paragraphs = text.split(/\n\n+/).filter((p) => p.trim());
+  if (paragraphs.length >= 3) return chunksByCharThirds(paragraphs, '\n\n');
+  const sentences = text.split(/(?<=[.!?])\s+/).filter(Boolean);
+  if (sentences.length >= 3) return chunksByCharThirds(sentences, ' ');
+  const third = Math.ceil(text.length / 3) || 1;
+  return {
+    body1: text.slice(0, third).trim(),
+    body2: text.slice(third, third * 2).trim(),
+    body3: text.slice(third * 2).trim(),
+  };
+}
+
 /**
  * Split a single free-text article body (as authored by a journalist in the
  * redazione dashboard) into the fixed body1/body2/body3 shape the rest of
  * the pipeline (REQUIRED_IT_BODY_FIELDS, validateItalianPayload,
- * translateArticle, enforceStrongInternalLinks, ...) already expects. An LLM
- * call decides the split points (issue #3174 follow-up — the journalist's
- * explicit choice over a blank-line heuristic) so it can balance section
- * length instead of cutting mid-thought.
+ * translateArticle, enforceStrongInternalLinks, ...) already expects.
+ *
+ * The LLM picks ONLY the two paragraph indices where section 2 and section 3
+ * start (issue #3174 follow-up — the journalist's explicit choice over a
+ * blank-line heuristic, so it can balance section length instead of cutting
+ * mid-thought) — it never re-emits the body text itself. Earlier versions had
+ * the LLM echo the full body back inside body1/body2/body3, which made output
+ * size scale 1:1 with input size against a fixed maxTokens:4000 cap: any body
+ * long enough that its escaped JSON echo exceeded ~4000 tokens (any free-tier
+ * model's output ceiling, see MODEL_MAX_OUTPUT_TOKENS in lib/ai-models.mjs)
+ * truncated identically on all 3 attempts — a structural cap mismatch, not a
+ * transient failure, so retrying never helped (root cause of the 44k-char
+ * "Accordo Italia-Svizzera" article failing 3/3). Requesting 2 integers keeps
+ * the LLM response constant-size regardless of body length, and slicing the
+ * original paragraphs verbatim in JS also removes any risk of the LLM
+ * mangling markdown while copying.
  */
 async function splitBodyIntoSections(fullBody, title) {
   const text = String(fullBody || '').trim();
   if (!text) throw new Error('splitBodyIntoSections: corpo vuoto');
 
-  const schema = {
-    name: 'body_split',
-    schema: {
-      type: 'object',
-      additionalProperties: false,
-      required: ['body1', 'body2', 'body3'],
-      properties: {
-        body1: { type: 'string' },
-        body2: { type: 'string' },
-        body3: { type: 'string' },
-      },
-    },
-  };
-  const messages = [
-    {
-      role: 'system',
-      content:
-        'Sei un redattore italiano. Dividi il testo fornito in ESATTAMENTE 3 sezioni bilanciate ' +
-        '(body1, body2, body3) senza aggiungere, riassumere o rimuovere contenuto — solo suddividere ' +
-        'nei punti più naturali. Preserva ESATTAMENTE la formattazione markdown esistente (grassetto ' +
-        '**testo**, elenchi, e link interni nel formato [testo](nav:azione)). Rispondi SOLO in JSON.\n\n' +
-        JSON_QUOTE_SAFETY_RULE_IT,
-    },
-    { role: 'user', content: `Titolo: ${title}\n\nTesto da dividere:\n${text}` },
-  ];
+  const paragraphs = text.split(/\n\n+/).filter((p) => p.trim());
 
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const raw = await _aiCallLLM(messages, {
-        temperature: 0.3,
-        maxTokens: 4000,
-        timeout: 60_000,
-        jsonMode: true,
-        jsonSchema: schema,
-      });
-      const parsed = JSON.parse(repairLlmJson(raw));
-      if (parsed?.body1 && parsed?.body2 && parsed?.body3 && parsed.body2.trim().length >= 40) {
-        return { body1: parsed.body1.trim(), body2: parsed.body2.trim(), body3: parsed.body3.trim() };
+  if (paragraphs.length >= 3) {
+    const numbered = paragraphs
+      .map((p, i) => `[${i}] ${p.length > 200 ? `${p.slice(0, 200)}…` : p}`)
+      .join('\n\n');
+    const schema = {
+      name: 'body_split_points',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['section2StartIndex', 'section3StartIndex'],
+        properties: {
+          section2StartIndex: { type: 'integer' },
+          section3StartIndex: { type: 'integer' },
+        },
+      },
+    };
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'Sei un redattore italiano. Il testo sottostante è numerato per paragrafo. Un articolo va diviso ' +
+          'in ESATTAMENTE 3 sezioni bilanciate senza aggiungere, riassumere o rimuovere contenuto: scegli ' +
+          'solo in quale paragrafo iniziano la sezione 2 e la sezione 3 (i punti di taglio più naturali). ' +
+          'Rispondi SOLO in JSON con i due indici (interi, 0-based, riferiti al numero tra parentesi quadre).',
+      },
+      { role: 'user', content: `Titolo: ${title}\n\nParagrafi (${paragraphs.length} totali):\n${numbered}` },
+    ];
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const raw = await _aiCallLLM(messages, {
+          temperature: 0.3,
+          maxTokens: 200,
+          timeout: 30_000,
+          jsonMode: true,
+          jsonSchema: schema,
+        });
+        const parsed = JSON.parse(repairLlmJson(raw));
+        const i2 = Number(parsed?.section2StartIndex);
+        const i3 = Number(parsed?.section3StartIndex);
+        if (Number.isInteger(i2) && Number.isInteger(i3) && i2 >= 1 && i3 > i2 && i3 < paragraphs.length) {
+          const body1 = paragraphs.slice(0, i2).join('\n\n').trim();
+          const body2 = paragraphs.slice(i2, i3).join('\n\n').trim();
+          const body3 = paragraphs.slice(i3).join('\n\n').trim();
+          if (body1 && body2.length >= 40 && body3) return { body1, body2, body3 };
+        }
+      } catch (err) {
+        console.warn(`  ⚠️  splitBodyIntoSections tentativo ${attempt} fallito: ${err.message}`);
       }
-    } catch (err) {
-      console.warn(`  ⚠️  splitBodyIntoSections tentativo ${attempt} fallito: ${err.message}`);
     }
+    console.warn('  ⚠️  splitBodyIntoSections: nessun punto di taglio valido dopo 3 tentativi — uso fallback deterministico a paragrafi');
+  } else {
+    console.warn(`  ⚠️  splitBodyIntoSections: solo ${paragraphs.length} paragrafo/i — uso fallback deterministico`);
   }
-  throw new Error('splitBodyIntoSections: impossibile ottenere una suddivisione valida dopo 3 tentativi');
+
+  return deterministicBodySplit(text);
 }
 
 /**

--- a/tests/scripts/split-body-into-sections.test.ts
+++ b/tests/scripts/split-body-into-sections.test.ts
@@ -1,0 +1,126 @@
+// tests/scripts/split-body-into-sections.test.ts
+//
+// Live incident: the journalist-authored article "L'Accordo Italia-Svizzera
+// del 2020 sulla tassazione dei lavoratori frontalieri" (44002-char body,
+// ~11x the typical size) failed publish 3/3 with "splitBodyIntoSections:
+// impossibile ottenere una suddivisione valida dopo 3 tentativi". Root cause:
+// the old implementation had the LLM re-emit the ENTIRE body inside the JSON
+// response (body1/body2/body3), so output size scaled 1:1 with input size
+// against a fixed maxTokens:4000 — any body whose escaped JSON echo exceeded
+// ~4000 tokens truncated identically on every retry (a structural cap
+// mismatch, not a transient failure retries could fix).
+//
+// The fix has the LLM pick only 2 paragraph-index cut points (constant-size
+// output regardless of body length) and slices the original paragraphs
+// verbatim in JS, with a deterministic non-LLM fallback so the function never
+// throws. These tests lock in both properties.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const aiModelsMock = vi.hoisted(() => ({ callLLM: vi.fn() }));
+
+vi.mock('../../scripts/lib/ai-models.mjs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../scripts/lib/ai-models.mjs')>();
+  return { ...actual, callLLM: aiModelsMock.callLLM };
+});
+
+const { splitBodyIntoSections } = await import('../../scripts/create-article.mjs');
+
+function paragraphs(n: number, wordsPerParagraph = 40): string[] {
+  return Array.from({ length: n }, (_, i) =>
+    Array.from({ length: wordsPerParagraph }, (_, w) => `p${i}w${w}`).join(' '),
+  );
+}
+
+describe('splitBodyIntoSections', () => {
+  beforeEach(() => {
+    aiModelsMock.callLLM.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('never asks the LLM to echo the body back — output size stays constant regardless of body length', async () => {
+    // 400 paragraphs (~44000 chars total) mirrors the failing article's size.
+    const ps = paragraphs(400);
+    const body = ps.join('\n\n');
+
+    aiModelsMock.callLLM.mockImplementation(async (_messages, opts) => {
+      // The old (buggy) implementation requested maxTokens:4000 to fit a full
+      // body echo. The fix only needs 2 small integers back.
+      expect(opts.maxTokens).toBeLessThanOrEqual(200);
+      return JSON.stringify({ section2StartIndex: 150, section3StartIndex: 300 });
+    });
+
+    const result = await splitBodyIntoSections(body, 'Titolo di test');
+
+    expect(result.body1).toBe(ps.slice(0, 150).join('\n\n'));
+    expect(result.body2).toBe(ps.slice(150, 300).join('\n\n'));
+    expect(result.body3).toBe(ps.slice(300).join('\n\n'));
+    // Content preserved verbatim — no re-summarization/rewriting risk.
+    expect([result.body1, result.body2, result.body3].join('\n\n')).toBe(body);
+    expect(aiModelsMock.callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back deterministically (paragraph thirds) when the LLM returns invalid indices on every attempt', async () => {
+    const ps = paragraphs(9);
+    const body = ps.join('\n\n');
+
+    aiModelsMock.callLLM.mockResolvedValue(JSON.stringify({ section2StartIndex: 'nope', section3StartIndex: null }));
+
+    const result = await splitBodyIntoSections(body, 'Titolo di test');
+
+    expect(result.body1).toBeTruthy();
+    expect(result.body2).toBeTruthy();
+    expect(result.body3).toBeTruthy();
+    // No content lost or duplicated.
+    expect(`${result.body1}\n\n${result.body2}\n\n${result.body3}`).toBe(body);
+    expect(aiModelsMock.callLLM).toHaveBeenCalledTimes(3);
+  });
+
+  it('never throws even when every LLM call rejects (network/quota exhaustion)', async () => {
+    const ps = paragraphs(6);
+    const body = ps.join('\n\n');
+
+    aiModelsMock.callLLM.mockRejectedValue(new Error('all models exhausted'));
+
+    const result = await splitBodyIntoSections(body, 'Titolo di test');
+
+    expect(result.body1).toBeTruthy();
+    expect(result.body2).toBeTruthy();
+    expect(result.body3).toBeTruthy();
+  });
+
+  it('falls back deterministically for a body with no paragraph breaks at all', async () => {
+    const sentences = Array.from({ length: 9 }, (_, i) => `Questa è la frase numero ${i}.`);
+    const body = sentences.join(' ');
+
+    const result = await splitBodyIntoSections(body, 'Titolo di test');
+
+    expect(result.body1).toBeTruthy();
+    expect(result.body2).toBeTruthy();
+    expect(result.body3).toBeTruthy();
+    expect(aiModelsMock.callLLM).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid LLM split on the first attempt without retrying', async () => {
+    const ps = paragraphs(5);
+    const body = ps.join('\n\n');
+
+    aiModelsMock.callLLM.mockResolvedValueOnce(
+      JSON.stringify({ section2StartIndex: 2, section3StartIndex: 4 }),
+    );
+
+    const result = await splitBodyIntoSections(body, 'Titolo di test');
+
+    expect(result.body1).toBe(ps.slice(0, 2).join('\n\n'));
+    expect(result.body2).toBe(ps.slice(2, 4).join('\n\n'));
+    expect(result.body3).toBe(ps.slice(4).join('\n\n'));
+    expect(aiModelsMock.callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on an empty body (unchanged pre-existing guard)', async () => {
+    await expect(splitBodyIntoSections('   ', 'Titolo di test')).rejects.toThrow('corpo vuoto');
+  });
+});


### PR DESCRIPTION
## Implementato

- Root cause fix for the journalist article "L'Accordo Italia-Svizzera del 2020 sulla tassazione dei lavoratori frontalieri" (doc `laccordo-italia-svizzera-del-2020-sulla-tassazione-dei-lavoratori-frontalieri`, 44002-char body, ~11x the typical journalist-article size), which failed publish 3/3 with `splitBodyIntoSections: impossibile ottenere una suddivisione valida dopo 3 tentativi`.
- Root cause: `splitBodyIntoSections` (`scripts/create-article.mjs`) had the LLM re-emit the ENTIRE body inside the JSON response (`body1`/`body2`/`body3`), so output size scaled 1:1 with input size against a fixed `maxTokens:4000`. Any body whose escaped JSON echo exceeded ~4000 tokens (the output ceiling of several free-tier models, see `MODEL_MAX_OUTPUT_TOKENS` in `scripts/lib/ai-models.mjs`) truncated identically on every one of the 3 retries — a structural cap mismatch, not a transient failure, so retrying never helped any body past a length threshold.
- Structural fix (this is the class-of-bug fix the task asked for, not just this one article): `splitBodyIntoSections` now asks the LLM for only 2 paragraph-index cut points (`section2StartIndex`/`section3StartIndex`) instead of the full body text — output stays constant-size (few tokens) regardless of body length, permanently removing this failure class. The original paragraphs are sliced verbatim in JS, which also removes any risk of the LLM mangling markdown while copying.
- Added a deterministic, non-LLM fallback (`deterministicBodySplit`/`chunksByCharThirds`: paragraph boundaries, falling back to sentence boundaries, falling back to a raw char cut) so the function never throws even if every model call in the cascade fails/times out — a redazione article no longer hard-fails at this step; it degrades to a slightly-less-natural (but always valid) 3-way split instead.
- Checked sibling LLM call sites in `scripts/create-article.mjs`/`scripts/publish-journalist-article.mjs` for the same "echo full content back with a fixed maxTokens" construct: `translateArticle`/`translateBodyField` already scales `maxTokens` dynamically by word count and sub-chunks large fields (not vulnerable); `generateExcerpt` and `generateFaqIT` truncate/bound their input and only produce small, input-length-independent output (not vulnerable). `splitBodyIntoSections` was the only outlier — no other sibling fix needed.
- New unit tests (`tests/scripts/split-body-into-sections.test.ts`, 6 tests, mocking `callLLM`): reproduces the 44k-char failing body and asserts the LLM is asked for a constant-size response; asserts the deterministic fallback triggers (and never loses/duplicates content) when the LLM returns invalid indices on every attempt or rejects on every attempt; asserts the no-paragraph-breaks fallback path; asserts the happy path takes only 1 LLM call; unchanged empty-body guard.
- `npx vitest run tests/scripts/split-body-into-sections.test.ts tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/blog-title-casing.test.ts tests/article-slug-derivation.test.ts tests/scripts/create-article-integration.test.ts tests/publish-journalist-hero-image-timeout.test.ts` → 105/105 green locally before opening this PR.

## Non implementato (ancora)

- Requeuing the failed Firestore doc (`journalist_articles/laccordo-italia-svizzera-del-2020-sulla-tassazione-dei-lavoratori-frontalieri`, currently `status:'failed'`) and re-running `publish-journalist-articles.yml` to actually get this specific article live — in questa PR non ancora, verrà fatto subito dopo il merge (serve il fix su `main` perché il workflow fa checkout di `main` a ogni run); questo turno resta aperto finché il doc non risulta `published` + link live verificati.