### PR TITLE
fix(seo): unblock double-validated profession-gap keyword pages

### DIFF
--- a/data/gsc-orphan-queries-clusters.json
+++ b/data/gsc-orphan-queries-clusters.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-20T06:30:48.275Z",
+  "generatedAt": "2026-07-20T06:53:38.359Z",
   "sourceFile": "data/gsc-orphan-queries.json",
   "totalClusters": 1212,
   "gates": {

--- a/data/keyword-pages-config.json
+++ b/data/keyword-pages-config.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-20T06:30:47.134Z",
+  "generatedAt": "2026-07-20T06:52:41.997Z",
   "totalQueriesAnalyzed": 4983,
   "qualifyingQueries": 310,
   "clustersFound": 163,
@@ -1088,6 +1088,94 @@
           "title": "Ergoterapista Ticino - Posizioni Aperte | Frontaliere Ticino",
           "description": "Offerte di lavoro per \"ergoterapista ticino\". Annunci da aziende svizzere aggiornati quotidianamente con link diretto alla candidatura.",
           "heading": "Ergoterapista Ticino"
+        }
+      }
+    },
+    {
+      "slug": "giardiniere-ticino",
+      "query": "giardiniere ticino",
+      "filterKeywords": [
+        "giardin"
+      ],
+      "totalClicks": 0,
+      "totalImpressions": 4,
+      "queryCount": 1,
+      "allQueries": [
+        "giardiniere ticino"
+      ],
+      "source": "profession-gap",
+      "professionId": "giardiniere",
+      "copy": {
+        "it": {
+          "title": "Giardiniere Ticino - Posizioni Aperte | Frontaliere Ticino",
+          "description": "Offerte di lavoro per \"giardiniere ticino\". Annunci da aziende svizzere aggiornati quotidianamente con link diretto alla candidatura.",
+          "heading": "Giardiniere Ticino"
+        }
+      }
+    },
+    {
+      "slug": "operatore-cnc-ticino",
+      "query": "operatore cnc ticino",
+      "filterKeywords": [
+        "cnc"
+      ],
+      "totalClicks": 0,
+      "totalImpressions": 0,
+      "queryCount": 1,
+      "allQueries": [
+        "operatore cnc ticino"
+      ],
+      "source": "profession-gap",
+      "professionId": "tecnico-cnc",
+      "copy": {
+        "it": {
+          "title": "Operatore Cnc Ticino - Posizioni Aperte | Frontaliere Ticino",
+          "description": "Offerte di lavoro per \"operatore cnc ticino\". Annunci da aziende svizzere aggiornati quotidianamente con link diretto alla candidatura.",
+          "heading": "Operatore Cnc Ticino"
+        }
+      }
+    },
+    {
+      "slug": "piastrellista-ticino",
+      "query": "piastrellista ticino",
+      "filterKeywords": [
+        "piastrell"
+      ],
+      "totalClicks": 0,
+      "totalImpressions": 0,
+      "queryCount": 1,
+      "allQueries": [
+        "piastrellista ticino"
+      ],
+      "source": "profession-gap",
+      "professionId": "piastrellista",
+      "copy": {
+        "it": {
+          "title": "Piastrellista Ticino - Posizioni Aperte | Frontaliere Ticino",
+          "description": "Offerte di lavoro per \"piastrellista ticino\". Annunci da aziende svizzere aggiornati quotidianamente con link diretto alla candidatura.",
+          "heading": "Piastrellista Ticino"
+        }
+      }
+    },
+    {
+      "slug": "carpentiere-ticino",
+      "query": "carpentiere ticino",
+      "filterKeywords": [
+        "carpent"
+      ],
+      "totalClicks": 0,
+      "totalImpressions": 0,
+      "queryCount": 1,
+      "allQueries": [
+        "carpentiere ticino"
+      ],
+      "source": "profession-gap",
+      "professionId": "carpentiere",
+      "copy": {
+        "it": {
+          "title": "Carpentiere Ticino - Posizioni Aperte | Frontaliere Ticino",
+          "description": "Offerte di lavoro per \"carpentiere ticino\". Annunci da aziende svizzere aggiornati quotidianamente con link diretto alla candidatura.",
+          "heading": "Carpentiere Ticino"
         }
       }
     }

