### PR TITLE
research(create-article): eval local-LLM rewrite for amplificazione — reject (#3656)

### DIFF
--- a/docs/LOCAL-OPEN-MODELS-STUDY.md
+++ b/docs/LOCAL-OPEN-MODELS-STUDY.md
@@ -210,6 +210,180 @@ remoto finché il tier locale non è validato.
 
 ---
 
+## 8. Issue #3656 — Eval mirata: solo la sotto-fase di riscrittura/ampliamento
+
+**Data: 2026-07-06.** Segue #3090 (`## 5` sopra), che aveva bocciato un
+tentativo di generazione locale (qwen2.5:7b, prompt "espandi con nuovi
+contenuti", run 28371401498) per due motivi: budget di 55min sforato + una
+riscrittura che aveva inventato un riferimento normativo fiscale inesistente.
+#3656 chiede una domanda più stretta: **non generazione da zero**, ma solo
+la sotto-fase di *riscrittura/allungamento* di un articolo già generato che
+è risultato troppo corto (oggi `expandShortItalianContent` in
+`scripts/create-article.mjs`, via remoto) — con modelli locali più piccoli/
+veloci e uno scope esplicitamente "zero fatti nuovi", verificato dallo stesso
+gate `llmFactCheck` di produzione (non un'approssimazione).
+
+### Metodologia
+
+- Harness: `scripts/eval-local-rewrite-llm.mjs` (nuovo file, incluso in questa
+  PR come artefatto di ricerca riusabile).
+- Riusa il path reale di produzione: `callLLM(messages, {model:
+  AI_MODELS.LOCAL_FALLBACK, chain: [AI_MODELS.LOCAL_FALLBACK]})` da
+  `scripts/lib/ai-models.mjs` per la generazione, e la funzione reale
+  `llmFactCheck` (ri-esportata da `create-article.mjs` — pure re-export, zero
+  cambio di comportamento per il caller interno di produzione) per la verifica
+  — stesse regole di blocco (consenso, categorie high-trust, soglia di peso
+  major ≥3.0) usate in produzione oggi.
+- 5 campioni **reali**, presi da `services/locales/blog-body/it/*.ts` (body1
+  pubblicato), scelti per diversità di dominio: fiscale
+  (`730-precompilato-frontalieri-ticino-2026`, lo stesso dominio che aveva
+  fatto fallire #3090), UE/politico (`accordi-svizzera-ue-parmelin-bruxelles`),
+  sanitario/legale (`assicurazione-dentaria-obbligatoria-ticino-2026`),
+  infrastrutturale (`autostrada-a9-disagi-frontalieri`), sociale
+  (`adulti-genitori-sostegno-finanziario-ticino-2026`). Ogni campione troncato
+  al ~58-65% a un confine di paragrafo, per simulare una bozza sotto-lunghezza
+  realistica da amplificare.
+- Prompt di riscrittura **deliberatamente più stretto** di quello di
+  produzione (`expandShortItalianContent` oggi chiede esplicitamente di
+  *aggiungere* contenuto — mismatch con lo scope "zero fatti nuovi" richiesto
+  dall'issue, ed è probabilmente parte della causa dell'allucinazione fiscale
+  in #3090): "riformula con parole diverse, NON introdurre alcun fatto/nome/
+  cifra/data/percentuale nuovo, puoi allungare solo con connettivi/
+  spiegazioni/transizioni che non aggiungono informazione".
+- 3 modelli candidati via Ollama locale: `qwen2.5:0.5b`, `qwen2.5:1.5b`,
+  `qwen2.5:3b` — tutti sensibilmente più piccoli/veloci del `qwen2.5:7b` di
+  #3090, per testare l'ipotesi "modello più piccolo + scope più stretto
+  compensa la propensione a inventare".
+- **Gruppo di controllo per campione**: fact-check sull'input troncato **non
+  riscritto** (zero modifiche del modello) — separa "il gate è di suo severo
+  su questo dominio/campione" da "il modello ha introdotto un'allucinazione
+  reale". Necessario per interpretare correttamente i FAIL.
+- Euristica supplementare (debole, solo indicativa): conteggio di "nuovi
+  token-fatto" (importi CHF, percentuali, anni, riferimenti `art.`, decimali)
+  assenti dall'input — si è rivelata poco efficace nel catturare le vere
+  allucinazioni osservate (nomi/istituzioni/persone inventate), che non sono
+  numeriche; il verdetto autorevole resta `llmFactCheck`.
+
+### Caveat espliciti di fedeltà
+
+- **GPU/Metal (sandbox Mac) vs CPU-only (runner self-hosted di produzione,
+  `docs/SELFHOSTED-RUNNER.md`)**: Ollama in questo sandbox carica i modelli su
+  GPU Metal (confermato via `/api/ps`) — i tempi misurati sono ottimistici
+  rispetto al runner CPU-only reale. Non è stato possibile forzare CPU-only
+  attraverso il path reale di produzione: `_callOpenAICompatible` in
+  `ai-models.mjs` costruisce un body di richiesta a forma fissa
+  (`model/messages/temperature/max_tokens/response_format`), senza
+  pass-through per opzioni Ollama-specifiche come `options.num_gpu`. Anche
+  stimando un fattore 5-10× più lento su CPU-only, i tempi restano ordini di
+  grandezza sotto al budget che aveva fatto fallire #3090 (vedi tabella sotto).
+- **Fact-check con una sola famiglia di verificatori**: in questo sandbox non
+  è disponibile un `GH_MODELS_PAT` → la cascata di verifica di `llmFactCheck`
+  è stata soddisfatta solo da modelli Gemini/Gemma (i primi due verificatori
+  configurati sono spesso esausti per quota/timeout nella sessione, con
+  fallback automatico più in basso nella chain). Le regole di blocco sono le
+  stesse di produzione, ma in produzione il set di verificatori reale è più
+  ampio (GPT-4.1/4o + famiglia Gemini) — un consenso a 2 famiglie diverse è
+  potenzialmente più severo o più permissivo di quanto misurato qui.
+
+### Risultati misurati (run completo, 15 trial riscrittura+fact-check + 5 controlli)
+
+```
+CONTROLLO (input troncato, zero riscrittura): fact-check 4/5 PASS
+(l'unico FAIL di controllo — accordi-svizzera-ue — indica che quel campione
+è già borderline per il gate indipendentemente da qualunque modello)
+
+qwen2.5:0.5b: media 11.3s/call | fact-check 3/5 PASS (60%) | 0 errori
+qwen2.5:1.5b: media 14.7s/call | fact-check 2/5 PASS (40%) | 0 errori
+qwen2.5:3b:   media 27.0s/call | fact-check 1/5 PASS (20%) | 0 errori
+
+Totale reale: 6/15 trial PASS (40%) — nessun errore infra, nessun timeout.
+```
+
+Confronto diretto con #3090: **il problema del tempo è risolto.** Anche il
+modello più lento testato (3b, 27.0s/call medi) è ~100× più veloce del
+qwen2.5:7b che aveva sforato un budget di 55 minuti. Il problema del
+**fact-check non lo è**: il tasso di successo (40% complessivo) è ben sotto
+la soglia "zero fallimenti" richiesta per considerare l'integrazione, e
+**peggiora** al crescere del modello (0.5b: 60% → 1.5b: 40% → 3b: 20%) — il
+modello più piccolo testato è risultato il più "conservativo"/sicuro dei tre,
+non il meno capace: contro-intuitivo rispetto all'assunto "modello più grande
+= più sicuro", ma coerente con l'osservazione che un modello locale più
+fluente è anche più incline a "riempire" con dettagli plausibili quando gli
+viene chiesto di raggiungere una lunghezza target (vedi `## 5` caveat sopra,
+già annotato prima di questo eval).
+
+### Allucinazioni osservate (stesso pattern di #3090, su modelli diversi)
+
+- **`assicurazione-dentaria-obbligatoria-ticino-2026`** (controllo: PASS
+  pulito) — **tutti e 3** i candidati hanno inventato un/a politico/a
+  ticinese inesistente con relativa citazione tra virgolette:
+  `qwen2.5:0.5b` → *"Raffaella Zucchetti, granconsigliera della Lega, ha
+  affermato: «Questa iniziativa...»"*; `qwen2.5:1.5b` e `qwen2.5:3b` →
+  *"Raide Bassi, deputata UDC in Gran Consiglio, ha dichiarato: «Parliamo di
+  un costo...»"*. Il fact-check reale (categoria `persone`, high-trust
+  critical) ha bloccato tutte e 3 le generazioni. Nessuno di questi nomi
+  esiste nella fonte troncata data in input — allucinazione genuina del
+  modello, non un artefatto del checker (il controllo passa pulito).
+- **`730-precompilato-frontalieri-ticino-2026`** (dominio fiscale, lo stesso
+  di #3090) — `qwen2.5:3b` ha ripetuto **esattamente lo stesso tipo di
+  errore** del tentativo precedente: *"Tutte le regole sono definite da un
+  provvedimento firmato dal direttore dell'Agenzia [...] Vincenzo Carbone"* —
+  nome inventato/obsoleto (il direttore reale è Ernesto Maria Ruffini),
+  bloccato per consenso su categoria high-trust `persone`. `qwen2.5:0.5b` ha
+  passato con soli warning; `qwen2.5:1.5b` è stato bloccato per soglia di peso
+  major (8.0 ≥ 3.0) su ripetute segnalazioni di `rilevanza_topica` da un solo
+  verificatore — un modo di fallire diverso (non un'invenzione fattuale, ma
+  contenuto giudicato non pertinente al titolo/focus frontalieri).
+- **`accordi-svizzera-ue-parmelin-bruxelles`** (controllo: già FAIL) — tutti
+  e 3 i modelli hanno aggiunto le stesse tre voci fittizie in stile
+  "Fatti chiave" (*"Investimenti Lugano: 150 milioni di franchi nel 2025"*,
+  *"Scadenza documentazione: 30 aprile di ogni anno"*, *"Data seminario: 15
+  novembre 2023"*), assenti dal controllo/input. Pattern distinto dalle altre
+  due invenzioni: sembra "list-continuation" — il modello, sotto pressione di
+  raggiungere la lunghezza target e trovandosi davanti a un elenco puntuale di
+  fatti nel testo originale, lo estende con voci fittizie nello stesso
+  formato "Etichetta: valore", indipendentemente dalla taglia del modello.
+- **`autostrada-a9-disagi-frontalieri`** — unico campione pulito su tutti e 3
+  i modelli (fact-check PASS, solo warning minori di elaborazione data/
+  attribuzione, già presenti anche nel controllo). L'euristica di "nuovi
+  token-fatto" aveva segnalato 2 falsi positivi qui (`qwen2.5:0.5b`, token
+  "102, 96" da un'elaborazione di data non bloccante) — conferma che
+  l'euristica supplementare è rumorosa e il verdetto autorevole resta
+  `llmFactCheck`.
+- **`adulti-genitori-sostegno-finanziario-ticino-2026`** — `0.5b` e `1.5b`
+  passano (quest'ultimo con warning su un errore ortografico e un termine
+  giudicante introdotti in riscrittura); `3b` bloccato per un critical isolato
+  di `rilevanza_topica` (forzatura del nesso col target frontalieri) — di
+  nuovo non un'invenzione di fatto, ma un problema di pertinenza.
+
+### Decisione: RIGETTO — non integrare (nessun flag, nessun cambio di
+`create-article.mjs` in produzione)
+
+Il tempo **non è più un ostacolo** per nessuno dei 3 candidati testati. Ma il
+tasso di successo del fact-check (40% complessivo, in peggioramento al
+crescere della taglia del modello) è troppo lontano dalla barra "zero
+fallimenti" richiesta per l'integrazione, e le allucinazioni osservate
+replicano **la stessa classe di errore** documentata come motivo di rigetto
+in #3090 (persone/istituzioni inventate su contenuto fiscale/legale/sanitario)
+— nonostante un prompt deliberatamente più stretto ("zero fatti nuovi") e
+modelli molto più piccoli. Il gate `llmFactCheck` ha catturato correttamente
+100% delle allucinazioni reali osservate (nessun falso negativo rilevato) —
+la sicurezza del gate non è in discussione, è il motivo per cui questo rigetto
+è possibile senza rischio per la qualità editoriale pubblicata. Un tasso di
+rejection del 60% renderebbe inoltre il local-rewrite-tier controproducente
+anche solo come primo tentativo in un retry loop: la maggior parte dei
+tentativi verrebbe scartata dal gate, consumando comunque il retry budget
+prima di ricadere sul remoto.
+
+**Non tentare di nuovo con questi stessi modelli/prompt.** Un nuovo tentativo
+avrebbe senso solo con: (a) modelli locali specificamente fine-tuned per
+fedeltà-al-testo/riassunto estrattivo (non generazione libera), o (b) un
+approccio non generativo per l'allungamento (es. espansione a livello di
+frase/sinonimi con librerie NLP deterministiche, senza free-generation) — non
+esplorati in questo eval, entrambi fuori scope per #3656 così come definito.
+
+---
+
 ## Fonti
 
 - [GLM-4.6 open weights & hardware (IntuitionLabs)](https://intuitionlabs.ai/articles/glm-4-6-open-source-coding-model)

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -9554,6 +9554,12 @@ export { translateArticle, enforceStrongInternalLinks, findBestFallbackImage, pi
 // candidates the shared pipeline above still expects.
 export { normalizeTitleCasing, collapseShoutingTitle, generateExcerpt, splitBodyIntoSections, findStockImageCandidates };
 
+// Re-exported so eval/research harnesses (e.g. the local-LLM rewrite eval,
+// issue #3656) can run the SAME blocking fact-check gate used in production
+// against candidate output, instead of re-implementing an approximation of
+// it. Pure re-export — no behavior change for the internal caller above.
+export { llmFactCheck };
+
 // Only run the AI generation pipeline when invoked directly as a CLI — importing
 // this module (to reuse registerArticleFiles/buildBodyFile) must NOT execute it.
 const invokedDirectly = (() => {

--- a/scripts/eval-local-rewrite-llm.mjs
+++ b/scripts/eval-local-rewrite-llm.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Eval harness — issue #3656 (local LLM for the amplificazione/rewrite step)
+ *
+ * Measures wall-clock + fact-check pass rate for candidate local Ollama
+ * models on a REWRITE-ONLY task (paraphrase/expand an existing article body
+ * back toward its original length, adding ZERO new facts), using real
+ * production article samples and the real blocking `llmFactCheck` gate
+ * (re-exported from create-article.mjs for this purpose).
+ *
+ * Prior attempt (documented in issue #3090, GH run 28371401498): qwen2.5:7b
+ * via the *expansion* prompt that asks the model to ADD new concrete
+ * examples/dates/amounts — too slow (>55min budget) AND hallucinated tax law.
+ * This eval deliberately narrows the task to pure rewrite (owner's stated
+ * fix per #3656) and tests smaller/faster models.
+ *
+ * Usage:
+ *   node scripts/eval-local-rewrite-llm.mjs [--models=qwen2.5:0.5b,qwen2.5:1.5b,qwen2.5:3b] [--samples=5]
+ *
+ * Requires: `ollama serve` running locally with the candidate models pulled,
+ * and GEMINI_API_KEY set (only verifier model available without a
+ * GH_MODELS_PAT in this environment — llmFactCheck degrades gracefully to
+ * single-model consensus, same as a GitHub Models outage in production).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { callLLM, AI_MODELS } from './lib/ai-models.mjs';
+import { llmFactCheck } from './create-article.mjs';
+
+const SAMPLE_DIR = 'services/locales/blog-body/it';
+// Diverse real published articles incl. one squarely in the domain that
+// hallucinated last time (frontaliere tax law: 730-precompilato).
+const SAMPLE_FILES = [
+  '730-precompilato-frontalieri-ticino-2026.ts',       // frontaliere tax (prior failure domain)
+  'accordi-svizzera-ue-parmelin-bruxelles.ts',          // national/EU relations
+  'assicurazione-dentaria-obbligatoria-ticino-2026.ts', // health insurance/law
+  'autostrada-a9-disagi-frontalieri.ts',                // infrastructure/frontaliere
+  'adulti-genitori-sostegno-finanziario-ticino-2026.ts',// social/financial support
+];
+
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const m = a.match(/^--([^=]+)=(.*)$/);
+  return m ? [m[1], m[2]] : [a.replace(/^--/, ''), true];
+}));
+const MODELS = (args.models || 'qwen2.5:0.5b,qwen2.5:1.5b,qwen2.5:3b').split(',');
+const N_SAMPLES = Number(args.samples || SAMPLE_FILES.length);
+
+function extractField(txt, field) {
+  const re = new RegExp(`'blog\\.article\\.[^']*\\.${field}'\\s*:\\s*'((?:[^'\\\\]|\\\\.)*)'`);
+  const m = txt.match(re);
+  if (!m) return null;
+  return m[1].replace(/\\n/g, '\n').replace(/\\'/g, "'");
+}
+function wc(s) { return (s || '').split(/\s+/).filter(Boolean).length; }
+
+// Truncate at a paragraph boundary to ~targetRatio of the original, so the
+// "draft" looks like a real too-short article body, not a mid-sentence cut.
+function truncateToRatio(text, targetRatio) {
+  const paras = text.split(/\n\n+/);
+  const targetWords = Math.round(wc(text) * targetRatio);
+  let out = [];
+  let acc = 0;
+  for (const p of paras) {
+    if (acc >= targetWords && out.length > 0) break;
+    out.push(p);
+    acc += wc(p);
+  }
+  return out.join('\n\n');
+}
+
+// Number/date/currency tokens — the concrete "facts" a pure-rewrite must not
+// invent. Deliberately broad (catches CHF amounts, %, years, plain numbers).
+function extractFactTokens(text) {
+  const tokens = new Set();
+  const re = /(?:CHF\s?[\d'.,]+|\d+[.,]?\d*\s?%|\b(?:19|20)\d{2}\b|\bart\.\s?\d+[a-z]?\b|\b\d+[.,]\d+\b|\b\d{2,}\b)/gi;
+  let m;
+  while ((m = re.exec(text)) !== null) tokens.add(m[0].toLowerCase().replace(/\s+/g, ' '));
+  return tokens;
+}
+
+function buildRewritePrompt(currentText, currentWords, targetWords) {
+  return `Sei un editor che RISCRIVE un testo giornalistico italiano SENZA aggiungere alcun fatto, numero, data, nome o cifra nuovi.
+
+TESTO DA RISCRIVERE (${currentWords} parole):
+"""
+${currentText}
+"""
+
+REGOLE FERREE:
+1. Riformula le frasi con parole diverse, MA ogni numero/data/nome/cifra/percentuale DEVE comparire ESATTAMENTE come nel testo sopra (stessi valori — nessuna aggiunta, nessuna modifica, nessun arrotondamento diverso).
+2. NON introdurre nessun fatto, esempio, statistica, legge, istituzione, citazione o nome che non sia GIA' presente nel testo sopra.
+3. Puoi allungare le frasi con connettivi, spiegazioni, riformulazioni, transizioni, sinonimi — SOLO se non aggiungono informazione nuova.
+4. Obiettivo lunghezza: circa ${targetWords} parole.
+5. Mantieni la formattazione Markdown esistente (titoli, elenchi, tabelle) e la lingua italiana.
+
+Rispondi SOLO col testo riscritto, nessun commento, nessuna premessa.`;
+}
+
+async function callLocalOllama(model, prompt) {
+  process.env.LOCAL_LLM_ENABLED = '1';
+  process.env.LOCAL_LLM_URL = process.env.LOCAL_LLM_URL || 'http://127.0.0.1:11434/v1/chat/completions';
+  process.env.LOCAL_LLM_MODEL = model;
+  process.env.LOCAL_LLM_TIMEOUT_MS = String(15 * 60_000); // 15min ceiling per call for this eval
+  const t0 = Date.now();
+  // NOTE: reuses the REAL production call shape verbatim (_callOpenAICompatible
+  // builds a fixed { model, messages, temperature, max_tokens } body — no
+  // pass-through for Ollama-specific fields like `options.num_gpu`), so a
+  // --cpu-only flag can't be wired through this path with production fidelity.
+  // This sandbox's Ollama runs Metal-accelerated (Apple Silicon); the
+  // self-hosted runner in docs/SELFHOSTED-RUNNER.md is CPU-only — see the
+  // GPU-vs-CPU caveat in the written eval before treating these numbers as
+  // representative of prod wall-clock.
+  const text = await callLLM(
+    [{ role: 'user', content: prompt }],
+    {
+      model: AI_MODELS.LOCAL_FALLBACK,
+      // Pin the chain to ONLY the local model — without this, a local
+      // timeout/error would silently fall through to a remote model later
+      // in DEFAULT_CHAIN, which would corrupt this eval's wall-clock/verdict
+      // attribution (looking like a fast local pass when a remote model
+      // actually answered).
+      chain: [AI_MODELS.LOCAL_FALLBACK],
+      temperature: 0.4,
+      maxTokens: 3000,
+    },
+  );
+  const elapsedMs = Date.now() - t0;
+  // Unset immediately — llmFactCheck() runs its own callLLM() cascade right
+  // after this, and LOCAL_LLM_ENABLED must not leak into that call (its
+  // internal guard already refuses local-self-verification, but this keeps
+  // the fact-check cascade on remote models by construction, not by relying
+  // on that guard as the only line of defense).
+  delete process.env.LOCAL_LLM_ENABLED;
+  return { text, elapsedMs };
+}
+
+async function main() {
+  console.log(`Models: ${MODELS.join(', ')} | Samples: ${N_SAMPLES}\n`);
+  const results = [];
+
+  const files = SAMPLE_FILES.slice(0, N_SAMPLES);
+  for (const file of files) {
+    const slug = file.replace(/\.ts$/, '');
+    const txt = fs.readFileSync(path.join(SAMPLE_DIR, file), 'utf8');
+    const body1 = extractField(txt, 'body1');
+    if (!body1) { console.warn(`  skip ${file}: no body1 found`); continue; }
+    const originalWords = wc(body1);
+    const truncated = truncateToRatio(body1, 0.58);
+    const truncatedWords = wc(truncated);
+    const targetWords = originalWords; // expand back toward original length
+
+    console.log(`=== ${slug} (${originalWords}w → truncated ${truncatedWords}w, target ${targetWords}w) ===`);
+    const prompt = buildRewritePrompt(truncated, truncatedWords, targetWords);
+    const inputFactTokens = extractFactTokens(truncated);
+
+    // CONTROL: run the fact-check gate on the truncated input verbatim (zero
+    // rewriting), to separate "checker is inherently strict on this domain
+    // (e.g. specific future dates outside its verified-facts baseline)" from
+    // "the candidate model introduced a new hallucination." Without this,
+    // a FAIL on tax-law content could be wrongly blamed on the local model
+    // when the same source text would also fail through the identical gate.
+    let controlFactCheck = null;
+    try {
+      const contentIt = { title: slug, excerpt: '', body1: truncated, body2: '', body3: '' };
+      controlFactCheck = await llmFactCheck(contentIt, truncated, `https://frontaliereticino.ch/blog/${slug}/`);
+    } catch (e) {
+      controlFactCheck = { error: e.message };
+    }
+    const controlLabel = controlFactCheck?.error
+      ? `ERROR: ${controlFactCheck.error}`
+      : controlFactCheck?.unverified ? 'UNVERIFIED' : controlFactCheck?.passed === true ? 'PASS' : 'FAIL';
+    console.log(`  [CONTROL: unmodified truncated input] fact-check: ${controlLabel}${controlFactCheck?.issues?.length ? ` (${controlFactCheck.issues.length} issue(s))` : ''}`);
+    results.push({
+      slug, model: '__CONTROL_UNMODIFIED__', elapsedMs: null,
+      factCheckVerdict: controlLabel, factCheckPassed: controlFactCheck?.passed ?? null,
+      factCheckUnverified: !!controlFactCheck?.unverified, factCheckIssues: controlFactCheck?.issues ?? [],
+    });
+
+    for (const model of MODELS) {
+      process.stdout.write(`  [${model}] generating... `);
+      let text, elapsedMs, error;
+      try {
+        ({ text, elapsedMs } = await callLocalOllama(model, prompt));
+      } catch (e) {
+        error = e.message;
+        console.log(`FAILED (${(Date.now())}): ${error}`);
+        results.push({ slug, model, error, elapsedMs: null });
+        continue;
+      }
+      const outWords = wc(text);
+      const outFactTokens = extractFactTokens(text);
+      const newTokens = [...outFactTokens].filter(t => !inputFactTokens.has(t));
+      console.log(`${(elapsedMs / 1000).toFixed(1)}s, ${outWords}w, ${newTokens.length} new-fact-token(s)`);
+      if (newTokens.length > 0) console.log(`    new tokens: ${newTokens.slice(0, 10).join(', ')}`);
+
+      let factCheck = null;
+      try {
+        const contentIt = { title: slug, excerpt: '', body1: text, body2: '', body3: '' };
+        factCheck = await llmFactCheck(contentIt, truncated, `https://frontaliereticino.ch/blog/${slug}/`);
+      } catch (e) {
+        factCheck = { error: e.message };
+      }
+
+      // Real return shape is { passed: boolean, issues: [...], unverified?: boolean }
+      // (NOT { verdict, issues } — that shape is per-model, internal to
+      // _runSingleFactCheck). See scripts/create-article.mjs:3102/3112/3127/3135/3144.
+      const verdictLabel = factCheck?.error
+        ? `ERROR: ${factCheck.error}`
+        : factCheck?.unverified
+          ? 'UNVERIFIED (infra outage, treated as pass per prod behavior)'
+          : factCheck?.passed === true ? 'PASS' : factCheck?.passed === false ? 'FAIL' : 'unknown';
+      console.log(`    fact-check: ${verdictLabel}${factCheck?.issues?.length ? ` (${factCheck.issues.length} issue(s))` : ''}`);
+
+      results.push({
+        slug, model, elapsedMs, outWords, targetWords, truncatedWords, originalWords,
+        newFactTokenCount: newTokens.length, newFactTokens: newTokens,
+        factCheckVerdict: verdictLabel,
+        factCheckPassed: factCheck?.passed ?? null,
+        factCheckUnverified: !!factCheck?.unverified,
+        factCheckIssues: factCheck?.issues ?? [],
+      });
+    }
+    console.log('');
+  }
+
+  const outPath = `/tmp/eval-local-rewrite-llm-results-${Date.now()}.json`;
+  fs.writeFileSync(outPath, JSON.stringify(results, null, 2));
+  console.log(`\nFull results written to ${outPath}`);
+
+  // Summary table
+  console.log('\n=== SUMMARY ===');
+  const controlRows = results.filter(r => r.model === '__CONTROL_UNMODIFIED__');
+  const controlPass = controlRows.filter(r => r.factCheckPassed === true).length;
+  console.log(`[CONTROL: unmodified truncated input, zero rewriting] fact-check ${controlPass}/${controlRows.length} PASS`);
+  console.log('(any FAIL here = checker is inherently strict on that sample regardless of model — discount matching model FAILs accordingly)\n');
+
+  const byModel = {};
+  for (const r of results) {
+    if (r.model === '__CONTROL_UNMODIFIED__') continue;
+    if (!byModel[r.model]) byModel[r.model] = { n: 0, totalMs: 0, pass: 0, fail: 0, newFacts: 0, errors: 0 };
+    const b = byModel[r.model];
+    b.n++;
+    if (r.error) { b.errors++; continue; }
+    b.totalMs += r.elapsedMs;
+    b.newFacts += r.newFactTokenCount;
+    if (r.factCheckPassed === true) b.pass++;
+    else b.fail++;
+  }
+  for (const [model, b] of Object.entries(byModel)) {
+    const avgS = b.n > b.errors ? (b.totalMs / (b.n - b.errors) / 1000).toFixed(1) : 'n/a';
+    console.log(`${model}: avg ${avgS}s/call | fact-check ${b.pass}/${b.n - b.errors} PASS | ${b.newFacts} total new-fact-tokens across samples | ${b.errors} errors`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Implementato

- Eval harness reale (`scripts/eval-local-rewrite-llm.mjs`, nuovo file) che misura, sulla sotto-fase di **riscrittura/allungamento** (non generazione da zero) di un articolo già generato ma troppo corto:
  - wall-clock reale di 3 candidati locali via Ollama: `qwen2.5:0.5b`, `qwen2.5:1.5b`, `qwen2.5:3b`
  - tasso di successo del gate **reale** `llmFactCheck` (stesso codice di produzione, riusato via `callLLM`/`AI_MODELS.LOCAL_FALLBACK`, non un'approssimazione)
  - su 5 campioni **reali** presi da `services/locales/blog-body/it/*.ts` (fiscale/UE-politico/sanitario-legale/infrastrutturale/sociale), ciascuno con un controllo "zero riscrittura" per separare severità intrinseca del gate da allucinazione reale
- `scripts/create-article.mjs`: aggiunto un **puro re-export** di `llmFactCheck` (nessun cambio di comportamento per il caller interno) così l'eval può chiamare il gate reale invece di reimplementarne un'approssimazione
- `docs/LOCAL-OPEN-MODELS-STUDY.md`: nuova sezione `## 8` datata 2026-07-06, con lo stesso rigore della voce "❌ Controindicato" di #3090 — metodologia, caveat di fedeltà (GPU/Metal sandbox vs CPU-only runner di produzione; singola famiglia di verificatori disponibile in questo sandbox), risultati misurati, esempi di allucinazione con citazione esatta, e decisione finale

**Risultato dell'eval (numeri reali, non stimati):**
- Tempo: risolto — max 27.0s/call medi (qwen2.5:3b), ~100× più veloce del qwen2.5:7b che aveva sforato il budget di 55min in #3090
- Fact-check: **non risolto** — 6/15 (40%) tasso di successo complessivo, in **peggioramento** al crescere del modello (0.5b 60% → 1.5b 40% → 3b 20%); le allucinazioni osservate replicano la stessa classe di errore di #3090 (persone/istituzioni inventate su contenuto fiscale/legale/sanitario), nonostante un prompt deliberatamente più stretto ("zero fatti nuovi") di quello di produzione
- Controllo (zero riscrittura): 4/5 PASS — conferma che le allucinazioni sono introdotte dai modelli, non un artefatto del gate

**Decisione: RIGETTO.** Nessun cambio al comportamento di produzione di `create-article.mjs`/`expandShortItalianContent` — resta remoto. Nessun flag introdotto (nessun candidato ha superato la barra "zero fallimenti fact-check" richiesta per l'integrazione).

Closes #3656

## Non implementato (ancora)

Nessuno — lo scope dell'issue è: (1) eval scritta con tempo+tasso di successo su campioni reali → fatto; (2) integrazione dietro flag SE un candidato passa → non applicabile, nessun candidato ha passato; (3) documentazione del rigetto con lo stesso rigore del precedente tentativo SE nessun candidato passa → fatto in `docs/LOCAL-OPEN-MODELS-STUDY.md ## 8`. Tutto lo scope è completo e live in questa PR; non c'è comportamento di produzione da cambiare perché la decisione è di non integrare.

## Test plan

- [x] `npx vitest run tests/create-article-author-registry.test.ts tests/create-article-gates.test.ts tests/create-article-template.test.ts tests/fact-check-consensus.test.ts` — 66/66 PASS
- [x] `node --check scripts/create-article.mjs` e `node --check scripts/eval-local-rewrite-llm.mjs` — sintassi OK
- [x] `git diff origin/main -- scripts/create-article.mjs` verificato: unico cambio è il re-export di `llmFactCheck`
- [x] GitNexus impact (`llmFactCheck`, upstream): risk LOW, 0 impacted (nota: indice stale da prima di questo lavoro — vedi caveat sotto)
- [ ] Eval run live end-to-end (15 trial + 5 controlli) già eseguito manualmente in questa sessione con `ollama serve` locale — non ripetibile in CI (richiede Ollama locale + modelli pulled); i numeri sono nel doc, non nel test plan CI

**Caveat espliciti (dichiarati anche nel doc):** GitNexus index stale (`049e08c`, precede questo lavoro — non ri-indicizzato in questa sessione, nessun rischio perché il diff è un puro re-export + doc + nuovo script standalone); fact-check verificato in questo sandbox con una sola famiglia di verificatori (niente `GH_MODELS_PAT`); tempi misurati su GPU Metal (sandbox), non sul runner CPU-only di produzione — entrambi i caveat sono nel doc.