### PR TITLE
fix(crawlers): real per-job location for Triaplus + real brand filter for Swatch Group sub-brands

### DIFF
--- a/scripts/lib/swatchgroup-brand-filter.mjs
+++ b/scripts/lib/swatchgroup-brand-filter.mjs
@@ -1,0 +1,67 @@
+/**
+ * Brand-identity filter for Swatch Group sub-brands that share the
+ * group-wide swatchgroup.com/careers job-finder seed URLs with no per-brand
+ * path segment (issue #4392).
+ *
+ * WHY this exists: rado, comadur-swatch-group, nivarox-swatch-group and
+ * swatch-group-assembly all resolve to the SAME `companyHost: swatchgroup.com`
+ * generic adapter (crawlerModes: generic_ats/html/jsonld, seedUrls like
+ * swatchgroup.com/careers). update-swatchgroup-jobs.mjs runs the generic
+ * crawl ONCE PER companyKey and the shared engine stamps `companyKey: ck` on
+ * EVERY job it extracts during that company's own iteration, regardless of
+ * the job's real employer — so filtering the aggregated pool by companyKey
+ * alone yields the FULL shared ~90-job Swiss pool mislabeled as `ck`, not a
+ * real per-brand subset. Confirmed live 2026-07-18: the persisted
+ * data/jobs/by-crawler/rado.json and swatch-group-assembly.json slices
+ * carried jobs whose real employer (`job.company`) was "Omega Ltd.", "ETA SA
+ * Manufacture Horlogère Suisse", "Renata AG", "The Swatch Group
+ * (Deutschland) GmbH" — zero genuine Rado/Assembly jobs.
+ *
+ * The generic jsonld extractor DOES correctly populate `job.company` with
+ * the JSON-LD `hiringOrganization.name` of the posting (verified live: e.g.
+ * "ETA SA Manufacture Horlogère Suisse", "The Swatch Group Research and
+ * Development Ltd", legal-entity text is the same across DE/EN/FR detail
+ * pages), so this module re-derives the real per-brand subset from that
+ * text instead of trusting the blindly-stamped companyKey.
+ *
+ * Historical check (every commit that ever touched these slices — 92 for
+ * rado.json, 462 for swatch-group-assembly.json; comadur-swatch-group.json
+ * and nivarox-swatch-group.json never persisted a single job in their
+ * history) found ZERO instances of a genuine brand-matching `company`
+ * value, so all 4 legitimately filter down to 0 jobs today — that is the
+ * CORRECT output of a real filter, not a parser bug. Each pattern still
+ * keys off the brand's real Swatch Group legal-entity name — Rado Watch Co.
+ * Ltd / Rado Uhren AG, Comadur SA, Nivarox-FAR SA, Swatch Group Assembly SA
+ * (the Ticino-based watch-assembly subsidiary, swatchgroup.com/en/companies-
+ * brands/production/swatch-group-assembly) — so a genuine future posting
+ * for any of them is picked up correctly instead of staying invisible.
+ *
+ * eta-sa-swatch-group and swiss-timing-swatch-group are deliberately NOT in
+ * this map: their adapters seed from eta.ch / swisstiming.com (their own
+ * domains), not the shared swatchgroup.com pool, so they don't redistribute
+ * and don't need this re-filter.
+ */
+import { normalizeKey } from './dedicated-crawler-common.mjs';
+
+export const SHARED_POOL_BRAND_PATTERNS = new Map([
+  ['rado', /\brado\b/i],
+  ['comadur-swatch-group', /\bcomadur\b/i],
+  ['nivarox-swatch-group', /\bnivarox\b/i],
+  ['swatch-group-assembly', /swatch group assembly/i],
+]);
+
+/**
+ * Re-derive a sub-brand's real jobs from the shared swatchgroup.com pool
+ * using the job's own (correctly-extracted) `company` text instead of the
+ * blindly-stamped `companyKey`. Companies not in SHARED_POOL_BRAND_PATTERNS
+ * (own-domain adapters) pass through unchanged.
+ *
+ * @param {string} companyKey
+ * @param {Array<{company?: string}>} jobs
+ * @returns {Array<object>}
+ */
+export function filterSharedPoolJobsByBrand(companyKey, jobs) {
+  const pattern = SHARED_POOL_BRAND_PATTERNS.get(normalizeKey(companyKey));
+  if (!pattern) return jobs;
+  return (jobs || []).filter((job) => pattern.test(String(job?.company || '')));
+}

--- a/scripts/lib/triaplus-job-parser.mjs
+++ b/scripts/lib/triaplus-job-parser.mjs
@@ -6,16 +6,27 @@
  *   → paginated WP listing (`/freie-stellen/page/{N}/`) of job pages at
  *     `/jobs/{slug}/`.
  *
- * Triaplus AG (formerly Psychiatrische Klinik Zugersee) operates four
- * psychiatric clinics across central Switzerland under one umbrella:
- *   - Klinik Zugersee, Oberwil b. Zug (ZG, head clinic)
- *   - Klinik Meissenberg (sister entity — separate site)
- *   - Outpatient centres in Zug, Lucerne, Schwyz
- * The career portal serves the whole group from a single WordPress install.
+ * Triaplus AG (formerly Psychiatrische Klinik Zugersee) is an integrated
+ * psychiatric provider ("Integrierte Psychiatrie Uri, Schwyz und Zug")
+ * operating outpatient/inpatient sites across those three cantons — head
+ * office Oberwil-Zug (ZG), plus Baar (ZG); Goldau, Pfäffikon SZ,
+ * Einsiedeln, Lachen, Steinen (SZ); Altdorf (UR). Confirmed live 2026-07
+ * against https://www.triaplus.ch/ueber-uns/triaplus-ag/standorte-und-bereiche
+ * (issue #4418 — CORRECTION: an earlier header version here claimed a
+ * "4 clinics incl. Klinik Meissenberg sister entity + Lucerne outpatient"
+ * model; no live page, the standorte list above, nor any job's own
+ * "Kantonen Uri, Schwyz und Zug" text mentions either, so that claim was
+ * wrong and has been dropped). The career portal serves the whole group
+ * from a single WordPress install.
  *
