### PR TITLE
feat(eventi): reverse lavoro -> evento crosslink (follow-up, issue 3646)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -32,6 +32,10 @@ import { shouldEmitLocale } from './shared/localeEmitFilter';
 import { jobDescriptionTextToHtml, inlineTextToHtml } from './shared/jobDescription/toHtml';
 import { markCantonNoindex } from './shared/cantonNoindexRegistry';
 import { markCantonSectorPage } from './shared/cantonSectorPageRegistry';
+// Reverse crosslink lavoro -> evento (#3646, epic #3125) — the item PR #3696
+// declared open. Isolated module reusing eventsSeoPagesPlugin's own data
+// primitives (AGENTS.md §6); see build-plugins/shared/jobEventsCrosslink.ts.
+import { nearbyEventsBlockForJobPage } from './shared/jobEventsCrosslink';
 import { EJP_STRIPPED_MARKER } from './shared/ejpMarker';
 import { WriteCollector } from './batchWrite';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
@@ -5958,6 +5962,7 @@ ${staticAnalyticsHtml}
  <h2 class="s-iEVPhz">${esc(locale === 'it' ? `Settori a ${location}` : locale === 'en' ? `Sectors in ${location}` : locale === 'de' ? `Branchen in ${location}` : `Secteurs a ${location}`)}</h2>
  <div class="s-J2fKgL">${sectorLinks}</div>
  </section>
+ ${nearbyEventsBlockForJobPage(locale, 'TI', location, getCantonDisplayLabel('TI', locale))}
  ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location }))}
  </main>${railGutters(true).close}
  <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
@@ -6663,7 +6668,7 @@ ${staticAnalyticsHtml}
    : locale === 'de' ? `Stellenangebote in ${cityDisplay}`
    : `Offres d'emploi à ${cityDisplay}`;
  const tilesHtml = `<section class="s-S6PRaY"><div class="s-CGuDZg"><div class="s-JFi4vt">${esc(jobCountLabel)}</div><div class="s-9UotdJ">${cityJobs.length}</div></div><div class="s-3kP_AL"><div class="s-z4q8yI">${esc(cantonTileLabel)}</div><div class="s-9UotdJ">${esc(canton)}</div></div><div class="s-3kP_AL"><div class="s-z4q8yI">${esc(permitTileLabel)}</div><div class="s-9UotdJ">G</div></div></section>`;
