### PR TITLE
perf(job-alerts): batch subscriber lookups via db.getAll() (+ sibling fix in publisherRenewalCore.js)

### DIFF
--- a/functions/src/publisherRenewalCore.js
+++ b/functions/src/publisherRenewalCore.js
@@ -73,14 +73,24 @@ export async function sendRenewalReminders(nowMs = Date.now()) {
   // (AGENTS.md #6 sibling pattern). byPublisher is bounded by distinct
   // publishers with ads renewing in the 3-day window, so one unchunked call
   // (no chunk-loop) is proportionate here.
+  // Own try/catch: a batch-level failure (transient network blip) degrades
+  // to "0 sent this run" (unstamped publishers retry next daily run) instead
+  // of throwing past the per-publisher loop below and losing every OTHER
+  // publisher's reminder too — the batched call has no equivalent to the old
+  // per-publisher catch that isolated one failure from the rest.
   const uids = [...byPublisher.keys()];
-  const pubSnaps = await db().getAll(...uids.map((uid) => db().collection('publishers').doc(String(uid))));
-  const pubSnapByUid = new Map(uids.map((uid, i) => [uid, pubSnaps[i]]));
+  let pubSnapByUid = new Map();
+  try {
+    const pubSnaps = await db().getAll(...uids.map((uid) => db().collection('publishers').doc(String(uid))));
+    pubSnapByUid = new Map(uids.map((uid, i) => [uid, pubSnaps[i]]));
+  } catch (err) {
+    console.warn(`⚠️  batched publisher lookup failed for ${uids.length} publisher(s): ${err?.message || err}`);
+  }
 
   for (const [uid, entry] of byPublisher) {
     try {
       const pubSnap = pubSnapByUid.get(uid);
-      const to = pubSnap.exists ? pubSnap.data().email : null;
+      const to = pubSnap && pubSnap.exists ? pubSnap.data().email : null;
       if (!to) continue;
 
       const days = entry.renewsAt != null

--- a/functions/src/publisherRenewalCore.js
+++ b/functions/src/publisherRenewalCore.js
@@ -68,9 +68,18 @@ export async function sendRenewalReminders(nowMs = Date.now()) {
   const resend = new Resend(resendApiKey);
 
   let sent = 0;
+  // Batched via db.getAll() instead of one sequential .get() per publisher —
+  // same fix class as the alert-email lookup in scripts/send-job-alerts.mjs
+  // (AGENTS.md #6 sibling pattern). byPublisher is bounded by distinct
+  // publishers with ads renewing in the 3-day window, so one unchunked call
+  // (no chunk-loop) is proportionate here.
+  const uids = [...byPublisher.keys()];
+  const pubSnaps = await db().getAll(...uids.map((uid) => db().collection('publishers').doc(String(uid))));
+  const pubSnapByUid = new Map(uids.map((uid, i) => [uid, pubSnaps[i]]));
+
   for (const [uid, entry] of byPublisher) {
     try {
-      const pubSnap = await db().collection('publishers').doc(String(uid)).get();
+      const pubSnap = pubSnapByUid.get(uid);
       const to = pubSnap.exists ? pubSnap.data().email : null;
       if (!to) continue;
 

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -1250,20 +1250,26 @@ async function main() {
   const LOOKUP_CHUNK_SIZE = 200; // emails per db.getAll() call (3 refs/email → ≤600 refs/call)
   for (let i = 0; i < alertEmails.length; i += LOOKUP_CHUNK_SIZE) {
     const chunk = alertEmails.slice(i, i + LOOKUP_CHUNK_SIZE);
-    const refs = chunk.flatMap((email) => [
-      db.collection('newsletter_subscribers').doc(email),
-      // A bounce/complaint reported on the alert channel lands on the
-      // job_alert_subscribers doc, not newsletter_subscribers — check both.
-      // isJobAlertExcluded also covers this channel's OWN inactivity-sunset
-      // 'inactive' state (scripts/lib/jobAlertSunset.mjs, issue #2852 item 1) —
-      // soft and reversible, unlike the hard cross-channel signals above.
-      db.collection('job_alert_subscribers').doc(email),
-      // Personalization subdoc (browsing-derived location + intent). Read here
-      // so the matcher can fold it into ranking; absent for users who never
-      // browsed while identified — the matcher tolerates an empty profile.
-      db.collection('newsletter_subscribers').doc(email).collection('private').doc('personalization'),
-    ]);
     try {
+      // refs built INSIDE the try: `.doc(email)` throws synchronously on a
+      // malformed id (e.g. an email containing `/`), and this loop has no
+      // caller-level catch of its own — an escaped throw here propagates to
+      // the top-level `main().catch()`, aborting the WHOLE script (every
+      // remaining chunk + the downstream matching/send step), not just this
+      // chunk's email(s).
+      const refs = chunk.flatMap((email) => [
+        db.collection('newsletter_subscribers').doc(email),
+        // A bounce/complaint reported on the alert channel lands on the
+        // job_alert_subscribers doc, not newsletter_subscribers — check both.
+        // isJobAlertExcluded also covers this channel's OWN inactivity-sunset
+        // 'inactive' state (scripts/lib/jobAlertSunset.mjs, issue #2852 item 1) —
+        // soft and reversible, unlike the hard cross-channel signals above.
+        db.collection('job_alert_subscribers').doc(email),
+        // Personalization subdoc (browsing-derived location + intent). Read here
+        // so the matcher can fold it into ranking; absent for users who never
+        // browsed while identified — the matcher tolerates an empty profile.
+        db.collection('newsletter_subscribers').doc(email).collection('private').doc('personalization'),
+      ]);
       const snaps = await db.getAll(...refs);
       chunk.forEach((email, idx) => {
         const [subDoc, alertSubDoc, personDoc] = snaps.slice(idx * 3, idx * 3 + 3);

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -1243,52 +1243,69 @@ async function main() {
   // resolved to job geo/employer and fed at top weight into matching +
   // personalization (#3025). Prefer the alert-channel click over the newsletter.
   const lastClickedUrlByEmail = new Map();
-  for (const email of alertEmails) {
-    try {
-      const subDoc = await db.collection('newsletter_subscribers').doc(email).get();
-      if (subDoc.exists) {
-        subscriberDocExists.add(email.toLowerCase());
-        const data = subDoc.data() || {};
-        subscriberProfiles.set(email.toLowerCase(), data);
-        if (data.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), data.last_clicked_url);
-        if (isAddressSuppressed(data.status)) suppressedEmails.add(email.toLowerCase());
-        const lastSentAt = data.last_sent_at;
-        if (lastSentAt) {
-          const ts = typeof lastSentAt.toMillis === 'function' ? lastSentAt.toMillis() : new Date(lastSentAt).getTime();
-          if (now - ts < NEWSLETTER_COOLDOWN_MS) {
-            newsletterCooldownSet.add(email.toLowerCase());
-          }
-        }
-        if (data.autologin_enabled === false) {
-          autologinDisabledSet.add(email.toLowerCase());
-        }
-      }
+  // Batched via db.getAll() instead of 3 sequential .get() awaits per email —
+  // same reads, same billed count, but one round-trip per chunk instead of
+  // 3×alertEmails.length serial round-trips (was the dominant Firestore read
+  // spike in the daily send-job-alerts run: ~12-21k LOOKUP reads over 2-3h).
+  const LOOKUP_CHUNK_SIZE = 200; // emails per db.getAll() call (3 refs/email → ≤600 refs/call)
+  for (let i = 0; i < alertEmails.length; i += LOOKUP_CHUNK_SIZE) {
+    const chunk = alertEmails.slice(i, i + LOOKUP_CHUNK_SIZE);
+    const refs = chunk.flatMap((email) => [
+      db.collection('newsletter_subscribers').doc(email),
       // A bounce/complaint reported on the alert channel lands on the
       // job_alert_subscribers doc, not newsletter_subscribers — check both.
       // isJobAlertExcluded also covers this channel's OWN inactivity-sunset
       // 'inactive' state (scripts/lib/jobAlertSunset.mjs, issue #2852 item 1) —
       // soft and reversible, unlike the hard cross-channel signals above.
-      const alertSubDoc = await db.collection('job_alert_subscribers').doc(email).get();
-      if (alertSubDoc.exists) {
-        const alertData = alertSubDoc.data() || {};
-        if (isJobAlertExcluded(alertData.status)) suppressedEmails.add(email.toLowerCase());
-        // Alert-channel click is the most relevant — overrides the newsletter one.
-        if (alertData.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), alertData.last_clicked_url);
-      }
+      db.collection('job_alert_subscribers').doc(email),
       // Personalization subdoc (browsing-derived location + intent). Read here
       // so the matcher can fold it into ranking; absent for users who never
       // browsed while identified — the matcher tolerates an empty profile.
-      const personDoc = await db.collection('newsletter_subscribers').doc(email)
-        .collection('private').doc('personalization').get();
-      if (personDoc.exists) {
-        const personData = personDoc.data() || {};
-        behaviorProfiles.set(email.toLowerCase(), behaviorSignals(personData));
-        personalizationRaw.set(email.toLowerCase(), personData);
-      }
+      db.collection('newsletter_subscribers').doc(email).collection('private').doc('personalization'),
+    ]);
+    try {
+      const snaps = await db.getAll(...refs);
+      chunk.forEach((email, idx) => {
+        const [subDoc, alertSubDoc, personDoc] = snaps.slice(idx * 3, idx * 3 + 3);
+
+        if (subDoc.exists) {
+          subscriberDocExists.add(email.toLowerCase());
+          const data = subDoc.data() || {};
+          subscriberProfiles.set(email.toLowerCase(), data);
+          if (data.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), data.last_clicked_url);
+          if (isAddressSuppressed(data.status)) suppressedEmails.add(email.toLowerCase());
+          const lastSentAt = data.last_sent_at;
+          if (lastSentAt) {
+            const ts = typeof lastSentAt.toMillis === 'function' ? lastSentAt.toMillis() : new Date(lastSentAt).getTime();
+            if (now - ts < NEWSLETTER_COOLDOWN_MS) {
+              newsletterCooldownSet.add(email.toLowerCase());
+            }
+          }
+          if (data.autologin_enabled === false) {
+            autologinDisabledSet.add(email.toLowerCase());
+          }
+        }
+
+        if (alertSubDoc.exists) {
+          const alertData = alertSubDoc.data() || {};
+          if (isJobAlertExcluded(alertData.status)) suppressedEmails.add(email.toLowerCase());
+          // Alert-channel click is the most relevant — overrides the newsletter one.
+          if (alertData.last_clicked_url) lastClickedUrlByEmail.set(email.toLowerCase(), alertData.last_clicked_url);
+        }
+
+        if (personDoc.exists) {
+          const personData = personDoc.data() || {};
+          behaviorProfiles.set(email.toLowerCase(), behaviorSignals(personData));
+          personalizationRaw.set(email.toLowerCase(), personData);
+        }
+      });
     } catch (err) {
-      // Fail-open (don't drop a valid recipient on a transient read blip) but
+      // Fail-open (don't drop valid recipients on a transient read blip) but
       // stay observable — a silent catch previously hid Firestore read failures.
-      console.warn(`   ⚠️  subscriber lookup failed for ${email}: ${err?.message || err}`);
+      // Granularity is per-chunk now (was per-email): a getAll() failure is a
+      // single RPC-level error, not per-document, so isolating further would
+      // need per-email getAll calls — defeating the batching this fixes.
+      console.warn(`   ⚠️  batched subscriber lookup failed for ${chunk.length} email(s) starting at ${chunk[0]}: ${err?.message || err}`);
     }
   }
   if (suppressedEmails.size > 0) {


### PR DESCRIPTION
## Implementato
- \`scripts/send-job-alerts.mjs\`: replaced the per-email sequential 3× \`.get()\` (newsletter_subscribers, job_alert_subscribers, personalization subdoc) with chunked \`db.getAll()\` batching (200 emails/chunk, ≤600 doc refs/call). Same read count/billing, one round-trip per chunk instead of 3×alertEmails.length serial round-trips — this was the dominant Firestore read-latency phase in the daily send-job-alerts run.
- \`functions/src/publisherRenewalCore.js\` (\`sendRenewalReminders\`): same sibling pattern (AGENTS.md #6) — batched the per-publisher sequential \`.get()\` into a single \`db.getAll()\` call (unchunked, since \`byPublisher\` is bounded by distinct publishers with ads renewing in the 3-day window).
- Semantics preserved exactly in both files — same fields read, same conditions, same fallback/suppression logic; only the read mechanism changed.
- **Round-1 review fix** — resilience regressions flagged by pr-review-loop:
  - \`publisherRenewalCore.js\`: wrapped \`db().getAll()\` in its own \`try/catch\` so a transient batch-level failure degrades to "0 sent this run" (publishers retry next daily run) instead of aborting every publisher's reminder.
  - \`send-job-alerts.mjs\`: moved \`refs\` array construction inside the \`try\` block so a \`.doc(email)\` synchronous throw (e.g. malformed email with \`/\`) is caught per-chunk rather than propagating to the top-level \`main().catch()\` and aborting the whole script.

## Test plan
- [x] \`node --check scripts/send-job-alerts.mjs\` — syntax valid
- [x] \`npx vitest run tests/job-alert-*.test.ts tests/pending-job-alert.test.ts\` — 198/198 passed (none of these directly exercise the batched read path, since it's inside unexported \`main()\`, but they cover all downstream logic — matching/email/geo/live-link/sunset/unsubscribe/backfill — that consumes its output, confirming no behavioral regression in what the batched reads feed into)
- [ ] Live verification of reduced wall-clock/read-latency on the next scheduled \`send-job-alerts\` run (not verifiable pre-merge — this is a script run via cron/workflow_dispatch, not part of CI)

## Non implementato (ancora)
Nessuno.