### PR TITLE
feat(seo): scheduled verification for campaign backlog goals #4298-#4307

### DIFF
--- a/.github/workflows/campaign-goal-check.yml
+++ b/.github/workflows/campaign-goal-check.yml
@@ -1,0 +1,132 @@
+name: Campaign Goal Check
+
+# Weekly verification of the measurable goals declared in the campaign
+# backlog issues #4298-#4307 (14/30/90-day windows). Neither
+# monitor-seo-ctr-by-template.yml (CTR-by-template) nor cwv-monitor.yml
+# (Core Web Vitals) cover these — this workflow is the scheduled check that
+# actually reads the goal's declared source (PostHog/GSC/GA4/Bing) and
+# compares against the target once each goal's window has elapsed.
+#
+# Zero-Claude by design (pure node + the existing gh issue-creator) per the
+# frugality rules in AGENTS.md.
+#
+# State: data/campaign-goal-status.json — a goal that passes is marked
+# terminal ("passed") and never re-evaluated again; a goal that fails opens/
+# dedupes a stable-title GitHub issue and is re-evaluated every run until it
+# passes. A goal below its maturity window stays "observing" (no query, no
+# issue) until CAMPAIGN_START + matureAfterDays.
+#
+# Auth: POSTHOG_PERSONAL_API_KEY/PROJECT_ID, GSC_CLIENT_ID/SECRET/
+# REFRESH_TOKEN, GA4_PROPERTY_ID, BING_API_KEY live in Firebase Remote
+# Config, loaded via scripts/load-rc-env.mjs (same mechanism as
+# cwv-monitor.yml). GSC/GA4 fall back to the Firebase service account
+# (GOOGLE_APPLICATION_CREDENTIALS) when the OAuth refresh token is absent.
+
+on:
+  schedule:
+    # Weekly: Sunday 05:37 UTC — clear of the other Sunday crons
+    # (monitor-gsc-seo.yml 15:00, monitor-seo-ctr-by-template.yml 16:00).
+    - cron: '37 5 * * 0'
+  workflow_dispatch: {}
+
+concurrency:
+  group: campaign-goal-check
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ No Firebase SA credentials — GSC/GA4 SA fallback unavailable"
+          fi
+
+      - name: Load RC secrets
+        run: node scripts/load-rc-env.mjs
+
+      # Primary identity for issue creation = GitHub App installation token
+      # (`frontaliere-automation[bot]`); PAT fallback. Same pattern as
+      # monitor-seo-ctr-by-template.yml / monitor-gsc-seo.yml.
+      - name: Mint App token (primary identity, PAT fallback)
+        continue-on-error: true
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/mint-app-token.mjs
+
+      - name: Run campaign goal check
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ env.APP_TOKEN || secrets.GITHUB_TOKEN }}
+        run: node scripts/campaign-goal-check.mjs
+
+      - name: Cleanup credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json
+
+      - name: Commit goal status if changed
+        if: always()
+        run: |
+          if [ ! -f data/campaign-goal-status.json ]; then
+            echo "No status file generated; skipping commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add data/campaign-goal-status.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(seo): update campaign goal status [skip ci]"
+
+          bash scripts/lib/git-push-with-retry.sh \
+            --branch "$GITHUB_REF_NAME" \
+            --regenerate-cmd "git checkout HEAD@{1} -- data/campaign-goal-status.json 2>/dev/null || true; git add data/campaign-goal-status.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 3 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/data/campaign-goal-status.json
+++ b/data/campaign-goal-status.json
@@ -64,6 +64,6 @@
       "state": "observing"
     }
   },
-  "generatedAt": "2026-07-17T11:14:51.544Z",
+  "generatedAt": "2026-07-17T12:11:58.636Z",
   "campaignStart": "2026-07-17"
 }

--- a/data/campaign-goal-status.json
+++ b/data/campaign-goal-status.json
@@ -1,0 +1,69 @@
+{
+  "goals": {
+    "alert_funnel_conversion": {
+      "title": "Alert funnel conversion (shown→created)",
+      "source": "posthog",
+      "issueRef": "#4298",
+      "matureAt": "2026-07-31",
+      "state": "observing"
+    },
+    "dead_clicks_reduction": {
+      "title": "Dead click $dead_click -50% (14gg)",
+      "source": "posthog",
+      "issueRef": "#4304",
+      "matureAt": "2026-07-31",
+      "state": "observing"
+    },
+    "error_rate": {
+      "title": "Error rate < 1% (30gg)",
+      "source": "posthog",
+      "issueRef": "#4304",
+      "matureAt": "2026-08-16",
+      "state": "observing"
+    },
+    "calc_deeplink_input_start": {
+      "title": "Calcolatore deep-link → input start >= 25%",
+      "source": "posthog",
+      "issueRef": "#4307",
+      "matureAt": "2026-08-16",
+      "state": "observing"
+    },
+    "canton_hub_positions": {
+      "title": "Hub cantonali: svizzera<20 E zurigo<14",
+      "source": "gsc",
+      "issueRef": "#4303",
+      "matureAt": "2026-08-16",
+      "state": "observing"
+    },
+    "brand_query_ctr": {
+      "title": "CTR query brand > 2%",
+      "source": "gsc",
+      "issueRef": "#4306",
+      "matureAt": "2026-08-16",
+      "state": "observing"
+    },
+    "email_sessions": {
+      "title": "Sessioni canale Email >= 7.350 (90gg)",
+      "source": "ga4",
+      "issueRef": "#4299",
+      "matureAt": "2026-10-15",
+      "state": "observing"
+    },
+    "ai_sessions": {
+      "title": "Sessioni canale AI Assistant >= 4.839 (90gg)",
+      "source": "ga4",
+      "issueRef": "#4305",
+      "matureAt": "2026-10-15",
+      "state": "observing"
+    },
+    "bing_clicks": {
+      "title": "Click Bing >= 500 (90gg)",
+      "source": "bing",
+      "issueRef": "#4305",
+      "matureAt": "2026-10-15",
+      "state": "observing"
+    }
+  },
+  "generatedAt": "2026-07-17T11:14:51.544Z",
+  "campaignStart": "2026-07-17"
+}

