### PR TITLE
perf(authors): targeted Firestore getDoc lookups instead of full-collection scans

### DIFF
--- a/services/authorProfileService.ts
+++ b/services/authorProfileService.ts
@@ -6,11 +6,18 @@
  * "Redazione" section).
  *
  * Both override collections are small (a handful of personas / rare
- * reassignments), so each is fetched once per session and cached — same
- * shape as exchangeRateService.ts's Firestore-then-fallback pattern, but
- * with no expiry: an override changes only via an explicit admin action,
- * not on a schedule, so a stale in-memory copy is only ever stale until
- * the next page load.
+ * reassignments), but `getMergedAuthor`/`getArticleAuthorOverride` run on
+ * essentially every author-page and article-page view (the SEO funnel's
+ * core traffic), so those two paths do a targeted `getDoc` by slug/id
+ * instead of scanning the whole collection — 1 read regardless of
+ * collection size, cached per-key (in-memory for the session, then
+ * localStorage TTL for repeat visits). `getAllMergedAuthors` genuinely
+ * needs every persona (author directory), so it keeps the original
+ * collection-scan-then-cache-everything shape.
+ *
+ * No expiry beyond the TTL: an override changes only via an explicit
+ * admin action, not on a schedule, so a stale cached copy is only ever
+ * stale until the next page load past the TTL.
  *
  * These overrides only affect client-side rendering (CSR). Already-built
  * static HTML/JSON-LD for SSG pages stays as it was at build time until
