### PR TITLE
fix(ci): cap glibc malloc arenas on build-locale to stop host-OOM kills

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -93,7 +93,7 @@ jobs:
         # pipeline runs, so the AdSense audit inspects production-identical
         # pages. build:ci sets its own inline `--max-old-space-size=12288
         # --expose-gc` (fits the 16 GB runner); build:prod's 18 GB exceeds
-        # physical RAM. The two env knobs are deploy.yml's documented OOM
+        # physical RAM. The three env knobs are deploy.yml's documented OOM
         # controls (build OOM #1290) — they cap the dominant memory term so the
         # full SEO build fits at 12 GB alongside the data-prep reduction above.
         env:
@@ -103,6 +103,10 @@ jobs:
           # Cap the post-walk worker pool so it doesn't structured-clone the full
           # path list into cpus()-many workers at once (the #1290 blowup).
           POST_WALK_WORKERS: '2'
+          # Same worker pool as above: cap glibc malloc arenas so they don't
+          # outlive the worker_threads and pin RSS for the rest of the build
+          # (mirrors deploy.yml's build-locale mitigation, run 30274470672).
+          MALLOC_ARENA_MAX: '2'
           # Force sequential plugin closeBundle: peak heap = max(single plugin)
           # instead of Σ(overlap). Always sequential here (scheduled/dispatch).
           SEQUENTIAL_PROFILE: '1'

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -138,7 +138,7 @@ jobs:
           # The previous `18432` here was dead config — silently overridden to
           # 12288 — and 18 GB exceeds the 16 GB runner's RAM anyway.
           #
-          # The two knobs below are deploy.yml's documented OOM controls
+          # The three knobs below are deploy.yml's documented OOM controls
           # (build OOM #1290) — they cap the DOMINANT memory term, not the
           # dataset size. deploy fits the full SEO build at 12288 BECAUSE of
           # these; the shared data-prep action above is a smaller,
@@ -151,6 +151,10 @@ jobs:
           # full ~247K-path list into cpus()-many workers at once (the #1290
           # blowup). Output-identical — only fewer parallel workers.
           POST_WALK_WORKERS: '2'
+          # Same worker pool as above: cap glibc malloc arenas so they don't
+          # outlive the worker_threads and pin RSS for the rest of the build
+          # (mirrors deploy.yml's build-locale mitigation, run 30274470672).
+          MALLOC_ARENA_MAX: '2'
           # Force sequential plugin closeBundle: peak heap = max(single plugin)
           # instead of Σ(overlap) → eliminates the parallel-build OOM. Always
           # sequential here (scheduled/dispatch gate run, never parallel).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,6 +296,21 @@ jobs:
       RELATED_SEARCH_CLUSTERS_NO_CACHE: '1'
       RELATED_SEARCH_PREPASS_CONCURRENCY: '1'
       DEPLOY_CONTENT_MANIFEST: '1'
+      # Runner-level OOM mitigation (run 30274470672, 2026-07-27): IT build
+      # got host-killed ("runner has received a shutdown signal") mid
+      # related-search-clusters at rss_mb=11848 while heapTotal was only
+      # ~5.1GB — the gap is glibc malloc arenas never returned to the OS,
+      # not V8 heap (jobsSeoPagesPlugin/staticPagesPlugin/etc. already gc()
+      # between phases — see profilePlugin.ts — so V8-side reclaim is not
+      # the gap). postWalkCoordinatorPlugin.ts spawns POST_WALK_WORKERS
+      # worker_threads earlier in the build; each worker's glibc arenas can
+      # outlive the thread and pin RSS for the rest of closeBundle, which
+      # matches the ~9.8GB pinned-RSS pattern already logged in past
+      # investigations. Capping arenas makes glibc trim more aggressively.
+      # Revert trigger: if a build still OOMs at/above this same RSS after
+      # this lands, this wasn't the (whole) cause — pursue reducing the
+      # related-search-clusters candidate set instead, don't re-try this knob.
+      MALLOC_ARENA_MAX: '2'
       # Per-locale emit filter + shared canonical build id (identical
       # dist/build-id.txt across all shards).
       BUILD_LOCALE: ${{ matrix.locale }}


### PR DESCRIPTION
## Implementato

