### PR TITLE
fix(blog): stop asterisk bullets and keyword-links corrupting article body

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -1451,7 +1451,10 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  let s = String(raw || '');
  // Strip markdown headings (at line start or inline after content)
  s = s.replace(/#{1,6}\s+/g, '');
- s = s.replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1');
+ // Delimiters excluded from crossing a newline — a stray unpaired `*` (e.g. a
+ // `* ` list bullet marker below) must not pair with an unrelated `*` on a
+ // different line and swallow an unrelated run of text into the match.
+ s = s.replace(/\*{1,3}([^*\n]+)\*{1,3}/g, '$1');
  s = s.replace(/^[-*_]{3,}$/gm, '');
  // Strip markdown links/images but keep text
  s = s.replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1');

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -21,6 +21,7 @@ import { inlineScriptJson } from './shared/inlineJsonScript';
 import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import { loadSwissArticleCanonicalOverrides, resolveSwissArticleCanonicalUrl, resolveShadowedArticleWinnerSlug } from './shared/swissArticleCanonicalOverrides';
+import { stripMarkdownPlain } from './shared/stripMarkdownPlain';
 
 export function ogPagesPlugin(rootDir: string): Plugin {
  return {
@@ -146,19 +147,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  'How', 'What', 'When', 'Where', 'Who', 'Why', 'Which', 'Can', 'Should', 'Is', 'Are', 'Do', 'Does',
  'Wie', 'Was', 'Wann', 'Wo', 'Wer', 'Warum', 'Welche',
  'Comment', 'Quoi', 'Quand', 'Où', 'Qui', 'Pourquoi', 'Quel', 'Quelle', 'Est-ce'];
- const stripMarkdownForFaq = (text: string): string =>
- text
- .replace(/\*\*([^*]+)\*\*/g, '$1')
- .replace(/\*([^*]+)\*/g, '$1')
- .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
- .replace(/^#{1,6}\s+/gm, '')
- .replace(/^[-*+]\s+/gm, '')
- .replace(/^\d+\.\s+/gm, '')
- .replace(/`([^`]+)`/g, '$1')
- .replace(/\n{2,}/g, ' ')
- .replace(/\n/g, ' ')
- .replace(/\s{2,}/g, ' ')
- .trim();
+ const stripMarkdownForFaq = stripMarkdownPlain;
 
  const extractArticleFaqPairs = (bodyText: string): Array<{ question: string; answer: string }> => {
  const pairs: Array<{ question: string; answer: string }> = [];

--- a/build-plugins/shared/stripMarkdownPlain.ts
+++ b/build-plugins/shared/stripMarkdownPlain.ts
@@ -1,0 +1,32 @@
+/**
+ * stripMarkdownPlain — single source of truth for flattening AI-generated
+ * article body markdown (bold/italic/links/headings/lists/code/newlines)
+ * into plain text for FAQPage JSON-LD `acceptedAnswer.text` and other
+ * plain-text surfaces derived from the same article body corpus.
+ *
+ * Bold/italic delimiters must not cross a newline — a negated character
+ * class like `[^*]` implicitly includes `\n`, so a stray unpaired `*`
+ * (e.g. a `* ` list bullet marker) can pair with an unrelated `*` many
+ * lines later and swallow an entire paragraph into a bogus emphasis span.
+ *
+ * This file exists because the same logic had drifted into two
+ * near-identical copies (BlogArticles.stripMarkdown, ogPagesPlugin's
+ * stripMarkdownForFaq) that both operate on the same AI-generated article
+ * body text — a fix applied to one without the other leaves the drifted
+ * copy free to keep corrupting FAQPage structured data. Pure, zero-import,
+ * safe to share between React components and build plugins.
+ */
+export function stripMarkdownPlain(text: string): string {
+  return text
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/^\d+\.\s+/gm, '')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\n{2,}/g, ' ')
+    .replace(/\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -127,8 +127,9 @@ export { NAV_ACTION_ROUTES } from '@/services/internalLinks';
 
 /** Inject [keyword](nav:action) markers into text for the first occurrence of each keyword.
  * Strips bold/italic markers before matching so patterns work even when keywords
- * span formatting boundaries (e.g. `cambio **franco-euro**`). */
-function autoLinkKeywords(text: string, navigators: NavigatorMap): string {
+ * span formatting boundaries (e.g. `cambio **franco-euro**`).
+ * Exported for regression testing (see tests/markdown-lite-formatting.test.ts). */
+export function autoLinkKeywords(text: string, navigators: NavigatorMap): string {
  if (!text) return text;
 
  // 1. Build a stripped copy (no * chars) with a position map back to the original
@@ -141,9 +142,13 @@ function autoLinkKeywords(text: string, navigators: NavigatorMap): string {
  }
  }
 
- // 2. Find all formatting spans (**bold** / *italic*) in the original text
+ // 2. Find all formatting spans (**bold** / *italic*) in the original text.
+ // Delimiters must not cross a newline — otherwise a stray unpaired `*` (e.g. a
+ // `* ` list bullet marker on one line) pairs with an unrelated `*` many lines
+ // later, producing a bogus span thousands of characters long that then inflates
+ // an unrelated keyword-link match in step 4.
  const fmtSpans: Array<[number, number]> = [];
- const fmtRe = /(\*\*(.+?)\*\*)|(\*([^*]+?)\*)/g;
+ const fmtRe = /(\*\*([^\n]+?)\*\*)|(\*([^*\n]+?)\*)/g;
  let fm: RegExpExecArray | null;
  while ((fm = fmtRe.exec(text)) !== null) {
  fmtSpans.push([fm.index, fm.index + fm[0].length]);
@@ -328,9 +333,23 @@ function tryRenderMdTable(text: string, keyPrefix: string, navigators?: Navigato
  );
 }
 
-/** True when every non-blank line in a block is a `- ` markdown list item. */
+/** Matches a `- ` or `* ` markdown list item marker at line start. AI-generated
+ *  body copy frequently emits `* ` bullets (pdfWhitepapersPlugin's parser already
+ *  accepts both) — without this, a bulleted block collapses into one run-on
+ *  paragraph with stray asterisks instead of a list. */
+const LIST_ITEM_RE = /^[-*]\s+/;
+
+/** True when every non-blank line in a block is a markdown list item. */
 function isListBlock(value: string): boolean {
- return value.split('\n').every(line => line.trim().startsWith('- ') || line.trim() === '');
+ return value.split('\n').every(line => LIST_ITEM_RE.test(line.trim()) || line.trim() === '');
+}
+
+/** AI-generated body copy sometimes tacks a decorative 📊/💡/⚠️ marker onto the
+ *  end of a sentence instead of using it as a leading callout-box marker (the
+ *  only place the renderer treats it as one) — strip the stray trailing glyph
+ *  so it doesn't render as noise. */
+function stripTrailingDecorativeEmoji(text: string): string {
+ return text.replace(/[ \t]*(?:📊|💡|⚠️|⚠)+\s*$/, '');
 }
 
 /** Render a heading's inline body as a table, a bullet list, or a plain paragraph —
@@ -342,7 +361,7 @@ function renderInlineBodyContent(inlineBody: string, keyPrefix: string, navigato
  const tableEl = tryRenderMdTable(inlineBody, `${keyPrefix}-tbl`, navigators);
  if (tableEl) return tableEl;
  if (isListBlock(inlineBody)) {
- const items = inlineBody.split('\n').filter(l => l.trim().startsWith('- ')).map(l => l.trim().slice(2));
+ const items = inlineBody.split('\n').filter(l => LIST_ITEM_RE.test(l.trim())).map(l => stripTrailingDecorativeEmoji(l.trim().replace(LIST_ITEM_RE, '')));
  return (
  <ul key={`${keyPrefix}-list`} className="space-y-2 pl-1">
  {items.map((item, i) => (
@@ -356,7 +375,7 @@ function renderInlineBodyContent(inlineBody: string, keyPrefix: string, navigato
  }
  return (
  <p key={`${keyPrefix}-p`} className="text-body leading-relaxed">
- {renderInlineFormatting(inlineBody, navigators)}
+ {renderInlineFormatting(stripTrailingDecorativeEmoji(inlineBody), navigators)}
  </p>
  );
 }
@@ -405,12 +424,13 @@ function renderFormattedContent(
 
  // If no block separators, render as a single paragraph.
  if (!processed.includes('\n\n') && !processed.includes('\n')) {
+  const cleanedSolo = stripTrailingDecorativeEmoji(processed);
   renderedBlocks.push(
    <p key="p-solo" className="text-body leading-relaxed">
-    {renderInlineFormatting(processed, navigators)}
+    {renderInlineFormatting(cleanedSolo, navigators)}
    </p>,
   );
-  markContent(countWordsIn(processed));
+  markContent(countWordsIn(cleanedSolo));
   tryEmitAd('post-solo');
   return <div className="space-y-5">{renderedBlocks}</div>;
  }
@@ -605,9 +625,9 @@ function renderFormattedContent(
  continue;
  }
 
- // List: lines starting with -
+ // List: lines starting with - or *
  if (isListBlock(trimmed)) {
- const items = trimmed.split('\n').filter(l => l.trim().startsWith('- ')).map(l => l.trim().slice(2));
+ const items = trimmed.split('\n').filter(l => LIST_ITEM_RE.test(l.trim())).map(l => stripTrailingDecorativeEmoji(l.trim().replace(LIST_ITEM_RE, '')));
  renderedBlocks.push(
  <ul key={`list-${idx}`} className="space-y-2 pl-1">
  {items.map((item, i) => (
@@ -623,12 +643,13 @@ function renderFormattedContent(
  }
 
  // Plain paragraph (default) — no mid-paragraph splitting (conservative profile).
+ const cleanedParagraph = stripTrailingDecorativeEmoji(trimmed);
  renderedBlocks.push(
  <p key={`p-${idx}`} className="text-body leading-relaxed">
- {renderInlineFormatting(trimmed, navigators)}
+ {renderInlineFormatting(cleanedParagraph, navigators)}
  </p>
  );
- markContent(countWordsIn(trimmed));
+ markContent(countWordsIn(cleanedParagraph));
  }
 
  // Final ad slot — the last section gets its own breakpoint at end-of-segment.
@@ -775,8 +796,11 @@ const QUESTION_PREFIXES = ['Come', 'Cosa', 'Quando', 'Quanto', 'Dove', 'Chi', 'P
 
 function stripMarkdown(text: string): string {
  return text
- .replace(/\*\*([^*]+)\*\*/g, '$1')
- .replace(/\*([^*]+)\*/g, '$1')
+ // Delimiters excluded from crossing a newline — same rationale as autoLinkKeywords'
+ // fmtRe: an unpaired `*` (list bullet marker) must not pair with an unrelated `*`
+ // on a different line and swallow everything between.
+ .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+ .replace(/\*([^*\n]+)\*/g, '$1')
  .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
  .replace(/^#{1,6}\s+/gm, '')
  .replace(/^[-*+]\s+/gm, '')

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -4,6 +4,7 @@ import { useTranslation, useLocale, loadBlogMeta, loadArticleBody, getCantonI18n
 import type { Locale } from '@/services/i18n';
 import { buildPath, preloadBlogData } from '@/services/router';
 import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
+import { stripMarkdownPlain } from '@/build-plugins/shared/stripMarkdownPlain';
 import type { BlogArticleId, AppRoute } from '@/services/router';
 import type { ArticleSection } from '@/services/articleSections';
 import { NAV_ACTION_ROUTES, KEYWORD_LINKS, type NavAction, type NavigatorMap } from '@/services/internalLinks';
@@ -794,23 +795,7 @@ export function estimateReadingMinutes(articleId: string, t: (key: string) => st
 const EVERGREEN_CATEGORIES = new Set(['fiscale', 'pratico', 'pensione']);
 const QUESTION_PREFIXES = ['Come', 'Cosa', 'Quando', 'Quanto', 'Dove', 'Chi', 'Perché', 'Quale'];
 
-function stripMarkdown(text: string): string {
- return text
- // Delimiters excluded from crossing a newline — same rationale as autoLinkKeywords'
- // fmtRe: an unpaired `*` (list bullet marker) must not pair with an unrelated `*`
- // on a different line and swallow everything between.
- .replace(/\*\*([^*\n]+)\*\*/g, '$1')
- .replace(/\*([^*\n]+)\*/g, '$1')
- .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
- .replace(/^#{1,6}\s+/gm, '')
- .replace(/^[-*+]\s+/gm, '')
- .replace(/^\d+\.\s+/gm, '')
- .replace(/`([^`]+)`/g, '$1')
- .replace(/\n{2,}/g, ' ')
- .replace(/\n/g, ' ')
- .replace(/\s{2,}/g, ' ')
- .trim();
-}
+const stripMarkdown = stripMarkdownPlain;
 
 export function extractFaqPairs(bodyText: string): Array<{ question: string; answer: string }> {
  const pairs: Array<{ question: string; answer: string }> = [];

--- a/tests/markdown-lite-formatting.test.ts
+++ b/tests/markdown-lite-formatting.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { autoLinkKeywords, extractFaqPairs } from '@/components/community/BlogArticles';
+
+describe('autoLinkKeywords — cross-line asterisk pairing (regression)', () => {
+  // Reproduces the gaggiolo-traffico.ts corruption: a `**bold**` marker followed,
+  // several lines later, by unrelated `* ` list-bullet markers used to make the
+  // fmtSpans regex pair a stray asterisk across lines into a multi-paragraph
+  // "italic" span — which then swallowed an unrelated keyword-link match and
+  // wrapped ~2800 chars (5 list items + several paragraphs) into a single link.
+  const navigators = new Proxy({}, { get: () => () => {} }) as Record<string, () => void>;
+
+  it('does not let a bold marker pair with a distant list-bullet asterisk', () => {
+    const text =
+      "## Fatti chiave\n* **Cosa**: Traffico al valico\n* Quando: 2024\n* Dove: Gaggiolo\n* Chi: Frontalieri che lavorano in Svizzera\n* Importo: N/A\n\n" +
+      'Molti lavoratori sono stati costretti a tornare a lavorare in Svizzera a causa della crisi.';
+
+    const out = autoLinkKeywords(text, navigators);
+
+    // The list block must survive untouched — no stray "[" from an inflated link span.
+    expect(out).toContain('* **Cosa**: Traffico al valico');
+    expect(out).toContain('* Importo: N/A');
+    expect(out).not.toMatch(/\[\s*Importo/);
+
+    // The real keyword match further down is still allowed to become a short link.
+    expect(out).toMatch(/\[lavorare in Svizzera\]\(nav:job-board\)/);
+  });
+
+  it('cleanly links a keyword that is itself bolded, without leaking asterisks', () => {
+    const text = 'Consulta il **calcolatore stipendio** per stimare il netto.';
+    const out = autoLinkKeywords(text, navigators);
+    expect(out).toBe('Consulta il [calcolatore stipendio](nav:calculator) per stimare il netto.');
+  });
+});
+
+describe('extractFaqPairs / stripMarkdown — cross-line asterisk pairing (regression)', () => {
+  it('does not swallow list items into a stripped span when extracting FAQ answers', () => {
+    const body =
+      '## Quando conviene?\n' +
+      '* **Primo** punto\n' +
+      '* Secondo punto\n' +
+      '* Terzo punto\n\n' +
+      'Risposta finale con dettagli aggiuntivi.';
+
+    const pairs = extractFaqPairs(body);
+    const pair = pairs.find(p => p.question.toLowerCase().includes('quando conviene'));
+    expect(pair).toBeDefined();
+    // All three bullet items must remain present in the extracted answer text.
+    expect(pair!.answer).toContain('Primo punto');
+    expect(pair!.answer).toContain('Secondo punto');
+    expect(pair!.answer).toContain('Terzo punto');
+  });
+});


### PR DESCRIPTION
## Implementato

Fixes broken layout in the blog article markdown-lite renderer (`components/community/BlogArticles.tsx`), reported against https://frontaliereticino.ch/articoli-frontaliere/gaggiolo-traffico/ as representative of the whole article template — not a content fix for that one article.

Two distinct root causes, both fixed:

1. **`isListBlock` only recognized `- ` bullets.** AI-generated body content (248 files, 2797 occurrences) frequently uses `* ` bullets. Blocks using `* ` fell through to the plain-paragraph branch, rendering as one run-on paragraph with visible stray asterisks. Fixed via a new `LIST_ITEM_RE = /^[-*]\s+/` used consistently in `isListBlock`, `renderInlineBodyContent`, and `renderFormattedContent`'s list branch — matching the dual-marker pattern `build-plugins/pdfWhitepapersPlugin.ts` already used independently.
2. **`autoLinkKeywords`'s `fmtSpans` regex crossed newlines.** Its single-asterisk alternative (`\*([^*]+?)\*`) could pair a real `**bold**` marker's stray partner asterisk with an unrelated `*` several lines later (e.g. a `* ` list bullet), producing a bogus "italic span" thousands of characters long. Any real keyword-link match falling inside that span then got its range inflated to match — swallowing whole list blocks and paragraphs into a single malformed `[...]` link. This is what produced the visible `[ Importo: ...` corruption in the "Fatti chiave" section. Fixed by excluding `\n` from both the bold and italic alternatives, so delimiters can no longer pair across lines. The same construct existed in `stripMarkdown` (used by `extractFaqPairs` for FAQ JSON-LD extraction) and is fixed there too.
3. Trailing decorative emoji (📊/💡/⚠️) tacked onto the end of AI-generated sentences (284 files) are now stripped via `stripTrailingDecorativeEmoji` instead of rendering as inline noise.

**Sibling-pattern audit (AGENTS.md rule #6):** grepped the codebase for the same negated-character-class-crosses-newline construct (`[^*]`/`[^*]+` used to strip bold/italic without excluding `\n`). Found 4 candidates:
- `build-plugins/pdfWhitepapersPlugin.ts` — false positive: its parser splits input per-line before calling the strip function, so the input structurally cannot contain `\n`.
- `build-plugins/professionLandingsPlugin.ts` / `professionLandingsCopy.ts` — false positive: the strings it strips are hand-authored, single-line JS template literals with no embedded `\n` or bullet markers anywhere in the generation code.
- `build-plugins/ogPagesPlugin.ts`'s `stripMarkdownForFaq` — **real bug**, byte-identical to `BlogArticles.tsx`'s `stripMarkdown`, feeding FAQPage JSON-LD `acceptedAnswer.text` from the same AI-generated article body corpus. Fixed, and since the two copies were byte-identical, extracted into `build-plugins/shared/stripMarkdownPlain.ts` so they can't drift again.
- `build-plugins/jobsSeoPagesPlugin.ts`'s `cleanMetaDescription` — **real bug** (differently-shaped combined regex, not a literal duplicate, fixed inline), feeding `<meta name="description">` from crawler-sourced, commonly bullet-heavy job description text.

Verified with a live dev-server + Playwright check against the exact reported URL: before → `strayAsteriskBulletLines: broken, [ Importo` corruption visible; after → `strayAsteriskBulletLines: 0`, `inlineDecorativeEmojiCount: 0`, all list blocks render as clean `<ul><li>` with correct `<strong>` labels (screenshot-confirmed).

`components/pages/PublisherPublishPage.tsx`'s similar-looking `startsWith('- ')` check is a false positive — it's a different, human-driven markdown editor (sponsored job descriptions) whose toolbar only ever inserts `- `, never AI-generated `* `.

Added `tests/markdown-lite-formatting.test.ts` covering both regressions (exported `autoLinkKeywords` for testability, `extractFaqPairs` was already exported).

## Non implementato (ancora)

Nessuno.

## Test plan
- [x] `npx vitest run tests/markdown-lite-formatting.test.ts tests/related-articles.test.ts tests/readingTime.test.ts tests/nav-actions.test.ts tests/article-ad-slots.test.ts tests/community/BlogArticles.content-gate.test.tsx` — all green
- [x] Live dev-server + Playwright check against `/articoli-frontaliere/gaggiolo-traffico/` before/after — confirmed fix, screenshot captured
- [x] Sibling-fix commit: `npx vitest run tests/markdown-lite-formatting.test.ts tests/jobs-seo-pages-plugin.test.ts tests/jobs-seo-editorial-below-floor-bridge.test.ts tests/jobs-seo-title-h1-datemodified.test.ts` — 79/79 green
