### PR TITLE
fix(deploy): rehydrate-section-shards.sh missing locale prefix on non-IT sub-path

### DIFF
--- a/scripts/lib/rehydrate-section-shards.sh
+++ b/scripts/lib/rehydrate-section-shards.sh
@@ -13,7 +13,18 @@ set -uo pipefail
 rehydrate_section() {
   local section="$1"
   for loc in it en de fr; do
-    sub="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
+    slug="$(jq -r --arg s "$section" --arg l "$loc" '.[$s][$l] // empty' scripts/lib/section-shard-slugs.json)"
+    # section-shard-slugs.json values are the URL slug ONLY (no locale
+    # prefix) — same it/en-de-fr branch as push-section-shard.sh and
+    # strip-section-subtree.sh. Using the bare slug as `sub` for en/de/fr
+    # made every non-IT dist-subtree check look at the wrong path (missing
+    # its `$loc/` prefix), so a correctly-packed tar always read back as 0
+    # files extracted and the git-clone fallback's dir check failed the
+    # same way (run 30238078775).
+    case "$loc" in
+      it) sub="$slug" ;;
+      en|de|fr) sub="$loc/$slug" ;;
+    esac
     if [ -d "dist/$sub" ]; then
       echo "$section $loc ($sub) present in artifact — skip rehydrate"
       continue


### PR DESCRIPTION
## Implementato

- `scripts/lib/rehydrate-section-shards.sh`: `rehydrate_section()` now derives `sub` with the same `it → slug` / `en|de|fr → loc/slug` branch already used correctly by `scripts/lib/push-section-shard.sh` and `scripts/lib/strip-section-subtree.sh`, instead of using the bare `section-shard-slugs.json` slug value for every locale.
- Root cause of all 3 validate-dist job failures in run [30238078775](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30238078775): the non-IT "Pack section shard dist (tar)" step in `deploy.yml` packs tars with entries under `$loc/$slug/...` (correct, per the JSON contract comment). The rehydrate step read them back looking for bare `dist/$slug` (missing `$loc/`), so `find dist/$sub -type f` always found 0 files even though `tar -tf` correctly listed N — triggering "tar extraction incomplete" for every section on every non-IT locale. The same wrong `sub` also broke the git-clone fallback's `$tmp/$sub` existence check.
- Sibling-pattern check (AGENTS.md #6): grepped all consumers of `section-shard-slugs.json` (`deploy.yml`, `post-deploy-validate-dist.yml`, `scripts/audit-404-risk.mjs`, `push-section-shard.sh`, `strip-section-subtree.sh`). `push-section-shard.sh` and `strip-section-subtree.sh` already implement the correct branch. `audit-404-risk.mjs` uses an unrelated, independently-correct shard-tree-walk (`SECTION_SHARD_REPOS`/`buildServedSet`) that doesn't consume this bare-slug pattern at all. `deploy.yml`'s own `pack_section()` already computes `sub="$loc/$slug"` correctly. `check-sibling-patterns.mjs --strict` (pre-push hook) confirms: no untouched sibling file shares the modified construct.
- Fix is in a single shared script, called from all 3 rehydrate call-sites in `post-deploy-validate-dist.yml` (lines 447, 834, 1390) — fixes all 3 failed validate-dist jobs from run 30238078775 in one change.

## Non implementato (ancora)

Nessuno.