### PR TITLE
feat(events): reusable agenda crawler factory + geneve.ch pilot canton

### DIFF
--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -1,9 +1,12 @@
-name: Crawl Ticino + nationwide events (tio.ch, guidle, myswitzerland)
+name: Crawl Ticino + nationwide + Genève pilot events (tio.ch, guidle, myswitzerland, geneve.ch)
 
-# Refreshes the events dataset (issue #2963, extended nationwide by #3125).
-# Three quota-free crawlers (plain fetch + jsdom, no API key, no Claude):
-# tio.ch agenda (Ticino only) + guidle.com and myswitzerland.com (all of
-# Switzerland). Each writes its own per-source slice
+# Refreshes the events dataset (issue #2963, extended nationwide by #3125,
+# extended with a second non-TI canton pilot by #3644).
+# Four quota-free crawlers (plain fetch + jsdom, no API key, no Claude):
+# tio.ch agenda (Ticino only), guidle.com and myswitzerland.com (all of
+# Switzerland), and geneve.ch/agenda (GE — pilot canton validating the
+# reusable createAgendaCrawler factory, scripts/lib/agenda-crawler-factory.mjs).
+# Each writes its own per-source slice
 # (data/events/by-source/<key>.json); scripts/assemble-events-dataset.mjs
 # merges them (by-id, then a cross-source fuzzy dedup pass) into
 # data/events.json. Commits data/events.json + every per-source slice +
@@ -123,6 +126,10 @@ jobs:
         id: crawl-myswitzerland
         run: node scripts/crawl-myswitzerland-events.mjs
 
+      - name: Crawl geneve.ch agenda (GE, pilot)
+        id: crawl-ge
+        run: node scripts/crawl-ge-agenda.mjs
+
       - name: Assemble events dataset
         id: assemble
         run: node scripts/assemble-events-dataset.mjs --stats
@@ -161,6 +168,14 @@ jobs:
             services/locales/blog-body/de/eventi-weekend-ticino.ts \
             services/locales/blog-body/fr/eventi-weekend-ticino.ts \
             data/blog-articles-data.ts services/seo/seo-blog-5.ts public/sitemap-blog.xml
+          # data/events/by-source/ge-agenda.json (geneve.ch pilot, #3644): guarded
+          # like the paths below, NOT added to the fixed list above — unlike the
+          # three long-committed slices above, this file won't exist on disk
+          # until the crawler's first-ever successful run, and `git add` on a
+          # missing path errors under `set -e`, which would otherwise abort the
+          # commit of tio/guidle/myswitzerland's data too on a day geneve.ch's
+          # crawl transiently fails before ever having produced a slice.
+          [ -f data/events/by-source/ge-agenda.json ] && git add data/events/by-source/ge-agenda.json || true
           # No-hotlink mirrored event images (scripts/lib/events-utils.mjs
           # mirrorEventImage → public/images/events/): guarded, unlike the
           # slice files above, because the dir only exists once a crawler has
@@ -197,6 +212,7 @@ jobs:
           - Crawl tio.ch agenda: ${{ steps.crawl-tio.outcome }}
           - Crawl guidle.com (nationwide): ${{ steps.crawl-guidle.outcome }}
           - Crawl myswitzerland.com (nationwide): ${{ steps.crawl-myswitzerland.outcome }}
+          - Crawl geneve.ch agenda (GE, pilot): ${{ steps.crawl-ge.outcome }}
           - Assemble events dataset: ${{ steps.assemble.outcome }}
           - Refresh weekend-digest article: ${{ steps.digest.outcome }}
           - Gate (vitest): ${{ steps.gate.outcome }}

--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -204,6 +204,24 @@ jobs:
           git commit -m "📅 Refresh Ticino + nationwide events agenda + weekend-digest article (tio.ch, guidle, myswitzerland)"
           bash scripts/lib/git-push-with-retry.sh
 
+      - name: Surface GE pilot crawl failures (review nit — continue-on-error swallows the signal)
+        # `continue-on-error: true` on "Crawl geneve.ch agenda" (added so a
+        # GE-only failure never blocks that day's tio/guidle/myswitzerland
+        # commit) has a side effect: it also stops a GE failure from ever
+        # making the JOB fail, so "Report failure to GitHub Issues" below
+        # (if: failure()) would never fire for it — the pilot source could
+        # regress silently and indefinitely (assemble prunes past events, so
+        # nothing shows expired data, it's just an invisible freshness gap).
+        # This step runs after the commit either way (if: always()) and only
+        # fails the job — deliberately, on purpose — to re-surface that one
+        # step's own outcome, separate from the cascade gate above.
+        if: always()
+        run: |
+          if [ "${{ steps.crawl-ge.outcome }}" = "failure" ]; then
+            echo "::error::Crawl geneve.ch agenda (GE, pilot) failed this run — dataset commit still proceeded via continue-on-error, but this needs investigation."
+            exit 1
+          fi
+
       - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true

--- a/.github/workflows/crawl-events.yml
+++ b/.github/workflows/crawl-events.yml
@@ -128,6 +128,15 @@ jobs:
 
       - name: Crawl geneve.ch agenda (GE, pilot)
         id: crawl-ge
+        # continue-on-error: geneve.ch is the newest, least battle-tested of
+        # the four sources (own DOM-drift guard exists specifically because
+        # selector drift is plausible on a brand-new source) and sits
+        # upstream of Assemble/Gate/Commit. Without this, a GE-only failure
+        # would cascade and skip that day's commit for tio/guidle/
+        # myswitzerland too, even though they crawled fine — the exact
+        # failure class the "Persist geo/translation caches" step above
+        # already exists to hedge against for tio-agenda's own caches.
+        continue-on-error: true
         run: node scripts/crawl-ge-agenda.mjs
 
       - name: Assemble events dataset

--- a/scripts/crawl-ge-agenda.mjs
+++ b/scripts/crawl-ge-agenda.mjs
@@ -61,6 +61,17 @@ function toIso(day, month, year) {
   return `${year}-${pad2(month)}-${pad2(day)}`;
 }
 
