### PR TITLE
fix(related-search-clusters): stop below-floor bridges leaking into sitemap on locale shards

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -315,7 +315,17 @@ const CACHE_KEY_INPUTS = [
 // the AND/OR job set for every cluster page changes (e.g. `…-infermieristiche-…`
 // now matches "infermiere" jobs). Old v6 caches hold the un-stemmed pages —
 // bump invalidates them so the next build re-emits with root matching.
-const CACHE_VERSION = 'v7';
+//
+// v8 (2026-07-18, run 29636707053) fixes the locale-shard render-skip branch
+// leaking below-floor cross-locale cluster URLs into `sitemapLocs` (it pushed
+// every cross-locale loc unconditionally, never applying the
+// MIN_JOBS_FOR_INDEXABLE_CLUSTER floor the owning shard's renderClusterPage
+// applies) — 31,624 noindex bridge URLs ended up self-canonical in
+// sitemap-search-clusters shards, failing audit:sitemap-canonicals,
+// validate:canonical and validate:content-quality. Old v7 caches still hold
+// the leaked locs — bump invalidates them so the next build recomputes the
+// floor decision for every cross-locale entry.
+const CACHE_VERSION = 'v8';
 
 /**
  * sitemaps.org caps each sitemap at 50,000 URLs. We shard at 45,000 to
@@ -1129,6 +1139,22 @@ const BELOW_FLOOR_BRIDGE_COPY: Record<Locale, {
 };
 
 /**
+ * True when a cluster falls below MIN_JOBS_FOR_INDEXABLE_CLUSTER and has no
+ * AI-enriched-intro exemption — i.e. `renderClusterPage` emits a
+ * noindex,follow below-floor bridge (canonical → hub) for it instead of a
+ * self-canonical page. Single source of truth shared by the full render
+ * path (`renderClusterPage`) and the locale-shard render-skip path
+ * (BUILD_LOCALE, LOCALE-SHARD-BUILD-PLAN Fase 0): both must agree on which
+ * URLs are self-canonical, or the skip path's cheap `sitemapLocs` entries
+ * leak below-floor bridge URLs into the sitemap once shards are merged —
+ * see CACHE_VERSION v8 history for the incident this de-duplication fixes.
+ */
+export function isClusterBelowFloor(ctx: ClusterContext, enriched: EnrichedEntry | undefined): boolean {
+  const hasEnrichedIntro = Boolean(enriched?.intro && enriched.intro.trim());
+  return !hasEnrichedIntro && ctx.matchingJobs.length < MIN_JOBS_FOR_INDEXABLE_CLUSTER;
+}
+
+/**
  * Below-floor bridge (issue #4303 item 4): consolidates clusters with
  * fewer than MIN_JOBS_FOR_INDEXABLE_CLUSTER matching jobs into the
  * Switzerland-wide hub instead of emitting a thin near-duplicate page.
@@ -1528,8 +1554,7 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
   // enriched entry (data/related-search-enriched.json), so this exemption
   // is narrow — it doesn't blunt the consolidation for the bulk of
   // generic, non-enriched below-floor clusters the issue targets.
-  const hasEnrichedIntro = Boolean(enriched?.intro && enriched.intro.trim());
-  if (!hasEnrichedIntro && ctx.matchingJobs.length < MIN_JOBS_FOR_INDEXABLE_CLUSTER) {
+  if (isClusterBelowFloor(ctx, enriched)) {
     return renderClusterBelowFloorBridge(locale, urlPath, canonicalUrl, ctx.keyword);
   }
 
@@ -2788,7 +2813,19 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         // No-op in the default all-locale build (shouldEmitLocale always true).
         if (!shouldEmitLocale(locale)) {
           const __skUrlPath = buildClusterPath(locale, ctx.candidate.slug, ctx.cantonGroup);
-          sitemapLocs.push(`${BASE_URL}${__skUrlPath}`);
+          // Mirror the MIN_JOBS_FOR_INDEXABLE_CLUSTER floor decision that
+          // renderClusterPage makes on the OWNING shard (line ~1532). Below
+          // floor, that shard renders a noindex,follow bridge (canonical →
+          // hub) at this same urlPath instead of a self-canonical page — so
+          // this cheap cross-locale entry must NOT self-canonicalize into
+          // sitemapLocs either, or audit:sitemap-canonicals/validate:canonical
+          // hard-fail once the shards are merged. dropOverwrittenLocs can't
+          // catch this post-hoc: its cross-shard branch trusts owning-shard
+          // locs unconditionally (this shard never writes the HTML to check).
+          const __skEnriched = enriched[`${locale}::${ctx.candidate.slug}`];
+          if (!isClusterBelowFloor(ctx, __skEnriched)) {
+            sitemapLocs.push(`${BASE_URL}${__skUrlPath}`);
+          }
           const __skMirror = new Set<string>();
           for (const __skMc of [ctx.legacyCantonGroup, 'TI']) {
             if (__skMc === AGGREGATE_KEY) continue;

--- a/tests/related-search-clusters-shell.test.ts
+++ b/tests/related-search-clusters-shell.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'nod
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
-import { renderClusterPage } from '../build-plugins/relatedSearchClustersPlugin';
+import { renderClusterPage, isClusterBelowFloor } from '../build-plugins/relatedSearchClustersPlugin';
 import { buildFlatBridgeFromSibling } from '../build-plugins/flatHtmlRedirectPlugin';
 
 const tmpDirs: string[] = [];
@@ -185,6 +185,84 @@ describe('related search cluster SEO shell', () => {
     expect(page.html).toContain('og:image');
     expect(page.html).toContain('Rel 4');
     expect(page.html).toContain('Rel 5');
+  });
+});
+
+describe('below-floor bridge floor decision (issue #4303 item 4 / run 29636707053)', () => {
+  // Regression coverage for the sitemap leak fixed alongside CACHE_VERSION
+  // v8: the locale-shard render-skip branch in closeBundle used to push
+  // every cross-locale cluster URL into sitemapLocs unconditionally, without
+  // checking whether renderClusterPage would actually render it as a
+  // below-floor noindex bridge. Both call sites now share
+  // `isClusterBelowFloor` as the single source of truth — these tests pin
+  // that decision function directly and prove renderClusterPage's output
+  // agrees with it, so the two can't silently diverge again.
+  const belowFloorCtx = {
+    candidate: { slug: 'ricerca-floor-test', locale: 'it', jobCount: 0, sampleTerms: ['floor test'], editorialCollision: null },
+    keyword: 'floor test',
+    city: null,
+    matchingJobs: [],
+    topCompanies: [],
+  } as any;
+
+  const aboveFloorCtx = {
+    ...belowFloorCtx,
+    matchingJobs: [
+      { id: 'a', title: 'Job A', company: 'Co', location: 'Lugano', canton: 'TI', slug: 'job-a' },
+      { id: 'b', title: 'Job B', company: 'Co', location: 'Lugano', canton: 'TI', slug: 'job-b' },
+      { id: 'c', title: 'Job C', company: 'Co', location: 'Lugano', canton: 'TI', slug: 'job-c' },
+    ],
+  };
+
+  it('is true below MIN_JOBS_FOR_INDEXABLE_CLUSTER with no enriched intro', () => {
+    expect(isClusterBelowFloor(belowFloorCtx, undefined)).toBe(true);
+  });
+
+  it('is false at/above MIN_JOBS_FOR_INDEXABLE_CLUSTER', () => {
+    expect(isClusterBelowFloor(aboveFloorCtx, undefined)).toBe(false);
+  });
+
+  it('is false below floor when an AI-enriched intro exempts the cluster', () => {
+    const enriched = { slug: 'ricerca-floor-test', locale: 'it', keyword: 'floor test', city: null, intro: 'Non-empty AI intro.', faqs: [] } as any;
+    expect(isClusterBelowFloor(belowFloorCtx, enriched)).toBe(false);
+  });
+
+  it('is true below floor when the enriched intro is present but blank', () => {
+    const enriched = { slug: 'ricerca-floor-test', locale: 'it', keyword: 'floor test', city: null, intro: '   ', faqs: [] } as any;
+    expect(isClusterBelowFloor(belowFloorCtx, enriched)).toBe(true);
+  });
+
+  it('renderClusterPage emits a noindex hub bridge, not self-canonical, when below floor', () => {
+    const distDir = makeDist();
+    const page = renderClusterPage({
+      distDir,
+      dateStamp: '2026-07-18',
+      ctx: belowFloorCtx,
+      enriched: undefined,
+      hreflang: [],
+      related: [],
+    });
+
+    expect(page.html).toMatch(/<meta name="?robots"? content="?noindex,follow"?/);
+    // `page.loc` is always the cluster's own URL (bridge or not) — a bridge's
+    // HTML canonical must point elsewhere (the hub), never back at itself.
+    expect(page.html).not.toContain(`<link rel=canonical href="${page.loc}"`);
+    expect(page.html).not.toContain('ricerca-floor-test');
+  });
+
+  it('renderClusterPage emits a self-canonical index,follow page at/above floor', () => {
+    const distDir = makeDist();
+    const page = renderClusterPage({
+      distDir,
+      dateStamp: '2026-07-18',
+      ctx: aboveFloorCtx,
+      enriched: undefined,
+      hreflang: [],
+      related: [],
+    });
+
+    expect(page.html).toMatch(/<meta name="?robots"? content="?index,follow"?/);
+    expect(page.html).toContain(`<link rel=canonical href="${page.loc}"`);
   });
 });
 


### PR DESCRIPTION
## Implementato

Fixes the `validate-dist` failure in [run 29636707053](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29636707053), which failed `audit:sitemap-canonicals`, `validate:canonical`, `validate:content-quality`, and (rolled up) `audit:all` with 31,624 blocking errors.

**Root cause**: `build-plugins/relatedSearchClustersPlugin.ts`'s locale-shard "render-skip" fast path (`BUILD_LOCALE` sharded builds) pushed every cross-locale search-cluster URL into `sitemapLocs` unconditionally. It never replicated the `MIN_JOBS_FOR_INDEXABLE_CLUSTER` floor decision that the full render path (`renderClusterPage`) applies — below that floor (and without an AI-enriched intro exemption), a cluster renders as a `noindex,follow` bridge (canonical → hub) instead of a self-canonical page. `dropOverwrittenLocs` can't catch this post-hoc: its cross-shard branch trusts owning-shard locs unconditionally, since this shard never writes that locale's HTML to disk to check against.

Once locale shards are merged for deploy, 31,624 of these noindex bridge URLs were listed as self-canonical entries in `sitemap-search-clusters-*.xml`.

**Fix**:
- Extracted the floor decision into `isClusterBelowFloor(ctx, enriched)` — a single source of truth now called by both `renderClusterPage` (full path) and the locale-shard render-skip branch in `closeBundle`, so the two can't diverge again.
- Bumped `CACHE_VERSION` v7 → v8 (documented inline) so caches holding the leaked locs are invalidated on the next build.
- Added 6 regression tests in `tests/related-search-clusters-shell.test.ts`: `isClusterBelowFloor` edge cases (floor, exemption, blank-intro non-exemption) plus a consistency check that `renderClusterPage`'s actual HTML output (noindex+hub-canonical vs. index+self-canonical) always agrees with the helper's prediction.
- Exported `isClusterBelowFloor` (consistent with the file's existing pattern of exporting small pure functions for testing, e.g. `dropOverwrittenLocs`, `dropUrlBlocksByLoc`).

**Verification**:
- `npx vitest run` (full suite): 1285 passed | 17 failed (7 files) | 11 skipped — all 7 failing files pre-existing/unrelated (see below), a sample of 4 reproduced identically with this fix's 2 files stashed out against clean `origin/main`.
- `node scripts/ci/check-below-floor-bridge.mjs`: clean (no new floor/`continue` guard without a bridge-call).
- Sibling-pattern candidates below: all individually inspected, all false positives.

Not in scope: `audit:max-bfs-depth` also failed in the same run (pendler-wetter/commute-weather/meteo-frontaliers pages at depth 5, some `border-wait` paths flagged unreachable). That's a separate, unrelated gate — a recurring baseline-drift pattern per project history, not a code defect in the file this PR touches. Left untouched to stay surgical (AGENTS.md #6 scopes fixes to "the class of the bug," not every red gate in the same CI run).

## Non implementato (ancora)

Nessuno per lo scope di questa PR (il fix del sitemap-leak è completo e live in questo branch).

Sibling-pattern candidates from `check-sibling-patterns.mjs --strict` (pre-push hook blocked on these; individually verified false positives, documented here per AGENTS.md #6 exception):

- `build-plugins/orphanQueryLandingPlugin.ts` — falso positivo: `matchingJobs`/`renderClusterPage` sono simboli locali propri e non correlati (tipo `OrphanCountableJob[]`, funzione `renderClusterPage` locale, non-esportata, dominio "orphan query landing" diverso). Il suo `shouldEmitLocale` skip (riga ~891) è un `continue` pieno — skip totale, non il pattern "cheap push senza floor-check" che ho corretto qui.
- `build-plugins/relatedSearchClustersData.ts` — falso positivo: è il file che DEFINISCE `EnrichedEntry` (io lo importo, non lo duplico); la menzione di `matchingJobs.length === 0` è un commento sulla logica di framing dell'H1, non sulla decisione floor/sitemap.
- `build-plugins/jobSectorPagesPlugin.ts` — falso positivo: `matchingJobs` è un nome locale non correlato (`SectorCountableJob[]`), dominio sector-page diverso, nessun render-skip cheap-push equivalente.
- `build-plugins/jobsSeoPagesPlugin.ts` — falso positivo: la sua variabile `matchingJobsByLocale` è strutturalmente diversa; il suo `shouldEmitLocale` skip (riga ~2654) decide l'inclusione PRIMA dello skip via un Set (`emittedActiveJobPaths`) popolato per OGNI locale prima del check — non c'è push cieco post-skip, l'antipattern non esiste lì.
- `build-plugins/searchConsoleCompat.ts` — falso positivo: menziona `MIN_JOBS_FOR_INDEXABLE_CLUSTER` solo in un commento che documenta il self-map GIÀ esistente per il below-floor bridge (riga ~417) — nessuna logica duplicata da correggere.
- `build-plugins/shared/clusterThinShell.ts` — falso positivo: menziona `renderClusterPage` solo in un commento descrittivo di header file, non chiama né duplica la funzione.
- `scripts/assemble-jobs-dataset.mjs` — falso positivo: ha una costante propria e diversa, `ASSEMBLE_OUTPUT_CACHE_VERSION`, nome diverso dal mio `CACHE_VERSION` — nessuna relazione col bump v7→v8.
- `scripts/profile-cluster-emission.mjs` — falso positivo: usa `ClusterContext` solo in un commento che descrive di "mirrorare" `buildClusterContext` per profiling/conteggio offline, non duplica la decisione floor/sitemap.

Pre-existing, unrelated vitest failures on this branch (7 files / 17 tests) — none import `relatedSearchClustersPlugin.ts` or `isClusterBelowFloor`, none touch search-cluster pages. Spot-checked 4 of the 7 (`h1-not-equal-title`, `title-length`, `cathedral-canton-dedup`, `cathedral-sector-hubs`) by stashing this PR's 2 files and re-running against clean `origin/main`: identical failures reproduced. Not touched here (different subsystem — job-detail/canton routing and analytics-callsite hygiene, not search-clusters):
- `tests/h1-not-equal-title.test.ts`
- `tests/title-length.test.ts`
- `tests/seo/cathedral-canton-dedup.test.ts`
- `tests/seo/cathedral-sector-hubs.test.ts`
- `tests/analytics-instrumentation.test.ts` (15s timeout on callsite-hygiene grep, under full-suite load)
- `tests/seo/cathedral-job-detail-canton.test.ts` (canton-aware job-detail page sampling)
- `tests/seo/cathedral-previous-slug-canton.test.ts` (previousSlug canton bridge sampling)
