### PR TITLE
fix: heap OOM in Translate Pending Jobs — cap heap + compact hot-path dataset writes

### DIFF
--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -43,7 +43,11 @@ permissions:
   issues: write     # for github-issue-creator on failure
 
 env:
-  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+  # --max-old-space-size=12288: ubuntu-latest standard runner has 16GB RAM;
+  # Phase 2b's per-company loop touches the full jobs.json (~25k jobs) many
+  # times per run, so give Node headroom above its ~4GB implicit default
+  # while leaving ~4GB for the OS/git/npm subprocesses (issue #3767 OOM).
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169 --max-old-space-size=12288'
 
 jobs:
   translate:

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -2289,9 +2289,9 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
       console.log(`  🧷 slugByLocale backfill: filled ${slugBackfilled} missing locale entries from canonical slug`);
     }
 
-    writeJson(DATA_JOBS, assembled);
+    writeJson(DATA_JOBS, assembled, { compact: true });
     fs.mkdirSync(path.dirname(PUBLIC_JOBS), { recursive: true });
-    writeJson(PUBLIC_JOBS, assembled);
+    writeJson(PUBLIC_JOBS, assembled, { compact: true });
     console.log(`✅ data/jobs.json assembled: ${assembled.length} jobs from ${listSliceFiles(JOBS_SLICES_DIR).length} slices`);
 
     // --- PostalCode enrichment (ensures 100% postalCode for JobPosting schema) ---
@@ -2315,8 +2315,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
         if (canton && cantonCapitals[canton]) { job.postalCode = cantonCapitals[canton]; postalFilled++; }
       }
       if (postalFilled > 0) {
-        writeJson(DATA_JOBS, assembled);
-        writeJson(PUBLIC_JOBS, assembled);
+        writeJson(DATA_JOBS, assembled, { compact: true });
+        writeJson(PUBLIC_JOBS, assembled, { compact: true });
         console.log(`  📮 PostalCode enrichment: filled ${postalFilled}/${assembled.length} jobs`);
       }
     }
@@ -2329,8 +2329,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
       job.qualityScore = total;
     }
     if (qsChanged > 0) {
-      writeJson(DATA_JOBS, assembled);
-      writeJson(PUBLIC_JOBS, assembled);
+      writeJson(DATA_JOBS, assembled, { compact: true });
+      writeJson(PUBLIC_JOBS, assembled, { compact: true });
       console.log(`  📊 Quality score: computed for ${assembled.length} jobs (${qsChanged} changed)`);
     }
 
@@ -2349,8 +2349,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
       if (ghostCount > 0) {
         console.log(`  👻 Ghost reconciliation: removed ${ghostCount} ghost expired entries, merged ${mergedSlugs} slugs into active previousSlugs`);
         // Write back active jobs with merged previousSlugs
-        writeJson(DATA_JOBS, assembled);
-        writeJson(PUBLIC_JOBS, assembled);
+        writeJson(DATA_JOBS, assembled, { compact: true });
+        writeJson(PUBLIC_JOBS, assembled, { compact: true });
       }
       writeJson(DATA_EXPIRED, cleanedExpired);
       fs.mkdirSync(path.dirname(PUBLIC_EXPIRED), { recursive: true });
@@ -2376,8 +2376,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
           const orphanResult = reconcileOrphanSlugs(assembled, orphanSlugs, enrichedData, { dryRun: false });
           if (orphanResult.mergedCount > 0) {
             console.log(`  🔗 Orphan reconciliation: ${orphanResult.mergedCount} slugs merged into active jobs' previousSlugs`);
-            writeJson(DATA_JOBS, assembled);
-            writeJson(PUBLIC_JOBS, assembled);
+            writeJson(DATA_JOBS, assembled, { compact: true });
+            writeJson(PUBLIC_JOBS, assembled, { compact: true });
           }
         }
 
