### PR TITLE
fix(newsletter): route List-Unsubscribe one-click to Cloud Function, not SPA

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -450,7 +450,7 @@ export const newsletterManageSubscription = onRequest(
  return;
  }
 
- const params = req.method === 'GET' ? req.query : req.body;
+ const params = req.method === 'GET' ? req.query : { ...req.query, ...req.body };
  const action = String(params.action || '').trim().toLowerCase();
  const email = String(params.email || '').trim();
  const token = String(params.token || '').trim();

--- a/functions/src/newsletterSubscriptionManagement.js
+++ b/functions/src/newsletterSubscriptionManagement.js
@@ -15,6 +15,11 @@ import { ensureAdminApp, getAdminDb } from './newsletterResendWebhookCore.js';
 import { t, htmlLang, normalizeLocale } from './emailI18n.js';
 
 const BASE_URL = 'https://frontaliereticino.ch';
+// Proxied by the CF Worker straight to this function (see UNSUB_PROXIES in
+// infra/cloudflare-worker/locale-router.js) — bypasses the SPA/index.html
+// catch-all so the confirmation page's own resubscribe link doesn't loop
+// back into the `ac`-autologin dead end (App.tsx rejects a plain token link).
+const ONE_CLICK_BASE_URL = `${BASE_URL}/disiscrivi-newsletter/`;
 const BRAND_BLUE = '#2563EB';
 const BRAND_DARK = '#0f172a';
 const LIGHT_BG = '#f3f4f6';
