### PR TITLE
fix(news): recupera publisher host reale dal wrapper Google News per source-quality (#4101)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -8340,6 +8340,11 @@ async function main() {
           relatedHeadlines: [],
           _discoveryId: id,
           _discoveryCandidate: c,
+          // Real publisher host behind a Google News wrapper (from the RSS
+          // <source url> attr, no decode needed). Lets the ranker's
+          // source-quality multiplier score a known publisher (RSI, etc.)
+          // instead of degrading news.google.com to neutral 1.0 (issue #4101).
+          _publisherHost: (c && c.meta && c.meta.publisherHost) || null,
         };
         // resolveGoogleNewsHeadline now ALWAYS returns an object: the direct
         // twin when the fuzzy-match hits, else the wrapper flagged

--- a/scripts/lib/article-topic-selector.mjs
+++ b/scripts/lib/article-topic-selector.mjs
@@ -731,6 +731,34 @@ function _domainFromUrl(url) {
   }
 }
 
+/**
+ * Resolve the domain used for the source-quality multiplier of a headline.
+ *
+ * For a Google News candidate not yet decoded, the URL is the opaque
+ * `news.google.com/rss/articles/…` wrapper — `_domainFromUrl` returns
+ * `news.google.com`, which is never in `perDomain`, so the multiplier
+ * degraded to a neutral 1.0 and a KNOWN publisher (RSI, RaiNews, TVS) lost
+ * its historical source-quality score, systematically under-ranking it
+ * against direct feeds with a positive domain score (issue #4101).
+ *
+ * When the caller carried the real publisher host (`_publisherHost`, taken
+ * from the RSS `<source url>` attribute — no batchexecute decode needed), we
+ * prefer it, but ONLY when the URL itself is the Google News wrapper. For any
+ * headline with a real URL (direct feed, or a Google News item already
+ * resolved to its direct twin) we keep the URL's own domain untouched.
+ *
+ * @param {{url?: string, link?: string, _publisherHost?: string}|null} item
+ * @returns {string|null}
+ */
+function _qualityDomain(item) {
+  const url = (item && (item.url || item.link)) || null;
+  const domain = _domainFromUrl(url);
+  if (domain === 'news.google.com' && item && typeof item._publisherHost === 'string' && item._publisherHost) {
+    return item._publisherHost.replace(/^www\./, '').toLowerCase();
+  }
+  return domain;
+}
+
 function computeNoveltyScore(headline, existingTitles) {
   if (!Array.isArray(existingTitles) || existingTitles.length === 0) return 1.0;
   const tokens = tokenize(headline);
@@ -1048,9 +1076,10 @@ async function rankWithCascade(list, titles, clusters, opts) {
     // 4+ picks → 0.1 floor.
     const diversity = computeClusterDiversityBonus(cluster, todayPicksByCluster);
 
-    // Source-quality multiplier (unchanged from legacy path).
-    const url = (list[i] && (list[i].url || list[i].link)) || null;
-    const domain = _domainFromUrl(url);
+    // Source-quality multiplier (unchanged from legacy path). `_qualityDomain`
+    // recovers the real publisher host behind a not-yet-decoded Google News
+    // wrapper so a known publisher keeps its score (issue #4101).
+    const domain = _qualityDomain(list[i]);
     const sqMultiplier = sourceQuality ? sourceQualityMultiplier(domain, sourceQuality) : 1.0;
 
     const finalScore = breakdown.finalScore * diversity * sqMultiplier;
@@ -1165,9 +1194,10 @@ export async function rankAndSelectHeadlines(headlines, vocab, opts = {}) {
     });
     // Source-quality multiplier: domains with historical winner-rate
     // above the corpus median get up to 1.5x boost; below median 0.5x.
-    // Neutral 1.0 when no domain data is available.
-    const url = (h && (h.url || h.link)) || null;
-    const domain = _domainFromUrl(url);
+    // Neutral 1.0 when no domain data is available. `_qualityDomain` recovers
+    // the real publisher host behind a not-yet-decoded Google News wrapper so a
+    // known publisher keeps its score instead of degrading to neutral (issue #4101).
+    const domain = _qualityDomain(h);
     const sqMultiplier = sourceQuality ? sourceQualityMultiplier(domain, sourceQuality) : 1.0;
     const breakdown = sqMultiplier === 1.0
       ? baseBreakdown

--- a/scripts/lib/discovery/sources/googleNewsRssSource.mjs
+++ b/scripts/lib/discovery/sources/googleNewsRssSource.mjs
@@ -15,11 +15,31 @@ const SOURCE_TAG = 'news';
 const FALLBACK_AGE_HOURS = 48;
 
 /**
+ * Bare publisher hostname (lowercased, no `www.`) from the Google News
+ * `<source url="…">` attribute — the REAL publisher origin behind the opaque
+ * `news.google.com/rss/articles/` wrapper. Returns null when absent/unparseable.
+ * Lets the downstream ranker recover the publisher's source-quality score
+ * WITHOUT paying the batchexecute decode cost (issue #4101).
+ *
+ * @param {string|null} rawUrl
+ * @returns {string|null}
+ */
+export function publisherHostFromSourceUrl(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') return null;
+  try {
+    const u = new URL(rawUrl.includes('//') ? rawUrl : `https://${rawUrl}`);
+    return u.hostname.replace(/^www\./, '').toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * @typedef {{
  *   headline: string,
  *   url: string|null,
  *   source: 'news',
- *   meta: { ageHours: number, sourceUrl: string|null, sourceName: string|null, pubDate: string|null, seed: string|null },
+ *   meta: { ageHours: number, sourceUrl: string|null, sourceName: string|null, publisherHost: string|null, pubDate: string|null, seed: string|null },
  * }} NewsCandidate
  */
 
@@ -81,6 +101,7 @@ export async function fetchNewsRssDiscoveryCandidates(evidence, opts = {}) {
         ageHours: ageHoursFromPubDate(pubDate, nowMs),
         sourceUrl: c?.demandSignals?.googleNewsRssLink || null,
         sourceName: c?.demandSignals?.googleNewsRssSource || null,
+        publisherHost: publisherHostFromSourceUrl(c?.demandSignals?.googleNewsRssSourceUrl || null),
         pubDate,
         seed: c?.demandSignals?.googleNewsRssSeed || null,
       },

--- a/scripts/lib/topic-sources/googleNewsRss.mjs
+++ b/scripts/lib/topic-sources/googleNewsRss.mjs
@@ -139,14 +139,24 @@ function extractTagText(block, tagName) {
   return (m[1] ?? m[2] ?? '').replace(/<[^>]+>/g, '').trim();
 }
 
+// Google News RSS items carry `<source url="https://www.rsi.ch">RSI</source>`.
+// `extractTagText` returns the publisher NAME; this returns the `url` attribute
+// (the real publisher origin) so downstream ranking can recover the publisher's
+// source-quality score even before the opaque wrapper URL is decoded.
+function extractSourceUrl(block) {
+  const m = block.match(/<source\b[^>]*\burl\s*=\s*(?:"([^"]*)"|'([^']*)')/i);
+  if (!m) return '';
+  return (m[1] ?? m[2] ?? '').trim();
+}
+
 /**
  * Parse the Google-News-RSS XML payload. Mirrors `parseTrendsRss` shape.
- * Returns array of `{ title, link, pubDate, source }`. Items missing a
- * non-empty `<title>` are skipped. Always returns an array — never
+ * Returns array of `{ title, link, pubDate, source, sourceUrl }`. Items
+ * missing a non-empty `<title>` are skipped. Always returns an array — never
  * throws.
  *
  * @param {string} xml
- * @returns {Array<{title: string, link: string, pubDate: string, source: string}>}
+ * @returns {Array<{title: string, link: string, pubDate: string, source: string, sourceUrl: string}>}
  */
 export function parseNewsRss(xml) {
   if (!xml || typeof xml !== 'string') return [];
@@ -159,7 +169,8 @@ export function parseNewsRss(xml) {
     const link = extractTagText(block, 'link');
     const pubDate = extractTagText(block, 'pubDate');
     const source = extractTagText(block, 'source');
-    out.push({ title, link, pubDate, source });
+    const sourceUrl = extractSourceUrl(block);
+    out.push({ title, link, pubDate, source, sourceUrl });
   }
   return out;
 }
@@ -261,6 +272,7 @@ export async function fetchNewsRssCandidates(opts = {}) {
             googleNewsRssLink: it.link || null,
             googleNewsRssPubDate: it.pubDate || null,
             googleNewsRssSource: it.source || null,
+            googleNewsRssSourceUrl: it.sourceUrl || null,
           },
           rationale: `Google News RSS seed "${seed}" — ${it.source || 'unknown source'}`,
         });

--- a/tests/scripts/article-topic-selector.test.ts
+++ b/tests/scripts/article-topic-selector.test.ts
@@ -313,6 +313,51 @@ describe('rankAndSelectHeadlines', () => {
     });
     expect(picks[0].url).toBe('u2'); // novita wins over hammered fiscale
   });
