### PR TITLE
perf(validate-dist): parallelize dist/ directory walk (bounded fan-out)

### DIFF
--- a/scripts/lib/audit-runner.mjs
+++ b/scripts/lib/audit-runner.mjs
@@ -139,21 +139,56 @@ function decodeEntities(s) {
  * @param {string} dir
  * @returns {Promise<string[]>}
  */
+// Bounded-concurrency directory fan-out — WALK_CONCURRENCY simultaneous
+// `readdir` calls instead of one at a time. The SSG output tree is one
+// directory per job/page (`dist/<locale>/<section>/<slug>/index.html`), so
+// on a ~3.3M-file dist that's ~3.3M individual `readdir` syscalls; awaiting
+// them fully sequentially (the previous stack-based DFS) leaves the event
+// loop idle between each one. Same lever this file's own `runAudits()`
+// collect loop already applies to file reads (see READAHEAD below) — this
+// mirrors that established pattern for the walk phase instead of inventing
+// a new one. Correctness is unaffected: every directory is still visited
+// exactly once, dot-prefixed directories are still skipped, and the
+// returned set of `.html` files is identical — only DISCOVERY ORDER changes
+// (no auditor or test depends on walk order; pass/fail is a function of the
+// complete file SET, not its enumeration order — see tests/seo/audit-
+// runner.test.ts, which only asserts membership/count/`.every()` predicates).
+const WALK_CONCURRENCY = 24;
+
 export async function walkHtmlFiles(dir) {
   const out = [];
-  const stack = [dir];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try { entries = await readdir(cur, { withFileTypes: true }); }
-    catch { continue; }
-    for (const e of entries) {
-      if (e.name.startsWith('.')) continue;
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(p);
-    }
-  }
+  const queue = [dir];
+  let inFlight = 0;
+  let cursor = 0;
+
+  // Same "swallow any readdir error and skip that subtree" contract as the
+  // original sequential walk's `catch { continue; }` — a speed refactor
+  // must not also change error-handling semantics.
+  await new Promise((resolve) => {
+    const pump = () => {
+      while (inFlight < WALK_CONCURRENCY && cursor < queue.length) {
+        const cur = queue[cursor++];
+        inFlight++;
+        readdir(cur, { withFileTypes: true })
+          .then((entries) => {
+            for (const e of entries) {
+              if (e.name.startsWith('.')) continue;
+              const p = join(cur, e.name);
+              if (e.isDirectory()) queue.push(p);
+              else if (e.isFile() && p.endsWith('.html')) out.push(p);
+            }
+          })
+          .catch(() => {})
+          .finally(() => {
+            inFlight--;
+            if (cursor >= queue.length && inFlight === 0) resolve();
+            else pump();
+          });
+      }
+    };
+    pump();
+  });
+
   return out;
 }
 

--- a/scripts/measure-l2-distribution.mjs
+++ b/scripts/measure-l2-distribution.mjs
@@ -11,9 +11,14 @@
  *   node scripts/measure-l2-distribution.mjs --dist=download/artifact --sample=1000 --by-feature
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
+import { relative } from 'node:path';
 import { minifyHtml } from '../build-plugins/shared/htmlMinify.ts';
+// Shared bounded-concurrency dist walker (was a 4th copy-pasted sequential
+// `stack.pop()` walk, identical to the ones in verify-l1/l2-equivalence.mjs
+// and the pre-fix scripts/lib/audit-runner.mjs — deduped per CLAUDE.md #6
+// rather than adding a 3rd parallelized copy of the same logic).
+import { walkHtmlFiles as walk } from './lib/audit-runner.mjs';
 
 function parseArgs() {
   const args = new Map();
@@ -24,24 +29,6 @@ function parseArgs() {
     }
   }
   return args;
