### PR TITLE
perf(newsletter): batch AI briefing generation per locale to cut request volume

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -32,7 +32,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildNewsletter, FEATURED_TOOLS, getFeaturedTools, nlNormLocale, directUrl } from '../services/newsletter-template.mjs';
-import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, isCompanyHubSlug } from '../services/newsletter-content.mjs';
+import { matchJobsForSubscriber, validateJobUrls, buildBriefingPrompt, buildBriefingBatchPrompt, buildSubjectPrompt, FALLBACK_SUBJECT, getFallbackBriefing, loadDashboardMetrics, isCompanyHubSlug } from '../services/newsletter-content.mjs';
 import { selectFeaturedArticleId } from '../services/newsletter-article-rotation.mjs';
 import { describeSegment, inferInterest, selectArticleCandidates, CONTENT_STRATEGIES, INTERESTS } from '../services/newsletter-segments.mjs';
 import { getSeasonalUtilityContent } from '../services/newsletter-seasonal.mjs';
@@ -69,6 +69,12 @@ const FROM_EMAIL = process.env.NEWSLETTER_FROM || DEFAULT_FROM_EMAIL;
 const EXPERIMENTAL_MODE = process.env.NEWSLETTER_EXPERIMENTAL_MODE !== 'false';
 const SEND_ENABLED = process.env.NEWSLETTER_ENABLE_SEND === 'true';
 const AI_CONCURRENCY = 5; // Max parallel AI calls
+// How many cohort briefings to request in a single AI call (same locale only,
+// see buildBriefingBatchPrompt). Keeps total request volume comfortably under
+// the tightest top-of-chain free-tier daily cap (Gemini flash: 1500/day) even
+// on high-subscriber days, so most batches succeed on the first model instead
+// of cascading through the whole chain to the claude-cli/haiku last resort.
+const AI_BRIEFING_BATCH_SIZE = 5;
 
 // ── Email provider selection ──
 // cascade = multi-provider free tier cascade (default)
@@ -232,6 +238,57 @@ async function generateAIBriefing(ctx) {
   } catch (e) {
     console.warn('\u26a0\ufe0f AI briefing failed:', e.message?.slice(0, 200));
     return null;
+  }
+}
+
+/**
+ * Split a batch AI response on "===BRIEFING <id>===" markers into a
+ * Map<id, rawHtml>. Missing/unmatched ids simply aren't in the returned map \u2014
+ * the caller treats that exactly like a single-item AI failure (null \u2192
+ * template fallback), so a partially-truncated batch degrades gracefully
+ * instead of losing the whole batch.
+ */
+function parseBriefingBatchResponse(raw) {
+  const map = new Map();
+  const marker = /===BRIEFING\s+(\S+?)===/g;
+  const matches = [...String(raw || '').matchAll(marker)];
+  for (let i = 0; i < matches.length; i++) {
+    const id = matches[i][1];
+    const start = matches[i].index + matches[i][0].length;
+    const end = i + 1 < matches.length ? matches[i + 1].index : raw.length;
+    const content = raw.slice(start, end).trim();
+    if (content) map.set(id, content);
+  }
+  return map;
+}
+
+/**
+ * Generate up to AI_BRIEFING_BATCH_SIZE cohort briefings in a single AI call.
+ * All items MUST share the same locale (see buildBriefingBatchPrompt). Falls
+ * back to an empty map (\u2192 every item gets the template fallback downstream)
+ * on total failure; individual items that fail the same quality gate as the
+ * single-call path (sanitizeAIBriefingHtml) are dropped the same way too.
+ */
+async function generateAIBriefingsBatch(items) {
+  if (!callLLM || items.length === 0) return new Map();
+  try {
+    const { system, user } = buildBriefingBatchPrompt(items);
+    const result = await callLLM([
+      { role: 'system', content: system },
+      { role: 'user', content: user },
+    ], { temperature: 0.7, maxTokens: 800 * items.length + 200, chain: NEWSLETTER_AI_CHAIN });
+    const parsed = parseBriefingBatchResponse(result);
+    const out = new Map();
+    for (const item of items) {
+      const block = parsed.get(item.id);
+      if (!block) continue;
+      const html = sanitizeAIBriefingHtml(block);
+      if (html) out.set(item.id, html);
+    }
+    return out;
+  } catch (e) {
+    console.warn('\u26a0\ufe0f AI briefing batch failed:', e.message?.slice(0, 200));
+    return new Map();
   }
 }
 
