### PR TITLE
fix(webhooks): normalize display-name emails before Firestore key

### DIFF
--- a/functions/src/lib/parseEmailField.js
+++ b/functions/src/lib/parseEmailField.js
@@ -1,0 +1,73 @@
+/**
+ * parseEmailField — robustly split a stored email field that may be a bare
+ * address ("mario.rossi@example.com") OR an RFC822 display form ("Mario Rossi
+ * <mario.rossi@example.com>" / "\"Mario Rossi\" <mario.rossi@example.com>").
+ *
+ * Some subscriber records were written with the full display string in the
+ * `email` field instead of a separate `name`. Left raw, that string leaks into
+ * the To: header and unsubscribe links (verified live 2026-06-25: a subscriber
+ * whose `email` held "Name <addr>" received To: that exact string and a
+ * polluted List-Unsubscribe param), and the human name sitting inside it never
+ * reaches the greeting.
+ *
+ * Canonical home for this parser is here (functions/src/lib) — Cloud
+ * Functions ships without a bundler, so anything it imports must live inside
+ * functions/. scripts/lib/parseEmailField.mjs re-exports from this file.
+ *
+ * Returns the bare lowercased address (what To:/unsubscribe/doc-lookups want)
+ * plus the ORIGINAL-case display name (null when absent) so the newsletter can
+ * fall back to it as a greeting-name source.
+ *
+ * @param {unknown} raw
+ * @returns {{ email: string, displayName: string | null }}
+ */
+export function parseEmailField(raw) {
+  const str = String(raw || '').trim();
+  if (!str) return { email: '', displayName: null };
+
+  // "Display Name <addr@host>" (optionally quoted display name).
+  const angle = str.match(/^(.*?)<\s*([^<>\s]+)\s*>\s*$/);
+  if (angle) {
+    const name = angle[1].trim().replace(/^"(.*)"$/, '$1').trim();
+    const email = angle[2].trim().toLowerCase();
+    // The inner token can still be a non-address (e.g. "<a@x,b@y>" — the regex
+    // allows commas) — don't trust it unvalidated, or it seeds a bogus key.
+    if (!isBareAddress(email)) return { email: '', displayName: null };
+    // A "name" that is itself an address (or empty) is not a human name.
+    return { email, displayName: name && !name.includes('@') ? name : null };
+  }
+
+  // Bare-address fallback. Degenerate forms the angle branch rejected ("Name
+  // <a@x, b@y>", an address with an internal space) and name-only strings reach
+  // here; a plain toLowerCase() would return a truthy NON-address that becomes a
+  // bogus subscriber key downstream (subscriberFromFirestoreRow only guards on a
+  // falsy email). Validate the shape and emit an empty (falsy) address instead.
+  const bare = str.toLowerCase();
+  return isBareAddress(bare) ? { email: bare, displayName: null } : { email: '', displayName: null };
+}
+
+/**
+ * Whether a string is a single usable bare address: exactly one `@` with no
+ * whitespace, angle brackets, or commas on either side. Rejects name-only
+ * strings, multi-address lists, and degenerate wrapped forms so they never
+ * become a (truthy) subscriber key. Intentionally permissive on the local/
+ * domain charset — full RFC5322 validation is out of scope; the goal is only to
+ * reject the clearly-not-an-address fallbacks the parser would otherwise pass
+ * through.
+ * @param {string} s
+ * @returns {boolean}
+ */
+function isBareAddress(s) {
+  return /^[^\s<>,@]+@[^\s<>,@]+$/.test(s);
+}
+
+/**
+ * Bare lowercased address from an email field, stripping any display name.
+ * Drop-in replacement for the old `trim().toLowerCase()` normalizer that also
+ * handles the "Name <addr>" form.
+ * @param {unknown} raw
+ * @returns {string}
+ */
+export function normalizeEmailAddress(raw) {
+  return parseEmailField(raw).email;
+}

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -5,6 +5,7 @@ import { refreshPreferredSendHour } from './lib/preferredSendHour.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
+import { normalizeEmailAddress } from './lib/parseEmailField.js';
 
 /**
  * Maileroo webhook handler — receives delivery events and stores them in Firestore.
@@ -23,10 +24,6 @@ import { instantReactivationFields } from './lib/subscriberReactivation.js';
  *   newsletter_subscribers/{email} (status updates: bounced, complained)
  *   job_alert_subscribers/{email} (when tagged type=job-alert)
  */
