### PR TITLE
fix(generate-article): tutti gli slot al pool news — stop agli articoli "offerte" dal pool discovery

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -232,6 +232,18 @@ jobs:
           # local fallback (or any subset) on demand to validate/measure it
           # without waiting for the remote pool to exhaust naturally.
           AI_MODELS_FORCE_CHAIN: ${{ github.event.inputs.force_chain }}
+          # Slot routing: ALL slots → proven/news pool (owner request
+          # 2026-07-11: "sta pubblicando offerte non articoli" — the product
+          # intent is articles regenerated from the news sources). This is the
+          # spec § 13.2 rollback lever read by quotaController.decideSlot; it
+          # bypasses the discovery/demand pool ("offres fielmann", "stellen
+          # lugano" orphan-query pieces) whose 80-99 counter window the
+          # Jul 8-10 push outage had frozen the run counter into, making every
+          # post-fix publish draw discovery instead of news. To re-enable a
+          # discovery share, set the repo variable DISCOVERY_QUOTA_OVERRIDE
+          # to a 60-95 quota (e.g. 80 = 20% discovery) or to 'file' to fall
+          # back to the tuner-managed data/quota-state.json value.
+          DISCOVERY_QUOTA_OVERRIDE: ${{ vars.DISCOVERY_QUOTA_OVERRIDE || '100' }}
           # Section-aware wall-clock budget. The `frontaliere` pipeline is
           # gate-heavier than `svizzera`: it carries the frontaliere-density
           # relevance gate (>=8 keyword hits) on top of the shared fact-check /


### PR DESCRIPTION
Richiesta owner 2026-07-11: "sta pubblicando offerte non articoli" — i primi publish post-ripristino (#4073) sono usciti dal pool **discovery** (query di domanda SEO tipo "offres fielmann", "stellen lugano", incluse le orfane `discovery://` senza alcuna fonte dietro) o dal fallback evergreen professioni, non dalle fonti news.

**Root cause**: il quota controller assegna lo slot con `counter % 100 < quota → proven/news, altrimenti discovery` (quota=80 → contatori 80-99 = discovery). Il contatore avanza **solo a pubblicazione riuscita**, e il blackout push dell'8-10/07 lo ha congelato a 96 — dentro la finestra discovery. Alla ripresa ogni run ha quindi pescato discovery finché la coda 96→99 non si smaltiva (evidenza: run 29139597327, `SLOT_DECISION pool=discovery counter=96 quota=80`).

## Implementato

- `.github/workflows/generate-article.yml` — step "Generate article": `DISCOVERY_QUOTA_OVERRIDE: ${{ vars.DISCOVERY_QUOTA_OVERRIDE || '100' }}`. È la leva di rollback già prevista dalla spec (§ 13.2) e già letta da `quotaController.decideSlot`: con 100, **tutti gli slot vanno al pool proven/news** — l'intento di prodotto dichiarato dall'owner ("prendere gli articoli dalle fonti e rigenerarli"). Nessuna modifica di codice, nessun effetto sugli altri consumer del quota-state (il tuner giornaliero continua a scrivere `data/quota-state.json`, semplicemente non viene letto finché l'override è attivo).
- Reversibile senza deploy: repo var `DISCOVERY_QUOTA_OVERRIDE` a `60-95` per reintrodurre una quota discovery (es. `80` = 20%), oppure `file` (→ NaN → fallback in `decideSlot`) per tornare al valore gestito dal tuner.
- Test: `quotaController` 11/11 verdi (il percorso override era già coperto dalla suite esistente).

## Non implementato (ancora)

- Nessuno.

### Sibling-check: valutazione per-file dei 3 candidati (tutti falsi positivi — nessun lavoro dovuto)

Sono i file che **implementano** la leva usata da questa PR, non consumatori dell'antipattern:

- `scripts/lib/scheduler/quotaController.mjs` (`DISCOVERY_QUOTA_OVERRIDE`, `decideSlot`) — DEFINISCE l'override (spec § 13.2) letto da `process.env`; questa PR non ne cambia la semantica, la usa.
- `scripts/create-article.mjs` (`decideSlot`, `quotaController`) — caller dello slot dispatch; riceve l'env dal workflow senza modifiche necessarie.
- `scripts/tune-discovery-quota.mjs` (`quotaController`) — tuner giornaliero di `data/quota-state.json`; resta corretto e attivo, il suo output è semplicemente bypassato finché l'override è impostato (comportamento previsto dalla spec per la leva di rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuiXL8CGBBnoHVSJxcHuG