+// Reviewer adversarial check (#3644 PR review): the token scanner only range-
+// checks day as 1-31, so "31 avril" would otherwise silently produce the
+// non-existent 2026-04-31. Round-tripping through Date.UTC (which
+// auto-normalizes out-of-range days, e.g. April 31 -> May 1) catches every
+// invalid day/month combo, leap years included, since it's checked once the
+// exact year is already known.
+function isValidCalendarDate(day, month, year) {
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day;
+}
+
 const MONTHS_FR = {
   janvier: 1,
   fevrier: 2,
@@ -151,6 +162,11 @@ export function parseGeneveDateFr(rawText, now = new Date()) {
     if (i > 0 && tokens[i].month < tokens[i - 1].month) yearOffset += 1;
     tokens[i].year = baseYear + yearOffset;
   }
+
+  // Reject a non-existent calendar date (e.g. a mis-scanned "31 avril")
+  // outright rather than silently fabricating it — skip-on-unparseable is
+  // the same contract as every other bail-out in this function.
+  if (tokens.some((t) => !isValidCalendarDate(t.day, t.month, t.year))) return null;
 
   const first = toIso(tokens[0].day, tokens[0].month, tokens[0].year);
   const last = toIso(tokens[tokens.length - 1].day, tokens[tokens.length - 1].month, tokens[tokens.length - 1].year);

--- a/scripts/crawl-ge-agenda.mjs
+++ b/scripts/crawl-ge-agenda.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Crawler — Ville de Genève Agenda (events, pilot non-TI canton, GE).
+ *
+ * Issue #3644 (F2 of #3125): validates the reusable `createAgendaCrawler`
+ * factory (scripts/lib/agenda-crawler-factory.mjs) on a second, non-Ticino
+ * canton. Quota-free: plain fetch + jsdom, no API key.
+ *
+ * geneve.ch/agenda is the City of Geneva's own official events listing — a
+ * Drupal "Views" page, PAGE-indexed (`?page=N`, 0-based, ~20 cards/page,
+ * chronologically ascending, verified live) rather than day-indexed like
+ * tio.ch. Each card carries: a detail-page link (its slug is the stable raw
+ * id), a thumbnail, a free-text French date string, a title, a free-text
+ * description (venue/address is embedded in the prose, no separate field),
+ * and 1-2 "tags" paragraphs (audience/label tags, then a category).
+ *
+ * Date text has several observed shapes ("Lundi 6 juillet, 09h30", "Du 6 au
+ * 10 juillet", "jusqu'au 2 août", "jusqu'au 3 septembre 2026", "2 et 3
+ * août", "31 octobre et 1 novembre") — see `parseGeneveDateFr` below. A card
+ * whose date genuinely can't be parsed is skipped and counted, never given
+ * a fabricated date.
+ *
+ * Comune: the listing is entirely scoped to the single municipality
+ * "Genève" (quartier names like "Eaux-Vives" only appear in a sidebar
+ * facet, not inline on the card), so every card resolves via the
+ * `REGION_TO_COMUNE['geneve'] = 'Genève'` fallback (extended in
+ * events-utils.mjs for this pilot) — `resolveComune`'s own exact
+ * venue/title match still takes priority if a different real GE comune name
+ * happens to appear in the description text.
+ *
+ * Flyer images (no-hotlink policy): mirrored by the factory itself via the
+ * shared `mirrorEventImage`, same as every other events crawler.
+ */
+import { pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { createAgendaCrawler } from './lib/agenda-crawler-factory.mjs';
+import { EVENT_SOURCES, eventStableId, loadCantonComuni, resolveComune, isoDay } from './lib/events-utils.mjs';
+
+const SOURCE = EVENT_SOURCES['ge-agenda'];
+const ORIGIN = 'https://www.geneve.ch';
+const PAGE_URL = (page) => `${ORIGIN}/agenda?page=${page}`;
+const HORIZON_DAYS = 21;
+// Safety ceiling: live pagination check (2026-07-06) reached the ~21-day
+// horizon around page 15; comfortable margin above that so a slower news
+// week never gets cut short before `horizonDays` actually kicks in.
+const MAX_PAGES = 40;
+
+function text(el) {
+  return (el?.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+function stripAccents(value) {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function toIso(day, month, year) {
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+const MONTHS_FR = {
+  janvier: 1,
+  fevrier: 2,
+  mars: 3,
+  avril: 4,
+  mai: 5,
+  juin: 6,
+  juillet: 7,
+  aout: 8,
+  septembre: 9,
+  octobre: 10,
+  novembre: 11,
+  decembre: 12,
+};
+
+const GRACE_DAYS = 3;
+
+/**
+ * Infer a year for a bare day/month combo (no year in the source text):
+ * prefer the CURRENT year unless that date would land more than
+ * `GRACE_DAYS` in the past relative to `now` — geneve.ch/agenda never lists
+ * past events (verified live), so a date that already happened a few days
+ * ago more likely means "next year" than "we're looking at a stale event".
+ */
+function inferYear(day, month, now) {
+  const year = now.getUTCFullYear();
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  if (candidate.getTime() < now.getTime() - GRACE_DAYS * 86400000) return year + 1;
+  return year;
+}
+
+/**
+ * Parse Ville de Genève's free-text agenda date string into
+ * `{ startDate, endDate }` ISO (date-only) strings — `endDate === startDate`
+ * for a single-day event. Returns `null` when the string can't be parsed
+ * with reasonable confidence; callers MUST skip the card rather than
+ * fabricate a guess.
+ *
+ * Exported for tests/crawl-ge-agenda.test.ts — pure string parsing, no live
+ * network/DOM needed to cover every observed format.
+ */
+export function parseGeneveDateFr(rawText, now = new Date()) {
+  if (!rawText || typeof rawText !== 'string') return null;
+  let normalized = stripAccents(rawText).toLowerCase().replace(/’/g, "'");
+
+  // Explicit year, if present: extract + strip BEFORE token-scanning so a
+  // "2026" is never misread as a 1-2 digit day token.
+  let explicitYear;
+  const yearMatch = /\b(20\d{2})\b/.exec(normalized);
+  if (yearMatch) {
+    explicitYear = Number.parseInt(yearMatch[1], 10);
+    normalized = normalized.replace(yearMatch[0], ' ');
+  }
+
+  // Strip time-of-day tokens ("09h30", "20h") BEFORE scanning day/month —
+  // otherwise "09h30"'s leading digits could be misread as a bogus day.
+  normalized = normalized.replace(/\d{1,2}h\d{0,2}/g, ' ');
+
+  const isOpenEnded = /jusqu'?\s*au\b/.test(normalized);
+  if (isOpenEnded) normalized = normalized.replace(/jusqu'?\s*au\b/, ' ');
+  const isRange = !isOpenEnded && /\bdu\b/.test(normalized) && /\bau\b/.test(normalized);
+
+  const TOKEN_RE = /(\d{1,2})(?:er)?(?:\s+([a-z]+))?/g;
+  const tokens = [];
+  let match;
+  while ((match = TOKEN_RE.exec(normalized))) {
+    const day = Number.parseInt(match[1], 10);
+    if (!Number.isInteger(day) || day < 1 || day > 31) continue;
+    const monthWord = match[2] ? match[2].trim() : undefined;
+    const month = monthWord && MONTHS_FR[monthWord] ? MONTHS_FR[monthWord] : undefined;
+    tokens.push({ day, month });
+  }
+  if (tokens.length === 0) return null;
+
+  // Right-to-left month inheritance: "Du 6 au 10 juillet" → token[0] (6)
+  // borrows token[1]'s (10 juillet) month; "2 et 3 août" the same way.
+  for (let i = tokens.length - 2; i >= 0; i -= 1) {
+    if (!tokens[i].month) tokens[i].month = tokens[i + 1].month;
+  }
+  if (tokens.some((t) => !t.month)) return null; // no month found anywhere in the string
+
+  // Per-token year: bump +1 each time month decreases vs. the previous
+  // token, so a year-boundary range ("31 décembre et 1 janvier") doesn't
+  // silently produce an (wrong) 11-month span.
+  const baseYear = explicitYear || inferYear(tokens[0].day, tokens[0].month, now);
+  let yearOffset = 0;
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (i > 0 && tokens[i].month < tokens[i - 1].month) yearOffset += 1;
+    tokens[i].year = baseYear + yearOffset;
+  }
+
+  const first = toIso(tokens[0].day, tokens[0].month, tokens[0].year);
+  const last = toIso(tokens[tokens.length - 1].day, tokens[tokens.length - 1].month, tokens[tokens.length - 1].year);
+
+  if (isOpenEnded) {
+    // We don't know the real start — use the crawl day as an honest lower
+    // bound (we DO know the event is running as of today, per "jusqu'au").
+    const today = isoDay(now);
+    return { startDate: today, endDate: last >= today ? last : today };
+  }
+  if (tokens.length > 1 || isRange) {
+    return first <= last ? { startDate: first, endDate: last } : { startDate: last, endDate: first };
+  }
+  return { startDate: first, endDate: first };
+}
+
+function rawIdFromHref(href) {
+  const cleaned = (href || '').split('?')[0].split('#')[0].replace(/^\/+|\/+$/g, '');
+  return cleaned.replace(/^agenda\//, '') || cleaned;
+}
+
+function absoluteUrl(href) {
+  if (!href) return undefined;
+  if (href.startsWith('http')) return href;
+  return `${ORIGIN}${href.startsWith('/') ? '' : '/'}${href}`;
+}
+
+/**
+ * Parse one `?page=N` listing page into event objects. Exported so tests
+ * cover the real card markup (fixture HTML) without a live fetch.
+ */
+export function parseGeneveAgendaHtml(html, page) {
+  const doc = new JSDOM(html).window.document;
+  const comuni = loadCantonComuni(SOURCE.canton);
+  const events = [];
+  let skippedNoDate = 0;
+
+  for (const card of doc.querySelectorAll('article.event')) {
+    const a = card.querySelector('a[href]');
+    const href = a?.getAttribute('href') || '';
+    if (!href) continue;
+    const rawId = rawIdFromHref(href);
+    if (!rawId) continue;
+
+    const title = text(card.querySelector('h3.titre'));
+    if (!title) continue;
+
+    const dateText = text(card.querySelector('.date small') || card.querySelector('.date'));
+    const parsedDate = parseGeneveDateFr(dateText);
+    if (!parsedDate) {
+      skippedNoDate += 1;
+      continue;
+    }
+
+    const paragraphs = [...card.querySelectorAll('.boite__contenu p, p')];
+    const tagParagraphs = paragraphs.filter((p) => p.classList.contains('tags'));
+    const descriptionEl = paragraphs.find((p) => !p.classList.contains('tags'));
+    const description = text(descriptionEl);
+    const tags = tagParagraphs.map((p) => text(p)).filter(Boolean);
+    const category = tags.length ? tags[tags.length - 1] : undefined;
+
+    const img = card.querySelector('.evenements-lies--img img, img');
+    const rawImageUrl = img?.getAttribute('src') || img?.getAttribute('data-src') || '';
+
+    const { comune, method } = resolveComune({ venue: description, title, region: 'Genève' }, comuni);
+
+    events.push({
+      id: eventStableId(SOURCE.key, rawId),
+      title,
+      startDate: parsedDate.startDate,
+      endDate: parsedDate.endDate !== parsedDate.startDate ? parsedDate.endDate : undefined,
+      category: category || undefined,
+      region: 'Genève',
+      description: description || undefined,
+      comune: comune || undefined,
+      comuneMatch: method || undefined,
+      canton: SOURCE.canton,
+      url: absoluteUrl(href),
+      imageUrl: absoluteUrl(rawImageUrl) || undefined,
+    });
+  }
+
+  if (skippedNoDate > 0) {
+    console.warn(`[ge-agenda] page ${page}: skipped ${skippedNoDate} card(s) with an unparseable date`);
+  }
+  return events;
+}
+
+const crawler = createAgendaCrawler({
+  sourceKey: SOURCE.key,
+  baseUrl: PAGE_URL,
+  parseDayHtml: parseGeneveAgendaHtml,
+  iterations: MAX_PAGES,
+  horizonDays: HORIZON_DAYS,
+  stopOnEmptyPage: true,
+});
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const { events } = await crawler.crawl({ dryRun });
+  if (dryRun) {
+    console.log(JSON.stringify(events.slice(0, 3), null, 2));
+  }
+}
+
+// Only crawl when invoked directly (`node scripts/crawl-ge-agenda.mjs`), so
+// tests can import `parseGeneveAgendaHtml`/`parseGeneveDateFr` without
+// triggering a live fetch.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`[ge-agenda] crawl failed: ${err?.message || err}`);
+    process.exit(1);
+  });
+}

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3576,6 +3576,12 @@ function extractDatesFromHtml(html, baseUrl) {
     try { href = new URL(am[1], baseUrl).href; } catch { continue; }
     if (!href.startsWith('http') || dateMap.has(href)) continue;
     const d = new Date(year, month - 1, day);
+    // Round-trip: reject calendar-impossible dates (31.04, 30.02) that
+    // Date's local-time constructor silently overflows into the next month
+    // instead of erroring — same anti-pattern fixed in
+    // scripts/lib/postch-job-parser.mjs (parseDdMmYyyy) and
+    // scripts/crawl-ge-agenda.mjs (parseGeneveDateFr / isValidCalendarDate).
+    if (d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day) continue;
     if (!isNaN(d.getTime())) dateMap.set(href, d);
   }
 

--- a/scripts/lib/agenda-crawler-factory.mjs
+++ b/scripts/lib/agenda-crawler-factory.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * scripts/lib/agenda-crawler-factory.mjs
+ *
+ * Reusable quota-free "agenda" crawler factory (issue #3644, F2 of #3125).
+ *
+ * Generalizes the fetch-loop → parse → merge-by-id → DOM-drift-guard →
+ * mirror-images → write-slice orchestration that scripts/crawl-tio-agenda.mjs's
+ * own `main()` pioneered, so a new source-canton pilot doesn't hand-roll it
+ * again — same relationship as `createWorkdaySwissParser` has to the job
+ * crawlers (scripts/lib/workday-swiss-job-parser-common.mjs): validates
+ * required config, returns a small object of functions; every source-specific
+ * detail (URL shape, card selectors, comune resolution, date-text parsing)
+ * lives in the caller-supplied `baseUrl`/`parseDayHtml`, not here.
+ *
+ * `crawl-tio-agenda.mjs` itself is NOT refactored onto this factory — it has
+ * extra per-event enrichment (price, geocoding, title translation) this pilot
+ * doesn't need, and re-plumbing a crawler that commits straight to `main`
+ * daily is a bigger, separate risk than this issue's stated scope (one pilot
+ * canton). New agenda sources should use this factory; nothing here
+ * duplicates it (there was no factory before this file).
+ *
+ * Contract per iteration `i` (0-based, opaque — interpreted by the caller):
+ *   - tio.ch is DAY-indexed: `i` is a day offset from today.
+ *   - Ville de Genève's `/agenda` listing is PAGE-indexed (`?page=N`,
+ *     chronologically ascending, no date in the URL) — `i` is a page number.
+ *   Either way, `baseUrl(i)` returns the URL to fetch for that iteration and
+ *   `parseDayHtml(html, i)` returns the events found on it.
+ *
+ * Required per-event fields from `parseDayHtml` (assembler's own gate — see
+ * assemble-events-dataset.mjs `assemble()`): `id` (MUST come from
+ * `eventStableId(sourceKey, rawId)` so identity is stable run-to-run),
+ * `title`, `startDate`.
+ *
+ * Recurrence across iterations: an id seen again on a later iteration has its
+ * `endDate` extended forward (mirrors tio-agenda's own within-run merge) —
+ * only matters for sources whose `parseDayHtml` can re-emit the same id with
+ * a later `startDate` (day-indexed sources); a no-op for page-indexed sources
+ * where each event appears on exactly one page.
+ *
+ * DOM-drift guard (issue #3644): if at least one page fetched OK (HTTP 200)
+ * but the WHOLE run parsed 0 events, `process.exitCode = 1` so
+ * crawl-events.yml opens a failure issue instead of letting the dataset go
+ * silently stale — mirrors crawl-tio-agenda.mjs's own guard exactly. If every
+ * fetch failed instead (network/WAF), that's treated as transient: soft-exit
+ * 0, no slice write, existing slice on disk is left untouched.
+ *
+ * Termination for page-indexed sources (no fixed day horizon): two optional,
+ * off-by-default knobs so day-indexed sources (there are none on this
+ * factory yet, but the default must stay safe) are unaffected —
+ *   - `horizonDays`: stop paging once an iteration's furthest-seen
+ *     `startDate` reaches `today + horizonDays` (assumes ascending
+ *     chronological order, true for Genève's listing — verified live).
+ *   - `stopOnEmptyPage`: once at least one event has been collected, stop
+ *     after 2 consecutive iterations that parsed 0 events (real end of a
+ *     paginated listing returns HTTP 200 with 0 cards, verified live at
+ *     `?page=999`) — NOT applied before any event has been seen, so a
+ *     source with genuine event-free gaps early in its horizon doesn't
+ *     terminate early.
+ *   `iterations` remains a hard safety ceiling in all cases.
+ *
+ * No-hotlink policy: every event's `imageUrl` is mirrored via the shared
+ * `mirrorEventImage` (events-utils.mjs) before the slice is written — the
+ * same convention every existing events crawler already follows.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { EVENT_SOURCES, EVENTS_SLICE_DIR, mirrorEventImage } from './events-utils.mjs';
+
+const DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch)';
+const DEFAULT_FETCH_TIMEOUT_MS = 20000;
+const DEFAULT_POLITE_DELAY_MS = 600;
+const DEFAULT_IMAGE_MIRROR_DELAY_MS = 150;
+const DEFAULT_ITERATIONS = 21;
+const CONSECUTIVE_EMPTY_LIMIT = 2;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * @typedef {object} AgendaCrawlerConfig
+ * @property {string} sourceKey - must have a matching `EVENT_SOURCES` entry.
+ * @property {(i: number) => string} baseUrl
+ * @property {(html: string, i: number) => Array<object> | Promise<Array<object>>} parseDayHtml
+ * @property {number} [iterations] - default loop count / hard safety ceiling.
+ * @property {number} [horizonDays] - stop once furthest-seen startDate reaches today+N.
+ * @property {boolean} [stopOnEmptyPage] - stop after 2 consecutive empty-but-ok pages (once >=1 event seen).
+ * @property {string} [userAgent]
+ * @property {number} [fetchTimeoutMs]
+ * @property {number} [politeDelayMs]
+ * @property {number} [imageMirrorDelayMs]
+ * @property {boolean} [mirrorImages] - default true (no-hotlink policy).
+ * @property {typeof fetch} [fetchImpl] - injectable for tests.
+ */
+
+/** @param {AgendaCrawlerConfig} config */
+export function createAgendaCrawler(config) {
+  const {
+    sourceKey,
+    baseUrl,
+    parseDayHtml,
+    iterations: defaultIterations = DEFAULT_ITERATIONS,
+    horizonDays,
+    stopOnEmptyPage = false,
+    userAgent = DEFAULT_USER_AGENT,
+    fetchTimeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+    politeDelayMs = DEFAULT_POLITE_DELAY_MS,
+    imageMirrorDelayMs = DEFAULT_IMAGE_MIRROR_DELAY_MS,
+    mirrorImages = true,
+    fetchImpl = fetch,
+  } = config || {};
+
+  if (!sourceKey || typeof sourceKey !== 'string') {
+    throw new Error('createAgendaCrawler: sourceKey (string) is required');
+  }
+  if (typeof baseUrl !== 'function') {
+    throw new Error('createAgendaCrawler: baseUrl(i) function is required');
+  }
+  if (typeof parseDayHtml !== 'function') {
+    throw new Error('createAgendaCrawler: parseDayHtml(html, i) function is required');
+  }
+  const source = EVENT_SOURCES[sourceKey];
+  if (!source) {
+    throw new Error(`createAgendaCrawler: no EVENT_SOURCES['${sourceKey}'] entry — add one in events-utils.mjs first`);
+  }
+
+  async function fetchHtml(url) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
+    try {
+      const res = await fetchImpl(url, { headers: { 'User-Agent': userAgent }, signal: controller.signal });
+      if (!res.ok) return null;
+      return await res.text();
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Returns a NEW array (does not mutate `events`). */
+  async function mirrorImagesForEvents(events) {
+    if (!mirrorImages) return events;
+    const out = [];
+    for (const ev of events) {
+      if (!ev.imageUrl) {
+        out.push(ev);
+        continue;
+      }
+      const mirrored = await mirrorEventImage(ev.imageUrl, ev.id);
+      out.push({ ...ev, imageUrl: mirrored || undefined });
+      await sleep(imageMirrorDelayMs);
+    }
+    return out;
+  }
+
+  /**
+   * Run the fetch → parse → merge loop, then write the per-source slice
+   * (unless `dryRun`). Never overwrites a good slice with an empty one —
+   * see the DOM-drift guard in the file header.
+   *
+   * @param {{ iterations?: number, dryRun?: boolean }} [options]
+   */
+  async function crawl({ iterations = defaultIterations, dryRun = false } = {}) {
+    const crawledAt = new Date().toISOString();
+    const today = crawledAt.slice(0, 10);
+    const horizonDate = horizonDays ? new Date(Date.now() + horizonDays * 86400000).toISOString().slice(0, 10) : null;
+
+    const byId = new Map();
+    let pagesOk = 0;
+    let pagesFail = 0;
+    let emptyStreak = 0;
+    let maxSeenDate = '';
+
+    for (let i = 0; i < iterations; i += 1) {
+      const html = await fetchHtml(baseUrl(i));
+      if (!html) {
+        pagesFail += 1;
+        if (i < iterations - 1) await sleep(politeDelayMs);
+        continue;
+      }
+      pagesOk += 1;
+
+      let parsed = [];
+      try {
+        parsed = (await parseDayHtml(html, i)) || [];
+      } catch (err) {
+        console.error(`[${sourceKey}] parseDayHtml threw on iteration ${i}: ${err?.message || err}`);
+        parsed = [];
+      }
+
+      if (parsed.length > 0) {
+        emptyStreak = 0;
+        for (const ev of parsed) {
+          if (!ev || !ev.id) continue;
+          if (ev.startDate && ev.startDate > maxSeenDate) maxSeenDate = ev.startDate;
+          const existing = byId.get(ev.id);
+          if (existing) {
+            if (ev.startDate && ev.startDate > (existing.endDate || existing.startDate)) {
+              existing.endDate = ev.startDate;
+            }
+          } else {
+            byId.set(ev.id, { ...ev, crawledAt });
+          }
+        }
+      } else if (stopOnEmptyPage && byId.size > 0) {
+        emptyStreak += 1;
+        if (emptyStreak >= CONSECUTIVE_EMPTY_LIMIT) break;
+      }
+
+      if (horizonDate && maxSeenDate >= horizonDate) break;
+      if (i < iterations - 1) await sleep(politeDelayMs);
+    }
+
+    const events = [...byId.values()];
+    console.log(
+      `[${sourceKey}] ${events.length} events over ${pagesOk + pagesFail} iteration(s) ` +
+        `(${pagesOk} pages ok, ${pagesFail} failed, today=${today})`,
+    );
+
+    if (events.length === 0) {
+      console.log(`[${sourceKey}] 0 events parsed — leaving existing slice untouched`);
+      if (pagesOk > 0) {
+        console.error(
+          `[${sourceKey}] DOM drift? ${pagesOk} page(s) returned HTTP 200 but yielded 0 events — check parseDayHtml's selectors`,
+        );
+        process.exitCode = 1;
+      }
+      return { events: [], pagesOk, pagesFail, written: false };
+    }
+
+    const mirroredEvents = await mirrorImagesForEvents(events);
+    const sorted = [...mirroredEvents].sort((a, b) => (a.startDate || '').localeCompare(b.startDate || ''));
+
+    if (dryRun) {
+      console.log(`[${sourceKey}] dry-run — slice not written`);
+      return { events: sorted, pagesOk, pagesFail, written: false };
+    }
+
+    mkdirSync(EVENTS_SLICE_DIR, { recursive: true });
+    const slicePath = path.join(EVENTS_SLICE_DIR, `${source.key}.json`);
+    const slice = {
+      schemaVersion: 1,
+      sourceKey: source.key,
+      sourceName: source.label,
+      canton: source.canton,
+      assembledAt: crawledAt,
+      events: sorted,
+    };
+    writeFileSync(slicePath, `${JSON.stringify(slice, null, 2)}\n`, 'utf-8');
+    console.log(`[${sourceKey}] wrote ${sorted.length} events → ${path.relative(process.cwd(), slicePath)}`);
+    return { events: sorted, pagesOk, pagesFail, written: true };
+  }
+
+  return { fetchHtml, crawl };
+}

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -92,6 +92,16 @@ export const EVENT_SOURCES = {
     homepage: 'https://www.myswitzerland.com',
     canton: null,
   },
+  // Pilot non-TI source-canton crawler (issue #3644, F2 of #3125) — validates
+  // the createAgendaCrawler factory (scripts/lib/agenda-crawler-factory.mjs)
+  // on a second canton. City of Geneva's own official events listing
+  // (Drupal "Views" pager, `?page=N`, no API/key) — see scripts/crawl-ge-agenda.mjs.
+  'ge-agenda': {
+    key: 'ge-agenda',
+    label: 'Ville de Genève Agenda',
+    homepage: 'https://www.geneve.ch/agenda',
+    canton: 'GE',
+  },
 };
 
 // ── Localized URL path config (single source of truth, §6) ───
@@ -240,6 +250,23 @@ export const REGION_TO_COMUNE = {
   blenio: 'Blenio',
   riviera: 'Biasca',
   malcantone: 'Caslano',
+
+  // ── Genève agenda quartiers/region fallback (issue #3644 pilot) ───────
+  // geneve.ch/agenda's card listing doesn't print a quartier name inline
+  // (only a sidebar facet does), so scripts/crawl-ge-agenda.mjs passes the
+  // literal region hint 'Genève' for every event — the whole source is
+  // scoped to the single municipality "Genève", so this always resolves.
+  // The 7 real quartier names are also mapped (same 'Genève' comune, since
+  // canton GE's municipality list has one "Genève" entry) for forward
+  // compatibility if a future pass starts reading the quartier facet.
+  geneve: 'Genève',
+  champel: 'Genève',
+  'eaux-vives cite': 'Genève',
+  'grottes saint-gervais': 'Genève',
+  'paquis secheron': 'Genève',
+  'plainpalais jonction': 'Genève',
+  'saint-jean charmilles': 'Genève',
+  'servette petit-saconnex': 'Genève',
 };
 
 // ── Text normalization ───────────────────────────────────────

--- a/tests/agenda-crawler-factory.test.ts
+++ b/tests/agenda-crawler-factory.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Reusable agenda crawler factory (#3644, F2 of #3125): the fetch → parse →
+ * merge-by-id → DOM-drift-guard → write-slice orchestration shared by every
+ * per-source agenda crawler (currently scripts/crawl-ge-agenda.mjs, the pilot
+ * non-TI canton). No live network — `fetchImpl` is always injected.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { createAgendaCrawler } from '../scripts/lib/agenda-crawler-factory.mjs';
+import { EVENT_SOURCES, EVENTS_SLICE_DIR } from '../scripts/lib/events-utils.mjs';
+
+const TEST_SOURCE_KEY = 'test-agenda-factory';
+const slicePath = path.join(EVENTS_SLICE_DIR, `${TEST_SOURCE_KEY}.json`);
+
+// Register a throwaway EVENT_SOURCES entry for the duration of this file —
+// EVENT_SOURCES is a plain (non-frozen) object shared across the module
+// graph, same pattern other events tests rely on for fixture data.
+EVENT_SOURCES[TEST_SOURCE_KEY] = {
+  key: TEST_SOURCE_KEY,
+  label: 'Test Agenda Factory Fixture',
+  homepage: 'https://example.test/agenda',
+  canton: 'ZZ',
+};
+
+afterEach(() => {
+  rmSync(slicePath, { force: true });
+});
+
+function makeConfig(overrides = {}) {
+  return {
+    sourceKey: TEST_SOURCE_KEY,
+    baseUrl: (i: number) => `https://example.test/agenda?page=${i}`,
+    parseDayHtml: () => [],
+    mirrorImages: false,
+    politeDelayMs: 0,
+    imageMirrorDelayMs: 0,
+    fetchTimeoutMs: 50,
+    ...overrides,
+  };
+}
+
+function okResponse(body: string) {
+  return { ok: true, text: async () => body };
+}
+
+describe('createAgendaCrawler — config validation', () => {
+  it('throws without sourceKey/baseUrl/parseDayHtml', () => {
+    expect(() => createAgendaCrawler({ baseUrl: () => '', parseDayHtml: () => [] } as never)).toThrow(/sourceKey/);
+    expect(() => createAgendaCrawler({ sourceKey: 'x', parseDayHtml: () => [] } as never)).toThrow(/baseUrl/);
+    expect(() => createAgendaCrawler({ sourceKey: 'x', baseUrl: () => '' } as never)).toThrow(/parseDayHtml/);
+  });
+
+  it('throws when sourceKey has no matching EVENT_SOURCES entry', () => {
+    expect(() => createAgendaCrawler(makeConfig({ sourceKey: 'no-such-source' }))).toThrow(/EVENT_SOURCES/);
+  });
+});
+
+describe('createAgendaCrawler — crawl()', () => {
+  it('merges events by id across iterations, extending endDate forward, and writes the slice', async () => {
+    const fetchImpl = async () => okResponse('<html></html>');
+    const parseDayHtml = (_html: string, i: number) => [
+      { id: 'src:evt-1', title: 'Recurring Event', startDate: `2026-08-0${i + 1}` },
+      ...(i === 0 ? [{ id: 'src:evt-2', title: 'One-off Event', startDate: '2026-08-01' }] : []),
+    ];
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml, iterations: 3 }));
+    const result = await crawler.crawl({ iterations: 3 });
+
+    expect(result.written).toBe(true);
+    expect(result.pagesOk).toBe(3);
+    expect(result.pagesFail).toBe(0);
+
+    const byId = Object.fromEntries(result.events.map((e: any) => [e.id, e]));
+    expect(byId['src:evt-1'].startDate).toBe('2026-08-01');
+    expect(byId['src:evt-1'].endDate).toBe('2026-08-03'); // extended across iterations 0,1,2
+    expect(byId['src:evt-2'].endDate).toBeUndefined(); // seen once — no extension
+
+    expect(existsSync(slicePath)).toBe(true);
+    const written = JSON.parse(readFileSync(slicePath, 'utf-8'));
+    expect(written).toMatchObject({ schemaVersion: 1, sourceKey: TEST_SOURCE_KEY, canton: 'ZZ' });
+    expect(written.events).toHaveLength(2);
+  });
+
+  it('dry-run never writes the slice, even with events parsed', async () => {
+    const fetchImpl = async () => okResponse('<html></html>');
+    const parseDayHtml = () => [{ id: 'src:evt-1', title: 'Event', startDate: '2026-08-01' }];
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml, iterations: 1 }));
+    const result = await crawler.crawl({ iterations: 1, dryRun: true });
+
+    expect(result.written).toBe(false);
+    expect(result.events).toHaveLength(1);
+    expect(existsSync(slicePath)).toBe(false);
+  });
+
+  it('DOM-drift guard: pages load OK but 0 events parsed → exitCode 1, no slice write', async () => {
+    const fetchImpl = async () => okResponse('<html>no cards here</html>');
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml: () => [], iterations: 2 }));
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const result = await crawler.crawl({ iterations: 2 });
+
+    expect(result.written).toBe(false);
+    expect(result.pagesOk).toBe(2);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(slicePath)).toBe(false);
+
+    process.exitCode = previousExitCode;
+  });
+
+  it('all pages failing is treated as transient: no exitCode flip, no slice write', async () => {
+    const fetchImpl = async () => ({ ok: false, text: async () => '' });
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml: () => [], iterations: 2 }));
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const result = await crawler.crawl({ iterations: 2 });
+
+    expect(result.written).toBe(false);
+    expect(result.pagesOk).toBe(0);
+    expect(result.pagesFail).toBe(2);
+    expect(process.exitCode).toBe(0);
+    expect(existsSync(slicePath)).toBe(false);
+
+    process.exitCode = previousExitCode;
+  });
+
+  it('a fetchImpl that throws (e.g. abort) counts as a failed page, not a crash', async () => {
+    const fetchImpl = async () => {
+      throw new Error('aborted');
+    };
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml: () => [], iterations: 1 }));
+    const result = await crawler.crawl({ iterations: 1 });
+    expect(result.pagesFail).toBe(1);
+    expect(result.written).toBe(false);
+  });
+
+  it('horizonDays stops paging once the furthest-seen startDate reaches the horizon', async () => {
+    const calledPages: number[] = [];
+    const fetchImpl = async (url: string) => {
+      calledPages.push(Number(new URL(url).searchParams.get('page')));
+      return okResponse('<html></html>');
+    };
+    const now = Date.now();
+    const farFuture = new Date(now + 100 * 86400000).toISOString().slice(0, 10);
+    const parseDayHtml = (_html: string, i: number) => [
+      { id: `src:evt-${i}`, title: `Event ${i}`, startDate: i === 0 ? farFuture : '2020-01-01' },
+    ];
+    const crawler = createAgendaCrawler(
+      makeConfig({ fetchImpl, parseDayHtml, iterations: 50, horizonDays: 21 }),
+    );
+    const result = await crawler.crawl({ iterations: 50 });
+
+    // Horizon already exceeded on iteration 0 — loop must break right after it.
+    expect(calledPages).toEqual([0]);
+    expect(result.pagesOk).toBe(1);
+  });
+
+  it('stopOnEmptyPage stops after 2 consecutive empty-but-ok pages, only once >=1 event was collected', async () => {
+    const calledPages: number[] = [];
+    const fetchImpl = async (url: string) => {
+      calledPages.push(Number(new URL(url).searchParams.get('page')));
+      return okResponse('<html></html>');
+    };
+    // Page 0 empty (must NOT stop yet — nothing collected so far), page 1 has
+    // one event, pages 2+3 empty (2 consecutive after >=1 event) → stop
+    // before ever reaching page 4.
+    const parseDayHtml = (_html: string, i: number) =>
+      i === 1 ? [{ id: 'src:evt-1', title: 'Event', startDate: '2026-08-01' }] : [];
+    const crawler = createAgendaCrawler(
+      makeConfig({ fetchImpl, parseDayHtml, iterations: 10, stopOnEmptyPage: true }),
+    );
+    const result = await crawler.crawl({ iterations: 10 });
+
+    expect(calledPages).toEqual([0, 1, 2, 3]);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it('a parseDayHtml that throws on one iteration does not abort the whole crawl', async () => {
+    const fetchImpl = async () => okResponse('<html></html>');
+    const parseDayHtml = (_html: string, i: number) => {
+      if (i === 0) throw new Error('selector exploded');
+      return [{ id: 'src:evt-1', title: 'Event', startDate: '2026-08-01' }];
+    };
+    const crawler = createAgendaCrawler(makeConfig({ fetchImpl, parseDayHtml, iterations: 2 }));
+    const result = await crawler.crawl({ iterations: 2 });
+    expect(result.written).toBe(true);
+    expect(result.events).toHaveLength(1);
+  });
+});

