### PR TITLE
fix(crawler): crawledAt = last-seen-live in mergeAndDeduplicate (newest-wins)

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -6656,6 +6656,13 @@ function mergeDuplicateJobPreservingSlugHistory(a, b) {
   // `datePosted`. Same older-wins rule as mergeAndDeduplicate's merge below.
   const mergedPostedDate = pickMergedPostedDate(a, b);
   if (mergedPostedDate) chosen.postedDate = mergedPostedDate;
+  // crawledAt = last-seen-live (newest-wins, see pickMergedCrawledAt below):
+  // the two colliding records are the SAME posting, so whichever side loses
+  // preferJob() must not take the fresher "seen live" proof down with it —
+  // quality outranks recency in preferJob, so the winner can carry the
+  // STALER timestamp.
+  const mergedCrawledAt = pickMergedCrawledAt(a, b);
+  if (mergedCrawledAt) chosen.crawledAt = mergedCrawledAt;
 
   // Whichever side didn't win, its currently-active slug/slugByLocale must
   // not vanish untracked — journal it via the shared capture helper.
@@ -6714,6 +6721,32 @@ export function pickMergedPostedDate(prev = {}, next = {}) {
     !Number.isNaN(prevD.getTime())
     && (Number.isNaN(nextD.getTime()) || prevD.getTime() < nextD.getTime())
   ) {
+    return prevVal;
+  }
+  return nextVal;
+}
+
+// Pick the merged crawledAt for a duplicate pair. Semantics contract:
+// crawledAt = the LAST time the posting was seen live on the source site —
+// NEWEST wins, the mirror image of pickMergedPostedDate's older-wins rule
+// above (postedDate is immutable history; crawledAt is a liveness heartbeat).
+// Every consumer reads it that way: send-job-alerts' 24h MATCH_WINDOW_MS,
+// jobsSeoPagesPlugin's validThrough = crawledAt+60d ("verified active at
+// crawl time") and sitemap lastmod, cleanup-jobs' STALE_DAYS age-out,
+// backfill-expired-from-history ("when we last saw it alive"), recencyTs
+// ranking. mergePreserveLocaleData (the dedicated-crawler merge) already
+// behaves this way because the fresh job wins wholesale; mergeAndDeduplicate
+// below historically kept prev's (oldest) crawledAt forever, so shared-
+// pipeline jobs aged out of every freshness window a day after first crawl
+// even though each run re-verified them live (~7k of 25.7k jobs stale).
+export function pickMergedCrawledAt(prev = {}, next = {}) {
+  const prevVal = prev.crawledAt || '';
+  const nextVal = next.crawledAt || '';
+  if (!prevVal) return nextVal;
+  if (!nextVal) return prevVal;
+  const prevT = new Date(prevVal).getTime();
+  const nextT = new Date(nextVal).getTime();
+  if (!Number.isNaN(prevT) && (Number.isNaN(nextT) || prevT > nextT)) {
     return prevVal;
   }
   return nextVal;
@@ -6801,7 +6834,12 @@ export function mergeAndDeduplicate(existingJobs, incomingJobs, qualityCfg, opti
       ...next,
       id: prev.id || next.id,
       postedDate: pickMergedPostedDate(prev, next) || nowIsoDate,
-      crawledAt: prev.crawledAt || next.crawledAt || nowIsoTs,
+      // crawledAt = last-seen-live (newest-wins, see pickMergedCrawledAt):
+      // `next` was scraped THIS run (stamped nowIsoTs above), which proves
+      // the posting is still up. The old `prev.crawledAt || …` order froze
+      // the FIRST crawl's timestamp forever, silently aging re-verified jobs
+      // out of send-job-alerts' 24h window and validThrough refresh.
+      crawledAt: pickMergedCrawledAt(prev, next) || nowIsoTs,
       firstSeenAt: prev.firstSeenAt || next.firstSeenAt || nowIsoTs,
       description: (next.description?.length || 0) >= (prev.description?.length || 0) ? next.description : prev.description,
       requirements: (next.requirements?.length || 0) >= (prev.requirements?.length || 0) ? next.requirements : prev.requirements,
@@ -6886,6 +6924,13 @@ export function mergeAndDeduplicate(existingJobs, incomingJobs, qualityCfg, opti
     // postedDate would silently win — force the merged date onto whichever
     // side was picked.
     chosen.postedDate = best.postedDate;
+    // Same bare-preferJob() discard pattern for crawledAt: `best.crawledAt`
+    // already holds the newest-wins last-seen-live timestamp; if preferJob
+    // returned `prev` wholesale (e.g. higher quality score), prev's stale
+    // crawledAt would win and the freshly re-verified job would drop out of
+    // every crawledAt-based freshness window — force the merged timestamp
+    // onto whichever side was picked.
+    chosen.crawledAt = best.crawledAt;
     // Preserve lost slugs: applied after preferJob so it works regardless of which
     // object was picked. Uses shared captureLostSlugs function.
     captureLostSlugs(chosen, prev.slugByLocale || {}, prev.slug || '');

--- a/tests/dedicated-crawler-common.test.ts
+++ b/tests/dedicated-crawler-common.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { hardenJobLocaleFields, mergeAndDeduplicate, mergePreserveLocaleData, seedCrawlerSlicesFromDataJobs, addPreviousSlugForLocale, captureLostSlugs, hasFullLocaleCoverage, normalizeContract, mergeLocaleTextMap, pickMergedPostedDate, DEFAULT_PREV_SLUG_CAP, LEGACY_PREV_SLUGS_CAP } from '../scripts/lib/dedicated-crawler-common.mjs';
+import { hardenJobLocaleFields, mergeAndDeduplicate, mergePreserveLocaleData, seedCrawlerSlicesFromDataJobs, addPreviousSlugForLocale, captureLostSlugs, hasFullLocaleCoverage, normalizeContract, mergeLocaleTextMap, pickMergedPostedDate, pickMergedCrawledAt, DEFAULT_PREV_SLUG_CAP, LEGACY_PREV_SLUGS_CAP } from '../scripts/lib/dedicated-crawler-common.mjs';
 import { getEvents, clear as clearSlugHistoryJournal } from '../scripts/lib/slug-history-journal.mjs';
 
 describe('normalizeContract — workload percentage-range classification (#3482)', () => {
@@ -1194,6 +1194,124 @@ describe('mergeAndDeduplicate — postedDate falls back to legacy datePosted ins
       { datePosted: '2026-06-01' },
     )).toBe('2026-06-01');
     expect(pickMergedPostedDate({}, {})).toBe('');
+  });
+});
+
+// Regression tests for the crawledAt semantics fix (follow-up announced in
+// PR #4137). crawledAt = last time the posting was seen LIVE on the source
+// site (newest-wins) — the mirror image of postedDate's older-wins rule.
+// mergeAndDeduplicate previously did `prev.crawledAt || next.crawledAt`
+// (oldest-wins-forever) on the incoming-vs-existing merge, so every job that
+// flows through the shared pipeline (shared-jobs-crawler.mjs) fell out of
+// send-job-alerts' 24h MATCH_WINDOW_MS a day after FIRST crawl even though
+// each subsequent run re-verified it live (~7k of 25.7k jobs stale), while
+// the dedicated-crawler path (mergePreserveLocaleData) correctly refreshed it.
+describe('mergeAndDeduplicate — crawledAt is last-seen-live, refreshed on every re-crawl (newest-wins)', () => {
+  const cfg = { minQualityScore: 0, minDescriptionChars: 0 };
+  let registryOverridePath;
+  let prevOverride;
+
+  beforeEach(() => {
+    prevOverride = process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+    registryOverridePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ft-slug-registry-')), 'slug-registry.json');
+    process.env.SLUG_REGISTRY_PATH_OVERRIDE = registryOverridePath;
+  });
+
+  afterEach(() => {
+    if (prevOverride === undefined) delete process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+    else process.env.SLUG_REGISTRY_PATH_OVERRIDE = prevOverride;
+  });
+
+  const STALE_CRAWLED_AT = '2026-06-01T00:00:00.000Z';
+
+  const baseJob = (over = {}) => ({
+    id: 'job-crawledat-1',
+    title: 'Infermiere diplomato',
+    company: 'Clinica Test',
+    location: 'Lugano, Ticino',
+    url: 'https://example.com/jobs/crawledat-1',
+    description: 'D'.repeat(60),
+    slug: 'infermiere-diplomato-clinica-test',
+    ...over,
+  });
+
+  it('a re-crawled existing job exits the merge with the FRESH crawledAt, with firstSeenAt and postedDate preserved', () => {
+    const testStart = Date.now();
+    const prev = baseJob({
+      crawledAt: STALE_CRAWLED_AT,
+      firstSeenAt: '2026-05-20T08:00:00.000Z',
+      postedDate: '2026-05-18',
+    });
+    const next = baseJob({}); // incoming re-crawl; merge stamps crawledAt=now
+    const { merged } = mergeAndDeduplicate([prev], [next], cfg);
+    expect(merged).toHaveLength(1);
+    // Before the fix: merged[0].crawledAt === STALE_CRAWLED_AT, forever.
+    expect(merged[0].crawledAt).not.toBe(STALE_CRAWLED_AT);
+    expect(Date.parse(merged[0].crawledAt)).toBeGreaterThanOrEqual(testStart);
+    // set-once / older-wins fields must NOT churn with the heartbeat:
+    expect(merged[0].firstSeenAt).toBe('2026-05-20T08:00:00.000Z');
+    expect(merged[0].postedDate).toBe('2026-05-18');
+  });
+
+  it('refreshes crawledAt even when preferJob returns prev wholesale (bare-preferJob discard pattern, as #3284/#3843)', () => {
+    const testStart = Date.now();
+    // featured + longer description ⇒ prev outscores the incoming job in
+    // preferJob, so `chosen` is prev wholesale — the fresh timestamp must
+    // still be forced onto it.
+    const prev = baseJob({
+      crawledAt: STALE_CRAWLED_AT,
+      firstSeenAt: '2026-05-20T08:00:00.000Z',
+      featured: true,
+      description: 'D'.repeat(400),
+    });
+    const next = baseJob({ description: 'D'.repeat(60) });
+    const { merged } = mergeAndDeduplicate([prev], [next], cfg);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].featured).toBe(true); // prev really won preferJob
+    expect(merged[0].crawledAt).not.toBe(STALE_CRAWLED_AT);
+    expect(Date.parse(merged[0].crawledAt)).toBeGreaterThanOrEqual(testStart);
+    expect(merged[0].firstSeenAt).toBe('2026-05-20T08:00:00.000Z');
+  });
+
+  it('existing-vs-existing collapse (mergeDuplicateJobPreservingSlugHistory path) keeps the NEWER crawledAt even when the staler record wins preferJob', () => {
+    const winner = baseJob({
+      crawledAt: STALE_CRAWLED_AT,
+      firstSeenAt: '2026-05-20T08:00:00.000Z',
+      featured: true, // outscores loser ⇒ wins preferJob despite staler crawledAt
+      description: 'D'.repeat(400),
+    });
+    const loser = baseJob({
+      crawledAt: '2026-06-25T12:00:00.000Z',
+      featured: false,
+      description: 'D'.repeat(60),
+    });
+    const { merged } = mergeAndDeduplicate([winner, loser], [], cfg);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].featured).toBe(true);
+    expect(merged[0].crawledAt).toBe('2026-06-25T12:00:00.000Z');
+    expect(merged[0].firstSeenAt).toBe('2026-05-20T08:00:00.000Z');
+  });
+
+  it('pickMergedCrawledAt: newest wins, real timestamps beat unparseable ones, blank sides fall through, both blank returns empty', () => {
+    expect(pickMergedCrawledAt(
+      { crawledAt: '2026-06-01T00:00:00.000Z' },
+      { crawledAt: '2026-07-01T00:00:00.000Z' },
+    )).toBe('2026-07-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt(
+      { crawledAt: '2026-07-01T00:00:00.000Z' },
+      { crawledAt: '2026-06-01T00:00:00.000Z' },
+    )).toBe('2026-07-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt(
+      { crawledAt: '2026-06-01T00:00:00.000Z' },
+      { crawledAt: 'not-a-date' },
+    )).toBe('2026-06-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt(
+      { crawledAt: 'not-a-date' },
+      { crawledAt: '2026-06-01T00:00:00.000Z' },
+    )).toBe('2026-06-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt({}, { crawledAt: '2026-06-01T00:00:00.000Z' })).toBe('2026-06-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt({ crawledAt: '2026-06-01T00:00:00.000Z' }, {})).toBe('2026-06-01T00:00:00.000Z');
+    expect(pickMergedCrawledAt({}, {})).toBe('');
   });
 });
 


