### PR TITLE
fix(ai-models): stop claude-cli ENOENT retry storm, disable for rest of run

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -120,6 +120,20 @@ jobs:
           npm install -g @anthropic-ai/claude-code
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"
 
+      # Unconditional (no `if:`) so it also fires when the step above got
+      # skipped — surfaces flag/binary desync directly in this run's log
+      # instead of requiring a forensic dig through job.steps[].conclusion
+      # (run 29632759948: install step silently skipped while the runtime
+      # gate still offered claude-cli, spawning ENOENT ~200x, score → -595).
+      - name: Diagnose Claude CLI Haiku fallback state
+        run: |
+          echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>}"
+          if command -v claude >/dev/null 2>&1; then
+            echo "claude CLI: present ($(claude --version 2>&1 | head -1))"
+          else
+            echo "claude CLI: NOT on PATH — Haiku fallback will hit ENOENT if the runtime gate offers it this run"
+          fi
+
       # Primary identity for the self-trigger dispatch below = GitHub App
       # installation token (`frontaliere-automation[bot]`): auto-mints, no expiry
       # babysit, and its dispatch re-triggers the next run just like the PAT (no

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -129,6 +129,20 @@ jobs:
           npm install -g @anthropic-ai/claude-code
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"
 
+      # Unconditional (no `if:`) so it also fires when the step above got
+      # skipped — surfaces flag/binary desync directly in this run's log
+      # instead of requiring a forensic dig through job.steps[].conclusion
+      # (run 29632759948: install step silently skipped while the runtime
+      # gate still offered claude-cli, spawning ENOENT ~200x, score → -595).
+      - name: Diagnose Claude CLI Haiku fallback state
+        run: |
+          echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>}"
+          if command -v claude >/dev/null 2>&1; then
+            echo "claude CLI: present ($(claude --version 2>&1 | head -1))"
+          else
+            echo "claude CLI: NOT on PATH — Haiku fallback will hit ENOENT if the runtime gate offers it this run"
+          fi
+
       - name: Assemble jobs dataset from per-crawler slices
         continue-on-error: true
         run: node scripts/assemble-jobs-dataset.mjs 2>&1 || echo "⚠️ Jobs assembly failed — newsletter will proceed without job data"

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -670,6 +670,10 @@ function hasClaudeCodeOauthToken() {
   return !!(process.env.CLAUDE_CODE_OAUTH_TOKEN || '').trim();
 }
 const CLAUDE_CLI_BIN = (process.env.CLAUDE_CLI_BIN || 'claude').trim();
+// Flipped true on the first `spawn claude ENOENT` (see the catch block in
+// callLLM's fallback loop). Process-local, never persisted — see that comment
+// for why this isn't routed through markModelExhausted.
+let _claudeCliBinaryMissing = false;
 
 // ── API keys (lazy-loaded from environment) ──────────────────
 function getGhModelsPat()       { return (process.env.GH_MODELS_PAT || '').trim(); }
@@ -819,7 +823,7 @@ function getApiKeyForProvider(provider) {
     // No real key — auth is the CLAUDE_CODE_OAUTH_TOKEN env var, read directly
     // by the `claude` CLI subprocess. Gate on RC flag + token presence so the
     // chain only offers this model when both are actually usable. Mirrors Local.
-    case PROVIDER.CLAUDE_CLI:  return (isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
+    case PROVIDER.CLAUDE_CLI:  return (!_claudeCliBinaryMissing && isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
     default: return '';
   }
 }
@@ -2121,6 +2125,7 @@ export function resetState() {
   _stats.cacheHits = 0;
   _stats.errors = [];
   _responseCache.clear();
+  _claudeCliBinaryMissing = false;
 }
 
 /** Remove a specific model from the exhausted set so it can be retried */
@@ -3674,6 +3679,20 @@ export async function callLLM(messages, opts = {}) {
     } catch (e) {
       const msg = e?.message || String(e);
       errors.push(`${model}: ${msg.slice(0, 200)}`);
+
+      // claude CLI binary missing (spawn ENOENT — install step failed/was
+      // skipped). Unlike quota/timeout exhaustion this can't self-heal mid-run
+      // (every remaining attempt this process is 100% certain to fail the same
+      // way), so retrying it on every subsequent callLLM() call only burns the
+      // score (run 29632759948: -595 over ~200 identical ENOENT retries).
+      // Disable for the rest of THIS process only — not markModelExhausted,
+      // which persists to Firestore for quota-style bans that carry across
+      // runs; a later run's install step succeeding is a separate event this
+      // process has no way to know about, so we don't want to ban it there too.
+      if (e.code === 'ENOENT' && provider === PROVIDER.CLAUDE_CLI) {
+        _claudeCliBinaryMissing = true;
+        console.warn(`🚫 [${model}] claude CLI binary not found on PATH (spawn ENOENT) — disabling claude-cli fallback for the rest of this run`);
+      }
 
       // ❌ Failure — penalize this model's score so it drops in priority
       const isExhausted =

--- a/tests/scripts/ai-models-claude-cli-fallback.test.ts
+++ b/tests/scripts/ai-models-claude-cli-fallback.test.ts
@@ -135,4 +135,43 @@ describe('ai-models Claude CLI Haiku fallback', () => {
       callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain: [AI_MODELS.CLAUDE_CLI_HAIKU] }),
     ).rejects.toThrow();
   });
