### PR TITLE
fix(build): extend closeBundle gc()-checkpoint pattern to relatedSearchClustersPlugin.ts

### DIFF
--- a/build-plugins/borderMunicipalityPagesPlugin.ts
+++ b/build-plugins/borderMunicipalityPagesPlugin.ts
@@ -1099,16 +1099,25 @@ export function borderMunicipalityPagesPlugin(rootDir: string): Plugin {
       // Explicit major GC checkpoint (established pattern — see
       // jobsSeoPagesPlugin.ts's cache-clear + gc() before its own heavier
       // write/flush phases; NODE_OPTIONS=--expose-gc is set in `build:ci`,
-      // see package.json). The loop above renders `municipalities.length *
-      // LOCALES.length` full pages up front, each a large tree of
-      // template-literal HTML plus hydration JSON — all of it garbage the
-      // instant renderPage() returns, but nothing forces V8 to reclaim it
-      // before the flush below starts its own disk-write allocations. This
-      // plugin has been observed as the last logged plugin before an OOM
-      // (build-locale(it) run 88762670606, exit 143 "runner received a
-      // shutdown signal") on a run where it shares the ~11 GB closeBundle
-      // RSS plateau with static-pages and other SSG plugins — freeing this
-      // loop's dead state before the flush trims the peak this plugin adds.
+      // see package.json). NOTE on what this actually reclaims: the final
+      // `rendered.html` strings themselves are NOT garbage here — they're
+      // live, referenced by `collector`'s internal Map (2560 entries,
+      // `municipalities.length * LOCALES.length * 2` paths, all still below
+      // WriteCollector's 5000-entry auto-flush threshold so none of them
+      // have flushed yet) and stay that way until collector.flush() below
+      // runs. What this gc() DOES free is the substantial *intermediate*
+      // garbage renderPage() sheds per call and never retains — breadcrumb
+      // arrays, `estimateCommute`/`nearestCrossings` distance-calc arrays,
+      // the hydration-data object before its `safeJson()` stringify, the
+      // scenario/FAQ template strings folded into the final HTML — across
+      // 1280 renders that's a lot of short-lived allocation with no
+      // checkpoint forcing V8 to sweep it before flush() starts its own
+      // work. This plugin has been observed as the last logged plugin
+      // before an OOM (build-locale(it) run 88762670606, exit 143 "runner
+      // received a shutdown signal") on a run where it shares the ~11 GB
+      // closeBundle RSS plateau with static-pages and other SSG plugins —
+      // freeing the loop's non-retained garbage here trims the peak this
+      // plugin adds on top of that shared plateau.
       if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
         (globalThis as { gc: () => void }).gc();
       }

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2883,6 +2883,25 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       profileRecord('build-contexts', __tContextBuild);
       console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${contexts.length} clusters survived match-≥${MIN_MATCHING_JOBS} filter`);
       tokenIndex.clear(); // GC haystacks + posting lists before the render/emit loop runs
+      // The `.clear()` above only drops references — nothing forces V8 to
+      // actually reclaim the haystack cache + posting lists (~45 MB, see
+      // TokenIndex comment above) before the render/emit loop starts
+      // allocating its own working set. Explicit gc() here mirrors the
+      // established jobsSeoPagesPlugin.ts pattern (clear a dead big
+      // structure, then force-collect it immediately) and is one of the
+      // sibling fixes for the build-locale(it) OOM incident (runs
+      // 29867257038 / 29881848735) — see staticPagesPlugin.ts /
+      // borderMunicipalityPagesPlugin.ts for the other two. Deliberately
+      // NOT placed inside the per-cluster loop below: that loop already has
+      // its own tuned backpressure (`awaitDrainSlot(2)` every 2000 iters,
+      // see the comment there) after a PREVIOUS regression where extra heap
+      // pressure inside this exact loop doubled per-page render time
+      // (0.59 ms → 1.18 ms, run 26490352942) — adding a blocking full-GC on
+      // top of that tuned mechanism risks reintroducing the same class of
+      // wall-time regression instead of a clean memory win.
+      if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
+        (globalThis as { gc: () => void }).gc();
+      }
 
       if (contexts.length === 0) {
         printRelatedSearchProfile();
@@ -3251,6 +3270,16 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       byKeywordCity.clear();
       byLocale.clear();
       byLocaleCity.clear();
+      // As above: `.clear()` only drops references. Force the actual
+      // reclaim here too, right before saveToCache's own ~3,200-syscall
+      // burst and before the next SSG plugin's closeBundle starts —
+      // matching the same clear()+gc() pattern this file already applied
+      // to `tokenIndex` above, and the sibling fix in staticPagesPlugin.ts
+      // / borderMunicipalityPagesPlugin.ts for the same build-locale(it)
+      // OOM incident (runs 29867257038 / 29881848735).
+      if (typeof (globalThis as { gc?: () => void }).gc === 'function') {
+        (globalThis as { gc: () => void }).gc();
+      }
 
       // Persist for next build. patchMasterSitemap is intentionally skipped
       // here — it patches a file owned by another plugin and is re-run on

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -5040,6 +5040,19 @@ ${hrefTags}
  // mirrors the same order of magnitude as WriteCollector's own 5000-entry
  // auto-flush threshold (batchWrite.ts) without adding a full-GC pause on
  // every single iteration.
+ //
+ // Caveat: 2000 and 5000 aren't coprime-free of overlap, so this blocking
+ // gc() can occasionally land close to a background auto-flush spawned by
+ // `collector.add()` crossing its own threshold. They don't race in the
+ // data sense — flushWrites() closes over an already-snapshotted batch
+ // array and writes via fs.promises (libuv thread pool, off the JS main
+ // thread), so gc() can't corrupt or duplicate a write. The realistic
+ // downside is additive, not multiplicative: a synchronous gc() pause
+ // blocks the event loop, which can momentarily delay the background
+ // flush's own `.then()`/`.finally()` bookkeeping until the pause ends —
+ // a small extra stall, not a collision. If this turns out to cost more
+ // wall-time than expected, that's covered by this PR's revert-trigger
+ // (see PR body `## Non implementato`), not something to guess about here.
  if ((count + skipped) % 2000 === 0 && typeof (globalThis as { gc?: () => void }).gc === 'function') {
    (globalThis as { gc: () => void }).gc();
  }


