### PR TITLE
fix: cross-company slug-Map collisions + crawler scratch-path/race fixes

### DIFF
--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -124,7 +124,13 @@ jobs:
           # actor (confirmed with both a human and a bot actor on the broken side).
           # Falling back to scoped --allowedTools (read-only audit: no Edit/Write
           # needed) until the upstream root cause is understood.
-          claude_args: "--max-turns 40 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob'"
+          # max-turns raised 40→65 after run 28790742227 hit error_max_turns
+          # without reaching a finding: 2 denied compound Bash calls (cd+redirect,
+          # xargs -I{} — Claude Code rejects compound patterns regardless of an
+          # allowlisted leading binary) plus a self-inflicted import error burned
+          # turns before any real audit work (issue #3679). Not a cost-cut lower,
+          # AGENTS.md permits raising turns for legitimate complexity.
+          claude_args: "--max-turns 65 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob'"
           prompt: |
             Audit qualità dati crawler, settimanale. Finestra lookback: ${{ env.WINDOW_DAYS }} giorni.
 
@@ -138,7 +144,7 @@ jobs:
 
             1. **Slug stability / previousSlugs correctness**: esegui `node scripts/decontaminate-prev-slugs.mjs` (SENZA `--apply`, dry-run) contro `data/jobs/by-crawler/*.json` corrente. Se riporta contaminazioni (`moved > 0`) → REGRESSIONE del bug fixato in #3245: è evidenza concreta, la decontaminazione post-merge dovrebbe aver riportato tutto a 0. Ispeziona anche a campione se `previousSlugs` flat e `previousSlugsByLocale` per-locale restano coerenti tra loro (stesso schema del bug flat-array fixato dopo #3245).
             2. **Translation system**: campiona job con `needsTranslation: true` — quanti sono più vecchi di 72h (`crawledAt`/`updatedAt`) senza traduzione risolta? Un accumulo crescente indica una pipeline di traduzione bloccata (non copiato da nessun health-check esistente).
-            3. **Crawling / merge system**: verifica a campione la correttezza del merge by-stable-id (`extractStableJobId(job.url)`) — job duplicati con lo stesso id-stabile ma slug diversi non collassati, o entries orfane dopo un merge.
+            3. **Crawling / merge system**: verifica a campione la correttezza del merge by-stable-id (`extractStableJobId(job.url)`, import da `scripts/lib/job-match-key.mjs` — NON da `dedicated-crawler-common.mjs`) — job duplicati con lo stesso id-stabile ma slug diversi non collassati, o entries orfane dopo un merge.
             4. **Slug regeneration correctness**: campiona slug troncati — verifica che `truncateSlugAtWordBoundary` non abbia prodotto tronconi a metà parola o slug regenerati senza motivo (title wording minore che NON dovrebbe produrre nuovo slug, vedi `docs/CRAWLERS.md` riga 32).
             5. **Housekeeping**: `previousSlugs`/`previousSlugsByLocale` che puntano a target inesistenti nel dataset corrente, oggetti locale vuoti, `crawledAt` molto vecchio su un job ancora marcato attivo.
 
@@ -157,6 +163,7 @@ jobs:
             - Read-only sul codice/dati: NIENTE `git commit`/`push`/edit di file. L'unica scrittura ammessa è `gh issue create`/`gh issue comment` (e la lettura via `gh issue list`).
             - Non tentare fix — questo audit trova, non ripara.
             - Incerto se qualcosa è un vero difetto → non aprire issue; se borderline ma degno di attenzione umana, apri comunque MA marca chiaramente "da verificare" nel body.
+            - Bash qui è allowlisted per binario ma NON accetta comandi composti: niente `cd ... && ...`/redirect (`> file`), niente `xargs -I{}`. Un comando per invocazione, output letto via tool separato — i pattern composti vengono negati a prescindere dal binario in testa e sprecano turni (causa di #3679).
 
       - name: Claude usage metrics
         if: always()

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1785,6 +1785,12 @@ function assembleExpiredJobs() {
     return null;
   }
 
+  // Keyed by companyKey+slug, not bare slug — this aggregates EVERY
+  // crawler's expired slice into one Map, and two companies' jobs sharing a
+  // computed slug would silently drop one company's expired-job record here
+  // (same collision class fixed in scatter-jobs-to-slices.mjs /
+  // reconcile-job-slugs.mjs for issue #3734).
+  const expiredKey = (entry) => `${entry.companyKey || ''}::${entry.slug}`;
   const bySlug = new Map();
   let totalSliceEntries = 0;
   const malformedExpired = [];
@@ -1798,10 +1804,11 @@ function assembleExpiredJobs() {
     totalSliceEntries += entries.length;
     for (const entry of entries) {
       if (!entry.slug) continue;
-      const existing = bySlug.get(entry.slug);
+      const key = expiredKey(entry);
+      const existing = bySlug.get(key);
       // Keep the most recently expired entry for each slug
       if (!existing || (entry.expiredAt || '') >= (existing.expiredAt || '')) {
-        bySlug.set(entry.slug, entry);
+        bySlug.set(key, entry);
       }
     }
   }
@@ -1818,9 +1825,10 @@ function assembleExpiredJobs() {
   if (Array.isArray(existingAgg)) {
     for (const entry of existingAgg) {
       if (!entry.slug) continue;
-      const existing = bySlug.get(entry.slug);
+      const key = expiredKey(entry);
+      const existing = bySlug.get(key);
       if (!existing || (entry.expiredAt || '') >= (existing.expiredAt || '')) {
-        bySlug.set(entry.slug, entry);
+        bySlug.set(key, entry);
       }
     }
   }

--- a/scripts/cleanup-jobs.mjs
+++ b/scripts/cleanup-jobs.mjs
@@ -249,16 +249,22 @@ function archiveExpiredJobs(removedJobs, allJobsById) {
     if (!Array.isArray(existing)) existing = [];
   } catch { /* file missing or malformed — start fresh */ }
 
+  // Keyed by companyKey+slug, not bare slug — this archives across every
+  // company in the assembled dataset, and two companies' jobs sharing a
+  // computed slug would silently drop one company's expired-job record here
+  // (same collision class fixed in scatter-jobs-to-slices.mjs /
+  // reconcile-job-slugs.mjs for issue #3734).
+  const archiveKey = (entry) => `${entry.companyKey || ''}::${entry.slug}`;
   const bySlug = new Map();
   for (const ej of existing) {
-    if (ej.slug) bySlug.set(ej.slug, ej);
+    if (ej.slug) bySlug.set(archiveKey(ej), ej);
   }
 
   let added = 0;
   for (const r of removedJobs) {
     const job = allJobsById.get(r.id);
     if (!job || !job.slug) continue;
-    bySlug.set(job.slug, buildExpiredEntry(job));
+    bySlug.set(archiveKey(job), buildExpiredEntry(job));
     added++;
   }
 

--- a/scripts/jobs-url-helper.mjs
+++ b/scripts/jobs-url-helper.mjs
@@ -108,6 +108,15 @@ function writeSummaryStore(filePath, payload) {
 }
 
 function persistCrawlChangeSummary(diff, label = '') {
+  // In CRAWLER_SLICE_ONLY CI mode (~25 sibling crawlers as background steps
+  // in one crawler-group job, sharing one filesystem) this shared, non-atomic
+  // read-modify-write races across processes and throws "Unexpected end of
+  // JSON input" on a torn read (issue #3771). assembleJobsDataset() already
+  // skips rebuilding this same file in that mode (deferred to deploy time,
+  // rebuilt from the safe per-crawler writeSummaryCrawlerSlice() slices) —
+  // so this write is pure wasted race exposure there. Skip it; the per-crawler
+  // slice already captures the same data safely.
+  if (String(process.env.CRAWLER_SLICE_ONLY || '0') === '1') return;
   const key = normalizeSummaryKey(label);
   const cleanLabel = label || 'Generic Crawler';
   const total = diff.newJobs.length + diff.updatedJobs.length + diff.removedJobs.length + diff.unchangedCount;

--- a/scripts/lib/git-commit-data.sh
+++ b/scripts/lib/git-commit-data.sh
@@ -762,6 +762,29 @@ ensure_git_auth() {
   fi
 }
 
+# `git fetch` inside the retry loop below is otherwise unguarded under
+# `set -e` — a transient network blip (e.g. "Connection reset by peer" under
+# ~24 concurrent crawler-group jobs) kills the whole script instantly instead
+# of going through the backoff/retry path that exists precisely for this kind
+# of race. Retry fetch itself before letting set -e propagate a real failure.
+MAX_FETCH_ATTEMPTS=5
+git_fetch_retry() {
+  local attempts=0
+  while true; do
+    attempts=$((attempts + 1))
+    if git fetch origin main; then
+      return 0
+    fi
+    if [ "$attempts" -ge "$MAX_FETCH_ATTEMPTS" ]; then
+      echo "❌ git fetch origin main failed after ${MAX_FETCH_ATTEMPTS} attempts"
+      return 1
+    fi
+    local delay=$(( attempts * 5 + RANDOM % 6 ))
+    echo "⚠️ git fetch origin main failed (attempt ${attempts}/${MAX_FETCH_ATTEMPTS}) — waiting ${delay}s before retry..."
+    sleep "$delay"
+  done
+}
+
 # ── 3+4 loop: Sync, align, commit, push (with retry on race conditions) ────
 MAX_PUSH_ATTEMPTS=8
 push_attempt=0
@@ -770,7 +793,7 @@ while true; do
 
 # ── 3. Sync with remote (stash → rebase → pop → merge if needed) ──────────
 ensure_git_auth
-git fetch origin main
+git_fetch_retry
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
 
@@ -897,7 +920,7 @@ git commit -m "$COMMIT_MSG"
 
 # Last-moment rebase: fetch latest remote right before push to minimise race window
 ensure_git_auth
-git fetch origin main
+git_fetch_retry
 if ! git rebase origin/main 2>/dev/null; then
   echo "⚠️ Last-moment rebase conflict — resolving with 3-way JSON merge..."
   git rebase --abort 2>/dev/null || true

--- a/scripts/reconcile-job-slugs.mjs
+++ b/scripts/reconcile-job-slugs.mjs
@@ -34,6 +34,7 @@ import {
   DEFAULT_PREV_SLUG_CAP,
   LEGACY_PREV_SLUGS_CAP,
 } from './lib/dedicated-crawler-common.mjs';
+import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 import { mergePreviousSlugsCapped } from './lib/slug-history-journal.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -947,7 +948,11 @@ export function reconcileOrphanSlugs(activeJobs, orphanSlugs, enrichedData, opti
     }
 
     index.allSlugSet.add(orphanSlug);
-    updatedJobs.set(job.slug || job.slugByLocale?.it, job);
+    // Keyed by resolveJobDiffKey, not bare slug — activeJobs spans every
+    // company, and two jobs sharing a computed slug would silently drop one
+    // company's update from this Map (same collision class fixed in
+    // scatter-jobs-to-slices.mjs for issue #3734).
+    updatedJobs.set(resolveJobDiffKey(job), job);
     mergedCount++;
 
     const prefix = dryRun ? '⏭️ [dry-run]' : '✅';
@@ -1089,7 +1094,7 @@ export function reconcileExpiredSlugs(activeJobs, expiredJobs, options = {}) {
     }
 
     for (const s of uniqueNew) index.allSlugSet.add(s);
-    updatedJobs.set(job.slug || job.slugByLocale?.it, job);
+    updatedJobs.set(resolveJobDiffKey(job), job);
     reconciledIds.add(ej.slug || ej.id || JSON.stringify(ej.slugByLocale));
     mergedCount++;
 

--- a/scripts/scatter-jobs-to-slices.mjs
+++ b/scripts/scatter-jobs-to-slices.mjs
@@ -17,6 +17,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
 import { addPreviousSlugForLocale } from './lib/dedicated-crawler-common.mjs';
+import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -37,10 +38,16 @@ if (!Array.isArray(jobs)) {
   process.exit(0);
 }
 
-// Index assembled jobs by companyKey + slug for lookup
+// Index assembled jobs by stable diff key (id / url / slug fallback — see
+// resolveJobDiffKey) — NOT bare .slug. Bare-slug keying collides across
+// companies whenever two jobs compute the same slug (463 live collisions
+// confirmed in data/jobs/by-crawler/*.json, e.g. klinik-sonnenhalde vs.
+// allianz-suisse), silently merging wrong-company locale/slug data into a
+// slice (previousSlugs writer regression, issue #3734).
 const jobIndex = new Map();
 for (const job of jobs) {
-  if (job.slug) jobIndex.set(job.slug, job);
+  const key = resolveJobDiffKey(job);
+  if (key) jobIndex.set(key, job);
 }
 
 // Read each slice, update jobs with matching slugs, write back if changed
@@ -80,8 +87,9 @@ for (const file of sliceFiles) {
 
   let sliceChanged = false;
   const updatedSliceJobs = slice.jobs.map((sliceJob) => {
-    if (!sliceJob.slug) return sliceJob;
-    const assembled = jobIndex.get(sliceJob.slug);
+    const sliceKey = resolveJobDiffKey(sliceJob);
+    if (!sliceKey) return sliceJob;
+    const assembled = jobIndex.get(sliceKey);
     if (!assembled) return sliceJob;
 
     // Compare locale fields — only update if they changed

--- a/scripts/update-a-plus-plus-group-jobs.mjs
+++ b/scripts/update-a-plus-plus-group-jobs.mjs
@@ -53,14 +53,17 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'a-group.json');
-
 const COMPANY_KEY = 'a-group';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'a-group.json');
 const COMPANY_NAME = 'A++ Group';
 const COMPANY_HOST = 'inrecruiting.intervieweb.it';
 const COMPANY_DOMAIN = 'a2plus.green';

--- a/scripts/update-abb-jobs.mjs
+++ b/scripts/update-abb-jobs.mjs
@@ -49,14 +49,19 @@ import { inferSwissTargetCanton, inferAnyCanton } from './lib/target-swiss-locat
 import { isTargetCanton, getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const ABB_KEY = 'abb-svizzera-sede-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(ABB_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const DEFAULT_CANTON = getCompanyDefaults(ABB_KEY)?.canton || 'TI';
 const ABB_COMPANY_NAME = 'ABB Svizzera (sede Ticino)';
 const ABB_HOST = 'careers.abb';

--- a/scripts/update-ail-jobs.mjs
+++ b/scripts/update-ail-jobs.mjs
@@ -60,16 +60,21 @@ import {
 } from './lib/pdf-job-content.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const COMPANY_KEY = 'ail-lugano';
 const HQ = getCompanyDefaults(COMPANY_KEY);
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const COMPANY_NAME = 'Aziende Industriali di Lugano (AIL) SA';
 const COMPANY_HOST = 'ail.ch';
 const CAREERS_URL =

--- a/scripts/update-aldi-suisse-jobs.mjs
+++ b/scripts/update-aldi-suisse-jobs.mjs
@@ -54,14 +54,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* -- Constants --------------------------------------------------------- */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const ALDI_KEY = 'aldi-suisse';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(ALDI_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const ALDI_COMPANY_NAME = 'ALDI SUISSE';
 const HQ = getCompanyDefaults(ALDI_KEY);
 const ALDI_HOST = 'www.jobs.aldi.ch';

--- a/scripts/update-allianz-jobs.mjs
+++ b/scripts/update-allianz-jobs.mjs
@@ -46,14 +46,17 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'allianz-suisse.json');
-
 const COMPANY_KEY = 'allianz-suisse';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'allianz-suisse.json');
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Allianz Suisse';
 const COMPANY_HOST = 'recruitingapp-2872.umantis.com';

--- a/scripts/update-alpiq-jobs.mjs
+++ b/scripts/update-alpiq-jobs.mjs
@@ -19,12 +19,18 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, d
 import { fetchAlpiqListingPages, slugify, inferEmploymentType } from './lib/alpiq-job-parser.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'alpiq';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Alpiq';
 
 /** Alpiq location → postal code map (Swiss locations, Ticino focus) */

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -37,14 +37,17 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, warnIfListingAtCap } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'alten-switzerland.json');
-
 const COMPANY_KEY = 'alten-switzerland';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'alten-switzerland.json');
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'ALTEN Switzerland';
 const COMPANY_DOMAIN = 'alten.ch';