--- a/tests/crawl-ge-agenda.test.ts
+++ b/tests/crawl-ge-agenda.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Ville de Genève agenda crawler (#3644, F2 of #3125, pilot non-TI canton):
+ * pure parsing logic only — no live network calls. Card fixture below is
+ * trimmed real markup captured from https://www.geneve.ch/agenda?page=0
+ * (2026-07-06) so the DOM selectors are exercised against the real shape.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseGeneveDateFr, parseGeneveAgendaHtml } from '../scripts/crawl-ge-agenda.mjs';
+
+const NOW = new Date('2026-07-06T00:00:00Z');
+
+describe('parseGeneveDateFr', () => {
+  it('parses a single weekday+day+month+time (no year)', () => {
+    expect(parseGeneveDateFr('Lundi 6 juillet, 09h30', NOW)).toEqual({
+      startDate: '2026-07-06',
+      endDate: '2026-07-06',
+    });
+  });
+
+  it('parses a "Du X au Y mois" range, inheriting the month leftward', () => {
+    expect(parseGeneveDateFr('Du 6 au 10 juillet', NOW)).toEqual({
+      startDate: '2026-07-06',
+      endDate: '2026-07-10',
+    });
+  });
+
+  it('parses an open-ended "jusqu\'au" date as [today, end]', () => {
+    expect(parseGeneveDateFr("jusqu'au 2 août", NOW)).toEqual({
+      startDate: '2026-07-06',
+      endDate: '2026-08-02',
+    });
+  });
+
+  it('parses "jusqu\'au" with an explicit year and ignores trailing recurrence text', () => {
+    expect(parseGeneveDateFr("jusqu'au 3 septembre 2026, certains mercredis", NOW)).toEqual({
+      startDate: '2026-07-06',
+      endDate: '2026-09-03',
+    });
+  });
+
+  it('parses a same-month "X et Y" pair', () => {
+    expect(parseGeneveDateFr('2 et 3 août', NOW)).toEqual({
+      startDate: '2026-08-02',
+      endDate: '2026-08-03',
+    });
+  });
+
+  it('parses a cross-month "X et Y" pair', () => {
+    expect(parseGeneveDateFr('31 octobre et 1 novembre', NOW)).toEqual({
+      startDate: '2026-10-31',
+      endDate: '2026-11-01',
+    });
+  });
+
+  it('collapses multiple same-day times into one date', () => {
+    expect(parseGeneveDateFr('Dimanche 1 novembre, 09h30, 10h30', NOW)).toEqual({
+      startDate: '2026-11-01',
+      endDate: '2026-11-01',
+    });
+  });
+
+  it('rolls the year forward across a year-boundary "X et Y" pair', () => {
+    expect(parseGeneveDateFr('31 décembre et 1 janvier', NOW)).toEqual({
+      startDate: '2026-12-31',
+      endDate: '2027-01-01',
+    });
+  });
+
+  it('infers next year for a bare day/month that already passed (beyond the grace window)', () => {
+    // "5 janvier" relative to a July crawl day has no explicit year and is
+    // far in the past for the current year — must roll to next year, not
+    // silently produce a stale past date.
+    expect(parseGeneveDateFr('5 janvier', NOW)).toEqual({
+      startDate: '2027-01-05',
+      endDate: '2027-01-05',
+    });
+  });
+
+  it('returns null for text with no day/month at all (never fabricates a date)', () => {
+    expect(parseGeneveDateFr('certains mercredis', NOW)).toBeNull();
+  });
+
+  it('returns null for empty/missing input', () => {
+    expect(parseGeneveDateFr('', NOW)).toBeNull();
+    expect(parseGeneveDateFr(undefined as unknown as string, NOW)).toBeNull();
+  });
+});
+
+function cardHtml({
+  href = '/agenda/atelier-initiation-ecriture-braille-7-grand-juillet-gratuit-0',
+  date = 'Lundi 6 juillet, 09h30',
+  title = "Atelier d'initiation à l'écriture braille dès 7 ans à Grand Juillet (gratuit)",
+  description = 'Atelier ludique de découverte du braille, tous les jours du festival sauf les 4, 8 et 12 juillet au Grand Lieu, ferme de Budé 1209',
+  tags = ['100% gratuit - En plein air', 'Atelier'],
+  img = '/sites/default/files/styles/1_48_445x300/public/openagenda/oa-48925009.jpg.webp?itok=6fZquLMj',
+}: {
+  href?: string;
+  date?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  img?: string;
+} = {}) {
+  const tagsHtml = tags.map((t) => `<p class="no-margin tags">${t}</p>`).join('\n');
+  return `
+    <article class="event teaser teaser-default clearfix">
+      <div class="boite bg-color-twentythree text-color-three illustration">
+        <a href="${href}">
+          <div class="evenements-lies--img">
+            <img loading="lazy" src="${img}" width="445" height="300" alt="">
+          </div>
+          <div class="boite__contenu bg-color-twentythree text-color-three">
+            <div class="date"><small class="bg-color-five text-color-three has-label">${date}</small></div>
+            <h3 class="titre bg-color-twentythree text-color-three">
+              <div class="field field--name-field-teaser-title field--type-string field--label-hidden field--item">${title}</div>
+            </h3>
+            <p class="bg-color-twentythree text-color-three">${description}</p>
+            ${tagsHtml}
+          </div>
+        </a>
+      </div>
+    </article>
+  `;
+}
+
+describe('parseGeneveAgendaHtml', () => {
+  it('parses a real card into the canonical event shape (region-fallback comune)', () => {
+    const html = `<div>${cardHtml()}</div>`;
+    const events = parseGeneveAgendaHtml(html, 0);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: 'ge-agenda:atelier-initiation-ecriture-braille-7-grand-juillet-gratuit-0',
+      title: "Atelier d'initiation à l'écriture braille dès 7 ans à Grand Juillet (gratuit)",
+      startDate: '2026-07-06',
+      category: 'Atelier',
+      region: 'Genève',
+      comune: 'Genève',
+      comuneMatch: 'region',
+      canton: 'GE',
+      url: 'https://www.geneve.ch/agenda/atelier-initiation-ecriture-braille-7-grand-juillet-gratuit-0',
+      imageUrl:
+        'https://www.geneve.ch/sites/default/files/styles/1_48_445x300/public/openagenda/oa-48925009.jpg.webp?itok=6fZquLMj',
+    });
+    expect(events[0].endDate).toBeUndefined();
+  });
+
+  it('sets endDate only when it differs from startDate (a "Du X au Y" range)', () => {
+    const html = `<div>${cardHtml({ date: 'Du 6 au 10 juillet' })}</div>`;
+    const events = parseGeneveAgendaHtml(html, 0);
+    expect(events[0].startDate).toBe('2026-07-06');
+    expect(events[0].endDate).toBe('2026-07-10');
+  });
+
+  it('resolves the exact comune when a different real GE municipality is named in the description', () => {
+    // "Vernier" is stored in data/canton-municipalities.json without a
+    // canton-disambiguator suffix (unlike e.g. "Carouge (GE)"), so it's a
+    // clean exact-match fixture for a non-Genève GE comune.
+    const html = `<div>${cardHtml({
+      href: '/agenda/spectacle-vernier',
+      title: 'Spectacle en plein air',
+      description: 'Un spectacle familial au parc de Vernier, entrée libre',
+    })}</div>`;
+    const events = parseGeneveAgendaHtml(html, 0);
+    expect(events[0].comune).toBe('Vernier');
+    expect(events[0].comuneMatch).toBe('exact');
+  });
+
+  it('skips a card whose date text is genuinely unparseable, never fabricating a date', () => {
+    const html = `<div>${cardHtml({ date: 'certains mercredis' })}</div>`;
+    const events = parseGeneveAgendaHtml(html, 0);
+    expect(events).toHaveLength(0);
+  });
+
+  it('skips a card with no title and one with no href', () => {
+    const noTitle = cardHtml({ title: '' });
+    const noHref = cardHtml({ href: '' });
+    const events = parseGeneveAgendaHtml(`<div>${noTitle}${noHref}</div>`, 0);
+    expect(events).toHaveLength(0);
+  });
+
+  it('parses multiple cards on one page independently', () => {
+    const html = `<div>${cardHtml({ href: '/agenda/event-a', title: 'Event A' })}${cardHtml({
+      href: '/agenda/event-b',
+      title: 'Event B',
+      date: '2 et 3 août',
+    })}</div>`;
+    const events = parseGeneveAgendaHtml(html, 0);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.title)).toEqual(['Event A', 'Event B']);
+  });
+
+  it('returns [] for a page with no event cards', () => {
+    expect(parseGeneveAgendaHtml('<div><p>no events today</p></div>', 5)).toEqual([]);
+  });
+});

