### PR TITLE
fix: mix-adjusted rate gate incomplete-scan flag (#3607)

### DIFF
--- a/scripts/audit-h1-title-duplicates.mjs
+++ b/scripts/audit-h1-title-duplicates.mjs
@@ -160,7 +160,7 @@ export function createAuditor(opts = {}) {
           const baseTotalRate = Number(baseline.totalRatePct ?? 0);
           const baseTotalOff = Number(baseline.totalOffenders ?? 0);
           const {
-            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression,
+            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression, missingFeatures,
           } = evaluateMixAdjustedTotalRegression({
             scannedByFeature, baseByFeature, tol,
             actualOffenders: offenders.length, actualScanned: scanned,
@@ -171,7 +171,7 @@ export function createAuditor(opts = {}) {
             expectedRate: Number(expectedTotalRate.toFixed(3)), expectedOffenders: Number(expectedOffenders.toFixed(2)),
             regression: Math.max(0, offenders.length - Math.round(expectedOffenders)),
           };
-          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)) };
+          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)), missingFeatures };
           if (totalRegression || regressedFeatures.length > 0) passed = false;
         } else {
           // Legacy absolute-count baseline (pre rate-ratchet). Kept so the
@@ -196,9 +196,16 @@ export function createAuditor(opts = {}) {
         }
       }
 
+      // Incomplete-scan flag (#3607): a baseline feature bucket entirely
+      // absent from the current scan is surfaced explicitly rather than
+      // silently folded into a lowered mix-adjusted expected total — see
+      // scripts/lib/mixAdjustedRateGate.mjs's computeMixAdjustedTotalCap.
+      const missingFeatureNote = totalCapInfo?.missingFeatures?.length
+        ? ` — INCOMPLETE SCAN: baseline feature(s) absent from current scan (${totalCapInfo.missingFeatures.join(', ')}); treated as a gate failure, not a lowered expected total`
+        : '';
       const humanSummary = passed
         ? `${offenders.length} duplicate(s) within baseline`
-        : `${offenders.length} title=h1 duplicate(s)${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
+        : `${offenders.length} title=h1 duplicate(s)${missingFeatureNote}${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
 
       return {
         passed,
@@ -208,7 +215,7 @@ export function createAuditor(opts = {}) {
         baselineFile: relBaseline(baselinePath),
         baselineDelta,
         byFeature,
-        extra: { scanned, skippedNoindex, missingTitle, missingH1, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit },
+        extra: { scanned, skippedNoindex, missingTitle, missingH1, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, missingFeatures: totalCapInfo?.missingFeatures ?? [] },
         humanSummary,
       };
     },

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -293,7 +293,7 @@ export function createAuditor(opts = {}) {
           // feature's own rate flat or improving. See
           // scripts/lib/mixAdjustedRateGate.mjs for the full rationale.
           const {
-            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression,
+            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression, missingFeatures,
           } = evaluateMixAdjustedTotalRegression({
             scannedByFeature, baseByFeature, tol,
             actualOffenders: offenders.length, actualScanned: scannedCount,
@@ -304,7 +304,7 @@ export function createAuditor(opts = {}) {
             expectedRate: Number(expectedTotalRate.toFixed(3)), expectedOffenders: Number(expectedOffenders.toFixed(2)),
             regression: Math.max(0, offenders.length - Math.round(expectedOffenders)),
           };
-          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)) };
+          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)), missingFeatures };
           if (totalRegression || regressedFeatures.length > 0) passed = false;
         } else {
           // Legacy absolute-count baseline (pre rate-ratchet). Kept so the
@@ -365,9 +365,16 @@ export function createAuditor(opts = {}) {
         })),
       };
 
+      // Incomplete-scan flag (#3607): a baseline feature bucket entirely
+      // absent from the current scan is surfaced explicitly rather than
+      // silently folded into a lowered mix-adjusted expected total — see
+      // scripts/lib/mixAdjustedRateGate.mjs's computeMixAdjustedTotalCap.
+      const missingFeatureNote = totalCapInfo?.missingFeatures?.length
+        ? ` — INCOMPLETE SCAN: baseline feature(s) absent from current scan (${totalCapInfo.missingFeatures.join(', ')}); treated as a gate failure, not a lowered expected total`
+        : '';
       const humanSummary = passed
         ? `${offenders.length} offender(s) within baseline (threshold ${threshold} %), ${nearFloor.total} page(s) in near-floor band (${threshold}-${warnThreshold} %), ${ejpDrift.total} EJP-marked index,follow shell(s) tracked for drift`
