### PR TITLE
fix(moduli): staticOverlay per pagina autocertificazione + link WhatsNew

### DIFF
--- a/components/community/WhatsNewModal.tsx
+++ b/components/community/WhatsNewModal.tsx
@@ -19,6 +19,8 @@ interface ReleaseItem {
  titleKey: string;
  descKey: string;
  link?: { tab: string; subTab?: string };
+ /** Absolute path to a standalone static page outside the SPA tab system (e.g. /moduli/...). Mutually exclusive with `link`. */
+ href?: string;
 }
 
 interface Release {
@@ -41,6 +43,7 @@ export const RELEASES: Release[] = [
         type: 'feature',
         titleKey: 'whatsNew.v3830.selfCertForms.title',
         descKey: 'whatsNew.v3830.selfCertForms.desc',
+        href: '/moduli/autocertificazione-candidatura/',
       },
     ],
   },
@@ -2428,13 +2431,18 @@ export default function WhatsNewModal({ open, onClose }: WhatsNewModalProps) {
  }
  }, [open]);
 
- const handleLinkClick = useCallback((e: MouseEvent<HTMLAnchorElement>, link: { tab: string; subTab?: string }) => {
- e.preventDefault();
+ const handleLinkClick = useCallback((e: MouseEvent<HTMLAnchorElement>, item: ReleaseItem) => {
  onClose();
+ if (item.href) {
+ // Standalone static page outside the SPA tab system (e.g. /moduli/...) —
+ // let the browser follow the href with a normal navigation.
+ return;
+ }
+ e.preventDefault();
  // Use SPA navigation when available; the href on the <a> element is a
  // deterministic fallback so the link works even if NavigationContext is absent.
- if (nav) {
- nav.navigateTo(link.tab as any, link.subTab);
+ if (nav && item.link) {
+ nav.navigateTo(item.link.tab as any, item.link.subTab);
  } else {
  window.location.href = e.currentTarget.getAttribute('href') || '/';
  }
@@ -2516,8 +2524,8 @@ export default function WhatsNewModal({ open, onClose }: WhatsNewModalProps) {
  const cfg = TYPE_CONFIG[item.type];
  const Icon = cfg.icon;
  const route = item.link ? releaseLinkToRoute(item.link) : null;
- const href = route ? buildPath(route, locale as any) : '';
- const isClickable = !!item.link;
+ const href = item.href ? item.href : route ? buildPath(route, locale as any) : '';
+ const isClickable = !!item.link || !!item.href;
  const cardContent = (
  <>
  <span className={`mt-0.5 p-1 rounded-md shrink-0 ${cfg.bg}`}>
@@ -2540,7 +2548,7 @@ export default function WhatsNewModal({ open, onClose }: WhatsNewModalProps) {
  <li key={idx}>
  <a
  href={href}
- onClick={(e) => handleLinkClick(e, item.link!)}
+ onClick={(e) => handleLinkClick(e, item)}
  className="w-full flex items-start gap-3 group p-2 -mx-2 rounded-lg cursor-pointer hover:bg-surface-raised/50 active:bg-surface-raised transition-colors text-left no-underline"
  aria-label={`${t(item.titleKey)} — ${t('whatsNew.goTo')}`}
  >

--- a/services/router.ts
+++ b/services/router.ts
@@ -2243,6 +2243,21 @@ export function parsePath(pathname: string): ParseResult {
    }
  }
 
+ // Self-certification forms guide — /moduli/autocertificazione-candidatura/
+ // (IT-only, source of truth: build-plugins/selfCertificationFormsPlugin.ts
+ // LANDING_URL_PATH). Emitted via buildSeoPageHtml (seoContentOutsideRoot:
+ // true); without staticOverlay this path is unmatched anywhere else in
+ // parsePath, falls through to the final notFoundPath fallback, and the SPA
+ // hides `main.seo-static-content` + renders NotFoundSuggestions inside
+ // #root on hydrate — the guide + PDF links vanish for real users. Routed to
+ // guida/first-day for back-nav, mirroring the salary-hub article pattern.
+ {
+   const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
+   if (normalized === '/moduli/autocertificazione-candidatura/') {
+     return { route: { activeTab: 'guida', guidaSubTab: 'first-day', staticOverlay: true }, locale: 'it' };
+   }
+ }
+
  // Border-municipality static SEO pages — one page per Italian comune under
  // the municipalities hub. The build emits the actual page body outside
  // #root; staticOverlay keeps SPA navigation from replacing it with the

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -673,6 +673,23 @@ describe('Router — per-municipality fiscal guide pages (finding #1)', () => {
   });
 });
 
+describe('Router — self-certification forms guide (/moduli/autocertificazione-candidatura/)', () => {
+  it('parsePath resolves the guide URL to a staticOverlay guida route (no notFoundPath)', () => {
+    const { route, locale, notFoundPath } = parsePath('/moduli/autocertificazione-candidatura/');
+    expect(route.activeTab).toBe('guida');
+    expect(route.staticOverlay).toBe(true);
+    expect(locale).toBe('it');
+    expect(notFoundPath).toBeUndefined();
+  });
+
+  it('parsePath resolves the guide URL without a trailing slash the same way', () => {
+    const { route, notFoundPath } = parsePath('/moduli/autocertificazione-candidatura');
+    expect(route.activeTab).toBe('guida');
+    expect(route.staticOverlay).toBe(true);
+    expect(notFoundPath).toBeUndefined();
+  });
+});
+
 /* ─────────── parsePath/buildPath round-trip symmetry (issue #2698) ─────────── */
 
 /**

--- a/tests/whats-new.test.tsx
+++ b/tests/whats-new.test.tsx
@@ -123,6 +123,18 @@ describe('WhatsNewModal', () => {
 
     expect(link.getAttribute('href')).toBe(buildPath({ activeTab: 'calculator', calcolatoreSubTab: 'calculator' }, 'it'));
   });
+
+  it('links the self-certification forms item to its standalone static page via href, not an SPA tab', () => {
+    const item = findReleaseItem('3.83.0', 'whatsNew.v3830.selfCertForms.title');
+    expect(item?.href).toBe('/moduli/autocertificazione-candidatura/');
+    expect(item?.link).toBeUndefined();
+
+    render(<WhatsNewModal open={true} onClose={vi.fn()} />);
+    const label = `${itCore['whatsNew.v3830.selfCertForms.title']} — ${itCore['whatsNew.goTo']}`;
+    const link = screen.getByRole('link', { name: label });
+
+    expect(link.getAttribute('href')).toBe('/moduli/autocertificazione-candidatura/');
+  });
 });
 
 // ─── RELEASES data integrity ─────────────────────────────────────────────


### PR DESCRIPTION
## Implementato

- **Bug 1 — pagina va in errore all'idratazione**: `/moduli/autocertificazione-candidatura/` (PR #4780) non era registrata in `parsePath()` (`services/router.ts`). Ogni URL non matchato cade nel fallback finale che setta `notFoundPath`; `App.tsx` allora nasconde `main.seo-static-content` e monta `NotFoundSuggestions` dentro `#root` all'idratazione — la guida + i link PDF sparivano per gli utenti reali. Aggiunta early-return con `staticOverlay: true` mappata su `guida/first-day` (stesso pattern già usato per 8+ landing statiche esistenti: annual/market report, border-wait map, taxation hub, eventi, nursing, ecc.).
- **Bug 2 — WhatsNew non punta alla pagina**: `ReleaseItem.link` supporta solo navigazione SPA interna (`{tab, subTab}`), non può esprimere un path assoluto verso una pagina standalone fuori dal sistema di tab. Aggiunto campo opzionale `href?: string` su `ReleaseItem`, consumato da `handleLinkClick` (navigazione browser normale, nessun `preventDefault` per gli item con `href`) e dal render (`isClickable`/`href` calcolati anche da `item.href`). Applicato all'item `whatsNew.v3830.selfCertForms`.
- Test aggiunti: `tests/router.test.ts` (staticOverlay + no notFoundPath per il nuovo path, con/senza slash finale), `tests/whats-new.test.tsx` (item href-based renderizza `<a href>` corretto, `item.link` assente).
- `npx tsc --noEmit`: nessun errore nuovo su `router.ts`/`WhatsNewModal.tsx` (rumore preesistente in altri test file, non toccato da questa PR). Vitest mirati: `tests/router.test.ts` (575/575), `tests/whats-new.test.tsx` (21/21).

## Non implementato (ancora)

Nessuno. Il pre-push hook (`check-sibling-patterns.mjs --strict`) ha segnalato 37 file gemello/i per token condivisi (`seoContentOutsideRoot`, `guidaSubTab`, `notFoundPath`, `parsePath`, `HTMLAnchorElement`, `NotFoundSuggestions`, `LANDING_URL_PATH`, `selfCertificationFormsPlugin`) — ispezionati singolarmente, tutti falsi positivi (nessuno replica la stessa classe di bug: pagina `seoContentOutsideRoot` non registrata in `parsePath()`, o link WhatsNew tab-only senza `href`):

**Già registrati in `services/router.ts` (stessa classe di bug, già risolta prima di questa PR)**
- `build-plugins/careerLandingsData.ts` — falso positivo: `CAREER_LANDING_ROUTES` già importato/matchato (router.ts:59).
- `build-plugins/comparisonsHubPlugin.ts` — falso positivo: branch `COMPARISONS_HUB_ROUTES`/`isComparisonsHubPath` già live (AE-7, router.ts:~2483).
- `build-plugins/eventsSeoPagesPlugin.ts` — falso positivo: hub/detail `/eventi/...` già staticOverlay-registrati (#3125/#3645).
- `build-plugins/faqHubPlugin.ts` — falso positivo: `FAQ_HUB_ROUTES`/`isFaqHubPath` già importati/matchati da `data/faq-hub/routes` (router.ts:~2524).
- `build-plugins/holidaysLandingsPlugin.ts` — falso positivo: `holidaysLandingsData` già importato (router.ts:79).
- `build-plugins/jobsSeoPagesPlugin.ts` — falso positivo: routing job-detail è la feature core, indipendentemente auditata con proprio meccanismo dedicato; gli hit sono commenti interni su `seoContentOutsideRoot`, non un gap di registrazione.
- `build-plugins/minimumWageLandingsPlugin.ts` — falso positivo: branch `MINWAGE_LANDING_ROUTES` già live (#4479, router.ts:~2406).
- `build-plugins/nursingLandingsPlugin.ts` — falso positivo: `NURSING_LANDING_ROUTES` già importato (router.ts:58).
- `build-plugins/sectionPagesPlugin.ts` — falso positivo: `isSectionPagePath`/`parseSectionPagePath` già importati da `sectionPagesPathsData` (router.ts:68).

**Infrastruttura condivisa (definisce/consuma il flag/helper, non emette pagine proprie)**
- `build-plugins/htmlTemplate.ts`, `build-plugins/shared/criticalCss.ts`, `build-plugins/shared/railGutters.ts`, `build-plugins/shared/seoPageShell.ts` — falso positivo: definiscono/consumano `seoContentOutsideRoot` come opzione condivisa, non emettono una pagina che richieda una registrazione router propria.
- `build-plugins/shared/clusterThinShell.ts`, `build-plugins/shared/hubChrome.ts` — falso positivo: riferiscono `parsePath` solo come tipo/commento di contesto.

**Feature di questa stessa PR (non un sibling diverso)**
- `build-plugins/selfCertificationFormsPlugin.ts` — falso positivo: è la pagina oggetto del fix, citata per nome nel nuovo commento di `router.ts`; non un sito diverso.
- `build-plugins/shared/pdfKitTheme.ts` — falso positivo: modulo condiviso estratto apposta (vedi header del file) per evitare la duplicazione delle costanti PDF tra `pdfWhitepapersPlugin.ts` e `selfCertificationFormsPlugin.ts`; non attinente al routing.

**Consumer generici di `parsePath()`/`notFoundPath`/`guidaSubTab`/`staticOverlay` (non un secondo sito di registrazione)**
- `hooks/useNavigationState.ts`, `components/community/JobBoard.tsx`, `hooks/seoHelpers.ts`, `services/seoService.ts`, `scripts/check-pages-publish-lag.mjs`, `scripts/create-article.mjs` — falso positivo: consumano l'output di `parsePath()` (incluso `staticOverlay`, già gestito genericamente per qualunque route) senza definire una registrazione indipendente.
- `components/calculator/SeasonalNaspiSimulator.tsx`, `components/community/BlogArticles.tsx`, `components/community/JobExpiredView.tsx`, `components/comparators/SalaryCompare.tsx`, `components/pages/SiteMapPage.tsx`, `components/tabs/GuidaTabContent.tsx`, `services/frontaliereChecklist.ts`, `services/internalLinks.ts`, `services/NavigationContext.ts`, `components/guide/FrontaliereWizard.tsx` — falso positivo: referenziano `guidaSubTab` come valore enum già esistente (riusato `'first-day'`, nessuna nuova semantica introdotta).
- `components/calculator/ConsultingCTA.tsx`, `components/navigation/SubTabNav.tsx`, `services/analytics.ts` — falso positivo: usano `HTMLAnchorElement` come tipo DOM nei propri handler di click, indipendenti dal modello `ReleaseItem.link`/`href` di `WhatsNewModal`.
- `components/shared/NotFoundSuggestions.tsx` — falso positivo: è il componente stesso citato genericamente, non una pagina che necessita di propria registrazione.

## Test plan

- [x] `npx tsc --noEmit` — nessun errore nuovo sui file toccati
- [x] `npx vitest run tests/router.test.ts tests/whats-new.test.tsx` — 596/596 verdi
- [ ] Verifica live post-merge: `curl` + hydration check su `https://frontaliereticino.ch/moduli/autocertificazione-candidatura/` (niente più NotFoundSuggestions) e click sul link WhatsNew