### PR TITLE
fix(ci): bump github-script@v7→v8 in send-hour-impact-report (main-red)

### DIFF
--- a/.github/workflows/send-hour-impact-report.yml
+++ b/.github/workflows/send-hour-impact-report.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Post report to #3798
         # Always on schedule; on manual runs only when explicitly requested.
         if: ${{ always() && (github.event_name == 'schedule' || inputs.post_to_issue) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Main-red unblock: `lint:gha-node-runtime` (parte del leg CI `vitest (unit + integration)`) fallisce su OGNI PR da quando #4178 ha aggiunto `send-hour-impact-report.yml` con `actions/github-script@v7` (runtime Node 20 — deprecato, floor del lint = Node 24). Il fix parziale #4179 ha coperto solo `upload-artifact@v4→v7` nello stesso file. Osservato live sulla PR #4181: leg vitest rosso con `FAIL — 1 first-party action ref(s) on a deprecated Node runtime (< 24): send-hour-impact-report.yml:89 actions/github-script@v7 → Node 20`.

## Implementato

- `.github/workflows/send-hour-impact-report.yml`: `actions/github-script@v7` → `@v8` (major su Node 24, da `NODE_RUNTIME_BY_ACTION` in `scripts/lint-gha-node-runtime.mjs`). Stessa superficie API per la chiamata `github.rest.issues.createComment` usata nello step — nessun altro cambiamento.

## Non implementato (ancora)

Nessuno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FefT6DJrQXRi6fvtZDEvGB)_