### PR TITLE
Completa le leve AI del backlog: kill-switch fact-check cache + dedup retry min-words

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -968,6 +968,54 @@ const MIN_WORDS_MODEL_ROTATION = [
   GH_MODEL_LIGHT,                    // attempt 6: gpt-4o-mini (then expansion fallback)
 ];
 
+// Quality-NEUTRAL dedup for the min-words retry model pick — DEFAULT ON,
+// with an explicit rollback flag per this file's usual "env-gated for
+// rollback" convention (see e.g. SOURCE_DROP_OFF_TOPIC above).
+// Set to '0' to restore the exact pre-existing selection (plain
+// Math.min(attempt-1, rotation.length-1) clamp, duplicates allowed).
+const CREATE_ARTICLE_MINWORDS_DEDUP = (process.env.CREATE_ARTICLE_MINWORDS_DEDUP ?? '1') !== '0';
+
+/**
+ * Pick the model for a given min-words retry attempt from `rotation`,
+ * skipping an immediate back-to-back repeat of `previousModel` (the model
+ * actually used on the attempt right before this one).
+ *
+ * Why this is needed: the plain index `Math.min(attempt - 1, rotation.length
+ * - 1)` clamps at the LAST entry once `attempt` exceeds `rotation.length`.
+ * CREATE_ARTICLE_MIN_WORDS_RETRIES (env, default 6) can be raised above
+ * MIN_WORDS_MODEL_ROTATION.length (6) — every attempt beyond the rotation's
+ * length would then clamp to the SAME last model as the attempt right
+ * before it, back-to-back, which is a near-certain repeat of the same
+ * too-short output (same model + same prompt ⇒ same failure). The same
+ * clamp-collision can also happen if a caller-supplied `previousModel`
+ * (from outside this loop) happens to coincide with the rotation's pick.
+ *
+ * Quality-NEUTRAL by construction: same set of models, same relative
+ * order — this only ADVANCES to the next rotation entry (wrapping once
+ * past the end) when the plain pick would repeat `previousModel`; it never
+ * reorders, drops, or substitutes a different/cheaper model. For the
+ * default config (retries == rotation.length == 6) the index never repeats
+ * on its own, so this is a no-op there — behavior changes ONLY once
+ * CREATE_ARTICLE_MIN_WORDS_RETRIES is raised past 6 (the exact case that
+ * used to silently repeat the last model).
+ *
+ * Pure + exported for testability (no network, no I/O).
+ */
+export function selectMinWordsRetryModel(attempt, previousModel, rotation = MIN_WORDS_MODEL_ROTATION, enabled = CREATE_ARTICLE_MINWORDS_DEDUP) {
+  const baseIndex = Math.min(attempt - 1, rotation.length - 1);
+  if (!enabled || rotation.length <= 1) return rotation[baseIndex];
+  let idx = baseIndex;
+  let guard = 0;
+  // Terminates within rotation.length steps: rotation entries are distinct,
+  // so wrapping all the way around always finds one that isn't previousModel
+  // (or, if every entry somehow equals previousModel, the guard stops it).
+  while (rotation[idx] === previousModel && guard < rotation.length) {
+    idx = (idx + 1) % rotation.length;
+    guard++;
+  }
+  return rotation[idx];
+}
+
 const RUN_REPORT = {
   startedAt: new Date().toISOString(),
   endedAt: null,
@@ -2928,6 +2976,46 @@ const EVERGREEN_FACTS_BRIEF = `FATTI VERIFICATI (ground truth — il fact-checke
 - Le aliquote fiscali (imposta alla fonte, aliquote federali/cantonali) sono stabilite da leggi federali/cantonali e amministrate da AFC/ESTV a livello federale e dalle amministrazioni cantonali delle contribuzioni — MAI da UFAS (previdenza sociale, AVS/AI) né da BFS (statistica: rileva dati, non fissa aliquote).
 - LAMal = assicurazione malattia (NON "tassa sulla salute"); frontalieri G hanno diritto d'opzione; franchige adulti CHF 300–2500.`;
 
+// ── Fact-check response cache (DEFAULT ON — kill switch) ────────────────
+// origin/main already hard-codes `cache: true` on this exact call (no flag,
+// no namespace) — the cache is ALREADY ACTIVE in production today. This
+// function's job is only to preserve that behavior by default; the env var
+// is a KILL SWITCH for turning it OFF, not an opt-in for turning it on.
+// SAFE-BY-DESIGN: ai-models.mjs' _responseCacheKey (scripts/lib/ai-models.mjs
+// ~1070-1088) hashes `messages` (full prompt = full article body) + `model` +
+// `bypassForceChain` + the live AI_MODELS_FORCE_CHAIN env state, so a cache
+// hit can only occur for the EXACT same article body, verified by the EXACT
+// same judge model, in the EXACT same force-chain state — there is no
+// cross-content or cross-model reuse possible, and a forced-local response
+// cannot enter the remote-consensus path (bypassForceChain is folded into
+// the key), so the "circular self-consensus" hazard ai-models.mjs flags
+// (~1039-1050) for this caller does not apply to the concrete key shape.
+// BENEFIT: dedupes the ~5s outer FACTCHECK_INFRA_RETRIES re-check
+// (triggered when a verifier returns non-JSON, see loop below) — a retry of
+// an unchanged body against the same judge model reuses the deterministic
+// (temperature 0) verdict instead of re-running the full fallback cascade.
+// If a circular-self-consensus problem is ever observed in practice, set
+// CREATE_ARTICLE_FACTCHECK_CACHE=0 to disable without a code change.
+function isFactCheckCacheEnabled() {
+  const raw = (process.env.CREATE_ARTICLE_FACTCHECK_CACHE || '').trim();
+  if (raw === '') return true; // unset → preserve production default (cache ON)
+  return !/^(0|false|no|off)$/i.test(raw); // explicit OFF values disable; anything else stays ON
+}
+
+/**
+ * Pure helper: builds the opts object passed to _aiCallLLM for a single
+ * fact-check verification call. Extracted so the cache on/off behavior is
+ * unit-testable without any network call. Never touches model choice,
+ * consensus logic, thresholds, or the blocking verdict — only whether the
+ * response cache is engaged for this call. DEFAULT ON (kill switch): when
+ * enabled this produces exactly `{ ...baseOpts, cache: true }`, byte-identical
+ * to the pre-existing production call (no cacheNamespace, so the cache key —
+ * which folds in `ns` — is unchanged from what's already live today).
+ */
+export function buildFactCheckCallOptions(baseOpts, cacheEnabled = isFactCheckCacheEnabled()) {
+  return cacheEnabled ? { ...baseOpts, cache: true } : { ...baseOpts };
+}
+
 /**
  * PRIMARY BLOCKING — Multi-model consensus fact verification.
  *
@@ -3290,14 +3378,14 @@ async function _runSingleFactCheck(model, prompt, opts = {}) {
     // Fact-check output is a compact JSON issues list (rarely >1500 tokens).
     // 60s is ample for any responsive model; a checker that hasn't replied in
     // 60s is stalled — fail over fast instead of burning the old 120s budget.
-    // cache:true — verdict is deterministic (temperature 0); re-checking an
-    // unchanged body with the same judge model reuses the result instead of
-    // re-running the full fallback cascade.
     // bypassForceChain:true — the verification models are the real quality gate
     // and must stay independent of AI_MODELS_FORCE_CHAIN. Without this, forcing
     // generation onto the local model would also force the checker onto it
     // (the model grading itself), so a forced run could publish unchecked content.
-    { model, temperature: 0.0, maxTokens: 4000, timeout: 60_000, cache: true, bypassForceChain: true, modelUsedRef }
+    // cache — see buildFactCheckCallOptions() above: DEFAULT ON (kill switch
+    // via CREATE_ARTICLE_FACTCHECK_CACHE=0), preserving the production
+    // `cache: true` this call already had.
+    buildFactCheckCallOptions({ model, temperature: 0.0, maxTokens: 4000, timeout: 60_000, bypassForceChain: true, modelUsedRef })
   );
   // Guard: if the full remote cascade is exhausted, callLLM falls through to
   // local/fallback — the same model that may have generated the content.
@@ -9047,6 +9135,10 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     console.error(`  📏 Source thin (${pageContent.length} chars) → min IT words target: ${adaptiveMinWords} (was ${CREATE_ARTICLE_MIN_IT_WORDS})`);
   }
 
+  // Tracks the model used by the immediately preceding attempt, for
+  // selectMinWordsRetryModel()'s back-to-back-duplicate skip below.
+  let previousMinWordsModel = null;
+
   for (let attempt = 1; attempt <= CREATE_ARTICLE_MIN_WORDS_RETRIES; attempt++) {
     // Wall-clock guard for the local-only cascade (2026-07-06, incident run
     // 28802314827): once local/fallback has generated at least one attempt
@@ -9075,7 +9167,12 @@ async function generateAndValidateArticle(url, sourceContext = null) {
         throw err;
       }
     }
-    const modelSlot = MIN_WORDS_MODEL_ROTATION[Math.min(attempt - 1, MIN_WORDS_MODEL_ROTATION.length - 1)];
+    // selectMinWordsRetryModel() picks the same model the plain index would,
+    // except it skips an immediate back-to-back repeat of the previous
+    // attempt's model (see its doc comment — quality-neutral, default ON,
+    // CREATE_ARTICLE_MINWORDS_DEDUP=0 reverts to the plain clamp).
+    const modelSlot = selectMinWordsRetryModel(attempt, previousMinWordsModel);
+    previousMinWordsModel = modelSlot;
     const useGeminiDirect = modelSlot === 'gemini';
     // Higher temperature on later attempts to get more varied/longer output
     const tempBoost = attempt >= 7 ? 0.9 : (attempt >= 5 ? 0.8 : 0.7);

--- a/tests/create-article-ai-pipeline-levers.test.ts
+++ b/tests/create-article-ai-pipeline-levers.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the two AI-optimization levers added to scripts/create-article.mjs
+ * on top of the fact-check gate (see AGENTS.md Non-Negotiable #1 — never
+ * publish unverified content):
+ *
+ * LEVA A — Fact-check response cache (DEFAULT ON — kill switch).
+ *   buildFactCheckCallOptions() decides whether a fact-check _aiCallLLM()
+ *   call carries `cache: true`, gated by the CREATE_ARTICLE_FACTCHECK_CACHE
+ *   env flag. Production already hard-codes `cache: true` on this call (no
+ *   flag, no namespace) — so the default here must stay ON to preserve
+ *   today's behavior byte-identically; the env var is a kill switch to turn
+ *   the cache OFF, not an opt-in to turn it on. Safe by construction
+ *   (ai-models.mjs' response cache key is content+model+force-chain-state
+ *   keyed — see scripts/lib/ai-models.mjs ~1070-1088), so no cacheNamespace
+ *   is added either (adding one would change the cache key vs. production).
+ *
+ * LEVA B — Min-words retry model dedup (quality-neutral, DEFAULT ON).
+ *   selectMinWordsRetryModel() never repeats the immediately preceding
+ *   attempt's model back-to-back. Same model set, same relative order —
+ *   only skips a redundant consecutive repeat (which is a near-certain
+ *   repeat of the same too-short output).
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import { buildFactCheckCallOptions, selectMinWordsRetryModel } from '../scripts/create-article.mjs';
+
+describe('buildFactCheckCallOptions (Leva A — fact-check cache, default ON / kill switch)', () => {
+  const ENV_KEY = 'CREATE_ARTICLE_FACTCHECK_CACHE';
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it('includes exactly cache: true (no cacheNamespace) when the env flag is unset — byte-identical to production', () => {
+    delete process.env[ENV_KEY];
+    const opts = buildFactCheckCallOptions({ model: 'gpt-4o', temperature: 0, maxTokens: 4000, timeout: 60_000, bypassForceChain: true });
+
+    expect(opts).toMatchObject({ cache: true, model: 'gpt-4o', temperature: 0, maxTokens: 4000, timeout: 60_000, bypassForceChain: true });
+    expect(opts).not.toHaveProperty('cacheNamespace');
+  });
+
+  it('includes exactly cache: true (no cacheNamespace) when the env flag is the empty string', () => {
+    process.env[ENV_KEY] = '';
+    const opts = buildFactCheckCallOptions({ model: 'gpt-4o' });
+    expect(opts).toMatchObject({ cache: true });
+    expect(opts).not.toHaveProperty('cacheNamespace');
+  });
+
+  it('does NOT include cache for explicit OFF flag values (kill switch)', () => {
+    for (const v of ['0', 'false', 'no', 'off', 'OFF', 'False']) {
+      process.env[ENV_KEY] = v;
+      const opts = buildFactCheckCallOptions({ model: 'gpt-4o' });
+      expect(opts, `flag value "${v}" must disable cache`).not.toHaveProperty('cache');
+    }
+  });
+
+  it('includes cache: true for explicit ON-ish flag values (any non-OFF value stays ON)', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', 'anything-else']) {
+      process.env[ENV_KEY] = v;
+      const opts = buildFactCheckCallOptions({ model: 'gpt-4o', bypassForceChain: true });
+      expect(opts, `flag value "${v}" must keep cache enabled`).toMatchObject({ cache: true });
+      expect(opts).not.toHaveProperty('cacheNamespace');
+    }
+  });
+
+  it('the explicit cacheEnabled param overrides env (unit-test hook, no network/env needed)', () => {
+    delete process.env[ENV_KEY];
+    expect(buildFactCheckCallOptions({ model: 'x' }, true)).toMatchObject({ cache: true });
+    process.env[ENV_KEY] = '0';
+    expect(buildFactCheckCallOptions({ model: 'x' }, false)).not.toHaveProperty('cache');
+  });
+
+  it('never mutates the caller-supplied base opts object', () => {
+    const base = { model: 'gpt-4o', modelUsedRef: { model: null } };
+    const frozenSnapshot = JSON.stringify({ model: base.model });
+    buildFactCheckCallOptions(base, true);
+    expect(JSON.stringify({ model: base.model })).toBe(frozenSnapshot);
+    expect(base).not.toHaveProperty('cache');
+  });
+});
+
+describe('selectMinWordsRetryModel (Leva B — min-words retry model dedup, default ON)', () => {
+  it('never repeats the previous attempt model back-to-back over an extended retry run (real rotation)', () => {
+    // Uses the REAL MIN_WORDS_MODEL_ROTATION (default param) — no rotation
+    // override — across more attempts than the rotation has entries, which
+    // is exactly the case that used to clamp-repeat the last model.
+    let previous: string | null = null;
+    for (let attempt = 1; attempt <= 15; attempt++) {
+      const model = selectMinWordsRetryModel(attempt, previous);
+      if (previous !== null) {
+        expect(model, `attempt ${attempt} repeated previous model "${previous}"`).not.toBe(previous);
+      }
+      previous = model;
+    }
+  });
+
+  it('is a no-op for the default 6-attempt config (all 6 picks already distinct, no behavior change)', () => {
+    let previous: string | null = null;
+    const picks: string[] = [];
+    for (let attempt = 1; attempt <= 6; attempt++) {
+      const model = selectMinWordsRetryModel(attempt, previous);
+      picks.push(model);
+      previous = model;
+    }
+    expect(new Set(picks).size).toBe(6);
+  });
+
+  it('advances to the next distinct rotation entry when the plain pick would repeat the previous model', () => {
+    const rotation = ['a', 'b', 'c'];
+    // Plain index for attempt 2 is rotation[1] = 'b'; if attempt 1 already
+    // used 'b' (e.g. an outer-context forced model), attempt 2 must skip to 'c'.
+    expect(selectMinWordsRetryModel(2, 'b', rotation)).toBe('c');
+    // Normal case (no collision) is untouched.
+    expect(selectMinWordsRetryModel(2, 'a', rotation)).toBe('b');
+  });
+
+  it('wraps around at the tail once attempts exceed the rotation length, still skipping the duplicate', () => {
+    const rotation = ['a', 'b', 'c'];
+    // attempt 4 clamps to index 2 ('c'). If the previous attempt (3) was
+    // also 'c' (the exact latent bug: CREATE_ARTICLE_MIN_WORDS_RETRIES > 3),
+    // it must wrap forward to 'a' instead of repeating 'c'.
+    expect(selectMinWordsRetryModel(4, 'c', rotation)).toBe('a');
+    // attempt 5 clamps to index 2 ('c') again; previous model was 'a' (from
+    // the wrap above), so no collision this time — plain pick stands.
+    expect(selectMinWordsRetryModel(5, 'a', rotation)).toBe('c');
+  });
+
+  it('keeps the full model set and relative order — only skips consecutive duplicates, never reorders below the plain pick', () => {
+    const rotation = ['a', 'b', 'c', 'd'];
+    // No collision anywhere: every attempt must equal the plain clamped pick.
+    let previous: string | null = null;
+    const expected = ['a', 'b', 'c', 'd'];
+    for (let i = 0; i < expected.length; i++) {
+      const model = selectMinWordsRetryModel(i + 1, previous, rotation);
+      expect(model).toBe(expected[i]);
+      previous = model;
+    }
+  });
+
+  it('can be disabled via the enabled flag to restore the exact legacy clamp (duplicates allowed) — rollback path', () => {
+    const rotation = ['a', 'b', 'c'];
+    expect(selectMinWordsRetryModel(4, 'c', rotation, false)).toBe('c');
+    expect(selectMinWordsRetryModel(1, 'a', rotation, false)).toBe('a');
+  });
+});


### PR DESCRIPTION
Completa le due ultime leve AI del backlog discusso, entrambe **che preservano il comportamento di produzione ai loro default** (nessun cambiamento silenzioso sulla pipeline che pubblica articoli).

## Implementato

- **Kill-switch cache fact-check** (`CREATE_ARTICLE_FACTCHECK_CACHE`, DEFAULT ON): `origin/main` aveva già `cache: true` hard-coded sulla call di verifica — la cache è **viva in produzione oggi**. L'ho incapsulata in `buildFactCheckCallOptions()`: al default produce esattamente `{ ...baseOpts, cache: true }` (niente `cacheNamespace`, stessa cache key) → **byte-identico a produzione**, con un kill-switch esplicito (`=0/false/no/off`) per disattivarla se mai emergesse un problema di circular-self-consensus. Sicura by-design: la key include corpo articolo + modello giudice + `bypassForceChain`, quindi nessun riuso cross-contenuto/modello e nessuna risposta forced-local può entrare nel path di consenso remoto.
- **Dedup del modello nel retry min-words** (`selectMinWordsRetryModel`, DEFAULT ON): salta la ripetizione back-to-back dello stesso modello del tentativo precedente. **Quality-neutral** (stesso set e ordine dei modelli, salta solo un no-op provabile) e **fix di un bug latente reale**: il vecchio clamp `Math.min` ripeteva l'ultimo modello all'infinito una volta che `CREATE_ARTICLE_MIN_WORDS_RETRIES` supera la lunghezza della rotation. No-op per la config attuale 6/6; `CREATE_ARTICLE_MINWORDS_DEDUP=0` ripristina il clamp.

Entrambe le helper sono pure e coperte da unit test (nessuna rete). 51 test create-article verdi, inclusa la suite `gates` estratta via regex. Nessuna modifica a soglie, temperature, logica di consenso o conteggi retry.

## Non implementato (ancora)

Restano solo azioni **non implementabili da codice** — richiedono credenziali/dati/segnali che non esistono ora, non giudizio rimandato:
- **Esecuzione probe Mailgun**: richiede credenziali reali + un invio reale → azione owner (`node scripts/probe-mailgun-scheduled.mjs --to <addr> --days 3 --send`). Lo script è pronto in main.
- **Validazione engagement**: i dati post-feature non esistono ancora (servono ~2 settimane di invii); la schedulazione automatica del promemoria è bloccata da un'approvazione tool non concedibile in sessione. Comando pronto: `node scripts/report-send-hour-impact.mjs --days 20 --since 2026-07-12`.
- **Generalizzazione timezone**: non c'è alcun segnale di fuso nei dati open/click da cui partire, e il comportamento UTC-assoluto attuale è **corretto** per una base mono-fuso CET/CEST — diventa lavoro reale solo se emergono utenti multi-fuso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M)_