### PR TITLE
fix(tests): bump ti-market-snapshot-sector-canton-scope timeout to 30s

### DIFF
--- a/tests/ti-market-snapshot-sector-canton-scope.test.ts
+++ b/tests/ti-market-snapshot-sector-canton-scope.test.ts
@@ -31,6 +31,10 @@ describe('ti-market-snapshot-sector-canton-scope', () => {
 
     const tiOut = generateSectorSnapshotPages({ history: null, jobs: tiJobs as never });
     const allOut = generateSectorSnapshotPages({ history: null, jobs: jobs as never });
+    // ^ two full generateSectorSnapshotPages passes (TI subset + all-CH) over
+    // an ever-growing data/jobs.json (80+ dedicated crawlers, several updates
+    // daily) — the default 15s testTimeout is no longer enough headroom; see
+    // the explicit per-test override below.
 
     // At least one sector must show fewer TI-only matches than all-Switzerland
     // matches — proves the filter (applied in closeBundle(), before this
@@ -52,5 +56,5 @@ describe('ti-market-snapshot-sector-canton-scope', () => {
         `${sector} TI-scoped count exceeds the total TI job pool`,
       ).toBeLessThanOrEqual(tiJobs.length);
     }
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## Implementato

- `main` is currently red (tests.yml run at 2026-07-16T18:40:08Z, before this PR existed — confirmed via `gh run view` on that run, same failure, unrelated to any in-flight PR): `tests/ti-market-snapshot-sector-canton-scope.test.ts` times out at the default 15s `testTimeout` (observed 17095ms in CI).
- Root cause: the test runs `generateSectorSnapshotPages` twice (TI subset + full-CH pass) over `data/jobs.json`, which grows daily from 80+ dedicated crawlers (per the file's own header comment) — the computation has legitimately outgrown the global 15s budget.
- Fix: added a per-test `30_000` timeout override, following the exact same established pattern already used elsewhere in this suite for large-dataset tests (`tests/cleanup-jobs-archive-dedup-losers.test.ts`, `tests/search-console-compat.test.ts`, `tests/i18n.test.ts`, etc.) — not a global timeout increase, not a lowered assertion/threshold, just wall-clock headroom for a correctness-unchanged computation on naturally-growing data.
- Verified locally: `npx vitest run tests/ti-market-snapshot-sector-canton-scope.test.ts` → 1/1 passed (6866ms with local stale `data/jobs.json`).
- GitNexus `detect_changes(scope:"all")`: `risk_level: "low"`, 0 changed symbols (test-only change), 0 affected processes.
- Sibling-pattern check (`.githooks/pre-push`): "nessun file di codice funnel-critical cambiato vs origin/main — niente da analizzare" (test-only diff, clean push, no `--no-verify` needed).

## Non implementato (ancora)

Nessuno — root cause identified (dataset growth vs static timeout), fix applied and verified, no further scope.