### PR TITLE
fix(crawlers): integra-biosciences zero-CH-legittimo in EMPTY_OK

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -351,6 +351,14 @@ const EMPTY_OK_CRAWLERS = new Set([
   // by the parser's SWISS_LOCATION_RE. Verified live 2026-07-11: HTTP 200,
   // parser healthy, zero CH openings is the genuine state (audit #3797).
   'franklin-university',
+  // INTEGRA Biosciences (Zizers, GR — but hires group-wide): the careers page
+  // is behind Cloudflare bot protection (403 "Just a moment…" to datacenter
+  // IPs); the crawler routes through the shared Jina clean-IP proxy and parses
+  // the real listing. Verified live 2026-07-14: Jina fetch succeeds, parser
+  // healthy, currently zero CH openings (the group posts mostly US/DE roles) —
+  // genuine 0, not a fetch failure (issue #4144, fixed in #4114). Re-arms when
+  // a CH vacancy appears.
+  'integra-biosciences',
   // Privatklinik Siloah (Swiss Medical Network): the SmartRecruiters tenant
   // API (companies/SwissMedicalNetwork1/postings) currently lists 80 CH
   // postings with ZERO attributed to the Siloah department — verified


### PR DESCRIPTION
## Implementato

- Aggiunto `integra-biosciences` al Set `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs`.
- INTEGRA Biosciences (Zizers, GR — assume a livello di gruppo): la careers page è dietro Cloudflare bot-protection (403 "Just a moment…" verso IP datacenter). Il crawler instrada attraverso il proxy Jina clean-IP condiviso e fa il parse del listing reale.
- Verificato live 2026-07-14: il fetch via Jina riesce, il parser è healthy, attualmente zero posizioni CH (il gruppo pubblica per lo più ruoli US/DE) — è uno 0 genuino, non un fetch failure. Il crawler si ri-arma quando compare una vacancy CH.

**Root cause (issue #4144):** il crawler restituiva 0 job CH e il monitor lo marcava `broken`/`stale`; in realtà il fetch funziona (via Jina) e lo 0 è legittimo. Stessa classe già risolta per `benteler` e `franklin-university` (#4114).

Closes #4144

## Non implementato (ancora)

- Nessuna modifica al parser o alla logica di fetch: il crawler è già healthy end-to-end via Jina; questa PR corregge solo la classificazione del monitor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_