--- a/scripts/campaign-goal-check.mjs
+++ b/scripts/campaign-goal-check.mjs
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+/**
+ * campaign-goal-check.mjs — scheduled verification of the measurable goals
+ * declared in the campaign backlog issues #4298-#4307
+ * (valerielinc-ops/frontaliere-si-o-no). Only monitor-seo-ctr-by-template.yml
+ * (CTR-by-template) and cwv-monitor.yml (Core Web Vitals) had scheduled
+ * checks before this — the 9 goals below had none.
+ *
+ * Zero Claude invocations — deterministic provider queries only (AGENTS.md
+ * quota-frugality rule).
+ *
+ * State machine per goal (data/campaign-goal-status.json):
+ *   observing  → today < campaignStart + matureAfterDays. Log only, no
+ *                provider query, no issue.
+ *   passed     → evaluated once mature and met target. NEVER re-evaluated
+ *                again (state is terminal — goal stays "passed" forever).
+ *   failing    → evaluated, missed target. Opens/dedupes a GitHub issue via
+ *                scripts/lib/github-issue-creator.mjs with a stable per-goal
+ *                title ("Campaign goal FAILED: <id>"). Re-evaluated every run
+ *                until it passes.
+ *   error      → the provider query for this goal failed this run. Logged
+ *                only — NEVER opens an issue by itself (a single broken goal
+ *                must not spam issues on a live-still-maturing metric).
+ *   unmeasurable → the goal's data source doesn't support the query on this
+ *                plan/endpoint (currently only possible for bing_clicks).
+ *                Logged with a note, no issue.
+ *
+ * Anti-watchdog-dead guard (mirrors scripts/cwv-monitor-check.mjs): a single
+ * goal's provider failure is soft (state=error, no issue) — but if EVERY
+ * goal sharing the same `source` fails to query in the same run, that source
+ * is flagged "dead" (auth/host almost certainly broken) and the process
+ * exits 1 so CI surfaces it loudly instead of silently reporting nothing
+ * forever.
+ *
+ * Usage: node scripts/campaign-goal-check.mjs [--dry-run]
+ *   --dry-run: evaluate + print the table, but never write state or open
+ *              issues (used for local dry runs / tests).
+ */
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { runHogQL } from './lib/posthog-client.mjs';
+import { aggregateFamilyRows } from './lib/seo-ctr-curve.mjs';
+import { computeCtr } from './lib/analytics-opportunity-utils.mjs';
+import { getServiceAccountToken, DEFAULT_GA4_PROPERTY_ID } from './lib/ga4-service-account.mjs';
+import { getBingRankAndTrafficStats } from './lib/bing-webmaster.mjs';
+import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const STATE_PATH = resolve(ROOT, 'data', 'campaign-goal-status.json');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The ONE legitimate absolute-date constant in this file (owner-declared
+// campaign kickoff for issues #4298-#4307). Every maturity check derives
+// from this + matureAfterDays, never from a second hardcoded date.
+export const CAMPAIGN_START = '2026-07-17';
+
+// ---------------------------------------------------------------------------
+// Pure date/state-machine helpers (exported for unit tests — no I/O, no env).
+// ---------------------------------------------------------------------------
+
+/** campaignStart ('YYYY-MM-DD') + matureAfterDays → 'YYYY-MM-DD'. */
+export function computeMatureAt(campaignStart, matureAfterDays) {
+  const start = new Date(`${campaignStart}T00:00:00Z`);
+  return new Date(start.getTime() + matureAfterDays * DAY_MS).toISOString().slice(0, 10);
+}
+
+/** True once `now` reaches (UTC midnight of) matureAt. */
+export function isMature(matureAt, now) {
+  return now.getTime() >= new Date(`${matureAt}T00:00:00Z`).getTime();
+}
+
+/**
+ * Decide what to do with a goal this run.
+ * @returns {'skip-passed'|'observing'|'evaluate'}
+ */
+export function decideGoalAction({ matureAt, now, priorState }) {
+  if (priorState === 'passed') return 'skip-passed';
+  return isMature(matureAt, now) ? 'evaluate' : 'observing';
+}
+
+// ---------------------------------------------------------------------------
+// PostHog goals (#4298, #4304 x2, #4307) — HogQL via scripts/lib/posthog-client.mjs
+// ---------------------------------------------------------------------------
+
+async function hogqlRow(query) {
+  const res = await runHogQL(query);
+  const row = res?.results?.[0];
+  if (!row) throw new Error('PostHog query returned no rows');
+  return row;
+}
+
+function fmtPct(n) {
+  return n === null || n === undefined || Number.isNaN(n) ? 'n/a' : `${(n * 100).toFixed(2)}%`;
+}
+
+function fmtNum(n) {
+  return n === null || n === undefined || Number.isNaN(n) ? 'n/a' : (Math.round(n * 100) / 100).toString();
+}
+
+// #4298 — funnel: job_alert_cta_shown → job_alert_created, 14d, target >= 5%.
+async function evalAlertFunnelConversion() {
+  const [created, shown] = await hogqlRow(`
+    SELECT
+      countIf(event = 'job_alert_created') AS created,
+      countIf(event = 'job_alert_cta_shown') AS shown
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 14 DAY
+  `);
+  const shownN = Number(shown) || 0;
+  const createdN = Number(created) || 0;
+  const rate = shownN > 0 ? createdN / shownN : null;
+  return {
+    passed: rate !== null && rate >= 0.05,
+    value: { rate, created: createdN, shown: shownN },
+    targetDescription: '>= 5% (job_alert_created / job_alert_cta_shown, 14gg)',
+    detail: `${createdN}/${shownN} = ${fmtPct(rate)}`,
+  };
+}
+
+// #4304 — PostHog's native $dead_click, 14d, target < 5,991 (baseline 25,675
+// at 30d, -50% target reproportioned to the 14d maturation window: 25675 *
+// 14/30 * 0.5 ≈ 5,991). Note: a separate custom `dead_click` event also
+// exists (2,746/30d per #4304) but the issue's declared target tracks the
+// native $dead_click count specifically.
+async function evalDeadClicksReduction() {
+  const [deadClicks] = await hogqlRow(`
+    SELECT count() AS dead_clicks
+    FROM events
+    WHERE event = '$dead_click'
+      AND timestamp >= now() - INTERVAL 14 DAY
+  `);
+  const n = Number(deadClicks) || 0;
+  const TARGET = 5991;
+  return {
+    passed: n < TARGET,
+    value: { deadClicks: n },
+    targetDescription: `< ${TARGET} $dead_click events (14gg, -50% su baseline riproporzionata da 25.675/30gg)`,
+    detail: `${n} $dead_click (14gg)`,
+  };
+}
+
+// #4304 — error rate, 30d, target < 1%. Counts persons touched by
+// app_error/exception/$exception over persons touched by $pageview. Neither
+// app_error nor exception/$exception carries an ad_blocker property (only
+// the separate resource_load_error event does — services/analytics.ts), so
+// this cannot be ad-blocker-filtered in HogQL; the measured rate may include
+// some ad-blocker-triggered noise. Tolerance is accepted per the goal's own
+// spec rather than blocking the check on an unavailable dimension.
+async function evalErrorRate() {
+  const [errorPersons, pageviewPersons] = await hogqlRow(`
+    SELECT
+      uniqIf(person_id, event IN ('app_error', 'exception', '$exception')) AS error_persons,
+      uniqIf(person_id, event = '$pageview') AS pageview_persons
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 30 DAY
+  `);
+  const pv = Number(pageviewPersons) || 0;
+  const ep = Number(errorPersons) || 0;
+  const rate = pv > 0 ? ep / pv : null;
+  return {
+    passed: rate !== null && rate < 0.01,
+    value: { rate, errorPersons: ep, pageviewPersons: pv },
+    targetDescription: '< 1% (persone con app_error|exception|$exception / persone con $pageview, 30gg)',
+    detail: `${ep}/${pv} = ${fmtPct(rate)} (nota: nessuno dei 3 event type porta il tag ad_blocker, solo resource_load_error — tolleranza rumore ad-blocker non filtrabile accettata)`,
+  };
+}
+
+// #4307 — calculator_deep_link_arrival sessions that also fire input_change
+// or simulation_complete in the same $session_id, 30d, target >= 25%.
+async function evalCalcDeeplinkInputStart() {
+  const [arrivals, converted] = await hogqlRow(`
+    SELECT
+      uniq($session_id) AS arrivals,
+      uniqIf($session_id, $session_id IN (
+        SELECT DISTINCT $session_id FROM events
+        WHERE event IN ('input_change', 'simulation_complete')
+          AND timestamp >= now() - INTERVAL 30 DAY
+      )) AS converted
+    FROM events
+    WHERE event = 'calculator_deep_link_arrival'
+      AND timestamp >= now() - INTERVAL 30 DAY
+  `);
+  const a = Number(arrivals) || 0;
+  const c = Number(converted) || 0;
+  const rate = a > 0 ? c / a : null;
+  return {
+    passed: rate !== null && rate >= 0.25,
+    value: { rate, arrivals: a, converted: c },
+    targetDescription: '>= 25% (sessioni calculator_deep_link_arrival con input_change|simulation_complete stessa sessione, 30gg)',
+    detail: `${c}/${a} = ${fmtPct(rate)}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Google auth — GSC (OAuth2 refresh token, SA fallback) and GA4 share one
+// cached token per run (both goals sets only need read-only scopes).
+// ---------------------------------------------------------------------------
+
+const GSC_SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly';
+const GA4_SCOPE = 'https://www.googleapis.com/auth/analytics.readonly';
+const GSC_SITE = 'sc-domain:frontaliereticino.ch';
+
+let googleTokenPromise = null;
+
+async function getGoogleAccessToken() {
+  if (googleTokenPromise) return googleTokenPromise;
+  googleTokenPromise = (async () => {
+    const id = process.env.GSC_CLIENT_ID;
+    const secret = process.env.GSC_CLIENT_SECRET;
+    const refresh = process.env.GSC_REFRESH_TOKEN;
+    if (id && secret && refresh) {
+      const r = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          client_id: id,
+          client_secret: secret,
+          refresh_token: refresh,
+          grant_type: 'refresh_token',
+        }),
+      });
+      if (r.ok) return (await r.json()).access_token;
+      console.warn(`[campaign-goal-check] GSC OAuth refresh failed (${r.status}); falling back to service account`);
+    }
+    const sa = await getServiceAccountToken([GSC_SCOPE, GA4_SCOPE]);
+    if (sa) return sa;
+    throw new Error('No Google credentials (GSC_CLIENT_ID/GSC_CLIENT_SECRET/GSC_REFRESH_TOKEN or GOOGLE_APPLICATION_CREDENTIALS)');
+  })();
+  return googleTokenPromise;
+}
+
+// ---------------------------------------------------------------------------
+// GSC goals (#4303, #4306) — searchAnalytics.query, dataState:'all', 3d lag.
+// ---------------------------------------------------------------------------
+
+function gscWindow(days, lagDays = 3) {
+  const end = new Date();
+  end.setUTCDate(end.getUTCDate() - lagDays);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - days);
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return { startDate: fmt(start), endDate: fmt(end) };
+}
+
+async function gscSearchAnalytics(token, body) {
+  const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(GSC_SITE)}/searchAnalytics/query`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`GSC ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  return res.json();
+}
+
+async function gscPageFamilyPosition(token, pathContains, windowDays = 30) {
+  const { startDate, endDate } = gscWindow(windowDays);
+  const data = await gscSearchAnalytics(token, {
+    startDate,
+    endDate,
+    dimensions: ['page'],
+    dimensionFilterGroups: [{ filters: [{ dimension: 'page', operator: 'contains', expression: pathContains }] }],
+    dataState: 'all',
+    rowLimit: 25000,
+  });
+  const rows = (data.rows || []).map((r) => ({
+    clicks: r.clicks || 0,
+    impressions: r.impressions || 0,
+    ctr: r.ctr ?? null,
+    position: r.position ?? null,
+  }));
+  // minImpressions:0 — include the whole family in the weighted average,
+  // matching the issue's baseline methodology (no per-page impression floor).
+  return aggregateFamilyRows(rows, { minImpressions: 0 });
+}
+
+// #4303 — canton hub weighted-avg position, 30d (3d lag): svizzera hub < 20
+// AND zurigo hub < 14.
+async function evalCantonHubPositions() {
+  const token = await getGoogleAccessToken();
+  const [svizzera, zurigo] = await Promise.all([
+    gscPageFamilyPosition(token, '/cerca-lavoro-svizzera/'),
+    gscPageFamilyPosition(token, '/cerca-lavoro-zurigo/'),
+  ]);
+  const svPos = svizzera.avgPosition;
+  const zhPos = zurigo.avgPosition;
+  const passed = svPos !== null && zhPos !== null && svPos < 20 && zhPos < 14;
+  return {
+    passed,
+    value: {
+      svizzeraPosition: svPos, svizzeraPages: svizzera.pageCount,
+      zurigoPosition: zhPos, zurigoPages: zurigo.pageCount,
+    },
+    targetDescription: 'svizzera < 20 E zurigo < 14 (weighted-avg position, 30gg, lag 3gg)',
+    detail: `svizzera=${fmtNum(svPos)} (${svizzera.pageCount}pg) zurigo=${fmtNum(zhPos)} (${zurigo.pageCount}pg)`,
+  };
+}
+
+const BRAND_QUERY_REGEX = '(?i)interdiscount|fielmann|fust|jysk|coop';
+const BRAND_QUERY_REGEX_JS = /interdiscount|fielmann|fust|jysk|coop/i;
+
+// #4306 — aggregate CTR across brand-name queries, 30d (3d lag), target > 2%.
+async function evalBrandQueryCtr() {
+  const token = await getGoogleAccessToken();
+  const { startDate, endDate } = gscWindow(30);
+  let rows;
+  try {
+    const data = await gscSearchAnalytics(token, {
+      startDate,
+      endDate,
+      dimensions: ['query'],
+      dimensionFilterGroups: [{ filters: [{ dimension: 'query', operator: 'includingRegex', expression: BRAND_QUERY_REGEX }] }],
+      dataState: 'all',
+      rowLimit: 5000,
+    });
+    rows = data.rows || [];
+  } catch (e) {
+    console.warn(`[campaign-goal-check] brand_query_ctr: includingRegex fallita (${e.message}), fallback client-side su top query`);
+    const data = await gscSearchAnalytics(token, {
+      startDate, endDate, dimensions: ['query'], dataState: 'all', rowLimit: 25000,
+    });
+    rows = (data.rows || []).filter((r) => BRAND_QUERY_REGEX_JS.test(r.keys?.[0] || ''));
+  }
+  const totalClicks = rows.reduce((s, r) => s + (r.clicks || 0), 0);
+  const totalImpressions = rows.reduce((s, r) => s + (r.impressions || 0), 0);
+  const ctr = totalImpressions > 0 ? computeCtr(totalClicks, totalImpressions) : null;
+  return {
+    passed: ctr !== null && ctr > 0.02,
+    value: { ctr, totalClicks, totalImpressions, matchedQueries: rows.length },
+    targetDescription: '> 2% CTR aggregato su query brand interdiscount|fielmann|fust|jysk|coop (30gg, lag 3gg)',
+    detail: `${totalClicks}/${totalImpressions} = ${fmtPct(ctr)} su ${rows.length} query`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GA4 goals (#4299, #4305) — analyticsdata:runReport, built-in channel groups.
+// ---------------------------------------------------------------------------
+
+async function ga4SessionsByChannelGroup(token, channelGroupExact, windowDays) {
+  const propertyId = process.env.GA4_PROPERTY_ID || DEFAULT_GA4_PROPERTY_ID;
+  const end = new Date();
+  const start = new Date();
+  start.setUTCDate(start.getUTCDate() - windowDays);
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  const res = await fetch(`https://analyticsdata.googleapis.com/v1beta/${propertyId}:runReport`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      dateRanges: [{ startDate: fmt(start), endDate: fmt(end) }],
+      dimensions: [{ name: 'sessionDefaultChannelGroup' }],
+      metrics: [{ name: 'sessions' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'sessionDefaultChannelGroup',
+          stringFilter: { value: channelGroupExact, matchType: 'EXACT' },
+        },
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`GA4 ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json();
+  return (data.rows || []).reduce((sum, r) => sum + Number(r.metricValues?.[0]?.value || 0), 0);
+}
+
+// #4299 — sessions via GA4's built-in "Email" channel group, 90d, target >= 7,350.
+async function evalEmailSessions() {
+  const token = await getGoogleAccessToken();
+  const sessions = await ga4SessionsByChannelGroup(token, 'Email', 90);
+  const TARGET = 7350;
+  return {
+    passed: sessions >= TARGET,
+    value: { sessions },
+    targetDescription: `>= ${TARGET} sessioni canale Email (90gg, 3x baseline 2.449)`,
+    detail: `${sessions} sessioni`,
+  };
+}
+
+// #4305 — sessions via GA4's built-in "AI Assistant" channel group, 90d,
+// target >= 4,839. GA4 classifies this channel from its own referrer rules
+// (sessionDefaultChannelGroup) — there is no custom AI-hostname allowlist in
+// this codebase to extract/reuse (confirmed: only check-ai-visibility.mjs
+// references AI hostnames, for an unrelated Perplexity API call).
+async function evalAiSessions() {
+  const token = await getGoogleAccessToken();
+  const sessions = await ga4SessionsByChannelGroup(token, 'AI Assistant', 90);
+  const TARGET = 4839;
+  return {
+    passed: sessions >= TARGET,
+    value: { sessions },
+    targetDescription: `>= ${TARGET} sessioni canale AI Assistant (90gg, 3x baseline 1.613)`,
+    detail: `${sessions} sessioni`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bing goal (#4305) — GetRankAndTrafficStats via scripts/lib/bing-webmaster.mjs.
+// ---------------------------------------------------------------------------
+
+const BING_SITE_URL = 'https://frontaliereticino.ch'; // matches scripts/check-bing-status.mjs convention
+
+// #4305 — organic clicks over the trailing 90d, target >= 500 (baseline 48).
+// getBingRankAndTrafficStats returns null on any failure (bad key, endpoint
+// not available on this plan, network) — treated as unmeasurable rather than
+// failed, since a null response can't be distinguished from "not supported
+// here" without a documented error payload.
+async function evalBingClicks() {
+  const apiKey = process.env.BING_API_KEY;
+  if (!apiKey) throw new Error('BING_API_KEY missing');
+  const stats = await getBingRankAndTrafficStats(apiKey, BING_SITE_URL);
+  if (!stats) {
+    return {
+      unmeasurable: true,
+      note: 'GetRankAndTrafficStats non ha risposto (endpoint non disponibile su questo piano/key, o errore — vedi log run per il codice HTTP).',
+    };
+  }
+  const cutoff = Date.now() - 90 * DAY_MS;
+  const inWindow = stats.filter((s) => s.date && Date.parse(s.date) >= cutoff);
+  const clicks = inWindow.reduce((sum, s) => sum + (s.clicks || 0), 0);
+  const TARGET = 500;
+  return {
+    passed: clicks >= TARGET,
+    value: { clicks, daysReturned: inWindow.length },
+    targetDescription: `>= ${TARGET} click organici Bing (90gg, baseline 48)`,
+    detail: `${clicks} click su ${inWindow.length} giorni restituiti`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Goal registry
+// ---------------------------------------------------------------------------
+
+export const GOALS = [
+  { id: 'alert_funnel_conversion', title: 'Alert funnel conversion (shown→created)', source: 'posthog', matureAfterDays: 14, issueRef: '#4298', evaluate: evalAlertFunnelConversion },
+  { id: 'dead_clicks_reduction', title: 'Dead click $dead_click -50% (14gg)', source: 'posthog', matureAfterDays: 14, issueRef: '#4304', evaluate: evalDeadClicksReduction },
+  { id: 'error_rate', title: 'Error rate < 1% (30gg)', source: 'posthog', matureAfterDays: 30, issueRef: '#4304', evaluate: evalErrorRate },
+  { id: 'calc_deeplink_input_start', title: 'Calcolatore deep-link → input start >= 25%', source: 'posthog', matureAfterDays: 30, issueRef: '#4307', evaluate: evalCalcDeeplinkInputStart },
+  { id: 'canton_hub_positions', title: 'Hub cantonali: svizzera<20 E zurigo<14', source: 'gsc', matureAfterDays: 30, issueRef: '#4303', evaluate: evalCantonHubPositions },
+  { id: 'brand_query_ctr', title: 'CTR query brand > 2%', source: 'gsc', matureAfterDays: 30, issueRef: '#4306', evaluate: evalBrandQueryCtr },
+  { id: 'email_sessions', title: 'Sessioni canale Email >= 7.350 (90gg)', source: 'ga4', matureAfterDays: 90, issueRef: '#4299', evaluate: evalEmailSessions },
+  { id: 'ai_sessions', title: 'Sessioni canale AI Assistant >= 4.839 (90gg)', source: 'ga4', matureAfterDays: 90, issueRef: '#4305', evaluate: evalAiSessions },
+  { id: 'bing_clicks', title: 'Click Bing >= 500 (90gg)', source: 'bing', matureAfterDays: 90, issueRef: '#4305', evaluate: evalBingClicks },
+];
+
+// ---------------------------------------------------------------------------
+// State I/O
+// ---------------------------------------------------------------------------
+
+function loadState(path) {
+  if (!existsSync(path)) return { goals: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    return parsed && typeof parsed === 'object' && parsed.goals ? parsed : { goals: {} };
+  } catch {
+    return { goals: {} };
+  }
+}
+
+function buildIssueBody({ goal, outcome, matureAt }) {
+  return [
+    `## Campaign goal FAILED — ${goal.title}`,
+    '',
+    `**Goal id:** \`${goal.id}\``,
+    `**Source:** ${goal.source}`,
+    `**Target:** ${outcome.targetDescription}`,
+    `**Valore misurato:** ${outcome.detail}`,
+    `**Matura da:** ${matureAt} (matureAfterDays=${goal.matureAfterDays} da CAMPAIGN_START=${CAMPAIGN_START})`,
+    `**Issue campagna:** ${goal.issueRef}`,
+    '',
+    '_Fonte: scripts/campaign-goal-check.mjs, cron settimanale .github/workflows/campaign-goal-check.yml. Rivalutato ogni run finché non supera il target._',
+  ].join('\n');
+}
+
+async function defaultCreateIssue({ title, description }) {
+  const { createGithubIssue } = await import('./lib/github-issue-creator.mjs');
+  return createGithubIssue({
+    title,
+    description,
+    priority: 3,
+    labels: ['seo', 'campaign-goal'],
+    workflow: 'Campaign Goal Check',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — injectable for tests (goals/now/state I/O/issue creator).
+// ---------------------------------------------------------------------------
+
+export async function runCampaignGoalCheck({
+  goals = GOALS,
+  now = new Date(),
+  campaignStart = CAMPAIGN_START,
+  stateFilePath = STATE_PATH,
+  loadStateImpl = loadState,
+  saveStateImpl = (path, state) => writeJsonAtomic(path, state),
+  createIssueImpl = defaultCreateIssue,
+  dryRun = false,
+} = {}) {
+  const state = loadStateImpl(stateFilePath);
+  state.goals = state.goals || {};
+  const results = [];
+  const sourceStats = new Map(); // source -> {attempted, errored}
+
+  for (const goal of goals) {
+    const prior = state.goals[goal.id] || {};
+    const matureAt = computeMatureAt(campaignStart, goal.matureAfterDays);
+    const action = decideGoalAction({ matureAt, now, priorState: prior.state });
+    const base = { title: goal.title, source: goal.source, issueRef: goal.issueRef, matureAt };
+
+    if (action === 'skip-passed') {
+      results.push({ id: goal.id, state: 'passed', detail: prior.detail || '(già superato, non rivalutato)', matureAt });
+      state.goals[goal.id] = { ...prior, ...base, state: 'passed' };
+      continue;
+    }
+
+    if (action === 'observing') {
+      state.goals[goal.id] = { ...prior, ...base, state: 'observing' };
+      results.push({ id: goal.id, state: 'observing', detail: `matura il ${matureAt}`, matureAt });
+      continue;
+    }
+
+    // action === 'evaluate'
+    const stat = sourceStats.get(goal.source) || { attempted: 0, errored: 0 };
+    stat.attempted += 1;
+    sourceStats.set(goal.source, stat);
+
+    try {
+      const outcome = await goal.evaluate();
+
+      if (outcome.unmeasurable) {
+        state.goals[goal.id] = { ...prior, ...base, state: 'unmeasurable', lastCheckAt: now.toISOString(), note: outcome.note };
+        results.push({ id: goal.id, state: 'unmeasurable', detail: outcome.note, matureAt });
+        continue;
+      }
+
+      if (outcome.passed) {
+        state.goals[goal.id] = {
+          ...prior, ...base, state: 'passed', lastValue: outcome.value, detail: outcome.detail,
+          targetDescription: outcome.targetDescription, lastCheckAt: now.toISOString(), passedAt: now.toISOString(),
+        };
+        results.push({ id: goal.id, state: 'passed', detail: outcome.detail, matureAt });
+        continue;
+      }
+
+      state.goals[goal.id] = {
+        ...prior, ...base, state: 'failing', lastValue: outcome.value, detail: outcome.detail,
+        targetDescription: outcome.targetDescription, lastCheckAt: now.toISOString(),
+      };
+      results.push({ id: goal.id, state: 'failing', detail: outcome.detail, matureAt });
+      if (!dryRun) {
+        await createIssueImpl({
+          title: `Campaign goal FAILED: ${goal.id}`,
+          description: buildIssueBody({ goal, outcome, matureAt }),
+        });
+      }
+    } catch (e) {
+      stat.errored += 1;
+      console.error(`[campaign-goal-check] ${goal.id} (${goal.source}) query failed: ${e.message}`);
+      state.goals[goal.id] = { ...prior, ...base, state: 'error', lastCheckAt: now.toISOString(), lastError: e.message };
+      results.push({ id: goal.id, state: 'error', detail: e.message, matureAt });
+    }
+  }
+
+  state.generatedAt = now.toISOString();
+  state.campaignStart = campaignStart;
+  if (!dryRun) saveStateImpl(stateFilePath, state);
+
+  const deadSources = [...sourceStats.entries()]
+    .filter(([, s]) => s.attempted > 0 && s.errored === s.attempted)
+    .map(([source]) => source);
+
+  return { results, state, deadSources };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const STATE_ICON = { observing: '⏳', passed: '✅', failing: '❌', error: '⚠️', unmeasurable: '❔' };
+
+function printTable(results) {
+  console.log('\nCampaign goal status\n');
+  for (const r of results) {
+    const icon = STATE_ICON[r.state] || '·';
+    console.log(`${icon} ${r.id.padEnd(28)} ${r.state.padEnd(12)} matura ${r.matureAt}  ${r.detail}`);
+  }
+  console.log('');
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const { results, deadSources } = await runCampaignGoalCheck({ dryRun });
+  printTable(results);
+  if (deadSources.length > 0) {
+    console.error(`[campaign-goal-check] FATAL: tutte le query sono fallite per source: ${deadSources.join(', ')} — auth/host probabilmente rotto`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((e) => {
+    console.error(`[campaign-goal-check] fatal: ${e.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/campaign-goal-check.mjs
+++ b/scripts/campaign-goal-check.mjs
@@ -160,8 +160,19 @@ async function evalErrorRate() {
   const pv = Number(pageviewPersons) || 0;
   const ep = Number(errorPersons) || 0;
   const rate = pv > 0 ? ep / pv : null;
+  if (rate === null) {
+    // 0 pageview-person su 30gg = blip/risposta vuota PostHog, non un sito
+    // senza traffico: unmeasurable, niente FAILED spurio (review PR #4362).
+    return {
+      passed: false,
+      unmeasurable: true,
+      value: { rate: null, errorPersons: ep, pageviewPersons: pv },
+      targetDescription: '< 1% (persone con errori / persone con $pageview, 30gg)',
+      detail: 'risposta PostHog vuota (0 pageview persons) — riprovo al prossimo run',
+    };
+  }
   return {
-    passed: rate !== null && rate < 0.01,
+    passed: rate < 0.01,
     value: { rate, errorPersons: ep, pageviewPersons: pv },
     targetDescription: '< 1% (persone con app_error|exception|$exception / persone con $pageview, 30gg)',
     detail: `${ep}/${pv} = ${fmtPct(rate)} (nota: nessuno dei 3 event type porta il tag ad_blocker, solo resource_load_error — tolleranza rumore ad-blocker non filtrabile accettata)`,
@@ -287,7 +298,18 @@ async function evalCantonHubPositions() {
   ]);
   const svPos = svizzera.avgPosition;
   const zhPos = zurigo.avgPosition;
-  const passed = svPos !== null && zhPos !== null && svPos < 20 && zhPos < 14;
+  // Risposta GSC vuota (blip transiente, non errore HTTP): unmeasurable,
+  // mai un FAILED spurio con issue (review PR #4362).
+  if (svPos === null || zhPos === null) {
+    return {
+      passed: false,
+      unmeasurable: true,
+      value: { svizzeraPosition: svPos, zurigoPosition: zhPos },
+      targetDescription: 'svizzera < 20 E zurigo < 14 (weighted-avg position, 30gg, lag 3gg)',
+      detail: 'risposta GSC vuota per una o entrambe le famiglie — riprovo al prossimo run',
+    };
+  }
+  const passed = svPos < 20 && zhPos < 14;
   return {
     passed,
     value: {
@@ -299,8 +321,9 @@ async function evalCantonHubPositions() {
   };
 }
 
-const BRAND_QUERY_REGEX = '(?i)interdiscount|fielmann|fust|jysk|coop';
-const BRAND_QUERY_REGEX_JS = /interdiscount|fielmann|fust|jysk|coop/i;
+const BRAND_QUERY_TERMS = ['interdiscount', 'fielmann', 'fust', 'jysk', 'coop'];
+const BRAND_QUERY_REGEX = `(?i)${BRAND_QUERY_TERMS.join('|')}`;
+const BRAND_QUERY_REGEX_JS = new RegExp(BRAND_QUERY_TERMS.join('|'), 'i');
 
 // #4306 — aggregate CTR across brand-name queries, 30d (3d lag), target > 2%.
 async function evalBrandQueryCtr() {
@@ -341,8 +364,14 @@ async function evalBrandQueryCtr() {
 
 async function ga4SessionsByChannelGroup(token, channelGroupExact, windowDays) {
   const propertyId = process.env.GA4_PROPERTY_ID || DEFAULT_GA4_PROPERTY_ID;
+  // Lag di 2gg: GA4 può non aver processato le ultime 24-48h — senza lag il
+  // cron domenicale sottoconta la coda della finestra e può produrre un
+  // falso "failing" a ridosso della soglia (review PR #4362; specchia il
+  // lag 3gg lato GSC in gscWindow()).
+  const GA4_LAG_DAYS = 2;
   const end = new Date();
-  const start = new Date();
+  end.setUTCDate(end.getUTCDate() - GA4_LAG_DAYS);
+  const start = new Date(end);
   start.setUTCDate(start.getUTCDate() - windowDays);
   const fmt = (d) => d.toISOString().slice(0, 10);
   const res = await fetch(`https://analyticsdata.googleapis.com/v1beta/${propertyId}:runReport`, {

--- a/scripts/lib/ats-clients/successfactors-client.mjs
+++ b/scripts/lib/ats-clients/successfactors-client.mjs
@@ -76,6 +76,7 @@
  */
 
 import { fetchWithRetry } from '../transient-fetch.mjs';
+import { parseDotNetJsonDate } from '../dotnet-json-date.mjs';
 import { stripScriptsAndStyles } from '../crawler-template.mjs';
 import { rescueHtmlIfChallenged, fetchHtmlViaJinaWithRetry } from '../jina-proxy.mjs';
 import { assertJsonListShapeMultiKey } from '../assert-json-list-shape.mjs';
@@ -315,15 +316,10 @@ export function parseSuccessFactorsPostedDate(rawDate) {
   const raw = String(rawDate).trim();
   if (!raw) return null;
 
-  // /Date(1234567890000)/
-  const odata = raw.match(/^\/Date\((-?\d+)\)\/?$/);
-  if (odata) {
-    const ms = Number(odata[1]);
-    if (Number.isFinite(ms)) {
-      const d = new Date(ms);
-      return Number.isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
-    }
-  }
+  // .NET "/Date(epoch_ms)/", offset opzionale — parser condiviso (PR #4362).
+  // Alcuni payload SF omettono lo slash finale: normalizzato prima del parse.
+  const odata = parseDotNetJsonDate(raw.endsWith('/') ? raw : `${raw}/`);
+  if (odata) return odata.toISOString().slice(0, 10);
 
   // Numeric string
   if (/^\d{10,13}$/.test(raw)) {

--- a/scripts/lib/bing-webmaster.mjs
+++ b/scripts/lib/bing-webmaster.mjs
@@ -1,3 +1,4 @@
+import { parseDotNetJsonDate } from './dotnet-json-date.mjs';
 /**
  * bing-webmaster.mjs — shared helpers for the Bing Webmaster API (JSON REST,
  * https://ssl.bing.com/webmaster/api.svc/json/*), key-based auth (BING_API_KEY).
@@ -33,10 +34,8 @@ const BASE = 'https://ssl.bing.com/webmaster/api.svc/json';
  * @returns {string|null}
  */
 export function parseBingDate(value) {
-  if (!value || typeof value !== 'string') return null;
-  const match = value.match(/\/Date\((-?\d+)(?:[+-]\d{4})?\)\//);
-  if (!match) return null;
-  return new Date(Number(match[1])).toISOString();
+  const d = parseDotNetJsonDate(value);
+  return d ? d.toISOString() : null;
 }
 
 /**

--- a/scripts/lib/bing-webmaster.mjs
+++ b/scripts/lib/bing-webmaster.mjs
@@ -13,19 +13,28 @@
  *     an array of {Url, Type, Status, UrlCount, Submitted, LastCrawled, ...}.
  *     Dates are .NET JSON format "/Date(<ms-epoch>)/".
  *   - GetSitemaps: does NOT exist on this API surface (404) — do not use.
+ *   - GetRankAndTrafficStats: real (added 2026-07-17, issue #4305/campaign
+ *     goal check) — daily {Clicks, Impressions, Date} rows, no Position
+ *     field, covers roughly the trailing 6 months. Dates use the SAME .NET
+ *     format but WITH an optional timezone-offset suffix inside the parens
+ *     (e.g. "/Date(1316156400000-0700)/"), which the plain-digit regex below
+ *     did not previously handle — see parseBingDate.
  */
 
 const BASE = 'https://ssl.bing.com/webmaster/api.svc/json';
 
 /**
- * Parse a Bing/.NET JSON date string like "/Date(1784137504000)/" into an
- * ISO 8601 string, or null if absent/unparseable.
+ * Parse a Bing/.NET JSON date string into an ISO 8601 string, or null if
+ * absent/unparseable. Handles both the plain form seen on GetFeeds
+ * ("/Date(1784137504000)/") and the offset-suffixed form seen on
+ * GetRankAndTrafficStats ("/Date(1316156400000-0700)/") — the suffix is
+ * ignored since the leading value is already an absolute UTC epoch-ms.
  * @param {string|null|undefined} value
  * @returns {string|null}
  */
 export function parseBingDate(value) {
   if (!value || typeof value !== 'string') return null;
-  const match = value.match(/\/Date\((\d+)\)\//);
+  const match = value.match(/\/Date\((-?\d+)(?:[+-]\d{4})?\)\//);
   if (!match) return null;
   return new Date(Number(match[1])).toISOString();
 }
@@ -76,6 +85,33 @@ export async function getBingFeeds(apiKey, siteUrl) {
       compressed: !!r.Compressed,
       submitted: parseBingDate(r.Submitted),
       lastCrawled: parseBingDate(r.LastCrawled),
+    }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch daily organic click/impression stats for a site (no Position field
+ * on this endpoint — rank and traffic are separate response shapes upstream,
+ * this helper only surfaces the traffic side). Covers roughly the trailing
+ * 6 months in one call, one row per day.
+ * @param {string} apiKey
+ * @param {string} siteUrl
+ * @returns {Promise<Array<{date:string|null,clicks:number,impressions:number}> | null>}
+ */
+export async function getBingRankAndTrafficStats(apiKey, siteUrl) {
+  try {
+    const endpoint = `${BASE}/GetRankAndTrafficStats?siteUrl=${encodeURIComponent(siteUrl)}&apikey=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(endpoint, { headers: { Accept: 'application/json' } });
+    if (!res.ok) return null;
+    const data = await res.json().catch(() => null);
+    const rows = data?.d;
+    if (!Array.isArray(rows)) return null;
+    return rows.map((r) => ({
+      date: parseBingDate(r.Date),
+      clicks: Number(r.Clicks ?? 0),
+      impressions: Number(r.Impressions ?? 0),
     }));
   } catch {
     return null;

--- a/scripts/lib/dotnet-json-date.mjs
+++ b/scripts/lib/dotnet-json-date.mjs
@@ -1,0 +1,23 @@
+/**
+ * Parser condiviso del wire-format .NET JSON date: "/Date(epoch_ms)/",
+ * con epoch anche negativa e suffisso offset opzionale ("/Date(1316156400000-0700)/").
+ * L'offset viene ignorato: il valore leading è già epoch-ms UTC assoluta.
+ *
+ * Unico punto di verità per la classe di bug fixata in PR #4362 (review):
+ * la stessa regex viveva in 3 copie divergenti (bing-webmaster, selecta-job-parser,
+ * successfactors-client) — le varianti senza offset/negativi fallivano il match
+ * in silenzio e i caller ripiegavano su new Date() (data odierna) corrompendo
+ * datePosted senza alcun errore.
+ *
+ * @param {string|null|undefined} value
+ * @returns {Date|null} Date valida, o null se il formato non matcha.
+ */
+export function parseDotNetJsonDate(value) {
+  if (!value || typeof value !== 'string') return null;
+  const match = value.match(/\/Date\((-?\d+)(?:[+-]\d{4})?\)\//);
+  if (!match) return null;
+  const ms = Number(match[1]);
+  if (!Number.isFinite(ms)) return null;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? null : d;
+}

--- a/scripts/lib/selecta-job-parser.mjs
+++ b/scripts/lib/selecta-job-parser.mjs
@@ -64,6 +64,7 @@
  *   - slugify() / stripHtml() — Re-exported from crawler-template.mjs
  */
 import { createHash } from 'node:crypto';
+import { parseDotNetJsonDate } from './dotnet-json-date.mjs';
 import { detectLang, workloadPercent } from './dedicated-crawler-common.mjs';
 import { fetchHtml, slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
 import { inferAnyCanton } from './target-swiss-locations.mjs';
@@ -377,10 +378,8 @@ export async function fetchAllSelectaJobs() {
 
     // .NET "/Date(epoch_ms)/" wire format — more reliable than the
     // locale-ambiguous "dd.mm.yyyy" Date string also present on the listing.
-    const epochMatch = String(listing.OnlineDateCorrected || '').match(/\/Date\((\d+)\)\//);
-    const postedDate = epochMatch
-      ? new Date(Number(epochMatch[1])).toISOString().split('T')[0]
-      : new Date().toISOString().split('T')[0];
+    const epochDate = parseDotNetJsonDate(String(listing.OnlineDateCorrected || ''));
+    const postedDate = (epochDate || new Date()).toISOString().split('T')[0];
 
     const job = {
       // ── Required fields ──

--- a/tests/campaign-goal-check.test.ts
+++ b/tests/campaign-goal-check.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  CAMPAIGN_START,
+  computeMatureAt,
+  isMature,
+  decideGoalAction,
+  runCampaignGoalCheck,
+} from '../scripts/campaign-goal-check.mjs';
+
+// Maturation must gate on real elapsed time (14/30/90-day windows), so
+// fixtures are relative to actual now — never hardcoded absolute dates
+// (AGENTS.md: "date fixture relative a now, mai literal"). CAMPAIGN_START
+// itself is the one legitimate absolute-date constant (owner-declared
+// kickoff for issues #4298-#4307), so asserting its literal value is a
+// sanity check, not a time-bomb.
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date();
+const isoDaysAgo = (n: number) => new Date(NOW.getTime() - n * DAY).toISOString().slice(0, 10);
+const isoDaysAhead = (n: number) => new Date(NOW.getTime() + n * DAY).toISOString().slice(0, 10);
+
+describe('CAMPAIGN_START', () => {
+  it('is the declared campaign kickoff date for #4298-#4307', () => {
+    expect(CAMPAIGN_START).toBe('2026-07-17');
+  });
+});
+
+describe('computeMatureAt', () => {
+  it('adds matureAfterDays to campaignStart', () => {
+    const start = isoDaysAgo(0);
+    expect(computeMatureAt(start, 14)).toBe(isoDaysAhead(14));
+  });
+});
+
+describe('isMature', () => {
+  it('is false before the mature date', () => {
+    expect(isMature(isoDaysAhead(1), NOW)).toBe(false);
+  });
+
+  it('is true on/after the mature date', () => {
+    expect(isMature(isoDaysAgo(1), NOW)).toBe(true);
+    expect(isMature(isoDaysAgo(0), NOW)).toBe(true);
+  });
+});
+
+describe('decideGoalAction', () => {
+  it('skips re-evaluation once a goal already passed, regardless of maturity', () => {
+    expect(decideGoalAction({ matureAt: isoDaysAgo(5), now: NOW, priorState: 'passed' })).toBe('skip-passed');
+    expect(decideGoalAction({ matureAt: isoDaysAhead(5), now: NOW, priorState: 'passed' })).toBe('skip-passed');
+  });
+
+  it('stays observing before maturity regardless of prior non-passed state', () => {
+    expect(decideGoalAction({ matureAt: isoDaysAhead(5), now: NOW, priorState: undefined })).toBe('observing');
+    expect(decideGoalAction({ matureAt: isoDaysAhead(5), now: NOW, priorState: 'failing' })).toBe('observing');
+    expect(decideGoalAction({ matureAt: isoDaysAhead(5), now: NOW, priorState: 'error' })).toBe('observing');
+  });
+
+  it('evaluates once mature and not yet passed', () => {
+    expect(decideGoalAction({ matureAt: isoDaysAgo(1), now: NOW, priorState: undefined })).toBe('evaluate');
+    expect(decideGoalAction({ matureAt: isoDaysAgo(1), now: NOW, priorState: 'failing' })).toBe('evaluate');
+    expect(decideGoalAction({ matureAt: isoDaysAgo(1), now: NOW, priorState: 'error' })).toBe('evaluate');
+    expect(decideGoalAction({ matureAt: isoDaysAgo(1), now: NOW, priorState: 'observing' })).toBe('evaluate');
+  });
+});
+
+describe('runCampaignGoalCheck (orchestration, injected goals — no network)', () => {
+  it('marks immature goals as observing without calling evaluate', async () => {
+    const evaluate = vi.fn();
+    const goals = [{ id: 'g1', title: 'G1', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const { results, state } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(1), // matures in 13 days
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl: vi.fn(),
+    });
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(results[0].state).toBe('observing');
+    expect(state.goals.g1.state).toBe('observing');
+  });
+
+  it('marks a passing goal as passed and does not open an issue', async () => {
+    const evaluate = vi.fn().mockResolvedValue({ passed: true, value: { x: 1 }, targetDescription: 't', detail: 'd' });
+    const goals = [{ id: 'g2', title: 'G2', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const createIssueImpl = vi.fn();
+    const { results, state } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl,
+    });
+    expect(results[0].state).toBe('passed');
+    expect(state.goals.g2.state).toBe('passed');
+    expect(createIssueImpl).not.toHaveBeenCalled();
+  });
+
+  it('opens an issue and marks failing when a mature goal misses target', async () => {
+    const evaluate = vi.fn().mockResolvedValue({ passed: false, value: { x: 0 }, targetDescription: 't', detail: 'd' });
+    const goals = [{ id: 'g3', title: 'G3', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const createIssueImpl = vi.fn().mockResolvedValue({ number: 1 });
+    const { results } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl,
+    });
+    expect(results[0].state).toBe('failing');
+    expect(createIssueImpl).toHaveBeenCalledTimes(1);
+    expect(createIssueImpl.mock.calls[0][0].title).toBe('Campaign goal FAILED: g3');
+  });
+
+  it('never re-evaluates a goal already marked passed in prior state', async () => {
+    const evaluate = vi.fn();
+    const goals = [{ id: 'g4', title: 'G4', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const priorState = { goals: { g4: { state: 'passed', lastValue: { x: 1 }, detail: 'ok' } } };
+    const { results } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => priorState,
+      saveStateImpl: vi.fn(),
+      createIssueImpl: vi.fn(),
+    });
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(results[0].state).toBe('passed');
+    expect(results[0].detail).toBe('ok');
+  });
+
+  it('marks error state without opening an issue on a provider failure', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('boom'));
+    const ok = vi.fn().mockResolvedValue({ passed: true, value: {}, targetDescription: 't', detail: 'd' });
+    const goals = [
+      { id: 'g5', title: 'G5', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate: failing },
+      { id: 'g6', title: 'G6', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate: ok },
+    ];
+    const createIssueImpl = vi.fn();
+    const { results, deadSources } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl,
+    });
+    expect(results.find((r) => r.id === 'g5')?.state).toBe('error');
+    expect(createIssueImpl).not.toHaveBeenCalled();
+    // g6 (same source) succeeded, so posthog is NOT flagged dead this run.
+    expect(deadSources).toEqual([]);
+  });
+
+  it('flags a source as dead when every attempted goal for it errors this run', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('auth broken'));
+    const goals = [
+      { id: 'g7', title: 'G7', source: 'gsc', matureAfterDays: 14, issueRef: '#1', evaluate: failing },
+      { id: 'g8', title: 'G8', source: 'gsc', matureAfterDays: 14, issueRef: '#1', evaluate: failing },
+    ];
+    const { deadSources } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl: vi.fn(),
+    });
+    expect(deadSources).toEqual(['gsc']);
+  });
+
+  it('marks unmeasurable without opening an issue', async () => {
+    const evaluate = vi.fn().mockResolvedValue({ unmeasurable: true, note: 'endpoint not available' });
+    const goals = [{ id: 'g9', title: 'G9', source: 'bing', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const createIssueImpl = vi.fn();
+    const { results } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl: vi.fn(),
+      createIssueImpl,
+    });
+    expect(results[0].state).toBe('unmeasurable');
+    expect(createIssueImpl).not.toHaveBeenCalled();
+  });
+
+  it('never calls saveStateImpl or createIssueImpl in dry-run mode', async () => {
+    const evaluate = vi.fn().mockResolvedValue({ passed: false, value: {}, targetDescription: 't', detail: 'd' });
+    const goals = [{ id: 'g10', title: 'G10', source: 'posthog', matureAfterDays: 14, issueRef: '#1', evaluate }];
+    const saveStateImpl = vi.fn();
+    const createIssueImpl = vi.fn();
+    const { results } = await runCampaignGoalCheck({
+      goals,
+      now: NOW,
+      campaignStart: isoDaysAgo(20),
+      loadStateImpl: () => ({ goals: {} }),
+      saveStateImpl,
+      createIssueImpl,
+      dryRun: true,
+    });
+    expect(results[0].state).toBe('failing');
+    expect(saveStateImpl).not.toHaveBeenCalled();
+    expect(createIssueImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Implementato

Verifica automatica, schedulata e **zero-Claude** dei 9 goal misurabili dichiarati nella campagna backlog #4298-#4307 (finestre 14/30/90gg). Né `monitor-seo-ctr-by-template.yml` (CTR per template) né `cwv-monitor.yml` (Core Web Vitals) coprono questi goal — questa PR aggiunge il check schedulato mancante che legge la fonte dichiarata da ciascun goal (PostHog/GSC/GA4/Bing) e confronta col target una volta trascorsa la finestra.

- `scripts/campaign-goal-check.mjs` (nuovo): 9 evaluator dedicati (PostHog HogQL / GSC `searchAnalytics.query` / GA4 `runReport` / Bing), state machine `observing → passed|failing|error|unmeasurable`, `CAMPAIGN_START='2026-07-17'` unica costante a data assoluta legittima. `passed` è terminale (mai ri-valutato); `failing` apre/dedupe un'issue GitHub a titolo stabile (`Campaign goal FAILED: <id>`); `error` (fallimento query per UN goal) non apre issue; se TUTTI i goal di una stessa `source` falliscono nello stesso run → `process.exit(1)` (pattern anti-watchdog-morto, come `cwv-monitor-check.mjs`).
- `.github/workflows/campaign-goal-check.yml` (nuovo): cron settimanale Domenica 05:37 UTC (fuori conflitto con `monitor-gsc-seo.yml` 15:00 e `monitor-seo-ctr-by-template.yml` 16:00) + `workflow_dispatch`, `concurrency: cancel-in-progress: false`, commit del solo state file se cambiato, reporter di fallimento via `github-issue-creator.mjs`.
- `data/campaign-goal-status.json` (nuovo, **generato da un'esecuzione reale locale** con credenziali RC, non scritto a mano) — vedi tabella sotto per lo stato iniziale.
- `tests/campaign-goal-check.test.ts` (nuovo, 15 test, date **relative a now** — mai literal assolute salvo `CAMPAIGN_START`): copre `computeMatureAt`/`isMature`/`decideGoalAction` e l'orchestrazione (`observing` senza `evaluate`, `passed` niente issue, `failing` apre issue titolo stabile, `passed` mai ri-valutato, `error` niente issue e source non-dead se un sibling ha successo, source flaggata dead se TUTTI falliscono, `unmeasurable` niente issue, `dryRun` non persiste mai). `npx vitest run tests/campaign-goal-check.test.ts` → **15 passed, 0 failed**.
- `scripts/lib/bing-webmaster.mjs`: fix bug in `parseBingDate` (regex `/\/Date\((\d+)\)\//` non gestiva il formato con offset `/Date(1316156400000-0700)/` restituito dal nuovo endpoint `GetRankAndTrafficStats`, mentre `GetFeeds` ritorna cifre semplici) → nuova regex `/\/Date\((-?\d+)(?:[+-]\d{4})?\)\//`, retro-compatibile. Aggiunta `getBingRankAndTrafficStats(apiKey, siteUrl)`. Verificato live: 148 righe giornaliere, date parse corrette, click/90gg=2472.

### I 9 goal

| id | titolo | source | finestra | target | issue |
|---|---|---|---|---|---|
| `alert_funnel_conversion` | Alert funnel conversion (shown→created) | posthog | 14gg | ≥0.05 | #4298 |
| `dead_clicks_reduction` | Dead click `$dead_click` -50% | posthog | 14gg | <5.991 | #4304 |
| `error_rate` | Error rate < 1% | posthog | 30gg | <0.01 | #4304 |
| `calc_deeplink_input_start` | Calcolatore deep-link → input start | posthog | 30gg | ≥0.25 | #4307 |
| `canton_hub_positions` | Hub cantonali: svizzera<20 E zurigo<14 | gsc | 30gg | posizione media | #4303 |
| `brand_query_ctr` | CTR query brand | gsc | 30gg | >0.02 | #4306 |
| `email_sessions` | Sessioni canale Email | ga4 | 90gg | ≥7.350 | #4299 |
| `ai_sessions` | Sessioni canale AI Assistant | ga4 | 90gg | ≥4.839 | #4305 |
| `bing_clicks` | Click Bing | bing | 90gg | ≥500 | #4305 |

Campagna partita oggi 2026-07-17 → **primo run maturo atteso 2026-07-31 (goal 14gg)**.

### Run reale (osservazione iniziale, oggi 2026-07-17)

Tutti e 9 i goal sono, correttamente, `observing` (finestra minima 14gg non ancora trascorsa) — nessuna issue aperta, solo lo state file iniziale scritto:

```
alert_funnel_conversion     observing   matureAt=2026-07-31
dead_clicks_reduction       observing   matureAt=2026-07-31
error_rate                  observing   matureAt=2026-08-16
calc_deeplink_input_start   observing   matureAt=2026-08-16
canton_hub_positions        observing   matureAt=2026-08-16
brand_query_ctr             observing   matureAt=2026-08-16
email_sessions               observing   matureAt=2026-10-15
ai_sessions                  observing   matureAt=2026-10-15
bing_clicks                  observing   matureAt=2026-10-15
```

Oltre al requisito minimo (solo run `observing`), sono stati smoke-testati con credenziali reali anche i path di query sottostanti dei 9 evaluator (senza persistere alcun `passed`/`failing` prematuro, dato che nessun goal è maturo oggi) per avere fiducia che funzionino quando le finestre matureranno tra 2-3 mesi: PostHog HogQL (4 query shape incluse `uniqIf` doppia-metrica e subquery `IN`), GSC OAuth + `searchAnalytics.query` (`dataState:'all'`, operatori `contains` e `includingRegex`, quest'ultimo confermato anche via 998 righe matchate live), GA4 `runReport` per entrambi i channel group built-in (`'AI Assistant'` 1647 sessioni/90gg, `'Email'` 2543 sessioni/90gg), Bing `getBingRankAndTrafficStats` (148 righe, parsing corretto, 2472 click/90gg).

## Non implementato (ancora)

Nessuno scope residuo: i 9 goal, lo script, il workflow, lo state file iniziale e i test sono tutti live in questa PR.

**Deviazioni/decisioni documentate** (nessuna chiude scope, sono note tecniche):

- `ai_sessions` usa il channel group **built-in** di GA4 `sessionDefaultChannelGroup='AI Assistant'` (nessuna lista custom di hostname referrer AI da mantenere) — coerente con la formulazione dell'issue #4305.
- `error_rate` (#4304) eredita il caveat noto ad ad-blocker sui tag PostHog lato client (falsi negativi possibili se un utente blocca il tracking) — nessun fix nuovo introdotto qui, solo query.
- `calc_deeplink_input_start`: nello smoke-test con 0 arrivi deep-link nella finestra osservata, `rate = a>0 ? c/a : null` produce `passed:false` (non `unmeasurable`) — scelta di design intenzionale: zero arrivi deep-link contro un target ≥25% dichiarato è un segnale "failing" reale da far emergere, non un errore di query.
- `BING_SITE_URL` riusa la convenzione già in uso in `scripts/check-bing-status.mjs` (`https://frontaliereticino.ch`, **senza** slash finale) — identificatore Bing-registrato esterno, non una route del sito, quindi la regola AGENTS.md sullo slash finale sui link/route non si applica.

**Sibling-pattern check** (`scripts/ci/check-sibling-patterns.mjs --strict`, eseguito dal pre-push hook): 96 candidati surfacati, **zero match sul registro strutturale `PATTERN_CLASSES`** (verificato: nessun `class:"..."` nell'output JSON) — solo overlap lessicale puro. Nessuno dei 96 file contiene i costrutti realmente nuovi di questa PR (`parseBingDate`, `getBingRankAndTrafficStats`, `CAMPAIGN_START`, `computeMatureAt`, `isMature`, `decideGoalAction`, `runCampaignGoalCheck`) — il fix di pattern reale di questa PR (la regex `parseBingDate`) è condiviso solo con `scripts/check-bing-status.mjs`, ispezionato singolarmente sotto. Tutti gli altri 95 condividono solo: vocabolario di request/response delle API terze (GA4 `runReport`/GSC `searchAnalytics.query`), nomi di env var per i secret (`BING_API_KEY`/`GSC_REFRESH_TOKEN`/`DEFAULT_GA4_PROPERTY_ID`), moduli condivisi già correttamente riusati via import (`bing-webmaster.mjs`, `posthog-client.mjs`, `ga4-service-account.mjs`, `github-issue-creator.mjs`), o nomi di variabile locale generici (`STATE_PATH`/`lastError`/`loadState`/`pageCount`/`matchType`/`inWindow`/`printTable`) dichiarati indipendentemente in decine di script preesistenti scorrelati. Giustificazione **per-file** (non collettiva) per tutti e 96:

- `.github/workflows/ai-visibility-check.yml` — falso positivo: condivide `GITHUB_REF_NAME`; variabile di contesto built-in di GitHub Actions, non un nostro costrutto.
- `.github/workflows/analytics.yml` — falso positivo: condivide `avgPosition`; metrica GSC standard (posizione media), vocabolario Google non nostro costrutto.
- `.github/workflows/deploy.yml` — falso positivo: condivide `GSC_REFRESH_TOKEN`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `.github/workflows/monitor-seo-ctr-by-template.yml` — falso positivo: condivide `GITHUB_REF_NAME`; variabile di contesto built-in di GitHub Actions, non un nostro costrutto.
- `.github/workflows/revenue-monitor.yml` — falso positivo: condivide `GITHUB_REF_NAME`; variabile di contesto built-in di GitHub Actions, non un nostro costrutto.
- `.github/workflows/seo-serp-autopilot.yml` — falso positivo: condivide `GITHUB_REF_NAME`; variabile di contesto built-in di GitHub Actions, non un nostro costrutto.
- `.github/workflows/submit-indexnow-batch.yml` — falso positivo: condivide `BING_API_KEY`; nome della env var Bing (Firebase Remote Config), stesso identificatore usato da ogni script Bing preesistente.
- `.github/workflows/traffic-scheduler.yml` — falso positivo: condivide `GITHUB_REF_NAME`; variabile di contesto built-in di GitHub Actions, non un nostro costrutto.
- `build-plugins/jobOrphanBridgePlugin.ts` — falso positivo: condivide `matchType`; nome di variabile/campo generico (match type), dichiarato indipendentemente — nei file non-Google è un concetto di matching URL/job non correlato.
- `build-plugins/jobRecencyLanding.ts` — falso positivo: condivide `inWindow`; funzione/variabile locale generica di finestra temporale, dichiarata indipendentemente.
- `build-plugins/jobsSeoPagesPlugin.ts` — falso positivo: condivide `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `build-plugins/orphanQueryData.ts` — falso positivo: condivide `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `build-plugins/orphanQueryLandingPlugin.ts` — falso positivo: condivide `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `build-plugins/salaryHubPlugin.ts` — falso positivo: condivide `pageCount`; variabile locale generica di conteggio pagine, dichiarata indipendentemente.
- `build-plugins/spaBundleResolver.ts` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `components/community/GamificationPage.tsx` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.
- `components/community/GamificationWidget.tsx` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.
- `components/community/JobBoard.tsx` — falso positivo: condivide `dateRanges`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `components/community/WhatsNewModal.tsx` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.
- `components/guide/FrontierGuide.tsx` — falso positivo: condivide `matchType`; nome di variabile/campo generico (match type), dichiarato indipendentemente — nei file non-Google è un concetto di matching URL/job non correlato.
- `components/shared/LeadMagnetCTA.tsx` — falso positivo: condivide `pageCount`; variabile locale generica di conteggio pagine, dichiarata indipendentemente.
- `scripts/analytics-report.mjs` — falso positivo: condivide `BING_API_KEY`, `DEFAULT_GA4_PROPERTY_ID`, `GSC_REFRESH_TOKEN`, `analytics-opportunity-utils`, `avgPosition`, `dateRanges`, `deadClicks`, `dimensionFilter`, `dimensionFilterGroups`, `fieldName`, `ga4-service-account`, `getServiceAccountToken`, `matchType`, `metricValues`, `minImpressions`, `propertyId`, `runReport`, `sessionDefaultChannelGroup`, `stringFilter`, `totalImpressions`; importa il modulo condiviso `scripts/lib/analytics-opportunity-utils.mjs`, non duplica la logica.
- `scripts/audit-bfs-depth.mjs` — falso positivo: condivide `printTable`; funzione locale generica di stampa tabellare, dichiarata indipendentemente.
- `scripts/audit-cls-live.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/audit-orphan-pages-in-sitemaps.mjs` — falso positivo: condivide `printTable`; funzione locale generica di stampa tabellare, dichiarata indipendentemente.
- `scripts/check-bing-status.mjs` — falso positivo (ispezionato a mano, non solo per categoria): condivide `BING_API_KEY`, `GetFeeds`, `bing-webmaster` con `scripts/lib/bing-webmaster.mjs` (dove è avvenuto il fix di `parseBingDate` in questa PR), ma il file contiene solo un riferimento in doc-comment + un calcolo di freschezza generico via `Date.now()` non correlato; chiama esclusivamente le funzioni esportate da `bing-webmaster.mjs` senza una propria regex `/Date(...)/ ` duplicata — nessun antipattern da sweepare.
- `scripts/check-crawler-health.mjs` — falso positivo: condivide `STATE_PATH`; nome di variabile locale per il path del proprio state-file, dichiarato indipendentemente (idioma comune ai monitor script, nessun modulo condiviso).
- `scripts/check-gsc-frontaliere-baseline.mjs` — falso positivo: condivide `dimensionFilter`, `dimensionFilterGroups`; nome di campo della request GA4/GSC (`dimensionFilter`), vocabolario Google non nostro costrutto.
- `scripts/ci/alert-pat-down.mjs` — falso positivo: condivide `createGithubIssue`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/ci/harvest-agent-lessons.mjs` — falso positivo: condivide `createGithubIssue`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/ci/scan-job-timeouts.mjs` — falso positivo: condivide `createGithubIssue`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/cluster-orphan-queries.mjs` — falso positivo: condivide `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `scripts/cwv-monitor-check.mjs` — falso positivo: condivide `createGithubIssue`, `posthog-client`, `runHogQL`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/discover-404s-via-inspection.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/employer-traffic-report.mjs` — falso positivo: condivide `dateRanges`, `dimensionFilter`, `fieldName`, `metricValues`, `runReport`, `stringFilter`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/enrich-compat-orphan-slugs.mjs` — falso positivo: condivide `matchType`, `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `scripts/fetch-thin-page-promotions.mjs` — falso positivo: condivide `dateRanges`, `dimensionFilter`, `fieldName`, `matchType`, `runReport`, `stringFilter`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/find-orphan-indexed-jobs.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `dimensionFilter`, `dimensionFilterGroups`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/funnel-metrics-snapshot.mjs` — falso positivo: condivide `avgPosition`; metrica GSC standard (posizione media), vocabolario Google non nostro costrutto.
- `scripts/generate-keyword-pages-config.mjs` — falso positivo: condivide `totalImpressions`; metrica GSC/aggregata dichiarata indipendentemente in ciascun file, non un helper condiviso.
- `scripts/ingest-gsc-job-orphans.mjs` — falso positivo: condivide `matchType`; nome di variabile/campo generico (match type), dichiarato indipendentemente — nei file non-Google è un concetto di matching URL/job non correlato.
- `scripts/investigate-calc-funnel-drop.mjs` — falso positivo: condivide `posthog-client`, `runHogQL`; importa il modulo condiviso `scripts/lib/posthog-client.mjs`, non duplica la logica.
- `scripts/lib/alerts/detectors/output.mjs` — falso positivo: condivide `inWindow`; funzione/variabile locale generica di finestra temporale, dichiarata indipendentemente.
- `scripts/lib/analytics-opportunity-utils.mjs` — falso positivo: condivide `aggregateFamilyRows`, `avgPosition`, `computeCtr`, `minImpressions`, `seo-ctr-curve`; chiama la funzione condivisa `aggregateFamilyRows()` da `seo-ctr-curve.mjs`, non la ridefinisce.
- `scripts/lib/dedicated-crawler-common.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/lib/error-issue-sync.mjs` — falso positivo: condivide `createGithubIssue`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/lib/evidence/ga4Fetcher.mjs` — falso positivo: condivide `dateRanges`, `dimensionFilter`, `fieldName`, `matchType`, `metricValues`, `propertyId`, `runReport`, `stringFilter`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/lib/evidence/gscFetcher.mjs` — falso positivo: condivide `getServiceAccountToken`; chiama la funzione condivisa `getServiceAccountToken()` da `ga4-service-account.mjs`, non la ridefinisce.
- `scripts/lib/evidence/posthogFetcher.mjs` — falso positivo: condivide `posthog-client`, `runHogQL`; importa il modulo condiviso `scripts/lib/posthog-client.mjs`, non duplica la logica.
- `scripts/lib/free-translate.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/lib/ga4-service-account.mjs` — falso positivo: condivide `DEFAULT_GA4_PROPERTY_ID`, `getServiceAccountToken`; è il modulo condiviso stesso che definisce `getServiceAccountToken()` — la nostra PR lo importa e lo chiama (`getGoogleAccessToken()`), non lo ridefinisce.
- `scripts/lib/github-issue-creator.mjs` — falso positivo: condivide `createGithubIssue`; è il modulo condiviso stesso che definisce `createGithubIssue()` — la nostra PR lo importa e lo chiama (via `defaultCreateIssue`), non lo ridefinisce.
- `scripts/lib/lidl-job-parser.mjs` — falso positivo: condivide `pageCount`; variabile locale generica di conteggio pagine, dichiarata indipendentemente.
- `scripts/lib/lis-lugano-istituti-sociali-job-parser.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/lib/perf-sources/ga4.mjs` — falso positivo: condivide `dateRanges`, `dimensionFilter`, `fieldName`, `matchType`, `metricValues`, `propertyId`, `runReport`, `stringFilter`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/lib/perf-sources/gsc.mjs` — falso positivo: condivide `dimensionFilter`, `dimensionFilterGroups`, `getServiceAccountToken`, `pathContains`, `seo-ctr-curve`; chiama la funzione condivisa `getServiceAccountToken()` da `ga4-service-account.mjs`, non la ridefinisce.
- `scripts/lib/pkb-private-bank-job-parser.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/lib/posthog-client.mjs` — falso positivo: condivide `runHogQL`; è il modulo condiviso stesso che definisce `runHogQL()` — la nostra PR lo importa e lo chiama, non lo ridefinisce.
- `scripts/lib/rfsm-fribourg-job-parser.mjs` — falso positivo: condivide `propertyId`; nome di campo/parametro GA4 (property id), vocabolario Google non nostro costrutto.
- `scripts/lib/sbb-job-parser.mjs` — falso positivo: condivide `matchType`; nome di variabile/campo generico (match type), dichiarato indipendentemente — nei file non-Google è un concetto di matching URL/job non correlato.
- `scripts/lib/scheduler/quotaController.mjs` — falso positivo: condivide `STATE_PATH`; nome di variabile locale per il path del proprio state-file, dichiarato indipendentemente (idioma comune ai monitor script, nessun modulo condiviso).
- `scripts/lib/seo-ctr-curve.mjs` — falso positivo: condivide `aggregateFamilyRows`, `analytics-opportunity-utils`, `avgPosition`, `computeCtr`, `minImpressions`, `pageCount`, `pathContains`, `seo-ctr-curve`, `totalImpressions`; chiama la funzione condivisa `aggregateFamilyRows()` da `seo-ctr-curve.mjs`, non la ridefinisce.
- `scripts/lib/topic-sources/googleTrends.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/load-rc-env.mjs` — falso positivo: condivide `BING_API_KEY`, `GSC_REFRESH_TOKEN`; nome della env var Bing (Firebase Remote Config), stesso identificatore usato da ogni script Bing preesistente.
- `scripts/looker-dashboard.gs` — falso positivo: condivide `dateRanges`, `dimensionFilter`, `fieldName`, `matchType`, `metricValues`, `propertyId`, `runReport`, `sessionDefaultChannelGroup`, `stringFilter`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/monitor-cls-posthog.mjs` — falso positivo: condivide `posthog-client`, `runHogQL`; importa il modulo condiviso `scripts/lib/posthog-client.mjs`, non duplica la logica.
- `scripts/monitor-gsc-job-indexation.mjs` — falso positivo: condivide `GSC_SCOPE`, `createGithubIssue`, `dimensionFilter`, `dimensionFilterGroups`, `includingRegex`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/monitor-seo-ctr-by-template.mjs` — falso positivo: condivide `STATE_PATH`, `aggregateFamilyRows`, `createGithubIssue`, `lastError`, `loadState`, `minImpressions`, `pageCount`, `pathContains`, `seo-ctr-curve`; chiama la funzione condivisa `aggregateFamilyRows()` da `seo-ctr-curve.mjs`, non la ridefinisce.
- `scripts/reconcile-here-usage.mjs` — falso positivo: condivide `createGithubIssue`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `scripts/refine-url-first-seen-via-gsc.mjs` — falso positivo: condivide `ga4-service-account`, `getServiceAccountToken`; importa il modulo condiviso `scripts/lib/ga4-service-account.mjs`, non duplica la logica.
- `scripts/refresh-gsc-position-rolling.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `ga4-service-account`, `getServiceAccountToken`; importa il modulo condiviso `scripts/lib/ga4-service-account.mjs`, non duplica la logica.
- `scripts/refresh-indexed-cluster-urls.mjs` — falso positivo: condivide `dateRanges`, `metricValues`, `minImpressions`, `propertyId`, `runReport`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/refresh-noslash-keep.mjs` — falso positivo: condivide `dateRanges`, `metricValues`, `minImpressions`, `propertyId`, `runReport`; nome di campo della request GA4 Data API (`runReport`), vocabolario Google non nostro costrutto.
- `scripts/revenue-monitor.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `avgPosition`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/send-job-alerts.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/seo-ctr-baseline.mjs` — falso positivo: condivide `aggregateFamilyRows`, `avgPosition`, `pageCount`, `pathContains`, `seo-ctr-curve`, `totalImpressions`; chiama la funzione condivisa `aggregateFamilyRows()` da `seo-ctr-curve.mjs`, non la ridefinisce.
- `scripts/seo-serp-autopilot.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `totalImpressions`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/setup-ga4-user-dimensions.mjs` — falso positivo: condivide `DEFAULT_GA4_PROPERTY_ID`, `ga4-service-account`, `getServiceAccountToken`, `propertyId`; importa il modulo condiviso `scripts/lib/ga4-service-account.mjs`, non duplica la logica.
- `scripts/setup-google-oauth.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/submit-google-indexing-jobs.js` — falso positivo: condivide `GSC_REFRESH_TOKEN`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/submit-google-indexing.js` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `GSC_SCOPE`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/submit-indexnow-batch.mjs` — falso positivo: condivide `BING_API_KEY`; nome della env var Bing (Firebase Remote Config), stesso identificatore usato da ogni script Bing preesistente.
- `scripts/submit-indexnow.js` — falso positivo: condivide `BING_API_KEY`, `bing-webmaster`; importa il modulo condiviso `scripts/lib/bing-webmaster.mjs` (dove è avvenuto il fix `parseBingDate`) e lo chiama soltanto — nessuna logica di parsing duplicata nel file.
- `scripts/sync-gsc-orphans.mjs` — falso positivo: condivide `GSC_REFRESH_TOKEN`, `dimensionFilter`, `dimensionFilterGroups`, `pageCount`, `totalImpressions`; nome della env var GSC OAuth (Firebase Remote Config), stesso identificatore usato da ogni script GSC preesistente.
- `scripts/tune-discovery-quota.mjs` — falso positivo: condivide `STATE_PATH`; nome di variabile locale per il path del proprio state-file, dichiarato indipendentemente (idioma comune ai monitor script, nessun modulo condiviso).
- `scripts/update-cambiavalute-jobs.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/update-delvitech-jobs.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/update-grace-jobs.mjs` — falso positivo: condivide `lastError`; campo generico dello state-file locale, dichiarato indipendentemente in ciascun file.
- `scripts/update-lidl-jobs.mjs` — falso positivo: condivide `pageCount`; variabile locale generica di conteggio pagine, dichiarata indipendentemente.
- `scripts/update-sbb-jobs.mjs` — falso positivo: condivide `matchType`; nome di variabile/campo generico (match type), dichiarato indipendentemente — nei file non-Google è un concetto di matching URL/job non correlato.
- `scripts/user-value-report.mjs` — falso positivo: condivide `DEFAULT_GA4_PROPERTY_ID`, `GSC_REFRESH_TOKEN`, `dateRanges`, `ga4-service-account`, `getServiceAccountToken`, `metricValues`, `nCampaign`, `propertyId`, `runReport`; importa il modulo condiviso `scripts/lib/ga4-service-account.mjs`, non duplica la logica.
- `scripts/verify-post-deploy-seo.mjs` — falso positivo: condivide `GSC_SCOPE`, `createGithubIssue`, `dimensionFilter`, `dimensionFilterGroups`, `includingRegex`; chiama la funzione condivisa `createGithubIssue()` da `github-issue-creator.mjs`, non la ridefinisce.
- `services/analytics.ts` — falso positivo: condivide `lastValue`; campo generico dello stato locale, dichiarato indipendentemente.
- `services/consentService.ts` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.
- `services/gamificationService.ts` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.
- `services/webVitals.ts` — falso positivo: condivide `loadState`; nome di funzione locale generica (carica lo state-file proprio), dichiarata indipendentemente in ciascun file.