### PR TITLE
fix(crawlers): anti-hang sweep — clearTimeout dopo la lettura del body su 134 crawler

### DIFF
--- a/components/shared/EmailInput.tsx
+++ b/components/shared/EmailInput.tsx
@@ -156,21 +156,26 @@ export function validateEmailStrict(emailStr: string): { valid: boolean; reason?
  * Falls back to true on network/timeout errors (fail-open).
  */
 export async function checkMxRecord(domain: string): Promise<boolean> {
- try {
  const controller = new AbortController();
  const timer = setTimeout(() => controller.abort(), 4000);
+ try {
  const res = await fetch(
  `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=MX`,
  { signal: controller.signal },
  );
- clearTimeout(timer);
  if (!res.ok) return true; // fail-open
+ // clearTimeout must run AFTER the body is read (in finally), not right after
+ // fetch(): the abort timer has to stay armed across res.json() so a stalled
+ // response body still trips the 4s timeout and the newsletter form never gets
+ // stuck on status:'loading'. See #4123 (anti-hang sweep).
  const data = await res.json();
  // Status 0 = NOERROR; Answer array contains MX records
  if (data.Status === 3) return false; // NXDOMAIN — domain doesn't exist
  return Array.isArray(data.Answer) && data.Answer.length > 0;
  } catch {
  return true; // fail-open on network error
+ } finally {
+ clearTimeout(timer);
  }
 }
 

--- a/functions/src/exchangeRate.js
+++ b/functions/src/exchangeRate.js
@@ -17,13 +17,16 @@ export async function handleGetExchangeRate() {
     return { status: 200, body: { ok: false, rate: null, error: 'not_configured' } };
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
     const res = await fetch(`${TWELVEDATA_URL}&apikey=${encodeURIComponent(apiKey)}`, {
       signal: controller.signal,
     });
-    clearTimeout(timeout);
+    // clearTimeout must run AFTER the body is fully read, not right after
+    // fetch() resolves: the AbortController has to stay armed across res.json()
+    // so a server that stalls the response body still trips the 5s timeout
+    // instead of hanging the Cloud Function. See #4123 (anti-hang sweep).
     const data = await res.json().catch(() => ({}));
     if (data?.rate) {
       return { status: 200, body: { ok: true, rate: parseFloat(data.rate) } };
@@ -31,5 +34,7 @@ export async function handleGetExchangeRate() {
     return { status: 200, body: { ok: false, rate: null, error: data?.message || 'no_rate' } };
   } catch (error) {
     return { status: 200, body: { ok: false, rate: null, error: error instanceof Error ? error.message : 'fetch_failed' } };
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/scripts/fetch-mebeko-equivalence.mjs
+++ b/scripts/fetch-mebeko-equivalence.mjs
@@ -79,11 +79,11 @@ async function fetchWithTimeout(url, timeoutMs = 10000) {
       signal: ctl.signal,
       headers: { 'User-Agent': 'FrontaliereTicino-AE3/1.0 (+https://frontaliereticino.ch)' },
     });
-    clearTimeout(t);
     return res.ok ? await res.text() : null;
   } catch {
-    clearTimeout(t);
     return null;
+  } finally {
+    clearTimeout(t);
   }
 }
 

--- a/scripts/fetch-sefri-equivalence.mjs
+++ b/scripts/fetch-sefri-equivalence.mjs
@@ -147,11 +147,11 @@ async function fetchWithTimeout(url, timeoutMs = 10000) {
       signal: ctl.signal,
       headers: { 'User-Agent': 'FrontaliereTicino-AE3/1.0 (+https://frontaliereticino.ch)' },
     });
-    clearTimeout(t);
     return res.ok ? await res.text() : null;
   } catch {
-    clearTimeout(t);
     return null;
+  } finally {
+    clearTimeout(t);
   }
 }
 

--- a/scripts/lib/adus-klinik-job-parser.mjs
+++ b/scripts/lib/adus-klinik-job-parser.mjs
@@ -174,12 +174,10 @@ async function fetchText(url) {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/rss+xml,application/xml,text/xml,*/*' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/alpiq-job-parser.mjs
+++ b/scripts/lib/alpiq-job-parser.mjs
@@ -230,7 +230,6 @@ export async function fetchAlpiqListingPages(maxPages = 10, timeoutMs = 15000) {
         headers: { Accept: 'text/html', 'User-Agent': UA },
         redirect: 'follow',
       });
-      clearTimeout(timer);
       if (!res.ok) break;
       const html = await res.text();
       if (looksLikeAntiBotChallenge(html)) {
@@ -255,9 +254,10 @@ export async function fetchAlpiqListingPages(maxPages = 10, timeoutMs = 15000) {
         if (isSwissLocation(j.location)) allJobs.push(j);
       }
     } catch (err) {
-      clearTimeout(timer);
       console.warn(`\u26a0\ufe0f Failed to fetch Alpiq page ${page}: ${err.message}`);
       break;
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/scripts/lib/arxada-job-parser.mjs
+++ b/scripts/lib/arxada-job-parser.mjs
@@ -125,9 +125,9 @@ function detectEmploymentType(timeType = '') {
  */
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -140,7 +140,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`\u26a0\ufe0f HTTP ${res.status} for ${url}`);
       return null;
@@ -149,6 +148,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`\u26a0\ufe0f Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/bachtelen-job-parser.mjs
+++ b/scripts/lib/bachtelen-job-parser.mjs
@@ -79,12 +79,10 @@ async function fetchJson(url, timeoutMs = 20000) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/badrutts-palace-job-parser.mjs
+++ b/scripts/lib/badrutts-palace-job-parser.mjs
@@ -192,12 +192,10 @@ async function fetchRssFeed() {
         'Accept-Language': 'en-GB,en;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from RSS feed`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/baronie-job-parser.mjs
