### PR TITLE
fix(deploy): stage events catalog SVGs to CDN push

### DIFF
--- a/scripts/lib/deploy-it-pages-prep.sh
+++ b/scripts/lib/deploy-it-pages-prep.sh
@@ -407,6 +407,15 @@ step_push_cdn() {
   for d in brands insurers providers logos authors publisher events; do
     [ -d "public/images/$d" ] && mkdir -p "$stage/images" && cp -r "public/images/$d" "$stage/images/$d"
   done
+  # Build-time generated per-category "catalog" fallback SVGs (#3740,
+  # writeCatalogImages() in build-plugins/eventsSeoPagesPlugin.ts): unlike the
+  # mirrored real event photos above (git-tracked under public/images/events/),
+  # these 11 deterministic SVGs are emitted straight into dist/images/events/catalog/
+  # at build time and are NOT git-tracked, so the public/images/$d loop above
+  # never picks them up. Without this stage copy, offload-generated-images-cdn.mjs
+  # still rewrote the HTML refs to the CDN and deleted the dist copies, leaving
+  # cdn.frontaliereticino.ch/images/events/catalog/*.svg permanently 404.
+  [ -d dist/images/events/catalog ] && mkdir -p "$stage/images/events" && cp -r dist/images/events/catalog "$stage/images/events/catalog"
   # Strip junk the recursive copies drag in: macOS .DS_Store files and the
   # internal build-telemetry assets/.hash-age.json (chunk first-seen/last-access
   # timestamps — not a runtime asset, must not be published).


### PR DESCRIPTION
## Implementato

- `scripts/lib/deploy-it-pages-prep.sh` (`step_push_cdn`): after the existing `public/images/<dir>` staging loop, added a stage copy of `dist/images/events/catalog/` (the 11 deterministic per-category fallback SVGs emitted at build time by `writeCatalogImages()` in `build-plugins/eventsSeoPagesPlugin.ts`, which are NOT git-tracked under `public/images/events/` like the real mirrored event photos).
- Root cause (pre-confirmed, not re-investigated): `offload-generated-images-cdn.mjs` already rewrites the HTML `<img>` refs for these SVGs to `cdn.frontaliereticino.ch/images/events/catalog/*.svg` and deletes the dist copies — but since the CDN stage never received these files, every deploy pushed a CDN payload missing them, producing a permanent 404 on that path. Verified pre-fix: `curl -sI https://cdn.frontaliereticino.ch/images/events/catalog/altro.svg` → 404.
- `bash -n scripts/lib/deploy-it-pages-prep.sh` passes (syntax sanity check — no dedicated vitest suite exists for this script; confirmed via `grep -rl "deploy-it-pages-prep" tests/` returning no matches).
- Sibling-pattern sweep (AGENTS.md #6): `node scripts/ci/check-sibling-patterns.mjs` flagged 8 files sharing the tokens `eventsSeoPagesPlugin`/`writeCatalogImages` (`build-plugins/eventsSeoPagesPlugin.ts`, `build-plugins/jobsSeoPagesPlugin.ts`, `build-plugins/shared/jobEventsCrosslink.ts`, `build-plugins/shared/sitemapUrlsetDedupe.ts`, `build-plugins/weeklyEmployersPlugin.ts`, `scripts/assemble-events-dataset.mjs`, `scripts/crawl-tio-agenda.mjs`, `scripts/lib/events-utils.mjs`). Manually inspected all 8 — every match is a **false positive**: the token only appears in comments/docblocks referencing the plugin by name, none contain the actual antipattern (a CDN-staging copy loop missing the catalog dir). No sibling fix needed.
- GitNexus `impact`/`context` on `step_push_cdn` failed with `Corrupted wal file. Read out invalid WAL record type.` (pre-existing `.gitnexus` index corruption, unrelated to this change). Fallback manual grep confirms `step_push_cdn` is defined once and called exactly once, from `main()` in the same file — no external callers, no other file references it → risk LOW, no HIGH/CRITICAL blast radius.
- `gitnexus_detect_changes({scope:"all"})` returned 0 changed symbols (bash scripts aren't part of the JS/TS-oriented code graph); `git status --short` independently confirms scope is exactly the one intended file.

## Non implementato (ancora)

- Verifica live (200 su `cdn.frontaliereticino.ch/images/events/catalog/*.svg`) non validabile pre-merge — richiede un deploy reale (il push CDN gira solo nella pipeline `deploy.yml`, non in CI di PR). Trigger di revert: se il prossimo deploy non risolve i 404 su questi path, revert.
- GitNexus `.gitnexus` index WAL corruption è un problema di infrastruttura pre-esistente e scorrelato da questo fix (bash script isolato, nessun impatto sul grafo codice JS/TS) — non affrontato in questa PR, richiede reindex separato (`npx gitnexus analyze --skip-agents-md`).

Closes #3740