### PR TITLE
fix(crawlers): banca-cler dedup-by-id + davos detail-selector (audit-parser-quality #3836)

### DIFF
--- a/scripts/lib/cler-job-parser.mjs
+++ b/scripts/lib/cler-job-parser.mjs
@@ -3,6 +3,60 @@
  * Converts rich HTML from cler.ch career pages to structured markdown.
  */
 import { JSDOM } from 'jsdom';
+import { extractStableJobId } from './job-match-key.mjs';
+
+/**
+ * Newest career-section year embedded in a Cler job URL, or 0 when the path
+ * carries no year suffix. Since the 2026-07 relaunch the jobssearch API
+ * publishes every posting under BOTH the legacy `…/jobs-und-karriere/…` path
+ * and the new `…/jobs-und-karriere-2026/…` path — same requisition id, two
+ * URLs. The year suffix marks the CANONICAL (live) section, so a higher year
+ * wins when we collapse the two records into one.
+ */
+export function clerCareerSectionYear(url = '') {
+  const m = String(url || '').match(/jobs-und-karriere-(\d{4})\b/i);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Deduplicate Cler job records that resolve to the SAME posting.
+ *
+ * Root cause (#3836): the jobssearch API returns each open position twice —
+ * once under the legacy `…/jobs-und-karriere/…` path and once under the
+ * relaunched `…/jobs-und-karriere-2026/…` path — with the SAME 3-4 digit
+ * requisition id in the leaf but two distinct whole URLs. The Cler requisition
+ * id is below the generic ≥6-digit stable-id floor, so before Rule K
+ * (job-url-key.mjs) every URL keyed to itself and each role emitted twice
+ * (12 records / 6 real jobs → duplicate-listings ratchet). Keying on the
+ * stable requisition id (`extractStableJobId` → `req:cler.ch:<id>`) collapses
+ * the pair; we keep ONE record per id, preferring the canonical (newest
+ * career-section) URL so the survivor points at the live path.
+ *
+ * Records with no derivable stable id (no url and no slug) are preserved
+ * as-is under a per-record synthetic key so a missing id never silently
+ * drops a job.
+ *
+ * @param {Array<object>} items
+ * @param {(item: object) => string} [getUrl] URL accessor (default `item.url`)
+ * @returns {Array<object>} one record per distinct requisition id
+ */
+export function dedupeClerJobsByStableId(items, getUrl = (it) => it?.url) {
+  const byKey = new Map();
+  let synthetic = 0;
+  for (const item of Array.isArray(items) ? items : []) {
+    const url = getUrl(item) || '';
+    const key = extractStableJobId(url)
+      || String(item?.slug || '').trim().toLowerCase()
+      || `__nokey_${synthetic++}`;
+    const prev = byKey.get(key);
+    if (!prev) { byKey.set(key, item); continue; }
+    // Keep whichever URL is more canonical (newest career-section year).
+    if (clerCareerSectionYear(url) > clerCareerSectionYear(getUrl(prev) || '')) {
+      byKey.set(key, item);
+    }
+  }
+  return [...byKey.values()];
+}
 
 // Localized labels Cler exposes in `.JobDetail__item`. Multilingual to survive
 // any future locale switch of the source site.

--- a/scripts/lib/davos-klosters-bergbahnen-job-parser.mjs
+++ b/scripts/lib/davos-klosters-bergbahnen-job-parser.mjs
@@ -31,6 +31,33 @@ export function stripHtml(html = '') {
     .replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Convert a job-body HTML fragment to plain text while PRESERVING list/line
+ * structure. `stripHtml` above deliberately flattens everything onto one line
+ * (correct for titles/metadata), but a description needs its bullet points to
+ * survive as line-start `• ` markers: downstream structure detection (the
+ * parser-quality audit's hasStructuredContent, JobPosting rendering) only
+ * recognises lists when the bullets sit at the start of a line, not inline
+ * inside a collapsed paragraph. Kept separate from stripHtml so the flattening
+ * behaviour other callers rely on is unchanged.
+ */
+export function richTextToLines(html = '') {
+  return String(html || '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, '')
+    .replace(/<li[^>]*>/gi, '\n• ')
+    .replace(/<\/(?:li|p|h[1-6]|div|ul|ol|tr)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ').replace(/&amp;/gi, '&').replace(/&lt;/gi, '<').replace(/&gt;/gi, '>').replace(/&quot;/gi, '"').replace(/&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/[ \t\f\v]+/g, ' ')
+    .split('\n').map((l) => l.trim()).filter(Boolean).join('\n')
+    .trim();
+}
+
 export function slugify(value = '') {
   return String(value || '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
     .replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-').slice(0, 180);
@@ -142,12 +169,26 @@ export function parseDavosKlostersBergbahnenDetailHtml(html) {
   const titleMatch = html.match(/<h1[^>]*>[\s\S]*?<span[^>]*class="[^"]*text-primary[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
   if (titleMatch) result.title = stripHtml(titleMatch[1]).trim();
 
+  // Bound description/metadata extraction to the per-job content subtree.
+  //
+  // #3836 (chrome-scraping): the live detail page renders a SITE-WIDE
+  // operational alert banner (e.g. "Aufgrund von tech. Arbeiten an der
+  // Pendelbahn … wird die 2. Sektion des Jakobshorns … geschlossen") inside its
+  // OWN `.wysiwyg` block ABOVE the main job content. An unscoped "first
+  // `.wysiwyg` on the page" match latched onto that banner, so all 9 davos jobs
+  // carried the identical 171-char notice instead of their own body. The job
+  // title `<h1>` always sits BELOW the banner, so anchor extraction there — only
+  // the per-job region is searched, and the shared banner (plus header/nav
+  // above it) is excluded.
+  const h1Idx = html.search(/<h1[\s>]/i);
+  const bodyScope = h1Idx >= 0 ? html.slice(h1Idx) : html;
+
   // Extract department from <div class="h3 ..."> before <h1>
   const deptMatch = html.match(/<div[^>]*class="h3[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
   if (deptMatch) result.department = stripHtml(deptMatch[1]).trim();
 
-  // Extract metadata from meta-list items
-  const metaListMatch = html.match(/<div[^>]*class="meta-list"[^>]*>([\s\S]*?)<\/div>\s*<\/div>/i);
+  // Extract metadata from meta-list items (within the per-job scope)
+  const metaListMatch = bodyScope.match(/<div[^>]*class="meta-list"[^>]*>([\s\S]*?)<\/div>\s*<\/div>/i);
   if (metaListMatch) {
     const items = metaListMatch[1].match(/<div[^>]*class="meta-list__item"[^>]*>([\s\S]*?)<\/div>/gi) || [];
     const metaValues = items.map(d => stripHtml(d).trim()).filter(v => v && !v.includes('download'));
@@ -155,17 +196,23 @@ export function parseDavosKlostersBergbahnenDetailHtml(html) {
     if (metaValues.length >= 2) result.percentage = metaValues[1];
   }
 
-  // Extract description from wysiwyg content block
+  // Extract description from the FIRST wysiwyg block WITHIN the per-job scope —
+  // i.e. the job body immediately following the title/meta-list, never the
+  // page-level alert banner above the title.
   let description = '';
-  const wysiwygMatch = html.match(/<div[^>]*class="wysiwyg[^"]*"[^>]*>([\s\S]*?)<\/div>\s*(?:<\/div>|$)/i);
+  const wysiwygMatch = bodyScope.match(/<div[^>]*class="[^"]*\bwysiwyg\b[^"]*"[^>]*>([\s\S]*?)<\/div>\s*(?:<\/div>|$)/i);
   if (wysiwygMatch) {
-    description = stripHtml(wysiwygMatch[1]);
+    description = richTextToLines(wysiwygMatch[1]);
   }
 
-  // Fallback: extract from <main>
+  // Fallback: still bounded to the per-job scope — take the text after the
+  // title but cut off at the first footer / nav / notification boundary so we
+  // never re-absorb the shared page chrome the wysiwyg scoping just excluded.
   if (!description || description.length < 30) {
-    const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
-    if (mainMatch) description = stripHtml(mainMatch[1]);
+    const cut = bodyScope.search(/<footer[\s>]|<nav[\s>]|class="[^"]*(?:footer|site-alert|notification|megamenu)/i);
+    const region = cut >= 0 ? bodyScope.slice(0, cut) : bodyScope;
+    const text = richTextToLines(region);
+    if (text.length >= 30) description = text;
   }
 
   if (description && description.length >= 30) {

--- a/scripts/update-cler-jobs.mjs
+++ b/scripts/update-cler-jobs.mjs
@@ -36,6 +36,7 @@ import {
   htmlToMarkdown,
   validateClerDescription,
   extractJobMeta,
+  dedupeClerJobsByStableId,
 } from './lib/cler-job-parser.mjs';
 import {
   getCompanyDefaults,
@@ -312,9 +313,24 @@ function buildDescription(title, html) {
 
 async function fetchClerJobs() {
   const listings = await fetchJobListings();
+
+  // #3836 — collapse postings the API returns twice (same requisition id under
+  // the legacy `…/jobs-und-karriere/…` and relaunched `…/jobs-und-karriere-2026/…`
+  // paths). Dedupe BEFORE fetching detail pages so we emit one record per
+  // distinct job and don't waste a detail fetch on the duplicate. The stable-id
+  // key needs the ABSOLUTE URL (Rule K in job-url-key.mjs is host-gated on
+  // cler.ch), so map the relative detail path to its absolute form here.
+  const uniqueListings = dedupeClerJobsByStableId(
+    listings,
+    (l) => (l?.link?.url ? `${API_BASE}${l.link.url}` : ''),
+  );
+  if (uniqueListings.length !== listings.length) {
+    console.log(`  ↺ Dedup: ${listings.length} listings → ${uniqueListings.length} unique postings (same req id under multiple career-section paths)`);
+  }
+
   const jobs = [];
 
-  for (const listing of listings) {
+  for (const listing of uniqueListings) {
     const title = (listing.title || '').trim();
     if (!title) continue;
 

--- a/tests/cler-crawler.test.ts
+++ b/tests/cler-crawler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { htmlToMarkdown, validateClerDescription, extractJobMeta } from '../scripts/lib/cler-job-parser.mjs';
+import { htmlToMarkdown, validateClerDescription, extractJobMeta, dedupeClerJobsByStableId, clerCareerSectionYear } from '../scripts/lib/cler-job-parser.mjs';
+import { extractStableJobId } from '../scripts/lib/job-match-key.mjs';
 
 // ──────────────────────────────────────────────────────────────
 // Real HTML fixture: Geschäftsstellenleiterin Schaffhausen
@@ -131,6 +132,91 @@ const FIXTURE_JOB2_HTML = `<!DOCTYPE html>
 // ──────────────────────────────────────────────────────────────
 // htmlToMarkdown tests
 // ──────────────────────────────────────────────────────────────
+
+// ──────────────────────────────────────────────────────────────
+// dedupeClerJobsByStableId — #3836 duplicate-listings collapse
+//
+// Since the 2026-07 relaunch the jobssearch API returns each open position
+// twice: once under the legacy `…/jobs-und-karriere/…` path and once under the
+// relaunched `…/jobs-und-karriere-2026/…` path — SAME 3-4 digit requisition id,
+// two distinct whole URLs. Left un-deduped this emitted 12 records for 6 real
+// jobs, tripping the duplicate-listings ratchet (12/12).
+// ──────────────────────────────────────────────────────────────
+
+const API_BASE = 'https://www.cler.ch';
+
+// 6 real roles, each returned under BOTH career-section paths (12 listings).
+const CLER_ROLES: Array<[string, string]> = [
+  ['2673', 'kundenberaterin-basis-zuerich-stv-teamleiterin-w-m'],
+  ['2685', 'kundenberaterin-vermoegende-privatkunden-zuerich-w-m'],
+  ['2680', 'kundenberaterin-individual-zuerich-w-m'],
+  ['2676', 'geschaeftsstellenleiterin-st-gallen-w-m'],
+  ['2662', 'kundenberater-privatkunden-individual-thun-w-m'],
+  ['2589', 'kundenberaterin-basis-thun-w-m'],
+];
+
+function buildClerListingFixture() {
+  const listings: Array<{ link: { url: string } }> = [];
+  for (const [id, slug] of CLER_ROLES) {
+    // Order mirrors the live API: legacy path first, relaunched path second.
+    listings.push({ link: { url: `/de/bank-cler/jobs-und-karriere/suchen-und-bewerben/offene-stellen/${slug}-${id}` } });
+    listings.push({ link: { url: `/de/bank-cler/jobs-und-karriere-2026/suchen-und-bewerben/offene-stellen/${slug}-${id}` } });
+  }
+  return listings;
+}
+
+const getListingUrl = (l: { link?: { url?: string } }) => (l?.link?.url ? `${API_BASE}${l.link.url}` : '');
+
+describe('dedupeClerJobsByStableId — #3836', () => {
+  it('collapses 12 duplicate listings into 6 distinct jobs', () => {
+    const listings = buildClerListingFixture();
+    expect(listings).toHaveLength(12);
+    const unique = dedupeClerJobsByStableId(listings, getListingUrl);
+    expect(unique).toHaveLength(6);
+  });
+
+  it('leaves NO id-duplicated records (each stable id appears exactly once)', () => {
+    const unique = dedupeClerJobsByStableId(buildClerListingFixture(), getListingUrl);
+    const ids = unique.map((l) => extractStableJobId(getListingUrl(l)));
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(ids)).toEqual(
+      new Set(CLER_ROLES.map(([id]) => `req:cler.ch:${id}`)),
+    );
+  });
+
+  it('preserves the canonical (newest career-section) URL for each survivor', () => {
+    const unique = dedupeClerJobsByStableId(buildClerListingFixture(), getListingUrl);
+    for (const l of unique) {
+      expect(l.link.url).toContain('jobs-und-karriere-2026');
+    }
+  });
+
+  it('picks the canonical URL regardless of API ordering', () => {
+    // Same posting, relaunched path listed FIRST this time — canonical must
+    // still win, not merely "last seen".
+    const listings = [
+      { link: { url: '/de/bank-cler/jobs-und-karriere-2026/suchen-und-bewerben/offene-stellen/kundenberaterin-basis-thun-w-m-2589' } },
+      { link: { url: '/de/bank-cler/jobs-und-karriere/suchen-und-bewerben/offene-stellen/kundenberaterin-basis-thun-w-m-2589' } },
+    ];
+    const unique = dedupeClerJobsByStableId(listings, getListingUrl);
+    expect(unique).toHaveLength(1);
+    expect(unique[0].link.url).toContain('jobs-und-karriere-2026');
+  });
+
+  it('keeps records with no derivable stable id instead of dropping them', () => {
+    const listings = [
+      { link: { url: '' }, slug: '' },
+      { link: { url: '' }, slug: '' },
+    ] as Array<{ link: { url: string }; slug: string }>;
+    const unique = dedupeClerJobsByStableId(listings, getListingUrl);
+    expect(unique).toHaveLength(2);
+  });
+
+  it('clerCareerSectionYear extracts the year suffix (0 when absent)', () => {
+    expect(clerCareerSectionYear(`${API_BASE}/de/bank-cler/jobs-und-karriere-2026/x-2589`)).toBe(2026);
+    expect(clerCareerSectionYear(`${API_BASE}/de/bank-cler/jobs-und-karriere/x-2589`)).toBe(0);
+  });
+});
 
 describe('htmlToMarkdown — Cler job pages', () => {
   it('extracts full description from Job 1 (Geschäftsstellenleiterin)', () => {

--- a/tests/davos-klosters-bergbahnen-crawler.test.ts
+++ b/tests/davos-klosters-bergbahnen-crawler.test.ts
@@ -165,6 +165,95 @@ describe('Davos Klosters Bergbahnen job parser', () => {
     });
   });
 
+  // Real-shaped detail page where a SITE-WIDE operational alert banner is
+  // rendered inside its OWN `.wysiwyg` block ABOVE the job content — the exact
+  // shape that made all 9 davos jobs share one 171-char notice (#3836).
+  const SAMPLE_DETAIL_WITH_ALERT_BANNER_HTML = `
+<html lang="de"><body>
+<header class="site-header">
+  <div class="site-alert notification">
+    <div class="wysiwyg">
+      <p>Aufgrund von tech. Arbeiten an der Pendelbahn (Jschalp-Jakobshorn), wird die 2. Sektion des Jakobshorns am 14.07.2026 ab 15:30 Uhr geschlossen. Danke für das Verständnis.</p>
+    </div>
+  </div>
+</header>
+<main id="main-content" role="main" class="content-block">
+  <div class="title-block title-block--main title-block--main-small">
+    <div class="media-text media-text--text-only text-center">
+      <div class="container container--no-padding-xs">
+        <div class="container-narrow">
+          <div class="media-text__content">
+            <div class="media-text__content__offset">
+              <div class="h3 mb-0 text-white">Bergbahnen</div>
+              <h1 class="mb-0 h2">
+                <span class="d-block text-primary">Betriebselektriker:in</span>
+              </h1>
+              <div class="meta-list">
+                <div class="meta-list__item">ab Sommersaison 2026</div>
+                <div class="meta-list__item">100%</div>
+                <div class="meta-list__item">
+                  <a href='https://example.com/download' class='text-primary'><span class='icon icon-download'></span> Infos downloaden</a>
+                </div>
+              </div>
+            </div>
+            <div class="wysiwyg mt-2 pt-1 text-left">
+              <p>Für die kommende <strong>Sommersaison 2026</strong> suchen wir eine engagierte Person als Betriebselektriker:in für unser Team in Davos.</p>
+              <ul>
+                <li>Unterhalt und Betrieb von Seilbahnen und Schneeanlagen</li>
+                <li>Unterhalt und Betrieb unserer Gebäudeinfrastruktur inkl. Gastronomiebetriebe</li>
+                <li>Störungsbehebung und Pikettdienst im Winterbetrieb</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+<footer class="site-footer"><div class="wysiwyg"><p>Davos Klosters Bergbahnen AG — Kontakt und Impressum. Folgen Sie uns auf allen Kanälen.</p></div></footer>
+</body></html>
+`;
+
+  // Faithful copy of the parser-quality audit's hasStructuredContent
+  // (scripts/audit-parser-quality.mjs) — it is module-local there, so mirror it
+  // to assert the extracted description would clear the no-structure signal.
+  const auditStripHtml = (html: string) => (html || '').replace(/<[^>]*>/g, ' ').replace(/&[a-z]+;/gi, ' ');
+  const auditHasStructuredContent = (desc: string) => {
+    const text = auditStripHtml(desc);
+    if (/<li[\s>]/i.test(desc)) return true;
+    if (/^\s*[-•*]\s/m.test(text)) return true;
+    if (/^\s*\d+[.)]\s/m.test(text)) return true;
+    return false;
+  };
+
+  describe('parseDavosKlostersBergbahnenDetailHtml — #3836 chrome-banner exclusion', () => {
+    it('extracts the per-job body, NOT the site-wide alert banner', () => {
+      const result = parseDavosKlostersBergbahnenDetailHtml(SAMPLE_DETAIL_WITH_ALERT_BANNER_HTML);
+      expect(result).not.toBeNull();
+      // Banner text (the #3836 chrome blob) must be excluded.
+      expect(result!.description).not.toContain('Jakobshorn');
+      expect(result!.description).not.toContain('geschlossen');
+      // Footer boilerplate must be excluded too.
+      expect(result!.description).not.toContain('Impressum');
+      // The actual job body must be present.
+      expect(result!.description).toContain('Seilbahnen');
+      expect(result!.description).toContain('Betriebselektriker');
+    });
+
+    it('produces a description that clears the audit hasStructuredContent signal', () => {
+      const result = parseDavosKlostersBergbahnenDetailHtml(SAMPLE_DETAIL_WITH_ALERT_BANNER_HTML);
+      expect(auditHasStructuredContent(result!.description)).toBe(true);
+    });
+
+    it('still extracts the correct title and department past the banner', () => {
+      const result = parseDavosKlostersBergbahnenDetailHtml(SAMPLE_DETAIL_WITH_ALERT_BANNER_HTML);
+      expect(result!.title).toBe('Betriebselektriker:in');
+      expect(result!.department).toBe('Bergbahnen');
+      expect(result!.period).toBe('ab Sommersaison 2026');
+      expect(result!.percentage).toBe('100%');
+    });
+  });
+
   describe('parseDavosKlostersBergbahnenDetailHtml', () => {
     it('extracts title from <h1><span class="text-primary">', () => {
       const result = parseDavosKlostersBergbahnenDetailHtml(SAMPLE_DETAIL_HTML);


### PR DESCRIPTION
## Implementato

Due bug reali del parser dietro il fallimento ricorrente di "Audit Parser Quality" (#3836).

**banca-cler — duplicate-listings (12 record / 6 job reali):** dal relaunch career-section 2026-07, l'API jobssearch di cler.ch restituisce ogni posting due volte — path legacy `.../jobs-und-karriere/...` e relaunch `.../jobs-und-karriere-2026/...`, stessa requisition id, due URL distinti → fingerprint title-aware collideva 12/12 → ratchet CRITICAL. Fix: `dedupeClerJobsByStableId` (+ `clerCareerSectionYear`) in `scripts/lib/cler-job-parser.mjs`, keyed su `extractStableJobId` (Rule K `req:cler.ch:<id>`), invocato in `fetchClerJobs` **prima** del fetch detail. Collassa 12→6, preserva l'URL canonico (career-section più recente) indipendentemente dall'ordine API, salta i detail-fetch duplicati.

**davos-klosters-bergbahnen — chrome-scraping (9/9 body identico 171-char):** la detail page rende un banner di alert operativo site-wide dentro un `.wysiwyg` **sopra** il body job; il match "primo `.wysiwyg`" prendeva il banner → tutti i 9 job stesso description; anche il fallback `<main>` era illimitato. Fix (`scripts/lib/davos-klosters-bergbahnen-job-parser.mjs`): estrazione limitata al subtree per-job — `bodyScope` = HTML dopo l'`<h1>` del titolo (il banner precede sempre); primo `.wysiwyg` **dentro** lo scope; fallback limitato alla regione prima del primo boundary footer/nav/notification. Aggiunto `richTextToLines` per preservare i bullet `<li>` come marker inizio-riga → `hasStructuredContent` passa.

**Verifica:** `node --check` OK sui 3 file; 52 test passano (43 esistenti + 9 nuovi) nelle due suite; audit sui dati-fixture → banca-cler 0 duplicati title-aware (era 12/12), davos chrome-bucket 1/9 no-structure 0/9 → nessuno CRITICAL.

Ref #3836 (non chiuso: l'audit green completo richiede il re-crawl di banca-cler e davos — le slice committate sono fossil, `data/**` intatto per CODE≠DATA — più il clear fossil postauto fuori scope).

## Non implementato (ancora)

- **postauto** (terzo critical #3836): fossil flat-translation data; il producer (`free-translate.mjs`, gate `isStructureFlattenedCopy`) è già corretto — serve solo il repair `scripts/clear-flattened-locale-translations.mjs` (data-session), fuori scope qui.
- `Closes #3836` NON aggiunto di proposito: chiuderlo ora sarebbe prematuro (dipende dal re-crawl).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_