### PR TITLE
fix(seo): close validate-dist orphan-shard + canonical-mismatch gates

### DIFF
--- a/build-plugins/bfsSalaryLandingsPlugin.ts
+++ b/build-plugins/bfsSalaryLandingsPlugin.ts
@@ -25,6 +25,7 @@ import { buildSeoPageHtml } from './shared/seoPageShell';
 import { CALC_HREF } from './shared/calcHref';
 import { formatUpdatedDate } from './shared/humanDate';
 import { WriteCollector } from './batchWrite';
+import { resolveBfsSalaryFlushed } from './shared/buildSignals';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import { guardArticleJsonLdDescription } from './shared/safeTruncate';
 import {
@@ -681,14 +682,19 @@ export function bfsSalaryLandingsPlugin(rootDir: string): Plugin {
     async closeBundle() {
       if (process.env.SKIP_BFS_SALARY === '1') {
         console.log('\x1b[33m[bfs-salary]\x1b[0m Skipped (SKIP_BFS_SALARY=1)');
+        resolveBfsSalaryFlushed([]);
         return;
       }
       const distDir = np.resolve(rootDir, 'dist');
-      if (!fs.existsSync(distDir)) return;
+      if (!fs.existsSync(distDir)) {
+        resolveBfsSalaryFlushed([]);
+        return;
+      }
 
       const dateStamp = new Date().toISOString().slice(0, 10);
       const collector = new WriteCollector({ distDir, pluginName: 'bfsSalaryLandingsPlugin' });
       const sitemapEntries: Array<{ canonical: string; alternates: readonly string[] }> = [];
+      const emittedPaths: string[] = [];
       let pagesWritten = 0;
       let thinSkipped = 0;
 
@@ -708,6 +714,7 @@ export function bfsSalaryLandingsPlugin(rootDir: string): Plugin {
         } else if (itSeen()) {
           sitemapEntries.push({ canonical: rendered.urlPath, alternates: altLinks });
         }
+        emittedPaths.push(rendered.urlPath);
         pagesWritten++;
       };
 
@@ -747,6 +754,7 @@ export function bfsSalaryLandingsPlugin(rootDir: string): Plugin {
       if (fs.existsSync(np.join(distDir, 'sitemap-bfs-salary.xml'))) {
         patchSitemapIndex(distDir, dateStamp);
       }
+      resolveBfsSalaryFlushed(emittedPaths);
     },
   };
 }

