### PR TITLE
Hardening script follow-up #3798 + chiusura gap test

### DIFF
--- a/scripts/probe-mailgun-scheduled.mjs
+++ b/scripts/probe-mailgun-scheduled.mjs
@@ -56,11 +56,18 @@ import { toRfc2822Utc } from './lib/email-cascade.mjs';
 
 function parseArgs(argv) {
   const out = { send: false };
+  // A flag's value must not itself look like another flag — otherwise e.g.
+  // `--to --days 3` (a missing --to value, `--days` typed right after by
+  // mistake) would silently swallow "--days" as the email address AND drop
+  // the real --days value ("3" is left over, matches no flag, and is
+  // silently ignored by this loop), producing a confusing bogus-recipient
+  // run instead of the clean "--to is required" error this should give.
+  const looksLikeFlag = (v) => typeof v === 'string' && v.startsWith('--');
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--send') { out.send = true; continue; }
-    if (a === '--to') { out.to = argv[++i]; continue; }
-    if (a === '--days') { out.days = argv[++i]; continue; }
+    if (a === '--to') { if (!looksLikeFlag(argv[i + 1])) out.to = argv[++i]; continue; }
+    if (a === '--days') { if (!looksLikeFlag(argv[i + 1])) out.days = argv[++i]; continue; }
     if (a === '--help' || a === '-h') { out.help = true; continue; }
   }
   return out;

--- a/scripts/report-send-hour-impact.mjs
+++ b/scripts/report-send-hour-impact.mjs
@@ -47,25 +47,64 @@
  * Env: GOOGLE_APPLICATION_CREDENTIALS (Firebase SA), GCLOUD_PROJECT (optional).
  */
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const SMALL_SAMPLE_THRESHOLD = 100;
 const BATCH_PAGE_SIZE = 200;
 const SUBCOLLECTION_CONCURRENCY = 20;
+const DEFAULT_DAYS = 30;
 
