### PR TITLE
fix(cold-email): real hyperlinks, web-UI html parity, modal z-index

### DIFF
--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -3617,7 +3617,7 @@ export default function AdminPanel() {
  {/* Contact + email-preview drawer */}
  {contactModalRow && (
  <div
- className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 p-0 sm:p-4"
+ className="fixed inset-0 z-[90] flex items-end sm:items-center justify-center bg-black/50 p-0 sm:p-4"
  role="dialog"
  aria-modal="true"
  aria-label={`Contatto e anteprima email per ${contactModalRow.companyName}`}

--- a/functions/index.js
+++ b/functions/index.js
@@ -181,12 +181,13 @@ export const adminSendColdEmail = onRequest(
         return;
       }
       const resend = new Resend(resendApiKey);
-      const sendEmail = async ({ from, to, subject, text, unsubUrl }) => {
+      const sendEmail = async ({ from, to, subject, text, html, unsubUrl }) => {
         const { data, error } = await resend.emails.send({
           from,
           to,
           subject,
           text,
+          html,
           headers: {
             'List-Unsubscribe': `<${unsubUrl}>`,
             'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',

--- a/functions/src/adminSendColdEmail.js
+++ b/functions/src/adminSendColdEmail.js
@@ -19,7 +19,7 @@
  */
 
 import { FieldValue } from 'firebase-admin/firestore';
-import { buildSequence } from './coldEmailSequence.js';
+import { buildSequence, bodyToHtml } from './coldEmailSequence.js';
 import { buildInsightsUrl } from './employerInsights.js';
 import { buildUnsubUrl } from './outreachUnsubscribe.js';
 
@@ -43,13 +43,13 @@ async function getDoc(db, collection, id) {
 
 /**
  * Core handler — `db` and `sendEmail` are injectable for unit tests.
- * Returns { status, body }. `sendEmail({ from, to, subject, text, unsubUrl })`
+ * Returns { status, body }. `sendEmail({ from, to, subject, text, html, unsubUrl })`
  * must resolve to { messageId } or throw.
  *
  * @param {{ companyKey?: string, touch?: number, force?: boolean,
  *           secret?: string, db: any,
- *           sendEmail: (msg: { from: string, to: string, subject: string,
- *                              text: string, unsubUrl: string }) => Promise<{ messageId?: string }> }} args
+ *           sendEmail: (msg: { from: string, to: string, subject: string, text: string,
+ *                              html: string, unsubUrl: string }) => Promise<{ messageId?: string }> }} args
  */
 export async function handleAdminSendColdEmail({ companyKey, touch, force, secret, db, sendEmail }) {
   const key = String(companyKey || '').trim();
@@ -101,6 +101,11 @@ export async function handleAdminSendColdEmail({ companyKey, touch, force, secre
   const text = message.body
     .split('{{INSIGHTS_URL}}').join(insightsUrl)
     .split('{{UNSUB_URL}}').join(unsubUrl);
+  // Same html part the CLI sends (send-cold-emails.mjs), so the web-UI send
+  // gains real <a href> links too instead of raw plain-text URLs.
+  const html = bodyToHtml(message.body)
+    .split('{{INSIGHTS_URL}}').join(insightsUrl)
+    .split('{{UNSUB_URL}}').join(unsubUrl);
 
   // Write a pre-send marker so the dedup gate stays active even if the
   // confirmed write below fails (Resend out → Firestore down → no touches
@@ -120,6 +125,7 @@ export async function handleAdminSendColdEmail({ companyKey, touch, force, secre
   try {
     result = await sendEmail({
       from: 'Valerie <valerie@frontaliereticino.ch>',
+      html,
       to: toEmail,
       subject: message.subject,
       text,

--- a/functions/src/coldEmailSequence.js
+++ b/functions/src/coldEmailSequence.js
@@ -12,6 +12,10 @@
  * `{{UNSUB_URL}}` / `{{INSIGHTS_URL}}` are placeholders substituted at send time
  * by the sender (send-cold-emails.mjs or adminSendColdEmail): the real tokenized
  * one-click unsubscribe link and the per-company stats-page link.
+ *
+ * `bodyToHtml` also lives here (not just in send-cold-emails.mjs) so the web-UI
+ * sender (adminSendColdEmail.js) builds the SAME html part as the CLI instead of
+ * sending text-only — same single-source rationale as buildSequence.
  */
 
 export const PRICE = 'CHF 49 al mese per annuncio';
@@ -85,4 +89,27 @@ Valerie`,
   ];
   // Append the opt-out footer to every touch so drafts and real sends match.
   return seq.map((m) => ({ ...m, body: m.body + footer }));
+}
+
+const escapeHtml = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Wraps the two known placeholder tokens in <a>. Runs BEFORE {{UNSUB_URL}} /
+// {{INSIGHTS_URL}} are substituted for the real signed URLs (send-cold-emails.mjs
+// / adminSendColdEmail.js), so that later substitution fills in both the href
+// and the visible text — turning the plain-text link into a real hyperlink.
+// Muted color on the opt-out link keeps it a footer aside, not a second CTA,
+// so the compliance-required unsubscribe doesn't read as mass-email chrome.
+function linkifyPlaceholders(escaped) {
+  return escaped
+    .split('{{INSIGHTS_URL}}').join('<a href="{{INSIGHTS_URL}}" style="color:#4f46e5">{{INSIGHTS_URL}}</a>')
+    .split('{{UNSUB_URL}}').join('<a href="{{UNSUB_URL}}" style="color:#6b7280">{{UNSUB_URL}}</a>');
+}
+
+/** Cold email = aspetto plain. HTML minimale: paragrafi, link reali, niente immagini/CTA grafiche. */
+export function bodyToHtml(body) {
+  const paras = body.trim().split(/\n\n+/).map((p) => {
+    const escaped = escapeHtml(p).replace(/\n/g, '<br>');
+    return `<p style="margin:0 0 14px">${linkifyPlaceholders(escaped)}</p>`;
+  });
+  return `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#1a1a1a">${paras.join('')}</div>`;
 }

--- a/scripts/lib/cold-email-sequence.d.mts
+++ b/scripts/lib/cold-email-sequence.d.mts
@@ -19,3 +19,4 @@ export interface BuildSequenceArgs {
 }
 
 export function buildSequence(args: BuildSequenceArgs): ColdEmailTouch[];
+export function bodyToHtml(body: string): string;

--- a/scripts/lib/cold-email-sequence.mjs
+++ b/scripts/lib/cold-email-sequence.mjs
@@ -9,4 +9,4 @@
  * SAME module instance, so the preview, the CLI send, and the web-UI send stay
  * byte-identical (AGENTS.md Non-Negotiable #6, no drift).
  */
-export { PRICE, OPTOUT_EMAIL, buildSequence } from '../../functions/src/coldEmailSequence.js';
+export { PRICE, OPTOUT_EMAIL, buildSequence, bodyToHtml } from '../../functions/src/coldEmailSequence.js';

--- a/scripts/send-cold-emails.mjs
+++ b/scripts/send-cold-emails.mjs
@@ -38,6 +38,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildSequence, OPTOUT_EMAIL } from './generate-cold-emails.mjs';
+import { bodyToHtml } from './lib/cold-email-sequence.mjs';
 import { classifySector } from './lib/employer-sectors.mjs';
 import { buildUnsubUrl } from './lib/outreach-unsubscribe-token.mjs';
 import { buildInsightsUrl } from './lib/employer-insights-token.mjs';
@@ -63,14 +64,6 @@ function arg(name, def) {
   return n && !n.startsWith('--') ? n : true;
 }
 const has = (name) => process.argv.includes(name);
-
-const escapeHtml = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-/** Cold email = aspetto plain. HTML minimale: paragrafi, niente immagini/CTA grafiche. */
-function bodyToHtml(body) {
-  const paras = body.trim().split(/\n\n+/).map((p) => `<p style="margin:0 0 14px">${escapeHtml(p).replace(/\n/g, '<br>')}</p>`);
-  return `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#1a1a1a">${paras.join('')}</div>`;
-}
 
 function loadJson(p, def) { try { return JSON.parse(fs.readFileSync(path.resolve(p), 'utf8')); } catch { return def; } }
 

--- a/tests/admin-send-cold-email-handler.test.ts
+++ b/tests/admin-send-cold-email-handler.test.ts
@@ -65,6 +65,11 @@ describe('handleAdminSendColdEmail', () => {
     expect(sent[0].text).not.toContain('{{INSIGHTS_URL}}');
     expect(sent[0].text).not.toContain('{{UNSUB_URL}}');
     expect(sent[0].unsubUrl).toContain('/disiscrivi-outreach/?c=casale-sa&t=');
+    // html part mirrors the CLI (send-cold-emails.mjs): real <a href> links,
+    // not raw plain-text URLs (no leftover template tokens either).
+    expect(sent[0].html).toContain('<a href="https://frontaliereticino.ch/azienda/casale-sa/?t=');
+    expect(sent[0].html).not.toContain('{{INSIGHTS_URL}}');
+    expect(sent[0].html).not.toContain('{{UNSUB_URL}}');
     // Two writes to employer_outreach_sends: pending marker (pre-send) + confirmed (post-send).
     const sendsWrites = db.writes.filter((w) => w.coll === 'employer_outreach_sends');
     expect(sendsWrites).toHaveLength(2);

--- a/tests/cold-email-sequence-shared.test.ts
+++ b/tests/cold-email-sequence-shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs helper, no types
-import { buildSequence as fromShared, OPTOUT_EMAIL } from '../scripts/lib/cold-email-sequence.mjs';
+import { buildSequence as fromShared, OPTOUT_EMAIL, bodyToHtml } from '../scripts/lib/cold-email-sequence.mjs';
 // @ts-expect-error — plain .mjs script re-exports the shared sequence
 import { buildSequence as fromGenerate, OPTOUT_EMAIL as OPTOUT_FROM_GENERATE } from '../scripts/generate-cold-emails.mjs';
 
@@ -35,5 +35,29 @@ describe('cold-email sequence: single shared source (no drift)', () => {
     expect(t1.body).toContain('Buongiorno,');
     expect(t1.body).toContain('pagina lavoro'); // generic role rejected
     expect(t1.body).not.toContain('pagina di "Lavora con noi"');
+  });
+});
+
+describe('bodyToHtml: single-source HTML builder (send-cold-emails.mjs + adminSendColdEmail.js)', () => {
+  it('wraps the {{INSIGHTS_URL}}/{{UNSUB_URL}} placeholders in real <a href> anchors', () => {
+    const [t1] = fromShared({ company: 'Casale SA', candidates: 49, periodLabel: 'Negli ultimi 3 mesi' });
+    const html = bodyToHtml(t1.body);
+    expect(html).toContain('<a href="{{INSIGHTS_URL}}"');
+    expect(html).toContain('<a href="{{UNSUB_URL}}"');
+  });
+
+  it('substituting the real URL after bodyToHtml fills both the href and the visible text', () => {
+    const [t1] = fromShared({ company: 'Casale SA', candidates: 49, periodLabel: 'Negli ultimi 3 mesi' });
+    const url = 'https://frontaliereticino.ch/azienda/casale-sa/?t=abc123';
+    const html = bodyToHtml(t1.body).split('{{INSIGHTS_URL}}').join(url);
+    expect(html).toContain(`<a href="${url}"`);
+    expect(html).toContain(`>${url}</a>`);
+  });
+
+  it('escapes HTML-significant characters in the body text', () => {
+    const html = bodyToHtml('Ciao <script>alert(1)</script> & co,\n\ntesto');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&amp; co');
   });
 });


### PR DESCRIPTION
## Implementato
- `bodyToHtml` spostato nel modulo condiviso `functions/src/coldEmailSequence.js` (single source), usato sia dal CLI (`send-cold-emails.mjs`) sia dal web-UI sender (`adminSendColdEmail.js` → `functions/index.js` Resend call) — entrambi ora emettono `<a href>` reali per `{{INSIGHTS_URL}}`/`{{UNSUB_URL}}` invece di URL plain-text.
- `adminSendColdEmail.js` ora costruisce e invia anche la parte `html` (prima solo `text`) — parità col CLI.
- Link di disiscrizione mantenuto (obbligatorio per cold-outreach B2B/deliverability) ma stilizzato in grigio muto come footer aside, visivamente separato dalla CTA principale (insights link), così non legge come "mass-email chrome" pur restando compliant.
- Modal outreach in `AdminPanel.tsx`: z-index `z-50` → `z-[90]` (allineato alla convenzione esistente `z-[60]/z-[70]/z-[80]/z-[90]` degli altri modal full-screen dell'app) — risolve il modal renderizzato sotto la navbar.
- `scripts/lib/cold-email-sequence.d.mts`: aggiunta dichiarazione tipo per `bodyToHtml` (gap reale emerso da `check-sibling-patterns.mjs`).
- Test: estesi `tests/admin-send-cold-email-handler.test.ts` (assert html) e `tests/cold-email-sequence-shared.test.ts` (linkify + escaping). Suite cold-email verde (30/30).

## Non implementato (ancora)
Nessuno per lo scope di questa PR. `check-sibling-patterns.mjs` ha segnalato 21 file gemello per overlap di token generici — ispezionati singolarmente, tutti falsi positivi (nessuno condivide l'antipattern reale: URL placeholder incollato come testo piatto in un body HTML senza `<a href>`):
- `scripts/generate-cold-emails.mjs` — solo re-export di `buildSequence`/`OPTOUT_EMAIL`, nessuna logica html propria.
- `functions/src/adminEmployerInsights.js`, `services/adminInsights.ts` — solo riferimenti/commenti a `adminSendColdEmail`/`insightsUrl` come consumer.
- `scripts/send-job-alerts.mjs` — già usa `<a href="${unsubscribeUrl}">` reale (riga 930).
- `functions/src/newsletterConfirmationEmail.js` — già usa `<a href="${escapeHtml(confirmUrl)}">` reale.
- `build-plugins/weatherAlertPagesPlugin.ts`, `weatherBorderWaitFusionPlugin.ts`, `weatherCityPagesPlugin.ts`, `functions/src/sendCalculatorReport.js`, `scripts/newsletter-template.mjs`, `services/jobCopyAttribution.ts`, `services/newsletter-template.mjs`, `services/publisherMarkdown.ts` — condividono solo il nome generico `escapeHtml` (utility indipendente, dominio estraneo).
- `scripts/lib/email-cascade.mjs`, `scripts/monitor-gsc-job-indexation.mjs`, `scripts/newsletter-sunset.mjs`, `scripts/send-newsletter.mjs` — condividono solo il nome generico `sendEmail`/`sendEmailCascade`, mittenti indipendenti.
- `functions/src/employerInsights.js`, `functions/src/journalistRoleCore.js`, `functions/src/outreachUnsubscribe.js` — solo commenti che referenziano `adminSendColdEmail` come consumer.
- `scripts/process-stop-replies.mjs` — solo commento che referenzia il footer condiviso per il rilevamento STOP.

Verificato anche (via `git stash`) che i 3 test falliti in `tests/seo/cathedral-sector-hubs.test.ts` sono preesistenti su `origin/main`, scollegati da questo diff — nessun file di questa PR tocca logica canton/cathedral/hub.

## Test plan
- [x] `npx vitest run tests/cold-email-sequence-shared.test.ts tests/admin-send-cold-email-handler.test.ts tests/cold-email-url-parity.test.ts tests/cold-email-optout.test.ts` — 30/30 verdi
- [x] `node --check` su tutti i file `.js`/`.mjs` toccati
- [x] `node scripts/ci/check-sibling-patterns.mjs` — 21 candidati ispezionati a mano, tutti falsi positivi (dettaglio sopra)