### PR TITLE
Shift translate-pending cron schedule +1h

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -5,11 +5,11 @@ on:
     workflows: ["Orchestrate Job Crawlers"]
     types: [completed]
   schedule:
-    - cron: '0 6 * * *'     # Daily: housekeeping + translate (replaces cleanup-stale-jobs cron)
-    - cron: '0 12 * * *'    # Midday: translate after 08:00 orchestration
-    - cron: '0 0 * * *'     # Midnight: translate after 20:00 orchestration
-    - cron: '20 0 * * *'    # Nightly retry: after quota reset
-    - cron: '20 3 * * *'    # Backup nightly retry
+    - cron: '0 7 * * *'     # Daily: housekeeping + translate (replaces cleanup-stale-jobs cron)
+    - cron: '0 13 * * *'    # Midday: translate after 08:00 orchestration
+    - cron: '0 1 * * *'     # Midnight: translate after 20:00 orchestration
+    - cron: '20 1 * * *'    # Nightly retry: after quota reset
+    - cron: '20 4 * * *'    # Backup nightly retry
   workflow_dispatch:
     inputs:
       max_jobs:
@@ -123,15 +123,15 @@ jobs:
 
       # ── Phase 1: Housekeeping (prune expired, validate URLs, dedup) ──────
       # Runs BEFORE translations so we don't waste AI quota on dead jobs.
-      # Determine if this is the daily housekeeping run (06:00 UTC cron).
-      # Other triggers (12:00, 00:00, workflow_run, manual) skip housekeeping
+      # Determine if this is the daily housekeeping run (07:00 UTC cron).
+      # Other triggers (13:00, 01:00, workflow_run, manual) skip housekeeping
       # to go straight to translations — saves ~8 min of URL validation.
       - name: Check if housekeeping should run
         id: hk
         run: |
-          if [ "${{ github.event.schedule }}" = "0 6 * * *" ]; then
+          if [ "${{ github.event.schedule }}" = "0 7 * * *" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "🧹 Daily 06:00 UTC — housekeeping enabled"
+            echo "🧹 Daily 07:00 UTC — housekeeping enabled"
           elif [ "${{ inputs.skip_housekeeping }}" = "true" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "⏭️  Housekeeping skipped (user input)"
@@ -325,7 +325,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success' && inputs.skip_translate != true && inputs.dry_run != true
         run: bash scripts/lib/git-commit-data.sh --slice-only "🌐 Auto-translate pending jobs" data/jobs/by-crawler/ data/translation-cache/ data/jobs-crawler-config.json data/slug-registry.json data/translation-stats-history.json
 
-      # ── Phase 2d: Fix source-copy titles (daily 06:00 only) ──────────────
+      # ── Phase 2d: Fix source-copy titles (daily 07:00 only) ──────────────
       # Only runs on the daily cron — no point retrying the same 30 failed titles
       # every run. New jobs from crawlers will have source-copy titles that 2d fixes.
       - name: "Phase 2d: Fix untranslated titles (free cascade)"


### PR DESCRIPTION
## Implementato
- Tutti e 5 i cron trigger di `.github/workflows/translate-pending.yml` spostati avanti di 1 ora (06:00→07:00, 12:00→13:00, 00:00→01:00, 00:20→01:20, 03:20→04:20 UTC).
- Aggiornato il confronto letterale `github.event.schedule == "0 6 * * *"` → `"0 7 * * *"` che gate la fase housekeeping giornaliera (senza questo fix la housekeeping non sarebbe mai partita al nuovo orario).
- Aggiornati i commenti che citavano gli orari vecchi (06:00/12:00/00:00) per restare coerenti col codice.

## Non implementato (ancora)
Nessuno.