### PR TITLE
fix(crawlers): mark kone as legitimately empty in Switzerland (#3797)

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -299,6 +299,14 @@ const EMPTY_OK_CRAWLERS = new Set([
   // no open postings on this ATS right now. Parser is healthy and will pick
   // up real jobs (CH-filtered) the moment any are published.
   'bally',
+  // KONE (elevators/escalators, Swiss entity KONE (Schweiz) AG, Zürich):
+  // the crawler pulls from the real, live SmartRecruiters tenant "KONE1"
+  // (https://api.smartrecruiters.com/v1/companies/KONE1/postings). Verified
+  // live 2026-07-08: `totalFound:0` for `country=CH`, and only 1 posting
+  // worldwide (Technicien de Maintenance, Charleroi, Belgium) — KONE
+  // genuinely has no open Swiss postings on this ATS right now. Parser is
+  // healthy and will pick up real jobs the moment any CH ones are published.
+  'kone',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Implementato

Root-caused `kone` from #3797's silently-empty backlog: the crawler pulls from the real, live SmartRecruiters tenant `KONE1` (`https://api.smartrecruiters.com/v1/companies/KONE1/postings`), which is not dead — it's a real, active tenant that simply has no open Swiss postings right now.

Live-verified 2026-07-08:
- `country=CH` filter: `{"offset":0,"limit":100,"totalFound":0,"content":[]}`
- No filter (worldwide): `{"totalFound":1,...}` — the sole posting is "Technicien de Maintenance" in Charleroi, Belgium.

This is a genuine empty state, not a scraper bug — added `kone` to `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs` with the evidence inline, matching the existing pattern used for the other 18 entries in that set (e.g. `bally`, #3825).

Tests: `npx vitest run tests/scripts/check-crawler-health.test.ts tests/scripts/check-crawler-health-discovery.test.ts tests/kone-crawler.test.ts` → 37/37 passing.

Related #3797 (partial).

## Non implementato (ancora)

Nessuno.