### PR TITLE
feat(tax-guide): FAQ fiscale strutturata + internal linking

### DIFF
--- a/build-plugins/faqHubPlugin.ts
+++ b/build-plugins/faqHubPlugin.ts
@@ -1,8 +1,8 @@
 /**
  * FAQ Hub (AE-5) — Vite build plugin.
  *
- * Emits one static HTML landing per locale (4 total) with 100 Q&A grouped
- * in 10 categories:
+ * Emits one static HTML landing per locale (4 total) grouped in 10
+ * categories:
  *   IT:  /domande-frequenti-frontalieri/
  *   EN:  /en/frequently-asked-questions/
  *   DE:  /de/haeufige-fragen/
@@ -11,8 +11,11 @@
  * Page body: TL;DR (100w) + table-of-contents + 10 sections (one per
  * category) with anchor IDs, every entry rendered as a semantic
  * <article>/<details> block so the FAQPage JSON-LD aggregates cleanly.
+ * Total Q&A count and per-category counts (`TOTAL_FAQ_COUNT`, TOC labels)
+ * are computed from `ALL_FAQ_HUB`/`getFaqHubByCategory` — never hardcoded —
+ * so adding entries never desyncs the on-page copy.
  *
- * Structured data: FAQPage (100 Q&A), BreadcrumbList, Article,
+ * Structured data: FAQPage (one entry per Q&A), BreadcrumbList, Article,
  * SpeakableSpecification on TL;DR + category headings.
  *
  * Hub chrome: `guida` hub with `permits` sub-tab (most common user need
@@ -45,7 +48,7 @@ import {
   buildFaqHubPath,
   getFaqHubByCategory,
 } from '../data/faq-hub';
-import type { FaqHubCategory, FaqHubEntry, FaqHubLocale } from '../data/faq-hub';
+import type { FaqHubCategory, FaqHubEntry, FaqHubLocale, FaqHubLocalizedString } from '../data/faq-hub';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 
@@ -68,19 +71,24 @@ interface FaqHubCopy {
   readonly relatedLinks: ReadonlyArray<{ href: string; label: string }>;
 }
 
+// Total Q&A count, computed from the live data set — never hardcoded, so
+// adding/removing entries can't desync the on-page copy below (see the
+// hardcoded-"100"/"(10)" class of bug this replaces).
+const TOTAL_FAQ_COUNT = ALL_FAQ_HUB.length;
+
 const COPY: Record<FaqHubLocale, FaqHubCopy> = {
   it: {
     title:
-      '100 domande frequenti dei frontalieri — risposte complete | Frontaliere Ticino',
+      `${TOTAL_FAQ_COUNT} domande frequenti dei frontalieri — risposte complete | Frontaliere Ticino`,
     description:
-      '100 risposte dettagliate per frontalieri italiani in Ticino: fisco 2026, LAMal, permessi G/B, AVS/LPP, stipendi, trasporti, lavoro, famiglia, diritti. Fonti ufficiali AFC, UFAS, SEM, Agenzia Entrate, Fedlex.',
-    h1: '100 domande frequenti dei frontalieri italiani in Ticino',
-    heroTitle: 'Il tuo centro di riferimento: 100 Q&A sul lavoro frontaliere',
+      `${TOTAL_FAQ_COUNT} risposte dettagliate per frontalieri italiani in Ticino: fisco 2026, LAMal, permessi G/B, AVS/LPP, stipendi, trasporti, lavoro, famiglia, diritti. Fonti ufficiali AFC, UFAS, SEM, Agenzia Entrate, Fedlex.`,
+    h1: `${TOTAL_FAQ_COUNT} domande frequenti dei frontalieri italiani in Ticino`,
+    heroTitle: `Il tuo centro di riferimento: ${TOTAL_FAQ_COUNT} Q&A sul lavoro frontaliere`,
     heroSubtitle:
-      '10 categorie, 100 risposte, quattro lingue. Ogni risposta cita la fonte primaria (AFC, Fedlex, UFAS, SEM, Agenzia Entrate, INPS).',
+      `10 categorie, ${TOTAL_FAQ_COUNT} risposte, quattro lingue. Ogni risposta cita la fonte primaria (AFC, Fedlex, UFAS, SEM, Agenzia Entrate, INPS).`,
     tldrTitle: 'In sintesi',
     tldrParagraphs: [
-      "Questo hub raccoglie 100 risposte verificate alle domande più ricorrenti dei frontalieri italiani che lavorano in Ticino, con attenzione alla nuova legge 2024 (Accordo CH-IT del 23/12/2020 ratificato dalla Legge italiana 83/2023) e alle scadenze fiscali 2026.",
+      `Questo hub raccoglie ${TOTAL_FAQ_COUNT} risposte verificate alle domande più ricorrenti dei frontalieri italiani che lavorano in Ticino, con attenzione alla nuova legge 2024 (Accordo CH-IT del 23/12/2020 ratificato dalla Legge italiana 83/2023) e alle scadenze fiscali 2026.`,
       "Ogni risposta è lunga 80-180 parole, cita la norma applicabile (LAMal, LAVS, LPP, CO, LStrI, TUIR, dlgs 230/2021) e rinvia a fonti ufficiali Fedlex, AFC Ticino, UFAS, SEM, Agenzia Entrate, INPS. Il contenuto è aggiornato ai dati 2026 (aliquote, massimali, premi, minimi).",
     ],
     tocTitle: 'Categorie trattate',
@@ -100,16 +108,16 @@ const COPY: Record<FaqHubLocale, FaqHubCopy> = {
   },
   en: {
     title:
-      '100 FAQs for Italian cross-border workers in Ticino — full answers | Frontaliere Ticino',
+      `${TOTAL_FAQ_COUNT} FAQs for Italian cross-border workers in Ticino — full answers | Frontaliere Ticino`,
     description:
-      '100 detailed answers for Italian cross-border workers in Ticino: 2026 tax, LAMal, G/B permits, AVS/LPP, salary, transport, work, family, rights. Primary sources: AFC, UFAS, SEM, Agenzia Entrate, Fedlex.',
-    h1: '100 FAQs for Italian cross-border workers in Ticino',
-    heroTitle: 'Your reference hub: 100 Q&A on cross-border work',
+      `${TOTAL_FAQ_COUNT} detailed answers for Italian cross-border workers in Ticino: 2026 tax, LAMal, G/B permits, AVS/LPP, salary, transport, work, family, rights. Primary sources: AFC, UFAS, SEM, Agenzia Entrate, Fedlex.`,
+    h1: `${TOTAL_FAQ_COUNT} FAQs for Italian cross-border workers in Ticino`,
+    heroTitle: `Your reference hub: ${TOTAL_FAQ_COUNT} Q&A on cross-border work`,
     heroSubtitle:
-      '10 categories, 100 answers, four languages. Every answer cites its primary source (AFC, Fedlex, UFAS, SEM, Agenzia Entrate, INPS).',
+      `10 categories, ${TOTAL_FAQ_COUNT} answers, four languages. Every answer cites its primary source (AFC, Fedlex, UFAS, SEM, Agenzia Entrate, INPS).`,
     tldrTitle: 'In a nutshell',
     tldrParagraphs: [
-      "This hub gathers 100 verified answers to the most recurrent questions of Italian cross-border workers employed in Ticino, with focus on the 2024 new law (CH-IT Agreement of 23/12/2020 ratified by Italian Law 83/2023) and the 2026 tax deadlines.",
+      `This hub gathers ${TOTAL_FAQ_COUNT} verified answers to the most recurrent questions of Italian cross-border workers employed in Ticino, with focus on the 2024 new law (CH-IT Agreement of 23/12/2020 ratified by Italian Law 83/2023) and the 2026 tax deadlines.`,
       "Every answer is 80-180 words long, cites the applicable statute (LAMal, LAVS, LPP, CO, FNA, TUIR, dlgs 230/2021) and links to official sources on Fedlex, AFC Ticino, UFAS, SEM, Agenzia Entrate and INPS. Content is updated to 2026 data (rates, ceilings, premiums, minima).",
     ],
     tocTitle: 'Covered categories',
@@ -127,16 +135,16 @@ const COPY: Record<FaqHubLocale, FaqHubCopy> = {
   },
   de: {
     title:
-      '100 häufige Fragen italienischer Grenzgänger im Tessin — Antworten | Frontaliere Ticino',
+      `${TOTAL_FAQ_COUNT} häufige Fragen italienischer Grenzgänger im Tessin — Antworten | Frontaliere Ticino`,
     description:
-      '100 detaillierte Antworten für italienische Grenzgänger im Tessin: Steuern 2026, KVG, G/B-Bewilligung, AHV/BVG, Lohn, Verkehr, Arbeit, Familie, Rechte. Primärquellen: AFC, BSV, SEM, Agenzia Entrate, Fedlex.',
-    h1: '100 häufige Fragen italienischer Grenzgänger im Tessin',
-    heroTitle: 'Ihre Nachschlagebasis: 100 Q&A zur Grenzgängerarbeit',
+      `${TOTAL_FAQ_COUNT} detaillierte Antworten für italienische Grenzgänger im Tessin: Steuern 2026, KVG, G/B-Bewilligung, AHV/BVG, Lohn, Verkehr, Arbeit, Familie, Rechte. Primärquellen: AFC, BSV, SEM, Agenzia Entrate, Fedlex.`,
+    h1: `${TOTAL_FAQ_COUNT} häufige Fragen italienischer Grenzgänger im Tessin`,
+    heroTitle: `Ihre Nachschlagebasis: ${TOTAL_FAQ_COUNT} Q&A zur Grenzgängerarbeit`,
     heroSubtitle:
-      '10 Kategorien, 100 Antworten, vier Sprachen. Jede Antwort nennt die Primärquelle (AFC, Fedlex, BSV, SEM, Agenzia Entrate, INPS).',
+      `10 Kategorien, ${TOTAL_FAQ_COUNT} Antworten, vier Sprachen. Jede Antwort nennt die Primärquelle (AFC, Fedlex, BSV, SEM, Agenzia Entrate, INPS).`,
     tldrTitle: 'Kurz gefasst',
     tldrParagraphs: [
-      'Dieser Hub sammelt 100 geprüfte Antworten auf die häufigsten Fragen italienischer Grenzgänger im Tessin, mit Schwerpunkt auf dem neuen Gesetz 2024 (CH-IT-Abkommen vom 23.12.2020, ratifiziert durch das italienische Gesetz 83/2023) und den Steuerfristen 2026.',
+      `Dieser Hub sammelt ${TOTAL_FAQ_COUNT} geprüfte Antworten auf die häufigsten Fragen italienischer Grenzgänger im Tessin, mit Schwerpunkt auf dem neuen Gesetz 2024 (CH-IT-Abkommen vom 23.12.2020, ratifiziert durch das italienische Gesetz 83/2023) und den Steuerfristen 2026.`,
       'Jede Antwort umfasst 80-180 Wörter, nennt die anwendbare Norm (KVG, AHVG, BVG, OR, AIG, TUIR, GD 230/2021) und verweist auf offizielle Quellen (Fedlex, AFC Tessin, BSV, SEM, Agenzia Entrate, INPS). Inhalte entsprechen dem Stand 2026 (Sätze, Obergrenzen, Prämien, Mindestlöhne).',
     ],
     tocTitle: 'Behandelte Kategorien',
@@ -154,16 +162,16 @@ const COPY: Record<FaqHubLocale, FaqHubCopy> = {
   },
   fr: {
     title:
-      '100 questions fréquentes des frontaliers au Tessin — réponses | Frontaliere Ticino',
+      `${TOTAL_FAQ_COUNT} questions fréquentes des frontaliers au Tessin — réponses | Frontaliere Ticino`,
     description:
-      '100 réponses détaillées pour les frontaliers italiens au Tessin : impôts 2026, LAMal, permis G/B, AVS/LPP, salaire, transports, travail, famille, droits. Sources officielles : AFC, OFAS, SEM, Agenzia Entrate, Fedlex.',
-    h1: '100 questions fréquentes des frontaliers italiens au Tessin',
-    heroTitle: 'Votre centre de référence : 100 Q&R sur le travail frontalier',
+      `${TOTAL_FAQ_COUNT} réponses détaillées pour les frontaliers italiens au Tessin : impôts 2026, LAMal, permis G/B, AVS/LPP, salaire, transports, travail, famille, droits. Sources officielles : AFC, OFAS, SEM, Agenzia Entrate, Fedlex.`,
+    h1: `${TOTAL_FAQ_COUNT} questions fréquentes des frontaliers italiens au Tessin`,
+    heroTitle: `Votre centre de référence : ${TOTAL_FAQ_COUNT} Q&R sur le travail frontalier`,
     heroSubtitle:
-      '10 catégories, 100 réponses, quatre langues. Chaque réponse cite sa source primaire (AFC, Fedlex, OFAS, SEM, Agenzia Entrate, INPS).',
+      `10 catégories, ${TOTAL_FAQ_COUNT} réponses, quatre langues. Chaque réponse cite sa source primaire (AFC, Fedlex, OFAS, SEM, Agenzia Entrate, INPS).`,
     tldrTitle: 'En bref',
     tldrParagraphs: [
-      "Ce hub rassemble 100 réponses vérifiées aux questions les plus fréquentes des frontaliers italiens employés au Tessin, avec un focus sur la nouvelle loi 2024 (Accord CH-IT du 23/12/2020 ratifié par la loi italienne 83/2023) et les échéances fiscales 2026.",
+      `Ce hub rassemble ${TOTAL_FAQ_COUNT} réponses vérifiées aux questions les plus fréquentes des frontaliers italiens employés au Tessin, avec un focus sur la nouvelle loi 2024 (Accord CH-IT du 23/12/2020 ratifié par la loi italienne 83/2023) et les échéances fiscales 2026.`,
       "Chaque réponse compte 80-180 mots, cite la norme applicable (LAMal, LAVS, LPP, CO, LEI, TUIR, décret 230/2021) et renvoie aux sources officielles Fedlex, AFC Tessin, OFAS, SEM, Agenzia Entrate, INPS. Contenu à jour 2026 (taux, plafonds, primes, minima).",
     ],
     tocTitle: 'Catégories traitées',
@@ -244,6 +252,10 @@ function truncateForSchema(text: string, maxChars = 280): string {
   return `${safe}…`;
 }
 
+function resolveRelatedHref(href: string | FaqHubLocalizedString, locale: FaqHubLocale): string {
+  return typeof href === 'string' ? href : href[locale];
+}
+
 function renderEntry(entry: FaqHubEntry, locale: FaqHubLocale): string {
   const q = entry.question[locale];
   const a = entry.answer[locale];
@@ -253,7 +265,7 @@ function renderEntry(entry: FaqHubEntry, locale: FaqHubLocale): string {
       ? `<ul class="fh-rel">${related
           .map(
             (l) =>
-              `<li><a href="${esc(l.href)}" class="fh-lnk">${esc(
+              `<li><a href="${esc(resolveRelatedHref(l.href, locale))}" class="fh-lnk">${esc(
                 l.label[locale],
               )}</a></li>`,
           )
@@ -283,7 +295,8 @@ function renderCategorySection(
 function renderToc(locale: FaqHubLocale, copy: FaqHubCopy): string {
   const items = FAQ_HUB_CATEGORIES.map((cat) => {
     const label = FAQ_HUB_CATEGORY_LABELS[cat][locale];
-    return `<li class="fh-toci"><a href="#cat-${esc(cat)}" class="fh-lnk">${esc(label)}</a> <span class="fh-tocc">(10)</span></li>`;
+    const count = getFaqHubByCategory(cat).length;
+    return `<li class="fh-toci"><a href="#cat-${esc(cat)}" class="fh-lnk">${esc(label)}</a> <span class="fh-tocc">(${count})</span></li>`;
   }).join('');
   return `<nav aria-label="${esc(copy.tocTitle)}" class="fh-toc">
   <h2 class="fh-toch">${esc(copy.tocTitle)}</h2>

--- a/data/faq-hub/category-fisco.ts
+++ b/data/faq-hub/category-fisco.ts
@@ -1,11 +1,13 @@
 import type { FaqHubEntry } from './types';
 
 /**
- * FAQ hub — category "fisco" (AE-5, 10/100).
+ * FAQ hub — category "fisco" (AE-5).
  *
  * Scope: imposta alla fonte, nuova legge fiscale 2026 (Accordo CH-IT
  * 17/07/2023 + LF 13 giugno 2023 n. 83), dichiarazione in Italia,
- * ritenute, deduzioni, ristorni ai comuni di confine.
+ * ritenute, deduzioni, ristorni ai comuni di confine. Entries 11-13
+ * (added for issue #3653) internal-link to the tax-guide pillar pages
+ * and to the evergreen salary-hub tax articles (build-plugins/salaryHubArticles.ts).
  */
 export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
   {
@@ -307,6 +309,183 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
     },
     sources: [
       'https://www.agenziaentrate.gov.it/portale/web/guest/schede/dichiarazioni/redditi-pf-2026',
+    ],
+  },
+  {
+    id: 'fisco-guida-completa-tassazione-2026',
+    category: 'fisco',
+    question: {
+      it: 'Dove trovo una guida completa e aggiornata alla tassazione dei frontalieri per il 2026?',
+      en: 'Where can I find a complete, up-to-date guide to cross-border worker taxation for 2026?',
+      de: 'Wo finde ich einen vollständigen, aktuellen Leitfaden zur Besteuerung von Grenzgängern für 2026?',
+      fr: 'Où trouver un guide complet et à jour sur la fiscalité des frontaliers pour 2026 ?',
+    },
+    answer: {
+      it: "L'Accordo Italia-Svizzera del 23/12/2020, in vigore dal 1° gennaio 2024 e ratificato dalla Legge 83/2023, distingue due regimi: i «vecchi frontalieri» (residenti in Italia già attivi in Svizzera prima del 17/07/2023) restano tassati solo alla fonte in Svizzera, con ristorno ai Comuni italiani di confine; i «nuovi frontalieri» sono tassati sia in Svizzera sia in Italia, con franchigia di 10.000 € e credito d'imposta per evitare la doppia imposizione. Per il quadro normativo completo, le tabelle di calcolo e gli scenari pratici aggiornati al 2026 consulta la guida di riferimento e la panoramica pratica qui sotto, oltre alle tabelle ufficiali di imposta alla fonte del Cantone Ticino.",
+      en: "The Italy-Switzerland Agreement of 23/12/2020, in force since 1 January 2024 and ratified by Italian Law 83/2023, sets out two regimes: 'old' cross-border workers (Italian residents already working in Switzerland before 17/07/2023) remain taxed only at source in Switzerland, with a rebate to Italian border municipalities; 'new' cross-border workers are taxed in both Switzerland and Italy, with a €10,000 exemption and a foreign-tax credit to avoid double taxation. For the full legal framework, calculation tables and practical 2026 scenarios, see the reference guide and practical overview below, plus the official Canton Ticino withholding-tax tables.",
+      de: "Das Abkommen Italien-Schweiz vom 23.12.2020, in Kraft seit dem 1. Januar 2024 und ratifiziert durch das italienische Gesetz 83/2023, unterscheidet zwei Regelungen: 'alte' Grenzgänger (italienische Wohnsitzer, die bereits vor dem 17.07.2023 in der Schweiz arbeiteten) werden weiterhin ausschliesslich an der Quelle in der Schweiz besteuert, mit Rückvergütung an die italienischen Grenzgemeinden; 'neue' Grenzgänger werden sowohl in der Schweiz als auch in Italien besteuert, mit einer Freigrenze von 10'000 € und einer Steueranrechnung zur Vermeidung der Doppelbesteuerung. Den vollständigen rechtlichen Rahmen, Berechnungstabellen und praxisnahe Szenarien für 2026 findest du im Referenzleitfaden und in der praktischen Übersicht unten sowie in den offiziellen Quellensteuertabellen des Kantons Tessin.",
+      fr: "L'Accord Italie-Suisse du 23/12/2020, en vigueur depuis le 1er janvier 2024 et ratifié par la loi italienne 83/2023, distingue deux régimes : les « anciens » frontaliers (résidents italiens déjà actifs en Suisse avant le 17/07/2023) restent imposés uniquement à la source en Suisse, avec une ristourne aux communes italiennes frontalières ; les « nouveaux » frontaliers sont imposés à la fois en Suisse et en Italie, avec une franchise de 10 000 € et un crédit d'impôt pour éviter la double imposition. Pour le cadre juridique complet, les tableaux de calcul et des scénarios pratiques à jour pour 2026, consultez le guide de référence et l'aperçu pratique ci-dessous, ainsi que les barèmes officiels d'impôt à la source du canton du Tessin.",
+    },
+    relatedLinks: [
+      {
+        href: {
+          it: '/guida-tassazione-frontalieri-2026/',
+          en: '/en/cross-border-taxation-guide-2026/',
+          de: '/de/grenzgaenger-besteuerung-leitfaden-2026/',
+          fr: '/fr/guide-imposition-frontaliers-2026/',
+        },
+        label: {
+          it: 'Guida di riferimento alla tassazione 2026',
+          en: '2026 taxation reference guide',
+          de: 'Referenzleitfaden Besteuerung 2026',
+          fr: 'Guide de référence fiscalité 2026',
+        },
+      },
+      {
+        href: {
+          it: '/guida-frontaliere/fiscalita/',
+          en: '/en/cross-border-guide/taxation/',
+          de: '/de/grenzgaenger-ratgeber/besteuerung/',
+          fr: '/fr/guide-frontalier/fiscalite/',
+        },
+        label: {
+          it: 'Panoramica pratica della fiscalità frontaliera',
+          en: 'Practical cross-border tax overview',
+          de: 'Praktische Übersicht Grenzgänger-Besteuerung',
+          fr: 'Aperçu pratique de la fiscalité frontalière',
+        },
+      },
+      {
+        href: {
+          it: '/guida-frontaliere/imposta-alla-fonte-ticino-tabelle-a-b-c-h/',
+          en: '/en/cross-border-guide/withholding-tax-ticino-tables-a-b-c-h/',
+          de: '/de/grenzgaenger-ratgeber/quellensteuer-tessin-tabellen-a-b-c-h/',
+          fr: '/fr/guide-frontalier/impot-source-tessin-baremes-a-b-c-h/',
+        },
+        label: {
+          it: 'Tabelle imposta alla fonte Ticino 2026',
+          en: 'Ticino withholding-tax tables 2026',
+          de: 'Quellensteuertabellen Tessin 2026',
+          fr: 'Barèmes impôt à la source Tessin 2026',
+        },
+      },
+    ],
+    sources: [
+      'https://www.fedlex.admin.ch/eli/cc/2023/694/it',
+      'https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:legge:2023-06-13;83',
+    ],
+  },
+  {
+    id: 'fisco-impatto-coniuge-figli-netto',
+    category: 'fisco',
+    question: {
+      it: 'Sposarsi o avere figli cambia le tasse che pago come frontaliere?',
+      en: 'Does getting married or having children change the taxes I pay as a cross-border worker?',
+      de: 'Ändert eine Heirat oder Kinder die Steuern, die ich als Grenzgänger zahle?',
+      fr: 'Le mariage ou les enfants changent-ils les impôts que je paie en tant que frontalier ?',
+    },
+    answer: {
+      it: "Sì, ma l'effetto dipende dal tuo regime. Per i «vecchi frontalieri» (tassati solo in Svizzera) stato civile e figli incidono sulla tabella di imposta alla fonte applicata dal datore di lavoro (coniugato monoreddito, coniugato doppio reddito, con figli a carico). Per i «nuovi frontalieri» (tassati anche in Italia) contano inoltre le detrazioni per carichi di famiglia previste dal TUIR nella dichiarazione dei redditi italiana, oltre alla franchigia di 10.000 € valida indipendentemente dallo stato civile. L'impatto esatto sullo stipendio netto varia molto in base a reddito, cantone e numero di figli: per una stima puntuale con i tuoi dati consulta gli approfondimenti dedicati qui sotto.",
+      en: "Yes, but the effect depends on your regime. For 'old' cross-border workers (taxed only in Switzerland), marital status and children affect which withholding-tax table the employer applies (single-earner married, dual-earner married, with dependent children). For 'new' cross-border workers (also taxed in Italy), family-dependant deductions under the Italian TUIR also apply in the Italian tax return, on top of the €10,000 exemption that applies regardless of marital status. The exact impact on net salary varies a lot by income, canton and number of children: see the dedicated deep-dives below for a precise estimate with your own figures.",
+      de: "Ja, aber die Wirkung hängt vom jeweiligen Regime ab. Für 'alte' Grenzgänger (nur in der Schweiz besteuert) beeinflussen Zivilstand und Kinder, welche Quellensteuertabelle der Arbeitgeber anwendet (verheiratet Einverdiener, verheiratet Zweiverdiener, mit unterhaltsberechtigten Kindern). Für 'neue' Grenzgänger (auch in Italien besteuert) gelten zusätzlich die Familienabzüge nach italienischem TUIR in der italienischen Steuererklärung, zusätzlich zur Freigrenze von 10'000 €, die unabhängig vom Zivilstand gilt. Die genaue Auswirkung auf den Nettolohn hängt stark von Einkommen, Kanton und Kinderzahl ab: Für eine präzise Schätzung mit deinen eigenen Zahlen findest du unten weiterführende Analysen.",
+      fr: "Oui, mais l'effet dépend de votre régime. Pour les « anciens » frontaliers (imposés uniquement en Suisse), l'état civil et les enfants déterminent le barème d'impôt à la source appliqué par l'employeur (marié un revenu, marié deux revenus, avec enfants à charge). Pour les « nouveaux » frontaliers (imposés aussi en Italie), les déductions pour charges de famille prévues par le TUIR italien s'appliquent en plus dans la déclaration italienne, en plus de la franchise de 10 000 € valable quel que soit l'état civil. L'impact exact sur le salaire net varie beaucoup selon le revenu, le canton et le nombre d'enfants : consultez les analyses détaillées ci-dessous pour une estimation précise avec vos propres chiffres.",
+    },
+    relatedLinks: [
+      {
+        href: {
+          it: '/guida-frontaliere/quanto-incidono-figli-stipendio-netto-frontaliere/',
+          en: '/en/cross-border-guide/how-children-affect-crossborder-worker-net-salary/',
+          de: '/de/grenzgaenger-ratgeber/wie-kinder-nettogehalt-grenzgaenger-beeinflussen/',
+          fr: '/fr/guide-frontalier/impact-enfants-salaire-net-frontalier/',
+        },
+        label: {
+          it: 'Impatto dei figli sullo stipendio netto',
+          en: 'Impact of children on net salary',
+          de: 'Einfluss von Kindern auf den Nettolohn',
+          fr: 'Impact des enfants sur le salaire net',
+        },
+      },
+      {
+        href: {
+          it: '/guida-frontaliere/sposato-o-single-impatto-tasse-frontaliere/',
+          en: '/en/cross-border-guide/married-or-single-impact-on-crossborder-taxes/',
+          de: '/de/grenzgaenger-ratgeber/verheiratet-oder-ledig-auswirkung-steuern-grenzgaenger/',
+          fr: '/fr/guide-frontalier/marie-ou-celibataire-impact-impots-frontalier/',
+        },
+        label: {
+          it: 'Sposato o single: impatto sulle tasse',
+          en: 'Married or single: impact on taxes',
+          de: 'Verheiratet oder ledig: Einfluss auf die Steuern',
+          fr: 'Marié ou célibataire : impact sur les impôts',
+        },
+      },
+      {
+        href: {
+          it: '/guida-frontaliere/nuovo-vs-vecchio-frontaliere-differenze-fiscali/',
+          en: '/en/cross-border-guide/new-vs-old-crossborder-worker-tax-differences/',
+          de: '/de/grenzgaenger-ratgeber/neuer-vs-alter-grenzgaenger-steuerliche-unterschiede/',
+          fr: '/fr/guide-frontalier/nouveau-vs-ancien-frontalier-differences-fiscales/',
+        },
+        label: {
+          it: 'Vecchio vs nuovo frontaliere: differenze fiscali',
+          en: 'Old vs new cross-border worker: tax differences',
+          de: 'Alter vs neuer Grenzgänger: steuerliche Unterschiede',
+          fr: 'Ancien vs nouveau frontalier : différences fiscales',
+        },
+      },
+    ],
+    sources: [
+      'https://www.fedlex.admin.ch/eli/cc/2023/694/it',
+      'https://www4.ti.ch/dfe/dc/imposta-alla-fonte',
+    ],
+  },
+  {
+    id: 'fisco-zona-frontaliera-20km-fiscalita',
+    category: 'fisco',
+    question: {
+      it: 'La distanza dal confine (20 km) incide sul mio status fiscale di frontaliere?',
+      en: 'Does the 20 km distance from the border affect my cross-border tax status?',
+      de: 'Wirkt sich die 20-km-Grenzdistanz auf meinen steuerlichen Grenzgängerstatus aus?',
+      fr: 'La distance de 20 km à la frontière a-t-elle un impact sur mon statut fiscal de frontalier ?',
+    },
+    answer: {
+      it: "La qualifica di «frontaliere» ai fini fiscali richiede di risiedere in un Comune italiano il cui territorio ricade, anche solo parzialmente, entro 20 km in linea d'aria dal confine svizzero, oltre a rientrare quotidianamente (o comunque con regolarità) alla propria residenza. Chi risiede oltre questa fascia perde l'accesso al regime frontaliere (vecchio o nuovo) e viene tassato secondo le regole ordinarie previste per i residenti italiani con reddito estero, senza franchigia né ristorno ai Comuni. La distanza si misura dal confine, non dal luogo di lavoro in Svizzera. Per i dettagli su Comuni ammessi e casi limite consulta l'approfondimento dedicato qui sotto.",
+      en: "The tax status of 'cross-border worker' requires residing in an Italian municipality whose territory falls, even partly, within 20 km as the crow flies from the Swiss border, plus returning to one's residence daily (or at least regularly). Anyone living beyond that zone loses access to the cross-border regime (old or new) and is taxed under the ordinary rules for Italian residents with foreign income, with no exemption and no municipal rebate. The distance is measured from the border, not from the Swiss workplace. For details on eligible municipalities and edge cases, see the dedicated deep-dive below.",
+      de: "Der steuerliche Grenzgängerstatus setzt voraus, dass man in einer italienischen Gemeinde wohnt, deren Gebiet zumindest teilweise innerhalb von 20 km Luftlinie von der Schweizer Grenze liegt, und täglich (oder zumindest regelmässig) an den Wohnort zurückkehrt. Wer ausserhalb dieser Zone wohnt, verliert den Zugang zum Grenzgängerregime (alt oder neu) und wird nach den ordentlichen Regeln für italienische Ansässige mit ausländischem Einkommen besteuert, ohne Freigrenze und ohne Rückvergütung an die Gemeinde. Die Distanz wird ab der Grenze gemessen, nicht ab dem Schweizer Arbeitsort. Details zu zulässigen Gemeinden und Grenzfällen findest du in der Vertiefung unten.",
+      fr: "Le statut fiscal de « frontalier » exige de résider dans une commune italienne dont le territoire se situe, même partiellement, à moins de 20 km à vol d'oiseau de la frontière suisse, et de rentrer quotidiennement (ou du moins régulièrement) à son domicile. Toute personne résidant au-delà de cette zone perd l'accès au régime frontalier (ancien ou nouveau) et est imposée selon les règles ordinaires applicables aux résidents italiens percevant un revenu étranger, sans franchise ni ristourne communale. La distance se mesure depuis la frontière, et non depuis le lieu de travail en Suisse. Pour le détail des communes éligibles et des cas limites, consultez l'analyse dédiée ci-dessous.",
+    },
+    relatedLinks: [
+      {
+        href: {
+          it: '/guida-frontaliere/frontaliere-entro-o-oltre-20km-cosa-cambia/',
+          en: '/en/cross-border-guide/crossborder-within-or-over-20km-what-changes/',
+          de: '/de/grenzgaenger-ratgeber/grenzgaenger-innerhalb-oder-ueber-20km-was-aendert-sich/',
+          fr: '/fr/guide-frontalier/frontalier-moins-ou-plus-20km-ce-qui-change/',
+        },
+        label: {
+          it: 'Entro o oltre i 20 km: cosa cambia',
+          en: 'Within or beyond 20 km: what changes',
+          de: 'Innerhalb oder ausserhalb 20 km: was sich ändert',
+          fr: 'À moins ou plus de 20 km : ce qui change',
+        },
+      },
+      {
+        href: {
+          it: '/guida-tassazione-frontalieri-2026/',
+          en: '/en/cross-border-taxation-guide-2026/',
+          de: '/de/grenzgaenger-besteuerung-leitfaden-2026/',
+          fr: '/fr/guide-imposition-frontaliers-2026/',
+        },
+        label: {
+          it: 'Guida di riferimento alla tassazione 2026',
+          en: '2026 taxation reference guide',
+          de: 'Referenzleitfaden Besteuerung 2026',
+          fr: 'Guide de référence fiscalité 2026',
+        },
+      },
+    ],
+    sources: [
+      'https://www.fedlex.admin.ch/eli/cc/2023/694/it',
     ],
   },
 ];

