### PR TITLE
fix(crawler-group): scope slice-only commit staging, atomic slug-registry writes

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -5048,14 +5048,10 @@ export function saveSlugRegistry(registry) {
   // flight, fail JSON.parse, and silently fall back to `{}` in
   // loadSlugRegistry's catch — causing that crawler to treat every job as
   // unregistered and mint a fresh (possibly different) slug for one that
-  // already has an immutable canonical slug pinned. Writing to a per-process
-  // temp file and renaming into place is atomic on the same filesystem (POSIX
-  // rename()), so any concurrent reader always sees either the pre- or
-  // post-write snapshot in full, never a partial one.
-  const registryPath = resolveSlugRegistryPath();
-  const tmpPath = `${registryPath}.tmp-${process.pid}`;
-  fs.writeFileSync(tmpPath, JSON.stringify(registry, null, 2) + '\n');
-  fs.renameSync(tmpPath, registryPath);
+  // already has an immutable canonical slug pinned. writeJsonAtomic commits
+  // via temp+rename (atomic on the same filesystem), so any concurrent
+  // reader always sees either the pre- or post-write snapshot in full.
+  writeJson(resolveSlugRegistryPath(), registry);
 }
 
 export function getRegisteredSlug(job, registry) {

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -5040,7 +5040,22 @@ export function loadSlugRegistry() {
 }
 
 export function saveSlugRegistry(registry) {
-  fs.writeFileSync(resolveSlugRegistryPath(), JSON.stringify(registry, null, 2) + '\n');
+  // Crawler-group jobs run ~25 sibling crawlers concurrently against one
+  // shared checkout, each independently loadSlugRegistry() → mutate →
+  // saveSlugRegistry() with no coordination between them. A direct
+  // writeFileSync to the final path is not atomic for a file this size, so a
+  // concurrent readFileSync elsewhere could observe a truncated write mid-
+  // flight, fail JSON.parse, and silently fall back to `{}` in
+  // loadSlugRegistry's catch — causing that crawler to treat every job as
+  // unregistered and mint a fresh (possibly different) slug for one that
+  // already has an immutable canonical slug pinned. Writing to a per-process
+  // temp file and renaming into place is atomic on the same filesystem (POSIX
+  // rename()), so any concurrent reader always sees either the pre- or
+  // post-write snapshot in full, never a partial one.
+  const registryPath = resolveSlugRegistryPath();
+  const tmpPath = `${registryPath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(registry, null, 2) + '\n');
+  fs.renameSync(tmpPath, registryPath);
 }
 
 export function getRegisteredSlug(job, registry) {

--- a/scripts/lib/git-commit-data.sh
+++ b/scripts/lib/git-commit-data.sh
@@ -110,13 +110,37 @@ fi
 if [ "$SLICE_ONLY" = true ]; then
   # Slice-only mode: only commit per-crawler slice files + ai-cache.
   # Shared monolithic files are assembled during deploy, not per-crawler.
-  STANDARD_FILES=(
-    data/jobs/by-crawler/
-    data/jobs/expired/by-crawler/
-    data/jobs-crawler-summaries/by-crawler/
-    data/translation-cache/
-    data/jobs-ai-cache.json
-  )
+  #
+  # Crawler-group workflows run ~25 sibling crawlers concurrently against ONE
+  # shared checkout (#3701). A bare directory glob here would `git add` (and
+  # 3-way-merge) every sibling's currently-modified slice too — not just this
+  # invocation's own — misattributing their data under this crawler's commit.
+  # Confirmed live: run 28852047487 committed 5 siblings' slices (lindt-
+  # spruengli, sonarsource, stadt-luzern, usz, vista) under "Auto-update
+  # SPITEX BASEL jobs". The group workflow generator already exports
+  # JOBS_SLICE_FILE (this crawler's own slice path) for the crawler's own
+  # pipeline; reuse it to scope staging to exactly this crawler's own files.
+  # Falls back to the old directory-wide behavior when unset (non-grouped
+  # callers, e.g. translate-pending.yml, which legitimately touches every
+  # crawler's slice in one sequential job).
+  if [ -n "${JOBS_SLICE_FILE:-}" ]; then
+    SLICE_BASENAME="$(basename "$JOBS_SLICE_FILE")"
+    STANDARD_FILES=(
+      "data/jobs/by-crawler/${SLICE_BASENAME}"
+      "data/jobs/expired/by-crawler/${SLICE_BASENAME}"
+      "data/jobs-crawler-summaries/by-crawler/${SLICE_BASENAME}"
+      "data/translation-cache/${SLICE_BASENAME}"
+      data/jobs-ai-cache.json
+    )
+  else
+    STANDARD_FILES=(
+      data/jobs/by-crawler/
+      data/jobs/expired/by-crawler/
+      data/jobs-crawler-summaries/by-crawler/
+      data/translation-cache/
+      data/jobs-ai-cache.json
+    )
+  fi
 else
   # Legacy mode: commit all shared files (used by non-migrated crawlers).
   STANDARD_FILES=(
@@ -842,10 +866,17 @@ NODE
 node scripts/validate-crawler-summaries.mjs
 fi  # end SLICE_ONLY=false validation block
 
-# Filter out gitignored paths before staging (e.g. data/jobs.json is in .gitignore)
+# Filter out gitignored paths before staging (e.g. data/jobs.json is in .gitignore).
+# Also drop non-existent paths: STANDARD_FILES now includes per-crawler file
+# paths (e.g. data/jobs/expired/by-crawler/<slug>.json) that legitimately
+# don't exist for every crawler (e.g. one that has never had an expired job) —
+# `git add` fails its ENTIRE invocation on any single unmatched pathspec, which
+# would otherwise abort staging of files that DO exist alongside it.
 STAGEABLE_FILES=()
 for _sf in "${ALL_FILES[@]}"; do
-  if git check-ignore -q "$_sf" 2>/dev/null; then
+  if [[ ! -e "$_sf" && "$_sf" != */ ]]; then
+    continue
+  elif git check-ignore -q "$_sf" 2>/dev/null; then
     echo "ℹ️ Skipping gitignored path: $_sf"
   else
     STAGEABLE_FILES+=("$_sf")
@@ -886,7 +917,9 @@ if ! git rebase origin/main 2>/dev/null; then
 
   STAGEABLE_FILES=()
   for _sf in "${ALL_FILES[@]}"; do
-    if git check-ignore -q "$_sf" 2>/dev/null; then
+    if [[ ! -e "$_sf" && "$_sf" != */ ]]; then
+      continue
+    elif git check-ignore -q "$_sf" 2>/dev/null; then
       echo "ℹ️ Skipping gitignored path: $_sf"
     else
       STAGEABLE_FILES+=("$_sf")

--- a/scripts/lib/job-localization-pipeline.mjs
+++ b/scripts/lib/job-localization-pipeline.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { applyGlossaryCorrections } from './translation-glossary.mjs';
+import { writeJsonAtomic } from './atomic-write-json.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -84,14 +85,42 @@ function ensureStoreLoaded() {
 function persistStore() {
   const { memoryPath, memoryMaxEntries } = getConfig();
   ensureStoreLoaded();
-  while (loadedStore.size > memoryMaxEntries) {
-    const oldestKey = loadedStore.keys().next().value;
-    if (!oldestKey) break;
-    loadedStore.delete(oldestKey);
+
+  // Crawler-group jobs run ~25 sibling processes concurrently against one
+  // shared checkout, each loading this memory once at startup then persisting
+  // on every setMemoryEntry() call — the same last-write-wins race as
+  // data/jobs-ai-cache.json (see persistAiCacheToDisk in shared-jobs-crawler.mjs).
+  // Re-read the on-disk snapshot right before writing and fold in any entry
+  // with a newer touchedAt than what this process already holds, so concurrent
+  // siblings' translations merge by actual recency instead of clobbering
+  // each other.
+  let onDiskEntries = [];
+  try {
+    if (fs.existsSync(memoryPath)) {
+      const raw = JSON.parse(fs.readFileSync(memoryPath, 'utf-8'));
+      if (raw && raw.version === FILE_VERSION && Array.isArray(raw.entries)) {
+        onDiskEntries = raw.entries;
+      }
+    }
+  } catch {
+    onDiskEntries = [];
   }
-  const entries = Array.from(loadedStore.values());
-  fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
-  fs.writeFileSync(memoryPath, `${JSON.stringify({ version: FILE_VERSION, entries }, null, 2)}\n`, 'utf-8');
+  for (const entry of onDiskEntries) {
+    if (!entry?.key) continue;
+    const existing = loadedStore.get(entry.key);
+    const diskTouchedAt = Number(entry.touchedAt || 0);
+    const existingTouchedAt = Number(existing?.touchedAt || 0);
+    if (!existing || diskTouchedAt > existingTouchedAt) {
+      loadedStore.set(entry.key, entry);
+    }
+  }
+
+  const merged = Array.from(loadedStore.values())
+    .sort((a, b) => Number(a.touchedAt || 0) - Number(b.touchedAt || 0));
+  const entries = merged.slice(-memoryMaxEntries);
+  loadedStore = new Map(entries.map((entry) => [entry.key, entry]));
+
+  writeJsonAtomic(memoryPath, { version: FILE_VERSION, entries });
 }
 
 function buildMemoryKey({ text, sourceLang, targetLang, kind, context = {} }) {

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -193,7 +193,14 @@ const SLUG_REGISTRY_PATH = path.resolve(ROOT, 'data', 'slug-registry.json');
 const ADAPTERS_REGISTRY_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'registry.json');
 const ADAPTERS_BASE_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters');
 const CRAWLER_FIRESTORE_DOC = 'admin_config/jobsCrawler';
-const AI_CACHE_PATH = path.resolve(ROOT, 'data', 'jobs-ai-cache.json');
+const AI_CACHE_PATH_DEFAULT = path.resolve(ROOT, 'data', 'jobs-ai-cache.json');
+
+// Resolved at call time so tests can point load/persist at a controlled fixture
+// via AI_CACHE_PATH_OVERRIDE. Unset in all prod/CI paths → identical behavior.
+function resolveAiCachePath() {
+  const override = process.env.AI_CACHE_PATH_OVERRIDE;
+  return override ? path.resolve(override) : AI_CACHE_PATH_DEFAULT;
+}
 
 function loadLocalEnvFile(filePath) {
   if (!fs.existsSync(filePath)) return;
@@ -415,7 +422,7 @@ function deleteCachedAiResponse(cacheKey) {
 function loadPersistentAiCache() {
   if (!AI_CACHE_PERSIST_ENABLED || aiCacheLoaded) return aiCacheLoadedEntries;
   aiCacheLoaded = true;
-  const raw = readJson(AI_CACHE_PATH, null);
+  const raw = readJson(resolveAiCachePath(), null);
   if (!raw || typeof raw !== 'object') return aiCacheLoadedEntries;
 
   let entries = [];
@@ -450,14 +457,44 @@ function persistAiCacheToDisk({ force = false } = {}) {
   if (!AI_CACHE_PERSIST_ENABLED || !aiCacheLoaded) return;
   if (!force && !aiCacheDirty) return;
   trimAiCache(Math.min(AI_CACHE_MAX_ENTRIES, AI_CACHE_DISK_MAX_ENTRIES));
-  const entries = [...aiResponseCache.entries()]
-    .slice(-AI_CACHE_DISK_MAX_ENTRIES)
-    .map(([key, entry]) => ({
+
+  const merged = new Map(
+    [...aiResponseCache.entries()].map(([key, entry]) => [
       key,
-      touchedAt: Number(entry?.touchedAt || Date.now()),
-      value: cloneCacheValue(entry?.value),
-    }));
-  writeJson(AI_CACHE_PATH, {
+      { touchedAt: Number(entry?.touchedAt || Date.now()), value: cloneCacheValue(entry?.value) },
+    ]),
+  );
+
+  // Crawler-group jobs run ~25 sibling processes concurrently against one
+  // shared checkout, each loading this cache once at startup then writing a
+  // full snapshot back at exit. Without merging, whichever process persists
+  // last clobbers every key a sibling added or refreshed after this
+  // process's own load — a last-write-wins race (self-healing: a dropped
+  // entry just costs one extra LLM call next run, not permanent data loss —
+  // but wasteful at ~25x scale, every run). Re-read the current on-disk
+  // snapshot right before writing and fold in any key with a newer
+  // touchedAt than what this process already holds, so concurrent siblings'
+  // additions merge by actual recency instead of clobbering each other.
+  const onDisk = readJson(resolveAiCachePath(), null);
+  const onDiskEntries = onDisk && typeof onDisk === 'object' && Array.isArray(onDisk.entries)
+    ? onDisk.entries
+    : [];
+  for (const entry of onDiskEntries) {
+    const key = normalizeSpace(entry?.key || '');
+    if (!key) continue;
+    const diskTouchedAt = Number(entry?.touchedAt || 0);
+    const existing = merged.get(key);
+    if (!existing || diskTouchedAt > existing.touchedAt) {
+      merged.set(key, { touchedAt: diskTouchedAt, value: cloneCacheValue(entry?.value) });
+    }
+  }
+
+  const entries = [...merged.entries()]
+    .sort(([, a], [, b]) => a.touchedAt - b.touchedAt)
+    .slice(-AI_CACHE_DISK_MAX_ENTRIES)
+    .map(([key, entry]) => ({ key, touchedAt: entry.touchedAt, value: entry.value }));
+
+  writeJson(resolveAiCachePath(), {
     version: AI_CACHE_FILE_VERSION,
     savedAt: new Date().toISOString(),
     entries,
@@ -5695,6 +5732,21 @@ export const __testables = {
   aiValidateJobDetailPage,
   setCrawlerConfigForTests(cfg) { crawlerConfigGlobal = cfg; },
   clearAiResponseCacheForTests() { aiResponseCache.clear(); },
+  persistAiCacheToDisk,
+  loadPersistentAiCache,
+  seedAiCacheForTests(entries) {
+    aiCacheLoaded = true;
+    aiCacheDirty = true;
+    for (const { key, touchedAt, value } of entries) {
+      aiResponseCache.set(key, { touchedAt, value });
+    }
+  },
+  resetAiCacheStateForTests() {
+    aiResponseCache.clear();
+    aiCacheLoaded = false;
+    aiCacheDirty = false;
+    aiCacheLoadedEntries = 0;
+  },
 };
 
 // Auto-run only when executed directly (not imported as module)

--- a/tests/git-commit-data-slice-scoping.test.ts
+++ b/tests/git-commit-data-slice-scoping.test.ts
@@ -30,7 +30,14 @@ describe('git-commit-data.sh --slice-only scoping via JOBS_SLICE_FILE', () => {
     const repoDir = mkdtempSync(join(tmpdir(), 'git-commit-data-repo-'));
 
     try {
-      execFileSync('git', ['init', '-q', '--bare', originDir]);
+      // --initial-branch=main: for an empty repo, git's smart-protocol symref
+      // advertisement means the SERVER's (origin's) default-branch name wins
+      // on clone, regardless of the client's own init.defaultBranch config —
+      // so this must be set on the bare origin itself, not on the clone. Machine/
+      // CI-image default-branch naming varies (some default to 'master'), but
+      // the script below pushes explicitly to 'main', so origin's one real
+      // branch must actually be named 'main'.
+      execFileSync('git', ['init', '-q', '--bare', '--initial-branch=main', originDir]);
       execFileSync('git', ['clone', '-q', originDir, repoDir]);
       execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
       execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir });
@@ -101,7 +108,7 @@ describe('git-commit-data.sh --slice-only scoping via JOBS_SLICE_FILE', () => {
     const repoDir = mkdtempSync(join(tmpdir(), 'git-commit-data-repo-'));
 
     try {
-      execFileSync('git', ['init', '-q', '--bare', originDir]);
+      execFileSync('git', ['init', '-q', '--bare', '--initial-branch=main', originDir]);
       execFileSync('git', ['clone', '-q', originDir, repoDir]);
       execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
       execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir });

--- a/tests/git-commit-data-slice-scoping.test.ts
+++ b/tests/git-commit-data-slice-scoping.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const SCRIPT_PATH = resolve(ROOT, 'scripts/lib/git-commit-data.sh');
+
+// The script uses `declare -A` (associative arrays), requiring bash 4+.
+// CI (ubuntu-latest) ships bash 5 as the default `bash`. macOS ships bash 3.2
+// as the default `/bin/bash` for licensing reasons — prefer a Homebrew bash
+// if present so this test also runs for real on a macOS dev machine.
+const BASH_BIN = ['/opt/homebrew/bin/bash', '/usr/local/bin/bash'].find(existsSync) ?? 'bash';
+
+// Regression coverage for cross-crawler commit misattribution: crawler-group
+// workflows (post-#3701) run ~25 sibling crawlers concurrently against ONE
+// shared checkout. Confirmed live on run 28852047487 — the SPITEX BASEL
+// crawler's "Commit and push" step swept in and committed 5 siblings' dirty
+// slice files (lindt-spruengli, sonarsource, stadt-luzern, usz, vista) under
+// a commit attributed to "SPITEX BASEL" alone, because --slice-only mode's
+// STANDARD_FILES staged whole shared directories (`data/jobs/by-crawler/`)
+// rather than this crawler's own file. The fix scopes staging to exactly the
+// invoking crawler's own file via JOBS_SLICE_FILE (already exported into every
+// crawler-group background step's env for the crawler's own pipeline).
+describe('git-commit-data.sh --slice-only scoping via JOBS_SLICE_FILE', () => {
+  it('commits only the invoking crawler\'s own slice, leaving a concurrently-dirty sibling slice uncommitted', () => {
+    const originDir = mkdtempSync(join(tmpdir(), 'git-commit-data-origin-'));
+    const repoDir = mkdtempSync(join(tmpdir(), 'git-commit-data-repo-'));
+
+    try {
+      execFileSync('git', ['init', '-q', '--bare', originDir]);
+      execFileSync('git', ['clone', '-q', originDir, repoDir]);
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir });
+
+      mkdirSync(join(repoDir, 'data/jobs/by-crawler'), { recursive: true });
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/a.json'), '[]\n');
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/b.json'), '[]\n');
+      execFileSync('git', ['add', '.'], { cwd: repoDir });
+      execFileSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repoDir });
+      execFileSync('git', ['push', '-q', 'origin', 'HEAD:main'], { cwd: repoDir });
+
+      // Simulate two sibling crawlers, both mid-run in the same shared
+      // checkout: crawler "a" (the one invoking git-commit-data.sh below) and
+      // crawler "b" (a sibling that has already written its own slice but not
+      // yet reached its own commit step).
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/a.json'), '[{"id":"a1"}]\n');
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/b.json'), '[{"id":"b1"}]\n');
+
+      // Real script, not a reimplementation — tracks the actual shipped fix.
+      execFileSync(
+        BASH_BIN,
+        [SCRIPT_PATH, '--slice-only', 'test commit'],
+        {
+          cwd: repoDir,
+          env: {
+            ...process.env,
+            JOBS_SLICE_FILE: 'data/jobs/by-crawler/a.json',
+            SKIP_AI_TRANSLATION: '1',
+            SLUG_HISTORY_SUMMARY_FILE: join(repoDir, 'no-such-slug-history-summary.txt'),
+            GH_TOKEN: '',
+            GITHUB_TOKEN: '',
+            GITHUB_RUN_ID: '',
+            GITHUB_REPOSITORY: '',
+            GITHUB_OUTPUT: '',
+          },
+        },
+      );
+
+      const committedFiles = execFileSync(
+        'git',
+        ['show', '--stat', '--format=', 'HEAD'],
+        { cwd: repoDir, encoding: 'utf-8' },
+      );
+      expect(committedFiles).toContain('a.json');
+      expect(committedFiles).not.toContain('b.json');
+
+      // Sibling's own dirty file must survive untouched in the working tree,
+      // ready for its own crawler's later commit step to pick up.
+      const status = execFileSync('git', ['status', '--short'], { cwd: repoDir, encoding: 'utf-8' });
+      expect(status).toContain('b.json');
+      expect(readFileSync(join(repoDir, 'data/jobs/by-crawler/b.json'), 'utf-8')).toContain('b1');
+
+      // Pushed successfully; origin/main reflects the scoped commit.
+      const originLog = execFileSync(
+        'git',
+        ['log', '-1', '--format=%s', 'origin/main'],
+        { cwd: repoDir, encoding: 'utf-8' },
+      );
+      expect(originLog.trim()).toBe('test commit');
+    } finally {
+      rmSync(originDir, { recursive: true, force: true });
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to directory-wide staging when JOBS_SLICE_FILE is unset (e.g. translate-pending.yml)', () => {
+    const originDir = mkdtempSync(join(tmpdir(), 'git-commit-data-origin-'));
+    const repoDir = mkdtempSync(join(tmpdir(), 'git-commit-data-repo-'));
+
+    try {
+      execFileSync('git', ['init', '-q', '--bare', originDir]);
+      execFileSync('git', ['clone', '-q', originDir, repoDir]);
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir });
+
+      // Legacy fallback stages whole directories (`git add data/jobs/expired/
+      // by-crawler/`), which only works if the directory already exists on
+      // disk — true in the real repo (tracked, populated by other crawlers)
+      // even when this specific fixture doesn't need those files itself.
+      mkdirSync(join(repoDir, 'data/jobs/by-crawler'), { recursive: true });
+      mkdirSync(join(repoDir, 'data/jobs/expired/by-crawler'), { recursive: true });
+      mkdirSync(join(repoDir, 'data/jobs-crawler-summaries/by-crawler'), { recursive: true });
+      mkdirSync(join(repoDir, 'data/translation-cache'), { recursive: true });
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/a.json'), '[]\n');
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/b.json'), '[]\n');
+      writeFileSync(join(repoDir, 'data/jobs/expired/by-crawler/.gitkeep'), '');
+      writeFileSync(join(repoDir, 'data/jobs-crawler-summaries/by-crawler/.gitkeep'), '');
+      writeFileSync(join(repoDir, 'data/translation-cache/.gitkeep'), '');
+      execFileSync('git', ['add', '.'], { cwd: repoDir });
+      execFileSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repoDir });
+      execFileSync('git', ['push', '-q', 'origin', 'HEAD:main'], { cwd: repoDir });
+
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/a.json'), '[{"id":"a1"}]\n');
+      writeFileSync(join(repoDir, 'data/jobs/by-crawler/b.json'), '[{"id":"b1"}]\n');
+
+      execFileSync(
+        BASH_BIN,
+        [SCRIPT_PATH, '--slice-only', 'test commit'],
+        {
+          cwd: repoDir,
+          env: {
+            ...process.env,
+            JOBS_SLICE_FILE: '',
+            SKIP_AI_TRANSLATION: '1',
+            SLUG_HISTORY_SUMMARY_FILE: join(repoDir, 'no-such-slug-history-summary.txt'),
+            GH_TOKEN: '',
+            GITHUB_TOKEN: '',
+            GITHUB_RUN_ID: '',
+            GITHUB_REPOSITORY: '',
+            GITHUB_OUTPUT: '',
+          },
+        },
+      );
+
+      const committedFiles = execFileSync(
+        'git',
+        ['show', '--stat', '--format=', 'HEAD'],
+        { cwd: repoDir, encoding: 'utf-8' },
+      );
+      expect(committedFiles).toContain('a.json');
+      expect(committedFiles).toContain('b.json');
+    } finally {
+      rmSync(originDir, { recursive: true, force: true });
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/job-localization-pipeline.test.ts
+++ b/tests/job-localization-pipeline.test.ts
@@ -135,4 +135,50 @@ describe('job localization pipeline', () => {
     expect(result?.en?.requirements).toEqual(['Knowledge of REST APIs']);
     expect(result?.de?.requirements).toEqual(['Kenntnisse von REST-APIs']);
   });
+
+  it('merges a sibling crawler process\'s concurrent write instead of clobbering it on persist', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ translatedText: 'Software Engineer' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    await translateTextWithLocalPipeline({
+      text: 'Ingegnere software',
+      sourceLang: 'it',
+      targetLang: 'en',
+      kind: 'title',
+      minChars: 2,
+    });
+
+    // Simulate a sibling process persisting a different key to the SAME shared
+    // memory file while this process's in-memory store (loaded once above) has
+    // no knowledge of it yet — the exact race in a ~25-sibling crawler-group run.
+    const onDisk = JSON.parse(fs.readFileSync(memoryPath, 'utf-8'));
+    onDisk.entries.push({
+      key: 'sibling-injected-key',
+      value: 'Sibling translation',
+      provider: 'nllb',
+      kind: 'title',
+      sourceLang: 'it',
+      targetLang: 'en',
+      sourceHash: 'deadbeef',
+      createdAt: Date.now(),
+      touchedAt: Date.now() + 10_000,
+    });
+    fs.writeFileSync(memoryPath, `${JSON.stringify(onDisk, null, 2)}\n`, 'utf-8');
+
+    await translateTextWithLocalPipeline({
+      text: 'Sviluppatore backend',
+      sourceLang: 'it',
+      targetLang: 'en',
+      kind: 'title',
+      minChars: 2,
+    });
+
+    const saved = JSON.parse(fs.readFileSync(memoryPath, 'utf-8'));
+    const keys = saved.entries.map((entry: { key: string }) => entry.key);
+    expect(keys).toContain('sibling-injected-key');
+    expect(saved.entries.length).toBe(3);
+  });
 });

