### PR TITLE
fix(ci): issue-fix checkpoint/resume + stable GitHub issue titles

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -180,6 +180,33 @@ jobs:
           fi
           echo "Aggregate: is_aggregate=$(grep is_aggregate= "$GITHUB_OUTPUT" | tail -1)"
 
+      - name: Check for resumable WIP branch (zero-Claude)
+        id: resume
+        if: steps.preflight.outputs.already_resolved != 'true'
+        # Problem A (#4337, confermato via GitHub API + run log): prima di questo
+        # fix commit+push+PR accadevano SOLO alla fine del flusso (dopo il gate
+        # test) — se `--max-turns` si esauriva PRIMA, il container CI moriva e
+        # NULLA veniva mai pushato: 71 turni, $6.58 spesi, edit reali a
+        # `build-plugins/staticPagesPlugin.ts`, ma `fix/issue-4337` mai esistito
+        # su GitHub (404). 100% del lavoro perso, retry costretto a ridiagnosticare
+        # da zero senza sapere che un tentativo precedente era arrivato lì. Ora il
+        # prompt fa un checkpoint WIP (commit+push) appena il fix è applicato,
+        # PRIMA del gate test (vedi step 4 del prompt) — quindi un run morto dopo
+        # quel punto lascia un branch `fix/issue-<N>` reale su origin. Questo step
+        # lo rileva deterministicamente (zero token Claude) così il prompt (step 1)
+        # sa se deve riprendere da lì invece di ricreare un branch fresh.
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -uo pipefail
+          if git ls-remote --exit-code --heads origin "fix/issue-${ISSUE_NUMBER}" >/dev/null 2>&1; then
+            echo "resume=true" >> "$GITHUB_OUTPUT"
+            echo "Branch fix/issue-${ISSUE_NUMBER} già presente su origin → resume da checkpoint WIP."
+          else
+            echo "resume=false" >> "$GITHUB_OUTPUT"
+            echo "Nessun branch fix/issue-${ISSUE_NUMBER} su origin → fresh start."
+          fi
+
       - name: Configure git identity
         if: steps.preflight.outputs.already_resolved != 'true'
         run: |
@@ -196,7 +223,7 @@ jobs:
         # Non far fallire il job sull'exit non-zero della CLI: lo step finale
         # `Classify outcome` decide il colore in base al LAVORO reale (PR aperta
         # per la issue), non al subtype della CLI. Un `error_max_turns` DOPO che
-        # l'agent ha gia' aperto la PR (passo 7) NON e' un fallimento del run:
+        # l'agent ha gia' aperto la PR (passo 9) NON e' un fallimento del run:
         # campione 7gg (#1951) = 4/11 fail issue-fix avevano una PR creata (3
         # gia' MERGED) ma la CLI moriva al cap turni DOPO `gh pr create` → job
         # RED = false-failure che gonfia il failure-rate del loop-health. Stessa
