### PR TITLE
docs: confirm Mailgun scheduled-send lookahead is exactly 72h (issue #3798 audit)

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -53,16 +53,19 @@
 
 // scheduledSend.maxLookaheadMs is the single source of truth for how far in
 // the future a per-message `scheduledAt` may be scheduled with each provider
-// (verified against live docs 2026-07-11). Mailgun/Maileroo's real ceiling is
-// either short (3d default plan) or undocumented — clamped conservatively
-// rather than risk a silent-drop by the provider past its real limit.
+// (verified against live docs 2026-07-11). Maileroo's real ceiling is
+// undocumented — clamped conservatively rather than risk a silent-drop by
+// the provider past its real limit. Mailgun's ceiling is confirmed exact
+// (see below).
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const PROVIDERS = [
   { id: 'mailgun',  dailyLimit: 100, monthlyLimit: 3000,
     // o:deliverytime, RFC 2822 with an explicit +0000 offset (NOT toUTCString(),
-    // which emits "GMT"). Lookahead clamped to 3 days (default-plan cap; the
-    // free-plan real ceiling is unverified, so this is the conservative floor).
+    // which emits "GMT"). Lookahead clamped to 3 days — confirmed EXACT via a
+    // live API probe on 2026-07-16 (scripts/probe-mailgun-scheduled.mjs): a
+    // real +7d send to this account/domain was rejected with "scheduled
+    // delivery time must not be farther than 72h0m0s from now". Not a guess.
     scheduledSend: { param: 'o:deliverytime', maxLookaheadMs: 3 * DAY_MS } },
   // resend: paid plan activated 2026-07-06 (50000/mo, owner request), bulk
   // workhorse of the cascade. No self-imposed dailyLimit (owner request

--- a/scripts/probe-mailgun-scheduled.mjs
+++ b/scripts/probe-mailgun-scheduled.mjs
@@ -4,14 +4,20 @@
  * lookahead ceiling on the free/default plan (issue #3798, Phase 0 "Non
  * implementato" item).
  *
+ * RESOLVED 2026-07-16: real ceiling confirmed EXACT at 72h (3 days). A live
+ * `--send --days 7` against this account/domain was rejected with "scheduled
+ * delivery time must not be farther than 72h0m0s from now" — matching
+ * `scripts/lib/email-cascade.mjs` PROVIDERS.mailgun.scheduledSend.maxLookaheadMs`
+ * exactly, so no clamp change was needed. Script kept for future
+ * re-verification if Mailgun changes plan/account limits.
+ *
  * Why this exists: `docs/NEWSLETTER-SEND-TIME-PERSONALIZATION.md`'s provider
- * matrix clamps Mailgun's `o:deliverytime` lookahead to a conservative 3 days
- * (`scripts/lib/email-cascade.mjs` PROVIDERS.mailgun.scheduledSend.maxLookaheadMs`)
- * because Mailgun's own free-plan docs page for this limit returns 403 when
- * fetched programmatically — the real ceiling has never been confirmed
- * against the live account. This script sends (or dry-run previews) an
- * actual `o:deliverytime`-scheduled test message so the real limit can be
- * read off Mailgun's own accept/reject response instead of guessed.
+ * matrix clamped Mailgun's `o:deliverytime` lookahead to 3 days because
+ * Mailgun's own free-plan docs page for this limit returns 403 when fetched
+ * programmatically — the real ceiling couldn't be read from docs, only from
+ * a live send. This script sends (or dry-run previews) an actual
+ * `o:deliverytime`-scheduled test message so the real limit can be read off
+ * Mailgun's own accept/reject response instead of guessed.
  *
  * ⚠️  WARNING — `--send` fires ONE REAL EMAIL through the production Mailgun
  * account to whatever `--to` address you give it. This is a manual,


### PR DESCRIPTION
## Implementato
- Probe Mailgun reale eseguito contro l'account/dominio di produzione (`o:deliverytime` +7d, destinatario autorizzato dall'owner): l'API ha rifiutato la richiesta con `"scheduled delivery time must not be farther than 72h0m0s from now"` — conferma ESATTA che il lookahead reale è 3 giorni, identico al clamp già presente in `scripts/lib/email-cascade.mjs`. Nessun valore `maxLookaheadMs` modificato (era già corretto).
- `scripts/lib/email-cascade.mjs`: commenti aggiornati per riflettere la verifica live del 2026-07-16, rimosso il linguaggio "unverified / conservative floor" specifico per Mailgun (Maileroo resta genuinamente undocumented, invariato).
- `scripts/probe-mailgun-scheduled.mjs`: header del file aggiornato con esito RESOLVED e citazione del messaggio di rifiuto reale, per futuri lettori/re-verifiche.

## Non implementato (ancora)
Nessuno.

## Context (audit issue #3798 — nessun cambio di codice richiesto)
- Cron congestion reale (14gg / 336 campioni orari via GitHub Actions API): `send-newsletter.yml` (03:33 UTC) e `send-job-alerts.yml` (01:47 UTC) sono già nelle ore a minor congestione osservata — nessun cambio cron necessario. Corregge il contesto stale dell'issue originale (che citava job-alerts a 05:00 UTC).
- `send-hour-impact-report.yml` (cron settimanale lunedì 02:20 UTC) posta automaticamente il report su issue #3798 ad ogni run schedulata, senza intervento manuale — Fase 4 (validazione engagement) è già auto-sufficiente, resta solo il tempo (soglia n≥100 sulla coorte `personal`, stima ~2026-07-26).
- Item 1 di follow-up issue 4116 risolto da questa PR (dettagli nel commento sull'issue). Item 2 di issue 4116 e l'item di issue 4187 restano `blocked` su soglia dati reale (non rimovibile, richiede solo tempo) — non toccati da questa PR, infra di tracking già confermata self-sufficient.

## Test plan
- [x] `npx vitest run tests/email-cascade-scheduling.test.ts tests/email-cascade-burst.test.ts tests/send-schedule.test.ts tests/preferred-send-hour.test.ts` — tutti verdi
- [x] Probe reale eseguito con esito definitivo (non simulato)