-        : `${offenders.length} offender(s) ≤ ${threshold} % — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feature}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feature}(${r.count}>${r.max})`).join(', ') || (totalCapInfo ? `total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : 'total rate cap exceeded')}`;
+        : `${offenders.length} offender(s) ≤ ${threshold} %${missingFeatureNote} — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feature}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feature}(${r.count}>${r.max})`).join(', ') || (totalCapInfo ? `total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : 'total rate cap exceeded')}`;
 
       return {
         passed,
@@ -377,7 +384,7 @@ export function createAuditor(opts = {}) {
         baselineFile: relBaseline(baselinePath),
         baselineDelta,
         byFeature,
-        extra: { scanned: scannedCount, skippedNoindex, skippedEjpStripped, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, threshold, warnThreshold, nearFloor, ejpDrift },
+        extra: { scanned: scannedCount, skippedNoindex, skippedEjpStripped, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, threshold, warnThreshold, nearFloor, ejpDrift, missingFeatures: totalCapInfo?.missingFeatures ?? [] },
         humanSummary,
       };
     },

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -234,7 +234,7 @@ export function createAuditor(opts = {}) {
           // Mix-adjusted total check (#3232-class fix) — see
           // scripts/lib/mixAdjustedRateGate.mjs for the full rationale.
           const {
-            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression,
+            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression, missingFeatures,
           } = evaluateMixAdjustedTotalRegression({
             scannedByFeature, baseByFeature, tol,
             actualOffenders: offenders.length, actualScanned: scanned,
@@ -245,7 +245,7 @@ export function createAuditor(opts = {}) {
             expectedRate: Number(expectedTotalRate.toFixed(3)), expectedOffenders: Number(expectedOffenders.toFixed(2)),
             regression: Math.max(0, offenders.length - Math.round(expectedOffenders)),
           };
-          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)) };
+          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)), missingFeatures };
           if (totalRegression || regressedFeatures.length > 0) passed = false;
         } else {
           // Legacy absolute-count baseline (pre rate-ratchet). Kept so the
@@ -270,10 +270,17 @@ export function createAuditor(opts = {}) {
         }
       }
 
+      // Incomplete-scan flag (#3607): a baseline feature bucket entirely
+      // absent from the current scan is surfaced explicitly rather than
+      // silently folded into a lowered mix-adjusted expected total — see
+      // scripts/lib/mixAdjustedRateGate.mjs's computeMixAdjustedTotalCap.
+      const missingFeatureNote = totalCapInfo?.missingFeatures?.length
+        ? ` — INCOMPLETE SCAN: baseline feature(s) absent from current scan (${totalCapInfo.missingFeatures.join(', ')}); treated as a gate failure, not a lowered expected total`
+        : '';
       const humanSummary =
         passed
           ? `${offenders.length} offender(s) within baseline (threshold ${threshold})`
