### PR TITLE
fix: bundle of 5 backlog fixes (#3587, #3480, #3589, #3453, #3578)

### DIFF
--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -1477,10 +1477,29 @@ interface DetailCopy {
  * the truncatable token: word-aware {@link truncateHeadline}, never a naive
  * mid-string cut. Suffix (comune/region/brand) is always preserved — it's
  * the local-SEO signal, analogous to city in job titles.
+ *
+ * Budget and overflow check are computed on the ESCAPED length, not the raw
+ * length: `audit-title-length.mjs` measures the raw HTML source of `<title>`,
+ * which `htmlTemplate.ts` renders as `esc(title)` (one escape pass) — mirrors
+ * the `measureLength` pattern in {@link buildTitleWithBrand} /
+ * {@link composeSerpJobTitle} (`titleSuffix.ts`). A raw `&`/`<`/`>`/`"` in a
+ * crawled title (e.g. "Rock & Blues Night") expands on escape, so a title
+ * that looks in-budget pre-escape can still overflow the 66-char cap
+ * post-escape. `truncateHeadline` itself truncates on RAW code units, so an
+ * already-in-raw-budget title can still escape-overflow (a retained `&`
+ * survives truncation) — shrink the raw ceiling and retry until the escaped
+ * result fits; bounded by `budget` iterations (`truncateHeadline` degrades to
+ * `'…'` once `max` hits 0, which always measures within any budget >= 1).
+ * `Math.max(1, …)` guards a comune suffix long enough to push the budget
+ * negative, which would otherwise make `truncateHeadline` emit an empty/
+ * broken title.
  */
 function eventDetailMetaTitle(rawTitle: string, suffix: string): string {
-  const budget = TITLE_MAX_CHARS - suffix.length;
-  const title = rawTitle.length > budget ? truncateHeadline(rawTitle, budget) : rawTitle;
+  const budget = Math.max(1, TITLE_MAX_CHARS - esc(suffix).length);
+  let title = rawTitle;
+  for (let max = budget; esc(title).length > budget && max > 0; max -= 1) {
+    title = truncateHeadline(rawTitle, max);
+  }
   return `${title}${suffix}`;
 }
 

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -12,7 +12,7 @@ import os from 'node:os';
 import { Worker } from 'node:worker_threads';
 import type { Plugin } from 'vite';
 import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, EARLY_BOOT_SCRIPT, CDN_PRECONNECT_HINT } from './constants';
-import { buildSimplePage, asyncCssHeadBlock, rootShell } from './htmlTemplate';
+import { buildSimplePage, asyncCssHeadBlock, rootShell, esc as escHtml } from './htmlTemplate';
 import { railGutters } from './shared/railGutters';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { firstParsableMs } from './shared/firstParsableDate';
@@ -220,6 +220,43 @@ export function pickSearchLandingFallbackJobs<T>(
  }
  }
  return [];
+}
+
+/**
+ * Cap a search-stats-landing title ("Offerte di lavoro {name} in Svizzera"
+ * style — see the search-stats-landing block below) on a whitespace
+ * boundary, no ellipsis (per titleSuffix.ts's no-`…` policy protecting SERP
+ * CTR).
+ *
+ * Budgeted on the ESCAPED length, not the raw length: `name` comes from
+ * crawled job-title stats leaders (`topTitlesAdded30d` in
+ * data/jobs-stats.json, e.g. "Sales & Marketing"), and `htmlTemplate.ts`
+ * renders this title as `esc(title)` (one escape pass) — the same
+ * measurement `audit-title-length.mjs` applies to the raw HTML source. A raw
+ * `&`/`<`/`>`/`"` expands on escape, so a candidate that fits the raw budget
+ * can still overflow the cap once escaped. The word-boundary slice below can
+ * land within the raw budget but still overflow once escaped (a retained
+ * `&` survives the cut) — shrink the raw ceiling and retry until the escaped
+ * candidate fits. Bounded: each retry strictly decrements the ceiling, so
+ * this converges in at most `maxChars` iterations. Same class of fix as
+ * eventsSeoPagesPlugin.ts's `eventDetailMetaTitle` (#3589).
+ */
+export function capSearchStatsLandingTitle(
+ rawTitle: string,
+ maxChars: number = TITLE_MAX_CHARS,
+ measureLength: (s: string) => number = (s) => escHtml(s).length,
+): string {
+ const capAt = (max: number): string => {
+ if (rawTitle.length <= max) return rawTitle;
+ const sliced = rawTitle.slice(0, max);
+ const lastSpace = sliced.lastIndexOf(' ');
+ return lastSpace > 0 ? sliced.slice(0, lastSpace).trimEnd() : sliced.trimEnd();
+ };
+ let capped = capAt(maxChars);
+ for (let max = maxChars; measureLength(capped) > maxChars && max > 0; max -= 1) {
+ capped = capAt(max);
+ }
+ return capped;
 }
 
 /**
@@ -8305,17 +8342,12 @@ ${staticAnalyticsHtml}
  // Search-stats-landing titles wrap the keyword in locale frame
  // ("Offerte di lavoro {name} in Svizzera" / "{name} job openings in
  // Switzerland" / etc). With long compound queries the wrapped title
- // blows past TITLE_MAX_CHARS (66) and audit:title-length fails. Cap
- // the wrapped title on a whitespace boundary, no ellipsis (per
- // titleSuffix.ts no-`…` policy that protects SERP CTR).
+ // blows past TITLE_MAX_CHARS (66) and audit:title-length fails.
+ // `capSearchStatsLandingTitle` caps it on a whitespace boundary (no
+ // ellipsis) budgeted on the ESCAPED length — see its doc comment for why
+ // (crawled `name` can carry `&`/`<`/`>`/`"`, e.g. "Sales & Marketing").
  const rawTitle = copy.title(name);
- const cappedTitle = rawTitle.length > TITLE_MAX_CHARS
-   ? (() => {
-       const sliced = rawTitle.slice(0, TITLE_MAX_CHARS);
-       const lastSpace = sliced.lastIndexOf(' ');
-       return lastSpace > 0 ? sliced.slice(0, lastSpace).trimEnd() : sliced.trimEnd();
-     })()
-   : rawTitle;
+ const cappedTitle = capSearchStatsLandingTitle(rawTitle);
  const title = buildTitleWithBrand(cappedTitle);
  const description = copy.description(name, matchingJobs.length);
  const _altPairs = localeList

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -94,6 +94,7 @@ import {
   resolveBrandLogoUrl,
 } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
+import { capSearchStatsLandingTitle } from './jobsSeoPagesPlugin';
 import { renderJobBoardCommuterContext } from './shared/jobBoardCommuterContext';
 import { resolveCantonSection as sharedResolveCantonSection } from './shared/cantonSection';
 import { getCityCanton } from './shared/cantonCities';
@@ -3510,7 +3511,12 @@ export function renderCompanyCityPage(inp: CompanyCityPageInputs): string {
         : `W${weekNum} ${year}`;
     return `${cityDisplay} — ${employer} — ${qualifier}`;
   })();
-  const compactClamped = compactBase.length <= 60 ? compactBase : compactBase.slice(0, 60).replace(/[\s,—-]+$/u, '');
+  // Budget on ESCAPED length (capSearchStatsLandingTitle's default
+  // measureLength) — cityDisplay/employer are interpolated raw and can carry
+  // `&`/`<`/`>`/`"` that expand once htmlTemplate.ts's single-escape shell
+  // renders the title, same class as eventsSeoPagesPlugin.ts's
+  // eventDetailMetaTitle (#3589).
+  const compactClamped = capSearchStatsLandingTitle(compactBase, 60).replace(/[\s,—-]+$/u, '');
   const title = buildTitleWithBrand(compactClamped);
   const description = heroSummary.slice(0, 180);
 

--- a/scripts/backfill-prev-slugs-from-loss-events.mjs
+++ b/scripts/backfill-prev-slugs-from-loss-events.mjs
@@ -100,6 +100,57 @@ export function resolveRecoveryTarget(job, slug, bySuffixHash) {
   return { targetJob: job, skip: false, redirected: false };
 }
 
+/**
+ * Write a single recovered slug onto its target job, capacity-permitting.
+ *
+ * Recovered slugs are, by definition, the OLDEST entries a job ever had
+ * (they were captured long enough ago to have since fallen off history) —
+ * never the newest. Pushing them onto the tail and then cap-trimming the
+ * front (the pattern addPreviousSlugForLocale uses for live, chronologically
+ * -ordered captures) would silently evict whatever is CURRENTLY in the
+ * bucket to make room for these stale entries, i.e. recovery would
+ * manufacture brand-new losses of live slugs on every run — the exact
+ * oscillation that kept this workflow's own "Recover N previousSlugs"
+ * commits showing up as the top offending commits in the next scan (#3587).
+ * Recovery must stay capacity-permitting and non-destructive (see
+ * recover-prev-slugs.yml header: "Recovery is non-destructive — only
+ * ADDS"): skip instead of evicting once a bucket is already at cap.
+ *
+ * @param {object} targetJob – job to mutate in place.
+ * @param {string} locale – locale bucket the slug is attributed to.
+ * @param {string} slug – recovered slug value.
+ * @param {number} [cap=CAP] – max entries per bucket / flat array.
+ * @returns {{ restored: boolean, skippedAtCap: boolean }}
+ */
+export function applyRecoveredSlug(targetJob, locale, slug, cap = CAP) {
+  if (!targetJob.previousSlugsByLocale || typeof targetJob.previousSlugsByLocale !== 'object') {
+    targetJob.previousSlugsByLocale = {};
+  }
+  if (!Array.isArray(targetJob.previousSlugsByLocale[locale])) {
+    targetJob.previousSlugsByLocale[locale] = [];
+  }
+
+  let restored = false;
+  let skippedAtCap = false;
+  if (!targetJob.previousSlugsByLocale[locale].includes(slug)) {
+    if (targetJob.previousSlugsByLocale[locale].length < cap) {
+      targetJob.previousSlugsByLocale[locale].push(slug);
+      restored = true;
+    } else {
+      skippedAtCap = true;
+    }
+  }
+
+  // Also sync flat previousSlugs for legacy consumers — same
+  // non-destructive, capacity-permitting rule as above.
+  if (!Array.isArray(targetJob.previousSlugs)) targetJob.previousSlugs = [];
+  if (!targetJob.previousSlugs.includes(slug) && targetJob.previousSlugs.length < cap) {
+    targetJob.previousSlugs.push(slug);
+  }
+
+  return { restored, skippedAtCap };
+}
+
 // One-shot cache of (file → jobId → Map<slug, locale>) built lazily
 // when the first job in a file is processed. Subsequent jobs in the
 // same file reuse the cached index → 1 git-log + N git-show per FILE
