### PR TITLE
fix(seo): scatter-jobs-to-slices porta avanti i bridge previousSlugs dell'assembled (regressione writer)

### DIFF
--- a/scripts/scatter-jobs-to-slices.mjs
+++ b/scripts/scatter-jobs-to-slices.mjs
@@ -16,7 +16,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
-import { addPreviousSlugForLocale } from './lib/dedicated-crawler-common.mjs';
+import { addPreviousSlugForLocale, DEFAULT_PREV_SLUG_CAP, LEGACY_PREV_SLUGS_CAP, LOCALES } from './lib/dedicated-crawler-common.mjs';
 import { resolveJobDiffKey } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -32,35 +32,12 @@ function readJson(filePath, fallback) {
   }
 }
 
-const jobs = readJson(DATA_JOBS, null);
-if (!Array.isArray(jobs)) {
-  console.log('ℹ️  data/jobs.json not found or not an array — nothing to scatter.');
-  process.exit(0);
-}
-
-// Index assembled jobs by stable diff key (id / url / slug fallback — see
-// resolveJobDiffKey) — NOT bare .slug. Bare-slug keying collides across
-// companies whenever two jobs compute the same slug (463 live collisions
-// confirmed in data/jobs/by-crawler/*.json, e.g. klinik-sonnenhalde vs.
-// allianz-suisse), silently merging wrong-company locale/slug data into a
-// slice (previousSlugs writer regression, issue #3734).
-const jobIndex = new Map();
-for (const job of jobs) {
-  const key = resolveJobDiffKey(job);
-  if (key) jobIndex.set(key, job);
-}
-
-// Read each slice, update jobs with matching slugs, write back if changed
-const sliceFiles = fs.existsSync(SLICES_DIR)
-  ? fs.readdirSync(SLICES_DIR).filter((f) => f.endsWith('.json') && f !== '.gitkeep')
-  : [];
-
 /**
  * Merge two locale maps. For each locale, prefer the assembled value if non-empty,
  * otherwise keep the slice value. This prevents AI translation failures from
  * destroying existing translations.
  */
