### PR TITLE
chore(ci): raise Claude automation max-turns fleet-wide + unify model on claude-sonnet-5

### DIFF
--- a/.github/workflows/crawler-data-quality-audit.yml
+++ b/.github/workflows/crawler-data-quality-audit.yml
@@ -48,7 +48,8 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 25→30 (2026-07-17): headroom per il cap turni alzato 65→80.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -130,7 +131,8 @@ jobs:
           # allowlisted leading binary) plus a self-inflicted import error burned
           # turns before any real audit work (issue #3679). Not a cost-cut lower,
           # AGENTS.md permits raising turns for legitimate complexity.
-          claude_args: "--max-turns 65 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob'"
+          # 65→80 (2026-07-17, owner): fleet-wide bump of every Claude max-turns cap.
+          claude_args: "--max-turns 80 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob'"
           prompt: |
             Audit qualità dati crawler, settimanale. Finestra lookback: ${{ env.WINDOW_DAYS }} giorni.
 

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -32,7 +32,9 @@ jobs:
        github.event.sender.login == 'frontaliere-automation[bot]' ||
        startsWith(github.event.sender.login, 'claude'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30→40 (2026-07-17): headroom per il cap turni alzato 50→70 — senza, il
+    # timeout ucciderebbe a metà turno quello che il cap voleva lasciar finire.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -122,7 +124,10 @@ jobs:
             # 0 PR, issue ri-accodata -> retry = doppio burn. Il cap esiste
             # anti-runaway, non come budget di lavoro: tenerlo sopra il p99
             # osservato dei run sani.
-            echo "max_turns=50" >> "$GITHUB_OUTPUT"
+            # 50->70 (2026-07-17, owner): bump fleet-wide di tutti i cap Claude
+            # dopo l'ennesimo error_max_turns (pr-review-loop tier high, run
+            # 29556645538) — stessa regola: cap sopra il p99, mai budget.
+            echo "max_turns=70" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
@@ -132,7 +137,8 @@ jobs:
             # il bump #1919 copriva solo il tier high (40->50); il campione
             # 7gg aveva mostrato solo morti opus (bias). Stessa regola: cap
             # anti-runaway sopra il p99 dei run sani, non budget di lavoro.
-            echo "max_turns=40" >> "$GITHUB_OUTPUT"
+            # 40->55 (2026-07-17, owner): bump fleet-wide, vedi tier high sopra.
+            echo "max_turns=55" >> "$GITHUB_OUTPUT"
           fi
           echo "Fix tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
           # Aggregate detection (deterministic, da titolo "N item deferred", N>=2).

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -92,7 +92,8 @@ jobs:
         # build-plugin/workflow CI/test gate, o uno script che MUTA/emette dati
         # indicizzati (backfill/migrate/assemble/sitemap/canonical/slug/
         # structured-data/seo). Bug lì = rischio propagato su ogni merge → probing
-        # rigoroso paga. Tier normal (claude-sonnet-4-6) per il resto. Mirror ESATTO di
+        # rigoroso paga. Tier normal per il resto (stesso modello claude-sonnet-5,
+        # unificato owner 2026-07-17 — mai claude-sonnet-4-6; cambiano solo i turni). Mirror ESATTO di
         # pr-review-loop: il bare `scripts/` NON escala più (mandava ogni menzione
         # di script — inclusi helper `scripts/{ci,dev,evals}/` e audit/report
         # read-only — a opus@40; osservato 2026-06-04 come tier-breadth waste). Gli
@@ -130,7 +131,7 @@ jobs:
             echo "max_turns=70" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
-            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
             # 30->40 (misurato 2026-06-12 post-#1919): 3 run tier=normal morti
             # error_max_turns al cap nella sola finestra 06:00-07:30Z (run
             # 27397873962/27399888568/27400421268, follow-up #1918/#1931) —

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -100,7 +100,8 @@ jobs:
           # (permissionMode resta "default", quasi ogni Bash bloccato); i workflow con
           # trigger workflow_run/issues invece funzionano con la stessa config identica.
           # 20→30 (2026-07-17, owner): bump fleet-wide di tutti i cap max-turns Claude.
-          claude_args: "--max-turns 30 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
+          # Modello → claude-sonnet-5 (owner 2026-07-17: mai claude-sonnet-4-6).
+          claude_args: "--max-turns 30 --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.
 

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -34,7 +34,8 @@ concurrency:
 jobs:
   harvest:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # 12→18 (2026-07-17): headroom per il cap turni alzato 20→30.
+    timeout-minutes: 18
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -98,7 +99,8 @@ jobs:
           # schedule/workflow_dispatch il flag non produce mai bypassPermissions
           # (permissionMode resta "default", quasi ogni Bash bloccato); i workflow con
           # trigger workflow_run/issues invece funzionano con la stessa config identica.
-          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
+          # 20→30 (2026-07-17, owner): bump fleet-wide di tutti i cap max-turns Claude.
+          claude_args: "--max-turns 30 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.
 

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -44,7 +44,8 @@ jobs:
     # `follow-up` quando il filtro scopo passa. Vedi FOLLOWUP.md.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 30 # batch di N PR in una sessione (era 10 per una sola PR)
+    # 30→40 (2026-07-17): headroom per il cap turni dinamico alzato (max 60→80).
+    timeout-minutes: 40 # batch di N PR in una sessione (era 10 per una sola PR)
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -78,7 +79,7 @@ jobs:
             {
               echo "batch_prs=${PR}"
               echo "batch_count=1"
-              echo "max_turns=26"
+              echo "max_turns=34" # = maxTurnsFor(1) — tenere allineato a collect-followup-batch.mjs
             } >> "$GITHUB_OUTPUT"
           else
             node scripts/ci/collect-followup-batch.mjs
@@ -135,10 +136,11 @@ jobs:
           # allowed_bots.
           allowed_non_write_users: "github-actions[bot], claude[bot], frontaliere-automation[bot]"
           show_full_output: true
-          # max-turns DINAMICO = min(20 + 6*batch_count, 60), floor 20 (era 20 fisso per
-          # UNA PR). AGENTS.md vieta di ABBASSARE i turni di post-merge-followup (15→20
+          # max-turns DINAMICO = min(26 + 8*batch_count, 80), floor 26 (era
+          # min(20+6n,60); bump fleet-wide 2026-07-17, owner). AGENTS.md vieta di
+          # ABBASSARE i turni di post-merge-followup (15→20
           # fu un fix di `error_max_turns` su PR perse); qui processiamo N PR in una
-          # sessione → vanno ALZATI in proporzione, mai sotto 20. Resta sonnet-4-6.
+          # sessione → vanno ALZATI in proporzione, mai sotto il floor. Resta sonnet-4-6.
           # Se una sessione satura il cap (batch grande) → error_max_turns → run NON
           # success → watermark non avanza → la prossima run schedulata ri-copre la
           # finestra; l'idempotenza salta le PR già commentate, riprende le restanti.

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -140,7 +140,8 @@ jobs:
           # min(20+6n,60); bump fleet-wide 2026-07-17, owner). AGENTS.md vieta di
           # ABBASSARE i turni di post-merge-followup (15→20
           # fu un fix di `error_max_turns` su PR perse); qui processiamo N PR in una
-          # sessione → vanno ALZATI in proporzione, mai sotto il floor. Resta sonnet-4-6.
+          # sessione → vanno ALZATI in proporzione, mai sotto il floor. Modello →
+          # claude-sonnet-5 (owner 2026-07-17: mai claude-sonnet-4-6).
           # Se una sessione satura il cap (batch grande) → error_max_turns → run NON
           # success → watermark non avanza → la prossima run schedulata ri-copre la
           # finestra; l'idempotenza salta le PR già commentate, riprende le restanti.
@@ -156,7 +157,7 @@ jobs:
           # anche con actor umano), non con settings/claude_args. Torniamo allo
           # scoped `--allowedTools` precedente (problema noto ma minore: rifiuta
           # a volte sintassi shell non staticamente analizzabile, non blocca TUTTO).
-          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          claude_args: "--max-turns ${{ steps.collect.outputs.max_turns }} --model claude-sonnet-5 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Triage automatico follow-up in BATCH (${{ github.event_name }}).
             PR da processare (CSV): ${{ steps.collect.outputs.batch_prs }}

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -97,7 +97,8 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.actionable == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30→40 (2026-07-17): headroom per il cap turni alzato 45→60.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -319,7 +320,9 @@ jobs:
           # 2026-07-02: --dangerously-skip-permissions sostituisce --allowedTools scoped
           # (rationale completo: post-merge-followup.yml claude_args comment, stesso
           # fix, evita drift tra copie duplicate).
-          claude_args: "--max-turns 45 --model ${{ steps.guard.outputs.model }} --dangerously-skip-permissions"
+          # 45->60 (2026-07-17, owner): bump fleet-wide di tutti i cap max-turns
+          # Claude dopo l'ennesimo error_max_turns (pr-review-loop run 29556645538).
+          claude_args: "--max-turns 60 --model ${{ steps.guard.outputs.model }} --dangerously-skip-permissions"
           prompt: |
             Sei l'agent di chiusura 🔴 per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.guard.outputs.tier }}. Round: ${{ steps.guard.outputs.round }}/2.
 

--- a/.github/workflows/pr-redflag-fixer.yml
+++ b/.github/workflows/pr-redflag-fixer.yml
@@ -228,16 +228,18 @@ jobs:
             exit 0
           fi
 
-          # Tier (mirror di pr-review-loop / issue-fix): high (claude-sonnet-5) se la PR
+          # Tier (mirror di pr-review-loop / issue-fix): high se la PR
           # tocca CODE funnel-critical (tests/, build-plugins/, scripts/lib/,
-          # services/seo*), normal (sonnet) altrimenti.
+          # services/seo*), normal altrimenti. Modello UNIFICATO claude-sonnet-5
+          # su entrambi i tier (owner 2026-07-17: mai claude-sonnet-4-6); i tier
+          # restano distinti solo per telemetria/prompt.
           crit=$(echo "$files" | grep -E '^(tests/|build-plugins/|scripts/lib/|services/seo)' || true)
           if [ -n "$crit" ]; then
             echo "tier=high"   >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-5"   >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
-            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
           fi
 
           # Posta/incrementa il marker round PRIMA di invocare Claude (così se la

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -292,7 +292,7 @@ jobs:
           # scatta.
           if [ -z "$files" ]; then
             echo "Empty file list (rebase-only or empty PR)."
-            set_tier normal claude-sonnet-4-6 35
+            set_tier normal claude-sonnet-5 35
             exit 0
           fi
           # Strip DATA/static: il tier si decide solo sul CODE.
@@ -309,7 +309,7 @@ jobs:
             # contract, posta review (~4-6 turni osservati). REVERT-TRIGGER: se
             # compaiono `error_max_turns` sul tier minimal → bump 12→16.
             echo "Data/docs-only PR (no reviewable code touched) → tier minimal."
-            set_tier minimal claude-sonnet-4-6 12
+            set_tier minimal claude-sonnet-5 12
             exit 0
           fi
           # funnel_crit <file-list> → exit 0 se la lista contiene CODE funnel-critical
@@ -323,20 +323,10 @@ jobs:
             [ -n "$a$b" ]
           }
 
