### PR TITLE
fix(seo): strip scripts before h1/title regex in thin-shell emitters (#4335 follow-up)

### DIFF
--- a/build-plugins/flatHtmlRedirectPlugin.ts
+++ b/build-plugins/flatHtmlRedirectPlugin.ts
@@ -31,6 +31,7 @@
  * staticPages, ogPages, jobs, and the various landing plugins.
  */
 import path from 'node:path';
+import { stripScriptsAndStyles } from '../scripts/lib/strip-scripts-styles.mjs';
 import fs from 'node:fs';
 import type { Plugin } from 'vite';
 
@@ -140,7 +141,7 @@ export function buildFlatBridgeFromSibling(siblingHtml: string, slashUrl: string
   let title = `Redirecting to ${slashUrl}`;
   let ogTags = '';
   try {
-    const titleMatch = siblingHtml.match(/<title[^>]*>([^<]+)<\/title>/i);
+    const titleMatch = stripScriptsAndStyles(siblingHtml).match(/<title[^>]*>([^<]+)<\/title>/i);
     if (titleMatch && titleMatch[1]) {
       const extracted = titleMatch[1].trim();
       if (extracted.length > 0) {
@@ -231,7 +232,7 @@ export function flatHtmlRedirectPlugin(rootDir: string, opts: FlatRedirectOption
         let ogTags = '';
         try {
           const siblingHtml = fs.readFileSync(sibling, 'utf-8');
-          const titleMatch = siblingHtml.match(/<title[^>]*>([^<]+)<\/title>/i);
+          const titleMatch = stripScriptsAndStyles(siblingHtml).match(/<title[^>]*>([^<]+)<\/title>/i);
           if (titleMatch && titleMatch[1]) {
             const extracted = titleMatch[1].trim();
             if (extracted.length > 0) {

--- a/build-plugins/shared/bridgeThinShell.ts
+++ b/build-plugins/shared/bridgeThinShell.ts
@@ -33,6 +33,7 @@
 // remains a valid indexable page.
 
 import { EJP_STRIPPED_MARKER } from './ejpMarker';
+import { stripScriptsAndStyles } from '../../scripts/lib/strip-scripts-styles.mjs';
 import { inlineScriptJson } from './inlineJsonScript';
 import { AGGREGATE_KEY, resolveCantonSection, type CantonLocale } from './cantonSection';
 
@@ -74,7 +75,7 @@ function htmlEscape(s: string): string {
 }
 
 function extractH1(cachedHtml: string): string {
-  const m = cachedHtml.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const m = stripScriptsAndStyles(cachedHtml).match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
   if (!m) return '';
   // Strip nested tags, collapse whitespace
   return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();

--- a/build-plugins/shared/clusterThinShell.ts
+++ b/build-plugins/shared/clusterThinShell.ts
@@ -46,6 +46,7 @@
 // returns 'full' for them. ≤25 h self-heal.
 
 import { EJP_STRIPPED_MARKER } from './ejpMarker';
+import { stripScriptsAndStyles } from '../../scripts/lib/strip-scripts-styles.mjs';
 
 const LOCALE_LISTING_PATH: Record<string, string> = {
   it: '/cerca-lavoro-svizzera/',
@@ -75,7 +76,7 @@ function htmlEscape(s: string): string {
 }
 
 function extractH1(html: string): string {
-  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const m = stripScriptsAndStyles(html).match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
   if (!m) return '';
   return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }

--- a/build-plugins/shared/softLandingThinShell.ts
+++ b/build-plugins/shared/softLandingThinShell.ts
@@ -21,6 +21,7 @@
 // identical to today.
 
 import { EJP_STRIPPED_MARKER } from './ejpMarker';
+import { stripScriptsAndStyles } from '../../scripts/lib/strip-scripts-styles.mjs';
 
 const LOCALE_LISTING_PATH: Record<string, string> = {
   it: '/cerca-lavoro-ticino/',
@@ -50,7 +51,7 @@ function htmlEscape(s: string): string {
 }
 
 function extractH1(html: string): string {
-  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const m = stripScriptsAndStyles(html).match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
   if (!m) return '';
   return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }

--- a/data/gsc-orphan-queries-clusters.json
+++ b/data/gsc-orphan-queries-clusters.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T09:31:00.339Z",
+  "generatedAt": "2026-07-17T10:10:33.165Z",
   "sourceFile": "data/gsc-orphan-queries.json",
   "totalClusters": 1212,
   "gates": {

--- a/data/gsc-orphan-queries-clusters.json
+++ b/data/gsc-orphan-queries-clusters.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T10:10:33.165Z",
+  "generatedAt": "2026-07-17T10:30:22.147Z",
   "sourceFile": "data/gsc-orphan-queries.json",
   "totalClusters": 1212,
   "gates": {

--- a/scripts/lib/caritas-schweiz-job-parser.mjs
+++ b/scripts/lib/caritas-schweiz-job-parser.mjs
@@ -23,7 +23,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace, stripScriptsAndStyles } from './crawler-template.mjs';
 import { extractReflineDetailTitle } from './refline-common.mjs';
 import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
@@ -230,9 +230,7 @@ export function parseReflineDetail(html = '') {
 
   const title = extractReflineDetailTitle(html);
 
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
+  const cleaned = stripScriptsAndStyles(html)
     .replace(/<header[\s\S]*?<\/header>/gi, '')
     .replace(/<footer[\s\S]*?<\/footer>/gi, '')
     .replace(/<nav[\s\S]*?<\/nav>/gi, '');

--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -423,18 +423,9 @@ export function cleanCrawlerArtifacts(text) {
   return out.join('\n\n');
 }
 
-/**
- * Drop <script>/<style> blocks so heading regexes match only rendered DOM.
- * A JSON-LD or JS string inside <script> can contain literal "<h1>…</h1>"
- * markup (Refline JSON-LD incident 2026-07, see refline-common.mjs →
- * extractReflineDetailTitle): matching the raw html captures that embedded
- * text instead of the visible heading.
- */
-export function stripScriptsAndStyles(html = '') {
-  return String(html || '')
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '');
-}
+// Shared with build-plugins and tests — the implementation lives in a
+// zero-dependency module so the vite config graph doesn't inherit crawler deps.
+export { stripScriptsAndStyles } from './strip-scripts-styles.mjs';
 
 /**
  * Strip HTML tags and decode common entities. Use for description fields.

--- a/scripts/lib/pigna-job-parser.mjs
+++ b/scripts/lib/pigna-job-parser.mjs
@@ -19,7 +19,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify } from './crawler-template.mjs';
+import { slugify, stripScriptsAndStyles } from './crawler-template.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -97,9 +97,7 @@ export function parseReflineDetail(html = '') {
   if (!html) return { title: '', description: '' };
   const title = extractReflineDetailTitle(html);
 
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
+  const cleaned = stripScriptsAndStyles(html)
     .replace(/<header[\s\S]*?<\/header>/gi, '')
     .replace(/<footer[\s\S]*?<\/footer>/gi, '')
     .replace(/<nav[\s\S]*?<\/nav>/gi, '');

--- a/scripts/lib/privatklinik-hohenegg-job-parser.mjs
+++ b/scripts/lib/privatklinik-hohenegg-job-parser.mjs
@@ -15,7 +15,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace, stripScriptsAndStyles } from './crawler-template.mjs';
 import { extractReflineDetailTitle } from './refline-common.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -183,9 +183,7 @@ export function parseReflineDetail(html = '') {
 
   const title = extractReflineDetailTitle(html);
 
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
+  const cleaned = stripScriptsAndStyles(html)
     .replace(/<header[\s\S]*?<\/header>/gi, '')
     .replace(/<footer[\s\S]*?<\/footer>/gi, '')
     .replace(/<nav[\s\S]*?<\/nav>/gi, '');

--- a/scripts/lib/refline-common.mjs
+++ b/scripts/lib/refline-common.mjs
@@ -50,7 +50,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace, stripScriptsAndStyles } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   decodeEntities,
@@ -211,9 +211,7 @@ export function extractReflineDetailTitle(html = '') {
     String(parseReflineJobPostingJsonLd(html)?.title || ''),
   )));
   if (jsonLdTitle) return jsonLdTitle;
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '');
+  const cleaned = stripScriptsAndStyles(html);
   const titleMatch = cleaned.match(/<h1[^>]*class="[^"]*posTitle[^"]*"[^>]*>([\s\S]*?)<\/h1>/i)
     || cleaned.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)
     || cleaned.match(/<h2[^>]*>([\s\S]*?)<\/h2>/i)
@@ -226,9 +224,7 @@ export function parseReflineDetail(html = '') {
 
   const title = extractReflineDetailTitle(html);
 
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
+  const cleaned = stripScriptsAndStyles(html)
     .replace(/<header[\s\S]*?<\/header>/gi, '')
     .replace(/<footer[\s\S]*?<\/footer>/gi, '')
     .replace(/<nav[\s\S]*?<\/nav>/gi, '');

--- a/scripts/lib/spital-limmattal-job-parser.mjs
+++ b/scripts/lib/spital-limmattal-job-parser.mjs
@@ -28,7 +28,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace, stripScriptsAndStyles } from './crawler-template.mjs';
 import { extractReflineDetailTitle } from './refline-common.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -201,9 +201,7 @@ export function parseReflineDetail(html = '') {
   const title = extractReflineDetailTitle(html);
 
   // Strip header/nav/footer/script/style noise
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
+  const cleaned = stripScriptsAndStyles(html)
     .replace(/<header[\s\S]*?<\/header>/gi, '')
     .replace(/<footer[\s\S]*?<\/footer>/gi, '')
     .replace(/<nav[\s\S]*?<\/nav>/gi, '');

--- a/scripts/lib/strip-scripts-styles.mjs
+++ b/scripts/lib/strip-scripts-styles.mjs
@@ -1,0 +1,16 @@
+/**
+ * Drop <script>/<style> blocks so heading/title regexes match only rendered
+ * DOM. A JSON-LD or JS string inside <script> can contain literal
+ * "<h1>…</h1>" / "<title>…</title>" markup (Refline JSON-LD incident
+ * 2026-07, PR #4335): matching the raw html captures that embedded text
+ * instead of the visible element.
+ *
+ * Zero-dependency on purpose: consumed by crawler parsers (via re-export in
+ * crawler-template.mjs), build-plugins (vite config graph — must not drag
+ * crawler deps in) and tests.
+ */
+export function stripScriptsAndStyles(html = '') {
+  return String(html || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
+}

--- a/tests/title-length.test.ts
+++ b/tests/title-length.test.ts
@@ -10,6 +10,7 @@
  * The test gracefully no-ops when `dist/` doesn't exist.
  */
 import { describe, it, expect } from 'vitest';
+import { stripScriptsAndStyles } from '../scripts/lib/strip-scripts-styles.mjs';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -42,7 +43,7 @@ function walkHtml(dir: string, out: string[] = []): string[] {
 }
 
 function extractTitle(html: string): string | null {
-  const m = html.match(/<title>([\s\S]*?)<\/title>/i);
+  const m = stripScriptsAndStyles(html).match(/<title>([\s\S]*?)<\/title>/i);
   if (!m) return null;
   return m[1]
     .replace(/&amp;/g, '&')


### PR DESCRIPTION
PR concatenata dei 2 🟡 della review di #4335 (round finale LGTM).

## Implementato

- **🟡 #1 — thin-shell**: `extractH1` in `build-plugins/shared/clusterThinShell.ts` e `softLandingThinShell.ts`, e `extractTitle` in `tests/title-length.test.ts`, ora matchano su HTML script-stripped come gli altri 66 siti dello sweep di #4335. Pagine proprie a rischio pratico basso (le description nei dati sono già plain-text), ma il costrutto era identico e funnel-critical.
- **Estrazione modulo zero-dep** — `stripScriptsAndStyles` vive ora in `scripts/lib/strip-scripts-styles.mjs` (nessuna dipendenza), re-exportata da `crawler-template.mjs` (i ~60 consumer crawler restano invariati). Motivo: i build-plugins stanno nel grafo vite.config e non devono ereditare le dipendenze del modulo crawler (regola no-drift: una sola definizione, mai copy-paste).
- **🟡 #2 — accuratezza audit**: il body di #4335 classificava `sbb-job-parser.mjs` come falso positivo ma il round 4 della stessa PR ne ha strippato i due helper heading — nota di rettifica aggiunta al body di #4335 (commento sotto).

Test: `tests/title-length.test.ts`, `tests/cluster-thin-shell.test.ts`, `tests/soft-landing-thin-shell.test.ts`, `tests/refline-detail-title.test.ts`, campione crawler — verdi. Suite completa verde in locale pre-PR. `tsc --noEmit`: unico errore pre-esistente su main in `AdminPanel.tsx` (file non toccato).

- **Round 2 (review 🔴+🟡)** — `bridgeThinShell.ts` (stesso sibling extractH1 nella stessa cartella, HEAD con JSON-LD JobPosting: scenario Refline esatto) e i due matcher `<title>` di `flatHtmlRedirectPlugin.ts` ora strippati; dedup: `refline-common` + 4 parser bespoke importano `stripScriptsAndStyles` invece di duplicare inline la catena replace che il nuovo modulo elimina. Sweep build-plugins: 0 residui.

## Non implementato (ancora)

Nessuno.
