### PR TITLE
feat(email-worker): auto-process newsletter unsubscribe replies

### DIFF
--- a/.github/workflows/deploy-email-worker.yml
+++ b/.github/workflows/deploy-email-worker.yml
@@ -6,7 +6,8 @@
 # every push to main that touches its directory, then configures it via the CF
 # API (scripts/cf-email-worker-setup.mjs): sets the worker secrets STOP_SECRET
 # (= NEWSLETTER_SECRET) and FORWARD_TO (resolved from the zone catch-all target,
-# so no email is committed), and binds the outreach reply address to the worker.
+# so no email is committed), and binds BOTH the outreach reply address and the
+# newsletter mailbox (auto-unsubscribe on a STOP/UNSUBSCRIBE reply) to the worker.
 #
 # Credentials come from Firebase Remote Config (repo convention — same as
 # deploy-worker.yml), hydrated by scripts/load-rc-env.mjs:
@@ -86,9 +87,10 @@ jobs:
           workingDirectory: infra/cloudflare-email-worker
           command: deploy
 
-      # Sets STOP_SECRET + FORWARD_TO worker secrets via the CF API and binds the
-      # outreach reply address to the worker. Runs AFTER deploy so the worker
-      # script exists. Secrets are essential (fail on error); the routing rule is
-      # best-effort (warns if the token lacks Email Routing:Edit).
+      # Sets STOP_SECRET + FORWARD_TO worker secrets via the CF API and binds both
+      # the outreach reply address and the newsletter mailbox to the worker. Runs
+      # AFTER deploy so the worker script exists. Secrets are essential (fail on
+      # error); each routing rule is best-effort (warns if the token lacks Email
+      # Routing:Edit).
       - name: Configure secrets + Email Routing binding
         run: node scripts/cf-email-worker-setup.mjs

--- a/infra/cloudflare-email-worker/stop-reply-handler.js
+++ b/infra/cloudflare-email-worker/stop-reply-handler.js
@@ -1,32 +1,51 @@
 /**
- * stop-reply-handler.js — Cloudflare Email Routing Worker for inbound cold-email
- * replies (follow-up #2620, item 2).
+ * stop-reply-handler.js — Cloudflare Email Routing Worker for inbound
+ * STOP/UNSUBSCRIBE replies (follow-up #2620, item 2; extended for the
+ * newsletter mailbox — Apple Mail's `List-Unsubscribe` mailto: fallback lands
+ * here as a plain email, e.g. "Please unsubscribe x@y.ch from Frontaliere
+ * Weekly").
  *
  * Cloudflare Email Routing forwards every @frontaliereticino.ch message; this
- * Worker is bound (Email Routing → custom address → "Send to a Worker") to the
- * outreach reply address (the cold-email `From`, e.g. valerie@frontaliereticino.ch
- * via OUTREACH_FROM_ADDRESS). On each inbound message it:
- *   1. Parses the From header + subject + a bounded prefix of the text body.
- *   2. If it expresses a STOP / UNSUBSCRIBE intent, POSTs { from, subject, body }
- *      to the outreachStopReply Cloud Function (secret-gated via STOP_SECRET),
- *      which reverse-maps the sender → companyKey and writes
- *      employer_outreach_suppression/{companyKey} — the SAME suppression
- *      send-cold-emails.mjs honours.
- *   3. ALWAYS forwards the original message to the human inbox (FORWARD_TO) so no
- *      reply is ever swallowed — STOP handling is additive, not a replacement for
- *      reading replies.
+ * Worker is bound (Email Routing → custom address → "Send to a Worker") to TWO
+ * addresses, both routed to the SAME worker, branched on the recipient
+ * (`message.to`):
+ *   - the cold-email outreach reply address (env.OUTREACH_ADDRESS, e.g.
+ *     valerie@frontaliereticino.ch) → handleOutreachReply
+ *   - the newsletter mailbox (env.NEWSLETTER_ADDRESS, newsletter@…) →
+ *     handleNewsletterUnsubscribe
  *
- * Detection MIRRORS scripts/lib/stop-reply-detect.mjs (single source) — kept in
- * lockstep (AGENTS.md Non-Negotiable #6); both are unit-tested.
+ * handleOutreachReply, on a STOP/UNSUBSCRIBE intent, POSTs { from, subject,
+ * body } to the outreachStopReply Cloud Function (secret-gated via
+ * STOP_SECRET), which reverse-maps the sender → companyKey and writes
+ * employer_outreach_suppression/{companyKey} — the SAME suppression
+ * send-cold-emails.mjs honours.
+ *
+ * handleNewsletterUnsubscribe, on the same intent, HMAC-signs the sender
+ * address (Web Crypto — no node:crypto in Workers) with STOP_SECRET (==
+ * NEWSLETTER_SECRET) and calls the SAME one-click endpoint the newsletter's
+ * own unsubscribe link/List-Unsubscribe header uses
+ * (services/newsletterUrls.mjs:makeOneClickUnsubscribeUrl →
+ * newsletterManageSubscription Cloud Function) — no new suppression path, no
+ * new secret.
+ *
+ * Either way the Worker ALWAYS forwards the original message to the human
+ * inbox (FORWARD_TO) so no reply is ever swallowed — STOP handling is
+ * additive, not a replacement for reading replies.
+ *
+ * STOP-intent detection MIRRORS scripts/lib/stop-reply-detect.mjs (single
+ * source) — kept in lockstep (AGENTS.md Non-Negotiable #6); both are
+ * unit-tested (tests/stop-reply-detect.test.ts, tests/cf-email-worker.test.ts).
  *
  * Deploy + config are AUTOMATED by .github/workflows/deploy-email-worker.yml
  * (wrangler deploy + scripts/cf-email-worker-setup.mjs). Bindings:
- *   vars (wrangler.toml):  STOP_REPLY_FN_URL, REPLY_TRACK_FN_URL
+ *   vars (wrangler.toml): STOP_REPLY_FN_URL, REPLY_TRACK_FN_URL,
+ *                          NEWSLETTER_UNSUB_URL, OUTREACH_ADDRESS,
+ *                          NEWSLETTER_ADDRESS
  *   secrets (CF API, set by the setup script): STOP_SECRET (== NEWSLETTER_SECRET),
  *            FORWARD_TO (the human inbox; resolved from the zone catch-all target)
  *
- * The inbound binding (outreach reply address → "send to worker") is also set
- * by the setup script via the Email Routing API — no manual dashboard step.
+ * The inbound bindings (both addresses → "send to worker") are also set by the
+ * setup script via the Email Routing API — no manual dashboard step.
  */
 
 // MIRROR of scripts/lib/stop-reply-detect.mjs STOP_INTENT_PATTERNS. Keep in sync.
