### PR TITLE
fix(stability): resilientImport per blog-articles-data (self-heal CDN) (#4176)

### DIFF
--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback, Suspense, memo, Fragment, type FC, type ReactNode, type ReactElement, type CSSProperties } from 'react';
 import { lazyRetry } from '@/services/lazyRetry';
+import { resilientImport } from '@/services/resilientImport';
 import { useTranslation, useLocale, loadBlogMeta, loadArticleBody, getCantonI18nParams } from '@/services/i18n';
 import type { Locale } from '@/services/i18n';
 import { buildPath, preloadBlogData } from '@/services/router';
@@ -1186,9 +1187,15 @@ function BlogArticles({
  // every article href below is canonical by construction (the slug map no
  // longer preloads unconditionally at App mount — #3528/#3532).
  useEffect(() => {
+ // FRO-314 / #4176: wrap the non-hashed data-chunk import() in resilientImport
+ // so a transient CDN deploy-window failure ("Failed to fetch dynamically
+ // imported module: .../blog-articles-data.js") self-heals (cache-bust +
+ // budgeted reload) instead of surfacing to the user and the error monitor.
+ // The validate guard also covers the mode-2 stale case (SPA-fallback HTML
+ // served HTTP 200 for a purged chunk → module resolves but export missing).
  const articlesPromise = section === 'svizzera'
- ? import('@/data/swiss-articles-data').then(m => m.SWISS_ARTICLES)
- : import('@/data/blog-articles-data').then(m => m.ARTICLES);
+ ? resilientImport(() => import('@/data/swiss-articles-data'), m => Array.isArray(m.SWISS_ARTICLES)).then(m => m.SWISS_ARTICLES)
+ : resilientImport(() => import('@/data/blog-articles-data'), m => Array.isArray(m.ARTICLES)).then(m => m.ARTICLES);
  Promise.all([
  loadBlogMeta(section),
  // Swallow slug-map failure: degrade to id-fallback hrefs (pre-#3532

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4197,7 +4197,9 @@ const JobBoard: React.FC<JobBoardProps> = ({
  Promise.all([
  loadBlogMeta(),
  preloadBlogData().catch(() => {}),
- import('@/data/blog-articles-data').then(m => m.ARTICLES),
+ // #4176: resilientImport so a transient CDN deploy-window failure on the
+ // non-hashed blog-articles-data.js chunk self-heals instead of surfacing.
+ resilientImport(() => import('@/data/blog-articles-data'), m => Array.isArray(m.ARTICLES)).then(m => m.ARTICLES),
  ]).then(([, , data]) => {
  setBlogArticles(data);
  setBlogMetaReady(true);

--- a/components/shared/SiteSearch.tsx
+++ b/components/shared/SiteSearch.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Search, X, ArrowRight, Calculator, Layers, PiggyBank, BookOpen, BarChart2, HelpCircle, ArrowRightLeft, Phone, Car, Heart, Building2, AlertTriangle, Briefcase, ShoppingCart, Euro, TrendingUp, Sparkles, MapPin, Calendar, PartyPopper, FileText, GraduationCap, Building, Compass, BriefcaseBusiness, MessageSquare, Map, Baby, Award, Scale, Home, Mail, Handshake, Video, Sunrise, User as UserIcon, Gift, Hammer, BookA, BarChart3, Wrench, Users, Clock, Newspaper, Receipt, Banknote, Coins, Star } from 'lucide-react';
 import { useTranslation, loadAllTranslations, getCantonI18nParams } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
+import { resilientImport } from '@/services/resilientImport';
 import { ALL_GLOSSARY_TERM_IDS } from '@/services/router';
 import type { GlossaryTermId, BlogArticleId } from '@/services/router';
 
@@ -41,7 +42,9 @@ const SiteSearch: React.FC<SiteSearchProps> = ({ onNavigate }) => {
  const [blogArticleIds, setBlogArticleIds] = useState<BlogArticleId[]>([]);
  useEffect(() => {
  if (!isOpen) return;
- import('@/data/blog-articles-data').then(m => {
+ // #4176: resilientImport so a transient CDN deploy-window failure on the
+ // non-hashed blog-articles-data.js chunk self-heals instead of surfacing.
+ resilientImport(() => import('@/data/blog-articles-data'), m => Array.isArray(m.ARTICLES)).then(m => {
  setBlogArticleIds(m.ARTICLES.map(a => a.id));
  });
  }, [isOpen]);

--- a/tests/community/BlogArticles.resilient-import.test.tsx
+++ b/tests/community/BlogArticles.resilient-import.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Source-level regression for issue #4176.
+ *
+ * The blog data chunk (data/blog-articles-data.ts → the non-hashed
+ * blog-articles-data.js on the CDN) is loaded via a dynamic import() in the
+ * mount effect. A plain, unwrapped import() surfaces a transient CDN
+ * deploy-window failure ("Failed to fetch dynamically imported module:
+ * .../blog-articles-data.js") straight to the user and the error monitor,
+ * instead of self-healing. Every other stale-deploy-prone dynamic import in
+ * the app is wrapped in resilientImport() (cache-bust + budgeted reload).
+ *
+ * These assertions guard against the wrapper being removed / regressing back
+ * to a bare import().
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (rel: string) => readFileSync(resolve(__dirname, '..', '..', rel), 'utf8');
+const SOURCE = read('components/community/BlogArticles.tsx');
+
+// Every CLIENT component that lazy-loads the non-hashed blog-articles-data
+// chunk must wrap the import() so a CDN deploy-window failure self-heals
+// (#4176 sibling-class fix, AGENTS.md §Non-Negotiables #6). A bare import()
+// of this chunk in any of these files is the regression to catch.
+const CLIENT_DATA_CHUNK_CONSUMERS = [
+  'components/community/BlogArticles.tsx',
+  'components/community/JobBoard.tsx',
+  'components/shared/SiteSearch.tsx',
+];
+
+describe('BlogArticles — data chunk import is stale-deploy resilient (#4176)', () => {
+  it('imports the resilientImport helper', () => {
+    expect(SOURCE).toMatch(
+      /import\s*\{\s*resilientImport\s*\}\s*from\s*['"]@\/services\/resilientImport['"]/,
+    );
+  });
+
+  it('wraps the blog-articles-data import() in resilientImport with an export guard', () => {
+    expect(SOURCE).toMatch(
+      /resilientImport\(\s*\(\)\s*=>\s*import\(['"]@\/data\/blog-articles-data['"]\)\s*,\s*[^)]*ARTICLES/,
+    );
+  });
+
+  it('wraps the swiss-articles-data import() in resilientImport with an export guard', () => {
+    expect(SOURCE).toMatch(
+      /resilientImport\(\s*\(\)\s*=>\s*import\(['"]@\/data\/swiss-articles-data['"]\)\s*,\s*[^)]*SWISS_ARTICLES/,
+    );
+  });
+
+  it.each(CLIENT_DATA_CHUNK_CONSUMERS)(
+    'does not load the data chunk via a bare, unwrapped import() in %s',
+    (rel) => {
+      const src = read(rel);
+      // A bare `import('@/data/blog-articles-data')` NOT preceded by
+      // `resilientImport(() => ` is the regression we are guarding against.
+      expect(src).not.toMatch(/(?<!\(\)\s=>\s)\bimport\(['"]@\/data\/blog-articles-data['"]\)/);
+      expect(src).not.toMatch(/(?<!\(\)\s=>\s)\bimport\(['"]@\/data\/swiss-articles-data['"]\)/);
+    },
+  );
+
+  it.each(CLIENT_DATA_CHUNK_CONSUMERS)(
+    'imports the resilientImport helper in %s',
+    (rel) => {
+      expect(read(rel)).toMatch(/resilientImport\b/);
+    },
+  );
+});


### PR DESCRIPTION
## Implementato

**#4176 — "Failed to fetch dynamically imported module: blog-articles-data.js"** (segnale chunk-load/CDN, prima solo monitorato).

- **Root cause:** tre componenti client lazy-caricavano il chunk non-hashed `data/blog-articles-data.ts` (servito come `cdn.frontaliereticino.ch/assets/blog-articles-data.js`) via un `import()` **nudo**. Durante una finestra di deploy CDN il vecchio URL 404 → l'errore emergeva all'utente e al monitor invece di auto-ripararsi come ogni altro dynamic import dell'app.
- **Fix (classe intera, AGENTS §6):** wrappati gli import in `services/resilientImport` (cache-bust + budgeted reload) con guardia `Array.isArray` che copre anche il caso stale mode-2 (SPA-fallback HTML 200 → modulo risolve ma export mancante). Shape dati e `.catch` esterno invariati. Consumer corretti:
  - `components/community/BlogArticles.tsx` (path `ARTICLES` + `SWISS_ARTICLES`)
  - `components/community/JobBoard.tsx` (cross-link related-articles)
  - `components/shared/SiteSearch.tsx` (search index)
  - `tests/community/BlogArticles.resilient-import.test.tsx` — nuova regression su tutti e 3 i consumer (9 assert, verdi).

Typecheck pulito sui file toccati.

Closes #4176

## Non implementato (ancora)

- **#4173 (RangeError Maximum call stack)** — indagato a fondo: nessuna ricorsione non-limitata first-party (sweep ~2677 funzioni named con self-call detection; handler globali solo report; pattern arrow/poll tutti setTimeout-driven → stack fresco). NON aggiunto deny pattern (regola conservativa: un deny message-only di un RangeError generico mascherebbe una vera ricorsione first-party). Il meccanismo sicuro è `isThirdPartyStackOnly` (stack-scoped) ma serve uno stacktrace risolto live non presente nella issue. Postato commento d'indagine su #4173 con next-step umano (query HogQL su `$exception_list[].stacktrace.frames[].filename`). Lasciato aperto (`needs-human`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJBwxi3y2iL9RzYxwrK76z)_