### PR TITLE
hotfix(google-news-decoder): impedisci l'hang su body di risposta bloccato (run appeso 2h42m)

### DIFF
--- a/scripts/lib/discovery/googleNewsUrlResolver.mjs
+++ b/scripts/lib/discovery/googleNewsUrlResolver.mjs
@@ -81,13 +81,32 @@ function extractToken(gnUrl) {
   return m ? m[1] : null;
 }
 
-function abortableFetch(fetchImpl, url, init, timeoutMs) {
+/**
+ * Fetch a URL and read its body text under ONE AbortController deadline.
+ *
+ * CRITICAL (hotfix 2026-07-12, run 29202963318 hung 2h42m): the previous
+ * helper timed out only the fetch() (up to response headers) and returned the
+ * Response, so the caller's separate `await res.text()` ran with NO timeout.
+ * When news.google.com sent headers but then stalled the body, `.text()` hung
+ * forever — and the article generator's wall-clock budget can't interrupt a
+ * single in-flight await, so the whole run sat in "Generate article" until the
+ * 6h job timeout, blocking the concurrency-1 chain. Reading the body inside the
+ * same abort scope means a stalled body aborts at `timeoutMs` too. Returns the
+ * body text, or null on any non-ok/abort/error (caller falls back cleanly).
+ */
+async function fetchText(fetchImpl, url, init, timeoutMs) {
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), timeoutMs);
   if (t && typeof t.unref === 'function') t.unref();
-  return Promise.resolve(fetchImpl(url, { ...init, signal: ac.signal })).finally(
-    () => clearTimeout(t),
-  );
+  try {
+    const res = await fetchImpl(url, { ...init, signal: ac.signal });
+    if (!res || res.ok === false) return null;
+    return await res.text();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
 }
 
 /**
@@ -119,14 +138,13 @@ export function decodeOfflineBase64(token) {
  */
 async function decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs) {
   // Step 1 — scrape signature + timestamp from the wrapper HTML.
-  const r1 = await abortableFetch(
+  const html = await fetchText(
     fetchImpl,
     gnUrl,
     { headers: { 'User-Agent': USER_AGENT } },
     timeoutMs,
   );
-  if (!r1 || r1.ok === false) return null;
-  const html = await r1.text();
+  if (!html) return null;
   const sg = html.match(/data-n-a-sg="([^"]+)"/);
   const ts = html.match(/data-n-a-ts="([^"]+)"/);
   if (!sg || !ts) return null;
