### PR TITLE
fix: Event structured data — organizer.name missing for ge-agenda events

### DIFF
--- a/scripts/lib/agenda-crawler-factory.mjs
+++ b/scripts/lib/agenda-crawler-factory.mjs
@@ -199,7 +199,10 @@ export function createAgendaCrawler(config) {
               existing.endDate = ev.startDate;
             }
           } else {
-            byId.set(ev.id, { ...ev, crawledAt });
+            // Per-event stamp, not just slice-level metadata below — eventLd()'s
+            // `organizer.name` reads `event.sourceName` directly (GSC "missing
+            // name in organizer" for every ge-agenda event before this fix).
+            byId.set(ev.id, { ...ev, sourceKey: source.key, sourceName: source.label, crawledAt });
           }
         }
       } else if (stopOnEmptyPage && byId.size > 0) {

--- a/tests/agenda-crawler-factory.test.ts
+++ b/tests/agenda-crawler-factory.test.ts
@@ -75,6 +75,15 @@ describe('createAgendaCrawler — crawl()', () => {
     expect(byId['src:evt-1'].endDate).toBe('2026-08-03'); // extended across iterations 0,1,2
     expect(byId['src:evt-2'].endDate).toBeUndefined(); // seen once — no extension
 
+    // Per-event sourceKey/sourceName — eventLd()'s organizer.name reads
+    // event.sourceName directly; omitting it here (only slice-level metadata
+    // stamped) silently shipped Event JSON-LD with no organizer.name for
+    // every ge-agenda event (GSC "missing name in organizer").
+    for (const e of result.events) {
+      expect(e.sourceKey).toBe(TEST_SOURCE_KEY);
+      expect(e.sourceName).toBe('Test Agenda Factory Fixture');
+    }
+
     expect(existsSync(slicePath)).toBe(true);
     const written = JSON.parse(readFileSync(slicePath, 'utf-8'));
     expect(written).toMatchObject({ schemaVersion: 1, sourceKey: TEST_SOURCE_KEY, canton: 'ZZ' });


### PR DESCRIPTION
## Implementato

- Root-caused GSC "Campo mancante \"name\" (in \"organizer\")" on Event structured data for `veranstaltungen/genf/...` pages: `createAgendaCrawler()` (`scripts/lib/agenda-crawler-factory.mjs`) stamped `sourceKey`/`sourceName` only at the **slice level**, never onto individual events. `eventLd()` reads `organizer.name = event.sourceName` directly, so all 70 `ge-agenda` (Ville de Genève) events shipped with `organizer` present but `organizer.name` undefined.
- Fixed at the per-event merge point (`byId.set(...)`) so every event from this factory carries `sourceKey`/`sourceName`. This factory is explicitly meant to be reused by future non-TI-canton agenda sources (per its own header comment), so the fix closes the bug class, not just the current 70 events.
- Added a regression assertion in `tests/agenda-crawler-factory.test.ts` that every returned event carries `sourceKey`/`sourceName` — this would have failed before the fix.
- Verified against current `data/events.json`: all 70 `ge-agenda:*` events are missing `sourceName` today (pre-fix); the crawler's own dry-run output confirms the fix stamps both fields correctly. Fix lands in the dataset on the next scheduled `crawl-events.yml` run.

## Non implementato (ancora)

Nessuno per questo bug (organizer.name). Investigated the second GSC issue reported alongside it ("Campo mancante \"offers\"") and concluded it is **not a bug**:
- `offers` is deliberately emitted only when a confident price/free signal exists (`hasConfidentPrice`), by design documented at length in `eventsSeoPagesPlugin.ts` — asserting a price on an event with unknown/ambiguous pricing would misrepresent the page (Google treats `offers` as recommended-not-required, and `validate-structured-data-completeness.mjs` only validates it when present).
- Checked the actual data: the "Aargau/Baden" pages in that GSC report are all `myswitzerland`-sourced events. Confirmed via the `crawl-events.yml` run log (`28853844360`) that MySwitzerland detail-page fetches succeed ~40% of the time (70/176), yet price is 0/1003 across the whole accumulated `myswitzerland` dataset even so — and `extractPrice`/`extractAddress` unit tests already confirm correct parsing of the schema.org shape when present. This points to MySwitzerland's own listings genuinely lacking `offers` data most of the time (nationwide tourism aggregator, not a ticketing source), not an extraction bug on our side.
- No code change proposed for this — fabricating price data would violate the existing structured-data honesty policy and isn't something GSC requires (explicitly listed non-critical).

## Test plan
- [x] `npx vitest run tests/agenda-crawler-factory.test.ts tests/crawl-ge-agenda.test.ts tests/events-pipeline.test.ts tests/events-detail-pages.test.ts` — 142 tests pass, including new regression assertion.
- [ ] Verify live after next `crawl-events.yml` run + deploy: re-pull GSC Event structured data report, confirm `organizer.name` no longer flagged for `veranstaltungen/genf/*` pages.