### PR TITLE
feat(job-match): fix similar-jobs self-exclusion + track job_match_similar_click

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4817,7 +4817,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  const renderJobCard = (job: JobListing) => (
  <JobCard
- key={job.id}
+ key={buildListingDedupKey(job)}
  job={job}
  jobHref={buildJobPath(job)}
  salary={formatSalary(job)}

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1726,6 +1726,50 @@ export function dedupeJobsForListing(jobs: JobListing[]): JobListing[] {
  return Array.from(byKey.values());
 }
 
+/** Why a job was surfaced as "similar" to the currently-viewed job, in priority order. */
+export type SimilarJobMatchReason = 'category' | 'location' | 'company' | 'other';
+
+/**
+ * Explains *why* a related job matched, mirroring the same category/location/
+ * company priority used by the scoring pass in computeSimilarJobs below. Used
+ * for analytics attribution (job_match_similar_click).
+ */
+export function describeSimilarJobMatchReason(source: JobListing, target: JobListing): SimilarJobMatchReason {
+ if (target.category === source.category) return 'category';
+ if (target.location === source.location) return 'location';
+ if (target.company === source.company) return 'company';
+ return 'other';
+}
+
+/**
+ * "Similar jobs" cluster for the JobDetail view — same sector/canton/company
+ * heuristic already used elsewhere in the listing, scoped to a single source job.
+ *
+ * Self-exclusion compares `buildListingDedupKey`, NOT raw `.id`: several
+ * crawlers ship jobs with `id: undefined` (see scripts/lib/job-match-key.mjs,
+ * #3411), and `dedupeJobsForListing` only guarantees uniqueness on the full
+ * dedup key — not on `.id` alone. Comparing raw ids meant every other id-less
+ * job in the pool got wrongly treated as "the same job" as an id-less selected
+ * job, and silently excluded from that job's own similar-jobs list.
+ */
+export function computeSimilarJobs(source: JobListing, pool: JobListing[], limit = 6): JobListing[] {
+ const sourceKey = buildListingDedupKey(source);
+ const withScore = pool
+ .filter((j) => j.slug && buildListingDedupKey(j) !== sourceKey)
+ .map((j) => {
+ let score = 0;
+ if (j.category === source.category) score += 3;
+ if (j.location === source.location) score += 2;
+ if (j.company === source.company) score += 1;
+ const freshness = new Date(j.crawledAt || j.postedDate).getTime();
+ return { job: j, score, freshness };
+ });
+ return withScore
+ .sort((a, b) => (b.score !== a.score ? b.score - a.score : b.freshness - a.freshness))
+ .slice(0, limit)
+ .map((x) => x.job);
+}
+
 function queryMatchesJob(job: JobListing, query: string, locale: Locale): boolean {
  const queryTokens = normalizeSearchText(query).split(' ').filter(Boolean);
  if (queryTokens.length === 0) return true;
@@ -3995,20 +4039,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  const relatedJobs = useMemo(() => {
  if (!selectedJob) return [];
- const withScore = sortedJobs
- .filter((j) => j.id !== selectedJob.id && j.slug)
- .map((j) => {
- let score = 0;
- if (j.category === selectedJob.category) score += 3;
- if (j.location === selectedJob.location) score += 2;
- if (j.company === selectedJob.company) score += 1;
- const freshness = new Date(j.crawledAt || j.postedDate).getTime();
- return { job: j, score, freshness };
- });
- return withScore
- .sort((a, b) => (b.score !== a.score ? b.score - a.score : b.freshness - a.freshness))
- .slice(0, 6)
- .map((x) => x.job);
+ return computeSimilarJobs(selectedJob, sortedJobs);
  }, [selectedJob, sortedJobs]);
 
  // Expired/orphan/bridge cascade: fetch expired-jobs.json only when needed.
@@ -6936,7 +6967,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const jobSalary = formatSalary(job);
  const card = (
  <article
- key={job.id}
+ key={buildListingDedupKey(job)}
  className={`rounded-xl border p-3 sm:p-4 transition-colors min-h-[72px] ${
  job.featured
  ? 'border-warning-border bg-warning-subtle hover:border-warning'
@@ -6945,7 +6976,18 @@ const JobBoard: React.FC<JobBoardProps> = ({
  >
  <a
  href={jobHref}
- onClick={(e) => { e.preventDefault(); openDetail(job); }}
+ onClick={(e) => {
+ e.preventDefault();
+ if (selectedJob) {
+ Analytics.trackJobMatchSimilarClick(
+ selectedJob.slug || '',
+ job.slug || '',
+ describeSimilarJobMatchReason(selectedJob, job),
+ relIdx,
+ );
+ }
+ openDetail(job);
+ }}
  className="block cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-lg"
  >
  <div className="flex items-start gap-3">
@@ -7698,7 +7740,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  />
  </Suspense>
  )}
- </article> <aside className="hidden lg:block lg:col-span-4"> <div className="sticky top-20 space-y-4"> <Callout status="accent" icon={<Briefcase size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.snapshotTitle')} </div> <div className="mt-3 space-y-2 text-xs text-subtle"> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.location')}</span> <div className="text-right"> <div className="font-semibold font-display text-strong"> {locationSnapshot?.locality || selectedJob.location} </div> {locationSnapshot?.postalCode && ( <div className="text-[11px] text-muted leading-tight mt-0.5"> {t('jobBoard.snapshot.postalCode')}: {locationSnapshot.postalCode} </div> )} </div> </div> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.contract')}</span> <span className="font-semibold font-display text-strong"> {t(contractTranslationKey(selectedJob))} </span> </div> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.published')}</span> <span className="font-semibold font-display text-strong">{daysSincePosted(selectedJob.postedDate)}</span> </div> {locationSnapshot?.crossings && locationSnapshot.crossings.length > 0 && ( <div className="pt-2 border-t border-edge/60"> <div className="mb-1.5 text-xs font-semibold font-display uppercase tracking-wide text-muted"> {t('jobBoard.snapshot.borderCrossings')} </div> <div className="space-y-1"> {locationSnapshot.crossings.map((crossing) => ( <a key={crossing.id} href={buildPath({ activeTab: 'guida', guidaSubTab: 'border', borderCrossing: crossing.id, }, locale)} className="flex items-center justify-between gap-2 rounded-lg px-2 py-2.5 min-h-[44px] lg:min-h-0 lg:py-1.5 bg-surface-alt hover:bg-surface-raised/50 text-body transition-colors" > <span className="font-medium font-display leading-tight">{crossing.name}</span> <ArrowUpRight className="w-3 h-3 text-muted" /> </a> ))} </div> </div> )} </div> </Callout> {canonicalContent.process.length > 0 && timelineSections.length === 0 && ( <Callout status="info" icon={<Calendar size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {canonicalCopy.process} </div> <ul className="mt-2 space-y-1.5 pl-4 list-disc marker:text-info "> {canonicalContent.process.map((item, i) => ( <li key={i} className="text-sm leading-relaxed text-subtle">{item}</li> ))} </ul> </Callout> )} <Callout status="success" icon={<Users size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.adviceTitle')} </div> <p className="mt-2 text-sm leading-relaxed text-subtle"> {t('jobBoard.adviceDescription')} </p> <button onClick={() => handleApply(selectedJob)} className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2.5 min-h-[44px] text-sm font-semibold font-display bg-success-strong hover:bg-success-strong-hover text-on-accent rounded-lg" > {t('jobBoard.adviceCta')} </button> </Callout> {relatedSearches.length > 0 && ( <Callout status="accent" icon={<Search size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {canonicalCopy.keywords} </div> <div className="mt-2 flex flex-wrap gap-2"> {relatedSearches.map((keyword, i) => { const searchHref = buildPath({ activeTab: 'job-board' as any, jobBoardCanton: JOB_BOARD_CANTON_AGGREGATE, jobSlug: buildSearchSlug(keyword, locale) }, locale); return ( <a key={i} href={searchHref} onClick={(e) => { e.preventDefault(); navigateToRelatedSearch(keyword); }} className="text-xs px-2.5 py-1.5 min-h-[44px] inline-flex items-center rounded-full bg-accent-subtle text-accent border border-accent-border" > {keyword} </a> ); })} </div> </Callout> )} {salaryEstimateWidget} {sectorContextWidget} {isDesktopLg && ( <AdSenseBanner adSlot={AD_SLOTS.JOBDETAIL_SIDEBAR.slot} adFormat={AD_SLOTS.JOBDETAIL_SIDEBAR.format} fullWidthResponsive className="mt-2" /> )}<Callout status="accent" icon={<Mail size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.publishTitle')} </div> <p className="mt-2 text-sm leading-relaxed text-subtle"> {t('jobBoard.publishDescription', cantonI18n)} </p> <button onClick={onPostJob} className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2.5 min-h-[44px] text-sm font-semibold font-display border border-accent-border text-accent rounded-lg hover:bg-accent-subtle" > {t('jobBoard.publishCta')} </button> </Callout> </div> </aside> </div> {/* ── Right Rail (desktop xl only) ── */} <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col"> <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense> </aside> </div> {/* AdSense — job detail end multiplex */} <AdSenseBanner adSlot={AD_SLOTS.JOBDETAIL_END_MULTIPLEX.slot} adFormat={AD_SLOTS.JOBDETAIL_END_MULTIPLEX.format} className="mt-6 mb-4" /> {relatedJobs.length > 0 && ( <section className="rounded-2xl border border-edge bg-surface p-5"> <h2 className="text-lg font-bold font-display text-heading mb-4">{t('jobBoard.relatedTitle')}</h2> <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"> {relatedJobs.flatMap((job, relIdx) => { const jobLogo = companyLogoUrl(job); const card = ( <button key={job.id} onClick={() => openDetail(job)} className="text-left rounded-xl border border-edge p-3 hover:border-accent-border hover:bg-surface-raised/40 transition-colors" > <div className="flex items-start gap-3"> <div className="w-12 h-12 rounded-lg bg-surface-raised flex items-center justify-center overflow-hidden border border-edge shrink-0"> {jobLogo ? ( <img src={jobLogo} alt={`Logo ${job.company}`} className="w-8 h-8 object-contain" width={32} height={32} loading="lazy" onError={handleCompanyLogoError} />
+ </article> <aside className="hidden lg:block lg:col-span-4"> <div className="sticky top-20 space-y-4"> <Callout status="accent" icon={<Briefcase size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.snapshotTitle')} </div> <div className="mt-3 space-y-2 text-xs text-subtle"> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.location')}</span> <div className="text-right"> <div className="font-semibold font-display text-strong"> {locationSnapshot?.locality || selectedJob.location} </div> {locationSnapshot?.postalCode && ( <div className="text-[11px] text-muted leading-tight mt-0.5"> {t('jobBoard.snapshot.postalCode')}: {locationSnapshot.postalCode} </div> )} </div> </div> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.contract')}</span> <span className="font-semibold font-display text-strong"> {t(contractTranslationKey(selectedJob))} </span> </div> <div className="flex items-center justify-between gap-2"> <span>{t('jobBoard.snapshot.published')}</span> <span className="font-semibold font-display text-strong">{daysSincePosted(selectedJob.postedDate)}</span> </div> {locationSnapshot?.crossings && locationSnapshot.crossings.length > 0 && ( <div className="pt-2 border-t border-edge/60"> <div className="mb-1.5 text-xs font-semibold font-display uppercase tracking-wide text-muted"> {t('jobBoard.snapshot.borderCrossings')} </div> <div className="space-y-1"> {locationSnapshot.crossings.map((crossing) => ( <a key={crossing.id} href={buildPath({ activeTab: 'guida', guidaSubTab: 'border', borderCrossing: crossing.id, }, locale)} className="flex items-center justify-between gap-2 rounded-lg px-2 py-2.5 min-h-[44px] lg:min-h-0 lg:py-1.5 bg-surface-alt hover:bg-surface-raised/50 text-body transition-colors" > <span className="font-medium font-display leading-tight">{crossing.name}</span> <ArrowUpRight className="w-3 h-3 text-muted" /> </a> ))} </div> </div> )} </div> </Callout> {canonicalContent.process.length > 0 && timelineSections.length === 0 && ( <Callout status="info" icon={<Calendar size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {canonicalCopy.process} </div> <ul className="mt-2 space-y-1.5 pl-4 list-disc marker:text-info "> {canonicalContent.process.map((item, i) => ( <li key={i} className="text-sm leading-relaxed text-subtle">{item}</li> ))} </ul> </Callout> )} <Callout status="success" icon={<Users size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.adviceTitle')} </div> <p className="mt-2 text-sm leading-relaxed text-subtle"> {t('jobBoard.adviceDescription')} </p> <button onClick={() => handleApply(selectedJob)} className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2.5 min-h-[44px] text-sm font-semibold font-display bg-success-strong hover:bg-success-strong-hover text-on-accent rounded-lg" > {t('jobBoard.adviceCta')} </button> </Callout> {relatedSearches.length > 0 && ( <Callout status="accent" icon={<Search size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {canonicalCopy.keywords} </div> <div className="mt-2 flex flex-wrap gap-2"> {relatedSearches.map((keyword, i) => { const searchHref = buildPath({ activeTab: 'job-board' as any, jobBoardCanton: JOB_BOARD_CANTON_AGGREGATE, jobSlug: buildSearchSlug(keyword, locale) }, locale); return ( <a key={i} href={searchHref} onClick={(e) => { e.preventDefault(); navigateToRelatedSearch(keyword); }} className="text-xs px-2.5 py-1.5 min-h-[44px] inline-flex items-center rounded-full bg-accent-subtle text-accent border border-accent-border" > {keyword} </a> ); })} </div> </Callout> )} {salaryEstimateWidget} {sectorContextWidget} {isDesktopLg && ( <AdSenseBanner adSlot={AD_SLOTS.JOBDETAIL_SIDEBAR.slot} adFormat={AD_SLOTS.JOBDETAIL_SIDEBAR.format} fullWidthResponsive className="mt-2" /> )}<Callout status="accent" icon={<Mail size={15} />} className="rounded-xl"> <div className="text-sm font-bold font-display text-heading"> {t('jobBoard.publishTitle')} </div> <p className="mt-2 text-sm leading-relaxed text-subtle"> {t('jobBoard.publishDescription', cantonI18n)} </p> <button onClick={onPostJob} className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2.5 min-h-[44px] text-sm font-semibold font-display border border-accent-border text-accent rounded-lg hover:bg-accent-subtle" > {t('jobBoard.publishCta')} </button> </Callout> </div> </aside> </div> {/* ── Right Rail (desktop xl only) ── */} <aside className="ft-rail-aside-x hidden xl:max-xlw:block xlw:flex xlw:flex-col"> <Suspense fallback={null}><ArticleRailAdStack side="right" /></Suspense> </aside> </div> {/* AdSense — job detail end multiplex */} <AdSenseBanner adSlot={AD_SLOTS.JOBDETAIL_END_MULTIPLEX.slot} adFormat={AD_SLOTS.JOBDETAIL_END_MULTIPLEX.format} className="mt-6 mb-4" /> {relatedJobs.length > 0 && ( <section className="rounded-2xl border border-edge bg-surface p-5"> <h2 className="text-lg font-bold font-display text-heading mb-4">{t('jobBoard.relatedTitle')}</h2> <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"> {relatedJobs.flatMap((job, relIdx) => { const jobLogo = companyLogoUrl(job); const card = ( <button key={buildListingDedupKey(job)} onClick={() => { if (selectedJob) { Analytics.trackJobMatchSimilarClick(selectedJob.slug || '', job.slug || '', describeSimilarJobMatchReason(selectedJob, job), relIdx); } openDetail(job); }} className="text-left rounded-xl border border-edge p-3 hover:border-accent-border hover:bg-surface-raised/40 transition-colors" > <div className="flex items-start gap-3"> <div className="w-12 h-12 rounded-lg bg-surface-raised flex items-center justify-center overflow-hidden border border-edge shrink-0"> {jobLogo ? ( <img src={jobLogo} alt={`Logo ${job.company}`} className="w-8 h-8 object-contain" width={32} height={32} loading="lazy" onError={handleCompanyLogoError} />
  ) : (
  <Building2 className="w-5 h-5 text-muted" />
  )}

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1421,6 +1421,21 @@ export const Analytics = {
  },
 
  /**
+ * Click su una card del blocco "offerte simili" nel JobDetail (#3649). Il
+ * blocco riusa il clustering settore/cantone già calcolato per la lista
+ * (categoria/località/azienda); `match_reason` riporta quale segnale ha
+ * prodotto il match e `position` l'indice nella lista mostrata (0-based).
+ */
+ trackJobMatchSimilarClick: (sourceJobSlug: string, matchedJobSlug: string, matchReason: string, position: number) => {
+ log('job_match_similar_click', {
+ source_job_slug: sourceJobSlug || '',
+ matched_job_slug: matchedJobSlug || '',
+ match_reason: matchReason || 'other',
+ position,
+ });
+ },
+
+ /**
  * Interazione grafico — single event, no double-fire with select_content
  */
  trackChartInteraction: (chartType: string, action: string) => {

--- a/tests/regression/jobboard-similar-jobs.test.ts
+++ b/tests/regression/jobboard-similar-jobs.test.ts
@@ -153,11 +153,15 @@ describe('JobBoard — job_match_similar_click wiring (source assertions)', () =
     expect(occurrences.length).toBe(2);
   });
 
-  it('keys related-jobs cards on buildListingDedupKey, not raw job.id', () => {
-    // Both related-jobs render blocks key their card on the fixed identity
-    // primitive; job.id alone can collide across distinct jobs (#3649).
+  it('keys related-jobs cards and renderJobCard on buildListingDedupKey, not raw job.id', () => {
+    // Both related-jobs render blocks, plus the shared renderJobCard used by
+    // renderJobListWithAds for the 8 editorial-landing sections, key their
+    // card on the fixed identity primitive; job.id alone can collide across
+    // distinct jobs (#3649). renderJobListWithAds flattens renderJobCard's
+    // output as a sibling of the interleaved ad node, so a raw job.id key
+    // collision there is a real React duplicate-key risk, not just cosmetic.
     const occurrences = SOURCE.match(/key=\{buildListingDedupKey\(job\)\}/g) || [];
-    expect(occurrences.length).toBe(2);
+    expect(occurrences.length).toBe(3);
   });
 });
 

--- a/tests/regression/jobboard-similar-jobs.test.ts
+++ b/tests/regression/jobboard-similar-jobs.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #3649 — "offerte simili" block on JobDetail.
+ *
+ * Regression coverage for the self-exclusion bug in the pre-existing
+ * `relatedJobs` clustering: the filter compared raw `j.id !== selectedJob.id`.
+ * Several crawlers ship jobs with `id: undefined` (scripts/lib/job-match-key.mjs,
+ * #3411), and `dedupeJobsForListing` only guarantees uniqueness on the full
+ * `buildListingDedupKey` — not on `.id` alone — so multiple genuinely different
+ * jobs can share `id: undefined` in the same pool. Comparing raw ids meant an
+ * id-less selected job wrongly excluded every other id-less job as "itself",
+ * collapsing its similar-jobs list.
+ *
+ * The extracted `computeSimilarJobs` / `describeSimilarJobMatchReason` reuse
+ * the existing sector/canton/company clustering signal (no new clustering
+ * logic — see #3649 scope: "riusa, non reinventare la clusterizzazione") and
+ * are exported so this can be tested without rendering the ~8500-line
+ * JobBoard component.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  computeSimilarJobs,
+  describeSimilarJobMatchReason,
+} from '@/components/community/JobBoard.tsx';
+import type { JobListing } from '@/components/community/JobBoard.tsx';
+
+function makeJob(overrides: Partial<JobListing>): JobListing {
+  return {
+    id: 'test-id',
+    title: 'Test Job',
+    company: 'Test Company',
+    location: 'Lugano',
+    canton: 'TI',
+    category: 'other',
+    slug: 'test-job-test-company-lugano',
+    postedDate: '2026-01-01',
+    crawledAt: '2026-01-01',
+    source: 'test',
+    url: 'https://example.com',
+    ...overrides,
+  } as unknown as JobListing;
+}
+
+describe('describeSimilarJobMatchReason', () => {
+  const source = makeJob({ category: 'tech', location: 'Lugano', company: 'Acme' });
+
+  it('prioritizes category over location/company', () => {
+    const target = makeJob({ category: 'tech', location: 'Bellinzona', company: 'Other' });
+    expect(describeSimilarJobMatchReason(source, target)).toBe('category');
+  });
+
+  it('falls back to location when category differs', () => {
+    const target = makeJob({ category: 'sales', location: 'Lugano', company: 'Other' });
+    expect(describeSimilarJobMatchReason(source, target)).toBe('location');
+  });
+
+  it('falls back to company when category and location differ', () => {
+    const target = makeJob({ category: 'sales', location: 'Bellinzona', company: 'Acme' });
+    expect(describeSimilarJobMatchReason(source, target)).toBe('company');
+  });
+
+  it('reports other when nothing matches', () => {
+    const target = makeJob({ category: 'sales', location: 'Bellinzona', company: 'Other' });
+    expect(describeSimilarJobMatchReason(source, target)).toBe('other');
+  });
+});
+
+describe('computeSimilarJobs — self-exclusion identity', () => {
+  it('does not treat two distinct id-less jobs as the same job (regression #3649)', () => {
+    // Two genuinely different vacancies that both ship id: undefined, as
+    // happens for ferrovia-retica/julius-baer/mikron/relewant/etc (#3411).
+    const source = makeJob({
+      id: undefined,
+      url: 'https://example.com/jobs/a',
+      slug: 'source-job',
+      category: 'tech',
+    });
+    const other = makeJob({
+      id: undefined,
+      url: 'https://example.com/jobs/b',
+      slug: 'other-job',
+      category: 'tech',
+    });
+    const result = computeSimilarJobs(source, [source, other]);
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe('other-job');
+  });
+
+  it('still excludes the source job itself when ids match', () => {
+    const source = makeJob({ id: 'job-1', slug: 'source-job' });
+    const same = makeJob({ id: 'job-1', slug: 'source-job' });
+    const different = makeJob({ id: 'job-2', slug: 'different-job' });
+    const result = computeSimilarJobs(source, [source, same, different]);
+    expect(result.map((j) => j.slug)).toEqual(['different-job']);
+  });
+
+  it('excludes candidates without a slug', () => {
+    const source = makeJob({ id: 'job-1', slug: 'source-job' });
+    const noSlug = makeJob({ id: 'job-2', slug: undefined });
+    const result = computeSimilarJobs(source, [source, noSlug]);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('computeSimilarJobs — scoring and cap', () => {
+  const source = makeJob({
+    id: 'job-1',
+    slug: 'source-job',
+    category: 'tech',
+    location: 'Lugano',
+    company: 'Acme',
+  });
+
+  it('ranks category match above location and company matches', () => {
+    const categoryMatch = makeJob({ id: 'job-2', slug: 'category-match', category: 'tech', location: 'Bellinzona', company: 'Other' });
+    const locationMatch = makeJob({ id: 'job-3', slug: 'location-match', category: 'sales', location: 'Lugano', company: 'Other' });
+    const companyMatch = makeJob({ id: 'job-4', slug: 'company-match', category: 'sales', location: 'Bellinzona', company: 'Acme' });
+    const result = computeSimilarJobs(source, [companyMatch, locationMatch, categoryMatch]);
+    expect(result.map((j) => j.slug)).toEqual(['category-match', 'location-match', 'company-match']);
+  });
+
+  it('breaks ties by freshness (crawledAt/postedDate) descending', () => {
+    const older = makeJob({ id: 'job-2', slug: 'older', category: 'tech', crawledAt: '2026-01-01' });
+    const newer = makeJob({ id: 'job-3', slug: 'newer', category: 'tech', crawledAt: '2026-06-01' });
+    const result = computeSimilarJobs(source, [older, newer]);
+    expect(result.map((j) => j.slug)).toEqual(['newer', 'older']);
+  });
+
+  it('caps the result at the given limit (default 6)', () => {
+    const pool = Array.from({ length: 10 }, (_, i) =>
+      makeJob({ id: `job-pool-${i}`, slug: `pool-${i}`, category: 'tech' }),
+    );
+    expect(computeSimilarJobs(source, pool)).toHaveLength(6);
+    expect(computeSimilarJobs(source, pool, 3)).toHaveLength(3);
+  });
+});
+
+describe('JobBoard — job_match_similar_click wiring (source assertions)', () => {
+  // JobBoard.tsx is the single largest component in the repo (~8500 LOC), and
+  // the unlocked-detail related-jobs block lives inside a long pre-existing
+  // dense JSX line. Source assertions are the only viable way to guard both
+  // click sites without making the suite brittle against unrelated refactors
+  // (mirrors tests/community/JobBoard.sticky-sidebar.test.tsx).
+  const SOURCE = readFileSync(
+    resolve(__dirname, '../../components/community/JobBoard.tsx'),
+    'utf8',
+  );
+
+  it('fires trackJobMatchSimilarClick from both related-jobs click sites', () => {
+    const occurrences = SOURCE.match(/Analytics\.trackJobMatchSimilarClick\(/g) || [];
+    expect(occurrences.length).toBe(2);
+  });
+
+  it('keys related-jobs cards on buildListingDedupKey, not raw job.id', () => {
+    // Both related-jobs render blocks key their card on the fixed identity
+    // primitive; job.id alone can collide across distinct jobs (#3649).
+    const occurrences = SOURCE.match(/key=\{buildListingDedupKey\(job\)\}/g) || [];
+    expect(occurrences.length).toBe(2);
+  });
+});
+
+describe('Analytics.trackJobMatchSimilarClick', () => {
+  it('emits job_match_similar_click via the shared log() dispatcher', () => {
+    const SOURCE = readFileSync(resolve(__dirname, '../../services/analytics.ts'), 'utf8');
+    expect(SOURCE).toMatch(/trackJobMatchSimilarClick:\s*\(/);
+    expect(SOURCE).toMatch(/log\('job_match_similar_click',/);
+  });
+});


### PR DESCRIPTION
## Implementato

- Fixed a latent self-exclusion bug in the pre-existing "offerte simili" (related jobs) block on `JobDetail` (both the gated-view teaser and the unlocked full-detail view in `components/community/JobBoard.tsx`): the filter excluded the currently-viewed job by comparing raw `j.id !== selectedJob.id`. Several crawlers ship jobs with `id: undefined` (`scripts/lib/job-match-key.mjs`, #3411 lists ferrovia-retica/julius-baer/mikron/relewant/swiss-medical-network/casale), and `dedupeJobsForListing` only guarantees uniqueness on the full `buildListingDedupKey` — not on `.id` alone — so multiple genuinely distinct jobs can share `id: undefined` in the same pool. Whenever the currently-viewed job itself had no `.id`, every other id-less job got wrongly treated as "the same job" and silently dropped from its own similar-jobs list.
- Extracted the existing sector/canton/company clustering heuristic (category +3 / location +2 / company +1, freshness tiebreak, cap 6) out of the `relatedJobs` `useMemo` into two exported pure functions, reusing (not reinventing) the clustering already in the repo:
  - `computeSimilarJobs(source, pool, limit = 6)` — same scoring, self-exclusion now via `buildListingDedupKey(j) !== buildListingDedupKey(source)`.
  - `describeSimilarJobMatchReason(source, target)` — labels *why* a candidate matched (`'category' | 'location' | 'company' | 'other'`), same priority order as the scorer, used for analytics attribution.
- Added `Analytics.trackJobMatchSimilarClick(sourceJobSlug, matchedJobSlug, matchReason, position)` to `services/analytics.ts` (mirrors the existing `trackJobApply` pattern — dual-dispatches to GA4 + PostHog via the shared `log()`), firing PostHog event `job_match_similar_click` as requested in the issue's "Misurazione" section.
- Wired the new tracking call into both existing related-jobs click sites (gated-view card + unlocked-detail-view card), passing the source job slug, matched job slug, match reason, and 0-based position in the list.
- Fixed the React `key` on both related-jobs card lists from `key={job.id}` to `key={buildListingDedupKey(job)}` — same root cause (raw `.id` isn't a reliable per-job identity for this pool), directly adjacent to the lines touched for the self-exclusion fix; without it, two distinct id-less related jobs would produce a duplicate React key.
- New test file `tests/regression/jobboard-similar-jobs.test.ts` (13 tests, all green): regression coverage for the id-less-collision self-exclusion fix, scoring priority (category > location > company), freshness tiebreak, slug-presence requirement, the `limit` cap, `describeSimilarJobMatchReason` priority, and source-regex assertions (mirroring `tests/community/JobBoard.sticky-sidebar.test.tsx`'s established pattern for this ~8500-line component) confirming both click sites call `Analytics.trackJobMatchSimilarClick` and both card lists key on `buildListingDedupKey`.

**Why `buildListingDedupKey` instead of literally importing `extractStableJobId`:** the issue text says "basato su `extractStableJobId` + cluster settore/cantone già calcolati altrove nel repo (riusa, non reinventare la clusterizzazione)". `extractStableJobId`/`resolveJobDiffKey` (`scripts/lib/job-match-key.mjs`) is Node-only crawl-time plumbing used exclusively by ~90 crawler scripts for cross-crawl diffing — it's never imported into browser code today. `buildListingDedupKey` (already in `JobBoard.tsx`, already tested in `tests/regression/jobboard-dedup-by-id.test.ts`) is the client-side stable-identity primitive explicitly documented as aligned with the build-side SSG dedup heuristic (`jobsSeoPagesPlugin.ts:dedupKey`) and is what the pool (`jobs`/`sortedJobs`) is *already* deduped by via `dedupeJobsForListing`. Using it for self-exclusion is the same "reuse, don't reinvent" identity concept the issue asks for, without adding an unnecessary Node-script→browser-bundle dependency. The sector/canton clustering itself (category/location/company scoring) was already reused unchanged from the pre-existing `relatedJobs` computation — nothing new invented there either.

**Sibling-pattern check** (`node scripts/ci/check-sibling-patterns.mjs --base origin/main`, tool is a lexical-token heuristic, manually triaged every flagged file): all other flags were generic shared-token overlap (`relatedJobs`, `relatedTitle`, `selectedJob`, `sortedJobs`, `canonicalContent`, `companyLogoUrl`, etc. — unrelated files that merely happen to use the same identifier names). I additionally grepped the whole repo for the actual buggy construct (`X.id !== Y.id` used as a self-exclusion filter for a "related items" cluster) beyond what the tool flagged:
  - `build-plugins/eventsSeoPagesPlugin.ts:1724` (`sameComuneEvents.filter((e) => e.id !== event.id)`) — **false positive**: `scripts/assemble-events-dataset.mjs` already merges the global event dataset into a `Map` keyed on raw `event.id` (last-write-wins) *before* this render step ever runs, so every event surviving into `events.json` already has a guaranteed-unique `id` by construction. Jobs are different: the client pool is deduped by the richer `buildListingDedupKey` specifically *because* raw `.id` is not guaranteed unique/present for jobs — events don't share that data-guarantee gap at this call site.
  - `components/community/BlogArticles.tsx:832` (`getRelatedArticles`, `allArticles.filter(a => a.id !== currentId)`) — **false positive**: blog article `id`s are author-curated static content keys (not crawled), always present and unique by editorial convention; already guarded by the existing `tests/related-articles.test.ts` invariant test.
  - `services/jobs/canonicalFallback.ts:703` (`guessed.id !== id`) — **false positive**: unrelated construct (slug-migration best-guess threshold check, not a self-exclusion list filter).

No new user-facing text was introduced (only internal function names + analytics event/param names), so no locale key changes were needed across `services/locales/{it,en,de,fr}-core.ts`.

## Non implementato (ancora)

Nessuno.

Closes #3649

## Test plan

- [x] `npx vitest run tests/regression/jobboard-similar-jobs.test.ts` — 13/13 green
- [x] `npx vitest run tests/regression/jobboard-dedup-by-id.test.ts tests/community/JobBoard.sticky-sidebar.test.tsx tests/analytics-instrumentation.test.ts tests/ad-analytics.test.ts` — 55/55 green, no regressions in adjacent JobBoard/analytics suites
- [x] `node scripts/ci/check-sibling-patterns.mjs --base origin/main` — every flag manually triaged (see PR description above); no unfixed same-class sibling bug found
- [x] `git merge origin/main` performed post-push-prep to pick up concurrently-merged work (adblock A/B gate, lane-a bundle) before opening this PR

## Review follow-up

- pr-review-loop's first pass flagged `renderJobCard` (JobBoard.tsx, used by `renderJobListWithAds` across the 8 editorial-landing sections) still keying `<JobCard key={job.id}>` on raw `.id` — the same identity bug class as the self-exclusion fix above, and a genuine one: `renderJobListWithAds`'s `flatMap` puts that card as a sibling of the interleaved ad node, so two distinct id-less jobs in the same `section.jobs` pool collide on React key. Fixed to `key={buildListingDedupKey(job)}` in the same commit, with the regression test's source-assertion count updated 2→3.
