### PR TITLE
fix(newsletter-ai): stop claude-cli/haiku timeout storm from eating CI wall clock

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -678,6 +678,22 @@ const CLAUDE_CLI_BIN = (process.env.CLAUDE_CLI_BIN || 'claude').trim();
 // callLLM's fallback loop). Process-local, never persisted — see that comment
 // for why this isn't routed through markModelExhausted.
 let _claudeCliBinaryMissing = false;
+// Same process-local, never-persisted pattern as _claudeCliBinaryMissing, but
+// for a timeout storm instead of a missing binary (run 29824354962: 159/162
+// claude-cli/haiku calls hit the hard 60s timeout — CI-runner CPU contention
+// from N parallel `claude` subprocesses each cold-loading this repo's full
+// CLAUDE.md/AGENTS.md + SessionStart hook, ~30min of the run burned on calls
+// that were never going to finish in time). claude-cli/haiku is exempt from
+// the normal markModelExhausted timeout circuit breaker (_isLastResortProvider,
+// see the comment above that function) because for most callers a single
+// timeout is a transient blip worth retrying next call. But once several
+// timeouts land back-to-back within one run, that's not a blip — it's the
+// subprocess itself unable to finish in time — and every further attempt is
+// a guaranteed 60s loss for a fallback that already has a template result
+// ready. Trip after CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD consecutive timeouts.
+let _claudeCliConsecutiveTimeouts = 0;
+let _claudeCliTimeoutStormDetected = false;
+const CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD = 8;
 
 // ── API keys (lazy-loaded from environment) ──────────────────
 function getGhModelsPat()       { return (process.env.GH_MODELS_PAT || '').trim(); }
