### PR TITLE
fix(crawlers): soft-defer proportional translation tolerance (#3783)

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -4000,7 +4000,10 @@ export function validateDedicatedLocaleCoverage({
   untranslatedCheck = true,
   sampleLimit = 30,
   minSourceDescriptionCharsForHardValidation = minDescriptionChars,
-  maxToleratedMissingDescriptions = 0,
+  // null = "caller didn't set one" (distinct from an explicit 0, which means
+  // "this source wants zero tolerance" and must be respected verbatim — see
+  // FRO-628 below).
+  maxToleratedMissingDescriptions = null,
   // Injectable for tests; defaults to the live free-translate cascade metrics.
   getCascadeStatsFn = getCascadeStats,
 }) {
@@ -4157,7 +4160,22 @@ export function validateDedicatedLocaleCoverage({
       'missing_description', 'untranslated_description',
       'missing_title', 'untranslated_title',
     ]);
-    let effectiveTolerance = maxToleratedMissingDescriptions;
+    // FRO-628 (2026-07-07): crawlers that never set an explicit tolerance
+    // defaulted to 0 — a single untranslated job (one transient 429 mid-run)
+    // discarded the ENTIRE batch, including every other successfully
+    // translated job (#3783: ALTEN lost 3/3 jobs over 1 bad locale, and
+    // ~105 sibling crawlers share the same implicit-0 gap). Give the unset
+    // case a size-proportional floor instead — small enough that a genuine
+    // systemic translation break (most/all jobs affected) still hard-fails.
+    // Callers that DO set an explicit value (including 0, e.g. a source
+    // whose content-quality bar demands zero tolerance) keep it verbatim;
+    // this floor only fills in when nothing was configured.
+    const usedExplicitTolerance = maxToleratedMissingDescriptions !== null;
+    const DEFAULT_TRANSLATION_TOLERANCE_RATIO = Number(process.env.JOBS_TRANSLATION_TOLERANCE_RATIO) || 0.2;
+    const ratioTolerance = Math.max(1, Math.ceil(jobs.length * DEFAULT_TRANSLATION_TOLERANCE_RATIO));
+    let effectiveTolerance = usedExplicitTolerance
+      ? maxToleratedMissingDescriptions
+      : ratioTolerance;
 
     // Detect whether the translation INFRASTRUCTURE is down (vs an individual
     // job's translation being absent). Two independent layers can fail: the LLM
@@ -4226,6 +4244,25 @@ export function validateDedicatedLocaleCoverage({
         console.warn(`⚠️  Tolerating ${translationIssues.length} translation issue(s) (tolerance ${effectiveTolerance}): ${sample}${suffix}`);
         softIssues.push(...translationIssues);
         blockingIssues.length = 0;
+        // FRO-628 visibility: this specific commit-would-succeed path only
+        // exists because of the NEW ratio floor (an explicit tolerance was
+        // already silent pre-existing behavior for 26+ crawlers — not
+        // touched here). validateDedicatedLocaleCoverage is called
+        // synchronously by ~130 crawler scripts, so a GitHub issue (async,
+        // requires gh auth that isn't guaranteed outside CI) isn't a safe
+        // fire-and-forget here; the run's own Step Summary is — it's
+        // synchronous, needs no auth, and is exactly where a human already
+        // looks after an anomalous run.
+        if (!usedExplicitTolerance && process.env.GITHUB_STEP_SUMMARY) {
+          try {
+            fs.appendFileSync(
+              process.env.GITHUB_STEP_SUMMARY,
+              `\n⚠️ **${label}**: tolerated ${translationIssues.length} translation issue(s) ` +
+              `(proportional tolerance ${effectiveTolerance}/${jobs.length} jobs): ${sample}${suffix}\n` +
+              `Recovered by translate-pending.yml; will hard-fail deploy via validate-translation-completeness.mjs if still missing.\n`,
+            );
+          } catch { /* best-effort only */ }
+        }
       }
     }
   }

--- a/tests/dedicated-crawler-translation-tolerance-ratio.test.ts
+++ b/tests/dedicated-crawler-translation-tolerance-ratio.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Translation-tolerance ratio floor (FRO-628, issue #3783 — ALTEN).
+ *
+ * `validateDedicatedLocaleCoverage`'s base translation tolerance (FRO-317,
+ * `maxToleratedMissingDescriptions`) defaulted to 0 for any crawler that
+ * didn't explicitly override it. A SINGLE untranslated locale on a SINGLE
+ * job (one transient 429 mid-run) then hard-failed the whole run and
+ * discarded every other successfully-crawled+translated job — not just the
+ * affected one. ALTEN lost 3/3 jobs this way over 1 bad locale (#3783); the
+ * same implicit-0 gap applies to every dedicated crawler that never set
+ * `maxToleratedMissingDescriptions` (~105 of them).
+ *
+ * Fix: when the caller leaves the tolerance UNSET (not explicit 0), the gate
+ * now floors it to a small size-proportional ratio instead. Callers that DO
+ * set an explicit value — including 0, for sources whose content-quality
+ * bar demands zero tolerance — keep it verbatim; the floor never overrides
+ * an explicit choice.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateDedicatedLocaleCoverage } from '../scripts/lib/dedicated-crawler-common.mjs';
+
+const STRICT_ENV = 'JOBS_TRANSLATION_RATIO_TEST_STRICT';
+const NO_BOILERPLATE_COMPANY = 'Zqx Ephemeral Source Sarl';
+
+// A fake-but-structurally-valid key: isAnyModelAvailable() only checks
+// presence, never makes a network call, so this keeps the LLM-pool branch
+// of isTranslationInfraDown() out of the way without hitting any real
+// provider — letting these tests isolate the ratio-tolerance branch instead
+// of always taking the (also-legitimate, separately tested in
+// dedicated-crawler-translation-infra-gate.test.ts) infra-down defer path.
+const PRIOR_GROQ_KEY = process.env.GROQ_API_KEY;
+beforeEach(() => {
+  process.env.GROQ_API_KEY = 'test-fake-key-not-a-real-secret';
+});
+afterEach(() => {
+  if (PRIOR_GROQ_KEY === undefined) delete process.env.GROQ_API_KEY;
+  else process.env.GROQ_API_KEY = PRIOR_GROQ_KEY;
+});
+
+function richDescriptionIt(): string {
+  return (
+    'Cerchiamo una persona motivata per unirsi al nostro team in Ticino. ' +
+    'Il ruolo prevede responsabilità operative quotidiane, collaborazione con i ' +
+    'colleghi e contatto diretto con i clienti. Offriamo un ambiente di lavoro ' +
+    'dinamico, formazione continua, condizioni di impiego competitive e reali ' +
+    'opportunità di crescita professionale all\'interno di un\'azienda solida e ' +
+    'radicata sul territorio cantonale.'
+  );
+}
+
+function richDescriptionEn(): string {
+  return (
+    'We are looking for a motivated person to join our team in Ticino. ' +
+    'The role involves daily operational responsibilities, collaboration with ' +
+    'colleagues and direct contact with customers. We offer a dynamic work ' +
+    'environment, continuous training, competitive employment conditions and ' +
+    'genuine opportunities for professional growth within a solid company ' +
+    'rooted in the canton.'
+  );
+}
+
+function makeTranslatedJob(slug: string, n: number) {
+  const title = `Collaboratore Operativo ${n}`;
+  return {
+    slug,
+    url: `https://example-source.test/jobs/${slug}/`,
+    title,
+    company: NO_BOILERPLATE_COMPANY,
+    description: richDescriptionIt(),
+    titleByLocale: { it: title, en: `Operations Associate ${n}` },
+    descriptionByLocale: { it: richDescriptionIt(), en: richDescriptionEn() },
+    slugByLocale: { it: slug, en: `${slug}-en` },
+  };
+}
+
+/** IT description is rich (not thin) but the EN translation never landed. */
+function makeUntranslatedJob(slug: string, n: number) {
+  const title = `Collaboratore Operativo ${n}`;
+  return {
+    slug,
+    url: `https://example-source.test/jobs/${slug}/`,
+    title,
+    company: NO_BOILERPLATE_COMPANY,
+    description: richDescriptionIt(),
+    titleByLocale: { it: title, en: `Operations Associate ${n}` },
+    descriptionByLocale: { it: richDescriptionIt(), en: '' },
+    slugByLocale: { it: slug, en: `${slug}-en` },
+  };
+}
+
+function writeJobs(jobs: unknown[]): { dir: string; jobsPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-translation-ratio-'));
+  const jobsPath = path.join(dir, 'jobs.json');
+  fs.writeFileSync(jobsPath, `${JSON.stringify(jobs, null, 2)}\n`, 'utf-8');
+  return { dir, jobsPath };
+}
+
+function runGuard(jobsPath: string, overrides: Record<string, unknown> = {}) {
+  process.env[STRICT_ENV] = '1';
+  return validateDedicatedLocaleCoverage({
+    strictEnvVar: STRICT_ENV,
+    label: 'TranslationRatioTest',
+    dataJobsPath: jobsPath,
+    isTargetJob: () => true,
+    locales: ['it', 'en'],
+    minDescriptionChars: 120,
+    minSourceDescriptionCharsForHardValidation: 120,
+    checkSlug: false,
+    untranslatedCheck: true,
+    isTrustedDomain: () => true,
+    getCascadeStatsFn: () => ({ calls: 0, successes: 0, byFieldType: {} }),
+    ...overrides,
+  } as Parameters<typeof validateDedicatedLocaleCoverage>[0]);
+}
+
+describe('validateDedicatedLocaleCoverage — translation tolerance ratio floor', () => {
+  it('(#3783 repro) 1 untranslated among 3, tolerance unset → does NOT throw, no data lost', () => {
+    const jobs = [
+      makeTranslatedJob('good-0', 0),
+      makeTranslatedJob('good-1', 1),
+      makeUntranslatedJob('bad-0', 2),
+    ];
+    const { jobsPath } = writeJobs(jobs);
+
+    expect(() => runGuard(jobsPath)).not.toThrow();
+
+    // Unlike the thin-source quarantine path, the tolerance path never
+    // rewrites the dataset — all 3 jobs (including the flagged one) stay,
+    // ready for translate-pending.yml to fill the gap.
+    const after = JSON.parse(fs.readFileSync(jobsPath, 'utf-8')) as unknown[];
+    expect(after).toHaveLength(3);
+  });
+
+  it('explicit tolerance=0 is respected verbatim → same 1-among-3 gap still throws', () => {
+    const jobs = [
+      makeTranslatedJob('good-0', 0),
+      makeTranslatedJob('good-1', 1),
+      makeUntranslatedJob('bad-0', 2),
+    ];
+    const { jobsPath } = writeJobs(jobs);
+
+    expect(() => runGuard(jobsPath, { maxToleratedMissingDescriptions: 0 }))
+      .toThrow(/localization validation failed/i);
+  });
+
+  it('systemic translation break (4/5 untranslated), tolerance unset → still throws', () => {
+    const jobs = [
+      makeTranslatedJob('good-0', 0),
+      makeUntranslatedJob('bad-0', 1),
+      makeUntranslatedJob('bad-1', 2),
+      makeUntranslatedJob('bad-2', 3),
+      makeUntranslatedJob('bad-3', 4),
+    ];
+    const { jobsPath } = writeJobs(jobs);
+
+    // ratio floor = max(1, ceil(5 * 0.2)) = 1, well below the 4 actual gaps.
+    expect(() => runGuard(jobsPath)).toThrow(/localization validation failed/i);
+  });
+
+  it('pre-existing explicit tolerance (e.g. 2) still tolerates exactly up to its own value', () => {
+    const jobs = [
+      makeTranslatedJob('good-0', 0),
+      makeTranslatedJob('good-1', 1),
+      makeTranslatedJob('good-2', 2),
+      makeUntranslatedJob('bad-0', 3),
+      makeUntranslatedJob('bad-1', 4),
+    ];
+    const { jobsPath } = writeJobs(jobs);
+
+    expect(() => runGuard(jobsPath, { maxToleratedMissingDescriptions: 2 })).not.toThrow();
+  });
+
+  it('pre-existing explicit tolerance (2) is not silently widened by the ratio floor', () => {
+    const jobs = [
+      makeTranslatedJob('good-0', 0),
+      makeUntranslatedJob('bad-0', 1),
+      makeUntranslatedJob('bad-1', 2),
+      makeUntranslatedJob('bad-2', 3),
+    ];
+    const { jobsPath } = writeJobs(jobs);
+
+    // 3 gaps > explicit tolerance of 2 — even though ratio floor for 4 jobs
+    // (max(1, ceil(4*0.2))=1) is smaller still, the explicit value must win
+    // in BOTH directions (never widened, never narrowed by the floor).
+    expect(() => runGuard(jobsPath, { maxToleratedMissingDescriptions: 2 })).toThrow(/localization validation failed/i);
+  });
+
+  it('all translated → passes cleanly regardless of tolerance setting', () => {
+    const jobs = [makeTranslatedJob('good-0', 0), makeTranslatedJob('good-1', 1)];
+    const { jobsPath } = writeJobs(jobs);
+
+    expect(() => runGuard(jobsPath)).not.toThrow();
+  });
+
+  it('$GITHUB_STEP_SUMMARY gets a breadcrumb only for the NEW ratio-floor path, not for explicit tolerances', () => {
+    const summaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-step-summary-'));
+
+    // (a) unset tolerance, ratio floor absorbs the gap → summary written.
+    const ratioSummaryPath = path.join(summaryDir, 'ratio-summary.md');
+    fs.writeFileSync(ratioSummaryPath, '');
+    const jobsA = [
+      makeTranslatedJob('good-0', 0),
+      makeTranslatedJob('good-1', 1),
+      makeUntranslatedJob('bad-0', 2),
+    ];
+    const { jobsPath: jobsPathA } = writeJobs(jobsA);
+    const priorSummary = process.env.GITHUB_STEP_SUMMARY;
+    try {
+      process.env.GITHUB_STEP_SUMMARY = ratioSummaryPath;
+      runGuard(jobsPathA);
+      const summaryA = fs.readFileSync(ratioSummaryPath, 'utf-8');
+      expect(summaryA).toMatch(/tolerated 1 translation issue/i);
+
+      // (b) explicit tolerance covers the same shape of gap → no new write.
+      const explicitSummaryPath = path.join(summaryDir, 'explicit-summary.md');
+      fs.writeFileSync(explicitSummaryPath, '');
+      const jobsB = [
+        makeTranslatedJob('good-0', 0),
+        makeTranslatedJob('good-1', 1),
+        makeUntranslatedJob('bad-0', 2),
+      ];
+      const { jobsPath: jobsPathB } = writeJobs(jobsB);
+      process.env.GITHUB_STEP_SUMMARY = explicitSummaryPath;
+      runGuard(jobsPathB, { maxToleratedMissingDescriptions: 1 });
+      const summaryB = fs.readFileSync(explicitSummaryPath, 'utf-8');
+      expect(summaryB).toBe('');
+    } finally {
+      if (priorSummary === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+      else process.env.GITHUB_STEP_SUMMARY = priorSummary;
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

- **Root cause (#3783)**: `validateDedicatedLocaleCoverage`'s base translation tolerance (`maxToleratedMissingDescriptions`, FRO-317) defaulted to `0` for any crawler that never explicitly overrode it. One untranslated locale on one job then hard-failed the whole run — since every generated `crawler-group-*.yml` step only commits `if [ "$crawler_exit" -eq 0 ]`, that discarded **every** job from the run, not just the affected one. Confirmed live: ALTEN's 07-07 test run lost 3/3 crawled jobs over a single missing EN description; `data/jobs/by-crawler/alten-switzerland.json` stayed at its 07-04 snapshot.
- **Fix (Option A, user-selected — "soft-defer proporzionale")**: `scripts/lib/dedicated-crawler-common.mjs:validateDedicatedLocaleCoverage`
  - `maxToleratedMissingDescriptions` default changed from `0` to `null` (sentinel for "caller didn't set one").
  - When unset, `effectiveTolerance` now floors to `Math.max(1, Math.ceil(jobs.length * ratio))`, ratio = `JOBS_TRANSLATION_TOLERANCE_RATIO` env (default `0.2`) — e.g. ALTEN's 3-job run now tolerates 1 gap instead of 0.
  - **Explicit overrides are untouched**: any caller passing a literal value — including an explicit `0` for a source that deliberately wants zero tolerance — keeps that value verbatim, byte-for-byte the same code path as before. Confirmed via grep: ~26 crawlers already set explicit values (2–20); ALTEN and ~105 siblings were at the implicit default and are the ones this actually changes.
  - A genuine systemic translation break (most/all jobs affected) still hard-fails: the ratio floor is proportionally small (20%, min 1), so e.g. 4/5 untranslated still exceeds it and throws.
- **Visibility**: since a tolerated run now exits 0, the existing workflow-level `if crawler_exit -ne 0 || git_commit_exit -ne 0` issue-creation gate no longer fires for these cases (by design — this mirrors the already-accepted silent behavior of the 26 crawlers with explicit tolerances, and of the infra-down defer path). Added a best-effort `$GITHUB_STEP_SUMMARY` breadcrumb, scoped **only** to the new ratio-floor path (not to pre-existing explicit-tolerance or infra-down paths, to avoid changing their established noise profile). Chose a step-summary write over a new GitHub issue because `validateDedicatedLocaleCoverage` is called **synchronously** by ~133 crawler scripts and `createGithubIssue` is async + requires `gh` auth not guaranteed outside CI — a step summary is synchronous, needs no auth, and is exactly where a human already looks after an anomalous run.
- Tests: new `tests/dedicated-crawler-translation-tolerance-ratio.test.ts` (7 tests) covering the #3783 repro (1-among-3, unset tolerance → no throw, no data lost), explicit-0 still hard-fails, systemic break still hard-fails, pre-existing explicit tolerances still work in both directions (not silently widened or narrowed by the floor), and the step-summary scoping. All pre-existing tests touching this function still pass (4 sibling test files + 3 broader ones, 232 tests total). `node --check` clean. `check-sibling-patterns.mjs` clean (single shared function, no divergent twin). GitNexus `impact()` confirms 133 direct callers (risk=CRITICAL by fan-out, as expected for this function) — de-risked by the explicit-override-preserved design + full existing test suite passing unchanged.

## Non implementato (ancora)

- **Does not retroactively recover #3783's specific lost jobs.** This run's 2 discarded jobs (all except `alten-switzerland`'s pre-existing 3) are gone; they only reappear on ALTEN's next crawl. A live re-dispatch of `crawler-group-20.yml` after merge is planned to confirm the fix works end-to-end in production (per project convention: verify via live deploy, not just unit tests) — not done as a pre-merge dry run since it commits real data.
- **Issue #3783 not closed by this PR** (no `Closes #3783` used deliberately) — leaving it open until the live re-dispatch confirms the fix, then will close manually with the run link as evidence.
- The bigger structural note from the exploratory investigation — that the crawler-group commit gate is all-or-nothing per crawler (a *non-translation* issue, e.g. one bad slug, still discards the whole batch) — is **out of scope** here; this PR only addresses the translation-tolerance slice (Option A as scoped/approved).
