### PR TITLE
fix(seo): dist-validation audit:all — scrub literal-markdown in hub + shave TI pagination weight (#4060)

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -56,6 +56,7 @@ import { isCantonNoindex } from './shared/cantonNoindexRegistry';
 import { hasCantonSectorPage } from './shared/cantonSectorPageRegistry';
 import { renderCantonSeoProse, type CantonSeoLocale, type CantonSeoSlot } from './shared/cantonSeoProse';
 import { buildDayStampIso } from './shared/buildDayStamp';
+import { stripLiteralMarkdown } from './shared/stripLiteralMarkdown';
 
 const LOCALE_OG: Record<HubLocale, string> = {
   it: 'it_CH',
@@ -165,6 +166,20 @@ function esc(s: unknown): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+// Escape a crawler-/AI-sourced hub-item label (job title, company, location)
+// for safe emission into `<main class="seo-static-content">`. Scrubs literal
+// markdown FIRST — HTML-escaping does NOT touch `**bold**` or `_`/`=`/`~`
+// separator runs, so a crawled job title like `Onkologie___Ärzte` leaks the
+// `___` straight into the hub listing and trips the 0-tolerance
+// `audit:no-literal-markdown` gate (CLAUDE.md rule #1). Mirrors
+// renderJobCardHtml, which already strips the card title via
+// stripLiteralMarkdown; the compact hub lists (`.thi` / `.s-7DS5hj`) bypassed
+// the card renderer and re-introduced the leak. Idempotent and byte-identical
+// on already-clean company/sector labels.
+function escLabel(s: unknown): string {
+  return esc(stripLiteralMarkdown(String(s ?? '')));
 }
 
 /** Convert a job slug like "infermiera-bellinzona-eoc" → "Infermiera Bellinzona Eoc" */
@@ -1094,7 +1109,7 @@ function buildHtml(args: BuildHtmlArgs): string {
       itemListElement: pageItems.slice(0, 25).map((it, idx) => ({
         '@type': 'ListItem',
         position: (page - 1) * 100 + idx + 1,
-        name: it.label,
+        name: stripLiteralMarkdown(String(it.label ?? '')),
         // Normalise to absolute: pageItems[].href is usually root-relative but
         // may be already-absolute (per-locale job URLs from all-known-job-slugs)
         // — bare `${BASE_URL}${href}` would double-prefix those (issue #2235).
@@ -1123,7 +1138,7 @@ function buildHtml(args: BuildHtmlArgs): string {
                 logoUrl: it.logo ?? undefined,
                 iconSvg: it.logo ? undefined : ICON_BUILDING_SVG,
                 logoOnerror: it.logo ? LOGO_IMG_ONERROR : undefined,
-                title: it.label,
+                title: stripLiteralMarkdown(String(it.label ?? '')),
                 subtitle: it.jobCount ? jobsActiveLabel(locale, it.jobCount) : undefined,
                 metric: it.jobCount ? String(it.jobCount) : undefined,
                 metricTone: 'accent',
@@ -1132,16 +1147,16 @@ function buildHtml(args: BuildHtmlArgs): string {
             }
             if (it.emoji !== undefined) {
               const subLabel = { it: 'Esplora →', en: 'Explore →', de: 'Erkunden →', fr: 'Explorer →' }[locale];
-              return `<li><a class="s-pJU7QH" href="${esc(it.href)}"><span class="s-PocAr6" aria-hidden="true">${it.emoji}</span><span class="s-KGNylX"><span class="s-wLg1zr">${esc(it.label)}</span><span class="s-Q0Kk4P">${subLabel}</span></span></a></li>`;
+              return `<li><a class="s-pJU7QH" href="${esc(it.href)}"><span class="s-PocAr6" aria-hidden="true">${it.emoji}</span><span class="s-KGNylX"><span class="s-wLg1zr">${escLabel(it.label)}</span><span class="s-Q0Kk4P">${subLabel}</span></span></a></li>`;
             }
             if (it.excerpt !== undefined) {
-              return `<li><a class="s-6gbS_B" href="${esc(it.href)}"><span class="s-lkdl0F">${esc(it.label)}</span><span class="s-hNvHD_">${esc(it.excerpt)}</span></a></li>`;
+              return `<li><a class="s-6gbS_B" href="${esc(it.href)}"><span class="s-lkdl0F">${escLabel(it.label)}</span><span class="s-hNvHD_">${escLabel(it.excerpt)}</span></a></li>`;
             }
-            return `<li><a class="s-7DS5hj" href="${esc(it.href)}">${esc(it.label)}</a></li>`;
+            return `<li><a class="s-7DS5hj" href="${esc(it.href)}">${escLabel(it.label)}</a></li>`;
           })
           .join('')}</ul>`
       : `<ul class="s-N93mPe">${pageItems
-          .map((it) => `<li><a class="s-7DS5hj" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+          .map((it) => `<li><a class="s-7DS5hj" href="${esc(it.href)}">${escLabel(it.label)}</a></li>`)
           .join('')}</ul>`;
 
   // Stat tiles + primary CTA — universal across hub kinds. Tiles surface the
@@ -1247,7 +1262,7 @@ function updatedLabel(locale: HubLocale): string {
   return { it: 'Aggiornato', en: 'Updated', de: 'Aktualisiert', fr: 'Mis à jour' }[locale];
 }
 
-function renderPagination(locale: HubLocale, basePath: string, current: number, total: number): string {
+export function renderPagination(locale: HubLocale, basePath: string, current: number, total: number): string {
   // Compact pagination (visible): prev, 1, current-1, current, current+1, last, next.
   // Plus a FLAT crawler-facing navigator inside a collapsed <details> linking
   // every page-N (BFS-depth closure 2026-05-12 run 25753701178 — without
@@ -1305,7 +1320,6 @@ function renderPagination(locale: HubLocale, basePath: string, current: number, 
     de: 'Vollständiges Archiv nach Seite durchsuchen',
     fr: 'Parcourir toutes les archives par page',
   }[locale];
-  const pageWord = locale === 'de' ? 'Seite' : locale === 'fr' || locale === 'en' ? 'Page' : 'Pagina';
   // Use CSS classes instead of per-anchor inline styles. With totalPages
   // ≥ 100 (master jobs hub) the inline-style variant ballooned to ~250 B
   // per anchor × ~400 anchors = ~100 KB, pushing the last-page HTML past
@@ -1322,13 +1336,26 @@ function renderPagination(locale: HubLocale, basePath: string, current: number, 
   // it alone pushed /fr/trouver-emploi-tessin/tous/ past the 215 KB budget
   // (run 28090796553, ~42 KB of prefix). rel=prev/next <link> head hints
   // stay absolute (canonical convention).
+  //
+  // Bare page number as the visible/anchor text (was `${pageWord}&nbsp;${p}`).
+  // The full ladder MUST keep every page-N anchor for BFS-depth closure (see
+  // header comment) — that link set is load-bearing and unchanged here — but
+  // the repeated per-anchor word prefix ("Pagina&nbsp;" / "Seite&nbsp;" /
+  // "Page&nbsp;", ~10-12 B each) is not: at ~2 200 archive pages it added
+  // ~24 KB that pushed /cerca-lavoro-ticino/tutti/ and its page-N back over
+  // the 215 KB audit:page-weight budget (post-deploy run 29330607996, 130
+  // offenders 223-228 KB). The compact nav above already renders bare `${p}`
+  // links, and the `<details><summary>` + `<nav aria-label>` supply the
+  // "browse by page" context, so the numbers stay understandable. Same
+  // byte-shave class as the prior inline-style→class and BASE_URL-prefix drops
+  // on this exact ladder; every anchor is preserved so BFS depth is unchanged.
   const flatAnchors: string[] = [];
   for (let p = 1; p <= total; p++) {
     const href = paginatedPath(basePath, p);
     if (p === current) {
-      flatAnchors.push(`<strong class="hc" aria-current="page">${pageWord}&nbsp;${p}</strong>`);
+      flatAnchors.push(`<strong class="hc" aria-current="page">${p}</strong>`);
     } else {
-      flatAnchors.push(`<a href="${href}" class="hp">${pageWord}&nbsp;${p}</a>`);
+      flatAnchors.push(`<a href="${href}" class="hp">${p}</a>`);
     }
   }
   const flatNav = `<nav class="s-4nYHgH" aria-label="${flatLabel}"><details class="s-Ery2Xe"><summary class="s-goeAUL">${flatLabel} (${total})</summary><div class="s-6_t7LY">${flatAnchors.join('')}</div></details></nav>`;
@@ -1591,7 +1618,7 @@ type ThinHubItem = {
   readonly metricTone?: 'default' | 'accent' | 'success' | 'warning' | 'danger';
 };
 
-function buildThinCantonHubHtml(args: {
+export function buildThinCantonHubHtml(args: {
   locale: HubLocale;
   hub: CantonHubKind;
   canton: string;
@@ -1661,14 +1688,20 @@ function buildThinCantonHubHtml(args: {
       : locale === 'de' ? 'Alle Seiten durchsuchen'
       : locale === 'fr' ? 'Parcourir toutes les pages'
       : 'Sfoglia tutte le pagine';
-    const pageWord = locale === 'de' ? 'Seite' : locale === 'fr' || locale === 'en' ? 'Page' : 'Pagina';
+    // Bare page number (was `${pageWord}&nbsp;${p}`). Same page-weight
+    // byte-shave as the master-hub `renderPagination` flat ladder: the full
+    // page-N link set is kept intact (load-bearing for BFS-depth) but the
+    // repeated per-anchor word prefix is dropped so a growing canton archive
+    // can't drift its /tutti/page-N/ HTML over the 215 KB audit:page-weight
+    // budget. The `<details><summary>` + `<nav aria-label>` give the "browse
+    // by page" context. CLAUDE.md #6: fixed in lockstep with renderPagination.
     const anchors: string[] = [];
     for (let p = 1; p <= totalPages; p++) {
       const href = p === 1 ? basePath : paginatedPath(basePath, p);
       if (p === page) {
-        anchors.push(`<strong class="thc">${pageWord}&nbsp;${p}</strong>`);
+        anchors.push(`<strong class="thc">${p}</strong>`);
       } else {
-        anchors.push(`<a href="${href}" class="thp">${pageWord}&nbsp;${p}</a>`);
+        anchors.push(`<a href="${href}" class="thp">${p}</a>`);
       }
     }
     // Always-open <details> so the BFS walker (and crawlers) see every <a>
@@ -1692,8 +1725,8 @@ function buildThinCantonHubHtml(args: {
                 logoUrl: it.logo ?? undefined,
                 iconSvg: it.logo ? undefined : ICON_BUILDING_SVG,
                 logoOnerror: it.logo ? LOGO_IMG_ONERROR : undefined,
-                title: it.label,
-                subtitle: it.sub,
+                title: stripLiteralMarkdown(String(it.label ?? '')),
+                subtitle: it.sub != null ? stripLiteralMarkdown(it.sub) : it.sub,
                 metric: it.metric,
                 metricTone: it.metricTone ?? 'accent',
               });
@@ -1703,7 +1736,7 @@ function buildThinCantonHubHtml(args: {
             // wrapper instead of renderEntityCard so the emoji renders at a
             // larger size than the 24×24 SVG icon bubble.
             const emoji = it.emoji ?? '🧭';
-            return `<li><a class="s-pJU7QH" href="${esc(it.href)}"><span class="s-PocAr6" aria-hidden="true">${emoji}</span><span class="s-KGNylX"><span class="s-wLg1zr">${esc(it.label)}</span>${it.sub ? `<span class="s-Q0Kk4P">${esc(it.sub)}</span>` : ''}</span></a></li>`;
+            return `<li><a class="s-pJU7QH" href="${esc(it.href)}"><span class="s-PocAr6" aria-hidden="true">${emoji}</span><span class="s-KGNylX"><span class="s-wLg1zr">${escLabel(it.label)}</span>${it.sub ? `<span class="s-Q0Kk4P">${escLabel(it.sub)}</span>` : ''}</span></a></li>`;
           })
           .join('')}</ul>`
       // CSS classes `.thi` / `.thi-s` replace ~200 B of inline styles per
@@ -1711,7 +1744,7 @@ function buildThinCantonHubHtml(args: {
       // `/tutti/page-N/`, this saves ~19 KB per page × ~2.8k paginated
       // pages across all cantons and locales ≈ 50 MB dist.
       : `<ul class="s-N93mPe">${items
-          .map((it) => `<li><a href="${esc(it.href)}" class="thi">${esc(it.label)}${it.sub ? `<span class="thi-s">${esc(it.sub)}</span>` : ''}</a></li>`)
+          .map((it) => `<li><a href="${esc(it.href)}" class="thi">${escLabel(it.label)}${it.sub ? `<span class="thi-s">${escLabel(it.sub)}</span>` : ''}</a></li>`)
           .join('')}</ul>`;
 
   // Stat tiles (rule #17) — only on page 1, only when caller supplied them.
@@ -1785,7 +1818,7 @@ function buildThinCantonHubHtml(args: {
             // via the shared normaliser (see absItemUrl) so the two ItemList
             // emitters cannot drift.
             url: absItemUrl(it.href),
-            name: it.label,
+            name: stripLiteralMarkdown(String(it.label ?? '')),
           })),
         },
       });

--- a/build-plugins/shared/jobCardHtml.ts
+++ b/build-plugins/shared/jobCardHtml.ts
@@ -296,13 +296,20 @@ export function renderJobCardHtml(
   const title = stripLiteralMarkdownFromTitle(
     String(titleSource).replace(/\s+/g, ' ').trim(),
   );
-  const company = String(job.company || '').trim();
+  // Company + location are crawler-/AI-sourced free text rendered into the
+  // indexed `<main class="seo-static-content">` (jc-sub / jc-chip) on every
+  // hub / sector / recency page. HTML-escaping does NOT touch `**bold**` or
+  // `_`/`=`/`~` separator runs, so — exactly like the title above — they must
+  // be scrubbed or a company like `ACME___GmbH` trips the 0-tolerance
+  // audit:no-literal-markdown gate (CLAUDE.md rule #1). Idempotent /
+  // byte-identical on the clean-string majority.
+  const company = stripLiteralMarkdownFromTitle(String(job.company || '').trim());
   // Display-only title-case for all-lowercase crawler localities; already
   // capitalised strings pass through untouched (byte-identical output). The
   // city linkifiers downstream match case-insensitively, so handing them the
   // cased string is safe.
   const rawLocation = titleCaseLocalityIfLowercase(
-    String(job.location || job.addressLocality || '').trim(),
+    stripLiteralMarkdownFromTitle(String(job.location || job.addressLocality || '').trim()),
   );
   const cantonStr = job.canton ? ` (${escHtml(String(job.canton))})` : '';
 

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -3721,11 +3721,16 @@ export function staticPagesPlugin(rootDir: string): Plugin {
        : navLocale === 'de' ? 'Listings nach Seite durchsuchen'
        : navLocale === 'fr' ? 'Parcourir les annonces page par page'
        : 'Sfoglia gli annunci pagina per pagina';
-     const pageWord = navLocale === 'en' || navLocale === 'fr' ? 'p.' : navLocale === 'de' ? 'S.' : 'p.';
+     // Bare page number (was a `<word>&nbsp;<n>` label). Same page-weight
+     // byte-shave as the canton hub flat ladders (CLAUDE.md #6): the full
+     // page-N link set is kept intact but the repeated per-anchor word prefix
+     // is dropped so a growing TI archive can't drift the injected navigator
+     // over the audit:page-weight budget. `<summary>`/`<nav aria-label>` supply
+     // the "page by page" context.
      const paginationAnchors: string[] = [];
      for (let p = 2; p <= tiPaginationPages; p++) {
        const href = `${tiBase}${TI_PAGINATION_SLUG[navLocale]}-${p}/`;
-       paginationAnchors.push(`<a href="${href}" class="jbx-l">${pageWord}&nbsp;${p}</a>`);
+       paginationAnchors.push(`<a href="${href}" class="jbx-l">${p}</a>`);
      }
      editorialBlocks.push(
        `<details class="s-01GpQM"><summary class="s-DhA4PZ">${esc(paginationNavLabel)} (${tiPaginationPages - 1})</summary><nav class="s-6_t7LY" aria-label="${esc(paginationNavLabel)}">${paginationAnchors.join('')}</nav></details>`,
@@ -3888,12 +3893,14 @@ export function staticPagesPlugin(rootDir: string): Plugin {
    : locale === 'en' ? 'Browse the full article archive by page'
    : locale === 'de' ? 'Vollständiges Artikelarchiv nach Seite durchsuchen'
    : 'Parcourir toutes les archives par page';
- const pageWord = locale === 'it' ? 'Pagina' : locale === 'en' ? 'Page' : locale === 'de' ? 'Seite' : 'Page';
  if (articlesTotalPages > 1) {
+ // Bare page number (was a `<word>&nbsp;<n>` label). Same BFS-safe page-weight
+ // byte-shave as the canton hub ladders (CLAUDE.md #6): every page-N anchor
+ // preserved, only the repeated word prefix dropped; `<nav aria-label>` context.
  const pageAnchors: string[] = [];
  for (let p = 1; p <= articlesTotalPages; p++) {
  const href = paginatedPath(articlesArchiveBase, p);
- pageAnchors.push(`<a class="s-4pFg-C" href="${href}">${pageWord}&nbsp;${p}</a>`);
+ pageAnchors.push(`<a class="s-4pFg-C" href="${href}">${p}</a>`);
  }
  editorialBlocks.push(
  `<nav class="s-rzdYWi" aria-label="${esc(navLabel)}"><p class="s-AYnHp_">${esc(navLabel)}:</p>${pageAnchors.join('')}</nav>`,

--- a/tests/seo/seo-hubs-literal-markdown-and-pagination-weight.test.ts
+++ b/tests/seo/seo-hubs-literal-markdown-and-pagination-weight.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  renderPagination,
+  buildThinCantonHubHtml,
+} from '../../build-plugins/seoHubsPlugin';
+import { createAuditor } from '../../scripts/audit-no-literal-markdown.mjs';
+import { ROOT } from '../../scripts/lib/audit-runner.mjs';
+import { minifyHtml } from '../../build-plugins/shared/htmlMinify';
+
+// Regression for post-deploy validate-dist run 29330607996 (issue #4060),
+// audit:all failing sub-audits:
+//   1) audit:no-literal-markdown — a crawled Stadtspital-Zürich job title
+//      `Assistenzärzt*in Medizinische Onkologie___Ärzte-DIM-Onkologie` leaked
+//      the literal `___` separator into the Zurich `/tutti/` hub listing
+//      (the compact `.thi` / `.s-7DS5hj` lists bypassed the card renderer's
+//      stripLiteralMarkdown), tripping the 0-tolerance gate.
+//   2) audit:page-weight — the `/cerca-lavoro-ticino/tutti/` full pagination
+//      ladder (every page-N anchor, load-bearing for BFS-depth) carried a
+//      repeated `Pagina&nbsp;`/`Seite&nbsp;`/`Page&nbsp;` word prefix that at
+//      ~2 200 archive pages pushed the HTML back over the 215 KB budget.
+
+const JOB_BOARD_PATH = `${ROOT}/dist/cerca-lavoro-zurigo/tutti/index.html`;
+
+const DIRTY_TITLE = 'Assistenzärzt*in Medizinische Onkologie___Ärzte-DIM-Onkologie';
+
+describe('seoHubs — no literal markdown leaks into hub listings', () => {
+  it('strips separator runs / bold tokens from tutti-hub item titles', () => {
+    const html = buildThinCantonHubHtml({
+      locale: 'de',
+      hub: 'tutti',
+      canton: 'zurigo',
+      cantonLabel: 'Zürich',
+      basePath: '/cerca-lavoro-zurigo/tutti/',
+      totalItems: 3,
+      items: [
+        { href: '/cerca-lavoro-zurigo/onkologie-stadtspital-zurich/', label: DIRTY_TITLE, sub: 'Zürich' },
+        { href: '/cerca-lavoro-zurigo/leiter-finanzen/', label: 'Leiter **Finanzen** === Abteilung', sub: 'Zürich' },
+        { href: '/cerca-lavoro-zurigo/pflege/', label: 'Pflegefachperson', sub: 'Winterthur' },
+      ],
+      hasSpaBundle: false,
+      entryJs: '',
+      entryCss: '',
+      dateStamp: '2026-07-14',
+    });
+
+    // The audit only scans the minified, quote-flexible shell.
+    const minified = minifyHtml(html);
+    const audit = createAuditor();
+    audit.collect(JOB_BOARD_PATH, minified);
+    const report = audit.report();
+
+    expect(report.passed).toBe(true);
+    expect(report.offendersTotal).toBe(0);
+    // Sanity: the raw markdown tokens are gone from the rendered listing.
+    expect(html).not.toContain('___');
+    expect(html).not.toMatch(/\*\*[^*\n]+\*\*/);
+    // The visible words survive the scrub (only the markdown noise is removed).
+    expect(html).toContain('Medizinische Onkologie');
+  });
+});
+
+describe('seoHubs — pagination ladder page-weight byte-shave', () => {
+  it('renderPagination keeps every page-N anchor (BFS) but drops the word prefix', () => {
+    const total = 2500;
+    const html = renderPagination('it', '/cerca-lavoro-ticino/tutti/', 1, total);
+
+    // BFS-depth closure: the full flat ladder must still link every page.
+    expect(html).toContain('/cerca-lavoro-ticino/tutti/page-2/');
+    expect(html).toContain(`/cerca-lavoro-ticino/tutti/page-${total}/`);
+    const linkedPages = new Set(
+      [...html.matchAll(/tutti\/page-(\d+)\//g)].map((m) => Number(m[1])),
+    );
+    // page-1 is the basePath (not `/page-1/`), so 2..2500 == 2499 distinct.
+    expect(linkedPages.size).toBe(total - 1);
+
+    // The repeated per-anchor word prefix is gone (this is the byte-shave).
+    expect(html).not.toContain('Pagina&nbsp;');
+    expect(html).not.toContain('Seite&nbsp;');
+    expect(html).not.toContain('Page&nbsp;');
+    // Bare-number anchors instead.
+    expect(html).toMatch(/class="hp">2500<\/a>/);
+  });
+
+  it('buildThinCantonHubHtml ladder is shaved in lockstep (CLAUDE.md #6)', () => {
+    const totalPages = 400;
+    const html = buildThinCantonHubHtml({
+      locale: 'it',
+      hub: 'tutti',
+      canton: 'argovia',
+      cantonLabel: 'Argovia',
+      basePath: '/cerca-lavoro-argovia/tutti/',
+      totalItems: 40000,
+      items: [{ href: '/cerca-lavoro-argovia/x/', label: 'Ruolo', sub: 'Aarau' }],
+      hasSpaBundle: false,
+      entryJs: '',
+      entryCss: '',
+      dateStamp: '2026-07-14',
+      page: 1,
+      totalPages,
+    });
+    expect(html).not.toContain('Pagina&nbsp;');
+    expect(html).toContain('/cerca-lavoro-argovia/tutti/page-400/');
+    expect(html).toMatch(/class="thp">400<\/a>/);
+  });
+});


### PR DESCRIPTION
## Implementato

Gate fallito (step #19, pool `audit:all`) confermato dall'artifact `audit-reports-29330607996-1` — due sub-audit `"passed": false`. (Il bfs-depth era un falso indizio: `max-bfs-depth.json` PASSA, i sitemap weather sono a `atDepthGtMax:24` vs baseline 32 → migliorati.)

**1. `no-literal-markdown` (4 offenders, `___`)** — il titolo job crawlato `Assistenzärzt*in Medizinische Onkologie___Ärzte-DIM-Onkologie` (Stadtspital Zürich) filtrava nelle liste hub compatte di `build-plugins/seoHubsPlugin.ts` (che bypassano `renderJobCardHtml`). Fix: nuovo `escLabel()` = `esc(stripLiteralMarkdown(x))` su ogni label/sub/excerpt + `name` JSON-LD in `buildHubHtml` e `buildThinCantonHubHtml`; scrub anche di `company`+`location` in `build-plugins/shared/jobCardHtml.ts` (choke point condiviso) → chiude la CLASSE per qualsiasi job con `**`/`___`/`===`/`~~~`.

**2. `page-weight` (130 pagine TI > 215KB)** — `/cerca-lavoro-ticino/tutti/` linka ~2200 pagine (load-bearing per BFS-depth); ogni anchor ripeteva il prefisso `Pagina&nbsp;`/`Seite&nbsp;`/`Page&nbsp;`. Fix: ladder ridotte a **numeri di pagina nudi** su tutti e 4 i siti (`renderPagination`, `buildThinCantonHubHtml`, ladder TI `pagina-N` + articles-archive in `staticPagesPlugin.ts`). **Preserva l'intero set di link page-N** → BFS-depth invariato (no re-baseline, no gate abbassato); risparmio ~22–26KB/pagina → tutti i 130 offender rientrano con ~13KB di margine.

**Verifica:** 153 test mirati passano (incl. nuovo `tests/seo/seo-hubs-literal-markdown-and-pagination-weight.test.ts`: l'auditor reale passa su titolo hub con `___`/`**`, e la ladder mantiene ogni anchor page-N droppando solo il prefisso), + cathedral-canton-hub-parity, seo-hubs-pagination-bfs, half-canton-merge, jobCardHtml. Byte-saving misurato empiricamente (~22KB/pagina). No full-dist rebuild possibile in-agent.

Closes #4060

## Non implementato (ancora)

- La ladder TI `/tutti/` è architetturalmente non-limitata (cresce ~78 B/pagina): lo shave compra headroom, non un bound permanente. Un cambio topologico durevole richiede un full-dist build per validarne l'interazione bfs/orphan (non eseguibile in-agent). Trigger di revert/follow-up registrato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_