### PR TITLE
fix(events): translate nationwide event locales + normalize source categories

### DIFF
--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -70,6 +70,7 @@ import {
   resolveCantonUrlKey,
   UNRESOLVED_CANTON_KEY,
   UNRESOLVED_CANTON_LABEL,
+  normalizeText,
 } from '../scripts/lib/events-utils.mjs';
 import { getCantonLabel, type CantonLocale } from '../services/cantonList';
 import { imageObjectLd, type ImageObjectLd } from '../services/seo/imageObjectLd';
@@ -675,9 +676,83 @@ const CATEGORY_LABEL: Record<string, Record<Locale, string>> = {
   altro: { it: 'Eventi', en: 'Events', de: 'Anlässe', fr: 'Événements' },
 };
 
-function categoryLabel(category: string | undefined, locale: Locale): string {
+// Source→taxonomy normalization (issue #3742): tio-agenda's own categories
+// already ARE the taxonomy keys above (verified live: every tio-agenda
+// event.category is one of arte/musica/teatro/cinema/feste/musei/conferenze/
+// sport/appuntamenti/sociale/altro), so the lookup below is a no-op for that
+// source. The two nationwide sources are not: myswitzerland derives its
+// category from a humanized schema.org Event `@type` (English — "Music",
+// "Sports", "Theater", "Food", "Exhibition", "Festival", or the generic
+// "Event" for 77% of its events), and guidle scrapes a free-text German/
+// Italian sub-genre from its "Kategorie" accordion (e.g. "Rock generalmente",
+// "Teatro: improvisazione", "Ambient / Electronica" — 47 distinct values,
+// none of them a taxonomy key). Left as-is, BOTH fell through to the raw
+// title-cased passthrough below, showing the wrong language on non-source
+// locales and, for the "Event" default alone, misclassifying 667/1084 (61.5%)
+// of ALL crawled events into the generic bucket under the literal English
+// word "Event". Normalizing HERE (at label-lookup time, not crawl time) fixes
+// every already-crawled event retroactively, not just future crawls.
+const SOURCE_CATEGORY_ALIASES: Record<string, string> = {
+  // myswitzerland: `humanizeCategory()` output (scripts/crawl-myswitzerland-events.mjs)
+  // — one entry per schema.org Event `@type` actually seen live in
+  // data/events/by-source/myswitzerland.json (verified 2026-07-07: Event 778,
+  // Music 98, Sports 50, Theater 43, Food 22, Exhibition 8, Festival 7).
+  event: 'altro',
+  music: 'musica',
+  sports: 'sport',
+  theater: 'teatro',
+  food: 'feste',
+  exhibition: 'musei',
+  festival: 'feste',
+};
+
+// guidle: free-text sub-genre keyword rules, checked in order (most specific
+// first) so an overlapping word (e.g. "Musical" containing "music") resolves
+// to the intended bucket. Matched against the accent-stripped/lowercased
+// category (see `normalizeCategoryKey`), so accented variants need no
+// duplicate entry. Deliberately conservative: a handful of genuinely
+// ambiguous long-tail categories (e.g. "Contemplazione / Meditazione",
+// "Salute / Medicina", "Danza libera", "Assistanza nella vita quotidiana")
+// are NOT covered and fall through to the `altro` default below — same
+// "no confident signal, don't guess" policy as everywhere else in this file.
+const CATEGORY_KEYWORD_RULES: Array<[RegExp, string]> = [
+  [/teatro|theater|theatre|comm?edia|improvisazion|musical/, 'teatro'],
+  [/cinema|\bfilm\b|kino/, 'cinema'],
+  [
+    /\brock\b|\bpop\b|jazz|classica|klassik|\bfolk\b|\bmusic\w*|musik|ambient|electronica|elettronica|barocco|cantautore|sperimentale|hip.?hop|\blatin\b|metal|hardcore|salsa|reggae|dancehall|industrial|\bnoise\b/,
+    'musica',
+  ],
+  [/festa|festival|\bparty\b|\bcibo\b|sagra/, 'feste'],
+  [/\barte\b|kunst|mostra|esposizione|ausstellung/, 'arte'],
+  [/museo|museum/, 'musei'],
+  [/\bsport\w*|escursionismo|equestre|nautic/, 'sport'],
+  [/conferenza|vortrag|\btalk\b/, 'conferenze'],
+];
+
+/**
+ * Resolve a raw source category to one of `CATEGORY_LABEL`'s taxonomy keys,
+ * or `undefined` when nothing matches (caller falls back to the raw
+ * passthrough, same as before this normalization existed). Pure, no i18n —
+ * exported for direct unit testing.
+ */
+export function normalizeCategoryKey(category: string | undefined): string | undefined {
+  if (!category) return undefined;
+  const trimmed = category.trim();
+  if (!trimmed) return undefined;
+  if (CATEGORY_LABEL[trimmed]) return trimmed; // already a valid taxonomy key
+  const normalized = normalizeText(trimmed);
+  if (SOURCE_CATEGORY_ALIASES[normalized]) return SOURCE_CATEGORY_ALIASES[normalized];
+  for (const [rx, key] of CATEGORY_KEYWORD_RULES) {
+    if (rx.test(normalized)) return key;
+  }
+  return undefined;
+}
+
+export function categoryLabel(category: string | undefined, locale: Locale): string {
   if (!category) return CATEGORY_LABEL.altro[locale];
-  return CATEGORY_LABEL[category]?.[locale] ?? category.charAt(0).toUpperCase() + category.slice(1);
+  const normalized = normalizeCategoryKey(category);
+  if (normalized) return CATEGORY_LABEL[normalized][locale];
+  return category.charAt(0).toUpperCase() + category.slice(1);
 }
 
 type CategoryTone = 'accent' | 'info' | 'success' | 'warning' | 'neutral';

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -105,6 +105,9 @@ import {
   resolveComuneNationwide,
   mirrorEventImage,
   parsePriceText,
+  loadEventTitleTranslationCache,
+  saveEventTitleTranslationCache,
+  enrichEventsWithLocaleFallbackTranslations,
 } from './lib/events-utils.mjs';
 import { loadCursor, saveCursor, mergeEventsIntoSlice } from './lib/crawl-checkpoint.mjs';
 
@@ -557,13 +560,23 @@ async function main() {
     );
   }
 