--- a/scripts/update-amag-jobs.mjs
+++ b/scripts/update-amag-jobs.mjs
@@ -47,14 +47,17 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'amag-group.json');
-
 const COMPANY_KEY = 'amag-group';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'amag-group.json');
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'AMAG Group';
 const COMPANY_HOST = 'jobs.amag-group.ch';

--- a/scripts/update-ariston-jobs.mjs
+++ b/scripts/update-ariston-jobs.mjs
@@ -37,14 +37,17 @@ import {
 } from './lib/ariston-job-parser.mjs';
 import { fetchHtml, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'ariston-group.json');
-
 const COMPANY_KEY = 'ariston-group';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'ariston-group.json');
 const COMPANY_NAME = 'Ariston Group';
 const COMPANY_HOST = 'careers.aristongroup.com';
 const COMPANY_DOMAIN = 'aristongroup.com';

--- a/scripts/update-artisa-jobs.mjs
+++ b/scripts/update-artisa-jobs.mjs
@@ -35,15 +35,18 @@ import {
 } from './lib/artisa-job-parser.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'artisa-group.json');
-
 const COMPANY_KEY = 'artisa-group';
 const HQ = getCompanyDefaults(COMPANY_KEY);
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'artisa-group.json');
 const COMPANY_NAME = 'Artisa Group';
 const COMPANY_HOST = 'artisagroup.com';
 const COMPANY_DOMAIN = 'artisagroup.com';

--- a/scripts/update-avaloq-jobs.mjs
+++ b/scripts/update-avaloq-jobs.mjs
@@ -37,14 +37,17 @@ import {
 } from './lib/avaloq-job-parser.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'avaloq.json');
-
 const COMPANY_KEY = 'avaloq';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'avaloq.json');
 const COMPANY_NAME = 'Avaloq';
 const COMPANY_HOST = 'www.avaloq.com';
 const COMPANY_DOMAIN = 'avaloq.com';

--- a/scripts/update-axpo-jobs.mjs
+++ b/scripts/update-axpo-jobs.mjs
@@ -35,14 +35,17 @@ import { isTargetSwissLocation, inferAnyCanton } from './lib/target-swiss-locati
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'axpo-group.json');
-
 const COMPANY_KEY = 'axpo-group';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'axpo-group.json');
 const COMPANY_NAME = 'Axpo Group';
 const COMPANY_DOMAIN = 'axpo.com';
 const RSS_URL = 'https://careers.axpo.com/jobs.rss';

--- a/scripts/update-banca-sempione-jobs.mjs
+++ b/scripts/update-banca-sempione-jobs.mjs
@@ -51,17 +51,22 @@ import {
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, warnIfListingAtCap } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const BANCA_SEMPIONE_KEY = 'banca-sempione';
 const HQ = getCompanyDefaults(BANCA_SEMPIONE_KEY);
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(BANCA_SEMPIONE_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const BANCA_SEMPIONE_COMPANY_NAME = 'Banca del Sempione';
 const BANCA_SEMPIONE_HOST = 'www.bancasempione.ch';
 const LISTING_PAGE_CAP = 100;

--- a/scripts/update-board-jobs.mjs
+++ b/scripts/update-board-jobs.mjs
@@ -38,14 +38,17 @@ import {
 } from './lib/board-job-parser.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'board-international.json');
-
 const COMPANY_KEY = 'board-international';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'board-international.json');
 const COMPANY_NAME = 'Board International';
 const COMPANY_HOST = 'www.board.com';
 const COMPANY_DOMAIN = 'board.com';

--- a/scripts/update-bosch-jobs.mjs
+++ b/scripts/update-bosch-jobs.mjs
@@ -37,14 +37,17 @@ import {
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'bosch-thermotechnik-ag.json');
-
 const COMPANY_KEY = 'bosch-thermotechnik-ag';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'bosch-thermotechnik-ag.json');
 const COMPANY_NAME = 'Bosch Thermotechnik AG';
 const COMPANY_HOST = 'jobs.bosch.com';
 const COMPANY_DOMAIN = 'bosch.ch';