- const bodyHtml = `<header class="s-S_0cal sx-hero"><p class="s-zNiFzy sx-kick">${esc(formatUpdatedSentence(updatedDate, locale))}</p><h1 class="s-P0Hs0W">${esc(cityHubSeo.h1)}</h1><p class="s-wU5Nrr">${esc(pageDesc)}</p>${intro}</header>${tilesHtml}<section class="s-KZc0LQ"><div class="s-r2QmTP"><h2 class="s-CqexyJ">${esc(listHeading)}</h2><a class="s-YszcPD" href="${sectionRootUrl}">${esc(backLabel)}</a></div><ul class="s-0WjlyL">${listHtml}</ul></section>${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
+ const bodyHtml = `<header class="s-S_0cal sx-hero"><p class="s-zNiFzy sx-kick">${esc(formatUpdatedSentence(updatedDate, locale))}</p><h1 class="s-P0Hs0W">${esc(cityHubSeo.h1)}</h1><p class="s-wU5Nrr">${esc(pageDesc)}</p>${intro}</header>${tilesHtml}<section class="s-KZc0LQ"><div class="s-r2QmTP"><h2 class="s-CqexyJ">${esc(listHeading)}</h2><a class="s-YszcPD" href="${sectionRootUrl}">${esc(backLabel)}</a></div><ul class="s-0WjlyL">${listHtml}</ul></section>${nearbyEventsBlockForJobPage(locale, canton, cityDisplay, cDisplay)}${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
  // Use buildSeoPageHtml (NOT buildSimplePage) so the page emits
  // `<main class="seo-static-content">` OUTSIDE `<div id="root">` +
  // `<div id="footer-root"></div>`. The legacy path (buildSimplePage default

--- a/build-plugins/shared/jobEventsCrosslink.ts
+++ b/build-plugins/shared/jobEventsCrosslink.ts
@@ -1,0 +1,190 @@
+/**
+ * Reverse crosslink: job-listing SEO pages (`jobsSeoPagesPlugin.ts`) -> nearby
+ * evento pages. Issue #3646 (epic #3125) — the one item PR #3696 declared
+ * open in "Non implementato (ancora)": that PR shipped evento -> lavoro /
+ * comune / articoli crosslinks (`eventsSeoPagesPlugin.ts`), but not the
+ * reverse direction, citing the risk of editing a 12.9k-line/~63%-revenue
+ * file without a dedicated impact analysis.
+ *
+ * Reuses the SAME data + matching primitives the evento pages themselves
+ * use (AGENTS.md #6 — one source of truth, no second comune-matching
+ * implementation): `loadEventsDataset` / `upcomingEvents` / `normalizeText`
+ * / `slugifyComune` / `eventsBasePathForCanton` from
+ * `scripts/lib/events-utils.mjs`. Direction is inverted here: FROM a
+ * job-listing page (comune + canton) TO the matching evento comune page, or
+ * the canton hub page when the comune itself has no upcoming event but the
+ * canton does elsewhere — never the other way.
+ *
+ * Kept isolated in its own module (not inlined into jobsSeoPagesPlugin.ts,
+ * which has zero pre-existing crosslink hook) so the render path only gets
+ * a single interpolated function call per page, not new inline branching in
+ * the revenue-critical file.
+ */
+import {
+  loadEventsDataset,
+  upcomingEvents,
+  normalizeText,
+  slugifyComune,
+  eventsBasePathForCanton,
+} from '../../scripts/lib/events-utils.mjs';
+import { escHtml } from './htmlEscape';
+
+export type CrosslinkLocale = 'it' | 'en' | 'de' | 'fr';
+
+export interface NearbyEventSourceEvent {
+  readonly comune?: string;
+  readonly canton?: string;
+  readonly startDate?: string;
+  readonly endDate?: string;
+}
+
+export type NearbyEventMatch =
+  | { readonly kind: 'comune'; readonly comune: string; readonly canton: string }
+  | { readonly kind: 'canton'; readonly canton: string }
+  | null;
+
+/**
+ * Pure matcher — given an already upcoming-filtered event list, decides
+ * whether `comuneDisplay` (within `canton`) has its own evento(s) worth
+ * linking, falls back to the canton hub (events exist elsewhere in the
+ * canton), or has nothing at all (`null`, meaning: render NOTHING — never an
+ * empty/dead crosslink section, Non-Negotiable #4).
+ */
+export function resolveNearbyEventMatch(
+  events: readonly NearbyEventSourceEvent[],
+  canton: string,
+  comuneDisplay: string,
+): NearbyEventMatch {
+  const cantonCode = String(canton || '').toUpperCase().trim();
+  if (!cantonCode) return null;
+  const needle = normalizeText(comuneDisplay);
+  let cantonHasAny = false;
+  let comuneMatch: string | null = null;
+  for (const event of events) {
+    const eventCanton = String(event?.canton || '').toUpperCase().trim();
+    if (eventCanton !== cantonCode) continue;
+    cantonHasAny = true;
+    if (comuneMatch || !needle) continue;
+    if (event?.comune && normalizeText(event.comune) === needle) {
+      comuneMatch = event.comune;
+    }
+  }
+  if (comuneMatch) return { kind: 'comune', comune: comuneMatch, canton: cantonCode };
+  if (cantonHasAny) return { kind: 'canton', canton: cantonCode };
+  return null;
+}
+
+const HEADING: Record<CrosslinkLocale, string> = {
+  it: 'Eventi vicino a te',
+  en: 'Events near you',
+  de: 'Veranstaltungen in deiner Nähe',
+  fr: 'Événements près de chez vous',
+};
+
+function comuneLabel(locale: CrosslinkLocale, comune: string): string {
+  switch (locale) {
+    case 'en':
+      return `See events in ${comune}`;
+    case 'de':
+      return `Veranstaltungen in ${comune} entdecken`;
+    case 'fr':
+      return `Découvrir les événements à ${comune}`;
+    case 'it':
+    default:
+      return `Scopri gli eventi a ${comune}`;
+  }
+}
+
+function cantonLabel(locale: CrosslinkLocale, cantonDisplay: string): string {
+  switch (locale) {
+    case 'en':
+      return `See events in ${cantonDisplay}`;
+    case 'de':
+      return `Veranstaltungen in ${cantonDisplay} entdecken`;
+    case 'fr':
+      return `Découvrir les événements en ${cantonDisplay}`;
+    case 'it':
+    default:
+      return `Scopri gli eventi in ${cantonDisplay}`;
+  }
+}
+
+/** Render-ready link: href + label already resolved for one locale. */
+export interface NearbyEventLink {
+  readonly href: string;
+  readonly label: string;
+}
+
+export function toNearbyEventLink(
+  match: NearbyEventMatch,
+  locale: CrosslinkLocale,
+  cantonDisplay: string,
+): NearbyEventLink | null {
+  if (!match) return null;
+  const base = eventsBasePathForCanton(match.canton)[locale];
+  if (!base) return null;
+  if (match.kind === 'comune') {
+    return {
+      href: `${base}/${slugifyComune(match.comune)}/`,
+      label: comuneLabel(locale, match.comune),
+    };
+  }
+  return {
+    href: `${base}/`,
+    label: cantonLabel(locale, cantonDisplay),
+  };
+}
+
+/**
+ * Full pure render — given an explicit event list, resolves the match and
+ * renders the HTML block. Returns `''` when there is nothing to link
+ * (Non-Negotiable #4: no empty/dead section ever rendered).
+ */
+export function renderNearbyEventsBlock(
+  events: readonly NearbyEventSourceEvent[],
+  locale: CrosslinkLocale,
+  canton: string,
+  comuneDisplay: string,
+  cantonDisplay: string,
+): string {
+  const match = resolveNearbyEventMatch(events, canton, comuneDisplay);
+  const link = toNearbyEventLink(match, locale, cantonDisplay);
+  if (!link) return '';
+  return `<section class="mt-8"><h2 class="text-lg font-semibold text-heading mb-3">${escHtml(HEADING[locale])}</h2><a class="inline-flex items-center gap-2 rounded-md border border-edge bg-surface-raised px-4 py-3 text-sm font-semibold text-heading transition-colors hover:border-accent-border hover:text-accent" href="${escHtml(link.href)}">${escHtml(link.label)} &rarr;</a></section>`;
+}
+
+let cachedUpcomingEvents: NearbyEventSourceEvent[] | null = null;
+
+function getUpcomingEventsCached(): NearbyEventSourceEvent[] {
+  if (!cachedUpcomingEvents) {
+    const dataset = loadEventsDataset();
+    cachedUpcomingEvents = upcomingEvents(dataset.events ?? []) as NearbyEventSourceEvent[];
+  }
+  return cachedUpcomingEvents;
+}
+
+/**
+ * Production entry point — the two per-comune render loops in
+ * `jobsSeoPagesPlugin.ts` call this directly, interpolating the result
+ * inline. Loads + filters `data/events.json` once per build process
+ * regardless of how many hundred comune pages call it.
+ */
+export function nearbyEventsBlockForJobPage(
+  locale: CrosslinkLocale,
+  canton: string,
+  comuneDisplay: string,
+  cantonDisplay: string,
+): string {
+  return renderNearbyEventsBlock(
+    getUpcomingEventsCached(),
+    locale,
+    canton,
+    comuneDisplay,
+    cantonDisplay,
+  );
+}
+
+/** Test-only reset for the module-level dataset cache. */
+export function __resetNearbyEventsCacheForTests(): void {
+  cachedUpcomingEvents = null;
+}

--- a/tests/job-events-crosslink.test.ts
+++ b/tests/job-events-crosslink.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveNearbyEventMatch,
+  toNearbyEventLink,
+  renderNearbyEventsBlock,
+  nearbyEventsBlockForJobPage,
+  type NearbyEventSourceEvent,
+} from '../build-plugins/shared/jobEventsCrosslink';
+
+// Issue #3646 (epic #3125) — reverse lavoro -> evento crosslink, the one
+// item PR #3696 declared open. Fixture events use no absolute dates (the
+// matcher itself is date-agnostic; date filtering happens upstream via
+// `upcomingEvents`, already covered by events-utils tests) — AGENTS.md
+// "test fixture: mai date assolute" applies to stale-prune windows, not to
+// this matcher, but we still avoid literal dates here on principle.
+const FIXTURE_EVENTS: NearbyEventSourceEvent[] = [
+  { comune: 'Lugano', canton: 'TI' },
+  { comune: 'Bellinzona', canton: 'TI' },
+  { comune: 'Zurich', canton: 'ZH' },
+];
+
+describe('resolveNearbyEventMatch', () => {
+  it('matches at comune level when the comune itself has an event', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'TI', 'Lugano');
+    expect(match).toEqual({ kind: 'comune', comune: 'Lugano', canton: 'TI' });
+  });
+
+  it('matches diacritics/case-insensitively (normalizeText)', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'ti', 'lugano');
+    expect(match).toEqual({ kind: 'comune', comune: 'Lugano', canton: 'TI' });
+  });
+
+  it('falls back to canton level when the comune has no event but the canton does (Chiasso real-data case: 0 events, TI has 137)', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'TI', 'Chiasso');
+    expect(match).toEqual({ kind: 'canton', canton: 'TI' });
+  });
+
+  it('returns null when the canton itself has no upcoming event at all', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'GE', 'Geneve');
+    expect(match).toBeNull();
+  });
+
+  it('returns null for an empty/blank canton', () => {
+    expect(resolveNearbyEventMatch(FIXTURE_EVENTS, '', 'Lugano')).toBeNull();
+  });
+});
+
+describe('toNearbyEventLink', () => {
+  it('returns null when there is no match (never renders a dead link)', () => {
+    expect(toNearbyEventLink(null, 'it', 'Ticino')).toBeNull();
+  });
+
+  it('builds a comune-scoped href + localized label per locale', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'TI', 'Lugano');
+    const it = toNearbyEventLink(match, 'it', 'Ticino');
+    const en = toNearbyEventLink(match, 'en', 'Ticino');
+    const de = toNearbyEventLink(match, 'de', 'Ticino');
+    const fr = toNearbyEventLink(match, 'fr', 'Ticino');
+
+    expect(it).toEqual({ href: '/eventi/ticino/lugano/', label: 'Scopri gli eventi a Lugano' });
+    expect(en).toEqual({ href: '/en/events/ticino/lugano/', label: 'See events in Lugano' });
+    expect(de).toEqual({
+      href: '/de/veranstaltungen/tessin/lugano/',
+      label: 'Veranstaltungen in Lugano entdecken',
+    });
+    expect(fr).toEqual({
+      href: '/fr/evenements/tessin/lugano/',
+      label: 'Découvrir les événements à Lugano',
+    });
+  });
+
+  it('builds a canton-hub href + localized label when falling back', () => {
+    const match = resolveNearbyEventMatch(FIXTURE_EVENTS, 'TI', 'Chiasso');
+    const link = toNearbyEventLink(match, 'it', 'Ticino');
+    expect(link).toEqual({ href: '/eventi/ticino/', label: 'Scopri gli eventi in Ticino' });
+  });
+});
+
+describe('renderNearbyEventsBlock', () => {
+  it('renders nothing (empty string) when there is no matching event — no empty/dead section', () => {
+    const html = renderNearbyEventsBlock(FIXTURE_EVENTS, 'it', 'GE', 'Geneve', 'Ginevra');
+    expect(html).toBe('');
+  });
+
+  it('renders a section with heading + link when a comune match exists', () => {
+    const html = renderNearbyEventsBlock(FIXTURE_EVENTS, 'it', 'TI', 'Lugano', 'Ticino');
+    expect(html).toContain('Eventi vicino a te');
+    expect(html).toContain('/eventi/ticino/lugano/');
+    expect(html).toContain('Scopri gli eventi a Lugano');
+    expect(html.startsWith('<section')).toBe(true);
+  });
+
+  it('escapes comune names that contain HTML-sensitive characters', () => {
+    const evilEvents: NearbyEventSourceEvent[] = [{ comune: '<b>Evil</b>', canton: 'XX' }];
+    const html = renderNearbyEventsBlock(evilEvents, 'it', 'XX', '<b>Evil</b>', '<b>Evil</b>');
+    expect(html).not.toContain('<b>Evil</b>');
+    expect(html).toContain('&lt;b&gt;Evil&lt;/b&gt;');
+  });
+});
+
+describe('nearbyEventsBlockForJobPage (production cached wrapper, real dataset smoke test)', () => {
+  it('returns a string without throwing for a canton/comune with no real events (e.g. a made-up one)', () => {
+    const html = nearbyEventsBlockForJobPage('it', 'ZZ', 'Nowhere', 'Nowhere');
+    expect(typeof html).toBe('string');
+    expect(html).toBe('');
+  });
+
+  it('does not throw for a real canton code + comune combination (dataset is live/mutable, so no content assertion — only wiring is under test here, matching logic is covered by the pure-function tests above)', () => {
+    const html = nearbyEventsBlockForJobPage('it', 'TI', 'ThisComuneDoesNotExist', 'Ticino');
+    expect(typeof html).toBe('string');
+  });
+});