@@ -827,7 +843,7 @@ function getApiKeyForProvider(provider) {
     // No real key — auth is the CLAUDE_CODE_OAUTH_TOKEN env var, read directly
     // by the `claude` CLI subprocess. Gate on RC flag + token presence so the
     // chain only offers this model when both are actually usable. Mirrors Local.
-    case PROVIDER.CLAUDE_CLI:  return (!_claudeCliBinaryMissing && isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
+    case PROVIDER.CLAUDE_CLI:  return (!_claudeCliBinaryMissing && !_claudeCliTimeoutStormDetected && isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
     default: return '';
   }
 }
@@ -2130,6 +2146,8 @@ export function resetState() {
   _stats.errors = [];
   _responseCache.clear();
   _claudeCliBinaryMissing = false;
+  _claudeCliConsecutiveTimeouts = 0;
+  _claudeCliTimeoutStormDetected = false;
 }
 
 /** Remove a specific model from the exhausted set so it can be retried */
@@ -3176,6 +3194,16 @@ async function _callLocal(model, messages, opts) {
  * CI env (`env: process.env` below, incl. secrets) — `--tools ""` is the
  * flag that actually matters for keeping this a plain one-shot completion
  * with no agentic/tool-call capability, regardless of permission mode.
+ * `--safe-mode` disables this repo's own CLAUDE.md/AGENTS.md auto-discovery,
+ * hooks (incl. the SessionStart worktree-prune script) and MCP servers
+ * (GitNexus) for this subprocess — unlike `--bare` it keeps OAuth auth
+ * working. Confirmed live (2026-07-22): without it, a one-shot completion
+ * cold-loads ~34K tokens of project system prompt per call (vs ~600-6.7K
+ * with `--safe-mode`, most of it dedupable across concurrent calls via
+ * prompt caching) and forks the SessionStart hook every invocation; run
+ * 29824354962 hit 159/162 hard 60s timeouts under AI_CONCURRENCY=5 on a
+ * resource-constrained CI runner, burning roughly half the run's wall clock
+ * on calls that could never finish in time.
  */
 async function _callClaudeCli(model, messages, opts) {
   const apiModel = getApiModelId(model); // e.g. 'haiku' — CLI resolves the alias to its current model
@@ -3188,6 +3216,7 @@ async function _callClaudeCli(model, messages, opts) {
     '--output-format', 'json',
     '--tools', '',
     '--permission-mode', 'bypassPermissions',
+    '--safe-mode',
   ];
   if (systemPrompt) args.push('--system-prompt', systemPrompt);
   if (opts.jsonSchema) args.push('--json-schema', JSON.stringify(opts.jsonSchema.schema || opts.jsonSchema));
@@ -3652,6 +3681,7 @@ export async function callLLM(messages, opts = {}) {
       // ✅ Success — boost this model's score so it stays near the top
       recordModelSuccess(model);
       _consecutive429.delete(model); // FRO-325: reset 429 counter on success
+      if (provider === PROVIDER.CLAUDE_CLI) _claudeCliConsecutiveTimeouts = 0;
 
       if (i > 0) {
         console.warn(`✅ Fallback to ${model} succeeded (score → ${_modelScores.get(model) || 0})`);
@@ -3728,16 +3758,29 @@ export async function callLLM(messages, opts = {}) {
       // intentionally raises the timeout floor for slow CPU inference, so a
       // timeout there is expected load, not a dead provider.
       const isTimeoutFailure = e.name === 'AbortError' || e.name === 'TimeoutError' || /timeout|aborted/i.test(msg);
+      let markedExhausted = false;
       if (isTimeoutFailure && !_isLastResortProvider(model)) {
         markModelExhausted(model, 'timeout');
         _stats.exhausted++;
+        markedExhausted = true;
+      }
+      // claude-cli's own timeout-storm circuit breaker (see
+      // _claudeCliTimeoutStormDetected declaration) — separate from the
+      // markModelExhausted path above, which _isLastResortProvider exempts
+      // claude-cli from.
+      if (isTimeoutFailure && provider === PROVIDER.CLAUDE_CLI) {
+        _claudeCliConsecutiveTimeouts++;
+        if (_claudeCliConsecutiveTimeouts >= CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD) {
+          _claudeCliTimeoutStormDetected = true;
+          console.warn(`🚫 [${model}] ${_claudeCliConsecutiveTimeouts} consecutive timeouts — disabling claude-cli fallback for the rest of this run`);
+        }
       }
       recordModelFailure(model, {
         nonRetryable: !!e.nonRetryable,
         exhausted: isExhausted || isTimeoutFailure,
       });
 
-      console.warn(`❌ [${model}] Failed${isTimeoutFailure ? ' (timeout → exhausted)' : ''} (score → ${_modelScores.get(model) || 0}): ${msg.slice(0, 200)}`);
+      console.warn(`❌ [${model}] Failed${markedExhausted ? ' (timeout → exhausted)' : ''} (score → ${_modelScores.get(model) || 0}): ${msg.slice(0, 200)}`);
       // Continue to next model in chain
     }
   }

--- a/tests/scripts/ai-models-claude-cli-fallback.test.ts
+++ b/tests/scripts/ai-models-claude-cli-fallback.test.ts
@@ -174,4 +174,59 @@ describe('ai-models Claude CLI Haiku fallback', () => {
     await expect(callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain })).rejects.toThrow();
     expect(spawnMock).toHaveBeenCalledTimes(1);
   });
+
+  describe('timeout-storm circuit breaker (independent of markModelExhausted)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('disables claude-cli after repeated consecutive timeouts instead of waiting out the full 60s on every remaining call', async () => {
+      // Regression test for run 29824354962 (send-newsletter, 2026-07-21):
+      // claude-cli/haiku is deliberately exempt from markModelExhausted's
+      // normal timeout circuit breaker (see _isLastResortProvider) because for
+      // most callers a single timeout is a transient blip worth retrying next
+      // call. But under CI-runner CPU contention it hit the hard 60s timeout
+      // 159/162 times back to back, burning roughly half the run's wall clock
+      // on calls that could never finish in time. This is the separate,
+      // in-process-only breaker (_claudeCliTimeoutStormDetected) that caps
+      // that worst case once a systemic timeout streak is unambiguous.
+      process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+
+      spawnMock.mockImplementation(() => ({
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: () => {}, // never fires 'close'/'error' — mirrors a hung subprocess
+        kill: vi.fn(),
+      }));
+
+      const msgs = [{ role: 'user', content: 'Write a briefing' }];
+      const chain = [AI_MODELS.CLAUDE_CLI_HAIKU];
+      const THRESHOLD = 8; // keep in sync with CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD in ai-models.mjs
+
+      for (let i = 0; i < THRESHOLD; i++) {
+        // deadlineMs shrinks _callClaudeCli's 60s floor down to its 15s floor
+        // so the fake-timer advance below doesn't need to simulate a full minute.
+        const deadlineMs = Date.now() + 15_000;
+        const promise = callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain, deadlineMs });
+        const assertion = expect(promise).rejects.toThrow();
+        await vi.advanceTimersByTimeAsync(15_000);
+        await assertion;
+      }
+
+      expect(spawnMock).toHaveBeenCalledTimes(THRESHOLD);
+
+      // Streak reached the threshold — model must now be reported unavailable...
+      expect(getPreferredModel({ chain })).toBeNull();
+
+      // ...and a further call must fail fast with no model available, not
+      // spawn (and wait out) yet another doomed subprocess.
+      await expect(callLLM(msgs, { model: AI_MODELS.CLAUDE_CLI_HAIKU, chain })).rejects.toThrow();
+      expect(spawnMock).toHaveBeenCalledTimes(THRESHOLD);
+    });
+  });
 });