--- a/scripts/generate-keyword-pages-config.mjs
+++ b/scripts/generate-keyword-pages-config.mjs
@@ -220,7 +220,6 @@ for (const cluster of topClusters) {
 // weekly (URL churn). A carried page is dropped only when a DEDICATED
 // landing (profession/nursing hub) takes over its profession.
 const OPPORTUNITIES_PATH = path.join(ROOT, 'data/profession-keyword-opportunities.json');
-const FEED_MIN_ONSITE = 25; // on-site searches in the window
 const FEED_MAX_NEW_PAGES = 10; // per run
 
 if (fs.existsSync(OPPORTUNITIES_PATH)) {
@@ -254,7 +253,11 @@ if (fs.existsSync(OPPORTUNITIES_PATH)) {
     for (const o of opp.opportunities || []) {
       if (fed >= FEED_MAX_NEW_PAGES) break;
       if (usedProfessions.has(o.id)) continue;
-      if (!o.doubleValidated || o.onsiteCount < FEED_MIN_ONSITE) continue;
+      // Trust doubleValidated as-is (onsite >= DOUBLE_VALIDATED_MIN_ONSITE
+      // already baked in upstream) — a second, stricter local floor here
+      // previously left true double-validated gaps (onsite 10-24) stuck in
+      // the weekly report forever, never promoted to a page (#4564).
+      if (!o.doubleValidated) continue;
       // Literal-match support: jobsSeoPagesPlugin filters with
       // `filterKeywords: [feedFilter]` (single substring) and skips pages
       // with <3 matching jobs — feeding below that produces a page that

--- a/scripts/lib/profession-taxonomy.mjs
+++ b/scripts/lib/profession-taxonomy.mjs
@@ -23,6 +23,16 @@
  *    hypothetical single-word "assistente" alias.
  */
 
+// Double-validation knobs (demand AND supply confirmed) — single source of
+// truth for both profession-keyword-opportunities.mjs (ranking) and
+// generate-keyword-pages-config.mjs (profession-gap feed gate). Keeping one
+// constant means a gap flagged "doppia validazione ✅" in the weekly report
+// is always eligible to become a page; a second, independently-tuned floor
+// in the feed script previously left true double-validated gaps (onsite
+// 10-24) stuck in the report forever without ever generating a page (#4564).
+export const DOUBLE_VALIDATED_MIN_ONSITE = 10; // on-site searches in window
+export const DOUBLE_VALIDATED_MIN_JOBS = 3; // live matching job ads (mirrors jobsSeoPagesPlugin's ≥3 gate)
+
 /** Lowercase, strip accents, collapse every non-alphanumeric run to a space. */
 export function normalizeText(text) {
   return String(text || '')

--- a/scripts/profession-keyword-opportunities.mjs
+++ b/scripts/profession-keyword-opportunities.mjs
@@ -37,6 +37,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   PROFESSION_TAXONOMY,
+  DOUBLE_VALIDATED_MIN_ONSITE,
+  DOUBLE_VALIDATED_MIN_JOBS,
   classifySearchTerm,
   matchProfession,
   normalizeText,
@@ -57,8 +59,10 @@ const OUTPUT_PATH = path.join(ROOT, 'data/profession-keyword-opportunities.json'
 // Ranking knobs — documented, deterministic. Double validation (demand AND
 // supply) is what makes a landing convert right away, so it dominates the
 // sort; the score only orders within the same validation bucket.
-const DOUBLE_VALIDATED_MIN_ONSITE = 10; // searches in window
-const DOUBLE_VALIDATED_MIN_JOBS = 3; // live matching job ads (mirrors jobsSeoPagesPlugin's ≥3 gate)
+// DOUBLE_VALIDATED_MIN_ONSITE / DOUBLE_VALIDATED_MIN_JOBS live in
+// lib/profession-taxonomy.mjs (imported above) — shared with
+// generate-keyword-pages-config.mjs so the feed's eligibility gate can never
+// drift stricter than what this report already calls "✅ doppia validazione".
 const JOB_COUNT_SCORE_CAP = 150; // huge generic supply must not drown intent
 const MAX_UNMAPPED_REPORTED = 30;
 

--- a/tests/profession-gap-double-validated-gate.test.ts
+++ b/tests/profession-gap-double-validated-gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { DOUBLE_VALIDATED_MIN_ONSITE, DOUBLE_VALIDATED_MIN_JOBS } from '../scripts/lib/profession-taxonomy.mjs';
+
+/**
+ * Drift guard for #4564: profession-keyword-opportunities.mjs flags a gap
+ * "✅ doppia validazione" once onsite >= DOUBLE_VALIDATED_MIN_ONSITE (10) AND
+ * enough matching job ads exist. generate-keyword-pages-config.mjs's
+ * profession-gap feed is what actually turns that flag into a live page —
+ * it previously re-checked a second, independently-tuned, stricter local
+ * floor (`onsiteCount >= 25`) on top of `doubleValidated`, so any gap with
+ * onsite in [10, 24] sat in the weekly report forever, correctly flagged
+ * "✅" but never promoted to a page. Fixed by trusting `doubleValidated` as
+ * the single source of truth (shared constants below) instead of a second
+ * copy-pasted threshold that could silently drift stricter again.
+ */
+
+const ROOT = resolve(import.meta.dirname, '..');
+const OPPORTUNITIES_SRC = readFileSync(resolve(ROOT, 'scripts/profession-keyword-opportunities.mjs'), 'utf-8');
+const FEED_SRC = readFileSync(resolve(ROOT, 'scripts/generate-keyword-pages-config.mjs'), 'utf-8');
+
+describe('DOUBLE_VALIDATED thresholds (#4564 drift guard)', () => {
+  it('are the expected values (catches an accidental rename/retune of the shared consts)', () => {
+    expect(DOUBLE_VALIDATED_MIN_ONSITE).toBe(10);
+    expect(DOUBLE_VALIDATED_MIN_JOBS).toBe(3);
+  });
+
+  it('profession-keyword-opportunities.mjs imports the shared consts instead of a local literal', () => {
+    expect(
+      /import\s*\{[^}]*\bDOUBLE_VALIDATED_MIN_ONSITE\b[^}]*\}\s*from\s*'\.\/lib\/profession-taxonomy\.mjs'/.test(OPPORTUNITIES_SRC),
+      "profession-keyword-opportunities.mjs must import DOUBLE_VALIDATED_MIN_ONSITE from './lib/profession-taxonomy.mjs'",
+    ).toBe(true);
+    expect(
+      /^\s*const DOUBLE_VALIDATED_MIN_ONSITE\s*=/m.test(OPPORTUNITIES_SRC),
+      'profession-keyword-opportunities.mjs must not re-declare DOUBLE_VALIDATED_MIN_ONSITE locally',
+    ).toBe(false);
+  });
+
+  it('the profession-gap feed trusts doubleValidated without a redundant stricter local onsite floor', () => {
+    expect(
+      FEED_SRC.includes('if (!o.doubleValidated) continue;'),
+      'generate-keyword-pages-config.mjs must gate the profession-gap feed on doubleValidated alone',
+    ).toBe(true);
+    expect(
+      /FEED_MIN_ONSITE/.test(FEED_SRC),
+      'generate-keyword-pages-config.mjs must not reintroduce a second, stricter onsite floor (the #4564 dead zone)',
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

`scripts/profession-keyword-opportunities.mjs` flags a profession gap "✅ doppia validazione" once on-site search demand (≥10 searches/60d) AND real job-ad supply (≥3 matching ads) are both confirmed — `DOUBLE_VALIDATED_MIN_ONSITE`/`DOUBLE_VALIDATED_MIN_JOBS`. `scripts/generate-keyword-pages-config.mjs`'s profession-gap feed is what turns that flag into a live `/xxx-ticino/` keyword page every Monday — but it re-checked a second, independently-tuned, stricter floor (`onsiteCount >= 25`) on top of `doubleValidated`. Any gap with onsite in `[10, 24]` was correctly marked "✅" in the weekly report yet never promoted to a page, forever.

This is exactly why the top opportunities in #4564 (Giardiniere onsite=19, Operatore CNC onsite=20, Piastrellista onsite=14, Carpentiere onsite=11) kept recurring week after week without ever generating a page — real matched search demand + real matched job supply, sitting unactioned.

- Moved `DOUBLE_VALIDATED_MIN_ONSITE`/`DOUBLE_VALIDATED_MIN_JOBS` into `scripts/lib/profession-taxonomy.mjs` (single source of truth for both scripts, no drift possible).
- Removed the redundant `FEED_MIN_ONSITE=25` local floor in the feed; it now trusts `doubleValidated` alone.
- Added `tests/profession-gap-double-validated-gate.test.ts` — drift guard asserting both scripts stay wired to the shared constants and the redundant floor never comes back.
- Re-ran `generate-keyword-pages-config.mjs` + `cluster-orphan-queries.mjs` against already-committed data and committed the regenerated `data/keyword-pages-config.json` (4 new profession-gap pages: giardiniere, tecnico-cnc, piastrellista, carpentiere) so the fix takes effect on the next deploy instead of waiting for next Monday's scheduled run.
- Ran `node scripts/ci/check-sibling-patterns.mjs` — no sibling files share the touched constructs.

Verified locally: `npx vitest run tests/profession-gap-double-validated-gate.test.ts tests/profession-taxonomy.test.ts tests/profession-synonyms.test.ts` — 26/26 passing.

Closes #4564

## Non implementato (ancora)

Nessuno. The threshold fix + regenerated config are both in this PR; merge → deploy.yml (triggered by the merge push, PAT-authored) builds and publishes the 4 new pages same as any other feature PR — no extra manual step needed. Will confirm live post-merge via `curl` per usual practice.