### PR TITLE
fix(email): remove Resend daily floor, byte-aware Firestore batch chunking

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -41,10 +41,17 @@
 
 const PROVIDERS = [
   { id: 'mailgun',  dailyLimit: 100, monthlyLimit: 3000  },
-  // resend: paid plan activated 2026-07-06 (50000/mo, owner request) — this is
-  // now the bulk workhorse of the cascade, not a fallback. dailyLimit = 50000/30
-  // months-average, floored.
-  { id: 'resend',   dailyLimit: 1666, monthlyLimit: 50000 },
+  // resend: paid plan activated 2026-07-06 (50000/mo, owner request), bulk
+  // workhorse of the cascade. No self-imposed dailyLimit (owner request
+  // 2026-07-07): the 1666/day floor (50000/30, months-average) was OUR OWN
+  // accounting, not a Resend-side cap, and it starved job-alerts on 2026-07-07
+  // — newsletter + ad-blast alone had already pushed the in-run counter to
+  // 1672/1666 by 11:06, so job-alerts found resend (and mailjet, separately
+  // maxed at its real 200/day free-tier cap) already "exhausted" for the rest
+  // of the day even though Resend's real monthly ceiling (50000) had ample
+  // room left. Real protection still stands: a genuine Resend-side 429/403
+  // still trips isRateLimitedError below and benches it for the run.
+  { id: 'resend',   dailyLimit: Infinity, monthlyLimit: 50000 },
   { id: 'mailjet',  dailyLimit: 200, monthlyLimit: 6000  },
   { id: 'mailtrap', dailyLimit: 150, monthlyLimit: 4000  },
   // maileroo: free tier (100/day). DKIM selector mta._domainkey.frontaliereticino.ch

--- a/scripts/lib/firestore-batch.mjs
+++ b/scripts/lib/firestore-batch.mjs
@@ -1,24 +1,47 @@
 /**
  * firestore-batch.mjs
  *
- * Firestore caps a single WriteBatch at 500 operations. A `db.batch()` that
- * accumulates one op per record and commits once therefore THROWS as soon as
- * the source collection exceeds 500 docs — and when that throw is swallowed as
- * "non-fatal" (the common pattern for best-effort writebacks) it silently writes
- * NOTHING that run. `commitInChunks()` splits the work into ≤FIRESTORE_BATCH_SIZE
- * batches so writes scale with inventory instead of breaking at the cap.
+ * Firestore caps a single WriteBatch at 500 operations AND at ~10MiB of
+ * serialized request payload. A `db.batch()` that accumulates one op per
+ * record and commits once therefore THROWS as soon as the source collection
+ * exceeds 500 docs, or as soon as accumulated doc size crosses the payload
+ * cap (variable-size docs, e.g. one carrying an email HTML body, can blow
+ * this well under 500 ops — incident 2026-07-07: 400 job-alert-retry docs
+ * each holding a full rendered email tripped "Request payload size exceeds
+ * the limit: 11534336 bytes" on a mass-failure run) — and when that throw is
+ * swallowed as "non-fatal" (the common pattern for best-effort writebacks) it
+ * silently writes NOTHING that run. `commitInChunks()` splits the work into
+ * ≤FIRESTORE_BATCH_SIZE batches AND flushes early once accumulated payload
+ * size nears the byte cap, so writes scale with inventory instead of
+ * breaking at either cap.
  *
  * Single source of truth for the chunked-batch idiom — import it instead of
  * re-implementing the `for (i += BATCH_SIZE) { db.batch() … commit() }` loop so
- * the 500-op guard cannot drift between funnel-critical sync scripts.
+ * the op/byte guards cannot drift between funnel-critical sync scripts.
  */
 
 // Firestore hard cap is 500 ops/batch; leave headroom (matches the BATCH_SIZE=400
 // convention in backfill-newsletter-campaign-ids.mjs / dev/backfill-onetap-orphan-subscribers.mjs).
 export const FIRESTORE_BATCH_SIZE = 400;
 
+// Firestore's real request-payload cap sits around 10-11MiB (observed error:
+// "exceeds the limit: 11534336 bytes" = 11MiB). Flush a batch once its
+// estimated serialized size crosses this safety margin, well below the real
+// cap to leave headroom for protobuf/field overhead the raw JSON-byte
+// estimate below doesn't capture.
+export const FIRESTORE_BATCH_MAX_BYTES = 8 * 1024 * 1024;
+
+function estimateBytes(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value));
+  } catch {
+    return 0;
+  }
+}
+
 /**
- * Apply `items` to Firestore in chunks that respect the per-batch op cap.
+ * Apply `items` to Firestore in chunks that respect both the per-batch op
+ * cap and a per-batch payload-size cap.
  *
  * `applyFn` must add AT MOST ONE operation per item to the supplied batch
  * (callers that skip some items should pre-filter, so the slice length stays a
@@ -28,17 +51,50 @@ export const FIRESTORE_BATCH_SIZE = 400;
  * @param {import('firebase-admin').firestore.Firestore} db
  * @param {T[]} items
  * @param {(batch: import('firebase-admin').firestore.WriteBatch, item: T) => void} applyFn
- * @param {{ chunkSize?: number }} [opts]
+ * @param {{ chunkSize?: number, maxBatchBytes?: number }} [opts]
  * @returns {Promise<number>} total items committed
  */
