### PR TITLE
test(crawler-health): lock in has-healthcare EMPTY_OK regression (#3819)

### DIFF
--- a/tests/scripts/check-crawler-health.test.ts
+++ b/tests/scripts/check-crawler-health.test.ts
@@ -265,6 +265,46 @@ describe('nextCrawlerState', () => {
     expect(state.consecutiveEmptyRuns).toBe(0);
   });
 
+  it('clears broken status for has-healthcare (Drupal micro-site, empty-ok) on a fresh zero-job run (#3565, #3819)', () => {
+    // Reproduces the #3819 recurrence of #3565: the e-lavoro.ch/node/104
+    // listing page (AITI Drupal micro-site) returns HTTP 200 with its own
+    // legitimate empty-state markup — "Purtroppo non ci sono offerte di
+    // lavoro, torna a trovarci!" — verified via a direct fetch with the
+    // crawler's own selectors (job-title-row / w-100 p-3 /
+    // main-list-job-percentage), which is unchanged and still correct; it
+    // simply has nothing to match. #3565 was closed on this same evidence
+    // but WITHOUT adding the crawler to EMPTY_OK_CRAWLERS, so the daily
+    // monitor kept re-flagging it as broken every day until #3819 was
+    // opened fresh 6 empty runs later. It must not stay flagged broken once
+    // added to EMPTY_OK_CRAWLERS.
+    const prev = {
+      lastSuccessfulRunAt: '2026-07-01T22:28:50.370Z',
+      lastNonZeroJobs: 4,
+      consecutiveEmptyRuns: 6,
+      lastFailureReason: '6 consecutive runs returned 0 jobs',
+      status: 'broken',
+      _lastObservedAt: new Date(NOW_MS - DAY_MS).toISOString(),
+      _lastObservedJobs: 0,
+      _lastObservedAssembledAt: new Date(NOW_MS - DAY_MS).toISOString(),
+    };
+    const { status, state, reason } = nextCrawlerState(
+      prev,
+      {
+        slug: 'has-healthcare',
+        jobCount: 0,
+        freshnessAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+        freshnessSource: 'summary',
+        generatedAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+        assembledAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+      },
+      NOW_ISO,
+      NOW_MS,
+    );
+    expect(status).toBe('healthy');
+    expect(reason).toBeNull();
+    expect(state.consecutiveEmptyRuns).toBe(0);
+  });
+
   it('flags stale when slice assembledAt is older than 7 days (regardless of empty streak)', () => {
     // heineken-ch fixture: slice from 8d ago.
     const { status, state, reason } = nextCrawlerState(


### PR DESCRIPTION
## Implementato

- Added a named regression test for `has-healthcare` in `tests/scripts/check-crawler-health.test.ts`, mirroring the existing `a-group`/`axa-svizzera`/`impresa-pizzarotti` pattern: given the exact prior-broken state from `data/crawler-health.json` (6 consecutive empty runs, `status: "broken"`) and a fresh zero-job observation with `EMPTY_OK_CRAWLERS` applied, `nextCrawlerState` must resolve to `status: "healthy"` with `consecutiveEmptyRuns` reset to `0`.
- Independently verified the source is genuinely, legitimately empty (not a parser/anti-bot regression): a direct fetch of `https://e-lavoro.ch/node/104` today returns HTTP 200 with the site's own Drupal empty-state markup ("Purtroppo non ci sono offerte di lavoro, torna a trovarci!"), and a live run of `node scripts/update-has-healthcare-jobs.mjs` cleanly discovers 0 listings with no fetch error and no anti-bot signal — same conclusion the #3565 closure comment reached, now double-checked fresh.
- Confirmed the actual code-level fix (`has-healthcare` added to `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs`) is **already merged to `origin/main`** via the unrelated #3797-batch PR #3824 (merged 2026-07-08T10:11:07Z). No further change to `check-crawler-health.mjs` itself is needed or made here — this PR only adds the missing regression coverage for that entry.
- `npx vitest run tests/scripts/check-crawler-health.test.ts tests/scripts/check-crawler-health-discovery.test.ts` — 20/20 passing (17/17 + 3/3).
- Verified no dangling/inconsistent references: `has-healthcare` remains correctly wired in `.github/workflows/crawler-group-14.yml` (orchestrator entry untouched, not retiring this crawler) and `data/jobs-crawler-adapters/adapters/has-healthcare.json`.

## Why #3565's earlier closure didn't stick

#3565 was closed 2026-07-07T13:08Z with a comment verifying the exact same legitimate-empty-source evidence, but the crawler was **never added to `EMPTY_OK_CRAWLERS`**. Without that allowlist entry, `scripts/check-crawler-health.mjs`'s daily cron kept counting consecutive empty runs against the 3-run "broken" threshold every day, so the flag inevitably came back — #3819 was auto-opened fresh 6 empty runs later, since #3565 was already closed and could not be reused.

Separately: the workflow run that generated #3819's underlying "broken" state (`crawler-health-monitor` run `28930916631`) checked out commit `a1401252f` at 09:05–09:13 UTC on 2026-07-08 — **before** PR #3824 merged the `EMPTY_OK_CRAWLERS` entry at 10:11 UTC. The issue itself was created at 10:32 UTC, i.e. *after* the fix had already landed on `main`, purely due to that scheduling race, not because the fix doesn't work. The next scheduled `crawler-health-monitor` run will re-observe `has-healthcare` with the now-merged allowlist entry and self-heal `data/crawler-health.json` to `status: "healthy"` (verified via the new test's exact assertion of that transition) — deliberately not hand-edited here per the "accumulator files are CI-only" convention.

## Non implementato (ancora)

Nessuno.

---

Backlog context: #3797 (does not close — broader multi-crawler audit, has-healthcare is only one line item in it).
Closes #3819