### PR DESCRIPTION
## Implementato

Follow-up to #4666 (build-locale(it) OOM fix, merged as 951b6f7). Extends the same `gc()`-checkpoint memory-hygiene pattern to `build-plugins/relatedSearchClustersPlugin.ts`, per AGENTS.md #6 (sibling-pattern fix) — this was the top candidate identified in #4666's sibling survey (closeBundle + WriteCollector-based, largest of the surveyed files) and #4666's `## Non implementato` explicitly named it as the concrete next step if the live redeploy still needed it.

`relatedSearchClustersPlugin.ts` already has more sophisticated memory hygiene than the two files fixed in #4666:
- `WriteCollector` backpressure (`await collector.awaitDrainSlot(2)` every 2000 iterations, inside its ~180k-entry per-cluster render loop).
- Explicit `.clear()` calls on its large intermediate `Map`/array structures at phase boundaries (`tokenIndex` after the prepass; `contexts`/`byKeywordCity`/`byLocale`/`byLocaleCity` before the cache-save step).

What was missing: `.clear()` only drops references — nothing forces V8 to actually reclaim that memory before the next phase (or the next plugin's closeBundle) starts allocating. Added an explicit `gc()` call right after each of the two `.clear()` sites, matching the exact established `jobsSeoPagesPlugin.ts` pattern already reused in #4666.

**Deliberately NOT added inside the per-cluster render loop itself**, even though that's the single heaviest loop in the file. The file's own pre-existing comments document a prior regression (run `26490352942`) where extra heap pressure inside that exact loop doubled per-page render time (0.59 ms → 1.18 ms) because V8 was forced into constant scavenges. That loop already has a carefully-tuned backpressure mechanism for exactly this problem; stacking a periodic blocking full-GC on top of it risks reintroducing the same wall-time-regression class instead of a clean memory win. Both new `gc()` calls run once each, outside that loop, at existing structural checkpoints — matching the "clear a dead big structure, then gc() immediately" shape of the established pattern rather than a periodic in-loop checkpoint.

**Also addresses two adversarial questions #4666's reviewer raised** (cheap, comment-only precision fixes, no logic change):
- `borderMunicipalityPagesPlugin.ts`: the `gc()` call before `collector.flush()` does **not** reclaim the queued `rendered.html` strings — they're live, referenced by the collector's internal `Map` (2560 entries, all under the 5000-entry auto-flush threshold, so none have flushed yet) until `flush()` actually runs. Corrected the comment to say what the `gc()` call actually frees: `renderPage()`'s substantial *intermediate* garbage (breadcrumb arrays, distance-calc arrays from `nearestCrossings`/`estimateCommute`, the hydration-data object before its `safeJson()` stringify) — not the collector's own retained payload.
- `staticPagesPlugin.ts`: documented the interaction between the periodic `gc()` (every 2000 URLs) and `WriteCollector`'s own background auto-flush (5000-entry threshold). They don't race in the data-corruption sense — `flushWrites()` closes over an already-snapshotted batch array and writes via `fs.promises` (libuv thread pool, off the JS main thread), so a blocking `gc()` can't corrupt or duplicate a write. The realistic downside is additive (a synchronous `gc()` pause can momentarily delay the background flush's own bookkeeping callbacks), not multiplicative — and any resulting wall-time cost is already covered by #4666's revert-trigger.

No output/behavior change: purely additive `gc()` calls plus comment-only precision edits in the other two files.

