### PR TITLE
fix(ci): raise issue-fix job timeout to GitHub-hosted max

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -32,9 +32,11 @@ jobs:
        github.event.sender.login == 'frontaliere-automation[bot]' ||
        startsWith(github.event.sender.login, 'claude'))
     runs-on: ubuntu-latest
-    # 30→40 (2026-07-17): headroom per il cap turni alzato 50→70 — senza, il
-    # timeout ucciderebbe a metà turno quello che il cap voleva lasciar finire.
-    timeout-minutes: 40
+    # 40→360 (2026-07-17, #4341): 40min ha già ricausato ci-timeout 2x (#4189,
+    # #4219) dopo il bump 30→40 — stesso costrutto di pr-review-loop.yml, stesso
+    # fix: portato al vero max runner-hosted (360) per non uccidere più a metà
+    # turno lavoro Claude già fatto. Costo: minuti effettivi usati, non il tetto.
+    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Implementato
- `fix` job in `.github/workflows/issue-fix.yml`: `timeout-minutes` 40→360, the GitHub-hosted runner hard ceiling. Same construct and failure mode as `pr-review-loop.yml` (see PR #4346, issue 4341): the job was already bumped once (30→40) after a prior timeout, but hit the same wall twice more (issues 4189, 4219), each time discarding completed Claude fix work. Actual cost stays bounded by minutes used, not the ceiling.

## Non implementato (ancora)
Nessuno.

Related: #4341, #4189, #4219