### PR TITLE
test(seo-hubs): raise emitSeoHubs beforeAll hookTimeout to 60s (fix flaky main-red)

### DIFF
--- a/tests/build-plugins/seoHubsPlugin-hub-locale-reciprocity.test.ts
+++ b/tests/build-plugins/seoHubsPlugin-hub-locale-reciprocity.test.ts
@@ -40,7 +40,13 @@ describe('emitSeoHubs — EN/DE/FR hub locales get reciprocal sitemap entries (#
       qw: () => {}, // HTML page bodies are irrelevant to this test
     }));
     xml = fs.readFileSync(path.join(distDir, 'sitemap-seo-hubs.xml'), 'utf-8');
-  });
+    // emitSeoHubs walks the full repo ROOT and writes every hub page + sitemap;
+    // on a heavily-loaded CI shard (full-suite runs measured at ~360s wall) this
+    // legitimately exceeds vitest's default 10s hookTimeout, intermittently
+    // reddening main on a green diff (observed runs 29348408768, 29351211797).
+    // Raise the hook budget so real work under load isn't misread as a failure —
+    // the test body assertions are unchanged.
+  }, 60000);
 
   afterAll(() => {
     fs.rmSync(distDir, { recursive: true, force: true });


### PR DESCRIPTION
## Implementato

- Il `beforeAll` di `tests/build-plugins/seoHubsPlugin-hub-locale-reciprocity.test.ts` esegue `emitSeoHubs`, che cammina l'intero ROOT del repo e scrive ogni hub page + sitemap. Su uno shard CI carico (full-suite ~360s wall) supera legittimamente il `hookTimeout` di default di vitest (10s), rendendo **main rosso in modo intermittente su un diff verde** (osservato nei run 29348408768 e 29351211797 — `Hook timed out in 10000ms`, con 110.5k+ test passati e SOLO questo hook in timeout).
- Fix: alzato il budget del solo hook a 60s (`beforeAll(fn, 60000)`). Nessuna assertion cambiata. Localmente il `beforeAll` da solo impiega ~8s → con carico CI supera i 10s: il 60s dà margine robusto.

**Verifica:** `npx vitest run tests/build-plugins/seoHubsPlugin-hub-locale-reciprocity.test.ts` → 4/4 pass (8.85s).

## Non implementato (ancora)

- Ottimizzare `emitSeoHubs` per non camminare l'intero ROOT nel test (fixture ridotta): fuori scope — il timeout è la fix minima e a rischio-zero per la stabilità di main; l'ottimizzazione della fixture è un refactor separato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_