--- a/data/faq-hub/index.ts
+++ b/data/faq-hub/index.ts
@@ -1,4 +1,4 @@
-import type { FaqHubEntry, FaqHubCategory, FaqHubLocale } from './types';
+import type { FaqHubEntry, FaqHubCategory, FaqHubLocale, FaqHubLocalizedString } from './types';
 import { FAQ_HUB_CATEGORIES, FAQ_HUB_LOCALES } from './types';
 import { FAQ_avsLpp } from './category-avs-lpp';
 import { FAQ_diritti } from './category-diritti';
@@ -12,7 +12,10 @@ import { FAQ_trasporti } from './category-trasporti';
 import { FAQ_vitaQuotidiana } from './category-vita-quotidiana';
 
 /**
- * AE-5 FAQ hub aggregate — 10 categories × 10 entries = 100 Q&A.
+ * AE-5 FAQ hub aggregate — 10 categories, ~10 entries each. Per-category
+ * counts may exceed 10 as content is added; `ALL_FAQ_HUB.length` and the
+ * per-category counts rendered by `faqHubPlugin.ts` are always computed
+ * dynamically, never hardcoded, so growth here never desyncs the page copy.
  *
  * Order: alphabetical by category, stable by entry id within each.
  * This is the source of truth consumed by `faqHubPlugin.ts` (build-time
@@ -47,7 +50,7 @@ export function getFaqHubByCategory(category: FaqHubCategory): ReadonlyArray<Faq
 }
 
 export { FAQ_HUB_CATEGORIES, FAQ_HUB_LOCALES };
-export type { FaqHubEntry, FaqHubCategory, FaqHubLocale };
+export type { FaqHubEntry, FaqHubCategory, FaqHubLocale, FaqHubLocalizedString };
 
 // Re-export route helpers from the router-safe module. See routes.ts for
 // the rationale (keeps the 340KB category data out of the SPA bundle).

--- a/data/faq-hub/types.ts
+++ b/data/faq-hub/types.ts
@@ -1,7 +1,8 @@
 /**
- * Types for the 100-Q&A FAQ hub (AE-5).
+ * Types for the FAQ hub (AE-5).
  *
- * 10 categories × 10 entries × 4 locales = 400 unique Q&A pairs.
+ * 10 categories, ~10 entries each, translated into 4 locales. Per-category
+ * counts may grow past 10 as content is added — see data/faq-hub/index.ts.
  * Each entry lives in data/faq-hub/category-<name>.ts and is aggregated
  * by data/faq-hub/index.ts into ALL_FAQ_HUB.
  */