--- a/build-plugins/bfsSalaryLinksPlugin.ts
+++ b/build-plugins/bfsSalaryLinksPlugin.ts
@@ -1,0 +1,184 @@
+/**
+ * BFS salary-by-age/education landings — internal-links injector.
+ *
+ * {@link bfsSalaryLandingsPlugin} emits `/stipendio-svizzera-{age}-anni/` and
+ * `/stipendio-svizzera-{education}/` pages (+ locale twins) that only
+ * cross-link their own 3-nearest siblings — a disconnected island with no
+ * external inbound link — so 20 URLs (55.56%) ship beyond
+ * `audit:max-bfs-depth`'s MAX_DEPTH=4.
+ *
+ * The whole family is tiny (5 age anchors + 4 education levels = 9
+ * identities per locale), so rather than seed one page and rely on the
+ * sibling ring to propagate (it doesn't reliably reach every node — see
+ * bfsSalaryLandingsPlugin.ts's `others = ....slice(0, 3)` cross-links,
+ * which always favour the same few array-order-adjacent entries), this
+ * plugin links every emitted identity directly from the per-locale HTML
+ * sitemap page:
+ *
+ *   it → /mappa-del-sito/      (in the main nav → depth 1 from `/`)
+ *   en → /en/site-map/         (in the /en/ nav  → depth 2 from `/`)
+ *   de → /de/seitenplan/       (in the /de/ nav  → depth 2 from `/`)
+ *   fr → /fr/plan-du-site/     (in the /fr/ nav  → depth 2 from `/`)
+ *
+ * Idempotent via the `data-bfs-salary-links` marker — see
+ * `build-plugins/shared/injectAfterMain.ts` for why independent injectors
+ * can safely stack on one file.
+ */
+
+import fs from 'node:fs';
+import np from 'node:path';
+import type { Plugin } from 'vite';
+import {
+  SALARY_LOCALES,
+  SALARY_AGE_ANCHORS,
+  SALARY_EDUCATION_IDS,
+  buildSalaryAgeLandingPath,
+  buildSalaryEducationLandingPath,
+  type SalaryLocale,
+} from './bfsSalaryLandingsData';
+import { bfsSalaryFlushed, staticPagesFlushed } from './shared/buildSignals';
+import { injectBlockAfterMain } from './shared/injectAfterMain';
+import { shouldEmitLocale } from './shared/localeEmitFilter';
+
+const MARKER = 'data-bfs-salary-links';
+
+/** HTML sitemap page (relative dir under dist) per locale — main-nav reachable. */
+const SITEMAP_PAGE_DIR: Record<SalaryLocale, string> = {
+  it: 'mappa-del-sito',
+  en: 'en/site-map',
+  de: 'de/seitenplan',
+  fr: 'fr/plan-du-site',
+};
+
+const BLOCK_COPY: Record<SalaryLocale, { heading: string; intro: string }> = {
+  it: { heading: 'Stipendio per età e formazione', intro: 'Stipendio medio in Svizzera per fascia d’età e livello di formazione.' },
+  en: { heading: 'Salary by age and education', intro: 'Average salary in Switzerland by age bracket and education level.' },
+  de: { heading: 'Lohn nach Alter und Ausbildung', intro: 'Durchschnittslohn in der Schweiz nach Altersgruppe und Ausbildungsniveau.' },
+  fr: { heading: 'Salaire par âge et formation', intro: 'Salaire moyen en Suisse par tranche d’âge et niveau de formation.' },
+};
+
+const AGE_LABEL: Record<SalaryLocale, (age: number) => string> = {
+  it: (a) => `${a} anni`,
+  en: (a) => `age ${a}`,
+  de: (a) => `${a} Jahre`,
+  fr: (a) => `${a} ans`,
+};
+
+const EDU_LABEL: Record<SalaryLocale, Record<(typeof SALARY_EDUCATION_IDS)[number], string>> = {
+  it: { 'scuola-obbligatoria': 'scuola obbligatoria', 'apprendistato-afc': 'apprendistato AFC', 'formazione-superiore': 'formazione superiore', universita: 'università' },
+  en: { 'scuola-obbligatoria': 'compulsory school', 'apprendistato-afc': 'apprenticeship (AFC)', 'formazione-superiore': 'higher education', universita: 'university' },
+  de: { 'scuola-obbligatoria': 'obligatorische Schule', 'apprendistato-afc': 'Berufslehre (EFZ)', 'formazione-superiore': 'höhere Bildung', universita: 'Universität' },
+  fr: { 'scuola-obbligatoria': 'scolarité obligatoire', 'apprendistato-afc': 'apprentissage (CFC)', 'formazione-superiore': 'formation supérieure', universita: 'université' },
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+interface LinkItem {
+  href: string;
+  label: string;
+}
+
+/** Build the injected block for one locale; '' when the locale has no links. */
+export function renderBfsSalaryLinksBlock(locale: SalaryLocale, items: readonly LinkItem[]): string {
+  if (items.length === 0) return '';
+  const copy = BLOCK_COPY[locale];
+  const lis = items
+    .map((it) => `<li class="s-xu5DGK"><a class="s-U9K6Vf" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+    .join('');
+  return (
+    `<aside ${MARKER}>` +
+    `<h3 class="s-ghlfvV">${esc(copy.heading)}</h3>` +
+    `<p>${esc(copy.intro)}</p>` +
+    `<ul class="s--Vsbr1">${lis}</ul>` +
+    `</aside>`
+  );
+}
+
+/**
+ * Build per-locale link items for every emitted age/education identity.
+ * Exported for unit testing without touching disk.
+ */
+export function buildBfsSalaryLinkItems(
+  emittedPaths: readonly string[],
+): Record<SalaryLocale, LinkItem[]> {
+  const emitted = new Set(emittedPaths);
+  const byLocale: Record<SalaryLocale, LinkItem[]> = { it: [], en: [], de: [], fr: [] };
+  for (const locale of SALARY_LOCALES) {
+    for (const age of SALARY_AGE_ANCHORS) {
+      const href = buildSalaryAgeLandingPath(locale, age);
+      if (emitted.has(href)) byLocale[locale].push({ href, label: AGE_LABEL[locale](age) });
+    }
+    for (const eduId of SALARY_EDUCATION_IDS) {
+      const href = buildSalaryEducationLandingPath(locale, eduId);
+      if (emitted.has(href)) byLocale[locale].push({ href, label: EDU_LABEL[locale][eduId] });
+    }
+  }
+  return byLocale;
+}
+
+export function bfsSalaryLinksPlugin(rootDir: string): Plugin {
+  return {
+    name: 'bfs-salary-links',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_BFS_SALARY === '1') return;
+
+      const distDir = np.resolve(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      const [emittedPaths] = await Promise.all([
+        bfsSalaryFlushed,
+        staticPagesFlushed,
+      ]);
+
+      if (emittedPaths.length === 0) {
+        console.log('\x1b[36m[bfs-salary-links]\x1b[0m No emitted pages — nothing to link.');
+        return;
+      }
+
+      const byLocale = buildBfsSalaryLinkItems(emittedPaths);
+
+      const failures: string[] = [];
+      let injected = 0;
+      for (const locale of SALARY_LOCALES) {
+        if (!shouldEmitLocale(locale)) continue;
+        const items = byLocale[locale];
+        if (items.length === 0) continue;
+        const indexPath = np.join(distDir, SITEMAP_PAGE_DIR[locale], 'index.html');
+        if (!fs.existsSync(indexPath)) {
+          failures.push(` - [missing-file] ${np.relative(distDir, indexPath)}`);
+          continue;
+        }
+        const html = fs.readFileSync(indexPath, 'utf-8');
+        const block = renderBfsSalaryLinksBlock(locale, items);
+        const { html: patched, outcome } = injectBlockAfterMain(html, block, MARKER);
+        if (outcome === 'inserted') {
+          fs.writeFileSync(indexPath, patched, 'utf-8');
+          injected++;
+        } else if (outcome === 'no-anchor') {
+          failures.push(` - [no-anchor] ${np.relative(distDir, indexPath)}`);
+        }
+      }
+
+      console.log(
+        `\x1b[36m[bfs-salary-links]\x1b[0m Injected salary-by-age/education links into ${injected} locale sitemap page(s).`,
+      );
+
+      if (failures.length > 0) {
+        throw new Error(
+          `[bfs-salary-links] failed to inject into ${failures.length} target(s):\n${failures.join('\n')}\n\n` +
+            'This re-orphans sitemap-bfs-salary.xml (audit:max-bfs-depth). ' +
+            'The target sitemap page did not exist after staticPagesFlushed (race / slug drift) ' +
+            'or had no <main>/</main>/</body> anchor. See build-plugins/shared/injectAfterMain.ts.',
+        );
+      }
+    },
+  };
+}

--- a/build-plugins/employerProfilePagesLinksPlugin.ts
+++ b/build-plugins/employerProfilePagesLinksPlugin.ts
@@ -1,0 +1,181 @@
+/**
+ * Employer-profile pages — internal-links injector.
+ *
+ * {@link employerProfilePagesPlugin} emits `/aziende/{slug}/` (+ locale
+ * twins) but nothing on a crawlable page links INTO them, so all 468 ship at
+ * BFS depth `unreachable` from `/` — `audit:max-bfs-depth` hard-fails the
+ * family as an entirely-buried new content tier (reached 0/468, epic #4462).
+ *
+ * This plugin closes that orphan tier the same way
+ * {@link professionCantonLandingsLinksPlugin} closed the profession-canton
+ * tier (CLAUDE.md regola #5 — real internal `<a href>` links from a hub
+ * reachable from `/`, never by relaxing the gate): after the profile emitter
+ * AND staticPagesPlugin flush, it injects one "Aziende in Svizzera" block
+ * into each locale's HTML sitemap page:
+ *
+ *   it → /mappa-del-sito/      (in the main nav → depth 1 from `/`)
+ *   en → /en/site-map/         (in the /en/ nav  → depth 2 from `/`)
+ *   de → /de/seitenplan/       (in the /de/ nav  → depth 2 from `/`)
+ *   fr → /fr/plan-du-site/     (in the /fr/ nav  → depth 2 from `/`)
+ *
+ * The sitemap page is on every page's nav, so each emitted employer profile
+ * lands at depth ≤ 3 (IT ≤ 2) — well inside the audit's MAX_DEPTH=4.
+ *
+ * Idempotent via the `data-employer-profiles-links` marker, distinct from
+ * {@link professionCantonLandingsLinksPlugin}'s own marker on the same page —
+ * see `build-plugins/shared/injectAfterMain.ts` for why two independent
+ * injectors can safely target one file.
+ */
+
+import fs from 'node:fs';
+import np from 'node:path';
+import type { Plugin } from 'vite';
+import { employerProfilesFlushed, staticPagesFlushed, type EmittedEmployerProfile } from './shared/buildSignals';
+import { injectBlockAfterMain } from './shared/injectAfterMain';
+import { shouldEmitLocale, type EmitLocale } from './shared/localeEmitFilter';
+
+const MARKER = 'data-employer-profiles-links';
+
+/** HTML sitemap page (relative dir under dist) per locale — main-nav reachable. */
+const SITEMAP_PAGE_DIR: Record<EmitLocale, string> = {
+  it: 'mappa-del-sito',
+  en: 'en/site-map',
+  de: 'de/seitenplan',
+  fr: 'fr/plan-du-site',
+};
+
+const BLOCK_COPY: Record<EmitLocale, { heading: string; intro: string }> = {
+  it: {
+    heading: 'Aziende in Svizzera',
+    intro: 'Profili aziendali con posizioni aperte, stipendio mediano e sedi reali.',
+  },
+  en: {
+    heading: 'Companies in Switzerland',
+    intro: 'Employer profiles with open positions, median salary and real locations.',
+  },
+  de: {
+    heading: 'Unternehmen in der Schweiz',
+    intro: 'Arbeitgeberprofile mit offenen Stellen, Medianlohn und echten Standorten.',
+  },
+  fr: {
+    heading: 'Entreprises en Suisse',
+    intro: 'Profils d’employeurs avec postes ouverts, salaire médian et sites réels.',
+  },
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+interface LinkItem {
+  href: string;
+  label: string;
+}
+
+/** Build the injected block for one locale; '' when the locale has no links. */
+export function renderEmployerLinksBlock(locale: EmitLocale, items: readonly LinkItem[]): string {
+  if (items.length === 0) return '';
+  const copy = BLOCK_COPY[locale];
+  const lis = items
+    .map((it) => `<li class="s-xu5DGK"><a class="s-U9K6Vf" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+    .join('');
+  return (
+    `<aside ${MARKER}>` +
+    `<h3 class="s-ghlfvV">${esc(copy.heading)}</h3>` +
+    `<p>${esc(copy.intro)}</p>` +
+    `<ul class="s--Vsbr1">${lis}</ul>` +
+    `</aside>`
+  );
+}
+
+/**
+ * Group emitted employer profiles into per-locale, sorted link items.
+ * Exported for unit testing the grouping without touching disk.
+ */
+export function buildEmployerLinkItems(
+  profiles: readonly EmittedEmployerProfile[],
+): Record<EmitLocale, LinkItem[]> {
+  const byLocale: Record<EmitLocale, LinkItem[]> = { it: [], en: [], de: [], fr: [] };
+  for (const p of profiles) {
+    byLocale[p.locale].push({ href: p.path, label: p.label });
+  }
+  for (const loc of Object.keys(byLocale) as EmitLocale[]) {
+    byLocale[loc].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return byLocale;
+}
+
+export function employerProfilePagesLinksPlugin(rootDir: string): Plugin {
+  return {
+    name: 'employer-profile-pages-links',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_EMPLOYER_PROFILE_PAGES === '1') return;
+
+      const distDir = np.resolve(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      // Wait for the profile emitter (gives us the emitted profiles) AND
+      // staticPagesPlugin (writes the sitemap pages we patch) so both
+      // producers have flushed to disk before we read+patch — mirrors
+      // professionCantonLandingsLinksPlugin's race fix.
+      const [profiles] = await Promise.all([
+        employerProfilesFlushed,
+        staticPagesFlushed,
+      ]);
+
+      if (profiles.length === 0) {
+        console.log('\x1b[36m[employer-profile-pages-links]\x1b[0m No emitted profiles — nothing to link.');
+        return;
+      }
+
+      const byLocale = buildEmployerLinkItems(profiles);
+
+      const failures: string[] = [];
+      let injected = 0;
+      for (const locale of Object.keys(SITEMAP_PAGE_DIR) as EmitLocale[]) {
+        // Per-locale shard build (BUILD_LOCALE): skip locales this shard did
+        // not emit — their sitemap pages are absent and would hard-fail as
+        // missing-file. No-op in the default all-locale build.
+        if (!shouldEmitLocale(locale)) continue;
+        const items = byLocale[locale];
+        if (items.length === 0) continue; // nothing emitted for this locale
+        const indexPath = np.join(distDir, SITEMAP_PAGE_DIR[locale], 'index.html');
+        if (!fs.existsSync(indexPath)) {
+          failures.push(` - [missing-file] ${np.relative(distDir, indexPath)}`);
+          continue;
+        }
+        const html = fs.readFileSync(indexPath, 'utf-8');
+        const block = renderEmployerLinksBlock(locale, items);
+        const { html: patched, outcome } = injectBlockAfterMain(html, block, MARKER);
+        if (outcome === 'inserted') {
+          fs.writeFileSync(indexPath, patched, 'utf-8');
+          injected++;
+        } else if (outcome === 'no-anchor') {
+          failures.push(` - [no-anchor] ${np.relative(distDir, indexPath)}`);
+        }
+        // 'duplicate' → already patched this build, no-op.
+      }
+
+      console.log(
+        `\x1b[36m[employer-profile-pages-links]\x1b[0m Injected employer-profile links into ${injected} locale sitemap page(s).`,
+      );
+
+      // Hard-fail on any miss: an un-patched sitemap page re-opens the
+      // sitemap-employer-profiles.xml orphan tier the audit hard-fails on.
+      if (failures.length > 0) {
+        throw new Error(
+          `[employer-profile-pages-links] failed to inject into ${failures.length} target(s):\n${failures.join('\n')}\n\n` +
+            'This re-orphans sitemap-employer-profiles.xml (audit:max-bfs-depth). ' +
+            'The target sitemap page did not exist after staticPagesFlushed (race / slug drift) ' +
+            'or had no <main>/</main>/</body> anchor. See build-plugins/shared/injectAfterMain.ts.',
+        );
+      }
+    },
+  };
+}

--- a/build-plugins/employerProfilePagesPlugin.ts
+++ b/build-plugins/employerProfilePagesPlugin.ts
@@ -48,6 +48,7 @@ import { buildCurrentWeekPath } from './weeklyEmployersData';
 import { buildSectorHubPath, SECTOR_HUB_KEYS, type SectorHubKey } from './jobSectorLanding';
 import { canonicalCompanyProfileSlug } from './shared/companyProfileSlug.mjs';
 import { MIN_ACTIVE_JOBS } from './shared/employerProfileConfig.mjs';
+import { resolveEmployerProfilesFlushed, type EmittedEmployerProfile } from './shared/buildSignals';
 
 const LOCALES = ['it', 'en', 'de', 'fr'] as const;
 type Locale = (typeof LOCALES)[number];
@@ -419,14 +420,19 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
     async closeBundle() {
       if (process.env.SKIP_EMPLOYER_PROFILE_PAGES === '1') {
         console.log('\x1b[33m[employer-profile-pages]\x1b[0m Skipped (SKIP_EMPLOYER_PROFILE_PAGES=1)');
+        resolveEmployerProfilesFlushed([]);
         return;
       }
       const distDir = np.resolve(rootDir, 'dist');
-      if (!fs.existsSync(distDir)) return;
+      if (!fs.existsSync(distDir)) {
+        resolveEmployerProfilesFlushed([]);
+        return;
+      }
 
       const dsPath = np.resolve(rootDir, 'data/employer-profiles.json');
       if (!fs.existsSync(dsPath)) {
         console.log('\x1b[33m[employer-profile-pages]\x1b[0m no employer-profiles.json — nothing to emit.');
+        resolveEmployerProfilesFlushed([]);
         return;
       }
       let dataset: EmployerDataset;
@@ -434,12 +440,14 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
         dataset = JSON.parse(fs.readFileSync(dsPath, 'utf-8')) as EmployerDataset;
       } catch (err) {
         console.warn('\x1b[33m[employer-profile-pages]\x1b[0m dataset parse failed:', err);
+        resolveEmployerProfilesFlushed([]);
         return;
       }
       const profiles = dataset.profiles || [];
       const belowFloor = dataset.belowFloor || [];
       if (profiles.length === 0 && belowFloor.length === 0) {
         console.log('\x1b[33m[employer-profile-pages]\x1b[0m empty dataset — nothing to emit.');
+        resolveEmployerProfilesFlushed([]);
         return;
       }
 
@@ -459,6 +467,7 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
       const dateStamp = new Date().toISOString().slice(0, 10);
       const collector = new WriteCollector({ distDir, pluginName: 'employerProfilePagesPlugin' });
       const sitemapEntries: Array<{ canonical: string; alternates: string[] }> = [];
+      const emittedProfiles: EmittedEmployerProfile[] = [];
       let profilePages = 0;
       let bridgePages = 0;
       let thinDowngraded = 0;
@@ -551,6 +560,10 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
           collector.add(np.join(distDir, urlPath.replace(/\/+$/, '') + '.html'), html);
           profilePages++;
 
+          if (indexable) {
+            emittedProfiles.push({ locale, path: urlPath, label: profile.name });
+          }
+
           if (locale === 'it' && indexable) {
             sitemapEntries.push({ canonical: urlPath, alternates });
           }
@@ -608,6 +621,7 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
         `${profilePages} profile pages (${thinDowngraded} noindex-thin) + ${bridgePages} bridge pages ` +
         `— flushed ${written} files.`,
       );
+      resolveEmployerProfilesFlushed(emittedProfiles);
     },
   };
 }

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -1438,7 +1438,12 @@ export function renderHubPage(params: {
   const canonicalPath = pathFor(locale, canton);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
-  const upcoming = events.slice(0, 60);
+  // Was 60 — the date-sorted tail beyond the cap never got a link anywhere,
+  // contributing to sitemap-eventi.xml's 14.99% BFS-depth orphan rate
+  // (audit:max-bfs-depth). Raised so canton/digest hubs surface more of the
+  // family within depth budget; see build-plugins/eventsSeoPagesPlugin.ts
+  // header for the depth ≤2 hub design this caps still nest under.
+  const upcoming = events.slice(0, 100);
 
   const comuneEntries = [...byComune.entries()].sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]));
   const comuneGrid =
