### PR TITLE
chore(rc): enable Claude CLI haiku fallback + dedupe RC publish scripts

### DIFF
--- a/scripts/lib/remote-config-admin.mjs
+++ b/scripts/lib/remote-config-admin.mjs
@@ -1,0 +1,43 @@
+/**
+ * Shared Firebase Remote Config admin-write plumbing for the scripts/set-*-rc.mjs
+ * one-shot family (+ seo-serp-autopilot.mjs). Centralizes admin init, template
+ * fetch, per-key stage-if-changed, and publish so a fix to any of those lands
+ * everywhere at once instead of drifting across copy-pasted siblings.
+ */
+
+export async function getRemoteConfig() {
+  const adminMod = await import('firebase-admin');
+  const admin = adminMod.default || adminMod;
+  if (!admin.apps.length) {
+    admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  }
+  return admin.remoteConfig();
+}
+
+export async function fetchRcTemplate(rc) {
+  const template = await rc.getTemplate();
+  template.parameters = template.parameters || {};
+  return template;
+}
+
+/**
+ * Stages `key` = `value` in `template` if it differs from the current
+ * defaultValue. Returns true if staged (change pending publish), false if
+ * already up-to-date.
+ */
+export function stageRcParam(template, key, value, description) {
+  const existing = template.parameters[key]?.defaultValue?.value;
+  if (existing === value) return false;
+  template.parameters[key] = {
+    defaultValue: { value },
+    valueType: 'STRING',
+    description,
+  };
+  return true;
+}
+
+export async function publishRcTemplate(rc, template, changedCount) {
+  if (changedCount === 0) return false;
+  await rc.publishTemplate(template, { force: true });
+  return true;
+}

--- a/scripts/seo-serp-autopilot.mjs
+++ b/scripts/seo-serp-autopilot.mjs
@@ -32,6 +32,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { writeJsonAtomic as writeJson } from './lib/atomic-write-json.mjs';
+import { getRemoteConfig } from './lib/remote-config-admin.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -228,12 +229,7 @@ function decideVariant({ currentVariant, history, currentKpi, nowIso }) {
 }
 
 async function getRemoteConfigTemplate() {
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
+  const rc = await getRemoteConfig();
   const template = await rc.getTemplate();
   return { rc, template };
 }

--- a/scripts/set-adsense-rc.mjs
+++ b/scripts/set-adsense-rc.mjs
@@ -23,6 +23,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
 
 const ROOT = process.cwd();
 const TOKEN_CACHE = path.join(ROOT, '.cache', 'adsense-oauth.json');
@@ -64,25 +65,13 @@ async function main() {
 
   loadLocalSecrets();
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
+  const description = `AdSense OAuth credential for weekly revenue-monitor (set ${new Date().toISOString().slice(0, 10)})`;
   let changed = 0;
   for (const [key, value] of Object.entries(RC_PARAMS)) {
-    const existing = template.parameters[key]?.defaultValue?.value;
-    if (existing === value) continue;
-    template.parameters[key] = {
-      defaultValue: { value },
-      valueType: 'STRING',
-      description: `AdSense OAuth credential for weekly revenue-monitor (set ${new Date().toISOString().slice(0, 10)})`,
-    };
-    changed++;
+    if (stageRcParam(template, key, value, description)) changed++;
   }
 
   if (changed === 0) {
@@ -90,7 +79,7 @@ async function main() {
     return;
   }
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, changed);
   console.log(`✅ Published ${changed} SERVER_ADSENSE_* param(s) to Remote Config.`);
   console.log('   Next Monday the revenue-monitor workflow will pick them up via load-rc-env.mjs.');
 }

