### PR TITLE
fix(seo): scope TI sector-hub pages to canton Ticino only

### DIFF
--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -309,12 +309,15 @@ jobs:
           PID_GSC=$!
           timeout 90 node scripts/verify-post-deploy-seo.mjs &
           PID_SEO=$!
+          timeout 90 npx tsx scripts/monitor-ti-sector-coverage.mjs &
+          PID_TI_SECTOR=$!
 
           FAIL=0
           wait $PID_GOOGLE  || { echo "⚠️ Google Indexing API failed"; FAIL=1; }
           wait $PID_INDEXNOW || { echo "⚠️ IndexNow submission failed"; FAIL=1; }
           wait $PID_GSC     || { echo "⚠️ GSC submission failed"; FAIL=1; }
           wait $PID_SEO     || { echo "⚠️ Post-deploy SEO verification failed"; FAIL=1; }
+          wait $PID_TI_SECTOR || { echo "⚠️ TI sector coverage check failed"; FAIL=1; }
 
           if [ $FAIL -ne 0 ]; then
             echo "::warning::Some post-deploy indexing steps failed (non-blocking)"

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -2,9 +2,10 @@
  * Vite build plugin that emits static HTML for the 3 sector-based job hubs
  * (Infermieri / Case Anziani / Educatori) in all 4 locales — 12 pages total.
  *
- * Filters `data/jobs.json` by sector keyword pattern (title/description/
- * category/tags) and emits a dedicated landing that consolidates the signal
- * for high-intent GSC queries that currently land on random job detail pages.
+ * Filters `data/jobs.json` to canton TI (via `resolveJobCanton`), then by
+ * sector keyword pattern (title/description/category/tags), and emits a
+ * dedicated landing that consolidates the signal for high-intent GSC queries
+ * that currently land on random job detail pages.
  *
  * Writes `sitemap-sector.xml` and patches `sitemap.xml`.
  *
@@ -62,6 +63,7 @@ import { SECTOR_HUB_EMOJI } from './shared/sectorHubEmoji';
 import { shouldEmitLocale } from './shared/localeEmitFilter';
 import { resolveSectorPagesFlushed } from './shared/buildSignals';
 import { SECTOR_HUB_SIBLINGS } from './shared/sectorHubClusters';
+import { resolveJobCanton as sharedResolveJobCanton } from './shared/cantonSection';
 
 const LOCALES: ReadonlyArray<JobBoardLocale> = ['it', 'en', 'de', 'fr'];
 
@@ -483,6 +485,11 @@ export function jobSectorPagesPlugin(rootDir: string): Plugin {
       } catch (err) {
         console.warn('[job-sector-pages] failed to read data/jobs.json', err);
       }
+
+      // These pages are branded "Cerca lavoro in Ticino" — scope to TI jobs only.
+      // Without this, sector counts/listings ingest every canton in Switzerland
+      // (same bug class as #3232, fixed for employer hubs in jobsSeoPagesPlugin.ts).
+      jobs = jobs.filter((job) => sharedResolveJobCanton(job) === 'TI');
 
       const counts = countSectorJobsByLocale(jobs);
       const sectorProseData = loadSectorProseData(rootDir);