--- a/tests/crawl-ge-agenda.test.ts
+++ b/tests/crawl-ge-agenda.test.ts
@@ -80,6 +80,17 @@ describe('parseGeneveDateFr', () => {
     expect(parseGeneveDateFr('certains mercredis', NOW)).toBeNull();
   });
 
+  it('returns null for a day that does not exist in the given month (never fabricates a date)', () => {
+    // April has 30 days — "31 avril" is a mis-scan, not a real date.
+    expect(parseGeneveDateFr('31 avril', NOW)).toBeNull();
+    // Feb 29 only exists in a leap year.
+    expect(parseGeneveDateFr('29 fevrier 2026', NOW)).toBeNull();
+    expect(parseGeneveDateFr('29 fevrier 2028', NOW)).toEqual({
+      startDate: '2028-02-29',
+      endDate: '2028-02-29',
+    });
+  });
+
   it('returns null for empty/missing input', () => {
     expect(parseGeneveDateFr('', NOW)).toBeNull();
     expect(parseGeneveDateFr(undefined as unknown as string, NOW)).toBeNull();


### PR DESCRIPTION
## Implementato

- `scripts/lib/agenda-crawler-factory.mjs` (new): reusable `createAgendaCrawler({ sourceKey, baseUrl, parseDayHtml, ... })` factory, generalizing the fetch→parse→merge-by-id→DOM-drift-guard→mirror-images→write-slice orchestration that `scripts/crawl-tio-agenda.mjs` pioneered — same relationship as `createWorkdaySwissParser` has to the job crawlers (config validated, small function object returned, no duplication).
  - Merges parsed events by stable id across iterations, extending `endDate` forward when the same event reappears on a later page/day.
  - DOM-drift guard: if every fetched page returned HTTP 200 but 0 events were parsed in total, sets `process.exitCode = 1` and skips the slice write (selector-drift signal). If pages genuinely failed to fetch (network/WAF), that's treated as transient — no exit-code flip, existing slice left untouched.
  - Two new termination knobs, both **off by default** so `crawl-tio-agenda.mjs`'s existing day-indexed behavior is completely unaffected: `horizonDays` (date-based auto-stop once the furthest-seen event date reaches the horizon) and `stopOnEmptyPage` (stop after 2 consecutive empty-but-ok pages, only once ≥1 event has already been collected — avoids a false-positive stop on a source with genuine event-free gaps).
  - `dryRun` option (no slice write, used by tests).
- `scripts/crawl-ge-agenda.mjs` (new): the pilot **non-Ticino canton** source validating the factory — City of Genève's own official events listing (`geneve.ch/agenda`, page-indexed Drupal Views pager, no API/key). Includes `parseGeneveDateFr`, a free-text French date parser covering every real format observed on the live site (single date, "Du X au Y", "jusqu'au …", same-month and cross-month "X et Y" pairs, multi-time single-day, year-boundary ranges) with skip-on-unparseable semantics — it never fabricates a date.
- `scripts/lib/events-utils.mjs`: adds the `'ge-agenda'` `EVENT_SOURCES` entry and extends `REGION_TO_COMUNE` with `Genève` + its 7 quartiers (all resolving to the canton's single `Genève` municipality, since `geneve.ch`'s card listing doesn't print a quartier name inline).
- **No changes needed** to `scripts/assemble-events-dataset.mjs` — its by-id merge/prune and cross-source fuzzy dedup (`title+startDate+comune`) are already fully source-agnostic; a correctly-shaped new slice is all that's required (verified by reading the file in full).
- `.github/workflows/crawl-events.yml`: new "Crawl geneve.ch agenda (GE, pilot)" step, guarded `git add` for the not-yet-committed first-run slice file (unlike the 3 already-committed slices, `ge-agenda.json` doesn't exist on disk until the crawler's first successful run — an unguarded `git add` on a missing path would abort the whole day's commit under `set -e` if geneve.ch is transiently unreachable before ever producing a slice), and an updated step-outcomes report line.
- Tests: `tests/crawl-ge-agenda.test.ts` (18 cases — date parser edge cases including the year-boundary rollover and unparseable-garbage-returns-null, plus card parsing against a fixture built from real captured `geneve.ch/agenda` markup) and `tests/agenda-crawler-factory.test.ts` (10 cases — id-merge/endDate-extension, dry-run, DOM-drift guard, all-pages-failed soft path, thrown-fetch/thrown-parse resilience, `horizonDays`, `stopOnEmptyPage`). All new + adjacent events suites green: `tests/crawl-ge-agenda.test.ts`, `tests/agenda-crawler-factory.test.ts`, `tests/events-pipeline.test.ts`, `tests/events-nationwide-sources.test.ts`, `tests/assemble-events-dedup.test.ts` (89 + 17 tests, all passing).

GE was chosen as the pilot canton — explicitly one of the two examples named in the parent issue (#3125 F2: "1 cantone pilota, es. ZH o GE").

## Non implementato (ancora)

Nessuno — issue #3644's stated scope (reusable factory, one pilot non-TI canton, slice + assembler reuse, quota-free fetch+jsdom, DOM-drift guard, `REGION_TO_COMUNE` extension, cross-source fuzzy dedup) is fully implemented in this PR. Further cantons (DE-CH/other FR-CH sources) and the base-path/hub multi-canton generalization are explicitly separate follow-on issues (#3125 F3+), not part of #3644's scope.

Closes #3644