- `MALLOC_ARENA_MAX: '2'` added to the `build-locale` job env in `.github/workflows/deploy.yml`. Root cause of https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30274470672/job/90007490212 (`build-locale (it)` killed with "runner has received a shutdown signal", exit 143): host-level OOM, not a code bug. `profile-mem` logs show `rss_mb=11848` right before the kill while `heapTotal_mb` was only ~5100 — the ~6.7GB gap isn't V8 heap (SSG plugins already call `gc()` between phases, see `profilePlugin.ts`/`jobsSeoPagesPlugin.ts`/`staticPagesPlugin.ts`/`relatedSearchClustersPlugin.ts`/`borderMunicipalityPagesPlugin.ts`), it's glibc malloc arenas that outlive the `worker_threads` spawned by `postWalkCoordinatorPlugin.ts` (`POST_WALK_WORKERS=2`) earlier in the build and never get trimmed back to the OS. This matches the "~9.8GB pinned RSS" pattern already logged in a prior investigation (memory: `project_ssg_plugins_memory_bound_not_parallelizable_jun29`, which tested and ruled out cross-runner plugin parallelization as a fix). Capping glibc arenas is a new, previously-untried lever, orthogonal to that prior work and to the existing `gc()` calls.
- This directly replaces reliance on the already-queued retry (run 30277539253, which did land the deploy while this PR was being prepared) as the recovery mechanism — the goal is to reduce how often this host-OOM happens at all, not to retry faster.
- **Follow-up commit (post-review):** propagated the same `MALLOC_ARENA_MAX: '2'` to `.github/workflows/adsense-prereview.yml` and `.github/workflows/cathedral-seo-gates-check.yml`. Reviewer correctly flagged (🔴 Important) that both self-declare as mirroring `deploy.yml`'s OOM controls (`build OOM #1290`, same `POST_WALK_WORKERS`) and run the identical `worker_threads`-spawning `build:ci` — the arena leak this PR fixes for `build-locale` was equally open on both. Added in the same place as their existing mirrored knobs, with their "two knobs" comments updated to "three".

## Non implementato (ancora)

Nessuno. Scope pieno di questa PR (knob `MALLOC_ARENA_MAX` su `build-locale` + i suoi due gate-audit siblings che si autodichiarano sincronizzati) è ora implementato in entrambi i commit; nessun residuo aperto.

Note per il reviewer — `check-sibling-patterns.mjs --strict` (pre-push hook) ha bloccato entrambi i push segnalando file gemelli. Sul primo push, 2 dei 10 candidati (`adsense-prereview.yml`, `cathedral-seo-gates-check.yml`) erano stati erroneamente classificati come falsi positivi da me — il reviewer li ha corretti, sono stati fixati nel secondo commit (`eb5ee77a863`), vedi sopra. I restanti 8 restano falsi positivi genuini, confermati singolarmente (menzione testuale in commento/prosa, nessuna modifica/duplicazione di costrutto):
- `build-plugins/postWalkCoordinatorPlugin.ts` — condivide `POST_WALK_WORKERS`/`postWalkCoordinatorPlugin` solo perché il commento li cita come causa del leak dei worker thread; il file non è toccato.
- `build-plugins/profilePlugin.ts` — condivide `profilePlugin`/`heapTotal` solo come riferimento (dove il gc() esistente già gira); nessuna modifica.
- `build-plugins/blogContextualLinksPlugin.ts` — condivide solo la menzione testuale `postWalkCoordinatorPlugin` nel commento.
- `build-plugins/flatHtmlRedirectPlugin.ts` — idem.
- `build-plugins/hreflangPostprocessPlugin.ts` — idem.
- `build-plugins/postWalkWorker.mjs` — idem.
- `build-plugins/shared/postWalkCoordinatorProfiler.ts` — idem.
- `scripts/ci/check-sibling-patterns.mjs` — condivide `POST_WALK_WORKERS` solo come stringa di esempio nella propria documentazione interna del tool.

**Risposta all'adversarial check (❓ nessuna baseline arena-count pre-fix loggata):** corretto, non esiste un log della baseline glibc `mallinfo2`/arena-count del run fallito — quel run è già concluso, non retroattivamente strumentabile. Non aggiungo strumentazione arena-count come scope di questa PR: è un investimento di osservabilità distinto (richiederebbe un binding Node→glibc `mallinfo2` dentro `profilePlugin.ts`, non solo un env knob) e il revert-trigger già dichiarato sotto fornisce un segnale di validazione empirico equivalente e sufficiente (rss_mb dal prossimo build reale) senza bisogno di quella metrica aggiuntiva.

**Revert trigger (claim di memoria non validabile pre-merge, `build:ci` non gira su `pull_request`):** se un prossimo build IT su `main` OOMma di nuovo allo stesso/maggiore RSS dopo questo merge, il knob non è la (sola) causa — la prossima leva è ridurre il candidate-set di `related-search-clusters` (349397 candidates loggati nel run fallito), non ri-tentare varianti malloc.

## Test plan

- [x] YAML validato (`python3 -c "import yaml; yaml.safe_load(...)"`) per tutti e 3 i workflow toccati
- [ ] Prossimo deploy `main` (`build-locale (it)`) completa senza "runner has received a shutdown signal" — verificabile solo post-merge, non su `pull_request`.
