### PR TITLE
fix(email): rebalance cascade quotas — cloudflare to free tier, resend to 1666/day

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -23,7 +23,8 @@
  *   MAILGUN_DOMAIN           — Mailgun sending domain
  *   MAILTRAP_API_TOKEN       — Mailtrap API token (4000/mo, 150/day free tier)
  *   MAILEROO_API_KEY         — Maileroo sending key (3000/mo free tier)
- *   RESEND_API_KEY           — Resend API key (fallback only)
+ *   RESEND_API_KEY           — Resend API key (50000/mo paid plan since 2026-07-06,
+ *                                bulk workhorse of the cascade, not a fallback)
  *   CF_API_TOKEN             — Cloudflare token used by default for Email Service:
  *                                it already carries Email Sending: Edit + Analytics
  *                                Read (verified live). 3000/mo included on the
@@ -40,7 +41,10 @@
 
 const PROVIDERS = [
   { id: 'mailgun',  dailyLimit: 100, monthlyLimit: 3000  },
-  { id: 'resend',   dailyLimit: 100, monthlyLimit: 3000  },
+  // resend: paid plan activated 2026-07-06 (50000/mo, owner request) — this is
+  // now the bulk workhorse of the cascade, not a fallback. dailyLimit = 50000/30
+  // months-average, floored.
+  { id: 'resend',   dailyLimit: 1666, monthlyLimit: 50000 },
   { id: 'mailjet',  dailyLimit: 200, monthlyLimit: 6000  },
   { id: 'mailtrap', dailyLimit: 150, monthlyLimit: 4000  },
   // maileroo: free tier (100/day). DKIM selector mta._domainkey.frontaliereticino.ch
@@ -51,13 +55,15 @@ const PROVIDERS = [
   // dmarc=pass at p=reject (dis=NONE), delivered to inbox. Placed before cloudflare so
   // the purely-free providers are preferred over the paid Workers quota.
   { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
-  // Cloudflare Email Service: 3000/mo is the included allowance on Workers Paid;
-  // no documented per-day cap. dailyLimit=1000, monthlyLimit=30000 (owner request
-  // 2026-07-03) — owner accepted paid overage above the included 3000/mo, up to
-  // ~$9.45/mo worst case ($0.35/1000 past the included allowance, if cloudflare
-  // maxes out every day of the month). Placed last: it draws on the paid-plan
-  // quota, so prefer the purely-free providers first.
-  { id: 'cloudflare', dailyLimit: 1000, monthlyLimit: 30000 },
+  // Cloudflare Email Service: reverted to the free-tier threshold 2026-07-06
+  // (owner request) — dailyLimit=100, monthlyLimit=3000, superseding the
+  // 2026-07-03 paid-overage bump (dailyLimit 1000/monthlyLimit 30000). Root
+  // cause for the revert: cloudflare's burst-rate throttle (429 code=10004)
+  // fires well below any of these daily caps (hit at ~200 sends on 2026-07-06),
+  // so raising the daily cap bought no real extra headroom — it only masked
+  // the fact that resend now covers the bulk volume instead. Placed last: it
+  // draws on the paid-plan quota, so prefer the purely-free providers first.
+  { id: 'cloudflare', dailyLimit: 100, monthlyLimit: 3000 },
 ];
 
 // In-memory daily counters (reset on new UTC day)
@@ -320,7 +326,8 @@ async function syncQuotasFromAPIs() {
   _counters.cloudflare = cloudflare;
   _quotasSynced = true;
 
-  console.log(`   Usage today: mailgun=${mailgun}/100, mailjet=${mailjet}/200, mailtrap=${mailtrap}/150, resend=${resend}/100, maileroo=${maileroo}/100, cloudflare=${cloudflare}/1000`);
+  const limit = id => PROVIDERS.find(p => p.id === id).dailyLimit;
+  console.log(`   Usage today: mailgun=${mailgun}/${limit('mailgun')}, mailjet=${mailjet}/${limit('mailjet')}, mailtrap=${mailtrap}/${limit('mailtrap')}, resend=${resend}/${limit('resend')}, maileroo=${maileroo}/${limit('maileroo')}, cloudflare=${cloudflare}/${limit('cloudflare')}`);
 }
 
 // ── Provider availability check ──────────────────────────────
@@ -928,11 +935,10 @@ function campaignIdTag(email) {
 }
 
 /**
- * Total theoretical daily send capacity across the whole cascade —
- * the sum of every provider's daily limit (currently mailgun 100 + resend 100
- * + mailjet 200 + mailtrap 150 + maileroo 100 + cloudflare 1000 = 1650). Single
- * source of truth so callers (e.g. the newsletter per-run cap) stay in sync when
- * providers change.
+ * Total theoretical daily send capacity across the whole cascade — the sum of
+ * every provider's daily limit (see PROVIDERS above). Single source of truth
+ * so callers (e.g. the newsletter per-run cap) stay in sync when providers
+ * change, instead of a second hardcoded total drifting from the array.
  */
 export function getCascadeDailyCapacity() {
   return PROVIDERS.reduce((sum, p) => sum + p.dailyLimit, 0);

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -171,13 +171,42 @@ async function fetchResendDailyUsage() {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) return 0;
   try {
-    const res = await fetch('https://api.resend.com/emails', {
-      headers: { Authorization: 'Bearer ' + apiKey }
-    });
-    if (!res.ok) return 0;
-    const data = await res.json();
     const today = getTodayUTC();
-    return (data.data || []).filter(e => e.created_at?.startsWith(today)).length;
+    let count = 0;
+    let after;
+    // /emails is sorted newest-first; page with limit=100 (API max) until an
+    // entry older than today appears or has_more is false. Capped at 20 pages
+    // (2000 entries) — comfortably above the 1666/day cascade cap, so a
+    // legitimate day's volume never gets truncated back into the same
+    // undercount bug this replaces (previously: default limit=20, single
+    // page, silently missed everything sent earlier that day past the 20
+    // most recent — harmless at the old 100/day resend cap, but a real
+    // over-send risk now that resend carries the 1666/day bulk cascade load).
+    for (let page = 0; page < 20; page++) {
+      const url = new URL('https://api.resend.com/emails');
+      url.searchParams.set('limit', '100');
+      if (after) url.searchParams.set('after', after);
+      const res = await fetch(url, { headers: { Authorization: 'Bearer ' + apiKey } });
+      if (!res.ok) break;
+      const data = await res.json();
+      const entries = data.data || [];
+      if (entries.length === 0) break;
+      const todayEntries = [];
+      let hitOlderDay = false;
+      for (const e of entries) {
+        if (e.created_at?.startsWith(today)) {
+          todayEntries.push(e);
+        } else {
+          hitOlderDay = true;
+          break;
+        }
+      }
+      count += todayEntries.length;
+      if (hitOlderDay || !data.has_more) break;
+      after = entries[entries.length - 1]?.id;
+      if (!after) break;
+    }
+    return count;
   } catch { return 0; }
 }
 
@@ -944,4 +973,4 @@ export function getCascadeDailyCapacity() {
   return PROVIDERS.reduce((sum, p) => sum + p.dailyLimit, 0);
 }
 
-export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs, isRateLimitedError, campaignIdTag };
+export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs, isRateLimitedError, campaignIdTag, fetchResendDailyUsage };

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -46,7 +46,7 @@ import { NEWSLETTER_EXCLUDED_STATUSES } from '../services/emailSuppression.mjs';
 import { makeUnsubscribeUrl, makeResubscribeUrl, generateAutologinCode } from '../services/newsletterUrls.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
