### PR TITLE
perf(deploy): parallelize section shard push/pack/upload + dedupe rehydrate loops

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -562,12 +562,29 @@ jobs:
           # Actions UI) when any section genuinely failed. Incident
           # 2026-07-24 (run 30057726623): svizzera-it's push failure silently
           # aborted this loop before zurigo-it was even attempted.
+          #
+          # Bounded-parallel, not unbounded: push-section-shard.sh's own
+          # header (see "$stage ... leaked disk" note) documents issue #4734
+          # — concurrent `stage` clones (up to several GB each for
+          # ticino/svizzera/zurigo) piling up unfreed exhausted runner disk
+          # even under the OLD sequential loop. Capping concurrent in-flight
+          # pushes keeps peak `stage` usage bounded to MAX_PARALLEL sections
+          # at a time instead of scaling with the full 27-section list.
+          MAX_PARALLEL=4
           fail=0
+          pids=(); names=()
           for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            bash scripts/lib/push-section-shard.sh "$section" it dist || {
-              echo "::warning::$section-it shard push step failed — continuing to the next section"
-              fail=1
-            }
+            bash scripts/lib/push-section-shard.sh "$section" it dist &
+            pids+=("$!"); names+=("$section")
+            if [ "${#pids[@]}" -ge "$MAX_PARALLEL" ]; then
+              for idx in "${!pids[@]}"; do
+                wait "${pids[$idx]}" || { echo "::warning::${names[$idx]}-it shard push step failed — continuing to the next section"; fail=1; }
+              done
+              pids=(); names=()
+            fi
+          done
+          for idx in "${!pids[@]}"; do
+            wait "${pids[$idx]}" || { echo "::warning::${names[$idx]}-it shard push step failed — continuing to the next section"; fail=1; }
           done
           exit "$fail"
 
@@ -617,16 +634,23 @@ jobs:
           ARTICOLISVIZZERA_SHARD_LIVE: ${{ vars.ARTICOLISVIZZERA_SHARD_LIVE }}
         run: |
           set -uo pipefail
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
+          # Bounded-parallel (cap 4, mirrors the push step above): tar +
+          # file-count-verify is CPU/IO-bound and independent per section
+          # (each reads/writes its own $RUNNER_TEMP/<section>-* paths, no
+          # cross-section overlap) — safe to fan out, capped for the same
+          # runner-disk-pressure reason as the push step.
+          pack_section() {
+            local section="$1"
+            local live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
             if [ "${!live_var:-}" != "true" ]; then
-              continue
+              return 0
             fi
+            local sub src packed_n src_n
             sub="$(jq -r --arg s "$section" --arg l "it" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
             src="$RUNNER_TEMP/${section}-src-it/dist"
             if [ ! -d "$src/$sub" ]; then
               echo "no staged $section-it subtree (push skipped/failed) — validate-dist will fall back to git clone"
-              continue
+              return 0
             fi
             tar -C "$src" -cf "$RUNNER_TEMP/$section-dist-it.tar" "$sub"
             ls -lh "$RUNNER_TEMP/$section-dist-it.tar"
@@ -644,10 +668,23 @@ jobs:
               rm -f "$RUNNER_TEMP/$section-dist-it.tar"
             fi
             rm -rf "$src"
+          }
+          MAX_PARALLEL=4
+          pids=()
+          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
+            pack_section "$section" &
+            pids+=("$!")
+            if [ "${#pids[@]}" -ge "$MAX_PARALLEL" ]; then
+              for pid in "${pids[@]}"; do wait "$pid"; done
+              pids=()
+            fi
           done
+          for pid in "${pids[@]}"; do wait "$pid"; done
       - name: Upload ticino shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.TICINO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-ticino-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: ticino-dist-it-${{ github.run_id }}
@@ -658,6 +695,8 @@ jobs:
       - name: Upload svizzera shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.SVIZZERA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-svizzera-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: svizzera-dist-it-${{ github.run_id }}
@@ -668,6 +707,8 @@ jobs:
       - name: Upload zurigo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.ZURIGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-zurigo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: zurigo-dist-it-${{ github.run_id }}
@@ -678,6 +719,8 @@ jobs:
       - name: Upload argovia shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.ARGOVIA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-argovia-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: argovia-dist-it-${{ github.run_id }}
@@ -688,6 +731,8 @@ jobs:
       - name: Upload appenzello shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.APPENZELLO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-appenzello-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: appenzello-dist-it-${{ github.run_id }}
@@ -698,6 +743,8 @@ jobs:
       - name: Upload basilea shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.BASILEA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-basilea-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: basilea-dist-it-${{ github.run_id }}
@@ -708,6 +755,8 @@ jobs:
       - name: Upload berna shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.BERNA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-berna-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: berna-dist-it-${{ github.run_id }}
@@ -718,6 +767,8 @@ jobs:
       - name: Upload friburgo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.FRIBURGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-friburgo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: friburgo-dist-it-${{ github.run_id }}
@@ -728,6 +779,8 @@ jobs:
       - name: Upload ginevra shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.GINEVRA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-ginevra-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: ginevra-dist-it-${{ github.run_id }}
@@ -738,6 +791,8 @@ jobs:
       - name: Upload glarona shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.GLARONA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-glarona-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: glarona-dist-it-${{ github.run_id }}
@@ -748,6 +803,8 @@ jobs:
       - name: Upload grigioni shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.GRIGIONI_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-grigioni-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: grigioni-dist-it-${{ github.run_id }}
@@ -758,6 +815,8 @@ jobs:
       - name: Upload giura shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.GIURA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-giura-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: giura-dist-it-${{ github.run_id }}
@@ -768,6 +827,8 @@ jobs:
       - name: Upload lucerna shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.LUCERNA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-lucerna-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: lucerna-dist-it-${{ github.run_id }}
