### PR TITLE
fix(journalist-publish): resolve rebase-conflict push failures + self-heal orphaned articles

### DIFF
--- a/.github/workflows/publish-journalist-articles.yml
+++ b/.github/workflows/publish-journalist-articles.yml
@@ -87,7 +87,20 @@ jobs:
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "📰 Publish journalist article(s)"
-            bash scripts/lib/git-push-with-retry.sh
+            # --in-place-resolver-cmd: this pipeline runs registerArticleFiles()
+            # (scripts/create-article.mjs) — the SAME writer of router.ts/
+            # seo-pages.ts/blog-articles-data.ts/sitemaps as generate-article.yml,
+            # which already mirrors this resolver for the identical append-only-
+            # file conflict shape. Without it, a concurrent main writer racing
+            # this commit hits "Rebase conflict and no resolver provided" and the
+            # push is abandoned — but Firestore was already stamped
+            # status:'published' by publish-journalist-article.mjs BEFORE this
+            # step ran, so the doc is left permanently orphaned (published in
+            # Firestore, never actually committed to git, no code re-processes a
+            # 'published' doc). Incident 2026-07-16: run 29485706663 hit exactly
+            # this, orphaning 4 of Samuele Valente's articles for 8+ hours.
+            bash scripts/lib/git-push-with-retry.sh \
+              --in-place-resolver-cmd "source scripts/lib/resolve-append-conflicts.sh && resolve_append_conflicts && git add -A"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/scripts/notify-journalist-article-live.mjs
+++ b/scripts/notify-journalist-article-live.mjs
@@ -31,9 +31,20 @@
 
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { checkLink, runWithConcurrency } from './lib/live-link-check.mjs';
+import { checkArticleIdExists } from './create-article.mjs';
+import { slugify } from './publish-journalist-article.mjs';
 
 const LIVE_CHECK_TIMEOUT_MS = 15_000;
 const ARTICLE_LOCALES = ['it', 'en', 'de', 'fr'];
