### PR TITLE
feat(omniroute): sync decrypted SQLite provider keys to Remote Config

### DIFF
--- a/.github/actions/setup-omniroute/action.yml
+++ b/.github/actions/setup-omniroute/action.yml
@@ -2,10 +2,12 @@ name: "Setup OmniRoute (self-hosted local AI gateway)"
 description: >-
   Installs OmniRoute (Homebrew CLI, published to npm), starts it with a
   random INITIAL_PASSWORD, waits for readiness on
-  http://localhost:20128, registers a small curated set of provider
-  connections from env (GROQ_API_KEY/OPENROUTER_API_KEY/GEMINI_API_KEY/
-  MISTRAL_API_KEY — see scripts/ci/omniroute-poc-register.mjs), then sets
-  OMNIROUTE_ENABLED=1 so scripts/lib/ai-models.mjs offers
+  http://localhost:20128, registers provider connections — the full set
+  decrypted from a local OmniRoute install when OMNIROUTE_PROVIDERS_JSON is
+  present in Remote Config (see scripts/sync-omniroute-providers-rc.mjs),
+  else a small curated fallback from env (GROQ_API_KEY/OPENROUTER_API_KEY/
+  GEMINI_API_KEY/MISTRAL_API_KEY — see scripts/ci/omniroute-poc-register.mjs),
+  then sets OMNIROUTE_ENABLED=1 so scripts/lib/ai-models.mjs offers
   AI_MODELS.OMNIROUTE_AUTO (single "auto" routing-sentinel node — OmniRoute
   does its OWN internal provider fallback across whatever it has
   registered; we deliberately don't enumerate its providers as separate

--- a/scripts/ci/omniroute-poc-register.mjs
+++ b/scripts/ci/omniroute-poc-register.mjs
@@ -1,17 +1,37 @@
 #!/usr/bin/env node
-// Registers a small representative set of provider connections into a locally
-// running OmniRoute instance (POC only — see .github/workflows/omniroute-poc.yml).
-// Includes one intentionally-dead key (mistral) to prove OmniRoute's auto
-// fallback skips it and still serves the completion via a live provider.
+// Registers provider connections into a locally running OmniRoute instance
+// (POC only — see .github/workflows/omniroute-poc.yml). When
+// OMNIROUTE_PROVIDERS_JSON is set (see scripts/sync-omniroute-providers-rc.mjs
+// / scripts/load-rc-env.mjs), registers that full decrypted provider set;
+// otherwise falls back to a small curated list. The fallback list includes
+// one intentionally-dead key (mistral) to prove OmniRoute's auto fallback
+// skips it and still serves the completion via a live provider.
 
 const OMNIROUTE_URL = 'http://localhost:20128';
 
-const PROVIDERS = [
-  ['groq', 'Groq (CI POC)', ['GROQ_API_KEY']],
-  ['openrouter', 'OpenRouter (CI POC)', ['OPENROUTER_API_KEY']],
-  ['gemini', 'Gemini (CI POC)', ['GEMINI_API_KEY']],
-  ['mistral', 'Mistral (CI POC, expected dead)', ['MISTRAL_API_KEY']],
+// Tuple shape: [provider, name, envNames|null, presetApiKey|null] — envNames
+// resolves the key from process.env (curated fallback), presetApiKey is
+// already-decrypted (OMNIROUTE_PROVIDERS_JSON path).
+const providersFromJson = (() => {
+  const raw = process.env.OMNIROUTE_PROVIDERS_JSON;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) throw new Error('not an array');
+    return parsed.map((p) => [p.provider, p.name || p.provider, null, p.apiKey]);
+  } catch (e) {
+    console.error('⚠️  OMNIROUTE_PROVIDERS_JSON present but invalid, falling back to curated POC list:', e.message);
+    return null;
+  }
+})();
+
+const PROVIDERS = providersFromJson || [
+  ['groq', 'Groq (CI POC)', ['GROQ_API_KEY'], null],
+  ['openrouter', 'OpenRouter (CI POC)', ['OPENROUTER_API_KEY'], null],
+  ['gemini', 'Gemini (CI POC)', ['GEMINI_API_KEY'], null],
+  ['mistral', 'Mistral (CI POC, expected dead)', ['MISTRAL_API_KEY'], null],
 ];