@@ -778,6 +839,8 @@ jobs:
       - name: Upload neuchatel shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.NEUCHATEL_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-neuchatel-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: neuchatel-dist-it-${{ github.run_id }}
@@ -788,6 +851,8 @@ jobs:
       - name: Upload nidvaldo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.NIDVALDO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-nidvaldo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: nidvaldo-dist-it-${{ github.run_id }}
@@ -798,6 +863,8 @@ jobs:
       - name: Upload obvaldo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.OBVALDO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-obvaldo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: obvaldo-dist-it-${{ github.run_id }}
@@ -808,6 +875,8 @@ jobs:
       - name: Upload sciaffusa shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.SCIAFFUSA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-sciaffusa-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: sciaffusa-dist-it-${{ github.run_id }}
@@ -818,6 +887,8 @@ jobs:
       - name: Upload soletta shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.SOLETTA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-soletta-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: soletta-dist-it-${{ github.run_id }}
@@ -828,6 +899,8 @@ jobs:
       - name: Upload svitto shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.SVITTO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-svitto-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: svitto-dist-it-${{ github.run_id }}
@@ -838,6 +911,8 @@ jobs:
       - name: Upload turgovia shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.TURGOVIA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-turgovia-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: turgovia-dist-it-${{ github.run_id }}
@@ -848,6 +923,8 @@ jobs:
       - name: Upload uri shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.URI_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-uri-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: uri-dist-it-${{ github.run_id }}
@@ -858,6 +935,8 @@ jobs:
       - name: Upload vaud shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.VAUD_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-vaud-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: vaud-dist-it-${{ github.run_id }}
@@ -868,6 +947,8 @@ jobs:
       - name: Upload vallese shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.VALLESE_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-vallese-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: vallese-dist-it-${{ github.run_id }}
@@ -878,6 +959,8 @@ jobs:
       - name: Upload zugo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.ZUGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-zugo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: zugo-dist-it-${{ github.run_id }}
@@ -888,6 +971,8 @@ jobs:
       - name: Upload sangallo shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.SANGALLO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-sangallo-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: sangallo-dist-it-${{ github.run_id }}
@@ -898,6 +983,8 @@ jobs:
       - name: Upload articolifrontaliere shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.ARTICOLIFRONTALIERE_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-articolifrontaliere-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: articolifrontaliere-dist-it-${{ github.run_id }}
@@ -908,6 +995,8 @@ jobs:
       - name: Upload articolisvizzera shard dist for post-deploy validation
         if: matrix.locale == 'it' && vars.ARTICOLISVIZZERA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-articolisvizzera-it
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: articolisvizzera-dist-it-${{ github.run_id }}
@@ -915,6 +1004,10 @@ jobs:
           compression-level: 1
           retention-days: 1
           if-no-files-found: ignore
+
+      - name: Wait for section shard uploads (IT)
+        if: matrix.locale == 'it'
+        wait-all: true
 
       - name: Strip section subtrees (IT)
         if: matrix.locale == 'it'
@@ -1282,12 +1375,28 @@ jobs:
           # Actions UI) when any section genuinely failed. Incident
           # 2026-07-24 (run 30057726623): svizzera-it's push failure silently
           # aborted this loop before zurigo-it was even attempted.
+          # Bounded-parallel, not unbounded: push-section-shard.sh's own
+          # header documents issue #4734 — concurrent `stage` clones (up to
+          # several GB each for ticino/svizzera/zurigo) piling up unfreed
+          # exhausted runner disk even under the OLD sequential loop. Capping
+          # concurrent in-flight pushes keeps peak `stage` usage bounded to
+          # MAX_PARALLEL sections at a time instead of scaling with the full
+          # 27-section list.
+          MAX_PARALLEL=4
           fail=0
+          pids=(); names=()
           for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            bash scripts/lib/push-section-shard.sh "$section" "${{ matrix.locale }}" dist || {
-              echo "::warning::$section-${{ matrix.locale }} shard push step failed — continuing to the next section"
-              fail=1
-            }
+            bash scripts/lib/push-section-shard.sh "$section" "${{ matrix.locale }}" dist &
+            pids+=("$!"); names+=("$section")
+            if [ "${#pids[@]}" -ge "$MAX_PARALLEL" ]; then
+              for idx in "${!pids[@]}"; do
+                wait "${pids[$idx]}" || { echo "::warning::${names[$idx]}-${{ matrix.locale }} shard push step failed — continuing to the next section"; fail=1; }
+              done
+              pids=(); names=()
+            fi
+          done
+          for idx in "${!pids[@]}"; do
+            wait "${pids[$idx]}" || { echo "::warning::${names[$idx]}-${{ matrix.locale }} shard push step failed — continuing to the next section"; fail=1; }
           done
           exit "$fail"
 
@@ -1331,17 +1440,21 @@ jobs:
         run: |
           set -uo pipefail
           loc="${{ matrix.locale }}"
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
+          # Bounded-parallel (cap 4) — see the IT leg's "Pack section shard
+          # dist" step above for the full rationale.
+          pack_section() {
+            local section="$1"
+            local live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
             if [ "${!live_var:-}" != "true" ]; then
-              continue
+              return 0
             fi
+            local slug sub src packed_n src_n
             slug="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
             sub="$loc/$slug"
             src="$RUNNER_TEMP/${section}-src-$loc/dist"
             if [ ! -d "$src/$sub" ]; then
               echo "no staged $section-$loc subtree (push skipped/failed) — validate-dist will fall back to git clone"
-              continue
+              return 0
             fi
             tar -C "$src" -cf "$RUNNER_TEMP/$section-dist-$loc.tar" "$sub"
             ls -lh "$RUNNER_TEMP/$section-dist-$loc.tar"
@@ -1358,10 +1471,23 @@ jobs:
               rm -f "$RUNNER_TEMP/$section-dist-$loc.tar"
             fi
             rm -rf "$src"
+          }
+          MAX_PARALLEL=4
+          pids=()
+          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
+            pack_section "$section" &
+            pids+=("$!")
+            if [ "${#pids[@]}" -ge "$MAX_PARALLEL" ]; then
+              for pid in "${pids[@]}"; do wait "$pid"; done
+              pids=()
+            fi
           done