-          # crawler_parser_only <file-list> → exit 0 se TUTTI i file funnel-critical
-          # sono crawler/parser/adapter di UNA singola fonte datore (fetch+parse di un
-          # employer). Owner-approved 2026-06-30 (Tier-3 token-lever): questi vanno
-          # reviewati dal tier normal/claude-sonnet-4-6 (non tier high) — bug-class =
-          # meno job da una sola fonte, NON regressione SEO/monetizzazione. RESTANO sul
-          # tier high/claude-sonnet-5 (NON match qui): SEO-emitter
-          # (sitemap/canonical/slug/structured-data/assemble/backfill/migrate),
-          # tests/, .github/workflows/, build-plugins/. Conservativo: anche UN solo file
-          # non-crawler nel set → tier high.
-          crawler_parser_only() {
-            local fs="$1" nonmatch
-            nonmatch=$(echo "$fs" | grep -vE '^scripts/update-[a-z0-9-]+-jobs\.mjs$|^scripts/lib/[a-z0-9-]+-job-parser\.mjs$|^scripts/lib/ats-clients/|^scripts/crawl-[a-z0-9-]+\.mjs$|^scripts/(scaffold-crawler|generate-company-parser|generate-company-adapter-stubs|generate-crawler-companies|manage-company-adapter|regen-parser-fix-slices|list-job-crawler-company-keys|check-crawler-health)\.mjs$' || true)
-            [ -z "$nonmatch" ]
-          }
+          # (Rimossa 2026-07-17 la variante crawler_parser_only del 2026-06-30:
+          # discriminava SOLO il modello — claude-sonnet-4-6 sui diff
+          # crawler/parser-only — e il modello è ora UNIFICATO claude-sonnet-5
+          # su ogni tier per decisione owner. Stesso scope e stessi turni.)
 
           # ── Incremental re-review (token-lever): se esiste GIÀ una review Claude su
           # un commit precedente, valuta SOLO il delta dei file della PR dall'ultimo
