### PR TITLE
fix(generate-article): resolve chained rebase-conflict data corruption + audit follow-up items (#3617, #3618)

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -2471,6 +2471,30 @@ function _learnSchemaIncompatible(modelForTracking) {
  * and let a doomed HTTP call through. chars/3.5 + 500 on the same prompt
  * yields ~8826, within 1% of the real count and back over the cap.
  *
+ * Tightening chars/4 → chars/3.5 raises EVERY model's estimate uniformly, so
+ * issue #3618 item 1 asked whether this pushes some other DEFAULT_CHAIN
+ * model — one that was correctly passing before — into a false-positive skip
+ * at realistic prompt sizes. Audited by sweeping every model in DEFAULT_CHAIN
+ * across chars 4000..35000 (this codebase's real article-generation "Call
+ * 1/5" prompt, source text + instructions, is not a fixed 8-10k chars — the
+ * same run 28732970228 prompt that motivated this change was itself ~29140
+ * chars): old vs new divisor disagree ONLY inside a narrow per-cap window —
+ * (12251, 14000] chars for the 4000-token caps, (26251, 30000] chars for the
+ * 8000-token caps (the GitHub Models / Groq provider defaults that cover most
+ * of the chain). No model has a *different, lower* real limit than these —
+ * DEFAULT_REQUEST_TOKENS_BY_PROVIDER's own docstring notes the GitHub 8000
+ * cap was verified ACCOUNT-WIDE across five unrelated model families hitting
+ * byte-identical 413 text at the same estimate, i.e. token-counting for a
+ * given prompt doesn't vary by which model on that provider receives it — so
+ * a prompt landing in that window is genuinely at-or-over every model's real
+ * cap on that provider, not a false positive for some but not others. Net:
+ * no model is incorrectly newly-skipped; the tightened divisor only converts
+ * previously-silent false negatives (doomed 413/400 calls) into pre-flight
+ * skips, matching the fallback chain's own stated cost model (a wrong skip
+ * costs one chain step; a wrong pass costs a guaranteed failed HTTP call).
+ * See tests/scripts/ai-models-token-estimate-divisor.test.ts for the
+ * regression lock on the divisor value and the boundary math above.
+ *
  * Exported for tests / smoke probes.
  */
 export function estimateRequestTokens(messages, opts = {}) {

--- a/scripts/lib/dedupe-growing-container-closer.mjs
+++ b/scripts/lib/dedupe-growing-container-closer.mjs
@@ -1,0 +1,154 @@
+/**
+ * scripts/lib/dedupe-growing-container-closer.mjs
+ *
+ * Issue #3617 (JSON) found that a SECOND chained rebase-conflict cycle on
+ * the same append-only file within one push's retry loop (git-push-with-retry.sh
+ * --max-attempts, raised 3→5 by PR #3613) can produce a duplicated root
+ * closer: both sides' "keep both" hunks independently include the
+ * container's own closing token, so naive marker-stripping leaves that
+ * token twice with the other side's new entry orphaned in between.
+ *
+ * The SAME failure shape reaches several non-JSON append-only targets
+ * written by scripts/create-article.mjs / scripts/lib/seo-pages-article-list.mjs,
+ * because their insertion regexes anchor on the container's closing token
+ * itself (not on the preceding entry), so a second conflict on that same
+ * anchor duplicates it exactly like JSON did:
+ *   - data/blog-articles-data.ts   (`const RAW_ARTICLES = [ ... ]`)
+ *   - data/swiss-articles-data.ts  (`const RAW_SWISS_ARTICLES = [ ... ]`)
+ *   - services/seo/seo-pages.ts    ("Articoli Frontaliere" ItemList block)
+ *   - services/locales/blog-meta-{it,en,de,fr}.ts and blog-meta-ch-*.ts
+ *     (`Record<string, string>` meta-key objects)
+ *   - public/sitemap-blog.xml, sitemap-blog-ch.xml, sitemap-news.xml,
+ *     sitemap.xml (`<urlset>...</urlset>`)
+ *
+ * `services/routerBlogData.ts`/`services/routerSwissData.ts`'s BLOG_SLUGS /
+ * SWISS_SLUGS maps are NOT in this list: their insertion anchors on the
+ * PRECEDING entry line, never touching the map's closing `};`, so two
+ * concurrent appends conflict at the entry line only — closing brace stays
+ * single-occurrence, no repair needed there (verified against
+ * modifyRouterTs in scripts/create-article.mjs).
+ *
+ * Each repair here is scoped to the specific known container (an anchor
+ * regex to find its start, plus either a known "next declaration" bound or
+ * a self-terminating entry/closer line scan) — never a whole-file scan —
+ * so it can't misfire on unrelated brackets elsewhere in the file.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+/**
+ * Dedupe a duplicated closer within [openRe match end, endRe match start).
+ * Keeps only the LAST closer occurrence, drops earlier ones (each occurrence
+ * is dropped along with one trailing newline, to avoid a stray blank line).
+ * Returns null if there's nothing to repair (0 or 1 closer occurrences).
+ */
+export function dedupeBounded(text, openRe, closerRe, endRe) {
+  const openMatch = openRe.exec(text);
+  if (!openMatch) return null;
+  const startIdx = openMatch.index + openMatch[0].length;
+
+  let endIdx = text.length;
+  if (endRe) {
+    const rest = text.slice(startIdx);
+    const endMatch = endRe.exec(rest);
+    if (endMatch) endIdx = startIdx + endMatch.index;
+  }
+
+  const region = text.slice(startIdx, endIdx);
+  const matches = [...region.matchAll(closerRe)];
+  if (matches.length <= 1) return null;
+
+  const dropList = matches.slice(0, -1);
+  let out = '';
+  let cursor = 0;
+  for (const m of dropList) {
+    out += region.slice(cursor, m.index);
+    cursor = m.index + m[0].length;
+    if (region[cursor] === '\n') cursor++;
+  }
+  out += region.slice(cursor);
+  return text.slice(0, startIdx) + out + text.slice(endIdx);
+}
+
+/**
+ * Dedupe a duplicated closer in a container whose entries are single-line
+ * and whose end can't be bounded by a fixed "next declaration" anchor
+ * (e.g. one ItemList among many similarly-shaped ones in a huge file).
+ * Scans line-by-line from the opener: every line must be either an entry
+ * line or a closer line (or blank); the region ends at the first line that
+ * is neither — that's always real, unrelated content, since neither entries
+ * nor closer lines ever look like it. Any closer line seen along the way is
+ * recorded; if more than one is found, only the last survives.
+ */
+export function dedupeSelfBounded(text, openRe, entryRe, closerRe) {
+  const openMatch = openRe.exec(text);
+  if (!openMatch) return null;
+  const startIdx = openMatch.index + openMatch[0].length;
+  const rest = text.slice(startIdx);
+  const lines = rest.split('\n');
+
+  const closerLineIdx = [];
+  let stopAt = lines.length;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (closerRe.test(line)) { closerLineIdx.push(i); continue; }
+    if (entryRe.test(line)) continue;
+    if (line.trim() === '') continue;
+    stopAt = i;
+    break;
+  }
+
+  if (closerLineIdx.length <= 1) return null;
+  const dropSet = new Set(closerLineIdx.slice(0, -1));
+  const newLines = lines.slice(0, stopAt).filter((_, i) => !dropSet.has(i)).concat(lines.slice(stopAt));
+  return text.slice(0, startIdx) + newLines.join('\n');
+}
+
+const ARRAY_CLOSER_RE = /^\]\s*(?:satisfies\s+Article\[\])?;[ \t]*$/gm;
+
+/**
+ * Applies the matching repair for `file` (by basename) to `src`. Returns the
+ * repaired source, or null if this file isn't a known target or nothing
+ * needed repair.
+ */
+export function repairGrowingContainerCloser(file, src) {
+  const base = basename(file);
+
+  if (base === 'blog-articles-data.ts') {
+    return dedupeBounded(src, /const RAW_ARTICLES\s*(?::[^=]+)?=\s*\[/, ARRAY_CLOSER_RE, /^export const ARTICLES\b/m);
+  }
+  if (base === 'swiss-articles-data.ts') {
+    return dedupeBounded(src, /const RAW_SWISS_ARTICLES\s*(?::[^=]+)?=\s*\[/, ARRAY_CLOSER_RE, /^export const SWISS_ARTICLES\b/m);
+  }
+  if (base === 'seo-pages.ts') {
+    return dedupeSelfBounded(
+      src,
+      /"name":\s*"Articoli Frontaliere",\s*\n\s*"numberOfItems":\s*\d+,\s*\n\s*"itemListElement":\s*\[/,
+      /^\s*\{\s*"@type":\s*"ListItem"/,
+      /^\s*\][,;]?\s*$/,
+    );
+  }
+  if (/^blog-meta(-ch)?-(it|en|de|fr)\.ts$/.test(base)) {
+    return dedupeBounded(src, /:\s*Record<string,\s*string>\s*=\s*\{/, /^\};[ \t]*$/gm, null);
+  }
+  if (/^sitemap(-blog(-ch)?|-news)?\.xml$/.test(base)) {
+    return dedupeBounded(src, /<urlset[^>]*>/, /^<\/urlset>[ \t]*$/gm, null);
+  }
+  return null;
+}
+
+// CLI entry point: `node dedupe-growing-container-closer.mjs <file>` — used
+// by scripts/lib/resolve-append-conflicts.sh. Exits 0 always (this is a
+// best-effort repair pass; the caller's own parse/validation checks after
+// this runs are what actually gate the push).
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const file = process.argv[2];
+  const src = readFileSync(file, 'utf8');
+  const repaired = repairGrowingContainerCloser(file, src);
+  if (repaired !== null) {
+    writeFileSync(file, repaired);
+    console.log(`  🔁 ${file}: deduped premature container closer (chained rebase-conflict cycle, issue #3617-class)`);
+  }
+}

--- a/scripts/lib/resolve-append-conflicts.sh
+++ b/scripts/lib/resolve-append-conflicts.sh
@@ -77,9 +77,52 @@ resolve_append_conflicts() {
         # - Trailing comma before closing bracket
         # - Missing comma between nested objects (}\n  {)
         # - Duplicate keys (both sides added at same insertion point)
+        # - Duplicated root closer (issue #3617): when THIS SAME file hits a
+        #   second (or later) rebase-conflict cycle inside one push's retry
+        #   loop (git-push-with-retry.sh --in-place-resolver-cmd re-runs this
+        #   resolver once per cycle, up to 4 times), each cycle's conflict
+        #   hunk independently ends at the container's closing token, so
+        #   "keep both sides" can leave the root '}'/']' twice, e.g.:
+        #     { "a": 1, "b": 2 }\n  "c": 3\n }
+        #   stripPrematureRootCloses() below drops every root-depth closer
+        #   except the last one (bracket-depth tracked, so legitimate NESTED
+        #   closers are left untouched) before the comma fixups run.
         node -e "
           const fs = require('fs');
           let s = fs.readFileSync('$file','utf8');
+          function stripPrematureRootCloses(src) {
+            const closerFor = { '{': '}', '[': ']' };
+            const m = src.match(/\S/);
+            if (!m) return src;
+            const rootClose = closerFor[src[m.index]];
+            if (!rootClose) return src;
+            let depth = 0, inString = false, escape = false;
+            const rootCloseIdx = [];
+            for (let i = 0; i < src.length; i++) {
+              const c = src[i];
+              if (inString) {
+                if (escape) escape = false;
+                else if (c === '\\\\') escape = true;
+                else if (c === '\"') inString = false;
+                continue;
+              }
+              if (c === '\"') { inString = true; continue; }
+              if (c === '{' || c === '[') { depth++; continue; }
+              if (c === '}' || c === ']') {
+                if (depth === 0) { rootCloseIdx.push(i); continue; }
+                depth--;
+                if (depth === 0) rootCloseIdx.push(i);
+              }
+            }
+            if (rootCloseIdx.length <= 1) return src;
+            const drop = new Set(rootCloseIdx.slice(0, -1));
+            let out = '';
+            for (let i = 0; i < src.length; i++) {
+              if (!drop.has(i)) out += src[i];
+            }
+            return out;
+          }
+          s = stripPrematureRootCloses(s);
           // Fix double commas
           s = s.replace(/,(\s*),/g, ',\$1');
           // Fix trailing comma before closing bracket/brace

--- a/scripts/lib/resolve-append-conflicts.sh
+++ b/scripts/lib/resolve-append-conflicts.sh
@@ -169,9 +169,21 @@ resolve_append_conflicts() {
           }
           const merged = [...ids].map((s) => \`'\${s}'\`).join(', ');
           const replacement = \`export const ALL_BLOG_ARTICLE_IDS: BlogArticleId[] = [\${merged}];\`;
+          // Remove the OTHER (non-first) duplicate declarations using their
+          // ORIGINAL captured offsets, back-to-front so an earlier removal
+          // never shifts a not-yet-processed offset (including \`first\`,
+          // which is always leftmost and is handled last, once nothing
+          // before it can shift). Do NOT re-scan the mutated string with
+          // \`listRx\` here (issue #3617): the merged \`replacement\` we are
+          // about to splice in is syntactically identical to what the regex
+          // matches, so a global re-scan would match — and delete — the
+          // declaration we just inserted, silently dropping every id.
+          for (let i = listMatches.length - 1; i > 0; i--) {
+            const m = listMatches[i];
+            src = src.slice(0, m.index) + src.slice(m.index + m[0].length);
+          }
           const first = listMatches[0];
           src = src.slice(0, first.index) + replacement + src.slice(first.index + first[0].length);
-          src = src.replace(listRx, '');
           console.log('  🔁 Merged ' + listMatches.length + ' ALL_BLOG_ARTICLE_IDS declarations into one (' + ids.size + ' ids)');
         }
         // Merge duplicate \`type _BlogId<N> = '…' | …;\` declarations

--- a/scripts/lib/resolve-append-conflicts.sh
+++ b/scripts/lib/resolve-append-conflicts.sh
@@ -8,16 +8,22 @@
 # same insertion point, git marks the spot as a conflict; both additions are
 # valid and must be kept. This helper:
 #   1. Strips conflict markers, keeping content from BOTH sides.
-#   2. Repairs JSON files that lose commas during marker removal.
-#   3. Dedupes single-declaration conflicts in routerBlogData.ts and router.ts
+#   2. Repairs a duplicated root closer left by a chained rebase-conflict
+#      cycle (issue #3617-class) in the non-JSON growing-container siblings —
+#      blog-articles-data.ts, swiss-articles-data.ts, seo-pages.ts,
+#      blog-meta-*.ts, sitemap*.xml — via
+#      scripts/lib/dedupe-growing-container-closer.mjs.
+#   3. Repairs JSON files that lose commas during marker removal (including
+#      the JSON-shaped version of the same duplicated-root-closer corruption).
+#   4. Dedupes single-declaration conflicts in routerBlogData.ts and router.ts
 #      (`export const ALL_BLOG_ARTICLE_IDS = [...]`, `type _BlogId<N> = …`).
-#   4. Validates BOTH article registries (blog-articles-data.ts AND the SVIZZERA
+#   5. Validates BOTH article registries (blog-articles-data.ts AND the SVIZZERA
 #      sibling swiss-articles-data.ts) for duplicate / merged article entries.
-#   5. Generic backstop: every conflicted .ts/.tsx must still parse and be free
+#   6. Generic backstop: every conflicted .ts/.tsx must still parse and be free
 #      of duplicate object keys (a mid-entry conflict boundary fuses two entries
 #      into one object — e.g. seo-blog-ch.ts dup keys, seo-pages.ts missing
 #      comma — which previously slipped through and broke the deploy build).
-#   6. Final cross-file integrity gate (scripts/ci/validate-article-append-integrity.mjs):
+#   7. Final cross-file integrity gate (scripts/ci/validate-article-append-integrity.mjs):
 #      catches the two corruption shapes that stay syntactically valid and so
 #      slip past step 5 — a duplicate localized slug in SWISS_SLUGS (REVERSE_SWISS
 #      collision) OR BLOG_SLUGS/FRONTALIERE (REVERSE_BLOG collision), and a fused
@@ -65,6 +71,20 @@ resolve_append_conflicts() {
       echo "  ❌ $file: conflict markers still present after resolution"
       ALL_RESOLVED=false
       continue
+    fi
+
+    # Repair duplicated root-closer growing-container corruption (issue
+    # #3617-class). The JSON-only fix above doesn't cover the non-JSON
+    # append-only siblings hit by the SAME chained-rebase-cycle failure mode
+    # (blog-articles-data.ts, swiss-articles-data.ts, seo-pages.ts,
+    # blog-meta-*.ts, sitemap*.xml) — see
+    # scripts/lib/dedupe-growing-container-closer.mjs for the per-target
+    # anchor-bounded repair. No-ops (file untouched) for anything else.
+    # Guarded on file existence like the integrity gate below: this script
+    # is also exercised from throwaway temp repos in tests, whose cwd has
+    # no `scripts/` tree at all.
+    if [ -f scripts/lib/dedupe-growing-container-closer.mjs ]; then
+      node scripts/lib/dedupe-growing-container-closer.mjs "$file"
     fi
 
     # Basic syntax check for JSON files

--- a/tests/dedupe-growing-container-closer.test.ts
+++ b/tests/dedupe-growing-container-closer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression coverage for the PR #3622 review finding: the issue #3617
+ * duplicated-root-closer repair only covered JSON. The SAME chained
+ * rebase-conflict-cycle corruption shape hits the non-JSON append-only
+ * siblings whose insertion anchors on the container's own closing token —
+ * blog-articles-data.ts, swiss-articles-data.ts, seo-pages.ts,
+ * blog-meta-*.ts, sitemap*.xml. This locks in
+ * scripts/lib/dedupe-growing-container-closer.mjs's per-target repair.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { dedupeBounded, dedupeSelfBounded, repairGrowingContainerCloser } from '../scripts/lib/dedupe-growing-container-closer.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI_SCRIPT = path.join(ROOT, 'scripts', 'lib', 'dedupe-growing-container-closer.mjs');
+
+const cleanupDirs: string[] = [];
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('repairGrowingContainerCloser — blog-articles-data.ts (satisfies-suffixed closer)', () => {
+  it('drops the premature `] satisfies Article[];` and keeps the true final one', () => {
+    const src = [
+      "const RAW_ARTICLES = [",
+      "  { id: 'a1', title: 'One' },",
+      "] satisfies Article[];",
+      "  { id: 'a2', title: 'Two' },",
+      "] satisfies Article[];",
+      '',
+      'export const ARTICLES: Article[] = RAW_ARTICLES.map((a) => ({ ...a, image: cdnBlogImage(a.image) }));',
+      '',
+    ].join('\n');
+
+    const out = repairGrowingContainerCloser('blog-articles-data.ts', src);
+    expect(out).not.toBeNull();
+    expect((out as string).match(/\] satisfies Article\[\];/g)?.length).toBe(1);
+    expect(out).toContain("{ id: 'a1', title: 'One' },");
+    expect(out).toContain("{ id: 'a2', title: 'Two' },");
+    expect(out).toContain('export const ARTICLES');
+  });
+
+  it('returns null when there is only one closer (nothing to repair)', () => {
+    const src = ["const RAW_ARTICLES = [", "  { id: 'a1' },", "] satisfies Article[];", '', 'export const ARTICLES: Article[] = RAW_ARTICLES;', ''].join(
+      '\n',
+    );
+    expect(repairGrowingContainerCloser('blog-articles-data.ts', src)).toBeNull();
+  });
+});
+
+describe('repairGrowingContainerCloser — swiss-articles-data.ts (plain `];` closer)', () => {
+  it('drops the premature plain `];` and keeps the true final one', () => {
+    const src = [
+      "const RAW_SWISS_ARTICLES: Article[] = [",
+      "  { id: 's1' },",
+      '];',
+      "  { id: 's2' },",
+      '];',
+      '',
+      'export const SWISS_ARTICLES: Article[] = RAW_SWISS_ARTICLES.map((a) => ({ ...a, image: cdnBlogImage(a.image) }));',
+      '',
+    ].join('\n');
+
+    const out = repairGrowingContainerCloser('swiss-articles-data.ts', src);
+    expect(out).not.toBeNull();
+    expect((out as string).match(/^\];[ \t]*$/gm)?.length).toBe(1);
+    expect(out).toContain("{ id: 's1' },");
+    expect(out).toContain("{ id: 's2' },");
+  });
+});
+
+describe('repairGrowingContainerCloser — blog-meta-*.ts (`};` object closer)', () => {
+  it('drops the premature `};` for the Record<string,string> meta map', () => {
+    const src = [
+      "const blogMetaIt: Record<string, string> = {",
+      "  'article-1': 'Title one',",
+      '};',
+      "  'article-2': 'Title two',",
+      '};',
+      '',
+      'export default blogMetaIt;',
+      '',
+    ].join('\n');
+
+    const out = repairGrowingContainerCloser('blog-meta-it.ts', src);
+    expect(out).not.toBeNull();
+    expect((out as string).match(/^\};[ \t]*$/gm)?.length).toBe(1);
+    expect(out).toContain("'article-1': 'Title one',");
+    expect(out).toContain("'article-2': 'Title two',");
+    expect(out).toContain('export default blogMetaIt;');
+  });
+});
+
+describe('repairGrowingContainerCloser — sitemap*.xml (`</urlset>` root closer)', () => {
+  it('drops the premature `</urlset>` and keeps the true final one', () => {
+    const src = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      '<url><loc>https://frontaliereticino.ch/blog/a1/</loc></url>',
+      '</urlset>',
+      '<url><loc>https://frontaliereticino.ch/blog/a2/</loc></url>',
+      '</urlset>',
+      '',
+    ].join('\n');
+
+    const out = repairGrowingContainerCloser('sitemap-blog.xml', src);
+    expect(out).not.toBeNull();
+    expect((out as string).match(/<\/urlset>/g)?.length).toBe(1);
+    expect(out).toContain('blog/a1/');
+    expect(out).toContain('blog/a2/');
+  });
+});
+
+describe('repairGrowingContainerCloser — seo-pages.ts (self-bounded ItemList closer)', () => {
+  it('drops the premature itemListElement `]` and keeps the true final one', () => {
+    const src = [
+      '"name": "Articoli Frontaliere",',
+      '"numberOfItems": 2,',
+      '"itemListElement": [',
+      '  { "@type": "ListItem", "position": 1 },',
+      '],',
+      '  { "@type": "ListItem", "position": 2 },',
+      '],',
+      'other unrelated trailing content',
+      '',
+    ].join('\n');
+
+    const out = repairGrowingContainerCloser('seo-pages.ts', src);
+    expect(out).not.toBeNull();
+    expect((out as string).match(/^\][,;]?\s*$/gm)?.length).toBe(1);
+    expect(out).toContain('"position": 1');
+    expect(out).toContain('"position": 2');
+    expect(out).toContain('other unrelated trailing content');
+  });
+});
+
+describe('repairGrowingContainerCloser — no-op for unrelated files', () => {
+  it('returns null for a file name it does not recognize', () => {
+    expect(repairGrowingContainerCloser('router.ts', 'export const X = 1;\n')).toBeNull();
+  });
+});
+
+describe('dedupeBounded / dedupeSelfBounded — direct unit coverage', () => {
+  it('dedupeBounded returns null when openRe does not match', () => {
+    expect(dedupeBounded('no opener here', /const RAW_ARTICLES\s*=\s*\[/, /^\];$/gm, null)).toBeNull();
+  });
+
+  it('dedupeSelfBounded returns null when openRe does not match', () => {
+    expect(dedupeSelfBounded('no opener here', /"itemListElement":\s*\[/, /^\{/, /^\]/)).toBeNull();
+  });
+});
+
+describe('CLI entry point', () => {
+  it('rewrites the file in place only when a repair was applied', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'dedupe-cli-'));
+    cleanupDirs.push(dir);
+
+    const dupFile = path.join(dir, 'swiss-articles-data.ts');
+    writeFileSync(
+      dupFile,
+      ["const RAW_SWISS_ARTICLES: Article[] = [", "  { id: 's1' },", '];', "  { id: 's2' },", '];', '', 'export const SWISS_ARTICLES = RAW_SWISS_ARTICLES;', ''].join(
+        '\n',
+      ),
+    );
+    execFileSync('node', [CLI_SCRIPT, dupFile], { encoding: 'utf-8' });
+    const repaired = readFileSync(dupFile, 'utf-8');
+    expect(repaired.match(/^\];[ \t]*$/gm)?.length).toBe(1);
+
+    const cleanFile = path.join(dir, 'router.ts');
+    const cleanContent = "export const ALL_BLOG_ARTICLE_IDS: string[] = ['a'];\n";
+    writeFileSync(cleanFile, cleanContent);
+    execFileSync('node', [CLI_SCRIPT, cleanFile], { encoding: 'utf-8' });
+    expect(readFileSync(cleanFile, 'utf-8')).toBe(cleanContent);
+  });
+});

--- a/tests/resolve-append-conflicts-idempotency.test.ts
+++ b/tests/resolve-append-conflicts-idempotency.test.ts
@@ -1,0 +1,189 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Regression coverage for GitHub issue #3617 (reviewer follow-up on PR #3613):
+// `scripts/lib/git-push-with-retry.sh` re-invokes `resolve_append_conflicts`
+// (scripts/lib/resolve-append-conflicts.sh) once per rebase-conflict cycle,
+// and PR #3613 raised the shared retry budget from 3 to 5 attempts — so a
+// single push can now drive up to 4 such cycles. This exercises the SAME
+// append-only file hitting a SECOND chained rebase conflict inside one
+// push's retry loop (a second concurrent writer landing on `origin/main`
+// while the first conflict was still being resolved) using REAL `git`
+// operations, not a hand-rolled simulation.
+//
+// Finding: it was NOT the "silently duplicates entries" shape the issue
+// speculated — git's rebase mechanics (each cycle only replays the ORIGINAL
+// local delta relative to its own parent) already prevent that. The real gap
+// was a HARD FAILURE: a second chained conflict on a flat JSON object (the
+// exact shape of data/article-source-urls.json) leaves the root `}` twice in
+// the "keep both sides" text, which the old comma-only JSON repair heuristic
+// could not fix — so `resolve_append_conflicts` returned 1, the whole push
+// aborted, and the generated article was lost (the exact "Article is LOST"
+// failure PR #3613 tried to reduce, just moved from cycle 4 to cycle 2).
+
+const RESOLVER = path.resolve(__dirname, '..', 'scripts', 'lib', 'resolve-append-conflicts.sh');
+
+let work: string;
+let shimBin: string | null = null;
+
+function sh(cmd: string, cwd: string): string {
+  return execFileSync('bash', ['-c', cmd], {
+    cwd,
+    encoding: 'utf-8',
+    env: shimEnv(),
+  });
+}
+
+// BSD `sed -i 'SCRIPT' file` (macOS, used by local/dev runs of this suite)
+// takes the -i argument differently than GNU sed (Linux CI runners, which is
+// what resolve-append-conflicts.sh is written for and actually ships on).
+// Shim only kicks in on darwin so CI keeps exercising the real system sed
+// unmodified.
+function shimEnv(): NodeJS.ProcessEnv {
+  if (process.platform !== 'darwin') return process.env;
+  if (!shimBin) {
+    shimBin = mkdtempSync(path.join(os.tmpdir(), 'gnusedshim-'));
+    const sedShim = path.join(shimBin, 'sed');
+    writeFileSync(
+      sedShim,
+      '#!/usr/bin/env bash\nif [ "$1" = "-i" ]; then shift; exec /usr/bin/sed -i \'\' "$@"; else exec /usr/bin/sed "$@"; fi\n',
+    );
+    chmodSync(sedShim, 0o755);
+  }
+  return { ...process.env, PATH: `${shimBin}:${process.env.PATH}` };
+}
+
+function writeJson(file: string, obj: unknown): void {
+  writeFileSync(file, JSON.stringify(obj, null, 2));
+}
+
+function readJson(cwd: string, rel: string): Record<string, string> {
+  return JSON.parse(readFileSync(path.join(cwd, rel), 'utf-8'));
+}
+
+const TARGET = 'data/article-source-urls.json';
+
+beforeEach(() => {
+  work = mkdtempSync(path.join(os.tmpdir(), 'resolve-append-'));
+  const env = { GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 'test@test', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 'test@test' };
+  Object.assign(process.env, env);
+
+  execFileSync('git', ['init', '--quiet', '-b', 'main', path.join(work, 'origin.git'), '--bare']);
+  execFileSync('git', ['clone', '--quiet', path.join(work, 'origin.git'), path.join(work, 'local')]);
+  mkdirSync(path.join(work, 'local', 'data'), { recursive: true });
+  writeJson(path.join(work, 'local', TARGET), { u0: 's0' });
+  sh('git add -A && git commit -q -m base', path.join(work, 'local'));
+  sh('git push -q origin main', path.join(work, 'local'));
+  execFileSync('git', ['clone', '--quiet', path.join(work, 'origin.git'), path.join(work, 'writer')]);
+});
+
+afterEach(() => {
+  rmSync(work, { recursive: true, force: true });
+  if (shimBin) rmSync(shimBin, { recursive: true, force: true });
+  shimBin = null;
+});
+
+// Drives exactly what scripts/lib/git-push-with-retry.sh's loop body does for
+// one rebase-conflict cycle: fetch, rebase, invoke the in-place resolver,
+// `rebase --continue`. Returns the resolver's exit status.
+function runRebaseCycle(localDir: string): number {
+  sh('git fetch -q origin main', localDir);
+  const rebase = spawnSync('git', ['rebase', 'origin/main'], { cwd: localDir, env: shimEnv() });
+  expect(rebase.status).not.toBe(0); // must actually conflict for this to be a real cycle
+
+  const resolve = spawnSync(
+    'bash',
+    ['-c', `source "${RESOLVER}" && resolve_append_conflicts && git add -A`],
+    { cwd: localDir, env: shimEnv() },
+  );
+  if (resolve.status !== 0) {
+    spawnSync('git', ['rebase', '--abort'], { cwd: localDir, env: shimEnv() });
+    return resolve.status ?? 1;
+  }
+  const cont = spawnSync('git', ['rebase', '--continue'], {
+    cwd: localDir,
+    env: { ...shimEnv(), GIT_EDITOR: ':' },
+  });
+  return cont.status ?? 1;
+}
+
+describe('resolve_append_conflicts — chained rebase-retry idempotency (issue #3617)', () => {
+  it('resolves a SECOND chained rebase conflict on the same push without corrupting or duplicating entries', () => {
+    const local = path.join(work, 'local');
+    const writer = path.join(work, 'writer');
+
+    // Local (article-generator) commit: append uLocal.
+    const localFile = path.join(local, TARGET);
+    writeJson(localFile, { ...readJson(local, TARGET), uLocal: 'sLocal' });
+    sh('git add -A && git commit -q -m "local: add uLocal"', local);
+
+    // Concurrent writer #1 lands uZ1 BEFORE local's first push attempt.
+    sh('git pull -q origin main', writer);
+    writeJson(path.join(writer, TARGET), { ...readJson(writer, TARGET), uZ1: 'sZ1' });
+    sh('git add -A && git commit -q -m "writer: add uZ1"', writer);
+    sh('git push -q origin main', writer);
+
+    // Cycle 1: first push attempt is rejected, first rebase conflict resolved.
+    const push1 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push1.status).not.toBe(0);
+    expect(runRebaseCycle(local)).toBe(0);
+    expect(readJson(local, TARGET)).toEqual({ u0: 's0', uZ1: 'sZ1', uLocal: 'sLocal' });
+
+    // Concurrent writer #2 lands uZ2 BEFORE local's second push attempt —
+    // this is what forces the SECOND chained rebase-conflict cycle within
+    // the SAME push's retry loop (up to 4 of these are now possible per
+    // PR #3613's max-attempts change).
+    sh('git pull -q origin main', writer);
+    writeJson(path.join(writer, TARGET), { ...readJson(writer, TARGET), uZ2: 'sZ2' });
+    sh('git add -A && git commit -q -m "writer: add uZ2"', writer);
+    sh('git push -q origin main', writer);
+
+    const push2 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push2.status).not.toBe(0);
+
+    // This is the regression this test locks in: before the fix, this
+    // second cycle's resolver returned 1 (JSON still invalid — a duplicated
+    // root `}` from "keep both sides" that the old comma-only repair
+    // couldn't fix), aborting the whole push and losing the article.
+    expect(runRebaseCycle(local)).toBe(0);
+
+    const push3 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push3.status).toBe(0);
+
+    const final = readJson(local, TARGET);
+    expect(final).toEqual({ u0: 's0', uZ1: 'sZ1', uZ2: 'sZ2', uLocal: 'sLocal' });
+    // Explicit "no duplicate keys" check on the raw committed text, since a
+    // duplicate-key JSON object would still parse (JSON.parse silently keeps
+    // the LAST occurrence), masking the corruption from the equality check
+    // above alone.
+    const raw = execFileSync('git', ['show', 'HEAD:' + TARGET], { cwd: local, encoding: 'utf-8' });
+    const keys = [...raw.matchAll(/^\s*"([^"]+)":/gm)].map((m) => m[1]);
+    expect(keys.length).toBe(new Set(keys).size);
+  });
+
+  it('still resolves an ordinary single-cycle conflict (no regression to the common case)', () => {
+    const local = path.join(work, 'local');
+    const writer = path.join(work, 'writer');
+
+    writeJson(path.join(local, TARGET), { ...readJson(local, TARGET), uLocal: 'sLocal' });
+    sh('git add -A && git commit -q -m "local: add uLocal"', local);
+
+    sh('git pull -q origin main', writer);
+    writeJson(path.join(writer, TARGET), { ...readJson(writer, TARGET), uZ1: 'sZ1' });
+    sh('git add -A && git commit -q -m "writer: add uZ1"', writer);
+    sh('git push -q origin main', writer);
+
+    const push1 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push1.status).not.toBe(0);
+    expect(runRebaseCycle(local)).toBe(0);
+
+    const push2 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push2.status).toBe(0);
+
+    expect(readJson(local, TARGET)).toEqual({ u0: 's0', uZ1: 'sZ1', uLocal: 'sLocal' });
+  });
+});

--- a/tests/scripts/ai-models-token-estimate-divisor.test.ts
+++ b/tests/scripts/ai-models-token-estimate-divisor.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { estimateRequestTokens } from '../../scripts/lib/ai-models.mjs';
+
+/**
+ * Regression lock for issue #3618 item 1 (reviewer follow-up on PR #3601's
+ * chars/4 → chars/3.5 token-estimate divisor tightening).
+ *
+ * The concern: tightening the divisor raises EVERY model's estimated token
+ * count uniformly, so a model whose typical production prompt sits near its
+ * own MODEL_MAX_REQUEST_TOKENS cap could newly get skip-guarded when it
+ * previously wasn't — a false positive that would cause unnecessary fallback
+ * churn.
+ *
+ * Audited by sweeping every model in DEFAULT_CHAIN (see ai-models.mjs's
+ * estimateRequestTokens docstring for the full writeup): old (chars/4) vs new
+ * (chars/3.5) only disagree in a narrow per-cap window — (12251, 14000]
+ * chars for 4000-token caps, (26251, 30000] chars for 8000-token caps. At the
+ * issue's cited "typical production prompt" size (~8000-10000 chars) neither
+ * divisor skip-guards ANY model in the chain: the estimate stays far below
+ * even the tightest known cap (4000). This test pins that finding so a future
+ * change to SAFETY_MARGIN or the divisor can't silently regress it.
+ */
+describe('estimateRequestTokens — divisor tightening safety (issue #3618 item 1)', () => {
+  const TIGHTEST_KNOWN_CAP = 4000; // MODEL_MAX_REQUEST_TOKENS' lowest entry (o1/gpt-4o-mini/DeepSeek family)
+
+  function messagesOfChars(chars: number) {
+    return [{ role: 'user', content: 'x'.repeat(chars) }];
+  }
+
+  it('stays well under the tightest known model cap at the realistic production prompt range (8000-10000 chars)', () => {
+    for (const chars of [8000, 9000, 10000]) {
+      const est = estimateRequestTokens(messagesOfChars(chars));
+      expect(est).toBeLessThan(TIGHTEST_KNOWN_CAP);
+    }
+  });
+
+  it('pins the chars/3.5 + 500 formula exactly (regression guard on the divisor value itself)', () => {
+    expect(estimateRequestTokens(messagesOfChars(3500))).toBe(1500); // 3500/3.5 + 500
+    expect(estimateRequestTokens(messagesOfChars(7000))).toBe(2500); // 7000/3.5 + 500
+    expect(estimateRequestTokens(messagesOfChars(35000))).toBe(10500); // 35000/3.5 + 500
+  });
+
+  it('matches the audited crossover boundary for an 8000-token cap (GitHub Models / Groq provider default)', () => {
+    const cap = 8000;
+    // (cap - 500) * 3.5 = 26250 chars is the exact boundary: at or below it,
+    // the estimate is <= cap (would NOT be skip-guarded); one char above it
+    // crosses into skip territory.
+    expect(estimateRequestTokens(messagesOfChars(26250))).toBe(cap);
+    expect(estimateRequestTokens(messagesOfChars(26251))).toBeGreaterThan(cap);
+  });
+
+  it('matches the audited crossover boundary for a 4000-token cap (o1 / gpt-4o-mini / DeepSeek family)', () => {
+    const cap = 4000;
+    // (cap - 500) * 3.5 = 12250 chars.
+    expect(estimateRequestTokens(messagesOfChars(12250))).toBe(cap);
+    expect(estimateRequestTokens(messagesOfChars(12251))).toBeGreaterThan(cap);
+  });
+
+  it('confirms the divisor tightening only newly-skips prompts that were ALREADY over cap under a realistic tokenizer ratio', () => {
+    // The motivating incident (run 28732970228): a 29140-char prompt whose
+    // real NVIDIA tokenizer count was 8771 tokens (real ratio ~3.32
+    // chars/token) against an 8000-token cap — genuinely over, regardless of
+    // divisor. The old chars/4 estimate (7785) wrongly passed it through;
+    // the new chars/3.5 estimate (8826) correctly flags it.
+    const chars = 29140;
+    const oldEstimate = Math.ceil(chars / 4) + 500;
+    const newEstimate = estimateRequestTokens(messagesOfChars(chars));
+    const realTokens = 8771;
+    const cap = 8000;
+    expect(oldEstimate).toBeLessThanOrEqual(cap); // old divisor: false negative (wrongly passes)
+    expect(newEstimate).toBeGreaterThan(cap); // new divisor: correctly skips
+    expect(realTokens).toBeGreaterThan(cap); // ground truth: request really was too large
+  });
+});

--- a/tests/scripts/llm-json-repair.test.ts
+++ b/tests/scripts/llm-json-repair.test.ts
@@ -191,6 +191,20 @@ describe('fixJsonStringBody', () => {
     expect(parsed.c).toBe(1);
   });
 
+  // Regression lock for the exact issue #3618 item 2 repro shape
+  // (imagePrompt/imageAlt, the real article-schema field pair this bug hits
+  // in production) — the generic 'a'/'b' test above already covers the
+  // mechanism, this pins the literal cited shape so it can't silently
+  // regress under a future refactor of either field's schema.
+  it('does not corrupt imagePrompt/imageAlt when a markdown-bold run precedes a stray unescaped quote inside imagePrompt (issue #3618 item 2 exact repro)', () => {
+    const broken =
+      '{"imagePrompt":"Un **famoso** spot di pesca "vicino al lago".","imageAlt":{"it":"Vista panoramica"}}';
+    const repaired = fixJsonStringBody(broken, { fixAsterisks: true });
+    const parsed = JSON.parse(repaired);
+    expect(parsed.imagePrompt).toBe('Un **famoso** spot di pesca "vicino al lago".');
+    expect(parsed.imageAlt).toEqual({ it: 'Vista panoramica' });
+  });
+
   // Regression: scanValueEnd() treated '{'/'[' as ending the value immediately
   // after the opening bracket instead of finding the matching close. That made
   // the lookahead wrongly reject a preceding string field's real closing quote

--- a/tests/scripts/resolve-append-conflicts-rebase-idempotency.test.ts
+++ b/tests/scripts/resolve-append-conflicts-rebase-idempotency.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression lock for follow-up issue #3617 (adversarial-check item on
+ * PR #3613): "Verify `resolve_append_conflicts` is idempotent across
+ * multiple rebase-retry cycles in the same push."
+ *
+ * `scripts/lib/git-push-with-retry.sh`'s retry loop can, in the worst case,
+ * hit a rebase conflict on more than one loop iteration within the same
+ * push (a fresh concurrent commit lands on `origin` again while we were
+ * resolving/pushing the previous conflict). Each conflicting iteration
+ * re-invokes `resolve_append_conflicts` (via `--in-place-resolver-cmd`)
+ * against the CURRENT rebase, so the open question was whether repeated
+ * invocation across cycles could duplicate/accumulate content instead of
+ * cleanly converging.
+ *
+ * This test drives the REAL `scripts/lib/resolve-append-conflicts.sh`
+ * (sourced, unmodified) through two SEQUENTIAL rebase-conflict cycles
+ * against a real temp git repo — simulating loop iteration N (resolve,
+ * `rebase --continue`) followed by loop iteration N+1 hitting a NEW
+ * conflict from a second concurrent writer — and asserts the final,
+ * pushed state contains every contributed id exactly once with a single
+ * surviving `ALL_BLOG_ARTICLE_IDS` declaration.
+ *
+ * Finding: no bug. Each rebase cycle's diff is computed relative to the
+ * immediately-preceding (already-resolved) commit, not replayed from the
+ * push's original starting point, so a later cycle only ever reconciles
+ * genuinely NEW conflicting content — it never re-processes a hunk an
+ * earlier cycle already resolved. The `ALL_BLOG_ARTICLE_IDS` merge itself
+ * also de-dupes via a `Set`, so even if the same id were seen twice it
+ * would not be duplicated in the output. This test locks that behavior.
+ *
+ * Environment note: `resolve-append-conflicts.sh` calls `sed -i 'EXPR' file`
+ * (the GNU form — no space-less suffix). BSD sed (macOS, used by local dev)
+ * requires the backup-suffix argument even when empty (`-i ''`), so the
+ * unmodified script's sed calls fail silently on macOS. Rather than patch
+ * the production script (out of scope for this issue, and CI always runs
+ * on Linux/GNU sed), the tests below prepend a tiny PATH-only `sed` shim
+ * that normalizes just that one call shape when the system `sed` is BSD —
+ * it is inert on Linux (GNU sed already accepts the unmodified call).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const RESOLVER_SCRIPT = path.join(ROOT, 'scripts', 'lib', 'resolve-append-conflicts.sh');
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Creates the PATH-only BSD/GNU `sed -i` normalizing shim (see file header). */
+function makeSedShimDir(): string {
+  const shimDir = mkdtempSync(path.join(tmpdir(), 'sed-shim-'));
+  const shimPath = path.join(shimDir, 'sed');
+  writeFileSync(
+    shimPath,
+    [
+      '#!/usr/bin/env bash',
+      '# Test-only shim: normalize `sed -i EXPR file` (GNU form, no suffix) so it',
+      "# also works under BSD sed, which requires the (possibly empty) in-place",
+      '# backup-suffix argument. Inert on Linux/GNU sed (the common case in CI).',
+      'if [ "$1" = "-i" ] && ! /usr/bin/sed --version >/dev/null 2>&1; then',
+      '  shift',
+      "  exec /usr/bin/sed -i '' \"$@\"",
+      'fi',
+      'exec /usr/bin/sed "$@"',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(shimPath, 0o755);
+  return shimDir;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+function initRepoUser(cwd: string): void {
+  git(['config', 'user.email', 'test@example.com'], cwd);
+  git(['config', 'user.name', 'Test Writer'], cwd);
+  git(['config', 'commit.gpgsign', 'false'], cwd);
+}
+
+/** Runs `source resolve-append-conflicts.sh && resolve_append_conflicts` for real. */
+function runResolver(cwd: string, pathWithShim: string): { status: number; output: string } {
+  try {
+    const output = execFileSync('bash', ['-c', `source '${RESOLVER_SCRIPT}' && resolve_append_conflicts`], {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: `${pathWithShim}:${process.env.PATH}` },
+    });
+    return { status: 0, output };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { status: err.status ?? -1, output: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+function continueRebase(cwd: string): void {
+  execFileSync('git', ['rebase', '--continue'], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, GIT_EDITOR: ':' },
+  });
+}
+
+const ROUTER_FIXTURE_BASE = ["export type BlogArticleId = string;", "export const ALL_BLOG_ARTICLE_IDS: BlogArticleId[] = ['base-1'];", ""].join(
+  '\n',
+);
+
+function withIds(ids: string[]): string {
+  return [
+    'export type BlogArticleId = string;',
+    `export const ALL_BLOG_ARTICLE_IDS: BlogArticleId[] = [${ids.map((id) => `'${id}'`).join(', ')}];`,
+    '',
+  ].join('\n');
+}
+
+describe('resolve_append_conflicts — no-op guard when nothing is conflicted', () => {
+  it('returns success without touching the tree on a clean repo (early-return guard)', () => {
+    const repoDir = mkdtempSync(path.join(tmpdir(), 'resolve-conflicts-clean-'));
+    cleanupDirs.push(repoDir);
+    git(['init', '-q', '-b', 'main'], repoDir);
+    initRepoUser(repoDir);
+    writeFileSync(path.join(repoDir, 'router.ts'), ROUTER_FIXTURE_BASE);
+    git(['add', '-A'], repoDir);
+    git(['commit', '-q', '-m', 'base'], repoDir);
+
+    const shimDir = makeSedShimDir();
+    cleanupDirs.push(shimDir);
+    const { status, output } = runResolver(repoDir, shimDir);
+
+    expect(status).toBe(0);
+    // The function returns immediately (no "Auto-resolving..." banner) when
+    // `git diff --name-only --diff-filter=U` finds nothing unmerged.
+    expect(output).not.toMatch(/Auto-resolving conflicts/);
+    expect(readFileSync(path.join(repoDir, 'router.ts'), 'utf-8')).toBe(ROUTER_FIXTURE_BASE);
+  });
+});
+
+describe('resolve_append_conflicts — idempotency across two sequential rebase-retry cycles', () => {
+  it('does not duplicate ids when the SAME push survives two separate conflicting rebase cycles', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'resolve-conflicts-multicycle-'));
+    cleanupDirs.push(root);
+    const shimDir = makeSedShimDir();
+    cleanupDirs.push(shimDir);
+
+    // --- origin (bare) ---
+    const originDir = path.join(root, 'origin.git');
+    mkdirSync(originDir);
+    git(['init', '-q', '--bare'], originDir);
+    git(['symbolic-ref', 'HEAD', 'refs/heads/main'], originDir);
+
+    // --- local: the "article generator" checkout with the commit to push ---
+    const localDir = path.join(root, 'local');
+    git(['clone', '-q', originDir, localDir], root);
+    initRepoUser(localDir);
+    writeFileSync(path.join(localDir, 'router.ts'), ROUTER_FIXTURE_BASE);
+    git(['add', '-A'], localDir);
+    git(['commit', '-q', '-m', 'base'], localDir);
+    git(['push', '-q', 'origin', 'main'], localDir);
+
+    // --- writer1: lands BEFORE local's first rebase attempt (cycle 1 conflict) ---
+    const writer1Dir = path.join(root, 'writer1');
+    git(['clone', '-q', originDir, writer1Dir], root);
+    initRepoUser(writer1Dir);
+    writeFileSync(path.join(writer1Dir, 'router.ts'), withIds(['base-1', 'remote-1']));
+    git(['add', '-A'], writer1Dir);
+    git(['commit', '-q', '-m', 'writer1: append remote-1'], writer1Dir);
+    git(['push', '-q', 'origin', 'main'], writer1Dir);
+
+    // local makes its own conflicting append (diverged from its OWN base, not
+    // yet aware of writer1's push) — this is the article generator's commit.
+    writeFileSync(path.join(localDir, 'router.ts'), withIds(['base-1', 'local-1']));
+    git(['add', '-A'], localDir);
+    git(['commit', '-q', '-m', 'feat(article): local-1'], localDir);
+
+    // === Cycle 1 (retry-loop iteration N): fetch + rebase -> conflict ===
+    git(['fetch', '-q', 'origin', 'main'], localDir);
+    expect(() => git(['rebase', 'origin/main'], localDir)).toThrow();
+    expect(readFileSync(path.join(localDir, 'router.ts'), 'utf-8')).toMatch(/<<<<<<</);
+
+    const cycle1 = runResolver(localDir, shimDir);
+    expect(cycle1.status, `cycle 1 resolver output:\n${cycle1.output}`).toBe(0);
+    continueRebase(localDir);
+
+    const afterCycle1 = readFileSync(path.join(localDir, 'router.ts'), 'utf-8');
+    expect(afterCycle1).not.toMatch(/<<<<<<<|=======|>>>>>>>/);
+    expect(afterCycle1.match(/export const ALL_BLOG_ARTICLE_IDS/g)?.length).toBe(1);
+    expect(afterCycle1).toContain("'base-1'");
+    expect(afterCycle1).toContain("'remote-1'");
+    expect(afterCycle1).toContain("'local-1'");
+
+    // --- writer2: lands AFTER cycle 1 resolved locally but BEFORE local's
+    // retry push lands — simulating the SAME push needing a SECOND
+    // conflicting rebase cycle (loop iteration N+1). writer2 branches off
+    // writer1's state (origin only has base+writer1 at this point). ---
+    const writer2Dir = path.join(root, 'writer2');
+    git(['clone', '-q', originDir, writer2Dir], root);
+    initRepoUser(writer2Dir);
+    writeFileSync(path.join(writer2Dir, 'router.ts'), withIds(['base-1', 'remote-1', 'remote-2']));
+    git(['add', '-A'], writer2Dir);
+    git(['commit', '-q', '-m', 'writer2: append remote-2'], writer2Dir);
+    git(['push', '-q', 'origin', 'main'], writer2Dir);
+
+    // === Cycle 2 (retry-loop iteration N+1): fetch + rebase -> conflict AGAIN ===
+    git(['fetch', '-q', 'origin', 'main'], localDir);
+    expect(() => git(['rebase', 'origin/main'], localDir)).toThrow();
+    expect(readFileSync(path.join(localDir, 'router.ts'), 'utf-8')).toMatch(/<<<<<<</);
+
+    const cycle2 = runResolver(localDir, shimDir);
+    expect(cycle2.status, `cycle 2 resolver output:\n${cycle2.output}`).toBe(0);
+    continueRebase(localDir);
+
+    // Push should now succeed (no further concurrent writers).
+    git(['push', '-q', 'origin', 'main'], localDir);
+
+    // --- Verify the FINAL state on origin from a fresh checkout ---
+    const verifyDir = path.join(root, 'verify');
+    git(['clone', '-q', originDir, verifyDir], root);
+    const finalContent = readFileSync(path.join(verifyDir, 'router.ts'), 'utf-8');
+
+    // Exactly ONE surviving declaration — the two-cycle conflict history
+    // collapsed into a single merged statement, not left as multiple
+    // fused/duplicated declarations.
+    expect(finalContent.match(/export const ALL_BLOG_ARTICLE_IDS/g)?.length).toBe(1);
+
+    const idMatch = finalContent.match(/ALL_BLOG_ARTICLE_IDS: BlogArticleId\[\] = \[([^\]]*)\];/);
+    expect(idMatch).not.toBeNull();
+    const ids = [...(idMatch?.[1].matchAll(/'([^']+)'/g) ?? [])].map((m) => m[1]);
+
+    // Every id contributed across BOTH cycles is present, and none is
+    // duplicated — the core idempotency claim under test.
+    expect(ids.sort()).toEqual(['base-1', 'local-1', 'remote-1', 'remote-2'].sort());
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
## Implementato

**#3617 — resolve_append_conflicts fails on a second chained rebase-conflict cycle within one push retry loop**
- Root cause: since PR #3613 raised `git-push-with-retry.sh`'s default max-attempts 3→5, a push can now hit 2+ chained rebase conflicts on the same append-only JSON file within one retry loop. On the *second* cycle, each side's "keep both" hunk independently includes the container's closing token, leaving a duplicated root `}`/`]` that the old comma-only regex repair in `resolve_append_conflicts` can't fix — the whole push aborts and the generated article is lost (the exact failure #3613 tried to reduce, just shifted from cycle 4 to cycle 2).
- Fix: `scripts/lib/resolve-append-conflicts.sh` — added `stripPrematureRootCloses()`, a bracket-depth-tracking, string/escape-aware scanner that removes every root-depth closing token except the last one, before the existing comma-fixup regexes run. Nested closers untouched. Single shared implementation, so it covers all 3 real callers (`generate-article.yml`, `ai-visibility-check.yml`, `revenue-monitor.yml`).
- Verified empirically, not just reasoned: `tests/resolve-append-conflicts-idempotency.test.ts` drives real `git init`/`clone`/`rebase` against a temp bare repo, forcing two chained rebase conflicts on the same file within one push's retry loop, sourcing the actual shipped script. Confirms cycle 2 now resolves (previously failed exit 1), final push succeeds, JSON valid, no duplicate keys — plus a regression case for the ordinary single-cycle conflict.
- Follow-up bug found during this same investigation (pre-existing since the function's original PR #645, unrelated to #3613): the `ALL_BLOG_ARTICLE_IDS` merge in this same script spliced its merged replacement declaration into the string, then re-scanned the now-MUTATED string with the same global regex to strip the other duplicate — which also matched (and deleted) the declaration it had just inserted, silently wiping every id on every ordinary 2-way conflict on that line. Fixed by removing the other duplicates by their originally-captured offsets, back-to-front, never re-scanning after splicing in the replacement. New `tests/scripts/resolve-append-conflicts-rebase-idempotency.test.ts` locks this.

**Review follow-up (🔴 Important) — duplicated-root-closer repair extended beyond JSON**
- Reviewer found `stripPrematureRootCloses()` above only covers `.json`, while this script's own header already lists non-JSON append-only siblings sharing the same conflict pipeline that got no repair at all for the identical duplicated-root-closer corruption: `blog-articles-data.ts` (`RAW_ARTICLES`, closes with `] satisfies Article[];`), `swiss-articles-data.ts` (`RAW_SWISS_ARTICLES`, closes with plain `];`), `seo-pages.ts` (ItemList block), `blog-meta-*.ts` (`Record<string, string>` maps, closes with `};`), and `sitemap*.xml` (`<urlset>...</urlset>`) — the last of these had no check of any kind, not even the generic esbuild parse guard.
- Fix: new `scripts/lib/dedupe-growing-container-closer.mjs`, wired into `resolve-append-conflicts.sh` right after conflict-marker stripping (before the JSON/router/registry/esbuild steps). Each target is repaired via an anchor-bounded scan (`dedupeBounded`/`dedupeSelfBounded`) scoped to that container's own known open/close tokens — never a whole-file bracket scan — so it can't misfire on unrelated brackets elsewhere in a large file. Keeps only the last closer occurrence, drops the earlier (premature) ones.
- New `tests/dedupe-growing-container-closer.test.ts` (10 tests): one per target file class (both closing-token variants of the article arrays, the meta-map `};`, the sitemap `</urlset>`, the self-bounded ItemList), plus no-op cases for already-clean input and unrecognized files, and a CLI round-trip check.

Closes #3617

**#3618 item 1 — token-estimate divisor (chars/4 → chars/3.5) audited across the full model chain**
- Confirmed safe, no bug: swept every model in `DEFAULT_CHAIN` across chars 4000-35000 against each model's real `MODEL_MAX_REQUEST_TOKENS`/provider cap. Old and new divisor disagree only in narrow per-cap crossover windows; at those windows the tightened divisor is the one that's *correct* (verified against real tokenizer ground truth on the motivating incident, run 28732970228, ~29140 chars: old divisor under-estimated and would have let a doomed 413 through, new divisor correctly skips). No model is newly-and-incorrectly skipped.
- Change: documentation-only addition to `estimateRequestTokens`'s docstring in `scripts/lib/ai-models.mjs` recording the audit; no logic touched. New `tests/scripts/ai-models-token-estimate-divisor.test.ts` (5 tests) pins the formula and the exact crossover boundaries.

**#3618 item 2 — llm-json-repair asterisk/quote interaction**
- Already fixed in PR 3619 (which explicitly cites "issue #3618 item 2" in its own commit) — confirmed via the existing 40-test suite plus the issue's literal repro and 2 realistic variants, all parsing correctly. Added one permanent regression test to `tests/scripts/llm-json-repair.test.ts` using the exact `imagePrompt`/`imageAlt` field-pair shape from the issue (prior coverage used generic `a`/`b` keys).

Addresses items 1 and 2 of #3618 (both items verified complete; not using a closing keyword here because #3618's title matches this repo's aggregate-follow-up pattern ("2 item deferred") — `pr-body-contract.yml` blocks that pattern on multi-item aggregates by design, since it can't verify cross-PR completeness on its own. Issue 3618 will be marked done manually post-merge via a separate evidence-citing comment, per the same path used for issue 3598.)

**Sibling sweep (Non-Negotiable #6)** — `node scripts/ci/check-sibling-patterns.mjs` flagged 5 files sharing tokens with the diff; all 5 hand-confirmed false positives (independently re-verified, not just taken on the sub-agents' word):
- `scripts/seo-audit-structural.mjs` (`rootClose`/`rootCloseIdx`): unrelated HTML `</div>` string-index lookup, not JSON depth-tracking.
- `scripts/recover-conflict-marker-slices.mjs` (`inString`): a separate, manually-invoked recovery tool for a different incident (conflict-marker-left-in-committed-slice, not the auto rebase-retry-loop this PR fixes), with its own already-idempotent balanced-object + id-dedup design — never auto-invoked more than once per push.
- `.github/workflows/smoke-test-ai-models.yml`, `scripts/set-chutes-rc.mjs`, `scripts/smoke-test-ai-models.mjs` (`DEFAULT_CHAIN`): the `ai-models.mjs` diff is comment-only and never touches `DEFAULT_CHAIN`'s definition or logic — matched only because the new docstring prose mentions the identifier by name.

## Non implementato (ancora)
- Nessuno (entrambe le issue coperte: #3617 chiusa da `Closes` in questa PR; #3618 sarà chiusa manualmente post-merge dopo verifica live, essendo un'aggregata multi-item — vedi sopra)

