### PR TITLE
fix(jobs-pipeline): exclude cleanup-jobs.mjs scratch files from slice globs

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -388,11 +388,19 @@ function readJson(filePath, fallback) {
   }
 }
 
-function listSliceFiles(dir) {
+// Excludes cleanup-jobs.mjs's own scratch file (`<slice>.cleanup-tmp.json`,
+// gitignored). It's written+unlinked in a try/finally, but a hard process
+// kill (e.g. OOM) mid-run can skip the finally and leave it on disk for the
+// rest of the SAME job — the malformed-slice guard below then hard-fails
+// assembly on the assembler's own transient scratch file, not real data
+// (run 28783188549: lidl-svizzera housekeeping died silently, orphaning
+// lidl-svizzera.json.cleanup-tmp.json, which the next "Assemble dataset"
+// step in the same job picked up as a slice and refused to parse).
+export function listSliceFiles(dir) {
   if (!fs.existsSync(dir)) return [];
   return fs
     .readdirSync(dir)
-    .filter((f) => f.endsWith('.json') && f !== '.gitkeep' && !f.includes('-cache'))
+    .filter((f) => f.endsWith('.json') && f !== '.gitkeep' && !f.includes('-cache') && !f.includes('.cleanup-tmp'))
     .map((f) => path.join(dir, f))
     .sort(); // lexicographic — deterministic order
 }

--- a/scripts/log-translation-stats.mjs
+++ b/scripts/log-translation-stats.mjs
@@ -43,8 +43,12 @@ function isIncomplete(job) {
   return false;
 }
 
+// Excludes cleanup-jobs.mjs's own scratch file (`<slice>.cleanup-tmp.json`):
+// a hard-killed cleanup run can leave it orphaned in the same CI job, and its
+// bare jobs-array shape passes straight through the `Array.isArray` check
+// below, double-counting every job in it into the committed stats history.
 const files = fs.existsSync(CRAWLERS_DIR)
-  ? fs.readdirSync(CRAWLERS_DIR).filter(f => f.endsWith('.json') && !f.includes('-locale-cache'))
+  ? fs.readdirSync(CRAWLERS_DIR).filter(f => f.endsWith('.json') && !f.includes('-locale-cache') && !f.includes('.cleanup-tmp'))
   : [];
 
 let total = 0;

--- a/tests/scripts/list-slice-files-excludes-cleanup-tmp.test.ts
+++ b/tests/scripts/list-slice-files-excludes-cleanup-tmp.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+/**
+ * cleanup-jobs.mjs writes a transient `<slice>.cleanup-tmp.json` scratch file
+ * per crawler and deletes it in a try/finally — but a hard process kill (OOM,
+ * SIGKILL) mid-run can skip the finally, leaving it on disk for the rest of
+ * that CI job. listSliceFiles() must not treat that orphan as a real slice:
+ * run 28783188549 hard-failed the whole translate-pending workflow this way
+ * (lidl-svizzera housekeeping died silently; the next "Assemble dataset" step
+ * in the same job picked up lidl-svizzera.json.cleanup-tmp.json and refused
+ * to parse it as malformed).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { listSliceFiles } from '../../scripts/assemble-jobs-dataset.mjs';
+
+describe('listSliceFiles()', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'slice-files-'));
+    writeFileSync(path.join(dir, 'lidl-svizzera.json'), '{"jobs":[]}');
+    writeFileSync(path.join(dir, 'lidl-svizzera.json.cleanup-tmp.json'), '[]');
+    writeFileSync(path.join(dir, 'some-crawler-locale-cache.json'), '{}');
+    writeFileSync(path.join(dir, '.gitkeep'), '');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('excludes orphaned .cleanup-tmp.json scratch files', () => {
+    const files = listSliceFiles(dir).map((f) => path.basename(f));
+    expect(files).not.toContain('lidl-svizzera.json.cleanup-tmp.json');
+  });
+
+  it('still includes the real slice for the same crawler', () => {
+    const files = listSliceFiles(dir).map((f) => path.basename(f));
+    expect(files).toContain('lidl-svizzera.json');
+  });
+
+  it('still excludes -cache files and .gitkeep', () => {
+    const files = listSliceFiles(dir).map((f) => path.basename(f));
+    expect(files).not.toContain('some-crawler-locale-cache.json');
+    expect(files).not.toContain('.gitkeep');
+  });
+});


### PR DESCRIPTION
## Implementato

- Root cause of `translate-pending.yml` run 28783188549 hard-failing at "Assemble dataset": `cleanup-jobs.mjs`'s per-slice housekeeping loop writes a transient `<slice>.cleanup-tmp.json` scratch file (gitignored, deleted in a `finally`). The `lidl-svizzera` slice's housekeeping child process died silently mid-run (zero further stdout after "checking 385 jobs", loop moved straight to the next slice) — a hard kill skips the `finally`, orphaning the scratch file on the shared job workspace.
- `scripts/assemble-jobs-dataset.mjs`: `listSliceFiles()` globbed `*.json` in `data/jobs/by-crawler/` without excluding `*.cleanup-tmp.json`, so the orphan got parsed as a real slice and tripped the malformed-slice hard-fail guard (added for the 2026-05-21 silent-drop incident) — crashing the whole workflow on the assembler's own scratch file, not real data. Now excluded; exported for direct unit testing.
- Sibling grep per repo convention: `scripts/log-translation-stats.mjs` had the identical unguarded glob feeding straight into `Array.isArray(content) ? content : content.jobs`, which the orphan's bare-array shape passes through — silently double-counting its jobs into the committed `data/translation-stats-history.json`. Fixed with the same exclusion.
- Added `tests/scripts/list-slice-files-excludes-cleanup-tmp.test.ts` covering the exact regression (orphaned cleanup-tmp file excluded; real slice for the same crawler still included; existing `-cache`/`.gitkeep` exclusions untouched).
- Audited all 35 other scripts touching `data/jobs/by-crawler` (Explore agent sweep) for the same construct — none else are vulnerable (all read one named file, already guard the shape, or only self-heal a path that can't collide).

## Non implementato (ancora)

Nessuno.

Note: no automated test added for `log-translation-stats.mjs` itself — its `CRAWLERS_DIR`/`STATS_FILE` paths are `process.cwd()`-relative with no override hook, and vitest here runs `pool:'threads'` where `process.chdir()` is process-global (would race across concurrently-running test files). The regression is covered by the `listSliceFiles` test (identical filter idiom); a CWD-relative test harness for that script would need a refactor beyond this fix's surgical scope.

Closes #3675

## Test plan

- [x] `npx vitest run tests/scripts/list-slice-files-excludes-cleanup-tmp.test.ts tests/scripts/assemble-jobs-cache.test.ts tests/scripts/shrink-guard.test.ts tests/scripts/assemble-per-locale-slug-collision-guard.test.ts tests/scripts/normalize-parsed-jobs-for-slice.test.ts tests/scripts/clean-crawler-artifacts-separator.test.ts tests/boilerplate-guard.test.ts` — all green locally.
- [ ] Verify live on the next `translate-pending.yml` scheduled run (housekeeping only runs on the 06:00 UTC daily cron) that "Assemble dataset" no longer fails on a stray `.cleanup-tmp.json`.