### PR TITLE
fix(validate-dist): root-cause 4 audit regressions still failing after PR #4611

### DIFF
--- a/build-plugins/employerProfilePagesPlugin.ts
+++ b/build-plugins/employerProfilePagesPlugin.ts
@@ -36,7 +36,7 @@ import type { Plugin } from 'vite';
 import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { endOfContentMultiplexHtml } from './lib/adSlotHtml';
-import { renderJobCardHtml, JOB_CARD_ICON_SYMBOLS, type JobCardJob } from './shared/jobCardHtml';
+import { renderJobCardHtml, JOB_CARD_ICON_SYMBOLS, localizedContract, type JobCardJob } from './shared/jobCardHtml';
 import { buildListItemJobPosting } from './shared/jobPostingListItem';
 import { renderEmployerCtaBlock } from './shared/employerCtaBlock';
 import { inlineScriptJson } from './shared/inlineJsonScript';
@@ -150,6 +150,19 @@ const TITLE_SUFFIX: Record<Locale, string> = {
   de: 'offene Stellen und Gehälter',
   fr: 'postes ouverts et salaires',
 };
+// Short last-resort suffix — MUST differ from the bare "{H1_PREFIX} {name}"
+// string used for <h1> (see renderProfileBody). composePlaceTitle's fallback
+// candidate used to be that exact bare string, so any company name whose
+// full TITLE_SUFFIX candidate overflowed TITLE_MAX_CHARS fell back to a
+// <title> byte-identical to <h1>, tripping audit:h1-title-duplicates (157
+// offenders, validate-dist run 29794187475 — regression from PR #4611's
+// title-length fix). Keeping a (however short) suffix on every candidate
+// guarantees title !== h1 by construction: if even this short candidate
+// overflows, composePlaceTitle's truncateHeadline() fallback always appends
+// "…", which also never equals the untruncated h1 text.
+const TITLE_SUFFIX_SHORT: Record<Locale, string> = {
+  it: 'offerte', en: 'jobs', de: 'Jobs', fr: 'offres',
+};
 
 /** Format a CHF annual amount with Swiss grouping (e.g. "CHF 86’250"). */
 function fmtChf(v: number): string {
@@ -229,6 +242,13 @@ interface ProseTemplate {
   readonly citiesMulti: (first: string, firstCount: number, rest: string) => string;
   readonly salary: (sal: string) => string;
   readonly trend: (added: number, win: number) => string;
+  /** Contract-type majority among the CURRENTLY listed postings — real
+   * per-build aggregate, distinct from the per-job contract badge already
+   * shown on each card (see contractMixProse). */
+  readonly contractMix: (label: string, count: number, total: number) => string;
+  /** Real salary min–max range across postings with a reported/estimated
+   * figure — distinct from the single median stat tile. */
+  readonly salaryRange: (min: string, max: string) => string;
   readonly outro: string;
 }
 const PROSE_TEMPLATES: Record<Locale, ProseTemplate> = {
@@ -240,6 +260,10 @@ const PROSE_TEMPLATES: Record<Locale, ProseTemplate> = {
     citiesMulti: (first, firstCount, rest) => `A livello di città, le sedi con più posizioni aperte sono ${first} (${firstCount} offerte), seguita da ${rest}.`,
     salary: (sal) => `Lo stipendio mediano stimato per queste offerte è di ${sal} lordi all’anno.`,
     trend: (added, win) => `Negli ultimi ${win} giorni sono state pubblicate ${added} nuove offerte.`,
+    contractMix: (label, count, total) => count === total
+      ? `Tutte le posizioni attive sono a ${label}.`
+      : `${count} delle ${total} posizioni attive pubblicate sono a ${label}.`,
+    salaryRange: (min, max) => `Gli stipendi pubblicati per queste posizioni vanno da ${min} a ${max} lordi all’anno.`,
     outro: 'Consulta qui sotto le posizioni attive e candidati direttamente sul sito del datore di lavoro.',
   },
   en: {
@@ -250,6 +274,10 @@ const PROSE_TEMPLATES: Record<Locale, ProseTemplate> = {
     citiesMulti: (first, firstCount, rest) => `By city, the locations with the most open positions are ${first} (${firstCount} openings), followed by ${rest}.`,
     salary: (sal) => `The estimated median salary for these roles is ${sal} gross per year.`,
     trend: (added, win) => `In the last ${win} days, ${added} new postings were published.`,
+    contractMix: (label, count, total) => count === total
+      ? `All active positions are ${label}.`
+      : `${count} of the ${total} active postings are ${label}.`,
+    salaryRange: (min, max) => `Published salaries for these roles range from ${min} to ${max} gross per year.`,
     outro: 'Browse the active roles below and apply directly on the employer’s own site.',
   },
   de: {
@@ -260,6 +288,10 @@ const PROSE_TEMPLATES: Record<Locale, ProseTemplate> = {
     citiesMulti: (first, firstCount, rest) => `Nach Stadt betrachtet haben ${first} (${firstCount} Stellen) die meisten offenen Stellen, gefolgt von ${rest}.`,
     salary: (sal) => `Das geschätzte Median­gehalt für diese Stellen beträgt ${sal} brutto pro Jahr.`,
     trend: (added, win) => `In den letzten ${win} Tagen wurden ${added} neue Stellen veröffentlicht.`,
+    contractMix: (label, count, total) => count === total
+      ? `Alle aktiven Stellen sind ${label}.`
+      : `${count} der ${total} aktiven Stellen sind ${label}.`,
+    salaryRange: (min, max) => `Die veröffentlichten Gehälter für diese Stellen reichen von ${min} bis ${max} brutto pro Jahr.`,
     outro: 'Sehen Sie sich unten die aktiven Stellen an und bewerben Sie sich direkt auf der Website des Arbeitgebers.',
   },
   fr: {
@@ -270,6 +302,10 @@ const PROSE_TEMPLATES: Record<Locale, ProseTemplate> = {
     citiesMulti: (first, firstCount, rest) => `Par ville, les sites avec le plus de postes ouverts sont ${first} (${firstCount} offres), suivi de ${rest}.`,
     salary: (sal) => `Le salaire médian estimé pour ces postes est de ${sal} brut par an.`,
     trend: (added, win) => `Au cours des ${win} derniers jours, ${added} nouvelles annonces ont été publiées.`,
+    contractMix: (label, count, total) => count === total
+      ? `Tous les postes actifs sont en ${label}.`
+      : `${count} des ${total} postes actifs publiés sont en ${label}.`,
+    salaryRange: (min, max) => `Les salaires publiés pour ces postes vont de ${min} à ${max} brut par an.`,
     outro: 'Parcourez les postes actifs ci-dessous et postulez directement sur le site de l’employeur.',
   },
 };
@@ -295,15 +331,60 @@ function citiesProse(profile: EmployerProfile, locale: Locale): string {
   return t.citiesMulti(c[0].name, c[0].count, rest);
 }
 
+/** Real contract-type majority across the company's FULL active-job set
+ * (not just the ≤MAX_JOBS_LISTED cards shown) — genuine aggregate fact,
+ * distinct from the per-job contract badge already on each card. Returns
+ * '' when the data is too sparse/fragmented to say anything meaningful
+ * (no single contract type reaches a majority), same graceful-skip pattern
+ * as cantonsProse/citiesProse when there's nothing real to report. */
+function contractMixProse(jobs: CorpusJob[], locale: Locale): string {
+  const counts = new Map<string, number>();
+  for (const job of jobs) {
+    const label = localizedContract(job.contract, locale);
+    if (!label) continue;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  const total = [...counts.values()].reduce((a, b) => a + b, 0);
+  if (total === 0) return '';
+  const [topLabel, topCount] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+  if (topCount / total < 0.5) return '';
+  return PROSE_TEMPLATES[locale].contractMix(topLabel.toLowerCase(), topCount, total);
+}
+
+/** Real salary min–max range across postings with a reported/estimated
+ * figure — distinct from the single median stat tile, and from the
+ * per-card salary line (this is the FULL active-job range, not just the
+ * ≤MAX_JOBS_LISTED shown). Returns '' when there isn't a genuine range
+ * (fewer than 2 data points, or min === max — nothing to compare). */
+function salaryRangeProse(jobs: CorpusJob[], locale: Locale): string {
+  const values = jobs
+    .flatMap((j) => [j.salaryMin, j.salaryMax])
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v) && v > 0);
+  if (values.length < 2) return '';
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (min >= max) return '';
+  return PROSE_TEMPLATES[locale].salaryRange(fmtChf(min), fmtChf(max));
+}
+
 /** Localized intro prose — templated FACTS only, now with the FULL
  * canton/city breakdown (was top-3 `locationsSummary`, still used for the
- * compact stat tile). Real per-company detail, not filler — length scales
- * with the company's actual canton/city footprint (data/employer-
- * profiles.json caps both arrays at 6, so this never runs away). Part of
- * the audit:text-html-ratio fix (#4593): still doesn't clear the 10% floor
- * for every profile at MAX_JOBS_LISTED cards (verified — see MAX_JOBS_LISTED
- * comment), but meaningfully narrows the gap with genuine content, not padding. */
-function introProse(profile: EmployerProfile, locale: Locale): string {
+ * compact stat tile), plus a real contract-mix and salary-range sentence
+ * computed from the company's full active-job set. Real per-company detail,
+ * not filler — length scales with the company's actual canton/city
+ * footprint (data/employer-profiles.json caps both arrays at 6, so this
+ * never runs away). Part of the audit:text-html-ratio fix (#4593): PR
+ * #4611's MAX_JOBS_LISTED reduction (24→8) + earlier prose expansion
+ * narrowed the gap but the LIVE measured ratio (~5%, validate-dist run
+ * 29794187475) was roughly half PR #4611's own local estimate (~9.8%) —
+ * this adds genuine additional facts rather than re-tuning MAX_JOBS_LISTED
+ * again (that lever was already verified NOT to help: more cards add more
+ * per-job JobPosting JSON-LD, mandated complete by Non-Negotiable #3, far
+ * faster than they add visible card text — see MAX_JOBS_LISTED comment).
+ * Does not guarantee every one of the ~1860 profiles clears the 10% floor
+ * (a handful with no contract/salary data at all get none of the two new
+ * sentences); see PR body for the honest remaining gap. */
+function introProse(profile: EmployerProfile, jobs: CorpusJob[], locale: Locale): string {
   const t = PROSE_TEMPLATES[locale];
   const sal = profile.salaryMedianChf ? fmtChf(profile.salaryMedianChf) : null;
   const added = profile.trend?.added ?? null;
@@ -314,6 +395,8 @@ function introProse(profile: EmployerProfile, locale: Locale): string {
     citiesProse(profile, locale),
     sal ? t.salary(sal) : '',
     added ? t.trend(added, win) : '',
+    contractMixProse(jobs, locale),
+    salaryRangeProse(jobs, locale),
     t.outro,
   ].filter(Boolean).join(' ');
 }
@@ -359,6 +442,7 @@ function renderProfileBody(
   profile: EmployerProfile,
   jobs: CorpusJob[],
   locale: Locale,
+  allActiveJobs: CorpusJob[] = jobs,
 ): string {
   const name = profile.name;
   const tiles = [
@@ -399,10 +483,10 @@ function renderProfileBody(
 ${breadcrumbHtml(locale, name)}
 <header class="rounded-2xl border border-edge bg-surface-alt p-5 mb-5">
 <h1 class="text-[26px] font-bold text-strong leading-tight m-0 mb-1.5">${esc(H1_PREFIX[locale])} ${esc(name)}</h1>
-<p class="text-[15px] text-muted m-0">${esc(introProse(profile, locale).split('. ')[0])}.</p>
+<p class="text-[15px] text-muted m-0">${esc(introProse(profile, allActiveJobs, locale).split('. ')[0])}.</p>
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-2.5 mt-4">${tiles}</div>
 </header>
-<section class="mb-7"><p class="my-2.5 leading-relaxed text-body">${esc(introProse(profile, locale))}</p></section>
+<section class="mb-7"><p class="my-2.5 leading-relaxed text-body">${esc(introProse(profile, allActiveJobs, locale))}</p></section>
 <section class="mb-2">
 <h2 class="text-lg font-bold text-strong mb-3">${esc(JOBS_HEADING[locale])} (${profile.activeJobs})</h2>
 ${JOB_CARD_ICON_SYMBOLS}
@@ -552,7 +636,7 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
         // page never points an alternate at a noindex sibling (reviewer
         // adversarial check). Rendering is reused in the emit loop below.
         const rendered = LOCALES.map((locale) => {
-          const bodyHtml = renderProfileBody(liveProfile, listed, locale);
+          const bodyHtml = renderProfileBody(liveProfile, listed, locale, group);
           const indexable = liveActive >= MIN_ACTIVE_JOBS && countHtmlBodyWords(bodyHtml) >= MIN_INDEXABLE_WORDS;
           return { locale, bodyHtml, indexable };
         });
@@ -618,14 +702,22 @@ export function employerProfilePagesPlugin(rootDir: string): Plugin {
           // Longest-first candidates, name never truncated (composePlaceTitle
           // policy) — same "shrink the boilerplate, never the place/name"
           // pattern as job titles (composeSerpJobTitle) and comune titles.
+          //
+          // The last candidate must NEVER be the bare `${H1_PREFIX} ${name}`
+          // string — that's byte-identical to <h1> (see renderProfileBody),
+          // so falling back to it trips audit:h1-title-duplicates (157
+          // offenders, validate-dist run 29794187475). Short-suffix middle
+          // candidate keeps title != h1 for virtually every name; the
+          // TITLE_SUFFIX_SHORT comment explains why this holds even on
+          // further overflow.
           const titleCandidates = [
             `${H1_PREFIX[locale]} ${profile.name}: ${TITLE_SUFFIX[locale]}`,
-            `${H1_PREFIX[locale]} ${profile.name}`,
+            `${H1_PREFIX[locale]} ${profile.name} · ${TITLE_SUFFIX_SHORT[locale]}`,
           ];
           const html = buildSeoPageHtml({
             locale,
             title: composePlaceTitle(titleCandidates, TITLE_MAX_CHARS, (s) => esc(s).length),
-            description: introProse(liveProfile, locale).slice(0, 160),
+            description: introProse(liveProfile, group, locale).slice(0, 160),
             canonicalUrl,
             robots: indexable ? 'index,follow' : 'noindex,follow',
             ogType: 'website',

--- a/build-plugins/eventsSeoPagesPlugin.ts
+++ b/build-plugins/eventsSeoPagesPlugin.ts
@@ -1439,6 +1439,21 @@ function dynamicFaqPair(
   return { q, a: aHasEvents(weekCount, localizedTitle(next, locale), humanDate(next.startDate, locale)) };
 }
 
+// Cap on ItemList JSON-LD entries per aggregate page (canton/national/comune/
+// digest hubs) — deliberately SMALLER than the visible card-list caps (80/100
+// items, see the `upcoming`/`list` comments above each render* function).
+// Those caps were raised 40/60→80/100 to fix audit:max-bfs-depth (every event
+// needs a real <a href> within crawl depth ≤2); this cap is unrelated to that
+// and stays independent. `lightEventLd()` already strips optional fields, but
+// even the "light" per-event JSON-LD entry for the busiest canton hub (Bern —
+// the most-crawled canton) pushed 2 pages ~1 KB over the 260 KB audit:page-
+// weight budget (validate-dist run 29794187475). Google's rich-result
+// eligibility already only surfaces a handful of ItemList entries regardless
+// of how many are marked up, so trimming the JSON-LD tail (while every event
+// keeps its real visible <a href> card, so BFS reachability is untouched) is
+// a real byte reduction rather than a page-weight-only patch.
+const EVENT_JSONLD_ITEM_CAP = 50;
+
 /**
  * Events eligible for Event JSON-LD markup on aggregate ItemList pages
  * (#3508): Google's event structured-data guidelines say not to mark up
@@ -1447,13 +1462,14 @@ function dynamicFaqPair(
  * year-long start→end span). Markup-only filter — the visible HTML list
  * is NOT affected (no page/content cut): keep events whose startDate is
  * today or later, with a 1-day grace window for timezone skew.
- * ISO yyyy-mm-dd strings compare lexicographically.
+ * ISO yyyy-mm-dd strings compare lexicographically. Also caps the result at
+ * {@link EVENT_JSONLD_ITEM_CAP} — see that constant for why.
  */
 function markupEligibleEvents(events: SiteEvent[], dateStamp: string): SiteEvent[] {
   const cutoff = new Date(`${dateStamp}T00:00:00Z`);
   cutoff.setUTCDate(cutoff.getUTCDate() - 1);
   const cutoffIso = cutoff.toISOString().slice(0, 10);
-  return events.filter((e) => e.startDate >= cutoffIso);
+  return events.filter((e) => e.startDate >= cutoffIso).slice(0, EVENT_JSONLD_ITEM_CAP);
 }
 
 export function renderHubPage(params: {

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -20,6 +20,7 @@ import { buildSlimSeed } from './shared/slimJobIndex';
 import { readCompatPaths } from '../scripts/lib/compat-paths-store.mjs';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { buildJobPostingFaqPairs, type BuildJobPostingFaqOptions } from './shared/jobPostingFaq';
+import { hostFromUrl } from './shared/hostFromUrl';
 import { dedupeUrlsetXmlByLoc } from './shared/sitemapUrlsetDedupe';
 import { stripLiteralMarkdown as stripLiteralMarkdownFromTitle } from './shared/stripLiteralMarkdown';
 import { minifyHtml } from './shared/htmlMinify';
@@ -1757,14 +1758,6 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  let h = 5381;
  for (let i = 0; i < s.length; i += 1) h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
  return h;
- };
- const hostFromUrl = (raw?: string): string => {
- if (!raw) return '';
- try {
- return new URL(raw).hostname.replace(/^www\./i, '').toLowerCase();
- } catch {
- return '';
- }
  };
  const companyWebsite = (job: any): string => {
  const domain = job?.companyDomain || hostFromUrl(job?.url);

--- a/build-plugins/salaryStatsChCantonPages.ts
+++ b/build-plugins/salaryStatsChCantonPages.ts
@@ -400,7 +400,17 @@ ${prose}${endOfContentMultiplexHtml({ indexable: true })}</div>`;
   // `metaTitle` carries the "2026 — mediana e settori (dati BFS)" suffix;
   // falls back to the shorter `h1` template (no year/source clause) when a
   // longer canton display name would overflow TITLE_MAX_CHARS.
-  const titleCandidates = [c.metaTitle(cantonName), c.h1(cantonName)];
+  //
+  // The bare `c.h1(cantonName)` fallback used to be the LAST candidate —
+  // byte-identical to the actual <h1> rendered below, which trips
+  // audit:h1-title-duplicates whenever a canton name is long enough to
+  // overflow `metaTitle`. Sibling of the exact bug fixed in
+  // employerProfilePagesPlugin.ts (validate-dist run 29794187475, found via
+  // check-sibling-patterns.mjs against that fix — CLAUDE.md #6). A trailing
+  // " · 2026" keeps title != h1 by construction (locale-neutral numeric
+  // token, no new translation strings needed) while every Swiss canton name
+  // is short enough that this candidate always has budget to spare.
+  const titleCandidates = [c.metaTitle(cantonName), `${c.h1(cantonName)} · 2026`];
 
   const html = buildSeoPageHtml({
     locale,

--- a/build-plugins/shared/hostFromUrl.ts
+++ b/build-plugins/shared/hostFromUrl.ts
@@ -1,0 +1,20 @@
+/**
+ * Extract a display-safe hostname from an absolute URL (`www.` stripped,
+ * lowercased). Returns `''` on malformed/relative input — callers decide
+ * the fallback.
+ *
+ * Shared so the same extraction logic isn't copy-pasted per call site
+ * (CLAUDE.md #6): originally a private closure in `jobsSeoPagesPlugin.ts`
+ * (`companyWebsite`'s domain resolution), now also used by
+ * `jobPostingFaq.ts` to avoid embedding a third-party ATS's raw URL path
+ * (which can contain arbitrary encoding artifacts, e.g. Rheinmetall's
+ * `___` space/paren escaping) as visible prose text.
+ */
+export function hostFromUrl(raw?: string): string {
+  if (!raw) return '';
+  try {
+    return new URL(raw).hostname.replace(/^www\./i, '').toLowerCase();
+  } catch {
+    return '';
+  }
+}

--- a/build-plugins/shared/jobPostingFaq.ts
+++ b/build-plugins/shared/jobPostingFaq.ts
@@ -17,6 +17,7 @@
  */
 
 import type { EmploymentType, JobPostingSchema } from './jobPostingSchema';
+import { hostFromUrl } from './hostFromUrl';
 
 export type FaqLocale = 'it' | 'en' | 'de' | 'fr';
 
@@ -27,7 +28,9 @@ export interface JobFaqPair {
 
 export interface BuildJobPostingFaqOptions {
   readonly locale: FaqLocale;
-  /** Absolute canonical job URL — used for the "how to apply" answer. */
+  /** Absolute job listing URL (the employer's original posting, falling back
+   * to our own canonical URL) — its HOSTNAME is cited in the "how to apply"
+   * answer, see {@link buildApplyFaq}. */
   readonly jobUrl: string;
   /** Localised canton display name (e.g. "Ticino", "Ginevra"). */
   readonly cantonDisplay: string;
@@ -223,27 +226,37 @@ function buildPermitFaq(opts: BuildJobPostingFaqOptions): JobFaqPair {
 function buildApplyFaq(schema: JobPostingSchema, opts: BuildJobPostingFaqOptions): JobFaqPair {
   const { locale, jobUrl } = opts;
   const company = schema.hiringOrganization.name;
+  // Display the SOURCE HOSTNAME, not the raw jobUrl path: third-party ATS
+  // systems encode arbitrary characters into their URL slugs (e.g.
+  // Rheinmetall's career site turns "/" "(" ")" into literal "_", producing
+  // paths like `ux_ui___xr_designer__m_w_d_`). Interpolating that raw path
+  // into visible prose leaked 3+-underscore runs into <main>, tripping
+  // audit:no-literal-markdown's 0-tolerance separator-run gate even though
+  // nothing here is AI-translation markdown (validate-dist run 29794187475,
+  // 119 offenders). The "Apply now" button (href, not text) still points at
+  // the exact full URL — only the human-readable citation is shortened.
+  const jobHost = hostFromUrl(jobUrl) || jobUrl.replace(/[_=~]{3,}/g, ' ').trim();
   if (locale === 'en') {
     return {
       q: `How do I apply for this position at ${company}?`,
-      a: `Use the "Apply now" button on this page — it links directly to ${company}'s original listing at ${jobUrl}, so your application goes straight to the employer's own applicant-tracking system. Frontaliere Ticino does not collect or forward applications itself.`,
+      a: `Use the "Apply now" button on this page — it links directly to ${company}'s original listing at ${jobHost}, so your application goes straight to the employer's own applicant-tracking system. Frontaliere Ticino does not collect or forward applications itself.`,
     };
   }
   if (locale === 'de') {
     return {
       q: `Wie bewerbe ich mich für diese Stelle bei ${company}?`,
-      a: `Nutzen Sie die Schaltfläche "Jetzt bewerben" auf dieser Seite — sie führt direkt zum Original-Inserat von ${company} unter ${jobUrl}, sodass Ihre Bewerbung direkt im Bewerbermanagementsystem des Arbeitgebers landet. Frontaliere Ticino sammelt oder leitet keine Bewerbungen selbst weiter.`,
+      a: `Nutzen Sie die Schaltfläche "Jetzt bewerben" auf dieser Seite — sie führt direkt zum Original-Inserat von ${company} unter ${jobHost}, sodass Ihre Bewerbung direkt im Bewerbermanagementsystem des Arbeitgebers landet. Frontaliere Ticino sammelt oder leitet keine Bewerbungen selbst weiter.`,
     };
   }
   if (locale === 'fr') {
     return {
       q: `Comment postuler à ce poste chez ${company} ?`,
-      a: `Utilisez le bouton « Postuler maintenant » sur cette page — il renvoie directement à l'annonce originale de ${company} sur ${jobUrl}, votre candidature arrive donc directement dans le système de suivi des candidatures de l'employeur. Frontaliere Ticino ne collecte ni ne transmet lui-même les candidatures.`,
+      a: `Utilisez le bouton « Postuler maintenant » sur cette page — il renvoie directement à l'annonce originale de ${company} sur ${jobHost}, votre candidature arrive donc directement dans le système de suivi des candidatures de l'employeur. Frontaliere Ticino ne collecte ni ne transmet lui-même les candidatures.`,
     };
   }
   return {
     q: `Come mi candido a questa posizione presso ${company}?`,
-    a: `Usa il pulsante "Candidati ora" in questa pagina — rimanda direttamente all'annuncio originale di ${company} su ${jobUrl}, quindi la tua candidatura arriva direttamente nel sistema di gestione candidature del datore di lavoro. Frontaliere Ticino non raccoglie né inoltra candidature in proprio.`,
+    a: `Usa il pulsante "Candidati ora" in questa pagina — rimanda direttamente all'annuncio originale di ${company} su ${jobHost}, quindi la tua candidatura arriva direttamente nel sistema di gestione candidature del datore di lavoro. Frontaliere Ticino non raccoglie né inoltra candidature in proprio.`,
   };
 }
 

--- a/tests/employer-profile-pages.test.ts
+++ b/tests/employer-profile-pages.test.ts
@@ -36,6 +36,7 @@ function job(i: number) {
     canton: 'TI',
     datePosted: '2026-07-10',
     employmentType: 'FULL_TIME',
+    contract: 'full-time',
     salaryMin: 80000 + i * 1000,
     salaryMax: 120000 + i * 1000,
     url: `https://acme.example/job/${i}`,
@@ -118,6 +119,19 @@ describe('employerProfilePagesPlugin', () => {
     expect(html).toContain('Lavorare in Acme Corp');
     expect(html).toContain('6'); // active jobs
     expect(html).toContain("CHF 100"); // median salary formatted
+  });
+
+  // text-html-ratio follow-up (validate-dist run 29794187475, PR #4611
+  // follow-up): real per-company facts computed from the FULL active-job
+  // set (not just the ≤8 cards shown), genuinely new visible text.
+  it('adds a real contract-mix and salary-range sentence from the full active-job set', () => {
+    const html = read('aziende/acme-corp/index.html');
+    // All 7 seeded jobs are 'full-time' → unanimous contract-mix sentence.
+    expect(html).toContain('Tutte le posizioni attive sono a tempo pieno.');
+    // salaryMin/salaryMax vary 81'000..127'000 across the 7 jobs — a real
+    // range distinct from the single CHF 100'000 median stat tile.
+    expect(html).toContain('CHF 81');
+    expect(html).toContain('CHF 127');
   });
 
   it('embeds COMPLETE JobPosting structured data (Non-Negotiable #3)', () => {

--- a/tests/events-detail-pages.test.ts
+++ b/tests/events-detail-pages.test.ts
@@ -933,6 +933,40 @@ describe('events schema data quality (#3508)', () => {
     // Markup-only filter: the stale event must still be visible in the HTML list.
     expect(page.html).toContain('Chilbi Vecchia');
   });
+
+  // Regression guard: validate-dist run 29794187475 found the Bern canton hub
+  // (the most-crawled canton, closest to the 100-event visible-card cap) ~1 KB
+  // over the 260 KB audit:page-weight budget — the ItemList JSON-LD mirrored
+  // all 100 visible cards' worth of `lightEventLd()` entries. The fix caps
+  // JSON-LD entries independently of the visible card list (EVENT_JSONLD_ITEM_CAP
+  // in eventsSeoPagesPlugin.ts), so every event still gets a real crawlable
+  // <a href> card (audit:max-bfs-depth reachability untouched) while the
+  // invisible structured-data tail shrinks.
+  it('caps ItemList JSON-LD entries well below the visible card count on a large hub', () => {
+    const dateStamp = '2026-06-30';
+    const events = Array.from({ length: 120 }, (_, i) => ({
+      ...EVENT,
+      id: `myswitzerland:${i}`,
+      title: `Evento Berna ${i}`,
+      startDate: `2026-07-${String((i % 27) + 1).padStart(2, '0')}`,
+      endDate: `2026-07-${String((i % 27) + 1).padStart(2, '0')}`,
+    })).sort((a, b) => a.startDate.localeCompare(b.startDate));
+    const page = renderHubPage({
+      locale: 'it',
+      canton: 'BE',
+      events: events as never,
+      byComune: new Map([['Bern', events]]) as never,
+      dateStamp,
+      weekendDays: new Set<string>(),
+      distDir,
+    });
+    const itemLists = [...page.html.matchAll(/<script type="application\/ld\+json">(\{"@context":"https:\/\/schema\.org","@type":"ItemList".*?\})<\/script>/g)];
+    const parsed = JSON.parse(itemLists[0][1]) as { itemListElement: unknown[] };
+    expect(parsed.itemListElement.length).toBeLessThanOrEqual(50);
+    // Visible cards stay uncapped by this change — every event keeps its own
+    // crawlable link (audit:max-bfs-depth reachability, PR #4611 fix #3645).
+    expect(page.html).toContain('Evento Berna 99');
+  });
 });
 
 describe('assignEventSlugs (issue #3700 — past-bridge slug collision)', () => {

--- a/tests/salary-stats-landing.test.ts
+++ b/tests/salary-stats-landing.test.ts
@@ -118,4 +118,28 @@ describe('salaryStats — page render', () => {
     expect(html).toContain('94%'); // vs-national tile (region median path)
     expect(html).toContain("105'000"); // gross-band high = round5000(110000 × 6623/7024), region-scaled
   });
+
+  // Regression guard: sibling of the employer-profiles bug fixed for
+  // validate-dist run 29794187475 (found via check-sibling-patterns.mjs).
+  // The title-length fallback candidate used to be the bare `c.h1(cantonName)`
+  // string — byte-identical to the actual <h1>, which trips
+  // audit:h1-title-duplicates whenever a canton name is long enough that
+  // `metaTitle` overflows TITLE_MAX_CHARS.
+  it('never emits a <title> byte-identical to the <h1> for any canton/locale', () => {
+    for (const key of SALARY_STATS_CANTON_KEYS) {
+      for (const locale of SALARY_STATS_LOCALES) {
+        const { html } = renderSalaryStatsPage({
+          locale,
+          cantonKey: key,
+          cantonSlug: SALARY_STATS_CANTON_SLUGS[key][locale],
+          distDir: '',
+        });
+        const title = html.match(/<title>([\s\S]*?)<\/title>/)?.[1];
+        const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)?.[1];
+        expect(title, `${key}/${locale} <title>`).toBeTruthy();
+        expect(h1, `${key}/${locale} <h1>`).toBeTruthy();
+        expect(title, `${key}/${locale} title !== h1`).not.toBe(h1);
+      }
+    }
+  });
 });

--- a/tests/seo/jobposting-faq.test.ts
+++ b/tests/seo/jobposting-faq.test.ts
@@ -110,10 +110,29 @@ describe('buildJobPostingFaqPairs', () => {
     }
   });
 
-  it('mentions the apply URL in the how-to-apply answer', () => {
+  it('mentions the apply URL hostname in the how-to-apply answer', () => {
     const schema = buildJobPostingSchema(TICINO_JOB, BASE_OPTS);
     const pairs = buildJobPostingFaqPairs(schema, faqOptsFor(TICINO_JOB, true, 'Ticino'));
-    expect(pairs[3].a).toContain(TICINO_JOB.url);
+    expect(pairs[3].a).toContain('acme.example.com');
+  });
+
+  // Regression guard: validate-dist run 29794187475 found 119 job pages
+  // where a third-party ATS URL (Rheinmetall) encoded spaces/parens as
+  // literal "_", producing a 3+-underscore run once interpolated verbatim
+  // into this FAQ answer's prose — tripping audit:no-literal-markdown's
+  // 0-tolerance separator-run gate even though the source isn't AI-translated
+  // markdown. The answer must cite only the hostname, never the raw path.
+  it('never leaks a 3+-underscore (or "=", "~") run from the raw ATS URL path', () => {
+    const job: JobInput = {
+      ...TICINO_JOB,
+      url: 'https://www.rheinmetall.com/en/job/ux_ui___xr_designer__m_w_d_/1081238',
+    };
+    const schema = buildJobPostingSchema(job, BASE_OPTS);
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const pairs = buildJobPostingFaqPairs(schema, { ...faqOptsFor(job, true, 'Ticino'), locale });
+      expect(pairs[3].a).not.toMatch(/[_=~]{3,}/);
+      expect(pairs[3].a).toContain('rheinmetall.com');
+    }
   });
 });
 


### PR DESCRIPTION
## Implementato

Diagnosed the 4 remaining `audit:all` failures from post-#4611 run [29794187475](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29794187475/job/88522058703) by downloading its `audit-reports` artifact (exact offender lists) and curling the live prod page for one offender, rather than guessing from code alone.

- **audit:no-literal-markdown (119 job pages)**: root cause was NOT AI-translation markdown — `build-plugins/shared/jobPostingFaq.ts`'s "how to apply" FAQ answer interpolates the raw external `job.url` into visible prose ("...links directly to {company}'s original listing at {jobUrl}..."). Rheinmetall's ATS encodes spaces/parens/slashes in job-title URL segments as literal `_` (e.g. `ux_ui___xr_designer__m_w_d_`), producing 3+-underscore runs that trip `SEPARATOR_RUN_RE` even though nothing here is AI-translated content. Fix: cite only the hostname (`hostFromUrl()`, extracted to `build-plugins/shared/hostFromUrl.ts` since `jobsSeoPagesPlugin.ts` already had an identical private closure — deduped per CLAUDE.md #6, that file now imports the shared version). The "Apply now" button `href` is untouched — only the human-readable citation shortened. `services/seoService.ts`'s SPA-runtime FAQ (same shared `buildJobPostingFaqPairs`) inherits the fix automatically, no separate change needed.
- **audit:h1-title-duplicates (157 employer-profiles offenders)**: `employerProfilePagesPlugin.ts`'s `composePlaceTitle` cascade (added by #4611 to fix `audit:title-length`) had its last-resort fallback candidate as the bare `"{H1_PREFIX} {name}"` string — byte-identical to the page's own `<h1>`. Any company name long enough to overflow the full-suffix candidate fell through to a `<title>` == `<h1>`. Fix: a short-suffix middle candidate (`TITLE_SUFFIX_SHORT`, e.g. "· offerte") guarantees `title !== h1` by construction — even on further overflow, `composePlaceTitle`'s `truncateHeadline()` fallback always appends `…`, which also never equals the untruncated h1. `check-sibling-patterns.mjs` found the **exact same bug** in `build-plugins/salaryStatsChCantonPages.ts` (`titleCandidates = [c.metaTitle(cantonName), c.h1(cantonName)]` — fallback literally calls the same `c.h1()` used for the rendered `<h1>`); fixed with the same "trailing distinguishing token" pattern (` · 2026`, locale-neutral, no new translation strings). Added a full canton×locale regression test (`tests/salary-stats-landing.test.ts`) asserting `title !== h1` for all 26 cantons × 4 locales.
- **audit:page-weight (2 events canton-hub pages, `fr/evenements/berne` + `de/veranstaltungen/bern` — Bern is the most-crawled canton, closest to the 100-event visible-card cap — ~1KB over the 260KB budget)**: `eventsSeoPagesPlugin.ts`'s `itemListLd` JSON-LD mirrors the FULL visible card-list length (80/100 items, raised by an earlier PR specifically to fix `audit:max-bfs-depth` reachability) across all 5 hub-render functions (`renderHubPage`, `renderEventsIndexPage`, `renderComunePage`, `renderOtherEventsPage`, `renderDigestPage`). Fix: `markupEligibleEvents()` now caps its output at `EVENT_JSONLD_ITEM_CAP = 50` — decoupling the (invisible, redundant-past-a-point) structured-data tail from the visible card count. Every event still gets a real crawlable `<a href>` card, so the BFS-reachability fix this cap increase was for is untouched. Single fix point covers all 5 sibling call sites (they all funnel through this one function). Added a regression test with a 120-event synthetic hub asserting the JSON-LD entry count stays ≤50 while a card near the end of the visible list (`Evento Berna 99`) is still present in the HTML.
- **audit:text-html-ratio (employer-profiles)**: live measured ratio was ~5% (e.g. `dist/en/aziende/stadt-chur/index.html`: 1763 text bytes / 34926 html bytes), roughly half of PR #4611's own local estimate (~9.8%) — its comment already admitted this couldn't be verified against a real 2.8M-page `dist/` locally. Re-tuning `MAX_JOBS_LISTED` again was **not** the lever: #4611's own comment on that constant documents it was already verified that more cards add more mandatory-complete `JobPosting` JSON-LD (Non-Negotiable #3) far faster than they add visible card text — reverting it up would make the ratio worse, not better. Instead added two genuine new sentences to `introProse()`, computed from the company's **full** active-job set (not just the ≤8 displayed cards, via a new `allActiveJobs` param threaded through `renderProfileBody`): a real contract-type-majority sentence and a real salary min–max range (distinct from the existing single median stat tile). Both gracefully return `''` when the underlying data is too sparse to say anything meaningful (same pattern as the existing `cantonsProse`/`citiesProse`).

## Non implementato (ancora)

- **audit:text-html-ratio full clearance for employer-profiles**: the two new sentences (~150-200 bytes/locale) meaningfully narrow the gap but do **not** close it to 10% for most of the ~1860 profiles — closing it fully would need roughly 2x the current real text per page, and the dominant remaining cost (per-card `JobPosting` JSON-LD, mandated complete by Non-Negotiable #3) is already capped/shared with other page types (`LIST_ITEM_DESCRIPTION_CAP = 300` in `jobPostingListItem.ts`) so isn't safely reducible further without affecting unrelated page types. **Next step**: watching the next post-deploy `validate-dist` run to confirm the real (not locally-estimated) new ratio; if still short, the two realistic options are (a) a genuine per-employer content investment (cost/quality tradeoffs similar to those already noted for AI-generated job descriptions elsewhere in the codebase), or (b) a dedicated baseline/cap for this bucket's `text-html-ratio` gate, mirroring the existing precedent for the `eventi` bucket (4577 offenders, already excluded from `regressedFeatures` rather than held to 10%) — this page type may be structurally incompatible with a flat 10% floor given the mandatory dense JSON-LD. Needs an explicit owner/reviewer call on which path, not silently resolved here — `blocked: needs owner decision on (a) vs (b), see above`.
- **`check-sibling-patterns.mjs --strict` surfaced 50 sibling candidates across ~12 shared-token groups** on push; every one individually inspected (not a collective dismiss). All are coincidental identifier/type reuse, not the same antipattern:
  - `JobCardJob` / `renderJobCardHtml` / `JOB_CARD_ICON_SYMBOLS` / `localizedContract` (`shared/jobCardHtml.ts`, `weeklyEmployersPlugin.ts`, `careerLandingsPlugin.ts`, `costOfLivingLandingsPlugin.ts`, `healthFacilitiesPlugin.ts`, `jobRecencyPagesPlugin.ts`, `jobSectorPagesPlugin.ts`, `nursingLandingsPlugin.ts`, `professionLandingsPlugin.ts`, `orphanQueryLandingPlugin.ts`, `seoHubsPlugin.ts`) — false positive: these files correctly *consume* the shared job-card component I imported from (`localizedContract`); none duplicate it.
  - `composePlaceTitle` / `titleCandidates` (`salaryProfessionCantonPages.ts`, `professionCantonLandings.ts`, `professionCityLandings.ts`, `fiscalMunicipalityPagesPlugin.ts`, `companyHubBridgePlugin.ts`, `locationHubBridgePlugin.ts`, `shared/titleSuffix.ts`) — false positive: individually inspected each cascade's last-resort candidate vs. that page's own `<h1>` template. `professionCantonLandings.ts`/`professionCityLandings.ts`/`salaryProfessionCantonPages.ts` fall back to `BRIDGE_COPY[locale].title(...)`, a *different* string template than `c.h1(...)`. `fiscalMunicipalityPagesPlugin.ts` falls back to the bare comune name `n`, while its `<h1>` is `c.h1(n)` (a wrapping template) — different strings. `companyHubBridgePlugin.ts`/`locationHubBridgePlugin.ts`'s `matchedTitle` cascade bottoms out at `"Offerte di lavoro {c}"` while `matchedH1` is `"{n} annunci {c}"` — different word order/content, not a duplicate. `shared/titleSuffix.ts` is the shared module itself (imported, not duplicated).
  - `EmployerProfile` type (`employerProfilePagesLinksPlugin.ts`, `searchConsoleCompat.ts`, `shared/buildSignals.ts`) and the `employerProfilePagesPlugin` filename token (`.github/workflows/refresh-employer-profiles.yml`, `shared/brandCanonicalMap.ts`, `shared/companyProfileSlug.mjs`, `shared/employerProfileConfig.mjs`, `scripts/build-employer-profiles.mjs`, `scripts/lib/employerLandingSections.mjs`, `services/router.ts`) — false positive: these are consumers/infra around the plugin I edited (config, slug helper, routing, its own generator/workflow), not independent reimplementations of any of the 3 fixed antipatterns.
  - `cantonName` (`healthFacilitiesPlugin.ts`, `healthFacilitiesCopy.ts`, `jobMarketSnapshotChCantonPages.ts`, `weeklyEmployersChCantonPages.ts`, `scripts/lib/target-swiss-locations.mjs`, `scripts/schedule-fb-events-daily.mjs`, `scripts/schedule-fb-jobs-daily.mjs`) — false positive: generic per-canton variable name used across dozens of unrelated files; none of these use `composePlaceTitle` with a bare-h1 fallback (already covered above).
  - `salaryRange` (`jobSectorLanding.ts`, `components/community/JobBoard.tsx`, `components/comparators/SalaryCompare.tsx`, `services/locales/{it,en,de,fr}-core.ts`) — false positive: verified each is either a static curated-copy field (`jobSectorLanding.ts`) or the unrelated SPA salary-range **filter** UI/translation-key feature (`JobBoard.tsx`, `SalaryCompare.tsx`, locale files) — not my new `salaryRangeProse()` aggregate-stat function.
  - `topCount` (`orphanQueryLandingPlugin.ts`, `orphanQueryData.ts`, `scripts/analytics-report.mjs`, `scripts/lib/alerts/detectors/algorithm.mjs`) — false positive: `orphanQueryData.ts`'s `topCounts()` is an unrelated generic "top-N by frequency" utility; the other two are unrelated local-variable/field-name coincidences.
  - `companyWebsite` (`components/pages/AdminPanel.tsx`, `scripts/generate-company-parser.mjs`, `scripts/lib/shared-jobs-crawler.mjs`) — false positive: unrelated local variable/parameter names for "employer website URL" input in admin-form parsing and crawler-seed generation, not the `hostFromUrl`-based closure I deduped in `jobsSeoPagesPlugin.ts`.
  - `TITLE_SUFFIX` (`scripts/create-article.mjs`) — false positive: a different, unrelated local constant (`' | Frontaliere Ticino'` blog-article brand suffix), same generic name as the pre-existing employer-profiles `TITLE_SUFFIX` I left untouched (I only added `TITLE_SUFFIX_SHORT` alongside it).
  - `jobPostingFaq` (`services/seoService.ts`) — not a gap: this is the SPA-runtime caller of the exact shared function I fixed (`buildJobPostingFaqPairs`), so it inherits the fix automatically with no separate change needed.

## Test plan

- [x] `npx vitest run tests/seo/jobposting-faq.test.ts tests/employer-profile-pages.test.ts tests/events-detail-pages.test.ts tests/salary-stats-landing.test.ts tests/regression/seo-static-ad-slots.test.ts tests/seo/title-uniqueness.test.ts` — 183 passing, including 3 new regression tests (raw-URL-leak guard, JSON-LD cap on a 120-event synthetic hub, title≠h1 across all 26 cantons × 4 locales)
- [x] `npx tsc --noEmit` — zero errors in any touched file (pre-existing unrelated errors on `origin/main` in unrelated test files left untouched)
- [ ] Live `validate-dist` run post-merge — will confirm all 3 fully-fixed audits (no-literal-markdown, h1-title-duplicates, page-weight) go green and give the real (not locally-estimated) new text-html-ratio number for employer-profiles; watching per repo convention

Fixes the 4 remaining `audit:all` failures from run 29794187475 (post-#4611 merge).