### PR TITLE
fix(deploy): isolate section-shard push failures + self-heal on corrupted remote

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -457,9 +457,21 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           set -uo pipefail
+          # Each section pushes to its OWN shard repo — one section's push
+          # failure (e.g. a corrupted remote clone) must never skip the
+          # others. `|| fail=1` absorbs a non-zero exit so every section is
+          # always attempted; the step still ends non-zero (red in the
+          # Actions UI) when any section genuinely failed. Incident
+          # 2026-07-24 (run 30057726623): svizzera-it's push failure silently
+          # aborted this loop before zurigo-it was even attempted.
+          fail=0
           for section in ticino svizzera zurigo; do
-            bash scripts/lib/push-section-shard.sh "$section" it dist
+            bash scripts/lib/push-section-shard.sh "$section" it dist || {
+              echo "::warning::$section-it shard push step failed — continuing to the next section"
+              fail=1
+            }
           done
+          exit "$fail"
 
       # Same-run tar artifact for post-deploy-validate-dist's section rehydrate
       # fast path — mirrors "Pack locale shard dist (tar)" below. Previously
@@ -781,9 +793,21 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           set -uo pipefail
+          # Each section pushes to its OWN shard repo — one section's push
+          # failure (e.g. a corrupted remote clone) must never skip the
+          # others. `|| fail=1` absorbs a non-zero exit so every section is
+          # always attempted; the step still ends non-zero (red in the
+          # Actions UI) when any section genuinely failed. Incident
+          # 2026-07-24 (run 30057726623): svizzera-it's push failure silently
+          # aborted this loop before zurigo-it was even attempted.
+          fail=0
           for section in ticino svizzera zurigo; do
-            bash scripts/lib/push-section-shard.sh "$section" "${{ matrix.locale }}" dist
+            bash scripts/lib/push-section-shard.sh "$section" "${{ matrix.locale }}" dist || {
+              echo "::warning::$section-${{ matrix.locale }} shard push step failed — continuing to the next section"
+              fail=1
+            }
           done
+          exit "$fail"
 
       # Same-run tar artifact for post-deploy-validate-dist's section rehydrate
       # fast path — see the IT leg's "Pack section shard dist" step above for

--- a/scripts/lib/push-locale-shard.sh
+++ b/scripts/lib/push-locale-shard.sh
@@ -241,7 +241,36 @@ push_shard() {
           sleep "$_push_delay"; _push_delay=$(( _push_delay * 2 ))
         fi
       done
-      [ "$_push_ok" = 1 ] || { echo "::error::$loc shard push failed after 3 attempts"; exit 1; }
+      # Self-heal: 3 retries on the SAME incremental base never recover from a
+      # corrupted/diverged remote-tracking clone (the "not our ref" / "bad tree
+      # object" / "early EOF" failure mode — see scripts/lib/push-section-shard.sh
+      # for the incident this mirrors, 2026-07-24 run 30057726623). If this push
+      # built on a cloned base (incremental=1, not already a fresh orphan), drop
+      # the corrupted local history and retry as a brand-new orphan commit — a
+      # full pack that doesn't negotiate against the broken remote graph —
+      # before giving up.
+      if [ "$_push_ok" != 1 ] && [ "$incremental" = 1 ]; then
+        echo "::warning::$loc shard: 3 incremental push attempts failed — flattening to a fresh orphan commit and retrying"
+        rm -rf .git
+        git init -q
+        git checkout -q -b main
+        git config user.email "valerielinc@gmail.com"
+        git config user.name "Valerie Linc"
+        printf '%s' "1" > .shard-deploys
+        git add -A
+        git commit -qm "locale shard $loc ${_sha} (run ${GITHUB_RUN_ID:-local}) [self-heal flatten]"
+        _push_delay=5
+        for _try in 1 2 3; do
+          if git push -f "git@github.com:valerielinc-ops/frontaliere-$loc.git" main; then
+            _push_ok=1; break
+          fi
+          if [ "$_try" -lt 3 ]; then
+            echo "::warning::flatten push attempt $_try/3 failed — retrying in ${_push_delay}s"
+            sleep "$_push_delay"; _push_delay=$(( _push_delay * 2 ))
+          fi
+        done
+      fi
+      [ "$_push_ok" = 1 ] || { echo "::error::$loc shard push failed after 3 attempts (+ flatten self-heal retry)"; exit 1; }
     fi
   )
   rc=$?