--- a/scripts/update-bps-suisse-jobs.mjs
+++ b/scripts/update-bps-suisse-jobs.mjs
@@ -54,16 +54,21 @@ import {
 } from './lib/pdf-job-content.mjs';
 import { fetchHtml as fetchHtmlShared, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const BPS_KEY = 'bps-suisse';
 const HQ = getCompanyDefaults(BPS_KEY);
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(BPS_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const BPS_COMPANY_NAME = 'BPS (Banca Popolare di Sondrio) SUISSE';
 const BPS_HOST = 'www.bps-suisse.ch';
 const BPS_LISTING_URL = 'https://www.bps-suisse.ch/lavora-in-bps-suisse.php';

--- a/scripts/update-bracco-jobs.mjs
+++ b/scripts/update-bracco-jobs.mjs
@@ -36,14 +36,19 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { isSwissLocationText } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const BRACCO_KEY = 'bracco';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(BRACCO_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const BRACCO_COMPANY_NAME = 'Bracco Suisse S.A.';
 const BRACCO_COMPANY_HOST = 'bracco.wd103.myworkdayjobs.com';
 const BRACCO_API_BASE = 'https://bracco.wd103.myworkdayjobs.com/wday/cxs/bracco/BraccoCareers';

--- a/scripts/update-burkhalter-jobs.mjs
+++ b/scripts/update-burkhalter-jobs.mjs
@@ -52,14 +52,17 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { fetchHtml, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-
 const COMPANY_KEY = 'burkhalter-group';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Burkhalter Group';
 const COMPANY_DOMAIN = 'burkhalter.ch';
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'ZH';

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -44,16 +44,21 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const CAMBIAVALUTE_KEY = 'cambiavalute';
 const HQ = getCompanyDefaults(CAMBIAVALUTE_KEY);
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(CAMBIAVALUTE_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const CAMBIAVALUTE_COMPANY_NAME = 'CambiaValute.ch';
 const CAMBIAVALUTE_COMPANY_DOMAIN = 'cambiavalute.ch';
 const CAMBIAVALUTE_HOST = 'cambiavalute.ch';

--- a/scripts/update-capri-holdings-jobs.mjs
+++ b/scripts/update-capri-holdings-jobs.mjs
@@ -49,15 +49,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const CAPRI_KEY = 'capri-holdings';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(CAPRI_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const DEFAULT_CANTON = getCompanyDefaults(CAPRI_KEY)?.canton || 'TI';
 const CAPRI_COMPANY_NAME = 'Capri Holdings (Michael Kors / Versace)';
 const CAPRI_HOST = 'capri.wd1.myworkdayjobs.com';

--- a/scripts/update-casale-jobs.mjs
+++ b/scripts/update-casale-jobs.mjs
@@ -20,14 +20,19 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseApiResponse, buildJobFromApi, parseListingPage, slugify, detectCategory, detectExperienceLevel } from './lib/casale-job-parser.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const COMPANY_KEY = 'casale';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Casale SA';
 const COMPANY_HOST = 'recruit.casale.ch';

--- a/scripts/update-caseificio-gottardo-jobs.mjs
+++ b/scripts/update-caseificio-gottardo-jobs.mjs
@@ -47,15 +47,20 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const COMPANY_KEY = 'caseificio-gottardo';
 const HQ = getCompanyDefaults(COMPANY_KEY);
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const COMPANY_NAME = 'Caseificio dimostrativo del Gottardo SA';
 const COMPANY_HOST = 'www.caseificiodelgottardo.ch';
 const CAREERS_URL = 'https://www.caseificiodelgottardo.ch/Offerte-di-impiego-e-tirocinio';

--- a/scripts/update-cedes-jobs.mjs
+++ b/scripts/update-cedes-jobs.mjs
@@ -17,12 +17,18 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'cedes';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'CEDES AG';
 

--- a/scripts/update-centiel-jobs.mjs
+++ b/scripts/update-centiel-jobs.mjs
@@ -55,15 +55,18 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { fetchHtml, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'centiel.json');
-
 const COMPANY_KEY = 'centiel';
+// Per-crawler-scoped scratch path so sibling background-step crawlers in the
+// same CI job never clobber each other by racing to merge into the shared,
+// gitignored data/jobs.json (bug class of #3775/#3768, ref #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'centiel.json');
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Centiel';
 const COMPANY_HOST = 'www.centiel.com';

--- a/scripts/update-cerbios-pharma-jobs.mjs
+++ b/scripts/update-cerbios-pharma-jobs.mjs
@@ -49,15 +49,20 @@ import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/ce
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { fetchHtml as fetchHtmlShared, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const COMPANY_KEY = 'cerbios-pharma';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const COMPANY_NAME = 'Cerbios-Pharma SA';
 const COMPANY_HOST = 'www.e-lavoro.ch';
 const CAREERS_URL = 'https://www.e-lavoro.ch/node/91';

--- a/scripts/update-citta-di-bellinzona-jobs.mjs
+++ b/scripts/update-citta-di-bellinzona-jobs.mjs
@@ -21,12 +21,18 @@ import {
 } from './lib/pdf-job-content.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'citta-di-bellinzona';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Città di Bellinzona';
 

--- a/scripts/update-citta-di-locarno-jobs.mjs
+++ b/scripts/update-citta-di-locarno-jobs.mjs
@@ -20,12 +20,18 @@ import {
 } from './lib/pdf-job-content.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'citta-di-locarno';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Città di Locarno';
 

--- a/scripts/update-citta-di-lugano-jobs.mjs
+++ b/scripts/update-citta-di-lugano-jobs.mjs
@@ -53,15 +53,20 @@ import {
 } from './lib/pdf-job-content.mjs';
 import { fetchHtml as fetchHtmlShared, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
-const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-
 const COMPANY_KEY = 'citta-di-lugano';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
+const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const COMPANY_NAME = 'Città di Lugano';
 const COMPANY_HOST = 'www.lugano.ch';
 const CAREERS_URL = 'https://www.lugano.ch/temi-servizi/lavoro-e-impresa/concorsi-pubblici-posti-lavoro/';

--- a/scripts/update-cler-jobs.mjs
+++ b/scripts/update-cler-jobs.mjs
@@ -45,14 +45,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'banca-cler';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 // Bank Cler HQ is Basel (BS). Per-job locations come from the detail page's
 // `Arbeitsort` field; this default is only used when extraction fails.
 const HQ_DEFAULTS = getCompanyDefaults(COMPANY_KEY) || {

--- a/scripts/update-colin-cie-jobs.mjs
+++ b/scripts/update-colin-cie-jobs.mjs
@@ -52,15 +52,21 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'colin-cie.json');
 
 const COMPANY_KEY = 'colin-cie';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Colin&Cie Wealth Management';
 const COMPANY_HOST = 'www.colin-cie.com';
 const COMPANY_DOMAIN = 'colin-cie.com';

--- a/scripts/update-confederazione-jobs.mjs
+++ b/scripts/update-confederazione-jobs.mjs
@@ -66,14 +66,20 @@ import { normalizeFederalJobLocation } from './lib/federal-job-normalization.mjs
 import { getCompanyDefaults, getCantonDisplayName } from './lib/crawler-location-config.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'confederazione-ticino.json');
 
 const COMPANY_KEY = 'confederazione-ticino';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Confederazione Svizzera';
 const COMPANY_HOST = 'jobs.admin.ch';

--- a/scripts/update-convit-jobs.mjs
+++ b/scripts/update-convit-jobs.mjs
@@ -50,14 +50,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'convit-holding.json');
 
 const COMPANY_KEY = 'convit-holding';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Convit Holding GmbH';
 const COMPANY_HOST = 'www.careers-page.com';

--- a/scripts/update-coop-jobs.mjs
+++ b/scripts/update-coop-jobs.mjs
@@ -57,12 +57,18 @@ import { detectLanguage } from './lib/detect-language.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const COOP_KEY = 'coop-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COOP_KEY);
 
 /**
  * Lightweight translation cache that persists Coop locale data across runs,
@@ -487,7 +493,7 @@ function runBaseCrawler() {
 // Post-processing: validate & repair Coop jobs against JSON-LD
 // ──────────────────────────────────────────────────────────────
 
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 
 async function postProcessCoopJobs() {
   if (!fs.existsSync(DATA_JOBS)) return;

--- a/scripts/update-corner-jobs.mjs
+++ b/scripts/update-corner-jobs.mjs
@@ -45,12 +45,18 @@ import {
 } from './lib/corner-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const CORNER_KEY = 'corner-banca';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(CORNER_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const RECRUITEE_API = 'https://cornerbancasa.recruitee.com/api/offers/';
 
 // ──────────────────────────────────────────────────────────────

--- a/scripts/update-csc-costruzioni-jobs.mjs
+++ b/scripts/update-csc-costruzioni-jobs.mjs
@@ -41,14 +41,20 @@ import {
   normalizeKey,
 } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const CSC_KEY = 'csc-costruzioni';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(CSC_KEY);
 const CSC_COMPANY_NAME = 'CSC Costruzioni SA';
 const CSC_HOST = 'csc-sa.ch';
 const CSC_CAREERS_URL = 'https://csc-sa.ch/lavoro-carriera-edilizia';

--- a/scripts/update-damiani-jobs.mjs
+++ b/scripts/update-damiani-jobs.mjs
@@ -38,14 +38,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'damiani-group.json');
 
 const COMPANY_KEY = 'damiani-group';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Damiani Group';
 const COMPANY_HOST = 'careers.damianigroup.com';

--- a/scripts/update-davos-klosters-bergbahnen-jobs.mjs
+++ b/scripts/update-davos-klosters-bergbahnen-jobs.mjs
@@ -17,12 +17,18 @@ import { fetchDavosKlostersBergbahnenJobUrls, fetchDavosKlostersBergbahnenDetail
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'davos-klosters-bergbahnen';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Davos Klosters Bergbahnen AG';
 

--- a/scripts/update-delvitech-jobs.mjs
+++ b/scripts/update-delvitech-jobs.mjs
@@ -41,14 +41,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'delvitech-sa.json');
 
 const COMPANY_KEY = 'delvitech-sa';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Delvitech SA';
 const COMPANY_HOST = 'legacy.delvi.tech';

--- a/scripts/update-denner-jobs.mjs
+++ b/scripts/update-denner-jobs.mjs
@@ -51,14 +51,20 @@ import { extractMigrosStructuredData } from './lib/migros-job-parser.mjs';
 import { inferEmploymentType } from './lib/denner-job-parser.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* -- Constants --------------------------------------------------------- */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const DENNER_KEY = 'denner';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(DENNER_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DENNER_COMPANY_NAME = 'Denner';
 const DENNER_HOST = 'jobs.migros.ch';
 const DENNER_LISTING_BASE = 'https://jobs.migros.ch/it/le-nostre-imprese/denner-sa/posti-di-lavoro-vacanti';

--- a/scripts/update-dxt-jobs.mjs
+++ b/scripts/update-dxt-jobs.mjs
@@ -48,14 +48,20 @@ import {
 } from './lib/dxt-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const DXT_KEY = 'dxt-commodities';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(DXT_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(DXT_KEY)?.canton || 'TI';
 const DXT_COMPANY_NAME = 'DXT Commodities S.A.';
 const DXT_COMPANY_HOST = 'dxt.com';

--- a/scripts/update-efg-jobs.mjs
+++ b/scripts/update-efg-jobs.mjs
@@ -34,12 +34,18 @@ import { detectLanguage } from './lib/detect-language.mjs';
 import { isTargetCanton } from './lib/crawler-location-config.mjs';
 import { locTokenHit } from '../services/locToken.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const EFG_KEY = 'efg-international';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(EFG_KEY);
 
 /**
  * Oracle HCM Cloud configuration for EFG International.

--- a/scripts/update-ems-chemie-jobs.mjs
+++ b/scripts/update-ems-chemie-jobs.mjs
@@ -49,15 +49,21 @@ mergeLocaleTextMap,
 import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/ems-chemie-job-parser.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'ems-chemie';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'EMS-Chemie AG';
 const COMPANY_HOST = 'www.ems-group.com';
 /**

--- a/scripts/update-engelvoelkers-jobs.mjs
+++ b/scripts/update-engelvoelkers-jobs.mjs
@@ -52,14 +52,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'engel-voelkers.json');
 
 const COMPANY_KEY = 'engel-voelkers';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Engel & Völkers';
 const COMPANY_HOST = 'www.engelvoelkers.com';

--- a/scripts/update-eoc-jobs.mjs
+++ b/scripts/update-eoc-jobs.mjs
@@ -31,12 +31,18 @@ import { capSlugArray } from './lib/slug-history-journal.mjs';
 import { normalizeDescriptionBullets, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const EOC_KEY = 'eoc-ente-ospedaliero-cantonale';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(EOC_KEY);
 const HQ = getCompanyDefaults(EOC_KEY);
 
 /**

--- a/scripts/update-fart-jobs.mjs
+++ b/scripts/update-fart-jobs.mjs
@@ -53,14 +53,20 @@ import {
   buildFartDescription,
 } from './lib/fart-job-parser.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'fart';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'FART – Ferrovie Autolinee Regionali Ticinesi';
 const COMPANY_HOST = 'fartiamo.ch';

--- a/scripts/update-ferrovia-retica-jobs.mjs
+++ b/scripts/update-ferrovia-retica-jobs.mjs
@@ -49,15 +49,21 @@ mergeLocaleTextMap,
 import { parseListingPage, parseDetailPage, buildJob, buildFallbackDescription, stripHtml } from './lib/ferrovia-retica-job-parser.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'ferrovia-retica';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Ferrovia Retica (RhB)';
 const COMPANY_HOST = 'www.rhb.ch';
 const CAREERS_URL = 'https://www.rhb.ch/it/lavoro-carriera/candidatura-posti-vacanti/job-uebersicht/';

--- a/scripts/update-fincons-jobs.mjs
+++ b/scripts/update-fincons-jobs.mjs
@@ -35,14 +35,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'fincons-group.json');
 
 const COMPANY_KEY = 'fincons-group';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Fincons Group';
 const COMPANY_HOST = 'fincons.applytojob.com';

--- a/scripts/update-fnz-jobs.mjs
+++ b/scripts/update-fnz-jobs.mjs
@@ -49,14 +49,20 @@ import {
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { isSwissLocationText } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const FNZ_KEY = 'fnz';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(FNZ_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const FNZ_COMPANY_NAME = 'FNZ (Switzerland) AG';
 const FNZ_COMPANY_HOST = 'fnz.wd3.myworkdayjobs.com';
 const FNZ_API_BASE = 'https://fnz.wd3.myworkdayjobs.com/wday/cxs/fnz/fnz_careers';

--- a/scripts/update-fust-jobs.mjs
+++ b/scripts/update-fust-jobs.mjs
@@ -56,14 +56,20 @@ import {
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const FUST_KEY = 'fust';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(FUST_KEY);
 const FUST_COMPANY_NAME = 'Fust';
 
 /**

--- a/scripts/update-galenica-jobs.mjs
+++ b/scripts/update-galenica-jobs.mjs
@@ -51,15 +51,21 @@ import { getCompanyDefaults, SWISS_CANTONS } from './lib/crawler-location-config
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const GALENICA_KEY = 'galenica';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(GALENICA_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(GALENICA_KEY)?.canton || 'TI';
 const GALENICA_COMPANY_NAME = 'Galenica AG';
 const GALENICA_HOST = 'jobs.galenica.com';

--- a/scripts/update-giorgio-armani-jobs.mjs
+++ b/scripts/update-giorgio-armani-jobs.mjs
@@ -65,14 +65,20 @@ import {
   buildGiorgioArmaniLocalizedContent,
 } from './lib/giorgio-armani-job-parser.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'giorgio-armani.json');
 
 const COMPANY_KEY = 'giorgio-armani';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Giorgio Armani S.p.A.';
 const COMPANY_HOST = 'career5.successfactors.eu';
 const COMPANY_DOMAIN = 'armani.com';

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -31,14 +31,20 @@ import {
 import { parseGolineOpportunitiesPage, buildGolineLocalizedContent } from './lib/goline-job-parser.mjs';
 import { launchChromium } from './lib/ensure-chromium.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'goline.json');
 
 const COMPANY_KEY = 'goline';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'GOLINE SA';
 const COMPANY_HOST = 'www.goline.ch';

--- a/scripts/update-grace-jobs.mjs
+++ b/scripts/update-grace-jobs.mjs
@@ -32,14 +32,20 @@ import { selectGraceDescription } from './lib/grace-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'grace-la-margna.json');
 
 const COMPANY_KEY = 'grace-la-margna';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Grace La Margna St. Moritz';
 const COMPANY_DOMAIN = 'gracehotels.com';
 const COMPANY_HOST = 'www.gracehotels.com';

--- a/scripts/update-groupe-mutuel-jobs.mjs
+++ b/scripts/update-groupe-mutuel-jobs.mjs
@@ -21,7 +21,6 @@
  *   7. Validate locale coverage across IT/EN/DE/FR
  */
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { fileURLToPath } from 'node:url';
@@ -54,17 +53,22 @@ import {  inferSwissTargetCanton, inferAnyCanton  } from './lib/target-swiss-loc
 import { isTargetCanton, TARGET_CANTONS, COMPANY_HQ } from './lib/crawler-location-config.mjs';
 import { assertJsonListShapeMultiKey } from './lib/assert-json-list-shape.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-// Per-crawler-scoped scratch path (never shared with sibling crawlers in the
-// same crawler-group CI job -- no cross-process race possible by construction).
-const SCRATCH_KEY = path.basename(fileURLToPath(import.meta.url), '.mjs');
-const DATA_JOBS = path.join(os.tmpdir(), `frontaliere-jobs-scratch-${SCRATCH_KEY}.json`);
-const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const GROUPE_MUTUEL_KEY = 'groupe-mutuel';
+// The old script-filename-derived scratch key (SCRATCH_KEY = basename) was
+// unique per-script but did NOT match what runDedicatedBaseCrawler resolves
+// internally (crawlerScratchPathFor(companyKeys.join('_'))) when no
+// dataJobsPath is passed — so this script's own pre/post-crawl reads/writes
+// were still blind to the engine's real output (bug class of #3775/#3768,
+// confirmed cause of #3769/#3770). Use the exact same key it passes as
+// companyKeys below so both sides agree on one path.
+const DATA_JOBS = crawlerScratchPathFor(GROUPE_MUTUEL_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const GROUPE_MUTUEL_COMPANY_NAME = 'Groupe Mutuel';
 const GROUPE_MUTUEL_HOST = 'groupemutuel.csod.com';
 const GROUPE_MUTUEL_COMPANY_DOMAIN = 'groupemutuel.ch';

--- a/scripts/update-guess-jobs.mjs
+++ b/scripts/update-guess-jobs.mjs
@@ -58,14 +58,20 @@ import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'guess-europe.json');
 
 const COMPANY_KEY = 'guess-europe';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Guess Europe Sagl';
 const COMPANY_HOST = 'apply.workable.com';

--- a/scripts/update-hamilton-jobs.mjs
+++ b/scripts/update-hamilton-jobs.mjs
@@ -55,14 +55,20 @@ import {
   captureLostSlugs,
 } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const COMPANY_KEY = 'hamilton-bonaduz-ag';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Hamilton Bonaduz AG';
 const COMPANY_DOMAIN = 'hamilton.ch';
 

--- a/scripts/update-has-healthcare-jobs.mjs
+++ b/scripts/update-has-healthcare-jobs.mjs
@@ -49,14 +49,20 @@ import {
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'has-healthcare';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'HAS Healthcare Advanced Synthesis';
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_HOST = 'e-lavoro.ch';

--- a/scripts/update-helsinn-jobs.mjs
+++ b/scripts/update-helsinn-jobs.mjs
@@ -22,14 +22,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseListingPage, parseDetailPage, slugify, detectCategory, detectExperienceLevel, inferEmploymentType } from './lib/helsinn-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'helsinn';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('helsinn');
 const COMPANY_NAME = 'Helsinn Healthcare SA';
 const COMPANY_HOST = 'www.e-lavoro.ch';

--- a/scripts/update-hes-so-valais-jobs.mjs
+++ b/scripts/update-hes-so-valais-jobs.mjs
@@ -25,7 +25,6 @@
  *   8. Validate locale coverage across IT/EN/DE/FR
  */
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { fileURLToPath } from 'node:url';
@@ -54,17 +53,22 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './lib/target-swiss-locations.mjs';
 import { isTargetCanton, TARGET_CANTONS, COMPANY_HQ } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-// Per-crawler-scoped scratch path (never shared with sibling crawlers in the
-// same crawler-group CI job -- no cross-process race possible by construction).
-const SCRATCH_KEY = path.basename(fileURLToPath(import.meta.url), '.mjs');
-const DATA_JOBS = path.join(os.tmpdir(), `frontaliere-jobs-scratch-${SCRATCH_KEY}.json`);
-const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const HESSO_KEY = 'hes-so-valais';
+// The old script-filename-derived scratch key (SCRATCH_KEY = basename) was
+// unique per-script but did NOT match what runDedicatedBaseCrawler resolves
+// internally (crawlerScratchPathFor(companyKeys.join('_'))) when no
+// dataJobsPath is passed — so this script's own pre/post-crawl reads/writes
+// were still blind to the engine's real output (bug class of #3775/#3768,
+// confirmed cause of #3769/#3770). Use the exact same key it passes as
+// companyKeys below so both sides agree on one path.
+const DATA_JOBS = crawlerScratchPathFor(HESSO_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HESSO_COMPANY_NAME = 'HES-SO Valais-Wallis';
 const HESSO_HOST = 'www.hevs.ch';
 const HESSO_COMPANY_DOMAIN = 'hevs.ch';

--- a/scripts/update-hilcona-jobs.mjs
+++ b/scripts/update-hilcona-jobs.mjs
@@ -17,12 +17,18 @@ import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { fetchHilconaJobUrls, fetchHilconaDetailPage, slugify, inferEmploymentType } from './lib/hilcona-job-parser.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'hilcona';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Hilcona AG (Bell Food Group)';
 
 function isCompanyJob(job) {

--- a/scripts/update-hugo-boss-jobs.mjs
+++ b/scripts/update-hugo-boss-jobs.mjs
@@ -29,14 +29,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseSearchPage, isHugoBossTargetLocation, buildDetailUrl, detectCategory, detectExperienceLevel, inferEmploymentType } from './lib/hugo-boss-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'hugo-boss';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Hugo Boss';
 const COMPANY_HOST = 'careers.hugoboss.com';

--- a/scripts/update-ibsa-jobs.mjs
+++ b/scripts/update-ibsa-jobs.mjs
@@ -42,14 +42,20 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const IBSA_KEY = 'ibsa-institut-biochimique';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(IBSA_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(IBSA_KEY)?.canton || 'TI';
 const IBSA_COMPANY_NAME = 'IBSA Institut Biochimique';
 const IBSA_COMPANY_DOMAIN = 'ibsa.ch';

--- a/scripts/update-interroll-jobs.mjs
+++ b/scripts/update-interroll-jobs.mjs
@@ -19,14 +19,20 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, mergePreserve
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseListingPage, isSwissLocation, slugify, detectCategory, detectExperienceLevel, inferEmploymentType } from './lib/interroll-job-parser.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'interroll';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Interroll Group';
 const COMPANY_HOST = 'www.interroll.com';
 const CAREERS_URL = 'https://www.interroll.com/company/careers/jobs/';

--- a/scripts/update-ist-jobs.mjs
+++ b/scripts/update-ist-jobs.mjs
@@ -62,14 +62,20 @@ import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { getCantonDisplayName, getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { locateTagByAttribute, extractBalancedTagBlock } from './lib/hospital-custom-html-helpers.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const IST_KEY = 'international-school-of-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(IST_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(IST_KEY)?.canton || 'TI';
 const IST_COMPANY_NAME = 'International School of Ticino';
 const IST_COMPANY_HOST = 'jobs.inspirededu.com';

--- a/scripts/update-julius-baer-jobs.mjs
+++ b/scripts/update-julius-baer-jobs.mjs
@@ -27,14 +27,20 @@ import { parseWorkdayListings, parseWorkdayJobDetail, slugify, normalizeSpace, s
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferSwissTargetCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'julius-baer';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Julius Baer';
 const LOCALES = ['it', 'en', 'de', 'fr'];

--- a/scripts/update-jysk-jobs.mjs
+++ b/scripts/update-jysk-jobs.mjs
@@ -43,14 +43,20 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const JYSK_KEY = 'jysk';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(JYSK_KEY);
 const JYSK_COMPANY_NAME = 'JYSK';
 const JYSK_HOST = 'jobs.de.jysk.ch';
 const JYSK_LISTING_URL = 'https://jobs.de.jysk.ch/offene-stellen';

--- a/scripts/update-kempinski-jobs.mjs
+++ b/scripts/update-kempinski-jobs.mjs
@@ -54,14 +54,20 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const COMPANY_KEY = 'grand-hotel-des-bains-kempinski';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Grand Hotel des Bains Kempinski St. Moritz';
 const COMPANY_DOMAIN = 'kempinski.com';
 

--- a/scripts/update-kronenhof-jobs.mjs
+++ b/scripts/update-kronenhof-jobs.mjs
@@ -50,14 +50,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const COMPANY_KEY = 'grand-hotel-kronenhof';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Grand Hotel Kronenhof';
 const COMPANY_DOMAIN = 'kronenhof.com';
 const HQ = getCompanyDefaults(COMPANY_KEY);

--- a/scripts/update-laderach-jobs.mjs
+++ b/scripts/update-laderach-jobs.mjs
@@ -17,12 +17,18 @@ import { inferAnyCanton, isKnownSwissMunicipality } from './lib/target-swiss-loc
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'laderach';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Läderach (Schweiz) AG';
 
 function isCompanyJob(job) {

--- a/scripts/update-lafonte-jobs.mjs
+++ b/scripts/update-lafonte-jobs.mjs
@@ -54,14 +54,20 @@ import {
 } from './lib/lafonte-job-parser.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'la-fonte';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults(COMPANY_KEY);
 const COMPANY_NAME = 'Fondazione La Fonte';
 const COMPANY_HOST = 'www.lafonte.ch';

--- a/scripts/update-lastminute-jobs.mjs
+++ b/scripts/update-lastminute-jobs.mjs
@@ -52,14 +52,20 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const LASTMINUTE_KEY = 'lastminute-com';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(LASTMINUTE_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(LASTMINUTE_KEY)?.canton || 'TI';
 const LASTMINUTE_COMPANY_NAME = 'lastminute.com';
 const LASTMINUTE_COMPANY_DOMAIN = 'lastminute.com';

--- a/scripts/update-lidl-jobs.mjs
+++ b/scripts/update-lidl-jobs.mjs
@@ -61,14 +61,20 @@ import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const LIDL_KEY = 'lidl-svizzera';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(LIDL_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const LIDL_COMPANY_NAME = 'Lidl Svizzera';
 const LIDL_TEAM_HOST = 'team.lidl.ch';
 const LIDL_COMPANY_DOMAIN = 'lidl.ch';

--- a/scripts/update-linnea-jobs.mjs
+++ b/scripts/update-linnea-jobs.mjs
@@ -47,14 +47,20 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const LINNEA_KEY = 'linnea';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(LINNEA_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('linnea');
 const LINNEA_COMPANY_NAME = 'Linnea SA';
 const LINNEA_COMPANY_HOST = 'www.linnea.ch';

--- a/scripts/update-lis-jobs.mjs
+++ b/scripts/update-lis-jobs.mjs
@@ -41,13 +41,21 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const LIS_KEY = 'lis-lugano-istituti-sociali';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run. crawlArca24Direct()'s own
+// merge-write and runBaseCrawler()'s AI-localization pass both need to land
+// on the SAME file this script later reads back; the shared, gitignored,
+// CI-absent data/jobs.json raced against ~25 sibling crawler-group steps
+// each overwriting it with their own company's jobs (bug class of
+// #3775/#3768, confirmed cause of #3769's silent 13-job loss).
+const DATA_JOBS = crawlerScratchPathFor(LIS_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const LOCALES = ['it', 'en', 'de', 'fr'];
 const LIS_SALARY_STRATEGY_VERSION = 'lis_salary_v2';
 const LIS_SALARY_LLM_FALLBACK_ENABLED = String(process.env.JOBS_LIS_SALARY_LLM_FALLBACK || '1') !== '0';

--- a/scripts/update-livingcircle-jobs.mjs
+++ b/scripts/update-livingcircle-jobs.mjs
@@ -32,14 +32,20 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'the-living-circle.json');
 
 const COMPANY_KEY = 'the-living-circle';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('livingcircle');
 const COMPANY_NAME = 'The Living Circle';
 const COMPANY_HOST = 'jobs.thelivingcircle.ch';

--- a/scripts/update-lombardi-jobs.mjs
+++ b/scripts/update-lombardi-jobs.mjs
@@ -48,14 +48,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'lombardi-group.json');
 
 const COMPANY_KEY = 'lombardi-group';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Lombardi Group';
 const COMPANY_HOST = 'lombardi.group';

--- a/scripts/update-lwphr-jobs.mjs
+++ b/scripts/update-lwphr-jobs.mjs
@@ -27,14 +27,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'lwphr.json');
 
 const COMPANY_KEY = 'lwphr';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('lwphr');
 const COMPANY_NAME = 'LWP Ledermann Wieting & Partners';
 const COMPANY_HOST = 'www.lwphr.ch';

--- a/scripts/update-manor-jobs.mjs
+++ b/scripts/update-manor-jobs.mjs
@@ -51,15 +51,21 @@ import { isTargetSwissLocation, isKnownSwissCity, inferAnyCanton } from './lib/t
 import { getCompanyDefaults, getCantonDisplayName } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const MANOR_KEY = 'manor';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(MANOR_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(MANOR_KEY)?.canton || 'TI';
 const MANOR_COMPANY_NAME = 'Manor AG';
 const MANOR_HOST = 'positions.manor.ch';

--- a/scripts/update-medacta-jobs.mjs
+++ b/scripts/update-medacta-jobs.mjs
@@ -43,13 +43,19 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { assertJsonListShapeMultiKey } from './lib/assert-json-list-shape.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const MEDACTA_KEY = 'medacta-international';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(MEDACTA_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('medacta');
 const LOCALES = ['it', 'en', 'de', 'fr'];
 

--- a/scripts/update-mendrisio-jobs.mjs
+++ b/scripts/update-mendrisio-jobs.mjs
@@ -52,15 +52,21 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const MENDRISIO_KEY = 'citta-di-mendrisio';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(MENDRISIO_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('mendrisio');
 const MENDRISIO_COMPANY_NAME = 'Città di Mendrisio';
 const MENDRISIO_HOST = 'mendrisio.ch';

--- a/scripts/update-migros-jobs.mjs
+++ b/scripts/update-migros-jobs.mjs
@@ -42,12 +42,18 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, d
 import { runQualityGuards } from './lib/crawler-quality-guards.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const MIGROS_KEY = 'migros-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(MIGROS_KEY);
 
 /**
  * Migros listing page URL — no REGION filter, so the whole of Switzerland is

--- a/scripts/update-mikron-jobs.mjs
+++ b/scripts/update-mikron-jobs.mjs
@@ -24,14 +24,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'mikron';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Mikron Group';
 const LOCALES = ['it', 'en', 'de', 'fr'];

--- a/scripts/update-mkspamp-jobs.mjs
+++ b/scripts/update-mkspamp-jobs.mjs
@@ -47,14 +47,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'mks-pamp.json');
 
 const COMPANY_KEY = 'mks-pamp';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'MKS PAMP';
 const COMPANY_HOST = 'careers.mkspamp.com';

--- a/scripts/update-mtic-jobs.mjs
+++ b/scripts/update-mtic-jobs.mjs
@@ -47,14 +47,20 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'mtic-group.json');
 
 const COMPANY_KEY = 'mtic-group';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'MTIC Group';
 const COMPANY_HOST = 'www.mtic-group.org';

--- a/scripts/update-oscam-jobs.mjs
+++ b/scripts/update-oscam-jobs.mjs
@@ -55,14 +55,20 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'oscam';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('oscam');
 const COMPANY_NAME = 'OSCAM – Ospedale e Casa Anziani Malcantonese';
 const COMPANY_HOST = 'www.oscam.ch';

--- a/scripts/update-otis-jobs.mjs
+++ b/scripts/update-otis-jobs.mjs
@@ -47,12 +47,18 @@ import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'otis';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Otis SA';
 
 function isCompanyJob(job) {

--- a/scripts/update-pemsa-jobs.mjs
+++ b/scripts/update-pemsa-jobs.mjs
@@ -47,14 +47,20 @@ import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'pemsa.json');
 
 const COMPANY_KEY = 'pemsa';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'PEMSA';
 const COMPANY_HOST = 'www.pemsa.ch';

--- a/scripts/update-pizzarotti-jobs.mjs
+++ b/scripts/update-pizzarotti-jobs.mjs
@@ -37,14 +37,20 @@ import {
   buildPizzarottiLocalizedContent,
 } from './lib/pizzarotti-job-parser.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'impresa-pizzarotti.json');
 
 const COMPANY_KEY = 'impresa-pizzarotti';
+// Per-crawler-scoped scratch path — this crawler does its own fetch+merge
+// (no runDedicatedBaseCrawler call), but still runs as one of ~25 sibling
+// background steps sharing a filesystem checkout in CI, so writing straight
+// to the shared, gitignored, CI-absent data/jobs.json is the same
+// cross-process-racy write pattern behind #3769/#3770. Scope it per-company.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Impresa Pizzarotti & C. S.p.A.';
 const COMPANY_HOST = 'www.pizzarotti.it';
 const COMPANY_DOMAIN = 'pizzarotti.it';

--- a/scripts/update-postch-jobs.mjs
+++ b/scripts/update-postch-jobs.mjs
@@ -41,13 +41,19 @@ import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { inferAnyCanton, normalizeCantonCode } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const POST_KEY = 'posta-svizzera-centro-regionale';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(POST_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const LOCALES = ['it', 'en', 'de', 'fr'];
 
 /**

--- a/scripts/update-postfinance-jobs.mjs
+++ b/scripts/update-postfinance-jobs.mjs
@@ -50,14 +50,20 @@ import { parsePostJobDetail } from './lib/postch-job-parser.mjs';
 import {  inferAnyCanton  } from './lib/target-swiss-locations.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'postfinance';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'PostFinance';
 const COMPANY_HOST = 'jobs.postfinance.ch';
 const LOCALES = ['it', 'en', 'de', 'fr'];

--- a/scripts/update-prada-jobs.mjs
+++ b/scripts/update-prada-jobs.mjs
@@ -47,12 +47,18 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { isLocationExplicitlyForeign } from './lib/dedicated-crawler-common.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'prada';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Prada Group';
 

--- a/scripts/update-raiffeisen-vc-jobs.mjs
+++ b/scripts/update-raiffeisen-vc-jobs.mjs
@@ -50,15 +50,21 @@ import {
 } from './lib/raiffeisen-vc-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const RAIFF_KEY = 'banca-raiffeisen-vedeggio-cassarate';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(RAIFF_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('raiffeisen-vc');
 const RAIFF_COMPANY_NAME = 'Banca Raiffeisen Vedeggio Cassarate';
 const RAIFF_HOST = 'www.raiffeisen.ch';

--- a/scripts/update-rapelli-jobs.mjs
+++ b/scripts/update-rapelli-jobs.mjs
@@ -45,12 +45,18 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { safeLocationToken } from './lib/safe-location-token.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const COMPANY_KEY = 'rapelli';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Rapelli - ORIOR Food AG';
 
 function isCompanyJob(job) {

--- a/scripts/update-relewant-jobs.mjs
+++ b/scripts/update-relewant-jobs.mjs
@@ -47,14 +47,22 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'relewant.json');
 
 const COMPANY_KEY = 'relewant';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end via Zoho Recruit's public API), but it still
+// runs as one of ~25 sibling background:true steps in the same CI job, all
+// racing to read-merge-write the same shared, gitignored, CI-absent
+// data/jobs.json — the same clobber bug class confirmed by #3769/#3770.
+// Scope this script's own read/write target to a private per-company
+// scratch path so it can no longer race with siblings.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'ReleWant';
 const COMPANY_HOST = 'relewant.zohorecruit.com';

--- a/scripts/update-rittmeyer-jobs.mjs
+++ b/scripts/update-rittmeyer-jobs.mjs
@@ -36,14 +36,22 @@ import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError, fetchHtml } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'rittmeyer-ag.json');
 
 const COMPANY_KEY = 'rittmeyer-ag';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end), but it still runs as one of ~25 sibling
+// background:true steps in the same CI job, all racing to read-merge-write
+// the same shared, gitignored, CI-absent data/jobs.json — the same clobber
+// bug class confirmed by #3769/#3770. Scope this script's own read/write
+// target to a private per-company scratch path so it can no longer race
+// with siblings.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Rittmeyer AG';
 const COMPANY_HOST = 'karriere.rittmeyer.com';
 const COMPANY_DOMAIN = 'rittmeyer.com';

--- a/scripts/update-ruag-jobs.mjs
+++ b/scripts/update-ruag-jobs.mjs
@@ -36,14 +36,22 @@ import {
   buildRuagLocalizedContent,
 } from './lib/ruag-job-parser.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'ruag-ag.json');
 
 const COMPANY_KEY = 'ruag-ag';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end), but it still runs as one of ~25 sibling
+// background:true steps in the same CI job, all racing to read-merge-write
+// the same shared, gitignored, CI-absent data/jobs.json — the same clobber
+// bug class confirmed by #3769/#3770. Scope this script's own read/write
+// target to a private per-company scratch path so it can no longer race
+// with siblings.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'RUAG AG';
 const COMPANY_HOST = 'jobs.ruag.ch';
 const COMPANY_DOMAIN = 'ruag.ch';

--- a/scripts/update-sbb-jobs.mjs
+++ b/scripts/update-sbb-jobs.mjs
@@ -58,13 +58,21 @@ import { parseSbbDetailPage, MIN_SBB_DESC_LENGTH } from './lib/sbb-job-parser.mj
 import { getCompanyDefaults, getCantonDisplayName, isTargetCanton } from './lib/crawler-location-config.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const SBB_KEY = 'ffs-officine-ferrovie-federali';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end across two sources), but it still runs as
+// one of ~25 sibling background:true steps in the same CI job, all racing
+// to read-merge-write the same shared, gitignored, CI-absent
+// data/jobs.json — the same clobber bug class confirmed by #3769/#3770.
+// Scope this script's own read/write target to a private per-company
+// scratch path so it can no longer race with siblings.
+const DATA_JOBS = crawlerScratchPathFor(SBB_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(SBB_KEY)?.canton || 'TI';
 /**
  * SBB AEM JSON API endpoint.

--- a/scripts/update-sintetica-jobs.mjs
+++ b/scripts/update-sintetica-jobs.mjs
@@ -19,14 +19,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseListingPage, parseDetailPage, slugify, detectCategory, detectExperienceLevel, inferEmploymentType, MIN_DESC_LENGTH } from './lib/sintetica-job-parser.mjs';
 import { normalizeAnyCantonCode, isTargetCanton } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'sintetica';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Sintetica SA';
 const COMPANY_HOST = 'app.ncoreplat.com';
 const CAREERS_URL = 'https://app.ncoreplat.com/jobboard/1255/sintetica';

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -38,14 +38,22 @@ import {
 } from './lib/skyguide-job-parser.mjs';
 import { fetchHtml, exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'skyguide-sa.json');
 
 const COMPANY_KEY = 'skyguide-sa';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end), but it still runs as one of ~26 sibling
+// background:true steps in crawler-group-08.yml, all racing to
+// read-merge-write the same shared, gitignored, CI-absent data/jobs.json —
+// the same clobber bug class confirmed by #3769/#3770. Scope this script's
+// own read/write target to a private per-company scratch path so it can no
+// longer race with siblings.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Skyguide';
 const COMPANY_HOST = 'jobs.skyguide.ch';
 const COMPANY_DOMAIN = 'skyguide.ch';

--- a/scripts/update-stadt-chur-jobs.mjs
+++ b/scripts/update-stadt-chur-jobs.mjs
@@ -47,14 +47,22 @@ import {
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'stadt-chur.json');
 
 const COMPANY_KEY = 'stadt-chur';
+// This script never calls runDedicatedBaseCrawler (it owns its own
+// fetch+merge cycle end-to-end), but it still runs as one of ~25 sibling
+// background:true steps in the same CI job, all racing to read-merge-write
+// the same shared, gitignored, CI-absent data/jobs.json — the same clobber
+// bug class confirmed by #3769/#3770. Scope this script's own read/write
+// target to a private per-company scratch path so it can no longer race
+// with siblings.
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Stadt Chur';
 const COMPANY_DOMAIN = 'chur.ch';
 const HQ = getCompanyDefaults(COMPANY_KEY);

--- a/scripts/update-sunrise-jobs.mjs
+++ b/scripts/update-sunrise-jobs.mjs
@@ -38,14 +38,20 @@ import {
   inferSunriseCategory,
 } from './lib/sunrise-job-parser.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'sunrise-sede-ticino.json');
 
 const COMPANY_KEY = 'sunrise-sede-ticino';
+// Per-crawler-scoped scratch path — isolates this script's own merge writes
+// from the shared, gitignored, CI-absent data/jobs.json that ~25 sibling
+// dedicated crawlers also target as `background: true` steps in one CI job;
+// writing directly to the shared path races and silently clobbers sibling
+// output (confirmed bug class of #3769/#3770, crash-class #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Sunrise Communications AG';
 const COMPANY_HOST = 'careers.sunrise.ch';
 const COMPANY_DOMAIN = 'sunrise.ch';

--- a/scripts/update-supsi-jobs.mjs
+++ b/scripts/update-supsi-jobs.mjs
@@ -48,14 +48,23 @@ import { parseSupsiJobDetail } from './lib/supsi-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { isAcceptableTranslation } from './lib/translation-quality.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const SUPSI_KEY = 'supsi-dti';
+// Same per-crawler-scoped scratch path that runDedicatedBaseCrawler defaults
+// to internally (crawlerScratchPathFor(companyKeys.join('_'))) for a
+// single-key run. Pointing this script's own DATA_JOBS at that path (instead
+// of the shared data/jobs.json, which CI's slice-only mode never populates
+// and which ~25 sibling crawler-group steps would otherwise race on) means
+// postProcessSupsiJobs/fillMissingLocaleDescriptions/validateDedicatedLocaleCoverage
+// see the shared engine's actual freshly-crawled+localized output instead of
+// silently no-op'ing (or, worse, wiping the committed slice — issue #3775).
+const DATA_JOBS = crawlerScratchPathFor(SUPSI_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('supsi');
 const SUPSI_COMPANY_NAME = 'SUPSI / DTI';
 const SUPSI_COMPANY_DOMAIN = 'supsi.ch';

--- a/scripts/update-swatchgroup-jobs.mjs
+++ b/scripts/update-swatchgroup-jobs.mjs
@@ -17,11 +17,18 @@ import {
 } from './assemble-jobs-dataset.mjs';
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
+// Fixed per-script scratch key (not the dynamic companyKeys array — that's
+// loaded from adapter files at runtime, after this module-scope const runs).
+// Passed explicitly as dataJobsPath below so runDedicatedBaseCrawler agrees
+// on the same path regardless of how it would resolve companyKeys.join('_')
+// internally (bug class #3775/#3768, confirmed cause #3769/#3770).
+const SWATCHGROUP_SCRATCH_KEY = 'swatchgroup';
+const DATA_JOBS = crawlerScratchPathFor(SWATCHGROUP_SCRATCH_KEY);
 const SWATCH_FALLBACK_KEYS = [
   'comadur-swatch-group',
   'eta-sa-swatch-group',
@@ -84,6 +91,7 @@ function runBaseCrawler(companyKeys) {
     companyKeys,
     localizeOnlyCompanyKeys: companyKeys,
     forceLocalizeKeys: companyKeys,
+    dataJobsPath: DATA_JOBS,
   });
 }
 

--- a/scripts/update-swiss-medical-network-jobs.mjs
+++ b/scripts/update-swiss-medical-network-jobs.mjs
@@ -25,14 +25,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { smnPostingsApiUrl, smnPostingDetailApiUrl, normalizeSmnApiPosting, extractSmnApiDescription, extractSmnPostingId, SMN_POSTINGS_API, slugify, normalizeSpace } from './lib/swiss-medical-network-job-parser.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'swiss-medical-network';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Swiss Medical Network';
 const COMPANY_HOST = 'www.swissmedical.net';
 const CAREERS_URL = 'https://www.swissmedical.net/en/career/job-offers';

--- a/scripts/update-swisscom-jobs.mjs
+++ b/scripts/update-swisscom-jobs.mjs
@@ -43,14 +43,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseSwisscomJobDescription } from './lib/swisscom-job-parser.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton, isTargetSwissLocation  } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const SWISSCOM_KEY = 'swisscom-sede-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(SWISSCOM_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const SWISSCOM_COMPANY_NAME = 'Swisscom (sede Ticino)';
 const SWISSCOM_COMPANY_HOST = 'swisscom.wd103.myworkdayjobs.com';
 const SWISSCOM_API_BASE = 'https://swisscom.wd103.myworkdayjobs.com/wday/cxs/swisscom/SwisscomExternalCareers';

--- a/scripts/update-tich-jobs.mjs
+++ b/scripts/update-tich-jobs.mjs
@@ -48,13 +48,19 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang } 
 import { parseTichDetailPage, titleOverlap, MIN_TICH_DESC_LENGTH } from './lib/tich-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_DATA_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const TICH_KEY = 'amministrazione-cantonale-ti';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(TICH_KEY);
+const PUBLIC_DATA_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('tich');
 const TICH_COMPANY_NAME = 'Amministrazione Cantonale Ticino';
 

--- a/scripts/update-tinext-jobs.mjs
+++ b/scripts/update-tinext-jobs.mjs
@@ -46,15 +46,21 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { assertJsonListShapeMultiKey } from './lib/assert-json-list-shape.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'tinext.json');
 
 const COMPANY_KEY = 'tinext';
+// Per-crawler-scoped scratch path — isolates this script's own merge writes
+// from the shared, gitignored, CI-absent data/jobs.json that ~25 sibling
+// dedicated crawlers also target as `background: true` steps in one CI job;
+// writing directly to the shared path races and silently clobbers sibling
+// output (confirmed bug class of #3769/#3770, crash-class #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('tinext');
 const COMPANY_NAME = 'Tinext SA';
 const COMPANY_HOST = 'tinext.kenjo.io';

--- a/scripts/update-tpl-lugano-jobs.mjs
+++ b/scripts/update-tpl-lugano-jobs.mjs
@@ -42,14 +42,20 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { parseTplListingPage, inferEmploymentType } from './lib/tpl-lugano-job-parser.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const TPL_KEY = 'tpl-lugano';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(TPL_KEY);
 const TPL_COMPANY_NAME = 'TPL - Trasporti Pubblici Luganesi';
 const TPL_HOST = 'www.tplsa.ch';
 const TPL_LISTING_URL = 'https://www.tplsa.ch/2/50/tpl-lavora-con-noi.html';

--- a/scripts/update-trumpf-jobs.mjs
+++ b/scripts/update-trumpf-jobs.mjs
@@ -45,14 +45,20 @@ import { isTargetCanton, getCompanyDefaults, getCantonDisplayName } from './lib/
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'trumpf-schweiz.json');
 
 const COMPANY_KEY = 'trumpf-schweiz';
+// Per-crawler-scoped scratch path — isolates this script's own merge writes
+// from the shared, gitignored, CI-absent data/jobs.json that ~25 sibling
+// dedicated crawlers also target as `background: true` steps in one CI job;
+// writing directly to the shared path races and silently clobbers sibling
+// output (confirmed bug class of #3769/#3770, crash-class #3775/#3768).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'TRUMPF Schweiz AG';
 const COMPANY_DOMAIN = 'trumpf.com';
 const TRUMPF_HQ = getCompanyDefaults(COMPANY_KEY);

--- a/scripts/update-tsmg-jobs.mjs
+++ b/scripts/update-tsmg-jobs.mjs
@@ -36,14 +36,22 @@ import {
   buildTsmgLocalizedContent,
 } from './lib/tsmg-job-parser.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTER_PATH = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters', 'tsmg.json');
 
 const COMPANY_KEY = 'tsmg';
+// Per-crawler-scoped scratch path. This script does its own Lever API
+// discovery + merge (no runDedicatedBaseCrawler pass) but still wrote
+// straight to the literal data/jobs.json path — shared across ~25 sibling
+// `background: true` crawler-group steps on one filesystem, gitignored and
+// absent in CI (CRAWLER_SLICE_ONLY=1). Scoping the path per company avoids
+// racing/clobbering siblings writing the same file (bug class of
+// #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'TSMG';
 const COMPANY_HOST = 'jobs.lever.co';
 const COMPANY_DOMAIN = 'tsmg.co';

--- a/scripts/update-usi-jobs.mjs
+++ b/scripts/update-usi-jobs.mjs
@@ -52,13 +52,21 @@ import { freeTranslateWithRetry } from './lib/free-translate.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const USI_KEY = 'usi-universita-della-svizzera-italiana';
+// Per-crawler-scoped scratch path. This script does its own Drupal-listing
+// discovery + merge (no runDedicatedBaseCrawler pass) but still wrote
+// straight to the literal data/jobs.json path — shared across ~25 sibling
+// `background: true` crawler-group steps on one filesystem, gitignored and
+// absent in CI (CRAWLER_SLICE_ONLY=1). Scoping the path per company avoids
+// racing/clobbering siblings writing the same file (bug class of
+// #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(USI_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('usi');
 const LOCALES = ['it', 'en', 'de', 'fr'];
 

--- a/scripts/update-vf-jobs.mjs
+++ b/scripts/update-vf-jobs.mjs
@@ -22,11 +22,19 @@ import {
   detectLang,
 } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const VF_KEY = 'vf-international-the-north-face-timberland';
+// Same per-crawler-scoped scratch path runDedicatedBaseCrawler defaults to
+// internally for a single-key run. The shared data/jobs.json is absent under
+// CI's slice-only mode (assembly deferred to deploy time) and would otherwise
+// race across ~25 sibling crawler-group steps sharing one filesystem —
+// pointing this script's own DATA_JOBS at the scratch path means it sees the
+// shared engine's actual freshly-crawled+localized output instead of
+// crashing on the unguarded read below (issue #3768).
+const DATA_JOBS = crawlerScratchPathFor(VF_KEY);
 
 function normalizeKey(value = '') {
   return String(value || '')
@@ -117,7 +125,7 @@ async function main() {
   });
   // Crawl change summary (new/updated/removed)
   {
-    const raw = JSON.parse(fs.readFileSync(DATA_JOBS, 'utf-8'));
+    const raw = fs.existsSync(DATA_JOBS) ? JSON.parse(fs.readFileSync(DATA_JOBS, 'utf-8')) : [];
     const jobs = (Array.isArray(raw) ? raw : []).filter(isVfJob);
     const afterSnapshot = snapshotJobSlugs(jobs);
     const crawlDiff = computeCrawlDiff(_beforeSnapshot, afterSnapshot);

--- a/scripts/update-vir-biotechnology-jobs.mjs
+++ b/scripts/update-vir-biotechnology-jobs.mjs
@@ -29,14 +29,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseGreenhouseJobs, slugify, normalizeSpace, GREENHOUSE_API, inferEmploymentType } from './lib/vir-biotechnology-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'vir-biotechnology';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const HQ = getCompanyDefaults('vir-biotechnology');
 const COMPANY_NAME = 'Vir Biotechnology (Humabs BioMed)';
 const COMPANY_HOST = 'job-boards.greenhouse.io';

--- a/scripts/update-volg-jobs.mjs
+++ b/scripts/update-volg-jobs.mjs
@@ -60,14 +60,22 @@ import {
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { getCantonDisplayName } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 
 const COMPANY_KEY = 'volg-fenaco';
+// Per-crawler-scoped scratch path. This script does its own Prospective.ch
+// fenaco career-center discovery + merge (no runDedicatedBaseCrawler pass)
+// but still wrote straight to the literal data/jobs.json path — shared
+// across ~25 sibling `background: true` crawler-group steps on one
+// filesystem, gitignored and absent in CI (CRAWLER_SLICE_ONLY=1). Scoping
+// the path per company avoids racing/clobbering siblings writing the same
+// file (bug class of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const COMPANY_NAME = 'Volg / fenaco';
 const COMPANY_DOMAIN = 'fenaco.com';
 

--- a/scripts/update-vtg-jobs.mjs
+++ b/scripts/update-vtg-jobs.mjs
@@ -49,14 +49,20 @@ import {
   normalizeFederalJobLocation,
 } from './lib/federal-job-normalization.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const VTG_KEY = 'vtg';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(VTG_KEY);
 const VTG_COMPANY_NAME = 'Swiss Armed Forces (VTG)';
 const VTG_HOST = 'jobs.admin.ch';
 

--- a/scripts/update-zambon-jobs.mjs
+++ b/scripts/update-zambon-jobs.mjs
@@ -24,14 +24,20 @@ import { extractStableJobId } from './lib/job-match-key.mjs';
 import { parseListingPage, slugify, detectCategory, detectExperienceLevel, inferEmploymentType } from './lib/zambon-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 
 const COMPANY_KEY = 'zambon';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(COMPANY_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const DEFAULT_CANTON = getCompanyDefaults(COMPANY_KEY)?.canton || 'TI';
 const COMPANY_NAME = 'Zambon Svizzera SA';
 const COMPANY_HOST = 'www.zambon.com';

--- a/scripts/update-zegna-jobs.mjs
+++ b/scripts/update-zegna-jobs.mjs
@@ -42,13 +42,19 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, m
 import { isTargetSwissLocation, inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { isTargetCanton, getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
-const PUBLIC_JOBS = path.resolve(ROOT, 'public', 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const ZEGNA_KEY = 'ermenegildo-zegna-logistica';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(ZEGNA_KEY);
+const PUBLIC_JOBS = `${DATA_JOBS}.public.json`;
 const ZEGNA_HQ = getCompanyDefaults(ZEGNA_KEY);
 const DEFAULT_CANTON = ZEGNA_HQ?.canton || 'TI';
 const DEFAULT_CITY = ZEGNA_HQ?.city || 'Stabio';

--- a/scripts/update-zurich-jobs.mjs
+++ b/scripts/update-zurich-jobs.mjs
@@ -21,12 +21,18 @@ import {
 } from './assemble-jobs-dataset.mjs';
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, deriveLocalizedSlug, normalize } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const DATA_JOBS = path.resolve(ROOT, 'data', 'jobs.json');
 const ADAPTERS_DIR = path.resolve(ROOT, 'data', 'jobs-crawler-adapters', 'adapters');
 const ZURICH_KEY = 'zurich-insurance-sede-ticino';
+// Per-crawler-scoped scratch path — matches what runDedicatedBaseCrawler
+// defaults to internally for a single-key run, so this script's own
+// pre/post-crawl reads see the shared engine's actual output instead of the
+// gitignored, CI-absent, cross-process-racy shared data/jobs.json (bug class
+// of #3775/#3768, confirmed cause of #3769/#3770).
+const DATA_JOBS = crawlerScratchPathFor(ZURICH_KEY);
 
 /**
  * Country-level search terms for the Zurich careers portal (SuccessFactors ATS).

--- a/tests/scripts/git-commit-data-auth.test.ts
+++ b/tests/scripts/git-commit-data-auth.test.ts
@@ -9,7 +9,14 @@ describe('scripts/lib/git-commit-data.sh authentication', () => {
     const source = readFileSync(SCRIPT, 'utf8');
     const configureIndex = source.indexOf('ensure_git_auth()');
     const callIndex = source.indexOf('ensure_git_auth', configureIndex + 1);
-    const fetchIndex = source.indexOf('git fetch origin main');
+    // `git fetch origin main` is wrapped in a git_fetch_retry() helper (retry
+    // on transient network errors under set -e — issue #3771/#3774) whose
+    // definition appears before the first real call site, so indexOf('git
+    // fetch origin main') now matches inside the helper's own body instead of
+    // an actual invocation. Locate the first real *call* of the helper
+    // (its definition + the following occurrence) instead.
+    const fetchDefIndex = source.indexOf('git_fetch_retry()');
+    const fetchCallIndex = source.indexOf('git_fetch_retry', fetchDefIndex + 1);
     const pushIndex = source.indexOf('git push origin main');
 
     expect(configureIndex).toBeGreaterThan(-1);
@@ -18,7 +25,7 @@ describe('scripts/lib/git-commit-data.sh authentication', () => {
     expect(source).not.toContain('GITHUB_PAT:-');
     expect(source).toContain('git config --local http.https://github.com/.extraheader');
     expect(callIndex).toBeGreaterThan(configureIndex);
-    expect(callIndex).toBeLessThan(fetchIndex);
+    expect(callIndex).toBeLessThan(fetchCallIndex);
     expect(callIndex).toBeLessThan(pushIndex);
   });
 });


### PR DESCRIPTION
## Implementato

**Cross-company slug-Map collision fix (root cause of #3734, "previousSlugs writer regression: 833 losses in 24 hours")**
- `scripts/scatter-jobs-to-slices.mjs`: `jobIndex` now keyed by `resolveJobDiffKey(job)` (id/url/slug fallback) instead of bare `.slug` — confirmed live: 463 real slug collisions across `data/jobs/by-crawler/*.json` were silently merging wrong-company locale/slug data. Top offending commit `576f36974b` (147 losses) traced directly to this script via `translate-pending.yml`'s final `scatter` step.
- `scripts/reconcile-job-slugs.mjs`: `reconcileOrphanSlugs`/`reconcileExpiredSlugs` — `updatedJobs` Map now keyed by `resolveJobDiffKey(job)`; same collision would silently drop one company's `addPreviousSlugForLocale` propagation to its per-crawler slice.
- `scripts/assemble-jobs-dataset.mjs`: `assembleExpiredJobs` — `bySlug` Map now keyed by `` `${companyKey}::${slug}` `` (archive entries have no `.id`/`.url`, so composite key instead of `resolveJobDiffKey`).
- `scripts/cleanup-jobs.mjs`: `archiveExpiredJobs` — same composite-key fix (sibling `archiveExpiredJobsPerCrawler` was already per-crawler-scoped, left untouched).
- Verified: 71 existing tests pass (incl. `tests/reconcile-slugs-merged-count-contract.test.ts`'s cross-company guards) + hand-built functional smoke test reproducing the exact `klinik-sonnenhalde`/`allianz-suisse` collision.
- Swept and ruled out as false positives: `lib/expired-jobs-archive.mjs`, `backfill-expired-from-history.mjs`, `backfill-dedup-lost-jobs.mjs` (already per-crawler-scoped), `mine-all-job-slugs.mjs`, `sync-gsc-orphans.mjs` (slug-as-URL-identity, not job-identity merge), `send-newsletter.mjs` (display-only, no disambiguating key available).

**DATA_JOBS scratch-path isolation for dedicated crawlers (#3775 supsi, #3768 vf)**
- Per-script fixed scratch key passed explicitly as `dataJobsPath`, so `runDedicatedBaseCrawler` can't resolve a different path than the rest of the script.
- Same fix applied across all 16 remaining `failOnMissingJobsFile:true` sibling dedicated-crawler scripts sharing the same bug class (113 files total incl. earlier-session staubli/lis/cler instances).

**Torn-read / race fixes (#3771 staubli, #3769 lis, #3770 cler, #3774 berner-klinik-montana)**
- `scripts/jobs-url-helper.mjs`: `persistCrawlChangeSummary` now skips the shared, non-atomic summary-store write in `CRAWLER_SLICE_ONLY` CI mode (~25 sibling crawlers as background steps sharing one filesystem) — the per-crawler slice already captures the same data safely, and `assembleJobsDataset()` already skips rebuilding this file in that mode.
- `scripts/lib/git-commit-data.sh`: added `git_fetch_retry` wrapper (5 attempts, exponential-ish backoff) around both `git fetch origin main` call sites in the sync/rebase retry loop — previously unguarded under `set -e`, so a transient "Connection reset by peer" under concurrent crawler-group load killed the whole commit script instead of going through the existing backoff/retry path. #3774 (berner-klinik-montana, today 12:12-12:18 UTC) is a live recurrence of exactly this failure mode, pre-dating this fix.

**Other backlog items**
- #3777 alten: fixed Azure 401 / DeepL exhaustion cascade handling.
- #3679 data-quality-audit: raised `--max-turns` 40→65 (run 28790742227 hit `error_max_turns` on denied compound Bash calls + a self-inflicted import error before reaching any real audit work — legitimate complexity, not a cost-cut lever per AGENTS.md).

**Sibling-check advisory triage (`node scripts/ci/check-sibling-patterns.mjs`, 28 candidati su 6 token condivisi — tutti falso positivo, nessuna istanza genuina residua)**
- `buildExpiredEntry` (`backfill-dedup-lost-jobs.mjs`, `backfill-expired-from-history.mjs`, `lib/expired-jobs-archive.mjs`): falso positivo — Map costruita dentro il loop per-slice/per-crawlerKey, non condivisa cross-company.
- `jobIndex` (`local-mt-mopup.mjs`, `send-newsletter.mjs`, `backfill-orphan-slugs-from-registry.mjs`): falso positivo — rispettivamente riferimento in commento a un indice array, arricchimento display-only senza chiave disambiguante disponibile, variabile numerica di indice array non correlata al pattern slug-Map.
- `resolveJobDiffKey` (`backfill-prev-slugs-from-loss-events.mjs`, `scan-prev-slug-losses.mjs`, `lib/job-match-key.mjs`): falso positivo — i primi due usano già correttamente `resolveJobDiffKey` per la propria Map (stesso fix, non un'istanza del bug); il terzo è il file sorgente della funzione.
- `LIS_KEY`/`IST_KEY`/`ZURICH_KEY`/`VF_KEY` (13 file): falso positivo — collisione di nome-token, non di pattern. `update-{balgrist,eth-zurich,kispi-zurich,novelis,nvidia-zurich}-jobs.mjs` usano `runStandardCrawlerPipeline`, già scratch-path-safe internamente via `crawlerScratchPathFor(companyKey)` (`scripts/lib/crawler-template.mjs:765`); i 5 `-job-parser.mjs` corrispondenti sono parser puri senza I/O su file (verificato via grep); `localize-vf-existing-jobs.mjs`, `clean-lis-data.mjs`, `repair-translations.mjs` sono script manuali standalone mai referenziati da alcun workflow CI (verificato via grep su `.github/workflows/`) — nessuna race possibile senza esecuzione parallela nella matrice crawler-group.
- `allowedTools` (`crawler-data-quality-audit.yml` + `issue-fix.yml`, `lessons-harvester.yml`, `post-merge-followup.yml`, `pr-redflag-fixer.yml`, `pr-review-loop.yml`, `scripts/ci/followup-drainer.mjs`): falso positivo — il mio `--max-turns` 40→65 è tuning specifico per il fallimento osservato di quel workflow (#3679: Bash compound-call negate + errore import auto-inflitto), non una richiesta generalizzabile a ogni workflow Claude che condivide la chiave YAML `allowedTools`.

## Non implementato (ancora)

- #3767 (Translate Pending Jobs — Node heap OOM in the translation cascade step, run 28850618400): genuinely different bug class (memory exhaustion, not slug-collision or scratch-path) — separate root-cause investigation in progress, PR concatenata sullo stesso task.

Closes #3775
Closes #3768
Closes #3771
Closes #3769
Closes #3770
Closes #3774
Closes #3777
Closes #3679
Closes #3734

