### PR TITLE
fix(build): raise SPA-bundle poll timeout, align enforce:post ordering

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -106,6 +106,9 @@ jobs:
           # Force sequential plugin closeBundle: peak heap = max(single plugin)
           # instead of Σ(overlap). Always sequential here (scheduled/dispatch).
           SEQUENTIAL_PROFILE: '1'
+          # See deploy.yml — og-pages/etc.'s spaBundleResolver poll needs CI
+          # headroom against the growing blog-body corpus (2026-07-21 incident).
+          SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
         run: |
           set -euo pipefail
           npm run build:ci &

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -142,6 +142,9 @@ jobs:
           # instead of Σ(overlap) → eliminates the parallel-build OOM. Always
           # sequential here (scheduled/dispatch gate run, never parallel).
           SEQUENTIAL_PROFILE: '1'
+          # See deploy.yml — og-pages/etc.'s spaBundleResolver poll needs CI
+          # headroom against the growing blog-body corpus (2026-07-21 incident).
+          SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
         run: |
           set -euo pipefail
           npm run build:ci &

--- a/.github/workflows/deploy-matrix-experiment.yml
+++ b/.github/workflows/deploy-matrix-experiment.yml
@@ -157,6 +157,9 @@ jobs:
       FAST_BUILD: ${{ github.event.inputs.fast_build == 'true' && '1' || '' }}
       SEQUENTIAL_PROFILE: ${{ github.event.inputs.parallel_plugins == 'true' && '' || '1' }}
       RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
+      # See deploy.yml — og-pages/etc.'s spaBundleResolver poll needs CI
+      # headroom against the growing blog-body corpus (2026-07-21 incident).
+      SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -289,6 +289,11 @@ jobs:
       RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
       RELATED_SEARCH_PREPASS_CONCURRENCY: '1'
       DEPLOY_CONTENT_MANIFEST: '1'
+      # og-pages/jobs-seo-pages/etc. share spaBundleResolver's poll for
+      # dist/index.html; the 3s local-dev/test default is too tight for CI
+      # given how large services/locales/blog-body* has grown (2026-07-21
+      # deploy incident: poll exhausted after 60 attempts on every locale).
+      SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
       # Per-locale emit filter + shared canonical build id (identical
       # dist/build-id.txt across all shards).
       BUILD_LOCALE: ${{ matrix.locale }}

--- a/.github/workflows/matrix-equivalence-check.yml
+++ b/.github/workflows/matrix-equivalence-check.yml
@@ -40,6 +40,9 @@ jobs:
       BUILD_LOCALE: it
       SEQUENTIAL_PROFILE: '1'
       RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
+      # See deploy.yml — og-pages/etc.'s spaBundleResolver poll needs CI
+      # headroom against the growing blog-body corpus (2026-07-21 incident).
+      SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
     steps:
       - name: Checkout the equivalence tooling (this branch)
         uses: actions/checkout@v5

--- a/.github/workflows/post-build-matrix-test.yml
+++ b/.github/workflows/post-build-matrix-test.yml
@@ -78,6 +78,9 @@ jobs:
           # enabled by default to mirror the deploy workflow (see deploy.yml).
           JOBS_SEO_PROFILE_PHASES: '1'
           JOBS_SEO_PROFILE_COMPARE_RELATED: ${{ github.event.inputs.profile_related_compare == 'true' && '1' || '' }}
