### PR TITLE
fix(ci): guard-data-integrity checkout blobless (evita timeout 8min) (#4120)

### DIFF
--- a/.github/workflows/guard-data-integrity.yml
+++ b/.github/workflows/guard-data-integrity.yml
@@ -29,17 +29,27 @@ permissions:
 jobs:
   guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 15
     # Non girare sui commit di revert del guard stesso (anti-ricorsione): il
     # revert restaura il file (cresce → nessuno shrink → no-op comunque), ma
     # saltarlo evita una run inutile.
     if: ${{ !contains(github.event.head_commit.message, '[data-guard revert]') }}
     steps:
-      - name: Checkout (full history)
+      # Checkout BLOBLESS (filter=blob:none): scarica l'intero commit-graph (così
+      # `$BEFORE` è sempre presente, anche a molti commit di distanza) MA NON i
+      # blob dei file upfront. I blob vengono recuperati on-demand solo quando il
+      # guard legge i pochi file toccati a BEFORE/AFTER — la truncation-detection
+      # e `git checkout "$BEFORE" -- "$f"` restano corretti. Il vecchio
+      # `fetch-depth: 0` full-clone scaricava TUTTI i blob dell'intera storia
+      # data-heavy (~GB) e sforava il timeout di 8 min in fase di checkout, prima
+      # ancora che il detector girasse (issue #4120: lo step "Detect" veniva
+      # saltato — il timeout era 100% nel checkout). Blobless → checkout in secondi.
+      - name: Checkout (blobless — full commit graph, blob on demand)
         uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: true
 
       - name: Setup Node


### PR DESCRIPTION
## Implementato

- `.github/workflows/guard-data-integrity.yml`: il checkout passa da full-clone (`fetch-depth: 0`) a **blobless** (`fetch-depth: 0` + `filter: blob:none`).
- `timeout-minutes` 8 → 15 (margine).

**Root cause (#4120):** il guard gira dopo ogni push su `main` e confronta i file-dati a `$BEFORE`/`$AFTER`. Il checkout `fetch-depth: 0` scaricava **tutti i blob dell'intera storia data-heavy** (~GB di JSON accumulatori committati direttamente su main) e sforava il timeout di 8 min **in fase di checkout** — lo step "Detect catastrophic truncation" veniva **saltato** (il timeout era 100% nel checkout, il detector non partiva mai).

**Fix:** `filter: blob:none` scarica l'intero commit-graph (così `$BEFORE` è sempre presente, anche a molti commit di distanza) ma **non** i blob upfront; i pochi blob dei file toccati a BEFORE/AFTER si recuperano on-demand quando il detector li legge (`git show`, `git checkout "$BEFORE" -- "$f"` restano corretti via promisor partial-clone). Checkout in secondi invece di 8 min → il detector gira e il guard funziona.

Closes #4120

## Non implementato (ancora)

- Stesso pattern di checkout-timeout su altri workflow (issue-fix.yml #4189) — trattato separatamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_