### PR TITLE
feat(seo): Article JSON-LD su hub fiscale + evergreen (tax-guide #3030)

### DIFF
--- a/build-plugins/salaryHubArticles.ts
+++ b/build-plugins/salaryHubArticles.ts
@@ -18,6 +18,8 @@ import { renderHreflangTags } from './shared/hreflang';
 import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
 import { renderAuthoritativeSourcesHtml } from './shared/authoritativeSources';
+import { buildDayStampIso } from './shared/buildDayStamp';
+import { imageObjectLd } from '../services/seo/imageObjectLd';
 
 type Locale = 'it' | 'en' | 'de' | 'fr';
 
@@ -687,6 +689,38 @@ export function generateArticleHtml(
     ],
   });
 
+  // Article schema — these pages set ogType 'article' but previously shipped no
+  // Article JSON-LD, so they were ineligible for Article rich results and lacked
+  // an explicit author/publisher E-E-A-T signal. Mirrors the accepted publisher
+  // Organization + licensable logo pattern used by comparisonsHubPlugin. Dates
+  // use the day-truncated build stamp (buildDayStampIso) so dateModified stays a
+  // valid freshness signal — the net figures in the body are recomputed from the
+  // simulation engine on every build — without churning every sub-second deploy.
+  const articleStamp = buildDayStampIso();
+  const articleSchema = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: title,
+    description,
+    image: `${BASE_URL}/og-image.png`,
+    inLanguage: locale,
+    url: canonicalUrl,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
+    datePublished: articleStamp,
+    dateModified: articleStamp,
+    author: { '@type': 'Organization', name: 'Frontaliere Ticino', url: `${BASE_URL}/` },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Frontaliere Ticino',
+      url: `${BASE_URL}/`,
+      logo: imageObjectLd({
+        url: `${BASE_URL}/icons/icon-512x512.png`,
+        width: 512,
+        height: 512,
+      }),
+    },
+  });
+
   // Get related scenarios for cross-linking grid
   const related = scenarioData.scenarios
     .filter(article.relatedScenarioFilter)
@@ -785,7 +819,7 @@ export function generateArticleHtml(
     canonicalUrl,
     hreflangHtml,
     ogType: 'article',
-    jsonLdScripts: [faqSchema, breadcrumbSchema],
+    jsonLdScripts: [articleSchema, faqSchema, breadcrumbSchema],
     bodyHtml: pageBody,
     distDir,
   });

