### PR TITLE
fix(email-cascade): sum all Mailgun stats buckets, not just stats[0]

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -135,7 +135,12 @@ async function fetchMailgunDailyUsage() {
     );
     if (!res.ok) return 0;
     const data = await res.json();
-    return data.stats?.[0]?.accepted?.outgoing || 0;
+    // duration=1d without an explicit start/end aligns buckets to UTC calendar
+    // days, so a rolling 24h window that straddles midnight UTC returns TWO
+    // entries in `stats[]` (yesterday's partial day + today's). Reading only
+    // stats[0] silently picked the older bucket and under-reported usage —
+    // sum every bucket in the window instead.
+    return (data.stats || []).reduce((sum, s) => sum + (s.accepted?.outgoing || 0), 0);
   } catch { return 0; }
 }
 


### PR DESCRIPTION
## Implementato

- `fetchMailgunDailyUsage()` in `scripts/lib/email-cascade.mjs` now sums every entry in Mailgun's `stats/total` response instead of reading only `stats[0]`.
- Root cause: the query uses `duration=1d` with no explicit `start`/`end`, so Mailgun buckets the rolling 24h window by UTC calendar day. When that window straddles UTC midnight, the API returns two `stats[]` entries (yesterday's partial day + today's), and `stats[0]` is the older one — silently under-reporting today's real usage.
- Observed live in run [28925487013](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/28925487013/job/85812005384): quota sync logged `mailgun=0/100`, then the very next send attempt got a `429` "daily request limit (100) exceeded". The cascade correctly failed over to Resend (0 failed, all 2107 alerts delivered), so no user-facing impact this run, but the misreport wastes an API call and would matter more if a future run needed mailgun's slice of quota for cascade planning.
- Checked for the same `stats?.[0]` pattern in the other four provider usage-fetchers (mailjet, mailtrap, resend, maileroo) in the same file — none share it; they all scope with an explicit calendar-day `start`/`end` already. Mailgun was the only one using the rolling-`duration` + first-bucket shape, confirmed via `grep -rn "stats?.\[0\]"` across `scripts/`, `services/`, `build-plugins/` (single hit).
- `npx vitest run tests/email-cascade-burst.test.ts tests/newsletter-provider-force-select.test.ts` → 33/33 passing.
- GitNexus impact analysis on `fetchMailgunDailyUsage` (upstream): LOW risk, no signature change, only affects quota-sync accuracy for all cascade callers (job alerts, newsletter, cold emails, winbacks).

## Non implementato (ancora)

Nessuno.

## Verificato ma non modificato (fuori scope, non è un bug)

Reviewed the rest of run 28925487013's log for other issues per the user's ask:
- 28 "Live-link check: only N/M resolved live — failing open" warnings across ~929 checks (~3%), scattered over the full ~66min run. This is the documented, intentional fail-open guard (`JOB_LIVE_CHECK_FAIL_OPEN_MIN_SAMPLE`/`_RATIO` in `scripts/send-job-alerts.mjs`) protecting against exactly this kind of transient outbound-network blip — working as designed, not a bug.
- Node `DEP0040`/`DEP0169` deprecation warnings and `npm warn deprecated` lines during setup/install are from transitive dependencies / the GH Actions runner's own Node setup, not this workflow's code.
- The `::error::FIREBASE_SERVICE_ACCOUNT_JSON secret is not set` line in the "Prepare Firebase credentials" step is the shell script source being echoed in the log group header, not a triggered error — the step and secret both resolved fine (step `conclusion: success`).
- `npm audit`: 37 vulnerabilities (3 low, 24 moderate, 8 high, 2 critical) reported during install — pre-existing, repo-wide dependency posture, not specific to this workflow or this diff; flagging for visibility but out of scope for a surgical fix here.