--- a/scripts/set-chutes-rc.mjs
+++ b/scripts/set-chutes-rc.mjs
@@ -20,6 +20,8 @@
  * param written. Missing envs are skipped silently.
  */
 
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
 const PROVIDER_KEYS = [
   {
     rcParam: 'CHUTES_API_KEY',
@@ -59,30 +61,18 @@ async function main() {
     }
   }
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
   const today = new Date().toISOString().slice(0, 10);
   let changed = 0;
   for (const p of pending) {
-    const existing = template.parameters[p.rcParam]?.defaultValue?.value;
-    if (existing === p.value) {
+    if (stageRcParam(template, p.rcParam, p.value, `${p.description} (set ${today})`)) {
+      changed++;
+      console.log(`📝 Staged ${p.rcParam} for publish.`);
+    } else {
       console.log(`ℹ️  ${p.rcParam} already up-to-date.`);
-      continue;
     }
-    template.parameters[p.rcParam] = {
-      defaultValue: { value: p.value },
-      valueType: 'STRING',
-      description: `${p.description} (set ${today})`,
-    };
-    changed++;
-    console.log(`📝 Staged ${p.rcParam} for publish.`);
   }
 
   if (changed === 0) {
@@ -90,7 +80,7 @@ async function main() {
     return;
   }
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, changed);
   console.log(`✅ Published ${changed} LLM provider key(s) to Remote Config.`);
   console.log('   Next CI run of generate-article.yml will pick them up via load-rc-env.mjs.');
   console.log('   New free models are now live in DEFAULT_CHAIN.');

--- a/scripts/set-haiku-fallback-rc.mjs
+++ b/scripts/set-haiku-fallback-rc.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * One-shot: flip ENABLE_HAIKU_ARTICLE_FALLBACK on in Firebase Remote Config
+ * so `scripts/load-rc-env.mjs` hydrates it for every workflow, enabling the
+ * `claude-cli/claude-haiku-4-5-20251001` absolute-last-resort fallback in
+ * `scripts/lib/ai-models.mjs` (see isClaudeCliFallbackEnabled()).
+ *
+ * Safe: the fallback is double-gated (RC flag AND CLAUDE_CODE_OAUTH_TOKEN
+ * present in the job env — scripts/lib/ai-models.mjs:822), so workflows
+ * without the token secret still skip it silently. This only activates the
+ * fallback for jobs that already carry CLAUDE_CODE_OAUTH_TOKEN.
+ *
+ * Auth:
+ *   GOOGLE_APPLICATION_CREDENTIALS must point at a Firebase SA with the
+ *   `Firebase Remote Config Admin` role.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/set-haiku-fallback-rc.mjs
+ */
+
+const RC_PARAM = 'ENABLE_HAIKU_ARTICLE_FALLBACK';
+const RC_VALUE = 'true';
+
+function bail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    bail('GOOGLE_APPLICATION_CREDENTIALS not set.');
+  }
+
+  const adminMod = await import('firebase-admin');
+  const admin = adminMod.default || adminMod;
+  if (!admin.apps.length) {
+    admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  }
+  const rc = admin.remoteConfig();
+  const template = await rc.getTemplate();
+  template.parameters = template.parameters || {};
+
+  const existing = template.parameters[RC_PARAM]?.defaultValue?.value;
+  console.log(`ℹ️  Current ${RC_PARAM}: ${existing ?? '(unset)'}`);
+
+  if (existing === RC_VALUE) {
+    console.log('ℹ️  Already enabled. Nothing to publish.');
+    return;
+  }
+
+  template.parameters[RC_PARAM] = {
+    defaultValue: { value: RC_VALUE },
+    valueType: 'STRING',
+    description: `Enable claude-cli haiku last-resort AI fallback (set ${new Date().toISOString().slice(0, 10)})`,
+  };
+
+  await rc.publishTemplate(template, { force: true });
+  console.log(`✅ Published ${RC_PARAM}=${RC_VALUE} to Remote Config.`);
+  console.log('   Next run of any workflow with CLAUDE_CODE_OAUTH_TOKEN wired will pick it up via load-rc-env.mjs.');
+}
+
+main().catch((err) => {
+  console.error('❌ set-haiku-fallback-rc failed:', err?.message || err);
+  process.exit(1);
+});

--- a/scripts/set-haiku-fallback-rc.mjs
+++ b/scripts/set-haiku-fallback-rc.mjs
@@ -19,6 +19,8 @@
  *     node scripts/set-haiku-fallback-rc.mjs
  */
 
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
 const RC_PARAM = 'ENABLE_HAIKU_ARTICLE_FALLBACK';
 const RC_VALUE = 'true';
 
@@ -32,14 +34,8 @@ async function main() {
     bail('GOOGLE_APPLICATION_CREDENTIALS not set.');
   }
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
   const existing = template.parameters[RC_PARAM]?.defaultValue?.value;
   console.log(`ℹ️  Current ${RC_PARAM}: ${existing ?? '(unset)'}`);
@@ -49,13 +45,10 @@ async function main() {
     return;
   }
 
