### PR TITLE
Fix local-fallback article generation stall (ground organic mode, route local-only to evergreen)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -65,7 +65,7 @@ import { execSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess, isQuotaExhaustedError, printRunSummary } from './lib/ai-models.mjs';
+import { callLLM as _aiCallLLM, AI_MODELS, DEFAULT_CHAIN, getPreferredModel, isLocalLlmEnabled, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess, isQuotaExhaustedError, printRunSummary } from './lib/ai-models.mjs';
 // Quota-free MT cascade (DeepL-free / Google / MyMemory / LibreTranslate /
 // local Opus-MT) — the SAME translator the job crawlers + FAQ batch use
 // (scripts/lib/dedicated-crawler-common.mjs, batch-add-faq-to-articles.mjs).
@@ -4122,7 +4122,14 @@ async function callGemini(pageContent, url, sourceContext = null) {
   //   2. Provide generous source content (6000 chars) so the model has facts to work with
   //   3. Send compact IT-only JSON template (EN/DE/FR generated in separate calls)
   //   4. Compress editorial rules (no repetition per locale)
-  const MAX_SOURCE_CHARS = 6000;
+  const generationAttempt = Number(sourceContext?._generationAttempt || 1);
+  // Regen attempts (2+) also carry factCheckRefinementInstruction (flagged
+  // claims to fix) and, since fix B above, domainFactsBlock — both compete
+  // with source content for the same ~8000-token input cap several free
+  // models enforce. Shrinking the re-sent source on retries only (never on
+  // the first, richness-matters attempt) buys headroom without touching
+  // first-attempt grounding.
+  const MAX_SOURCE_CHARS = generationAttempt > 1 ? 4500 : 6000;
   const MAX_IDS_TO_SEND = 50;
 
   const truncatedContent = pageContent
@@ -4142,7 +4149,6 @@ async function callGemini(pageContent, url, sourceContext = null) {
     ? sourceContext.relatedHeadlines.map((h, i) => `- [${i + 1}] (${h.source}) ${h.headline}`).join('\n')
     : '';
 
-  const generationAttempt = Number(sourceContext?._generationAttempt || 1);
   const generationAttemptMax = Number(sourceContext?._generationAttemptMax || 1);
   const minItalianWords = Number(sourceContext?._minItalianWords || CREATE_ARTICLE_MIN_IT_WORDS);
 
@@ -4303,11 +4309,24 @@ Il notizia/evento è solo il punto di partenza. Il valore sta nelle implicazioni
     ? `- imagePrompt: scena fotorealistica Ticino, DSLR, non sembrare AI`
     : `- imagePrompt: scena svizzera nazionale/cantonale pertinente al tema, fotorealistica, DSLR, non sembrare AI`;
 
+  // Organic/news sources (real URL) carry no ground-truth facts — only the
+  // evergreen:// and stats-bfs:// branches bake EVERGREEN_FACTS_BRIEF into
+  // pageContent upstream (see the evergreen prompt builder above). Without it,
+  // a model filling REGOLA #1's requested "implicazioni pratiche" gap reaches
+  // for training-data recall instead, and the fact-checker's own copy of these
+  // exact values (VERIFIED_DOMAIN_FACTS) then flags any mismatch as critical —
+  // the dominant failure mode observed on local/fallback runs (2026-07-06).
+  // Feeding the same compact brief here closes the generator/checker grounding
+  // gap for every model in the cascade, not just local.
+  const isSyntheticSource = url.startsWith('evergreen://') || url.startsWith('stats-bfs://');
+  const domainFactsBlock = isSyntheticSource ? '' : `\nFATTI DI DOMINIO VERIFICATI (materiale di riferimento per contesto/implicazioni pratiche, SEPARATO dalla notizia sopra — non attribuirli alla fonte, usali solo se pertinenti al tema):\n${EVERGREEN_FACTS_BRIEF}\n`;
+
   const prompt = `${systemRoleLine}
 
 SOURCE URL: ${url.startsWith('evergreen://') ? '(editorial research)' : url.startsWith('stats-bfs://') ? 'https://www.bfs.admin.ch/bfs/it/home/statistiche/industria-servizi.html (BFS)' : url}
 SOURCE CONTENT:
 ${truncatedContent}
+${domainFactsBlock}
 ${sourceContext?.headline ? `\nHEADLINE: ${sourceContext.headline}` : ''}
 ${relatedContext ? `\nRELATED:\n${relatedContext}` : ''}
 
@@ -7965,7 +7984,23 @@ async function main() {
     // future-soft-preference) but no longer skips the news scan. Manual
     // override via FORCE_EVERGREEN=1 still works for admin/testing.
     const evergreenCounterState = _loadEvergreenCounter();
-    const forceEvergreen = process.env.FORCE_EVERGREEN === '1';
+    // Local-only cascade detection: when every cloud model is exhausted/
+    // cooling-down and only local/fallback remains, organic/news generation
+    // forces the (weak, CPU-only) local model to closely follow a specific
+    // news article — the failure mode that actually blocks runs is source-
+    // fidelity ("coerenza") drift, not hallucination. Evergreen mode is
+    // grounded on EVERGREEN_FACTS_BRIEF and exempt from that check (see
+    // llmFactCheck's isEvergreen branch), so route local-only runs there
+    // instead of burning the wall-clock budget on organic retries unlikely
+    // to pass. No-op when local/fallback is disabled or cloud has capacity.
+    await initScoreStore();
+    const cloudOnlyChain = DEFAULT_CHAIN.filter((m) => m !== AI_MODELS.LOCAL_FALLBACK);
+    const cloudCascadeExhausted = isLocalLlmEnabled() && !getPreferredModel({ chain: cloudOnlyChain });
+    if (cloudCascadeExhausted) {
+      console.error('🔀 Cascata cloud esaurita, solo local/fallback disponibile — route diretto a evergreen (grounding garantito).');
+      RUN_REPORT.notes.push('Local-only cascade detected pre-scan: routed to evergreen (organic/news generation skipped)');
+    }
+    const forceEvergreen = process.env.FORCE_EVERGREEN === '1' || cloudCascadeExhausted;
     let newsSuccess = false;
 
     // ── Phase 3: quota-based slot dispatch (proven vs discovery) ──
@@ -8897,11 +8932,15 @@ async function generateAndValidateArticle(url, sourceContext = null) {
           // ordered by llmFactCheck) so a long violation list can't bloat an
           // already-large prompt past the input window of the degraded free
           // models this fix targets (adversarial review PR #2615). Surface the
-          // truncation rather than silently dropping the tail.
+          // truncation rather than silently dropping the tail. Per-issue claim/
+          // reason lengths tightened 2026-07-06 (90/110→70/90 chars) alongside
+          // the regen-attempt MAX_SOURCE_CHARS cut above — both compete for the
+          // same ~8000-token input ceiling once fix B's domainFactsBlock also
+          // rides along on organic-mode regen attempts.
           const FACTCHECK_FEEDBACK_CAP = 8;
           lastFactCheckErrors = factResult.issues
             .slice(0, FACTCHECK_FEEDBACK_CAP)
-            .map(i => `- [${i.category || '?'}] "${(i.claim || '').slice(0, 90)}" — ${(i.reason || 'non nella fonte').slice(0, 110)}`)
+            .map(i => `- [${i.category || '?'}] "${(i.claim || '').slice(0, 70)}" — ${(i.reason || 'non nella fonte').slice(0, 90)}`)
             .join('\n');
           if (factResult.issues.length > FACTCHECK_FEEDBACK_CAP) {
             lastFactCheckErrors += `\n(+${factResult.issues.length - FACTCHECK_FEEDBACK_CAP} altre violazioni: applica lo STESSO principio a tutto il testo, non solo a queste)`;

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -622,7 +622,7 @@ const ZAI_API_BASE         = 'https://api.z.ai/api/paas/v4/chat/completions';
 // weights are whatever the local server has loaded — so we keep a stable id.
 const LOCAL_LLM_DEFAULT_URL   = 'http://127.0.0.1:8080/v1/chat/completions';
 const LOCAL_LLM_DEFAULT_MODEL = 'local-fallback';
-function isLocalLlmEnabled()  { return /^(1|true|yes|on)$/i.test((process.env.LOCAL_LLM_ENABLED || '').trim()); }
+export function isLocalLlmEnabled()  { return /^(1|true|yes|on)$/i.test((process.env.LOCAL_LLM_ENABLED || '').trim()); }
 function getLocalLlmUrl()     { return (process.env.LOCAL_LLM_URL || LOCAL_LLM_DEFAULT_URL).trim(); }
 function getLocalLlmModelId() { return (process.env.LOCAL_LLM_MODEL || LOCAL_LLM_DEFAULT_MODEL).trim(); }
 // llama.cpp/ollama ignore the key, but _callOpenAICompatible requires a non-empty


### PR DESCRIPTION
## Implementato

- **Local-only cascade → evergreen routing** (`scripts/create-article.mjs`, `main()`): when the cloud model cascade is fully exhausted and only `local/fallback` (qwen2.5:14b) remains available, generation now routes directly to evergreen mode instead of attempting organic/news generation. Detection uses `getPreferredModel({chain: cloudOnlyChain})` — a zero-API-call peek at cascade state — and reuses the pre-existing `FORCE_EVERGREEN`-gated code path (`forceEvergreen` flag), so no new branching logic was added.
- **Grounding facts injected into organic/news prompts** (`callGemini` in `scripts/create-article.mjs`): `EVERGREEN_FACTS_BRIEF` (imposta alla fonte, franchigia, aliquote CH/IT, istituzioni valide, etc.) is now injected into the organic/news generation prompt too, not just evergreen mode. This closes the asymmetry where the fact-check gate (`llmFactCheck`) grades against `VERIFIED_DOMAIN_FACTS` but the generator had no access to those facts — the weak local model was fabricating domain facts that didn't match ground truth, which `llmFactCheck`'s "coerenza" dimension correctly flags as critical (fabricated facts) rather than minor (correct enrichment). Benefits remote models on regen attempts too, not just local.
- **Regeneration token budget tightened** (`callGemini` + regen-feedback loop in `main()`): `MAX_SOURCE_CHARS` now scales down on retry attempts (6000 → 4500 chars from attempt 2 onward), and per-issue fact-check feedback truncation tightened from 90/110 to 70/90 chars (issue count cap unchanged at 8). Keeps regen prompts under the ~8000-token cap that was excluding otherwise-eligible remote models on retries.
- `isLocalLlmEnabled()` in `scripts/lib/ai-models.mjs` exported (was module-private) so `create-article.mjs` reuses the same truthy-check instead of duplicating the regex.

Root cause addressed: zero articles produced across 34+ commits to `main` since the qwen2.5:14b local-fallback bump (PR #3642) — organic-mode generation with the local model had no grounding, so it hallucinated domain facts that the fact-check gate correctly blocked as critical. Verified via GitHub Actions run history that this was a genuine production stall, not a false alarm.

## Non implementato (ancora)

Nessuno. Deferred items identified during exploration (local RAG/retrieval via onnxruntime-node, template/slot-based evergreen generation, closing the fact-check fail-open hole) were explicitly out of scope for this fix and not requested — not part of this task's scope, so not tracked here as open work.

## Test plan

- [x] `npx vitest run tests/create-article-gates.test.ts tests/scripts/ai-models-get-preferred-model.test.ts tests/scripts/create-article-integration.test.ts tests/fact-check-consensus.test.ts` — 78/78 passing, re-verified after merging latest `origin/main`.
- [x] `node --check` on both edited files — syntax valid.
- [x] Sibling-pattern sweep (`scripts/ci/check-sibling-patterns.mjs`) — 18 flagged files manually reviewed, all false positives (lexically similar names or shared-import co-occurrence, not the same construct).
- [x] GitNexus impact/context on `callGemini`/`generateAndValidateArticle` — single internal caller, LOW risk, narrow blast radius.
- [ ] Live verification: next `generate-article.yml` run on `main` actually produces a published article (to be checked post-merge).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>