### PR TITLE
chore(cf): IP-scope Semrush unblock instead of full UA removal

### DIFF
--- a/scripts/cf-locale-failover-setup.mjs
+++ b/scripts/cf-locale-failover-setup.mjs
@@ -39,7 +39,10 @@
  *       SEO traffic, no clicks, no monetizable traffic. (It also keeps Worker
  *       invocations down — the WAF runs BEFORE the Worker — a bonus, not the
  *       reason.) Real search + AI-search crawlers are deliberately NOT
- *       matched (#1867).
+ *       matched (#1867). TRUSTED_CRAWLER_IP_RANGES (2026-07-22) carves an
+ *       IP-verified exception out of this block — currently Semrush's own
+ *       Site Audit crawler range, unblocked by source IP (not by UA removal,
+ *       which a spoofed UA from elsewhere would still bypass this block for).
  *    b) unidentified-scripted-traffic-challenge — `managed_challenge` (NOT a
  *       hard block — too uncertain to block outright) for requests with an
  *       empty User-Agent or the literal UA "node": live traffic analysis
@@ -145,6 +148,18 @@ const BLOCKED_CRAWLER_UAS = [
 // genuine human through.
 const CHALLENGED_UAS = ['', 'node'];
 
+// IP-verified exception to the block above (owner request, 2026-07-22):
+// Semrush's own Site Audit tool (`SemrushBot-SI` UA) was getting 403'd by the
+// 2026-07-20 zone-wide block — an over-widening side effect, not the original
+// intent. Carved out by SOURCE IP (owner-supplied range), not by removing
+// "SemrushBot" from BLOCKED_CRAWLER_UAS, because a UA string is trivially
+// spoofed: this way a "SemrushBot" UA from any OTHER IP still gets blocked,
+// only requests actually originating from Semrush's published crawler range
+// pass. Excluded from the block expression AND added to the allowlist skip
+// below so other zone security (WAF managed rules, Bot Fight Mode) doesn't
+// re-block it downstream of the custom ruleset.
+const TRUSTED_CRAWLER_IP_RANGES = ['85.208.98.128/25'];
+
 // The crawlers this site deliberately welcomes — organic-search + AI-search
 // visibility channels. Mirrors the owner's original allowlist rule (adopted
 // under management 2026-07-20; was a "foreign" rule with Amazonbot/Bytespider
@@ -181,7 +196,9 @@ const MANAGED_FIREWALL_RULES = [
     description: 'locale-bot-throttle-noindex-scrapers (managed by scripts/cf-locale-failover-setup.mjs)',
     action: 'block',
     expression:
-      '(http.host eq "frontaliereticino.ch" and (' +
+      '(http.host eq "frontaliereticino.ch" and not (ip.src in {' +
+      TRUSTED_CRAWLER_IP_RANGES.join(' ') +
+      '}) and (' +
       BLOCKED_CRAWLER_UAS.map((ua) => `http.user_agent contains "${ua}"`).join(' or ') +
       '))',
   },
@@ -200,7 +217,7 @@ const MANAGED_FIREWALL_RULES = [
       'Allowlist verified SEO + AI crawlers — skip ALL security so crawlers are never challenged + our IP (never challenge/rate-limit us)',
     action: 'skip',
     expression:
-      `(ip.src eq ${OWNER_IP}) or ((` +
+      `(ip.src eq ${OWNER_IP}) or (ip.src in {${TRUSTED_CRAWLER_IP_RANGES.join(' ')}}) or ((` +
       VERIFIED_CRAWLER_UAS.map((ua) => `http.user_agent contains "${ua}"`).join(') or (') +
       ') or (cf.client.bot))',
     action_parameters: {


### PR DESCRIPTION
## Implementato

- Aggiunta eccezione IP-verificata (`TRUSTED_CRAWLER_IP_RANGES = ['85.208.98.128/25']`) alla firewall rule `locale-bot-throttle-noindex-scrapers` in `scripts/cf-locale-failover-setup.mjs`: le richieste da quel subnet non matchano più il block anche se lo user-agent contiene "SemrushBot" (`SemrushBot-SI` — Site Audit — era 403'd dal block zone-wide del 2026-07-20).
- Stesso range aggiunto alla regola skip-all-security ("Allowlist verified SEO + AI crawlers"), cosi' anche WAF managed/Bot Fight Mode non ri-bloccano il traffico da quell'IP a valle della custom ruleset.
- Scelto scoping per IP invece di rimuovere "SemrushBot" da `BLOCKED_CRAWLER_UAS`: uno user-agent e' facilmente spoofabile, un "SemrushBot" UA da un IP diverso da quel range resta bloccato.
- Applicato live su Cloudflare (`node scripts/cf-locale-failover-setup.mjs --firewall-only`, poi verificato idempotente con `--dry-run` → "all in shape") prima di aprire questa PR — il fix e' gia' attivo in produzione, questa PR ne allinea il codice sorgente/idempotency-script.
- Header doc del file aggiornato (§3a) per riflettere la nuova eccezione.

## Non implementato (ancora)

Nessuno.

## Sibling-pattern check (AGENTS.md #6)

`check-sibling-patterns.mjs` ha segnalato `scripts/audit-ai-crawlers.mjs` (condivide il token "SemrushBot").

- `scripts/audit-ai-crawlers.mjs` — **falso positivo**: e' un classificatore regex sola-lettura per un report bandwidth GraphQL (`classifyUA`), non un meccanismo di enforcement/block. Non esiste li' nessuna block-list IP-based da cui carve-are un'eccezione — condivide solo la stringa "SemrushBot" come label di categorizzazione, non l'antipattern (block-then-except-by-IP) toccato in questa PR.

## Test plan

- [x] `node --check scripts/cf-locale-failover-setup.mjs`
- [x] `--dry-run` pre-change: drift rilevato come atteso
- [x] Applicato live, poi `--dry-run` post-change: "all in shape" (convergenza confermata)