### PR TITLE
fix(ci): annota locale-segment-ok sul job-finder EN di swatchgroup (main rosso)

### DIFF
--- a/scripts/lib/omega-job-parser.mjs
+++ b/scripts/lib/omega-job-parser.mjs
@@ -61,6 +61,7 @@ const BASE_URL = 'https://www.swatchgroup.com';
 // jf_country=40 = Switzerland in the shared Swatch Group / brand taxonomy.
 const SWITZERLAND_COUNTRY_ID = '40';
 const listUrl = (page) =>
+  // locale-segment-ok: portale esterno swatchgroup.com — il job-finder di gruppo è crawlato deliberatamente nella sola versione EN (taxonomy jf_country stabile), nessun path per-locale nostro.
   `${BASE_URL}/en/job-finder?jf_country=${SWITZERLAND_COUNTRY_ID}&page=${page}`;
 // 92 Swiss jobs group-wide ≈ 10 pages today; hard cap so a pager regression
 // can never turn into an unbounded crawl.


### PR DESCRIPTION
## Implementato
- `scripts/lib/omega-job-parser.mjs`: annotazione `// locale-segment-ok: <motivo>` sulla riga del job-finder di gruppo (`${BASE_URL}/en/job-finder?...`). Il gate `check-hardcoded-locale-segments` è **rosso su main dal run 29091587467** (2026-07-10 12:08) e fa fallire il job vitest di ogni PR aperta in cascata, tenendo fermo il reviewer-loop. Il segmento `/en/` è legittimamente fisso: portale esterno swatchgroup.com crawlato deliberatamente nella sola versione EN (taxonomy `jf_country` stabile), esattamente il caso "portale esterno" previsto dall'allowlist inline del lint stesso. Nessun indebolimento del gate.
- Verifica locale: `node scripts/ci/check-hardcoded-locale-segments.mjs` → exit 0 (resta solo il warning pre-esistente su 2 voci baseline stantie, non bloccante); `npx vitest run tests/omega-crawler.test.ts` verde.

## Non implementato (ancora)
- Rigenerazione della baseline del lint (2 voci stantie segnalate come warning): pre-esistente e non bloccante, fuori dallo scope di questo unblock chirurgico.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_