@@ -2087,21 +2144,43 @@ async function main() {
   }
   console.log(`  ${subscribers.length} subscribers → ${cohorts.size} cohorts`);
 
-  // ── Phase 2: Generate 1 AI briefing per cohort (parallel) ──
-  console.log('🧠 Phase 2: AI briefings (1 per cohort, parallel)...');
+  // ── Phase 2: Generate AI briefings, batched per locale (parallel) ──
+  console.log(`🧠 Phase 2: AI briefings (batches of ≤${AI_BRIEFING_BATCH_SIZE} cohorts, same locale, parallel)...`);
   const cohortEntries = [...cohorts.entries()];
-  const briefingResults = noAI
-    ? cohortEntries.map(([key, c]) => [key, getFallbackBriefing(c.locale, exchangeRate)])
-    : await pMap(cohortEntries, async ([key, cohort]) => {
-        const briefing = await generateAIBriefing({
+  let briefingResults;
+  if (noAI) {
+    briefingResults = cohortEntries.map(([key, c]) => [key, getFallbackBriefing(c.locale, exchangeRate)]);
+  } else {
+    // Never mix locales in one batch (see buildBriefingBatchPrompt) — group
+    // by locale first, then chunk each locale's cohorts into fixed-size batches.
+    const byLocale = new Map();
+    for (const entry of cohortEntries) {
+      const loc = entry[1].locale;
+      if (!byLocale.has(loc)) byLocale.set(loc, []);
+      byLocale.get(loc).push(entry);
+    }
+    const batches = [];
+    for (const entries of byLocale.values()) {
+      for (let i = 0; i < entries.length; i += AI_BRIEFING_BATCH_SIZE) {
+        batches.push(entries.slice(i, i + AI_BRIEFING_BATCH_SIZE));
+      }
+    }
+    const batchResults = await pMap(batches, async (batch) => {
+      const items = batch.map(([, cohort], idx) => ({
+        id: String(idx),
+        ctx: {
           subscriber: cohort.subscriber,
           exchangeRate, exchangeInsight,
           matchedJobs: cohort.matchedJobs,
           weeklyFact: getWeeklyFact(cohort.locale),
           featuredTool: getFeaturedToolForLocale(cohort.locale),
-        });
-        return [key, briefing];
-      }, AI_CONCURRENCY);
+        },
+      }));
+      const resultMap = await generateAIBriefingsBatch(items);
+      return batch.map(([key], idx) => [key, resultMap.get(String(idx)) || null]);
+    }, AI_CONCURRENCY);
+    briefingResults = batchResults.flat();
+  }
 
   const briefingMap = new Map();
   for (const [key, briefing] of briefingResults) {

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -74,7 +74,11 @@ const AI_CONCURRENCY = 5; // Max parallel AI calls
 // the tightest top-of-chain free-tier daily cap (Gemini flash: 1500/day) even
 // on high-subscriber days, so most batches succeed on the first model instead
 // of cascading through the whole chain to the claude-cli/haiku last resort.
-const AI_BRIEFING_BATCH_SIZE = 5;
+// Kept at 3 (not higher) so the batch's combined maxTokens request stays
+// comfortably under smaller free-tier models' per-request output caps —
+// a bigger batch cuts request volume further but risks silent truncation
+// on the weaker links in the chain.
+const AI_BRIEFING_BATCH_SIZE = 3;
 
 // ── Email provider selection ──
 // cascade = multi-provider free tier cascade (default)
@@ -250,13 +254,18 @@ async function generateAIBriefing(ctx) {
  */
 function parseBriefingBatchResponse(raw) {
   const map = new Map();
-  const marker = /===BRIEFING\s+(\S+?)===/g;
-  const matches = [...String(raw || '').matchAll(marker)];
+  const text = String(raw || '');
+  // Tolerant of minor formatting drift models are prone to (extra/missing
+  // spaces around the marker, e.g. "== BRIEFING 0 ==" instead of the exact
+  // "===BRIEFING 0===" requested) — a strict marker match would silently
+  // drop an otherwise-good item to the template fallback over whitespace.
+  const marker = /={2,}\s*BRIEFING\s+(\S+?)\s*={2,}/g;
+  const matches = [...text.matchAll(marker)];
   for (let i = 0; i < matches.length; i++) {
     const id = matches[i][1];
     const start = matches[i].index + matches[i][0].length;
-    const end = i + 1 < matches.length ? matches[i + 1].index : raw.length;
-    const content = raw.slice(start, end).trim();
+    const end = i + 1 < matches.length ? matches[i + 1].index : text.length;
+    const content = text.slice(start, end).trim();
     if (content) map.set(id, content);
   }
   return map;

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -990,13 +990,13 @@ export function buildBriefingPrompt(ctx) {
  */
 export function buildBriefingBatchPrompt(items) {
   if (!items.length) throw new Error('buildBriefingBatchPrompt: items must be non-empty');
-  const { system: baseSystem } = buildBriefingPrompt(items[0].ctx);
-  const readerBlocks = items.map((item) => {
-    const { user } = buildBriefingPrompt(item.ctx);
+  const first = buildBriefingPrompt(items[0].ctx);
+  const readerBlocks = items.map((item, idx) => {
+    const { user } = idx === 0 ? first : buildBriefingPrompt(item.ctx);
     return `===READER ${item.id}===\n${user}`;
   });
   const system = [
-    baseSystem,
+    first.system,
     `BATCH MODE: below are ${items.length} independent readers, each starting with a "===READER <id>===" marker. Apply every rule above separately to EACH reader, using ONLY that reader's own data — never mix jobs, facts, or details between readers.`,
     `Output EXACTLY ${items.length} blocks, one per reader, in the SAME ORDER as the readers below. Each block starts with "===BRIEFING <id>===" on its own line (the same id as that reader's marker) followed immediately by that reader's briefing HTML. No text outside these blocks.`,
   ].join(' ');

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -977,6 +977,33 @@ export function buildBriefingPrompt(ctx) {
 }
 
 /**
+ * Build ONE prompt that asks the AI to generate N independent briefings in a
+ * single call instead of N separate calls — cuts total AI request volume
+ * roughly N-fold on high-cohort-count days. All items MUST share the same
+ * locale: the system prompt (language rules, structure rules) is built once
+ * from the first item and reused verbatim for the whole batch, so mixing
+ * languages in one batch would risk the phrasing bleed that the per-locale
+ * system prompt exists to prevent (see tests/newsletter-locale-leakage.test.ts).
+ *
+ * @param {Array<{ id: string, ctx: object }>} items — same ctx shape as buildBriefingPrompt
+ * @returns {{ system: string, user: string }}
+ */
+export function buildBriefingBatchPrompt(items) {
+  if (!items.length) throw new Error('buildBriefingBatchPrompt: items must be non-empty');
+  const { system: baseSystem } = buildBriefingPrompt(items[0].ctx);
+  const readerBlocks = items.map((item) => {
+    const { user } = buildBriefingPrompt(item.ctx);
+    return `===READER ${item.id}===\n${user}`;
+  });
+  const system = [
+    baseSystem,
+    `BATCH MODE: below are ${items.length} independent readers, each starting with a "===READER <id>===" marker. Apply every rule above separately to EACH reader, using ONLY that reader's own data — never mix jobs, facts, or details between readers.`,
+    `Output EXACTLY ${items.length} blocks, one per reader, in the SAME ORDER as the readers below. Each block starts with "===BRIEFING <id>===" on its own line (the same id as that reader's marker) followed immediately by that reader's briefing HTML. No text outside these blocks.`,
+  ].join(' ');
+  return { system, user: readerBlocks.join('\n\n') };
+}
+
+/**
  * Build a prompt for AI to generate a personalized email subject line.
  *
  * @param {object} ctx


### PR DESCRIPTION
## Implementato

Phase 2 di `send-newsletter.mjs` chiedeva 1 chiamata AI per cohort — fino a ~1445 nella run di oggi (3367 subscriber), contro il budget free-tier per cui la chain era dimensionata (commento nel codice: "~150 cohort briefings ... well within free tier limits"). Ogni cohort che falliva cascava attraverso l'intera chain di 9 modelli — incluso l'ultima risorsa `claude-cli/haiku` con timeout hard 60s — prima di arrendersi. Questo ha esaurito ogni quota free-tier a metà run. **La run 29806287583 è POI effettivamente fallita** (non solo lenta): il runner GitHub ha perso comunicazione col server ("lost communication with the server... starves it for CPU/Memory") dopo 2h26m, conclusione `failure` alle 08:38 UTC — zero email inviate oggi, nessuna issue di failure aperta in automatico (lo step "Report failure to GitHub Issues" non ha fatto in tempo a girare).

- `services/newsletter-content.mjs`: nuova `buildBriefingBatchPrompt(items)` — costruisce UN prompt per N cohort (stesso locale), riusando `buildBriefingPrompt` internamente per il system prompt (nessuna duplicazione delle regole di lingua/struttura/job-linking) e delimitando ogni reader con marker `===READER <id>===` / `===BRIEFING <id>===`.
- `scripts/send-newsletter.mjs`:
  - `AI_BRIEFING_BATCH_SIZE = 3` — dimensiona il volume totale di richieste comodamente sotto la quota free-tier più stretta in cima alla chain (Gemini flash: 1500/giorno). Scelto conservativo (non 5+) per tenere il `maxTokens` combinato del batch (`800 * N + 200` = 2600 per N=3) comodamente sotto i cap di output dei modelli più deboli della chain — un batch più grande taglierebbe ulteriormente il volume ma rischierebbe troncamenti silenziosi sugli anelli deboli.
  - `parseBriefingBatchResponse` — split sui marker delimitatori, tollerante a drift di formattazione del modello (spazi/conteggio `=` variabili attorno al marker, es. `== BRIEFING 0 ==` invece di `===BRIEFING 0===` esatto — un match troppo rigido avrebbe silenziosamente scartato un item altrimenti buono). Un batch parzialmente troncato degrada per singolo item (esattamente come il fallback per-item esistente), non fallisce l'intero batch.
  - `generateAIBriefingsBatch` — orchestratore: chiama `callLLM` una volta per batch, ogni item passa comunque per `sanitizeAIBriefingHtml` (stesso quality gate già in produzione — verificato che gestisce correttamente un item troncato a metà, es. `dropped "..."` / `too short — falling back`).
  - Loop Phase 2 riscritto: raggruppa i cohort per locale (mai locale misti in un batch — vedi rischio locale-leakage sotto), poi chunk in batch da `AI_BRIEFING_BATCH_SIZE`, con la stessa concorrenza `AI_CONCURRENCY=5` di prima (solo il numero di *chiamate* cala, non il parallelismo).
- Riduzione attesa: da 1445 chiamate AI a ~482 (÷3) — meno aggressivo del batch=5 iniziale, ma con margine di sicurezza sui token per i modelli più piccoli. Ancora ben sotto la quota daily del primo modello in chain.

**Trade-off deliberato — raggio di failure per-batch**: un'eccezione nella chiamata `callLLM` (rete/rate-limit totale) ora fa cadere in fallback template TUTTI gli N cohort del batch invece di 1 solo come prima (`generateAIBriefingsBatch` ritorna una Map vuota per l'intero batch on catch). Non mitigato deliberatamente: ri-splittare in chiamate singole solo sul percorso d'eccezione reintrodurrebbe esattamente il volume di richieste che questa PR vuole evitare, proprio nello scenario (esaurimento quota) in cui questo path si attiva più spesso. Accettato: peggiora la granularità del fallback in caso di outage totale, ma nell'incidente reale di oggi TUTTI i modelli fallivano comunque simultaneamente — la granularità non avrebbe cambiato l'esito.

**Nota su una seconda ottimizzazione discussa ma NON implementata**: raggruppare i cohort per locale+canton invece che per set esatto di job matchati (`cohortKey = locale:jobSetHash(matchedJobs)`) è stato **scartato dopo analisi** — il prompt AI istruisce esplicitamente il modello a nominare per titolo job specifici con link cliccabili, e il post-processing deterministico (`injectJobAndCompanyLinks`) usa `cohort.matchedJobs` applicato all'INTERO cohort. Cohort più larghi con job-set diversi tra i membri produrrebbero un mismatch di contenuto reale (link a offerte non pertinenti al singolo subscriber), non solo un problema di performance. Richiede prima una scelta di prodotto (prosa AI generica + iniezione job 100% deterministica per-subscriber) — fuori scope di questa PR.

## Non implementato (ancora)

Scope di questa PR (batching Phase 2) interamente implementato. Due impegni tracciati, non bloccanti sul merge:

- **Verifica live in questa PR — in corso**: subito dopo il merge, lancio manuale (`gh workflow run send-newsletter.yml --ref main`, autorizzato esplicitamente dall'owner) per recuperare l'invio odierno mancato E validare la fix in condizioni reali (stesso ordine di grandezza di cohort di oggi, 1445). Osservo: (a) volume di chiamate effettivo vs stimato ~482, (b) se la run completa entro il cap 360min invece di fallire per starvation runner come oggi, (c) tasso di successo AI vs fallback template.
- **Revert-risk esplicito** (richiesto da review, precedente diretto #795/#802→#822 su claim "atteso" non misurato): se la run di verifica sopra fallisce di nuovo per lo stesso sintomo (runner "lost communication"/starvation, o cascata fino a haiku sulla maggioranza dei cohort), o se la prossima run cron schedulata (03:33 UTC) supera ancora ~1h di durata anomala, rollback di questa PR (revert diretto, il diff è isolato a 2 file) invece di iterare sul batch size o altri tuning in-place.

Il gate `check-sibling-patterns.mjs --strict` (pre-push hook) ha segnalato 10 file che condividono simboli/token col diff — inspezionati singolarmente, tutti falsi positivi (nessuno condivide il pattern reale, ossia un loop bulk con 1 chiamata AI per item in scala):

- `services/newsletterPreview.ts` — condivide `buildBriefingPrompt`/`getFallbackBriefing`/`matchJobsForSubscriber` ma genera UN solo briefing per l'anteprima admin on-demand, nessun loop bulk da batchare.
- `scripts/newsletter-qa.mjs` — importa `getFallbackBriefing`/`matchJobsForSubscriber`/`loadDashboardMetrics` per QA check statici; verificato via grep, zero chiamate `callLLM`/`generateAIBriefing`, nessun loop-per-item.
- `.github/workflows/send-newsletter.yml` — `NEWSLETTER_AI_CHAIN` compare solo in un commento di documentazione (riga 118) sullo step "Setup Claude CLI Haiku fallback", non un costrutto di codice.
- `build-plugins/relatedSearchClustersPlugin.ts` — `batchResults` è coincidenza di naming, batch di `runPrepassWorker` per cluster di ricerca correlata (dominio diverso), già bulk/parallelo.
- `build-plugins/shared/slimJobIndex.ts` — importa `matchJobsForSubscriber` preesistente per indicizzazione job, nessuna generazione AI né loop-per-item.
- `scripts/audit-articles-factcheck.mjs` — `batchResults` variabile locale per iterare risultati di fact-check paralleli preesistenti, dominio diverso.
- `scripts/audit-parser-quality.mjs` — `batchResults` da `Promise.all(batch.map(checkUrl))` per audit URL, non generazione briefing.
- `scripts/monitor-gsc-job-indexation.mjs` — importa `isCompanyHubSlug` per monitoraggio indicizzazione GSC, dominio non correlato.
- `services/newsletter-subject-variants.mjs` — usa `buildSubjectPrompt` per Phase 3 (subject A/B), già naturalmente limitata a ≤8 chiamate totali per l'intero invio — non soffre del volume esploso risolto in Phase 2.
- `services/publisherBlastMatch.mjs` — importa `matchJobsForSubscriber` preesistente per una feature diversa (publisher blast match), nessun loop-per-item.

## Test plan

- [x] `node --check scripts/send-newsletter.mjs services/newsletter-content.mjs` — sintassi OK
- [x] `npx vitest run tests/newsletter-*.test.ts` — tutti i test passano (443/443, incl. `newsletter-locale-leakage.test.ts`, `newsletter-briefing-prompt-locale.test.ts`)
- [x] Smoke test standalone di `buildBriefingBatchPrompt` (marker `===READER n===` corretti, nessun mix di locale)
- [x] Smoke test del parser (`parseBriefingBatchResponse`) su risposta troncata a metà (item completi estratti correttamente, item troncato passato al quality gate esistente) e su drift di formattazione marker (`== BRIEFING 0 ==`, `==== BRIEFING 2====`) — tutti riconosciuti
- [ ] Verifica end-to-end su una run reale (non eseguibile pre-merge — `send-newsletter.mjs --send` mai in locale) — lancio manuale pianificato subito dopo il merge, vedi `## Non implementato` sopra

Non chiude nessuna issue (nessuna issue aperta referenziata per questo lavoro — nasce da diagnosi conversazionale della run 29806287583, poi confermata fallita durante la review).