### PR DESCRIPTION
## Implementato

- Reverse crosslink direction for epic #3125 "eventi": job-listing SEO pages -> nearby evento pages. This is the one item PR #3696 (F4) declared open in its own `## Non implementato (ancora)`, on issue 3646 (already closed by #3696 — no `Closes` keyword used here, referenced in prose per AGENTS.md).
- Manual impact analysis before editing `build-plugins/jobsSeoPagesPlugin.ts` (12.9k lines, ~63% site revenue): GitNexus does not index this specific file (confirmed via `cypher` query returning empty vs a hit for the sibling `eventsSeoPagesPlugin.ts`/`jobSectorPagesPlugin.ts` — a structural indexing gap for this one large file, not a staleness issue). Fell back to manual analysis: exactly one real importer (`vite.config.ts`), no golden/snapshot test covers the touched `bodyHtml` templates (`tests/jobs-seo-pages-plugin.test.ts` only tests narrow named exports), and the existing 195KB byte-budget hard-fail guard has ample headroom for the ~300 byte addition. Risk assessed LOW-MEDIUM — no HIGH/CRITICAL finding, so proceeded per the task's own conditional.
- New isolated module `build-plugins/shared/jobEventsCrosslink.ts`: reuses the events side's own data primitives from `scripts/lib/events-utils.mjs` (`loadEventsDataset`, `upcomingEvents`, `normalizeText`, `slugifyComune`, `eventsBasePathForCanton`) instead of re-implementing comune matching (AGENTS.md §6 — one source of truth). No changes needed to `eventsSeoPagesPlugin.ts` or `events-utils.mjs` themselves, and no cross-plugin import (avoids coupling the two SSG plugins).
- Renders exactly one "Eventi vicino a te" link per per-comune job page: comune-level match when the comune itself has an upcoming event, canton-level fallback when it doesn't (verified against real data: Chiasso has 0 events in TI's current dataset, 137 total in TI overall — correctly falls back to "Eventi in Ticino"), nothing at all when the canton has none (no empty/dead section, Non-Negotiable #4). All label/heading/href copy is a `Record<locale,string>` map per locale — never a single string reused across the 4 locale bodies (this exact bug class was fixed 3x already on this task's lineage: #3686, #3694, and inside #3696 itself).
- Wired into the two per-comune job-listing render loops that exist in `jobsSeoPagesPlugin.ts` — the TI legacy 5-city editorial loop (canton hardcoded `'TI'`) and the non-TI per-canton city-hub loop (using the in-scope `canton`/`cDisplay`/`cityDisplay`/`locale` variables) — matching PR #3696's own declared minimal scope ("singolo link contestuale 'eventi in [comune]' nelle pagine lavoro per-comune").
- Sibling-pattern-fix pass (AGENTS.md §6): checked `jobSectorPagesPlugin.ts`, `jobOrphanBridgePlugin.ts`, `jobEditorialLanding.ts`, `jobRecencyPagesPlugin.ts`, `jobMarketSnapshotPlugin.ts` — none contain a per-comune job-listing render loop (they render sector/canton pages, noindex bridges, job-detail helpers, recency-filtered listings, and analytics pages respectively — a different page taxonomy, not the "pagine lavoro per-comune" this issue scoped). Not extended to them; flagged here as a genuine out-of-scope finding, not a deferred bug.
- New test file `tests/job-events-crosslink.test.ts` (13 tests, all green): comune-level match, canton-fallback match (including the real Chiasso 0-events case), no-match renders nothing, per-locale href/label correctness for all 4 locales, HTML escaping, and a non-throwing smoke test of the production cached wrapper against the real dataset (no content assertion there since the dataset is live/mutable, not a fixture).
- `npx tsc --noEmit`: zero new errors — confirmed none of the pre-existing repo-wide tsc errors reference `jobsSeoPagesPlugin.ts`, the new module, or the new test file.
- Targeted vitest green: `tests/job-events-crosslink.test.ts`, `tests/jobs-seo-pages-plugin.test.ts`, `tests/jobs-seo-editorial-below-floor-bridge.test.ts`, `tests/jobs-seo-title-h1-datemodified.test.ts`, `tests/events-pipeline.test.ts` — 107+ tests, no regressions.
- Translation copy: kept local to the new build-plugin module (`Record<locale,string>` literals), following the established precedent of `eventsSeoPagesPlugin.ts`'s own `CROSSLINKS`/copy objects, which define their locale copy the same way rather than routing through `services/locales/*-core.ts` — these are SSG-emitted static pages, a different rendering pipeline from the React SPA that consumes those locale files.

## Non implementato (ancora)

Nessuno.