-const args = process.argv.slice(2);
-const JSON_OUT = args.includes('--json');
-
-function argValue(flag) {
+export function argValue(args, flag) {
   const i = args.indexOf(flag);
   return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
 }
 
-const DAYS = Number(argValue('--days')) || 30;
-const SINCE_RAW = argValue('--since');
-let SINCE_DATE = null;
-if (SINCE_RAW) {
-  const parsed = new Date(`${SINCE_RAW}T00:00:00.000Z`);
-  if (!Number.isNaN(parsed.getTime())) SINCE_DATE = parsed;
-  else console.warn(`⚠️  --since "${SINCE_RAW}" is not a valid YYYY-MM-DD date — ignoring the pre/post split.`);
+/**
+ * `--days` is a lookback window, so it must be a finite positive number.
+ * Bug this guards against: `Number(raw) || DEFAULT_DAYS` (the previous
+ * implementation) only falls back to the default for `NaN`/`0` — a negative
+ * value like `--days -5` is truthy and survives untouched, which then makes
+ * `cutoffDate = now - DAYS*24h` land 5 days in the FUTURE. The query still
+ * "succeeds" (0 rows, since nothing is dated in the future), so the report
+ * silently prints "Nothing to report" instead of erroring on the bad input.
+ * @param {string|null} raw - the raw --days value, or null when the flag was omitted
+ * @returns {{ days: number, warning: string|null }}
+ */
+export function parseDaysArg(raw) {
+  if (raw === null) return { days: DEFAULT_DAYS, warning: null };
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    return { days: DEFAULT_DAYS, warning: `⚠️  --days "${raw}" must be a positive number — using the default (${DEFAULT_DAYS}).` };
+  }
+  return { days: n, warning: null };
+}
+
+/**
+ * Strict YYYY-MM-DD parse for `--since`. Rejects malformed strings AND
+ * calendar-invalid-but-JS-Date-"helpfully"-rolled-over dates: plain
+ * `new Date("2026-02-30T00:00:00.000Z")` silently returns 2026-03-02 instead
+ * of throwing, which would silently shift the pre/post split boundary by
+ * however many days the invalid date overflowed by, with no warning at all
+ * (the previous implementation only checked `Number.isNaN(parsed.getTime())`,
+ * which a rolled-over date never triggers). This round-trips the parsed
+ * UTC components against the input and rejects on mismatch instead.
+ * @param {string|null} raw
+ * @returns {{ date: Date|null, warning: string|null }}
+ */
+export function parseSinceArg(raw) {
+  if (!raw) return { date: null, warning: null };
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  const invalidWarning = `⚠️  --since "${raw}" is not a valid YYYY-MM-DD date — ignoring the pre/post split.`;
+  if (!m) return { date: null, warning: invalidWarning };
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  const [, y, mo, d] = m;
+  const roundTrips = !Number.isNaN(parsed.getTime())
+    && parsed.getUTCFullYear() === Number(y)
+    && parsed.getUTCMonth() + 1 === Number(mo)
+    && parsed.getUTCDate() === Number(d);
+  if (!roundTrips) return { date: null, warning: invalidWarning };
+  return { date: parsed, warning: null };
 }
 
 /** Thrown when a collectionGroup query needs a Firestore index that doesn't exist. */
@@ -91,12 +130,12 @@ async function initFirebase() {
   return { admin: a, db: a.firestore() };
 }
 
-function normalizeEmail(value) {
+export function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
 }
 
 /** Mirrors functions/src/lib/deliveryDocId.js buildDeliveryDocId (kept in sync by hand — read-only report, no import to avoid a functions/ → scripts/ runtime dependency). */
-function buildCanonicalDeliveryDocId(campaignId, email) {
+export function buildCanonicalDeliveryDocId(campaignId, email) {
   return `${campaignId}__${normalizeEmail(email)}`.replace(/[^a-z0-9@._-]+/gi, '-');
 }
 
@@ -204,27 +243,27 @@ async function loadEvents(db, cutoffDate) {
 
 // ── Aggregation ──────────────────────────────────────────────────────────
 
-const IMMEDIATE_LABEL = 'immediate/pre-feature';
-const GROUP_ORDER = ['personal', 'global', IMMEDIATE_LABEL];
+export const IMMEDIATE_LABEL = 'immediate/pre-feature';
+export const GROUP_ORDER = ['personal', 'global', IMMEDIATE_LABEL];
 
-function emptyCell() {
+export function emptyCell() {
   return { deliveries: 0, opens: 0, clicks: 0 };
 }
 
-function newSegment() {
+export function newSegment() {
   const cells = {};
   for (const g of GROUP_ORDER) cells[g] = emptyCell();
   return cells;
 }
 
-const pct = (n, d) => (d > 0 ? (100 * n) / d : 0);
+export const pct = (n, d) => (d > 0 ? (100 * n) / d : 0);
 
 /**
  * @param {FirebaseFirestore.QueryDocumentSnapshot[]} deliveryDocs
  * @param {FirebaseFirestore.QueryDocumentSnapshot[]} eventDocs
  * @param {Date|null} sinceDate - when set, returns { before, after } segments; else { combined }
  */
-function aggregate(deliveryDocs, eventDocs, sinceDate) {
+export function aggregate(deliveryDocs, eventDocs, sinceDate) {
   // Only newsletter events carry campaign_id (job_alert_subscribers events use
   // alert_id instead) — collectionGroup('events') pulls from BOTH collections
   // since they share the subcollection name, so filter to newsletter ones.
@@ -283,7 +322,7 @@ function aggregate(deliveryDocs, eventDocs, sinceDate) {
 
 // ── Reporting ────────────────────────────────────────────────────────────
 
-function formatSegmentTable(title, cells) {
+export function formatSegmentTable(title, cells) {
   const lines = [];
   lines.push(title);
   lines.push('  group                    deliveries    opens  open-rate    clicks  click-rate');
@@ -300,7 +339,7 @@ function formatSegmentTable(title, cells) {
   return lines.join('\n');
 }
 
-function comparisonLine(label, cellA, cellB, nameA, nameB) {
+export function comparisonLine(label, cellA, cellB, nameA, nameB) {
   if (cellA.deliveries === 0 || cellB.deliveries === 0) {
     return `${label}: insufficient data (${nameA}=${cellA.deliveries}, ${nameB}=${cellB.deliveries} deliveries)`;
   }
@@ -324,7 +363,50 @@ function printSegment(name, cells) {
   console.log(comparisonLine('  → personal vs global   ', cells.personal, cells.global, 'personal', 'global'));
 }
 
+function printHelp() {
+  console.log(`
+report-send-hour-impact.mjs — READ-ONLY validation report for feature #3798
+(per-user scheduled-send time personalization). Compares open/click rate
+between subscribers sent at their personal preferred hour, the site-wide
+global hour, and the pre-feature immediate send.
+
+Usage:
+  node scripts/report-send-hour-impact.mjs                    # last 30 days
+  node scripts/report-send-hour-impact.mjs --days 60
+  node scripts/report-send-hour-impact.mjs --since 2026-07-01  # pre/post split
+  node scripts/report-send-hour-impact.mjs --json
+
+Options:
+  --days <N>       Lookback window in days. Default: 30. Must be > 0.
+  --since <DATE>   YYYY-MM-DD. Splits the window into before/on-after this date.
+  --json           Emit a single JSON object on stdout instead of the table.
+  --help, -h       Show this help.
+
+Read-only: no Firestore writes, no emails sent. Exit code is always 0.
+Env: GOOGLE_APPLICATION_CREDENTIALS (Firebase SA), GCLOUD_PROJECT (optional).
+`);
+}
+
 async function main() {
+  const argv = process.argv.slice(2);
+
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  const JSON_OUT = argv.includes('--json');
+  const { days: DAYS, warning: daysWarning } = parseDaysArg(argValue(argv, '--days'));
+  const SINCE_RAW = argValue(argv, '--since');
+  const { date: SINCE_DATE, warning: sinceWarning } = parseSinceArg(SINCE_RAW);
+  // console.warn → stderr, never stdout, so these are safe to print
+  // unconditionally without corrupting `--json`'s stdout output.
+  if (daysWarning) console.warn(daysWarning);
+  if (sinceWarning) console.warn(sinceWarning);
+  if (SINCE_DATE && SINCE_DATE.getTime() > Date.now()) {
+    console.warn(`⚠️  --since "${SINCE_RAW}" is in the future — the "after" segment will be empty.`);
+  }
+
   const now = new Date();
   const cutoffDate = new Date(now.getTime() - DAYS * 24 * 60 * 60 * 1000);
   const queryFloor = SINCE_DATE && SINCE_DATE < cutoffDate ? SINCE_DATE : cutoffDate;
@@ -350,8 +432,14 @@ async function main() {
   ]);
 
   if (deliveryDocs.length === 0) {
-    console.log('⚠️  No campaign_deliveries found in this window. Nothing to report.');
-    if (JSON_OUT) console.log(JSON.stringify({ deliveries: 0 }, null, 2));
+    // JSON mode must emit ONLY valid JSON on stdout (a consumer piping this
+    // into `jq`/JSON.parse would otherwise choke on the human-readable
+    // warning line printed ahead of it — this used to print both).
+    if (JSON_OUT) {
+      console.log(JSON.stringify({ deliveries: 0 }, null, 2));
+    } else {
+      console.log('⚠️  No campaign_deliveries found in this window. Nothing to report.');
+    }
     process.exit(0);
   }
 
@@ -379,8 +467,13 @@ async function main() {
   console.log(`\n(Fallback per-subscriber query used: ${usedFallback ? 'yes' : 'no'}; ${droppedNonCanonical} non-canonical duplicate delivery doc(s) ignored.)\n`);
 }
 
-main().catch((err) => {
-  // Report, not a gate: log the failure but never fail the process.
-  console.error('❌ Report failed to complete:', err?.message || err);
-  process.exit(0);
-});
+// Run only when invoked directly (node scripts/report-send-hour-impact.mjs);
+// the pure aggregation/parsing functions above stay importable for tests
+// without triggering a live Firestore connection attempt.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    // Report, not a gate: log the failure but never fail the process.
+    console.error('❌ Report failed to complete:', err?.message || err);
+    process.exit(0);
+  });
+}

--- a/tests/preferred-send-hour.test.ts
+++ b/tests/preferred-send-hour.test.ts
@@ -347,3 +347,56 @@ describe('refreshPreferredSendHour — staleness gate (#3798 code review)', () =
     expect(result.updated).toBe(true);
   });
 });
+
+// Gap flagged by #3798 code review: the catch block (mirrors refreshEngagementScore's
+// swallow-and-console.warn idiom) had no direct test forcing it to actually execute.
+// Both possible throw sites inside the try are exercised separately: the initial
+// subscriberRef.get() (staleness-gate read) and the events subcollection query.
+describe('refreshPreferredSendHour — error handling (catch path, #3798 code review)', () => {
+  it('swallows a thrown error from subscriberRef.get() and returns { updated: false } without writing', async () => {
+    const sets: Array<{ data: unknown; opts?: unknown }> = [];
+    const ref = {
+      get: async () => {
+        throw new Error('boom-get');
+      },
+      set: async (data: unknown, opts?: unknown) => {
+        sets.push({ data, opts });
+      },
+      collection: () => {
+        throw new Error('should not reach the events collection when get() already threw');
+      },
+    };
+
+    const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
+
+    expect(result).toEqual({ updated: false });
+    expect(sets.length).toBe(0);
+  });
+
+  it('swallows a thrown error from the events subcollection query and returns { updated: false } without writing', async () => {
+    const sets: Array<{ data: unknown; opts?: unknown }> = [];
+    const ref = {
+      get: async () => ({ exists: false, data: () => null }),
+      set: async (data: unknown, opts?: unknown) => {
+        sets.push({ data, opts });
+      },
+      collection: (name: string) => {
+        if (name !== 'events') throw new Error(`unexpected subcollection: ${name}`);
+        return {
+          orderBy: () => ({
+            limit: () => ({
+              get: async () => {
+                throw new Error('boom-events-query');
+              },
+            }),
+          }),
+        };
+      },
+    };
+
+    const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
+
+    expect(result).toEqual({ updated: false });
+    expect(sets.length).toBe(0);
+  });
+});

--- a/tests/report-send-hour-impact.test.ts
+++ b/tests/report-send-hour-impact.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregate,
+  pct,
+  comparisonLine,
+  formatSegmentTable,
+  emptyCell,
+  newSegment,
+  buildCanonicalDeliveryDocId,
+  normalizeEmail,
+  parseDaysArg,
+  parseSinceArg,
+  argValue,
+  GROUP_ORDER,
+  IMMEDIATE_LABEL,
+} from '../scripts/report-send-hour-impact.mjs';
+
+// ── Fixture helpers ──────────────────────────────────────────────────────
+// `aggregate()` only reads `doc.id` and `doc.data()` off each item (it never
+// touches `doc.ref` when `data().email` is already set — `d.email || ...`
+// short-circuits before the ref-chasing fallback runs), so a plain object
+// with those two members is a faithful stand-in for a Firestore
+// QueryDocumentSnapshot here. No Firestore mocking needed.
+
+function deliveryDoc({ campaignId, email, sentAt, sendTimeSource = null, opened = false, clicked = false, messageId = null, canonicalId = true }: {
+  campaignId: string; email: string; sentAt: Date; sendTimeSource?: string | null;
+  opened?: boolean; clicked?: boolean; messageId?: string | null; canonicalId?: boolean;
+}) {
+  const id = canonicalId
+    ? buildCanonicalDeliveryDocId(campaignId, email)
+    : `${campaignId}_${normalizeEmail(email)}`; // single-underscore webhook-doc shape
+  return {
+    id,
+    data: () => ({
+      email: normalizeEmail(email),
+      campaign_id: campaignId,
+      sent_at: sentAt,
+      send_time_source: sendTimeSource,
+      message_id: messageId,
+      opened_at: opened ? sentAt : null,
+      clicked_at: clicked ? sentAt : null,
+    }),
+  };
+}
+
+function eventDoc({ campaignId, email, type, messageId = null }: {
+  campaignId?: string; email: string; type: 'open' | 'click'; messageId?: string | null;
+}) {
+  return {
+    id: `evt-${Math.random()}`,
+    data: () => ({
+      email: normalizeEmail(email),
+      campaign_id: campaignId ?? null,
+      event_type: type,
+      message_id: messageId,
+    }),
+  };
+}
+
+const CAMPAIGN = 'weekly_2026-07-01';
+
+describe('pct', () => {
+  it('returns 0 instead of dividing by zero when deliveries is 0', () => {
+    expect(pct(0, 0)).toBe(0);
+    expect(pct(5, 0)).toBe(0);
+  });
+
+  it('computes a normal percentage', () => {
+    expect(pct(25, 100)).toBe(25);
+    expect(pct(1, 3)).toBeCloseTo(33.333, 2);
+  });
+});
+
+describe('aggregate — normal case with mixed groups', () => {
+  it('buckets by send_time_source and computes per-group open/click rates', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'personal1@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal', opened: true }),
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'personal2@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'global1@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'global', clicked: true }),
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'immediate1@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: null }),
+    ];
+    const { segments, droppedNonCanonical } = aggregate(deliveries, [], null);
+    expect(droppedNonCanonical).toBe(0);
+    expect(segments.combined.personal).toEqual({ deliveries: 2, opens: 1, clicks: 0 });
+    expect(segments.combined.global).toEqual({ deliveries: 1, opens: 0, clicks: 1 });
+    expect(segments.combined[IMMEDIATE_LABEL]).toEqual({ deliveries: 1, opens: 0, clicks: 0 });
+    expect(pct(segments.combined.personal.opens, segments.combined.personal.deliveries)).toBe(50);
+  });
+
+  it('cross-checks opens/clicks against the events subcollection (webhook-doc providers), ORing with opened_at/clicked_at', () => {
+    const deliveries = [
+      // No opened_at/clicked_at on the delivery doc itself (as for the 4
+      // non-Resend webhook providers) — only the events subcollection knows.
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'viaevents@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+    ];
+    const events = [
+      eventDoc({ campaignId: CAMPAIGN, email: 'viaevents@x.com', type: 'open' }),
+      eventDoc({ campaignId: CAMPAIGN, email: 'viaevents@x.com', type: 'click' }),
+    ];
+    const { segments } = aggregate(deliveries, events, null);
+    expect(segments.combined.personal).toEqual({ deliveries: 1, opens: 1, clicks: 1 });
+  });
+
+  it('matches an event to its delivery by message_id when email differs (namespaced key, no collision)', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'a@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'global', messageId: 'msg-1' }),
+    ];
+    const events = [eventDoc({ campaignId: CAMPAIGN, email: 'a@x.com', type: 'open', messageId: 'msg-1' })];
+    const { segments } = aggregate(deliveries, events, null);
+    expect(segments.combined.global.opens).toBe(1);
+  });
+});
+
+describe('aggregate — deliveries=0 (no division by zero, no crash)', () => {
+  it('returns all-zero cells for an empty input, never NaN/Infinity', () => {
+    const { segments, droppedNonCanonical } = aggregate([], [], null);
+    expect(droppedNonCanonical).toBe(0);
+    for (const g of GROUP_ORDER) {
+      expect(segments.combined[g]).toEqual({ deliveries: 0, opens: 0, clicks: 0 });
+      expect(pct(segments.combined[g].opens, segments.combined[g].deliveries)).toBe(0);
+    }
+  });
+
+  it('comparisonLine reports "insufficient data" instead of NaN% when one side has 0 deliveries', () => {
+    const line = comparisonLine('test', emptyCell(), emptyCell(), 'a', 'b');
+    expect(line).toContain('insufficient data');
+    expect(line).not.toContain('NaN');
+    expect(line).not.toContain('Infinity');
+  });
+});
+
+describe('aggregate — canonical vs non-canonical delivery doc dedup', () => {
+  it('drops the non-Resend webhook duplicate (single-underscore id) instead of double-counting', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'dup@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal', canonicalId: true }),
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'dup@x.com', sentAt: new Date('2026-07-05T10:00:01Z'), sendTimeSource: 'personal', canonicalId: false }),
+    ];
+    const { segments, droppedNonCanonical } = aggregate(deliveries, [], null);
+    expect(segments.combined.personal.deliveries).toBe(1);
+    expect(droppedNonCanonical).toBe(1);
+  });
+
+  it('skips delivery docs missing sent_at (webhook-only stub docs, not real sends)', () => {
+    const stub = { id: buildCanonicalDeliveryDocId(CAMPAIGN, 'stub@x.com'), data: () => ({ email: 'stub@x.com', campaign_id: CAMPAIGN, sent_at: null }) };
+    const { segments } = aggregate([stub], [], null);
+    expect(segments.combined.personal.deliveries + segments.combined.global.deliveries + segments.combined[IMMEDIATE_LABEL].deliveries).toBe(0);
+  });
+});
+
+describe('aggregate — events filtering (job-alert cross-collection leakage)', () => {
+  it('ignores events with no campaign_id (job_alert_subscribers events use alert_id, not campaign_id)', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'a@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+    ];
+    const jobAlertEvent = { id: 'evt-1', data: () => ({ email: 'a@x.com', event_type: 'open' /* no campaign_id */ }) };
+    const { segments } = aggregate(deliveries, [jobAlertEvent], null);
+    expect(segments.combined.personal.opens).toBe(0);
+  });
+
+  it('ignores non open/click event types (delivered/bounce/etc.)', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'a@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+    ];
+    const bounceEvent = eventDoc({ campaignId: CAMPAIGN, email: 'a@x.com', type: 'bounce' as unknown as 'open' });
+    const { segments } = aggregate(deliveries, [bounceEvent], null);
+    expect(segments.combined.personal.opens).toBe(0);
+  });
+});
+
+describe('aggregate — since-date boundary (before/after split)', () => {
+  const since = new Date('2026-07-10T00:00:00.000Z');
+
+  it('a delivery sent exactly at the since instant lands in "after" (>=, not >)', () => {
+    const exactlyAt = deliveryDoc({ campaignId: CAMPAIGN, email: 'boundary@x.com', sentAt: new Date(since), sendTimeSource: 'personal' });
+    const { segments } = aggregate([exactlyAt], [], since);
+    expect(segments.after.personal.deliveries).toBe(1);
+    expect(segments.before.personal.deliveries).toBe(0);
+  });
+
+  it('one millisecond before the since instant lands in "before"', () => {
+    const justBefore = deliveryDoc({ campaignId: CAMPAIGN, email: 'boundary2@x.com', sentAt: new Date(since.getTime() - 1), sendTimeSource: 'personal' });
+    const { segments } = aggregate([justBefore], [], since);
+    expect(segments.before.personal.deliveries).toBe(1);
+    expect(segments.after.personal.deliveries).toBe(0);
+  });
+
+  it('reads a Firestore Timestamp-shaped sent_at (toDate()) the same as a plain Date', () => {
+    const fakeTimestamp = { toDate: () => new Date(since.getTime() + 1000) };
+    const doc = {
+      id: buildCanonicalDeliveryDocId(CAMPAIGN, 'ts@x.com'),
+      data: () => ({ email: 'ts@x.com', campaign_id: CAMPAIGN, sent_at: fakeTimestamp, send_time_source: 'global' }),
+    };
+    const { segments } = aggregate([doc], [], since);
+    expect(segments.after.global.deliveries).toBe(1);
+  });
+});
+
+describe('n<100 small-sample flagging (SMALL_SAMPLE_THRESHOLD)', () => {
+  it('formatSegmentTable annotates a group with fewer than 100 deliveries as not significant', () => {
+    const cells = newSegment();
+    cells.personal = { deliveries: 42, opens: 10, clicks: 2 };
+    const table = formatSegmentTable('title', cells);
+    expect(table).toContain('n<100, not significant');
+  });
+
+  it('does NOT flag a group with >= 100 deliveries', () => {
+    const cells = newSegment();
+    cells.personal = { deliveries: 150, opens: 30, clicks: 5 };
+    const table = formatSegmentTable('title', cells);
+    const personalLine = table.split('\n').find((l) => l.trim().startsWith('personal'));
+    expect(personalLine).toBeDefined();
+    expect(personalLine).not.toContain('not significant');
+  });
+
+  it('comparisonLine flags [not significant] when either side is below the threshold', () => {
+    const small = { deliveries: 10, opens: 5, clicks: 1 };
+    const big = { deliveries: 500, opens: 250, clicks: 50 };
+    expect(comparisonLine('x', small, big, 'a', 'b')).toContain('not significant');
+    expect(comparisonLine('x', big, big, 'a', 'b')).not.toContain('not significant');
+  });
+});
+
+describe('parseDaysArg — off-by-one / invalid-input hardening', () => {
+  it('defaults to 30 when the flag is absent', () => {
+    expect(parseDaysArg(null)).toEqual({ days: 30, warning: null });
+  });
+
+  it('rejects a negative value instead of silently using it as a future cutoff', () => {
+    // Bug this regression-tests: `Number(raw) || 30` treats -5 as truthy and
+    // keeps it, which computes a cutoff date in the FUTURE (now - (-5)d).
+    const { days, warning } = parseDaysArg('-5');
+    expect(days).toBe(30);
+    expect(warning).toMatch(/positive number/);
+  });
+
+  it('rejects zero and NaN, falling back to the default with a warning', () => {
+    expect(parseDaysArg('0').days).toBe(30);
+    expect(parseDaysArg('abc').days).toBe(30);
+    expect(parseDaysArg('abc').warning).toMatch(/positive number/);
+  });
+
+  it('accepts a valid positive value with no warning', () => {
+    expect(parseDaysArg('60')).toEqual({ days: 60, warning: null });
+  });
+});
+
+describe('parseSinceArg — calendar-invalid date hardening', () => {
+  it('accepts a valid YYYY-MM-DD date', () => {
+    const { date, warning } = parseSinceArg('2026-07-01');
+    expect(warning).toBeNull();
+    expect(date?.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('rejects a calendar-invalid date instead of silently rolling it over', () => {
+    // Bug this regression-tests: plain `new Date("2026-02-30T00:00:00.000Z")`
+    // silently returns 2026-03-02 (JS Date rolls over out-of-range fields)
+    // instead of failing, which would shift the pre/post split with zero
+    // warning to the operator.
+    const { date, warning } = parseSinceArg('2026-02-30');
+    expect(date).toBeNull();
+    expect(warning).toMatch(/not a valid/);
+  });
+
+  it('rejects a malformed string', () => {
+    const { date, warning } = parseSinceArg('not-a-date');
+    expect(date).toBeNull();
+    expect(warning).toMatch(/not a valid/);
+  });
+
+  it('returns no date and no warning when omitted', () => {
+    expect(parseSinceArg(null)).toEqual({ date: null, warning: null });
+  });
+});
+
+describe('argValue', () => {
+  it('reads the value following a flag', () => {
+    expect(argValue(['--days', '7'], '--days')).toBe('7');
+  });
+
+  it('returns null when the flag is absent or has no following value', () => {
+    expect(argValue(['--json'], '--days')).toBeNull();
+    expect(argValue(['--days'], '--days')).toBeNull();
+  });
+});
+
+describe('normalizeEmail / buildCanonicalDeliveryDocId', () => {
+  it('lowercases and trims email, and matches functions/src/lib/deliveryDocId.js\'s double-underscore shape', () => {
+    expect(normalizeEmail('  User@Example.COM  ')).toBe('user@example.com');
+    expect(buildCanonicalDeliveryDocId('weekly_2026-07-01', 'User@Example.com')).toBe('weekly_2026-07-01__user@example.com');
+  });
+});

--- a/tests/send-schedule.test.ts
+++ b/tests/send-schedule.test.ts
@@ -82,6 +82,25 @@ describe('computeScheduledSendAt', () => {
     const iso = computeScheduledSendAt({ preferredHourUtc: 7, email: 'anyone@example.com', now: NOW }) as string;
     expect(iso).toMatch(/:\d{2}:00\.000Z$/);
   });
+
+  it('is deterministic and does not throw when email is empty, null, or undefined (String(email || "") fallback)', () => {
+    const emptyIso = computeScheduledSendAt({ preferredHourUtc: 5, email: '', now: NOW });
+    const nullIso = computeScheduledSendAt({ preferredHourUtc: 5, email: null as never, now: NOW });
+    const undefinedIso = computeScheduledSendAt({ preferredHourUtc: 5, email: undefined as never, now: NOW });
+    expect(emptyIso).not.toBeNull();
+    // null/undefined collapse to the same '' input as an explicit empty string,
+    // so all three must land on the exact same jittered minute.
+    expect(nullIso).toBe(emptyIso);
+    expect(undefinedIso).toBe(emptyIso);
+  });
+
+  it('is deterministic for an email containing unicode characters', () => {
+    const email = 'ünïçødé.ключ.例え@münchen.example';
+    const iso1 = computeScheduledSendAt({ preferredHourUtc: 5, email, now: NOW });
+    const iso2 = computeScheduledSendAt({ preferredHourUtc: 5, email, now: NOW });
+    expect(iso1).not.toBeNull();
+    expect(iso1).toBe(iso2);
+  });
 });
 
 describe('resolveEffectivePreferredHour', () => {


### PR DESCRIPTION
Passaggio autonomo di hardening sui due script nuovi meno scrutinati della feature #3798 (girano presto su dati/account reali) e chiusura dei gap di copertura test segnalati in review. Nessun cambiamento di contratto CLI/output per input validi.

## Implementato

**`scripts/report-send-hour-impact.mjs`** (girerà su Firestore di produzione tra ~2 settimane) — 3 bug reali fixati:
- `--json` su finestra vuota stampava una riga di warning su stdout prima del JSON → rompeva `... --json | jq`. Ora il warning è solo in modalità tabellare; `--json` emette JSON puro.
- `--days` negativo (truthy, sopravviveva a `Number(raw) || 30`) → cutoff nel futuro e report vuoto silenzioso. Ora rifiutato → default 30.
- `--since` con data calendario-invalida (es. `2026-02-30`) veniva arrotolata da `Date()` spostando il confine before/after senza avviso. Ora round-trip dei componenti Y/M/D e rifiuto del mismatch.
- Aggiunti `--help` reale, warning se `--since` è nel futuro, e refactor del parsing CLI dentro `main()` dietro guard di invocazione diretta (per rendere importabili le funzioni pure di aggregazione).

**`scripts/probe-mailgun-scheduled.mjs`**:
- `--to`/`--days` non consumano più il token successivo se è un altro flag (`--to --days 3` ora dà errore pulito invece di usare `"--days"` come destinatario).

**Test**: nuovo `tests/report-send-hour-impact.test.ts` (28 test, funzioni pure di aggregazione + parser CLI, nessun mock Firestore); aggiunti il path di errore di `refreshPreferredSendHour` e gli edge-case del jitter (email vuota/null/unicode). Suite interessata: 171 verdi.

## Non implementato (ancora)

- **Esecuzione probe Mailgun** e **validazione engagement post-merge** — azioni owner (credenziali reali / dati tra ~2 settimane), invariate.
- **2 leve AI** (reorder `MIN_WORDS_MODEL_ROTATION`, cache fact-check) — restano decisioni di prodotto/qualità dell'owner, non applicate di proposito.
- **Nota per reviewer futuri**: `report-send-hour-impact.mjs` `GROUP_ORDER` non ha un bucket `fallback-doc`; oggi impossibile per la newsletter (`send-newsletter.mjs` non passa `fallbackDoc`), ma se un domani lo passasse quelle delivery finirebbero nel gruppo `immediate`. Non fixato per non alterare il contratto di output per uno scenario oggi irraggiungibile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M)_