### PR TITLE
docs(crawler): verify cham-swiss-properties jobs.ch id 142189 is stable

### DIFF
--- a/scripts/lib/cham-swiss-properties-job-parser.mjs
+++ b/scripts/lib/cham-swiss-properties-job-parser.mjs
@@ -26,6 +26,24 @@
  *
  * jobs.ch company profile id: 142189.
  *
+ * IMPORTANT — re-verified 2026-07-06 (follow-up #3637, item 2) whether this
+ * numeric id risks going stale the way DIC SA's did (see ./dic-sa-job-parser.mjs:
+ * that company had a duplicate legacy numeric profile with jobCount: 0,
+ * requiring a switch to its separate active UUID profile). Cham Swiss
+ * Properties AG has NO such duplicate:
+ *   - `job-search-api.jobs.ch/search?companyIds=142189` → totalHits: 1
+ *     (confirmed live, same posting as at crawler creation).
+ *   - the profile's own React state carries `"id":"142189"`,
+ *     `"redirectToCompanyId":null`, `"redirectToCompanySlug":null` — i.e.
+ *     jobs.ch itself does not consider 142189 superseded/redirected.
+ *   - a jobs.ch company-name search for "Cham Swiss Properties" returns
+ *     exactly one record (142189, jobCount: 1) — no second/UUID-only entry
+ *     exists to migrate to (unlike DIC SA, which had two distinct company
+ *     records for the same employer).
+ * Conclusion: 142189 is the sole, active, stable id — no UUID migration
+ * applies here. Keep as-is; re-check only if the search API starts
+ * returning 0 hits for it.
+ *
  * HQ fallback address (confirmed via jobs.ch company profile JSON-LD,
  * company website imprint and LinkedIn): Fabrikstrasse 5, 6330 Cham, ZG.
  *


### PR DESCRIPTION
## Implementato

- Investigated follow-up issue 3637 item 2: whether `scripts/lib/cham-swiss-properties-job-parser.mjs:L30`'s legacy numeric jobs.ch company id `142189` risks going stale, the same failure mode discovered for DIC SA in the originating PR (#3627), where the legacy numeric id `81584` was dead (0 postings) and had to be replaced with a separate, active UUID company profile (`ee30c164-...`).
- Reproduced the same verification method used for DIC SA against the live jobs.ch public search API and company-search page:
  - `job-search-api.jobs.ch/search?companyIds=142189` → `totalHits: 1` (same posting confirmed live at crawler creation time, still live today).
  - The company profile's own embedded state carries `"id":"142189"`, `"redirectToCompanyId":null`, `"redirectToCompanySlug":null` — jobs.ch itself does not consider this id superseded.
  - A jobs.ch company-name search for "Cham Swiss Properties" returns exactly **one** company record (id `142189`, `jobCount: 1`) — no second/UUID-only profile exists to migrate to, unlike DIC SA which had two distinct company records for the same employer (a dead numeric one and a live UUID one).
- Conclusion: **142189 is confirmed the sole, active, stable id.** No UUID migration applies here — forcing a switch would not be a real fix, just a no-op churn on a working id. Documented the verification (method + evidence + conclusion) in the parser's docblock so this finding is traceable and the follow-up concern is resolved, not just silently dropped.
- Verified item 1 of issue 3637 (hardcoded `'de'` `detectLang` fallback in city-pop/cham-swiss-properties parsers) is already fixed and live on `main` via PR #3664 — not touched again in this PR.
- Ran `tests/cham-swiss-properties-crawler.test.ts` (19/19 passing) and `tests/dic-sa-crawler.test.ts` (19/19 passing, sibling parser) locally — green.

## Non implementato (ancora)

Nessuno. Both items of issue 3637 are now fully resolved — item 1 via PR #3664 (already merged), item 2 in this PR. Not using an auto-close keyword adjacent to the issue number here because issue 3637 is a multi-item follow-up aggregate (pr-body-contract's aggregate-close veto, per AGENTS.md/FOLLOWUP.md incident #3050 to #3036: a single-item PR must never auto-close a multi-item aggregate via a bare `Closes #N`). This PR addresses item 2 of that issue (item 1 was already addressed via PR #3664). The tracking issue will be closed by hand after merge, citing both fixing PRs, once verified live.
