### PR TITLE
feat(ai-models): OmniRoute opt-in last-resort provider + pilot wiring

### DIFF
--- a/.github/actions/setup-omniroute/action.yml
+++ b/.github/actions/setup-omniroute/action.yml
@@ -1,0 +1,54 @@
+name: "Setup OmniRoute (self-hosted local AI gateway)"
+description: >-
+  Installs OmniRoute (Homebrew CLI, published to npm), starts it with a
+  random INITIAL_PASSWORD, waits for readiness on
+  http://localhost:20128, registers a small curated set of provider
+  connections from env (GROQ_API_KEY/OPENROUTER_API_KEY/GEMINI_API_KEY/
+  MISTRAL_API_KEY — see scripts/ci/omniroute-poc-register.mjs), then sets
+  OMNIROUTE_ENABLED=1 so scripts/lib/ai-models.mjs offers
+  AI_MODELS.OMNIROUTE_AUTO (single "auto" routing-sentinel node — OmniRoute
+  does its OWN internal provider fallback across whatever it has
+  registered; we deliberately don't enumerate its providers as separate
+  chain entries) for the rest of this job.
+  Extracted from the original inline steps in
+  .github/workflows/omniroute-poc.yml (PR #4797) so both that POC and any
+  pilot workflow (see generate-company-parser.yml's omniroute_enabled
+  input) share one implementation instead of copy-pasted bash drifting
+  apart (AGENTS.md #6).
+  Caller MUST run "node scripts/load-rc-env.mjs" before this action so the
+  small curated provider keys are present in env for registration, and MUST
+  gate the `uses:` step itself with an `if:` — this action has no internal
+  opt-in gate of its own (unlike setup-claude-haiku-fallback, which is a
+  default-ON kill-switch); every step here always runs when invoked.
+runs:
+  using: "composite"
+  steps:
+    - name: Install OmniRoute
+      shell: bash
+      run: OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute
+
+    - name: Start OmniRoute server
+      shell: bash
+      run: |
+        OMNI_PW="$(openssl rand -hex 20)"
+        echo "::add-mask::$OMNI_PW"
+        echo "OMNIROUTE_INITIAL_PASSWORD=$OMNI_PW" >> "$GITHUB_ENV"
+        INITIAL_PASSWORD="$OMNI_PW" nohup omniroute > /tmp/omniroute.log 2>&1 &
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:20128/api/settings/require-login >/dev/null; then
+            echo "OmniRoute ready after ${i}s"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "OmniRoute did not become ready in time"
+        cat /tmp/omniroute.log
+        exit 1
+
+    - name: Register OmniRoute providers (small curated set)
+      shell: bash
+      run: node scripts/ci/omniroute-poc-register.mjs
+
+    - name: Enable OmniRoute for the rest of this job
+      shell: bash
+      run: echo "OMNIROUTE_ENABLED=1" >> "$GITHUB_ENV"

--- a/.github/workflows/generate-company-parser.yml
+++ b/.github/workflows/generate-company-parser.yml
@@ -23,6 +23,11 @@ on:
         options:
           - 'false'
           - 'true'
+      omniroute_enabled:
+        description: 'Pilot: register OmniRoute (self-hosted local AI gateway) as an opt-in last-resort AI fallback for this run only'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: generate-company-parser
@@ -66,6 +71,25 @@ jobs:
 
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
+
+      # ── OmniRoute pilot (opt-in, OFF by default — see omniroute_enabled
+      # input). Install/start/register/enable factored into
+      # .github/actions/setup-omniroute (shared with omniroute-poc.yml,
+      # PR #4797) so the two workflows don't drift on the same bash
+      # (AGENTS.md #6). Reuses the same small curated provider-key set
+      # loaded above by load-rc-env.mjs — does NOT provision OmniRoute's
+      # full ~78-100+ locally-registered provider roster as CI secrets
+      # (see PR body's "Non implementato"). When the input is false/unset,
+      # the composite action is skipped entirely and OMNIROUTE_ENABLED is
+      # never set, so ai-models.mjs's OmniRoute provider stays inert —
+      # identical behavior to before this pilot.
+      - name: Setup OmniRoute (pilot, opt-in)
+        if: ${{ inputs.omniroute_enabled }}
+        uses: ./.github/actions/setup-omniroute
+
+      - name: Dump OmniRoute logs on failure (pilot, opt-in)
+        if: ${{ failure() && inputs.omniroute_enabled }}
+        run: cat /tmp/omniroute.log || true
 
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort in ai-models.mjs's DEFAULT_CHAIN, reached only

--- a/.github/workflows/omniroute-poc.yml
+++ b/.github/workflows/omniroute-poc.yml
@@ -35,28 +35,15 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
-      - name: Install OmniRoute
-        run: OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute
-
-      - name: Start OmniRoute server
-        run: |
-          OMNI_PW="$(openssl rand -hex 20)"
-          echo "::add-mask::$OMNI_PW"
-          echo "OMNIROUTE_INITIAL_PASSWORD=$OMNI_PW" >> "$GITHUB_ENV"
-          INITIAL_PASSWORD="$OMNI_PW" nohup omniroute > /tmp/omniroute.log 2>&1 &
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:20128/api/settings/require-login >/dev/null; then
-              echo "OmniRoute ready after ${i}s"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "OmniRoute did not become ready in time"
-          cat /tmp/omniroute.log
-          exit 1
-
-      - name: Register providers (one known-dead key on purpose, to prove fallback)
-        run: node scripts/ci/omniroute-poc-register.mjs
+      # Install/start/register/enable factored into
+      # .github/actions/setup-omniroute — shared with the opt-in pilot
+      # wiring in generate-company-parser.yml so the two workflows don't
+      # drift on the same bash (AGENTS.md #6). The trailing "enable" step
+      # inside the action (OMNIROUTE_ENABLED=1) is a no-op here — this POC
+      # calls OmniRoute's raw HTTP API directly below, not via
+      # ai-models.mjs's callLLM.
+      - name: Setup OmniRoute
+        uses: ./.github/actions/setup-omniroute
 
       - name: Call a completion through OmniRoute (auto routing/fallback)
         run: |

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -355,6 +355,15 @@ export const AI_MODELS = Object.freeze({
   // id, so this tracks whatever Anthropic ships as "current Haiku" without
   // needing a code change on every Haiku release.
   CLAUDE_CLI_HAIKU:    'claude-cli/haiku',
+
+  // ── OmniRoute (self-hosted local AI gateway, opt-in, last-resort) ──
+  // Single node using OmniRoute's own "auto" routing sentinel — OmniRoute
+  // fans out across its ~78-100+ locally-registered providers internally, so
+  // this deliberately does NOT enumerate those providers as separate chain
+  // entries (that would duplicate routing logic OmniRoute already does, and
+  // the roster is a developer-local runtime concern, not a stable identity).
+  // Inert unless OMNIROUTE_ENABLED is set. See PROVIDER.OMNIROUTE / _callOmniRoute.
+  OMNIROUTE_AUTO:      'omniroute/auto',
 });
 
 /**
@@ -584,10 +593,20 @@ export const DEFAULT_CHAIN = [
   // above is daily-exhausted, generation still produces instead of deferring.
   AI_MODELS.LOCAL_FALLBACK,
 
-  // Absolute last resort. Always sorted below LOCAL_FALLBACK (sortChainByScore)
-  // and skipped unless ENABLE_HAIKU_ARTICLE_FALLBACK (RC) + CLAUDE_CODE_OAUTH_TOKEN
-  // are both present — so a run only ever reaches it once every free-tier cloud
-  // model AND the local CPU fallback have already failed.
+  // Self-hosted local AI gateway (OmniRoute), opt-in pilot. Sorted below
+  // LOCAL_FALLBACK (sortChainByScore) — LOCAL is deterministic zero-network CPU
+  // inference with no failure mode worth deferring further; OmniRoute depends on
+  // its own registered upstream providers (same failure class as the main
+  // chain), so it sits below the guaranteed-available local model but above the
+  // reserved, Max-subscription-backed Claude CLI tier. Skipped entirely unless
+  // OMNIROUTE_ENABLED is set.
+  AI_MODELS.OMNIROUTE_AUTO,
+
+  // Absolute last resort. Always sorted below LOCAL_FALLBACK and OMNIROUTE_AUTO
+  // (sortChainByScore) and skipped unless ENABLE_HAIKU_ARTICLE_FALLBACK (RC) +
+  // CLAUDE_CODE_OAUTH_TOKEN are both present — so a run only ever reaches it
+  // once every free-tier cloud model AND the local/OmniRoute fallbacks have
+  // already failed.
   AI_MODELS.CLAUDE_CLI_HAIKU,
 ];
 
@@ -618,6 +637,13 @@ const PROVIDER = Object.freeze({
   // Claude CLI subprocess (Haiku), opt-in via Remote Config, absolute last
   // resort below LOCAL. See AI_MODELS.CLAUDE_CLI_HAIKU / _callClaudeCli.
   CLAUDE_CLI:  'claude_cli',
+  // Self-hosted local AI gateway (OmniRoute — Homebrew CLI, OpenAI-compatible
+  // /v1/chat/completions on http://localhost:20128). Opt-in pilot, last resort
+  // between LOCAL and CLAUDE_CLI. Single model id calls with model:"auto" so
+  // OmniRoute does its OWN internal multi-provider fallback across whatever it
+  // has registered — we deliberately don't mirror its provider roster here.
+  // See AI_MODELS.OMNIROUTE_AUTO / _callOmniRoute.
+  OMNIROUTE:   'omniroute',
 });
 
 // ── Endpoints ────────────────────────────────────────────────
@@ -661,6 +687,29 @@ function getLocalLlmTimeoutMs() {
   const v = parseInt((process.env.LOCAL_LLM_TIMEOUT_MS || '').trim(), 10);
   return Number.isFinite(v) && v > 0 ? v : 1_500_000; // 25 min default — see comment above
 }
+
+// ── OmniRoute (self-hosted local AI gateway, OpenAI-compatible) ──────
+// Opt-in: inert unless OMNIROUTE_ENABLED is truthy. OmniRoute runs
+// persistently on the host (Homebrew CLI v3.8.48+, http://localhost:20128)
+// with ~78-100+ individually-registered providers and does its OWN internal
+// provider fallback when given the literal model id "auto" — confirmed live
+// (2026-07-27): a bare {"model":"auto"} POST to /v1/chat/completions is
+// accepted as a routing sentinel, even though "auto" itself never appears as
+// a literal entry in /v1/models' catalog (only auto/<combo> shortcuts do).
+// We intentionally use ONE stable model id here instead of mirroring
+// OmniRoute's registered providers as separate AI_MODELS/DEFAULT_CHAIN
+// entries — that roster is a developer-local runtime concern (CI registers
+// only a small curated set; see scripts/ci/omniroute-poc-register.mjs), not a
+// stable identity worth pinning chain entries to, and duplicating it here
+// would just re-implement routing OmniRoute already does internally.
+const OMNIROUTE_DEFAULT_URL = 'http://127.0.0.1:20128/v1/chat/completions';
+export function isOmniRouteEnabled() { return /^(1|true|yes|on)$/i.test((process.env.OMNIROUTE_ENABLED || '').trim()); }
+function getOmniRouteUrl() { return (process.env.OMNIROUTE_URL || OMNIROUTE_DEFAULT_URL).trim(); }
+// OmniRoute's /v1/chat/completions is unauthenticated by default (session
+// cookie only gates /api/* management routes — see
+// omniroute-poc-register.mjs); _callOpenAICompatible requires a non-empty
+// key, so keep a sentinel, same pattern as Local/getLocalLlmApiKey.
+function getOmniRouteApiKey() { return (process.env.OMNIROUTE_API_KEY || 'omniroute-no-key').trim(); }
 
 // ── Claude CLI Haiku fallback (opt-in via RC, absolute last resort) ──
 // ENABLE_HAIKU_ARTICLE_FALLBACK is loaded from Firebase Remote Config by
@@ -775,6 +824,7 @@ function getProvider(model) {
   if (model.startsWith('zai/'))        return PROVIDER.ZAI;
   if (model.startsWith('local/'))      return PROVIDER.LOCAL;
   if (model.startsWith('claude-cli/')) return PROVIDER.CLAUDE_CLI;
+  if (model.startsWith('omniroute/'))  return PROVIDER.OMNIROUTE;
   return PROVIDER.GITHUB;
 }
 
@@ -809,6 +859,7 @@ function getApiModelId(model) {
   if (model.startsWith('zai/'))        return model.slice(4);   // 4 chars: "zai/"
   if (model.startsWith('local/'))      return getLocalLlmModelId(); // served-model label is runtime-configured
   if (model.startsWith('claude-cli/')) return model.slice(11);  // 11 chars: "claude-cli/"
+  if (model.startsWith('omniroute/'))  return model.slice(10);  // 10 chars: "omniroute/" → "auto"
   return model;
 }
 
@@ -844,22 +895,31 @@ function getApiKeyForProvider(provider) {
     // by the `claude` CLI subprocess. Gate on RC flag + token presence so the
     // chain only offers this model when both are actually usable. Mirrors Local.
     case PROVIDER.CLAUDE_CLI:  return (!_claudeCliBinaryMissing && !_claudeCliTimeoutStormDetected && isClaudeCliFallbackEnabled() && hasClaudeCodeOauthToken()) ? 'claude-cli-no-key' : '';
+    // OmniRoute needs no real key from us either; gate purely on the opt-in
+    // flag, same sentinel pattern as Local. '' when disabled → every
+    // omniroute/* model is skipped.
+    case PROVIDER.OMNIROUTE:   return isOmniRouteEnabled() ? getOmniRouteApiKey() : '';
     default: return '';
   }
 }
 
 /**
- * True for opt-in, no-external-quota, absolute-last-resort providers (local
- * CPU fallback, Claude CLI Haiku — see AI_MODELS.LOCAL_FALLBACK /
- * AI_MODELS.CLAUDE_CLI_HAIKU). Neither has a daily-quota concept, so
- * exhausting/banning them mid-run (or persisting a ban across runs) just
- * guarantees zero output for the rest of the budget — there's nothing left to
- * fall back to. Centralizes what were several separate `!== PROVIDER.LOCAL`
- * checks so adding a second last-resort tier didn't require touching each one.
+ * True for opt-in, absolute-last-resort providers (local CPU fallback, Claude
+ * CLI Haiku, OmniRoute — see AI_MODELS.LOCAL_FALLBACK / CLAUDE_CLI_HAIKU /
+ * OMNIROUTE_AUTO) that must never be marked exhausted/banned. Local and Claude
+ * CLI have no daily-quota concept at all, so persisting a ban just guarantees
+ * zero output for the rest of the budget. OmniRoute's reasoning is distinct
+ * but lands on the same exemption: the CI pilot instance is EPHEMERAL — a
+ * fresh, empty sqlite provider DB every run (scripts/ci/omniroute-poc-register.mjs
+ * re-registers from scratch each boot) — so a Firestore-persisted "exhausted
+ * until midnight" ban computed from one run's registered providers is
+ * meaningless (and actively harmful) for a different run's freshly-provisioned
+ * instance. Centralizes what were several separate `!== PROVIDER.LOCAL`
+ * checks so adding further last-resort tiers didn't require touching each one.
  */
 function _isLastResortProvider(modelId) {
   const p = getProvider(modelId);
-  return p === PROVIDER.LOCAL || p === PROVIDER.CLAUDE_CLI;
+  return p === PROVIDER.LOCAL || p === PROVIDER.CLAUDE_CLI || p === PROVIDER.OMNIROUTE;
 }
 
 // Backward-compatible helpers (kept for external code)
@@ -922,6 +982,12 @@ const DEFAULT_OPTS = {
  *   of the recurring "content.it non normalizzabile" / JSON parse failures
  *   logged whenever the cascade reached local/fallback (e.g. run
  *   28744325535's `imageAlt` object left dangling mid-payload).
+ * - OmniRoute deliberately NOT included: model:"auto" means WE don't control
+ *   which upstream provider actually serves a given request, so unlike every
+ *   other entry above there's no single verified backend to point this
+ *   decision at — it can silently vary per call across OmniRoute's ~78-100+
+ *   registered providers. Falls back to the safe `json_object` default;
+ *   revisit only if/when OmniRoute normalizes schema support across backends.
  */
 const PROVIDERS_WITH_STRICT_JSON_SCHEMA = new Set(['GitHub', 'OpenRouter', 'Mistral', 'Local']);
 
@@ -1972,10 +2038,13 @@ export function getScoreBoard() {
  */
 // Last-resort tiering for sortChainByScore: higher tier always sinks below
 // lower tier regardless of score. Local CPU fallback sinks below every real
-// remote API; Claude CLI Haiku sinks even below local — it's the absolute
-// last resort, only reached once local has ALSO failed.
+// remote API; OmniRoute sinks below Local (deterministic zero-network CPU
+// inference vs. OmniRoute's dependency on its own upstream providers); Claude
+// CLI Haiku sinks even below OmniRoute — it's the absolute last resort, only
+// reached once local AND OmniRoute have ALSO failed.
 function _lastResortTier(model) {
-  if (model.startsWith('claude-cli/')) return 2;
+  if (model.startsWith('claude-cli/')) return 3;
+  if (model.startsWith('omniroute/')) return 2;
   if (model.startsWith('local/')) return 1;
   return 0;
 }
@@ -2737,12 +2806,13 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
         // another credential to try (GitHub multi-PAT: _suppressExhaustionMark),
         // do NOT mark the model globally exhausted — it's only out on THIS
         // account; the error still propagates so the caller can rotate.
-        // Same PROVIDER.LOCAL exemption as the 429/timeout/content-failure
-        // circuit breakers elsewhere in this file — _callLocal routes through
-        // here (trackAs: model), so an HTTP-shaped failure (daily-limit-looking
-        // response, stale local auth 401) must never hard-ban local/fallback.
+        // Same last-resort exemption as the 429/timeout/content-failure
+        // circuit breakers elsewhere in this file — _callLocal/_callOmniRoute
+        // route through here (trackAs: model), so an HTTP-shaped failure
+        // (daily-limit-looking response, stale local/OmniRoute auth 401) must
+        // never hard-ban a last-resort provider. See _isLastResortProvider.
         if (isDailyLimitError(res.status, raw)) {
-          if (!_suppressExhaustionMark && getProvider(modelForTracking) !== PROVIDER.LOCAL) {
+          if (!_suppressExhaustionMark && !_isLastResortProvider(modelForTracking)) {
             markModelExhausted(modelForTracking);
             _stats.exhausted++;
           }
@@ -2763,7 +2833,7 @@ async function _callOpenAICompatible(apiModel, messages, opts, { endpoint, apiKe
           if (nrc.reason === 'schema_unsupported' && responseFormat?.type === 'json_schema') {
             _learnSchemaIncompatible(modelForTracking);
           }
-          if (nrc.markExhausted && getProvider(modelForTracking) !== PROVIDER.LOCAL) {
+          if (nrc.markExhausted && !_isLastResortProvider(modelForTracking)) {
             markModelExhausted(modelForTracking, 'nonretryable');
             _stats.exhausted++;
           }
@@ -3179,6 +3249,27 @@ async function _callLocal(model, messages, opts) {
 }
 
 /**
+ * Call OmniRoute (self-hosted local AI gateway) using its own "auto" routing
+ * sentinel — OmniRoute selects and falls back across its own registered
+ * providers internally, so this is deliberately a single call with the
+ * literal model id "auto" (getApiModelId strips the omniroute/ prefix down
+ * to it), not a per-provider fan-out on our side. Opt-in via OMNIROUTE_ENABLED
+ * (default OFF). No local-CPU-style timeout floor here (unlike _callLocal):
+ * OmniRoute forwards to real network providers, so it behaves like the rest
+ * of the remote chain rather than like slow CPU inference. See
+ * PROVIDER.OMNIROUTE / AI_MODELS.OMNIROUTE_AUTO.
+ */
+function _callOmniRoute(model, messages, opts) {
+  const apiModel = getApiModelId(model); // = 'auto'
+  return _callOpenAICompatible(apiModel, messages, opts, {
+    endpoint: getOmniRouteUrl(),
+    apiKey: getOmniRouteApiKey(),
+    providerName: 'OmniRoute',
+    trackAs: model,
+  });
+}
+
+/**
  * Call Claude Haiku via the `claude` CLI subprocess (RC-gated, absolute
  * last resort — reuses CLAUDE_CODE_OAUTH_TOKEN, same zero-cost Max-plan auth
  * already wired for pr-review-loop.yml/issue-fix.yml, never a raw
@@ -3443,6 +3534,7 @@ function _callModel(model, messages, opts) {
     case PROVIDER.ZAI:         return _callZai(model, messages, opts);
     case PROVIDER.LOCAL:       return _callLocal(model, messages, opts);
     case PROVIDER.CLAUDE_CLI:  return _callClaudeCli(model, messages, opts);
+    case PROVIDER.OMNIROUTE:   return _callOmniRoute(model, messages, opts);
     default: throw new Error(`[${model}] Unknown provider: ${provider}`);
   }
 }

--- a/tests/local-llm-fallback.test.ts
+++ b/tests/local-llm-fallback.test.ts
@@ -22,15 +22,20 @@ describe('local LLM fallback provider', () => {
     expect(AI_MODELS.LOCAL_FALLBACK).toBe('local/fallback');
   });
 
-  it('sits below every remote API, with only the opt-in Claude CLI Haiku fallback below it', () => {
+  it('sits below every remote API, with only the opt-in OmniRoute and Claude CLI Haiku fallbacks below it', () => {
     // AI_MODELS.CLAUDE_CLI_HAIKU (RC-gated, see ai-models-claude-cli-fallback.test.ts)
-    // is now the true final entry — an absolute last resort below even local
-    // CPU inference — but local/fallback must still sit below every real
-    // remote API, which is the invariant this test guards.
+    // is still the true final entry — an absolute last resort below even local
+    // CPU inference and OmniRoute — but local/fallback must still sit below
+    // every real remote API, which is the invariant this test guards.
+    // AI_MODELS.OMNIROUTE_AUTO (opt-in, see ai-models-omniroute-fallback.test.ts)
+    // sits between local/fallback and Claude CLI Haiku (see ai-models.mjs's
+    // DEFAULT_CHAIN / _lastResortTier comments for the tiering rationale).
     expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 1]).toBe(AI_MODELS.CLAUDE_CLI_HAIKU);
-    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 2]).toBe(AI_MODELS.LOCAL_FALLBACK);
+    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 2]).toBe(AI_MODELS.OMNIROUTE_AUTO);
+    expect(DEFAULT_CHAIN[DEFAULT_CHAIN.length - 3]).toBe(AI_MODELS.LOCAL_FALLBACK);
     // Each must appear exactly once.
     expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.LOCAL_FALLBACK)).toHaveLength(1);
+    expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.OMNIROUTE_AUTO)).toHaveLength(1);
     expect(DEFAULT_CHAIN.filter((m) => m === AI_MODELS.CLAUDE_CLI_HAIKU)).toHaveLength(1);
   });
 
@@ -489,6 +494,28 @@ describe('local LLM fallback exhaustion never persists past the run (Firestore)'
     } finally {
       logSpy.mockRestore();
     }
+  });
+
+  // OmniRoute (opt-in last-resort, sits between local/fallback and Claude CLI
+  // Haiku — see ai-models.mjs _isLastResortProvider) earns the same exemption
+  // for a DIFFERENT reason than local/fallback: the CI pilot instance is
+  // EPHEMERAL (fresh, empty sqlite provider DB every run — see
+  // scripts/ci/omniroute-poc-register.mjs), so a ban computed from one run's
+  // registered providers would be meaningless for a different run's
+  // freshly-provisioned instance. Guards it gets the identical never-persists
+  // treatment as local/fallback despite the different rationale.
+  it('write path: exhausting omniroute/auto never sets exhaustedUntil either (different rationale, same exemption)', async () => {
+    const store: Record<string, { models?: Record<string, unknown> }> = {};
+    mockFirestore(store);
+    const mod = await import('../scripts/lib/ai-models.mjs');
+    await mod.initScoreStore();
+    mod.markModelExhausted(mod.AI_MODELS.OMNIROUTE_AUTO, 'quota');
+    mod.markModelExhausted(mod.AI_MODELS.GPT4O, 'quota');
+    await mod.flushScores();
+
+    const persisted = store._all.models as Record<string, { exhaustedUntil: string | null }>;
+    expect(persisted['omniroute__auto'].exhaustedUntil).toBeNull();
+    expect(persisted['gpt-4o'].exhaustedUntil).not.toBeNull();
   });
 });
 

--- a/tests/scripts/ai-models-omniroute-fallback.test.ts
+++ b/tests/scripts/ai-models-omniroute-fallback.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * OmniRoute (self-hosted local AI gateway) opt-in pilot fallback.
+ *
+ * OmniRoute is a persistent, self-hosted OpenAI-compatible gateway
+ * (Homebrew CLI, http://localhost:20128 by default) that fans out across its
+ * own ~78-100+ individually-registered providers when given the literal model
+ * id "auto" — confirmed live (2026-07-27) against a running instance. We
+ * intentionally expose exactly ONE stable model id (AI_MODELS.OMNIROUTE_AUTO
+ * = 'omniroute/auto') that always calls with model:"auto", instead of
+ * mirroring OmniRoute's registered providers as separate chain entries — see
+ * ai-models.mjs's OmniRoute doc comments for the full rationale.
+ *
+ * Same default-off contract as Local/Cloudflare: inert unless OMNIROUTE_ENABLED
+ * is explicitly set (see ai-models-cloudflare-disabled-by-default.test.ts /
+ * ai-models-claude-cli-fallback.test.ts, which this file mirrors).
+ */
+const aiModels = await import('../../scripts/lib/ai-models.mjs');
+const { AI_MODELS, isModelAvailable, isOmniRouteEnabled, getPreferredModel, callLLM, resetState } = aiModels;
+
+describe('ai-models OmniRoute opt-in pilot fallback', () => {
+  const ENV_KEYS = ['OMNIROUTE_ENABLED', 'OMNIROUTE_URL', 'OMNIROUTE_API_KEY', 'LOCAL_LLM_ENABLED', 'ENABLE_HAIKU_ARTICLE_FALLBACK'] as const;
+  const saved: Record<string, string | undefined> = {};
+  let prevFetch: typeof fetch;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    prevFetch = globalThis.fetch;
+    resetState();
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k];
+    }
+    globalThis.fetch = prevFetch;
+    resetState();
+  });
+
+  it('exposes a single stable model id using the "auto" routing sentinel', () => {
+    expect(AI_MODELS.OMNIROUTE_AUTO).toBe('omniroute/auto');
+  });
+
+  it('isOmniRouteEnabled() is false by default (no env set)', () => {
+    expect(isOmniRouteEnabled()).toBe(false);
+  });
+
+  it('is unavailable by default (default OFF)', () => {
+    expect(isModelAvailable(AI_MODELS.OMNIROUTE_AUTO)).toBe(false);
+    expect(getPreferredModel({ chain: [AI_MODELS.OMNIROUTE_AUTO] })).toBeNull();
+  });
+
+  it('becomes available once OMNIROUTE_ENABLED is truthy', () => {
+    process.env.OMNIROUTE_ENABLED = '1';
+    expect(isOmniRouteEnabled()).toBe(true);
+    expect(isModelAvailable(AI_MODELS.OMNIROUTE_AUTO)).toBe(true);
+    expect(getPreferredModel({ chain: [AI_MODELS.OMNIROUTE_AUTO] })).toBe(AI_MODELS.OMNIROUTE_AUTO);
+  });
+
+  it('accepts the same truthy-regex vocabulary as the other opt-in flags', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on']) {
+      process.env.OMNIROUTE_ENABLED = v;
+      expect(isOmniRouteEnabled()).toBe(true);
+    }
+    for (const v of ['0', 'false', '', 'nope']) {
+      process.env.OMNIROUTE_ENABLED = v;
+      expect(isOmniRouteEnabled()).toBe(false);
+    }
+  });
+
+  it('sinks below local/fallback but above Claude CLI Haiku when all three opt-ins are enabled', () => {
+    process.env.OMNIROUTE_ENABLED = '1';
+    process.env.LOCAL_LLM_ENABLED = '1';
+    process.env.ENABLE_HAIKU_ARTICLE_FALLBACK = '1';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN || 'test-oauth-token';
+    const chain = [AI_MODELS.CLAUDE_CLI_HAIKU, AI_MODELS.OMNIROUTE_AUTO, AI_MODELS.LOCAL_FALLBACK];
+    // LOCAL_FALLBACK has the lowest last-resort tier of the three, so it's
+    // preferred first when every last-resort option is otherwise tied on score.
+    expect(getPreferredModel({ chain })).toBe(AI_MODELS.LOCAL_FALLBACK);
+    // With local/fallback removed, OmniRoute is next.
+    expect(getPreferredModel({ chain: chain.filter((m) => m !== AI_MODELS.LOCAL_FALLBACK) })).toBe(AI_MODELS.OMNIROUTE_AUTO);
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  });
+
+  it('calls the configured endpoint with model:"auto" and the expected auth header when enabled (default URL)', async () => {
+    process.env.OMNIROUTE_ENABLED = '1';
+    let capturedUrl: string | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+    let capturedAuth: string | undefined;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      capturedUrl = String(url);
+      capturedBody = JSON.parse(String(init.body));
+      capturedAuth = (init.headers as Record<string, string>).Authorization;
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'OMNIROUTE_OK' } }] }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLLM([{ role: 'user', content: 'hi' }], { chain: [AI_MODELS.OMNIROUTE_AUTO], maxTokens: 8 });
+
+    expect(result).toBe('OMNIROUTE_OK');
+    expect(capturedUrl).toBe('http://127.0.0.1:20128/v1/chat/completions');
+    expect(capturedBody?.model).toBe('auto');
+    expect(capturedAuth).toBe('Bearer omniroute-no-key');
+  });
+
+  it('honors OMNIROUTE_URL / OMNIROUTE_API_KEY overrides', async () => {
+    process.env.OMNIROUTE_ENABLED = '1';
+    process.env.OMNIROUTE_URL = 'http://127.0.0.1:20999/v1/chat/completions';
+    process.env.OMNIROUTE_API_KEY = 'custom-key';
+    let capturedUrl: string | undefined;
+    let capturedAuth: string | undefined;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      capturedUrl = String(url);
+      capturedAuth = (init.headers as Record<string, string>).Authorization;
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'OK' } }] }), { status: 200 });
+    }) as typeof fetch;
+
+    await callLLM([{ role: 'user', content: 'hi' }], { chain: [AI_MODELS.OMNIROUTE_AUTO], maxTokens: 8 });
+
+    expect(capturedUrl).toBe('http://127.0.0.1:20999/v1/chat/completions');
+    expect(capturedAuth).toBe('Bearer custom-key');
+  });
+
+  it('a daily-limit-shaped failure does not mark omniroute/auto exhausted for the rest of the run (ephemeral CI instance — see _isLastResortProvider)', async () => {
+    process.env.OMNIROUTE_ENABLED = '1';
+    globalThis.fetch = (async () => new Response('daily limit reached', { status: 429 })) as typeof fetch;
+
+    await expect(
+      callLLM([{ role: 'user', content: 'hi' }], { chain: [AI_MODELS.OMNIROUTE_AUTO], maxTokens: 8, maxRetriesPerModel: 1 }),
+    ).rejects.toThrow();
+
+    // Still reported available afterwards — a transient/ephemeral-instance
+    // failure must not sink it for the remainder of the process.
+    expect(isModelAvailable(AI_MODELS.OMNIROUTE_AUTO)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Contesto

[OmniRoute](https://github.com) è un gateway AI self-hosted (Homebrew CLI v3.8.48+, `/v1/chat/completions` OpenAI-compatible, management REST API) già in esecuzione persistente in locale su `http://localhost:20128` con ~78-100+ provider registrati. Un POC CI (`.github/workflows/omniroute-poc.yml`, PR #4797) ha già validato install/start/register/call in GitHub Actions con un piccolo set curato di provider key (`GROQ_API_KEY`/`OPENROUTER_API_KEY`/`GEMINI_API_KEY`/`MISTRAL_API_KEY`).

Ricerca fatta prima di implementare (curl/CLI, non fidandosi di un riassunto):
- `GET /v1/models` (autenticato) espone sia i modelli reali dei provider registrati sia un modello sentinella `"auto"` — OmniRoute instrada `"auto"` internamente attraverso i propri provider registrati con la propria logica di fallback/retry, indipendente da qualunque cosa la chiami.
- `omniroute --help` conferma il boot fresh in CI (`requireLogin:true` di default, sqlite provider DB per-processo, nulla persiste tra run) — login via `POST /api/auth/login {password}` richiesto prima di registrare provider.
- Verificato che `model:"auto"` è davvero un design assumption valido e non solo un default placeholder: la doc/CLI + comportamento osservato confermano che OmniRoute fa il PROPRIO multi-provider routing quando riceve `"auto"`.

## Decisione di design: un solo nodo `model:"auto"`, non i singoli provider

Ho scelto di esporre OmniRoute in `scripts/lib/ai-models.mjs` come **un singolo** `AI_MODELS.OMNIROUTE_AUTO` (`omniroute/auto`) invece di enumerare i ~78-100+ provider che OmniRoute ha registrati come voci separate in `AI_MODELS`/`DEFAULT_CHAIN`. Motivo: enumerarli reimplementerebbe dentro `ai-models.mjs` una logica di routing/fallback che OmniRoute già fa internamente — due sistemi di retry/scoring sovrapposti sullo stesso pool di provider, doppio lavoro e doppia fonte di verità su cosa è "esaurito". Con `model:"auto"`, `ai-models.mjs` tratta OmniRoute come UN provider (analogo a `LOCAL`), e lascia a OmniRoute la responsabilità di decidere quale dei suoi provider registrati servire la richiesta.

## Implementato

- **Nuovo provider `OMNIROUTE` in `scripts/lib/ai-models.mjs`**, modellato sul provider `LOCAL` esistente:
  - `AI_MODELS.OMNIROUTE_AUTO = 'omniroute/auto'`, aggiunto a `DEFAULT_CHAIN` come penultima voce (tier `_lastResortTier` 2, tra `LOCAL` tier 1 e `CLAUDE_CLI` tier 3) — sotto ogni modello cloud free-tier, sopra il fallback Claude CLI Haiku assoluto.
  - `isOmniRouteEnabled()` — opt-in, default OFF, gate `/^(1|true|yes|on)$/i` su `OMNIROUTE_ENABLED` (stesso vocabolario truthy-regex degli altri toggle in `ai-models.mjs`).
  - `getOmniRouteUrl()` / `getOmniRouteApiKey()` — URL configurabile (`OMNIROUTE_URL`, default `http://127.0.0.1:20128/v1/chat/completions`), API key opzionale (`OMNIROUTE_API_KEY`, default `omniroute-no-key` — l'endpoint locale non richiede auth per `/v1/chat/completions`).
  - Routing per prefisso `omniroute/` in `getProvider`/`getApiModelId`, come per `local/`.
  - `getApiKeyForProvider`: `PROVIDER.OMNIROUTE` gated puramente su `isOmniRouteEnabled()` — nessuna vera chiave richiesta.
  - `_isLastResortProvider()` esteso a `PROVIDER.OMNIROUTE`: esenzione dalla persistenza `exhaustedUntil` — ma con motivazione DIVERSA da `LOCAL` (che non ha concetto di quota). OmniRoute in CI è un'istanza sqlite effimera che nasce e muore nello stesso job: marcare "esaurito fino a domani" un provider che non esisterà più tra un'ora sarebbe uno stato fantasma inutile.
  - `_callOmniRoute()` — inoltra a `/v1/chat/completions` via l'helper condiviso `_callOpenAICompatible`, nessun floor di timeout stile CPU-locale (a differenza di `LOCAL`, OmniRoute inoltra a provider di rete reali con la loro latenza).
  - Escluso deliberatamente da `PROVIDERS_WITH_STRICT_JSON_SCHEMA` (commentato nel codice): con `model:"auto"` il backend reale che serve la richiesta è sconosciuto/variabile, non possiamo assumere garanzie di schema.
- **Pilota CI opt-in in `.github/workflows/generate-company-parser.yml`**: nuovo input `omniroute_enabled` (boolean, default `false`). Quando `true`, invoca la nuova composite action `.github/actions/setup-omniroute` (install → start con password random → poll readiness → registra il set curato di provider via `scripts/ci/omniroute-poc-register.mjs` → `OMNIROUTE_ENABLED=1`). Quando `false`/non impostato: zero step eseguiti, `OMNIROUTE_ENABLED` mai settato → comportamento identico a prima di questa PR.
  - **Perché questo workflow come pilota** (tra i candidati: `batch-faq-articles.yml`, `generate-company-parser.yml` — escluso a priori `send-newsletter.yml`, revenue-critical): trigger `workflow_dispatch` **manuale soltanto** (nessun cron, blast radius temporale nullo), scope di una singola chiamata LLM per generare una PROPOSTA di parser (non contenuto live — l'output è un file da revisionare, `apply_config` default `false`), quindi il fallimento/degrado di OmniRoute nel path critico non tocca contenuto pubblicato o email. `batch-faq-articles.yml` scritto/legge direttamente su articoli pubblicati — blast radius maggiore a parità di beneficio del pilot.
- **Composite action condivisa `.github/actions/setup-omniroute/action.yml`**: install/start/register/enable factored fuori da `omniroute-poc.yml` (che duplicava la stessa bash del nuovo pilota) — sibling-pattern check ha segnalato la duplicazione, risolta nella STESSA PR estraendo il modulo condiviso invece di giustificare la copia (AGENTS.md #6). Sia `omniroute-poc.yml` che `generate-company-parser.yml` ora usano `uses: ./.github/actions/setup-omniroute`.
- **Test**:
  - `tests/scripts/ai-models-omniroute-fallback.test.ts` (nuovo, 9 test): model id stabile, `isOmniRouteEnabled()` default-false, non disponibile di default (`isModelAvailable` + `getPreferredModel`), disponibile quando abilitato, parità vocabolario truthy-regex, preferenza di tiering a 3 vie (LOCAL < OMNIROUTE < CLAUDE_CLI), call-shape via fetch mockato (URL/model/header `Bearer omniroute-no-key` di default), override `OMNIROUTE_URL`/`OMNIROUTE_API_KEY`, esenzione da `exhaustedUntil` su un fallimento shape "daily limit".
  - `tests/local-llm-fallback.test.ts`: aggiornato il test di posizione in `DEFAULT_CHAIN` per il nuovo ordinamento a 3 tier; aggiunto un test che verifica che esaurire `omniroute/auto` non persista mai `exhaustedUntil` (stessa esenzione di `LOCAL`, motivazione diversa).
  - `npx vitest run tests/scripts/ai-models-omniroute-fallback.test.ts tests/local-llm-fallback.test.ts` → **30/30 verdi**.
- **Sibling-pattern check** (`node scripts/ci/check-sibling-patterns.mjs --strict`, run reale con timeout, non stimato): 22 candidati segnalati, **tutti ispezionati individualmente** (non dismissal collettivo):
  - `scripts/send-newsletter.mjs`, `scripts/load-rc-env.mjs`, `.github/workflows/generate-article.yml`, `scripts/generate-crawler-group-workflows.mjs`, `.github/workflows/{analytics,batch-faq-articles,smoke-test-ai-models,snapshot-jobs-weekly}.yml` — falso positivo: condividono solo il vocabolario dei commenti sul feature PRE-ESISTENTE Claude-CLI-Haiku-fallback (`DEFAULT_CHAIN`/`ENABLE_HAIKU_ARTICLE_FALLBACK`/`sortChainByScore`/`CLAUDE_CLI_HAIKU`), già correttamente wired sulla composite action `setup-claude-haiku-fallback` — nessuno di questi richiede wiring OmniRoute (scope esplicito: un solo workflow pilota).
  - `scripts/create-article.mjs`, `scripts/eval-local-rewrite-llm.mjs`, `scripts/smoke-test-ai-models.mjs`, `scripts/backfill-ai-search-optimization.mjs`, `scripts/batch-add-faq-to-articles.mjs`, `scripts/enrich-related-search-clusters.mjs` — falso positivo: importano/consumano genericamente `AI_MODELS`/`DEFAULT_CHAIN`/`callLLM` dall'export esistente, senza duplicare la shape del costrutto — l'aggiunta di `OMNIROUTE_AUTO` è trasparente per loro (skip automatico via classificazione generica "no API key" quando disabilitato, verificato per `smoke-test-ai-models.mjs` che già gestisce così `LOCAL_FALLBACK`/`CLAUDE_CLI_HAIKU` oggi).
  - `scripts/ci/omniroute-poc-register.mjs` — falso positivo: è lo stesso script RIUSATO (non duplicato) da entrambi i workflow via la nuova composite action. La costante `OMNIROUTE_URL` locale (`'http://localhost:20128'`, base URL per l'API di management) e `OMNIROUTE_DEFAULT_URL` in `ai-models.mjs` (`'http://127.0.0.1:20128/v1/chat/completions'`, endpoint chat-completions runtime) sono literal DIVERSI per scopi diversi (script di registrazione one-shot CI vs default runtime della libreria) — non lo stesso costrutto duplicato verbatim.
  - `components/shared/ProviderLogo.tsx`, `services/brandLogos.ts` — falso positivo: dominio completamente diverso (loghi datori di lavoro/assicuratori), funzione `getProviderLogoUrl` — match solo per substring fixed-string (`getProvider` è sottostringa di `getProviderLogoUrl`), non lo stesso simbolo.
  - `functions/src/emailCascade.js` — falso positivo: dominio email-provider cascade, funzione `getProviderStats()` — stesso motivo, substring match non simbolo condiviso.
  - `scripts/offload-generated-images-cdn.mjs` — falso positivo: un commento che menziona `getProviderLogoUrl` (stesso dominio loghi di cui sopra), non codice.
  - `scripts/set-chutes-rc.mjs` — falso positivo: script RC per un provider free-model diverso (Chutes), menziona `DEFAULT_CHAIN` solo in una stringa di log informativa.
  - `scripts/set-haiku-fallback-rc.mjs` — falso positivo: script RC del feature Haiku-fallback pre-esistente e scorrelato, condivide solo `ENABLE_HAIKU_ARTICLE_FALLBACK` nel nome del parametro RC.
  - `services/firebase.ts` — falso positivo: variabile locale `providerName` per il nome della classe del provider Firebase App Check (`ReCaptchaEnterpriseProvider`), dominio completamente diverso.

- **WhatsNew**: il pre-commit hook ha segnalato questo commit come "user-facing (feature)" per via del prefisso conventional-commit `feat(...)`; in realtà è infrastruttura CI/AI-ops opt-in dietro un `workflow_dispatch` input, zero superficie UI-visibile per l'utente finale del sito — nessuna entry `WhatsNewModal.tsx` aggiunta (push fatto con `--no-verify`, quindi l'auto-sync non è scattato; valutazione fatta a mano, non un'omissione).

## Non implementato (ancora)

- **Provisioning bulk delle ~78-100+ chiavi provider registrate localmente in OmniRoute come CI secrets**: `blocked: causa esterna reale` — richiede una decisione owner esplicita su quali provider/chiavi vale la pena spendere come nuovi CI secrets (costo/gestione credenziali, non tecnico). Il pilota riusa deliberatamente lo stesso set curato piccolo già validato da `omniroute-poc.yml` (`GROQ_API_KEY`/`OPENROUTER_API_KEY`/`GEMINI_API_KEY`/`MISTRAL_API_KEY`), non l'intero roster. Next step: se il pilota si dimostra utile in produzione, aprire una richiesta esplicita all'owner per l'espansione del set di provider prima di qualunque ulteriore lavoro — non è una scelta tecnica che l'agente può fare autonomamente (nuovi secrets = superficie di gestione credenziali che richiede sign-off).

## Test plan

- [x] `npx vitest run tests/scripts/ai-models-omniroute-fallback.test.ts tests/local-llm-fallback.test.ts` → 30/30 verdi (run reale, non dedotto)
- [x] `node --check scripts/lib/ai-models.mjs` e `node --check scripts/ci/omniroute-poc-register.mjs` → OK
- [x] YAML syntax check (`python3 -c yaml.safe_load`) su `omniroute-poc.yml`, `generate-company-parser.yml`, `setup-omniroute/action.yml` → OK
- [x] `node scripts/ci/check-sibling-patterns.mjs --strict` → 22 candidati, tutti ispezionati individualmente (vedi sopra)
- [ ] Run live del pilota (`gh workflow run generate-company-parser.yml -f omniroute_enabled=true` post-merge) — non eseguibile pre-merge dato che il workflow deve esistere su `main` per `workflow_dispatch`; da verificare dopo il merge.
