### PR TITLE
fix(job-alerts): honest "new offers" counts + freshness-first ranking

### DIFF
--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -25,7 +25,7 @@ import { createHmac } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { normalizeContract } from '../services/newsletter-content.mjs';
 import { nlNormLocale } from '../services/newsletter-template.mjs';
-import { buildAlertProfile, scoreJobForAlert, partitionByGeoPreference } from '../services/jobAlertMatching.mjs';
+import { buildAlertProfile, scoreJobForAlert, partitionByGeoPreference, freshnessBoost } from '../services/jobAlertMatching.mjs';
 import { createCantonResolvers, AGGREGATE_KEY } from '../build-plugins/shared/cantonResolvers.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { commitInChunks } from './lib/firestore-batch.mjs';
@@ -51,7 +51,16 @@ const BASE_URL = 'https://frontaliereticino.ch';
 const IMAGE_CDN_BASE = 'https://cdn.frontaliereticino.ch';
 const FROM_EMAIL = 'Frontaliere Ticino <alerts@frontaliereticino.ch>';
 const DRY_RUN = process.argv.includes('--dry-run');
+// Candidate-pool gate: jobs whose crawledAt (or postedDate fallback) falls
+// inside this window. NOTE: crawledAt refreshes on every re-crawl, so this is
+// an "inventory still listed as of the last day" gate, NOT a "new jobs" gate —
+// genuine novelty is keyed on firstSeenAt (freshnessBoost + the NEW badge),
+// and per-user novelty is enforced by the sentJobIds dedup (alert-sent-jobs.mjs).
 const MATCH_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Max job cards rendered in one alert email. Also the honest basis for the
+// subject/hero counts and for the sentJobIds rotation (only what the user
+// actually SAW is marked as sent).
+const MAX_JOB_CARDS = 10;
 const MAX_RETRY_COUNT = 2; // Max 2 retries (original + 2 = 3 total attempts)
 const RETRY_COLLECTION = 'job_alert_retry_queue';
 
@@ -634,6 +643,15 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
   const locationLabel = alert.locations?.length > 0 ? alert.locations.join(', ') : '';
   const subjectLabel = keyword || locationLabel || s.subjectDefault;
 
+  // Honest counts (live report: "186 nuove offerte per te" on an email showing
+  // 10 cards). Every count the email states — subject "(+N more)", hero,
+  // preheader — is based on the jobs actually RENDERED in this email, not the
+  // full match-pool size: the pool is a rolling crawledAt window that re-admits
+  // the whole re-crawled inventory daily, so its size says nothing about
+  // novelty. What makes the rendered jobs "new for you" is the sentJobIds
+  // dedup (never emailed to this alert before) + the freshness-first ranking.
+  const shownJobs = matchedJobs.slice(0, MAX_JOB_CARDS);
+
   // Subject: lead with the most relevant job (LinkedIn-style personalization).
   // Format: "🔔 {title} at {company}" or "🔔 {title} at {company} (+N more)"
   // Capped at 78 characters total. Empty matches fall back to the legacy generic subject.
@@ -694,10 +712,10 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
   if (matchedJobs.length === 0) {
     subject = `${s.subjectNew(matchedJobs.length)} ${s.subjectFor}: ${subjectLabel}`;
   } else {
-    const topJob = matchedJobs[0];
+    const topJob = shownJobs[0];
     const topTitle = stripTitleNoise(cleanTitle(topJob.titleByLocale?.[locale] || topJob.titleByLocale?.it || topJob.title || s.fallbackTitle));
     const topCompany = (topJob.company || '').trim();
-    const extra = matchedJobs.length - 1;
+    const extra = shownJobs.length - 1;
     const bell = '\ud83d\udd14';
     const suffix = extra > 0 ? ` (+${extra} ${s.more})` : '';
     // Build: "🔔 {title} at {company}{suffix}"
@@ -757,7 +775,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
     return `<span style="font-size:10px;background:${bg};color:${color};padding:2px 8px;border-radius:6px;text-transform:uppercase;letter-spacing:0.5px;font-weight:600;">${label}</span>`;
   };
 