+          for pid in "${pids[@]}"; do wait "$pid"; done
       - name: Upload ticino shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.TICINO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-ticino-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: ticino-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1372,6 +1498,8 @@ jobs:
       - name: Upload svizzera shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.SVIZZERA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-svizzera-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: svizzera-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1382,6 +1510,8 @@ jobs:
       - name: Upload zurigo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.ZURIGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-zurigo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: zurigo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1392,6 +1522,8 @@ jobs:
       - name: Upload argovia shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.ARGOVIA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-argovia-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: argovia-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1402,6 +1534,8 @@ jobs:
       - name: Upload appenzello shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.APPENZELLO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-appenzello-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: appenzello-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1412,6 +1546,8 @@ jobs:
       - name: Upload basilea shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.BASILEA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-basilea-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: basilea-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1422,6 +1558,8 @@ jobs:
       - name: Upload berna shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.BERNA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-berna-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: berna-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1432,6 +1570,8 @@ jobs:
       - name: Upload friburgo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.FRIBURGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-friburgo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: friburgo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1442,6 +1582,8 @@ jobs:
       - name: Upload ginevra shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.GINEVRA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-ginevra-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: ginevra-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1452,6 +1594,8 @@ jobs:
       - name: Upload glarona shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.GLARONA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-glarona-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: glarona-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1462,6 +1606,8 @@ jobs:
       - name: Upload grigioni shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.GRIGIONI_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-grigioni-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: grigioni-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1472,6 +1618,8 @@ jobs:
       - name: Upload giura shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.GIURA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-giura-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: giura-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1482,6 +1630,8 @@ jobs:
       - name: Upload lucerna shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.LUCERNA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-lucerna-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: lucerna-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1492,6 +1642,8 @@ jobs:
       - name: Upload neuchatel shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.NEUCHATEL_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-neuchatel-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: neuchatel-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1502,6 +1654,8 @@ jobs:
       - name: Upload nidvaldo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.NIDVALDO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-nidvaldo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: nidvaldo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1512,6 +1666,8 @@ jobs:
       - name: Upload obvaldo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.OBVALDO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-obvaldo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: obvaldo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1522,6 +1678,8 @@ jobs:
       - name: Upload sciaffusa shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.SCIAFFUSA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-sciaffusa-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: sciaffusa-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1532,6 +1690,8 @@ jobs:
       - name: Upload soletta shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.SOLETTA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-soletta-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: soletta-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1542,6 +1702,8 @@ jobs:
       - name: Upload svitto shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.SVITTO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-svitto-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: svitto-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1552,6 +1714,8 @@ jobs:
       - name: Upload turgovia shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.TURGOVIA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-turgovia-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: turgovia-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1562,6 +1726,8 @@ jobs:
       - name: Upload uri shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.URI_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-uri-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: uri-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1572,6 +1738,8 @@ jobs:
       - name: Upload vaud shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.VAUD_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-vaud-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: vaud-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1582,6 +1750,8 @@ jobs:
       - name: Upload vallese shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.VALLESE_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-vallese-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: vallese-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1592,6 +1762,8 @@ jobs:
       - name: Upload zugo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.ZUGO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-zugo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: zugo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1602,6 +1774,8 @@ jobs:
       - name: Upload sangallo shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.SANGALLO_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-sangallo-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: sangallo-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1612,6 +1786,8 @@ jobs:
       - name: Upload articolifrontaliere shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.ARTICOLIFRONTALIERE_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-articolifrontaliere-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: articolifrontaliere-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1622,6 +1798,8 @@ jobs:
       - name: Upload articolisvizzera shard dist for post-deploy validation
         if: matrix.locale != 'it' && vars.ARTICOLISVIZZERA_SHARD_LIVE == 'true'
         continue-on-error: true
+        id: up-articolisvizzera-nonit
+        background: true
         uses: actions/upload-artifact@v7
         with:
           name: articolisvizzera-dist-${{ matrix.locale }}-${{ github.run_id }}
@@ -1629,6 +1807,10 @@ jobs:
           compression-level: 1
           retention-days: 1
           if-no-files-found: ignore
+
+      - name: Wait for section shard uploads (non-IT)
+        if: matrix.locale != 'it'
+        wait-all: true
 
       - name: Strip section subtrees (non-IT)
         if: matrix.locale != 'it'

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -433,67 +433,6 @@ jobs:
             df -h / | tail -1
           }
 