### PR DESCRIPTION
## Implementato

Deep-dive on the claude-cli/haiku usage flagged after PR #4643 (AI-briefing batching): run 29824354962 (the post-batching verification run, 2026-07-21) completed successfully (769 emails, 0 failed) but spent roughly half its 64min wall clock — ~30min — inside the `claude-cli/haiku` last-resort fallback, which hit the hard 60s timeout on 159 of 162 attempts (98%).

**Root cause, confirmed live (2026-07-22):** `_callClaudeCli` in `scripts/lib/ai-models.mjs` spawns the full `claude` CLI for a one-shot completion without `--safe-mode`, so every invocation cold-loads this repo's own `CLAUDE.md`/`AGENTS.md` (~34K system-prompt tokens per call, measured via `duration_ms`/`cache_creation_input_tokens` on a local single-call and a 5-way concurrent test) and forks the `SessionStart` hook (`prune-merged-worktrees.mjs`). Under `AI_CONCURRENCY=5` on a resource-constrained GitHub-hosted runner, this contention pushed most calls past the 60s timeout. Local before/after measurement (5 concurrent calls): without `--safe-mode`, 9.66s wall / 10.43s CPU-user, ~21.7K–30.8K `cache_creation_input_tokens` per call; with `--safe-mode`, 4.52s wall / 3.58s CPU-user, ~596 tokens per call.