+  // #3741: guidle's it→en→de→fr locale-page merge very often carries the SAME
+  // title/description text across locales (organizer never translated it)
+  // instead of a missing locale — fill those gaps via the free-translate.mjs
+  // cascade, same disk cache as crawl-tio-agenda.mjs.
+  const translationCache = loadEventTitleTranslationCache();
+  const translatedEvents = await enrichEventsWithLocaleFallbackTranslations(events, translationCache);
+  const titleFilled = translatedEvents.filter((e) => e.titleByLocale && LOCALES.every((l) => e.titleByLocale[l])).length;
+  console.log(`[guidle] locale-fallback translation: ${titleFilled}/${translatedEvents.length} event(s) now have title in all ${LOCALES.length} locales`);
+
   if (dryRun) {
     console.log('🏃 dry-run — slice/checkpoint not written');
-    console.log(JSON.stringify(events.slice(0, 3), null, 2));
+    console.log(JSON.stringify(translatedEvents.slice(0, 3), null, 2));
     return;
   }
 
   if (!limit && entries.length > 0) saveCursor(SOURCE.key, cursor, crawledAt);
+  saveEventTitleTranslationCache(translationCache);
 
   if (events.length === 0 && goneIds.length === 0) {
     // Never overwrite a good slice with an empty run. Distinguish two causes:
@@ -590,7 +603,7 @@ async function main() {
     slicePath,
     sourceKey: SOURCE.key,
     sourceName: SOURCE.label,
-    freshEvents: events,
+    freshEvents: translatedEvents,
     goneIds,
     crawledAt,
   });

--- a/scripts/crawl-myswitzerland-events.mjs
+++ b/scripts/crawl-myswitzerland-events.mjs
@@ -68,6 +68,9 @@ import {
   resolveComuneNationwide,
   resolveItalianFrontierComuni,
   mirrorEventImage,
+  loadEventTitleTranslationCache,
+  saveEventTitleTranslationCache,
+  enrichEventsWithLocaleFallbackTranslations,
 } from './lib/events-utils.mjs';
 import { loadCursor, saveCursor, mergeEventsIntoSlice } from './lib/crawl-checkpoint.mjs';
 
@@ -555,13 +558,23 @@ async function main() {
       `detail-page enrichment ${detailOk} ok / ${detailFail} fallback (index-only fields) — comune resolved ${resolved}/${events.length}`,
   );
 
