### PR TITLE
fix(create-article): local/fallback wall-clock stranding + topic-gate self-contradiction

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3274,7 +3274,7 @@ async function callLLM(messages, opts = {}) {
     // attempt consumed nearly all of it). ...opts still wins if a caller passes
     // its own deadlineMs (or explicit null to opt out of the cap entirely).
     const result = await _aiCallLLM(messages, { temperature: 0.7, maxTokens: 4000, timeout: 90_000, deadlineMs: RUN_START_MS + RUN_WALL_BUDGET_MS, ...opts, modelUsedRef });
-    if (modelUsedRef.model === AI_MODELS.LOCAL_FALLBACK) _localFallbackUsedThisRun = true;
+    if (modelUsedRef.model === AI_MODELS.LOCAL_FALLBACK) _localFallbackUsedThisHeadline = true;
     if (isBody2Check) {
       let itContent = null;
       let parseErr = null;
@@ -7957,16 +7957,22 @@ function wallBudgetExceeded() {
 
 /**
  * Set true the first time callLLM() observes local/fallback actually serving
- * a request this run (see callLLM below). Cheaper and more precise than the
- * Firestore-score-based cloudCascadeExhausted check used by main()'s
+ * a request for the CURRENT headline (see callLLM below). Reset to false at
+ * the top of generateAndValidateArticle (2026-07-06, PR #3704 review round
+ * 2) — the process handles multiple headlines/pools/evergreen per run, each
+ * via its own generateAndValidateArticle call, and a module-level flag left
+ * set across headlines would poison a brand-new headline's first attempt
+ * (which hasn't even tried the cloud model yet) purely because a PREVIOUS,
+ * unrelated headline had cascaded to local. Cheaper and more precise than
+ * the Firestore-score-based cloudCascadeExhausted check used by main()'s
  * evergreen pre-scan: that one only sees model scoring/cooldown state and
  * misses per-request cascades caused by prompt token-size alone. Read by
- * generateAndValidateArticle's retry-loop wall-clock guard below.
+ * generateAndValidateArticle's own retry-loop wall-clock guard below.
  */
-let _localFallbackUsedThisRun = false;
+let _localFallbackUsedThisHeadline = false;
 /**
  * Minimum wall-clock remaining (ms) to risk another local/fallback attempt
- * once one has already run this run. Local/fallback (qwen2.5:14b via Ollama)
+ * once one has already run for this headline. Local/fallback (qwen2.5:14b via Ollama)
  * full inference for this prompt size took ~17.5min and ~12.5min in the two
  * observed cases (run 28802314827); below this floor a further attempt would
  * be truncated mid-inference by _callLocal's own deadline cap (ai-models.mjs)
@@ -8699,6 +8705,17 @@ async function main() {
 
 /** Core article pipeline: fetch → generate IT → validate → duplicates → translate → sanitize → image → modify files → git */
 async function generateAndValidateArticle(url, sourceContext = null) {
+  // Scope the local-only wall-clock guard to THIS headline (2026-07-06,
+  // PR #3704 review): the flag is set by any callLLM() in the process that
+  // cascades to local/fallback — including a PREVIOUS headline's retries,
+  // its translation, or its body expansion, all of which run inside the
+  // same process before this call. Without resetting per-headline, a prior
+  // headline touching local/fallback would poison a brand-new headline's
+  // very first attempt (which hasn't even tried the cloud model yet) the
+  // moment wall-clock ran low — reproducing the "run publishes zero
+  // articles" failure via a different path than the one this guard exists
+  // to fix.
+  _localFallbackUsedThisHeadline = false;
   if (isGoogleNewsRssUrl(url)) {
     const err = new Error(`topic-gate abort: Google News RSS wrapper senza fonte diretta (${url})`);
     err.topicGateAbort = true;
@@ -8765,7 +8782,9 @@ async function generateAndValidateArticle(url, sourceContext = null) {
   for (let attempt = 1; attempt <= CREATE_ARTICLE_MIN_WORDS_RETRIES; attempt++) {
     // Wall-clock guard for the local-only cascade (2026-07-06, incident run
     // 28802314827): once local/fallback has generated at least one attempt
-    // this run, cloud has empirically proven unusable for this prompt (the
+    // for THIS headline (flag reset per-headline — see the reset at the top
+    // of this function), cloud has empirically proven unusable for this
+    // prompt (the
     // Firestore-score-based cloudCascadeExhausted check in main() only sees
     // model scoring/cooldown state and misses per-request token-size
     // cascades). Each full local/fallback inference took ~12-17min observed;
@@ -8778,10 +8797,10 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     // fresh full budget. Same qualityReject disposition as the other
     // "survived retry budget" throws (see isQualityRejectError above) — this
     // is a clean per-headline deferral, not an infrastructure crash.
-    if (_localFallbackUsedThisRun) {
+    if (_localFallbackUsedThisHeadline) {
       const remainingMs = RUN_WALL_BUDGET_MS - (Date.now() - RUN_START_MS);
       if (remainingMs < LOCAL_MIN_VIABLE_MS) {
-        console.error(`  ⏭️  Interrompo i retry: local/fallback già usato in questo run, restano ${Math.round(remainingMs / 60_000)}min (< ${LOCAL_MIN_VIABLE_MS / 60_000}min necessari per completare un altro tentativo senza timeout) — evito un timeout a vuoto.`);
+        console.error(`  ⏭️  Interrompo i retry: local/fallback già usato per questo headline, restano ${Math.round(remainingMs / 60_000)}min (< ${LOCAL_MIN_VIABLE_MS / 60_000}min necessari per completare un altro tentativo senza timeout) — evito un timeout a vuoto.`);
         RUN_REPORT.notes.push(`Retry loop stopped early: local-only wall-clock guard (attempt=${attempt}, remainingMin=${Math.round(remainingMs / 60_000)})`);
         const err = new Error(`Local/fallback wall-clock budget insufficiente per un altro tentativo (restano ${Math.round(remainingMs / 60_000)}min)`);
         err.qualityReject = true;

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3274,6 +3274,7 @@ async function callLLM(messages, opts = {}) {
     // attempt consumed nearly all of it). ...opts still wins if a caller passes
     // its own deadlineMs (or explicit null to opt out of the cap entirely).
     const result = await _aiCallLLM(messages, { temperature: 0.7, maxTokens: 4000, timeout: 90_000, deadlineMs: RUN_START_MS + RUN_WALL_BUDGET_MS, ...opts, modelUsedRef });
+    if (modelUsedRef.model === AI_MODELS.LOCAL_FALLBACK) _localFallbackUsedThisRun = true;
     if (isBody2Check) {
       let itContent = null;
       let parseErr = null;
@@ -4640,7 +4641,20 @@ Rispondi SOLO con JSON valido, senza markdown.` },
   // hallucination defense). Treat the abort as a controlled failure so
   // the run report classifies it and the workflow's retry/self-trigger
   // path can pick a different headline instead of publishing slop.
-  if (itData?.abort_topical_relevance === true) {
+  //
+  // Self-contradiction guard (2026-07-06, run 28802314827): the schema's own
+  // contract (see buildArticleJsonSchema above) requires the model to EITHER
+  // set abort_topical_relevance and leave content null, OR fill content and
+  // leave abort_topical_relevance null — never both. Weaker models (observed:
+  // local/fallback qwen2.5:14b) sometimes set the abort flag while ALSO fully
+  // populating content.it with a genuinely relevant article (the `reason`
+  // text itself affirmed frontaliere relevance) — blindly trusting the flag
+  // discarded a valid, on-topic article and burned the remaining retry
+  // budget on doomed local/fallback re-attempts. When content is actually
+  // present the model contradicted its own abort signal; trust the content
+  // it produced over the flag instead of throwing.
+  const itContentPreAbortCheck = itData?.abort_topical_relevance === true ? normalizeItalianContentFromPayload(itData) : null;
+  if (itData?.abort_topical_relevance === true && !itContentPreAbortCheck) {
     const reason = String(itData.reason || '').slice(0, 500) || '(no reason)';
     console.error(`  ⏭️  [topic-gate] Generation aborted by REGOLA #0 — source lacks real frontaliere angle.`);
     console.error(`     Reason: ${reason}`);
@@ -4652,8 +4666,14 @@ Rispondi SOLO con JSON valido, senza markdown.` },
     err.topicGateAbort = true;
     throw err;
   }
+  if (itContentPreAbortCheck) {
+    console.error(`  ⚠️  [topic-gate] Model set abort_topical_relevance=true but ALSO returned full content.it — contract violation, trusting content over the flag (reason given: "${String(itData.reason || '').slice(0, 200)}").`);
+    if (RUN_REPORT && typeof RUN_REPORT === 'object') {
+      RUN_REPORT.topicGateSelfContradictions = (RUN_REPORT.topicGateSelfContradictions || 0) + 1;
+    }
+  }
 
-  const itContent = normalizeItalianContentFromPayload(itData);
+  const itContent = itContentPreAbortCheck || normalizeItalianContentFromPayload(itData);
   if (!itContent) {
     // qualityReject=true: same content-quality class as the JSON-parse and
     // missing-field siblings above/below — see their comments for why.
@@ -7936,6 +7956,27 @@ function wallBudgetExceeded() {
 }
 
 /**
+ * Set true the first time callLLM() observes local/fallback actually serving
+ * a request this run (see callLLM below). Cheaper and more precise than the
+ * Firestore-score-based cloudCascadeExhausted check used by main()'s
+ * evergreen pre-scan: that one only sees model scoring/cooldown state and
+ * misses per-request cascades caused by prompt token-size alone. Read by
+ * generateAndValidateArticle's retry-loop wall-clock guard below.
+ */
+let _localFallbackUsedThisRun = false;
+/**
+ * Minimum wall-clock remaining (ms) to risk another local/fallback attempt
+ * once one has already run this run. Local/fallback (qwen2.5:14b via Ollama)
+ * full inference for this prompt size took ~17.5min and ~12.5min in the two
+ * observed cases (run 28802314827); below this floor a further attempt would
+ * be truncated mid-inference by _callLocal's own deadline cap (ai-models.mjs)
+ * instead of completing — zero output, wasted GH Actions minutes. Set below
+ * the faster observed completion (~12.5min) with a small margin so an
+ * average-length attempt still gets a chance.
+ */
+const LOCAL_MIN_VIABLE_MS = 11 * 60_000;
+
+/**
  * True when the error is a CONTENT/QUALITY rejection (fact-check block,
  * topic-gate REGOLA #0 abort, fabrication, or a non-conformant headline that
  * survived its retry budget) rather than an infrastructure bug.
@@ -8722,6 +8763,31 @@ async function generateAndValidateArticle(url, sourceContext = null) {
   }
 
   for (let attempt = 1; attempt <= CREATE_ARTICLE_MIN_WORDS_RETRIES; attempt++) {
+    // Wall-clock guard for the local-only cascade (2026-07-06, incident run
+    // 28802314827): once local/fallback has generated at least one attempt
+    // this run, cloud has empirically proven unusable for this prompt (the
+    // Firestore-score-based cloudCascadeExhausted check in main() only sees
+    // model scoring/cooldown state and misses per-request token-size
+    // cascades). Each full local/fallback inference took ~12-17min observed;
+    // a further attempt below LOCAL_MIN_VIABLE_MS remaining would be
+    // truncated mid-inference by _callLocal's own deadline cap instead of
+    // completing — zero output, wasted GH Actions minutes. That exact chain
+    // (17.5min + 12.5min burned on unrelated rejections, leaving only 5.5min
+    // for a 3rd local attempt that then hard-timed-out) is why that run
+    // published nothing. Stop cleanly here instead; the next cron run gets a
+    // fresh full budget. Same qualityReject disposition as the other
+    // "survived retry budget" throws (see isQualityRejectError above) — this
+    // is a clean per-headline deferral, not an infrastructure crash.
+    if (_localFallbackUsedThisRun) {
+      const remainingMs = RUN_WALL_BUDGET_MS - (Date.now() - RUN_START_MS);
+      if (remainingMs < LOCAL_MIN_VIABLE_MS) {
+        console.error(`  ⏭️  Interrompo i retry: local/fallback già usato in questo run, restano ${Math.round(remainingMs / 60_000)}min (< ${LOCAL_MIN_VIABLE_MS / 60_000}min necessari per completare un altro tentativo senza timeout) — evito un timeout a vuoto.`);
+        RUN_REPORT.notes.push(`Retry loop stopped early: local-only wall-clock guard (attempt=${attempt}, remainingMin=${Math.round(remainingMs / 60_000)})`);
+        const err = new Error(`Local/fallback wall-clock budget insufficiente per un altro tentativo (restano ${Math.round(remainingMs / 60_000)}min)`);
+        err.qualityReject = true;
+        throw err;
+      }
+    }
     const modelSlot = MIN_WORDS_MODEL_ROTATION[Math.min(attempt - 1, MIN_WORDS_MODEL_ROTATION.length - 1)];
     const useGeminiDirect = modelSlot === 'gemini';
     // Higher temperature on later attempts to get more varied/longer output


### PR DESCRIPTION
## Implementato

Root-caused why run 28802314827 (section=frontaliere, 55min budget, 2026-07-06) published nothing despite the job showing green. Reconstructed the attempt-by-attempt sequence from the run log:

1. Attempt nominal \`gpt-4o\` → cascaded to \`local/fallback\` (qwen2.5:14b via Ollama, ~17.5min) → succeeded but content too short (214 words vs 900 required) → outer word-count gate rejected, regenerated.
2. Attempt nominal \`gpt-4.1\` → cascaded to \`local/fallback\` again (~12.5min) → succeeded, but discarded by a **self-contradicting REGOLA #0 topic-gate abort**: the model set \`abort_topical_relevance: true\` while its own \`reason\` text affirmed frontaliere relevance, and it ALSO returned a fully populated, valid \`content.it\` — violating the schema's own documented either/or contract (abort-with-null-content XOR content-with-null-abort).
3. Attempt nominal \`gpt-4.1-nano\` → cascaded to \`local/fallback\` a third time, but by now only ~5.5min of the run's wall-clock budget remained (needs 12-17min) → hard timeout mid-inference, zero output.
4. Remaining rotation slots failed near-instantly; run ended in \`no_changes_streak_5_backoff_600s\` — no article committed.

Confirmed via \`git merge-base --is-ancestor\` that PR #3684 (merged the same day, grounds organic/news mode against local-model fact-check mismatches) was already present in the commit this run executed against — it did not cover either failure mode below, so this is genuinely additional work, not a duplicate fix.

Three targeted fixes in \`scripts/create-article.mjs\` (GitNexus impact confirmed LOW risk — single-file blast radius, no \`ai-models.mjs\` changes):

- **Topic-gate self-contradiction guard** (\`callGemini\`, REGOLA #0 abort gate): now checks whether \`content.it\` is actually populated *before* honoring \`abort_topical_relevance === true\`. When content is present the model contradicted its own abort signal — the fix trusts the content it produced over the flag and falls through to normal validation (still gated by the existing \`validateItalianPayload\`/\`llmFactCheck\` defense-in-depth) instead of discarding a valid, on-topic article. A genuine abort (no content produced) still throws exactly as before. New \`RUN_REPORT.topicGateSelfContradictions\` counter for visibility.
- **Wall-clock guard for the local-only cascade** (\`generateAndValidateArticle\`'s retry loop): \`_localFallbackUsedThisHeadline\` (set inside the \`callLLM\` wrapper whenever \`modelUsedRef.model === AI_MODELS.LOCAL_FALLBACK\`) tracks whether local/fallback has already served a request *for the current headline*. Once it has, and wall-clock remaining drops below \`LOCAL_MIN_VIABLE_MS\` (11min), the loop breaks out cleanly with a \`qualityReject\`-tagged error instead of starting a doomed attempt that would timeout mid-inference.
- **Per-headline scope fix** (🔴 round-2 review): renamed flag from \`_localFallbackUsedThisRun\` to \`_localFallbackUsedThisHeadline\` and reset it at the top of \`generateAndValidateArticle\`. The original module-level flag was never reset between headlines — a cascade from a previous headline's \`callLLM\` (or headline-selection / \`translateArticle\`) would arm the guard for a brand-new headline before its cloud models were even tried, reproducing the zero-publish failure via a different path. Scoping to per-headline invocation fixes the bleed-over. 87 vitest tests green.

## Non implementato (ancora)

Nessuno.

(Known adjacent gap, not part of this fix's scope and not blocking: \`cloudCascadeExhausted\`'s Firestore-score-based check still can't independently detect per-request token-size cascades ahead of time — \`_localFallbackUsedThisHeadline\` is a reactive, after-the-fact complement to it, not a replacement. Closing the score-based blind spot entirely would require instrumenting the shared, HIGH-risk \`ai-models.mjs\` cascade walk itself — deliberately out of reach for this fix per the GitNexus risk assessment.)