### PR TITLE
fix(ci): OmniRoute POC — login before registering providers on fresh boot

### DIFF
--- a/.github/workflows/omniroute-poc.yml
+++ b/.github/workflows/omniroute-poc.yml
@@ -40,7 +40,10 @@ jobs:
 
       - name: Start OmniRoute server
         run: |
-          nohup omniroute > /tmp/omniroute.log 2>&1 &
+          OMNI_PW="$(openssl rand -hex 20)"
+          echo "::add-mask::$OMNI_PW"
+          echo "OMNIROUTE_INITIAL_PASSWORD=$OMNI_PW" >> "$GITHUB_ENV"
+          INITIAL_PASSWORD="$OMNI_PW" nohup omniroute > /tmp/omniroute.log 2>&1 &
           for i in $(seq 1 30); do
             if curl -sf http://localhost:20128/api/settings/require-login >/dev/null; then
               echo "OmniRoute ready after ${i}s"

--- a/scripts/ci/omniroute-poc-register.mjs
+++ b/scripts/ci/omniroute-poc-register.mjs
@@ -13,6 +13,26 @@ const PROVIDERS = [
   ['mistral', 'Mistral (CI POC, expected dead)', ['MISTRAL_API_KEY']],
 ];
 
+// A fresh OmniRoute boot (always the case in CI — new sqlite db each run) sets
+// requireLogin:true and needs a session cookie for /api/* management routes
+// even when INITIAL_PASSWORD is left unset (falls back to an internal default).
+// /v1/chat/completions is unaffected — it stays open with no auth.
+let cookie = '';
+const password = process.env.OMNIROUTE_INITIAL_PASSWORD;
+if (password) {
+  const loginRes = await fetch(`${OMNIROUTE_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password }),
+  });
+  if (!loginRes.ok) {
+    console.error('Login failed:', loginRes.status, await loginRes.text().catch(() => ''));
+    process.exit(1);
+  }
+  const setCookie = loginRes.headers.get('set-cookie');
+  cookie = setCookie ? setCookie.split(';')[0] : '';
+}
+
 const skipped = [];
 const results = [];
 
@@ -25,7 +45,7 @@ for (const [provider, name, envNames] of PROVIDERS) {
 
   const res = await fetch(`${OMNIROUTE_URL}/api/providers`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...(cookie ? { Cookie: cookie } : {}) },
     body: JSON.stringify({ provider, name, apiKey: apiKey.trim() }),
   });
   const data = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Implementato

Root cause della run live fallita (30255976958): un boot fresco di OmniRoute in CI (sqlite db nuovo ad ogni run) imposta `requireLogin:true` di default anche senza `INITIAL_PASSWORD` esplicita (fallback a default interno) — a differenza dell'istanza locale long-lived (`requireLogin:false`). Tutte e 4 le registrazioni provider fallivano con `HTTP 401 AUTH_001 Authentication required`.

Fix:
- `omniroute-poc.yml`: genera password random per-run (`openssl rand -hex 20`), mascherata in log, passata come `INITIAL_PASSWORD` all'avvio server e persistita in `$GITHUB_ENV`.
- `omniroute-poc-register.mjs`: prima di registrare, `POST /api/auth/login {"password"}`, estrae il cookie `Set-Cookie`, lo allega come header `Cookie` alle POST successive su `/api/providers`.
- `/v1/chat/completions` confermato non impattato (nessuna auth richiesta lì, verificato con/senza cookie).

Verificato end-to-end contro un'istanza isolata (HOME/porta fittizie, mai toccata l'istanza locale reale con le 54 connessioni registrate): login OK, registrazione provider OK (`OK groq id=...`, exit 0).

## Non implementato (ancora)

Nessuna feature rimandata — fix mirato al solo root cause del 401.

### Sibling-pattern hook — 14 falsi positivi (giustificati singolarmente)

Il pre-push hook ha segnalato 14 file gemelli che condividono i token `set-cookie`/`setCookie` col diff. Verificati singolarmente — tutti crawler/parser di job board ATS (scraping), non toccati:

- `scripts/lib/gavi-job-parser.mjs`, `sygnum-job-parser.mjs` — coalescing manuale multi Set-Cookie in singolo header Cookie per replay fetch
- `scripts/lib/inselspital-job-parser.mjs`, `see-spital-job-parser.mjs`, `spital-maennedorf-job-parser.mjs` — stesso pattern, split su virgola per pair multipli
- `scripts/lib/apple-retail-switzerland-job-parser.mjs`, `implenia-job-parser.mjs`, `marriott-job-parser.mjs`, `microsoft-job-parser.mjs`, `ubs-job-parser.mjs`, `scripts/update-groupe-mutuel-jobs.mjs`, `scripts/update-supsi-jobs.mjs` — uso di `res.headers.getSetCookie()` (array multi-header) per cookie-jar di sessione scraping
- `scripts/lib/ats-clients/csod-client.mjs` — estrazione JWT + Set-Cookie multi-sessione per client ATS Cornerstone
- `scripts/lib/tiChCookieJar.mjs` — cookie jar condiviso persistente per crawler ti.ch

Tutti gestiscono **più** header Set-Cookie da un jar di sessione persistente per scraping job board (dominio: crawling ATS svizzeri). Il mio diff estrae **un singolo** cookie da **una singola** risposta di login OmniRoute (`split(';')[0]`), per uno script CI one-shot (dominio: auth verso gateway AI self-hosted). Nessuna logica duplicata da consolidare — token condiviso è solo il nome header HTTP `Set-Cookie`/sua variante camelCase, non lo stesso antipattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)