### PR TITLE
fix(events): dedupe same-source event duplicates via geo match

### DIFF
--- a/scripts/assemble-events-dataset.mjs
+++ b/scripts/assemble-events-dataset.mjs
@@ -21,13 +21,16 @@
  *      myswitzerland) and the TI-only tio-agenda crawler can each index the
  *      SAME physical event under a different `<sourceKey>:<rawId>` id, so the
  *      by-id merge above does not catch it. A second pass groups the
- *      survivors by `(normalized title, startDate, normalized comune)` and,
- *      ONLY when a group spans 2+ DISTINCT sources, collapses it down to the
- *      single richest record — see `dedupeFuzzy` below for the scoring/
- *      tie-break rule. A same-source collision (e.g. two different events
- *      that happen to share a generic title and a low-confidence
- *      region-fallback comune) is left untouched — merging those would risk
- *      silently dropping a genuine event.
+ *      survivors by `(normalized title, startDate, normalized comune)` and
+ *      collapses a group down to the single richest record when either
+ *      (a) it spans 2+ DISTINCT sources, or (b) it is a single-source group
+ *      whose members ALSO carry near-identical `geo` coordinates (issue
+ *      #3744: the same source can re-index its own event under a second raw
+ *      id/URL) — see `dedupeFuzzy` below for the scoring/tie-break rule and
+ *      geo tolerance. A same-source collision WITHOUT a geo match (e.g. two
+ *      different events that happen to share a generic title and a
+ *      low-confidence region-fallback comune) is left untouched — merging
+ *      those would risk silently dropping a genuine event.
  *   4. Italian frontier comuni geo-link (issue #3125): every assembled event
  *      that carries `geo` but has no `italianFrontierComuni` yet (a crawler
  *      may already have attached it) gets `resolveItalianFrontierComuni`
@@ -52,6 +55,7 @@ import {
   isoDay,
   normalizeText,
   resolveItalianFrontierComuni,
+  haversineKm,
 } from './lib/events-utils.mjs';
 
 function readSlices() {
@@ -135,19 +139,86 @@ export function pickRichestEvent(group) {
   })[0];
 }
 