-import { getCascadeDailyCapacity } from './lib/email-cascade.mjs';
+import { getCascadeDailyCapacity, PROVIDERS as EMAIL_PROVIDERS } from './lib/email-cascade.mjs';
 import { normalizeEmailAddress } from './lib/parseEmailField.mjs';
 import { subscriberFromFirestoreRow } from './lib/subscriberFromFirestoreRow.mjs';
 
@@ -77,18 +77,20 @@ const SINGLE_PROVIDERS = ['mailgun', 'mailjet', 'mailtrap', 'cloudflare'];
 const IS_SINGLE_PROVIDER = SINGLE_PROVIDERS.includes(EMAIL_PROVIDER);
 // The per-run cap tracks the FULL cascade capacity — the sum of every configured
 // provider's daily limit (getCascadeDailyCapacity, single source of truth in
-// email-cascade.mjs). Currently 750/day = mailgun 100 + resend 100 + mailjet 200
-// + mailtrap 150 + maileroo 100 + cloudflare 100. Adding/removing a provider
-// auto-updates this cap.
-// resend-only legacy mode stays 100.
+// email-cascade.mjs, PROVIDERS array). Adding/removing a provider or changing a
+// limit auto-updates this cap — see PROVIDERS in email-cascade.mjs for current
+// per-provider numbers instead of a second hardcoded total here that would drift.
+// resend-only legacy mode stays at resend's own dailyLimit (also derived, not hardcoded).
 // The weekly campaign (campaignId=weekly_{monday}) resumes across daily cron runs and must clear
 // the full active list (~2.5k) before Monday's campaign-ID rollover strands the unsent tail.
 // On healthy days the old 350 cap was the binding limit: 2026-05-26 and 05-27 both hit 350 with
 // mailjet delivering 149-200 and thousands still pending. Deriving from providers lets each day
