### PR TITLE
fix(jobs): stop slug-collision guard from permanently deleting valid translations

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -48,7 +48,7 @@ import { supersedeCrawledByPublisher } from './lib/publisher-supersede.mjs';
 import { assembleUrlKey } from './lib/job-url-key.mjs';
 import { hardenJobsWithStructuredSalary } from './lib/structured-salary.mjs';
 import { normalizeDescriptionBullets, cleanCrawlerArtifacts } from './lib/crawler-template.mjs';
-import { computeCrawlerQualityAggregate, computeJobQualityScore, buildStableId, cleanPreviousSlugsPerLocale, isLocationExplicitlyForeign, healTruncatedStLocalities, addPreviousSlugForLocale, captureLostSlugs, DEFAULT_PREV_SLUG_CAP } from './lib/dedicated-crawler-common.mjs';
+import { computeCrawlerQualityAggregate, computeJobQualityScore, buildStableId, cleanPreviousSlugsPerLocale, isLocationExplicitlyForeign, healTruncatedStLocalities, addPreviousSlugForLocale, captureLostSlugs, DEFAULT_PREV_SLUG_CAP, stableSlugHash, appendSlugDisambiguator } from './lib/dedicated-crawler-common.mjs';
 import { inferAnyCanton, isKnownSwissCity, isCantonOnlyLabel, findSwissCityInText, rescueSwissCityFromText, isTargetCanton, TARGET_CANTONS } from './lib/target-swiss-locations.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { SWISS_LOCALITY_SENTENCE_SPLIT_RX } from './lib/swiss-locality-sentence-split.mjs';
