### PR TITLE
fix(create-article): ground tax-institution facts, size local-fallback timeout for 14b

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -173,19 +173,30 @@ jobs:
           # LOCAL_LLM_TIMEOUT_MS also sizes undici's headers/body timeout via the
           # local dispatcher — non-streaming CPU inference otherwise dies at
           # undici's 300s default as `fetch failed` before any output.
-          # 900000 (15min), not 30min: run 28755532056 showed both real
-          # successful completions finish in 9.3min/11.9min (qwen2.5:7b, full
-          # production prompt), while the one call that never finishes still
-          # burns the ENTIRE ceiling before giving up. At 30min that single
-          # stuck attempt consumed more than half of the 55min frontaliere wall
-          # budget for zero output — starving every later retry/expand attempt
-          # of the time they needed. 15min keeps ~25% headroom over the slowest
-          # observed success while halving the worst-case wasted-attempt cost.
+          # 900000 (15min) was sized for qwen2.5:7b: run 28755532056 showed
+          # real successful completions at 9.3min/11.9min, later confirmed
+          # faster in practice (6-11min across 60 live runs, 2026-06-30..07-03,
+          # local fallback engaged 2/60). Bumped to 1500000 (25min) 2026-07-06
+          # for the qwen2.5:14b upgrade (2x params vs 7b — quality fix for
+          # fact-check criticals the 7b model was hallucinating, e.g. inventing
+          # non-existent institutions): ~2x the 7b range gives an estimated
+          # 12-22min per call, so 25min keeps headroom without letting a single
+          # stuck call burn past the smallest section wall-budget (30min,
+          # svizzera) on its own. Deliberately NOT touching
+          # CREATE_ARTICLE_MAX_WALL_MS below to compensate for the larger
+          # model — #3102 already tried blowing that budget up for local
+          # fallback (300min) and #3307 reverted it: the bigger ceiling
+          # silently defeated the deadlineMs cascade-abort safety, letting
+          # unrelated stuck free-tier calls walk the entire chain uninterrupted
+          # (the real driver of 60-140min runaway runs). The per-run budget
+          # stays exactly as validated; if 14b keeps hitting this per-call
+          # timeout or the run-level deadline in live runs, revert
+          # ARTICLE_LOCAL_MODEL to qwen2.5:7b (repo variable, no code change).
           {
             echo "LOCAL_LLM_ENABLED=1"
             echo "LOCAL_LLM_URL=http://127.0.0.1:11434/v1/chat/completions"
             echo "LOCAL_LLM_MODEL=$LOCAL_MODEL"
-            echo "LOCAL_LLM_TIMEOUT_MS=900000"
+            echo "LOCAL_LLM_TIMEOUT_MS=1500000"
           } >> "$GITHUB_ENV"
           echo "🧠 Local LLM fallback ready: $LOCAL_MODEL (last-resort in the cascade)"
 

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2795,13 +2795,27 @@ ASSICURAZIONI:
 // models are back in the pool. Regeneration attempts append fact-check feedback
 // (pre-existing behaviour shared by all sections); this brief keeps that path
 // strictly smaller than the #3009 full-sheet version.
