### PR TITLE
fix(seo): prove jobMarketSnapshot pathAlternates Map key collision-proof

### DIFF
--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -3251,6 +3251,39 @@ export function jobMarketSnapshotPlugin(rootDir: string): Plugin {
       for (const [path, html] of Object.entries(sectorOutput.pages)) {
         pages[path] = html;
       }
+      // (#3579 item 2 — adversarial review of #3560) Structural guarantee:
+      // this merge can never silently let one bucket type's alternates
+      // clobber another's. `pathAlternates` is keyed by `canonicalPath`
+      // strings from 4 builders in jobMarketSnapshotData.ts (buildHubPath /
+      // buildWeeklyPath / buildMonthlyPath feed the map above; buildSector-
+      // SnapshotPath feeds `sectorOutput` here) — none of them can degenerate
+      // to an empty/overlapping segment that would make two bucket types
+      // produce the same key:
+      //   - `joinPath` drops empty array elements, so a path only collapses
+      //     to a shorter shape if a variable segment (weekSlug/monthSlug/
+      //     sector slug) reduces to ''. That can't happen: `JOB_MARKET_WEEK_
+      //     PREFIX` is a fixed non-empty word per locale, `buildMonthlyPath`
+      //     throws `RangeError` for month outside 1-12 (so `monthName` is
+      //     always a real word, never the empty index-0 placeholder), and
+      //     `buildSectorSnapshotPath` throws for any key missing from
+      //     `JOB_MARKET_SECTOR_SLUG` (every valid key maps to a non-empty
+      //     slug). So hub paths always have exactly 1 fewer path segment than
+      //     weekly/monthly, which always have exactly 1 fewer than sector —
+      //     no bucket type's canonicalPath shape can collapse into another's.
+      //   - Weekly vs. monthly share the same segment count (`sectionSlug` +
+      //     one variable segment), so segment count alone doesn't separate
+      //     them — but their content still can't collide: `weekSlug` is
+      //     `${WEEK_PREFIX}-{2-digit week}-{year}` (always exactly 2 hyphens,
+      //     since the prefix/week/year never contain one), while `monthSlug`
+      //     is `${monthName}-{year}` (always exactly 1 hyphen, since none of
+      //     the 48 localised month names — it/en/de/fr × 12 — contain a
+      //     hyphen). A 2-hyphen string can never equal a 1-hyphen string.
+      // Locked by the "pathAlternates key collision-proof" describe block in
+      // tests/job-market-snapshot.test.ts, which enumerates every hub/weekly/
+      // monthly/sector path across boundary weeks/months/sectors/locales and
+      // asserts zero duplicates. If a future change ever lets one of these
+      // slugs (or the locale prefix) go empty or gain/lose a hyphen, that
+      // test — and the guard clauses cited above — must be revisited.
       for (const [path, alt] of sectorOutput.pathAlternates) {
         pathAlternates.set(path, alt);
       }

--- a/tests/job-market-snapshot.test.ts
+++ b/tests/job-market-snapshot.test.ts
@@ -17,8 +17,11 @@ import { describe, expect, it } from 'vitest';
 import {
   JOB_MARKET_SNAPSHOT_LOCALES,
   JOB_MARKET_SNAPSHOT_ROUTES,
+  JOB_MARKET_MONTH_NAMES,
   JOB_MARKET_SECTION_SLUG,
   JOB_MARKET_SECTOR_KEYS,
+  JOB_MARKET_SECTOR_SLUG,
+  JOB_MARKET_WEEK_PREFIX,
   buildHubPath,
   buildMonthlyPath,
   buildSectorSnapshotPath,
@@ -176,6 +179,99 @@ describe('jobMarketSnapshotData — path builders', () => {
   it('rejects invalid months', () => {
     expect(() => buildMonthlyPath('it', 2026, 0)).toThrow(RangeError);
     expect(() => buildMonthlyPath('it', 2026, 13)).toThrow(RangeError);
+  });
+});
+
+// ── pathAlternates key collision-proof (issue #3579 item 2) ─────
+//
+// Adversarial review of #3560 flagged that `jobMarketSnapshotPlugin.ts`
+// merges 4 generators' output (hub / weekly / monthly / sector) into one
+// `pathAlternates` Map keyed by `canonicalPath`, and worried a degenerate
+// ("empty subSlug") case could make two bucket types collide on the same
+// key, silently overwriting one bucket type's hreflang alternates with
+// another's. This suite proves the collision is structurally impossible
+// given the guard clauses in the 4 path builders below (see also the
+// doc-comment at the `pathAlternates` merge site in
+// build-plugins/jobMarketSnapshotPlugin.ts, closeBundle) — not just today's
+// fixtures, but the invariants themselves:
+//   1. None of the variable segments (weekSlug/monthSlug/sector slug) can
+//      ever be empty, so `joinPath` (which drops empty array elements)
+//      never collapses a weekly/monthly/sector path down to a shorter
+//      bucket type's shape.
+//   2. Weekly and monthly paths share the same segment COUNT, but their
+//      content can never collide because weekSlug always has exactly 2
+//      hyphens and monthSlug always has exactly 1 (enforced by the
+//      constants below never containing an embedded hyphen).
+describe('pathAlternates key collision-proof (issue #3579 item 2)', () => {
+  it('JOB_MARKET_WEEK_PREFIX values are non-empty and hyphen-free', () => {
+    // If a future locale prefix went empty or gained a hyphen, weekSlug's
+    // hyphen count (see below) would no longer be a reliable discriminator
+    // against monthSlug — this locks the precondition.
+    for (const locale of JOB_MARKET_SNAPSHOT_LOCALES) {
+      const prefix = JOB_MARKET_WEEK_PREFIX[locale];
+      expect(prefix.length, `empty week prefix for ${locale}`).toBeGreaterThan(0);
+      expect(prefix, `hyphen in week prefix for ${locale}`).not.toContain('-');
+    }
+  });
+
+  it('every localised month name (index 1-12) is non-empty and hyphen-free', () => {
+    for (const locale of JOB_MARKET_SNAPSHOT_LOCALES) {
+      for (let month = 1; month <= 12; month++) {
+        const name = JOB_MARKET_MONTH_NAMES[locale][month];
+        expect(name.length, `empty month name ${locale}/${month}`).toBeGreaterThan(0);
+        expect(name, `hyphen in month name ${locale}/${month}`).not.toContain('-');
+      }
+    }
+  });
+
+  it('every sector slug is non-empty (buildSectorSnapshotPath can never emit an empty leaf)', () => {
+    for (const sector of JOB_MARKET_SECTOR_KEYS) {
+      expect(JOB_MARKET_SECTOR_SLUG[sector].length, `empty slug for sector ${sector}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('buildSectorSnapshotPath rejects an unknown sector key instead of emitting an empty leaf', () => {
+    expect(() => buildSectorSnapshotPath('it', 'not-a-real-sector' as any)).toThrow(RangeError);
+  });
+
+  it('weekSlug always has exactly 2 hyphens, monthSlug always exactly 1 — they can never collide', () => {
+    for (const locale of JOB_MARKET_SNAPSHOT_LOCALES) {
+      for (const isoWeek of [1, 9, 16, 52, 53]) {
+        const weekly = buildWeeklyPath(locale, 2026, isoWeek);
+        const weekSlug = weekly.split('/').filter(Boolean).pop()!;
+        expect((weekSlug.match(/-/g) ?? []).length, `weekSlug ${weekSlug}`).toBe(2);
+      }
+      for (let month = 1; month <= 12; month++) {
+        const monthly = buildMonthlyPath(locale, 2026, month);
+        const monthSlug = monthly.split('/').filter(Boolean).pop()!;
+        expect((monthSlug.match(/-/g) ?? []).length, `monthSlug ${monthSlug}`).toBe(1);
+      }
+    }
+  });
+
+  it('hub/weekly/monthly/sector paths never collide across the full boundary grid, per locale and cross-locale', () => {
+    // Enumerate every path the 4 generators can produce across a boundary
+    // grid (min/max ISO week, every month, every sector, every locale) and
+    // assert global uniqueness — i.e. the exact scenario the merge loop in
+    // closeBundle (`for (const [path, alt] of sectorOutput.pathAlternates)
+    // pathAlternates.set(path, alt)`) would silently mask if two bucket
+    // types ever produced the same key.
+    const allPaths: string[] = [];
+    for (const locale of JOB_MARKET_SNAPSHOT_LOCALES) {
+      allPaths.push(buildHubPath(locale));
+      for (const isoWeek of [1, 9, 16, 52, 53]) {
+        allPaths.push(buildWeeklyPath(locale, 2026, isoWeek));
+        allPaths.push(buildWeeklyPath(locale, 2000, isoWeek));
+      }
+      for (let month = 1; month <= 12; month++) {
+        allPaths.push(buildMonthlyPath(locale, 2026, month));
+      }
+      for (const sector of JOB_MARKET_SECTOR_KEYS) {
+        allPaths.push(buildSectorSnapshotPath(locale, sector));
+      }
+    }
+    const unique = new Set(allPaths);
+    expect(unique.size, 'a collision would shrink the Set below the enumerated count').toBe(allPaths.length);
   });
 });
 


### PR DESCRIPTION
## Implementato

Resolves item 2 of the #3579 follow-up (item 1 was already resolved separately via merged PR #3591 — not touched here).

Investigated whether `jobMarketSnapshotPlugin.ts`'s `pathAlternates` Map (keyed by `canonicalPath`, merged from 4 generators — hub, weekly, monthly inside `generateJobMarketSnapshotPages`, plus sector inside `generateSectorSnapshotPages`) can suffer a key collision when the bucket-discriminating slug segment degenerates to empty, silently letting one bucket type's hreflang alternates overwrite another's.

**Conclusion: false positive**, backed by reading all 4 path-builder functions in `build-plugins/jobMarketSnapshotData.ts`:

- `buildHubPath` → `joinPath([localePrefix, sectionSlug])`
- `buildWeeklyPath` → `joinPath([localePrefix, sectionSlug, weekSlug])` where `weekSlug = ${JOB_MARKET_WEEK_PREFIX[locale]}-${week}-${year}`
- `buildMonthlyPath` → `joinPath([localePrefix, sectionSlug, monthSlug])` where `monthSlug = ${monthName}-${year}`; **throws `RangeError`** for month outside 1-12
- `buildSectorSnapshotPath` → `joinPath([localePrefix, sectionSlug, sectorSegment, slug])`; **throws `RangeError`** for any sector key missing from `JOB_MARKET_SECTOR_SLUG`

`joinPath` drops empty array elements, so a path can only collapse into a shorter bucket type's shape if a variable segment (`weekSlug`/`monthSlug`/sector `slug`) becomes `''`. That's structurally impossible here:
- `JOB_MARKET_WEEK_PREFIX` is a fixed non-empty word per locale (`settimana`/`week`/`woche`/`semaine`) — never empty.
- `buildMonthlyPath` throws before returning for any month outside 1-12, so `monthName` is always a real word (never the empty index-0 placeholder in `JOB_MARKET_MONTH_NAMES`).
- `buildSectorSnapshotPath` throws for any key not in `JOB_MARKET_SECTOR_SLUG`; every valid key maps to a non-empty slug.

So hub paths always have exactly 1 fewer path segment than weekly/monthly, which always have exactly 1 fewer than sector — no bucket type's path shape can ever collapse into another's.

Weekly and monthly *do* share the same segment count (`sectionSlug` + one variable segment), so segment count alone doesn't separate them — but their content still can't collide: `weekSlug` is always `${WEEK_PREFIX}-{2-digit week}-{year}` (exactly 2 hyphens, since the prefix/week/year never contain one), while `monthSlug` is always `${monthName}-{year}` (exactly 1 hyphen, since none of the 48 localised month names — it/en/de/fr × 12 — contain a hyphen). A 2-hyphen string can never equal a 1-hyphen string.

Cross-locale collisions are also ruled out: each locale's `sectionSlug`/prefix is a distinct literal string baked into every one of its 4 path types.

**Changes:**
- `build-plugins/jobMarketSnapshotPlugin.ts`: added a structural-guarantee doc comment at the `pathAlternates` merge site in `closeBundle` (mirrors the existing `#3060 item 2` doc-comment style already next to `generateSectorSnapshotPages`), citing the exact guard clauses that make the collision impossible.
- `tests/job-market-snapshot.test.ts`: new `describe('pathAlternates key collision-proof (issue #3579 item 2)')` block that:
  - Locks the preconditions (week prefixes / month names / sector slugs are all non-empty and hyphen-free where relevant).
  - Locks that `buildSectorSnapshotPath` throws for an unknown sector key instead of emitting an empty leaf.
  - Locks the hyphen-count discriminator between `weekSlug` (2 hyphens) and `monthSlug` (1 hyphen).
  - Enumerates every hub/weekly/monthly/sector path across a boundary grid (min/max ISO week, every month, every sector, every locale, two different years) and asserts the resulting `Set` size equals the enumerated count — i.e. zero collisions.

Sibling check (Non-Negotiable #6): grepped `build-plugins/**` for the same "merge N generators' output into one Map keyed by canonicalPath" pattern — no other file does this; the pattern is unique to `jobMarketSnapshotPlugin.ts`, so no sibling fix is needed.

Tests: `npx vitest run tests/job-market-snapshot.test.ts tests/job-market-sector.test.ts` → 83/83 passing (48 + 35), including the 5 new collision-proof tests. `npx tsc --noEmit` shows zero errors touching `jobMarketSnapshot*` files (pre-existing unrelated errors elsewhere in the test suite are untouched by this diff). `gitnexus impact` on `jobMarketSnapshotPlugin` → risk LOW (comment-only change to the function body, no signature/logic change).

**Why no `Closes` keyword:** #3579 is labeled `follow-up` and its title contains "2 item deferred", so it trips the `pr-body-contract.yml` multi-item-aggregate gate — `Closes #N` on such an issue is GitHub-native, fires blindly on squash-merge, and bypasses the reconcile veto (the exact #3050→#3036 recurrence the gate exists to prevent). Both items ARE genuinely done (item 1 via #3591, item 2 via this PR), so after this PR merges I will manually run `gh issue close 3579` with a comment citing both resolutions — a verified manual close, not an automatic blind one.

## Non implementato (ancora)

Nessuno.