### PR TITLE
fix(article-gen): resolve site-relative source URLs before fetch

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3572,9 +3572,15 @@ async function fetchPageContent(url) {
     console.error(`📚 Articolo evergreen: "${keyword}"`);
     return `[ARTICOLO EVERGREEN SEO]\nKeyword target: ${keyword}\nAngolo editoriale: ${angle}\n\nGenera un articolo approfondito e pratico ottimizzato per questa keyword long-tail. Usa solo fatti verificati e stabili sul dominio frontalieri Ticino-Italia. Se servono esempi, presentali come scenari ipotetici, senza nomi, aziende, città o importi specifici inventati.\n\n${EVERGREEN_FACTS_BRIEF}\n\n⚠️ I FATTI VERIFICATI qui sopra DEVONO corrispondere ESATTAMENTE (lo stesso ground truth è usato dal fact-checker, che blocca l'articolo se diverghi). Per dettagli NON coperti, attieniti a nozioni stabili e generali del dominio; se un dato specifico non è certo, ometti o usa formulazioni qualitative invece di inventare cifre/date precise.`;
   }
-  console.error(`📰 Fetching: ${url}`);
+  // Orphan-query candidates carry a site-relative path (GSC topLandingPage
+  // is stored path-only by design, see gscFetcher.mjs:231) — fetch() has no
+  // implicit base URL and throws "Failed to parse URL from /..." on these,
+  // silently degrading to a sourceless generation. Resolve against the
+  // canonical domain before fetching.
+  const absoluteUrl = url.startsWith('/') ? `${BASE_URL}${url}` : url;
+  console.error(`📰 Fetching: ${absoluteUrl}`);
   try {
-    const res = await fetch(url, {
+    const res = await fetch(absoluteUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
         'Accept': 'text/html,application/xhtml+xml',


### PR DESCRIPTION
## Implementato

- `fetchPageContent` (create-article.mjs): quando l'URL candidato inizia con `/` (site-relative — è così che `gscFetcher.mjs:231` immagazzina `topLandingPage` per i candidati orphan-query, by design, path-only), lo risolve contro `BASE_URL` (`https://frontaliereticino.ch`) prima del `fetch()`. Prima: `fetch('/guida-frontaliere/...')` throwava `Failed to parse URL from /...` (Node non ha base URL implicito), silenziosamente degradando a sorgente 0-char.
- Verificato live sul run 28921831888 (job 85800553822, 2026-07-08): l'unico bug di questa classe scattato in tutto il run, sull'unica headline candidata (`chiasso-strada` — pagina reale, 200 OK verificato via curl). La sorgente 0-char ha fatto scattare `computeAdaptiveMinWords` (floor 400, intenzionale, non toccato) → il modello ha inventato fatti (leggi/istituzioni inesistenti: "LProtInfo del 2023", "INSAI") → fact-check bloccato 2× → 3 round di rigenerazione via local/fallback (ollama, ~15min/round) → wall-clock esaurito → 0 articoli pubblicati nonostante ~50min di run.

## Non implementato (ancora)

Nessuno per lo scope di questa PR (fix isolato, singolo call-site, sibling-check completato — vedi sotto). Le altre findings analizzate nella stessa investigazione **non richiedono fix di codice** (verificato, non deferito):

- **Headline/URL dedup senza time-decay** (`isSourceUrlAlreadyUsed`, `preFlightHeadlineCheck`, `checkForDuplicates`): confermato construct condiviso da 3 funzioni sibling, ma è policy editoriale deliberata (mai ripubblicare stesso topic/URL, a prescindere dall'età, per evitare contenuto duplicato/cannibalizzante su pagine ancora live) — non un bug. `checkForDuplicates` documenta un tuning incidente-driven recente (2026-07-01, #3138 follow-up) sulla stessa soglia, confermando manutenzione attiva e deliberata. Allentarla è decisione editoriale, non un fix silenzioso — richiede OK esplicito prima di toccarla.
- **Google News RSS non risolto** (225/226 candidati in run 28921831888): verificato empiricamente — Google News non fa redirect HTTP (risposta 200, stessa URL), la destinazione reale richiede decodifica di un endpoint interno non documentato (`batchexecute`). Un fix "segui redirect" sarebbe morto in partenza. Fix reale = reverse-engineering di API non documentata: fragile, rischio che Google la cambi, effort non banale — decisione da prendere esplicitamente prima di investirci, non incluso qui.
- **`computeAdaptiveMinWords`**: safeguard intenzionale anti-hallucination (incidente #2947), non un bug.
- **nvidia 8000-token-limit skip**: comportamento benigno del cascade — prova il prossimo modello, non un blocker.

## Nota per il diagnostic più ampio (model-availability)

Il log del run conferma il sospetto originale: al minuto 5 del run (06:25 UTC) decine di modelli free (openrouter/nvidia) erano già "exhausted (daily limit)" — quota giornaliera già bruciata da run precedenti dello stesso giorno. Questo forza fallback locale (ollama, ~15min/tentativo) ripetuto, che con 3 round di rigenerazione fact-check-driven consuma l'intero wall-clock del job. Non incluso in questa PR (scope diverso, decisione su cadenza self-trigger/retry-budget da discutere separatamente).