+
+  // ── source-quality multiplier for undecoded Google News wrappers (#4101) ──
+  // A Google News candidate not yet decoded has url=news.google.com/…, which is
+  // never in perDomain → the multiplier used to degrade to a neutral 1.0 and a
+  // known publisher lost its historical score. With `_publisherHost` (from the
+  // RSS <source url> attr) the ranker recovers the real publisher's multiplier.
+  const sourceQualityBoostingRsi = {
+    medianWinnerRate: 0.5,
+    perDomain: { 'rsi.ch': { winnerRate: 1.0, total: 10 } },
+  };
+
+  it('#4101: Google News wrapper with _publisherHost gets the publisher domain multiplier', async () => {
+    const headlines = [
+      {
+        headline: 'Frontalieri Ticino in calo nel 2026',
+        url: 'https://news.google.com/rss/articles/opaque',
+        _publisherHost: 'rsi.ch',
+      },
+    ];
+    const picks = await rankAndSelectHeadlines(headlines, vocab, {
+      classifierOpts: { forceRegex: true },
+      sourceQuality: sourceQualityBoostingRsi,
+      maxPicks: 1,
+    });
+    expect(picks).toHaveLength(1);
+    // rsi.ch winnerRate (1.0) is 2x the median (0.5) → boost multiplier > 1.
+    expect(picks[0]._score.sourceQualityMultiplier).toBeGreaterThan(1);
+  });
+
+  it('#4101: same wrapper WITHOUT _publisherHost degrades to neutral (control)', async () => {
+    const headlines = [
+      {
+        headline: 'Frontalieri Ticino in calo nel 2026',
+        url: 'https://news.google.com/rss/articles/opaque',
+      },
+    ];
+    const picks = await rankAndSelectHeadlines(headlines, vocab, {
+      classifierOpts: { forceRegex: true },
+      sourceQuality: sourceQualityBoostingRsi,
+      maxPicks: 1,
+    });
+    expect(picks).toHaveLength(1);
+    // news.google.com absent from perDomain → neutral 1.0 → field not attached.
+    expect(picks[0]._score.sourceQualityMultiplier).toBeUndefined();
+  });
 });
 
 // ── Today-picks-by-cluster persistence ────────────────────────────