-// clear up to the real ceiling (now 750 incl maileroo + cloudflare) instead of an unused-capacity static number.
+// clear up to the real ceiling instead of an unused-capacity static number.
 // CAVEAT: on days a provider is down (mailjet "fetch failed" on 05-28..30; 05-29 delivered only
 // 98/350) provider reliability — not this cap — is the binding constraint, and the cap is moot.
-const DAILY_SEND_LIMIT = EMAIL_PROVIDER === 'resend' ? 100 : getCascadeDailyCapacity();
+const DAILY_SEND_LIMIT = EMAIL_PROVIDER === 'resend'
+  ? EMAIL_PROVIDERS.find(p => p.id === 'resend').dailyLimit
+  : getCascadeDailyCapacity();
 
 /**
  * Run async tasks with bounded concurrency.

--- a/tests/email-cascade-burst.test.ts
+++ b/tests/email-cascade-burst.test.ts
@@ -3,6 +3,7 @@ import {
   isRateLimitedError,
   sendEmailCascade,
   fetchMailtrapDailyUsage,
+  fetchResendDailyUsage,
   fetchCloudflareUsage,
   fetchCloudflareDeliveryStats,
   campaignIdTag,
@@ -88,6 +89,69 @@ describe('fetchMailtrapDailyUsage', () => {
   it('returns 0 when no token is configured', async () => {
     delete process.env.MAILTRAP_API_TOKEN;
     expect(await fetchMailtrapDailyUsage()).toBe(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  fetchResendDailyUsage — must paginate past the API's default      */
