### PR TITLE
fix(router): recognize all SSG page families in parsePath, prevent hydration 404s

### DIFF
--- a/build-plugins/fiscalMunicipalityData.ts
+++ b/build-plugins/fiscalMunicipalityData.ts
@@ -101,3 +101,37 @@ const FISCAL_PATH_SET: ReadonlySet<string> = (() => {
 export function isFiscalMunicipalityPath(inputPath: string): boolean {
   return FISCAL_PATH_SET.has(normalizePath(inputPath));
 }
+
+/**
+ * Reverse index (path → locale + slug) for the per-comune detail/bridge pages,
+ * used by services/router.ts to recognise the URL at hydration time and
+ * recover the locale without re-parsing the path shape. Same membership as
+ * FISCAL_PATH_SET/isFiscalMunicipalityPath above (above + below floor).
+ */
+const FISCAL_DETAIL_INDEX: ReadonlyMap<string, { locale: FiscalLocale; slug: string }> = (() => {
+  const map = new Map<string, { locale: FiscalLocale; slug: string }>();
+  for (const m of [...FISCAL_ABOVE_FLOOR, ...FISCAL_BELOW_FLOOR]) {
+    for (const locale of FISCAL_LOCALES) {
+      map.set(normalizePath(fiscalPathFor(locale, m.slug)), { locale, slug: m.slug });
+    }
+  }
+  return map;
+})();
+
+export function parseFiscalMunicipalityPath(inputPath: string): { locale: FiscalLocale; slug: string } | null {
+  return FISCAL_DETAIL_INDEX.get(normalizePath(inputPath)) ?? null;
+}
+
+/** Reverse index (path → locale) for the hub/index page, one per locale. */
+const FISCAL_HUB_INDEX: ReadonlyMap<string, FiscalLocale> = new Map(
+  FISCAL_LOCALES.map((l) => [normalizePath(FISCAL_HUB_PATH[l]), l]),
+);
+
+export function isFiscalHubPath(inputPath: string): boolean {
+  return FISCAL_HUB_INDEX.has(normalizePath(inputPath));
+}
+
+export function parseFiscalHubPath(inputPath: string): { locale: FiscalLocale } | null {
+  const found = FISCAL_HUB_INDEX.get(normalizePath(inputPath));
+  return found ? { locale: found } : null;
+}

--- a/build-plugins/healthFacilitiesData.ts
+++ b/build-plugins/healthFacilitiesData.ts
@@ -111,3 +111,21 @@ function normalizePath(urlPath: string): string {
 export function isHealthFacilityPath(urlPath: string): boolean {
   return PATH_INDEX.has(normalizePath(urlPath));
 }
+
+export interface HealthFacilityRoutePath {
+  locale: HealthFacilityLocale;
+  slug: string;
+}
+
+// Parsed twin of PATH_INDEX — services/router.ts needs the locale (isHealthFacilityPath
+// is boolean-only), mirroring exchangeSsgPaths.ts's isX/parseX shape.
+const PARSED_PATH_INDEX: ReadonlyMap<string, HealthFacilityRoutePath> = new Map(
+  HEALTH_FACILITIES.flatMap((f) =>
+    HEALTH_FACILITY_LOCALES.map((locale) => [buildHealthFacilityPath(locale, f.slug), { locale, slug: f.slug }] as const),
+  ),
+);
+
+/** Parses a facility canonical path into its locale + slug, or null if unmatched. */
+export function parseHealthFacilityPath(urlPath: string): HealthFacilityRoutePath | null {
+  return PARSED_PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}

--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -66,16 +66,17 @@ interface JobLike {
   needsRetranslation?: boolean | Record<string, boolean>;
 }
 
-type Locale = 'it' | 'en' | 'de' | 'fr';
-
-const LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
-
-const LOCALE_PREFIX: Record<Locale, string> = {
-  it: '',
-  en: '/en',
-  de: '/de',
-  fr: '/fr',
-};
+import {
+  type ChCantonSnapshotLocale as Locale,
+  CH_CANTON_SNAPSHOT_LOCALES as LOCALES,
+  CH_CANTON_SNAPSHOT_LOCALE_PREFIX as LOCALE_PREFIX,
+  CH_CANTON_SNAPSHOT_JOB_BOARD_PREFIX as JOB_BOARD_PREFIX,
+  CH_CANTON_SNAPSHOT_SEGMENT as SNAPSHOT_SEGMENT,
+  buildCantonSnapshotPath,
+} from './jobMarketSnapshotChCantonPathsData';
+// Re-exported for existing consumers (tests) that import path builders from
+// this plugin file rather than the new browser-safe paths module directly.
+export { SNAPSHOT_SEGMENT, buildCantonSnapshotPath };
 
 const OG_LOCALE: Record<Locale, string> = {
   it: 'it_CH',
@@ -83,23 +84,6 @@ const OG_LOCALE: Record<Locale, string> = {
   de: 'de_CH',
   fr: 'fr_CH',
 };
-
-/** Locale-aware "find-jobs-{canton}" URL segment prefix. */
-const JOB_BOARD_PREFIX: Record<Locale, string> = {
-  it: 'cerca-lavoro',
-  en: 'find-jobs',
-  de: 'jobs-im',
-  fr: 'trouver-emploi',
-};
-
-/**
- * "snapshot" segment — same word in all 4 locales for predictable URL shape.
- * Exported so searchConsoleCompat.ts can self-map this family's URLs (every
- * canton either gets the full page or a below-floor noindex bridge at this
- * exact path — see resolveSearchConsoleCompatTarget) without duplicating the
- * literal.
- */
-export const SNAPSHOT_SEGMENT = 'snapshot';
 
 const COPY: Record<
   Locale,
@@ -322,16 +306,6 @@ const SECTOR_DISPLAY: Record<string, Record<Locale, string>> = {
   ingegneria: { it: 'Ingegneria', en: 'Engineering', de: 'Ingenieurwesen', fr: 'Ingénierie' },
   altro: { it: 'Altro', en: 'Other', de: 'Sonstige', fr: 'Autre' },
 };
-
-/** Build canonical path for a per-canton snapshot page. */
-export function buildCantonSnapshotPath(
-  locale: Locale,
-  cantonSlug: string,
-): string {
-  const prefix = LOCALE_PREFIX[locale];
-  const board = JOB_BOARD_PREFIX[locale];
-  return `${prefix}/${board}-${cantonSlug}/${SNAPSHOT_SEGMENT}/`.replace(/\/{2,}/g, '/');
-}
 
 interface RankedCity {
   name: string;

--- a/build-plugins/jobMarketSnapshotChCantonPathsData.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPathsData.ts
@@ -1,0 +1,73 @@
+/**
+ * jobMarketSnapshotChCantonPathsData.ts — browser-safe path data for the
+ * per-canton job-market snapshot pages (jobMarketSnapshotChCantonPages.ts,
+ * T2.5). Split out because that plugin imports `node:fs`/`node:path`
+ * (jobs-pool loading) and is therefore unsafe to bundle into the client —
+ * mirrors the exchangeSsgPaths.ts / exchangeRateSsgData.ts split.
+ *
+ * Every enumerated (locale, canton) pair gets real HTML at build time —
+ * either the full snapshot or a below-floor `noindex,follow` bridge at the
+ * identical canonical path (renderBelowFloorBridge in the plugin) — so the
+ * router can safely recognise the full set without knowing the per-canton
+ * job-count floor.
+ */
+
+import { SALARY_STATS_CANTON_KEYS, SALARY_STATS_CANTON_SLUGS } from './salaryStatsData';
+import { CANTON_JOB_BOARD_PREFIX } from './shared/cantonJobBoardPrefix';
+
+export type ChCantonSnapshotLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const CH_CANTON_SNAPSHOT_LOCALES: readonly ChCantonSnapshotLocale[] = ['it', 'en', 'de', 'fr'];
+
+export const CH_CANTON_SNAPSHOT_LOCALE_PREFIX: Record<ChCantonSnapshotLocale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+/** Locale-aware "find-jobs-{canton}" URL segment prefix. */
+export const CH_CANTON_SNAPSHOT_JOB_BOARD_PREFIX: Record<ChCantonSnapshotLocale, string> = CANTON_JOB_BOARD_PREFIX;
+
+/** "snapshot" segment — same word in all 4 locales for predictable URL shape. */
+export const CH_CANTON_SNAPSHOT_SEGMENT = 'snapshot';
+
+/** Canton keys this family emits for: every URL canton key except Ticino (legacy dedicated pipeline). */
+export const CH_CANTON_SNAPSHOT_CANTON_KEYS: readonly string[] = Object.freeze(
+  SALARY_STATS_CANTON_KEYS.filter((k) => k !== 'TI'),
+);
+
+export function buildCantonSnapshotPath(locale: ChCantonSnapshotLocale, cantonSlug: string): string {
+  const prefix = CH_CANTON_SNAPSHOT_LOCALE_PREFIX[locale];
+  const board = CH_CANTON_SNAPSHOT_JOB_BOARD_PREFIX[locale];
+  return `${prefix}/${board}-${cantonSlug}/${CH_CANTON_SNAPSHOT_SEGMENT}/`.replace(/\/{2,}/g, '/');
+}
+
+export interface ChCantonSnapshotPath {
+  locale: ChCantonSnapshotLocale;
+  cantonKey: string;
+  path: string;
+}
+
+function normalizePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+const PATH_INDEX: ReadonlyMap<string, ChCantonSnapshotPath> = new Map(
+  CH_CANTON_SNAPSHOT_LOCALES.flatMap((locale) =>
+    CH_CANTON_SNAPSHOT_CANTON_KEYS.map((cantonKey) => {
+      const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+      const path = buildCantonSnapshotPath(locale, cantonSlug);
+      return [path, { locale, cantonKey, path }] as const;
+    }),
+  ),
+);
+
+export function isChCantonSnapshotPath(urlPath: string): boolean {
+  return PATH_INDEX.has(normalizePath(urlPath));
+}
+
+export function parseChCantonSnapshotPath(urlPath: string): ChCantonSnapshotPath | null {
+  return PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}

--- a/build-plugins/searchConsoleCompat.ts
+++ b/build-plugins/searchConsoleCompat.ts
@@ -16,7 +16,7 @@ import { isSalaryProfessionCantonPath } from './salaryProfessionCantonData';
 import { isProfessionCityPath } from './professionCityData';
 import { isHealthFacilityPath } from './healthFacilitiesData';
 import { WEEKLY_EMPLOYERS_SECTION } from './weeklyEmployersData';
-import { SNAPSHOT_SEGMENT } from './jobMarketSnapshotChCantonPages';
+import { CH_CANTON_SNAPSHOT_SEGMENT as SNAPSHOT_SEGMENT } from './jobMarketSnapshotChCantonPathsData';
 import { HUB_SLUG_BY_LOCALE } from './seoHubsData';
 import {
  EDITORIAL_CANTONS,

--- a/build-plugins/sectionPagesPathsData.ts
+++ b/build-plugins/sectionPagesPathsData.ts
@@ -1,0 +1,64 @@
+/**
+ * sectionPagesPathsData.ts — browser-safe canonical path table for the 7
+ * Google-News topic section pages (sectionPagesPlugin.ts: fisco, lavoro,
+ * salari, cambio, trasporti, pensioni, dogana × 4 locales = 28 pages).
+ * Split out because the plugin imports `node:fs`/`node:path`, `ARTICLES`
+ * and `buildSeoPageHtml` and is therefore unsafe to bundle into the client
+ * — mirrors the exchangeSsgPaths.ts / jobMarketSnapshotChCantonPathsData.ts
+ * split. The plugin imports `SECTION_PATHS` from here so the literal path
+ * table has one source of truth.
+ */
+
+export type SectionId = 'fisco' | 'lavoro' | 'salari' | 'cambio' | 'trasporti' | 'pensioni' | 'dogana';
+
+export const SECTION_IDS: readonly SectionId[] = [
+  'fisco',
+  'lavoro',
+  'salari',
+  'cambio',
+  'trasporti',
+  'pensioni',
+  'dogana',
+];
+
+export type SectionPageLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const SECTION_PAGE_LOCALES: readonly SectionPageLocale[] = ['it', 'en', 'de', 'fr'];
+
+export const SECTION_PATHS: Record<SectionId, Record<SectionPageLocale, string>> = {
+  fisco: { it: '/fisco/', en: '/en/tax/', de: '/de/steuern/', fr: '/fr/fiscalite/' },
+  lavoro: { it: '/lavoro-frontaliere/', en: '/en/cross-border-work/', de: '/de/grenzgaenger-arbeit/', fr: '/fr/travail-frontalier/' },
+  salari: { it: '/salari/', en: '/en/salaries/', de: '/de/loehne/', fr: '/fr/salaires/' },
+  cambio: { it: '/cambio-valuta/', en: '/en/currency-exchange/', de: '/de/waehrung/', fr: '/fr/change/' },
+  trasporti: { it: '/trasporti/', en: '/en/transport/', de: '/de/verkehr/', fr: '/fr/transports/' },
+  pensioni: { it: '/pensioni/', en: '/en/pensions/', de: '/de/renten/', fr: '/fr/retraites/' },
+  dogana: { it: '/dogana/', en: '/en/customs/', de: '/de/zoll/', fr: '/fr/douane/' },
+};
+
+export interface SectionPageMatch {
+  sectionId: SectionId;
+  locale: SectionPageLocale;
+  path: string;
+}
+
+function normalizePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+const PATH_INDEX: ReadonlyMap<string, SectionPageMatch> = new Map(
+  SECTION_IDS.flatMap((sectionId) =>
+    SECTION_PAGE_LOCALES.map((locale) => {
+      const path = SECTION_PATHS[sectionId][locale];
+      return [normalizePath(path), { sectionId, locale, path }] as const;
+    }),
+  ),
+);
+
+export function isSectionPagePath(urlPath: string): boolean {
+  return PATH_INDEX.has(normalizePath(urlPath));
+}
+
+export function parseSectionPagePath(urlPath: string): SectionPageMatch | null {
+  return PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}

--- a/build-plugins/sectionPagesPlugin.ts
+++ b/build-plugins/sectionPagesPlugin.ts
@@ -30,9 +30,17 @@
  * Locale-specific blog slugs are resolved via `services/routerBlogData.ts`
  * (BLOG_SLUGS) so each link points to the locale's canonical article URL.
  *
- * No SPA navigation: these pages are static-only. They are NOT registered
- * as SPA routes in `services/router.ts`. The 6-tab top-level cap is
- * preserved (these are footer/sitemap-only entry points).
+ * Static-only content, no dedicated SPA tab: the 6-tab top-level cap is
+ * preserved (these are footer/sitemap-only entry points, not nav items).
+ * `buildSeoPageHtml` still injects the SPA hydration bundle (site shell),
+ * so `services/router.ts` DOES need a `parsePath()` branch recognising
+ * these 28 canonical paths — via `sectionPagesPathsData.ts` — with
+ * `staticOverlay: true` mapped onto the existing `blog` tab (closest
+ * conceptual match: a topic-filtered article list). Without it, hydration
+ * falls through to the notFoundPath catch-all (or, for `/fisco/` and its
+ * DE/FR equivalents, silently swaps in the live interactive fisco tab) —
+ * same SSG-hydration-gap bug class as the exchange-rate/canton-snapshot
+ * fixes in this file's history.
  *
  * Gate: SKIP_SECTION_PAGES=1 fast-exits the plugin for local builds. CI
  * (`npm run build:ci`) always exercises it — exit 0 required.
@@ -56,31 +64,15 @@ import { BLOG_SLUGS } from '../services/routerBlogData';
 import type { BlogArticleId } from '../services/router';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import { inlineScriptJson } from './shared/inlineJsonScript';
+import {
+  type SectionId,
+  SECTION_IDS,
+  type SectionPageLocale as SectionLocale,
+  SECTION_PAGE_LOCALES as LOCALES,
+  SECTION_PATHS,
+} from './sectionPagesPathsData';
 
 // ── Types ─────────────────────────────────────────────────────────
-
-type SectionLocale = 'it' | 'en' | 'de' | 'fr';
-
-type SectionId =
-  | 'fisco'
-  | 'lavoro'
-  | 'salari'
-  | 'cambio'
-  | 'trasporti'
-  | 'pensioni'
-  | 'dogana';
-
-const SECTION_IDS: readonly SectionId[] = [
-  'fisco',
-  'lavoro',
-  'salari',
-  'cambio',
-  'trasporti',
-  'pensioni',
-  'dogana',
-] as const;
-
-const LOCALES: readonly SectionLocale[] = ['it', 'en', 'de', 'fr'] as const;
 
 const OG_LOCALE: Record<SectionLocale, string> = {
   it: 'it_CH',
@@ -171,12 +163,7 @@ interface SectionConfig {
 const SECTIONS: Record<SectionId, SectionConfig> = {
   fisco: {
     id: 'fisco',
-    paths: {
-      it: '/fisco/',
-      en: '/en/tax/',
-      de: '/de/steuern/',
-      fr: '/fr/fiscalite/',
-    },
+    paths: SECTION_PATHS.fisco,
     keywords: [
       'fisco',
       'fiscal',
@@ -259,12 +246,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   lavoro: {
     id: 'lavoro',
-    paths: {
-      it: '/lavoro-frontaliere/',
-      en: '/en/cross-border-work/',
-      de: '/de/grenzgaenger-arbeit/',
-      fr: '/fr/travail-frontalier/',
-    },
+    paths: SECTION_PATHS.lavoro,
     keywords: [
       'lavoro',
       'lavor',
@@ -349,12 +331,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   salari: {
     id: 'salari',
-    paths: {
-      it: '/salari/',
-      en: '/en/salaries/',
-      de: '/de/loehne/',
-      fr: '/fr/salaires/',
-    },
+    paths: SECTION_PATHS.salari,
     keywords: [
       'salar',
       'stipend',
@@ -430,12 +407,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   cambio: {
     id: 'cambio',
-    paths: {
-      it: '/cambio-valuta/',
-      en: '/en/currency-exchange/',
-      de: '/de/waehrung/',
-      fr: '/fr/change/',
-    },
+    paths: SECTION_PATHS.cambio,
     keywords: [
       'cambio',
       'cambi-',
@@ -514,12 +486,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   trasporti: {
     id: 'trasporti',
-    paths: {
-      it: '/trasporti/',
-      en: '/en/transport/',
-      de: '/de/verkehr/',
-      fr: '/fr/transports/',
-    },
+    paths: SECTION_PATHS.trasporti,
     keywords: [
       'trasport',
       'transport',
@@ -612,12 +579,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   pensioni: {
     id: 'pensioni',
-    paths: {
-      it: '/pensioni/',
-      en: '/en/pensions/',
-      de: '/de/renten/',
-      fr: '/fr/retraites/',
-    },
+    paths: SECTION_PATHS.pensioni,
     keywords: [
       'pension',
       'pensione',
@@ -699,12 +661,7 @@ const SECTIONS: Record<SectionId, SectionConfig> = {
   },
   dogana: {
     id: 'dogana',
-    paths: {
-      it: '/dogana/',
-      en: '/en/customs/',
-      de: '/de/zoll/',
-      fr: '/fr/douane/',
-    },
+    paths: SECTION_PATHS.dogana,
     keywords: [
       'dogana',
       'dogane',

--- a/build-plugins/shared/cantonJobBoardPrefix.ts
+++ b/build-plugins/shared/cantonJobBoardPrefix.ts
@@ -1,0 +1,17 @@
+/**
+ * cantonJobBoardPrefix.ts — shared "find-jobs-{canton}" URL segment prefix,
+ * locale-keyed. Every canton-scoped job-board family (job-market snapshot,
+ * weekly employers) builds its canonical path as `{prefix}-{cantonSlug}/`,
+ * so this literal is centralised here instead of copy-pasted per family
+ * (AGENTS.md rule #6 — a literal duplicated in ≥2 files goes in one shared
+ * module so drift is impossible by construction).
+ */
+
+export type CantonJobBoardLocale = 'it' | 'en' | 'de' | 'fr';
+
+export const CANTON_JOB_BOARD_PREFIX: Record<CantonJobBoardLocale, string> = {
+  it: 'cerca-lavoro',
+  en: 'find-jobs',
+  de: 'jobs-im',
+  fr: 'trouver-emploi',
+};

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -52,30 +52,22 @@ import {
 import { PROFESSION_CANTON_KEYS } from './professionCantonData';
 import { renderSalaryStatsBridge } from './shared/salaryStatsBridge';
 
-type Locale = WeeklyEmployersLocale;
-
-const LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
-
-const LOCALE_PREFIX: Record<Locale, string> = {
-  it: '',
-  en: '/en',
-  de: '/de',
-  fr: '/fr',
-};
+import {
+  type ChCantonEmployersLocale as Locale,
+  CH_CANTON_EMPLOYERS_LOCALES as LOCALES,
+  CH_CANTON_EMPLOYERS_LOCALE_PREFIX as LOCALE_PREFIX,
+  CH_CANTON_EMPLOYERS_JOB_BOARD_PREFIX as JOB_BOARD_PREFIX,
+  buildCantonEmployersPath,
+} from './weeklyEmployersChCantonPathsData';
+// Re-exported for existing consumers (tests) that import path builders from
+// this plugin file rather than the new browser-safe paths module directly.
+export { buildCantonEmployersPath };
 
 const OG_LOCALE: Record<Locale, string> = {
   it: 'it_CH',
   en: 'en_US',
   de: 'de_CH',
   fr: 'fr_CH',
-};
-
-/** Locale-aware "find-jobs" segment prefix (mirror of jobMarketSnapshotChCantonPages). */
-const JOB_BOARD_PREFIX: Record<Locale, string> = {
-  it: 'cerca-lavoro',
-  en: 'find-jobs',
-  de: 'jobs-im',
-  fr: 'trouver-emploi',
 };
 
 const COPY: Record<
@@ -257,14 +249,6 @@ function esc(s: unknown): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
-}
-
-/** Build canonical path for the per-canton weekly-employers page. */
-export function buildCantonEmployersPath(
-  locale: Locale,
-  cantonSlug: string,
-): string {
-  return `${LOCALE_PREFIX[locale]}/${JOB_BOARD_PREFIX[locale]}-${cantonSlug}/${WEEKLY_EMPLOYERS_SECTION[locale]}/`.replace(/\/{2,}/g, '/');
 }
 
 interface RankedEmployer {

--- a/build-plugins/weeklyEmployersChCantonPathsData.ts
+++ b/build-plugins/weeklyEmployersChCantonPathsData.ts
@@ -1,0 +1,66 @@
+/**
+ * weeklyEmployersChCantonPathsData.ts — browser-safe path data for the
+ * per-canton "companies hiring" pages (weeklyEmployersChCantonPages.ts).
+ * Split out because that plugin imports `node:fs`/`node:path` (jobs-pool +
+ * canton-slug-file loading) and is therefore unsafe to bundle into the
+ * client — mirrors the exchangeSsgPaths.ts / exchangeRateSsgData.ts split
+ * and jobMarketSnapshotChCantonPathsData.ts (same canton family).
+ *
+ * Every enumerated (locale, canton) pair gets real HTML at build time —
+ * either the full page or a below-floor `noindex,follow` bridge at the
+ * identical canonical path (renderBelowFloorBridge in the plugin) — so the
+ * router can safely recognise the full set without knowing the per-canton
+ * job-count floor.
+ */
+
+import { SALARY_STATS_CANTON_KEYS, SALARY_STATS_CANTON_SLUGS } from './salaryStatsData';
+import { CANTON_JOB_BOARD_PREFIX } from './shared/cantonJobBoardPrefix';
+import { WEEKLY_EMPLOYERS_LOCALE_PREFIX, WEEKLY_EMPLOYERS_SECTION, type WeeklyEmployersLocale } from './weeklyEmployersData';
+
+export type { WeeklyEmployersLocale as ChCantonEmployersLocale };
+
+export const CH_CANTON_EMPLOYERS_LOCALES: readonly WeeklyEmployersLocale[] = ['it', 'en', 'de', 'fr'];
+
+export const CH_CANTON_EMPLOYERS_LOCALE_PREFIX: Record<WeeklyEmployersLocale, string> = WEEKLY_EMPLOYERS_LOCALE_PREFIX;
+
+export const CH_CANTON_EMPLOYERS_JOB_BOARD_PREFIX: Record<WeeklyEmployersLocale, string> = CANTON_JOB_BOARD_PREFIX;
+
+/** Canton keys this family emits for: every URL canton key except Ticino (legacy dedicated pipeline). */
+export const CH_CANTON_EMPLOYERS_CANTON_KEYS: readonly string[] = Object.freeze(
+  SALARY_STATS_CANTON_KEYS.filter((k) => k !== 'TI'),
+);
+
+export function buildCantonEmployersPath(locale: WeeklyEmployersLocale, cantonSlug: string): string {
+  const prefix = CH_CANTON_EMPLOYERS_LOCALE_PREFIX[locale];
+  const board = CH_CANTON_EMPLOYERS_JOB_BOARD_PREFIX[locale];
+  return `${prefix}/${board}-${cantonSlug}/${WEEKLY_EMPLOYERS_SECTION[locale]}/`.replace(/\/{2,}/g, '/');
+}
+
+export interface ChCantonEmployersPath {
+  locale: WeeklyEmployersLocale;
+  cantonKey: string;
+  path: string;
+}
+
+function normalizePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+const PATH_INDEX: ReadonlyMap<string, ChCantonEmployersPath> = new Map(
+  CH_CANTON_EMPLOYERS_LOCALES.flatMap((locale) =>
+    CH_CANTON_EMPLOYERS_CANTON_KEYS.map((cantonKey) => {
+      const cantonSlug = SALARY_STATS_CANTON_SLUGS[cantonKey][locale];
+      const path = buildCantonEmployersPath(locale, cantonSlug);
+      return [path, { locale, cantonKey, path }] as const;
+    }),
+  ),
+);
+
+export function isChCantonEmployersPath(urlPath: string): boolean {
+  return PATH_INDEX.has(normalizePath(urlPath));
+}
+
+export function parseChCantonEmployersPath(urlPath: string): ChCantonEmployersPath | null {
+  return PATH_INDEX.get(normalizePath(urlPath)) ?? null;
+}

--- a/services/exchangeSsgPaths.ts
+++ b/services/exchangeSsgPaths.ts
@@ -84,3 +84,44 @@ export function buildNearestExchangeAmountPath(locale: ExchangeLocale, chf: numb
   }
   return buildExchangeAmountPath(locale, best);
 }
+
+// ── Route matching (services/router.ts) ─────────────────────────────────────
+// Client-side twin of build-plugins/exchangeRateSsgData.ts's isExchangeSsgPath
+// (which is node-context and boolean-only). Router needs the parsed locale
+// too, mirroring build-plugins/salaryStatsData.ts's isXPath/parseXPath shape.
+
+export interface ExchangeSsgPath {
+  locale: ExchangeLocale;
+  kind: 'hub' | 'amount';
+  amount?: number;
+  path: string;
+}
+
+/** Enumerate every canonical path (locale × hub + curated amounts). */
+export function listAllExchangeSsgPaths(): ExchangeSsgPath[] {
+  const out: ExchangeSsgPath[] = [];
+  for (const locale of EXCHANGE_LOCALES) {
+    out.push({ locale, kind: 'hub', path: buildExchangeHubPath(locale) });
+    for (const amount of EXCHANGE_AMOUNTS) {
+      out.push({ locale, kind: 'amount', amount, path: buildExchangeAmountPath(locale, amount) });
+    }
+  }
+  return out;
+}
+
+const EXCHANGE_SSG_PATH_INDEX: ReadonlyMap<string, ExchangeSsgPath> = new Map(
+  listAllExchangeSsgPaths().map((p) => [p.path, p]),
+);
+
+function normalizeExchangePath(urlPath: string): string {
+  const p = String(urlPath || '').split('?')[0].split('#')[0];
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+export function isExchangeSsgPath(urlPath: string): boolean {
+  return EXCHANGE_SSG_PATH_INDEX.has(normalizeExchangePath(urlPath));
+}
+
+export function parseExchangeSsgPath(urlPath: string): ExchangeSsgPath | null {
+  return EXCHANGE_SSG_PATH_INDEX.get(normalizeExchangePath(urlPath)) ?? null;
+}

--- a/services/router.ts
+++ b/services/router.ts
@@ -51,6 +51,7 @@ import { FUEL_DAILY_ROUTES, isFuelDailyPath } from '../build-plugins/fuelDailyDa
 import { HEALTH_PREMIUMS_ROUTES, isHealthPremiumsPath } from '../build-plugins/healthPremiumsData';
 import { JOB_MARKET_SNAPSHOT_ROUTES, isJobMarketSnapshotPath } from '../build-plugins/jobMarketSnapshotData';
 import { isSalaryStatsPath, parseSalaryStatsPath } from '../build-plugins/salaryStatsData';
+import { isExchangeSsgPath, parseExchangeSsgPath } from './exchangeSsgPaths';
 import { parseOrphanLandingPath as ORPHAN_LANDING_ROUTES } from '../build-plugins/orphanQueryData';
 import { WEEKLY_EMPLOYERS_ROUTES, parseCompanyCityPath, parseWeeklyEmployersPath, parseWeeklyEmployersTopHubPath } from '../build-plugins/weeklyEmployersData';
 import { BORDER_WAIT_ROUTES, isBorderWaitPath, parseBorderWaitPath } from '../build-plugins/borderWaitData';
@@ -61,6 +62,11 @@ import { FRONTALIERE_PILLAR_ROUTES, isFrontalierePillarPath, parseFrontalierePil
 import { isProfessionCantonPath, parseProfessionCantonPath } from '../build-plugins/professionCantonData';
 import { isSalaryProfessionCantonPath, parseSalaryProfessionCantonPath } from '../build-plugins/salaryProfessionCantonData';
 import { isProfessionCityPath, parseProfessionCityPath } from '../build-plugins/professionCityData';
+import { isHealthFacilityPath, parseHealthFacilityPath } from '../build-plugins/healthFacilitiesData';
+import { isChCantonSnapshotPath, parseChCantonSnapshotPath } from '../build-plugins/jobMarketSnapshotChCantonPathsData';
+import { parseChCantonEmployersPath } from '../build-plugins/weeklyEmployersChCantonPathsData';
+import { isSectionPagePath, parseSectionPagePath } from '../build-plugins/sectionPagesPathsData';
+import { isFiscalHubPath, parseFiscalHubPath, parseFiscalMunicipalityPath } from '../build-plugins/fiscalMunicipalityData';
 import {
   COST_OF_LIVING_LANDING_ROUTES,
   isCostOfLivingLandingPath,
@@ -1984,6 +1990,21 @@ export function parsePath(pathname: string): ParseResult {
    return { route: { activeTab: 'stats', statsSubTab: 'health-premiums', staticOverlay: true }, locale };
  }
 
+ // CHF/EUR exchange SSG vertical (epic #4452) — hub /cambio-franco-euro/ +
+ // curated amount pages /cambio-franco-euro/{amount}-franchi-in-euro/ (+
+ // EN/DE/FR variants, e.g. /en/chf-eur-exchange/4500-chf-to-eur/). This
+ // branch was missing entirely, so hydration fell through to the final
+ // notFoundPath fallback, replacing the correct static HTML with the
+ // generic "Pagina non trovata" screen and rewriting the URL back to '/'
+ // (reported live for /cambio-franco-euro/4500-franchi-in-euro/, linked
+ // from the calculator results cross-link — affects every hub/amount page
+ // in all 4 locales). staticOverlay keeps the static content visible and
+ // hydrates to the exchange comparator sub-tab.
+ if (isExchangeSsgPath(pathname)) {
+   const parsed = parseExchangeSsgPath(pathname);
+   return { route: { activeTab: 'confronti', confrontiSubTab: 'exchange', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
+ }
+
  // Per-canton salary statistics landings (F-salary) — /stipendi-{canton}/ +
  // localised variants. Build-time static HTML; staticOverlay keeps the
  // per-canton salary content visible (hydrates to the salary-compare sub-tab).
@@ -2030,6 +2051,16 @@ export function parsePath(pathname: string): ParseResult {
    const companyCityMatch = parseCompanyCityPath(pathname);
    if (companyCityMatch) {
      return { route: { activeTab: 'job-board', staticOverlay: true }, locale: companyCityMatch.locale as Locale };
+   }
+   // Per-canton "aziende che assumono" (weeklyEmployersChCantonPages.ts) —
+   // /cerca-lavoro-{canton}/aziende-che-assumono/ (+ locale variants). Same
+   // failure mode as the other gaps in this file: this branch was missing
+   // entirely, so hydration fell through to notFoundPath. Every enumerated
+   // (locale, canton) pair has a live target — full page or below-floor
+   // bridge at the identical URL — so recognising the whole set is safe.
+   const chCantonEmployersMatch = parseChCantonEmployersPath(pathname);
+   if (chCantonEmployersMatch) {
+     return { route: { activeTab: 'job-board', staticOverlay: true }, locale: chCantonEmployersMatch.locale as Locale };
    }
  }
 
@@ -2079,6 +2110,62 @@ export function parsePath(pathname: string): ParseResult {
  // staticOverlay keeps the per-snapshot/per-sector page content visible.
  if (JOB_MARKET_SNAPSHOT_ROUTES.includes(pathname.endsWith('/') ? pathname : `${pathname}/`) || isJobMarketSnapshotPath(pathname)) {
    return { route: { activeTab: 'stats', statsSubTab: 'jobs-observatory', staticOverlay: true }, locale };
+ }
+
+ // Per-canton job-market snapshot static SEO pages (T2.5) —
+ // /cerca-lavoro-{canton}/snapshot/ (+ locale variants). Same page family as
+ // the Ticino snapshot above, one per non-TI canton. This branch was missing
+ // entirely (same failure mode as the exchange/health-facilities gaps below):
+ // hydration fell through to notFoundPath, replacing the live static HTML
+ // with the generic "Pagina non trovata" screen. Every enumerated (locale,
+ // canton) pair has a live target — full snapshot or below-floor bridge at
+ // the identical URL (renderBelowFloorBridge in the plugin) — so recognising
+ // the whole enumerable set here is safe.
+ if (isChCantonSnapshotPath(pathname)) {
+   const parsed = parseChCantonSnapshotPath(pathname);
+   return { route: { activeTab: 'stats', statsSubTab: 'jobs-observatory', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
+ }
+
+ // Google-News topic section pages (sectionPagesPlugin.ts) — /fisco/,
+ // /lavoro-frontaliere/, /salari/, /cambio-valuta/, /trasporti/,
+ // /pensioni/, /dogana/ (+ locale variants, 28 URLs total). This branch
+ // was missing entirely: 24 of the 28 fell through to the notFoundPath
+ // catch-all, and the other 4 (/fisco/, /de/steuern/, /fr/fiscalite/, plus
+ // the top-level intuitive-alias fallback) silently resolved to the LIVE
+ // interactive fisco tab instead, wiping the static article-list content
+ // on hydrate either way — same SSG-hydration-gap bug class as the
+ // exchange-rate/canton-snapshot fixes above. Placed before the
+ // REVERSE_TOP alias lookup further below so it takes priority over the
+ // accidental `/fisco/` collision too. No dedicated nav tab exists for a
+ // topic-filtered article list, so this maps onto the existing `blog` tab
+ // (closest conceptual match) with staticOverlay to keep the emitted HTML
+ // visible post-hydration.
+ if (isSectionPagePath(pathname)) {
+   const parsed = parseSectionPagePath(pathname);
+   return { route: { activeTab: 'blog', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
+ }
+
+ // Per-municipality FISCAL guide pages (epic #4482/#4484,
+ // fiscalMunicipalityPagesPlugin.ts) — hub index at
+ // /tasse-frontalieri-comune/ (+ locale variants) plus per-comune detail
+ // pages at /tasse-frontalieri-comune/{slug}/ (above-floor page OR
+ // below-floor noindex bridge, same URL either way — self-mapping, per
+ // fiscalMunicipalityData.ts). This branch was missing entirely: same
+ // SSG-hydration-gap bug class as the section-pages/canton-snapshot fixes
+ // above, hydration fell through to notFoundPath for every one of these
+ // URLs. Routed to the existing `fisco` tab — same precedent as the
+ // taxation-hub pillar page below (activeTab: 'fisco', staticOverlay:
+ // true) — since this is a tax-guide content family, not the vita/
+ // border-municipality family it cross-links.
+ if (isFiscalHubPath(pathname)) {
+   const parsed = parseFiscalHubPath(pathname);
+   return { route: { activeTab: 'fisco', staticOverlay: true }, locale: (parsed?.locale ?? locale) as Locale };
+ }
+ {
+   const parsed = parseFiscalMunicipalityPath(pathname);
+   if (parsed) {
+     return { route: { activeTab: 'fisco', staticOverlay: true }, locale: parsed.locale as Locale };
+   }
  }
 
  // Border-wait static SEO pages (F8) — /traffico-dogane/{crossing}/oggi/, hubs, archives.
@@ -2361,6 +2448,18 @@ export function parsePath(pathname: string): ParseResult {
  // issue #4301). Same static-overlay pattern as the per-canton family above.
  if (isProfessionCityPath(pathname)) {
    const parsed = parseProfessionCityPath(pathname);
+   if (parsed) {
+     return { route: { activeTab: 'job-board', staticOverlay: true }, locale: parsed.locale as Locale };
+   }
+ }
+
+ // Health-facilities hub (/strutture-sanitarie/{slug}/ + locale variants,
+ // epic #4455). This branch was missing entirely — same failure mode as the
+ // exchange-vertical bug (notFoundPath fallback + URL rewritten to '/').
+ // Static HTML emitted by healthFacilitiesPlugin; staticOverlay hydrates to
+ // the job board so the SPA doesn't replace the facility content.
+ if (isHealthFacilityPath(pathname)) {
+   const parsed = parseHealthFacilityPath(pathname);
    if (parsed) {
      return { route: { activeTab: 'job-board', staticOverlay: true }, locale: parsed.locale as Locale };
    }

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -431,6 +431,248 @@ describe('Router — author profile slug segment', () => {
   });
 });
 
+/* ─────────── CHF/EUR exchange SSG vertical (/cambio-franco-euro/) ─────────── */
+
+describe('Router — CHF/EUR exchange SSG vertical (epic #4452)', () => {
+  // Regression: parsePath never had a branch for the hub/amount pages, so
+  // hydration fell through to the notFoundPath fallback and replaced the
+  // correct static HTML with "Pagina non trovata" — plus replaceRoute()
+  // rewrote the address bar back to '/' since the resolved fallback route
+  // wasn't staticOverlay (reported live for
+  // /cambio-franco-euro/4500-franchi-in-euro/, linked from the calculator
+  // results cross-link).
+  const hubCases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/cambio-franco-euro/', locale: 'it' },
+    { path: '/en/chf-eur-exchange/', locale: 'en' },
+    { path: '/de/franken-euro-kurs/', locale: 'de' },
+    { path: '/fr/change-franc-euro/', locale: 'fr' },
+  ];
+
+  const amountCases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/cambio-franco-euro/4500-franchi-in-euro/', locale: 'it' },
+    { path: '/en/chf-eur-exchange/4500-chf-to-eur/', locale: 'en' },
+    { path: '/de/franken-euro-kurs/4500-franken-in-euro/', locale: 'de' },
+    { path: '/fr/change-franc-euro/4500-francs-en-euros/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of [...hubCases, ...amountCases]) {
+    it(`parsePath resolves ${path} to a staticOverlay confronti/exchange route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('confronti');
+      expect(route.confrontiSubTab).toBe('exchange');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('does not match the unrelated SPA comparator sub-route /compara-servizi/cambio-franco-euro/', () => {
+    // Same wording, different (SPA, non-root) path — must NOT staticOverlay.
+    const { route, notFoundPath } = parsePath('/compara-servizi/cambio-franco-euro/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBeUndefined();
+  });
+});
+
+/* ─────────── Health-facilities hub (/strutture-sanitarie/{slug}/) ─────────── */
+
+describe('Router — health-facilities hub (epic #4455)', () => {
+  // Regression: parsePath never had a branch for facility detail pages —
+  // same failure mode as the exchange-vertical bug above.
+  const cases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/strutture-sanitarie/hirslanden/', locale: 'it' },
+    { path: '/en/healthcare-facilities/hirslanden/', locale: 'en' },
+    { path: '/de/gesundheitseinrichtungen/hirslanden/', locale: 'de' },
+    { path: '/fr/etablissements-sante/hirslanden/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of cases) {
+    it(`parsePath resolves ${path} to a staticOverlay job-board route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('job-board');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('unknown facility slug does not staticOverlay (genuinely unmatched)', () => {
+    const { route, notFoundPath } = parsePath('/strutture-sanitarie/not-a-real-facility/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBe('/strutture-sanitarie/not-a-real-facility/');
+  });
+});
+
+/* ─────────── Per-canton job-market snapshot (/cerca-lavoro-{canton}/snapshot/) ─────────── */
+
+describe('Router — per-canton job-market snapshot (T2.5)', () => {
+  // Regression: parsePath never had a branch for this family — same failure
+  // mode as the exchange-vertical bug above. Uses canton AG (Aargau), a real
+  // non-TI canton emitted by jobMarketSnapshotChCantonPathsData.ts.
+  const cases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/cerca-lavoro-argovia/snapshot/', locale: 'it' },
+    { path: '/en/find-jobs-aargau/snapshot/', locale: 'en' },
+    { path: '/de/jobs-im-aargau/snapshot/', locale: 'de' },
+    { path: '/fr/trouver-emploi-argovie/snapshot/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of cases) {
+    it(`parsePath resolves ${path} to a staticOverlay stats/jobs-observatory route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('stats');
+      expect(route.statsSubTab).toBe('jobs-observatory');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('unknown canton slug does not staticOverlay (genuinely unmatched)', () => {
+    const { route, notFoundPath } = parsePath('/cerca-lavoro-narnia/snapshot/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBe('/cerca-lavoro-narnia/snapshot/');
+  });
+});
+
+/* ─────────── Per-canton "aziende che assumono" (/cerca-lavoro-{canton}/aziende-che-assumono/) ─────────── */
+
+describe('Router — per-canton weekly employers hub (finding #4)', () => {
+  // Regression: parsePath never had a branch for this family — same failure
+  // mode as the exchange-vertical bug above. Uses canton AG (Aargau), a real
+  // non-TI canton emitted by weeklyEmployersChCantonPathsData.ts.
+  const cases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/cerca-lavoro-argovia/aziende-che-assumono/', locale: 'it' },
+    { path: '/en/find-jobs-aargau/companies-hiring/', locale: 'en' },
+    { path: '/de/jobs-im-aargau/unternehmen-einstellen/', locale: 'de' },
+    { path: '/fr/trouver-emploi-argovie/entreprises-recrutent/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of cases) {
+    it(`parsePath resolves ${path} to a staticOverlay job-board route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('job-board');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('unknown canton slug does not staticOverlay (genuinely unmatched)', () => {
+    const { route, notFoundPath } = parsePath('/cerca-lavoro-narnia/aziende-che-assumono/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBe('/cerca-lavoro-narnia/aziende-che-assumono/');
+  });
+});
+
+/* ─────────── Google-News topic section pages (/fisco/, /salari/, ...) ─────────── */
+
+describe('Router — topic section pages (finding #5)', () => {
+  // Regression: parsePath never had a branch for this family. 24 of the 28
+  // URLs fell through to notFoundPath; the other 4 (/fisco/, /de/steuern/,
+  // /fr/fiscalite/ plus the bare-word alias) silently resolved to the LIVE
+  // interactive fisco tab instead of the static article-list HTML — same
+  // SSG-hydration-gap bug class either way.
+  const cases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/fisco/', locale: 'it' },
+    { path: '/en/tax/', locale: 'en' },
+    { path: '/de/steuern/', locale: 'de' },
+    { path: '/fr/fiscalite/', locale: 'fr' },
+    { path: '/lavoro-frontaliere/', locale: 'it' },
+    { path: '/en/cross-border-work/', locale: 'en' },
+    { path: '/de/grenzgaenger-arbeit/', locale: 'de' },
+    { path: '/fr/travail-frontalier/', locale: 'fr' },
+    { path: '/salari/', locale: 'it' },
+    { path: '/en/salaries/', locale: 'en' },
+    { path: '/de/loehne/', locale: 'de' },
+    { path: '/fr/salaires/', locale: 'fr' },
+    { path: '/cambio-valuta/', locale: 'it' },
+    { path: '/en/currency-exchange/', locale: 'en' },
+    { path: '/de/waehrung/', locale: 'de' },
+    { path: '/fr/change/', locale: 'fr' },
+    { path: '/trasporti/', locale: 'it' },
+    { path: '/en/transport/', locale: 'en' },
+    { path: '/de/verkehr/', locale: 'de' },
+    { path: '/fr/transports/', locale: 'fr' },
+    { path: '/pensioni/', locale: 'it' },
+    { path: '/en/pensions/', locale: 'en' },
+    { path: '/de/renten/', locale: 'de' },
+    { path: '/fr/retraites/', locale: 'fr' },
+    { path: '/dogana/', locale: 'it' },
+    { path: '/en/customs/', locale: 'en' },
+    { path: '/de/zoll/', locale: 'de' },
+    { path: '/fr/douane/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of cases) {
+    it(`parsePath resolves ${path} to a staticOverlay blog route (no notFoundPath, no live-tab swap)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('blog');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('unrelated bare-word path does not staticOverlay (genuinely unmatched)', () => {
+    const { route, notFoundPath } = parsePath('/narnia-topic/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBe('/narnia-topic/');
+  });
+});
+
+/* ─────────── Per-municipality FISCAL guide pages (epic #4482/#4484, finding #1) ─────────── */
+
+describe('Router — per-municipality fiscal guide pages (finding #1)', () => {
+  // Regression: parsePath never had a branch for this family. Every hub +
+  // per-comune detail/bridge URL fell through to notFoundPath — same
+  // SSG-hydration-gap bug class as the other findings in this suite. `como`
+  // is a real above-floor comune (indexable page), `gallarate` a real
+  // below-floor comune (noindex,follow bridge, same URL shape either way).
+  const hubCases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/tasse-frontalieri-comune/', locale: 'it' },
+    { path: '/en/cross-border-tax-municipality/', locale: 'en' },
+    { path: '/de/grenzgaenger-steuern-gemeinde/', locale: 'de' },
+    { path: '/fr/impots-frontaliers-commune/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of hubCases) {
+    it(`parsePath resolves hub ${path} to a staticOverlay fisco route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('fisco');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  const detailCases: ReadonlyArray<{ path: string; locale: string }> = [
+    { path: '/tasse-frontalieri-comune/como/', locale: 'it' },
+    { path: '/en/cross-border-tax-municipality/como/', locale: 'en' },
+    { path: '/de/grenzgaenger-steuern-gemeinde/como/', locale: 'de' },
+    { path: '/fr/impots-frontaliers-commune/como/', locale: 'fr' },
+    { path: '/tasse-frontalieri-comune/gallarate/', locale: 'it' },
+    { path: '/en/cross-border-tax-municipality/gallarate/', locale: 'en' },
+    { path: '/de/grenzgaenger-steuern-gemeinde/gallarate/', locale: 'de' },
+    { path: '/fr/impots-frontaliers-commune/gallarate/', locale: 'fr' },
+  ];
+
+  for (const { path, locale } of detailCases) {
+    it(`parsePath resolves comune page ${path} to a staticOverlay fisco route (no notFoundPath)`, () => {
+      const { route, locale: parsedLocale, notFoundPath } = parsePath(path);
+      expect(route.activeTab).toBe('fisco');
+      expect(route.staticOverlay).toBe(true);
+      expect(parsedLocale).toBe(locale);
+      expect(notFoundPath).toBeUndefined();
+    });
+  }
+
+  it('unknown comune slug does not staticOverlay (genuinely unmatched)', () => {
+    const { route, notFoundPath } = parsePath('/tasse-frontalieri-comune/narnia/');
+    expect(route.staticOverlay).toBeUndefined();
+    expect(notFoundPath).toBe('/tasse-frontalieri-comune/narnia/');
+  });
+});
+
 /* ─────────── parsePath/buildPath round-trip symmetry (issue #2698) ─────────── */
 
 /**


### PR DESCRIPTION
## Problema

Link rotto in home: `/cambio-franco-euro/4500-franchi-in-euro/` → "Pagina non trovata". Causa: `services/router.ts` `parsePath()` non riconosce l'URL a livello di hydration client-side. `buildSeoPageHtml` inietta SEMPRE il bundle SPA in ogni pagina SSG — quindi ogni famiglia di pagine statiche DEVE avere un branch in `parsePath()`, altrimenti l'hydration sostituisce l'HTML statico valido con la 404 (stessa classe di bug per più famiglie di pagine, non un caso isolato).

Per AGENTS.md #6 (sibling-pattern rule) è stata condotta una ricerca esaustiva di TUTTE le famiglie SSG prive di branch in `parsePath()`, non solo quella segnalata.

## Implementato

Aggiunto/ripristinato branch `parsePath()` (+ helper dati dedicati dove mancanti) per **6 famiglie di pagine SSG** precedentemente non riconosciute, tutte con test di regressione:

1. **Exchange rate vertical** (`/cambio-franco-euro/...`, incl. `4500-franchi-in-euro`) — `services/exchangeSsgPaths.ts` + `router.ts`. Il link originariamente segnalato.
2. **Health facilities** (per-comune, hub + dettaglio) — `build-plugins/healthFacilitiesData.ts` + `router.ts`.
3. **CH-canton job-market-snapshot** — nuovo modulo browser-safe `build-plugins/jobMarketSnapshotChCantonPathsData.ts` (split dati/nodo dal plugin), `router.ts`.
4. **Weekly-employers per-canton** — nuovo modulo browser-safe `build-plugins/weeklyEmployersChCantonPathsData.ts`, `router.ts`.
5. **Sezioni "bare"** (topic section pages) — nuovo modulo `build-plugins/sectionPagesPathsData.ts`, `router.ts`.
6. **Guide fiscali per-comune** (`/tasse-frontalieri-comune/...`, hub + above-floor + below-floor bridge) — `build-plugins/fiscalMunicipalityData.ts` + `router.ts`.

Ogni famiglia: nuovi helper `parse*Path()`/`is*Path()` (riuso pattern "reverse index" già in uso), branch `parsePath()` inserito PRIMA del matching `REVERSE_TOP` (stessa priorità delle altre famiglie SSG esistenti), route `{ staticOverlay: true }` per non rimontare `<main>` sopra l'HTML statico. 242 righe di nuovi test in `tests/router.test.ts` (13+ casi per famiglia, incl. hub/detail/locale-variant/slug-sconosciuto).

**Verifica:** `tsc --noEmit` pulito, suite `vitest` completa verde (664+ test), rebase pulito su `origin/main` (no conflitti, ri-testato verde dopo il merge).

## Non implementato (ancora)

Il pre-push hook (`check-sibling-patterns.mjs --strict`) ha segnalato 111 file non toccati che condividono token col diff. Ho ispezionato ogni candidato individualmente (non dismissal in blocco) raggruppandoli per causa verificata condivisa:

**A. Altre famiglie di pagine SSG — verificato che `router.ts` le riconosce GIÀ** (branch pre-esistenti, import già presenti prima di questa PR): `build-plugins/exchangeRatePagesPlugin.ts`, `exchangeRateSsgData.ts`, `fiscalMunicipalityPagesPlugin.ts`, `healthFacilitiesPlugin.ts`, `jobMarketSnapshotPlugin.ts`, `professionCantonData.ts`, `salaryProfessionCantonPages.ts`, `salaryStatsData.ts`, `salaryProfessionCantonData.ts`, `salaryStatsChCantonPages.ts`, `professionCantonLandings.ts`, `salaryProfessionCantonLinksPlugin.ts`, `professionCityData.ts`, `professionCityLandings.ts`, `weeklyEmployersPlugin.ts`, `weeklyEmployersData.ts`, `borderWaitPagesPlugin.ts`, `fuelDailyPagesPlugin.ts`, `shared/salaryStatsBridge.ts`, `shared/cantonSalaryIndex.ts`. Confermato via grep diretto su `services/router.ts` (import + chiamata `is*Path`/`parse*Path` per ciascuna). `exchangeRateSsgData.ts` è il modulo build-time gemello (node-context) di `services/exchangeSsgPaths.ts` (browser-safe) — split architetturale intenzionale, non duplicato morto (verificato: entrambi importati da consumer reali).

**B. Plugin "links"** (`fiscalMunicipalityLinksPlugin.ts`, `healthFacilitiesLinksPlugin.ts`) — patchano `index.html` già emesso per iniettare cross-link (`fs.writeFileSync` su pagine esistenti), non emettono URL propri instradabili. Nessun branch router necessario per definizione.

**C. Costanti di build-orchestration/display, non routing** (`shared/buildSignals.ts`, `shared/cantonDisplay.ts`, `shared/bridgeBreadcrumb.ts`, `shared/relatedLinks.ts`) — signal/resolver di sequenziamento plugin o lookup di display-name; non definiscono né consumano URL.

**D. Tabella locale duplicata pre-esistente, stessa forma ma non correlata** (`annualReportPlugin.ts`, `marketReportPlugin.ts`, `borderMunicipalityPagesPlugin.ts`, `cantonOrphanRedirectsPlugin.ts`, `companyHubBridgePlugin.ts`, `eventsSeoPagesPlugin.ts`, `jobOrphanBridgePlugin.ts`, `locationHubBridgePlugin.ts`, `relatedSearchClustersData.ts`) — match è solo perché `sectionPagesPlugin.ts` (punto 5 sopra) ha rimosso un `LOCALES`/`LOCALE_PREFIX` locale duplicato in favore dell'import condiviso; questi file hanno ciascuno la PROPRIA tabella locale duplicata pre-esistente, stessa forma generica ma nessun rapporto con l'antipattern di questa PR (branch router mancante). Deduplicarle è un refactor separato, fuori scope.

**E. Letterale `fr: 'trouver-emploi'` pre-esistente e già duplicato intenzionalmente** (`scripts/cathedral-noindex-flip.mjs`, `scripts/ci/check-below-floor-bridge.mjs`, `scripts/lib/orphan-canton-paths.mjs`, `build-plugins/shared/cantonResolvers.mjs`, `scripts/ingest-gsc-company-hubs.mjs`, `scripts/ingest-gsc-job-orphans.mjs`, `scripts/ingest-gsc-location-hubs.mjs`, `scripts/ingest-gsc-orphans-into-candidates.mjs`) — `build-plugins/jobsSeoPagesPlugin.ts` ha una propria tabella locale indipendente con lo stesso letterale (riga 1041), commentata esplicitamente da un agente precedente: "Sibling agents (jobMarketSnapshot, weeklyEmployers) are not touched" — duplicazione già adjudicata, non introdotta da questo diff.

**F. Script Node/CI/Cloud Functions/workflow — categoria strutturalmente esclusa** (non passano mai per `services/router.ts`, non hydratano nel browser, quindi non possono avere l'antipattern "branch parsePath mancante"): tutti i restanti file in `scripts/**/*.{mjs,js,ts}`, `functions/src/**`, `.github/workflows/pr-body-contract.yml` — es. `scripts/create-article.mjs`, `scripts/check-pages-publish-lag.mjs`, `scripts/lib/*`, `scripts/audit-*.mjs`, `scripts/ingest-*`, `functions/src/lib/jobBoardUrlCanton.js`, `functions/src/newsletterResendWebhookCore.js`.

**G. Componenti React / servizi client consumer, non producer di route** (consumano `activeTab`/subTab/costanti di route già esistenti, non definiscono URL SSG): `components/community/WhatsNewModal.tsx`, `BlogArticles.tsx`, `components/comparators/CurrencyExchange.tsx`, `components/pages/JobBoardStatsOverview.tsx`, `JobsSalaryObservatory.tsx`, `SiteMapPage.tsx`, `components/tabs/StatsTabContent.tsx`, `ConfrontiTabContent.tsx`, `components/community/JobBoard.tsx`, `components/guide/FrontaliereWizard.tsx`, `components/shared/SiteSearch.tsx`, `WeeklyEmployersTeaser.tsx`, `components/calculator/InputCard.tsx`, `ResultsView.tsx`, `services/internalLinks.ts`, `services/NavigationContext.ts`, `services/locales/it-seo-links.ts`, `services/frontaliereChecklist.ts`, `services/newsletterSubscribers.ts`, `services/analytics*.ts`.

**H. Consumer legittimi di `parsePath` come single-source-of-truth** (chiamano/menzionano `parsePath()` esistente, beneficiano automaticamente dei nuovi branch senza modifiche proprie — pattern corretto, non un antipattern): `hooks/useNavigationState.ts`, `hooks/seoHelpers.ts`, `services/seoService.ts`, `build-plugins/shared/hubChrome.ts`, `build-plugins/shared/clusterThinShell.ts`.

Nessun candidato ha rivelato una VERA istanza dell'antipattern (branch `parsePath()` mancante per una famiglia SSG realmente non instradata) al di fuori delle 6 già corrette in questa PR.

## Test

- `npx tsc --noEmit -p .` — pulito
- `npx vitest run` — verde (suite `router.test.ts` 573+ test incl. 13 nuovi per le fiscal-municipality pages, suite completa 664+)
- Merge pulito con `origin/main`, ri-testato dopo merge