-          rehydrate_section() {
-            set -uo pipefail
-            local section="$1"
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                # Completeness, not just existence (#2761 item 2, mirrors the locale
-                # rehydrate above): `[ -d dist/$sub ]` alone only proves SOME files
-                # landed, not that extraction finished. Compare what the tar itself
-                # claims to contain (`tar -tf`, empty on a corrupt header) against
-                # what actually landed on disk after extraction — catches a
-                # truncated/corrupted tar that a bare directory check would miss.
-                # `|| true` throughout: any anomaly here must fall through to the
-                # git-clone fallback below, not abort under `set -e`.
-                expected_n=$(tar -tf "$dl/$section-dist-$loc.tar" 2>/dev/null | { grep -vc '/$' || true; })
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                actual_n=0
-                if [ -d "dist/$sub" ]; then
-                  actual_n=$(find "dist/$sub" -type f | wc -l)
-                fi
-                if [ -d "dist/$sub" ] && [ "${expected_n:-0}" -gt 0 ] && [ "$actual_n" -ge "$expected_n" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $actual_n files (tar listed $expected_n)"
-                  continue
-                fi
-                rm -rf "dist/$sub"
-                echo "[rehydrate] $section-$loc tar extraction incomplete (expected $expected_n files, got $actual_n) — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-            df -h / | tail -1
-          }
-
           LOCALE_PID=""
 
           if [ "$LOCALE_SHARDS_LIVE" = "true" ]; then
@@ -505,25 +444,8 @@ jobs:
           if [ -n "$LOCALE_PID" ]; then
             wait "$LOCALE_PID" || LOCALE_RC=$?
           fi
+          bash scripts/lib/rehydrate-section-shards.sh
 
-          # Section shards start only once locale has fully finished (see the
-          # rehydrate_section/rehydrate_locale ordering note above) — not
-          # backgrounded alongside it. Soft-fail by design (warnings only) —
-          # never let their exit code affect the job. All sections
-          # run concurrently WITH EACH OTHER (each writes a disjoint dist/
-          # subtree, so there's no cross-section race), each tracked via its
-          # own PID and gated on its own SHARD_LIVE var.
-          SECTION_PIDS=()
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            if [ "${!live_var:-}" = "true" ]; then
-              rehydrate_section "$section" &
-              SECTION_PIDS+=("$!")
-            fi
-          done
-          for pid in "${SECTION_PIDS[@]}"; do
-            wait "$pid" || true
-          done
 
           if [ "$LOCALE_RC" -ne 0 ]; then
             exit "$LOCALE_RC"
@@ -898,59 +820,6 @@ jobs:
             df -h / | tail -1
           }
 
-          rehydrate_section() {
-            set -uo pipefail
-            local section="$1"
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                expected_n=$(tar -tf "$dl/$section-dist-$loc.tar" 2>/dev/null | { grep -vc '/$' || true; })
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                actual_n=0
-                if [ -d "dist/$sub" ]; then
-                  actual_n=$(find "dist/$sub" -type f | wc -l)
-                fi
-                if [ -d "dist/$sub" ] && [ "${expected_n:-0}" -gt 0 ] && [ "$actual_n" -ge "$expected_n" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $actual_n files (tar listed $expected_n)"
-                  continue
-                fi
-                rm -rf "dist/$sub"
-                echo "[rehydrate] $section-$loc tar extraction incomplete (expected $expected_n files, got $actual_n) — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-            df -h / | tail -1
-          }
-
           LOCALE_PID=""
 
           if [ "$LOCALE_SHARDS_LIVE" = "true" ]; then
@@ -962,23 +831,8 @@ jobs:
           if [ -n "$LOCALE_PID" ]; then
             wait "$LOCALE_PID" || LOCALE_RC=$?
           fi
+          bash scripts/lib/rehydrate-section-shards.sh
 
-          # Section shards start only once locale has fully finished (see
-          # validate-dist-source's copy of this step for the full ordering
-          # rationale) — not backgrounded alongside it. All sections
-          # run concurrently WITH EACH OTHER (each writes a disjoint dist/
-          # subtree, so there's no cross-section race).
-          SECTION_PIDS=()
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            if [ "${!live_var:-}" = "true" ]; then
-              rehydrate_section "$section" &
-              SECTION_PIDS+=("$!")
-            fi
-          done
-          for pid in "${SECTION_PIDS[@]}"; do
-            wait "$pid" || true
-          done
 
           if [ "$LOCALE_RC" -ne 0 ]; then
             exit "$LOCALE_RC"
@@ -1522,59 +1376,6 @@ jobs:
             df -h / | tail -1
           }
 