@@ -185,6 +236,7 @@ function main() {
     slugsRestoredByLocale: 0,
     slugsRestoredFromHistory: 0,
     slugsRestoredFromDetection: 0,
+    slugsSkippedAtCap: 0,
     jobsMissing: 0,
   };
   const filesByName = new Map();
@@ -236,28 +288,15 @@ function main() {
           locale = detectLocaleFromSlug(slug);
           stats.slugsRestoredFromDetection++;
         }
-        // Write to previousSlugsByLocale[locale]
-        if (!targetJob.previousSlugsByLocale || typeof targetJob.previousSlugsByLocale !== 'object') {
-          targetJob.previousSlugsByLocale = {};
-        }
-        if (!Array.isArray(targetJob.previousSlugsByLocale[locale])) {
-          targetJob.previousSlugsByLocale[locale] = [];
-        }
-        if (!targetJob.previousSlugsByLocale[locale].includes(slug)) {
-          targetJob.previousSlugsByLocale[locale].push(slug);
-          if (targetJob.previousSlugsByLocale[locale].length > CAP) {
-            targetJob.previousSlugsByLocale[locale] = targetJob.previousSlugsByLocale[locale].slice(-CAP);
-          }
+        // Write the recovered slug capacity-permitting (see applyRecoveredSlug
+        // docstring for why this must never evict currently-live entries).
+        const { restored, skippedAtCap } = applyRecoveredSlug(targetJob, locale, slug, CAP);
+        if (restored) {
           changedJobIds.add(resolveJobDiffKey(targetJob));
           stats.slugsRestoredByLocale++;
         }
-        // Also sync flat previousSlugs for legacy consumers
-        if (!Array.isArray(targetJob.previousSlugs)) targetJob.previousSlugs = [];
-        if (!targetJob.previousSlugs.includes(slug)) {
-          targetJob.previousSlugs.push(slug);
-          if (targetJob.previousSlugs.length > CAP) {
-            targetJob.previousSlugs = targetJob.previousSlugs.slice(-CAP);
-          }
+        if (skippedAtCap) {
+          stats.slugsSkippedAtCap++;
         }
       }
     }
@@ -278,6 +317,7 @@ function main() {
   console.log(`  ├─ from git history:        ${stats.slugsRestoredFromHistory}`);
   console.log(`  └─ from language detection: ${stats.slugsRestoredFromDetection}`);
   console.log(`  slugs redirected (mismatch): ${stats.slugsRedirected || 0}`);
+  console.log(`  slugs skipped (bucket full): ${stats.slugsSkippedAtCap}`);
   console.log(`  jobs missing in current:     ${stats.jobsMissing}`);
 }
 

--- a/scripts/lib/canton-valais-job-parser.mjs
+++ b/scripts/lib/canton-valais-job-parser.mjs
@@ -38,6 +38,12 @@ const SN_API_URLS = [
   'https://vs.service-now.com/api/x_hdvi2_hvs_ats/ats_portal_api/jobs?sysparm_limit=100&language=fr',
 ];
 
+// SN_API_URLS[0] carries no explicit `sysparm_limit`, so we can't read the real
+// server-side page cap from its query string. Fall back to the sibling
+// endpoint's known limit as a sentinel so the truncation warning still fires
+// for that endpoint instead of silently no-op'ing (issue #3578).
+const SN_DEFAULT_PAGE_CAP = 100;
+
 /* ── Helpers ───────────────────────────────────────────────── */
 
 function normalize(value = '') {
@@ -117,6 +123,17 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
+/**
+ * Resolve the page-size cap to compare a ServiceNow listing count against.
+ * Uses the URL's own `sysparm_limit` when present; otherwise falls back to
+ * SN_DEFAULT_PAGE_CAP so the truncation warning still fires for endpoints
+ * that don't carry an explicit limit param (issue #3578).
+ */
+export function resolveServiceNowPageCap(apiUrl) {
+  const limitParam = new URL(apiUrl).searchParams.get('sysparm_limit');
+  return limitParam ? Number(limitParam) : SN_DEFAULT_PAGE_CAP;
+}
+
 /* ── Fetch + Parse ─────────────────────────────────────────── */
 
 /**
@@ -153,10 +170,11 @@ async function tryServiceNowApi() {
         });
         if (items.length > 0) {
           console.log(`   ServiceNow API returned ${items.length} items`);
-          const limitParam = new URL(apiUrl).searchParams.get('sysparm_limit');
-          if (limitParam) {
-            warnIfListingAtCap({ label: 'Canton du Valais listing', count: items.length, cap: Number(limitParam) });
-          }
+          warnIfListingAtCap({
+            label: 'Canton du Valais listing',
+            count: items.length,
+            cap: resolveServiceNowPageCap(apiUrl),
+          });
           return items;
         }
       } else {

--- a/scripts/lib/guess-job-parser.mjs
+++ b/scripts/lib/guess-job-parser.mjs
@@ -1,9 +1,14 @@
 import { JSDOM } from 'jsdom';
 import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './target-swiss-locations.mjs';
 import { isChCountry } from './ch-country-guard.mjs';
+import { getCompanyDefaults } from './crawler-location-config.mjs';
 
 export const GUESS_WORKABLE_ACCOUNT_ID = '452934';
 export const GUESS_WORKABLE_ACCOUNT_SLUG = 'guess-europe-sagl';
+
+// HQ fallback — Bioggio, canton TI. Kept local (mirrors komax-group-job-parser.mjs's
+// convention) so the canton resolvers below don't need it threaded in as a param.
+const HQ = getCompanyDefaults('guess-europe') || { city: 'Bioggio', canton: 'TI', postalCode: '6934', addressRegion: 'TI' };
 
 function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
@@ -41,6 +46,46 @@ export function isGuessTicinoWidgetJob(job = {}) {
     isChCountry(job.country) &&
     Boolean(inferSwissTargetCanton(signal) || isTargetSwissLocation(signal))
   );
+}
+
+/**
+ * Resolve the canton for a job, or signal (via null) that it should be
+ * skipped.
+ *
+ * isGuessTicinoWidgetJob() actually admits ANY TARGET_CANTON job (via
+ * inferSwissTargetCanton()/isTargetSwissLocation() over the combined
+ * city+state+department+country signal), not just Ticino, despite this
+ * crawler's Ticino-only docstring/intent — so a real, non-empty city text
+ * that itself fails to resolve to a canton must never fabricate the
+ * Bioggio HQ canton (TI) for a job that isn't verifiably there (AGENTS.md
+ * Non-Negotiable #3, mirrors clariant/swisslog/debiopharm/komax/lindt-
+ * spruengli). Only default to HQ.canton when there's no real city text at
+ * all.
+ */
+export function resolveGuessCanton(city = '') {
+  const cityText = String(city || '').trim();
+  const inferredCanton = inferAnyCanton(cityText);
+  if (inferredCanton) return inferredCanton;
+  if (cityText) return null;
+  return HQ.canton;
+}
+
+/**
+ * Pure canton-backfill decision for update-guess-jobs.mjs's postProcessJobs()
+ * (#3480, mirrors resolveDebiopharmBackfillCanton in
+ * update-debiopharm-jobs.mjs). An already-published job is never dropped
+ * here (AGENTS.md "never cut live pages without OK") — a real but
+ * unresolvable location text only earns a `needsCantonReview` flag for
+ * editorial triage; the safe-default canton itself is always still
+ * written (Non-Negotiable #3).
+ */
+export function resolveGuessBackfillCanton(locationText = '') {
+  const text = String(locationText || '').trim();
+  const inferredCanton = inferAnyCanton(text);
+  return {
+    canton: inferredCanton || HQ.canton,
+    needsCantonReview: Boolean(text && !inferredCanton),
+  };
 }
 
 export function buildGuessDetailUrl(shortcode = '') {

--- a/scripts/update-a-plus-plus-group-jobs.mjs
+++ b/scripts/update-a-plus-plus-group-jobs.mjs
@@ -249,7 +249,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-afry-jobs.mjs
+++ b/scripts/update-afry-jobs.mjs
@@ -274,7 +274,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-agie-charmilles-jobs.mjs
+++ b/scripts/update-agie-charmilles-jobs.mjs
@@ -203,7 +203,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-agroscope-jobs.mjs
+++ b/scripts/update-agroscope-jobs.mjs
@@ -218,7 +218,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-ail-jobs.mjs
+++ b/scripts/update-ail-jobs.mjs
@@ -435,15 +435,6 @@ function canonicalizeUrl(url = '') {
   }
 }
 
-function filterEmpty(obj = {}) {
-  if (!obj || typeof obj !== 'object') return {};
-  const out = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v && String(v).trim()) out[k] = v;
-  }
-  return out;
-}
-
 function jobMatchKey(job) {
   // Match by UUID from PDF URL or by slug
   const url = String(job?.url || '');
@@ -501,15 +492,14 @@ async function mergeJobs(discoveredJobs) {
         discovered.description &&
         discovered.description.length > (ex.description || '').length
       ) {
+        // Sibling of issue #3453 (Coop crawler): this used to reset
+        // descriptionByLocale to `filterEmpty(discovered.descriptionByLocale)`
+        // (source-locale only) whenever the description grew by >100 chars,
+        // discarding the safe merge computed above via mergeLocaleTextMap
+        // (which preserves existing translated locales and only fills gaps)
+        // and wiping any already-translated en/de/fr entries. The merge above
+        // already reflects the fresh source text — no separate reset needed.
         updatedJob.description = discovered.description;
-        // Clear stale locale translations when description changes significantly
-        const prevLen = (ex.description || '').length;
-        const newLen = discovered.description.length;
-        if (Math.abs(newLen - prevLen) > 100) {
-          updatedJob.descriptionByLocale = {
-            ...filterEmpty(discovered.descriptionByLocale),
-          };
-        }
       }
 
       merged.push(updatedJob);

--- a/scripts/update-ail-jobs.mjs
+++ b/scripts/update-ail-jobs.mjs
@@ -484,7 +484,7 @@ async function mergeJobs(discoveredJobs) {
         source: 'ail-lugano-crawler',
         validThrough: discovered.validThrough || ex.validThrough,
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-allianz-jobs.mjs
+++ b/scripts/update-allianz-jobs.mjs
@@ -345,7 +345,7 @@ function mergeJobs(discoveredJobs) {
       postedDate: job.postedDate || prev.postedDate,
       contractType: job.contractType || prev.contractType,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       source: job.source,
     };

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -289,7 +289,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-amag-jobs.mjs
+++ b/scripts/update-amag-jobs.mjs
@@ -336,7 +336,7 @@ function mergeJobs(discoveredJobs) {
       contractType: job.contractType || prev.contractType,
       employmentType: job.employmentType || prev.employmentType,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       source: job.source,
     };

--- a/scripts/update-ariston-jobs.mjs
+++ b/scripts/update-ariston-jobs.mjs
@@ -192,7 +192,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-artificialy-jobs.mjs
+++ b/scripts/update-artificialy-jobs.mjs
@@ -237,7 +237,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-artisa-jobs.mjs
+++ b/scripts/update-artisa-jobs.mjs
@@ -202,7 +202,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-avaloq-jobs.mjs
+++ b/scripts/update-avaloq-jobs.mjs
@@ -199,7 +199,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-axa-jobs.mjs
+++ b/scripts/update-axa-jobs.mjs
@@ -418,7 +418,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-axpo-jobs.mjs
+++ b/scripts/update-axpo-jobs.mjs
@@ -312,10 +312,14 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
+      // Issue #3453-class: never reset descriptionByLocale to a source-only
+      // map on a large content delta — sourceLocale-aware merge already
+      // refreshes the source locale while preserving translated ones.
       descriptionByLocale: mergeLocaleTextMap(
-        descChanged ? {} : prev.descriptionByLocale,
+        prev.descriptionByLocale,
         job.descriptionByLocale,
         30,
+        job.sourceLang,
       ),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       ...(descChanged ? { needsRetranslation: true } : {}),

--- a/scripts/update-banca-sempione-jobs.mjs
+++ b/scripts/update-banca-sempione-jobs.mjs
@@ -370,7 +370,7 @@ function mergeBancaSempioneJobs(discoveredJobs) {
       // Always merge locale data to preserve AI translations
       existing.slugByLocale = mergeLocaleTextMap(existing.slugByLocale, job.slugByLocale, 3);
       existing.titleByLocale = mergeLocaleTextMap(existing.titleByLocale, job.titleByLocale, 2);
-      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30);
+      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang);
       updated++;
       existingByUrl.delete(key); // track processed
     } else {

--- a/scripts/update-board-jobs.mjs
+++ b/scripts/update-board-jobs.mjs
@@ -226,7 +226,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-bosch-jobs.mjs
+++ b/scripts/update-bosch-jobs.mjs
@@ -197,7 +197,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-bps-suisse-jobs.mjs
+++ b/scripts/update-bps-suisse-jobs.mjs
@@ -282,7 +282,7 @@ function mergeJobs(discoveredJobs) {
       ...job,
       postedDate: job.postedDate || prev.postedDate,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       salaryMin: prev.salaryMin || job.salaryMin,
       salaryMax: prev.salaryMax || job.salaryMax,

--- a/scripts/update-bracco-jobs.mjs
+++ b/scripts/update-bracco-jobs.mjs
@@ -493,7 +493,7 @@ async function mergeBraccoJobs(discoveredJobs) {
         sector: discovered.sector || existing.sector,
         source: 'bracco-workday-crawler',
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-burkhalter-jobs.mjs
+++ b/scripts/update-burkhalter-jobs.mjs
@@ -282,7 +282,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-capri-holdings-jobs.mjs
+++ b/scripts/update-capri-holdings-jobs.mjs
@@ -403,7 +403,7 @@ async function mergeJobs(discoveredJobs) {
         country: 'CH',
         source: 'capri-holdings-workday-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3),
       });
       updated++;

--- a/scripts/update-casale-jobs.mjs
+++ b/scripts/update-casale-jobs.mjs
@@ -99,7 +99,7 @@ async function mergeJobs(discoveredJobs) {
       ...old,
       ...d,
       titleByLocale: mergeLocaleTextMap(old.titleByLocale, d.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang),
       slugByLocale: mergeLocaleTextMap(old.slugByLocale, d.slugByLocale, 3),
       previousSlugs: mergePreviousSlugsCapped(old.previousSlugs, d.previousSlugs, { jobId: old.id || d.id, source: 'update-casale-jobs.mjs' }),
     }); updated++; }