--- a/scripts/monitor-ti-sector-coverage.mjs
+++ b/scripts/monitor-ti-sector-coverage.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * monitor-ti-sector-coverage.mjs — Post-deploy check for TI sector-hub pages
+ * (`/cerca-lavoro-ticino/{sector}/`) with zero real Ticino job matches.
+ *
+ * These pages have no job-count floor (owner decision 2026-07-16: stay
+ * live/indexed even at 0 jobs — curated prose keeps them above the
+ * thin-content word floor). A sector stuck at 0 real TI jobs is still worth
+ * tracking: it usually signals a crawler-coverage gap for that vertical
+ * (see #3337) rather than a genuine absence of demand. This opens/updates a
+ * single tracking issue instead of silently letting the gap go unnoticed.
+ *
+ * Reuses the real build-time canton resolver (cantonResolvers.mjs) and
+ * sector counter (countSectorJobsByLocale from jobSectorLanding.ts) — same
+ * source the SSG plugin uses — so this can never drift from what the live
+ * pages actually show.
+ *
+ * Always exits 0 — non-blocking, alerting only.
+ * Usage: npx tsx scripts/monitor-ti-sector-coverage.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const JOBS_PATH = path.join(REPO_ROOT, 'public/data/jobs.json');
+
+function log(emoji, msg) {
+  console.log(`${emoji} ${msg}`);
+}
+
+async function main() {
+  if (!fs.existsSync(JOBS_PATH)) {
+    log('⚠️', `${JOBS_PATH} not present — skipping TI sector coverage check`);
+    return;
+  }
+
+  const cantonSlugFile = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, 'data/canton-url-slugs.json'), 'utf8'),
+  );
+  const municipalitiesFile = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, 'data/canton-municipalities.json'), 'utf8'),
+  );
+  const { createCantonResolvers } = await import(
+    path.join(REPO_ROOT, 'build-plugins/shared/cantonResolvers.mjs')
+  );
+  const { resolveJobCanton } = createCantonResolvers({ cantonSlugFile, municipalitiesFile });
+
+  const { SECTOR_HUB_KEYS, countSectorJobsByLocale } = await import(
+    path.join(REPO_ROOT, 'build-plugins/jobSectorLanding.ts')
+  );
+
+  const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
+  const tiJobs = jobs.filter((job) => resolveJobCanton(job) === 'TI');
+  const counts = countSectorJobsByLocale(tiJobs);
+
+  const zeroSectors = SECTOR_HUB_KEYS.filter((sector) => (counts.it?.[sector] ?? 0) === 0);
+
+  if (zeroSectors.length === 0) {
+    log('✅', 'All TI sector-hub pages have >=1 real job match.');
+    return;
+  }
+
+  log('⚠️', `${zeroSectors.length} TI sector(s) with 0 real job matches: ${zeroSectors.join(', ')}`);
+
+  const runUrl = process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+    ? `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : '(local run)';
+
+  const description = `## Sector TI a 0 match reali
+
+Le seguenti pagine \`/cerca-lavoro-ticino/{settore}/\` non hanno **nessuna offerta reale** per il canton Ticino in questo deploy. La pagina resta live/indicizzata (decisione owner 2026-07-16: nessuna soglia minima per i settori TI), ma il gap va investigato:
+
+${zeroSectors.map((s) => `- \`/cerca-lavoro-ticino/${s}/\``).join('\n')}
+
+**Possibili cause da verificare:**
+- Gap di copertura crawler per questo settore/vertical (vedi #3337 — backlog aziende svizzere non ancora crawlate)
+- Regex \`SECTOR_MATCHERS\` (\`build-plugins/jobSectorLanding.ts\`) troppo stretta rispetto ai titoli/categorie reali del settore
+- Domanda di lavoro genuinamente scarsa in Ticino per questo settore (verificare vs. altri cantoni)
+
+**Run:** ${runUrl}
+**Totale job TI (raw, ${'canton==TI'}):** ${tiJobs.length}`;
+
+  execFileSync('node', [
+    path.join(REPO_ROOT, 'scripts/lib/github-issue-creator.mjs'),
+    '--title', 'TI sector coverage: settori a 0 match reali',
+    '--description', description,
+    '--priority', '3',
+    '--label', 'bug',
+    '--label', 'funnel-seo',
+    '--workflow', 'Post-deploy Publish (side-effects + mark good)',
+  ], { stdio: 'inherit' });
+}
+
+main().catch((err) => {
+  console.error('[monitor-ti-sector-coverage] unexpected error (non-blocking):', err);
+});

