### PR TITLE
fix(crawlers): fetchWithTimeout falls back to direct fetch when Jina proxy is exhausted (cambiavalute)

### DIFF
--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -101,7 +101,7 @@ import { translateWithMyMemory, getMyMemoryStats } from './mymemory-translate.mj
 import { freeTranslateWithRetry, logCascadeSummary } from './free-translate.mjs';
 import { parseSupsiJobDetail } from './supsi-job-parser.mjs';
 import { hasConcatenatedWords } from './translation-quality.mjs';
-import { jinaProxiedRequest, hostMatchesProxyList, fetchViaJinaWithRetry } from './jina-proxy.mjs';
+import { jinaProxiedRequest, hostMatchesProxyList, fetchViaJinaWithRetry, detectJinaErrorBody } from './jina-proxy.mjs';
 import {
   extractMigrosStructuredData,
   extractMigrosSectionItems,
@@ -2400,6 +2400,7 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
   // what callers use for the job's canonical URL.
   let targetUrl = url;
   let proxyHeaders = {};
+  let postJinaFallback = false;
   if (hostMatchesProxyList(url, process.env.JOBS_CRAWLER_FETCH_PROXY)) {
     // Route through Jina Reader, and for idempotent GET/HEAD retry on a fresh
     // Jina egress IP when the proxy lands on a WAF-flagged IP (the challenge
@@ -2428,6 +2429,7 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
       // caller's `if (!res.ok) continue` masked it entirely).
       const jinaFailReason = jinaRes.headers.get('x-jina-retry-reason') || `HTTP ${jinaRes.status}`;
       console.warn(`⚠️ Jina proxy exhausted for ${url} (${jinaFailReason}) — falling back to direct fetch.`);
+      postJinaFallback = true;
     } else {
       const proxied = jinaProxiedRequest(url);
       targetUrl = proxied.url;
@@ -2465,6 +2467,25 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
         try { await res.body?.cancel(); } catch {}
         await sleep(fetchRetryDelayMs(attempt));
         continue;
+      }
+      if (postJinaFallback && res.ok) {
+        // Direct-fetch fallback after Jina exhaustion (see above): a CI
+        // datacenter IP can hit the same sgcaptcha WAF challenge Jina's blocked
+        // IPs get, but on a plain HTTP 200 — no `!res.ok` signal at all. Validate
+        // the body with the same detector Jina's own retry path already relies
+        // on before trusting this as real content; otherwise a challenge page
+        // silently gets parsed as a job page instead of the old (safe) skip.
+        const probe = res.clone();
+        const text = await probe.text().catch(() => '');
+        const errorReason = detectJinaErrorBody(text);
+        if (errorReason) {
+          console.warn(`⚠️ Direct-fetch fallback for ${url} also hit a WAF challenge (${errorReason}) — treating as failed fetch.`);
+          try { await res.body?.cancel(); } catch {}
+          return new Response('', {
+            status: 502,
+            headers: { 'content-type': 'text/html', 'x-fallback-fail-reason': errorReason },
+          });
+        }
       }
       return res;
     } catch (err) {

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -2413,11 +2413,26 @@ async function fetchWithTimeout(url, { method = 'GET', headers = {}, body, userA
     // body. Let HEAD fall through to the generic proxied fetch below, which keeps
     // the original method.
     if (canRetry && upperMethod === 'GET') {
-      return await fetchViaJinaWithRetry(url, { timeoutMs: REQUEST_TIMEOUT_MS });
+      const jinaRes = await fetchViaJinaWithRetry(url, { timeoutMs: REQUEST_TIMEOUT_MS });
+      if (jinaRes.ok) return jinaRes;
+      // Every Jina egress IP tried was still blocked/erroring (#3797 recurrence,
+      // 2026-07-07: all 4 cambiavalute.ch detail pages silently dropped this way
+      // in one CI run — zero log trace, even though a plain direct fetch worked
+      // fine for discovery in that SAME run and reproduced locally afterwards).
+      // A degraded/rate-limited proxy pool must not be a harder failure mode than
+      // no proxy at all, so fall through to the direct-fetch retry loop below
+      // (targetUrl/proxyHeaders are left at their unproxied defaults — do NOT
+      // route this fallback through jinaProxiedRequest, or it just re-hits the
+      // same exhausted proxy path). Logged so a future recurrence is diagnosable
+      // from CI output alone (previously this path was completely silent — the
+      // caller's `if (!res.ok) continue` masked it entirely).
+      const jinaFailReason = jinaRes.headers.get('x-jina-retry-reason') || `HTTP ${jinaRes.status}`;
+      console.warn(`⚠️ Jina proxy exhausted for ${url} (${jinaFailReason}) — falling back to direct fetch.`);
+    } else {
+      const proxied = jinaProxiedRequest(url);
+      targetUrl = proxied.url;
+      proxyHeaders = proxied.headers;
     }
-    const proxied = jinaProxiedRequest(url);
-    targetUrl = proxied.url;
-    proxyHeaders = proxied.headers;
   }
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -5738,6 +5753,7 @@ export { main as runSharedCrawlerPipeline };
 // in-memory Map that must be reset between test cases (#3080).
 export const __testables = {
   aiValidateJobDetailPage,
+  fetchWithTimeout,
   setCrawlerConfigForTests(cfg) { crawlerConfigGlobal = cfg; },
   clearAiResponseCacheForTests() { aiResponseCache.clear(); },
   persistAiCacheToDisk,

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -389,6 +389,14 @@ function updateAdapter(seedUrls, seedMetaByUrl) {
     enabled: true,
     priority: 10,
     crawlerModes: ['html', 'jsonld'],
+    // Detail-page fetches otherwise default to the shared crawler's generic bot
+    // UA (`FrontaliereTicinoBot/1.0`), which is exactly what the WAF blocks
+    // (#1277/#1303/#1363). Reuse the same known-good rotating-window Chrome UA
+    // as the listing/discovery fetch (BROWSER_USER_AGENTS) so the direct-fetch
+    // fallback in fetchWithTimeout — used when the Jina proxy is exhausted, see
+    // #3797 — presents a real browser fingerprint instead of an instantly-403'd
+    // bot UA.
+    userAgent: BROWSER_USER_AGENTS[0],
     seedUrls,
     seedDetailUrls: seedUrls,
     seedMetaByUrl,

--- a/tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts
+++ b/tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts
@@ -64,9 +64,14 @@ describe('fetchWithTimeout — JOBS_CRAWLER_FETCH_PROXY Jina-exhaustion fallback
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  // Real target pages are always well over detectJinaErrorBody's 200-char
+  // short-body floor — pad with filler so this reads as genuine content, not
+  // an accidental "too short" false-positive.
+  const REAL_DIRECT_BODY = `<html><body>${'Real cambiavalute.ch job posting content. '.repeat(6)}</body></html>`;
+
   it('falls back to a genuine direct (unproxied) fetch when Jina is exhausted, and warns', async () => {
     fetchViaJinaWithRetry.mockResolvedValue(jinaResponse(false, { reason: 'all-egress-ips-blocked' }));
-    global.fetch = vi.fn(async () => new Response('<html>direct body</html>', { status: 200 })) as unknown as typeof fetch;
+    global.fetch = vi.fn(async () => new Response(REAL_DIRECT_BODY, { status: 200 })) as unknown as typeof fetch;
     const res = await fetchWithTimeout(TARGET_URL);
     expect(res.ok).toBe(true);
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -75,6 +80,27 @@ describe('fetchWithTimeout — JOBS_CRAWLER_FETCH_PROXY Jina-exhaustion fallback
     // target — or it would just re-hit the same exhausted proxy path.
     expect(calledUrl).toBe(TARGET_URL);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('all-egress-ips-blocked'));
+  });
+
+  // PR #3832 review finding (🔴): the direct-fetch fallback used to trust any
+  // res.ok===true blindly. A CI datacenter IP can get the exact same sgcaptcha
+  // WAF challenge cambiavalute.ch's Jina-blocked IPs get (#1363) — but as a
+  // plain HTTP 200, so `!res.ok` never catches it. Must validate the body with
+  // the same detector Jina's own retry path already uses before trusting it.
+  it('treats a WAF challenge page on the direct-fetch fallback as a failed fetch, not real content', async () => {
+    fetchViaJinaWithRetry.mockResolvedValue(jinaResponse(false, { reason: 'all-egress-ips-blocked' }));
+    const challengeBody = `<html><body>${'Please wait while we verify your browser. sgcaptcha challenge. '.repeat(4)}</body></html>`;
+    global.fetch = vi.fn(async () => new Response(challengeBody, { status: 200 })) as unknown as typeof fetch;
+    const res = await fetchWithTimeout(TARGET_URL);
+    expect(res.ok).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('sgcaptcha'));
+  });
+
+  it('treats a suspiciously short direct-fetch fallback body as a failed fetch too', async () => {
+    fetchViaJinaWithRetry.mockResolvedValue(jinaResponse(false, { reason: 'all-egress-ips-blocked' }));
+    global.fetch = vi.fn(async () => new Response('<html>short</html>', { status: 200 })) as unknown as typeof fetch;
+    const res = await fetchWithTimeout(TARGET_URL);
+    expect(res.ok).toBe(false);
   });
 
   it('leaves fetch behavior untouched for hosts outside JOBS_CRAWLER_FETCH_PROXY', async () => {

--- a/tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts
+++ b/tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3797 recurrence (2026-07-07): fetchWithTimeout's JOBS_CRAWLER_FETCH_PROXY
+// gated GET path used to `return` unconditionally on fetchViaJinaWithRetry's
+// result, even when Jina had exhausted every retry and was still
+// blocked/erroring. That silently lost the response with zero log trace —
+// the caller's generic `if (!res.ok) continue` (shared by ~400 crawlers)
+// swallowed it — and never attempted a direct (unproxied) fetch as a
+// fallback, even though a plain direct fetch of the same URL worked fine in
+// the very same CI run (confirmed via live reproduction). This covers the
+// fix: a Jina failure now warns (diagnosable from CI output) and falls
+// through to a genuine direct fetch of the original, non-proxied URL.
+const { fetchViaJinaWithRetry } = vi.hoisted(() => ({
+  fetchViaJinaWithRetry: vi.fn(),
+}));
+
+vi.mock('../../scripts/lib/jina-proxy.mjs', async (importOriginal) => {
+  // Only fetchViaJinaWithRetry is stubbed — hostMatchesProxyList and
+  // jinaProxiedRequest stay real so the env-var host-gating itself is
+  // exercised, not assumed.
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, fetchViaJinaWithRetry };
+});
+
+const { __testables } = await import('../../scripts/lib/shared-jobs-crawler.mjs');
+const { fetchWithTimeout } = __testables;
+
+const PROXY_HOST = 'cambiavalute.ch';
+const TARGET_URL = `https://${PROXY_HOST}/annuncio-di-lavoro/test-job/`;
+
+function jinaResponse(ok: boolean, opts: { status?: number; reason?: string } = {}) {
+  return {
+    ok,
+    status: opts.status ?? (ok ? 200 : 502),
+    headers: new Headers(opts.reason ? { 'x-jina-retry-reason': opts.reason } : {}),
+    text: async () => '<html>jina body</html>',
+  };
+}
+
+describe('fetchWithTimeout — JOBS_CRAWLER_FETCH_PROXY Jina-exhaustion fallback (#3797)', () => {
+  const origFetch = global.fetch;
+  const origEnv = process.env.JOBS_CRAWLER_FETCH_PROXY;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.JOBS_CRAWLER_FETCH_PROXY = PROXY_HOST;
+    fetchViaJinaWithRetry.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    if (origEnv === undefined) delete process.env.JOBS_CRAWLER_FETCH_PROXY;
+    else process.env.JOBS_CRAWLER_FETCH_PROXY = origEnv;
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the Jina response directly on success, without attempting a direct fetch', async () => {
+    fetchViaJinaWithRetry.mockResolvedValue(jinaResponse(true));
+    global.fetch = vi.fn();
+    const res = await fetchWithTimeout(TARGET_URL);
+    expect(res.ok).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a genuine direct (unproxied) fetch when Jina is exhausted, and warns', async () => {
+    fetchViaJinaWithRetry.mockResolvedValue(jinaResponse(false, { reason: 'all-egress-ips-blocked' }));
+    global.fetch = vi.fn(async () => new Response('<html>direct body</html>', { status: 200 })) as unknown as typeof fetch;
+    const res = await fetchWithTimeout(TARGET_URL);
+    expect(res.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [calledUrl] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    // The fallback must hit the plain, original URL — not a Jina-rewritten
+    // target — or it would just re-hit the same exhausted proxy path.
+    expect(calledUrl).toBe(TARGET_URL);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('all-egress-ips-blocked'));
+  });
+
+  it('leaves fetch behavior untouched for hosts outside JOBS_CRAWLER_FETCH_PROXY', async () => {
+    delete process.env.JOBS_CRAWLER_FETCH_PROXY;
+    global.fetch = vi.fn(async () => new Response('<html>ok</html>', { status: 200 })) as unknown as typeof fetch;
+    const res = await fetchWithTimeout('https://example.test/jobs');
+    expect(res.ok).toBe(true);
+    expect(fetchViaJinaWithRetry).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Implementato

- Root cause of cambiavalute.ch's crawler dropping from 4 jobs to 0 on 2026-07-07 (flagged in issue 3797's crawler backlog audit): `fetchWithTimeout()` in `scripts/lib/shared-jobs-crawler.mjs` — the shared fetch chokepoint used by every dedicated crawler — has an opt-in egress-proxy path gated by `JOBS_CRAWLER_FETCH_PROXY` (currently set only by `update-cambiavalute-jobs.mjs`, routing cambiavalute.ch through Jina Reader to dodge the site's IP-reputation WAF, per issue 1363). That GET path returned Jina's response **unconditionally**, even when every Jina retry attempt was still blocked/erroring. The response object itself (`res.ok === false`) was then silently dropped by the generic `if (!res.ok) continue` in the detail-page fetch loop — a pattern shared by ~400 other crawlers — with **zero log trace**. All 4 cambiavalute detail-page fetches were lost this way in the 2026-07-07 CI run.
- **Live verification of root cause**: direct `curl` (plain and via Jina) of the listing page and all 4 detail pages from my own machine returned correct, unchanged HTML with the same job titles/slugs previously crawled — ruling out a site-structure change or a renewed direct-IP block. A full local run of the unmodified crawler script also completed discovery+parsing successfully end-to-end (4/4 real jobs), confirming the breakage was a transient/proximate failure inside the Jina-proxy detail-fetch path itself, not a change to cambiavalute.ch.
- Fix (`scripts/lib/shared-jobs-crawler.mjs`, `fetchWithTimeout`): when Jina is exhausted, `console.warn` with the failure reason (`x-jina-retry-reason` header or HTTP status) and fall through to the existing direct-fetch retry loop using the original, unproxied URL — instead of trusting an exhausted proxy result. Strictly scoped inside the existing `JOBS_CRAWLER_FETCH_PROXY` conditional (currently true only for cambiavalute.ch) — zero behavior change for every other crawler through this shared function. `gitnexus_impact` on `fetchWithTimeout` confirmed 14 direct callers all within this one file; the change is a no-op for all of them since none set `JOBS_CRAWLER_FETCH_PROXY`.
- `scripts/update-cambiavalute-jobs.mjs`: set a realistic Chrome `userAgent` on the adapter (reusing the existing `BROWSER_USER_AGENTS` rotation already used for listing discovery) so the new direct-fetch fallback — and any other adapter-driven fetch for this company — presents a real browser fingerprint instead of the shared crawler's default bot UA, which is exactly what the WAF blocks (issue 1277 / 1363).
- **Review fix (🔴 Important, round 1)**: the direct-fetch fallback trusted any `res.ok === true` blindly. A CI datacenter IP can hit the same `sgcaptcha` WAF challenge Jina's blocked IPs get, but as a plain HTTP 200 — no `!res.ok` signal. `scripts/lib/shared-jobs-crawler.mjs` now clones the fallback response and runs it through `detectJinaErrorBody()` (the same detector `fetchViaJinaWithRetry` already relies on) before trusting it; on a match it warns and returns a synthetic `502` so the caller's existing `if (!res.ok) continue` still skips it. Sibling-checked: the only other direct `fetchViaJinaWithRetry()` callers (`scripts/lib/google-switzerland-job-parser.mjs`, `scripts/update-goline-jobs.mjs`) already call `detectJinaErrorBody` themselves — no other sibling needed the sweep. Confirmed via incremental-high re-review (`## LGTM`, no new findings).
- Regression test: `tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts` (5 cases) — exposes `fetchWithTimeout` via the existing `__testables` pattern and covers: (1) Jina success returns directly with no direct fetch attempted, (2) Jina exhaustion falls back to a genuine direct fetch of the *original* URL and warns, (3) a WAF challenge page on the fallback is treated as a failed fetch, (4) a suspiciously short fallback body is treated as failed too, (5) hosts outside `JOBS_CRAWLER_FETCH_PROXY` are untouched. All 5 tests green.
- Post-fix re-verification: ran `node scripts/update-cambiavalute-jobs.mjs` locally against the live site again — crawler recovered all 4/4 real jobs. Tracked data-file mutations from the diagnostic run were reverted before commit (not part of this PR's payload).
- Sibling-pattern check (AGENTS.md #6): `node scripts/ci/check-sibling-patterns.mjs` flagged 19 files sharing generic tokens (`REQUEST_TIMEOUT_MS`, `BROWSER_USER_AGENTS`) used across dozens of unrelated per-company parsers — false positives, unrelated domain. No other `scripts/update-*.mjs` currently sets `JOBS_CRAWLER_FETCH_PROXY`, so no sibling script duplicates the fixed construct.

## Non implementato (ancora)

Nessuno.

---

Not part of the separate "45 silent-exit-0 post-#3701" crawler class discussed in issue 3797 (that class's shard file `data/jobs/by-crawler/{key}.json` never exists at all — cambiavalute's shard exists with real prior data and a legitimate 4-job removal diff, confirming this is a genuine anti-bot-adjacent regression, not a resource-contention silent no-op).

References issue 1277, issue 1363, issue 1417, and issue 1321 (all already closed — historical context on cambiavalute's prior anti-bot breakage/fix cycle; this PR fixes a related but distinct proximate failure in the Jina-proxy detail-fetch path introduced by that same prior fix, not a recurrence of the exact same bug). Does not close issue 3797 (broader crawler backlog audit, out of this PR's scope).

## Test plan

- [x] `npx vitest run tests/scripts/fetch-with-timeout-jina-proxy-fallback.test.ts tests/jina-proxy.test.ts tests/crawler-egress-jina-fallback.test.ts tests/scripts/ai-validate-job-detail-page-model-cache.test.ts tests/scripts/ensure-locale-fields-no-mass-reflag.test.ts tests/scripts/resolve-locale-prompt-context.test.ts` — 6 files / 44 tests, all green.
- [x] Live re-run of `scripts/update-cambiavalute-jobs.mjs` against the real site post-fix — 4/4 real jobs recovered.
- [x] CI `tests` workflow green on this branch (verified post-push).
- [x] Re-review (incremental-high) confirmed the 🔴 fix, `## LGTM`, auto-merged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>