### PR TITLE
fix(create-article): pubblica news vere dalle fonti (decoder Google News) + anti-duplicati cross-sezione

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -126,6 +126,7 @@ import {
   incrementCounter as _incrementCounter,
 } from './lib/scheduler/quotaController.mjs';
 import { buildDiscoveryPool as _buildDiscoveryPool } from './lib/discovery/discoveryPool.mjs';
+import { decodeGoogleNewsUrl } from './lib/discovery/googleNewsUrlResolver.mjs';
 import { isNearDuplicate as _isNearDuplicateHeadline } from './lib/scheduler/slugSimilarity.mjs';
 import { fetchWordpressSearchHeadlines } from './lib/topic-sources/wordpressSearch.mjs';
 import { extractArticleText } from './lib/extract-article-text.mjs';
@@ -1676,6 +1677,28 @@ function readSectionMetaIt() {
   return read(SECTION_META_IT_FILE);
 }
 
+/**
+ * Read the IT meta source of ALL sections concatenated (frontaliere +
+ * svizzera). The id/SEO/i18n namespace is shared across sections (see
+ * getAllArticleIds), and evergreen topics (professioni, "assicurazione vita",
+ * "vivere nei Grigioni") are frequently generated in BOTH sections — but
+ * checkForDuplicates historically compared titles/excerpts only within the
+ * ACTIVE section's file, so cross-section near-duplicates slipped through
+ * (2026-07-11: `assicurazione-vita-…-frontaliere` in svizzera vs
+ * `…-frontalieri` in frontaliere, one letter apart). Both meta files use the
+ * same `'blog.article.<id>.title'` key shape, so the callers' regexes work
+ * unchanged over the concatenation.
+ */
+function readAllSectionsMetaIt() {
+  const parts = [];
+  for (const cfg of Object.values(ARTICLE_SECTION_CONFIGS)) {
+    try {
+      parts.push(read(`services/locales/${cfg.metaPrefix}-it.ts`));
+    } catch { /* missing/empty section file — skip */ }
+  }
+  return parts.join('\n');
+}
+
 function getIsoWeekKey(date = new Date()) {
   const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   const dayNum = d.getUTCDay() || 7; // Mon=1 .. Sun=7
@@ -1776,7 +1799,13 @@ function resolveGoogleNewsHeadline(candidate, provenHeadlines) {
       _resolvedGoogleNewsScore: bestScore,
     };
   }
-  return null;
+  // No direct-scan twin: instead of dropping the candidate (the old behaviour
+  // that discarded ~219 real frontaliere news items/run — run 29142084681,
+  // the "disoccupazione frontalieri" story), keep the wrapper and flag it for
+  // on-demand decoding at fetch time (decodeGoogleNewsUrl → real publisher
+  // URL via batchexecute). Lazy by design: only the headline the ranker
+  // actually picks pays the 2-request decode cost, not all 219.
+  return { ...candidate, _needsGoogleNewsDecode: true };
 }
 
 /** Extract slug words from a URL path for fuzzy matching against article IDs */