@@ -157,7 +175,7 @@ async function decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs) {
     'f.req=' +
     encodeURIComponent(JSON.stringify([[['Fbv4je', inner, null, 'generic']]]));
 
-  const r2 = await abortableFetch(
+  const raw = await fetchText(
     fetchImpl,
     BATCHEXECUTE_URL,
     {
@@ -170,8 +188,7 @@ async function decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs) {
     },
     timeoutMs,
   );
-  if (!r2 || r2.ok === false) return null;
-  const raw = await r2.text();
+  if (!raw) return null;
   // The RPC payload is JSON-inside-JSON: forward slashes may arrive plain or
   // escaped as \/ (and unicode-escaped as /). Normalise BEFORE matching
   // so the URL regex captures the whole path either way.
@@ -207,7 +224,18 @@ export async function decodeGoogleNewsUrl(gnUrl, opts = {}) {
   resolved = decodeOfflineBase64(token);
   if (!resolved) {
     try {
-      resolved = await decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs);
+      // Belt-and-suspenders total deadline: fetchText already bounds each
+      // request+body, but a fetchImpl that ignores the abort signal could
+      // still stall. Race the whole two-request decode against a hard cap so
+      // decodeGoogleNewsUrl can NEVER hang the caller (article generator).
+      const hardCapMs = timeoutMs * 2 + 5000;
+      resolved = await Promise.race([
+        decodeViaBatchExecute(gnUrl, token, fetchImpl, timeoutMs),
+        new Promise((res) => {
+          const t = setTimeout(() => res(null), hardCapMs);
+          if (t && typeof t.unref === 'function') t.unref();
+        }),
+      ]);
     } catch {
       resolved = null;
     }

--- a/scripts/scaffold-crawler.mjs
+++ b/scripts/scaffold-crawler.mjs
@@ -571,12 +571,13 @@ async function callApi(url, body = null) {
     };
     if (body) opts.body = JSON.stringify(body);
     const res = await fetch(url, opts);
-    clearTimeout(timer);
+    // clearTimeout in \`finally\` AFTER res.json() reads the body — keep the
+    // abort armed during the body read so a server that stalls the body aborts
+    // at timeoutMs instead of hanging the crawler forever (PR #4118).
     if (!res.ok) throw new Error(\`HTTP \${res.status} from API\`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/update-kronenhof-jobs.mjs
+++ b/scripts/update-kronenhof-jobs.mjs
@@ -123,6 +123,9 @@ function sleep(ms) {
 async function fetchJson(url) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  // clearTimeout in `finally`, AFTER `res.json()` reads the body — keeping the
+  // abort armed during the body read so a stalled body aborts at TIMEOUT_MS
+  // instead of hanging the crawler (same class as PR #4118 / review sibling).
   try {
     const res = await fetch(url, {
       signal: controller.signal,
@@ -131,12 +134,10 @@ async function fetchJson(url) {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/update-swiss-medical-network-jobs.mjs
+++ b/scripts/update-swiss-medical-network-jobs.mjs
@@ -84,14 +84,16 @@ function detectExperienceLevel(title = '') {
 
 async function fetchJson(url) {
   const timeoutMs = parseInt(process.env.JOBS_CRAWLER_TIMEOUT_MS || '20000', 10);
+  // clearTimeout in `finally` (after res.json() reads the body) so a stalled
+  // body aborts at timeoutMs instead of hanging (PR #4118 / review sibling).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)', Accept: 'application/json' } });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
     return await res.json();
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 /**

--- a/scripts/update-usi-jobs.mjs
+++ b/scripts/update-usi-jobs.mjs
@@ -287,9 +287,13 @@ function pdfFilenameId(pdfUrl = '') {
  * Returns the response body as text, or null on failure.
  */
 async function fetchPage(url, timeoutMs = 15000) {
+  // clearTimeout in `finally` (after the body read), NOT right after fetch():
+  // the abort timer must stay armed while `res.text()` streams the body, else
+  // a server that sends headers then stalls the body hangs the crawler forever
+  // (same class as the Google-News-decoder hang, PR #4118 / review sibling).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -299,7 +303,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -308,6 +311,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/tests/google-news-url-resolver.test.ts
+++ b/tests/google-news-url-resolver.test.ts
@@ -103,6 +103,25 @@ describe('decodeGoogleNewsUrl', () => {
     expect(await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl })).toBeNull();
   });
 
+  it('does NOT hang when the response body stalls — aborts at timeout → null (hotfix 2026-07-12)', async () => {
+    // Regression for run 29202963318 (hung 2h42m): headers arrive OK but the
+    // body never completes. fetchText reads the body under the same abort
+    // scope, so it aborts at timeoutMs instead of hanging forever.
+    const opaqueUrl = 'https://news.google.com/rss/articles/CBMiwAFAU_yqLMstall?oc=5';
+    const fetchImpl = vi.fn(async (_url: string, init: any) => ({
+      ok: true,
+      // body that never resolves on its own — only the abort signal ends it
+      text: () => new Promise((_res, rej) => {
+        init.signal.addEventListener('abort', () => rej(new Error('aborted')));
+      }),
+    }));
+    const started = Date.now();
+    const out = await decodeGoogleNewsUrl(opaqueUrl, { fetchImpl, timeoutMs: 50 });
+    expect(out).toBeNull();
+    // Completed promptly (abort fired) — nowhere near a hang.
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
   it('rejects a malformed batchexecute URL via validateRealUrl (host with no dot)', async () => {
     // The regex DOES match `https://localhost/foo` (valid chars), so this
     // reaches validateRealUrl — which rejects it because the host has no dot


### PR DESCRIPTION
**Hotfix urgente.** Un run di generate-article (29202963318) è rimasto **appeso 2h42min** allo step "Generate article", bloccando la catena (concurrency=1). Regressione del decoder Google News (#4090).

**Root cause**: l'`AbortController` copriva **solo la `fetch()`** (fino agli header); il successivo `await res.text()`/`.json()` girava **senza timeout**. Se il server invia gli header ma poi **stalla il body**, la lettura si appende all'infinito — e il wall-budget non può interrompere una singola `await` in volo → run bloccato fino al timeout job di 6h.

## Implementato

- **Decoder (`googleNewsUrlResolver.mjs`)** — `fetchText()` legge fetch **+ body** sotto lo **stesso `AbortController`** (abort a `timeoutMs`, default 12s → `null` → fallback), su entrambe le richieste di `decodeViaBatchExecute`. In più `Promise.race` con hard-cap totale (`timeoutMs*2+5s`): il decoder **non può mai** appendere il chiamante. Test: caso "body che stalla → `null` in <2s"; suite **14/14**.
- **Sibling-fix dei 4 🔴 della review** — stesso anti-pattern (`clearTimeout` **prima** della lettura del body) corretto spostando `clearTimeout` in `finally` **dopo** `res.json()`/`res.text()`:
  - `scripts/scaffold-crawler.mjs` (`callApi` nel template) — **il più importante**: scriveva il bug in ogni nuovo crawler `--ats=custom --source=api` generato.
  - `scripts/update-usi-jobs.mjs` (`fetchPage`), `scripts/update-kronenhof-jobs.mjs` (`fetchJson`), `scripts/update-swiss-medical-network-jobs.mjs` (`fetchJson`) — crawler attivi funnel-critical.

Le 3 `❓` adversarial della review non richiedono azione: l'abort-durante-body è comportamento standard undici (coperto dal test signal-aware); il negative-caching di `_decodeCache` è pre-esistente; l'unico path che chiama `decodeGoogleNewsUrl` in create-article è quello nel loop del ranker.

## Non implementato (ancora)

- **Anti-pattern pervasivo `clearTimeout`-prima-del-body in ~130 script crawler** (es. `dedicated-crawler-common.mjs`, `lonza`/`coop`/molti `*-job-parser.mjs`) — **stessa classe**, pre-esistente, verificata reale da un audit repo-wide in questa PR. NON corretta inline qui perché: (a) l'hotfix deve mergiare subito per sbloccare la produzione articoli; (b) 130 file inline è alto rischio in un hotfix; (c) questi crawler girano in **workflow separati** — un loro hang blocca il singolo crawler, non la catena generate-article. **Follow-up dovuto**: estrarre un helper condiviso `fetchTextWithTimeout`/`fetchJsonWithTimeout` (body-read sotto abort) e migrare i crawler, così il fix è centralizzato invece di 130 patch inline. Da fare come PR concatenata dedicata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuiXL8CGBBnoHVSJxcHuG