### PR TITLE
fix(ci): dedupe workflow-scope detection, break issue #4437 infinite loop

### DIFF
--- a/scripts/ci/check-workflows-scope.mjs
+++ b/scripts/ci/check-workflows-scope.mjs
@@ -132,12 +132,14 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { WORKFLOW_PATH_RE, hasNonWorkflowCodeRefs } from '../lib/workflow-scope-detect.mjs';
 
 const DRY_RUN = process.env.DRY_RUN === '1';
 const ISSUE = process.env.ISSUE_NUMBER;
 const OUTCOME_MARKER = '<!-- FIX_OUTCOME: blocked-workflows-scope -->';
 const OUTCOME_MARKER_RE = /<!--\s*FIX_OUTCOME:\s*blocked-workflows-scope\s*-->/i;
 const BLOCKED_LABEL = 'blocked-workflows-scope';
+const PARKED_LABEL = 'fu-parked';
 // Signature string scan-job-timeouts.mjs stamps into every issue it auto-files —
 // see that script's issue-body template. Used (Mode 2) to recognize the auto-filed
 // CI-timeout shape without depending on the `ci-timeout` label alone (label taxonomy
@@ -172,11 +174,11 @@ function setOutput(blocked) {
 // anchor (`\.ya?ml\b`) makes this precise even outside backticks/fences: no bare
 // `.yml` name matches without the literal `.github/workflows/` prefix, and no
 // generic prose ("the traffic-scheduler workflow") matches without the literal
-// path substring. Mirrors the equivalent, already-proven full-text scan in
-// followup-drainer.mjs's `detectWorkflowScoped` (WORKFLOW_PATH_RE) — see issue
-// #4518 module docstring below for why the previous backtick/fence-only version
-// under-detected.
-const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/g;
+// path substring. Imported from ../lib/workflow-scope-detect.mjs, shared with
+// followup-drainer.mjs's `detectWorkflowScoped` — see issue #4518 module
+// docstring below for why the previous backtick/fence-only version under-detected,
+// and #4437 (module docstring "Mode 1 exclusivity gate") for why plain path
+// extraction alone is not sufficient to decide BLOCKED.
 
 /**
  * Extract explicit .github/workflows/** path references from an issue body.
@@ -193,6 +195,25 @@ const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/g;
 export function extractWorkflowPaths(body) {
   const text = body || '';
   return [...new Set(text.match(WORKFLOW_PATH_RE) || [])];
+}
+
+/**
+ * Mode 1 exclusivity gate (issue #4437): a body citing a `.github/workflows/**` path is
+ * BLOCKED only if it does NOT also cite a non-workflow code path (scripts/build-plugins/
+ * services/components/hooks/build/src/...). A false positive was observed live on issue
+ * #4437: the body mentioned `.github/workflows/send-job-alerts.yml` only in passing (a
+ * "live-verification, manual post-deploy" checklist bullet pointing at where the cron
+ * runs), while the actual required fix lived entirely in `scripts/send-job-alerts.mjs` —
+ * a normal script file. Because `extractWorkflowPaths` alone had no exclusion,
+ * check-workflows-scope.mjs blocked the issue every time it got promoted, while
+ * followup-drainer.mjs's OWN pre-flight (`detectWorkflowScoped`, which DOES exclude on
+ * code refs) correctly judged it promotable — the asymmetry drove an infinite
+ * block→unroute→requeue→promote→block loop (~4h cadence, 51 comments over 9 days) and
+ * the real funnel-monetization bug never got a genuine fix attempt.
+ * CONSERVATIVE (bias to PROMOTE): mirrors followup-drainer.mjs's `detectWorkflowScoped`.
+ */
+export function isExclusivelyWorkflowScoped(body) {
+  return extractWorkflowPaths(body).length > 0 && !hasNonWorkflowCodeRefs(body);
 }
 
 /**
@@ -236,9 +257,14 @@ export function filterExactTitleRecurrences(candidates, title, currentIssueNumbe
 /**
  * Shared side-effects for a BLOCKED verdict (either mode): post the advisory comment
  * (body already includes the OUTCOME_MARKER), remove `agent:fix` (no re-dispatch),
- * ensure the `blocked-workflows-scope` label exists, and apply it. Best-effort
- * (`allowFail: true` throughout) — a comment/label API hiccup must never throw past
- * the `workflows_blocked=true` output already decided.
+ * ensure the `blocked-workflows-scope` label exists, apply it, and add `fu-parked`.
+ * Best-effort (`allowFail: true` throughout) — a comment/label API hiccup must never
+ * throw past the `workflows_blocked=true` output already decided.
+ *
+ * `fu-parked` is required (issue #4437): without a `ROUTING_LABELS` member on the
+ * issue, `issue-triage.yml`'s sweep treats a blocked issue as "unrouted" and re-queues
+ * it every ~4h, which the drainer then re-promotes and this script re-blocks — forever.
+ * Adding `fu-parked` here marks it terminal so the sweep leaves it alone.
  */
 function applyBlockedOutcome(comment) {
   gh(['issue', 'comment', ISSUE, ...repoArgs, '--body', comment], { allowFail: true });
@@ -257,6 +283,7 @@ function applyBlockedOutcome(comment) {
     { allowFail: true },
   );
   gh(['issue', 'edit', ISSUE, ...repoArgs, '--add-label', BLOCKED_LABEL], { allowFail: true });
+  gh(['issue', 'edit', ISSUE, ...repoArgs, '--add-label', PARKED_LABEL], { allowFail: true });
 }
 
 /**
@@ -352,10 +379,12 @@ function main() {
   // Extract explicit .github/workflows/** path references from the issue body.
   const workflowPaths = extractWorkflowPaths(body);
 
-  if (workflowPaths.length === 0) {
-    // Mode 1 (explicit body paths) found nothing. Mode 2: does a PRIOR issue with the
-    // exact same stable title already carry a blocked-workflows-scope marker? (issue
-    // #4227, broadened by #4749 — see module docstring "Mode 2" for the full
+  if (!isExclusivelyWorkflowScoped(body)) {
+    // Mode 1 found no *exclusive* workflow-scope signal — either no path at all, or a
+    // path co-cited with a non-workflow code path (issue #4437: the real fix may live in
+    // that code file — see `isExclusivelyWorkflowScoped` docstring). Mode 2: does a PRIOR
+    // issue with the exact same stable title already carry a blocked-workflows-scope
+    // marker? (issue #4227, broadened by #4749 — see module docstring "Mode 2" for the full
     // rationale/evidence.) Applied to EVERY issue with a title, not just
     // scan-job-timeouts.mjs ci-timeout auto-files: escalation #4749 found the same
     // exact-stable-title recurrence pattern in several other monitor-filed categories
@@ -401,11 +430,15 @@ function main() {
       );
     }
 
-    // No explicit workflow paths, no recurrence match → proceed. The pre-commit hook
+    // Not exclusively workflow-scoped, no recurrence match → proceed. The pre-commit hook
     // handles fixes discovered during agent diagnosis.
     console.log(
-      `Issue #${ISSUE}: no explicit .github/workflows/** paths in body — proceeding ` +
-        `(pre-commit hook guards diagnosis-time discoveries).`,
+      workflowPaths.length > 0
+        ? `Issue #${ISSUE}: workflow path(s) co-cited with non-workflow code path(s) — ` +
+            `proceeding (fix may live in code; pre-commit hook guards diagnosis-time ` +
+            `discoveries).`
+        : `Issue #${ISSUE}: no explicit .github/workflows/** paths in body — proceeding ` +
+            `(pre-commit hook guards diagnosis-time discoveries).`,
     );
     setOutput(false);
     return;

--- a/scripts/ci/followup-drainer.mjs
+++ b/scripts/ci/followup-drainer.mjs
@@ -34,6 +34,15 @@
  */
 import { execFileSync } from 'node:child_process';
 import { classifyIssue } from '../lib/classify-issue.mjs';
+import {
+  WORKFLOW_PATH_RE,
+  BARE_YML_RE,
+  NON_WORKFLOW_YML,
+  CODE_PATH_RE,
+  detectWorkflowScoped,
+} from '../lib/workflow-scope-detect.mjs';
+
+export { detectWorkflowScoped };
 
 const DRY = process.argv.includes('--dry-run');
 const REPO = process.env.GITHUB_REPOSITORY || '';
@@ -123,43 +132,11 @@ export function latestFixOutcomeFromComments(comments) {
 // il primo run Claude ha bruciato ~1M token per scoprire il blocco. Questa
 // pre-flight deterministica lo rileva PRIMA della promozione a agent:fix.
 //
-// CONSERVATIVA (bias a PROMUOVERE — un falso park ritarda un fix reale): scatta
-// SOLO sul segnale forte «il fix è esclusivamente workflow-scoped» = il body cita
-// ≥1 path di workflow (`.github/workflows/x.yml` o un bare `x.yml`) E NESSUN path
-// di codice non-workflow (scripts/build-plugins/services/components/hooks/build/
-// src/...). Se cita anche un file di codice → il fix potrebbe vivere lì → PROMUOVI
-// (lascia decidere il fixer). Nessun path citato → PROMUOVI. Mirror del bias
-// dell'already-resolved gate (check-issue-already-resolved.mjs).
-const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/g;
-// Bare `<name>.yml` (un workflow è sempre .yml; in una follow-up un bare .yml
-// che non sia un file di config noto indica quasi sempre un workflow file).
-const BARE_YML_RE = /\b[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\b/g;
-// File di codice NON-workflow: se citati, il fix potrebbe vivere lì → non scoped.
-const CODE_PATH_RE = /\b(?:scripts|build-plugins|services|components|hooks|build|src)\/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+\b/g;
-// `.yml` di config che NON sono workflow (non implicano scope workflows).
-const NON_WORKFLOW_YML = new Set([
-  'lighthouserc.yml', 'pnpm-workspace.yml', 'docker-compose.yml',
-  '.prettierrc.yml', 'vitest.yml',
-]);
-
-/**
- * Vero se il fix della follow-up è ESCLUSIVAMENTE workflow-scoped (richiede di
- * editare `.github/workflows/**`), così la promozione a agent:fix brucerebbe
- * quota in un run che il push bloccherebbe comunque. Pura → testabile.
- * @param {string} text  title + body della issue
- */
-export function detectWorkflowScoped(text) {
-  const s = String(text || '');
-  const wfFull = s.match(WORKFLOW_PATH_RE) || [];
-  const bareYml = (s.match(BARE_YML_RE) || []).filter(
-    (y) => !NON_WORKFLOW_YML.has(y.toLowerCase()),
-  );
-  const workflowRefs = [...new Set([...wfFull, ...bareYml])];
-  if (workflowRefs.length === 0) return false; // nessun riferimento a workflow → promuovi
-  const codeRefs = s.match(CODE_PATH_RE) || [];
-  if (codeRefs.length > 0) return false; // cita anche codice non-workflow → potrebbe fixarsi lì → promuovi
-  return true; // solo workflow → blocked-workflows-scope by-construction
-}
+// Detection logic (WORKFLOW_PATH_RE/BARE_YML_RE/NON_WORKFLOW_YML/CODE_PATH_RE/
+// detectWorkflowScoped) is shared with check-workflows-scope.mjs via
+// ../lib/workflow-scope-detect.mjs — see that module's docstring for the
+// bias-to-promote rationale and the #4437 false-positive-loop incident that
+// motivated extracting it out of a hand-duplicated copy.
 
 // --- MALFORMED-BODY & NETWORK-AUDIT PRE-FLIGHT (escalation #2291) -----------
 // `fix-outcome:max-turns` ricorre ≥7×/14gg (dal 2026-06-02): due sottoclassi

--- a/scripts/lib/workflow-scope-detect.mjs
+++ b/scripts/lib/workflow-scope-detect.mjs
@@ -1,0 +1,61 @@
+/**
+ * workflow-scope-detect.mjs — shared `.github/workflows/**`-scope detection.
+ *
+ * Extracted from followup-drainer.mjs (escalation #1724) so `check-workflows-scope.mjs`
+ * (escalation #3887/#4227) shares the SAME regex + exclusion logic instead of a
+ * hand-duplicated copy. The duplication was the direct cause of a false-positive
+ * infinite loop (issue #4437, observed 2026-07-18→2026-07-27, 51 identical park
+ * comments over 9 days): followup-drainer's `detectWorkflowScoped` correctly bails out
+ * when the body ALSO cites non-workflow code paths (the fix might live there), but
+ * check-workflows-scope.mjs's `extractWorkflowPaths` had no such exclusion — it blocked
+ * on ANY `.github/workflows/*.yml` substring, even a passing reference inside an
+ * unrelated "live-verification" checklist bullet. That asymmetry meant: the drainer
+ * would happily re-promote the issue (its own check says "not scoped"), issue-fix.yml's
+ * own pre-flight would immediately re-block it, and — because the block removed
+ * `agent:fix` without adding any terminal label — issue-triage.yml's sweep would treat
+ * it as unrouted and re-queue it, forever, ~4h cadence.
+ *
+ * CONSERVATIVE (bias to PROMOTE — a false park/block delays a real fix): a body is
+ * "exclusively workflow-scoped" only when it cites ≥1 workflow path AND no non-workflow
+ * code path (scripts/build-plugins/services/components/hooks/build/src/...). If it
+ * cites both, the fix might live in the code file → let the fixer decide.
+ */
+
+// Matches `.github/workflows/<name>.yml` (or `.yaml`) ANYWHERE in body text — backticks,
+// fenced code blocks, or bare markdown prose/bullets.
+export const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/g;
+
+// Bare `<name>.yml` (a workflow is always .yml; in a follow-up a bare .yml that isn't a
+// known config file indicates a workflow file almost every time).
+export const BARE_YML_RE = /\b[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\b/g;
+
+// Non-workflow code paths: if cited, the fix might live there → not exclusively scoped.
+export const CODE_PATH_RE = /\b(?:scripts|build-plugins|services|components|hooks|build|src)\/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+\b/g;
+
+// `.yml` config files that are NOT workflows (don't imply the `workflows` scope).
+export const NON_WORKFLOW_YML = new Set([
+  'lighthouserc.yml', 'pnpm-workspace.yml', 'docker-compose.yml',
+  '.prettierrc.yml', 'vitest.yml',
+]);
+
+/** True if `text` cites at least one non-workflow code path (scripts/, build-plugins/, ...). */
+export function hasNonWorkflowCodeRefs(text) {
+  return (String(text || '').match(CODE_PATH_RE) || []).length > 0;
+}
+
+/**
+ * True if the fix is EXCLUSIVELY workflow-scoped (requires editing `.github/workflows/**`),
+ * so promoting it would burn quota on a run the push would block anyway. Pure → testable.
+ * @param {string} text  title + body of the issue
+ */
+export function detectWorkflowScoped(text) {
+  const s = String(text || '');
+  const wfFull = s.match(WORKFLOW_PATH_RE) || [];
+  const bareYml = (s.match(BARE_YML_RE) || []).filter(
+    (y) => !NON_WORKFLOW_YML.has(y.toLowerCase()),
+  );
+  const workflowRefs = [...new Set([...wfFull, ...bareYml])];
+  if (workflowRefs.length === 0) return false; // no workflow reference → promote
+  if (hasNonWorkflowCodeRefs(s)) return false; // also cites non-workflow code → might fix there → promote
+  return true; // workflow-only → blocked-workflows-scope by construction
+}

--- a/scripts/lib/workflow-scope-detect.mjs
+++ b/scripts/lib/workflow-scope-detect.mjs
@@ -30,7 +30,14 @@ export const WORKFLOW_PATH_RE = /\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml\b/
 export const BARE_YML_RE = /\b[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\b/g;
 
 // Non-workflow code paths: if cited, the fix might live there → not exclusively scoped.
-export const CODE_PATH_RE = /\b(?:scripts|build-plugins|services|components|hooks|build|src)\/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+\b/g;
+// Must cover every top-level code dir in the repo (`ls -d */`), not just scripts/services/
+// components/hooks/build/src — a PR review on #4778 caught this list missing `infra/`
+// (infra/cloudflare-worker/locale-router.js — funnel-critical), `server/`
+// (server/newsletterResendWebhook.js), and `functions/` (functions/index.js,
+// functions/src/*.js): an issue citing a workflow path alongside one of those would be
+// wrongly judged "exclusively workflow-scoped" and blocked, reproducing the #4437 bug
+// class in a different directory.
+export const CODE_PATH_RE = /\b(?:scripts|build-plugins|services|components|hooks|build|src|infra|server|functions)\/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+\b/g;
 
 // `.yml` config files that are NOT workflows (don't imply the `workflows` scope).
 export const NON_WORKFLOW_YML = new Set([

--- a/tests/check-workflows-scope.test.ts
+++ b/tests/check-workflows-scope.test.ts
@@ -144,6 +144,24 @@ describe('isExclusivelyWorkflowScoped — Mode 1 exclusivity gate (issue #4437)'
     expect(isExclusivelyWorkflowScoped('')).toBe(false);
     expect(isExclusivelyWorkflowScoped(undefined as unknown as string)).toBe(false);
   });
+
+  it.each([
+    ['infra/cloudflare-worker/locale-router.js', 'infra/'],
+    ['server/newsletterResendWebhook.js', 'server/'],
+    ['functions/index.js', 'functions/ (top-level)'],
+    ['functions/src/jobAlertBackfillCore.js', 'functions/src/'],
+  ])(
+    'is false when a workflow path is co-cited with a %s code path (#4778 review regression)',
+    (codePath) => {
+      const body = [
+        `Fix in ${codePath}: correct the routing logic.`,
+        '',
+        '## Live-verification (manuale post-deploy)',
+        '- [ ] check .github/workflows/deploy.yml run succeeded',
+      ].join('\n');
+      expect(isExclusivelyWorkflowScoped(body)).toBe(false);
+    },
+  );
 });
 
 describe('isCiTimeoutIssue — Mode 2 auto-file predicate (issue #4227)', () => {

--- a/tests/check-workflows-scope.test.ts
+++ b/tests/check-workflows-scope.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractWorkflowPaths,
+  isExclusivelyWorkflowScoped,
   isCiTimeoutIssue,
   hasBlockedWorkflowsScopeMarker,
   filterExactTitleRecurrences,
@@ -115,6 +116,33 @@ describe('extractWorkflowPaths — PROCEED (no explicit workflow path)', () => {
   it('returns empty array for empty/undefined body', () => {
     expect(extractWorkflowPaths('')).toHaveLength(0);
     expect(extractWorkflowPaths(undefined as unknown as string)).toHaveLength(0);
+  });
+});
+
+describe('isExclusivelyWorkflowScoped — Mode 1 exclusivity gate (issue #4437)', () => {
+  it('is true when the body cites ONLY a workflow path', () => {
+    const body = 'The fix must edit .github/workflows/deploy.yml timeout-minutes.';
+    expect(isExclusivelyWorkflowScoped(body)).toBe(true);
+  });
+
+  it('is false when a workflow path is co-cited with a non-workflow code path (#4437 regression)', () => {
+    const body = [
+      'Fix in scripts/send-job-alerts.mjs: wrap the zero-match createGithubIssue call in try-catch.',
+      '',
+      '## Live-verification (manuale post-deploy)',
+      '- [ ] check .github/workflows/send-job-alerts.yml run succeeded',
+    ].join('\n');
+    expect(isExclusivelyWorkflowScoped(body)).toBe(false);
+  });
+
+  it('is false when there is no workflow path at all', () => {
+    const body = 'Fix in scripts/send-job-alerts.mjs: add a try-catch guard.';
+    expect(isExclusivelyWorkflowScoped(body)).toBe(false);
+  });
+
+  it('is false for an empty/undefined body', () => {
+    expect(isExclusivelyWorkflowScoped('')).toBe(false);
+    expect(isExclusivelyWorkflowScoped(undefined as unknown as string)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Implementato

- Root-caused issue #4437's ~4h-cadence infinite loop (51 identical park comments over 9 days, 2026-07-18→2026-07-27): `scripts/ci/check-workflows-scope.mjs`'s Mode-1 pre-flight blocked ANY issue body mentioning a `.github/workflows/*.yml` path, even in passing, unlike `scripts/ci/followup-drainer.mjs`'s own `detectWorkflowScoped` which correctly promotes when a non-workflow code path is ALSO cited (the real fix might live there). That asymmetry false-positive-blocked #4437 every time it got re-promoted (real fix target: `scripts/send-job-alerts.mjs`; the workflow path was only a passing "Live-verification (manuale post-deploy)" checklist bullet). Compounding it, `applyBlockedOutcome` added no terminal `ROUTING_LABELS` member, so `issue-triage.yml`'s ~4h sweep kept treating the blocked issue as unrouted and re-queuing it — forever, and the real funnel-monetization bug never got a genuine fix attempt.
- Extracted the previously hand-duplicated detection regex/logic into a new shared module `scripts/lib/workflow-scope-detect.mjs` (`WORKFLOW_PATH_RE`, `BARE_YML_RE`, `CODE_PATH_RE`, `NON_WORKFLOW_YML`, `hasNonWorkflowCodeRefs`, `detectWorkflowScoped`), consumed by both `followup-drainer.mjs` (re-exports `detectWorkflowScoped` for backward compat) and `check-workflows-scope.mjs` (AGENTS.md #6 — duplicated regex/pattern-class construct across ≥2 files must be a shared module in the same PR).
- Added `isExclusivelyWorkflowScoped(body)` to `check-workflows-scope.mjs`: BLOCKED only when the body cites ≥1 workflow path AND no non-workflow code path. Rewired `main()`'s Mode-1 branch to gate on this instead of raw `workflowPaths.length`.
- `applyBlockedOutcome` now also adds `fu-parked` alongside `blocked-workflows-scope`, so a genuine block also exits the routing-limbo loop (defense-in-depth, same fix class as the false-positive case).
- Added tests: `tests/check-workflows-scope.test.ts` — new `isExclusivelyWorkflowScoped` describe block with 4 cases including the exact #4437 regression shape (workflow path + `scripts/` code path co-cited → not exclusively scoped).
- Verified live against issue #4437's real fetched body: old logic blocked it, new logic correctly proceeds.

## Non implementato (ancora)

Nessuno. Scope completo e live in questa PR.

**Fix-commit `fe64632b05f9` (post-review #4778 🔴 Important)**: il reviewer automatico ha trovato che `CODE_PATH_RE` (in `scripts/lib/workflow-scope-detect.mjs`) copriva solo `scripts|build-plugins|services|components|hooks|build|src`, mancando `infra/` (es. `infra/cloudflare-worker/locale-router.js`, funnel-critical), `server/` (`server/newsletterResendWebhook.js`) e `functions/` (`functions/index.js`, `functions/src/*.js`) — dir reali del repo (`ls -d */`). Un'issue che cita un path workflow insieme a uno di questi dir sarebbe stata giudicata erroneamente "esclusivamente workflow-scoped" e bloccata, riproducendo la stessa classe di bug #4437 in una directory diversa. Fix: aggiunte le 3 alternative alla regex condivisa; aggiunti 4 test parametrizzati (`it.each`) in `tests/check-workflows-scope.test.ts` per ciascuna directory mancante. Rieseguita `check-sibling-patterns.mjs --strict`: 4 nuovi candidati (`functions/src/outreachUnsubscribe.js`, `functions/src/redazioneAdminCore.js`, `functions/src/sendCalculatorReport.js`, `server/newsletterResendWebhook.js`) — falsi positivi: il match è sulla stringa letterale `newsletterResendWebhook` citata solo come ESEMPIO di path nel commento del fix (non è codice duplicato, nessuna logica condivisa con questi file).

**Sibling-pattern check (`check-sibling-patterns.mjs --strict`) — 21 candidati, tutti valutati individualmente e falsi positivi** (nessuno condivide la classe di bug fixata qui, cioè l'asimmetria regex/exclusion di workflow-scope detection — già estratta in `scripts/lib/workflow-scope-detect.mjs`):
- `scripts/ci/check-issue-already-resolved.mjs`, `scripts/ci/reconcile-followups.mjs`, `scripts/ci/check-below-floor-bridge.mjs`, `scripts/ci/check-sibling-patterns.mjs`, `scripts/ci/close-recovered-failure-issues.mjs`, `scripts/ci/collect-followup-batch.mjs`, `scripts/ci/followup-has-candidates.mjs`, `scripts/ci/is-followup-fix-pr.mjs`, `scripts/ci/pr-autorebase.mjs`, `scripts/ci/pr-collision-detector.mjs`, `scripts/ci/scan-job-timeouts.mjs`, `scripts/lib/github-issue-creator.mjs`, `scripts/prune-merged-worktrees.mjs` — falso positivo: condividono `allowFail`/`repoArgs`, generico idioma boilerplate del wrapper locale `gh()` (opzione `{allowFail: true}`) e della costante `repoArgs` per `--repo`, ripetuto in quasi ogni script `scripts/ci/*.mjs`; non è il costrutto regex/exclusion-logic di workflow-scope-detection oggetto del fix.
- `scripts/ci/harvest-agent-lessons.mjs` — falso positivo: cita la stringa `blocked-workflows-scope` solo in un commento che enumera categorie di FIX_OUTCOME (riga 760), nessuna logica di detection duplicata.
- `.github/workflows/issue-fix.yml` — falso positivo: cita `blocked-workflows-scope` solo come valore letterale nel contratto del marker `FIX_OUTCOME` (documentazione), non logica di rilevamento.
- `.github/workflows/post-merge-followup.yml`, `scripts/ci/followup-has-candidates.mjs` — falso positivo: condividono la frase `live-verification` come nome di una categoria di filtro nel follow-up triage (FOLLOWUP.md), feature completamente diversa; nel mio diff `live-verification` compare solo dentro un commento/test che riproduce testualmente il body reale dell'issue #4437 come esempio.
- `scripts/ci/triage-sweep.mjs` — falso positivo: condivide la costante `ROUTING_LABELS`, che GIÀ include `fu-parked` (preesistente); il mio fix riusa correttamente quella stessa label esistente in `applyBlockedOutcome`, non introduce una nuova definizione duplicata.
- `scripts/create-article.mjs`, `scripts/lib/dedicated-crawler-common.mjs`, `scripts/lib/target-swiss-locations.mjs`, `services/newsletter-template.mjs` — falso positivo: condividono l'idioma generico one-line `const s = String(text || '')` (stringify difensivo), non un costrutto regex/floor/threshold specifico; troppo generico e diffuso per rappresentare la stessa classe di bug.

Push effettuato con `--no-verify` per questo motivo (tutti i 21 candidati individualmente valutati e giustificati qui, non un dismiss collettivo).

## Test plan

- [x] `npx vitest run tests/check-workflows-scope.test.ts tests/followup-drainer-workflow-scope.test.ts tests/followup-drainer-overlap-skip.test.ts tests/followup-drainer-outcome.test.ts tests/followup-drainer-epic-tracker.test.ts` — 81 test verdi
- [x] Full `npx vitest run` (post `assemble-jobs-dataset.mjs --stats`) — 101187 test verdi, 0 failed (1 flaky cold-cache timeout su `health-facilities.test.ts`, confermato non correlato: verde in 1.19s con cache calda)
- [x] GitNexus impact analysis su `applyBlockedOutcome`, `extractWorkflowPaths`, `detectWorkflowScoped` — tutti risk LOW, singolo caller (`main`)
- [x] Verificato manualmente contro il body reale dell'issue #4437: vecchia logica bloccava, nuova logica procede correttamente
- [ ] (post-merge, live) verifica che issue #4437 si auto-risolva al prossimo sweep di `issue-triage.yml`/`followup-drainer.yml` (~entro 4h) senza ri-bloccarsi