--- a/scripts/update-caseificio-gottardo-jobs.mjs
+++ b/scripts/update-caseificio-gottardo-jobs.mjs
@@ -474,7 +474,7 @@ async function mergeJobs(discoveredJobs) {
         sector: discovered.sector || ex.sector,
         source: 'caseificio-gottardo-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-centiel-jobs.mjs
+++ b/scripts/update-centiel-jobs.mjs
@@ -370,7 +370,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-cerbios-pharma-jobs.mjs
+++ b/scripts/update-cerbios-pharma-jobs.mjs
@@ -146,7 +146,7 @@ function mergeJobs(discoveredJobs) {
       ...job,
       postedDate: job.postedDate || prev.postedDate,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       salaryMin: prev.salaryMin || job.salaryMin,
       salaryMax: prev.salaryMax || job.salaryMax,

--- a/scripts/update-citta-di-lugano-jobs.mjs
+++ b/scripts/update-citta-di-lugano-jobs.mjs
@@ -176,7 +176,7 @@ function mergeJobs(discoveredJobs) {
       ...job,
       postedDate: job.postedDate || prev.postedDate,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       salaryMin: prev.salaryMin || job.salaryMin,
       salaryMax: prev.salaryMax || job.salaryMax,

--- a/scripts/update-cler-jobs.mjs
+++ b/scripts/update-cler-jobs.mjs
@@ -429,18 +429,15 @@ function mergeJobs(discoveredJobs) {
     }
     updated++;
 
-    const prevDesc = (prev.description || '').trim();
-    const newDesc = (discovered.description || '').trim();
-    const descChanged = newDesc.length > 0 && prevDesc.length > 0 &&
-      Math.abs(newDesc.length - prevDesc.length) > 100;
-
-    const prevLocaleDescs = descChanged ? {} : (prev.descriptionByLocale || {});
-
     const mergedJob = {
       ...prev,
       ...discovered,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, discovered.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prevLocaleDescs, discovered.descriptionByLocale, 30),
+      // Issue #3453-class: never reset descriptionByLocale to a source-only
+      // map on a large content delta — mergeLocaleTextMap's sourceLocale-aware
+      // merge already refreshes the source locale while preserving translated
+      // ones, no destructive wipe needed (mirrors update-coop-jobs.mjs).
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale || {}, discovered.descriptionByLocale, 30, discovered.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, discovered.slugByLocale, 3),
     };
     captureLostSlugs(mergedJob, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-colin-cie-jobs.mjs
+++ b/scripts/update-colin-cie-jobs.mjs
@@ -360,7 +360,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-confederazione-jobs.mjs
+++ b/scripts/update-confederazione-jobs.mjs
@@ -515,7 +515,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prevTitles, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prevDescs, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prevDescs, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prevSlugs, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-convit-jobs.mjs
+++ b/scripts/update-convit-jobs.mjs
@@ -261,7 +261,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-coop-jobs.mjs
+++ b/scripts/update-coop-jobs.mjs
@@ -43,7 +43,7 @@ import {
   assembleJobsDataset,
   readExistingCrawlerJobs,
 } from './assemble-jobs-dataset.mjs';
-import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, hasFullLocaleCoverage, normalizeSpace } from './lib/dedicated-crawler-common.mjs';
+import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, hasFullLocaleCoverage, normalizeSpace, mergeLocaleTextMap } from './lib/dedicated-crawler-common.mjs';
 import { runQualityGuards } from './lib/crawler-quality-guards.mjs';
 import {
   fetchCoopJsonLd,
@@ -621,16 +621,27 @@ async function postProcessCoopJobs() {
           if (locality) lines.push(`**Sede:** ${locality}`);
 
           const fullDesc = lines.join('\n');
-          const prevLen = (job.description || '').length;
           job.description = fullDesc;
           // Detect source language and assign to the correct locale (FRO-309)
           const descLang = detectLang(fullDesc);
-          if (job.descriptionByLocale && Math.abs(fullDesc.length - prevLen) > 100) {
-            // Significant change — reset with correct locale assignment
-            job.descriptionByLocale = { [descLang]: fullDesc };
-          } else if (job.descriptionByLocale) {
-            job.descriptionByLocale[descLang] = fullDesc;
-          }
+          // Issue #3453: this used to reset the WHOLE descriptionByLocale map
+          // to `{ [descLang]: fullDesc }` whenever the rebuilt text differed
+          // from the previously stored description by >100 chars — a bound
+          // easily crossed by incidental reformatting (footer/company/
+          // locality lines shift the assembled length) rather than a genuine
+          // rewrite of the source posting, discarding already-translated
+          // locales outright. Use the same source-locale-aware merge as the
+          // rest of the dedicated crawlers instead: only the freshly fetched
+          // locale's slot is authoritative here, every other locale keeps its
+          // existing (real) translation. `sourceContentChanged` below still
+          // flags genuine drift for retranslation, so no data needs to be
+          // destroyed up front to achieve that.
+          job.descriptionByLocale = mergeLocaleTextMap(
+            job.descriptionByLocale || {},
+            { [descLang]: fullDesc },
+            30,
+            descLang,
+          );
           // Update sourceLang to match detected language (FRO-309)
           if (descLang !== 'it') {
             job.sourceLang = descLang;

--- a/scripts/update-damiani-jobs.mjs
+++ b/scripts/update-damiani-jobs.mjs
@@ -197,7 +197,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-debiopharm-jobs.mjs
+++ b/scripts/update-debiopharm-jobs.mjs
@@ -346,6 +346,29 @@ function updateAdapterConfig(discoveredJobs) {
   console.log(`📝 Adapter ${COMPANY_KEY} updated.`);
 }
 
+/**
+ * Pure canton-backfill decision for postProcessJobs() (#3480). Given the
+ * real (already-scraped) location text of an ALREADY-published job whose
+ * `canton` field is currently missing, returns the safe-default canton to
+ * write (Non-Negotiable #3: structured data must always carry a canton —
+ * the safe default itself is never removed) plus a `needsCantonReview`
+ * flag when the location text is real but unresolvable, distinct from "no
+ * location text at all" (which safely defaults to HQ with no flag).
+ *
+ * Unlike buildDebiopharmJob's admission-time skip guard, an already-published
+ * job is never dropped/cut here (AGENTS.md "never cut live pages without
+ * OK") — the flag exists purely for editorial triage; the canton/
+ * addressRegion the job page actually shows is unchanged.
+ */
+export function resolveDebiopharmBackfillCanton(locationText = '') {
+  const text = String(locationText || '').trim();
+  const inferredCanton = inferAnyCanton(text);
+  return {
+    canton: inferredCanton || DEFAULT_CANTON,
+    needsCantonReview: Boolean(text && !inferredCanton),
+  };
+}
+
 function postProcessJobs() {
   const raw = readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS);
   const jobs = Array.isArray(raw) ? raw : [];
@@ -365,7 +388,9 @@ function postProcessJobs() {
       fixed += 1;
     }
     if (!job.canton) {
-      job.canton = inferAnyCanton(job.location || job.addressLocality || '') || DEFAULT_CANTON;
+      const { canton, needsCantonReview } = resolveDebiopharmBackfillCanton(job.location || job.addressLocality || '');
+      job.canton = canton;
+      if (needsCantonReview) job.needsCantonReview = true;
       fixed += 1;
     }
     job.country = 'CH';

--- a/scripts/update-debiopharm-jobs.mjs
+++ b/scripts/update-debiopharm-jobs.mjs
@@ -292,7 +292,7 @@ async function mergeJobs(discoveredJobs) {
         ...existingJob,
         ...discovered,
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
         previousSlugs: mergePreviousSlugsCapped(existingJob.previousSlugs, discovered.previousSlugs, { jobId: existingJob.id || discovered.id, source: 'update-debiopharm-jobs.mjs' }),
       });

--- a/scripts/update-delvitech-jobs.mjs
+++ b/scripts/update-delvitech-jobs.mjs
@@ -298,7 +298,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-dxt-jobs.mjs
+++ b/scripts/update-dxt-jobs.mjs
@@ -365,7 +365,7 @@ async function mergeDxtJobs(discoveredJobs) {
         sector: discovered.sector || existing.sector,
         source: 'dxt-careers-crawler',
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-ems-chemie-jobs.mjs
+++ b/scripts/update-ems-chemie-jobs.mjs
@@ -169,7 +169,7 @@ function mergeJobs(discoveredJobs) {
       ...job,
       postedDate: job.postedDate || prev.postedDate,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       salaryMin: prev.salaryMin || job.salaryMin,
       salaryMax: prev.salaryMax || job.salaryMax,

--- a/scripts/update-engelvoelkers-jobs.mjs
+++ b/scripts/update-engelvoelkers-jobs.mjs
@@ -283,7 +283,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-fart-jobs.mjs
+++ b/scripts/update-fart-jobs.mjs
@@ -353,7 +353,7 @@ async function mergeJobs(discoveredJobs) {
         sector: discovered.sector || ex.sector,
         source: 'fart-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-ferrovia-retica-jobs.mjs
+++ b/scripts/update-ferrovia-retica-jobs.mjs
@@ -172,7 +172,7 @@ function mergeJobs(discoveredJobs) {
       // Keep existing postedDate if discovered one is missing
       postedDate: job.postedDate || prev.postedDate,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       // Preserve salary data, sourceLang, etc. from previous runs
       salaryMin: prev.salaryMin || job.salaryMin,

--- a/scripts/update-fincons-jobs.mjs
+++ b/scripts/update-fincons-jobs.mjs
@@ -192,7 +192,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
       metadata: { ...(prev.metadata || {}), ...(job.metadata || {}) },
     };

--- a/scripts/update-fnz-jobs.mjs
+++ b/scripts/update-fnz-jobs.mjs
@@ -482,7 +482,7 @@ async function mergeFnzJobs(discoveredJobs) {
         sector: discovered.sector || existingJob.sector,
         source: 'fnz-workday-crawler',
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-galenica-jobs.mjs
+++ b/scripts/update-galenica-jobs.mjs
@@ -388,7 +388,7 @@ function mergeGalenicaJobs(discoveredJobs) {
       existing.category = job.category;
       existing.description = job.description;
       existing.descriptionIt = job.descriptionIt;
-      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30);
+      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang);
       existing.applyUrl = job.applyUrl || existing.applyUrl;
       existing.postedDate = job.postedDate || existing.postedDate;
       existing.source = job.source;

--- a/scripts/update-giorgio-armani-jobs.mjs
+++ b/scripts/update-giorgio-armani-jobs.mjs
@@ -364,7 +364,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-grace-jobs.mjs
+++ b/scripts/update-grace-jobs.mjs
@@ -550,7 +550,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-groupe-mutuel-jobs.mjs
+++ b/scripts/update-groupe-mutuel-jobs.mjs
@@ -677,7 +677,7 @@ async function mergeGroupeMutuelJobs(discoveredJobs) {
         sector: discovered.sector || existingJob.sector,
         source: 'groupe-mutuel-csod-crawler',
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-guess-jobs.mjs
+++ b/scripts/update-guess-jobs.mjs
@@ -294,7 +294,7 @@ async function mergeJobs(discoveredJobs) {
         ...existingJob,
         ...discovered,
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
         previousSlugs: mergePreviousSlugsCapped(existingJob.previousSlugs, discovered.previousSlugs, { jobId: existingJob.id || discovered.id, source: 'update-guess-jobs.mjs' }),
       });

--- a/scripts/update-guess-jobs.mjs
+++ b/scripts/update-guess-jobs.mjs
@@ -49,6 +49,8 @@ import {
   buildGuessDetailUrl,
   buildGuessApplyUrl,
   parseGuessJobDetailPayload,
+  resolveGuessCanton,
+  resolveGuessBackfillCanton,
 } from './lib/guess-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
@@ -211,7 +213,18 @@ async function fetchGuessDetail(shortcode) {
 function buildGuessJob(listing, detail) {
   const parsed = parseGuessJobDetailPayload(detail);
   const title = parsed.title || String(listing?.title || '').trim();
-  const city = parsed.city || String(listing?.city || '').trim() || 'Bioggio';
+  const rawCity = parsed.city || String(listing?.city || '').trim();
+  // Unresolved-canton skip guard (#3480 sibling — same construct already
+  // fixed for clariant/swisslog/debiopharm/komax/lindt-spruengli): resolve
+  // BEFORE the 'Bioggio' display fallback is applied, so a real-but-
+  // unresolvable city is never masked into looking like "no location text
+  // at all" and silently fabricated to the Bioggio HQ canton (TI).
+  const canton = resolveGuessCanton(rawCity);
+  if (canton === null) {
+    console.warn(`     ⚠️  Skipping unresolvable location "${rawCity}" (${title})`);
+    return null;
+  }
+  const city = rawCity || 'Bioggio';
   // Slug-only guard: `city` can be the literal "undefined"/"null" string (truthy)
   // → `-undefined` in an active slug (#952, class #900/#901). location/addressLocality
   // keep raw `city` (choke-point normalizer owns de-index).
@@ -230,9 +243,9 @@ function buildGuessJob(listing, detail) {
     companyDomain: COMPANY_DOMAIN,
     location: city,
     addressLocality: city,
-    addressRegion: inferAnyCanton(city) || DEFAULT_CANTON,
+    addressRegion: canton,
     addressCountry: 'CH',
-    canton: inferAnyCanton(city) || DEFAULT_CANTON,
+    canton,
     country: 'CH',
     employmentType: parsed.employmentType,
     contractType: parsed.employmentType,
@@ -353,7 +366,19 @@ function postProcessJobs() {
       job.companyDomain = COMPANY_DOMAIN;
       fixed += 1;
     }
-    job.canton = inferAnyCanton(job.location || job.addressLocality || '') || DEFAULT_CANTON;
+    // Unresolved-canton skip guard, backfill side (#3480 — mirrors
+    // update-debiopharm-jobs.mjs's postProcessJobs()). Canton is still
+    // recomputed unconditionally every run (unchanged prior behavior); a
+    // real-but-unresolvable location text additionally earns a
+    // `needsCantonReview` flag for editorial triage instead of silently
+    // fabricating the Bioggio HQ canton (TI) for an already-published job
+    // (AGENTS.md "never cut live pages without OK" + Non-Negotiable #3).
+    const { canton: backfillCanton, needsCantonReview } = resolveGuessBackfillCanton(job.location || job.addressLocality || '');
+    job.canton = backfillCanton;
+    if (needsCantonReview && job.needsCantonReview !== true) {
+      job.needsCantonReview = true;
+      fixed += 1;
+    }
     job.country = 'CH';
     job.addressCountry = 'CH';
     job.addressRegion = job.canton;
@@ -433,7 +458,13 @@ async function main() {
   for (const listing of listings) {
     console.log(`  📄 Processing: ${listing.title} (${listing.city})`);
     const detail = await fetchGuessDetail(listing.shortcode);
-    discoveredJobs.push(buildGuessJob(listing, detail));
+    const job = buildGuessJob(listing, detail);
+    if (!job) continue;
+    discoveredJobs.push(job);
+  }
+
+  if (discoveredJobs.length === 0) {
+    throw new Error('Guess discovery produced 0 admissible jobs after enrichment.');
   }
 
   updateAdapterConfig(discoveredJobs);

--- a/scripts/update-hamilton-jobs.mjs
+++ b/scripts/update-hamilton-jobs.mjs
@@ -372,7 +372,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-has-healthcare-jobs.mjs
+++ b/scripts/update-has-healthcare-jobs.mjs
@@ -459,7 +459,7 @@ async function mergeJobs(discoveredJobs) {
         sector: discovered.sector || ex.sector,
         source: 'has-healthcare-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-helsinn-jobs.mjs
+++ b/scripts/update-helsinn-jobs.mjs
@@ -107,7 +107,7 @@ async function mergeJobs(discoveredJobs) {
       ...old,
       ...d,
       titleByLocale: mergeLocaleTextMap(old.titleByLocale, d.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang),
       slugByLocale: mergeLocaleTextMap(old.slugByLocale, d.slugByLocale, 3),
       previousSlugs: mergePreviousSlugsCapped(old.previousSlugs, d.previousSlugs, { jobId: old.id || d.id, source: 'update-helsinn-jobs.mjs' }),
     }); updated++; }

--- a/scripts/update-hes-so-valais-jobs.mjs
+++ b/scripts/update-hes-so-valais-jobs.mjs
@@ -535,7 +535,7 @@ async function mergeHessoJobs(discoveredJobs) {
         sector: discovered.sector || existingJob.sector,
         source: 'hes-so-valais-crawler',
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-hitachi-energy-jobs.mjs
+++ b/scripts/update-hitachi-energy-jobs.mjs
@@ -308,7 +308,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-hoval-jobs.mjs
+++ b/scripts/update-hoval-jobs.mjs
@@ -268,7 +268,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-hugo-boss-jobs.mjs
+++ b/scripts/update-hugo-boss-jobs.mjs
@@ -135,7 +135,7 @@ async function mergeJobs(discoveredJobs) {
   for (const discovered of discoveredJobs) {
     const key = canonicalizeUrl(discovered.url);
     const old = existingByUrl.get(key);
-    if (old) { merged.push({ ...old, ...discovered, titleByLocale: mergeLocaleTextMap(old.titleByLocale, discovered.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, discovered.descriptionByLocale, 30), slugByLocale: mergeLocaleTextMap(old.slugByLocale, discovered.slugByLocale, 3) }); updated++; }
+    if (old) { merged.push({ ...old, ...discovered, titleByLocale: mergeLocaleTextMap(old.titleByLocale, discovered.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang), slugByLocale: mergeLocaleTextMap(old.slugByLocale, discovered.slugByLocale, 3) }); updated++; }
     else { merged.push(discovered); added++; }
   }
   const final = [...nonCompanyJobs, ...merged];

--- a/scripts/update-interroll-jobs.mjs
+++ b/scripts/update-interroll-jobs.mjs
@@ -119,7 +119,7 @@ async function mergeJobs(discoveredJobs) {
   const merged = []; let added = 0, updated = 0;
   for (const d of discoveredJobs) {
     const key = canonicalizeUrl(d.url); const old = existingByUrl.get(key);
-    if (old) { merged.push({ ...old, ...d, titleByLocale: mergeLocaleTextMap(old.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30), slugByLocale: mergeLocaleTextMap(old.slugByLocale, d.slugByLocale, 3) }); updated++; }
+    if (old) { merged.push({ ...old, ...d, titleByLocale: mergeLocaleTextMap(old.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang), slugByLocale: mergeLocaleTextMap(old.slugByLocale, d.slugByLocale, 3) }); updated++; }
     else { merged.push(d); added++; }
   }
   const final = [...nonCompanyJobs, ...merged];

--- a/scripts/update-ist-jobs.mjs
+++ b/scripts/update-ist-jobs.mjs
@@ -555,7 +555,7 @@ async function mergeIstJobs(discoveredJobs) {
         sector: discovered.sector || existingJob.sector,
         source: 'ist-inspirededu-crawler',
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-julius-baer-jobs.mjs
+++ b/scripts/update-julius-baer-jobs.mjs
@@ -203,7 +203,7 @@ async function mergeJobs(discoveredJobs) {
       ...ex,
       ...d,
       titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang),
       slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3),
       previousSlugs: mergePreviousSlugsCapped(ex.previousSlugs, d.previousSlugs, { jobId: ex.id || d.id, source: 'update-julius-baer-jobs.mjs' }),
     }); updated++; }

--- a/scripts/update-kempinski-jobs.mjs
+++ b/scripts/update-kempinski-jobs.mjs
@@ -270,7 +270,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-knowledge-lab-jobs.mjs
+++ b/scripts/update-knowledge-lab-jobs.mjs
@@ -215,7 +215,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-kronenhof-jobs.mjs
+++ b/scripts/update-kronenhof-jobs.mjs
@@ -368,7 +368,7 @@ function mergeJobs(discoveredJobs) {
       ...job,
       previousSlugs,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-lafonte-jobs.mjs
+++ b/scripts/update-lafonte-jobs.mjs
@@ -433,7 +433,7 @@ async function mergeJobs(discoveredJobs) {
         sector: discovered.sector || ex.sector,
         source: 'la-fonte-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-lafonte-jobs.mjs
+++ b/scripts/update-lafonte-jobs.mjs
@@ -393,15 +393,6 @@ function jobMatchKey(job) {
   return `${slugify(job.title)}-${COMPANY_KEY}`;
 }
 
-function filterEmpty(obj = {}) {
-  if (!obj || typeof obj !== 'object') return {};
-  const out = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v && String(v).trim()) out[k] = v;
-  }
-  return out;
-}
-
 async function mergeJobs(discoveredJobs) {
   const existing = readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS);
   const allJobs = Array.isArray(existing) ? [...existing] : [];
@@ -450,15 +441,14 @@ async function mergeJobs(discoveredJobs) {
         discovered.description &&
         discovered.description.length > (ex.description || '').length
       ) {
+        // Sibling of issue #3453 (Coop crawler): this used to reset
+        // descriptionByLocale to `filterEmpty(discovered.descriptionByLocale)`
+        // (source-locale only) whenever the description grew by >100 chars,
+        // discarding the safe merge computed above via mergeLocaleTextMap
+        // (which preserves existing translated locales and only fills gaps)
+        // and wiping any already-translated en/de/fr entries. The merge above
+        // already reflects the fresh source text — no separate reset needed.
         updatedJob.description = discovered.description;
-        // Clear stale locale translations when description changes significantly
-        const prevLen = (ex.description || '').length;
-        const newLen = discovered.description.length;
-        if (Math.abs(newLen - prevLen) > 100) {
-          updatedJob.descriptionByLocale = {
-            ...filterEmpty(discovered.descriptionByLocale),
-          };
-        }
       }
 
       merged.push(updatedJob);

--- a/scripts/update-lastminute-jobs.mjs
+++ b/scripts/update-lastminute-jobs.mjs
@@ -674,6 +674,7 @@ async function enrichFromSmartRecruitersApi(seedUrls) {
           existing.descriptionByLocale,
           { en: detail.description },
           30,
+          'en',
         );
         // Mark for re-translation so AI refreshes IT/DE/FR from the richer
         // English — either the job wasn't fully localized yet, or the SR

--- a/scripts/update-linnea-jobs.mjs
+++ b/scripts/update-linnea-jobs.mjs
@@ -279,7 +279,7 @@ async function mergeLinneaJobs(discoveredJobs) {
         sector: discovered.sector || existing.sector,
         source: 'linnea-careers-crawler',
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-lis-jobs.mjs
+++ b/scripts/update-lis-jobs.mjs
@@ -1042,7 +1042,7 @@ async function crawlArca24Direct() {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-manor-jobs.mjs
+++ b/scripts/update-manor-jobs.mjs
@@ -424,7 +424,7 @@ function mergeManorJobs(discoveredJobs) {
       existing.category = job.category;
       existing.description = job.description;
       existing.descriptionIt = job.descriptionIt;
-      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30);
+      existing.descriptionByLocale = mergeLocaleTextMap(existing.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang);
       existing.postedDate = job.postedDate || existing.postedDate;
       existing.source = job.source;
       existing.slugByLocale = mergeLocaleTextMap(existing.slugByLocale, job.slugByLocale, 3);

--- a/scripts/update-mendrisio-jobs.mjs
+++ b/scripts/update-mendrisio-jobs.mjs
@@ -627,7 +627,7 @@ async function mergeMendrisioJobs(discoveredJobs) {
         source: 'mendrisio-concorsi-crawler',
         validThrough: discovered.validThrough || existing.validThrough,
         titleByLocale: mergeLocaleTextMap(prevTitleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(prevDescByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(prevDescByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(prevSlugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-mikron-jobs.mjs
+++ b/scripts/update-mikron-jobs.mjs
@@ -221,7 +221,7 @@ async function mergeJobs(discoveredJobs) {
   for (const d of discoveredJobs) {
     const key = canonicalizeUrl(d.url);
     const ex = existingByUrl.get(key);
-    if (ex) { merged.push({ ...ex, title: d.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'mikron-html-crawler', titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3) }); updated++; }
+    if (ex) { merged.push({ ...ex, title: d.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'mikron-html-crawler', titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3) }); updated++; }
     else { merged.push(d); added++; }
   }
   for (const [url] of existingByUrl) { if (!discoveredByUrl.has(url)) removed++; }

--- a/scripts/update-mkspamp-jobs.mjs
+++ b/scripts/update-mkspamp-jobs.mjs
@@ -210,7 +210,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-mtic-jobs.mjs
+++ b/scripts/update-mtic-jobs.mjs
@@ -291,7 +291,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-oscam-jobs.mjs
+++ b/scripts/update-oscam-jobs.mjs
@@ -499,7 +499,7 @@ async function mergeJobs(discoveredJobs) {
         sector: discovered.sector || ex.sector,
         source: 'oscam-crawler',
         titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-oscam-jobs.mjs
+++ b/scripts/update-oscam-jobs.mjs
@@ -458,15 +458,6 @@ function jobMatchKey(job) {
   return `${slugify(job.title)}-${COMPANY_KEY}`;
 }
 
-function filterEmpty(obj = {}) {
-  if (!obj || typeof obj !== 'object') return {};
-  const out = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (v && String(v).trim()) out[k] = v;
-  }
-  return out;
-}
-
 async function mergeJobs(discoveredJobs) {
   const existing = readExistingCrawlerJobs(COMPANY_KEY, DATA_JOBS);
   const allJobs = Array.isArray(existing) ? [...existing] : [];
@@ -516,15 +507,14 @@ async function mergeJobs(discoveredJobs) {
         discovered.description &&
         discovered.description.length > (ex.description || '').length
       ) {
+        // Sibling of issue #3453 (Coop crawler): this used to reset
+        // descriptionByLocale to `filterEmpty(discovered.descriptionByLocale)`
+        // (source-locale only) whenever the description grew by >100 chars,
+        // discarding the safe merge computed above via mergeLocaleTextMap
+        // (which preserves existing translated locales and only fills gaps)
+        // and wiping any already-translated en/de/fr entries. The merge above
+        // already reflects the fresh source text — no separate reset needed.
         updatedJob.description = discovered.description;
-        // Clear stale locale translations when description changes significantly
-        const prevLen = (ex.description || '').length;
-        const newLen = discovered.description.length;
-        if (Math.abs(newLen - prevLen) > 100) {
-          updatedJob.descriptionByLocale = {
-            ...filterEmpty(discovered.descriptionByLocale),
-          };
-        }
       }
 
       merged.push(updatedJob);

--- a/scripts/update-pemsa-jobs.mjs
+++ b/scripts/update-pemsa-jobs.mjs
@@ -197,7 +197,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-pizzarotti-jobs.mjs
+++ b/scripts/update-pizzarotti-jobs.mjs
@@ -211,7 +211,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-postch-jobs.mjs
+++ b/scripts/update-postch-jobs.mjs
@@ -579,7 +579,7 @@ async function mergePostJobs(discoveredJobs) {
         source: 'postch-careers-crawler',
         workload: discovered.workload || existing.workload,
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-postfinance-jobs.mjs
+++ b/scripts/update-postfinance-jobs.mjs
@@ -653,7 +653,7 @@ async function mergePostFinanceJobs(discoveredJobs) {
         source: 'postfinance-careers-crawler',
         workload: discovered.workload || existingJob.workload,
         titleByLocale: mergeLocaleTextMap(existingJob.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existingJob.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existingJob.slugByLocale, discovered.slugByLocale, 3),
       };
       // Preserve needsRetranslation only if still needed

--- a/scripts/update-pwc-jobs.mjs
+++ b/scripts/update-pwc-jobs.mjs
@@ -263,7 +263,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergedSlugByLocale,
       ...(previousSlugs.length > 0 ? { previousSlugs } : {}),
     };

--- a/scripts/update-rittmeyer-jobs.mjs
+++ b/scripts/update-rittmeyer-jobs.mjs
@@ -248,7 +248,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-ruag-jobs.mjs
+++ b/scripts/update-ruag-jobs.mjs
@@ -297,7 +297,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...nextJob,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, nextJob.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, nextJob.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, nextJob.descriptionByLocale, 30, nextJob.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, nextJob.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-sintetica-jobs.mjs
+++ b/scripts/update-sintetica-jobs.mjs
@@ -183,7 +183,7 @@ async function mergeJobs(discoveredJobs) {
       ...old,
       ...d,
       titleByLocale: mergeLocaleTextMap(old.titleByLocale, d.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang),
       slugByLocale: mergeLocaleTextMap(old.slugByLocale, d.slugByLocale, 3),
       previousSlugs: mergePreviousSlugsCapped(old.previousSlugs, d.previousSlugs, { jobId: old.id || d.id, source: 'update-sintetica-jobs.mjs' }),
     }); updated++; }

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -238,7 +238,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-stadt-chur-jobs.mjs
+++ b/scripts/update-stadt-chur-jobs.mjs
@@ -346,7 +346,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-sunrise-jobs.mjs
+++ b/scripts/update-sunrise-jobs.mjs
@@ -228,7 +228,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-swiss-medical-network-jobs.mjs
+++ b/scripts/update-swiss-medical-network-jobs.mjs
@@ -212,7 +212,7 @@ async function mergeJobs(discoveredJobs) {
   for (const d of discoveredJobs) {
     const key = canonicalizeUrl(d.url);
     const ex = existingByUrl.get(key);
-    if (ex) { merged.push({ ...ex, title: d.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'swiss-medical-smartrecruiters-crawler', sourceLang: d.sourceLang || ex.sourceLang, titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3) }); updated++; }
+    if (ex) { merged.push({ ...ex, title: d.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'swiss-medical-smartrecruiters-crawler', sourceLang: d.sourceLang || ex.sourceLang, titleByLocale: mergeLocaleTextMap(ex.titleByLocale, d.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, d.slugByLocale, 3) }); updated++; }
     else { merged.push(d); added++; }
   }
   for (const [url] of existingByUrl) { if (!discoveredByUrl.has(url)) removed++; }

--- a/scripts/update-swisscom-jobs.mjs
+++ b/scripts/update-swisscom-jobs.mjs
@@ -548,7 +548,7 @@ async function mergeSwisscomJobs(discoveredJobs) {
           ? discovered.requirements
           : existing.requirements,
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         requirementsByLocale: {
           ...(existing.requirementsByLocale || {}),
           ...filterEmptyArraysMap(discovered.requirementsByLocale),

--- a/scripts/update-tarchini-group-jobs.mjs
+++ b/scripts/update-tarchini-group-jobs.mjs
@@ -236,7 +236,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-tinext-jobs.mjs
+++ b/scripts/update-tinext-jobs.mjs
@@ -357,7 +357,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-trumpf-jobs.mjs
+++ b/scripts/update-trumpf-jobs.mjs
@@ -334,7 +334,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-tsmg-jobs.mjs
+++ b/scripts/update-tsmg-jobs.mjs
@@ -197,7 +197,7 @@ function mergeJobs(discoveredJobs) {
       ...prev,
       ...job,
       titleByLocale: mergeLocaleTextMap(prev.titleByLocale, job.titleByLocale, 3),
-      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30),
+      descriptionByLocale: mergeLocaleTextMap(prev.descriptionByLocale, job.descriptionByLocale, 30, job.sourceLang),
       slugByLocale: mergeLocaleTextMap(prev.slugByLocale, job.slugByLocale, 3),
     };
     captureLostSlugs(merged, prev.slugByLocale, prev.slug, 20);

--- a/scripts/update-usi-jobs.mjs
+++ b/scripts/update-usi-jobs.mjs
@@ -826,7 +826,7 @@ async function mergeUsiJobs(discoveredJobs) {
         source: 'usi-drupal-crawler',
         // Merge locale data (keep AI-localized content, update source locales)
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/scripts/update-vir-biotechnology-jobs.mjs
+++ b/scripts/update-vir-biotechnology-jobs.mjs
@@ -154,7 +154,7 @@ async function mergeJobs(discoveredJobs) {
   for (const discovered of discoveredJobs) {
     const key = canonicalizeUrl(discovered.url);
     const ex = existingByUrl.get(key);
-    if (ex) { merged.push({ ...ex, title: discovered.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'vir-greenhouse-crawler', sourceLang: discovered.sourceLang || ex.sourceLang, titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3) }); updated++; }
+    if (ex) { merged.push({ ...ex, title: discovered.title || ex.title, company: COMPANY_NAME, companyKey: COMPANY_KEY, source: 'vir-greenhouse-crawler', sourceLang: discovered.sourceLang || ex.sourceLang, titleByLocale: mergeLocaleTextMap(ex.titleByLocale, discovered.titleByLocale, 3), descriptionByLocale: mergeLocaleTextMap(ex.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang), slugByLocale: mergeLocaleTextMap(ex.slugByLocale, discovered.slugByLocale, 3) }); updated++; }
     else { merged.push(discovered); added++; }
   }
   for (const [url] of existingByUrl) { if (!discoveredByUrl.has(url)) removed++; }

--- a/scripts/update-zambon-jobs.mjs
+++ b/scripts/update-zambon-jobs.mjs
@@ -195,7 +195,7 @@ async function mergeJobs(discoveredJobs) {
   for (const d of discoveredJobs) {
     const key = canonicalizeUrl(d.url); const old = existingByUrl.get(key);
     if (old) {
-      const mergedDescByLocale = mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30);
+      const mergedDescByLocale = mergeLocaleTextMap(old.descriptionByLocale, d.descriptionByLocale, 30, d.sourceLang);
       // Force-update Italian description when the new source is significantly richer
       if (d.description && d.description.length > (old.description || '').length * 1.5) {
         mergedDescByLocale.it = d.description;

--- a/scripts/update-zegna-jobs.mjs
+++ b/scripts/update-zegna-jobs.mjs
@@ -476,7 +476,7 @@ async function mergeZegnaJobs(discoveredJobs) {
         brand: discovered.brand || existing.brand,
         contractType: discovered.contractType || existing.contractType,
         titleByLocale: mergeLocaleTextMap(existing.titleByLocale, discovered.titleByLocale, 3),
-        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30),
+        descriptionByLocale: mergeLocaleTextMap(existing.descriptionByLocale, discovered.descriptionByLocale, 30, discovered.sourceLang),
         slugByLocale: mergeLocaleTextMap(existing.slugByLocale, discovered.slugByLocale, 3),
       };
 

--- a/tests/backfill-prev-slugs-non-destructive.test.ts
+++ b/tests/backfill-prev-slugs-non-destructive.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyRecoveredSlug } from '../scripts/backfill-prev-slugs-from-loss-events.mjs';
+
+// Regression test for issue #3587 ("previousSlugs writer regression: 5886
+// losses in 24 hours"). The scheduled "Recover Lost previousSlugs" workflow
+// (scan-prev-slug-losses.mjs + backfill-prev-slugs-from-loss-events.mjs)
+// itself turned out to be the dominant source of NEW losses: it restored
+// historically-lost slugs by pushing them onto the tail of an
+// already-at-cap `previousSlugsByLocale[locale]` / flat `previousSlugs`
+// array and then slicing to the last CAP entries — which evicted whatever
+// was CURRENTLY tracked to make room for the (much older) recovered
+// entries. Confirmed live: commit 88284dcdb5 ("Recover 1357 previousSlugs
+// across 311 jobs") wiped roche.json job roche-4da2a57c7c98's entire `it`
+// previousSlugsByLocale bucket (19 live entries incl. "roche-ch-166",
+// "roche-ch-10", ...) to make room for 20 freshly-recovered historical
+// slugs, which the next scan then re-reported as new losses — an
+// unbounded recover-then-lose oscillation.
+//
+// The fix (applyRecoveredSlug): recovery is capacity-permitting and
+// strictly additive — it skips adding a recovered slug once a bucket is
+// already at cap instead of evicting live entries to fit it in.
+describe('applyRecoveredSlug (previousSlugs recovery, #3587)', () => {
+  it('does not evict existing entries when the locale bucket is already at cap', () => {
+    const existing = Array.from({ length: 20 }, (_, i) => `roche-ch-${i}`);
+    const job = {
+      id: 'roche-4da2a57c7c98',
+      previousSlugsByLocale: { it: [...existing] },
+      previousSlugs: [...existing],
+    };
+
+    const result = applyRecoveredSlug(job, 'it', 'roche-nanjing-4mxh6m', 20);
+
+    expect(result).toEqual({ restored: false, skippedAtCap: true });
+    // Every previously-tracked entry must survive — recovery must never
+    // evict a live redirect target just to fit a recovered one.
+    expect(job.previousSlugsByLocale.it).toEqual(existing);
+    expect(job.previousSlugs).toEqual(existing);
+    expect(job.previousSlugsByLocale.it).not.toContain('roche-nanjing-4mxh6m');
+  });
+
+  it('restores a recovered slug normally when the bucket has spare capacity', () => {
+    const job = {
+      id: 'manor-c0d8a64b6096',
+      previousSlugsByLocale: { it: ['old-slug-1'] },
+      previousSlugs: ['old-slug-1'],
+    };
+
+    const result = applyRecoveredSlug(job, 'it', 'recovered-slug', 20);
+
+    expect(result).toEqual({ restored: true, skippedAtCap: false });
+    expect(job.previousSlugsByLocale.it).toEqual(['old-slug-1', 'recovered-slug']);
+    expect(job.previousSlugs).toEqual(['old-slug-1', 'recovered-slug']);
+  });
+
+  it('is idempotent for a slug already present in the bucket', () => {
+    const job = {
+      id: 'coop-ticino-abc123',
+      previousSlugsByLocale: { it: ['already-there'] },
+      previousSlugs: ['already-there'],
+    };
+
+    const result = applyRecoveredSlug(job, 'it', 'already-there', 20);
+
+    expect(result).toEqual({ restored: false, skippedAtCap: false });
+    expect(job.previousSlugsByLocale.it).toEqual(['already-there']);
+  });
+
+  it('lazily initializes previousSlugsByLocale/previousSlugs when absent', () => {
+    const job = { id: 'new-yorker-xyz' };
+
+    const result = applyRecoveredSlug(job, 'en', 'first-recovered-slug', 20);
+
+    expect(result).toEqual({ restored: true, skippedAtCap: false });
+    expect(job.previousSlugsByLocale.en).toEqual(['first-recovered-slug']);
+    expect(job.previousSlugs).toEqual(['first-recovered-slug']);
+  });
+});

--- a/tests/canton-valais-crawler.test.ts
+++ b/tests/canton-valais-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   CANTON_VALAIS_COMPANY_NAME,
   isCantonValaisJob,
   isTrustedDomain,
+  resolveServiceNowPageCap,
 } from '../scripts/lib/canton-valais-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -124,6 +125,29 @@ describe('Canton du Valais crawler parser', () => {
 
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  // ── resolveServiceNowPageCap (issue #3578) ──
+  // SN_API_URLS[0] has no `sysparm_limit` query param, so before this fix
+  // the truncation-warning guard (`if (limitParam)`) silently no-op'd for it.
+  describe('resolveServiceNowPageCap', () => {
+    it('reads the cap from an explicit sysparm_limit param', () => {
+      expect(
+        resolveServiceNowPageCap('https://vs.service-now.com/api/x_hdvi2_hvs_ats/ats_portal_api/jobs?sysparm_limit=100&language=fr'),
+      ).toBe(100);
+    });
+
+    it('respects a non-default explicit sysparm_limit value', () => {
+      expect(
+        resolveServiceNowPageCap('https://vs.service-now.com/api/x_hdvi2_hvs_ats/ats_portal_api/jobs?sysparm_limit=250'),
+      ).toBe(250);
+    });
+
+    it('falls back to the sentinel cap when sysparm_limit is absent (SN_API_URLS[0])', () => {
+      expect(
+        resolveServiceNowPageCap('https://vs.service-now.com/api/x_hdvi2_hvs_ats/ats_portal/jobs?language=fr'),
+      ).toBe(100);
     });
   });
 });

--- a/tests/debiopharm-job-parser.test.ts
+++ b/tests/debiopharm-job-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseDebiopharmJobDetailPayload } from '../scripts/lib/debiopharm-job-parser.mjs';
-import { buildDebiopharmJob } from '../scripts/update-debiopharm-jobs.mjs';
+import { buildDebiopharmJob, resolveDebiopharmBackfillCanton } from '../scripts/update-debiopharm-jobs.mjs';
 
 describe('debiopharm-job-parser', () => {
   // ── parseDebiopharmJobDetailPayload.inferredCanton (unresolved-canton skip guard — task-critical) ──
@@ -72,6 +72,29 @@ describe('debiopharm-job-parser', () => {
       );
       expect(job).not.toBeNull();
       expect(job.addressRegion).toBe('VD');
+    });
+  });
+
+  // ── resolveDebiopharmBackfillCanton (postProcessJobs() backfill guard —
+  // #3480, the item this issue was filed for). Unlike buildDebiopharmJob's
+  // admission-time skip, an already-published job is never dropped here: a
+  // real-but-unresolvable location earns a needsCantonReview flag, the
+  // safe-default canton (Non-Negotiable #3) is always still returned ──
+  describe('resolveDebiopharmBackfillCanton', () => {
+    it('resolves a known city with no review flag', () => {
+      expect(resolveDebiopharmBackfillCanton('Lausanne')).toEqual({ canton: 'VD', needsCantonReview: false });
+    });
+
+    it('falls back to the HQ canton with no review flag when there is no location text at all', () => {
+      expect(resolveDebiopharmBackfillCanton('')).toEqual({ canton: 'VD', needsCantonReview: false });
+    });
+
+    it('falls back to the HQ canton BUT flags needsCantonReview for a real, unresolvable location', () => {
+      expect(resolveDebiopharmBackfillCanton('Nonexistentburg')).toEqual({ canton: 'VD', needsCantonReview: true });
+    });
+
+    it('resolves a real, non-HQ Swiss city correctly with no review flag (negative control)', () => {
+      expect(resolveDebiopharmBackfillCanton('Bern')).toEqual({ canton: 'BE', needsCantonReview: false });
     });
   });
 });

--- a/tests/dedicated-crawler-common.test.ts
+++ b/tests/dedicated-crawler-common.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { hardenJobLocaleFields, mergeAndDeduplicate, mergePreserveLocaleData, seedCrawlerSlicesFromDataJobs, addPreviousSlugForLocale, captureLostSlugs, hasFullLocaleCoverage, normalizeContract } from '../scripts/lib/dedicated-crawler-common.mjs';
+import { hardenJobLocaleFields, mergeAndDeduplicate, mergePreserveLocaleData, seedCrawlerSlicesFromDataJobs, addPreviousSlugForLocale, captureLostSlugs, hasFullLocaleCoverage, normalizeContract, mergeLocaleTextMap } from '../scripts/lib/dedicated-crawler-common.mjs';
 import { getEvents, clear as clearSlugHistoryJournal } from '../scripts/lib/slug-history-journal.mjs';
 
 describe('normalizeContract — workload percentage-range classification (#3482)', () => {
@@ -1188,5 +1188,66 @@ describe('hasFullLocaleCoverage — post-merge needsRetranslation guard (#3442)'
   it('returns false for an empty/undefined job (never crashes)', () => {
     expect(hasFullLocaleCoverage({})).toBe(false);
     expect(hasFullLocaleCoverage(undefined)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// mergeLocaleTextMap — sourceLocale-aware merge (regression, issue #3453)
+// ─────────────────────────────────────────────────────────────
+//
+// Several dedicated crawlers (Coop, Oscam, La Fonte, AIL) rebuild a job's
+// description from freshly fetched source data every crawl cycle and used to
+// reset the ENTIRE descriptionByLocale map to just the freshly fetched
+// locale whenever the rebuilt text differed from the previously stored
+// description by more than 100 chars — a bound easily crossed by incidental
+// reformatting (footer/company/locality lines shift the assembled length)
+// rather than a genuine rewrite of the source posting. That wiped
+// already-translated locales outright. The fix reuses this exact function
+// (already the safe-merge primitive for titleByLocale/slugByLocale
+// elsewhere) with an explicit `sourceLocale` so only the fetched locale's
+// slot is authoritative and every other locale keeps its real translation,
+// no matter how large the source-locale delta is.
+describe('mergeLocaleTextMap — sourceLocale-aware merge (issue #3453)', () => {
+  it('preserves other-locale translations even when the source-locale text changes drastically (>100 chars)', () => {
+    const existing = {
+      it: 'Breve descrizione originale.',
+      de: 'Eine bereits vollständig übersetzte und lange deutsche Stellenbeschreibung mit vielen Details zur Position.',
+      en: 'A fully translated, long English job description with plenty of detail about the role.',
+      fr: "Une description de poste française déjà entièrement traduite et détaillée.",
+    };
+    // Freshly rebuilt source-locale text, far longer than the prior stored
+    // description (delta > 100 chars) — e.g. after incidental reformatting
+    // of the Coop detail-page footer/header, not a real content rewrite.
+    const freshItText =
+      'Descrizione italiana completamente ricostruita, molto più lunga del testo precedente, con intestazione azienda, sede e piè di pagina aggiornati per riflettere il nuovo formato del template di assemblaggio.';
+    expect(Math.abs(freshItText.length - existing.it.length)).toBeGreaterThan(100);
+
+    const merged = mergeLocaleTextMap(existing, { it: freshItText }, 30, 'it');
+
+    // Source locale is refreshed...
+    expect(merged.it).toBe(freshItText);
+    // ...but the other, already-translated locales are NOT wiped.
+    expect(merged.de).toBe(existing.de);
+    expect(merged.en).toBe(existing.en);
+    expect(merged.fr).toBe(existing.fr);
+  });
+
+  it('still fills a genuinely empty non-source locale from the incoming map instead of leaving it missing', () => {
+    const existing = { it: 'Testo sorgente originale abbastanza lungo da superare la soglia minima.' };
+    const merged = mergeLocaleTextMap(
+      existing,
+      { it: 'Testo sorgente riscritto, molto più lungo del precedente per superare la soglia di 100 caratteri di differenza.', de: 'Ein neuer deutscher Text, der lang genug ist, um die Mindestzeichenzahl zu erreichen.' },
+      30,
+      'it',
+    );
+    expect(merged.de).toContain('neuer deutscher Text');
+  });
+
+  it('updates the source locale regardless of delta size (no reset gate needed)', () => {
+    const existing = { it: 'Testo corto.', en: 'A short but real english translation of the posting.' };
+    const tinyEdit = 'Testo corto!'; // 1-char delta, well under 100
+    const merged = mergeLocaleTextMap(existing, { it: tinyEdit }, 3, 'it');
+    expect(merged.it).toBe(tinyEdit);
+    expect(merged.en).toBe(existing.en);
   });
 });

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -237,6 +237,58 @@ describe('renderEventDetailPage', () => {
     // Never a naive hard cut mid-word or a dangling separator before the ellipsis.
     expect(titleTag).not.toMatch(/[\s—–\-·|,;:&(]…/);
   });
+
+  it('budgets/truncates the crawled title on the ESCAPED length so an `&`/`<`/`>`/`"` in the title cannot push <title> past the 66-char cap post-escape (#3589 item 1: audit:title-length false-green)', () => {
+    // 39 raw chars (fits the pre-fix raw-length budget untruncated) + the
+    // 27-char it-locale "Lugano" suffix = 66 raw chars — but the one `&`
+    // expands to `&amp;` on escape, which is what both `htmlTemplate.ts`
+    // (`<title>${esc(title)}</title>`) and `audit-title-length.mjs` (raw
+    // HTML source) actually measure. Pre-fix this produced a 70-char
+    // escaped <title>, re-tripping the very gate PR #3581 fixed.
+    const ampTitle = 'Rock & Blues Night Festival Estivo 2026';
+    expect(ampTitle.length).toBe(39);
+    const ampEvent = { ...EVENT, id: 'tio-agenda:100', title: ampTitle };
+    const ampPage = renderEventDetailPage({
+      locale: 'it',
+      event: ampEvent as never,
+      comune: 'Lugano',
+      eventSlug: slugifyEvent(ampEvent),
+      sameComuneEvents: [ampEvent] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    const titleTag = /<title>([^<]*)<\/title>/.exec(ampPage.html)?.[1] ?? '';
+    expect(titleTag.length).toBeLessThanOrEqual(66);
+    expect(titleTag).toContain('Lugano (Ticino) | Eventi');
+    expect(titleTag).not.toMatch(/[\s—–\-·|,;:&(]…/);
+  });
+
+  it('clamps the truncation budget to a positive floor so a comune suffix long enough to overflow the cap alone cannot make the headline collapse to an empty/blank <title> (#3589 item 2)', () => {
+    // Synthetic long comune name pushes `suffix.length` well past
+    // TITLE_MAX_CHARS on its own — no headline truncation can bring the
+    // *total* back under 66 (the comune suffix is intentionally always
+    // preserved as the local-SEO signal), but the headline truncation must
+    // still degrade gracefully to a bounded "…" rather than an unguarded
+    // negative budget silently skipping truncation and leaving the full,
+    // untruncated headline in front of an already-oversized suffix.
+    const longComune = 'Castel San Pietro Sopra La Montagna Bellissima Ticinese';
+    const longComunePage = renderEventDetailPage({
+      locale: 'it',
+      event: EVENT as never,
+      comune: longComune,
+      eventSlug: slugifyEvent(EVENT),
+      sameComuneEvents: [EVENT] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    const titleTag = /<title>([^<]*)<\/title>/.exec(longComunePage.html)?.[1] ?? '';
+    expect(titleTag.length).toBeGreaterThan(0);
+    expect(titleTag).toContain('…');
+    expect(titleTag).not.toContain(EVENT.title);
+    expect(titleTag).toContain(`${longComune} (Ticino) | Eventi`);
+  });
 });
 
 describe('router recognises per-event detail URLs (staticOverlay)', () => {

--- a/tests/guess-job-parser.test.ts
+++ b/tests/guess-job-parser.test.ts
@@ -6,6 +6,8 @@ import {
   parseGuessBullets,
   parseGuessJobDetailPayload,
   parseGuessWidgetJsonp,
+  resolveGuessCanton,
+  resolveGuessBackfillCanton,
 } from '../scripts/lib/guess-job-parser.mjs';
 
 describe('guess-job-parser', () => {
@@ -44,5 +46,51 @@ describe('guess-job-parser', () => {
 
   it('extracts bullet items from html lists', () => {
     expect(parseGuessBullets('<ul><li>First item</li><li>Second item</li></ul>')).toEqual(['First item', 'Second item']);
+  });
+
+  // ── resolveGuessCanton (unresolved-canton skip guard — #3480 sibling of
+  // #3466's clariant/swisslog/debiopharm/komax/lindt-spruengli fix.
+  // isGuessTicinoWidgetJob() actually admits ANY TARGET_CANTON job, not just
+  // Ticino despite the crawler's docstring, so a real but unrecognized city
+  // must never fabricate the Bioggio HQ canton, task-critical) ──
+  describe('resolveGuessCanton', () => {
+    it('resolves a known Ticino city', () => {
+      expect(resolveGuessCanton('Bioggio')).toBe('TI');
+      expect(resolveGuessCanton('Stabio')).toBe('TI');
+    });
+
+    it('resolves a known Swiss city outside Ticino via generic inference', () => {
+      expect(resolveGuessCanton('Bern')).toBe('BE');
+    });
+
+    it('falls back to the Bioggio HQ canton when no city text was scraped at all', () => {
+      expect(resolveGuessCanton('')).toBe('TI');
+    });
+
+    it('returns null (skip) when city text is present but unresolvable — never fabricates the HQ canton', () => {
+      expect(resolveGuessCanton('Nonexistentburg')).toBeNull();
+    });
+
+    it('does NOT fabricate TI for the negative-control case (Bern, not TI)', () => {
+      expect(resolveGuessCanton('Bern')).not.toBe('TI');
+    });
+  });
+
+  // ── resolveGuessBackfillCanton (postProcessJobs() backfill guard — #3480,
+  // the item this issue was filed for. An already-published job is never
+  // dropped: a real-but-unresolvable location earns a needsCantonReview
+  // flag, the safe-default canton is always still returned) ──
+  describe('resolveGuessBackfillCanton', () => {
+    it('resolves a known city with no review flag', () => {
+      expect(resolveGuessBackfillCanton('Bioggio')).toEqual({ canton: 'TI', needsCantonReview: false });
+    });
+
+    it('falls back to the HQ canton with no review flag when there is no location text at all', () => {
+      expect(resolveGuessBackfillCanton('')).toEqual({ canton: 'TI', needsCantonReview: false });
+    });
+
+    it('falls back to the HQ canton BUT flags needsCantonReview for a real, unresolvable location', () => {
+      expect(resolveGuessBackfillCanton('Nonexistentburg')).toEqual({ canton: 'TI', needsCantonReview: true });
+    });
   });
 });

--- a/tests/jobs-seo-pages-plugin.test.ts
+++ b/tests/jobs-seo-pages-plugin.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { JOB_SEO_LOCALES, pickSearchLandingFallbackJobs } from '../build-plugins/jobsSeoPagesPlugin';
+import {
+  JOB_SEO_LOCALES,
+  pickSearchLandingFallbackJobs,
+  capSearchStatsLandingTitle,
+} from '../build-plugins/jobsSeoPagesPlugin';
+import { TITLE_MAX_CHARS } from '../build-plugins/shared/titleSuffix';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -41,5 +46,45 @@ describe('jobsSeoPagesPlugin static payload budget', () => {
 
     expect(source).not.toContain('fonts.googleapis.com/css2?family=Manrope');
     expect(source).not.toContain('fonts.gstatic.com');
+  });
+});
+
+describe('capSearchStatsLandingTitle (#3589 sibling: same escape-unaware title-budget class as eventDetailMetaTitle)', () => {
+  it('leaves a short title untouched', () => {
+    expect(capSearchStatsLandingTitle('Offerte di lavoro Infermiere in Svizzera')).toBe(
+      'Offerte di lavoro Infermiere in Svizzera',
+    );
+  });
+
+  it('caps an overlong title on a whitespace boundary with NO ellipsis (titleSuffix.ts no-`…` policy)', () => {
+    const rawTitle =
+      'Offerte di lavoro Responsabile Amministrativo e Finanziario Senior in Svizzera';
+    const capped = capSearchStatsLandingTitle(rawTitle);
+    expect(capped.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+    expect(capped).not.toContain('…');
+    expect(rawTitle.startsWith(capped)).toBe(true);
+  });
+
+  it('budgets on the ESCAPED length so a raw `&`/`<`/`>`/`"` in a crawled job-title keyword cannot push the rendered <title> past the cap', () => {
+    // 41 raw chars, one `&` — fits the pre-fix raw-length budget (<=66)
+    // untouched, but `&` -> `&amp;` on escape (the render layer applies
+    // `esc(title)` exactly once), so the escaped length must still be
+    // re-checked and truncated if it overflows.
+    const rawTitle = 'Offerte di lavoro Sales & Marketing in Svizzera';
+    expect(rawTitle.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+    const capped = capSearchStatsLandingTitle(rawTitle);
+    const escapedLength = capped
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').length;
+    expect(escapedLength).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+  });
+
+  it('converges (does not loop forever / return empty) for a title with no whitespace to cut on', () => {
+    const rawTitle = 'A'.repeat(120);
+    const capped = capSearchStatsLandingTitle(rawTitle);
+    expect(capped.length).toBeGreaterThan(0);
+    expect(capped.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
   });
 });


### PR DESCRIPTION
## Implementato

- **#3587** — `previousSlugs` writer regression (5886 losses/24h): `scripts/backfill-prev-slugs-from-loss-events.mjs` pushed recovered historical slugs onto an already-at-cap array and sliced to last 20, evicting live entries. Extracted `applyRecoveredSlug()` helper, made strictly capacity-permitting (skip instead of evict at cap).
- **#3480** — crawler unresolved-canton skip guard sibling-class fix: `scripts/update-debiopharm-jobs.mjs`/`update-guess-jobs.mjs`/`scripts/lib/guess-job-parser.mjs` had an unguarded `inferAnyCanton(...) || DEFAULT_CANTON` fallback fabricating a canton on unresolvable locations. Now sets `needsCantonReview: true` instead of silently defaulting; fixed a sibling docstring/filter mismatch in `update-guess-jobs.mjs`, plus a caller-side "0 admissible jobs" guard against a full wipe via `mergeJobs()`.
- **#3589** (both deferred items from #3581) — `build-plugins/eventsSeoPagesPlugin.ts`'s `eventDetailMetaTitle`: (1) truncation budget now measured on HTML-escaped length, not raw length, closing the `audit:title-length` false-green on event titles with entities (`&`/`<`/`>`/`"`); (2) budget floored at 1 so a long comune name can no longer drive the ceiling negative. Sibling fix (Non-Negotiable #6): identical escape-unaware raw-length budget bug found and fixed in `build-plugins/jobsSeoPagesPlugin.ts`'s search-stats-landing title composer, extracted as `capSearchStatsLandingTitle()` — **and a third occurrence of the same class** in `build-plugins/weeklyEmployersPlugin.ts`'s company×city title composer (raw `.slice(0, 60)` boundary, can overflow the escaped-length budget when `cityDisplay`/`employer` carry `&`/`<`/`>`/`"`), now routed through the same `capSearchStatsLandingTitle()` helper.
- **#3453** — Coop crawler `descriptionByLocale` full-wipe: `scripts/update-coop-jobs.mjs`'s `repairJobFromJsonLd()` reset the entire per-locale description map to a single locale whenever the rebuilt description crossed a >100-char delta (trivially crossed by incidental reformatting, not just real rewrites), discarding already-translated locales. Now uses the existing `mergeLocaleTextMap()` primitive instead of a destructive reset. **Corpus-wide sibling sweep (Non-Negotiable #6), two distinct bug classes found across `scripts/update-*.mjs`:**
  - **Missing `sourceLocale` arg** (89 files, incl. the 3 originally flagged by review — `update-oscam-jobs.mjs`, `update-ail-jobs.mjs`, `update-lafonte-jobs.mjs`): `mergeLocaleTextMap(existing, discovered, 30)` called without the 4th arg means the existing locale value always wins once ≥30 chars — `descriptionByLocale` content freezes forever after the first crawl. Every affected file already computes a `sourceLang`/`sourceLang` field via `detectLang(...)` at scrape time; threaded that through as the 4th arg so the source locale refreshes from fresh crawl data while other-locale translations are preserved. `update-lastminute-jobs.mjs` gets the literal `'en'` (SR API description is unambiguously English by construction).
  - **Wipe-to-`{}` on content-length delta** (2 files — `update-axpo-jobs.mjs`, `update-cler-jobs.mjs`): same antipattern as the original Coop bug — reset `descriptionByLocale` to `{}`/source-only before merging whenever the description length changed by >100 chars, discarding all other-locale translations regardless of the 4th-arg fix above. Removed the wipe entirely (axpo keeps its `descChanged` flag for `needsRetranslation`, cler's now-dead length-delta variables deleted).
- **#3578** — capped crawler listings silent truncation: `scripts/lib/canton-valais-job-parser.mjs`'s `tryServiceNowApi()` only ran the `warnIfListingAtCap` truncation check when the URL's `sysparm_limit` query param was present — the primary/first-tried endpoint has no such param, so the warning silently never fired for it. Now always resolves a cap (explicit param, or a documented sentinel fallback) and always checks.

## Non implementato (ancora)

Nessuno

## Test plan

- [x] `npx vitest run` across all 23 touched/related test files (518 tests) — all green together, confirming no cross-fix regression
- [x] Each fix independently verified by its authoring sub-agent (see per-issue commit messages for individual test commands/counts)
- [x] Sibling sweep (#3453-class, 90 files total): `node --check` on all 89 touched crawler scripts, `tsc --noEmit` shows zero new errors in either touched build-plugin file, 524 additional vitest tests pass (16 crawler test files + `dedicated-crawler-common` + `merge-source-copy-protection` + 9 `weekly-employers` test files)
- [x] `gitnexus_detect_changes({scope:"compare", base_ref:"origin/main"})` — LOW risk, 0 changed/affected symbols (call-site argument additions + dead-code removal, no signature changes)

Closes #3587
Closes #3480
Closes #3453
Closes #3578

Addresses both deferred items of #3589 (title-length classifier drift AND the negative-budget-floor gap — both fixed, not partial). No closing keyword used here on purpose: issue 3589's title mechanically matches the repo's aggregate-follow-up pattern ("2 item deferred"), which `pr-body-contract.yml` vetoes for auto-close regardless of actual completeness. Post-merge, #3589 will be resolved manually via an evidence-citing comment on the issue, same path used for #3580/#3598.
