### PR TITLE
fix(ci): drop unset-vars kill-switch that always skipped Claude CLI install

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -107,15 +107,15 @@ jobs:
       # subscription token already used by pr-review-loop.yml/issue-fix.yml),
       # never ANTHROPIC_API_KEY — which is why this is now enabled BY DEFAULT
       # (owner request 2026-07-11: the recurring free-pool exhaustion deferrals
-      # must never zero production again). Kill-switch: set the repo variable
-      # ENABLE_HAIKU_ARTICLE_FALLBACK=0 (Settings → Secrets and variables →
-      # Actions → Variables) or the Remote Config flag to '0' — either
-      # disables the setup below, ai-models.mjs then never offers the model
-      # (getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns ''). The
-      # $GITHUB_ENV export normalizes the flag for ai-models.mjs's
-      # isClaudeCliFallbackEnabled regardless of which source enabled it.
+      # must never zero production again). Kill-switch: set the Remote Config
+      # flag to '0' — ai-models.mjs's isClaudeCliFallbackEnabled reads ONLY
+      # env.ENABLE_HAIKU_ARTICLE_FALLBACK (sourced from RC via load-rc-env.mjs
+      # → $GITHUB_ENV), so that is the single source of truth for both this
+      # install step and the runtime gate; there is no separate repo-variable
+      # switch (see incident below — a `vars.*` clause here was never read by
+      # the runtime, so it could only desync, never actually kill).
       - name: Setup Claude CLI Haiku fallback
-        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0' && vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
+        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
         run: |
           npm install -g @anthropic-ai/claude-code
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"
@@ -125,6 +125,16 @@ jobs:
       # instead of requiring a forensic dig through job.steps[].conclusion
       # (run 29632759948: install step silently skipped while the runtime
       # gate still offered claude-cli, spawning ENOENT ~200x, score → -595).
+      # Root cause of THAT desync (run 29676088799, jul19): the `if:` above
+      # used to also gate on `vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'`. That
+      # repo variable was never configured, and GitHub Actions coerces an
+      # unset context to null→0 for comparison, so `null != '0'` evaluates to
+      # `0 != 0` = false — the install step silently skipped on EVERY run,
+      # while the runtime gate (which never reads `vars`, only `env`) kept
+      # offering claude-cli regardless → guaranteed ENOENT once free-tier
+      # quota ran out. Same coercion gotcha documented in
+      # translate-pending.yml (TRANSLATE_ARGOS_FIRST_DISABLE). Fixed by
+      # dropping the `vars.*` clause so install and runtime share one flag.
       - name: Diagnose Claude CLI Haiku fallback state
         run: |
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>}"

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -119,12 +119,15 @@ jobs:
       # every free-tier model has failed. Zero marginal cost — auth is
       # CLAUDE_CODE_OAUTH_TOKEN (same Max-plan subscription token already used
       # by pr-review-loop.yml/issue-fix.yml), never ANTHROPIC_API_KEY. Kill
-      # switch: repo variable ENABLE_HAIKU_ARTICLE_FALLBACK=0 (Settings →
-      # Secrets and variables → Actions → Variables) or the Remote Config flag
-      # to '0' — either disables the setup below, ai-models.mjs then never
-      # offers the model (getApiKeyForProvider(PROVIDER.CLAUDE_CLI) returns '').
+      # switch: set the Remote Config flag to '0' — ai-models.mjs's
+      # isClaudeCliFallbackEnabled reads ONLY env.ENABLE_HAIKU_ARTICLE_FALLBACK
+      # (sourced from RC via load-rc-env.mjs → $GITHUB_ENV), so that is the
+      # single source of truth for both this install step and the runtime
+      # gate; there is no separate repo-variable switch (see incident below —
+      # a `vars.*` clause here was never read by the runtime, so it could
+      # only desync, never actually kill).
       - name: Setup Claude CLI Haiku fallback
-        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0' && vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
+        if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
         run: |
           npm install -g @anthropic-ai/claude-code
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=1" >> "$GITHUB_ENV"
@@ -134,6 +137,17 @@ jobs:
       # instead of requiring a forensic dig through job.steps[].conclusion
       # (run 29632759948: install step silently skipped while the runtime
       # gate still offered claude-cli, spawning ENOENT ~200x, score → -595).
+      # Root cause of THAT desync (run 29676088799, jul19, 958x "All AI
+      # models failed"): the `if:` above used to also gate on
+      # `vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'`. That repo variable was
+      # never configured, and GitHub Actions coerces an unset context to
+      # null→0 for comparison, so `null != '0'` evaluates to `0 != 0` = false
+      # — the install step silently skipped on EVERY run, while the runtime
+      # gate (which never reads `vars`, only `env`) kept offering claude-cli
+      # regardless → guaranteed ENOENT once free-tier quota ran out. Same
+      # coercion gotcha documented in translate-pending.yml
+      # (TRANSLATE_ARGOS_FIRST_DISABLE). Fixed by dropping the `vars.*`
+      # clause so install and runtime share one flag.
       - name: Diagnose Claude CLI Haiku fallback state
         run: |
           echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>}"


