### PR TITLE
fix(scripts): default User-Agent on same-origin fetches — bypass our own CF challenge rule

### DIFF
--- a/scripts/build-search-cluster-301-map.mjs
+++ b/scripts/build-search-cluster-301-map.mjs
@@ -62,6 +62,7 @@ import {
 import { createCantonResolvers, AGGREGATE_KEY } from '../build-plugins/shared/cantonResolvers.mjs';
 import { readCompatPaths, writeCompatPaths } from './lib/compat-paths-store.mjs';
 import { assertCompatFloor, COMPAT_PATHS_SANITY_FLOOR } from './lib/compat-paths-floor-guard.mjs';
+import { DEFAULT_LIVE_CHECK_USER_AGENT } from './lib/live-link-check.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -168,7 +169,11 @@ async function isLive(pathUrl) {
   if (liveCache.has(pathUrl)) return liveCache.get(pathUrl);
   let ok = false;
   try {
-    const res = await fetch(`${BASE}${pathUrl}`, { method: 'GET', redirect: 'manual' });
+    const res = await fetch(`${BASE}${pathUrl}`, {
+      method: 'GET',
+      redirect: 'manual',
+      headers: { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT },
+    });
     ok = res.status === 200;
   } catch {
     ok = false;
@@ -311,7 +316,7 @@ export async function fetchLiveClusterSet() {
     const url = `${BASE}/sitemap-search-clusters-${idx}.xml`;
     let xml;
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { headers: { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT } });
       if (!res.ok) break; // no more shards
       xml = await res.text();
     } catch {

--- a/scripts/capture-deployed-sitemaps.mjs
+++ b/scripts/capture-deployed-sitemaps.mjs
@@ -44,6 +44,7 @@
  */
 
 import { writeFileSync } from 'node:fs';
+import { DEFAULT_LIVE_CHECK_USER_AGENT } from './lib/live-link-check.mjs';
 
 const HOST = process.env.HOST || 'frontaliereticino.ch';
 const OUTPUT = process.env.OUTPUT || '/tmp/pre-deploy-sitemap-urls.json';
@@ -73,7 +74,7 @@ function parseSitemapBody(xml) {
 async function fetchText(url) {
   try {
     const res = await fetch(url, {
-      headers: { Accept: 'application/xml, text/xml' },
+      headers: { Accept: 'application/xml, text/xml', 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) return null;

--- a/scripts/check-journalist-article-links.mjs
+++ b/scripts/check-journalist-article-links.mjs
@@ -47,7 +47,7 @@
  */
 
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { checkPageBodyLive, runWithConcurrency } from './lib/live-link-check.mjs';
+import { checkPageBodyLive, runWithConcurrency, DEFAULT_LIVE_CHECK_USER_AGENT } from './lib/live-link-check.mjs';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 const FETCH_TIMEOUT_MS = 10_000;
@@ -92,7 +92,10 @@ function extractSameOriginLinks(html, pageUrl) {
 /** Fetch a live page + check all its same-origin outlinks. Returns the
  * linkCheck result shape (services/journalistTypes.ts JournalistArticleLinkCheckResult). */
 async function checkPageLinks(pageUrl) {
-  const pageRes = await fetch(pageUrl, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  const pageRes = await fetch(pageUrl, {
+    headers: { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!pageRes.ok) throw new Error(`page fetch failed: HTTP ${pageRes.status}`);
   const html = await pageRes.text();
   const links = extractSameOriginLinks(html, pageUrl);

--- a/scripts/lib/live-link-check.mjs
+++ b/scripts/lib/live-link-check.mjs
@@ -24,9 +24,26 @@
  * expired-job soft-landing marker check, for same-origin frontaliereticino.ch
  * URLs where checkLink()'s HEAD/status-only check is blind to the site's
  * soft-404 policy (see its own doc comment below).
+ *
+ * DEFAULT_LIVE_CHECK_USER_AGENT: Cloudflare's own
+ * "unidentified-scripted-traffic-challenge" firewall rule (managed by
+ * scripts/cf-locale-failover-setup.mjs, CHALLENGED_UAS) `managed_challenge`s
+ * any request whose User-Agent is empty or the literal "node" — undici's
+ * default `fetch()` sends no User-Agent header at all, which reads as empty
+ * to Cloudflare, so every check in this module was silently hitting the CF
+ * JS-challenge interstitial (HTTP 403 "Just a moment...") and reading as
+ * "dead" 100% of the time, regardless of the target's real liveness (found
+ * investigating the send-job-alerts.mjs preflight always failing open).
+ * Same convention/fix as scripts/seo-audit-structural.mjs,
+ * scripts/canary-article-content.mjs, scripts/probe-5xx.mjs, etc. — a
+ * descriptive UA clears the challenge rule and reaches the real origin.
+ * Both checkLink() and checkPageBodyLive() apply this as a default, merged
+ * under any caller-supplied `opts.headers` (wait-for-pages-propagation.mjs's
+ * own UA still wins where it sets one explicitly).
  */
 
 export const DEFAULT_LIVE_CHECK_TIMEOUT_MS = 8_000;
+export const DEFAULT_LIVE_CHECK_USER_AGENT = 'FrontaliereTicino-LiveLinkCheck/1.0 (+https://frontaliereticino.ch)';
 
 /** HEAD-check a single URL; falls back to a ranged GET if the origin rejects
  * HEAD (some static hosts / edge configs return 405/501 for it). Never
@@ -47,17 +64,18 @@ export const DEFAULT_LIVE_CHECK_TIMEOUT_MS = 8_000;
  */
 export async function checkLink(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS, opts = {}) {
   const { cacheBust = false, headers = {} } = opts;
+  const mergedHeaders = { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT, ...headers };
   const target = cacheBust ? `${url}${url.includes('?') ? '&' : '?'}_=${Date.now()}` : url;
   try {
     const res = await fetch(target, {
       method: 'HEAD',
-      headers,
+      headers: mergedHeaders,
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (res.status === 405 || res.status === 501) {
       const getRes = await fetch(target, {
         method: 'GET',
-        headers: { ...headers, Range: 'bytes=0-0' },
+        headers: { ...mergedHeaders, Range: 'bytes=0-0' },
         signal: AbortSignal.timeout(timeoutMs),
       });
       return getRes.ok || getRes.status === 206;
@@ -84,9 +102,13 @@ export const EXPIRED_JOB_MARKER = '__EXPIRED_JOB_DATA__=';
  * EXPIRED_JOB_MARKER above — HEAD/status alone can never see this, the page
  * always 200s). Never throws — resolves `false` on any non-ok status,
  * network error, timeout, or marker match. */
-export async function checkPageBodyLive(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS) {
+export async function checkPageBodyLive(url, timeoutMs = DEFAULT_LIVE_CHECK_TIMEOUT_MS, opts = {}) {
+  const { headers = {} } = opts;
   try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const res = await fetch(url, {
+      headers: { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT, ...headers },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
     if (!res.ok) return false;
     const body = await res.text();
     return !body.includes(EXPIRED_JOB_MARKER);

--- a/scripts/seed-url-first-seen-precise.mjs
+++ b/scripts/seed-url-first-seen-precise.mjs
@@ -33,6 +33,7 @@
 import { readFileSync, readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_LIVE_CHECK_USER_AGENT } from './lib/live-link-check.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -133,7 +134,7 @@ function loadSlugIndex(rootDir) {
 }
 
 async function fetchSitemap(url) {
-  const r = await fetch(url);
+  const r = await fetch(url, { headers: { 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT } });
   if (!r.ok) throw new Error(`${url} → ${r.status}`);
   return await r.text();
 }

--- a/scripts/submit-indexnow-batch.mjs
+++ b/scripts/submit-indexnow-batch.mjs
@@ -40,6 +40,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { DEFAULT_LIVE_CHECK_USER_AGENT } from './lib/live-link-check.mjs';
 
 // ── Configuration ─────────────────────────────────────────────
 const DEFAULT_KEY = '39093e02a74b4a2dbf867c74bc53a7d8';
@@ -153,7 +154,7 @@ async function fetchSitemapXml(file) {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const res = await fetch(url, {
-        headers: { Accept: 'application/xml,text/xml' },
+        headers: { Accept: 'application/xml,text/xml', 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT },
         signal: AbortSignal.timeout(30_000),
       });
       if (res.ok) return await res.text();
@@ -267,7 +268,7 @@ export async function getUrlsFromSitemaps() {
 async function verifyKeyFile() {
   try {
     const res = await fetch(KEY_LOCATION, {
-      headers: { Accept: 'text/plain' },
+      headers: { Accept: 'text/plain', 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT },
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {

--- a/tests/job-alert-live-link-check.test.ts
+++ b/tests/job-alert-live-link-check.test.ts
@@ -165,19 +165,19 @@ describe('filterLiveJobs', () => {
 // checkLink option surface added for the deep-sample propagation gate (PR #4181
 // review 🟡: the gate must REUSE checkLink, not re-implement it — these tests
 // pin the option semantics both callers now share).
-import { checkLink } from '../scripts/lib/live-link-check.mjs';
+import { checkLink, DEFAULT_LIVE_CHECK_USER_AGENT } from '../scripts/lib/live-link-check.mjs';
 
 describe('checkLink — cacheBust + headers options (deep-sample gate reuse)', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('default call has NO cache-bust query and no extra headers (send-job-alerts semantics unchanged)', async () => {
+  it('default call has NO cache-bust query and only the default User-Agent header (CF challenge bypass, no caller override)', async () => {
     const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
     await checkLink('https://example.com/page/');
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.com/page/');
     expect(init.method).toBe('HEAD');
-    expect(init.headers).toEqual({});
+    expect(init.headers).toEqual({ 'User-Agent': DEFAULT_LIVE_CHECK_USER_AGENT });
   });
 
   it('cacheBust appends a unique _=<ts> query param (origin read, edge defeated)', async () => {


### PR DESCRIPTION
## Implementato

Root cause (found investigating "perché solo 2180 email" / the `⚠️ Live-link check: only 0/N ... suspected transient network issue` spam in `send-job-alerts.mjs` logs): Cloudflare's own `unidentified-scripted-traffic-challenge` firewall rule (managed by `scripts/cf-locale-failover-setup.mjs`, `CHALLENGED_UAS = ['', 'node']`) `managed_challenge`s any request with an empty User-Agent. Node's native `fetch()` (undici) sends no User-Agent header by default, which Cloudflare reads as empty — so every same-origin liveness/content check built on a bare `fetch()` was silently hitting our own JS-challenge interstitial (HTTP 403 "Just a moment...") and reading as "dead", 100% of the time, regardless of the target's real liveness. Reproduced live and deterministically: bare `fetch()` → 403, same URL with any non-empty User-Agent → 200 (3/3 repeats).

Not a "transient network issue" as the log message claimed — deterministic and permanent since the challenge rule was introduced.

- `scripts/lib/live-link-check.mjs`: `checkLink()` and `checkPageBodyLive()` now default to `DEFAULT_LIVE_CHECK_USER_AGENT` (`FrontaliereTicino-LiveLinkCheck/1.0 (+https://frontaliereticino.ch)`), merged under any caller-supplied `opts.headers` (caller override still wins — `wait-for-pages-propagation.mjs`'s own explicit UA is unaffected). `checkPageBodyLive()` gained an `opts` param (backward compatible, previously had none).
- Same construct fixed at every other same-origin `fetch()` call site found via `scripts/ci/check-sibling-patterns.mjs` + manual sweep: `check-journalist-article-links.mjs` (page-HTML fetch), `capture-deployed-sitemaps.mjs` (sitemap snapshot), `build-search-cluster-301-map.mjs` (×2: `isLive()` + `fetchLiveClusterSet()`), `submit-indexnow-batch.mjs` (×2: sitemap fetch + `verifyKeyFile()`), `seed-url-first-seen-precise.mjs` (sitemap fetch).
- `scripts/send-job-alerts.mjs` and `scripts/notify-journalist-article-live.mjs` call the shared helpers without their own headers, so they inherit the fix with **no direct diff** — verified by `tests/job-alert-live-link-check.test.ts`, `tests/job-alert-geo-preference-pipeline.test.ts`, and `tests/check-journalist-article-links-ordering.test.ts` (all green).
- Fixed a stale assertion in `tests/job-alert-live-link-check.test.ts` that had encoded the pre-fix (broken) no-UA behavior as the expected/correct one.
- Highest-impact instance found: `submit-indexnow-batch.mjs`'s `verifyKeyFile()` gates the entire run (`process.exit(1)` on failure, step 4 of 5) — IndexNow submission has likely never successfully reached step 5 (actual submission to Bing/Yandex) in production since this script's inception.
- Full test run on every touched script's suite: `job-alert-live-link-check`, `job-alert-geo-preference-pipeline`, `submit-indexnow-batch`, `build-search-cluster-301-map`, `build-search-cluster-301-map-shape-guard`, `check-journalist-article-links-ordering`, `refine-url-first-seen-via-gsc` — **40/40 passing**.
- GitNexus impact analysis on `checkLink`/`checkPageBodyLive` (upstream): risk **LOW** both.

## Non implementato (ancora)

Nessuno. `check-sibling-patterns.mjs --strict` flagged 12 files sharing tokens with this diff; each individually inspected (required for the `--no-verify` push below) — all are false positives or already covered by this same PR, no code change needed:

- `scripts/send-job-alerts.mjs` / `scripts/notify-journalist-article-live.mjs` — **not deferred**: fixed transitively in this PR (call the shared helpers with no headers of their own → inherit the new default UA), confirmed by the passing test suites listed above.
- `scripts/cf-locale-failover-setup.mjs` — false positive: this is the *definer* of the `CHALLENGED_UAS` firewall rule we're routing around, not a broken fetch caller.
- `scripts/wait-for-pages-propagation.mjs` — false positive: already passes its own explicit `User-Agent` to `checkLink()` — this was the pre-existing correct reference pattern this fix generalizes.
- `components/pages/AdminPanel.tsx` — false positive: fetches `api.frankfurter.dev`/`.app` (CHF/EUR FX rates), not frontaliereticino.ch.
- `functions/src/trafficSchedulerCore.js` — false positive: fetches the TomTom Traffic Flow API, not frontaliereticino.ch.
- `scripts/geocode-municipalities.mjs` — false positive: fetches the Google Maps Geocoding API, not frontaliereticino.ch.
- `scripts/batch-add-faq-to-articles.mjs` / `scripts/enrich-related-search-clusters.mjs` — false positive: each defines its own local `runWithConcurrency`, not importing `scripts/lib/live-link-check.mjs` — name collision only.
- `scripts/lib/mcdonalds-job-parser.mjs` / `scripts/lib/shared-jobs-crawler.mjs` — false positive: local `runWithConcurrency` + these crawl third-party ATS/employer sites (not frontaliereticino.ch), already sending their own `FrontaliereTicinoBot/1.0` UA to identify themselves *outbound* to those external sites — the opposite, unrelated concern from this *inbound* CF-challenge bypass.
- `scripts/probe-5xx.mjs` — false positive: local `runWithConcurrency` + already sets its own correct UA (`FrontaliereTicino-Probe5xx/1.0`) predating this PR — this file was the prior art that confirmed the established convention/root cause.

## Test plan

- [x] Reproduced the 403 live against production (`frontaliereticino.ch`) with a bare `fetch()`, confirmed 200 with any non-empty User-Agent (3/3 deterministic repeats).
- [x] `npx vitest run tests/job-alert-live-link-check.test.ts tests/job-alert-geo-preference-pipeline.test.ts tests/submit-indexnow-batch.test.ts tests/build-search-cluster-301-map.test.ts tests/check-journalist-article-links-ordering.test.ts tests/scripts/build-search-cluster-301-map-shape-guard.test.ts tests/scripts/refine-url-first-seen-via-gsc.test.ts` → 40/40 passing.
- [x] Live-verified fixed `checkPageBodyLive`/`checkLink` against a real job page pulled fresh from the production sitemap: both now correctly read it as live.