+  // #3741: the Algolia per-locale search index very often ships the SAME
+  // title/description text across it/en/de/fr (the organizer never
+  // translated it) instead of a missing locale — fill those gaps via the
+  // free-translate.mjs cascade, same disk cache as crawl-tio-agenda.mjs.
+  const translationCache = loadEventTitleTranslationCache();
+  const translatedEvents = await enrichEventsWithLocaleFallbackTranslations(events, translationCache);
+  const titleFilled = translatedEvents.filter((e) => e.titleByLocale && LOCALES.every((l) => e.titleByLocale[l])).length;
+  console.log(`[myswitzerland] locale-fallback translation: ${titleFilled}/${translatedEvents.length} event(s) now have title in all ${LOCALES.length} locales`);
+
   if (dryRun) {
     console.log('🏃 dry-run — slice/checkpoint not written');
-    console.log(JSON.stringify(events.slice(0, 3), null, 2));
+    console.log(JSON.stringify(translatedEvents.slice(0, 3), null, 2));
     return;
   }
 
   if (!limit && records.length > 0) saveCursor(SOURCE.key, cursor, crawledAt);
+  saveEventTitleTranslationCache(translationCache);
 
   if (events.length === 0) {
     // Never overwrite a good slice with an empty run. Distinguish three causes:
@@ -592,7 +605,7 @@ async function main() {
     slicePath,
     sourceKey: SOURCE.key,
     sourceName: SOURCE.label,
-    freshEvents: events,
+    freshEvents: translatedEvents,
     goneIds: [],
     crawledAt,
   });

--- a/scripts/lib/events-utils.mjs
+++ b/scripts/lib/events-utils.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { truncateSlugAtWordBoundary } from './slug-truncate.mjs';
 import CANTON_URL_SLUGS from '../../data/canton-url-slugs.json' with { type: 'json' };
 import { MUNICIPALITIES } from '../../data/municipalities.ts';
