### PR TITLE
fix(ci): blobless checkout (issue-fix #4189) + GSC push-attempts cap (#4162)

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -38,6 +38,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Blobless clone (#4189): con fetch-depth:0 il checkout scaricava TUTTI
+          # i blob storici di questo repo data-heavy, consumando l'intero budget
+          # job da 30min → "Run Claude fix" non partiva mai. `filter: blob:none`
+          # prende il commit-graph completo + il working tree di HEAD ma salta i
+          # blob storici (fetch on-demand se mai servono): checkout da ~minuti a
+          # ~secondi, HEAD materializzato identico → il fixer lavora invariato.
+          filter: blob:none
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/sync-gsc-orphans.yml
+++ b/.github/workflows/sync-gsc-orphans.yml
@@ -135,6 +135,26 @@ jobs:
             data/seo-404-compat
         env:
           SKIP_AI_TRANSLATION: '1'
+          # #4162: il job (30min) veniva cancellato per timeout DENTRO questo step.
+          # sync-gsc-orphans.mjs è veloce (~104s); il tempo se ne va tutto nella
+          # push-contention war di git-commit-data.sh (path sequenziale
+          # commit_isolated_from_worktree) contro le push concorrenti dei ~crawler
+          # su main. Col default MAX_PUSH_ATTEMPTS=14 + backoff escalante
+          # (5,10,…,65s + jitter) il loop di retry dura ~24min sotto contention e
+          # sfora il budget job PRIMA di poter ritornare 42 (contention-exhausted)
+          # → il soft-fail sequenziale (exit 42 → exit 0, già presente in
+          # git-commit-data.sh righe ~1038) NON scatta mai perché il job viene
+          # killato a metà loop. Abbassare il tetto SOLO per questo caller (env,
+          # zero modifiche allo script condiviso dai 40+ crawler) fa concludere il
+          # loop in ~5-6min anche sotto contention: su perdita-race ritorna 42 →
+          # soft exit 0 (i dati si auto-guariscono al prossimo run schedulato
+          # bi-settimanale), mentre un fallimento NON-contention (auth/rete/hook)
+          # ritorna comunque exit 1 → job rosso → issue di failure (semantica
+          # exit-code preservata, nessun mascheramento di errori reali — perciò
+          # NON uso continue-on-error, che ingoierebbe anche gli exit 1 genuini).
+          # 8 tentativi = ~8 chance di vincere la ref-race, con margine ampio
+          # sotto i 30min.
+          MAX_PUSH_ATTEMPTS: '8'
 
       - name: Trigger deploy if data changed
         if: steps.commit.outputs.has_changes == 'true' && inputs.dry_run != true


### PR DESCRIPTION
## Implementato

Due CI-timeout ricorrenti risolti (entrambi workflow-level, chirurgici).

### #4189 — Issue fix (Claude → PR): checkout timeout
- `.github/workflows/issue-fix.yml`: aggiunto `filter: blob:none` allo step Checkout (mantenuto `fetch-depth: 0`). Il full-clone scaricava tutti i blob storici bruciando i 30 min di job budget prima che "Run Claude fix" partisse. Blobless → commit-graph completo + working tree HEAD materializzato identico, blob storici on-demand → checkout in secondi. Prompt embedded intatto.

### #4162 — Sync GSC Orphan Job Slugs: push contention
- `.github/workflows/sync-gsc-orphans.yml`: `MAX_PUSH_ATTEMPTS: '8'` come env **solo** sullo step "Commit and push". Lo sync-script è veloce (~104s); il timeout era nella push-contention war (14 retry × backoff crescente ~24 min) che sforava il job budget **prima** di poter ritornare exit 42 → il soft-fail sequenziale già presente in `git-commit-data.sh` non scattava. Con 8 attempt il loop chiude in ~5-6 min: ritorna 42 su ref-race → exit 0 (i dati si auto-riparano al prossimo run schedulato), mentre un fallimento reale (auth/network/hook) ritorna comunque exit 1 → job rosso. **Zero modifiche** allo script condiviso `git-commit-data.sh` (usato da 40+ crawler) — override per-caller via il suo contratto env esistente; semantica exit-code 42-vs-1 preservata. NON usato `continue-on-error` (inghiottirebbe anche i fail reali).

Verifica: YAML parse OK su entrambi.

Closes #4189
Closes #4162

## Non implementato (ancora)

- **#4079** (equivalence gate in deploy.yml) — lasciato aperto di proposito: wire di `compare-dist-manifests.mjs` in produzione richiede un monolith reference build che `deploy.yml` **non** costruisce più (rimosso per costo ~23min + cap 10GB Pages), e in prod ogni shard subisce Ticino-strip + CDN-offload → HTML non byte-identico al monolith → il gate sha256 bloccherebbe i deploy con mismatch spuri. Il validator strutturale per-shard `validate-locale-shard-build.mjs` è già wired (deploy.yml:415). Serve una PR dedicata con un vero deploy run (o un adattamento che hasha al punto pre-offload/pre-strip).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_