@@ -344,7 +334,7 @@ jobs:
           # reviewato; ri-leggerlo per intero a ogni fix-push brucia token (osservato
           # su #3038: review Opus full ripetute sullo stesso codice). Modello per
           # criticità del DELTA: funnel-critical → tier high/claude-sonnet-5 (rigore,
-          # scope ridotto); altrimenti tier normal/claude-sonnet-4-6. Prima review /
+          # scope ridotto); altrimenti tier incremental (modello sempre claude-sonnet-5). Prima review /
           # nessun commit precedente / delta vuoto
           # → review piena (sotto). Il fingerprint-skip a monte (guard step) copre già
           # il caso "contributo invariato"; qui il contributo È cambiato, ma in modo
@@ -358,29 +348,23 @@ jobs:
             if [ -n "$delta_code" ]; then
               echo "incremental_base=$lastRev" >> "$GITHUB_OUTPUT"
               echo "Incremental re-review: solo il delta dei file PR da $lastRev:"; echo "$delta_code"
-              if funnel_crit "$delta_code" && ! crawler_parser_only "$delta_code"; then
+              if funnel_crit "$delta_code"; then
                 set_tier incremental-high claude-sonnet-5 35
-              elif funnel_crit "$delta_code"; then
-                # crawler/parser-only funnel-critical delta → sonnet (owner-approved)
-                set_tier incremental-high claude-sonnet-4-6 35
               else