--- a/tests/scripts/lib/discovery/sources/googleNewsRssSource.test.ts
+++ b/tests/scripts/lib/discovery/sources/googleNewsRssSource.test.ts
@@ -5,7 +5,22 @@ import { describe, expect, it } from 'vitest';
 import {
   fetchNewsRssDiscoveryCandidates,
   ageHoursFromPubDate,
+  publisherHostFromSourceUrl,
 } from '../../../../../scripts/lib/discovery/sources/googleNewsRssSource.mjs';
+
+describe('publisherHostFromSourceUrl (issue #4101)', () => {
+  it('returns bare lowercased host without www', () => {
+    expect(publisherHostFromSourceUrl('https://www.rsi.ch')).toBe('rsi.ch');
+    expect(publisherHostFromSourceUrl('https://WWW.Tio.CH/news')).toBe('tio.ch');
+  });
+  it('tolerates a bare host with no scheme', () => {
+    expect(publisherHostFromSourceUrl('www.varesenews.it')).toBe('varesenews.it');
+  });
+  it('returns null for missing/unparseable input', () => {
+    expect(publisherHostFromSourceUrl(null)).toBeNull();
+    expect(publisherHostFromSourceUrl('')).toBeNull();
+  });
+});
 
 describe('ageHoursFromPubDate', () => {
   it('returns 48 (fallback) for missing/invalid input', () => {
@@ -59,6 +74,29 @@ describe('fetchNewsRssDiscoveryCandidates', () => {
     expect(out[0].url).toBe('https://example.com/article');
     expect(out[0].meta.ageHours).toBeCloseTo(2, 5);
     expect(out[0].meta.sourceName).toBe('tio.ch');
+  });
+
+  it('exposes meta.publisherHost from the RSS <source url> (issue #4101)', async () => {
+    const candidates = [
+      {
+        keyword: 'Frontalieri Ticino in calo nel 2026',
+        demandSignals: {
+          googleNewsRssLink: 'https://news.google.com/rss/articles/opaque',
+          googleNewsRssSource: 'RSI',
+          googleNewsRssSourceUrl: 'https://www.rsi.ch',
+        },
+      },
+    ];
+    const out = await fetchNewsRssDiscoveryCandidates({}, { newsFn: stubNewsFn(candidates) });
+    expect(out[0].meta.publisherHost).toBe('rsi.ch');
+  });
+
+  it('meta.publisherHost is null when the source url is absent', async () => {
+    const candidates = [
+      { keyword: 'x', demandSignals: { googleNewsRssLink: 'https://news.google.com/rss/articles/x' } },
+    ];
+    const out = await fetchNewsRssDiscoveryCandidates({}, { newsFn: stubNewsFn(candidates) });
+    expect(out[0].meta.publisherHost).toBeNull();
   });
 
   it('dedupes by lowercased headline', async () => {

--- a/tests/scripts/topic-sources/googleNewsRss.test.ts
+++ b/tests/scripts/topic-sources/googleNewsRss.test.ts
@@ -48,6 +48,20 @@ describe('parseNewsRss', () => {
     expect(items[0].source).toBe('tio.ch');
   });
 
+  it('captures the <source url="…"> publisher origin (issue #4101)', () => {
+    const items = parseNewsRss(NEWS_OK_XML);
+    expect(items[0].sourceUrl).toBe('https://www.tio.ch');
+    expect(items[2].sourceUrl).toBe('https://www.rsi.ch');
+  });
+
+  it('sourceUrl is empty when <source> has no url attribute', () => {
+    const xml = `<rss><channel>
+      <item><title>No source url</title><link>x</link><source>RSI</source></item>
+    </channel></rss>`;
+    const items = parseNewsRss(xml);
+    expect(items[0].sourceUrl).toBe('');
+  });
+
   it('returns [] on malformed XML', () => {
     expect(parseNewsRss('<not really xml>')).toEqual([]);
   });


### PR DESCRIPTION
## Implementato

- **#4101 (follow-up #4090):** i candidati Google News non decodificati avevano il moltiplicatore source-quality degradato a 1.0 neutro (`_domainFromUrl` su un wrapper `news.google.com`), sotto-classificando sistematicamente publisher noti (RSI/RaiNews/TVS).
- **Fix:** recupera l'host publisher reale dall'attributo RSS `<source url="…">` (già fetchato, nessun decode batchexecute). Il ranker lo preferisce **solo** quando l'URL è il wrapper Google News; URL reali/diretti/risolti restano intatti.
- **File:** `scripts/lib/topic-sources/googleNewsRss.mjs`, `scripts/lib/discovery/sources/googleNewsRssSource.mjs`, `scripts/create-article.mjs`, `scripts/lib/article-topic-selector.mjs` (`_qualityDomain` a entrambi i call site del ranker).
- **Test:** aggiunti a 3 file (parser `sourceUrl`, `publisherHostFromSourceUrl`, `meta.publisherHost`, ranker con/senza `_publisherHost`) → 71/71 green; `node --check` clean.

Closes #4101

## Non implementato (ancora)

- **#4079** (404-risk sitemap URL): root cause strutturale/deploy-orchestration — la sitemap è autorizzata dalla build monolite all-locale, ma le pagine `/de /en /fr` sono servite da shard per-locale costruiti separatamente, e il gate di equivalenza union==monolite (`scripts/ci/compare-dist-manifests.mjs`) è cablato solo in `deploy-matrix-experiment.yml`, NON nel `deploy.yml` di produzione. Il fix (cablare il gate in deploy.yml / atomicizzare i push shard) è un cambiamento `.github/workflows/**` — fuori scope (no `workflows` scope). L'audit `audit-404-risk.mjs` NON è stato toccato/soppresso (è corretto). Issue lasciata aperta con root-cause commentata.
- **#4125** già chiusa come obsoleta (fatta via PR #4131, `48637bb4d`: rotation gpt-4.1 attempt-1, gpt-4o attempt-2).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_