### PR TITLE
fix(events): re-verify title length after canton-name substitution (#3772 recurrence)

### DIFF
--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -483,6 +483,18 @@ function applyCantonSubstitution(text: string, rules: Array<[RegExp, string]>): 
   return rules.reduce((acc, [re, repl]) => acc.replace(re, repl), text);
 }
 
+/** Short, budget-safe fallback `hubTitle` per locale — `sub(base.hubTitle)`
+ * substitutes the real canton name into a title budgeted for TI's short
+ * "Ticino"/"Tessin" with no re-check, so a long canton name (e.g. German
+ * "Appenzell Ausserrhoden") can push it past TITLE_MAX_CHARS. Composed via
+ * {@link composePlaceTitle} like `comuneTitle`, never emitted verbatim. */
+const HUB_TITLE_FALLBACK: Record<Locale, (display: string) => string> = {
+  it: (d) => `Eventi in ${d}: agenda aggiornata`,
+  en: (d) => `Events in ${d}: an updated agenda`,
+  de: (d) => `Veranstaltungen in ${d}: aktuelle Agenda`,
+  fr: (d) => `Événements à ${d} : agenda à jour`,
+};
+
 const copyCache = new Map<string, Copy>();
 /** TI → the literal, hand-tuned `COPY[locale]` object (byte-identical, zero
  * risk). Any other canton → a derived copy with the safe substitution rules
@@ -495,9 +507,14 @@ function copyFor(canton: string, locale: Locale): Copy {
   const rules = cantonSubstitutionRules(canton, locale);
   const base = COPY[locale];
   const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const display = cantonDisplayLabel(canton, locale);
   const out: Copy = {
     ...base,
-    hubTitle: sub(base.hubTitle),
+    hubTitle: composePlaceTitle(
+      [sub(base.hubTitle), HUB_TITLE_FALLBACK[locale](display)],
+      TITLE_MAX_CHARS,
+      (s) => esc(s).length,
+    ),
     hubH1: sub(base.hubH1),
     hubLede: sub(base.hubLede),
     comuneLede: (c: string) => sub(base.comuneLede(c)),
@@ -656,6 +673,27 @@ function buildNationalAlternates(): string {
 
 type DigestCopy = { title: string; h1: string; lede: string; desc: string; faqQ: string; faqA: string };
 const digestCopyCache = new Map<string, DigestCopy>();
+
+/** Short, budget-safe fallback `title` per digest key + locale — same
+ * overflow risk as `HUB_TITLE_FALLBACK` (canton substituted into a title
+ * budgeted for TI's short name, no re-check). Keeps the weekend/week
+ * distinction so the two digest pages for one canton never end up with an
+ * identical (or near-identical) truncated `<title>`. */
+const DIGEST_TITLE_FALLBACK: Record<string, Record<Locale, (display: string) => string>> = {
+  weekend: {
+    it: (d) => `Eventi nel weekend a ${d}`,
+    en: (d) => `Events this weekend in ${d}`,
+    de: (d) => `Veranstaltungen am Wochenende: ${d}`,
+    fr: (d) => `Événements ce week-end à ${d}`,
+  },
+  week: {
+    it: (d) => `Eventi questa settimana a ${d}`,
+    en: (d) => `Events this week in ${d}`,
+    de: (d) => `Veranstaltungen diese Woche: ${d}`,
+    fr: (d) => `Événements cette semaine à ${d}`,
+  },
+};
+
 /** Same TI-verbatim / non-TI-substituted split as `copyFor`, applied to a
  * single `DigestDef.copy[locale]` entry. */
 function digestCopyFor(def: { key: string; copy: Record<Locale, DigestCopy> }, canton: string, locale: Locale): DigestCopy {
@@ -666,8 +704,12 @@ function digestCopyFor(def: { key: string; copy: Record<Locale, DigestCopy> }, c
   if (cached) return cached;
   const rules = cantonSubstitutionRules(canton, locale);
   const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const display = cantonDisplayLabel(canton, locale);
+  const fallbackTitle = DIGEST_TITLE_FALLBACK[def.key]?.[locale];
   const out: DigestCopy = {
-    title: sub(base.title),
+    title: fallbackTitle
+      ? composePlaceTitle([sub(base.title), fallbackTitle(display)], TITLE_MAX_CHARS, (s) => esc(s).length)
+      : sub(base.title),
     h1: sub(base.h1),
     lede: sub(base.lede),
     desc: sub(base.desc),
@@ -1775,6 +1817,15 @@ const OTHER_EVENTS_COPY: Record<Locale, OtherEventsCopy> = {
   },
 };
 
+/** Short, budget-safe fallback `metaTitle` per locale — same overflow risk
+ * as `HUB_TITLE_FALLBACK`/`DIGEST_TITLE_FALLBACK`. */
+const OTHER_EVENTS_TITLE_FALLBACK: Record<Locale, (display: string) => string> = {
+  it: (d) => `Altri eventi in ${d}`,
+  en: (d) => `Other events in ${d}`,
+  de: (d) => `Weitere Veranstaltungen in ${d}`,
+  fr: (d) => `Autres événements à ${d}`,
+};
+
 const otherEventsCopyCache = new Map<string, OtherEventsCopy>();
 /** Same TI-verbatim / non-TI-substituted split as `copyFor`/`detailCopyFor`. */
 function otherEventsCopyFor(canton: string, locale: Locale): OtherEventsCopy {
@@ -1785,9 +1836,14 @@ function otherEventsCopyFor(canton: string, locale: Locale): OtherEventsCopy {
   const rules = cantonSubstitutionRules(canton, locale);
   const base = OTHER_EVENTS_COPY[locale];
   const sub = (s: string) => applyCantonSubstitution(s, rules);
+  const display = cantonDisplayLabel(canton, locale);
   const out: OtherEventsCopy = {
     ...base,
-    metaTitle: sub(base.metaTitle),
+    metaTitle: composePlaceTitle(
+      [sub(base.metaTitle), OTHER_EVENTS_TITLE_FALLBACK[locale](display)],
+      TITLE_MAX_CHARS,
+      (s) => esc(s).length,
+    ),
     metaDesc: sub(base.metaDesc),
     h1: sub(base.h1),
     lede: sub(base.lede),
@@ -1997,9 +2053,25 @@ function eventDetailMetaTitle(rawTitle: string, suffix: string): string {
   return `${title}${suffix}`;
 }
 
+/** Per-locale event-detail `<title>` suffix template (comune + region +
+ * brand), extracted out of `DETAIL_COPY[locale].metaTitle` so
+ * `detailCopyFor` can canton-substitute the suffix itself and re-run it
+ * through {@link eventDetailMetaTitle} for non-TI cantons. The old code
+ * substituted the canton name into the ALREADY-budgeted/truncated string
+ * `eventDetailMetaTitle` returned (assuming TI's short "Ticino"/"Tessin"),
+ * with no re-check — a long canton display name (e.g. "Appenzell
+ * Rhodes-Extérieures", 28 chars vs "Tessin"'s 6) silently pushed the final
+ * `<title>` past TITLE_MAX_CHARS for every affected event-detail page. */
+const DETAIL_TITLE_SUFFIX: Record<Locale, (comune: string) => string> = {
+  it: (c) => ` — ${c} (Ticino) | Eventi`,
+  en: (c) => ` — ${c} (Ticino) | Events`,
+  de: (c) => ` — ${c} (Tessin) | Veranstaltungen`,
+  fr: (c) => ` — ${c} (Tessin) | Événements`,
+};
+
 const DETAIL_COPY: Record<Locale, DetailCopy> = {
   it: {
-    metaTitle: (t, c) => eventDetailMetaTitle(t, ` — ${c} (Ticino) | Eventi`),
+    metaTitle: (t, c) => eventDetailMetaTitle(t, DETAIL_TITLE_SUFFIX.it(c)),
     metaDesc: (t, c, w) => `${t}: ${w} a ${c}, in Ticino. Data, orario, luogo e link al sito ufficiale dell'evento.`,
     whenLabel: 'Quando',
     whereLabel: 'Dove',
@@ -2027,7 +2099,7 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     descriptionTitle: 'Descrizione',
   },
   en: {
-    metaTitle: (t, c) => eventDetailMetaTitle(t, ` — ${c} (Ticino) | Events`),
+    metaTitle: (t, c) => eventDetailMetaTitle(t, DETAIL_TITLE_SUFFIX.en(c)),
     metaDesc: (t, c, w) => `${t}: ${w} in ${c}, Ticino. Date, time, venue and a link to the event’s official site.`,
     whenLabel: 'When',
     whereLabel: 'Where',
@@ -2055,7 +2127,7 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     descriptionTitle: 'Description',
   },
   de: {
-    metaTitle: (t, c) => eventDetailMetaTitle(t, ` — ${c} (Tessin) | Veranstaltungen`),
+    metaTitle: (t, c) => eventDetailMetaTitle(t, DETAIL_TITLE_SUFFIX.de(c)),
     metaDesc: (t, c, w) => `${t}: ${w} in ${c}, Tessin. Datum, Uhrzeit, Ort und Link zur offiziellen Website der Veranstaltung.`,
     whenLabel: 'Wann',
     whereLabel: 'Wo',
@@ -2083,7 +2155,7 @@ const DETAIL_COPY: Record<Locale, DetailCopy> = {
     descriptionTitle: 'Beschreibung',
   },
   fr: {
-    metaTitle: (t, c) => eventDetailMetaTitle(t, ` — ${c} (Tessin) | Événements`),
+    metaTitle: (t, c) => eventDetailMetaTitle(t, DETAIL_TITLE_SUFFIX.fr(c)),
     metaDesc: (t, c, w) => `${t} : ${w} à ${c}, au Tessin. Date, heure, lieu et lien vers le site officiel de l’événement.`,
     whenLabel: 'Quand',
     whereLabel: 'Où',
@@ -2127,7 +2199,11 @@ function detailCopyFor(canton: string, locale: Locale): DetailCopy {
   const sub = (s: string) => applyCantonSubstitution(s, rules);
   const out: DetailCopy = {
     ...base,
-    metaTitle: (t: string, c: string) => sub(base.metaTitle(t, c)),
+    // Root-cause fix (recurrence of #3772): re-run the escape/budget-aware
+    // truncation against the REAL (canton-substituted) suffix, instead of
+    // substituting into `base.metaTitle`'s already-truncated output — see
+    // `DETAIL_TITLE_SUFFIX` doc comment above.
+    metaTitle: (t: string, c: string) => eventDetailMetaTitle(t, sub(DETAIL_TITLE_SUFFIX[locale](c))),
     metaDesc: (t: string, c: string, w: string) => sub(base.metaDesc(t, c, w)),
     lede: (w: string, ti: string, v: string, c: string) => sub(base.lede(w, ti, v, c)),
     about: (t: string, c: string, w: string, cat: string, venue?: string) => sub(base.about(t, c, w, cat, venue)),

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -16,6 +16,7 @@ import {
   renderHubPage,
   renderComunePage,
   renderDigestPage,
+  renderOtherEventsPage,
   DIGESTS,
   assignEventSlugs,
   reserveLiveSiblingSlugs,
@@ -377,6 +378,30 @@ describe('renderEventDetailPage', () => {
     expect(titleTag).not.toContain(EVENT.title);
     expect(titleTag).toContain(`${longComune} (Ticino) | Eventi`);
   });
+
+  it('keeps <title> within the 66-char cap for a non-TI canton with a long display name (regression: issue #3772 recurrence — validate-dist still failing on `eventi` after PR #3786)', () => {
+    // The old `detailCopyFor.metaTitle` substituted the real canton name
+    // into the string `eventDetailMetaTitle` had ALREADY budgeted/truncated
+    // assuming the short "Ticino"/"Tessin" placeholder — with no re-check.
+    // fr/AR ("Appenzell Rhodes-Extérieures", 28 chars vs "Tessin"'s 6) is
+    // the worst observed case, pushing the pre-fix <title> ~20 chars over
+    // budget for every event in that canton, nationwide.
+    const arEvent = { ...EVENT, id: 'guidle:ar1', canton: 'AR', comune: 'Herisau' };
+    const page = renderEventDetailPage({
+      locale: 'fr',
+      event: arEvent as never,
+      comune: 'Herisau',
+      eventSlug: slugifyEvent(arEvent),
+      sameComuneEvents: [arEvent] as never,
+      dateStamp: '2026-06-30',
+      distDir,
+      detailHref: (() => null) as never,
+    });
+    const titleTag = /<title>([^<]*)<\/title>/.exec(page.html)?.[1] ?? '';
+    expect(titleTag.length).toBeGreaterThan(0);
+    expect(titleTag.length).toBeLessThanOrEqual(66);
+    expect(titleTag).toContain('Appenzell Rhodes-Extérieures');
+  });
 });
 
 describe('router recognises per-event detail URLs (staticOverlay)', () => {
@@ -666,6 +691,64 @@ describe('renderHubPage / renderComunePage generalize to a non-TI canton (#3125 
     expect(tiPage.urlPath).toBe('/eventi/ticino/lugano/');
     expect(tiPage.html).toContain('in Ticino');
   });
+
+  it('hub-page <title> stays within the 66-char cap for a long-name canton in every locale (regression: issue #3772 recurrence — validate-dist still failing on `eventi` after PR #3786)', () => {
+    // AR ("Appenzell Rhodes-Extérieures" in fr, 28 chars) is the worst case
+    // vs. the short "Ticino"/"Tessin" (6 chars) the old code budgeted for.
+    const arEvent = { ...EVENT, id: 'guidle:ar-hub', canton: 'AR', comune: 'Herisau' };
+    const arByComune = new Map([['Herisau', [arEvent]]]);
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const page = renderHubPage({
+        locale,
+        canton: 'AR',
+        events: [arEvent] as never,
+        byComune: arByComune as never,
+        dateStamp: '2026-06-30',
+        weekendDays: new Set(),
+        distDir,
+      });
+      const titleTag = /<title>([^<]*)<\/title>/.exec(page.html)?.[1] ?? '';
+      expect(titleTag.length).toBeGreaterThan(0);
+      expect(titleTag.length).toBeLessThanOrEqual(66);
+    }
+  });
+});
+
+describe('digest-page <title> budget for a long-name canton (regression: issue #3772 recurrence)', () => {
+  const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-digest-title-'));
+  // Saturday 2026-07-04 falls inside both the weekend window and the
+  // this-week window when todayIso is 2026-07-01 (Wednesday).
+  const arEvent = { ...EVENT, id: 'guidle:ar-digest', canton: 'AR', comune: 'Herisau', startDate: '2026-07-04' };
+  const weekendDef = DIGESTS.find((d) => d.key === 'weekend')!;
+  const weekDef = DIGESTS.find((d) => d.key === 'week')!;
+
+  it('keeps both the weekend and this-week digest <title> within the 66-char cap, distinct from each other, for every locale', () => {
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const weekendPage = renderDigestPage({
+        def: weekendDef,
+        locale,
+        canton: 'AR',
+        events: [arEvent] as never,
+        dateStamp: '2026-07-01',
+        distDir,
+      });
+      const weekPage = renderDigestPage({
+        def: weekDef,
+        locale,
+        canton: 'AR',
+        events: [arEvent] as never,
+        dateStamp: '2026-07-01',
+        distDir,
+      });
+      const weekendTitle = /<title>([^<]*)<\/title>/.exec(weekendPage.html)?.[1] ?? '';
+      const weekTitle = /<title>([^<]*)<\/title>/.exec(weekPage.html)?.[1] ?? '';
+      expect(weekendTitle.length).toBeGreaterThan(0);
+      expect(weekendTitle.length).toBeLessThanOrEqual(66);
+      expect(weekTitle.length).toBeGreaterThan(0);
+      expect(weekTitle.length).toBeLessThanOrEqual(66);
+      expect(weekendTitle).not.toBe(weekTitle);
+    }
+  });
 });
 
 // #3141 item 2: the tio-agenda MVP source never crawls a real per-event
@@ -877,5 +960,27 @@ describe('reserveLiveSiblingSlugs (issue #3715 — reviewer-found collision)', (
     const pastSlugs = assignEventSlugs([pastEvent] as never, reserved);
     // Must land on a third slug — neither live sibling's real URL is reused.
     expect(pastSlugs.get('tio-agenda:700')).toBe('mercato-di-natale-2026-12-05-3');
+  });
+});
+
+describe('other-events-page <title> budget for a long-name canton (regression: issue #3772 recurrence)', () => {
+  it('keeps <title> within the 66-char cap for a long-name canton in every locale', () => {
+    const distDir = mkdtempSync(path.join(os.tmpdir(), 'events-other-title-'));
+    // de/AR ("Appenzell Ausserrhoden") was the confirmed overflow instance
+    // (67 chars) for otherEventsCopyFor.metaTitle before this fix.
+    const arEvent = { ...EVENT, id: 'guidle:ar-other', canton: 'AR', comune: 'Herisau' };
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const page = renderOtherEventsPage({
+        locale,
+        canton: 'AR',
+        events: [arEvent] as never,
+        dateStamp: '2026-06-30',
+        weekendDays: new Set(),
+        distDir,
+      });
+      const titleTag = /<title>([^<]*)<\/title>/.exec(page.html)?.[1] ?? '';
+      expect(titleTag.length).toBeGreaterThan(0);
+      expect(titleTag.length).toBeLessThanOrEqual(66);
+    }
   });
 });


### PR DESCRIPTION
## Implementato

- Root-caused why `validate-dist` kept failing on the `eventi` feature's title-length audit after PR #3786 (which fixed a different, escape-awareness bug in the same gate but never touched this code path).
- Real root cause: four functions in `build-plugins/eventsSeoPagesPlugin.ts` share the same anti-pattern — a `<title>` string is budgeted/truncated to fit `TITLE_MAX_CHARS` (66 chars) assuming the SHORT canton placeholder ("Ticino"/"Tessin", 6 chars), and only afterward a regex-based canton-name substitution swaps in the REAL canton's display name — up to 28 chars for cantons like Appenzell Ausserrhoden/Innerrhoden in French ("Appenzell Rhodes-Extérieures") — with no re-verification of the resulting length. This silently overflows the 66-char cap for every event/digest/hub page in the affected cantons, nationwide.
- Fixed all four sibling occurrences of the same construct (Non-Negotiable #6 — whole class, same PR):
  - `copyFor.hubTitle`
  - `digestCopyFor.title` (both weekend and week digests)
  - `otherEventsCopyFor.metaTitle`
  - `detailCopyFor.metaTitle` (the dominant contributor — one event-detail page per crawled event, thousands nationwide)
- Fix pattern: the 3 static-literal titles now go through `composePlaceTitle([longSubstitutedCandidate, shortVerifiedFallback], TITLE_MAX_CHARS, escLen)` (existing, already-imported utility). The dynamically-budgeted detail-page title is restructured so the canton substitution happens on the suffix TEMPLATE first, then the existing escape/budget-aware truncation loop (`eventDetailMetaTitle`) re-runs fresh against the correctly-substituted suffix — guaranteeing the final title is always ≤66 chars by construction, not by chance.
- Added regression tests in `tests/events-detail-pages.test.ts` using canton `AR` (Appenzell Ausserrhoden, worst-case long display name) across all four render entry points (`renderEventDetailPage`, `renderHubPage`, `renderDigestPage`, `renderOtherEventsPage`) and all four locales. Verified each new test FAILS against the pre-fix code (79/72/67 chars, confirmed via `git stash` on just the plugin file) and PASSES after the fix.
- Verified via GitNexus impact analysis that all four functions are LOW/MEDIUM risk, contained entirely within this SSG build-plugin's own render functions — no cross-module blast radius.
- Ran `scripts/ci/check-sibling-patterns.mjs` and manually audited all 17 flagged candidate files for the same construct (shared tokens `TITLE_MAX_CHARS`/`hubTitle`/`composePlaceTitle`/`cantonDisplayLabel`/`eventDetailMetaTitle`) — confirmed 0 of the 17 contain the actual antipattern (either they already substitute-then-budget in the correct order, or they never perform canton/location substitution into a `<title>` at all). One footnote below is a genuinely different, non-blocking observation, not a deferred fix.
- Closes #3772

## Non implementato (ancora)

Nessuno. Lo scope di questa PR (il bug class del canton-substitution-after-budget in `eventsSeoPagesPlugin.ts`) è interamente implementato e coperto da test in questa PR.

Unico footnote non-bloccante emerso dall'audit sibling-pattern (non fa parte di questa classe di bug, dichiarato qui per trasparenza, non come scope deferito): `build-plugins/seoHubsPlugin.ts:1642` costruisce il `<title>` dell'hub per-cantone per concatenazione diretta, senza alcun budget-check su `TITLE_MAX_CHARS` — ma usa una propria `cantonDisplayLabel` locale derivata da slug URL bounded (`data/canton-url-slugs.json`, bucket "APPENZELLO" già accorpato, max ~12 char), quindi il caso peggiore calcolato è ~46 char, ben sotto il cap: non riproducibile con i dati correnti, non è lo stesso costrutto (nessun placeholder-poi-sostituzione), quindi è un **falso positivo** rispetto alla classe di bug fixata qui — non un item aperto.

## Test plan

- [x] `npx vitest run tests/events-detail-pages.test.ts tests/events-digest.test.ts tests/events-pipeline.test.ts` — 119/119 passed
- [x] New regression tests confirmed to fail against pre-fix code (79/72/67 chars) via `git stash` isolation, and pass after the fix
- [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated errors in other test files confirmed via grep to not reference `eventsSeoPagesPlugin`)
- [ ] Post-merge: confirm via a subsequent `validate-dist` CI run that the `eventi` feature's title-length offender count has genuinely dropped (will verify live after merge + next deploy, per standing instruction not to declare this resolved until confirmed with real data)