@@ -44,10 +63,31 @@ const STOP_INTENT_PATTERNS = [
   /annull\w*\s+l\W?iscrizione/i,
 ];
 
-function isStopReply(subject, body) {
+export function isStopReply(subject, body) {
   const haystack = `${subject || ''}\n${body || ''}`;
   if (!haystack.trim()) return false;
   return STOP_INTENT_PATTERNS.some((re) => re.test(haystack));
+}
+
+// MIRROR of scripts/lib/stop-reply-detect.mjs extractSenderEmail. Keep in sync.
+export function extractSenderEmail(fromHeader) {
+  const raw = String(fromHeader || '').trim();
+  if (!raw) return '';
+  const angle = raw.match(/<([^>]+)>/);
+  const candidate = (angle ? angle[1] : raw).trim();
+  const m = candidate.match(/[^\s<>"']+@[^\s<>"']+\.[^\s<>"']+/);
+  return m ? m[0].toLowerCase().replace(/[).,;]+$/, '') : '';
+}
+
+// Web Crypto HMAC-SHA256 hex digest — byte-identical to Node's
+// createHmac('sha256', secret).update(message).digest('hex')
+// (services/newsletterUrls.mjs:signedEmailToken), which the Worker runtime
+// cannot call directly (no node:crypto).
+export async function hmacHex(secret, message) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(message));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 // Read a bounded prefix of the raw email stream as text. We only need the first
@@ -76,6 +116,56 @@ async function readBodyPrefix(stream, maxBytes = 8192) {
   return new TextDecoder('utf-8', { fatal: false }).decode(merged.subarray(0, maxBytes));
 }
 