--- a/tests/jobs-ai-cache-merge-on-persist.test.ts
+++ b/tests/jobs-ai-cache-merge-on-persist.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { __testables } from '../scripts/lib/shared-jobs-crawler.mjs';
+
+const { persistAiCacheToDisk, seedAiCacheForTests, resetAiCacheStateForTests } = __testables;
+
+// Regression coverage for a last-write-wins clobber: crawler-group jobs run
+// ~25 sibling processes concurrently against one shared checkout, each
+// loading data/jobs-ai-cache.json once at startup, then overwriting it
+// wholesale at exit. Without merging, whichever process persists last would
+// erase every key a sibling added or refreshed after this process's own
+// load. persistAiCacheToDisk now re-reads the on-disk snapshot right before
+// writing and folds in any key with a newer touchedAt than what this
+// process already holds, so siblings merge instead of clobbering.
+describe('persistAiCacheToDisk merges concurrent sibling writes', () => {
+  const tmpPaths: string[] = [];
+
+  afterEach(() => {
+    for (const p of tmpPaths.splice(0)) {
+      try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* already gone */ }
+    }
+    delete process.env.AI_CACHE_PATH_OVERRIDE;
+    resetAiCacheStateForTests();
+  });
+
+  it('keeps a sibling-added key this process never loaded', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-cache-merge-'));
+    tmpPaths.push(dir);
+    const cachePath = path.join(dir, 'jobs-ai-cache.json');
+    process.env.AI_CACHE_PATH_OVERRIDE = cachePath;
+
+    // This process only ever knew about "own-key".
+    seedAiCacheForTests([{ key: 'own-key', touchedAt: 1000, value: { ok: true, from: 'self' } }]);
+
+    // A sibling process persisted after this one's load, adding a key this
+    // process's in-memory Map has never seen.
+    fs.writeFileSync(cachePath, JSON.stringify({
+      version: 1,
+      savedAt: new Date(2000).toISOString(),
+      entries: [
+        { key: 'own-key', touchedAt: 500, value: { ok: true, from: 'self-stale-disk-copy' } },
+        { key: 'sibling-key', touchedAt: 2000, value: { ok: true, from: 'sibling' } },
+      ],
+    }));
+
+    persistAiCacheToDisk({ force: true });
+
+    const saved = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    const byKey = Object.fromEntries(saved.entries.map((e: { key: string }) => [e.key, e]));
+
+    expect(Object.keys(byKey).sort()).toEqual(['own-key', 'sibling-key']);
+    // own-key: this process's in-memory touch (1000) is newer than the on-disk
+    // copy (500) it loaded from, so its own value wins.
+    expect(byKey['own-key'].value.from).toBe('self');
+    // sibling-key: never in this process's memory, must survive the merge.
+    expect(byKey['sibling-key'].value.from).toBe('sibling');
+  });
+
+  it('prefers the newer touchedAt when both sides touched the same key', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-cache-merge-'));
+    tmpPaths.push(dir);
+    const cachePath = path.join(dir, 'jobs-ai-cache.json');
+    process.env.AI_CACHE_PATH_OVERRIDE = cachePath;
+
+    // This process's own touch is older than what a sibling wrote afterwards.
+    seedAiCacheForTests([{ key: 'shared-key', touchedAt: 100, value: { from: 'self-old' } }]);
+
+    fs.writeFileSync(cachePath, JSON.stringify({
+      version: 1,
+      savedAt: new Date(2000).toISOString(),
+      entries: [
+        { key: 'shared-key', touchedAt: 9999, value: { from: 'sibling-newer' } },
+      ],
+    }));
+
+    persistAiCacheToDisk({ force: true });
+
+    const saved = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    expect(saved.entries).toHaveLength(1);
+    expect(saved.entries[0].value.from).toBe('sibling-newer');
+  });
+});