--- a/tests/build-plugins/salary-hub-article-schema.test.ts
+++ b/tests/build-plugins/salary-hub-article-schema.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVERGREEN_ARTICLES,
+  generateArticleHtml,
+  type ScenarioDataMap,
+} from '../../build-plugins/salaryHubArticles';
+
+// generateArticleHtml resolves SPA entry assets from `distDir`; a non-existent
+// path is handled gracefully (resolveEntryAssets try/catch → empty strings), so
+// no prior Vite build is needed for these unit assertions.
+const NO_DIST = '/tmp/nonexistent-dist-for-article-schema-test';
+const EMPTY_DATA: ScenarioDataMap = { scenarios: [], results: new Map() };
+const LOCALES = ['it', 'en', 'de', 'fr'] as const;
+
+/** Extract every application/ld+json payload from a rendered page as objects. */
+function extractJsonLd(html: string): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  const rx = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(html)) !== null) {
+    // The template escapes `<` → <; JSON.parse decodes it back.
+    out.push(JSON.parse(m[1]) as Record<string, unknown>);
+  }
+  return out;
+}
+
+function articleSchemaOf(html: string): Record<string, unknown> | undefined {
+  return extractJsonLd(html).find((s) => s['@type'] === 'Article');
+}
+
+const taxHub = EVERGREEN_ARTICLES.find((a) => a.id === 'hub-fiscale-frontalieri')!;
+
+describe('salary-hub evergreen articles — Article JSON-LD', () => {
+  it('the tax-guide hub emits a complete Article schema in every locale', () => {
+    expect(taxHub).toBeDefined();
+    for (const locale of LOCALES) {
+      const html = generateArticleHtml(taxHub, locale, EMPTY_DATA, NO_DIST);
+      const article = articleSchemaOf(html);
+      expect(article, `Article schema present for ${locale}`).toBeDefined();
+
+      // Core Article rich-result fields.
+      expect(article!['@context']).toBe('https://schema.org');
+      expect(article!.headline).toBe(taxHub.titles[locale]);
+      expect(article!.description).toBe(taxHub.descriptions[locale]);
+      expect(article!.inLanguage).toBe(locale);
+      expect(typeof article!.image).toBe('string');
+      expect(article!.image).toMatch(/\/og-image\.png$/);
+
+      // url + mainEntityOfPage must agree with the canonical locale URL.
+      const url = article!.url as string;
+      expect(url).toMatch(/^https?:\/\//);
+      expect((article!.mainEntityOfPage as Record<string, unknown>)['@id']).toBe(url);
+
+      // Dates present and ISO — day-truncated so they don't churn per deploy.
+      expect(article!.datePublished).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/);
+      expect(article!.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/);
+
+      // Explicit author + publisher E-E-A-T signal.
+      const author = article!.author as Record<string, unknown>;
+      expect(author['@type']).toBe('Organization');
+      expect(author.name).toBe('Frontaliere Ticino');
+
+      const publisher = article!.publisher as Record<string, unknown>;
+      expect(publisher['@type']).toBe('Organization');
+      expect(publisher.name).toBe('Frontaliere Ticino');
+
+      // Publisher logo must be a licensable ImageObject (GSC image gate).
+      const logo = publisher.logo as Record<string, unknown>;
+      expect(logo['@type']).toBe('ImageObject');
+      for (const field of ['acquireLicensePage', 'copyrightNotice', 'license', 'creator', 'creditText']) {
+        expect(logo[field], `logo.${field} present`).toBeTruthy();
+      }
+    }
+  });
+
+  it('FAQPage and BreadcrumbList schemas still ship alongside Article (no regression)', () => {
+    const html = generateArticleHtml(taxHub, 'it', EMPTY_DATA, NO_DIST);
+    const types = extractJsonLd(html).map((s) => s['@type']);
+    expect(types).toContain('Article');
+    expect(types).toContain('FAQPage');
+    expect(types).toContain('BreadcrumbList');
+  });
+
+  it('every evergreen article (not just the tax hub) emits an Article schema', () => {
+    for (const article of EVERGREEN_ARTICLES) {
+      const html = generateArticleHtml(article, 'it', EMPTY_DATA, NO_DIST);
+      const schema = articleSchemaOf(html);
+      expect(schema, `Article schema present for ${article.id}`).toBeDefined();
+      expect(schema!.headline).toBe(article.titles.it);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Enhancement tax-guide (#3030). Gli item 1/3/4/5 del piano erano già shipped (#3686 hub fiscalità + linking + measurement; #3694 FAQ strutturata FAQPage). Questa PR chiude un gap di **structured-data completeness** esplicitamente in scope:

- `build-plugins/salaryHubArticles.ts` — `generateArticleHtml` impostava `ogType:'article'` ma emetteva solo FAQPage + BreadcrumbList, **senza `Article` JSON-LD** → l'hub fiscale (e gli 8 sibling evergreen) non erano eleggibili per Article rich-result né avevano segnale E-E-A-T author/publisher. Aggiunto schema `Article` completo (headline, description, image, `inLanguage` per-locale, url, `mainEntityOfPage`, datePublished/dateModified, author + publisher Organization con logo licensable). Fix di CLASSE: 9 articoli × 4 locali.
- Riuso helper condivisi (AGENTS §6): `imageObjectLd` (passa il gate GSC image-license) e `buildDayStampIso` (date day-truncated → freshness valido senza churn per-deploy), come il pattern accettato in `comparisonsHubPlugin`.
- Nuovo test `tests/build-plugins/salary-hub-article-schema.test.ts` (3 test): completezza Article su 4 locali per l'hub fisco, coesistenza con FAQPage+BreadcrumbList, presenza su ogni evergreen.

Verifica: nuovo test 3/3; sibling esistenti (salary-hub-ownership, tile-cta, faq-hub-content, fisco-landing, sibling-hub-reciprocity) 24/24; `tsc --noEmit` 0 errori nei file toccati.

Refs #3030

## Non implementato (ancora)

- **Item 2 #3030/#3652** (calcolatore netto per-cantone/comune): BLOCCATO — i dati di ritenuta alla fonte per-cantone non sono ottenibili in questo ambiente (ESTV pubblica solo un calcolatore SPA non-scrapable) e fabbricare aliquote violerebbe le regole di accuratezza. #3030 resta aperto per questo item finché la fonte dati non è disponibile.
- WhatsNew: 2 entry user-facing pending dall'auto-sync hook — sync separato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_