### PR TITLE
fix(deploy): section-split-aware main-shard shrink guard (en/fr stale)

### DIFF
--- a/scripts/lib/push-locale-shard.sh
+++ b/scripts/lib/push-locale-shard.sh
@@ -88,6 +88,17 @@ push_shard() {
   src_n="$(find "$dist_dir/$loc" -type f | wc -l)"
   prev_n="$(curl -fsS "https://raw.githubusercontent.com/valerielinc-ops/frontaliere-$loc/main/.shard-filecount" 2>/dev/null || echo 0)"
   [[ "$prev_n" =~ ^[0-9]+$ ]] || prev_n=0
+  # Files removed from THIS locale's dist subtree by the "Strip section
+  # subtrees" step that ran BEFORE this push — section shards (svizzera /
+  # zurigo / ticino) that are now LIVE in their own repos. strip-section-
+  # subtree.sh gates the strip on the section shard's push ok-marker, so that
+  # content is already verified-live elsewhere; the main shard shrinks by
+  # exactly this many files as a PLANNED split, not a build regression. We add
+  # it back below to reconstruct the BUILT (pre-strip) size for gate (b), so a
+  # section going live no longer trips the >50% shrink guard (incident jul20).
+  # Absent marker (local run / no strip) → 0 → identical to the old behaviour.
+  stripped_n="$(cat "${RUNNER_TEMP}/shard-stripped-$loc" 2>/dev/null || echo 0)"
+  [[ "$stripped_n" =~ ^[0-9]+$ ]] || stripped_n=0
   # EVERYTHING that builds the shard tree AND pushes runs inside one
   # `set -e` subshell with the integrity gates before the push. A failed
   # copy / truncated tree ABORTS before push: a monco tree is never
@@ -174,20 +185,31 @@ push_shard() {
     if [ -f "$dist_dir/$loc.html" ]; then cp "$dist_dir/$loc.html" "$stage/$loc.html"; fi  # homepage at /{loc}
     printf '<!doctype html><meta charset=utf-8><title>frontaliereticino.ch %s shard</title>' "$loc" > "$stage/index.html"
     n="$(find "$stage/$loc" -type f | wc -l)"
+    # BUILT size = the shard as EMITTED by the build, before the "Strip section
+    # subtrees" step removed already-verified-live section subtrees. Gate (b)
+    # reasons on THIS (not the smaller served $n) so a populate-then-strip
+    # section split — which drops served files but not built files — reads flat
+    # instead of as a >50% regression. stripped_n is 0 on a normal (no-strip)
+    # run, so built_n == n and the behaviour is identical to before.
+    built_n="$(( n + stripped_n ))"
     # (a) copy integrity: the staged subtree must have AT LEAST as many
     #     files as the source — a partial cp (disk-full) lands fewer → abort.
     test -s "$stage/$loc/index.html"
     [ "$n" -ge "$src_n" ]
-    # (b) regression guard: refuse a push that would shrink the shard
-    #     >50% vs its last-published count (suspected upstream build
-    #     regression emitting a partial locale). First seed → prev_n 0 → skip.
-    if [ "$prev_n" -gt 0 ] && [ "$((n * 2))" -lt "$prev_n" ]; then
-      echo "::error::$loc shard would shrink $prev_n -> $n files (>50%) — refusing push (suspected build regression)"
+    # (b) regression guard: refuse a push whose BUILT tree shrank >50% vs its
+    #     last-published high-water (a genuine upstream partial-locale build).
+    #     Compares built_n (served + section-stripped) so a planned section
+    #     split passes while a real partial build is still caught. The recorded
+    #     high-water below is likewise the BUILT size, keeping the comparison
+    #     consistent across the seed → split transition. First seed → prev_n 0
+    #     → skip.
+    if [ "$prev_n" -gt 0 ] && [ "$((built_n * 2))" -lt "$prev_n" ]; then
+      echo "::error::$loc shard would shrink $prev_n -> $built_n built files ($n served + $stripped_n section-stripped) (>50%) — refusing push (suspected build regression)"
       exit 1
     fi
-    printf '%s' "$n" > "$stage/.shard-filecount"   # high-water-mark for the next run's gate (b)
+    printf '%s' "$built_n" > "$stage/.shard-filecount"   # high-water-mark (BUILT size) for the next run's gate (b)
     printf '%s' "$((dcount + 1))" > "$stage/.shard-deploys"  # commits since last flatten (history-cap counter)
-    echo "$loc shard: $(du -sh "$stage" 2>/dev/null | cut -f1), $n files (src $src_n, prev $prev_n, incremental=$incremental, deploys-since-flatten=$((dcount + 1)))"
+    echo "$loc shard: $(du -sh "$stage" 2>/dev/null | cut -f1), $n files served / $built_n built (src $src_n, section-stripped $stripped_n, prev $prev_n, incremental=$incremental, deploys-since-flatten=$((dcount + 1)))"
     cd "$stage"
     git config user.email "valerielinc@gmail.com"
     git config user.name "Valerie Linc"

--- a/scripts/lib/strip-section-subtree.sh
+++ b/scripts/lib/strip-section-subtree.sh
@@ -63,6 +63,22 @@ if [ ! -d "$dist_dir/$sub" ]; then
   exit 0
 fi
 
+# Count the files we are about to remove BEFORE deleting them, then add the
+# tally to a per-locale accumulator marker. push-locale-shard.sh reads it so
+# its >50% shrink guard can reconstruct the BUILT (pre-strip) shard size and
+# NOT mistake this PLANNED section split for a partial-build regression. This
+# strip only runs after BOTH gates above (section shard LIVE + push ok-marker),
+# so the removed content is already verified-live on its own shard — the main
+# shard legitimately shrinks by exactly this many files. Without the tally the
+# main-shard push refuses the (correctly) smaller shard and the locale freezes
+# stale (incident jul20: en/fr main shards stuck when svizzera+zurigo went live
+# — 403338→186096 read as a >50% regression).
+n_stripped="$(find "${dist_dir:?}/$sub" -type f 2>/dev/null | wc -l | tr -d ' ')"
+[[ "$n_stripped" =~ ^[0-9]+$ ]] || n_stripped=0
 # Guarded `${dist_dir:?}` so an unset var can never expand `rm -rf /$sub`.
 rm -rf "${dist_dir:?}/$sub"
-echo "stripped $dist_dir/$sub from dist (now served by the $section-$loc shard via the Worker)"
+acc="${RUNNER_TEMP:-/tmp}/shard-stripped-$loc"
+prev_acc="$(cat "$acc" 2>/dev/null || echo 0)"
+[[ "$prev_acc" =~ ^[0-9]+$ ]] || prev_acc=0
+printf '%s' "$(( prev_acc + n_stripped ))" > "$acc"
+echo "stripped $dist_dir/$sub from dist ($n_stripped files; now served by the $section-$loc shard via the Worker)"


### PR DESCRIPTION
## Root cause (evidence-based, not a page regression)

The en/fr **main** locale shards (`origin-en/-fr.frontaliereticino.ch`) have been frozen stale since the last seed-phase push (commit 75600613). This is **NOT** a build/page-generation regression — every SSG family generates identical counts in the good vs bad run (clusters 329997=329997, soft-landing 161396→161725, job pages 69272→69332, cf-hot-404 ~397K both). It is a **section-shard split transition**:

- **Good run** (75600613): `SVIZZERA_SHARD_LIVE`/`ZURIGO_SHARD_LIVE` empty → seed phase → svizzera+zurigo subtrees **kept** in the main en shard → **403338** files.
- **Bad run** (e3f356d9, issues 4559/4560): both vars flipped `true` → section shards pushed successfully (`✅ pushed svizzera-en`, `✅ pushed zurigo-en`) and `strip-section-subtree.sh` **removed** `find-jobs-switzerland` (170185) + `find-jobs-zurich` (47031) from `dist/en` → **186096** files.

`403338 − 170185 − 47031 = 186122 ≈ 186096`. The drop is *exactly* the two sections moving to their own shards — verified by cloning the stale en shard (`find-jobs-switzerland`=170185, `find-jobs-zurich`=47031 top-level dirs). fr mirrors this (402728→190115). de was unaffected because its sections went live in an earlier cycle (its high-water 253345 already excludes them).

`push-locale-shard.sh`'s `>50%` shrink guard compared the **served** (post-strip 186096) count against the **seed-phase** high-water (403338) and refused the push as a "suspected build regression". The guard was unaware of the planned, verified-live section split (populate-then-strip: the strip is gated on the section shard's push ok-marker).

## Implementato

- **`scripts/lib/strip-section-subtree.sh`**: counts the files it removes and accumulates them into a per-locale marker `$RUNNER_TEMP/shard-stripped-<loc>` (summed across ticino/svizzera/zurigo).
- **`scripts/lib/push-locale-shard.sh`**: reads that marker (`stripped_n`), reconstructs the **BUILT** (pre-strip) size `built_n = n + stripped_n`, gates the `>50%` regression check (b) on `built_n`, and records `built_n` as the new `.shard-filecount` high-water so the comparison stays consistent across the seed→split transition. `stripped_n` defaults to `0` (local / no-strip run) → byte-identical to prior behaviour.
- **Verified locally** by exercising the real scripts on a fake dist reproducing the incident: strip tally exact (500+1701+470=2671), `built_n` reconstruction exact, guard **PASSES** the split (old code TRIPS — bug reproduced). Scenario matrix confirms a genuine `>50%` partial build is **still refused** (65k<403k → REFUSE) and near-empty is refused, so the guard's original sensitivity is preserved. `tests/seo/cathedral-no-ti-hardcodes.test.ts` passes 5/5 (no new TI slug literals; edits use generic `$sub`/`$loc`).

Closes #4559
Closes #4560

## Non implementato (ancora)

Nessuno scope residuo. Note di completezza:

- **`scripts/lib/push-section-shard.sh`** (flaggato dal pre-push sibling-pattern hook, stesso costrutto `[ "$((n * 2))" -lt "$prev_n" ]`): **falso positivo, non un fix posposto.** Quello script pusha i shard *leaf* di sezione (`frontaliere-svizzera-en` …), staggati DIRETTAMENTE dal subtree pieno (`cp -al "$stage_src/dist/$sub"`, riga 164) **senza** alcuno strip pre-push — lo strip gira DOPO, solo sul main shard. Per un section shard `served == built` sempre, quindi non esiste `stripped_n` da sommare e la sua guard è semanticamente corretta (un `>50%` shrink lì È una regressione reale). Costrutto lessicalmente uguale, precondizione buggata (strip pre-push) assente → nessuna modifica dovuta.
- **Verifica live post-merge**: il prossimo deploy naturale su `main` deve ripubblicare en/fr al conteggio built (~403K high-water) senza tripare la guard; confermerò con un nuovo commit su `valerielinc-ops/frontaliere-en` / `-fr` con timestamp successivo al merge, poi chiuderò le issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)