- `scripts/lib/ai-models.mjs`:
  - `_callClaudeCli`: add `--safe-mode` to the CLI args. Unlike `--bare` (already rejected in an existing code comment — it requires `ANTHROPIC_API_KEY`/`apiKeyHelper` and ignores OAuth), `--safe-mode` disables CLAUDE.md auto-discovery, hooks, and MCP servers for the subprocess while keeping `CLAUDE_CODE_OAUTH_TOKEN` auth working.
  - New in-process (never persisted) timeout-storm circuit breaker: `claude-cli/haiku` is deliberately exempt from the normal `markModelExhausted` timeout path (`_isLastResortProvider`) because for most callers (crawlers, translation, FAQ generation — 20+ call sites per `gitnexus_impact`) a single timeout is a transient blip worth retrying next call. But 159 consecutive failures in one run is not a blip — it's the subprocess systemically unable to finish in time, and every further attempt is a guaranteed 60s loss for a fallback that already has a template result ready. After `CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD` (8) consecutive timeouts, `_claudeCliTimeoutStormDetected` disables the model for the rest of the process only — same never-persisted pattern already used for the ENOENT missing-binary case, same gating point (`getApiKeyForProvider`'s `PROVIDER.CLAUDE_CLI` case).
  - Fixed a pre-existing log-accuracy bug found while reading this code path: the failure log always appended `(timeout → exhausted)` whenever a timeout occurred, even for claude-cli where `markModelExhausted` is never actually called (that's what caused my own initial mis-read of the incident log). Now only appended when the model was actually marked exhausted.
- `tests/scripts/ai-models-claude-cli-fallback.test.ts`: new `describe('timeout-storm circuit breaker …')` — fake-timer-driven regression test that drives `CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD` consecutive timeouts and asserts the model becomes unavailable and a further call fails fast without spawning (mirrors the existing ENOENT test's shape).

Evidence (run 29824354962, job 88614146858 logs):
```
claude-cli/haiku: 162 attempts, 159 timed out (60000ms each), 3 succeeded
Timeout window: 11:14:41–11:50:56 UTC (~36min) inside a 64min total run
```

- [x] `npx vitest run tests/scripts/ai-models-claude-cli-fallback.test.ts` — 9/9 pass, incl. new timeout-storm test (fake timers, 49ms wall clock, no real 60s waits)
- [x] `npx vitest run tests/scripts/ai-models*.test.ts tests/local-llm-fallback.test.ts` — 124/124 pass (no regression in ENOENT/quota/429/content-failure circuit breakers)
- [x] `node --check scripts/lib/ai-models.mjs` — syntax OK
- [x] `mcp__gitnexus__impact` upstream on `_callClaudeCli` — HIGH risk (breadth: 24 dependents across newsletter, crawlers, translation, FAQ) but the diff itself is additive/backward-compatible: a new CLI flag + a counter gated strictly on `provider === PROVIDER.CLAUDE_CLI`, no change to any other provider's code path or to `_callClaudeCli`'s signature/return contract
- [ ] Verify end-to-end on a real run — not executable pre-merge (`send-newsletter.mjs --send` never run locally per repo convention); next scheduled cron run (03:33 UTC) or a manual `workflow_dispatch` post-merge is the verification point, see below

## Non implementato (ancora)

- **Verifica end-to-end su una run reale**: in questa PR non eseguibile (full local SEO/newsletter send vietato). Next step: dopo il merge, osservare la prossima run cron (03:33 UTC) o lanciare manualmente `gh workflow run send-newsletter.yml`; controllare che claude-cli/haiku non colleziani più 100+ timeout consecutivi e che la durata totale torni vicina ai 45min della run sana pre-incidente (29722019907). Se la storm persiste nonostante `--safe-mode`, il circuit breaker da solo limita comunque il danno a max `CLAUDE_CLI_TIMEOUT_STORM_THRESHOLD` (8) × 60s ≈ 8min invece di 30+.
- **Revert-risk esplicito**: se la prossima run mostra ancora una timeout-storm sistemica su claude-cli/haiku (>50% fail rate) nonostante `--safe-mode`, o se `--safe-mode` introduce una regressione osservabile nella qualità/formato delle risposte briefing (es. perdita di contesto che il CLAUDE.md forniva involontariamente), rollback diretto di questa PR (diff isolato, 2 file) invece di iterare in-place.

Gate `check-sibling-patterns.mjs --strict` (pre-push hook) ha segnalato 5 file che condividono token con questo diff — ispezionati singolarmente, tutti falsi positivi (nessuno implementa una seconda copia della spawn/args logic o del timeout-circuit-breaker che questa PR tocca):

- `.github/workflows/generate-article.yml` — falso positivo: menziona `CLAUDE_CLI`/`hasClaudeCodeOauthToken`/`isClaudeCliFallbackEnabled` solo in commenti che spiegano il setup step (installa il binario CLI + seta il flag RC); non costruisce args di spawn né logica di timeout — usa `_callClaudeCli` via `callLLM` come ogni altro caller, quindi eredita il fix automaticamente.
- `scripts/load-rc-env.mjs` — falso positivo: menziona `CLAUDE_CLI` solo in un commento che spiega il flag RC `ENABLE_HAIKU_ARTICLE_FALLBACK`; nessuna logica di spawn/timeout duplicata.
- `scripts/send-newsletter.mjs` — falso positivo: `AI_CONCURRENCY` è la sua costante di concorrenza `pMap` locale (non correlata alla logica interna di `_callClaudeCli`), `CLAUDE_CLI` è solo il riferimento a `AI_MODELS.CLAUDE_CLI_HAIKU` nella chain — è il chiamante, non una seconda implementazione; eredita il fix via `callLLM`.
- `.github/workflows/send-newsletter.yml` — falso positivo: stesso pattern di `generate-article.yml`, riferimenti in commenti al setup step, nessuna logica duplicata.
- `scripts/lib/tl-lausanne-job-parser.mjs` — falso positivo: il match è la stringa "GitNexus" in un commento di impact-analysis pre-esistente, semanticamente scorrelato dal costrutto claude-cli/timeout toccato in questa PR.
- `scripts/set-haiku-fallback-rc.mjs` — falso positivo: menziona `isClaudeCliFallbackEnabled()` solo in un commento di riferimento al flag che il proprio script setta; non tocca `_callClaudeCli`/spawn/timeout.

Non chiude nessuna issue (nessuna issue aperta referenziata — nasce da diagnosi conversazionale del log della run 29824354962 dopo la verifica di PR #4643).