+// Detect on subject first (cheap); read the body only if needed. Shared by
+// both the outreach and newsletter paths so the "read body lazily" behavior
+// can't drift between them.
+async function classifyStopIntent(subject, message) {
+  if (isStopReply(subject, '')) return { stop: true, body: '' };
+  const body = await readBodyPrefix(message.raw);
+  return { stop: isStopReply(subject, body), body };
+}
+
+async function handleOutreachReply({ from, subject, message, env, ctx }) {
+  // Track EVERY inbound reply (best-effort) so the admin dashboard can show
+  // whether a company replied. Only from+subject are needed (no body read),
+  // so this runs cheaply on every message. Additive to STOP suppression below.
+  if (env.REPLY_TRACK_FN_URL && env.STOP_SECRET) {
+    const track = fetch(env.REPLY_TRACK_FN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
+      body: JSON.stringify({ from, subject }),
+    }).catch(() => { /* best-effort telemetry; never block forwarding */ });
+    ctx.waitUntil(track);
+  }
+
+  const { stop, body } = await classifyStopIntent(subject, message);
+
+  if (stop && env.STOP_REPLY_FN_URL && env.STOP_SECRET) {
+    // Fire-and-forget the suppression POST; never block forwarding on it.
+    const suppress = fetch(env.STOP_REPLY_FN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
+      body: JSON.stringify({ from, subject, body: body.slice(0, 2000) }),
+    }).catch(() => { /* best-effort; the cron processor is the safety net */ });
+    ctx.waitUntil(suppress);
+  }
+}
+
+async function handleNewsletterUnsubscribe({ from, subject, message, env, ctx }) {
+  const { stop } = await classifyStopIntent(subject, message);
+  if (!stop) return;
+
+  const senderEmail = extractSenderEmail(from);
+  if (!senderEmail || !env.STOP_SECRET || !env.NEWSLETTER_UNSUB_URL) return;
+
+  const unsub = (async () => {
+    const token = await hmacHex(env.STOP_SECRET, senderEmail);
+    const url = `${env.NEWSLETTER_UNSUB_URL}?action=unsubscribe&email=${encodeURIComponent(senderEmail)}&token=${token}&format=json`;
+    return fetch(url);
+  })().catch(() => { /* best-effort; the recipient still reaches the human inbox below */ });
+  ctx.waitUntil(unsub);
+}
+
 export default {
   /**
    * Cloudflare Email Routing entrypoint.
@@ -85,37 +175,17 @@ export default {
    */
   async email(message, env, ctx) {
     const from = message.from || '';
+    const to = String(message.to || '').trim().toLowerCase();
     const subject = (message.headers && message.headers.get && message.headers.get('subject')) || '';
 
-    // Track EVERY inbound reply (best-effort) so the admin dashboard can show
-    // whether a company replied. Only from+subject are needed (no body read),
-    // so this runs cheaply on every message. Additive to STOP suppression below.
-    if (env.REPLY_TRACK_FN_URL && env.STOP_SECRET) {
-      const track = fetch(env.REPLY_TRACK_FN_URL, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
-        body: JSON.stringify({ from, subject }),
-      }).catch(() => { /* best-effort telemetry; never block forwarding */ });
-      ctx.waitUntil(track);
+    const isNewsletterAddress = !!env.NEWSLETTER_ADDRESS && to === env.NEWSLETTER_ADDRESS.toLowerCase();
+    if (isNewsletterAddress) {
+      await handleNewsletterUnsubscribe({ from, subject, message, env, ctx });
+    } else {
+      await handleOutreachReply({ from, subject, message, env, ctx });
     }
 
-    // Detect on subject first (cheap); read the body only if needed.
-    let body = '';
-    if (!isStopReply(subject, '')) {
-      body = await readBodyPrefix(message.raw);
-    }
-
-    if (isStopReply(subject, body) && env.STOP_REPLY_FN_URL && env.STOP_SECRET) {
-      // Fire-and-forget the suppression POST; never block forwarding on it.
-      const suppress = fetch(env.STOP_REPLY_FN_URL, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-stop-secret': env.STOP_SECRET },
-        body: JSON.stringify({ from, subject, body: body.slice(0, 2000) }),
-      }).catch(() => { /* best-effort; the cron processor is the safety net */ });
-      ctx.waitUntil(suppress);
-    }
-
-    // ALWAYS forward to the human inbox so no reply is lost.
+    // ALWAYS forward to the human inbox so no reply is ever lost.
     if (env.FORWARD_TO) {
       try { await message.forward(env.FORWARD_TO); } catch { /* recipient may be unverified; ignore */ }
     }

--- a/infra/cloudflare-email-worker/wrangler.toml
+++ b/infra/cloudflare-email-worker/wrangler.toml
@@ -1,14 +1,16 @@
 # Cloudflare Email Routing Worker for inbound cold-email STOP replies + reply
-# tracking.
+# tracking, and for newsletter mailbox unsubscribe replies (Apple Mail's
+# List-Unsubscribe mailto: fallback lands here as a plain email).
 #
 # Deploy + config are AUTOMATED by .github/workflows/deploy-email-worker.yml on
 # every push to main touching this dir: it runs `wrangler deploy` then
 # scripts/cf-email-worker-setup.mjs, which (via the CF API) sets the worker
 # secrets STOP_SECRET (= NEWSLETTER_SECRET) and FORWARD_TO (resolved from the
-# zone catch-all target, so no address is committed), and binds the outreach
-# reply address (valerie@frontaliereticino.ch) → this worker. No manual step.
+# zone catch-all target, so no address is committed), and binds BOTH the
+# outreach reply address (OUTREACH_ADDRESS below) and the newsletter mailbox
+# (NEWSLETTER_ADDRESS below) → this worker. No manual step.
 #
-# The two CF-URL vars below are plain (non-secret) and applied on each deploy.
+# The vars below are plain (non-secret) and applied on each deploy.
 # STOP_SECRET / FORWARD_TO are worker SECRETS set out-of-band by the setup script
 # — never committed here.
 
@@ -17,11 +19,22 @@ main = "stop-reply-handler.js"
 compatibility_date = "2026-01-01"
 
 [vars]
-# Cloud Function that resolves sender→companyKey and writes the suppression doc.
+# Cloud Function that resolves sender→companyKey and writes the suppression doc
+# (outreach reply path only).
 STOP_REPLY_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachStopReply"
 # Cloud Function that records EVERY inbound reply (reply telemetry for the admin
-# dashboard). Additive to STOP suppression; same x-stop-secret gate.
+# dashboard). Additive to STOP suppression; same x-stop-secret gate. Outreach
+# reply path only.
 REPLY_TRACK_FN_URL = "https://europe-west6-frontaliere-ticino.cloudfunctions.net/outreachReplyTrack"
+# One-click unsubscribe endpoint (same one services/newsletterUrls.mjs's
+# makeOneClickUnsubscribeUrl builds for the email footer / List-Unsubscribe
+# header) — newsletter mailbox path only.
+NEWSLETTER_UNSUB_URL = "https://frontaliereticino.ch/disiscrivi-newsletter/"
+# Recipient address that selects the newsletter path in stop-reply-handler.js's
+# email() branch (anything else falls through to the outreach path — today
+# that's OUTREACH_ADDRESS in scripts/cf-email-worker-setup.mjs). Plain,
+# non-secret — already appears in DNS/MX and in outbound mail headers.
+NEWSLETTER_ADDRESS = "newsletter@frontaliereticino.ch"
 # NOTE: FORWARD_TO (the human inbox replies are forwarded to) is a worker SECRET
 # set by scripts/cf-email-worker-setup.mjs from the zone catch-all target — not a
 # committed var, so no personal address lands in the repo.

--- a/scripts/cf-email-worker-setup.mjs
+++ b/scripts/cf-email-worker-setup.mjs
@@ -10,10 +10,9 @@
  *      FORWARD_TO is resolved from the zone's catch-all forward target, so the
  *      worker forwards replies to the SAME inbox the catch-all already used —
  *      adding the worker rule never silently drops a reply.
- *   2. Ensures an Email Routing rule: the outreach address
- *      (valerie@frontaliereticino.ch) → "send to worker"
- *      frontaliere-stop-reply-handler. Idempotent (updates an existing rule by
- *      matcher, else creates one).
+ *   2. Ensures an Email Routing rule per address in ROUTING_RULES below → "send
+ *      to worker" frontaliere-stop-reply-handler. Idempotent (updates an
+ *      existing rule by matcher, else creates one).
  *
  * Env (hydrated by scripts/load-rc-env.mjs in CI):
  *   CF_API_TOKEN      — needs Workers Scripts:Edit (secrets) + Email Routing:Edit (rule)
