### PR TITLE
fix(articles): repetition-check safety net mancante dopo body expansion

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -5188,6 +5188,95 @@ function italianBodyWordCount(data) {
     .reduce((acc, n) => acc + n, 0);
 }
 
+// ── Repetition detection + cleanup helpers ──────────────────────────
+// Shared between the main generation retry loop and the last-resort
+// content-expansion path below (expandShortItalianContent). Extracted
+// 2026-07-21: that expansion path — invoked when the source is too thin to
+// reach adaptiveMinWords through normal regeneration — is the code path
+// MOST likely to trigger LLM repetition-degeneration, since it explicitly
+// asks the model to keep adding content past what a thin source genuinely
+// supports. Before this fix, only the main retry loop ran this check; the
+// expansion path had none, so runaway repeats (a paragraph copy-pasted 5x,
+// a sentence repeated 26x) reached the live site untouched. Live incident:
+// articoli-svizzera swatch-crescita-2026 / novartis-superaspettative
+// (2026-07-21) — both expanded from thin tio.ch/AWP wire snippets.
+
+/** Detect exact-duplicate paragraphs or heavily-repeated sentences across body1-3. */
+function detectBodyRepetition(itContent) {
+  const allBodies = ['body1', 'body2', 'body3'].map(k => itContent?.[k] || '');
+
+  // 1. Repeated paragraphs within a single body field.
+  for (const [idx, body] of allBodies.entries()) {
+    const paragraphs = body.split(/\n\n+/).map(p => p.trim()).filter(p => p.length > 60);
+    const seen = new Map();
+    let dupeCount = 0;
+    for (const p of paragraphs) {
+      const normalized = p.replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
+      seen.set(normalized, (seen.get(normalized) || 0) + 1);
+      if (seen.get(normalized) > 1) dupeCount++;
+    }
+    if (dupeCount >= 3) {
+      return { hasRepetition: true, reason: `body${idx + 1} ha ${dupeCount} paragrafi ripetuti` };
+    }
+  }
+
+  // 2. Sentences repeated 4+ times across all bodies.
+  const allText = allBodies.join('\n\n');
+  const sentences = allText.split(/[.!?]\s+/).map(s => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter(s => s.length > 40);
+  const sentCounts = new Map();
+  for (const s of sentences) sentCounts.set(s, (sentCounts.get(s) || 0) + 1);
+  const heavyRepeats = [...sentCounts.entries()].filter(([, c]) => c >= 4);
+  if (heavyRepeats.length > 0) {
+    return {
+      hasRepetition: true,
+      reason: `${heavyRepeats.length} frasi ripetute 4+ volte: "${heavyRepeats[0][0].substring(0, 60)}..." (${heavyRepeats[0][1]}x)`,
+    };
+  }
+
+  return { hasRepetition: false, reason: '' };
+}
+
+/** Strip exact-duplicate paragraphs (post-normalization) from each body field, keeping the first. Mutates itContent. */
+function dedupeRepeatedParagraphs(itContent) {
+  for (const field of ['body1', 'body2', 'body3']) {
+    if (!itContent?.[field]) continue;
+    const paras = itContent[field].split(/\n\n+/);
+    const seen = new Set();
+    const unique = [];
+    for (const p of paras) {
+      const norm = p.trim().replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
+      if (norm.length < 60 || !seen.has(norm)) {
+        seen.add(norm);
+        unique.push(p);
+      }
+    }
+    itContent[field] = unique.join('\n\n');
+  }
+}
+
+/** Strip the article title when echoed as the opening line of 2+ body fields. Mutates itContent. */
+function stripDuplicateTitleFromBody(itContent) {
+  const titleCheck = String(itContent?.title || '').trim();
+  if (!titleCheck) return;
+  const allBodies = ['body1', 'body2', 'body3'].map(k => itContent?.[k] || '');
+  let titleInBodyCount = 0;
+  for (const body of allBodies) {
+    const firstLine = body.split('\n')[0].trim();
+    if (firstLine === titleCheck || firstLine.startsWith(titleCheck)) titleInBodyCount++;
+  }
+  if (titleInBodyCount < 2) return;
+  for (const field of ['body1', 'body2', 'body3']) {
+    if (!itContent?.[field]) continue;
+    const lines = itContent[field].split('\n');
+    if (lines[0].trim() === titleCheck || lines[0].trim().startsWith(titleCheck)) {
+      lines.shift();
+      while (lines.length > 0 && lines[0].trim() === '') lines.shift();
+      itContent[field] = lines.join('\n');
+      console.error(`  🧹 Rimosso titolo duplicato da it.${field}`);
+    }
+  }
+}
+
 /**
  * Expand short Italian body content by asking the LLM to enrich each body field.
  * This is a last-resort fallback that's far more effective than regenerating from scratch,
@@ -9766,86 +9855,19 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     if (itWords >= adaptiveMinWords) {
       // ── Repetition check INSIDE the loop — triggers retry if AI looped ──
       const itContentLoop = data.content.it || data.content;
-      const allBodiesLoop = ['body1', 'body2', 'body3'].map(k => itContentLoop?.[k] || '');
-      let hasRepetition = false;
-      let repetitionReason = '';
-
-      // 1. Detect repeated paragraphs within a single body field
-      for (const [idx, body] of allBodiesLoop.entries()) {
-        const paragraphs = body.split(/\n\n+/).map(p => p.trim()).filter(p => p.length > 60);
-        const seen = new Map();
-        let dupeCount = 0;
-        for (const p of paragraphs) {
-          const normalized = p.replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-          seen.set(normalized, (seen.get(normalized) || 0) + 1);
-          if (seen.get(normalized) > 1) dupeCount++;
-        }
-        if (dupeCount >= 3) {
-          hasRepetition = true;
-          repetitionReason = `body${idx + 1} ha ${dupeCount} paragrafi ripetuti`;
-          break;
-        }
-      }
-
-      // 2. Detect sentences repeated 4+ times across all bodies
-      if (!hasRepetition) {
-        const allText = allBodiesLoop.join('\n\n');
-        const sentences = allText.split(/[.!?]\s+/).map(s => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter(s => s.length > 40);
-        const sentCounts = new Map();
-        for (const s of sentences) sentCounts.set(s, (sentCounts.get(s) || 0) + 1);
-        const heavyRepeats = [...sentCounts.entries()].filter(([, c]) => c >= 4);
-        if (heavyRepeats.length > 0) {
-          hasRepetition = true;
-          repetitionReason = `${heavyRepeats.length} frasi ripetute 4+ volte: "${heavyRepeats[0][0].substring(0, 60)}..." (${heavyRepeats[0][1]}x)`;
-        }
-      }
+      const { hasRepetition, reason: repetitionReason } = detectBodyRepetition(itContentLoop);
 
       if (hasRepetition) {
         console.error(`  ⚠️  AI loop rilevato: ${repetitionReason} — rigenero (${attempt}/${maxAttempts})...`);
         if (attempt < maxAttempts) continue;
         // Last attempt: auto-strip duplicate paragraphs as fallback
         console.error(`  🔧 Ultimo tentativo: auto-deduplica paragrafi ripetuti...`);
-        for (const field of ['body1', 'body2', 'body3']) {
-          if (itContentLoop?.[field]) {
-            const paras = itContentLoop[field].split(/\n\n+/);
-            const seen = new Set();
-            const unique = [];
-            for (const p of paras) {
-              const norm = p.trim().replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-              if (norm.length < 60 || !seen.has(norm)) {
-                seen.add(norm);
-                unique.push(p);
-              }
-            }
-            itContentLoop[field] = unique.join('\n\n');
-          }
-        }
+        dedupeRepeatedParagraphs(itContentLoop);
         console.error(`  ✅ Auto-deduplica completata`);
         break;
       }
 
-      // 3. Auto-strip title duplicated as first line in body fields
-      const titleCheck = String(itContentLoop?.title || '').trim();
-      if (titleCheck) {
-        let titleInBodyCount = 0;
-        for (const body of allBodiesLoop) {
-          const firstLine = body.split('\n')[0].trim();
-          if (firstLine === titleCheck || firstLine.startsWith(titleCheck)) titleInBodyCount++;
-        }
-        if (titleInBodyCount >= 2) {
-          for (const field of ['body1', 'body2', 'body3']) {
-            if (itContentLoop?.[field]) {
-              const lines = itContentLoop[field].split('\n');
-              if (lines[0].trim() === titleCheck || lines[0].trim().startsWith(titleCheck)) {
-                lines.shift();
-                while (lines.length > 0 && lines[0].trim() === '') lines.shift();
-                itContentLoop[field] = lines.join('\n');
-                console.error(`  🧹 Rimosso titolo duplicato da it.${field}`);
-              }
-            }
-          }
-        }
-      }
+      stripDuplicateTitleFromBody(itContentLoop);
 
       console.error(`  ✅ Soglia parole IT raggiunta: ${itWords} (min ${adaptiveMinWords}), nessun loop AI`);
       break;
@@ -9858,6 +9880,21 @@ async function generateAndValidateArticle(url, sourceContext = null) {
     console.error(`  🔧 Ultimo tentativo: espansione contenuto esistente (${itWords} → min ${adaptiveMinWords})...`);
     try {
       data = await expandShortItalianContent(data, adaptiveMinWords);
+
+      // Re-run the SAME repetition check the main loop uses above — this
+      // expansion call is the path MOST likely to produce it (see
+      // detectBodyRepetition's doc comment). Before this fix, runaway
+      // repeats from this specific path shipped straight to the live site
+      // uncaught (incident 2026-07-21: swatch-crescita-2026,
+      // novartis-superaspettative).
+      const expandedItContent = data.content.it || data.content;
+      const { hasRepetition: expandHasRepetition, reason: expandRepetitionReason } = detectBodyRepetition(expandedItContent);
+      if (expandHasRepetition) {
+        console.error(`  ⚠️  AI loop rilevato dopo espansione: ${expandRepetitionReason} — auto-deduplica...`);
+        dedupeRepeatedParagraphs(expandedItContent);
+      }
+      stripDuplicateTitleFromBody(expandedItContent);
+
       const expandedWords = italianBodyWordCount(data);
       if (expandedWords >= adaptiveMinWords) {
         console.error(`  ✅ Espansione riuscita: ${expandedWords} parole (min ${adaptiveMinWords})`);

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -135,6 +135,7 @@ import { matchesFrontaliereAnchor, matchesFrontaliereUnambiguousAnchor } from '.
 import { isNonItalianScript, nonItalianScriptRatio } from './lib/itLanguageCheck.mjs';
 import { checkSemanticNearDuplicate } from './lib/scoring/semanticDedup.mjs';
 import { computeAdaptiveEvergreenThresholds } from './lib/scoring/constants.mjs';
+import { detectBodyRepetition, dedupeRepeatedParagraphs, stripDuplicateTitleFromBody } from './lib/article-body-repetition.mjs';
 import { loadEmbeddingStore, loadEmbeddingMeta } from './lib/scoring/embeddingMatcher.mjs';
 import { appendCatalogEntry } from './generate-journalist-image-catalog.mjs';
 import { appendArticleListItem } from './lib/seo-pages-article-list.mjs';
@@ -5186,95 +5187,6 @@ function italianBodyWordCount(data) {
   return ['body1', 'body2', 'body3']
     .map((k) => countWords(it[k] || ''))
     .reduce((acc, n) => acc + n, 0);
-}
-
-// ── Repetition detection + cleanup helpers ──────────────────────────
-// Shared between the main generation retry loop and the last-resort
-// content-expansion path below (expandShortItalianContent). Extracted
-// 2026-07-21: that expansion path — invoked when the source is too thin to
-// reach adaptiveMinWords through normal regeneration — is the code path
-// MOST likely to trigger LLM repetition-degeneration, since it explicitly
-// asks the model to keep adding content past what a thin source genuinely
-// supports. Before this fix, only the main retry loop ran this check; the
-// expansion path had none, so runaway repeats (a paragraph copy-pasted 5x,
-// a sentence repeated 26x) reached the live site untouched. Live incident:
-// articoli-svizzera swatch-crescita-2026 / novartis-superaspettative
-// (2026-07-21) — both expanded from thin tio.ch/AWP wire snippets.
-
-/** Detect exact-duplicate paragraphs or heavily-repeated sentences across body1-3. */
-function detectBodyRepetition(itContent) {
-  const allBodies = ['body1', 'body2', 'body3'].map(k => itContent?.[k] || '');
-
-  // 1. Repeated paragraphs within a single body field.
-  for (const [idx, body] of allBodies.entries()) {
-    const paragraphs = body.split(/\n\n+/).map(p => p.trim()).filter(p => p.length > 60);
-    const seen = new Map();
-    let dupeCount = 0;
-    for (const p of paragraphs) {
-      const normalized = p.replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-      seen.set(normalized, (seen.get(normalized) || 0) + 1);
-      if (seen.get(normalized) > 1) dupeCount++;
-    }
-    if (dupeCount >= 3) {
-      return { hasRepetition: true, reason: `body${idx + 1} ha ${dupeCount} paragrafi ripetuti` };
-    }
-  }
-
-  // 2. Sentences repeated 4+ times across all bodies.
-  const allText = allBodies.join('\n\n');
-  const sentences = allText.split(/[.!?]\s+/).map(s => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter(s => s.length > 40);
-  const sentCounts = new Map();
-  for (const s of sentences) sentCounts.set(s, (sentCounts.get(s) || 0) + 1);
-  const heavyRepeats = [...sentCounts.entries()].filter(([, c]) => c >= 4);
-  if (heavyRepeats.length > 0) {
-    return {
-      hasRepetition: true,
-      reason: `${heavyRepeats.length} frasi ripetute 4+ volte: "${heavyRepeats[0][0].substring(0, 60)}..." (${heavyRepeats[0][1]}x)`,
-    };
-  }
-
-  return { hasRepetition: false, reason: '' };
-}
-
-/** Strip exact-duplicate paragraphs (post-normalization) from each body field, keeping the first. Mutates itContent. */
-function dedupeRepeatedParagraphs(itContent) {
-  for (const field of ['body1', 'body2', 'body3']) {
-    if (!itContent?.[field]) continue;
-    const paras = itContent[field].split(/\n\n+/);
-    const seen = new Set();
-    const unique = [];
-    for (const p of paras) {
-      const norm = p.trim().replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-      if (norm.length < 60 || !seen.has(norm)) {
-        seen.add(norm);
-        unique.push(p);
-      }
-    }
-    itContent[field] = unique.join('\n\n');
-  }
-}
-
-/** Strip the article title when echoed as the opening line of 2+ body fields. Mutates itContent. */
-function stripDuplicateTitleFromBody(itContent) {
-  const titleCheck = String(itContent?.title || '').trim();
-  if (!titleCheck) return;
-  const allBodies = ['body1', 'body2', 'body3'].map(k => itContent?.[k] || '');
-  let titleInBodyCount = 0;
-  for (const body of allBodies) {
-    const firstLine = body.split('\n')[0].trim();
-    if (firstLine === titleCheck || firstLine.startsWith(titleCheck)) titleInBodyCount++;
-  }
-  if (titleInBodyCount < 2) return;
-  for (const field of ['body1', 'body2', 'body3']) {
-    if (!itContent?.[field]) continue;
-    const lines = itContent[field].split('\n');
-    if (lines[0].trim() === titleCheck || lines[0].trim().startsWith(titleCheck)) {
-      lines.shift();
-      while (lines.length > 0 && lines[0].trim() === '') lines.shift();
-      itContent[field] = lines.join('\n');
-      console.error(`  🧹 Rimosso titolo duplicato da it.${field}`);
-    }
-  }
 }
 
 /**

--- a/scripts/lib/article-body-repetition.mjs
+++ b/scripts/lib/article-body-repetition.mjs
@@ -93,17 +93,30 @@ export function dedupeRepeatedParagraphs(bodies) {
       }
     }
 
-    // Step 2: within each surviving paragraph, strip sentences repeated 3+
-    // times globally down to a single occurrence across the whole document.
+    // Step 2: within each surviving paragraph, strip sentences repeated 4+
+    // times globally (same bar as detectBodyRepetition's own trigger, so
+    // dedup never touches a sentence that wouldn't independently have
+    // flagged detection — was 3+ before code review found it could
+    // silently strip unrelated, legitimately 3x-repeated content whenever
+    // dedup ran for a different reason) down to a single occurrence across
+    // the whole document.
+    //
+    // No `sentences.length < 2` short-circuit for single-sentence
+    // paragraphs (code review found this too): a repeated sentence that
+    // stands alone as its own paragraph — a callout/pull-quote line, which
+    // this article format explicitly supports (📊/💡/⚠️ markers) — must
+    // still go through the SAME filter so it both (a) gets stripped when
+    // it's a repeat and (b) registers in `globalSeen` on its first/kept
+    // occurrence; skipping it silently undercounted, letting one extra
+    // occurrence elsewhere survive.
     const cleaned = uniqueParas
       .map((para) => {
         const sentences = para.split(/(?<=[.!?])\s+/);
-        if (sentences.length < 2) return para;
         const filtered = sentences.filter((s) => {
           const norm = s.trim().toLowerCase().replace(/\s+/g, ' ');
           if (norm.length <= 30) return true;
           const globalCount = globalSentCounts.get(norm) || 1;
-          if (globalCount < 3) return true;
+          if (globalCount < 4) return true;
           const soFar = (globalSeen.get(norm) || 0) + 1;
           globalSeen.set(norm, soFar);
           return soFar <= 1;

--- a/scripts/lib/article-body-repetition.mjs
+++ b/scripts/lib/article-body-repetition.mjs
@@ -1,0 +1,142 @@
+// ── Repetition detection + cleanup for AI-generated article bodies ──────
+// Shared between scripts/create-article.mjs (preventive checks during
+// generation) and scripts/repair-repetitive-articles.mjs (retroactive CLI
+// repair of already-published articles). Extracted 2026-07-21 after a PR
+// review caught the two implementations drifting: create-article.mjs's
+// dedupeRepeatedParagraphs only stripped whole-paragraph exact duplicates,
+// silently no-op-ing when detectBodyRepetition fired on its OTHER branch
+// (a sentence repeated 4+ times embedded across otherwise-different
+// paragraphs — no single paragraph is an exact duplicate, so paragraph-only
+// dedup can't touch it). repair-repetitive-articles.mjs already had the
+// correct cross-paragraph sentence-strip (deduplicateBodies); this module
+// is that logic promoted to a single shared source so both call sites stay
+// in sync by construction (AGENTS.md #6).
+//
+// Live incident this closes: articoli-svizzera swatch-crescita-2026 /
+// novartis-superaspettative (2026-07-21) — a sentence repeated ~26 times
+// and a 2-paragraph block copy-pasted 5x, both from
+// scripts/create-article.mjs's expandShortItalianContent last-resort path,
+// which had no repetition check of any kind before this fix.
+
+const BODY_FIELDS = ['body1', 'body2', 'body3'];
+
+/** Detect exact-duplicate paragraphs, or sentences repeated 4+ times (even across otherwise-distinct paragraphs), across body1-3. */
+export function detectBodyRepetition(bodies) {
+  const allBodies = BODY_FIELDS.map((k) => bodies?.[k] || '');
+
+  // 1. Repeated paragraphs within a single body field.
+  for (const [idx, body] of allBodies.entries()) {
+    const paragraphs = body.split(/\n\n+/).map((p) => p.trim()).filter((p) => p.length > 60);
+    const seen = new Map();
+    let dupeCount = 0;
+    for (const p of paragraphs) {
+      const normalized = p.replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
+      seen.set(normalized, (seen.get(normalized) || 0) + 1);
+      if (seen.get(normalized) > 1) dupeCount++;
+    }
+    if (dupeCount >= 3) {
+      return { hasRepetition: true, reason: `body${idx + 1} ha ${dupeCount} paragrafi ripetuti` };
+    }
+  }
+
+  // 2. Sentences repeated 4+ times across all bodies — catches a repeated
+  // sentence embedded inside otherwise-distinct paragraphs, which branch 1
+  // (whole-paragraph comparison) cannot see.
+  const allText = allBodies.join('\n\n');
+  const sentences = allText.split(/[.!?]\s+/).map((s) => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter((s) => s.length > 40);
+  const sentCounts = new Map();
+  for (const s of sentences) sentCounts.set(s, (sentCounts.get(s) || 0) + 1);
+  const heavyRepeats = [...sentCounts.entries()].filter(([, c]) => c >= 4);
+  if (heavyRepeats.length > 0) {
+    return {
+      hasRepetition: true,
+      reason: `${heavyRepeats.length} frasi ripetute 4+ volte: "${heavyRepeats[0][0].substring(0, 60)}..." (${heavyRepeats[0][1]}x)`,
+    };
+  }
+
+  return { hasRepetition: false, reason: '' };
+}
+
+/**
+ * Strip repeated content from body1-3: exact-duplicate whole paragraphs
+ * first, then sentences repeated 3+ times globally (kept only on their
+ * first occurrence across the whole document) — covers both branches of
+ * detectBodyRepetition, unlike a paragraph-only pass. Mutates `bodies` in
+ * place AND returns it, so callers can either rely on the mutation or use
+ * the return value functionally (pass a shallow copy to avoid mutating the
+ * original, as scripts/repair-repetitive-articles.mjs does).
+ */
+export function dedupeRepeatedParagraphs(bodies) {
+  // Cross-body sentence frequency, computed BEFORE any field is mutated so
+  // counts reflect the original content across all three fields.
+  const globalSentCounts = new Map();
+  for (const field of BODY_FIELDS) {
+    const text = bodies?.[field] || '';
+    const sentences = text.split(/(?<=[.!?])\s+/).map((s) => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter((s) => s.length > 30);
+    for (const s of sentences) globalSentCounts.set(s, (globalSentCounts.get(s) || 0) + 1);
+  }
+
+  const globalSeen = new Map(); // cross-body: track how many times each heavily-repeated sentence has been kept so far
+
+  for (const field of BODY_FIELDS) {
+    if (!bodies?.[field]) continue;
+
+    // Step 1: deduplicate whole paragraphs (exact match after normalization).
+    const paragraphs = bodies[field].split(/\n\n+/);
+    const seenParas = new Set();
+    const uniqueParas = [];
+    for (const p of paragraphs) {
+      const norm = p.trim().replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
+      if (norm.length < 60 || !seenParas.has(norm)) {
+        seenParas.add(norm);
+        uniqueParas.push(p);
+      }
+    }
+
+    // Step 2: within each surviving paragraph, strip sentences repeated 3+
+    // times globally down to a single occurrence across the whole document.
+    const cleaned = uniqueParas
+      .map((para) => {
+        const sentences = para.split(/(?<=[.!?])\s+/);
+        if (sentences.length < 2) return para;
+        const filtered = sentences.filter((s) => {
+          const norm = s.trim().toLowerCase().replace(/\s+/g, ' ');
+          if (norm.length <= 30) return true;
+          const globalCount = globalSentCounts.get(norm) || 1;
+          if (globalCount < 3) return true;
+          const soFar = (globalSeen.get(norm) || 0) + 1;
+          globalSeen.set(norm, soFar);
+          return soFar <= 1;
+        });
+        return filtered.join(' ');
+      })
+      .filter((p) => p.trim().length > 10);
+
+    bodies[field] = cleaned.join('\n\n');
+  }
+
+  return bodies;
+}
+
+/** Strip the article title when echoed as the opening line of 2+ body fields. Mutates itContent. */
+export function stripDuplicateTitleFromBody(itContent) {
+  const titleCheck = String(itContent?.title || '').trim();
+  if (!titleCheck) return;
+  const allBodies = BODY_FIELDS.map((k) => itContent?.[k] || '');
+  let titleInBodyCount = 0;
+  for (const body of allBodies) {
+    const firstLine = body.split('\n')[0].trim();
+    if (firstLine === titleCheck || firstLine.startsWith(titleCheck)) titleInBodyCount++;
+  }
+  if (titleInBodyCount < 2) return;
+  for (const field of BODY_FIELDS) {
+    if (!itContent?.[field]) continue;
+    const lines = itContent[field].split('\n');
+    if (lines[0].trim() === titleCheck || lines[0].trim().startsWith(titleCheck)) {
+      lines.shift();
+      while (lines.length > 0 && lines[0].trim() === '') lines.shift();
+      itContent[field] = lines.join('\n');
+      console.error(`  🧹 Rimosso titolo duplicato da it.${field}`);
+    }
+  }
+}

--- a/scripts/repair-repetitive-articles.mjs
+++ b/scripts/repair-repetitive-articles.mjs
@@ -12,6 +12,7 @@
 
 import { readFileSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { detectBodyRepetition, dedupeRepeatedParagraphs } from './lib/article-body-repetition.mjs';
 
 const LOCALES = ['it', 'en', 'de', 'fr'];
 const BODY_DIR = 'services/locales/blog-body';
@@ -34,83 +35,15 @@ function escapeForTS(s) {
   return String(s || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n').replace(/\r/g, '');
 }
 
+// Thin adapters over the shared detection/cleanup module (2026-07-21): this
+// script used to carry its own copy of both, which had already drifted
+// ahead of scripts/create-article.mjs's copy (this one already had the
+// cross-paragraph sentence-strip that create-article.mjs's was missing —
+// see article-body-repetition.mjs's doc comment for the incident that
+// surfaced the gap). Single source of truth now.
 function detectRepetition(bodies) {
-  const issues = [];
-  const allBodies = ['body1', 'body2', 'body3'].map(k => bodies[k] || '');
-
-  // Check repeated paragraphs
-  for (const [idx, body] of allBodies.entries()) {
-    const paragraphs = body.split(/\n\n+/).map(p => p.trim()).filter(p => p.length > 60);
-    const seen = new Map();
-    let dupeCount = 0;
-    for (const p of paragraphs) {
-      const norm = p.replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-      seen.set(norm, (seen.get(norm) || 0) + 1);
-      if (seen.get(norm) > 1) dupeCount++;
-    }
-    if (dupeCount >= 3) issues.push(`body${idx + 1}: ${dupeCount} repeated paragraphs`);
-  }
-
-  // Check repeated sentences
-  const allText = allBodies.join('\n\n');
-  const sentences = allText.split(/[.!?]\s+/).map(s => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter(s => s.length > 40);
-  const sentCounts = new Map();
-  for (const s of sentences) sentCounts.set(s, (sentCounts.get(s) || 0) + 1);
-  const heavy = [...sentCounts.entries()].filter(([, c]) => c >= 4);
-  if (heavy.length > 0) issues.push(`${heavy.length} sentences 4+ times (worst: ${heavy[0][1]}x)`);
-
-  return issues;
-}
-
-function deduplicateBodies(bodies) {
-  // First pass: cross-body sentence frequency
-  const globalSentCounts = new Map();
-  for (const field of ['body1', 'body2', 'body3']) {
-    const text = bodies[field] || '';
-    const sentences = text.split(/(?<=[.!?])\s+/).map(s => s.trim().toLowerCase().replace(/\s+/g, ' ')).filter(s => s.length > 30);
-    for (const s of sentences) globalSentCounts.set(s, (globalSentCounts.get(s) || 0) + 1);
-  }
-  
-  const result = {};
-  const globalSeen = new Map(); // track cross-body sentence usage
-  
-  for (const field of ['body1', 'body2', 'body3']) {
-    const text = bodies[field] || '';
-    if (!text) continue;
-    
-    // Step 1: Deduplicate whole paragraphs
-    const paragraphs = text.split(/\n\n+/);
-    const seenParas = new Set();
-    const unique = [];
-    for (const p of paragraphs) {
-      const norm = p.trim().replace(/[.!?,;:\s]+$/g, '').toLowerCase().replace(/\s+/g, ' ');
-      if (norm.length < 60 || !seenParas.has(norm)) {
-        seenParas.add(norm);
-        unique.push(p);
-      }
-    }
-    
-    // Step 2: Within each paragraph, remove sentences repeated 3+ times globally
-    const cleaned = unique.map(para => {
-      const sentences = para.split(/(?<=[.!?])\s+/);
-      if (sentences.length < 2) return para;
-      const filtered = sentences.filter(s => {
-        const norm = s.trim().toLowerCase().replace(/\s+/g, ' ');
-        if (norm.length <= 30) return true;
-        const globalCount = globalSentCounts.get(norm) || 1;
-        if (globalCount < 3) return true;
-        // Allow max 1 occurrence of heavily repeated sentences across all bodies
-        const soFar = (globalSeen.get(norm) || 0) + 1;
-        globalSeen.set(norm, soFar);
-        return soFar <= 1;
-      });
-      return filtered.join(' ');
-    }).filter(p => p.trim().length > 10);
-    
-    result[field] = cleaned.join('\n\n');
-  }
-  
-  return result;
+  const { hasRepetition, reason } = detectBodyRepetition(bodies);
+  return hasRepetition ? [reason] : [];
 }
 
 // Main
@@ -141,7 +74,9 @@ for (const file of files) {
     } catch { continue; }
 
     const localeBodies = extractBodies(content, id);
-    const dedupedBodies = deduplicateBodies(localeBodies);
+    // Pass a shallow copy — dedupeRepeatedParagraphs mutates its argument,
+    // and localeBodies is compared against the result below per field.
+    const dedupedBodies = dedupeRepeatedParagraphs({ ...localeBodies });
     let changed = false;
 
     for (const field of ['body1', 'body2', 'body3']) {


### PR DESCRIPTION
## Contesto

Follow-up diretto di PR #4633 (fix pool news esaurita). Quel fix ha portato la sezione news da ~0 a decine di articoli/giorno — e ha immediatamente esposto un bug preesistente e mai visto prima perché il path news raramente veniva eseguito: i primi 2 articoli news pubblicati live (`swatch-crescita-2026`, `novartis-superaspettative`) contenevano paragrafi ripetuti letteralmente 5 volte, una frase ripetuta ~26 volte, e cifre/date/leggi svizzere inventate (es. "legge sul lavoro (LTF) del 7 giugno 2005" — LTF è in realtà la sigla della Legge sul Tribunale Federale, non ha nulla a che fare col lavoro; anno sbagliato 2023 invece di 2026; sede Swatch attribuita al Canton Vaud invece di Berna).

## Causa

Il codice ha GIÀ un controllo anti-ripetizione (paragrafi duplicati ≥3 volte, frasi ripetute ≥4 volte → auto-dedup) ma esisteva SOLO nel loop normale di rigenerazione. Il percorso di ultima istanza `expandShortItalianContent` — invocato quando la fonte è troppo povera per raggiungere la soglia minima di parole tramite rigenerazione normale — non rieseguiva mai questo controllo.

## Implementato

- Estratte 3 funzioni condivise (`detectBodyRepetition`, `dedupeRepeatedParagraphs`, `stripDuplicateTitleFromBody`), riapplicate anche dopo `expandShortItalianContent` — colma il gap che ha lasciato passare i 2 articoli live col bug
- **Round 1 review (🔴 Important, corretto)**: la prima versione di `dedupeRepeatedParagraphs` puliva SOLO paragrafi interi duplicati — no-op silenzioso sul ramo "frasi ripetute cross-paragrafo" di `detectBodyRepetition` (esattamente il pattern "frase ripetuta ~26 volte" dell'incidente). `scripts/repair-repetitive-articles.mjs` aveva GIÀ la logica corretta per la pulizia retroattiva — le due copie erano in drift. Estratta in `scripts/lib/article-body-repetition.mjs`, condivisa ora da entrambi gli script.
- **Round 2 review in background (2 bug reali, corretti)**:
  1. *Under-stripping*: paragrafi mono-frase saltavano il filtro con un `return` anticipato, senza registrarsi in `globalSeen` — una frase ripetuta che capitava come paragrafo a sé (es. riga callout) sopravviveva 2 volte invece di 1. Fix: rimossa la scorciatoia, tutti i paragrafi passano dallo stesso filtro.
  2. *Over-stripping*: soglia di pulizia frasi (≥3) più permissiva della soglia di rilevamento (≥4) — dedup scattato per QUALSIASI motivo poteva cancellare contenuto legittimo ripetuto solo 3 volte che da solo non avrebbe mai fatto scattare nulla. Allineata la soglia di pulizia a ≥4 (stessa barra della rilevazione).
- Nessun cambiamento di comportamento nel loop normale di rigenerazione (stessa logica, solo estratta/condivisa/corretta)

## Risposta ai 3 ❓ del round 1

- **`startsWith(titleCheck)` falso-positivo su titoli brevi**: comportamento pre-esistente, non introdotto da questa PR.
- **Forma dati `data.content.it` vs `data.content` dopo `expandShortItalianContent`**: verificato corretto — early-return su dato invariato se `.it` assente, il mio fallback lo gestisce correttamente, stesso pattern già usato altrove nel file.
- **Ripetizione parafrasata sfuggirebbe al match esatto**: confermato, rischio residuo reale fuori scope (richiederebbe similarity semantica, non match testuale).

## Non implementato (ancora)

- **Fix del prompt di espansione** (chiede esplicitamente "numeri reali"/"normative con date e importi" anche su fonte povera, incentivando la fabbricazione): cambio di prompt engineering più ampio, da valutare con più dati reali. **Next step**: monitorare i prossimi articoli da fonti brevi; se la fabbricazione di dettagli non ripetuti resta un problema, follow-up dedicato.
- **I 2 articoli già live col bug** (`swatch-crescita-2026`, `novartis-superaspettative`): non corretti/rimossi qui — decisione dell'owner, segnalato separatamente in chat. `repair-repetitive-articles.mjs` non li rileva (scansiona solo `blog-body/`, non `blog-body-ch/` dove vivono questi due) — gap separato non affrontato qui.

## Sibling-pattern check (AGENTS.md #6)

L'unico sibling REALE (`scripts/repair-repetitive-articles.mjs`) è stato unificato nello stesso modulo condiviso, non scartato come falso positivo. Altri candidati (`const seen = new Map()`, `firstLine`, `itContent` in parser di job-listing/submit-indexnow/journalistTypes) sono nomi di variabili generici in domini scollegati — falsi positivi verificati singolarmente.

## Test plan

- [x] Sintassi OK su tutti i file toccati
- [x] Test isolato con riproduzione sintetica di TUTTI e 3 gli scenari di bug trovati dalle 2 review (whole-paragraph repeat, cross-paragraph sentence repeat, mono-frase standalone, over-stripping di contenuto legittimo 3x) — tutti confermati corretti
- [x] `npm run test:articles` (stesso set gate CI) — tutto verde su ogni round
- [x] `node scripts/repair-repetitive-articles.mjs` (dry-run) gira end-to-end su 2938 articoli con la logica condivisa aggiornata, nessun errore
- [ ] Verifica live: il prossimo articolo news da fonte breve non dovrebbe più mostrare ripetizioni nello step summary/log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
