### PR TITLE
fix(batch-add-faq): escalate maxTokens on truncation, salvage complete pairs

### DIFF
--- a/scripts/batch-add-faq-to-articles.mjs
+++ b/scripts/batch-add-faq-to-articles.mjs
@@ -457,16 +457,45 @@ Scrivi ora il testo:`;
   return text;
 }
 
-async function _generateFaqITAttempt(bodyText) {
-  const prompt = `Sei un esperto di lavoro transfrontaliero Svizzera-Italia. Leggi questo articolo e genera ESATTAMENTE 5 coppie FAQ (domanda/risposta) in italiano. Il MINIMO ASSOLUTO è 3 coppie.
+// Salvage last resort: pull out whichever {"q":"...","a":"..."} objects are
+// already complete in a response that got cut off mid-array (maxTokens hit
+// before the model finished) — JSON.parse-per-field un-escapes properly
+// (handles the same embedded-quote/apostrophe content extractFaqFromText's
+// plain-label regex can't), and any still-incomplete trailing object is
+// simply not matched, so nothing malformed leaks through.
+function _extractCompleteJsonFaqPairs(raw) {
+  const pairs = [];
+  const objRe = /\{\s*"q"\s*:\s*"((?:[^"\\]|\\.)*)"\s*,\s*"a"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\}/g;
+  let m;
+  while ((m = objRe.exec(raw)) !== null) {
+    try {
+      pairs.push({ q: JSON.parse(`"${m[1]}"`), a: JSON.parse(`"${m[2]}"`) });
+    } catch {
+      // Malformed individual pair — skip, keep scanning for the rest.
+    }
+  }
+  return pairs;
+}
+
+function _isTruncationError(err) {
+  return /Unterminated|Unexpected end/i.test(err?.message || '');
+}
+
+function _faqPrompt({ isTopUp, needed, existingQs, bodyText }) {
+  const countInstruction = isTopUp
+    ? `genera esattamente ${needed} coppie FAQ (domanda/risposta) NUOVE in italiano.\n\nDOMANDE GIÀ ESISTENTI (NON ripeterle né riformularle):\n- ${existingQs}`
+    : `genera ESATTAMENTE 5 coppie FAQ (domanda/risposta) in italiano. Il MINIMO ASSOLUTO è 3 coppie.`;
+  const rules = isTopUp
+    ? `- Le nuove FAQ devono coprire aspetti DIVERSI da quelli già presenti`
+    : `- Genera ALMENO 3 coppie, idealmente 5\n- Le FAQ devono coprire aspetti DIVERSI dell'articolo\n- NON ripetere il titolo dell'articolo nelle domande`;
+
+  return `Sei un esperto di lavoro transfrontaliero Svizzera-Italia. Leggi questo articolo e ${countInstruction}
 
 REGOLE:
-- Genera ALMENO 3 coppie, idealmente 5
+${rules}
 - Ogni domanda deve essere una query di ricerca naturale che un frontaliere potrebbe digitare su Google
 - Ogni risposta deve essere concisa e autosufficiente (40-80 parole), con dati concreti
-- Le FAQ devono coprire aspetti DIVERSI dell'articolo
 - Usa apostrofi diritti ('), mai virgolette curve
-- NON ripetere il titolo dell'articolo nelle domande
 
 ARTICOLO:
 ${bodyText.slice(0, 6000)}
@@ -475,10 +504,14 @@ ${JSON_QUOTE_SAFETY_RULE_IT}
 
 Rispondi SOLO con un JSON array (no markdown, no code fences):
 [{"q":"Domanda 1?","a":"Risposta 1."},{"q":"Domanda 2?","a":"Risposta 2."}]`;
+}
+
+async function _generateFaqITAttempt(bodyText, maxTokens) {
+  const prompt = _faqPrompt({ isTopUp: false, bodyText });
 
   const raw = await callFaqModel(
     [{ role: 'user', content: prompt }],
-    { temperature: 0.5, maxTokens: 2000, jsonMode: true },
+    { temperature: 0.5, maxTokens, jsonMode: true },
   );
 
   const repaired = repairJsonArray(raw);
@@ -489,6 +522,10 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
     // Try extracting Q&A pairs via regex as last resort
     const regexFaq = extractFaqFromText(raw);
     if (regexFaq && regexFaq.length >= 2) return regexFaq;
+    // A cut-off array (maxTokens hit mid-generation) still has complete
+    // leading pairs worth salvaging instead of discarding the whole response.
+    const salvaged = _extractCompleteJsonFaqPairs(raw);
+    if (salvaged.length >= 2) return salvaged;
     console.error(`  [JSON parse failed] ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
     console.error(`  ${describeRawForDiagnostics(raw)}`);
     throw new Error(`JSON non valido dalla generazione FAQ: ${parseErr.message}`);
@@ -508,56 +545,47 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
 // malformed-JSON response ("Unterminated string in JSON") with zero retries
 // — the regex last-resort fallback only recognizes labeled plain-text Q&A
 // ("Domanda: ... Risposta: ..."), not a truncated JSON array, so it couldn't
-// recover either. A malformed/truncated single response from one model roll
-// is exactly the kind of transient glitch a retry fixes (same pattern already
-// used by splitBodyIntoSections/translateArticle elsewhere in this pipeline)
-// — this failed the entire publish over a small, independently-regenerable
-// FAQ field. generateTopUpFaqIT (below) hits the same LLM-JSON-array shape
-// with the same single-attempt fragility, so both share this retry wrapper
-// rather than duplicating the loop.
+// recover either. generateTopUpFaqIT (below) hits the same LLM-JSON-array
+// shape with the same single-attempt fragility, so both share this retry
+// wrapper rather than duplicating the loop.
+//
+// Follow-up (same article, next publish attempt): the retry alone wasn't
+// enough — all 3 attempts truncated identically at maxTokens:2000, each
+// cutting off mid-answer at a different point (raw response lengths ~1300,
+// ~2330, ~2350 chars each time — real content, not a corruption artifact,
+// see the salvage extractor above), because this article's 5 detailed
+// 40-80-word answers plus JSON overhead don't fit in 2000 tokens. Escalating
+// maxTokens on a detected truncation mirrors translateArticle's
+// callWithRetry elsewhere in this pipeline (3x on truncation, capped) instead
+// of retrying the exact same insufficient budget 3 times for an identical
+// result.
 async function _withFaqRetry(label, attemptFn) {
   let lastErr;
+  let maxTokens = 2000;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
-      return await attemptFn();
+      return await attemptFn(maxTokens);
     } catch (err) {
       lastErr = err;
       console.error(`  ⚠️  ${label} tentativo ${attempt} fallito: ${err.message}`);
+      if (_isTruncationError(err)) maxTokens = Math.min(maxTokens * 2, 8000);
     }
   }
   throw lastErr;
 }
 
 export async function generateFaqIT(articleId, bodyText) {
-  return _withFaqRetry('generateFaqIT', () => _generateFaqITAttempt(bodyText));
+  return _withFaqRetry('generateFaqIT', (maxTokens) => _generateFaqITAttempt(bodyText, maxTokens));
 }
 
-async function _generateTopUpFaqITAttempt(bodyText, existingFaq) {
+async function _generateTopUpFaqITAttempt(bodyText, existingFaq, maxTokens) {
   const needed = MIN_FAQ_PAIRS - existingFaq.length;
   const existingQs = existingFaq.map(p => p.q).join('\n- ');
-
-  const prompt = `Sei un esperto di lavoro transfrontaliero Svizzera-Italia. Leggi questo articolo e genera esattamente ${needed + 2} coppie FAQ (domanda/risposta) NUOVE in italiano.
-
-DOMANDE GIÀ ESISTENTI (NON ripeterle né riformularle):
-- ${existingQs}
-
-REGOLE:
-- Le nuove FAQ devono coprire aspetti DIVERSI da quelli già presenti
-- Ogni domanda deve essere una query di ricerca naturale che un frontaliere potrebbe digitare su Google
-- Ogni risposta deve essere concisa e autosufficiente (40-80 parole), con dati concreti
-- Usa apostrofi diritti ('), mai virgolette curve
-
-ARTICOLO:
-${bodyText.slice(0, 6000)}
-
-${JSON_QUOTE_SAFETY_RULE_IT}
-
-Rispondi SOLO con un JSON array (no markdown, no code fences):
-[{"q":"Domanda 1?","a":"Risposta 1."},{"q":"Domanda 2?","a":"Risposta 2."}]`;
+  const prompt = _faqPrompt({ isTopUp: true, needed: needed + 2, existingQs, bodyText });
 
   const raw = await callFaqModel(
     [{ role: 'user', content: prompt }],
-    { temperature: 0.5, maxTokens: 2000, jsonMode: true },
+    { temperature: 0.5, maxTokens, jsonMode: true },
   );
 
   const repaired = repairJsonArray(raw);
@@ -567,6 +595,8 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
   } catch (parseErr) {
     const regexFaq = extractFaqFromText(raw);
     if (regexFaq && regexFaq.length >= 1) return regexFaq;
+    const salvaged = _extractCompleteJsonFaqPairs(raw);
+    if (salvaged.length >= 1) return salvaged;
     console.error(`  [JSON parse failed] ${parseErr.message} — ${describeJsonParseError(repaired, parseErr)}`);
     console.error(`  ${describeRawForDiagnostics(raw)}`);
     throw new Error(`JSON non valido dalla generazione top-up FAQ: ${parseErr.message}`);
@@ -595,7 +625,7 @@ Rispondi SOLO con un JSON array (no markdown, no code fences):
  * response.
  */
 export async function generateTopUpFaqIT(articleId, bodyText, existingFaq) {
-  return _withFaqRetry('generateTopUpFaqIT', () => _generateTopUpFaqITAttempt(bodyText, existingFaq));
+  return _withFaqRetry('generateTopUpFaqIT', (maxTokens) => _generateTopUpFaqITAttempt(bodyText, existingFaq, maxTokens));
 }
 
 async function translateFaq(faqArray, targetLang) {

--- a/tests/scripts/generate-faq-it-retry.test.ts
+++ b/tests/scripts/generate-faq-it-retry.test.ts
@@ -33,6 +33,18 @@ const VALID_FAQ_JSON = JSON.stringify([
 // Mirrors the actual truncated-JSON shape from the live incident.
 const TRUNCATED_JSON = '[{"q":"Cosa prevede l\'Accordo?","a":"L\'Accordo Italia-Svizzera del 2020 sulla tassazione dei';
 
+// Mirrors the SECOND live incident on the same article (after the first
+// retry fix landed): every one of 3 retry attempts truncated identically at
+// maxTokens:2000 — 2+ complete pairs generated, then cut off mid-answer on
+// the next one. Real cause: 2000 tokens wasn't enough for 5 detailed answers,
+// not a random glitch (confirmed by the raw response showing clean prose cut
+// mid-sentence, not corruption around a special character).
+const TRUNCATED_WITH_COMPLETE_PAIRS =
+  '[{"q":"Cosa prevede l\'Accordo?","a":"L\'Accordo del 2020 introduce un modello di tassazione alla fonte."},' +
+  '{"q":"Quali sono i requisiti di frontiera?","a":"Risiedere entro 20 km dal confine e rientrare quotidianamente."},' +
+  '{"q":"Quali comuni beneficiano della compensazione?","a":"I comuni italiani frontalieri ricevono il 40% fino al 2033."},' +
+  '{"q":"Come funziona il telelavoro dal 2024?","a":"È previsto un adeguamento del 25% per il telelavoro in regime permanente, in attesa della ratifica del prot';
+
 // Real calls are mocked, but generateFaqIT still pays the module's real
 // rate-limit gap (~4.5s) between attempts — fake timers (which also fake
 // Date, matching the rate limiter's Date.now()-based slot bookkeeping) let
@@ -50,7 +62,9 @@ async function runWithFakeTimers<T>(fn: () => Promise<T>): Promise<T> {
     // The rate limiter's module-level slot bookkeeping carries over between
     // tests while each test's fake clock resets to "now" — advance generously
     // (real wall-clock cost of this call is ~0 regardless of the ms value).
-    await vi.advanceTimersByTimeAsync(60000);
+    // Generous margin: drift accumulates across every test in this file since
+    // the rate limiter's slot state is module-global, not reset per test.
+    await vi.advanceTimersByTimeAsync(180000);
     return await promise;
   } finally {
     vi.useRealTimers();
@@ -98,6 +112,29 @@ describe('generateFaqIT — retries on malformed/truncated LLM output', () => {
 
     expect(faq.length).toBe(3);
     expect(aiModelsMock.callSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('salvages complete pairs from a truncated array without needing a retry', async () => {
+    aiModelsMock.callSingleModel.mockResolvedValueOnce(TRUNCATED_WITH_COMPLETE_PAIRS);
+
+    const faq = await runWithFakeTimers(() => generateFaqIT('test-article-id', 'Corpo di test '.repeat(50)));
+
+    expect(faq.length).toBe(3);
+    expect(faq[0].q).toBe("Cosa prevede l'Accordo?");
+    expect(faq[2].q).toBe('Quali comuni beneficiano della compensazione?');
+    expect(aiModelsMock.callSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates maxTokens on a truncation-shaped failure instead of repeating the same budget', async () => {
+    aiModelsMock.callSingleModel
+      .mockResolvedValueOnce(TRUNCATED_JSON)
+      .mockResolvedValueOnce(TRUNCATED_JSON)
+      .mockResolvedValue(VALID_FAQ_JSON);
+
+    await runWithFakeTimers(() => generateFaqIT('test-article-id', 'Corpo di test '.repeat(50)));
+
+    const maxTokensUsed = aiModelsMock.callSingleModel.mock.calls.map((call) => call[1]?.maxTokens);
+    expect(maxTokensUsed).toEqual([2000, 4000, 8000]);
   });
 });
 


### PR DESCRIPTION
## Implementato

- Fourth bug found while republishing the "L'Accordo Italia-Svizzera del 2020 sulla tassazione dei lavoratori frontalieri" redazione article (doc `journalist_articles/laccordo-italia-svizzera-del-2020-sulla-tassazione-dei-lavoratori-frontalieri`), this time AFTER PR #3629's `generateFaqIT` retry fix landed and was exercised live: all 3 retry attempts failed identically with `Unterminated string in JSON`, each cutting off at a different length (~1300, ~2330, ~2350 chars).
- Root cause (confirmed from the run's raw-response diagnostics, not guessed): genuine output truncation, not corruption — the raw text cuts off cleanly mid-sentence with no suspicious character near the cutoff each time. This article's 5 detailed 40-80-word answers plus JSON structural overhead don't fit in `maxTokens:2000`, so retrying with the SAME budget 3 times reproduced the SAME failure 3 times — retrying alone (PR #3629) wasn't enough for this specific article; the budget itself needed to grow.
- Fix 1: `_withFaqRetry` now escalates `maxTokens` (2000 → 4000 → 8000) when a retry follows a truncation-shaped error (`Unterminated`/`Unexpected end`), mirroring `translateArticle`'s `callWithRetry` elsewhere in this same pipeline (`scripts/create-article.mjs`) instead of blindly repeating an already-proven-insufficient budget.
- Fix 2: added `_extractCompleteJsonFaqPairs` — salvages whichever `{"q":"...","a":"..."}` objects are already complete in a truncated array (per-field `JSON.parse` properly un-escapes embedded quotes/apostrophes, which `extractFaqFromText`'s plain-label regex fallback can't handle). This recovers the response's already-good data instead of discarding a mostly-successful generation, and can avoid needing a retry at all when ≥2 (generateFaqIT) / ≥1 (generateTopUpFaqIT) complete pairs already exist before the cutoff.
- Extracted the duplicated prompt-building (generateFaqIT/generateTopUpFaqIT had near-identical prompt templates) into a shared `_faqPrompt()` helper while touching both call sites for the `maxTokens` plumbing — avoids a second copy of the same wiring PR #3629 already unified via `_withFaqRetry`.
- New tests (`tests/scripts/generate-faq-it-retry.test.ts`, 2 added — 7 total in the file now): locks in that `maxTokens` escalates `[2000, 4000, 8000]` across attempts on truncation; locks in that a truncated-but-partially-complete array salvages its complete pairs without needing any retry at all.
- `npx vitest run tests/scripts/generate-faq-it-retry.test.ts tests/scripts/llm-json-repair.test.ts tests/create-article-author-registry.test.ts tests/authors.test.ts tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/blog-title-casing.test.ts tests/article-slug-derivation.test.ts tests/scripts/create-article-integration.test.ts tests/scripts/split-body-into-sections.test.ts tests/publish-journalist-hero-image-timeout.test.ts` → 172/172 green locally before opening this PR.

## Non implementato (ancora)

- Requeuing the Firestore doc again and re-running `publish-journalist-articles.yml` for the 5th time — in questa PR non ancora, verrà fatto subito dopo il merge; il task complessivo (articolo pubblicato live con byline Samuele Valente, verificato) resta aperto oltre questo merge fino alla verifica finale.