### PR DESCRIPTION
## Implementato

Root cause of run [29676088799](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29676088799/job/88163709854) (958x `⚠️ AI briefing failed: All AI models failed`, chain ending `... → gpt-4.1-nano → claude-cli/haiku` → `spawn claude ENOENT`):

- `Setup Claude CLI Haiku fallback` in both `send-newsletter.yml` and `generate-article.yml` gated the `npm install -g @anthropic-ai/claude-code` step on `env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0' && vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'`.
- The repo Actions variable `ENABLE_HAIKU_ARTICLE_FALLBACK` was never configured (confirmed via `gh variable list` — absent). GitHub Actions coerces an unset `vars` context to `null`, and comparing it against the string `'0'` coerces both sides to numbers: `null → 0`, `'0' → 0`, so `null != '0'` evaluates `0 != 0` = **false**. The install step therefore silently skipped on **every single run**, not just this one.
- Meanwhile `scripts/lib/ai-models.mjs` (`isClaudeCliFallbackEnabled()`) only ever reads `process.env.ENABLE_HAIKU_ARTICLE_FALLBACK` (RC-sourced) — it never reads the GH Actions `vars` context at all. So the "repo variable kill switch" documented in the old comment could never actually disable the runtime offer; it could only ever desync install-vs-runtime.
- Once every free-tier model (Mistral 401 invalid key, all Gemini/Gemma daily quota exhausted) was exhausted, every remaining item's fallback chain reached `claude-cli/haiku`, which the runtime always offered but whose binary was never installed → guaranteed `ENOENT`.
- Same coercion gotcha already diagnosed and fixed correctly in `translate-pending.yml` (`TRANSLATE_ARGOS_FIRST_DISABLE`, using the proven `vars.X != '1'` disable-flag idiom instead of `!= '0'`).

**Fix:** drop the `vars.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'` clause from both workflows' `if:` conditions, leaving only the RC-sourced `env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'` check — the exact same flag `ai-models.mjs` already consults. Install step and runtime gate now share one source of truth; this class of desync is structurally impossible going forward. Updated the surrounding comments in both files to stop documenting a "repo variable kill switch" that the runtime never respected, and added an incident note pointing at this run.

Files changed: `.github/workflows/send-newsletter.yml`, `.github/workflows/generate-article.yml`.

## Sibling-pattern check (AGENTS.md #6)

`scripts/ci/check-sibling-patterns.mjs --strict` surfaced 5 candidates sharing tokens (`ENABLE_HAIKU_ARTICLE_FALLBACK`, `CLAUDE_CLI`, `isClaudeCliFallbackEnabled`) with this diff. All inspected individually — none contain the actual antipattern (a `vars.*` GitHub Actions expression compared against `'0'` while the variable is left unconfigured):

- `scripts/lib/ai-models.mjs` — false positive: only reads `process.env.ENABLE_HAIKU_ARTICLE_FALLBACK` via a plain JS regex test; no `vars` GH Actions context involved at all.
- `scripts/load-rc-env.mjs` — false positive: writes `$GITHUB_ENV`, no `vars.*` comparison.
- `scripts/send-newsletter.mjs` — false positive: comment-only references to the flag name; no `vars.*` comparison.
- `scripts/set-haiku-fallback-rc.mjs` — false positive: sets the Remote Config param via the Firebase Admin SDK; plain Node string constant, no `vars.*` comparison.
- `.github/workflows/translate-pending.yml` — false positive: already uses the *correct* proven idiom (`vars.TRANSLATE_ARGOS_FIRST_DISABLE != '1'`, a disable-flag immune to the unset→0 coercion) — this is the reference pattern the fix is modeled after, not an instance of the bug.

Pushed with `--no-verify` per AGENTS.md #6 exception (all candidates individually evaluated and justified above).

## Non implementato (ancora)

Nessuno — questo task (bug del kill-switch `vars.*` unset) è chiuso. Nota separata, non in scope di questa PR: la stessa run ha anche esposto una `MISTRAL_API_KEY` scaduta/invalida (HTTP 401) sul primo modello della catena — è una rotazione di secret/ops, non un bug di codice; segnalato all'owner separatamente.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on both edited files — valid YAML.
- [x] Confirmed via `gh variable list` that `ENABLE_HAIKU_ARTICLE_FALLBACK` repo variable is absent (root cause precondition).
- [ ] Live verification: next scheduled `send-newsletter.yml`/`generate-article.yml` run should show the `Setup Claude CLI Haiku fallback` step as `✓` (not skipped) when RC flag is enabled, and `claude CLI: present (...)` in the Diagnose step — will confirm post-merge on the next live run and check off here.