+          # See deploy.yml — og-pages/etc.'s spaBundleResolver poll needs CI
+          # headroom against the growing blog-body corpus (2026-07-21 incident).
+          SPA_BUNDLE_POLL_TIMEOUT_MS: '30000'
         run: npm run build:ci
 
       - name: SPA fallback

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -115,6 +115,7 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
   return {
     name: 'job-recency-pages',
     apply: 'build',
+    enforce: 'post',
     async closeBundle() {
       const fs = await import('node:fs');
       const np = await import('node:path');

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -527,6 +527,7 @@ export function jobSectorPagesPlugin(rootDir: string): Plugin {
   return {
     name: 'job-sector-pages',
     apply: 'build',
+    enforce: 'post',
     async closeBundle() {
       const fs = await import('node:fs');
       const np = await import('node:path');

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -545,6 +545,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  return {
  name: 'jobs-seo-pages',
  apply: 'build',
+ enforce: 'post',
  async closeBundle() {
  // Fail the build loudly (follow-up #3608 item 2) instead of silently
  // emitting a literal "undefined" segment in a sector-hub canonical URL —

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -30,6 +30,7 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  return {
  name: 'og-pages',
  apply: 'build',
+ enforce: 'post',
  async closeBundle() {
  const fs = await import('node:fs');
  const np = await import('node:path');

--- a/build-plugins/spaBundleResolver.ts
+++ b/build-plugins/spaBundleResolver.ts
@@ -21,11 +21,15 @@
  * One module-level cache, populated on first call by polling the on-disk
  * `dist/index.html` until both regexes match (bounded retry). Once the
  * cache is populated, all subsequent callers — across plugins — read the
- * same value. The poll is bounded at 3 s (60 attempts × 50 ms): plenty of
- * head room for the rare case where closeBundle wins the race against
- * writeBundle, but tight enough to fail loudly when the file is genuinely
- * absent (e.g. someone calls the resolver from a hook earlier than
- * writeBundle).
+ * same value. The poll is bounded at 30 s (600 attempts × 50 ms): the
+ * corpus `og-pages`/`jobs-seo-pages`/etc. parse before calling this (e.g.
+ * `services/locales/blog-body/*` alone) keeps growing with every
+ * auto-generated article, so the original 3 s budget (introduced when the
+ * corpus was much smaller) eroded from "rare race, huge head room" to
+ * "consistent CI failure" without any plugin-order or timeout code change
+ * — see the 2026-07-21 deploy incident. 30 s is still tight enough to fail
+ * loudly when the file is genuinely absent (e.g. someone calls the
+ * resolver from a hook earlier than writeBundle).
  *
  * Hard-fail vs silent fallback
  * ----------------------------
@@ -71,7 +75,7 @@ const cache = new Map<string, SpaBundleInfo>();
  * template-build path — making it async would propagate `await` through
  * 50+ template helpers in jobsSeoPagesPlugin alone.
  */
-function pollDistIndexHtml(distDir: string, timeoutMs = 3000, intervalMs = 50): SpaBundleInfo {
+function pollDistIndexHtml(distDir: string, timeoutMs = 30000, intervalMs = 50): SpaBundleInfo {
   const indexPath = path.join(distDir, 'index.html');
   const deadline = Date.now() + timeoutMs;
   let attempts = 0;

--- a/build-plugins/spaBundleResolver.ts
+++ b/build-plugins/spaBundleResolver.ts
@@ -21,15 +21,18 @@
  * One module-level cache, populated on first call by polling the on-disk
  * `dist/index.html` until both regexes match (bounded retry). Once the
  * cache is populated, all subsequent callers — across plugins — read the
- * same value. The poll is bounded at 30 s (600 attempts × 50 ms): the
- * corpus `og-pages`/`jobs-seo-pages`/etc. parse before calling this (e.g.
- * `services/locales/blog-body/*` alone) keeps growing with every
- * auto-generated article, so the original 3 s budget (introduced when the
- * corpus was much smaller) eroded from "rare race, huge head room" to
+ * same value. The poll defaults to 3 s (60 attempts × 50 ms), overridable
+ * via `SPA_BUNDLE_POLL_TIMEOUT_MS` — the CI deploy workflow sets it to 30 s
+ * because the corpus `og-pages`/`jobs-seo-pages`/etc. parse before calling
+ * this (e.g. `services/locales/blog-body/*` alone) keeps growing with every
+ * auto-generated article, so the original fixed 3 s budget (introduced when
+ * the corpus was much smaller) eroded from "rare race, huge head room" to
  * "consistent CI failure" without any plugin-order or timeout code change
- * — see the 2026-07-21 deploy incident. 30 s is still tight enough to fail
- * loudly when the file is genuinely absent (e.g. someone calls the
- * resolver from a hook earlier than writeBundle).
+ * — see the 2026-07-21 deploy incident. The 3 s default is kept for local
+ * dev/tests, where dist/index.html is either already there or genuinely
+ * never coming (tests/spa-bundle-resolver.test.ts asserts a fast throw on
+ * missing/empty/malformed index.html — a 30 s default would make every one
+ * of those a 30 s timeout instead of an assertion).
  *
  * Hard-fail vs silent fallback
  * ----------------------------
@@ -75,7 +78,9 @@ const cache = new Map<string, SpaBundleInfo>();
  * template-build path — making it async would propagate `await` through
  * 50+ template helpers in jobsSeoPagesPlugin alone.
  */
-function pollDistIndexHtml(distDir: string, timeoutMs = 30000, intervalMs = 50): SpaBundleInfo {
+const DEFAULT_POLL_TIMEOUT_MS = Number(process.env.SPA_BUNDLE_POLL_TIMEOUT_MS) || 3000;
+
+function pollDistIndexHtml(distDir: string, timeoutMs = DEFAULT_POLL_TIMEOUT_MS, intervalMs = 50): SpaBundleInfo {
   const indexPath = path.join(distDir, 'index.html');
   const deadline = Date.now() + timeoutMs;
   let attempts = 0;


### PR DESCRIPTION
## Implementato
- `build-plugins/spaBundleResolver.ts`: `pollDistIndexHtml`'s poll timeout is now env-configurable via `SPA_BUNDLE_POLL_TIMEOUT_MS`, defaulting to **3s** (unchanged, fast for local dev/tests). Root cause of the currently-failing `Deploy to GitHub Pages` (all 4 locales, ~05:55 UTC 2026-07-21 onward): the fixed 3s budget was sized when the corpus was much smaller; `services/locales/blog-body*` is now 11k+ files that `og-pages` (and siblings) parse synchronously in `closeBundle` before polling — the margin eroded from "rare non-deterministic race" (documented in the resolver's own history log) to a consistent failure, with zero plugin-order/timeout code changes in the failure window (confirmed via `git log -- build-plugins/ vite.config.ts`).
- **Every CI workflow that runs a full (non-`FAST_BUILD`) `build:ci`** now sets `SPA_BUNDLE_POLL_TIMEOUT_MS=30000`: `deploy.yml` (the one actually failing), `adsense-prereview.yml`, `cathedral-seo-gates-check.yml`, `deploy-matrix-experiment.yml`, `matrix-equivalence-check.yml`, `post-build-matrix-test.yml` — grep-verified as the complete set (`grep -rl "build:ci" .github/workflows/*.yml`, cross-checked each for `FAST_BUILD: ''`/unset).
- `build-plugins/{ogPagesPlugin,jobsSeoPagesPlugin,jobRecencyPagesPlugin,jobSectorPagesPlugin}.ts`: added `enforce: 'post'`, matching `staticPagesPlugin` which already has it. Defense-in-depth for phase ordering (the actual race is at Rollup's generateBundle/writeBundle/closeBundle phase boundary, not plugin registration order).

**Revision note:** the first commit on this PR used a flat 3s→30s *default* change, which broke `tests/spa-bundle-resolver.test.ts` (3 tests assert a fast throw on missing/empty/malformed `index.html` — a 30s default turned each into a 30s timeout instead of a fast assertion, caught by this PR's own `tests` CI run). Fixed by keeping the fast default and making it env-overridable instead — see second commit.

## Non implementato (ancora)
Nessuno. Sibling-check re-run post-fix — all candidates verified false positives:
- `build-plugins/staticPagesPlugin.ts` — falso positivo: solo importa/chiama `resolveSpaBundle` (nessuna logica di timeout duplicata, beneficia automaticamente della env-var centralizzata)
- `build-plugins/flatHtmlRedirectPlugin.ts` / `profilePlugin.ts` — falso positivo: già hanno `enforce: 'post'`, match solo su commenti doc
- `build-plugins/shared/seoPageShell.ts` / `spaBundleRx.ts` — falso positivo: condividono solo le regex (modulo dedicato apposta per evitare drift), nessuna logica di timeout
- `scripts/wait-for-live-article-meta.mjs` — falso positivo: script post-deploy indipendente, proprio `intervalMs` locale, dominio scorrelato

## Test plan
- [x] `npx vitest run tests/spa-bundle-resolver.test.ts tests/build-plugin-order.test.ts` — 11/11 verdi (i 3 test "throws" tornano a ~3s ciascuno, invariati)
- [x] `tsc --noEmit` — nessun errore sui file toccati
- [x] YAML syntax check (`python3 -c "import yaml; yaml.safe_load(...)"`) su tutti i 6 workflow modificati — validi
- [x] GitNexus impact — LOW risk, 4 caller diretti (i 4 plugin che condividono il resolver)
- [ ] Claim non validato pre-merge: non posso riprodurre localmente il full multi-locale `build:ci` (OOM-prone, vietato senza richiesta esplicita). Se il prossimo deploy post-merge fallisce ancora con lo stesso `poll exhausted` → revert-trigger: il timeout va alzato ulteriormente (env var già in place, basta cambiare il valore) o la vera causa è un ordering bug genuino da investigare più a fondo.

Trovato durante la verifica live del fix #4629 (bug email-case alert). Issue di tracking: #4637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)