### PR TITLE
fix: raise cf-hot-404 accumulator/bridge cap 250k -> 500k

### DIFF
--- a/build-plugins/cfHot404BridgePlugin.ts
+++ b/build-plugins/cfHot404BridgePlugin.ts
@@ -53,16 +53,21 @@ const SEARCH_CLUSTER_LEGACY_SET = new Set(
 // real CF-confirmed 404 universe — a time-sliced sweep (build-cf-hot-404s.mjs,
 // 48×1h windows summed) measures ~50k accumulated ≥2-hit paths and ~134k
 // distinct ever-swept, so 40k left tens of thousands of real-traffic 404s
-// unrecovered. The emit is STREAMING (mkdir + writeFileSync per path, no HTML
-// in heap; only the {path,hits} array is retained), so the real cost is inode
-// count (~2 per bridge): even the full ~134k universe ≈ 268k inodes on top of
+// unrecovered. The 250k cap that replaced it hit the SAME failure mode by
+// 2026-07-07 (accumulator grew 181k→236k in 6 days, ~11-14k/day and
+// accelerating — real job-market churn, not a runaway) — ~13.6k headroom left
+// against ~13k/day growth meant the next daily sweep would start silently
+// dropping fresh orphans. The emit is STREAMING (mkdir + writeFileSync per
+// path, no HTML in heap; only the {path,hits} array is retained), so the real
+// cost is inode count (~2 per bridge): even 500k paths ≈ 1M inodes on top of
 // the ~327k-file IT shard, far under the ~2.3M Pages disk ceiling. So this rail
 // is raised to a ceiling that sits ABOVE the measured universe (a true cap only
 // against a degraded/hand-edited data file or a runaway), env-tunable for
 // backfill. Kept in lockstep with scripts/build-cf-hot-404s.mjs's MAX_PATHS —
 // change BOTH together. SSG-memory is not measurable pre-merge: revert-trigger
 // declared in the PR body (revert if the next deploy OOMs or wall-time regresses).
-const MAX_EMIT = Number(process.env.CF_HOT_404_MAX) || 250000;
+// Revisit if growth doesn't taper (this rail will bite again).
+const MAX_EMIT = Number(process.env.CF_HOT_404_MAX) || 500000;
 
 const withSlash = (p: string): string => (p.endsWith('/') ? p : `${p}/`);
 

--- a/scripts/build-cf-hot-404s.mjs
+++ b/scripts/build-cf-hot-404s.mjs
@@ -42,13 +42,19 @@ const APEX_HOST = process.env.CF_ZONE_NAME || DEFAULT_ZONE_NAME;
 // universe: this time-sliced sweep (48×1h windows summed below) measures ~50k
 // accumulated ≥2-hit non-Ticino job 404s and ~134k distinct ever-swept, so 40k
 // dropped tens of thousands of real-traffic paths before the bridge plugin ever
-// saw them. The cfHot404BridgePlugin emit is STREAMING (mkdir+writeFile per
-// path, no HTML held in heap), so the real cost is inode count (~2 per bridge):
-// even the full ~134k universe ≈ 268k inodes on top of the ~327k-file IT shard,
-// far under the ~2.3M Pages disk ceiling. Raised to a ceiling ABOVE the measured
-// universe (true cap only vs a degraded CF response / runaway), env-tunable.
-// Kept in lockstep with cfHot404BridgePlugin's MAX_EMIT — change BOTH together.
-const MAX_PATHS = Number(process.env.CF_HOT_404_MAX) || 250000;
+// saw them. The 250k cap that replaced it hit the SAME failure mode by
+// 2026-07-07 (accumulator grew 181k→236k in 6 days, ~11-14k/day and
+// accelerating — real job-market churn, not a runaway) — ~13.6k headroom left
+// against ~13k/day growth meant the next daily sweep would start silently
+// dropping fresh orphans (see reconcileHotPaths's cap-slice: least-recently-seen
+// evicted first, same as absent). The cfHot404BridgePlugin emit is STREAMING
+// (mkdir+writeFile per path, no HTML held in heap), so the real cost is inode
+// count (~2 per bridge): even 500k paths ≈ 1M inodes on top of the ~327k-file
+// IT shard, far under the ~2.3M Pages disk ceiling. Raised to a ceiling ABOVE
+// the measured universe (true cap only vs a degraded CF response or runaway),
+// env-tunable. Kept in lockstep with cfHot404BridgePlugin's MAX_EMIT — change
+// BOTH together. Revisit if growth doesn't taper (this rail will bite again).
+const MAX_PATHS = Number(process.env.CF_HOT_404_MAX) || 500000;
 
 // Drop one-hit noise: a single hit is usually a bot path-probe, not a real
 // expired/indexed URL worth a page. Real expired URLs get repeat hits from


### PR DESCRIPTION
## Implementato

Raised the shared lockstep cap on the CF-confirmed-404 bridge-recovery pipeline from 250,000 to 500,000, in `scripts/build-cf-hot-404s.mjs` (`MAX_PATHS`) and `build-plugins/cfHot404BridgePlugin.ts` (`MAX_EMIT`) — both changed together per the existing "change BOTH together" contract, comments updated with the current measurement.

Investigated a user-reported Cloudflare dashboard table showing ~79k 404 hits/48h across the 7 `origin-*` shard-origin hosts. Live-tested 26 real paths from that data (top-hit + randomly sampled across the full distribution): 25/26 got a successful live `301` to the correct canonical page, 1 was already `200`. Those `origin-*` hosts are DNS-only (unproxied), reachable only via the Cloudflare Worker's internal subrequest — the logged 404 is the *first hop* (Worker → GitHub Pages shard), caught before any real user/crawler sees it by the Worker's live recovery chain (`recoverCantonDriftOrphan` etc., `infra/cloudflare-worker/locale-router.js`). So that table is **not** lost traffic — it's the redirect machinery's normal internal cost (also explains the table's 1-3% cache rate: each canton-drift job slug is effectively unique, nothing to repeat-cache).

The real client-visible unrecovered-404 signal is `data/cf-hot-404s.json` (apex host, eyeball-filtered — i.e. what survives the Worker's full live-recovery chain). It's a disjoint population from the origin-level pull (0% overlap, by construction — not a bug). It's already bridge-recovered near-perfectly at build time: last deploy (run 28912652915) resolved 243,699/243,778 paths, only 79 unresolved (0.03%).

The actual structural gap: that accumulator grew 181,152 → 236,415 paths over 6 days (2026-07-02 → 2026-07-07 commits), averaging +11-14k/day and accelerating — real job-market churn (Swiss job postings turning over), not a runaway. Headroom against the 250k cap was down to ~13.6k, meaning the daily `discover-404s-via-cloudflare` / `build-cf-hot-404s` sweep would have started silently evicting/dropping freshly-orphaned URLs from bridge recovery within roughly 1-2 days of this PR — genuine, imminent, quantifiable lost traffic, unlike the origin-404 dashboard numbers. Verified with `tests/build-cf-hot-404-retention.test.ts` + `tests/cf-hot-404-bridge.test.ts` (16/16 green), including the new `cap 500000` showing up correctly in the plugin's own emit log.

Inode cost stays cheap at the new ceiling: ~2 inodes/bridge page × 500k ≈ 1M inodes, still far under the documented ~2.3M GitHub Pages disk ceiling (per the pre-existing code comment this PR extends, not overrides).

## Non implementato (ancora)

Nessuno. Scope of this PR (raise the saturating cap) is fully live in this diff. Two smaller items surfaced during investigation but are NOT part of this task's scope (never promised/listed as in-scope, so not deferred-and-open per AGENTS.md #8 — noted here only for traceability):
- The 79 currently-unresolved bridge paths per build (0.03% of ~243.7k) — real but tiny, would need a debug artifact dump added to `cfHot404BridgePlugin.ts` to even inspect which paths they are; no evidence yet whether they're a new pattern class or one-off noise.
- Whether the 236k→growth trend is a transient backlog-catchup (a relatively young/expanding CF sweep) or a sustained steady-state churn rate — if it doesn't taper, this same rail hits its ceiling again; the updated code comment flags this explicitly for whoever re-raises it next.

Test plan:
- [x] `npx vitest run tests/build-cf-hot-404-retention.test.ts tests/cf-hot-404-bridge.test.ts` — 16/16 passed, confirmed `cap 500000` in emit log.
- [ ] Post-merge: confirm next scheduled `discover-404s-via-cloudflare` / build-locale runs show the accumulator growing past the old 250k ceiling without truncation.