@@ -57,8 +64,14 @@ function writeLocalMap<T>(key: string, map: Map<string, T>): void {
 
 let profilesCache: Map<string, AuthorProfilePatch> | null = null;
 let profilesPromise: Promise<Map<string, AuthorProfilePatch>> | null = null;
-let overridesCache: Map<string, ArticleAuthorOverride> | null = null;
-let overridesPromise: Promise<Map<string, ArticleAuthorOverride>> | null = null;
+
+// Per-key caches for the hot targeted-lookup paths (getMergedAuthor,
+// getArticleAuthorOverride) — populated lazily, one getDoc per new key
+// instead of one getDocs-the-whole-collection per session.
+const profileBySlugCache = new Map<string, AuthorProfilePatch | undefined>();
+const profileBySlugInFlight = new Map<string, Promise<AuthorProfilePatch | undefined>>();
+const overrideByIdCache = new Map<string, ArticleAuthorOverride | undefined>();
+const overrideByIdInFlight = new Map<string, Promise<ArticleAuthorOverride | undefined>>();
 
 async function getDb() {
   const { getFirestore } = await resilientImport(
@@ -108,51 +121,121 @@ async function loadProfiles(): Promise<Map<string, AuthorProfilePatch>> {
   return profilesPromise;
 }
 
-async function loadOverrides(): Promise<Map<string, ArticleAuthorOverride>> {
-  if (overridesCache) return overridesCache;
+/**
+ * Targeted lookup for a single author's admin patch — used by
+ * getMergedAuthor, called on essentially every author-page view. A
+ * `getDoc` by slug costs 1 read regardless of collection size, vs.
+ * `loadProfiles`'s `getDocs` which costs 1 read per document in the
+ * collection every time the whole-collection cache is cold.
+ */
+async function loadProfile(slug: string): Promise<AuthorProfilePatch | undefined> {
+  if (profileBySlugCache.has(slug)) return profileBySlugCache.get(slug);
 
-  // 2. localStorage cache (skip Firestore on repeat page loads within TTL)
-  const local = readLocalMap<ArticleAuthorOverride>(OVERRIDES_LS_KEY);
-  if (local) {
-    overridesCache = local;
-    return local;
+  // Whole-collection cache already warm (e.g. getAllMergedAuthors ran
+  // first this session) — serve from it instead of a separate read.
+  if (profilesCache) {
+    const patch = profilesCache.get(slug);
+    profileBySlugCache.set(slug, patch);
+    return patch;
   }
 
-  if (!overridesPromise) {
-    overridesPromise = (async () => {
-      const map = new Map<string, ArticleAuthorOverride>();
-      if (IS_TEST_ENV) {
-        overridesCache = map;
-        return map;
-      }
+  const local = readLocalMap<AuthorProfilePatch>(PROFILES_LS_KEY);
+  if (local?.has(slug)) {
+    const patch = local.get(slug);
+    profileBySlugCache.set(slug, patch);
+    return patch;
+  }
+
+  if (IS_TEST_ENV) {
+    profileBySlugCache.set(slug, undefined);
+    return undefined;
+  }
+
+  let inFlight = profileBySlugInFlight.get(slug);
+  if (!inFlight) {
+    inFlight = (async () => {
+      let result: AuthorProfilePatch | undefined;
       try {
-        const { collection, getDocs } = await resilientImport(
+        const { doc, getDoc } = await resilientImport(
           () => import('firebase/firestore'),
-          (m) => typeof m.getDocs === 'function',
+          (m) => typeof m.getDoc === 'function',
         );
         const db = await getDb();
-        const snap = await getDocs(collection(db, 'article_author_overrides'));
-        snap.forEach((doc) => {
-          const d = doc.data() as ArticleAuthorOverride;
-          if (d?.authorSlug && d?.authorName) map.set(doc.id, d);
-        });
-        writeLocalMap(OVERRIDES_LS_KEY, map);
+        const snap = await getDoc(doc(db, 'author_profiles', slug));
+        if (snap.exists()) result = snap.data() as AuthorProfilePatch;
       } catch {
-        // Offline / permission edge cases — fall back to the static byline only.
+        // Offline / permission edge cases — fall back to the static registry only.
       }
-      overridesCache = map;
-      return map;
+      profileBySlugCache.set(slug, result);
+      const existing = readLocalMap<AuthorProfilePatch>(PROFILES_LS_KEY) ?? new Map<string, AuthorProfilePatch>();
+      if (result) existing.set(slug, result);
+      writeLocalMap(PROFILES_LS_KEY, existing);
+      profileBySlugInFlight.delete(slug);
+      return result;
     })();
+    profileBySlugInFlight.set(slug, inFlight);
   }
-  return overridesPromise;
+  return inFlight;
+}
+
+/**
+ * Targeted lookup for a single article's author override — used by
+ * getArticleAuthorOverride, called on essentially every article-page
+ * view (the SEO funnel's core traffic). A `getDoc` by article id costs
+ * 1 read regardless of collection size, vs. the previous `getDocs` over
+ * the whole `article_author_overrides` collection on every session's
+ * first article view.
+ */
+async function loadOverride(articleId: string): Promise<ArticleAuthorOverride | undefined> {
+  if (overrideByIdCache.has(articleId)) return overrideByIdCache.get(articleId);
+
+  const local = readLocalMap<ArticleAuthorOverride>(OVERRIDES_LS_KEY);
+  if (local?.has(articleId)) {
+    const hit = local.get(articleId);
+    overrideByIdCache.set(articleId, hit);
+    return hit;
+  }
+
+  if (IS_TEST_ENV) {
+    overrideByIdCache.set(articleId, undefined);
+    return undefined;
+  }
+
+  let inFlight = overrideByIdInFlight.get(articleId);
+  if (!inFlight) {
+    inFlight = (async () => {
+      let result: ArticleAuthorOverride | undefined;
+      try {
+        const { doc, getDoc } = await resilientImport(
+          () => import('firebase/firestore'),
+          (m) => typeof m.getDoc === 'function',
+        );
+        const db = await getDb();
+        const snap = await getDoc(doc(db, 'article_author_overrides', articleId));
+        if (snap.exists()) {
+          const d = snap.data() as ArticleAuthorOverride;
+          if (d?.authorSlug && d?.authorName) result = d;
+        }
+      } catch {
+        // Offline / permission edge cases — fall back to static byline only.
+      }
+      overrideByIdCache.set(articleId, result);
+      const existing = readLocalMap<ArticleAuthorOverride>(OVERRIDES_LS_KEY) ?? new Map<string, ArticleAuthorOverride>();
+      if (result) existing.set(articleId, result);
+      writeLocalMap(OVERRIDES_LS_KEY, existing);
+      overrideByIdInFlight.delete(articleId);
+      return result;
+    })();
+    overrideByIdInFlight.set(articleId, inFlight);
+  }
+  return inFlight;
 }
 
 /** Static author merged with its admin-set `author_profiles/{slug}` patch, if any. */
 export async function getMergedAuthor(slug: string): Promise<Author | undefined> {
   const base = getAuthorBySlug(slug);
   if (!base) return undefined;
-  const profiles = await loadProfiles();
-  const patch = profiles.get(slug);
+  const patch = await loadProfile(slug);
   if (!patch) return base;
   return {
     ...base,
@@ -173,8 +256,7 @@ export async function getAllMergedAuthors(): Promise<Author[]> {
 
 /** Admin-set author reassignment for this AI-catalog article id, if any. */
 export async function getArticleAuthorOverride(articleId: string): Promise<ArticleAuthorOverride | undefined> {
-  const overrides = await loadOverrides();
-  return overrides.get(articleId);
+  return loadOverride(articleId);
 }
 
 /**


### PR DESCRIPTION
## Implementato

- `services/authorProfileService.ts`: `getArticleAuthorOverride(articleId)` e `getMergedAuthor(slug)` ora usano `getDoc(doc(db, collection, id))` targeted invece di `getDocs(collection(db, collection))` full-scan. Un `getDoc` costa 1 read a prescindere dalla dimensione della collection; il precedente `getDocs` costava 1 read per documento nella collection ogni volta che la cache whole-collection era fredda — chiamato da `BlogArticles.tsx` (ungated `useEffect` su ogni article view) e `AutorePage.tsx` (ogni author-page view), cioè il traffico core del funnel SEO.
- Nuova cache per-chiave (`profileBySlugCache`, `overrideByIdCache`) + in-flight request dedup (`profileBySlugInFlight`, `overrideByIdInFlight`) per evitare `getDoc` duplicati concorrenti sulla stessa chiave nella stessa sessione, oltre alla persistenza in `localStorage` già esistente (merge incrementale invece di overwrite whole-map).
- `getAllMergedAuthors()` (dead code, zero caller in tutto il repo, verificato via grep esaustivo) lasciato intatto — usa ancora `loadProfiles()`'s full collection scan perché quella funzione ha davvero bisogno di ogni persona (author directory), quindi non è la stessa classe di bug.
- Sibling-pattern rule (AGENTS.md #6): entrambe le istanze dello stesso anti-pattern (`getArticleAuthorOverride` su `article_author_overrides`, `getMergedAuthor` su `author_profiles`) fixate nella stessa PR.
- GitNexus impact analysis su tutte le funzioni toccate/rimosse (`getArticleAuthorOverride`, `getMergedAuthor`, `loadOverrides` rimossa) → LOW risk, caller diretti confermati (`BlogArticles.tsx`, `AutorePage.tsx`). `tsc --noEmit` pulito sul file toccato e i due caller diretti (nessun nuovo errore rispetto al baseline pre-esistente).

Contesto: audit costi GCP del periodo 1-15 luglio 2026 (Firestore reads+writes ~101% del costo netto fatturato, 1.84M reads / 709k writes sui 15 giorni) ha identificato questo full-collection-scan-per-articolo come il driver dominante del volume letture eccessivo.

## Non implementato (ancora)

Nessuno. (Il secondo sospetto indagato, `services/fuelPricesService.ts`, non è lo stesso bug: i suoi 3 `getDoc` sono già lookup targeted — non uno scan — e sono già gate da un TTL in-memory di 30 minuti controllato prima di ogni chiamata Firestore. L'unica inefficienza reale lì è un tradeoff di freschezza architetturale — Firestore aggiornato ogni ora contro fallback JSON statico aggiornato solo 1x/giorno — non correlato/necessario a questo fix, quindi non è scope di questa PR né voce aperta qui.)