### PR TITLE
fix(crawlers): retry once on stale-key 401 for Hornbach + Hochgebirgsklinik Davos

### DIFF
--- a/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
+++ b/scripts/lib/hochgebirgsklinik-davos-job-parser.mjs
@@ -292,7 +292,11 @@ async function fetchJobListings(apiKey) {
       }),
     });
 
-    if (!res.ok) throw new Error(`HTTP ${res.status} from Typesense API`);
+    if (!res.ok) {
+      const err = new Error(`HTTP ${res.status} from Typesense API`);
+      err.status = res.status;
+      throw err;
+    }
 
     const data = await res.json();
     const results = data?.results?.[0];
@@ -304,6 +308,27 @@ async function fetchJobListings(apiKey) {
     return hits.map((h) => h.document);
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/**
+ * Run the offer search, refreshing the scoped Typesense API key once on an
+ * HTTP 401 before giving up — same vendor (`api.my-job-shop.com`) and same
+ * failure class as Hornbach's crawler (#4556, recurring: #3688/#3940/#4319).
+ * Mirrors the retry-once-on-401 idiom in `microsoft-job-parser.mjs`'s
+ * `pcsGetJson` and `hornbach-job-parser.mjs`'s `fetchOfferDocumentsWithKeyRetry`.
+ *
+ * @param {string} apiKey
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function fetchJobListingsWithKeyRetry(apiKey) {
+  try {
+    return await fetchJobListings(apiKey);
+  } catch (err) {
+    if (err?.status !== 401) throw err;
+    console.warn('⚠️ Hochgebirgsklinik Davos Typesense search got HTTP 401 (stale scoped key) — refreshing key and retrying once');
+    const freshKey = await fetchTypesenseApiKey();
+    return fetchJobListings(freshKey);
   }
 }
 
@@ -389,7 +414,7 @@ export async function fetchAllHochgebirgsklinikDavosJobs() {
   const apiKey = await fetchTypesenseApiKey();
 
   // Step 2: Query all jobs
-  const documents = await fetchJobListings(apiKey);
+  const documents = await fetchJobListingsWithKeyRetry(apiKey);
   if (!documents || documents.length === 0) {
     console.warn('⚠️ No job documents returned from Typesense.');
     return [];

--- a/scripts/lib/hornbach-job-parser.mjs
+++ b/scripts/lib/hornbach-job-parser.mjs
@@ -414,6 +414,27 @@ export async function fetchHornbachOfferDocuments(apiKey, perPage = 250) {
 }
 
 /**
+ * Run the offer search, refreshing the scoped Typesense API key once on an
+ * HTTP 401 before giving up — the vendor's short-lived key is occasionally
+ * already stale/rejected by the time `multi_search` is called, even though
+ * it was just issued (#4556, recurring: #3688/#3940/#4319). Mirrors the
+ * retry-once-on-401 idiom in `microsoft-job-parser.mjs`'s `pcsGetJson`.
+ *
+ * @param {string} apiKey
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function fetchOfferDocumentsWithKeyRetry(apiKey) {
+  try {
+    return await fetchHornbachOfferDocuments(apiKey);
+  } catch (err) {
+    if (err?.status !== 401) throw err;
+    console.warn('⚠️ Hornbach Typesense search got HTTP 401 (stale scoped key) — refreshing key and retrying once');
+    const freshKey = await fetchHornbachSearchApiKey();
+    return fetchHornbachOfferDocuments(freshKey);
+  }
+}
+
+/**
  * Fetch all Hornbach jobs (Switzerland only — the scoped API key's
  * `backoffice_vanity:=ch` filter already restricts to the CH tenant, and
  * `isSwissCountryArray` re-checks the `country` facet defensively).
@@ -436,7 +457,7 @@ export async function fetchAllHornbachJobs() {
 
   let documents;
   try {
-    documents = await fetchHornbachOfferDocuments(apiKey);
+    documents = await fetchOfferDocumentsWithKeyRetry(apiKey);
   } catch (err) {
     console.warn(`⚠️ Hornbach Typesense search failed: ${err?.message || err}`);
     throw err;

--- a/tests/hochgebirgsklinik-davos-crawler.test.ts
+++ b/tests/hochgebirgsklinik-davos-crawler.test.ts
@@ -1,11 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   HOCHGEBIRGSKLINIK_DAVOS_KEY,
   HOCHGEBIRGSKLINIK_DAVOS_COMPANY_NAME,
   isHochgebirgsklinikDavosJob,
   isTrustedDomain,
+  fetchJobListingsWithKeyRetry,
 } from '../scripts/lib/hochgebirgsklinik-davos-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
+
+const JOB_SHOP_ID = '9c3b04cb-7265-5acb-a208-199c8a9d547a';
+
+function nuxtDataHtml(key: string): string {
+  const nuxtArr = [{}, {}, {}, { [`typesenseApiKey-${JOB_SHOP_ID}`]: 4 }, key];
+  return `<html><body><script id="__NUXT_DATA__" type="application/json">${JSON.stringify(nuxtArr)}</script></body></html>`;
+}
 
 describe('Hochgebirgsklinik Davos crawler parser', () => {
   // ── Constants ──
@@ -179,6 +187,61 @@ describe('Hochgebirgsklinik Davos crawler parser', () => {
 
     it('uses correct sector for healthcare', () => {
       expect(validJob.sector).toBe('Sanità / Assistenza');
+    });
+  });
+
+  // ── fetchJobListingsWithKeyRetry (#4556: same vendor as Hornbach —
+  //    api.my-job-shop.com occasionally rejects a scoped Typesense key that
+  //    was just extracted from the career page moments earlier. A single
+  //    in-run retry with a freshly re-scraped key covers the same self-heal
+  //    seen in the Hornbach crawler's #3688/#3940/#4319 pattern) ──
+  describe('fetchJobListingsWithKeyRetry', () => {
+    const orig = global.fetch;
+
+    afterEach(() => {
+      global.fetch = orig;
+    });
+
+    it('retries once with a freshly re-scraped key after an HTTP 401 from multi_search', async () => {
+      let searchCalls = 0;
+      global.fetch = vi.fn(async (url: unknown) => {
+        const href = String(url);
+        if (href.includes('multi_search')) {
+          searchCalls += 1;
+          if (searchCalls === 1) return { ok: false, status: 401, text: async () => '' };
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ results: [{ found: 1, hits: [{ document: { title: 'Pflegefachperson' } }] }] }),
+          };
+        }
+        return { ok: true, status: 200, text: async () => nuxtDataHtml('fresh-key-1234567890123456789012') };
+      }) as unknown as typeof fetch;
+
+      const docs = await fetchJobListingsWithKeyRetry('stale-key');
+      expect(docs).toEqual([{ title: 'Pflegefachperson' }]);
+      expect(searchCalls).toBe(2);
+    });
+
+    it('propagates the error when the retry also gets a 401 (no infinite loop)', async () => {
+      global.fetch = vi.fn(async (url: unknown) => {
+        const href = String(url);
+        if (href.includes('multi_search')) return { ok: false, status: 401, text: async () => '' };
+        return { ok: true, status: 200, text: async () => nuxtDataHtml('still-bad-key-123456789012345') };
+      }) as unknown as typeof fetch;
+
+      await expect(fetchJobListingsWithKeyRetry('stale-key')).rejects.toThrow(/401/);
+    });
+
+    it('does not retry a non-401 error (e.g. HTTP 500)', async () => {
+      let calls = 0;
+      global.fetch = vi.fn(async () => {
+        calls += 1;
+        return { ok: false, status: 500, text: async () => '' };
+      }) as unknown as typeof fetch;
+
+      await expect(fetchJobListingsWithKeyRetry('any-key')).rejects.toThrow(/500/);
+      expect(calls).toBe(1); // one multi_search attempt only — never re-scrapes the key for a 500
     });
   });
 });

--- a/tests/hornbach-crawler.test.ts
+++ b/tests/hornbach-crawler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   HORNBACH_KEY,
   HORNBACH_COMPANY_NAME,
@@ -13,6 +13,7 @@ import {
   resolveHornbachPostedDate,
   resolveHornbachEmploymentType,
   parseHornbachOffer,
+  fetchOfferDocumentsWithKeyRetry,
 } from '../scripts/lib/hornbach-job-parser.mjs';
 
 describe('Hornbach crawler parser', () => {
@@ -430,6 +431,67 @@ describe('Hornbach crawler parser', () => {
         expect(validJob[field as keyof typeof validJob]).toBeTruthy();
       }
       expect(validJob.company).toBe('Hornbach');
+    });
+  });
+
+  // ── fetchOfferDocumentsWithKeyRetry (#4556: recurring vendor 401 —
+  //    api.my-job-shop.com occasionally rejects a scoped Typesense key that
+  //    was just issued moments earlier; #3688/#3940/#4319 all self-healed
+  //    only on the NEXT scheduled cron run, filing a low-priority issue each
+  //    time. A single in-run retry with a freshly re-fetched key covers the
+  //    same self-heal without the issue-per-week churn) ──
+  describe('fetchOfferDocumentsWithKeyRetry', () => {
+    const orig = global.fetch;
+    const origRetries = process.env.JOBS_CRAWLER_RETRIES;
+
+    afterEach(() => {
+      global.fetch = orig;
+      if (origRetries === undefined) delete process.env.JOBS_CRAWLER_RETRIES;
+      else process.env.JOBS_CRAWLER_RETRIES = origRetries;
+    });
+
+    it('retries once with a freshly re-fetched key after an HTTP 401 from multi_search', async () => {
+      let searchCalls = 0;
+      global.fetch = vi.fn(async (url: unknown) => {
+        const href = String(url);
+        if (href.includes('multi_search')) {
+          searchCalls += 1;
+          if (searchCalls === 1) return { ok: false, status: 401, text: async () => '' };
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ results: [{ hits: [{ document: { title: 'Verkäufer:in' } }] }] }),
+          };
+        }
+        return { ok: true, status: 200, text: async () => JSON.stringify({ key: 'fresh-key' }) };
+      }) as unknown as typeof fetch;
+
+      const docs = await fetchOfferDocumentsWithKeyRetry('stale-key');
+      expect(docs).toEqual([{ title: 'Verkäufer:in' }]);
+      expect(searchCalls).toBe(2);
+    });
+
+    it('propagates the error when the retry also gets a 401 (no infinite loop)', async () => {
+      process.env.JOBS_CRAWLER_RETRIES = '0';
+      global.fetch = vi.fn(async (url: unknown) => {
+        const href = String(url);
+        if (href.includes('multi_search')) return { ok: false, status: 401, text: async () => '' };
+        return { ok: true, status: 200, text: async () => JSON.stringify({ key: 'still-bad-key' }) };
+      }) as unknown as typeof fetch;
+
+      await expect(fetchOfferDocumentsWithKeyRetry('stale-key')).rejects.toThrow(/401/);
+    });
+
+    it('does not retry a non-401 error (e.g. HTTP 500)', async () => {
+      process.env.JOBS_CRAWLER_RETRIES = '0';
+      let calls = 0;
+      global.fetch = vi.fn(async () => {
+        calls += 1;
+        return { ok: false, status: 500, text: async () => '' };
+      }) as unknown as typeof fetch;
+
+      await expect(fetchOfferDocumentsWithKeyRetry('any-key')).rejects.toThrow(/500/);
+      expect(calls).toBe(1); // one multi_search attempt only — never re-fetches the key for a 500
     });
   });
 });


### PR DESCRIPTION
## Implementato

- `scripts/lib/hornbach-job-parser.mjs`: nuovo `fetchOfferDocumentsWithKeyRetry()` — su HTTP 401 dal `multi_search` (chiave scoped rifiutata), rifetcha una chiave fresca via `fetchHornbachSearchApiKey()` e ritenta la ricerca **una sola volta** prima di propagare l'errore. `fetchAllHornbachJobs()` ora chiama questo wrapper invece della search diretta.
- `scripts/lib/hochgebirgsklinik-davos-job-parser.mjs`: stesso fix, stesso vendor (`api.my-job-shop.com`, job-shop/TalentsConnect) — nuovo `fetchJobListingsWithKeyRetry()`, e `fetchJobListings()` ora allega `err.status` sull'errore HTTP per abilitare il check del 401. `fetchAllHochgebirgsklinikDavosJobs()` aggiornato per usare il wrapper.
- Test: 6 nuovi casi (`tests/hornbach-crawler.test.ts`, `tests/hochgebirgsklinik-davos-crawler.test.ts`) — retry-riuscito-al-secondo-tentativo, propagazione errore se il retry fallisce ancora (niente loop infinito), nessun retry su status non-401 (es. 500). 133/133 test verdi sui 4 file toccati + sibling correlati (`microsoft-crawler.test.ts`, `transient-fetch.test.ts`).

**Root cause (issue #4556, verificato nel log del run fallito):** `fetchAllHornbachJobs()` fa un flusso a due step — GET chiave Typesense scoped, poi POST `multi_search` con quella chiave. Il vendor a volte rifiuta con HTTP 401 una chiave appena emessa (`⚠️ Hornbach Typesense search failed: HTTP 401 from https://api.my-job-shop.com/api/typesense/multi_search?...`). `401` è deliberatamente escluso da `RETRYABLE_STATUS` in `transient-fetch.mjs` (per design, è considerato un fallimento "genuino" non transiente) → nessun retry automatico, run intero fallito. Stesso identico pattern ricorso 4 volte (#3688, #3940, #4319, #4556) dal 2026-07-04, sempre auto-risolto solo al prossimo cron schedulato, mai da un fix di codice. Fix: un retry mirato SOLO su 401, con chiave fresca, prima di fallire — evita il ciclo issue-a-settimana senza toccare il comportamento di retry generico per altri status.

Closes #4556

## Non implementato (ancora)

Nessuno per lo scope di questa PR. Due candidati sibling emersi da `check-sibling-patterns.mjs` (AGENTS.md #6), entrambi valutati singolarmente come falsi positivi — nessuna modifica necessaria:

- `components/community/JobBoard.tsx` — falso positivo: il match è su `adRefreshKey` (contatore React `useState` per forzare il re-render dello slot AdSense in-feed), la sottostringa "freshKey" è pura coincidenza lessicale — dominio (ad-slot refresh) e costrutto (retry auth-key su HTTP 401) completamente diversi, nessun key-fetch/Typesense/vendor-auth coinvolto.
- `scripts/lib/microsoft-job-parser.mjs` — falso positivo: `pcsGetJson` è l'implementazione ESISTENTE citata/imitata nei commenti dei nuovi retry helper (già applica correttamente il pattern "refresh-once-on-401/403" per il proprio CSRF token PCS/Eightfold) — è la reference implementation da cui ho copiato l'idioma, non un sibling mancante del fix.