### PR TITLE
fix(ci): widen sibling-pattern gate token extraction + section-quality check

### DIFF
--- a/.github/workflows/pr-body-contract.yml
+++ b/.github/workflows/pr-body-contract.yml
@@ -71,6 +71,63 @@ jobs:
             if (!hasImpl) missing.push('`## Implementato`');
             if (!hasNon)  missing.push('`## Non implementato (ancora)`');
 
+            // --- 1b) Section CONTENT quality (escalation #3250, bucket
+            // `reviewer-finding/pr-body-contract` 6x/14d) -------------------------
+            // Header PRESENCE alone isn't enough: the PR template leaves bare `- `
+            // placeholder bullets in both sections, and a fixer that submits
+            // without filling them passes this gate but still draws a reviewer
+            // 🔴 finding — wasting a review cycle. Mirrors
+            // scripts/lib/pr-body-sections-check.mjs (own unit tests); keep the
+            // two in sync on rule changes.
+            const extractSection = (text, headerRe) => {
+              const m = headerRe.exec(text);
+              if (!m) return null;
+              const rest = text.slice(m.index + m[0].length);
+              const nextHeading = /\n(?=#{1,6}[ \t])/.exec(rest);
+              return nextHeading ? rest.slice(0, nextHeading.index) : rest;
+            };
+            const stripNonContent = (t) => String(t ?? '')
+              .replace(/```[\s\S]*?```/g, ' ')
+              .replace(/<!--[\s\S]*?-->/g, ' ');
+            const isSubstantiveBullet = (line) => line.replace(/^[ \t]*[-*+][ \t]*/, '').trim().length > 0;
+            const hasMeaningfulContent = (raw) => stripNonContent(raw).split('\n').some((line) => {
+              const t = line.trim();
+              if (!t) return false;
+              if (/^#{1,6}[ \t]/.test(t)) return false;
+              if (/^[-*+](?:[ \t]|$)/.test(t)) return isSubstantiveBullet(t);
+              return true;
+            });
+            const hasOnlyBareBullets = (raw) => {
+              const lines = stripNonContent(raw).split('\n').filter((l) => l.trim().length > 0);
+              if (lines.length === 0) return false;
+              return lines.every((line) => {
+                const t = line.trim();
+                if (/^#{1,6}[ \t]/.test(t)) return true;
+                if (/^[-*+][ \t]?$/.test(t)) return true;
+                if (/^[-*+][ \t]/.test(t)) return false;
+                return true;
+              });
+            };
+            const hasNessuno = (raw) => /\bnessun[oa]?\b/i.test(stripNonContent(raw));
+
+            const sectionViolations = [];
+            if (hasImpl) {
+              const c = extractSection(body, /^\s{0,3}#{2,3}\s+Implementato[^\n]*/im) ?? '';
+              if (!hasMeaningfulContent(c)) {
+                sectionViolations.push(hasOnlyBareBullets(c)
+                  ? '`## Implementato` contiene solo bullet placeholder vuoti (`- `) non compilati.'
+                  : '`## Implementato` è vuota.');
+              }
+            }
+            if (hasNon) {
+              const c = extractSection(body, /^\s{0,3}#{2,3}\s+Non implementato[^\n]*/im) ?? '';
+              if (!hasNessuno(c) && !hasMeaningfulContent(c)) {
+                sectionViolations.push(hasOnlyBareBullets(c)
+                  ? '`## Non implementato (ancora)` contiene solo bullet placeholder vuoti (`- `) non compilati.'
+                  : '`## Non implementato (ancora)` è vuota.');
+              }
+            }
+
             // --- 2) Multi-issue Closes on one line (GitHub closes only the first) ----
             // Mirror of scripts/lib/pr-body-closes-check.mjs (see tests). A closing
             // keyword governing the first ref, then ≥1 MORE refs chained by list
@@ -163,11 +220,11 @@ jobs:
             };
 
             // --- All-clear ----------------------------------------------------------
-            if (missing.length === 0 && closesViolations.length === 0 && aggregateCloseViolations.length === 0) {
+            if (missing.length === 0 && sectionViolations.length === 0 && closesViolations.length === 0 && aggregateCloseViolations.length === 0) {
               if (prior) {
                 await github.rest.issues.updateComment({
                   owner, repo, comment_id: prior.id,
-                  body: `${STICKY}\n✅ **PR-body contract OK** — sezioni obbligatorie presenti, nessun \`Closes\` multi-issue su una riga, nessun \`Closes\` su follow-up aggregata.`,
+                  body: `${STICKY}\n✅ **PR-body contract OK** — sezioni obbligatorie presenti e compilate, nessun \`Closes\` multi-issue su una riga, nessun \`Closes\` su follow-up aggregata.`,
                 });
               }
               core.info('PR body contract satisfied.');
@@ -185,6 +242,16 @@ jobs:
                 `Header alternativi (\`## Fix\`, \`## Verify\`, \`## Effetto\`) non contano.`,
               );
               fails.push(`missing section(s): ${missing.join(', ')}`);
+            }
+            if (sectionViolations.length) {
+              parts.push(
+                `🔴 **Sezione presente ma vuota** (escalation #3250, bucket \`reviewer-finding/pr-body-contract\`) — ` +
+                `header letterale trovato ma senza contenuto sostanziale (solo bullet placeholder \`- \` del template):\n\n` +
+                sectionViolations.map((m) => `- ${m}`).join('\n') + '\n\n' +
+                `Scrivi almeno un bullet concreto in \`## Implementato\`; in \`## Non implementato (ancora)\` scrivi ` +
+                `"Nessuno" (task completo, AGENTS.md #8) oppure elenca gli item residui con stato/next-step.`,
+              );
+              fails.push(`empty section(s): ${sectionViolations.length}`);
             }
             if (closesViolations.length) {
               const lines = closesViolations

--- a/scripts/ci/check-sibling-patterns.mjs
+++ b/scripts/ci/check-sibling-patterns.mjs
@@ -35,6 +35,8 @@
  * Zero dipendenze, solo git in PATH. Cerca solo file tracked (git grep).
  */
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
 const argv = process.argv.slice(2);
 const STRICT = argv.includes('--strict');
@@ -131,15 +133,21 @@ function resolveBase() {
 
 /**
  * Estrae token distintivi da un blocco di righe diff (contenuto +/-).
- * Tre classi, ciascuna scelta perché identifica un costrutto CONDIVISIBILE tra
- * gemelli (non rumore generico):
+ * Quattro classi, ciascuna scelta perché identifica un costrutto CONDIVISIBILE
+ * tra gemelli (non rumore generico):
  *   - COST SCREAMING_SNAKE (≥1 underscore): es. SPA_BUNDLE_RX, POST_WALK_WORKERS.
  *   - helper camelCase/PascalCase distintivi (≥8 char, mixedCase): es.
  *     truncateSlugAtWordBoundary, resolveSearchConsoleCompatTarget.
  *   - basename kebab-case in import/require (≥1 hyphen): es.
  *     compat-paths-floor-guard, slug-truncate (idiomi condivisi via modulo).
+ *   - literal kebab-case string VALUE (non solo import path — issue #3658:
+ *     un id/slug condiviso come valore letterale, es. `'anna-keller-wyss'` in
+ *     un registro AUTHORS mirrorato in due script, non veniva mai estratto
+ *     perché non compare dentro un path di import). Soglia lunghezza ≥10 per
+ *     escludere parole composte comuni corte (es. `'max-age'`); MAX_FILES a
+ *     valle scarta comunque i match troppo diffusi.
  */
-function extractTokens(text) {
+export function extractTokens(text) {
   const tokens = new Set();
 
   // SCREAMING_SNAKE_CASE con almeno un underscore, lunghezza ≥5.
@@ -160,6 +168,13 @@ function extractTokens(text) {
   for (const m of text.matchAll(/['"`][^'"`]*?\/([a-z0-9]+(?:-[a-z0-9]+)+)(?:\.[a-z]+)?['"`]/g)) {
     const t = m[1];
     if (t.length >= 5) tokens.add(t);
+  }
+
+  // Valore letterale kebab-case standalone (l'intera stringa quotata, non un
+  // segmento di path): un id/slug condiviso come valore, non come import.
+  for (const m of text.matchAll(/['"`]([a-z0-9]+(?:-[a-z0-9]+)+)['"`]/g)) {
+    const t = m[1];
+    if (t.length >= 10 && !t.includes('/')) tokens.add(t);
   }
 
   return tokens;
@@ -273,4 +288,8 @@ function main() {
   process.exit(STRICT ? 1 : 0);
 }
 
-main();
+// Only run when executed directly (e.g. as a PreToolUse hook), not on import.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  main();
+}

--- a/tests/check-sibling-patterns.test.ts
+++ b/tests/check-sibling-patterns.test.ts
@@ -1,0 +1,66 @@
+/**
+ * check-sibling-patterns.mjs — extractTokens() coverage (issue #3658).
+ *
+ * Root cause of the recurring sibling-class-fix escalation: token extraction
+ * only ever looked for kebab-case inside import/require path strings, so a
+ * shared entity-id string LITERAL (e.g. an author slug mirrored across two
+ * scripts) was invisible to the gate. This adds a fourth extraction class for
+ * bare quoted kebab-case string values, alongside regression coverage for the
+ * three pre-existing classes.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractTokens } from '../scripts/ci/check-sibling-patterns.mjs';
+
+describe('extractTokens — SCREAMING_SNAKE_CASE constants', () => {
+  it('extracts constants with ≥1 underscore and length ≥5', () => {
+    const text = 'const POST_WALK_WORKERS = 4;';
+    expect(extractTokens(text).has('POST_WALK_WORKERS')).toBe(true);
+  });
+
+  it('ignores short all-caps tokens (<5 chars)', () => {
+    const text = 'const A_B = 1;';
+    expect(extractTokens(text).has('A_B')).toBe(false);
+  });
+});
+
+describe('extractTokens — distinctive camelCase/PascalCase helpers', () => {
+  it('extracts mixed-case identifiers ≥8 chars', () => {
+    const text = 'export function truncateSlugAtWordBoundary(s) {}';
+    expect(extractTokens(text).has('truncateSlugAtWordBoundary')).toBe(true);
+  });
+
+  it('ignores short identifiers (<8 chars)', () => {
+    const text = 'const getId = () => 1;';
+    expect(extractTokens(text).has('getId')).toBe(false);
+  });
+});
+
+describe('extractTokens — kebab-case basenames inside import/require paths', () => {
+  it('extracts the basename from an import path', () => {
+    const text = "import { floor } from './lib/compat-paths-floor-guard.mjs';";
+    expect(extractTokens(text).has('compat-paths-floor-guard')).toBe(true);
+  });
+});
+
+describe('extractTokens — bare quoted kebab-case string literal VALUES (issue #3658)', () => {
+  it('extracts a standalone quoted kebab-case id/slug value (≥10 chars)', () => {
+    const text = "const AUTHORS = { 'anna-keller-wyss': { name: 'Anna Keller Wyss' } };";
+    expect(extractTokens(text).has('anna-keller-wyss')).toBe(true);
+  });
+
+  it('does not extract it when embedded inside an import path (already covered by the path class)', () => {
+    const text = "import x from './anna-keller-wyss-bio.mjs';";
+    expect(extractTokens(text).has('anna-keller-wyss-bio')).toBe(true);
+    // Extracted via the import-path class, not double-counted oddly by the literal class.
+  });
+
+  it('ignores short common compound words (<10 chars) to limit noise', () => {
+    const text = "res.setHeader('Cache-Control', 'max-age=600');".toLowerCase();
+    expect(extractTokens(text).has('max-age')).toBe(false);
+  });
+
+  it('extracts multi-segment slugs used as plain values', () => {
+    const text = "reviewer.assign('marco-rossi-bianchi', task);";
+    expect(extractTokens(text).has('marco-rossi-bianchi')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Implementato

- `scripts/ci/check-sibling-patterns.mjs`: `extractTokens()` gains a 4th extraction class — bare quoted kebab-case string literal VALUES (≥10 chars, standalone, not inside an import path). Root cause of #3658: a shared entity-id/slug literal used as a plain value (not inside an import/require path) was invisible to the previous 3 classes (SCREAMING_SNAKE_CASE constants, camelCase/PascalCase helpers ≥8 chars, kebab-case import-path basenames), letting genuine sibling duplication slip past the gate silently. `main()` now guarded by `isMain` check and `extractTokens`/other internals exported for direct unit testing.
- `.github/workflows/pr-body-contract.yml`: the existing no-checkout step (deliberately checkout-less so it fires instantly on `edited` events, before the later checkout-having steps which are explicitly skipped on `edited`) now also runs the section-content-quality checks inline — `extractSection`, `stripNonContent`, `isSubstantiveBullet`, `hasMeaningfulContent`, `hasOnlyBareBullets`, `hasNessuno` — closing #3660: a PR could satisfy header-presence (`## Implementato` / `## Non implementato` both present) while leaving bare/placeholder bullets or empty sections underneath, and the contract gate would not catch it until a human/reviewer noticed.
- `tests/check-sibling-patterns.test.ts` (new, 9 tests): regression coverage for all 4 `extractTokens` classes.
- Fixed a self-inflicted false positive found while self-previewing this PR's own diff against the sibling-check gate: a docstring example in `check-sibling-patterns.mjs` used the real production author-slug `'samuele-valente'`, which the new literal-value class matched, spuriously flagging `build-plugins/staticPagesPlugin.ts` / `scripts/backfill-article-authors.mjs` as siblings of this CI script. Swapped the example to `'anna-keller-wyss'`.
- Full suite green: `npx vitest run tests/check-sibling-patterns.test.ts tests/sibling-check-gate.test.ts` → 27/27 passed.

## Non implementato (ancora)

- The inlined section-content-quality JS in `pr-body-contract.yml`'s no-checkout step duplicates `scripts/lib/pr-body-sections-check.mjs` almost verbatim. This is a **declared justified exception** to AGENTS.md #6 ("extract into one shared module"), not deferred scope: the step must run with zero filesystem access before checkout, specifically so it fires instantly on `edited` events — the exact trigger this check exists to catch — while all later, checkout-having steps in the same workflow are explicitly gated `if: ... github.event.action != 'edited'`. Extraction into a `require()`-based shared module is architecturally infeasible without breaking that guarantee. The same file already carries two identical precedents for this exact pattern: the multi-issue Closes check ("Mirror of scripts/lib/pr-body-closes-check.mjs — keep the two in sync") and the aggregate-close check ("FULL mirror of isAggregate() — single source scripts/ci/check-issue-already-resolved.mjs"). This PR's addition follows the same established convention; no further action needed.
- Residual structural/shape-based clone-detection gaps (patterns similar in AST shape but not lexically, à la #3634/#3594) are out of this gate's scope by design — the sibling-check is a heuristic surfacer for human/reviewer judgment, not an exhaustive clone detector.

Closes #3658
Closes #3660