@@ -21,16 +20,23 @@
  *   NEWSLETTER_SECRET — becomes the worker's STOP_SECRET
  *
  * Failure policy: secrets are essential → fail the job if they can't be set.
- * The Email Routing rule is best-effort → on error (e.g. token missing the
+ * Each Email Routing rule is best-effort → on error (e.g. token missing the
  * Email Routing:Edit scope) it warns and exits 0, so the worker still deploys
  * and the rule can be bound once.
  */
 
 const ZONE_NAME = 'frontaliereticino.ch';
 const WORKER_NAME = 'frontaliere-stop-reply-handler';
-// The cold-email From / reply address. Inbound replies to it must hit the worker.
+// Recipient addresses that must route to the worker, and the routing-rule name
+// for each. stop-reply-handler.js branches on `message.to` (NEWSLETTER_ADDRESS
+// var in wrangler.toml) — anything not matching that falls through to the
+// outreach-reply path, so OUTREACH_ADDRESS below stays first/default in intent.
 const OUTREACH_ADDRESS = 'valerie@frontaliereticino.ch';
-const RULE_NAME = 'cold-email reply → stop-reply-handler';
+const NEWSLETTER_ADDRESS = 'newsletter@frontaliereticino.ch';
+const ROUTING_RULES = [
+  { address: OUTREACH_ADDRESS, name: 'cold-email reply → stop-reply-handler' },
+  { address: NEWSLETTER_ADDRESS, name: 'newsletter unsubscribe reply → stop-reply-handler' },
+];
 
 const API = 'https://api.cloudflare.com/client/v4';
 const TOKEN = process.env.CF_API_TOKEN;
@@ -83,29 +89,29 @@ async function putSecret(name, text) {
   console.log(`✓ secret ${name} set on ${WORKER_NAME}`);
 }
 
-async function ensureRoutingRule(zoneId) {
+async function ensureRoutingRule(zoneId, address, ruleName) {
   const desired = {
-    name: RULE_NAME,
+    name: ruleName,
     enabled: true,
-    matchers: [{ type: 'literal', field: 'to', value: OUTREACH_ADDRESS }],
+    matchers: [{ type: 'literal', field: 'to', value: address }],
     actions: [{ type: 'worker', value: [WORKER_NAME] }],
   };
   const list = await cf(`/zones/${zoneId}/email/routing/rules`);
   if (!list.ok) {
-    console.log(`::warning::could not list Email Routing rules (status ${list.status}) — bind ${OUTREACH_ADDRESS} → ${WORKER_NAME} manually.`);
+    console.log(`::warning::could not list Email Routing rules (status ${list.status}) — bind ${address} → ${WORKER_NAME} manually.`);
     return;
   }
   const existing = (list.json.result || []).find((rule) =>
-    (rule.matchers || []).some((m) => m.type === 'literal' && (m.value || '').toLowerCase() === OUTREACH_ADDRESS));
+    (rule.matchers || []).some((m) => m.type === 'literal' && (m.value || '').toLowerCase() === address.toLowerCase()));
   const target = existing
     ? { method: 'PUT', path: `/zones/${zoneId}/email/routing/rules/${existing.tag}` }
     : { method: 'POST', path: `/zones/${zoneId}/email/routing/rules` };
   const r = await cf(target.path, { method: target.method, body: desired });
   if (!r.ok) {
-    console.log(`::warning::could not ${existing ? 'update' : 'create'} the Email Routing rule (status ${r.status}: ${JSON.stringify(r.json.errors || r.json).slice(0, 200)}). Bind ${OUTREACH_ADDRESS} → ${WORKER_NAME} manually (token Email Routing:Edit scope?).`);
+    console.log(`::warning::could not ${existing ? 'update' : 'create'} the Email Routing rule for ${address} (status ${r.status}: ${JSON.stringify(r.json.errors || r.json).slice(0, 200)}). Bind ${address} → ${WORKER_NAME} manually (token Email Routing:Edit scope?).`);
     return;
   }
-  console.log(`✓ Email Routing rule ${existing ? 'updated' : 'created'}: ${OUTREACH_ADDRESS} → worker ${WORKER_NAME}`);
+  console.log(`✓ Email Routing rule ${existing ? 'updated' : 'created'}: ${address} → worker ${WORKER_NAME}`);
 }
 
 async function main() {
@@ -127,8 +133,10 @@ async function main() {
   await putSecret('STOP_SECRET', NEWSLETTER_SECRET);
   if (forwardTo) await putSecret('FORWARD_TO', forwardTo);
 
-  // Best-effort: the inbound binding.
-  await ensureRoutingRule(zoneId);
+  // Best-effort: the inbound bindings (one per address the worker branches on).
+  for (const rule of ROUTING_RULES) {
+    await ensureRoutingRule(zoneId, rule.address, rule.name);
+  }
 
   console.log('Email worker setup complete.');
 }

--- a/tests/cf-email-worker-stop-reply-handler.test.ts
+++ b/tests/cf-email-worker-stop-reply-handler.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+// @ts-expect-error — Cloudflare Worker module, no types
+import worker, { isStopReply, extractSenderEmail, hmacHex } from '../infra/cloudflare-email-worker/stop-reply-handler.js';
+
+// The worker binds TWO Email Routing addresses to the same script
+// (scripts/cf-email-worker-setup.mjs's ROUTING_RULES) and branches on
+// `message.to`: NEWSLETTER_ADDRESS → auto-unsubscribe via the one-click Cloud
+// Function, anything else → the existing cold-email outreach STOP path. Both
+// must keep forwarding to the human inbox unconditionally.
+
+const SECRET = 'shared-test-secret';
+
+function fakeMessage({ from, to, subject, rawText = '' }: { from: string; to: string; subject: string; rawText?: string }) {
+  const bytes = new TextEncoder().encode(rawText);
+  return {
+    from,
+    to,
+    headers: { get: (name: string) => (name.toLowerCase() === 'subject' ? subject : undefined) },
+    raw: {
+      getReader() {
+        let done = false;
+        return {
+          async read() {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: bytes };
+          },
+          releaseLock() {},
+        };
+      },
+    },
+    forward: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function fakeCtx() {
+  const waited: Promise<unknown>[] = [];
+  return { waitUntil: (p: Promise<unknown>) => { waited.push(p); }, waited };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('hmacHex (Web Crypto)', () => {
+  it('matches Node createHmac(sha256).digest(hex) byte-for-byte', async () => {
+    const expected = createHmac('sha256', SECRET).update('someone@example.com').digest('hex');
+    expect(await hmacHex(SECRET, 'someone@example.com')).toBe(expected);
+  });
+});
+
+describe('worker email() — newsletter mailbox branch', () => {
+  it('signs the sender email and calls the one-click unsubscribe endpoint, then forwards', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"success":true}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = fakeMessage({
+      from: 'Jane Reader <jane.reader@example.com>',
+      to: 'newsletter@frontaliereticino.ch',
+      subject: 'Unsubscribe Frontaliere Weekly',
+      rawText: 'Please unsubscribe jane.reader@example.com from Frontaliere Weekly.',
+    });
+    const ctx = fakeCtx();
+    const env = {
+      NEWSLETTER_ADDRESS: 'newsletter@frontaliereticino.ch',
+      NEWSLETTER_UNSUB_URL: 'https://frontaliereticino.ch/disiscrivi-newsletter/',
+      STOP_SECRET: SECRET,
+      FORWARD_TO: 'ops@example.com',
+    };
+
+    await worker.email(message, env, ctx);
+    await Promise.all(ctx.waited);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = new URL(fetchMock.mock.calls[0][0]);
+    expect(calledUrl.origin + calledUrl.pathname).toBe('https://frontaliereticino.ch/disiscrivi-newsletter/');
+    expect(calledUrl.searchParams.get('action')).toBe('unsubscribe');
+    expect(calledUrl.searchParams.get('email')).toBe('jane.reader@example.com');
+    expect(calledUrl.searchParams.get('token')).toBe(
+      createHmac('sha256', SECRET).update('jane.reader@example.com').digest('hex'),
+    );
+    expect(message.forward).toHaveBeenCalledWith('ops@example.com');
+  });
+
+  it('never calls the unsubscribe endpoint when the reply has no STOP intent', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = fakeMessage({
+      from: 'reader@example.com',
+      to: 'newsletter@frontaliereticino.ch',
+      subject: 'Question about last week issue',
+      rawText: 'Hey, loved the article on cross-border commuters, any plans to cover Basel?',
+    });
+    const ctx = fakeCtx();
+    const env = {
+      NEWSLETTER_ADDRESS: 'newsletter@frontaliereticino.ch',
+      NEWSLETTER_UNSUB_URL: 'https://frontaliereticino.ch/disiscrivi-newsletter/',
+      STOP_SECRET: SECRET,
+      FORWARD_TO: 'ops@example.com',
+    };
+
+    await worker.email(message, env, ctx);
+    await Promise.all(ctx.waited);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(message.forward).toHaveBeenCalledWith('ops@example.com');
+  });
+
+  it('does not route the outreach reply address into the newsletter path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = fakeMessage({
+      from: 'hr@aldi.ch',
+      to: 'valerie@frontaliereticino.ch',
+      subject: 'STOP',
+      rawText: '',
+    });
+    const ctx = fakeCtx();
+    const env = {
+      NEWSLETTER_ADDRESS: 'newsletter@frontaliereticino.ch',
+      NEWSLETTER_UNSUB_URL: 'https://frontaliereticino.ch/disiscrivi-newsletter/',
+      STOP_REPLY_FN_URL: 'https://example.test/outreachStopReply',
+      REPLY_TRACK_FN_URL: 'https://example.test/outreachReplyTrack',
+      STOP_SECRET: SECRET,
+      FORWARD_TO: 'ops@example.com',
+    };
+
+    await worker.email(message, env, ctx);
+    await Promise.all(ctx.waited);
+
+    const calledUrls = fetchMock.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calledUrls.some((u: string) => u.startsWith('https://example.test/'))).toBe(true);
+    expect(calledUrls.some((u: string) => u.includes('disiscrivi-newsletter'))).toBe(false);
+    expect(message.forward).toHaveBeenCalledWith('ops@example.com');
+  });
+});
+
+describe('isStopReply / extractSenderEmail (worker-local mirror)', () => {
+  it('matches the same intent forms as the shared lib', () => {
+    expect(isStopReply('Unsubscribe Frontaliere Weekly', '')).toBe(true);
+    expect(isStopReply('', 'Please unsubscribe me from this list.')).toBe(true);
+    expect(isStopReply('Re: last newsletter', 'loved this week issue')).toBe(false);
+  });
+
+  it('extracts a bare address from a display-name From header', () => {
+    expect(extractSenderEmail('Jane Reader <jane.reader@example.com>')).toBe('jane.reader@example.com');
+  });
+});


