### PR TITLE
Ottimizzazione quota AI: titolo-cap retry su GPT-4o-mini

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -4827,7 +4827,12 @@ Rispondi SOLO con JSON valido, senza markdown.` },
               content: `Riformula il seguente titolo in italiano per il sito Frontaliere Ticino.\n\nTITOLO ATTUALE (${firstCap.originalLength} caratteri, troppo lungo):\n${itContent.title}\n\nVINCOLI OBBLIGATORI:\n- MASSIMO 60 caratteri totali (target 50-55).\n- NON includere il suffisso " | Frontaliere Ticino" (verrà aggiunto automaticamente).\n- Mantieni la keyword principale e il significato.\n- Stile giornalistico, niente clickbait.\n\nRispondi con JSON: {"title": "..."}`,
             },
           ],
-          { model: forceModel || GH_MODEL_HEAVY, temperature: 0.3, maxTokens: 200, jsonMode: true, timeout: 30_000 },
+          // Title reformulation is a short, low-stakes rewrite to ≤60 chars whose
+          // length floor is guaranteed by the deterministic capBlogTitle() below
+          // (and the try/catch falls back to the hard cap on any failure), so a
+          // premium GPT-4o call here is wasted quota — GPT-4o-mini reformulates a
+          // one-line title to a length target just as well. forceModel still wins.
+          { model: forceModel || GH_MODEL_LIGHT, temperature: 0.3, maxTokens: 200, jsonMode: true, timeout: 30_000 },
         );
         const retryParsed = JSON.parse(repairLlmJson(retryRaw));
         if (retryParsed?.title && typeof retryParsed.title === 'string') {


### PR DESCRIPTION
Ottimizzazione di costo/quota AI sulla pipeline di generazione articoli, indipendente da #3798. Un solo punto, quello dove il downgrade di modello è **provatamente senza rischio di qualità**.

## Implementato

- `scripts/create-article.mjs`: il retry di riformulazione del titolo (quando un titolo supera la soglia di lunghezza) passa da **GPT-4o** a **GPT-4o-mini**. È sicuro perché subito dopo gira sempre `capBlogTitle()` — un hard-cap **deterministico** che garantisce la lunghezza a prescindere dal modello, e il `try/catch` ripiega sul cap in caso di fallimento. È una riscrittura breve (≤60 char, 200 token), non il corpo dell'articolo. `forceModel` ha ancora precedenza; il path di generazione del corpo è intatto. 221 test title/create-article verdi.

## Non implementato (ancora)

Altri due punti di risparmio AI sono stati **individuati e verificati sul main corrente ma NON applicati**, perché toccano la qualità del corpo articolo (SEO/revenue) o il gate di sicurezza fact-check — sono decisioni di prodotto dell'owner, non downgrade sicuri:

- **Ordine della `MIN_WORDS_MODEL_ROTATION`**: l'attempt 1 è GPT-4o, cioè ri-tenta lo stesso modello che ha appena prodotto un articolo troppo corto. Riordinare (modello diverso/più economico per primo) potrebbe migliorare il tasso di successo e risparmiare quota, ma cambia quale modello genera il corpo che viene pubblicato, senza un pavimento deterministico di qualità (solo il conteggio parole è vincolato). Lista battle-tested con commenti storici → lasciata alla revisione owner.
- **Cache del fact-check**: il fact-check è il gate di sicurezza contro i fatti fabbricati (i commenti citano incidenti reali). Il beneficio della cache è marginale (chiave sul contenuto) e il rischio alto se sbagliata → raccomando di NON introdurla senza una revisione dedicata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M)_