### PR TITLE
fix(resolve-append-conflicts): correct duplicated-closer test premise with real repro (post-#3622)

### DIFF
--- a/scripts/lib/resolve-append-conflicts.sh
+++ b/scripts/lib/resolve-append-conflicts.sh
@@ -8,11 +8,17 @@
 # same insertion point, git marks the spot as a conflict; both additions are
 # valid and must be kept. This helper:
 #   1. Strips conflict markers, keeping content from BOTH sides.
-#   2. Repairs a duplicated root closer left by a chained rebase-conflict
-#      cycle (issue #3617-class) in the non-JSON growing-container siblings —
+#   2. Defense-in-depth for the non-JSON growing-container siblings —
 #      blog-articles-data.ts, swiss-articles-data.ts, seo-pages.ts,
 #      blog-meta-*.ts, sitemap*.xml — via
-#      scripts/lib/dedupe-growing-container-closer.mjs.
+#      scripts/lib/dedupe-growing-container-closer.mjs: repairs a duplicated
+#      root closer IF one is present (no-op otherwise). Real chained-rebase
+#      reproduction (tests/resolve-append-conflicts-idempotency.test.ts)
+#      found this exact corruption shape only actually occurs for JSON;
+#      these siblings either resolve cleanly on their own or hit a
+#      different failure caught by step 5 below. Kept in case a future
+#      insertion-anchor change or a different conflict shape does produce
+#      it.
 #   3. Repairs JSON files that lose commas during marker removal (including
 #      the JSON-shaped version of the same duplicated-root-closer corruption).
 #   4. Dedupes single-declaration conflicts in routerBlogData.ts and router.ts

--- a/tests/dedupe-growing-container-closer.test.ts
+++ b/tests/dedupe-growing-container-closer.test.ts
@@ -1,11 +1,20 @@
 /**
- * Regression coverage for the PR #3622 review finding: the issue #3617
- * duplicated-root-closer repair only covered JSON. The SAME chained
- * rebase-conflict-cycle corruption shape hits the non-JSON append-only
- * siblings whose insertion anchors on the container's own closing token —
- * blog-articles-data.ts, swiss-articles-data.ts, seo-pages.ts,
- * blog-meta-*.ts, sitemap*.xml. This locks in
- * scripts/lib/dedupe-growing-container-closer.mjs's per-target repair.
+ * Unit coverage for scripts/lib/dedupe-growing-container-closer.mjs's
+ * per-target repair (PR #3622 review follow-up to issue #3617's JSON-only
+ * duplicated-root-closer fix). These tests feed the repair functions the
+ * documented corrupted shape directly and check the repair logic in
+ * isolation — they do not assert that real concurrent-writer git mechanics
+ * produce that shape for every target. End-to-end reproduction via real
+ * chained rebase (tests/resolve-append-conflicts-idempotency.test.ts) found
+ * that only JSON files reach a duplicated closer this way: the array-of-
+ * object siblings (blog-articles-data.ts, swiss-articles-data.ts) instead
+ * hit a different, already-handled failure (aligned inner-field conflict,
+ * safely rejected by the pre-existing article-registry check), and the
+ * single-line-entry siblings (blog-meta-*.ts, sitemap*.xml, seo-pages.ts's
+ * ItemList) resolve cleanly across chained cycles with no duplication at
+ * all. This module is kept as defense-in-depth for the documented shape —
+ * a no-op on already-correct input — not as a fix for a confirmed-reachable
+ * bug in these targets.
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/resolve-append-conflicts-idempotency.test.ts
+++ b/tests/resolve-append-conflicts-idempotency.test.ts
@@ -187,3 +187,159 @@ describe('resolve_append_conflicts — chained rebase-retry idempotency (issue #
     expect(readJson(local, TARGET)).toEqual({ u0: 's0', uZ1: 'sZ1', uLocal: 'sLocal' });
   });
 });
+
+// Regression coverage for PR #3622's reviewer follow-up: the #3617 fix above
+// only repaired the duplicated-root-closer shape for JSON. The reviewer asked
+// whether the SAME shape hits non-JSON append-only siblings whose insertion
+// regex anchors on the container's own closing token.
+//
+// Empirical finding (real git rebase, not hand-rolled, for both shapes
+// below): it does NOT reproduce the same way as JSON. Two concurrent
+// single-*line*-entry insertions (sitemap*.xml `<url>` blocks, blog-meta-
+// *.ts `Record<string, string>` keys, seo-pages.ts's ItemList) resolve
+// cleanly across chained cycles with a single closer, verified below for
+// dist/sitemap-blog.xml. Two concurrent single-*object*-entry insertions
+// into an array (blog-articles-data.ts, swiss-articles-data.ts) instead
+// produce an ALIGNED inner-field conflict — git's diff3 treats both sides as
+// editing the SAME new entry slot rather than two adjacent slots — which
+// "keep both" would fuse into one object with duplicate `id`/`category`
+// keys. That is a DIFFERENT failure mode than a duplicated closer, and it
+// was already caught (not silently merged) by the pre-existing
+// article-registry validation further down in resolve_append_conflicts
+// (`entryStarts !== ids.length`), which predates this PR — verified below.
+//
+// scripts/lib/dedupe-growing-container-closer.mjs is kept as defense-in-depth
+// for the literal duplicated-closer shape (it's a no-op on already-correct
+// input — see the "clean/no-op" cases in
+// tests/scripts/dedupe-growing-container-closer.test.ts) but nothing here
+// claims that shape is reachable via natural concurrent-writer git mechanics
+// for these targets.
+describe('resolve_append_conflicts — non-JSON growing-container siblings (issue #3617-class follow-up, PR #3622)', () => {
+  const TS_TARGET = 'data/blog-articles-data.ts';
+
+  function appendEntry(dir: string, id: string): void {
+    const file = path.join(dir, TS_TARGET);
+    const src = readFileSync(file, 'utf-8');
+    const newEntry = `  {\n    id: '${id}',\n    category: 'guide',\n  },`;
+    const next = src.replace(
+      /([ \t]*},\n)(\](?:[ \t]+satisfies[ \t]+Article\[\])?;)/,
+      `$1${newEntry}\n$2`,
+    );
+    expect(next).not.toBe(src); // sanity: the anchor regex must actually match
+    writeFileSync(file, next);
+  }
+
+  it('safely rejects (does not corrupt) a same-anchor array-entry collision on blog-articles-data.ts', () => {
+    const local = path.join(work, 'local');
+    const writer = path.join(work, 'writer');
+
+    const base = [
+      'const RAW_ARTICLES = [',
+      '  {',
+      "    id: 'base',",
+      "    category: 'guide',",
+      '  },',
+      '] satisfies Article[];',
+      '',
+      'export const ARTICLES = RAW_ARTICLES;',
+      '',
+    ].join('\n');
+    writeFileSync(path.join(local, TS_TARGET), base);
+    sh('git add -A && git commit -q -m "ts base"', local);
+    sh('git push -q origin main', local);
+    sh('git pull -q origin main', writer);
+
+    appendEntry(local, 'local');
+    sh('git add -A && git commit -q -m "local: add entry"', local);
+
+    appendEntry(writer, 'z1');
+    sh('git add -A && git commit -q -m "writer: add z1"', writer);
+    sh('git push -q origin main', writer);
+
+    const push1 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push1.status).not.toBe(0);
+
+    sh('git fetch -q origin main', local);
+    const rebase = spawnSync('git', ['rebase', 'origin/main'], { cwd: local, env: shimEnv() });
+    expect(rebase.status).not.toBe(0);
+
+    // The resolver must refuse to "keep both" here — that would silently
+    // fuse z1's and local's entries into one malformed object — and instead
+    // fail the cycle, leaving the rebase in progress for the caller to abort.
+    const resolve = spawnSync(
+      'bash',
+      ['-c', `source "${RESOLVER}" && resolve_append_conflicts && git add -A`],
+      { cwd: local, env: shimEnv() },
+    );
+    expect(resolve.status).not.toBe(0);
+
+    spawnSync('git', ['rebase', '--abort'], { cwd: local, env: shimEnv() });
+    const final = readFileSync(path.join(local, TS_TARGET), 'utf-8');
+    const ids = [...final.matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1]);
+    expect(ids).toEqual(['base', 'local']); // rebase aborted, local's own pre-conflict state restored
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate/merged keys anywhere
+  });
+
+  const XML_TARGET = 'dist/sitemap-blog.xml';
+
+  function appendUrl(dir: string, id: string): void {
+    const file = path.join(dir, XML_TARGET);
+    const src = readFileSync(file, 'utf-8');
+    const next = src.replace(
+      /(<\/urlset>)/,
+      `<url><loc>https://frontaliereticino.ch/blog/${id}/</loc></url>\n$1`,
+    );
+    expect(next).not.toBe(src);
+    writeFileSync(file, next);
+  }
+
+  it('resolves a single-line-entry sitemap target cleanly across two chained rebase cycles', () => {
+    const local = path.join(work, 'local');
+    const writer = path.join(work, 'writer');
+
+    mkdirSync(path.join(local, 'dist'), { recursive: true });
+    const base = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      '<url><loc>https://frontaliereticino.ch/blog/base/</loc></url>',
+      '</urlset>',
+      '',
+    ].join('\n');
+    writeFileSync(path.join(local, XML_TARGET), base);
+    sh('git add -A && git commit -q -m "xml base"', local);
+    sh('git push -q origin main', local);
+    sh('git pull -q origin main', writer);
+
+    // Cycle 1.
+    appendUrl(local, 'local');
+    sh('git add -A && git commit -q -m "local: add url"', local);
+
+    appendUrl(writer, 'z1');
+    sh('git add -A && git commit -q -m "writer: add z1"', writer);
+    sh('git push -q origin main', writer);
+
+    const push1 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push1.status).not.toBe(0);
+    expect(runRebaseCycle(local)).toBe(0);
+
+    // Cycle 2 (chained): another writer append lands before local's second
+    // push attempt settles.
+    appendUrl(writer, 'z2');
+    sh('git add -A && git commit -q -m "writer: add z2"', writer);
+    sh('git push -q origin main', writer);
+
+    const push2 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push2.status).not.toBe(0);
+    expect(runRebaseCycle(local)).toBe(0);
+
+    const push3 = spawnSync('git', ['push', 'origin', 'HEAD:main'], { cwd: local, env: shimEnv() });
+    expect(push3.status).toBe(0);
+
+    const final = readFileSync(path.join(local, XML_TARGET), 'utf-8');
+    const closers = [...final.matchAll(/<\/urlset>/g)];
+    expect(closers.length).toBe(1);
+    for (const id of ['base', 'local', 'z1', 'z2']) {
+      expect(final).toContain(`/blog/${id}/`);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

PR #3622 shipped `scripts/lib/dedupe-growing-container-closer.mjs` (defense-in-depth repair for a duplicated-root-closer shape) plus a docstring/test claiming the 5 non-JSON growing-container siblings (`blog-articles-data.ts`, `swiss-articles-data.ts`, `blog-meta-*.ts`, `sitemap*.xml`, `seo-pages.ts`'s ItemList) are "confirmed vulnerable" to the same corruption class as issue #3617 (JSON-only). That PR merged (2026-07-06T06:13:42Z) before this correction was ready — this is a follow-up PR against the now-merged `main`, not an update to #3622 (its branch was auto-deleted on merge).

This PR corrects that premise with real end-to-end reproduction (real chained rebase-conflict cycles, not hand-authored fixtures):

- Extended `tests/resolve-append-conflicts-idempotency.test.ts` with 2 new integration tests that actually run 2 concurrent writers through a real `git rebase` conflict cycle (matching the exact mechanics used by the pre-existing #3617 JSON test) against:
  - `blog-articles-data.ts` (array-of-objects shape, proxy for `swiss-articles-data.ts`'s identical code path): the concurrent single-entry insertions produce an *aligned inner-field conflict* (both sides' `id:` line land in the same conflict hunk), NOT a duplicated closer. `resolve_append_conflicts` correctly refuses to "keep both" here (non-zero exit) — already safely caught by the pre-existing article-registry validation, not silently corrupted.
  - `sitemap-blog.xml` (single-line-entry shape, proxy for `blog-meta-*.ts` and `seo-pages.ts`'s ItemList): resolves cleanly across two chained rebase cycles with a single closer and no duplication at all, with or without the new dedupe module.
- Rewrote the overclaiming docstrings in `scripts/lib/resolve-append-conflicts.sh` (item 2 of the header comment) and `tests/dedupe-growing-container-closer.test.ts` to accurately describe `dedupe-growing-container-closer.mjs` as defense-in-depth (a no-op on already-correct input) rather than a fix for a demonstrated-reachable bug in these 5 targets — since natural git mechanics don't reproduce the duplicated-closer shape for them.
- No functional/behavioral change: `dedupe-growing-container-closer.mjs` and its wiring in `resolve-append-conflicts.sh` are untouched: same repair logic stays in place as defense-in-depth in case a future insertion-anchor change or different conflict shape does produce this corruption for these targets.

Verified: `tests/resolve-append-conflicts-idempotency.test.ts` + `tests/dedupe-growing-container-closer.test.ts` — 14/14 pass on top of current `main` (`cdef85d036e`). `bash -n scripts/lib/resolve-append-conflicts.sh` — syntax OK.

## Non implementato (ancora)

Nessuno.