### PR TITLE
fix(articles): diagnostica live pool news + fix evergreen svizzera Ticino-only

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -328,6 +328,8 @@ jobs:
             const dupLines = Object.keys(dup).length
               ? Object.entries(dup).map(([k,v]) => `- ${k}: ${v}`).join("\n")
               : "- none";
+            const preDrops = r.preFilterDrops || {};
+            const samples = Array.isArray(r.discardedHeadlineSamples) ? r.discardedHeadlineSamples : [];
             const lines = [
               "## Create-article report",
               "",
@@ -342,6 +344,26 @@ jobs:
               "### Headline pool stats",
               `- total=${r.headlines?.total ?? 0}, recent=${r.headlines?.recent ?? 0}, undated=${r.headlines?.undated ?? 0}`,
               `- usedRecent=${r.headlines?.usedRecent ?? 0}, usedUndated=${r.headlines?.usedUndated ?? 0}`,
+              `- droppedPreSpendGate=${r.headlines?.droppedPreSpendGate ?? 0} (frontaliere-relevance classifier)`,
+              "",
+              "### Fase 1 pre-filter drops (perché la pool news si è svuotata)",
+              `- URL gia usata (source gia pubblicata): ${preDrops.urlAlreadyUsed ?? 0}`,
+              `- Topic gia coperto (dedup vs corpus): ${preDrops.topicAlreadyCovered ?? 0}`,
+              "",
+              samples.length
+                ? [
+                    "| motivo | headline scartata | matcha con | segnale |",
+                    "|---|---|---|---|",
+                    ...samples.map((s) => {
+                      const headline = String(s.headline || "").replace(/\|/g, "\\|").slice(0, 90);
+                      const matched = s.existingTitle
+                        ? `${String(s.existingTitle).replace(/\|/g, "\\|").slice(0, 90)} (${s.existingId || ""})`
+                        : (s.existingId || s.classifierReason || "-");
+                      const signal = s.sim != null ? `${s.signal}=${s.sim}` : (s.signal || s.reason || "-");
+                      return `| ${s.reason || "-"} | ${headline} | ${matched} | ${signal} |`;
+                    }),
+                  ].join("\n")
+                : "_nessun sample registrato questo run._",
               "",
               "### Report file",
               `- \`${p}\``

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -9033,15 +9033,37 @@ async function main() {
             // out already-used, skip to the next headline instead of fetching
             // an unusable news.google.com wrapper (which would yield no source
             // text → topic-gate abort → wasted attempt).
+            //
+            // `attempt--` before both `continue`s below (2026-07-21): these are
+            // CHEAP skips (no LLM call, no fetch of source content) — the
+            // candidate never reached generateAndValidateArticle. Without the
+            // decrement they silently consumed a MAX_DUPLICATE_RETRIES slot
+            // just like an expensive failed generation, so a run whose first
+            // 8 ranker picks all happened to decode to already-published
+            // Google News wrappers (common: the same underlying story
+            // re-surfaces under many GNews headline variants) burned its
+            // entire retry budget on decode-only skips and fell through to
+            // the Fase 2 evergreen fallback WITHOUT EVER calling
+            // generateAndValidateArticle once — even though `triedUrls`
+            // (updated above at candidate-selection time) still had dozens of
+            // untried, already relevance/dedup-filtered headlines left in
+            // `pool.headlines`. Confirmed live: run 29801301652 logged exactly
+            // 8 consecutive "URL già usata" skips before "Fase 2: Fallback
+            // evergreen", pool=93 headlines still available. The decrement
+            // makes these free (bounded only by wall-clock/availableHeadlines
+            // guards above, same as before), reserving MAX_DUPLICATE_RETRIES
+            // for attempts that actually spend LLM budget.
             if (chosen?._needsGoogleNewsDecode || isGoogleNewsRssUrl(url)) {
               const realUrl = await decodeGoogleNewsUrl(url);
               if (!realUrl) {
-                console.error(`   ⏭️  Google News non decodificabile — provo un'altra headline: "${String(chosen.headline || '').slice(0, 60)}"`);
+                console.error(`   ⏭️  Google News non decodificabile — provo un'altra headline (non conta come tentativo): "${String(chosen.headline || '').slice(0, 60)}"`);
+                attempt--;
                 continue;
               }
               const used = isSourceUrlAlreadyUsed(realUrl);
               if (used.used) {
-                console.error(`   🔗 Google News decodificata ma URL già usata (→ ${used.articleId}) — provo un'altra headline`);
+                console.error(`   🔗 Google News decodificata ma URL già usata (→ ${used.articleId}) — provo un'altra headline (non conta come tentativo)`);
+                attempt--;
                 continue;
               }
               console.error(`   🔓 Google News decodificata → fonte reale: ${realUrl.slice(0, 80)}`);

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -567,6 +567,13 @@ async function applyPreSpendTopicGate(headlines, opts = {}) {
       }
     }
   }
+  for (const f of filtered) {
+    recordDiscardedHeadline({
+      reason: 'not_frontaliere_relevant',
+      headline: f.rawHeadline,
+      classifierReason: f.reason,
+    });
+  }
   if (typeof RUN_REPORT === 'object' && RUN_REPORT?.headlines) {
     RUN_REPORT.headlines.droppedPreSpendGate = (RUN_REPORT.headlines.droppedPreSpendGate || 0) + dropped;
     RUN_REPORT.headlines.preSpendGateClassifierCalls = (RUN_REPORT.headlines.preSpendGateClassifierCalls || 0) + classifierCalls;
@@ -1128,6 +1135,16 @@ const RUN_REPORT = {
     attemptsUndated: 0,
   },
   duplicateReasonBreakdown: {},
+  // Pre-generation pool-exhaustion diagnostics (2026-07-21): the Fase 1 news
+  // pool routinely empties before any headline reaches generation, silently
+  // falling back to Fase 2 evergreen. These counts + samples make WHY a
+  // headline was dropped (and WHAT it matched) visible in the run's step
+  // summary instead of requiring a raw-log grep after the fact.
+  preFilterDrops: {
+    urlAlreadyUsed: 0,
+    topicAlreadyCovered: 0,
+  },
+  discardedHeadlineSamples: [],
   article: {
     id: null,
     url: null,
@@ -1137,6 +1154,16 @@ const RUN_REPORT = {
 };
 
 let REPORT_FINALIZED = false;
+
+// Cap on discardedHeadlineSamples — a single run's pre-filter can drop 50-100+
+// headlines; the report only needs enough examples to judge whether the gate
+// is catching real duplicates or false-positiving on distinct stories.
+const DISCARDED_HEADLINE_SAMPLE_CAP = 20;
+
+function recordDiscardedHeadline(entry) {
+  if (RUN_REPORT.discardedHeadlineSamples.length >= DISCARDED_HEADLINE_SAMPLE_CAP) return;
+  RUN_REPORT.discardedHeadlineSamples.push(entry);
+}
 
 function addDuplicateReason(key) {
   const k = key || 'other';
@@ -1397,6 +1424,39 @@ const PRIORITY_EVERGREEN_TOPICS = [
   { keyword: 'longlake festival lugano eventi gratuiti', angle: 'LongLake Festival a Lugano: calendario eventi gratuiti, location, come organizzare una serata dall\'altra parte del confine' },
   { keyword: 'blues to bop lugano concerti gratuiti', angle: 'Blues to Bop a Lugano: date, concerti gratuiti in piazza, come organizzare la trasferta serale da chi vive vicino al confine' },
   { keyword: 'fiera di lugano manifestazioni annuali', angle: 'Le principali fiere e manifestazioni annuali a Lugano: calendario, ingresso, cosa aspettarsi, utile per chi organizza la trasferta dal confine' },
+];
+
+// ── Long-tail SEO: evergreen keyword topics — sezione `svizzera` (2026-07-21) ──
+// National-scope counterpart to PRIORITY_EVERGREEN_TOPICS above. The `svizzera`
+// section targets anyone living/working in Switzerland at national scale (see
+// the prompt framing near IS_FRONTALIERE — "NON sei limitato ai frontalieri",
+// spans all cantons), NOT the frontaliere/Ticino niche. Before this pool
+// existed, the Fase 2 fallback for `svizzera` reused PRIORITY_EVERGREEN_TOPICS
+// (100% Ticino/frontaliere keywords) whenever Fase 1 found no usable news —
+// every /articoli-svizzera/ evergreen article ended up Ticino-scoped despite
+// the national prompt wrapper. Keep entries genuinely national/cantonal, no
+// frontaliere framing.
+const PRIORITY_EVERGREEN_TOPICS_SVIZZERA = [
+  { keyword: 'confronto imposta cantonale svizzera cantoni', angle: 'Confronto tra le aliquote di imposta cantonale in Svizzera: perché Zugo e Svitto costano meno di Ginevra o Vaud, con esempi di calcolo' },
+  { keyword: 'costo della vita per cantone svizzera', angle: 'Costo della vita nei principali cantoni svizzeri: affitti, spesa, trasporti e assicurazioni a confronto tra Zurigo, Ginevra, Berna, Basilea e Ticino' },
+  { keyword: 'premi cassa malati lamal per cantone', angle: 'Perché i premi LAMal variano così tanto tra cantoni: fattori regionali, come cambiare cassa, franchigia ottimale e sussidi disponibili' },
+  { keyword: 'salario medio in svizzera per professione', angle: 'Salari medi per professione e settore in Svizzera: dati ufficiali UST/BFS, differenze tra cantoni e città, fattori che spiegano il divario' },
+  { keyword: 'secondo pilastro lpp guida completa svizzera', angle: 'Guida al secondo pilastro LPP: come funziona, contributi, riscatto lacune, prelievo per acquisto casa o partenza dalla Svizzera' },
+  { keyword: 'terzo pilastro 3a vantaggi fiscali svizzera', angle: 'Terzo pilastro 3a: vantaggi fiscali reali, differenze tra 3a bancario e assicurativo, quanto versare per ottimizzare le imposte' },
+  { keyword: 'affitti svizzera diritti inquilino disdetta', angle: 'Diritti dell\'inquilino in Svizzera: deposito cauzionale, procedura di disdetta, contestazione dell\'affitto, differenze cantonali' },
+  { keyword: 'dichiarazione delle imposte in svizzera guida', angle: 'Guida pratica alla dichiarazione delle imposte in Svizzera: scadenze cantonali, deduzioni ammesse, procedura online per cantone' },
+  { keyword: 'permesso di soggiorno svizzera tipologie B C L', angle: 'Permessi di soggiorno in Svizzera: differenze tra permesso B, C e L, requisiti, durata e procedura di rinnovo o conversione' },
+  { keyword: 'cercare lavoro in svizzera dall estero guida', angle: 'Come cercare lavoro in Svizzera: portali di annunci, CV in formato svizzero, colloqui, permesso di lavoro e primi passi burocratici' },
+  { keyword: 'aprire un attivita in svizzera guida pratica', angle: 'Aprire un\'attività in Svizzera: forma giuridica, registro di commercio, capitale minimo, differenze cantonali e oneri fiscali' },
+  { keyword: 'assicurazione disoccupazione svizzera come funziona', angle: 'Assicurazione disoccupazione svizzera: requisiti, calcolo dell\'indennità, durata delle prestazioni, obblighi verso l\'URC' },
+  { keyword: 'naturalizzazione svizzera requisiti procedura', angle: 'Naturalizzazione svizzera: requisiti di residenza, esame di integrazione, costi e differenze procedurali tra cantoni e comuni' },
+  { keyword: 'sistema sanitario svizzero lamal come funziona', angle: 'Come funziona il sistema sanitario svizzero: obbligo LAMal, scelta della cassa malati, franchigia, rimborsi e pronto soccorso' },
+  { keyword: 'comprare casa in svizzera mutuo requisiti', angle: 'Comprare casa in Svizzera: requisiti del mutuo ipotecario, fondi propri minimi, tassi, differenze tra banche cantonali e private' },
+  { keyword: 'votazioni federali svizzera come funzionano', angle: 'Come funziona la democrazia diretta svizzera: iniziative popolari, referendum, doppia maggioranza di popolo e cantoni' },
+  { keyword: 'trasporti pubblici svizzera abbonamenti sconti', angle: 'Guida agli abbonamenti di trasporto pubblico in Svizzera: AG, mezza tariffa, abbonamenti cantonali e comunitari, costi e vantaggi' },
+  { keyword: 'lavoro part-time in svizzera diritti contratto', angle: 'Lavoro part-time in Svizzera: diritti contrattuali, contributi sociali proporzionali, ferie, differenze rispetto al tempo pieno' },
+  { keyword: 'congedo parentale svizzera durata indennita', angle: 'Congedo di maternità e paternità in Svizzera: durata, indennità giornaliera, procedura di richiesta, differenze cantonali per gli assegni' },
+  { keyword: 'franco svizzero economia bns politica monetaria', angle: 'Il ruolo della Banca Nazionale Svizzera (BNS): politica monetaria, tassi di interesse, impatto del franco forte su economia e salari' },
 ];
 
 // ── News sources to auto-scan ───────────────────────────────
@@ -2123,6 +2183,43 @@ function buildDynamicEvergreenTopics() {
       out.push({
         keyword: `${base.k} ${addon}`,
         angle: `${base.a} Focus su "${addon}" con checklist operativa e confronto scenari.`,
+      });
+    }
+  }
+  return out;
+}
+
+// National counterpart to buildDynamicEvergreenTopics, for the `svizzera`
+// section (2026-07-21, see PRIORITY_EVERGREEN_TOPICS_SVIZZERA above for the
+// full rationale). Addon dimension is cantons instead of frontaliere-specific
+// facets (20km confine, permesso G, ...) so the combinatorial pool stays
+// genuinely national instead of re-deriving Ticino-only angles.
+function buildDynamicEvergreenTopicsSvizzera() {
+  const y = new Date().getFullYear();
+  const pillars = [
+    { k: `imposta cantonale confronto svizzera ${y}`, a: `Confronto ${y} delle aliquote di imposta cantonale in Svizzera: differenze tra cantoni, scaglioni e strategie di ottimizzazione lecita.` },
+    { k: `costo della vita svizzera ${y}`, a: `Analisi ${y} del costo della vita in Svizzera: affitti, spesa alimentare, trasporti e assicurazioni a confronto tra cantoni.` },
+    { k: `premi cassa malati lamal ${y}`, a: `Guida ${y} ai premi LAMal: differenze cantonali, franchigia ottimale, cambio cassa e sussidi disponibili.` },
+    { k: `salario medio professioni svizzera ${y}`, a: `Salari medi per professione in Svizzera nel ${y}: confronto tra cantoni e settori, con dati ufficiali e fattori di variazione.` },
+    { k: `secondo pilastro lpp svizzera guida ${y}`, a: `Guida ${y} al secondo pilastro LPP: contributi, prelievo, riscatto lacune e pianificazione previdenziale in Svizzera.` },
+    { k: `affitti svizzera mercato immobiliare ${y}`, a: `Mercato degli affitti in Svizzera nel ${y}: prezzi medi per cantone, diritti dell'inquilino, deposito cauzionale e disdetta.` },
+    { k: `dichiarazione imposte svizzera guida pratica ${y}`, a: `Guida pratica ${y} alla dichiarazione delle imposte in Svizzera: scadenze cantonali, deduzioni ammesse, procedura online.` },
+    { k: `terzo pilastro 3a svizzera vantaggi ${y}`, a: `Guida ${y} al terzo pilastro 3a: vantaggi fiscali, provider bancari e assicurativi, strategia di versamento.` },
+    { k: `cercare lavoro in svizzera guida pratica ${y}`, a: `Guida ${y} alla ricerca di lavoro in Svizzera: portali, CV svizzero, colloqui e permesso di lavoro.` },
+    { k: `sistema sanitario svizzero lamal guida ${y}`, a: `Guida ${y} al sistema sanitario svizzero: obbligo LAMal, scelta della cassa, franchigia e rimborsi.` },
+  ];
+  const addOns = [
+    'canton Zurigo', 'canton Ginevra', 'canton Berna', 'canton Basilea',
+    'canton Vaud', 'canton San Gallo', 'canton Lucerna', 'canton Argovia',
+  ];
+
+  const out = [];
+  for (const base of pillars) {
+    out.push({ keyword: base.k, angle: base.a });
+    for (const addon of addOns) {
+      out.push({
+        keyword: `${base.k} ${addon}`,
+        angle: `${base.a} Focus sul ${addon} con dati specifici e confronto nazionale.`,
       });
     }
   }
@@ -8633,6 +8730,13 @@ async function main() {
         const check = isSourceUrlAlreadyUsed(h.url);
         if (check.used) {
           console.error(`  🔗 Headline scartata (URL già usata → ${check.articleId}): ${h.headline.slice(0, 60)}…`);
+          RUN_REPORT.preFilterDrops.urlAlreadyUsed += 1;
+          recordDiscardedHeadline({
+            reason: 'url_already_used',
+            headline: h.headline,
+            existingId: check.articleId,
+            signal: check.signal,
+          });
           return false;
         }
         return true;
@@ -8651,6 +8755,15 @@ async function main() {
         const check = preFlightHeadlineCheck(h.headline);
         if (check.duplicate) {
           console.error(`  📰 Headline scartata (topic già coperto → ${check.existingId}, ${check.signal}=${check.sim.toFixed(2)}): ${h.headline.slice(0, 60)}…`);
+          RUN_REPORT.preFilterDrops.topicAlreadyCovered += 1;
+          recordDiscardedHeadline({
+            reason: 'topic_already_covered',
+            headline: h.headline,
+            existingId: check.existingId,
+            existingTitle: check.existingTitle,
+            signal: check.signal,
+            sim: Number(check.sim.toFixed(3)),
+          });
           return false;
         }
         return true;
@@ -9058,9 +9171,19 @@ async function main() {
       // instead of another hand-written batch, since those saturate every
       // 1-2 weeks as the corpus grows (#3138 2026-07-02, again 2026-07-08,
       // again 2026-07-17).
-      const dynamicTopics = buildDynamicEvergreenTopics();
-      const structuralTopics = buildStructuralEvergreenTopics();
-      const topicPool = [...PRIORITY_EVERGREEN_TOPICS, ...dynamicTopics, ...structuralTopics];
+      //
+      // Section-aware pool (2026-07-21): PRIORITY_EVERGREEN_TOPICS,
+      // buildDynamicEvergreenTopics and buildStructuralEvergreenTopics are ALL
+      // frontaliere/Ticino-scoped (border comuni × frontaliere professions).
+      // Before this fix the `svizzera` section (national CH, all cantons —
+      // see the prompt's "NON sei limitato ai frontalieri" framing) silently
+      // reused this same Ticino-only pool for its evergreen fallback, so
+      // every /articoli-svizzera/ static article ended up Ticino-scoped
+      // regardless of the national framing wrapped around it. `svizzera` now
+      // draws from its own national pool (all-canton keywords) instead.
+      const topicPool = IS_FRONTALIERE
+        ? [...PRIORITY_EVERGREEN_TOPICS, ...buildDynamicEvergreenTopics(), ...buildStructuralEvergreenTopics()]
+        : [...PRIORITY_EVERGREEN_TOPICS_SVIZZERA, ...buildDynamicEvergreenTopicsSvizzera()];
       const weekNum = Math.floor((Date.now() - new Date('2025-01-06').getTime()) / (7 * 24 * 60 * 60 * 1000));
       const baseIndex = weekNum % topicPool.length;
       const totalTopics = topicPool.length;
@@ -9133,7 +9256,9 @@ async function main() {
         }
         try {
           const topic = selectedTopic;
-          const isStaticTopic = PRIORITY_EVERGREEN_TOPICS.includes(topic);
+          const isStaticTopic = IS_FRONTALIERE
+            ? PRIORITY_EVERGREEN_TOPICS.includes(topic)
+            : PRIORITY_EVERGREEN_TOPICS_SVIZZERA.includes(topic);
           RUN_REPORT.selectedArticleType = isStaticTopic ? 'evergreen_static' : 'evergreen_dynamic';
           RUN_REPORT.selectedSource = 'evergreen';
           RUN_REPORT.selectedUrl = `evergreen://${encodeURIComponent(topic.keyword)}`;


### PR DESCRIPTION
## Contesto

Indagine partita da: perché /articoli-frontaliere/ mostra solo template "quanto guadagna X"/"requisiti lavoro Ticino" e non articoli news reali, nonostante la Fase 1 di `generate-article.yml` scansioni fonti Ticino/Svizzera ogni run?

Analisi di 10+ run consecutivi live (log + report): Fase 1 trova 47-93 headline candidate a run, ma vengono TUTTE scartate (topic già coperto vs corpus ~2900+ articoli, o URL Google News già usata) prima di raggiungere la generazione → fallback automatico su Fase 2 evergreen ogni singola volta. Ultimi 3gg = 100% commit `feat(article)` evergreen, 0% news.

Audit manuale di 6 esempi reali di headline scartate (titolo vs titolo esistente matchato): 4-5 erano veri positivi (stessa notizia ripresa da testate diverse — es. riapertura linea Gallarate-Stabio, stesso referendum AVS), 1 chiaro falso positivo (notizia su scadenze CU 2026 bloccata da un explainer sul telelavoro perché condivide il vocabolario "45 giorni").

**Aggiornamento**: trovato un secondo bug, più impattante del primo, guardando il codice del loop di tentativi (non solo i log) — vedi terzo punto in "Implementato".

## Implementato

- **Diagnostica live nel workflow** (`scripts/create-article.mjs`, `.github/workflows/generate-article.yml`): ogni headline scartata in Fase 1 (URL già usata / topic già coperto / non rilevante per il classificatore frontaliere) ora registra `{headline, existingId, existingTitle, signal, sim}` in `RUN_REPORT.discardedHeadlineSamples` (cap 20) + contatori `RUN_REPORT.preFilterDrops`. Lo step "Create-article final report" del workflow li rende in una tabella nello step summary — visibile senza grep sui log grezzi.
- **Fix bug #1 (scope svizzera)**: la sezione `svizzera` (scala nazionale, tutti i cantoni — vedi framing del prompt "NON sei limitato ai frontalieri") riusava per il fallback evergreen (Fase 2) lo STESSO pool `PRIORITY_EVERGREEN_TOPICS`/`buildDynamicEvergreenTopics`/`buildStructuralEvergreenTopics` della sezione `frontaliere` — 100% keyword Ticino/frontaliere (Lugano, permesso G, comuni di confine italiani...). Ogni articolo statico `/articoli-svizzera/` finiva quindi scoped su Ticino nonostante il wrapper prompt "nazionale". Aggiunto `PRIORITY_EVERGREEN_TOPICS_SVIZZERA` (20 keyword nazionali/cantonali) + `buildDynamicEvergreenTopicsSvizzera()` (10 pillar × 8 cantoni) e branching su `IS_FRONTALIERE` in entrambi i punti che consumavano il pool (selezione + `isStaticTopic`).
- **Fix bug #2 (il vero motivo per cui Fase 1 cede quasi sempre)**: il loop di tentativi Fase 1 ha un budget `MAX_DUPLICATE_RETRIES = 8`. I due `continue` per "Google News non decodificabile" e "URL già usata" erano dentro questo for-loop e **consumavano un tentativo pieno pur non avendo mai chiamato l'LLM** — sono skip a costo zero (nessun fetch, nessuna generazione), non tentativi falliti costosi. Prova diretta dal log del run 29801301652: 8 skip "URL già usata" consecutivi → subito "Fase 2: Fallback evergreen", con **93 headline ancora non provate** nel pool (già passate dedup + gate di rilevanza). In pratica molti run non chiamavano MAI `generateAndValidateArticle` — il budget si esauriva prima ancora di iniziare un tentativo vero. Fix: `attempt--` prima di questi due `continue`, così non contano contro `MAX_DUPLICATE_RETRIES`. I guard esistenti (wall-clock budget, pool esaurito) restano invariati e continuano a limitare il loop — nessun rischio di loop infinito (verificato leggendo i guard, girano a ogni iterazione indipendentemente da `attempt`).

## Non implementato (ancora)

- **Soglia dedup `preFlightHeadlineCheck` (fixed, non corpus-adaptive)**: tentato un fix analogo a `preFlightEvergreenTopicCheck` (soglie corpus-size-adaptive via `scaleSaturationThreshold`), che avrebbe risolto il falso positivo CU-2026 trovato nell'audit. **Rollback deliberato**: rompeva `tests/pre-flight-headline-check.test.ts > catches a different angle on the same topic` — un test di regressione esistente che protegge un incidente reale di maggio 2026 (6 cicli LLM sprecati su una notizia riformulata). Il caso che il test protegge ("stesso fatto, angolo editoriale diverso") e il falso positivo trovato ("fatto diverso, vocabolario condiviso") non sono separabili con un singolo threshold globale senza più dati. **Next step**: usare la diagnostica live appena aggiunta per accumulare più esempi reali `topic_already_covered` sui prossimi run, poi decidere una soglia/euristica basata su evidenza reale invece di un tentativo alla cieca. Resta nello scope di questo lavoro di analisi, riprendo appena ci sono abbastanza sample dai run live — nessuna issue di follow-up separata necessaria.

## Sibling-pattern check (AGENTS.md #6) — candidati valutati, tutti falsi positivi

- `scripts/lib/evergreen-topic-generator.mjs` — condivide `PRIORITY_EVERGREEN_TOPICS`/`buildStructuralEvergreenTopics`/`topicPool`: falso positivo. Questo file resta intenzionalmente Ticino/frontaliere-scoped by design (profession × comuni di confine italiani) — il fix esclude esplicitamente `buildStructuralEvergreenTopics` dal path `svizzera` (non viene più invocato), quindi non serve un equivalente nazionale in questo file.
- `scripts/lib/article-topic-selector.mjs` — condivide `PRIORITY_EVERGREEN_TOPICS`: falso positivo, è un riferimento descrittivo in un commento, non definisce né consuma il pool.
- `scripts/cwv-monitor-check.mjs`, `scripts/update-efg-jobs.mjs`, `scripts/update-medacta-jobs.mjs` — condividono `existingId`/`existingIdx`: falso positivo, è un indice di array in contesti completamente diversi (CWV weekly rows, job-sync EFG/Medacta), non dedup di articoli.
- `scripts/lib/ai-models.mjs`, `scripts/manage-article.mjs` — condividono `existingId(s)`: falso positivo, Set/array di dedup generico interno al modulo, non correlato al pool evergreen.
- `scripts/lib/topic-sources/gscOrphans.mjs`, `scripts/lib/topic-sources/noveltyCheck.mjs`, `scripts/mine-topic-candidates.mjs` — condividono `existingTitle(s)`: falso positivo, parametro generico di scoring passato dal chiamante (già cross-section), nessun pool statico Ticino-only da correggere.

## Test plan

- [x] `node --check scripts/create-article.mjs` — sintassi OK
- [x] `npx vitest run tests/pre-flight-headline-check.test.ts tests/article-duplicate-detection.test.ts tests/create-article-gates.test.ts tests/pre-spend-topic-gate.test.ts tests/dup-stoplist.test.ts tests/scripts/create-article-integration.test.ts tests/topic-gate-abort-retry.test.ts tests/evergreen-topic-generator.test.ts` — tutti verdi
- [x] `npm run test:articles` (stesso set gate CI) — tutto verde
- [x] YAML del workflow validato (python yaml.safe_load) + script node embedded estratto e sintassi-checkato a parte
- [x] Letto a mano i guard del retry-loop (wall-clock budget, pool esaurito) per confermare che girano a ogni iterazione indipendentemente da `attempt` — nessun rischio di loop infinito con `attempt--`
- [ ] Verifica live post-merge: controllare lo step summary di `generate-article.yml` sui prossimi run per confermare (a) che la tabella diagnostica renderizzi con dati reali, (b) che il tasso di successo Fase 1 (selectedArticleType=news) salga rispetto al ~0% degli ultimi 3gg, (c) che un run `svizzera` in Fase 2 selezioni un topic dal nuovo pool nazionale

🤖 Generated with [Claude Code](https://claude.com/claude-code)