-          : `${offenders.length} offender(s) over threshold ${threshold}${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
+          : `${offenders.length} offender(s) over threshold ${threshold}${missingFeatureNote}${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
 
       return {
         passed,
@@ -283,7 +290,7 @@ export function createAuditor(opts = {}) {
         baselineFile: relBaseline(baselinePath),
         baselineDelta,
         byFeature,
-        extra: { scanned, skippedNoindex, missingTitle, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, threshold },
+        extra: { scanned, skippedNoindex, missingTitle, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, threshold, missingFeatures: totalCapInfo?.missingFeatures ?? [] },
         humanSummary,
       };
     },

--- a/scripts/audit-title-no-disambig-hash.mjs
+++ b/scripts/audit-title-no-disambig-hash.mjs
@@ -160,7 +160,7 @@ export function createAuditor(opts = {}) {
           const baseTotalRate = Number(baseline.totalRatePct ?? 0);
           const baseTotalOff = Number(baseline.totalOffenders ?? 0);
           const {
-            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression,
+            expectedOffenders, expectedTotalRate, totalCap, regression: totalRegression, missingFeatures,
           } = evaluateMixAdjustedTotalRegression({
             scannedByFeature, baseByFeature, tol,
             actualOffenders: offenders.length, actualScanned: scanned,
@@ -171,7 +171,7 @@ export function createAuditor(opts = {}) {
             expectedRate: Number(expectedTotalRate.toFixed(3)), expectedOffenders: Number(expectedOffenders.toFixed(2)),
             regression: Math.max(0, offenders.length - Math.round(expectedOffenders)),
           };
-          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)) };
+          totalCapInfo = { actual: Number(totalRatePct.toFixed(3)), expected: Number(expectedTotalRate.toFixed(3)), cap: Number(totalCap.toFixed(3)), missingFeatures };
           if (totalRegression || regressedFeatures.length > 0) passed = false;
         } else {
           // Legacy absolute-count baseline (pre rate-ratchet). Kept so the
@@ -196,9 +196,16 @@ export function createAuditor(opts = {}) {
         }
       }
 
+      // Incomplete-scan flag (#3607): a baseline feature bucket entirely
+      // absent from the current scan is surfaced explicitly rather than
+      // silently folded into a lowered mix-adjusted expected total — see
+      // scripts/lib/mixAdjustedRateGate.mjs's computeMixAdjustedTotalCap.
+      const missingFeatureNote = totalCapInfo?.missingFeatures?.length
+        ? ` — INCOMPLETE SCAN: baseline feature(s) absent from current scan (${totalCapInfo.missingFeatures.join(', ')}); treated as a gate failure, not a lowered expected total`
+        : '';
       const humanSummary = passed
         ? `${offenders.length} offender(s) within baseline`