@@ -6251,7 +6280,10 @@ function preFlightEvergreenTopicCheck(candidate, existingArticles) {
 }
 
 function loadExistingArticleSummaries() {
-  const blogItSrc = readSectionMetaIt();
+  // Cross-section (2026-07-11): powers preFlightEvergreenCheck. Evergreen
+  // topics recur in both sections, so a sibling-section twin must be caught
+  // BEFORE spending an LLM generation cycle on a duplicate.
+  const blogItSrc = readAllSectionsMetaIt();
   const titleMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.title':\s*'([^']+)'/g)];
   const excerptMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.excerpt':\s*'([^']*)'/g)];
   const excerptsById = new Map(excerptMatches.map((m) => [m[1], m[2]]));
@@ -6302,7 +6334,9 @@ function preFlightEvergreenCheck(candidate) {
 //      otherwise fall through to title Jaccard.
 //   4. Thresholds unchanged because we're measuring on a meaningful denominator.
 function preFlightHeadlineCheck(headline) {
-  const blogItSrc = readSectionMetaIt();
+  // Cross-section (2026-07-11): a news headline already covered in the sibling
+  // section is a duplicate too (shared id/title namespace).
+  const blogItSrc = readAllSectionsMetaIt();
   const titleMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.title':\s*'([^']+)'/g)];
 
   const headlineWords = tokenizeIt(headline);
@@ -6342,8 +6376,12 @@ function preFlightHeadlineCheck(headline) {
 
 // ── Step 3a.2: Programmatic duplicate detection (multi-signal) ──
 function checkForDuplicates(data) {
-  // Read existing article titles AND excerpts from the section meta-it
-  const blogItSrc = readSectionMetaIt();
+  // Read existing article titles AND excerpts across ALL sections (frontaliere
+  // + svizzera). Cross-section coverage (was: active section only) so an
+  // evergreen already published in the sibling section is caught — the
+  // one-letter `…-frontaliere`/`…-frontalieri` twins, "vivere nei Grigioni",
+  // etc. (2026-07-11). Same shared id/title namespace as getAllArticleIds.
+  const blogItSrc = readAllSectionsMetaIt();
   const titleMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.title':\s*'([^']+)'/g)];
   const excerptMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.excerpt':\s*'([^']+)'/g)];
   const existingArticles = titleMatches.map(m => {
@@ -8034,6 +8072,13 @@ function gitAddAll(data) {
 // ── Main ────────────────────────────────────────────────────
 const MAX_DUPLICATE_RETRIES = 8;
 
+// Cap on how many Google-News candidates get folded into the proven pool per
+// run (see the GOOGLE_NEWS_INJECT block in main). Keeps the pre-spend topic
+// gate's classifier cost bounded — the pool already carries the direct-source
+// scan; this is a top-up of the frontaliere stories that only live on Google
+// News. Post-gate + dedup the effective count is far smaller.
+const GOOGLE_NEWS_INJECT_MAX = Number(process.env.GOOGLE_NEWS_INJECT_MAX) || 60;
+
 // Global wall-clock budget (2026-06-15). The generator has no overall deadline,
 // so a pathological run (slow free-tier models + fact-check treadmill) can balloon
 // to ~57min — past which the 30-min cron's next run cancels it anyway (5/60 runs
@@ -8270,6 +8315,37 @@ async function main() {
         headlines = headlines.filter((h) => !_isNearDuplicateHeadline(String(h.headline || ''), orphanStrings));
         if (beforeDedup > headlines.length) {
           console.error(`PROVEN_CROSS_POOL_DEDUP dropped=${beforeDedup - headlines.length} kept=${headlines.length}`);
+        }
+      }
+
+      // ── Inject Google-News candidates into the proven pool (2026-07-11) ──
+      // The 51/26 direct feeds carry mostly local cronaca; the genuinely
+      // frontaliere-relevant stories (es. "disoccupazione dei frontalieri")
+      // surface ONLY on Google News. Before this, they reached create-article
+      // solely via the discovery fallback and were dropped as "non risolto a
+      // fonte diretta" (run 29142084681: 219 dropped, 1 resolved → evergreen).
+      // We now fold the Google-News NEWS candidates (source='news' ONLY —
+      // never orphan/suggest, so no demand-query "offerte" leak in) into the
+      // proven pool so the same ranker + gates rank them alongside direct
+      // sources. Real-URL decoding is deferred to fetch time (lazy). Entirely
+      // best-effort: any failure leaves the direct-source pool untouched.
+      if (slotKind === 'proven' && evidenceForDiscovery) {
+        try {
+          _provenHeadlinesForDiscovery = headlines.slice();
+          const provenStrings = headlines.map((h) => String(h.headline || ''));
+          const gnPool = await _buildDiscoveryPool(evidenceForDiscovery, { provenHeadlines: provenStrings });
+          const newsOnly = (gnPool.candidates || []).filter((c) => c && c.source === 'news');
+          const gnHeadlines = _discoveryCandidatesToHeadlines(newsOnly).slice(0, GOOGLE_NEWS_INJECT_MAX);
+          if (gnHeadlines.length > 0) {
+            const beforeInject = headlines.length;
+            const existingUrls = new Set(headlines.map((h) => h.url));
+            for (const gh of gnHeadlines) {
+              if (!existingUrls.has(gh.url)) headlines.push(gh);
+            }
+            console.error(`GOOGLE_NEWS_INJECT news_candidates=${newsOnly.length} injected=${headlines.length - beforeInject} pool=${headlines.length}`);
+          }
+        } catch (err) {
+          console.error(`⚠️  Google-News injection into proven pool failed (non-blocking): ${err?.message || err}`);
         }
       }
     }
@@ -8558,6 +8634,31 @@ async function main() {
                 console.warn(`[generator] could not persist ranker state: ${e?.message || e}`);
               }
             };
+
+            // ── Lazy Google-News URL decode (2026-07-11) ──
+            // A candidate folded in from Google News carries the wrapper URL +
+            // _needsGoogleNewsDecode. Decode the real publisher URL NOW — only
+            // for the ONE headline the ranker picked, so the 2-request decode
+            // cost is bounded — so fetchPageContent below hits the actual
+            // source article. On decode failure, or when the decoded URL turns
+            // out already-used, skip to the next headline instead of fetching
+            // an unusable news.google.com wrapper (which would yield no source
+            // text → topic-gate abort → wasted attempt).
+            if (chosen?._needsGoogleNewsDecode || isGoogleNewsRssUrl(url)) {
+              const realUrl = await decodeGoogleNewsUrl(url);
+              if (!realUrl) {
+                console.error(`   ⏭️  Google News non decodificabile — provo un'altra headline: "${String(chosen.headline || '').slice(0, 60)}"`);
+                continue;
+              }
+              const used = isSourceUrlAlreadyUsed(realUrl);
+              if (used.used) {
+                console.error(`   🔗 Google News decodificata ma URL già usata (→ ${used.articleId}) — provo un'altra headline`);
+                continue;
+              }
+              console.error(`   🔓 Google News decodificata → fonte reale: ${realUrl.slice(0, 80)}`);
+              url = realUrl;
+              chosen = { ...chosen, url: realUrl, _resolvedFromGoogleNewsRss: chosen.url };
+            }
 
             // Attempt the full article generation + duplicate check
             await generateAndValidateArticle(url, chosen);

--- a/scripts/lib/discovery/googleNewsUrlResolver.mjs
+++ b/scripts/lib/discovery/googleNewsUrlResolver.mjs
@@ -1,0 +1,202 @@
+// scripts/lib/discovery/googleNewsUrlResolver.mjs
+//
+// Resolve a Google News RSS wrapper link
+// (https://news.google.com/rss/articles/<token>?...) to the REAL publisher
+// article URL, so the article generator can fetch the source content and
+// regenerate a news article from it.
+//
+// WHY (run 29142084681, 2026-07-11): create-article.mjs' Google News handling
+// only fuzzy-matched the RSS headline against the direct-source proven scan
+// (resolveGoogleNewsHeadline). News that lives ONLY on Google News (e.g. the
+// whole "disoccupazione dei frontalieri" story — the single most relevant
+// frontaliere topic that week) never matched a direct-scan headline, so ~219
+// candidates/run were dropped as "non risolto a fonte diretta" and the run
+// fell back to a generic evergreen. Decoding the real URL unlocks those.
+//
+// TWO wrapper formats exist:
+//   • OLD: the token after /articles/ is base64url of a small protobuf whose
+//     body contains the real URL as a plain UTF-8 string. Decodable OFFLINE.
+//   • NEW (2024+, current): the token is opaque (starts AU_yqL… once decoded)
+//     and the real URL must be fetched from Google's `batchexecute` RPC using
+//     a signature+timestamp scraped from the wrapper HTML. Verified working
+//     2026-07-11 against a live RSI link.
+//
+// Everything here is DEFENSIVE: any failure (network, format change, timeout)
+// returns null, and the caller keeps its existing fuzzy-match/skip behaviour.
+// A single format change on Google's side degrades to "same as before this
+// module existed", never worse.
+
+const BATCHEXECUTE_URL =
+  'https://news.google.com/_/DotsSplashUi/data/batchexecute';
+
+const DEFAULT_TIMEOUT_MS = 12000;
+
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+
+// Process-lifetime memo so the same wrapper is never decoded twice in a run
+// (the ranker may re-encounter a candidate across attempts). Keyed by the
+// wrapper token. Value is the resolved URL or null (negative caching).
+const _decodeCache = new Map();
+
+/** True when `rawUrl` is a Google News RSS article wrapper link. */
+export function isGoogleNewsRssUrl(rawUrl) {
+  try {
+    const u = new URL(rawUrl);
+    return (
+      u.hostname === 'news.google.com' &&
+      u.pathname.startsWith('/rss/articles/')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Extract the opaque article token from a wrapper link. */
+function extractToken(gnUrl) {
+  const m = String(gnUrl).match(/\/rss\/articles\/([^?/]+)/);
+  return m ? m[1] : null;
+}
+
+function abortableFetch(fetchImpl, url, init, timeoutMs) {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), timeoutMs);
+  if (t && typeof t.unref === 'function') t.unref();
+  return Promise.resolve(fetchImpl(url, { ...init, signal: ac.signal })).finally(
+    () => clearTimeout(t),
+  );
+}
+
+/**
+ * OFFLINE decode for the legacy format: base64url-decode the token and look
+ * for a plain http(s) URL in the bytes. Returns null for the opaque new
+ * format (no readable URL present).
+ */
+export function decodeOfflineBase64(token) {
+  if (!token || typeof token !== 'string') return null;
+  try {
+    let t = token;
+    // Legacy tokens are commonly prefixed with "CBMi" (protobuf framing).
+    if (t.startsWith('CBMi')) t = t.slice(4);
+    const b64 = t.replace(/-/g, '+').replace(/_/g, '/');
+    const buf = Buffer.from(b64, 'base64');
+    const s = buf.toString('utf8');
+    const m = s.match(/https?:\/\/[^\s\x00-\x1f"'\\<>]+/);
+    if (!m) return null;
+    const url = m[0];
+    // Reject the opaque-new-format sentinel and any google-internal URL.
+    if (/^https?:\/\/news\.google\.com/.test(url)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ONLINE decode for the current opaque format via Google's batchexecute RPC.
+ * Two requests: (1) GET the wrapper to scrape data-n-a-sg / data-n-a-ts,
+ * (2) POST batchexecute with the token to receive the real URL.
+ */
+async function decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs) {
+  // Step 1 — scrape signature + timestamp from the wrapper HTML.
+  const r1 = await abortableFetch(
+    fetchImpl,
+    gnUrl,
+    { headers: { 'User-Agent': USER_AGENT } },
+    timeoutMs,
+  );
+  if (!r1 || r1.ok === false) return null;
+  const html = await r1.text();
+  const sg = html.match(/data-n-a-sg="([^"]+)"/);
+  const ts = html.match(/data-n-a-ts="([^"]+)"/);
+  if (!sg || !ts) return null;
+
+  // Step 2 — batchexecute RPC. The inner payload shape mirrors Google's
+  // `Fbv4je`/`garturlreq` request (verified live 2026-07-11).
+  const inner = JSON.stringify([
+    'garturlreq',
+    [
+      ['X', 'X', ['X', 'X'], null, null, 1, 1, 'US:en', null, 1, null, null, null, null, null, 0, 1],
+      'X',
+      'X',
+      1,
+      [1, 1, 1],
+      1,
+      1,
+      null,
+      0,
+      0,
+      null,
+      0,
+    ],
+    token,
+    Number(ts[1]),
+    sg[1],
+  ]);
+  const body =
+    'f.req=' +
+    encodeURIComponent(JSON.stringify([[['Fbv4je', inner, null, 'generic']]]));
+
+  const r2 = await abortableFetch(
+    fetchImpl,
+    BATCHEXECUTE_URL,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'User-Agent': USER_AGENT,
+      },
+      body,
+    },
+    timeoutMs,
+  );
+  if (!r2 || r2.ok === false) return null;
+  const raw = await r2.text();
+  // The RPC payload is JSON-inside-JSON: forward slashes may arrive plain or
+  // escaped as \/ (and unicode-escaped as /). Normalise BEFORE matching
+  // so the URL regex captures the whole path either way.
+  const txt = raw.replace(/\\\//g, '/').replace(/\\u002f/gi, '/');
+  const m = txt.match(/https?:\/\/(?!news\.google\.com)[^\s"\\]+/);
+  if (!m) return null;
+  return m[0];
+}
+
+/**
+ * Resolve a Google News RSS wrapper link to the real publisher URL.
+ * Returns the real URL string, or null on any failure (caller falls back).
+ *
+ * @param {string} gnUrl
+ * @param {{ fetchImpl?: Function, timeoutMs?: number }} [opts]
+ * @returns {Promise<string|null>}
+ */
+export async function decodeGoogleNewsUrl(gnUrl, opts = {}) {
+  if (!isGoogleNewsRssUrl(gnUrl)) return null;
+  const token = extractToken(gnUrl);
+  if (!token) return null;
+  if (_decodeCache.has(token)) return _decodeCache.get(token);
+
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const timeoutMs = Number.isFinite(opts.timeoutMs)
+    ? Number(opts.timeoutMs)
+    : DEFAULT_TIMEOUT_MS;
+
+  let resolved = null;
+  // Cheap offline attempt first (legacy format) — no network.
+  resolved = decodeOfflineBase64(token);
+  if (!resolved) {
+    try {
+      resolved = await decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs);
+    } catch {
+      resolved = null;
+    }
+  }
+  _decodeCache.set(token, resolved);
+  return resolved;
+}
+
+/** Test-only: clear the process-lifetime decode cache. */
+export function _resetDecodeCache() {
+  _decodeCache.clear();
+}
+
+export default decodeGoogleNewsUrl;

--- a/tests/create-article-gates.test.ts
+++ b/tests/create-article-gates.test.ts
@@ -127,17 +127,25 @@ describe('create-article gate helpers', () => {
     expect(resolved?._resolvedFromGoogleNewsRss).toContain('news.google.com');
   });
 
-  it('drops unresolved Google News RSS wrappers before article generation', () => {
+  it('keeps unresolved Google News RSS wrappers flagged for lazy decode (was: dropped)', () => {
+    // Since 2026-07-11: a Google News item with no direct-scan twin is no
+    // longer discarded (that dropped ~219 real frontaliere news/run). Instead
+    // it is kept with the wrapper URL + _needsGoogleNewsDecode so the real
+    // publisher URL is resolved lazily at fetch time (decodeGoogleNewsUrl).
+    const wrapper = 'https://news.google.com/rss/articles/abc?oc=5';
     const resolved = resolveGoogleNewsHeadline(
       {
         headline: 'Permesso G frontalieri: notizia non presente nelle fonti dirette',
-        url: 'https://news.google.com/rss/articles/abc?oc=5',
+        url: wrapper,
         source: 'news',
       },
       [{ headline: 'Sciopero treni regionali in Lombardia', url: 'https://example.com/a', source: 'example' }],
     );
 
-    expect(resolved).toBeNull();
+    expect(resolved).not.toBeNull();
+    expect(resolved._needsGoogleNewsDecode).toBe(true);
+    // Wrapper URL preserved (real URL is decoded later, only for the picked one).
+    expect(resolved.url).toBe(wrapper);
   });
 
   it('blocks evergreen variants in an already-covered canonical family before LLM spend', () => {

--- a/tests/google-news-url-resolver.test.ts
+++ b/tests/google-news-url-resolver.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+// Tests for scripts/lib/discovery/googleNewsUrlResolver.mjs — decoding Google
+// News RSS wrapper links to the real publisher URL. Motivated by run
+// 29142084681 (2026-07-11): ~219 Google-News news candidates/run dropped as
+// "non risolto a fonte diretta", forcing the generator into evergreen. All
+// network is mocked — no live Google calls in CI.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mod = await import('../scripts/lib/discovery/googleNewsUrlResolver.mjs');
+const {
+  decodeGoogleNewsUrl,
+  decodeOfflineBase64,
+  isGoogleNewsRssUrl,
+  _resetDecodeCache,
+} = mod;
+
+// Build a legacy-format token: "CBMi" + base64url(protobuf-ish framing + url).
+function legacyToken(realUrl: string): string {
+  const urlBytes = Buffer.from(realUrl, 'utf8');
+  const buf = Buffer.concat([
+    Buffer.from([0x08, 0x13, 0x12, urlBytes.length]),
+    urlBytes,
+    Buffer.from([0x18, 0x01]),
+  ]);
+  const b64 = buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return 'CBMi' + b64;
+}
+
+afterEach(() => {
+  _resetDecodeCache();
+  vi.restoreAllMocks();
+});
+
+describe('isGoogleNewsRssUrl', () => {
+  it('recognises the RSS article wrapper and rejects everything else', () => {
+    expect(isGoogleNewsRssUrl('https://news.google.com/rss/articles/CBMiABC?oc=5')).toBe(true);
+    expect(isGoogleNewsRssUrl('https://www.rsi.ch/info/svizzera/x.html')).toBe(false);
+    expect(isGoogleNewsRssUrl('https://news.google.com/search?q=x')).toBe(false);
+    expect(isGoogleNewsRssUrl('not-a-url')).toBe(false);
+  });
+});
+
+describe('decodeOfflineBase64 (legacy format, no network)', () => {
+  it('recovers the real URL embedded in a legacy token', () => {
+    const real = 'https://www.rsi.ch/info/svizzera/Frontalieri-disoccupati-123.html';
+    expect(decodeOfflineBase64(legacyToken(real))).toBe(real);
+  });
+
+  it('returns null for an opaque new-format token (no embedded URL)', () => {
+    // "AU_yqL…" opaque tokens contain no readable http URL.
+    const opaque = Buffer.from('AU_yqLMxOpaqueTokenWithNoUrlInside').toString('base64');
+    expect(decodeOfflineBase64(opaque)).toBeNull();
+  });
+});
+
+describe('decodeGoogleNewsUrl', () => {
+  it('short-circuits offline for a legacy token without hitting the network', async () => {
+    const real = 'https://www.corriere.ch/economia/frontalieri-berna.html';
+    const fetchImpl = vi.fn();
+    const out = await decodeGoogleNewsUrl(
+      `https://news.google.com/rss/articles/${legacyToken(real)}?oc=5`,
+      { fetchImpl },
+    );
+    expect(out).toBe(real);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('resolves the opaque format via the batchexecute RPC (mocked)', async () => {
+    const real = 'https://www.rsi.ch/info/svizzera/riforma-disoccupazione-frontalieri.html';
+    const opaqueUrl =
+      'https://news.google.com/rss/articles/CBMiwAFAU_yqLMxKEXg6MIkNtxhJ1fBazfGIBuflaA?oc=5';
+    const fetchImpl = vi.fn(async (url: string, init?: any) => {
+      if (init?.method === 'POST') {
+        // batchexecute reply shape: leading )]}' then a JSON array whose
+        // inner string embeds the real URL. Google returns plain slashes
+        // (verified live 2026-07-11); the module also tolerates \/-escaped.
+        return { ok: true, text: async () => `)]}'\n[["wrb.fr","Fbv4je","[\\"garturlres\\",\\"${real}\\"]"]]` };
+      }
+      // wrapper HTML with signature + timestamp
+      return {
+        ok: true,
+        text: async () => '<c-wiz data-n-a-sg="SIG123" data-n-a-ts="1700000000">x</c-wiz>',
+      };
+    });
+    const out = await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl });
+    expect(out).toBe(real);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null (defensive) when the wrapper HTML lacks signature/timestamp', async () => {
+    const opaqueUrl = 'https://news.google.com/rss/articles/CBMiwAFAU_yqLMopaque?oc=5';
+    const fetchImpl = vi.fn(async () => ({ ok: true, text: async () => '<html>no sig here</html>' }));
+    expect(await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl })).toBeNull();
+  });
+
+  it('returns null (defensive) on network throw, never propagates', async () => {
+    const opaqueUrl = 'https://news.google.com/rss/articles/CBMiwAFAU_yqLMopaque2?oc=5';
+    const fetchImpl = vi.fn(async () => { throw new Error('network down'); });
+    expect(await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl })).toBeNull();
+  });
+
+  it('returns null for a non-Google-News URL', async () => {
+    expect(await decodeGoogleNewsUrl('https://www.rsi.ch/x.html')).toBeNull();
+  });
+
+  it('negative-caches so a failing token is not re-fetched', async () => {
+    const opaqueUrl = 'https://news.google.com/rss/articles/CBMiwAFAU_yqLMcached?oc=5';
+    const fetchImpl = vi.fn(async () => { throw new Error('boom'); });
+    expect(await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl })).toBeNull();
+    expect(await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl })).toBeNull();
+    // Only the first call touched the network; the second was served from cache.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/pre-flight-headline-check.test.ts
+++ b/tests/pre-flight-headline-check.test.ts
@@ -35,20 +35,23 @@ type CheckResult =
   | { duplicate: false }
   | { duplicate: true; signal: string; sim: number; existingId: string; existingTitle: string };
 
-// The function references `readSectionMetaIt`, `tokenizeIt`, `jaccardSim`,
-// `containmentSim`, and `filterDistinctive` — inject them. `readSectionMetaIt`
-// is the section-aware meta seam (frontaliere → blog-meta-it.ts); the dedup
-// contract under test is unchanged, so we inject the frontaliere reader.
-const readSectionMetaIt = () => read('services/locales/blog-meta-it.ts');
+// The function references `readAllSectionsMetaIt`, `tokenizeIt`, `jaccardSim`,
+// `containmentSim`, and `filterDistinctive` — inject them. Since 2026-07-11 the
+// meta seam is cross-section (readAllSectionsMetaIt → both blog-meta-it.ts and
+// blog-meta-ch-it.ts) so a sibling-section twin is caught too. The dedup
+// contract under test is unchanged; injecting the frontaliere reader alone
+// keeps these fixtures deterministic (the frontaliere corpus is the one they
+// were tuned against).
+const readAllSectionsMetaIt = () => read('services/locales/blog-meta-it.ts');
 const runner = new Function(
-  'readSectionMetaIt',
+  'readAllSectionsMetaIt',
   'tokenizeIt',
   'jaccardSim',
   'containmentSim',
   'filterDistinctive',
   `${fnMatch[0]}\nreturn preFlightHeadlineCheck;`,
 );
-const preFlightHeadlineCheck = runner(readSectionMetaIt, tokenizeIt, jaccardSim, containmentSim, filterDistinctive) as (
+const preFlightHeadlineCheck = runner(readAllSectionsMetaIt, tokenizeIt, jaccardSim, containmentSim, filterDistinctive) as (
   headline: string,
 ) => CheckResult;
 


### PR DESCRIPTION
Chiude la segnalazione owner *"sta pubblicando offerte non articoli"* / *"verifica se hanno prodotto articoli veri"*. Dopo i fix del blackout (#4073/#4075/#4077), la verifica sui run mostrava **0 articoli news veri su 6, tutti evergreen**.

**Root cause** (dai log, run 29142084681): le notizie frontaliere vere — es. l'intera vicenda *"disoccupazione dei frontalieri"* (Quadri, Gobbi, Berna vs Bruxelles) — arrivano **solo** via Google News, ma il resolver le ricollegava alla fonte con un semplice fuzzy-match dei titoli contro le 51 fonti dirette → **~219 news scartate / 1 risolta per run** → fallback evergreen. In più, l'anti-duplicati confrontava solo la sezione attiva → doppioni cross-sezione (`assicurazione-vita-…-frontaliere` in svizzera vs `…-frontalieri` in frontaliere, una lettera di differenza).

## Implementato

- **Nuovo `scripts/lib/discovery/googleNewsUrlResolver.mjs`** — decodifica il wrapper `news.google.com/rss/articles/<token>` all'URL reale del publisher via l'endpoint **batchexecute** (formato opaco attuale) con fallback base64 offline (formato legacy). Difensivo: ogni fallimento (rete, formato, timeout) → `null`, il chiamante mantiene il comportamento attuale → **zero regressione**. Cache in-memory (anche negativa). Verificato **live 3/3** su feed reale (RSI, RaiNews, TVS svizzera); **9 unit test** con `fetch` mockato (nessuna chiamata a Google in CI).
- **`create-article.mjs` — le news vere raggiungono il ranker**: `resolveGoogleNewsHeadline` non scarta più le news senza gemello diretto (le mantiene col wrapper + flag `_needsGoogleNewsDecode`). I candidati Google News (**solo `source='news'`, mai orphan/suggest → nessuna "offerta" rientra**) vengono immessi nel pool `proven` (cap `GOOGLE_NEWS_INJECT_MAX=60`) così lo **stesso ranker + gate** li valutano accanto alle fonti dirette. La decodifica dell'URL reale è **lazy**: solo la headline scelta dal ranker paga il costo (2 richieste), poi il fetch colpisce la fonte reale. Su decodifica fallita o URL già usata → si prova un'altra headline.
- **Anti-duplicati cross-sezione**: `checkForDuplicates`, `preFlightHeadlineCheck` e `loadExistingArticleSummaries` (→ `preFlightEvergreenCheck`) ora confrontano titoli/testi su **entrambe le sezioni** (nuova `readAllSectionsMetaIt`) invece che solo quella attiva. Il namespace id/title è già condiviso; gli evergreen ricorrono in entrambe le sezioni → un gemello nell'altra sezione viene bloccato **prima** di spendere il ciclo LLM. Verificato: i due `assicurazione-vita` ora rientrano nello stesso corpus di confronto.
- Nuova env `GOOGLE_NEWS_INJECT_MAX` (default 60, override via repo var per il tuning).

## Non implementato (ancora)

- Nessuno.

### Sibling-check: valutazione dei 14 candidati (tutti falsi positivi — collisione di token, nessun lavoro dovuto)

- `scripts/lib/it-text-similarity.mjs` (`checkForDuplicates`, `preFlightEvergreenCheck`) — libreria di similarità *usata da* checkForDuplicates; questa PR non cambia la logica di similarità, solo il **corpus** confrontato (cross-sezione). API invariata.
- `build-plugins/ogPagesPlugin.ts`, `seoHubsPlugin.ts`, `shared/articleArchiveUnion.ts`, `shared/articleReaders.ts` (`metaPrefix`) — leggono i file meta con la **loro** logica di build; `readAllSectionsMetaIt` è additiva lato generatore e non tocca il percorso di build. Nessun antipattern condiviso.
- `scripts/ci/check-sibling-patterns.mjs`, `scripts/lib/rfsm-fribourg-job-parser.mjs` (`extractToken`) — hanno una funzione `extractToken` **omonima ma non correlata** (tokenizzazione diversa); pura collisione di nome con la mia `extractToken` interna al decoder.
- `scripts/lib/discovery/discoveryPool.mjs` (`provenHeadlines`) — è l'API che questa PR **consuma** passando `provenHeadlines`; uso coerente col contratto esistente, nessuna modifica dovuta.
- `scripts/lib/scheduler/quotaController.mjs` (`slotKind`) — definisce `slotKind`; il mio `if (slotKind === 'proven')` ne è un consumatore coerente (stessa semantica introdotta in #4077).
- `scripts/lib/scoring/constants.mjs` (`checkForDuplicates`) — riferimento in commento/costante, non l'implementazione; nessun antipattern.
- Restanti 4 candidati: stessa classe (token generici `metaPrefix`/`provenHeadlines`/`checkForDuplicates`), nessuno condivide l'antipattern fixato.

### Note

Il decoder dipende da un endpoint non ufficiale di Google (batchexecute): può cambiare formato nel tempo. È **interamente difensivo** — se un giorno smettesse di risolvere, il pipeline torna al comportamento attuale (fuzzy-match/evergreen), senza rotture; il tasso `risolte/scartate` nei log segnala subito un eventuale degrado. Trigger di revert: se i log post-merge mostrano decodifiche a 0 per più run, il fix è inerte (non dannoso) e va rivista la logica batchexecute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuiXL8CGBBnoHVSJxcHuG