-}
-
-async function walk(root) {
-  const out = [];
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try { entries = await readdir(cur, { withFileTypes: true }); }
-    catch { continue; }
-    for (const e of entries) {
-      if (e.name.startsWith('.')) continue;
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(p);
-    }
-  }
-  return out;
 }
 
 function sampleRandom(arr, n) {

--- a/scripts/verify-l1-equivalence.mjs
+++ b/scripts/verify-l1-equivalence.mjs
@@ -27,8 +27,14 @@
  * is a bug.
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+// Shared bounded-concurrency dist walker — was a copy-pasted sequential
+// `stack.pop()` walk, identical to measure-l2-distribution.mjs,
+// verify-l2-equivalence.mjs, and the pre-fix scripts/lib/audit-runner.mjs
+// (deduped per CLAUDE.md #6). Returns absolute paths; this script needs
+// root-relative ones to compare baseline vs. candidate trees.
+import { walkHtmlFiles } from './lib/audit-runner.mjs';
 
 function parseArgs() {
   const args = new Map();
@@ -42,21 +48,8 @@ function parseArgs() {
 }
 
 async function walk(root) {
-  const out = [];
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try { entries = await readdir(cur, { withFileTypes: true }); }
-    catch { continue; }
-    for (const e of entries) {
-      if (e.name.startsWith('.')) continue;
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(relative(root, p));
-    }
-  }
-  return out;
+  const absolute = await walkHtmlFiles(root);
+  return absolute.map((p) => relative(root, p));
 }
 
 function sampleRandom(arr, n) {

--- a/scripts/verify-l2-equivalence.mjs
+++ b/scripts/verify-l2-equivalence.mjs
@@ -31,9 +31,15 @@
  *     --sample=1000
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { load as cheerioLoad } from 'cheerio';
+// Shared bounded-concurrency dist walker — was a copy-pasted sequential
+// `stack.pop()` walk, identical to measure-l2-distribution.mjs,
+// verify-l1-equivalence.mjs, and the pre-fix scripts/lib/audit-runner.mjs
+// (deduped per CLAUDE.md #6). Returns absolute paths; this script needs
+// root-relative ones to compare baseline vs. candidate trees.
+import { walkHtmlFiles } from './lib/audit-runner.mjs';
 
 function parseArgs() {
   const args = new Map();
@@ -47,21 +53,8 @@ function parseArgs() {
 }
 
 async function walk(root) {
-  const out = [];
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try { entries = await readdir(cur, { withFileTypes: true }); }
-    catch { continue; }
-    for (const e of entries) {
-      if (e.name.startsWith('.')) continue;
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(relative(root, p));
-    }
-  }
-  return out;
+  const absolute = await walkHtmlFiles(root);
+  return absolute.map((p) => relative(root, p));
 }
 
 function sampleRandom(arr, n) {

--- a/tests/seo/audit-runner.test.ts
+++ b/tests/seo/audit-runner.test.ts
@@ -75,6 +75,34 @@ describe('walkHtmlFiles', () => {
     const files = await walkHtmlFiles(root);
     expect(files.every((f) => f.endsWith('.html'))).toBe(true);
   });
+
+  // Regression guard for the bounded-concurrency directory fan-out
+  // (WALK_CONCURRENCY): with N directories in flight at once, a wide+deep
+  // tree exercises the queue/cursor/inFlight bookkeeping far harder than the
+  // 3-file fixture above — completeness (every file found, no duplicates,
+  // no dropped subtree) must hold regardless of readdir completion order.
+  it('finds every file in a wide, deep tree with no duplicates or omissions (parallel walk correctness)', async () => {
+    const wideRoot = mkdtempSync(join(tmpdir(), 'audit-runner-wide-'));
+    const expected = new Set<string>();
+    for (let locale = 0; locale < 4; locale++) {
+      for (let section = 0; section < 5; section++) {
+        for (let slug = 0; slug < 10; slug++) {
+          const dir = join(wideRoot, `locale-${locale}`, `section-${section}`, `slug-${slug}`);
+          mkdirSync(dir, { recursive: true });
+          const file = join(dir, 'index.html');
+          writeFileSync(file, '<html></html>');
+          expected.add(file);
+        }
+      }
+    }
+    try {
+      const files = await walkHtmlFiles(wideRoot);
+      expect(files.length).toBe(expected.size); // 200 files, no dupes/drops
+      expect(new Set(files)).toEqual(expected);
+    } finally {
+      rmSync(wideRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('sharedExtract', () => {


### PR DESCRIPTION
## Implementato

Addresses the "campionare i check" (sample the checks) speed ask from PR #4611's original scope — its body states: *"Per-deploy sampling audit:all: investigated per original ask ('controlli campione'), not implemented."*

**Investigated file-level sampling first, and it's not safe here.** `scripts/lib/audit-runner.mjs`'s own header already documents why: *"they share the file read but not the regex parse (which is already very fast — the I/O is the dominant cost)."* Several registered auditors are 0-tolerance gates over virtually the whole dist — `no-literal-markdown` alone scans 3.27M of ~3.34M dist files (validate-dist run [29794187475](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/29794187475/job/88522058703)). Sampling *which files* get read would let a real regression hide in the unsampled majority (exactly the class of bug fixed in #4632 — implementing unsound sampling here would be self-defeating). Sampling *which auditors* run their regex on a given file doesn't touch the dominant read-I/O cost at all, since regex is "already very fast" per the file's own header. Both are dead ends — my own analysis, PR #4611's own investigation, and this file's own documentation all independently converge on the same conclusion. Weakening a 0-tolerance gate to enable sampling would violate CLAUDE.md's non-negotiable #1, so I didn't.

**What genuinely is safe and fast: parallelizing directory discovery.** `walkHtmlFiles()` was a single `readdir()` at a time, fully sequential (stack-based DFS). The SSG output is one directory per page (`dist/<locale>/<section>/<slug>/index.html`), so a ~3.34M-file dist means ~3.34M sequential syscalls with the event loop idle between each — this is the walk phase's 630s in the CI log. Parallelized with a bounded-concurrency fan-out (`WALK_CONCURRENCY = 24`), mirroring the exact pattern `runAudits()`'s collect loop already uses for file reads (`READAHEAD`) — same established idiom in this file, not a new one. Correctness is unaffected: every directory is still visited exactly once, dot-directories still skipped, the same complete `.html` file SET is returned — only discovery *order* changes, and no auditor or test depends on order (`tests/seo/audit-runner.test.ts` only asserts membership/count/`.every()` predicates). Added a 200-file wide/deep-tree regression test exercising the concurrency bookkeeping (queue/cursor/inFlight) harder than the existing 3-file fixture.

**Measured locally**: 10,000 files / ~8,400 directories — sequential 396ms vs. parallel (concurrency=24) 142ms — **2.8x**. Real dist-scale numbers can only be confirmed on the next live `validate-dist` run (CI runner I/O characteristics differ from local SSD; per repo convention I'm not fabricating a CI-scale claim — see Non implementato).

**Sibling dedup**: `check-sibling-patterns.mjs` found 3 more copy-pasted instances of the exact same sequential walk (`scripts/measure-l2-distribution.mjs`, `scripts/verify-l1-equivalence.mjs`, `scripts/verify-l2-equivalence.mjs`). Rather than patching each separately (reintroducing the copy-paste-drift risk CLAUDE.md #6 exists to prevent), all 3 now import the already-tested, already-parallelized `walkHtmlFiles()` from `scripts/lib/audit-runner.mjs`, converting to root-relative paths where needed. Smoke-tested each against a small synthetic `dist/` tree.

## Non implementato (ancora)

- **`scripts/dist-shrink.mjs`** shares the identical walk construct but is deliberately left untouched: `git grep` across `.github/workflows/*.yml` for `dist-shrink`/`dist:shrink` returns zero hits — it isn't wired into any automated workflow, so it doesn't affect validate-dist's (or deploy's) actual wall-clock today. It's also a post-`vite build` minification pass with an explicit "never change output bytes" invariant that I have no way to verify byte-identical without a full local build (project convention: no full local SEO build) — if it *is* invoked manually or from somewhere the grep missed, it's genuinely build-critical, and I'd rather leave 1 stale copy than risk a silent minification regression I can't check pre-merge. `blocked: would need either CI wiring confirmation or a full build run to verify byte-identical output before it's safe to touch — not decidable in this PR.`
- **6 more sibling candidates evaluated, out of scope** (not the "validate dist" pipeline this PR targets, or false positives — each individually checked, not a collective dismiss):
  - `scripts/ci/validate-locale-shard-build.mjs` — real sequential-walk sibling, confirmed wired into `deploy.yml`/`deploy-matrix-experiment.yml`, but a *different* pipeline stage (post-shard build validation, not the `validate-dist` gate this PR is about). Left for a follow-up PR scoped to that pipeline specifically, so its own correctness/blast-radius can get the same dedicated attention this PR gave `audit-runner.mjs`.
  - `scripts/seo/{internal-link,meta-description,schema,title}-audit.mjs` — real sequential-walk siblings, but `git grep` across `package.json` + `.github/workflows/*.yml` finds no wiring into any automated script or workflow — standalone/manual-run tools, not part of validate-dist's (or any CI job's) wall-clock.
  - `scripts/audit-no-merge-markers.mjs` — false positive: walks the ~30K-file *source repo* via `git ls-files` (not the 3.3M-file `dist/` output); the shared `while (stack.length)` token is a small, unrelated fallback loop, irrelevant to dist-walk performance at the scale this PR targets.
  - `inFlight` (`components/community/JobBoard.tsx`, `hooks/useNewsletterAutologinInFlight.ts`, `services/authorProfileService.ts`, `services/newsletterAutologinSignal.ts`, `services/router.ts`, `scripts/ci/{check-issue-already-resolved,followup-drainer,reconcile-followups}.mjs`) — false positive: generic request-deduplication/in-flight-promise-cache variable name used across many unrelated files; none touch directory-walk concurrency.
  - `runAudits` (`services/mobileUxMonitor.ts`, `scripts/audit-all.mjs`) — false positive: `mobileUxMonitor.ts`'s `runAudits` is an unrelated client-side Core Web Vitals monitor local function; `scripts/audit-all.mjs` is the legitimate *consumer* of the `runAudits()` I modified (calls it, doesn't duplicate it).

## Test plan

- [x] `npx vitest run tests/seo/audit-runner.test.ts` — 21 passing, including the new 200-file wide/deep-tree parallel-walk correctness regression test
- [x] `npx tsc --noEmit` — zero errors in any touched file
- [x] Manual smoke test: `measure-l2-distribution.mjs` and `verify-l1-equivalence.mjs` run correctly end-to-end against a synthetic `dist/` tree post-refactor (`verify-l2-equivalence.mjs` has a pre-existing, unrelated broken `cheerio` dependency — confirmed via `git show origin/main` on the untouched file, not a regression from this change)
- [x] Local benchmark: 10K-file/~8.4K-directory synthetic tree, sequential vs. parallel walk — 2.8x
- [ ] Live `validate-dist` run post-merge — will confirm the real (not locally-benchmarked) walk-phase wall-clock reduction; watching per repo convention

Follow-up to #4632 (root-caused the 4 `audit:all` correctness failures; this PR addresses the speed/sampling half of the original ask).