### PR TITLE
fix(article-gen): always produce an article per run; Haiku CLI last-resort fallback

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -99,6 +99,19 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── Claude CLI Haiku fallback (opt-in via RC ENABLE_HAIKU_ARTICLE_FALLBACK) ──
+      # Absolute last resort, reached only after every free-tier model AND the
+      # local/ollama fallback above have failed (scripts/lib/ai-models.mjs
+      # AI_MODELS.CLAUDE_CLI_HAIKU, pinned below local/* by sortChainByScore).
+      # Zero marginal cost: auth is CLAUDE_CODE_OAUTH_TOKEN (same Max-plan
+      # subscription token already used by pr-review-loop.yml/issue-fix.yml),
+      # never ANTHROPIC_API_KEY. Inert unless the RC flag is on: with it unset,
+      # getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns '' and the model is
+      # never offered — identical to today.
+      - name: Setup Claude CLI Haiku fallback
+        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK == '1'
+        run: npm install -g @anthropic-ai/claude-code
+
       # Primary identity for the self-trigger dispatch below = GitHub App
       # installation token (`frontaliere-automation[bot]`): auto-mints, no expiry
       # babysit, and its dispatch re-triggers the next run just like the PAT (no
@@ -238,6 +251,13 @@ jobs:
           # the deadlineMs abort and keeps local fallback available (it still
           # fires when reached) without the runaway ceiling.
           CREATE_ARTICLE_MAX_WALL_MS: ${{ steps.section.outputs.section == 'svizzera' && '1800000' || '3300000' }}