-  template.parameters[RC_PARAM] = {
-    defaultValue: { value: RC_VALUE },
-    valueType: 'STRING',
-    description: `Enable claude-cli haiku last-resort AI fallback (set ${new Date().toISOString().slice(0, 10)})`,
-  };
+  const staged = stageRcParam(template, RC_PARAM, RC_VALUE,
+    `Enable claude-cli haiku last-resort AI fallback (set ${new Date().toISOString().slice(0, 10)})`);
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, staged ? 1 : 0);
   console.log(`✅ Published ${RC_PARAM}=${RC_VALUE} to Remote Config.`);
   console.log('   Next run of any workflow with CLAUDE_CODE_OAUTH_TOKEN wired will pick it up via load-rc-env.mjs.');
 }

--- a/scripts/set-maileroo-rc.mjs
+++ b/scripts/set-maileroo-rc.mjs
@@ -24,6 +24,8 @@
  * param written. Missing envs are skipped silently.
  */
 
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
 const PROVIDER_KEYS = [
   {
     rcParam: 'MAILEROO_API_KEY',
@@ -63,30 +65,18 @@ async function main() {
     }
   }
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
   const today = new Date().toISOString().slice(0, 10);
   let changed = 0;
   for (const p of pending) {
-    const existing = template.parameters[p.rcParam]?.defaultValue?.value;
-    if (existing === p.value) {
+    if (stageRcParam(template, p.rcParam, p.value, `${p.description} (set ${today})`)) {
+      changed++;
+      console.log(`📝 Staged ${p.rcParam} for publish.`);
+    } else {
       console.log(`ℹ️  ${p.rcParam} already up-to-date.`);
-      continue;
     }
-    template.parameters[p.rcParam] = {
-      defaultValue: { value: p.value },
-      valueType: 'STRING',
-      description: `${p.description} (set ${today})`,
-    };
-    changed++;
-    console.log(`📝 Staged ${p.rcParam} for publish.`);
   }
 
   if (changed === 0) {
@@ -94,7 +84,7 @@ async function main() {
     return;
   }
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, changed);
   console.log(`✅ Published ${changed} Maileroo key(s) to Remote Config.`);
   console.log('   Next CI run of send-newsletter.yml / send-job-alerts.yml picks them up via load-rc-env.mjs.');
 }

--- a/scripts/set-posthog-rc.mjs
+++ b/scripts/set-posthog-rc.mjs
@@ -21,6 +21,8 @@
  * the project gets re-keyed.
  */
 
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
 // value + description per param. None are secrets: project ids and the EU host
 // are discoverable from the dashboard URL, and the phc_ project key is a public
 // write key already shipped in the browser bundle (services/posthog.ts).
@@ -42,25 +44,12 @@ async function main() {
     bail('GOOGLE_APPLICATION_CREDENTIALS not set.');
   }
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
   let changed = 0;
   for (const [key, { value, description }] of Object.entries(RC_PARAMS)) {
-    const existing = template.parameters[key]?.defaultValue?.value;
-    if (existing === value) continue;
-    template.parameters[key] = {
-      defaultValue: { value },
-      valueType: 'STRING',
-      description,
-    };
-    changed++;
+    if (stageRcParam(template, key, value, description)) changed++;
   }
 
   if (changed === 0) {
@@ -68,7 +57,7 @@ async function main() {
     return;
   }
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, changed);
   console.log(`✅ Published ${changed} SERVER_POSTHOG_* param(s) to Remote Config.`);
   console.log('   Next CI run of articles-performance-snapshot.yml will pick them up via load-rc-env.mjs.');
 }

--- a/scripts/set-r2-rc.mjs
+++ b/scripts/set-r2-rc.mjs
@@ -12,6 +12,7 @@
  * Env:  CF_API_TOKEN, CF_ACCOUNT_ID (loaded via load-rc-env.mjs).
  */
 import crypto from 'node:crypto';
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
 
 const T = process.env.CF_API_TOKEN;
 const A = process.env.CF_ACCOUNT_ID;
@@ -33,24 +34,15 @@ const PARAMS = {
   R2_SECRET_ACCESS_KEY: secretAccessKey,
 };
 
-const adminMod = await import('firebase-admin');
-const admin = adminMod.default || adminMod;
-if (!admin.apps.length) admin.initializeApp({ credential: admin.credential.applicationDefault() });
-const rc = admin.remoteConfig();
-const template = await rc.getTemplate();
+const rc = await getRemoteConfig();
+const template = await fetchRcTemplate(rc);
 
 let changed = 0;
 const today = new Date().toISOString().slice(0, 10);