+++ b/scripts/lib/baronie-job-parser.mjs
@@ -267,7 +267,6 @@ export async function fetchBaronieJobUrls(timeoutMs = 15000) {
       headers: { Accept: 'text/html', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const html = await res.text();
 

--- a/scripts/lib/bcvs-job-parser.mjs
+++ b/scripts/lib/bcvs-job-parser.mjs
@@ -139,12 +139,10 @@ async function fetchHtml(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/berner-montage-job-parser.mjs
+++ b/scripts/lib/berner-montage-job-parser.mjs
@@ -141,12 +141,10 @@ async function fetchCareerPage() {
       signal: controller.signal,
       headers: BROWSER_HEADERS,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from career page`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -163,7 +161,6 @@ async function fetchDetailPage(url) {
       signal: controller.signal,
       headers: BROWSER_HEADERS,
     });
-    clearTimeout(timer);
     if (!res.ok) return null;
     const html = await res.text();
 
@@ -207,6 +204,8 @@ async function fetchDetailPage(url) {
     return null;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/bitfinex-job-parser.mjs
+++ b/scripts/lib/bitfinex-job-parser.mjs
@@ -203,9 +203,9 @@ function dedupeBitfinexJobs(jobs) {
  */
 async function fetchJobListings() {
   console.log(`   Fetching from: ${API_URL}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 25000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 25000);
     const res = await fetch(API_URL, {
       signal: controller.signal,
       headers: {
@@ -213,7 +213,6 @@ async function fetchJobListings() {
         'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`   ⚠️ HTTP ${res.status} from Recruitee API`);
       return [];
@@ -225,6 +224,8 @@ async function fetchJobListings() {
   } catch (err) {
     console.warn(`   ⚠️ Fetch failed: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/bls-job-parser.mjs
+++ b/scripts/lib/bls-job-parser.mjs
@@ -125,12 +125,10 @@ async function fetchHtml(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/bms-building-job-parser.mjs
+++ b/scripts/lib/bms-building-job-parser.mjs
@@ -125,12 +125,10 @@ async function fetchHtml(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/bobst-job-parser.mjs
+++ b/scripts/lib/bobst-job-parser.mjs
@@ -52,13 +52,13 @@ async function fetchBobstDetail(detailUrl) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) return '';
     const html = await res.text();
     return extractUmantisDetailContent(html);
   } catch {
-    clearTimeout(timer);
     return '';
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/caritas-schweiz-job-parser.mjs
+++ b/scripts/lib/caritas-schweiz-job-parser.mjs
@@ -172,13 +172,11 @@ async function fetchPage(url, timeoutMs = 20000) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/citta-di-bellinzona-job-parser.mjs
+++ b/scripts/lib/citta-di-bellinzona-job-parser.mjs
@@ -216,7 +216,6 @@ export async function fetchBellinzonaJobs(timeoutMs = 15000) {
       headers: { Accept: 'text/html', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const html = await res.text();
     return parseBellinzonaListingHtml(html);

--- a/scripts/lib/citta-di-locarno-job-parser.mjs
+++ b/scripts/lib/citta-di-locarno-job-parser.mjs
@@ -209,7 +209,6 @@ export async function fetchLocarnoJobs(timeoutMs = 15000) {
       headers: { Accept: 'text/html', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const html = await res.text();
     return parseLocarnoListingHtml(html);

--- a/scripts/lib/climeworks-job-parser.mjs
+++ b/scripts/lib/climeworks-job-parser.mjs
@@ -163,12 +163,10 @@ async function fetchOffers() {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Climeworks Recruitee API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/csd-engineers-job-parser.mjs
+++ b/scripts/lib/csd-engineers-job-parser.mjs
@@ -133,7 +133,6 @@ async function fetchRssFeed() {
         'User-Agent': USER_AGENT,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from RSS feed`);
     const xml = await res.text();
 
@@ -179,9 +178,8 @@ async function fetchRssFeed() {
       });
     }
     return items;
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/cseb-job-parser.mjs
+++ b/scripts/lib/cseb-job-parser.mjs
@@ -396,12 +396,10 @@ async function fetchPublications() {
         'User-Agent': USER_AGENT,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Abacus API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -5727,9 +5727,9 @@ export async function geocodeCountry(locationString) {
   const q = String(locationString || '').trim();
   if (!q || q.length < 2) return null;
   const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=1&addressdetails=1`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 8000);
     const res = await globalThis.fetch(url, {
       signal: controller.signal,
       headers: {
@@ -5737,13 +5737,14 @@ export async function geocodeCountry(locationString) {
         Accept: 'application/json',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) return null;
     const data = await res.json();
     if (!Array.isArray(data) || data.length === 0) return null;
     return (data[0].address?.country_code || '').toLowerCase() || null;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/edmond-de-rothschild-job-parser.mjs
+++ b/scripts/lib/edmond-de-rothschild-job-parser.mjs
@@ -198,7 +198,6 @@ async function fetchJson(url, timeoutMs = 15000) {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`   ⚠️ HTTP ${res.status} from ${url}`);
       return null;
@@ -207,9 +206,10 @@ async function fetchJson(url, timeoutMs = 15000) {
     if (!text) return null;
     return JSON.parse(text);
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`   ⚠️ fetchJson failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/fhgr-job-parser.mjs
+++ b/scripts/lib/fhgr-job-parser.mjs
@@ -360,12 +360,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/fielmann-job-parser.mjs
+++ b/scripts/lib/fielmann-job-parser.mjs
@@ -134,16 +134,16 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
     }
     return await res.json();
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/flury-stiftung-job-parser.mjs
+++ b/scripts/lib/flury-stiftung-job-parser.mjs
@@ -195,12 +195,10 @@ async function fetchListingPage() {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from listing page`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/fmi-job-parser.mjs
+++ b/scripts/lib/fmi-job-parser.mjs
@@ -94,12 +94,10 @@ async function postListing({ offset = 0, limit = 100, lang = 'de', timeoutMs } =
       body,
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${LISTING_URL}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -112,12 +110,12 @@ async function fetchDetail(url, { timeoutMs } = {}) {
       headers: { Accept: 'text/html,application/xhtml+xml,*/*', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
   } catch (err) {
-    clearTimeout(timer);
     return '';
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/fondation-domus-job-parser.mjs
+++ b/scripts/lib/fondation-domus-job-parser.mjs
@@ -207,12 +207,10 @@ async function fetchCareerPage() {
         'Accept-Language': 'fr-CH,fr;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from career page`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -310,7 +308,6 @@ async function fetchJobUpDescription(jobUpUrl) {
         'Accept-Language': 'fr-CH,fr;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) return null;
     const html = await res.text();
 
@@ -338,8 +335,9 @@ async function fetchJobUpDescription(jobUpUrl) {
 
     return null;
   } catch {
-    clearTimeout(timer);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/fondation-soins-lausanne-job-parser.mjs
+++ b/scripts/lib/fondation-soins-lausanne-job-parser.mjs
@@ -114,7 +114,6 @@ async function fetchJobupJobPosting(url) {
       headers: { Accept: 'text/html', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) return null;
     const html = await res.text();
     const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
@@ -130,8 +129,9 @@ async function fetchJobupJobPosting(url) {
     }
     return null;
   } catch {
-    clearTimeout(timer);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/fusalp-job-parser.mjs
+++ b/scripts/lib/fusalp-job-parser.mjs
@@ -120,12 +120,10 @@ async function fetchPage(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/giardino-job-parser.mjs
+++ b/scripts/lib/giardino-job-parser.mjs
@@ -324,12 +324,10 @@ async function fetchJobListings() {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from WordPress API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/gkb-job-parser.mjs
+++ b/scripts/lib/gkb-job-parser.mjs
@@ -347,12 +347,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/hilcona-job-parser.mjs
+++ b/scripts/lib/hilcona-job-parser.mjs
@@ -199,7 +199,6 @@ export async function fetchHilconaJobUrls(timeoutMs = 15000) {
       headers: { 'User-Agent': UA, Accept: 'application/xml, text/xml' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const xml = await res.text();
     return parseHilconaSitemapXml(xml);

--- a/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
+++ b/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
@@ -209,7 +209,6 @@ async function fetchTypesenseApiKey() {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from career page`);
     const html = await res.text();
 
@@ -255,9 +254,8 @@ async function fetchTypesenseApiKey() {
 
     console.log(`  🔑 Extracted Typesense API key (${apiKey.length} chars)`);
     return apiKey;
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -293,7 +291,6 @@ async function fetchJobListings(apiKey) {
         }],
       }),
     });
-    clearTimeout(timer);
 
     if (!res.ok) throw new Error(`HTTP ${res.status} from Typesense API`);
 
@@ -305,9 +302,8 @@ async function fetchJobListings(apiKey) {
     console.log(`  📊 Typesense found: ${results.found} jobs, returned: ${hits.length}`);
     warnIfListingAtCap({ label: 'Hochgebirgsklinik Davos listing', count: hits.length, cap: TYPESENSE_PAGE_CAP, total: results.found });
     return hits.map((h) => h.document);
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/hopital-du-valais-job-parser.mjs
+++ b/scripts/lib/hopital-du-valais-job-parser.mjs
@@ -148,7 +148,6 @@ async function callDatabroker(definitionSysId, inputValues, pipelineId) {
       }]),
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} from ServiceNow API`);
@@ -161,9 +160,8 @@ async function callDatabroker(definitionSysId, inputValues, pipelineId) {
     // first `result` row) warns loudly instead of silently yielding [].
     const executionResult = data?.result?.[0]?.executionResult;
     return assertJsonListShape(executionResult, { key: 'output', source: 'hopital-du-valais' });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/huntsman-job-parser.mjs
+++ b/scripts/lib/huntsman-job-parser.mjs
@@ -118,9 +118,9 @@ function detectEmploymentType(timeType = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -133,7 +133,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -142,6 +141,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/institution-lavigny-job-parser.mjs
+++ b/scripts/lib/institution-lavigny-job-parser.mjs
@@ -52,12 +52,10 @@ async function fetchLavignyHtml(url, opts = {}) {
       headers: { Accept: 'text/html', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/interdiscount-job-parser.mjs
+++ b/scripts/lib/interdiscount-job-parser.mjs
@@ -199,12 +199,10 @@ async function callApi(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Prospective API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -351,7 +351,6 @@ export async function fetchJobupDetailDescription(detailUrl) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) return '';
     const html = await res.text();
     // Extract every <script type="application/ld+json"> block and look for JobPosting
@@ -378,8 +377,9 @@ export async function fetchJobupDetailDescription(detailUrl) {
     }
     return '';
   } catch {
-    clearTimeout(timer);
     return '';
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/jumbo-job-parser.mjs
+++ b/scripts/lib/jumbo-job-parser.mjs
@@ -198,12 +198,10 @@ async function callApi(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Prospective API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/kanton-gr-job-parser.mjs
+++ b/scripts/lib/kanton-gr-job-parser.mjs
@@ -178,12 +178,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/kellerhals-carrard-job-parser.mjs
+++ b/scripts/lib/kellerhals-carrard-job-parser.mjs
@@ -148,12 +148,10 @@ async function fetchJson(url) {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/klinik-susenberg-job-parser.mjs
+++ b/scripts/lib/klinik-susenberg-job-parser.mjs
@@ -60,12 +60,10 @@ async function fetchHtml(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/kone-job-parser.mjs
+++ b/scripts/lib/kone-job-parser.mjs
@@ -132,12 +132,10 @@ async function fetchJson(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from SmartRecruiters API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/ksbl-job-parser.mjs
+++ b/scripts/lib/ksbl-job-parser.mjs
@@ -106,12 +106,10 @@ async function fetchHtml(url) {
       headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/ksw-job-parser.mjs
+++ b/scripts/lib/ksw-job-parser.mjs
@@ -287,12 +287,10 @@ async function fetchPage(url) {
       },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/kulm-hotel-job-parser.mjs
+++ b/scripts/lib/kulm-hotel-job-parser.mjs
@@ -169,12 +169,10 @@ async function fetchJson(url) {
         'User-Agent': USER_AGENT,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -191,12 +189,10 @@ async function fetchHtml(url) {
         'Accept-Language': 'en,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/lalive-job-parser.mjs
+++ b/scripts/lib/lalive-job-parser.mjs
@@ -157,7 +157,6 @@ async function fetchJson(url) {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
   } finally {

--- a/scripts/lib/lastminute-job-parser.mjs
+++ b/scripts/lib/lastminute-job-parser.mjs
@@ -287,15 +287,15 @@ export async function fetchSmartRecruitersDetail(postingId, timeoutMs = 12000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ SR API ${res.status} for posting ${postingId}`);
       return null;
     }
     return await res.json();
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`⚠️ SR API fetch failed for ${postingId}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/scripts/lib/lindenhofgruppe-job-parser.mjs
+++ b/scripts/lib/lindenhofgruppe-job-parser.mjs
@@ -125,12 +125,10 @@ async function fetchProspectivePage(offset = 0) {
       headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/localsearch-job-parser.mjs
+++ b/scripts/lib/localsearch-job-parser.mjs
@@ -127,12 +127,10 @@ async function fetchPage(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/lonza-job-parser.mjs
+++ b/scripts/lib/lonza-job-parser.mjs
@@ -97,9 +97,9 @@ export function isTrustedDomain(rawUrl = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -112,7 +112,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -121,6 +120,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/marriott-job-parser.mjs
+++ b/scripts/lib/marriott-job-parser.mjs
@@ -201,7 +201,6 @@ async function obtainSessionCookie() {
       redirect: 'follow',
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} fetching jobs page for cookie`);
@@ -219,9 +218,8 @@ async function obtainSessionCookie() {
     await res.text();
 
     return cookies.join('; ');
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -251,16 +249,14 @@ async function callSearchApi(cookie, pageNumber = 1) {
       }),
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} from Paradox search API (page ${pageNumber})`);
     }
 
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/mymemory-translate.mjs
+++ b/scripts/lib/mymemory-translate.mjs
@@ -65,6 +65,8 @@ export async function translateWithMyMemory(text, sourceLang, targetLang) {
     await new Promise((r) => setTimeout(r, wait));
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
   try {
     const params = new URLSearchParams({
       q: text.slice(0, 5000), // API supports up to 5000 chars per call
@@ -76,14 +78,11 @@ export async function translateWithMyMemory(text, sourceLang, targetLang) {
     }
 
     const url = `${MYMEMORY_API}?${params.toString()}`;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8000);
 
     const res = await fetch(url, {
       signal: controller.signal,
       headers: { 'User-Agent': 'FrontaliereTicino/1.0' },
     });
-    clearTimeout(timeout);
 
     if (!res.ok) return null;
     const data = await res.json();
@@ -106,6 +105,8 @@ export async function translateWithMyMemory(text, sourceLang, targetLang) {
     return translated.trim();
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/scripts/lib/omega-job-parser.mjs
+++ b/scripts/lib/omega-job-parser.mjs
@@ -281,7 +281,6 @@ async function fetchPage(url) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (res.ok) {
       const body = await res.text();
       if (!looksLikeAntiBotChallenge(body)) return body;
@@ -290,8 +289,9 @@ async function fetchPage(url) {
       directErr = new Error(`HTTP ${res.status} from ${url}`);
     }
   } catch (err) {
-    clearTimeout(timer);
     directErr = err;
+  } finally {
+    clearTimeout(timer);
   }
 
   const viaJina = await fetchHtmlViaJinaWithRetry(jinaSafeUrl(url), { timeoutMs: Math.max(timeoutMs, 30000) });

--- a/scripts/lib/pastahr-widget-client.mjs
+++ b/scripts/lib/pastahr-widget-client.mjs
@@ -319,7 +319,6 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
         body: params.toString(),
         signal: controller.signal,
       });
-      clearTimeout(timer);
       if (res.ok) return await res.json();
       firstStatus = res.status;
       const err = new Error(`HTTP ${res.status} from ${PASTAHR_ENDPOINT}`);
@@ -327,7 +326,6 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
       err.retryable = RETRYABLE_STATUS.has(res.status);
       throw err;
     } catch (err) {
-      clearTimeout(timer);
       // Anti-bot fence (403/401/406): try the headless-browser replay, which
       // the WAF treats as a genuine visitor — but see the cross-origin caveat
       // above, PastaHR always skips it and falls straight through to marking
@@ -344,6 +342,8 @@ export async function fetchPastaHrWidgetPage(params, { referer, origin, timeoutM
         err.retryable = true;
       }
       throw err;
+    } finally {
+      clearTimeout(timer);
     }
   }, { label: `pastahr ${PASTAHR_ENDPOINT}` });
 }
@@ -418,7 +418,6 @@ export async function fetchPostWidgetWithAntiBotHardening(body, endpoint, { refe
         body: bodyString,
         signal: controller.signal,
       });
-      clearTimeout(timer);
       if (res.ok) return await res.json();
       firstStatus = res.status;
       const err = new Error(`HTTP ${res.status} from ${endpoint}`);
@@ -426,7 +425,6 @@ export async function fetchPostWidgetWithAntiBotHardening(body, endpoint, { refe
       err.retryable = RETRYABLE_STATUS.has(res.status);
       throw err;
     } catch (err) {
-      clearTimeout(timer);
       const status = firstStatus ?? err?.status;
       if (isAntiBotStatus(status)) {
         console.warn(`[widget] HTTP ${status} from ${endpoint} — trying Playwright anti-bot fallback`);
@@ -445,6 +443,8 @@ export async function fetchPostWidgetWithAntiBotHardening(body, endpoint, { refe
         if (isCrossOrigin(referer, endpoint)) err.retryable = true;
       }
       throw err;
+    } finally {
+      clearTimeout(timer);
     }
   }, { label: `widget ${endpoint}` });
 }

--- a/scripts/lib/pdgr-job-parser.mjs
+++ b/scripts/lib/pdgr-job-parser.mjs
@@ -178,13 +178,11 @@ async function fetchListingPage() {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from listing page`);
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), CAREER_URL, { timeoutMs });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -285,13 +283,11 @@ async function fetchDetailPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from detail page: ${url}`);
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/postauto-job-parser.mjs
+++ b/scripts/lib/postauto-job-parser.mjs
@@ -251,7 +251,6 @@ async function fetchJobsApiPage(locale, pageNumber, timeoutMs) {
       },
       body: JSON.stringify({ locale, pageNumber, sortBy: 'date' }),
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for jobs API (${locale} page ${pageNumber})`);
       return { totalJobs: 0, jobs: [] };
@@ -262,9 +261,10 @@ async function fetchJobsApiPage(locale, pageNumber, timeoutMs) {
       : [];
     return { totalJobs: Number(data?.totalJobs ?? 0), jobs };
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`⚠️ Jobs API fetch failed (${locale} page ${pageNumber}): ${err.message}`);
     return { totalJobs: 0, jobs: [] };
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/privatklinik-hohenegg-job-parser.mjs
+++ b/scripts/lib/privatklinik-hohenegg-job-parser.mjs
@@ -132,12 +132,10 @@ async function fetchPage(url, timeoutMs = 20000) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/rapelli-job-parser.mjs
+++ b/scripts/lib/rapelli-job-parser.mjs
@@ -183,7 +183,6 @@ export async function fetchRapelliJobUrls(timeoutMs = 15000) {
       headers: { Accept: 'text/html', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const html = await res.text();
     return parseRapelliListingHtml(html);

--- a/scripts/lib/reboot-monkey-job-parser.mjs
+++ b/scripts/lib/reboot-monkey-job-parser.mjs
@@ -156,16 +156,14 @@ async function fetchJobPage(page = 1) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} from Reboot Monkey API`);
     }
 
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/riveneuve-job-parser.mjs
+++ b/scripts/lib/riveneuve-job-parser.mjs
@@ -51,12 +51,10 @@ async function fetchRiveneuveHtml(url) {
       headers: { Accept: 'text/html', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/rsbj-job-parser.mjs
+++ b/scripts/lib/rsbj-job-parser.mjs
@@ -80,12 +80,10 @@ async function fetchHtml(url) {
       headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/rss-surselva-job-parser.mjs
+++ b/scripts/lib/rss-surselva-job-parser.mjs
@@ -185,12 +185,10 @@ async function fetchOstendisListings() {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Ostendis API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -214,12 +212,10 @@ async function fetchDetailPage(detailUrl) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from detail page: ${detailUrl}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/schindler-job-parser.mjs
+++ b/scripts/lib/schindler-job-parser.mjs
@@ -367,13 +367,11 @@ async function fetchPage(url, timeoutMs, userAgent) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), url, { timeoutMs });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/siegfried-job-parser.mjs
+++ b/scripts/lib/siegfried-job-parser.mjs
@@ -127,9 +127,9 @@ function detectEmploymentType(timeType = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -143,7 +143,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -152,6 +151,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/solothurner-spitaeler-job-parser.mjs
+++ b/scripts/lib/solothurner-spitaeler-job-parser.mjs
@@ -318,12 +318,10 @@ async function fetchPage(url) {
       },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-davos-job-parser.mjs
+++ b/scripts/lib/spital-davos-job-parser.mjs
@@ -349,13 +349,11 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     // 200-but-challenge (IP-reputation WAF, cambiavalute class #1363) → Jina.
     return await rescueHtmlIfChallenged(await res.text(), url, {});
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-lachen-job-parser.mjs
+++ b/scripts/lib/spital-lachen-job-parser.mjs
@@ -48,12 +48,10 @@ async function fetchJson(url) {
       headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-limmattal-job-parser.mjs
+++ b/scripts/lib/spital-limmattal-job-parser.mjs
@@ -148,12 +148,10 @@ async function fetchPage(url, timeoutMs = 20000) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-thurgau-job-parser.mjs
+++ b/scripts/lib/spital-thurgau-job-parser.mjs
@@ -228,12 +228,10 @@ async function fetchPage(url) {
       },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-thusis-job-parser.mjs
+++ b/scripts/lib/spital-thusis-job-parser.mjs
@@ -184,12 +184,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/spital-uster-job-parser.mjs
+++ b/scripts/lib/spital-uster-job-parser.mjs
@@ -131,12 +131,10 @@ async function fetchProspectivePage(offset = 0) {
       headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/srg-ssr-job-parser.mjs
+++ b/scripts/lib/srg-ssr-job-parser.mjs
@@ -197,12 +197,10 @@ async function fetchPage(url) {
       signal: controller.signal,
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/sro-job-parser.mjs
+++ b/scripts/lib/sro-job-parser.mjs
@@ -150,12 +150,10 @@ async function fetchHtml(url) {
       headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/stadt-zuerich-job-parser.mjs
+++ b/scripts/lib/stadt-zuerich-job-parser.mjs
@@ -207,12 +207,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/stadtspital-zuerich-job-parser.mjs
+++ b/scripts/lib/stadtspital-zuerich-job-parser.mjs
@@ -184,12 +184,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/sune-egge-job-parser.mjs
+++ b/scripts/lib/sune-egge-job-parser.mjs
@@ -124,12 +124,10 @@ async function fetchJson(url) {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/swiss-life-job-parser.mjs
+++ b/scripts/lib/swiss-life-job-parser.mjs
@@ -165,16 +165,16 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
     }
     return await res.json();
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`⚠️ Fetch failed for ${url}: ${err?.message || err}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/tally-weijl-job-parser.mjs
+++ b/scripts/lib/tally-weijl-job-parser.mjs
@@ -162,7 +162,6 @@ async function fetchJobListings() {
           },
           signal: controller.signal,
         });
-        clearTimeout(timer);
 
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const html = await res.text();
@@ -219,9 +218,10 @@ async function fetchJobListings() {
         page++;
         await new Promise((r) => setTimeout(r, 300));
       } catch (err) {
-        clearTimeout(timer);
         console.warn(`  ⚠️ Error fetching ${country} page ${page}: ${err.message}`);
         break;
+      } finally {
+        clearTimeout(timer);
       }
     }
   }
@@ -252,7 +252,6 @@ async function fetchJobDetail(jobUrl) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) return null;
     const html = await res.text();
@@ -267,8 +266,9 @@ async function fetchJobDetail(jobUrl) {
 
     return descMatch ? stripHtml(descMatch[1]).trim() : null;
   } catch {
-    clearTimeout(timer);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/tether-job-parser.mjs
+++ b/scripts/lib/tether-job-parser.mjs
@@ -152,9 +152,9 @@ function isGenericOffer(offer = {}) {
  */
 async function fetchJobListings() {
   console.log(`   Fetching from: ${API_URL}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 25000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 25000);
     const res = await fetch(API_URL, {
       signal: controller.signal,
       headers: {
@@ -162,7 +162,6 @@ async function fetchJobListings() {
         'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`   ⚠️ HTTP ${res.status} from Recruitee API`);
       return [];
@@ -174,6 +173,8 @@ async function fetchJobListings() {
   } catch (err) {
     console.warn(`   ⚠️ Fetch failed: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/transgourmet-job-parser.mjs
+++ b/scripts/lib/transgourmet-job-parser.mjs
@@ -176,12 +176,10 @@ async function callApi(url) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Prospective API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/tschuggen-job-parser.mjs
+++ b/scripts/lib/tschuggen-job-parser.mjs
@@ -376,12 +376,10 @@ async function fetchPage(url) {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/ubp-job-parser.mjs
+++ b/scripts/lib/ubp-job-parser.mjs
@@ -146,7 +146,6 @@ async function fetchJson(url, timeoutMs = 15000) {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`   ⚠️ HTTP ${res.status} from ${url}`);
       return null;
@@ -155,9 +154,10 @@ async function fetchJson(url, timeoutMs = 15000) {
     if (!text) return null;
     return JSON.parse(text);
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`   ⚠️ fetchJson failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/ubs-job-parser.mjs
+++ b/scripts/lib/ubs-job-parser.mjs
@@ -350,7 +350,6 @@ async function bootstrapSession(siteId) {
       redirect: 'follow',
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`Failed to load Taleo search page: HTTP ${res.status}`);
@@ -370,9 +369,8 @@ async function bootstrapSession(siteId) {
     }
 
     return { cookies: cookieStr, rft };
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -431,7 +429,6 @@ async function searchJobs(cookies, rft, siteId) {
       body: JSON.stringify(requestBody),
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`Taleo MatchedJobs API returned HTTP ${res.status}`);
@@ -446,9 +443,8 @@ async function searchJobs(cookies, rft, siteId) {
     const totalCount = data?.JobsCount || 0;
 
     return { jobs: jobList, totalCount };
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -499,7 +495,6 @@ async function searchMoreJobs(cookies, rft, pageNumber, siteId) {
       body: JSON.stringify(requestBody),
       signal: controller.signal,
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       throw new Error(`Taleo ProcessSortAndShowMoreJobs API returned HTTP ${res.status}`);
@@ -510,9 +505,8 @@ async function searchMoreJobs(cookies, rft, pageNumber, siteId) {
     const totalCount = data?.JobsCount || 0;
 
     return { jobs: jobList, totalCount };
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/unispital-basel-job-parser.mjs
+++ b/scripts/lib/unispital-basel-job-parser.mjs
@@ -138,12 +138,10 @@ async function fetchProspectivePage(offset = 0) {
       headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/usz-job-parser.mjs
+++ b/scripts/lib/usz-job-parser.mjs
@@ -143,12 +143,10 @@ async function fetchProspectivePage(offset = 0) {
       headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/vaxcyte-job-parser.mjs
+++ b/scripts/lib/vaxcyte-job-parser.mjs
@@ -193,16 +193,16 @@ async function fetchGreenhouseApi() {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`\u26a0\ufe0f HTTP ${res.status} from Greenhouse API`);
       return null;
     }
     return await res.json();
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`\u26a0\ufe0f Greenhouse API fetch failed: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/lib/villa-im-park-job-parser.mjs
+++ b/scripts/lib/villa-im-park-job-parser.mjs
@@ -130,12 +130,10 @@ async function fetchJson(url) {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/vista-job-parser.mjs
+++ b/scripts/lib/vista-job-parser.mjs
@@ -127,12 +127,10 @@ async function fetchOstendisListings() {
         'Accept-Language': 'de-CH,de;q=0.9',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from Ostendis API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -150,12 +148,10 @@ async function fetchDetailPage(detailUrl) {
         'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from detail page: ${detailUrl}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/weisse-arena-job-parser.mjs
+++ b/scripts/lib/weisse-arena-job-parser.mjs
@@ -183,12 +183,10 @@ async function callTalentLinkApi(url, body = null) {
       signal: controller.signal,
       body: body ? JSON.stringify(body) : undefined,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from TalentLink API`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/lib/wuerth-international-job-parser.mjs
+++ b/scripts/lib/wuerth-international-job-parser.mjs
@@ -303,12 +303,12 @@ export async function fetchAllWuerthInternationalJobs() {
       headers: { 'User-Agent': userAgent },
       signal: controller1.signal,
     });
-    clearTimeout(timer1);
     if (!res.ok) throw new Error(`HTTP ${res.status} from listing page`);
     listingHtml = await res.text();
   } catch (err) {
-    clearTimeout(timer1);
     throw new Error(`Failed to fetch listing page: ${err?.message || err}`);
+  } finally {
+    clearTimeout(timer1);
   }
 
   const listings = parseListingPage(listingHtml);
@@ -325,16 +325,20 @@ export async function fetchAllWuerthInternationalJobs() {
     try {
       const controller2 = new AbortController();
       const timer2 = setTimeout(() => controller2.abort(), timeoutMs);
-      const res = await fetch(listing.url, {
-        headers: { 'User-Agent': userAgent },
-        signal: controller2.signal,
-      });
-      clearTimeout(timer2);
 
       let detail = null;
-      if (res.ok) {
-        const detailHtml = await res.text();
-        detail = parseDetailPage(detailHtml);
+      try {
+        const res = await fetch(listing.url, {
+          headers: { 'User-Agent': userAgent },
+          signal: controller2.signal,
+        });
+
+        if (res.ok) {
+          const detailHtml = await res.text();
+          detail = parseDetailPage(detailHtml);
+        }
+      } finally {
+        clearTimeout(timer2);
       }
 
       // Build job object

--- a/scripts/sync-gsc-orphans.mjs
+++ b/scripts/sync-gsc-orphans.mjs
@@ -888,8 +888,16 @@ async function enrichWayback(enrichedOrphans) {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10000);
 
-      const res = await fetch(cdxUrl, { signal: controller.signal });
-      clearTimeout(timeout);
+      let res;
+      let data;
+      try {
+        res = await fetch(cdxUrl, { signal: controller.signal });
+        if (res.ok) {
+          data = await res.json();
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
 
       if (!res.ok) {
         errors++;
@@ -897,7 +905,6 @@ async function enrichWayback(enrichedOrphans) {
         continue;
       }
 
-      const data = await res.json();
       // CDX returns [["timestamp","original"], ["20240101...","url"]]
       if (!Array.isArray(data) || data.length < 2) {
         await sleep(1000);

--- a/scripts/update-aldi-suisse-jobs.mjs
+++ b/scripts/update-aldi-suisse-jobs.mjs
@@ -142,15 +142,14 @@ async function fetchAldiListings() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
   console.log(`\ud83d\udd0d Fetching ALDI Suisse jobs: ${ALDI_SEARCH_API}`);
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(ALDI_SEARCH_API, {
       signal: controller.signal,
       headers: { Accept: 'application/json', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       console.warn(`\u26a0\ufe0f ALDI search API returned ${res.status}`);
@@ -164,6 +163,8 @@ async function fetchAldiListings() {
   } catch (err) {
     console.warn(`\u26a0\ufe0f Failed to fetch ALDI search API: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -186,13 +187,13 @@ async function fetchAndParseDetailPages(listings) {
             headers: { Accept: 'text/html', 'User-Agent': UA },
             redirect: 'follow',
           });
-          clearTimeout(timer);
           if (!res.ok) return null;
           const html = await res.text();
           return { listing, html };
         } catch {
-          clearTimeout(timer);
           return null;
+        } finally {
+          clearTimeout(timer);
         }
       })
     );

--- a/scripts/update-bracco-jobs.mjs
+++ b/scripts/update-bracco-jobs.mjs
@@ -144,9 +144,9 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -159,7 +159,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -168,6 +167,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-capri-holdings-jobs.mjs
+++ b/scripts/update-capri-holdings-jobs.mjs
@@ -202,9 +202,9 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -217,7 +217,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -226,6 +225,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-casale-jobs.mjs
+++ b/scripts/update-casale-jobs.mjs
@@ -48,11 +48,11 @@ function isCompanyJob(job) {
 function isTrustedDomain(rawUrl = '') { try { const h = new URL(rawUrl).hostname.toLowerCase(); return h.includes('casale'); } catch { return false; } }
 
 async function fetchJson(url, timeoutMs = 20000) {
+  const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { Accept: 'application/json', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)' } });
-    clearTimeout(timer); if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.json();
-  } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; }
+    if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.json();
+  } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; } finally { clearTimeout(timer); }
 }
 
 async function fetchJobs() {

--- a/scripts/update-colin-cie-jobs.mjs
+++ b/scripts/update-colin-cie-jobs.mjs
@@ -162,21 +162,23 @@ async function fetchPage(url) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await fetch(url, {
-        signal: controller.signal,
-        headers: {
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
-          'User-Agent': USER_AGENTS[attempt],
-          Referer: 'https://www.google.com/',
-        },
-        redirect: 'follow',
-      });
-      clearTimeout(timer);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      return await res.text();
+      try {
+        const res = await fetch(url, {
+          signal: controller.signal,
+          headers: {
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+            'User-Agent': USER_AGENTS[attempt],
+            Referer: 'https://www.google.com/',
+          },
+          redirect: 'follow',
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.text();
+      } finally {
+        clearTimeout(timer);
+      }
     } catch (err) {
-      clearTimeout(timer);
       if (attempt < 2) {
         const delay = 3000 * (attempt + 1);
         console.log(`  ⚠️  fetch attempt ${attempt + 1} failed (${err.message}), retrying in ${delay / 1000}s...`);

--- a/scripts/update-coop-jobs.mjs
+++ b/scripts/update-coop-jobs.mjs
@@ -283,21 +283,28 @@ async function fetchCoopJobDetailUrls() {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-      const res = await fetch(apiUrl, {
-        signal: controller.signal,
-        headers: {
-          Accept: 'application/json',
-          'User-Agent': 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
-        },
-      });
-      clearTimeout(timer);
+      let res;
+      let data;
+      try {
+        res = await fetch(apiUrl, {
+          signal: controller.signal,
+          headers: {
+            Accept: 'application/json',
+            'User-Agent': 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
+          },
+        });
+        if (res.ok) {
+          data = await res.json();
+        }
+      } finally {
+        clearTimeout(timer);
+      }
 
       if (!res.ok) {
         console.warn(`⚠️ API returned ${res.status} at offset ${offset} — stopping pagination.`);
         break;
       }
 
-      const data = await res.json();
       jobs = assertJsonListShape(data, { key: 'jobs', source: 'coop', lang: `offset:${offset}` });
       if (apiTotal === null && typeof data?.total === 'number') apiTotal = data.total;
     } catch (err) {

--- a/scripts/update-corner-jobs.mjs
+++ b/scripts/update-corner-jobs.mjs
@@ -175,16 +175,16 @@ async function fetchRecruiteeOffers() {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.error(`❌ HTTP ${res.status} for ${RECRUITEE_API}`);
       return [];
     }
     body = await res.text();
   } catch (err) {
-    clearTimeout(timer);
     console.error(`❌ Fetch failed for ${RECRUITEE_API}: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 
   let data;

--- a/scripts/update-csc-costruzioni-jobs.mjs
+++ b/scripts/update-csc-costruzioni-jobs.mjs
@@ -92,10 +92,10 @@ async function fetchCscJobUrls() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
   console.log(`🔍 Fetching CSC careers page: ${CSC_CAREERS_URL}`);
 
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  try {
     const res = await fetch(CSC_CAREERS_URL, {
       signal: controller.signal,
       headers: {
@@ -103,7 +103,6 @@ async function fetchCscJobUrls() {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       console.warn(`⚠️ CSC careers page returned ${res.status}`);
@@ -146,6 +145,8 @@ async function fetchCscJobUrls() {
   } catch (err) {
     console.warn(`⚠️ Failed to fetch CSC careers page: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-denner-jobs.mjs
+++ b/scripts/update-denner-jobs.mjs
@@ -159,16 +159,22 @@ async function fetchDennerJobUrls() {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-        const res = await fetch(fetchUrl, {
-          signal: controller.signal,
-          headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': UA },
-          redirect: 'follow',
-        });
-        clearTimeout(timer);
+        let res;
+        let html;
+        try {
+          res = await fetch(fetchUrl, {
+            signal: controller.signal,
+            headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': UA },
+            redirect: 'follow',
+          });
+          if (res.ok) {
+            html = await res.text();
+          }
+        } finally {
+          clearTimeout(timer);
+        }
 
         if (!res.ok) { console.warn(`\u26a0\ufe0f Denner listing returned ${res.status} for ${name} page ${page}`); break; }
-
-        const html = await res.text();
         const pageUrls = new Set();
 
         let match;
@@ -217,13 +223,13 @@ async function fetchAndParseDetailPages(urls) {
             headers: { Accept: 'text/html', 'User-Agent': UA },
             redirect: 'follow',
           });
-          clearTimeout(timer);
           if (!res.ok) return null;
           const html = await res.text();
           return { url, html };
         } catch {
-          clearTimeout(timer);
           return null;
+        } finally {
+          clearTimeout(timer);
         }
       })
     );

--- a/scripts/update-dxt-jobs.mjs
+++ b/scripts/update-dxt-jobs.mjs
@@ -150,9 +150,9 @@ const DXT_DEFAULT_USER_AGENT =
 const DXT_MIN_PAGE_SIZE = 10000;
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -161,7 +161,6 @@ async function fetchPage(url, timeoutMs = 20000) {
         'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || DXT_DEFAULT_USER_AGENT,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -178,6 +177,8 @@ async function fetchPage(url, timeoutMs = 20000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-efg-jobs.mjs
+++ b/scripts/update-efg-jobs.mjs
@@ -221,9 +221,9 @@ function isGenericLocation(value = '') {
  * Fetch a URL with timeout, returning text or null on failure.
  */
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -232,7 +232,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -241,6 +240,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-eoc-jobs.mjs
+++ b/scripts/update-eoc-jobs.mjs
@@ -195,9 +195,9 @@ export function buildEocRegeneratedSlug(job, location) {
  * Returns the response body as text, or null on failure.
  */
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -206,7 +206,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -215,6 +214,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-fnz-jobs.mjs
+++ b/scripts/update-fnz-jobs.mjs
@@ -152,9 +152,9 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -167,7 +167,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -176,6 +175,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-fust-jobs.mjs
+++ b/scripts/update-fust-jobs.mjs
@@ -179,16 +179,14 @@ async function fetchFustJobUrls() {
     console.log(`🔍 Fetching Coop Group feed CH-wide page ${page + 1} (offset ${offset})…`);
 
     let jobs;
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+    try {
       const res = await fetch(apiUrl, {
         signal: controller.signal,
         headers: { Accept: 'application/json', 'User-Agent': UA },
       });
-      clearTimeout(timer);
-
       if (!res.ok) {
         console.warn(`⚠️ API returned ${res.status} at offset ${offset} — stopping pagination.`);
         break;
@@ -200,6 +198,8 @@ async function fetchFustJobUrls() {
     } catch (err) {
       console.warn(`⚠️ API fetch failed at offset ${offset}: ${err.message}`);
       break;
+    } finally {
+      clearTimeout(timer);
     }
 
     if (jobs.length === 0) break;

--- a/scripts/update-goline-jobs.mjs
+++ b/scripts/update-goline-jobs.mjs
@@ -109,11 +109,9 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
           Referer: 'https://www.google.com/',
         },
       });
-      clearTimeout(timer);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return await res.text();
     } catch (err) {
-      clearTimeout(timer);
       if (attempt < 2) {
         const delay = 3000 * (attempt + 1);
         console.log(`  ⚠️  fetch attempt ${attempt + 1} failed (${err.message}), retrying in ${delay / 1000}s...`);
@@ -155,6 +153,8 @@ async function fetchPage(url, timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOU
           throw new Error(`All fetch methods failed. Last fetch: ${err.message}. Playwright: ${pwErr.message}`);
         }
       }
+    } finally {
+      clearTimeout(timer);
     }
   }
 }

--- a/scripts/update-hamilton-jobs.mjs
+++ b/scripts/update-hamilton-jobs.mjs
@@ -168,12 +168,10 @@ async function fetchJobsPage(offset = 0) {
       }),
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -189,12 +187,12 @@ async function fetchJobDetail(externalPath) {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) return null;
     return await res.json();
   } catch {
-    clearTimeout(timer);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-helsinn-jobs.mjs
+++ b/scripts/update-helsinn-jobs.mjs
@@ -56,14 +56,14 @@ function isTrustedDomain(rawUrl = '') {
 }
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { Accept: 'text/html,application/xhtml+xml', 'Accept-Language': 'it,en;q=0.9', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)' } });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
     return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 async function fetchJobs() {

--- a/scripts/update-hes-so-valais-jobs.mjs
+++ b/scripts/update-hes-so-valais-jobs.mjs
@@ -153,9 +153,9 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchHtml(url) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 30000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -165,7 +165,6 @@ async function fetchHtml(url) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return '';
@@ -174,6 +173,8 @@ async function fetchHtml(url) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return '';
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-hugo-boss-jobs.mjs
+++ b/scripts/update-hugo-boss-jobs.mjs
@@ -63,9 +63,9 @@ function isTrustedDomain(rawUrl = '') {
 }
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -74,10 +74,10 @@ async function fetchPage(url, timeoutMs = 20000) {
         'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
     return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 function slugify(value = '') {

--- a/scripts/update-interroll-jobs.mjs
+++ b/scripts/update-interroll-jobs.mjs
@@ -72,11 +72,12 @@ function isCompanyJob(job) {
 function isTrustedDomain(rawUrl = '') { try { return new URL(rawUrl).hostname.toLowerCase().includes('interroll.com'); } catch { return false; } }
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { Accept: 'text/html,application/xhtml+xml', 'Accept-Language': 'en,it-CH;q=0.9', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)' } });
-    clearTimeout(timer); if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
+    if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 async function fetchJobs() {

--- a/scripts/update-ist-jobs.mjs
+++ b/scripts/update-ist-jobs.mjs
@@ -177,9 +177,9 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchHtml(url) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -188,7 +188,6 @@ async function fetchHtml(url) {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -197,6 +196,8 @@ async function fetchHtml(url) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-julius-baer-jobs.mjs
+++ b/scripts/update-julius-baer-jobs.mjs
@@ -61,14 +61,14 @@ function isTrustedDomain(rawUrl = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { ...options, signal: controller.signal, headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'Accept-Language': 'en,it-CH;q=0.9', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)', ...options.headers } });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
     return await res.json();
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 // Workday `Location_Country` facet ID for Switzerland on the Julius Baer tenant.

--- a/scripts/update-jysk-jobs.mjs
+++ b/scripts/update-jysk-jobs.mjs
@@ -92,10 +92,10 @@ async function fetchJyskJobUrls() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
   console.log(`🔍 Fetching JYSK listing page: ${JYSK_LISTING_URL}`);
 
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  try {
     const res = await fetch(JYSK_LISTING_URL, {
       signal: controller.signal,
       headers: {
@@ -103,8 +103,6 @@ async function fetchJyskJobUrls() {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
-
     if (!res.ok) {
       console.warn(`⚠️ JYSK listing page returned ${res.status}`);
       return [];
@@ -128,6 +126,8 @@ async function fetchJyskJobUrls() {
   } catch (err) {
     console.warn(`⚠️ Failed to fetch JYSK listing page: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-kempinski-jobs.mjs
+++ b/scripts/update-kempinski-jobs.mjs
@@ -172,13 +172,11 @@ async function fetchAllPostings() {
       },
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
     const json = await res.json();
     return assertJsonListShape(json, { key: 'data', source: 'kempinski' });
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/update-linnea-jobs.mjs
+++ b/scripts/update-linnea-jobs.mjs
@@ -107,9 +107,9 @@ function isTrustedDomain(rawUrl = '') {
 // ─────────────────────────────────────────────────────────────
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -119,7 +119,6 @@ async function fetchPage(url, timeoutMs = 20000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -128,6 +127,8 @@ async function fetchPage(url, timeoutMs = 20000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-medacta-jobs.mjs
+++ b/scripts/update-medacta-jobs.mjs
@@ -336,9 +336,9 @@ function detectCanton(location = '') {
  * Returns response body as text, or null on failure.
  */
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -348,7 +348,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -357,6 +356,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-mendrisio-jobs.mjs
+++ b/scripts/update-mendrisio-jobs.mjs
@@ -225,9 +225,9 @@ function isTrustedDomain(rawUrl = '') {
 
 /* ── HTML fetching ─────────────────────────────────────────── */
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -238,7 +238,6 @@ async function fetchPage(url, timeoutMs = 20000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -247,6 +246,8 @@ async function fetchPage(url, timeoutMs = 20000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-mikron-jobs.mjs
+++ b/scripts/update-mikron-jobs.mjs
@@ -79,14 +79,14 @@ function detectExperienceLevel(title = '') {
 
 async function fetchPage(url) {
   const timeoutMs = parseInt(process.env.JOBS_CRAWLER_TIMEOUT_MS || '20000', 10);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)', Accept: 'text/html', 'Accept-Language': 'en,it-CH;q=0.9' } });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for ${url}`); return null; }
     return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 /**

--- a/scripts/update-postch-jobs.mjs
+++ b/scripts/update-postch-jobs.mjs
@@ -145,9 +145,9 @@ function isPostJob(job) {
 // ──────────────────────────────────────────────────────────────
 
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -157,7 +157,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -166,6 +165,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -197,7 +198,6 @@ async function fetchJobsApiPage(locale, pageNumber, timeoutMs = 20000) {
       },
       body: JSON.stringify({ locale, pageNumber, sortBy: 'date' }),
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for jobs API (${locale} page ${pageNumber})`);
       return { totalJobs: 0, jobs: [] };
@@ -208,9 +208,10 @@ async function fetchJobsApiPage(locale, pageNumber, timeoutMs = 20000) {
       .filter(Boolean);
     return { totalJobs: Number(data?.totalJobs ?? 0), jobs };
   } catch (err) {
-    clearTimeout(timer);
     console.warn(`⚠️ Jobs API fetch failed (${locale} page ${pageNumber}): ${err.message}`);
     return { totalJobs: 0, jobs: [] };
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-postfinance-jobs.mjs
+++ b/scripts/update-postfinance-jobs.mjs
@@ -127,9 +127,9 @@ function isPostFinanceJob(job) {
 // ──────────────────────────────────────────────────────────────
 
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -139,7 +139,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -148,6 +147,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-raiffeisen-vc-jobs.mjs
+++ b/scripts/update-raiffeisen-vc-jobs.mjs
@@ -107,15 +107,14 @@ async function fetchJobUrls() {
 
   for (const pageUrl of CAREERS_URLS) {
     console.log(`🔍 Fetching: ${pageUrl}`);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
       const res = await fetch(pageUrl, {
         signal: controller.signal,
         headers: { Accept: 'text/html', 'User-Agent': UA },
         redirect: 'follow',
       });
-      clearTimeout(timer);
 
       if (!res.ok) {
         console.warn(`   ⚠️ HTTP ${res.status}`);
@@ -140,6 +139,8 @@ async function fetchJobUrls() {
       }
     } catch (err) {
       console.warn(`   ⚠️ Failed: ${err.message}`);
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -157,15 +158,14 @@ async function fetchJobUrls() {
  */
 async function fetchDetailBody(url) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: { Accept: 'text/html', 'User-Agent': UA },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`   ⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -179,6 +179,8 @@ async function fetchDetailBody(url) {
   } catch (err) {
     console.warn(`   ⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-sbb-jobs.mjs
+++ b/scripts/update-sbb-jobs.mjs
@@ -171,9 +171,9 @@ function deriveLocalizedSlug(job, locale) {
  * Returns the response body as text, or null on failure.
  */
 async function fetchPage(url, timeoutMs = 15000, accept = 'application/json') {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -182,7 +182,6 @@ async function fetchPage(url, timeoutMs = 15000, accept = 'application/json') {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -191,6 +190,8 @@ async function fetchPage(url, timeoutMs = 15000, accept = 'application/json') {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-sintetica-jobs.mjs
+++ b/scripts/update-sintetica-jobs.mjs
@@ -84,11 +84,12 @@ function isTrustedDomain(rawUrl = '') { try { const h = new URL(rawUrl).hostname
 const SINTETICA_DEFAULT_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { Accept: 'text/html,application/xhtml+xml', 'Accept-Language': 'en-US,en;q=0.9,it-CH;q=0.8', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || SINTETICA_DEFAULT_UA } });
-    clearTimeout(timer); if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
+    if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 async function fetchJobs() {

--- a/scripts/update-swisscom-jobs.mjs
+++ b/scripts/update-swisscom-jobs.mjs
@@ -137,9 +137,9 @@ function isSwissLocation(locText = '') {
 
 async function fetchJson(url, options = {}) {
   const timeoutMs = options.timeoutMs || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -152,7 +152,6 @@ async function fetchJson(url, options = {}) {
         ...options.headers,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -161,6 +160,8 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-tich-jobs.mjs
+++ b/scripts/update-tich-jobs.mjs
@@ -389,10 +389,9 @@ async function fetchTichJobDetailUrls() {
 
   // ── Step 1: Fetch the main listing page ──
   console.log(`🔍 Fetching Ti.CH listing page: ${LISTING_URL}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
     const res = await fetch(LISTING_URL, {
       signal: controller.signal,
       headers: {
@@ -400,7 +399,6 @@ async function fetchTichJobDetailUrls() {
         'User-Agent': userAgent,
       },
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       console.warn(`⚠️ Listing returned ${res.status} — will try RSS fallback.`);
@@ -419,22 +417,22 @@ async function fetchTichJobDetailUrls() {
     }
   } catch (err) {
     console.warn(`⚠️ Listing fetch failed: ${err.message} — will try RSS fallback.`);
+  } finally {
+    clearTimeout(timer);
   }
 
   // ── Step 2: Fetch the RSS/Atom feed as fallback/supplement ──
   console.log(`🔍 Fetching Ti.CH RSS feed: ${RSS_URL}`);
+  const rssController = new AbortController();
+  const rssTimer = setTimeout(() => rssController.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
     const res = await fetch(RSS_URL, {
-      signal: controller.signal,
+      signal: rssController.signal,
       headers: {
         Accept: 'application/atom+xml, application/rss+xml, application/xml, text/xml',
         'User-Agent': userAgent,
       },
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       console.warn(`⚠️ RSS feed returned ${res.status} — skipping.`);
@@ -462,6 +460,8 @@ async function fetchTichJobDetailUrls() {
     }
   } catch (err) {
     console.warn(`⚠️ RSS feed fetch failed: ${err.message}`);
+  } finally {
+    clearTimeout(rssTimer);
   }
 
   console.log(`✅ Total unique Ti.CH detail URLs discovered: ${allUrls.size}`);

--- a/scripts/update-tinext-jobs.mjs
+++ b/scripts/update-tinext-jobs.mjs
@@ -168,12 +168,10 @@ async function fetchJson(url) {
       },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.json();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -190,12 +188,10 @@ async function fetchHtml(url) {
       },
       redirect: 'follow',
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 

--- a/scripts/update-tpl-lugano-jobs.mjs
+++ b/scripts/update-tpl-lugano-jobs.mjs
@@ -88,10 +88,9 @@ async function fetchTplJobUrls() {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
   console.log(`🔍 Fetching TPL careers page: ${TPL_LISTING_URL}`);
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
     const res = await fetch(TPL_LISTING_URL, {
       signal: controller.signal,
       headers: {
@@ -99,7 +98,6 @@ async function fetchTplJobUrls() {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
 
     if (!res.ok) {
       console.warn(`⚠️ TPL careers page returned ${res.status}`);
@@ -114,6 +112,8 @@ async function fetchTplJobUrls() {
   } catch (err) {
     console.warn(`⚠️ Failed to fetch TPL careers page: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-vir-biotechnology-jobs.mjs
+++ b/scripts/update-vir-biotechnology-jobs.mjs
@@ -87,9 +87,9 @@ async function fetchGreenhouseJobs() {
   console.log(`🔍 Fetching Vir Biotechnology jobs from Greenhouse API`);
   console.log(`   API: ${GREENHOUSE_API}`);
   const timeoutMs = parseInt(process.env.JOBS_CRAWLER_TIMEOUT_MS || '20000', 10);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(GREENHOUSE_API, {
       signal: controller.signal,
       headers: {
@@ -97,7 +97,6 @@ async function fetchGreenhouseJobs() {
         'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) { console.warn(`⚠️ HTTP ${res.status} for Greenhouse API`); return []; }
     const data = await res.json();
     const swissJobs = parseGreenhouseJobs(data);
@@ -106,6 +105,8 @@ async function fetchGreenhouseJobs() {
   } catch (err) {
     console.warn(`⚠️ Greenhouse API fetch failed: ${err.message}`);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/scripts/update-volg-jobs.mjs
+++ b/scripts/update-volg-jobs.mjs
@@ -135,12 +135,10 @@ async function fetchPage(url) {
         'User-Agent': UA,
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     return await res.text();
-  } catch (err) {
+  } finally {
     clearTimeout(timer);
-    throw err;
   }
 }
 
@@ -454,7 +452,6 @@ async function enrichWithDetails(jobs) {
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
             },
           });
-          clearTimeout(timer);
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const html = await res.text();
           const result = parseDetailPage(html, resolveCantonLocale(job.canton));
@@ -496,9 +493,10 @@ async function enrichWithDetails(jobs) {
             enriched++;
           }
         } catch (err) {
-          clearTimeout(timer);
           failed++;
           console.warn(`  ⚠️ Detail fetch failed for ${job.title}: ${err.message}`);
+        } finally {
+          clearTimeout(timer);
         }
       }),
     );

--- a/scripts/update-vtg-jobs.mjs
+++ b/scripts/update-vtg-jobs.mjs
@@ -166,15 +166,13 @@ async function fetchVtgJobUrls() {
     const apiUrl = `${API_BASE}/jobs?${params}`;
     console.log(`🔍 Fetching VTG jobs for region ${regionKey} from Prospective API…`);
 
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-
       const res = await fetch(apiUrl, {
         signal: controller.signal,
         headers: { Accept: 'application/json', 'User-Agent': UA },
       });
-      clearTimeout(timer);
 
       if (!res.ok) {
         console.warn(`⚠️ API returned ${res.status} for region ${regionKey} — skipping.`);
@@ -199,6 +197,8 @@ async function fetchVtgJobUrls() {
       console.log(`  🎖️ ${regionKey}: ${addedCount} new unique URLs added`);
     } catch (err) {
       console.warn(`⚠️ API fetch failed for region ${regionKey}: ${err.message}`);
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/scripts/update-zambon-jobs.mjs
+++ b/scripts/update-zambon-jobs.mjs
@@ -53,11 +53,12 @@ function isCompanyJob(job) {
 function isTrustedDomain(rawUrl = '') { try { const h = new URL(rawUrl).hostname.toLowerCase(); return h.includes('zambon') || h.includes('ncoreplat.com'); } catch { return false; } }
 
 async function fetchPage(url, timeoutMs = 20000) {
+  const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, { signal: controller.signal, headers: { Accept: 'text/html,application/xhtml+xml', 'Accept-Language': 'en,it-CH;q=0.9', 'User-Agent': process.env.JOBS_CRAWLER_USER_AGENT || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)' } });
-    clearTimeout(timer); if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
+    if (!res.ok) { console.warn(`⚠️ HTTP ${res.status}`); return null; } return await res.text();
   } catch (err) { console.warn(`⚠️ Fetch failed: ${err.message}`); return null; }
+  finally { clearTimeout(timer); }
 }
 
 /**
@@ -103,9 +104,9 @@ function buildZambonDescription(title, raw) {
 async function fetchJobs() {
   // Primary: use the JSON API (Vue.js frontend loads from this)
   console.log(`🔍 Fetching Zambon jobs from API: ${CAREERS_API}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 20000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 20000);
     const res = await fetch(CAREERS_API, {
       signal: controller.signal,
       headers: {
@@ -114,7 +115,6 @@ async function fetchJobs() {
         'User-Agent': 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body = await res.json();
     const allJobs = body.data || body;
@@ -151,6 +151,8 @@ async function fetchJobs() {
     });
   } catch (err) {
     console.warn(`⚠️ API fetch failed: ${err.message} — falling back to HTML parsing`);
+  } finally {
+    clearTimeout(timer);
   }
 
   // Fallback: HTML parsing (unlikely to work for Vue.js rendered pages)

--- a/scripts/update-zegna-jobs.mjs
+++ b/scripts/update-zegna-jobs.mjs
@@ -128,9 +128,9 @@ function isZegnaJob(job) {
 // ──────────────────────────────────────────────────────────────
 
 async function fetchPage(url, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
@@ -140,7 +140,6 @@ async function fetchPage(url, timeoutMs = 15000) {
           'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)',
       },
     });
-    clearTimeout(timer);
     if (!res.ok) {
       console.warn(`⚠️ HTTP ${res.status} for ${url}`);
       return null;
@@ -149,6 +148,8 @@ async function fetchPage(url, timeoutMs = 15000) {
   } catch (err) {
     console.warn(`⚠️ Fetch failed for ${url}: ${err.message}`);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## Implementato

Estende a **136 file** la stessa correzione anti-hang già applicata a decoder + 4 sibling in #4118.

- **Antipattern rimosso:** `clearTimeout(timer)` veniva chiamato subito dopo `await fetch()` ma **prima** di `await res.text()/json()`. Così l'`AbortController` non protegge più la lettura del body: se il server stalla lo stream del corpo, la richiesta resta appesa a tempo indefinito (fino al job-timeout di 6h). È esattamente la causa del run appeso **2h42m** risolto in #4118 sul solo decoder + 4 crawler.
- **Fix:** `clearTimeout(timer)` spostato in un blocco `finally` **dopo** la lettura completa del body, così il timer di abort copre anche `res.text()/json()`.
- **Ambito crawler (134 file):** job-parser condivisi (`scripts/lib/*-job-parser.mjs`), `scripts/update-*-jobs.mjs`, `scripts/fetch-*-equivalence.mjs` e helper di rete condivisi (`dedicated-crawler-common.mjs`, `mymemory-translate.mjs`, `jobup-ch-feed-common.mjs`, `pastahr-widget-client.mjs`, `sync-gsc-orphans.mjs`). Nessuno dei 134 è stato toccato da #4118 o #4122.
- **Ambito fuori-crawler (2 file, dal review):** stessa classe di bug fuori da `scripts/`:
  - `functions/src/exchangeRate.js` — `handleGetExchangeRate`, Cloud Function live (wired in `functions/index.js:81`): un body bloccato appendeva la CF. `clearTimeout` → `finally`.
  - `components/shared/EmailInput.tsx` — `checkMxRecord`, chiamato dal submit della newsletter: un MX-check con body stallato lasciava il form su `status:'loading'`. `clearTimeout` → `finally`.
- **Audit completo fuori scripts/:** verificato il resto del codebase (`services/*`, `infra/cloudflare-worker/locale-router.js`, `adBlockDetection.ts`, `weatherService.ts`) → già conforme (clearTimeout in `finally`, oppure timeout globale `raceWithTimeout`). Nessun'altra istanza dell'antipattern.
- **Validazione:** tutti i 134 `.mjs` + `exchangeRate.js` passano `node --check`; `EmailInput.tsx` parsa via esbuild (loader tsx). L'unica modifica di comportamento è lo spostamento del `clearTimeout`.

## Non implementato (ancora)

**Nessuno** — sweep completo e live. I 4 file gemello surfacati dal sibling-gate sono stati assessati singolarmente e sono **falsi positivi** (già conformi o senza l'antipattern):

- `scripts/lib/gavi-job-parser.mjs` — `fetchUrl`: `clearTimeout(timer)` è **già** in `finally` **dopo** `await res.text()`. Corretto.
- `scripts/lib/sygnum-job-parser.mjs` — `fetchUrl`: idem, `clearTimeout` in `finally` dopo `res.text()`. Corretto.
- `scripts/update-cambiavalute-jobs.mjs` — `fetchListingPage`: `clearTimeout` già in `finally` dopo `res.text()`; il secondo `res.text()` passa per l'helper condiviso `fetchViaJinaWithRetry`. Corretto.
- `scripts/lib/klinik-schloss-mammern-job-parser.mjs` — usa l'helper condiviso `fetchHtml`; l'unico `setTimeout(200)` è un delay di cortesia. Nessun antipattern.

Push effettuato con `--no-verify` dopo assessment per-file (eccezione sibling-hook documentata in `.githooks/pre-push` / AGENTS.md § Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)