-
-function normalizeEmail(value) {
-  return String(value || '').trim().toLowerCase();
-}
 
 // ── Signature verification ───────────────────────────────────
 // HMAC-SHA256(rawBody, secret) → hex, compared against x-maileroo-signature.
@@ -75,7 +72,7 @@ function extractCampaignId(event) {
 
 function getRecipient(event) {
   const data = event.event_data || {};
-  return normalizeEmail(data.to || event.to);
+  return normalizeEmailAddress(data.to || event.to);
 }
 
 function isJobAlertEvent(event) {

--- a/functions/src/newsletterMailgunWebhookCore.js
+++ b/functions/src/newsletterMailgunWebhookCore.js
@@ -5,6 +5,7 @@ import { refreshPreferredSendHour } from './lib/preferredSendHour.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
+import { normalizeEmailAddress } from './lib/parseEmailField.js';
 
 /**
  * Mailgun webhook handler — receives delivery events and stores them in Firestore.
@@ -17,10 +18,6 @@ import { instantReactivationFields } from './lib/subscriberReactivation.js';
  * newsletter_subscribers/{email}/campaign_deliveries/{campaign-id}
  * newsletter_subscribers/{email} (status updates: bounced, unsubscribed)
  */
-
-function normalizeEmail(value) {
- return String(value || '').trim().toLowerCase();
-}
 
 // ── Signature verification ───────────────────────────────────
 
@@ -73,7 +70,7 @@ function extractMessageId(eventData) {
 // ── Persist event to Firestore ───────────────────────────────
 
 export async function persistMailgunEvent(db, eventData) {
- const email = normalizeEmail(eventData.recipient);
+ const email = normalizeEmailAddress(eventData.recipient);
  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
 
  const mgEvent = eventData.event;

--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -4,6 +4,7 @@ import { refreshPreferredSendHour } from './lib/preferredSendHour.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
+import { normalizeEmailAddress } from './lib/parseEmailField.js';
 
 /**
  * Mailjet webhook handler — receives delivery events and stores them in Firestore.
@@ -23,10 +24,6 @@ import { instantReactivationFields } from './lib/subscriberReactivation.js';
  * newsletter_subscribers/{email}/campaign_deliveries/{campaign-id}
  * newsletter_subscribers/{email} (status updates: bounced, unsubscribed, etc.)
  */
-
-function normalizeEmail(value) {
- return String(value || '').trim().toLowerCase();
-}
 
 // ── Event type mapping (Mailjet → our normalized types) ──────
 
@@ -67,7 +64,7 @@ function extractMessageId(eventData) {
 // ── Persist a single Mailjet event to Firestore ──────────────
 
 export async function persistMailjetEvent(db, eventData) {
- const email = normalizeEmail(eventData.email);
+ const email = normalizeEmailAddress(eventData.email);
  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
 
  const mjEvent = eventData.event;

--- a/functions/src/newsletterMailtrapWebhookCore.js
+++ b/functions/src/newsletterMailtrapWebhookCore.js
@@ -4,6 +4,7 @@ import { refreshPreferredSendHour } from './lib/preferredSendHour.js';
 import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
+import { normalizeEmailAddress } from './lib/parseEmailField.js';
 
 /**
  * Mailtrap webhook handler — receives delivery events and stores them in Firestore.
@@ -19,10 +20,6 @@ import { instantReactivationFields } from './lib/subscriberReactivation.js';
  * newsletter_subscribers/{email}/campaign_deliveries/{campaign-id}
  * newsletter_subscribers/{email} (status updates: bounced, unsubscribed, etc.)
  */
-
-function normalizeEmail(value) {
- return String(value || '').trim().toLowerCase();
-}
 
 // ── Event type mapping (Mailtrap → normalized types) ────────
 
@@ -53,7 +50,7 @@ function extractCampaignId(data) {
 // ── Persist a single event to Firestore ─────────────────────
 
 export async function persistMailtrapEvent(db, eventData) {
- const email = normalizeEmail(eventData.email);
+ const email = normalizeEmailAddress(eventData.email);
  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
 
  const type = mapMailtrapEvent(eventData.event);

--- a/functions/src/newsletterResendWebhookCore.js
+++ b/functions/src/newsletterResendWebhookCore.js
@@ -6,10 +6,7 @@ import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimen
 import { buildDeliveryDocId as buildCanonicalDeliveryDocId } from './lib/deliveryDocId.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
-
-function normalizeEmail(value) {
- return String(value || '').trim().toLowerCase();
-}
+import { normalizeEmailAddress } from './lib/parseEmailField.js';
 
 function sanitizeString(value) {
  const normalized = String(value || '').trim();
@@ -119,7 +116,7 @@ const TERMINAL_NEGATIVE_STATUSES = new Set(['complained', 'suppressed', 'bounced
 function buildSubscriberUpdate(eventType, data, currentStatus) {
  const FieldValue = admin.firestore.FieldValue;
  const update = {
- email: normalizeEmail(data.email),
+ email: normalizeEmailAddress(data.email),
  updated_at: admin.firestore.FieldValue.serverTimestamp(),
  updatedAt: admin.firestore.FieldValue.serverTimestamp(),
  };
@@ -199,7 +196,7 @@ export async function applyResendWebhookEvent(rawEvent, options = {}) {
 
  const data = rawEvent?.data || {};
  const tags = extractTagMap(data.tags);
- const email = normalizeEmail(
+ const email = normalizeEmailAddress(
  data.email
  || data.to?.[0]
  || data.to

--- a/scripts/lib/parseEmailField.mjs
+++ b/scripts/lib/parseEmailField.mjs
@@ -1,69 +1,7 @@
 /**
- * parseEmailField — robustly split a stored email field that may be a bare
- * address ("mario.rossi@example.com") OR an RFC822 display form ("Mario Rossi
- * <mario.rossi@example.com>" / "\"Mario Rossi\" <mario.rossi@example.com>").
- *
- * Some subscriber records were written with the full display string in the
- * `email` field instead of a separate `name`. Left raw, that string leaks into
- * the To: header and unsubscribe links (verified live 2026-06-25: a subscriber
- * whose `email` held "Name <addr>" received To: that exact string and a
- * polluted List-Unsubscribe param), and the human name sitting inside it never
- * reaches the greeting.
- *
- * Returns the bare lowercased address (what To:/unsubscribe/doc-lookups want)
- * plus the ORIGINAL-case display name (null when absent) so the newsletter can
- * fall back to it as a greeting-name source.
- *
- * @param {unknown} raw
- * @returns {{ email: string, displayName: string | null }}
+ * Re-export shim. Canonical implementation lives in functions/src/lib/parseEmailField.js
+ * (Cloud Functions ships without a bundler, so the webhook cores need their own copy
+ * inside functions/; this file keeps scripts/ on the same implementation instead of a
+ * second, drift-prone copy).
  */
-export function parseEmailField(raw) {
-  const str = String(raw || '').trim();
-  if (!str) return { email: '', displayName: null };
-
-  // "Display Name <addr@host>" (optionally quoted display name).
-  const angle = str.match(/^(.*?)<\s*([^<>\s]+)\s*>\s*$/);
-  if (angle) {
-    const name = angle[1].trim().replace(/^"(.*)"$/, '$1').trim();
-    const email = angle[2].trim().toLowerCase();
-    // The inner token can still be a non-address (e.g. "<a@x,b@y>" — the regex
-    // allows commas) — don't trust it unvalidated, or it seeds a bogus key.
-    if (!isBareAddress(email)) return { email: '', displayName: null };
-    // A "name" that is itself an address (or empty) is not a human name.
-    return { email, displayName: name && !name.includes('@') ? name : null };
-  }
-
-  // Bare-address fallback. Degenerate forms the angle branch rejected ("Name
-  // <a@x, b@y>", an address with an internal space) and name-only strings reach
-  // here; a plain toLowerCase() would return a truthy NON-address that becomes a
-  // bogus subscriber key downstream (subscriberFromFirestoreRow only guards on a
-  // falsy email). Validate the shape and emit an empty (falsy) address instead.
-  const bare = str.toLowerCase();
-  return isBareAddress(bare) ? { email: bare, displayName: null } : { email: '', displayName: null };
-}
-
-/**
- * Whether a string is a single usable bare address: exactly one `@` with no
- * whitespace, angle brackets, or commas on either side. Rejects name-only
- * strings, multi-address lists, and degenerate wrapped forms so they never
- * become a (truthy) subscriber key. Intentionally permissive on the local/
- * domain charset — full RFC5322 validation is out of scope; the goal is only to
- * reject the clearly-not-an-address fallbacks the parser would otherwise pass
- * through.
- * @param {string} s
- * @returns {boolean}
- */
-function isBareAddress(s) {
-  return /^[^\s<>,@]+@[^\s<>,@]+$/.test(s);
-}
-
-/**
- * Bare lowercased address from an email field, stripping any display name.
- * Drop-in replacement for the old `trim().toLowerCase()` normalizer that also
- * handles the "Name <addr>" form.
- * @param {unknown} raw
- * @returns {string}
- */
-export function normalizeEmailAddress(raw) {
-  return parseEmailField(raw).email;
-}
+export { parseEmailField, normalizeEmailAddress } from '../../functions/src/lib/parseEmailField.js';

--- a/tests/newsletter-maileroo-webhook-core.test.ts
+++ b/tests/newsletter-maileroo-webhook-core.test.ts
@@ -381,3 +381,21 @@ describe('verifyMailerooSignature', () => {
     expect(verifyMailerooSignature({ payload, signature: goodSig, signingSecret: '' })).toBe(false);
   });
 });
+
+describe('newsletterMailerooWebhookCore — malformed "Name <email>" recipient (root-cause fix)', () => {
+  it('keys the subscriber doc by the bare address, not the raw "Name <email>" string', async () => {
+    const db = createFakeDb();
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'delivered',
+      event_data: { to: 'Mario Rossi <mario.rossi@example.com>' },
+    });
+
+    expect(result).toMatchObject({ processed: true, type: 'delivered', email: 'mario.rossi@example.com' });
+    const subscriberSet = db.__sets.find(
+      (s) => s.collection === 'newsletter_subscribers' && s.docId === 'mario.rossi@example.com',
+    );
+    expect(subscriberSet).toBeTruthy();
+    expect(db.__sets.some((s) => s.docId.includes('<'))).toBe(false);
+  });
+});

--- a/tests/newsletter-mailgun-webhook-core.test.ts
+++ b/tests/newsletter-mailgun-webhook-core.test.ts
@@ -158,3 +158,22 @@ describe('newsletterMailgunWebhookCore — job alert bounce handling', () => {
     expect(subscriberSet!.data.status).toBe('bounced');
   });
 });
+
+describe('newsletterMailgunWebhookCore — malformed "Name <email>" recipient (root-cause fix)', () => {
+  it('keys the subscriber doc by the bare address, not the raw "Name <email>" string', async () => {
+    const db = createFakeDb();
+
+    const result = await persistMailgunEvent(db as any, {
+      event: 'delivered',
+      recipient: 'Mario Rossi <mario.rossi@example.com>',
+      timestamp: 1700000300,
+    });
+
+    expect(result).toMatchObject({ processed: true, type: 'delivered', email: 'mario.rossi@example.com' });
+    const subscriberSet = db.__sets.find(
+      (s) => s.collection === 'newsletter_subscribers' && s.docId === 'mario.rossi@example.com',
+    );
+    expect(subscriberSet).toBeTruthy();
+    expect(db.__sets.some((s) => s.docId.includes('<'))).toBe(false);
+  });
+});

--- a/tests/newsletter-mailjet-webhook-core.test.ts
+++ b/tests/newsletter-mailjet-webhook-core.test.ts
@@ -485,3 +485,22 @@ describe('newsletterMailjetWebhookCore', () => {
     });
   });
 });
+
+describe('newsletterMailjetWebhookCore — malformed "Name <email>" recipient (root-cause fix)', () => {
+  it('keys the subscriber doc by the bare address, not the raw "Name <email>" string', async () => {
+    const db = createFakeDb();
+
+    const result = await persistMailjetEvent(db as any, {
+      event: 'sent',
+      email: 'Mario Rossi <mario.rossi@example.com>',
+      time: 1700000300,
+    });
+
+    expect(result).toMatchObject({ processed: true, type: 'send', email: 'mario.rossi@example.com' });
+    const subscriberSet = db.__sets.find(
+      (s) => s.collection === 'newsletter_subscribers' && s.docId === 'mario.rossi@example.com',
+    );
+    expect(subscriberSet).toBeTruthy();
+    expect(db.__sets.some((s) => s.docId.includes('<'))).toBe(false);
+  });
+});

--- a/tests/newsletter-mailtrap-webhook-core.test.ts
+++ b/tests/newsletter-mailtrap-webhook-core.test.ts
@@ -159,3 +159,21 @@ describe('newsletterMailtrapWebhookCore — job alert bounce handling', () => {
     expect(subscriberSet!.data.status).toBe('bounced');
   });
 });
+
+describe('newsletterMailtrapWebhookCore — malformed "Name <email>" recipient (root-cause fix)', () => {
+  it('keys the subscriber doc by the bare address, not the raw "Name <email>" string', async () => {
+    const db = createFakeDb();
+
+    const result = await persistMailtrapEvent(db as any, {
+      event: 'delivery',
+      email: 'Mario Rossi <mario.rossi@example.com>',
+    });
+
+    expect(result).toMatchObject({ processed: true, type: 'delivered', email: 'mario.rossi@example.com' });
+    const subscriberSet = db.__sets.find(
+      (s) => s.collection === 'newsletter_subscribers' && s.docId === 'mario.rossi@example.com',
+    );
+    expect(subscriberSet).toBeTruthy();
+    expect(db.__sets.some((s) => s.docId.includes('<'))).toBe(false);
+  });
+});

--- a/tests/newsletter-resend-webhook-core.test.ts
+++ b/tests/newsletter-resend-webhook-core.test.ts
@@ -461,3 +461,24 @@ describe('newsletterResendWebhookCore', () => {
     expect(result).toMatchObject({ handled: false, reason: 'missing_recipient' });
   });
 });
+
+describe('newsletterResendWebhookCore — malformed "Name <email>" recipient (root-cause fix)', () => {
+  it('keys the subscriber doc by the bare address, not the raw "Name <email>" string', async () => {
+    const db = createFakeDb();
+
+    const result = await applyResendWebhookEvent({
+      type: 'email.sent',
+      data: {
+        email: 'Mario Rossi <mario.rossi@example.com>',
+        email_id: 'msg_456',
+        tags: [{ name: 'campaign_id', value: 'weekly_2026-07-16' }],
+      },
+    }, { db: db as any });
+
+    expect(result).toMatchObject({ handled: true, email: 'mario.rossi@example.com', type: 'send' });
+    expect(db.__sets.some(
+      (entry) => entry.collection === 'newsletter_subscribers' && entry.docId === 'mario.rossi@example.com',
+    )).toBe(true);
+    expect(db.__sets.some((entry) => entry.docId.includes('<'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

- Root cause: five newsletter/job-alert webhook cores (`newsletterResendWebhookCore.js`, `newsletterMailjetWebhookCore.js`, `newsletterMailgunWebhookCore.js`, `newsletterMailtrapWebhookCore.js`, `newsletterMailerooWebhookCore.js`) each had a local `normalizeEmail(value) => String(value||'').trim().toLowerCase()` that passed an ESP payload shaped like `"Name <addr@host>"` straight through as the Firestore doc key instead of extracting the bare address.
- Moved the existing, already-tested `parseEmailField`/`normalizeEmailAddress` parser (previously `scripts/lib/parseEmailField.mjs`, written 2026-06-25 for the newsletter-send path) into `functions/src/lib/parseEmailField.js` as the canonical copy — Cloud Functions ships without a bundler and cannot import from outside `functions/`.
- Turned `scripts/lib/parseEmailField.mjs` into a re-export shim pointing at the new canonical module, so `scripts/send-newsletter.mjs` and `scripts/lib/subscriberFromFirestoreRow.mjs` keep working unchanged.
- Removed the local `normalizeEmail` duplicate from all 5 webhook core files and pointed every call site at `normalizeEmailAddress` from the shared module (sibling-pattern fix, AGENTS.md #6 — whole class fixed in this PR, not just the one file).
- Added a `"Name <email>"` regression test to each of the 5 webhook-core test files, asserting the subscriber doc is keyed by the bare address and no doc key contains `<`. `tests/parse-email-field.test.ts` still passes against the shim. Full targeted run: 91/91 green.
- Quantified blast radius (read-only Firestore scan, no code dependency): 4 malformed docs existed across ~11,700 subscriber docs (3 in `newsletter_subscribers`, 1 in `job_alert_subscribers`); one was already manually unsubscribed in a prior session.
- **Migrated the other 3 malformed docs** (owner-approved in chat, "Sì, migra tutti e 3 ora"): rekeyed each doc from `"Name <email>"` to the bare email, preserving subscribe/unsubscribe status exactly as-is on every doc.
  - `denniscapuozzo@gmail.com` (newsletter): additive counters summed (`send_count`/`sendCount`/`open_count`/`openCount`/`soft_bounce_count`), `last_sent_at`/`last_open_at`/`updated_at` set to the more-recent-of-both, 29 `events` + 1 `campaign_deliveries` doc moved, old malformed doc deleted. Derived fields (`engagement_score`, `preferred_send_*`) left untouched on the canonical doc — self-correct off the now-consolidated event history on the next real send.
  - `samuelevalente96@gmail.com` (newsletter): the canonical doc never had delivery/engagement fields — copied OLD's wholesale (additive, zero clobber): `engagement_*`, `preferred_send_*`, `send_count`/`open_count`/`click_count` (+camelCase pairs), `last_sent_at`/`last_open_at`/`last_click_at`/`last_clicked_url`, `updated_at`. 44 `events` + 1 `campaign_deliveries` doc moved, old malformed doc deleted.
  - `mjarlfeldt@gmail.com` (job-alert): **zero root-field writes** — canonical doc's `status` (`active`) and every bounce-related field left exactly as approved ("stato iscrizione invariato"). Only subcollections moved: 7 `events` docs (full bounce-event audit trail). 1 `alert_deliveries` doc (`backfill-newsletter`) was already present on the canonical doc for the same `message_id` — left untouched rather than overwritten, since OLD's copy only added a conflicting `bounced_at` on top of NEW's `delivered_at`/`opened_at` (the full bounce record is preserved via the `events` copy instead). Old malformed doc deleted.
  - Post-migration scan confirms zero remaining malformed doc keys in `job_alert_subscribers` and only the already-known, already-handled `jas veronelli <...>` doc left in `newsletter_subscribers` (unsubscribed in a prior session, out of this migration's scope by design).
  - Subcollection-embedded `email` fields (found inside individual `events`/`campaign_deliveries`/`alert_deliveries` docs, not just the parent doc key) were normalized to the bare address during the move, so the malformed string doesn't survive anywhere in the moved data.

### Sibling-pattern scan (`check-sibling-patterns.mjs`) — 10 candidates, all inspected, all false positives

- `scripts/send-newsletter.mjs` — already delegates its local `normalizeEmail` wrapper to `normalizeEmailAddress` (imported from the shim); no duplicate weak logic.
- `scripts/lib/subscriberFromFirestoreRow.mjs` — already calls `parseEmailField` directly.
- `scripts/lib/send-schedule.mjs` — surfaced only because a docblock comment references `subscriberFromFirestoreRow`; no email-normalization logic in the file.
- `functions/src/lib/bounceClassification.js` — surfaced only because it shares the generic parameter name `eventData`; unrelated to email parsing.
- `scripts/lib/cereneo-job-parser.mjs`, `forel-klinik-job-parser.mjs`, `klinik-aadorf-job-parser.mjs`, `klinik-arlesheim-job-parser.mjs`, `spital-affoltern-job-parser.mjs`, `uroviva-job-parser.mjs` — surfaced only because they reference an HTML `data-eventData` attribute in job-listing scraping; unrelated domain, same token by coincidence.

## Non implementato (ancora)

Nessuno.

**Nota separata (non blocca questa PR):** durante la migrazione di `mjarlfeldt@gmail.com` è emerso un conflitto reale sullo stato dati — il doc canonico riporta `status: active`, ma il doc malformato conteneva 7 eventi di soft-bounce recenti (`bounce_count: 7`, l'ultimo del 2026-07-16) mai arrivati sul record canonico. Questa PR non risolve il conflitto (come da approvazione: stato iscrizione invariato) — riportato all'owner in chat come decisione separata, non come scope di questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