### PR DESCRIPTION
## Implementato

- Extended the existing Cloudflare Email Routing worker (`infra/cloudflare-email-worker/stop-reply-handler.js`, previously bound only to the cold-email outreach reply address) to also bind `newsletter@frontaliereticino.ch` and branch on `message.to`.
- New `handleNewsletterUnsubscribe` path: on a STOP/UNSUBSCRIBE intent (same detection patterns as `scripts/lib/stop-reply-detect.mjs`, mirrored per existing convention), it HMAC-signs the sender email (Web Crypto, since Workers have no `node:crypto`) and calls the SAME one-click unsubscribe Cloud Function (`newsletterManageSubscription`) that the newsletter's own footer link / `List-Unsubscribe` header already use — no new suppression path, no new secret (`STOP_SECRET == NEWSLETTER_SECRET`, already provisioned).
- Always still forwards the original reply to the human inbox (unchanged safety net — STOP handling stays additive).
- `scripts/cf-email-worker-setup.mjs`: generalized the single-address routing-rule upsert into a loop over `ROUTING_RULES` (outreach address + newsletter address), both idempotently bound to the same worker via the CF Email Routing API.
- Verified read-only against the live CF zone before writing this: `newsletter@` currently falls through to the catch-all (forward → the same human inbox `FORWARD_TO` already resolves to), so this change is purely additive — no existing routing behavior for that address changes.
- Manually processed the specific unsubscribe request that prompted this (Apple Mail `mailto:` fallback reply) via the existing one-click endpoint while building this — confirmed `{"success":true}`.
- Added `tests/cf-email-worker-stop-reply-handler.test.ts`: HMAC parity vs Node's `createHmac`, the newsletter branch calls the right URL/token and still forwards, a non-STOP reply doesn't trigger unsubscribe, and the outreach-address branch is unaffected (regression guard). All fixture emails are fictitious (`@example.com`) — no real subscriber data committed.
- `npm test` scoped to the touched/related files (`cf-email-worker-stop-reply-handler`, `stop-reply-detect`, `outreach-stop-reply-handler`, `newsletter-unsubscribe-oneclick`): 26/26 passing.
- GitNexus `impact()` on touched symbols (`isStopReply`, `ensureRoutingRule`) before editing: LOW risk both.
- `scripts/ci/check-sibling-patterns.mjs`: clean, no untouched sibling shares the modified constructs.

## Non implementato (ancora)

Nessuno.