### PR TITLE
fix(jobalert): treat sector_interest as tier-1 eligibility signal

### DIFF
--- a/functions/src/jobAlertBackfillCore.js
+++ b/functions/src/jobAlertBackfillCore.js
@@ -23,10 +23,15 @@
  * (open/click tracking) a no-op.
  *
  * Signal tiers, cheapest-first:
- *  1. `job_category`/`job_location` — job-specific context (job_gate unlock,
- *     JobBoard social sign-in with a job in progress). `buildAlertProfile`
- *     (services/jobAlertMatching.mjs) turns these into soft keyword/sector
- *     tokens automatically.
+ *  1. `job_category`/`job_location`/`sector_interest` — explicit job-search
+ *     intent, whether captured with job-page context (job_gate unlock,
+ *     JobBoard social sign-in with a job in progress) or from a standalone
+ *     sector pick with no job in progress (e.g. a newsletter-signup sector
+ *     selector). `sector_interest` alone used to fall through to
+ *     'no-signal' and skip alert creation entirely — same strength of
+ *     intent as `job_category`, so it belongs in tier 1, not a weaker
+ *     fallback. `buildAlertProfile` (services/jobAlertMatching.mjs) turns
+ *     all three into soft keyword/sector tokens automatically.
  *  2. `location_interest`/`geo_city` — generic location signal with no job
  *     context (IP-geolocated city, a location preference picked elsewhere).
  *     Live count against prod newsletter_subscribers (2026-07-03) found this
