### PR TITLE
fix: Calendly widget non carica su /consulenza/ (CORS blocked by crossOrigin attribute)

### DIFF
--- a/components/pages/ConsultingPage.tsx
+++ b/components/pages/ConsultingPage.tsx
@@ -29,7 +29,6 @@ function ensureCalendlyScript(): Promise<void> {
  const s = document.createElement('script');
  s.src = 'https://assets.calendly.com/assets/external/widget.js';
  s.async = true;
- s.crossOrigin = 'anonymous';
  s.onload = () => { calendlyScriptLoaded = true; resolve(); };
  document.head.appendChild(s);
  });


### PR DESCRIPTION
## Implementato

- `components/pages/ConsultingPage.tsx`: rimosso `s.crossOrigin = 'anonymous'` sullo script tag che carica `assets.calendly.com/assets/external/widget.js`.
- Root cause confermata: `assets.calendly.com` risponde `Access-Control-Allow-Origin: https://calendly.com` (fisso, non riflette l'origin chiamante). Impostare `crossOrigin='anonymous'` forza il browser a trattare il caricamento come richiesta CORS, che viene bloccata (`net::ERR_FAILED`) perché l'header ACAO non corrisponde a `frontaliereticino.ch`. Risultato: `widget.js` non viene mai eseguito, `window.Calendly` resta undefined, e il click su "Prenota ora" seleziona il tier/scrolla ma non mostra mai il calendario di prenotazione — bottone visivamente "non funziona".
- Un tag `<script src>` semplice non necessita di `crossOrigin` per essere eseguito (serve solo per leggere errori dettagliati via `window.onerror` o SRI, non è il nostro caso). Rimuoverlo è sufficiente e non cambia altro comportamento.
- Verificato riproducendo il bug live con Playwright (dialog consenso Google Funding Choices dismesso, poi click reale su "Prenota ora" → `net::ERR_FAILED` CORS su `widget.js`, 0 widget montati) e poi confermando il fix isolato: stesso script senza `crossOrigin` → `loaded`, `window.Calendly` definito, zero console errors.
- GitNexus impact analysis: `ensureCalendlyScript` ha un solo caller (`ConsultingPage`), nessun altro simbolo dipendente — blast radius nullo fuori da questo file.
- Test mirato eseguito: `npx vitest run tests/calculator/consulting-cta.test.tsx` → 7/7 verdi (nessun test dedicato esiste per `ConsultingPage` stesso).

## Non implementato (ancora)

Nessuno.