### PR TITLE
feat(newsletter): add Claude CLI Haiku last-resort fallback to AI chain

### DIFF
--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -113,6 +113,22 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
+      # Same mechanism as generate-article.yml: absolute last resort in
+      # NEWSLETTER_AI_CHAIN (scripts/send-newsletter.mjs), reached only after
+      # every free-tier model has failed. Zero marginal cost — auth is
+      # CLAUDE_CODE_OAUTH_TOKEN (same Max-plan subscription token already used
+      # by pr-review-loop.yml/issue-fix.yml), never ANTHROPIC_API_KEY. Kill
+      # switch: repo variable ENABLE_HAIKU_ARTICLE_FALLBACK=0 (Settings →
+      # Secrets and variables → Actions → Variables) or the Remote Config flag
+      # to '0' — either disables the setup below, ai-models.mjs then never
+      # offers the model (getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns '').
+      - name: Setup Claude CLI Haiku fallback
+        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0' && vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"
+
       - name: Assemble jobs dataset from per-crawler slices
         continue-on-error: true
         run: node scripts/assemble-jobs-dataset.mjs 2>&1 || echo "⚠️ Jobs assembly failed — newsletter will proceed without job data"
@@ -135,6 +151,11 @@ jobs:
           VARIANT: ${{ inputs.variant || 'general' }}
           ENHANCEMENTS: ${{ inputs.enhancements || 'topJobs,clusterPages,evergreen' }}
           AB_TEST: ${{ inputs.ab_test || '' }}
+          # Auth for the opt-in Claude CLI Haiku last-resort fallback (see
+          # "Setup Claude CLI Haiku fallback" step above). Harmless to always
+          # pass: ai-models.mjs only offers the model when this AND the RC
+          # flag are both set.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           SEGMENTED_FLAG=""
           VARIANT_FLAG="--variant $VARIANT"

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -197,6 +197,14 @@ const NEWSLETTER_AI_CHAIN = [
   'gemma-4-26b-a4b-it',         // Google — 14,400 req/day free (Gemma 4 MoE — exact API id)
   'mistral/mistral-small-latest', // Mistral — 1B tokens/month free
   'gemini-2.5-pro',             // Google — 500 req/day free, highest quality fallback
+  // Absolute last resort — same AI_MODELS.CLAUDE_CLI_HAIKU used by
+  // create-article.mjs's DEFAULT_CHAIN. Routed through the local `claude` CLI
+  // using CLAUDE_CODE_OAUTH_TOKEN (Max-plan subscription, $0 marginal cost),
+  // never ANTHROPIC_API_KEY. Only reached once every free model above has
+  // failed (sortChainByScore always sinks it to the bottom); inert unless
+  // ENABLE_HAIKU_ARTICLE_FALLBACK + CLAUDE_CODE_OAUTH_TOKEN are both set (see
+  // "Setup Claude CLI Haiku fallback" step in send-newsletter.yml).
+  'claude-cli/claude-haiku-4-5-20251001',
 ];
 
 async function generateAIBriefing(ctx) {


### PR DESCRIPTION
## Implementato
- `scripts/send-newsletter.mjs`: appended `AI_MODELS.CLAUDE_CLI_HAIKU` (`claude-cli/claude-haiku-4-5-20251001`) as the last entry of `NEWSLETTER_AI_CHAIN`, used by both `generateAIBriefing` and `generateAISubject`. Mirrors the existing last-resort rung already live in `scripts/lib/ai-models.mjs`'s `DEFAULT_CHAIN` for `create-article.mjs` — only reached once every free-tier model above it fails (`sortChainByScore` always sinks it below `LOCAL_FALLBACK`).
- `.github/workflows/send-newsletter.yml`: added the "Setup Claude CLI Haiku fallback" step (installs `@anthropic-ai/claude-code`, ON by default, kill-switch via repo variable or Remote Config `ENABLE_HAIKU_ARTICLE_FALLBACK=0`) and wired `CLAUDE_CODE_OAUTH_TOKEN` into the "Run newsletter job" step env — byte-for-byte the same pattern already live in `.github/workflows/generate-article.yml`.
- Auth is the existing Max-plan `CLAUDE_CODE_OAUTH_TOKEN` (same token already used by `pr-review-loop.yml`/`issue-fix.yml`/`generate-article.yml`) — **zero marginal cost**, no new `ANTHROPIC_API_KEY` secret added.
- Job-alert system (`scripts/send-job-alerts.mjs`, `send-job-alerts.yml`): confirmed **no AI call sites exist** — subject lines are fully template-based (`s.subjectNew`/`subjectFor`/`subjectDefault`), no `callLLM`/`ai-models` import anywhere in the file. Nothing to change there ("dove è necessario" → 0 touch points).

## Non implementato (ancora)
Nessuno.

Sibling-pattern grep (`scripts/ci/check-sibling-patterns.mjs`) surfaced 11 candidates sharing tokens like `AI_MODELS`/`DEFAULT_CHAIN`/`CLAUDE_CLI_HAIKU`/`ENABLE_HAIKU_ARTICLE_FALLBACK`. All evaluated as false positives:
- `scripts/lib/ai-models.mjs`, `scripts/load-rc-env.mjs` — the shared modules being correctly reused, not duplicated logic.
- `.github/workflows/generate-article.yml` — the source pattern this PR mirrors; already correct, nothing further to change there.
- `scripts/create-article.mjs`, `scripts/eval-local-rewrite-llm.mjs`, `scripts/smoke-test-ai-models.mjs`, `.github/workflows/smoke-test-ai-models.yml`, `scripts/backfill-ai-search-optimization.mjs`, `scripts/batch-add-faq-to-articles.mjs`, `scripts/enrich-related-search-clusters.mjs`, `scripts/set-chutes-rc.mjs` — all consume the generic exported `DEFAULT_CHAIN` (which already includes `CLAUDE_CLI_HAIKU` at the tail) rather than a hand-curated subset; no gap to fix. Verified via grep that `NEWSLETTER_AI_CHAIN` was the only hand-rolled model subset missing the last-resort rung (the other two subset hits — `eval-local-rewrite-llm.mjs`'s single-model `LOCAL_FALLBACK` test and `create-article.mjs`'s `cloudOnlyChain`, which is `DEFAULT_CHAIN` filtered to drop only `LOCAL_FALLBACK` — already retain/target different scope, not production generation chains missing Haiku).

GitNexus `detect_changes` (unstaged, pre-commit): risk `low`, 1 changed symbol (`generateAIBriefing`), 0 affected downstream processes.

## Test plan
- [x] `npx vitest run tests/scripts/ai-models-claude-cli-fallback.test.ts` — 7/7 pass (existing coverage of the shared `CLAUDE_CLI_HAIKU` mechanism, unchanged).
- [x] `npx vitest run tests/newsletter-fallback-subjects.test.ts tests/newsletter-briefing-prompt-locale.test.ts tests/newsletter-subject-variants.test.ts` — 47/47 pass.
- [x] `node --check scripts/send-newsletter.mjs` — syntax OK.
- [x] YAML parse check on `send-newsletter.yml` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)