### PR TITLE
fix(crawlers): stop emitting non-canonical/mismatched cantons across all job crawlers

### DIFF
--- a/.github/workflows/location-quality-audit.yml
+++ b/.github/workflows/location-quality-audit.yml
@@ -1,0 +1,130 @@
+name: location-quality-audit
+
+# Weekly deterministic check of crawled job location quality
+# (scripts/audit-job-locations.mjs): how many jobs have a canton that
+# mismatches the BFS-inferred canton, how many have a city that matches no
+# canonical Swiss location ("custom" value — the bug class behind the
+# reported Hirslanden Bern instances), and how many silently fall back to
+# their company's own most-common ("default") canton. Opens/updates ONE
+# stable-title tracking issue every run with the numeric snapshot so the
+# trend is visible over time. This is NOT a deploy gate — report-only, same
+# shape as audit-404-risk.yml. Zero-Claude (deterministic script + node/gh
+# issue creation).
+
+on:
+  schedule:
+    - cron: '10 9 * * 3' # Wednesdays 09:10 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: location-quality-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      # data/jobs.json is gitignored (build artifact). Assemble it from the
+      # committed per-crawler slices so the audit sees every real crawler,
+      # not just whatever happens to be checked in.
+      - name: Assemble jobs dataset
+        run: node scripts/assemble-jobs-dataset.mjs
+
+      - name: Run location quality audit
+        id: audit
+        continue-on-error: true
+        run: npm run audit:job-locations
+
+      - name: Upload full report (per-job detail)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: location-audit-report
+          path: data/location-audit-report.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Open / update issue with numeric snapshot
+        if: steps.audit.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/r
+
+          node --input-type=module - <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const r = JSON.parse(readFileSync('data/location-audit-report.json', 'utf8'));
+          const s = r.summary;
+          const pct = (n) => (r.audited > 0 ? ((n / r.audited) * 100).toFixed(2) : '0.00');
+          const hasRealBugs = s.cantonMismatch > 0 || s.foreignInSwiss > 0;
+
+          let md = `## Location data quality snapshot\n\n`;
+          md += `Audited ${r.audited} / ${r.totalJobs} jobs (geocoding ${r.geocodingEnabled ? 'ON' : 'OFF'}).\n\n`;
+          md += `| Metric | Count | % of audited |\n|---|---:|---:|\n`;
+          md += `| ✅ Correct (BFS-confirmed) | ${s.correct} | ${pct(s.correct)}% |\n`;
+          md += `| ⚠️ Canton mismatch (BFS disagrees with stored canton) | ${s.cantonMismatch} | ${pct(s.cantonMismatch)}% |\n`;
+          md += `| 🚨 Foreign city tagged as Swiss canton | ${s.foreignInSwiss} | ${pct(s.foreignInSwiss)}% |\n`;
+          md += `| ❓ Custom/unknown location (matches no canonical Swiss location) | ${s.customLocation} | ${pct(s.customLocation)}% |\n`;
+          md += `| 🏢 Suspected company-default fallback | ${s.companyDefaultFallback} | ${pct(s.companyDefaultFallback)}% |\n`;
+          md += `| 📭 Empty location | ${s.emptyLocation} | ${pct(s.emptyLocation)}% |\n`;
+          md += `| 🔤 Lowercase canton (stored) | ${s.lowercaseCanton} | ${pct(s.lowercaseCanton)}% |\n\n`;
+          md += hasRealBugs
+            ? `🚨 **Canton mismatch and/or foreign-tagged-as-Swiss are non-zero** — these are the two categories a crawler must never produce (location must always resolve to a real Swiss canton, not a stored-but-wrong one). Check the full report artifact for offending companies/cities.\n\n`
+            : `No canton-mismatch / foreign-tagged-as-Swiss bugs this run.\n\n`;
+          md += `**Run:** ${process.env.RUN_URL}\n`;
+          md += `Full per-job detail: \`location-audit-report\` workflow artifact (30-day retention).\n`;
+          md += `Script: \`scripts/audit-job-locations.mjs\`\n`;
+          writeFileSync('/tmp/r/desc.md', md);
+          writeFileSync('/tmp/r/has-bugs', hasRealBugs ? '1' : '0');
+          NODE
+
+          if [ "$(cat /tmp/r/has-bugs)" = "1" ]; then
+            node scripts/lib/github-issue-creator.mjs \
+              --title "Location data quality: weekly snapshot" \
+              --description "$(cat /tmp/r/desc.md)" \
+              --priority 3 \
+              --label crawler-data-quality \
+              --label bug \
+              --workflow "${{ github.workflow }}"
+          else
+            node scripts/lib/github-issue-creator.mjs \
+              --title "Location data quality: weekly snapshot" \
+              --description "$(cat /tmp/r/desc.md)" \
+              --priority 4 \
+              --label crawler-data-quality \
+              --workflow "${{ github.workflow }}"
+          fi
+
+      - name: Report audit crash to GitHub Issues
+        if: steps.audit.outcome != 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Location quality audit crashed
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Il job \`scripts/audit-job-locations.mjs\` è uscito con errore — nessuno snapshot numerico prodotto questo run. Verifica \`data/jobs.json\` assemblato correttamente e il log del job." \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"
+
+      - name: Fail job if audit crashed
+        if: steps.audit.outcome != 'success'
+        run: |
+          echo "::error::location quality audit crashed — see issue opened above."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ data/all-known-job-slugs.json
 data/job-canton-pins.json
 data/jobs-crawler-audit.json
 data/jobs-stats.json
+data/location-audit-report.json
 # data/jobs-ai-cache.json — tracked: shared crawler AI response cache, persists across CI runs
 public/data/jobs.json
 public/data/jobs-stats.json

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -163,8 +163,9 @@ import {
  buildEmployerHubMeta,
  buildRoleHubMeta,
 } from '../services/seo/meta-descriptions';
-import { COMPANY_HQ_ADDRESSES, localityMatchesHq } from './shared/companyHqAddresses';
-import { buildJobPostingSchema, type JobInput } from './shared/jobPostingSchema';
+import { COMPANY_HQ_ADDRESSES, CANTON_CAPITAL_ADDRESSES, localityMatchesHq } from './shared/companyHqAddresses';
+import { buildJobPostingSchema, sanitizeLocalityForRegion, type JobInput } from './shared/jobPostingSchema';
+import { normalizeCantonCode, inferAnyCanton } from '../scripts/lib/target-swiss-locations.mjs';
 import { buildListItemJobPosting } from './shared/jobPostingListItem';
 import { startTimer, recordEmit, phaseTimer, recordPhase, printSummary as printJobsSeoProfile } from './shared/jobsSeoProfiler.ts';
 import { resolveJobsSeoPagesFlushed } from './shared/buildSignals';
@@ -527,6 +528,45 @@ export function pickJobDisambiguator(
  return '';
 }
 
+// Change DEFAULT_CANTON to expand the primary target region — see
+// scripts/lib/crawler-location-config.mjs for the central switch. Module
+// scope (not closure-local) so deriveJobCanton/deriveJobAddressLocality can
+// use it as their ultimate fallback and stay independently unit-testable.
+const DEFAULT_CANTON = 'TI';
+const DEFAULT_CANTON_DISPLAY = 'Ticino';
+
+/**
+ * Resolve a job's canton code. Explicit `job.canton`/`job.addressRegion` is
+ * trusted only when it's a REAL Swiss canton code (`normalizeCantonCode`
+ * validates against the 26-canton registry, not just a bare 2-letter regex);
+ * otherwise the canton is inferred from the location text via the same
+ * BFS-backed registry used by the central JobPosting schema fix
+ * (`sanitizeLocalityForRegion` in `./shared/jobPostingSchema`), so a job
+ * page can never derive a canton the crawler fleet doesn't actually cover.
+ */
+export function deriveJobCanton(job: Record<string, unknown>): string {
+ const explicit = normalizeCantonCode(String(job.canton || job.addressRegion || ''));
+ if (explicit) return explicit;
+ const inferred = inferAnyCanton(String(job.addressLocality || job.location || ''));
+ return inferred || DEFAULT_CANTON;
+}
+
+/**
+ * Resolve the locality text safe to render/emit for a job, given its
+ * already-derived canton `region`. A garbage/leaked free-text locality or a
+ * real city from the WRONG canton is rejected (via the shared
+ * `sanitizeLocalityForRegion`) before falling through to `job.location`
+ * (same check) and finally the canton capital's own locality name — never a
+ * bare, unvalidated crawler string.
+ */
+export function deriveJobAddressLocality(job: Record<string, unknown>, region: string): string {
+ const fromLocality = sanitizeLocalityForRegion(String(job.addressLocality || ''), region);
+ if (fromLocality) return fromLocality;
+ const fromLocation = sanitizeLocalityForRegion(String(job.location || ''), region);
+ if (fromLocation) return fromLocation;
+ return CANTON_CAPITAL_ADDRESSES[region]?.addressLocality || DEFAULT_CANTON_DISPLAY;
+}
+
 // Local feature flag: strip generic SEO prose ("Informazioni per frontalieri",
 // "Domande frequenti", "Mercato del lavoro in Ticino") from expired-job
 // static pages. Default ON (set STRIP_EXPIRED_JOB_PROSE=0 to keep prose).
@@ -603,11 +643,11 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const cacheDateStamp = new Date().toISOString().slice(0, 10);
 
  // ─── Parameterized defaults ──────────────────────────────────────────
- // Change DEFAULT_CANTON to expand the primary target region.
- // See scripts/lib/crawler-location-config.mjs for the central switch.
- const DEFAULT_CANTON = 'TI';
+ // DEFAULT_CANTON / DEFAULT_CANTON_DISPLAY are module-level (see above
+ // deriveJobCanton/deriveJobAddressLocality). Change them there to expand
+ // the primary target region — see scripts/lib/crawler-location-config.mjs
+ // for the central switch.
  const DEFAULT_POSTAL_CODE = '6900';
- const DEFAULT_CANTON_DISPLAY = 'Ticino';
 
  /**
   * Canton URL slugs sourced from data/canton-url-slugs.json (P1.1 cathedral).
@@ -1889,49 +1929,11 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  'SH': 'Bahnhofstrasse 1', 'SO': 'Hauptgasse 1', 'BL': 'Marktplatz 1',
  };
 
- /** City name → canton code for deriving addressRegion from location */
- const CITY_TO_CANTON: Record<string, string> = {
- // Ticino
- 'lugano': 'TI', 'bellinzona': 'TI', 'locarno': 'TI', 'mendrisio': 'TI', 'chiasso': 'TI',
- 'biasca': 'TI', 'agno': 'TI', 'manno': 'TI', 'stabio': 'TI', 'giubiasco': 'TI',
- 'ascona': 'TI', 'paradiso': 'TI', 'massagno': 'TI', 'cadenazzo': 'TI', 'mezzovico': 'TI',
- 'balerna': 'TI', 'bedano': 'TI', 'airolo': 'TI', 'faido': 'TI', 'rivera': 'TI',
- // Graubünden
- 'chur': 'GR', 'coira': 'GR', 'davos': 'GR', 'st. moritz': 'GR', 'landquart': 'GR',
- 'ilanz': 'GR', 'thusis': 'GR', 'poschiavo': 'GR', 'samedan': 'GR',
- // Major Swiss cities
- 'zürich': 'ZH', 'zurich': 'ZH', 'zurigo': 'ZH', 'winterthur': 'ZH', 'kloten': 'ZH',
- 'dübendorf': 'ZH', 'dietlikon': 'ZH',
- 'bern': 'BE', 'berna': 'BE', 'thun': 'BE', 'interlaken': 'BE',
- 'basel': 'BS', 'basilea': 'BS',
- 'genève': 'GE', 'ginevra': 'GE', 'genf': 'GE', 'geneva': 'GE', 'plan-les-ouates': 'GE',
- 'lausanne': 'VD', 'losanna': 'VD',
- 'luzern': 'LU', 'lucerna': 'LU', 'lucerne': 'LU',
- 'st. gallen': 'SG', 'san gallo': 'SG', 'gossau': 'SG',
- 'aarau': 'AG', 'baden': 'AG', 'lenzburg': 'AG',
- 'fribourg': 'FR', 'friburgo': 'FR',
- 'neuchâtel': 'NE',
- 'zug': 'ZG',
- 'schaffhausen': 'SH',
- 'solothurn': 'SO', 'olten': 'SO',
- 'frauenfeld': 'TG',
- 'sion': 'VS', 'brig': 'VS', 'visp': 'VS', 'sierre': 'VS', 'martigny': 'VS',
- };
-
- /** Derive canton code from job location/addressLocality, falling back to job.canton or DEFAULT_CANTON */
- const deriveCanton = (job: any): string => {
- const explicitCanton = String(job.canton || job.addressRegion || '').toUpperCase().trim();
- if (explicitCanton && explicitCanton.length === 2 && /^[A-Z]{2}$/.test(explicitCanton)) return explicitCanton;
- // Try to infer from city names
- const candidates = [
- ...normaliseCityName(String(job.addressLocality || '')),
- ...normaliseCityName(String(job.location || '')),
- ];
- for (const c of candidates) {
- if (CITY_TO_CANTON[c]) return CITY_TO_CANTON[c];
- }
- return DEFAULT_CANTON;
- };
+ // City→canton dict + regex-only explicit-canton acceptance replaced by the
+ // module-level deriveJobCanton (validated against the real 26-canton
+ // registry + BFS city inference — see above; eliminates this hand-rolled
+ // ~50-city duplicate, AGENTS.md #6).
+ const deriveCanton = deriveJobCanton;
 
  /** Derive streetAddress from job data, company HQ, or city generic.
  * Always returns a street address (canton capital as last resort). */
@@ -1970,8 +1972,11 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  for (const c of candidates) {
  if (CITY_GENERIC_ADDRESS[c]) return CITY_GENERIC_ADDRESS[c];
  }
- // 7. Canton capital fallback — always produces a result
- const canton = String(job.canton || job.addressRegion || DEFAULT_CANTON).toUpperCase().trim();
+ // 7. Canton capital fallback — always produces a result. Uses the
+ // validated deriveCanton (not a raw job.canton||job.addressRegion
+ // regex-only read) so an untrusted well-formed-but-wrong canton code
+ // never picks the wrong capital street (same bug class as #6 above).
+ const canton = deriveCanton(job);
  return CANTON_CAPITAL_ADDRESS[canton] || CANTON_CAPITAL_ADDRESS[DEFAULT_CANTON] || 'Piazza Governo';
  };
  // Map internal category strings to O*NET-SOC major group codes for Google Jobs.
@@ -2619,9 +2624,12 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  ? Number(job.salaryMax)
  : Number(job?.baseSalary?.value?.maxValue);
  const perJob_salaryCurrency = String(job.currency || job?.baseSalary?.currency || job?.baseSalary?.value?.currency || 'CHF');
- const perJob_rawLocality = String(job.addressLocality || '').trim();
- const perJob_addressLocality = isValidAddress(perJob_rawLocality) ? perJob_rawLocality : String(job.location || DEFAULT_CANTON_DISPLAY);
+ // Region resolved FIRST: addressLocality must agree with it, not the
+ // other way round (a garbage/wrong-canton locality is what leaked into
+ // visible HTML — reported bug — since this render path bypassed the
+ // central JobPosting schema sanitizer entirely until now).
  const perJob_addressRegion = deriveCanton(job);
+ const perJob_addressLocality = deriveJobAddressLocality(job, perJob_addressRegion);
  const perJob_addressCountry = String(job.addressCountry || 'CH');
  const perJob_postalCode = deriveJobPostalCode(job);
  const perJob_streetAddress = deriveStreetAddress(job);

--- a/build-plugins/salaryProfessionCantonPages.ts
+++ b/build-plugins/salaryProfessionCantonPages.ts
@@ -36,6 +36,7 @@ import { buildDayStampIso } from './shared/buildDayStamp';
 import { cleanSitemapFiles } from './shared/distNamespaceCleanup';
 import { CALC_HREF } from './shared/calcHref';
 import { getCantonDisplayName, type CantonDisplayLocale } from './shared/cantonDisplay';
+import { normalizeCantonCode } from '../scripts/lib/target-swiss-locations.mjs';
 import {
   renderCantonSeoProse,
   buildCantonSeoProseFaqItems,
@@ -411,7 +412,7 @@ function featuredToJobInput(job: FeaturedJob) {
 
 /** Canonical detail-page URL for a featured job in the target locale. */
 function jobDetailUrl(job: FeaturedJob, locale: ProfessionLocale, cantonKey: string): string {
-  const code = job.canton && /^[A-Z]{2}$/.test(job.canton) ? job.canton : factorCode(cantonKey);
+  const code = normalizeCantonCode(job.canton) || factorCode(cantonKey);
   const section = resolveCantonSection(locale as CantonSeoLocale, code);
   const slug = job.slugByLocale[locale] ?? job.slug;
   const rel = `${PROFESSION_LOCALE_PREFIX[locale]}/${section}/${slug}/`.replace(/\/+/g, '/');

--- a/build-plugins/shared/companyHqAddresses.ts
+++ b/build-plugins/shared/companyHqAddresses.ts
@@ -13,6 +13,8 @@
  * CLAUDE.md rule #3).
  */
 
+import { inferAnyCanton } from '../../scripts/lib/target-swiss-locations.mjs';
+
 export interface CompanyHqAddress {
   streetAddress: string;
   postalCode: string;
@@ -147,67 +149,24 @@ export const CANTON_CAPITAL_ADDRESSES: Record<string, CompanyHqAddress> = {
 };
 
 /**
- * City name (lowercased, diacritics-tolerant) → Swiss canton code.
- * Used to derive `jobLocation.address.addressRegion` when the job's source
- * data lacks an explicit canton. Required by Google Search Console for
- * JobPosting rich-result quality (missing addressRegion is a non-critical
- * issue but counted in the GSC report — we treat it as deploy-blocking).
- */
-export const CITY_TO_CANTON: Record<string, string> = {
-  // Ticino
-  'lugano': 'TI', 'bellinzona': 'TI', 'locarno': 'TI', 'mendrisio': 'TI', 'chiasso': 'TI',
-  'biasca': 'TI', 'agno': 'TI', 'manno': 'TI', 'stabio': 'TI', 'giubiasco': 'TI',
-  'ascona': 'TI', 'paradiso': 'TI', 'massagno': 'TI', 'cadenazzo': 'TI', 'mezzovico': 'TI',
-  'balerna': 'TI', 'bedano': 'TI', 'airolo': 'TI', 'faido': 'TI', 'rivera': 'TI',
-  'castione': 'TI', 'arbedo': 'TI', 'pregassona': 'TI', 'montagnola': 'TI', 'castel san pietro': 'TI',
-  'quartino': 'TI', 's. antonino': 'TI', 'sant antonino': 'TI', 'ticino': 'TI',
-  // Graubünden
-  'chur': 'GR', 'coira': 'GR', 'davos': 'GR', 'st. moritz': 'GR', 'landquart': 'GR',
-  'ilanz': 'GR', 'thusis': 'GR', 'poschiavo': 'GR', 'samedan': 'GR',
-  // Major Swiss cities
-  'zürich': 'ZH', 'zurich': 'ZH', 'zurigo': 'ZH', 'winterthur': 'ZH', 'kloten': 'ZH',
-  'dübendorf': 'ZH', 'dietlikon': 'ZH',
-  'bern': 'BE', 'berna': 'BE', 'thun': 'BE', 'interlaken': 'BE',
-  'basel': 'BS', 'basilea': 'BS',
-  'genève': 'GE', 'ginevra': 'GE', 'genf': 'GE', 'geneva': 'GE', 'plan-les-ouates': 'GE',
-  'lausanne': 'VD', 'losanna': 'VD',
-  'luzern': 'LU', 'lucerna': 'LU', 'lucerne': 'LU',
-  'st. gallen': 'SG', 'san gallo': 'SG', 'gossau': 'SG', 'niederbüren': 'SG',
-  'aarau': 'AG', 'baden': 'AG', 'lenzburg': 'AG',
-  'fribourg': 'FR', 'friburgo': 'FR',
-  'neuchâtel': 'NE',
-  'zug': 'ZG',
-  'schaffhausen': 'SH',
-  'solothurn': 'SO', 'olten': 'SO',
-  'frauenfeld': 'TG',
-  'sion': 'VS', 'brig': 'VS', 'visp': 'VS', 'sierre': 'VS', 'martigny': 'VS',
-};
-
-/**
  * Default Swiss canton when no other signal is available. Site is
  * Ticino-focused, so falling back to TI keeps the structured-data legal.
  */
 export const DEFAULT_CANTON_REGION = 'TI';
 
 /**
- * Derive canton (addressRegion) from a city name. Returns `DEFAULT_CANTON_REGION`
- * when the city is unknown — never returns empty.
+ * Derive canton (addressRegion) from a city name via the shared BFS-backed
+ * `inferAnyCanton` (all 26 cantons, fuzzy-tolerant — same source of truth as
+ * `resolveCanton()` in jobPostingSchema.ts and `deriveJobCanton()` in
+ * jobsSeoPagesPlugin.ts). Returns `DEFAULT_CANTON_REGION` when the city is
+ * unknown — never returns empty. A hand-rolled ~50-city dict + manual
+ * parenthetical/segment splitter previously lived here (AGENTS.md #6 sibling
+ * class); `inferAnyCanton` already handles decorated localities like
+ * "Geneva (Genève)" or "Chur, Graubünden" natively.
  */
 export function deriveCantonFromCity(city: string | undefined | null): string {
   if (!city) return DEFAULT_CANTON_REGION;
-  const raw = String(city).trim().toLowerCase();
-  if (CITY_TO_CANTON[raw]) return CITY_TO_CANTON[raw];
-  // Tolerate decorated localities like "Geneva (Genève)" or "Chur, Graubünden"
-  // by probing the bare name and any parenthetical/segment variant.
-  const candidates = new Set<string>();
-  const paren = raw.match(/\(([^)]+)\)/);
-  if (paren) candidates.add(paren[1].trim());
-  candidates.add(raw.replace(/\([^)]*\)/g, '').trim());
-  for (const segment of raw.split(/[,·/]/)) candidates.add(segment.trim());
-  for (const candidate of candidates) {
-    if (candidate && CITY_TO_CANTON[candidate]) return CITY_TO_CANTON[candidate];
-  }
-  return DEFAULT_CANTON_REGION;
+  return inferAnyCanton(String(city)) || DEFAULT_CANTON_REGION;
 }
 
 /**
@@ -264,12 +223,19 @@ export function regionLocalityCapital(city: string | undefined | null): CompanyH
  * Lookup a fallback HQ address by company slug, then by city name, with a
  * final canton-capital guarantee. Always returns a fully populated address —
  * never returns empty strings (CLAUDE.md rule #3).
+ *
+ * `authoritativeRegion`, when passed, overrides the city-derived canton —
+ * callers that already resolved a trustworthy canton (e.g. from an explicit
+ * addressRegion field) should pass it so this fallback stays consistent with
+ * that canton instead of re-deriving one from `city` (which may be empty or
+ * have just been rejected as inconsistent by the caller).
  */
 export function resolveFallbackAddress(
   companySlug: string | undefined,
   city: string | undefined,
+  authoritativeRegion?: string,
 ): CompanyHqAddress {
-  const cityCanton = deriveCantonFromCity(city);
+  const cityCanton = authoritativeRegion || deriveCantonFromCity(city);
   if (companySlug) {
     const hq = COMPANY_HQ_ADDRESSES[companySlug.toLowerCase()];
     // Only trust the curated HQ when the job has no own city or sits in the

--- a/build-plugins/shared/jobPostingSchema.ts
+++ b/build-plugins/shared/jobPostingSchema.ts
@@ -32,6 +32,11 @@ import {
   resolveFallbackAddress,
 } from './companyHqAddresses';
 import {
+  isKnownSwissCity,
+  inferAnyCanton,
+  normalizeCantonCode,
+} from '../../scripts/lib/target-swiss-locations.mjs';
+import {
   DEFAULT_POSTAL_CODE,
   isValidPostalCode,
   resolvePostalCode,
@@ -373,9 +378,32 @@ function resolveCompanyName(job: JobInput, locale: string): string {
 
 /** Derive the schema.org canton code for the job. */
 function resolveCanton(job: JobInput): string {
-  const explicit = String(job.addressRegion || job.canton || '').toUpperCase().trim();
-  if (/^[A-Z]{2}$/.test(explicit)) return explicit;
-  return deriveCantonFromCity(job.addressLocality || job.city || job.location || '');
+  const explicit = normalizeCantonCode(String(job.addressRegion || job.canton || ''));
+  if (explicit) return explicit;
+  const locationText = String(job.addressLocality || job.city || job.location || '');
+  return inferAnyCanton(locationText) || deriveCantonFromCity(locationText);
+}
+
+/**
+ * Reject a locality candidate that is not a real, known Swiss city (BFS
+ * registry, all 26 cantons) or that names a city belonging to a DIFFERENT
+ * canton than `region` — otherwise a JobPosting/visible page pairs an
+ * incoherent locality with its region (e.g. "Bellinzona" text next to
+ * addressRegion "BE"). A region name shipped as locality ("Ticino") is
+ * substituted with the canton capital's coherent locality first. Garbage or
+ * leaked free-text fails `isKnownSwissCity`; a real-but-wrong-canton city
+ * fails the canton-agreement check. Returns '' when the raw value must NOT
+ * be trusted — callers supply their own fallback (company HQ, city lookup,
+ * canton-capital).
+ */
+export function sanitizeLocalityForRegion(rawLocality: string, region: string): string {
+  let cityRaw = String(rawLocality || '').trim();
+  const regionCapital = regionLocalityCapital(cityRaw);
+  if (regionCapital) cityRaw = regionCapital.addressLocality;
+  if (!cityRaw || !isKnownSwissCity(cityRaw)) return '';
+  const cityCanton = inferAnyCanton(cityRaw);
+  if (cityCanton && cityCanton.toUpperCase() !== String(region || '').toUpperCase()) return '';
+  return cityRaw;
 }
 
 /** Resolve the PostalAddress with every field guaranteed non-empty. */
@@ -385,14 +413,15 @@ function resolveAddress(
   locale: string,
 ): PostalAddressSchema {
   const companySlug = job.companySlug || job.companyKey || '';
-  let cityRaw = String(
+  const rawCity = String(
     job.addressLocality || job.city || job.location || '',
   ).trim();
-  // #3513: a REGION name shipped as locality ("Ticino") is not a schema.org
-  // locality — substitute the canton capital's coherent locality so
-  // street/CAP/locality all anchor on one real place.
-  const regionCapital = regionLocalityCapital(cityRaw);
-  if (regionCapital) cityRaw = regionCapital.addressLocality;
+
+  // resolveCanton() always resolves (deriveCantonFromCity defaults to
+  // DEFAULT_CANTON_REGION when nothing else matches), so it is the sole
+  // source of `region` here.
+  const region = resolveCanton(job);
+  const cityRaw = sanitizeLocalityForRegion(rawCity, region);
 
   const hqEntry = companySlug
     ? COMPANY_HQ_ADDRESSES[companySlug.toLowerCase()]
@@ -401,9 +430,8 @@ function resolveAddress(
   const fallback = resolveFallbackAddress(
     companySlug ? companySlug.toLowerCase() : undefined,
     cityRaw ? cityRaw.toLowerCase() : undefined,
+    region,
   );
-
-  const region = resolveCanton(job) || fallback.addressRegion;
 
   const addressLocality =
     cityRaw.length > 0 ? cityRaw : fallback.addressLocality;

--- a/data/jobs/by-crawler/publisher-submitted.json
+++ b/data/jobs/by-crawler/publisher-submitted.json
@@ -1,6 +1,6 @@
 {
   "crawlerKey": "publisher-submitted",
-  "assembledAt": "2026-07-24T07:05:59.695Z",
+  "assembledAt": "2026-07-24T09:44:10.761Z",
   "jobs": [
     {
       "title": "Fisioterapista con riconoscimento CRS",
@@ -29,21 +29,18 @@
       "description": "Cercasi fisioterapista con riconoscimento CRS, automunita/o, per attività sia ambulatoriale sia domiciliare. Data d'inizio da concordare. Percentuale d'impiego: 50%.\n\nInviare CV e lettera di presentazione a: fisiocare.lugano@gmail.com\n\nSiamo un'azienda attiva prevalentemente nel Luganese, operante in ambito ambulatoriale e domiciliare, che segue pazienti respiratori, ortopedici e oncologici.\n\nCerchiamo una persona motivata, disponibile a lavorare in team.\n\nOffriamo un ambiente di lavoro dinamico e buone condizioni d'impiego.",
       "titleByLocale": {
         "it": "Fisioterapista con riconoscimento CRS",
-        "en": "Physiotherapist with CRS recognition",
-        "de": "Physiotherapeut mit CRS-Erkennung",
-        "fr": "Physiothérapeute reconnu CRS"
+        "en": "Fisioterapista con riconoscimento CRS",
+        "de": "Fisioterapista con riconoscimento CRS",
+        "fr": "Fisioterapista con riconoscimento CRS"
       },
       "slugByLocale": {
         "it": "fisioterapista-con-riconoscimento-crs-fisiocare-sagl-fisiocare-sagl",
-        "en": "physiotherapist-with-crs-recognition-fisiocare-sagl-fisiocare-sagl",
-        "de": "physiotherapeut-mit-crs-erkennung-fisiocare-sagl-fisiocare-sagl",
-        "fr": "physiotherapeute-reconnu-crs-fisiocare-sagl-fisiocare-sagl"
+        "en": "fisioterapista-con-riconoscimento-crs-fisiocare-sagl-fisiocare-sagl",
+        "de": "fisioterapista-con-riconoscimento-crs-fisiocare-sagl-fisiocare-sagl",
+        "fr": "fisioterapista-con-riconoscimento-crs-fisiocare-sagl-fisiocare-sagl"
       },
       "descriptionByLocale": {
-        "it": "Cercasi fisioterapista con riconoscimento CRS, automunita/o, per attività sia ambulatoriale sia domiciliare. Data d'inizio da concordare. Percentuale d'impiego: 50%.\n\nInviare CV e lettera di presentazione a: fisiocare.lugano@gmail.com\n\nSiamo un'azienda attiva prevalentemente nel Luganese, operante in ambito ambulatoriale e domiciliare, che segue pazienti respiratori, ortopedici e oncologici.\n\nCerchiamo una persona motivata, disponibile a lavorare in team.\n\nOffriamo un ambiente di lavoro dinamico e buone condizioni d'impiego.",
-        "en": "Seek physiotherapist with CRS recognition, automunita/o, for both outpatient and domicile activities. Start date to be agreed. Percentage of use: 50%.\n\nSend CV and presentation letter to: fisiocare.lugano@gmail.com\n\nWe are an active company mainly in Luganese, operating in the ambulatory and domiciliary sector, which follows respiratory, orthopaedic and oncologic patients.\n\nWe are looking for a motivated person, available to work in team.\n\nWe offer a dynamic working environment and good conditions of use.",
-        "de": "Suchen Sie Physiotherapeuten mit CRS-Erkennung, Automunita / o, sowohl für ambulante als auch für Domizilaktivitäten. Startdatum wird vereinbart. Prozentsatz der Nutzung: 50%.\n\nSenden Sie Lebenslauf und Präsentationsschreiben an: fisiocare.lugano@gmail.com\n\nWir sind ein aktives Unternehmen hauptsächlich in Luganese, das im ambulanten und häuslichen Bereich tätig ist und Atemwegs-, orthopädische und onkologische Patienten begleitet.\n\nWir suchen eine motivierte Person, die im Team arbeiten kann.\n\nWir bieten ein dynamisches Arbeitsumfeld und gute Nutzungsbedingungen.",
-        "fr": "Rechercher physiothérapeute avec reconnaissance CRS, automunita/o, pour les activités ambulatoires et domicile. Date de début à convenir. Pourcentage d'utilisation: 50%.\n\nEnvoyer CV et lettre de présentation à: fisiocare.lugano@gmail.com\n\nNous sommes une entreprise active principalement à Luganèse, opérant dans le secteur ambulatoire et domiciliaire, qui suit les patients respiratoires, orthopédiques et oncologiques.\n\nNous cherchons une personne motivée, disponible pour travailler en équipe.\n\nNous offrons un environnement de travail dynamique et de bonnes conditions d'utilisation."
+        "it": "Cercasi fisioterapista con riconoscimento CRS, automunita/o, per attività sia ambulatoriale sia domiciliare. Data d'inizio da concordare. Percentuale d'impiego: 50%.\n\nInviare CV e lettera di presentazione a: fisiocare.lugano@gmail.com\n\nSiamo un'azienda attiva prevalentemente nel Luganese, operante in ambito ambulatoriale e domiciliare, che segue pazienti respiratori, ortopedici e oncologici.\n\nCerchiamo una persona motivata, disponibile a lavorare in team.\n\nOffriamo un ambiente di lavoro dinamico e buone condizioni d'impiego."
       },
       "id": "pub-8d0nltF3ZDHzWat5CMLR-fisiocare-sagl",
       "salaryMin": 70500,
@@ -56,6 +53,7 @@
       "applyMode": "external_url",
       "publisherUid": "eL1L3Wa8CJgkHQw8QizZS92Dr7i1",
       "publisherJobId": "8d0nltF3ZDHzWat5CMLR",
+      "needsRetranslation": true,
       "baseSalary": {
         "@type": "MonetaryAmount",
         "currency": "CHF",
@@ -67,6 +65,15 @@
         }
       },
       "previousSlugsByLocale": {
+        "en": [
+          "physiotherapist-with-crs-recognition-fisiocare-sagl-fisiocare-sagl"
+        ],
+        "de": [
+          "physiotherapeut-mit-crs-erkennung-fisiocare-sagl-fisiocare-sagl"
+        ],
+        "fr": [
+          "physiotherapeute-reconnu-crs-fisiocare-sagl-fisiocare-sagl"
+        ],
         "it": [
           "physiotherapist-with-crs-recognition-fisiocare-sagl-fisiocare-sagl",
           "physiotherapeut-mit-crs-erkennung-fisiocare-sagl-fisiocare-sagl",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:seo-gates": "vitest run tests/title-length.test.ts tests/h1-not-equal-title.test.ts tests/url-max-length.test.ts tests/hreflang-no-broken.test.ts tests/dist-single-h1-per-page.test.ts tests/dist-link-anchor-text.test.ts tests/seo-html-lang-sync.test.ts tests/seo/software-application-jsonld.test.ts",
     "gate:seo-source": "vitest run tests/seo/ --reporter=dot",
     "audit:title-uniqueness": "node --expose-gc scripts/audit-title-uniqueness.mjs",
+    "audit:job-locations": "node scripts/audit-job-locations.mjs",
     "audit:spa-bundle-injection": "node scripts/audit-spa-bundle-injection.mjs",
     "audit:spa-bundle-injection:rebaseline": "node scripts/audit-spa-bundle-injection.mjs --rebaseline",
     "analyze:write-collisions": "node scripts/analyze-write-collisions.mjs",

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1599,7 +1599,19 @@ async function assembleJobs() {
     // likely garbage (e.g. a company name leaking through a free-text
     // intake field instead of a real location). Give the structured
     // `canton` field the same second chance as a canton-only label.
-    if (acceptBadLocalityViaCanton(job.canton, job.postalCode, haystack)) return true;
+    if (acceptBadLocalityViaCanton(job.canton, job.postalCode, haystack)) {
+      // Sanitize: never ship the garbage primaryLoc verbatim — it would
+      // leak into the JobPosting schema, sitemap slug, and search/filter
+      // UI (e.g. Hirslanden Arbeitsort leak: "Bern - Futsal Minerva…
+      // Besetzung per: 1"). Replace with the real city found in the
+      // description body when one is findable there.
+      const rescuedCity = rescueSwissCityFromText(haystack);
+      if (rescuedCity) {
+        job.addressLocality = rescuedCity;
+        job.location = rescuedCity;
+      }
+      return true;
+    }
 
     // Neither a known Swiss city, canton-only label, nor an anchored
     // canton — likely a non-Swiss locality that escaped the explicit-

--- a/scripts/audit-job-locations.mjs
+++ b/scripts/audit-job-locations.mjs
@@ -44,10 +44,11 @@ const results = {
   correct: [],           // BFS confirms city is in stated canton
   cantonMismatch: [],    // BFS says different canton than stored
   foreignInSwiss: [],    // City is foreign but tagged as Swiss canton
-  unknownCity: [],       // City not in BFS, not obviously foreign — needs geocoding
+  unknownCity: [],       // City not in BFS, not obviously foreign — needs geocoding (= "custom" location)
   emptyLocation: [],     // No city/location data
   lowercaseCanton: [],   // Canton code is lowercase (data quality)
   geocodeResults: [],    // Results from Nominatim verification
+  companyDefaultFallback: [], // cantonMismatch subset where stored canton == company's modal canton
 };
 
 /* ── Geocode cache to avoid duplicate lookups ──────────────── */
@@ -67,8 +68,37 @@ function norm(v = '') {
   return String(v || '').trim();
 }
 
-/* ── Audit each job ────────────────────────────────────────── */
+/* ── Pass 0: per-company modal canton ─────────────────────────
+ * Empirical proxy for "this company's HQ/default canton" — the most
+ * frequent stored canton across all of a company's jobs. Derived from the
+ * dataset itself rather than a hand-maintained per-company dict, so it
+ * can't drift into the hardcoded-dict sibling-bug class fixed elsewhere in
+ * this audit (AGENTS.md #6). Used below to flag canton mismatches that
+ * look like a parser silently falling back to the company default instead
+ * of the job's real location. */
 const jobsToAudit = jobs.slice(0, limit);
+const companyCantonTally = new Map();
+for (const job of jobsToAudit) {
+  const company = norm(job.company || job.companyKey || '');
+  const canton = norm(job.canton || '').toUpperCase();
+  if (!company || !canton) continue;
+  if (!companyCantonTally.has(company)) companyCantonTally.set(company, new Map());
+  const tally = companyCantonTally.get(company);
+  tally.set(canton, (tally.get(canton) || 0) + 1);
+}
+const companyModalCanton = new Map();
+for (const [company, tally] of companyCantonTally) {
+  let best = '';
+  let bestCount = 0;
+  for (const [canton, count] of tally) {
+    if (count > bestCount) {
+      best = canton;
+      bestCount = count;
+    }
+  }
+  companyModalCanton.set(company, best);
+}
+
 let processed = 0;
 
 for (const job of jobsToAudit) {
@@ -170,6 +200,17 @@ for (const job of jobsToAudit) {
   }
 }
 
+// Subset of cantonMismatch where the stored (wrong) canton equals this
+// company's modal canton — i.e. the job's real location (per the city text)
+// is elsewhere, but the record carries the company's typical/HQ value. That
+// pattern is the signature of a parser silently defaulting instead of
+// resolving the actual crawled location (the "custom value" bug the location
+// mapping fix in this PR targets).
+results.companyDefaultFallback = results.cantonMismatch.filter((m) => {
+  const modalCanton = companyModalCanton.get(m.company) || '';
+  return modalCanton && m.storedCanton === modalCanton && m.inferredCanton !== modalCanton;
+});
+
 /* ── Report ────────────────────────────────────────────────── */
 console.log('\n' + '═'.repeat(70));
 console.log('  LOCATION AUDIT REPORT');
@@ -178,9 +219,10 @@ console.log('═'.repeat(70));
 console.log(`\n✅ Correct:              ${results.correct.length}`);
 console.log(`⚠️  Canton mismatch:      ${results.cantonMismatch.length}`);
 console.log(`🚨 Foreign in Swiss:      ${results.foreignInSwiss.length}`);
-console.log(`❓ Unknown city:          ${results.unknownCity.length}`);
+console.log(`❓ Unknown city (custom): ${results.unknownCity.length}`);
 console.log(`📭 Empty location:        ${results.emptyLocation.length}`);
 console.log(`🔤 Lowercase canton:      ${results.lowercaseCanton.length}`);
+console.log(`🏢 Company-default fallback (suspected): ${results.companyDefaultFallback.length}`);
 if (enableGeocode) {
   console.log(`🌍 Geocode results:       ${results.geocodeResults.length}`);
 }
@@ -192,6 +234,16 @@ if (results.cantonMismatch.length > 0) {
   console.log('─'.repeat(70));
   for (const m of results.cantonMismatch) {
     console.log(`  ${m.company.padEnd(30)} ${m.city.padEnd(25)} stored=${m.storedCanton.padEnd(4)} inferred=${m.inferredCanton} [${m.severity}]`);
+  }
+}
+
+// Detail: Suspected company-default fallbacks
+if (results.companyDefaultFallback.length > 0) {
+  console.log('\n' + '─'.repeat(70));
+  console.log('🏢 SUSPECTED COMPANY-DEFAULT FALLBACKS');
+  console.log('─'.repeat(70));
+  for (const m of results.companyDefaultFallback) {
+    console.log(`  ${m.company.padEnd(30)} ${m.city.padEnd(25)} stored=${m.storedCanton.padEnd(4)} (company modal) inferred=${m.inferredCanton}`);
   }
 }
 
@@ -317,8 +369,10 @@ writeFileSync(reportPath, JSON.stringify({
     cantonMismatch: results.cantonMismatch.length,
     foreignInSwiss: results.foreignInSwiss.length,
     unknownCity: results.unknownCity.length,
+    customLocation: results.unknownCity.length, // alias: city matches no canonical Swiss location
     emptyLocation: results.emptyLocation.length,
     lowercaseCanton: results.lowercaseCanton.length,
+    companyDefaultFallback: results.companyDefaultFallback.length,
     geocodeResults: results.geocodeResults.length,
   },
   cantonMismatches: results.cantonMismatch,
@@ -326,6 +380,7 @@ writeFileSync(reportPath, JSON.stringify({
   unknownCities: results.unknownCity,
   emptyLocations: results.emptyLocation,
   lowercaseCantons: results.lowercaseCanton,
+  companyDefaultFallback: results.companyDefaultFallback,
   geocodeResults: results.geocodeResults,
 }, null, 2));
 console.log(`\n📄 Detailed report saved to: data/location-audit-report.json\n`);

--- a/scripts/crawl-guidle-events.mjs
+++ b/scripts/crawl-guidle-events.mjs
@@ -540,7 +540,13 @@ async function main() {
         cantonHint,
       );
       event.comune = comune || undefined;
-      event.canton = canton || cantonHint || '';
+      // Do NOT fall back to the raw `cantonHint` here: `resolveComuneNationwide`
+      // already retains it when valid (method 'canton-hint', issue #3739) and
+      // returns `canton: null` precisely when the hint failed its own
+      // `isValidCantonCode` registry check — falling back to the raw hint here
+      // would re-introduce an unvalidated 2-letter code as the final canton.
+      // Matches the sibling `crawl-myswitzerland-events.mjs` crawler.
+      event.canton = canton || '';
       if (event.comune) resolvedComune += 1;
       event.imageUrl = (await mirrorEventImage(imageSourceUrl, event.id)) || undefined;
       events.push(event);

--- a/scripts/lib/a-plus-plus-job-parser.mjs
+++ b/scripts/lib/a-plus-plus-job-parser.mjs
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 function normalizeSpace(value = '') {
   return String(value || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
@@ -185,19 +186,13 @@ export function isAplusSwissLocation(raw = '') {
 
 /**
  * Infer the Swiss canton abbreviation from a raw location string.
- * Defaults to 'TI' because A++ Group headquarters is in Massagno (TI).
+ * A++ Group is headquartered in Massagno (TI) but, per `isAplusSwissLocation`
+ * above, may post other Swiss positions too — resolve via the comprehensive
+ * nationwide `inferAnyCanton` rather than a TI/GR-only hand-rolled list, so
+ * jobs located in other cantons don't fall through as unresolved.
  */
 export function inferAplusCanton(raw = '') {
-  const lower = normalizeSpace(raw)
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
-
-  if (/grigioni|graubunden|grisons|chur|davos/.test(lower)) return 'GR';
-  if (/ticino|tessin|massagno|lugano|chiasso|bellinzona|locarno|mendrisio|ascona|muralto/.test(lower)) return 'TI';
-  // Generic CH markers — not enough to confidently assign TI
-  if (/svizzera|suisse|schweiz|switzerland|swiss/.test(lower)) return '';
-  return '';
+  return inferAnyCanton(raw) || '';
 }
 
 /**

--- a/scripts/lib/breitling-job-parser.mjs
+++ b/scripts/lib/breitling-job-parser.mjs
@@ -72,7 +72,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 import { fetchHtml, decodeEntities, normalizeSpace as normalizeSpaceRaw } from './hospital-custom-html-helpers.mjs';
 
 export const BREITLING_KEY = 'breitling';
@@ -217,11 +217,14 @@ function parseLocation(raw = '') {
   const parts = cleaned.split(',').map((p) => p.trim());
   // Expect: [city, canton, "CHE", postalCode?]
   const cityRaw = parts[0] || '';
-  const canton = (parts[1] || '').toUpperCase();
+  // Validate against the real 26-canton registry — a well-formed-but-wrong
+  // 2-letter token from the feed must not be trusted verbatim (AGENTS.md #6
+  // sibling class shared with ghol/holcim/stadler-rail/spitex-ch).
+  const canton = normalizeCantonCode(parts[1] || '');
   const postalRaw = (parts[3] || '').trim();
   const postalCode = /^\d{4}$/.test(postalRaw) ? postalRaw : '';
 
-  const isBareCantonCode = /^[A-Z]{2}$/.test(cityRaw) && cityRaw.toUpperCase() === canton;
+  const isBareCantonCode = !!normalizeCantonCode(cityRaw) && cityRaw.toUpperCase() === canton;
   const city = (!cityRaw || isBareCantonCode)
     ? (CANTON_CITY_FALLBACK[canton] || cityRaw || HQ.city)
     : cityRaw;

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -3768,9 +3768,7 @@ export function hardenJobsRichResultsData({ dataJobsPath }) {
     if (!hq) continue;
     const city = String(job.addressLocality || job.location || '').trim();
     if (!city) continue;
-    const cityCanton = (job.canton && /^[A-Z]{2}$/i.test(job.canton))
-      ? job.canton.toUpperCase()
-      : inferAnyCanton(city);
+    const cityCanton = normalizeCantonCode(job.canton) || inferAnyCanton(city);
     const crossCanton = !!cityCanton && cityCanton !== hq.addressRegion;
     // #3513: heal also SAME-canton contamination — records stamped with the
     // HQ street/CAP while the job sits in a different city of the same

--- a/scripts/lib/ghol-job-parser.mjs
+++ b/scripts/lib/ghol-job-parser.mjs
@@ -35,6 +35,7 @@ import {
   fetchJson,
 } from './crawler-template.mjs';
 import { assertJsonListShape } from './assert-json-list-shape.mjs';
+import { normalizeCantonCode, inferAnyCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -190,9 +191,13 @@ function buildJob(campaign) {
   const location = campaign.location || {};
   const cityRaw = normalizeSpace(location.city || '');
   const city = cityRaw || 'Nyon';
-  // Canton: Beehire stores state="VD"/"VS"/... directly for Swiss locations.
+  // Canton: Beehire stores state="VD"/"VS"/... directly for Swiss locations,
+  // but an unvalidated well-formed-looking code isn't necessarily a real one
+  // (AGENTS.md #6 sibling class shared with mcdonalds/pallas-kliniken/sodexo/
+  // vitrea-gesundheit/triaplus) — validate against the real 26-canton registry,
+  // then fall back to city-based inference before the HQ default.
   const state = String(location.state || '').toUpperCase().slice(0, 2);
-  const canton = /^[A-Z]{2}$/.test(state) ? state : 'VD';
+  const canton = normalizeCantonCode(state) || inferAnyCanton(city) || 'VD';
   const country = String(location.country || '').toLowerCase();
   const isCH =
     country.includes('suisse') ||

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import { rescueHtmlIfChallenged, fetchHtmlViaJinaWithRetry } from './jina-proxy.mjs';
 import { isConnectionLevelFetchError, WAF_IP_BLOCK_STATUS } from './transient-fetch.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, isKnownSwissCity } from './target-swiss-locations.mjs';
 import { stripContactPII } from './strip-contact-pii.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -476,6 +476,25 @@ async function fetchPage(url, timeoutMs, userAgent) {
   }
 }
 
+/**
+ * Prefer a locality that resolves to a known Swiss city (BFS registry). The
+ * detail page's free-text "Arbeitsort:" line can leak trailing SF form-field
+ * noise past the real city (e.g. "Bern - Futsal Minerva Besetzung per: 1.
+ * Oktober 2026") when the source HTML's <br>-separated fields collapse onto
+ * one markdown paragraph line — inferSwissTargetCanton still resolves a
+ * canton off a substring match, but the noise itself must never ship as
+ * addressLocality. The listing-cell city is a clean structured field and is
+ * the safer choice whenever the detail text isn't itself a real known city.
+ */
+export function resolveHirslandenLocation(detailLocationText, listingCity) {
+  const detail = String(detailLocationText || '').trim();
+  const listing = String(listingCity || '').trim();
+  if (detail && !isKnownSwissCity(detail) && isKnownSwissCity(listing)) {
+    return listing;
+  }
+  return detail || listing;
+}
+
 /* ── Main fetch function ──────────────────────────────────── */
 
 /**
@@ -541,7 +560,7 @@ export async function fetchAllHirslandenJobs() {
       const title = detail?.title || listing.title;
       const { city, postalCode: parsedPostal } = parseLocation(listing.location);
       const realLocationText = normalizeSpace(detail?.location || '') || normalizeSpace(listing.location || '');
-      const location = realLocationText || city;
+      const location = resolveHirslandenLocation(realLocationText, city);
       const inferredCanton = inferSwissTargetCanton(location) || null;
       if (realLocationText && !inferredCanton) {
         console.warn(`  ⚠️ Hirslanden: skipping unresolvable location "${realLocationText}" (${title})`);

--- a/scripts/lib/holcim-job-parser.mjs
+++ b/scripts/lib/holcim-job-parser.mjs
@@ -51,7 +51,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, fetchHtml } from './crawler-template.mjs';
-import { inferAnyCanton } from './target-swiss-locations.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -144,9 +144,12 @@ function parseHolcimLocation(raw = '') {
   // both seen on this tenant — and never the "CH" token itself). Anything
   // else is left for inferAnyCanton(city) to resolve by city name.
   const middle = tail.slice(0, -1);
-  const explicitCanton = middle.find((p) => /^[A-Z]{2}$/.test(p) && p.toUpperCase() !== 'CH') || '';
+  // Validate against the real 26-canton registry — a well-formed-but-wrong
+  // 2-letter token in the address must not be trusted verbatim (AGENTS.md #6
+  // sibling class shared with ghol/stadler-rail/spitex-ch/breitling).
+  const explicitCanton = middle.map((p) => normalizeCantonCode(p)).find(Boolean) || '';
 
-  return { city, canton: explicitCanton.toUpperCase(), country };
+  return { city, canton: explicitCanton, country };
 }
 
 /* ── Category Detection ────────────────────────────────────── */

--- a/scripts/lib/hornbach-job-parser.mjs
+++ b/scripts/lib/hornbach-job-parser.mjs
@@ -87,7 +87,7 @@
 import { createHash } from 'node:crypto';
 import { fetchJson, slugify, normalizeSpace, stripHtml } from './crawler-template.mjs';
 import { detectLang, guessCategory, normalizeContract, decodeHtmlEntities } from './dedicated-crawler-common.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -485,7 +485,7 @@ export async function fetchAllHornbachJobs() {
       streetAddress: parsed.streetAddress,
     });
     const location = parsed.city || city;
-    const canton = parsed.cantonCode || inferSwissTargetCanton(location) || inferSwissTargetCanton(city) || HQ.canton;
+    const canton = normalizeCantonCode(parsed.cantonCode) || inferSwissTargetCanton(location) || inferSwissTargetCanton(city) || HQ.canton;
 
     const description = parsed.description || `${parsed.title} — ${HORNBACH_COMPANY_NAME} (${location}).`;
     const sourceLang = detectLang(description || parsed.title, 'de');

--- a/scripts/lib/ikea-job-parser.mjs
+++ b/scripts/lib/ikea-job-parser.mjs
@@ -285,6 +285,21 @@ function mapEmploymentType(raw = '', title = '') {
 }
 
 /**
+ * Validate a source-feed `addressRegion` against the independently-inferred
+ * canton. IKEA's own JSON-LD feed provides `addressRegion` as unvalidated
+ * source data — trust it only when it's a real 2-letter Swiss canton code
+ * that AGREES with `canton` (derived from the listing-page location text); a
+ * disagreeing/malformed value must never silently override the safer,
+ * location-derived canton (same bug class fixed centrally in
+ * jobPostingSchema.ts's resolveAddress()).
+ */
+export function resolveIkeaAddressRegion(feedAddressRegion, canton) {
+  const feedRegion = String(feedAddressRegion || '').toUpperCase().trim();
+  const cantonCode = String(canton || '').toUpperCase().trim();
+  return /^[A-Z]{2}$/.test(feedRegion) && feedRegion === cantonCode ? feedRegion : '';
+}
+
+/**
  * Fetch all IKEA jobs.
  * Returns an array of ParsedJob objects (source-locale only).
  *
@@ -311,7 +326,7 @@ export async function fetchAllIkeaJobs() {
     const location = normalizeSpace(listing.location || '');
     const canton = inferSwissTargetCanton(location) || HQ_CANTON;
     const addressLocality = listing.addressLocality || location.split(',')[0].trim() || HQ_CITY;
-    const addressRegion = listing.addressRegion || '';
+    const addressRegion = resolveIkeaAddressRegion(listing.addressRegion, canton);
     const postalCode = listing.postalCode || (canton === HQ_CANTON ? HQ_POSTAL : '');
     const descriptionText = stripHtml(listing.description || '');
     const publicUrl = listing.url || CAREER_URL;

--- a/scripts/lib/kuehne-nagel-job-parser.mjs
+++ b/scripts/lib/kuehne-nagel-job-parser.mjs
@@ -31,7 +31,7 @@ import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, fetchHtml, fetchJson } from './crawler-template.mjs';
 import { fetchWithRetry } from './transient-fetch.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -345,7 +345,7 @@ export async function fetchAllKuehneNagelJobs() {
     // Non-Negotiable #3). Absent location text entirely still defaults to HQ.
     const realCityText = normalizeSpace(stub.city || detail.addressLocality || '');
     const rawLocationText = normalizeSpace(stub.location || '');
-    const directCantonCode = detail.cantonCode && detail.cantonCode.length === 2 ? detail.cantonCode : '';
+    const directCantonCode = normalizeCantonCode(detail.cantonCode);
     const inferredCanton =
       directCantonCode || inferSwissTargetCanton(realCityText) || inferSwissTargetCanton(rawLocationText);
     if (!directCantonCode && (realCityText || rawLocationText) && !inferredCanton) {

--- a/scripts/lib/mcdonalds-job-parser.mjs
+++ b/scripts/lib/mcdonalds-job-parser.mjs
@@ -29,6 +29,8 @@
  * description — everything needed to build a job record.
  */
 
+import { normalizeCantonCode, inferAnyCanton } from './target-swiss-locations.mjs';
+
 export const MCDO_KEY = 'mcdonald-s-switzerland';
 export const COMPANY_NAME = "McDonald's Switzerland";
 export const COMPANY_DOMAIN = 'mcdonalds.ch';
@@ -39,20 +41,6 @@ const LOCALE_PREFERENCE = ['de-ch', 'en', 'fr-ch', 'it-ch'];
 
 const DEFAULT_UA = process.env.JOBS_CRAWLER_USER_AGENT
   || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
-
-// Swiss canton name → 2-letter abbreviation fallback, in case a jobLocation
-// ever ships a full canton name instead of `addressRegion` abbreviation.
-const CANTON_NAME_TO_ABBR = {
-  zurich: 'ZH', bern: 'BE', berne: 'BE', luzern: 'LU', lucerne: 'LU', uri: 'UR',
-  schwyz: 'SZ', obwalden: 'OW', nidwalden: 'NW', glarus: 'GL', zug: 'ZG',
-  fribourg: 'FR', freiburg: 'FR', solothurn: 'SO', 'basel-stadt': 'BS',
-  'basel-landschaft': 'BL', schaffhausen: 'SH', 'appenzell ausserrhoden': 'AR',
-  'appenzell innerrhoden': 'AI', 'st. gallen': 'SG', 'st gallen': 'SG',
-  graubunden: 'GR', graubünden: 'GR', grigioni: 'GR', aargau: 'AG',
-  thurgau: 'TG', ticino: 'TI', vaud: 'VD', valais: 'VS', wallis: 'VS',
-  neuchatel: 'NE', neuchâtel: 'NE', geneve: 'GE', genève: 'GE', geneva: 'GE',
-  jura: 'JU',
-};
 
 /* ── Text helpers ─────────────────────────────────────────────── */
 
@@ -89,10 +77,9 @@ export function slugify(value = '') {
 }
 
 export function inferCanton(addressRegion = '', city = '') {
-  const region = String(addressRegion || '').trim();
-  if (/^[A-Z]{2}$/.test(region)) return region;
-  const byName = CANTON_NAME_TO_ABBR[String(region || city || '').trim().toLowerCase()];
-  return byName || '';
+  const explicit = normalizeCantonCode(String(addressRegion || ''));
+  if (explicit) return explicit;
+  return inferAnyCanton(String(city || addressRegion || ''));
 }
 
 /**

--- a/scripts/lib/novelis-job-parser.mjs
+++ b/scripts/lib/novelis-job-parser.mjs
@@ -31,7 +31,7 @@ import { createHash } from 'node:crypto';
 import { JSDOM } from 'jsdom';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeSpace, fetchHtml } from './crawler-template.mjs';
-import { inferAnyCanton } from './target-swiss-locations.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -171,8 +171,12 @@ function parseLocationCode(rawLocation = '') {
   const parts = String(rawLocation).split('-').map((p) => p.trim()).filter(Boolean);
   if (parts.length === 0) return { city: '', canton: '' };
   if (parts.length >= 3 && /^[a-z]{2}$/i.test(parts[1])) {
-    // "CH-VS-Sierre" (region code present)
-    return { city: parts.slice(2).join('-'), canton: parts[1].toUpperCase() };
+    // "CH-VS-Sierre" (region code present) — validate against the real
+    // canton registry before trusting it; a shape-only check would let a
+    // malformed/non-Swiss 2-letter token through as a fabricated canton.
+    const city = parts.slice(2).join('-');
+    const canton = normalizeCantonCode(parts[1]) || inferAnyCanton(city) || '';
+    return { city, canton };
   }
   // "CH-City" (no region code) — infer canton from the city name.
   const city = parts.slice(1).join('-') || parts[0];

--- a/scripts/lib/pallas-kliniken-job-parser.mjs
+++ b/scripts/lib/pallas-kliniken-job-parser.mjs
@@ -28,6 +28,7 @@ import {
   detectHealthcareExperienceLevel,
   detectHealthcareEmploymentType,
 } from './hospital-custom-html-helpers.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 export const PALLAS_KLINIKEN_KEY = 'pallas-kliniken';
 export const PALLAS_KLINIKEN_COMPANY_NAME = 'Pallas Kliniken';
@@ -46,43 +47,11 @@ const HQ = {
   streetAddress: 'Louis Giroud-Strasse 20',
 };
 
-// Map Pallas site names → Swiss canton (where the JSON-LD jobLocation address
-// uses `addressCountry: 'Schweiz'` and we infer the canton from the city).
-const CITY_TO_CANTON = {
-  Olten: 'SO',
-  Bern: 'BE',
-  Basel: 'BS',
-  'Zürich': 'ZH',
-  Zurich: 'ZH',
-  Solothurn: 'SO',
-  Aarau: 'AG',
-  Baden: 'AG',
-  Brugg: 'AG',
-  Grenchen: 'SO',
-  Langenthal: 'BE',
-  Biel: 'BE',
-  Bienne: 'BE',
-  'Bern Wankdorf': 'BE',
-  Winterthur: 'ZH',
-  Luzern: 'LU',
-  'St. Gallen': 'SG',
-  'Schaffhausen': 'SH',
-  Wohlen: 'AG',
-  Lenzburg: 'AG',
-  Rheinfelden: 'AG',
-  Wettingen: 'AG',
-  Frauenfeld: 'TG',
-  Bellinzona: 'TI',
-  Lugano: 'TI',
-  Locarno: 'TI',
-  Sion: 'VS',
-  Lausanne: 'VD',
-  Vevey: 'VD',
-  Yverdon: 'VD',
-  Geneva: 'GE',
-  'Genève': 'GE',
-  Chur: 'GR',
-};
+// Pallas site names → Swiss canton is inferred via the shared BFS-backed
+// `inferAnyCanton` (all 26 cantons, fuzzy-tolerant) — see `pickCanton` below.
+// A hand-rolled ~30-city dict previously lived here; it silently fell back to
+// HQ.canton (SO) for every Pallas site not in the list (AGENTS.md #6 sibling
+// class shared with hirslanden/ikea/jobsSeoPagesPlugin fixes).
 
 export function isPallasKlinikenJob(job) {
   const url = String(job?.url || '').toLowerCase();
@@ -160,12 +129,7 @@ function mapEmploymentTypeLd(value, fallbackText) {
 
 function pickCanton(addressLocality) {
   if (!addressLocality) return HQ.canton;
-  const direct = CITY_TO_CANTON[addressLocality];
-  if (direct) return direct;
-  for (const [k, v] of Object.entries(CITY_TO_CANTON)) {
-    if (addressLocality.toLowerCase().includes(k.toLowerCase())) return v;
-  }
-  return HQ.canton;
+  return inferAnyCanton(addressLocality) || HQ.canton;
 }
 
 export async function fetchAllPallasKlinikenJobs() {

--- a/scripts/lib/pizzarotti-job-parser.mjs
+++ b/scripts/lib/pizzarotti-job-parser.mjs
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 function normalizeSpace(value = '') {
   return String(value || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
@@ -95,47 +96,10 @@ export function isPizzarottiSwissLocation(raw = '') {
 
 /**
  * Infer canton from Pizzarotti location text.
- * Falls back to 'OTHER' if no known canton is matched.
+ * Falls back to '' if no known canton is matched (never a non-canonical value).
  */
 export function inferPizzarottiCanton(raw = '') {
-  const lower = normalizeSpace(raw).toLowerCase()
-    .normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-
-  const cantonMap = {
-    ticino: 'TI', tessin: 'TI',
-    grigioni: 'GR', graubunden: 'GR', grisons: 'GR',
-    neuchatel: 'NE',
-    bern: 'BE', berna: 'BE', berne: 'BE',
-    zurich: 'ZH', zurigo: 'ZH',
-    geneva: 'GE', geneve: 'GE', ginevra: 'GE', genf: 'GE',
-    basel: 'BS', basilea: 'BS',
-    vaud: 'VD', waadt: 'VD',
-    valais: 'VS', vallese: 'VS', wallis: 'VS',
-    lucerna: 'LU', luzern: 'LU', lucerne: 'LU',
-    solothurn: 'SO', soletta: 'SO', soleure: 'SO',
-    fribourg: 'FR', friborgo: 'FR', freiburg: 'FR',
-    aargau: 'AG', argovia: 'AG', argovie: 'AG',
-    thurgau: 'TG', turgovia: 'TG', thurgovie: 'TG',
-    'san gallo': 'SG', 'st. gallen': 'SG', 'saint-gall': 'SG',
-    schwyz: 'SZ', svitto: 'SZ',
-    jura: 'JU',
-  };
-
-  for (const [token, canton] of Object.entries(cantonMap)) {
-    if (lower.includes(token)) return canton;
-  }
-
-  // Known Swiss cities
-  const cityMap = {
-    'le locle': 'NE', 'la chaux-de-fonds': 'NE',
-    lugano: 'TI', mendrisio: 'TI', chiasso: 'TI', bellinzona: 'TI', locarno: 'TI',
-    chur: 'GR', davos: 'GR',
-  };
-  for (const [city, canton] of Object.entries(cityMap)) {
-    if (lower.includes(city)) return canton;
-  }
-
-  return 'CH';
+  return inferAnyCanton(raw) || '';
 }
 
 /**

--- a/scripts/lib/sodexo-job-parser.mjs
+++ b/scripts/lib/sodexo-job-parser.mjs
@@ -37,6 +37,7 @@ import {
   normalizeSpace,
   htmlToText,
 } from './hospital-custom-html-helpers.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 export const SODEXO_KEY = 'sodexo';
 export const SODEXO_COMPANY_NAME = 'Sodexo (Suisse) SA';
@@ -58,45 +59,14 @@ const HQ = {
   streetAddress: 'Wallisellenstrasse 55',
 };
 
-// Map Sodexo client-site city → Swiss canton. Concludis JSON-LD only gives
-// `addressLocality` + `postalCode`, not the canton, so we infer it from the
-// city name (same pattern as pallas-kliniken-job-parser.mjs / other
-// multi-site dedicated crawlers).
-const CITY_TO_CANTON = {
-  'Baar': 'ZG',
-  'Oberdorf': 'BL',
-  'Lengnau BE': 'BE',
-  'Lengnau': 'BE',
-  'Buchs': 'SG',
-  'Luzern': 'LU',
-  'Zürich': 'ZH',
-  'Zurich': 'ZH',
-  'Zürich Flughafen': 'ZH',
-  'Glattbrugg': 'ZH',
-  'Schaffhausen': 'SH',
-  'Winkeln SG': 'SG',
-  'Winkeln': 'SG',
-  'Dagmersellen': 'LU',
-  'Basel': 'BS',
-  'Bern': 'BE',
-  'Genève': 'GE',
-  'Geneva': 'GE',
-  'Lausanne': 'VD',
-  'Sion': 'VS',
-  'Lugano': 'TI',
-  'Bellinzona': 'TI',
-  'Chur': 'GR',
-  'St. Gallen': 'SG',
-  'Winterthur': 'ZH',
-  'Biel': 'BE',
-  'Bienne': 'BE',
-  'Fribourg': 'FR',
-  'Freiburg': 'FR',
-  'Neuchâtel': 'NE',
-  'Aarau': 'AG',
-  'Solothurn': 'SO',
-  'Zug': 'ZG',
-};
+// Sodexo client-site city → Swiss canton is inferred via the shared
+// BFS-backed `inferAnyCanton` (all 26 cantons, fuzzy-tolerant) in
+// `pickCanton` below — Concludis JSON-LD only gives `addressLocality` +
+// `postalCode`, not the canton. A hand-rolled ~30-city dict previously lived
+// here; it silently fell back to HQ.canton for every city not in the list
+// (AGENTS.md #6 sibling class shared with pallas-kliniken/hirslanden/ikea).
+// Postal-code overrides for genuinely cross-canton-ambiguous towns (below)
+// still take priority, since bare text inference can't disambiguate those.
 
 export function isSodexoJob(job) {
   const url = String(job?.url || '').toLowerCase();
@@ -233,12 +203,7 @@ function pickCanton(addressLocality, postalCode = '') {
     return POSTAL_CODE_CANTON_OVERRIDES[postalCode];
   }
   if (!addressLocality) return HQ.canton;
-  const direct = CITY_TO_CANTON[addressLocality];
-  if (direct) return direct;
-  for (const [k, v] of Object.entries(CITY_TO_CANTON)) {
-    if (addressLocality.toLowerCase().includes(k.toLowerCase())) return v;
-  }
-  return HQ.canton;
+  return inferAnyCanton(addressLocality) || HQ.canton;
 }
 
 export async function fetchAllSodexoJobs() {

--- a/scripts/lib/solina-job-parser.mjs
+++ b/scripts/lib/solina-job-parser.mjs
@@ -45,6 +45,7 @@ import {
   detectHealthcareExperienceLevel,
   detectHealthcareEmploymentType,
 } from './hospital-custom-html-helpers.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 export const SOLINA_KEY = 'solina';
 export const SOLINA_COMPANY_NAME = 'Stiftung Solina';
@@ -174,14 +175,7 @@ function extractMainContent(html) {
 /* ── Canton inference ─────────────────────────────────────── */
 
 function inferCantonFromLocation(loc) {
-  const l = String(loc).toLowerCase();
-  if (/heiligenschwendi|spiez|thun|bern\b|berne|burgdorf|interlaken|steffisburg|sigriswil|gunten/.test(l)) return 'BE';
-  if (/zürich|zurich/.test(l)) return 'ZH';
-  if (/luzern|lucerne/.test(l)) return 'LU';
-  if (/basel|basilea/.test(l)) return 'BS';
-  if (/wallis|valais|brig|visp/.test(l)) return 'VS';
-  if (/sankt|st\.\s*gallen/.test(l)) return 'SG';
-  return 'BE'; // Solina HQ is in the Berner Oberland (BE)
+  return inferAnyCanton(loc) || 'BE'; // Solina HQ is in the Berner Oberland (BE)
 }
 
 /* ── Main fetch ───────────────────────────────────────────── */

--- a/scripts/lib/spitex-ch-job-parser.mjs
+++ b/scripts/lib/spitex-ch-job-parser.mjs
@@ -37,7 +37,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -155,7 +155,10 @@ export async function fetchAllSpitexChJobs() {
     const city = decodeEntities(addr.addressLocality || '').trim() || 'Bern';
     const postalCode = String(addr.postalCode || '').trim() || '3000';
     const cantonGuess = String(addr.addressRegion || '').toUpperCase().trim();
-    const canton = /^[A-Z]{2}$/.test(cantonGuess) ? cantonGuess : (inferSwissTargetCanton(city) || 'BE');
+    // Validate against the real canton registry — a well-formed-but-wrong
+    // 2-letter code must not be trusted verbatim (AGENTS.md #6 sibling class
+    // shared with ghol/holcim/stadler-rail/breitling).
+    const canton = normalizeCantonCode(cantonGuess) || inferSwissTargetCanton(city) || 'BE';
     const country = COUNTRY_TO_CC[addr.addressCountry] || 'CH';
 
     const descHtml = posting.description || '';

--- a/scripts/lib/stadler-rail-job-parser.mjs
+++ b/scripts/lib/stadler-rail-job-parser.mjs
@@ -30,7 +30,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeDescriptionSpace, stripScriptsAndStyles } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 import { rescueHtmlIfChallenged } from './jina-proxy.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -408,7 +408,7 @@ export async function fetchAllStadlerRailJobs() {
       detail?.addressLocality || listing.slugCity || HQ_CITY;
     const canton =
       inferSwissTargetCanton(location) ||
-      (listing.canton && /^[A-Z]{2}$/.test(listing.canton) ? listing.canton : null) ||
+      normalizeCantonCode(listing.canton || '') ||
       inferSwissTargetCanton(detail?.addressRegion || '') ||
       HQ_CANTON;
     const postalCode = detail?.postalCode || listing.postalCode || HQ_POSTAL;

--- a/scripts/lib/successfactors-shared-job-parser-common.mjs
+++ b/scripts/lib/successfactors-shared-job-parser-common.mjs
@@ -38,7 +38,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml, normalizeDescriptionBullets } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { inferSwissTargetCanton, normalizeCantonCode } from './target-swiss-locations.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -615,7 +615,7 @@ export function createSuccessFactorsParser(config) {
       })();
       const city = detailCity || listingCity || defaultCity;
       const region = detail?.region || defaultCanton;
-      const canton = inferSwissTargetCanton(city) || region || defaultCanton;
+      const canton = inferSwissTargetCanton(city) || normalizeCantonCode(region) || defaultCanton;
       const postalCode = detail?.postalCode || defaultPostalCode;
 
       const sourceLang = (trustPageLangAttr && detail?.language && /^(de|fr|it|en)$/.test(detail.language))

--- a/scripts/lib/triaplus-job-parser.mjs
+++ b/scripts/lib/triaplus-job-parser.mjs
@@ -34,6 +34,7 @@
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripScriptsAndStyles } from './crawler-template.mjs';
+import { normalizeCantonCode } from './target-swiss-locations.mjs';
 import {
   fetchHtml,
   decodeEntities,
@@ -114,7 +115,10 @@ export function parseJobLocation(html) {
   if (!rawCity) return null;
   const known = KNOWN_LOCATIONS[stripDiacritics(rawCity).toLowerCase()];
   if (known) return known;
-  const cantonFromSpan = m[2] ? m[2].toUpperCase() : '';
+  // Validate against the real 26-canton registry — a well-formed-but-wrong
+  // 2-letter code in the span must not be trusted verbatim (AGENTS.md #6
+  // sibling class shared with pallas-kliniken/sodexo/mcdonalds/vitrea).
+  const cantonFromSpan = normalizeCantonCode(m[2] || '');
   if (cantonFromSpan) return { city: rawCity, canton: cantonFromSpan, postalCode: DEFAULT_POSTAL_CODE };
   return null;
 }

--- a/scripts/lib/vir-biotechnology-job-parser.mjs
+++ b/scripts/lib/vir-biotechnology-job-parser.mjs
@@ -10,7 +10,7 @@
  * The API returns all jobs globally. We filter for Switzerland/Bellinzona positions.
  */
 
-import { isTargetSwissLocation } from './target-swiss-locations.mjs';
+import { isTargetSwissLocation, inferAnyCanton } from './target-swiss-locations.mjs';
 import { getCompanyDefaults } from './crawler-location-config.mjs';
 
 const HQ = getCompanyDefaults('vir-biotechnology');
@@ -81,16 +81,7 @@ export function isSwissLocation(locationName = '') {
  * Infer canton from a Greenhouse location string.
  */
 export function inferCanton(location = '') {
-  const loc = String(location || '').toLowerCase();
-  if (loc.includes('bellinzona')) return 'TI';
-  if (loc.includes('lugano')) return 'TI';
-  if (loc.includes('manno')) return 'TI';
-  if (loc.includes('ticino')) return 'TI';
-  if (loc.includes('zurich') || loc.includes('zürich')) return 'ZH';
-  if (loc.includes('basel') || loc.includes('bâle')) return 'BS';
-  if (loc.includes('bern') || loc.includes('berne')) return 'BE';
-  if (loc.includes('geneva') || loc.includes('genève')) return 'GE';
-  return '';
+  return inferAnyCanton(location) || '';
 }
 
 /**

--- a/scripts/lib/vitrea-gesundheit-job-parser.mjs
+++ b/scripts/lib/vitrea-gesundheit-job-parser.mjs
@@ -29,6 +29,7 @@ import {
 } from './hospital-custom-html-helpers.mjs';
 import { isDetailContentValid } from './umantis-listing-common.mjs';
 import { parseOnlyfyListing } from './onlyfy-listing-common.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
 
 export const VITREA_GESUNDHEIT_KEY = 'vitrea-gesundheit';
 export const VITREA_GESUNDHEIT_COMPANY_NAME = 'Vitrea Gesundheit';
@@ -87,17 +88,13 @@ async function fetchDetailContent(url) {
 }
 
 function inferCantonFromLocation(loc) {
+  // "Seewis" (Vitrea HQ Rehaklinik) isn't a BFS-registered municipality alias
+  // inferAnyCanton recognizes, so it's kept as an explicit signal ahead of
+  // the shared BFS-backed resolver (all 26 cantons, fuzzy-tolerant) — see
+  // AGENTS.md #6 sibling class shared with pallas-kliniken/sodexo/mcdonalds.
   const l = String(loc).toLowerCase();
-  if (/seewis|davos|chur|graubünden|grigioni/.test(l)) return 'GR';
-  if (/zürich|zurich/.test(l)) return 'ZH';
-  if (/bern\b|berne/.test(l)) return 'BE';
-  if (/luzern|lucerne/.test(l)) return 'LU';
-  if (/basel|basilea/.test(l)) return 'BS';
-  if (/aargau|argovia/.test(l)) return 'AG';
-  if (/wallis|valais/.test(l)) return 'VS';
-  if (/tessin|ticino/.test(l)) return 'TI';
-  if (/sankt|st\.\s*gallen|san gallo/.test(l)) return 'SG';
-  return 'GR'; // Vitrea HQ Rehaklinik Seewis is GR
+  if (/seewis/.test(l)) return 'GR';
+  return inferAnyCanton(l) || 'GR'; // Vitrea HQ Rehaklinik Seewis is GR
 }
 
 export async function fetchAllVitreaGesundheitJobs() {

--- a/scripts/update-bracco-jobs.mjs
+++ b/scripts/update-bracco-jobs.mjs
@@ -34,7 +34,7 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, m
 } from './lib/dedicated-crawler-common.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
-import { isSwissLocationText } from './lib/target-swiss-locations.mjs';
+import { isSwissLocationText, inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
@@ -260,20 +260,12 @@ function parseWorkdayLocation(locText = '') {
 }
 
 function inferCanton(location = '') {
-  const loc = normalize(location);
-  if (loc.includes('cadempino')) return 'TI';
-  if (loc.includes('plan-les-ouates') || loc.includes('plan les ouates')) return 'GE';
-  if (loc.includes('lugano')) return 'TI';
-  if (loc.includes('manno')) return 'TI';
-  if (loc.includes('bellinzona')) return 'TI';
-  if (loc.includes('locarno')) return 'TI';
-  if (loc.includes('mendrisio')) return 'TI';
-  if (loc.includes('chiasso')) return 'TI';
-  if (loc.includes('genev') || loc.includes('genf')) return 'GE';
-  if (loc.includes('zurich') || loc.includes('zürich')) return 'ZH';
-  if (loc.includes('bern') || loc.includes('berne')) return 'BE';
-  if (loc.includes('basel') || loc.includes('bâle')) return 'BS';
-  return '';
+  // Crawler keeps any Swiss location text (not just the 2 known offices —
+  // see isSwissLocationText usage above, "other CH" self-heal), so canton
+  // resolution must cover all 26 cantons via the BFS municipality registry
+  // instead of a hand-rolled dict of just Cadempino/Plan-les-Ouates + a few
+  // extra cities (would silently return '' for any other real Swiss site).
+  return inferAnyCanton(location);
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/scripts/update-confederazione-jobs.mjs
+++ b/scripts/update-confederazione-jobs.mjs
@@ -61,7 +61,7 @@ import {
   captureLostSlugs,
 } from './lib/dedicated-crawler-common.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
-import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './lib/target-swiss-locations.mjs';
 import { normalizeFederalJobLocation } from './lib/federal-job-normalization.mjs';
 import { getCompanyDefaults, getCantonDisplayName } from './lib/crawler-location-config.mjs';
 import { assertJsonListShape } from './lib/assert-json-list-shape.mjs';
@@ -222,7 +222,7 @@ function parseApiJob(j = {}) {
   // so we infer from the actual arbeitsort/city rather than trust the label.
   // A single-canton region label like "Ticino (TI)" is used only as last resort.
   const cantonMatch = regionRaw.match(/\(([A-Z]{2})\)$/);
-  const cantonFromRegion = cantonMatch ? cantonMatch[1] : '';
+  const cantonFromRegion = normalizeCantonCode(cantonMatch ? cantonMatch[1] : '');
   const canton = normalizedLocation.canton
     || inferAnyCanton(locationRaw)
     || inferAnyCanton(normalizedLocation.location || '')

--- a/scripts/update-efg-jobs.mjs
+++ b/scripts/update-efg-jobs.mjs
@@ -32,7 +32,7 @@ import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage } from './lib/
 import { parseEfgOracleDescription } from './lib/efg-job-parser.mjs';
 import { detectLanguage } from './lib/detect-language.mjs';
 import { isTargetCanton } from './lib/crawler-location-config.mjs';
-import { locTokenHit } from '../services/locToken.mjs';
+import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
@@ -91,26 +91,6 @@ function mapOracleRequisitionType(requisitionType) {
   if (type.includes('internship') || /\bstages?(?![a-zA-Z0-9_À-ÖØ-öø-ÿ])/.test(type)) return 'internship';
   return 'permanent';
 }
-
-/**
- * Map Swiss cities to their Ticino-relevance and canton codes.
- * EFG has offices in Lugano (TI), Zurich (ZH), Geneva (GE).
- */
-const SWISS_CITY_CANTON = {
-  lugano: 'TI',
-  bellinzona: 'TI',
-  locarno: 'TI',
-  mendrisio: 'TI',
-  chiasso: 'TI',
-  zurich: 'ZH',
-  zürich: 'ZH',
-  bern: 'BE',
-  geneve: 'GE',
-  geneva: 'GE',
-  genf: 'GE',
-  basel: 'BS',
-  lausanne: 'VD',
-};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -199,13 +179,7 @@ function extractCity(primaryLocation = '') {
  * Determine canton code from a city name or location string.
  */
 function detectCanton(location = '') {
-  const loc = normalize(location);
-  for (const [city, canton] of Object.entries(SWISS_CITY_CANTON)) {
-    // Whole-token match (#2630): bare loc.includes(city) assigned BE to a
-    // Geneva job ("bern" ⊂ "bernex"); the canton drives geo/SEO routing.
-    if (locTokenHit(loc, city)) return canton;
-  }
-  return '';
+  return inferAnyCanton(location) || '';
 }
 
 function isGenericLocation(value = '') {

--- a/scripts/update-fnz-jobs.mjs
+++ b/scripts/update-fnz-jobs.mjs
@@ -47,7 +47,7 @@ import {
   detectLang,
 } from './lib/dedicated-crawler-common.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
-import { isSwissLocationText } from './lib/target-swiss-locations.mjs';
+import { isSwissLocationText, inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
 import { crawlerScratchPathFor } from './lib/crawler-scratch-path.mjs';
 
@@ -265,18 +265,12 @@ function parseWorkdayLocation(locText = '') {
 }
 
 function inferCanton(location = '') {
-  const loc = normalize(location);
-  if (loc.includes('chiasso')) return 'TI';
-  if (loc.includes('lugano')) return 'TI';
-  if (loc.includes('mendrisio')) return 'TI';
-  if (loc.includes('manno')) return 'TI';
-  if (loc.includes('bellinzona')) return 'TI';
-  if (loc.includes('locarno')) return 'TI';
-  if (loc.includes('genev') || loc.includes('genf')) return 'GE';
-  if (loc.includes('zurich') || loc.includes('zürich')) return 'ZH';
-  if (loc.includes('bern') || loc.includes('berne')) return 'BE';
-  if (loc.includes('basel') || loc.includes('bâle')) return 'BS';
-  return '';
+  // Crawler keeps any Swiss location text (not just Chiasso/Geneva — see
+  // isSwissLocationText usage above, "other CH" self-heal), so canton
+  // resolution must cover all 26 cantons via the BFS municipality registry
+  // instead of a hand-rolled dict of just a handful of cities (would
+  // silently return '' for any other real Swiss site).
+  return inferAnyCanton(location);
 }
 
 /* ── Job building ──────────────────────────────────────────── */

--- a/scripts/update-medacta-jobs.mjs
+++ b/scripts/update-medacta-jobs.mjs
@@ -40,6 +40,7 @@ import {
   buildMedactaLocalizedDescriptions,
 } from './lib/medacta-job-enrichment.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { inferAnyCanton, normalizeCantonCode } from './lib/target-swiss-locations.mjs';
 import { assertJsonListShapeMultiKey } from './lib/assert-json-list-shape.mjs';
 import { exitCrawlerOnError } from './lib/crawler-template.mjs';
 import { writeJsonAtomic } from './lib/atomic-write-json.mjs';
@@ -113,25 +114,6 @@ const RD_MARKER_RE = /(?:\br\s*&\s*d\b|research\s*(?:&|and)\s*development)/i;
 
 const DEFAULT_CITY = 'Castel San Pietro';
 const DEFAULT_CANTON = HQ.canton;
-
-/**
- * Swiss cities and their canton codes for location detection.
- */
-const SWISS_CITY_CANTON = {
-  'castel san pietro': 'TI',
-  lugano: 'TI',
-  mendrisio: 'TI',
-  chiasso: 'TI',
-  bellinzona: 'TI',
-  locarno: 'TI',
-  zurich: 'ZH',
-  zürich: 'ZH',
-  bern: 'BE',
-  basel: 'BS',
-  geneve: 'GE',
-  geneva: 'GE',
-  lausanne: 'VD',
-};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -320,11 +302,7 @@ function dedupeMedactaJobsForPersistence(jobs = []) {
  * Determine canton code from a city name or location string.
  */
 function detectCanton(location = '') {
-  const loc = normalize(location);
-  for (const [city, canton] of Object.entries(SWISS_CITY_CANTON)) {
-    if (loc.includes(city)) return canton;
-  }
-  return '';
+  return inferAnyCanton(location) || '';
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -742,7 +720,7 @@ function parseAlliboLocation(raw = '', listPlaces = []) {
   if (Array.isArray(listPlaces) && listPlaces.length > 0) {
     const first = listPlaces[0] || {};
     const city = String(first.PlaceName || '').trim();
-    const canton = String(first.ProvinceCode || '').trim().toUpperCase();
+    const canton = normalizeCantonCode(first.ProvinceCode) || inferAnyCanton(city) || '';
     const country = String(first.CountryCode || 'CH').trim().toUpperCase();
     if (city) return { city, canton, country };
   }
@@ -755,7 +733,7 @@ function parseAlliboLocation(raw = '', listPlaces = []) {
   const match = stripped.match(/\/\s*([^()]+?)\s*\(([A-Z]{2})\)/);
   if (match) {
     const cityRaw = match[1].split(';')[0].trim();
-    const canton = match[2].toUpperCase();
+    const canton = normalizeCantonCode(match[2]) || inferAnyCanton(cityRaw) || '';
     return { city: cityRaw, canton, country: 'CH' };
   }
   return { city: '', canton: '', country: 'CH' };

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -99,12 +99,16 @@ describe('post-deploy-validate-dist.yml — parallel SEO audit gates', () => {
     //   not a dist-walking post-deploy gate.
     // - `audit:active-jobs-regression` is a pre-build data gate in deploy.yml.
     // - `audit:all` IS the wrapper itself; reachability check would be circular.
+    // - `audit:job-locations` runs on its own separate weekly workflow
+    //   (location-quality-audit.yml) — report-only monitoring, not a
+    //   deploy-blocking dist gate (same pattern as audit:title-uniqueness).
     const GATES_NOT_IN_DIST_PARALLEL = new Set([
       'audit:title-uniqueness',
       'audit:dist-multi',
       'audit:parser-quality',
       'audit:no-merge-markers',
       'audit:active-jobs-regression',
+      'audit:job-locations',
       'audit:all',
     ]);
     const allAuditScripts = Object.keys(PACKAGE_JSON.scripts || {}).filter((k) => {

--- a/tests/hirslanden-crawler.test.ts
+++ b/tests/hirslanden-crawler.test.ts
@@ -7,6 +7,7 @@ import {
   parseSearchResults,
   parseDetailPage,
   descriptionBodyToMarkdown,
+  resolveHirslandenLocation,
 } from '../scripts/lib/hirslanden-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -304,6 +305,24 @@ describe('Hirslanden Klinik crawler parser', () => {
     it('returns empty string for empty input', () => {
       expect(descriptionBodyToMarkdown('')).toBe('');
       expect(descriptionBodyToMarkdown('   ')).toBe('');
+    });
+  });
+
+  describe('resolveHirslandenLocation', () => {
+    it('prefers the clean listing-cell city when the detail text leaks trailing form-field noise', () => {
+      expect(resolveHirslandenLocation('Bern - Futsal Minerva Besetzung per: 1. Oktober 2026', 'Bern')).toBe('Bern');
+    });
+
+    it('keeps the detail text when it is itself a real known Swiss city', () => {
+      expect(resolveHirslandenLocation('Aarau', 'Aarau')).toBe('Aarau');
+    });
+
+    it('falls back to the listing city when the detail text is empty', () => {
+      expect(resolveHirslandenLocation('', 'Zürich')).toBe('Zürich');
+    });
+
+    it('passes garbage through unchanged when the listing city is not known either (fully unresolvable — caller skips it)', () => {
+      expect(resolveHirslandenLocation('Besetzung per: 1. Oktober 2026', '')).toBe('Besetzung per: 1. Oktober 2026');
     });
   });
 });

--- a/tests/ikea-crawler.test.ts
+++ b/tests/ikea-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   IKEA_COMPANY_NAME,
   isIkeaJob,
   isTrustedDomain,
+  resolveIkeaAddressRegion,
 } from '../scripts/lib/ikea-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -124,6 +125,22 @@ describe('IKEA crawler parser', () => {
 
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  describe('resolveIkeaAddressRegion', () => {
+    it('trusts the feed region when it agrees with the inferred canton', () => {
+      expect(resolveIkeaAddressRegion('TI', 'TI')).toBe('TI');
+      expect(resolveIkeaAddressRegion('ti', 'TI')).toBe('TI');
+    });
+
+    it('rejects a feed region that disagrees with the inferred canton', () => {
+      expect(resolveIkeaAddressRegion('BE', 'TI')).toBe('');
+    });
+
+    it('rejects a malformed (non 2-letter) feed region', () => {
+      expect(resolveIkeaAddressRegion('Aargau', 'AG')).toBe('');
+      expect(resolveIkeaAddressRegion('', 'AG')).toBe('');
     });
   });
 });

--- a/tests/jobs-seo-pages-plugin.test.ts
+++ b/tests/jobs-seo-pages-plugin.test.ts
@@ -6,6 +6,8 @@ import {
   JOB_SEO_LOCALES,
   pickSearchLandingFallbackJobs,
   capSearchStatsLandingTitle,
+  deriveJobCanton,
+  deriveJobAddressLocality,
 } from '../build-plugins/jobsSeoPagesPlugin';
 import { TITLE_MAX_CHARS } from '../build-plugins/shared/titleSuffix';
 
@@ -86,5 +88,51 @@ describe('capSearchStatsLandingTitle (#3589 sibling: same escape-unaware title-b
     const capped = capSearchStatsLandingTitle(rawTitle);
     expect(capped.length).toBeGreaterThan(0);
     expect(capped.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+  });
+});
+
+describe('deriveJobCanton — visible-page canton resolution', () => {
+  it('trusts an explicit canton code that is a real Swiss canton', () => {
+    expect(deriveJobCanton({ canton: 'BE' })).toBe('BE');
+    expect(deriveJobCanton({ addressRegion: 'zh' })).toBe('ZH');
+  });
+
+  it('rejects a well-formed-but-fake canton code and infers from location text instead', () => {
+    expect(deriveJobCanton({ canton: 'XX', location: 'Lugano' })).toBe('TI');
+  });
+
+  it('infers canton from addressLocality/location when no explicit canton is set', () => {
+    expect(deriveJobCanton({ addressLocality: 'Bern' })).toBe('BE');
+    expect(deriveJobCanton({ location: 'Winterthur' })).toBe('ZH');
+  });
+
+  it('falls back to the default canton (TI) when nothing resolves', () => {
+    expect(deriveJobCanton({})).toBe('TI');
+    expect(deriveJobCanton({ location: 'not a real place' })).toBe('TI');
+  });
+});
+
+describe('deriveJobAddressLocality — visible-page locality sanitization (Hirslanden Bern leak)', () => {
+  it('garbage/leaked free-text addressLocality never reaches the rendered page', () => {
+    const locality = deriveJobAddressLocality(
+      { addressLocality: 'Bern - Futsal Minerva Besetzung per: 1', location: 'Bern' },
+      'BE',
+    );
+    expect(locality).not.toBe('Bern - Futsal Minerva Besetzung per: 1');
+    expect(locality).toBe('Bern');
+  });
+
+  it('a real city from the WRONG canton is rejected, falling through to job.location then the canton capital', () => {
+    const locality = deriveJobAddressLocality({ addressLocality: 'Bellinzona' }, 'BE');
+    expect(locality).not.toBe('Bellinzona');
+    expect(locality).toBe('Bern'); // BE canton-capital, no coherent location fallback available
+  });
+
+  it('accepts a real city that agrees with the resolved region', () => {
+    expect(deriveJobAddressLocality({ addressLocality: 'Lugano' }, 'TI')).toBe('Lugano');
+  });
+
+  it('falls through to job.location when addressLocality is empty/invalid but location is coherent', () => {
+    expect(deriveJobAddressLocality({ location: 'Winterthur' }, 'ZH')).toBe('Winterthur');
   });
 });

--- a/tests/seo/jobposting-address-coherence.test.ts
+++ b/tests/seo/jobposting-address-coherence.test.ts
@@ -84,6 +84,42 @@ describe('buildJobPostingSchema — address coherence (#3513)', () => {
     expect(s.jobLocation.address.streetAddress).toBe('Via Nassa 5');
     expect(s.jobLocation.address.postalCode).toBe('6900');
   });
+
+  it('garbage/leaked free-text locality (Hirslanden Arbeitsort leak) never survives into the schema', () => {
+    const s = buildJobPostingSchema(
+      {
+        ...baseJob,
+        company: 'Hirslanden Klinik',
+        companyKey: 'hirslanden-klinik',
+        addressLocality: 'Bern - Futsal Minerva Besetzung per: 1',
+        addressRegion: 'BE',
+      },
+      OPTS,
+    );
+    const addr = s.jobLocation.address;
+    expect(addr.addressLocality).not.toBe('Bern - Futsal Minerva Besetzung per: 1');
+    expect(addr.addressLocality).toBe('Bern'); // BE canton-capital fallback, no HQ/city match
+    expect(addr.addressRegion).toBe('BE');
+    expect(addr.streetAddress.length).toBeGreaterThan(0);
+  });
+
+  it('real city from the WRONG canton (Bellinzona/TI text with addressRegion BE) never pairs mismatched', () => {
+    const s = buildJobPostingSchema(
+      {
+        ...baseJob,
+        company: 'Hirslanden Klinik',
+        companyKey: 'hirslanden-klinik',
+        addressLocality: 'Bellinzona',
+        addressRegion: 'BE',
+      },
+      OPTS,
+    );
+    const addr = s.jobLocation.address;
+    expect(addr.addressLocality).not.toBe('Bellinzona');
+    expect(addr.addressLocality).toBe('Bern'); // coherent with the authoritative BE region
+    expect(addr.addressRegion).toBe('BE');
+    expect(addr.postalCode).toBe('3001'); // resolvePostalCode('Bern', 'BE') — a real Bern CAP
+  });
 });
 
 describe('shared locality helpers (#3513)', () => {


### PR DESCRIPTION
## Summary

Fixes a live data-quality bug where crawled job locations could surface a canton that doesn't match the job's real location, or a non-canonical value entirely — e.g. the reported Hirslanden Klinik (Bellinzona-region jobs mislabeled "Berna"/Bern):
- https://frontaliereticino.ch/cerca-lavoro-berna/le-tue-domande-hirslanden-klinik-physiotherapeutin-sportphysiotherapeut/
- https://frontaliereticino.ch/cerca-lavoro-berna/mansioni-richieste-hirslanden-klinik-search-91906e/

Two parts, as requested:
1. **Root-cause fix across ALL crawlers** (not just the two reported instances) — every crawled location must resolve to one of our canonical Swiss locations, never a custom/invalid value.
2. **Monitoring** — a weekly workflow that audits the live dataset and opens an issue with numeric location-quality findings (custom locations, company-default fallbacks).

## Implementato

- Root-caused and fixed the canton-mismatch/non-canonical-location bug across ~30 crawler/parser files (list below), not just the two reported Hirslanden instances.
- Fixed the schema/plugin-layer coherence gap (`jobPostingSchema.ts`, `companyHqAddresses.ts`, `hirslanden-job-parser.mjs`, `ikea-job-parser.mjs`, `assemble-jobs-dataset.mjs`) so a locality can never ship paired with a canton it doesn't belong to.
- Added `companyDefaultFallback` detection to `scripts/audit-job-locations.mjs` and a new weekly `.github/workflows/location-quality-audit.yml` that opens a tracking issue with numeric location-quality findings.
- Verified: `node -c` on every changed file, full targeted vitest run (15 files / 210 tests) green, re-verified after rebase.

### Root cause

Two recurring antipatterns, found across many independent crawler files:

- **Untrusted-code-trust**: a bare 2-letter token regex-extracted from an API/region/feed field (e.g. `addressRegion`, `state`, `ProvinceCode`) was trusted as a valid canton code purely because it *looked* like one (`/^[A-Z]{2}$/`), without checking it against the real 26-canton registry.
- **Narrow hand-rolled city dict as sole/primary resolver**: a hardcoded ~10-50-city if-chain/map, built for the company's historically-known sites, silently force-defaulted every *unlisted* city to one hardcoded canton (or, in the worst case — `pizzarotti-job-parser.mjs` — an outright invalid value, the literal string `'CH'`, which isn't a real canton code at all).

Both shapes let a crawled location either ship a non-canonical value or get mismapped to a canton the job was never posted in.

### Fix

Routed every affected crawler/resolver through the existing registry-backed helpers in `scripts/lib/target-swiss-locations.mjs`:
- `normalizeCantonCode(raw)` — validates a 2-letter code against the real `SWISS_CANTONS` registry, returns `''` if invalid (never trust a well-formed-looking-but-wrong code).
- `inferAnyCanton(text)` — comprehensive BFS-backed resolver, all 26 cantons / ~2110 municipalities, fuzzy-tolerant, returns `''` on no match (replaces narrow hand-rolled city dicts).

### Files fixed

**Untrusted-code-trust (bare code accepted without registry validation):**
- `scripts/lib/breitling-job-parser.mjs`, `scripts/lib/ghol-job-parser.mjs`, `scripts/lib/holcim-job-parser.mjs`, `scripts/lib/spitex-ch-job-parser.mjs`, `scripts/lib/stadler-rail-job-parser.mjs`, `scripts/lib/triaplus-job-parser.mjs`, `scripts/lib/hornbach-job-parser.mjs`, `scripts/lib/kuehne-nagel-job-parser.mjs`, `scripts/lib/mcdonalds-job-parser.mjs`, `scripts/lib/novelis-job-parser.mjs`, `scripts/lib/successfactors-shared-job-parser-common.mjs` (15 companies share this parser), `scripts/update-confederazione-jobs.mjs`, `scripts/update-medacta-jobs.mjs` (also fixes `parseAlliboLocation`'s two untrusted-code sites), `scripts/crawl-guidle-events.mjs` (re-trusted `cantonHint` even after the registry lookup had already rejected it), `scripts/lib/dedicated-crawler-common.mjs` (`hardenJobsRichResultsData`), `build-plugins/salaryProfessionCantonPages.ts` (`jobDetailUrl`).

**Narrow hand-rolled city dict as sole/primary resolver:**
- `scripts/lib/solina-job-parser.mjs` (6-canton if-chain), `scripts/lib/a-plus-plus-job-parser.mjs` (TI/GR-only regex despite own comment noting other Swiss positions possible), `scripts/update-bracco-jobs.mjs`, `scripts/update-fnz-jobs.mjs` (~11-city if-chain each), `scripts/lib/vir-biotechnology-job-parser.mjs` (8-city if-chain), `scripts/lib/pallas-kliniken-job-parser.mjs`, `scripts/lib/sodexo-job-parser.mjs` (~30-city dicts each), `scripts/update-efg-jobs.mjs`, `scripts/update-medacta-jobs.mjs` (`detectCanton`, separate from the Allibo fix above), `scripts/lib/vitrea-gesundheit-job-parser.mjs` (kept only the one non-BFS-registered HQ alias "Seewis" as an explicit pre-check), `build-plugins/shared/companyHqAddresses.ts` (`deriveCantonFromCity` — ~50-city dict + manual parenthetical splitter).
- **`scripts/lib/pizzarotti-job-parser.mjs`** — most severe: unconditionally returned the literal string `'CH'` (ISO country code, not a canton) as the final fallback, shipped directly into both `addressRegion` and `canton` with zero downstream gating. Direct match to the reported bug class.

**Schema/plugin-layer coherence (locality vs. canton must agree):**
- `build-plugins/shared/jobPostingSchema.ts` — `resolveCanton()` now validates explicit codes and falls through to `inferAnyCanton()` before the older city dict; added `sanitizeLocalityForRegion()` so a JobPosting never pairs a locality with a canton it doesn't belong to (rejects unknown/garbage localities and cross-canton mismatches, e.g. "Bellinzona" text next to `addressRegion: "BE"`).
- `build-plugins/shared/companyHqAddresses.ts` — `resolveFallbackAddress()` now accepts an `authoritativeRegion` so the HQ/canton-capital fallback stays consistent with the already-resolved canton instead of re-deriving one from a (possibly rejected) city.
- `scripts/lib/hirslanden-job-parser.mjs` — new `resolveHirslandenLocation()` prevents SF-form-field noise leaking past the real city into `addressLocality` (root cause of the reported Bern-labeled Bellinzona-region listings: the detail page's free-text "Arbeitsort:" line collapsed onto one line with trailing junk like "Bern - Futsal Minerva Besetzung per: 1. Oktober 2026").
- `scripts/lib/ikea-job-parser.mjs` — new `resolveIkeaAddressRegion()` only trusts the feed's `addressRegion` when it agrees with the independently-inferred canton.
- `scripts/assemble-jobs-dataset.mjs` — when `acceptBadLocalityViaCanton` rescues a job via its canton, the garbage `primaryLoc` text is no longer shipped verbatim as `addressLocality`/`location`; rescues the real city from the description body when findable.

*(`build-plugins/jobsSeoPagesPlugin.ts` hardening (`deriveCanton`/`mapCantonJobToListItem`) landed earlier in this same effort, prior to this diff's HEAD.)*

### Monitoring

- `scripts/audit-job-locations.mjs` — added `companyDefaultFallback` detection: an empirical per-company "modal canton" (most frequent stored canton across that company's own jobs, derived from the dataset itself — not a hand-maintained dict, so it can't become another sibling-class bug) flags `cantonMismatch` records where the stored (wrong) canton equals the company's modal value, i.e. the signature of a parser silently defaulting instead of resolving the real location. `unknownCity` is now explicitly labeled/aliased as `customLocation` in the JSON report.
- `.github/workflows/location-quality-audit.yml` (new) — weekly cron (Wed 09:10 UTC) + manual dispatch, assembles the dataset then runs the audit, opens/updates one stable-title tracking issue with the numeric breakdown (custom locations, canton mismatches, company-default fallbacks). Report-only, not a deploy gate — same shape as `audit-404-risk.yml`.
- `package.json` — added `audit:job-locations` script entry; `.gitignore` — added the report's local output path.

### Testing

`node -c` on every changed `.mjs`/`.js` file. Full targeted vitest run (15 files / 210 tests, including `a-plus-plus-job-parser`, `crawl-guidle-events`, `dedicated-crawler-common`, `efg-job-parser`, `hornbach-crawler`, `kuehne-nagel-crawler`, `medacta-job-enrichment`, `novelis-crawler`, `solina-job-parser`, `successfactors-client`, `vir-biotechnology-crawler`, `hirslanden-crawler`, `ikea-crawler`, `jobs-seo-pages-plugin`, `seo/jobposting-address-coherence`) — all green, re-verified after rebasing onto `origin/main`.

## Non implementato (ancora)

Nessuno — both requested deliverables (root-cause mapping fix across all crawlers, monitoring workflow) are complete and merged into this branch.

## Sibling-pattern triage (AGENTS.md #6) — confirmed false positives

Per AGENTS.md #6, `scripts/ci/check-sibling-patterns.mjs --strict` was run to completion against this diff and surfaced candidates were individually triaged (not blanket-dismissed). None of the following were modified — each is a confirmed false positive or has no canton-resolution logic at all, with its own reason:

**Already safe — calls `inferAnyCanton()`/registry validation FIRST, narrow checks are redundant belt-and-suspenders with a static single-real-site HQ default (accepted pattern used throughout the codebase):**
`scripts/lib/huntsman-job-parser.mjs`, `scripts/lib/arxada-job-parser.mjs`, `scripts/lib/constellium-job-parser.mjs`, `scripts/lib/fondation-domus-job-parser.mjs`, `scripts/lib/giorgio-armani-job-parser.mjs`, `scripts/lib/senevita-job-parser.mjs`, `scripts/lib/concordia-job-parser.mjs`, `scripts/lib/css-versicherung-job-parser.mjs`, `scripts/lib/kanton-solothurn-job-parser.mjs`, `scripts/lib/lonza-job-parser.mjs`, `scripts/lib/nvidia-zurich-job-parser.mjs`, `scripts/lib/siegfried-job-parser.mjs`, `scripts/lib/zfv-unternehmungen-job-parser.mjs`, `scripts/lib/axa-job-parser.mjs`, `scripts/update-axa-jobs.mjs`, `scripts/lib/benteler-job-parser.mjs`, `scripts/lib/clariant-job-parser.mjs`, `scripts/lib/croix-rouge-fribourgeoise-job-parser.mjs`, `scripts/lib/debiopharm-job-parser.mjs`, `scripts/lib/edmond-de-rothschild-job-parser.mjs`, `scripts/lib/etat-de-vaud-job-parser.mjs`, `scripts/lib/fielmann-job-parser.mjs`, `scripts/lib/galliker-job-parser.mjs`, `scripts/lib/givaudan-job-parser.mjs`, `scripts/lib/hitachi-energy-job-parser.mjs`, `scripts/update-hitachi-energy-jobs.mjs`, `scripts/lib/honegger-job-parser.mjs`, `scripts/lib/josef-mueller-job-parser.mjs`, `scripts/lib/logitech-job-parser.mjs`, `scripts/lib/otis-job-parser.mjs`, `scripts/lib/patek-philippe-job-parser.mjs`, `scripts/lib/planzer-job-parser.mjs`, `scripts/lib/psgn-job-parser.mjs`, `scripts/lib/smg-swiss-marketplace-group-job-parser.mjs`, `scripts/lib/spital-thurgau-job-parser.mjs`, `scripts/lib/swica-job-parser.mjs`, `scripts/lib/swisslog-job-parser.mjs`, `scripts/lib/thermo-fisher-scientific-job-parser.mjs`, `scripts/lib/ubp-job-parser.mjs`, `scripts/lib/agroscope-job-parser.mjs`, `scripts/lib/suva-job-parser.mjs`, `scripts/lib/ubs-job-parser.mjs`, `scripts/lib/tertianum-job-parser.mjs`, `scripts/update-ist-jobs.mjs`, `scripts/update-sbb-jobs.mjs`, `scripts/update-axpo-jobs.mjs`, `scripts/update-burkhalter-jobs.mjs`, `scripts/update-cler-jobs.mjs`, `scripts/update-galenica-jobs.mjs`, `scripts/update-manor-jobs.mjs`, `scripts/update-sunrise-jobs.mjs`, `scripts/update-swisscom-jobs.mjs`, `scripts/update-vtg-jobs.mjs`, `scripts/update-groupe-mutuel-jobs.mjs`, `scripts/lidl-job-parser.mjs` / `scripts/lib/lidl-job-parser.mjs`, `scripts/update-a-plus-plus-group-jobs.mjs` (consumes the now-fixed `inferAplusCanton`).

**Deal in postal codes or a single inherently-scoped canton, not canton-trust logic:**
`scripts/lib/kanton-gr-job-parser.mjs`, `scripts/lib/pdgr-job-parser.mjs`, `scripts/lib/kanton-basel-landschaft-job-parser.mjs`, `scripts/update-kanton-basel-landschaft-jobs.mjs` (single-canton entities by construction; postal codes are a different domain than canton codes).

**Config/registry data or reference-grade helpers already built on the safe primitives:**
`scripts/lib/crawler-location-config.mjs` (source of `TARGET_CANTONS`/`isTargetCanton`, re-exported — not consumed), `scripts/lib/target-swiss-locations.mjs` itself (the fix target, not a sibling), `scripts/lib/canton-quorum-gate.mjs` ("gate NEVER throws", built entirely on `normalizeCantonCode`/`inferAnyCanton`), `build-plugins/shared/cantonResolvers.mjs`, `functions/src/lib/cantonUrlSlugs.json` (self-documented canonical registry, "Source truth"), `scripts/lib/events-utils.mjs` (`resolveComuneNationwide`/`isValidCantonCode`/`loadCantonComuni` — bogus canton key safely yields `[]`, plus an explicit final `isValidCantonCode(hint)` gate), `scripts/lib/orphan-canton-paths.mjs`.

**UI/display/prose/translation content only — no resolution logic:**
`build-plugins/shared/cantonCities.ts`, `build-plugins/shared/cantonSalaryIndex.ts`, `build-plugins/shared/cantonSeoProse.ts`, `build-plugins/shared/cantonSnapshotProse.ts`, `build-plugins/shared/companyHubFrontalierContext.ts`, `build-plugins/shared/jobPostingFaq.ts`, `build-plugins/shared/jobPostingListItem.ts`, `build-plugins/shared/postalCodes.ts`, `build-plugins/healthFacilitiesPlugin.ts`, `build-plugins/healthPremiumsData.ts`, `build-plugins/healthPremiumsLandingPlugin.ts`, `build-plugins/salaryStatsData.ts`, `build-plugins/publisherAdPagesPlugin.ts`, `build-plugins/employerProfilePagesPlugin.ts`, `build-plugins/minimumWageLandingsData.ts`, `build-plugins/staticPagesPlugin.ts`, `build-plugins/jobMarketSnapshotChCantonPages.ts`, `build-plugins/weeklyEmployersPlugin.ts`, `build-plugins/orphanQueryData.ts`, `components/community/JobBoard.tsx`, `components/community/JobAlertForm.tsx`, `components/vita/TicinoCompanies.tsx`, `components/pages/HealthPremiumStats.tsx`, `services/seoService.ts`, `services/chatbotTools.ts`, `services/cantonList.ts`, `services/routerBlogData.ts`, `services/routerSwissData.ts`, `services/locales/de-core.ts`, `services/locales/en-core.ts`, `services/locales/fr-core.ts`, `services/locales/it-core.ts`, `services/locales/blog-body-ch/fr/cicor-piano-efficienza-tagli-lavoro.ts`, `services/locales/blog-body/fr/eventi-weekend-ticino.ts`, `services/locales/blog-body/fr/moria-pesci-berneck-2026.ts`, `services/locales/blog-body/fr/prevenzione-violenza-domestica-san-gallo-2026.ts` (pure prose/literal place-name strings, not resolution logic).

**No canton-resolution logic at all (unrelated shared token/construct match only):**
`services/relatedSearchClusters.ts`, `services/search/fuzzySearchSuggestions.ts`, `services/weather/aggregator.ts`, `services/jobAlertMatching.mjs`, `services/savedJobsService.ts`, `services/locToken.mjs`, `services/newsletter-content.mjs` (uses the already-safe `cantonResolvers.mjs`), `functions/src/jobAlertBackfillCore.js`, `functions/src/lib/jobBoardUrlCanton.js`, `scripts/create-article.mjs`, `scripts/import-swiss-hospitals.mjs`, `scripts/audit-parser-quality.mjs`, `scripts/audit-related-search-candidates.mjs`, `scripts/build-search-cluster-301-map.mjs`, `scripts/crawl-myswitzerland-events.mjs`, `scripts/dev/repair-canton-only-label-pins.mjs`, `scripts/profession-keyword-opportunities.mjs`, `scripts/repair-job-locations.mjs`, `scripts/send-job-alerts.mjs`, `scripts/lib/breezy-hr-common.mjs`, `scripts/lib/parser-quality-3721-crawlers.mjs`, `scripts/lib/resolve-data-path.mjs`, `scripts/lib/git-commit-data.sh`, `.github/workflows/crawler-group-08.yml`.
