### PR TITLE
fix: crawler-health monitor tracks crawlers with no active-jobs shard (#3797)

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -301,18 +301,32 @@ async function readJsonSafe(filePath) {
   }
 }
 
-/** List `*.json` files in by-crawler dir, return slugs. */
-async function listCrawlerSlugs() {
+/** List `*.json` slugs in a dir (best-effort; empty array on read failure). */
+async function listJsonSlugs(dir) {
   try {
-    const entries = await fs.readdir(BY_CRAWLER_DIR);
+    const entries = await fs.readdir(dir);
     return entries
       .filter((name) => name.endsWith('.json'))
-      .map((name) => name.replace(/\.json$/, ''))
-      .sort();
+      .map((name) => name.replace(/\.json$/, ''));
   } catch (err) {
-    console.error(`[health] Cannot read ${BY_CRAWLER_DIR}: ${err.message}`);
+    console.error(`[health] Cannot read ${dir}: ${err.message}`);
     return [];
   }
+}
+
+/**
+ * List all known crawler slugs: union of `data/jobs/by-crawler/*.json` and
+ * `data/jobs-crawler-summaries/by-crawler/*.json`. A crawler that has never
+ * produced an active-jobs shard (e.g. `earlyExit: true` on every run) only
+ * ever writes the summary slice — reading BY_CRAWLER_DIR alone made those
+ * crawlers permanently invisible to this monitor (issue #3797).
+ */
+async function listCrawlerSlugs() {
+  const [byCrawler, summaries] = await Promise.all([
+    listJsonSlugs(BY_CRAWLER_DIR),
+    listJsonSlugs(SUMMARIES_DIR),
+  ]);
+  return [...new Set([...byCrawler, ...summaries])].sort();
 }
 
 /**
@@ -322,9 +336,10 @@ async function listCrawlerSlugs() {
  *   - `data/jobs/by-crawler/{slug}.json`            → activeJobCount + fallback timestamp
  *   - `data/jobs-crawler-summaries/by-crawler/{slug}.json` → primary timestamp
  *
- * Returns null if the by-crawler slice cannot be read/parsed (caller logs +
- * skips). The summary slice is optional — when missing we fall back to
- * `assembledAt`.
+ * The by-crawler slice is optional — a crawler that has never produced an
+ * active-jobs shard (e.g. every run exits early with `earlyExit: true`,
+ * issue #3797) is tracked via the summary slice alone instead of being
+ * skipped. `activeJobCount` and `assembledAt` degrade to 0/null in that case.
  *
  * Returns `{ slug, freshnessAt, freshnessSource, assembledAt, generatedAt,
  * jobCount, activeJobCount }`:
@@ -336,8 +351,7 @@ async function inspectCrawler(slug) {
   const sliceFilePath = path.join(BY_CRAWLER_DIR, `${slug}.json`);
   const data = await readJsonSafe(sliceFilePath);
   if (data === null) {
-    console.warn(`[health] ${slug}: cannot read/parse slice; skipping`);
-    return null;
+    console.warn(`[health] ${slug}: no active-jobs shard (never produced or unparseable) — tracking via summary only`);
   }
 
   // Tolerate any shape: array of jobs OR { jobs: [...] } OR { entries: [...] }.
@@ -585,7 +599,7 @@ async function main() {
 }
 
 // Exported for tests. `main()` only runs when the script is invoked directly.
-export { nextCrawlerState, inspectCrawler };
+export { nextCrawlerState, inspectCrawler, listCrawlerSlugs };
 
 const isMain = (() => {
   try {

--- a/tests/scripts/check-crawler-health-discovery.test.ts
+++ b/tests/scripts/check-crawler-health-discovery.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+/**
+ * Coverage for the crawler-discovery gap fixed in issue #3797:
+ * `listCrawlerSlugs()` used to read only `data/jobs/by-crawler/*.json`, and
+ * `inspectCrawler()` returned null (causing the caller to skip the crawler
+ * entirely) whenever that shard file was missing. A crawler that only ever
+ * writes the summary slice (`data/jobs-crawler-summaries/by-crawler/*.json`
+ * — e.g. every run exits early with `earlyExit: true`, never producing an
+ * active-jobs shard) was therefore invisible to the health monitor even
+ * though the "safety net" is exactly meant to catch persistent failures
+ * like this.
+ *
+ * `node:fs`'s `promises.readdir`/`readFile`/`stat` are mocked so the tests
+ * don't depend on real repo data (same technique as
+ * tests/error-issue-sync.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const readdir = vi.fn();
+const readFile = vi.fn();
+const stat = vi.fn();
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readdir: (...args: unknown[]) => readdir(...args),
+      readFile: (...args: unknown[]) => readFile(...args),
+      stat: (...args: unknown[]) => stat(...args),
+    },
+  };
+});
+
+const { listCrawlerSlugs, inspectCrawler } = await import(
+  '../../scripts/check-crawler-health.mjs'
+);
+
+function enoent() {
+  return Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+}
+
+const isSummaryDir = (dir: unknown) =>
+  String(dir).includes('jobs-crawler-summaries');
+const isByCrawlerDir = (dir: unknown) =>
+  String(dir).includes('by-crawler') && !isSummaryDir(dir);
+
+beforeEach(() => {
+  readdir.mockReset();
+  readFile.mockReset();
+  stat.mockReset();
+});
+
+describe('listCrawlerSlugs', () => {
+  it('discovers a slug that only exists in the summaries dir, not by-crawler', async () => {
+    readdir.mockImplementation(async (dir: string) => {
+      if (isSummaryDir(dir)) return ['omega.json', 'gavi.json'];
+      if (isByCrawlerDir(dir)) return ['gavi.json'];
+      throw enoent();
+    });
+
+    const slugs = await listCrawlerSlugs();
+
+    // 'omega' never produced a by-crawler shard, but IS discovered via the
+    // summaries dir. 'gavi' exists in both and is deduped, not doubled.
+    expect(slugs).toContain('omega');
+    expect(slugs.filter((s: string) => s === 'gavi')).toHaveLength(1);
+  });
+
+  it('still works when the by-crawler dir cannot be read at all', async () => {
+    readdir.mockImplementation(async (dir: string) => {
+      if (isSummaryDir(dir)) return ['omega.json'];
+      throw enoent();
+    });
+
+    const slugs = await listCrawlerSlugs();
+    expect(slugs).toEqual(['omega']);
+  });
+});
+
+describe('inspectCrawler', () => {
+  it('tracks a crawler via the summary alone when the by-crawler shard was never written', async () => {
+    readFile.mockImplementation(async (file: string) => {
+      if (isSummaryDir(file)) {
+        return JSON.stringify({
+          generatedAt: '2026-07-08T04:00:00.000Z',
+          total: 0,
+          earlyExit: true,
+          exitCode: 0,
+        });
+      }
+      throw enoent(); // by-crawler shard: never produced
+    });
+    stat.mockRejectedValue(enoent());
+
+    const observation = await inspectCrawler('omega');
+
+    // Before the fix this returned null and the caller skipped the crawler
+    // entirely (`if (!observation) continue;`).
+    expect(observation).not.toBeNull();
+    expect(observation.slug).toBe('omega');
+    expect(observation.freshnessSource).toBe('summary');
+    expect(observation.freshnessAt).toBe('2026-07-08T04:00:00.000Z');
+    expect(observation.jobCount).toBe(0);
+    expect(observation.activeJobCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Implementato

- `scripts/check-crawler-health.mjs`: `listCrawlerSlugs()` now unions `data/jobs/by-crawler/*.json` with `data/jobs-crawler-summaries/by-crawler/*.json` (new `listJsonSlugs()` helper) instead of reading only the former.
- `inspectCrawler(slug)` no longer bails/returns null when the by-crawler shard file is missing — it warns and falls through to summary-only tracking (the rest of the function was already null-safe for a missing shard; only the early `return null` blocked it).
- Root cause (issue #3797): 52 companies (44 post-#3701 silent-exit crawlers + 8 orphaned/stale ones) never write `data/jobs/by-crawler/{slug}.json`, so the monitor's discovery step never saw them at all — invisible to the one safety net meant to catch exactly this (per-run alerting deliberately exits 0 on connection-level errors by design, per `exitCrawlerOnError`'s doc comment — left unchanged, only the monitor's blind spot was a bug).
- Regression test: `tests/scripts/check-crawler-health-discovery.test.ts` (mocks `node:fs`, same technique as `tests/error-issue-sync.test.ts`) — covers `listCrawlerSlugs()` discovering a summary-only slug without duplicating shard+summary slugs, and `inspectCrawler()` returning a valid observation (not null) when only the summary exists.
- Verified locally: ran `node scripts/check-crawler-health.mjs` in the worktree — all 44+8 previously-invisible slugs now log `tracking via summary only` and are correctly evaluated (8 orphaned flagged stale, `has-healthcare` flagged broken; the 44 fresh post-#3701 failures aren't old/frequent enough yet to cross the 3-empty-run/7-day thresholds — expected, not a gap). Reverted the resulting `data/crawler-health.json` mutation + deleted the generated `data/crawler-health-issues.json` before committing (data-only side effect of a manual verification run, not part of this fix).
- Sibling check (AGENTS.md #6): grepped repo-wide for `readdir(BY_CRAWLER_DIR)`-style crawler-roster discovery — `check-crawler-health.mjs` is the only script that builds a crawler roster this way; no other sibling shares the bug class.

## Non implementato (ancora)

Nessuno — questa PR chiude interamente lo scope del fix di visibilità (Parte A di #3797). La Parte B (verifica browser reale dei 58 crawler coinvolti) è un lavoro distinto in corso separatamente sulla stessa issue, non bloccato da questa PR.