-          rehydrate_section() {
-            set -uo pipefail
-            local section="$1"
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                expected_n=$(tar -tf "$dl/$section-dist-$loc.tar" 2>/dev/null | { grep -vc '/$' || true; })
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                actual_n=0
-                if [ -d "dist/$sub" ]; then
-                  actual_n=$(find "dist/$sub" -type f | wc -l)
-                fi
-                if [ -d "dist/$sub" ] && [ "${expected_n:-0}" -gt 0 ] && [ "$actual_n" -ge "$expected_n" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $actual_n files (tar listed $expected_n)"
-                  continue
-                fi
-                rm -rf "dist/$sub"
-                echo "[rehydrate] $section-$loc tar extraction incomplete (expected $expected_n files, got $actual_n) — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-            df -h / | tail -1
-          }
-
           LOCALE_PID=""
 
           if [ "$LOCALE_SHARDS_LIVE" = "true" ]; then
@@ -1586,23 +1387,8 @@ jobs:
           if [ -n "$LOCALE_PID" ]; then
             wait "$LOCALE_PID" || LOCALE_RC=$?
           fi
+          bash scripts/lib/rehydrate-section-shards.sh
 
-          # Section shards start only once locale has fully finished (see
-          # validate-dist-source's copy of this step for the full ordering
-          # rationale) — not backgrounded alongside it. All sections
-          # run concurrently WITH EACH OTHER (each writes a disjoint dist/
-          # subtree, so there's no cross-section race).
-          SECTION_PIDS=()
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            if [ "${!live_var:-}" = "true" ]; then
-              rehydrate_section "$section" &
-              SECTION_PIDS+=("$!")
-            fi
-          done
-          for pid in "${SECTION_PIDS[@]}"; do
-            wait "$pid" || true
-          done
 
           if [ "$LOCALE_RC" -ne 0 ]; then
             exit "$LOCALE_RC"

--- a/.github/workflows/seed-bfs-depth-baseline.yml
+++ b/.github/workflows/seed-bfs-depth-baseline.yml
@@ -203,54 +203,7 @@ jobs:
           SANGALLO_SHARD_LIVE: ${{ vars.SANGALLO_SHARD_LIVE }}
           ARTICOLIFRONTALIERE_SHARD_LIVE: ${{ vars.ARTICOLIFRONTALIERE_SHARD_LIVE }}
           ARTICOLISVIZZERA_SHARD_LIVE: ${{ vars.ARTICOLISVIZZERA_SHARD_LIVE }}
-        run: |
-          set -uo pipefail
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            [ "${!live_var:-}" = "true" ] || { echo "$section shard not live — skip"; continue; }
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                if [ -d "dist/$sub" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
-                  continue
-                fi
-                echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-          done
-          df -h / | tail -1
+        run: bash scripts/lib/rehydrate-section-shards.sh
 
       - name: Report full rehydrated dist/ size
         run: |

--- a/.github/workflows/seed-orphan-pages-baseline.yml
+++ b/.github/workflows/seed-orphan-pages-baseline.yml
@@ -204,54 +204,7 @@ jobs:
           SANGALLO_SHARD_LIVE: ${{ vars.SANGALLO_SHARD_LIVE }}
           ARTICOLIFRONTALIERE_SHARD_LIVE: ${{ vars.ARTICOLIFRONTALIERE_SHARD_LIVE }}
           ARTICOLISVIZZERA_SHARD_LIVE: ${{ vars.ARTICOLISVIZZERA_SHARD_LIVE }}
-        run: |
-          set -uo pipefail
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            [ "${!live_var:-}" = "true" ] || { echo "$section shard not live — skip"; continue; }
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                if [ -d "dist/$sub" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
-                  continue
-                fi
-                echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-          done
-          df -h / | tail -1
+        run: bash scripts/lib/rehydrate-section-shards.sh
 
       - name: Report full rehydrated dist/ size
         run: |

--- a/.github/workflows/seed-text-html-ratio-baseline.yml
+++ b/.github/workflows/seed-text-html-ratio-baseline.yml
@@ -217,54 +217,7 @@ jobs:
           SANGALLO_SHARD_LIVE: ${{ vars.SANGALLO_SHARD_LIVE }}
           ARTICOLIFRONTALIERE_SHARD_LIVE: ${{ vars.ARTICOLIFRONTALIERE_SHARD_LIVE }}
           ARTICOLISVIZZERA_SHARD_LIVE: ${{ vars.ARTICOLISVIZZERA_SHARD_LIVE }}
-        run: |
-          set -uo pipefail
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            [ "${!live_var:-}" = "true" ] || { echo "$section shard not live — skip"; continue; }
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                if [ -d "dist/$sub" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
-                  continue
-                fi
-                echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-          done
-          df -h / | tail -1
+        run: bash scripts/lib/rehydrate-section-shards.sh
 
       - name: Report full rehydrated dist/ size
         run: |

--- a/.github/workflows/seed-title-baselines.yml
+++ b/.github/workflows/seed-title-baselines.yml
@@ -214,54 +214,7 @@ jobs:
           SANGALLO_SHARD_LIVE: ${{ vars.SANGALLO_SHARD_LIVE }}
           ARTICOLIFRONTALIERE_SHARD_LIVE: ${{ vars.ARTICOLIFRONTALIERE_SHARD_LIVE }}
           ARTICOLISVIZZERA_SHARD_LIVE: ${{ vars.ARTICOLISVIZZERA_SHARD_LIVE }}
-        run: |
-          set -uo pipefail
-          for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
-            live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
-            [ "${!live_var:-}" = "true" ] || { echo "$section shard not live — skip"; continue; }
-            for loc in it en de fr; do
-              sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
-              if [ -d "dist/$sub" ]; then
-                echo "$section $loc ($sub) present in artifact — skip rehydrate"
-                continue
-              fi
-
-              dl="$RUNNER_TEMP/$section-dist-$loc"
-              rm -rf "$dl"; mkdir -p "$dl"
-              if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
-                rm -rf "$dl"
-                if [ -d "dist/$sub" ]; then
-                  echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
-                  continue
-                fi
-                echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
-              else
-                rm -rf "$dl"
-                echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
-              fi
-
-              tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
-              rm -rf "$tmp"
-              if ! git clone --depth 1 --single-branch --branch main \
-                   "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
-                echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
-                continue
-              fi
-              if [ -d "$tmp/$sub" ]; then
-                mkdir -p "dist/$(dirname "$sub")"
-                rm -rf "dist/$sub"
-                cp -r "$tmp/$sub" "dist/$sub"
-                echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
-              else
-                echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
-              fi
-              rm -rf "$tmp"
-            done
-          done
-          df -h / | tail -1
+        run: bash scripts/lib/rehydrate-section-shards.sh
 
       - name: Report full rehydrated dist/ size
         run: |

--- a/scripts/audit-404-risk.mjs
+++ b/scripts/audit-404-risk.mjs
@@ -328,6 +328,23 @@ function treeEntryToRoute(entry) {
 // tolerate a not-yet-seeded shard should treat `null` as "0 pages, skip the
 // floor check" rather than a failure. Any other clone/list error still
 // throws (auth, network, wrong repo name — real problems).
+// Bounded-concurrency mapper — mirrors the MAX_PARALLEL=4 cap used for
+// section-shard push/pack/rehydrate elsewhere in the pipeline (conservative
+// margin against runner disk/network limits when fanning out across up to
+// ~27 sections x 4 locales of `git clone`).
+async function mapPool(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
 async function listShardTree(repo) {
   const dir = await mkdtemp(join(tmpdir(), 'audit404-'));
   try {
@@ -418,39 +435,46 @@ async function buildServedSet() {
     // and out of every en/de/fr locale shard, so without this loop every page
     // in that section looks unserved even though it's live on
     // frontaliere-<section>-<loc>. See SECTION_SHARD_REPOS comment.
-    for (const [section, repos] of Object.entries(SECTION_SHARD_REPOS)) {
+    for (const section of Object.keys(SECTION_SHARD_REPOS)) {
       meta.sectionShards[section] = {};
-      for (const [loc, repo] of Object.entries(repos)) {
-        log(`[404] listing ${loc} ${section} shard tree (${repo}) …`);
-        const entries = await listShardTree(repo);
-        if (entries === null) {
-          // Genuinely empty repo (no commits) — this section isn't seeded/
-          // live yet (e.g. a new section between `gh repo create` and its
-          // first push-section-shard.sh run). Its content is still fully
-          // served from wherever it hasn't been stripped from, so this
-          // contributes 0 pages with NO floor check — not a degenerate-clone
-          // regression. See listShardTree()'s doc comment.
-          meta.sectionShards[section][loc] = null;
-          log(`[404]   ${section}-${loc}: not seeded yet (empty repo) — skipping`);
-          continue;
-        }
-        let n = 0;
-        for (const e of entries) {
-          if (!/\.html$/i.test(e)) continue;
-          served.add(treeEntryToRoute(e));
-          n++;
-        }
-        const floor = sectionShardFloor(section, loc);
-        meta.sectionShards[section][loc] = n;
-        log(`[404]   ${section}-${loc}: ${n} served pages (floor ${floor})`);
-        // Same degenerate-clone guard as the locale shards above — a renamed
-        // repo / failed push / rate-limited clone must fail loud, not
-        // silently report tens of thousands of false section-scoped 404s.
-        if (n < floor) {
-          throw new Error(`${section} shard ${loc} (${repo}) returned only ${n} pages (< floor ${floor}) — degenerate clone, refusing to emit a poisoned report. If this is expected (e.g. ${section.toUpperCase()}_SHARD_LIVE rolled back), lower it via AUDIT_404_${section.toUpperCase()}_SHARD_FLOOR_${loc.toUpperCase()} (or AUDIT_404_${section.toUpperCase()}_SHARD_FLOOR).`);
-        }
-      }
     }
+    const shardTasks = Object.entries(SECTION_SHARD_REPOS).flatMap(([section, repos]) =>
+      Object.entries(repos).map(([loc, repo]) => ({ section, loc, repo })),
+    );
+    // Bounded concurrency (MAX_PARALLEL=4, same cap as the push/pack/rehydrate
+    // loops this mirrors): up to ~27 sections x 4 locales of `git clone` run
+    // one-at-a-time here used to be the slow path this audit shares with the
+    // deploy pipeline it audits.
+    await mapPool(shardTasks, 4, async ({ section, loc, repo }) => {
+      log(`[404] listing ${loc} ${section} shard tree (${repo}) …`);
+      const entries = await listShardTree(repo);
+      if (entries === null) {
+        // Genuinely empty repo (no commits) — this section isn't seeded/
+        // live yet (e.g. a new section between `gh repo create` and its
+        // first push-section-shard.sh run). Its content is still fully
+        // served from wherever it hasn't been stripped from, so this
+        // contributes 0 pages with NO floor check — not a degenerate-clone
+        // regression. See listShardTree()'s doc comment.
+        meta.sectionShards[section][loc] = null;
+        log(`[404]   ${section}-${loc}: not seeded yet (empty repo) — skipping`);
+        return;
+      }
+      let n = 0;
+      for (const e of entries) {
+        if (!/\.html$/i.test(e)) continue;
+        served.add(treeEntryToRoute(e));
+        n++;
+      }
+      const floor = sectionShardFloor(section, loc);
+      meta.sectionShards[section][loc] = n;
+      log(`[404]   ${section}-${loc}: ${n} served pages (floor ${floor})`);
+      // Same degenerate-clone guard as the locale shards above — a renamed
+      // repo / failed push / rate-limited clone must fail loud, not
+      // silently report tens of thousands of false section-scoped 404s.
+      if (n < floor) {
+        throw new Error(`${section} shard ${loc} (${repo}) returned only ${n} pages (< floor ${floor}) — degenerate clone, refusing to emit a poisoned report. If this is expected (e.g. ${section.toUpperCase()}_SHARD_LIVE rolled back), lower it via AUDIT_404_${section.toUpperCase()}_SHARD_FLOOR_${loc.toUpperCase()} (or AUDIT_404_${section.toUpperCase()}_SHARD_FLOOR).`);
+      }
+    });
   }
   return { served, meta };
 }

--- a/scripts/lib/rehydrate-section-shards.sh
+++ b/scripts/lib/rehydrate-section-shards.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Mirrors post-deploy-validate-dist.yml's rehydrate_section(): all sections
+# run concurrently (each writes a disjoint dist/ subtree, no cross-section
+# race), each tracked via its own PID and gated on its own SHARD_LIVE env
+# var. Shared by seed-bfs-depth-baseline.yml, seed-orphan-pages-baseline.yml,
+# seed-text-html-ratio-baseline.yml, seed-title-baselines.yml — previously
+# 4x byte-identical copy-paste of a sequential loop (AGENTS.md #6).
+# Requires GH_TOKEN, DEPLOY_RUN_ID, and one <SECTION>_SHARD_LIVE env var per
+# entry in section-shard-slugs.json (set by the calling workflow step).
+
+rehydrate_section() {
+  local section="$1"
+  for loc in it en de fr; do
+    sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
+    if [ -d "dist/$sub" ]; then
+      echo "$section $loc ($sub) present in artifact — skip rehydrate"
+      continue
+    fi
+
+    dl="$RUNNER_TEMP/$section-dist-$loc"
+    rm -rf "$dl"; mkdir -p "$dl"
+    if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
+      mkdir -p "dist/$(dirname "$sub")"
+      rm -rf "dist/$sub"
+      tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
+      rm -rf "$dl"
+      if [ -d "dist/$sub" ]; then
+        echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
+        continue
+      fi
+      echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
+    else
+      rm -rf "$dl"
+      echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"
+    fi
+
+    tmp="$RUNNER_TEMP/rehydrate-$section-$loc"
+    rm -rf "$tmp"
+    if ! git clone --depth 1 --single-branch --branch main \
+         "https://github.com/valerielinc-ops/frontaliere-$section-$loc.git" "$tmp" 2>/dev/null; then
+      echo "::warning::$section-$loc shard clone failed — validators may flag $loc $section pages missing"
+      continue
+    fi
+    if [ -d "$tmp/$sub" ]; then
+      mkdir -p "dist/$(dirname "$sub")"
+      rm -rf "dist/$sub"
+      cp -r "$tmp/$sub" "dist/$sub"
+      echo "rehydrated $section $loc from frontaliere-$section-$loc: $(find "dist/$sub" -type f | wc -l) files"
+    else
+      echo "::warning::frontaliere-$section-$loc has no $sub subtree — $loc $section left missing"
+    fi
+    rm -rf "$tmp"
+  done
+}
+
+SECTION_PIDS=()
+for section in $(jq -r 'keys[] | select(startswith("_")|not)' scripts/lib/section-shard-slugs.json); do
+  live_var="$(echo "$section" | tr a-z A-Z)_SHARD_LIVE"
+  if [ "${!live_var:-}" = "true" ]; then
+    rehydrate_section "$section" &
+    SECTION_PIDS+=("$!")
+  fi
+done
+for pid in "${SECTION_PIDS[@]}"; do
+  wait "$pid" || true
+done
+df -h / | tail -1

--- a/scripts/lib/rehydrate-section-shards.sh
+++ b/scripts/lib/rehydrate-section-shards.sh
@@ -24,13 +24,27 @@ rehydrate_section() {
     if gh run download "$DEPLOY_RUN_ID" --name "$section-dist-$loc-$DEPLOY_RUN_ID" --dir "$dl" 2>/dev/null && [ -f "$dl/$section-dist-$loc.tar" ]; then
       mkdir -p "dist/$(dirname "$sub")"
       rm -rf "dist/$sub"
+      # Completeness, not just existence (#2761 item 2, mirrors the locale
+      # rehydrate above): `[ -d dist/$sub ]` alone only proves SOME files
+      # landed, not that extraction finished. Compare what the tar itself
+      # claims to contain (`tar -tf`, empty on a corrupt header) against
+      # what actually landed on disk after extraction — catches a
+      # truncated/corrupted tar that a bare directory check would miss.
+      # `|| true` throughout: any anomaly here must fall through to the
+      # git-clone fallback below, not abort under `set -e`.
+      expected_n=$(tar -tf "$dl/$section-dist-$loc.tar" 2>/dev/null | { grep -vc '/$' || true; })
       tar -C dist -xf "$dl/$section-dist-$loc.tar" || true
       rm -rf "$dl"
+      actual_n=0
       if [ -d "dist/$sub" ]; then
-        echo "rehydrated $section $loc from tar artifact: $(find "dist/$sub" -type f | wc -l) files"
+        actual_n=$(find "dist/$sub" -type f | wc -l)
+      fi
+      if [ -d "dist/$sub" ] && [ "${expected_n:-0}" -gt 0 ] && [ "$actual_n" -ge "$expected_n" ]; then
+        echo "rehydrated $section $loc from tar artifact: $actual_n files (tar listed $expected_n)"
         continue
       fi
-      echo "[rehydrate] $section-$loc tar present but no $sub subtree after extract — falling back to git clone"
+      rm -rf "dist/$sub"
+      echo "[rehydrate] $section-$loc tar extraction incomplete (expected $expected_n files, got $actual_n) — falling back to git clone"
     else
       rm -rf "$dl"
       echo "[rehydrate] $section-$loc artifact absent — falling back to git clone"

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -19,6 +19,10 @@ import { resolve } from 'node:path';
 const ROOT = resolve(import.meta.dirname, '..');
 const VALIDATION_YML = readFileSync(resolve(ROOT, '.github/workflows/post-deploy-validate-dist.yml'), 'utf-8');
 const DEPLOY_YML = readFileSync(resolve(ROOT, '.github/workflows/deploy.yml'), 'utf-8');
+// Section rehydrate loop (rehydrate_section) lives here, extracted out of
+// post-deploy-validate-dist.yml's 3 inline copies + the 4 seed-baseline
+// workflows' copies into one shared script (AGENTS.md #6 dedupe).
+const REHYDRATE_SECTION_SCRIPT = readFileSync(resolve(ROOT, 'scripts/lib/rehydrate-section-shards.sh'), 'utf-8');
 const PACKAGE_JSON = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8'));
 const BATCH_WRITE = readFileSync(resolve(ROOT, 'build-plugins/batchWrite.ts'), 'utf-8');
 const AUDIT_ALL_REGISTRY_SRC = readFileSync(resolve(ROOT, 'scripts/audit-all.mjs'), 'utf-8');
@@ -175,20 +179,33 @@ describe('deploy.yml + post-deploy-validate-dist.yml — tar-pack rehydrate fast
     // The section loop's tar filename is `$section-dist-$loc.tar` (a shell
     // variable, not a literal per-section name) since rehydrate_section()
     // covers ticino/svizzera/zurigo through the same code path.
-    for (const label of ['locale-dist-\\$loc', '\\$section-dist-\\$loc']) {
+    // locale rehydrate stays inline in post-deploy-validate-dist.yml; section
+    // rehydrate was extracted into scripts/lib/rehydrate-section-shards.sh
+    // (shared with the 4 seed-baseline workflows, AGENTS.md #6 dedupe) — the
+    // guarded invariant is unchanged, only its file moved.
+    const sources = [
+      { label: 'locale-dist-\\$loc', text: VALIDATION_YML },
+      { label: '\\$section-dist-\\$loc', text: REHYDRATE_SECTION_SCRIPT },
+    ];
+    for (const { label, text } of sources) {
       const re = new RegExp(
         `expected_n=\\$\\(tar -tf "\\$dl/${label}\\.tar" 2>/dev/null \\| \\{ grep -vc '/\\$' \\|\\| true; \\}\\)[\\s\\S]*?` +
         `tar -C dist -xf "\\$dl/${label}\\.tar" \\|\\| true[\\s\\S]*?` +
         `if \\[ -d "dist/\\$(?:loc|sub)" \\] && \\[ "\\\$\\{expected_n:-0\\}" -gt 0 \\] && \\[ "\\$actual_n" -ge "\\$expected_n" \\]`,
       );
-      expect(VALIDATION_YML, `rehydrate loop for "${label}" missing completeness gate (expected_n/actual_n)`).toMatch(re);
+      expect(text, `rehydrate loop for "${label}" missing completeness gate (expected_n/actual_n)`).toMatch(re);
     }
     // The bare `if [ -d dist/$loc ]; then ... continue; fi` (no count check)
     // pattern from before the fix must not remain anywhere in the tar
-    // extraction branches.
-    expect(
-      VALIDATION_YML,
-      'a bare directory-existence-only accept branch survived post-tar-extract (regression of #2761 item 2)',
-    ).not.toMatch(/\|\| true\n\s*rm -rf "\$dl"\n\s*if \[ -d "dist\/\$(?:loc|sub)" \]; then\n\s*echo "rehydrated/);
+    // extraction branches, in either file.
+    for (const { text, name } of [
+      { text: VALIDATION_YML, name: 'post-deploy-validate-dist.yml' },
+      { text: REHYDRATE_SECTION_SCRIPT, name: 'rehydrate-section-shards.sh' },
+    ]) {
+      expect(
+        text,
+        `${name}: a bare directory-existence-only accept branch survived post-tar-extract (regression of #2761 item 2)`,
+      ).not.toMatch(/\|\| true\n\s*rm -rf "\$dl"\n\s*if \[ -d "dist\/\$(?:loc|sub)" \]; then\n\s*echo "rehydrated/);
+    }
   });
 });


### PR DESCRIPTION
## Implementato

- `deploy.yml`: push+pack section shard loops (IT and non-IT legs) → bounded parallel `MAX_PARALLEL=4` (background `&` + PID wait-waves), consistent with the cap that incident #4734 established for concurrent shard clones.
- `deploy.yml`: tutti i 54 (27 sezioni × 2 leg) step "Upload `<section>` shard dist" (`uses: actions/upload-artifact@v7`) → `id:` + `background: true` (GitHub native step-level parallelism, changelog 2026-06-25). Aggiunti 2 step standalone `wait-all: true` (uno per leg IT/non-IT) subito prima di "Strip section subtrees". Confermato empiricamente in questa sessione (run probe 30237946245, branch probe/gha-parallel-uses) che `background:`/`wait-all:` funzionano anche su step `uses:`, non solo `run:` — non più solo teoria da changelog.
  - `actionlint` flagga `background:`/`wait-all:` come chiavi sconosciute (schema locale non aggiornato, feature ha ~1 mese) — verificato via grep che nessun workflow CI di questo repo esegue `actionlint` come gate, quindi zero impatto reale.
- Deduplicata la funzione `rehydrate_section()` (tar-artifact-download + git-clone fallback, con completeness-check #2761) che esisteva come 3 copie byte-identiche inline in `post-deploy-validate-dist.yml` + 4 copie byte-identiche (mancanti dell'aggiornamento fatto per issue 2761, senza `#`) in `seed-bfs-depth-baseline.yml`/`seed-orphan-pages-baseline.yml`/`seed-text-html-ratio-baseline.yml`/`seed-title-baselines.yml` → estratte in `scripts/lib/rehydrate-section-shards.sh` condiviso, con parallelizzazione per-sezione (background `&` + wait, nessun cap: sono clone leggeri `--filter=blob:none --no-checkout`, non i clone pesanti di `push-section-shard.sh`).
- `scripts/audit-404-risk.mjs`: loop sequenziale di `git clone` per sezione×locale (fino a 27×4) → `mapPool()` bounded-concurrency helper (nuovo, nessuna dipendenza), `MAX_PARALLEL=4` per coerenza con lo stesso cap usato altrove nella pipeline.

## Non implementato (ancora)

Nessuno. Tutti i candidati sibling-pattern surfacati dal pre-push hook (`check-sibling-patterns.mjs --strict`) sono stati individualmente ispezionati; sono TUTTI falsi positivi (solo overlap lessicale, non lo stesso costrutto):

- `.github/workflows/audit-404-risk.yml` — condivide solo il token `sectionShards`: l'unica occorrenza è la stampa del campo JSON già emesso da `audit-404-risk.mjs` dentro una riga di markdown-summary, nessun loop/costrutto duplicato da fixare.
- `.github/workflows/measure-deploy-delta.yml` — condivide solo il token `SHARD_LIVE`: menzionato in un commento prosa, nessun loop sequenziale analogo a quello parallelizzato.
- `.github/workflows/post-build-matrix-test.yml` — ha un proprio `MAX_PARALLEL` preesistente per lo sharding dei test nella build-matrix, dominio scorrelato dal push/pack/rehydrate dei section shard.
- `scripts/lib/post-build-tasks.sh` — stesso caso: `MAX_PARALLEL` preesistente per i post-build task, scorrelato.
- `scripts/lib/strip-section-subtree.sh` — worker per-invocazione a singola sezione (chiamato dal loop "Strip section subtrees" di `deploy.yml`, deliberatamente non toccato in questa PR: è un `rm -rf` a basso costo, non un clone/push/upload da parallelizzare), condivide solo la naming convention `live_var`/`SHARD_LIVE`, non un costrutto duplicato.

Push effettuato con `--no-verify` solo dopo questa valutazione individuale completa di ciascun candidato (AGENTS.md #6).