@@ -44,7 +49,7 @@ function buildResponseHtml({ title, message, showResubscribe, email, token, loca
  const resubscribeBlock = showResubscribe
  ? `<table width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
  <tr><td align="center">
- <a href="${BASE_URL}/?action=resubscribe&email=${encodeURIComponent(email)}&token=${token}&lang=${lang}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:14px 28px;border-radius:12px;font-size:15px;font-weight:700;">
+ <a href="${ONE_CLICK_BASE_URL}?action=resubscribe&email=${encodeURIComponent(email)}&token=${token}&lang=${lang}" style="display:inline-block;background:${BRAND_BLUE};color:#ffffff;text-decoration:none;padding:14px 28px;border-radius:12px;font-size:15px;font-weight:700;">
  ${t(lang, 'manageResubscribeLink')}
  </a>
  </td></tr>

--- a/infra/cloudflare-worker/locale-router.js
+++ b/infra/cloudflare-worker/locale-router.js
@@ -134,6 +134,7 @@ const CF_FN_BASE = 'https://europe-west6-frontaliere-ticino.cloudfunctions.net';
 const UNSUB_PROXIES = {
   '/disiscrivi-alert': `${CF_FN_BASE}/jobAlertUnsubscribe`,
   '/disiscrivi-outreach': `${CF_FN_BASE}/outreachUnsubscribe`,
+  '/disiscrivi-newsletter': `${CF_FN_BASE}/newsletterManageSubscription`,
 };
 
 // Returns the upstream Cloud Function origin for an unsubscribe path (bare or

--- a/infra/cloudflare-worker/wrangler.toml
+++ b/infra/cloudflare-worker/wrangler.toml
@@ -75,6 +75,20 @@ routes = [
   # emitted link carries `?c=…&t=…`, so a non-wildcard route would silently miss
   # all real traffic (#2611). Look-alike paths rejected by the in-code guard.
   { pattern = "frontaliereticino.ch/disiscrivi-outreach*", zone_name = "frontaliereticino.ch" },
+  # Newsletter one-click unsubscribe (RFC 8058). Same deliberate non-locale
+  # exception as /disiscrivi-alert above: the List-Unsubscribe header in
+  # newsletter emails MUST live on the sending domain (frontaliereticino.ch)
+  # or the URL↔From-domain mismatch trips spam filters. Previously the header
+  # pointed at the apex root (`/`), which Firebase Hosting's catch-all always
+  # serves as the SPA (index.html) — the Cloud Function was never reached, and
+  # the SPA itself rejects the plain token-only link for lack of an `ac`
+  # autologin credential. This dedicated path bypasses both: the Worker
+  # proxies it straight to the newsletterManageSubscription Cloud Function
+  # (in-code UNSUB_PROXIES branch — method + query + body preserved for the
+  # one-click POST). WILDCARD required: every emitted link carries
+  # `?action=…&email=…&token=…`, so a non-wildcard route would silently miss
+  # all real traffic (#2611). Look-alike paths rejected by the in-code guard.
+  { pattern = "frontaliereticino.ch/disiscrivi-newsletter*", zone_name = "frontaliereticino.ch" },
   # NOTE: the /assets/* /data/* /og/* CDN-proxy routes were removed (2026-06-10).
   # Since #1665 the shard locale HTML references those static paths CDN-absolute
   # (cdn.frontaliereticino.ch/...), so the browser fetches them straight from the

--- a/scripts/blast-publisher-ads.mjs
+++ b/scripts/blast-publisher-ads.mjs
@@ -24,6 +24,7 @@ import { matchSubscribersForAd } from '../services/publisherBlastMatch.mjs';
 import { OWNER_EMAIL, isCanaryJob } from './lib/canaryAd.mjs';
 import { buildBlastEmail } from '../services/publisherBlastEmail.mjs';
 import { slugifyPublisher, truncatePublisherSlug, distinctLocations } from './lib/publisherJobProjection.mjs';
+import { makeAuthenticatedActionUrl } from '../services/newsletterUrls.mjs';
 
 const SEND = process.argv.includes('--send');
 const PER_AD_CAP = 200;   // max recipients per ad
@@ -129,7 +130,7 @@ async function main() {
         recipientEmail: r.email,
         locale,
         adUrl: adUrlFor(locale),
-        unsubscribeUrl: `${SITE}/?action=unsubscribe&email=${encodeURIComponent(r.email)}`,
+        unsubscribeUrl: makeAuthenticatedActionUrl('unsubscribe', r.email),
         // Same label the CTA slug is built from → card city and linked page agree.
         locationLabel: firstLocationLabel,
       });

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -43,7 +43,7 @@ import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib
 import { refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { NEWSLETTER_EXCLUDED_STATUSES } from '../services/emailSuppression.mjs';
-import { makeUnsubscribeUrl, makeResubscribeUrl, generateAutologinCode } from '../services/newsletterUrls.mjs';
+import { makeUnsubscribeUrl, makeResubscribeUrl, makeOneClickUnsubscribeUrl, generateAutologinCode } from '../services/newsletterUrls.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { getCascadeDailyCapacity, finiteDailyLimit, PROVIDERS as EMAIL_PROVIDERS } from './lib/email-cascade.mjs';
@@ -1364,7 +1364,7 @@ function buildEmailHeaders(email, campaign) {
   const campaignKey = slugifyHeaderValue(campaign);
   const emailKey = Buffer.from(String(email).toLowerCase()).toString('hex').slice(0, 24);
   return {
-    'List-Unsubscribe': `<${makeUnsubscribeUrl(email)}>, <${makeMailtoUnsubscribe(email)}>`,
+    'List-Unsubscribe': `<${makeOneClickUnsubscribeUrl(email)}>, <${makeMailtoUnsubscribe(email)}>`,
     'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
     'List-ID': `Frontaliere Weekly <weekly.frontaliereticino.ch>`,
     'Feedback-ID': `${campaignKey}:frontaliere-weekly:frontaliere-ticino`,

--- a/services/newsletterUrls.mjs
+++ b/services/newsletterUrls.mjs
@@ -14,6 +14,12 @@ import { createHmac } from 'node:crypto';
 // Canonical prod domain (no www) — matches BASE_URL in send-newsletter.mjs.
 const BASE_URL = 'https://frontaliereticino.ch';
 
+// Dedicated path proxied straight to the newsletterManageSubscription Cloud
+// Function by the CF Worker (infra/cloudflare-worker/locale-router.js) — bypasses
+// the SPA/index.html catch-all and its `ac` autologin requirement entirely, so
+// both a mail client's automated POST and a manual GET click work end-to-end.
+const ONE_CLICK_BASE_URL = `${BASE_URL}/disiscrivi-newsletter/`;
+
 function signedEmailToken(email) {
   const secret = process.env.NEWSLETTER_SECRET;
   if (!secret) return null;
@@ -22,11 +28,26 @@ function signedEmailToken(email) {
 
 /**
  * @param {string} email
- * @returns {string} one-click unsubscribe URL (RFC 8058 List-Unsubscribe target)
+ * @returns {string} unsubscribe URL for links the SPA processes client-side
+ * (e.g. the email body footer link, which gets the `ac` autologin code
+ * injected separately at send time). NOT a valid List-Unsubscribe header
+ * target — use makeOneClickUnsubscribeUrl for that.
  */
 export function makeUnsubscribeUrl(email) {
   const token = signedEmailToken(email);
   const base = `${BASE_URL}/?action=unsubscribe&email=${encodeURIComponent(email)}`;
+  return token ? `${base}&token=${token}` : base;
+}
+
+/**
+ * @param {string} email
+ * @returns {string} the actual RFC 8058 List-Unsubscribe one-click target —
+ * routed directly to the Cloud Function (GET and POST), no SPA/autologin
+ * dependency. Use this for the List-Unsubscribe header only.
+ */
+export function makeOneClickUnsubscribeUrl(email) {
+  const token = signedEmailToken(email);
+  const base = `${ONE_CLICK_BASE_URL}?action=unsubscribe&email=${encodeURIComponent(email)}`;
   return token ? `${base}&token=${token}` : base;
 }
 

--- a/services/winbackEmail.mjs
+++ b/services/winbackEmail.mjs
@@ -11,7 +11,7 @@
  * Pure + dependency-light (only the shared HMAC URL builders) so it is unit
  * testable. Table-based inline-styled HTML for email-client compatibility.
  */
-import { makeUnsubscribeUrl, makeAuthenticatedActionUrl } from './newsletterUrls.mjs';
+import { makeAuthenticatedActionUrl, makeOneClickUnsubscribeUrl } from './newsletterUrls.mjs';
 
 // Brand tokens — kept in sync with services/newsletter-template.mjs.
 const BRAND_ORANGE = '#f97316'; // accent / wordmark
@@ -85,8 +85,9 @@ export function buildWinbackEmail({ email, locale = 'it' }) {
   // action instead of rejecting with "Link non valido".
   const stayUrl = makeAuthenticatedActionUrl('resubscribe', email);
   const footerUnsubUrl = makeAuthenticatedActionUrl('unsubscribe', email);
-  // Header List-Unsubscribe uses the token form (RFC 8058 one-click endpoint).
-  const unsubscribeUrl = makeUnsubscribeUrl(email);
+  // Header List-Unsubscribe uses the dedicated one-click endpoint (RFC 8058) —
+  // proxied straight to the Cloud Function, bypassing the SPA's `ac` requirement.
+  const unsubscribeUrl = makeOneClickUnsubscribeUrl(email);
 
   const html = `<!DOCTYPE html>
 <html lang="${l}">

--- a/tests/newsletter-unsubscribe-oneclick.test.ts
+++ b/tests/newsletter-unsubscribe-oneclick.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHmac } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { makeOneClickUnsubscribeUrl, makeUnsubscribeUrl } from '../services/newsletterUrls.mjs';
+import { handleSubscriptionManagement } from '../functions/src/newsletterSubscriptionManagement.js';
+
+// The newsletter's List-Unsubscribe header previously pointed at the apex root
+// (`/?action=unsubscribe&...`), which Firebase Hosting's catch-all always serves
+// as the SPA — the Cloud Function was never reached (POST 405), and the SPA
+// itself rejects a plain token-only link for lack of an `ac` autologin
+// credential (GET also failed, silently, with "Link non valido"). Fixed by a
+// dedicated /disiscrivi-newsletter/ path proxied straight to the Cloud
+// Function, mirroring the already-working /disiscrivi-alert pattern.
+describe('newsletter unsubscribe — one-click link routes to the Cloud Function, not the SPA', () => {
+  let prevSecret: string | undefined;
+  beforeEach(() => {
+    prevSecret = process.env.NEWSLETTER_SECRET;
+    process.env.NEWSLETTER_SECRET = 'test-secret-for-unsub-urls';
+  });
+  afterEach(() => {
+    if (prevSecret === undefined) delete process.env.NEWSLETTER_SECRET;
+    else process.env.NEWSLETTER_SECRET = prevSecret;
+  });
+
+  it('makeOneClickUnsubscribeUrl uses the dedicated apex path, not the SPA root', () => {
+    const url = makeOneClickUnsubscribeUrl('user@example.com');
+    expect(url).toMatch(/^https:\/\/frontaliereticino\.ch\/disiscrivi-newsletter\/\?/);
+    expect(url).toContain('action=unsubscribe');
+    expect(url).toContain('token=');
+    expect(url).not.toContain('cloudfunctions.net');
+  });
+
+  it('makeUnsubscribeUrl (footer/SPA link) stays on the root path — unchanged for the working autologin flow', () => {
+    const url = makeUnsubscribeUrl('user@example.com');
+    expect(url).toMatch(/^https:\/\/frontaliereticino\.ch\/\?action=unsubscribe/);
+  });
+
+  it('newsletterManageSubscription reads identifiers from the query on POST (one-click works)', () => {
+    // RFC 8058 one-click POST carries action/email/token in the query string,
+    // not the body (the body is only `List-Unsubscribe=One-Click`) — so the
+    // function MUST merge the query into POST params or the one-click verifies
+    // an empty token (403) and never unsubscribes.
+    const src = fs.readFileSync(path.resolve(__dirname, '../functions/index.js'), 'utf8');
+    const handler = src.slice(src.indexOf('export const newsletterManageSubscription'));
+    expect(handler).toMatch(
+      /req\.method === 'GET' \? req\.query : \{\s*\.\.\.req\.query,\s*\.\.\.req\.body\s*\}/,
+    );
+  });
+
+  it('the locale-router Worker proxies /disiscrivi-newsletter to newsletterManageSubscription (no drift)', () => {
+    const worker = fs.readFileSync(
+      path.resolve(__dirname, '../infra/cloudflare-worker/locale-router.js'),
+      'utf8',
+    );
+    expect(worker).toMatch(
+      /'\/disiscrivi-newsletter':\s*`?\$\{CF_FN_BASE\}\/newsletterManageSubscription`?/,
+    );
+    const wrangler = fs.readFileSync(
+      path.resolve(__dirname, '../infra/cloudflare-worker/wrangler.toml'),
+      'utf8',
+    );
+    // Wildcard required: every emitted link carries `?action=…&email=…&token=…`.
+    expect(wrangler).toContain('frontaliereticino.ch/disiscrivi-newsletter*');
+  });
+
+  it('the confirmation page\'s own resubscribe link also targets the dedicated path (no dead-end loop)', async () => {
+    const db = {
+      collection: () => ({
+        doc: () => ({
+          get: async () => ({ exists: true, data: () => ({ status: 'confirmed', isActive: true }) }),
+          set: async () => {},
+          collection: () => ({ add: async () => {} }),
+        }),
+      }),
+    };
+    const token = createHmac('sha256', 'test-secret-for-unsub-urls')
+      .update('user@example.com')
+      .digest('hex');
+    const result = await handleSubscriptionManagement({
+      action: 'unsubscribe',
+      email: 'user@example.com',
+      token,
+      locale: 'it',
+      secret: 'test-secret-for-unsub-urls',
+      db: db as any,
+    });
+    expect(result.html).toContain('/disiscrivi-newsletter/?action=resubscribe');
+    expect(result.html).not.toMatch(/href="https:\/\/frontaliereticino\.ch\/\?action=resubscribe/);
+  });
+});


### PR DESCRIPTION
## Implementato

- `services/newsletterUrls.mjs`: nuovo `makeOneClickUnsubscribeUrl(email)` — costruisce l'URL RFC 8058 dedicato (`/disiscrivi-newsletter/?action=unsubscribe&email=...&token=...`), distinto dal link SPA esistente `makeUnsubscribeUrl` (che resta invariato, usato solo nel footer body dove serve l'`ac` autologin).
- `infra/cloudflare-worker/locale-router.js` + `wrangler.toml`: wired `/disiscrivi-newsletter` in `UNSUB_PROXIES`, proxato direttamente a `newsletterManageSubscription` (stesso pattern già funzionante di `/disiscrivi-alert`/`/disiscrivi-outreach`). Prima il link header puntava alla root apex, servita SEMPRE dalla SPA (catch-all Firebase Hosting) — la Cloud Function non veniva mai raggiunta.
- `functions/index.js:453`: fix del merge `req.query`/`req.body` su POST (`newsletterManageSubscription`) — allineato ai due sibling già corretti (righe 699/746). Senza questo fix, il POST one-click (che porta i parametri in query string, non nel body) verificava un token vuoto → 403, unsubscribe mai eseguito.
- `functions/src/newsletterSubscriptionManagement.js`: il link di resubscribe nella pagina di conferma (`buildResponseHtml`) ora punta anch'esso al path dedicato — prima rientrava nello stesso dead-end SPA/`ac`.
- `scripts/send-newsletter.mjs` + `services/winbackEmail.mjs`: header `List-Unsubscribe` di entrambi i sender ora usa `makeOneClickUnsubscribeUrl`. Il body-footer link (che richiede `ac` autologin, iniettato via `personalizeHtmlWithToken`) resta invariato — continua a funzionare via SPA come prima.
- `scripts/blast-publisher-ads.mjs`: il link di unsubscribe (bug trovato en passant) non portava alcun token — chiunque poteva disiscrivere qualsiasi email indovinandola. Ora usa `makeAuthenticatedActionUrl('unsubscribe', email)`.
- `tests/newsletter-unsubscribe-oneclick.test.ts` (nuovo, 5 test): copre URL builder, merge query/body POST, wiring Worker↔Cloud Function, e il link di resubscribe nella pagina di conferma.

Test: 151 test mirati sui 9 file toccati + suite intera post `assemble-jobs-dataset.mjs` (78.886 passed, 0 failed — i 7 file rossi visti su worktree fresh erano solo `data/jobs.json` mancante, pre-esistente e non correlato).

## Non implementato (ancora)

Nessuna feature/scope residuo. `check-sibling-patterns.mjs` ha segnalato 12 candidati — ispezionati singolarmente (non dismissal collettivo), tutti falsi positivi:

- `scripts/newsletter-template.mjs` — falso positivo: `unsubscribeUrl` è un parametro ricevuto (template puro), non costruisce/instrada nulla; il chiamante (`send-newsletter.mjs`, già fixato) passa l'URL.
- `scripts/send-job-alerts.mjs` — falso positivo: schema job-alert (`makeAlertUnsubscribeUrl`), già instradato correttamente su `/disiscrivi-alert` — dominio diverso dal bug newsletter, nessun apex-root dead-end da fixare.
- `components/preferences/SubscriptionPreferencesController.tsx` — falso positivo: menzione in un commento (`newsletterManageSubscription`), nessuna costruzione di URL duplicata.
- `functions/src/newsletterConfirmationEmail.js` — falso positivo: `BRAND_BLUE` è solo un token colore condiviso, non riguarda instradamento unsubscribe.
- `functions/src/sendCalculatorReport.js` — falso positivo: stesso motivo, `BRAND_BLUE` è un token colore.
- `scripts/cf-locale-failover-setup.mjs` — falso positivo: gestisce cache-rules/fail-open per TUTTE le route del Worker `frontaliere-locale-router` in blocco (non un elenco per-path); la nuova route `/disiscrivi-newsletter*` la eredita automaticamente via `wrangler deploy` (che risincronizza le route da `wrangler.toml`), nessun elenco hardcoded da aggiornare qui.
- `scripts/newsletter-qa.mjs` — falso positivo: URL hardcoded solo per QA preview locale (`qa-preview@frontaliereticino.ch`), mai inviato/POSTato realmente — non soggetto al bug (routing header + merge POST) che riguarda solo invii reali.
- `scripts/newsletter-sunset.mjs` — falso positivo: consumer passthrough di `unsubscribeUrl` restituito da `buildWinbackEmail()` (già fixato in questa PR in `services/winbackEmail.mjs`).
- `services/newsletter-template.mjs` — falso positivo: `renderFooter` riceve `unsubscribeUrl` come parametro (link footer-body, intenzionalmente invariato — richiede `ac` autologin via SPA, non è il link header one-click).
- `services/newsletterPreview.ts` — falso positivo: URL hardcoded solo per preview UI di sviluppo, mai inviato realmente.
- `services/newsletterSubscribers.ts` — falso positivo: chiama l'endpoint `newsletterManageSubscription` come API autenticata-sessione dalla SPA (fetch diretto), non costruisce/instrada un link email.
- `services/publisherBlastEmail.mjs` — falso positivo: consumer passthrough di `unsubscribeUrl` ricevuto come parametro da `blast-publisher-ads.mjs` (già fixato in questa PR).

Nota: il pre-push hook `.githooks/pre-push` non era wired in questo worktree (`core.hooksPath` puntava a `.git/hooks`, non `.githooks` — probabilmente perché `npm ci`/`install` non è mai girato in questo worktree fresh, quindi lo script `prepare` non ha settato l'hook). Ho rieseguito `node scripts/ci/check-sibling-patterns.mjs` manualmente per compensare, con lo stesso risultato (12/12 falsi positivi documentati sopra).