+/*  20-item page instead of silently under-counting today's sends     */
+/* ------------------------------------------------------------------ */
+
+describe('fetchResendDailyUsage', () => {
+  const realFetch = globalThis.fetch;
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+  function entry(id, dateStr) {
+    return { id, created_at: `${dateStr}T10:00:00.000Z` };
+  }
+
+  beforeEach(() => { process.env.RESEND_API_KEY = 'test-key'; });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it('counts past the default 20-item page across multiple pages', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (url) => {
+      calls++;
+      if (calls === 1) {
+        expect(String(url)).toContain('limit=100');
+        expect(String(url)).not.toContain('after=');
+        const page = Array.from({ length: 100 }, (_, i) => entry(`p1-${i}`, today));
+        return { ok: true, json: async () => ({ data: page, has_more: true }) };
+      }
+      expect(String(url)).toContain(`after=p1-99`);
+      const page = Array.from({ length: 50 }, (_, i) => entry(`p2-${i}`, today));
+      return { ok: true, json: async () => ({ data: page, has_more: false }) };
+    });
+    expect(await fetchResendDailyUsage()).toBe(150);
+    expect(calls).toBe(2);
+  });
+
+  it('stops at the first entry from a previous day without fetching another page', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      const page = [
+        ...Array.from({ length: 30 }, (_, i) => entry(`today-${i}`, today)),
+        ...Array.from({ length: 10 }, (_, i) => entry(`yesterday-${i}`, yesterday)),
+      ];
+      return { ok: true, json: async () => ({ data: page, has_more: true }) };
+    });
+    expect(await fetchResendDailyUsage()).toBe(30);
+    expect(calls).toBe(1);
+  });
+
+  it('returns 0 when no API key is configured', async () => {
+    delete process.env.RESEND_API_KEY;
+    expect(await fetchResendDailyUsage()).toBe(0);
+  });
+
+  it('returns 0 on a failed request', async () => {
+    globalThis.fetch = (async () => ({ ok: false, json: async () => ({}) }));
+    expect(await fetchResendDailyUsage()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Implementato

- `scripts/lib/email-cascade.mjs`: `cloudflare` daily/monthly limit reverted 1000/30000 → 100/3000 (free-tier threshold, owner request). `resend` daily/monthly limit raised 100/3000 → 1666/50000 (owner activated 50000/mo paid plan; 50000/30 floored).
- Fixed the log line and the total-capacity doc comment in the same file that hardcoded the old per-provider numbers a second time (would have drifted from the `PROVIDERS` array again) — both now derive from `PROVIDERS` directly.
- `scripts/send-newsletter.mjs`: the resend-only legacy mode's daily cap (`EMAIL_PROVIDER=resend`) was hardcoded to `100`; now derives from `EMAIL_PROVIDERS.find(p => p.id === 'resend').dailyLimit` so it doesn't drift from the cascade config either. Updated the adjacent stale doc comment (still said "750/day" from an earlier config).
- `scripts/send-job-alerts.mjs` needs no direct edit — it calls the shared `sendEmailCascade()` and reads quotas from the same `PROVIDERS` array in `email-cascade.mjs`, so it picks up the new limits automatically.
- **Review fix (🔴 Important):** `fetchResendDailyUsage()` (`scripts/lib/email-cascade.mjs`) only read the un-paginated default page of `GET /emails` (20 items, no `limit`/`after`), which plateaus once more than ~20-100 emails go out in a day — an under-count → over-send risk now that resend carries the 1666/day bulk cascade load, same failure class already guarded for Mailtrap. Now pages with `limit=100` + `after=<last id>` cursor until an entry older than today appears or `has_more` is false (capped at 20 pages as a safety backstop). Added 4 tests covering multi-page counting, day-boundary early stop, no-API-key, and failed-request fallback.

Root cause of the 2026-07-06 mass newsletter failure (805/1650 failed): Cloudflare's burst-rate throttle (`429 code=10004`) fires well below any daily cap — it hit at ~200 sends this run, long before the 1000/day ceiling. By then every other provider (mailgun/resend/mailjet/mailtrap/maileroo) had already used its own full daily quota, so once cloudflare entered its 30s cooldown, every remaining recipient failed instantly (no provider left to try, `errors=[]` → blank `"All providers failed: "` message). Raising cloudflare's daily cap in 2026-07-03 never fixed this class of failure since the real limiter is the burst-rate, not the daily total — so reverting it to the free tier and shifting real bulk capacity to resend's new paid plan removes the false sense of headroom instead of raising a cap that was never the binding constraint.

Verified: `npx vitest run tests/email-cascade-burst.test.ts` — 28/28 passed (24 original + 4 new pagination tests). `node --check` clean on all edited files. Confirmed new `getCascadeDailyCapacity()` = 2316/day (100+1666+200+150+100+100).

Sibling sweep for the pagination anti-pattern (🔴 fix class): grepped `api.resend.com` across `scripts/**` — the only other call sites (`notify-journalist-article-live.mjs`, `monitor-gsc-job-indexation.mjs`, `send-newsletter.mjs`, `email-cascade.mjs:sendViaResend`) are all single-email `POST` sends, not paginated `GET /emails` list reads, so none share this bug class. No sibling to sweep.

## Non implementato (ancora)

Nessuno.
