### PR TITLE
chore(crawlers): pulizia post-review #4114 (HQ alprose morto + export tpl detail non cablato)

### DIFF
--- a/scripts/lib/crawler-location-config.mjs
+++ b/scripts/lib/crawler-location-config.mjs
@@ -381,7 +381,6 @@ export const COMPANY_HQ = {
   'apg-sga':                      { city: 'Lugano',             canton: 'TI', postalCode: '6900', addressRegion: 'TI' },
   'imerys':                       { city: 'Bodio',              canton: 'TI', postalCode: '6743', addressRegion: 'TI' },
   'faulhaber':                    { city: 'Croglio',            canton: 'TI', postalCode: '6981', addressRegion: 'TI' },
-  'alprose':                      { city: 'Caslano',            canton: 'TI', postalCode: '6987', addressRegion: 'TI' },
   'kudelski-nagra':               { city: 'Lugano',             canton: 'TI', postalCode: '6900', addressRegion: 'TI' },
   'franklin-university':          { city: 'Sorengo',            canton: 'TI', postalCode: '6924', addressRegion: 'TI' },
   'elettra-1938':                 { city: 'Mendrisio',          canton: 'TI', postalCode: '6850', addressRegion: 'TI' },

--- a/scripts/lib/tpl-lugano-job-parser.mjs
+++ b/scripts/lib/tpl-lugano-job-parser.mjs
@@ -7,8 +7,11 @@
  *
  * This module exports:
  *   parseTplListingPage(html)  — extract job links from careers page
- *   parseTplDetailPage(html)   — extract job data from a detail page
  *   isTplJob(job)              — match TPL jobs in dataset
+ *
+ * Detail-page parsing is handled by the shared `runDedicatedBaseCrawler`
+ * generic engine (see scripts/update-tpl-lugano-jobs.mjs), not by a
+ * crawler-specific parser here.
  */
 
 function normalizeSpace(s = '') {
@@ -73,51 +76,6 @@ export function parseTplListingPage(html = '') {
   }
 
   return results;
-}
-
-/**
- * Extract job data from a TPL detail page.
- *
- * @param {string} html - Raw HTML of a job detail page
- * @returns {{ title: string, body: string, location: string } | null}
- */
-export function parseTplDetailPage(html = '') {
-  if (!html) return null;
-
-  const titleMatch = html.match(/<h[12][^>]*>([\s\S]*?)<\/h[12]>/i);
-  const title = titleMatch ? normalizeSpace(stripHtml(titleMatch[1])) : '';
-
-  // TPL jobs are always in Lugano area
-  const location = 'Lugano';
-
-  let body = '';
-  const contentMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
-    || html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
-  if (contentMatch) {
-    body = stripHtml(contentMatch[1]);
-  }
-
-  // Real tplsa.ch application pages (/2/50/candidati/?idhr=N) have no
-  // <main>/<article>: the job block runs from the <h1> (title + link to the
-  // PDF "capitolato" + application instructions) up to the generic "Menu2"
-  // accordion of company cards that follows it.
-  if (!body && titleMatch) {
-    const afterTitle = html.slice(titleMatch.index + titleMatch[0].length);
-    const endIdx = afterTitle.search(/<div[^>]*class\s*=\s*"[^"]*Menu2[^"]*"/i);
-    if (endIdx >= 0) {
-      body = stripHtml(afterTitle.slice(0, endIdx));
-    }
-  }
-
-  body = body
-    .split('\n')
-    .map((line) => normalizeSpace(line))
-    .filter(Boolean)
-    .join('\n');
-
-  if (!title && !body) return null;
-
-  return { title, body, location };
 }
 
 /**

--- a/tests/tpl-lugano-crawler.test.ts
+++ b/tests/tpl-lugano-crawler.test.ts
@@ -1,10 +1,9 @@
 /**
  * TPL (Trasporti Pubblici Luganesi) crawler parser tests
  *
- * Tests parseTplListingPage(), parseTplDetailPage(), and isTplJob().
+ * Tests parseTplListingPage() and isTplJob().
  * Fixtures recalced from the live tplsa.ch markup (2026-07):
  *   - listing: https://www.tplsa.ch/2/50/tpl-lavora-con-noi.html
- *   - detail:  https://www.tplsa.ch/2/50/candidati/?idhr=748
  * The CMS emits spaces around attribute `=` (href = "...") and links each
  * position to /2/50/candidati/?idhr=NNN; idhr=0 is the spontaneous form.
  */
@@ -12,7 +11,6 @@ import { describe, it, expect } from 'vitest';
 
 import {
   parseTplListingPage,
-  parseTplDetailPage,
   isTplJob,
   inferEmploymentType,
 } from '@/scripts/lib/tpl-lugano-job-parser.mjs';
@@ -77,36 +75,6 @@ const LISTING_NO_JOBS_HTML = `
 </body>
 </html>`;
 
-// ─── Fixture: Detail/application page (live markup, no <main>) ───
-const DETAIL_HTML = `
-<html>
-<body>
-	<section id="tabs">
-		<div class="container mt-5 mb-5">
-					<div class="col-md-12">
-						<h1>Specialista Risorse Umane </h1>
-						<a class="btn btn-candidati" href = "/repository/pdf/863388487-BandoSpecialistaRisorseUmane.pdf" target = "_blank" >Guarda il Capitolato <i class="fas fa-file"></i></a>
-					</div>
-					<div class="col-md-12">
-						<hr>
-							Le candidature per le posizioni vacanti, complete dei documenti richiesti, dovranno pervenire esclusivamente in formato elettronico all'indirizzo e-mail: <a href = "mailto:candidature@tplsa.ch">candidature@tplsa.ch</a>
-	    			</div>
-			<div class="row">
-				<div class="col-12 col-md-12 col-lg-12 col-xl-12">
-<div class="Menu2 mt-5" id="accordion">
-		<div class="card col-12 col-md-6 col-lg-3 col-xl-3">
-			<div class="card-body">
-					<p>La Trasporti Pubblici Luganesi SA (TPL) è la società di trasporto pubblico che serve la città di Lugano e i comuni limitrofi.</p>
-			</div>
-		</div>
-</div>
-				</div>
-			</div>
-    	</div>
-    </section>
-</body>
-</html>`;
-
 // ═══════════════════════════════════════════════════════════════
 // parseTplListingPage
 // ═══════════════════════════════════════════════════════════════
@@ -152,44 +120,6 @@ describe('parseTplListingPage', () => {
   it('returns empty array for empty input', () => {
     expect(parseTplListingPage('')).toEqual([]);
     expect(parseTplListingPage(null)).toEqual([]);
-  });
-});
-
-// ═══════════════════════════════════════════════════════════════
-// parseTplDetailPage
-// ═══════════════════════════════════════════════════════════════
-
-describe('parseTplDetailPage', () => {
-  it('extracts title from the live application page markup', () => {
-    const result = parseTplDetailPage(DETAIL_HTML);
-    expect(result).not.toBeNull();
-    expect(result.title).toBe('Specialista Risorse Umane');
-  });
-
-  it('sets location to Lugano', () => {
-    const result = parseTplDetailPage(DETAIL_HTML);
-    expect(result.location).toBe('Lugano');
-  });
-
-  it('extracts body up to the Menu2 accordion (no <main> on real pages)', () => {
-    const result = parseTplDetailPage(DETAIL_HTML);
-    expect(result.body).toContain('candidature@tplsa.ch');
-    expect(result.body).toContain('Guarda il Capitolato');
-    // Accordion boilerplate must not leak into the body
-    expect(result.body).not.toContain('società di trasporto pubblico');
-  });
-
-  it('still supports pages with a <main> container', () => {
-    const result = parseTplDetailPage(
-      '<main><h1>Autista Autobus</h1><p>Guida sulla rete di trasporto pubblico di Lugano.</p></main>'
-    );
-    expect(result.title).toBe('Autista Autobus');
-    expect(result.body).toContain('trasporto pubblico');
-  });
-
-  it('returns null for empty input', () => {
-    expect(parseTplDetailPage('')).toBeNull();
-    expect(parseTplDetailPage(null)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Implementato

Chiude i due nit 🟡 deferiti dalla review della PR #4114 (già mergiata):

- **`scripts/lib/crawler-location-config.mjs`**: rimossa la entry HQ `'alprose'` (Caslano/TI), chiave morta dopo il retire del crawler `alprose` in #4114. Nessun consumer residuo (`getCompanyDefaults('alprose')` non è chiamato da nessuna parte).
- **`scripts/lib/tpl-lugano-job-parser.mjs`**: droppato l'export `parseTplDetailPage` (+ i suoi 5 test e la fixture `DETAIL_HTML`). Il detail-parsing di produzione passa dal motore generico `runDedicatedBaseCrawler` (vedi `scripts/update-tpl-lugano-jobs.mjs`), non da questo parser — aveva **effetto runtime nullo**. Restano `parseTplListingPage`/`isTplJob` (usati davvero) e gli helper condivisi `stripHtml`/`normalizeSpace`. Il wire-in del parser custom richiederebbe modifiche al motore condiviso: sproporzionato per un nit, quindi la scelta è drop come suggerito dal reviewer.

## Test
- `npx vitest run` su 7 suite crawler (tpl-lugano, benteler, constellium, belimo, arosa, integra, stadtspital): **207 verdi**. Include benteler/constellium che importano `crawler-location-config` per confermare che la rimozione dell'HQ non li rompe.
- Nessun riferimento orfano residuo a `parseTplDetailPage` in tutto il repo.

## Non implementato (ancora)
- **stadt-chur (#3897)**: **non fixabile da CI** — indagine live 2026-07-12: l'intero host `jobs.chur.ch` (Rexx ATS) blocca ogni egress datacenter disponibile: fetch diretto `HTTP 000` (connessione TCP rifiutata), Jina Reader `HTTP 422 TimeoutError` (anche il browser headless di Jina non carica l'host, né il feed RSS né `stellenangebote.html`), proxy CORS pubblici `522`. Aggiungere un fallback Jina sarebbe codice morto (Jina non raggiunge comunque la fonte). La fonte è viva (posizioni reali confermate via egress clean-IP) ma richiede un proxy residenziale/clean-IP (es. pool Jina a pagamento con `JINA_API_KEY`, o un egress dedicato) oppure il retire — **decisione owner**. Diagnosi completa postata sull'issue #3897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_