-                set_tier incremental claude-sonnet-4-6 25
+                set_tier incremental claude-sonnet-5 25
               fi
               exit 0
             fi
             echo "Nessun delta-code nei file PR dall'ultima review → review piena."
           fi
 
-          # CODE funnel-critical → high (full scope, 60 turni). Modello: claude-sonnet-5,
-          # salvo i diff crawler/parser-only → claude-sonnet-4-6 (owner-approved
-          # 2026-06-30, stesso scope+turni, solo modello del tier normal). Altrimenti
-          # normal (claude-sonnet-4-6/35).
-          if funnel_crit "$code_files" && ! crawler_parser_only "$code_files"; then
+          # CODE funnel-critical → high (full scope, 60 turni), altrimenti normal
+          # (35 turni). Modello UNIFICATO claude-sonnet-5 su OGNI tier (owner
+          # 2026-07-17: mai claude-sonnet-4-6).
+          if funnel_crit "$code_files"; then
             set_tier high claude-sonnet-5 60
-          elif funnel_crit "$code_files"; then
-            set_tier high claude-sonnet-4-6 60
           else
-            set_tier normal claude-sonnet-4-6 35
+            set_tier normal claude-sonnet-5 35
           fi
 
       - name: Setup Headroom compression proxy

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -246,7 +246,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
-        # Tier high (claude-sonnet-5, max-turns 40, adversarial pass): toccato CODE
+        # Tier high (claude-sonnet-5, max-turns 60, adversarial pass): toccato CODE
         # funnel-critical — test gate, workflow CI, build-plugin SEO, o script
         # che mutano/emettono dati indicizzati (crawler/parser/adapter, backfill,
         # migrate, assemble dataset, sitemap/canonical/slug/structured-data).
@@ -254,7 +254,7 @@ jobs:
         # merge, quindi probing rigoroso paga. Tier normal 15->25 (misurato: 13
         # run/7gg morti `error_max_turns` a num_turns=16 senza postare review,
         # es. run 27345572135/27340191180 - review intera bruciata + PR ferma
