### PR TITLE
feat(crawler): 3 new dedicated crawlers (city-pop, cham-swiss-properties, dic-sa) — closes #3621

### DIFF
--- a/.github/workflows/update-jobs-cham-swiss-properties.yml
+++ b/.github/workflows/update-jobs-cham-swiss-properties.yml
@@ -1,0 +1,101 @@
+name: Update Cham Swiss Properties Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-cham-swiss-properties
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-cham-swiss-properties-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/load-rc-env.mjs
+          echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Run dedicated Cham Swiss Properties crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-cham-swiss-properties-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'cham-swiss-properties'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/cham-swiss-properties.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Cham Swiss Properties jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-city-pop.yml
+++ b/.github/workflows/update-jobs-city-pop.yml
@@ -1,0 +1,101 @@
+name: Update City Pop Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-city-pop
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-city-pop-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/load-rc-env.mjs
+          echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Run dedicated City Pop crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-city-pop-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'city-pop'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/city-pop.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update City Pop jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-dic-sa.yml
+++ b/.github/workflows/update-jobs-dic-sa.yml
@@ -1,0 +1,101 @@
+name: Update DIC SA Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-dic-sa
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-dic-sa-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/load-rc-env.mjs
+          echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Run dedicated DIC SA crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-dic-sa-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'dic-sa'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/dic-sa.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update DIC SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/cham-swiss-properties-job-parser.mjs
+++ b/scripts/lib/cham-swiss-properties-job-parser.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Cham Swiss Properties AG job parser — jobs.ch public search API + JSON-LD detail.
+ *
+ * Source: https://www.jobs.ch/en/companies/142189-cham-swiss-properties-ag/
+ * (public company profile page; the jobs.ch API discovery below is what
+ * actually feeds this parser — see ./jobs-ch-search-common.mjs)
+ *
+ * Cham Swiss Properties AG (SIX: CHAM) is a listed Swiss real-estate
+ * development / project-management company headquartered in Cham (ZG),
+ * formed in 2025 through the merger of Ina Invest AG and Cham Group AG
+ * (itself tracing back to the historic 1657 Cham paper-mill site). It
+ * develops residential/mixed-use urban quarters (Papieri-Areal Cham,
+ * Bredella Pratteln, plus projects in Zurich and Geneva) on a CHF ~1.7bn
+ * portfolio. Confirmed GENUINE DIRECT EMPLOYER, not a staffing/placement
+ * agency:
+ *   - own company careers page (champroperties.ch/en/company/karriere)
+ *     lists open positions as its own headcount, with an in-house HR
+ *     contact (Fachverantwortliche Personaladministration) — not a
+ *     third-party recruiter.
+ *   - jobs.ch company profile posts directly under "Cham Swiss
+ *     Properties AG" as `hiringOrganization`, no client/mandate framing.
+ *   - Small (~50 employee) in-house team; postings are corporate/real-
+ *     estate development roles (contract management, project management,
+ *     IT), consistent with an owner-developer, not a placement agency.
+ *
+ * jobs.ch company profile id: 142189.
+ *
+ * HQ fallback address (confirmed via jobs.ch company profile JSON-LD,
+ * company website imprint and LinkedIn): Fabrikstrasse 5, 6330 Cham, ZG.
+ *
+ * Exports the 3 functions used by the crawler template:
+ *   - fetchAllChamSwissPropertiesJobs()  — Fetch and parse all Swiss jobs
+ *   - isChamSwissPropertiesJob()         — Match jobs belonging to this company
+ *   - isTrustedDomain()                  — Validate URLs belong to this company
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
+import { detectEmploymentTypeFromOccupation } from './jobup-ch-feed-common.mjs';
+import {
+  fetchJobsChCompanyListings,
+  fetchJobsChJobPostingLd,
+  jobsChDetailUrl,
+} from './jobs-ch-search-common.mjs';
+
+/* Constants ─────────────────────────────────────────────── */
+
+export const CHAM_SWISS_PROPERTIES_KEY = 'cham-swiss-properties';
+export const CHAM_SWISS_PROPERTIES_COMPANY_NAME = 'Cham Swiss Properties';
+export const CHAM_SWISS_PROPERTIES_COMPANY_DOMAIN = 'champroperties.ch';
+
+const COMPANY_IDS = ['142189'];
+const CAREER_URL = 'https://www.jobs.ch/en/companies/142189-cham-swiss-properties-ag/';
+
+/* HQ fallback: Fabrikstrasse 5, 6330 Cham (jobs.ch company profile + LinkedIn). */
+const HQ = {
+  city: 'Cham',
+  canton: 'ZG',
+  postalCode: '6330',
+  streetAddress: 'Fabrikstrasse 5',
+};
+
+const SECTOR = 'Immobiliare / Project Management';
+
+/* Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isChamSwissPropertiesJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === CHAM_SWISS_PROPERTIES_KEY ||
+    key.startsWith('cham-swiss-properties') ||
+    company.includes('cham swiss properties') ||
+    url.includes('champroperties.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'champroperties.ch' || host.endsWith('.champroperties.ch')) return true;
+    if (host === 'jobs.ch' || host.endsWith('.jobs.ch')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category Detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(vertrag|contract|contrat|contratt)/.test(t)) return 'Contract Management';
+  if (/\b(projekt|project|projet|progetto|bauherr|entwickl|develop)/.test(t)) return 'Project Management';
+  if (/\b(it|software|digital|system)/.test(t)) return 'IT';
+  if (/\b(hr|human|risorse|personal|ressources)/.test(t)) return 'Risorse Umane';
+  if (/\b(immobil|liegenschaft|real estate|property|portfolio)/.test(t)) return 'Immobiliare';
+  if (/\b(admin|segret|contab|buchhalt|account|assistant)/.test(t)) return 'Amministrazione';
+  if (/\b(marketing|communication|kommunikation|comunicaz)/.test(t)) return 'Marketing';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|stage|stagiair|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab|leiter)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+/**
+ * Map jobs.ch's free-text `employmentType` (JSON-LD) + posting workload
+ * grades to the schema.org employmentType enum consumed downstream.
+ */
+function resolveEmploymentType(ldEmploymentType = '', grades = []) {
+  const t = normalize(ldEmploymentType);
+  if (/intern/.test(t)) return 'INTERN';
+  if (/temporary|fixed.term|contract/.test(t)) return 'TEMPORARY';
+  if (/supplementary/.test(t)) return 'PER_DIEM';
+  const nums = (Array.isArray(grades) ? grades : []).map(Number).filter(Number.isFinite);
+  const min = nums.length ? Math.min(...nums) : 0;
+  const max = nums.length ? Math.max(...nums) : 100;
+  return detectEmploymentTypeFromOccupation(min, max) === 'PART_TIME' ? 'PART_TIME' : 'FULL_TIME';
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+/**
+ * Fetch all Cham Swiss Properties jobs. Returns an array of ParsedJob
+ * objects (source-locale only — other locales are filled by the AI
+ * localization step and translate-pending pipeline).
+ */
+export async function fetchAllChamSwissPropertiesJobs() {
+  console.log(`🔍 Fetching ${CHAM_SWISS_PROPERTIES_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const listings = await fetchJobsChCompanyListings({ companyIds: COMPANY_IDS });
+  if (!listings || listings.length === 0) {
+    console.warn('⚠️ No job listings returned.');
+    return [];
+  }
+
+  console.log(`  📋 Listings found: ${listings.length}`);
+
+  const jobs = [];
+  const seen = new Set();
+  const seenSlugs = new Set();
+
+  for (const listing of listings) {
+    const title = normalizeSpace(listing.title || '');
+    if (!title || title.length < 3) continue;
+    if (seen.has(listing.id)) continue;
+    seen.add(listing.id);
+
+    let ld = null;
+    let detailUrl = jobsChDetailUrl(listing.id, 'en');
+    try {
+      const detail = await fetchJobsChJobPostingLd(listing.id, { locale: 'en' });
+      ld = detail.ld;
+      detailUrl = detail.url;
+    } catch (err) {
+      console.warn(`⚠️ Failed to fetch detail for ${listing.id}: ${err?.message || err}`);
+    }
+
+    const loc0 = Array.isArray(listing.locations) ? listing.locations[0] : null;
+    const place = normalizeSpace(listing.place || loc0?.city || '');
+    const canton =
+      normalizeCantonCode(loc0?.cantonCode || '') ||
+      inferAnyCanton(place) ||
+      HQ.canton;
+
+    const descriptionHtml = ld?.description || '';
+    const descriptionText = stripHtml(descriptionHtml);
+    const description = descriptionText || `${title} presso ${CHAM_SWISS_PROPERTIES_COMPANY_NAME} a ${place || HQ.city}.`;
+    const sourceLang = detectLang(descriptionText || title, 'de');
+
+    const urlHash = createHash('sha1').update(listing.id).digest('hex').slice(0, 12);
+
+    // Two distinct postings can legitimately share title+location —
+    // disambiguate in-run collisions with a short id suffix so both jobs
+    // keep a stable, unique slug instead of silently colliding.
+    let jobSlug = slugify(`${title} cham-swiss-properties ${place || HQ.city}`);
+    if (seenSlugs.has(jobSlug)) {
+      jobSlug = slugify(`${title} cham-swiss-properties ${place || HQ.city} ${urlHash.slice(0, 6)}`);
+    }
+    seenSlugs.add(jobSlug);
+
+    const employmentType = resolveEmploymentType(ld?.employmentType || '', listing.employmentGrades);
+    const postedDate = (listing.publicationDate && String(listing.publicationDate).slice(0, 10))
+      || (listing.initialPublicationDate && String(listing.initialPublicationDate).slice(0, 10))
+      || new Date().toISOString().split('T')[0];
+
+    const hiringOrganizationName = ld?.hiringOrganization?.name || listing.company?.name || CHAM_SWISS_PROPERTIES_COMPANY_NAME;
+
+    const job = {
+      // ── Required fields ──
+      id: `${CHAM_SWISS_PROPERTIES_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CHAM_SWISS_PROPERTIES_COMPANY_NAME,
+      companyKey: CHAM_SWISS_PROPERTIES_KEY,
+      companyDomain: CHAM_SWISS_PROPERTIES_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      location: place || HQ.city,
+      canton,
+      url: detailUrl,
+      source: 'Cham Swiss Properties Dedicated Parser (jobs.ch)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      // ── Recommended fields ──
+      addressLocality: loc0?.city || place || HQ.city,
+      addressRegion: canton,
+      streetAddress: normalizeSpace(loc0?.street || '') || (canton === HQ.canton ? HQ.streetAddress : ''),
+      postalCode: normalizeSpace(loc0?.postalCode || '') || (canton === HQ.canton ? HQ.postalCode : ''),
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectCategory(title),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectExperienceLevel(title),
+      sector: SECTOR,
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: detailUrl,
+      hiringOrganizationName,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${CHAM_SWISS_PROPERTIES_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/city-pop-job-parser.mjs
+++ b/scripts/lib/city-pop-job-parser.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * City Pop AG job parser — jobs.ch public search API + JSON-LD detail.
+ *
+ * Source: https://www.jobs.ch/en/companies/eb0155fc-e81e-4f2c-8770-e211d2689811-city-pop-ag/
+ * (public company profile page; the jobs.ch API discovery below is what
+ * actually feeds this parser — see ./jobs-ch-search-common.mjs)
+ *
+ * City Pop is a Swiss "micro-living" / serviced-apartment scale-up (fully
+ * furnished flexible-stay apartments) founded in Ticino, now operating in
+ * Zürich, Lugano, Lausanne, Bern, Geneva, Baden and expanding into Germany,
+ * Italy and Poland. Confirmed GENUINE DIRECT EMPLOYER, not a staffing or
+ * placement agency:
+ *   - Registered in the Swiss commercial register as "City Pop AG"
+ *     (CHE-325.832.314, Zefix), with an active Ticino branch
+ *     "City Pop AG, succursale di Manno" (CHE-479.731.100) — confirming the
+ *     company's continued Ticino presence even though the legal seat moved
+ *     to Zürich in 2021.
+ *   - jobs.ch company profile (`webPageUrl`) points directly at
+ *     https://citypop.com/, its own corporate site, and the profile
+ *     "portraitDescription" is first-person marketing copy about the
+ *     company itself, not a client-mandate agency blurb.
+ *
+ * jobs.ch company profile id (UUID-form, not a legacy numeric id):
+ *   eb0155fc-e81e-4f2c-8770-e211d2689811
+ * Confirmed live via the public, unauthenticated jobs.ch search API
+ * (`job-search-api.jobs.ch/search?companyIds=...`) — as of the initial
+ * build (2026-07) the company has 0 open postings (`totalHits: 0`), but the
+ * feed itself is live and will surface new roles automatically as City Pop
+ * posts them (fast-growing scale-up, multiple Swiss cities).
+ *
+ * HQ fallback address (confirmed via Zefix commercial-register extract,
+ * CHE-325.832.314): Bernerstrasse Süd 169, 8048 Zürich, ZH.
+ *
+ * Exports the 3 functions used by the crawler template:
+ *   - fetchAllCityPopJobs() — Fetch and parse all Swiss jobs
+ *   - isCityPopJob()        — Match jobs belonging to this company
+ *   - isTrustedDomain()     — Validate URLs belong to this company
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
+import { detectEmploymentTypeFromOccupation } from './jobup-ch-feed-common.mjs';
+import {
+  fetchJobsChCompanyListings,
+  fetchJobsChJobPostingLd,
+  jobsChDetailUrl,
+} from './jobs-ch-search-common.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const CITY_POP_KEY = 'city-pop';
+export const CITY_POP_COMPANY_NAME = 'City Pop';
+export const CITY_POP_COMPANY_DOMAIN = 'citypop.com';
+
+const COMPANY_IDS = ['eb0155fc-e81e-4f2c-8770-e211d2689811'];
+const CAREER_URL =
+  'https://www.jobs.ch/en/companies/eb0155fc-e81e-4f2c-8770-e211d2689811-city-pop-ag/';
+
+/* HQ fallback: Bernerstrasse Süd 169, 8048 Zürich (Zefix, CHE-325.832.314). */
+const HQ = {
+  city: 'Zürich',
+  canton: 'ZH',
+  postalCode: '8048',
+  streetAddress: 'Bernerstrasse Süd 169',
+};
+
+const SECTOR = 'Immobiliare / Micro-living / Ospitalità';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isCityPopJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === CITY_POP_KEY ||
+    key.startsWith('city-pop') ||
+    company.includes('city pop') ||
+    url.includes('citypop.com')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'citypop.com' || host.endsWith('.citypop.com')) return true;
+    if (host === 'jobs.ch' || host.endsWith('.jobs.ch')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category Detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(reception|réception|empfang|guest|ospiti|front.?desk|concierge)/.test(t)) return 'Ospitalità';
+  if (/\b(immobil|property|liegenschaft|immeuble|facility)/.test(t)) return 'Immobiliare';
+  if (/\b(vendita|sales|verkauf|commerc|acquisiz)/.test(t)) return 'Commerciale';
+  if (/\b(marketing|comunicaz|communication|kommunikation)/.test(t)) return 'Marketing';
+  if (/\b(it|software|develop|programm|tech)/.test(t)) return 'IT';
+  if (/\b(admin|segret|contab|buchhalt|finance|finanz|controll)/.test(t)) return 'Amministrazione';
+  if (/\b(manuten|wartung|maintenance|entretien|hauswart|janitor)/.test(t)) return 'Manutenzione';
+  if (/\b(operations|operativ|betrieb|exploitation)/.test(t)) return 'Operations';
+  if (/\b(hr|human|risorse|personal|ressources)/.test(t)) return 'Risorse Umane';
+  if (/\b(project|projekt|progett)/.test(t)) return 'Project Management';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|stage|stagiair|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+/**
+ * Map jobs.ch's free-text `employmentType` (JSON-LD) + posting workload
+ * grades to the schema.org employmentType enum consumed downstream.
+ * Confirmed values used across other jobs.ch-fed crawlers: "Permanent
+ * position", "Internship", "Temporary", "Supplementary income".
+ */
+function resolveEmploymentType(ldEmploymentType = '', grades = []) {
+  const t = normalize(ldEmploymentType);
+  if (/intern/.test(t)) return 'INTERN';
+  if (/temporary|fixed.term|contract/.test(t)) return 'TEMPORARY';
+  if (/supplementary/.test(t)) return 'PER_DIEM';
+  const nums = (Array.isArray(grades) ? grades : []).map(Number).filter(Number.isFinite);
+  const min = nums.length ? Math.min(...nums) : 0;
+  const max = nums.length ? Math.max(...nums) : 100;
+  return detectEmploymentTypeFromOccupation(min, max) === 'PART_TIME' ? 'PART_TIME' : 'FULL_TIME';
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+/**
+ * Fetch all City Pop jobs. Returns an array of ParsedJob objects
+ * (source-locale only — other locales are filled by the AI localization
+ * step and translate-pending pipeline).
+ */
+export async function fetchAllCityPopJobs() {
+  console.log(`🔍 Fetching ${CITY_POP_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const listings = await fetchJobsChCompanyListings({ companyIds: COMPANY_IDS });
+  if (!listings || listings.length === 0) {
+    console.warn('⚠️ No job listings returned.');
+    return [];
+  }
+
+  console.log(`  📋 Listings found: ${listings.length}`);
+
+  const jobs = [];
+  const seen = new Set();
+  const seenSlugs = new Set();
+
+  for (const listing of listings) {
+    const title = normalizeSpace(listing.title || '');
+    if (!title || title.length < 3) continue;
+    if (seen.has(listing.id)) continue;
+    seen.add(listing.id);
+
+    let ld = null;
+    let detailUrl = jobsChDetailUrl(listing.id, 'en');
+    try {
+      const detail = await fetchJobsChJobPostingLd(listing.id, { locale: 'en' });
+      ld = detail.ld;
+      detailUrl = detail.url;
+    } catch (err) {
+      console.warn(`⚠️ Failed to fetch detail for ${listing.id}: ${err?.message || err}`);
+    }
+
+    const loc0 = Array.isArray(listing.locations) ? listing.locations[0] : null;
+    const place = normalizeSpace(listing.place || loc0?.city || '');
+    const canton =
+      normalizeCantonCode(loc0?.cantonCode || '') ||
+      inferAnyCanton(place) ||
+      HQ.canton;
+
+    const descriptionHtml = ld?.description || '';
+    const descriptionText = stripHtml(descriptionHtml);
+    const description = descriptionText || `${title} presso ${CITY_POP_COMPANY_NAME} a ${place || HQ.city}.`;
+    const sourceLang = detectLang(descriptionText || title, 'de');
+
+    const urlHash = createHash('sha1').update(listing.id).digest('hex').slice(0, 12);
+
+    // Two distinct postings can legitimately share title+location (e.g.
+    // City Pop opening 2 identical headcount slots at the same site) —
+    // disambiguate in-run collisions with a short id suffix so both jobs
+    // keep a stable, unique slug instead of silently colliding.
+    let jobSlug = slugify(`${title} city pop ${place || HQ.city}`);
+    if (seenSlugs.has(jobSlug)) {
+      jobSlug = slugify(`${title} city pop ${place || HQ.city} ${urlHash.slice(0, 6)}`);
+    }
+    seenSlugs.add(jobSlug);
+
+    const employmentType = resolveEmploymentType(ld?.employmentType || '', listing.employmentGrades);
+    const postedDate = (listing.publicationDate && String(listing.publicationDate).slice(0, 10))
+      || (listing.initialPublicationDate && String(listing.initialPublicationDate).slice(0, 10))
+      || new Date().toISOString().split('T')[0];
+
+    const hiringOrganizationName = ld?.hiringOrganization?.name || listing.company?.name || CITY_POP_COMPANY_NAME;
+
+    const job = {
+      // ── Required fields ──
+      id: `${CITY_POP_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CITY_POP_COMPANY_NAME,
+      companyKey: CITY_POP_KEY,
+      companyDomain: CITY_POP_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      location: place || HQ.city,
+      canton,
+      url: detailUrl,
+      source: 'City Pop Dedicated Parser (jobs.ch)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      // ── Recommended fields ──
+      addressLocality: loc0?.city || place || HQ.city,
+      addressRegion: canton,
+      streetAddress: normalizeSpace(loc0?.street || '') || (canton === HQ.canton ? HQ.streetAddress : ''),
+      postalCode: normalizeSpace(loc0?.postalCode || '') || (canton === HQ.canton ? HQ.postalCode : ''),
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectCategory(title),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectExperienceLevel(title),
+      sector: SECTOR,
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: detailUrl,
+      hiringOrganizationName,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${CITY_POP_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/dic-sa-job-parser.mjs
+++ b/scripts/lib/dic-sa-job-parser.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * DIC SA (ingénieurs) job parser — jobs.ch public search API + JSON-LD detail.
+ *
+ * Source: https://www.jobup.ch/fr/societes/ee30c164-1431-42ab-af87-d45a5dc3579f-dic-sa/
+ * (public company profile; jobs.ch/jobup.ch are both operated by JobCloud AG
+ * and share the same public search API — see ./jobs-ch-search-common.mjs)
+ *
+ * DIC SA ingénieurs is a small civil-engineering consultancy ("bureau
+ * d'ingénieur-conseil") headquartered in Aigle (VD), with branch offices in
+ * Sion and Martigny (VS). Founded 1982, incorporated as SA in 1991
+ * (CHE-105.986.545), ISO 9001 certified since 1998. Confirmed GENUINE DIRECT
+ * EMPLOYER, not a staffing/placement agency:
+ * - dic-ing.ch (own corporate site) describes itself as "un bureau reconnu
+ *   pour la qualité et la précision de ses ouvrages" in civil engineering,
+ *   structural works and road/rail infrastructure — a design/consulting firm
+ *   with its own permanent engineering staff, not a temp-work intermediary.
+ * - The single live posting's description uses first-person "notre équipe à
+ *   taille humaine", "Depuis plus de 40 ans, DIC SA ingénieurs s'impose
+ *   comme..." language, never third-party-placement/staffing phrasing.
+ * - `hiringOrganization`/`company.name` on jobs.ch is consistently "DIC SA",
+ *   matching the Aigle head-office entity (no unrelated client name).
+ *
+ * IMPORTANT — jobs.ch numeric company id (81584, "dic-sa-ingenieurs" slug,
+ * from https://www.jobs.ch/fr/entreprises/81584-dic-sa-ingenieurs/) returns
+ * jobCount: 0 and totalHits: 0 against the search API — it is a STALE/legacy
+ * profile record. The company's ACTIVE profile (confirmed live) uses a UUID
+ * company id under the plain name "DIC SA":
+ *   ee30c164-1431-42ab-af87-d45a5dc3579f
+ * (https://www.jobup.ch/fr/societes/ee30c164-1431-42ab-af87-d45a5dc3579f-dic-sa/,
+ * redirects/mirrors from legacy jobup numeric id 25347). Confirmed live via
+ * `job-search-api.jobs.ch/search?companyIds=ee30c164-...` → totalHits: 1,
+ * job "Ingenieur civil EPF - Chef de projet (H/F)", Aigle VD, published
+ * 2026-06-29. Use the UUID id, not the numeric jobs.ch id.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
+import { detectEmploymentTypeFromOccupation } from './jobup-ch-feed-common.mjs';
+import {
+  fetchJobsChCompanyListings,
+  fetchJobsChJobPostingLd,
+  jobsChDetailUrl,
+} from './jobs-ch-search-common.mjs';
+
+/* Constants ─────────────────────────────────────────────── */
+
+export const DIC_SA_KEY = 'dic-sa';
+export const DIC_SA_COMPANY_NAME = 'DIC SA';
+export const DIC_SA_COMPANY_DOMAIN = 'dic-ing.ch';
+
+const COMPANY_IDS = ['ee30c164-1431-42ab-af87-d45a5dc3579f'];
+const CAREER_URL = 'https://www.jobup.ch/fr/societes/ee30c164-1431-42ab-af87-d45a5dc3579f-dic-sa/';
+
+/* HQ fallback: Les Glariers, 1860 Aigle (jobs.ch/jobup.ch listing address). */
+const HQ = {
+  city: 'Aigle',
+  canton: 'VD',
+  postalCode: '1860',
+  streetAddress: 'Les Glariers',
+};
+
+const SECTOR = 'Ingegneria Civile / Costruzioni';
+
+/* Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isDicSaJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-');
+  if (key.includes('dic-sa')) return true;
+
+  const company = normalize(job?.company || '');
+  if (/\bdic sa\b/.test(company)) return true;
+
+  const url = normalize(job?.url || '');
+  if (/dic-ing\.ch/.test(url)) return true;
+
+  return false;
+}
+
+export function isTrustedDomain(url = '') {
+  try {
+    const { hostname } = new URL(url);
+    const host = hostname.toLowerCase();
+    return (
+      host === DIC_SA_COMPANY_DOMAIN ||
+      host.endsWith(`.${DIC_SA_COMPANY_DOMAIN}`) ||
+      host === 'www.jobs.ch' ||
+      host === 'jobs.ch' ||
+      host === 'www.jobup.ch' ||
+      host === 'jobup.ch'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(ingenieur|ingénieur|ingegnere|engineer)/.test(t)) return 'Ingegneria';
+  if (/\b(dessinateur|dessinatrice|disegnatore|technical draw|drafts)/.test(t)) return 'Disegno Tecnico';
+  if (/\b(chef de projet|projektleiter|project manager|capo progetto)/.test(t)) return 'Project Management';
+  if (/\b(apprenti|lehrling|apprendist|stage|stagiair)/.test(t)) return 'Formazione';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|stage|stagiair|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+/**
+ * Map jobs.ch's free-text `employmentType` (JSON-LD) + posting workload
+ * grades to the schema.org employmentType enum consumed downstream.
+ * Confirmed live values (shared jobs.ch behaviour, see equans-job-parser.mjs):
+ * "Permanent position", "Internship", "Temporary", "Supplementary income".
+ */
+function resolveEmploymentType(ldEmploymentType = '', grades = []) {
+  const t = normalize(ldEmploymentType);
+  if (/intern/.test(t)) return 'INTERN';
+  if (/temporary|fixed.term|contract/.test(t)) return 'TEMPORARY';
+  if (/supplementary/.test(t)) return 'PER_DIEM';
+  const nums = (Array.isArray(grades) ? grades : []).map(Number).filter(Number.isFinite);
+  const min = nums.length ? Math.min(...nums) : 0;
+  const max = nums.length ? Math.max(...nums) : 100;
+  return detectEmploymentTypeFromOccupation(min, max) === 'PART_TIME' ? 'PART_TIME' : 'FULL_TIME';
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+/**
+ * Fetch all DIC SA jobs. Returns an array of ParsedJob objects (source-locale
+ * only — other locales are filled by the AI localization step and
+ * translate-pending pipeline).
+ */
+export async function fetchAllDicSaJobs() {
+  console.log(`🔍 Fetching ${DIC_SA_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const listings = await fetchJobsChCompanyListings({ companyIds: COMPANY_IDS });
+  if (!listings || listings.length === 0) {
+    console.warn('⚠️ No job listings returned.');
+    return [];
+  }
+
+  console.log(`  📋 Listings found: ${listings.length}`);
+
+  const jobs = [];
+  const seen = new Set();
+  const seenSlugs = new Set();
+
+  for (const listing of listings) {
+    const title = normalizeSpace(listing.title || '');
+    if (!title || title.length < 3) continue;
+    if (seen.has(listing.id)) continue;
+    seen.add(listing.id);
+
+    let ld = null;
+    let detailUrl = jobsChDetailUrl(listing.id, 'fr');
+    try {
+      const detail = await fetchJobsChJobPostingLd(listing.id, { locale: 'fr' });
+      ld = detail.ld;
+      detailUrl = detail.url;
+    } catch (err) {
+      console.warn(`⚠️ Failed to fetch detail for ${listing.id}: ${err?.message || err}`);
+    }
+
+    const loc0 = Array.isArray(listing.locations) ? listing.locations[0] : null;
+    const place = normalizeSpace(listing.place || loc0?.city || '');
+    const canton =
+      normalizeCantonCode(loc0?.cantonCode || '') ||
+      inferAnyCanton(place) ||
+      HQ.canton;
+
+    const descriptionHtml = ld?.description || '';
+    const descriptionText = stripHtml(descriptionHtml);
+    const description = descriptionText || `${title} presso ${DIC_SA_COMPANY_NAME} a ${place || HQ.city}.`;
+    const sourceLang = detectLang(descriptionText || title, 'fr');
+
+    const urlHash = createHash('sha1').update(listing.id).digest('hex').slice(0, 12);
+
+    // Disambiguate in-run title+location collisions with a short id suffix
+    // so multiple postings keep a stable, unique slug instead of colliding.
+    let jobSlug = slugify(`${title} dic sa ${place || HQ.city}`);
+    if (seenSlugs.has(jobSlug)) {
+      jobSlug = slugify(`${title} dic sa ${place || HQ.city} ${urlHash.slice(0, 6)}`);
+    }
+    seenSlugs.add(jobSlug);
+
+    const employmentType = resolveEmploymentType(ld?.employmentType || '', listing.employmentGrades);
+    const postedDate = (listing.publicationDate && String(listing.publicationDate).slice(0, 10))
+      || (listing.initialPublicationDate && String(listing.initialPublicationDate).slice(0, 10))
+      || new Date().toISOString().split('T')[0];
+
+    const hiringOrganizationName = ld?.hiringOrganization?.name || listing.company?.name || DIC_SA_COMPANY_NAME;
+
+    const job = {
+      // ── Required fields ──
+      id: `${DIC_SA_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: DIC_SA_COMPANY_NAME,
+      companyKey: DIC_SA_KEY,
+      companyDomain: DIC_SA_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      location: place || HQ.city,
+      canton,
+      url: detailUrl,
+      source: 'DIC SA Dedicated Parser (jobs.ch)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      // ── Recommended fields ──
+      addressLocality: loc0?.city || place || HQ.city,
+      addressRegion: canton,
+      streetAddress: normalizeSpace(loc0?.street || '') || (canton === HQ.canton ? HQ.streetAddress : ''),
+      postalCode: normalizeSpace(loc0?.postalCode || '') || (canton === HQ.canton ? HQ.postalCode : ''),
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectCategory(title),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectExperienceLevel(title),
+      sector: SECTOR,
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: detailUrl,
+      hiringOrganizationName,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${DIC_SA_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/update-cham-swiss-properties-jobs.mjs
+++ b/scripts/update-cham-swiss-properties-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Cham Swiss Properties crawler runner.
+ *
+ * Uses the standard crawler template with the Cham Swiss Properties parser.
+ * All fetch/parse logic lives in ./lib/cham-swiss-properties-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllChamSwissPropertiesJobs,
+  isChamSwissPropertiesJob,
+  isTrustedDomain,
+  CHAM_SWISS_PROPERTIES_KEY,
+  CHAM_SWISS_PROPERTIES_COMPANY_NAME,
+} from './lib/cham-swiss-properties-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CHAM_SWISS_PROPERTIES_KEY,
+  companyLabel: CHAM_SWISS_PROPERTIES_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllChamSwissPropertiesJobs,
+  isCompanyJob: isChamSwissPropertiesJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Cham Swiss Properties crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-city-pop-jobs.mjs
+++ b/scripts/update-city-pop-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated City Pop crawler runner.
+ *
+ * Uses the standard crawler template with the City Pop parser.
+ * All fetch/parse logic lives in ./lib/city-pop-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllCityPopJobs,
+  isCityPopJob,
+  isTrustedDomain,
+  CITY_POP_KEY,
+  CITY_POP_COMPANY_NAME,
+} from './lib/city-pop-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CITY_POP_KEY,
+  companyLabel: CITY_POP_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllCityPopJobs,
+  isCompanyJob: isCityPopJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ City Pop crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-dic-sa-jobs.mjs
+++ b/scripts/update-dic-sa-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated DIC SA crawler runner.
+ *
+ * Uses the standard crawler template with the DIC SA parser.
+ * All fetch/parse logic lives in ./lib/dic-sa-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllDicSaJobs,
+  isDicSaJob,
+  isTrustedDomain,
+  DIC_SA_KEY,
+  DIC_SA_COMPANY_NAME,
+} from './lib/dic-sa-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: DIC_SA_KEY,
+  companyLabel: DIC_SA_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllDicSaJobs,
+  isCompanyJob: isDicSaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'fr',
+}).catch((err) => {
+  console.error(`❌ DIC SA crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/tests/cham-swiss-properties-crawler.test.ts
+++ b/tests/cham-swiss-properties-crawler.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHAM_SWISS_PROPERTIES_KEY,
+  CHAM_SWISS_PROPERTIES_COMPANY_NAME,
+  isChamSwissPropertiesJob,
+  isTrustedDomain,
+} from '../scripts/lib/cham-swiss-properties-job-parser.mjs';
+import { jobsChDetailUrl } from '../scripts/lib/jobs-ch-search-common.mjs';
+import { slugify } from '../scripts/lib/crawler-template.mjs';
+
+describe('Cham Swiss Properties crawler parser', () => {
+  // ── Constants ──
+  it('exports valid company key and name', () => {
+    expect(CHAM_SWISS_PROPERTIES_KEY).toBe('cham-swiss-properties');
+    expect(CHAM_SWISS_PROPERTIES_COMPANY_NAME).toBe('Cham Swiss Properties');
+  });
+
+  // ── isCompanyJob ──
+  describe('isChamSwissPropertiesJob', () => {
+    it('matches by companyKey', () => {
+      expect(isChamSwissPropertiesJob({ companyKey: 'cham-swiss-properties' })).toBe(true);
+    });
+
+    it('matches by company name', () => {
+      expect(isChamSwissPropertiesJob({ company: 'Cham Swiss Properties' })).toBe(true);
+      expect(isChamSwissPropertiesJob({ company: 'Cham Swiss Properties AG' })).toBe(true);
+    });
+
+    it('matches by URL domain', () => {
+      expect(
+        isChamSwissPropertiesJob({ url: 'https://www.champroperties.ch/en/company/karriere' })
+      ).toBe(true);
+    });
+
+    it('rejects unrelated jobs', () => {
+      expect(
+        isChamSwissPropertiesJob({ companyKey: 'other-company', company: 'Other', url: 'https://other.com/jobs' })
+      ).toBe(false);
+    });
+
+    it('rejects lexically similar but unrelated Cham-named entities', () => {
+      // Cham (ZG) real-estate holdings are a common naming pattern —
+      // make sure a generic "Cham ... AG" doesn't false-positive match.
+      expect(
+        isChamSwissPropertiesJob({ company: 'Cham Papier AG', url: 'https://cham-papier.ch/jobs' })
+      ).toBe(false);
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(isChamSwissPropertiesJob(null)).toBe(false);
+      expect(isChamSwissPropertiesJob(undefined)).toBe(false);
+      expect(isChamSwissPropertiesJob({})).toBe(false);
+    });
+  });
+
+  // ── isTrustedDomain ──
+  describe('isTrustedDomain', () => {
+    it('trusts champroperties.ch host and subdomains', () => {
+      expect(isTrustedDomain('https://www.champroperties.ch/en/company/karriere')).toBe(true);
+      expect(isTrustedDomain('https://champroperties.ch/en')).toBe(true);
+    });
+
+    it('trusts jobs.ch host (public search API source)', () => {
+      expect(isTrustedDomain('https://www.jobs.ch/en/vacancies/detail/abc-123/')).toBe(true);
+      expect(isTrustedDomain('https://jobs.ch/en')).toBe(true);
+    });
+
+    it('rejects untrusted domains', () => {
+      expect(isTrustedDomain('https://evil.example.com/jobs')).toBe(false);
+    });
+
+    it('handles malformed URLs gracefully', () => {
+      expect(isTrustedDomain('not-a-url')).toBe(false);
+      expect(isTrustedDomain('')).toBe(false);
+    });
+  });
+
+  // ── Detail URL helper ──
+  describe('jobsChDetailUrl', () => {
+    it('builds a valid jobs.ch detail URL', () => {
+      const url = jobsChDetailUrl('abc-123', 'en');
+      expect(url).toContain('abc-123');
+      expect(url).toMatch(/^https:\/\/www\.jobs\.ch\//);
+    });
+  });
+
+  // ── Slugify ──
+  describe('slugify', () => {
+    it('produces a URL-safe slug from title + company + location', () => {
+      const slug = slugify('Fachspezialist:in Vertragsmanagement 80-100% cham-swiss-properties Cham');
+      expect(slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  // ── Job Shape Validation ──
+  describe('job shape', () => {
+    const validJob = {
+      id: 'cham-swiss-properties-abc123',
+      slug: 'fachspezialist-vertragsmanagement-cham-swiss-properties-cham',
+      slugByLocale: { de: 'fachspezialist-vertragsmanagement-cham-swiss-properties-cham' },
+      company: 'Cham Swiss Properties',
+      companyKey: 'cham-swiss-properties',
+      companyDomain: 'champroperties.ch',
+      title: 'Fachspezialist:in Vertragsmanagement 80-100%',
+      titleByLocale: { de: 'Fachspezialist:in Vertragsmanagement 80-100%' },
+      description:
+        'Diese Beschreibung eines Testjobs ist absichtlich lang genug, um die Mindestanforderung von fünfzig Wörtern zu erfüllen, die von der automatisierten Thin-Content-Prüfung im dedizierten Crawler dieses Repositories verwendet wird, damit der Test sauber und ohne zusätzlichen Fülltext läuft, selbst wenn man die Worttrennung an Satzzeichen und Zeilenumbrüchen über verschiedene Sprachvarianten hinweg berücksichtigt und zählt.',
+      descriptionByLocale: {
+        de: 'Diese Beschreibung eines Testjobs ist absichtlich lang genug, um die Mindestanforderung von fünfzig Wörtern zu erfüllen, die von der automatisierten Thin-Content-Prüfung im dedizierten Crawler dieses Repositories verwendet wird, damit der Test sauber und ohne zusätzlichen Fülltext läuft, selbst wenn man die Worttrennung an Satzzeichen und Zeilenumbrüchen über verschiedene Sprachvarianten hinweg berücksichtigt und zählt.',
+      },
+      location: 'Cham',
+      canton: 'ZG',
+      url: 'https://www.jobs.ch/en/vacancies/detail/3c0276c4-c92c-4e6c-9fd5-06adef0ade09/',
+      source: 'Cham Swiss Properties Dedicated Parser (jobs.ch)',
+      sourceLang: 'de',
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: 'Cham',
+      addressRegion: 'ZG',
+      streetAddress: 'Fabrikstrasse 5',
+      postalCode: '6330',
+      addressCountry: 'CH',
+      country: 'CH',
+      employmentType: 'FULL_TIME',
+      postedDate: new Date().toISOString().slice(0, 10),
+      applyUrl: 'https://www.jobs.ch/en/vacancies/detail/3c0276c4-c92c-4e6c-9fd5-06adef0ade09/',
+      hiringOrganizationName: 'Cham Swiss Properties AG',
+      requirements: [],
+      requirementsByLocale: { de: [] },
+      category: 'Contract Management',
+      contract: 'full-time',
+      experienceLevel: 'mid',
+      sector: 'Immobiliare / Project Management',
+      currency: 'CHF',
+      featured: false,
+    };
+
+    it('includes all Non-Negotiable #3 required structured-data fields', () => {
+      expect(validJob.title).toBeTruthy();
+      expect(validJob.description).toBeTruthy();
+      expect(validJob.datePosted ?? validJob.postedDate).toBeTruthy();
+      expect(validJob.hiringOrganizationName).toBeTruthy();
+      expect(validJob.jobLocation ?? validJob.location).toBeTruthy();
+      expect(validJob.employmentType).toBeTruthy();
+      expect(validJob.postalCode).toBeTruthy();
+      expect(validJob.streetAddress).toBeTruthy();
+      expect(validJob.baseSalary ?? validJob.currency).toBeTruthy();
+    });
+
+    it('description meets the 50-word minimum (Non-Negotiable #4 thin-content floor)', () => {
+      const wordCount = validJob.description.split(/\s+/).filter(Boolean).length;
+      expect(wordCount).toBeGreaterThanOrEqual(50);
+    });
+
+    it('slug only contains the source locale', () => {
+      const locales = Object.keys(validJob.slugByLocale);
+      expect(locales).toHaveLength(1);
+      expect(locales[0]).toBe(validJob.sourceLang);
+    });
+
+    it('id starts with the company key', () => {
+      expect(validJob.id).toMatch(/^cham-swiss-properties-/);
+    });
+
+    it('slug is URL-safe', () => {
+      expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+
+    it('address country is CH', () => {
+      expect(validJob.addressCountry).toBe('CH');
+      expect(validJob.country).toBe('CH');
+    });
+  });
+});

--- a/tests/city-pop-crawler.test.ts
+++ b/tests/city-pop-crawler.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CITY_POP_KEY,
+  CITY_POP_COMPANY_NAME,
+  isCityPopJob,
+  isTrustedDomain,
+} from '../scripts/lib/city-pop-job-parser.mjs';
+import { jobsChDetailUrl } from '../scripts/lib/jobs-ch-search-common.mjs';
+import { slugify } from '../scripts/lib/crawler-template.mjs';
+
+describe('City Pop crawler parser', () => {
+  // ── Constants ──
+  it('exports valid company key and name', () => {
+    expect(CITY_POP_KEY).toBe('city-pop');
+    expect(CITY_POP_COMPANY_NAME).toBe('City Pop');
+  });
+
+  // ── isCompanyJob ──
+  describe('isCityPopJob', () => {
+    it('matches by companyKey', () => {
+      expect(isCityPopJob({ companyKey: 'city-pop' })).toBe(true);
+    });
+
+    it('matches by company name', () => {
+      expect(isCityPopJob({ company: 'City Pop' })).toBe(true);
+      expect(isCityPopJob({ company: 'City Pop AG' })).toBe(true);
+    });
+
+    it('matches by URL domain', () => {
+      expect(isCityPopJob({ url: 'https://citypop.com/career/test-job' })).toBe(true);
+    });
+
+    it('rejects unrelated jobs', () => {
+      expect(
+        isCityPopJob({ companyKey: 'other-company', company: 'Other', url: 'https://other.com/jobs' })
+      ).toBe(false);
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(isCityPopJob(null)).toBe(false);
+      expect(isCityPopJob(undefined)).toBe(false);
+      expect(isCityPopJob({})).toBe(false);
+    });
+  });
+
+  // ── isTrustedDomain ──
+  describe('isTrustedDomain', () => {
+    it('trusts the citypop.com host and subdomains', () => {
+      expect(isTrustedDomain('https://citypop.com/career/')).toBe(true);
+      expect(isTrustedDomain('https://www.citypop.com/')).toBe(true);
+    });
+
+    it('trusts the jobs.ch host (source-of-record ATS, not the corporate domain)', () => {
+      expect(isTrustedDomain('https://www.jobs.ch/en/vacancies/detail/abc-123/')).toBe(true);
+    });
+
+    it('rejects other domains', () => {
+      expect(isTrustedDomain('https://example.com/jobs')).toBe(false);
+    });
+
+    it('handles invalid URLs', () => {
+      expect(isTrustedDomain('')).toBe(false);
+      expect(isTrustedDomain('not-a-url')).toBe(false);
+    });
+  });
+
+  // ── jobsChDetailUrl (shared jobs.ch client, imported from jobs-ch-search-common) ──
+  describe('jobsChDetailUrl', () => {
+    it('builds the default (en) detail URL', () => {
+      expect(jobsChDetailUrl('abc-123')).toBe('https://www.jobs.ch/en/vacancies/detail/abc-123/');
+    });
+
+    it('respects a custom locale', () => {
+      expect(jobsChDetailUrl('abc-123', 'de')).toBe('https://www.jobs.ch/de/vacancies/detail/abc-123/');
+    });
+  });
+
+  // ── slugify (imported from crawler-template) ──
+  describe('slugify', () => {
+    it('converts title to URL-safe slug', () => {
+      const slug = slugify('Réceptionniste / Guest Relations (h/f), 80-100%');
+      expect(slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+
+    it('builds slug with company suffix inline', () => {
+      expect(slugify('receptionist city pop zurich')).toBe(
+        'receptionist-city-pop-zurich'
+      );
+    });
+  });
+
+  // ── Job Shape Validation ──
+  describe('job shape', () => {
+    const validJob = {
+      id: 'city-pop-abc123',
+      slug: 'test-position-city-pop-zurich',
+      slugByLocale: { de: 'test-position-city-pop-zurich' },
+      company: 'City Pop',
+      companyKey: 'city-pop',
+      companyDomain: 'citypop.com',
+      title: 'Test Position',
+      titleByLocale: { de: 'Test Position' },
+      description: 'A test job description long enough to satisfy the fifty word minimum content guard used across every dedicated crawler in this repository, so the automated thin-content check passes cleanly during validation runs without any additional padding text required here at all today, even after accounting for whitespace splitting and word boundary edge cases across locales and punctuation marks throughout this fixture string.',
+      descriptionByLocale: {
+        de: 'A test job description long enough to satisfy the fifty word minimum content guard used across every dedicated crawler in this repository, so the automated thin-content check passes cleanly during validation runs without any additional padding text required here at all today, even after accounting for whitespace splitting and word boundary edge cases across locales and punctuation marks throughout this fixture string.',
+      },
+      location: 'Zürich',
+      canton: 'ZH',
+      url: 'https://www.jobs.ch/en/vacancies/detail/abc-123/',
+      source: 'City Pop Dedicated Parser (jobs.ch)',
+      sourceLang: 'de',
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: 'Zürich',
+      addressRegion: 'ZH',
+      streetAddress: 'Bernerstrasse Süd 169',
+      postalCode: '8048',
+      addressCountry: 'CH',
+      country: 'CH',
+      employmentType: 'FULL_TIME',
+      postedDate: new Date().toISOString().slice(0, 10),
+      applyUrl: 'https://www.jobs.ch/en/vacancies/detail/abc-123/',
+    };
+
+    it('has all required fields', () => {
+      const required = [
+        'id', 'slug', 'slugByLocale', 'company', 'companyKey',
+        'title', 'titleByLocale', 'description', 'descriptionByLocale',
+        'location', 'canton', 'url', 'source', 'sourceLang', 'crawledAt',
+      ];
+      for (const field of required) {
+        expect(validJob).toHaveProperty(field);
+      }
+    });
+
+    it('has the structured-data fields required by Non-Negotiable #3', () => {
+      const structuredDataFields = [
+        'postalCode', 'streetAddress', 'title', 'description',
+        'postedDate', 'company', 'addressLocality', 'employmentType',
+      ];
+      for (const field of structuredDataFields) {
+        expect(validJob).toHaveProperty(field);
+      }
+    });
+
+    it('description is at least 50 words (Non-Negotiable #4 thin-content floor)', () => {
+      const wordCount = validJob.description.split(/\s+/).filter(Boolean).length;
+      expect(wordCount).toBeGreaterThanOrEqual(50);
+    });
+
+    it('slug only contains source locale', () => {
+      const locales = Object.keys(validJob.slugByLocale);
+      expect(locales).toHaveLength(1);
+      expect(locales[0]).toBe(validJob.sourceLang);
+    });
+
+    it('id starts with company key', () => {
+      expect(validJob.id).toMatch(/^city-pop-/);
+    });
+
+    it('slug is URL-safe', () => {
+      expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+});

--- a/tests/dic-sa-crawler.test.ts
+++ b/tests/dic-sa-crawler.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DIC_SA_KEY,
+  DIC_SA_COMPANY_NAME,
+  isDicSaJob,
+  isTrustedDomain,
+} from '../scripts/lib/dic-sa-job-parser.mjs';
+import { jobsChDetailUrl } from '../scripts/lib/jobs-ch-search-common.mjs';
+import { slugify } from '../scripts/lib/crawler-template.mjs';
+
+describe('DIC SA crawler parser', () => {
+  // ── Constants ──
+  it('exports valid company key name', () => {
+    expect(DIC_SA_KEY).toBe('dic-sa');
+    expect(DIC_SA_COMPANY_NAME).toBe('DIC SA');
+  });
+
+  // ── isCompanyJob ──
+  describe('isDicSaJob', () => {
+    it('matches by companyKey', () => {
+      expect(isDicSaJob({ companyKey: 'dic-sa' })).toBe(true);
+    });
+
+    it('matches by company name', () => {
+      expect(isDicSaJob({ company: 'DIC SA' })).toBe(true);
+    });
+
+    it('matches by URL domain', () => {
+      expect(isDicSaJob({ url: 'https://www.dic-ing.ch/fr/emploi/test-job' })).toBe(true);
+    });
+
+    it('rejects unrelated jobs', () => {
+      expect(
+        isDicSaJob({ companyKey: 'other-company', company: 'Other', url: 'https://other.com/jobs' })
+      ).toBe(false);
+    });
+
+    it('rejects unrelated jobs with a generic "DIC" acronym but different company', () => {
+      expect(
+        isDicSaJob({ companyKey: 'dic-holding-inc', company: 'DIC Holding Inc', url: 'https://dic-holding.example.com/careers' })
+      ).toBe(false);
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(isDicSaJob(null)).toBe(false);
+      expect(isDicSaJob(undefined)).toBe(false);
+      expect(isDicSaJob({})).toBe(false);
+    });
+  });
+
+  // ── isTrustedDomain ──
+  describe('isTrustedDomain', () => {
+    it('trusts dic-ing.ch host and subdomains', () => {
+      expect(isTrustedDomain('https://www.dic-ing.ch/fr/emploi/test-job')).toBe(true);
+      expect(isTrustedDomain('https://dic-ing.ch/team/')).toBe(true);
+    });
+
+    it('trusts jobs.ch and jobup.ch (jobs.ch API source)', () => {
+      expect(isTrustedDomain('https://www.jobs.ch/en/vacancies/detail/abc-123/')).toBe(true);
+      expect(isTrustedDomain('https://www.jobup.ch/fr/emploi/detail/abc-123/')).toBe(true);
+    });
+
+    it('rejects unrelated domains', () => {
+      expect(isTrustedDomain('https://other-company.com/jobs')).toBe(false);
+    });
+
+    it('handles malformed URLs gracefully', () => {
+      expect(isTrustedDomain('not-a-url')).toBe(false);
+      expect(isTrustedDomain('')).toBe(false);
+    });
+  });
+
+  // ── jobsChDetailUrl helper ──
+  describe('jobsChDetailUrl', () => {
+    it('builds a valid jobs.ch detail URL', () => {
+      const url = jobsChDetailUrl('abc-123', 'fr');
+      expect(url).toMatch(/^https:\/\/www\.jobs\.ch\/fr\/vacancies\/detail\/abc-123\/?$/);
+    });
+  });
+
+  // ── slugify ──
+  describe('slugify', () => {
+    it('produces a URL-safe slug from a job title + company + location', () => {
+      expect(slugify('Ingénieur civil EPF - Chef de projet (H/F) dic sa aigle')).toBe(
+        'ingenieur-civil-epf-chef-de-projet-h-f-dic-sa-aigle'
+      );
+    });
+  });
+
+  // ── Job Shape Validation ──
+  describe('job shape', () => {
+    const validJob = {
+      id: 'dic-sa-abc123',
+      slug: 'ingenieur-civil-chef-de-projet-dic-sa-aigle',
+      slugByLocale: { fr: 'ingenieur-civil-chef-de-projet-dic-sa-aigle' },
+      company: 'DIC SA',
+      companyKey: 'dic-sa',
+      companyDomain: 'dic-ing.ch',
+      title: 'Ingénieur civil EPF - Chef de projet (H/F)',
+      titleByLocale: { fr: 'Ingénieur civil EPF - Chef de projet (H/F)' },
+      description:
+        'Depuis plus de 40 ans, DIC SA ingénieurs s\'impose comme un bureau reconnu pour la qualité et la précision de ses ouvrages dans les domaines du génie civil, des ouvrages d\'art et des infrastructures routières et ferroviaires. Notre équipe à taille humaine met un point d\'honneur à produire des projets techniquement exigeants, avec un haut niveau de responsabilité et une forte autonomie au sein du bureau basé à Aigle dans le canton de Vaud, avec des succursales à Sion et Martigny en Valais desservant toute la région.',
+      descriptionByLocale: {
+        fr:
+          'Depuis plus de 40 ans, DIC SA ingénieurs s\'impose comme un bureau reconnu pour la qualité et la précision de ses ouvrages dans les domaines du génie civil, des ouvrages d\'art et des infrastructures routières et ferroviaires. Notre équipe à taille humaine met un point d\'honneur à produire des projets techniquement exigeants, avec un haut niveau de responsabilité et une forte autonomie au sein du bureau basé à Aigle dans le canton de Vaud, avec des succursales à Sion et Martigny en Valais desservant toute la région.',
+      },
+      location: 'Aigle',
+      canton: 'VD',
+      url: 'https://www.jobs.ch/fr/vacancies/detail/90aca745-50a2-46aa-ba78-f551572468cb/',
+      source: 'DIC SA Dedicated Parser (jobs.ch)',
+      sourceLang: 'fr',
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: 'Aigle',
+      addressRegion: 'VD',
+      streetAddress: 'Les Glariers',
+      postalCode: '1860',
+      addressCountry: 'CH',
+      country: 'CH',
+      employmentType: 'FULL_TIME',
+      postedDate: new Date().toISOString().slice(0, 10),
+      applyUrl: 'https://www.jobs.ch/fr/vacancies/detail/90aca745-50a2-46aa-ba78-f551572468cb/',
+      hiringOrganizationName: 'DIC SA',
+    };
+
+    it('includes all Non-Negotiable #3 required structured-data fields', () => {
+      expect(validJob.title).toBeTruthy();
+      expect(validJob.description).toBeTruthy();
+      expect(validJob.datePosted ?? validJob.postedDate).toBeTruthy();
+      expect(validJob.hiringOrganizationName).toBeTruthy();
+      expect(validJob.employmentType).toBeTruthy();
+      expect(validJob.postalCode).toBeTruthy();
+      expect(validJob.streetAddress).toBeTruthy();
+      expect(validJob.addressLocality || validJob.location).toBeTruthy();
+      expect(validJob.canton).toBeTruthy();
+    });
+
+    it('description satisfies Non-Negotiable #4 (≥50 word thin-content floor)', () => {
+      const wordCount = validJob.description.split(/\s+/).filter(Boolean).length;
+      expect(wordCount).toBeGreaterThanOrEqual(50);
+    });
+
+    it('slug only contains source locale', () => {
+      const locales = Object.keys(validJob.slugByLocale);
+      expect(locales).toHaveLength(1);
+      expect(locales[0]).toBe(validJob.sourceLang);
+    });
+
+    it('id starts with company key', () => {
+      expect(validJob.id).toMatch(/^dic-sa-/);
+    });
+
+    it('slug is URL-safe', () => {
+      expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+
+    it('canton is a valid Swiss canton code', () => {
+      expect(validJob.canton).toMatch(/^[A-Z]{2}$/);
+    });
+  });
+});


### PR DESCRIPTION
## Implementato

Crawler dedicati costruiti per issue #3621 (residuo di #3342, 17 aziende senza copertura). Ogni voce del residuo è stata verificata individualmente (career URL reale, ATS, natura dell'azienda) prima di costruire o skippare — diverse premesse dell'issue originale si sono rivelate errate e sono state corrette sul campo (dettagli sotto).

**3 crawler dedicati live (pattern jobs.ch / JobCloud AG feed, riuso di `scripts/lib/jobs-ch-search-common.mjs`, nessuna modifica a moduli condivisi):**

- `city-pop` — City Pop AG (micro-living/serviced-apartment scale-up, fondata in Ticino, sede legale oggi Zürich, succursale TI attiva a Manno). jobs.ch companyId `eb0155fc-e81e-4f2c-8770-e211d2689811`. 0 posizioni aperte al momento del build (feed live, `totalHits: 0`) — si popolerà automaticamente alle prossime aperture.
- `cham-swiss-properties` — Cham Swiss Properties AG (SIX: CHAM), real estate/project management, sede **Cham (ZG)** — corretta la premessa dell'issue originale che indicava Ginevra (era solo un cantiere, non l'HQ). jobs.ch companyId `142189`.
- `dic-sa` — DIC SA ingénieurs, ingegneria civile, Aigle (VD). jobs.ch companyId (UUID attivo) `ee30c164-1431-42ab-af87-d45a5dc3579f` — il numeric id legacy `81584` risultava stale/0 annunci, individuato l'id UUID corretto con annuncio live confermato (Ingénieur civil EPF, pubblicato 2026-06-29).

Ogni crawler: 4 file per convenzione `docs/CRAWLERS.md` (`scripts/lib/{slug}-job-parser.mjs`, `scripts/update-{slug}-jobs.mjs`, `.github/workflows/update-jobs-{slug}.yml`, `tests/{slug}-crawler.test.ts`), test verdi (58/58 su 3 file), `node --check` pulito, HQ locale nel parser (non nello shared `crawler-location-config.mjs`, zero rischio di conflitto).

**14 item verificati e risolti come skip motivato (non silenzioso):**

- **Insel Gruppe SA** — duplicato: `jobs.inselgruppe.ch` è lo stesso portale già coperto da `scripts/lib/inselspital-job-parser.mjs`.
- **beeworx GmbH** — agenzia di staffing/verniciatura industriale in appalto, esclusa da policy "no staffing/interinali".
- **exedra** — agenzia di staffing assicurativo; nessun legame reale con Sanitas (gruppo citato nell'issue come alibi per lo skip è risultato infondato — verificato comunque, Sanitas stessa non ha crawler proprio).
- **Zurich Insurance Company Ltd** — duplicato: `scripts/update-zurich-jobs.mjs` già crawla `careers.zurich.com` (SuccessFactors) con termini di ricerca CH-wide, non solo TI/GR come indicato nell'issue. **Nota**: durante la verifica è emerso che questo crawler pre-esistente è rotto in produzione (0 job estratti nelle ultime run pur con 47 posizioni reali live) — tracciato separatamente, vedi issue follow-up.
- **Klinik im Park** — duplicato: stesso gruppo/portale di Hirslanden (`scripts/lib/hirslanden-job-parser.mjs`, `careers.mediclinic.com`), 34 posting con URL `Hirslanden-Klinik-Im-Park-...` già presenti in `data/jobs/by-crawler/hirslanden.json`.
- **Centre Dentaire B1 SA** — nessun portale annunci pubblico trovato dopo ricerca.
- **Società Bancaria Ticinese** — nessun portale annunci pubblico esistente.
- **Gruppo GKSD** — nessuna operatività TI verificabile + nessun portale scrapabile.
- **Tecnopinz SA** — nessun portale annunci pubblico trovato.
- **Trasteel Trading Holding SA** — nessun portale, solo contatto via email.
- **Increo®** — entità non identificabile pubblicamente in modo affidabile.
- **Dickies® (VF Corp)** — duplicato: `scripts/update-vf-jobs.mjs` (companyKey `vf-international-the-north-face-timberland`) già crawla il tenant Workday `vfc.wd5.myworkdayjobs.com/vfc_careers` filtrato per `Location_Country=Switzerland` (non per brand) — 35 job attivi già in `data/jobs/by-crawler/vf-international-the-north-face-timberland.json` (Vans/Timberland/North Face/icebreaker/Smartwool/Altra/Napapijri), Dickies incluso by-construction.
- **C.P. Company** — nessun portale trovato; nessun legame reale con gruppo OTB verificato (premessa issue infondata).
- **Avenir Rénovations** — nessuna presenza operativa TI verificabile, solo recruitment via rete franchising senza portale scrapabile.

## Non implementato (ancora)

Nessuno — tutti i 17 item del residuo #3621 hanno una risoluzione finale: 3 crawler dedicati costruiti e live in questa PR, 14 skip motivati e verificati singolarmente (nessuno silenzioso, tutti documentati sopra con la ragione specifica).

Nota fuori scope di questa PR, tracciata separatamente: il crawler pre-esistente `zurich-insurance-sede-ticino`/`update-zurich-jobs.mjs` risulta rotto in produzione (0 job estratti nelle ultime 4 run schedulate nonostante 47 posting reali live su jobs.ch) — issue follow-up dedicata aperta, non è uno scope di questa PR (bug in infra condivisa pre-esistente, non parte del residuo #3621).

Closes #3621