@@ -241,14 +268,16 @@ jobs:
             - **Follow-up aggregata multi-item — is_aggregate=${{ steps.tier.outputs.is_aggregate }} (count=${{ steps.tier.outputs.agg_count }}):** se `is_aggregate=true` questa issue ha ${{ steps.tier.outputs.agg_count }} item distinti e tentarli TUTTI in un run sfora il turn budget → `error_max_turns` → 0 PR, ~2M token persi (osservato #1095/#1101/#1172). **REGOLA FERREA (circuit-breaker):** fixa **ESATTAMENTE UN item** poi FERMATI (per una issue *sweep/batch* "item" = UN singolo target/file: es. "~30 crawlers" → fixa 1 crawler, deferisci gli altri 29). Procedura: (a) capability guard **PER-ITEM** — salta gli item che toccano `.github/workflows/**`/admin/secret (NON abortire l'intera issue), (b) scegli il PRIMO item in-capability a massimo valore funnel, (c) implementa SOLO quello, (d) **appena la PR per quell'unico item è aperta → STOP IMMEDIATO, non iniziare un secondo item** (anche se hai turni residui), (e) elenca tutti gli altri item in `## Non implementato` (motivo `follow-up`/`blocked`) → `post-merge-followup` li ri-accoda come nuova follow-up (re-queue esistente; ogni ciclo chiude ≥1 item → converge). Se `is_aggregate=false`: issue singola, comportamento invariato (capability guard whole-issue come sopra). Razionale: il budget di turni basta per 1 item con margine; 2+ item lo bruciano.
 
             **Fix flow (vedi ISSUES.md):**
-            1. Branch isolato: `git checkout -b fix/issue-$ISSUE_NUMBER`.
-            2. Diagnosi root cause della issue (NON sintomo). Per categoria `crawler`: il selector è driftato → rigenera/aggiusta il parser; preferisci `node scripts/generate-company-parser.mjs` o l'edit mirato del parser/config citato nel body.
+            1. Branch isolato — **resume-aware** (`resume=${{ steps.resume.outputs.resume }}`): se `resume=false`, `git checkout -b fix/issue-$ISSUE_NUMBER` (fresh, come sempre). Se `resume=true` esiste già un branch `fix/issue-$ISSUE_NUMBER` su origin (lasciato da un run precedente morto per max-turns DOPO il checkpoint WIP, vedi step 4) — fai `git fetch origin fix/issue-$ISSUE_NUMBER && git checkout fix/issue-$ISSUE_NUMBER` invece di ricreare da zero. Ispeziona cosa c'è già (`git log --oneline origin/main..HEAD --stat`): se il diff è pertinente alla issue corrente, CONTINUA da lì (non ridiagnosticare/rifare il lavoro già presente). Se il diff sembra stale/scollegato dal body della issue attuale → `git reset --hard origin/main` e riparti pulito — usa giudizio, non è un automatismo cieco.
+               **Questo container CI è GIÀ un checkout isolato monouso** (step `Checkout` in cima al workflow, `actions/checkout@v5` fresh a ogni run). **NON creare un worktree interno `.claude/worktrees/**` qui**: la regola "worktree-first" di `AGENTS.md`/`CLAUDE.md` esiste per sessioni interattive locali con un `main` condiviso — non si applica in un container CI già isolato, e crearne uno dentro non aggiunge isolamento, brucia solo turni rifacendo la meccanica del checkout (osservato #4263: ~6 turni finali sprecati su un ciclo `git diff` → patch → fetch → `.claude/worktrees/... add` → apply mai completato, 0 PR). Lavora direttamente nella root del checkout.
+            2. Diagnosi root cause della issue (NON sintomo). Per categoria `crawler`: il selector è driftato → rigenera/aggiusta il parser; preferisci `node scripts/generate-company-parser.mjs` o l'edit mirato del parser/config citato nel body. **Turn-budget:** se dopo ~15 turni di esplorazione non emerge una root cause chiara, NON continuare a scavare sullo stesso vicolo cieco — restringi lo scope (issue aggregate: scegli un item più semplice, vedi circuit-breaker sopra) o termina pulito con l'outcome `no-root-cause` (già definito in fondo al prompt) invece di bruciare il resto del budget senza convergere.
             3. Applica fix CHIRURGICO alla **CLASSE del bug, NON al singolo file** (AGENTS.md non-negotiable #6): no drive-by refactor / no speculative abstraction, MA per un fix di pattern (regex/replace/guard/floor/threshold/selector/bullet-idiom) `rg`/`grep` i sibling funnel-critical (`scripts/update-*.mjs`, `scripts/lib/*-parser.mjs`, `build-plugins/**`) per lo STESSO costrutto → sweepa l'intera classe nella STESSA PR, oppure giustifica OGNI sibling non toccato in `## Non implementato`. Toccare i file gemelli con lo stesso antipattern NON è drive-by: è il fix completo. Pre-empt del 🔴 reviewer "stesso antipattern nel file gemello" (osservato #1083/#1073 il 2026-06-02: PR mono-file → 🔴 sibling → 2 cicli review+fix sprecati sulla quota Max condivisa).
-            4. Mai abbassare quality gate/test/validation per "far passare" (non-negotiable #1).
-            5. **Gate test pre-PR (anti re-review — OBBLIGATORIO):** prima di committare/aprire la PR, gira i test che coprono l'area che hai toccato: `npx vitest run <path/glob pertinente al code modificato>` (es. fix a un parser → `npx vitest run tests/<area>`). Verde → procedi; rosso introdotto da te → fixa la root cause e ri-gira fino a verde. NON girare la suite intera col `npm test` cieco: qui manca `data/jobs.json` (lo assembla la CI `tests`) → sarebbe rossa per infra, non per il tuo fix; se il tuo cambiamento tocca l'assembly dati gira prima `node scripts/assemble-jobs-dataset.mjs`. **Perché:** la review Claude ora parte SOLO dopo `tests` verde (gate `pr-review-loop` su `workflow_run[tests]==success`). Una PR coi test rossi NON riceve review e resta ferma — e tu sei già terminato → spreco di un ciclo. Test d'area verdi = la suite CI passa al primo colpo e la review parte subito.
-            6. Commit con identity canonica già configurata. Messaggio conventional, in fondo nessuna email non-canonica.
-            7. Push del branch: `git push -u origin fix/issue-$ISSUE_NUMBER`.
-            8. Apri PR con `gh pr create`. Body OBBLIGATORIO (REVIEW.md completeness contract):
+            4. **Checkpoint WIP — commit+push IMMEDIATO (anti-100%-loss, #4337):** appena il fix del passo 3 è applicato (anche se non ancora testato dal gate del passo 6), committa tutto con `git add -A && git commit -m "wip(issue-$ISSUE_NUMBER): checkpoint pre-test"` e pusha SUBITO: `git push -u origin fix/issue-$ISSUE_NUMBER`. **Perché ORA:** prima di questo cambio commit+push+PR accadevano SOLO a fine flusso — un run morto per `--max-turns` prima di arrivarci perdeva il 100% del diff col container (#4337: 71 turni, $6.58, edit reali a `build-plugins/staticPagesPlugin.ts`, branch mai pushato, 404 su GitHub). Con questo checkpoint, se il run muore DOPO questo punto il branch sopravvive su GitHub col diff reale — recuperabile dal prossimo retry via la resume-logic del passo 1, invece di una perdita totale.
+            5. Mai abbassare quality gate/test/validation per "far passare" (non-negotiable #1).
+            6. **Gate test pre-PR (anti re-review — OBBLIGATORIO):** gira UNA VOLTA i test che coprono l'area toccata: `npx vitest run <path/glob pertinente al code modificato>` (es. fix a un parser → `npx vitest run tests/<area>`). Verde → procedi al passo 7. Rosso → NON ri-lanciare l'intero file/suite da capo: rigira SOLO il test fallito con `-t <pattern che matcha il nome del test>`, fixa la root cause, ri-verifica scoped, ripeti finché verde. NON girare la suite intera col `npm test` cieco: qui manca `data/jobs.json` (lo assembla la CI `tests`) → sarebbe rossa per infra, non per il tuo fix; se il tuo cambiamento tocca l'assembly dati gira prima `node scripts/assemble-jobs-dataset.mjs`. NON lanciare un `npx tsc --noEmit` full-repo a meno che il fix tocchi davvero type definitions condivise ampiamente (`types/`, interfacce esportate cross-modulo) — per un fix scoped il vitest sull'area toccata basta. **Perché la tightening:** #4263 (aggregate già ristretto a 1 item dal circuit-breaker) ha bruciato il budget 50 turni su ~25 di diagnosi + DUE pass completi di `npx vitest run` sull'intero file + un `npx tsc --noEmit` full-repo + ~6 turni finali di un ciclo patch→worktree mai completato (vedi passo 1) — zero PR consegnata. Test scoping disciplinato = turni per il fix vero, non per ripetere verifiche già fatte. La review Claude ora parte SOLO dopo `tests` verde (gate `pr-review-loop` su `workflow_run[tests]==success`): una PR coi test rossi non riceve review e resta ferma — spreco di un ciclo.
+            7. Commit (SOLO se ci sono cambi oltre il checkpoint WIP del passo 4, es. fix ai test rossi del passo 6): identity canonica già configurata, messaggio conventional, in fondo nessuna email non-canonica. Se dal passo 4 non è cambiato altro, questo passo è un no-op — non serve squashare: una storia wip+fix sul branch va bene.
+            8. Push (aggiorna il branch già pushato al passo 4 col commit più recente, se presente): `git push -u origin fix/issue-$ISSUE_NUMBER`.
+            9. Apri PR con `gh pr create`. Body OBBLIGATORIO (REVIEW.md completeness contract):
                ```
                ## Implementato
                - <cosa fa il fix>
@@ -257,7 +286,7 @@ jobs:
                ## Non implementato (ancora)
                - <scope NON fatto + motivo: out of scope / follow-up / blocked / posposto>
                ```
-            9. La PR entra automaticamente in `pr-review-loop` → review → `## LGTM` → `auto-merge-on-lgtm`. NON mergiare a mano.
+            10. La PR entra automaticamente in `pr-review-loop` → review → `## LGTM` → `auto-merge-on-lgtm`. NON mergiare a mano.
 
             **Constraint:**
             - Changes chirurgiche, root-cause, una issue alla volta.
@@ -267,7 +296,7 @@ jobs:
             - Mai committare path home assoluti o email personali (Privacy).
             - Se la root cause non è determinabile con confidenza → NON forzare un fix; posta su issue "Root cause non determinata: <cosa hai trovato>. Serve indagine umana." rimuovi nulla e TERMINA senza PR.
             - Se il fix richiede credenziali/segreti non disponibili in CI → documenta in commento e TERMINA senza PR.
-            - **Telemetria outcome (OBBLIGATORIO):** ogni volta che termini, l'ULTIMO commento che posti sulla issue DEVE iniziare con un marker HTML su riga propria: `<!-- FIX_OUTCOME: <code> -->`. `<code>` ∈ `pr-created` (PR aperta) · `blocked-workflows-scope` · `blocked-secrets` · `blocked-admin-settings` · `no-root-cause` · `overlap-skip` · `pr-already-open` · `already-fixed` · `revenue-tracker-manual`. Se apri una PR (passo 7) e non posti altri commenti, aggiungi comunque un commento col solo marker `<!-- FIX_OUTCOME: pr-created -->`. Il lessons-harvester aggrega questi marker per rilevare classi di blocco ricorrenti e proporre migliorie ai doc/prompt (vedi ISSUES.md → "Auto-improvement loop").
+            - **Telemetria outcome (OBBLIGATORIO):** ogni volta che termini, l'ULTIMO commento che posti sulla issue DEVE iniziare con un marker HTML su riga propria: `<!-- FIX_OUTCOME: <code> -->`. `<code>` ∈ `pr-created` (PR aperta) · `blocked-workflows-scope` · `blocked-secrets` · `blocked-admin-settings` · `no-root-cause` · `overlap-skip` · `pr-already-open` · `already-fixed` · `revenue-tracker-manual`. Se apri una PR (passo 9) e non posti altri commenti, aggiungi comunque un commento col solo marker `<!-- FIX_OUTCOME: pr-created -->`. Il lessons-harvester aggrega questi marker per rilevare classi di blocco ricorrenti e proporre migliorie ai doc/prompt (vedi ISSUES.md → "Auto-improvement loop").
 
       - name: Claude usage metrics
         # Skip when the pre-flight short-circuited (Claude never ran → no execution file).

--- a/.github/workflows/recover-prev-slugs.yml
+++ b/.github/workflows/recover-prev-slugs.yml
@@ -175,7 +175,7 @@ jobs:
           EOF
           )
           node scripts/lib/github-issue-creator.mjs \
-            --title "previousSlugs writer regression: ${TOTAL} losses in ${WINDOW}" \
+            --title "previousSlugs writer regression detected" \
             --description "$body" \
             --priority 2 \
             --label bug \

--- a/scripts/monitor-gsc-job-indexation.mjs
+++ b/scripts/monitor-gsc-job-indexation.mjs
@@ -638,7 +638,7 @@ async function createGithubIssue(failedPages, results, priority = 1, titlePrefix
   try {
     const { createGithubIssue: create } = await import('./lib/github-issue-creator.mjs');
     await create({
-      title: `[Monitor] ${titlePrefix}${failedPages.length} job page(s) with indexation issues`,
+      title: `[Monitor] ${titlePrefix}job page(s) with indexation issues`,
       description,
       priority,
       labels: ['Bug'],
@@ -661,6 +661,7 @@ async function createStructuredDataIssue(pages) {
     '## GSC Job Indexation Monitor — Structured Data Errors Detected',
     '',
     `**Date**: ${new Date().toISOString().split('T')[0]}`,
+    `**Affected pages**: ${pages.length}`,
     `**Source**: GSC URL Inspection API — richResultsResult`,
     '',
     '### Affected Pages',
@@ -681,7 +682,7 @@ async function createStructuredDataIssue(pages) {
   try {
     const { createGithubIssue: create } = await import('./lib/github-issue-creator.mjs');
     await create({
-      title: `[Monitor] ${pages.length} job page(s) with structured data issues`,
+      title: '[Monitor] job page(s) with structured data issues',
       description,
       priority: 3,
       labels: ['Bug', 'seo'],

--- a/scripts/verify-post-deploy-seo.mjs
+++ b/scripts/verify-post-deploy-seo.mjs
@@ -340,7 +340,7 @@ async function createGithubIssue(issues) {
     // Use the GitHub issue creator module
     const { createGithubIssue: create } = await import('./lib/github-issue-creator.mjs');
     await create({
-      title: `SEO Regression: ${issues.length} job page(s) with canonical/schema issues`,
+      title: 'SEO Regression: job page(s) with canonical/schema issues',
       description,
       priority: 1,
       labels: ['Bug'],


### PR DESCRIPTION
## Implementato

**Thread 1+2 — `issue-fix.yml` checkpoint + resume + turn-budget tightening** (root cause: confirmed 100% work-loss on max-turns death, issue #4337 — 71 turns/$6.58 spent, real edits made, zero branch ever pushed):
- New zero-Claude step `Check for resumable WIP branch` (`git ls-remote --heads origin fix/issue-<N>`) sets `steps.resume.outputs.resume`.
- Prompt step 1 (branch creation) is now resume-aware: fetches+continues an existing WIP branch instead of blindly recreating, or resets if the existing diff is stale/unrelated.
- New prompt step: WIP checkpoint commit+push immediately after the fix is applied, **before** the test-gate — so a mid-run max-turns death preserves the real diff on the branch instead of losing it, recoverable by the next retry via the resume step above.
- Forbids the CI agent from creating an internal `.claude/worktrees/**` (this container is already isolated; observed on issue #4263 burning ~6 turns on an incomplete `git diff`→patch→`worktree add` cycle that never finished).
- Test-gate step tightened: run the touched-area test once, re-run scoped to only failing tests on failure, no redundant full-repo `tsc --noEmit` unless the fix touches shared types broadly (also from #4263: two full vitest passes + one full tsc burned turns for a single-file fix).
- Diagnosis step gained a ~15-turn budget note: narrow scope or exit via the existing `no-root-cause` outcome instead of grinding past it.

**Thread 3 — stable GitHub issue titles (dedup fix)** (root cause: `github-issue-creator.mjs`'s dedup matches only the first `DEDUP_TITLE_PREFIX_LEN=60` chars of the title; embedding a per-run variable count early in the title makes every run's prefix different, so dedup never fires and the same regression gets re-filed every cycle — confirmed 21× "previousSlugs writer regression" issues from this exact bug):
- `recover-prev-slugs.yml`: title changed from `previousSlugs writer regression: ${TOTAL} losses in ${WINDOW}` → stable `previousSlugs writer regression detected` (count/window already present in the issue body, unchanged).
- `scripts/verify-post-deploy-seo.mjs`: title changed from `SEO Regression: ${issues.length} job page(s)...` → stable `SEO Regression: job page(s) with canonical/schema issues` (count already in body via `**Affected pages**`).
- `scripts/monitor-gsc-job-indexation.mjs` (2 call sites): `[Monitor] ${titlePrefix}${failedPages.length} job page(s)...` → stable `[Monitor] ${titlePrefix}job page(s) with indexation issues` (count already in body via the PASS/FAIL/WARN/STALE summary line); `[Monitor] ${pages.length} job page(s) with structured data issues` → stable `[Monitor] job page(s) with structured data issues` (added an explicit `**Affected pages**: ${pages.length}` line to the body, since none existed before, to preserve the count).

Tests: `npx vitest run tests/github-issue-creator-gate.test.ts` green (8/8) before and after, on the combined branch. YAML validated (`yaml.safe_load`), edited `.mjs` files validated (`node --check`).

## Non implementato (ancora)

Nessuno.

**Sibling-pattern check (AGENTS.md #6) — pre-push hook `check-sibling-patterns.mjs --strict` surfaced 25 candidates sharing tokens with this diff (`FIX_OUTCOME`, `ISSUE_NUMBER`, `titlePrefix`, `failedPages`, `auto-merge-on-lgtm`, `generate-company-parser`). Each individually inspected — all confirmed false positives, pushed with `--no-verify` per the documented exception:**

- `scripts/ci/followup-drainer.mjs`, `scripts/ci/check-issue-already-resolved.mjs`, `scripts/ci/is-followup-fix-pr.mjs`, `scripts/ci/auto-merge-eval.mjs`, `scripts/ci/auto-merge-sweep.mjs`, `scripts/ci/pr-autorebase.mjs`, `scripts/ci/pr-collision-detector.mjs`, `scripts/ci/lib/constants.mjs`, `scripts/generate-company-parser.mjs`, `scripts/validate-jsonld-shape.mjs`, `.github/workflows/auto-merge-sweep.yml`, `.github/workflows/issue-triage.yml`, `.github/workflows/post-merge-followup.yml`, `.github/workflows/pr-body-contract.yml`, `.github/workflows/pr-collision-detector.yml`, `.github/workflows/tests.yml`, `build-plugins/jobMarketSnapshotChCantonPages.ts`, `build-plugins/weeklyEmployersChCantonPages.ts`, `components/pages/AdminPanel.tsx` — zero `git commit`/`git push`/`gh pr create`/`createGithubIssue`/`--title` constructs in any of them; the shared token is incidental vocabulary reuse (e.g. `ISSUE_NUMBER` as an unrelated env var name, `FIX_OUTCOME` marker values referenced only for parsing/telemetry, `titlePrefix`/`failedPages` as unrelated local variable names, `auto-merge-on-lgtm`/`generate-company-parser` as the *name* of another workflow mentioned in a comment or UI string).
- `scripts/ci/check-workflows-scope.mjs:8` — mentions "git push" only inside a prose comment describing a different failure mode (GH_TOKEN lacking workflows scope); no actual commit/push construct in the file.
- `.github/workflows/pr-review-loop.yml:19` — mentions "gh pr create" only inside a comment referencing the discipline enforced elsewhere (issue-fix.yml's own test-gate rule); no commit/push/PR construct of its own.
- `.github/workflows/gh-pat-expiry-monitor.yml` — 3 `--title` calls to `github-issue-creator.mjs`, but all 3 titles (`LOAD_FAIL_TITLE`, `EXPIRY_TITLE`, and a third static string) are fully static strings with zero per-run variable embedded — not subject to the dedup-breaking bug fixed here.
- `.github/workflows/generate-company-parser.yml:102` — a `git commit` exists, but it's a single deterministic `node scripts/generate-company-parser.mjs` script call (not a multi-turn Claude Code CLI agentic session with a `--max-turns` budget) followed immediately by an atomic commit — either the script completes and produces a file, or it fails outright with nothing created yet to lose. No incremental-work-loss risk of the class fixed in `issue-fix.yml`.
- `scripts/ci/harvest-agent-lessons.mjs:614` — calls `createGithubIssue({ title: escalationTitle(c), ... })`; `escalationTitle` (line 405-407) already builds a title keyed only on the stable bucket identity (`c.source`/`c.key`), with no per-run count embedded — this is in fact the exact fix pattern applied here, already correctly in place (context comment at lines 597-604 confirms this was deliberately hardened against title-drift in a prior pass).
- `scripts/lib/github-issue-creator.mjs` — the shared module whose `DEDUP_TITLE_PREFIX_LEN=60` mechanism this PR's Thread 3 fix respects; not itself a sibling needing a fix (all its callers were audited above).
