### PR TITLE
fix(adblock-gate): offer explicit reload when recheck stays blocked

### DIFF
--- a/components/community/AdBlockGate.tsx
+++ b/components/community/AdBlockGate.tsx
@@ -70,6 +70,8 @@ const COPY: Record<GateLocale, {
   instructionsBody: string;
   recheck: string;
   rechecking: string;
+  reloadHint: string;
+  reloadCta: string;
   subscribeCta: string;
 }> = {
   it: {
@@ -87,6 +89,8 @@ const COPY: Record<GateLocale, {
     instructionsBody: 'Apri l’icona dell’estensione AdBlock/uBlock nella barra degli strumenti del browser e scegli "Disattiva su questo sito" o "Metti in pausa". Poi premi "Ricontrolla" qui sotto.',
     recheck: 'Ricontrolla AdBlock',
     rechecking: 'Verifica in corso…',
+    reloadHint: 'Ancora rilevato. Se hai già disattivato l’estensione, il browser deve ricaricare la pagina per applicare la modifica.',
+    reloadCta: 'Ricarica pagina',
     subscribeCta: 'Attiva l’abbonamento — CHF 2.99/mese',
   },
   en: {
@@ -104,6 +108,8 @@ const COPY: Record<GateLocale, {
     instructionsBody: 'Open your AdBlock/uBlock extension icon in the browser toolbar and choose "Disable on this site" or "Pause". Then press "Recheck" below.',
     recheck: 'Recheck ad blocker',
     rechecking: 'Checking…',
+    reloadHint: 'Still detected. If you’ve already disabled the extension, the browser needs to reload the page for the change to take effect.',
+    reloadCta: 'Reload page',
     subscribeCta: 'Subscribe — CHF 2.99/mo',
   },
   de: {
@@ -121,6 +127,8 @@ const COPY: Record<GateLocale, {
     instructionsBody: 'Öffnen Sie das Symbol Ihrer AdBlock/uBlock-Erweiterung in der Symbolleiste des Browsers und wählen Sie „Auf dieser Website deaktivieren“ oder „Pausieren“. Klicken Sie danach unten auf „Erneut prüfen“.',
     recheck: 'Werbeblocker erneut prüfen',
     rechecking: 'Wird geprüft…',
+    reloadHint: 'Weiterhin erkannt. Wenn Sie die Erweiterung bereits deaktiviert haben, muss die Seite neu geladen werden, damit die Änderung wirksam wird.',
+    reloadCta: 'Seite neu laden',
     subscribeCta: 'Abonnieren — CHF 2.99/Monat',
   },
   fr: {
@@ -138,6 +146,8 @@ const COPY: Record<GateLocale, {
     instructionsBody: 'Ouvrez l’icône de votre extension AdBlock/uBlock dans la barre d’outils du navigateur et choisissez « Désactiver sur ce site » ou « Mettre en pause ». Puis cliquez sur « Revérifier » ci-dessous.',
     recheck: 'Revérifier le bloqueur',
     rechecking: 'Vérification…',
+    reloadHint: 'Toujours détecté. Si vous avez déjà désactivé l’extension, le navigateur doit recharger la page pour appliquer le changement.',
+    reloadCta: 'Recharger la page',
     subscribeCta: 'S’abonner — CHF 2.99/mois',
   },
 };
@@ -175,6 +185,7 @@ const AdBlockGate: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [showInstructions, setShowInstructions] = useState(false);
   const [rechecking, setRechecking] = useState(false);
+  const [recheckFailed, setRecheckFailed] = useState(false);
   const outcomeLoggedRef = useRef(false);
   const activeTabRef = useRef(nav?.activeTab);
   activeTabRef.current = nav?.activeTab;
@@ -215,6 +226,7 @@ const AdBlockGate: React.FC = () => {
       // Never trap the visitor on the escape-hatch page itself.
       if (activeTabRef.current === 'subscribe') return;
       outcomeLoggedRef.current = false;
+      setRecheckFailed(false);
       setOpen(true);
       try { Analytics.trackUIInteraction('adblock_gate', 'modal', 'show', 'detected'); } catch { /* no-op */ }
     });
@@ -240,6 +252,7 @@ const AdBlockGate: React.FC = () => {
     detectAdBlock().then((blocked) => {
       if (cancelled || !blocked) return;
       outcomeLoggedRef.current = false;
+      setRecheckFailed(false);
       setOpen(true);
       try { Analytics.trackUIInteraction('adblock_gate', 'modal', 'show', 'detected_revisit'); } catch { /* no-op */ }
     });
@@ -276,6 +289,14 @@ const AdBlockGate: React.FC = () => {
     };
   }, [open, logOutcome]);
 
+  // Most ad blockers apply cosmetic CSS hiding rules via a content script
+  // that only runs on page load — pausing/disabling the extension mid-session
+  // does not retroactively strip the already-injected rules, so the bait
+  // element in detectAdBlock() keeps reporting "blocked" until the page is
+  // reloaded (the network-level signal alone updates live, but detectAdBlock
+  // ORs it with the stale cosmetic signal). A second failed check offers an
+  // explicit reload instead of leaving the visitor re-clicking a button that
+  // can never succeed without one.
   const handleRecheck = async () => {
     trackPopupEvent('popup_cta_adblock', 'recheck_cta');
     setRechecking(true);
@@ -284,10 +305,17 @@ const AdBlockGate: React.FC = () => {
       if (!stillBlocked) {
         trackPopupEvent('popup_adblock_disable', 'adblock_disabled_confirmed');
         closeGate('disabled');
+        return;
       }
+      setRecheckFailed(true);
     } finally {
       setRechecking(false);
     }
+  };
+
+  const handleReload = () => {
+    trackPopupEvent('popup_cta_adblock', 'reload_cta');
+    window.location.reload();
   };
 
   const handleSubscribeClick = () => {
@@ -367,6 +395,19 @@ const AdBlockGate: React.FC = () => {
             {rechecking && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
             {rechecking ? copy.rechecking : copy.recheck}
           </button>
+
+          {recheckFailed && (
+            <div className="mt-3">
+              <p className="mb-2 text-xs text-on-accent/75">{copy.reloadHint}</p>
+              <button
+                type="button"
+                onClick={handleReload}
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-white/10 px-4 py-2 text-xs font-semibold text-on-accent transition hover:bg-white/15"
+              >
+                {copy.reloadCta}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>,

--- a/tests/AdBlockGate.test.tsx
+++ b/tests/AdBlockGate.test.tsx
@@ -65,6 +65,11 @@ const detectAdBlockMock = vi.mocked(detectAdBlock);
 const trackUIInteractionMock = vi.mocked(Analytics.trackUIInteraction);
 const registerSuperPropertyMock = vi.mocked(registerSuperProperty);
 
+// JSDOM marks `window.location` read-only; replace it with a writable stub
+// so we can spy on .reload(), same pattern as ChunkLoadErrorBoundary.test.tsx.
+const originalLocation = window.location;
+let reloadSpy: ReturnType<typeof vi.fn>;
+
 describe('AdBlockGate', () => {
   beforeEach(() => {
     isLikelyBotMock.mockReturnValue(false);
@@ -73,11 +78,22 @@ describe('AdBlockGate', () => {
     mockActiveTab = 'calculator';
     navigateToMock.mockClear();
     localStorage.clear();
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+      writable: true,
+    });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
   });
 
   it('never resolves a bucket or runs detection for bots', async () => {
@@ -134,6 +150,23 @@ describe('AdBlockGate', () => {
 
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
     expect(trackUIInteractionMock).toHaveBeenCalledWith('adblock_gate', 'modal', 'outcome', 'disabled');
+  });
+
+  it('offers a reload button when recheck still finds a blocker, and reload triggers window.location.reload()', async () => {
+    detectAdBlockMock.mockResolvedValue(true);
+    render(<AdBlockGate />);
+    await screen.findByRole('dialog');
+
+    expect(screen.queryByRole('button', { name: /ricarica/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /ricontrolla/i }));
+    await screen.findByRole('button', { name: /ricarica/i });
+
+    // Gate stays open — a still-blocked recheck is not an outcome by itself.
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /ricarica/i }));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 
   it('closes the gate, logs subscribe_clicked, and navigates to the subscribe page on CTA click', async () => {


### PR DESCRIPTION
## Implementato

- Root cause: `detectAdBlock()` (`services/adBlockDetection.ts`) ORs a network probe (updates live on disable) with a bait-element/cosmetic-CSS check (stays stale until page reload — most ad-blocker extensions only strip already-injected cosmetic CSS on next navigation, not on live toggle). The in-place "Ricontrolla" button therefore kept reporting `blocked` even after a genuine disable.
- Data confirming this: PostHog showed 65 unique visitors clicking recheck (139 clicks) vs only 1 confirmed `disabled` outcome in 9 days — ~98% failure rate on the intended-compliant path.
- `components/community/AdBlockGate.tsx`: added `recheckFailed` state. On a recheck that still finds a blocker, the gate now shows a hint (`copy.reloadHint`) + explicit "Ricarica pagina" button (`copy.reloadCta`) that calls `window.location.reload()`, tracked via the existing `popup_cta_adblock` event (`event_label: reload_cta`). State resets when the gate reopens (initial detection + revisit re-arm paths).
- Copy added in all 4 locales (it/en/de/fr) per `AGENTS.md § Accessibility And UX`.
- `tests/AdBlockGate.test.tsx`: new test asserting the reload button appears only after a still-blocked recheck, gate stays open (not an outcome by itself), and clicking it calls `window.location.reload()` (same JSDOM `window.location` stub pattern as `tests/components/ChunkLoadErrorBoundary.test.tsx`).
- GitNexus impact analysis on `AdBlockGate`: 0 upstream dependents, risk LOW (top-level mounted component, no other caller).
- `npx vitest run tests/AdBlockGate.test.tsx tests/adblock-detection.test.ts tests/adblock-abtest.test.ts` — 24/24 green. `tsc --noEmit` — no new errors (pre-existing unrelated errors elsewhere untouched).

## Non implementato (ancora)

Nessuno.

Sibling-pattern surfacer (`check-sibling-patterns.mjs --strict`, pre-push hook) flagged `services/adBlockDetection.ts` for sharing the token `detectAdBlock` — verified false positive: that file is `detectAdBlock()`'s own definition, not a second call-site of the "recheck without reload" antipattern. `grep -rl detectAdBlock` confirms `AdBlockGate.tsx` is the only consumer in the repo (excluding tests). No other component calls `detectAdBlock()`, so there is no sibling instance of this bug to fix. Pushed with `--no-verify` per the documented exception in `AGENTS.md § Non-Negotiables #6`.

## Test plan

- [x] `npx vitest run tests/AdBlockGate.test.tsx` — 12/12 green (11 pre-existing + 1 new)
- [x] `npx vitest run tests/adblock-detection.test.ts tests/adblock-abtest.test.ts` — 12/12 green, unaffected
- [x] `tsc --noEmit` — no new type errors
- [x] GitNexus impact(`AdBlockGate`, upstream) — 0 dependents, risk LOW
- [ ] Live verification post-merge: watch PostHog `popup_cta_adblock` (`event_label: reload_cta`) + `adblock_gate/modal/outcome/disabled` rate over the following days to confirm the fix actually raises the disable-success rate (can't be verified pre-merge — no adblocker install in CI)