### PR TITLE
chore(ci): slow notify-journalist-article-live fallback cron to 2h

### DIFF
--- a/.github/workflows/notify-journalist-article-live.yml
+++ b/.github/workflows/notify-journalist-article-live.yml
@@ -13,7 +13,7 @@ on:
   schedule:
     # Fallback in case a workflow_run event is missed/delayed — cheap no-op
     # when there's nothing awaiting live confirmation.
-    - cron: '*/20 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Implementato
- Fallback cron in `.github/workflows/notify-journalist-article-live.yml` cambiato da `*/20 * * * *` (ogni 20 min) a `0 */2 * * *` (ogni 2h), su richiesta owner
- Trigger primario resta `workflow_run` su `Deploy to GitHub Pages` completato — invariato

## Non implementato (ancora)
Nessuno