### PR DESCRIPTION
PR concatenata annunciata nel `## Non implementato (ancora)` di #4137 (conteggi "nuove offerte" + ranking freshness-first del job-alert sender).

## Implementato

- `scripts/lib/dedicated-crawler-common.mjs` — fissata la semantica di `crawledAt` = **ultima volta che il posting è stato visto live sul sito sorgente** (newest-wins) in `mergeAndDeduplicate`, allineandola a `mergePreserveLocaleData` (percorso crawler dedicati, dove il job fresh vince già wholesale). Prima il merge incoming-vs-existing faceva `prev.crawledAt || next.crawledAt` → il timestamp del PRIMO crawl restava congelato per sempre: ogni job del percorso shared (`scripts/lib/shared-jobs-crawler.mjs`) usciva dalla finestra `MATCH_WINDOW_MS` 24h di `scripts/send-job-alerts.mjs` un giorno dopo il primo crawl pur essendo ri-verificato live a ogni run (~7k job su 25.7k con crawledAt stale) — under-matching sistematico, più `validThrough`/sitemap-lastmod/`STALE_DAYS` calcolati su un timestamp morto.
- Nuovo helper esportato `pickMergedCrawledAt(prev, next)` (newest-wins, specchio di `pickMergedPostedDate` older-wins), con commento-contratto sulla semantica e sull'elenco consumer, per prevenire regressioni. Fix applicato all'intera CLASSE dentro `mergeAndDeduplicate`:
  1. merge incoming-vs-existing (~riga 6830): `crawledAt: pickMergedCrawledAt(prev, next) || nowIsoTs` (il job incoming è stampato `nowIsoTs` → fresh vince);
  2. pattern bare-`preferJob()`-discard (stessa classe di previousSlugs #3284 e postedDate #3843): `chosen.crawledAt = best.crawledAt` dopo `preferJob`, così un `prev` che vince per quality score non porta con sé il timestamp stale;
  3. collasso existing-vs-existing (`mergeDuplicateJobPreservingSlugHistory`, usato da tutte e tre le passate di dedup): il merged tiene il crawledAt più NUOVO dei due anche quando il record più stale vince `preferJob`.
- `firstSeenAt` (set-once) e `postedDate`/`datePosted` (older-wins) NON toccati — i test verificano che restino preservati mentre `crawledAt` si aggiorna.
- `tests/dedicated-crawler-common.test.ts` — nuovo blocco di regressione (4 test): job esistente ri-crawlato esce dal merge con crawledAt fresco e firstSeenAt/postedDate preservati; refresh anche quando `preferJob` ritorna `prev` wholesale; collasso existing-vs-existing tiene il crawledAt più nuovo; unit test di `pickMergedCrawledAt` (newest-wins, timestamp reali > unparseable, blank fall-through).
- **Audit consumer** (`crawledAt` in scripts/, build-plugins/, tests/): nessun consumer dipende dalla semantica "oldest". Tutti leggono last-seen-live: `send-job-alerts` freshness window (con guard anti-re-invio #2993 già in place per il crawledAt che si rinfresca), `jobsSeoPagesPlugin` `validThrough = crawledAt+60d` ("verified active at crawl time") e sitemap lastmod, `cleanup-jobs.mjs` age-out `STALE_DAYS` (e il suo dedup title/company fa già newest-wins), `backfill-expired-from-history.mjs` ("crawledAt is when we last saw it alive"), `recencyTs` ranking. La riga fixata era l'UNICO writer oldest-wins nel repo (grep `crawledAt.*||.*crawledAt`: zero altri match).

Test: `npx vitest run` su tutti i 39 file di test che importano `dedicated-crawler-common`/`shared-jobs-crawler` (421 test) + i 10 file `*alert*` (241 test) → tutti verdi.

## Non implementato (ancora)

Nessuno.

Candidati del pre-push hook `check-sibling-patterns --strict` (7), valutati singolarmente — tutti falsi positivi / consumer read-only, nessun sibling con lo stesso antipattern:
- `scripts/lib/shared-jobs-crawler.mjs` — falso positivo: condivide i token `mergeAndDeduplicate`/`preferJob`/`recencyTs` ma li IMPORTA da `dedicated-crawler-common.mjs` (righe 63-72); zero logica propria su `crawledAt` (grep: nessun match) → è il consumer corretto by-construction dal fix nella funzione condivisa, niente da cambiare lì.
- `scripts/send-job-alerts.mjs` — falso positivo: condivide `MATCH_WINDOW_MS` perché citato nei commenti del diff; è il consumer read-only che il fix serve, e ha già il guard di dedup per il re-ingresso dei job ri-crawlati nella finestra (#2993, riga ~1475). Nessun writer di crawledAt.
- `scripts/cleanup-jobs.mjs` — falso positivo: condivide `STALE_DAYS` (citato in un commento del diff); legge crawledAt come last-seen-live per l'age-out (beneficiario del fix, smette di rimuovere prematuramente job shared-pipeline vivi) e il suo dedup interno (righe ~714-716) fa GIÀ newest-wins su crawledAt. Nessun antipattern oldest-wins.
- `scripts/lib/social-post-utils.mjs` — falso positivo: ha una propria `recencyTs` che preferisce `firstSeenAt` → `crawledAt` → `postedDate` per selezionare job mai postati (dedup per id via `postedSet`); read-only, nessuna dipendenza dalla semantica oldest.
- `scripts/build-cf-hot-404s.mjs` — falso positivo: `STALE_DAYS` riguarda i path 404 all'edge Cloudflare ("not seen at the edge"), dominio scorrelato dai job; già semantica last-seen sui propri dati.
- `.github/workflows/cleanup-stale-jobs.yml` — falso positivo: solo plumbing env `JOBS_STALE_DAYS` verso `cleanup-jobs.mjs` (vedi sopra); nessuna logica di merge.
- `.github/workflows/worktree-branch-janitor.yml` — falso positivo: `STALE_DAYS` è l'age-gate dei branch git abbandonati, dominio completamente scorrelato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB)_