+import { freeTranslateWithRetry } from './free-translate.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -752,6 +753,116 @@ export function loadEventTitleTranslationCache() {
 /** Persist the title translation cache back to disk (pretty-printed, stable diffs). */
 export function saveEventTitleTranslationCache(cache) {
   writeFileSync(TRANSLATION_CACHE_PATH, `${JSON.stringify(cache, null, 2)}\n`, 'utf-8');
+}
+
+// ── Cross-locale fallback translation (issue #3741) ──────────────────────
+// tio-agenda (crawl-tio-agenda.mjs `enrichEventsWithTranslations`) already
+// runs the free-translate.mjs cascade for its own locale-less IT-only cards.
+// The two nationwide sources (guidle, myswitzerland) DO ship real per-locale
+// `titleByLocale`/`descriptionByLocale` text, but the organizer very often
+// leaves it duplicated verbatim across locales instead of translating it —
+// verified live: 699/854 myswitzerland events and 89/97 guidle events carry
+// identical text in every present locale (vs 0/133 for tio-agenda). A locale
+// slot counts as "untranslated" when it is missing OR its normalized text
+// collides with another present locale's normalized text; those slots get
+// machine-translated from the first present, non-colliding locale (in
+// `locales` priority order), or from the first present locale if ALL of them
+// collide. Shared here (not copy-pasted into both crawlers, AGENTS.md §6) and
+// reuses the SAME on-disk cache as `loadEventTitleTranslationCache` — a
+// compound key (`fieldType::sourceLocale::normalizedSourceText`) keeps new
+// entries collision-free against tio-agenda's own bare-title keys.
+const LOCALE_FALLBACK_DELAY_MS = 200;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Which locales in `byLocale` (a `titleByLocale`/`descriptionByLocale`-shaped
+ * map) need a machine translation: missing, or textually identical (after
+ * accent/case/whitespace normalization) to another present locale. Pure — no
+ * network, no mutation. Exported for direct unit testing.
+ */
+export function localesNeedingTranslation(byLocale, locales = ['it', 'en', 'de', 'fr']) {
+  const present = locales.filter((l) => typeof byLocale?.[l] === 'string' && byLocale[l].trim());
+  const normalized = new Map();
+  const counts = new Map();
+  for (const l of present) {
+    const n = normalizeText(byLocale[l]).replace(/\s+/g, ' ');
+    normalized.set(l, n);
+    counts.set(n, (counts.get(n) || 0) + 1);
+  }
+  const needing = [];
+  for (const l of locales) {
+    if (!present.includes(l)) {
+      needing.push(l);
+    } else if ((counts.get(normalized.get(l)) || 0) > 1) {
+      needing.push(l); // duplicate of another present locale — treat as untranslated
+    }
+  }
+  return needing;
+}
+
+/**
+ * Fill in missing/duplicate locales of ONE `titleByLocale`/
+ * `descriptionByLocale` map via the free translation cascade, memoized on
+ * disk in `cache` (caller loads/saves once per run, same convention as
+ * `loadEventTitleTranslationCache`). Returns a NEW map — never mutates
+ * `byLocale` — or the SAME reference when nothing needs translating.
+ */
+async function fillLocaleGaps(byLocale, cache, { fieldType, locales, delayMs, translateFn }) {
+  const needing = localesNeedingTranslation(byLocale, locales);
+  if (needing.length === 0) return byLocale;
+
+  const present = locales.filter((l) => typeof byLocale?.[l] === 'string' && byLocale[l].trim());
+  if (present.length === 0) return byLocale;
+  const sourceLocale = present.find((l) => !needing.includes(l)) || present[0];
+  const sourceText = byLocale[sourceLocale];
+  const normalizedSource = normalizeText(sourceText).replace(/\s+/g, ' ');
+
+  const updated = { ...byLocale };
+  for (const target of needing) {
+    if (target === sourceLocale) continue;
+    const cacheKey = `${fieldType}::${sourceLocale}::${normalizedSource}`;
+    const entry = cache[cacheKey] || {};
+    let translated = entry[target];
+    if (!translated) {
+      translated = await translateFn({ text: sourceText, sourceLang: sourceLocale, targetLang: target, fieldType, maxRetries: 1 });
+      if (translated) {
+        cache[cacheKey] = { ...entry, [target]: translated };
+        if (translateFn === freeTranslateWithRetry) await sleep(delayMs);
+      }
+    }
+    if (translated) updated[target] = translated;
+  }
+  return updated;
+}
+
+/**
+ * Enrich a batch of SiteEvent-shaped records — fills gaps in both
+ * `titleByLocale` and `descriptionByLocale` for every event, memoized via
+ * `cache` (load once, mutate, save once — see
+ * `loadEventTitleTranslationCache`/`saveEventTitleTranslationCache`). Returns
+ * a NEW array; events are shallow-copied, never mutated in place. Used by
+ * `crawl-myswitzerland-events.mjs` and `crawl-guidle-events.mjs`; `translateFn`
+ * is injectable so tests never hit the network.
+ */
+export async function enrichEventsWithLocaleFallbackTranslations(events, cache, options = {}) {
+  const { locales = ['it', 'en', 'de', 'fr'], delayMs = LOCALE_FALLBACK_DELAY_MS, translateFn = freeTranslateWithRetry } = options;
+  const out = [];
+  for (const event of events) {
+    const next = { ...event };
+    if (event.titleByLocale) {
+      next.titleByLocale = await fillLocaleGaps(event.titleByLocale, cache, { fieldType: 'title', locales, delayMs, translateFn });
+    }
+    if (event.descriptionByLocale) {
+      next.descriptionByLocale = await fillLocaleGaps(event.descriptionByLocale, cache, {
+        fieldType: 'description',
+        locales,
+        delayMs,
+        translateFn,
+      });
+    }
+    out.push(next);
+  }
+  return out;
 }
 
 // ── Stable identity ──────────────────────────────────────────

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -19,6 +19,8 @@ import {
   DIGESTS,
   assignEventSlugs,
   reserveLiveSiblingSlugs,
+  categoryLabel,
+  normalizeCategoryKey,
 } from '../build-plugins/eventsSeoPagesPlugin';
 import { SITE_LICENSE_PAGE } from '../services/seo/imageObjectLd';
 import { MIN_INDEXABLE_WORDS } from '../build-plugins/constants';