+//
+// Extended 2026-07-06: run flagged 2 critical fact-check issues from an
+// evergreen tax-calculation article — the generator invented "Istituto
+// Federale della Statistica (STATIKA)" (real entity: BFS) and wrongly
+// attributed tax-rate-setting to UFAS (real institution, wrong competency —
+// UFAS is social-insurance, not taxation). Neither BFS nor a tax-authority
+// acronym were in the brief's institution whitelist, so a model without
+// training-data recall of the real Swiss tax administration had nothing
+// grounded to reach for. Added BFS + AFC/ESTV and an explicit competency
+// line so every model in the cascade (not just local/fallback — this brief
+// feeds whichever model the chain picks) has the real names before writing,
+// instead of only being graded against them after the fact. New estTokens
+// ~7333 (+118 vs the measurement above) — still ~667 under the 8000 cap.
 const EVERGREEN_FACTS_BRIEF = `FATTI VERIFICATI (ground truth — il fact-checker blocca l'articolo se diverghi da questi valori):
 - Imposta alla fonte sul reddito da lavoro: trattenuta SOLO in Svizzera per i frontalieri (MAI "in entrambi i paesi"). L'Italia evita la doppia imposizione con il credito d'imposta (quadro CE del 730).
 - Nuovo Accordo Frontalieri: firmato 23/12/2020, in vigore dal 1° GENNAIO 2024 (NON 2026). Ratifica IT: Legge 83 del 13/6/2023.
 - Vecchi frontalieri (già tali prima del 17/7/2023): esenzione €7'500, regime transitorio 2024–2033. Nuovi frontalieri: franchigia €10'000.
 - Convenzione doppie imposizioni Italia-Svizzera: firmata il 9 DICEMBRE 1976. La Svizzera NON è membro UE/SEE.
 - Aliquote/contributi svizzeri: AVS/AI/IPG 5.3% dipendente, AD/AC 1.1% (cap CHF 148'200), LAINF 0.7–1.5%, LPP 7–18% per fascia età (dal 25 anni). IRPEF italiana: 23% fino €28'000, 35% €28'001–50'000, 43% oltre €50'000.
-- Acronimi/enti VALIDI (non inventarne altri): SECO, SEM, USTAT, UFSP/BAG, SUVA, INPS, Agenzia delle Entrate, MEF.
+- Acronimi/enti VALIDI (non inventarne altri): SECO, SEM, USTAT, UFSP/BAG, SUVA, INPS, Agenzia delle Entrate, MEF, BFS (Ufficio Federale di Statistica), AFC/ESTV (Amministrazione Federale delle Contribuzioni).
+- Le aliquote fiscali (imposta alla fonte, aliquote federali/cantonali) sono stabilite da leggi federali/cantonali e amministrate da AFC/ESTV a livello federale e dalle amministrazioni cantonali delle contribuzioni — MAI da UFAS (previdenza sociale, AVS/AI) né da BFS (statistica: rileva dati, non fissa aliquote).
 - LAMal = assicurazione malattia (NON "tassa sulla salute"); frontalieri G hanno diritto d'opzione; franchige adulti CHF 300–2500.`;
 
 /**

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -629,9 +629,15 @@ function getLocalLlmModelId() { return (process.env.LOCAL_LLM_MODEL || LOCAL_LLM
 // one; allow an override for servers behind an auth proxy.
 function getLocalLlmApiKey()  { return (process.env.LOCAL_LLM_API_KEY || 'local-no-key').trim(); }
 // CPU inference is slow; give the local call a generous floor (overridable).
+// Fallback-of-fallback only: the generate-article.yml workflow always exports
+// LOCAL_LLM_TIMEOUT_MS explicitly when LOCAL_LLM_ENABLED, so this default only
+// fires for ad-hoc/manual invocations without that env var set. Kept in sync
+// with the workflow's explicit value (1_500_000, sized 2026-07-06 for the
+// qwen2.5:14b upgrade) rather than the old 7b-era 600_000 — a smaller floor
+// here would silently under-time a 14b call in exactly that manual scenario.
 function getLocalLlmTimeoutMs() {
   const v = parseInt((process.env.LOCAL_LLM_TIMEOUT_MS || '').trim(), 10);
-  return Number.isFinite(v) && v > 0 ? v : 600_000; // 10 min default
+  return Number.isFinite(v) && v > 0 ? v : 1_500_000; // 25 min default — see comment above
 }
 
 // ── API keys (lazy-loaded from environment) ──────────────────


### PR DESCRIPTION
## Implementato

- `EVERGREEN_FACTS_BRIEF` (scripts/create-article.mjs): aggiunti BFS + AFC/ESTV alla whitelist istituzioni valide, più una riga esplicita di competenza (chi fissa le aliquote fiscali vs statistica vs previdenza sociale). Questo brief alimenta il prompt di generazione per QUALSIASI modello scelto dalla cascade (non solo local/fallback), quindi il fix vale per tutti i 71 modelli in chain.
- `LOCAL_LLM_TIMEOUT_MS` alzato 900000→1500000 in `.github/workflows/generate-article.yml` e nel default di `getLocalLlmTimeoutMs()` (`scripts/lib/ai-models.mjs`, sibling-check l'ha segnalato — stesso costrutto, stesso fix, tenuti in sync via commento incrociato), in preparazione dell'upgrade a `qwen2.5:14b` (repo variable, applicato DOPO il merge di questa PR — sequenza necessaria per non far girare il modello più lento con il vecchio timeout da 15min).
- Deliberatamente NON toccato `CREATE_ARTICLE_MAX_WALL_MS`/budget per-run: #3102 aveva già provato ad alzarlo per il local-fallback e #3307 l'ha revertito perché disattivava silenziosamente il safety-net `deadlineMs` di cascade-abort. Il budget per-run resta quello validato (30min svizzera / 55min frontaliere).

## Root cause

Run in produzione (2026-07-06): `local/fallback` (qwen2.5:7b, CPU last-resort quando tutti i 70 modelli remoti free-tier sono esauriti) ha allucinato un'istituzione inesistente ("Istituto Federale della Statistica STATIKA", nome reale: BFS) e attribuito erroneamente a UFAS (previdenza sociale) la competenza di fissare le aliquote fiscali → 2 critical dal fact-check LLM (gpt-4.1 + gemini-2.5-flash), articolo correttamente BLOCCATO. Causa: `EVERGREEN_FACTS_BRIEF` non elencava BFS/AFC-ESTV, quindi un modello senza recall di training-data sull'amministrazione fiscale svizzera non aveva nulla di grounded a cui appoggiarsi.

Il fact-check gate ha funzionato come da design — non è stato toccato/rilassato (non-negoziabile #1 AGENTS.md).

## Non implementato (ancora)

Nessuno per questa PR. Il passo successivo (bump repo variable `ARTICLE_LOCAL_MODEL` a `qwen2.5:14b`) è deliberatamente FUORI da questo commit di codice — va eseguito solo DOPO il merge (sequenza necessaria: il nuovo timeout deve essere live prima che il modello più lento inizi a girare) e verrà validato live via `workflow_dispatch` con `force_chain=local/fallback` per misurare i tempi reali sul runner CPU-only prima di lasciarlo nel path organico. Se il tempo reale eccede il nuovo timeout o degrada i run → revert immediato della sola repo variable a `qwen2.5:7b` (nessun code change necessario).

## Test plan

- [x] `npx vitest run tests/local-llm-fallback.test.ts tests/create-article-gates.test.ts` — 39 test verdi (i test parametrizzano `LOCAL_LLM_TIMEOUT_MS` come fixture locale, non dipendono dal valore di produzione)
- [x] GitNexus `detect_changes` scope=all — risk LOW, scope conferma solo i 3 file attesi
- [x] `check-sibling-patterns.mjs` — 1 sibling flaggato (`ai-models.mjs` stesso costrutto timeout) e fixato nella stessa PR; secondo giro pulito
- [x] YAML validato (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Validazione live post-merge: `gh workflow run generate-article.yml -f force_chain=local/fallback` dopo il bump della repo variable, per misurare il tempo reale di qwen2.5:14b sul runner