### PR TITLE
fix(email): bidirectional 36h jobalert/newsletter cooldown + subscriber history check

### DIFF
--- a/.github/workflows/check-subscriber-history.yml
+++ b/.github/workflows/check-subscriber-history.yml
@@ -1,0 +1,45 @@
+name: Check Subscriber History
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Email address to inspect (jobalert + newsletter send history)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON secret is not set"
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Query subscriber history (read-only)
+        env:
+          CHECK_EMAIL: ${{ inputs.email }}
+        run: node scripts/check-subscriber-history.mjs | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-subscriber-history.mjs
+++ b/scripts/check-subscriber-history.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Read-only Firestore inspector: prints the jobalert + newsletter send
+ * history for a single email address. Never writes to Firestore.
+ *
+ * Environment variables:
+ *   GOOGLE_APPLICATION_CREDENTIALS — Firebase service account for Firestore
+ *   CHECK_EMAIL                    — address to inspect (required)
+ *
+ * Usage:
+ *   CHECK_EMAIL=someone@example.com node scripts/check-subscriber-history.mjs
+ */
+
+import fs from 'node:fs';
+
+function fmtTs(ts) {
+  if (!ts) return null;
+  if (typeof ts.toDate === 'function') return ts.toDate().toISOString();
+  if (typeof ts === 'number') return new Date(ts).toISOString();
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? String(ts) : d.toISOString();
+}
+
+async function getFirestoreAdmin() {
+  const { initializeApp, cert, getApps, applicationDefault } = await import('firebase-admin/app');
+  const { getFirestore } = await import('firebase-admin/firestore');
+  if (getApps().length === 0) {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credPath || !fs.existsSync(credPath)) {
+      throw new Error('GOOGLE_APPLICATION_CREDENTIALS not set or file missing');
+    }
+    const cred = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
+    if (cred.project_id) {
+      initializeApp({ credential: cert(cred) });
+    } else {
+      initializeApp({ credential: applicationDefault(), projectId: 'frontaliere-ticino' });
+    }
+  }
+  return getFirestore();
+}
+
+function section(title) {
+  console.log(`\n## ${title}\n`);
+}
+
+async function main() {
+  const email = (process.env.CHECK_EMAIL || '').trim().toLowerCase();
+  if (!email) {
+    console.error('CHECK_EMAIL env var is required');
+    process.exit(1);
+  }
+
+  const db = await getFirestoreAdmin();
+
+  console.log(`# Subscriber history — ${email}`);
+
+  // ── job_alert_subscribers/{email} ──
+  section('job_alert_subscribers (root doc)');
+  const jaRootSnap = await db.collection('job_alert_subscribers').doc(email).get();
+  if (!jaRootSnap.exists) {
+    console.log('(no document)');
+  } else {
+    const d = jaRootSnap.data() || {};
+    console.log(JSON.stringify({
+      status: d.status ?? null,
+      last_sent_at: fmtTs(d.last_sent_at),
+      delivered_count: d.delivered_count ?? null,
+      last_delivered_at: fmtTs(d.last_delivered_at),
+      open_count: d.open_count ?? null,
+      last_open_at: fmtTs(d.last_open_at),
+      click_count: d.click_count ?? null,
+      last_click_at: fmtTs(d.last_click_at),
+      bounce_count: d.bounce_count ?? null,
+    }, null, 2));
+  }
+
+  // ── job_alert_subscribers/{email}/alerts/* ──
+  section('job_alert_subscribers/{email}/alerts');
+  const alertsSnap = await db.collection('job_alert_subscribers').doc(email).collection('alerts').get();
+  if (alertsSnap.empty) {
+    console.log('(no alerts)');
+  } else {
+    alertsSnap.forEach((doc) => {
+      const d = doc.data() || {};
+      const sentJobIds = d.sentJobIds || {};
+      const sentTimestamps = Object.values(sentJobIds)
+        .map((v) => (typeof v === 'number' ? v : (v?.toMillis ? v.toMillis() : null)))
+        .filter(Boolean)
+        .sort((a, b) => b - a);
+      console.log(`\nalert ${doc.id}:`);
+      console.log(JSON.stringify({
+        active: d.active ?? null,
+        frequency: d.frequency ?? null,
+        createdAt: fmtTs(d.createdAt),
+        lastMatchedAt: fmtTs(d.lastMatchedAt),
+        matchCount: d.matchCount ?? null,
+        sentJobsTracked: Object.keys(sentJobIds).length,
+        mostRecentSentJobAt: sentTimestamps[0] ? new Date(sentTimestamps[0]).toISOString() : null,
+        allSentJobTimestamps: sentTimestamps.map((t) => new Date(t).toISOString()),
+      }, null, 2));
+    });
+  }
+
+  // ── job_alert_subscribers/{email}/events (delivered) ──
+  section('job_alert_subscribers/{email}/events (delivery log)');
+  try {
+    const eventsSnap = await db.collection('job_alert_subscribers').doc(email)
+      .collection('events').orderBy('timestamp', 'desc').limit(100).get();
+    if (eventsSnap.empty) {
+      console.log('(no events)');
+    } else {
+      const rows = eventsSnap.docs.map((doc) => {
+        const d = doc.data() || {};
+        return { event_type: d.event_type ?? null, occurred_at: d.occurred_at ?? fmtTs(d.timestamp), provider: d.provider ?? null };
+      });
+      console.log(JSON.stringify(rows, null, 2));
+      const delivered = rows.filter((r) => r.event_type === 'delivered' || r.event_type === 'delivery');
+      console.log(`\nDelivered event count (last 100 events window): ${delivered.length}`);
+    }
+  } catch (e) {
+    console.log(`(events query failed: ${e?.message || e})`);
+  }
+
+  // ── newsletter_subscribers/{email} ──
+  section('newsletter_subscribers (root doc)');
+  const nlRootSnap = await db.collection('newsletter_subscribers').doc(email).get();
+  if (!nlRootSnap.exists) {
+    console.log('(no document)');
+  } else {
+    const d = nlRootSnap.data() || {};
+    console.log(JSON.stringify({
+      status: d.status ?? null,
+      isActive: d.isActive ?? null,
+      last_sent_at: fmtTs(d.last_sent_at),
+      send_count: d.send_count ?? null,
+      last_open_at: fmtTs(d.last_open_at),
+      open_count: d.open_count ?? null,
+      last_click_at: fmtTs(d.last_click_at),
+      click_count: d.click_count ?? null,
+    }, null, 2));
+  }
+
+  // ── newsletter_subscribers/{email}/campaign_deliveries ──
+  section('newsletter_subscribers/{email}/campaign_deliveries');
+  const deliveriesSnap = await db.collection('newsletter_subscribers').doc(email)
+    .collection('campaign_deliveries').get();
+  if (deliveriesSnap.empty) {
+    console.log('(no deliveries)');
+  } else {
+    const rows = deliveriesSnap.docs
+      .map((doc) => {
+        const d = doc.data() || {};
+        return { campaign_id: d.campaign_id ?? null, sent_at: fmtTs(d.sent_at), provider: d.provider ?? null };
+      })
+      .sort((a, b) => (b.sent_at || '').localeCompare(a.sent_at || ''));
+    console.log(JSON.stringify(rows, null, 2));
+    console.log(`\nTotal newsletter deliveries: ${rows.length}`);
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -1479,11 +1479,15 @@ async function main() {
   }
 
   // 4. Send emails
+  let failedEmailSet = new Set();
   if (DRY_RUN) {
     console.log('   🔵 DRY RUN — not sending emails');
   } else {
     const result = await sendBatch(emailsToSend);
     console.log(`   ✅ Sent ${result.sent} emails`);
+    failedEmailSet = new Set(
+      result.failedItems.map((item) => (item.recipient?.email || '').toLowerCase()).filter(Boolean),
+    );
 
     // 4b. Enqueue failed emails for retry on the next run
     if (result.failed > 0) {
@@ -1510,6 +1514,25 @@ async function main() {
       });
     });
     console.log('   📊 Firestore updated');
+
+    // 5b. Mirror last_sent_at onto job_alert_subscribers/{email} (root doc),
+    // the same field/shape newsletter_subscribers/{email}.last_sent_at already
+    // carries. This is what lets send-newsletter.mjs apply a symmetric 36h
+    // cooldown (see NEWSLETTER_COOLDOWN_MS above) — until this write existed,
+    // the newsletter had no way to know a job alert had just gone out.
+    const sentEmails = [...new Set(
+      emailsToSend
+        .map((email) => email.to.toLowerCase())
+        .filter((email) => !failedEmailSet.has(email)),
+    )];
+    if (sentEmails.length > 0) {
+      await commitInChunks(db, sentEmails, (batch, email) => {
+        batch.set(db.collection('job_alert_subscribers').doc(email), {
+          last_sent_at: FieldValue.serverTimestamp(),
+        }, { merge: true });
+      });
+      console.log(`   📬 last_sent_at recorded for ${sentEmails.length} job-alert recipient(s)`);
+    }
 
     // 6. Personalization enrichment (no-clobber). Consolidate every signal we
     // just read — browsing subdoc (filter usage, viewed-job cities/categories,

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1953,6 +1953,40 @@ async function main() {
     subscribers = await fetchSubscribers();
     console.log(`\ud83d\udce8 Send mode: ${subscribers.length} active subscribers`);
 
+    // ── Job-alert cooldown (symmetric to the 36h newsletter cooldown in
+    // send-job-alerts.mjs:NEWSLETTER_COOLDOWN_MS): skip subscribers who
+    // received a job alert in the last 36h, so nobody gets two automated
+    // emails within the same ~1.5-day window. Reads job_alert_subscribers/
+    // {email}.last_sent_at, written by send-job-alerts.mjs after each send.
+    // SKIP_JOB_ALERT_COOLDOWN=1 bypasses this (manual/test sends).
+    const JOB_ALERT_COOLDOWN_MS = process.env.SKIP_JOB_ALERT_COOLDOWN === '1' ? 0 : 36 * 60 * 60 * 1000;
+    if (JOB_ALERT_COOLDOWN_MS > 0 && db) {
+      const nowMs = Date.now();
+      const cooldownSet = new Set();
+      const emails = [...new Set(subscribers.map((s) => normalizeEmail(s.email)).filter(Boolean))];
+      const LOOKUP_CHUNK_SIZE = 200;
+      for (let i = 0; i < emails.length; i += LOOKUP_CHUNK_SIZE) {
+        const chunk = emails.slice(i, i + LOOKUP_CHUNK_SIZE);
+        try {
+          const refs = chunk.map((email) => db.collection('job_alert_subscribers').doc(email));
+          const snaps = await db.getAll(...refs);
+          snaps.forEach((snap, idx) => {
+            if (!snap.exists) return;
+            const lastSentAt = snap.data()?.last_sent_at;
+            if (!lastSentAt) return;
+            const ts = typeof lastSentAt.toMillis === 'function' ? lastSentAt.toMillis() : new Date(lastSentAt).getTime();
+            if (nowMs - ts < JOB_ALERT_COOLDOWN_MS) cooldownSet.add(chunk[idx]);
+          });
+        } catch (e) {
+          console.warn(`\u26a0\ufe0f  Job-alert cooldown lookup failed for ${chunk.length} email(s): ${e?.message || e}`);
+        }
+      }
+      if (cooldownSet.size > 0) {
+        const before = subscribers.length;
+        subscribers = subscribers.filter((s) => !cooldownSet.has(normalizeEmail(s.email)));
+        console.log(`\ud83d\udce8 Job-alert cooldown (36h): ${before - subscribers.length} subscriber(s) deferred (job alert sent recently)`);
+      }
+    }
     // ── Digest targeting ──
     // Design decision: By default, ALL subscribers receive the weekly Monday digest.
     // The subscriber `type` field (e.g., 'weekly_digest', 'general') is informational


### PR DESCRIPTION
## Summary
- The jobalert sender already skipped users who'd just received a newsletter (36h cooldown), but the newsletter sender had no equivalent check — a user could get a jobalert then a newsletter (or vice versa) less than 36h apart.
- `scripts/send-job-alerts.mjs` now mirrors `last_sent_at` onto `job_alert_subscribers/{email}` after each successful send (same shape `newsletter_subscribers/{email}.last_sent_at` already has).
- `scripts/send-newsletter.mjs`'s bulk send path now reads that field and defers subscribers who got a jobalert in the last 36h, symmetric to the existing jobalert → newsletter check. `SKIP_JOB_ALERT_COOLDOWN=1` bypasses it for manual/test sends, mirroring `SKIP_NEWSLETTER_COOLDOWN`.
- Adds a manual-only (`workflow_dispatch`), read-only `Check Subscriber History` workflow + `scripts/check-subscriber-history.mjs` to inspect a given email's jobalert/newsletter send history in Firestore (no writes) for verifying cooldown behavior.

## Test plan
- [x] `node --check` on both modified scripts and the new script
- [x] YAML syntax validated for the new workflow
- [ ] `npm test` (not run — `node_modules` not installed in this session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UFiYt6ZHGoYyNGPpMyNRTE)_