@@ -59,6 +61,78 @@ describe('pathForEventDetail', () => {
     expect(pathForEventDetail('en', 'Lugano', slug)).toBe(`/en/events/ticino/lugano/${slug}/`);
     expect(pathForEventDetail('de', 'Lugano', slug)).toBe(`/de/veranstaltungen/tessin/lugano/${slug}/`);
     expect(pathForEventDetail('fr', 'Lugano', slug)).toBe(`/fr/evenements/tessin/lugano/${slug}/`);
+  });
+});
+
+// Issue #3742: myswitzerland ships English schema.org-derived categories
+// ("Event", "Music", "Sports", "Theater", "Food", "Exhibition", "Festival")
+// and guidle ships free-text German/Italian sub-genres ("Rock generalmente",
+// "Teatro: improvisazione", …) — neither matches the IT taxonomy keys, so
+// both used to fall through to a raw, wrong-language passthrough. Verified
+// live: 667/1084 (61.5%) events landed in the generic bucket, most literally
+// showing the English word "Event" on every locale.
+describe('normalizeCategoryKey', () => {
+  it('is a no-op for an already-valid taxonomy key (tio-agenda categories)', () => {
+    for (const key of ['arte', 'musica', 'teatro', 'cinema', 'feste', 'musei', 'conferenze', 'sport', 'appuntamenti', 'sociale', 'altro']) {
+      expect(normalizeCategoryKey(key)).toBe(key);
+    }
+  });
+
+  it('maps every myswitzerland humanizeCategory() output seen live', () => {
+    expect(normalizeCategoryKey('Event')).toBe('altro'); // 778/1006 (77%) — the highest-impact case
+    expect(normalizeCategoryKey('Music')).toBe('musica');
+    expect(normalizeCategoryKey('Sports')).toBe('sport');
+    expect(normalizeCategoryKey('Theater')).toBe('teatro');
+    expect(normalizeCategoryKey('Food')).toBe('feste');
+    expect(normalizeCategoryKey('Exhibition')).toBe('musei');
+    expect(normalizeCategoryKey('Festival')).toBe('feste');
+  });
+
+  it('maps guidle free-text sub-genres seen live', () => {
+    expect(normalizeCategoryKey('Rock generalmente')).toBe('musica');
+    expect(normalizeCategoryKey('Pop generalmente')).toBe('musica');
+    expect(normalizeCategoryKey('Teatro: improvisazione')).toBe('teatro');
+    expect(normalizeCategoryKey('Sperimentale')).toBe('musica');
+    expect(normalizeCategoryKey('Ambient / Electronica')).toBe('musica');
+    expect(normalizeCategoryKey('Barocco')).toBe('musica');
+    expect(normalizeCategoryKey("L'arte in generale")).toBe('arte');
+    expect(normalizeCategoryKey('Festival del teatro')).toBe('teatro');
+    expect(normalizeCategoryKey('Commedia')).toBe('teatro');
+    expect(normalizeCategoryKey('Musical')).toBe('teatro'); // overlaps "music" but must resolve to teatro
+    expect(normalizeCategoryKey('Film festival')).toBe('cinema');
+    expect(normalizeCategoryKey('Escursionismo')).toBe('sport');
+  });
+
+  it('leaves genuinely ambiguous long-tail categories unmapped (caller falls back to raw passthrough)', () => {
+    expect(normalizeCategoryKey('Contemplazione / Meditazione')).toBeUndefined();
+    expect(normalizeCategoryKey('Danza libera')).toBeUndefined();
+    expect(normalizeCategoryKey('Assistanza nella vita quotidiana')).toBeUndefined();
+  });
+
+  it('returns undefined for missing/blank input', () => {
+    expect(normalizeCategoryKey(undefined)).toBeUndefined();
+    expect(normalizeCategoryKey('')).toBeUndefined();
+    expect(normalizeCategoryKey('   ')).toBeUndefined();
+  });
+});
+
+describe('categoryLabel', () => {
+  it('renders the correct per-locale label for a normalized myswitzerland/guidle category', () => {
+    expect(categoryLabel('Event', 'it')).toBe('Eventi');
+    expect(categoryLabel('Event', 'en')).toBe('Events');
+    expect(categoryLabel('Music', 'it')).toBe('Musica');
+    expect(categoryLabel('Music', 'de')).toBe('Musik');
+    expect(categoryLabel('Rock generalmente', 'fr')).toBe('Musique');
+    expect(categoryLabel('Teatro: improvisazione', 'en')).toBe('Theatre');
+  });
+
+  it('still title-cases a genuinely unmapped raw category (unchanged pre-existing fallback)', () => {
+    expect(categoryLabel('Contemplazione / Meditazione', 'it')).toBe('Contemplazione / Meditazione');
+  });
+
+  it('falls back to the "altro" label for missing/blank category, in every locale', () => {
+    expect(categoryLabel(undefined, 'it')).toBe('Eventi');
+    expect(categoryLabel(undefined, 'en')).toBe('Events');
   });
 });
 