@@ -1609,7 +1614,12 @@ export function renderEventsIndexPage(params: {
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
   const totalComuni = cantonStats.reduce((sum, c) => sum + c.comuneCount, 0);
-  const upcoming = events.slice(0, 60);
+  // Was 60 — the date-sorted tail beyond the cap never got a link anywhere,
+  // contributing to sitemap-eventi.xml's 14.99% BFS-depth orphan rate
+  // (audit:max-bfs-depth). Raised so canton/digest hubs surface more of the
+  // family within depth budget; see build-plugins/eventsSeoPagesPlugin.ts
+  // header for the depth ≤2 hub design this caps still nest under.
+  const upcoming = events.slice(0, 100);
 
   const cantonGrid = cantonStats
     .map(
@@ -1728,7 +1738,9 @@ export function renderComunePage(params: {
   const copy = copyFor(canton, locale);
   const canonicalPath = pathFor(locale, canton, comune);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
-  const list = events.slice(0, 40);
+  // Was 40 — see the `upcoming` cap above for why this was raised (same
+  // audit:max-bfs-depth orphan-tail fix).
+  const list = events.slice(0, 80);
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
   // #4414: real weekly count + soonest upcoming event for this comune —
   // scoped to the FULL comune `events` list (not the 40-item display slice)
@@ -1987,7 +1999,9 @@ export function renderOtherEventsPage(params: {
   const oeCopy = otherEventsCopyFor(canton, locale);
   const canonicalPath = pathFor(locale, canton, OTHER_EVENTS_COMUNE_KEY);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
-  const list = events.slice(0, 40);
+  // Was 40 — see the `upcoming` cap above for why this was raised (same
+  // audit:max-bfs-depth orphan-tail fix).
+  const list = events.slice(0, 80);
   const weekendCount = events.filter((e) => isWeekend(e.startDate, weekendDays)).length;
 
   const body = `${EVENTS_STYLE_BLOCK}<div class="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
@@ -2471,7 +2485,10 @@ export function renderEventDetailPage(params: {
   const when = humanDate(event.startDate, locale);
   const time = event.startTime ? ` · ${esc(event.startTime)}` : '';
   const cat = categoryLabel(event.category, locale);
-  const others = sameComuneEvents.filter((e) => e.id !== event.id).slice(0, 6);
+  // Was 6 — raised alongside the hub/digest list caps above (same
+  // audit:max-bfs-depth orphan-tail fix): more sibling cross-links per
+  // detail page means more paths into the date-sorted tail.
+  const others = sameComuneEvents.filter((e) => e.id !== event.id).slice(0, 10);
   const map = osmLink(event, displayComune);
   const description = localizedDescription(event, locale);
   const visual = categoryVisual(event.category);
@@ -2735,7 +2752,9 @@ export function renderDigestPage(params: {
   const dc = digestCopyFor(def, canton, locale);
   const canonicalPath = pathForDigest(locale, canton, def.slug);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
-  const list = events.slice(0, 60);
+  // Was 60 — see the `upcoming` cap above for why this was raised (same
+  // audit:max-bfs-depth orphan-tail fix).
+  const list = events.slice(0, 100);
   const byComune = groupByComune(events) as Map<string, SiteEvent[]>;
 
   const comuneGrid = [...byComune.entries()]

--- a/build-plugins/healthFacilitiesLinksPlugin.ts
+++ b/build-plugins/healthFacilitiesLinksPlugin.ts
@@ -51,7 +51,8 @@ import { NEAR_YOU_BLOCK } from './healthFacilitiesCopy';
 // HTML) is skipped. Within one build the producer always re-renders the
 // landing fresh, so the marker can only be absent when this injector runs.
 const MARKER = 'data-health-facility-links';
-const MAX_FACILITY_LINKS = 8;
+// Was 8 — see pickFacilities() below for why raising this alone wasn't enough.
+const MAX_FACILITY_LINKS = 24;
 
 function esc(s: string): string {
   return String(s)
@@ -61,7 +62,19 @@ function esc(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
-/** Rank the above-floor facilities for a given nursing landing id. */
+/**
+ * Rank the above-floor facilities for a given nursing landing id.
+ *
+ * `nurses` and `oss` used to both take the identical top-N by liveCount, so
+ * across all 3 ids × 4 locales only N unique facilities ever got linked (was
+ * N=8 → 428/436 = 98.2% of the family stayed orphaned, tripping the
+ * new-shard check in audit:max-bfs-depth). No per-facility "care-assistant
+ * openings" signal exists on {@link EmittedFacility} to split on topically
+ * (the file header doc predates this — it was never actually implemented),
+ * so instead `nurses`/`oss` take disjoint even/odd slices of the SAME
+ * ranked list — a real, data-available way to make the two ids' link sets
+ * non-overlapping — while `healthcare-ticino` keeps its TI-first behaviour.
+ */
 function pickFacilities(id: NursingLandingId, all: readonly EmittedFacility[]): EmittedFacility[] {
   const byCount = [...all].sort((a, b) => b.liveCount - a.liveCount);
   if (id === 'healthcare-ticino') {
@@ -69,7 +82,8 @@ function pickFacilities(id: NursingLandingId, all: readonly EmittedFacility[]): 
     const rest = byCount.filter((f) => f.canton !== 'TI');
     return [...ti, ...rest].slice(0, MAX_FACILITY_LINKS);
   }
-  return byCount.slice(0, MAX_FACILITY_LINKS);
+  const parity = id === 'oss' ? 1 : 0;
+  return byCount.filter((_, i) => i % 2 === parity).slice(0, MAX_FACILITY_LINKS);
 }
 
 function facilityLinkLabel(f: EmittedFacility, locale: HealthFacilityLocale): string {

--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -771,11 +771,17 @@ export async function emitChCantonSnapshotPages(
       });
 
       const words = countHtmlBodyWords(html);
+      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       if (words < MIN_INDEXABLE_WORDS) {
         result.pagesSkippedForWordCount++;
+        // Same below-floor-bridge treatment as the cantonsSkipped loop below —
+        // a bare `continue` here (sibling bug class, see jobsSeoPagesPlugin.ts
+        // "Structural 404 fix" comment) leaves this locale's slot empty for a
+        // locale-partitioned CI build to fill with a different verdict.
+        collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, cantonCode));
+        result.bridgesWritten++;
         continue;
       }
-      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       collector.add(np.join(outDir, 'index.html'), html);
       result.pagesWritten++;
     }

--- a/build-plugins/professionCantonLandings.ts
+++ b/build-plugins/professionCantonLandings.ts
@@ -427,6 +427,20 @@ export async function emitProfessionCantonPages(opts: { rootDir: string; distDir
       }));
       if (rendered.some((r) => r.words < MIN_INDEXABLE_WORDS)) {
         result.pagesSkippedForWordCount += PROFESSION_LOCALES.length;
+        // Same below-floor-bridge treatment as the liveCount<MIN_JOBS branch
+        // above: a bare `continue` here leaves the page's disk slot empty for
+        // this plugin's own sitemap check but not for a locale-partitioned CI
+        // build (scripts/ci/prune-locale-shard.mjs), which reruns this same
+        // gate independently per locale and can reach a different verdict for
+        // the same (canton, profession) pair — the "winning" shard's stale/
+        // foreign content then sits at a URL another shard's sitemap lists as
+        // self-canonical, failing audit:sitemap-canonicals downstream.
+        for (const locale of PROFESSION_LOCALES) {
+          const canonicalPath = buildProfessionCantonPath(locale, cantonKey, id);
+          const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+          collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, cantonKey, id));
+          result.bridgesWritten++;
+        }
         continue;
       }
       for (const r of rendered) {

--- a/build-plugins/professionCityLandings.ts
+++ b/build-plugins/professionCityLandings.ts
@@ -73,6 +73,7 @@ import {
   renderStatGrid,
   pickStatTileTone,
 } from './shared/seoContentTokens';
+import { resolveProfessionCitiesFlushed } from './shared/buildSignals';
 
 /** Minimum real active jobs for a (city, profession) page to be emitted. */
 const MIN_JOBS = 3;
@@ -480,6 +481,16 @@ export async function emitProfessionCityPages(opts: { rootDir: string; distDir: 
       }));
       if (rendered.some((r) => r.words < MIN_INDEXABLE_WORDS)) {
         result.pagesSkippedForWordCount += PROFESSION_LOCALES.length;
+        // Same below-floor-bridge treatment as the liveCount<MIN_JOBS branch
+        // above (sibling bug class, see professionCantonLandings.ts): a bare
+        // `continue` here leaves this pair's slot empty for a locale-
+        // partitioned CI build to fill with a different verdict per locale.
+        for (const locale of PROFESSION_LOCALES) {
+          const canonicalPath = buildProfessionCityPath(locale, cityKey, id);
+          const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
+          collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, cityKey, id));
+          result.bridgesWritten++;
+        }
         continue;
       }
       for (const r of rendered) {
@@ -511,11 +522,18 @@ export function professionCityLandings(rootDir: string): Plugin {
     apply: 'build',
     enforce: 'post',
     async closeBundle() {
-      if (process.env.SKIP_PROFESSION_CITIES === '1') return;
+      if (process.env.SKIP_PROFESSION_CITIES === '1') {
+        resolveProfessionCitiesFlushed([]);
+        return;
+      }
       const distDir = np.resolve(rootDir, 'dist');
       const res = await emitProfessionCityPages({ rootDir, distDir });
       // eslint-disable-next-line no-console
       console.log(`[profession-cities] emitted ${res.pagesWritten} pages, ${res.bridgesWritten} below-floor bridges (${res.pagesSkippedForJobs} pairs below job floor, ${res.pagesSkippedForWordCount} below word gate)`);
+      // Hand emitted canonical paths to professionCityLinksPlugin so it can
+      // de-orphan exactly the pages shipped (CLAUDE.md regola #5: close
+      // orphans with real internal links, not by relaxing the gate).
+      resolveProfessionCitiesFlushed(res.emittedPaths);
     },
   };
 }

--- a/build-plugins/professionCityLinksPlugin.ts
+++ b/build-plugins/professionCityLinksPlugin.ts
@@ -1,0 +1,199 @@
+/**
+ * Profession × city landings — internal-links injector.
+ *
+ * {@link professionCityLandings} emits `/lavoro-{city}-{role}/` (+ /en/jobs-,
+ * /de/arbeit-, /fr/travail-) but — unlike its sibling family
+ * {@link professionCantonLandings}, which already has
+ * {@link professionCantonLandingsLinksPlugin} — nothing on a crawlable page
+ * links INTO these city pages, so 208 URLs (62.65%) ship beyond
+ * `audit:max-bfs-depth`'s MAX_DEPTH=4 (epic #4301/#4488).
+ *
+ * This plugin closes that orphan tier the same way
+ * {@link professionCantonLandingsLinksPlugin} closed the profession-canton
+ * tier (CLAUDE.md regola #5 — real internal `<a href>` links from a hub
+ * reachable from `/`, never by relaxing the gate): after the city emitter AND
+ * staticPagesPlugin flush, it injects one "Lavoro per città e professione"
+ * block into each locale's HTML sitemap page:
+ *
+ *   it → /mappa-del-sito/      (in the main nav → depth 1 from `/`)
+ *   en → /en/site-map/         (in the /en/ nav  → depth 2 from `/`)
+ *   de → /de/seitenplan/       (in the /de/ nav  → depth 2 from `/`)
+ *   fr → /fr/plan-du-site/     (in the /fr/ nav  → depth 2 from `/`)
+ *
+ * Idempotent via the `data-profession-cities-links` marker, distinct from
+ * {@link professionCantonLandingsLinksPlugin}'s and
+ * {@link employerProfilePagesLinksPlugin}'s own markers on the same page —
+ * see `build-plugins/shared/injectAfterMain.ts` for why independent
+ * injectors can safely stack on one file.
+ */
+
+import fs from 'node:fs';
+import np from 'node:path';
+import type { Plugin } from 'vite';
+import {
+  PROFESSION_LOCALES,
+  professionRoleKeyword,
+  type ProfessionLocale,
+  type ProfessionId,
+} from './professionLandingsData';
+import { parseProfessionCityPath, getProfessionCityDef } from './professionCityData';
+import { staticPagesFlushed, professionCitiesFlushed } from './shared/buildSignals';
+import { injectBlockAfterMain } from './shared/injectAfterMain';
+import { shouldEmitLocale } from './shared/localeEmitFilter';
+
+const MARKER = 'data-profession-cities-links';
+
+/** HTML sitemap page (relative dir under dist) per locale — main-nav reachable. */
+const SITEMAP_PAGE_DIR: Record<ProfessionLocale, string> = {
+  it: 'mappa-del-sito',
+  en: 'en/site-map',
+  de: 'de/seitenplan',
+  fr: 'fr/plan-du-site',
+};
+
+const BLOCK_COPY: Record<ProfessionLocale, { heading: string; intro: string }> = {
+  it: {
+    heading: 'Lavoro per città e professione',
+    intro: 'Offerte attive e stipendio mediano per professione nelle principali città svizzere.',
+  },
+  en: {
+    heading: 'Jobs by city and profession',
+    intro: 'Active openings and median salary by profession in major Swiss cities.',
+  },
+  de: {
+    heading: 'Stellen nach Stadt und Beruf',
+    intro: 'Aktive Stellen und Medianlohn nach Beruf in den wichtigsten Schweizer Städten.',
+  },
+  fr: {
+    heading: 'Emplois par ville et profession',
+    intro: 'Offres actives et salaire médian par métier dans les principales villes suisses.',
+  },
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Title-cased role keyword (mirror of professionCityLandings' internal label builder). */
+function professionLabel(locale: ProfessionLocale, id: ProfessionId): string {
+  const role = professionRoleKeyword(locale, id).replace(/-/g, ' ');
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+interface LinkItem {
+  href: string;
+  label: string;
+}
+
+/** Build the injected block for one locale; '' when the locale has no links. */
+export function renderCityLinksBlock(locale: ProfessionLocale, items: readonly LinkItem[]): string {
+  if (items.length === 0) return '';
+  const copy = BLOCK_COPY[locale];
+  const lis = items
+    .map((it) => `<li class="s-xu5DGK"><a class="s-U9K6Vf" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+    .join('');
+  return (
+    `<aside ${MARKER}>` +
+    `<h3 class="s-ghlfvV">${esc(copy.heading)}</h3>` +
+    `<p>${esc(copy.intro)}</p>` +
+    `<ul class="s--Vsbr1">${lis}</ul>` +
+    `</aside>`
+  );
+}
+
+/**
+ * Group emitted profession-city canonical paths into per-locale, sorted link
+ * items. Exported for unit testing the grouping without touching disk.
+ */
+export function buildCityLinkItems(
+  emittedPaths: readonly string[],
+): Record<ProfessionLocale, LinkItem[]> {
+  const byLocale: Record<ProfessionLocale, LinkItem[]> = { it: [], en: [], de: [], fr: [] };
+  for (const path of emittedPaths) {
+    const parsed = parseProfessionCityPath(path);
+    if (!parsed) continue;
+    const { locale, cityKey, id } = parsed;
+    const city = getProfessionCityDef(cityKey)?.display ?? cityKey;
+    const role = professionLabel(locale, id);
+    byLocale[locale].push({ href: path, label: `${role} · ${city}` });
+  }
+  for (const loc of PROFESSION_LOCALES) {
+    byLocale[loc].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return byLocale;
+}
+
+export function professionCityLinksPlugin(rootDir: string): Plugin {
+  return {
+    name: 'profession-city-landings-links',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_PROFESSION_CITIES === '1') return;
+
+      const distDir = np.resolve(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      // Wait for the city emitter (gives us emitted paths) AND
+      // staticPagesPlugin (writes the sitemap pages we patch) so both
+      // producers have flushed to disk before we read+patch — mirrors
+      // professionCantonLandingsLinksPlugin's race fix.
+      const [emittedPaths] = await Promise.all([
+        professionCitiesFlushed,
+        staticPagesFlushed,
+      ]);
+
+      if (emittedPaths.length === 0) {
+        console.log('\x1b[36m[profession-city-landings-links]\x1b[0m No emitted pages — nothing to link.');
+        return;
+      }
+
+      const byLocale = buildCityLinkItems(emittedPaths);
+
+      const failures: string[] = [];
+      let injected = 0;
+      for (const locale of PROFESSION_LOCALES) {
+        // Per-locale shard build (BUILD_LOCALE): skip locales this shard did
+        // not emit — their sitemap pages are absent and would hard-fail as
+        // missing-file. No-op in the default all-locale build.
+        if (!shouldEmitLocale(locale)) continue;
+        const items = byLocale[locale];
+        if (items.length === 0) continue; // nothing emitted for this locale
+        const indexPath = np.join(distDir, SITEMAP_PAGE_DIR[locale], 'index.html');
+        if (!fs.existsSync(indexPath)) {
+          failures.push(` - [missing-file] ${np.relative(distDir, indexPath)}`);
+          continue;
+        }
+        const html = fs.readFileSync(indexPath, 'utf-8');
+        const block = renderCityLinksBlock(locale, items);
+        const { html: patched, outcome } = injectBlockAfterMain(html, block, MARKER);
+        if (outcome === 'inserted') {
+          fs.writeFileSync(indexPath, patched, 'utf-8');
+          injected++;
+        } else if (outcome === 'no-anchor') {
+          failures.push(` - [no-anchor] ${np.relative(distDir, indexPath)}`);
+        }
+        // 'duplicate' → already patched this build, no-op.
+      }
+
+      console.log(
+        `\x1b[36m[profession-city-landings-links]\x1b[0m Injected per-city links into ${injected} locale sitemap page(s).`,
+      );
+
+      // Hard-fail on any miss: an un-patched sitemap page re-opens the
+      // sitemap-profession-cities.xml orphan tier audit:max-bfs-depth hard-fails on.
+      if (failures.length > 0) {
+        throw new Error(
+          `[profession-city-landings-links] failed to inject into ${failures.length} target(s):\n${failures.join('\n')}\n\n` +
+            'This re-orphans sitemap-profession-cities.xml (audit:max-bfs-depth). ' +
+            'The target sitemap page did not exist after staticPagesFlushed (race / slug drift) ' +
+            'or had no <main>/</main>/</body> anchor. See build-plugins/shared/injectAfterMain.ts.',
+        );
+      }
+    },
+  };
+}

--- a/build-plugins/publisherAdLinksPlugin.ts
+++ b/build-plugins/publisherAdLinksPlugin.ts
@@ -1,0 +1,158 @@
+/**
+ * Publisher-ad detail pages — internal-links injector.
+ *
+ * {@link publisherAdPagesPlugin} emits `/lavoro/{slug}/` (+ locale twins) —
+ * paid content publishers bought a listing for — but no job-card renderer
+ * anywhere on the site respects the ad's own canonical URL (they all build
+ * their own canton/section href instead), so the family shipped with zero
+ * crawlable inbound link (`audit:max-bfs-depth`, currently 1/1 URLs
+ * unreachable — small today, but this is paid revenue content and will grow
+ * as the publisher portal sells more listings).
+ *
+ * Rather than touch the many job-card call sites across the much larger
+ * `jobsSeoPagesPlugin.ts` (broad, risky change for a currently-tiny family),
+ * this plugin follows the same low-risk pattern already used for the other
+ * orphaned tiers in this build: after the ad emitter AND staticPagesPlugin
+ * flush, it injects a small "Offerte sponsorizzate" CTA block into each
+ * locale's HTML sitemap page:
+ *
+ *   it → /mappa-del-sito/      (in the main nav → depth 1 from `/`)
+ *   en → /en/site-map/         (in the /en/ nav  → depth 2 from `/`)
+ *   de → /de/seitenplan/       (in the /de/ nav  → depth 2 from `/`)
+ *   fr → /fr/plan-du-site/     (in the /fr/ nav  → depth 2 from `/`)
+ *
+ * Idempotent via the `data-publisher-ads-links` marker — see
+ * `build-plugins/shared/injectAfterMain.ts` for why independent injectors
+ * can safely stack on one file.
+ */
+
+import fs from 'node:fs';
+import np from 'node:path';
+import type { Plugin } from 'vite';
+import { publisherAdsFlushed, staticPagesFlushed, type EmittedPublisherAd } from './shared/buildSignals';
+import { injectBlockAfterMain } from './shared/injectAfterMain';
+import { shouldEmitLocale } from './shared/localeEmitFilter';
+
+const MARKER = 'data-publisher-ads-links';
+
+/** HTML sitemap page (relative dir under dist) per locale — main-nav reachable. */
+const SITEMAP_PAGE_DIR: Record<EmittedPublisherAd['locale'], string> = {
+  it: 'mappa-del-sito',
+  en: 'en/site-map',
+  de: 'de/seitenplan',
+  fr: 'fr/plan-du-site',
+};
+
+const BLOCK_COPY: Record<EmittedPublisherAd['locale'], { heading: string; intro: string }> = {
+  it: { heading: 'Offerte sponsorizzate', intro: 'Posizioni pubblicate direttamente dai datori di lavoro.' },
+  en: { heading: 'Sponsored listings', intro: 'Positions published directly by employers.' },
+  de: { heading: 'Gesponserte Stellen', intro: 'Von Arbeitgebern direkt veröffentlichte Stellen.' },
+  fr: { heading: 'Offres sponsorisées', intro: 'Postes publiés directement par les employeurs.' },
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+interface LinkItem {
+  href: string;
+  label: string;
+}
+
+/** Build the injected block for one locale; '' when the locale has no links. */
+export function renderPublisherAdsLinksBlock(
+  locale: EmittedPublisherAd['locale'],
+  items: readonly LinkItem[],
+): string {
+  if (items.length === 0) return '';
+  const copy = BLOCK_COPY[locale];
+  const lis = items
+    .map((it) => `<li class="s-xu5DGK"><a class="s-U9K6Vf" href="${esc(it.href)}">${esc(it.label)}</a></li>`)
+    .join('');
+  return (
+    `<aside ${MARKER}>` +
+    `<h3 class="s-ghlfvV">${esc(copy.heading)}</h3>` +
+    `<p>${esc(copy.intro)}</p>` +
+    `<ul class="s--Vsbr1">${lis}</ul>` +
+    `</aside>`
+  );
+}
+
+/** Group emitted ads into per-locale, sorted link items. Exported for unit testing. */
+export function buildPublisherAdLinkItems(
+  ads: readonly EmittedPublisherAd[],
+): Record<EmittedPublisherAd['locale'], LinkItem[]> {
+  const byLocale: Record<EmittedPublisherAd['locale'], LinkItem[]> = { it: [], en: [], de: [], fr: [] };
+  for (const ad of ads) {
+    byLocale[ad.locale].push({ href: ad.path, label: ad.label });
+  }
+  for (const loc of Object.keys(byLocale) as EmittedPublisherAd['locale'][]) {
+    byLocale[loc].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return byLocale;
+}
+
+export function publisherAdLinksPlugin(rootDir: string): Plugin {
+  return {
+    name: 'publisher-ad-links',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_PUBLISHER_AD_PAGES === '1') return;
+
+      const distDir = np.resolve(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      const [ads] = await Promise.all([
+        publisherAdsFlushed,
+        staticPagesFlushed,
+      ]);
+
+      if (ads.length === 0) {
+        console.log('\x1b[36m[publisher-ad-links]\x1b[0m No emitted ads — nothing to link.');
+        return;
+      }
+
+      const byLocale = buildPublisherAdLinkItems(ads);
+
+      const failures: string[] = [];
+      let injected = 0;
+      for (const locale of Object.keys(SITEMAP_PAGE_DIR) as EmittedPublisherAd['locale'][]) {
+        if (!shouldEmitLocale(locale)) continue;
+        const items = byLocale[locale];
+        if (items.length === 0) continue;
+        const indexPath = np.join(distDir, SITEMAP_PAGE_DIR[locale], 'index.html');
+        if (!fs.existsSync(indexPath)) {
+          failures.push(` - [missing-file] ${np.relative(distDir, indexPath)}`);
+          continue;
+        }
+        const html = fs.readFileSync(indexPath, 'utf-8');
+        const block = renderPublisherAdsLinksBlock(locale, items);
+        const { html: patched, outcome } = injectBlockAfterMain(html, block, MARKER);
+        if (outcome === 'inserted') {
+          fs.writeFileSync(indexPath, patched, 'utf-8');
+          injected++;
+        } else if (outcome === 'no-anchor') {
+          failures.push(` - [no-anchor] ${np.relative(distDir, indexPath)}`);
+        }
+      }
+
+      console.log(
+        `\x1b[36m[publisher-ad-links]\x1b[0m Injected publisher-ad links into ${injected} locale sitemap page(s).`,
+      );
+
+      if (failures.length > 0) {
+        throw new Error(
+          `[publisher-ad-links] failed to inject into ${failures.length} target(s):\n${failures.join('\n')}\n\n` +
+            'This re-orphans sitemap-publisher-ads.xml (audit:max-bfs-depth) — paid revenue content. ' +
+            'The target sitemap page did not exist after staticPagesFlushed (race / slug drift) ' +
+            'or had no <main>/</main>/</body> anchor. See build-plugins/shared/injectAfterMain.ts.',
+        );
+      }
+    },
+  };
+}

--- a/build-plugins/publisherAdPagesPlugin.ts
+++ b/build-plugins/publisherAdPagesPlugin.ts
@@ -32,6 +32,7 @@ import { truncateCodeUnits } from './shared/safeTruncate';
 import { composeSerpJobTitle } from './shared/titleSuffix';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { WriteCollector } from './batchWrite';
+import { resolvePublisherAdsFlushed, type EmittedPublisherAd } from './shared/buildSignals';
 import { renderPublisherMarkdown } from '../services/publisherMarkdown';
 import { generateInitialsLogo } from '../services/logoService';
 
@@ -348,14 +349,19 @@ export function publisherAdPagesPlugin(rootDir: string): Plugin {
     async closeBundle() {
       if (process.env.SKIP_PUBLISHER_AD_PAGES === '1') {
         console.log('\x1b[33m[publisher-ad-pages]\x1b[0m Skipped (SKIP_PUBLISHER_AD_PAGES=1)');
+        resolvePublisherAdsFlushed([]);
         return;
       }
       const distDir = np.resolve(rootDir, 'dist');
-      if (!fs.existsSync(distDir)) return;
+      if (!fs.existsSync(distDir)) {
+        resolvePublisherAdsFlushed([]);
+        return;
+      }
 
       const slicePath = np.resolve(rootDir, 'data/jobs/by-crawler/publisher-submitted.json');
       if (!fs.existsSync(slicePath)) {
         console.log('\x1b[33m[publisher-ad-pages]\x1b[0m no publisher-submitted.json — nothing to emit.');
+        resolvePublisherAdsFlushed([]);
         return;
       }
       let records: AdRecord[] = [];
@@ -364,10 +370,12 @@ export function publisherAdPagesPlugin(rootDir: string): Plugin {
         records = Array.isArray(parsed) ? parsed : (parsed.jobs || parsed.records || []);
       } catch (err) {
         console.warn('\x1b[33m[publisher-ad-pages]\x1b[0m slice parse failed:', err);
+        resolvePublisherAdsFlushed([]);
         return;
       }
       if (!records.length) {
         console.log('\x1b[33m[publisher-ad-pages]\x1b[0m 0 publisher ads — nothing to emit.');
+        resolvePublisherAdsFlushed([]);
         return;
       }
 
@@ -387,6 +395,7 @@ export function publisherAdPagesPlugin(rootDir: string): Plugin {
       const dateStamp = new Date().toISOString().slice(0, 10);
       const collector = new WriteCollector({ distDir, pluginName: 'publisherAdPagesPlugin' });
       const sitemapEntries: Array<{ canonical: string; alternates: string[] }> = [];
+      const emittedAds: EmittedPublisherAd[] = [];
       let pagesWritten = 0;
       let thinSkipped = 0;
       let canarySkipped = 0;
@@ -453,6 +462,14 @@ export function publisherAdPagesPlugin(rootDir: string): Plugin {
           collector.add(np.join(distDir, urlPath.replace(/\/+$/, '') + '.html'), html);
           pagesWritten++;
 
+          // Same indexable + non-canary gate as the IT-only sitemap push
+          // below, but per-locale: feeds publisherAdLinksPlugin's CTA on
+          // every locale's HTML sitemap page (audit:max-bfs-depth — paid ad
+          // content had zero crawlable inbound link anywhere on the site).
+          if (wordCount >= MIN_INDEXABLE_WORDS && !isCanaryOrTestAd(rec)) {
+            emittedAds.push({ locale, path: urlPath, label: title });
+          }
+
           // Whenever the CTA resolves to the /candidatura/ sub-page (in-house /
           // forward-email ads, plus the defensive self-link fallback), emit that
           // page too (200-status stub; the SPA mounts the apply form — see
@@ -515,6 +532,7 @@ export function publisherAdPagesPlugin(rootDir: string): Plugin {
       console.log(
         `\x1b[36m[publisher-ad-pages]\x1b[0m ${records.length} ad record(s) → ${pagesWritten} pages (${thinSkipped} noindex-thin${collisions.length ? `, ${collisions.length} slug-collision skipped` : ''}${canarySkipped ? `, ${canarySkipped} canary/test excluded from sitemap` : ''}) — flushed ${written} files.`,
       );
+      resolvePublisherAdsFlushed(emittedAds);
     },
   };
 }

--- a/build-plugins/shared/buildSignals.ts
+++ b/build-plugins/shared/buildSignals.ts
@@ -72,6 +72,8 @@ const salaryHubSignal = makeSignal();
 const jobsSeoPagesSignal = makeSignal();
 const sectorPagesSignal = makeSignal();
 const professionCantonsSignal = makeValueSignal<readonly string[]>();
+const professionCitiesSignal = makeValueSignal<readonly string[]>();
+const bfsSalarySignal = makeValueSignal<readonly string[]>();
 const salaryProfessionCantonsSignal = makeValueSignal<readonly string[]>();
 const salaryStatsSignal = makeSignal();
 
@@ -85,6 +87,15 @@ export interface EmittedFacility {
 
 const nursingLandingsSignal = makeSignal();
 const healthFacilitiesSignal = makeValueSignal<readonly EmittedFacility[]>();
+
+/** An indexable employer-profile page emitted this build, one entry per locale. */
+export interface EmittedEmployerProfile {
+  readonly locale: 'it' | 'en' | 'de' | 'fr';
+  readonly path: string;
+  readonly label: string;
+}
+
+const employerProfilesSignal = makeValueSignal<readonly EmittedEmployerProfile[]>();
 
 /** Resolves when {@link staticPagesPlugin} has flushed all its queued writes. */
 export const staticPagesFlushed: Promise<void> = staticPagesSignal.promise;
@@ -158,6 +169,64 @@ export function resolveProfessionCantonsFlushed(paths: readonly string[]): void 
 }
 
 /**
+ * Resolves with the list of canonical paths {@link professionCityLandings}
+ * actually wrote this build (job-floor + word-count gated subset of the
+ * enumerated profession×city routes). Consumed by
+ * {@link professionCityLinksPlugin}, which injects a "jobs by city and
+ * profession" link block into the per-locale HTML sitemap pages so
+ * BFS-from-`/` reaches every emitted page (closes the
+ * `sitemap-profession-cities.xml` orphan tier flagged by
+ * `audit:max-bfs-depth`, 62.65% unreachable), mirroring the
+ * professionCantonsFlushed contract.
+ */
+export const professionCitiesFlushed: Promise<readonly string[]> =
+  professionCitiesSignal.promise;
+export function resolveProfessionCitiesFlushed(paths: readonly string[]): void {
+  professionCitiesSignal.resolve(paths);
+}
+
+/**
+ * Resolves with every non-thin page path {@link bfsSalaryLandingsPlugin}
+ * actually wrote this build (age-anchor + education-level landings, all
+ * locales). The family only cross-links its own 3-nearest siblings (a
+ * disconnected island with no external inbound link), so it shipped
+ * 55.56% unreachable per `audit:max-bfs-depth`. Consumed by
+ * {@link bfsSalaryLinksPlugin}, which — since the whole family is only
+ * ~9 identities × 4 locales — links every one of them directly from the
+ * per-locale HTML sitemap page rather than relying on ring propagation.
+ */
+export const bfsSalaryFlushed: Promise<readonly string[]> = bfsSalarySignal.promise;
+export function resolveBfsSalaryFlushed(paths: readonly string[]): void {
+  bfsSalarySignal.resolve(paths);
+}
+
+/** An indexable, non-canary publisher-ad detail page emitted this build. */
+export interface EmittedPublisherAd {
+  readonly locale: 'it' | 'en' | 'de' | 'fr';
+  readonly path: string;
+  readonly label: string;
+}
+
+const publisherAdsSignal = makeValueSignal<readonly EmittedPublisherAd[]>();
+
+/**
+ * Resolves with every indexable, non-canary `/lavoro/{slug}/` publisher-ad
+ * page {@link publisherAdPagesPlugin} wrote this build. Paid ad content with
+ * no crawlable inbound link anywhere on the site (job-card renderers build
+ * their own canton/section href rather than respecting a publisher ad's own
+ * URL) — currently only 1 URL, but 100% unreachable per
+ * `audit:max-bfs-depth`, and revenue-critical (CLAUDE.md §7-adjacent: paid
+ * content must be discoverable). Consumed by {@link publisherAdLinksPlugin},
+ * which injects a CTA into the per-locale HTML sitemap page, mirroring the
+ * professionCantonsFlushed contract.
+ */
+export const publisherAdsFlushed: Promise<readonly EmittedPublisherAd[]> =
+  publisherAdsSignal.promise;
+export function resolvePublisherAdsFlushed(ads: readonly EmittedPublisherAd[]): void {
+  publisherAdsSignal.resolve(ads);
+}
+
+/**
  * Resolves once {@link nursingLandingsPlugin} has flushed its landing pages.
  * Consumed by {@link healthFacilitiesLinksPlugin} so it can safely read +
  * patch the nursing landing HTML on disk before injecting the "facilities
@@ -208,4 +277,21 @@ export function resolveSalaryProfessionCantonsFlushed(paths: readonly string[]):
 export const salaryStatsFlushed: Promise<void> = salaryStatsSignal.promise;
 export function resolveSalaryStatsFlushed(): void {
   salaryStatsSignal.resolve();
+}
+
+/**
+ * Resolves with every indexable `/aziende/{slug}/` employer-profile page
+ * {@link employerProfilePagesPlugin} wrote this build (one entry per
+ * indexable locale — below-floor noindex bridges excluded). Consumed by
+ * {@link employerProfilePagesLinksPlugin}, which injects a "Lavorare in..."
+ * link block into the per-locale HTML sitemap pages so BFS-from-`/` reaches
+ * every emitted page (closes the `sitemap-employer-profiles.xml` orphan tier
+ * flagged by `audit:max-bfs-depth`, 468/468 unreachable), mirroring the
+ * professionCantonsFlushed contract. Carries `label` (the company display
+ * name) directly since the URL slug is a one-way hash of it.
+ */
+export const employerProfilesFlushed: Promise<readonly EmittedEmployerProfile[]> =
+  employerProfilesSignal.promise;
+export function resolveEmployerProfilesFlushed(profiles: readonly EmittedEmployerProfile[]): void {
+  employerProfilesSignal.resolve(profiles);
 }

--- a/build-plugins/shared/jobDescription/toHtml.ts
+++ b/build-plugins/shared/jobDescription/toHtml.ts
@@ -149,7 +149,17 @@ export function inlineTextToHtml(text: string): string {
   // wrap section headers in `===== Cosa offriamo: =====`.
   const s = String(text).replace(/[_=~]{3,}/g, ' ').replace(/ {2,}/g, ' ');
   if (/<(strong|em|a|span|br)\b/i.test(s)) {
-    return stripExternalHtmlAttributes(s);
+    // Sources that mix real structural tags with literal, unconverted
+    // `**bold**` markdown in the same string (seen from partially
+    // pre-formatted ATS/crawler output) hit this branch. Scrub `**` here
+    // too — same as computeJobDescriptionTextToHtml's structural-tag
+    // branch above — or it leaks into <main> and trips
+    // audit:no-literal-markdown (0-tolerance, CLAUDE.md rule #1).
+    return stripExternalHtmlAttributes(
+      s
+        .replace(/\*\*\s*[\s:;,.\-–—]*\s*\*\*/g, ' ')
+        .replace(/\*\*([^*\n]{1,200}?)\*\*/g, '<strong>$1</strong>'),
+    );
   }
   return inlinesToHtml(parseInline(s));
 }

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -622,11 +622,17 @@ export async function emitChCantonEmployersPages(
       });
 
       const words = countHtmlBodyWords(html);
+      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       if (words < MIN_INDEXABLE_WORDS) {
         result.pagesSkippedForWordCount++;
+        // Same below-floor-bridge treatment as the cantonsSkipped loop below —
+        // a bare `continue` here (sibling bug class, see jobsSeoPagesPlugin.ts
+        // "Structural 404 fix" comment) leaves this locale's slot empty for a
+        // locale-partitioned CI build to fill with a different verdict.
+        collector.add(np.join(outDir, 'index.html'), renderBelowFloorBridge(locale, cantonCode));
+        result.bridgesWritten++;
         continue;
       }
-      const outDir = np.join(opts.distDir, canonicalPath.replace(/^\/+/, ''));
       collector.add(np.join(outDir, 'index.html'), html);
       result.pagesWritten++;
     }

--- a/scripts/lib/employerLandingSections.mjs
+++ b/scripts/lib/employerLandingSections.mjs
@@ -71,15 +71,31 @@ export const WEEKLY_EMPLOYERS_HUB_RX =
   /(?:^|\/)(?:aziende-che-assumono|companies-hiring|unternehmen-einstellen|firmen-die-einstellen|entreprises-recrutent|entreprises-qui-recrutent)\//;
 
 /**
+ * Evergreen employer-profile page, one per company (`/aziende/{slug}/`, IT
+ * unprefixed; `/en|/de|/fr/aziende/{slug}/` elsewhere — see
+ * `build-plugins/employerProfilePagesPlugin.ts:61`, epic #4462/#4511). A
+ * literal `/aziende/` segment never collides with the hyphenated
+ * `aziende-che-assumono` weekly-employers family above (`-` vs `/` right
+ * after the token), so match order doesn't matter here either.
+ *
+ * Same classifier-drift class as every other bucket in this file: shipped
+ * 2026-07 without a matcher, so it fell into the `spa-other`/`spa-locale`
+ * catch-all in `audit-title-length`/`audit-text-html-ratio` and regressed
+ * both baselines (2026-07-19).
+ */
+export const EMPLOYER_PROFILES_RX = /(?:^|\/)aziende\/[^/]+\/?$/;
+
+/**
  * @param {string} normalisedPath path that already starts with `/` and has had
  *   the `dist/` prefix and trailing `index.html` stripped.
- * @returns {'career-landings' | 'weekly-employers' | 'weekly-employers-hub' | null}
- *   `null` when none of the three families match — caller continues its own
+ * @returns {'career-landings' | 'weekly-employers' | 'weekly-employers-hub' | 'employer-profiles' | null}
+ *   `null` when none of the families match — caller continues its own
  *   classification chain.
  */
 export function classifyEmployerLandingFeature(normalisedPath) {
   if (CAREER_LANDINGS_RX.test(normalisedPath)) return 'career-landings';
   if (WEEKLY_EMPLOYERS_LEAF_RX.test(normalisedPath)) return 'weekly-employers';
   if (WEEKLY_EMPLOYERS_HUB_RX.test(normalisedPath)) return 'weekly-employers-hub';
+  if (EMPLOYER_PROFILES_RX.test(normalisedPath)) return 'employer-profiles';
   return null;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,7 @@ import { professionCantonLandings } from './build-plugins/professionCantonLandin
 import { salaryProfessionCantonPages } from './build-plugins/salaryProfessionCantonPages';
 import { salaryBadgeEmbedPlugin } from './build-plugins/salaryBadgeEmbedPlugin';
 import { professionCityLandings } from './build-plugins/professionCityLandings';
+import { professionCityLinksPlugin } from './build-plugins/professionCityLinksPlugin';
 import { healthPremiumsLandingPlugin } from './build-plugins/healthPremiumsLandingPlugin';
 import { exchangeRatePagesPlugin } from './build-plugins/exchangeRatePagesPlugin';
 // blogContextualLinksPlugin import retained for tests / type re-exports.
@@ -97,11 +98,14 @@ import { costOfLivingLandingsPlugin } from './build-plugins/costOfLivingLandings
 import { frontalierePillarPlugin } from './build-plugins/frontalierePillarPlugin';
 import { faqHubPlugin } from './build-plugins/faqHubPlugin';
 import { publisherAdPagesPlugin } from './build-plugins/publisherAdPagesPlugin';
+import { publisherAdLinksPlugin } from './build-plugins/publisherAdLinksPlugin';
 import { employerProfilePagesPlugin } from './build-plugins/employerProfilePagesPlugin';
+import { employerProfilePagesLinksPlugin } from './build-plugins/employerProfilePagesLinksPlugin';
 import { faqHubLinksPlugin } from './build-plugins/faqHubLinksPlugin';
 import { frSalaireNetLandingPlugin } from './build-plugins/frSalaireNetLandingPlugin';
 import { holidaysLandingsPlugin } from './build-plugins/holidaysLandingsPlugin';
 import { bfsSalaryLandingsPlugin } from './build-plugins/bfsSalaryLandingsPlugin';
+import { bfsSalaryLinksPlugin } from './build-plugins/bfsSalaryLinksPlugin';
 import { minimumWageLandingsPlugin } from './build-plugins/minimumWageLandingsPlugin';
 import { sectionPagesPlugin } from './build-plugins/sectionPagesPlugin';
 import { precompressHtmlPlugin } from './build-plugins/precompressHtmlPlugin';
@@ -371,6 +375,36 @@ export default defineConfig(({ mode }) => {
  // signals from professionCantonLandings (emitted paths) + staticPagesPlugin
  // (sitemap-page HTML). Idempotent via `data-profession-cantons-links`.
  professionCantonLandingsLinksPlugin(__dirname),
+ // Employer-profile pages orphan fix — inject an "Aziende in Svizzera" block
+ // into each locale's HTML sitemap page (main-nav reachable) so the ~468
+ // /aziende/{slug}/ pages reach BFS depth ≤ 3 instead of shipping fully
+ // unreachable (audit:max-bfs-depth, 468/468 orphaned). Awaits explicit
+ // signals from employerProfilePagesPlugin (emitted profiles) +
+ // staticPagesPlugin (sitemap-page HTML). Idempotent via
+ // `data-employer-profiles-links`.
+ employerProfilePagesLinksPlugin(__dirname),
+ // Profession×city orphan fix — inject a "jobs by city and profession" block
+ // into each locale's HTML sitemap page (main-nav reachable) so the ~208
+ // /lavoro-{city}-{role}/ pages reach BFS depth ≤ 3 instead of shipping
+ // 62.65% unreachable (audit:max-bfs-depth). Awaits explicit signals from
+ // professionCityLandings (emitted paths) + staticPagesPlugin (sitemap-page
+ // HTML). Idempotent via `data-profession-cities-links`.
+ professionCityLinksPlugin(__dirname),
+ // BFS salary-by-age/education orphan fix — inject a "salary by age and
+ // education" block into each locale's HTML sitemap page (main-nav
+ // reachable) so the ~20 stipendio-svizzera-{age|education}/ pages reach
+ // BFS depth ≤ 3 instead of shipping 55.56% unreachable
+ // (audit:max-bfs-depth). Awaits explicit signals from bfsSalaryLandingsPlugin
+ // (emitted paths) + staticPagesPlugin (sitemap-page HTML). Idempotent via
+ // `data-bfs-salary-links`.
+ bfsSalaryLinksPlugin(__dirname),
+ // Publisher-ad (paid) orphan fix — inject a "sponsored listings" CTA into
+ // each locale's HTML sitemap page (main-nav reachable) so /lavoro/{slug}/
+ // ad pages reach BFS depth ≤ 3 instead of shipping fully unreachable
+ // (audit:max-bfs-depth) — revenue-critical paid content. Awaits explicit
+ // signals from publisherAdPagesPlugin (emitted ads) + staticPagesPlugin
+ // (sitemap-page HTML). Idempotent via `data-publisher-ads-links`.
+ publisherAdLinksPlugin(__dirname),
  // Salary-intent profession×canton orphan fix — inject a "salary by profession
  // and canton" block into each locale HTML sitemap page (main-nav reachable) so
  // the /stipendio-{prof}-{canton}/ pages reach BFS depth ≤ 2 instead of shipping


### PR DESCRIPTION
## Implementato

Root-caused and fixed all 4 gates failing on [run 29692957521](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29692957521/job/88208801646) (`validate-dist` / `validate-dist-postbuild`).

**1. `audit:sitemap-canonicals` + `validate:sitemap-pages` (31 self-canonicalize / noindex-in-sitemap offenders)**
- `build-plugins/professionCantonLandings.ts`: the word-count-gate branch did a bare `continue` instead of writing the below-floor bridge its own `liveCount<MIN_JOBS` branch writes a few lines above. On the locale-partitioned CI build (`scripts/ci/prune-locale-shard.mjs`), different locale shards can reach different word-count verdicts for the same (canton, profession) pair — the "losing" shard's slot stayed empty while another shard's sitemap still listed the path as self-canonical.
- Same sibling bug, same fix, in `build-plugins/weeklyEmployersChCantonPages.ts`, `build-plugins/jobMarketSnapshotChCantonPages.ts`, and `build-plugins/professionCityLandings.ts` (the last one wasn't named in the existing sibling-bug comment in `jobsSeoPagesPlugin.ts` — found by direct inspection of the same page-family shape). `build-plugins/salaryProfessionCantonPages.ts` already had the bridge in both branches — verified, no fix needed.

**2. `audit:no-literal-markdown` (4 pages)**
- `build-plugins/shared/jobDescription/toHtml.ts`: `inlineTextToHtml`'s "already has structural HTML tags" branch skipped the `**bold**`/separator-run scrub that `computeJobDescriptionTextToHtml` applies in the equivalent branch — bullet fields whose source mixed a real tag (`<strong>`/`<em>`/`<a>`/`<span>`/`<br>`) with literal markdown leaked `**` into `<main>`. Added the same scrub. Smoke-tested against a mixed-format string.

**3. `audit:title-length` / `audit:text-html-ratio` (spa-other/spa-locale regression)**
- `scripts/lib/employerLandingSections.mjs`: the new `/aziende/{slug}/` employer-profile family (epic #4462, PR #4511) had no matcher in `classifyEmployerLandingFeature`, so it fell into the `spa-other`/`spa-locale` catch-all bucket whose baselines predate the family. Added `EMPLOYER_PROFILES_RX` + an `employer-profiles` bucket — both audits already call this shared classifier first, so no per-audit change needed. Verified the regex doesn't collide with the existing `aziende-che-assumono` weekly-employers family (`/` vs `-` right after the token) with a grouping smoke test.
- **Not verified pre-merge:** whether the new `employer-profiles` bucket itself now passes its *own* first-run rate check (baseRate=0, tolerance ~1pp/5 offenders — see `scripts/audit-title-length.mjs`'s `DEFAULT_TOL`). Real Swiss company names can exceed the ~22–25 char budget left by the title template's fixed prefix/suffix, and this codebase's own documented policy (`audit-title-length.mjs` header comment) is uniqueness-over-length, so I did **not** truncate company names to force compliance. Needs a live post-merge run to confirm; if the new bucket fails, next step is `--write-baseline` (the same remediation the bfs-depth gate itself prints), not a template rewrite.

**4. `audit:max-bfs-depth` (7 new sitemap shards, majority unreachable)**
| Shard | Before | Fix |
|---|---|---|
| `sitemap-employer-profiles.xml` | 468/468 (100%) | New `employerProfilePagesLinksPlugin.ts` |
| `sitemap-profession-cities.xml` | 208 (62.65%) | New `professionCityLinksPlugin.ts` |
| `sitemap-bfs-salary.xml` | 20 (55.56%) | New `bfsSalaryLinksPlugin.ts` — links all 9 identities/locale (ring propagation alone doesn't reach every node) |
| `sitemap-publisher-ads.xml` | 1 (100%) | New `publisherAdLinksPlugin.ts` (revenue-critical paid content) |
| `sitemap-health-facilities.xml` | 436 (98.2%) | `healthFacilitiesLinksPlugin.ts`: cap 8→24 + `nurses`/`oss` now pick disjoint even/odd slices instead of the identical top-8 (the file's own doc comment described a topical split that was never actually implemented — no per-facility field exists to do that, so used ranking parity instead) |
| `sitemap-eventi.xml` | 223 (14.99%) | `eventsSeoPagesPlugin.ts`: raised the date-sorted tail-list caps (40→80, 60→100, cross-link 6→10) |
| `sitemap-salary-stats.xml` | 8 (8.33%) | **Not found** — see below |

All 4 new `*LinksPlugin.ts` follow the existing `professionCantonLandingsLinksPlugin.ts` pattern: inject a link block into each locale's HTML sitemap page (`/mappa-del-sito/` etc., main-nav reachable, depth ≤3), gated on explicit `buildSignals.ts` producer/consumer promises so the injector never runs before its emitter has flushed. Each new signal resolves `[]` on every early-return path (checked against the source plugin's own SKIP/missing-data guards).

## Non implementato (ancora)

- **`sitemap-salary-stats.xml`'s 8 orphaned URLs (8.33%, smallest of the 7 shards)** — investigated and ruled out a canton-key-mismatch hypothesis (`professionCantonLandings.ts`'s `PROFESSION_CANTON_KEYS` derives from the same `SALARY_STATS_CANTON_KEYS` list that indexes `SALARY_STATS_CANTON_SLUGS`, so no lookup mismatch). This family already has the most extensive existing inbound-link network of the 7 (5+ separate CTA/bridge sources per the investigation). Pinpointing the exact 8 URLs needs live crawl data I can't produce locally (no full SEO build per repo policy). **Next step:** post-merge, run `gh workflow run audit-dist-from-run.yml -f deploy_run_id=<next-deploy> -f audits=max-bfs-depth` and patch the specific gap with the precise offender list.
- **`build-plugins/salaryStatsChCantonPages.ts:466-468`** — same word-count-skip-without-bridge shape as the 4 files fixed above, surfaced by `check-sibling-patterns.mjs`. Different risk profile: this family's word count is driven by static BFS salary data, not fluctuating live job counts, so the cross-shard-divergence mechanism that caused bug #1 is far less likely to trigger here — but if it ever does, every plugin that builds a `buildSalaryStatsPath` CTA (5+ call sites) would dangle. **Next step:** dedicated follow-up PR — confirm whether this ever actually fires (add build-time logging or check historical `pagesSkippedForWordCount` counts) before deciding bridge vs. accept.
- **`build-plugins/fuelDailyPagesPlugin.ts`** (6 word-count-skip sites, lines ~5284–5417) — surfaced by the sibling-pattern check via shared `emittedPaths`/`MIN_INDEXABLE_WORDS` tokens. This is a large (5000+ line), fully separate subsystem (daily fuel/gas-station pricing, not job-canton listings) with its own floor semantics I haven't studied — deep-diving it was out of proportion for this PR and it isn't implicated in any of the 4 failing gates. **Next step:** separate dedicated audit of fuel-daily's floor/bridge conventions.

### Sibling-pattern check — remaining 59 of 62 candidates individually reviewed, false positive

`node scripts/ci/check-sibling-patterns.mjs` (pre-push `--strict`) surfaced 62 files sharing tokens with this diff. The 3 above are genuine follow-ups. Every other file was opened and checked against the actual bug (silent `continue` without a below-floor bridge write, or a missing classifier bucket) — none reproduce it:

- **Already-correct siblings of bug #1** (verified via direct read, bridge already written in the word-count branch): `salaryProfessionCantonPages.ts`, `healthFacilitiesPlugin.ts` (uses an `every(...) ? full : bridge` shape, not a loop-continue). `weeklyEmployersPlugin.ts` pre-filters bridge pages via a `page.bridge` flag before the word-count check (own comment confirms). `jobMarketSnapshotPlugin.ts`'s word-count-skip is on a *different*, fixed-size (~14) sector-page family with an extensive doc comment explicitly justifying no bridge (no per-sector "old" state, unlike job-count-driven cantons — "thin content handled upstream of noindex entirely... never written to disk... rather than noindex'd").
- **Already self-mapped, no gap** — `searchConsoleCompat.ts` already registers `isProfessionCantonPath`, `isProfessionCityPath`, and `EMPLOYER_PROFILE_PATH_RX` self-maps; these cover above-floor pages *and* below-floor bridges identically since both use the same URL-shape helper.
- **Tooling / CI / doc cross-references, not duplicated logic**: `.github/workflows/refresh-employer-profiles.yml`, `.github/workflows/seed-text-html-ratio-baseline.yml`, `scripts/ci/check-below-floor-bridge.mjs`, `scripts/update-bfs-salary-by-age.mjs`, `scripts/generate-health-facilities-jobs.mjs`, `scripts/mine-search-location-gaps.mjs`, `scripts/report-salary-intent-floor.mjs`, `scripts/profession-keyword-opportunities.mjs`, `scripts/check-canonicals.py`, `scripts/probe-urls.txt`, `scripts/validate-critical-dist-pages.mjs`, `scripts/analytics-report.mjs`, `scripts/audit-bfs-depth.mjs`, `services/publisherMarkdown.ts`, `services/seo/seo-pages.ts`, `build-plugins/shared/jobPostingSchema.ts`, `build-plugins/shared/brandCanonicalMap.ts` — each matched only because it mentions the family name/constant in a comment or cross-reference, not because it reimplements the emission loop.
- **Shared classifier consumers that already inherit the fix via import** (no duplicate `spa-locale`/`spa-other` fallback of their own): `scripts/audit-dist-multi.mjs` (re-imports `classifyFeature` directly from `audit-title-length.mjs`/`audit-text-html-ratio.mjs` — not wired into any CI gate, `npm run audit:dist-multi` only), `scripts/audit-page-weight.mjs`, `scripts/lib/auditReport.mjs`, `scripts/measure-l2-distribution.mjs`, `build-plugins/jobsSeoPagesPlugin.ts`.
- **Generic shared domain vocabulary** (`cantonKey`, `PROFESSION_LOCALES`, `buildProfessionCantonPath`/`buildProfessionCityPath`, `emittedPaths`, `bridgesWritten`, `healthcare-ticino`, `career-landings`, `weekly-employers-hub`, `mappa-del-sito`) used for unrelated purposes across the codebase's ~200 build-plugins, not a duplicated bug pattern: `professionCantonLandingsLinksPlugin.ts`, `professionCantonData.ts`, `salaryProfessionCantonLinksPlugin.ts`, `professionCityData.ts`, `salaryProfessionCantonData.ts`, `build-plugins/shared/cantonSalaryIndex.ts`, `cantonNoindexRegistry.ts`, `cantonSectorPageRegistry.ts`, `cantonSeoProse.ts`, `companyHubFrontalierContext.ts`, `landingHeroPersonality.ts`, `relatedLinks.ts` (its `HEALTH_PREMIUM_AGE_LABEL` is unrelated to my new `AGE_LABEL` — different module, coincidental substring), `salaryLandingShell.ts`, `salaryStatsBridge.ts`, `scripts/lib/bfs-stats-parser.mjs` (its `COL_AGE_LABEL` is a CSV column index, same coincidental substring), `localeTableCompletenessPlugin.ts`, `nursingJobsAggregate.ts`, `nursingLandingsCopy.ts`, `nursingLandingsData.ts`, `nursingLandingsPlugin.ts`, `professionLandingsData.ts`, `professionLandingsLinksPlugin.ts`, `professionLandingsPlugin.ts`, `salaryStatsData.ts`, `careerLandingsPlugin.ts`, `costOfLivingLandingsPlugin.ts`, `companyProfileSlug.mjs`, `fuelStationIndexPages.ts` (its `emittedPaths` is a `ReadonlySet` membership check, not an emission loop), `components/pages/SiteMapPage.tsx` (`LinkItem` is a generic interface name, unrelated to my new `LinkItem` interfaces which are file-local, not shared).

## Test plan

- [x] `tsc --noEmit` clean on every touched file (0 new errors; pre-existing unrelated errors in `AdminPanel.tsx`/`JournalistDashboardPage.tsx`/`PublisherDashboardPage.tsx` untouched by this diff)
- [x] `npx vitest run` — 22 targeted suites covering every touched module (`profession-canton-landings`, `canton-ti-misclassification-guard`, `publisher-ad-page-render`, `salary-profession-canton`, `health-facilities`, `employer-profile-pages`, `bfs-salary-landings`, `profession-canton-links-injection`, `ch-canton-below-floor-bridge`, `events-digest`, `below-floor-bridge-locale-shard`, `build-plugin-order`, `ch-canton-hreflang`, `compose-place-title`, `search-console-compat`, `job-description-parser`, `events-detail-pages`, `events-pipeline`, `seo-static-ad-slots`, `employer-landing-section-classifier`, `static-job-page-body`, `inline-text-to-html-sanitize`) — 369/369 passing
- [x] Manual smoke tests (tsx, ad hoc) for every new pure function: `inlineTextToHtml` mixed-markdown scrub, `classifyEmployerLandingFeature` grouping vs. `aziende-che-assumono` collision, `buildEmployerLinkItems`/`buildCityLinkItems`/`buildBfsSalaryLinkItems`/`buildPublisherAdLinkItems` grouping+sort, `buildCityLinkItems` round-tripped against all 1056 real enumerated profession×city routes, `buildBfsSalaryLinkItems` round-tripped against all 36 real enumerated age/education routes, health-facilities even/odd parity split confirmed disjoint
- [ ] Live confirmation that `audit:sitemap-canonicals`, `audit:no-literal-markdown`, `audit:title-length`, `audit:text-html-ratio`, `audit:max-bfs-depth` all pass on the next `validate-dist` run — cannot run the full SEO build locally (3.2M pages, OOM-prone, repo policy requires CI/audit-replay) — will watch the next post-deploy `validate-dist` run and iterate if any gate still fails