+if (providersFromJson) console.log(`ℹ️  Using OMNIROUTE_PROVIDERS_JSON — ${PROVIDERS.length} provider connection(s).`);
 
 // A fresh OmniRoute boot (always the case in CI — new sqlite db each run) sets
 // requireLogin:true and needs a session cookie for /api/* management routes
@@ -36,8 +56,8 @@ if (password) {
 const skipped = [];
 const results = [];
 
-for (const [provider, name, envNames] of PROVIDERS) {
-  const apiKey = envNames.map((n) => process.env[n]).find((v) => v && v.trim());
+for (const [provider, name, envNames, presetApiKey] of PROVIDERS) {
+  const apiKey = presetApiKey || envNames?.map((n) => process.env[n]).find((v) => v && v.trim());
   if (!apiKey) {
     skipped.push(provider);
     continue;

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -193,6 +193,13 @@ const RC_TO_ENV = {
   // (OFF) — code requires this AND CLAUDE_CODE_OAUTH_TOKEN before offering the
   // model at all (see isClaudeCliFallbackEnabled/hasClaudeCodeOauthToken).
   ENABLE_HAIKU_ARTICLE_FALLBACK:  ['ENABLE_HAIKU_ARTICLE_FALLBACK'],
+
+  // JSON array of {provider, name, apiKey} — decrypted OmniRoute provider
+  // connections synced from a local ~/.omniroute/storage.sqlite via
+  // scripts/sync-omniroute-providers-rc.mjs. Consumed by
+  // scripts/ci/omniroute-poc-register.mjs to register the full provider set
+  // into a fresh CI OmniRoute instance instead of the small hardcoded list.
+  OMNIROUTE_PROVIDERS_JSON:       ['OMNIROUTE_PROVIDERS_JSON'],
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/scripts/sync-omniroute-providers-rc.mjs
+++ b/scripts/sync-omniroute-providers-rc.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * One-shot (local-only): decrypt this machine's local OmniRoute provider
+ * connections (~/.omniroute/storage.sqlite) and publish the apikey-type ones
+ * to Firebase Remote Config as a single JSON blob, so CI's OmniRoute
+ * instance can register the full provider set instead of the small
+ * hardcoded 4 in scripts/ci/omniroute-poc-register.mjs.
+ *
+ * Local sqlite file never leaves this machine — only the decrypted
+ * {provider, name, apiKey} tuples for connections with a real key and
+ * test_status='active' are published (pass --include-all to also publish
+ * error/expired/unknown connections; default skips them since CI has no use
+ * for keys already known-dead).
+ *
+ * OAuth-type connections (github, antigravity, kilocode) are session/device
+ * bound — no portable credential to sync, always excluded.
+ *
+ * Auth: GOOGLE_APPLICATION_CREDENTIALS -> Firebase SA (Remote Config Admin).
+ * Env:  STORAGE_ENCRYPTION_KEY (from ~/.omniroute/.env — same key OmniRoute
+ *       itself uses to encrypt api_key at rest, AES-256-GCM).
+ */
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+import { getRemoteConfig, fetchRcTemplate, stageRcParam, publishRcTemplate } from './lib/remote-config-admin.mjs';
+
+const DB_PATH = process.env.OMNIROUTE_DB_PATH || path.join(os.homedir(), '.omniroute', 'storage.sqlite');
+const STORAGE_KEY = process.env.STORAGE_ENCRYPTION_KEY;
+const INCLUDE_ALL = process.argv.includes('--include-all');
+
+if (!STORAGE_KEY) {
+  console.error('❌ STORAGE_ENCRYPTION_KEY missing in env (see ~/.omniroute/.env on the OmniRoute host).');
+  process.exit(1);
+}
+
+// Same enc:v1:<ivHex>:<ciphertextHex>:<authTagHex> AES-256-GCM scheme
+// OmniRoute uses to encrypt api_key at rest (reverse-engineered from its
+// bundled server source; key derivation: scrypt(STORAGE_ENCRYPTION_KEY,
+// "omniroute-field-encryption-v1", 32)).
+function decryptApiKey(enc) {
+  const parts = String(enc).split(':');
+  if (parts.length !== 5 || parts[0] !== 'enc' || parts[1] !== 'v1') return null;
+  const [, , ivHex, ciphertextHex, authTagHex] = parts;
+  try {
+    const key = crypto.scryptSync(STORAGE_KEY, 'omniroute-field-encryption-v1', 32);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
+    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+    return Buffer.concat([decipher.update(Buffer.from(ciphertextHex, 'hex')), decipher.final()]).toString('utf8');
+  } catch (e) {
+    console.warn(`  ⚠️  decrypt failed: ${e.message}`);
+    return null;
+  }
+}
+
+const db = new DatabaseSync(DB_PATH, { readOnly: true });
+const statusFilter = INCLUDE_ALL ? '' : `AND test_status = 'active'`;
+const rows = db.prepare(
+  `SELECT provider, name, api_key, test_status FROM provider_connections
+   WHERE auth_type = 'apikey' AND api_key IS NOT NULL AND api_key != '' ${statusFilter}
+   ORDER BY provider, name`
+).all();
+db.close();
+
+const payload = [];
+let failed = 0;
+for (const row of rows) {
+  const apiKey = decryptApiKey(row.api_key);
+  if (!apiKey) { failed++; continue; }
+  payload.push({ provider: row.provider, name: row.name || row.provider, apiKey });
+}
+
+if (failed > 0) console.warn(`⚠️  ${failed} connection(s) failed to decrypt — skipped.`);
+if (payload.length === 0) {
+  console.error('❌ Nothing to publish (0 decryptable apikey connections matched the filter).');
+  process.exit(1);
+}
+
+const json = JSON.stringify(payload);
+console.log(`🔓 Decrypted ${payload.length} provider connection(s) (${INCLUDE_ALL ? 'all statuses' : 'active only'}).`);
+
+const rc = await getRemoteConfig();
+const template = await fetchRcTemplate(rc);
+const today = new Date().toISOString().slice(0, 10);
+const changed = stageRcParam(
+  template,
+  'OMNIROUTE_PROVIDERS_JSON',
+  json,
+  `OmniRoute provider connections (decrypted from local storage.sqlite; ${payload.length} entries; set ${today})`
+) ? 1 : 0;
+
+if (changed === 0) {
+  console.log('ℹ️  OMNIROUTE_PROVIDERS_JSON already up-to-date in Remote Config. Nothing published.');
+  process.exit(0);
+}
+await publishRcTemplate(rc, template, changed);
+console.log(`✅ Published OMNIROUTE_PROVIDERS_JSON to Remote Config (${payload.length} providers, ${Math.round(json.length / 1024)}KB).`);


### PR DESCRIPTION
## Implementato

- `scripts/sync-omniroute-providers-rc.mjs` (nuovo, local-only, one-shot): decripta le `provider_connections` di tipo `apikey` dal `~/.omniroute/storage.sqlite` locale (stesso schema `enc:v1` AES-256-GCM usato da OmniRoute at-rest) e pubblica un unico param `OMNIROUTE_PROVIDERS_JSON` su Firebase Remote Config. Default: solo connessioni `test_status='active'` (`--include-all` per includere anche error/expired/unknown).
- `scripts/load-rc-env.mjs`: nuova entry `RC_TO_ENV` idrata `OMNIROUTE_PROVIDERS_JSON` come env var in CI (riusa il path GITHUB_ENV/masking esistente, zero plumbing nuovo).
- `scripts/ci/omniroute-poc-register.mjs`: se `OMNIROUTE_PROVIDERS_JSON` è presente, registra l'intero set decriptato invece della lista curata di 4 provider hardcoded (che resta il fallback quando il param è assente).
- `.github/actions/setup-omniroute/action.yml`: commento aggiornato per descrivere il nuovo path condizionale. Nessuna modifica YAML ai workflow necessaria — sia `omniroute-poc.yml` che `generate-company-parser.yml` già eseguono `node scripts/load-rc-env.mjs` prima di questa action, quindi ereditano `OMNIROUTE_PROVIDERS_JSON` automaticamente una volta pubblicato.
- Connessioni oauth (`github`, `antigravity`, `kilocode`) escluse deliberatamente — credenziali session/device-bound, non portabili in un'istanza CI fresca.
- Eseguito lo script reale contro il DB locale: pubblicazione su Remote Config completata (vedi commento separato con i dettagli numerici).

## Non implementato (ancora)

Nessuno.

## Sibling-pattern audit (AGENTS.md #6)

25 candidati emersi da `check-sibling-patterns.mjs --strict`, ognuno ispezionato individualmente (nessun dismiss collettivo) — dettaglio completo nel commit message. Riassunto per classe:
- **Riuso corretto del modulo condiviso** `remote-config-admin.mjs` (stesso pattern single-source-of-truth del mio nuovo script, non duplicazione): `scripts/set-adsense-rc.mjs`, `set-chutes-rc.mjs`, `set-haiku-fallback-rc.mjs`, `set-maileroo-rc.mjs`, `set-posthog-rc.mjs`, `set-r2-rc.mjs`, `set-stripe-rc.mjs`, `scripts/lib/remote-config-admin.mjs`, `scripts/seo-serp-autopilot.mjs`.
- **Nome env var/provider riusato come credenziale per la propria chiamata LLM**, dominio diverso (inference, non registration/RC-sync): `scripts/lib/ai-models.mjs`, `scripts/backfill-ai-search-optimization.mjs`, `scripts/generate-company-parser.mjs`, `scripts/lib/alerts/detectors/cost.mjs`, `scripts/smoke-test-ai-models.mjs`, `functions/src/chatbotInference.js`, `functions/src/geminiGenerate.js`, `scripts/build-article-embeddings.mjs`, `scripts/check-ai-visibility.mjs`, `scripts/lib/shared-jobs-crawler.mjs`, `.github/workflows/snapshot-jobs-weekly.yml`.
- **Solo token "OmniRoute" condiviso**, concern diverso: `.github/workflows/generate-company-parser.yml` e `omniroute-poc.yml` (verificato: entrambi già chiamano `load-rc-env.mjs` prima della action, ereditano il nuovo param senza modifiche); `scripts/omniroute-diagnose.mjs` (dump read-only, non tocca la registration).
- **Coincidenza lessicale di variabile**, verificata leggendo il sito: `scripts/cf-status-report.mjs` (`statusFilter()` proprio, dominio Cloudflare-zone); `components/pages/JournalistDashboardPage.tsx` + `services/locales/{de,en,fr,it}-core.ts` (`readOnly` = stringa i18n `journalistDashboard.detail.readOnlyNotice`, non l'opzione di apertura sqlite).

## Test plan

- [x] `npx vitest run tests/scripts/ai-models-omniroute-fallback.test.ts tests/local-llm-fallback.test.ts` — 30/30 verdi
- [x] `gitnexus detect_changes(scope:all)` — risk_level low, affected_count 0
- [x] PII pre-commit scan (`.git/info/pii-blocklist.txt`) — pulito
- [x] YAML validati (`yaml.safe_load`) su action.yml modificato

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>