### PR TITLE
fix: FAQ-hub locale hrefs + events half-canton/slug-collision (Lane A bundle)

### DIFF
--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -67,6 +67,7 @@ import {
   OTHER_EVENTS_COMUNE_KEY,
   eventReferralUrl,
   recentlyEndedEvents,
+  resolveCantonUrlKey,
 } from '../scripts/lib/events-utils.mjs';
 import { getCantonLabel, type CantonLocale } from '../services/cantonList';
 import { imageObjectLd, type ImageObjectLd } from '../services/seo/imageObjectLd';
@@ -2625,7 +2626,13 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
       // Every downstream loop iterates `cantons`, not a hardcoded 'TI'.
       const byCanton = new Map<string, SiteEvent[]>();
       for (const ev of all) {
-        const canton = (ev.canton || 'TI').toUpperCase();
+        // #3715: resolve to the shared URL group key (BL/BS -> BASILEA,
+        // AI/AR -> APPENZELLO) BEFORE grouping — otherwise both halves of a
+        // half-canton pair render at the identical hub URL and the second
+        // one silently clobbers the first via WriteCollector's last-write-
+        // wins dedup (raw canton codes differ, but their emitted path does
+        // not).
+        const canton = resolveCantonUrlKey(ev.canton || 'TI');
         const arr = byCanton.get(canton) ?? [];
         arr.push(ev);
         byCanton.set(canton, arr);
@@ -2794,7 +2801,12 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
       const pastEvents = recentlyEndedEvents(dataset.events, dateStamp) as SiteEvent[];
       const pastEventsByCanton = new Map<string, SiteEvent[]>();
       for (const ev of pastEvents) {
-        const canton = (ev.canton || 'TI').toUpperCase();
+        // #3715: same group-key resolution as the live `byCanton` pass above
+        // — keeps this bridge-page grouping keyed identically to
+        // `byCantonComune` (used just below for `liveSameComune`), otherwise
+        // a half-canton pair's past events would fail to look up their live
+        // siblings entirely.
+        const canton = resolveCantonUrlKey(ev.canton || 'TI');
         if (!ev.comune) continue; // comune-less past events: not worth a bridge page (rare, no stable bucket to land on)
         pastEventsByCanton.set(canton, [...(pastEventsByCanton.get(canton) ?? []), ev]);
       }

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -2629,6 +2629,22 @@ export function assignEventSlugs(list: SiteEvent[], reservedBaseSlugs: ReadonlyS
   return slugFor;
 }
 
+/**
+ * Build the `reservedBaseSlugs` set for a past-bridge `assignEventSlugs` call:
+ * the ACTUAL assigned slug (post-dedup, e.g. `base-2` for a second
+ * same-title+date sibling) for every still-live event in the same comune —
+ * never the raw `slugifyEvent(ev)` base. Two live siblings sharing
+ * title+date collapse to the same raw base, so reserving the raw base only
+ * ever protects the FIRST one and leaves the disambiguated sibling's real
+ * URL unprotected against a past-bridge page landing on it (issue #3715).
+ */
+export function reserveLiveSiblingSlugs(
+  liveSameComune: readonly SiteEvent[],
+  detailSlugs: ReadonlyMap<string, { slug: string }>,
+): Set<string> {
+  return new Set(liveSameComune.map((ev) => detailSlugs.get(ev.id)!.slug));
+}
+
 export function eventsSeoPagesPlugin(rootDir: string): Plugin {
   return {
     name: 'events-seo-pages',
@@ -2838,14 +2854,15 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
         const liveByComune = byCantonComune.get(canton);
         for (const [comune, list] of byComune) {
           const liveSameComune = liveByComune?.get(comune) ?? [];
-          // #3700: reserve base slugs already claimed by a still-live
+          // #3700/#3715: reserve base slugs already claimed by a still-live
           // sibling in this comune (e.g. a multi-day event sharing the
           // exact same title+startDate as a now-past one, still "upcoming"
           // via a later endDate). Without this, the past-bridge slug is
           // assigned from `list` alone and can collide with — or even
           // reuse — the slug that is still the CURRENT live/indexed URL
-          // for that sibling.
-          const reservedBaseSlugs = new Set(liveSameComune.map((ev) => slugifyEvent(ev)));
+          // for that sibling. See reserveLiveSiblingSlugs() doc for why this
+          // must use the actual assigned slug, not the raw base.
+          const reservedBaseSlugs = reserveLiveSiblingSlugs(liveSameComune, detailSlugs);
           const pastSlugFor = assignEventSlugs(list, reservedBaseSlugs);
           for (const locale of LOCALES) {
             const detailHref = detailHrefFor(locale);

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -2596,6 +2596,39 @@ function patchInboundLink(distDir: string, relIndex: string, locale: Locale): bo
   return true;
 }
 
+/**
+ * Assign a stable, collision-free detail slug to every event in `list`
+ * (already scoped to one canton+comune peer group). `slugifyEvent(ev)` is
+ * the base; ties (same title+date) are broken with a plain incrementing
+ * suffix (`-2`, `-3`, ...) in list order. `list` must already be
+ * deterministically ordered on ties — both `upcomingEvents` and
+ * `recentlyEndedEvents` (scripts/lib/events-utils.mjs) sort ties on
+ * `.title` then `.id`, so two colliding events always land in the same
+ * relative order regardless of crawl/dataset insertion order or which of
+ * the two functions produced `list`.
+ *
+ * `reservedBaseSlugs` marks base slugs already claimed by a sibling OUTSIDE
+ * `list` — used so a "recently ended" bridge-page slug can never silently
+ * reuse a base slug that is still the CURRENT live/indexed slug for a
+ * same-title+date sibling in the same comune (issue #3700: a multi-day
+ * event sharing the exact title+startDate as one that already ended keeps
+ * its live bare slug; the ending one gets the decorated fallback instead of
+ * fighting over the same URL).
+ */
+export function assignEventSlugs(list: SiteEvent[], reservedBaseSlugs: ReadonlySet<string> = new Set()): Map<string, string> {
+  const used = new Set<string>(reservedBaseSlugs);
+  const slugFor = new Map<string, string>();
+  for (const ev of list) {
+    const base = slugifyEvent(ev);
+    let slug = base;
+    let n = 2;
+    while (used.has(slug)) slug = `${base}-${n++}`;
+    used.add(slug);
+    slugFor.set(ev.id, slug);
+  }
+  return slugFor;
+}
+
 export function eventsSeoPagesPlugin(rootDir: string): Plugin {
   return {
     name: 'events-seo-pages',
@@ -2656,28 +2689,18 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
         const byComune = groupByComune(byCanton.get(canton)!) as Map<string, SiteEvent[]>;
         byCantonComune.set(canton, byComune);
         for (const [comune, list] of byComune) {
-          const used = new Set<string>();
+          const slugs = assignEventSlugs(list);
           for (const ev of list) {
-            const base = slugifyEvent(ev);
-            let slug = base;
-            let n = 2;
-            while (used.has(slug)) slug = `${base}-${n++}`;
-            used.add(slug);
-            detailSlugs.set(ev.id, { canton, comune, slug });
+            detailSlugs.set(ev.id, { canton, comune, slug: slugs.get(ev.id)! });
           }
         }
 
         const otherEvents = byCanton.get(canton)!.filter((e) => !e.comune);
         if (otherEvents.length > 0) {
           otherEventsByCanton.set(canton, otherEvents);
-          const used = new Set<string>();
+          const slugs = assignEventSlugs(otherEvents);
           for (const ev of otherEvents) {
-            const base = slugifyEvent(ev);
-            let slug = base;
-            let n = 2;
-            while (used.has(slug)) slug = `${base}-${n++}`;
-            used.add(slug);
-            detailSlugs.set(ev.id, { canton, comune: OTHER_EVENTS_COMUNE_KEY, slug });
+            detailSlugs.set(ev.id, { canton, comune: OTHER_EVENTS_COMUNE_KEY, slug: slugs.get(ev.id)! });
           }
         }
       }
@@ -2814,17 +2837,16 @@ export function eventsSeoPagesPlugin(rootDir: string): Plugin {
         const byComune = groupByComune(events) as Map<string, SiteEvent[]>;
         const liveByComune = byCantonComune.get(canton);
         for (const [comune, list] of byComune) {
-          const used = new Set<string>();
-          const pastSlugFor = new Map<string, string>();
-          for (const ev of list) {
-            const base = slugifyEvent(ev);
-            let slug = base;
-            let n = 2;
-            while (used.has(slug)) slug = `${base}-${n++}`;
-            used.add(slug);
-            pastSlugFor.set(ev.id, slug);
-          }
           const liveSameComune = liveByComune?.get(comune) ?? [];
+          // #3700: reserve base slugs already claimed by a still-live
+          // sibling in this comune (e.g. a multi-day event sharing the
+          // exact same title+startDate as a now-past one, still "upcoming"
+          // via a later endDate). Without this, the past-bridge slug is
+          // assigned from `list` alone and can collide with — or even
+          // reuse — the slug that is still the CURRENT live/indexed URL
+          // for that sibling.
+          const reservedBaseSlugs = new Set(liveSameComune.map((ev) => slugifyEvent(ev)));
+          const pastSlugFor = assignEventSlugs(list, reservedBaseSlugs);
           for (const locale of LOCALES) {
             const detailHref = detailHrefFor(locale);
             for (const ev of list) {

--- a/data/faq-hub/category-avs-lpp.ts
+++ b/data/faq-hub/category-avs-lpp.ts
@@ -28,7 +28,12 @@ export const FAQ_avsLpp: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/avs-lpp-frontalieri/',
+        href: {
+          it: '/tasse-e-pensione/calcola-previdenza/',
+          en: '/en/taxes-and-pension/calculate-retirement/',
+          de: '/de/steuern-und-vorsorge/rente-berechnen/',
+          fr: '/fr/impots-et-retraite/calculer-pension/',
+        },
         label: {
           it: 'Guida AVS/LPP frontalieri',
           en: 'AVS/LPP cross-border guide',

--- a/data/faq-hub/category-famiglia.ts
+++ b/data/faq-hub/category-famiglia.ts
@@ -28,7 +28,12 @@ export const FAQ_famiglia: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/assegni-familiari-frontalieri/',
+        href: {
+          it: '/guida-frontaliere/',
+          en: '/en/cross-border-guide/',
+          de: '/de/grenzgaenger-ratgeber/',
+          fr: '/fr/guide-frontalier/',
+        },
         label: {
           it: 'Assegni familiari frontalieri',
           en: 'Cross-border family allowances',

--- a/data/faq-hub/category-fisco.ts
+++ b/data/faq-hub/category-fisco.ts
@@ -31,7 +31,12 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/nuova-legge-frontalieri-2024/',
+        href: {
+          it: '/guida-frontaliere/',
+          en: '/en/cross-border-guide/',
+          de: '/de/grenzgaenger-ratgeber/',
+          fr: '/fr/guide-frontalier/',
+        },
         label: {
           it: 'Guida alla nuova legge frontalieri 2024',
           en: 'Guide to the 2024 cross-border law',
@@ -40,7 +45,12 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
         },
       },
       {
-        href: '/fisco-frontalieri/',
+        href: {
+          it: '/tasse-e-pensione/',
+          en: '/en/taxes-and-pension/',
+          de: '/de/steuern-und-vorsorge/',
+          fr: '/fr/impots-et-retraite/',
+        },
         label: {
           it: 'Hub fiscale frontalieri',
           en: 'Cross-border tax hub',
@@ -76,7 +86,12 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/nuova-legge-frontalieri-2024/',
+        href: {
+          it: '/guida-frontaliere/',
+          en: '/en/cross-border-guide/',
+          de: '/de/grenzgaenger-ratgeber/',
+          fr: '/fr/guide-frontalier/',
+        },
         label: {
           it: 'Nuova legge frontalieri 2024',
           en: 'New 2024 cross-border law',
@@ -111,7 +126,12 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/fisco-frontalieri/',
+        href: {
+          it: '/tasse-e-pensione/',
+          en: '/en/taxes-and-pension/',
+          de: '/de/steuern-und-vorsorge/',
+          fr: '/fr/impots-et-retraite/',
+        },
         label: {
           it: 'Hub fiscale',
           en: 'Tax hub',
@@ -275,7 +295,12 @@ export const FAQ_fisco: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/secondo-pilastro-frontalieri/',
+        href: {
+          it: '/tasse-e-pensione/calcola-previdenza/',
+          en: '/en/taxes-and-pension/calculate-retirement/',
+          de: '/de/steuern-und-vorsorge/rente-berechnen/',
+          fr: '/fr/impots-et-retraite/calculer-pension/',
+        },
         label: {
           it: 'Guida al 2° pilastro',
           en: '2nd pillar guide',

--- a/data/faq-hub/category-permessi.ts
+++ b/data/faq-hub/category-permessi.ts
@@ -28,7 +28,12 @@ export const FAQ_permessi: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/permessi-lavoro/',
+        href: {
+          it: '/guida-frontaliere/permessi-di-lavoro/',
+          en: '/en/cross-border-guide/work-permits-guide/',
+          de: '/de/grenzgaenger-ratgeber/arbeitsbewilligungen/',
+          fr: '/fr/guide-frontalier/permis-de-travail/',
+        },
         label: {
           it: 'Guida ai permessi di lavoro',
           en: 'Work permits guide',
@@ -203,7 +208,12 @@ export const FAQ_permessi: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/disoccupazione-frontalieri/',
+        href: {
+          it: '/guida-frontaliere/disoccupazione-transfrontaliera/',
+          en: '/en/cross-border-guide/unemployment-benefits/',
+          de: '/de/grenzgaenger-ratgeber/arbeitslosengeld/',
+          fr: '/fr/guide-frontalier/allocations-chomage/',
+        },
         label: {
           it: 'Disoccupazione frontalieri',
           en: 'Cross-border unemployment',

--- a/data/faq-hub/category-trasporti.ts
+++ b/data/faq-hub/category-trasporti.ts
@@ -28,7 +28,12 @@ export const FAQ_trasporti: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/trasferimento-auto/',
+        href: {
+          it: '/guida-frontaliere/trasferire-auto-svizzera/',
+          en: '/en/cross-border-guide/transfer-car-to-switzerland/',
+          de: '/de/grenzgaenger-ratgeber/auto-in-schweiz-ummelden/',
+          fr: '/fr/guide-frontalier/transferer-voiture-suisse/',
+        },
         label: {
           it: 'Trasferimento auto CH-IT',
           en: 'CH-IT car transfer',
@@ -224,7 +229,12 @@ export const FAQ_trasporti: ReadonlyArray<FaqHubEntry> = [
     },
     relatedLinks: [
       {
-        href: '/guida-frontaliere/traffico-valichi/',
+        href: {
+          it: '/guida-frontaliere/tempi-attesa-dogana/',
+          en: '/en/cross-border-guide/border-waiting-times/',
+          de: '/de/grenzgaenger-ratgeber/wartezeiten-grenze/',
+          fr: '/fr/guide-frontalier/temps-attente-douane/',
+        },
         label: {
           it: 'Tempi di attesa ai valichi',
           en: 'Border crossing times',

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -17,6 +17,7 @@ import {
   renderComunePage,
   renderDigestPage,
   DIGESTS,
+  assignEventSlugs,
 } from '../build-plugins/eventsSeoPagesPlugin';
 import { SITE_LICENSE_PAGE } from '../services/seo/imageObjectLd';
 import { MIN_INDEXABLE_WORDS } from '../build-plugins/constants';
@@ -720,5 +721,45 @@ describe('events schema data quality (#3508)', () => {
     expect(names).not.toContain('Chilbi Vecchia');
     // Markup-only filter: the stale event must still be visible in the HTML list.
     expect(page.html).toContain('Chilbi Vecchia');
+  });
+});
+
+describe('assignEventSlugs (issue #3700 — past-bridge slug collision)', () => {
+  it('assigns the bare slugifyEvent() base when there is no collision', () => {
+    const list = [{ ...EVENT, id: 'a', title: 'Sagra', startDate: '2026-08-01' }];
+    const slugs = assignEventSlugs(list as never);
+    expect(slugs.get('a')).toBe('sagra-2026-08-01');
+  });
+
+  it('same title+date collision within the list gets a stable -2 suffix, id order breaks the tie', () => {
+    const evA = { ...EVENT, id: 'tio-agenda:100', title: 'Sagra', startDate: '2026-08-01' };
+    const evB = { ...EVENT, id: 'tio-agenda:200', title: 'Sagra', startDate: '2026-08-01' };
+    // Feed both orders — callers (upcomingEvents/recentlyEndedEvents) already
+    // sort ties on id, so assignEventSlugs itself must not depend on the
+    // caller's insertion order beyond what it's given; here we assert the
+    // *given* order determines the suffix (matches how the caller's
+    // pre-sorted list drives it).
+    const forward = assignEventSlugs([evA, evB] as never);
+    expect(forward.get('tio-agenda:100')).toBe('sagra-2026-08-01');
+    expect(forward.get('tio-agenda:200')).toBe('sagra-2026-08-01-2');
+  });
+
+  it('reservedBaseSlugs forces the decorated suffix even with zero in-list collisions (the actual #3700 gap)', () => {
+    // The past-bridge loop calls assignEventSlugs(pastList, reservedBaseSlugs)
+    // where reservedBaseSlugs is seeded from the STILL-LIVE siblings in the
+    // same comune. A still-live multi-day event (later endDate, so it never
+    // entered the past list at all) must not have its bare/indexed slug
+    // silently reused by a same-title+date event that just became past.
+    const pastEvent = { ...EVENT, id: 'tio-agenda:300', title: 'Mercatino di Natale', startDate: '2026-12-01' };
+    const liveSiblingBase = 'mercatino-di-natale-2026-12-01'; // slugifyEvent() of the still-live sibling
+    const slugs = assignEventSlugs([pastEvent] as never, new Set([liveSiblingBase]));
+    expect(slugs.get('tio-agenda:300')).not.toBe(liveSiblingBase);
+    expect(slugs.get('tio-agenda:300')).toBe('mercatino-di-natale-2026-12-01-2');
+  });
+
+  it('reservedBaseSlugs does not affect events whose base slug does not collide', () => {
+    const pastEvent = { ...EVENT, id: 'tio-agenda:400', title: 'Concerto', startDate: '2026-05-01' };
+    const slugs = assignEventSlugs([pastEvent] as never, new Set(['some-other-event-2026-01-01']));
+    expect(slugs.get('tio-agenda:400')).toBe('concerto-2026-05-01');
   });
 });

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -18,6 +18,7 @@ import {
   renderDigestPage,
   DIGESTS,
   assignEventSlugs,
+  reserveLiveSiblingSlugs,
 } from '../build-plugins/eventsSeoPagesPlugin';
 import { SITE_LICENSE_PAGE } from '../services/seo/imageObjectLd';
 import { MIN_INDEXABLE_WORDS } from '../build-plugins/constants';
@@ -761,5 +762,46 @@ describe('assignEventSlugs (issue #3700 — past-bridge slug collision)', () => 
     const pastEvent = { ...EVENT, id: 'tio-agenda:400', title: 'Concerto', startDate: '2026-05-01' };
     const slugs = assignEventSlugs([pastEvent] as never, new Set(['some-other-event-2026-01-01']));
     expect(slugs.get('tio-agenda:400')).toBe('concerto-2026-05-01');
+  });
+});
+
+describe('reserveLiveSiblingSlugs (issue #3715 — reviewer-found collision)', () => {
+  it('reserves the ACTUAL assigned slug for each live sibling, not the collapsed raw base', () => {
+    // Two still-live events sharing title+date in the same comune: assignEventSlugs
+    // gives them 'base' and 'base-2'. Reserving raw slugifyEvent() bases would
+    // collapse both to the same 'base' string, leaving the second sibling's real
+    // URL ('base-2') completely unprotected against a same-title+date past-bridge
+    // page landing on it.
+    const liveA = { ...EVENT, id: 'tio-agenda:500', title: 'Mercato di Natale', startDate: '2026-12-05' };
+    const liveB = { ...EVENT, id: 'tio-agenda:600', title: 'Mercato di Natale', startDate: '2026-12-05' };
+    const slugs = assignEventSlugs([liveA, liveB] as never);
+    expect(slugs.get('tio-agenda:500')).toBe('mercato-di-natale-2026-12-05');
+    expect(slugs.get('tio-agenda:600')).toBe('mercato-di-natale-2026-12-05-2');
+
+    // `reserveLiveSiblingSlugs` reads from the real `detailSlugs` shape
+    // (Map<string, { canton, comune, slug }>), not the bare slug-string map
+    // `assignEventSlugs` returns.
+    const detailSlugs = new Map(
+      [liveA, liveB].map((ev) => [ev.id, { canton: 'TI', comune: 'Lugano', slug: slugs.get(ev.id)! }]),
+    );
+    const reserved = reserveLiveSiblingSlugs([liveA, liveB] as never, detailSlugs);
+    expect(reserved.has('mercato-di-natale-2026-12-05')).toBe(true);
+    expect(reserved.has('mercato-di-natale-2026-12-05-2')).toBe(true);
+    expect(reserved.size).toBe(2);
+  });
+
+  it('a past-bridge event colliding with the SECOND live sibling still gets pushed to a free slug', () => {
+    const liveA = { ...EVENT, id: 'tio-agenda:500', title: 'Mercato di Natale', startDate: '2026-12-05' };
+    const liveB = { ...EVENT, id: 'tio-agenda:600', title: 'Mercato di Natale', startDate: '2026-12-05' };
+    const slugs = assignEventSlugs([liveA, liveB] as never);
+    const detailSlugs = new Map(
+      [liveA, liveB].map((ev) => [ev.id, { canton: 'TI', comune: 'Lugano', slug: slugs.get(ev.id)! }]),
+    );
+    const reserved = reserveLiveSiblingSlugs([liveA, liveB] as never, detailSlugs);
+
+    const pastEvent = { ...EVENT, id: 'tio-agenda:700', title: 'Mercato di Natale', startDate: '2026-12-05' };
+    const pastSlugs = assignEventSlugs([pastEvent] as never, reserved);
+    // Must land on a third slug — neither live sibling's real URL is reused.
+    expect(pastSlugs.get('tio-agenda:700')).toBe('mercato-di-natale-2026-12-05-3');
   });
 });

--- a/tests/events-nationwide-sources.test.ts
+++ b/tests/events-nationwide-sources.test.ts
@@ -49,6 +49,19 @@ describe('eventsBasePathForCanton', () => {
     expect(ai.it).toBe('/eventi/appenzello');
   });
 
+  // Issue #3715: the SSG emit loop groups events by this canton key before
+  // rendering one hub page per key. BL and BS resolving to the exact same
+  // base path (not just the same `.it` slug) is the precondition the fix
+  // relies on — if they ever diverged, grouping by the resolved key would
+  // stop being equivalent to grouping by the emitted URL.
+  it('BL and BS resolve to the byte-identical base path object (same emitted hub URL)', () => {
+    expect(eventsBasePathForCanton('BL')).toEqual(eventsBasePathForCanton('BS'));
+  });
+
+  it('AI and AR resolve to the byte-identical base path object (same emitted hub URL)', () => {
+    expect(eventsBasePathForCanton('AI')).toEqual(eventsBasePathForCanton('AR'));
+  });
+
   it('degrades to the TI fallback for an unknown/blank canton', () => {
     expect(eventsBasePathForCanton('')).toEqual(EVENTS_BASE_PATH);
     expect(eventsBasePathForCanton('XX')).toEqual(EVENTS_BASE_PATH);


### PR DESCRIPTION
## Implementato

**#3708 — FAQ-hub pre-existing relatedLinks locale hrefs**
- Migrated 11 pre-existing `relatedLinks[].href` plain-string entries across `data/faq-hub/category-{avs-lpp,famiglia,permessi,trasporti,fisco}.ts` to the `Record<locale,path>` pattern PR #3694 introduced for new fisco entries (6 in original issue scope + 5 sibling instances in the same already-open files: fisco.ts:43,114,278 and trasporti.ts:227).
- `resolveRelatedHref()` in `build-plugins/faqHubPlugin.ts` already handles both union members — no plugin change needed.
- Canonical target for each migrated href verified against `build-plugins/legacyRedirectsPlugin.ts` redirect map + `services/router.ts` `SLUG_TABLES`/`FiscoSubTab`/`GuidaSubTab`, not guessed.
- `data/faq-hub/category-lamal.ts:31,66` left unchanged — confirmed false positive (both destinations are genuinely single-locale-only pages).
- Tests: `tests/build-plugins/faq-hub-content.test.ts` 4/4 green.

**#3715 — events half-canton URL group collision (page-content loss)**
- `closeBundle()` grouping in `build-plugins/eventsSeoPagesPlugin.ts` keyed events by raw 2-letter canton code instead of the shared URL group key, so `AI/AR` and `BL/BS` pairs rendered separate hub/comune/digest pages at the *identical* output path — second half silently clobbered the first via last-write-wins dedup.
- Fix: apply `resolveCantonUrlKey` (already used by `scripts/schedule-fb-events-daily.mjs`/`scripts/lib/events-digest-content.mjs` per #3710) in both the live `byCanton` and "recently ended" `pastEventsByCanton` construction.
- Added 2 regression tests proving `eventsBasePathForCanton('BL')`/`('BS')` and `('AI')`/`('AR')` resolve to identical path objects.

**#3700 — events past-bridge slug collision-safety**
- Past-bridge slug-suffix assignment only considered peers within the "recently ended" list, blind to a same-title+date sibling still live in the same build — could collide with/reuse a still-indexed live URL.
- Extracted the 3x-duplicated inline suffix loop into `assignEventSlugs(list, reservedBaseSlugs?)`, and seeded `reservedBaseSlugs` from still-live siblings in the past-bridge loop so a live sibling always keeps its bare slug.
- Behavior byte-identical when `reservedBaseSlugs` is empty (default). Added 4 unit tests directly exercising `assignEventSlugs`.

**Verification (bundle branch, all 3 commits cherry-picked onto fresh origin/main, cherry-picks applied with zero conflicts):**
- `npx vitest run` on all 5 touched suites: 138/138 green (`faq-hub-content`, `events-nationwide-sources`, `events-digest`, `events-detail-pages`, `events-pipeline`).
- GitNexus impact analysis on `eventsSeoPagesPlugin`/`resolveCantonUrlKey`/`slugifyEvent`/`groupByComune`: all LOW risk, no HIGH/CRITICAL, all impacted call sites already-safe existing consumers.
- No new URL/href literals introduced without trailing slash (events fixes touch only internal grouping/slug logic feeding existing slash-correct path builders; FAQ hrefs verified against router/redirect source of truth).

Closes #3708
Closes #3715
Closes #3700

## Non implementato (ancora)

Nessuno.