@@ -2385,8 +2385,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
         const expResult = reconcileExpiredSlugs(assembled, cleanedExpired, { dryRun: false });
         if (expResult.mergedCount > 0) {
           console.log(`  🔗 Expired reconciliation: ${expResult.mergedCount} slugs merged into active jobs' previousSlugs`);
-          writeJson(DATA_JOBS, assembled);
-          writeJson(PUBLIC_JOBS, assembled);
+          writeJson(DATA_JOBS, assembled, { compact: true });
+          writeJson(PUBLIC_JOBS, assembled, { compact: true });
           writeJson(DATA_EXPIRED, cleanedExpired);
           writeJson(PUBLIC_EXPIRED, cleanedExpired);
         }

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -5551,8 +5551,8 @@ async function main() {
   if (strippedCount > 0) {
     console.log(`⚠️  stripCopyPasteLocales modified ${strippedCount}/${merged.length} jobs (titles/descriptions blanked)`);
   }
-  writeJson(DATA_JOBS, mergedEnriched);
-  writeJson(PUBLIC_JOBS, mergedEnriched);
+  writeJson(DATA_JOBS, mergedEnriched, { compact: true });
+  writeJson(PUBLIC_JOBS, mergedEnriched, { compact: true });
   updateMeta({ totalJobs: merged.length, companiesCrawled, extracted, inserted, refreshed, startedAt });
 
   const audit = {

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -865,7 +865,7 @@ async function main() {
   // Fast-path: clear flags for jobs that are already complete (no AI call needed).
   const preCleared = clearRetranslationFlags(jobs);
   if (preCleared > 0) {
-    writeJsonAtomic(DATA_JOBS_PATH, jobs);
+    writeJsonAtomic(DATA_JOBS_PATH, jobs, { compact: true });
     console.log(`⚡ Pre-cleared ${preCleared} flags for already-complete jobs in assembled dataset`);
     console.log('');
 
@@ -979,7 +979,7 @@ async function main() {
       if (Array.isArray(currentJobs)) {
         const cleared = clearRetranslationFlags(currentJobs);
         if (cleared > 0) {
-          writeJsonAtomic(DATA_JOBS_PATH, currentJobs);
+          writeJsonAtomic(DATA_JOBS_PATH, currentJobs, { compact: true });
           totalFixed += cleared;
           console.log(`   ✅ ${key}: ${cleared} jobs translated, progress saved`);
         } else {
@@ -1071,7 +1071,7 @@ async function main() {
           if (Array.isArray(afterRetry)) {
             const cleared = clearRetranslationFlags(afterRetry);
             if (cleared > 0) {
-              writeJsonAtomic(DATA_JOBS_PATH, afterRetry);
+              writeJsonAtomic(DATA_JOBS_PATH, afterRetry, { compact: true });
               totalFixed += cleared;
               console.log(`   ✅ ${key} retry: ${cleared} more jobs translated`);
               const retryAttempted = changedSlugsSince(preRetrySig, afterRetry, key);


### PR DESCRIPTION
## Implementato

Root cause (confirmed via `gh run view` log/jobs JSON + local synthetic repro, not guessed):

- `relocalize-pending-jobs.mjs` loops over 50-200+ companies inside a single long-lived Node process (56 invocations of `runSharedCrawlerPipeline()` in the crashed run, ~90 minutes). On every iteration it does full-dataset `readJson`/`writeJsonAtomic(data/jobs.json)` round-trips, and internally `shared-jobs-crawler.mjs`'s `main()` ALSO pretty-prints (`JSON.stringify(value, null, 2)`) and writes the entire ~25k-job dataset to both `data/jobs.json` and `public/data/jobs.json` (both gitignored scratch files) on every call.
- With no `--max-old-space-size` set anywhere in the workflow, Node hit its implicit ~4GB old-space ceiling on the 16GB `ubuntu-latest` runner. The V8 crash native stack trace (`WriteUtf8 -> SlowFlatten -> NewRawTwoByteString`) matches flattening a huge pretty-printed JSON string for `fs.writeFileSync`.
- Local repro: synthetic 25k-job dataset, looped writes (compact vs pretty) in isolated processes — `heapUsed` plateaus at ~200MB across iterations rather than growing, confirming this is **not an unbounded-accumulator leak**, but legitimately large, repeated work exceeding an implicit heap budget. Pretty-print was also measurably slower per call (~31% more wall time) than compact for the same payload.

Fix (both parts, since neither alone is a complete/honest fix for "legitimate work exceeding an implicit budget"):

1. Switched the 5 hot-path full-dataset writes to compact JSON (`{ compact: true }`, an option `writeJsonAtomic` already supported) — no indentation-string construction, faster `JSON.stringify`, smaller transient string:
   - `scripts/relocalize-pending-jobs.mjs:868,982,1074`
   - `scripts/lib/shared-jobs-crawler.mjs:5554-5555`
   - Both target files (`data/jobs.json`, `public/data/jobs.json`) are gitignored scratch/build artifacts, confirmed via `git check-ignore -v` — reformatting them has zero impact on any git-tracked consumer.
2. Raised `NODE_OPTIONS` in `.github/workflows/translate-pending.yml` to add `--max-old-space-size=12288` (12GB), leaving ~4GB headroom on the 16GB standard runner for OS/git/npm overhead.

Sibling-pattern check (repo-wide grep for `runSharedCrawlerPipeline`/`shared-jobs-crawler` callers): `update-coop-jobs.mjs`, `update-efg-jobs.mjs`, `update-eoc-jobs.mjs` each call `runDedicatedBaseCrawler` with a single `companyKeys` — one company per process, no repeated-loop pattern. `generate-company-parser.mjs`, `re-enrich-jobs.mjs` don't call the pipeline runner at all. `local-mt-mopup.mjs` operates only on small per-crawler slice files via a Python Argos subprocess (and a Python-side issue wouldn't produce this Node/V8 crash anyway).

**Correction (caught by `pr-review-loop` on this PR, 🔴 Important):** the caller-based sibling check above was too narrow — it only checked who invokes `runSharedCrawlerPipeline`, and on that basis wrongly cleared `assemble-jobs-dataset.mjs`. That script independently has the *identical symptom* (pretty-printed `writeJson(DATA_JOBS/PUBLIC_JOBS, assembled)` on the full ~25k-job dataset, called 12 times across the file — once per enrichment stage — all within the same process), and is itself invoked twice in this same `translate-pending.yml` workflow (lines 204, 223). Fixed: all 12 `writeJson(DATA_JOBS, ...)`/`writeJson(PUBLIC_JOBS, ...)` call sites in `scripts/assemble-jobs-dataset.mjs` now pass `{ compact: true }`, same as the original 5. `DATA_EXPIRED`/`PUBLIC_EXPIRED` writes in the same file are untouched (much smaller dataset, not part of the flagged pattern). Both `data/jobs.json`/`public/data/jobs.json` reconfirmed gitignored/untracked via `git check-ignore -v` — same safety precedent as the original fix. `node --check` clean; 36 relevant tests pass (`tests/scripts/assemble-jobs-cache.test.ts`, `tests/reconcile-slugs-merged-count-contract.test.ts`, `tests/scripts/assemble-per-locale-slug-collision-guard.test.ts`, `tests/scripts/shrink-guard.test.ts`).

Reviewer's 🟡 Nit (`scripts/cleanup-jobs.mjs:595,794`, same non-compact pattern) was explicitly dispositioned by the reviewer itself as deferred/non-blocking: housekeeping runs once per slice in fresh short-lived processes via a shell loop, not accumulating heap in-process like the OOM pattern — not fixed here, no action needed per `REVIEW.md`'s nit-disposition rule.

Verification:
- `node --check` clean on both edited `.mjs` files; workflow YAML parses.
- Existing vitest suite for this area green: `tests/relocalize-suppression-loop.test.ts`, `tests/relocalize-is-incomplete.test.ts`, `tests/scripts/atomic-write-json.test.ts`, `tests/slug-registry-atomic-write.test.ts` — 18/18 passing.
- Local memory repro (synthetic 25k-job dataset, isolated Node processes, `--expose-gc`) confirming non-leak classification and compact-vs-pretty cost delta, as described above. Full local SEO/dataset build was NOT attempted (known to OOM the dev machine).
- GitNexus `context()`/`impact()` on both edited `main()` functions: zero external upstream callers besides each file's own CLI entrypoint; `writeJsonAtomic`'s signature/default behavior is unchanged (only call sites now pass an already-supported option), so the wide fan-out of that utility carries no behavior-change risk. `detect_changes` could not be used meaningfully here — the indexed GitNexus repo path is the main checkout, not this worktree, so it reported no diff; this is a known tool/path limitation, not a real "no risk" signal.

## Non implementato (ancora)

Nessuno.

Closes #3767