@@ -23,7 +24,15 @@ export type FaqHubLocale = 'it' | 'en' | 'de' | 'fr';
 export type FaqHubLocalizedString = Readonly<Record<FaqHubLocale, string>>;
 
 export type FaqHubRelatedLink = Readonly<{
-  href: string;
+  /**
+   * Target path. Plain `string` when the destination route is identical
+   * across locales (e.g. a tool page with no localized slug). Use the
+   * `Record<locale, path>` form whenever the target has a locale-specific
+   * slug (e.g. evergreen articles under `/guida-frontaliere/<slug>/` vs
+   * `/en/cross-border-guide/<slug>/`) — never hardcode a single locale's
+   * path and reuse it verbatim across all 4 locale renders.
+   */
+  href: string | FaqHubLocalizedString;
   label: FaqHubLocalizedString;
 }>;
 

--- a/tests/build-plugins/faq-hub-content.test.ts
+++ b/tests/build-plugins/faq-hub-content.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression coverage for issue #3653 (FAQ hub fiscal entries + internal
+ * linking to the tax-guide pillar pages and the evergreen salary-hub tax
+ * articles).
+ *
+ * Three things are guarded here because they were the concrete risks of
+ * growing `data/faq-hub/category-fisco.ts` past its original fixed size:
+ *
+ * 1. `faqHubPlugin.ts` used to hardcode "100" (total Q&A) and "(10)" (per
+ *    category count) directly in the on-page copy/TOC. Adding entries
+ *    without also making those dynamic would ship a page that visibly
+ *    lies about its own content. This test asserts the FAQPage JSON-LD
+ *    `mainEntity` length always matches `ALL_FAQ_HUB.length` and that the
+ *    stale "100 ..." strings are gone from the rendered HTML.
+ * 2. The per-category TOC count must track `getFaqHubByCategory(cat).length`
+ *    for every category, not just fisco.
+ * 3. `FaqHubRelatedLink.href` was extended to accept a
+ *    `Record<locale, path>` so new entries can link to locale-specific
+ *    routes without hardcoding a single locale's path and reusing it
+ *    across all 4 rendered pages (the exact anti-pattern fixed in #3686
+ *    for build-plugins/salaryHubArticles.ts). This test proves the three
+ *    new fisco entries actually resolve a different href per locale.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import { faqHubPlugin } from '../../build-plugins/faqHubPlugin';
+import {
+  ALL_FAQ_HUB,
+  FAQ_HUB_CATEGORIES,
+  FAQ_HUB_LOCALES,
+  buildFaqHubPath,
+  getFaqHubByCategory,
+} from '../../data/faq-hub';
+import { extractJsonLdBlocks, flattenSchemas } from '../post-build/seo-helpers';
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(): string {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'faq-hub-content-test-'));
+  fs.mkdirSync(path.join(tempRoot, 'dist'));
+  tempRoots.push(tempRoot);
+  return tempRoot;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Attribute matcher tolerant to `build-plugins/shared/htmlMinify.ts` step 5
+ * ("remove quotes from HTML5-safe attribute values"): a value like `fh-lnk`
+ * or a kebab-case id gets unquoted (`class=fh-lnk`) unless it ends in `/`
+ * (every route path here does, per the site's mandatory-trailing-slash
+ * convention, so hrefs stay quoted — but we don't rely on that either way).
+ */
+function attrEq(name: string, value: string): string {
+  const v = escapeRegex(value);
+  return `${name}=(?:"${v}"|${v})`;
+}
+
+async function runCloseBundle(plugin: Plugin): Promise<void> {
+  await (plugin as unknown as { closeBundle: () => Promise<void> }).closeBundle();
+}
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop()!;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function buildAllLocaleHtml(): Promise<Record<string, string>> {
+  const tempRoot = makeTempRoot();
+  await runCloseBundle(faqHubPlugin(tempRoot));
+  const out: Record<string, string> = {};
+  for (const locale of FAQ_HUB_LOCALES) {
+    const urlPath = buildFaqHubPath(locale);
+    const htmlPath = path.join(tempRoot, 'dist', urlPath, 'index.html');
+    expect(fs.existsSync(htmlPath), `missing rendered page for locale ${locale}: ${htmlPath}`).toBe(true);
+    out[locale] = fs.readFileSync(htmlPath, 'utf-8');
+  }
+  return out;
+}
+
+describe('FAQ hub (AE-5) — dynamic count sync (#3653 regression)', () => {
+  it('FAQPage mainEntity count matches ALL_FAQ_HUB.length on every locale page, no stale "100" copy', async () => {
+    const htmlByLocale = await buildAllLocaleHtml();
+
+    for (const locale of FAQ_HUB_LOCALES) {
+      const html = htmlByLocale[locale];
+      const schemas = flattenSchemas(extractJsonLdBlocks(html));
+      const faqPage = schemas.find((s) => s['@type'] === 'FAQPage');
+      expect(faqPage, `${locale}: missing FAQPage JSON-LD`).toBeDefined();
+
+      const mainEntity = faqPage?.mainEntity;
+      expect(Array.isArray(mainEntity), `${locale}: FAQPage.mainEntity must be an array`).toBe(true);
+      expect(mainEntity.length, `${locale}: FAQPage entity count must track ALL_FAQ_HUB`).toBe(
+        ALL_FAQ_HUB.length,
+      );
+
+      // Regression guard: the old hardcoded "100 domande/risposte/FAQs/..."
+      // copy must never resurface once the data set grows past 100.
+      expect(html).not.toMatch(
+        /\b100\s+(domande|risposte|FAQs?|answers|Fragen|Antworten|questions|réponses)\b/i,
+      );
+    }
+  });
+
+  it('per-category TOC count matches getFaqHubByCategory(cat).length for every category', async () => {
+    const htmlByLocale = await buildAllLocaleHtml();
+    const html = htmlByLocale.it;
+
+    for (const cat of FAQ_HUB_CATEGORIES) {
+      const count = getFaqHubByCategory(cat).length;
+      const re = new RegExp(
+        `${attrEq('href', `#cat-${cat}`)}[^>]*>[^<]*</a>[\\s\\S]{0,10}${attrEq(
+          'class',
+          'fh-tocc',
+        )}>\\(${count}\\)</span>`,
+      );
+      expect(re.test(html), `TOC entry for category "${cat}" should read (${count})`).toBe(true);
+    }
+
+    // fisco grew from 10 to 13 entries as part of #3653.
+    expect(getFaqHubByCategory('fisco').length).toBe(13);
+  });
+});
+
+describe('FAQ hub (AE-5) — new fisco entries link internally per-locale (#3653)', () => {
+  const NEW_ENTRY_IDS = [
+    'fisco-guida-completa-tassazione-2026',
+    'fisco-impatto-coniuge-figli-netto',
+    'fisco-zona-frontaliera-20km-fiscalita',
+  ];
+
+  function extractArticle(html: string, id: string): string {
+    const re = new RegExp(`<article ${attrEq('id', id)}[\\s\\S]*?</article>`);
+    const match = re.exec(html);
+    return match ? match[0] : '';
+  }
+
+  it('renders on every locale page with non-empty question/answer text', async () => {
+    const htmlByLocale = await buildAllLocaleHtml();
+    for (const locale of FAQ_HUB_LOCALES) {
+      const html = htmlByLocale[locale];
+      for (const id of NEW_ENTRY_IDS) {
+        const articleHtml = extractArticle(html, id);
+        expect(articleHtml, `${locale}: entry "${id}" missing from rendered page`).not.toBe('');
+        const question = new RegExp(`<h3 ${attrEq('class', 'fh-qt')}>([^<]+)</h3>`).exec(articleHtml)?.[1];
+        const answer = new RegExp(`<p ${attrEq('class', 'fh-qa')}>([\\s\\S]*?)</p>`).exec(articleHtml)?.[1];
+        expect(question && question.trim().length > 0, `${locale}: entry "${id}" has empty question`).toBe(
+          true,
+        );
+        expect(answer && answer.trim().length > 20, `${locale}: entry "${id}" has too-short answer`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it('resolves a distinct related-link href per locale (Record<locale, path> pattern, not one IT path reused)', async () => {
+    const htmlByLocale = await buildAllLocaleHtml();
+
+    for (const id of NEW_ENTRY_IDS) {
+      const hrefByLocale: Record<string, string> = {};
+      for (const locale of FAQ_HUB_LOCALES) {
+        const html = htmlByLocale[locale];
+        const articleHtml = extractArticle(html, id);
+        expect(articleHtml, `${locale}: entry "${id}" missing`).not.toBe('');
+        const hrefMatch = new RegExp(`href=(?:"([^"]+)"|([^\\s>]+))\\s+${attrEq(
+          'class',
+          'fh-lnk',
+        )}`).exec(articleHtml);
+        expect(hrefMatch, `${locale}: entry "${id}" has no related-link href`).toBeTruthy();
+        hrefByLocale[locale] = (hrefMatch![1] ?? hrefMatch![2])!;
+
+        // Every rendered href must itself carry the correct locale prefix
+        // (or be the IT-rooted path for the it locale, which has none).
+        if (locale !== 'it') {
+          expect(
+            hrefByLocale[locale].startsWith(`/${locale}/`),
+            `${locale}: entry "${id}" related-link href "${hrefByLocale[locale]}" must be locale-prefixed`,
+          ).toBe(true);
+        }
+      }
+
+      expect(hrefByLocale.it, `entry "${id}": EN href must differ from IT`).not.toBe(hrefByLocale.en);
+      expect(hrefByLocale.it, `entry "${id}": DE href must differ from IT`).not.toBe(hrefByLocale.de);
+      expect(hrefByLocale.it, `entry "${id}": FR href must differ from IT`).not.toBe(hrefByLocale.fr);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

- 3 nuove voci Q&A nella categoria `fisco` del FAQ hub (`data/faq-hub/category-fisco.ts`, 10 → 13 entries, 4 locale ciascuna): guida completa alla tassazione 2026, impatto di stato civile/figli sul netto, rilevanza della zona di frontiera 20km. Contenuto fondato su fatti verificati (Accordo CH-IT 23/12/2020, in vigore 1/1/2024, ratificato da L. 83/2023; franchigia €10'000; regola 20km) — nessun tasso/data/istituzione inventati.
- Internal linking via nuovo campo `FaqHubRelatedLink.href: string | Record<locale, path>` (prima solo `string`): ogni nuova voce collega la pillar page `/guida-tassazione-frontalieri-2026/` (+ varianti EN/DE/FR già registrate in `services/router.ts`) e/o gli articoli evergreen fiscali in `build-plugins/salaryHubArticles.ts`, risolvendo un href diverso per locale invece di riusare un singolo path IT su tutti i render (stesso bug-pattern già corretto in PR #3686, non reintrodotto qui).
- `FAQPage` JSON-LD: nessun meccanismo nuovo — l'aggregazione in `faqHubPlugin.ts` (`renderPage` → `allEntries`) è già dinamica, quindi le nuove voci compaiono automaticamente nello schema per ogni locale.
- Rimosso il numero "100"/"(10)" hardcoded dalla copy on-page e dal conteggio TOC di `faqHubPlugin.ts`: ora calcolati da `ALL_FAQ_HUB.length` / `getFaqHubByCategory(cat).length`, così la crescita futura del data set non può più desincronizzare la copy visibile (bug-class fix, non solo il sintomo puntuale).
- Nuovo test `tests/build-plugins/faq-hub-content.test.ts`: verifica che `FAQPage.mainEntity.length` segua sempre `ALL_FAQ_HUB.length` su ogni locale, che il conteggio TOC per categoria segua `getFaqHubByCategory(cat).length` (incl. `fisco === 13`), e che le 3 nuove voci risolvano un href diverso per ciascuno dei 4 locale.
- Verificato: `npx vitest run tests/build-plugins/faq-hub-content.test.ts tests/build-plugins/sibling-hub-locale-reciprocity.test.ts` → 11/11 verdi. `npx tsc --noEmit` → zero errori nuovi (i tsc error preesistenti in `tests/fb-events-scheduler.test.ts`, `tests/local-llm-fallback.test.ts`, `tests/locale-router-*.test.ts` ecc. sono scollegati da questo diff, nessuno tocca `data/faq-hub/*` o `faqHubPlugin.ts`). GitNexus `impact` su `renderToc`/`renderEntry` → LOW risk, solo caller interni allo stesso file.

## Non implementato (ancora)

Nessuno.

Closes #3653