### PR TITLE
fix(journalist): trust submitter identity over topic-guessed byline

### DIFF
--- a/data/authors.ts
+++ b/data/authors.ts
@@ -35,6 +35,8 @@ export interface Author {
   photoPath: string;
   /** Optional contact email. */
   email?: string;
+  /** Firebase Auth uid for guest journalists — trusted for byline attribution over topic guessing (see pickAuthorForTopic). */
+  uid?: string;
   /** Optional downloadable CV, e.g. `/documents/authors/marco-ferrari-cv.pdf`. */
   cvPath?: string;
   /** Social profiles for `sameAs` JSON-LD signals. */
@@ -110,6 +112,7 @@ export const AUTHORS: ReadonlyArray<Author> = Object.freeze([
   {
     slug: 'samuele-valente',
     name: 'Samuele Valente',
+    uid: 'rAaDN0AvhkUjvRxN2TJijgYodm22',
     role: 'Autore ospite — fiscalità transfrontaliera',
     bio: "Samuele Valente è un professionista esperto di fiscalità internazionale e transfrontaliera tra Italia e Svizzera. Collabora con Frontaliere Ticino come autore ospite, proponendo analisi e commenti sulla prassi dell'Agenzia delle Entrate e sull'applicazione del nuovo Accordo tra Italia e Svizzera sui lavoratori frontalieri, entrato in vigore dal 1° gennaio 2024. Nei suoi contributi approfondisce in particolare le risposte a interpello, i requisiti dell'area di frontiera, la nozione di residenza fiscale e i meccanismi di imposizione concorrente che riguardano i frontalieri del Canton Ticino e delle regioni italiane di confine. Il suo obiettivo è tradurre la normativa e i documenti di prassi in indicazioni chiare e operative per i lavoratori e le imprese interessati dalla disciplina convenzionale.",
     photoPath: '/images/authors/samuele-valente.webp',

--- a/data/blog-articles-data.ts
+++ b/data/blog-articles-data.ts
@@ -25673,8 +25673,8 @@ const RAW_ARTICLES = [
  date: '2026-07-16T18:08:24.141Z',
  image: '/images/places/lago-lugano.webp',
  hasCalculator: false,
- authorSlug: 'marco-ferrari',
- authorName: 'Marco Ferrari',
+ authorSlug: 'samuele-valente',
+ authorName: 'Samuele Valente',
  },
  {
  id: 'dividenti-italiani-stop-alle-discriminazioni-fiscali-per-gli-enti-esteri',
@@ -25682,8 +25682,8 @@ const RAW_ARTICLES = [
  date: '2026-07-16T18:09:11.789Z',
  image: '/images/places/lugano-view.webp',
  hasCalculator: false,
- authorSlug: 'marco-ferrari',
- authorName: 'Marco Ferrari',
+ authorSlug: 'samuele-valente',
+ authorName: 'Samuele Valente',
  },
  {
  id: 'frontalieri-la-flat-tax-entra-nel-tuir-dal-2027-imposta-sostitutiva-pari-al-25-d',
@@ -25691,8 +25691,8 @@ const RAW_ARTICLES = [
  date: '2026-07-16T18:09:55.646Z',
  image: '/images/places/mendrisio.webp',
  hasCalculator: false,
- authorSlug: 'marco-ferrari',
- authorName: 'Marco Ferrari',
+ authorSlug: 'samuele-valente',
+ authorName: 'Samuele Valente',
  },
  {
  id: 'telelavoro-dei-frontalieri-tra-italia-e-svizzera-doppia-soglia-tra-fisco-e-previ',
@@ -25700,8 +25700,8 @@ const RAW_ARTICLES = [
  date: '2026-07-16T18:10:34.056Z',
  image: '/images/places/monte-san-salvatore.webp',
  hasCalculator: false,
- authorSlug: 'laura-bianchi',
- authorName: 'Laura Bianchi',
+ authorSlug: 'samuele-valente',
+ authorName: 'Samuele Valente',
  },
  {
  id: 'ticino-traffico-2024',

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -835,6 +835,7 @@ const AUTHORS = Object.freeze([
   Object.freeze({
     slug: 'samuele-valente',
     name: 'Samuele Valente',
+    uid: 'rAaDN0AvhkUjvRxN2TJijgYodm22',
     linkedinUrl: 'https://www.linkedin.com/in/samuele-valente-9b8a4335b/',
     // 'frontalieri' deliberately excluded: optimizeSeoMetadata()'s baseKeywords
     // (line ~5998) appends it to literally every article's seo.keywords, which
@@ -898,6 +899,19 @@ function pickAuthorForTopic(articleSection, articleId) {
     : _authorRoundRobinIdx++ % AUTHORS.length;
   const a = AUTHORS[idx];
   return { slug: a.slug, name: a.name, linkedinUrl: a.linkedinUrl };
+}
+
+/**
+ * Looks up a registered guest journalist by Firebase Auth uid (see the `uid`
+ * field on data/authors.ts's AUTHORS + this file's mirror). Returns
+ * `undefined` if no author in the registry has that uid — callers must not
+ * fall back to pickAuthorForTopic() for a known human submitter; see
+ * scripts/publish-journalist-article.mjs's resolveJournalistAuthor().
+ */
+function getAuthorByUid(uid) {
+  if (!uid) return undefined;
+  const a = AUTHORS.find((author) => author.uid === uid);
+  return a ? { slug: a.slug, name: a.name, linkedinUrl: a.linkedinUrl } : undefined;
 }
 
 /** Tiny FNV-1a-ish hash for stable author bucketing. Not cryptographic. */
@@ -9936,7 +9950,7 @@ export { buildBodyFile };
 // own en/de/fr slugs (deriveLocaleSlugs()) but, before this fix, never
 // validated them against the registry — the same gap that historically only
 // existed for the IT slug in the AI path.
-export { translateArticle, enforceStrongInternalLinks, findBestFallbackImage, pickAuthorForTopic, sanitizeBoldFormatting, validateAndEnforceCTA, optimizeSeoMetadata, checkTranslatedSlugCollisions };
+export { translateArticle, enforceStrongInternalLinks, findBestFallbackImage, pickAuthorForTopic, getAuthorByUid, sanitizeBoldFormatting, validateAndEnforceCTA, optimizeSeoMetadata, checkTranslatedSlugCollisions };
 
 // Redazione redesign (issue #3174 follow-up): the journalist now authors only
 // {title, body}; these derive the title-casing/excerpt/body1-3/cover-image

--- a/scripts/publish-journalist-article.mjs
+++ b/scripts/publish-journalist-article.mjs
@@ -53,6 +53,7 @@ import {
   enforceStrongInternalLinks,
   findBestFallbackImage,
   pickAuthorForTopic,
+  getAuthorByUid,
   sanitizeBoldFormatting,
   validateAndEnforceCTA,
   optimizeSeoMetadata,
@@ -225,6 +226,31 @@ async function resolveHeroImage(data, doc) {
   return { source: 'static-fallback', path: data.image };
 }
 
+/**
+ * Resolves the byline for a journalist submission from its own captured
+ * identity (`doc.authorUid`/`doc.authorName`, set at draft time in
+ * journalistArticleService.ts) — never by guessing via article topic.
+ *
+ * - Registered guest journalist (uid matches an AUTHORS entry, e.g.
+ *   samuele-valente): full profile byline with author-page slug.
+ * - Authenticated journalist without a registry profile page yet (granted
+ *   access via AdminPanel.tsx "Giornalisti" but not yet added to
+ *   data/authors.ts): real name, generic team slug — correct attribution
+ *   without linking to a nonexistent author page.
+ * - No identity on the doc at all (malformed/legacy doc): `null`, caller
+ *   falls back to pickAuthorForTopic().
+ *
+ * @returns {{slug: string, name: string, linkedinUrl: string|null}|null}
+ */
+function resolveJournalistAuthor(doc) {
+  const registered = doc?.authorUid ? getAuthorByUid(doc.authorUid) : undefined;
+  if (registered) return registered;
+  if (doc?.authorName) {
+    return { slug: 'redazione', name: doc.authorName, linkedinUrl: null };
+  }
+  return null;
+}
+
 async function processDoc(db, FieldValue, docSnap) {
   const docId = docSnap.id;
   const doc = docSnap.data();
@@ -247,10 +273,19 @@ async function processDoc(db, FieldValue, docSnap) {
     console.log('  ✂️  sanitizing bold formatting (sanitizeBoldFormatting, pre-translation)...');
     sanitizeBoldFormatting(data);
 
-    data.author = pickAuthorForTopic(
-      [data.category, data.seo.keywords, data.seo.headline, data.content.it.title, data.id].join(' '),
-      data.id,
-    );
+    // Journalist submissions carry a real, authenticated identity captured at
+    // draft time (JournalistDashboardPage.tsx -> journalistArticleService.ts:
+    // doc.authorUid/authorName) — trust it instead of guessing a teammate by
+    // topic-keyword overlap. pickAuthorForTopic() is for AI-generated content,
+    // which has no real author; using it here previously misattributed every
+    // journalist byline to whichever registry author's keywords happened to
+    // match the article's topic (e.g. samuele-valente's articles landing on
+    // marco-ferrari/laura-bianchi — see issue report 2026-07-16).
+    data.author = resolveJournalistAuthor(doc)
+      || pickAuthorForTopic(
+        [data.category, data.seo.keywords, data.seo.headline, data.content.it.title, data.id].join(' '),
+        data.id,
+      );
 
     const imageResolution = await resolveHeroImage(data, doc);
     console.log(`  🖼️  hero image: ${imageResolution.source}`);
@@ -360,4 +395,4 @@ if (invokedDirectly) {
   });
 }
 
-export { buildPipelineData, slugify, resolveHeroImage };
+export { buildPipelineData, slugify, resolveHeroImage, resolveJournalistAuthor };

--- a/scripts/publish-journalist-article.mjs
+++ b/scripts/publish-journalist-article.mjs
@@ -228,27 +228,27 @@ async function resolveHeroImage(data, doc) {
 
 /**
  * Resolves the byline for a journalist submission from its own captured
- * identity (`doc.authorUid`/`doc.authorName`, set at draft time in
- * journalistArticleService.ts) — never by guessing via article topic.
+ * identity (`doc.authorUid`, set at draft time in journalistArticleService.ts)
+ * — never by guessing via article topic.
  *
- * - Registered guest journalist (uid matches an AUTHORS entry, e.g.
- *   samuele-valente): full profile byline with author-page slug.
- * - Authenticated journalist without a registry profile page yet (granted
- *   access via AdminPanel.tsx "Giornalisti" but not yet added to
- *   data/authors.ts): real name, generic team slug — correct attribution
- *   without linking to a nonexistent author page.
- * - No identity on the doc at all (malformed/legacy doc): `null`, caller
- *   falls back to pickAuthorForTopic().
+ * Only returns non-null for a uid that matches a registered guest journalist
+ * (e.g. samuele-valente in data/authors.ts / the AUTHORS mirror here), since
+ * `slug` doubles as both the JSON-LD Person `@id`/`url` and the CSR byline
+ * link target (components/community/BlogArticles.tsx) — pairing a real name
+ * with a slug that resolves to a *different* declared Person (e.g. the
+ * generic 'redazione' team page) would create an E-E-A-T entity mismatch:
+ * same `@id`, two different names (review finding on this fix, PR #4325).
+ *
+ * An authenticated-but-not-yet-registered journalist (access granted via
+ * AdminPanel.tsx "Giornalisti" but not yet added to data/authors.ts) is not
+ * a regression introduced by this fix — falling through to
+ * pickAuthorForTopic() here is the same pre-existing behavior as before,
+ * for a case this incident never actually involved.
  *
  * @returns {{slug: string, name: string, linkedinUrl: string|null}|null}
  */
 function resolveJournalistAuthor(doc) {
-  const registered = doc?.authorUid ? getAuthorByUid(doc.authorUid) : undefined;
-  if (registered) return registered;
-  if (doc?.authorName) {
-    return { slug: 'redazione', name: doc.authorName, linkedinUrl: null };
-  }
-  return null;
+  return (doc?.authorUid ? getAuthorByUid(doc.authorUid) : undefined) || null;
 }
 
 async function processDoc(db, FieldValue, docSnap) {

--- a/tests/publish-journalist-article-author-attribution.test.ts
+++ b/tests/publish-journalist-article-author-attribution.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Live incident (2026-07-16): journalist Samuele Valente reported his
+ * published articles showed "Marco Ferrari" as the author instead of him.
+ * Root cause: processDoc() in scripts/publish-journalist-article.mjs called
+ * pickAuthorForTopic() unconditionally — the same topic-keyword scorer used
+ * for AI-generated content, which has no real author. For a journalist
+ * submission the doc already carries a real, authenticated identity
+ * (doc.authorUid/authorName, captured at draft time by
+ * JournalistDashboardPage.tsx -> journalistArticleService.ts) but that
+ * identity was discarded in favor of a keyword-match guess, silently handing
+ * the byline to whichever registry author's expertise happened to overlap
+ * the article's topic.
+ *
+ * This mirrors a prior, narrower fix (2026-06-30, samuele-valente missing
+ * from the create-article.mjs AUTHORS mirror — see
+ * tests/create-article-author-registry.test.ts) that only made the guest
+ * author *selectable* by the topic scorer; it did not stop the scorer from
+ * being used for real human submissions at all, so the same class of bug
+ * recurred. resolveJournalistAuthor() removes the topic scorer from the
+ * journalist-publish path entirely except as a last resort for docs with no
+ * identity at all.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveJournalistAuthor } from '../scripts/publish-journalist-article.mjs';
+
+const SAMUELE_UID = 'rAaDN0AvhkUjvRxN2TJijgYodm22';
+
+describe('resolveJournalistAuthor — trusts the submitting journalist identity over topic guessing', () => {
+  it('resolves a registered guest author by uid, regardless of article topic', () => {
+    const doc = {
+      authorUid: SAMUELE_UID,
+      authorName: 'Samuele Valente',
+      authorEmail: 'samuelevalente96@gmail.com',
+    };
+    const resolved = resolveJournalistAuthor(doc);
+    expect(resolved).not.toBeNull();
+    expect(resolved.slug).toBe('samuele-valente');
+    expect(resolved.name).toBe('Samuele Valente');
+  });
+
+  it('never falls through to a different registry author when the uid matches', () => {
+    // Even a doc whose title/category would keyword-match a different
+    // registry author entirely (pensions is laura-bianchi's specialty) must
+    // still resolve to the actual submitting journalist.
+    const doc = { authorUid: SAMUELE_UID, authorName: 'Samuele Valente' };
+    const resolved = resolveJournalistAuthor(doc);
+    expect(resolved.slug).toBe('samuele-valente');
+  });
+
+  it('trusts doc.authorName for an authenticated journalist not yet in the author registry', () => {
+    const doc = { authorUid: 'some-future-journalist-uid-not-registered', authorName: 'Nuova Firma' };
+    const resolved = resolveJournalistAuthor(doc);
+    expect(resolved).toEqual({ slug: 'redazione', name: 'Nuova Firma', linkedinUrl: null });
+  });
+
+  it('returns null (caller falls back to pickAuthorForTopic) when the doc has no identity at all', () => {
+    const doc = { category: 'novita' };
+    expect(resolveJournalistAuthor(doc)).toBeNull();
+  });
+
+  it('returns null for an undefined doc without throwing', () => {
+    expect(resolveJournalistAuthor(undefined)).toBeNull();
+  });
+});

--- a/tests/publish-journalist-article-author-attribution.test.ts
+++ b/tests/publish-journalist-article-author-attribution.test.ts
@@ -17,8 +17,17 @@
  * author *selectable* by the topic scorer; it did not stop the scorer from
  * being used for real human submissions at all, so the same class of bug
  * recurred. resolveJournalistAuthor() removes the topic scorer from the
- * journalist-publish path entirely except as a last resort for docs with no
- * identity at all.
+ * journalist-publish path for any registered author, falling back to it
+ * only when a doc's authorUid has no registry match at all.
+ *
+ * resolveJournalistAuthor() deliberately does NOT build a name-only
+ * fallback (e.g. pairing a real name with a generic 'redazione' slug) for
+ * an authenticated-but-unregistered journalist — a first review round of
+ * this fix did exactly that and was flagged 🔴: `slug` doubles as the
+ * JSON-LD Person `@id`/url and the CSR byline link target, so a made-up
+ * slug pointing to a page that declares a *different* name is an E-E-A-T
+ * entity mismatch. That case falls through to pickAuthorForTopic()
+ * unchanged (pre-existing behavior, not a regression this incident touched).
  */
 import { describe, expect, it } from 'vitest';
 import { resolveJournalistAuthor } from '../scripts/publish-journalist-article.mjs';
@@ -47,10 +56,13 @@ describe('resolveJournalistAuthor — trusts the submitting journalist identity 
     expect(resolved.slug).toBe('samuele-valente');
   });
 
-  it('trusts doc.authorName for an authenticated journalist not yet in the author registry', () => {
+  it('returns null (never a name+generic-slug pairing) for an authenticated journalist not yet in the author registry', () => {
+    // A made-up slug (e.g. 'redazione') paired with the real submitter's name
+    // would create a JSON-LD entity mismatch: same @id, two different
+    // declared Person names (review finding on this fix). Caller falls back
+    // to pickAuthorForTopic() for this case — pre-existing behavior.
     const doc = { authorUid: 'some-future-journalist-uid-not-registered', authorName: 'Nuova Firma' };
-    const resolved = resolveJournalistAuthor(doc);
-    expect(resolved).toEqual({ slug: 'redazione', name: 'Nuova Firma', linkedinUrl: null });
+    expect(resolveJournalistAuthor(doc)).toBeNull();
   });
 
   it('returns null (caller falls back to pickAuthorForTopic) when the doc has no identity at all', () => {


### PR DESCRIPTION
## Implementato

- Root cause fixed: `scripts/publish-journalist-article.mjs` called `pickAuthorForTopic()` (a keyword-overlap scorer meant for AI-generated content, which has no real author) unconditionally for every journalist submission, discarding the real authenticated identity already captured on the Firestore doc (`doc.authorUid`/`doc.authorName`, set at draft time by `JournalistDashboardPage.tsx` → `journalistArticleService.ts`).
- New `resolveJournalistAuthor(doc)` in `scripts/publish-journalist-article.mjs`: resolves the byline from `doc.authorUid` via a new `getAuthorByUid()` registry lookup; returns `null` (falling back to `pickAuthorForTopic()`, pre-existing behavior) when the uid isn't registered or the doc has no identity at all — see review round 2 note below for why a name-only fallback was deliberately not added. Exported + unit tested (`tests/publish-journalist-article-author-attribution.test.ts`, 5 cases).
- New optional `uid` field on `Author` (`data/authors.ts`) and its Node-ESM mirror (`scripts/create-article.mjs`'s `AUTHORS` array — plain `.mjs` can't import `.ts`, this mirror is the file's own documented convention). Populated on `samuele-valente`'s entry with the Firestore-confirmed uid.
- New `getAuthorByUid(uid)` in `scripts/create-article.mjs`, exported alongside `pickAuthorForTopic`.
- Corrected the 4 already-published articles' `authorSlug`/`authorName` in `data/blog-articles-data.ts` from `marco-ferrari`/`laura-bianchi` back to `samuele-valente` (verified 1:1 against live Firestore `journalist_articles` docs — `authorUid`/`authorName`/`authorEmail` all confirmed Samuele Valente on all 4):
  - `diritto-allindennita-di-maternita-della-lavoratrice-frontaliera`
  - `dividenti-italiani-stop-alle-discriminazioni-fiscali-per-gli-enti-esteri` (the article specifically reported)
  - `frontalieri-la-flat-tax-entra-nel-tuir-dal-2027-imposta-sostitutiva-pari-al-25-d`
  - `telelavoro-dei-frontalieri-tra-italia-e-svizzera-doppia-soglia-tra-fisco-e-previ`
- This is a structural fix, not the one-off data patch applied on 2026-07-03 for the same reporter — that patch corrected only the then-wrong articles' data and left `pickAuthorForTopic()` in the journalist-publish call path, which is why it recurred on 4 more articles on 2026-07-16.
- `node --check` clean on both touched `.mjs` files. `npx tsc --noEmit` shows zero errors attributable to `data/authors.ts` (project has pre-existing unrelated errors elsewhere, confirmed via `grep -i authors.ts` on the full output — empty).
- GitNexus `impact()` on `pickAuthorForTopic` (data/authors.ts variant): 0 upstream callers, LOW risk. Manual grep confirmed the only two real call sites of the `create-article.mjs` `pickAuthorForTopic` are its own internal AI-pipeline caller (unchanged, correct) and the now-fixed `publish-journalist-article.mjs` call site.
- Sibling-pattern check (`node scripts/ci/check-sibling-patterns.mjs`) surfaced 22 candidates — all individually inspected, all false positives (see `## Non implementato` below); confirmed via direct grep that no other file in the repo actually calls `pickAuthorForTopic(` (only a comment mention in `scripts/backfill-article-authors.mjs`, not a call).
- **Review round 2 fix (🔴 Important, resolved in `003372080e75`)**: v1 of `resolveJournalistAuthor()` fell back to `{ slug: 'redazione', name: doc.authorName, linkedinUrl: null }` for an authenticated-but-not-yet-registered journalist. Reviewer flagged this as an E-E-A-T/JSON-LD entity mismatch: `slug` drives both the `Person.@id`/`url` in structured data and the CSR byline link (`components/community/BlogArticles.tsx`), and `/autori/redazione/` independently declares its own JSON-LD `name: "Redazione Frontaliere Ticino"` — pairing a real submitter's name with that slug asserts two different names for the same `@id`. Confirmed real by reading `BlogArticles.tsx`'s actual render gating (both the meta-bar byline and the author-bio box require `effectiveAuthorSlug && effectiveAuthorName` together, so there's no clean name-only-no-link middle ground without expanding scope). Fix: removed the fallback branch — `resolveJournalistAuthor()` now returns `null` for any uid without a registry match, falling through unchanged to the pre-existing `pickAuthorForTopic()` behavior for that case (not a regression this incident ever involved). Test suite updated to match (`tests/publish-journalist-article-author-attribution.test.ts`, case 3 rewritten); re-verified `node --check` + full 29-test touched-area suite green before pushing.

## Non implementato (ancora)

Nessuno scope residuo. Tutti i 22 candidati sibling-pattern sono stati ispezionati singolarmente — nessuno condivide il vero antipattern (topic-guessing automatico che scavalca un'identità nota); il match è puramente lessicale su token condivisi (`authorUid`, `linkedinUrl`, la stringa `publish-journalist-article`, o nomi di funzioni *importate* dallo stesso modulo condiviso, non reimplementate):

- **`components/pages/JournalistDashboardPage.tsx`** — falso positivo: lato scrittura (cattura `authorUid`/`authorName` all'invio bozza), già corretto, non chiama `pickAuthorForTopic`.
- **`scripts/generate-journalist-image-catalog.mjs`** — falso positivo: catalogo immagini, dominio scorrelato dall'assegnazione autore.
- **`services/journalistTypes.ts`** — falso positivo: solo definizione di tipo per `authorUid`, nessuna logica.
- **`.github/workflows/publish-journalist-articles.yml`** — falso positivo: trigger CI che invoca lo script per nome file, nessun codice duplicato.
- **`scripts/batch-add-faq-to-articles.mjs`** — falso positivo: importato da `publish-journalist-article.mjs` per arricchimento FAQ, scorrelato dall'autore.
- **`services/journalistArticleService.ts`** — falso positivo: lato scrittura Firestore del draft (già verificato corretto in precedenza), non chiama `pickAuthorForTopic`.
- **`services/journalistImageCatalog.ts`** — falso positivo: catalogo immagini, scorrelato.
- **`.github/workflows/notify-journalist-article-live.yml`** — falso positivo: riferimento al nome file dello script trigger.
- **`functions/src/redazioneAdminCore.js`** — falso positivo: meccanismo di reassign MANUALE via admin (`article_author_overrides`, patch runtime lato client, non riscrive l'HTML statico) — architetturalmente diverso, nessun topic-guessing automatico.
- **`scripts/backfill-article-authors.mjs`** — falso positivo: menzione in un commento (`pickAuthorForTopic()'s keyword match`), nessuna call reale; questo script è round-robin cieco e esclude deliberatamente i guest specialist dal proprio pool (proprio commento in-file, incidente PR #3625).
- **`scripts/check-journalist-article-links.mjs`** — falso positivo: riferimento al nome file dello script.
- **`scripts/ci/check-seo-pages-syntax.mjs`** — falso positivo: riferimento al nome file dello script in una lista di file da validare.
- **`scripts/enrich-employer-contacts.mjs`** — falso positivo: campo `linkedinUrl` riusato in un dominio completamente diverso (contatti datori di lavoro).
- **`scripts/fetch-article-performance.mjs`** — falso positivo: riferimento al nome file dello script.
- **`scripts/fetch-article-trending.mjs`** — falso positivo: riferimento al nome file dello script.
- **`scripts/generate-events-digest-article.mjs`** — falso positivo: riferimento al nome file dello script.
- **`scripts/notify-journalist-article-live.mjs`** — falso positivo: usa correttamente `doc.authorEmail`/`doc.authorName` per l'email di notifica (motivo per cui quell'email era già corretta mentre la byline della pagina no) — non chiama `pickAuthorForTopic`.
- **`services/articleDocumentImport.ts`** — falso positivo: solo riferimento al nome componente `JournalistDashboardPage`.
- **`services/journalistAdminService.ts`** — falso positivo: solo riferimento al nome componente `JournalistDashboardPage`, nessuna logica di assegnazione autore.
- **`services/redazioneAdminService.ts`** — falso positivo: client del meccanismo di reassign MANUALE (`reassignArticleAuthor()`), stesso discorso di `redazioneAdminCore.js` — override esplicito admin, non guessing automatico.
- **`services/seo/article-translations.ts`** — falso positivo: importa `translateArticle` dal modulo condiviso, non lo reimplementa.
- **`services/seo/schema-translators.ts`** — falso positivo: importa `translateArticle` dal modulo condiviso, non lo reimplementa.

## Test plan

- [x] `npx vitest run tests/publish-journalist-article-author-attribution.test.ts` — 5/5 verdi (nuovo test che copre `resolveJournalistAuthor`)
- [x] `npx vitest run tests/authors.test.ts tests/create-article-author-registry.test.ts` — 20/20 verdi (registry esistenti, nessuna regressione)
- [x] `npx vitest run tests/publish-journalist-hero-image-timeout.test.ts` — 4/4 verdi (nessuna regressione sull'export list del file toccato)
- [x] `node --check scripts/publish-journalist-article.mjs scripts/create-article.mjs` — sintassi valida
- [x] `npx tsc --noEmit` — zero errori attribuibili a `data/authors.ts`
- [x] Verifica dati: 4 articoli corretti in `data/blog-articles-data.ts` cross-validati 1:1 contro i doc Firestore `journalist_articles` (authorUid/authorName/authorEmail → samuele-valente su tutti e 4)
- [ ] Validazione live post-merge: confermare che le 4 pagine pubblicate mostrino "Samuele Valente" come autore dopo il deploy (curl/verifica diretta) — riporterò l'esito post-merge.

