### PR TITLE
fix(ci): centralized retry helper for refresh-thin-promotions push

### DIFF
--- a/.github/workflows/refresh-thin-promotions.yml
+++ b/.github/workflows/refresh-thin-promotions.yml
@@ -101,31 +101,15 @@ jobs:
           git config user.email "thin-promotions-bot@frontaliereticino.ch"
           git add data/thin-page-promotions-active.json data/thin-page-promotions.jsonl
           git commit -m "chore(thin-promotions): refresh self-heal feedback (last hour)"
-          # Retry-on-rebase: many scheduled workflows push to main concurrently
-          # (crawlers, fuel, weather, etc.); a non-fast-forward push is the
-          # expected failure mode, NOT a code bug. Mirror the rebase loop used
-          # by crawler-health-monitor.yml so a parallel push between our fetch
-          # and push does not fail the entire run.
-          MAX_ATTEMPTS=5
-          BACKOFF_BASE=3
-          attempt=1
-          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
-            if git push origin HEAD:main; then
-              echo "✅ Pushed thin-promotions refresh."
-              exit 0
-            fi
-            echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
-            git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
-            if ! git rebase origin/main; then
-              echo "⚠️ Rebase conflict on data/thin-page-promotions-*.json — aborting and resetting."
-              git rebase --abort || true
-              exit 1
-            fi
-            sleep $((BACKOFF_BASE * attempt))
-            attempt=$((attempt + 1))
-          done
-          echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving change uncommitted."
-          exit 1
+          # Centralized rebase-retry helper (survives concurrent pushes from other
+          # workflows) instead of a bespoke inline loop — see
+          # scripts/lib/git-push-with-retry.sh, already used by
+          # ai-visibility-check.yml / cathedral-noindex-flip.yml / crawl-events.yml.
+          # No --regenerate-cmd / --in-place-resolver-cmd needed: this workflow is
+          # the single writer of these two files (see comment above), so a real
+          # rebase conflict should never occur — the helper's default abort-on-
+          # conflict fallback matches this step's previous behavior.
+          bash scripts/lib/git-push-with-retry.sh
 
       - name: Report failure to GitHub Issues
         if: failure()


### PR DESCRIPTION
## Implementato

- `refresh-thin-promotions.yml` "Commit if changed" step: replaced bespoke inline 5-attempt/45s-budget rebase-retry-push loop with a single call to the shared `scripts/lib/git-push-with-retry.sh` helper — same pattern already used by `ai-visibility-check.yml`, `cathedral-noindex-flip.yml`, `crawl-events.yml`.
- Root cause: production run [28865053336/job 85612914322](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28865053336/job/85612914322) exhausted all 5 attempts of the bespoke loop under high `main` commit churn (non-fast-forward push rejected repeatedly). The shared helper has the same rebase-retry shape but is centrally maintained and used successfully by the sibling workflows above.
- No `--regenerate-cmd`/`--in-place-resolver-cmd` flags needed: this workflow is documented as the single automated writer of `data/thin-page-promotions-active.json` + `.jsonl`, so a real rebase conflict should never occur — default abort-on-conflict fallback matches the prior step's behavior.
- YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Non implementato (ancora)

- Nessuno per lo scope di questa PR (fix mirato a `refresh-thin-promotions.yml`, come da richiesta esplicita owner: "non devi modificare gli altri ma applicare la soluzione applicata in altri in quello che abbiamo risultato andasse in errore del refresh thin").
- Sibling deferral (dichiarato, non silenzioso): altri 9 workflow condividono lo stesso anti-pattern bespoke inline retry-loop invece dello shared helper — `build-evidence-and-tune.yml`, `crawler-health-monitor.yml`, `fb-events-daily-schedule.yml`, `gsc-frontaliere-monitor.yml`, `guard-data-integrity.yml`, `quality-alerts.yml`, `regenerate-visual-baselines.yml`, `update-weather.yml`, `deploy.yml`. Owner explicitly scoped this PR to `refresh-thin-promotions.yml` only; migrating these is a separate, explicitly out-of-scope follow-up (not opened as an issue per owner instruction — reference retained here per AGENTS.md #6 sibling-pattern disclosure requirement). `deploy.yml` in particular has incident-tuned backoff/merge-driver logic that would need careful flag-mapping, not a drop-in swap.
