### PR TITLE
fix(job-alerts): detect expired job pages via body marker, not HTTP status

### DIFF
--- a/scripts/check-journalist-article-links.mjs
+++ b/scripts/check-journalist-article-links.mjs
@@ -8,9 +8,13 @@
  * concept of an individual journalist_articles Firestore doc. This script
  * instead crawls each PUBLISHED journalist article's live URLs (one per
  * locale) straight from Firestore `publishedUrls`, fetches the live HTML,
- * extracts same-origin links, HEAD-checks them with a small concurrency cap,
- * and writes the result back onto the doc so the dashboard can surface
- * "3 broken links" without a human re-checking manually.
+ * extracts same-origin links, checks each via checkPageBodyLive (GET + the
+ * expired-job soft-landing marker, not just HTTP status — see issue #3172 /
+ * scripts/lib/live-link-check.mjs; a plain HEAD/status check can't see a
+ * since-expired job link because the site's soft-404 policy always 200s it)
+ * with a small concurrency cap, and writes the result back onto the doc so
+ * the dashboard can surface "3 broken links" without a human re-checking
+ * manually.
  *
  * Result is a SINGLE aggregate across all locale pages, not one per locale
  * (was: `linkCheck.<locale>`). Each locale page carries the same site chrome
@@ -43,7 +47,7 @@
  */
 
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { checkLink, runWithConcurrency } from './lib/live-link-check.mjs';
+import { checkPageBodyLive, runWithConcurrency } from './lib/live-link-check.mjs';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 const FETCH_TIMEOUT_MS = 10_000;
@@ -96,7 +100,7 @@ async function checkPageLinks(pageUrl) {
   const brokenUrls = [];
   let brokenCount = 0;
   await runWithConcurrency(links, HEAD_CONCURRENCY, async (url) => {
-    const ok = await checkLink(url, HEAD_TIMEOUT_MS);
+    const ok = await checkPageBodyLive(url, HEAD_TIMEOUT_MS);
     if (ok) return;
     brokenCount += 1;
     if (brokenUrls.length < MAX_BROKEN_URLS_STORED) brokenUrls.push(url);

--- a/scripts/lib/live-link-check.mjs
+++ b/scripts/lib/live-link-check.mjs
@@ -18,6 +18,12 @@
  * blip on OUR side making every check fail) must add their own fail-open
  * guard around the aggregate result; this helper only reports per-URL
  * liveness.
+ *
+ * checkPageBodyLive() (added for issue #3172, then reused back into
+ * check-journalist-article-links.mjs per the sibling-pattern rule): GET +
+ * expired-job soft-landing marker check, for same-origin frontaliereticino.ch
+ * URLs where checkLink()'s HEAD/status-only check is blind to the site's
+ * soft-404 policy (see its own doc comment below).
  */
 
 export const DEFAULT_LIVE_CHECK_TIMEOUT_MS = 8_000;
@@ -57,6 +63,33 @@ export async function checkLink(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS, 
       return getRes.ok || getRes.status === 206;
     }
     return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Marker `buildSoftLandingHtml` (build-plugins/jobsSeoPagesPlugin.ts) is the
+ * SOLE emitter of, seeded into `window.__EXPIRED_JOB_DATA__` on the soft-404
+ * bridge page the site renders (HTTP 200) for any expired/pulled job — per
+ * AGENTS.md "Static SEO Pages" the site never serves a real 404 for a
+ * previously-known job slug. So `checkLink()`'s HEAD/status-only check is a
+ * structural no-op against frontaliereticino.ch job URLs: the expired page
+ * 200s forever. Any caller checking same-origin frontaliereticino.ch links
+ * that may include a job page (issue #3172) must use `checkPageBodyLive`
+ * below instead of `checkLink` for those URLs. */
+export const EXPIRED_JOB_MARKER = '__EXPIRED_JOB_DATA__=';
+
+/** GET (not HEAD) a same-origin URL and treat it as dead when the request
+ * fails/non-oks OR the body carries the expired-job soft-landing marker (see
+ * EXPIRED_JOB_MARKER above — HEAD/status alone can never see this, the page
+ * always 200s). Never throws — resolves `false` on any non-ok status,
+ * network error, timeout, or marker match. */
+export async function checkPageBodyLive(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return false;
+    const body = await res.text();
+    return !body.includes(EXPIRED_JOB_MARKER);
   } catch {
     return false;
   }

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -38,7 +38,7 @@ import {
 } from './lib/alert-sent-jobs.mjs';
 import { derivePersonalizationPatch } from './lib/subscriber-personalization.mjs';
 import { extractSlugFromSourcePage } from './backfill-newsletter-job-context.mjs';
-import { checkLink, runWithConcurrency } from './lib/live-link-check.mjs';
+import { runWithConcurrency, DEFAULT_LIVE_CHECK_TIMEOUT_MS } from './lib/live-link-check.mjs';
 import { computeScheduledSendAt, resolveEffectivePreferredHour, perUserSendTimeEnabled, logScheduleDistribution } from './lib/send-schedule.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -108,11 +108,20 @@ const { resolveCantonSection, resolveJobCanton } = createCantonResolvers({ canto
 // data/jobs.json is a periodic crawl snapshot; a job listed as "recent" at
 // crawl-time can be pulled/expired by an employer, or its per-locale SSG page
 // may not have deployed yet, before this script actually sends the alert.
-// Mirrors the HEAD-check pattern from check-journalist-article-links.mjs
-// (issue #3174) via scripts/lib/live-link-check.mjs — same HEAD → 405/501
-// ranged-GET fallback, same 8s timeout, same "network error = not-live, no
-// retry" semantics — so this preflight and that one can never silently drift
-// apart on what "live" means.
+//
+// This CANNOT reuse the plain HEAD-check from check-journalist-article-links.mjs
+// (scripts/lib/live-link-check.mjs checkLink): that helper checks EXTERNAL
+// URLs, which genuinely 404 when dead. Our own job pages never do — the site's
+// soft-404 policy (AGENTS.md "Static SEO Pages": no real 404s, always a bridge)
+// means an expired job's URL keeps returning 200 forever, rendering the
+// "Questa offerta di lavoro non è più attiva" soft-landing page instead
+// (build-plugins/jobsSeoPagesPlugin.ts buildSoftLandingHtml). So a HEAD/status
+// check alone is a no-op here — it was passing 200 for exactly the expired
+// jobs it was meant to catch. buildSoftLandingHtml is the ONLY template that
+// seeds `window.__EXPIRED_JOB_DATA__` (a live job page never does), so a GET +
+// body-marker check (checkJobPageLive below) is the real liveness signal for
+// our own URLs.
+const EXPIRED_JOB_MARKER = '__EXPIRED_JOB_DATA__=';
 const JOB_LIVE_CHECK_CONCURRENCY = 5;
 // Fail-open guard: check-journalist-article-links.mjs is a monitoring/report
 // tool (a failed check just marks one outlink broken in a report — never
@@ -137,23 +146,38 @@ function jobPageUrl(job, locale) {
   return slug ? `${BASE_URL}${localizedJobBoardPath}/${slug}` : null;
 }
 
+// GET (not HEAD) our own job page and treat it as dead when the request
+// fails/non-oks OR the body carries the expired-job soft-landing marker (see
+// the preflight comment above JOB_LIVE_CHECK_CONCURRENCY — HEAD/status alone
+// can never see this, our job pages always 200). Exported for tests.
+export async function checkJobPageLive(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return false;
+    const body = await res.text();
+    return !body.includes(EXPIRED_JOB_MARKER);
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Filters `jobs` down to those whose live page resolves OK, checking each
- * distinct URL at most once per run via `cache` (shared across alerts/locales
- * so overlapping job pools aren't re-checked). Jobs with no resolvable slug
- * fall back to the site root in the email (always live) and are never
- * filtered. Exported for tests.
+ * Filters `jobs` down to those whose live page resolves OK AND is not the
+ * expired-job soft-landing bridge, checking each distinct URL at most once
+ * per run via `cache` (shared across alerts/locales so overlapping job pools
+ * aren't re-checked). Jobs with no resolvable slug fall back to the site root
+ * in the email (always live) and are never filtered. Exported for tests.
  */
 async function filterLiveJobs(jobs, locale, cache) {
   const withUrls = jobs.map((job) => ({ job, url: jobPageUrl(job, locale) }));
   // Dedupe by URL both across calls (via the shared `cache`) AND within this
   // single call (two jobs — e.g. two locale variants — can resolve to the
   // same page); otherwise a duplicate URL in the same batch would be
-  // HEAD-checked once per occurrence before either result lands in `cache`.
+  // checked once per occurrence before either result lands in `cache`.
   const uniqueToCheck = [...new Set(withUrls.map(({ url }) => url).filter((url) => url && !cache.has(url)))];
   if (uniqueToCheck.length > 0) {
     await runWithConcurrency(uniqueToCheck, JOB_LIVE_CHECK_CONCURRENCY, async (url) => {
-      cache.set(url, await checkLink(url));
+      cache.set(url, await checkJobPageLive(url));
     });
   }
   const results = withUrls.map(({ job, url }) => ({ job, live: !url || cache.get(url) !== false }));

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -38,7 +38,7 @@ import {
 } from './lib/alert-sent-jobs.mjs';
 import { derivePersonalizationPatch } from './lib/subscriber-personalization.mjs';
 import { extractSlugFromSourcePage } from './backfill-newsletter-job-context.mjs';
-import { runWithConcurrency, DEFAULT_LIVE_CHECK_TIMEOUT_MS } from './lib/live-link-check.mjs';
+import { runWithConcurrency, checkPageBodyLive } from './lib/live-link-check.mjs';
 import { computeScheduledSendAt, resolveEffectivePreferredHour, perUserSendTimeEnabled, logScheduleDistribution } from './lib/send-schedule.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -110,18 +110,17 @@ const { resolveCantonSection, resolveJobCanton } = createCantonResolvers({ canto
 // may not have deployed yet, before this script actually sends the alert.
 //
 // This CANNOT reuse the plain HEAD-check from check-journalist-article-links.mjs
-// (scripts/lib/live-link-check.mjs checkLink): that helper checks EXTERNAL
-// URLs, which genuinely 404 when dead. Our own job pages never do — the site's
-// soft-404 policy (AGENTS.md "Static SEO Pages": no real 404s, always a bridge)
-// means an expired job's URL keeps returning 200 forever, rendering the
-// "Questa offerta di lavoro non è più attiva" soft-landing page instead
-// (build-plugins/jobsSeoPagesPlugin.ts buildSoftLandingHtml). So a HEAD/status
-// check alone is a no-op here — it was passing 200 for exactly the expired
-// jobs it was meant to catch. buildSoftLandingHtml is the ONLY template that
-// seeds `window.__EXPIRED_JOB_DATA__` (a live job page never does), so a GET +
-// body-marker check (checkJobPageLive below) is the real liveness signal for
-// our own URLs.
-const EXPIRED_JOB_MARKER = '__EXPIRED_JOB_DATA__=';
+// (scripts/lib/live-link-check.mjs checkLink): that check is blind to our own
+// job pages — the site's soft-404 policy (AGENTS.md "Static SEO Pages": no
+// real 404s, always a bridge) means an expired job's URL keeps returning 200
+// forever, rendering the "Questa offerta di lavoro non è più attiva"
+// soft-landing page instead (build-plugins/jobsSeoPagesPlugin.ts
+// buildSoftLandingHtml). So a HEAD/status check alone is a no-op here — it
+// was passing 200 for exactly the expired jobs it was meant to catch.
+// checkPageBodyLive (scripts/lib/live-link-check.mjs, shared with
+// check-journalist-article-links.mjs) is the real liveness signal: GET + look
+// for the `window.__EXPIRED_JOB_DATA__` marker buildSoftLandingHtml alone
+// seeds.
 const JOB_LIVE_CHECK_CONCURRENCY = 5;
 // Fail-open guard: check-journalist-article-links.mjs is a monitoring/report
 // tool (a failed check just marks one outlink broken in a report — never
@@ -146,20 +145,10 @@ function jobPageUrl(job, locale) {
   return slug ? `${BASE_URL}${localizedJobBoardPath}/${slug}` : null;
 }
 
-// GET (not HEAD) our own job page and treat it as dead when the request
-// fails/non-oks OR the body carries the expired-job soft-landing marker (see
-// the preflight comment above JOB_LIVE_CHECK_CONCURRENCY — HEAD/status alone
-// can never see this, our job pages always 200). Exported for tests.
-export async function checkJobPageLive(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS) {
-  try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-    if (!res.ok) return false;
-    const body = await res.text();
-    return !body.includes(EXPIRED_JOB_MARKER);
-  } catch {
-    return false;
-  }
-}
+// Delegates to the shared checkPageBodyLive (scripts/lib/live-link-check.mjs)
+// — kept as its own export/name here since it's the job-alerts-specific
+// liveness check callers and tests reach for. Exported for tests.
+export const checkJobPageLive = checkPageBodyLive;
 
 /**
  * Filters `jobs` down to those whose live page resolves OK AND is not the

--- a/tests/check-journalist-article-links-ordering.test.ts
+++ b/tests/check-journalist-article-links-ordering.test.ts
@@ -10,7 +10,7 @@
  * any doc missing that field, regardless of how long ago it was published.
  */
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { processDoc } from '../scripts/check-journalist-article-links.mjs';
+import { processDoc, checkPageLinks } from '../scripts/check-journalist-article-links.mjs';
 
 describe('processDoc — live gate (issue #3209 item 2 follow-up)', () => {
   afterEach(() => {
@@ -63,5 +63,52 @@ describe('processDoc — live gate (issue #3209 item 2 follow-up)', () => {
         linkCheck: expect.objectContaining({ totalLinks: 0, brokenLinks: 0, localesChecked: 1 }),
       }),
     );
+  });
+});
+
+describe('checkPageLinks — soft-404 expired-job outlink detection (sibling of issue #3172)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flags a same-origin outlink to an expired job as broken, even though it 200s', async () => {
+    const articlePage =
+      '<html><body><a href="https://frontaliereticino.ch/cerca-lavoro-ticino/some-expired-job/">job</a></body></html>';
+    const expiredJobPage =
+      '<html><script>window.__EXPIRED_JOB_DATA__={"slug":"some-expired-job"};</script></html>';
+
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes('some-expired-job')) {
+        return { ok: true, status: 200, text: async () => expiredJobPage };
+      }
+      return { ok: true, status: 200, text: async () => articlePage };
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await checkPageLinks('https://frontaliereticino.ch/articoli-frontaliere/test/');
+
+    expect(result.totalLinks).toBe(1);
+    expect(result.brokenLinks).toBe(1);
+    expect(result.brokenUrls).toEqual(['https://frontaliereticino.ch/cerca-lavoro-ticino/some-expired-job/']);
+    // Never HEAD — a HEAD/status-only check can't see the soft-404 marker.
+    expect(fetchSpy.mock.calls.every(([, init]) => (init as RequestInit | undefined)?.method !== 'HEAD')).toBe(true);
+  });
+
+  it('does not flag a same-origin outlink that resolves to a normal live page', async () => {
+    const articlePage =
+      '<html><body><a href="https://frontaliereticino.ch/articoli-frontaliere/altro/">altro</a></body></html>';
+
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => articlePage,
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await checkPageLinks('https://frontaliereticino.ch/articoli-frontaliere/test/');
+
+    expect(result.totalLinks).toBe(1);
+    expect(result.brokenLinks).toBe(0);
+    expect(result.brokenUrls).toEqual([]);
   });
 });

--- a/tests/job-alert-geo-preference-pipeline.test.ts
+++ b/tests/job-alert-geo-preference-pipeline.test.ts
@@ -76,7 +76,10 @@ describe('geo-preference floor survives the full send pipeline (nit: minLocal vs
     expect(deduped.map((j) => j.id)).toEqual(['ti-0', 'ti-2', 'bs-0', 'bs-1', 'bs-2']);
 
     // Live-link check drops one BS job (filterLiveJobs preserves order too).
-    const fetchSpy = vi.fn(async (url: string) => ({ status: String(url).includes('bs-1') ? 404 : 200, ok: !String(url).includes('bs-1') }));
+    const fetchSpy = vi.fn(async (url: string) => {
+      const dead = String(url).includes('bs-1');
+      return { status: dead ? 404 : 200, ok: !dead, text: async () => '<html>live job page</html>' };
+    });
     vi.stubGlobal('fetch', fetchSpy);
     const liveMatched = await filterLiveJobs(deduped, 'it', new Map());
 

--- a/tests/job-alert-live-link-check.test.ts
+++ b/tests/job-alert-live-link-check.test.ts
@@ -1,16 +1,32 @@
 /**
- * Guard for issue #3172: scripts/send-job-alerts.mjs must not embed a dead
- * job-page link in an alert email. data/jobs.json is a periodic crawl
- * snapshot — a job listed as "recent" at crawl-time can be pulled/expired,
- * or its per-locale SSG page may not have deployed yet, before the alert
- * actually sends. filterLiveJobs() HEAD-checks each job's live page (the
- * same URL buildAlertEmail() would embed) and drops the ones that don't
- * resolve, reusing the exact liveness semantics of
- * check-journalist-article-links.mjs (issue #3174) via
- * scripts/lib/live-link-check.mjs.
+ * Guard for issue #3172 (and the expired-job report resolved alongside it):
+ * scripts/send-job-alerts.mjs must not embed a dead OR expired job-page link
+ * in an alert email. data/jobs.json is a periodic crawl snapshot — a job
+ * listed as "recent" at crawl-time can be pulled/expired, or its per-locale
+ * SSG page may not have deployed yet, before the alert actually sends.
+ *
+ * filterLiveJobs() GETs each job's live page (the same URL buildAlertEmail()
+ * would embed) via checkJobPageLive() and drops jobs whose page doesn't
+ * resolve OK OR renders the expired-job soft-landing bridge
+ * (build-plugins/jobsSeoPagesPlugin.ts buildSoftLandingHtml, which seeds
+ * `window.__EXPIRED_JOB_DATA__` — the site never serves a real 404 for a
+ * once-known job slug, so HTTP status alone cannot tell a live job page from
+ * an expired one).
  */
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { filterLiveJobs, jobPageUrl } from '../scripts/send-job-alerts.mjs';
+import { filterLiveJobs, jobPageUrl, checkJobPageLive } from '../scripts/send-job-alerts.mjs';
+
+function liveResponse(status = 200, body = '<html>live job page</html>') {
+  return { status, ok: status >= 200 && status < 300, text: async () => body };
+}
+
+function expiredResponse() {
+  return {
+    status: 200,
+    ok: true,
+    text: async () => '<html><script>window.__EXPIRED_JOB_DATA__={"slug":"dead-job"};</script></html>',
+  };
+}
 
 function fixtureJob(overrides: Record<string, unknown> = {}) {
   return {
@@ -50,8 +66,8 @@ describe('filterLiveJobs', () => {
     const liveJob = fixtureJob({ slug: 'live-job' });
     const deadJob = fixtureJob({ slug: 'dead-job' });
     const fetchSpy = vi.fn(async (url: string) => {
-      if (String(url).includes('dead-job')) return { status: 404, ok: false };
-      return { status: 200, ok: true };
+      if (String(url).includes('dead-job')) return liveResponse(404, '');
+      return liveResponse();
     });
     vi.stubGlobal('fetch', fetchSpy);
 
@@ -62,14 +78,17 @@ describe('filterLiveJobs', () => {
     expect(out[0]).toBe(liveJob);
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://frontaliereticino.ch/cerca-lavoro-ticino/live-job',
-      expect.objectContaining({ method: 'HEAD' }),
+      expect.any(Object),
     );
+    // GET, not HEAD — a HEAD response has no body to inspect for the expired marker.
+    const [, init] = fetchSpy.mock.calls.find(([url]) => String(url).includes('live-job')) as [string, RequestInit];
+    expect(init?.method).not.toBe('HEAD');
   });
 
   it('never re-checks the same URL twice in one run (shared cache)', async () => {
     const jobA = fixtureJob({ slug: 'shared-slug' });
     const jobB = fixtureJob({ slug: 'shared-slug' });
-    const fetchSpy = vi.fn().mockResolvedValue({ status: 200, ok: true });
+    const fetchSpy = vi.fn().mockResolvedValue(liveResponse());
     vi.stubGlobal('fetch', fetchSpy);
 
     const cache = new Map();
@@ -77,6 +96,28 @@ describe('filterLiveJobs', () => {
 
     expect(out).toHaveLength(2);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a job whose page is HTTP 200 but renders the expired-job soft-landing bridge', async () => {
+    const liveJob = fixtureJob({ slug: 'live-job' });
+    const expiredJob = fixtureJob({ slug: 'expired-job' });
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (String(url).includes('expired-job')) return expiredResponse();
+      return liveResponse();
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const out = await filterLiveJobs([liveJob, expiredJob], 'it', new Map());
+
+    expect(out).toEqual([liveJob]);
+  });
+
+  it('checkJobPageLive: true for a plain 200 body, false when the body carries __EXPIRED_JOB_DATA__=', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(liveResponse()));
+    expect(await checkJobPageLive('https://frontaliereticino.ch/cerca-lavoro-ticino/live-job')).toBe(true);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(expiredResponse()));
+    expect(await checkJobPageLive('https://frontaliereticino.ch/cerca-lavoro-ticino/expired-job')).toBe(false);
   });
 
   it('never drops a job with no resolvable slug (falls back to the site root, always live)', async () => {
@@ -111,27 +152,13 @@ describe('filterLiveJobs', () => {
     const jobs = Array.from({ length: 10 }, (_, i) => fixtureJob({ slug: `job-${i}` }));
     const fetchSpy = vi.fn(async (url: string) => {
       const idx = Number(String(url).match(/job-(\d+)/)?.[1]);
-      return idx < 4 ? { status: 200, ok: true } : { status: 404, ok: false };
+      return idx < 4 ? liveResponse() : liveResponse(404, '');
     });
     vi.stubGlobal('fetch', fetchSpy);
 
     const out = await filterLiveJobs(jobs, 'it', new Map());
 
     expect(out).toHaveLength(4);
-  });
-
-  it('falls back to a ranged GET when the origin rejects HEAD with 405 (mirrors check-journalist-article-links.mjs)', async () => {
-    const job = fixtureJob({ slug: 'head-rejected' });
-    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
-      if (init?.method === 'HEAD') return { status: 405, ok: false };
-      return { status: 206, ok: false };
-    });
-    vi.stubGlobal('fetch', fetchSpy);
-
-    const out = await filterLiveJobs([job], 'it', new Map());
-
-    expect(out).toHaveLength(1);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Implementato

- `filterLiveJobs()`'s pre-send liveness preflight in `scripts/send-job-alerts.mjs` switched from a HEAD-only status check (`checkLink()`) to a new `checkJobPageLive()` GET-based check that also inspects the response body for the `__EXPIRED_JOB_DATA__=` marker.
- Root cause: the site never serves a real HTTP 404 for a previously-known job slug (soft-404/bridge SEO policy, see `AGENTS.md` "Static SEO Pages"). An expired job's URL keeps returning HTTP 200 with a "questa offerta non è più attiva" soft-landing page (`build-plugins/jobsSeoPagesPlugin.ts` `buildSoftLandingHtml`, the sole emitter of `window.__EXPIRED_JOB_DATA__`). A HEAD/status-only check is structurally blind to this, so expired jobs could reach alert emails — reported live: a job alert today linked to `ufficio-vendite-a-80-100-helsana-ticino`, which is expired but returns 200.
- `tests/job-alert-live-link-check.test.ts` updated to match: mocks now return a `.text()` body, HEAD-method assertion removed (check is a plain GET), obsolete 405-ranged-GET-fallback test removed (that fallback lived in `checkLink()`, no longer used here), and two new tests added — direct `checkJobPageLive()` marker detection, and `filterLiveJobs()` dropping a 200-status job whose body carries the expired marker. All 15 tests in the file pass locally.
- Sibling test-mock fix: `tests/job-alert-geo-preference-pipeline.test.ts` also exercises `filterLiveJobs()` with its own `fetch` mock, which lacked `.text()` — CI caught this (mock threw inside `checkJobPageLive`, tripped the fail-open safety net, masking the real assertion). Fixed with the same mock shape as the other test file. 18/18 across both files pass locally.
- **Sibling code fix (corrects an earlier wrong claim in this same section — see below):** `scripts/check-journalist-article-links.mjs`'s `checkPageLinks()` extracts same-origin (`frontaliereticino.ch`) outlinks from a journalist article's live HTML and HEAD-checked them via the exact same broken `checkLink()` construct — same-origin explicitly includes job page URLs (`extractSameOriginLinks()` filters `href.origin === BASE_URL`), so a journalist article linking to a since-expired job would have that link silently reported "healthy" in the redazione dashboard. Fixed by extracting the GET+marker check into a shared `checkPageBodyLive()` in `scripts/lib/live-link-check.mjs`, now used by both `send-job-alerts.mjs` (as `checkJobPageLive`, kept as a named re-export for the existing test/caller API) and `check-journalist-article-links.mjs`, instead of duplicating the marker logic. New tests added to `tests/check-journalist-article-links-ordering.test.ts`: `checkPageLinks()` flags a same-origin outlink to an expired job as broken (never via HEAD) and does not flag a normal live outlink. 4/4 in that file pass locally.

### Sibling-check correction

An earlier revision of this section incorrectly claimed `scripts/check-journalist-article-links.mjs` was safe because it "checks genuinely-404-capable external URLs" — the PR reviewer correctly flagged this as wrong (see above; it's same-origin, not external) and it's fixed in this PR now. Re-ran `node scripts/ci/check-sibling-patterns.mjs` against the corrected diff and individually verified every remaining candidate — all are genuine false positives, not deferred:

- `scripts/notify-journalist-article-live.mjs` (`checkLink`, `runWithConcurrency`) — checks a journalist article's *own* just-published URL to confirm deploy propagation, not outbound links to job pages; articles aren't job listings and never get the `__EXPIRED_JOB_DATA__` soft-landing bridge — different content type, not the same bug class.
- `scripts/wait-for-pages-propagation.mjs` (`checkLink`) — deploy-propagation probe; for its purpose ("did this URL deploy at all") a 200 response — even the expired-job soft-landing bridge — is the *correct* answer, not a false positive of liveness. Different question being asked, not a broken check.
- `build-plugins/jobsSeoPagesPlugin.ts`, `build-plugins/shared/softLandingThinShell.ts` (`buildSoftLandingHtml`) — these are the *definition*/emitter side of the soft-404 marker this PR consumes, not a liveness-check consumer with the broken pattern.
- `scripts/batch-add-faq-to-articles.mjs`, `scripts/enrich-related-search-clusters.mjs`, `scripts/lib/mcdonalds-job-parser.mjs`, `scripts/lib/shared-jobs-crawler.mjs`, `scripts/probe-5xx.mjs` (`runWithConcurrency`) — each defines its own independent local `runWithConcurrency` function; none imports `scripts/lib/live-link-check.mjs`. Name-only match, not the shared module or the liveness-check construct.
- `scripts/send-newsletter.mjs` — uses a distinct `validateJobUrls()` (`services/newsletter-content.mjs`) that checks matched jobs against an in-memory known-slug `Set` built from the current jobs dataset, not an HTTP/HEAD check at all — no shared construct with `checkLink`/`live-link-check.mjs`.

## Non implementato (ancora)

Nessuno.