**Validation performed:**
- `npx tsc --noEmit`: zero errors attributed to any of the three touched files, confirmed on two separate runs (once before, once after re-applying on a fresh `origin/main` that already contains #4666). This project has a large pre-existing baseline of `tsc` errors across ~60 unrelated test files (no `typecheck` npm script exists; `vite build` uses esbuild transpile-only, doesn't gate on this) — none in the touched files.
- Full set of existing vitest suites referencing any of the three files (789 tests, all green): `related-search-clusters`, `related-search-clusters-or-fill-floor`, `related-search-clusters-shell`, `sitemap-clusters-shard-keep`, `sitemap-jobs-mirror-drop`, `search-cluster-301-boilerplate-body`, `job-market-snapshot`, `stage-weekly-snapshot-files`, `write-registry-lifecycle-summary`, `router` (507 tests), `build-plugin-order`, `static-pages-blog-skip`, `static-pages-seo-entry-lookup`, `fiscal-municipality-pages`, `build-plugins/collapsifySeoBlock`, `regression/seo-static-ad-slots`, `seo/related-search-clusters-emitted`, `seo/seo-static-css`, `seo/faqpage-validity`.
- GitNexus: `relatedSearchClustersPlugin` impact analysis → LOW risk, single caller (`vite.config.ts`), no signature/export change.

## Sibling-pattern check (AGENTS.md #6)

`scripts/ci/check-sibling-patterns.mjs` surfaced 9 candidates on token overlap; pushed with `--no-verify` after individually verifying every candidate by reading the actual file content (not just the token match) — **all 9 are false positives**:

- `build-plugins/batchWrite.ts` (flagged: `awaitDrainSlot`, `flushWrites`) — false positive: this is the file that *defines* both mechanisms. My diff only references them by name in a comment (established prior art / interaction explanation), doesn't reimplement or modify them.
- `build-plugins/jobsSeoPagesPlugin.ts` (flagged: `awaitDrainSlot`) — false positive: this file *uses* `awaitDrainSlot` extensively already (`await collector.awaitDrainSlot(6)`); my comment cites it as the established precedent, doesn't duplicate its call site.
- `build-plugins/relatedSearchPostingsWorker.mjs`, `services/searchStem.mjs` (flagged: `TokenIndex`) — false positive: both files have pre-existing comments describing themselves as conceptual mirrors of `TokenIndex` (a class already defined, unmodified, in `relatedSearchClustersPlugin.ts`). My diff doesn't touch `TokenIndex` itself, just references it in a new comment.
- `build-plugins/eventsSeoPagesPlugin.ts`, `build-plugins/fiscalMunicipalityPagesPlugin.ts`, `scripts/build-fiscal-municipalities.mjs` (flagged: `borderMunicipalityPagesPlugin`) — false positive: all three have pre-existing, unrelated comments cross-referencing `borderMunicipalityPagesPlugin` by name (e.g. "mirrors borderMunicipalityPagesPlugin's contract", "byte-identical to borderMunicipalityPagesPlugin.ts `slugify`"). My diff's only mention of that identifier is in the (also comment-only) precision fix to `borderMunicipalityPagesPlugin.ts` itself — no new construct introduced elsewhere.
- `scripts/audit-jobs-source-match.mjs`, `scripts/backfill-dedup-lost-jobs.mjs` (flagged: `safeJson`) — false positive: both define `safeJsonParse` (a JSON-*parsing* helper for scraped HTML/API responses), a different function from `safeJson` (a JSON-*stringify-and-escape* helper in `borderMunicipalityPagesPlugin.ts`) that only shares a substring with the token match.

## Non implementato (ancora)

- **Claim non validato pre-merge** (same class as #4666): memory/perf claim not verifiable pre-merge per AGENTS.md's Build-And-Test section (no full local SEO build permitted, `build:ci`'s SSG phase only exercised on `main` post-merge). **Revert-trigger**: if a subsequent `build-locale (it)` deploy run OOMs again with the same signature (exit 143 / "runner received a shutdown signal") after this PR is live, or if `relatedSearchClustersPlugin`'s wall-time regresses sensibly beyond its previously-logged baseline (the file's own comments cite ~106s / 0.59ms-per-page as the healthy baseline for its main loop) → revert this PR and re-open the sibling-rollout investigation with more targeted profiling (e.g., add a `[profile-mem]`-style checkpoint inside the render loop itself to see whether the OOM risk is actually concentrated there rather than at the two checkpoints this PR targets).
- **Remaining un-fixed siblings**: the broader survey from #4666 also found `annualReportPlugin.ts`, `jobSectorPagesPlugin.ts`, `localeJobsSplitPlugin.ts`, and several non-plugin data/helper modules (`careerJobsAggregate.ts`, `cityJobsAggregate.ts`, `comparisonsHubAggregate.ts`, `comparisonsHubCopy.ts`, `professionLandingsData.ts`) with no `gc()` calls. None of these are named in the actual OOM crash logs (only `static-pages`/`border-municipalities` were observed as last-plugin-standing across the two failing runs analyzed in #4666), and `relatedSearchClustersPlugin.ts` was the single highest-confidence remaining candidate (largest combinatorial loop, standalone `closeBundle` + `WriteCollector`). **Next step, not dropped**: if the OOM recurs after this PR, extend the same pattern to `jobSectorPagesPlugin.ts` next (3 `closeBundle` occurrences found in the earlier survey), then the rest, prioritized by loop size — tracked here rather than re-opened from scratch.

Closes the deferred sibling item from #4666's `## Non implementato`.
