### PR TITLE
fix(crawlers): leukerbad-clinic URL-fingerprint collapse (15 job → 2 → shrink-guard fail)

### DIFF
--- a/scripts/lib/leukerbad-clinic-job-parser.mjs
+++ b/scripts/lib/leukerbad-clinic-job-parser.mjs
@@ -222,10 +222,23 @@ function buildJob(doc) {
   // job documents only inside the listing page; /{lang}/page/jobs/{uid}/
   // returns 404. Keep the source URL on the live language-specific listing so
   // URL housekeeping does not expire valid Prismic jobs.
+  //
+  // Every job on a given language listing therefore shares the SAME path
+  // (…/fr/page/jobs/ or …/de/page/jobs/). Without a per-job discriminator the
+  // shared crawler's URL-based fingerprint (canonicalizeJobUrl strips the hash,
+  // so a bare listing URL collapses to one key) folds all N jobs of a locale
+  // onto ONE fingerprint in mergeAndDeduplicate — the whole slice shrinks to 2
+  // (fr + de) and the shrink-guard hard-fails the crawler every run
+  // (issues #4085 / #4169). Append a stable per-doc fragment: it never reaches
+  // the server (the listing page still 200s, URL housekeeping still passes) and
+  // extractJobIdentityFromUrl's bare-hash rule turns it into a distinct
+  // `id|leukerbadclinic.ch|#job-<hash>` fingerprint — the exact same
+  // fragment-as-identity convention the other single-listing-page crawlers use
+  // (galenica #job.id=, eHnv #offer/, état de vaud #…/job/, klinik-gut #…-id-).
   const sitePath = sourceLang === 'de' ? 'de' : 'fr';
-  const publicUrl = `https://leukerbadclinic.ch/${sitePath}/page/jobs/`;
   const urlForHash = `${PRISMIC_REPO}:${doc.id || doc.uid || title}`;
   const urlHash = createHash('sha1').update(urlForHash).digest('hex').slice(0, 12);
+  const publicUrl = `https://leukerbadclinic.ch/${sitePath}/page/jobs/#job-${urlHash}`;
 
   const jobSlug = slugify(`${title} ${LEUKERBAD_CLINIC_COMPANY_NAME} ${workplace}`);
   const postedDate = (() => {

--- a/tests/leukerbad-clinic-crawler.test.ts
+++ b/tests/leukerbad-clinic-crawler.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import {
+  LEUKERBAD_CLINIC_KEY,
+  LEUKERBAD_CLINIC_COMPANY_NAME,
+  isLeukerbadClinicJob,
+  isTrustedDomain,
+  fetchAllLeukerbadClinicJobs,
+} from '../scripts/lib/leukerbad-clinic-job-parser.mjs';
+import { fingerprintJob } from '../scripts/lib/dedicated-crawler-common.mjs';
+
+// Regression (issues #4085 / #4169): Leukerbad's Nuxt/Prismic site renders
+// every job on ONE language-specific listing page (…/fr/page/jobs/,
+// …/de/page/jobs/) — the per-doc detail path 404s, so the parser keeps the
+// listing URL as the source URL. Without a per-job discriminator all N jobs of
+// a locale shared ONE URL; the shared crawler's URL-based fingerprint
+// (canonicalizeJobUrl strips the hash → a bare listing URL collapses to a
+// single key) folded them onto ONE fingerprint in mergeAndDeduplicate. The
+// slice shrank to 2 (fr + de) and the shrink-guard hard-failed the crawler on
+// EVERY run. The fix appends a stable `#job-<hash>` fragment so
+// extractJobIdentityFromUrl mints a distinct identity per job — the same
+// fragment-as-identity convention the other single-listing-page crawlers use
+// (galenica, eHnv, état de vaud, klinik-gut).
+
+const PRISMIC_API = 'https://leukerbad-clinic.cdn.prismic.io/api/v2';
+
+function jobDoc(id: string, uid: string, lang: string, titleText: string) {
+  return {
+    id,
+    uid,
+    lang,
+    first_publication_date: '2025-09-01T00:00:00+0000',
+    last_publication_date: '2025-09-25T00:00:00+0000',
+    data: {
+      job_title: [{ type: 'heading1', text: titleText }],
+      time_percentage: '80-100%',
+      workplace: 'Leukerbad',
+      job_description: [
+        {
+          type: 'paragraph',
+          text:
+            'Nous recherchons une personne motivée pour rejoindre notre équipe. ' +
+            'Vous participerez aux soins et au suivi des patients dans un cadre ' +
+            'de réadaptation moderne, en collaboration avec une équipe ' +
+            'pluridisciplinaire engagée et bienveillante au quotidien.',
+        },
+      ],
+    },
+  };
+}
+
+describe('Leukerbad Clinic (leukerbad-clinic) crawler parser', () => {
+  it('exports valid company key and name', () => {
+    expect(LEUKERBAD_CLINIC_KEY).toBe('leukerbad-clinic');
+    expect(LEUKERBAD_CLINIC_COMPANY_NAME).toBe('Leukerbad Clinic');
+  });
+
+  describe('isLeukerbadClinicJob', () => {
+    it('matches by companyKey', () => {
+      expect(isLeukerbadClinicJob({ companyKey: 'leukerbad-clinic' })).toBe(true);
+    });
+    it('matches by URL domain', () => {
+      expect(isLeukerbadClinicJob({ url: 'https://leukerbadclinic.ch/fr/page/jobs/#job-abc' })).toBe(true);
+    });
+    it('rejects unrelated jobs', () => {
+      expect(isLeukerbadClinicJob({ companyKey: 'other', url: 'https://other.com/jobs' })).toBe(false);
+    });
+    it('handles null gracefully', () => {
+      expect(isLeukerbadClinicJob(null)).toBe(false);
+    });
+  });
+
+  describe('isTrustedDomain', () => {
+    it('trusts the corporate domain (with per-job fragment)', () => {
+      expect(isTrustedDomain('https://leukerbadclinic.ch/de/page/jobs/#job-abc')).toBe(true);
+    });
+    it('rejects other domains', () => {
+      expect(isTrustedDomain('https://example.com/jobs')).toBe(false);
+    });
+  });
+
+  describe('fetchAllLeukerbadClinicJobs — Prismic REST API', () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+      process.env.JOBS_CRAWLER_TIMEOUT_MS = '1000';
+    });
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+      delete process.env.JOBS_CRAWLER_TIMEOUT_MS;
+    });
+
+    function mockPrismic(docs: unknown[]) {
+      globalThis.fetch = vi.fn(async (url: any) => {
+        const u = String(url);
+        if (u === PRISMIC_API) {
+          return new Response(
+            JSON.stringify({
+              refs: [{ ref: 'MASTER_REF', isMasterRef: true }],
+              types: { job: 'Job' },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        if (u.includes('/documents/search')) {
+          return new Response(
+            JSON.stringify({ page: 1, total_pages: 1, results_size: docs.length, results: docs }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return new Response('', { status: 404 });
+      }) as any;
+    }
+
+    it('gives every job a DISTINCT fingerprint even though all share one listing URL (shrink-guard regression)', async () => {
+      // Multiple distinct job documents on the SAME fr listing page.
+      mockPrismic([
+        jobDoc('doc-A', 'infirmiere', 'fr-ch', 'INFIRMIER/INFIRMIÈRE DIPLÔMÉ-E (H/F) 80-100%'),
+        jobDoc('doc-B', 'assc', 'fr-ch', 'ASSISTANT-E EN SOINS ET SANTE COMMUNAUTAIRE CFC (ASSC)'),
+        jobDoc('doc-C', 'physio', 'fr-ch', 'PHYSIOTHERAPEUTE DIPLOME-E (H/F)'),
+        jobDoc('doc-D', 'mpa', 'de-ch', 'Medizinische/r Praxisassistent/in (m/w)'),
+      ]);
+
+      const jobs = await fetchAllLeukerbadClinicJobs();
+      expect(jobs).toHaveLength(4);
+
+      // Every job carries the per-doc fragment and points at the live listing.
+      for (const job of jobs) {
+        expect(job.companyKey).toBe('leukerbad-clinic');
+        expect(job.url).toMatch(/^https:\/\/leukerbadclinic\.ch\/(fr|de)\/page\/jobs\/#job-[0-9a-f]{12}$/);
+        expect(isTrustedDomain(job.url)).toBe(true);
+      }
+
+      // The fr jobs share the same path but MUST NOT share a fingerprint —
+      // this is the exact collapse that shrank the slice 15→2 and tripped the
+      // shrink-guard on every run.
+      const fps = jobs.map((j) => fingerprintJob(j));
+      expect(new Set(fps).size).toBe(jobs.length);
+
+      // And each fingerprint resolves via the fragment identity, not the bare
+      // (collapsing) listing URL.
+      for (const fp of fps) {
+        expect(fp).toMatch(/^id\|leukerbadclinic\.ch\|#job-[0-9a-f]{12}$/);
+      }
+    });
+
+    it('produces a stable fragment across runs for the same Prismic doc', async () => {
+      mockPrismic([jobDoc('doc-A', 'infirmiere', 'fr-ch', 'INFIRMIER/INFIRMIÈRE DIPLÔMÉ-E (H/F) 80-100%')]);
+      const first = await fetchAllLeukerbadClinicJobs();
+      mockPrismic([jobDoc('doc-A', 'infirmiere', 'fr-ch', 'INFIRMIER/INFIRMIÈRE DIPLÔMÉ-E (H/F) 80-100%')]);
+      const second = await fetchAllLeukerbadClinicJobs();
+      expect(first[0].url).toBe(second[0].url);
+      expect(fingerprintJob(first[0])).toBe(fingerprintJob(second[0]));
+    });
+  });
+});


### PR DESCRIPTION
## Implementato

- **Root cause (#4085 Crawler Failure + #4169 stale, stessa causa):** il sito Nuxt/Prismic di Leukerbad rende tutti i job su UNA pagina-listing per lingua (`…/fr/page/jobs/`, `…/de/page/jobs/`); il path per-doc va in 404, quindi il parser teneva l'URL del listing e **tutti i 15 job condividevano solo 2 URL**. Il `fingerprintJob` URL-based del crawler condiviso (`canonicalizeJobUrl` strippa l'hash) li collassava su 2 chiavi in `mergeAndDeduplicate` → slice 15→2 → **shrink-guard falliva ogni run** (la "Crawler Failure" ricorrente e la conseguente "stale").
- **Fix:** append di un fragment stabile `#job-<urlHash>` a ogni URL job (`scripts/lib/leukerbad-clinic-job-parser.mjs`). Il fragment non raggiunge mai il server (il listing resta 200), e la regola bare-hash di `extractJobIdentityFromUrl` produce un fingerprint distinto `id|leukerbadclinic.ch|#job-<hash>` — stessa convenzione già usata dai sibling galenica/eHnv/état-de-vaud/klinik-gut.

**Verifica:** Prismic REST healthy (15 job docs); pipeline completa ora scrive **15 job (era 2)** e passa lo shrink-guard; nuova suite `tests/leukerbad-clinic-crawler.test.ts` (9 test, pass) mocka l'API Prismic e asserisce fingerprint distinti + stabilità fragment; suite correlate verdi (75 totali); `node --check` OK.

Closes #4085
Closes #4169

## Non implementato (ancora)

- **rado (#4170) e swatch-group-assembly (#4171):** NON in questa PR. Diagnosi live: sorgente swatchgroup.com sana (57 job oggi; slice rado 19 / assembly 15 job reali) — non morta/spostata/bloccata. Causa = freeze del summary per-brand, **già risolto dal #4177 mergiato** (`f57bf63c5`, in main dal 07-14). Si auto-sbloccano alla prossima run swatchgroup. #4170/#4171 chiusi come duplicati di #4167 con evidenza live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_