--- a/tests/ti-sector-hub-canton-scope.test.ts
+++ b/tests/ti-sector-hub-canton-scope.test.ts
@@ -1,0 +1,52 @@
+/**
+ * TI sector-hub canton-scope regression guard.
+ *
+ * /cerca-lavoro-ticino/{sector}/ pages are branded Ticino-only. Without a
+ * canton filter, jobSectorPagesPlugin.ts counted/listed every canton in
+ * Switzerland under a TI-branded URL — fixed alongside this test (same bug
+ * class as #3232, previously fixed for employer hubs in jobsSeoPagesPlugin.ts).
+ *
+ * Reads the CI-assembled data/jobs.json (gitignored, rebuilt before vitest by
+ * tests.yml — same dependency as canton-ti-misclassification-guard.test.ts).
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveJobCanton } from '@/build-plugins/shared/cantonSection';
+import { SECTOR_HUB_KEYS, countSectorJobsByLocale } from '@/build-plugins/jobSectorLanding';
+
+const DATA_JOBS_PATH = path.resolve(__dirname, '..', 'data', 'jobs.json');
+const jobs: Array<{ canton?: string; location?: string }> = JSON.parse(
+  fs.readFileSync(DATA_JOBS_PATH, 'utf-8'),
+);
+
+describe('ti-sector-hub-canton-scope', () => {
+  it('TI sector-hub counts reflect canton=TI jobs only, not all of Switzerland', () => {
+    const tiJobs = jobs.filter((job) => resolveJobCanton(job) === 'TI');
+    expect(tiJobs.length).toBeGreaterThan(0);
+    expect(tiJobs.length).toBeLessThan(jobs.length);
+
+    const tiCounts = countSectorJobsByLocale(tiJobs as never);
+    const allChCounts = countSectorJobsByLocale(jobs as never);
+
+    // At least one sector must show fewer TI-only matches than all-Switzerland
+    // matches — proves the filter is load-bearing, not a no-op. If every
+    // sector goes flat (tiCounts === allChCounts everywhere), the canton
+    // filter has silently regressed back to counting the whole country.
+    const narrowedSectors = SECTOR_HUB_KEYS.filter(
+      (sector) => tiCounts.it[sector] < allChCounts.it[sector],
+    );
+    expect(
+      narrowedSectors.length,
+      'No sector shows a narrower TI-only count than all-Switzerland — the TI canton filter may have regressed',
+    ).toBeGreaterThan(0);
+
+    // No TI sector-hub count may exceed the total TI job pool.
+    for (const sector of SECTOR_HUB_KEYS) {
+      expect(
+        tiCounts.it[sector],
+        `${sector} TI-scoped count exceeds the total TI job pool`,
+      ).toBeLessThanOrEqual(tiJobs.length);
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

- `build-plugins/jobSectorPagesPlugin.ts`: `/cerca-lavoro-ticino/{sector}/` sector-hub pages were counting/listing jobs from **all of Switzerland**, not just canton Ticino (root cause of the reported "105 offerte" showing non-TI jobs on `educatori`). Added a `jobs.filter((job) => sharedResolveJobCanton(job) === 'TI')` pass in `closeBundle()` before `countSectorJobsByLocale(jobs)`, reusing the same `resolveJobCanton` primitive already used for the equivalent employer-hub fix (#3232, `jobsSeoPagesPlugin.ts:3768`).
- **No job-count floor introduced.** Per explicit owner decision, TI sector pages stay live/indexed at any count, including 0 — verified the existing template already degrades gracefully at 0 jobs (empty-state copy, stat tiles, CTA fallback) and the `padToMinWords(..., 210)` prose padding already satisfies the thin-content floor (AGENTS.md Non-Negotiable #4) independent of job count. No code change was needed for this part; confirmed by reading `build-plugins/jobSectorLanding.ts`.
- **Undercount verification**: checked whether low/zero counts (`agricoltura`, `autisti`=1, `sicurezza`=1) reflect a matching bug vs. genuine scarcity. `resolveJobCanton` confirmed correct (100% of current TI jobs use the explicit `job.canton === 'TI'` path, no faulty location-inference fallback in play). The counts are real — not a matching defect — but persistently-zero sectors likely indicate a **crawler-coverage gap** (see `scripts/monitor-ti-sector-coverage.mjs` below and #3337).
- `scripts/monitor-ti-sector-coverage.mjs` (new): post-deploy check that recomputes real TI-only sector counts from the deployed `data/jobs.json` (same `resolveJobCanton` + `countSectorJobsByLocale` primitives as the build plugin, so it can't drift from what the live pages show) and opens/updates a single tracking issue whenever a sector nets 0 real TI jobs. Wired into `.github/workflows/post-deploy-publish.yml`'s existing parallel post-deploy indexing block, reusing the `jobs-master` artifact already staged there — no new data fetch. Non-blocking (always exits 0), dedup-safe via `github-issue-creator.mjs`'s title-prefix matching.
  - Validated end-to-end during local testing (unintentionally live, since an empty `GH_TOKEN` didn't block `gh`'s cached auth as expected): it correctly flagged **`agricoltura`** as the only 0-match TI sector and correctly did *not* flag `autisti`/`sicurezza` (count=1, not 0) — see issue #4253, already live, content verified accurate. Future runs will dedup onto it via title-prefix match instead of duplicating.
- `tests/ti-sector-hub-canton-scope.test.ts` (new): regression guard asserting (a) TI-only sector counts are strictly narrower than all-Switzerland counts for at least one sector (catches silent removal/regression of the canton filter), and (b) no TI sector count exceeds the total TI job pool. Follows the `tests/canton-ti-misclassification-guard.test.ts` convention (reads CI-assembled `data/jobs.json` unconditionally — can't run locally without the CI dataset assembly step, same known limitation as its precedent).
- GitNexus `impact()` on `jobSectorPagesPlugin`: **LOW risk**, single direct caller (`vite.config.ts`), 0 processes/modules affected.
- `tsc --noEmit`: same 205 pre-existing baseline errors, none in touched files.
- Existing suites re-verified green after the edit: `tests/job-sector-landing.test.ts` (128 tests), `tests/seo/cathedral-no-ti-hardcodes.test.ts` (5 tests).

## Non implementato (ancora)

Nessuno.

Sibling-pattern-fix check (`check-sibling-patterns.mjs`) surfaced 2 candidates sharing the `sharedResolveJobCanton` construct — both individually inspected and confirmed **false positive**:
- `build-plugins/jobsSeoPagesPlugin.ts` — falso positivo: è il file SORGENTE del pattern (fix #3232 di riferimento a riga 3768), filtra già correttamente per canton ovunque; nessun loop TI-branded non filtrato.
- `scripts/build-cf-hot-404s.mjs` — falso positivo: `sharedResolveJobCanton` appare solo in un commento esplicativo, nessuna chiamata reale né logica di conteggio/listing non filtrata.

## Test plan

- [x] `npx tsc --noEmit` — no new errors vs. baseline
- [x] `npx vitest run tests/job-sector-landing.test.ts tests/seo/cathedral-no-ti-hardcodes.test.ts` — 133/133 pass
- [x] `npx vitest run tests/ti-sector-hub-canton-scope.test.ts` — resolves/imports correctly locally (fails only on missing CI-assembled `data/jobs.json`, expected per precedent); will run for real in CI
- [x] `check-sibling-patterns.mjs` — 2 candidates, both false positives, justified above
- [ ] Live verification post-merge: `curl https://frontaliereticino.ch/cerca-lavoro-ticino/educatori/` shows only TI jobs and a corrected count