+// Same-source geo-match tolerance (issue #3744): a single crawler can emit
+// two records for the SAME physical event under different objectIDs/URLs
+// (observed: myswitzerland's "Heididorf Saisoneröffnung" indexed twice, same
+// startDate/comune and EXACT geo, two different objectIDs). 50m is tight
+// enough to only catch true re-indexing dupes — two genuinely different
+// venues that happen to share a generic title/date/region-fallback comune
+// are not normally 50m apart — while still tolerant of float rounding in the
+// source coordinates.
+const SAME_SOURCE_GEO_TOLERANCE_KM = 0.05;
+
+function hasGeo(ev) {
+  return (
+    typeof ev?.geo?.lat === 'number' &&
+    typeof ev?.geo?.lng === 'number' &&
+    Number.isFinite(ev.geo.lat) &&
+    Number.isFinite(ev.geo.lng)
+  );
+}
+
 /**
- * Collapse fuzzy cross-source duplicates. Returns the deduped event list plus
- * how many records were merged away (for --stats reporting).
+ * Partition a same-`sourceKey` fuzzy-dedup group (already collided on
+ * title+startDate+comune) into geo-match clusters — 2+ members within
+ * `SAME_SOURCE_GEO_TOLERANCE_KM` of each other, chained transitively so a
+ * rare 3-way same-source duplicate still collapses to one cluster — plus the
+ * leftover singles (events with no `geo`, or whose `geo` doesn't match anyone
+ * else in the group). Reuses the shared `haversineKm` helper
+ * (scripts/lib/events-utils.mjs) rather than re-implementing great-circle
+ * distance here (AGENTS.md §6).
+ */
+function clusterBySameGeo(group) {
+  const withGeo = group.filter(hasGeo);
+  const singles = group.filter((ev) => !hasGeo(ev));
+  const clusters = [];
+  const assigned = new Set();
+  for (let i = 0; i < withGeo.length; i += 1) {
+    if (assigned.has(i)) continue;
+    const cluster = [withGeo[i]];
+    assigned.add(i);
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (let j = 0; j < withGeo.length; j += 1) {
+        if (assigned.has(j)) continue;
+        const withinTolerance = cluster.some(
+          (member) =>
+            haversineKm(member.geo.lat, member.geo.lng, withGeo[j].geo.lat, withGeo[j].geo.lng) <=
+            SAME_SOURCE_GEO_TOLERANCE_KM,
+        );
+        if (withinTolerance) {
+          cluster.push(withGeo[j]);
+          assigned.add(j);
+          grew = true;
+        }
+      }
+    }
+    if (cluster.length > 1) clusters.push(cluster);
+    else singles.push(cluster[0]);
+  }
+  return { clusters, singles };
+}
+
+/**
+ * Collapse fuzzy duplicates. Returns the deduped event list plus how many
+ * records were merged away (for --stats reporting).
  *
- * Deliberately scoped to groups spanning >= 2 DISTINCT `sourceKey`s. A group
- * that collides on title+startDate+comune but comes entirely from a single
- * source is left untouched — e.g. two unrelated "Street Food" events on the
- * same day both region-resolved (low-confidence fallback) to the same
- * representative comune are a real, observed false-positive collision that
- * must not eat a genuine second event. Same-source id collisions are each
- * source's own responsibility (and are already deduped by the by-id merge
- * above); this pass only exists to catch the SAME physical event indexed
- * independently by two-or-more different crawlers.
+ * Two collapse conditions on a title+startDate+comune group:
+ *   - >= 2 DISTINCT `sourceKey`s (issue #3125) — the SAME physical event
+ *     indexed independently by two-or-more different crawlers.
+ *   - a single-source group whose members ALSO carry `geo` coordinates
+ *     within `SAME_SOURCE_GEO_TOLERANCE_KM` of each other (issue #3744) —
+ *     the same source re-indexed its own event under a second raw id/URL.
+ *
+ * A single-source group WITHOUT a geo match (e.g. two unrelated "Street
+ * Food" events on the same day both region-resolved — low-confidence
+ * fallback — to the same representative comune) is left untouched — a real,
+ * observed false-positive collision that must not eat a genuine second
+ * event. Geo is the only signal that discriminates a true same-source
+ * duplicate from that false positive; events with no `geo` on either side
+ * never collapse via this path (they may still collapse via the
+ * cross-source condition above if applicable).
  */
 export function dedupeFuzzy(events) {
   const groups = new Map();
@@ -159,9 +230,18 @@ export function dedupeFuzzy(events) {
   const out = [];
   let mergedAway = 0;
   for (const group of groups.values()) {
-    const distinctSources = new Set(group.map((ev) => ev.sourceKey || String(ev.id || '').split(':')[0]));
-    if (group.length === 1 || distinctSources.size < 2) {
+    if (group.length === 1) {
       out.push(...group);
+      continue;
+    }
+    const distinctSources = new Set(group.map((ev) => ev.sourceKey || String(ev.id || '').split(':')[0]));
+    if (distinctSources.size < 2) {
+      const { clusters, singles } = clusterBySameGeo(group);
+      for (const cluster of clusters) {
+        mergedAway += cluster.length - 1;
+        out.push(pickRichestEvent(cluster));
+      }
+      out.push(...singles);
       continue;
     }
     mergedAway += group.length - 1;

--- a/scripts/assemble-events-dataset.mjs
+++ b/scripts/assemble-events-dataset.mjs
@@ -160,13 +160,22 @@ function hasGeo(ev) {
 
 /**
  * Partition a same-`sourceKey` fuzzy-dedup group (already collided on
- * title+startDate+comune) into geo-match clusters — 2+ members within
- * `SAME_SOURCE_GEO_TOLERANCE_KM` of each other, chained transitively so a
- * rare 3-way same-source duplicate still collapses to one cluster — plus the
- * leftover singles (events with no `geo`, or whose `geo` doesn't match anyone
- * else in the group). Reuses the shared `haversineKm` helper
- * (scripts/lib/events-utils.mjs) rather than re-implementing great-circle
- * distance here (AGENTS.md §6).
+ * title+startDate+comune) into geo-match clusters — 2+ members MUTUALLY
+ * within `SAME_SOURCE_GEO_TOLERANCE_KM` of every OTHER member of the same
+ * cluster (a clique, not a chain) — plus the leftover singles (events with no
+ * `geo`, or whose `geo` doesn't clique-match anyone else in the group).
+ *
+ * Deliberately a clique check (`cluster.every(...)`), not a "some existing
+ * member is close enough" chain check: a chain check lets a cluster's
+ * diameter grow past the tolerance transitively (e.g. A-B 45m, B-C 45m would
+ * chain A-B-C together even though A-C is 90m, well past the ~50m same-venue
+ * assumption) — exactly the false-positive risk this same-source path exists
+ * to avoid (see `dedupeFuzzy` docstring below). Requiring every new member to
+ * already be within tolerance of every current member keeps every accepted
+ * cluster's own diameter bounded by `SAME_SOURCE_GEO_TOLERANCE_KM`.
+ *
+ * Reuses the shared `haversineKm` helper (scripts/lib/events-utils.mjs)
+ * rather than re-implementing great-circle distance here (AGENTS.md §6).
  */
 function clusterBySameGeo(group) {
   const withGeo = group.filter(hasGeo);
@@ -182,12 +191,12 @@ function clusterBySameGeo(group) {
       grew = false;
       for (let j = 0; j < withGeo.length; j += 1) {
         if (assigned.has(j)) continue;
-        const withinTolerance = cluster.some(
+        const withinToleranceOfEveryMember = cluster.every(
           (member) =>
             haversineKm(member.geo.lat, member.geo.lng, withGeo[j].geo.lat, withGeo[j].geo.lng) <=
             SAME_SOURCE_GEO_TOLERANCE_KM,
         );
-        if (withinTolerance) {
+        if (withinToleranceOfEveryMember) {
           cluster.push(withGeo[j]);
           assigned.add(j);
           grew = true;

--- a/tests/assemble-events-dedup.test.ts
+++ b/tests/assemble-events-dedup.test.ts
@@ -211,6 +211,45 @@ describe('dedupeFuzzy', () => {
     expect(mergedAway).toBe(1);
   });
 
+  it('does not chain unrelated same-source venues past the geo tolerance (diameter must stay bounded, not just consecutive links)', () => {
+    // Regression for a chain-based clustering bug (caught in PR review): three
+    // same-source records spaced ~40m apart along a line — A-B ~40m,
+    // B-C ~40m, but A-C ~80m, past the 50m tolerance. A clustering rule that
+    // only requires "close to ANY existing cluster member" would incorrectly
+    // chain all three into one record even though the two endpoints are
+    // clearly two different venues — exactly the false-positive this
+    // same-source path exists to avoid.
+    const latPerMeter = 1 / 111194.926645; // matches haversineKm's R=6371km model
+    const base = 46.0;
+    const a = ev({
+      id: 'myswitzerland:a',
+      sourceKey: 'myswitzerland',
+      title: 'Mercatino di Primavera',
+      comune: 'Bellinzona',
+      geo: { lat: base, lng: 8.9 },
+    });
+    const b = ev({
+      id: 'myswitzerland:b',
+      sourceKey: 'myswitzerland',
+      title: 'Mercatino di Primavera',
+      comune: 'Bellinzona',
+      geo: { lat: base + 40 * latPerMeter, lng: 8.9 },
+    });
+    const c = ev({
+      id: 'myswitzerland:c',
+      sourceKey: 'myswitzerland',
+      title: 'Mercatino di Primavera',
+      comune: 'Bellinzona',
+      geo: { lat: base + 80 * latPerMeter, lng: 8.9 },
+    });
+    const { events, mergedAway } = dedupeFuzzy([a, b, c]);
+    // A and B (40m apart) collapse; C (80m from A, past tolerance) must NOT
+    // be swept in just because it is within tolerance of B alone.
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(1);
+    expect(events.some((e) => e.id === 'myswitzerland:c')).toBe(true);
+  });
+
   it('leaves a singleton group untouched', () => {
     const only = ev();
     const { events, mergedAway } = dedupeFuzzy([only]);

--- a/tests/assemble-events-dedup.test.ts
+++ b/tests/assemble-events-dedup.test.ts
@@ -4,7 +4,9 @@
  * per-source slices (data/events/by-source/<key>.json) by `event.id`
  * (last-write-wins), then this SECOND pass collapses the same physical event
  * when two or more different sources (tio-agenda / guidle / myswitzerland)
- * index it independently under a different id.
+ * index it independently under a different id — OR (issue #3744) when the
+ * SAME source indexes its own event twice under a different raw id/URL, as
+ * long as the two records also carry near-identical `geo` coordinates.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -116,16 +118,97 @@ describe('dedupeFuzzy', () => {
     expect(mergedAway).toBe(0);
   });
 
-  it('does NOT collapse a same-source collision (only cross-source groups are merged)', () => {
+  it('does NOT collapse a same-source collision without a geo match (only cross-source or geo-matched same-source groups are merged)', () => {
     // Real observed shape: two DIFFERENT events from the same crawler share a
-    // generic title and both region-resolved to the same fallback comune.
-    // Merging these would silently drop a genuine event, so same-source
-    // groups are left untouched even when the fuzzy key collides.
+    // generic title and both region-resolved to the same fallback comune,
+    // with no geo on either side. Merging these would silently drop a
+    // genuine event, so a same-source group without a geo match is left
+    // untouched even when the fuzzy key collides.
     const first = ev({ id: 'tio-agenda:1', sourceKey: 'tio-agenda', venue: 'Piazza A' });
     const second = ev({ id: 'tio-agenda:2', sourceKey: 'tio-agenda', venue: 'Piazza B' });
     const { events, mergedAway } = dedupeFuzzy([first, second]);
     expect(events).toHaveLength(2);
     expect(mergedAway).toBe(0);
+  });
+
+  it('does NOT collapse a same-source collision when only one side has geo', () => {
+    const first = ev({
+      id: 'tio-agenda:1',
+      sourceKey: 'tio-agenda',
+      venue: 'Piazza A',
+      geo: { lat: 46.0037, lng: 8.9511 },
+    });
+    const second = ev({ id: 'tio-agenda:2', sourceKey: 'tio-agenda', venue: 'Piazza B' });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('does NOT collapse a same-source collision when geo coordinates are far apart (> tolerance)', () => {
+    const first = ev({
+      id: 'tio-agenda:1',
+      sourceKey: 'tio-agenda',
+      venue: 'Piazza A',
+      geo: { lat: 46.0037, lng: 8.9511 }, // Lugano
+    });
+    const second = ev({
+      id: 'tio-agenda:2',
+      sourceKey: 'tio-agenda',
+      venue: 'Piazza B',
+      geo: { lat: 46.1712, lng: 8.7955 }, // Bellinzona, ~20km away
+    });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(2);
+    expect(mergedAway).toBe(0);
+  });
+
+  it('collapses a same-source collision when geo coordinates match exactly (issue #3744)', () => {
+    // Real observed shape: myswitzerland indexed "Heididorf Saisoneröffnung"
+    // twice under two different objectIDs, same startDate/comune and EXACT
+    // geo coordinates — the by-id merge never catches it (different ids) and
+    // the cross-source condition never catches it either (same sourceKey).
+    const geo = { lat: 47.017265, lng: 9.5443047 };
+    const first = ev({
+      id: 'myswitzerland:objA',
+      sourceKey: 'myswitzerland',
+      title: 'Heididorf Saisoneröffnung',
+      comune: 'Maienfeld',
+      geo,
+    });
+    const second = ev({
+      id: 'myswitzerland:objB',
+      sourceKey: 'myswitzerland',
+      title: 'Heididorf Saisoneröffnung',
+      comune: 'Maienfeld',
+      geo: { ...geo },
+      description: 'Richer description on this duplicate.',
+    });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(1);
+    expect(mergedAway).toBe(1);
+    // Richer (has description) record wins.
+    expect(events[0].id).toBe('myswitzerland:objB');
+  });
+
+  it('collapses a same-source collision when geo coordinates are within the ~50m tolerance but not exact', () => {
+    const first = ev({
+      id: 'myswitzerland:objA',
+      sourceKey: 'myswitzerland',
+      title: 'Heididorf Saisoneröffnung',
+      comune: 'Maienfeld',
+      geo: { lat: 47.017265, lng: 9.5443047 },
+    });
+    // ~10m latitude offset — same physical venue, minor geocoding jitter.
+    const second = ev({
+      id: 'myswitzerland:objB',
+      sourceKey: 'myswitzerland',
+      title: 'Heididorf Saisoneröffnung',
+      comune: 'Maienfeld',
+      geo: { lat: 47.017355, lng: 9.5443047 },
+    });
+    const { events, mergedAway } = dedupeFuzzy([first, second]);
+    expect(events).toHaveLength(1);
+    expect(mergedAway).toBe(1);
   });
 
   it('leaves a singleton group untouched', () => {


### PR DESCRIPTION
## Implementato

- Extended `dedupeFuzzy` in `scripts/assemble-events-dataset.mjs` so a fuzzy-dedup group `(normalizedTitle, startDate, normalizedComune)` that comes entirely from a **single** `sourceKey` now ALSO collapses when its members carry `geo` coordinates within ~50m of each other (haversine), not just when the group spans 2+ distinct sources.
- Added `clusterBySameGeo` helper + `SAME_SOURCE_GEO_TOLERANCE_KM` constant; reuses the existing `haversineKm` export from `scripts/lib/events-utils.mjs` (imported, not duplicated — AGENTS.md §6).
- Confirmed real-world case now collapses: two `myswitzerland` records for "Heididorf Saisoneröffnung" (same startDate 2026-07-04, same comune Maienfeld, identical geo `{lat: 47.017265, lng: 9.5443047}`, different objectIDs) merge to a single richest record.
- **Follow-up commit (review fix):** the first pass grouped candidates with a chain check (join if within tolerance of ANY existing cluster member), which could let a cluster's diameter exceed the tolerance transitively (e.g. A-B 45m, B-C 45m chained even though A-C was 90m). Fixed to a clique check (join only if within tolerance of EVERY current member), bounding every accepted cluster's diameter to `SAME_SOURCE_GEO_TOLERANCE_KM`. Added a regression test for the exact 0m/40m/80m chain scenario.
- Extended `tests/assemble-events-dedup.test.ts` with 6 new cases (same-source geo-exact match, geo within tolerance/~10m jitter, geo far apart, one-sided geo, the chain/diameter regression) plus updated one pre-existing same-source test's wording to reflect the new geo-based exemption boundary. Full suite: 22/22 passing (`npx vitest run assemble-events-dedup`).
- Updated the module-header doc comment and `dedupeFuzzy`/`clusterBySameGeo` JSDoc to describe both collapse conditions and the clique-vs-chain rationale accurately.

## Non implementato (ancora)

- Nessuno per lo scope di questa issue. Il fix copre esattamente il caso confermato (same-sourceKey + geo match) richiesto da #3744, incluso il fix del finding di review sulla diameter/chain.
- Nota per chiarezza (comportamento intenzionale, non scope residuo): il dataset contiene altri 8 gruppi con lo stesso `(title, startDate)` non ancora verificati a fondo (menzionati nell'issue stessa, inclusi alcuni `tio-agenda`). Questa PR NON li tocca — restano separati a meno che le loro coordinate `geo` non coincidano entro la tolleranza di ~50m introdotta qui, che è esattamente il criterio-guardia richiesto per discriminare falsi positivi (es. repliche legittimamente distinte dello stesso evento nello stesso giorno) da veri duplicati. Se un futuro triage manuale conferma un geo-match su uno di quei gruppi, questo stesso fix lo collasserà automaticamente al prossimo run di `assemble-events-dataset.mjs` — nessun lavoro aggiuntivo necessario in quel caso.

Closes #3744