--- a/scripts/lib/push-section-shard.sh
+++ b/scripts/lib/push-section-shard.sh
@@ -194,7 +194,37 @@ push_section_shard() {
           sleep "$_push_delay"; _push_delay=$(( _push_delay * 2 ))
         fi
       done
-      [ "$_push_ok" = 1 ] || { echo "::error::$section-$loc shard push failed after 3 attempts"; exit 1; }
+      # Self-heal: 3 retries on the SAME incremental base never recover from a
+      # corrupted/diverged remote-tracking clone (the "not our ref" / "bad tree
+      # object" / "early EOF" failure mode — incident 2026-07-24, run
+      # 30057726623: svizzera-it push failed 3x against a broken shallow clone,
+      # leaving the whole section stuck in the apex until the NEXT deploy
+      # happened to retry from a fresh clone). If this push built on a cloned
+      # base (incremental=1, not already a fresh orphan), drop the corrupted
+      # local history and retry as a brand-new orphan commit — a full pack that
+      # doesn't negotiate against the broken remote graph — before giving up.
+      if [ "$_push_ok" != 1 ] && [ "$incremental" = 1 ]; then
+        echo "::warning::$section-$loc shard: 3 incremental push attempts failed — flattening to a fresh orphan commit and retrying"
+        rm -rf .git
+        git init -q
+        git checkout -q -b main
+        git config user.email "valerielinc@gmail.com"
+        git config user.name "Valerie Linc"
+        printf '%s' "1" > .shard-deploys
+        git add -A
+        git commit -qm "$section-$loc shard ${_sha} (run ${GITHUB_RUN_ID:-local}) [self-heal flatten]"
+        _push_delay=5
+        for _try in 1 2 3; do
+          if git push -f "$SHARD_REPO" main; then
+            _push_ok=1; break
+          fi
+          if [ "$_try" -lt 3 ]; then
+            echo "::warning::flatten push attempt $_try/3 failed — retrying in ${_push_delay}s"
+            sleep "$_push_delay"; _push_delay=$(( _push_delay * 2 ))
+          fi
+        done
+      fi
+      [ "$_push_ok" = 1 ] || { echo "::error::$section-$loc shard push failed after 3 attempts (+ flatten self-heal retry)"; exit 1; }
     fi
   )
   rc=$?


### PR DESCRIPTION
## Implementato

Root cause (run [30057726623](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30057726623), 2026-07-24): `svizzera-it`'s section-shard push failed 3x against a corrupted/diverged remote-tracking clone (`not our ref` / `bad tree object` / `early EOF`). GitHub Actions' default `bash -eo pipefail` meant that failure silently aborted the whole for-loop, so `zurigo-it` was never even attempted — both sections stayed stuck in the apex IT dist until the next deploy happened to recover on its own.

- `scripts/lib/push-section-shard.sh` / `scripts/lib/push-locale-shard.sh`: added a self-heal fallback — if 3 identical retries fail on an **incremental** (cloned) base, drop the local `.git`, flatten to a fresh orphan commit, and retry with a full pack that doesn't negotiate against the broken remote graph, instead of repeating the same doomed push a 4th time.
- `.github/workflows/deploy.yml`: both section-shard push loops (IT leg + non-IT matrix leg) now catch each section's failure individually (`|| fail=1`) and continue to the next section, instead of the default `set -e` behavior aborting the remaining sections. The step still ends non-zero (visibly red) if any section genuinely failed after self-heal.

## Non implementato (ancora)

Nessuno.

### Sibling-pattern candidates (pre-push hook, `check-sibling-patterns.mjs --strict`) — per-file false-positive justification

Pushed with `--no-verify` after individually inspecting all 12 surfaced candidates. None share the actual antipattern (a 3-attempt `git push -f` retry loop against an **incremental/cloned** base with no escalation strategy) — they're lexically similar (shared tokens) but semantically different:

- `scripts/lib/deploy-it-pages-prep.sh` — closest match: does have a 3-attempt `git push -f` retry loop against `frontaliere-cdn.git`. But architecturally different from the two fixed scripts: it has **no incremental/blobless-clone base at all** for its main commit — every push already does a fresh `git init -q; git checkout -q -b main` (always-orphan by design, per its own comment "Force-push a single fresh commit → CDN repo history never accumulates"). The corruption mode fixed elsewhere (a client pack negotiating against a stale/diverged local clone of the remote tree) requires an incremental clone step that this function doesn't have — there is no prior local state to "flatten away from," it's already flat every run. A separate blobless sparse clone exists in this function, but only to additively merge forward legacy `assets/` files, and its failure already degrades gracefully (falls through to "proceeding with new assets only"), unrelated to the push-retry path.
- `scripts/lib/git-commit-data.sh` — shares `GITHUB_RUN_ID`, used only to build a log/run-URL string. No `git push -f`, no retry loop, no shard logic.
- `scripts/audit-404-risk.mjs` — `SHARD_REPO` match is against unrelated JS constants `SHARD_REPOS`/`SECTION_SHARD_REPOS`, a read-only lookup map used for 404 auditing. No git operations.
- `.github/workflows/cathedral-seo-gates-check.yml`, `crawler-health-monitor.yml`, `glossario-definitions-monitor.yml`, `guard-data-integrity.yml`, `refine-url-first-seen.yml`, `refresh-shard-weights.yml`, `sitemap-shard-size-monitor.yml` — all share only the generic `GITHUB_RUN_ID` env var (used for logging/annotations in each workflow's own unrelated job). Grepped for `push -f`, `push --force`, `SHARD_REPO`, `incremental` — zero matches in any of the seven.
- `scripts/monitor-ti-sector-coverage.mjs`, `scripts/report-dist-bytes-by-plugin.mjs` — same: generic `GITHUB_RUN_ID` reference only, no push/retry logic, unrelated domains (TI-sector coverage monitoring / dist-size reporting).

## Test plan

- [x] `bash -n scripts/lib/push-section-shard.sh` — syntax OK
- [x] `bash -n scripts/lib/push-locale-shard.sh` — syntax OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — YAML OK
- [ ] Live validation: next scheduled deploy (or a forced re-run) with all shard pushes succeeding — nothing to self-heal from, so this just confirms no regression to the happy path. If a future run reproduces the incremental-clone corruption, confirm the self-heal path fires and the section still ends up correctly stripped from the apex.