-  const jobCards = matchedJobs.slice(0, 10).map((job) => {
+  const jobCards = shownJobs.map((job) => {
     const title = cleanTitle(job.titleByLocale?.[locale] || job.titleByLocale?.it || job.title || s.fallbackTitle);
     const company = job.company || '';
     const rawLocation = job.location || job.addressLocality || '';
@@ -832,7 +850,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
   </style>
 </head>
 <body>
-  <div style="display:none!important;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">${s.preheader(matchedJobs.length, subjectLabel)}&nbsp;\u200c\u200c\u200c\u200c</div>
+  <div style="display:none!important;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">${s.preheader(shownJobs.length, subjectLabel)}&nbsp;\u200c\u200c\u200c\u200c</div>
   <table width="100%" cellpadding="0" cellspacing="0" style="background:${LIGHT_BG};">
     <tr><td align="center" style="padding:0;">
       <table class="outer-table" width="620" cellpadding="0" cellspacing="0" style="width:100%;max-width:620px;">
@@ -853,7 +871,7 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
 
         <!-- Hero -->
         <tr><td style="background:${BRAND_DARK};padding:20px 28px 28px;" class="section-pad">
-          <div style="font-size:22px;font-weight:800;color:${WHITE};margin:0;">${s.heroTitle(matchedJobs.length)}</div>
+          <div style="font-size:22px;font-weight:800;color:${WHITE};margin:0;">${s.heroTitle(shownJobs.length)}</div>
           <div style="font-size:13px;color:#94a3b8;margin-top:6px;">${s.filters}: ${filterSummary}</div>
         </td></tr>
 
@@ -912,8 +930,8 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
 
   // ── Plaintext alternative (multipart/alternative) ──────────
   // Built from the same data source as the HTML — never regex-stripped.
-  const heroLine = s.heroTitle(matchedJobs.length).replace(/\ud83d\udd14\s*/, '\u{1F514} ');
-  const textJobs = matchedJobs.slice(0, 10).map((job) => {
+  const heroLine = s.heroTitle(shownJobs.length).replace(/\ud83d\udd14\s*/, '\u{1F514} ');
+  const textJobs = shownJobs.map((job) => {
     const title = cleanTitle(job.titleByLocale?.[locale] || job.titleByLocale?.it || job.title || s.fallbackTitle);
     const company = job.company || '';
     const rawLocation = (job.location || job.addressLocality || '').replace(/^[-\u2013\u2014\s]+/, '').trim();
@@ -1425,8 +1443,17 @@ async function main() {
     // Canary gate: broadcast-restricted ads only ever match the OWNER's alerts,
     // so a test listing can't reach real alert subscribers.
     const eligibleJobs = isOwnerEmail(alert.email) ? recentJobs : recentJobs.filter((j) => !isCanaryJob(j));
+    // Relevance score + graduated freshness boost: a job first seen within
+    // 24h/48h gets +2/+1 on top of its relevance so GENUINELY new listings win
+    // near-ties against the re-crawled backlog (the pool re-admits the whole
+    // inventory daily — see MATCH_WINDOW_MS). The boost never resurrects a
+    // 0-score job: relevance still decides IF a job surfaces, freshness only
+    // decides how high.
     const sorted = eligibleJobs
-      .map((job) => ({ job, score: scoreJobForAlert(job, profile) }))
+      .map((job) => {
+        const relevance = scoreJobForAlert(job, profile);
+        return { job, score: relevance > 0 ? relevance + freshnessBoost(job, now) : 0 };
+      })
       .filter((m) => m.score > 0)
       .sort((a, b) => {
         // Primary: higher score first.
@@ -1498,9 +1525,9 @@ async function main() {
     const { subject, html, text, unsubscribeUrl } = buildAlertEmail(alert, liveMatched, autologinEnabled);
 
     // Mark the jobs actually shown (the rendered cards) as sent so they rotate
-    // out next run. buildAlertEmail renders up to 10 cards. References, not
-    // copies — cheap to carry to the post-send persistence step.
-    const sentJobs = liveMatched.slice(0, 10);
+    // out next run. buildAlertEmail renders up to MAX_JOB_CARDS cards.
+    // References, not copies — cheap to carry to the post-send persistence step.
+    const sentJobs = liveMatched.slice(0, MAX_JOB_CARDS);
 
     // Per-user send-time (#3798): this channel's own preferred hour first
     // (job_alert_subscribers/{email}), falling back to the subscriber's

--- a/services/jobAlertMatching.mjs
+++ b/services/jobAlertMatching.mjs
@@ -63,6 +63,45 @@ const SWISS_CANTONS = new Set([
 export const GEO_PREFERENCE_MIN_LOCAL = 5;
 
 /**
+ * Freshness-boost windows for {@link freshnessBoost}. The 48h outer window
+ * deliberately matches the "✨ NUOVA" badge window in the alert email
+ * (send-job-alerts.mjs) so a boosted job and a badged job are the same thing.
+ */
+export const FRESHNESS_BOOST_24H_MS = 24 * 60 * 60 * 1000;
+export const FRESHNESS_BOOST_48H_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Relevance bonus for GENUINELY new jobs, keyed on `firstSeenAt` — the only
+ * recency field the crawlers set once and never refresh (`crawledAt` updates on
+ * every re-crawl, `postedDate` is employer-declared and often missing/stale).
+ *
+ * Why: the alert sender's candidate pool is a rolling `crawledAt` window, which
+ * re-admits the ENTIRE re-crawled inventory every day (~16k jobs vs ~400
+ * actually new). Score ties were previously broken by `firstSeenAt` recency,
+ * but a stale job with a marginally higher relevance score still headlined the
+ * email over a just-published equally-relevant one. This graduated boost
+ * (+2 within 24h, +1 within 48h) lets truly fresh listings win those near-ties
+ * without letting an irrelevant-but-new job outrank a strong old match.
+ *
+ * Pure: caller supplies `nowMs`. Returns 0 for jobs with no parseable
+ * `firstSeenAt` (never resurrects a 0-score job — callers must only add the
+ * boost to already-positive scores).
+ *
+ * @param {object} job    Job from data/jobs.json.
+ * @param {number} nowMs  Current epoch ms.
+ * @returns {0|1|2}
+ */
+export function freshnessBoost(job, nowMs) {
+  const ts = Date.parse(String(job?.firstSeenAt || ''));
+  if (!Number.isFinite(ts)) return 0;
+  const age = nowMs - ts;
+  if (age < 0) return 0; // malformed future timestamp — no boost
+  if (age <= FRESHNESS_BOOST_24H_MS) return 2;
+  if (age <= FRESHNESS_BOOST_48H_MS) return 1;
+  return 0;
+}
+
+/**
  * @typedef {object} AlertProfile
  * @property {TokenSet}  hardKeywords  Explicit user keywords (hard filter when non-empty).
  * @property {TokenSet}  softTokens    Intent tokens from source job + newsletter profile.

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -128,7 +128,12 @@ function toDateValue(job) {
   // carry a malformed/ambiguous postedDate (European DD/MM/YY) that would
   // otherwise shadow a perfectly good firstSeenAt and force the job into
   // decayFactor's neutral UNDATED branch (date present ≠ date usable).
-  for (const raw of [job?.postedDate, job?.crawledAt, job?.publishedAt, job?.firstSeenAt]) {
+  // Order matters: firstSeenAt (set once at discovery, never refreshed) must
+  // come BEFORE crawledAt — crawledAt refreshes on every re-crawl, so with it
+  // first every re-crawled job "aged" ~0 days forever, which both defeated the
+  // anti-evergreen popularity decay below and made the no-profile "fresh
+  // slots" rotation in matchJobsForSubscriber treat stale inventory as new.
+  for (const raw of [job?.postedDate, job?.firstSeenAt, job?.publishedAt, job?.crawledAt]) {
     if (!raw) continue;
     const ts = parseDateField(raw);
     if (Number.isFinite(ts)) return ts;

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -78,6 +78,61 @@ describe('job alert email — subject personalization', () => {
   });
 });
 
+describe('job alert email — honest counts (shown jobs, never the raw pool size)', () => {
+  // Live regression (July 2026): "🔔 186 nuove offerte per te" on an email
+  // rendering 10 cards. The candidate pool is a rolling crawledAt window that
+  // re-admits the whole re-crawled inventory daily (~16k jobs, only ~400
+  // genuinely new), so the raw match count is meaningless as a "new" claim.
+  // Every stated count must describe what the email actually shows.
+  it('hero and preheader count the rendered cards (max 10), not all matches', () => {
+    const jobs = Array.from({ length: 186 }, (_, i) => fixtureJob({ title: `Job ${i + 1}` }));
+    const result = buildAlertEmail(fixtureAlert('it'), jobs, true);
+    expect(result.html).toContain('10 nuove offerte per te');
+    expect(result.html).not.toContain('186 nuove');
+    // Preheader too.
+    expect(result.html).toContain('10 nuove offerte:');
+    // Plaintext hero line.
+    expect(result.text).toContain('10 nuove offerte per te');
+  });
+
+  it('subject "+N more" counts the other rendered cards, not the pool', () => {
+    const jobs = Array.from({ length: 186 }, (_, i) => fixtureJob({ title: `Job ${i + 1}` }));
+    const result = buildAlertEmail(fixtureAlert('en'), jobs, true);
+    expect(result.subject).toContain('(+9 more)');
+    expect(result.subject).not.toContain('185');
+  });
+
+  it('counts stay exact when fewer than 10 jobs match', () => {
+    const jobs = Array.from({ length: 3 }, (_, i) => fixtureJob({ title: `Job ${i + 1}` }));
+    const result = buildAlertEmail(fixtureAlert('it'), jobs, true);
+    expect(result.html).toContain('3 nuove offerte per te');
+    expect(result.subject).toContain('(+2 altre offerte)');
+  });
+});
+
+describe('job alert email — ✨ NUOVA badge keyed on firstSeenAt (48h)', () => {
+  it('badges a job first seen within 48h', () => {
+    const job = fixtureJob({ firstSeenAt: new Date(Date.now() - 3 * 3600 * 1000).toISOString() });
+    const result = buildAlertEmail(fixtureAlert('it'), [job], true);
+    expect(result.html).toContain('✨ NUOVA');
+  });
+
+  it('does NOT badge a job first seen 5 days ago, even if just re-crawled', () => {
+    const job = fixtureJob({
+      firstSeenAt: new Date(Date.now() - 5 * 24 * 3600 * 1000).toISOString(),
+      crawledAt: new Date().toISOString(), // re-crawl must not fake novelty
+    });
+    const result = buildAlertEmail(fixtureAlert('it'), [job], true);
+    expect(result.html).not.toContain('✨ NUOVA');
+  });
+
+  it('does NOT badge a job with no firstSeenAt at all', () => {
+    const job = fixtureJob({ firstSeenAt: undefined });
+    const result = buildAlertEmail(fixtureAlert('it'), [job], true);
+    expect(result.html).not.toContain('✨ NUOVA');
+  });
+});
+
 describe('job alert email — plaintext alternative', () => {
   it('returns text alongside html', () => {
     const result = buildAlertEmail(fixtureAlert('it'), [fixtureJob()], true);
@@ -215,9 +270,10 @@ describe('job alert email — subject truncation polish', () => {
     expect(result.subject.length).toBeLessThanOrEqual(78);
     // No dangling punctuation directly before the ellipsis.
     expect(result.subject).not.toMatch(/[,;:\-]\u2026/);
-    // Full title preserved (+57 altre offerte) — company was dropped.
+    // Full title preserved (+9 altre offerte: honest shown-count, 10 cards
+    // rendered — never the raw match-pool size) — company was dropped.
     expect(result.subject).toContain('Revisori dei conti, esperti tecnici e clinici');
-    expect(result.subject).toContain('(+57 altre offerte)');
+    expect(result.subject).toContain('(+9 altre offerte)');
     // No "presso ..." segment when company was dropped.
     expect(result.subject).not.toMatch(/\bpresso\b/);
   });
@@ -265,7 +321,8 @@ describe('job alert email — subject title noise (Pensum / gender markers)', ()
     // No unbalanced "(" left anywhere in the subject.
     expect((result.subject.match(/\(/g) || []).length).toBe((result.subject.match(/\)/g) || []).length);
     expect(result.subject).toContain('Senior Technical Product Manager - Portafogli');
-    expect(result.subject).toContain('(+48 altre offerte)');
+    // Honest shown-count: 10 cards rendered → +9, not the raw pool size (+48).
+    expect(result.subject).toContain('(+9 altre offerte)');
   });
 
   it('strips range Pensum "(80-100%)" and gender markers "(m/w/d)"', () => {

--- a/tests/job-alert-matching.test.ts
+++ b/tests/job-alert-matching.test.ts
@@ -3,6 +3,7 @@ import {
   buildAlertProfile,
   scoreJobForAlert,
   partitionByGeoPreference,
+  freshnessBoost,
   GEO_PREFERENCE_MIN_LOCAL,
 } from '../services/jobAlertMatching.mjs';
 
@@ -388,5 +389,37 @@ describe('jobAlertMatching — profile geo preference (issue #2993)', () => {
     const profile = buildAlertProfile({ keywords: ['infermiere'] }, {}, { cityToCanton });
     const ranked = [baselNurse(0), tiNurse(0)];
     expect(partitionByGeoPreference(ranked, profile)).toEqual(ranked);
+  });
+});
+
+describe('jobAlertMatching — freshnessBoost (genuinely-new jobs win near-ties)', () => {
+  const NOW = Date.parse('2026-07-13T08:00:00Z');
+  const hoursAgo = (h: number) => new Date(NOW - h * 3600 * 1000).toISOString();
+
+  it('+2 for a job first seen within 24h', () => {
+    expect(freshnessBoost(job({ firstSeenAt: hoursAgo(3) }), NOW)).toBe(2);
+  });
+
+  it('+1 for a job first seen between 24h and 48h ago', () => {
+    expect(freshnessBoost(job({ firstSeenAt: hoursAgo(36) }), NOW)).toBe(1);
+  });
+
+  it('0 for a job first seen more than 48h ago', () => {
+    expect(freshnessBoost(job({ firstSeenAt: hoursAgo(72) }), NOW)).toBe(0);
+  });
+
+  it('0 when firstSeenAt is missing or unparseable (never invents freshness)', () => {
+    expect(freshnessBoost(job({ firstSeenAt: undefined }), NOW)).toBe(0);
+    expect(freshnessBoost(job({ firstSeenAt: 'not-a-date' }), NOW)).toBe(0);
+    expect(freshnessBoost(null as unknown as Record<string, unknown>, NOW)).toBe(0);
+  });
+
+  it('0 for a malformed FUTURE firstSeenAt', () => {
+    expect(freshnessBoost(job({ firstSeenAt: hoursAgo(-5) }), NOW)).toBe(0);
+  });
+
+  it('is keyed on firstSeenAt only — a fresh crawledAt on an old job earns nothing', () => {
+    const recrawled = job({ firstSeenAt: hoursAgo(24 * 30), crawledAt: hoursAgo(1) });
+    expect(freshnessBoost(recrawled, NOW)).toBe(0);
   });
 });

--- a/tests/newsletter-template-tracking.test.ts
+++ b/tests/newsletter-template-tracking.test.ts
@@ -284,6 +284,18 @@ describe('popularity decay (anti-evergreen-freeze)', () => {
     expect(decayFactor(job, NOW)).toBeCloseTo(1, 5);
     expect(decayFactor({ postedDate: '30/13/26', firstSeenAt: daysAgoIso(30) }, NOW)).toBeCloseTo(0.5, 5);
   });
+
+  it('a daily re-crawl cannot reset a job\'s age (firstSeenAt beats crawledAt)', () => {
+    // crawledAt refreshes on EVERY re-crawl; with it ahead of firstSeenAt in
+    // the date-field order, every re-crawled postedDate-less job "aged" ~0 days
+    // forever and the anti-evergreen decay never kicked in.
+    const evergreen = { firstSeenAt: daysAgoIso(90), crawledAt: daysAgoIso(0) };
+    expect(decayFactor(evergreen, NOW)).toBeCloseTo(0.125, 5);
+  });
+
+  it('still uses crawledAt as the last-resort date when nothing else parses', () => {
+    expect(decayFactor({ crawledAt: daysAgoIso(30) }, NOW)).toBeCloseTo(0.5, 5);
+  });
 });
 
 describe('no-profile job blend + backfill-slug relevance', () => {


### PR DESCRIPTION
## Implementato

Live report (13 lug 2026): l'email di job alert dichiarava «🔔 186 nuove offerte per te» mostrando 10 card. Il pool candidati è una finestra rolling di 24h su `crawledAt`, che si aggiorna a ogni ricrawl: nello snapshot corrente **16.685 job hanno `crawledAt` <24h ma solo 393 sono genuinamente nuovi** (`firstSeenAt` <24h). Ogni conteggio dell'email citava quel pool.

- **`scripts/send-job-alerts.mjs` — conteggi onesti**: subject «(+N altre offerte)», hero e preheader ora contano i job effettivamente renderizzati (max 10 card, nuova costante `MAX_JOB_CARDS`), garantiti mai-visti-prima dall'utente dal dedup `sentJobIds` — mai la dimensione del pool. Slice della rotazione allineata alla stessa costante.
- **`services/jobAlertMatching.mjs` — `freshnessBoost(job, nowMs)`** (pura): +2 per job first-seen ≤24h, +1 ≤48h (stessa finestra del badge ✨ NUOVA), sommata nel send loop solo ai punteggi già positivi — le offerte davvero nuove vincono i quasi-pareggi contro il backlog ricrawlato, senza mai resuscitare un job a score 0.
- **`services/newsletter-content.mjs` — ordine campi data in `toDateValue`**: `firstSeenAt` ora precede `crawledAt`. Prima, ogni job ricrawlato senza `postedDate` risultava «vecchio ~0 giorni» per sempre: decay anti-evergreen azzerato e slot "fresh" della rotazione no-profile falsati.
- **Verifica logica "new" nei crawler: corretta, nessuna modifica** — `firstSeenAt` è set-once e preservato da entrambi i percorsi di merge; `postedDate` mantiene la data più vecchia.
- **Test**: aspettative subject aggiornate alla semantica shown-count; nuova copertura per conteggi onesti, finestre badge NUOVA, `freshnessBoost`, e regressione «il ricrawl non azzera l'età» (`decayFactor`). Suite locale: 78.065 passed, 0 failed (6 file non caricabili preesistenti, dipendono da artefatti di build assenti nell'ambiente).

## Non implementato (ancora)

- Incoerenza semantica `crawledAt` in `scripts/lib/dedicated-crawler-common.mjs`: `mergeAndDeduplicate` (pipeline shared) mantiene il valore più VECCHIO (`prev.crawledAt || next.crawledAt`), `mergePreserveLocaleData` (crawler dedicati) lo aggiorna a ogni run — i job del percorso shared possono uscire dal pool alert dopo 24h pur essendo ancora attivi — **PR concatenata (in arrivo, branch in lavorazione)**

Sibling surfacati da `check-sibling-patterns --strict`, tutti valutati singolarmente — falsi positivi:
- `scripts/backfill-jobalerts-from-newsletter.mjs`, `functions/src/jobAlertBackfillCore.js`, `functions/src/jobAlertBackfillTrigger.js` — falso positivo: importano `buildAlertProfile`/`scoreJobForAlert` per creare/backfillare alert, non dichiarano conteggi né rankano job per email; le firme esistenti sono invariate (solo aggiunto un export nuovo).
- `scripts/send-newsletter.mjs`, `scripts/newsletter-qa.mjs`, `services/newsletterPreview.ts` — falso positivo: `matchedJobs` lì è già il set mostrato (≤4 card da `matchJobsForSubscriber`), nessun claim di conteggio dal pool.
- `services/newsletter-template.mjs`, `scripts/newsletter-template.mjs` — falso positivo: `heroTitle` è una stringa editoriale fissa («Le cose utili della settimana…»), `jobCards` renderizza il set già limitato; nessun conteggio.
- `build-plugins/shared/slimJobIndex.ts` — falso positivo: `'postedDate', 'crawledAt', 'firstSeenAt'` è un elenco di NOMI di campi da includere nell'indice slim, non un ordine di scelta data.
- `build-plugins/jobSectorPagesPlugin.ts`, `build-plugins/orphanQueryLandingPlugin.ts` — falso positivo: condividono il token `jobCards` (markup SSG) ma non hanno logica "new"/badge/conteggi (`grep isNew|firstSeenAt` → 0 hit).
- `build-plugins/comparisonsHubCopy.ts`, `build-plugins/comparisonsHubPlugin.ts`, `build-plugins/faqHubPlugin.ts` — falso positivo: `heroTitle` è il titolo hero delle pagine hub, collisione puramente lessicale.
- `scripts/lib/alert-sent-jobs.mjs`, `scripts/check-subscriber-history.mjs` — falso positivo: condividono i token `sentJobIds`/`sentJobs`; il modulo dedup è invariato nella semantica (la slice usa ora la costante), lo script history è read-only diagnostico.
- `services/jobAlertService.ts`, `services/jobMatchProfile.ts`, `services/locToken.mjs`, `services/publisherBlastMatch.mjs` — falso positivo: condividono solo import/lessico col modulo matcher; nessuna logica di freschezza o conteggio "new".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB)_