@@ -285,6 +285,29 @@ export function applyPerLocaleSlugCollisionGuard(jobs) {
       if (!slug || slug === myBaseSlug) continue;
       const owner = baseSlugOwners.get(`${canton}|${slug}`);
       if (!owner || owner === myId) continue;
+
+      // Recurrence guard: this exact slug string was already dropped by this
+      // guard in a prior assemble run (tracked in previousSlugs). Deterministic
+      // MT engines (Argos/CTranslate2) regenerate byte-identical output for the
+      // same source text, so re-flagging needsRetranslation here just
+      // recreates the identical collision on every future run — permanently
+      // destroying an otherwise-correct translation instead of fixing anything
+      // (confirmed incident: Fisiocare Sagl / EOC — Ente Ospedaliero Cantonale
+      // physiotherapist postings stuck needsRetranslation for 12-36 days with
+      // fully correct per-crawler titleByLocale/descriptionByLocale). Once a
+      // collision recurs, the fix isn't a new translation — it's a unique
+      // slug — so disambiguate and stop looping instead of deleting again.
+      const recurring = Array.isArray(job.previousSlugs) && job.previousSlugs.includes(slug);
+      if (recurring) {
+        const disambiguator = stableSlugHash(job) || String(job.id || '').slice(-6) || 'dup';
+        job.slugByLocale[locale] = appendSlugDisambiguator(slug, disambiguator);
+        count++;
+        if (details.length < 10) {
+          details.push(`${canton}/${locale}/${slug}: ${myId} → owned by ${owner} (disambiguated, repeat collision)`);
+        }
+        continue;
+      }
+
       addPreviousSlugForLocale(job, locale, slug, DEFAULT_PREV_SLUG_CAP, 'assemble-jobs-dataset.collision-guard');
       delete job.slugByLocale[locale];
       if (job.titleByLocale && typeof job.titleByLocale === 'object') {

--- a/tests/scripts/assemble-per-locale-slug-collision-guard.test.ts
+++ b/tests/scripts/assemble-per-locale-slug-collision-guard.test.ts
@@ -157,6 +157,52 @@ describe('applyPerLocaleSlugCollisionGuard', () => {
     expect((jobA as any).previousSlugs).toContain('projektmanager-m-w-d-acme-corp-leibstadt');
   });
 
+  it('disambiguates instead of deleting when the exact same slug collided before (recurring collision)', () => {
+    // Regression: a job whose translated EN slug already collided once (this
+    // run's assemble already dropped it and recorded it in previousSlugs) hits
+    // the SAME collision again — because deterministic MT regenerates the
+    // identical string on retry. Confirmed live: Fisiocare Sagl / EOC –
+    // Ente Ospedaliero Cantonale physiotherapist postings stuck
+    // needsRetranslation for 12-36 days despite fully correct per-crawler
+    // translations, because delete+reflag never breaks a deterministic loop.
+    const jobA: JobFixture = {
+      id: 'job-a',
+      url: 'https://employer.example/jobs/a',
+      canton: 'AG',
+      slug: 'ingegnere-di-calcolo-acme-corp-leibstadt',
+      slugByLocale: {
+        it: 'ingegnere-di-calcolo-acme-corp-leibstadt',
+        en: 'projektmanager-m-w-d-acme-corp-leibstadt',
+      },
+      titleByLocale: {
+        it: 'Ingegnere di calcolo',
+        en: 'Projektmanager (m/w/d)',
+      },
+      // Already dropped this exact EN slug in a prior assemble run.
+      previousSlugs: ['projektmanager-m-w-d-acme-corp-leibstadt'],
+    };
+    const jobB: JobFixture = {
+      id: 'job-b',
+      url: 'https://employer.example/jobs/b',
+      canton: 'AG',
+      slug: 'projektmanager-m-w-d-acme-corp-leibstadt',
+      slugByLocale: { it: 'projektmanager-m-w-d-acme-corp-leibstadt' },
+      titleByLocale: { it: 'Projektmanager (m/w/d)' },
+    };
+
+    const report = applyPerLocaleSlugCollisionGuard([jobA, jobB]);
+
+    expect(report.count).toBe(1);
+    // Title is PRESERVED — nothing was actually wrong with the translation.
+    expect(jobA.titleByLocale.en).toBe('Projektmanager (m/w/d)');
+    // Slug is disambiguated (unique suffix), not deleted.
+    expect(jobA.slugByLocale.en).not.toBeUndefined();
+    expect(jobA.slugByLocale.en).not.toBe('projektmanager-m-w-d-acme-corp-leibstadt');
+    expect(jobA.slugByLocale.en!.startsWith('projektmanager-m-w-d-acme-corp-leibstadt-')).toBe(true);
+    // No retranslation flag — there is nothing to retranslate.
+    expect(jobA.needsRetranslation).toBeUndefined();
+  });
+
   it('caps the details list at 10 to keep build logs short', () => {
     const owner = {
       url: 'owner', canton: 'AG', slug: 'shared-slug-acme-corp-aarau',


### PR DESCRIPTION
## Implementato

`applyPerLocaleSlugCollisionGuard` (`scripts/assemble-jobs-dataset.mjs`) deleted a job's translated `titleByLocale`/`slugByLocale` entry and set `needsRetranslation=true` whenever its translated slug collided with another job's base slug — with no way to tell "genuinely bad/hallucinated translation" (the 2026-05-26 incident this guard was built for) apart from "coincidental slug collision between two already-correct translations". In the second case, deleting achieves nothing: deterministic MT (Argos/CTranslate2) regenerates the byte-identical slug on the next retry, recolliding forever.

Confirmed live via `gh run view --log` on real `translate-pending.yml` runs + direct inspection of `data/jobs/by-crawler/*.json` vs the assembled `data/jobs.json`:
- Fisiocare Sagl's "Fisioterapista con riconoscimento CRS" posting: fully correct IT/EN/DE/FR translations at the per-crawler source, but `needsRetranslation:true` in the assembled dataset for 12 days — `previousSlugsByLocale`/`previousSlugs` showed the same 3 translated slugs repeatedly demoted.
- EOC – Ente Ospedaliero Cantonale's near-duplicate physiotherapist postings (Bellinzona/Novaggio/Locarno) — 25 entries in `previousSlugs`, confirming a long-running repeat-collision cycle.
- Both jobs were excluded from the `/cerca-lavoro-ticino/fisioterapisti/` sector-hub page (`jobSectorLanding.ts`'s `jobIsActive()` treats `needsRetranslation:true` as inactive on every locale, IT included) despite having complete, correct content — live page showed 0 matching jobs.

Fix: track whether the exact same slug string already collided once (`job.previousSlugs.includes(slug)`, already populated by the existing `addPreviousSlugForLocale` call). On a first-time collision, behavior is unchanged (delete + flag, in case retranslation happens to produce different wording). On a **repeat** collision, disambiguate the slug with a stable per-job suffix (reusing the already-established `stableSlugHash` + `appendSlugDisambiguator` helpers used elsewhere for exactly this EOC/AXA/Swisscom-style near-duplicate-posting scenario) instead of deleting again — breaking the loop while keeping the already-correct title/description.

Files changed:
- `scripts/assemble-jobs-dataset.mjs` — recurrence-guard branch in `applyPerLocaleSlugCollisionGuard`.
- `tests/scripts/assemble-per-locale-slug-collision-guard.test.ts` — new test for the repeat-collision → disambiguate path; all 8 pre-existing tests in this file (first-collision delete+reflag behavior, self-match, cross-canton, details cap) pass unchanged.

Verified: targeted test file (9/9 pass), sibling test `relocalize-carry-forward-slug-bridges.test.ts` (3/3 pass), full-suite `-t collision` filter (132 passed / rest skipped, no regressions), plus `job-locale-completeness`/`job-locale-consistency`/`job-cross-locale-guard`/`dedicated-crawler-common`/`merge-source-copy-protection`/`locale-merge-structure-flattening`/`ensure-locale-fields-no-mass-reflag`/`job-sector-landing` — all green against a freshly re-assembled `data/jobs.json`.

## Non implementato (ancora)

Nessuno per lo scope di questa PR (il bug strutturale è fixato: prima collisione = comportamento invariato, collisione ripetuta = disambigua invece di cancellare).

**Sibling-pattern check (`check-sibling-patterns.mjs`, 20 candidati) — tutti falsi positivi, valutati singolarmente** (pre-push hook bypassato con `--no-verify` dopo verifica manuale, come da AGENTS.md #6):

- `scripts/lib/dedicated-crawler-common.mjs` — falso positivo: definisce le helper condivise (`stableSlugHash`, `appendSlugDisambiguator`, ecc.) che questo fix importa; non contiene l'antipattern.
- `scripts/lib/shared-jobs-crawler.mjs` — falso positivo: usa `needsRetranslation` per difetti di qualità reali (parole concatenate, titolo non tradotto, contaminazione lingua) con guardia esplicita "don't clear locale content" — mai cancella `titleByLocale` per collisione slug.
- `scripts/relocalize-pending-jobs.mjs` — falso positivo: condivide solo `cleanPreviousSlugsPerLocale`/`DEFAULT_PREV_SLUG_CAP` per il give-up counter generico (`MAX_RETRANSLATION_ATTEMPTS`), non la logica di collisione slug corretta qui.
- `components/community/JobBoard.tsx` — falso positivo: usa `buildStableId` lato SPA per il rendering, nessuna logica di traduzione/collisione.
- `scripts/backfill-prev-slugs-from-loss-events.mjs` — falso positivo: usa `stableSlugHash` per un backfill storico one-off di `previousSlugs` perduti, non tocca `needsRetranslation` né collisioni slug.
- `scripts/cleanup-jobs.mjs` — falso positivo: usa `needsRetranslation` solo per marcare descrizioni fallback-boilerplate come da ritradurre, mai cancella traduzioni esistenti per collisione slug.
- `scripts/decontaminate-prev-slugs.mjs` — falso positivo: usa `stableSlugHash` per rimuovere entry contaminate da `previousSlugs`, non genera né risolve collisioni.
- `scripts/lib/crawler-template.mjs` — falso positivo: unico riferimento a `needsRetranslation` è un commento descrittivo generico, nessun codice attivo.
- `scripts/lib/job-match-key.mjs` — falso positivo: usa `buildStableId` per chiavi di matching dedup, nessuna logica di traduzione/collisione.
- `scripts/lib/ksml-job-parser.mjs` — falso positivo: usa `appendSlugDisambiguator` per disambiguare slug duplicati alla sorgente del parser KSML, non per risolvere collisioni post-assemble cross-job.
- `scripts/rebaseline-truncated-st-locality.mjs` — falso positivo: usa `healTruncatedStLocalities` per un fix di località troncate ("St."), estraneo a traduzioni/collisioni slug.
- `scripts/reconcile-duplicate-stable-id-jobs.mjs` — falso positivo: usa `DEFAULT_PREV_SLUG_CAP` per riconciliare id duplicati, non tocca la collision guard.
- `scripts/reconcile-job-slugs.mjs` — falso positivo: usa `DEFAULT_PREV_SLUG_CAP` per riconciliazione slug generica, non l'antipattern del collision-guard.
- `scripts/regenerate-slugs-by-locale.mjs` — falso positivo: unico riferimento è un commento storico che descrive il vecchio `hardenJobLocaleFields` (già rimpiazzato da questo stesso script proprio per evitare loop simili) — non codice attivo con l'antipattern.
- `scripts/repair-unicode-escape-titles.mjs` — falso positivo: flag `needsRetranslation` one-shot per titoli corrotti da unicode-escape decodificati, riparazione singola non ricorsiva, non collegata a collisioni slug.
- `scripts/scan-prev-slug-losses.mjs` — falso positivo: usa `DEFAULT_PREV_SLUG_CAP` solo per scansionare/riportare perdite storiche, nessuna scrittura né logica di collisione.
- `scripts/scatter-jobs-to-slices.mjs` — falso positivo: usa `DEFAULT_PREV_SLUG_CAP` per sincronizzare `previousSlugs` verso gli slice per-crawler, non genera collisioni.
- `scripts/update-axa-jobs.mjs` — falso positivo: usa `stableSlugHash` per lo slug disambiguation specifico del crawler AXA, non la collision guard cross-job.
- `scripts/update-eoc-jobs.mjs` — falso positivo: usa `stableSlugHash` per lo slug disambiguation specifico del parser sorgente EOC, non il punto dove `needsRetranslation` viene impostato in loop (quello è l'assembler, fixato in questa PR).
- `scripts/update-swisscom-jobs.mjs` — falso positivo: usa `stableSlugHash` per lo slug disambiguation specifico del crawler Swisscom, non la collision guard cross-job.

## Test plan

- [x] `npx vitest run tests/scripts/assemble-per-locale-slug-collision-guard.test.ts` — 9/9 pass (8 pre-existing + 1 new)
- [x] `npx vitest run tests/relocalize-carry-forward-slug-bridges.test.ts` — 3/3 pass
- [x] `npx vitest run -t collision` (full suite filter) — 132 passed, no regressions
- [x] `npx vitest run tests/job-locale-completeness.test.ts tests/job-locale-consistency.test.ts tests/job-cross-locale-guard.test.ts tests/dedicated-crawler-common.test.ts tests/merge-source-copy-protection.test.ts tests/locale-merge-structure-flattening.test.ts tests/scripts/ensure-locale-fields-no-mass-reflag.test.ts tests/job-sector-landing.test.ts` — all pass against a freshly re-assembled `data/jobs.json`
- [ ] Live confirmation that `/cerca-lavoro-ticino/fisioterapisti/` shows the Fisiocare/EOC postings — depends on the next `translate-pending.yml` + deploy cycle re-triggering a fresh collision for these specific jobs (the exact collision is currently NOT reproducing on a fresh local assemble, since it's driven by transient near-duplicate-posting churn); the fix's effect is on the *next* time this class of collision recurs, verifiable via `previousSlugs`/`needsRetranslation` state on subsequent scheduled runs.