--- a/tests/events-nationwide-sources.test.ts
+++ b/tests/events-nationwide-sources.test.ts
@@ -20,6 +20,8 @@ import {
   haversineKm,
   resolveItalianFrontierComuni,
   mirrorEventImage,
+  localesNeedingTranslation,
+  enrichEventsWithLocaleFallbackTranslations,
 } from '../scripts/lib/events-utils.mjs';
 
 describe('EVENT_SOURCES nationwide registry', () => {
@@ -253,5 +255,101 @@ describe('mirrorEventImage', () => {
   it('returns null when fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
     expect(await mirrorEventImage('https://example.com/x.jpg', 'test:mirror-fixture')).toBeNull();
+  });
+});
+
+// Issue #3741: guidle/myswitzerland ship real per-locale text but very often
+// duplicate it verbatim across locales instead of translating — these two
+// helpers generalize crawl-tio-agenda.mjs's enrichEventsWithTranslations to
+// detect + fill that gap for both nationwide crawlers.
+describe('localesNeedingTranslation', () => {
+  it('flags every locale as missing when the map is empty/undefined', () => {
+    expect(localesNeedingTranslation({})).toEqual(['it', 'en', 'de', 'fr']);
+    expect(localesNeedingTranslation(undefined)).toEqual(['it', 'en', 'de', 'fr']);
+  });
+
+  it('flags only the missing locales when the present ones are all distinct', () => {
+    expect(localesNeedingTranslation({ it: 'Concerto', en: 'Concert' })).toEqual(['de', 'fr']);
+  });
+
+  it('flags a present locale that is a verbatim duplicate of another present locale', () => {
+    // it/en/de/fr all ship the exact same text — the myswitzerland/guidle
+    // "organizer never translated it" case (699/854 + 89/97 events live).
+    expect(
+      localesNeedingTranslation({ it: 'Festival della Musica', en: 'Festival della Musica', de: 'Festival della Musica', fr: 'Festival della Musica' }),
+    ).toEqual(['it', 'en', 'de', 'fr']);
+  });
+
+  it('treats accent/case/whitespace-only differences as a duplicate, not a real translation', () => {
+    expect(localesNeedingTranslation({ it: 'Città Vecchia', en: 'citta   vecchia' })).toEqual(['it', 'en', 'de', 'fr']);
+  });
+
+  it('does not flag genuinely distinct present locales even when short', () => {
+    expect(localesNeedingTranslation({ it: 'Festa', en: 'Feast', de: 'Fest', fr: 'Fête' })).toEqual([]);
+  });
+});
+
+describe('enrichEventsWithLocaleFallbackTranslations', () => {
+  it('fills missing locales from the first present locale via translateFn, memoized in cache', async () => {
+    const events = [{ id: 'guidle:1', titleByLocale: { it: 'Concerto in piazza' } }];
+    const cache = {};
+    const translateFn = vi.fn(async ({ targetLang }: { targetLang: string }) => `[${targetLang}] Concerto in piazza`);
+
+    const out = await enrichEventsWithLocaleFallbackTranslations(events, cache, { translateFn, delayMs: 0 });
+    expect(out).not.toBe(events); // new array, not mutated in place
+    expect(out[0].titleByLocale).toEqual({
+      it: 'Concerto in piazza',
+      en: '[en] Concerto in piazza',
+      de: '[de] Concerto in piazza',
+      fr: '[fr] Concerto in piazza',
+    });
+    expect(translateFn).toHaveBeenCalledTimes(3);
+    expect(Object.keys(cache).length).toBeGreaterThan(0);
+
+    // Second run: same source text, cache hit — translateFn must NOT be called again.
+    const translateFn2 = vi.fn();
+    await enrichEventsWithLocaleFallbackTranslations(
+      [{ id: 'guidle:2', titleByLocale: { it: 'Concerto in piazza' } }],
+      cache,
+      { translateFn: translateFn2, delayMs: 0 },
+    );
+    expect(translateFn2).not.toHaveBeenCalled();
+  });
+
+  it('re-translates a locale that is a verbatim duplicate of the source, from the first non-duplicate present locale', async () => {
+    // myswitzerland/guidle shape: it+en both carry the untranslated IT text,
+    // de/fr are missing entirely.
+    const events = [{ id: 'myswitzerland:1', titleByLocale: { it: 'Festival della Musica', en: 'Festival della Musica' } }];
+    const cache = {};
+    const translateFn = vi.fn(async ({ sourceLang, targetLang }: { sourceLang: string; targetLang: string }) => `${sourceLang}->${targetLang}`);
+
+    const out = await enrichEventsWithLocaleFallbackTranslations(events, cache, { translateFn, delayMs: 0 });
+    expect(out[0].titleByLocale.it).toBe('Festival della Musica'); // source untouched
+    expect(out[0].titleByLocale.en).toBe('it->en'); // duplicate slot re-translated from it
+    expect(out[0].titleByLocale.de).toBe('it->de');
+    expect(out[0].titleByLocale.fr).toBe('it->fr');
+  });
+
+  it('enriches descriptionByLocale independently of titleByLocale, and leaves events with neither field untouched', async () => {
+    const events = [
+      { id: 'guidle:3', descriptionByLocale: { de: 'Ein tolles Konzert.' } },
+      { id: 'guidle:4', title: 'No locale maps at all' },
+    ];
+    const cache = {};
+    const translateFn = vi.fn(async ({ targetLang }: { targetLang: string }) => `de->${targetLang}`);
+
+    const out = await enrichEventsWithLocaleFallbackTranslations(events, cache, { translateFn, delayMs: 0 });
+    expect(out[0].descriptionByLocale).toEqual({ de: 'Ein tolles Konzert.', it: 'de->it', en: 'de->en', fr: 'de->fr' });
+    expect(out[0].titleByLocale).toBeUndefined();
+    expect(out[1]).toEqual(events[1]); // no locale maps present — passthrough
+  });
+
+  it('leaves a slot untranslated (no crash) when translateFn returns empty', async () => {
+    const events = [{ id: 'guidle:5', titleByLocale: { it: 'Solo italiano' } }];
+    const cache = {};
+    const translateFn = vi.fn(async () => '');
+
+    const out = await enrichEventsWithLocaleFallbackTranslations(events, cache, { translateFn, delayMs: 0 });
+    expect(out[0].titleByLocale).toEqual({ it: 'Solo italiano' });
   });
 });


### PR DESCRIPTION
## Implementato

- `scripts/lib/events-utils.mjs`: nuovo helper condiviso `enrichEventsWithLocaleFallbackTranslations` (+ `localesNeedingTranslation`) che rileva slot locale mancanti O duplicati (testo normalizzato identico a un altro locale presente) e li traduce via la stessa cascata `free-translate.mjs` già usata da `crawl-tio-agenda.mjs`, riusando la stessa cache disco `data/events-translation-cache.json` con chiave composta collision-free (`fieldType::sourceLocale::normalizedSourceText`).
- `scripts/crawl-myswitzerland-events.mjs` e `scripts/crawl-guidle-events.mjs`: wired il nuovo helper in `main()` prima del merge nello slice dataset — verificato live 699/854 eventi myswitzerland e 89/97 guidle avevano testo duplicato verbatim su tutti e 4 i locali (vs 0/133 tio-agenda).
- `build-plugins/eventsSeoPagesPlugin.ts`: `categoryLabel()` ora normalizza le categorie sorgente (schema.org `@type` inglesi di myswitzerland: Event/Music/Sports/Theater/Food/Exhibition/Festival; sotto-generi liberi tedesco/italiano di guidle: "Rock generalmente", "Teatro: improvisazione", ecc.) sulle 11 chiavi tassonomia IT esistenti (`arte, musica, teatro, cinema, feste, musei, conferenze, sport, appuntamenti, sociale, altro`), invece del passthrough raw multilingua errato. Le 11 chiavi/label esistenti restano invariate; categorie ambigue genuinamente non mappate restano sul passthrough raw title-case pre-esistente (comportamento invariato).
- Test aggiunti: `tests/events-nationwide-sources.test.ts` (translation fallback: cache hit, duplicate-locale re-translation, title/description indipendenti, passthrough senza locale map, no-op su translateFn vuoto) e `tests/events-detail-pages.test.ts` (`normalizeCategoryKey`/`categoryLabel`: passthrough tassonomia già valida, mapping myswitzerland/guidle live, categorie ambigue non mappate restano raw, fallback su categoria mancante).

## Non implementato (ancora)

Nessuno.

Closes #3741
Closes #3742