+
+// A `status:'published'` doc whose commit never actually landed on main
+// (e.g. the calling workflow's git-push hit an unresolved rebase conflict
+// and aborted — incident 2026-07-16, run 29485706663) is otherwise invisible
+// forever: nothing else reprocesses a 'published' doc, so it stays orphaned
+// while this script logs "not live yet" every run for good. Worst observed
+// real deploy took 2h4m37s (run 29505580973); 3h gives that a safety margin
+// before concluding the article was never committed and requeuing it.
+const ORPHAN_THRESHOLD_MS = 3 * 60 * 60 * 1000;
 
 async function initDb() {
   const admin = (await import('firebase-admin')).default;
@@ -103,6 +114,25 @@ async function processDoc(FieldValue, docSnap) {
 
   const live = await checkAllLocalesLive(publishedUrls);
   if (!live) {
+    const publishedAtMs = doc.publishedAt?.toMillis ? doc.publishedAt.toMillis() : null;
+    const ageMs = publishedAtMs ? Date.now() - publishedAtMs : 0;
+    if (ageMs > ORPHAN_THRESHOLD_MS) {
+      const articleId = slugify(docId) || docId;
+      if (!checkArticleIdExists(articleId)) {
+        console.warn(
+          `  ♻️  ${docId}: still not live after ${Math.round(ageMs / 3_600_000)}h and "${articleId}" is absent ` +
+            `from the article registry — requeuing (publish commit likely never landed on main).`,
+        );
+        await docSnap.ref.update({
+          status: 'queued',
+          publishedAt: FieldValue.delete(),
+          publishedUrls: FieldValue.delete(),
+          slugs: FieldValue.delete(),
+          liveVerifiedAt: FieldValue.delete(),
+        });
+        return;
+      }
+    }
     console.log(`  ⏭️  ${docId}: not live yet (deploy pending) — will retry next run.`);
     return;
   }

--- a/tests/notify-journalist-article-live.test.ts
+++ b/tests/notify-journalist-article-live.test.ts
@@ -4,7 +4,16 @@
  * (post-deploy), never based on publish/commit time alone.
  */
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+
+vi.mock('../scripts/create-article.mjs', () => ({
+  checkArticleIdExists: vi.fn(() => false),
+}));
+vi.mock('../scripts/publish-journalist-article.mjs', () => ({
+  slugify: (input: string) => input,
+}));
+
 import { checkAllLocalesLive, processDoc } from '../scripts/notify-journalist-article-live.mjs';
+import { checkArticleIdExists } from '../scripts/create-article.mjs';
 
 const PUBLISHED_URLS = {
   it: 'https://frontaliereticino.ch/articoli-frontaliere/test/',
@@ -41,16 +50,24 @@ describe('checkAllLocalesLive', () => {
 describe('processDoc', () => {
   beforeEach(() => {
     vi.stubEnv('RESEND_API_KEY', '');
+    // mockReturnValueOnce queues leak across tests if a prior test never
+    // actually calls the mock (e.g. the grace-window test short-circuits
+    // before reaching checkArticleIdExists) — reset the queue every test.
+    vi.mocked(checkArticleIdExists).mockReset().mockReturnValue(false);
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
 
-  function makeDocSnap() {
+  function makeDocSnap(overrides: Record<string, unknown> = {}) {
     return {
       id: 'test-doc',
-      data: () => ({ authorEmail: 'journalist@example.com', publishedUrls: PUBLISHED_URLS }),
+      data: () => ({
+        authorEmail: 'journalist@example.com',
+        publishedUrls: PUBLISHED_URLS,
+        ...overrides,
+      }),
       ref: { update: vi.fn().mockResolvedValue(undefined) },
     };
   }
@@ -76,5 +93,45 @@ describe('processDoc', () => {
     await processDoc(FieldValue as any, docSnap as any);
 
     expect(docSnap.ref.update).toHaveBeenCalledWith({ liveVerifiedAt: 'SERVER_TIMESTAMP' });
+  });
+
+  it('requeues a doc still 404 past the orphan threshold when its id is absent from the registry', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false })));
+    const fourHoursAgo = { toMillis: () => Date.now() - 4 * 60 * 60 * 1000 };
+    const docSnap = makeDocSnap({ publishedAt: fourHoursAgo });
+    const FieldValue = { serverTimestamp: () => 'SERVER_TIMESTAMP', delete: () => 'FIELD_DELETE' };
+
+    await processDoc(FieldValue as any, docSnap as any);
+
+    expect(docSnap.ref.update).toHaveBeenCalledWith({
+      status: 'queued',
+      publishedAt: 'FIELD_DELETE',
+      publishedUrls: 'FIELD_DELETE',
+      slugs: 'FIELD_DELETE',
+      liveVerifiedAt: 'FIELD_DELETE',
+    });
+  });
+
+  it('does not requeue while still within the orphan grace window', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false })));
+    const oneHourAgo = { toMillis: () => Date.now() - 1 * 60 * 60 * 1000 };
+    const docSnap = makeDocSnap({ publishedAt: oneHourAgo });
+    const FieldValue = { serverTimestamp: () => 'SERVER_TIMESTAMP', delete: () => 'FIELD_DELETE' };
+
+    await processDoc(FieldValue as any, docSnap as any);
+
+    expect(docSnap.ref.update).not.toHaveBeenCalled();
+  });
+
+  it('does not requeue past the threshold when the id IS present in the registry (commit landed, deploy just slow)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false })));
+    vi.mocked(checkArticleIdExists).mockReturnValueOnce(true);
+    const fourHoursAgo = { toMillis: () => Date.now() - 4 * 60 * 60 * 1000 };
+    const docSnap = makeDocSnap({ publishedAt: fourHoursAgo });
+    const FieldValue = { serverTimestamp: () => 'SERVER_TIMESTAMP', delete: () => 'FIELD_DELETE' };
+
+    await processDoc(FieldValue as any, docSnap as any);
+
+    expect(docSnap.ref.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Implementato

- `.github/workflows/publish-journalist-articles.yml`: added the missing `--in-place-resolver-cmd` to the publish-push step, mirroring the sibling `generate-article.yml` (same `registerArticleFiles()` writer, same append-only-file conflict shape). Root cause of the incident: run 29485706663 hit a rebase conflict with no resolver, the push aborted, but `publish-journalist-article.mjs` had already stamped Firestore `status:'published'` beforehand — orphaning 4 of Samuele Valente's articles (never committed, never live, nothing ever reprocessed them).
- `scripts/notify-journalist-article-live.mjs`: defense-in-depth self-heal. A `status:'published'` doc still not live 3h+ after `publishedAt` (worst observed real deploy: 2h4m37s, run 29505580973) AND whose id is confirmed absent from the on-disk article registry (`checkArticleIdExists`, same check `registerArticleFiles()` itself uses) gets reset to `status:'queued'` so the next publish run reprocesses it. Guards against any other failure mode producing the same split-brain state, not just this one.
- `tests/notify-journalist-article-live.test.ts`: 3 new cases covering the requeue (past threshold + id absent), the grace-window no-op (within threshold), and the safety no-op when the id is actually present (commit landed, deploy just slow — must not requeue a live-in-progress article).
- Recovery of the 4 already-orphaned docs (`diritto-allindennita-di-maternita-della-lavoratrice-frontaliera`, `dividenti-italiani-stop-alle-discriminazioni-fiscali-per-gli-enti-esteri`, `frontalieri-la-flat-tax-entra-nel-tuir-dal-2027-imposta-sostitutiva-pari-al-25-d`, `telelavoro-dei-frontalieri-tra-italia-e-svizzera-doppia-soglia-tra-fisco-e-previ`): done directly against Firestore post-merge (once the fixed resolver is live on `main`, so the reprocessed commit doesn't hit the same unfixed conflict again).

Refs #4265 (auto-closed by a later unrelated successful run — did not actually recover the orphaned articles; this PR is the real root-cause fix).

## Non implementato (ancora)

- Recovery of the 4 orphaned Firestore docs: **in questa PR, ma eseguito dopo il merge** (richiede il resolver fixato live su `main` prima di far ripartire il publish, altrimenti lo stesso conflitto le riorfanerebbe). Verrà eseguito e verificato live (curl) nello stesso turno subito dopo il merge.
- Sibling-pattern grep (Non-Negotiable #6): tutti i 31 workflow che chiamano `scripts/lib/git-push-with-retry.sh` sono stati ispezionati. Due invocazioni "nude" (nessun resolver) oltre a questa: `crawl-events.yml:205` (job GE) e `topic-candidates-mining.yml:80`. Entrambi **falsi positivi** — condividono solo lessicalmente il costrutto (`bash scripts/lib/git-push-with-retry.sh` senza argomenti), ma non la classe di bug (nessuno stato esterno viene marcato "fatto" prima del push): `crawl-events.yml` ha `continue-on-error: true` esplicito e il commento nel file dichiara il design "next scheduled run retries with fresh data"; `topic-candidates-mining.yml` rigenera interamente `data/demand-vocabulary.json`/`data/experimental-candidates.json` da zero ogni run settimanale. In entrambi un push fallito è già auto-recuperabile al run successivo — nessuno split-brain persistente, quindi nessun fix necessario.