-export async function commitInChunks(db, items, applyFn, { chunkSize = FIRESTORE_BATCH_SIZE } = {}) {
+export async function commitInChunks(
+  db,
+  items,
+  applyFn,
+  { chunkSize = FIRESTORE_BATCH_SIZE, maxBatchBytes = FIRESTORE_BATCH_MAX_BYTES } = {},
+) {
   let processed = 0;
-  for (let i = 0; i < items.length; i += chunkSize) {
-    const slice = items.slice(i, i + chunkSize);
-    const batch = db.batch();
-    for (const item of slice) applyFn(batch, item);
+  let batch = db.batch();
+  let opsInBatch = 0;
+  let bytesInBatch = 0;
+
+  const flush = async () => {
+    if (opsInBatch === 0) return;
     await batch.commit();
-    processed += slice.length;
+    processed += opsInBatch;
+    batch = db.batch();
+    opsInBatch = 0;
+    bytesInBatch = 0;
+  };
+
+  for (const item of items) {
+    let itemBytes = 0;
+    const meteredBatch = {
+      set: (ref, data, setOpts) => {
+        itemBytes += estimateBytes(data);
+        return batch.set(ref, data, setOpts);
+      },
+      update: (ref, data) => {
+        itemBytes += estimateBytes(data);
+        return batch.update(ref, data);
+      },
+      delete: (ref) => batch.delete(ref),
+    };
+    applyFn(meteredBatch, item);
+    opsInBatch += 1;
+    bytesInBatch += itemBytes;
+
+    if (opsInBatch >= chunkSize || bytesInBatch >= maxBatchBytes) {
+      await flush();
+    }
   }
+  await flush();
   return processed;
 }


### PR DESCRIPTION
## Implementato

- `scripts/lib/email-cascade.mjs`: rimosso il tetto giornaliero auto-imposto su Resend (`dailyLimit: 1666` → `Infinity`), che era accounting interno non un limite reale del provider (real cap: 50000/mese). Altri 5 provider invariati (Mailgun/Mailjet/Mailtrap/Maileroo/Cloudflare mantengono i cap reali lato-provider).
- `scripts/lib/firestore-batch.mjs`: `commitInChunks()` ora flush-a anche su soglia byte (8MB, `FIRESTORE_BATCH_MAX_BYTES`), non solo su conteggio operazioni (400/batch). Fix del crash `Request payload size exceeds the limit: 11534336 bytes` osservato nel run 28859126912 durante `enqueueFailedEmails()` (coda di retry con ~905 email, ciascuna con HTML pieno renderizzato). Firma invariata, default comportamento identico per doc piccoli — validato: 270 test esistenti + 28 test dedicati `email-cascade-burst.test.ts` verdi.
- Diagnosi root-cause postata su #3764 (esaurimento quota a cascata newsletter+ad-blast → job-alerts, non un guasto di rete/codice).

## Non implementato (ancora)

Nessuno.

Closes #3764
