### PR TITLE
fix(ai-models): reason 'nonretryable' sul ramo Gemini (review 🔴 #4073) + Haiku fallback attivo di default

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -99,23 +99,23 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
-      # ── Claude CLI Haiku fallback (opt-in) ──────────────────────────────
+      # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort, reached only after every free-tier model AND the
       # local/ollama fallback above have failed (scripts/lib/ai-models.mjs
       # AI_MODELS.CLAUDE_CLI_HAIKU, pinned below local/* by sortChainByScore).
       # Zero marginal cost: auth is CLAUDE_CODE_OAUTH_TOKEN (same Max-plan
       # subscription token already used by pr-review-loop.yml/issue-fix.yml),
-      # never ANTHROPIC_API_KEY. Two equivalent switches — either enables it:
-      #   • Remote Config flag ENABLE_HAIKU_ARTICLE_FALLBACK=1 (loaded into
-      #     $GITHUB_ENV by load-rc-env.mjs above), or
-      #   • repo variable ENABLE_HAIKU_ARTICLE_FALLBACK=1 (Settings → Secrets
-      #     and variables → Actions → Variables — no Firebase access needed).
-      # With both unset, getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns ''
-      # and the model is never offered — identical to today. The $GITHUB_ENV
-      # export below normalizes the repo-var path so ai-models.mjs sees the
-      # flag in process.env either way.
+      # never ANTHROPIC_API_KEY — which is why this is now enabled BY DEFAULT
+      # (owner request 2026-07-11: the recurring free-pool exhaustion deferrals
+      # must never zero production again). Kill-switch: set the repo variable
+      # ENABLE_HAIKU_ARTICLE_FALLBACK=0 (Settings → Secrets and variables →
+      # Actions → Variables) or the Remote Config flag to '0' — either
+      # disables the setup below, ai-models.mjs then never offers the model
+      # (getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns ''). The
+      # $GITHUB_ENV export normalizes the flag for ai-models.mjs's
+      # isClaudeCliFallbackEnabled regardless of which source enabled it.
       - name: Setup Claude CLI Haiku fallback
-        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK == '1' || vars.ENABLE_HAIKU_ARTICLE_FALLBACK == '1'
+        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0' && vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
         run: |
           npm install -g @anthropic-ai/claude-code
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -3313,7 +3313,14 @@ async function _callGeminiRaw(model, messages, opts) {
             _learnSchemaIncompatible(model);
           }
           if (nrc.markExhausted) {
-            markModelExhausted(model);
+            // 'nonretryable', NOT the default 'quota': this is the Gemini twin
+            // of the _callOpenAICompatible non-retryable branch, which already
+            // labels correctly. Left at the default, a 404/unknown-model here
+            // was persisted to the shared Firestore doc until midnight UTC as
+            // if it were a daily quota — exactly the over-persistence #4073
+            // removed (quota-only persist gate in _persistScoresToFirestore).
+            // Review 🔴 on #4073.
+            markModelExhausted(model, 'nonretryable');
             _stats.exhausted++;
           }
           const err = new Error(`[${model}] HTTP ${res.status}: ${raw.slice(0, 300)}`);

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -451,12 +451,17 @@ describe('local LLM fallback exhaustion never persists past the run (Firestore)'
     mod.markModelExhausted(mod.AI_MODELS.GPT4O, 'timeout');
     mod.markModelExhausted(mod.AI_MODELS.GPT4O_MINI, 'content');
     mod.markModelExhausted(mod.AI_MODELS.GEMINI_FLASH, 'quota');
+    // 'nonretryable' = 404 unknown-model / decommissioned id (the Gemini
+    // non-retryable branch labels with this reason since the #4073 review 🔴
+    // fix) — a static incompatibility, not a daily quota: must not persist.
+    mod.markModelExhausted(mod.AI_MODELS.GEMINI_PRO, 'nonretryable');
     await mod.flushScores();
 
     const key = (id: string) => id.replace(/\//g, '__');
     const persisted = store._all.models as Record<string, { exhaustedUntil: string | null }>;
     expect(persisted[key(mod.AI_MODELS.GPT4O)].exhaustedUntil).toBeNull();
     expect(persisted[key(mod.AI_MODELS.GPT4O_MINI)].exhaustedUntil).toBeNull();
+    expect(persisted[key(mod.AI_MODELS.GEMINI_PRO)].exhaustedUntil).toBeNull();
     expect(persisted[key(mod.AI_MODELS.GEMINI_FLASH)].exhaustedUntil).not.toBeNull();
   });
 


### PR DESCRIPTION
Follow-up della review su #4073 (mergiata dall'auto-merge prima che il 🔴 potesse atterrare nella stessa PR) + attivazione di default del last-resort Haiku richiesta dall'owner.

## Implementato

- `scripts/lib/ai-models.mjs` — il ramo Gemini per errori client non-retryable (404 unknown-model / decommissioned id via `classifyNonRetryableError`, `nrc.markExhausted`) ora chiama `markModelExhausted(model, 'nonretryable')` invece del default `'quota'`. Col gate quota-only introdotto da #4073 (`_persistScoresToFirestore`), il default mislabellava un'incompatibilità statica come quota giornaliera e la persisteva sul doc Firestore condiviso fino a mezzanotte UTC, bannando il modello per TUTTI i workflow — l'esatta over-persistence che #4073 rimuove. Allineato al path gemello `_callOpenAICompatible`, che etichetta già `'nonretryable'`. (Review 🔴 di #4073.)
- Verificati gli altri due call-site senza reason esplicito: il ramo daily-limit Gemini (`isDailyLimitError`) e il breaker 2×429 (`MAX_CONSECUTIVE_429`) restano correttamente sul default `'quota'` — semantica quota/rate-limit genuina, persistenza fino a mezzanotte voluta.
- `.github/workflows/generate-article.yml` — il fallback Claude CLI Haiku (ultimo della cascata, dopo ogni free-tier E il local/ollama) è ora **attivo di default** invece che opt-in: richiesta owner 2026-07-11, la rete di sicurezza contro i deferral "tutti i modelli esauriti" non deve dipendere da Firebase RC né da variabili repo (l'API Actions variables non è impostabile dall'ambiente). Costo marginale zero (`CLAUDE_CODE_OAUTH_TOKEN` Max-plan, mai `ANTHROPIC_API_KEY`). Kill-switch esplicito: repo var `ENABLE_HAIKU_ARTICLE_FALLBACK=0` o RC flag a `'0'`.
- Test: caso `'nonretryable'` → `exhaustedUntil: null` aggiunto al write-path quota-only in `tests/local-llm-fallback.test.ts`. Suite verdi: local-llm-fallback + ai-models-content-failures + quota-exhausted-classifier 33/33.

## Non implementato (ancora)

- Nessuno.

### Sibling-check: falsi positivi attesi

`ENABLE_HAIKU_ARTICLE_FALLBACK`/`CLAUDE_CLI` condivisi con `scripts/load-rc-env.mjs` (loader RC, invariato — il default-ON è lato workflow); token generici (`markModelExhausted`, `initScoreStore`) condivisi con i consumer dell'API score-store, che beneficiano del fix senza modifiche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuiXL8CGBBnoHVSJxcHuG