- * Each job page is a server-rendered `<article>` of type `single-jobs`
- * with H2 sections ("Ihre Aufgaben beinhalten", "Sie bringen dafür mit",
- * "Wir bieten Ihnen") that we concatenate into the description.
+ * Each job page is a server-rendered `<article>` of type `single-jobs`.
+ * The title block renders the REAL per-job location right after the H2:
+ * `<span class="ort">in  Pfäffikon (SZ)</span>` / `in  Oberwil-Zug` /
+ * `in  Baar` / `in  Altdorf` — confirmed live against 20 sample listings
+ * spanning all three cantons (see `parseJobLocation` / `KNOWN_LOCATIONS`
+ * below; issue #4418 fix — do NOT reintroduce a single hardcoded city for
+ * every job). H3 sections ("Ihre Aufgaben beinhalten", "Sie bringen dafür
+ * mit", "Wir bieten Ihnen") are concatenated into the description.
  *
  * Modelled on `scripts/lib/uroviva-job-parser.mjs` (multi-site Dualoo) and
  * `scripts/lib/spital-affoltern-job-parser.mjs` (multi-portal listing).
@@ -43,10 +54,70 @@ const PUBLIC_CAREER_URL = LISTING_URL;
 const DETAIL_DELAY_MS = 250;
 const MAX_PAGES = 10; // safety cap
 
-// Head clinic is Klinik Zugersee in Oberwil-Zug (ZG).
+// Head clinic is Klinik Zugersee in Oberwil-Zug (ZG). Used as the
+// LAST-RESORT fallback only, when a job's own detail page doesn't carry a
+// parsable `<span class="ort">` (see `parseJobLocation` below) — issue
+// #4418, do not use this as the primary per-job location.
 const DEFAULT_CITY = 'Oberwil';
 const DEFAULT_POSTAL_CODE = '6317';
 const DEFAULT_CANTON = 'ZG';
+
+/**
+ * Real Triaplus AG sites across cantons UR/SZ/ZG (confirmed live 2026-07
+ * against https://www.triaplus.ch/ueber-uns/triaplus-ag/standorte-und-bereiche,
+ * postal codes read from that page's address list; head-office postal code
+ * cross-checked against the group's own "Widenstrasse 55, 6317 Oberwil-Zug"
+ * address). Keyed by lowercased, diacritic-stripped city name so both
+ * "Pfäffikon" and an ASCII-decoded "Pfaffikon" resolve. "oberwil-zug" (the
+ * exact string the site renders) normalizes to the pre-existing
+ * `DEFAULT_CITY` ('Oberwil') so head-clinic jobs keep the same city label
+ * whether resolved via this table or via the fallback.
+ */
+const KNOWN_LOCATIONS = {
+  'oberwil-zug': { city: DEFAULT_CITY, canton: DEFAULT_CANTON, postalCode: DEFAULT_POSTAL_CODE },
+  oberwil: { city: DEFAULT_CITY, canton: DEFAULT_CANTON, postalCode: DEFAULT_POSTAL_CODE },
+  baar: { city: 'Baar', canton: 'ZG', postalCode: '6340' },
+  altdorf: { city: 'Altdorf', canton: 'UR', postalCode: '6460' },
+  goldau: { city: 'Goldau', canton: 'SZ', postalCode: '6410' },
+  pfaffikon: { city: 'Pfäffikon', canton: 'SZ', postalCode: '8808' },
+  einsiedeln: { city: 'Einsiedeln', canton: 'SZ', postalCode: '8840' },
+  lachen: { city: 'Lachen', canton: 'SZ', postalCode: '8853' },
+  steinen: { city: 'Steinen', canton: 'SZ', postalCode: '6422' },
+};
+
+function stripDiacritics(s = '') {
+  return String(s || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/**
+ * Extract the REAL per-job location from a Triaplus job detail page.
+ * Every job's title block renders
+ * `<span class="ort">in  <City>[ (<CANTON>)]</span>` right after the
+ * `<h2 class="… jobtitel">` — e.g. "in  Pfäffikon (SZ)", "in  Oberwil-Zug",
+ * "in  Baar", "in  Altdorf". Confirmed live against 20 sample job pages
+ * spanning all three cantons the group operates in (every page's own
+ * "Integrierte Psychiatrie Uri, Schwyz und Zug" / "Kantonen Uri, Schwyz und
+ * Zug" text agrees — issue #4418, replaces the previous hardcoded
+ * `DEFAULT_CITY` used for every job regardless of clinic).
+ *
+ * Looks the extracted city up in `KNOWN_LOCATIONS` for the correct canton +
+ * postal code (the span itself only sometimes carries a canton
+ * abbreviation, and never a postal code). Falls back to a best-effort
+ * `{ city, canton: <from span>, postalCode: DEFAULT_POSTAL_CODE }` for an
+ * unrecognised-but-parsed city, and returns `null` only when the span
+ * itself is missing/unparsable — callers then fall back to `DEFAULT_CITY`.
+ */
+export function parseJobLocation(html) {
+  const m = String(html || '').match(/<span class="ort">\s*in\s+([^<(]+?)(?:\s*\(([A-Za-z]{2})\))?\s*<\/span>/i);
+  if (!m) return null;
+  const rawCity = normalizeSpace(decodeEntities(m[1]));
+  if (!rawCity) return null;
+  const known = KNOWN_LOCATIONS[stripDiacritics(rawCity).toLowerCase()];
+  if (known) return known;
+  const cantonFromSpan = m[2] ? m[2].toUpperCase() : '';
+  if (cantonFromSpan) return { city: rawCity, canton: cantonFromSpan, postalCode: DEFAULT_POSTAL_CODE };
+  return null;
+}
 
 export function isTriaplusJob(job) {
   const url = String(job?.url || '').toLowerCase();
@@ -184,18 +255,24 @@ export async function fetchAllTriaplusJobs() {
     const { title, sections } = parseJobDetail(html);
     if (!title || title.length < 3) continue;
 
+    // Real per-job location (issue #4418) — falls back to the head-clinic
+    // default only when this specific job's `<span class="ort">` is
+    // missing/unparsable, not as the primary path.
+    const loc = parseJobLocation(html)
+      || { city: DEFAULT_CITY, canton: DEFAULT_CANTON, postalCode: DEFAULT_POSTAL_CODE };
+
     const rich = sections.join('\n\n').trim();
     if (rich) detailHits += 1;
 
     const description = [
       rich,
-      `${TRIAPLUS_COMPANY_NAME} — Psychiatrische Klinik (Klinik Zugersee), ${DEFAULT_CITY} (${DEFAULT_CANTON}), Schweiz.`,
+      `${TRIAPLUS_COMPANY_NAME} — Psychiatrische Klinik, ${loc.city} (${loc.canton}), Schweiz.`,
       `Bewerbung über das Karriereportal: ${detailUrl}`,
     ].filter(Boolean).join('\n\n');
 
     const sourceLang = detectLang(description || title, 'de');
     const slugFromUrl = (detailUrl.match(/\/jobs\/([a-z0-9-]+)\/?$/) || [])[1] || '';
-    const jobSlug = slugify(`${title} ${TRIAPLUS_KEY} ${slugFromUrl || DEFAULT_CITY}`);
+    const jobSlug = slugify(`${title} ${TRIAPLUS_KEY} ${slugFromUrl || loc.city}`);
     const urlHash = createHash('sha1').update(detailUrl).digest('hex').slice(0, 12);
     const id = `${TRIAPLUS_KEY}-${urlHash}`;
     if (seenIds.has(id)) continue;
@@ -218,17 +295,17 @@ export async function fetchAllTriaplusJobs() {
       // `translate-pending.yml` picks the job up out-of-band. Without this
       // flag the locale-completeness gate trips before translation can run.
       needsRetranslation: true,
-      location: DEFAULT_CITY,
-      canton: DEFAULT_CANTON,
+      location: loc.city,
+      canton: loc.canton,
       url: detailUrl,
       source: `${TRIAPLUS_COMPANY_NAME} Dedicated Parser (WordPress career site)`,
       sourceLang,
       crawledAt: new Date().toISOString(),
-      addressLocality: DEFAULT_CITY,
-      addressRegion: DEFAULT_CANTON,
+      addressLocality: loc.city,
+      addressRegion: loc.canton,
       addressCountry: 'CH',
       country: 'CH',
-      postalCode: DEFAULT_POSTAL_CODE,
+      postalCode: loc.postalCode,
       category: detectHealthcareCategory(title),
       contract: 'full-time',
       employmentType: detectHealthcareEmploymentType(title),

--- a/scripts/update-swatchgroup-jobs.mjs
+++ b/scripts/update-swatchgroup-jobs.mjs
@@ -240,8 +240,19 @@ async function main() {
     // aggregate 'swatchgroup' key below). Always refresh the per-brand
     // summary, reporting the still-persisted slice count when this run found
     // nothing new for that brand.
+    //
+    // Two different reasons _ckJobs can be empty, and only one should skip
+    // the write: (a) _ckJobsRaw.length === 0 — this crawl found no listings
+    // at all for the key, transient/site-down, preserve the prior slice as
+    // before; (b) _ckJobsRaw.length > 0 but the brand filter (#4392) zeroed
+    // every one of them as cross-brand redistribution — that's a REAL
+    // correction the shrink guard needs to see and act on (16→0 for
+    // rado/swatch-group-assembly today), not a transient gap. Gating this
+    // case out too would freeze the stale mislabeled slice on disk forever,
+    // silently contradicting the guard-driven correction this fix depends on.
+    const _ckFilterEmptiedRealScrape = _ckJobs.length === 0 && _ckJobsRaw.length > 0;
     let _ckTotal = _ckJobs.length > 0 ? _ckJobs.length : readExistingCrawlerJobs(ck, DATA_JOBS).length;
-    if (_ckJobs.length > 0) {
+    if (_ckJobs.length > 0 || _ckFilterEmptiedRealScrape) {
       // Swatch Group is a multi-sub-brand umbrella crawler: comadur, eta-sa,
       // nivarox, rado, swatch-group-assembly and swiss-timing all persist in
       // this SAME loop within this ONE script run. writeJobsCrawlerSlice()
@@ -258,6 +269,7 @@ async function main() {
       // on-disk count for the summary/aggregate, and let the loop continue.
       try {
         writeJobsCrawlerSlice(ck, _ckJobs);
+        _ckTotal = _ckJobs.length;
         _aggregateTotal += _ckJobs.length;
       } catch (err) {
         _guardTrippedKeys.push(ck);

--- a/scripts/update-swatchgroup-jobs.mjs
+++ b/scripts/update-swatchgroup-jobs.mjs
@@ -18,6 +18,7 @@ import {
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang } from './lib/dedicated-crawler-common.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
+import { filterSharedPoolJobsByBrand } from './lib/swatchgroup-brand-filter.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -84,6 +85,12 @@ function isSwatchJob(job, swatchKeysSet) {
   })();
   return swatchKeysSet.has(key) || host.includes('swatchgroup.com');
 }
+
+// Brand-identity re-filter for the sub-brands that share the group-wide
+// swatchgroup.com/careers seed pool with no per-brand path segment (issue
+// #4392) — see scripts/lib/swatchgroup-brand-filter.mjs for the full
+// rationale and evidence. eta-sa-swatch-group / swiss-timing-swatch-group
+// seed from their own domains (eta.ch / swisstiming.com) and are unaffected.
 
 function runBaseCrawler(companyKeys) {
   return runDedicatedBaseCrawler({
@@ -214,7 +221,15 @@ async function main() {
   const _guardTrippedKeys = [];
   for (const ck of companyKeys) {
     const _ckNorm = normalizeKey(ck);
-    const _ckJobs = _allJobs.filter((j) => normalizeKey(j?.companyKey || '') === _ckNorm);
+    const _ckJobsRaw = _allJobs.filter((j) => normalizeKey(j?.companyKey || '') === _ckNorm);
+    // Re-filter the shared-pool sub-brands (rado, comadur-swatch-group,
+    // nivarox-swatch-group, swatch-group-assembly) down to jobs whose real
+    // employer text actually matches — see lib/swatchgroup-brand-filter.mjs
+    // (issue #4392). No-op for brands with their own-domain adapter.
+    const _ckJobs = filterSharedPoolJobsByBrand(ck, _ckJobsRaw);
+    if (_ckJobs.length !== _ckJobsRaw.length) {
+      console.log(`  🔎 ${ck}: brand filter kept ${_ckJobs.length}/${_ckJobsRaw.length} job(s) — dropped cross-brand redistribution from the shared swatchgroup.com pool (#4392).`);
+    }
     // A brand with 0 jobs THIS run only means this crawl found no fresh
     // listings for it — writeJobsCrawlerSlice(ck, []) would throw via the
     // shrink guard if a non-empty slice already exists on disk, so the slice

--- a/tests/swatchgroup-brand-filter.test.ts
+++ b/tests/swatchgroup-brand-filter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SHARED_POOL_BRAND_PATTERNS,
+  filterSharedPoolJobsByBrand,
+} from '../scripts/lib/swatchgroup-brand-filter.mjs';
+
+// Real hiringOrganization.name values observed live on the swatchgroup.com
+// group job-finder (2026-07-18, issue #4392) — none of them are rado,
+// comadur, nivarox or "swatch group assembly".
+const REAL_POOL_COMPANIES = [
+  'Omega Ltd.',
+  'ETA SA Manufacture Horlogère Suisse',
+  'The Swatch Group (Deutschland) GmbH',
+  'Renata AG',
+  'The Swatch Group Les Boutiques Ltd',
+  'Tissot Ltd',
+  'Longines Watch Co. Francillon Ltd.',
+  'Hamilton International Ltd',
+  'Swatch Ltd',
+  'EM Microelectronic-Marin Ltd',
+  'Montres Breguet Ltd',
+  'The Swatch Group Research and Development Ltd',
+  'The Swatch Group Services Ltd',
+  'The Swatch Group Ltd',
+  'ICB Ingénieurs Conseils en Brevets SA',
+  'Swatch Group (France) S.A.S.',
+];
+
+function jobsFor(companies: string[]) {
+  return companies.map((company, i) => ({
+    id: `job-${i}`,
+    company,
+    companyKey: 'placeholder', // the buggy blindly-stamped key; must be ignored
+  }));
+}
+
+describe('swatchgroup-brand-filter', () => {
+  describe('SHARED_POOL_BRAND_PATTERNS', () => {
+    it('covers exactly the 4 companyKeys affected by issue #4392', () => {
+      expect([...SHARED_POOL_BRAND_PATTERNS.keys()].sort()).toEqual(
+        ['comadur-swatch-group', 'nivarox-swatch-group', 'rado', 'swatch-group-assembly'].sort(),
+      );
+    });
+
+    it('does not cover the own-domain sub-brands (eta-sa, swiss-timing)', () => {
+      expect(SHARED_POOL_BRAND_PATTERNS.has('eta-sa-swatch-group')).toBe(false);
+      expect(SHARED_POOL_BRAND_PATTERNS.has('swiss-timing-swatch-group')).toBe(false);
+    });
+  });
+
+  describe('filterSharedPoolJobsByBrand', () => {
+    it('rejects the entire real shared pool for all 4 companyKeys (live evidence: 0 genuine matches today)', () => {
+      const jobs = jobsFor(REAL_POOL_COMPANIES);
+      for (const key of ['rado', 'comadur-swatch-group', 'nivarox-swatch-group', 'swatch-group-assembly']) {
+        expect(filterSharedPoolJobsByBrand(key, jobs)).toEqual([]);
+      }
+    });
+
+    it('keeps a genuine Rado job by legal-entity name', () => {
+      const jobs = [
+        { id: 'a', company: 'Rado Watch Co. Ltd' },
+        { id: 'b', company: 'Omega Ltd.' },
+      ];
+      const kept = filterSharedPoolJobsByBrand('rado', jobs);
+      expect(kept).toHaveLength(1);
+      expect(kept[0].id).toBe('a');
+    });
+
+    it('keeps a genuine Comadur job and rejects lookalikes', () => {
+      const jobs = [
+        { id: 'a', company: 'Comadur SA' },
+        { id: 'b', company: 'The Swatch Group Ltd' },
+      ];
+      expect(filterSharedPoolJobsByBrand('comadur-swatch-group', jobs).map((j) => j.id)).toEqual(['a']);
+    });
+
+    it('keeps a genuine Nivarox job (Nivarox-FAR SA legal name)', () => {
+      const jobs = [
+        { id: 'a', company: 'Nivarox-FAR SA' },
+        { id: 'b', company: 'ETA SA Manufacture Horlogère Suisse' },
+      ];
+      expect(filterSharedPoolJobsByBrand('nivarox-swatch-group', jobs).map((j) => j.id)).toEqual(['a']);
+    });
+
+    it('keeps a genuine Swatch Group Assembly job but not the plain holding company', () => {
+      const jobs = [
+        { id: 'a', company: 'Swatch Group Assembly SA' },
+        { id: 'b', company: 'The Swatch Group Ltd' },
+        { id: 'c', company: 'The Swatch Group Research and Development Ltd' },
+      ];
+      expect(filterSharedPoolJobsByBrand('swatch-group-assembly', jobs).map((j) => j.id)).toEqual(['a']);
+    });
+
+    it('does not word-boundary-false-positive (e.g. "rado" inside another word)', () => {
+      const jobs = [{ id: 'a', company: 'Corado Trading SA' }];
+      expect(filterSharedPoolJobsByBrand('rado', jobs)).toEqual([]);
+    });
+
+    it('is a no-op passthrough for companyKeys outside the shared-pool map', () => {
+      const jobs = jobsFor(['Anything Ltd']);
+      expect(filterSharedPoolJobsByBrand('eta-sa-swatch-group', jobs)).toEqual(jobs);
+      expect(filterSharedPoolJobsByBrand('swiss-timing-swatch-group', jobs)).toEqual(jobs);
+      expect(filterSharedPoolJobsByBrand('some-unrelated-company', jobs)).toEqual(jobs);
+    });
+
+    it('handles missing/empty company field and empty job list gracefully', () => {
+      expect(filterSharedPoolJobsByBrand('rado', [{ id: 'a' }])).toEqual([]);
+      expect(filterSharedPoolJobsByBrand('rado', [])).toEqual([]);
+      expect(filterSharedPoolJobsByBrand('rado', undefined as unknown as [])).toEqual([]);
+    });
+
+    it('is case-insensitive', () => {
+      const jobs = [{ id: 'a', company: 'rado watch co. ltd' }];
+      expect(filterSharedPoolJobsByBrand('rado', jobs)).toHaveLength(1);
+    });
+  });
+});

--- a/tests/triaplus-crawler.test.ts
+++ b/tests/triaplus-crawler.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  TRIAPLUS_KEY,
+  TRIAPLUS_COMPANY_NAME,
+  TRIAPLUS_COMPANY_DOMAIN,
+  isTriaplusJob,
+  isTrustedDomain,
+  parseListingPage,
+  parseJobLocation,
+  fetchAllTriaplusJobs,
+} from '../scripts/lib/triaplus-job-parser.mjs';
+import { slugify } from '../scripts/lib/crawler-template.mjs';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const LISTING_URL = 'https://karriere.triaplus.ch/freie-stellen/';
+
+const LISTING_HTML = `
+  <a href="https://karriere.triaplus.ch/jobs/assistenzaerztin-oder-fachaerztin-w-m-d-ambulant/">Assistenzärztin</a>
+  <a href="https://karriere.triaplus.ch/jobs/sozialarbeiter-in-w-m-d/">Sozialarbeiter/in</a>
+  <a href="https://karriere.triaplus.ch/jobs/assistenzaerztin-oder-fachaerztin-w-m-d-ambulant/">dup</a>
+`;
+
+/**
+ * Realistic Triaplus detail-page fixture, modelled on the live markup
+ * (confirmed 2026-07 against https://karriere.triaplus.ch/jobs/... — issue
+ * #4418): the job title block renders
+ * `<span class="ort">in  <City>[ (<CANTON>)]</span>` right after the H2,
+ * BEFORE the H3 body sections. `ortSpan` lets tests override/omit it to
+ * cover the markup-missing fallback path.
+ */
+function detailHtml({
+  title = 'Assistenzärztin oder Fachärztin (w/m/d) ambulant',
+  ortSpan = '<span class="ort">in  Pfäffikon (SZ)</span><span class="prozent">, 80 – 100%',
+} = {}) {
+  return `<!doctype html><html><head><title>${title} | Triaplus AG</title></head><body>
+    <div class="section titel">
+      <h2 class="has-d-3-font-size jobtitel">${title} <br>
+        ${ortSpan}</h2>
+    </div>
+    <h3>Ihre Aufgaben beinhalten</h3>
+    <ul>
+      <li>Ambulante und teilstationäre Betreuung von Patientinnen und Patienten</li>
+      <li>Interdisziplinäre Zusammenarbeit im Behandlungsteam</li>
+    </ul>
+    <h3>Sie bringen dafür mit</h3>
+    <ul>
+      <li>Abgeschlossenes Studium der Humanmedizin</li>
+      <li>Freude an der Arbeit mit psychisch erkrankten Menschen</li>
+    </ul>
+    <div class="cta-content">apply widget</div>
+  </body></html>`;
+}
+
+function urlFor(slug: string) {
+  return `https://karriere.triaplus.ch/jobs/${slug}/`;
+}
+
+function mockFetch(handlers: Record<string, string>) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: unknown) => {
+    const url = String(input);
+    for (const [key, html] of Object.entries(handlers)) {
+      if (url.includes(key)) {
+        return { ok: true, status: 200, text: async () => html } as unknown as Response;
+      }
+    }
+    return { ok: false, status: 404, text: async () => 'not found' } as unknown as Response;
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('Triaplus AG crawler parser', () => {
+  it('exports valid company key, name and domain', () => {
+    expect(TRIAPLUS_KEY).toBe('triaplus');
+    expect(TRIAPLUS_COMPANY_NAME).toBe('Triaplus AG');
+    expect(TRIAPLUS_COMPANY_DOMAIN).toBe('triaplus.ch');
+  });
+
+  describe('isTriaplusJob', () => {
+    it('matches by companyKey', () => {
+      expect(isTriaplusJob({ companyKey: 'triaplus' })).toBe(true);
+    });
+
+    it('matches by URL domain', () => {
+      expect(isTriaplusJob({ url: urlFor('some-job') })).toBe(true);
+    });
+
+    it('rejects unrelated jobs', () => {
+      expect(isTriaplusJob({ companyKey: 'other', url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('isTrustedDomain', () => {
+    it('trusts the primary domain', () => {
+      expect(isTrustedDomain(urlFor('some-job'))).toBe(true);
+    });
+
+    it('rejects other domains', () => {
+      expect(isTrustedDomain('https://example.com/jobs')).toBe(false);
+    });
+
+    it('handles invalid URLs', () => {
+      expect(isTrustedDomain('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('parseListingPage', () => {
+    it('extracts and dedupes /jobs/{slug}/ hrefs', () => {
+      const urls = parseListingPage(LISTING_HTML);
+      expect(urls).toHaveLength(2);
+      expect(urls).toContain(urlFor('assistenzaerztin-oder-fachaerztin-w-m-d-ambulant'));
+      expect(urls).toContain(urlFor('sozialarbeiter-in-w-m-d'));
+    });
+
+    it('returns an empty array when no job hrefs are present', () => {
+      expect(parseListingPage('<html><body>no jobs</body></html>')).toEqual([]);
+    });
+  });
+
+  // Issue #4418: the crawler used to hardcode DEFAULT_CITY ('Oberwil') for
+  // every single job regardless of which of Triaplus's real sites (Uri,
+  // Schwyz, Zug cantons) it was actually posted at. parseJobLocation reads
+  // the REAL per-job `<span class="ort">` the site itself renders.
+  describe('parseJobLocation', () => {
+    it('resolves a known city with an explicit canton in the span (Pfäffikon (SZ))', () => {
+      const loc = parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Pfäffikon (SZ)</span>' }));
+      expect(loc).toEqual({ city: 'Pfäffikon', canton: 'SZ', postalCode: '8808' });
+    });
+
+    it('resolves a known city with no canton in the span (Oberwil-Zug -> head-clinic default city)', () => {
+      const loc = parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Oberwil-Zug</span>' }));
+      expect(loc).toEqual({ city: 'Oberwil', canton: 'ZG', postalCode: '6317' });
+    });
+
+    it('resolves other known outpatient sites across all three cantons (not just Oberwil)', () => {
+      expect(parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Baar</span>' })))
+        .toEqual({ city: 'Baar', canton: 'ZG', postalCode: '6340' });
+      expect(parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Altdorf</span>' })))
+        .toEqual({ city: 'Altdorf', canton: 'UR', postalCode: '6460' });
+      expect(parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Goldau</span>' })))
+        .toEqual({ city: 'Goldau', canton: 'SZ', postalCode: '6410' });
+      expect(parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Einsiedeln</span>' })))
+        .toEqual({ city: 'Einsiedeln', canton: 'SZ', postalCode: '8840' });
+      expect(parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Steinen</span>' })))
+        .toEqual({ city: 'Steinen', canton: 'SZ', postalCode: '6422' });
+    });
+
+    it('falls back to a best-effort record for an unrecognised city that does carry a canton', () => {
+      const loc = parseJobLocation(detailHtml({ ortSpan: '<span class="ort">in  Neuestadt (SZ)</span>' }));
+      expect(loc).toEqual({ city: 'Neuestadt', canton: 'SZ', postalCode: '6317' });
+    });
+
+    it('returns null when the ort span is missing (markup drift) so the caller can fall back to DEFAULT_CITY', () => {
+      expect(parseJobLocation('<html><body>no ort span here</body></html>')).toBeNull();
+    });
+  });
+
+  describe('fetchAllTriaplusJobs (listing + per-job detail-page fetch)', () => {
+    beforeEach(() => {
+      process.env.JOBS_CRAWLER_RETRY_BASE_MS = '0';
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      delete process.env.JOBS_CRAWLER_RETRY_BASE_MS;
+    });
+
+    it('assigns REAL, varied per-job locations instead of the same hardcoded city for every job', async () => {
+      mockFetch({
+        [LISTING_URL]: LISTING_HTML,
+        [urlFor('assistenzaerztin-oder-fachaerztin-w-m-d-ambulant')]: detailHtml({
+          title: 'Assistenzärztin oder Fachärztin (w/m/d) ambulant',
+          ortSpan: '<span class="ort">in  Pfäffikon (SZ)</span>',
+        }),
+        [urlFor('sozialarbeiter-in-w-m-d')]: detailHtml({
+          title: 'Sozialarbeiter/in (w/m/d)',
+          ortSpan: '<span class="ort">in  Baar</span>',
+        }),
+      });
+
+      const jobs = await fetchAllTriaplusJobs();
+      expect(jobs).toHaveLength(2);
+
+      const szJob = jobs.find((j: { title: string }) => j.title.startsWith('Assistenzärztin'));
+      expect(szJob.location).toBe('Pfäffikon');
+      expect(szJob.canton).toBe('SZ');
+      expect(szJob.postalCode).toBe('8808');
+      expect(szJob.addressLocality).toBe('Pfäffikon');
+      expect(szJob.addressRegion).toBe('SZ');
+
+      const zgJob = jobs.find((j: { title: string }) => j.title.startsWith('Sozialarbeiter'));
+      expect(zgJob.location).toBe('Baar');
+      expect(zgJob.canton).toBe('ZG');
+      expect(zgJob.postalCode).toBe('6340');
+
+      // The regression this test guards: both jobs must NOT collapse onto
+      // the same hardcoded city.
+      expect(szJob.location).not.toBe(zgJob.location);
+      expect(szJob.canton).not.toBe(zgJob.canton);
+
+      expect(szJob.description).toMatch(/Pfäffikon \(SZ\)/);
+      expect(zgJob.description).toMatch(/Baar \(ZG\)/);
+      expect(szJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+      expect(szJob.id).toMatch(/^triaplus-/);
+    });
+
+    it('falls back to DEFAULT_CITY/DEFAULT_CANTON only when a job genuinely has no parsable ort span', async () => {
+      mockFetch({
+        [LISTING_URL]: LISTING_HTML,
+        [urlFor('assistenzaerztin-oder-fachaerztin-w-m-d-ambulant')]: '<!doctype html><html><body><h1>Assistenzärztin</h1><h3>Ihre Aufgaben beinhalten</h3><ul><li>Betreuung von Patientinnen</li></ul></body></html>',
+        [urlFor('sozialarbeiter-in-w-m-d')]: detailHtml({
+          title: 'Sozialarbeiter/in (w/m/d)',
+          ortSpan: '<span class="ort">in  Baar</span>',
+        }),
+      });
+
+      const jobs = await fetchAllTriaplusJobs();
+      const fallbackJob = jobs.find((j: { title: string }) => j.title.startsWith('Assistenzärztin'));
+      expect(fallbackJob.location).toBe('Oberwil');
+      expect(fallbackJob.canton).toBe('ZG');
+      expect(fallbackJob.postalCode).toBe('6317');
+
+      const realJob = jobs.find((j: { title: string }) => j.title.startsWith('Sozialarbeiter'));
+      expect(realJob.location).toBe('Baar');
+    });
+
+    it('returns [] (no throw) when the listing page has no job hrefs', async () => {
+      mockFetch({ [LISTING_URL]: '<html><body>no jobs</body></html>' });
+      const jobs = await fetchAllTriaplusJobs();
+      expect(jobs).toEqual([]);
+    });
+  });
+
+  // ── slugify (imported from crawler-template) ──
+  describe('slugify', () => {
+    it('converts title to URL-safe slug', () => {
+      expect(slugify('Assistenzärztin oder Fachärztin (w/m/d)')).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+});


### PR DESCRIPTION
## Implementato

**Issue #4418 — Triaplus AG: location reale per-job invece di `DEFAULT_CITY` fisso**

- Root cause: la pagina di dettaglio già fetchata dal crawler conteneva già la location reale (`<span class="ort">in  <City>[ (<CANTON>)]</span>` subito dopo l'H2 del titolo), ma veniva scartata in favore del default fisso `Oberwil`.
- `scripts/lib/triaplus-job-parser.mjs`: aggiunta `KNOWN_LOCATIONS` (lookup slug→city/canton/postalCode) + `parseJobLocation()` + `stripDiacritics()`; `location`/`canton`/`postalCode`/`addressLocality`/`addressRegion` ora derivati per-job, `DEFAULT_CITY`/`DEFAULT_CANTON`/`DEFAULT_POSTAL_CODE` ridotti a fallback di ultima istanza.
- Corretto anche il docstring header del file, che dichiarava erroneamente un sito "Klinik Meissenberg" + sede Lucerna mai esistiti (verificato contro la pagina Standorte live del sito).
- Verifica end-to-end live (39/39 job reali): 24 Oberwil (ZG), 6 Baar (ZG), 3 Altdorf (UR), 2 Pfäffikon (SZ), 2 Steinen (SZ), 1 Goldau (SZ), 1 Einsiedeln (SZ) — 15/39 (38%) ora risolvono correttamente a un sito diverso da Oberwil, su tutti e 3 i cantoni reali (ZG/SZ/UR) invece di essere tutti etichettati Oberwil.
- `tests/triaplus-crawler.test.ts` (nuovo, 18 test) + regressione `tests/rhne-reseau-hospitalier-neuchatelois-crawler.test.ts` (19 test, stesso pattern di bug-class già fixato in #4419).

Addresses item di #4418

**Issue #4392 — Swatch Group: filtro brand reale per rado/comadur/nivarox/swatch-group-assembly**

- Root cause: `update-swatchgroup-jobs.mjs` esegue il generic engine condiviso una volta per companyKey, tutti puntati allo stesso pool `swatchgroup.com/careers` — `processCompany()` stampa `companyKey` su OGNI job estratto durante l'iterazione di quella company, indipendentemente dal reale datore di lavoro. I 4 companyKey ridistribuivano quindi lo stesso pool condiviso senza filtro brand reale (confermato: `data/jobs/by-crawler/rado.json` conteneva job con `company` reale "Omega Ltd.", "ETA SA...", "Renata AG", ecc.).
- Investigazione live (91 posting Swiss correnti, JSON-LD `hiringOrganization.name`) + storica (92 commit su `rado.json`, 462 su `swatch-group-assembly.json`): **zero istanze storiche o correnti** di un job realmente Rado/Comadur/Nivarox/Swatch-Group-Assembly-branded nella fonte dati condivisa attuale.
- Nuovo `scripts/lib/swatchgroup-brand-filter.mjs`: `SHARED_POOL_BRAND_PATTERNS` (regex per nome legale reale) + `filterSharedPoolJobsByBrand()`, ri-derivando il vero sottoinsieme per brand dal `job.company` già estratto correttamente (non dal `companyKey` stampato ciecamente). `eta-sa-swatch-group`/`swiss-timing-swatch-group` esclusi (seedano da domini propri, non dal pool condiviso).
- Wired in `update-swatchgroup-jobs.mjs`.
- `tests/swatchgroup-brand-filter.test.ts` (nuovo, 11 test): validato contro i 16 job reali attualmente persistiti per `rado`/`swatch-group-assembly` (filtro corregge 16→0, poiché nessuno è realmente brand-matched) + contro job sintetici con nome brand reale (correttamente accettati — prova che il filtro funziona in avanti, non solo respinge tutto).

Closes #4392

**Nota operativa per #4392**: non ho editato a mano `data/jobs/by-crawler/rado.json`/`swatch-group-assembly.json` (attualmente mislabeled, 16 job ciascuno) — la prossima run schedulata di `update-jobs-swatchgroup.yml` farà scattare lo shrink-guard (16→0) e auto-filerà una issue `parser-health`, che è il meccanismo sanzionato per uno shrink legittimo dei dati (override `SKIP_SHRINK_GUARD=1`), non un bug. Rispetta la regola "mai cuttare pagine senza OK esplicito".

**Fix review round 1 (🔴 Important, commit `2616e5a847c`)**: `scripts/update-swatchgroup-jobs.mjs` chiamava `writeJobsCrawlerSlice()` (e con esso lo shrink guard) solo quando `filterSharedPoolJobsByBrand()` restituiva jobs non-vuoti. Per rado/comadur-swatch-group/nivarox-swatch-group/swatch-group-assembly l'output *corretto* a regime è 0 (vedi Nota operativa sopra) — quindi il gate non veniva MAI attraversato, `writeJobsCrawlerSlice` non veniva mai chiamato, e le slice stale mislabeled (16 job) restavano su disco per sempre con `generatedAt` fresco, senza mai far scattare lo shrink-guard/issue `parser-health` descritto dalla Nota operativa. Fix: distinta `_ckFilterEmptiedRealScrape` (crawl raw non-vuoto ma filtro brand → 0) da "crawl non ha trovato nulla" (`_ckJobsRaw` vuoto, skip legittimo) — nel primo caso `writeJobsCrawlerSlice(ck, [])` viene comunque chiamato, così lo shrink guard valuta davvero il drop e apre l'issue `parser-health` come già descritto nel body originale. Corretto anche il bookkeeping di `_ckTotal` dopo una write riuscita (rifletteva il conteggio pre-write stale invece del nuovo conteggio corretto).

## Non implementato (ancora)

Nessuno scope residuo per #4418/#4392. #4418 è rilevata come follow-up aggregata dal contratto automatico — niente `Closes` per contratto (vedi incidente #3050→#3036 in AGENTS.md); verrà chiusa manualmente con commento di evidenza dopo il merge, stesso pattern già usato per #4057/#4383/#4227.

### Sibling-pattern check — 40 candidati sul diff combinato, tutti falsi positivi (ispezionati singolarmente)

- **`removed:"addressLocality/addressRegion/location/postalCode: DEFAULT_*"`** su 13 file (`kispi-sg`, `klinik-aadorf`, `klinik-susenberg`, `cds-savognin`, `clinica-hildebrand`, `clinica-varini`, `oscam-castelrotto`, `reha-andeer`, `sune-egge`, `therapiezentrum-meggen`, `amina-bank`, `badrutts-palace`, `adus-klinik`, `fmi`, `salina-reha`, `spitex-zuerich`, `rhne` già fixato in #4419) — ognuno verificato via header docstring: datori di lavoro **mono-sede reale** (una città fissa è il dato corretto) OPPURE già usano un pattern "real-value || DEFAULT_*" con estrazione primaria reale (`adus-klinik`: `item.locationCity || DEFAULT_CITY`; `fmi`: `pickLocation()` legge JSON-LD reale prima del fallback; `spitex-zuerich`: `it.location || DEFAULT_CITY`) — il loro `addressRegion: DEFAULT_CANTON` residuo è legittimo perché ognuno opera in un solo cantone anche con città variabile.
- **`comadur-swatch-group`, `nivarox-swatch-group`, `swatch-group-assembly`** in `.github/workflows/crawler-group-06.yml` (path args step git-commit), `scripts/re-enrich-jobs.mjs` (lookup table indirizzo-fallback), `services/jobDataNormalization.ts` (lookup table logo-URL) — riferimenti a companyKey esistenti, non la logica di redistribuzione del pool condiviso.
- **`DEFAULT_POSTAL_CODE`** su 10 file (`badrutts-palace`, `build-plugins/jobsSeoPagesPlugin.ts`, `build-plugins/shared/jobPostingSchema.ts`, `build-plugins/shared/postalCodes.ts`, `components/community/JobBoard.tsx`, `cereneo`, `forel-klinik`, `kispi` [non kispi-sg], `uroviva`) — convenzione di naming per costante locale-al-modulo (ogni crawler/plugin definisce il PROPRIO fallback), non logica condivisa da consolidare. Verificato specificamente `build-plugins/shared/postalCodes.ts`: è un layer DIVERSO (lookup build-time città→CAP per l'emissione SSG, usato per QUALSIASI job mancante di postalCode), non lo stesso scopo del `KNOWN_LOCATIONS` di triaplus (lookup crawler-time slug-sito→città/cantone/CAP specifico di Triaplus) — diversa fase pipeline, diversa chiave, non duplicazione.
- **`stripDiacritics`** su 7 file (`build-plugins/cityJobsAggregate.ts`, `scripts/audit-jobs-source-match.mjs`, `scripts/lib/scoring/termExtractor.mjs`, `scripts/lib/social-post-utils.mjs`, `scripts/lib/etat-de-vaud-job-parser.mjs`, `scripts/schedule-fb-events-daily.mjs`, `scripts/schedule-fb-jobs-daily.mjs`) — verificato: è un idioma da 1 riga (`normalize('NFD').replace(...)`) già duplicato letteralmente su 6 file PRIMA di questa PR, spaziando domini completamente non correlati (SSG build-plugin, audit script, scoring/NLP, crawler Vaud, scheduling Facebook). Tech-debt pre-esistente, non introdotta da questa PR (triaplus aggiunge una 7ª copia dello stesso idioma banale) — consolidare 7 file cross-dominio in un modulo condiviso è fuori scope chirurgico per un fix di location per-job (Non-Negotiable #6: "chirurgico = la classe del bug, NON il singolo file" — la classe qui è "default fisso maschera dati reali per-job", non "diacritic-stripping duplicato nel repo").
- **`TRIAPLUS_COMPANY_NAME`, `TRIAPLUS_KEY`** (`scripts/update-triaplus-jobs.mjs`) — file CALLER del parser modificato, uso invariato delle costanti esistenti.
- **`parseJobLocation`** in `omega-job-parser.mjs` (firma/scopo diverso: parsing di un blocco indirizzo free-text, non HTML) e in `postch-job-parser.mjs` (falso match: commento che menziona una funzione esterna non correlata `parseJobLocations`).
- **`slugFromUrl`** (`klinik-schloss-mammern-job-parser.mjs`) — variabile locale generica non correlata a location.
- **`KNOWN_LOCATIONS`** (`components/community/JobOrphanView.tsx`) — dominio completamente diverso (componente React UI), coincidenza di naming.

## Test plan

- [x] `npx vitest run tests/triaplus-crawler.test.ts tests/swatchgroup-brand-filter.test.ts tests/rhne-reseau-hospitalier-neuchatelois-crawler.test.ts tests/omega-crawler.test.ts` — 87/87 verdi (18+11+19+39 incl. regressione siblings già fixati)
- [x] Verifica live triaplus.ch: 39/39 job reali, location corretta su tutti e 3 i cantoni
- [x] Verifica dati reali swatchgroup: filtro corregge 16→0 su rado/swatch-group-assembly (dataset attuale non contiene job realmente di quei brand), accetta correttamente job sintetici brand-matched
- [x] GitNexus impact — LOW risk, nessun HIGH/CRITICAL

🤖 Generated with parallel-agent batch (worktree-isolated fix assembled by orchestrator)