-function mergeLocaleMap(sliceMap, assembledMap) {
+export function mergeLocaleMap(sliceMap, assembledMap) {
   const s = (sliceMap && typeof sliceMap === 'object') ? sliceMap : {};
   const a = (assembledMap && typeof assembledMap === 'object') ? assembledMap : {};
   const merged = { ...s };
@@ -77,82 +54,240 @@ function mergeLocaleMap(sliceMap, assembledMap) {
   return merged;
 }
 
-let updatedSlices = 0;
-let updatedJobs = 0;
+/**
+ * Collect every slug the ASSEMBLED job already knows about as a previousSlugs
+ * bridge (flat legacy array + per-locale buckets) that is NOT yet present
+ * anywhere on the slice job's active-or-history slug set. These are SEO
+ * redirect bridges the assembled pipeline captured (via
+ * assemble-jobs-dataset's trackSlugHistoryDrift / ensureLocaleFields / the
+ * cross-job collision guard) but that the per-crawler slice — the committed
+ * source of truth the build plugin reads to emit bridge pages — is missing.
+ *
+ * Scatter is the assembled→slice writer for every job NOT touched by
+ * relocalize-pending-jobs.mjs; relocalize already carries these bridges
+ * forward (see its "Sync previousSlugs from assembled dataset" block), so
+ * scatter dropping them was the sibling gap that silently lost bridges for
+ * the non-pending majority of jobs (issue class #4165/#4161/#4134/#4112/
+ * #4102/#4088/#4076/#3885).
+ *
+ * Bounded by the flat legacy cap (LEGACY_PREV_SLUGS_CAP): only as many NEW
+ * distinct bridges are returned as fit under the cap alongside the slice's
+ * existing history, so carrying them forward can NEVER evict a slug the slice
+ * already had (the flat array is the widest cap and the only bucket whose
+ * eviction shows up as a scan-detected loss — per-locale eviction stays
+ * mirrored in the flat union). Attributed (per-locale) bridges are preferred
+ * over unattributed flat-only ones when headroom is scarce, since correct
+ * locale attribution drives which prefix the bridge page is emitted under.
+ *
+ * @returns {Array<{ locale: string|null, slug: string }>} ordered add-list
+ */
+export function collectMissingAssembledBridges(sliceJob, assembled) {
+  const known = new Set();
+  if (sliceJob.slug) known.add(String(sliceJob.slug));
+  for (const s of Object.values(sliceJob.slugByLocale || {})) if (s) known.add(String(s));
+  for (const s of (Array.isArray(sliceJob.previousSlugs) ? sliceJob.previousSlugs : [])) if (s) known.add(String(s));
+  const existingByLocale = (sliceJob.previousSlugsByLocale && typeof sliceJob.previousSlugsByLocale === 'object')
+    ? sliceJob.previousSlugsByLocale : {};
+  for (const arr of Object.values(existingByLocale)) {
+    for (const s of (Array.isArray(arr) ? arr : [])) if (s) known.add(String(s));
+  }
 
-for (const file of sliceFiles) {
-  const slicePath = path.join(SLICES_DIR, file);
-  const slice = readJson(slicePath, null);
-  if (!slice || !Array.isArray(slice.jobs)) continue;
+  // Headroom under the flat legacy cap: adding more distinct bridges than this
+  // would push the flat union past the cap and trim the oldest (possibly a
+  // pre-existing slice entry). `known` already deduplicates every slug the
+  // job currently holds anywhere, so its size is exactly the flat union size.
+  const headroom = Math.max(0, LEGACY_PREV_SLUGS_CAP - known.size);
+  if (headroom === 0) return [];
 
-  let sliceChanged = false;
-  const updatedSliceJobs = slice.jobs.map((sliceJob) => {
-    const sliceKey = resolveJobDiffKey(sliceJob);
-    if (!sliceKey) return sliceJob;
-    const assembled = jobIndex.get(sliceKey);
-    if (!assembled) return sliceJob;
-
-    // Compare locale fields — only update if they changed
-    const changed =
-      JSON.stringify(assembled.titleByLocale) !== JSON.stringify(sliceJob.titleByLocale) ||
-      JSON.stringify(assembled.descriptionByLocale) !== JSON.stringify(sliceJob.descriptionByLocale) ||
-      JSON.stringify(assembled.slugByLocale) !== JSON.stringify(sliceJob.slugByLocale);
-
-    if (changed) {
-      sliceChanged = true;
-      updatedJobs++;
-      // Defensive merge: never overwrite a non-empty locale value with an empty one.
-      // The assembled data may have had locales stripped by ensureLocaleFields when
-      // AI translation failed — the per-crawler file is the source of truth.
-      const mergedTitle = mergeLocaleMap(sliceJob.titleByLocale, assembled.titleByLocale);
-      const mergedDesc = mergeLocaleMap(sliceJob.descriptionByLocale, assembled.descriptionByLocale);
-      const mergedSlug = mergeLocaleMap(sliceJob.slugByLocale, assembled.slugByLocale);
-
-      // Track slug changes: preserve old slug values in previousSlugsByLocale so the build
-      // plugin can generate bridge/redirect pages for SEO continuity (prevents 404s
-      // for URLs that Google/Bing may have already indexed).
-      const oldSlugs = sliceJob.slugByLocale && typeof sliceJob.slugByLocale === 'object'
-        ? sliceJob.slugByLocale : {};
-      const newSlugs = mergedSlug && typeof mergedSlug === 'object' ? mergedSlug : {};
-
-      let updatedJob = { ...sliceJob, titleByLocale: mergedTitle, descriptionByLocale: mergedDesc, slugByLocale: mergedSlug };
-
-      // Detect per-locale slug changes and record with locale context.
-      // Route through the canonical journal-backed helper (instead of a
-      // hand-rolled push + flat-array cap) so every capture/cap-trim is
-      // recorded via recordSlugMutation like every other slug-mutation path
-      // (previousSlugs regression: issue #3284 — this call site pushed into
-      // previousSlugsByLocale and re-derived the legacy `previousSlugs`
-      // mirror with its own `.slice(0, 20)` that kept the OLDEST 20 entries
-      // instead of the most recent ones, with no journal entry for the trim).
-      const locales = ['it', 'en', 'de', 'fr'];
-      for (const locale of locales) {
-        const oldSlug = String(oldSlugs[locale] || '').trim();
-        const newSlug = String(newSlugs[locale] || '').trim();
-        if (oldSlug && newSlug && oldSlug !== newSlug) {
-          addPreviousSlugForLocale(updatedJob, locale, oldSlug, 20, 'scatter-jobs-to-slices');
-        }
+  // Pass 1 (preferred): locale-attributed bridges. A value already present in
+  // the flat array but missing from THIS locale's bucket still counts as new
+  // for the bucket (bridge emission routes through the bucket preferentially),
+  // but it is NOT new for the flat union, so it does not consume headroom.
+  const adds = [];
+  const seen = new Set();
+  if (assembled.previousSlugsByLocale && typeof assembled.previousSlugsByLocale === 'object') {
+    for (const locale of LOCALES) {
+      const arr = assembled.previousSlugsByLocale[locale];
+      if (!Array.isArray(arr)) continue;
+      const bucket = Array.isArray(existingByLocale[locale]) ? existingByLocale[locale] : [];
+      for (const s of arr) {
+        const v = String(s || '');
+        if (!v || bucket.includes(v)) continue;
+        const dedupKey = `${locale} ${v}`;
+        if (seen.has(dedupKey)) continue;
+        const consumesHeadroom = !known.has(v);
+        if (consumesHeadroom && adds.filter((a) => !a._free).length >= headroom) continue;
+        seen.add(dedupKey);
+        adds.push({ locale, slug: v, _free: !consumesHeadroom });
+        if (consumesHeadroom) known.add(v);
       }
-
-      return updatedJob;
     }
-    return sliceJob;
-  });
+  }
+  // Pass 2: unattributed flat-only bridges → default to the IT bucket, only up
+  // to remaining headroom.
+  for (const s of (Array.isArray(assembled.previousSlugs) ? assembled.previousSlugs : [])) {
+    const v = String(s || '');
+    if (!v || known.has(v)) continue;
+    if (adds.filter((a) => !a._free).length >= headroom) break;
+    known.add(v);
+    adds.push({ locale: 'it', slug: v, _free: false });
+  }
+  return adds.map(({ locale, slug }) => ({ locale, slug }));
+}
 
-  if (sliceChanged) {
-    // Preserve the original assembledAt timestamp from the crawler.
-    // Scatter only propagates locale changes from the assembled dataset — it
-    // does not represent a new crawl run, so bumping assembledAt would cause
-    // unnecessary git churn across 90+ files when only a single company was
-    // actually translated.
-    const envelope = { ...slice, jobs: updatedSliceJobs };
-    writeJson(slicePath, envelope);
-    updatedSlices++;
+/**
+ * Apply an assembled job's translated locale fields + captured slug history
+ * onto its per-crawler slice job. Pure: returns a NEW job object (never
+ * mutates the input) plus whether anything changed. Unit-tested directly.
+ *
+ * @param {object} sliceJob  the per-crawler slice job (source of truth)
+ * @param {object} assembled the matching assembled data/jobs.json entry
+ * @returns {{ job: object, changed: boolean }}
+ */
+export function applyAssembledToSliceJob(sliceJob, assembled) {
+  // SEO bridge slugs the assembled job captured (trackSlugHistoryDrift /
+  // ensureLocaleFields / collision guard) but the slice is still missing.
+  // Computed up front so it can ALSO trigger a write for a job whose
+  // locale/slug fields are otherwise unchanged — otherwise a slug renamed on
+  // the assembled side in a prior run (its old value living only in the
+  // assembled previousSlugs) would never make it onto the committed slice.
+  const missingBridges = collectMissingAssembledBridges(sliceJob, assembled);
+
+  // Compare locale fields — only update if they changed
+  const changed =
+    JSON.stringify(assembled.titleByLocale) !== JSON.stringify(sliceJob.titleByLocale) ||
+    JSON.stringify(assembled.descriptionByLocale) !== JSON.stringify(sliceJob.descriptionByLocale) ||
+    JSON.stringify(assembled.slugByLocale) !== JSON.stringify(sliceJob.slugByLocale) ||
+    missingBridges.length > 0;
+
+  if (!changed) return { job: sliceJob, changed: false };
+
+  // Defensive merge: never overwrite a non-empty locale value with an empty one.
+  // The assembled data may have had locales stripped by ensureLocaleFields when
+  // AI translation failed — the per-crawler file is the source of truth.
+  const mergedTitle = mergeLocaleMap(sliceJob.titleByLocale, assembled.titleByLocale);
+  const mergedDesc = mergeLocaleMap(sliceJob.descriptionByLocale, assembled.descriptionByLocale);
+  const mergedSlug = mergeLocaleMap(sliceJob.slugByLocale, assembled.slugByLocale);
+
+  // Track slug changes: preserve old slug values in previousSlugsByLocale so the build
+  // plugin can generate bridge/redirect pages for SEO continuity (prevents 404s
+  // for URLs that Google/Bing may have already indexed).
+  const oldSlugs = sliceJob.slugByLocale && typeof sliceJob.slugByLocale === 'object'
+    ? sliceJob.slugByLocale : {};
+  const newSlugs = mergedSlug && typeof mergedSlug === 'object' ? mergedSlug : {};
+
+  const updatedJob = { ...sliceJob, titleByLocale: mergedTitle, descriptionByLocale: mergedDesc, slugByLocale: mergedSlug };
+
+  // Detect per-locale slug changes and record with locale context.
+  // Route through the canonical journal-backed helper (instead of a
+  // hand-rolled push + flat-array cap) so every capture/cap-trim is
+  // recorded via recordSlugMutation like every other slug-mutation path
+  // (previousSlugs regression: issue #3284 — this call site pushed into
+  // previousSlugsByLocale and re-derived the legacy `previousSlugs`
+  // mirror with its own `.slice(0, 20)` that kept the OLDEST 20 entries
+  // instead of the most recent ones, with no journal entry for the trim).
+  const locales = ['it', 'en', 'de', 'fr'];
+  for (const locale of locales) {
+    const oldSlug = String(oldSlugs[locale] || '').trim();
+    const newSlug = String(newSlugs[locale] || '').trim();
+    if (oldSlug && newSlug && oldSlug !== newSlug) {
+      addPreviousSlugForLocale(updatedJob, locale, oldSlug, 20, 'scatter-jobs-to-slices');
+    }
+  }
+
+  // Carry forward SEO bridge slugs the assembled dataset already knows about
+  // but the slice was missing. relocalize-pending-jobs.mjs does this for the
+  // jobs it processes ("Sync previousSlugs from assembled dataset to
+  // per-crawler file"); scatter is the writer for every OTHER job, so it must
+  // mirror the carry-forward or those bridges are dropped from the committed
+  // slice → 404s for URLs Google already indexed (issue class
+  // #4165/#4161/#4134/#4112/#4102/#4088/#4076/#3885). Routed through the
+  // journal-backed helper so every capture is recorded via recordSlugMutation,
+  // exactly like trackSlugHistoryDrift's carry-forward. The add-list is already
+  // bounded to the flat cap headroom so this can never evict a bridge the
+  // slice already had.
+  for (const { locale, slug } of missingBridges) {
+    addPreviousSlugForLocale(updatedJob, locale, slug, DEFAULT_PREV_SLUG_CAP, `scatter-jobs-to-slices/carry-forward-${locale === 'it' ? 'flat' : 'locale'}`);
+  }
+
+  return { job: updatedJob, changed: true };
+}
+
+function main() {
+  const jobs = readJson(DATA_JOBS, null);
+  if (!Array.isArray(jobs)) {
+    console.log('ℹ️  data/jobs.json not found or not an array — nothing to scatter.');
+    process.exit(0);
+  }
+
+  // Index assembled jobs by stable diff key (id / url / slug fallback — see
+  // resolveJobDiffKey) — NOT bare .slug. Bare-slug keying collides across
+  // companies whenever two jobs compute the same slug (463 live collisions
+  // confirmed in data/jobs/by-crawler/*.json, e.g. klinik-sonnenhalde vs.
+  // allianz-suisse), silently merging wrong-company locale/slug data into a
+  // slice (previousSlugs writer regression, issue #3734).
+  const jobIndex = new Map();
+  for (const job of jobs) {
+    const key = resolveJobDiffKey(job);
+    if (key) jobIndex.set(key, job);
+  }
+
+  // Read each slice, update jobs with matching slugs, write back if changed
+  const sliceFiles = fs.existsSync(SLICES_DIR)
+    ? fs.readdirSync(SLICES_DIR).filter((f) => f.endsWith('.json') && f !== '.gitkeep')
+    : [];
+
+  let updatedSlices = 0;
+  let updatedJobs = 0;
+
+  for (const file of sliceFiles) {
+    const slicePath = path.join(SLICES_DIR, file);
+    const slice = readJson(slicePath, null);
+    if (!slice || !Array.isArray(slice.jobs)) continue;
+
+    let sliceChanged = false;
+    const updatedSliceJobs = slice.jobs.map((sliceJob) => {
+      const sliceKey = resolveJobDiffKey(sliceJob);
+      if (!sliceKey) return sliceJob;
+      const assembled = jobIndex.get(sliceKey);
+      if (!assembled) return sliceJob;
+
+      const { job, changed } = applyAssembledToSliceJob(sliceJob, assembled);
+      if (changed) {
+        sliceChanged = true;
+        updatedJobs++;
+      }
+      return job;
+    });
+
+    if (sliceChanged) {
+      // Preserve the original assembledAt timestamp from the crawler.
+      // Scatter only propagates locale changes from the assembled dataset — it
+      // does not represent a new crawl run, so bumping assembledAt would cause
+      // unnecessary git churn across 90+ files when only a single company was
+      // actually translated.
+      const envelope = { ...slice, jobs: updatedSliceJobs };
+      writeJson(slicePath, envelope);
+      updatedSlices++;
+    }
+  }
+
+  if (updatedSlices > 0) {
+    console.log(`✅ Scattered ${updatedJobs} updated jobs across ${updatedSlices} per-crawler slices.`);
+  } else {
+    console.log('ℹ️  No changes to scatter back to per-crawler slices.');
   }
 }
 
-if (updatedSlices > 0) {
-  console.log(`✅ Scattered ${updatedJobs} updated jobs across ${updatedSlices} per-crawler slices.`);
-} else {
-  console.log('ℹ️  No changes to scatter back to per-crawler slices.');
+const isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`
+      || import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  main();
 }

--- a/tests/scatter-jobs-carry-forward-bridges.test.ts
+++ b/tests/scatter-jobs-carry-forward-bridges.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression tests for the previousSlugs writer regression fired daily by the
+ * "Recover Lost previousSlugs" monitor (issues #4165 #4161 #4134 #4112 #4102
+ * #4088 #4076 #3885 — all the same class).
+ *
+ * Root cause: scatter-jobs-to-slices.mjs is the assembled→slice writer for
+ * every job NOT processed by relocalize-pending-jobs.mjs. It journaled
+ * per-locale slug RENAMES (old active slug → previousSlugsByLocale) correctly,
+ * but — unlike relocalize (which has an explicit "Sync previousSlugs from
+ * assembled dataset to per-crawler file" block) and unlike
+ * assemble-jobs-dataset's trackSlugHistoryDrift — it never carried forward the
+ * SEO bridge slugs the assembled dataset had already captured
+ * (previousSlugs / previousSlugsByLocale). Those bridges were silently dropped
+ * from the committed slice (the source of truth the build plugin reads to emit
+ * redirect/bridge pages), producing 404s for URLs Google already indexed.
+ *
+ * The fix carries forward the missing bridges through the canonical
+ * journal-backed helper (addPreviousSlugForLocale), bounded to the flat
+ * legacy cap headroom so it can NEVER evict a bridge the slice already had.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyAssembledToSliceJob,
+  collectMissingAssembledBridges,
+} from '../scripts/scatter-jobs-to-slices.mjs';
+import { LEGACY_PREV_SLUGS_CAP } from '../scripts/lib/dedicated-crawler-common.mjs';
+
+const baseSlice = () => ({
+  id: 'company-abc',
+  url: 'https://example.test/company-abc',
+  company: 'C',
+  location: 'L',
+  slug: 's-it',
+  slugByLocale: { it: 's-it', en: 's-en-old' },
+  titleByLocale: { it: 'T', en: 'T' },
+  descriptionByLocale: {},
+});
+
+describe('scatter carry-forward of assembled previousSlugs bridges', () => {
+  it('preserves an assembled bridge slug the slice was missing (the dropped-bridge regression)', () => {
+    const sliceJob = baseSlice();
+    const assembled = {
+      ...baseSlice(),
+      // en renamed on the assembled side; the old EN active slug must be
+      // captured AND the assembler-known bridge must be carried forward.
+      slugByLocale: { it: 's-it', en: 's-en-new' },
+      previousSlugs: ['bridge-old'],
+      previousSlugsByLocale: { en: ['bridge-old'] },
+    };
+
+    const { job, changed } = applyAssembledToSliceJob(sliceJob, assembled);
+    expect(changed).toBe(true);
+
+    // Bridge the assembled dataset knew about but the slice lacked — was
+    // silently dropped before the fix.
+    expect(job.previousSlugs).toContain('bridge-old');
+    expect(job.previousSlugsByLocale.en).toContain('bridge-old');
+
+    // The old active EN slug is still captured (pre-existing behaviour).
+    expect(job.previousSlugs).toContain('s-en-old');
+    expect(job.previousSlugsByLocale.en).toContain('s-en-old');
+
+    // Input never mutated.
+    expect(sliceJob.previousSlugs).toBeUndefined();
+  });
+
+  it('carries forward a bridge even when locale/slug fields are otherwise unchanged', () => {
+    const sliceJob = baseSlice();
+    // Identical locale fields — only the assembled bridge history is richer.
+    const assembled = {
+      ...baseSlice(),
+      previousSlugsByLocale: { en: ['legacy-en-bridge'] },
+    };
+
+    const { job, changed } = applyAssembledToSliceJob(sliceJob, assembled);
+    expect(changed).toBe(true);
+    expect(job.previousSlugsByLocale.en).toContain('legacy-en-bridge');
+  });
+
+  it('is a no-op when the slice already holds every assembled bridge', () => {
+    const sliceJob = {
+      ...baseSlice(),
+      previousSlugs: ['bridge-old'],
+      previousSlugsByLocale: { en: ['bridge-old'] },
+    };
+    const assembled = {
+      ...baseSlice(),
+      previousSlugs: ['bridge-old'],
+      previousSlugsByLocale: { en: ['bridge-old'] },
+    };
+    const { changed } = applyAssembledToSliceJob(sliceJob, assembled);
+    expect(changed).toBe(false);
+  });
+
+  it('NEVER evicts a pre-existing slice bridge when the assembled side floods new ones (cap headroom guard)', () => {
+    // Slice already near the flat legacy cap with its own committed bridges.
+    const existing = Array.from({ length: LEGACY_PREV_SLUGS_CAP - 2 }, (_, i) => `slice-bridge-${i}`);
+    const sliceJob = {
+      ...baseSlice(),
+      slugByLocale: { it: 's-it', en: 's-en-old' },
+      previousSlugs: [...existing],
+      previousSlugsByLocale: { it: [...existing] },
+    };
+    // Assembled renames EN and offers far more bridges than the cap can hold.
+    const flood = Array.from({ length: 50 }, (_, i) => `assembled-bridge-${i}`);
+    const assembled = {
+      ...baseSlice(),
+      slugByLocale: { it: 's-it', en: 's-en-new' },
+      previousSlugs: flood,
+      previousSlugsByLocale: { en: flood },
+    };
+
+    const { job } = applyAssembledToSliceJob(sliceJob, assembled);
+    const survivingUnion = new Set([
+      ...(job.previousSlugs || []),
+      ...Object.values(job.previousSlugsByLocale || {}).flat(),
+    ]);
+    // Every pre-existing committed bridge must survive — that was the
+    // secondary regression risk (carry-forward appended as "newest" and the
+    // cap trimmed the slice's own older entries).
+    for (const s of existing) {
+      expect(survivingUnion.has(s)).toBe(true);
+    }
+    // The old active EN slug is still captured too.
+    expect(survivingUnion.has('s-en-old')).toBe(true);
+  });
+
+  it('collectMissingAssembledBridges returns nothing once the flat cap is already full', () => {
+    const full = Array.from({ length: LEGACY_PREV_SLUGS_CAP }, (_, i) => `b-${i}`);
+    const sliceJob = { ...baseSlice(), previousSlugs: full, previousSlugsByLocale: { it: full } };
+    const assembled = {
+      ...baseSlice(),
+      previousSlugs: ['brand-new-bridge'],
+      previousSlugsByLocale: { en: ['brand-new-bridge'] },
+    };
+    expect(collectMissingAssembledBridges(sliceJob, assembled)).toEqual([]);
+  });
+
+  it('applying twice is idempotent (no runaway history growth)', () => {
+    const sliceJob = baseSlice();
+    const assembled = {
+      ...baseSlice(),
+      slugByLocale: { it: 's-it', en: 's-en-new' },
+      previousSlugs: ['bridge-old'],
+      previousSlugsByLocale: { en: ['bridge-old'] },
+    };
+    const first = applyAssembledToSliceJob(sliceJob, assembled).job;
+    const second = applyAssembledToSliceJob(first, assembled);
+    expect(second.changed).toBe(false);
+    expect(second.job).toBe(first);
+  });
+});


### PR DESCRIPTION
## Implementato

- **Root cause:** `scripts/scatter-jobs-to-slices.mjs` è il writer che propaga `data/jobs.json` assemblato (campi locale tradotti + storia slug catturata) sulle slice per-crawler per ogni job non gestito da `relocalize-pending-jobs.mjs`. Il suo loop journalava correttamente i *rename* per-locale (vecchio slug attivo → `previousSlugsByLocale`), ma **non riportava mai i bridge SEO che l'assembled aveva già catturato** in `assembled.previousSlugs` / `assembled.previousSlugsByLocale` (popolati a monte da `assemble-jobs-dataset.mjs`). Poiché `updatedJob = { ...sliceJob, ... }` fa spread solo della slice, quei bridge noti all'assembler venivano droppati dalla slice committata — la source of truth che il build plugin legge per emettere le pagine bridge/redirect → 404 per URL già indicizzati da Google. Il sibling `relocalize-pending-jobs.mjs` fa esplicitamente questo carry-forward (linee 739-748); scatter era il writer della classe che lo ometteva.
- **Fix:** nuova `collectMissingAssembledBridges()` raccoglie le entry assembled `previousSlugs[ByLocale]` mancanti dalla slice, **limitata all'headroom di `LEGACY_PREV_SLUGS_CAP`** così il carry-forward non può mai evictare un bridge già presente nella slice (un draft intermedio ne evictava 13 su un job Coop con storia estrema via cap overflow; il guard headroom lo risolve). Riportati via il canonico `addPreviousSlugForLocale` journal-backed (`recordSlugMutation`). Logica per-job estratta in `applyAssembledToSliceJob()` pura ed esportata; esecuzione in `main()` guardato.

**Verifica su dati live:** **0 slug persi, 1198 bridge ripristinati su 161 job**, idempotente su re-run. Prova before/after isolata: slice con `slugByLocale.en=s-en-old`, assembled con `previousSlugsByLocale.en=['bridge-old']` → scatter non-fixato droppava `bridge-old`; fixato lo preserva. `tests/scatter-jobs-carry-forward-bridges.test.ts` (6 test: bridge preservato, no-eviction cap-headroom, write su bridge-only-change, idempotenza) → 6/6 pass; suite slug allargata (scan-prev-slug-losses, slug-history-journal, previous-slugs-bridge, relocalize-sync, previous-slug-winners) → 63/63 pass; `node --check` clean.

**Class check:** gli altri due writer assembled→slice già portano avanti (`relocalize` ha il sync block; `reconcile-job-slugs` fa l'operazione inversa). Nessun altro sibling con l'antipattern.

Closes #4194
Closes #4165
Closes #4161
Closes #4134
Closes #4112
Closes #4102
Closes #4088
Closes #4076
Closes #3885

## Non implementato (ancora)

- La pipeline deterministica sul checkpoint produceva 0 losses nella riproduzione offline; i conteggi storici richiedevano lo stato intermedio della traduzione AI live non eseguibile offline. Il gap dropped-bridge risolto è un difetto strutturale *provato* (dimostrato direttamente) e combacia esattamente col sintomo, ma la riproduzione end-to-end dei conteggi storici richiede il traduttore live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_