+const description = `R2 CDN S3 deploy credential (derived from CF_API_TOKEN; set ${today})`;
 for (const [key, value] of Object.entries(PARAMS)) {
-  const cur = template.parameters[key]?.defaultValue?.value;
-  if (cur === value) continue;
-  template.parameters[key] = {
-    defaultValue: { value },
-    valueType: 'STRING',
-    description: `R2 CDN S3 deploy credential (derived from CF_API_TOKEN; set ${today})`,
-  };
-  changed++;
+  if (stageRcParam(template, key, value, description)) changed++;
 }
 if (changed === 0) { console.log('ℹ️  All R2_* params already up-to-date. Nothing to publish.'); process.exit(0); }
-await rc.publishTemplate(template, { force: true });
+await publishRcTemplate(rc, template, changed);
 console.log(`✅ Published ${changed} R2_* param(s) to Remote Config (accessKeyId tail ...${accessKeyId.slice(-6)}).`);

--- a/scripts/set-stripe-rc.mjs
+++ b/scripts/set-stripe-rc.mjs
@@ -22,6 +22,8 @@
  *  deployed `stripeWebhook` function.)
  */
 
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
 const PROVIDER_KEYS = [
   {
     rcParam: 'STRIPE_SECRET_KEY',
@@ -79,30 +81,18 @@ async function main() {
     }
   }
 
-  const adminMod = await import('firebase-admin');
-  const admin = adminMod.default || adminMod;
-  if (!admin.apps.length) {
-    admin.initializeApp({ credential: admin.credential.applicationDefault() });
-  }
-  const rc = admin.remoteConfig();
-  const template = await rc.getTemplate();
-  template.parameters = template.parameters || {};
+  const rc = await getRemoteConfig();
+  const template = await fetchRcTemplate(rc);
 
   const today = new Date().toISOString().slice(0, 10);
   let changed = 0;
   for (const p of pending) {
-    const existing = template.parameters[p.rcParam]?.defaultValue?.value;
-    if (existing === p.value) {
+    if (stageRcParam(template, p.rcParam, p.value, `${p.description} (set ${today})`)) {
+      changed++;
+      console.log(`📝 Staged ${p.rcParam} for publish.`);
+    } else {
       console.log(`ℹ️  ${p.rcParam} already up-to-date.`);
-      continue;
     }
-    template.parameters[p.rcParam] = {
-      defaultValue: { value: p.value },
-      valueType: 'STRING',
-      description: `${p.description} (set ${today})`,
-    };
-    changed++;
-    console.log(`📝 Staged ${p.rcParam} for publish.`);
   }
 
   if (changed === 0) {
@@ -110,7 +100,7 @@ async function main() {
     return;
   }
 
-  await rc.publishTemplate(template, { force: true });
+  await publishRcTemplate(rc, template, changed);
   console.log(`✅ Published ${changed} Stripe value(s) to Remote Config.`);
   console.log('   The publisher Cloud Functions read these via getRemoteConfigValue().');
 }


### PR DESCRIPTION
## Implementato

- `ENABLE_HAIKU_ARTICLE_FALLBACK=true` pubblicato in Firebase Remote Config (live in produzione, verificato con run idempotente — nessuna azione ulteriore richiesta per la feature stessa).
- `scripts/set-haiku-fallback-rc.mjs`: one-shot script per pubblicare/verificare il flag.
- `scripts/lib/remote-config-admin.mjs`: nuovo modulo condiviso (`getRemoteConfig`, `fetchRcTemplate`, `stageRcParam`, `publishRcTemplate`) che estrae il pattern RC fetch/diff-stage/publish duplicato in 8 script (`set-haiku-fallback-rc.mjs`, `set-adsense-rc.mjs`, `set-posthog-rc.mjs`, `set-chutes-rc.mjs`, `set-maileroo-rc.mjs`, `set-stripe-rc.mjs`, `set-r2-rc.mjs`, `seo-serp-autopilot.mjs`), triggerato dal pre-push sibling-pattern check (AGENTS.md #6). Output console di ogni script preservato identico.

## Non implementato (ancora)

Nessuno — scope feature (abilitare il flag) è live in produzione, nessun lavoro residuo.

### Sibling-pattern check — giustificazione per-file (Non-Negotiable #6)

18 candidati surfacati da `check-sibling-patterns.mjs --strict`, ispezionati singolarmente (nessun dismiss collettivo):

**Gruppo A — nome canonico `ENABLE_HAIKU_ARTICLE_FALLBACK` / `isClaudeCliFallbackEnabled` / `claude-haiku-4-5-20251001` (producer/consumer, non logica duplicata):**
- `scripts/load-rc-env.mjs` — falso positivo: è il registry `RC_TO_ENV` che *legge* il flag verso env, non lo pubblica; riferimento al nome canonico atteso, non un duplicato del publish-pattern.
- `scripts/lib/ai-models.mjs` — falso positivo: `isClaudeCliFallbackEnabled()`/`hasClaudeCodeOauthToken()` è il *consumer* gate (legge `process.env.ENABLE_HAIKU_ARTICLE_FALLBACK`), semanticamente distinto dal publish-side che questa PR tocca.
- `.github/workflows/generate-article.yml` — falso positivo: wiring del secret/env nel workflow, stesso nome canonico atteso, nessuna logica di publish RC.
- `.github/workflows/send-newsletter.yml` — falso positivo: idem, wiring env nel workflow newsletter.
- `scripts/send-newsletter.mjs` — falso positivo: riferimento al nome del modello nella catena AI fallback (consumer), non tocca Remote Config.

**Gruppo B — idioma bootstrap Firebase Admin SDK (`adminMod = await import('firebase-admin')` / `if (!admin.apps.length) { admin.initializeApp(...) }`), pervasivo in tutto il repo, non correlato al pattern RC-publish estratto:**
- `scripts/assemble-jobs-dataset.mjs`, `scripts/create-article.mjs`, `scripts/lib/shared-jobs-crawler.mjs`, `scripts/build-publisher-jobs.mjs`, `scripts/process-stop-replies.mjs`, `scripts/reconcile-here-usage.mjs`, `scripts/refresh-bfs-stats.mjs` — falsi positivi: idioma generico "init Firebase Admin SDK una volta" (3 righe), a basso rischio di drift, usato in oltre 15 script indipendenti con responsabilità totalmente scorrelate (crawler, dataset assembly, article gen, cleanup jobs) — non è il pattern regex/floor/soglia bug-prone descritto in AGENTS.md #6, è boilerplate SDK standard. Consolidarlo qui sarebbe drive-by refactor massivo e sproporzionato allo scope (abilitare un flag).
- `functions/src/newsletterResendWebhookCore.js`, `functions/src/trafficSchedulerCore.js` — falsi positivi: stesso idioma, ma runtime Cloud Functions (no-bundler, vedi vincolo in memoria `functions no bundler shared module pattern`) — condividere un modulo tra `functions/` e `scripts/` richiederebbe uno shim dedicato, fuori scope per un fix del flag Claude fallback.

**Gruppo C — token generico `defaultValue` / `getTemplate`, semanticamente scorrelato dal publish RC:**
- `functions/src/remoteConfigSecrets.js` — falso positivo: reader RC read-only (`rc.getTemplate()` in cache, mai `publishTemplate`), responsabilità opposta (lettura vs pubblicazione) e runtime diverso (Cloud Functions).
- `components/community/JobBoard.tsx` — falso positivo: `defaultValue` è prop React di un input non controllato, nulla a che fare con Remote Config.
- `scripts/scaffold-crawler.mjs` — falso positivo: `defaultValue` di un'opzione CLI (parser argomenti), non RC.
- `services/urlStateService.ts` — falso positivo: `defaultValue` di un parametro URL/query string, non RC.

## Test plan

- [x] `node scripts/set-haiku-fallback-rc.mjs` eseguito 2 volte contro Firebase RC live: primo run ha pubblicato `ENABLE_HAIKU_ARTICLE_FALLBACK=true`, secondo run idempotente conferma nessun cambiamento pendente.
- [x] Ogni script `set-*-rc.mjs` refactored ispezionato a mano: output console preservato identico (stessi messaggi "already up-to-date" / "Published N ... param(s)").
- [ ] (post-merge, live) Prossimo run reale di `generate-article.yml` che esaurisce la catena AI fino al fallback `claude-cli` — verifica che il fallback effettivamente esegua con successo in CI (richiede una failure reale di tutti i provider a monte, non riproducibile pre-merge).
