### PR TITLE
fix(telemetry): deny benign app-errors #4172/#4175/#4148 (parità mirror + test)

### DIFF
--- a/scripts/app-error-issue-sync.mjs
+++ b/scripts/app-error-issue-sync.mjs
@@ -47,6 +47,22 @@ export function main() {
 
   const entries = (eh.appErrors || [])
     .filter((e) => (e.count || 0) >= MIN_COUNT)
+    // GA4 renders an empty/absent `error_message` custom dimension as the
+    // literal "(not set)". Such a bucket is a message-less error class
+    // (overwhelmingly reason-less unhandled_rejection — Promise.reject() /
+    // rejected with undefined): the client handler already captured everything
+    // available (String(reason) → 'Unknown rejection', plus the stack when the
+    // reason is an Error — services/analytics.ts initGlobalErrorTracking), so
+    // there is no further context to extract and no code change can close a
+    // ticket with no message, no reason and no stack (#4148). This is a
+    // GA4-feeder data-quality artifact, NOT a client error signature — hence
+    // guarded here at the feeder rather than in the client-mirrored,
+    // parity-pinned ISSUE_DENY_PATTERNS (which the PostHog feeder shares; PostHog
+    // always carries a real message, never "(not set)").
+    .filter((e) => {
+      const msg = String(e.errorMessage ?? '').trim();
+      return msg.length > 0 && msg.toLowerCase() !== '(not set)';
+    })
     // Shared issue-creation deny-list (self-healed version-skew transients,
     // #3758/#3759/#3761 class): the same error reaches GA4 app_error and
     // PostHog $exception through parallel pipelines, so the "tracked in

--- a/scripts/lib/error-issue-sync.mjs
+++ b/scripts/lib/error-issue-sync.mjs
@@ -100,6 +100,20 @@ export const ISSUE_DENY_PATTERNS = [
   // MUST mirror UNIVERSAL_BENIGN_PATTERNS in services/benignErrorPatterns.ts
   // — parity-pinned by tests/error-issue-sync.test.ts ("deny-list parity").
   /Firebase:.*auth\/network-request-failed/i,
+  // Unsupported-browser parse failure (#4172): a browser too old to parse
+  // optional-chaining `?.` / nullish `??` throws "Unexpected token '?'" on a
+  // modern chunk. Below our Vite `build.target: 'modules'` baseline → an
+  // unsupported-browser environmental failure no code change can close. Matched
+  // on the `?` token so "Unexpected token '<'" (HTML-for-JS) / JSON parse bugs
+  // still file. MUST mirror UNIVERSAL_BENIGN_PATTERNS in
+  // services/benignErrorPatterns.ts — parity-pinned by tests/error-issue-sync.test.ts.
+  /Unexpected token ['"]?\?['"]?/i,
+  // OS/hardware file-read failure (#4175): DOMException "NotReadableError: The
+  // I/O read operation failed." — the OS could not read a user-selected
+  // file/blob (flaky disk / ejected media). Environmental, unfixable in code.
+  // MUST mirror UNIVERSAL_BENIGN_PATTERNS in services/benignErrorPatterns.ts
+  // — parity-pinned by tests/error-issue-sync.test.ts ("deny-list parity").
+  /NotReadableError: The I\/O read operation failed/i,
 ];
 
 /**

--- a/services/benignErrorPatterns.ts
+++ b/services/benignErrorPatterns.ts
@@ -110,6 +110,29 @@ export const UNIVERSAL_BENIGN_PATTERNS: readonly RegExp[] = [
   // is the only viable catch. `standardSelectors` is not used anywhere in this
   // codebase, so any error mentioning it is unambiguously Clarity noise.
   /\bstandardSelectors\b/,
+
+  // ── Unsupported-browser parse failure (below our support matrix) — #4172 ──
+  // A browser too old to PARSE modern syntax (optional chaining `?.` / nullish
+  // coalescing `??`) throws "SyntaxError: Unexpected token '?'" while loading a
+  // current module chunk. Vite's default `build.target: 'modules'` baseline
+  // (chrome87/safari14/firefox78/edge88) already ships these operators
+  // un-transpiled, so ONLY browsers below that baseline hit this — an
+  // unsupported-browser environmental failure no code change can close (a real
+  // un-transpiled ship would break every modern browser at ~100% volume, not
+  // 60 hits across 31 long-tail sessions). Distinct from the link-time
+  // version-skew SyntaxErrors (MODULE_LINK_SKEW_PATTERNS, "does not provide an
+  // export named …") which are self-healed, not old-browser. Matched on the `?`
+  // token specifically so a genuine "Unexpected token '<'" (HTML-for-JS CDN
+  // fault) or JSON parse bug still reports.
+  /Unexpected token ['"]?\?['"]?/i,
+
+  // ── OS/hardware file-read failure — #4175 ──
+  // "NotReadableError: The I/O read operation failed." is a DOMException the
+  // browser raises when the OS cannot read a user-selected file/blob (flaky
+  // disk, ejected removable media, a file locked or changed mid-read). Purely
+  // environmental — the user's storage failed while reading; no code change can
+  // prevent it. 9 hits / 1 session (a single user's failing drive).
+  /NotReadableError: The I\/O read operation failed/i,
 ];
 
 /**

--- a/tests/error-issue-sync.test.ts
+++ b/tests/error-issue-sync.test.ts
@@ -191,6 +191,36 @@ describe('app-error-issue-sync.mjs', () => {
     expect(title).not.toContain('does not provide an export');
   });
 
+  it('skips message-less "(not set)" / empty GA4 buckets (#4148 — no message, reason or stack to act on)', async () => {
+    issueListEmptyThenCreate(104);
+    readFileSync.mockReturnValue(JSON.stringify({
+      ga4: {
+        errorHealth: {
+          totalErrors: 200,
+          errorRate: 5.8,
+          healthStatus: '🔴 CRITICAL',
+          appErrors: [
+            // Message-less bucket: GA4 renders an empty error_message as "(not set)".
+            { errorType: 'unhandled_rejection', errorMessage: '(not set)', pagePath: '/', count: 143, users: 2 },
+            // Genuinely empty string — same message-less class.
+            { errorType: 'unhandled_rejection', errorMessage: '', pagePath: '/', count: 40, users: 2 },
+            // Real actionable error — must still be synced.
+            { errorType: 'TypeError', errorMessage: 'x is not a function', pagePath: '/it/lavoro', count: 12, users: 9 },
+          ],
+          topStacks: [],
+        },
+      },
+    }));
+
+    await appErrorSync.main();
+
+    const calls = createCalls();
+    expect(calls).toHaveLength(1);
+    const title = calls[0][calls[0].indexOf('--title') + 1];
+    expect(title).toContain('x is not a function');
+    expect(title).not.toContain('not set');
+  });
+
   it('escalates priority to high when the site-wide error rate is critical', async () => {
     issueListEmptyThenCreate(102);
     readFileSync.mockReturnValue(JSON.stringify({
@@ -376,6 +406,33 @@ describe('deny-list parity (scripts/lib/error-issue-sync.mjs cannot import the .
     );
     expect(benignPattern).toBeDefined();
     expect(ISSUE_DENY_PATTERNS.map((p: RegExp) => p.source)).toContain(benignPattern!.source);
+  });
+
+  it('mirrors the unsupported-browser "Unexpected token ?" parse pattern from services/benignErrorPatterns.ts byte-for-byte (#4172)', () => {
+    const benignPattern = UNIVERSAL_BENIGN_PATTERNS.find((p) => p.test("Unexpected token '?'"));
+    expect(benignPattern).toBeDefined();
+    expect(ISSUE_DENY_PATTERNS.map((p: RegExp) => p.source)).toContain(benignPattern!.source);
+  });
+
+  it('mirrors the NotReadableError I/O file-read pattern from services/benignErrorPatterns.ts byte-for-byte (#4175)', () => {
+    const benignPattern = UNIVERSAL_BENIGN_PATTERNS.find((p) =>
+      p.test('NotReadableError: The I/O read operation failed.'),
+    );
+    expect(benignPattern).toBeDefined();
+    expect(ISSUE_DENY_PATTERNS.map((p: RegExp) => p.source)).toContain(benignPattern!.source);
+  });
+
+  it('denies unsupported-browser parse failures (#4172) and OS/hardware file-read failures (#4175)', () => {
+    // Old browser parsing optional-chaining / nullish on a modern chunk.
+    expect(isIssueDenied("Unexpected token '?'")).toBe(true);
+    expect(isIssueDenied('Unexpected token ?')).toBe(true);
+    expect(isIssueDenied("SyntaxError: Unexpected token '?'")).toBe(true);
+    // But HTML-served-for-JS (real CDN fault) and JSON parse bugs still file.
+    expect(isIssueDenied("Unexpected token '<'")).toBe(false);
+    expect(isIssueDenied("Unexpected token 'o', \"<!DOCTYPE \"... is not valid JSON")).toBe(false);
+    // OS/hardware file-read failure — user's disk/file, unfixable in code.
+    expect(isIssueDenied('NotReadableError: The I/O read operation failed.')).toBe(true);
+    expect(isIssueDenied('DOMException: NotReadableError: The I/O read operation failed.')).toBe(true);
   });
 
   it('isIssueDenied keeps real errors issue-able (incl. call-time skew TypeErrors and chunk-load 404s)', () => {

--- a/tests/services/benignErrorPatterns.test.ts
+++ b/tests/services/benignErrorPatterns.test.ts
@@ -37,6 +37,12 @@ describe('isBenignErrorMessage()', () => {
       // Firebase Auth transient connectivity failure (#4174)
       'Firebase: Error (auth/network-request-failed).',
       '[auth.googleSignIn] Firebase: Error (auth/network-request-failed).',
+      // Unsupported-browser parse failure (#4172) — optional-chaining / nullish
+      // on a browser below our Vite build.target baseline.
+      "SyntaxError: Unexpected token '?'",
+      'Unexpected token ?',
+      // OS/hardware file-read failure (#4175) — user's disk/file, unfixable.
+      'NotReadableError: The I/O read operation failed.',
     ])('drops: %s', (msg) => {
       expect(isBenignErrorMessage(msg)).toBe(true);
     });


### PR DESCRIPTION
## Implementato

Triage dei 5 error-issue app; 3 benigni denied, 2 lasciati aperti come segnali monitorati.

- **#4172 SyntaxError "Unexpected token ?"** → DENY (browser sotto la baseline Vite `modules`: chrome87/safari14/ff78/edge88 non parsano `?.`/`??`). 60 hit / 31 sessioni long-tail = below-support-matrix, non nostro codice non-transpilato (verificato `vite.config.ts` senza target abbassato). Pattern `/Unexpected token ['"]?\?['"]?/i` ancorato al token `?`.
- **#4175 DOMException NotReadableError I/O** → DENY (OS/hardware: lettura file/blob utente fallita). Non fixabile in codice.
- **#4148 unhandled_rejection "(not set)"** → DENY al **feeder GA4** (`scripts/app-error-issue-sync.mjs`): "(not set)" è artefatto di report GA4, mai un messaggio client reale.
- **#4176 "Failed to fetch dynamically imported module"** → LASCIATO APERTO, monitorato (segnale CDN/chunk-load deliberatamente issue-abile). NON chiuso.
- **#4173 RangeError "Maximum call stack"** → LASCIATO APERTO, monitorato (denyarlo maschererebbe ricorsione infinita first-party). NON chiuso.

**Parità:** `services/benignErrorPatterns.ts` (source) ↔ `scripts/lib/error-issue-sync.mjs` (mirror). Verifica: `npx vitest run tests/error-issue-sync.test.ts tests/services/benignErrorPatterns.test.ts` → 68 passed local; `node --check` + `tsc --noEmit` clean.

Closes #4172
Closes #4175
Closes #4148

## Non implementato (ancora)

- #4176 e #4173 restano aperti di proposito come segnali monitorati.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_