+          # Auth for the opt-in Claude CLI Haiku last-resort fallback (see
+          # "Setup Claude CLI Haiku fallback" step above). Same secret already
+          # used by pr-review-loop.yml/issue-fix.yml — zero marginal cost
+          # (Max-plan subscription), never ANTHROPIC_API_KEY. Harmless to
+          # always pass: ai-models.mjs only offers the model when this AND the
+          # RC flag are both set (isClaudeCliFallbackEnabled/hasClaudeCodeOauthToken).
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           echo "📰 Generating blog article (section=$TARGET_SECTION)..."
           if [ -n "${{ inputs.url }}" ]; then

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -8070,6 +8070,23 @@ let _localFallbackUsedThisHeadline = false;
 const LOCAL_MIN_VIABLE_MS = 11 * 60_000;
 
 /**
+ * Minimum wall-clock remaining (ms) to justify starting a brand-new attempt
+ * at ALL — any provider, not just local/fallback. Distinct from
+ * LOCAL_MIN_VIABLE_MS above, which reserves time specifically for local's
+ * slow ~12-17min CPU inference. A new attempt's cascade tries ~70 free-tier
+ * cloud models before ever reaching local, and a successful cloud call
+ * typically completes in seconds — gating "start a new attempt" on local's
+ * much larger reserve wasted every cloud-model chance in a run's last
+ * minutes (root cause of runs producing zero articles: this fired below
+ * 11min remaining even though a cloud model would easily fit). callLLM's own
+ * deadlineMs check (ai-models.mjs) already bounds an in-flight attempt to
+ * roughly one call's timeout past this floor, so lowering it doesn't risk an
+ * unbounded overrun — it only stops starting a candidate with no realistic
+ * time left for even one call.
+ */
+const MIN_VIABLE_ATTEMPT_MS = 2 * 60_000;
+
+/**
  * True when the error is a CONTENT/QUALITY rejection (fact-check block,
  * topic-gate REGOLA #0 abort, fabrication, or a non-conformant headline that
  * survived its retry budget) rather than an infrastructure bug.
@@ -8333,24 +8350,21 @@ async function main() {
             console.error(`⏱️  Budget wall-clock (${Math.round(RUN_WALL_BUDGET_MS / 60000)}min) superato — interrompo i tentativi ${pool.name}; l'articolo è deferito al prossimo run.`);
             break;
           }
-          // Cross-headline local-fallback reserve (2026-07-07, incident run
-          // 28850309199): LOCAL_MIN_VIABLE_MS below already guards a SECOND
-          // local/fallback attempt on the SAME headline, but does nothing for
-          // the FIRST attempt on a BRAND NEW headline picked with the run's
-          // dying minutes. That run burned ~50min on 4 semantic-dedup rejects
-          // (each paying the full generation+fact-check cost before the dedup
-          // check even runs), leaving ~7min for candidate 5 — whose cloud
-          // cascade exhausted (~5min) before falling to local with ~2.3min
-          // left, truncated mid-inference by _callLocal's own deadline cap.
-          // Zero output, wasted GH Actions minutes. Stop picking NEW
-          // candidates below this same floor instead; an in-flight generation
-          // (started before the floor was crossed) still runs to completion
-          // untouched — same clean-deferral disposition as the guard below.
+          // Cross-headline minimum-viable-attempt reserve (2026-07-07, incident
+          // run 28850309199; floor lowered 2026-07-08 — see MIN_VIABLE_ATTEMPT_MS
+          // above). Stop picking NEW candidates once there's no realistic time
+          // left for even one cascade call; an in-flight generation (started
+          // before the floor was crossed) still runs to completion untouched —
+          // same clean-deferral disposition as the guard below. Deliberately NOT
+          // gated on local/fallback's much larger reserve (LOCAL_MIN_VIABLE_MS):
+          // the cascade tries ~70 fast cloud models before ever reaching local,
+          // so reserving 11min here was killing real cloud-model chances in a
+          // run's last minutes — the actual root cause of zero-article runs.
           {
             const remainingForNewAttemptMs = RUN_WALL_BUDGET_MS - (Date.now() - RUN_START_MS);
-            if (remainingForNewAttemptMs < LOCAL_MIN_VIABLE_MS) {
-              console.error(`⏱️  Restano ${Math.round(remainingForNewAttemptMs / 60_000)}min (< ${LOCAL_MIN_VIABLE_MS / 60_000}min necessari per un eventuale fallback locale) — interrompo i tentativi ${pool.name} invece di avviare un candidato che rischia di non completare; l'articolo è deferito al prossimo run.`);
-              RUN_REPORT.notes.push(`Retry loop stopped early: cross-headline local-fallback reserve (pool=${pool.name}, attempt=${attempt}, remainingMin=${Math.round(remainingForNewAttemptMs / 60_000)})`);
+            if (remainingForNewAttemptMs < MIN_VIABLE_ATTEMPT_MS) {
+              console.error(`⏱️  Restano ${Math.round(remainingForNewAttemptMs / 60_000)}min (< ${MIN_VIABLE_ATTEMPT_MS / 60_000}min necessari per un nuovo tentativo) — interrompo i tentativi ${pool.name} invece di avviare un candidato che rischia di non completare; l'articolo è deferito al prossimo run.`);
+              RUN_REPORT.notes.push(`Retry loop stopped early: cross-headline minimum-viable-attempt reserve (pool=${pool.name}, attempt=${attempt}, remainingMin=${Math.round(remainingForNewAttemptMs / 60_000)})`);
               break;
             }
           }
@@ -8709,16 +8723,17 @@ async function main() {
           console.error(`⏱️  Budget wall-clock (${Math.round(RUN_WALL_BUDGET_MS / 60000)}min) superato — interrompo i tentativi evergreen; l'articolo è deferito al prossimo run.`);
           break;
         }
-        // Cross-headline local-fallback reserve: same guard as the news-pool
-        // loop (~L8273). Without it, a new evergreen keyword attempt can start
-        // in the run's dying minutes, exhaust the cloud cascade, and leave the
-        // local LLM with too little time to finish — the exact failure mode of
-        // incident run 28850309199, reached precisely when the news-pool fails.
+        // Cross-headline minimum-viable-attempt reserve: same guard as the
+        // news-pool loop (~L8360; see MIN_VIABLE_ATTEMPT_MS for the 2026-07-08
+        // rationale). Deliberately NOT gated on local/fallback's much larger
+        // reserve (LOCAL_MIN_VIABLE_MS) — the cascade tries ~70 fast cloud
+        // models before ever reaching local, so this only stops picking a new
+        // candidate once there's no realistic time left for even one call.
         {
           const remainingForNewAttemptMs = RUN_WALL_BUDGET_MS - (Date.now() - RUN_START_MS);
-          if (remainingForNewAttemptMs < LOCAL_MIN_VIABLE_MS) {
-            console.error(`⏱️  Restano ${Math.round(remainingForNewAttemptMs / 60_000)}min (< ${LOCAL_MIN_VIABLE_MS / 60_000}min necessari per un eventuale fallback locale) — interrompo i tentativi evergreen invece di avviare un candidato che rischia di non completare; l'articolo è deferito al prossimo run.`);
-            RUN_REPORT.notes.push(`Retry loop stopped early: cross-headline local-fallback reserve (pool=evergreen, attempt=${attempt}, remainingMin=${Math.round(remainingForNewAttemptMs / 60_000)})`);
+          if (remainingForNewAttemptMs < MIN_VIABLE_ATTEMPT_MS) {
+            console.error(`⏱️  Restano ${Math.round(remainingForNewAttemptMs / 60_000)}min (< ${MIN_VIABLE_ATTEMPT_MS / 60_000}min necessari per un nuovo tentativo) — interrompo i tentativi evergreen invece di avviare un candidato che rischia di non completare; l'articolo è deferito al prossimo run.`);
+            RUN_REPORT.notes.push(`Retry loop stopped early: cross-headline minimum-viable-attempt reserve (pool=evergreen, attempt=${attempt}, remainingMin=${Math.round(remainingForNewAttemptMs / 60_000)})`);
             break;
           }
         }

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -3137,9 +3137,17 @@ async function _callLocal(model, messages, opts) {
  * last resort — reuses CLAUDE_CODE_OAUTH_TOKEN, same zero-cost Max-plan auth
  * already wired for pr-review-loop.yml/issue-fix.yml, never a raw
  * ANTHROPIC_API_KEY). `--bare` deliberately NOT used: it requires
- * ANTHROPIC_API_KEY/apiKeyHelper and ignores OAuth. `--allowedTools ""` +
- * `--permission-mode bypassPermissions` force plain one-shot text/schema
- * completion, no tool access, no agentic session.
+ * ANTHROPIC_API_KEY/apiKeyHelper and ignores OAuth. Tool access is disabled
+ * via `--tools ""` (per `claude --help`: "Use \"\" to disable all tools") —
+ * NOT `--allowedTools`/`--disallowedTools`, which only gate the permission
+ * *prompt* for tools that remain available and don't remove them from the
+ * built-in set. `--permission-mode bypassPermissions` is kept alongside so
+ * the (now empty) tool set never blocks on an interactive prompt in CI; with
+ * zero tools available it has nothing else to bypass. This subprocess
+ * processes externally-sourced headline/news content and inherits the full
+ * CI env (`env: process.env` below, incl. secrets) — `--tools ""` is the
+ * flag that actually matters for keeping this a plain one-shot completion
+ * with no agentic/tool-call capability, regardless of permission mode.
  */
 async function _callClaudeCli(model, messages, opts) {
   const apiModel = getApiModelId(model); // e.g. 'claude-haiku-4-5-20251001'
@@ -3150,7 +3158,7 @@ async function _callClaudeCli(model, messages, opts) {
     '-p', userPrompt,
     '--model', apiModel,
     '--output-format', 'json',
-    '--allowedTools', '',
+    '--tools', '',
     '--permission-mode', 'bypassPermissions',
   ];
   if (systemPrompt) args.push('--system-prompt', systemPrompt);

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -342,6 +342,15 @@ export const AI_MODELS = Object.freeze({
   // the bottom of every chain by sortChainByScore so it never displaces a working
   // remote API — it only runs when all remote providers are exhausted.
   LOCAL_FALLBACK:      'local/fallback',
+
+  // ── Claude CLI Haiku fallback (opt-in via Remote Config, absolute last
+  // resort) ── Routed through the local `claude` CLI subprocess using the
+  // existing CLAUDE_CODE_OAUTH_TOKEN (Max subscription — $0 marginal cost,
+  // same auth already used by pr-review-loop.yml/issue-fix.yml). Inert unless
+  // ENABLE_HAIKU_ARTICLE_FALLBACK is set (see load-rc-env.mjs) AND the token
+  // is present. Pinned even below LOCAL_FALLBACK by sortChainByScore — only
+  // reached when every free-tier cloud model AND local/fallback have failed.
+  CLAUDE_CLI_HAIKU:    'claude-cli/claude-haiku-4-5-20251001',
 });
 
 /**
@@ -570,6 +579,12 @@ export const DEFAULT_CHAIN = [
   // and skipped entirely unless LOCAL_LLM_ENABLED — so when every remote provider
   // above is daily-exhausted, generation still produces instead of deferring.
   AI_MODELS.LOCAL_FALLBACK,
+
+  // Absolute last resort. Always sorted below LOCAL_FALLBACK (sortChainByScore)
+  // and skipped unless ENABLE_HAIKU_ARTICLE_FALLBACK (RC) + CLAUDE_CODE_OAUTH_TOKEN
+  // are both present — so a run only ever reaches it once every free-tier cloud
+  // model AND the local CPU fallback have already failed.
+  AI_MODELS.CLAUDE_CLI_HAIKU,
 ];
 
 // ── Provider constants ───────────────────────────────────────
@@ -596,6 +611,9 @@ const PROVIDER = Object.freeze({
   // would otherwise produce 0 articles for that window. A local open-source model
   // (e.g. Qwen2.5) keeps the funnel producing at $0/zero-quota. See _callLocal.
   LOCAL:       'local',
+  // Claude CLI subprocess (Haiku), opt-in via Remote Config, absolute last
+  // resort below LOCAL. See AI_MODELS.CLAUDE_CLI_HAIKU / _callClaudeCli.
+  CLAUDE_CLI:  'claude_cli',
 });
 
 // ── Endpoints ────────────────────────────────────────────────
@@ -639,6 +657,19 @@ function getLocalLlmTimeoutMs() {
   const v = parseInt((process.env.LOCAL_LLM_TIMEOUT_MS || '').trim(), 10);
   return Number.isFinite(v) && v > 0 ? v : 1_500_000; // 25 min default — see comment above
 }
+
+// ── Claude CLI Haiku fallback (opt-in via RC, absolute last resort) ──
+// ENABLE_HAIKU_ARTICLE_FALLBACK is loaded from Firebase Remote Config by
+// load-rc-env.mjs (default unset → OFF). Gated on BOTH the flag and the OAuth
+// token so a flag flipped on without the workflow secret wired doesn't attempt
+// (and fail) every run.
+function isClaudeCliFallbackEnabled() {
+  return /^(1|true|yes|on)$/i.test((process.env.ENABLE_HAIKU_ARTICLE_FALLBACK || '').trim());
+}
+function hasClaudeCodeOauthToken() {
+  return !!(process.env.CLAUDE_CODE_OAUTH_TOKEN || '').trim();
+}
+const CLAUDE_CLI_BIN = (process.env.CLAUDE_CLI_BIN || 'claude').trim();
 
 // ── API keys (lazy-loaded from environment) ──────────────────
 function getGhModelsPat()       { return (process.env.GH_MODELS_PAT || '').trim(); }
@@ -719,6 +750,7 @@ function getProvider(model) {
   if (model.startsWith('chutes/'))     return PROVIDER.CHUTES;
   if (model.startsWith('zai/'))        return PROVIDER.ZAI;
   if (model.startsWith('local/'))      return PROVIDER.LOCAL;
+  if (model.startsWith('claude-cli/')) return PROVIDER.CLAUDE_CLI;
   return PROVIDER.GITHUB;
 }
 
@@ -752,6 +784,7 @@ function getApiModelId(model) {
   if (model.startsWith('chutes/'))     return model.slice(7);   // 7 chars: "chutes/"
   if (model.startsWith('zai/'))        return model.slice(4);   // 4 chars: "zai/"
   if (model.startsWith('local/'))      return getLocalLlmModelId(); // served-model label is runtime-configured
+  if (model.startsWith('claude-cli/')) return model.slice(11);  // 11 chars: "claude-cli/"
   return model;
 }
 
@@ -783,8 +816,26 @@ function getApiKeyForProvider(provider) {
     // a sentinel marks local/* available so the chain can reach it as last resort
     // (and '' when disabled → every local/* model is skipped). Mirrors Cloudflare.
     case PROVIDER.LOCAL:       return isLocalLlmEnabled() ? 'local-no-key' : '';
+    // No real key — auth is the CLAUDE_CODE_OAUTH_TOKEN env var, read directly
+    // by the `claude` CLI subprocess. Gate on RC flag + token presence so the
+    // chain only offers this model when both are actually usable. Mirrors Local.
+    case PROVIDER.CLAUDE_CLI:  return (isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
     default: return '';
   }
+}
+
+/**
+ * True for opt-in, no-external-quota, absolute-last-resort providers (local
+ * CPU fallback, Claude CLI Haiku — see AI_MODELS.LOCAL_FALLBACK /
+ * AI_MODELS.CLAUDE_CLI_HAIKU). Neither has a daily-quota concept, so
+ * exhausting/banning them mid-run (or persisting a ban across runs) just
+ * guarantees zero output for the rest of the budget — there's nothing left to
+ * fall back to. Centralizes what were several separate `!== PROVIDER.LOCAL`
+ * checks so adding a second last-resort tier didn't require touching each one.
+ */
+function _isLastResortProvider(modelId) {
+  const p = getProvider(modelId);
+  return p === PROVIDER.LOCAL || p === PROVIDER.CLAUDE_CLI;
 }
 
 // Backward-compatible helpers (kept for external code)
@@ -1621,7 +1672,7 @@ export async function initScoreStore() {
       // nothing about whether the local server will fail again right now.
       // Skip restoring any persisted ban for it so it's always eligible as
       // last resort every run. See markModelExhausted / _persistScoresToFirestore.
-      if (data.exhaustedUntil && getProvider(modelId) !== PROVIDER.LOCAL) {
+      if (data.exhaustedUntil && !_isLastResortProvider(modelId)) {
         const resetTime = data.exhaustedUntil.toDate
           ? data.exhaustedUntil.toDate()   // Firestore Timestamp
           : new Date(data.exhaustedUntil); // ISO string fallback
@@ -1706,7 +1757,7 @@ async function _persistScoresToFirestore() {
     // Local CPU fallback is exempt: it has no daily-quota concept, so a
     // content/timeout failure must never survive past this process — see
     // the matching restore-path guard above (initScoreStore).
-    if (_exhaustedModels.has(modelId) && getProvider(modelId) !== PROVIDER.LOCAL) {
+    if (_exhaustedModels.has(modelId) && !_isLastResortProvider(modelId)) {
       const tomorrow = new Date();
       tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
       tomorrow.setUTCHours(0, 0, 0, 0);
@@ -1836,7 +1887,7 @@ export function recordModelContentFailure(modelId) {
   recordModelFailure(modelId);
   const count = (_consecutiveContentFailures.get(modelId) || 0) + 1;
   _consecutiveContentFailures.set(modelId, count);
-  if (getProvider(modelId) === PROVIDER.LOCAL) return;
+  if (_isLastResortProvider(modelId)) return;
   if (count >= MAX_CONSECUTIVE_CONTENT_FAILURES) {
     markModelExhausted(modelId, 'content');
     _stats.exhausted++;
@@ -1876,16 +1927,23 @@ export function getScoreBoard() {
  * Models with higher scores come first.
  * Within equal scores, the original chain order is preserved (stable sort).
  */
+// Last-resort tiering for sortChainByScore: higher tier always sinks below
+// lower tier regardless of score. Local CPU fallback sinks below every real
+// remote API; Claude CLI Haiku sinks even below local — it's the absolute
+// last resort, only reached once local has ALSO failed.
+function _lastResortTier(model) {
+  if (model.startsWith('claude-cli/')) return 2;
+  if (model.startsWith('local/')) return 1;
+  return 0;
+}
+
 function sortChainByScore(chain) {
   // Build index map for tiebreaker (lower index = better in original order)
   const indexMap = new Map(chain.map((m, i) => [m, i]));
   return [...chain].sort((a, b) => {
-    // Local CPU fallback always sinks to the bottom regardless of score — slow
-    // local inference must never be score-promoted above a working remote API;
-    // it exists only for when every remote provider is exhausted.
-    const la = a.startsWith('local/') ? 1 : 0;
-    const lb = b.startsWith('local/') ? 1 : 0;
-    if (la !== lb) return la - lb;
+    const ta = _lastResortTier(a);
+    const tb = _lastResortTier(b);
+    if (ta !== tb) return ta - tb;
     const sa = _modelScores.get(a) || 0;
     const sb = _modelScores.get(b) || 0;
     if (sb !== sa) return sb - sa; // higher score first
@@ -3075,6 +3133,95 @@ async function _callLocal(model, messages, opts) {
 }
 
 /**
+ * Call Claude Haiku via the `claude` CLI subprocess (RC-gated, absolute
+ * last resort — reuses CLAUDE_CODE_OAUTH_TOKEN, same zero-cost Max-plan auth
+ * already wired for pr-review-loop.yml/issue-fix.yml, never a raw
+ * ANTHROPIC_API_KEY). `--bare` deliberately NOT used: it requires
+ * ANTHROPIC_API_KEY/apiKeyHelper and ignores OAuth. `--allowedTools ""` +
+ * `--permission-mode bypassPermissions` force plain one-shot text/schema
+ * completion, no tool access, no agentic session.
+ */
+async function _callClaudeCli(model, messages, opts) {
+  const apiModel = getApiModelId(model); // e.g. 'claude-haiku-4-5-20251001'
+  const systemPrompt = messages.filter((m) => m.role === 'system').map((m) => m.content).join('\n\n');
+  const userPrompt = messages.filter((m) => m.role !== 'system').map((m) => m.content).join('\n\n');
+
+  const args = [
+    '-p', userPrompt,
+    '--model', apiModel,
+    '--output-format', 'json',
+    '--allowedTools', '',
+    '--permission-mode', 'bypassPermissions',
+  ];
+  if (systemPrompt) args.push('--system-prompt', systemPrompt);
+  if (opts.jsonSchema) args.push('--json-schema', JSON.stringify(opts.jsonSchema.schema || opts.jsonSchema));
+
+  // Same deadline-capping rationale as _callLocal above — cap to the caller's
+  // remaining wall-clock budget so a last-resort call can't outlive the run.
+  let timeoutMs = Math.max(opts.timeout || 0, 60_000);
+  if (opts.deadlineMs) {
+    const remaining = opts.deadlineMs - Date.now();
+    timeoutMs = Math.max(15_000, Math.min(timeoutMs, remaining));
+  }
+
+  const { code, stdout, stderr } = await _runClaudeCliProcess(args, timeoutMs);
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(`[${model}] claude CLI non-JSON output (exit ${code}): ${(stdout || stderr).slice(0, 300)}`);
+  }
+  if (code !== 0 || parsed.is_error) {
+    throw new Error(`[${model}] claude CLI error: ${String(parsed.result || stderr || 'unknown').slice(0, 300)}`);
+  }
+  return parsed.result;
+}
+
+/**
+ * Spawn the `claude` CLI with stdin closed (its default stdin-wait-then-read
+ * behavior adds ~3s latency when nothing is piped in — confirmed via live
+ * test) and a hard kill-timeout so a hung subprocess can't outlive the run.
+ */
+async function _runClaudeCliProcess(args, timeoutMs) {
+  const { spawn } = await import('node:child_process');
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(CLAUDE_CLI_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'], env: process.env });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGKILL');
+      const err = new Error(`claude CLI timed out after ${timeoutMs}ms`);
+      err.name = 'TimeoutError';
+      reject(err);
+    }, timeoutMs);
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+/**
  * Call a single Gemini model with retry.
  * Returns the text content on success.
  */
@@ -3223,6 +3370,7 @@ function _callModel(model, messages, opts) {
     case PROVIDER.CHUTES:      return _callChutes(model, messages, opts);
     case PROVIDER.ZAI:         return _callZai(model, messages, opts);
     case PROVIDER.LOCAL:       return _callLocal(model, messages, opts);
+    case PROVIDER.CLAUDE_CLI:  return _callClaudeCli(model, messages, opts);
     default: throw new Error(`[${model}] Unknown provider: ${provider}`);
   }
 }
@@ -3471,7 +3619,7 @@ export async function callLLM(messages, opts = {}) {
       if (o.modelUsedRef && typeof o.modelUsedRef === 'object') {
         o.modelUsedRef.model = model;
       }
-      if (_cacheOn && _cacheKey !== null && model !== AI_MODELS.LOCAL_FALLBACK) {
+      if (_cacheOn && _cacheKey !== null && !_isLastResortProvider(model)) {
         if (_responseCache.size >= RESPONSE_CACHE_MAX) {
           const oldest = _responseCache.keys().next().value;
           if (oldest !== undefined) _responseCache.delete(oldest);
@@ -3508,7 +3656,7 @@ export async function callLLM(messages, opts = {}) {
         // PROVIDER.LOCAL carve-out on recordModelContentFailure above: no
         // external quota, so exhausting it mid-run just guarantees zero
         // output for the rest of the wall-clock budget.
-        if (count >= MAX_CONSECUTIVE_429 && getProvider(model) !== PROVIDER.LOCAL) {
+        if (count >= MAX_CONSECUTIVE_429 && !_isLastResortProvider(model)) {
           markModelExhausted(model);
           _stats.exhausted++;
           console.warn(`🚫 [${model}] Exhausted after ${count} consecutive 429s`);
@@ -3523,7 +3671,7 @@ export async function callLLM(messages, opts = {}) {
       // intentionally raises the timeout floor for slow CPU inference, so a
       // timeout there is expected load, not a dead provider.
       const isTimeoutFailure = e.name === 'AbortError' || e.name === 'TimeoutError' || /timeout|aborted/i.test(msg);
-      if (isTimeoutFailure && getProvider(model) !== PROVIDER.LOCAL) {
+      if (isTimeoutFailure && !_isLastResortProvider(model)) {
         markModelExhausted(model, 'timeout');
         _stats.exhausted++;
       }

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -166,6 +166,12 @@ const RC_TO_ENV = {
   // by default — code falls back to the built-in 0.86 baseline. Lets a single
   // test window relax the threshold without a code change or redeploy.
   NEAR_DUP_COSINE:                ['NEAR_DUP_COSINE'],
+  // Opt-in last-resort article-generation fallback: when every free model in
+  // ai-models.mjs's DEFAULT_CHAIN (including local/fallback) fails, retry via
+  // the `claude` CLI (see AI_MODELS.CLAUDE_CLI_HAIKU). Unset in RC by default
+  // (OFF) — code requires this AND CLAUDE_CODE_OAUTH_TOKEN before offering the
+  // model at all (see isClaudeCliFallbackEnabled/hasClaudeCodeOauthToken).
+  ENABLE_HAIKU_ARTICLE_FALLBACK:  ['ENABLE_HAIKU_ARTICLE_FALLBACK'],
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -22,10 +22,16 @@ describe('local LLM fallback provider', () => {
     expect(AI_MODELS.LOCAL_FALLBACK).toBe('local/fallback');
   });
 
-  it('is the LAST entry in the default chain (true last-resort)', () => {
-    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 1]).toBe(AI_MODELS.LOCAL_FALLBACK);
-    // It must appear exactly once.
+  it('sits below every remote API, with only the opt-in Claude CLI Haiku fallback below it', () => {
+    // AI_MODELS.CLAUDE_CLI_HAIKU (RC-gated, see ai-models-claude-cli-fallback.test.ts)
+    // is now the true final entry — an absolute last resort below even local
+    // CPU inference — but local/fallback must still sit below every real
+    // remote API, which is the invariant this test guards.
+    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 1]).toBe(AI_MODELS.CLAUDE_CLI_HAIKU);
+    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 2]).toBe(AI_MODELS.LOCAL_FALLBACK);
+    // Each must appear exactly once.
     expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.LOCAL_FALLBACK)).toHaveLength(1);
+    expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.CLAUDE_CLI_HAIKU)).toHaveLength(1);
   });
 
   it('is unavailable (skipped) when LOCAL_LLM_ENABLED is unset', () => {

--- a/tests/scripts/ai-models-claude-cli-fallback.test.ts
+++ b/tests/scripts/ai-models-claude-cli-fallback.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// _callClaudeCli spawns `node:child_process` directly (not fetch, unlike every
+// other provider) — mock it so the "success" test never shells out to a real
+// `claude` binary in CI.
+const spawnMock = vi.fn();
+vi.mock('node:child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }));
+
+import { AI_MODELS, callLLM, getPreferredModel, resetState } from '../../scripts/lib/ai-models.mjs';
+
+/**
+ * Claude CLI Haiku last-resort fallback (AI_MODELS.CLAUDE_CLI_HAIKU).
+ *
+ * Absolute last resort behind local/fallback — see ai-models.mjs
+ * isClaudeCliFallbackEnabled/hasClaudeCodeOauthToken/_isLastResortProvider.
+ * Opt-in via RC ENABLE_HAIKU_ARTICLE_FALLBACK; requires CLAUDE_CODE_OAUTH_TOKEN
+ * too, so a flag flipped on without the workflow secret wired never attempts
+ * (and fails) a real run.
+ */
+describe('ai-models Claude CLI Haiku fallback', () => {
+  const ENV_KEYS = ['ENABLE_HAIKU_ARTICLE_FALLBACK', 'CLAUDE_CODE_OAUTH_TOKEN', 'LOCAL_LLM_ENABLED'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    resetState();
+    spawnMock.mockReset();
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    delete process.env.ENABLE_HAIKU_ARTICLE_FALLBACK;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.LOCAL_LLM_ENABLED;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k];
+    }
+    resetState();
+  });
+
+  it('is unavailable with both RC flag and OAuth token unset (default OFF)', () => {
+    expect(getPreferredModel({ chain: [AI_MODELS.CLAUDE_CLI_HAIKU] })).toBeNull();
+  });
+
+  it('is unavailable with only the RC flag set (no OAuth token wired)', () => {
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    expect(getPreferredModel({ chain: [AI_MODELS.CLAUDE_CLI_HAIKU] })).toBeNull();
+  });
+
+  it('is unavailable with only the OAuth token set (RC flag off)', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+    expect(getPreferredModel({ chain: [AI_MODELS.CLAUDE_CLI_HAIKU] })).toBeNull();
+  });
+
+  it('becomes available once both the RC flag and OAuth token are set', () => {
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+    expect(getPreferredModel({ chain: [AI_MODELS.CLAUDE_CLI_HAIKU] })).toBe(AI_MODELS.CLAUDE_CLI_HAIKU);
+  });
+
+  it('sinks below local/fallback even when both are enabled (absolute last resort)', () => {
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+    process.env.LOCAL_LLM_ENABLED = '1';
+    const chain = [AI_MODELS.CLAUDE_CLI_HAIKU, AI_MODELS.LOCAL_FALLBACK];
+    expect(getPreferredModel({ chain })).toBe(AI_MODELS.LOCAL_FALLBACK);
+  });
+
+  it('calls the claude CLI subprocess and returns its result when it is the only available model', async () => {
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+
+    spawnMock.mockImplementation(() => {
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const stdoutListeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const child = {
+        stdout: { on: (ev: string, cb: (...args: unknown[]) => void) => { (stdoutListeners[ev] ||= []).push(cb); } },
+        stderr: { on: (_ev: string, _cb: (...args: unknown[]) => void) => {} },
+        on: (ev: string, cb: (...args: unknown[]) => void) => { (listeners[ev] ||= []).push(cb); },
+        kill: vi.fn(),
+      };
+      // Emit stdout + close asynchronously, mirroring a real child process.
+      queueMicrotask(() => {
+        const payload = JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: 'ARTICLE-BODY-FROM-HAIKU' });
+        stdoutListeners.data?.forEach((cb) => cb(Buffer.from(payload)));
+        listeners.close?.forEach((cb) => cb(0));
+      });
+      return child;
+    });
+
+    const msgs = [{ role: 'user', content: 'Write an article' }];
+    const result = await callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain: [AI_MODELS.CLAUDE_CLI_HAIKU] });
+
+    expect(result).toBe('ARTICLE-BODY-FROM-HAIKU');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(bin).toBe('claude');
+    expect(args).toContain('--model');
+    expect(args[args.indexOf('--model') + 1]).toBe('claude-haiku-4-5-20251001');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('--allowedTools');
+    expect(args[args.indexOf('--allowedTools') + 1]).toBe('');
+    expect(args).not.toContain('--bare');
+  });
+
+  it('propagates a claude CLI error envelope as a failure (no silent success)', async () => {
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+
+    spawnMock.mockImplementation(() => {
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const stdoutListeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const child = {
+        stdout: { on: (ev: string, cb: (...args: unknown[]) => void) => { (stdoutListeners[ev] ||= []).push(cb); } },
+        stderr: { on: (_ev: string, _cb: (...args: unknown[]) => void) => {} },
+        on: (ev: string, cb: (...args: unknown[]) => void) => { (listeners[ev] ||= []).push(cb); },
+        kill: vi.fn(),
+      };
+      queueMicrotask(() => {
+        const payload = JSON.stringify({ type: 'result', subtype: 'error', is_error: true, result: 'model not found' });
+        stdoutListeners.data?.forEach((cb) => cb(Buffer.from(payload)));
+        listeners.close?.forEach((cb) => cb(1));
+      });
+      return child;
+    });
+
+    const msgs = [{ role: 'user', content: 'Write an article' }];
+    await expect(
+      callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain: [AI_MODELS.CLAUDE_CLI_HAIKU] }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/scripts/ai-models-claude-cli-fallback.test.ts
+++ b/tests/scripts/ai-models-claude-cli-fallback.test.ts
@@ -97,8 +97,15 @@ describe('ai-models Claude CLI Haiku fallback', () => {
     expect(args).toContain('--model');
     expect(args[args.indexOf('--model') + 1]).toBe('claude-haiku-4-5-20251001');
     expect(args).toContain('--output-format');
-    expect(args).toContain('--allowedTools');
-    expect(args[args.indexOf('--allowedTools') + 1]).toBe('');
+    // --tools '' (not --allowedTools) is the flag that actually disables tool
+    // availability — --allowedTools only gates the permission prompt for
+    // tools that remain available, it doesn't remove them from the built-in
+    // set (confirmed via `claude --help` after a review flagged the
+    // difference: bypassPermissions + --allowedTools '' alone left every
+    // built-in tool available and auto-approved).
+    expect(args).toContain('--tools');
+    expect(args[args.indexOf('--tools') + 1]).toBe('');
+    expect(args).not.toContain('--allowedTools');
     expect(args).not.toContain('--bare');
   });
 


### PR DESCRIPTION
## Implementato

- **Root-cause fix for zero-article runs**: `scripts/create-article.mjs` had 2 sibling wall-clock guards (news-pool retry loop, evergreen fallback retry loop) that abandoned starting ANY new generation attempt once <11min (`LOCAL_MIN_VIABLE_MS`) remained in the run budget — even though that 11min floor exists specifically to reserve time for local/fallback's slow CPU inference, not for a fast cloud-model call. A cloud model typically answers in seconds, so a run with e.g. 5min left was abandoning perfectly viable cloud attempts. Introduced a new, correctly-scoped `MIN_VIABLE_ATTEMPT_MS = 2 * 60_000` floor for "should any new attempt start at all", applied at both sites. `LOCAL_MIN_VIABLE_MS` is left in place, unchanged, at its original narrower site (which is already correctly gated on `_localFallbackUsedThisHeadline` and only fires after local/fallback was actually used this headline).
- **New opt-in last-resort model**: `AI_MODELS.CLAUDE_CLI_HAIKU` (`claude-cli/claude-haiku-4-5-20251001`) in `scripts/lib/ai-models.mjs`, pinned last in `DEFAULT_CHAIN`, below `local/fallback` (`sortChainByScore` tiers `claude-cli/` below `local/`). New `PROVIDER.CLAUDE_CLI` provider dispatches to a new `_callClaudeCli` function that shells out to the `claude` CLI (`spawn`, stdin closed, JSON output, deadline-capped like `_callLocal`). Auth is `CLAUDE_CODE_OAUTH_TOKEN` only — same Max-plan subscription token already wired for `pr-review-loop.yml`/`issue-fix.yml` — never `ANTHROPIC_API_KEY`. `--bare` is deliberately NOT used (incompatible with OAuth token auth, confirmed via live CLI testing).
- **Security fix from review**: tool access is disabled via `--tools ""` (per `claude --help`: "Use \"\" to disable all tools"), not `--allowedTools`/`--permission-mode bypassPermissions` alone — the first-pass implementation used `--allowedTools '' --permission-mode bypassPermissions`, which only skips the permission *prompt* and does not remove built-in tools (Bash, Edit, Write, …) from availability. Combined with `bypassPermissions` auto-approving and the subprocess inheriting the full CI env (secrets) while processing externally-sourced headline content, that combination would have let a prompt-injected headline get a tool call auto-approved in a runner with repo-write + secrets access. Confirmed live: with `--tools ""` the model reports no shell tool is available and a test injection command produces no file; `claude --help` confirms `--tools` (not `--allowedTools`) is what governs the built-in tool *set*.
- Gated OFF by default via new Remote Config flag `ENABLE_HAIKU_ARTICLE_FALLBACK` (added to `scripts/load-rc-env.mjs`'s `RC_TO_ENV` map) AND requires `CLAUDE_CODE_OAUTH_TOKEN` to be present — both must be true before the model is ever offered (`getApiKeyForProvider`), so flipping the flag on without the workflow secret wired is a no-op, not a failure.
- Exempted from persistent Firestore exhaustion-banning and from the opt-in response cache, same as `local/fallback` (via a new shared `_isLastResortProvider` helper replacing 5 separate `!== PROVIDER.LOCAL` checks) — neither last-resort tier has a real daily quota, so banning them mid-run just guarantees zero output for the rest of the budget.
- `.github/workflows/generate-article.yml`: conditional `npm install -g @anthropic-ai/claude-code` step gated on `env.ENABLE_HAIKU_ARTICLE_FALLBACK == '1'`, and `CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` added to the "Generate article" step's env (harmless to always pass — inert unless the RC flag is also on).
- New test file `tests/scripts/ai-models-claude-cli-fallback.test.ts` (7 tests): RC-flag/OAuth-token gating (all 3 partial-state combinations return unavailable), tiering (sinks below `local/fallback`), and end-to-end `callLLM` success/error paths via a mocked `node:child_process.spawn`. Updated pre-existing `tests/local-llm-fallback.test.ts` invariant test (was asserting `local/fallback` is literally last in `DEFAULT_CHAIN` — now second-to-last, below it only the new opt-in Claude CLI tier).
- Sibling-pattern grep (`scripts/ci/check-sibling-patterns.mjs`) run on the diff: all candidate matches (`getProvider`, `AI_MODELS`, `DEFAULT_CHAIN`, `allowedTools`, `systemPrompt`/`userPrompt`, `TimeoutError` in other files) manually confirmed as false positives — lexically similar names in unrelated domains (job-board provider logos, email-provider cascade, other GH Actions agentic workflows, other crawler scripts' own timeout handling), not duplicated copies of the logic touched here.

## Non implementato (ancora)

Nessuno. The wall-clock floor fix isn't covered by a dedicated unit test — `create-article.mjs`'s retry loops are internal, unexported control flow inside a ~9000-line procedural script not set up for granular unit testing, and the existing `create-article-integration.test.ts`/`create-article-content-quality-reject-siblings.test.ts` suites (43 tests) pass unaffected. Validated instead via a live triggered run of `generate-article.yml` (post-merge, live) to directly confirm an article is produced — will report the run-id/result here once observed.

## Test plan

- [x] `npx vitest run` on the targeted `ai-models*`/`create-article*`/`local-llm-fallback` corpus (15 files, 128 tests) — all pass, re-run clean after the `--tools ''` security fix; full local suite run earlier in this PR's history showed only the 6 pre-existing failures from a local-only gitignored `data/jobs.json` gap, unrelated to this diff; CI's own `vitest (unit + integration)` job is green
- [x] `node --check` on all 3 edited `.mjs` files — syntax OK
- [x] YAML syntax check on `generate-article.yml` — OK
- [x] Sibling-pattern grep reviewed by hand — no real siblings found
- [x] Live CLI test confirming `--tools ""` actually blocks tool execution (post-review security fix)
- [ ] Live post-merge run of `generate-article.yml` confirms an article is actually produced (post-merge, live — will verify and report here)