-        # fino al rescuer). Tier normal (sonnet, max-turns 25) per
+        # fino al rescuer). Tier normal (sonnet, max-turns 35) per
         # tutto il resto, inclusi gli script NON-funnel: `scripts/{ci,dev,evals}/`
         # (helper CI/dev) e gli audit/report read-only (`audit-*`, `analytics*`,
         # `*-report` — non mutano l'indice, verificano soltanto). Vedi REVIEW.md
@@ -272,7 +272,12 @@ jobs:
         # tier-high su un diff reale sforava i 25 turni e terminava
         # `error_max_turns` SENZA postare review (PR #838, num_turns=26) — peggio
         # del process gate, perché niente LGTM → PR bloccata e zero finding.
-        # 26 turni ≈ 3.5 min; 40 ≈ ~5.5 min, ben dentro il timeout 15 min.
+        # Budget 40→60 (2026-07-17, owner): tier high morto di nuovo al cap 40
+        # senza verdetto su PR #4324 (run 29556645538) — stessa classe #838.
+        # Bump fleet-wide di tutti i tier (cap = anti-runaway sopra il p99 dei
+        # run sani, non budget di lavoro; un run che muore al cap brucia la
+        # quota intera e lascia la PR ferma, peggio di qualche turno in più).
+        # 40 turni ≈ ~5.5 min; 60 ≈ ~8.5 min, ancora dentro il timeout 15 min.
         run: |
           set -euo pipefail
           set_tier() {
@@ -287,7 +292,7 @@ jobs:
           # scatta.
           if [ -z "$files" ]; then
             echo "Empty file list (rebase-only or empty PR)."
-            set_tier normal claude-sonnet-4-6 25
+            set_tier normal claude-sonnet-4-6 35
             exit 0
           fi
           # Strip DATA/static: il tier si decide solo sul CODE.
@@ -295,15 +300,16 @@ jobs:
           if [ -z "$code_files" ]; then
             # Token-lever: una PR data/docs-only (zero code) non ha contributo
             # code-reviewable — l'unica cosa da verificare è il completeness
-            # contract del body. Tier `minimal`: sonnet + max-turns 8 (da 15) +
+            # contract del body. Tier `minimal`: sonnet + max-turns 12 (8→12
+            # nel bump fleet-wide 2026-07-17, il revert-trigger pre-dichiarato) +
             # prompt corto che SALTA la lettura di REVIEW.md, il cross-file
             # probing e l'adversarial check (tutti no-op senza code). Posta
             # comunque `## LGTM` come claude-bot → auto-merge invariato.
-            # 8 turni bastano con margine per: leggi body+files, valida
+            # 12 turni bastano con margine per: leggi body+files, valida
             # contract, posta review (~4-6 turni osservati). REVERT-TRIGGER: se
-            # compaiono `error_max_turns` sul tier minimal → bump 8→12.
+            # compaiono `error_max_turns` sul tier minimal → bump 12→16.
             echo "Data/docs-only PR (no reviewable code touched) → tier minimal."
-            set_tier minimal claude-sonnet-4-6 8
+            set_tier minimal claude-sonnet-4-6 12
             exit 0
           fi
           # funnel_crit <file-list> → exit 0 se la lista contiene CODE funnel-critical
@@ -353,28 +359,28 @@ jobs:
               echo "incremental_base=$lastRev" >> "$GITHUB_OUTPUT"
               echo "Incremental re-review: solo il delta dei file PR da $lastRev:"; echo "$delta_code"
               if funnel_crit "$delta_code" && ! crawler_parser_only "$delta_code"; then
-                set_tier incremental-high claude-sonnet-5 25
+                set_tier incremental-high claude-sonnet-5 35
               elif funnel_crit "$delta_code"; then
                 # crawler/parser-only funnel-critical delta → sonnet (owner-approved)
-                set_tier incremental-high claude-sonnet-4-6 25
+                set_tier incremental-high claude-sonnet-4-6 35
               else
-                set_tier incremental claude-sonnet-4-6 15
+                set_tier incremental claude-sonnet-4-6 25
               fi
               exit 0
             fi
             echo "Nessun delta-code nei file PR dall'ultima review → review piena."
           fi
 
-          # CODE funnel-critical → high (full scope, 40 turni). Modello: claude-sonnet-5,
+          # CODE funnel-critical → high (full scope, 60 turni). Modello: claude-sonnet-5,
           # salvo i diff crawler/parser-only → claude-sonnet-4-6 (owner-approved
           # 2026-06-30, stesso scope+turni, solo modello del tier normal). Altrimenti
-          # normal (claude-sonnet-4-6/25).
+          # normal (claude-sonnet-4-6/35).
           if funnel_crit "$code_files" && ! crawler_parser_only "$code_files"; then
-            set_tier high claude-sonnet-5 40
+            set_tier high claude-sonnet-5 60
           elif funnel_crit "$code_files"; then
-            set_tier high claude-sonnet-4-6 40
+            set_tier high claude-sonnet-4-6 60
           else
-            set_tier normal claude-sonnet-4-6 25
+            set_tier normal claude-sonnet-4-6 35
           fi
 
       - name: Setup Headroom compression proxy

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -79,8 +79,8 @@ Trigger sull'aggiunta della label `agent:fix`. La label È il consenso. Può met
 
 | Tier | Trigger | Model / max-turns |
 |---|---|---|
-| high | issue tocca `crawler`/`parser`/`scripts/`/`build-plugin`/`.github/workflows/`/test gate | opus, 40 |
-| normal | resto | sonnet, 30 |
+| high | issue tocca `crawler`/`parser`/`scripts/`/`build-plugin`/`.github/workflows/`/test gate | claude-sonnet-5, 70 |
+| normal | resto | claude-sonnet-4-6, 55 |
 
 ### CODE vs DATA (no scroll dei blob — frugalità token, mirror del guard reviewer #1096)
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -80,7 +80,7 @@ Trigger sull'aggiunta della label `agent:fix`. La label È il consenso. Può met
 | Tier | Trigger | Model / max-turns |
 |---|---|---|
 | high | issue tocca `crawler`/`parser`/`scripts/`/`build-plugin`/`.github/workflows/`/test gate | claude-sonnet-5, 70 |
-| normal | resto | claude-sonnet-4-6, 55 |
+| normal | resto | claude-sonnet-5, 55 |
 
 ### CODE vs DATA (no scroll dei blob — frugalità token, mirror del guard reviewer #1096)
 

--- a/scripts/ci/collect-followup-batch.mjs
+++ b/scripts/ci/collect-followup-batch.mjs
@@ -29,7 +29,7 @@
  *    con motivo loggato. Meglio una run Claude in più che perdere un follow-up.
  *
  * Output (GITHUB_OUTPUT): `batch_prs=<csv di numeri>`, `batch_count=<n>`,
- *   `max_turns=<n>` (min(20 + 6*batch_count, 60); MAI < 20 — AGENTS.md vieta di
+ *   `max_turns=<n>` (min(26 + 8*batch_count, 80); MAI < 26 — AGENTS.md vieta di
  *   abbassare i turni di post-merge-followup, qui li alza in proporzione al batch).
  *
  * Uso:  node scripts/ci/collect-followup-batch.mjs
@@ -137,9 +137,13 @@ export function hasTriageComment(commentsJson, prefix = TRIAGE_COMMENT_PREFIX) {
   return comments.some((c) => typeof c?.body === 'string' && c.body.trimStart().startsWith(prefix));
 }
 
-/** Turni Claude proporzionati al batch: min(20 + 6*n, 60), floor 20 (mai abbassare). */
+/**
+ * Turni Claude proporzionati al batch: min(26 + 8*n, 80), floor 26 (mai abbassare).
+ * Era min(20+6n,60) — bump fleet-wide 2026-07-17 (owner) di tutti i cap max-turns
+ * Claude dopo l'ennesimo error_max_turns (cap = anti-runaway, non budget di lavoro).
+ */
 export function maxTurnsFor(batchCount) {
-  return Math.min(20 + 6 * Math.max(0, Number(batchCount) || 0), 60);
+  return Math.min(26 + 8 * Math.max(0, Number(batchCount) || 0), 80);
 }
 
 // ── I/O helpers ─────────────────────────────────────────────────────

--- a/tests/collect-followup-batch.test.ts
+++ b/tests/collect-followup-batch.test.ts
@@ -118,12 +118,12 @@ describe('hasTriageComment (idempotency)', () => {
 describe('maxTurnsFor', () => {
   it('never drops below the original floor of 20 (AGENTS.md: mai abbassare)', () => {
     expect(maxTurnsFor(0)).toBeGreaterThanOrEqual(20);
-    expect(maxTurnsFor(1)).toBe(26);
+    expect(maxTurnsFor(1)).toBe(34);
   });
   it('scales with batch size', () => {
-    expect(maxTurnsFor(5)).toBe(50);
+    expect(maxTurnsFor(5)).toBe(66);
   });
-  it('caps at 60', () => {
-    expect(maxTurnsFor(20)).toBe(60);
+  it('caps at 80', () => {
+    expect(maxTurnsFor(20)).toBe(80);
   });
 });


### PR DESCRIPTION
## Implementato

**Bump max-turns fleet-wide** (trigger: review run 29556645538 su PR #4324 morta `terminal_reason=max_turns` al cap 40, tier high, senza verdetto — stessa classe di #838; cap = anti-runaway sopra il p99 dei run sani, mai budget di lavoro):

- `pr-review-loop.yml`: high 40→60, normal 25→35, incremental-high 25→35, incremental 15→25, minimal 8→12 (valore revert-trigger pre-dichiarato nel commento), fallback PR-vuota 25→35
- `issue-fix.yml`: high 50→70, normal 40→55; timeout 30→40 min
- `post-merge-followup.yml`: `maxTurnsFor` min(20+6n,60) → **min(26+8n,80)** (`scripts/ci/collect-followup-batch.mjs`), dispatch fisso 26→34 (= maxTurnsFor(1)); timeout 30→40 min
- `pr-redflag-fixer.yml`: 45→60; timeout 30→40 min
- `crawler-data-quality-audit.yml`: 65→80; timeout 25→30 min
- `lessons-harvester.yml`: 20→30; timeout 12→18 min
- test aggiornati: `tests/collect-followup-batch.test.ts` (nuova formula, 20/20 verdi in locale)

I timeout ricevono headroom proporzionale: senza, il timeout ucciderebbe a metà turno ciò che il cap alzato voleva lasciar finire. I 6 monitor Claude senza `--max-turns` esplicito non sono toccati (nessun cap da alzare).

**Modello unificato claude-sonnet-5** (decisione owner 2026-07-17: mai più claude-sonnet-4-6 nelle attività Claude automatiche; i tier restano distinti solo per turni/prompt):

- `pr-review-loop.yml`: normal/minimal/incremental/incremental-high/PR-vuota → claude-sonnet-5; rimossa `crawler_parser_only()` (discriminava SOLO il modello — scope e turni erano già identici → branch morti collassati)
- `issue-fix.yml` tier normal, `pr-redflag-fixer.yml` tier normal, `post-merge-followup.yml`, `lessons-harvester.yml` → claude-sonnet-5
- `ISSUES.md`: tabella tier allineata (era stale: "opus, 40 / sonnet, 30" — non rifletteva già più i valori reali)

## Non implementato (ancora)

Nessuno — scope completo. Il sibling-check pre-push (`check-sibling-patterns.mjs --strict`) ha surfacato 3 candidati, tutti valutati individualmente come **falsi positivi** (push `--no-verify` ex AGENTS.md #6):

- `scripts/backfill-newsletter-job-context.mjs` — falso positivo: condivide il token `batchCount` ma è il counter di flush dei batch-write Firestore (soglia 400), nessun turno/cap Claude.
- `scripts/ci/followup-drainer.mjs` — falso positivo: `max_turns`/`allowedTools` compaiono solo in commenti e nel classificatore fix-outcome (rileva run morte per max-turns), nessun cap impostato nel file.
- `scripts/lib/ai-models.mjs` — falso positivo: `allowedTools` citato in un commento sulla semantica dei flag CLI, nessun modello/cap di workflow CI.

Nota merge: la PR modifica `pr-review-loop.yml` → il reviewer Claude non può girare (workflow-validation 401); auto-merge atteso via drift-fallback deterministico (`auto-merge-eval.mjs`: autore fidato + pr-body-contract verde; vitest e collision restano gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)