### PR TITLE
fix(ci): reclaim boost/swift toolchains in validate-dist disk cleanup

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -85,7 +85,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 
@@ -618,7 +619,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 

--- a/.github/workflows/seed-bfs-depth-baseline.yml
+++ b/.github/workflows/seed-bfs-depth-baseline.yml
@@ -69,7 +69,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 

--- a/.github/workflows/seed-orphan-pages-baseline.yml
+++ b/.github/workflows/seed-orphan-pages-baseline.yml
@@ -70,7 +70,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 

--- a/.github/workflows/seed-text-html-ratio-baseline.yml
+++ b/.github/workflows/seed-text-html-ratio-baseline.yml
@@ -85,7 +85,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 

--- a/.github/workflows/seed-title-baselines.yml
+++ b/.github/workflows/seed-title-baselines.yml
@@ -80,7 +80,8 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
-            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 


### PR DESCRIPTION
## Summary
- `validate-dist-source` crashed on run [29514961777](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29514961777) with `System.IO.IOException: No space left on device`, killing the runner worker mid-job (before logs could flush — hence the missing job log). This came from our own merge's post-deploy publish chain (`d1b77288767`), which is otherwise fully green: `deploy` ✅, `validate-live` ✅ (live build-id confirmed correct), `validate-dist-postbuild` ✅. Only `validate-dist-source` failed, which skipped `publish` (IndexNow/GSC/social sync) for this deploy.
- `deploy.yml`, `adsense-prereview.yml`, and `cathedral-seo-gates-check.yml` already hit this exact same disk-exhaustion failure mode in the past and fixed it by additionally reclaiming `/usr/local/share/boost` and `/usr/share/swift` in their "Free disk space" cleanup step — but that fix was never propagated to `post-deploy-validate-dist.yml`'s two jobs (`validate-dist-source`, `validate-dist-postbuild`), nor to the four `seed-*.yml` baseline workflows that explicitly mirror its cleanup step verbatim.
- This PR propagates the same two extra reclaim paths to all 6 occurrences of the outdated cleanup list, closing the gap.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on all 5 changed files — valid YAML
- [x] Diff reviewed — purely additive to the existing `sudo rm -rf ... || true` best-effort cleanup list, no behavior change beyond freeing more disk
- [ ] Re-run `validate-dist` + `publish` on run 29514961777 after merge to confirm the deploy completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)