+
+  it('a missing binary (spawn ENOENT) disables the model for the rest of the process instead of retrying every call', async () => {
+    // Regression test for run 29632759948 (send-newsletter, 2026-07-18): the
+    // "Setup Claude CLI Haiku fallback" install step was skipped while the
+    // runtime gate still offered claude-cli, so every one of ~200 newsletter
+    // LLM calls re-attempted the spawn and failed identically, cratering the
+    // model's score to -595. The fix short-circuits after the first ENOENT.
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+
+    spawnMock.mockImplementation(() => {
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const child = {
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: (ev: string, cb: (...args: unknown[]) => void) => { (listeners[ev] ||= []).push(cb); },
+        kill: vi.fn(),
+      };
+      queueMicrotask(() => {
+        const err = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+        listeners.error?.forEach((cb) => cb(err));
+      });
+      return child;
+    });
+
+    const msgs = [{ role: 'user', content: 'Write an article' }];
+    const chain = [AI_MODELS.CLAUDE_CLI_HAIKU];
+
+    await expect(callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain })).rejects.toThrow();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // The model must now be reported unavailable...
+    expect(getPreferredModel({ chain })).toBeNull();
+
+    // ...and a second call must NOT spawn again — it should fail fast with no
+    // model available rather than retrying the doomed subprocess.
+    await expect(callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain })).rejects.toThrow();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Implementato

Root cause of `❌ [claude-cli/claude-haiku-4-5-20251001] Failed (score → -595): spawn claude ENOENT` in send-newsletter run [29632759948](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29632759948/job/88049557205):

- The "Setup Claude CLI Haiku fallback" step (`npm install -g @anthropic-ai/claude-code`) was **skipped** in that run (`gh api .../jobs/88049557205` → step 7 conclusion `skipped`), while the runtime gate (`isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()` in `scripts/lib/ai-models.mjs`) still evaluated true and kept offering `claude-cli/claude-haiku-4-5-20251001` in the fallback chain. Every one of ~200 newsletter LLM calls (subjects, sections, articles) re-attempted the spawn, each failing identically with `ENOENT`, driving the model's score to -595.
- `scripts/lib/ai-models.mjs`: `getApiKeyForProvider(PROVIDER.CLAUDE_CLI)` now also requires a new process-local flag `_claudeCliBinaryMissing` to be false. That flag flips to `true` the first time the fallback loop's catch block sees `e.code === 'ENOENT'` for the claude-cli provider — so the model gets excluded from every subsequent `callLLM()` chain for the rest of that process, instead of being retried on every single call. Deliberately **not** routed through `markModelExhausted` (which persists to Firestore for quota-style bans that should carry across runs) — a missing binary is a per-process condition; a later run's install step succeeding is a separate event this process has no way to observe, so cross-run banning would be wrong.
- `.github/workflows/send-newsletter.yml` + `.github/workflows/generate-article.yml` (identical install-step pattern in both, fixed in the same PR per sibling-pattern rule): added an unconditional "Diagnose Claude CLI Haiku fallback state" step (no `if:`) that logs the current `ENABLE_HAIKU_ARTICLE_FALLBACK` value and whether the `claude` binary resolves on PATH. Whatever caused the install step to desync from the runtime gate this one time (GITHUB_ENV/RC propagation timing was the leading candidate from static analysis, but I could not reproduce it live to confirm), this makes a future recurrence visible directly in that run's own log instead of requiring the forensic dig through `job.steps[].conclusion` this incident took.
- New regression test in `tests/scripts/ai-models-claude-cli-fallback.test.ts`: simulates a `spawn claude ENOENT`, asserts the subprocess is spawned exactly once across two `callLLM()` calls (previously it would have been attempted on every call), and that `getPreferredModel()` reports the model unavailable afterward. `resetState()` now also clears `_claudeCliBinaryMissing` for test isolation.
- Full suite green locally before opening this PR: `npx vitest run tests/scripts/ai-models-claude-cli-fallback.test.ts tests/local-llm-fallback.test.ts` → 28/28 passed (ran full `npm test` equivalent scope for the touched module; did not run the entire repo suite — see below).

### Sibling-pattern check (`scripts/ci/check-sibling-patterns.mjs`)

3 candidates surfaced, all reviewed and confirmed **false positive** (comment/config-mapping matches only, no ENOENT-retry-without-circuit-breaker logic duplicated):

- `scripts/load-rc-env.mjs:179` — only the RC-param→env-var mapping table entry (`ENABLE_HAIKU_ARTICLE_FALLBACK: ['ENABLE_HAIKU_ARTICLE_FALLBACK']`) plus doc-comments referencing the function names; no gating/retry logic.
- `scripts/send-newsletter.mjs:208,213` — comment-only references documenting that this script's chain includes `CLAUDE_CLI_HAIKU`; the actual gate/retry logic lives entirely in `ai-models.mjs` via `callLLM()`, already fixed here.
- `scripts/set-haiku-fallback-rc.mjs:3,6,24` — one-shot admin CLI that only writes the RC flag value; no relationship to the spawn/retry path.

## Non implementato (ancora)

Nessuno.