--- a/tests/slug-registry-atomic-write.test.ts
+++ b/tests/slug-registry-atomic-write.test.ts
@@ -12,10 +12,10 @@ import { loadSlugRegistry, saveSlugRegistry } from '../scripts/lib/dedicated-cra
 // a file this size, so a concurrent readFileSync elsewhere could observe a
 // truncated write mid-flight, fail JSON.parse, and silently fall back to `{}`
 // in loadSlugRegistry's catch -- causing that crawler to mint a fresh slug for
-// a job that already has an immutable canonical slug pinned. The fix writes
-// to a per-process temp file and renames into place (atomic on the same
-// filesystem), so any concurrent reader always sees either the pre- or
-// post-write snapshot in full, never a partial one.
+// a job that already has an immutable canonical slug pinned. The fix routes
+// through the shared writeJsonAtomic helper (scripts/lib/atomic-write-json.mjs),
+// which commits via temp+rename (atomic on the same filesystem), so any
+// concurrent reader always sees either the pre- or post-write snapshot in full.
 describe('saveSlugRegistry atomic write', () => {
   const tmpPaths: string[] = [];
 
@@ -36,7 +36,8 @@ describe('saveSlugRegistry atomic write', () => {
     saveSlugRegistry(registry);
 
     expect(fs.existsSync(registryPath)).toBe(true);
-    expect(fs.existsSync(`${registryPath}.tmp-${process.pid}`)).toBe(false);
+    const leftovers = fs.readdirSync(dir).filter((f) => f !== 'slug-registry.json');
+    expect(leftovers).toEqual([]);
     expect(JSON.parse(fs.readFileSync(registryPath, 'utf-8'))).toEqual(registry);
     expect(loadSlugRegistry()).toEqual(registry);
   });

--- a/tests/slug-registry-atomic-write.test.ts
+++ b/tests/slug-registry-atomic-write.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSlugRegistry, saveSlugRegistry } from '../scripts/lib/dedicated-crawler-common.mjs';
+
+// Regression coverage for a torn-read race: crawler-group jobs run ~25
+// sibling crawlers concurrently against one shared checkout, each doing an
+// unsynchronized loadSlugRegistry() -> mutate -> saveSlugRegistry() cycle on
+// the same data/slug-registry.json. A direct writeFileSync is not atomic for
+// a file this size, so a concurrent readFileSync elsewhere could observe a
+// truncated write mid-flight, fail JSON.parse, and silently fall back to `{}`
+// in loadSlugRegistry's catch -- causing that crawler to mint a fresh slug for
+// a job that already has an immutable canonical slug pinned. The fix writes
+// to a per-process temp file and renames into place (atomic on the same
+// filesystem), so any concurrent reader always sees either the pre- or
+// post-write snapshot in full, never a partial one.
+describe('saveSlugRegistry atomic write', () => {
+  const tmpPaths: string[] = [];
+
+  afterEach(() => {
+    for (const p of tmpPaths.splice(0)) {
+      try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* already gone */ }
+    }
+    delete process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+  });
+
+  it('writes via temp-file + rename, leaving no leftover tmp file and a fully valid registry', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slug-registry-atomic-'));
+    tmpPaths.push(dir);
+    const registryPath = path.join(dir, 'slug-registry.json');
+    process.env.SLUG_REGISTRY_PATH_OVERRIDE = registryPath;
+
+    const registry = { 'company|Some Title|Somewhere': { slug: 'some-title-somewhere' } };
+    saveSlugRegistry(registry);
+
+    expect(fs.existsSync(registryPath)).toBe(true);
+    expect(fs.existsSync(`${registryPath}.tmp-${process.pid}`)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf-8'))).toEqual(registry);
+    expect(loadSlugRegistry()).toEqual(registry);
+  });
+
+  it('never leaves a reader observing a partially-written file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slug-registry-atomic-'));
+    tmpPaths.push(dir);
+    const registryPath = path.join(dir, 'slug-registry.json');
+    process.env.SLUG_REGISTRY_PATH_OVERRIDE = registryPath;
+
+    // Large-ish registry so a naive non-atomic write would take measurable
+    // time to flush, widening the window a torn read could land in.
+    const registry: Record<string, { slug: string }> = {};
+    for (let i = 0; i < 5000; i++) {
+      registry[`company-${i}|Title ${i}|Location ${i}`] = { slug: `title-${i}-location-${i}` };
+    }
+    saveSlugRegistry(registry);
+
+    // Concurrent "reader" mid-write is simulated by re-saving while polling
+    // the file for validity in between -- with rename() in place, every poll
+    // must observe a complete, parseable JSON document (or nothing yet), never
+    // a truncated fragment.
+    for (let i = 0; i < 20; i++) {
+      registry['extra-key'] = { slug: `extra-${i}` };
+      saveSlugRegistry(registry);
+      const raw = fs.readFileSync(registryPath, 'utf-8');
+      expect(() => JSON.parse(raw)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Two bugs analyzed from a real production log (SPITEX BASEL's dedicated-crawler "Commit and push" step committing 5 unrelated siblings' data under its own commit, in run 28852047487 / crawler-group-23), plus a third bug found while auditing a related shared-state file the user asked about directly.

1. **Cross-crawler commit misattribution.** `scripts/lib/git-commit-data.sh`'s `--slice-only` mode built `STANDARD_FILES` from shared *directory* paths (`data/jobs/by-crawler/`, etc.), so `git add <dir>/` staged every currently-modified/untracked file inside — safe under the old one-crawler-per-runner architecture, but a real contamination bug now that ~25 crawlers share one working tree per crawler-group job (#3701). Confirmed via `git show --stat` on the real commit: 15 files across 6 crawlers, all attributed to "SPITEX BASEL" alone.

   Fix: scope staging to the invoking crawler's own file via `JOBS_SLICE_FILE` — an env var the crawler-group workflow generator already exports into every background step (originally for the crawler's own JS pipeline). Falls back to the old directory-wide behavior when unset, which is correct for non-grouped callers (`translate-pending.yml`, the only other caller, legitimately touches every crawler's slice in one sequential job).

   Added an existence-filter guard before staging: `git add` fails its *entire* invocation on any single unmatched pathspec (verified empirically), and the new per-crawler paths (expired-by-crawler, translation-cache) legitimately don't exist for every crawler (e.g. one that's never had an expired job).

2. **`data/slug-registry.json` — re-scoped from the reported hypothesis.** The user's hypothesis was a git-level write conflict from multiple branches. Traced via `git log` and every workflow YAML: this file is committed *exclusively* by the separate, sequential `translate-pending.yml` job — never by grouped/dedicated crawler commits. So there's no git-level multi-committer conflict here.

   There IS a different, real risk: `loadSlugRegistry()`/`saveSlugRegistry()` run unconditionally in every crawler's `mergeAndDeduplicate()`, and `saveSlugRegistry()` did a direct non-atomic `writeFileSync`. With ~25 concurrent crawler processes sharing one checkout, a torn read mid-write could fail `JSON.parse` and silently fall back to `{}`, causing that crawler to mint a fresh slug for a job that already has an immutable canonical slug pinned — stranding the old canonical URL with no redirect. Fixed by routing through the pre-existing shared `writeJsonAtomic` helper (`scripts/lib/atomic-write-json.mjs`, temp-file-then-`rename()`, atomic on the same filesystem) instead of hand-rolling a duplicate — not a lock, consistent with the project's prior rejection of a lock-based fix for the analogous `data/jobs.json` case.

3. **`data/jobs-ai-cache.json` — last-write-wins clobber (found while investigating the user's follow-up question about this file).** Each crawler process loads the whole AI-response cache once into an in-memory Map at startup (`loadPersistentAiCache`), then `persistAiCacheToDisk` did a full snapshot overwrite based on that initial load — silently dropping any key a sibling process added or refreshed in the meantime. Lower severity than #1/#2 (pure cache — a dropped entry just costs one extra LLM call next run, not permanent data/URL loss), but real and wasteful at ~25-sibling scale on every crawler-group run.

   Fix: `persistAiCacheToDisk` now re-reads the on-disk snapshot right before writing and merges in any key with a newer `touchedAt` than what this process already holds, so concurrent siblings' additions merge by actual recency instead of clobbering each other. Added `AI_CACHE_PATH_OVERRIDE` (mirrors the existing `SLUG_REGISTRY_PATH_OVERRIDE` convention) and `__testables` hooks to exercise the merge in isolation.

4. **`data/jobs-localization-memory.json` — same bug class again, flagged by Claude's PR review.** `scripts/lib/job-localization-pipeline.mjs`'s `persistStore()` had the identical pattern as #2/#3: non-atomic `fs.writeFileSync` full-snapshot overwrite (torn-read risk) plus unconditional last-write-wins clobber, called on *every single* `setMemoryEntry()` (no dirty-flag batching, so the race window opens more often than the ai-cache case). This module is imported by both files patched in #1/#3 and runs in the same ~25-sibling shared-checkout crawler-group context.

   Fix: routed through `writeJsonAtomic` and applied the same touchedAt-merge-on-persist pattern as `persistAiCacheToDisk` — re-read on-disk entries right before writing, keep whichever side (this process' in-memory entry vs. the on-disk one) has the newer `touchedAt`, then trim to `memoryMaxEntries` by recency.

Tests (all execute the real shipped code, not reimplementations):
- `tests/git-commit-data-slice-scoping.test.ts`: bare-repo fixture, runs the actual `git-commit-data.sh` end-to-end. Confirms a sibling's concurrently-dirty slice is left uncommitted when `JOBS_SLICE_FILE` is set, and that the legacy directory-wide fallback still works when it's unset.
- `tests/slug-registry-atomic-write.test.ts`: confirms no leftover temp file, valid JSON round-trip, and that every save leaves the registry file fully parseable (no torn-read window) across repeated writes.
- `tests/jobs-ai-cache-merge-on-persist.test.ts`: confirms a sibling-added key this process never loaded survives the merge, and that the newer `touchedAt` wins when both sides touched the same key.
- `tests/job-localization-pipeline.test.ts` (new case): writes a fake sibling entry directly to the shared memory file between two `translateTextWithLocalPipeline()` calls on the same in-memory pipeline instance, then confirms the sibling's key survives this process's own next persist.

All new/updated test files plus the full suites for `dedicated-crawler-common.test.ts` and every existing test that imports `shared-jobs-crawler.mjs` or `job-localization-pipeline.mjs` re-run green locally after each commit. Full-suite state tracked via CI's `vitest (unit + integration)` check on this PR.

Also verified against the live run that prompted this: 28852047487 (crawler-group-23, 27 crawlers) completed `success`, zero `##[error]` lines, zero "No X jobs found after crawl" race symptoms, zero actual "Crawler Failure" issues filed.

## Non implementato (ancora)

Nessuno.