-        : `${offenders.length} offender(s)${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
+        : `${offenders.length} offender(s)${missingFeatureNote}${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => r.rate != null ? `${r.feat}(${r.rate}% > ${r.maxRate}% allowed, ${r.count} vs ${r.max})` : `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : (totalCapInfo ? ` — total rate cap exceeded (actual ${totalCapInfo.actual}% > mix-adjusted expected ${totalCapInfo.expected}% + tolerance = ${totalCapInfo.cap}%)` : '')}`;
 
       return {
         passed,
@@ -208,7 +215,7 @@ export function createAuditor(opts = {}) {
         baselineFile: relBaseline(baselinePath),
         baselineDelta,
         byFeature,
-        extra: { scanned, skippedNoindex, missingTitle, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit },
+        extra: { scanned, skippedNoindex, missingTitle, byLocale, regressedFeatures, scannedByFeature, rateByFeature, totalRatePct: Number(totalRatePct.toFixed(4)), limit, missingFeatures: totalCapInfo?.missingFeatures ?? [] },
         humanSummary,
       };
     },

--- a/scripts/lib/mixAdjustedRateGate.mjs
+++ b/scripts/lib/mixAdjustedRateGate.mjs
@@ -24,9 +24,9 @@
 /**
  * @param {object} args
  * @param {Record<string, number>} args.scannedByFeature current per-feature scanned counts
- * @param {Record<string, {ratePct?: number}>} args.baseByFeature baseline per-feature rate snapshot
+ * @param {Record<string, {ratePct?: number, scanned?: number}>} args.baseByFeature baseline per-feature rate snapshot
  * @param {{relPct: number, absPp: number, maxDeltaPp: number}} args.tol
- * @returns {{ expectedOffenders: number, expectedTotalRate: number, totalCap: number }}
+ * @returns {{ expectedOffenders: number, expectedTotalRate: number, totalCap: number, missingFeatures: string[] }}
  */
 export function computeMixAdjustedTotalCap({ scannedByFeature, baseByFeature, tol }) {
   let expectedOffenders = 0;
@@ -42,10 +42,24 @@ export function computeMixAdjustedTotalCap({ scannedByFeature, baseByFeature, to
     const baseRate = Number(baseByFeature?.[feature]?.ratePct ?? 0);
     expectedOffenders += (scanned * baseRate) / 100;
   }
+  // Inverse case (#3607): a baseline feature bucket that is entirely ABSENT
+  // from the current scan (e.g. a partial BFS walk that never reached that
+  // template category) contributes nothing to totalScanned/expectedOffenders
+  // above — silently narrowing the total check's scope down to whatever the
+  // (possibly incomplete) scan happened to cover, instead of flagging that
+  // the scan itself is incomplete. That's a false-green: an incomplete scan
+  // reads as a legitimately smaller expected total. Only baseline features
+  // that actually had scanned pages recorded are flagged — a feature the
+  // baseline legitimately retired (recorded with scanned:0) isn't a scan
+  // regression.
+  const missingFeatures = Object.keys(baseByFeature ?? {}).filter((feature) => {
+    if (Object.prototype.hasOwnProperty.call(scannedByFeature, feature)) return false;
+    return Number(baseByFeature[feature]?.scanned ?? 0) > 0;
+  });
   const expectedTotalRate = totalScanned ? (expectedOffenders / totalScanned) * 100 : 0;
   const totalCap =
     expectedTotalRate + Math.min((expectedTotalRate * tol.relPct) / 100, tol.maxDeltaPp) + tol.absPp;
-  return { expectedOffenders, expectedTotalRate, totalCap };
+  return { expectedOffenders, expectedTotalRate, totalCap, missingFeatures };
 }
 
 /**
@@ -63,7 +77,7 @@ export function evaluateMixAdjustedTotalRegression({
   actualOffenders,
   actualScanned,
 }) {
-  const { expectedOffenders, expectedTotalRate, totalCap } = computeMixAdjustedTotalCap({
+  const { expectedOffenders, expectedTotalRate, totalCap, missingFeatures } = computeMixAdjustedTotalCap({
     scannedByFeature,
     baseByFeature,
     tol,
@@ -73,6 +87,13 @@ export function evaluateMixAdjustedTotalRegression({
   // (e.g. from a shrinking denominator) with no meaningful absolute growth
   // must not fail the gate on its own (class #1604 — see
   // audit-text-html-ratio.mjs's per-feature comment for the incident).
-  const regression = actualTotalRate > totalCap && actualOffenders > expectedOffenders + tol.minAbsDelta;
-  return { expectedOffenders, expectedTotalRate, totalCap, actualTotalRate, regression };
+  const rateRegression = actualTotalRate > totalCap && actualOffenders > expectedOffenders + tol.minAbsDelta;
+  // A baseline feature bucket entirely missing from the current scan means
+  // the scan is INCOMPLETE, not that the site legitimately improved (#3607).
+  // Fail the gate unconditionally on this — it must not be masked by the
+  // AND-condition floor above, since an incomplete scan can under-report
+  // `actualOffenders`/`actualScanned` too, hiding real regressions in the
+  // untouched feature.
+  const regression = rateRegression || missingFeatures.length > 0;
+  return { expectedOffenders, expectedTotalRate, totalCap, actualTotalRate, regression, missingFeatures };
 }

--- a/tests/seo/mix-adjusted-rate-gate.test.ts
+++ b/tests/seo/mix-adjusted-rate-gate.test.ts
@@ -33,6 +33,38 @@ describe('computeMixAdjustedTotalCap', () => {
     expect(expectedOffenders).toBeCloseTo(10, 5); // 100*10/100 + 50*0
     expect(expectedTotalRate).toBeCloseTo(10 / 150 * 100, 5);
   });
+
+  // #3607: the inverse case — a baseline feature bucket absent from the
+  // CURRENT scan (e.g. a partial BFS walk that never reached that template
+  // category). Previously this silently contributed 0 to both
+  // expectedOffenders and totalScanned, quietly lowering the expected total
+  // instead of flagging that the scan itself is incomplete.
+  it('flags a baseline feature missing from the current scan as an incomplete-scan signal', () => {
+    const { missingFeatures } = computeMixAdjustedTotalCap({
+      scannedByFeature: { a: 100 },
+      baseByFeature: { a: { ratePct: 10, scanned: 100 }, b: { ratePct: 20, scanned: 500 } },
+      tol: TOL,
+    });
+    expect(missingFeatures).toEqual(['b']);
+  });
+
+  it('does NOT flag a baseline feature that legitimately had zero scanned pages historically', () => {
+    const { missingFeatures } = computeMixAdjustedTotalCap({
+      scannedByFeature: { a: 100 },
+      baseByFeature: { a: { ratePct: 10, scanned: 100 }, retired: { ratePct: 0, scanned: 0 } },
+      tol: TOL,
+    });
+    expect(missingFeatures).toEqual([]);
+  });
+
+  it('does not flag when every baseline feature is present in the current scan', () => {
+    const { missingFeatures } = computeMixAdjustedTotalCap({
+      scannedByFeature: { a: 100, b: 400 },
+      baseByFeature: { a: { ratePct: 5, scanned: 90 }, b: { ratePct: 50, scanned: 380 } },
+      tol: TOL,
+    });
+    expect(missingFeatures).toEqual([]);
+  });
 });
 
 describe('evaluateMixAdjustedTotalRegression', () => {
@@ -67,5 +99,34 @@ describe('evaluateMixAdjustedTotalRegression', () => {
       actualScanned: 100,
     });
     expect(r.regression).toBe(false);
+  });
+
+  // #3607: an incomplete scan (baseline feature bucket entirely missing from
+  // the current scan) must fail the gate unconditionally — it must NOT be
+  // masked by the same AND-condition noise floor that protects legitimate
+  // denominator shrinks (class #1604), since the whole point is that a
+  // missing bucket could be hiding a real regression the scan never saw.
+  it('FAIL: baseline feature missing from current scan fails the gate even when the visible rate is perfectly within cap', () => {
+    const r = evaluateMixAdjustedTotalRegression({
+      scannedByFeature: { a: 100 },
+      baseByFeature: { a: { ratePct: 5, scanned: 100 }, b: { ratePct: 20, scanned: 500 } },
+      tol: TOL,
+      actualOffenders: 5, // exactly at baseline rate for the features that WERE scanned
+      actualScanned: 100,
+    });
+    expect(r.regression).toBe(true);
+    expect(r.missingFeatures).toEqual(['b']);
+  });
+
+  it('PASS: no missing baseline features and rate within cap', () => {
+    const r = evaluateMixAdjustedTotalRegression({
+      scannedByFeature: { a: 100, b: 400 },
+      baseByFeature: { a: { ratePct: 5, scanned: 90 }, b: { ratePct: 50, scanned: 380 } },
+      tol: TOL,
+      actualOffenders: 205,
+      actualScanned: 500,
+    });
+    expect(r.regression).toBe(false);
+    expect(r.missingFeatures).toEqual([]);
   });
 });


### PR DESCRIPTION
Addresses all 3 items of #3607 (aggregate follow-up issue — closed manually post-merge, not via `Closes` keyword, per repo contract for multi-item aggregate issues).

## Implementato

Issue #3607 aveva 3 item indipendenti derivati da PR #3595. Stato:

**Item 1 — reseed baseline JSON a `mode:'rate'`**: GIA' RISOLTO, non da questa PR. `data/title-length-baseline.json`, `data/title-no-disambig-hash-baseline.json`, `data/h1-title-duplicates-baseline.json` sono gia' `mode:'rate'` su `origin/main`, landati via PR numero 3609 (commit `ba79f47184f`, merged 2026-07-05T23:44:16Z). Verificato leggendo il contenuto dei 3 file su `origin/main` — tutti hanno la shape `{ generated, mode:'rate', tolerance, scanned, totalOffenders, totalRatePct, byFeature }`. Nota correttiva: l'assunzione dell'issue che `seed-title-baselines.yml` "committi direttamente su main" e' FALSA — il workflow e' `workflow_dispatch`-only e produce solo un artifact scaricabile, richiede un commit manuale di follow-up (`permissions: contents: read`, nessun push step). Non rilevante ai fini della chiusura visto che il reseed reale e' comunque avvenuto (via commit diretto separato, non via questo workflow).

**Item 2 — `computeMixAdjustedTotalCap` mascherava scan incompleti**: FIXATO in questa PR. Root cause: quando una feature presente nel baseline (con `scanned > 0` storicamente) era assente dallo scan corrente, la funzione la trattava silenziosamente come contributo zero, abbassando il totale atteso invece di segnalare che lo scan stesso era incompleto — un false-green su scan parziale.

Fix nel modulo condiviso `scripts/lib/mixAdjustedRateGate.mjs` (unico source of truth, Non-Negotiable #6):
- `computeMixAdjustedTotalCap` ora calcola e ritorna `missingFeatures` (feature del baseline con `scanned > 0` assenti dallo scan corrente; le feature storicamente a `scanned: 0` — es. categorie ritirate — NON vengono flaggate, comportamento corretto).
- `evaluateMixAdjustedTotalRegression` fa hard-fail (`regression = true`) quando `missingFeatures.length > 0`, **incondizionatamente** — non mascherato dall'AND-condition noise floor che protegge i legittimi denominator-shrink (classe #1604), perché il punto e' proprio che un bucket mancante potrebbe nascondere una regressione mai vista dallo scan.

Propagato (per visibilita', zero logica aggiuntiva richiesta — il gate su `regression` gia' esisteva in ogni caller) ai 4 caller reali, grepped e verificati come unico set di call-site del modulo:
- `scripts/audit-title-length.mjs`
- `scripts/audit-h1-title-duplicates.mjs`
- `scripts/audit-text-html-ratio.mjs`
- `scripts/audit-title-no-disambig-hash.mjs`

Ognuno ora destruttura `missingFeatures` da `totalCapInfo`, lo espone in `humanSummary` (nota dedicata) e nel campo `extra` di ritorno.

`scripts/audit-dist-multi.mjs` ha un costrutto lessicalmente simile ma e' FUORI SCOPE da questa PR: e' gia' in fix su un branch separato di un altro agent per issue numero 3596 (verificato via `git branch -a`/`git log --all`, commit `6c05ba279a40`, non ancora mergiato) — non toccato per evitare collisione, non e' un deferral bensì lavoro gia' in corso altrove sotto un issue diverso.

Test: estesi 5 nuovi casi in `tests/seo/mix-adjusted-rate-gate.test.ts` (10/10 pass), copertura sia per `computeMixAdjustedTotalCap` (flag corretto/non-flag su zero storico/nessuna feature mancante) sia per `evaluateMixAdjustedTotalRegression` (hard-fail incondizionato, non mascherato dal noise floor).

**Item 3 — light-pool concorrente con la sequential heavy chain in `post-deploy-validate-dist.yml`**: VERIFICATO SICURO CON EVIDENZA REALE, nessun fix di codice necessario. L'issue segnalava che fino a 4 audit "light" (4096MB heap cap ciascuno) partono in concorrenza con una catena "heavy" sequenziale (8192MB heap cap, `audit:all` → `audit:max-bfs-depth` → `audit:orphan-sitemap-pages`), con un worst-case teorico additivo di ~24.5GB contro un runner da ~7GB — ma richiedeva conferma con dati reali, non un fix speculativo.

Ho recuperato i log completi di 2 run reali e consecutivi post-merge di #3595, a scala di produzione reale (~2.8M pagine):
- Run `28766388874`: TUTTI i post-build gate `rc=0`/PASS, inclusi `audit:all` (1867.41s), `audit:max-bfs-depth` (400.24s, 8192MB), `audit:orphan-sitemap-pages` (407.79s, 8192MB) e l'intero light pool concorrente (`audit:hreflang` 1464.81s, `audit:canonical-trailing-slash` 1166.68s, `audit:spa-bundle-injection` 1009.54s, etc., tutti a 4096MB cap, MAX_PARALLEL=4).
- Run `28769520142`: stesso esito, tutti i gate `rc=0`/PASS (il job `deploy` di questo run e' fallito per una ragione scorrelata, verificato via `gh run view --json jobs`; il job `validate-dist` e' `success`).

Grep su entrambi i log completi per `rc=134`/OOM/SIGKILL/"out of memory": zero match reali (solo commenti di shell script echeggiati, non eventi runtime). Conclusione: il worst-case teorico non si materializza in pratica — l'uso reale di RSS resta ben sotto il ceiling del runner in entrambe le run osservate. Nessuna modifica al workflow.

## Non implementato (ancora)

Nessuno — tutti e 3 gli item sono completi. Chiusura di #3607 va fatta manualmente post-merge (issue aggregata, niente `Closes` automatico per contratto CI).
