### PR TITLE
feat(authors): view author CV inline instead of forcing download

### DIFF
--- a/components/community/WhatsNewModal.tsx
+++ b/components/community/WhatsNewModal.tsx
@@ -33,6 +33,18 @@ interface Release {
 
 export const RELEASES: Release[] = [
  {
+ version: '3.61.0',
+ date: '2026-07-17',
+ titleKey: 'whatsNew.v3610.title',
+ items: [
+ {
+ type: 'improvement',
+ titleKey: 'whatsNew.v3610.authorCv.title',
+ descKey: 'whatsNew.v3610.authorCv.desc',
+ },
+ ],
+ },
+ {
  version: '3.60.0',
  date: '2026-07-16',
  titleKey: 'whatsNew.v3600.title',

--- a/components/pages/AutorePage.tsx
+++ b/components/pages/AutorePage.tsx
@@ -132,6 +132,32 @@ export const AutorePage: React.FC<AutorePageProps> = ({ slug }) => {
           </ul>
         </Section>
 
+        {/* CV — embedded PDF viewer (view in-page, no forced download) */}
+        {author.cvPath ? (
+          <Section icon={FileText} title="Curriculum Vitae">
+            <object
+              data={author.cvPath}
+              type="application/pdf"
+              aria-label={`CV di ${author.name} (PDF)`}
+              className="w-full h-[75vh] min-h-[420px] rounded-xl border border-edge"
+            >
+              {/* Fallback for browsers without an inline PDF viewer (most mobile). */}
+              <p>
+                Il tuo browser non supporta l'anteprima PDF integrata.{' '}
+                <a
+                  href={author.cvPath}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline font-medium"
+                >
+                  Apri il CV di {author.name} (PDF)
+                </a>
+                .
+              </p>
+            </object>
+          </Section>
+        ) : null}
+
         {/* Editorial trust footer */}
         <div className="bg-surface rounded-2xl border border-edge p-4 sm:p-6 shadow-sm">
           <h2 className="text-lg font-bold font-display text-strong mb-2">
@@ -190,7 +216,6 @@ function SocialLinks({ author }: { author: Author }) {
     href: string;
     label: string;
     Icon: React.FC<{ size?: number; className?: string }>;
-    download?: boolean;
   }> = [];
   if (author.social.linkedin) {
     items.push({
@@ -220,21 +245,25 @@ function SocialLinks({ author }: { author: Author }) {
     items.push({
       key: 'cv',
       href: author.cvPath,
-      label: `Scarica il CV di ${author.name} (PDF)`,
+      label: `Visualizza il CV di ${author.name} (PDF)`,
       Icon: FileText,
-      download: true,
     });
   }
   if (items.length === 0) return null;
   return (
     <ul className="flex items-center gap-3 mt-3">
-      {items.map(({ key, href, label, Icon, download }) => (
+      {items.map(({ key, href, label, Icon }) => (
         <li key={key}>
           <a
             href={href}
             target={href.startsWith('mailto:') ? undefined : '_blank'}
-            rel={href.startsWith('mailto:') ? undefined : download ? 'noopener noreferrer' : 'noopener me'}
-            download={download || undefined}
+            rel={
+              href.startsWith('mailto:')
+                ? undefined
+                : href.endsWith('.pdf')
+                  ? 'noopener noreferrer'
+                  : 'noopener me'
+            }
             aria-label={label}
             title={label}
             className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-info text-on-accent hover:opacity-90 transition-opacity"

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -3461,6 +3461,9 @@ Regeln:
   'survey.feature.thanks.title': 'Danke!',
   'survey.feature.thanks.body': 'Dein Feedback hilft uns, besser zu werden.',
 
+  'whatsNew.v3610.title': 'Autoren-Lebensläufe direkt auf der Seite',
+  'whatsNew.v3610.authorCv.title': 'CV-Vorschau auf der Autorenseite',
+  'whatsNew.v3610.authorCv.desc': 'Der Lebenslauf der Autoren lässt sich jetzt direkt auf der Profilseite in einer eingebetteten PDF-Vorschau lesen, statt heruntergeladen zu werden.',
   'whatsNew.v3600.title': 'Steuerpräzision pro Kanton',
   'whatsNew.v3600.cantonWithholding.title': 'Realer kantonaler Quellensteuersatz im Lohnvergleich',
   'whatsNew.v3600.cantonWithholding.desc': 'Der Schweizer Nettolohn pro Kanton verwendet jetzt die reale Steuerbelastung des Hauptorts jedes der 26 Kantone (offizielle ESTV-Daten) statt eines generischen Satzes für alle Kantone.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -3458,6 +3458,9 @@ Rules:
   'survey.feature.thanks.title': 'Thank you!',
   'survey.feature.thanks.body': 'Your feedback helps us improve.',
 
+  'whatsNew.v3610.title': 'Author CVs viewable on-site',
+  'whatsNew.v3610.authorCv.title': 'CV preview on the author page',
+  'whatsNew.v3610.authorCv.desc': 'Author CVs can now be read directly on the profile page in an embedded PDF preview, instead of being force-downloaded.',
   'whatsNew.v3600.title': 'Per-canton tax precision',
   'whatsNew.v3600.cantonWithholding.title': 'Real per-canton withholding rate in the salary comparator',
   'whatsNew.v3600.cantonWithholding.desc': 'The Swiss net-by-canton figure now uses the real tax burden of each of the 26 cantons\' capital cities (official ESTV data), instead of one generic rate for every canton.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -3461,6 +3461,9 @@ Règles :
   'survey.feature.thanks.title': 'Merci !',
   'survey.feature.thanks.body': 'Votre avis nous aide à nous améliorer.',
 
+  'whatsNew.v3610.title': 'CV des auteurs consultables sur le site',
+  'whatsNew.v3610.authorCv.title': 'Aperçu du CV sur la page auteur',
+  'whatsNew.v3610.authorCv.desc': 'Le CV des auteurs se consulte désormais directement sur la page de profil via un aperçu PDF intégré, sans téléchargement forcé.',
   'whatsNew.v3600.title': 'Précision fiscale par canton',
   'whatsNew.v3600.cantonWithholding.title': 'Taux d\'imposition réel par canton dans le comparateur de salaires',
   'whatsNew.v3600.cantonWithholding.desc': 'Le salaire net suisse par canton utilise désormais la charge fiscale réelle du chef-lieu de chacun des 26 cantons (données officielles ESTV/AFC), au lieu d\'un taux générique identique pour tous.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -3548,6 +3548,9 @@ Regole:
   'survey.feature.thanks.title': 'Grazie!',
   'survey.feature.thanks.body': 'Il tuo parere ci aiuta a migliorare.',
 
+  'whatsNew.v3610.title': 'CV degli autori visibile nel sito',
+  'whatsNew.v3610.authorCv.title': 'Anteprima del CV nella pagina autore',
+  'whatsNew.v3610.authorCv.desc': 'Il curriculum degli autori ora si sfoglia direttamente nella pagina del profilo con un\'anteprima PDF integrata, senza download forzato.',
   'whatsNew.v3600.title': 'Precisione fiscale per cantone',
   'whatsNew.v3600.cantonWithholding.title': 'Aliquota fiscale reale per cantone nel confronto stipendi',
   'whatsNew.v3600.cantonWithholding.desc': 'Il netto svizzero per cantone ora usa il carico fiscale reale del capoluogo di ciascuno dei 26 cantoni (dati ufficiali ESTV), non più un\'aliquota generica uguale per tutti.',


### PR DESCRIPTION
## Implementato

- `components/pages/AutorePage.tsx` — il link CV nella hero non forza più il download: rimosso l'attributo `download` (e il campo `download` dal tipo interno di `SocialLinks`), label aggiornata da «Scarica il CV…» a «Visualizza il CV…»; `rel` ora differenziato per href `.pdf` (`noopener noreferrer`) vs. profili social (`noopener me`).
- `components/pages/AutorePage.tsx` — nuova sezione «Curriculum Vitae» nella pagina autore: viewer PDF integrato (`<object type="application/pdf">`, `h-[75vh] min-h-[420px]`, dimensioni fisse → no CLS) con fallback per browser senza viewer inline (paragrafo + link che apre il PDF in nuova scheda). Vale per ogni autore con `cvPath` (oggi: `/documents/authors/samuele-valente-cv.pdf`).
- `components/community/WhatsNewModal.tsx` — entry release 3.61.0 (2026-07-17, tipo `improvement`).
- `services/locales/{it,en,de,fr}-core.ts` — chiavi `whatsNew.v3610.*` nei 4 locali.

## Test plan

- [x] `npx vitest run tests/whats-new.test.tsx tests/authors.test.ts` — 35/35 verdi.
- [x] `npx vitest run tests/i18n-completeness.test.ts tests/locale-table-completeness.test.ts` — 24/24 verdi (parità chiavi nei 4 locali).
- [x] `tsc --noEmit`: zero errori nei file toccati (errori pre-esistenti in file non correlati invariati).
- [x] Verifica runtime con Playwright su dev server: `/autori/samuele-valente/` mostra la sezione «Curriculum Vitae» con il PDF renderizzato in-page (2 pagine, viewer Chromium) e il link hero «Visualizza il CV di Samuele Valente (PDF)» senza attributo `download`.

## Non implementato (ancora)

Nessuno.

Nota sibling-gate (`check-sibling-patterns --strict`, push con `--no-verify` come da AGENTS.md §Workflow): entrambi i candidati valutati singolarmente come falsi positivi — questa PR non fixa una classe di bug, aggiunge una feature UI:
- `scripts/generate-whats-new.mjs` — falso positivo: condivide il token `whatsNew` solo perché genera le stesse chiavi i18n che qui sono state aggiunte a mano nel formato canonico (release newest-first, chiavi `whatsNew.vNNNN.*` nei 4 locali); nessun costrutto difettoso da propagare. Il `data/pending-releases.json` locale (untracked) è stato svuotato per evitare una futura entry duplicata via `npm run update-whats-new`.
- `services/seo/seo-blog-ch.ts` — falso positivo: condivide solo il literal della data odierna `2026-07-17`; nessuna relazione semantica col diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
