### PR TITLE
fix(newsletter): DE title-hints dictionary gap + headline-locale backstop for job alert emails

### DIFF
--- a/scripts/lib/job-locale-utils.mjs
+++ b/scripts/lib/job-locale-utils.mjs
@@ -8,10 +8,29 @@ const TITLE_HINTS = {
     // Note: "jr"/"sr" removed from EN-only hints — they are used across IT/EN/DE/FR job titles
   ],
   de: [
-    /\b(mitarbeiter|fachspezialist|fachfrau|fachmann|oberarzt|arzt|pflege|leiter|logistik|spital|praktikant|qualitat|qualität|ingenieur|techniker|verantwortliche|verantwortlicher|diatkoch|diätkoch|apotheker|systemgastronomie|systemgastronomiefachfrau|systemgastronomiefachmann|sekretär|sekretärin|onkologie|hämatologie|rayonleiter|metzger|detailhandelsfachfrau|detailhandelsfachmann|medizinische|berufsbildner|assistenzarzt|pflegefach|chefarzt)\b/gi,
+    /\b(mitarbeiter|fachspezialist|fachfrau|fachmann|oberarzt|arzt|pflege|leiter|logistik|spital|praktikant|qualitat|qualität|ingenieur|techniker|verantwortliche|verantwortlicher|diatkoch|diätkoch|apotheker|systemgastronomie|systemgastronomiefachfrau|systemgastronomiefachmann|sekretär|sekretärin|onkologie|hämatologie|rayonleiter|metzger|detailhandelsfachfrau|detailhandelsfachmann|medizinische|berufsbildner|assistenzarzt|pflegefach|chefarzt|altersmedizin|kardiologie|herzchirurgie)\b/gi,
     /\b[a-zäöüß]+:in\b/gi,
     /\b[a-zäöüß]+:mann\b/gi,
     /\befz\b/gi,
+    // Swiss health/hospital vocational + institutional vocabulary: German builds
+    // these as single fused compound words (no space), so a bare word-boundary
+    // alternative in the group above can't reach the stem inside e.g.
+    // "Pflegefachperson" or "Poliklinik" (\b requires a non-word char right after
+    // the match). Each gets its own \w*-padded stem regex instead of enumerating
+    // every inflection/compound by hand. Bug: "Fachperson Gesundheit Universitäre
+    // Klinik für Altersmedizin" shipped untranslated into an IT-locale slot —
+    // none of fachperson/gesundheit/universitäre/klinik/altersmedizin had
+    // word-hint support, so detection fell through to the char-hint-only tier
+    // (0.45), under the 0.55 needsRetranslation threshold.
+    // universität/universitär require the literal "ä" (no plain-"a" fallback,
+    // unlike qualitat/qualität above) — "universit[aä][tr]" would also match
+    // Italian "universitario/universitari(a)", which has no umlaut.
+    /\b\w*fachperson\w*\b/gi,
+    /\bgesundheit\w*\b/gi,
+    /\b\w*klinik\w*\b/gi,
+    /\b(universität|universitär)\w*\b/gi,
+    /\b\w*geriatrie\w*\b/gi,
+    /\bhauswirtschaft\w*\b/gi,
   ],
   it: [
     /\b(responsabile|medico|infermiere|impiegato|tecnico|cuoco|apprendista|apprendiste|candidato|collaboratore|ingegnere|caporeparto|fisioterapista|servizio civile|radiologia|ginecologia|ostetricia|ristorazione|operatore|segretario|segretaria|assistente|ricercatrice|ricercatore|architetture|sistemi|cucina|dietista|educatore|educatrice)\b/gi,

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -32,6 +32,7 @@ import { createCantonResolvers, AGGREGATE_KEY } from '../build-plugins/shared/ca
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { commitInChunks } from './lib/firestore-batch.mjs';
 import { isAddressSuppressed, isJobAlertExcluded } from '../services/emailSuppression.mjs';
+import { detectJobTitleLocaleDetails } from './lib/job-locale-utils.mjs';
 import {
   normalizeSentMap,
   filterUnsentJobs,
@@ -673,6 +674,40 @@ function behaviorSignals(personalization) {
 
 // ── Email template ───────────────────────────────────────────
 
+// Mirrors the confidence bar used by the upstream needsRetranslation gate
+// (scripts/lib/dedicated-crawler-common.mjs, ~line 1395/1415: detectJobTitleLocaleDetails
+// + minConfidence 0.55) so the two layers stay consistent.
+const HEADLINE_LOCALE_MIN_CONFIDENCE = 0.55;
+
+// Second, independent line of defense against a wrong-language headline
+// (live bug, 2026-07-27: an 'it' subscriber's subject + lead card was built
+// from an untranslated German title, even though a correctly-localized job
+// sat lower in the same ranked list). The upstream `needsRetranslation` flag
+// is supposed to fully exclude untranslated-title jobs before they ever reach
+// `matchedJobs`, but by construction it can't catch every case (new
+// employers, new source languages, code-switched titles under its confidence
+// threshold). So rather than trust `shownJobs[0]` blindly, walk the
+// rank-ordered list and headline the FIRST job whose title reliably reads as
+// `locale` — a bad title can never become the thing a subscriber sees first,
+// regardless of whether the upstream flag caught it.
+//
+// Pure + unit-testable (kept next to buildAlertEmail per this file's stated
+// design goal — see the "Matching logic" comment above).
+function selectHeadlineIndex(shownJobs, locale) {
+  for (let i = 0; i < shownJobs.length; i++) {
+    const job = shownJobs[i];
+    const title = job.titleByLocale?.[locale] || job.titleByLocale?.it || job.title || '';
+    const detected = detectJobTitleLocaleDetails(title, locale);
+    const reliablyInLocale = detected.lang === locale || detected.confidence < HEADLINE_LOCALE_MIN_CONFIDENCE;
+    if (reliablyInLocale) return i;
+  }
+  // Edge case: none pass (e.g. a single-job alert whose only job is
+  // untranslated) — never break the "an alert always sends something"
+  // guarantee, and never produce an empty subject. Fall back to today's
+  // behavior: the top-ranked job leads regardless.
+  return 0;
+}
+
 function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
   const locale = nlNormLocale(alert.locale);
   const s = getStrings(locale);
@@ -693,6 +728,17 @@ function buildAlertEmail(alert, matchedJobs, autologinEnabled = true) {
   // novelty. What makes the rendered jobs "new for you" is the sentJobIds
   // dedup (never emailed to this alert before) + the freshness-first ranking.
   const shownJobs = matchedJobs.slice(0, MAX_JOB_CARDS);
+
+  // Headline-language backstop (see selectHeadlineIndex): swap the first
+  // reliably-`locale` job into the lead position (index 0) so it becomes both
+  // the subject and the visually-first card. This only exchanges two
+  // positions — the rest of shownJobs keeps its original rank order, and the
+  // displaced job is NOT dropped, just no longer leads (its salary/location/
+  // company data is still valid; only its fitness as a headline was in doubt).
+  const headlineIdx = selectHeadlineIndex(shownJobs, locale);
+  if (headlineIdx > 0) {
+    [shownJobs[0], shownJobs[headlineIdx]] = [shownJobs[headlineIdx], shownJobs[0]];
+  }
 
   // Subject: lead with the most relevant job (LinkedIn-style personalization).
   // Format: "🔔 {title} at {company}" or "🔔 {title} at {company} (+N more)"

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -78,6 +78,70 @@ describe('job alert email — subject personalization', () => {
   });
 });
 
+describe('job alert email — headline-locale backstop (second line of defense)', () => {
+  // Live regression (2026-07-27): an 'it' subscriber's subject AND lead card
+  // were built from the top-ranked job's title, which was 100% untranslated
+  // German ("Fachperson Gesundheit Universitäre Klinik per Altersmedizin",
+  // employer Stadtspital Zürich) — even though a lower-ranked job in the SAME
+  // email had a correctly-localized Italian title. The upstream
+  // needsRetranslation flag is *supposed* to exclude untranslated titles
+  // before they reach buildAlertEmail, but has real detection gaps by
+  // construction. buildAlertEmail must not trust shownJobs[0]'s title blindly:
+  // it now headlines the first job whose title reliably reads as the alert's
+  // locale (via detectJobTitleLocaleDetails, same 0.55 confidence bar as the
+  // upstream gate). Fixture mirrors the real title/employer, swapping in a
+  // stronger German dictionary word ("Fachfrau" instead of "Fachperson", which
+  // isn't in the detector's DE hint list) so it deterministically crosses the
+  // 0.55 bar in this test — the literal live-bug string itself only scored
+  // ~0.45, illustrating that even this backstop can't catch every case.
+  const wrongLocaleJob = () => fixtureJob({
+    title: 'Fachfrau Gesundheit Universitäre Klinik für Altersmedizin',
+    company: 'Stadtspital Zürich',
+  });
+  const correctLocaleJob = () => fixtureJob({
+    title: 'Infermiere di reparto medicina interna',
+    company: 'Ospedale Regionale',
+  });
+
+  it('headlines the correctly-localized job when the top-ranked job is untranslated', () => {
+    // Rank order matters: index 0 is the "best match" per scoreJobForAlert —
+    // deliberately the untranslated German job here, mirroring the live bug.
+    const jobs = [wrongLocaleJob(), correctLocaleJob()];
+    const result = buildAlertEmail(fixtureAlert('it'), jobs, true);
+
+    // (a) subject is derived from the correctly-localized job, not the German one.
+    expect(result.subject).toContain('Infermiere');
+    expect(result.subject).not.toContain('Fachfrau');
+
+    // (b) the correctly-localized job is the first rendered card, in both
+    // the HTML and plaintext alternatives.
+    expect(result.html.indexOf('Infermiere')).toBeGreaterThan(-1);
+    expect(result.html.indexOf('Fachfrau')).toBeGreaterThan(-1);
+    expect(result.html.indexOf('Infermiere')).toBeLessThan(result.html.indexOf('Fachfrau'));
+    expect(result.text.indexOf('Infermiere')).toBeGreaterThan(-1);
+    expect(result.text.indexOf('Fachfrau')).toBeGreaterThan(-1);
+    expect(result.text.indexOf('Infermiere')).toBeLessThan(result.text.indexOf('Fachfrau'));
+
+    // (c) the German-titled job is demoted, NOT dropped — unlike
+    // needsRetranslation (which excludes a flagged job entirely), it still
+    // appears further down (its salary/location/company data is still valid).
+    expect(result.html).toContain('Fachfrau');
+    expect(result.text).toContain('Fachfrau');
+  });
+
+  it('falls back to the top-ranked job when NO job passes the locale check (never breaks a send)', () => {
+    // Edge case: a single-job alert whose only job is untranslated. There is
+    // no better option to headline — the email must still build successfully,
+    // with a non-empty subject, rather than crash or send blank.
+    const result = buildAlertEmail(fixtureAlert('it'), [wrongLocaleJob()], true);
+    expect(result.subject).toBeTruthy();
+    expect(result.subject.length).toBeGreaterThan(0);
+    expect(result.subject).toContain('Fachfrau');
+    expect(result.html).toContain('Fachfrau');
+    expect(result.text).toContain('Fachfrau');
+  });
+});
+
 describe('job alert email — honest counts (shown jobs, never the raw pool size)', () => {
   // Live regression (July 2026): "🔔 186 nuove offerte per te" on an email
   // rendering 10 cards. The candidate pool is a rolling crawledAt window that
@@ -312,7 +376,14 @@ describe('job alert email — subject title noise (Pensum / gender markers)', ()
   // — the "(100%)" Pensum overflowed the cap and was truncated mid-token, leaving
   // a dangling unbalanced "(100%…". The subject must drop the Pensum entirely.
   it('strips a trailing workload "(100%)" from the subject title (no dangling paren)', () => {
-    const job = { ...fixtureJob(), title: 'Senior Technical Product Manager - Portafogli (100%)', company: 'Helvetia' };
+    // Title reworded to a reliably-Italian phrasing (was originally an
+    // English-loanword-heavy title) so this fixture — which is testing
+    // Pensum-stripping/truncation, NOT headline-locale selection — doesn't
+    // collide with the headline-locale backstop (see the dedicated describe
+    // block below): "Senior Technical Product Manager" scores confidence 0.85
+    // as 'en' via detectJobTitleLocaleDetails and would otherwise get
+    // demoted below a "Filler" job, which is not what this test is about.
+    const job = { ...fixtureJob(), title: 'Responsabile Tecnico Prodotto - Gestione Portafogli (100%)', company: 'Helvetia' };
     const jobs = [job, ...Array.from({ length: 48 }, () => fixtureJob({ title: 'Filler' }))];
     const result = buildAlertEmail(fixtureAlert('it'), jobs, true);
     expect(result.subject.length).toBeLessThanOrEqual(78);
@@ -320,7 +391,7 @@ describe('job alert email — subject title noise (Pensum / gender markers)', ()
     expect(result.subject).not.toContain('(100%');
     // No unbalanced "(" left anywhere in the subject.
     expect((result.subject.match(/\(/g) || []).length).toBe((result.subject.match(/\)/g) || []).length);
-    expect(result.subject).toContain('Senior Technical Product Manager - Portafogli');
+    expect(result.subject).toContain('Responsabile Tecnico Prodotto - Gestione Portafogli');
     // Honest shown-count: 10 cards rendered → +9, not the raw pool size (+48).
     expect(result.subject).toContain('(+9 altre offerte)');
   });

--- a/tests/job-title-locale-utils.test.ts
+++ b/tests/job-title-locale-utils.test.ts
@@ -17,6 +17,23 @@ describe('job title locale utils', () => {
     expect(detected.lang).toBe('fr');
     expect(detected.confidence).toBeGreaterThanOrEqual(0.55);
   });
+
+  // Regression (2026-07-27 live bug): "Fachperson Gesundheit Universitäre Klinik
+  // für Altersmedizin" (Stadtspital Zürich, DE-source) shipped completely
+  // untranslated into an IT-locale subscriber's job-alert email. None of
+  // fachperson/gesundheit/universitäre/klinik/altersmedizin had word-hint
+  // support in TITLE_HINTS.de, so detection fell through to the weak
+  // char-hint-only tier (0.45, driven solely by the "ä" diacritic) — under the
+  // 0.55 needsRetranslation threshold in dedicated-crawler-common.mjs. Health-
+  // sector vocabulary added to TITLE_HINTS.de now gives genuine word support.
+  it('detects the Stadtspital Zürich leftover-German title as German with word support', () => {
+    const detected = detectJobTitleLocaleDetails(
+      'Fachperson Gesundheit Universitäre Klinik per Altersmedizin', 'it'
+    );
+    expect(detected.lang).toBe('de');
+    expect(detected.confidence).toBeGreaterThanOrEqual(0.55);
+    expect(detected.method).not.toBe('char-hint-only');
+  });
 });
 
 describe('titleLooksUntranslatedFromSource (generic leftover-source-language check)', () => {


### PR DESCRIPTION
## Contesto

Job-alert email spedita a subscriber IT (locale `it`) con titolo lead/subject non tradotto: "Fachperson Gesundheit Universitäre Klinik per Altersmedizin" (Stadtspital Zürich) — sia il subject che la card visivamente-prima erano in tedesco.

Root cause: `TITLE_HINTS.de` (dizionario word-hint di `detectJobTitleLocaleDetails`) non copriva vocaboli chiave del titolo → confidence rilevata 0.45 (tier debole `char-hint-only`), sotto la soglia 0.55 richiesta da `shouldDropLocalizedValue` per flaggare `needsRetranslation` → il job non veniva mai escluso dal pool di candidati per l'alert.

Due fix complementari, sviluppati in parallelo su worktree isolati e consolidati qui:

1. **Root-cause: gap dizionario DE** (`scripts/lib/job-locale-utils.mjs`) — aggiunte le parole mancanti (fachperson, gesundheit, klinik, universität/universitär, altersmedizin, kardiologie, herzchirurgie, geriatrie, hauswirtschaft) a `TITLE_HINTS.de`. La stringa reale del bug ora rileva `lang: 'de', confidence: 0.85, method: 'title-hints-strong'` (verificato live in questa PR, vedi sotto). Deliberatamente esclusi: `spitex` (loanword svizzero che appare correttamente anche in titoli IT/EN/FR già tradotti), `kompetenzzentrum`/`betreuung` (troppo generici, usi non-health trovati nel dataset).
2. **Difesa a runtime: headline-locale backstop** (`scripts/send-job-alerts.mjs`) — nuovo `selectHeadlineIndex(shownJobs, locale)`, usa lo stesso `detectJobTitleLocaleDetails` condiviso per verificare che il job promosso a subject/prima-card sia affidabilmente nella lingua del subscriber; se il job in cima al ranking risulta con confidence ≥0.55 in una lingua diversa da quella del subscriber, viene scambiato con il primo job successivo che passa il check (mai droppato, solo riordinato). Rete di sicurezza indipendente da `needsRetranslation` — protegge anche i job già indicizzati (vedi nota sotto sul motivo per cui serve).

## Implementato

- `scripts/lib/job-locale-utils.mjs` — vocabolario `TITLE_HINTS.de` esteso (settore sanitario/health svizzero).
- `tests/job-title-locale-utils.test.ts` — nuovo test pinnato sulla stringa live del bug (9/9 verdi).
- `scripts/send-job-alerts.mjs` — `selectHeadlineIndex` + wiring in `buildAlertEmail` (subject e prima card).
- `tests/job-alert-email.test.ts` — 2 nuovi test (demotion caso reale + edge-case singolo-job); 1 fixture pre-esistente riformulata (titolo che scorava 0.85 'en' per il detector condiviso, demotion legittima non correlata a quel che il test verificava — Pensum-stripping).
- Verifica combinata post-merge dei due branch (questa PR): 94/94 test verdi (`job-title-locale-utils.test.ts` + `job-alert-email.test.ts`), stringa live del bug ri-verificata a confidence 0.85 con dizionario aggiornato.
- Sibling-pattern check (`check-sibling-patterns.mjs`) sul diff combinato: 9 candidati, tutti falsi positivi verificati individualmente (dettaglio sotto).
- Filed issue di follow-up #4788 per una scoperta collaterale correlata (vedi sotto) — non nello scope di questa PR.

## Non implementato (ancora)

Nessuno. Falsi positivi sibling-pattern-check (per-file, richiesti da AGENTS.md #6 per il `--no-verify` sul pre-push hook):

- `scripts/lib/dedicated-crawler-common.mjs` — condivide `detectJobTitleLocaleDetails`/`minConfidence`: consuma la funzione via import da `job-locale-utils.mjs`, nessuna copia locale del dizionario → beneficia automaticamente del fix senza modifiche proprie.
- `scripts/lib/shared-jobs-crawler.mjs` — stesso motivo: solo import (`detectJobTitleLang, detectJobTitleLocaleDetails, pinnedTitleSourceLang`), nessuna logica duplicata.
- `scripts/relocalize-pending-jobs.mjs` — verificato via grep: non chiama `detectJobTitleLocaleDetails` né importa `job-locale-utils.mjs` in alcuna forma; consuma solo il flag `needsRetranslation` già calcolato altrove. Falso positivo del surfacer euristico (token generico condiviso).
- `scripts/newsletter-qa.mjs`, `scripts/newsletter-template.mjs`, `scripts/send-newsletter.mjs`, `services/newsletter-content.mjs`, `services/newsletter-template.mjs`, `services/newsletterPreview.ts` — condividono solo il token generico `matchedJobs`; appartengono al prodotto weekly-newsletter separato, che renderizza una LISTA di job card (`renderJobs`/`renderJobSection`) senza logica di selezione "headline singola" — `selectHeadlineIndex` non si applica architetturalmente a questo pattern (nessun subject/card "a scelta singola" da proteggere).

**Scoperta correlata ma fuori scope** (issue #4788, non blocca questa PR): durante l'investigazione ho trovato un "translation stability lock" in `dedicated-crawler-common.mjs:6412-6433` che ri-azzera silenziosamente `needsRetranslation` sui ri-crawl successivi per job già indicizzati con titolo sorgente stabile, perché `hasFullLocaleCoverage` verifica solo presenza (non correttezza linguistica). Questo significa che il fix del dizionario (punto 1 sopra) funziona pienamente per job **nuovi** al primo crawl, ma per i ~3800+ job **già indicizzati** in stato bacato il flag può essere ri-soppresso ad ogni crawl finché il titolo sorgente non cambia. È esattamente per questo che il backstop a runtime (punto 2) è stato sviluppato come seconda linea di difesa indipendente da `needsRetranslation` — protegge comunque l'email anche se il dataset resta sporco. Fix strutturale del lock è un cambio più ampio (richiede distinguere presenza da correttezza-linguistica, validare contro l'intero dataset, probabile rate-limiting sulla coda di retranslation) → tracciato separatamente in #4788, non correlato/necessario per chiudere il bug email riportato.

## Test plan

- [x] `npx vitest run tests/job-title-locale-utils.test.ts tests/job-alert-email.test.ts` — 94/94 verdi
- [x] Verifica manuale: `detectJobTitleLocaleDetails('Fachperson Gesundheit Universitäre Klinik per Altersmedizin', 'it')` → `{lang: 'de', confidence: 0.85, method: 'title-hints-strong'}`
- [x] `node scripts/ci/check-sibling-patterns.mjs` — 9 candidati, tutti documentati come falsi positivi sopra