### PR TITLE
Indici Firestore + report schedulato nel backlog + workflow probe Mailgun (#3798)

### DIFF
--- a/.github/workflows/probe-mailgun-scheduled.yml
+++ b/.github/workflows/probe-mailgun-scheduled.yml
@@ -1,0 +1,72 @@
+name: Probe Mailgun Scheduled-Send
+
+# On-demand verification of Mailgun's real free-plan scheduled-send lookahead
+# (#3798, Phase 0). Manual only — never scheduled — because `send: true` sends
+# ONE real email. Mailgun credentials come from Remote Config (same path as the
+# send-* workflows). Dry-run by default: preview the request without sending.
+
+on:
+  workflow_dispatch:
+    inputs:
+      to:
+        description: 'Test recipient email address'
+        required: true
+        type: string
+      days:
+        description: 'Scheduled-send offset in days from now (try 3, then 7, then 4 to bisect the limit)'
+        required: false
+        default: '3'
+        type: string
+      send:
+        description: 'Actually send the email (unchecked = dry-run, no network call)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON secret is not set"
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run Mailgun scheduled-send probe
+        env:
+          PROBE_TO: ${{ inputs.to }}
+          PROBE_DAYS: ${{ inputs.days }}
+          PROBE_SEND: ${{ inputs.send }}
+        run: |
+          if [ "$PROBE_SEND" = "true" ]; then
+            echo "⚠️  Live send requested (--send): one real email will be delivered."
+            node scripts/probe-mailgun-scheduled.mjs --to "$PROBE_TO" --days "$PROBE_DAYS" --send | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Dry-run (no email sent). Re-run with 'send' checked to actually deliver."
+            node scripts/probe-mailgun-scheduled.mjs --to "$PROBE_TO" --days "$PROBE_DAYS" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/send-hour-impact-report.yml
+++ b/.github/workflows/send-hour-impact-report.yml
@@ -1,11 +1,19 @@
 name: Send-Time Impact Report
 
-# On-demand engagement validation for the per-user send-time feature (#3798).
+# Engagement validation for the per-user send-time feature (#3798).
 # Runs the read-only report against production Firestore using the CI-side
 # Firebase service account, so the result can be produced without any local
-# credentials. Output is echoed to the job log AND the run summary.
+# credentials. Output goes to the job log, the run summary, an artifact, and
+# (on schedule, or on demand when post_to_issue=true) a comment on the #3798
+# tracker so the cohort growth is recorded in the backlog over time.
 
 on:
+  schedule:
+    # Weekly, Monday 02:20 UTC — inside the quiet 01:00-04:00 UTC concurrency
+    # window (same audit as send-job-alerts, #3798). Weekly cadence tracks the
+    # slow-growing `personal` cohort (subscribers need 3+ post-feature events
+    # before they get a personal hour) into the backlog without spamming it.
+    - cron: '20 2 * * 1'
   workflow_dispatch:
     inputs:
       days:
@@ -18,9 +26,15 @@ on:
         required: false
         default: '2026-07-12'
         type: string
+      post_to_issue:
+        description: 'Post the report as a comment on issue #3798'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
+  issues: write   # to post the report onto the #3798 tracker
 
 jobs:
   report:
@@ -51,10 +65,15 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
 
       - name: Run send-time impact report (read-only)
+        env:
+          # `inputs` is empty on a `schedule` event, so fall back to the same
+          # defaults the workflow_dispatch inputs declare.
+          REPORT_DAYS: ${{ inputs.days || '20' }}
+          REPORT_SINCE: ${{ inputs.since || '2026-07-12' }}
         run: |
           node scripts/report-send-hour-impact.mjs \
-            --days "${{ inputs.days }}" \
-            --since "${{ inputs.since }}" | tee /tmp/send-hour-impact.txt | tee -a "$GITHUB_STEP_SUMMARY"
+            --days "$REPORT_DAYS" \
+            --since "$REPORT_SINCE" | tee /tmp/send-hour-impact.txt | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report artifact
         if: always()
@@ -63,3 +82,28 @@ jobs:
           name: send-hour-impact-report
           path: /tmp/send-hour-impact.txt
           if-no-files-found: ignore
+
+      - name: Post report to #3798
+        # Always on schedule; on manual runs only when explicitly requested.
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.post_to_issue) }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '(no report output captured)';
+            try { body = fs.readFileSync('/tmp/send-hour-impact.txt', 'utf8').trim() || body; } catch {}
+            const trigger = context.eventName === 'schedule' ? 'scheduled' : 'manual';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 3798,
+              body: [
+                `### 📬 Send-time impact report (${trigger})`,
+                '',
+                '```',
+                body,
+                '```',
+                '',
+                `_Auto-posted by the Send-Time Impact Report workflow — [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Cohorts flagged \`n<100\` are still below the significance threshold._`,
+              ].join('\n'),
+            });

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -153,6 +153,20 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "campaign_deliveries",
+      "fieldPath": "sent_at",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "fieldPath": "timestamp",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Tre follow-up di osservabilità/indipendenza per #3798, sulla base del primo run reale del report.

## Implementato

- **Indici Firestore** (`firestore.indexes.json`): aggiunti i due override single-field `COLLECTION_GROUP` per `campaign_deliveries.sent_at` ed `events.timestamp` — i due indici che mancavano al report (che era caduto sul fallback per-subscriber lento, ~64s). Si auto-deployano via `deploy-firestore-rules.yml` al merge su main.
- **Report schedulato → backlog** (`send-hour-impact-report.yml`): aggiunti uno **schedule settimanale** (lun 02:20 UTC, finestra concorrenza scarica) e uno step che **posta il report come commento sull'issue #3798** (`issues: write`), così la crescita lenta della coorte `personal` (i subscriber servono 3+ eventi post-feature prima di avere un'ora personale) viene registrata nel backlog nel tempo. I run manuali postano solo se `post_to_issue` è selezionato; sui run schedulati (dove `inputs` è vuoto) si applicano i default.
- **Workflow probe Mailgun** (`probe-mailgun-scheduled.yml`, nuovo): dispatch **solo manuale** per lanciare il probe da CI (credenziali via Remote Config), **dry-run di default**, invio reale dietro l'input esplicito `send`.

## Non implementato (ancora)

- **Verdetto engagement**: i dati sono ancora troppo pochi (14 invii `personal`, n<100). Lo schedule settimanale ora traccia la crescita nel backlog automaticamente; il verdetto arriverà quando la coorte `personal` supera la soglia di significatività.
- **Timezone multi-fuso**: nessun segnale di fuso nei dati; comportamento UTC-assoluto corretto per base mono-fuso CET/CEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh19wGXze6uqrtcr4M7v1M)_