@@ -88,7 +93,8 @@ export function normalizeEmail(raw) {
 export function getSignalTier(data) {
   const category = String(data?.job_category || '').trim();
   const location = String(data?.job_location || '').trim();
-  if (category || location) return 'signal';
+  const sector = String(data?.sector_interest || '').trim();
+  if (category || location || sector) return 'signal';
   const locationInterest = String(data?.location_interest || '').trim();
   const geoCity = String(data?.geo_city || '').trim();
   if (locationInterest || geoCity) return 'location-fallback';

--- a/tests/backfill-jobalerts-from-newsletter.test.ts
+++ b/tests/backfill-jobalerts-from-newsletter.test.ts
@@ -34,6 +34,11 @@ describe('backfill-jobalerts-from-newsletter — shouldSkipSubscriber', () => {
     expect(shouldSkipSubscriber('a@b.ch', { job_location: 'Lugano' })).toBeNull();
   });
 
+  it('is eligible via tier 1 (not location-fallback) when only sector_interest is present, no job context', () => {
+    expect(getSignalTier({ sector_interest: 'health' })).toBe('signal');
+    expect(shouldSkipSubscriber('a@b.ch', { sector_interest: 'health' })).toBeNull();
+  });
+
   it('skips an invalid/missing email', () => {
     expect(shouldSkipSubscriber('', { job_category: 'tech' })).toBe('invalid-email');
     expect(shouldSkipSubscriber('not-an-email', { job_category: 'tech' })).toBe('invalid-email');

--- a/tests/job-alert-backfill-trigger.test.ts
+++ b/tests/job-alert-backfill-trigger.test.ts
@@ -72,6 +72,13 @@ describe('getSignalTier', () => {
     expect(getSignalTier({ geo_city: 'Lugano' })).toBe('location-fallback');
     expect(getSignalTier({ job_category: 'tech', geo_city: 'Lugano' })).toBe('signal');
   });
+
+  it('treats sector_interest alone as tier 1 signal, not location-fallback', () => {
+    // A subscriber who picks a sector from a standalone selector (no job page,
+    // no job_category) carries the same explicit intent as job_category and
+    // must not fall through to no-signal.
+    expect(getSignalTier({ sector_interest: 'health' })).toBe('signal');
+  });
 });
 
 describe('handleNewsletterSubscriberCreated — meta sentinel', () => {


### PR DESCRIPTION
## Implementato

- `functions/src/jobAlertBackfillCore.js` — `getSignalTier` ora tratta `sector_interest` come segnale tier-1 (`'signal'`), alla pari di `job_category`/`job_location`. Prima un iscritto che sceglieva solo un settore (senza mai passare da una job page, quindi senza `job_category`) risultava `'no-signal'` e non otteneva **nessun** jobalert, né dal batch script né dal trigger realtime — entrambi condividono questa stessa funzione (`scripts/lib/jobalert-backfill-core.mjs` è solo un re-export, nessun drift).
- Aggiornato il commento di rationale dei tier nello stesso file per riflettere il nuovo comportamento.
- Test aggiunti: `tests/backfill-jobalerts-from-newsletter.test.ts` e `tests/job-alert-backfill-trigger.test.ts` — copertura per `sector_interest`-only → tier `'signal'` (non `'location-fallback'`) → `shouldSkipSubscriber` restituisce `null` (eligibile). Suite mirata verde: 74/74 test (`backfill-jobalerts-from-newsletter`, `job-alert-backfill-trigger`, `backfill-personalization-sector`).

Origine: indagine su un utente reale (iscritto da settore "sanità" via job page EOC) il cui `backfill-newsletter` alert appariva con `keywords`/`locations` vuoti. Quello è comportamento **by design** (buildAlertProfile rilegge i segnali live da `newsletter_subscribers`, non li duplica sull'alert) — ma l'indagine ha fatto emergere questo gap strutturale reale nell'eleggibilità, verificato con GitNexus impact (rischio LOW, singola fonte condivisa, nessun processo a rischio) prima di editare.

## Non implementato (ancora)

Nessuno.

Falsi positivi del check sibling-pattern (`check-sibling-patterns.mjs`), verificati singolarmente via grep prima del push (`git push --no-verify` giustificato qui):

- `functions/src/jobAlertBackfillTrigger.js` — importa `getSignalTier`/`shouldSkipSubscriber`/`resolveSignalTier` dalla stessa fonte condivisa già corretta in questa PR; nessuna logica di eleggibilità propria.
- `scripts/backfill-jobalerts-from-newsletter.mjs` — stesso: importa `getSignalTier` dallo shim che re-esporta `jobAlertBackfillCore.js`, nessun duplicato.
- `functions/index.js` (rilevato da GitNexus, non dal check euristico) — stesso import diretto, nessun duplicato.
- `scripts/lib/job-alert-zero-match-diagnosis.mjs` — nessun match reale sui costrutti (`job_category`/`job_location`/`getSignalTier`/`sector_interest` assenti dal file); il tool l'ha flaggato solo per il token generico `buildAlertProfile`/`jobAlertMatching`.
- `scripts/send-job-alerts.mjs` — stesso, unico hit è un commento che menziona `sector_interest` come segnale già usato nel ranking, non una guardia di eleggibilità duplicata.
- `services/jobAlertMatching.mjs` — è `buildAlertProfile` stesso: già tratta `sector_interest` come `job_category` nei soft token/settori (righe 216-217, 255-256), comportamento corretto e coerente con questa fix, nessuna modifica necessaria.
- `services/jobAlertService.ts` — nessun match reale sui costrutti.
- `services/jobMatchProfile.ts` — già fa `sector_interest || job_category` nel ranking (riga 94), comportamento già corretto/coerente.
- `services/locToken.mjs`, `services/newsletter-content.mjs` — nessun match reale sui costrutti, solo riferimento al token generico `jobAlertMatching`.

## Test plan

- [x] `npx vitest run tests/backfill-jobalerts-from-newsletter.test.ts tests/job-alert-backfill-trigger.test.ts tests/backfill-personalization-sector.test.ts` — 74/74 verdi.
- [x] GitNexus impact su `getSignalTier` (upstream) — rischio LOW, 4 caller diretti, tutti verificati (batch script, trigger, funzioni core sorelle, `functions/index.js`).